### PR TITLE
Add metric views as first-class analytics layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ static/app.css
 static/*.js
 !static/theme.js
 static/model-graph.css
+static/metric-usage-graph.css
 .env
 .env.*
 !.env.example

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ go run ./cmd/libredash
 - `GET /models/{model}` renders the semantic model graph.
 - `GET /updates?dashboard={dashboard}&page={page}` opens a long-running Datastar SSE stream and patches signals with `datastar.MarshalAndPatchSignals`.
 - DuckDB registers local CSV files as views and materializes model-scoped import tables.
-- `dashboards/catalog.yaml` discovers semantic models and dashboards; dashboard YAML owns pages, filters, KPIs, visuals, tables, and interactions.
+- `dashboards/catalog.yaml` discovers semantic models, metrics views, and dashboards.
+- Semantic model YAML owns sources, cache tables, datasets, and relationships; metrics view YAML owns business dimensions and aggregate measure expressions.
+- Dashboard YAML owns pages, filters, KPIs, visuals, tables, and interactions over metrics views.
 - Lit chart components bind to signal paths such as `charts.revenue`.
 - The bundled `datastar-inspector` web component shows live Datastar signals in the browser.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ go run ./cmd/libredash
 
 - `GET /` renders the file-backed dashboard catalog with gomponents.
 - `GET /dashboards/{dashboard}` opens a dashboard, and `GET /dashboards/{dashboard}/pages/{page}` renders a report page.
-- `GET /models/{model}` renders the semantic model graph.
+- `GET /metrics` renders the metric view catalog, and `GET /metrics/{view}` renders metric contract details.
+- `GET /models/{model}` renders the semantic model lineage graph, including metric views built on top of datasets.
 - `GET /updates?dashboard={dashboard}&page={page}` opens a long-running Datastar SSE stream and patches signals with `datastar.MarshalAndPatchSignals`.
 - DuckDB registers local CSV files as views and materializes model-scoped import tables.
 - `dashboards/catalog.yaml` discovers semantic models, metrics views, and dashboards.

--- a/dashboards/catalog.yaml
+++ b/dashboards/catalog.yaml
@@ -9,10 +9,16 @@ semantic_models:
     path: olist/model.yaml
     description: Brazilian ecommerce model backed by local Olist CSVs.
 
+metrics_views:
+  - id: orders
+    title: Orders Metrics
+    path: olist/orders.metrics.yaml
+    semantic_model: olist
+    description: Governed order metrics and dimensions for Olist commerce dashboards.
+
 dashboards:
   - id: executive-sales
     title: Executive Sales Dashboard
-    semantic_model: olist
     path: olist/executive-sales.yaml
     description: Sales, order, category, and delivery overview.
     tags: [sales, ecommerce, operations]

--- a/dashboards/olist/executive-sales.yaml
+++ b/dashboards/olist/executive-sales.yaml
@@ -338,7 +338,7 @@ tables:
   state_status_matrix:
     kind: matrix_table
     title: State status matrix
-    dataset: orders
+    metrics_view: orders
     rows: [state]
     columns: [status]
     measures: [order_count, revenue]
@@ -348,7 +348,7 @@ tables:
   category_status_pivot:
     kind: pivot_table
     title: Category status pivot
-    dataset: orders
+    metrics_view: orders
     rows: [category]
     columns: [status]
     measures: [order_count]

--- a/dashboards/olist/executive-sales.yaml
+++ b/dashboards/olist/executive-sales.yaml
@@ -1,13 +1,13 @@
 id: executive-sales
 title: Executive Sales Dashboard
 description: Sales, order, category, and delivery overview.
-semantic_model: olist
+metrics_views: [orders]
 
 filters:
   purchase_date:
     type: date_range
     label: Period
-    dataset: orders
+    metrics_view: orders
     dimension: purchase_timestamp
     url_param: period
     from_url_param: from
@@ -32,7 +32,7 @@ filters:
   state:
     type: multi_select
     label: State
-    dataset: orders
+    metrics_view: orders
     dimension: state
     url_param: state
     operator: in
@@ -42,7 +42,7 @@ filters:
   category:
     type: text
     label: Category
-    dataset: orders
+    metrics_view: orders
     dimension: category
     url_param: category
     operator_url_param: category_op
@@ -52,25 +52,25 @@ filters:
 kpis:
   total_orders:
     title: Orders
-    dataset: orders
+    metrics_view: orders
     measure: order_count
     note: Filtered order count
     tone: ink
   revenue:
     title: Revenue
-    dataset: orders
+    metrics_view: orders
     measure: revenue
     note: Cached payment value
     tone: green
   aov:
     title: AOV
-    dataset: orders
+    metrics_view: orders
     measure: aov
     note: Revenue per order
     tone: amber
   review:
     title: Review
-    dataset: orders
+    metrics_view: orders
     measure: review_score
     note: Average score
     tone: coral
@@ -79,7 +79,7 @@ visuals:
   revenue:
     title: Revenue by month
     type: area
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [purchase_month]
       measures: [revenue]
@@ -95,7 +95,7 @@ visuals:
   orders:
     title: Orders by status
     type: donut
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [status]
       measures: [order_count]
@@ -114,7 +114,7 @@ visuals:
     type: column
     options:
       stacked: true
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [purchase_month]
       series: status
@@ -131,7 +131,7 @@ visuals:
   categories:
     title: Top product categories
     type: bar
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [category]
       measures: [revenue]
@@ -147,7 +147,7 @@ visuals:
   delivery:
     title: Delivery speed
     type: bar
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [delivery_bucket]
       measures: [order_count]
@@ -164,7 +164,7 @@ visuals:
     shape: matrix
     renderer: echarts
     type: heatmap
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [state, status]
       measures: [order_count]
@@ -179,7 +179,7 @@ visuals:
     shape: graph
     renderer: echarts
     type: sankey
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [status, delivery_bucket]
       measures: [order_count]
@@ -192,7 +192,7 @@ visuals:
     shape: distribution
     renderer: echarts
     type: boxplot
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [delivery_bucket]
       measures: [delivery_days]
@@ -206,7 +206,7 @@ visuals:
     type: map
     options:
       map: brazil_states
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [state]
       measures: [order_count]
@@ -219,7 +219,7 @@ visuals:
     shape: graph
     renderer: echarts
     type: graph
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [status, delivery_bucket]
       measures: [order_count]
@@ -236,7 +236,7 @@ visuals:
       series_types:
         Revenue: line
         Orders: column
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [purchase_month]
       measures: [revenue, order_count]
@@ -249,7 +249,7 @@ visuals:
     shape: category_delta
     renderer: echarts
     type: waterfall
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [purchase_month]
       measures: [revenue]
@@ -264,7 +264,7 @@ visuals:
     type: histogram
     options:
       bin_count: 16
-    dataset: orders
+    metrics_view: orders
     query:
       measures: [delivery_days]
   status_radar:
@@ -272,7 +272,7 @@ visuals:
     shape: category_value
     renderer: echarts
     type: radar
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [status]
       measures: [order_count]
@@ -285,7 +285,7 @@ visuals:
     shape: hierarchy
     renderer: echarts
     type: sunburst
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [category, status]
       measures: [order_count]
@@ -298,7 +298,7 @@ visuals:
     shape: hierarchy
     renderer: echarts
     type: tree
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [state, status]
       measures: [order_count]
@@ -311,7 +311,7 @@ tables:
   orders:
     kind: data_table
     title: Orders
-    dataset: orders
+    metrics_view: orders
     default_sort:
       key: purchase_date
       direction: desc

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -74,59 +74,6 @@ cache:
 datasets:
   orders:
     source: orders_enriched
-    dimensions:
-      purchase_month:
-        label: Purchase month
-        expr: purchase_month
-      purchase_timestamp:
-        label: Purchase timestamp
-        expr: purchase_timestamp
-      purchase_date:
-        label: Purchase date
-        expr: purchase_date
-      status:
-        label: Status
-        expr: status
-      state:
-        label: State
-        expr: state
-      category:
-        label: Category
-        expr: category
-      delivery_bucket:
-        label: Delivery speed
-        expr: delivery_bucket
-        where: delivery_bucket IS NOT NULL
-        order_expr: MIN(e.delivery_days)
-    measures:
-      order_count:
-        label: Orders
-        aggregate: count_distinct
-        column: order_id
-        unit: orders
-        format: integer
-      revenue:
-        label: Revenue
-        aggregate: sum
-        column: revenue
-        unit: R$
-        format: currency
-      aov:
-        label: AOV
-        aggregate: expression
-        expression: CASE WHEN COUNT(DISTINCT e.order_id) = 0 THEN 0 ELSE SUM(e.revenue) / COUNT(DISTINCT e.order_id) END
-        unit: R$
-        format: currency
-      review_score:
-        label: Review
-        aggregate: avg
-        column: review_score
-        format: decimal
-      delivery_days:
-        label: Delivery days
-        aggregate: avg
-        column: delivery_days
-        format: decimal
 
 relationships:
   - id: orders_customers

--- a/dashboards/olist/orders.metrics.yaml
+++ b/dashboards/olist/orders.metrics.yaml
@@ -1,0 +1,56 @@
+id: orders
+title: Orders Metrics
+description: Governed order metrics and dimensions for the Olist commerce model.
+semantic_model: olist
+dataset: orders
+timeseries: purchase_timestamp
+
+dimensions:
+  purchase_month:
+    label: Purchase month
+    expr: e.purchase_month
+  purchase_timestamp:
+    label: Purchase timestamp
+    expr: e.purchase_timestamp
+  purchase_date:
+    label: Purchase date
+    expr: e.purchase_date
+  status:
+    label: Status
+    expr: e.status
+  state:
+    label: State
+    expr: e.state
+  category:
+    label: Category
+    expr: e.category
+  delivery_bucket:
+    label: Delivery speed
+    expr: e.delivery_bucket
+    where: e.delivery_bucket IS NOT NULL
+    order_expr: MIN(e.delivery_days)
+
+measures:
+  order_count:
+    label: Orders
+    expression: COUNT(DISTINCT e.order_id)
+    unit: orders
+    format: integer
+  revenue:
+    label: Revenue
+    expression: SUM(e.revenue)
+    unit: R$
+    format: currency
+  aov:
+    label: AOV
+    expression: SUM(e.revenue) / NULLIF(COUNT(DISTINCT e.order_id), 0)
+    unit: R$
+    format: currency
+  review_score:
+    label: Review
+    expression: AVG(e.review_score)
+    format: decimal
+  delivery_days:
+    label: Delivery days
+    expression: AVG(e.delivery_days)
+    format: decimal

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -21,6 +21,7 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/dashboards/{dashboard}/pages/{page}", s.protected(platform.PermissionDashboardView, s.page))
 		r.Get("/metrics", s.protected(platform.PermissionDashboardView, s.metricsCatalog))
 		r.Get("/metrics/{view}", s.protected(platform.PermissionDashboardView, s.metricView))
+		r.Get("/metrics/{view}/{section}", s.protected(platform.PermissionDashboardView, s.metricViewSection))
 		r.Get("/models", s.protected(platform.PermissionDashboardView, s.models))
 		r.Get("/models/{model}", s.protected(platform.PermissionDashboardView, s.model))
 		r.With(s.rateLimits.updatesMiddleware()).Get("/updates", s.protected(platform.PermissionDashboardView, s.updates))

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -19,6 +19,8 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/", s.protected(platform.PermissionDashboardView, s.home))
 		r.Get("/dashboards/{dashboard}", s.protected(platform.PermissionDashboardView, s.dashboard))
 		r.Get("/dashboards/{dashboard}/pages/{page}", s.protected(platform.PermissionDashboardView, s.page))
+		r.Get("/metrics", s.protected(platform.PermissionDashboardView, s.metricsCatalog))
+		r.Get("/metrics/{view}", s.protected(platform.PermissionDashboardView, s.metricView))
 		r.Get("/models", s.protected(platform.PermissionDashboardView, s.models))
 		r.Get("/models/{model}", s.protected(platform.PermissionDashboardView, s.model))
 		r.With(s.rateLimits.updatesMiddleware()).Get("/updates", s.protected(platform.PermissionDashboardView, s.updates))

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -123,14 +123,28 @@ func (s *Server) metricsCatalog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) metricView(w http.ResponseWriter, r *http.Request) {
+	viewID := r.PathValue("view")
+	if _, ok := s.metrics.MetricView(viewID); !ok {
+		http.NotFound(w, r)
+		return
+	}
+	http.Redirect(w, r, "/metrics/"+viewID+"/measures", http.StatusFound)
+}
+
+func (s *Server) metricViewSection(w http.ResponseWriter, r *http.Request) {
 	view, ok := s.metrics.MetricView(r.PathValue("view"))
 	if !ok {
 		http.NotFound(w, r)
 		return
 	}
+	section := r.PathValue("section")
+	if !ui.ValidMetricViewSection(section) {
+		http.NotFound(w, r)
+		return
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if err := ui.MetricViewPage(s.metrics.Catalog(), view).Render(w); err != nil {
+	if err := ui.MetricViewPage(s.metrics.Catalog(), view, section).Render(w); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -19,6 +19,8 @@ import (
 
 type queryMetrics interface {
 	Catalog() dashboard.Catalog
+	MetricViews() []dashboard.MetricViewSummary
+	MetricView(id string) (dashboard.MetricViewDetail, bool)
 	DefaultDashboardID() string
 	ModelIDForDashboard(dashboardID string) string
 	Report(dashboardID string) (semantic.Dashboard, *semantic.Model, bool)
@@ -110,6 +112,27 @@ func (s *Server) dashboard(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) page(w http.ResponseWriter, r *http.Request) {
 	s.renderPage(w, r, chi.URLParam(r, "dashboard"), chi.URLParam(r, "page"))
+}
+
+func (s *Server) metricsCatalog(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if err := ui.MetricViewsPage(s.metrics.Catalog(), s.metrics.MetricViews()).Render(w); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) metricView(w http.ResponseWriter, r *http.Request) {
+	view, ok := s.metrics.MetricView(r.PathValue("view"))
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if err := ui.MetricViewPage(s.metrics.Catalog(), view).Render(w); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func (s *Server) models(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -24,8 +24,11 @@ func (fakeMetrics) Catalog() dashboard.Catalog {
 		Models: []dashboard.CatalogModel{
 			{ID: "test", Title: "Test Model", Description: "Fixture model"},
 		},
+		MetricViews: []dashboard.CatalogMetricView{
+			{ID: "orders", Title: "Orders Metrics", Description: "Fixture metrics view", SemanticModel: "test", ModelTitle: "Test Model"},
+		},
 		Dashboards: []dashboard.CatalogDashboard{
-			{ID: "executive-sales", Title: "Executive Sales Dashboard", Description: "Fixture report", SemanticModel: "test", ModelTitle: "Test Model", Tags: []string{"sales"}, PageCount: 2},
+			{ID: "executive-sales", Title: "Executive Sales Dashboard", Description: "Fixture report", MetricViews: []string{"orders"}, MetricViewTitles: []string{"Orders Metrics"}, Tags: []string{"sales"}, PageCount: 2},
 		},
 	}
 }
@@ -50,17 +53,17 @@ func (fakeMetrics) Report(dashboardID string) (semantic.Dashboard, *semantic.Mod
 		return semantic.Dashboard{}, nil, false
 	}
 	return semantic.Dashboard{
-			ID:            "executive-sales",
-			Title:         "Executive Sales Dashboard",
-			SemanticModel: "test",
+			ID:          "executive-sales",
+			Title:       "Executive Sales Dashboard",
+			MetricViews: []string{"orders"},
 			Filters: map[string]semantic.FilterDefinition{
-				"state": {Type: "multi_select", Label: "State", Dataset: "orders", Dimension: "status", URLParam: "state", Operator: "in", Values: semantic.FilterValues{Source: "distinct", Limit: 50}},
+				"state": {Type: "multi_select", Label: "State", MetricView: "orders", Dimension: "status", URLParam: "state", Operator: "in", Values: semantic.FilterValues{Source: "distinct", Limit: 50}},
 			},
 			Visuals: map[string]semantic.Visual{
-				"orders": {Title: "Orders", Type: "donut", Dataset: "orders", Query: semantic.VisualQuery{Dimensions: []string{"status"}, Measures: []string{"order_count"}}, Interaction: semantic.Interaction{Field: "status"}},
+				"orders": {Title: "Orders", Type: "donut", MetricView: "orders", Query: semantic.VisualQuery{Dimensions: []string{"status"}, Measures: []string{"order_count"}}, Interaction: semantic.Interaction{Field: "status"}},
 			},
 			Tables: map[string]semantic.TableVisual{
-				"orders": {Title: "Orders", Dataset: "orders", DefaultSort: dashboard.TableSort{Key: "purchase_date", Direction: "desc"}, Columns: []dashboard.TableColumn{{Key: "order_id", Label: "Order"}}},
+				"orders": {Title: "Orders", MetricView: "orders", DefaultSort: dashboard.TableSort{Key: "purchase_date", Direction: "desc"}, Columns: []dashboard.TableColumn{{Key: "order_id", Label: "Order"}}},
 			},
 			Pages: fakeMetrics{}.Pages(dashboardID),
 		}, &semantic.Model{
@@ -68,8 +71,7 @@ func (fakeMetrics) Report(dashboardID string) (semantic.Dashboard, *semantic.Mod
 			Title: "Test Model",
 			Datasets: map[string]semantic.Dataset{
 				"orders": {
-					Dimensions: map[string]semantic.Dimension{"status": {Expr: "status"}},
-					Measures:   map[string]semantic.Measure{"order_count": {Aggregate: "count_distinct", Column: "order_id", Unit: "orders"}},
+					Source: "orders_enriched",
 				},
 			},
 		}, true

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -328,7 +328,7 @@ func TestMetricsRouteRendersMetricViewCatalog(t *testing.T) {
 	if !strings.Contains(body, `Orders Metrics`) {
 		t.Fatalf("metric view catalog missing metric view card:\n%s", body)
 	}
-	if !strings.Contains(body, `href="/metrics/orders"`) {
+	if !strings.Contains(body, `href="/metrics/orders/measures"`) {
 		t.Fatalf("metric view catalog missing detail link:\n%s", body)
 	}
 	if !strings.Contains(body, `Metric Views`) || !strings.Contains(body, `/metrics`) {
@@ -336,8 +336,22 @@ func TestMetricsRouteRendersMetricViewCatalog(t *testing.T) {
 	}
 }
 
-func TestMetricViewRouteRendersMetricViewDetail(t *testing.T) {
+func TestMetricViewRouteRedirectsToMeasures(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/metrics/orders", nil)
+	rec := httptest.NewRecorder()
+
+	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if got, want := rec.Header().Get("Location"), "/metrics/orders/measures"; got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+}
+
+func TestMetricViewMeasuresRouteRendersMeasuresTab(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/metrics/orders/measures", nil)
 	rec := httptest.NewRecorder()
 
 	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
@@ -349,24 +363,106 @@ func TestMetricViewRouteRendersMetricViewDetail(t *testing.T) {
 	for _, want := range []string{
 		`Orders Metrics`,
 		`href="/models/test"`,
-		`>Dataset</span><code>orders</code>`,
-		`>Timeseries</span><code>purchase_timestamp</code>`,
-		`<h2>Measures</h2>`,
-		`<h2>Dimensions</h2>`,
-		`Category`,
-		`e.category`,
+		`<code>orders</code>`,
+		`<code>purchase_timestamp</code>`,
+		`href="/metrics/orders/measures"`,
+		`href="/metrics/orders/dimensions"`,
+		`href="/metrics/orders/usage"`,
+		`aria-current="page"`,
+		`>Measures</h2>`,
 		`Revenue`,
 		`SUM(e.revenue)`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metric view measures tab missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, `metric-contract-rail`) || strings.Contains(body, `metric-rail-section`) {
+		t.Fatalf("metric view detail should not render the old right rail:\n%s", body)
+	}
+	for _, notWant := range []string{`>Dimensions</h2>`, `>Used by</h2>`, `metricUsageGraph`, `data-signals=`, `<ld-metric-usage-graph`} {
+		if strings.Contains(body, notWant) {
+			t.Fatalf("metric view measures tab should not render %q:\n%s", notWant, body)
+		}
+	}
+}
+
+func TestMetricViewDimensionsRouteRendersDimensionsTab(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/metrics/orders/dimensions", nil)
+	rec := httptest.NewRecorder()
+
+	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`>Dimensions</h2>`,
+		`aria-current="page"`,
+		`Category`,
+		`e.category`,
+		`Delivery speed`,
+		`e.delivery_bucket IS NOT NULL`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metric view dimensions tab missing %q:\n%s", want, body)
+		}
+	}
+	for _, notWant := range []string{`>Measures</h2>`, `>Used by</h2>`, `SUM(e.revenue)`, `<ld-metric-usage-graph`} {
+		if strings.Contains(body, notWant) {
+			t.Fatalf("metric view dimensions tab should not render %q:\n%s", notWant, body)
+		}
+	}
+}
+
+func TestMetricViewUsageRouteRendersUsageTab(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/metrics/orders/usage", nil)
+	rec := httptest.NewRecorder()
+
+	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`>Used by</h2>`,
+		`aria-current="page"`,
+		`data-signals=`,
+		`metricUsageGraph`,
+		`<ld-metric-usage-graph data-attr:graph="$metricUsageGraph"></ld-metric-usage-graph>`,
+		`<th>Dashboard</th>`,
+		`<th>Tags</th>`,
 		`href="/dashboards/executive-sales"`,
 	} {
 		if !strings.Contains(body, want) {
-			t.Fatalf("metric view detail missing %q:\n%s", want, body)
+			t.Fatalf("metric view usage tab missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, `data-graph=`) {
+		t.Fatalf("metric view detail should use signals instead of a serialized data-graph attribute:\n%s", body)
+	}
+	for _, notWant := range []string{`>Measures</h2>`, `>Dimensions</h2>`, `SUM(e.revenue)`, `e.category`} {
+		if strings.Contains(body, notWant) {
+			t.Fatalf("metric view usage tab should not render %q:\n%s", notWant, body)
 		}
 	}
 }
 
 func TestUnknownMetricViewRouteReturnsNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/metrics/missing", nil)
+	rec := httptest.NewRecorder()
+
+	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestUnknownMetricViewSectionRouteReturnsNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/metrics/orders/missing", nil)
 	rec := httptest.NewRecorder()
 
 	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -369,7 +369,11 @@ func TestMetricViewMeasuresRouteRendersMeasuresTab(t *testing.T) {
 		`href="/metrics/orders/dimensions"`,
 		`href="/metrics/orders/usage"`,
 		`aria-current="page"`,
-		`>Measures</h2>`,
+		`/static/detail-rail.js`,
+		`<ld-detail-rail class="metric-workspace">`,
+		`data-signals=`,
+		`metricGrid`,
+		`<ld-data-grid data-attr:grid="$metricGrid"></ld-data-grid>`,
 		`Revenue`,
 		`SUM(e.revenue)`,
 	} {
@@ -380,7 +384,7 @@ func TestMetricViewMeasuresRouteRendersMeasuresTab(t *testing.T) {
 	if strings.Contains(body, `metric-contract-rail`) || strings.Contains(body, `metric-rail-section`) {
 		t.Fatalf("metric view detail should not render the old right rail:\n%s", body)
 	}
-	for _, notWant := range []string{`>Dimensions</h2>`, `>Used by</h2>`, `metricUsageGraph`, `data-signals=`, `<ld-metric-usage-graph`} {
+	for _, notWant := range []string{`>Measures</h2>`, `>Dimensions</h2>`, `>Used by</h2>`, `metric-section-header`, `metricUsageGraph`, `<ld-metric-usage-graph`} {
 		if strings.Contains(body, notWant) {
 			t.Fatalf("metric view measures tab should not render %q:\n%s", notWant, body)
 		}
@@ -398,18 +402,19 @@ func TestMetricViewDimensionsRouteRendersDimensionsTab(t *testing.T) {
 	}
 	body := rec.Body.String()
 	for _, want := range []string{
-		`>Dimensions</h2>`,
 		`aria-current="page"`,
 		`Category`,
 		`e.category`,
 		`Delivery speed`,
 		`e.delivery_bucket IS NOT NULL`,
+		`metricGrid`,
+		`<ld-data-grid data-attr:grid="$metricGrid"></ld-data-grid>`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("metric view dimensions tab missing %q:\n%s", want, body)
 		}
 	}
-	for _, notWant := range []string{`>Measures</h2>`, `>Used by</h2>`, `SUM(e.revenue)`, `<ld-metric-usage-graph`} {
+	for _, notWant := range []string{`>Measures</h2>`, `>Dimensions</h2>`, `>Used by</h2>`, `metric-section-header`, `SUM(e.revenue)`, `<ld-metric-usage-graph`} {
 		if strings.Contains(body, notWant) {
 			t.Fatalf("metric view dimensions tab should not render %q:\n%s", notWant, body)
 		}
@@ -427,14 +432,15 @@ func TestMetricViewUsageRouteRendersUsageTab(t *testing.T) {
 	}
 	body := rec.Body.String()
 	for _, want := range []string{
-		`>Used by</h2>`,
 		`aria-current="page"`,
 		`data-signals=`,
 		`metricUsageGraph`,
 		`<ld-metric-usage-graph data-attr:graph="$metricUsageGraph"></ld-metric-usage-graph>`,
-		`<th>Dashboard</th>`,
-		`<th>Tags</th>`,
-		`href="/dashboards/executive-sales"`,
+		`metricGrid`,
+		`<ld-data-grid data-attr:grid="$metricGrid"></ld-data-grid>`,
+		`Dashboard`,
+		`Tags`,
+		`/dashboards/executive-sales`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("metric view usage tab missing %q:\n%s", want, body)
@@ -443,7 +449,7 @@ func TestMetricViewUsageRouteRendersUsageTab(t *testing.T) {
 	if strings.Contains(body, `data-graph=`) {
 		t.Fatalf("metric view detail should use signals instead of a serialized data-graph attribute:\n%s", body)
 	}
-	for _, notWant := range []string{`>Measures</h2>`, `>Dimensions</h2>`, `SUM(e.revenue)`, `e.category`} {
+	for _, notWant := range []string{`>Measures</h2>`, `>Dimensions</h2>`, `>Used by</h2>`, `metric-section-header`, `SUM(e.revenue)`, `e.category`} {
 		if strings.Contains(body, notWant) {
 			t.Fatalf("metric view usage tab should not render %q:\n%s", notWant, body)
 		}

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -33,6 +33,54 @@ func (fakeMetrics) Catalog() dashboard.Catalog {
 	}
 }
 
+func (fakeMetrics) MetricViews() []dashboard.MetricViewSummary {
+	return []dashboard.MetricViewSummary{
+		{
+			ID:             "orders",
+			Title:          "Orders Metrics",
+			Description:    "Fixture metrics view",
+			SemanticModel:  "test",
+			ModelTitle:     "Test Model",
+			Dataset:        "orders",
+			Timeseries:     "purchase_timestamp",
+			DimensionCount: 2,
+			MeasureCount:   2,
+			DashboardCount: 1,
+		},
+	}
+}
+
+func (fakeMetrics) MetricView(id string) (dashboard.MetricViewDetail, bool) {
+	if id != "orders" {
+		return dashboard.MetricViewDetail{}, false
+	}
+	return dashboard.MetricViewDetail{
+		MetricViewSummary: dashboard.MetricViewSummary{
+			ID:             "orders",
+			Title:          "Orders Metrics",
+			Description:    "Fixture metrics view",
+			SemanticModel:  "test",
+			ModelTitle:     "Test Model",
+			Dataset:        "orders",
+			Timeseries:     "purchase_timestamp",
+			DimensionCount: 2,
+			MeasureCount:   2,
+			DashboardCount: 1,
+		},
+		Dimensions: []dashboard.MetricViewDimension{
+			{Name: "category", Label: "Category", Expr: "e.category"},
+			{Name: "delivery_bucket", Label: "Delivery speed", Expr: "e.delivery_bucket", Where: "e.delivery_bucket IS NOT NULL", OrderExpr: "MIN(e.delivery_days)"},
+		},
+		Measures: []dashboard.MetricViewMeasure{
+			{Name: "order_count", Label: "Orders", Expression: "COUNT(DISTINCT e.order_id)", Unit: "orders", Format: "integer"},
+			{Name: "revenue", Label: "Revenue", Expression: "SUM(e.revenue)", Unit: "R$", Format: "currency", Description: "Total paid revenue"},
+		},
+		Dashboards: []dashboard.MetricViewDashboard{
+			{ID: "executive-sales", Title: "Executive Sales Dashboard", Description: "Fixture report", Tags: []string{"sales"}, PageCount: 2},
+		},
+	}, true
+}
+
 func (fakeMetrics) DefaultDashboardID() string {
 	return "executive-sales"
 }
@@ -124,9 +172,13 @@ func (fakeMetrics) ModelGraph(modelID string) (dashboard.ModelGraph, bool) {
 		Nodes: []dashboard.ModelNode{
 			{ID: "source:orders", Label: "orders", Kind: "source"},
 			{ID: "cache:orders_enriched", Label: "orders_enriched", Kind: "cache"},
+			{ID: "dataset:orders", Label: "orders", Kind: "dataset"},
+			{ID: "metrics_view:orders", Label: "Orders Metrics", Kind: "metrics_view"},
 		},
 		Edges: []dashboard.ModelEdge{
 			{ID: "orders_cache", Source: "source:orders", Target: "cache:orders_enriched", Kind: "materialization"},
+			{ID: "orders_dataset", Source: "cache:orders_enriched", Target: "dataset:orders", Kind: "dataset"},
+			{ID: "orders_metrics", Source: "dataset:orders", Target: "metrics_view:orders", Kind: "metrics"},
 		},
 	}, true
 }
@@ -257,6 +309,70 @@ func TestModelsRouteRendersSemanticModelCatalog(t *testing.T) {
 	}
 	if strings.Contains(body, `<ld-report-sidebar`) {
 		t.Fatalf("models catalog should not render report sidebar:\n%s", body)
+	}
+}
+
+func TestMetricsRouteRendersMetricViewCatalog(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+
+	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `Metric Views`) {
+		t.Fatalf("metric view catalog missing title:\n%s", body)
+	}
+	if !strings.Contains(body, `Orders Metrics`) {
+		t.Fatalf("metric view catalog missing metric view card:\n%s", body)
+	}
+	if !strings.Contains(body, `href="/metrics/orders"`) {
+		t.Fatalf("metric view catalog missing detail link:\n%s", body)
+	}
+	if !strings.Contains(body, `Metric Views`) || !strings.Contains(body, `/metrics`) {
+		t.Fatalf("sidebar missing metric views navigation:\n%s", body)
+	}
+}
+
+func TestMetricViewRouteRendersMetricViewDetail(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/metrics/orders", nil)
+	rec := httptest.NewRecorder()
+
+	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`Orders Metrics`,
+		`href="/models/test"`,
+		`>Dataset</span><code>orders</code>`,
+		`>Timeseries</span><code>purchase_timestamp</code>`,
+		`<h2>Measures</h2>`,
+		`<h2>Dimensions</h2>`,
+		`Category`,
+		`e.category`,
+		`Revenue`,
+		`SUM(e.revenue)`,
+		`href="/dashboards/executive-sales"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metric view detail missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestUnknownMetricViewRouteReturnsNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/metrics/missing", nil)
+	rec := httptest.NewRecorder()
+
+	New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
 

--- a/internal/dashboard/types.go
+++ b/internal/dashboard/types.go
@@ -8,9 +8,10 @@ type Signals struct {
 }
 
 type Catalog struct {
-	Workspace  CatalogWorkspace   `json:"workspace"`
-	Models     []CatalogModel     `json:"models"`
-	Dashboards []CatalogDashboard `json:"dashboards"`
+	Workspace   CatalogWorkspace    `json:"workspace"`
+	Models      []CatalogModel      `json:"models"`
+	MetricViews []CatalogMetricView `json:"metricViews"`
+	Dashboards  []CatalogDashboard  `json:"dashboards"`
 }
 
 type CatalogWorkspace struct {
@@ -25,14 +26,22 @@ type CatalogModel struct {
 	Description string `json:"description"`
 }
 
+type CatalogMetricView struct {
+	ID            string `json:"id"`
+	Title         string `json:"title"`
+	Description   string `json:"description"`
+	SemanticModel string `json:"semanticModel"`
+	ModelTitle    string `json:"modelTitle"`
+}
+
 type CatalogDashboard struct {
-	ID            string   `json:"id"`
-	Title         string   `json:"title"`
-	Description   string   `json:"description"`
-	SemanticModel string   `json:"semanticModel"`
-	ModelTitle    string   `json:"modelTitle"`
-	Tags          []string `json:"tags"`
-	PageCount     int      `json:"pageCount"`
+	ID               string   `json:"id"`
+	Title            string   `json:"title"`
+	Description      string   `json:"description"`
+	MetricViews      []string `json:"metricViews"`
+	MetricViewTitles []string `json:"metricViewTitles"`
+	Tags             []string `json:"tags"`
+	PageCount        int      `json:"pageCount"`
 }
 
 type Page struct {

--- a/internal/dashboard/types.go
+++ b/internal/dashboard/types.go
@@ -44,6 +44,51 @@ type CatalogDashboard struct {
 	PageCount        int      `json:"pageCount"`
 }
 
+type MetricViewSummary struct {
+	ID             string `json:"id"`
+	Title          string `json:"title"`
+	Description    string `json:"description"`
+	SemanticModel  string `json:"semanticModel"`
+	ModelTitle     string `json:"modelTitle"`
+	Dataset        string `json:"dataset"`
+	Timeseries     string `json:"timeseries"`
+	DimensionCount int    `json:"dimensionCount"`
+	MeasureCount   int    `json:"measureCount"`
+	DashboardCount int    `json:"dashboardCount"`
+}
+
+type MetricViewDetail struct {
+	MetricViewSummary
+	Dimensions []MetricViewDimension `json:"dimensions"`
+	Measures   []MetricViewMeasure   `json:"measures"`
+	Dashboards []MetricViewDashboard `json:"dashboards"`
+}
+
+type MetricViewDimension struct {
+	Name      string `json:"name"`
+	Label     string `json:"label"`
+	Expr      string `json:"expr"`
+	Where     string `json:"where,omitempty"`
+	OrderExpr string `json:"orderExpr,omitempty"`
+}
+
+type MetricViewMeasure struct {
+	Name        string `json:"name"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	Expression  string `json:"expression"`
+	Unit        string `json:"unit,omitempty"`
+	Format      string `json:"format,omitempty"`
+}
+
+type MetricViewDashboard struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
+	PageCount   int      `json:"pageCount"`
+}
+
 type Page struct {
 	ID          string       `json:"id" yaml:"id"`
 	Title       string       `json:"title" yaml:"title"`

--- a/internal/data/service.go
+++ b/internal/data/service.go
@@ -21,6 +21,7 @@ import (
 )
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var aggregateWrapperPattern = regexp.MustCompile(`(?is)^\s*(?:AVG|SUM|MIN|MAX|MEDIAN)\s*\((.+)\)\s*$`)
 
 type MissingDataError struct {
 	DataDir string
@@ -143,7 +144,11 @@ func (m *DuckDBMetrics) ModelIDForDashboard(dashboardID string) string {
 	if !ok {
 		return ""
 	}
-	return report.SemanticModel
+	view, ok := m.firstMetricView(report)
+	if !ok {
+		return ""
+	}
+	return view.SemanticModel
 }
 
 func (m *DuckDBMetrics) Report(dashboardID string) (semantic.Dashboard, *semantic.Model, bool) {
@@ -151,7 +156,11 @@ func (m *DuckDBMetrics) Report(dashboardID string) (semantic.Dashboard, *semanti
 	if !ok {
 		return semantic.Dashboard{}, nil, false
 	}
-	model, ok := m.workspace.Models[report.SemanticModel]
+	view, ok := m.firstMetricView(report)
+	if !ok {
+		return semantic.Dashboard{}, nil, false
+	}
+	model, ok := m.workspace.Models[view.SemanticModel]
 	if !ok {
 		return semantic.Dashboard{}, nil, false
 	}
@@ -237,7 +246,7 @@ func (m *DuckDBMetrics) ModelGraph(modelID string) (dashboard.ModelGraph, bool) 
 	if !ok {
 		return dashboard.ModelGraph{}, false
 	}
-	return modelGraph(model), true
+	return modelGraph(model, m.workspace.MetricViews), true
 }
 
 func (m *DuckDBMetrics) catalogView() dashboard.Catalog {
@@ -247,8 +256,9 @@ func (m *DuckDBMetrics) catalogView() dashboard.Catalog {
 			Title:       workspaceTitle(m.workspace.Catalog.Workspace),
 			Description: m.workspace.Catalog.Workspace.Description,
 		},
-		Models:     make([]dashboard.CatalogModel, 0, len(m.workspace.Catalog.SemanticModels)),
-		Dashboards: make([]dashboard.CatalogDashboard, 0, len(m.workspace.Catalog.Dashboards)),
+		Models:      make([]dashboard.CatalogModel, 0, len(m.workspace.Catalog.SemanticModels)),
+		MetricViews: make([]dashboard.CatalogMetricView, 0, len(m.workspace.Catalog.MetricViews)),
+		Dashboards:  make([]dashboard.CatalogDashboard, 0, len(m.workspace.Catalog.Dashboards)),
 	}
 	modelTitles := map[string]string{}
 	for _, model := range m.workspace.Catalog.SemanticModels {
@@ -259,19 +269,38 @@ func (m *DuckDBMetrics) catalogView() dashboard.Catalog {
 			Description: model.Description,
 		})
 	}
+	metricViewTitles := map[string]string{}
+	for _, view := range m.workspace.Catalog.MetricViews {
+		metricViewTitles[view.ID] = view.Title
+		catalog.MetricViews = append(catalog.MetricViews, dashboard.CatalogMetricView{
+			ID:            view.ID,
+			Title:         view.Title,
+			Description:   view.Description,
+			SemanticModel: view.SemanticModel,
+			ModelTitle:    modelTitles[view.SemanticModel],
+		})
+	}
 	for _, report := range m.workspace.Catalog.Dashboards {
 		pageCount := 0
+		metricViews := []string{}
+		metricViewNames := []string{}
 		if loaded, ok := m.workspace.Dashboards[report.ID]; ok {
 			pageCount = len(loaded.Pages)
+			metricViews = append(metricViews, loaded.MetricViews...)
+			for _, viewID := range loaded.MetricViews {
+				if title := metricViewTitles[viewID]; title != "" {
+					metricViewNames = append(metricViewNames, title)
+				}
+			}
 		}
 		catalog.Dashboards = append(catalog.Dashboards, dashboard.CatalogDashboard{
-			ID:            report.ID,
-			Title:         report.Title,
-			Description:   report.Description,
-			SemanticModel: report.SemanticModel,
-			ModelTitle:    modelTitles[report.SemanticModel],
-			Tags:          append([]string{}, report.Tags...),
-			PageCount:     pageCount,
+			ID:               report.ID,
+			Title:            report.Title,
+			Description:      report.Description,
+			MetricViews:      metricViews,
+			MetricViewTitles: metricViewNames,
+			Tags:             append([]string{}, report.Tags...),
+			PageCount:        pageCount,
 		})
 	}
 	return catalog
@@ -296,11 +325,23 @@ func (m *DuckDBMetrics) reportRuntime(dashboardID string) (*semantic.Dashboard, 
 	if !ok {
 		return nil, nil, fmt.Errorf("unknown dashboard %q", dashboardID)
 	}
-	runtime, ok := m.runtimes[report.SemanticModel]
+	view, ok := m.firstMetricView(report)
 	if !ok {
-		return nil, nil, fmt.Errorf("unknown semantic model %q", report.SemanticModel)
+		return nil, nil, fmt.Errorf("dashboard %q has no metrics views", dashboardID)
+	}
+	runtime, ok := m.runtimes[view.SemanticModel]
+	if !ok {
+		return nil, nil, fmt.Errorf("unknown semantic model %q", view.SemanticModel)
 	}
 	return report, runtime, nil
+}
+
+func (m *DuckDBMetrics) firstMetricView(report *semantic.Dashboard) (*semantic.MetricView, bool) {
+	if report == nil || len(report.MetricViews) == 0 {
+		return nil, false
+	}
+	view, ok := m.workspace.MetricViews[report.MetricViews[0]]
+	return view, ok
 }
 
 func (m *DuckDBMetrics) QueryDashboard(ctx context.Context, dashboardID string, filters dashboard.Filters) (dashboard.Patch, error) {
@@ -377,7 +418,7 @@ func (m *DuckDBMetrics) QueryTable(ctx context.Context, dashboardID string, filt
 		return m.queryAggregateTable(ctx, runtime, report, request, tableModel, filters)
 	}
 
-	totalRows, err := m.countRows(ctx, runtime, report, tableModel.Dataset, filters, "table", request.Table)
+	totalRows, err := m.countRows(ctx, runtime, report, tableModel.MetricView, filters, "table", request.Table)
 	if err != nil {
 		return dashboard.EmptyTable(request, err), nil
 	}
@@ -413,12 +454,12 @@ func (m *DuckDBMetrics) filterOptions(ctx context.Context, runtime *modelRuntime
 		if filter.Values.Source != "distinct" {
 			continue
 		}
-		source, err := datasetSource(runtime.model, filter.Dataset)
+		source, err := m.metricViewSource(filter.MetricView)
 		if err != nil {
 			return nil, err
 		}
-		dataset := runtime.model.Datasets[filter.Dataset]
-		dimension := dataset.Dimensions[filter.Dimension]
+		view := m.workspace.MetricViews[filter.MetricView]
+		dimension := view.Dimensions[filter.Dimension]
 		expr := dimensionExpression(dimension, "e")
 		where := "1 = 1"
 		if dimension.Where != "" {
@@ -592,7 +633,7 @@ func (m *DuckDBMetrics) kpis(ctx context.Context, runtime *modelRuntime, report 
 		if err != nil {
 			return nil, err
 		}
-		measure := runtime.model.Datasets[kpi.Dataset].Measures[kpi.Measure]
+		measure := m.workspace.MetricViews[kpi.MetricView].Measures[kpi.Measure]
 		kpis = append(kpis, dashboard.KPI{
 			Label: kpi.Title,
 			Value: formatMetric(value, measure.Format),
@@ -604,17 +645,17 @@ func (m *DuckDBMetrics) kpis(ctx context.Context, runtime *modelRuntime, report 
 }
 
 func (m *DuckDBMetrics) kpiValue(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, kpi semantic.KPI, filters dashboard.Filters) (float64, error) {
-	source, err := datasetSource(runtime.model, kpi.Dataset)
+	source, err := m.metricViewSource(kpi.MetricView)
 	if err != nil {
 		return 0, err
 	}
-	dataset := runtime.model.Datasets[kpi.Dataset]
+	dataset := m.workspace.MetricViews[kpi.MetricView]
 	measure := dataset.Measures[kpi.Measure]
 	expr, err := measureAggregateExpr(measure)
 	if err != nil {
 		return 0, err
 	}
-	where, args := m.filterWhere("e", runtime, report, kpi.Dataset, filters, "kpi", kpi.Measure)
+	where, args := m.filterWhere("e", runtime, report, kpi.MetricView, filters, "kpi", kpi.Measure)
 	query := fmt.Sprintf("SELECT COALESCE(%s, 0) FROM %s e WHERE %s", expr, source, where)
 
 	var value float64
@@ -637,7 +678,7 @@ func (m *DuckDBMetrics) charts(ctx context.Context, runtime *modelRuntime, repor
 		if err != nil {
 			return nil, err
 		}
-		dataset := runtime.model.Datasets[visual.Dataset]
+		dataset := m.workspace.MetricViews[visual.MetricView]
 		measureName := visual.Query.Measures[0]
 		measure := dataset.Measures[measureName]
 		unit := measure.Unit
@@ -705,11 +746,11 @@ func (m *DuckDBMetrics) visualData(ctx context.Context, runtime *modelRuntime, r
 }
 
 func (m *DuckDBMetrics) categoryData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	labelDimension := visual.Query.Dimensions[0]
 	labelExpr := dimensionExpression(dataset.Dimensions[labelDimension], "e")
 	measureName := visual.Query.Measures[0]
@@ -724,7 +765,7 @@ func (m *DuckDBMetrics) categoryData(ctx context.Context, runtime *modelRuntime,
 		groupBy = append(groupBy, "series")
 	}
 
-	where, args := m.filterWhere("e", runtime, report, visual.Dataset, filters, "visual", visualID)
+	where, args := m.filterWhere("e", runtime, report, visual.MetricView, filters, "visual", visualID)
 	for _, dimensionName := range append(append([]string{}, visual.Query.Dimensions...), visual.Query.Series) {
 		if dimensionName == "" {
 			continue
@@ -754,11 +795,11 @@ ORDER BY %s`, labelExpr, seriesExpr, valueExpr, source, where, strings.Join(grou
 }
 
 func (m *DuckDBMetrics) categoryMultiMeasureData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	labelExpr := dimensionExpression(dataset.Dimensions[visual.Query.Dimensions[0]], "e")
 	where, args := m.visualWhere(runtime, report, visual, filters, visualID)
 	orderBy := m.visualOrderBy(runtime.model, visual)
@@ -808,21 +849,22 @@ func (m *DuckDBMetrics) categoryDeltaData(ctx context.Context, runtime *modelRun
 }
 
 func (m *DuckDBMetrics) binnedMeasureData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	measure := dataset.Measures[visual.Query.Measures[0]]
-	if err := validateIdentifier(measure.Column); err != nil {
+	columnExpr, err := rawValueExpression(measure)
+	if err != nil {
 		return nil, err
 	}
-	columnExpr := "CAST(e." + measure.Column + " AS DOUBLE)"
+	columnExpr = "CAST(" + columnExpr + " AS DOUBLE)"
 	where, args := m.visualWhere(runtime, report, visual, filters, visualID)
 	binCount := optionInt(visual.Options, "bin_count", 20, 5, 60)
 
 	var minValue, maxValue sql.NullFloat64
-	boundsQuery := fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s e WHERE %s AND e.%s IS NOT NULL", columnExpr, columnExpr, source, where, measure.Column)
+	boundsQuery := fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s e WHERE %s AND %s IS NOT NULL", columnExpr, columnExpr, source, where, columnExpr)
 	if err := runtime.db.QueryRowContext(ctx, boundsQuery, args...).Scan(&minValue, &maxValue); err != nil {
 		return nil, err
 	}
@@ -831,7 +873,7 @@ func (m *DuckDBMetrics) binnedMeasureData(ctx context.Context, runtime *modelRun
 	}
 	if minValue.Float64 == maxValue.Float64 {
 		var count int
-		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s e WHERE %s AND e.%s IS NOT NULL", source, where, measure.Column)
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s e WHERE %s AND %s IS NOT NULL", source, where, columnExpr)
 		if err := runtime.db.QueryRowContext(ctx, countQuery, args...).Scan(&count); err != nil {
 			return nil, err
 		}
@@ -847,9 +889,9 @@ func (m *DuckDBMetrics) binnedMeasureData(ctx context.Context, runtime *modelRun
 	query := fmt.Sprintf(`
 SELECT %s AS bucket, COUNT(*) AS value
 FROM %s e
-WHERE %s AND e.%s IS NOT NULL
+WHERE %s AND %s IS NOT NULL
 GROUP BY bucket
-ORDER BY bucket ASC`, bucketExpr, source, where, measure.Column)
+ORDER BY bucket ASC`, bucketExpr, source, where, columnExpr)
 	queryArgs := append([]any{minValue.Float64, maxValue.Float64, minValue.Float64, binCount}, args...)
 	rows, err := runtime.db.QueryContext(ctx, query, queryArgs...)
 	if err != nil {
@@ -878,11 +920,11 @@ ORDER BY bucket ASC`, bucketExpr, source, where, measure.Column)
 }
 
 func (m *DuckDBMetrics) hierarchyData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	levelExprs := make([]string, 0, len(visual.Query.Dimensions))
 	levelAliases := make([]string, 0, len(visual.Query.Dimensions))
 	for index, dimensionName := range visual.Query.Dimensions {
@@ -938,11 +980,11 @@ ORDER BY %s`, strings.Join(levelExprs, ", "), valueExpr, source, where, strings.
 }
 
 func (m *DuckDBMetrics) singleValueData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	measureName := visual.Query.Measures[0]
 	valueExpr, err := measureAggregateExpr(dataset.Measures[measureName])
 	if err != nil {
@@ -976,11 +1018,11 @@ func (m *DuckDBMetrics) graphData(ctx context.Context, runtime *modelRuntime, re
 }
 
 func (m *DuckDBMetrics) dimensionPairData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters, leftAlias, rightAlias string) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	leftExpr := dimensionExpression(dataset.Dimensions[visual.Query.Dimensions[0]], "e")
 	rightExpr := dimensionExpression(dataset.Dimensions[visual.Query.Dimensions[1]], "e")
 	rightSQLAlias := rightAlias
@@ -1012,11 +1054,11 @@ ORDER BY %s`, leftExpr, leftAlias, rightExpr, rightSQLAlias, valueExpr, source, 
 }
 
 func (m *DuckDBMetrics) geoData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	nameExpr := dimensionExpression(dataset.Dimensions[visual.Query.Dimensions[0]], "e")
 	valueExpr, err := measureAggregateExpr(dataset.Measures[visual.Query.Measures[0]])
 	if err != nil {
@@ -1041,11 +1083,11 @@ ORDER BY %s`, nameExpr, valueExpr, source, where, m.visualOrderBy(runtime.model,
 }
 
 func (m *DuckDBMetrics) ohlcData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	labelExpr := dimensionExpression(dataset.Dimensions[visual.Query.Dimensions[0]], "e")
 	measureExprs := make([]string, 0, 4)
 	for _, measureName := range visual.Query.Measures {
@@ -1069,17 +1111,17 @@ ORDER BY %s`, labelExpr, measureExprs[0], measureExprs[1], measureExprs[2], meas
 }
 
 func (m *DuckDBMetrics) distributionData(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, visualID string, visual semantic.Visual, filters dashboard.Filters) ([]dashboard.Datum, error) {
-	source, err := datasetSource(runtime.model, visual.Dataset)
+	source, err := m.metricViewSource(visual.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	dataset := runtime.model.Datasets[visual.Dataset]
+	dataset := m.workspace.MetricViews[visual.MetricView]
 	labelExpr := dimensionExpression(dataset.Dimensions[visual.Query.Dimensions[0]], "e")
 	measure := dataset.Measures[visual.Query.Measures[0]]
-	if err := validateIdentifier(measure.Column); err != nil {
+	columnExpr, err := rawValueExpression(measure)
+	if err != nil {
 		return nil, err
 	}
-	columnExpr := "e." + measure.Column
 	where, args := m.visualWhere(runtime, report, visual, filters, visualID)
 	query := fmt.Sprintf(`
 SELECT %s AS label,
@@ -1099,8 +1141,8 @@ ORDER BY %s`, labelExpr, columnExpr, columnExpr, columnExpr, columnExpr, columnE
 }
 
 func (m *DuckDBMetrics) visualWhere(runtime *modelRuntime, report *semantic.Dashboard, visual semantic.Visual, filters dashboard.Filters, visualID string) (string, []any) {
-	dataset := runtime.model.Datasets[visual.Dataset]
-	where, args := m.filterWhere("e", runtime, report, visual.Dataset, filters, "visual", visualID)
+	dataset := m.workspace.MetricViews[visual.MetricView]
+	where, args := m.filterWhere("e", runtime, report, visual.MetricView, filters, "visual", visualID)
 	for _, dimensionName := range visualQueryDimensions(visual) {
 		if dimensionName == "" {
 			continue
@@ -1146,12 +1188,12 @@ func (m *DuckDBMetrics) queryDatums(ctx context.Context, runtime *modelRuntime, 
 	return data, rows.Err()
 }
 
-func (m *DuckDBMetrics) countRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, datasetName string, filters dashboard.Filters, targetKind, targetID string) (int, error) {
-	source, err := datasetSource(runtime.model, datasetName)
+func (m *DuckDBMetrics) countRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, metricViewID string, filters dashboard.Filters, targetKind, targetID string) (int, error) {
+	source, err := m.metricViewSource(metricViewID)
 	if err != nil {
 		return 0, err
 	}
-	where, args := m.filterWhere("e", runtime, report, datasetName, filters, targetKind, targetID)
+	where, args := m.filterWhere("e", runtime, report, metricViewID, filters, targetKind, targetID)
 	query := fmt.Sprintf("SELECT COUNT(*) FROM %s e WHERE %s", source, where)
 
 	var total int
@@ -1577,11 +1619,11 @@ func (m *DuckDBMetrics) tableRows(ctx context.Context, runtime *modelRuntime, re
 	if start+count > availableRows {
 		count = availableRows - start
 	}
-	source, err := datasetSource(runtime.model, table.Dataset)
+	source, err := m.metricViewSource(table.MetricView)
 	if err != nil {
 		return nil, err
 	}
-	where, args := m.filterWhere("e", runtime, report, table.Dataset, filters, "table", request.Table)
+	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
 	sortExpr := tableSortExpr(table, request.Sort.Key)
 	direction := "DESC"
 	if request.Sort.Direction == "asc" {
@@ -1630,36 +1672,28 @@ LIMIT ? OFFSET ?`, strings.Join(selects, ", "), source, where, sortExpr, directi
 	return result, rows.Err()
 }
 
-func measureAggregateExpr(measure semantic.Measure) (string, error) {
-	switch measure.Aggregate {
-	case "count":
-		return "COUNT(*)", nil
-	case "count_distinct":
-		if err := validateIdentifier(measure.Column); err != nil {
-			return "", err
-		}
-		return "COUNT(DISTINCT e." + measure.Column + ")", nil
-	case "sum":
-		if err := validateIdentifier(measure.Column); err != nil {
-			return "", err
-		}
-		return "SUM(e." + measure.Column + ")", nil
-	case "avg":
-		if err := validateIdentifier(measure.Column); err != nil {
-			return "", err
-		}
-		return "AVG(e." + measure.Column + ")", nil
-	case "expression":
-		if measure.Expression == "" {
-			return "", fmt.Errorf("measure %q is missing expression", measure.Label)
-		}
-		return measure.Expression, nil
-	default:
-		return "", fmt.Errorf("unsupported measure aggregate %q", measure.Aggregate)
+func measureAggregateExpr(measure semantic.MetricMeasure) (string, error) {
+	if strings.TrimSpace(measure.Expression) == "" {
+		return "", fmt.Errorf("measure %q is missing expression", measure.Label)
 	}
+	return measure.Expression, nil
 }
 
-func measureLabel(name string, measure semantic.Measure) string {
+func rawValueExpression(measure semantic.MetricMeasure) (string, error) {
+	expr := strings.TrimSpace(measure.Expression)
+	if expr == "" {
+		return "", fmt.Errorf("measure %q is missing expression", measure.Label)
+	}
+	if matches := aggregateWrapperPattern.FindStringSubmatch(expr); len(matches) == 2 {
+		return strings.TrimSpace(matches[1]), nil
+	}
+	if strings.Contains(expr, "(") {
+		return "", fmt.Errorf("measure %q cannot be used as a raw value expression", measure.Label)
+	}
+	return expr, nil
+}
+
+func measureLabel(name string, measure semantic.MetricMeasure) string {
 	if strings.TrimSpace(measure.Label) != "" {
 		return measure.Label
 	}
@@ -1740,7 +1774,7 @@ func (m *DuckDBMetrics) visualOrderBy(model *semantic.Model, visual semantic.Vis
 	if len(visual.Query.Sort) == 0 {
 		return "label ASC"
 	}
-	dataset := model.Datasets[visual.Dataset]
+	metricView := m.workspace.MetricViews[visual.MetricView]
 	parts := make([]string, 0, len(visual.Query.Sort))
 	for _, sortSpec := range visual.Query.Sort {
 		direction := "ASC"
@@ -1749,7 +1783,7 @@ func (m *DuckDBMetrics) visualOrderBy(model *semantic.Model, visual semantic.Vis
 		}
 		expr := sortSpec.Expr
 		if expr == "" {
-			expr = m.sortExpression(dataset, visual, sortSpec.Field)
+			expr = m.sortExpression(metricView, visual, sortSpec.Field)
 		}
 		if expr == "" {
 			expr = "label"
@@ -1759,7 +1793,7 @@ func (m *DuckDBMetrics) visualOrderBy(model *semantic.Model, visual semantic.Vis
 	return strings.Join(parts, ", ")
 }
 
-func (m *DuckDBMetrics) sortExpression(dataset semantic.Dataset, visual semantic.Visual, field string) string {
+func (m *DuckDBMetrics) sortExpression(metricView *semantic.MetricView, visual semantic.Visual, field string) string {
 	if field == "" {
 		return defaultSortColumn(visual)
 	}
@@ -1769,7 +1803,10 @@ func (m *DuckDBMetrics) sortExpression(dataset semantic.Dataset, visual semantic
 	if field == visual.Query.Series {
 		return "series"
 	}
-	if dimension, ok := dataset.Dimensions[field]; ok {
+	if metricView == nil {
+		return ""
+	}
+	if dimension, ok := metricView.Dimensions[field]; ok {
 		if dimension.OrderExpr != "" {
 			return dimension.OrderExpr
 		}
@@ -1819,25 +1856,25 @@ func dimensionSortColumn(shape string, index int) string {
 	}
 }
 
-func (m *DuckDBMetrics) filterWhere(alias string, runtime *modelRuntime, report *semantic.Dashboard, datasetName string, filters dashboard.Filters, targetKind, targetID string) (string, []any) {
+func (m *DuckDBMetrics) filterWhere(alias string, runtime *modelRuntime, report *semantic.Dashboard, metricViewID string, filters dashboard.Filters, targetKind, targetID string) (string, []any) {
 	filters = normalizeFilters(report, filters)
 	conditions := []string{"1 = 1"}
 	args := []any{}
 
 	for _, name := range sortedKeys(report.Filters) {
 		filter := report.Filters[name]
-		if filter.Dataset != datasetName {
+		if filter.MetricView != metricViewID {
 			continue
 		}
 		control, ok := filters.Controls[name]
 		if !ok {
 			continue
 		}
-		dataset, ok := runtime.model.Datasets[filter.Dataset]
+		metricView, ok := m.workspace.MetricViews[filter.MetricView]
 		if !ok {
 			continue
 		}
-		dimension, ok := dataset.Dimensions[filter.Dimension]
+		dimension, ok := metricView.Dimensions[filter.Dimension]
 		if !ok {
 			continue
 		}
@@ -1895,11 +1932,11 @@ func (m *DuckDBMetrics) filterWhere(alias string, runtime *modelRuntime, report 
 		if selection.Operator != "" && selection.Operator != "in" {
 			continue
 		}
-		dataset, ok := runtime.model.Datasets[datasetName]
+		metricView, ok := m.workspace.MetricViews[metricViewID]
 		if !ok {
 			continue
 		}
-		dimension, ok := dataset.Dimensions[selection.Field]
+		dimension, ok := metricView.Dimensions[selection.Field]
 		if !ok {
 			continue
 		}
@@ -1936,12 +1973,12 @@ func (m *DuckDBMetrics) dateFilterCondition(runtime *modelRuntime, filter semant
 			continue
 		}
 		if preset.RelativeDays > 0 {
-			source, err := datasetSource(runtime.model, filter.Dataset)
+			source, err := m.metricViewSource(filter.MetricView)
 			if err != nil {
 				return "", nil
 			}
-			dataset := runtime.model.Datasets[filter.Dataset]
-			dimension := dataset.Dimensions[filter.Dimension]
+			metricView := m.workspace.MetricViews[filter.MetricView]
+			dimension := metricView.Dimensions[filter.Dimension]
 			sourceExpr := dimensionExpression(dimension, "recent")
 			return fmt.Sprintf("%s >= (SELECT max(%s) - INTERVAL %d DAY FROM %s recent)", expr, sourceExpr, preset.RelativeDays, source), nil
 		}
@@ -1972,14 +2009,14 @@ func contains(values []string, value string) bool {
 	return false
 }
 
-func dimensionExpression(dimension semantic.Dimension, alias string) string {
+func dimensionExpression(dimension semantic.MetricDimension, alias string) string {
 	if identifierPattern.MatchString(dimension.Expr) {
 		return alias + "." + dimension.Expr
 	}
 	return strings.ReplaceAll(dimension.Expr, "{alias}", alias)
 }
 
-func dimensionWhere(dimension semantic.Dimension, alias string) string {
+func dimensionWhere(dimension semantic.MetricDimension, alias string) string {
 	if dimension.Where == "" {
 		return ""
 	}
@@ -2044,10 +2081,18 @@ func normalizeDBValue(value any) any {
 	}
 }
 
-func datasetSource(model *semantic.Model, name string) (string, error) {
-	dataset, ok := model.Datasets[name]
+func (m *DuckDBMetrics) metricViewSource(name string) (string, error) {
+	view, ok := m.workspace.MetricViews[name]
 	if !ok {
-		return "", fmt.Errorf("unknown dataset %q", name)
+		return "", fmt.Errorf("unknown metrics view %q", name)
+	}
+	model, ok := m.workspace.Models[view.SemanticModel]
+	if !ok {
+		return "", fmt.Errorf("unknown semantic model %q", view.SemanticModel)
+	}
+	dataset, ok := model.Datasets[view.Dataset]
+	if !ok {
+		return "", fmt.Errorf("metrics view %q references unknown dataset %q", name, view.Dataset)
 	}
 	return cacheSource(dataset.Source)
 }
@@ -2091,14 +2136,14 @@ func sqlString(path string) string {
 	return strings.ReplaceAll(filepath.ToSlash(path), "'", "''")
 }
 
-func modelGraph(model *semantic.Model) dashboard.ModelGraph {
+func modelGraph(model *semantic.Model, metricViews map[string]*semantic.MetricView) dashboard.ModelGraph {
 	graph := dashboard.ModelGraph{
 		Name:  model.Name,
 		Title: model.Title,
 		Stats: dashboard.ModelStats{
 			Sources:       len(model.Sources),
 			CacheTables:   len(model.Cache.Tables),
-			Metrics:       measureCount(model),
+			Metrics:       measureCount(model.Name, metricViews),
 			Visuals:       0,
 			ReportTables:  0,
 			Relationships: len(model.Relationships),
@@ -2162,23 +2207,13 @@ func modelGraph(model *semantic.Model) dashboard.ModelGraph {
 
 	for _, name := range sortedKeys(model.Datasets) {
 		dataset := model.Datasets[name]
-		fields := make([]dashboard.ModelField, 0, len(dataset.Dimensions)+len(dataset.Measures))
-		for _, dimension := range sortedKeys(dataset.Dimensions) {
-			fields = append(fields, dashboard.ModelField{Name: dimension, Role: "dimension"})
-		}
-		for _, measure := range sortedKeys(dataset.Measures) {
-			fields = append(fields, dashboard.ModelField{Name: measure, Role: "measure"})
-		}
 		graph.Nodes = append(graph.Nodes, dashboard.ModelNode{
 			ID:     nodeID("dataset", name),
 			Label:  name,
 			Kind:   "dataset",
 			Schema: "semantic",
-			Fields: fields,
 			Meta: []dashboard.ModelMeta{
 				{Label: "Source", Value: dataset.Source},
-				{Label: "Dimensions", Value: strconv.Itoa(len(dataset.Dimensions))},
-				{Label: "Measures", Value: strconv.Itoa(len(dataset.Measures))},
 			},
 		})
 		graph.Edges = append(graph.Edges, dashboard.ModelEdge{
@@ -2187,6 +2222,41 @@ func modelGraph(model *semantic.Model) dashboard.ModelGraph {
 			Target: nodeID("dataset", name),
 			Label:  "semantic dataset",
 			Kind:   "semantic",
+		})
+	}
+
+	for _, name := range sortedKeys(metricViews) {
+		view := metricViews[name]
+		if view.SemanticModel != model.Name {
+			continue
+		}
+		fields := make([]dashboard.ModelField, 0, len(view.Dimensions)+len(view.Measures))
+		for _, dimension := range sortedKeys(view.Dimensions) {
+			fields = append(fields, dashboard.ModelField{Name: dimension, Role: "dimension"})
+		}
+		for _, measure := range sortedKeys(view.Measures) {
+			fields = append(fields, dashboard.ModelField{Name: measure, Role: "measure"})
+		}
+		graph.Nodes = append(graph.Nodes, dashboard.ModelNode{
+			ID:          nodeID("metrics_view", name),
+			Label:       view.Title,
+			Kind:        "metrics_view",
+			Schema:      "metrics",
+			Description: view.Description,
+			Fields:      fields,
+			Meta: []dashboard.ModelMeta{
+				{Label: "Dataset", Value: view.Dataset},
+				{Label: "Timeseries", Value: view.Timeseries},
+				{Label: "Dimensions", Value: strconv.Itoa(len(view.Dimensions))},
+				{Label: "Measures", Value: strconv.Itoa(len(view.Measures))},
+			},
+		})
+		graph.Edges = append(graph.Edges, dashboard.ModelEdge{
+			ID:     "metrics_view_" + name + "_from_" + view.Dataset,
+			Source: nodeID("dataset", view.Dataset),
+			Target: nodeID("metrics_view", name),
+			Label:  "metrics view",
+			Kind:   "metrics",
 		})
 	}
 
@@ -2234,10 +2304,12 @@ func refreshLabel(runtime *modelRuntime) string {
 	return runtime.lastRefresh.Format("15:04:05")
 }
 
-func measureCount(model *semantic.Model) int {
+func measureCount(modelID string, metricViews map[string]*semantic.MetricView) int {
 	count := 0
-	for _, dataset := range model.Datasets {
-		count += len(dataset.Measures)
+	for _, view := range metricViews {
+		if view.SemanticModel == modelID {
+			count += len(view.Measures)
+		}
 	}
 	return count
 }

--- a/internal/data/service.go
+++ b/internal/data/service.go
@@ -1392,29 +1392,30 @@ func (m *DuckDBMetrics) matrixTableRows(ctx context.Context, runtime *modelRunti
 	if len(table.ColumnDims) == 1 {
 		return m.crossTabTableRows(ctx, runtime, report, table, filters, request, false)
 	}
-	source, err := datasetSource(runtime.model, table.Dataset)
+	source, err := m.metricViewSource(table.MetricView)
 	if err != nil {
 		return nil, nil, err
 	}
-	dataset := runtime.model.Datasets[table.Dataset]
+	metricView := m.workspace.MetricViews[table.MetricView]
 	columns := make([]dashboard.TableColumn, 0, len(table.Rows)+len(table.Measures))
 	selects := make([]string, 0, len(table.Rows)+len(table.Measures))
 	groupBy := make([]string, 0, len(table.Rows))
 	for _, dimensionName := range table.Rows {
-		dimension := dataset.Dimensions[dimensionName]
+		dimension := metricView.Dimensions[dimensionName]
 		selects = append(selects, fmt.Sprintf("%s AS %s", dimensionExpression(dimension, "e"), dimensionName))
 		groupBy = append(groupBy, dimensionName)
 		columns = append(columns, dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header"})
 	}
 	for _, measureName := range table.Measures {
-		expr, err := measureAggregateExpr(dataset.Measures[measureName])
+		measure := metricView.Measures[measureName]
+		expr, err := measureAggregateExpr(measure)
 		if err != nil {
 			return nil, nil, err
 		}
 		selects = append(selects, fmt.Sprintf("%s AS %s", expr, measureName))
-		columns = append(columns, dashboard.TableColumn{Key: measureName, Label: measureLabel(measureName, dataset.Measures[measureName]), Align: "right", Role: "measure", Measure: measureName})
+		columns = append(columns, dashboard.TableColumn{Key: measureName, Label: measureLabel(measureName, measure), Align: "right", Role: "measure", Measure: measureName})
 	}
-	where, args := m.filterWhere("e", runtime, report, table.Dataset, filters, "table", request.Table)
+	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
 	orderBy := strings.Join(groupBy, ", ")
 	if request.Sort.Key != "" && tableHasColumn(columns, request.Sort.Key) {
 		direction := "DESC"
@@ -1440,26 +1441,26 @@ func (m *DuckDBMetrics) pivotTableRows(ctx context.Context, runtime *modelRuntim
 }
 
 func (m *DuckDBMetrics) crossTabTableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest, pivotMode bool) ([]dashboard.TableColumn, []map[string]any, error) {
-	source, err := datasetSource(runtime.model, table.Dataset)
+	source, err := m.metricViewSource(table.MetricView)
 	if err != nil {
 		return nil, nil, err
 	}
-	dataset := runtime.model.Datasets[table.Dataset]
+	metricView := m.workspace.MetricViews[table.MetricView]
 	rowSelects := make([]string, 0, len(table.Rows))
 	groupBy := make([]string, 0, len(table.Rows)+1)
 	baseColumns := make([]dashboard.TableColumn, 0, len(table.Rows))
 	for _, dimensionName := range table.Rows {
-		dimension := dataset.Dimensions[dimensionName]
+		dimension := metricView.Dimensions[dimensionName]
 		rowSelects = append(rowSelects, fmt.Sprintf("%s AS %s", dimensionExpression(dimension, "e"), dimensionName))
 		groupBy = append(groupBy, dimensionName)
 		baseColumns = append(baseColumns, dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header"})
 	}
 	columnDimensionName := table.ColumnDims[0]
-	columnDimension := dataset.Dimensions[columnDimensionName]
+	columnDimension := metricView.Dimensions[columnDimensionName]
 	valueSelects := make([]string, 0, len(table.Measures))
 	valueColumns := make([]string, 0, len(table.Measures))
 	for _, measureName := range table.Measures {
-		measureExpr, err := measureAggregateExpr(dataset.Measures[measureName])
+		measureExpr, err := measureAggregateExpr(metricView.Measures[measureName])
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1467,7 +1468,7 @@ func (m *DuckDBMetrics) crossTabTableRows(ctx context.Context, runtime *modelRun
 		valueColumns = append(valueColumns, measureName)
 	}
 	groupBy = append(groupBy, "pivot_label")
-	where, args := m.filterWhere("e", runtime, report, table.Dataset, filters, "table", request.Table)
+	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
 	query := fmt.Sprintf(`
 SELECT %s, %s AS pivot_label, %s
 FROM %s e
@@ -1507,7 +1508,7 @@ LIMIT ?`, strings.Join(rowSelects, ", "), dimensionExpression(columnDimension, "
 		label := fmt.Sprint(raw["pivot_label"])
 		groupLabel := label
 		if pivotMode {
-			groupLabel = measureLabel(table.Measures[0], dataset.Measures[table.Measures[0]])
+			groupLabel = measureLabel(table.Measures[0], metricView.Measures[table.Measures[0]])
 		}
 		pivotKey, exists := pivotKeys[label]
 		if !exists {
@@ -1515,7 +1516,7 @@ LIMIT ?`, strings.Join(rowSelects, ", "), dimensionExpression(columnDimension, "
 			pivotKeys[label] = pivotKey
 		}
 		for _, measureName := range table.Measures {
-			measure := dataset.Measures[measureName]
+			measure := metricView.Measures[measureName]
 			columnIdentity := label + "\x00" + measureName
 			columnKey, columnExists := columnKeys[columnIdentity]
 			candidate := "pivot_" + pivotKey
@@ -1649,7 +1650,7 @@ func numericTableValue(value any) (float64, bool) {
 	}
 }
 
-func dimensionLabel(name string, dimension semantic.Dimension) string {
+func dimensionLabel(name string, dimension semantic.MetricDimension) string {
 	if strings.TrimSpace(dimension.Label) != "" {
 		return dimension.Label
 	}

--- a/internal/data/service.go
+++ b/internal/data/service.go
@@ -135,6 +135,58 @@ func (m *DuckDBMetrics) Catalog() dashboard.Catalog {
 	return m.catalog
 }
 
+func (m *DuckDBMetrics) MetricViews() []dashboard.MetricViewSummary {
+	summaries := make([]dashboard.MetricViewSummary, 0, len(m.workspace.MetricViews))
+	for _, id := range sortedKeys(m.workspace.MetricViews) {
+		summary, ok := m.metricViewSummary(id)
+		if ok {
+			summaries = append(summaries, summary)
+		}
+	}
+	return summaries
+}
+
+func (m *DuckDBMetrics) MetricView(id string) (dashboard.MetricViewDetail, bool) {
+	summary, ok := m.metricViewSummary(id)
+	if !ok {
+		return dashboard.MetricViewDetail{}, false
+	}
+	view := m.workspace.MetricViews[id]
+	detail := dashboard.MetricViewDetail{MetricViewSummary: summary}
+
+	for _, name := range sortedKeys(view.Dimensions) {
+		dimension := view.Dimensions[name]
+		detail.Dimensions = append(detail.Dimensions, dashboard.MetricViewDimension{
+			Name:      name,
+			Label:     dimension.Label,
+			Expr:      dimension.Expr,
+			Where:     dimension.Where,
+			OrderExpr: dimension.OrderExpr,
+		})
+	}
+	for _, name := range sortedKeys(view.Measures) {
+		measure := view.Measures[name]
+		detail.Measures = append(detail.Measures, dashboard.MetricViewMeasure{
+			Name:        name,
+			Label:       measure.Label,
+			Description: measure.Description,
+			Expression:  measure.Expression,
+			Unit:        measure.Unit,
+			Format:      measure.Format,
+		})
+	}
+	for _, report := range m.dashboardsForMetricView(id) {
+		detail.Dashboards = append(detail.Dashboards, dashboard.MetricViewDashboard{
+			ID:          report.ID,
+			Title:       report.Title,
+			Description: report.Description,
+			Tags:        append([]string{}, report.Tags...),
+			PageCount:   dashboardPageCount(m.workspace.Dashboards[report.ID]),
+		})
+	}
+	return detail, true
+}
+
 func (m *DuckDBMetrics) DefaultDashboardID() string {
 	return m.defaultID
 }
@@ -304,6 +356,51 @@ func (m *DuckDBMetrics) catalogView() dashboard.Catalog {
 		})
 	}
 	return catalog
+}
+
+func (m *DuckDBMetrics) metricViewSummary(id string) (dashboard.MetricViewSummary, bool) {
+	view, ok := m.workspace.MetricViews[id]
+	if !ok {
+		return dashboard.MetricViewSummary{}, false
+	}
+	modelTitle := ""
+	for _, model := range m.workspace.Catalog.SemanticModels {
+		if model.ID == view.SemanticModel {
+			modelTitle = model.Title
+			break
+		}
+	}
+	return dashboard.MetricViewSummary{
+		ID:             view.ID,
+		Title:          view.Title,
+		Description:    view.Description,
+		SemanticModel:  view.SemanticModel,
+		ModelTitle:     modelTitle,
+		Dataset:        view.Dataset,
+		Timeseries:     view.Timeseries,
+		DimensionCount: len(view.Dimensions),
+		MeasureCount:   len(view.Measures),
+		DashboardCount: len(m.dashboardsForMetricView(id)),
+	}, true
+}
+
+func (m *DuckDBMetrics) dashboardsForMetricView(id string) []semantic.CatalogDashboard {
+	reports := []semantic.CatalogDashboard{}
+	for _, report := range m.workspace.Catalog.Dashboards {
+		loaded, ok := m.workspace.Dashboards[report.ID]
+		if !ok || !contains(loaded.MetricViews, id) {
+			continue
+		}
+		reports = append(reports, report)
+	}
+	return reports
+}
+
+func dashboardPageCount(report *semantic.Dashboard) int {
+	if report == nil {
+		return 0
+	}
+	return len(report.Pages)
 }
 
 func workspaceID(workspace semantic.CatalogWorkspace) string {

--- a/internal/data/service_test.go
+++ b/internal/data/service_test.go
@@ -127,6 +127,54 @@ relogios_presentes,watches_gifts
 		t.Fatalf("expected DuckDB cache file: %v", err)
 	}
 
+	views := metrics.MetricViews()
+	if len(views) != 1 {
+		t.Fatalf("metric views = %d, want 1", len(views))
+	}
+	if got := views[0].ID; got != "orders" {
+		t.Fatalf("metric view id = %q, want orders", got)
+	}
+	if got := views[0].DimensionCount; got != 7 {
+		t.Fatalf("metric view dimension count = %d, want 7", got)
+	}
+	if got := views[0].MeasureCount; got != 5 {
+		t.Fatalf("metric view measure count = %d, want 5", got)
+	}
+	if got := views[0].DashboardCount; got != 1 {
+		t.Fatalf("metric view dashboard count = %d, want 1", got)
+	}
+
+	view, ok := metrics.MetricView("orders")
+	if !ok {
+		t.Fatal("metric view orders not found")
+	}
+	if got := view.Dataset; got != "orders" {
+		t.Fatalf("metric view dataset = %q, want orders", got)
+	}
+	if got := view.Timeseries; got != "purchase_timestamp" {
+		t.Fatalf("metric view timeseries = %q, want purchase_timestamp", got)
+	}
+	if !hasMetricDimension(view.Dimensions, "category", "e.category") {
+		t.Fatalf("metric view dimensions missing category: %#v", view.Dimensions)
+	}
+	if !hasMetricMeasure(view.Measures, "revenue", "SUM(e.revenue)") {
+		t.Fatalf("metric view measures missing revenue: %#v", view.Measures)
+	}
+	if len(view.Dashboards) != 1 || view.Dashboards[0].ID != "executive-sales" {
+		t.Fatalf("metric view dashboards = %#v, want executive-sales", view.Dashboards)
+	}
+
+	graph, ok := metrics.ModelGraph("olist")
+	if !ok {
+		t.Fatal("model graph olist not found")
+	}
+	if !hasModelNode(graph.Nodes, "metrics_view:orders") {
+		t.Fatalf("model graph missing metrics view node: %#v", graph.Nodes)
+	}
+	if !hasModelEdge(graph.Edges, "dataset:orders", "metrics_view:orders") {
+		t.Fatalf("model graph missing dataset to metrics view edge: %#v", graph.Edges)
+	}
+
 	patch, err := metrics.QueryDashboard(context.Background(), "executive-sales", dashboard.Filters{Controls: map[string]dashboard.FilterControl{
 		"state":         {Type: "multi_select", Operator: "in", Values: []string{"SP"}},
 		"purchase_date": {Type: "date_range", Preset: "2018"},
@@ -468,6 +516,42 @@ func hasHierarchyPathValue(rows []dashboard.Datum, value string) bool {
 func tableRowsHaveKey(rows []map[string]any, key string) bool {
 	for _, row := range rows {
 		if _, ok := row[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMetricDimension(dimensions []dashboard.MetricViewDimension, name, expr string) bool {
+	for _, dimension := range dimensions {
+		if dimension.Name == name && dimension.Expr == expr {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMetricMeasure(measures []dashboard.MetricViewMeasure, name, expression string) bool {
+	for _, measure := range measures {
+		if measure.Name == name && measure.Expression == expression {
+			return true
+		}
+	}
+	return false
+}
+
+func hasModelNode(nodes []dashboard.ModelNode, id string) bool {
+	for _, node := range nodes {
+		if node.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func hasModelEdge(edges []dashboard.ModelEdge, source, target string) bool {
+	for _, edge := range edges {
+		if edge.Source == source && edge.Target == target {
 			return true
 		}
 	}

--- a/internal/deploy/assets.go
+++ b/internal/deploy/assets.go
@@ -59,20 +59,29 @@ func ExtractAssets(workspaceID, deploymentID string, workspace *semantic.Workspa
 				return nil, nil, err
 			}
 			edge(datasetID, byKey["cache_table:"+modelEntry.ID+"."+dataset.Source], "uses_cache_table")
-			for dimensionName, dimension := range dataset.Dimensions {
-				id, err := add("dimension", modelEntry.ID+"."+datasetName+"."+dimensionName, datasetID, dimensionLabel(dimensionName, dimension.Label), "", dimension)
-				if err != nil {
-					return nil, nil, err
-				}
-				edge(datasetID, id, "contains")
+		}
+	}
+	for _, viewEntry := range workspace.Catalog.MetricViews {
+		view := workspace.MetricViews[viewEntry.ID]
+		viewID, err := add("metric_view", viewEntry.ID, byKey["semantic_model:"+view.SemanticModel], viewEntry.Title, viewEntry.Description, view)
+		if err != nil {
+			return nil, nil, err
+		}
+		edge(byKey["semantic_model:"+view.SemanticModel], viewID, "contains")
+		edge(viewID, byKey["dataset:"+view.SemanticModel+"."+view.Dataset], "uses_dataset")
+		for dimensionName, dimension := range view.Dimensions {
+			id, err := add("dimension", view.ID+"."+dimensionName, viewID, dimensionLabel(dimensionName, dimension.Label), "", dimension)
+			if err != nil {
+				return nil, nil, err
 			}
-			for measureName, measure := range dataset.Measures {
-				id, err := add("measure", modelEntry.ID+"."+datasetName+"."+measureName, datasetID, measureLabel(measureName, measure.Label), "", measure)
-				if err != nil {
-					return nil, nil, err
-				}
-				edge(datasetID, id, "contains")
+			edge(viewID, id, "contains")
+		}
+		for measureName, measure := range view.Measures {
+			id, err := add("measure", view.ID+"."+measureName, viewID, measureLabel(measureName, measure.Label), "", measure)
+			if err != nil {
+				return nil, nil, err
 			}
+			edge(viewID, id, "contains")
 		}
 	}
 	for _, reportEntry := range workspace.Catalog.Dashboards {
@@ -81,7 +90,9 @@ func ExtractAssets(workspaceID, deploymentID string, workspace *semantic.Workspa
 		if err != nil {
 			return nil, nil, err
 		}
-		edge(reportID, byKey["semantic_model:"+reportEntry.SemanticModel], "uses_model")
+		for _, viewID := range report.MetricViews {
+			edge(reportID, byKey["metric_view:"+viewID], "uses_metric_view")
+		}
 		for _, page := range report.Pages {
 			pageID, err := add("page", report.ID+"."+page.ID, reportID, page.Title, page.Description, page)
 			if err != nil {
@@ -94,29 +105,29 @@ func ExtractAssets(workspaceID, deploymentID string, workspace *semantic.Workspa
 			if err != nil {
 				return nil, nil, err
 			}
-			edge(filterID, byKey["dimension:"+report.SemanticModel+"."+filter.Dataset+"."+filter.Dimension], "filters_dimension")
+			edge(filterID, byKey["dimension:"+filter.MetricView+"."+filter.Dimension], "filters_dimension")
 		}
 		for kpiName, kpi := range report.KPIs {
 			kpiID, err := add("kpi", report.ID+"."+kpiName, reportID, kpi.Title, kpi.Note, kpi)
 			if err != nil {
 				return nil, nil, err
 			}
-			edge(kpiID, byKey["measure:"+report.SemanticModel+"."+kpi.Dataset+"."+kpi.Measure], "uses_measure")
+			edge(kpiID, byKey["measure:"+kpi.MetricView+"."+kpi.Measure], "uses_measure")
 		}
 		for visualName, visual := range report.Visuals {
 			visualID, err := add("visual", report.ID+"."+visualName, reportID, visual.Title, "", visual)
 			if err != nil {
 				return nil, nil, err
 			}
-			edge(visualID, byKey["dataset:"+report.SemanticModel+"."+visual.Dataset], "uses_dataset")
+			edge(visualID, byKey["metric_view:"+visual.MetricView], "uses_metric_view")
 			for _, measure := range visual.Query.Measures {
-				edge(visualID, byKey["measure:"+report.SemanticModel+"."+visual.Dataset+"."+measure], "uses_measure")
+				edge(visualID, byKey["measure:"+visual.MetricView+"."+measure], "uses_measure")
 			}
 			for _, dimension := range visual.Query.Dimensions {
-				edge(visualID, byKey["dimension:"+report.SemanticModel+"."+visual.Dataset+"."+dimension], "uses_dimension")
+				edge(visualID, byKey["dimension:"+visual.MetricView+"."+dimension], "uses_dimension")
 			}
 			if visual.Query.Series != "" {
-				edge(visualID, byKey["dimension:"+report.SemanticModel+"."+visual.Dataset+"."+visual.Query.Series], "uses_dimension")
+				edge(visualID, byKey["dimension:"+visual.MetricView+"."+visual.Query.Series], "uses_dimension")
 			}
 		}
 		for tableName, table := range report.Tables {
@@ -124,7 +135,16 @@ func ExtractAssets(workspaceID, deploymentID string, workspace *semantic.Workspa
 			if err != nil {
 				return nil, nil, err
 			}
-			edge(tableID, byKey["dataset:"+report.SemanticModel+"."+table.Dataset], "uses_dataset")
+			edge(tableID, byKey["metric_view:"+table.MetricView], "uses_metric_view")
+			for _, row := range table.Rows {
+				edge(tableID, byKey["dimension:"+table.MetricView+"."+row], "uses_dimension")
+			}
+			for _, dimension := range table.ColumnDims {
+				edge(tableID, byKey["dimension:"+table.MetricView+"."+dimension], "uses_dimension")
+			}
+			for _, measure := range table.Measures {
+				edge(tableID, byKey["measure:"+table.MetricView+"."+measure], "uses_measure")
+			}
 		}
 	}
 	return assets, edges, nil

--- a/internal/deploy/bundle.go
+++ b/internal/deploy/bundle.go
@@ -29,6 +29,7 @@ type Manifest struct {
 	CatalogPath    string         `json:"catalogPath"`
 	Files          []ManifestFile `json:"files"`
 	SemanticModels []string       `json:"semanticModels"`
+	MetricViews    []string       `json:"metricViews"`
 	Dashboards     []string       `json:"dashboards"`
 }
 
@@ -62,6 +63,9 @@ func PackCatalog(catalogPath string, out io.Writer) (Manifest, string, error) {
 	for _, model := range workspace.Catalog.SemanticModels {
 		relFiles = append(relFiles, cleanBundlePath(model.Path))
 	}
+	for _, view := range workspace.Catalog.MetricViews {
+		relFiles = append(relFiles, cleanBundlePath(view.Path))
+	}
 	for _, report := range workspace.Catalog.Dashboards {
 		relFiles = append(relFiles, cleanBundlePath(report.Path))
 	}
@@ -80,6 +84,9 @@ func PackCatalog(catalogPath string, out io.Writer) (Manifest, string, error) {
 	}
 	for _, model := range workspace.Catalog.SemanticModels {
 		manifest.SemanticModels = append(manifest.SemanticModels, model.ID)
+	}
+	for _, view := range workspace.Catalog.MetricViews {
+		manifest.MetricViews = append(manifest.MetricViews, view.ID)
 	}
 	for _, report := range workspace.Catalog.Dashboards {
 		manifest.Dashboards = append(manifest.Dashboards, report.ID)

--- a/internal/deploy/bundle_test.go
+++ b/internal/deploy/bundle_test.go
@@ -36,7 +36,7 @@ func TestPackValidateAndExtractAssets(t *testing.T) {
 	for _, asset := range validation.Assets {
 		types[asset.Type] = true
 	}
-	for _, typ := range []string{"catalog", "semantic_model", "dashboard", "page", "visual", "kpi", "filter", "table", "dataset", "measure", "dimension", "cache_table", "source"} {
+	for _, typ := range []string{"catalog", "semantic_model", "metric_view", "dashboard", "page", "visual", "kpi", "filter", "table", "dataset", "measure", "dimension", "cache_table", "source"} {
 		if !types[typ] {
 			t.Fatalf("missing asset type %q", typ)
 		}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -165,6 +165,22 @@ func (m *Manager) Catalog() dashboard.Catalog {
 	return metrics.Catalog()
 }
 
+func (m *Manager) MetricViews() []dashboard.MetricViewSummary {
+	metrics, err := m.metrics()
+	if err != nil {
+		return nil
+	}
+	return metrics.MetricViews()
+}
+
+func (m *Manager) MetricView(id string) (dashboard.MetricViewDetail, bool) {
+	metrics, err := m.metrics()
+	if err != nil {
+		return dashboard.MetricViewDetail{}, false
+	}
+	return metrics.MetricView(id)
+}
+
 func (m *Manager) DefaultDashboardID() string {
 	metrics, err := m.metrics()
 	if err != nil {

--- a/internal/semantic/catalog.go
+++ b/internal/semantic/catalog.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Catalog struct {
-	Workspace      CatalogWorkspace   `yaml:"workspace"`
-	SemanticModels []CatalogModel     `yaml:"semantic_models"`
-	Dashboards     []CatalogDashboard `yaml:"dashboards"`
+	Workspace      CatalogWorkspace    `yaml:"workspace"`
+	SemanticModels []CatalogModel      `yaml:"semantic_models"`
+	MetricViews    []CatalogMetricView `yaml:"metrics_views"`
+	Dashboards     []CatalogDashboard  `yaml:"dashboards"`
 }
 
 type CatalogWorkspace struct {
@@ -27,20 +28,28 @@ type CatalogModel struct {
 	Description string `yaml:"description"`
 }
 
+type CatalogMetricView struct {
+	ID            string `yaml:"id"`
+	Title         string `yaml:"title"`
+	Path          string `yaml:"path"`
+	Description   string `yaml:"description"`
+	SemanticModel string `yaml:"semantic_model"`
+}
+
 type CatalogDashboard struct {
-	ID            string   `yaml:"id"`
-	Title         string   `yaml:"title"`
-	SemanticModel string   `yaml:"semantic_model"`
-	Path          string   `yaml:"path"`
-	Description   string   `yaml:"description"`
-	Tags          []string `yaml:"tags"`
+	ID          string   `yaml:"id"`
+	Title       string   `yaml:"title"`
+	Path        string   `yaml:"path"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags"`
 }
 
 type Workspace struct {
-	Catalog    Catalog
-	Models     map[string]*Model
-	Dashboards map[string]*Dashboard
-	BaseDir    string
+	Catalog     Catalog
+	Models      map[string]*Model
+	MetricViews map[string]*MetricView
+	Dashboards  map[string]*Dashboard
+	BaseDir     string
 }
 
 func LoadWorkspace(path string) (*Workspace, error) {
@@ -58,10 +67,11 @@ func LoadWorkspace(path string) (*Workspace, error) {
 	}
 
 	workspace := &Workspace{
-		Catalog:    catalog,
-		Models:     map[string]*Model{},
-		Dashboards: map[string]*Dashboard{},
-		BaseDir:    baseDir,
+		Catalog:     catalog,
+		Models:      map[string]*Model{},
+		MetricViews: map[string]*MetricView{},
+		Dashboards:  map[string]*Dashboard{},
+		BaseDir:     baseDir,
 	}
 
 	for _, entry := range catalog.SemanticModels {
@@ -75,17 +85,28 @@ func LoadWorkspace(path string) (*Workspace, error) {
 		workspace.Models[entry.ID] = model
 	}
 
-	for _, entry := range catalog.Dashboards {
+	for _, entry := range catalog.MetricViews {
 		model := workspace.Models[entry.SemanticModel]
-		report, err := LoadDashboard(filepath.Join(baseDir, entry.Path), model)
+		view, err := LoadMetricView(filepath.Join(baseDir, entry.Path), model)
+		if err != nil {
+			return nil, fmt.Errorf("loading metrics view %q: %w", entry.ID, err)
+		}
+		if view.ID != entry.ID {
+			return nil, fmt.Errorf("catalog metrics view %q path loads metrics view %q", entry.ID, view.ID)
+		}
+		if view.SemanticModel != entry.SemanticModel {
+			return nil, fmt.Errorf("catalog metrics view %q references model %q but file references %q", entry.ID, entry.SemanticModel, view.SemanticModel)
+		}
+		workspace.MetricViews[entry.ID] = view
+	}
+
+	for _, entry := range catalog.Dashboards {
+		report, err := LoadDashboard(filepath.Join(baseDir, entry.Path), workspace.MetricViews)
 		if err != nil {
 			return nil, fmt.Errorf("loading dashboard %q: %w", entry.ID, err)
 		}
 		if report.ID != entry.ID {
 			return nil, fmt.Errorf("catalog dashboard %q path loads dashboard %q", entry.ID, report.ID)
-		}
-		if report.SemanticModel != entry.SemanticModel {
-			return nil, fmt.Errorf("catalog dashboard %q references model %q but file references %q", entry.ID, entry.SemanticModel, report.SemanticModel)
 		}
 		workspace.Dashboards[entry.ID] = report
 	}
@@ -96,6 +117,9 @@ func LoadWorkspace(path string) (*Workspace, error) {
 func (c Catalog) Validate(baseDir string) error {
 	if len(c.SemanticModels) == 0 {
 		return fmt.Errorf("catalog requires semantic_models")
+	}
+	if len(c.MetricViews) == 0 {
+		return fmt.Errorf("catalog requires metrics_views")
 	}
 	if len(c.Dashboards) == 0 {
 		return fmt.Errorf("catalog requires dashboards")
@@ -114,18 +138,32 @@ func (c Catalog) Validate(baseDir string) error {
 		}
 	}
 
+	metricViews := map[string]struct{}{}
+	for index, view := range c.MetricViews {
+		if view.ID == "" || view.Title == "" || view.Path == "" || view.SemanticModel == "" {
+			return fmt.Errorf("catalog metrics view %d requires id, title, path, and semantic_model", index)
+		}
+		if _, exists := metricViews[view.ID]; exists {
+			return fmt.Errorf("duplicate metrics view id %q", view.ID)
+		}
+		metricViews[view.ID] = struct{}{}
+		if _, ok := models[view.SemanticModel]; !ok {
+			return fmt.Errorf("metrics view %q references unknown semantic model %q", view.ID, view.SemanticModel)
+		}
+		if _, err := os.Stat(filepath.Join(baseDir, view.Path)); err != nil {
+			return fmt.Errorf("metrics view %q path %q: %w", view.ID, view.Path, err)
+		}
+	}
+
 	dashboards := map[string]struct{}{}
 	for index, report := range c.Dashboards {
-		if report.ID == "" || report.Title == "" || report.SemanticModel == "" || report.Path == "" {
-			return fmt.Errorf("catalog dashboard %d requires id, title, semantic_model, and path", index)
+		if report.ID == "" || report.Title == "" || report.Path == "" {
+			return fmt.Errorf("catalog dashboard %d requires id, title, and path", index)
 		}
 		if _, exists := dashboards[report.ID]; exists {
 			return fmt.Errorf("duplicate dashboard id %q", report.ID)
 		}
 		dashboards[report.ID] = struct{}{}
-		if _, ok := models[report.SemanticModel]; !ok {
-			return fmt.Errorf("dashboard %q references unknown semantic model %q", report.ID, report.SemanticModel)
-		}
 		if _, err := os.Stat(filepath.Join(baseDir, report.Path)); err != nil {
 			return fmt.Errorf("dashboard %q path %q: %w", report.ID, report.Path, err)
 		}

--- a/internal/semantic/dashboard.go
+++ b/internal/semantic/dashboard.go
@@ -12,21 +12,21 @@ import (
 )
 
 type Dashboard struct {
-	ID            string                      `yaml:"id"`
-	Title         string                      `yaml:"title"`
-	Description   string                      `yaml:"description"`
-	SemanticModel string                      `yaml:"semantic_model"`
-	Filters       map[string]FilterDefinition `yaml:"filters"`
-	KPIs          map[string]KPI              `yaml:"kpis"`
-	Visuals       map[string]Visual           `yaml:"visuals"`
-	Tables        map[string]TableVisual      `yaml:"tables"`
-	Pages         []dashboard.Page            `yaml:"pages"`
+	ID          string                      `yaml:"id"`
+	Title       string                      `yaml:"title"`
+	Description string                      `yaml:"description"`
+	MetricViews []string                    `yaml:"metrics_views"`
+	Filters     map[string]FilterDefinition `yaml:"filters"`
+	KPIs        map[string]KPI              `yaml:"kpis"`
+	Visuals     map[string]Visual           `yaml:"visuals"`
+	Tables      map[string]TableVisual      `yaml:"tables"`
+	Pages       []dashboard.Page            `yaml:"pages"`
 }
 
 type FilterDefinition struct {
 	Type             string         `yaml:"type" json:"type"`
 	Label            string         `yaml:"label" json:"label"`
-	Dataset          string         `yaml:"dataset" json:"dataset"`
+	MetricView       string         `yaml:"metrics_view" json:"metricsView"`
 	Dimension        string         `yaml:"dimension" json:"dimension"`
 	Default          FilterDefault  `yaml:"default" json:"default"`
 	Custom           bool           `yaml:"custom" json:"custom,omitempty"`
@@ -70,11 +70,11 @@ type FilterValues struct {
 }
 
 type KPI struct {
-	Title   string `yaml:"title"`
-	Dataset string `yaml:"dataset"`
-	Measure string `yaml:"measure"`
-	Note    string `yaml:"note"`
-	Tone    string `yaml:"tone"`
+	Title      string `yaml:"title"`
+	MetricView string `yaml:"metrics_view"`
+	Measure    string `yaml:"measure"`
+	Note       string `yaml:"note"`
+	Tone       string `yaml:"tone"`
 }
 
 type Visual struct {
@@ -83,7 +83,7 @@ type Visual struct {
 	Shape           string         `yaml:"shape"`
 	Renderer        string         `yaml:"renderer"`
 	Type            string         `yaml:"type"`
-	Dataset         string         `yaml:"dataset"`
+	MetricView      string         `yaml:"metrics_view"`
 	Query           VisualQuery    `yaml:"query"`
 	Options         map[string]any `yaml:"options"`
 	RendererOptions map[string]any `yaml:"renderer_options"`
@@ -117,7 +117,7 @@ type InteractionTargets struct {
 type TableVisual struct {
 	Kind        string                  `yaml:"kind"`
 	Title       string                  `yaml:"title"`
-	Dataset     string                  `yaml:"dataset"`
+	MetricView  string                  `yaml:"metrics_view"`
 	DefaultSort dashboard.TableSort     `yaml:"default_sort"`
 	Columns     []dashboard.TableColumn `yaml:"columns"`
 	Rows        []string                `yaml:"rows"`
@@ -129,7 +129,7 @@ func (t *TableVisual) UnmarshalYAML(value *yaml.Node) error {
 	type rawTableVisual struct {
 		Kind        string              `yaml:"kind"`
 		Title       string              `yaml:"title"`
-		Dataset     string              `yaml:"dataset"`
+		MetricView  string              `yaml:"metrics_view"`
 		DefaultSort dashboard.TableSort `yaml:"default_sort"`
 		Rows        []string            `yaml:"rows"`
 		Measures    []string            `yaml:"measures"`
@@ -140,7 +140,7 @@ func (t *TableVisual) UnmarshalYAML(value *yaml.Node) error {
 	}
 	t.Kind = raw.Kind
 	t.Title = raw.Title
-	t.Dataset = raw.Dataset
+	t.MetricView = raw.MetricView
 	t.DefaultSort = raw.DefaultSort
 	t.Rows = raw.Rows
 	t.Measures = raw.Measures
@@ -242,7 +242,7 @@ func copyMap(source map[string]any) map[string]any {
 	return next
 }
 
-func LoadDashboard(path string, model *Model) (*Dashboard, error) {
+func LoadDashboard(path string, metricViews map[string]*MetricView) (*Dashboard, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -254,7 +254,7 @@ func LoadDashboard(path string, model *Model) (*Dashboard, error) {
 	if err := rejectLegacyVisualStacked(bytes); err != nil {
 		return nil, err
 	}
-	if err := report.Validate(model); err != nil {
+	if err := report.Validate(metricViews); err != nil {
 		return nil, err
 	}
 	return &report, nil
@@ -308,15 +308,27 @@ func mappingValue(node *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
-func (d *Dashboard) Validate(model *Model) error {
-	if d.ID == "" || d.Title == "" || d.SemanticModel == "" {
-		return fmt.Errorf("dashboard requires id, title, and semantic_model")
+func (d *Dashboard) Validate(metricViews map[string]*MetricView) error {
+	if d.ID == "" || d.Title == "" {
+		return fmt.Errorf("dashboard requires id and title")
 	}
-	if model == nil {
-		return fmt.Errorf("dashboard %q requires semantic model %q", d.ID, d.SemanticModel)
+	if len(d.MetricViews) == 0 {
+		return fmt.Errorf("dashboard %q requires metrics_views", d.ID)
 	}
-	if d.SemanticModel != model.Name {
-		return fmt.Errorf("dashboard %q semantic_model %q does not match model %q", d.ID, d.SemanticModel, model.Name)
+	allowedViews := map[string]*MetricView{}
+	modelName := ""
+	for _, viewName := range d.MetricViews {
+		view, ok := metricViews[viewName]
+		if !ok {
+			return fmt.Errorf("dashboard %q references unknown metrics view %q", d.ID, viewName)
+		}
+		if modelName == "" {
+			modelName = view.SemanticModel
+		}
+		if view.SemanticModel != modelName {
+			return fmt.Errorf("dashboard %q metrics views must use one semantic model", d.ID)
+		}
+		allowedViews[viewName] = view
 	}
 	if len(d.KPIs) == 0 {
 		return fmt.Errorf("dashboard %q requires kpis", d.ID)
@@ -328,14 +340,14 @@ func (d *Dashboard) Validate(model *Model) error {
 		return fmt.Errorf("dashboard %q requires pages", d.ID)
 	}
 	for name, filter := range d.Filters {
-		if filter.Type == "" || filter.Label == "" || filter.Dataset == "" || filter.Dimension == "" {
-			return fmt.Errorf("filter %q requires type, label, dataset, and dimension", name)
+		if filter.Type == "" || filter.Label == "" || filter.MetricView == "" || filter.Dimension == "" {
+			return fmt.Errorf("filter %q requires type, label, metrics_view, and dimension", name)
 		}
-		dataset, ok := model.Datasets[filter.Dataset]
+		view, ok := allowedViews[filter.MetricView]
 		if !ok {
-			return fmt.Errorf("filter %q references unknown dataset %q", name, filter.Dataset)
+			return fmt.Errorf("filter %q references unknown metrics view %q", name, filter.MetricView)
 		}
-		if _, ok := dataset.Dimensions[filter.Dimension]; !ok {
+		if _, ok := view.Dimensions[filter.Dimension]; !ok {
 			return fmt.Errorf("filter %q references unknown dimension %q", name, filter.Dimension)
 		}
 		switch filter.Type {
@@ -398,24 +410,24 @@ func (d *Dashboard) Validate(model *Model) error {
 		return err
 	}
 	for name, kpi := range d.KPIs {
-		if kpi.Title == "" || kpi.Dataset == "" || kpi.Measure == "" {
-			return fmt.Errorf("kpi %q requires title, dataset, and measure", name)
+		if kpi.Title == "" || kpi.MetricView == "" || kpi.Measure == "" {
+			return fmt.Errorf("kpi %q requires title, metrics_view, and measure", name)
 		}
-		dataset, ok := model.Datasets[kpi.Dataset]
+		view, ok := allowedViews[kpi.MetricView]
 		if !ok {
-			return fmt.Errorf("kpi %q references unknown dataset %q", name, kpi.Dataset)
+			return fmt.Errorf("kpi %q references unknown metrics view %q", name, kpi.MetricView)
 		}
-		if _, ok := dataset.Measures[kpi.Measure]; !ok {
+		if _, ok := view.Measures[kpi.Measure]; !ok {
 			return fmt.Errorf("kpi %q references unknown measure %q", name, kpi.Measure)
 		}
 	}
 	for name, visual := range d.Visuals {
-		if visual.Title == "" || visual.Dataset == "" || visual.Type == "" {
-			return fmt.Errorf("visual %q requires title, dataset, and type", name)
+		if visual.Title == "" || visual.MetricView == "" || visual.Type == "" {
+			return fmt.Errorf("visual %q requires title, metrics_view, and type", name)
 		}
-		dataset, ok := model.Datasets[visual.Dataset]
+		view, ok := allowedViews[visual.MetricView]
 		if !ok {
-			return fmt.Errorf("visual %q references unknown dataset %q", name, visual.Dataset)
+			return fmt.Errorf("visual %q references unknown metrics view %q", name, visual.MetricView)
 		}
 		kind := visual.KindOrDefault()
 		shape := visual.ShapeOrDefault()
@@ -442,12 +454,12 @@ func (d *Dashboard) Validate(model *Model) error {
 			return err
 		}
 		for _, dimension := range visual.Query.Dimensions {
-			if _, ok := dataset.Dimensions[dimension]; !ok {
+			if _, ok := view.Dimensions[dimension]; !ok {
 				return fmt.Errorf("visual %q references unknown dimension %q", name, dimension)
 			}
 		}
 		if visual.Query.Series != "" {
-			if _, ok := dataset.Dimensions[visual.Query.Series]; !ok {
+			if _, ok := view.Dimensions[visual.Query.Series]; !ok {
 				return fmt.Errorf("visual %q references unknown series dimension %q", name, visual.Query.Series)
 			}
 			if !supportsSeries(shape) {
@@ -458,12 +470,9 @@ func (d *Dashboard) Validate(model *Model) error {
 			}
 		}
 		for _, measure := range visual.Query.Measures {
-			if _, ok := dataset.Measures[measure]; !ok {
+			if _, ok := view.Measures[measure]; !ok {
 				return fmt.Errorf("visual %q references unknown measure %q", name, measure)
 			}
-		}
-		if (shape == "distribution" || shape == "binned_measure") && dataset.Measures[visual.Query.Measures[0]].Column == "" {
-			return fmt.Errorf("visual %q shape %s requires a column-backed measure", name, shape)
 		}
 		if shape == "geo" {
 			if mapName, ok := visual.Options["map"].(string); !ok || strings.TrimSpace(mapName) == "" {
@@ -475,26 +484,26 @@ func (d *Dashboard) Validate(model *Model) error {
 				return fmt.Errorf("visual %q has sort missing field or expr", name)
 			}
 			if sort.Field != "" && sort.Field != "value" && sort.Field != visual.Query.Series {
-				if _, ok := dataset.Dimensions[sort.Field]; !ok {
-					if _, ok := dataset.Measures[sort.Field]; !ok {
+				if _, ok := view.Dimensions[sort.Field]; !ok {
+					if _, ok := view.Measures[sort.Field]; !ok {
 						return fmt.Errorf("visual %q sort references unknown field %q", name, sort.Field)
 					}
 				}
 			}
 		}
 		if visual.Interaction.Field != "" {
-			if _, ok := dataset.Dimensions[visual.Interaction.Field]; !ok {
+			if _, ok := view.Dimensions[visual.Interaction.Field]; !ok {
 				return fmt.Errorf("visual %q interaction references unknown field %q", name, visual.Interaction.Field)
 			}
 		}
 	}
 	for name, table := range d.Tables {
-		if table.Title == "" || table.Dataset == "" {
-			return fmt.Errorf("table %q requires title and dataset", name)
+		if table.Title == "" || table.MetricView == "" {
+			return fmt.Errorf("table %q requires title and metrics_view", name)
 		}
-		dataset, ok := model.Datasets[table.Dataset]
+		view, ok := allowedViews[table.MetricView]
 		if !ok {
-			return fmt.Errorf("table %q references unknown dataset %q", name, table.Dataset)
+			return fmt.Errorf("table %q references unknown metrics view %q", name, table.MetricView)
 		}
 		switch table.KindOrDefault() {
 		case "data_table":
@@ -509,12 +518,12 @@ func (d *Dashboard) Validate(model *Model) error {
 				return fmt.Errorf("table %q kind matrix_table supports at most one column dimension", name)
 			}
 			for _, dimension := range append(append([]string{}, table.Rows...), table.ColumnDims...) {
-				if _, ok := dataset.Dimensions[dimension]; !ok {
+				if _, ok := view.Dimensions[dimension]; !ok {
 					return fmt.Errorf("table %q references unknown dimension %q", name, dimension)
 				}
 			}
 			for _, measure := range table.Measures {
-				if _, ok := dataset.Measures[measure]; !ok {
+				if _, ok := view.Measures[measure]; !ok {
 					return fmt.Errorf("table %q references unknown measure %q", name, measure)
 				}
 			}
@@ -523,11 +532,11 @@ func (d *Dashboard) Validate(model *Model) error {
 				return fmt.Errorf("table %q kind pivot_table requires rows, one column dimension, and one measure", name)
 			}
 			for _, dimension := range append(append([]string{}, table.Rows...), table.ColumnDims...) {
-				if _, ok := dataset.Dimensions[dimension]; !ok {
+				if _, ok := view.Dimensions[dimension]; !ok {
 					return fmt.Errorf("table %q references unknown dimension %q", name, dimension)
 				}
 			}
-			if _, ok := dataset.Measures[table.Measures[0]]; !ok {
+			if _, ok := view.Measures[table.Measures[0]]; !ok {
 				return fmt.Errorf("table %q references unknown measure %q", name, table.Measures[0])
 			}
 		default:

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -32,25 +32,33 @@ type CacheTable struct {
 }
 
 type Dataset struct {
-	Source     string               `yaml:"source"`
-	Dimensions map[string]Dimension `yaml:"dimensions"`
-	Measures   map[string]Measure   `yaml:"measures"`
+	Source string `yaml:"source"`
 }
 
-type Dimension struct {
+type MetricView struct {
+	ID            string                     `yaml:"id"`
+	Title         string                     `yaml:"title"`
+	Description   string                     `yaml:"description"`
+	SemanticModel string                     `yaml:"semantic_model"`
+	Dataset       string                     `yaml:"dataset"`
+	Timeseries    string                     `yaml:"timeseries"`
+	Dimensions    map[string]MetricDimension `yaml:"dimensions"`
+	Measures      map[string]MetricMeasure   `yaml:"measures"`
+}
+
+type MetricDimension struct {
 	Label     string `yaml:"label"`
 	Expr      string `yaml:"expr"`
 	Where     string `yaml:"where"`
 	OrderExpr string `yaml:"order_expr"`
 }
 
-type Measure struct {
-	Label      string `yaml:"label"`
-	Aggregate  string `yaml:"aggregate"`
-	Column     string `yaml:"column"`
-	Expression string `yaml:"expression"`
-	Unit       string `yaml:"unit"`
-	Format     string `yaml:"format"`
+type MetricMeasure struct {
+	Label       string `yaml:"label"`
+	Description string `yaml:"description"`
+	Expression  string `yaml:"expression"`
+	Unit        string `yaml:"unit"`
+	Format      string `yaml:"format"`
 }
 
 type Relationship struct {
@@ -106,28 +114,6 @@ func (m *Model) Validate() error {
 		if _, ok := m.Cache.Tables[dataset.Source]; !ok {
 			return fmt.Errorf("dataset %q references unknown cache table %q", name, dataset.Source)
 		}
-		if len(dataset.Dimensions) == 0 {
-			return fmt.Errorf("dataset %q requires dimensions", name)
-		}
-		if len(dataset.Measures) == 0 {
-			return fmt.Errorf("dataset %q requires measures", name)
-		}
-		for dimensionName, dimension := range dataset.Dimensions {
-			if dimension.Expr == "" {
-				return fmt.Errorf("dataset %q dimension %q requires expr", name, dimensionName)
-			}
-		}
-		for measureName, measure := range dataset.Measures {
-			if measure.Aggregate == "" {
-				return fmt.Errorf("dataset %q measure %q requires aggregate", name, measureName)
-			}
-			if measure.Aggregate != "count" && measure.Aggregate != "expression" && measure.Column == "" {
-				return fmt.Errorf("dataset %q measure %q requires column", name, measureName)
-			}
-			if measure.Aggregate == "expression" && measure.Expression == "" {
-				return fmt.Errorf("dataset %q measure %q requires expression", name, measureName)
-			}
-		}
 	}
 	seenRelationships := map[string]struct{}{}
 	for index, relationship := range m.Relationships {
@@ -138,6 +124,59 @@ func (m *Model) Validate() error {
 			return fmt.Errorf("duplicate relationship id %q", relationship.ID)
 		}
 		seenRelationships[relationship.ID] = struct{}{}
+	}
+	return nil
+}
+
+func LoadMetricView(path string, model *Model) (*MetricView, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var view MetricView
+	if err := yaml.Unmarshal(bytes, &view); err != nil {
+		return nil, err
+	}
+	if err := view.Validate(model); err != nil {
+		return nil, err
+	}
+	return &view, nil
+}
+
+func (v *MetricView) Validate(model *Model) error {
+	if v.ID == "" || v.Title == "" || v.SemanticModel == "" || v.Dataset == "" {
+		return fmt.Errorf("metrics view requires id, title, semantic_model, and dataset")
+	}
+	if model == nil {
+		return fmt.Errorf("metrics view %q requires semantic model %q", v.ID, v.SemanticModel)
+	}
+	if v.SemanticModel != model.Name {
+		return fmt.Errorf("metrics view %q semantic_model %q does not match model %q", v.ID, v.SemanticModel, model.Name)
+	}
+	if _, ok := model.Datasets[v.Dataset]; !ok {
+		return fmt.Errorf("metrics view %q references unknown dataset %q", v.ID, v.Dataset)
+	}
+	if v.Timeseries == "" {
+		return fmt.Errorf("metrics view %q requires timeseries", v.ID)
+	}
+	if len(v.Dimensions) == 0 {
+		return fmt.Errorf("metrics view %q requires dimensions", v.ID)
+	}
+	if len(v.Measures) == 0 {
+		return fmt.Errorf("metrics view %q requires measures", v.ID)
+	}
+	if _, ok := v.Dimensions[v.Timeseries]; !ok {
+		return fmt.Errorf("metrics view %q timeseries %q is not a dimension", v.ID, v.Timeseries)
+	}
+	for name, dimension := range v.Dimensions {
+		if dimension.Expr == "" {
+			return fmt.Errorf("metrics view %q dimension %q requires expr", v.ID, name)
+		}
+	}
+	for name, measure := range v.Measures {
+		if measure.Label == "" || measure.Expression == "" {
+			return fmt.Errorf("metrics view %q measure %q requires label and expression", v.ID, name)
+		}
 	}
 	return nil
 }

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -19,6 +19,9 @@ func TestLoadWorkspaceCatalog(t *testing.T) {
 	if len(workspace.Catalog.SemanticModels) != 1 {
 		t.Fatalf("model catalog count = %d, want 1", len(workspace.Catalog.SemanticModels))
 	}
+	if len(workspace.Catalog.MetricViews) != 1 {
+		t.Fatalf("metrics view catalog count = %d, want 1", len(workspace.Catalog.MetricViews))
+	}
 	if len(workspace.Catalog.Dashboards) != 1 {
 		t.Fatalf("dashboard catalog count = %d, want 1", len(workspace.Catalog.Dashboards))
 	}
@@ -27,6 +30,9 @@ func TestLoadWorkspaceCatalog(t *testing.T) {
 	}
 	if _, ok := workspace.Models["olist"]; !ok {
 		t.Fatal("workspace missing olist model")
+	}
+	if _, ok := workspace.MetricViews["orders"]; !ok {
+		t.Fatal("workspace missing orders metrics view")
 	}
 	if _, ok := workspace.Dashboards["executive-sales"]; !ok {
 		t.Fatal("workspace missing executive-sales dashboard")
@@ -40,22 +46,28 @@ func TestCatalogValidateRejectsDuplicateIDs(t *testing.T) {
 			{ID: "olist", Title: "Olist", Path: "olist/model.yaml"},
 			{ID: "olist", Title: "Olist Copy", Path: "olist/model.yaml"},
 		},
+		MetricViews: []CatalogMetricView{
+			{ID: "orders", Title: "Orders", Path: "olist/orders.metrics.yaml", SemanticModel: "olist"},
+		},
 		Dashboards: []CatalogDashboard{
-			{ID: "executive-sales", Title: "Executive Sales", SemanticModel: "olist", Path: "olist/executive-sales.yaml"},
+			{ID: "executive-sales", Title: "Executive Sales", Path: "olist/executive-sales.yaml"},
 		},
 	}
 
 	assertCatalogValidateError(t, catalog, baseDir, "duplicate semantic model")
 }
 
-func TestCatalogValidateRejectsUnknownDashboardModel(t *testing.T) {
+func TestCatalogValidateRejectsUnknownMetricViewModel(t *testing.T) {
 	baseDir := filepath.Join("..", "..", "dashboards")
 	catalog := Catalog{
 		SemanticModels: []CatalogModel{
 			{ID: "olist", Title: "Olist", Path: "olist/model.yaml"},
 		},
+		MetricViews: []CatalogMetricView{
+			{ID: "orders", Title: "Orders", Path: "olist/orders.metrics.yaml", SemanticModel: "missing"},
+		},
 		Dashboards: []CatalogDashboard{
-			{ID: "executive-sales", Title: "Executive Sales", SemanticModel: "missing", Path: "olist/executive-sales.yaml"},
+			{ID: "executive-sales", Title: "Executive Sales", Path: "olist/executive-sales.yaml"},
 		},
 	}
 
@@ -68,8 +80,11 @@ func TestCatalogValidateRejectsMissingPath(t *testing.T) {
 		SemanticModels: []CatalogModel{
 			{ID: "olist", Title: "Olist", Path: "olist/missing.yaml"},
 		},
+		MetricViews: []CatalogMetricView{
+			{ID: "orders", Title: "Orders", Path: "olist/orders.metrics.yaml", SemanticModel: "olist"},
+		},
 		Dashboards: []CatalogDashboard{
-			{ID: "executive-sales", Title: "Executive Sales", SemanticModel: "olist", Path: "olist/executive-sales.yaml"},
+			{ID: "executive-sales", Title: "Executive Sales", Path: "olist/executive-sales.yaml"},
 		},
 	}
 
@@ -95,7 +110,7 @@ func TestLoadOlistModel(t *testing.T) {
 
 func TestLoadOlistDashboard(t *testing.T) {
 	model := loadOlistModel(t)
-	report, err := LoadDashboard(filepath.Join("..", "..", "dashboards", "olist", "executive-sales.yaml"), model)
+	report, err := LoadDashboard(filepath.Join("..", "..", "dashboards", "olist", "executive-sales.yaml"), loadOlistMetricViews(t, model))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +118,7 @@ func TestLoadOlistDashboard(t *testing.T) {
 	if report.ID != "executive-sales" {
 		t.Fatalf("dashboard id = %q, want executive-sales", report.ID)
 	}
-	if got := report.Visuals["revenue"].Dataset; got != "orders" {
+	if got := report.Visuals["revenue"].MetricView; got != "orders" {
 		t.Fatalf("revenue visual dataset = %q, want orders", got)
 	}
 	if got := report.Visuals["orders"].Type; got != "donut" {
@@ -201,7 +216,7 @@ func TestDashboardValidateAcceptsV3VisualMetadata(t *testing.T) {
 	}
 	report.Visuals["revenue"] = visual
 
-	if err := report.Validate(model); err != nil {
+	if err := report.Validate(loadOlistMetricViews(t, model)); err != nil {
 		t.Fatalf("validate v3 visual: %v", err)
 	}
 }
@@ -222,26 +237,26 @@ func TestLoadDashboardRejectsLegacyTopLevelStacked(t *testing.T) {
 	path := filepath.Join(dir, "dashboard.yaml")
 	content := strings.ReplaceAll(`id: executive-sales
 title: Executive Sales Dashboard
-semantic_model: olist
+metrics_views: [orders]
 filters: {}
 kpis:
   total_orders:
     title: Orders
-    dataset: orders
+    metrics_view: orders
     measure: order_count
 visuals:
   revenue:
     title: Revenue
     type: area
     stacked: true
-    dataset: orders
+    metrics_view: orders
     query:
       dimensions: [purchase_month]
       measures: [revenue]
 tables:
   orders:
     title: Orders
-    dataset: orders
+    metrics_view: orders
     columns:
       - key: order_id
         label: Order
@@ -257,7 +272,7 @@ pages:
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := LoadDashboard(path, model)
+	_, err := LoadDashboard(path, loadOlistMetricViews(t, model))
 	if err == nil || !strings.Contains(err.Error(), "legacy top-level stacked") {
 		t.Fatalf("LoadDashboard error = %v, want legacy stacked rejection", err)
 	}
@@ -299,91 +314,91 @@ func TestDashboardValidateAcceptsAdvancedVisualShapes(t *testing.T) {
 
 	cases := map[string]Visual{
 		"heatmap": {
-			Title:    "Heatmap",
-			Shape:    "matrix",
-			Renderer: "echarts",
-			Type:     "heatmap",
-			Dataset:  "orders",
-			Query:    VisualQuery{Dimensions: []string{"state", "status"}, Measures: []string{"order_count"}},
+			Title:      "Heatmap",
+			Shape:      "matrix",
+			Renderer:   "echarts",
+			Type:       "heatmap",
+			MetricView: "orders",
+			Query:      VisualQuery{Dimensions: []string{"state", "status"}, Measures: []string{"order_count"}},
 		},
 		"sankey": {
-			Title:    "Flow",
-			Shape:    "graph",
-			Renderer: "echarts",
-			Type:     "sankey",
-			Dataset:  "orders",
-			Query:    VisualQuery{Dimensions: []string{"status", "delivery_bucket"}, Measures: []string{"order_count"}},
+			Title:      "Flow",
+			Shape:      "graph",
+			Renderer:   "echarts",
+			Type:       "sankey",
+			MetricView: "orders",
+			Query:      VisualQuery{Dimensions: []string{"status", "delivery_bucket"}, Measures: []string{"order_count"}},
 		},
 		"geo": {
-			Title:    "Map",
-			Shape:    "geo",
-			Renderer: "echarts",
-			Type:     "map",
-			Dataset:  "orders",
-			Options:  map[string]any{"map": "brazil_states"},
-			Query:    VisualQuery{Dimensions: []string{"state"}, Measures: []string{"order_count"}},
+			Title:      "Map",
+			Shape:      "geo",
+			Renderer:   "echarts",
+			Type:       "map",
+			MetricView: "orders",
+			Options:    map[string]any{"map": "brazil_states"},
+			Query:      VisualQuery{Dimensions: []string{"state"}, Measures: []string{"order_count"}},
 		},
 		"boxplot": {
-			Title:    "Distribution",
-			Shape:    "distribution",
-			Renderer: "echarts",
-			Type:     "boxplot",
-			Dataset:  "orders",
-			Query:    VisualQuery{Dimensions: []string{"delivery_bucket"}, Measures: []string{"delivery_days"}},
+			Title:      "Distribution",
+			Shape:      "distribution",
+			Renderer:   "echarts",
+			Type:       "boxplot",
+			MetricView: "orders",
+			Query:      VisualQuery{Dimensions: []string{"delivery_bucket"}, Measures: []string{"delivery_days"}},
 		},
 		"combo": {
-			Title:    "Combo",
-			Shape:    "category_multi_measure",
-			Renderer: "echarts",
-			Type:     "combo",
-			Dataset:  "orders",
-			Query:    VisualQuery{Dimensions: []string{"purchase_month"}, Measures: []string{"revenue", "order_count"}},
+			Title:      "Combo",
+			Shape:      "category_multi_measure",
+			Renderer:   "echarts",
+			Type:       "combo",
+			MetricView: "orders",
+			Query:      VisualQuery{Dimensions: []string{"purchase_month"}, Measures: []string{"revenue", "order_count"}},
 		},
 		"waterfall": {
-			Title:    "Waterfall",
-			Shape:    "category_delta",
-			Renderer: "echarts",
-			Type:     "waterfall",
-			Dataset:  "orders",
-			Query:    VisualQuery{Dimensions: []string{"purchase_month"}, Measures: []string{"revenue"}},
+			Title:      "Waterfall",
+			Shape:      "category_delta",
+			Renderer:   "echarts",
+			Type:       "waterfall",
+			MetricView: "orders",
+			Query:      VisualQuery{Dimensions: []string{"purchase_month"}, Measures: []string{"revenue"}},
 		},
 		"histogram": {
-			Title:    "Histogram",
-			Shape:    "binned_measure",
-			Renderer: "echarts",
-			Type:     "histogram",
-			Dataset:  "orders",
-			Query:    VisualQuery{Measures: []string{"delivery_days"}},
+			Title:      "Histogram",
+			Shape:      "binned_measure",
+			Renderer:   "echarts",
+			Type:       "histogram",
+			MetricView: "orders",
+			Query:      VisualQuery{Measures: []string{"delivery_days"}},
 		},
 		"radar": {
-			Title:    "Radar",
-			Shape:    "category_value",
-			Renderer: "echarts",
-			Type:     "radar",
-			Dataset:  "orders",
-			Query:    VisualQuery{Dimensions: []string{"status"}, Measures: []string{"order_count"}},
+			Title:      "Radar",
+			Shape:      "category_value",
+			Renderer:   "echarts",
+			Type:       "radar",
+			MetricView: "orders",
+			Query:      VisualQuery{Dimensions: []string{"status"}, Measures: []string{"order_count"}},
 		},
 		"tree": {
-			Title:    "Tree",
-			Shape:    "hierarchy",
-			Renderer: "echarts",
-			Type:     "tree",
-			Dataset:  "orders",
-			Query:    VisualQuery{Dimensions: []string{"state", "status"}, Measures: []string{"order_count"}},
+			Title:      "Tree",
+			Shape:      "hierarchy",
+			Renderer:   "echarts",
+			Type:       "tree",
+			MetricView: "orders",
+			Query:      VisualQuery{Dimensions: []string{"state", "status"}, Measures: []string{"order_count"}},
 		},
 		"sunburst": {
-			Title:    "Sunburst",
-			Shape:    "hierarchy",
-			Renderer: "echarts",
-			Type:     "sunburst",
-			Dataset:  "orders",
-			Query:    VisualQuery{Dimensions: []string{"category", "status"}, Measures: []string{"order_count"}},
+			Title:      "Sunburst",
+			Shape:      "hierarchy",
+			Renderer:   "echarts",
+			Type:       "sunburst",
+			MetricView: "orders",
+			Query:      VisualQuery{Dimensions: []string{"category", "status"}, Measures: []string{"order_count"}},
 		},
 	}
 	for name, visual := range cases {
 		report.Visuals = map[string]Visual{name: visual}
 		report.Pages = []dashboard.Page{{ID: "overview", Title: "Overview", Visuals: []dashboard.PageVisual{{ID: name, Kind: visual.Type + "_chart", Visual: name, Placement: dashboard.PagePlacement{Col: 1, Row: 1, ColSpan: 1, RowSpan: 1}}}}}
-		if err := report.Validate(model); err != nil {
+		if err := report.Validate(loadOlistMetricViews(t, model)); err != nil {
 			t.Fatalf("validate advanced shape %s: %v", name, err)
 		}
 	}
@@ -641,9 +656,18 @@ func loadOlistModel(t *testing.T) *Model {
 	return model
 }
 
+func loadOlistMetricViews(t *testing.T, model *Model) map[string]*MetricView {
+	t.Helper()
+	view, err := LoadMetricView(filepath.Join("..", "..", "dashboards", "olist", "orders.metrics.yaml"), model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string]*MetricView{view.ID: view}
+}
+
 func loadOlistDashboard(t *testing.T, model *Model) *Dashboard {
 	t.Helper()
-	report, err := LoadDashboard(filepath.Join("..", "..", "dashboards", "olist", "executive-sales.yaml"), model)
+	report, err := LoadDashboard(filepath.Join("..", "..", "dashboards", "olist", "executive-sales.yaml"), loadOlistMetricViews(t, model))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -663,7 +687,7 @@ func assertModelValidateError(t *testing.T, model *Model, contains string) {
 
 func assertDashboardValidateError(t *testing.T, report *Dashboard, model *Model, contains string) {
 	t.Helper()
-	err := report.Validate(model)
+	err := report.Validate(loadOlistMetricViews(t, model))
 	if err == nil {
 		t.Fatalf("Validate() error = nil, want %q", contains)
 	}

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -354,30 +354,15 @@ func metricViewHeader(view dashboard.MetricViewDetail) g.Node {
 }
 
 func metricViewInfoSidebar(view dashboard.MetricViewDetail) g.Node {
-	return h.Aside(h.Class("metric-info-sidebar"), h.Aria("label", "Metric view data contract"),
+	return h.Aside(h.Class("metric-info-sidebar"), h.Aria("label", "Metric view details"),
 		h.Div(h.Class("metric-info-header"),
-			h.H2(lucide.FileText(iconAttrs()), h.Span(g.Text("Data Contract"))),
-			h.Span(h.Class("metric-verified-badge"), lucide.Check(iconAttrs()), g.Text("Verified")),
+			h.H2(lucide.FileText(iconAttrs()), h.Span(g.Text("Details"))),
 		),
 		h.Div(h.Class("metric-info-body"),
 			h.Div(h.Class("metric-info-group"),
 				metricInfoItem("Model context", h.A(h.Href("/models/"+view.SemanticModel), lucide.Box(iconAttrs()), h.Span(g.Text(view.ModelTitle)))),
 				metricInfoItem("Source dataset", h.Span(lucide.Table2(iconAttrs()), h.Code(g.Text(view.Dataset)))),
 				metricInfoItem("Primary timeseries", h.Span(lucide.Calendar(iconAttrs()), h.Code(g.Text(view.Timeseries)))),
-			),
-			h.Div(h.Class("metric-info-divider")),
-			h.Div(h.Class("metric-info-group"),
-				h.H3(g.Text("Fields")),
-				metricInfoStat("Measures", view.MeasureCount, lucide.Sigma(iconAttrs())),
-				metricInfoStat("Dimensions", view.DimensionCount, lucide.List(iconAttrs())),
-				metricInfoStat("Dashboards", view.DashboardCount, lucide.LayoutDashboard(iconAttrs())),
-			),
-			h.Div(h.Class("metric-info-divider")),
-			h.Div(h.Class("metric-info-group"),
-				h.H3(g.Text("Governance")),
-				metricInfoRow("Owner", "Data Platform"),
-				metricInfoRow("Tier", "Core"),
-				metricInfoRow("Status", "Ready"),
 			),
 		),
 	)
@@ -387,20 +372,6 @@ func metricInfoItem(label string, value g.Node) g.Node {
 	return h.Div(h.Class("metric-info-item"),
 		h.Span(h.Class("metric-info-label"), g.Text(label)),
 		h.Div(h.Class("metric-info-value"), value),
-	)
-}
-
-func metricInfoStat(label string, count int, icon g.Node) g.Node {
-	return h.Div(h.Class("metric-info-stat"),
-		h.Span(icon, g.Text(label)),
-		h.Strong(g.Text(strconv.Itoa(count))),
-	)
-}
-
-func metricInfoRow(label, value string) g.Node {
-	return h.Div(h.Class("metric-info-row"),
-		h.Span(g.Text(label)),
-		h.Strong(g.Text(value)),
 	)
 }
 
@@ -439,89 +410,124 @@ func normalizeMetricViewSection(section string) string {
 	return "measures"
 }
 
-func metricViewDimensions(dimensions []dashboard.MetricViewDimension) g.Node {
+type metricGrid struct {
+	Columns  []metricGridColumn `json:"columns"`
+	Rows     []map[string]any   `json:"rows"`
+	Empty    string             `json:"empty"`
+	MinWidth string             `json:"minWidth,omitempty"`
+}
+
+type metricGridColumn struct {
+	ID      string `json:"id"`
+	Header  string `json:"header"`
+	Kind    string `json:"kind,omitempty"`
+	Align   string `json:"align,omitempty"`
+	HrefKey string `json:"hrefKey,omitempty"`
+	Width   string `json:"width,omitempty"`
+}
+
+type metricGridBadge struct {
+	Label string `json:"label"`
+	Tone  string `json:"tone,omitempty"`
+}
+
+func metricViewDimensions() g.Node {
 	return h.Section(h.ID("dimensions"), h.Class("metric-contract-section metric-contract-section-dimensions"),
-		metricSectionHeader("Dimensions"),
-		h.Div(h.Class("metric-table-wrap"),
-			h.Table(h.Class("metric-field-table"),
-				h.THead(
-					h.Tr(
-						h.Th(g.Text("Name")),
-						h.Th(g.Text("Label")),
-						h.Th(g.Text("Expression")),
-						h.Th(g.Text("Filter")),
-						h.Th(g.Text("Order")),
-					),
-				),
-				h.TBody(g.Map(dimensions, func(dimension dashboard.MetricViewDimension) g.Node {
-					return h.Tr(
-						h.Td(h.Code(g.Text(dimension.Name))),
-						h.Td(g.Text(displayLabel(dimension.Label, dimension.Name))),
-						h.Td(h.Code(h.Class("metric-expression"), g.Text(dimension.Expr))),
-						h.Td(g.Text(emptyDash(dimension.Where))),
-						h.Td(g.Text(emptyDash(dimension.OrderExpr))),
-					)
-				})),
-			),
-		),
+		g.El("ld-data-grid", g.Attr("data-attr:grid", "$metricGrid")),
 	)
 }
 
-func metricViewMeasures(measures []dashboard.MetricViewMeasure) g.Node {
+func metricViewMeasures() g.Node {
 	return h.Section(h.ID("measures"), h.Class("metric-contract-section metric-contract-section-measures"),
-		metricSectionHeader("Measures"),
-		h.Div(h.Class("metric-table-wrap"),
-			h.Table(h.Class("metric-field-table metric-measure-table"),
-				h.THead(
-					h.Tr(
-						h.Th(g.Text("Name")),
-						h.Th(g.Text("Label")),
-						h.Th(g.Text("Expression")),
-						h.Th(g.Text("Unit")),
-						h.Th(g.Text("Format")),
-					),
-				),
-				h.TBody(g.Map(measures, func(measure dashboard.MetricViewMeasure) g.Node {
-					return h.Tr(
-						h.Td(h.Code(g.Text(measure.Name))),
-						h.Td(g.Text(displayLabel(measure.Label, measure.Name))),
-						h.Td(h.Code(h.Class("metric-expression"), g.Text(measure.Expression))),
-						h.Td(metricFieldChip(measure.Unit, "unit", unitIcon(measure.Unit))),
-						h.Td(metricFieldChip(measure.Format, "format", formatIcon(measure.Format))),
-					)
-				})),
-			),
-		),
+		g.El("ld-data-grid", g.Attr("data-attr:grid", "$metricGrid")),
 	)
 }
 
-func metricViewDashboards(view dashboard.MetricViewDetail) g.Node {
-	reports := view.Dashboards
+func metricViewDashboards() g.Node {
 	return h.Section(h.ID("usage"), h.Class("metric-contract-section metric-contract-section-usage"),
-		metricSectionHeader("Used by"),
 		g.El("ld-metric-usage-graph", g.Attr("data-attr:graph", "$metricUsageGraph")),
-		g.If(len(reports) == 0, h.P(h.Class("metric-empty"), g.Text("No dashboards reference this metric view yet."))),
-		g.If(len(reports) > 0, h.Div(h.Class("metric-table-wrap"),
-			h.Table(h.Class("metric-field-table metric-usage-table"),
-				h.THead(
-					h.Tr(
-						h.Th(g.Text("Dashboard")),
-						h.Th(g.Text("Description")),
-						h.Th(g.Text("Tags")),
-						h.Th(g.Text("Pages")),
-					),
-				),
-				h.TBody(g.Map(reports, func(report dashboard.MetricViewDashboard) g.Node {
-					return h.Tr(
-						h.Td(h.A(h.Class("metric-table-link"), h.Href("/dashboards/"+report.ID), g.Text(report.Title))),
-						h.Td(g.Text(emptyDash(report.Description))),
-						h.Td(metricTagList(report.Tags)),
-						h.Td(g.Text(strconv.Itoa(report.PageCount))),
-					)
-				})),
-			),
-		)),
+		g.El("ld-data-grid", g.Attr("data-attr:grid", "$metricGrid")),
 	)
+}
+
+func metricViewGrid(view dashboard.MetricViewDetail, activeSection string) metricGrid {
+	switch activeSection {
+	case "dimensions":
+		rows := make([]map[string]any, 0, len(view.Dimensions))
+		for _, dimension := range view.Dimensions {
+			rows = append(rows, map[string]any{
+				"name":       dimension.Name,
+				"label":      displayLabel(dimension.Label, dimension.Name),
+				"expression": dimension.Expr,
+				"filter":     emptyDash(dimension.Where),
+				"order":      emptyDash(dimension.OrderExpr),
+			})
+		}
+		return metricGrid{
+			Columns: []metricGridColumn{
+				{ID: "name", Header: "Name", Kind: "code", Width: "170px"},
+				{ID: "label", Header: "Label", Width: "180px"},
+				{ID: "expression", Header: "Expression", Kind: "expression", Width: "260px"},
+				{ID: "filter", Header: "Filter", Kind: "expression", Width: "220px"},
+				{ID: "order", Header: "Order", Kind: "expression", Width: "190px"},
+			},
+			Rows:     rows,
+			Empty:    "No dimensions are defined for this metric view.",
+			MinWidth: "1020px",
+		}
+	case "usage":
+		rows := make([]map[string]any, 0, len(view.Dashboards))
+		for _, report := range view.Dashboards {
+			rows = append(rows, map[string]any{
+				"dashboard":     report.Title,
+				"dashboardHref": "/dashboards/" + report.ID,
+				"description":   emptyDash(report.Description),
+				"tags":          report.Tags,
+				"pages":         report.PageCount,
+			})
+		}
+		return metricGrid{
+			Columns: []metricGridColumn{
+				{ID: "dashboard", Header: "Dashboard", Kind: "link", HrefKey: "dashboardHref", Width: "250px"},
+				{ID: "description", Header: "Description", Width: "420px"},
+				{ID: "tags", Header: "Tags", Kind: "tags", Width: "220px"},
+				{ID: "pages", Header: "Pages", Kind: "number", Align: "right", Width: "90px"},
+			},
+			Rows:     rows,
+			Empty:    "No dashboards reference this metric view yet.",
+			MinWidth: "980px",
+		}
+	default:
+		rows := make([]map[string]any, 0, len(view.Measures))
+		for _, measure := range view.Measures {
+			rows = append(rows, map[string]any{
+				"name":       measure.Name,
+				"label":      displayLabel(measure.Label, measure.Name),
+				"expression": measure.Expression,
+				"unit":       metricGridBadgeValue(measure.Unit, "success"),
+				"format":     metricGridBadgeValue(measure.Format, "accent"),
+			})
+		}
+		return metricGrid{
+			Columns: []metricGridColumn{
+				{ID: "name", Header: "Name", Kind: "code", Width: "150px"},
+				{ID: "label", Header: "Label", Width: "160px"},
+				{ID: "expression", Header: "Expression", Kind: "expression", Width: "420px"},
+				{ID: "unit", Header: "Unit", Kind: "badge", Width: "96px"},
+				{ID: "format", Header: "Format", Kind: "badge", Width: "108px"},
+			},
+			Rows:     rows,
+			Empty:    "No measures are defined for this metric view.",
+			MinWidth: "934px",
+		}
+	}
+}
+
+func metricGridBadgeValue(value, tone string) any {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	return metricGridBadge{Label: value, Tone: tone}
 }
 
 func metricUsageGraph(view dashboard.MetricViewDetail) any {
@@ -570,22 +576,6 @@ func metricUsageGraph(view dashboard.MetricViewDetail) any {
 	return graph{Nodes: nodes, Edges: edges}
 }
 
-func metricSectionHeader(title string) g.Node {
-	return h.Div(h.Class("metric-section-header"),
-		h.H2(g.Text(title)),
-	)
-}
-
-func metricFieldChip(value, tone string, icon g.Node) g.Node {
-	if strings.TrimSpace(value) == "" {
-		return g.Text("-")
-	}
-	return h.Span(h.Class("metric-field-chip metric-field-chip-"+tone),
-		icon,
-		g.Text(value),
-	)
-}
-
 func metricTabs(view dashboard.MetricViewDetail, activeSection string) g.Node {
 	return h.Nav(h.Class("metric-tabs"), h.Aria("label", "Metric view sections"),
 		metricTabLink(view.ID, "measures", activeSection, "Measures", metricTabCount(view.MeasureCount)),
@@ -605,49 +595,22 @@ func metricTabLink(viewID, section, activeSection, label string, meta g.Node) g.
 func metricViewActiveSection(view dashboard.MetricViewDetail, activeSection string) g.Node {
 	switch activeSection {
 	case "dimensions":
-		return metricViewDimensions(view.Dimensions)
+		return metricViewDimensions()
 	case "usage":
-		return metricViewDashboards(view)
+		return metricViewDashboards()
 	default:
-		return metricViewMeasures(view.Measures)
+		return metricViewMeasures()
 	}
 }
 
-func formatIcon(format string) g.Node {
-	switch strings.ToLower(strings.TrimSpace(format)) {
-	case "currency":
-		return lucide.BadgeDollarSign(iconAttrs())
-	case "integer":
-		return lucide.Hash(iconAttrs())
-	case "decimal":
-		return lucide.Binary(iconAttrs())
-	case "percent", "percentage":
-		return lucide.Percent(iconAttrs())
-	default:
-		return lucide.Type(iconAttrs())
+func metricViewSignals(view dashboard.MetricViewDetail, activeSection string) map[string]any {
+	signals := map[string]any{
+		"metricGrid": metricViewGrid(view, activeSection),
 	}
-}
-
-func unitIcon(unit string) g.Node {
-	switch strings.ToLower(strings.TrimSpace(unit)) {
-	case "r$", "$", "usd", "eur", "gbp":
-		return lucide.DollarSign(iconAttrs())
-	case "orders", "order":
-		return lucide.Hash(iconAttrs())
-	default:
-		return lucide.Type(iconAttrs())
+	if activeSection == "usage" {
+		signals["metricUsageGraph"] = metricUsageGraph(view)
 	}
-}
-
-func metricTagList(tags []string) g.Node {
-	if len(tags) == 0 {
-		return g.Text("-")
-	}
-	nodes := []g.Node{h.Class("metric-tag-list")}
-	for _, tag := range tags {
-		nodes = append(nodes, h.Span(g.Text(tag)))
-	}
-	return h.Div(nodes...)
+	return signals
 }
 
 func displayLabel(label, fallback string) string {
@@ -683,19 +646,19 @@ func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail, 
 			g.If(activeSection == "usage", h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/metric-usage-graph.css")))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/sidebar.js"))),
+			h.Script(h.Type("module"), h.Src(staticAsset("/static/data-grid.js"))),
+			h.Script(h.Type("module"), h.Src(staticAsset("/static/detail-rail.js"))),
 			g.If(activeSection == "usage", h.Script(h.Type("module"), h.Src(staticAsset("/static/metric-usage-graph.js")))),
-			g.If(activeSection == "usage", h.Script(h.Type("module"), h.Src("https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js"))),
+			h.Script(h.Type("module"), h.Src("https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js")),
 		},
 		Body: []g.Node{
 			h.Main(h.Class("report-app"),
-				g.If(activeSection == "usage", ds.Signals(map[string]any{
-					"metricUsageGraph": metricUsageGraph(view),
-				})),
+				ds.Signals(metricViewSignals(view, activeSection)),
 				h.Div(h.Class("app-shell"),
 					sidebar(sidebarConfigForMetricView(catalog, view)),
 					h.Section(h.Class("app-main metric-main"), h.Aria("label", "LibreDash metric view"),
 						metricViewHeader(view),
-						h.Div(h.Class("metric-workspace"),
+						g.El("ld-detail-rail", h.Class("metric-workspace"),
 							h.Div(h.Class("metric-content-column"),
 								metricTabs(view, activeSection),
 								h.Div(h.Class("metric-contract-main"),

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -613,6 +613,10 @@ func metricViewSignals(view dashboard.MetricViewDetail, activeSection string) ma
 	return signals
 }
 
+func metricDetailRailStateScript() g.Node {
+	return h.Script(g.Raw(`try{if(window.localStorage.getItem("libredash.metricDetailRail")==="collapsed"){document.documentElement.setAttribute("data-metric-detail-rail","collapsed")}}catch(e){}`))
+}
+
 func displayLabel(label, fallback string) string {
 	if strings.TrimSpace(label) != "" {
 		return label
@@ -642,6 +646,7 @@ func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail, 
 			h.Link(h.Rel("preconnect"), h.Href("https://cdn.jsdelivr.net")),
 			h.Link(h.Href("https://cdn.jsdelivr.net/npm/daisyui@5"), h.Rel("stylesheet"), h.Type("text/css")),
 			h.Script(h.Src("https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4")),
+			metricDetailRailStateScript(),
 			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/app.css"))),
 			g.If(activeSection == "usage", h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/metric-usage-graph.css")))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -221,9 +221,13 @@ func ModelsPage(catalog dashboard.Catalog) g.Node {
 }
 
 func dashboardCard(report dashboard.CatalogDashboard) g.Node {
+	eyebrow := strings.Join(report.MetricViewTitles, ", ")
+	if eyebrow == "" {
+		eyebrow = "Dashboard"
+	}
 	return h.Article(h.Class("catalog-card"),
 		h.Div(h.Class("catalog-card-main"),
-			h.P(h.Class("report-eyebrow"), g.Text(report.ModelTitle)),
+			h.P(h.Class("report-eyebrow"), g.Text(eyebrow)),
 			h.H2(g.Text(report.Title)),
 			h.P(g.Text(report.Description)),
 		),
@@ -233,7 +237,7 @@ func dashboardCard(report dashboard.CatalogDashboard) g.Node {
 			}),
 		),
 		h.Footer(h.Class("catalog-card-footer"),
-			h.Span(g.Textf("%d pages", report.PageCount)),
+			h.Span(g.Textf("%d pages, %d views", report.PageCount, len(report.MetricViews))),
 			h.A(h.Class("catalog-open"), h.Href("/dashboards/"+report.ID),
 				lucide.ExternalLink(iconAttrs()),
 				h.Span(g.Text("Open")),
@@ -343,10 +347,10 @@ func sidebar(config map[string]any) g.Node {
 func sidebarConfigForCatalog(catalog dashboard.Catalog) map[string]any {
 	modelID := ""
 	modelTitle := ""
-	if len(catalog.Dashboards) > 0 {
-		report := catalog.Dashboards[0]
-		modelID = report.SemanticModel
-		modelTitle = report.ModelTitle
+	if len(catalog.MetricViews) > 0 {
+		view := catalog.MetricViews[0]
+		modelID = view.SemanticModel
+		modelTitle = view.ModelTitle
 	}
 	return sidebarConfig(catalog, "dashboards", "", workspaceDisplayTitle(catalog), "Dashboards", "Discovery", modelID, modelTitle, false)
 }
@@ -512,7 +516,7 @@ func initialSignals(dataDir, clientID, csrfToken string, report semantic.Dashboa
 			},
 		},
 		"tables": tableSignals(report, tableRequest),
-		"charts": chartSignals(report, model),
+		"charts": chartSignals(report),
 		"kpis":   []any{},
 		"status": map[string]any{
 			"loading":       false,
@@ -583,7 +587,7 @@ func tableResetExpression() string {
 	return "$tableCommand.block = 'all'; $tableCommand.start = 0; $tableCommand.count = " + count + "; $tableCommand.resetVersion = ($tableCommand.resetVersion || 0) + 1; "
 }
 
-func chartSignals(report semantic.Dashboard, model *semantic.Model) map[string]any {
+func chartSignals(report semantic.Dashboard) map[string]any {
 	charts := map[string]any{}
 	for _, id := range sortedKeys(report.Visuals) {
 		visual := report.Visuals[id]
@@ -591,9 +595,6 @@ func chartSignals(report semantic.Dashboard, model *semantic.Model) map[string]a
 		unit := ""
 		if len(visual.Query.Measures) > 0 {
 			measureName = visual.Query.Measures[0]
-			if dataset, ok := model.Datasets[visual.Dataset]; ok {
-				unit = dataset.Measures[measureName].Unit
-			}
 		}
 		charts[id] = chartSignal(id, visual, unit, measureName)
 	}

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -298,7 +298,7 @@ func metricViewCard(view dashboard.MetricViewSummary) g.Node {
 		),
 		h.Footer(h.Class("catalog-card-footer"),
 			h.Span(g.Textf("%d dimensions, %d measures", view.DimensionCount, view.MeasureCount)),
-			h.A(h.Class("catalog-open"), h.Href("/metrics/"+view.ID),
+			h.A(h.Class("catalog-open"), h.Href("/metrics/"+view.ID+"/measures"),
 				lucide.ExternalLink(iconAttrs()),
 				h.Span(g.Text("Open")),
 			),
@@ -332,26 +332,61 @@ func metricViewActions(view dashboard.MetricViewDetail) g.Node {
 }
 
 func metricViewSummary(view dashboard.MetricViewDetail) g.Node {
-	return h.Div(h.Class("metric-summary-strip"),
-		metricSummaryItem("Semantic model", h.A(h.Href("/models/"+view.SemanticModel), g.Text(view.ModelTitle))),
-		metricSummaryItem("Dataset", h.Code(g.Text(view.Dataset))),
-		metricSummaryItem("Timeseries", h.Code(g.Text(view.Timeseries))),
-		metricSummaryItem("Measures", h.Strong(g.Text(strconv.Itoa(view.MeasureCount)))),
-		metricSummaryItem("Dimensions", h.Strong(g.Text(strconv.Itoa(view.DimensionCount)))),
-		metricSummaryItem("Dashboards", h.Strong(g.Text(strconv.Itoa(view.DashboardCount)))),
+	return h.Div(h.Class("metric-metadata-bar"),
+		h.Div(h.Class("metric-metadata-items"),
+			metricMetadataItem("Model", h.A(h.Href("/models/"+view.SemanticModel), g.Text(view.ModelTitle))),
+			metricMetadataItem("Dataset", h.Code(g.Text(view.Dataset))),
+			metricMetadataItem("Timeseries", h.Code(g.Text(view.Timeseries))),
+		),
+		h.Div(h.Class("metric-count-pills"),
+			metricCountPill("Measure", view.MeasureCount, "measure", lucide.Sigma(iconAttrs())),
+			metricCountPill("Dimension", view.DimensionCount, "dimension", lucide.List(iconAttrs())),
+			metricCountPill("Dashboard", view.DashboardCount, "dashboard", lucide.LayoutDashboard(iconAttrs())),
+		),
 	)
 }
 
-func metricSummaryItem(label string, value g.Node) g.Node {
-	return h.Div(h.Class("metric-summary-item"),
+func metricMetadataItem(label string, value g.Node) g.Node {
+	return h.Div(h.Class("metric-metadata-item"),
 		h.Span(g.Text(label)),
 		value,
 	)
 }
 
+func metricCountPill(label string, count int, tone string, icon g.Node) g.Node {
+	return h.Span(h.Class("metric-count-pill metric-count-pill-"+tone),
+		icon,
+		h.Strong(g.Text(strconv.Itoa(count))),
+		g.Text(" "+pluralize(label, count)),
+	)
+}
+
+func pluralize(label string, count int) string {
+	if count == 1 {
+		return label
+	}
+	return label + "s"
+}
+
+func ValidMetricViewSection(section string) bool {
+	switch section {
+	case "measures", "dimensions", "usage":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeMetricViewSection(section string) string {
+	if ValidMetricViewSection(section) {
+		return section
+	}
+	return "measures"
+}
+
 func metricViewDimensions(dimensions []dashboard.MetricViewDimension) g.Node {
-	return h.Section(h.ID("dimensions"), h.Class("metric-contract-section"),
-		metricSectionHeader("Dimensions", "Fields available for grouping and filtering.", len(dimensions)),
+	return h.Section(h.ID("dimensions"), h.Class("metric-contract-section metric-contract-section-dimensions"),
+		metricSectionHeader("Dimensions"),
 		h.Div(h.Class("metric-table-wrap"),
 			h.Table(h.Class("metric-field-table"),
 				h.THead(
@@ -378,8 +413,8 @@ func metricViewDimensions(dimensions []dashboard.MetricViewDimension) g.Node {
 }
 
 func metricViewMeasures(measures []dashboard.MetricViewMeasure) g.Node {
-	return h.Section(h.ID("measures"), h.Class("metric-contract-section"),
-		metricSectionHeader("Measures", "Aggregate SQL expressions available for analysis.", len(measures)),
+	return h.Section(h.ID("measures"), h.Class("metric-contract-section metric-contract-section-measures"),
+		metricSectionHeader("Measures"),
 		h.Div(h.Class("metric-table-wrap"),
 			h.Table(h.Class("metric-field-table metric-measure-table"),
 				h.THead(
@@ -397,8 +432,8 @@ func metricViewMeasures(measures []dashboard.MetricViewMeasure) g.Node {
 						h.Td(h.Code(g.Text(measure.Name))),
 						h.Td(g.Text(displayLabel(measure.Label, measure.Name))),
 						h.Td(h.Code(h.Class("metric-expression"), g.Text(measure.Expression))),
-						h.Td(g.Text(emptyDash(measure.Unit))),
-						h.Td(g.Text(emptyDash(measure.Format))),
+						h.Td(metricFieldChip(measure.Unit, "unit", unitIcon(measure.Unit))),
+						h.Td(metricFieldChip(measure.Format, "format", formatIcon(measure.Format))),
 						h.Td(g.Text(emptyDash(measure.Description))),
 					)
 				})),
@@ -407,55 +442,159 @@ func metricViewMeasures(measures []dashboard.MetricViewMeasure) g.Node {
 	)
 }
 
-func metricViewDashboards(reports []dashboard.MetricViewDashboard) g.Node {
-	return h.Section(h.ID("usage"), h.Class("metric-rail-section"),
-		h.H2(g.Text("Used by")),
+func metricViewDashboards(view dashboard.MetricViewDetail) g.Node {
+	reports := view.Dashboards
+	return h.Section(h.ID("usage"), h.Class("metric-contract-section metric-contract-section-usage"),
+		metricSectionHeader("Used by"),
+		g.El("ld-metric-usage-graph", g.Attr("data-attr:graph", "$metricUsageGraph")),
 		g.If(len(reports) == 0, h.P(h.Class("metric-empty"), g.Text("No dashboards reference this metric view yet."))),
-		g.Map(reports, func(report dashboard.MetricViewDashboard) g.Node {
-			return h.A(h.Class("metric-dashboard-link"), h.Href("/dashboards/"+report.ID),
-				h.Span(g.Text(report.Title)),
-				h.Small(g.Textf("%d pages", report.PageCount)),
-				lucide.ExternalLink(iconAttrs()),
-			)
-		}),
+		g.If(len(reports) > 0, h.Div(h.Class("metric-table-wrap"),
+			h.Table(h.Class("metric-field-table metric-usage-table"),
+				h.THead(
+					h.Tr(
+						h.Th(g.Text("Dashboard")),
+						h.Th(g.Text("Description")),
+						h.Th(g.Text("Tags")),
+						h.Th(g.Text("Pages")),
+					),
+				),
+				h.TBody(g.Map(reports, func(report dashboard.MetricViewDashboard) g.Node {
+					return h.Tr(
+						h.Td(h.A(h.Class("metric-table-link"), h.Href("/dashboards/"+report.ID), g.Text(report.Title))),
+						h.Td(g.Text(emptyDash(report.Description))),
+						h.Td(metricTagList(report.Tags)),
+						h.Td(g.Text(strconv.Itoa(report.PageCount))),
+					)
+				})),
+			),
+		)),
 	)
 }
 
-func metricSectionHeader(title, description string, count int) g.Node {
+func metricUsageGraph(view dashboard.MetricViewDetail) any {
+	type graphNode struct {
+		ID    string `json:"id"`
+		Label string `json:"label"`
+		Kind  string `json:"kind"`
+		Meta  string `json:"meta,omitempty"`
+	}
+	type graphEdge struct {
+		ID     string `json:"id"`
+		Source string `json:"source"`
+		Target string `json:"target"`
+		Label  string `json:"label,omitempty"`
+		Kind   string `json:"kind"`
+	}
+	type graph struct {
+		Nodes []graphNode `json:"nodes"`
+		Edges []graphEdge `json:"edges"`
+	}
+	nodes := []graphNode{
+		{ID: "model", Label: view.ModelTitle, Kind: "model", Meta: view.SemanticModel},
+		{ID: "dataset", Label: view.Dataset, Kind: "dataset", Meta: "semantic dataset"},
+		{ID: "metrics_view", Label: view.Title, Kind: "metrics_view", Meta: "metric contract"},
+	}
+	edges := []graphEdge{
+		{ID: "model_dataset", Source: "model", Target: "dataset", Label: "defines", Kind: "semantic"},
+		{ID: "dataset_metric_view", Source: "dataset", Target: "metrics_view", Label: "powers", Kind: "semantic"},
+	}
+	for _, report := range view.Dashboards {
+		nodeID := "dashboard:" + report.ID
+		nodes = append(nodes, graphNode{
+			ID:    nodeID,
+			Label: report.Title,
+			Kind:  "dashboard",
+			Meta:  strconv.Itoa(report.PageCount) + " " + pluralize("page", report.PageCount),
+		})
+		edges = append(edges, graphEdge{
+			ID:     "metrics_view_" + report.ID,
+			Source: "metrics_view",
+			Target: nodeID,
+			Label:  "used by",
+			Kind:   "usage",
+		})
+	}
+	return graph{Nodes: nodes, Edges: edges}
+}
+
+func metricSectionHeader(title string) g.Node {
 	return h.Div(h.Class("metric-section-header"),
-		h.Div(
-			h.P(h.Class("report-eyebrow"), g.Textf("%d fields", count)),
-			h.H2(g.Text(title)),
-			h.P(g.Text(description)),
-		),
+		h.H2(g.Text(title)),
 	)
 }
 
-func metricViewRail(view dashboard.MetricViewDetail) g.Node {
-	return h.Aside(h.Class("metric-contract-rail"),
-		h.Nav(h.Class("metric-rail-section metric-section-nav"), h.Aria("label", "Metric view sections"),
-			h.H2(g.Text("Sections")),
-			h.A(h.Href("#measures"), g.Text("Measures")),
-			h.A(h.Href("#dimensions"), g.Text("Dimensions")),
-			h.A(h.Href("#usage"), g.Text("Usage")),
-		),
-		h.Section(h.Class("metric-rail-section"),
-			h.H2(g.Text("Contract")),
-			metricRailRow("Model", h.A(h.Href("/models/"+view.SemanticModel), g.Text(view.ModelTitle))),
-			metricRailRow("Dataset", h.Code(g.Text(view.Dataset))),
-			metricRailRow("Timeseries", h.Code(g.Text(view.Timeseries))),
-			metricRailRow("Measures", h.Strong(g.Text(strconv.Itoa(view.MeasureCount)))),
-			metricRailRow("Dimensions", h.Strong(g.Text(strconv.Itoa(view.DimensionCount)))),
-		),
-		metricViewDashboards(view.Dashboards),
+func metricFieldChip(value, tone string, icon g.Node) g.Node {
+	if strings.TrimSpace(value) == "" {
+		return g.Text("-")
+	}
+	return h.Span(h.Class("metric-field-chip metric-field-chip-"+tone),
+		icon,
+		g.Text(value),
 	)
 }
 
-func metricRailRow(label string, value g.Node) g.Node {
-	return h.Div(h.Class("metric-rail-row"),
-		h.Span(g.Text(label)),
-		value,
+func metricTabs(view dashboard.MetricViewDetail, activeSection string) g.Node {
+	return h.Nav(h.Class("metric-tabs"), h.Aria("label", "Metric view sections"),
+		metricTabLink(view.ID, "measures", activeSection, lucide.Sigma(iconAttrs()), "Measures"),
+		metricTabLink(view.ID, "dimensions", activeSection, lucide.List(iconAttrs()), "Dimensions"),
+		metricTabLink(view.ID, "usage", activeSection, lucide.LayoutDashboard(iconAttrs()), "Used by"),
 	)
+}
+
+func metricTabLink(viewID, section, activeSection string, icon g.Node, label string) g.Node {
+	className := "metric-tab"
+	if section == activeSection {
+		className += " metric-tab-active"
+	}
+	return h.A(h.Class(className), h.Href("/metrics/"+viewID+"/"+section), g.If(section == activeSection, h.Aria("current", "page")), icon, h.Span(g.Text(label)))
+}
+
+func metricViewActiveSection(view dashboard.MetricViewDetail, activeSection string) g.Node {
+	switch activeSection {
+	case "dimensions":
+		return metricViewDimensions(view.Dimensions)
+	case "usage":
+		return metricViewDashboards(view)
+	default:
+		return metricViewMeasures(view.Measures)
+	}
+}
+
+func formatIcon(format string) g.Node {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "currency":
+		return lucide.BadgeDollarSign(iconAttrs())
+	case "integer":
+		return lucide.Hash(iconAttrs())
+	case "decimal":
+		return lucide.Binary(iconAttrs())
+	case "percent", "percentage":
+		return lucide.Percent(iconAttrs())
+	default:
+		return lucide.Type(iconAttrs())
+	}
+}
+
+func unitIcon(unit string) g.Node {
+	switch strings.ToLower(strings.TrimSpace(unit)) {
+	case "r$", "$", "usd", "eur", "gbp":
+		return lucide.DollarSign(iconAttrs())
+	case "orders", "order":
+		return lucide.Hash(iconAttrs())
+	default:
+		return lucide.Type(iconAttrs())
+	}
+}
+
+func metricTagList(tags []string) g.Node {
+	if len(tags) == 0 {
+		return g.Text("-")
+	}
+	nodes := []g.Node{h.Class("metric-tag-list")}
+	for _, tag := range tags {
+		nodes = append(nodes, h.Span(g.Text(tag)))
+	}
+	return h.Div(nodes...)
 }
 
 func displayLabel(label, fallback string) string {
@@ -472,7 +611,8 @@ func emptyDash(value string) string {
 	return value
 }
 
-func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail) g.Node {
+func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail, activeSection string) g.Node {
+	activeSection = normalizeMetricViewSection(activeSection)
 	return c.HTML5(c.HTML5Props{
 		Title:    "LibreDash Metric View",
 		Language: "en",
@@ -487,11 +627,17 @@ func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail) 
 			h.Link(h.Href("https://cdn.jsdelivr.net/npm/daisyui@5"), h.Rel("stylesheet"), h.Type("text/css")),
 			h.Script(h.Src("https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4")),
 			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/app.css"))),
+			g.If(activeSection == "usage", h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/metric-usage-graph.css")))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/sidebar.js"))),
+			g.If(activeSection == "usage", h.Script(h.Type("module"), h.Src(staticAsset("/static/metric-usage-graph.js")))),
+			g.If(activeSection == "usage", h.Script(h.Type("module"), h.Src("https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js"))),
 		},
 		Body: []g.Node{
 			h.Main(h.Class("report-app"),
+				g.If(activeSection == "usage", ds.Signals(map[string]any{
+					"metricUsageGraph": metricUsageGraph(view),
+				})),
 				h.Div(h.Class("app-shell"),
 					sidebar(sidebarConfigForMetricView(catalog, view)),
 					h.Section(h.Class("app-main metric-main"), h.Aria("label", "LibreDash metric view"),
@@ -503,12 +649,9 @@ func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail) 
 						),
 						h.Div(h.Class("metric-contract-shell"),
 							metricViewSummary(view),
-							h.Div(h.Class("metric-contract-layout"),
-								h.Div(h.Class("metric-contract-main"),
-									metricViewMeasures(view.Measures),
-									metricViewDimensions(view.Dimensions),
-								),
-								metricViewRail(view),
+							metricTabs(view, activeSection),
+							h.Div(h.Class("metric-contract-main"),
+								metricViewActiveSection(view, activeSection),
 							),
 						),
 					),

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -331,26 +331,81 @@ func metricViewActions(view dashboard.MetricViewDetail) g.Node {
 	)
 }
 
-func metricViewSummary(view dashboard.MetricViewDetail) g.Node {
-	return h.Div(h.Class("metric-metadata-bar"),
-		h.Div(h.Class("metric-metadata-items"),
-			metricMetadataItem("Model", h.A(h.Href("/models/"+view.SemanticModel), g.Text(view.ModelTitle))),
-			metricMetadataItem("Dataset", h.Code(g.Text(view.Dataset))),
-			metricMetadataItem("Timeseries", h.Code(g.Text(view.Timeseries))),
+func metricViewHeader(view dashboard.MetricViewDetail) g.Node {
+	return h.Header(h.Class("metric-detail-header"),
+		h.Nav(h.Class("metric-breadcrumb"), h.Aria("label", "Metric view breadcrumb"),
+			h.A(h.Href("/metrics"), g.Text("Metric Views")),
+			lucide.ChevronRight(iconAttrs()),
+			h.A(h.Href("/models/"+view.SemanticModel), lucide.Box(iconAttrs()), h.Span(g.Text(view.ModelTitle))),
+			lucide.ChevronRight(iconAttrs()),
+			h.Span(lucide.Table2(iconAttrs()), h.Code(g.Text(view.Dataset))),
+			lucide.ChevronRight(iconAttrs()),
+			h.Span(lucide.Calendar(iconAttrs()), h.Code(g.Text(view.Timeseries))),
 		),
-		h.Div(h.Class("metric-count-pills"),
-			metricCountPill("Measure", view.MeasureCount, "measure", lucide.Sigma(iconAttrs())),
-			metricCountPill("Dimension", view.DimensionCount, "dimension", lucide.List(iconAttrs())),
-			metricCountPill("Dashboard", view.DashboardCount, "dashboard", lucide.LayoutDashboard(iconAttrs())),
+		h.Div(h.Class("metric-header-row"),
+			h.Div(h.Class("metric-header-copy"),
+				h.P(h.Class("report-eyebrow"), g.Text("Metric view")),
+				h.H1(h.Class("workspace-title"), g.Text(view.Title)),
+				g.If(strings.TrimSpace(view.Description) != "", h.P(h.Class("workspace-detail"), g.Text(view.Description))),
+			),
+			metricViewActions(view),
 		),
 	)
 }
 
-func metricMetadataItem(label string, value g.Node) g.Node {
-	return h.Div(h.Class("metric-metadata-item"),
-		h.Span(g.Text(label)),
-		value,
+func metricViewInfoSidebar(view dashboard.MetricViewDetail) g.Node {
+	return h.Aside(h.Class("metric-info-sidebar"), h.Aria("label", "Metric view data contract"),
+		h.Div(h.Class("metric-info-header"),
+			h.H2(lucide.FileText(iconAttrs()), h.Span(g.Text("Data Contract"))),
+			h.Span(h.Class("metric-verified-badge"), lucide.Check(iconAttrs()), g.Text("Verified")),
+		),
+		h.Div(h.Class("metric-info-body"),
+			h.Div(h.Class("metric-info-group"),
+				metricInfoItem("Model context", h.A(h.Href("/models/"+view.SemanticModel), lucide.Box(iconAttrs()), h.Span(g.Text(view.ModelTitle)))),
+				metricInfoItem("Source dataset", h.Span(lucide.Table2(iconAttrs()), h.Code(g.Text(view.Dataset)))),
+				metricInfoItem("Primary timeseries", h.Span(lucide.Calendar(iconAttrs()), h.Code(g.Text(view.Timeseries)))),
+			),
+			h.Div(h.Class("metric-info-divider")),
+			h.Div(h.Class("metric-info-group"),
+				h.H3(g.Text("Fields")),
+				metricInfoStat("Measures", view.MeasureCount, lucide.Sigma(iconAttrs())),
+				metricInfoStat("Dimensions", view.DimensionCount, lucide.List(iconAttrs())),
+				metricInfoStat("Dashboards", view.DashboardCount, lucide.LayoutDashboard(iconAttrs())),
+			),
+			h.Div(h.Class("metric-info-divider")),
+			h.Div(h.Class("metric-info-group"),
+				h.H3(g.Text("Governance")),
+				metricInfoRow("Owner", "Data Platform"),
+				metricInfoRow("Tier", "Core"),
+				metricInfoRow("Status", "Ready"),
+			),
+		),
 	)
+}
+
+func metricInfoItem(label string, value g.Node) g.Node {
+	return h.Div(h.Class("metric-info-item"),
+		h.Span(h.Class("metric-info-label"), g.Text(label)),
+		h.Div(h.Class("metric-info-value"), value),
+	)
+}
+
+func metricInfoStat(label string, count int, icon g.Node) g.Node {
+	return h.Div(h.Class("metric-info-stat"),
+		h.Span(icon, g.Text(label)),
+		h.Strong(g.Text(strconv.Itoa(count))),
+	)
+}
+
+func metricInfoRow(label, value string) g.Node {
+	return h.Div(h.Class("metric-info-row"),
+		h.Span(g.Text(label)),
+		h.Strong(g.Text(value)),
+	)
+}
+
+func metricTabCount(count int) g.Node {
+	return h.Span(h.Class("metric-tab-count"), g.Text(strconv.Itoa(count)))
 }
 
 func metricCountPill(label string, count int, tone string, icon g.Node) g.Node {
@@ -424,7 +479,6 @@ func metricViewMeasures(measures []dashboard.MetricViewMeasure) g.Node {
 						h.Th(g.Text("Expression")),
 						h.Th(g.Text("Unit")),
 						h.Th(g.Text("Format")),
-						h.Th(g.Text("Description")),
 					),
 				),
 				h.TBody(g.Map(measures, func(measure dashboard.MetricViewMeasure) g.Node {
@@ -434,7 +488,6 @@ func metricViewMeasures(measures []dashboard.MetricViewMeasure) g.Node {
 						h.Td(h.Code(h.Class("metric-expression"), g.Text(measure.Expression))),
 						h.Td(metricFieldChip(measure.Unit, "unit", unitIcon(measure.Unit))),
 						h.Td(metricFieldChip(measure.Format, "format", formatIcon(measure.Format))),
-						h.Td(g.Text(emptyDash(measure.Description))),
 					)
 				})),
 			),
@@ -535,18 +588,18 @@ func metricFieldChip(value, tone string, icon g.Node) g.Node {
 
 func metricTabs(view dashboard.MetricViewDetail, activeSection string) g.Node {
 	return h.Nav(h.Class("metric-tabs"), h.Aria("label", "Metric view sections"),
-		metricTabLink(view.ID, "measures", activeSection, lucide.Sigma(iconAttrs()), "Measures"),
-		metricTabLink(view.ID, "dimensions", activeSection, lucide.List(iconAttrs()), "Dimensions"),
-		metricTabLink(view.ID, "usage", activeSection, lucide.LayoutDashboard(iconAttrs()), "Used by"),
+		metricTabLink(view.ID, "measures", activeSection, "Measures", metricTabCount(view.MeasureCount)),
+		metricTabLink(view.ID, "dimensions", activeSection, "Dimensions", metricTabCount(view.DimensionCount)),
+		metricTabLink(view.ID, "usage", activeSection, "Usage", metricTabCount(view.DashboardCount)),
 	)
 }
 
-func metricTabLink(viewID, section, activeSection string, icon g.Node, label string) g.Node {
+func metricTabLink(viewID, section, activeSection, label string, meta g.Node) g.Node {
 	className := "metric-tab"
 	if section == activeSection {
 		className += " metric-tab-active"
 	}
-	return h.A(h.Class(className), h.Href("/metrics/"+viewID+"/"+section), g.If(section == activeSection, h.Aria("current", "page")), icon, h.Span(g.Text(label)))
+	return h.A(h.Class(className), h.Href("/metrics/"+viewID+"/"+section), g.If(section == activeSection, h.Aria("current", "page")), h.Span(g.Text(label)), meta)
 }
 
 func metricViewActiveSection(view dashboard.MetricViewDetail, activeSection string) g.Node {
@@ -641,18 +694,15 @@ func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail, 
 				h.Div(h.Class("app-shell"),
 					sidebar(sidebarConfigForMetricView(catalog, view)),
 					h.Section(h.Class("app-main metric-main"), h.Aria("label", "LibreDash metric view"),
-						workspaceHeader(
-							"Metric view",
-							view.Title,
-							view.Description,
-							metricViewActions(view),
-						),
-						h.Div(h.Class("metric-contract-shell"),
-							metricViewSummary(view),
-							metricTabs(view, activeSection),
-							h.Div(h.Class("metric-contract-main"),
-								metricViewActiveSection(view, activeSection),
+						metricViewHeader(view),
+						h.Div(h.Class("metric-workspace"),
+							h.Div(h.Class("metric-content-column"),
+								metricTabs(view, activeSection),
+								h.Div(h.Class("metric-contract-main"),
+									metricViewActiveSection(view, activeSection),
+								),
 							),
+							metricViewInfoSidebar(view),
 						),
 					),
 				),

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -220,6 +220,45 @@ func ModelsPage(catalog dashboard.Catalog) g.Node {
 	})
 }
 
+func MetricViewsPage(catalog dashboard.Catalog, views []dashboard.MetricViewSummary) g.Node {
+	return c.HTML5(c.HTML5Props{
+		Title:    "LibreDash Metric Views",
+		Language: "en",
+		HTMLAttrs: []g.Node{
+			g.Attr("data-color-mode", "auto"),
+			g.Attr("data-light-theme", "light"),
+			g.Attr("data-dark-theme", "dark"),
+		},
+		Head: []g.Node{
+			h.Meta(h.Name("viewport"), h.Content("width=device-width, initial-scale=1")),
+			h.Link(h.Rel("preconnect"), h.Href("https://cdn.jsdelivr.net")),
+			h.Link(h.Href("https://cdn.jsdelivr.net/npm/daisyui@5"), h.Rel("stylesheet"), h.Type("text/css")),
+			h.Script(h.Src("https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4")),
+			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/app.css"))),
+			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
+			h.Script(h.Type("module"), h.Src(staticAsset("/static/sidebar.js"))),
+		},
+		Body: []g.Node{
+			h.Main(h.Class("report-app"),
+				h.Div(h.Class("app-shell"),
+					sidebar(sidebarConfigForMetrics(catalog)),
+					h.Section(h.Class("app-main catalog-main"), h.Aria("label", "LibreDash metric view catalog"),
+						workspaceHeader(
+							"",
+							"Metric Views",
+							"Business-facing analytics contracts.",
+							nil,
+						),
+						h.Div(h.Class("catalog-grid"),
+							g.Map(views, metricViewCard),
+						),
+					),
+				),
+			),
+		},
+	})
+}
+
 func dashboardCard(report dashboard.CatalogDashboard) g.Node {
 	eyebrow := strings.Join(report.MetricViewTitles, ", ")
 	if eyebrow == "" {
@@ -246,6 +285,27 @@ func dashboardCard(report dashboard.CatalogDashboard) g.Node {
 	)
 }
 
+func metricViewCard(view dashboard.MetricViewSummary) g.Node {
+	return h.Article(h.Class("catalog-card"),
+		h.Div(h.Class("catalog-card-main"),
+			h.P(h.Class("report-eyebrow"), g.Text(view.ModelTitle)),
+			h.H2(g.Text(view.Title)),
+			h.P(g.Text(view.Description)),
+		),
+		h.Div(h.Class("catalog-tags"),
+			h.Span(g.Text(view.Dataset)),
+			h.Span(g.Text(view.Timeseries)),
+		),
+		h.Footer(h.Class("catalog-card-footer"),
+			h.Span(g.Textf("%d dimensions, %d measures", view.DimensionCount, view.MeasureCount)),
+			h.A(h.Class("catalog-open"), h.Href("/metrics/"+view.ID),
+				lucide.ExternalLink(iconAttrs()),
+				h.Span(g.Text("Open")),
+			),
+		),
+	)
+}
+
 func modelCard(model dashboard.CatalogModel) g.Node {
 	return h.Article(h.Class("catalog-card"),
 		h.Div(h.Class("catalog-card-main"),
@@ -261,6 +321,201 @@ func modelCard(model dashboard.CatalogModel) g.Node {
 			),
 		),
 	)
+}
+
+func metricViewActions(view dashboard.MetricViewDetail) g.Node {
+	return h.Div(h.Class("report-actions"),
+		h.A(h.Class("report-action-button"), h.Href("/models/"+view.SemanticModel), h.Title("Open semantic model"), h.Aria("label", "Open semantic model"),
+			lucide.Network(iconAttrs()),
+		),
+	)
+}
+
+func metricViewSummary(view dashboard.MetricViewDetail) g.Node {
+	return h.Div(h.Class("metric-summary-strip"),
+		metricSummaryItem("Semantic model", h.A(h.Href("/models/"+view.SemanticModel), g.Text(view.ModelTitle))),
+		metricSummaryItem("Dataset", h.Code(g.Text(view.Dataset))),
+		metricSummaryItem("Timeseries", h.Code(g.Text(view.Timeseries))),
+		metricSummaryItem("Measures", h.Strong(g.Text(strconv.Itoa(view.MeasureCount)))),
+		metricSummaryItem("Dimensions", h.Strong(g.Text(strconv.Itoa(view.DimensionCount)))),
+		metricSummaryItem("Dashboards", h.Strong(g.Text(strconv.Itoa(view.DashboardCount)))),
+	)
+}
+
+func metricSummaryItem(label string, value g.Node) g.Node {
+	return h.Div(h.Class("metric-summary-item"),
+		h.Span(g.Text(label)),
+		value,
+	)
+}
+
+func metricViewDimensions(dimensions []dashboard.MetricViewDimension) g.Node {
+	return h.Section(h.ID("dimensions"), h.Class("metric-contract-section"),
+		metricSectionHeader("Dimensions", "Fields available for grouping and filtering.", len(dimensions)),
+		h.Div(h.Class("metric-table-wrap"),
+			h.Table(h.Class("metric-field-table"),
+				h.THead(
+					h.Tr(
+						h.Th(g.Text("Name")),
+						h.Th(g.Text("Label")),
+						h.Th(g.Text("Expression")),
+						h.Th(g.Text("Filter")),
+						h.Th(g.Text("Order")),
+					),
+				),
+				h.TBody(g.Map(dimensions, func(dimension dashboard.MetricViewDimension) g.Node {
+					return h.Tr(
+						h.Td(h.Code(g.Text(dimension.Name))),
+						h.Td(g.Text(displayLabel(dimension.Label, dimension.Name))),
+						h.Td(h.Code(h.Class("metric-expression"), g.Text(dimension.Expr))),
+						h.Td(g.Text(emptyDash(dimension.Where))),
+						h.Td(g.Text(emptyDash(dimension.OrderExpr))),
+					)
+				})),
+			),
+		),
+	)
+}
+
+func metricViewMeasures(measures []dashboard.MetricViewMeasure) g.Node {
+	return h.Section(h.ID("measures"), h.Class("metric-contract-section"),
+		metricSectionHeader("Measures", "Aggregate SQL expressions available for analysis.", len(measures)),
+		h.Div(h.Class("metric-table-wrap"),
+			h.Table(h.Class("metric-field-table metric-measure-table"),
+				h.THead(
+					h.Tr(
+						h.Th(g.Text("Name")),
+						h.Th(g.Text("Label")),
+						h.Th(g.Text("Expression")),
+						h.Th(g.Text("Unit")),
+						h.Th(g.Text("Format")),
+						h.Th(g.Text("Description")),
+					),
+				),
+				h.TBody(g.Map(measures, func(measure dashboard.MetricViewMeasure) g.Node {
+					return h.Tr(
+						h.Td(h.Code(g.Text(measure.Name))),
+						h.Td(g.Text(displayLabel(measure.Label, measure.Name))),
+						h.Td(h.Code(h.Class("metric-expression"), g.Text(measure.Expression))),
+						h.Td(g.Text(emptyDash(measure.Unit))),
+						h.Td(g.Text(emptyDash(measure.Format))),
+						h.Td(g.Text(emptyDash(measure.Description))),
+					)
+				})),
+			),
+		),
+	)
+}
+
+func metricViewDashboards(reports []dashboard.MetricViewDashboard) g.Node {
+	return h.Section(h.ID("usage"), h.Class("metric-rail-section"),
+		h.H2(g.Text("Used by")),
+		g.If(len(reports) == 0, h.P(h.Class("metric-empty"), g.Text("No dashboards reference this metric view yet."))),
+		g.Map(reports, func(report dashboard.MetricViewDashboard) g.Node {
+			return h.A(h.Class("metric-dashboard-link"), h.Href("/dashboards/"+report.ID),
+				h.Span(g.Text(report.Title)),
+				h.Small(g.Textf("%d pages", report.PageCount)),
+				lucide.ExternalLink(iconAttrs()),
+			)
+		}),
+	)
+}
+
+func metricSectionHeader(title, description string, count int) g.Node {
+	return h.Div(h.Class("metric-section-header"),
+		h.Div(
+			h.P(h.Class("report-eyebrow"), g.Textf("%d fields", count)),
+			h.H2(g.Text(title)),
+			h.P(g.Text(description)),
+		),
+	)
+}
+
+func metricViewRail(view dashboard.MetricViewDetail) g.Node {
+	return h.Aside(h.Class("metric-contract-rail"),
+		h.Nav(h.Class("metric-rail-section metric-section-nav"), h.Aria("label", "Metric view sections"),
+			h.H2(g.Text("Sections")),
+			h.A(h.Href("#measures"), g.Text("Measures")),
+			h.A(h.Href("#dimensions"), g.Text("Dimensions")),
+			h.A(h.Href("#usage"), g.Text("Usage")),
+		),
+		h.Section(h.Class("metric-rail-section"),
+			h.H2(g.Text("Contract")),
+			metricRailRow("Model", h.A(h.Href("/models/"+view.SemanticModel), g.Text(view.ModelTitle))),
+			metricRailRow("Dataset", h.Code(g.Text(view.Dataset))),
+			metricRailRow("Timeseries", h.Code(g.Text(view.Timeseries))),
+			metricRailRow("Measures", h.Strong(g.Text(strconv.Itoa(view.MeasureCount)))),
+			metricRailRow("Dimensions", h.Strong(g.Text(strconv.Itoa(view.DimensionCount)))),
+		),
+		metricViewDashboards(view.Dashboards),
+	)
+}
+
+func metricRailRow(label string, value g.Node) g.Node {
+	return h.Div(h.Class("metric-rail-row"),
+		h.Span(g.Text(label)),
+		value,
+	)
+}
+
+func displayLabel(label, fallback string) string {
+	if strings.TrimSpace(label) != "" {
+		return label
+	}
+	return fallback
+}
+
+func emptyDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}
+
+func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail) g.Node {
+	return c.HTML5(c.HTML5Props{
+		Title:    "LibreDash Metric View",
+		Language: "en",
+		HTMLAttrs: []g.Node{
+			g.Attr("data-color-mode", "auto"),
+			g.Attr("data-light-theme", "light"),
+			g.Attr("data-dark-theme", "dark"),
+		},
+		Head: []g.Node{
+			h.Meta(h.Name("viewport"), h.Content("width=device-width, initial-scale=1")),
+			h.Link(h.Rel("preconnect"), h.Href("https://cdn.jsdelivr.net")),
+			h.Link(h.Href("https://cdn.jsdelivr.net/npm/daisyui@5"), h.Rel("stylesheet"), h.Type("text/css")),
+			h.Script(h.Src("https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4")),
+			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/app.css"))),
+			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
+			h.Script(h.Type("module"), h.Src(staticAsset("/static/sidebar.js"))),
+		},
+		Body: []g.Node{
+			h.Main(h.Class("report-app"),
+				h.Div(h.Class("app-shell"),
+					sidebar(sidebarConfigForMetricView(catalog, view)),
+					h.Section(h.Class("app-main metric-main"), h.Aria("label", "LibreDash metric view"),
+						workspaceHeader(
+							"Metric view",
+							view.Title,
+							view.Description,
+							metricViewActions(view),
+						),
+						h.Div(h.Class("metric-contract-shell"),
+							metricViewSummary(view),
+							h.Div(h.Class("metric-contract-layout"),
+								h.Div(h.Class("metric-contract-main"),
+									metricViewMeasures(view.Measures),
+									metricViewDimensions(view.Dimensions),
+								),
+								metricViewRail(view),
+							),
+						),
+					),
+				),
+			),
+		},
+	})
 }
 
 func ModelPage(catalog dashboard.Catalog, model dashboard.ModelGraph) g.Node {
@@ -359,6 +614,14 @@ func sidebarConfigForModels(catalog dashboard.Catalog) map[string]any {
 	return sidebarConfig(catalog, "models", "", workspaceDisplayTitle(catalog), "Semantic Models", "Catalog", "", "", false)
 }
 
+func sidebarConfigForMetrics(catalog dashboard.Catalog) map[string]any {
+	return sidebarConfig(catalog, "metrics", "", workspaceDisplayTitle(catalog), "Metric Views", "Catalog", "", "", false)
+}
+
+func sidebarConfigForMetricView(catalog dashboard.Catalog, view dashboard.MetricViewDetail) map[string]any {
+	return sidebarConfig(catalog, "metrics", "", workspaceDisplayTitle(catalog), "Metric view", view.Title, view.SemanticModel, view.ModelTitle, false)
+}
+
 func sidebarConfigForReport(catalog dashboard.Catalog, report semantic.Dashboard, model *semantic.Model, activePage dashboard.Page) map[string]any {
 	return sidebarConfig(catalog, "dashboards", report.ID, workspaceDisplayTitle(catalog), report.Title, activePage.Title, model.Name, model.Title, true)
 }
@@ -387,6 +650,7 @@ func sidebarGroups(catalog dashboard.Catalog) []map[string]any {
 			"label": "Navigation",
 			"items": []map[string]any{
 				{"id": "dashboards", "label": "Dashboards", "href": "/", "icon": "dashboard", "meta": "Reports and models"},
+				{"id": "metrics", "label": "Metric Views", "href": "/metrics", "icon": "data", "meta": "Business metrics"},
 				{"id": "models", "label": "Semantic Models", "href": "/models", "icon": "model", "meta": "Reusable data models"},
 			},
 		},

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -333,18 +333,8 @@ func metricViewActions(view dashboard.MetricViewDetail) g.Node {
 
 func metricViewHeader(view dashboard.MetricViewDetail) g.Node {
 	return h.Header(h.Class("metric-detail-header"),
-		h.Nav(h.Class("metric-breadcrumb"), h.Aria("label", "Metric view breadcrumb"),
-			h.A(h.Href("/metrics"), g.Text("Metric Views")),
-			lucide.ChevronRight(iconAttrs()),
-			h.A(h.Href("/models/"+view.SemanticModel), lucide.Box(iconAttrs()), h.Span(g.Text(view.ModelTitle))),
-			lucide.ChevronRight(iconAttrs()),
-			h.Span(lucide.Table2(iconAttrs()), h.Code(g.Text(view.Dataset))),
-			lucide.ChevronRight(iconAttrs()),
-			h.Span(lucide.Calendar(iconAttrs()), h.Code(g.Text(view.Timeseries))),
-		),
 		h.Div(h.Class("metric-header-row"),
 			h.Div(h.Class("metric-header-copy"),
-				h.P(h.Class("report-eyebrow"), g.Text("Metric view")),
 				h.H1(h.Class("workspace-title"), g.Text(view.Title)),
 				g.If(strings.TrimSpace(view.Description) != "", h.P(h.Class("workspace-detail"), g.Text(view.Description))),
 			),

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "npm run build:css && npm run build:url-sync && npm run build:sidebar && npm run build:report-sidebar && npm run build:filters && npm run build:filter-panel && npm run build:filter-card && npm run build:inspector && npm run build:table && npm run build:canvas && npm run build:footer && npm run build:charts && npm run build:visual-modal && npm run build:model && npm run build:login && npm run build:metric-usage",
+    "build": "npm run build:css && npm run build:url-sync && npm run build:sidebar && npm run build:report-sidebar && npm run build:filters && npm run build:filter-panel && npm run build:filter-card && npm run build:inspector && npm run build:table && npm run build:data-grid && npm run build:detail-rail && npm run build:canvas && npm run build:footer && npm run build:charts && npm run build:visual-modal && npm run build:model && npm run build:login && npm run build:metric-usage",
     "build:css": "tailwindcss -i ./static/app.input.css -o ./static/app.css",
     "build:url-sync": "esbuild web/components/url-sync.ts --bundle --format=esm --outfile=static/url-sync.js",
     "build:sidebar": "esbuild web/components/sidebar.ts --bundle --format=esm --outfile=static/sidebar.js",
@@ -14,6 +14,8 @@
     "build:filter-card": "esbuild web/components/filter-card.ts --bundle --format=esm --outfile=static/filter-card.js",
     "build:inspector": "esbuild web/components/datastar-inspector/index.ts --bundle --format=esm --outfile=static/datastar-inspector.js",
     "build:table": "esbuild web/components/data-table.ts --bundle --format=esm --outfile=static/table.js",
+    "build:data-grid": "esbuild web/components/data-grid.ts --bundle --format=esm --outfile=static/data-grid.js",
+    "build:detail-rail": "esbuild web/components/detail-rail.ts --bundle --format=esm --outfile=static/detail-rail.js",
     "build:canvas": "esbuild web/components/report-canvas.ts --bundle --format=esm --outfile=static/report-canvas.js",
     "build:footer": "esbuild web/components/report-footer.ts --bundle --format=esm --outfile=static/report-footer.js",
     "build:charts": "esbuild web/components/charts.ts --bundle --format=esm --outfile=static/charts.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "npm run build:css && npm run build:url-sync && npm run build:sidebar && npm run build:report-sidebar && npm run build:filters && npm run build:filter-panel && npm run build:filter-card && npm run build:inspector && npm run build:table && npm run build:canvas && npm run build:footer && npm run build:charts && npm run build:visual-modal && npm run build:model && npm run build:login",
+    "build": "npm run build:css && npm run build:url-sync && npm run build:sidebar && npm run build:report-sidebar && npm run build:filters && npm run build:filter-panel && npm run build:filter-card && npm run build:inspector && npm run build:table && npm run build:canvas && npm run build:footer && npm run build:charts && npm run build:visual-modal && npm run build:model && npm run build:login && npm run build:metric-usage",
     "build:css": "tailwindcss -i ./static/app.input.css -o ./static/app.css",
     "build:url-sync": "esbuild web/components/url-sync.ts --bundle --format=esm --outfile=static/url-sync.js",
     "build:sidebar": "esbuild web/components/sidebar.ts --bundle --format=esm --outfile=static/sidebar.js",
@@ -20,6 +20,7 @@
     "build:visual-modal": "esbuild web/components/visual-modal.ts --bundle --format=esm --outfile=static/visual-modal.js",
     "build:model": "esbuild web/components/model-graph.ts --bundle --format=esm --outfile=static/model-graph.js",
     "build:login": "esbuild web/components/login.ts --bundle --format=esm --outfile=static/login.js",
+    "build:metric-usage": "esbuild web/components/metric-usage-graph.ts --bundle --format=esm --outfile=static/metric-usage-graph.js",
     "watch:css": "tailwindcss -i ./static/app.input.css -o ./static/app.css --watch"
   },
   "devDependencies": {

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -389,57 +389,114 @@
     align-self: start;
   }
 
-  .metric-summary-strip {
-    display: grid;
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+  .metric-metadata-bar {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
     border: 1px solid var(--borderColor-default);
     border-radius: 6px;
-    background: var(--bgColor-default);
+    background:
+      linear-gradient(90deg, color-mix(in srgb, var(--fgColor-accent), transparent 94%), transparent 46%),
+      var(--bgColor-default);
     box-shadow: var(--shadow-resting-small);
-    overflow: hidden;
-  }
-
-  .metric-summary-item {
-    display: grid;
-    gap: 5px;
-    min-width: 0;
-    border-left: 1px solid var(--borderColor-muted);
     padding: 12px 14px;
   }
 
-  .metric-summary-item:first-child {
-    border-left: 0;
+  .metric-metadata-items {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
   }
 
-  .metric-summary-item > span,
-  .metric-rail-row > span {
+  .metric-metadata-item {
+    display: inline-flex;
+    min-height: 27px;
+    align-items: center;
+    gap: 7px;
+    border: 1px solid var(--borderColor-muted);
+    border-radius: 999px;
+    background: var(--bgColor-muted);
+    padding: 0 9px;
+  }
+
+  .metric-metadata-item > span {
     color: var(--fgColor-muted);
     font-size: 0.62rem;
     font-weight: 900;
     text-transform: uppercase;
   }
 
-  .metric-summary-item a,
-  .metric-summary-item strong,
-  .metric-summary-item code,
-  .metric-rail-row a,
-  .metric-rail-row strong,
-  .metric-rail-row code {
-    overflow: hidden;
-    color: var(--fgColor-default);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 0.8rem;
-    font-weight: 850;
+  .metric-metadata-item a {
+    color: var(--fgColor-accent);
     text-decoration: none;
   }
 
-  .metric-contract-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 280px;
-    gap: 18px;
-    align-items: start;
-    min-width: 0;
+  .metric-metadata-item a,
+  .metric-metadata-item code {
+    color: var(--fgColor-default);
+    font-size: 0.76rem;
+    font-weight: 800;
+  }
+
+  .metric-count-pills {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: end;
+    gap: 7px;
+  }
+
+  .metric-count-pill {
+    display: inline-flex;
+    min-height: 26px;
+    align-items: center;
+    gap: 5px;
+    border: 1px solid var(--borderColor-muted);
+    border-radius: 999px;
+    background: var(--bgColor-muted);
+    color: var(--fgColor-muted);
+    padding: 0 9px;
+    font-size: 0.68rem;
+    font-weight: 850;
+  }
+
+  .metric-count-pill svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  .metric-count-pill strong {
+    color: var(--fgColor-default);
+  }
+
+  .metric-count-pill-measure {
+    border-color: color-mix(in srgb, var(--fgColor-success), transparent 62%);
+    background: color-mix(in srgb, var(--fgColor-success), transparent 91%);
+  }
+
+  .metric-count-pill-measure svg {
+    color: var(--fgColor-success);
+  }
+
+  .metric-count-pill-dimension {
+    border-color: color-mix(in srgb, var(--fgColor-accent), transparent 62%);
+    background: color-mix(in srgb, var(--fgColor-accent), transparent 91%);
+  }
+
+  .metric-count-pill-dimension svg {
+    color: var(--fgColor-accent);
+  }
+
+  .metric-count-pill-dashboard {
+    border-color: color-mix(in srgb, var(--fgColor-attention), transparent 62%);
+    background: color-mix(in srgb, var(--fgColor-attention), transparent 91%);
+  }
+
+  .metric-count-pill-dashboard svg {
+    color: var(--fgColor-attention);
   }
 
   .metric-contract-main {
@@ -448,9 +505,59 @@
     min-width: 0;
   }
 
+  .metric-tabs {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+    border: 1px solid var(--borderColor-default);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--bgColor-default), transparent 4%);
+    box-shadow: var(--shadow-resting-small);
+    padding: 7px;
+  }
+
+  .metric-tabs a {
+    display: inline-flex;
+    min-height: 30px;
+    align-items: center;
+    gap: 7px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: var(--fgColor-default);
+    padding: 0 10px;
+    font-size: 0.78rem;
+    font-weight: 850;
+    text-decoration: none;
+  }
+
+  .metric-tabs a:hover,
+  .metric-tabs a:focus-visible {
+    border-color: var(--borderColor-muted);
+    background: var(--bgColor-muted);
+    outline: 0;
+  }
+
+  .metric-tabs a[aria-current="page"] {
+    border-color: var(--borderColor-accent-muted);
+    background: var(--bgColor-accent-muted);
+    color: var(--fgColor-accent);
+  }
+
+  .metric-tabs svg {
+    width: 14px;
+    height: 14px;
+    color: var(--fgColor-muted);
+  }
+
+  .metric-tabs a[aria-current="page"] svg {
+    color: currentColor;
+  }
+
   .metric-contract-section {
     display: grid;
-    gap: 12px;
     min-width: 0;
     border: 1px solid var(--borderColor-default);
     border-radius: 6px;
@@ -459,11 +566,95 @@
     overflow: hidden;
   }
 
-  .metric-section-header {
-    display: grid;
-    gap: 4px;
+  .metric-contract-section-measures {
+    border-top: 3px solid var(--fgColor-success);
+  }
+
+  .metric-contract-section-dimensions {
+    border-top: 3px solid var(--fgColor-accent);
+  }
+
+  .metric-contract-section-usage {
+    border-top: 3px solid var(--fgColor-attention);
+  }
+
+  ld-metric-usage-graph {
+    display: block;
+    min-width: 0;
+    min-height: 280px;
     border-bottom: 1px solid var(--borderColor-muted);
-    padding: 16px 18px 14px;
+  }
+
+  ld-metric-usage-graph .metric-usage-flow {
+    height: 280px;
+    min-width: 0;
+    background:
+      linear-gradient(var(--bgColor-default), var(--bgColor-default)),
+      radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--fgColor-muted), transparent 87%) 1px, transparent 0);
+    background-size: auto, 18px 18px;
+  }
+
+  ld-metric-usage-graph .react-flow {
+    color: var(--fgColor-default);
+  }
+
+  ld-metric-usage-graph .react-flow__attribution {
+    display: none;
+  }
+
+  ld-metric-usage-graph .react-flow__controls {
+    border: 1px solid var(--borderColor-default);
+    background: var(--bgColor-default);
+    box-shadow: var(--shadow-resting-small);
+  }
+
+  ld-metric-usage-graph .react-flow__controls-button {
+    border-bottom-color: var(--borderColor-muted);
+    background: var(--bgColor-default);
+    color: var(--fgColor-default);
+  }
+
+  ld-metric-usage-graph .metric-usage-node {
+    width: 190px;
+    border: 1px solid var(--usage-node-border);
+    border-left: 4px solid var(--usage-node-accent);
+    border-radius: 6px;
+    background: var(--usage-node-bg);
+    box-shadow: var(--shadow-resting-small);
+    color: var(--fgColor-default);
+    padding: 9px 10px;
+  }
+
+  ld-metric-usage-graph .metric-usage-node-kind {
+    color: var(--fgColor-muted);
+    font-size: 0.58rem;
+    font-weight: 950;
+    text-transform: uppercase;
+  }
+
+  ld-metric-usage-graph .metric-usage-node-title {
+    overflow: hidden;
+    margin-top: 3px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.82rem;
+    font-weight: 900;
+    line-height: 1.15;
+  }
+
+  ld-metric-usage-graph .metric-usage-node-meta {
+    overflow: hidden;
+    margin-top: 5px;
+    color: var(--fgColor-muted);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.68rem;
+    font-weight: 750;
+  }
+
+  .metric-section-header {
+    border-bottom: 1px solid var(--borderColor-muted);
+    padding: 14px 18px;
   }
 
   .metric-section-header h2 {
@@ -472,14 +663,6 @@
     font-size: 1.05rem;
     line-height: 1.15;
     font-weight: 850;
-  }
-
-  .metric-section-header p:last-child {
-    margin: 0;
-    color: var(--fgColor-muted);
-    font-size: 0.78rem;
-    line-height: 1.4;
-    font-weight: 650;
   }
 
   .metric-table-wrap {
@@ -521,8 +704,7 @@
   }
 
   .metric-field-table code,
-  .metric-summary-item code,
-  .metric-rail-row code {
+  .metric-metadata-item code {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
   }
 
@@ -545,6 +727,42 @@
     white-space: normal;
     font-size: 0.76rem;
     font-weight: 800;
+  }
+
+  .metric-field-chip {
+    display: inline-flex;
+    min-height: 22px;
+    align-items: center;
+    gap: 5px;
+    border-radius: 999px;
+    padding: 0 8px;
+    font-size: 0.66rem;
+    font-weight: 850;
+  }
+
+  .metric-field-chip svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .metric-field-chip-unit {
+    border: 1px solid color-mix(in srgb, var(--fgColor-success), transparent 64%);
+    background: color-mix(in srgb, var(--fgColor-success), transparent 91%);
+    color: var(--fgColor-default);
+  }
+
+  .metric-field-chip-unit svg {
+    color: var(--fgColor-success);
+  }
+
+  .metric-field-chip-format {
+    border: 1px solid color-mix(in srgb, var(--fgColor-accent), transparent 64%);
+    background: color-mix(in srgb, var(--fgColor-accent), transparent 91%);
+    color: var(--fgColor-default);
+  }
+
+  .metric-field-chip-format svg {
+    color: var(--fgColor-accent);
   }
 
   .metric-field-table th:nth-child(1),
@@ -576,91 +794,36 @@
     width: 150px;
   }
 
-  .metric-contract-rail {
-    position: sticky;
-    top: 16px;
-    display: grid;
-    gap: 12px;
-    min-width: 0;
-  }
-
-  .metric-rail-section {
-    display: grid;
-    gap: 10px;
-    border: 1px solid var(--borderColor-default);
-    border-radius: 6px;
-    background: var(--bgColor-default);
-    box-shadow: var(--shadow-resting-small);
-    padding: 14px;
-  }
-
-  .metric-rail-section h2 {
-    margin: 0;
-    color: var(--fgColor-default);
-    font-size: 0.88rem;
-    line-height: 1.15;
+  .metric-table-link {
+    color: var(--fgColor-accent);
     font-weight: 850;
-  }
-
-  .metric-section-nav a {
-    color: var(--fgColor-default);
-    font-size: 0.8rem;
-    font-weight: 750;
     text-decoration: none;
   }
 
-  .metric-section-nav a:hover,
-  .metric-section-nav a:focus-visible,
-  .metric-dashboard-link:hover,
-  .metric-dashboard-link:focus-visible {
-    color: var(--fgColor-accent);
+  .metric-table-link:hover,
+  .metric-table-link:focus-visible {
+    text-decoration: underline;
     outline: 0;
   }
 
-  .metric-rail-row {
-    display: grid;
-    gap: 4px;
-    min-width: 0;
-    border-top: 1px solid var(--borderColor-muted);
-    padding-top: 9px;
+  .metric-tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
   }
 
-  .metric-rail-row:nth-child(2) {
-    border-top: 0;
-    padding-top: 0;
-  }
-
-  .metric-dashboard-link {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 4px 8px;
+  .metric-tag-list span {
+    display: inline-flex;
+    min-height: 21px;
     align-items: center;
-    border-top: 1px solid var(--borderColor-muted);
-    padding-top: 10px;
-    color: var(--fgColor-default);
-    text-decoration: none;
-  }
-
-  .metric-dashboard-link span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 0.8rem;
-    font-weight: 850;
-  }
-
-  .metric-dashboard-link small {
-    grid-column: 1;
+    border: 1px solid var(--borderColor-muted);
+    border-radius: 999px;
+    background: var(--bgColor-muted);
     color: var(--fgColor-muted);
-    font-size: 0.68rem;
-    font-weight: 800;
-  }
-
-  .metric-dashboard-link svg {
-    grid-column: 2;
-    grid-row: 1 / span 2;
-    width: 14px;
-    height: 14px;
+    padding: 0 7px;
+    font-size: 0.64rem;
+    font-weight: 850;
+    text-transform: uppercase;
   }
 
   .metric-empty {
@@ -1569,19 +1732,13 @@
       padding: 12px;
     }
 
-    .metric-summary-strip,
-    .metric-contract-rail {
-      grid-template-columns: 1fr;
+    .metric-metadata-bar {
+      align-items: stretch;
+      flex-direction: column;
     }
 
-    .metric-summary-item,
-    .metric-summary-item:nth-child(4) {
-      border-top: 1px solid var(--borderColor-muted);
-      border-left: 0;
-    }
-
-    .metric-summary-item:first-child {
-      border-top: 0;
+    .metric-count-pills {
+      justify-content: start;
     }
 
     .metric-field-table {

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -382,11 +382,250 @@
     font-weight: 800;
   }
 
-  .metric-contract-shell {
+  .metric-detail-header {
     display: grid;
     gap: 14px;
+    border-bottom: 1px solid var(--borderColor-default);
+    padding-bottom: 18px;
+  }
+
+  .metric-breadcrumb {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 8px;
+    color: var(--fgColor-muted);
+    font-size: 0.72rem;
+    font-weight: 800;
+  }
+
+  .metric-breadcrumb > svg {
+    width: 12px;
+    height: 12px;
+    color: var(--fgColor-muted);
+    opacity: 0.7;
+  }
+
+  .metric-breadcrumb a,
+  .metric-breadcrumb span {
+    display: inline-flex;
+    min-width: 0;
+    align-items: center;
+    gap: 6px;
+    color: var(--fgColor-muted);
+    text-decoration: none;
+  }
+
+  .metric-breadcrumb a:hover,
+  .metric-breadcrumb a:focus-visible {
+    color: var(--fgColor-default);
+    outline: 0;
+  }
+
+  .metric-breadcrumb a svg,
+  .metric-breadcrumb span svg {
+    width: 13px;
+    height: 13px;
+    color: var(--fgColor-muted);
+  }
+
+  .metric-breadcrumb code {
+    overflow: hidden;
+    max-width: 22ch;
+    border: 1px solid var(--borderColor-muted);
+    border-radius: 4px;
+    background: var(--bgColor-muted);
+    color: var(--fgColor-default);
+    padding: 2px 6px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.68rem;
+  }
+
+  .metric-header-row {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 18px;
+  }
+
+  .metric-header-copy {
+    min-width: 0;
+  }
+
+  .metric-workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(250px, 288px);
+    gap: 0;
+    min-height: 0;
+    border-bottom: 1px solid var(--borderColor-default);
+  }
+
+  .metric-content-column {
+    display: grid;
     min-width: 0;
     align-self: start;
+    border-right: 1px solid var(--borderColor-default);
+  }
+
+  .metric-info-sidebar {
+    display: grid;
+    align-self: stretch;
+    align-content: start;
+    min-width: 0;
+    background: var(--bgColor-default);
+  }
+
+  .metric-info-header {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    border-bottom: 1px solid var(--borderColor-default);
+    background: color-mix(in srgb, var(--bgColor-default), transparent 2%);
+    padding: 16px 18px;
+  }
+
+  .metric-info-header h2 {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    color: var(--fgColor-default);
+    font-size: 0.86rem;
+    line-height: 1.2;
+    font-weight: 850;
+  }
+
+  .metric-info-header svg {
+    width: 15px;
+    height: 15px;
+    color: var(--fgColor-muted);
+  }
+
+  .metric-verified-badge {
+    display: inline-flex;
+    min-height: 20px;
+    align-items: center;
+    gap: 4px;
+    border: 1px solid color-mix(in srgb, var(--fgColor-success), transparent 72%);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--fgColor-success), transparent 91%);
+    color: var(--fgColor-success);
+    padding: 0 6px;
+    font-size: 0.56rem;
+    font-weight: 950;
+    text-transform: uppercase;
+  }
+
+  .metric-verified-badge svg {
+    width: 10px;
+    height: 10px;
+    color: currentColor;
+  }
+
+  .metric-info-body {
+    display: grid;
+    gap: 20px;
+    padding: 18px;
+  }
+
+  .metric-info-group {
+    display: grid;
+    gap: 13px;
+    min-width: 0;
+  }
+
+  .metric-info-group h3 {
+    margin: 0 0 -2px;
+    color: var(--fgColor-muted);
+    font-size: 0.62rem;
+    font-weight: 950;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .metric-info-divider {
+    height: 1px;
+    background: var(--borderColor-muted);
+  }
+
+  .metric-info-item {
+    display: grid;
+    gap: 5px;
+    min-width: 0;
+  }
+
+  .metric-info-label {
+    color: var(--fgColor-muted);
+    font-size: 0.62rem;
+    font-weight: 950;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .metric-info-value,
+  .metric-info-value a,
+  .metric-info-value span {
+    display: inline-flex;
+    min-width: 0;
+    align-items: center;
+    gap: 7px;
+    color: var(--fgColor-default);
+    text-decoration: none;
+    font-size: 0.82rem;
+    font-weight: 800;
+  }
+
+  .metric-info-value a:hover,
+  .metric-info-value a:focus-visible {
+    color: var(--fgColor-accent);
+    outline: 0;
+  }
+
+  .metric-info-value svg,
+  .metric-info-stat svg {
+    width: 14px;
+    height: 14px;
+    color: var(--fgColor-muted);
+    flex: 0 0 auto;
+  }
+
+  .metric-info-value code {
+    overflow: hidden;
+    max-width: 20ch;
+    color: var(--fgColor-default);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.76rem;
+  }
+
+  .metric-info-stat,
+  .metric-info-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    color: var(--fgColor-muted);
+    font-size: 0.76rem;
+    font-weight: 750;
+  }
+
+  .metric-info-stat span {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+  }
+
+  .metric-info-stat strong,
+  .metric-info-row strong {
+    color: var(--fgColor-default);
+    font-weight: 850;
   }
 
   .metric-metadata-bar {
@@ -501,8 +740,8 @@
 
   .metric-contract-main {
     display: grid;
-    gap: 18px;
     min-width: 0;
+    padding: 18px;
   }
 
   .metric-tabs {
@@ -511,78 +750,90 @@
     z-index: 4;
     display: flex;
     flex-wrap: wrap;
-    gap: 7px;
-    border: 1px solid var(--borderColor-default);
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--bgColor-default), transparent 4%);
-    box-shadow: var(--shadow-resting-small);
-    padding: 7px;
+    gap: 24px;
+    border-bottom: 1px solid var(--borderColor-default);
+    background: color-mix(in srgb, var(--bgColor-default), transparent 2%);
+    padding: 0 18px;
   }
 
   .metric-tabs a {
+    position: relative;
     display: inline-flex;
-    min-height: 30px;
+    min-height: 44px;
     align-items: center;
-    gap: 7px;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    color: var(--fgColor-default);
-    padding: 0 10px;
-    font-size: 0.78rem;
+    gap: 8px;
+    border: 0;
+    color: var(--fgColor-muted);
+    padding: 0;
+    font-size: 0.82rem;
     font-weight: 850;
     text-decoration: none;
   }
 
+  .metric-tabs a::after {
+    position: absolute;
+    right: 0;
+    bottom: -1px;
+    left: 0;
+    height: 2px;
+    background: transparent;
+    content: "";
+  }
+
   .metric-tabs a:hover,
   .metric-tabs a:focus-visible {
-    border-color: var(--borderColor-muted);
-    background: var(--bgColor-muted);
+    color: var(--fgColor-default);
     outline: 0;
   }
 
   .metric-tabs a[aria-current="page"] {
-    border-color: var(--borderColor-accent-muted);
-    background: var(--bgColor-accent-muted);
-    color: var(--fgColor-accent);
+    color: var(--fgColor-default);
   }
 
-  .metric-tabs svg {
-    width: 14px;
-    height: 14px;
+  .metric-tabs a[aria-current="page"]::after {
+    background: var(--fgColor-accent);
+  }
+
+  .metric-tab-count {
+    display: inline-flex;
+    min-width: 22px;
+    min-height: 20px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--borderColor-muted);
+    border-radius: 999px;
+    background: var(--bgColor-muted);
     color: var(--fgColor-muted);
-  }
-
-  .metric-tabs a[aria-current="page"] svg {
-    color: currentColor;
+    padding: 0 7px;
+    font-size: 0.65rem;
+    font-weight: 900;
   }
 
   .metric-contract-section {
     display: grid;
     min-width: 0;
-    border: 1px solid var(--borderColor-default);
-    border-radius: 6px;
-    background: var(--bgColor-default);
-    box-shadow: var(--shadow-resting-small);
-    overflow: hidden;
+    background: transparent;
   }
 
   .metric-contract-section-measures {
-    border-top: 3px solid var(--fgColor-success);
+    border-top: 0;
   }
 
   .metric-contract-section-dimensions {
-    border-top: 3px solid var(--fgColor-accent);
+    border-top: 0;
   }
 
   .metric-contract-section-usage {
-    border-top: 3px solid var(--fgColor-attention);
+    border-top: 0;
   }
 
   ld-metric-usage-graph {
     display: block;
     min-width: 0;
     min-height: 280px;
-    border-bottom: 1px solid var(--borderColor-muted);
+    border: 1px solid var(--borderColor-default);
+    border-radius: 6px;
+    overflow: hidden;
   }
 
   ld-metric-usage-graph .metric-usage-flow {
@@ -653,20 +904,20 @@
   }
 
   .metric-section-header {
-    border-bottom: 1px solid var(--borderColor-muted);
-    padding: 14px 18px;
+    padding: 0 0 12px;
   }
 
   .metric-section-header h2 {
     margin: 0;
     color: var(--fgColor-default);
-    font-size: 1.05rem;
+    font-size: 0.96rem;
     line-height: 1.15;
     font-weight: 850;
   }
 
   .metric-table-wrap {
     min-width: 0;
+    border-top: 1px solid var(--borderColor-default);
     overflow-x: auto;
   }
 
@@ -677,18 +928,46 @@
     table-layout: fixed;
   }
 
+  .metric-measure-table {
+    min-width: 0;
+  }
+
+  .metric-measure-table th:nth-child(1),
+  .metric-measure-table td:nth-child(1) {
+    width: 20%;
+  }
+
+  .metric-measure-table th:nth-child(2),
+  .metric-measure-table td:nth-child(2) {
+    width: 20%;
+  }
+
+  .metric-measure-table th:nth-child(3),
+  .metric-measure-table td:nth-child(3) {
+    width: 36%;
+  }
+
+  .metric-measure-table th:nth-child(4),
+  .metric-measure-table td:nth-child(4),
+  .metric-measure-table th:nth-child(5),
+  .metric-measure-table td:nth-child(5) {
+    width: 12%;
+  }
+
   .metric-field-table th,
   .metric-field-table td {
     border-bottom: 1px solid var(--borderColor-muted);
-    padding: 10px 12px;
+    padding: 11px 12px;
     text-align: left;
     vertical-align: top;
   }
 
   .metric-field-table th {
+    background: color-mix(in srgb, var(--bgColor-default), transparent 2%);
     color: var(--fgColor-muted);
     font-size: 0.62rem;
     font-weight: 900;
+    letter-spacing: 0.03em;
     text-transform: uppercase;
   }
 
@@ -701,6 +980,14 @@
 
   .metric-field-table tr:last-child td {
     border-bottom: 0;
+  }
+
+  .metric-field-table tbody tr {
+    transition: background-color 0.12s ease;
+  }
+
+  .metric-field-table tbody tr:hover {
+    background: var(--bgColor-muted);
   }
 
   .metric-field-table code,
@@ -1739,6 +2026,42 @@
 
     .metric-count-pills {
       justify-content: start;
+    }
+
+    .metric-detail-header {
+      gap: 12px;
+      padding-bottom: 14px;
+    }
+
+    .metric-breadcrumb {
+      flex-wrap: wrap;
+    }
+
+    .metric-header-row {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .metric-workspace {
+      grid-template-columns: 1fr;
+    }
+
+    .metric-content-column {
+      border-right: 0;
+    }
+
+    .metric-info-sidebar {
+      border-top: 1px solid var(--borderColor-default);
+    }
+
+    .metric-tabs {
+      gap: 16px;
+      overflow-x: auto;
+      padding: 0 12px;
+    }
+
+    .metric-contract-main {
+      padding: 14px 12px;
     }
 
     .metric-field-table {

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -393,7 +393,6 @@
   .metric-detail-header {
     display: grid;
     gap: 14px;
-    border-bottom: 1px solid var(--borderColor-default);
     padding-bottom: 18px;
   }
 
@@ -463,15 +462,18 @@
   }
 
   .metric-workspace {
+    --metric-detail-rail-width: 288px;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(250px, 288px);
+    grid-template-columns: minmax(0, 1fr) var(--metric-detail-rail-width);
     gap: 0;
     min-height: 0;
     overflow: hidden;
+    transition: grid-template-columns 180ms var(--ld-ease-out);
   }
 
-  .metric-workspace[data-rail-collapsed] {
-    grid-template-columns: minmax(0, 1fr) 48px;
+  .metric-workspace[data-rail-collapsed],
+  :root[data-metric-detail-rail="collapsed"] .metric-workspace {
+    --metric-detail-rail-width: 48px;
   }
 
   .metric-content-column {
@@ -489,6 +491,7 @@
     align-content: start;
     min-width: 0;
     overflow: hidden;
+    border-top: 1px solid var(--borderColor-default);
     background: var(--report-workspace-bg);
   }
 
@@ -500,7 +503,6 @@
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    border-bottom: 1px solid var(--borderColor-default);
     background: var(--report-workspace-bg);
     padding: 16px 18px;
   }
@@ -542,15 +544,22 @@
     outline: 0;
   }
 
-  .metric-workspace[data-rail-collapsed] .metric-info-header {
+  .metric-workspace[data-rail-collapsed] .metric-info-header,
+  :root[data-metric-detail-rail="collapsed"] .metric-workspace .metric-info-header {
     justify-content: center;
     border-bottom: 0;
     padding: 10px;
   }
 
   .metric-workspace[data-rail-collapsed] .metric-info-header h2,
-  .metric-workspace[data-rail-collapsed] .metric-info-body {
+  :root[data-metric-detail-rail="collapsed"] .metric-workspace .metric-info-header h2 {
     display: none;
+  }
+
+  .metric-workspace[data-rail-collapsed] .metric-info-body,
+  :root[data-metric-detail-rail="collapsed"] .metric-workspace .metric-info-body {
+    opacity: 0;
+    pointer-events: none;
   }
 
   .metric-info-header svg {
@@ -563,6 +572,8 @@
     display: grid;
     gap: 20px;
     padding: 18px;
+    opacity: 1;
+    transition: opacity 120ms var(--ld-ease-out);
   }
 
   .metric-info-group {
@@ -908,7 +919,6 @@
     width: 100%;
     min-width: 0;
     max-width: 100%;
-    border-top: 1px solid var(--borderColor-default);
     overflow-x: auto;
   }
 
@@ -920,17 +930,17 @@
 
   .data-grid th,
   .data-grid td {
-    border-bottom: 1px solid var(--borderColor-muted);
-    padding: 11px 12px;
+    border-bottom: 1px solid color-mix(in srgb, var(--borderColor-muted), transparent 28%);
+    padding: 10px 12px;
     text-align: left;
     vertical-align: top;
   }
 
   .data-grid th {
-    background: color-mix(in srgb, var(--bgColor-default), transparent 2%);
+    background: transparent;
     color: var(--fgColor-muted);
-    font-size: 0.62rem;
-    font-weight: 900;
+    font-size: 0.6rem;
+    font-weight: 850;
     letter-spacing: 0.03em;
     text-transform: uppercase;
   }
@@ -939,7 +949,7 @@
     color: var(--fgColor-default);
     font-size: 0.78rem;
     line-height: 1.4;
-    font-weight: 700;
+    font-weight: 600;
   }
 
   .data-grid th.is-right,
@@ -956,7 +966,7 @@
   }
 
   .data-grid tbody tr:hover {
-    background: var(--bgColor-muted);
+    background: color-mix(in srgb, var(--bgColor-muted), transparent 58%);
   }
 
   .data-grid-sort {
@@ -999,15 +1009,12 @@
     display: inline-flex;
     max-width: 100%;
     overflow: hidden;
-    border: 1px solid var(--borderColor-muted);
-    border-radius: 4px;
-    background: var(--bgColor-muted);
-    color: var(--fgColor-muted);
-    padding: 2px 6px;
+    color: var(--fgColor-default);
+    padding: 0;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 0.72rem;
-    font-weight: 800;
+    font-size: 0.78rem;
+    font-weight: 700;
   }
 
   .grid-expression {
@@ -1017,7 +1024,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     font-size: 0.76rem;
-    font-weight: 800;
+    font-weight: 650;
   }
 
   .grid-badge {
@@ -2041,11 +2048,13 @@
       grid-template-columns: 1fr;
     }
 
-    .metric-workspace[data-rail-collapsed] {
+    .metric-workspace[data-rail-collapsed],
+    :root[data-metric-detail-rail="collapsed"] .metric-workspace {
       grid-template-columns: 1fr;
     }
 
-    .metric-workspace[data-rail-collapsed] .metric-info-sidebar {
+    .metric-workspace[data-rail-collapsed] .metric-info-sidebar,
+    :root[data-metric-detail-rail="collapsed"] .metric-workspace .metric-info-sidebar {
       display: none;
     }
 

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -183,6 +183,14 @@
     padding: 16px 18px 18px;
   }
 
+  .metric-main {
+    height: 100svh;
+    min-height: 0;
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
+    padding-bottom: 0;
+  }
+
   .workspace-header {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
@@ -459,14 +467,20 @@
     grid-template-columns: minmax(0, 1fr) minmax(250px, 288px);
     gap: 0;
     min-height: 0;
-    border-bottom: 1px solid var(--borderColor-default);
+    overflow: hidden;
+  }
+
+  .metric-workspace[data-rail-collapsed] {
+    grid-template-columns: minmax(0, 1fr) 48px;
   }
 
   .metric-content-column {
     display: grid;
     min-width: 0;
-    align-self: start;
+    align-self: stretch;
+    grid-template-rows: auto minmax(0, 1fr);
     border-right: 1px solid var(--borderColor-default);
+    overflow: hidden;
   }
 
   .metric-info-sidebar {
@@ -474,7 +488,8 @@
     align-self: stretch;
     align-content: start;
     min-width: 0;
-    background: var(--bgColor-default);
+    overflow: hidden;
+    background: var(--report-workspace-bg);
   }
 
   .metric-info-header {
@@ -486,12 +501,13 @@
     justify-content: space-between;
     gap: 10px;
     border-bottom: 1px solid var(--borderColor-default);
-    background: color-mix(in srgb, var(--bgColor-default), transparent 2%);
+    background: var(--report-workspace-bg);
     padding: 16px 18px;
   }
 
   .metric-info-header h2 {
     display: inline-flex;
+    min-width: 0;
     align-items: center;
     gap: 8px;
     margin: 0;
@@ -501,31 +517,46 @@
     font-weight: 850;
   }
 
+  .metric-rail-toggle {
+    display: grid;
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    place-items: center;
+    border: 1px solid var(--borderColor-muted);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--fgColor-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.76rem;
+    font-weight: 900;
+    line-height: 1;
+  }
+
+  .metric-rail-toggle:hover,
+  .metric-rail-toggle:focus-visible {
+    border-color: var(--borderColor-default);
+    background: var(--bgColor-muted);
+    color: var(--fgColor-default);
+    outline: 0;
+  }
+
+  .metric-workspace[data-rail-collapsed] .metric-info-header {
+    justify-content: center;
+    border-bottom: 0;
+    padding: 10px;
+  }
+
+  .metric-workspace[data-rail-collapsed] .metric-info-header h2,
+  .metric-workspace[data-rail-collapsed] .metric-info-body {
+    display: none;
+  }
+
   .metric-info-header svg {
     width: 15px;
     height: 15px;
     color: var(--fgColor-muted);
-  }
-
-  .metric-verified-badge {
-    display: inline-flex;
-    min-height: 20px;
-    align-items: center;
-    gap: 4px;
-    border: 1px solid color-mix(in srgb, var(--fgColor-success), transparent 72%);
-    border-radius: 4px;
-    background: color-mix(in srgb, var(--fgColor-success), transparent 91%);
-    color: var(--fgColor-success);
-    padding: 0 6px;
-    font-size: 0.56rem;
-    font-weight: 950;
-    text-transform: uppercase;
-  }
-
-  .metric-verified-badge svg {
-    width: 10px;
-    height: 10px;
-    color: currentColor;
   }
 
   .metric-info-body {
@@ -538,20 +569,6 @@
     display: grid;
     gap: 13px;
     min-width: 0;
-  }
-
-  .metric-info-group h3 {
-    margin: 0 0 -2px;
-    color: var(--fgColor-muted);
-    font-size: 0.62rem;
-    font-weight: 950;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-  }
-
-  .metric-info-divider {
-    height: 1px;
-    background: var(--borderColor-muted);
   }
 
   .metric-info-item {
@@ -587,8 +604,7 @@
     outline: 0;
   }
 
-  .metric-info-value svg,
-  .metric-info-stat svg {
+  .metric-info-value svg {
     width: 14px;
     height: 14px;
     color: var(--fgColor-muted);
@@ -603,29 +619,6 @@
     white-space: nowrap;
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
     font-size: 0.76rem;
-  }
-
-  .metric-info-stat,
-  .metric-info-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    color: var(--fgColor-muted);
-    font-size: 0.76rem;
-    font-weight: 750;
-  }
-
-  .metric-info-stat span {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-  }
-
-  .metric-info-stat strong,
-  .metric-info-row strong {
-    color: var(--fgColor-default);
-    font-weight: 850;
   }
 
   .metric-metadata-bar {
@@ -741,6 +734,8 @@
   .metric-contract-main {
     display: grid;
     min-width: 0;
+    align-content: start;
+    overflow: hidden;
     padding: 18px;
   }
 
@@ -752,7 +747,7 @@
     flex-wrap: wrap;
     gap: 24px;
     border-bottom: 1px solid var(--borderColor-default);
-    background: color-mix(in srgb, var(--bgColor-default), transparent 2%);
+    background: var(--report-workspace-bg);
     padding: 0 18px;
   }
 
@@ -813,6 +808,12 @@
     display: grid;
     min-width: 0;
     background: transparent;
+  }
+
+  ld-data-grid {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
   }
 
   .metric-contract-section-measures {
@@ -903,66 +904,29 @@
     font-weight: 750;
   }
 
-  .metric-section-header {
-    padding: 0 0 12px;
-  }
-
-  .metric-section-header h2 {
-    margin: 0;
-    color: var(--fgColor-default);
-    font-size: 0.96rem;
-    line-height: 1.15;
-    font-weight: 850;
-  }
-
-  .metric-table-wrap {
+  .data-grid-wrap {
+    width: 100%;
     min-width: 0;
+    max-width: 100%;
     border-top: 1px solid var(--borderColor-default);
     overflow-x: auto;
   }
 
-  .metric-field-table {
+  .data-grid {
     width: 100%;
-    min-width: 760px;
     border-collapse: collapse;
     table-layout: fixed;
   }
 
-  .metric-measure-table {
-    min-width: 0;
-  }
-
-  .metric-measure-table th:nth-child(1),
-  .metric-measure-table td:nth-child(1) {
-    width: 20%;
-  }
-
-  .metric-measure-table th:nth-child(2),
-  .metric-measure-table td:nth-child(2) {
-    width: 20%;
-  }
-
-  .metric-measure-table th:nth-child(3),
-  .metric-measure-table td:nth-child(3) {
-    width: 36%;
-  }
-
-  .metric-measure-table th:nth-child(4),
-  .metric-measure-table td:nth-child(4),
-  .metric-measure-table th:nth-child(5),
-  .metric-measure-table td:nth-child(5) {
-    width: 12%;
-  }
-
-  .metric-field-table th,
-  .metric-field-table td {
+  .data-grid th,
+  .data-grid td {
     border-bottom: 1px solid var(--borderColor-muted);
     padding: 11px 12px;
     text-align: left;
     vertical-align: top;
   }
 
-  .metric-field-table th {
+  .data-grid th {
     background: color-mix(in srgb, var(--bgColor-default), transparent 2%);
     color: var(--fgColor-muted);
     font-size: 0.62rem;
@@ -971,52 +935,92 @@
     text-transform: uppercase;
   }
 
-  .metric-field-table td {
+  .data-grid td {
     color: var(--fgColor-default);
     font-size: 0.78rem;
     line-height: 1.4;
     font-weight: 700;
   }
 
-  .metric-field-table tr:last-child td {
+  .data-grid th.is-right,
+  .data-grid td.is-right {
+    text-align: right;
+  }
+
+  .data-grid tr:last-child td {
     border-bottom: 0;
   }
 
-  .metric-field-table tbody tr {
+  .data-grid tbody tr {
     transition: background-color 0.12s ease;
   }
 
-  .metric-field-table tbody tr:hover {
+  .data-grid tbody tr:hover {
     background: var(--bgColor-muted);
   }
 
-  .metric-field-table code,
+  .data-grid-sort {
+    display: inline-flex;
+    width: 100%;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    letter-spacing: inherit;
+    text-align: inherit;
+    text-transform: inherit;
+  }
+
+  .data-grid-sort:hover,
+  .data-grid-sort:focus-visible {
+    color: var(--fgColor-default);
+    outline: 0;
+  }
+
+  .data-grid-sort-indicator {
+    min-width: 8px;
+    color: var(--fgColor-accent);
+    text-align: right;
+  }
+
+  .grid-code,
+  .grid-expression,
   .metric-metadata-item code {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
   }
 
-  .metric-field-table td:first-child code {
+  .grid-code {
     display: inline-flex;
     max-width: 100%;
+    overflow: hidden;
     border: 1px solid var(--borderColor-muted);
     border-radius: 4px;
     background: var(--bgColor-muted);
     color: var(--fgColor-muted);
     padding: 2px 6px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     font-size: 0.72rem;
     font-weight: 800;
   }
 
-  .metric-expression {
+  .grid-expression {
     display: block;
-    overflow-wrap: anywhere;
+    overflow: hidden;
     color: var(--fgColor-default);
-    white-space: normal;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     font-size: 0.76rem;
     font-weight: 800;
   }
 
-  .metric-field-chip {
+  .grid-badge {
     display: inline-flex;
     min-height: 22px;
     align-items: center;
@@ -1027,79 +1031,54 @@
     font-weight: 850;
   }
 
-  .metric-field-chip svg {
-    width: 12px;
-    height: 12px;
-  }
-
-  .metric-field-chip-unit {
+  .grid-badge-success {
     border: 1px solid color-mix(in srgb, var(--fgColor-success), transparent 64%);
     background: color-mix(in srgb, var(--fgColor-success), transparent 91%);
     color: var(--fgColor-default);
   }
 
-  .metric-field-chip-unit svg {
-    color: var(--fgColor-success);
-  }
-
-  .metric-field-chip-format {
+  .grid-badge-accent {
     border: 1px solid color-mix(in srgb, var(--fgColor-accent), transparent 64%);
     background: color-mix(in srgb, var(--fgColor-accent), transparent 91%);
     color: var(--fgColor-default);
   }
 
-  .metric-field-chip-format svg {
-    color: var(--fgColor-accent);
+  .grid-badge-attention {
+    border: 1px solid color-mix(in srgb, var(--fgColor-attention), transparent 64%);
+    background: color-mix(in srgb, var(--fgColor-attention), transparent 91%);
+    color: var(--fgColor-default);
   }
 
-  .metric-field-table th:nth-child(1),
-  .metric-field-table td:nth-child(1) {
-    width: 150px;
+  .grid-badge-muted,
+  .grid-badge-default {
+    border: 1px solid var(--borderColor-muted);
+    background: var(--bgColor-muted);
+    color: var(--fgColor-muted);
   }
 
-  .metric-field-table th:nth-child(2),
-  .metric-field-table td:nth-child(2) {
-    width: 150px;
+  .grid-number {
+    font-variant-numeric: tabular-nums;
   }
 
-  .metric-field-table th:nth-child(4),
-  .metric-field-table td:nth-child(4),
-  .metric-field-table th:nth-child(5),
-  .metric-field-table td:nth-child(5) {
-    width: 150px;
-  }
-
-  .metric-measure-table th:nth-child(4),
-  .metric-measure-table td:nth-child(4),
-  .metric-measure-table th:nth-child(5),
-  .metric-measure-table td:nth-child(5) {
-    width: 86px;
-  }
-
-  .metric-measure-table th:nth-child(6),
-  .metric-measure-table td:nth-child(6) {
-    width: 150px;
-  }
-
-  .metric-table-link {
+  .grid-link {
     color: var(--fgColor-accent);
     font-weight: 850;
     text-decoration: none;
   }
 
-  .metric-table-link:hover,
-  .metric-table-link:focus-visible {
+  .grid-link:hover,
+  .grid-link:focus-visible {
     text-decoration: underline;
     outline: 0;
   }
 
-  .metric-tag-list {
+  .grid-tags {
     display: flex;
     flex-wrap: wrap;
     gap: 5px;
   }
 
-  .metric-tag-list span {
+  .grid-tags span {
     display: inline-flex;
     min-height: 21px;
     align-items: center;
@@ -1111,6 +1090,18 @@
     font-size: 0.64rem;
     font-weight: 850;
     text-transform: uppercase;
+  }
+
+  .grid-muted,
+  .data-grid-empty {
+    color: var(--fgColor-muted);
+  }
+
+  .data-grid-empty {
+    border-top: 1px solid var(--borderColor-default);
+    padding: 16px 0 0;
+    font-size: 0.78rem;
+    font-weight: 650;
   }
 
   .metric-empty {
@@ -2019,6 +2010,10 @@
       padding: 12px;
     }
 
+    .metric-main {
+      padding-bottom: 0;
+    }
+
     .metric-metadata-bar {
       align-items: stretch;
       flex-direction: column;
@@ -2046,6 +2041,14 @@
       grid-template-columns: 1fr;
     }
 
+    .metric-workspace[data-rail-collapsed] {
+      grid-template-columns: 1fr;
+    }
+
+    .metric-workspace[data-rail-collapsed] .metric-info-sidebar {
+      display: none;
+    }
+
     .metric-content-column {
       border-right: 0;
     }
@@ -2062,10 +2065,6 @@
 
     .metric-contract-main {
       padding: 14px 12px;
-    }
-
-    .metric-field-table {
-      min-width: 680px;
     }
 
     .workspace-header {

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -177,6 +177,7 @@
   }
 
   .catalog-main,
+  .metric-main,
   .model-main {
     gap: 12px;
     padding: 16px 18px 18px;
@@ -379,6 +380,295 @@
     color: var(--fgColor-muted);
     font-size: 0.74rem;
     font-weight: 800;
+  }
+
+  .metric-contract-shell {
+    display: grid;
+    gap: 14px;
+    min-width: 0;
+    align-self: start;
+  }
+
+  .metric-summary-strip {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    border: 1px solid var(--borderColor-default);
+    border-radius: 6px;
+    background: var(--bgColor-default);
+    box-shadow: var(--shadow-resting-small);
+    overflow: hidden;
+  }
+
+  .metric-summary-item {
+    display: grid;
+    gap: 5px;
+    min-width: 0;
+    border-left: 1px solid var(--borderColor-muted);
+    padding: 12px 14px;
+  }
+
+  .metric-summary-item:first-child {
+    border-left: 0;
+  }
+
+  .metric-summary-item > span,
+  .metric-rail-row > span {
+    color: var(--fgColor-muted);
+    font-size: 0.62rem;
+    font-weight: 900;
+    text-transform: uppercase;
+  }
+
+  .metric-summary-item a,
+  .metric-summary-item strong,
+  .metric-summary-item code,
+  .metric-rail-row a,
+  .metric-rail-row strong,
+  .metric-rail-row code {
+    overflow: hidden;
+    color: var(--fgColor-default);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.8rem;
+    font-weight: 850;
+    text-decoration: none;
+  }
+
+  .metric-contract-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 18px;
+    align-items: start;
+    min-width: 0;
+  }
+
+  .metric-contract-main {
+    display: grid;
+    gap: 18px;
+    min-width: 0;
+  }
+
+  .metric-contract-section {
+    display: grid;
+    gap: 12px;
+    min-width: 0;
+    border: 1px solid var(--borderColor-default);
+    border-radius: 6px;
+    background: var(--bgColor-default);
+    box-shadow: var(--shadow-resting-small);
+    overflow: hidden;
+  }
+
+  .metric-section-header {
+    display: grid;
+    gap: 4px;
+    border-bottom: 1px solid var(--borderColor-muted);
+    padding: 16px 18px 14px;
+  }
+
+  .metric-section-header h2 {
+    margin: 0;
+    color: var(--fgColor-default);
+    font-size: 1.05rem;
+    line-height: 1.15;
+    font-weight: 850;
+  }
+
+  .metric-section-header p:last-child {
+    margin: 0;
+    color: var(--fgColor-muted);
+    font-size: 0.78rem;
+    line-height: 1.4;
+    font-weight: 650;
+  }
+
+  .metric-table-wrap {
+    min-width: 0;
+    overflow-x: auto;
+  }
+
+  .metric-field-table {
+    width: 100%;
+    min-width: 760px;
+    border-collapse: collapse;
+    table-layout: fixed;
+  }
+
+  .metric-field-table th,
+  .metric-field-table td {
+    border-bottom: 1px solid var(--borderColor-muted);
+    padding: 10px 12px;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .metric-field-table th {
+    color: var(--fgColor-muted);
+    font-size: 0.62rem;
+    font-weight: 900;
+    text-transform: uppercase;
+  }
+
+  .metric-field-table td {
+    color: var(--fgColor-default);
+    font-size: 0.78rem;
+    line-height: 1.4;
+    font-weight: 700;
+  }
+
+  .metric-field-table tr:last-child td {
+    border-bottom: 0;
+  }
+
+  .metric-field-table code,
+  .metric-summary-item code,
+  .metric-rail-row code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  }
+
+  .metric-field-table td:first-child code {
+    display: inline-flex;
+    max-width: 100%;
+    border: 1px solid var(--borderColor-muted);
+    border-radius: 4px;
+    background: var(--bgColor-muted);
+    color: var(--fgColor-muted);
+    padding: 2px 6px;
+    font-size: 0.72rem;
+    font-weight: 800;
+  }
+
+  .metric-expression {
+    display: block;
+    overflow-wrap: anywhere;
+    color: var(--fgColor-default);
+    white-space: normal;
+    font-size: 0.76rem;
+    font-weight: 800;
+  }
+
+  .metric-field-table th:nth-child(1),
+  .metric-field-table td:nth-child(1) {
+    width: 150px;
+  }
+
+  .metric-field-table th:nth-child(2),
+  .metric-field-table td:nth-child(2) {
+    width: 150px;
+  }
+
+  .metric-field-table th:nth-child(4),
+  .metric-field-table td:nth-child(4),
+  .metric-field-table th:nth-child(5),
+  .metric-field-table td:nth-child(5) {
+    width: 150px;
+  }
+
+  .metric-measure-table th:nth-child(4),
+  .metric-measure-table td:nth-child(4),
+  .metric-measure-table th:nth-child(5),
+  .metric-measure-table td:nth-child(5) {
+    width: 86px;
+  }
+
+  .metric-measure-table th:nth-child(6),
+  .metric-measure-table td:nth-child(6) {
+    width: 150px;
+  }
+
+  .metric-contract-rail {
+    position: sticky;
+    top: 16px;
+    display: grid;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  .metric-rail-section {
+    display: grid;
+    gap: 10px;
+    border: 1px solid var(--borderColor-default);
+    border-radius: 6px;
+    background: var(--bgColor-default);
+    box-shadow: var(--shadow-resting-small);
+    padding: 14px;
+  }
+
+  .metric-rail-section h2 {
+    margin: 0;
+    color: var(--fgColor-default);
+    font-size: 0.88rem;
+    line-height: 1.15;
+    font-weight: 850;
+  }
+
+  .metric-section-nav a {
+    color: var(--fgColor-default);
+    font-size: 0.8rem;
+    font-weight: 750;
+    text-decoration: none;
+  }
+
+  .metric-section-nav a:hover,
+  .metric-section-nav a:focus-visible,
+  .metric-dashboard-link:hover,
+  .metric-dashboard-link:focus-visible {
+    color: var(--fgColor-accent);
+    outline: 0;
+  }
+
+  .metric-rail-row {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+    border-top: 1px solid var(--borderColor-muted);
+    padding-top: 9px;
+  }
+
+  .metric-rail-row:nth-child(2) {
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  .metric-dashboard-link {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 4px 8px;
+    align-items: center;
+    border-top: 1px solid var(--borderColor-muted);
+    padding-top: 10px;
+    color: var(--fgColor-default);
+    text-decoration: none;
+  }
+
+  .metric-dashboard-link span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.8rem;
+    font-weight: 850;
+  }
+
+  .metric-dashboard-link small {
+    grid-column: 1;
+    color: var(--fgColor-muted);
+    font-size: 0.68rem;
+    font-weight: 800;
+  }
+
+  .metric-dashboard-link svg {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    width: 14px;
+    height: 14px;
+  }
+
+  .metric-empty {
+    margin: 0;
+    color: var(--fgColor-muted);
+    font-size: 0.78rem;
+    line-height: 1.4;
+    font-weight: 650;
   }
 
   .catalog-open {
@@ -1248,15 +1538,54 @@
     background: #ffb900;
   }
 
+  @media (max-width: 1120px) {
+    .metric-summary-strip {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .metric-summary-item:nth-child(4) {
+      border-left: 0;
+    }
+
+    .metric-contract-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .metric-contract-rail {
+      position: static;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
   @media (max-width: 640px) {
     .app-shell {
       grid-template-columns: 1fr;
     }
 
     .catalog-main,
+    .metric-main,
     .model-main {
       min-height: auto;
       padding: 12px;
+    }
+
+    .metric-summary-strip,
+    .metric-contract-rail {
+      grid-template-columns: 1fr;
+    }
+
+    .metric-summary-item,
+    .metric-summary-item:nth-child(4) {
+      border-top: 1px solid var(--borderColor-muted);
+      border-left: 0;
+    }
+
+    .metric-summary-item:first-child {
+      border-top: 0;
+    }
+
+    .metric-field-table {
+      min-width: 680px;
     }
 
     .workspace-header {

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -188,7 +188,7 @@
     min-height: 0;
     grid-template-rows: auto minmax(0, 1fr);
     overflow: hidden;
-    padding-bottom: 0;
+    padding: 0;
   }
 
   .workspace-header {
@@ -391,68 +391,16 @@
   }
 
   .metric-detail-header {
-    display: grid;
-    gap: 14px;
-    padding-bottom: 18px;
-  }
-
-  .metric-breadcrumb {
     display: flex;
-    min-width: 0;
     align-items: center;
-    gap: 8px;
-    color: var(--fgColor-muted);
-    font-size: 0.72rem;
-    font-weight: 800;
-  }
-
-  .metric-breadcrumb > svg {
-    width: 12px;
-    height: 12px;
-    color: var(--fgColor-muted);
-    opacity: 0.7;
-  }
-
-  .metric-breadcrumb a,
-  .metric-breadcrumb span {
-    display: inline-flex;
-    min-width: 0;
-    align-items: center;
-    gap: 6px;
-    color: var(--fgColor-muted);
-    text-decoration: none;
-  }
-
-  .metric-breadcrumb a:hover,
-  .metric-breadcrumb a:focus-visible {
-    color: var(--fgColor-default);
-    outline: 0;
-  }
-
-  .metric-breadcrumb a svg,
-  .metric-breadcrumb span svg {
-    width: 13px;
-    height: 13px;
-    color: var(--fgColor-muted);
-  }
-
-  .metric-breadcrumb code {
-    overflow: hidden;
-    max-width: 22ch;
-    border: 1px solid var(--borderColor-muted);
-    border-radius: 4px;
-    background: var(--bgColor-muted);
-    color: var(--fgColor-default);
-    padding: 2px 6px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
-    font-size: 0.68rem;
+    min-height: 112px;
+    padding: 16px 28px 12px;
   }
 
   .metric-header-row {
     display: flex;
-    align-items: end;
+    width: 100%;
+    align-items: center;
     justify-content: space-between;
     gap: 18px;
   }
@@ -542,6 +490,16 @@
     background: var(--bgColor-muted);
     color: var(--fgColor-default);
     outline: 0;
+  }
+
+  .metric-rail-toggle svg {
+    width: 15px;
+    height: 15px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
   }
 
   .metric-workspace[data-rail-collapsed] .metric-info-header,
@@ -747,7 +705,7 @@
     min-width: 0;
     align-content: start;
     overflow: hidden;
-    padding: 18px;
+    padding: 18px 28px;
   }
 
   .metric-tabs {
@@ -759,7 +717,7 @@
     gap: 24px;
     border-bottom: 1px solid var(--borderColor-default);
     background: var(--report-workspace-bg);
-    padding: 0 18px;
+    padding: 0;
   }
 
   .metric-tabs a {
@@ -770,7 +728,7 @@
     gap: 8px;
     border: 0;
     color: var(--fgColor-muted);
-    padding: 0;
+    padding: 0 28px;
     font-size: 0.82rem;
     font-weight: 850;
     text-decoration: none;
@@ -2018,7 +1976,7 @@
     }
 
     .metric-main {
-      padding-bottom: 0;
+      padding: 0;
     }
 
     .metric-metadata-bar {
@@ -2031,12 +1989,8 @@
     }
 
     .metric-detail-header {
-      gap: 12px;
+      min-height: auto;
       padding-bottom: 14px;
-    }
-
-    .metric-breadcrumb {
-      flex-wrap: wrap;
     }
 
     .metric-header-row {
@@ -2069,7 +2023,10 @@
     .metric-tabs {
       gap: 16px;
       overflow-x: auto;
-      padding: 0 12px;
+    }
+
+    .metric-tabs a {
+      padding: 0 16px;
     }
 
     .metric-contract-main {

--- a/web/components/data-grid.ts
+++ b/web/components/data-grid.ts
@@ -1,0 +1,199 @@
+import { LitElement, html } from 'lit'
+import { property, state } from 'lit/decorators.js'
+import {
+  TableController,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type ColumnDef,
+  type SortingState,
+} from '@tanstack/lit-table'
+
+type GridCellTone = 'default' | 'accent' | 'success' | 'attention' | 'muted'
+
+type GridCell = {
+  label?: string
+  value?: string | number
+  tone?: GridCellTone
+}
+
+type GridColumn = {
+  id: string
+  header: string
+  kind?: 'text' | 'code' | 'expression' | 'badge' | 'number' | 'link' | 'tags'
+  align?: 'left' | 'right'
+  hrefKey?: string
+  width?: string
+}
+
+type GridRow = Record<string, unknown>
+
+type Grid = {
+  columns?: GridColumn[]
+  rows?: GridRow[]
+  empty?: string
+  minWidth?: string
+}
+
+const emptyGrid: Required<Grid> = {
+  columns: [],
+  rows: [],
+  empty: 'No rows to show.',
+  minWidth: '0',
+}
+
+function applyUpdater<T>(updater: unknown, current: T): T {
+  return typeof updater === 'function' ? (updater as (old: T) => T)(current) : updater as T
+}
+
+function cellLabel(value: unknown): string {
+  if (value == null || value === '') return '-'
+  if (typeof value === 'object' && 'label' in value) {
+    const label = (value as GridCell).label ?? (value as GridCell).value
+    return label == null || label === '' ? '-' : String(label)
+  }
+  return String(value)
+}
+
+function cellTone(value: unknown): GridCellTone {
+  if (typeof value === 'object' && value && 'tone' in value) {
+    return (value as GridCell).tone ?? 'default'
+  }
+  return 'default'
+}
+
+function sortValue(value: unknown): string | number {
+  if (typeof value === 'number') return value
+  return cellLabel(value).toLowerCase()
+}
+
+class DataGrid extends LitElement {
+  @property({ type: Object }) grid: Grid | null = null
+  @property({ attribute: 'data-grid' }) dataGrid = '{}'
+  @state() private sorting: SortingState = []
+  private tableController = new TableController<GridRow>(this)
+
+  createRenderRoot(): HTMLElement {
+    return this
+  }
+
+  render() {
+    const grid = this.resolvedGrid
+    const columns: ColumnDef<GridRow, unknown>[] = grid.columns.map((column) => ({
+      id: column.id,
+      accessorFn: (row) => row[column.id],
+      header: column.header,
+      cell: (info) => this.renderCell(column, info.getValue(), info.row.original),
+      sortingFn: (left, right, columnID) => {
+        const leftValue = sortValue(left.original[columnID])
+        const rightValue = sortValue(right.original[columnID])
+        if (typeof leftValue === 'number' && typeof rightValue === 'number') return leftValue - rightValue
+        return String(leftValue).localeCompare(String(rightValue), undefined, { numeric: true })
+      },
+      meta: column,
+    }))
+    const table = this.tableController.table({
+      data: grid.rows,
+      columns,
+      state: { sorting: this.sorting },
+      onSortingChange: (updater) => {
+        this.sorting = applyUpdater(updater, this.sorting)
+      },
+      getCoreRowModel: getCoreRowModel(),
+      getSortedRowModel: getSortedRowModel(),
+    })
+
+    if (grid.rows.length === 0) {
+      return html`<div class="data-grid-empty">${grid.empty}</div>`
+    }
+
+    return html`
+      <div class="data-grid-wrap">
+        <table class="data-grid" style=${grid.minWidth ? `min-width: ${grid.minWidth}` : ''}>
+          <thead>
+            ${table.getHeaderGroups().map((headerGroup) => html`
+              <tr>
+                ${headerGroup.headers.map((header) => {
+                  const column = header.column.columnDef.meta as GridColumn | undefined
+                  const direction = header.column.getIsSorted()
+                  return html`
+                    <th style=${column?.width ? `width: ${column.width}` : ''} class=${column?.align === 'right' ? 'is-right' : ''}>
+                      <button
+                        type="button"
+                        class="data-grid-sort"
+                        @click=${header.column.getToggleSortingHandler()}
+                        aria-label=${`Sort by ${cellLabel(header.column.columnDef.header)}`}
+                      >
+                        <span>${flexRender(header.column.columnDef.header, header.getContext())}</span>
+                        <span class="data-grid-sort-indicator" aria-hidden="true">${direction === 'asc' ? '^' : direction === 'desc' ? 'v' : ''}</span>
+                      </button>
+                    </th>
+                  `
+                })}
+              </tr>
+            `)}
+          </thead>
+          <tbody>
+            ${table.getRowModel().rows.map((row) => html`
+              <tr>
+                ${row.getVisibleCells().map((cell) => {
+                  const column = cell.column.columnDef.meta as GridColumn | undefined
+                  return html`<td class=${column?.align === 'right' ? 'is-right' : ''}>${flexRender(cell.column.columnDef.cell, cell.getContext())}</td>`
+                })}
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    `
+  }
+
+  private get resolvedGrid(): Required<Grid> {
+    if (this.grid) return normalizeGrid(this.grid)
+    const gridAttribute = this.getAttribute('grid')
+    for (const source of [this.dataGrid, gridAttribute]) {
+      if (!source) continue
+      try {
+        return normalizeGrid(JSON.parse(source) as Grid)
+      } catch {
+        // Datastar sets the property in normal operation. Attribute parsing is only a fallback.
+      }
+    }
+    return emptyGrid
+  }
+
+  private renderCell(column: GridColumn, value: unknown, row: GridRow) {
+    const label = cellLabel(value)
+    switch (column.kind) {
+      case 'code':
+        return html`<code class="grid-code">${label}</code>`
+      case 'expression':
+        return html`<code class="grid-expression">${label}</code>`
+      case 'badge':
+        return label === '-' ? html`<span class="grid-muted">-</span>` : html`<span class=${`grid-badge grid-badge-${cellTone(value)}`}>${label}</span>`
+      case 'number':
+        return html`<span class="grid-number">${label}</span>`
+      case 'link': {
+        const href = column.hrefKey ? cellLabel(row[column.hrefKey]) : ''
+        return href && href !== '-' ? html`<a class="grid-link" href=${href}>${label}</a>` : html`<span>${label}</span>`
+      }
+      case 'tags':
+        return Array.isArray(value) && value.length > 0
+          ? html`<span class="grid-tags">${value.map((tag) => html`<span>${String(tag)}</span>`)}</span>`
+          : html`<span class="grid-muted">-</span>`
+      default:
+        return html`<span>${label}</span>`
+    }
+  }
+}
+
+function normalizeGrid(grid: Grid): Required<Grid> {
+  return {
+    columns: grid.columns ?? [],
+    rows: grid.rows ?? [],
+    empty: grid.empty ?? emptyGrid.empty,
+    minWidth: grid.minWidth ?? emptyGrid.minWidth,
+  }
+}
+
+customElements.define('ld-data-grid', DataGrid)

--- a/web/components/data-grid.ts
+++ b/web/components/data-grid.ts
@@ -2,9 +2,9 @@ import { LitElement, html } from 'lit'
 import { property, state } from 'lit/decorators.js'
 import {
   TableController,
+  createCoreRowModel,
+  createSortedRowModel,
   flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
   type ColumnDef,
   type SortingState,
 } from '@tanstack/lit-table'
@@ -99,8 +99,8 @@ class DataGrid extends LitElement {
       onSortingChange: (updater) => {
         this.sorting = applyUpdater(updater, this.sorting)
       },
-      getCoreRowModel: getCoreRowModel(),
-      getSortedRowModel: getSortedRowModel(),
+      getCoreRowModel: createCoreRowModel(),
+      getSortedRowModel: createSortedRowModel(),
     })
 
     if (grid.rows.length === 0) {

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -1,15 +1,9 @@
 import { LitElement, css, html, nothing } from 'lit'
 import { createRef, ref, type Ref } from 'lit/directives/ref.js'
 import {
-  FlexRender,
   TableController,
-  columnPinningFeature,
-  columnResizingFeature,
-  columnSizingFeature,
-  columnVisibilityFeature,
-  rowSelectionFeature,
-  rowSortingFeature,
-  tableFeatures,
+  flexRender,
+  getCoreRowModel,
   type ColumnDef,
   type ColumnSizingState,
   type ColumnVisibilityState,
@@ -36,15 +30,6 @@ import {
   type VisualAction,
   type VisibleRowSlot,
 } from './table/types'
-
-const tableFeaturesConfig = tableFeatures({
-  columnPinningFeature,
-  columnResizingFeature,
-  columnSizingFeature,
-  columnVisibilityFeature,
-  rowSelectionFeature,
-  rowSortingFeature,
-})
 
 function defaultColumnSize(column: TableColumn): number {
   const widths: Record<string, number> = {
@@ -99,7 +84,7 @@ class DataTable extends LitElement {
   private blockCache: Record<BlockID, TableBlock> = emptyBlocks()
   private scrollElementRef: Ref<HTMLDivElement> = createRef()
   private resizeObserver?: ResizeObserver
-  private tableController = new TableController<typeof tableFeaturesConfig, TanStackTableRow>(this)
+  private tableController = new TableController<TanStackTableRow>(this)
   private handleOutsidePointerDown = (event: PointerEvent) => {
     const details = this.renderRoot.querySelector<HTMLDetailsElement>('.visual-options')
     if (!details?.open) return
@@ -814,7 +799,7 @@ class DataTable extends LitElement {
     return segments
   }
 
-  private tanstackColumnDefs(): Array<ColumnDef<typeof tableFeaturesConfig, TanStackTableRow, unknown>> {
+  private tanstackColumnDefs(): Array<ColumnDef<TanStackTableRow, unknown>> {
     return this.columnsForTanStack().map((column) => ({
       id: column.key,
       accessorKey: column.key,
@@ -824,7 +809,7 @@ class DataTable extends LitElement {
       minSize: column.key === 'order_id' || column.key === 'category' ? 160 : 64,
       enableResizing: true,
       meta: { align: column.align },
-    })) as Array<ColumnDef<typeof tableFeaturesConfig, TanStackTableRow, unknown>>
+    })) as Array<ColumnDef<TanStackTableRow, unknown>>
   }
 
   private tanstackTable() {
@@ -834,10 +819,10 @@ class DataTable extends LitElement {
       : []
     return this.tableController.table(
       {
-        features: tableFeaturesConfig,
         columns: this.tanstackColumnDefs(),
         data: this.tanstackRows,
         getRowId: (row) => row.__rowKey,
+        getCoreRowModel: getCoreRowModel(),
         manualSorting: true,
         manualFiltering: true,
         manualPagination: true,
@@ -864,12 +849,6 @@ class DataTable extends LitElement {
           if (!this.selectedRowId) this.selectedCellKey = ''
         },
       } as any,
-      (state: any) => ({
-        columnVisibility: state.columnVisibility,
-        columnSizing: state.columnSizing,
-        rowSelection: state.rowSelection,
-        sorting: state.sorting,
-      }),
     ) as any
   }
 
@@ -968,7 +947,7 @@ class DataTable extends LitElement {
                     return html`
                       <div class=${`header-cell ${column.role === 'row_header' ? 'row-header' : ''} ${sorted ? 'sorted' : ''}`} role="columnheader">
                         <button class="header-button" type="button" @click=${() => this.sortColumn(column)}>
-                          <span>${FlexRender({ header })}</span>
+                          <span>${flexRender(header.column.columnDef.header, header.getContext())}</span>
                           <span class="sort">${sortMark}</span>
                         </button>
                         ${header.column.getCanResize?.() ? html`
@@ -1035,7 +1014,7 @@ class DataTable extends LitElement {
                               this.selectCell(row, column, index)
                             }}
                           >
-                            ${FlexRender({ cell })}
+                            ${flexRender(cell.column.columnDef.cell, cell.getContext())}
                           </button>
                         `
                       })}

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -2,8 +2,8 @@ import { LitElement, css, html, nothing } from 'lit'
 import { createRef, ref, type Ref } from 'lit/directives/ref.js'
 import {
   TableController,
+  createCoreRowModel,
   flexRender,
-  getCoreRowModel,
   type ColumnDef,
   type ColumnSizingState,
   type ColumnVisibilityState,
@@ -822,7 +822,7 @@ class DataTable extends LitElement {
         columns: this.tanstackColumnDefs(),
         data: this.tanstackRows,
         getRowId: (row) => row.__rowKey,
-        getCoreRowModel: getCoreRowModel(),
+        getCoreRowModel: createCoreRowModel(),
         manualSorting: true,
         manualFiltering: true,
         manualPagination: true,

--- a/web/components/detail-rail.ts
+++ b/web/components/detail-rail.ts
@@ -1,0 +1,52 @@
+const storageKey = 'libredash.metricDetailRail'
+
+class DetailRail extends HTMLElement {
+  private button?: HTMLButtonElement
+  private collapsed = false
+
+  connectedCallback(): void {
+    this.collapsed = this.savedState()
+    this.ensureToggle()
+    this.sync()
+  }
+
+  private ensureToggle(): void {
+    if (this.button) return
+    const header = this.querySelector<HTMLElement>('.metric-info-header')
+    if (!header) return
+    this.button = document.createElement('button')
+    this.button.type = 'button'
+    this.button.className = 'metric-rail-toggle'
+    this.button.addEventListener('click', () => this.toggle())
+    header.append(this.button)
+  }
+
+  private toggle(): void {
+    this.collapsed = !this.collapsed
+    try {
+      window.localStorage.setItem(storageKey, this.collapsed ? 'collapsed' : 'expanded')
+    } catch {
+      // The rail still works if storage is unavailable.
+    }
+    this.sync()
+  }
+
+  private sync(): void {
+    this.toggleAttribute('data-rail-collapsed', this.collapsed)
+    if (!this.button) return
+    this.button.setAttribute('aria-expanded', String(!this.collapsed))
+    this.button.setAttribute('aria-label', this.collapsed ? 'Expand details' : 'Collapse details')
+    this.button.title = this.collapsed ? 'Expand details' : 'Collapse details'
+    this.button.textContent = this.collapsed ? '<' : '>'
+  }
+
+  private savedState(): boolean {
+    try {
+      return window.localStorage.getItem(storageKey) === 'collapsed'
+    } catch {
+      return false
+    }
+  }
+}
+
+customElements.define('ld-detail-rail', DetailRail)

--- a/web/components/detail-rail.ts
+++ b/web/components/detail-rail.ts
@@ -33,6 +33,11 @@ class DetailRail extends HTMLElement {
 
   private sync(): void {
     this.toggleAttribute('data-rail-collapsed', this.collapsed)
+    if (this.collapsed) {
+      document.documentElement.setAttribute('data-metric-detail-rail', 'collapsed')
+    } else {
+      document.documentElement.removeAttribute('data-metric-detail-rail')
+    }
     if (!this.button) return
     this.button.setAttribute('aria-expanded', String(!this.collapsed))
     this.button.setAttribute('aria-label', this.collapsed ? 'Expand details' : 'Collapse details')

--- a/web/components/detail-rail.ts
+++ b/web/components/detail-rail.ts
@@ -42,7 +42,7 @@ class DetailRail extends HTMLElement {
     this.button.setAttribute('aria-expanded', String(!this.collapsed))
     this.button.setAttribute('aria-label', this.collapsed ? 'Expand details' : 'Collapse details')
     this.button.title = this.collapsed ? 'Expand details' : 'Collapse details'
-    this.button.textContent = this.collapsed ? '<' : '>'
+    this.button.innerHTML = this.collapsed ? detailsIcon() : collapseIcon()
   }
 
   private savedState(): boolean {
@@ -52,6 +52,14 @@ class DetailRail extends HTMLElement {
       return false
     }
   }
+}
+
+function detailsIcon(): string {
+  return '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"></path><path d="M14 2v6h6"></path><path d="M8 13h8"></path><path d="M8 17h6"></path></svg>'
+}
+
+function collapseIcon(): string {
+  return '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m15 18-6-6 6-6"></path></svg>'
 }
 
 customElements.define('ld-detail-rail', DetailRail)

--- a/web/components/metric-usage-graph.ts
+++ b/web/components/metric-usage-graph.ts
@@ -1,0 +1,209 @@
+import { LitElement, css, html } from 'lit'
+import { property } from 'lit/decorators.js'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import '@xyflow/react/dist/style.css'
+import {
+  Background,
+  Controls,
+  Handle,
+  MarkerType,
+  Position,
+  ReactFlow,
+  type Edge,
+  type Node,
+} from '@xyflow/react'
+
+type UsageGraph = {
+  nodes: UsageNode[]
+  edges: UsageEdge[]
+}
+
+type UsageNode = {
+  id: string
+  label: string
+  kind: string
+  meta?: string
+}
+
+type UsageEdge = {
+  id: string
+  source: string
+  target: string
+  label?: string
+  kind: string
+}
+
+class MetricUsageGraph extends LitElement {
+  @property({ type: Object }) graph: UsageGraph | null = null
+  @property({ attribute: 'data-graph' }) dataGraph = '{}'
+  private root?: Root
+  private mount?: HTMLDivElement
+
+  static styles = css``
+
+  createRenderRoot(): HTMLElement {
+    return this
+  }
+
+  firstUpdated(): void {
+    this.mount = this.renderRoot.querySelector('.metric-usage-flow') as HTMLDivElement | null ?? undefined
+    if (this.mount) {
+      this.root = createRoot(this.mount)
+      this.renderFlow()
+    }
+  }
+
+  updated(changed: Map<string, unknown>): void {
+    if (changed.has('graph') || changed.has('dataGraph')) this.renderFlow()
+  }
+
+  disconnectedCallback(): void {
+    this.root?.unmount()
+    super.disconnectedCallback()
+  }
+
+  render() {
+    return html`<div class="metric-usage-flow" aria-label="Metric usage lineage"></div>`
+  }
+
+  private renderFlow(): void {
+    if (!this.root) return
+    const graph = this.resolvedGraph
+    this.root.render(
+      React.createElement(ReactFlow, {
+        nodes: graph.nodes.map((node) => toFlowNode(node, graph.nodes)),
+        edges: graph.edges.map(toFlowEdge),
+        nodeTypes: { usageNode: UsageNodeComponent },
+        fitView: true,
+        fitViewOptions: { padding: 0.18 },
+        minZoom: 0.55,
+        maxZoom: 1.35,
+        nodesDraggable: false,
+        nodesConnectable: false,
+        elementsSelectable: false,
+        panOnDrag: true,
+        zoomOnScroll: false,
+        preventScrolling: false,
+        children: [
+          React.createElement(Background, { key: 'background', gap: 18, size: 1 }),
+          React.createElement(Controls, { key: 'controls', showInteractive: false }),
+        ],
+      }),
+    )
+  }
+
+  private get resolvedGraph(): UsageGraph {
+    if (this.graph) {
+      return {
+        nodes: this.graph.nodes ?? [],
+        edges: this.graph.edges ?? [],
+      }
+    }
+    try {
+      const parsed = JSON.parse(this.dataGraph) as UsageGraph
+      return {
+        nodes: parsed.nodes ?? [],
+        edges: parsed.edges ?? [],
+      }
+    } catch {
+      return { nodes: [], edges: [] }
+    }
+  }
+}
+
+function toFlowNode(node: UsageNode, nodes: UsageNode[]): Node {
+  const { x, y } = positionFor(node, nodes)
+  return {
+    id: node.id,
+    type: 'usageNode',
+    position: { x, y },
+    sourcePosition: Position.Right,
+    targetPosition: Position.Left,
+    data: node,
+  }
+}
+
+function toFlowEdge(edge: UsageEdge): Edge {
+  return {
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    label: edge.label ?? '',
+    markerEnd: { type: MarkerType.ArrowClosed },
+    style: {
+      stroke: edge.kind === 'usage' ? 'var(--fgColor-attention)' : 'var(--borderColor-accent-emphasis)',
+      strokeWidth: edge.kind === 'usage' ? 1.8 : 1.4,
+    },
+    labelStyle: {
+      fill: 'var(--fgColor-muted)',
+      fontSize: 10,
+      fontWeight: 800,
+    },
+    labelBgStyle: {
+      fill: 'var(--bgColor-default)',
+      fillOpacity: 0.92,
+    },
+  }
+}
+
+function positionFor(node: UsageNode, nodes: UsageNode[]): { x: number; y: number } {
+  const index = nodes.filter((candidate) => candidate.kind === node.kind).findIndex((candidate) => candidate.id === node.id)
+  switch (node.kind) {
+    case 'model':
+      return { x: 0, y: 92 }
+    case 'dataset':
+      return { x: 250, y: 92 }
+    case 'metrics_view':
+      return { x: 500, y: 92 }
+    case 'dashboard':
+      return { x: 760, y: Math.max(18, index * 118) }
+    default:
+      return { x: 250, y: index * 118 }
+  }
+}
+
+function UsageNodeComponent({ data }: { data: UsageNode }) {
+  const styles = nodeStyle(data.kind)
+  return React.createElement(
+    'div',
+    { className: 'metric-usage-node', style: styles },
+    React.createElement(Handle, { type: 'target', position: Position.Left }),
+    React.createElement('div', { className: 'metric-usage-node-kind' }, kindLabel(data.kind)),
+    React.createElement('div', { className: 'metric-usage-node-title', title: data.label }, data.label),
+    data.meta ? React.createElement('div', { className: 'metric-usage-node-meta' }, data.meta) : null,
+    React.createElement(Handle, { type: 'source', position: Position.Right }),
+  )
+}
+
+function nodeStyle(kind: string): Record<string, string> {
+  const palette: Record<string, [string, string, string]> = {
+    model: ['var(--data-blue-color-muted)', 'var(--data-blue-color-emphasis)', 'var(--borderColor-accent-muted)'],
+    dataset: ['var(--data-auburn-color-muted)', 'var(--data-auburn-color-emphasis)', 'var(--borderColor-attention-muted)'],
+    metrics_view: ['var(--data-yellow-color-muted)', 'var(--data-yellow-color-emphasis)', 'var(--borderColor-attention-muted)'],
+    dashboard: ['var(--data-purple-color-muted)', 'var(--data-purple-color-emphasis)', 'var(--borderColor-accent-muted)'],
+  }
+  const [bg, accent, border] = palette[kind] ?? palette.model
+  return {
+    '--usage-node-bg': bg,
+    '--usage-node-accent': accent,
+    '--usage-node-border': border,
+  } as Record<string, string>
+}
+
+function kindLabel(kind: string): string {
+  switch (kind) {
+    case 'model':
+      return 'Semantic model'
+    case 'dataset':
+      return 'Dataset'
+    case 'metrics_view':
+      return 'Metrics view'
+    case 'dashboard':
+      return 'Dashboard'
+    default:
+      return kind
+  }
+}
+
+customElements.define('ld-metric-usage-graph', MetricUsageGraph)

--- a/web/components/model-graph.ts
+++ b/web/components/model-graph.ts
@@ -426,8 +426,10 @@ function positionFor(node: ModelGraphNode, nodes: ModelGraphNode[]): { x: number
       return { x: 300, y: 292 + index * 128 }
     case 'dataset':
       return { x: 560, y: 292 + index * 128 }
+    case 'metrics_view':
+      return { x: 820, y: index * 128 }
     case 'metric':
-      return { x: 820, y: index * 116 }
+      return { x: 1040, y: index * 116 }
     case 'visual':
       return { x: 1060, y: index * 116 }
     case 'table':
@@ -477,6 +479,7 @@ function nodeStyle(kind: string): Record<string, string> {
     source: ['var(--data-blue-color-muted)', 'var(--data-blue-color-emphasis)', 'var(--borderColor-default)'],
     cache: ['var(--data-green-color-muted)', 'var(--data-green-color-emphasis)', 'var(--borderColor-success-muted)'],
     dataset: ['var(--data-auburn-color-muted)', 'var(--data-auburn-color-emphasis)', 'var(--borderColor-attention-muted)'],
+    metrics_view: ['var(--data-yellow-color-muted)', 'var(--data-yellow-color-emphasis)', 'var(--borderColor-attention-muted)'],
     metric: ['var(--data-yellow-color-muted)', 'var(--data-yellow-color-emphasis)', 'var(--borderColor-attention-muted)'],
     visual: ['var(--data-purple-color-muted)', 'var(--data-purple-color-emphasis)', 'var(--borderColor-accent-muted)'],
     report_table: ['var(--data-coral-color-muted)', 'var(--data-coral-color-emphasis)', 'var(--borderColor-default)'],
@@ -495,6 +498,8 @@ function nodeColor(kind: string): string {
       return 'var(--data-green-color-emphasis)'
     case 'dataset':
       return 'var(--data-auburn-color-emphasis)'
+    case 'metrics_view':
+      return 'var(--data-yellow-color-emphasis)'
     case 'metric':
       return 'var(--data-yellow-color-emphasis)'
     case 'visual':
@@ -514,6 +519,8 @@ function kindLabel(kind: string): string {
       return 'DuckDB cache'
     case 'dataset':
       return 'Semantic dataset'
+    case 'metrics_view':
+      return 'Metrics view'
     case 'metric':
       return 'Metric'
     case 'visual':


### PR DESCRIPTION
## Summary
- introduce first-class metric views between semantic models and dashboards
- refactor dashboards, queries, catalog data, and Olist YAML to use metric views and aggregate SQL measures
- add metric view catalog/detail routes with reusable data grid and usage lineage
- polish the metric detail UI with route tabs, details rail, collapsible sidebar, and calmer table styling

## Verification
- go test ./...
- npm run build