### PR TITLE
Improve Datastar inspector tree view

### DIFF
--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -246,6 +246,44 @@ func TestPageRouteSeedsFiltersFromURL(t *testing.T) {
 	}
 }
 
+func TestHTMLRoutesIncludeDatastarInspector(t *testing.T) {
+	for _, path := range []string{
+		"/login",
+		"/",
+		"/dashboards/executive-sales/pages/overview",
+		"/models",
+		"/models/test",
+		"/metrics",
+		"/metrics/orders/measures",
+		"/metrics/orders/dimensions",
+		"/metrics/orders/usage",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rec := httptest.NewRecorder()
+
+			New(fakeMetrics{}).Routes().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+			assertDatastarInspector(t, rec.Body.String())
+		})
+	}
+}
+
+func assertDatastarInspector(t *testing.T, body string) {
+	t.Helper()
+	for _, want := range []string{
+		`/static/datastar-inspector.js`,
+		`<datastar-inspector`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("page missing Datastar inspector marker %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestCatalogRouteRendersDashboardCatalog(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -27,6 +27,14 @@ func staticAsset(path string) string {
 	return path + "?v=dev"
 }
 
+func inspectorScript() g.Node {
+	return h.Script(h.Type("module"), h.Src(staticAsset("/static/datastar-inspector.js")))
+}
+
+func inspectorElement() g.Node {
+	return g.El("datastar-inspector")
+}
+
 func Page(dataDir, clientID, csrfToken string, catalog dashboard.Catalog, report semantic.Dashboard, model *semantic.Model, pages []dashboard.Page, activePage dashboard.Page, initialFilters dashboard.Filters) g.Node {
 	if activePage.ID == "" {
 		activePage = defaultPage()
@@ -60,7 +68,7 @@ func Page(dataDir, clientID, csrfToken string, catalog dashboard.Catalog, report
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/charts.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/table.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/visual-modal.js"))),
-			h.Script(h.Type("module"), h.Src(staticAsset("/static/datastar-inspector.js"))),
+			inspectorScript(),
 			h.Script(h.Type("module"), h.Src("https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js")),
 		},
 		Body: []g.Node{
@@ -93,7 +101,7 @@ func Page(dataDir, clientID, csrfToken string, catalog dashboard.Catalog, report
 					),
 				),
 				g.El("ld-visual-modal"),
-				g.El("datastar-inspector"),
+				inspectorElement(),
 			),
 		},
 	})
@@ -118,6 +126,7 @@ func LoginPage() g.Node {
 			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/app.css"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/login.js"))),
+			inspectorScript(),
 		},
 		Body: []g.Node{
 			h.Main(h.Class("login-screen"), h.Aria("label", "LibreDash login"),
@@ -137,6 +146,7 @@ func LoginPage() g.Node {
 						h.Span(g.Text("Sign in with Azure Active Directory")),
 					),
 				),
+				inspectorElement(),
 			),
 		},
 	})
@@ -159,6 +169,7 @@ func CatalogPage(catalog dashboard.Catalog) g.Node {
 			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/app.css"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/sidebar.js"))),
+			inspectorScript(),
 		},
 		Body: []g.Node{
 			h.Main(h.Class("report-app"),
@@ -176,6 +187,7 @@ func CatalogPage(catalog dashboard.Catalog) g.Node {
 						),
 					),
 				),
+				inspectorElement(),
 			),
 		},
 	})
@@ -198,6 +210,7 @@ func ModelsPage(catalog dashboard.Catalog) g.Node {
 			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/app.css"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/sidebar.js"))),
+			inspectorScript(),
 		},
 		Body: []g.Node{
 			h.Main(h.Class("report-app"),
@@ -215,6 +228,7 @@ func ModelsPage(catalog dashboard.Catalog) g.Node {
 						),
 					),
 				),
+				inspectorElement(),
 			),
 		},
 	})
@@ -237,6 +251,7 @@ func MetricViewsPage(catalog dashboard.Catalog, views []dashboard.MetricViewSumm
 			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/app.css"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/sidebar.js"))),
+			inspectorScript(),
 		},
 		Body: []g.Node{
 			h.Main(h.Class("report-app"),
@@ -254,6 +269,7 @@ func MetricViewsPage(catalog dashboard.Catalog, views []dashboard.MetricViewSumm
 						),
 					),
 				),
+				inspectorElement(),
 			),
 		},
 	})
@@ -644,6 +660,7 @@ func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail, 
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/data-grid.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/detail-rail.js"))),
 			g.If(activeSection == "usage", h.Script(h.Type("module"), h.Src(staticAsset("/static/metric-usage-graph.js")))),
+			inspectorScript(),
 			h.Script(h.Type("module"), h.Src("https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js")),
 		},
 		Body: []g.Node{
@@ -664,6 +681,7 @@ func MetricViewPage(catalog dashboard.Catalog, view dashboard.MetricViewDetail, 
 						),
 					),
 				),
+				inspectorElement(),
 			),
 		},
 	})
@@ -688,6 +706,7 @@ func ModelPage(catalog dashboard.Catalog, model dashboard.ModelGraph) g.Node {
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/theme.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/sidebar.js"))),
 			h.Script(h.Type("module"), h.Src(staticAsset("/static/model-graph.js"))),
+			inspectorScript(),
 		},
 		Body: []g.Node{
 			h.Main(
@@ -707,6 +726,7 @@ func ModelPage(catalog dashboard.Catalog, model dashboard.ModelGraph) g.Node {
 						),
 					),
 				),
+				inspectorElement(),
 			),
 		},
 	})

--- a/web/components/datastar-inspector/datastar-inspector.ts
+++ b/web/components/datastar-inspector/datastar-inspector.ts
@@ -7,14 +7,12 @@
 import { LitElement, html, nothing } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
 
-import type { InspectorState, ViewMode, SignalObject } from './types.js'
+import type { InspectorState, SignalObject } from './types.js'
 import {
   countSignals,
-  flattenSignals,
   filterObject,
   findChangedPaths,
   parseFilterPattern,
-  renderJsonValue,
 } from './utils.js'
 
 const FLASH_DURATION = 400
@@ -28,16 +26,18 @@ export class DatastarInspector extends LitElement {
 
   @state() private expanded = false
   @state() private filter = ''
-  @state() private viewMode: ViewMode = 'json'
   @state() private signals: SignalObject = {}
   @state() private signalCount = 0
   @state() private changedPaths: Set<string> = new Set()
+  @state() private expandedPaths: Set<string> = new Set()
   @state() private hasUnseenChanges = false
 
   private observer: MutationObserver | null = null
   private signalsElementId = `ds-inspector-signals-${Math.random().toString(36).slice(2, 9)}`
+  private signalsElement: HTMLElement | null = null
   private previousSignals: SignalObject = {}
   private flashTimeout: number | null = null
+  private parseFrame: number | null = null
 
   override connectedCallback() {
     super.connectedCallback()
@@ -47,6 +47,9 @@ export class DatastarInspector extends LitElement {
   override disconnectedCallback() {
     super.disconnectedCallback()
     this.observer?.disconnect()
+    if (this.parseFrame !== null) {
+      cancelAnimationFrame(this.parseFrame)
+    }
     if (this.flashTimeout) {
       clearTimeout(this.flashTimeout)
     }
@@ -63,7 +66,7 @@ export class DatastarInspector extends LitElement {
         const state: InspectorState = JSON.parse(saved)
         this.expanded = state.expanded ?? false
         this.filter = state.filter ?? ''
-        this.viewMode = state.viewMode ?? 'json'
+        this.expandedPaths = new Set(state.expandedPaths ?? [])
       }
     } catch {
       /* ignore parse errors */
@@ -74,7 +77,7 @@ export class DatastarInspector extends LitElement {
     const state: InspectorState = {
       expanded: this.expanded,
       filter: this.filter,
-      viewMode: this.viewMode,
+      expandedPaths: [...this.expandedPaths],
     }
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
   }
@@ -83,12 +86,24 @@ export class DatastarInspector extends LitElement {
     const el = document.getElementById(this.signalsElementId)
     if (!el) return
 
+    this.observer?.disconnect()
+    this.signalsElement = el
     this.parseSignals(el.textContent || '{}', true)
 
     this.observer = new MutationObserver(() => {
-      this.parseSignals(el.textContent || '{}', false)
+      this.scheduleSignalParse()
     })
     this.observer.observe(el, { childList: true, characterData: true, subtree: true })
+  }
+
+  private scheduleSignalParse() {
+    if (this.parseFrame !== null) {
+      cancelAnimationFrame(this.parseFrame)
+    }
+    this.parseFrame = requestAnimationFrame(() => {
+      this.parseFrame = null
+      this.parseSignals(this.signalsElement?.textContent || '{}', false)
+    })
   }
 
   private parseSignals(json: string, isInitial: boolean) {
@@ -114,7 +129,7 @@ export class DatastarInspector extends LitElement {
         }
       }
 
-      this.previousSignals = JSON.parse(json) as SignalObject
+      this.previousSignals = newSignals
       this.signals = newSignals
       this.signalCount = countSignals(this.signals)
     } catch {
@@ -135,7 +150,6 @@ export class DatastarInspector extends LitElement {
     this.saveState()
     if (this.expanded) {
       this.hasUnseenChanges = false
-      requestAnimationFrame(() => this.setupSignalObserver())
     }
   }
 
@@ -154,20 +168,22 @@ export class DatastarInspector extends LitElement {
     this.saveState()
   }
 
-  private setViewMode(mode: ViewMode) {
-    this.viewMode = mode
+  private togglePath(path: string) {
+    const next = new Set(this.expandedPaths)
+    if (next.has(path)) {
+      next.delete(path)
+    } else {
+      next.add(path)
+    }
+    this.expandedPaths = next
     this.saveState()
   }
 
   override render() {
-    const filteredSignals = this.getFilteredSignals()
-    const filteredCount = countSignals(filteredSignals)
-    const hasFilter = this.filter.trim().length > 0
-
     return html`
       <pre id="${this.signalsElementId}" class="hidden" data-json-signals></pre>
 
-      ${this.expanded ? this.renderPanel(filteredSignals, filteredCount, hasFilter) : this.renderToggle()}
+      ${this.expanded ? this.renderOpenPanel() : this.renderToggle()}
     `
   }
 
@@ -176,11 +192,18 @@ export class DatastarInspector extends LitElement {
       <button
         class="btn bg-primary text-on-primary border-primary btn-circle btn-sm fixed bottom-4 right-4 z-[99999] shadow-xl ${this.hasUnseenChanges ? 'animate-pulse' : ''}"
         @click=${this.toggle}
-        title="Open Datastar Inspector"
+        aria-label="Open Datastar Inspector"
       >
         DS
       </button>
     `
+  }
+
+  private renderOpenPanel() {
+    const filteredSignals = this.getFilteredSignals()
+    const filteredCount = countSignals(filteredSignals)
+    const hasFilter = this.filter.trim().length > 0
+    return this.renderPanel(filteredSignals, filteredCount, hasFilter)
   }
 
   private renderPanel(filteredSignals: SignalObject, filteredCount: number, hasFilter: boolean) {
@@ -208,25 +231,9 @@ export class DatastarInspector extends LitElement {
           @input=${this.handleFilterInput}
         />
         ${hasFilter
-          ? html`<button class="btn btn-ghost btn-xs" @click=${this.clearFilter} title="Clear filter">&times;</button>`
+          ? html`<button class="btn btn-ghost btn-xs" @click=${this.clearFilter} aria-label="Clear filter">&times;</button>`
           : nothing}
-        <div class="join">
-          <button
-            class="btn btn-xs join-item ${this.viewMode === 'json' ? 'btn-active' : ''}"
-            @click=${() => this.setViewMode('json')}
-            title="JSON view"
-          >
-            { }
-          </button>
-          <button
-            class="btn btn-xs join-item ${this.viewMode === 'table' ? 'btn-active' : ''}"
-            @click=${() => this.setViewMode('table')}
-            title="Table view"
-          >
-            ≡
-          </button>
-        </div>
-        <button class="btn btn-ghost btn-xs" @click=${this.close} title="Close">&times;</button>
+        <button class="btn btn-ghost btn-xs" @click=${this.close} aria-label="Close">&times;</button>
       </div>
     `
   }
@@ -240,46 +247,116 @@ export class DatastarInspector extends LitElement {
           ? html`<div class="flex h-full items-center justify-center text-sm text-on-surface-variant">
               ${hasFilter ? 'No signals match filter' : 'No signals found'}
             </div>`
-          : this.viewMode === 'json'
-            ? this.renderJsonView(filteredSignals)
-            : this.renderTableView(filteredSignals)}
+          : this.renderJsonView(filteredSignals)}
       </div>
     `
   }
 
   private renderJsonView(signals: SignalObject) {
     return html`
-      <pre class="whitespace-pre-wrap break-words text-xs leading-6" .innerHTML=${renderJsonValue(signals, this.changedPaths)}></pre>
-    `
-  }
-
-  private renderTableView(signals: SignalObject) {
-    return html`
-      <div class="overflow-x-auto">
-        <table class="table table-zebra table-xs">
-          <thead>
-            <tr>
-              <th>Signal</th>
-              <th>Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${flattenSignals(signals).map(([path, value]) => {
-              const isChanged = this.changedPaths.has(path)
-              return html`
-                <tr class="${isChanged ? 'bg-warning' : ''}">
-                  <td class="font-mono">${path}</td>
-                  <td class="max-w-40 truncate font-mono" title=${JSON.stringify(value)}>
-                    ${JSON.stringify(value)}
-                  </td>
-                </tr>
-              `
-            })}
-          </tbody>
-        </table>
+      <div class="font-mono text-xs leading-6">
+        ${Object.entries(signals).map(([key, value]) => this.renderTreeNode(key, value, key, 0, this.filter.trim().length > 0))}
       </div>
     `
   }
+
+  private renderTreeNode(key: string, value: unknown, path: string, depth: number, hasFilter: boolean) {
+    const changed = this.isChanged(path)
+    const rowClass = changed ? 'bg-warning' : ''
+    const rowStyle = this.treeRowStyle(depth)
+
+    if (!this.isBranch(value)) {
+      return html`
+        <div class="flex min-w-0 items-baseline gap-1 rounded px-1 py-0.5 whitespace-nowrap ${rowClass}" style=${rowStyle}>
+          <span class="font-medium text-on-surface-variant opacity-80">${key}</span>
+          <span class="text-on-surface-variant opacity-70">:</span>
+          ${this.renderPrimitive(value)}
+        </div>
+      `
+    }
+
+    const count = countSignals(value)
+    const expanded = hasFilter || this.expandedPaths.has(path)
+    const marker = Array.isArray(value) ? `[${count}]` : `{${count}}`
+
+    return html`
+      <div>
+        <button
+          type="button"
+          class="flex min-w-0 cursor-pointer items-center gap-1 rounded border-0 bg-transparent px-1 py-0.5 text-left font-mono hover:bg-container-low ${rowClass}"
+          style=${rowStyle}
+          aria-expanded=${String(expanded)}
+          aria-label=${expanded ? `Collapse ${key}` : `Expand ${key}`}
+          @click=${() => this.togglePath(path)}
+        >
+          <span class="inline-block w-4 text-center text-on-surface-variant opacity-75">${expanded ? '▾' : '▸'}</span>
+          <span class="font-medium text-on-surface-variant opacity-90">${key}</span>
+          <span
+            class="rounded border border-outline-variant bg-container-low px-1.5 text-[0.62rem] font-medium leading-4 text-on-surface-variant opacity-80"
+          >
+            ${marker}
+          </span>
+        </button>
+        ${expanded
+          ? this.childEntries(value).map(([childKey, childValue]) =>
+              this.renderTreeNode(childKey, childValue, this.childPath(path, childKey, value), depth + 1, hasFilter)
+            )
+          : nothing}
+      </div>
+    `
+  }
+
+  private treeRowStyle(depth: number) {
+    const indent = depth * 0.85
+    const guide = depth > 0 ? 'border-left: 1px solid var(--borderColor-muted); padding-left: 0.55rem;' : ''
+    return `margin-left: ${indent}rem; width: calc(100% - ${indent}rem); ${guide}`
+  }
+
+  private renderPrimitive(value: unknown) {
+    if (value === null) {
+      return html`<span class="text-on-surface-variant opacity-85">null</span>`
+    }
+    if (typeof value === 'boolean') {
+      return html`<span class="text-primary opacity-90">${String(value)}</span>`
+    }
+    if (typeof value === 'number') {
+      return html`<span class="text-warning opacity-90">${value}</span>`
+    }
+    if (typeof value === 'string') {
+      return html`
+        <span class="min-w-0 max-w-64 truncate text-success opacity-85">
+          "${value}"
+        </span>
+      `
+    }
+    return html`<span class="min-w-0 max-w-64 truncate text-on-surface-variant opacity-85">${String(value)}</span>`
+  }
+
+  private isBranch(value: unknown): value is Record<string, unknown> | unknown[] {
+    return typeof value === 'object' && value !== null
+  }
+
+  private childEntries(value: Record<string, unknown> | unknown[]): Array<[string, unknown]> {
+    if (Array.isArray(value)) {
+      return value.map((item, index) => [String(index), item])
+    }
+    return Object.entries(value)
+  }
+
+  private childPath(path: string, key: string, parent: Record<string, unknown> | unknown[]) {
+    return Array.isArray(parent) ? `${path}[${key}]` : `${path}.${key}`
+  }
+
+  private isChanged(path: string) {
+    if (this.changedPaths.has(path)) return true
+    for (const changedPath of this.changedPaths) {
+      if (changedPath.startsWith(`${path}.`) || changedPath.startsWith(`${path}[`)) {
+        return true
+      }
+    }
+    return false
+  }
+
 }
 
 declare global {

--- a/web/components/datastar-inspector/index.ts
+++ b/web/components/datastar-inspector/index.ts
@@ -6,4 +6,4 @@
 export { DatastarInspector } from './datastar-inspector.js'
 
 // Types
-export type { InspectorState, ViewMode, SignalObject, SignalValue } from './types.js'
+export type { InspectorState, SignalObject, SignalValue } from './types.js'

--- a/web/components/datastar-inspector/types.ts
+++ b/web/components/datastar-inspector/types.ts
@@ -3,11 +3,6 @@
  */
 
 /**
- * View mode for signal display
- */
-export type ViewMode = 'json' | 'table'
-
-/**
  * Persisted inspector state (stored in sessionStorage)
  */
 export interface InspectorState {
@@ -15,8 +10,8 @@ export interface InspectorState {
   expanded: boolean
   /** Current filter text */
   filter: string
-  /** Current view mode */
-  viewMode: ViewMode
+  /** Expanded tree paths */
+  expandedPaths?: string[]
 }
 
 /**

--- a/web/components/datastar-inspector/utils.ts
+++ b/web/components/datastar-inspector/utils.ts
@@ -24,25 +24,6 @@ export function countSignals(obj: unknown, count = 0): number {
   return count
 }
 
-export function flattenSignals(
-  obj: Record<string, unknown>,
-  prefix = ''
-): Array<[string, unknown]> {
-  const result: Array<[string, unknown]> = []
-
-  for (const [key, value] of Object.entries(obj)) {
-    const path = prefix ? `${prefix}.${key}` : key
-
-    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-      result.push(...flattenSignals(value as Record<string, unknown>, path))
-    } else {
-      result.push([path, value])
-    }
-  }
-
-  return result
-}
-
 export function parseFilterPattern(filterText: string): RegExp {
   if (filterText.startsWith('/') && filterText.lastIndexOf('/') > 0) {
     const lastSlash = filterText.lastIndexOf('/')
@@ -121,51 +102,4 @@ export function findChangedPaths(
   }
 
   return changed
-}
-
-export function renderJsonValue(
-  value: unknown,
-  changedPaths: Set<string>,
-  indent = 0,
-  path = ''
-): string {
-  const pad = '  '.repeat(indent)
-
-  if (value === null) {
-    return `<span class="text-on-surface-variant">null</span>`
-  }
-  if (typeof value === 'boolean') {
-    return `<span class="text-primary">${value}</span>`
-  }
-  if (typeof value === 'number') {
-    return `<span class="text-warning">${value}</span>`
-  }
-  if (typeof value === 'string') {
-    return `<span class="text-success">"${escapeHtml(value)}"</span>`
-  }
-  if (Array.isArray(value)) {
-    if (value.length === 0) return '[]'
-    const items = value
-      .map((v, i) => {
-        const itemPath = `${path}[${i}]`
-        return `${pad}  ${renderJsonValue(v, changedPaths, indent + 1, itemPath)}`
-      })
-      .join(',\n')
-    return `[\n${items}\n${pad}]`
-  }
-  if (typeof value === 'object') {
-    const entries = Object.entries(value)
-    if (entries.length === 0) return '{}'
-    const items = entries
-      .map(([k, v]) => {
-        const keyPath = path ? `${path}.${k}` : k
-        const isChanged = changedPaths.has(keyPath)
-        const flashClass = isChanged ? ' bg-warning rounded px-1' : ''
-        const lineContent = `<span class="text-secondary">"${escapeHtml(k)}"</span>: ${renderJsonValue(v, changedPaths, indent + 1, keyPath)}`
-        return `${pad}  <span class="${flashClass.trim()}">${lineContent}</span>`
-      })
-      .join(',\n')
-    return `{\n${items}\n${pad}}`
-  }
-  return String(value)
 }


### PR DESCRIPTION
## Summary
- show the Datastar inspector on every page shell
- replace the inspector JSON/list views with a single collapsible tree view
- add descendant counts, softer tree styling, full-row toggles, and no native tooltips

## Tests
- npm run build
- go test ./...
