### PR TITLE
Add connection-centric DuckDB source model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,89 @@ go run ./cmd/libredash
 - Lit chart components bind to signal paths such as `charts.revenue`.
 - The bundled `datastar-inspector` web component shows live Datastar signals in the browser.
 
+## Source Model
+
+Semantic model YAML declares user-facing `sources` and optional named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract.
+
+Local CSV:
+
+```yaml
+sources:
+  orders:
+    type: file
+    format: csv
+    location: olist_orders_dataset.csv
+    options:
+      header: true
+```
+
+S3 Parquet with credential-chain auth:
+
+```yaml
+connections:
+  prod_lake:
+    type: s3
+    scope: s3://analytics-prod/
+    auth:
+      method: credential_chain
+      profile: analytics
+      params:
+        region: us-east-1
+
+sources:
+  sales_events:
+    type: file
+    format: parquet
+    location: s3://analytics-prod/events/*.parquet
+    connection: prod_lake
+```
+
+Azure Delta Lake:
+
+```yaml
+connections:
+  azure_lake:
+    type: azure
+    auth:
+      method: credential_chain
+      account: mystorageaccount
+
+sources:
+  delta_orders:
+    type: lakehouse
+    format: delta
+    location: az://warehouse/tables/orders
+    connection: azure_lake
+```
+
+Postgres table via a DuckDB secret:
+
+```yaml
+connections:
+  crm:
+    type: postgres
+    secret: crm_readonly
+
+sources:
+  crm_accounts:
+    type: database
+    engine: postgres
+    connection: crm
+    object: public.accounts
+```
+
+Trusted query source:
+
+```yaml
+sources:
+  custom:
+    type: query
+    query: |
+      SELECT * FROM future_scan_function('...')
+```
+
+`query` sources are trusted workspace code. Treat them like application SQL, not end-user input.
+
 ## Deploy
 
 Production mode serves the active deployed BI-as-code bundle from `.libredash` by default:

--- a/README.md
+++ b/README.md
@@ -46,20 +46,27 @@ go run ./cmd/libredash
 
 ## Source Model
 
-Semantic model YAML declares user-facing `sources`, optional `source_defaults`, and optional named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract. A scalar source value is shorthand for `location`.
+Semantic model YAML declares user-facing `sources` and named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract. Each source is an object with exactly one of `location`, `object`, or `query`.
 
 Local CSV:
 
 ```yaml
-source_defaults:
-  type: file
-  format: csv
-  options:
-    header: true
+default_connection: olist
+
+connections:
+  olist:
+    kind: local
+    defaults:
+      format: csv
+      options:
+        header: true
 
 sources:
-  orders: olist_orders_dataset.csv
-  order_items: olist_order_items_dataset.csv
+  orders:
+    location: olist_orders_dataset.csv
+
+  order_items:
+    location: olist_order_items_dataset.csv
 ```
 
 S3 Parquet with credential-chain auth:
@@ -67,7 +74,7 @@ S3 Parquet with credential-chain auth:
 ```yaml
 connections:
   prod_lake:
-    type: s3
+    kind: s3
     scope: s3://analytics-prod/
     auth:
       method: credential_chain
@@ -75,13 +82,11 @@ connections:
       params:
         region: us-east-1
 
-source_defaults:
-  type: file
-  format: parquet
-  connection: prod_lake
-
 sources:
-  sales_events: s3://analytics-prod/events/*.parquet
+  sales_events:
+    connection: prod_lake
+    location: events/*
+    format: parquet
 ```
 
 Azure Delta Lake:
@@ -89,17 +94,17 @@ Azure Delta Lake:
 ```yaml
 connections:
   azure_lake:
-    type: azure
+    kind: azure_blob
+    scope: az://warehouse/
     auth:
       method: credential_chain
       account: mystorageaccount
 
 sources:
   delta_orders:
-    type: lakehouse
-    format: delta
-    location: az://warehouse/tables/orders
     connection: azure_lake
+    location: tables/orders
+    format: delta
 ```
 
 Postgres table via a DuckDB secret:
@@ -107,13 +112,11 @@ Postgres table via a DuckDB secret:
 ```yaml
 connections:
   crm:
-    type: postgres
+    kind: postgres
     secret: crm_readonly
 
 sources:
   crm_accounts:
-    type: database
-    engine: postgres
     connection: crm
     object: public.accounts
 ```
@@ -123,12 +126,11 @@ Trusted query source:
 ```yaml
 sources:
   custom:
-    type: query
     query: |
       SELECT * FROM future_scan_function('...')
 ```
 
-`query` sources are trusted workspace code. Treat them like application SQL, not end-user input.
+For file locations, LibreDash infers `format` from clear extensions such as `.csv`, `.json`, `.jsonl`, `.parquet`, and `.xlsx`. Set `format` explicitly for ambiguous paths or table directories such as `events/*`, `format: delta`, and `format: iceberg`. `query` sources are trusted workspace code. Treat them like application SQL, not end-user input.
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -46,18 +46,20 @@ go run ./cmd/libredash
 
 ## Source Model
 
-Semantic model YAML declares user-facing `sources` and optional named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract.
+Semantic model YAML declares user-facing `sources`, optional `source_defaults`, and optional named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract. A scalar source value is shorthand for `location`.
 
 Local CSV:
 
 ```yaml
+source_defaults:
+  type: file
+  format: csv
+  options:
+    header: true
+
 sources:
-  orders:
-    type: file
-    format: csv
-    location: olist_orders_dataset.csv
-    options:
-      header: true
+  orders: olist_orders_dataset.csv
+  order_items: olist_order_items_dataset.csv
 ```
 
 S3 Parquet with credential-chain auth:
@@ -73,12 +75,13 @@ connections:
       params:
         region: us-east-1
 
+source_defaults:
+  type: file
+  format: parquet
+  connection: prod_lake
+
 sources:
-  sales_events:
-    type: file
-    format: parquet
-    location: s3://analytics-prod/events/*.parquet
-    connection: prod_lake
+  sales_events: s3://analytics-prod/events/*.parquet
 ```
 
 Azure Delta Lake:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sources:
     path: olist_order_items_dataset.csv
 ```
 
-S3 Parquet with credential-chain auth:
+S3 Parquet with LibreDash-managed auth:
 
 ```yaml
 connections:
@@ -76,10 +76,9 @@ connections:
     kind: s3
     scope: s3://analytics-prod/
     auth:
-      method: credential_chain
-      profile: analytics
-      params:
-        region: us-east-1
+      access_key_id: ${AWS_ACCESS_KEY_ID}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+      region: ${AWS_REGION}
 
 sources:
   sales_events:
@@ -96,8 +95,7 @@ connections:
     kind: azure_blob
     scope: az://warehouse/
     auth:
-      method: credential_chain
-      account: mystorageaccount
+      connection_string: ${AZURE_STORAGE_CONNECTION_STRING}
 
 sources:
   delta_orders:
@@ -106,13 +104,14 @@ sources:
     format: delta
 ```
 
-Postgres table via a DuckDB secret:
+Postgres table:
 
 ```yaml
 connections:
   crm:
     kind: postgres
-    secret: crm_readonly
+    auth:
+      connection_string: ${CRM_DATABASE_URL}
 
 sources:
   crm_accounts:
@@ -128,7 +127,9 @@ connections:
     kind: s3
     scope: s3://analytics-prod/
     auth:
-      method: credential_chain
+      access_key_id: ${AWS_ACCESS_KEY_ID}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+      region: ${AWS_REGION}
 
 sources:
   product_embeddings:
@@ -145,7 +146,9 @@ connections:
     scope: s3://analytics-prod/ducklake/
     path: metadata.ducklake
     auth:
-      method: credential_chain
+      access_key_id: ${AWS_ACCESS_KEY_ID}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+      region: ${AWS_REGION}
     options:
       data_path: data
 
@@ -154,6 +157,8 @@ sources:
     connection: lakehouse
     object: main.orders
 ```
+
+LibreDash owns the credential contract. Connection `auth` fields are resolved from `${ENV_VAR}` references or literal config values, validated by connection kind, and compiled into temporary DuckDB secrets internally. External secret managers such as Infisical should inject environment variables before `libredash serve` starts.
 
 For file and table paths, LibreDash infers `format` from clear extensions such as `.csv`, `.csv.gz`, `.json`, `.jsonl`, `.ndjson`, `.parquet`, `.xlsx`, `.txt`, `.blob`, `.vortex`, and `.lance`. Set source-level `format` explicitly for ambiguous paths or table directories such as `events/*`, `format: delta`, and `format: iceberg`. Advanced DuckDB integrations should be modeled explicitly before being exposed in source YAML.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ python3 scripts/bootstrap_olist.py
 go run ./cmd/libredash
 ```
 
-By default, the bootstrap script copies CSVs into `.data/olist`. To use a different location:
+By default, the bootstrap script copies CSVs into `.data/olist`. To use a different path:
 
 ```sh
 export LIBREDASH_DATA_DIR=/path/to/olist-csvs
@@ -46,7 +46,7 @@ go run ./cmd/libredash
 
 ## Source Model
 
-Semantic model YAML declares user-facing `sources` and named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract. Each source is an object with exactly one of `location` or `object`.
+Semantic model YAML declares user-facing `sources` and named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract. Each source is an object with exactly one of `path` or `object`.
 
 Local CSV:
 
@@ -62,10 +62,10 @@ connections:
 
 sources:
   orders:
-    location: olist_orders_dataset.csv
+    path: olist_orders_dataset.csv
 
   order_items:
-    location: olist_order_items_dataset.csv
+    path: olist_order_items_dataset.csv
 ```
 
 S3 Parquet with credential-chain auth:
@@ -84,7 +84,7 @@ connections:
 sources:
   sales_events:
     connection: prod_lake
-    location: events/*
+    path: events/*
     format: parquet
 ```
 
@@ -102,7 +102,7 @@ connections:
 sources:
   delta_orders:
     connection: azure_lake
-    location: tables/orders
+    path: tables/orders
     format: delta
 ```
 
@@ -120,7 +120,42 @@ sources:
     object: public.accounts
 ```
 
-For file locations, LibreDash infers `format` from clear extensions such as `.csv`, `.csv.gz`, `.json`, `.jsonl`, `.ndjson`, `.parquet`, `.xlsx`, `.txt`, `.blob`, and `.vortex`. Set source-level `format` explicitly for ambiguous paths or table directories such as `events/*`, `format: delta`, and `format: iceberg`. Advanced DuckDB integrations should be modeled explicitly before being exposed in source YAML.
+Lance dataset:
+
+```yaml
+connections:
+  prod_lake:
+    kind: s3
+    scope: s3://analytics-prod/
+    auth:
+      method: credential_chain
+
+sources:
+  product_embeddings:
+    connection: prod_lake
+    path: vectors/products.lance
+```
+
+DuckLake catalog:
+
+```yaml
+connections:
+  lakehouse:
+    kind: ducklake
+    scope: s3://analytics-prod/ducklake/
+    path: metadata.ducklake
+    auth:
+      method: credential_chain
+    options:
+      data_path: data
+
+sources:
+  lake_orders:
+    connection: lakehouse
+    object: main.orders
+```
+
+For file and table paths, LibreDash infers `format` from clear extensions such as `.csv`, `.csv.gz`, `.json`, `.jsonl`, `.ndjson`, `.parquet`, `.xlsx`, `.txt`, `.blob`, `.vortex`, and `.lance`. Set source-level `format` explicitly for ambiguous paths or table directories such as `events/*`, `format: delta`, and `format: iceberg`. Advanced DuckDB integrations should be modeled explicitly before being exposed in source YAML.
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ go run ./cmd/libredash
 
 ## Source Model
 
-Semantic model YAML declares user-facing `sources` and named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract. Each source is an object with exactly one of `location`, `object`, or `query`.
+Semantic model YAML declares user-facing `sources` and named `connections`. LibreDash compiles these declarations into DuckDB `raw.*` views and keeps DuckDB extension, secret, and scan setup behind the source contract. Each source is an object with exactly one of `location` or `object`.
 
 Local CSV:
 
@@ -57,7 +57,6 @@ connections:
   olist:
     kind: local
     defaults:
-      format: csv
       options:
         header: true
 
@@ -121,16 +120,7 @@ sources:
     object: public.accounts
 ```
 
-Trusted query source:
-
-```yaml
-sources:
-  custom:
-    query: |
-      SELECT * FROM future_scan_function('...')
-```
-
-For file locations, LibreDash infers `format` from clear extensions such as `.csv`, `.json`, `.jsonl`, `.parquet`, and `.xlsx`. Set `format` explicitly for ambiguous paths or table directories such as `events/*`, `format: delta`, and `format: iceberg`. `query` sources are trusted workspace code. Treat them like application SQL, not end-user input.
+For file locations, LibreDash infers `format` from clear extensions such as `.csv`, `.csv.gz`, `.json`, `.jsonl`, `.ndjson`, `.parquet`, `.xlsx`, `.txt`, `.blob`, and `.vortex`. Set source-level `format` explicitly for ambiguous paths or table directories such as `events/*`, `format: delta`, and `format: iceberg`. Advanced DuckDB integrations should be modeled explicitly before being exposed in source YAML.
 
 ## Deploy
 

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -2,20 +2,31 @@ name: olist
 title: Olist Commerce Semantic Model
 description: Brazilian ecommerce semantic model backed by DuckDB import tables.
 
-source_defaults:
-  type: file
-  format: csv
-  options:
-    header: true
+default_connection: olist
+
+connections:
+  olist:
+    kind: local
+    defaults:
+      format: csv
+      options:
+        header: true
 
 sources:
-  orders: olist_orders_dataset.csv
-  order_items: olist_order_items_dataset.csv
-  payments: olist_order_payments_dataset.csv
-  products: olist_products_dataset.csv
-  customers: olist_customers_dataset.csv
-  reviews: olist_order_reviews_dataset.csv
-  translations: product_category_name_translation.csv
+  orders:
+    location: olist_orders_dataset.csv
+  order_items:
+    location: olist_order_items_dataset.csv
+  payments:
+    location: olist_order_payments_dataset.csv
+  products:
+    location: olist_products_dataset.csv
+  customers:
+    location: olist_customers_dataset.csv
+  reviews:
+    location: olist_order_reviews_dataset.csv
+  translations:
+    location: product_category_name_translation.csv
 
 cache:
   tables:

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -13,19 +13,19 @@ connections:
 
 sources:
   orders:
-    location: olist_orders_dataset.csv
+    path: olist_orders_dataset.csv
   order_items:
-    location: olist_order_items_dataset.csv
+    path: olist_order_items_dataset.csv
   payments:
-    location: olist_order_payments_dataset.csv
+    path: olist_order_payments_dataset.csv
   products:
-    location: olist_products_dataset.csv
+    path: olist_products_dataset.csv
   customers:
-    location: olist_customers_dataset.csv
+    path: olist_customers_dataset.csv
   reviews:
-    location: olist_order_reviews_dataset.csv
+    path: olist_order_reviews_dataset.csv
   translations:
-    location: product_category_name_translation.csv
+    path: product_category_name_translation.csv
 
 cache:
   tables:

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -2,49 +2,20 @@ name: olist
 title: Olist Commerce Semantic Model
 description: Brazilian ecommerce semantic model backed by DuckDB import tables.
 
+source_defaults:
+  type: file
+  format: csv
+  options:
+    header: true
+
 sources:
-  orders:
-    type: file
-    format: csv
-    location: olist_orders_dataset.csv
-    options:
-      header: true
-  order_items:
-    type: file
-    format: csv
-    location: olist_order_items_dataset.csv
-    options:
-      header: true
-  payments:
-    type: file
-    format: csv
-    location: olist_order_payments_dataset.csv
-    options:
-      header: true
-  products:
-    type: file
-    format: csv
-    location: olist_products_dataset.csv
-    options:
-      header: true
-  customers:
-    type: file
-    format: csv
-    location: olist_customers_dataset.csv
-    options:
-      header: true
-  reviews:
-    type: file
-    format: csv
-    location: olist_order_reviews_dataset.csv
-    options:
-      header: true
-  translations:
-    type: file
-    format: csv
-    location: product_category_name_translation.csv
-    options:
-      header: true
+  orders: olist_orders_dataset.csv
+  order_items: olist_order_items_dataset.csv
+  payments: olist_order_payments_dataset.csv
+  products: olist_products_dataset.csv
+  customers: olist_customers_dataset.csv
+  reviews: olist_order_reviews_dataset.csv
+  translations: product_category_name_translation.csv
 
 cache:
   tables:

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -4,19 +4,47 @@ description: Brazilian ecommerce semantic model backed by DuckDB import tables.
 
 sources:
   orders:
-    file: olist_orders_dataset.csv
+    type: file
+    format: csv
+    location: olist_orders_dataset.csv
+    options:
+      header: true
   order_items:
-    file: olist_order_items_dataset.csv
+    type: file
+    format: csv
+    location: olist_order_items_dataset.csv
+    options:
+      header: true
   payments:
-    file: olist_order_payments_dataset.csv
+    type: file
+    format: csv
+    location: olist_order_payments_dataset.csv
+    options:
+      header: true
   products:
-    file: olist_products_dataset.csv
+    type: file
+    format: csv
+    location: olist_products_dataset.csv
+    options:
+      header: true
   customers:
-    file: olist_customers_dataset.csv
+    type: file
+    format: csv
+    location: olist_customers_dataset.csv
+    options:
+      header: true
   reviews:
-    file: olist_order_reviews_dataset.csv
+    type: file
+    format: csv
+    location: olist_order_reviews_dataset.csv
+    options:
+      header: true
   translations:
-    file: product_category_name_translation.csv
+    type: file
+    format: csv
+    location: product_category_name_translation.csv
+    options:
+      header: true
 
 cache:
   tables:

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -8,7 +8,6 @@ connections:
   olist:
     kind: local
     defaults:
-      format: csv
       options:
         header: true
 

--- a/internal/data/service.go
+++ b/internal/data/service.go
@@ -661,8 +661,19 @@ func (m *DuckDBMetrics) RefreshCache(ctx context.Context, modelID string) error 
 
 func (m *DuckDBMetrics) validateFiles(runtime *modelRuntime) error {
 	var missing []string
-	for _, file := range runtime.model.SourceFiles() {
-		if _, err := os.Stat(filepath.Join(m.dataDir, file)); errors.Is(err, os.ErrNotExist) {
+	for name, source := range runtime.model.Sources {
+		if source.Location == "" {
+			continue
+		}
+		connection := runtime.model.Connections[source.Connection]
+		if connection.Kind != "local" {
+			continue
+		}
+		file, err := m.resolveSourceLocation(runtime.model, source)
+		if err != nil {
+			return fmt.Errorf("resolving local source %s: %w", name, err)
+		}
+		if _, err := os.Stat(file); errors.Is(err, os.ErrNotExist) {
 			missing = append(missing, file)
 		} else if err != nil {
 			return err
@@ -692,7 +703,7 @@ func (m *DuckDBMetrics) registerSourceViews(ctx context.Context, runtime *modelR
 		if err := validateIdentifier(name); err != nil {
 			return err
 		}
-		relation, err := m.sourceRelation(source)
+		relation, err := m.sourceRelation(runtime.model, source)
 		if err != nil {
 			return fmt.Errorf("compiling source %s: %w", name, err)
 		}
@@ -1774,15 +1785,13 @@ func modelGraph(model *semantic.Model, metricViews map[string]*semantic.MetricVi
 
 	for _, name := range sortedKeys(model.Sources) {
 		source := model.Sources[name]
+		sourceKind := source.Kind()
 		meta := []dashboard.ModelMeta{
-			{Label: "Type", Value: source.Type},
+			{Label: "Kind", Value: sourceKind},
 			{Label: "Schema", Value: "raw"},
 		}
 		if source.Format != "" {
 			meta = append(meta, dashboard.ModelMeta{Label: "Format", Value: source.Format})
-		}
-		if source.Engine != "" {
-			meta = append(meta, dashboard.ModelMeta{Label: "Engine", Value: source.Engine})
 		}
 		if source.Location != "" {
 			meta = append(meta, dashboard.ModelMeta{Label: "Location", Value: source.Location})
@@ -1792,6 +1801,9 @@ func modelGraph(model *semantic.Model, metricViews map[string]*semantic.MetricVi
 		}
 		if source.Connection != "" {
 			meta = append(meta, dashboard.ModelMeta{Label: "Connection", Value: source.Connection})
+			if connection, ok := model.Connections[source.Connection]; ok {
+				meta = append(meta, dashboard.ModelMeta{Label: "Connection Kind", Value: connection.Kind})
+			}
 		}
 		graph.Nodes = append(graph.Nodes, dashboard.ModelNode{
 			ID:     nodeID("source", name),

--- a/internal/data/service.go
+++ b/internal/data/service.go
@@ -662,14 +662,14 @@ func (m *DuckDBMetrics) RefreshCache(ctx context.Context, modelID string) error 
 func (m *DuckDBMetrics) validateFiles(runtime *modelRuntime) error {
 	var missing []string
 	for name, source := range runtime.model.Sources {
-		if source.Location == "" {
+		if source.Path == "" {
 			continue
 		}
 		connection := runtime.model.Connections[source.Connection]
 		if connection.Kind != "local" {
 			continue
 		}
-		file, err := m.resolveSourceLocation(runtime.model, source)
+		file, err := m.resolveSourcePath(runtime.model, source)
 		if err != nil {
 			return fmt.Errorf("resolving local source %s: %w", name, err)
 		}
@@ -1793,8 +1793,8 @@ func modelGraph(model *semantic.Model, metricViews map[string]*semantic.MetricVi
 		if source.Format != "" {
 			meta = append(meta, dashboard.ModelMeta{Label: "Format", Value: source.Format})
 		}
-		if source.Location != "" {
-			meta = append(meta, dashboard.ModelMeta{Label: "Location", Value: source.Location})
+		if source.Path != "" {
+			meta = append(meta, dashboard.ModelMeta{Label: "Path", Value: source.Path})
 		}
 		if source.Object != "" {
 			meta = append(meta, dashboard.ModelMeta{Label: "Object", Value: source.Object})

--- a/internal/data/service.go
+++ b/internal/data/service.go
@@ -29,7 +29,7 @@ type MissingDataError struct {
 }
 
 func (e *MissingDataError) Error() string {
-	return fmt.Sprintf("Olist CSVs are missing in %s: %s. Run scripts/bootstrap_olist.py or set LIBREDASH_DATA_DIR.", e.DataDir, strings.Join(e.Missing, ", "))
+	return fmt.Sprintf("local source files are missing in %s: %s. Run the workspace bootstrap script or set LIBREDASH_DATA_DIR.", e.DataDir, strings.Join(e.Missing, ", "))
 }
 
 type DuckDBMetrics struct {
@@ -43,12 +43,13 @@ type DuckDBMetrics struct {
 }
 
 type modelRuntime struct {
-	db          *sql.DB
-	dbPath      string
-	model       *semantic.Model
-	ready       bool
-	missing     error
-	lastRefresh time.Time
+	db                  *sql.DB
+	dbPath              string
+	model               *semantic.Model
+	ready               bool
+	missing             error
+	lastRefresh         time.Time
+	attachedConnections map[string]struct{}
 }
 
 func NewDuckDBMetrics(dataDir string) (*DuckDBMetrics, error) {
@@ -682,12 +683,20 @@ func (m *DuckDBMetrics) registerSourceViews(ctx context.Context, runtime *modelR
 		return err
 	}
 
-	for name, source := range runtime.model.Sources {
+	if err := m.prepareSourceRuntime(ctx, runtime); err != nil {
+		return err
+	}
+
+	for _, name := range sortedKeys(runtime.model.Sources) {
+		source := runtime.model.Sources[name]
 		if err := validateIdentifier(name); err != nil {
 			return err
 		}
-		path := filepath.Join(m.dataDir, source.File)
-		stmt := fmt.Sprintf("CREATE OR REPLACE VIEW raw.%s AS SELECT * FROM read_csv_auto('%s', header=true)", name, sqlString(path))
+		relation, err := m.sourceRelation(source)
+		if err != nil {
+			return fmt.Errorf("compiling source %s: %w", name, err)
+		}
+		stmt := fmt.Sprintf("CREATE OR REPLACE VIEW raw.%s AS %s", name, relation)
 		if _, err := runtime.db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("registering source %s: %w", name, err)
 		}
@@ -1300,476 +1309,6 @@ func (m *DuckDBMetrics) countRows(ctx context.Context, runtime *modelRuntime, re
 	return total, nil
 }
 
-func (m *DuckDBMetrics) tableBlocks(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest, availableRows int) (map[string]dashboard.TableBlock, error) {
-	blocks := map[string]dashboard.TableBlock{}
-	count := request.Count
-	if count <= 0 {
-		count = dashboard.TableChunkSize
-	}
-	if count > dashboard.TableMaxRequestCount {
-		count = dashboard.TableMaxRequestCount
-	}
-	if request.Block == "all" {
-		starts := initialBlockStarts(request.Start, count, availableRows)
-		for block, start := range starts {
-			rows, err := m.tableRows(ctx, runtime, report, table, filters, request, start, count, availableRows)
-			if err != nil {
-				return nil, err
-			}
-			blocks[block] = dashboard.TableBlock{
-				Start:        start,
-				RequestSeq:   request.RequestSeq,
-				ResetVersion: request.ResetVersion,
-				Sort:         request.Sort,
-				Rows:         rows,
-			}
-		}
-		return blocks, nil
-	}
-
-	start := clampTableStart(request.Start, availableRows)
-	rows, err := m.tableRows(ctx, runtime, report, table, filters, request, start, count, availableRows)
-	if err != nil {
-		return nil, err
-	}
-	blocks[request.Block] = dashboard.TableBlock{
-		Start:        start,
-		RequestSeq:   request.RequestSeq,
-		ResetVersion: request.ResetVersion,
-		Sort:         request.Sort,
-		Rows:         rows,
-	}
-	return blocks, nil
-}
-
-func (m *DuckDBMetrics) queryAggregateTable(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, request dashboard.TableRequest, table semantic.TableVisual, filters dashboard.Filters) (dashboard.Table, error) {
-	var (
-		columns []dashboard.TableColumn
-		rows    []map[string]any
-		err     error
-	)
-	switch table.KindOrDefault() {
-	case "matrix_table":
-		columns, rows, err = m.matrixTableRows(ctx, runtime, report, table, filters, request)
-	case "pivot_table":
-		columns, rows, err = m.pivotTableRows(ctx, runtime, report, table, filters, request)
-	default:
-		err = fmt.Errorf("unsupported aggregate table kind %q", table.KindOrDefault())
-	}
-	if err != nil {
-		return dashboard.EmptyTable(request, err), nil
-	}
-	totalRows := len(rows)
-	isCapped := totalRows > dashboard.TableInteractiveRowCap
-	if isCapped {
-		rows = rows[:dashboard.TableInteractiveRowCap]
-	}
-	chunkSize := max(dashboard.TableChunkSize, len(rows))
-	return dashboard.Table{
-		Version:       2,
-		Kind:          table.KindOrDefault(),
-		Title:         table.Title,
-		Columns:       columns,
-		TotalRows:     totalRows,
-		AvailableRows: len(rows),
-		IsCapped:      isCapped,
-		RowCap:        dashboard.TableInteractiveRowCap,
-		ChunkSize:     chunkSize,
-		RowHeight:     dashboard.TableRowHeight,
-		ResetVersion:  request.ResetVersion,
-		Sort:          request.Sort,
-		Blocks: map[string]dashboard.TableBlock{
-			"a": {Start: 0, RequestSeq: request.RequestSeq, ResetVersion: request.ResetVersion, Sort: request.Sort, Rows: rows},
-			"b": {Start: chunkSize, RequestSeq: request.RequestSeq, ResetVersion: request.ResetVersion, Sort: request.Sort, Rows: []map[string]any{}},
-			"c": {Start: chunkSize * 2, RequestSeq: request.RequestSeq, ResetVersion: request.ResetVersion, Sort: request.Sort, Rows: []map[string]any{}},
-		},
-		LoadingBlock: "",
-		Error:        "",
-	}, nil
-}
-
-func (m *DuckDBMetrics) matrixTableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest) ([]dashboard.TableColumn, []map[string]any, error) {
-	if len(table.ColumnDims) == 1 {
-		return m.crossTabTableRows(ctx, runtime, report, table, filters, request, false)
-	}
-	source, err := m.metricViewSource(table.MetricView)
-	if err != nil {
-		return nil, nil, err
-	}
-	metricView := m.workspace.MetricViews[table.MetricView]
-	columns := make([]dashboard.TableColumn, 0, len(table.Rows)+len(table.Measures))
-	selects := make([]string, 0, len(table.Rows)+len(table.Measures))
-	groupBy := make([]string, 0, len(table.Rows))
-	for _, dimensionName := range table.Rows {
-		dimension := metricView.Dimensions[dimensionName]
-		selects = append(selects, fmt.Sprintf("%s AS %s", dimensionExpression(dimension, "e"), dimensionName))
-		groupBy = append(groupBy, dimensionName)
-		columns = append(columns, dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header"})
-	}
-	for _, measureName := range table.Measures {
-		measure := metricView.Measures[measureName]
-		expr, err := measureAggregateExpr(measure)
-		if err != nil {
-			return nil, nil, err
-		}
-		selects = append(selects, fmt.Sprintf("%s AS %s", expr, measureName))
-		columns = append(columns, dashboard.TableColumn{Key: measureName, Label: measureLabel(measureName, measure), Align: "right", Role: "measure", Measure: measureName})
-	}
-	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
-	orderBy := strings.Join(groupBy, ", ")
-	if request.Sort.Key != "" && tableHasColumn(columns, request.Sort.Key) {
-		direction := "DESC"
-		if request.Sort.Direction == "asc" {
-			direction = "ASC"
-		}
-		orderBy = request.Sort.Key + " " + direction
-	}
-	query := fmt.Sprintf(`
-SELECT %s
-FROM %s e
-WHERE %s
-GROUP BY %s
-ORDER BY %s
-LIMIT ?`, strings.Join(selects, ", "), source, where, strings.Join(groupBy, ", "), orderBy)
-	args = append(args, dashboard.TableInteractiveRowCap+1)
-	rows, err := m.queryTableDatums(ctx, runtime, query, tableColumnKeys(columns), args...)
-	return columns, rows, err
-}
-
-func (m *DuckDBMetrics) pivotTableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest) ([]dashboard.TableColumn, []map[string]any, error) {
-	return m.crossTabTableRows(ctx, runtime, report, table, filters, request, true)
-}
-
-func (m *DuckDBMetrics) crossTabTableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest, pivotMode bool) ([]dashboard.TableColumn, []map[string]any, error) {
-	source, err := m.metricViewSource(table.MetricView)
-	if err != nil {
-		return nil, nil, err
-	}
-	metricView := m.workspace.MetricViews[table.MetricView]
-	rowSelects := make([]string, 0, len(table.Rows))
-	groupBy := make([]string, 0, len(table.Rows)+1)
-	baseColumns := make([]dashboard.TableColumn, 0, len(table.Rows))
-	for _, dimensionName := range table.Rows {
-		dimension := metricView.Dimensions[dimensionName]
-		rowSelects = append(rowSelects, fmt.Sprintf("%s AS %s", dimensionExpression(dimension, "e"), dimensionName))
-		groupBy = append(groupBy, dimensionName)
-		baseColumns = append(baseColumns, dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header"})
-	}
-	columnDimensionName := table.ColumnDims[0]
-	columnDimension := metricView.Dimensions[columnDimensionName]
-	valueSelects := make([]string, 0, len(table.Measures))
-	valueColumns := make([]string, 0, len(table.Measures))
-	for _, measureName := range table.Measures {
-		measureExpr, err := measureAggregateExpr(metricView.Measures[measureName])
-		if err != nil {
-			return nil, nil, err
-		}
-		valueSelects = append(valueSelects, fmt.Sprintf("%s AS %s", measureExpr, measureName))
-		valueColumns = append(valueColumns, measureName)
-	}
-	groupBy = append(groupBy, "pivot_label")
-	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
-	query := fmt.Sprintf(`
-SELECT %s, %s AS pivot_label, %s
-FROM %s e
-WHERE %s
-GROUP BY %s
-ORDER BY %s
-LIMIT ?`, strings.Join(rowSelects, ", "), dimensionExpression(columnDimension, "e"), strings.Join(valueSelects, ", "), source, where, strings.Join(groupBy, ", "), strings.Join(groupBy, ", "))
-	args = append(args, dashboard.TableInteractiveRowCap+1)
-	rawRows, err := m.queryTableDatums(ctx, runtime, query, append(append(append([]string{}, table.Rows...), "pivot_label"), valueColumns...), args...)
-	if err != nil {
-		return nil, nil, err
-	}
-	columns := append([]dashboard.TableColumn{}, baseColumns...)
-	pivotKeys := map[string]string{}
-	usedKeys := map[string]string{}
-	columnKeys := map[string]string{}
-	for _, column := range baseColumns {
-		usedKeys[column.Key] = column.Key
-	}
-	resultByKey := map[string]map[string]any{}
-	order := []string{}
-	for _, raw := range rawRows {
-		rowKeyParts := make([]string, 0, len(table.Rows))
-		for _, dimension := range table.Rows {
-			rowKeyParts = append(rowKeyParts, fmt.Sprint(raw[dimension]))
-		}
-		resultKey := strings.Join(rowKeyParts, "\x00")
-		row, exists := resultByKey[resultKey]
-		if !exists {
-			row = map[string]any{}
-			for _, dimension := range table.Rows {
-				row[dimension] = raw[dimension]
-			}
-			resultByKey[resultKey] = row
-			order = append(order, resultKey)
-		}
-		label := fmt.Sprint(raw["pivot_label"])
-		groupLabel := label
-		if pivotMode {
-			groupLabel = measureLabel(table.Measures[0], metricView.Measures[table.Measures[0]])
-		}
-		pivotKey, exists := pivotKeys[label]
-		if !exists {
-			pivotKey = sanitizeTableKey(label)
-			pivotKeys[label] = pivotKey
-		}
-		for _, measureName := range table.Measures {
-			measure := metricView.Measures[measureName]
-			columnIdentity := label + "\x00" + measureName
-			columnKey, columnExists := columnKeys[columnIdentity]
-			candidate := "pivot_" + pivotKey
-			columnLabel := label
-			if !pivotMode || len(table.Measures) > 1 {
-				candidate += "__" + sanitizeTableKey(measureName)
-				columnLabel = measureLabel(measureName, measure)
-			}
-			if !columnExists {
-				columnKey = uniqueTableColumnKey(candidate, usedKeys)
-				columnKeys[columnIdentity] = columnKey
-				usedKeys[columnKey] = columnKey
-				columns = append(columns, dashboard.TableColumn{
-					Key:         columnKey,
-					Label:       columnLabel,
-					Align:       "right",
-					Role:        "measure",
-					Group:       groupLabel,
-					Measure:     measureName,
-					ColumnValue: label,
-				})
-			}
-			row[columnKey] = raw[measureName]
-		}
-	}
-	result := make([]map[string]any, 0, len(order))
-	for _, key := range order {
-		result = append(result, resultByKey[key])
-	}
-	sortAggregateTableRows(result, request.Sort)
-	return columns, result, nil
-}
-
-func (m *DuckDBMetrics) queryTableDatums(ctx context.Context, runtime *modelRuntime, query string, columns []string, args ...any) ([]map[string]any, error) {
-	rows, err := runtime.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	values := make([]any, len(columns))
-	scans := make([]any, len(columns))
-	for i := range values {
-		scans[i] = &values[i]
-	}
-	result := []map[string]any{}
-	for rows.Next() {
-		if err := rows.Scan(scans...); err != nil {
-			return nil, err
-		}
-		row := map[string]any{}
-		for i, column := range columns {
-			row[column] = normalizeDBValue(values[i])
-		}
-		result = append(result, row)
-	}
-	return result, rows.Err()
-}
-
-func tableColumnKeys(columns []dashboard.TableColumn) []string {
-	keys := make([]string, len(columns))
-	for i, column := range columns {
-		keys[i] = column.Key
-	}
-	return keys
-}
-
-func tableHasColumn(columns []dashboard.TableColumn, key string) bool {
-	for _, column := range columns {
-		if column.Key == key {
-			return true
-		}
-	}
-	return false
-}
-
-func sortAggregateTableRows(rows []map[string]any, tableSort dashboard.TableSort) {
-	if tableSort.Key == "" {
-		return
-	}
-	direction := tableSort.Direction
-	sort.SliceStable(rows, func(i, j int) bool {
-		cmp := compareTableValues(rows[i][tableSort.Key], rows[j][tableSort.Key])
-		if direction == "desc" {
-			return cmp > 0
-		}
-		return cmp < 0
-	})
-}
-
-func compareTableValues(a, b any) int {
-	aFloat, aNumeric := numericTableValue(a)
-	bFloat, bNumeric := numericTableValue(b)
-	if aNumeric && bNumeric {
-		switch {
-		case aFloat < bFloat:
-			return -1
-		case aFloat > bFloat:
-			return 1
-		default:
-			return 0
-		}
-	}
-	aText := strings.ToLower(fmt.Sprint(a))
-	bText := strings.ToLower(fmt.Sprint(b))
-	switch {
-	case aText < bText:
-		return -1
-	case aText > bText:
-		return 1
-	default:
-		return 0
-	}
-}
-
-func numericTableValue(value any) (float64, bool) {
-	switch typed := value.(type) {
-	case int:
-		return float64(typed), true
-	case int64:
-		return float64(typed), true
-	case float64:
-		return typed, true
-	case float32:
-		return float64(typed), true
-	case string:
-		parsed, err := strconv.ParseFloat(typed, 64)
-		return parsed, err == nil
-	default:
-		return 0, false
-	}
-}
-
-func dimensionLabel(name string, dimension semantic.MetricDimension) string {
-	if strings.TrimSpace(dimension.Label) != "" {
-		return dimension.Label
-	}
-	return name
-}
-
-func sanitizeTableKey(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	var builder strings.Builder
-	for _, r := range value {
-		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
-			builder.WriteRune(r)
-			continue
-		}
-		builder.WriteByte('_')
-	}
-	key := strings.Trim(builder.String(), "_")
-	if key == "" {
-		return "value"
-	}
-	return key
-}
-
-func uniqueTableColumnKey(candidate string, existing map[string]string) string {
-	used := map[string]struct{}{}
-	for _, key := range existing {
-		used[key] = struct{}{}
-	}
-	key := candidate
-	for i := 2; ; i++ {
-		if _, ok := used[key]; !ok {
-			return key
-		}
-		key = fmt.Sprintf("%s_%d", candidate, i)
-	}
-}
-
-func initialBlockStarts(start, count, availableRows int) map[string]int {
-	start = clampTableStart(start, availableRows)
-	if start <= 0 {
-		return map[string]int{"a": 0, "b": count, "c": count * 2}
-	}
-	base := (start / count) * count
-	return map[string]int{"a": max(0, base-count), "b": base, "c": base + count}
-}
-
-func clampTableStart(start, availableRows int) int {
-	if start < 0 {
-		return 0
-	}
-	if availableRows <= 0 {
-		return 0
-	}
-	if start >= availableRows {
-		return max(0, availableRows-1)
-	}
-	return start
-}
-
-func (m *DuckDBMetrics) tableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest, start, count, availableRows int) ([]map[string]any, error) {
-	if count <= 0 || start >= availableRows {
-		return []map[string]any{}, nil
-	}
-	if start+count > availableRows {
-		count = availableRows - start
-	}
-	source, err := m.metricViewSource(table.MetricView)
-	if err != nil {
-		return nil, err
-	}
-	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
-	sortExpr := tableSortExpr(table, request.Sort.Key)
-	direction := "DESC"
-	if request.Sort.Direction == "asc" {
-		direction = "ASC"
-	}
-
-	selects := make([]string, 0, len(table.Columns))
-	for _, column := range table.Columns {
-		if err := validateIdentifier(column.Key); err != nil {
-			return nil, err
-		}
-		selects = append(selects, "e."+column.Key)
-	}
-
-	query := fmt.Sprintf(`
-SELECT %s
-FROM %s e
-WHERE %s
-ORDER BY %s %s, e.order_id ASC
-LIMIT ? OFFSET ?`, strings.Join(selects, ", "), source, where, sortExpr, direction)
-
-	args = append(args, count, start)
-	rows, err := runtime.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	values := make([]any, len(table.Columns))
-	scans := make([]any, len(table.Columns))
-	for i := range values {
-		scans[i] = &values[i]
-	}
-
-	result := []map[string]any{}
-	for rows.Next() {
-		if err := rows.Scan(scans...); err != nil {
-			return nil, err
-		}
-		row := map[string]any{}
-		for i, column := range table.Columns {
-			row[column.Key] = normalizeDBValue(values[i])
-		}
-		result = append(result, row)
-	}
-	return result, rows.Err()
-}
-
 func measureAggregateExpr(measure semantic.MetricMeasure) (string, error) {
 	if strings.TrimSpace(measure.Expression) == "" {
 		return "", fmt.Errorf("measure %q is missing expression", measure.Label)
@@ -1851,21 +1390,6 @@ func formatBinLabel(start, end float64) string {
 		return strconv.FormatFloat(round(start), 'f', -1, 64)
 	}
 	return fmt.Sprintf("%s-%s", strconv.FormatFloat(round(start), 'f', -1, 64), strconv.FormatFloat(round(end), 'f', -1, 64))
-}
-
-func tableSortExpr(table semantic.TableVisual, key string) string {
-	if key == "" {
-		key = table.DefaultSort.Key
-	}
-	for _, column := range table.Columns {
-		if column.Key == key {
-			return "e." + column.Key
-		}
-	}
-	if table.DefaultSort.Key != "" {
-		return "e." + table.DefaultSort.Key
-	}
-	return "e.order_id"
 }
 
 func (m *DuckDBMetrics) visualOrderBy(model *semantic.Model, visual semantic.Visual) string {
@@ -2250,16 +1774,32 @@ func modelGraph(model *semantic.Model, metricViews map[string]*semantic.MetricVi
 
 	for _, name := range sortedKeys(model.Sources) {
 		source := model.Sources[name]
+		meta := []dashboard.ModelMeta{
+			{Label: "Type", Value: source.Type},
+			{Label: "Schema", Value: "raw"},
+		}
+		if source.Format != "" {
+			meta = append(meta, dashboard.ModelMeta{Label: "Format", Value: source.Format})
+		}
+		if source.Engine != "" {
+			meta = append(meta, dashboard.ModelMeta{Label: "Engine", Value: source.Engine})
+		}
+		if source.Location != "" {
+			meta = append(meta, dashboard.ModelMeta{Label: "Location", Value: source.Location})
+		}
+		if source.Object != "" {
+			meta = append(meta, dashboard.ModelMeta{Label: "Object", Value: source.Object})
+		}
+		if source.Connection != "" {
+			meta = append(meta, dashboard.ModelMeta{Label: "Connection", Value: source.Connection})
+		}
 		graph.Nodes = append(graph.Nodes, dashboard.ModelNode{
 			ID:     nodeID("source", name),
 			Label:  name,
 			Kind:   "source",
 			Schema: "raw",
-			Fields: []dashboard.ModelField{{Name: source.File, Role: "csv"}},
-			Meta: []dashboard.ModelMeta{
-				{Label: "File", Value: source.File},
-				{Label: "Schema", Value: "raw"},
-			},
+			Fields: []dashboard.ModelField{{Name: source.Description(), Role: source.Role()}},
+			Meta:   meta,
 		})
 	}
 

--- a/internal/data/service_test.go
+++ b/internal/data/service_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -10,7 +11,308 @@ import (
 	"testing"
 
 	"github.com/Yacobolo/libredash/internal/dashboard"
+	"github.com/Yacobolo/libredash/internal/semantic"
 )
+
+func TestCompileSourceRelation(t *testing.T) {
+	cases := map[string]struct {
+		location string
+		source   semantic.Source
+		want     string
+	}{
+		"csv": {
+			location: "/data/orders.csv",
+			source:   semantic.Source{Type: "file", Format: "csv", Options: map[string]any{"header": true, "sample_size": 1000}},
+			want:     "SELECT * FROM read_csv('/data/orders.csv', header = true, sample_size = 1000)",
+		},
+		"json": {
+			location: "/data/orders.json",
+			source:   semantic.Source{Type: "file", Format: "json", Options: map[string]any{"format": "array"}},
+			want:     "SELECT * FROM read_json('/data/orders.json', format = 'array')",
+		},
+		"parquet": {
+			location: "s3://bucket/orders/*.parquet",
+			source:   semantic.Source{Type: "file", Format: "parquet", Options: map[string]any{"union_by_name": true}},
+			want:     "SELECT * FROM read_parquet('s3://bucket/orders/*.parquet', union_by_name = true)",
+		},
+		"excel": {
+			location: "/data/budget.xlsx",
+			source:   semantic.Source{Type: "file", Format: "excel", Options: map[string]any{"sheet": "FY2026"}},
+			want:     "SELECT * FROM read_xlsx('/data/budget.xlsx', sheet = 'FY2026')",
+		},
+		"delta": {
+			location: "az://warehouse/orders",
+			source:   semantic.Source{Type: "lakehouse", Format: "delta"},
+			want:     "SELECT * FROM delta_scan('az://warehouse/orders')",
+		},
+		"iceberg": {
+			location: "s3://warehouse/orders/metadata/v1.metadata.json",
+			source:   semantic.Source{Type: "lakehouse", Format: "iceberg", Options: map[string]any{"allow_moved_paths": true}},
+			want:     "SELECT * FROM iceberg_scan('s3://warehouse/orders/metadata/v1.metadata.json', allow_moved_paths = true)",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			relation, err := compileSourceRelation(tc.location, tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if relation != tc.want {
+				t.Fatalf("relation = %q, want %q", relation, tc.want)
+			}
+		})
+	}
+
+	var relation string
+	var err error
+	relation, err = compileSourceRelation("", semantic.Source{
+		Type:       "database",
+		Engine:     "postgres",
+		Connection: "crm",
+		Object:     "public.accounts",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "SELECT * FROM conn_crm.public.accounts"; relation != want {
+		t.Fatalf("database relation = %q, want %q", relation, want)
+	}
+
+	relation, err = compileSourceRelation("", semantic.Source{Type: "query", Query: "SELECT 1 AS id"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if relation != "SELECT 1 AS id" {
+		t.Fatalf("query relation = %q, want trusted query passthrough", relation)
+	}
+
+	_, err = compileSourceRelation("/data/orders.csv", semantic.Source{Type: "file", Format: "csv", Options: map[string]any{"bad-key": true}})
+	if err == nil || !strings.Contains(err.Error(), "invalid source option") {
+		t.Fatalf("invalid option error = %v, want invalid source option", err)
+	}
+}
+
+func TestCompileConnectionSecret(t *testing.T) {
+	stmt, ok, err := compileConnectionSecret("prod_lake", semantic.Connection{
+		Type:  "s3",
+		Scope: "s3://analytics-prod/",
+		Auth:  semantic.ConnectionAuth{Method: "credential_chain", Profile: "analytics", Params: map[string]any{"region": "us-east-1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("secret ok = false, want true")
+	}
+	want := "CREATE OR REPLACE SECRET libredash_prod_lake (TYPE s3, PROVIDER credential_chain, PROFILE 'analytics', REGION 'us-east-1', SCOPE 's3://analytics-prod/')"
+	if stmt != want {
+		t.Fatalf("s3 secret = %q, want %q", stmt, want)
+	}
+
+	stmt, ok, err = compileConnectionSecret("azure_lake", semantic.Connection{
+		Type: "azure",
+		Auth: semantic.ConnectionAuth{Method: "credential_chain", Account: "mystorageaccount"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = "CREATE OR REPLACE SECRET libredash_azure_lake (TYPE azure, PROVIDER credential_chain, ACCOUNT_NAME 'mystorageaccount')"
+	if !ok || stmt != want {
+		t.Fatalf("azure secret = %q ok=%v, want %q ok=true", stmt, ok, want)
+	}
+
+	stmt, ok, err = compileConnectionSecret("crm", semantic.Connection{Type: "postgres", Secret: "crm_readonly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || stmt != "" {
+		t.Fatalf("named secret compile = %q ok=%v, want empty ok=false", stmt, ok)
+	}
+}
+
+func TestCompileDatabaseAttach(t *testing.T) {
+	cases := map[string]struct {
+		engine     string
+		connection semantic.Connection
+		want       string
+	}{
+		"postgres_existing_secret": {
+			engine:     "postgres",
+			connection: semantic.Connection{Type: "postgres", Secret: "crm_readonly"},
+			want:       "ATTACH '' AS conn_crm (TYPE postgres, READ_ONLY, SECRET crm_readonly)",
+		},
+		"mysql_uri": {
+			engine:     "mysql",
+			connection: semantic.Connection{Type: "mysql", Options: map[string]any{"connection_string": "host=localhost database=sales"}},
+			want:       "ATTACH 'host=localhost database=sales' AS conn_crm (TYPE mysql, READ_ONLY)",
+		},
+		"sqlite_path": {
+			engine:     "sqlite",
+			connection: semantic.Connection{Type: "sqlite", Options: map[string]any{"path": "/tmp/source.sqlite"}},
+			want:       "ATTACH '/tmp/source.sqlite' AS conn_crm (TYPE sqlite, READ_ONLY)",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			stmt, err := compileDatabaseAttach("crm", tc.engine, tc.connection)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stmt != tc.want {
+				t.Fatalf("attach = %q, want %q", stmt, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequiredExtensions(t *testing.T) {
+	model := &semantic.Model{
+		Connections: map[string]semantic.Connection{
+			"lake": {Type: "s3"},
+			"crm":  {Type: "postgres"},
+		},
+		Sources: map[string]semantic.Source{
+			"events":   {Type: "file", Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
+			"budget":   {Type: "file", Format: "excel", Location: "budget.xlsx"},
+			"orders":   {Type: "lakehouse", Format: "delta", Location: "az://warehouse/orders"},
+			"accounts": {Type: "database", Engine: "postgres", Connection: "crm", Object: "public.accounts"},
+		},
+	}
+	if got := strings.Join(requiredExtensions(model), ","); got != "azure,delta,excel,httpfs,postgres" {
+		t.Fatalf("required extensions = %q, want azure,delta,excel,httpfs,postgres", got)
+	}
+}
+
+func TestDuckDBMetricsRegistersCSVAndQuerySources(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "orders.csv", "order_id,revenue\no1,10.50\no2,20.25\n")
+	db, err := sql.Open("duckdb", filepath.Join(dir, "test.duckdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	metrics := &DuckDBMetrics{dataDir: dir}
+	runtime := &modelRuntime{
+		db: db,
+		model: &semantic.Model{
+			Name: "test",
+			Sources: map[string]semantic.Source{
+				"orders": {
+					Type:     "file",
+					Format:   "csv",
+					Location: "orders.csv",
+					Options:  map[string]any{"header": true},
+				},
+				"targets": {
+					Type:  "query",
+					Query: "SELECT 'o1' AS order_id, 100::DOUBLE AS target",
+				},
+			},
+			Cache: semantic.Cache{Tables: map[string]semantic.CacheTable{
+				"joined": {
+					SQL: `
+						SELECT o.order_id, try_cast(o.revenue AS DOUBLE) AS revenue, t.target
+						FROM raw.orders o
+						LEFT JOIN raw.targets t ON t.order_id = o.order_id
+					`,
+				},
+			}},
+		},
+	}
+	if err := metrics.registerSourceViews(context.Background(), runtime); err != nil {
+		t.Fatalf("register sources: %v", err)
+	}
+	if err := metrics.materializeCache(context.Background(), runtime); err != nil {
+		t.Fatalf("materialize cache: %v", err)
+	}
+
+	var total float64
+	if err := db.QueryRowContext(context.Background(), "SELECT SUM(revenue) FROM cache.joined").Scan(&total); err != nil {
+		t.Fatal(err)
+	}
+	if total != 30.75 {
+		t.Fatalf("total revenue = %v, want 30.75", total)
+	}
+	var target float64
+	if err := db.QueryRowContext(context.Background(), "SELECT target FROM cache.joined WHERE order_id = 'o1'").Scan(&target); err != nil {
+		t.Fatal(err)
+	}
+	if target != 100 {
+		t.Fatalf("target = %v, want 100", target)
+	}
+}
+
+func TestDuckDBMetricsRegistersDatabaseSourceTwice(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.sqlite")
+	db, err := sql.Open("duckdb", filepath.Join(dir, "test.duckdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(context.Background(), "INSTALL sqlite"); err != nil {
+		t.Skipf("sqlite extension unavailable: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), "LOAD sqlite"); err != nil {
+		t.Skipf("sqlite extension unavailable: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), "ATTACH '"+sqlString(sourcePath)+"' AS seed (TYPE sqlite)"); err != nil {
+		t.Fatalf("attach seed sqlite: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), "CREATE TABLE seed.accounts (id INTEGER, name VARCHAR)"); err != nil {
+		t.Fatalf("create seed table: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), "INSERT INTO seed.accounts VALUES (1, 'Acme')"); err != nil {
+		t.Fatalf("insert seed table: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), "DETACH seed"); err != nil {
+		t.Fatalf("detach seed sqlite: %v", err)
+	}
+
+	metrics := &DuckDBMetrics{dataDir: dir}
+	runtime := &modelRuntime{
+		db: db,
+		model: &semantic.Model{
+			Name: "test",
+			Connections: map[string]semantic.Connection{
+				"crm": {Type: "sqlite", Options: map[string]any{"path": sourcePath}},
+			},
+			Sources: map[string]semantic.Source{
+				"accounts": {Type: "database", Engine: "sqlite", Connection: "crm", Object: "accounts"},
+			},
+			Cache: semantic.Cache{Tables: map[string]semantic.CacheTable{
+				"accounts": {SQL: "SELECT * FROM raw.accounts"},
+			}},
+		},
+	}
+	for i := 0; i < 2; i++ {
+		if err := metrics.registerSourceViews(context.Background(), runtime); err != nil {
+			t.Fatalf("register sources pass %d: %v", i+1, err)
+		}
+	}
+	if err := metrics.materializeCache(context.Background(), runtime); err != nil {
+		t.Fatalf("materialize cache: %v", err)
+	}
+	var name string
+	if err := db.QueryRowContext(context.Background(), "SELECT name FROM cache.accounts WHERE id = 1").Scan(&name); err != nil {
+		t.Fatal(err)
+	}
+	if name != "Acme" {
+		t.Fatalf("name = %q, want Acme", name)
+	}
+}
+
+func TestDuckDBMetricsValidateFilesIgnoresRemoteAndQuerySources(t *testing.T) {
+	metrics := &DuckDBMetrics{dataDir: t.TempDir()}
+	runtime := &modelRuntime{model: &semantic.Model{Sources: map[string]semantic.Source{
+		"events":  {Type: "file", Format: "parquet", Location: "s3://bucket/events/*.parquet"},
+		"targets": {Type: "query", Query: "SELECT 1 AS id"},
+	}}}
+	if err := metrics.validateFiles(runtime); err != nil {
+		t.Fatalf("validate files = %v, want nil", err)
+	}
+}
 
 func TestMissingDataReturnsSetupPatch(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/data/service_test.go
+++ b/internal/data/service_test.go
@@ -20,39 +20,43 @@ func TestCompileSourceRelation(t *testing.T) {
 		want string
 	}{
 		"csv": {
-			plan: sourcePlan{kind: "location", format: "csv", location: "/data/orders.csv", options: map[string]any{"header": true, "sample_size": 1000}},
+			plan: sourcePlan{kind: "path", format: "csv", path: "/data/orders.csv", options: map[string]any{"header": true, "sample_size": 1000}},
 			want: "SELECT * FROM read_csv('/data/orders.csv', header = true, sample_size = 1000)",
 		},
 		"json": {
-			plan: sourcePlan{kind: "location", format: "json", location: "/data/orders.json", options: map[string]any{"format": "array"}},
+			plan: sourcePlan{kind: "path", format: "json", path: "/data/orders.json", options: map[string]any{"format": "array"}},
 			want: "SELECT * FROM read_json('/data/orders.json', format = 'array')",
 		},
 		"parquet": {
-			plan: sourcePlan{kind: "location", format: "parquet", location: "s3://bucket/orders/*.parquet", options: map[string]any{"union_by_name": true}},
+			plan: sourcePlan{kind: "path", format: "parquet", path: "s3://bucket/orders/*.parquet", options: map[string]any{"union_by_name": true}},
 			want: "SELECT * FROM read_parquet('s3://bucket/orders/*.parquet', union_by_name = true)",
 		},
 		"excel": {
-			plan: sourcePlan{kind: "location", format: "excel", location: "/data/budget.xlsx", options: map[string]any{"sheet": "FY2026"}},
+			plan: sourcePlan{kind: "path", format: "excel", path: "/data/budget.xlsx", options: map[string]any{"sheet": "FY2026"}},
 			want: "SELECT * FROM read_xlsx('/data/budget.xlsx', sheet = 'FY2026')",
 		},
 		"text": {
-			plan: sourcePlan{kind: "location", format: "text", location: "/data/readme.txt"},
+			plan: sourcePlan{kind: "path", format: "text", path: "/data/readme.txt"},
 			want: "SELECT * FROM read_text('/data/readme.txt')",
 		},
 		"blob": {
-			plan: sourcePlan{kind: "location", format: "blob", location: "/data/archive.blob"},
+			plan: sourcePlan{kind: "path", format: "blob", path: "/data/archive.blob"},
 			want: "SELECT * FROM read_blob('/data/archive.blob')",
 		},
 		"vortex": {
-			plan: sourcePlan{kind: "location", format: "vortex", location: "/data/orders.vortex"},
+			plan: sourcePlan{kind: "path", format: "vortex", path: "/data/orders.vortex"},
 			want: "SELECT * FROM read_vortex('/data/orders.vortex')",
 		},
+		"lance": {
+			plan: sourcePlan{kind: "path", format: "lance", path: "s3://bucket/vectors/products.lance"},
+			want: "SELECT * FROM 's3://bucket/vectors/products.lance'",
+		},
 		"delta": {
-			plan: sourcePlan{kind: "location", format: "delta", location: "az://warehouse/orders"},
+			plan: sourcePlan{kind: "path", format: "delta", path: "az://warehouse/orders"},
 			want: "SELECT * FROM delta_scan('az://warehouse/orders')",
 		},
 		"iceberg": {
-			plan: sourcePlan{kind: "location", format: "iceberg", location: "s3://warehouse/orders/metadata/v1.metadata.json", options: map[string]any{"allow_moved_paths": true}},
+			plan: sourcePlan{kind: "path", format: "iceberg", path: "s3://warehouse/orders/metadata/v1.metadata.json", options: map[string]any{"allow_moved_paths": true}},
 			want: "SELECT * FROM iceberg_scan('s3://warehouse/orders/metadata/v1.metadata.json', allow_moved_paths = true)",
 		},
 	}
@@ -76,9 +80,14 @@ func TestCompileSourceRelation(t *testing.T) {
 		t.Fatalf("database relation = %q, want %q", relation, want)
 	}
 
-	_, err = compileSourceRelation(sourcePlan{kind: "location", format: "csv", location: "/data/orders.csv", options: map[string]any{"bad-key": true}})
+	_, err = compileSourceRelation(sourcePlan{kind: "path", format: "csv", path: "/data/orders.csv", options: map[string]any{"bad-key": true}})
 	if err == nil || !strings.Contains(err.Error(), "invalid source option") {
 		t.Fatalf("invalid option error = %v, want invalid source option", err)
+	}
+
+	_, err = compileSourceRelation(sourcePlan{kind: "path", format: "lance", path: "/data/products.lance", options: map[string]any{"sample_size": 1000}})
+	if err == nil || !strings.Contains(err.Error(), "lance source cannot set options") {
+		t.Fatalf("lance option error = %v, want lance option rejection", err)
 	}
 }
 
@@ -118,6 +127,49 @@ func TestCompileConnectionSecret(t *testing.T) {
 	if ok || stmt != "" {
 		t.Fatalf("named secret compile = %q ok=%v, want empty ok=false", stmt, ok)
 	}
+
+	stmt, ok, err = compileConnectionSecret("lakehouse", semantic.Connection{
+		Kind:  "ducklake",
+		Path:  "metadata.ducklake",
+		Scope: "s3://analytics-prod/ducklake/",
+		Auth:  semantic.ConnectionAuth{Method: "credential_chain"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = "CREATE OR REPLACE SECRET libredash_lakehouse (TYPE ducklake, PROVIDER credential_chain, SCOPE 's3://analytics-prod/ducklake/')"
+	if !ok || stmt != want {
+		t.Fatalf("ducklake secret = %q ok=%v, want %q ok=true", stmt, ok, want)
+	}
+}
+
+func TestCompileLanceSourceSecrets(t *testing.T) {
+	model := &semantic.Model{
+		Connections: map[string]semantic.Connection{
+			"prod_lake": {
+				Kind:  "s3",
+				Scope: "s3://analytics-prod/",
+				Auth:  semantic.ConnectionAuth{Method: "credential_chain", Profile: "analytics"},
+			},
+			"existing": {
+				Kind:   "s3",
+				Secret: "existing_lance_secret",
+			},
+		},
+		Sources: map[string]semantic.Source{
+			"embeddings": {Connection: "prod_lake", Path: "vectors/products.lance", Format: "lance"},
+			"orders":     {Connection: "prod_lake", Path: "orders.parquet", Format: "parquet"},
+			"named":      {Connection: "existing", Path: "named/products.lance", Format: "lance"},
+		},
+	}
+	statements, err := compileLanceSourceSecrets(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"CREATE OR REPLACE SECRET libredash_prod_lake_lance (TYPE lance, PROVIDER credential_chain, PROFILE 'analytics', SCOPE 's3://analytics-prod/')"}
+	if fmt.Sprint(statements) != fmt.Sprint(want) {
+		t.Fatalf("lance secrets = %#v, want %#v", statements, want)
+	}
 }
 
 func TestCompileDatabaseAttach(t *testing.T) {
@@ -151,23 +203,61 @@ func TestCompileDatabaseAttach(t *testing.T) {
 	}
 }
 
+func TestCompileDuckLakeAttach(t *testing.T) {
+	dir := t.TempDir()
+	metrics := &DuckDBMetrics{dataDir: dir}
+	stmt, err := metrics.compileObjectAttach(&semantic.Model{}, "lakehouse", semantic.Connection{
+		Kind: "ducklake",
+		Path: "metadata.ducklake",
+		Options: map[string]any{
+			"data_path": "data_files",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ATTACH 'ducklake:" + sqlString(filepath.Join(dir, "metadata.ducklake")) + "' AS conn_lakehouse (DATA_PATH '" + sqlString(filepath.Join(dir, "data_files")) + "')"
+	if stmt != want {
+		t.Fatalf("local ducklake attach = %q, want %q", stmt, want)
+	}
+
+	stmt, err = metrics.compileObjectAttach(&semantic.Model{}, "lakehouse", semantic.Connection{
+		Kind:  "ducklake",
+		Scope: "s3://analytics-prod/ducklake/",
+		Path:  "metadata.ducklake",
+		Options: map[string]any{
+			"data_path": "data",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = "ATTACH 'ducklake:s3://analytics-prod/ducklake/metadata.ducklake' AS conn_lakehouse (DATA_PATH 's3://analytics-prod/ducklake/data')"
+	if stmt != want {
+		t.Fatalf("remote ducklake attach = %q, want %q", stmt, want)
+	}
+}
+
 func TestRequiredExtensions(t *testing.T) {
 	model := &semantic.Model{
 		Connections: map[string]semantic.Connection{
 			"lake":  {Kind: "s3"},
 			"azure": {Kind: "azure_blob"},
 			"crm":   {Kind: "postgres"},
+			"duck":  {Kind: "ducklake", Path: "metadata.ducklake"},
 		},
 		Sources: map[string]semantic.Source{
-			"events":   {Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
-			"budget":   {Format: "excel", Location: "budget.xlsx", Connection: "lake"},
-			"orders":   {Format: "delta", Location: "az://warehouse/orders", Connection: "azure"},
-			"archive":  {Format: "vortex", Location: "orders.vortex", Connection: "lake"},
+			"events":   {Format: "parquet", Path: "s3://bucket/events/*.parquet", Connection: "lake"},
+			"budget":   {Format: "excel", Path: "budget.xlsx", Connection: "lake"},
+			"orders":   {Format: "delta", Path: "az://warehouse/orders", Connection: "azure"},
+			"archive":  {Format: "vortex", Path: "orders.vortex", Connection: "lake"},
+			"vectors":  {Format: "lance", Path: "vectors/products.lance", Connection: "lake"},
 			"accounts": {Connection: "crm", Object: "public.accounts"},
+			"lake_tbl": {Connection: "duck", Object: "main.orders"},
 		},
 	}
-	if got := strings.Join(requiredExtensions(model), ","); got != "azure,delta,excel,httpfs,postgres,vortex" {
-		t.Fatalf("required extensions = %q, want azure,delta,excel,httpfs,postgres,vortex", got)
+	if got := strings.Join(requiredExtensions(model), ","); got != "azure,delta,ducklake,excel,httpfs,lance,postgres,vortex" {
+		t.Fatalf("required extensions = %q, want azure,delta,ducklake,excel,httpfs,lance,postgres,vortex", got)
 	}
 }
 
@@ -186,11 +276,13 @@ func TestDuckDBMetricsResolvesSourcePlans(t *testing.T) {
 			},
 			"prod_lake": {Kind: "s3", Scope: "s3://analytics-prod/"},
 			"azure":     {Kind: "azure_blob", Scope: "az://warehouse/"},
+			"vectors":   {Kind: "s3", Scope: "s3://analytics-prod/"},
 		},
 		Sources: map[string]semantic.Source{
-			"orders": {Location: "orders.csv"},
-			"events": {Connection: "prod_lake", Location: "events/*", Format: "parquet"},
-			"delta":  {Connection: "azure", Location: "tables/orders", Format: "delta"},
+			"orders":     {Path: "orders.csv"},
+			"events":     {Connection: "prod_lake", Path: "events/*", Format: "parquet"},
+			"delta":      {Connection: "azure", Path: "tables/orders", Format: "delta"},
+			"embeddings": {Connection: "vectors", Path: "vectors/products.lance"},
 		},
 		Cache: semantic.Cache{Tables: map[string]semantic.CacheTable{
 			"orders_cache": {SQL: "SELECT * FROM raw.orders"},
@@ -229,11 +321,19 @@ func TestDuckDBMetricsResolvesSourcePlans(t *testing.T) {
 		t.Fatalf("delta relation = %q, want %q", relation, want)
 	}
 
+	relation, err = metrics.sourceRelation(model, model.Sources["embeddings"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "SELECT * FROM 's3://analytics-prod/vectors/products.lance'"; relation != want {
+		t.Fatalf("lance relation = %q, want %q", relation, want)
+	}
+
 	bad := model.Sources["events"]
-	bad.Location = "s3://other-bucket/events/*"
+	bad.Path = "s3://other-bucket/events/*"
 	_, err = metrics.sourceRelation(model, bad)
 	if err == nil || !strings.Contains(err.Error(), "outside connection") {
-		t.Fatalf("mismatched remote location error = %v, want outside connection", err)
+		t.Fatalf("mismatched remote path error = %v, want outside connection", err)
 	}
 }
 
@@ -260,7 +360,7 @@ func TestDuckDBMetricsRegistersCSVSources(t *testing.T) {
 			},
 			Sources: map[string]semantic.Source{
 				"orders": {
-					Location:   "orders.csv",
+					Path:       "orders.csv",
 					Connection: "local_files",
 				},
 			},
@@ -363,7 +463,7 @@ func TestDuckDBMetricsValidateFilesIgnoresRemoteSources(t *testing.T) {
 			"lake": {Kind: "s3"},
 		},
 		Sources: map[string]semantic.Source{
-			"events": {Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
+			"events": {Format: "parquet", Path: "s3://bucket/events/*.parquet", Connection: "lake"},
 		},
 	}}
 	if err := metrics.validateFiles(runtime); err != nil {
@@ -378,7 +478,7 @@ func TestDuckDBMetricsValidateFilesUsesLocalConnectionRoot(t *testing.T) {
 			"local_files": {Kind: "local", Root: "fixtures"},
 		},
 		Sources: map[string]semantic.Source{
-			"orders": {Format: "csv", Location: "orders.csv", Connection: "local_files"},
+			"orders": {Format: "csv", Path: "orders.csv", Connection: "local_files"},
 		},
 	}
 	metrics := &DuckDBMetrics{dataDir: dir}

--- a/internal/data/service_test.go
+++ b/internal/data/service_test.go
@@ -16,44 +16,37 @@ import (
 
 func TestCompileSourceRelation(t *testing.T) {
 	cases := map[string]struct {
-		location string
-		source   semantic.Source
-		want     string
+		plan sourcePlan
+		want string
 	}{
 		"csv": {
-			location: "/data/orders.csv",
-			source:   semantic.Source{Type: "file", Format: "csv", Options: map[string]any{"header": true, "sample_size": 1000}},
-			want:     "SELECT * FROM read_csv('/data/orders.csv', header = true, sample_size = 1000)",
+			plan: sourcePlan{kind: "location", format: "csv", location: "/data/orders.csv", options: map[string]any{"header": true, "sample_size": 1000}},
+			want: "SELECT * FROM read_csv('/data/orders.csv', header = true, sample_size = 1000)",
 		},
 		"json": {
-			location: "/data/orders.json",
-			source:   semantic.Source{Type: "file", Format: "json", Options: map[string]any{"format": "array"}},
-			want:     "SELECT * FROM read_json('/data/orders.json', format = 'array')",
+			plan: sourcePlan{kind: "location", format: "json", location: "/data/orders.json", options: map[string]any{"format": "array"}},
+			want: "SELECT * FROM read_json('/data/orders.json', format = 'array')",
 		},
 		"parquet": {
-			location: "s3://bucket/orders/*.parquet",
-			source:   semantic.Source{Type: "file", Format: "parquet", Options: map[string]any{"union_by_name": true}},
-			want:     "SELECT * FROM read_parquet('s3://bucket/orders/*.parquet', union_by_name = true)",
+			plan: sourcePlan{kind: "location", format: "parquet", location: "s3://bucket/orders/*.parquet", options: map[string]any{"union_by_name": true}},
+			want: "SELECT * FROM read_parquet('s3://bucket/orders/*.parquet', union_by_name = true)",
 		},
 		"excel": {
-			location: "/data/budget.xlsx",
-			source:   semantic.Source{Type: "file", Format: "excel", Options: map[string]any{"sheet": "FY2026"}},
-			want:     "SELECT * FROM read_xlsx('/data/budget.xlsx', sheet = 'FY2026')",
+			plan: sourcePlan{kind: "location", format: "excel", location: "/data/budget.xlsx", options: map[string]any{"sheet": "FY2026"}},
+			want: "SELECT * FROM read_xlsx('/data/budget.xlsx', sheet = 'FY2026')",
 		},
 		"delta": {
-			location: "az://warehouse/orders",
-			source:   semantic.Source{Type: "lakehouse", Format: "delta"},
-			want:     "SELECT * FROM delta_scan('az://warehouse/orders')",
+			plan: sourcePlan{kind: "location", format: "delta", location: "az://warehouse/orders"},
+			want: "SELECT * FROM delta_scan('az://warehouse/orders')",
 		},
 		"iceberg": {
-			location: "s3://warehouse/orders/metadata/v1.metadata.json",
-			source:   semantic.Source{Type: "lakehouse", Format: "iceberg", Options: map[string]any{"allow_moved_paths": true}},
-			want:     "SELECT * FROM iceberg_scan('s3://warehouse/orders/metadata/v1.metadata.json', allow_moved_paths = true)",
+			plan: sourcePlan{kind: "location", format: "iceberg", location: "s3://warehouse/orders/metadata/v1.metadata.json", options: map[string]any{"allow_moved_paths": true}},
+			want: "SELECT * FROM iceberg_scan('s3://warehouse/orders/metadata/v1.metadata.json', allow_moved_paths = true)",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			relation, err := compileSourceRelation(tc.location, tc.source)
+			relation, err := compileSourceRelation(tc.plan)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -65,12 +58,7 @@ func TestCompileSourceRelation(t *testing.T) {
 
 	var relation string
 	var err error
-	relation, err = compileSourceRelation("", semantic.Source{
-		Type:       "database",
-		Engine:     "postgres",
-		Connection: "crm",
-		Object:     "public.accounts",
-	})
+	relation, err = compileSourceRelation(sourcePlan{kind: "database", connection: "crm", object: "public.accounts"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +66,7 @@ func TestCompileSourceRelation(t *testing.T) {
 		t.Fatalf("database relation = %q, want %q", relation, want)
 	}
 
-	relation, err = compileSourceRelation("", semantic.Source{Type: "query", Query: "SELECT 1 AS id"})
+	relation, err = compileSourceRelation(sourcePlan{kind: "query", query: "SELECT 1 AS id"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +74,7 @@ func TestCompileSourceRelation(t *testing.T) {
 		t.Fatalf("query relation = %q, want trusted query passthrough", relation)
 	}
 
-	_, err = compileSourceRelation("/data/orders.csv", semantic.Source{Type: "file", Format: "csv", Options: map[string]any{"bad-key": true}})
+	_, err = compileSourceRelation(sourcePlan{kind: "location", format: "csv", location: "/data/orders.csv", options: map[string]any{"bad-key": true}})
 	if err == nil || !strings.Contains(err.Error(), "invalid source option") {
 		t.Fatalf("invalid option error = %v, want invalid source option", err)
 	}
@@ -94,7 +82,7 @@ func TestCompileSourceRelation(t *testing.T) {
 
 func TestCompileConnectionSecret(t *testing.T) {
 	stmt, ok, err := compileConnectionSecret("prod_lake", semantic.Connection{
-		Type:  "s3",
+		Kind:  "s3",
 		Scope: "s3://analytics-prod/",
 		Auth:  semantic.ConnectionAuth{Method: "credential_chain", Profile: "analytics", Params: map[string]any{"region": "us-east-1"}},
 	})
@@ -110,7 +98,7 @@ func TestCompileConnectionSecret(t *testing.T) {
 	}
 
 	stmt, ok, err = compileConnectionSecret("azure_lake", semantic.Connection{
-		Type: "azure",
+		Kind: "azure_blob",
 		Auth: semantic.ConnectionAuth{Method: "credential_chain", Account: "mystorageaccount"},
 	})
 	if err != nil {
@@ -121,7 +109,7 @@ func TestCompileConnectionSecret(t *testing.T) {
 		t.Fatalf("azure secret = %q ok=%v, want %q ok=true", stmt, ok, want)
 	}
 
-	stmt, ok, err = compileConnectionSecret("crm", semantic.Connection{Type: "postgres", Secret: "crm_readonly"})
+	stmt, ok, err = compileConnectionSecret("crm", semantic.Connection{Kind: "postgres", Secret: "crm_readonly"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,29 +120,25 @@ func TestCompileConnectionSecret(t *testing.T) {
 
 func TestCompileDatabaseAttach(t *testing.T) {
 	cases := map[string]struct {
-		engine     string
 		connection semantic.Connection
 		want       string
 	}{
 		"postgres_existing_secret": {
-			engine:     "postgres",
-			connection: semantic.Connection{Type: "postgres", Secret: "crm_readonly"},
+			connection: semantic.Connection{Kind: "postgres", Secret: "crm_readonly"},
 			want:       "ATTACH '' AS conn_crm (TYPE postgres, READ_ONLY, SECRET crm_readonly)",
 		},
 		"mysql_uri": {
-			engine:     "mysql",
-			connection: semantic.Connection{Type: "mysql", Options: map[string]any{"connection_string": "host=localhost database=sales"}},
+			connection: semantic.Connection{Kind: "mysql", Options: map[string]any{"connection_string": "host=localhost database=sales"}},
 			want:       "ATTACH 'host=localhost database=sales' AS conn_crm (TYPE mysql, READ_ONLY)",
 		},
 		"sqlite_path": {
-			engine:     "sqlite",
-			connection: semantic.Connection{Type: "sqlite", Options: map[string]any{"path": "/tmp/source.sqlite"}},
+			connection: semantic.Connection{Kind: "sqlite", Options: map[string]any{"path": "/tmp/source.sqlite"}},
 			want:       "ATTACH '/tmp/source.sqlite' AS conn_crm (TYPE sqlite, READ_ONLY)",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			stmt, err := compileDatabaseAttach("crm", tc.engine, tc.connection)
+			stmt, err := compileDatabaseAttach("crm", tc.connection)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -168,18 +152,85 @@ func TestCompileDatabaseAttach(t *testing.T) {
 func TestRequiredExtensions(t *testing.T) {
 	model := &semantic.Model{
 		Connections: map[string]semantic.Connection{
-			"lake": {Type: "s3"},
-			"crm":  {Type: "postgres"},
+			"lake":  {Kind: "s3"},
+			"azure": {Kind: "azure_blob"},
+			"crm":   {Kind: "postgres"},
 		},
 		Sources: map[string]semantic.Source{
-			"events":   {Type: "file", Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
-			"budget":   {Type: "file", Format: "excel", Location: "budget.xlsx"},
-			"orders":   {Type: "lakehouse", Format: "delta", Location: "az://warehouse/orders"},
-			"accounts": {Type: "database", Engine: "postgres", Connection: "crm", Object: "public.accounts"},
+			"events":   {Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
+			"budget":   {Format: "excel", Location: "budget.xlsx", Connection: "lake"},
+			"orders":   {Format: "delta", Location: "az://warehouse/orders", Connection: "azure"},
+			"accounts": {Connection: "crm", Object: "public.accounts"},
 		},
 	}
 	if got := strings.Join(requiredExtensions(model), ","); got != "azure,delta,excel,httpfs,postgres" {
 		t.Fatalf("required extensions = %q, want azure,delta,excel,httpfs,postgres", got)
+	}
+}
+
+func TestDuckDBMetricsResolvesSourcePlans(t *testing.T) {
+	dir := t.TempDir()
+	model := &semantic.Model{
+		Name:              "test",
+		DefaultConnection: "local_files",
+		Connections: map[string]semantic.Connection{
+			"local_files": {
+				Kind: "local",
+				Root: "fixtures",
+				Defaults: semantic.ConnectionDefaults{
+					Options: map[string]any{"header": true},
+				},
+			},
+			"prod_lake": {Kind: "s3", Scope: "s3://analytics-prod/"},
+			"azure":     {Kind: "azure_blob", Scope: "az://warehouse/"},
+		},
+		Sources: map[string]semantic.Source{
+			"orders": {Location: "orders.csv"},
+			"events": {Connection: "prod_lake", Location: "events/*", Format: "parquet"},
+			"delta":  {Connection: "azure", Location: "tables/orders", Format: "delta"},
+		},
+		Cache: semantic.Cache{Tables: map[string]semantic.CacheTable{
+			"orders_cache": {SQL: "SELECT * FROM raw.orders"},
+		}},
+		Datasets: map[string]semantic.Dataset{
+			"orders": {Source: "orders_cache"},
+		},
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	metrics := &DuckDBMetrics{dataDir: dir}
+
+	relation, err := metrics.sourceRelation(model, model.Sources["orders"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLocal := "SELECT * FROM read_csv('" + sqlString(filepath.Join(dir, "fixtures", "orders.csv")) + "', header = true)"
+	if relation != wantLocal {
+		t.Fatalf("local relation = %q, want %q", relation, wantLocal)
+	}
+
+	relation, err = metrics.sourceRelation(model, model.Sources["events"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "SELECT * FROM read_parquet('s3://analytics-prod/events/*')"; relation != want {
+		t.Fatalf("remote relation = %q, want %q", relation, want)
+	}
+
+	relation, err = metrics.sourceRelation(model, model.Sources["delta"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "SELECT * FROM delta_scan('az://warehouse/tables/orders')"; relation != want {
+		t.Fatalf("delta relation = %q, want %q", relation, want)
+	}
+
+	bad := model.Sources["events"]
+	bad.Location = "s3://other-bucket/events/*"
+	_, err = metrics.sourceRelation(model, bad)
+	if err == nil || !strings.Contains(err.Error(), "outside connection") {
+		t.Fatalf("mismatched remote location error = %v, want outside connection", err)
 	}
 }
 
@@ -196,16 +247,22 @@ func TestDuckDBMetricsRegistersCSVAndQuerySources(t *testing.T) {
 	runtime := &modelRuntime{
 		db: db,
 		model: &semantic.Model{
-			Name: "test",
+			Name:              "test",
+			DefaultConnection: "local_files",
+			Connections: map[string]semantic.Connection{
+				"local_files": {
+					Kind:     "local",
+					Defaults: semantic.ConnectionDefaults{Format: "csv", Options: map[string]any{"header": true}},
+				},
+			},
 			Sources: map[string]semantic.Source{
 				"orders": {
-					Type:     "file",
-					Format:   "csv",
-					Location: "orders.csv",
-					Options:  map[string]any{"header": true},
+					Format:     "csv",
+					Location:   "orders.csv",
+					Connection: "local_files",
+					Options:    map[string]any{"header": true},
 				},
 				"targets": {
-					Type:  "query",
 					Query: "SELECT 'o1' AS order_id, 100::DOUBLE AS target",
 				},
 			},
@@ -276,10 +333,10 @@ func TestDuckDBMetricsRegistersDatabaseSourceTwice(t *testing.T) {
 		model: &semantic.Model{
 			Name: "test",
 			Connections: map[string]semantic.Connection{
-				"crm": {Type: "sqlite", Options: map[string]any{"path": sourcePath}},
+				"crm": {Kind: "sqlite", Options: map[string]any{"path": sourcePath}},
 			},
 			Sources: map[string]semantic.Source{
-				"accounts": {Type: "database", Engine: "sqlite", Connection: "crm", Object: "accounts"},
+				"accounts": {Connection: "crm", Object: "accounts"},
 			},
 			Cache: semantic.Cache{Tables: map[string]semantic.CacheTable{
 				"accounts": {SQL: "SELECT * FROM raw.accounts"},
@@ -305,12 +362,39 @@ func TestDuckDBMetricsRegistersDatabaseSourceTwice(t *testing.T) {
 
 func TestDuckDBMetricsValidateFilesIgnoresRemoteAndQuerySources(t *testing.T) {
 	metrics := &DuckDBMetrics{dataDir: t.TempDir()}
-	runtime := &modelRuntime{model: &semantic.Model{Sources: map[string]semantic.Source{
-		"events":  {Type: "file", Format: "parquet", Location: "s3://bucket/events/*.parquet"},
-		"targets": {Type: "query", Query: "SELECT 1 AS id"},
-	}}}
+	runtime := &modelRuntime{model: &semantic.Model{
+		Connections: map[string]semantic.Connection{
+			"lake": {Kind: "s3"},
+		},
+		Sources: map[string]semantic.Source{
+			"events":  {Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
+			"targets": {Query: "SELECT 1 AS id"},
+		},
+	}}
 	if err := metrics.validateFiles(runtime); err != nil {
 		t.Fatalf("validate files = %v, want nil", err)
+	}
+}
+
+func TestDuckDBMetricsValidateFilesUsesLocalConnectionRoot(t *testing.T) {
+	dir := t.TempDir()
+	model := &semantic.Model{
+		Connections: map[string]semantic.Connection{
+			"local_files": {Kind: "local", Root: "fixtures"},
+		},
+		Sources: map[string]semantic.Source{
+			"orders": {Format: "csv", Location: "orders.csv", Connection: "local_files"},
+		},
+	}
+	metrics := &DuckDBMetrics{dataDir: dir}
+	err := metrics.validateFiles(&modelRuntime{model: model})
+	var missing *MissingDataError
+	if !errors.As(err, &missing) {
+		t.Fatalf("validate files error = %v, want MissingDataError", err)
+	}
+	want := filepath.Join(dir, "fixtures", "orders.csv")
+	if len(missing.Missing) != 1 || missing.Missing[0] != want {
+		t.Fatalf("missing files = %#v, want %q", missing.Missing, want)
 	}
 }
 

--- a/internal/data/service_test.go
+++ b/internal/data/service_test.go
@@ -95,7 +95,11 @@ func TestCompileConnectionSecret(t *testing.T) {
 	stmt, ok, err := compileConnectionSecret("prod_lake", semantic.Connection{
 		Kind:  "s3",
 		Scope: "s3://analytics-prod/",
-		Auth:  semantic.ConnectionAuth{Method: "credential_chain", Profile: "analytics", Params: map[string]any{"region": "us-east-1"}},
+		Auth: semantic.ConnectionAuth{
+			"access_key_id":     "key",
+			"secret_access_key": "secret",
+			"region":            "us-east-1",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -103,41 +107,65 @@ func TestCompileConnectionSecret(t *testing.T) {
 	if !ok {
 		t.Fatal("secret ok = false, want true")
 	}
-	want := "CREATE OR REPLACE SECRET libredash_prod_lake (TYPE s3, PROVIDER credential_chain, PROFILE 'analytics', REGION 'us-east-1', SCOPE 's3://analytics-prod/')"
+	want := "CREATE OR REPLACE SECRET libredash_prod_lake (TYPE s3, PROVIDER config, KEY_ID 'key', REGION 'us-east-1', SECRET 'secret', SCOPE 's3://analytics-prod/')"
 	if stmt != want {
 		t.Fatalf("s3 secret = %q, want %q", stmt, want)
 	}
 
 	stmt, ok, err = compileConnectionSecret("azure_lake", semantic.Connection{
 		Kind: "azure_blob",
-		Auth: semantic.ConnectionAuth{Method: "credential_chain", Account: "mystorageaccount"},
+		Auth: semantic.ConnectionAuth{"connection_string": "DefaultEndpointsProtocol=https;AccountName=mystorageaccount"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = "CREATE OR REPLACE SECRET libredash_azure_lake (TYPE azure, PROVIDER credential_chain, ACCOUNT_NAME 'mystorageaccount')"
+	want = "CREATE OR REPLACE SECRET libredash_azure_lake (TYPE azure, PROVIDER config, CONNECTION_STRING 'DefaultEndpointsProtocol=https;AccountName=mystorageaccount')"
 	if !ok || stmt != want {
 		t.Fatalf("azure secret = %q ok=%v, want %q ok=true", stmt, ok, want)
 	}
 
-	stmt, ok, err = compileConnectionSecret("crm", semantic.Connection{Kind: "postgres", Secret: "crm_readonly"})
+	stmt, ok, err = compileConnectionSecret("azure_lake", semantic.Connection{
+		Kind: "azure_blob",
+		Auth: semantic.ConnectionAuth{
+			"account_name":  "mystorageaccount",
+			"tenant_id":     "tenant",
+			"client_id":     "client",
+			"client_secret": "secret",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = "CREATE OR REPLACE SECRET libredash_azure_lake (TYPE azure, PROVIDER service_principal, ACCOUNT_NAME 'mystorageaccount', CLIENT_ID 'client', CLIENT_SECRET 'secret', TENANT_ID 'tenant')"
+	if !ok || stmt != want {
+		t.Fatalf("azure service principal secret = %q ok=%v, want %q ok=true", stmt, ok, want)
+	}
+
+	stmt, ok, err = compileConnectionSecret("crm", semantic.Connection{
+		Kind: "postgres",
+		Auth: semantic.ConnectionAuth{"connection_string": "postgres://crm"},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ok || stmt != "" {
-		t.Fatalf("named secret compile = %q ok=%v, want empty ok=false", stmt, ok)
+		t.Fatalf("postgres secret = %q ok=%v, want empty ok=false", stmt, ok)
 	}
 
 	stmt, ok, err = compileConnectionSecret("lakehouse", semantic.Connection{
 		Kind:  "ducklake",
 		Path:  "metadata.ducklake",
 		Scope: "s3://analytics-prod/ducklake/",
-		Auth:  semantic.ConnectionAuth{Method: "credential_chain"},
+		Auth: semantic.ConnectionAuth{
+			"access_key_id":     "key",
+			"secret_access_key": "secret",
+			"region":            "us-east-1",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = "CREATE OR REPLACE SECRET libredash_lakehouse (TYPE ducklake, PROVIDER credential_chain, SCOPE 's3://analytics-prod/ducklake/')"
+	want = "CREATE OR REPLACE SECRET libredash_lakehouse (TYPE ducklake, PROVIDER config, KEY_ID 'key', REGION 'us-east-1', SECRET 'secret', SCOPE 's3://analytics-prod/ducklake/')"
 	if !ok || stmt != want {
 		t.Fatalf("ducklake secret = %q ok=%v, want %q ok=true", stmt, ok, want)
 	}
@@ -149,24 +177,26 @@ func TestCompileSourceSecretStatements(t *testing.T) {
 			"prod_lake": {
 				Kind:  "s3",
 				Scope: "s3://analytics-prod/",
-				Auth:  semantic.ConnectionAuth{Method: "credential_chain", Profile: "analytics"},
+				Auth: semantic.ConnectionAuth{
+					"access_key_id":     "key",
+					"secret_access_key": "secret",
+				},
 			},
-			"existing": {
-				Kind:   "s3",
-				Secret: "existing_lance_secret",
+			"public": {
+				Kind: "http",
 			},
 		},
 		Sources: map[string]semantic.Source{
 			"embeddings": {Connection: "prod_lake", Path: "vectors/products.lance", Format: "lance"},
 			"orders":     {Connection: "prod_lake", Path: "orders.parquet", Format: "parquet"},
-			"named":      {Connection: "existing", Path: "named/products.lance", Format: "lance"},
+			"public":     {Connection: "public", Path: "https://example.com/products.lance", Format: "lance"},
 		},
 	}
 	statements, err := compileSourceSecretStatements(model)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"CREATE OR REPLACE SECRET libredash_prod_lake_lance (TYPE lance, PROVIDER credential_chain, PROFILE 'analytics', SCOPE 's3://analytics-prod/')"}
+	want := []string{"CREATE OR REPLACE SECRET libredash_prod_lake_lance (TYPE lance, PROVIDER config, KEY_ID 'key', SECRET 'secret', SCOPE 's3://analytics-prod/')"}
 	if fmt.Sprint(statements) != fmt.Sprint(want) {
 		t.Fatalf("lance secrets = %#v, want %#v", statements, want)
 	}
@@ -177,16 +207,20 @@ func TestCompileDatabaseAttach(t *testing.T) {
 		connection semantic.Connection
 		want       string
 	}{
-		"postgres_existing_secret": {
-			connection: semantic.Connection{Kind: "postgres", Secret: "crm_readonly"},
-			want:       "ATTACH '' AS conn_crm (TYPE postgres, READ_ONLY, SECRET crm_readonly)",
+		"postgres_auth": {
+			connection: semantic.Connection{Kind: "postgres", Auth: semantic.ConnectionAuth{"connection_string": "postgres://crm"}},
+			want:       "ATTACH 'postgres://crm' AS conn_crm (TYPE postgres, READ_ONLY)",
 		},
-		"mysql_uri": {
-			connection: semantic.Connection{Kind: "mysql", Options: map[string]any{"connection_string": "host=localhost database=sales"}},
-			want:       "ATTACH 'host=localhost database=sales' AS conn_crm (TYPE mysql, READ_ONLY)",
+		"mysql_auth": {
+			connection: semantic.Connection{Kind: "mysql", Auth: semantic.ConnectionAuth{"connection_string": "mysql://sales"}},
+			want:       "ATTACH 'mysql://sales' AS conn_crm (TYPE mysql, READ_ONLY)",
 		},
-		"sqlite_path": {
+		"sqlite_option_path": {
 			connection: semantic.Connection{Kind: "sqlite", Options: map[string]any{"path": "/tmp/source.sqlite"}},
+			want:       "ATTACH '/tmp/source.sqlite' AS conn_crm (TYPE sqlite, READ_ONLY)",
+		},
+		"sqlite_auth_path": {
+			connection: semantic.Connection{Kind: "sqlite", Auth: semantic.ConnectionAuth{"path": "/tmp/source.sqlite"}},
 			want:       "ATTACH '/tmp/source.sqlite' AS conn_crm (TYPE sqlite, READ_ONLY)",
 		},
 	}
@@ -274,9 +308,9 @@ func TestDuckDBMetricsResolvesSourcePlans(t *testing.T) {
 					Options: map[string]any{"header": true},
 				},
 			},
-			"prod_lake": {Kind: "s3", Scope: "s3://analytics-prod/"},
-			"azure":     {Kind: "azure_blob", Scope: "az://warehouse/"},
-			"vectors":   {Kind: "s3", Scope: "s3://analytics-prod/"},
+			"prod_lake": {Kind: "s3", Scope: "s3://analytics-prod/", Auth: semantic.ConnectionAuth{"access_key_id": "key", "secret_access_key": "secret"}},
+			"azure":     {Kind: "azure_blob", Scope: "az://warehouse/", Auth: semantic.ConnectionAuth{"connection_string": "DefaultEndpointsProtocol=https;AccountName=warehouse"}},
+			"vectors":   {Kind: "s3", Scope: "s3://analytics-prod/", Auth: semantic.ConnectionAuth{"access_key_id": "key", "secret_access_key": "secret"}},
 		},
 		Sources: map[string]semantic.Source{
 			"orders":     {Path: "orders.csv"},

--- a/internal/data/service_test.go
+++ b/internal/data/service_test.go
@@ -72,12 +72,12 @@ func TestCompileSourceRelation(t *testing.T) {
 		})
 	}
 
-	relation, err := compileSourceRelation(sourcePlan{kind: "database", connection: "crm", object: "public.accounts"})
+	relation, err := compileSourceRelation(sourcePlan{kind: "object", connection: "crm", object: "public.accounts"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if want := "SELECT * FROM conn_crm.public.accounts"; relation != want {
-		t.Fatalf("database relation = %q, want %q", relation, want)
+		t.Fatalf("object relation = %q, want %q", relation, want)
 	}
 
 	_, err = compileSourceRelation(sourcePlan{kind: "path", format: "csv", path: "/data/orders.csv", options: map[string]any{"bad-key": true}})
@@ -143,7 +143,7 @@ func TestCompileConnectionSecret(t *testing.T) {
 	}
 }
 
-func TestCompileLanceSourceSecrets(t *testing.T) {
+func TestCompileSourceSecretStatements(t *testing.T) {
 	model := &semantic.Model{
 		Connections: map[string]semantic.Connection{
 			"prod_lake": {
@@ -162,7 +162,7 @@ func TestCompileLanceSourceSecrets(t *testing.T) {
 			"named":      {Connection: "existing", Path: "named/products.lance", Format: "lance"},
 		},
 	}
-	statements, err := compileLanceSourceSecrets(model)
+	statements, err := compileSourceSecretStatements(model)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/data/service_test.go
+++ b/internal/data/service_test.go
@@ -35,6 +35,18 @@ func TestCompileSourceRelation(t *testing.T) {
 			plan: sourcePlan{kind: "location", format: "excel", location: "/data/budget.xlsx", options: map[string]any{"sheet": "FY2026"}},
 			want: "SELECT * FROM read_xlsx('/data/budget.xlsx', sheet = 'FY2026')",
 		},
+		"text": {
+			plan: sourcePlan{kind: "location", format: "text", location: "/data/readme.txt"},
+			want: "SELECT * FROM read_text('/data/readme.txt')",
+		},
+		"blob": {
+			plan: sourcePlan{kind: "location", format: "blob", location: "/data/archive.blob"},
+			want: "SELECT * FROM read_blob('/data/archive.blob')",
+		},
+		"vortex": {
+			plan: sourcePlan{kind: "location", format: "vortex", location: "/data/orders.vortex"},
+			want: "SELECT * FROM read_vortex('/data/orders.vortex')",
+		},
 		"delta": {
 			plan: sourcePlan{kind: "location", format: "delta", location: "az://warehouse/orders"},
 			want: "SELECT * FROM delta_scan('az://warehouse/orders')",
@@ -56,22 +68,12 @@ func TestCompileSourceRelation(t *testing.T) {
 		})
 	}
 
-	var relation string
-	var err error
-	relation, err = compileSourceRelation(sourcePlan{kind: "database", connection: "crm", object: "public.accounts"})
+	relation, err := compileSourceRelation(sourcePlan{kind: "database", connection: "crm", object: "public.accounts"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if want := "SELECT * FROM conn_crm.public.accounts"; relation != want {
 		t.Fatalf("database relation = %q, want %q", relation, want)
-	}
-
-	relation, err = compileSourceRelation(sourcePlan{kind: "query", query: "SELECT 1 AS id"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if relation != "SELECT 1 AS id" {
-		t.Fatalf("query relation = %q, want trusted query passthrough", relation)
 	}
 
 	_, err = compileSourceRelation(sourcePlan{kind: "location", format: "csv", location: "/data/orders.csv", options: map[string]any{"bad-key": true}})
@@ -160,11 +162,12 @@ func TestRequiredExtensions(t *testing.T) {
 			"events":   {Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
 			"budget":   {Format: "excel", Location: "budget.xlsx", Connection: "lake"},
 			"orders":   {Format: "delta", Location: "az://warehouse/orders", Connection: "azure"},
+			"archive":  {Format: "vortex", Location: "orders.vortex", Connection: "lake"},
 			"accounts": {Connection: "crm", Object: "public.accounts"},
 		},
 	}
-	if got := strings.Join(requiredExtensions(model), ","); got != "azure,delta,excel,httpfs,postgres" {
-		t.Fatalf("required extensions = %q, want azure,delta,excel,httpfs,postgres", got)
+	if got := strings.Join(requiredExtensions(model), ","); got != "azure,delta,excel,httpfs,postgres,vortex" {
+		t.Fatalf("required extensions = %q, want azure,delta,excel,httpfs,postgres,vortex", got)
 	}
 }
 
@@ -234,7 +237,7 @@ func TestDuckDBMetricsResolvesSourcePlans(t *testing.T) {
 	}
 }
 
-func TestDuckDBMetricsRegistersCSVAndQuerySources(t *testing.T) {
+func TestDuckDBMetricsRegistersCSVSources(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "orders.csv", "order_id,revenue\no1,10.50\no2,20.25\n")
 	db, err := sql.Open("duckdb", filepath.Join(dir, "test.duckdb"))
@@ -252,30 +255,30 @@ func TestDuckDBMetricsRegistersCSVAndQuerySources(t *testing.T) {
 			Connections: map[string]semantic.Connection{
 				"local_files": {
 					Kind:     "local",
-					Defaults: semantic.ConnectionDefaults{Format: "csv", Options: map[string]any{"header": true}},
+					Defaults: semantic.ConnectionDefaults{Options: map[string]any{"header": true}},
 				},
 			},
 			Sources: map[string]semantic.Source{
 				"orders": {
-					Format:     "csv",
 					Location:   "orders.csv",
 					Connection: "local_files",
-					Options:    map[string]any{"header": true},
-				},
-				"targets": {
-					Query: "SELECT 'o1' AS order_id, 100::DOUBLE AS target",
 				},
 			},
 			Cache: semantic.Cache{Tables: map[string]semantic.CacheTable{
-				"joined": {
+				"orders": {
 					SQL: `
-						SELECT o.order_id, try_cast(o.revenue AS DOUBLE) AS revenue, t.target
-						FROM raw.orders o
-						LEFT JOIN raw.targets t ON t.order_id = o.order_id
+						SELECT order_id, try_cast(revenue AS DOUBLE) AS revenue
+						FROM raw.orders
 					`,
 				},
 			}},
+			Datasets: map[string]semantic.Dataset{
+				"orders": {Source: "orders"},
+			},
 		},
+	}
+	if err := runtime.model.Validate(); err != nil {
+		t.Fatalf("validate model: %v", err)
 	}
 	if err := metrics.registerSourceViews(context.Background(), runtime); err != nil {
 		t.Fatalf("register sources: %v", err)
@@ -285,18 +288,11 @@ func TestDuckDBMetricsRegistersCSVAndQuerySources(t *testing.T) {
 	}
 
 	var total float64
-	if err := db.QueryRowContext(context.Background(), "SELECT SUM(revenue) FROM cache.joined").Scan(&total); err != nil {
+	if err := db.QueryRowContext(context.Background(), "SELECT SUM(revenue) FROM cache.orders").Scan(&total); err != nil {
 		t.Fatal(err)
 	}
 	if total != 30.75 {
 		t.Fatalf("total revenue = %v, want 30.75", total)
-	}
-	var target float64
-	if err := db.QueryRowContext(context.Background(), "SELECT target FROM cache.joined WHERE order_id = 'o1'").Scan(&target); err != nil {
-		t.Fatal(err)
-	}
-	if target != 100 {
-		t.Fatalf("target = %v, want 100", target)
 	}
 }
 
@@ -360,15 +356,14 @@ func TestDuckDBMetricsRegistersDatabaseSourceTwice(t *testing.T) {
 	}
 }
 
-func TestDuckDBMetricsValidateFilesIgnoresRemoteAndQuerySources(t *testing.T) {
+func TestDuckDBMetricsValidateFilesIgnoresRemoteSources(t *testing.T) {
 	metrics := &DuckDBMetrics{dataDir: t.TempDir()}
 	runtime := &modelRuntime{model: &semantic.Model{
 		Connections: map[string]semantic.Connection{
 			"lake": {Kind: "s3"},
 		},
 		Sources: map[string]semantic.Source{
-			"events":  {Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
-			"targets": {Query: "SELECT 1 AS id"},
+			"events": {Format: "parquet", Location: "s3://bucket/events/*.parquet", Connection: "lake"},
 		},
 	}}
 	if err := metrics.validateFiles(runtime); err != nil {

--- a/internal/data/sources.go
+++ b/internal/data/sources.go
@@ -1,0 +1,364 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Yacobolo/libredash/internal/semantic"
+)
+
+func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *modelRuntime) error {
+	for _, extension := range requiredExtensions(runtime.model) {
+		if err := validateIdentifier(extension); err != nil {
+			return fmt.Errorf("invalid extension %q: %w", extension, err)
+		}
+		if _, err := runtime.db.ExecContext(ctx, "INSTALL "+extension); err != nil {
+			return fmt.Errorf("installing DuckDB extension %s: %w", extension, err)
+		}
+		if _, err := runtime.db.ExecContext(ctx, "LOAD "+extension); err != nil {
+			return fmt.Errorf("loading DuckDB extension %s: %w", extension, err)
+		}
+	}
+	for _, name := range sortedKeys(runtime.model.Connections) {
+		stmt, ok, err := compileConnectionSecret(name, runtime.model.Connections[name])
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if _, err := runtime.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("creating DuckDB secret for connection %s: %w", name, err)
+		}
+	}
+	if runtime.attachedConnections == nil {
+		runtime.attachedConnections = map[string]struct{}{}
+	}
+	for _, sourceName := range sortedKeys(runtime.model.Sources) {
+		source := runtime.model.Sources[sourceName]
+		if source.Type != "database" {
+			continue
+		}
+		if _, ok := runtime.attachedConnections[source.Connection]; ok {
+			continue
+		}
+		connection := runtime.model.Connections[source.Connection]
+		stmt, err := compileDatabaseAttach(source.Connection, source.Engine, connection)
+		if err != nil {
+			return err
+		}
+		if _, err := runtime.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("attaching database connection %s: %w", source.Connection, err)
+		}
+		runtime.attachedConnections[source.Connection] = struct{}{}
+	}
+	return nil
+}
+
+func (m *DuckDBMetrics) sourceRelation(source semantic.Source) (string, error) {
+	location := source.Location
+	if source.Type == "file" && source.Location != "" && isLocalSourceLocation(source.Location) {
+		location = filepath.Join(m.dataDir, source.Location)
+	}
+	return compileSourceRelation(location, source)
+}
+
+func compileSourceRelation(location string, source semantic.Source) (string, error) {
+	switch source.Type {
+	case "file":
+		switch source.Format {
+		case "csv":
+			return scanRelation("read_csv", location, source.Options)
+		case "json":
+			return scanRelation("read_json", location, source.Options)
+		case "parquet":
+			return scanRelation("read_parquet", location, source.Options)
+		case "excel":
+			return scanRelation("read_xlsx", location, source.Options)
+		default:
+			return "", fmt.Errorf("unsupported file format %q", source.Format)
+		}
+	case "lakehouse":
+		switch source.Format {
+		case "delta":
+			return scanRelation("delta_scan", location, source.Options)
+		case "iceberg":
+			return scanRelation("iceberg_scan", location, source.Options)
+		default:
+			return "", fmt.Errorf("unsupported lakehouse format %q", source.Format)
+		}
+	case "database":
+		object, err := qualifiedSQLName(source.Object)
+		if err != nil {
+			return "", err
+		}
+		alias, err := databaseAlias(source.Connection)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("SELECT * FROM %s.%s", alias, object), nil
+	case "query":
+		return source.Query, nil
+	default:
+		return "", fmt.Errorf("unsupported source type %q", source.Type)
+	}
+}
+
+func scanRelation(function, location string, options map[string]any) (string, error) {
+	optionSQL, err := sqlOptions(options)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("SELECT * FROM %s('%s'%s)", function, sqlString(location), optionSQL), nil
+}
+
+func sqlOptions(options map[string]any) (string, error) {
+	if len(options) == 0 {
+		return "", nil
+	}
+	keys := make([]string, 0, len(options))
+	for key := range options {
+		if err := validateIdentifier(key); err != nil {
+			return "", fmt.Errorf("invalid source option %q: %w", key, err)
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var builder strings.Builder
+	for _, key := range keys {
+		builder.WriteString(", ")
+		builder.WriteString(key)
+		builder.WriteString(" = ")
+		builder.WriteString(sqlLiteral(options[key]))
+	}
+	return builder.String(), nil
+}
+
+func sqlLiteral(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return "NULL"
+	case string:
+		return "'" + sqlString(v) + "'"
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case []any:
+		values := make([]string, 0, len(v))
+		for _, item := range v {
+			values = append(values, sqlLiteral(item))
+		}
+		return "[" + strings.Join(values, ", ") + "]"
+	case []string:
+		values := make([]string, 0, len(v))
+		for _, item := range v {
+			values = append(values, sqlLiteral(item))
+		}
+		return "[" + strings.Join(values, ", ") + "]"
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		fields := make([]string, 0, len(keys))
+		for _, key := range keys {
+			fields = append(fields, "'"+sqlString(key)+"': "+sqlLiteral(v[key]))
+		}
+		return "{" + strings.Join(fields, ", ") + "}"
+	default:
+		return "'" + sqlString(fmt.Sprint(v)) + "'"
+	}
+}
+
+func requiredExtensions(model *semantic.Model) []string {
+	extensions := map[string]struct{}{}
+	addConnection := func(connectionType string) {
+		switch connectionType {
+		case "s3", "r2", "gcs", "http":
+			extensions["httpfs"] = struct{}{}
+		case "azure":
+			extensions["azure"] = struct{}{}
+		case "postgres", "mysql", "sqlite":
+			extensions[connectionType] = struct{}{}
+		}
+	}
+	addLocation := func(location string) {
+		switch {
+		case strings.HasPrefix(location, "s3://"), strings.HasPrefix(location, "r2://"), strings.HasPrefix(location, "gcs://"), strings.HasPrefix(location, "gs://"), strings.HasPrefix(location, "http://"), strings.HasPrefix(location, "https://"):
+			extensions["httpfs"] = struct{}{}
+		case strings.HasPrefix(location, "az://"), strings.HasPrefix(location, "azure://"), strings.HasPrefix(location, "abfss://"):
+			extensions["azure"] = struct{}{}
+		}
+	}
+	for _, name := range sortedKeys(model.Connections) {
+		addConnection(model.Connections[name].Type)
+	}
+	for _, name := range sortedKeys(model.Sources) {
+		source := model.Sources[name]
+		addLocation(source.Location)
+		switch source.Type {
+		case "file":
+			if source.Format == "excel" {
+				extensions["excel"] = struct{}{}
+			}
+		case "lakehouse":
+			extensions[source.Format] = struct{}{}
+		case "database":
+			extensions[source.Engine] = struct{}{}
+		}
+	}
+	return sortedKeys(extensions)
+}
+
+func compileConnectionSecret(name string, connection semantic.Connection) (string, bool, error) {
+	if connection.Secret != "" {
+		return "", false, nil
+	}
+	if connection.Auth.Method == "" && len(connection.Auth.Params) == 0 && connection.Auth.Profile == "" && connection.Auth.Chain == "" && connection.Auth.Account == "" && connection.Scope == "" {
+		return "", false, nil
+	}
+	secret, err := connectionSecretName(name, connection)
+	if err != nil {
+		return "", false, err
+	}
+	parts := []string{"TYPE " + connection.Type}
+	if connection.Auth.Method != "" {
+		if err := validateIdentifier(connection.Auth.Method); err != nil {
+			return "", false, fmt.Errorf("invalid auth method %q: %w", connection.Auth.Method, err)
+		}
+		parts = append(parts, "PROVIDER "+connection.Auth.Method)
+	}
+	if connection.Auth.Profile != "" {
+		parts = append(parts, "PROFILE '"+sqlString(connection.Auth.Profile)+"'")
+	}
+	if connection.Auth.Chain != "" {
+		parts = append(parts, "CHAIN '"+sqlString(connection.Auth.Chain)+"'")
+	}
+	if connection.Auth.Account != "" {
+		parts = append(parts, "ACCOUNT_NAME '"+sqlString(connection.Auth.Account)+"'")
+	}
+	for _, key := range sortedKeys(connection.Auth.Params) {
+		if err := validateIdentifier(key); err != nil {
+			return "", false, fmt.Errorf("invalid auth param %q: %w", key, err)
+		}
+		parts = append(parts, strings.ToUpper(key)+" "+sqlLiteral(connection.Auth.Params[key]))
+	}
+	if connection.Scope != "" {
+		parts = append(parts, "SCOPE '"+sqlString(connection.Scope)+"'")
+	}
+	return fmt.Sprintf("CREATE OR REPLACE SECRET %s (%s)", secret, strings.Join(parts, ", ")), true, nil
+}
+
+func compileDatabaseAttach(connectionName, engine string, connection semantic.Connection) (string, error) {
+	alias, err := databaseAlias(connectionName)
+	if err != nil {
+		return "", err
+	}
+	connectionString, err := connectionStringOption(connection)
+	if err != nil {
+		return "", err
+	}
+	parts := []string{"TYPE " + engine, "READ_ONLY"}
+	if secret, ok, err := databaseAttachSecret(connectionName, connection); err != nil {
+		return "", err
+	} else if ok {
+		parts = append(parts, "SECRET "+secret)
+	}
+	return fmt.Sprintf("ATTACH '%s' AS %s (%s)", sqlString(connectionString), alias, strings.Join(parts, ", ")), nil
+}
+
+func databaseAttachSecret(connectionName string, connection semantic.Connection) (string, bool, error) {
+	if connection.Secret != "" {
+		if err := validateIdentifier(connection.Secret); err != nil {
+			return "", false, fmt.Errorf("invalid connection secret %q: %w", connection.Secret, err)
+		}
+		return connection.Secret, true, nil
+	}
+	if connection.Auth.Method == "" && len(connection.Auth.Params) == 0 && connection.Auth.Profile == "" && connection.Auth.Chain == "" && connection.Auth.Account == "" {
+		return "", false, nil
+	}
+	secret, err := connectionSecretName(connectionName, connection)
+	if err != nil {
+		return "", false, err
+	}
+	return secret, true, nil
+}
+
+func connectionSecretName(name string, connection semantic.Connection) (string, error) {
+	if connection.Secret != "" {
+		if err := validateIdentifier(connection.Secret); err != nil {
+			return "", fmt.Errorf("invalid connection secret %q: %w", connection.Secret, err)
+		}
+		return connection.Secret, nil
+	}
+	if err := validateIdentifier(name); err != nil {
+		return "", fmt.Errorf("invalid connection %q: %w", name, err)
+	}
+	return "libredash_" + name, nil
+}
+
+func connectionStringOption(connection semantic.Connection) (string, error) {
+	for key := range connection.Options {
+		if !supportsDatabaseConnectionOption(key) {
+			return "", fmt.Errorf("unsupported database connection option %q", key)
+		}
+	}
+	for _, key := range []string{"connection_string", "uri", "path", "database"} {
+		if value, ok := connection.Options[key]; ok {
+			return fmt.Sprint(value), nil
+		}
+	}
+	return "", nil
+}
+
+func supportsDatabaseConnectionOption(option string) bool {
+	switch option {
+	case "connection_string", "uri", "path", "database":
+		return true
+	default:
+		return false
+	}
+}
+
+func databaseAlias(connection string) (string, error) {
+	if err := validateIdentifier(connection); err != nil {
+		return "", fmt.Errorf("invalid database connection %q: %w", connection, err)
+	}
+	return "conn_" + connection, nil
+}
+
+func qualifiedSQLName(name string) (string, error) {
+	parts := strings.Split(name, ".")
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if err := validateIdentifier(part); err != nil {
+			return "", fmt.Errorf("invalid database object %q: %w", name, err)
+		}
+		quoted = append(quoted, part)
+	}
+	return strings.Join(quoted, "."), nil
+}
+
+func isLocalSourceLocation(location string) bool {
+	for _, prefix := range []string{"s3://", "r2://", "gcs://", "gs://", "az://", "azure://", "abfss://", "http://", "https://", "file://"} {
+		if strings.HasPrefix(location, prefix) {
+			return false
+		}
+	}
+	return !strings.Contains(location, "://")
+}

--- a/internal/data/sources.go
+++ b/internal/data/sources.go
@@ -305,7 +305,7 @@ func compileSourceSecretStatements(model *semantic.Model) ([]string, error) {
 			continue
 		}
 		connection := model.Connections[source.Connection]
-		if connection.Secret != "" || connection.Auth.Method == "" && len(connection.Auth.Params) == 0 && connection.Auth.Profile == "" && connection.Auth.Chain == "" && connection.Auth.Account == "" && connection.Scope == "" {
+		if len(connection.Auth) == 0 {
 			continue
 		}
 		stmt, ok, err := compileTypedConnectionSecret(source.Connection+"_"+format.SourceSecretType, connection, format.SourceSecretType)
@@ -329,46 +329,73 @@ func compileConnectionSecret(name string, connection semantic.Connection) (strin
 	if !ok || connectionSpec.SecretType == "" {
 		return "", false, nil
 	}
+	if connectionSpec.AttachKind == sourcereg.AttachDatabase {
+		return "", false, nil
+	}
 	return compileTypedConnectionSecret(name, connection, connectionSpec.SecretType)
 }
 
 func compileTypedConnectionSecret(name string, connection semantic.Connection, secretType string) (string, bool, error) {
-	if connection.Secret != "" {
+	if len(connection.Auth) == 0 {
 		return "", false, nil
 	}
-	if connection.Auth.Method == "" && len(connection.Auth.Params) == 0 && connection.Auth.Profile == "" && connection.Auth.Chain == "" && connection.Auth.Account == "" && connection.Scope == "" {
-		return "", false, nil
-	}
-	secret, err := connectionSecretName(name, connection)
+	secret, err := connectionSecretName(name)
 	if err != nil {
 		return "", false, err
 	}
-	parts := []string{"TYPE " + secretType}
-	if connection.Auth.Method != "" {
-		if err := validateIdentifier(connection.Auth.Method); err != nil {
-			return "", false, fmt.Errorf("invalid auth method %q: %w", connection.Auth.Method, err)
-		}
-		parts = append(parts, "PROVIDER "+connection.Auth.Method)
-	}
-	if connection.Auth.Profile != "" {
-		parts = append(parts, "PROFILE '"+sqlString(connection.Auth.Profile)+"'")
-	}
-	if connection.Auth.Chain != "" {
-		parts = append(parts, "CHAIN '"+sqlString(connection.Auth.Chain)+"'")
-	}
-	if connection.Auth.Account != "" {
-		parts = append(parts, "ACCOUNT_NAME '"+sqlString(connection.Auth.Account)+"'")
-	}
-	for _, key := range sortedKeys(connection.Auth.Params) {
+	parts := []string{"TYPE " + secretType, "PROVIDER " + duckDBSecretProvider(secretType, connection.Auth)}
+	for _, key := range sortedKeys(connection.Auth) {
 		if err := validateIdentifier(key); err != nil {
 			return "", false, fmt.Errorf("invalid auth param %q: %w", key, err)
 		}
-		parts = append(parts, strings.ToUpper(key)+" "+sqlLiteral(connection.Auth.Params[key]))
+		parts = append(parts, duckDBAuthParameter(key)+" "+sqlLiteral(connection.Auth[key]))
 	}
 	if connection.Scope != "" {
 		parts = append(parts, "SCOPE '"+sqlString(connection.Scope)+"'")
 	}
 	return fmt.Sprintf("CREATE OR REPLACE SECRET %s (%s)", secret, strings.Join(parts, ", ")), true, nil
+}
+
+func duckDBSecretProvider(secretType string, auth semantic.ConnectionAuth) string {
+	if secretType == "azure" {
+		if _, hasTenant := auth["tenant_id"]; hasTenant {
+			if _, hasClient := auth["client_id"]; hasClient {
+				if _, hasSecret := auth["client_secret"]; hasSecret {
+					return "service_principal"
+				}
+			}
+		}
+	}
+	return "config"
+}
+
+func duckDBAuthParameter(key string) string {
+	switch key {
+	case "access_key_id":
+		return "KEY_ID"
+	case "secret_access_key":
+		return "SECRET"
+	case "account_name":
+		return "ACCOUNT_NAME"
+	case "account_id":
+		return "ACCOUNT_ID"
+	case "client_id":
+		return "CLIENT_ID"
+	case "client_secret":
+		return "CLIENT_SECRET"
+	case "connection_string":
+		return "CONNECTION_STRING"
+	case "session_token":
+		return "SESSION_TOKEN"
+	case "tenant_id":
+		return "TENANT_ID"
+	case "url_style":
+		return "URL_STYLE"
+	case "use_ssl":
+		return "USE_SSL"
+	default:
+		return strings.ToUpper(key)
+	}
 }
 
 func (m *DuckDBMetrics) compileObjectAttach(model *semantic.Model, connectionName string, connection semantic.Connection) (string, error) {
@@ -448,29 +475,23 @@ func (m *DuckDBMetrics) resolvePathInConnectionScope(_ *semantic.Model, connecti
 }
 
 func databaseAttachSecret(connectionName string, connection semantic.Connection) (string, bool, error) {
-	if connection.Secret != "" {
-		if err := validateIdentifier(connection.Secret); err != nil {
-			return "", false, fmt.Errorf("invalid connection secret %q: %w", connection.Secret, err)
-		}
-		return connection.Secret, true, nil
-	}
-	if connection.Auth.Method == "" && len(connection.Auth.Params) == 0 && connection.Auth.Profile == "" && connection.Auth.Chain == "" && connection.Auth.Account == "" {
+	if len(connection.Auth) == 0 {
 		return "", false, nil
 	}
-	secret, err := connectionSecretName(connectionName, connection)
+	if _, ok := connection.Auth["connection_string"]; ok {
+		return "", false, nil
+	}
+	if _, ok := connection.Auth["path"]; ok {
+		return "", false, nil
+	}
+	secret, err := connectionSecretName(connectionName)
 	if err != nil {
 		return "", false, err
 	}
 	return secret, true, nil
 }
 
-func connectionSecretName(name string, connection semantic.Connection) (string, error) {
-	if connection.Secret != "" {
-		if err := validateIdentifier(connection.Secret); err != nil {
-			return "", fmt.Errorf("invalid connection secret %q: %w", connection.Secret, err)
-		}
-		return connection.Secret, nil
-	}
+func connectionSecretName(name string) (string, error) {
 	if err := validateIdentifier(name); err != nil {
 		return "", fmt.Errorf("invalid connection %q: %w", name, err)
 	}
@@ -484,8 +505,19 @@ func connectionStringOption(connection semantic.Connection) (string, error) {
 			return "", fmt.Errorf("unsupported database connection option %q", key)
 		}
 	}
-	for _, key := range []string{"connection_string", "uri", "path", "database"} {
-		if value, ok := connection.Options[key]; ok {
+	if len(connection.Auth) > 0 {
+		if value, ok := connection.Auth["connection_string"]; ok {
+			return fmt.Sprint(value), nil
+		}
+		if connection.Kind == "sqlite" {
+			if value, ok := connection.Auth["path"]; ok {
+				return fmt.Sprint(value), nil
+			}
+		}
+		return "", nil
+	}
+	if connection.Kind == "sqlite" {
+		if value, ok := connection.Options["path"]; ok {
 			return fmt.Sprint(value), nil
 		}
 	}

--- a/internal/data/sources.go
+++ b/internal/data/sources.go
@@ -40,14 +40,14 @@ func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *model
 	}
 	for _, sourceName := range sortedKeys(runtime.model.Sources) {
 		source := runtime.model.Sources[sourceName]
-		if source.Type != "database" {
+		if source.Kind() != "database" {
 			continue
 		}
 		if _, ok := runtime.attachedConnections[source.Connection]; ok {
 			continue
 		}
 		connection := runtime.model.Connections[source.Connection]
-		stmt, err := compileDatabaseAttach(source.Connection, source.Engine, connection)
+		stmt, err := compileDatabaseAttach(source.Connection, connection)
 		if err != nil {
 			return err
 		}
@@ -59,52 +59,115 @@ func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *model
 	return nil
 }
 
-func (m *DuckDBMetrics) sourceRelation(source semantic.Source) (string, error) {
-	location := source.Location
-	if source.Type == "file" && source.Location != "" && isLocalSourceLocation(source.Location) {
-		location = filepath.Join(m.dataDir, source.Location)
-	}
-	return compileSourceRelation(location, source)
+type sourcePlan struct {
+	kind       string
+	format     string
+	location   string
+	connection string
+	object     string
+	query      string
+	options    map[string]any
 }
 
-func compileSourceRelation(location string, source semantic.Source) (string, error) {
-	switch source.Type {
-	case "file":
-		switch source.Format {
-		case "csv":
-			return scanRelation("read_csv", location, source.Options)
-		case "json":
-			return scanRelation("read_json", location, source.Options)
-		case "parquet":
-			return scanRelation("read_parquet", location, source.Options)
-		case "excel":
-			return scanRelation("read_xlsx", location, source.Options)
-		default:
-			return "", fmt.Errorf("unsupported file format %q", source.Format)
+func (m *DuckDBMetrics) sourceRelation(model *semantic.Model, source semantic.Source) (string, error) {
+	plan, err := m.resolveSourcePlan(model, source)
+	if err != nil {
+		return "", err
+	}
+	return compileSourceRelation(plan)
+}
+
+func (m *DuckDBMetrics) resolveSourcePlan(model *semantic.Model, source semantic.Source) (sourcePlan, error) {
+	plan := sourcePlan{
+		kind:       source.Kind(),
+		format:     source.Format,
+		connection: source.Connection,
+		object:     source.Object,
+		query:      source.Query,
+		options:    source.Options,
+	}
+	if source.Location == "" {
+		return plan, nil
+	}
+	location, err := m.resolveSourceLocation(model, source)
+	if err != nil {
+		return plan, err
+	}
+	plan.location = location
+	return plan, nil
+}
+
+func (m *DuckDBMetrics) resolveSourceLocation(model *semantic.Model, source semantic.Source) (string, error) {
+	connection := model.Connections[source.Connection]
+	switch connection.Kind {
+	case "local":
+		if filepath.IsAbs(source.Location) {
+			return source.Location, nil
 		}
-	case "lakehouse":
-		switch source.Format {
+		root := connection.Root
+		if root == "" {
+			root = m.dataDir
+		} else if !filepath.IsAbs(root) {
+			root = filepath.Join(m.dataDir, root)
+		}
+		return filepath.Join(root, source.Location), nil
+	default:
+		if connection.Scope == "" {
+			return source.Location, nil
+		}
+		if isLocalSourceLocation(source.Location) {
+			return joinRemoteScope(connection.Scope, source.Location), nil
+		}
+		if !withinRemoteScope(connection.Scope, source.Location) {
+			return "", fmt.Errorf("location %q is outside connection %q scope %q", source.Location, source.Connection, connection.Scope)
+		}
+		return source.Location, nil
+	}
+}
+
+func joinRemoteScope(scope, location string) string {
+	return strings.TrimRight(scope, "/") + "/" + strings.TrimLeft(location, "/")
+}
+
+func withinRemoteScope(scope, location string) bool {
+	scope = strings.TrimRight(scope, "/")
+	location = strings.TrimRight(location, "/")
+	return location == scope || strings.HasPrefix(location, scope+"/")
+}
+
+func compileSourceRelation(plan sourcePlan) (string, error) {
+	switch plan.kind {
+	case "location":
+		switch plan.format {
+		case "csv":
+			return scanRelation("read_csv", plan.location, plan.options)
+		case "json":
+			return scanRelation("read_json", plan.location, plan.options)
+		case "parquet":
+			return scanRelation("read_parquet", plan.location, plan.options)
+		case "excel":
+			return scanRelation("read_xlsx", plan.location, plan.options)
 		case "delta":
-			return scanRelation("delta_scan", location, source.Options)
+			return scanRelation("delta_scan", plan.location, plan.options)
 		case "iceberg":
-			return scanRelation("iceberg_scan", location, source.Options)
+			return scanRelation("iceberg_scan", plan.location, plan.options)
 		default:
-			return "", fmt.Errorf("unsupported lakehouse format %q", source.Format)
+			return "", fmt.Errorf("unsupported source format %q", plan.format)
 		}
 	case "database":
-		object, err := qualifiedSQLName(source.Object)
+		object, err := qualifiedSQLName(plan.object)
 		if err != nil {
 			return "", err
 		}
-		alias, err := databaseAlias(source.Connection)
+		alias, err := databaseAlias(plan.connection)
 		if err != nil {
 			return "", err
 		}
 		return fmt.Sprintf("SELECT * FROM %s.%s", alias, object), nil
 	case "query":
-		return source.Query, nil
+		return plan.query, nil
 	default:
-		return "", fmt.Errorf("unsupported source type %q", source.Type)
+		return "", fmt.Errorf("unsupported source kind %q", plan.kind)
 	}
 }
 
@@ -187,14 +250,14 @@ func sqlLiteral(value any) string {
 
 func requiredExtensions(model *semantic.Model) []string {
 	extensions := map[string]struct{}{}
-	addConnection := func(connectionType string) {
-		switch connectionType {
+	addConnection := func(kind string) {
+		switch kind {
 		case "s3", "r2", "gcs", "http":
 			extensions["httpfs"] = struct{}{}
-		case "azure":
+		case "azure_blob":
 			extensions["azure"] = struct{}{}
 		case "postgres", "mysql", "sqlite":
-			extensions[connectionType] = struct{}{}
+			extensions[kind] = struct{}{}
 		}
 	}
 	addLocation := func(location string) {
@@ -206,23 +269,34 @@ func requiredExtensions(model *semantic.Model) []string {
 		}
 	}
 	for _, name := range sortedKeys(model.Connections) {
-		addConnection(model.Connections[name].Type)
+		addConnection(model.Connections[name].Kind)
 	}
 	for _, name := range sortedKeys(model.Sources) {
 		source := model.Sources[name]
 		addLocation(source.Location)
-		switch source.Type {
-		case "file":
-			if source.Format == "excel" {
+		switch source.Kind() {
+		case "location":
+			switch source.Format {
+			case "excel":
 				extensions["excel"] = struct{}{}
+			case "delta", "iceberg":
+				extensions[source.Format] = struct{}{}
 			}
-		case "lakehouse":
-			extensions[source.Format] = struct{}{}
 		case "database":
-			extensions[source.Engine] = struct{}{}
+			connection := model.Connections[source.Connection]
+			extensions[connection.Kind] = struct{}{}
 		}
 	}
 	return sortedKeys(extensions)
+}
+
+func duckDBConnectionType(kind string) string {
+	switch kind {
+	case "azure_blob":
+		return "azure"
+	default:
+		return kind
+	}
 }
 
 func compileConnectionSecret(name string, connection semantic.Connection) (string, bool, error) {
@@ -236,7 +310,7 @@ func compileConnectionSecret(name string, connection semantic.Connection) (strin
 	if err != nil {
 		return "", false, err
 	}
-	parts := []string{"TYPE " + connection.Type}
+	parts := []string{"TYPE " + duckDBConnectionType(connection.Kind)}
 	if connection.Auth.Method != "" {
 		if err := validateIdentifier(connection.Auth.Method); err != nil {
 			return "", false, fmt.Errorf("invalid auth method %q: %w", connection.Auth.Method, err)
@@ -264,7 +338,7 @@ func compileConnectionSecret(name string, connection semantic.Connection) (strin
 	return fmt.Sprintf("CREATE OR REPLACE SECRET %s (%s)", secret, strings.Join(parts, ", ")), true, nil
 }
 
-func compileDatabaseAttach(connectionName, engine string, connection semantic.Connection) (string, error) {
+func compileDatabaseAttach(connectionName string, connection semantic.Connection) (string, error) {
 	alias, err := databaseAlias(connectionName)
 	if err != nil {
 		return "", err
@@ -273,7 +347,7 @@ func compileDatabaseAttach(connectionName, engine string, connection semantic.Co
 	if err != nil {
 		return "", err
 	}
-	parts := []string{"TYPE " + engine, "READ_ONLY"}
+	parts := []string{"TYPE " + duckDBConnectionType(connection.Kind), "READ_ONLY"}
 	if secret, ok, err := databaseAttachSecret(connectionName, connection); err != nil {
 		return "", err
 	} else if ok {

--- a/internal/data/sources.go
+++ b/internal/data/sources.go
@@ -35,6 +35,15 @@ func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *model
 			return fmt.Errorf("creating DuckDB secret for connection %s: %w", name, err)
 		}
 	}
+	lanceSecrets, err := compileLanceSourceSecrets(runtime.model)
+	if err != nil {
+		return err
+	}
+	for _, stmt := range lanceSecrets {
+		if _, err := runtime.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("creating DuckDB Lance secret: %w", err)
+		}
+	}
 	if runtime.attachedConnections == nil {
 		runtime.attachedConnections = map[string]struct{}{}
 	}
@@ -47,12 +56,15 @@ func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *model
 			continue
 		}
 		connection := runtime.model.Connections[source.Connection]
-		stmt, err := compileDatabaseAttach(source.Connection, connection)
+		stmt, err := m.compileObjectAttach(runtime.model, source.Connection, connection)
 		if err != nil {
 			return err
 		}
+		if stmt == "" {
+			continue
+		}
 		if _, err := runtime.db.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("attaching database connection %s: %w", source.Connection, err)
+			return fmt.Errorf("attaching source connection %s: %w", source.Connection, err)
 		}
 		runtime.attachedConnections[source.Connection] = struct{}{}
 	}
@@ -62,7 +74,7 @@ func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *model
 type sourcePlan struct {
 	kind       string
 	format     string
-	location   string
+	path       string
 	connection string
 	object     string
 	options    map[string]any
@@ -84,23 +96,23 @@ func (m *DuckDBMetrics) resolveSourcePlan(model *semantic.Model, source semantic
 		object:     source.Object,
 		options:    source.Options,
 	}
-	if source.Location == "" {
+	if source.Path == "" {
 		return plan, nil
 	}
-	location, err := m.resolveSourceLocation(model, source)
+	path, err := m.resolveSourcePath(model, source)
 	if err != nil {
 		return plan, err
 	}
-	plan.location = location
+	plan.path = path
 	return plan, nil
 }
 
-func (m *DuckDBMetrics) resolveSourceLocation(model *semantic.Model, source semantic.Source) (string, error) {
+func (m *DuckDBMetrics) resolveSourcePath(model *semantic.Model, source semantic.Source) (string, error) {
 	connection := model.Connections[source.Connection]
 	switch connection.Kind {
 	case "local":
-		if filepath.IsAbs(source.Location) {
-			return source.Location, nil
+		if filepath.IsAbs(source.Path) {
+			return source.Path, nil
 		}
 		root := connection.Root
 		if root == "" {
@@ -108,18 +120,18 @@ func (m *DuckDBMetrics) resolveSourceLocation(model *semantic.Model, source sema
 		} else if !filepath.IsAbs(root) {
 			root = filepath.Join(m.dataDir, root)
 		}
-		return filepath.Join(root, source.Location), nil
+		return filepath.Join(root, source.Path), nil
 	default:
 		if connection.Scope == "" {
-			return source.Location, nil
+			return source.Path, nil
 		}
-		if isLocalSourceLocation(source.Location) {
-			return joinRemoteScope(connection.Scope, source.Location), nil
+		if isLocalSourcePath(source.Path) {
+			return joinRemoteScope(connection.Scope, source.Path), nil
 		}
-		if !withinRemoteScope(connection.Scope, source.Location) {
-			return "", fmt.Errorf("location %q is outside connection %q scope %q", source.Location, source.Connection, connection.Scope)
+		if !withinRemoteScope(connection.Scope, source.Path) {
+			return "", fmt.Errorf("path %q is outside connection %q scope %q", source.Path, source.Connection, connection.Scope)
 		}
-		return source.Location, nil
+		return source.Path, nil
 	}
 }
 
@@ -135,26 +147,31 @@ func withinRemoteScope(scope, location string) bool {
 
 func compileSourceRelation(plan sourcePlan) (string, error) {
 	switch plan.kind {
-	case "location":
+	case "path":
 		switch plan.format {
 		case "csv":
-			return scanRelation("read_csv", plan.location, plan.options)
+			return scanRelation("read_csv", plan.path, plan.options)
 		case "json":
-			return scanRelation("read_json", plan.location, plan.options)
+			return scanRelation("read_json", plan.path, plan.options)
 		case "parquet":
-			return scanRelation("read_parquet", plan.location, plan.options)
+			return scanRelation("read_parquet", plan.path, plan.options)
 		case "excel":
-			return scanRelation("read_xlsx", plan.location, plan.options)
+			return scanRelation("read_xlsx", plan.path, plan.options)
 		case "text":
-			return scanRelation("read_text", plan.location, plan.options)
+			return scanRelation("read_text", plan.path, plan.options)
 		case "blob":
-			return scanRelation("read_blob", plan.location, plan.options)
+			return scanRelation("read_blob", plan.path, plan.options)
 		case "vortex":
-			return scanRelation("read_vortex", plan.location, plan.options)
+			return scanRelation("read_vortex", plan.path, plan.options)
+		case "lance":
+			if len(plan.options) > 0 {
+				return "", fmt.Errorf("lance source cannot set options")
+			}
+			return replacementScanRelation(plan.path), nil
 		case "delta":
-			return scanRelation("delta_scan", plan.location, plan.options)
+			return scanRelation("delta_scan", plan.path, plan.options)
 		case "iceberg":
-			return scanRelation("iceberg_scan", plan.location, plan.options)
+			return scanRelation("iceberg_scan", plan.path, plan.options)
 		default:
 			return "", fmt.Errorf("unsupported source format %q", plan.format)
 		}
@@ -171,6 +188,10 @@ func compileSourceRelation(plan sourcePlan) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported source kind %q", plan.kind)
 	}
+}
+
+func replacementScanRelation(path string) string {
+	return fmt.Sprintf("SELECT * FROM '%s'", sqlString(path))
 }
 
 func scanRelation(function, location string, options map[string]any) (string, error) {
@@ -258,7 +279,7 @@ func requiredExtensions(model *semantic.Model) []string {
 			extensions["httpfs"] = struct{}{}
 		case "azure_blob":
 			extensions["azure"] = struct{}{}
-		case "postgres", "mysql", "sqlite":
+		case "postgres", "mysql", "sqlite", "ducklake":
 			extensions[kind] = struct{}{}
 		}
 	}
@@ -271,17 +292,22 @@ func requiredExtensions(model *semantic.Model) []string {
 		}
 	}
 	for _, name := range sortedKeys(model.Connections) {
-		addConnection(model.Connections[name].Kind)
+		connection := model.Connections[name]
+		addConnection(connection.Kind)
+		addLocation(connection.Path)
+		if dataPath, ok := connection.Options["data_path"]; ok {
+			addLocation(fmt.Sprint(dataPath))
+		}
 	}
 	for _, name := range sortedKeys(model.Sources) {
 		source := model.Sources[name]
-		addLocation(source.Location)
+		addLocation(source.Path)
 		switch source.Kind() {
-		case "location":
+		case "path":
 			switch source.Format {
 			case "excel":
 				extensions["excel"] = struct{}{}
-			case "delta", "iceberg", "vortex":
+			case "delta", "iceberg", "vortex", "lance":
 				extensions[source.Format] = struct{}{}
 			}
 		case "database":
@@ -301,7 +327,38 @@ func duckDBConnectionType(kind string) string {
 	}
 }
 
+func compileLanceSourceSecrets(model *semantic.Model) ([]string, error) {
+	statements := map[string]string{}
+	for _, sourceName := range sortedKeys(model.Sources) {
+		source := model.Sources[sourceName]
+		if source.Kind() != "path" || source.Format != "lance" {
+			continue
+		}
+		connection := model.Connections[source.Connection]
+		if connection.Secret != "" || connection.Auth.Method == "" && len(connection.Auth.Params) == 0 && connection.Auth.Profile == "" && connection.Auth.Chain == "" && connection.Auth.Account == "" && connection.Scope == "" {
+			continue
+		}
+		stmt, ok, err := compileTypedConnectionSecret(source.Connection+"_lance", connection, "lance")
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		statements[source.Connection] = stmt
+	}
+	result := make([]string, 0, len(statements))
+	for _, name := range sortedKeys(statements) {
+		result = append(result, statements[name])
+	}
+	return result, nil
+}
+
 func compileConnectionSecret(name string, connection semantic.Connection) (string, bool, error) {
+	return compileTypedConnectionSecret(name, connection, duckDBConnectionType(connection.Kind))
+}
+
+func compileTypedConnectionSecret(name string, connection semantic.Connection, secretType string) (string, bool, error) {
 	if connection.Secret != "" {
 		return "", false, nil
 	}
@@ -312,7 +369,7 @@ func compileConnectionSecret(name string, connection semantic.Connection) (strin
 	if err != nil {
 		return "", false, err
 	}
-	parts := []string{"TYPE " + duckDBConnectionType(connection.Kind)}
+	parts := []string{"TYPE " + secretType}
 	if connection.Auth.Method != "" {
 		if err := validateIdentifier(connection.Auth.Method); err != nil {
 			return "", false, fmt.Errorf("invalid auth method %q: %w", connection.Auth.Method, err)
@@ -340,6 +397,13 @@ func compileConnectionSecret(name string, connection semantic.Connection) (strin
 	return fmt.Sprintf("CREATE OR REPLACE SECRET %s (%s)", secret, strings.Join(parts, ", ")), true, nil
 }
 
+func (m *DuckDBMetrics) compileObjectAttach(model *semantic.Model, connectionName string, connection semantic.Connection) (string, error) {
+	if connection.Kind == "ducklake" {
+		return m.compileDuckLakeAttach(model, connectionName, connection)
+	}
+	return compileDatabaseAttach(connectionName, connection)
+}
+
 func compileDatabaseAttach(connectionName string, connection semantic.Connection) (string, error) {
 	alias, err := databaseAlias(connectionName)
 	if err != nil {
@@ -356,6 +420,53 @@ func compileDatabaseAttach(connectionName string, connection semantic.Connection
 		parts = append(parts, "SECRET "+secret)
 	}
 	return fmt.Sprintf("ATTACH '%s' AS %s (%s)", sqlString(connectionString), alias, strings.Join(parts, ", ")), nil
+}
+
+func (m *DuckDBMetrics) compileDuckLakeAttach(model *semantic.Model, connectionName string, connection semantic.Connection) (string, error) {
+	alias, err := databaseAlias(connectionName)
+	if err != nil {
+		return "", err
+	}
+	path, err := m.resolveConnectionPath(model, connection)
+	if err != nil {
+		return "", err
+	}
+	attachPath := path
+	if !strings.HasPrefix(attachPath, "ducklake:") {
+		attachPath = "ducklake:" + attachPath
+	}
+	parts := []string{}
+	if dataPath, ok := connection.Options["data_path"]; ok {
+		resolved, err := m.resolvePathInConnectionScope(model, connection, fmt.Sprint(dataPath))
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, "DATA_PATH '"+sqlString(resolved)+"'")
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("ATTACH '%s' AS %s", sqlString(attachPath), alias), nil
+	}
+	return fmt.Sprintf("ATTACH '%s' AS %s (%s)", sqlString(attachPath), alias, strings.Join(parts, ", ")), nil
+}
+
+func (m *DuckDBMetrics) resolveConnectionPath(model *semantic.Model, connection semantic.Connection) (string, error) {
+	return m.resolvePathInConnectionScope(model, connection, connection.Path)
+}
+
+func (m *DuckDBMetrics) resolvePathInConnectionScope(_ *semantic.Model, connection semantic.Connection, path string) (string, error) {
+	if connection.Scope != "" {
+		if isLocalSourcePath(path) {
+			return joinRemoteScope(connection.Scope, path), nil
+		}
+		if !withinRemoteScope(connection.Scope, path) {
+			return "", fmt.Errorf("path %q is outside connection scope %q", path, connection.Scope)
+		}
+		return path, nil
+	}
+	if filepath.IsAbs(path) || !isLocalSourcePath(path) {
+		return path, nil
+	}
+	return filepath.Join(m.dataDir, path), nil
 }
 
 func databaseAttachSecret(connectionName string, connection semantic.Connection) (string, bool, error) {
@@ -430,7 +541,7 @@ func qualifiedSQLName(name string) (string, error) {
 	return strings.Join(quoted, "."), nil
 }
 
-func isLocalSourceLocation(location string) bool {
+func isLocalSourcePath(location string) bool {
 	for _, prefix := range []string{"s3://", "r2://", "gcs://", "gs://", "az://", "azure://", "abfss://", "http://", "https://", "file://"} {
 		if strings.HasPrefix(location, prefix) {
 			return false

--- a/internal/data/sources.go
+++ b/internal/data/sources.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Yacobolo/libredash/internal/semantic"
+	sourcereg "github.com/Yacobolo/libredash/internal/source"
 )
 
 func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *modelRuntime) error {
@@ -35,13 +36,13 @@ func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *model
 			return fmt.Errorf("creating DuckDB secret for connection %s: %w", name, err)
 		}
 	}
-	lanceSecrets, err := compileLanceSourceSecrets(runtime.model)
+	sourceSecrets, err := compileSourceSecretStatements(runtime.model)
 	if err != nil {
 		return err
 	}
-	for _, stmt := range lanceSecrets {
+	for _, stmt := range sourceSecrets {
 		if _, err := runtime.db.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("creating DuckDB Lance secret: %w", err)
+			return fmt.Errorf("creating DuckDB source secret: %w", err)
 		}
 	}
 	if runtime.attachedConnections == nil {
@@ -49,7 +50,7 @@ func (m *DuckDBMetrics) prepareSourceRuntime(ctx context.Context, runtime *model
 	}
 	for _, sourceName := range sortedKeys(runtime.model.Sources) {
 		source := runtime.model.Sources[sourceName]
-		if source.Kind() != "database" {
+		if source.Kind() != sourcereg.KindObject {
 			continue
 		}
 		if _, ok := runtime.attachedConnections[source.Connection]; ok {
@@ -125,57 +126,35 @@ func (m *DuckDBMetrics) resolveSourcePath(model *semantic.Model, source semantic
 		if connection.Scope == "" {
 			return source.Path, nil
 		}
-		if isLocalSourcePath(source.Path) {
-			return joinRemoteScope(connection.Scope, source.Path), nil
+		if sourcereg.IsLocalPath(source.Path) {
+			return sourcereg.JoinScope(connection.Scope, source.Path), nil
 		}
-		if !withinRemoteScope(connection.Scope, source.Path) {
+		if !sourcereg.WithinScope(connection.Scope, source.Path) {
 			return "", fmt.Errorf("path %q is outside connection %q scope %q", source.Path, source.Connection, connection.Scope)
 		}
 		return source.Path, nil
 	}
 }
 
-func joinRemoteScope(scope, location string) string {
-	return strings.TrimRight(scope, "/") + "/" + strings.TrimLeft(location, "/")
-}
-
-func withinRemoteScope(scope, location string) bool {
-	scope = strings.TrimRight(scope, "/")
-	location = strings.TrimRight(location, "/")
-	return location == scope || strings.HasPrefix(location, scope+"/")
-}
-
 func compileSourceRelation(plan sourcePlan) (string, error) {
 	switch plan.kind {
-	case "path":
-		switch plan.format {
-		case "csv":
-			return scanRelation("read_csv", plan.path, plan.options)
-		case "json":
-			return scanRelation("read_json", plan.path, plan.options)
-		case "parquet":
-			return scanRelation("read_parquet", plan.path, plan.options)
-		case "excel":
-			return scanRelation("read_xlsx", plan.path, plan.options)
-		case "text":
-			return scanRelation("read_text", plan.path, plan.options)
-		case "blob":
-			return scanRelation("read_blob", plan.path, plan.options)
-		case "vortex":
-			return scanRelation("read_vortex", plan.path, plan.options)
-		case "lance":
-			if len(plan.options) > 0 {
-				return "", fmt.Errorf("lance source cannot set options")
-			}
-			return replacementScanRelation(plan.path), nil
-		case "delta":
-			return scanRelation("delta_scan", plan.path, plan.options)
-		case "iceberg":
-			return scanRelation("iceberg_scan", plan.path, plan.options)
-		default:
+	case sourcereg.KindPath:
+		format, ok := sourcereg.LookupFormat(plan.format)
+		if !ok {
 			return "", fmt.Errorf("unsupported source format %q", plan.format)
 		}
-	case "database":
+		if !format.AllowsOptions && len(plan.options) > 0 {
+			return "", fmt.Errorf("%s source cannot set options", plan.format)
+		}
+		switch format.ScanKind {
+		case sourcereg.ScanTableFunction:
+			return scanRelation(format.ScanFunction, plan.path, plan.options)
+		case sourcereg.ScanReplacement:
+			return replacementScanRelation(plan.path), nil
+		default:
+			return "", fmt.Errorf("unsupported source scan kind %q", format.ScanKind)
+		}
+	case sourcereg.KindObject:
 		object, err := qualifiedSQLName(plan.object)
 		if err != nil {
 			return "", err
@@ -274,71 +253,62 @@ func sqlLiteral(value any) string {
 func requiredExtensions(model *semantic.Model) []string {
 	extensions := map[string]struct{}{}
 	addConnection := func(kind string) {
-		switch kind {
-		case "s3", "r2", "gcs", "http":
-			extensions["httpfs"] = struct{}{}
-		case "azure_blob":
-			extensions["azure"] = struct{}{}
-		case "postgres", "mysql", "sqlite", "ducklake":
-			extensions[kind] = struct{}{}
+		if connection, ok := sourcereg.LookupConnection(kind); ok && connection.RequiredExtension != "" {
+			extensions[connection.RequiredExtension] = struct{}{}
 		}
 	}
-	addLocation := func(location string) {
-		switch {
-		case strings.HasPrefix(location, "s3://"), strings.HasPrefix(location, "r2://"), strings.HasPrefix(location, "gcs://"), strings.HasPrefix(location, "gs://"), strings.HasPrefix(location, "http://"), strings.HasPrefix(location, "https://"):
-			extensions["httpfs"] = struct{}{}
-		case strings.HasPrefix(location, "az://"), strings.HasPrefix(location, "azure://"), strings.HasPrefix(location, "abfss://"):
-			extensions["azure"] = struct{}{}
+	addPath := func(path string) {
+		if extension, ok := sourcereg.StorageExtension(path); ok {
+			extensions[extension] = struct{}{}
 		}
 	}
 	for _, name := range sortedKeys(model.Connections) {
 		connection := model.Connections[name]
 		addConnection(connection.Kind)
-		addLocation(connection.Path)
+		addPath(connection.Path)
 		if dataPath, ok := connection.Options["data_path"]; ok {
-			addLocation(fmt.Sprint(dataPath))
+			addPath(fmt.Sprint(dataPath))
 		}
 	}
 	for _, name := range sortedKeys(model.Sources) {
 		source := model.Sources[name]
-		addLocation(source.Path)
+		addPath(source.Path)
 		switch source.Kind() {
-		case "path":
-			switch source.Format {
-			case "excel":
-				extensions["excel"] = struct{}{}
-			case "delta", "iceberg", "vortex", "lance":
-				extensions[source.Format] = struct{}{}
+		case sourcereg.KindPath:
+			if format, ok := sourcereg.LookupFormat(source.Format); ok && format.RequiredExtension != "" {
+				extensions[format.RequiredExtension] = struct{}{}
 			}
-		case "database":
+		case sourcereg.KindObject:
 			connection := model.Connections[source.Connection]
-			extensions[connection.Kind] = struct{}{}
+			addConnection(connection.Kind)
 		}
 	}
 	return sortedKeys(extensions)
 }
 
 func duckDBConnectionType(kind string) string {
-	switch kind {
-	case "azure_blob":
-		return "azure"
-	default:
-		return kind
+	if connection, ok := sourcereg.LookupConnection(kind); ok && connection.SecretType != "" {
+		return connection.SecretType
 	}
+	return kind
 }
 
-func compileLanceSourceSecrets(model *semantic.Model) ([]string, error) {
+func compileSourceSecretStatements(model *semantic.Model) ([]string, error) {
 	statements := map[string]string{}
 	for _, sourceName := range sortedKeys(model.Sources) {
 		source := model.Sources[sourceName]
-		if source.Kind() != "path" || source.Format != "lance" {
+		if source.Kind() != sourcereg.KindPath {
+			continue
+		}
+		format, ok := sourcereg.LookupFormat(source.Format)
+		if !ok || format.SourceSecretType == "" {
 			continue
 		}
 		connection := model.Connections[source.Connection]
 		if connection.Secret != "" || connection.Auth.Method == "" && len(connection.Auth.Params) == 0 && connection.Auth.Profile == "" && connection.Auth.Chain == "" && connection.Auth.Account == "" && connection.Scope == "" {
 			continue
 		}
-		stmt, ok, err := compileTypedConnectionSecret(source.Connection+"_lance", connection, "lance")
+		stmt, ok, err := compileTypedConnectionSecret(source.Connection+"_"+format.SourceSecretType, connection, format.SourceSecretType)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +325,11 @@ func compileLanceSourceSecrets(model *semantic.Model) ([]string, error) {
 }
 
 func compileConnectionSecret(name string, connection semantic.Connection) (string, bool, error) {
-	return compileTypedConnectionSecret(name, connection, duckDBConnectionType(connection.Kind))
+	connectionSpec, ok := sourcereg.LookupConnection(connection.Kind)
+	if !ok || connectionSpec.SecretType == "" {
+		return "", false, nil
+	}
+	return compileTypedConnectionSecret(name, connection, connectionSpec.SecretType)
 }
 
 func compileTypedConnectionSecret(name string, connection semantic.Connection, secretType string) (string, bool, error) {
@@ -398,7 +372,11 @@ func compileTypedConnectionSecret(name string, connection semantic.Connection, s
 }
 
 func (m *DuckDBMetrics) compileObjectAttach(model *semantic.Model, connectionName string, connection semantic.Connection) (string, error) {
-	if connection.Kind == "ducklake" {
+	connectionSpec, ok := sourcereg.LookupConnection(connection.Kind)
+	if !ok {
+		return "", fmt.Errorf("unsupported connection kind %q", connection.Kind)
+	}
+	if connectionSpec.AttachKind == sourcereg.AttachDuckLake {
 		return m.compileDuckLakeAttach(model, connectionName, connection)
 	}
 	return compileDatabaseAttach(connectionName, connection)
@@ -455,15 +433,15 @@ func (m *DuckDBMetrics) resolveConnectionPath(model *semantic.Model, connection 
 
 func (m *DuckDBMetrics) resolvePathInConnectionScope(_ *semantic.Model, connection semantic.Connection, path string) (string, error) {
 	if connection.Scope != "" {
-		if isLocalSourcePath(path) {
-			return joinRemoteScope(connection.Scope, path), nil
+		if sourcereg.IsLocalPath(path) {
+			return sourcereg.JoinScope(connection.Scope, path), nil
 		}
-		if !withinRemoteScope(connection.Scope, path) {
+		if !sourcereg.WithinScope(connection.Scope, path) {
 			return "", fmt.Errorf("path %q is outside connection scope %q", path, connection.Scope)
 		}
 		return path, nil
 	}
-	if filepath.IsAbs(path) || !isLocalSourcePath(path) {
+	if filepath.IsAbs(path) || !sourcereg.IsLocalPath(path) {
 		return path, nil
 	}
 	return filepath.Join(m.dataDir, path), nil
@@ -501,7 +479,8 @@ func connectionSecretName(name string, connection semantic.Connection) (string, 
 
 func connectionStringOption(connection semantic.Connection) (string, error) {
 	for key := range connection.Options {
-		if !supportsDatabaseConnectionOption(key) {
+		connectionSpec, _ := sourcereg.LookupConnection(connection.Kind)
+		if !connectionAllowsOption(connectionSpec, key) {
 			return "", fmt.Errorf("unsupported database connection option %q", key)
 		}
 	}
@@ -513,13 +492,13 @@ func connectionStringOption(connection semantic.Connection) (string, error) {
 	return "", nil
 }
 
-func supportsDatabaseConnectionOption(option string) bool {
-	switch option {
-	case "connection_string", "uri", "path", "database":
-		return true
-	default:
-		return false
+func connectionAllowsOption(connection sourcereg.Connection, option string) bool {
+	for _, allowed := range connection.AllowedOptions {
+		if option == allowed {
+			return true
+		}
 	}
+	return false
 }
 
 func databaseAlias(connection string) (string, error) {
@@ -539,13 +518,4 @@ func qualifiedSQLName(name string) (string, error) {
 		quoted = append(quoted, part)
 	}
 	return strings.Join(quoted, "."), nil
-}
-
-func isLocalSourcePath(location string) bool {
-	for _, prefix := range []string{"s3://", "r2://", "gcs://", "gs://", "az://", "azure://", "abfss://", "http://", "https://", "file://"} {
-		if strings.HasPrefix(location, prefix) {
-			return false
-		}
-	}
-	return !strings.Contains(location, "://")
 }

--- a/internal/data/sources.go
+++ b/internal/data/sources.go
@@ -65,7 +65,6 @@ type sourcePlan struct {
 	location   string
 	connection string
 	object     string
-	query      string
 	options    map[string]any
 }
 
@@ -83,7 +82,6 @@ func (m *DuckDBMetrics) resolveSourcePlan(model *semantic.Model, source semantic
 		format:     source.Format,
 		connection: source.Connection,
 		object:     source.Object,
-		query:      source.Query,
 		options:    source.Options,
 	}
 	if source.Location == "" {
@@ -147,6 +145,12 @@ func compileSourceRelation(plan sourcePlan) (string, error) {
 			return scanRelation("read_parquet", plan.location, plan.options)
 		case "excel":
 			return scanRelation("read_xlsx", plan.location, plan.options)
+		case "text":
+			return scanRelation("read_text", plan.location, plan.options)
+		case "blob":
+			return scanRelation("read_blob", plan.location, plan.options)
+		case "vortex":
+			return scanRelation("read_vortex", plan.location, plan.options)
 		case "delta":
 			return scanRelation("delta_scan", plan.location, plan.options)
 		case "iceberg":
@@ -164,8 +168,6 @@ func compileSourceRelation(plan sourcePlan) (string, error) {
 			return "", err
 		}
 		return fmt.Sprintf("SELECT * FROM %s.%s", alias, object), nil
-	case "query":
-		return plan.query, nil
 	default:
 		return "", fmt.Errorf("unsupported source kind %q", plan.kind)
 	}
@@ -279,7 +281,7 @@ func requiredExtensions(model *semantic.Model) []string {
 			switch source.Format {
 			case "excel":
 				extensions["excel"] = struct{}{}
-			case "delta", "iceberg":
+			case "delta", "iceberg", "vortex":
 				extensions[source.Format] = struct{}{}
 			}
 		case "database":

--- a/internal/data/tables.go
+++ b/internal/data/tables.go
@@ -1,0 +1,497 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Yacobolo/libredash/internal/dashboard"
+	"github.com/Yacobolo/libredash/internal/semantic"
+)
+
+func (m *DuckDBMetrics) tableBlocks(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest, availableRows int) (map[string]dashboard.TableBlock, error) {
+	blocks := map[string]dashboard.TableBlock{}
+	count := request.Count
+	if count <= 0 {
+		count = dashboard.TableChunkSize
+	}
+	if count > dashboard.TableMaxRequestCount {
+		count = dashboard.TableMaxRequestCount
+	}
+	if request.Block == "all" {
+		starts := initialBlockStarts(request.Start, count, availableRows)
+		for block, start := range starts {
+			rows, err := m.tableRows(ctx, runtime, report, table, filters, request, start, count, availableRows)
+			if err != nil {
+				return nil, err
+			}
+			blocks[block] = dashboard.TableBlock{
+				Start:        start,
+				RequestSeq:   request.RequestSeq,
+				ResetVersion: request.ResetVersion,
+				Sort:         request.Sort,
+				Rows:         rows,
+			}
+		}
+		return blocks, nil
+	}
+
+	start := clampTableStart(request.Start, availableRows)
+	rows, err := m.tableRows(ctx, runtime, report, table, filters, request, start, count, availableRows)
+	if err != nil {
+		return nil, err
+	}
+	blocks[request.Block] = dashboard.TableBlock{
+		Start:        start,
+		RequestSeq:   request.RequestSeq,
+		ResetVersion: request.ResetVersion,
+		Sort:         request.Sort,
+		Rows:         rows,
+	}
+	return blocks, nil
+}
+
+func (m *DuckDBMetrics) queryAggregateTable(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, request dashboard.TableRequest, table semantic.TableVisual, filters dashboard.Filters) (dashboard.Table, error) {
+	var (
+		columns []dashboard.TableColumn
+		rows    []map[string]any
+		err     error
+	)
+	switch table.KindOrDefault() {
+	case "matrix_table":
+		columns, rows, err = m.matrixTableRows(ctx, runtime, report, table, filters, request)
+	case "pivot_table":
+		columns, rows, err = m.pivotTableRows(ctx, runtime, report, table, filters, request)
+	default:
+		err = fmt.Errorf("unsupported aggregate table kind %q", table.KindOrDefault())
+	}
+	if err != nil {
+		return dashboard.EmptyTable(request, err), nil
+	}
+	totalRows := len(rows)
+	isCapped := totalRows > dashboard.TableInteractiveRowCap
+	if isCapped {
+		rows = rows[:dashboard.TableInteractiveRowCap]
+	}
+	chunkSize := max(dashboard.TableChunkSize, len(rows))
+	return dashboard.Table{
+		Version:       2,
+		Kind:          table.KindOrDefault(),
+		Title:         table.Title,
+		Columns:       columns,
+		TotalRows:     totalRows,
+		AvailableRows: len(rows),
+		IsCapped:      isCapped,
+		RowCap:        dashboard.TableInteractiveRowCap,
+		ChunkSize:     chunkSize,
+		RowHeight:     dashboard.TableRowHeight,
+		ResetVersion:  request.ResetVersion,
+		Sort:          request.Sort,
+		Blocks: map[string]dashboard.TableBlock{
+			"a": {Start: 0, RequestSeq: request.RequestSeq, ResetVersion: request.ResetVersion, Sort: request.Sort, Rows: rows},
+			"b": {Start: chunkSize, RequestSeq: request.RequestSeq, ResetVersion: request.ResetVersion, Sort: request.Sort, Rows: []map[string]any{}},
+			"c": {Start: chunkSize * 2, RequestSeq: request.RequestSeq, ResetVersion: request.ResetVersion, Sort: request.Sort, Rows: []map[string]any{}},
+		},
+		LoadingBlock: "",
+		Error:        "",
+	}, nil
+}
+
+func (m *DuckDBMetrics) matrixTableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest) ([]dashboard.TableColumn, []map[string]any, error) {
+	if len(table.ColumnDims) == 1 {
+		return m.crossTabTableRows(ctx, runtime, report, table, filters, request, false)
+	}
+	source, err := m.metricViewSource(table.MetricView)
+	if err != nil {
+		return nil, nil, err
+	}
+	metricView := m.workspace.MetricViews[table.MetricView]
+	columns := make([]dashboard.TableColumn, 0, len(table.Rows)+len(table.Measures))
+	selects := make([]string, 0, len(table.Rows)+len(table.Measures))
+	groupBy := make([]string, 0, len(table.Rows))
+	for _, dimensionName := range table.Rows {
+		dimension := metricView.Dimensions[dimensionName]
+		selects = append(selects, fmt.Sprintf("%s AS %s", dimensionExpression(dimension, "e"), dimensionName))
+		groupBy = append(groupBy, dimensionName)
+		columns = append(columns, dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header"})
+	}
+	for _, measureName := range table.Measures {
+		measure := metricView.Measures[measureName]
+		expr, err := measureAggregateExpr(measure)
+		if err != nil {
+			return nil, nil, err
+		}
+		selects = append(selects, fmt.Sprintf("%s AS %s", expr, measureName))
+		columns = append(columns, dashboard.TableColumn{Key: measureName, Label: measureLabel(measureName, measure), Align: "right", Role: "measure", Measure: measureName})
+	}
+	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
+	orderBy := strings.Join(groupBy, ", ")
+	if request.Sort.Key != "" && tableHasColumn(columns, request.Sort.Key) {
+		direction := "DESC"
+		if request.Sort.Direction == "asc" {
+			direction = "ASC"
+		}
+		orderBy = request.Sort.Key + " " + direction
+	}
+	query := fmt.Sprintf(`
+SELECT %s
+FROM %s e
+WHERE %s
+GROUP BY %s
+ORDER BY %s
+LIMIT ?`, strings.Join(selects, ", "), source, where, strings.Join(groupBy, ", "), orderBy)
+	args = append(args, dashboard.TableInteractiveRowCap+1)
+	rows, err := m.queryTableDatums(ctx, runtime, query, tableColumnKeys(columns), args...)
+	return columns, rows, err
+}
+
+func (m *DuckDBMetrics) pivotTableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest) ([]dashboard.TableColumn, []map[string]any, error) {
+	return m.crossTabTableRows(ctx, runtime, report, table, filters, request, true)
+}
+
+func (m *DuckDBMetrics) crossTabTableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest, pivotMode bool) ([]dashboard.TableColumn, []map[string]any, error) {
+	source, err := m.metricViewSource(table.MetricView)
+	if err != nil {
+		return nil, nil, err
+	}
+	metricView := m.workspace.MetricViews[table.MetricView]
+	rowSelects := make([]string, 0, len(table.Rows))
+	groupBy := make([]string, 0, len(table.Rows)+1)
+	baseColumns := make([]dashboard.TableColumn, 0, len(table.Rows))
+	for _, dimensionName := range table.Rows {
+		dimension := metricView.Dimensions[dimensionName]
+		rowSelects = append(rowSelects, fmt.Sprintf("%s AS %s", dimensionExpression(dimension, "e"), dimensionName))
+		groupBy = append(groupBy, dimensionName)
+		baseColumns = append(baseColumns, dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header"})
+	}
+	columnDimensionName := table.ColumnDims[0]
+	columnDimension := metricView.Dimensions[columnDimensionName]
+	valueSelects := make([]string, 0, len(table.Measures))
+	valueColumns := make([]string, 0, len(table.Measures))
+	for _, measureName := range table.Measures {
+		measureExpr, err := measureAggregateExpr(metricView.Measures[measureName])
+		if err != nil {
+			return nil, nil, err
+		}
+		valueSelects = append(valueSelects, fmt.Sprintf("%s AS %s", measureExpr, measureName))
+		valueColumns = append(valueColumns, measureName)
+	}
+	groupBy = append(groupBy, "pivot_label")
+	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
+	query := fmt.Sprintf(`
+SELECT %s, %s AS pivot_label, %s
+FROM %s e
+WHERE %s
+GROUP BY %s
+ORDER BY %s
+LIMIT ?`, strings.Join(rowSelects, ", "), dimensionExpression(columnDimension, "e"), strings.Join(valueSelects, ", "), source, where, strings.Join(groupBy, ", "), strings.Join(groupBy, ", "))
+	args = append(args, dashboard.TableInteractiveRowCap+1)
+	rawRows, err := m.queryTableDatums(ctx, runtime, query, append(append(append([]string{}, table.Rows...), "pivot_label"), valueColumns...), args...)
+	if err != nil {
+		return nil, nil, err
+	}
+	columns := append([]dashboard.TableColumn{}, baseColumns...)
+	pivotKeys := map[string]string{}
+	usedKeys := map[string]string{}
+	columnKeys := map[string]string{}
+	for _, column := range baseColumns {
+		usedKeys[column.Key] = column.Key
+	}
+	resultByKey := map[string]map[string]any{}
+	order := []string{}
+	for _, raw := range rawRows {
+		rowKeyParts := make([]string, 0, len(table.Rows))
+		for _, dimension := range table.Rows {
+			rowKeyParts = append(rowKeyParts, fmt.Sprint(raw[dimension]))
+		}
+		resultKey := strings.Join(rowKeyParts, "\x00")
+		row, exists := resultByKey[resultKey]
+		if !exists {
+			row = map[string]any{}
+			for _, dimension := range table.Rows {
+				row[dimension] = raw[dimension]
+			}
+			resultByKey[resultKey] = row
+			order = append(order, resultKey)
+		}
+		label := fmt.Sprint(raw["pivot_label"])
+		groupLabel := label
+		if pivotMode {
+			groupLabel = measureLabel(table.Measures[0], metricView.Measures[table.Measures[0]])
+		}
+		pivotKey, exists := pivotKeys[label]
+		if !exists {
+			pivotKey = sanitizeTableKey(label)
+			pivotKeys[label] = pivotKey
+		}
+		for _, measureName := range table.Measures {
+			measure := metricView.Measures[measureName]
+			columnIdentity := label + "\x00" + measureName
+			columnKey, columnExists := columnKeys[columnIdentity]
+			candidate := "pivot_" + pivotKey
+			columnLabel := label
+			if !pivotMode || len(table.Measures) > 1 {
+				candidate += "__" + sanitizeTableKey(measureName)
+				columnLabel = measureLabel(measureName, measure)
+			}
+			if !columnExists {
+				columnKey = uniqueTableColumnKey(candidate, usedKeys)
+				columnKeys[columnIdentity] = columnKey
+				usedKeys[columnKey] = columnKey
+				columns = append(columns, dashboard.TableColumn{
+					Key:         columnKey,
+					Label:       columnLabel,
+					Align:       "right",
+					Role:        "measure",
+					Group:       groupLabel,
+					Measure:     measureName,
+					ColumnValue: label,
+				})
+			}
+			row[columnKey] = raw[measureName]
+		}
+	}
+	result := make([]map[string]any, 0, len(order))
+	for _, key := range order {
+		result = append(result, resultByKey[key])
+	}
+	sortAggregateTableRows(result, request.Sort)
+	return columns, result, nil
+}
+
+func (m *DuckDBMetrics) queryTableDatums(ctx context.Context, runtime *modelRuntime, query string, columns []string, args ...any) ([]map[string]any, error) {
+	rows, err := runtime.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	values := make([]any, len(columns))
+	scans := make([]any, len(columns))
+	for i := range values {
+		scans[i] = &values[i]
+	}
+	result := []map[string]any{}
+	for rows.Next() {
+		if err := rows.Scan(scans...); err != nil {
+			return nil, err
+		}
+		row := map[string]any{}
+		for i, column := range columns {
+			row[column] = normalizeDBValue(values[i])
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+func tableColumnKeys(columns []dashboard.TableColumn) []string {
+	keys := make([]string, len(columns))
+	for i, column := range columns {
+		keys[i] = column.Key
+	}
+	return keys
+}
+
+func tableHasColumn(columns []dashboard.TableColumn, key string) bool {
+	for _, column := range columns {
+		if column.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func sortAggregateTableRows(rows []map[string]any, tableSort dashboard.TableSort) {
+	if tableSort.Key == "" {
+		return
+	}
+	direction := tableSort.Direction
+	sort.SliceStable(rows, func(i, j int) bool {
+		cmp := compareTableValues(rows[i][tableSort.Key], rows[j][tableSort.Key])
+		if direction == "desc" {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+}
+
+func compareTableValues(a, b any) int {
+	aFloat, aNumeric := numericTableValue(a)
+	bFloat, bNumeric := numericTableValue(b)
+	if aNumeric && bNumeric {
+		switch {
+		case aFloat < bFloat:
+			return -1
+		case aFloat > bFloat:
+			return 1
+		default:
+			return 0
+		}
+	}
+	aText := strings.ToLower(fmt.Sprint(a))
+	bText := strings.ToLower(fmt.Sprint(b))
+	switch {
+	case aText < bText:
+		return -1
+	case aText > bText:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func numericTableValue(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case string:
+		parsed, err := strconv.ParseFloat(typed, 64)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func dimensionLabel(name string, dimension semantic.MetricDimension) string {
+	if strings.TrimSpace(dimension.Label) != "" {
+		return dimension.Label
+	}
+	return name
+}
+
+func sanitizeTableKey(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			builder.WriteRune(r)
+			continue
+		}
+		builder.WriteByte('_')
+	}
+	key := strings.Trim(builder.String(), "_")
+	if key == "" {
+		return "value"
+	}
+	return key
+}
+
+func uniqueTableColumnKey(candidate string, existing map[string]string) string {
+	used := map[string]struct{}{}
+	for _, key := range existing {
+		used[key] = struct{}{}
+	}
+	key := candidate
+	for i := 2; ; i++ {
+		if _, ok := used[key]; !ok {
+			return key
+		}
+		key = fmt.Sprintf("%s_%d", candidate, i)
+	}
+}
+
+func initialBlockStarts(start, count, availableRows int) map[string]int {
+	start = clampTableStart(start, availableRows)
+	if start <= 0 {
+		return map[string]int{"a": 0, "b": count, "c": count * 2}
+	}
+	base := (start / count) * count
+	return map[string]int{"a": max(0, base-count), "b": base, "c": base + count}
+}
+
+func clampTableStart(start, availableRows int) int {
+	if start < 0 {
+		return 0
+	}
+	if availableRows <= 0 {
+		return 0
+	}
+	if start >= availableRows {
+		return max(0, availableRows-1)
+	}
+	return start
+}
+
+func (m *DuckDBMetrics) tableRows(ctx context.Context, runtime *modelRuntime, report *semantic.Dashboard, table semantic.TableVisual, filters dashboard.Filters, request dashboard.TableRequest, start, count, availableRows int) ([]map[string]any, error) {
+	if count <= 0 || start >= availableRows {
+		return []map[string]any{}, nil
+	}
+	if start+count > availableRows {
+		count = availableRows - start
+	}
+	source, err := m.metricViewSource(table.MetricView)
+	if err != nil {
+		return nil, err
+	}
+	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
+	sortExpr := tableSortExpr(table, request.Sort.Key)
+	direction := "DESC"
+	if request.Sort.Direction == "asc" {
+		direction = "ASC"
+	}
+
+	selects := make([]string, 0, len(table.Columns))
+	for _, column := range table.Columns {
+		if err := validateIdentifier(column.Key); err != nil {
+			return nil, err
+		}
+		selects = append(selects, "e."+column.Key)
+	}
+
+	query := fmt.Sprintf(`
+SELECT %s
+FROM %s e
+WHERE %s
+ORDER BY %s %s, e.order_id ASC
+LIMIT ? OFFSET ?`, strings.Join(selects, ", "), source, where, sortExpr, direction)
+
+	args = append(args, count, start)
+	rows, err := runtime.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	values := make([]any, len(table.Columns))
+	scans := make([]any, len(table.Columns))
+	for i := range values {
+		scans[i] = &values[i]
+	}
+
+	result := []map[string]any{}
+	for rows.Next() {
+		if err := rows.Scan(scans...); err != nil {
+			return nil, err
+		}
+		row := map[string]any{}
+		for i, column := range table.Columns {
+			row[column.Key] = normalizeDBValue(values[i])
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+func tableSortExpr(table semantic.TableVisual, key string) string {
+	if key == "" {
+		key = table.DefaultSort.Key
+	}
+	for _, column := range table.Columns {
+		if column.Key == key {
+			return "e." + column.Key
+		}
+	}
+	if table.DefaultSort.Key != "" {
+		return "e." + table.DefaultSort.Key
+	}
+	return "e.order_id"
+}

--- a/internal/deploy/assets.go
+++ b/internal/deploy/assets.go
@@ -37,7 +37,7 @@ func ExtractAssets(workspaceID, deploymentID string, workspace *semantic.Workspa
 		}
 		edge(catalogID, modelID, "contains")
 		for sourceName, source := range model.Sources {
-			id, err := add("source", modelEntry.ID+"."+sourceName, modelID, sourceName, source.File, source)
+			id, err := add("source", modelEntry.ID+"."+sourceName, modelID, sourceName, source.Description(), source)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -11,7 +11,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var semanticIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var (
+	semanticIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	envReferencePattern       = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
+)
 
 type Model struct {
 	Name              string                `yaml:"name"`
@@ -29,7 +32,6 @@ type Connection struct {
 	Kind     string             `yaml:"kind"`
 	Path     string             `yaml:"path"`
 	Root     string             `yaml:"root"`
-	Secret   string             `yaml:"secret"`
 	Scope    string             `yaml:"scope"`
 	Auth     ConnectionAuth     `yaml:"auth"`
 	Options  map[string]any     `yaml:"options"`
@@ -40,13 +42,7 @@ type ConnectionDefaults struct {
 	Options map[string]any `yaml:"options"`
 }
 
-type ConnectionAuth struct {
-	Method  string         `yaml:"method"`
-	Profile string         `yaml:"profile"`
-	Chain   string         `yaml:"chain"`
-	Account string         `yaml:"account"`
-	Params  map[string]any `yaml:"params"`
-}
+type ConnectionAuth map[string]any
 
 type Source struct {
 	Format     string         `yaml:"format"`
@@ -131,9 +127,11 @@ func (m *Model) Validate() error {
 		return fmt.Errorf("semantic model %q has no cache tables", m.Name)
 	}
 	for name, connection := range m.Connections {
-		if err := connection.Validate(name); err != nil {
+		resolved, err := connection.Validate(name)
+		if err != nil {
 			return err
 		}
+		m.Connections[name] = resolved
 	}
 	if m.DefaultConnection != "" {
 		if err := validateSemanticIdentifier(m.DefaultConnection); err != nil {
@@ -332,48 +330,40 @@ func (s Source) Validate(name string, connections map[string]Connection) error {
 	return nil
 }
 
-func (c Connection) Validate(name string) error {
+func (c Connection) Validate(name string) (Connection, error) {
 	if err := validateSemanticIdentifier(name); err != nil {
-		return fmt.Errorf("connection %q has invalid name: %w", name, err)
+		return c, fmt.Errorf("connection %q has invalid name: %w", name, err)
 	}
 	if c.Kind == "" {
-		return fmt.Errorf("connection %q requires kind", name)
+		return c, fmt.Errorf("connection %q requires kind", name)
 	}
 	connectionSpec, ok := sourcereg.LookupConnection(c.Kind)
 	if !ok {
-		return fmt.Errorf("connection %q has unsupported kind %q", name, c.Kind)
+		return c, fmt.Errorf("connection %q has unsupported kind %q", name, c.Kind)
 	}
 	if connectionSpec.RequiresPath {
 		if c.Path == "" {
-			return fmt.Errorf("connection %q %s requires path", name, c.Kind)
+			return c, fmt.Errorf("connection %q %s requires path", name, c.Kind)
 		}
 	} else if c.Path != "" && !connectionSpec.AllowsPath {
-		return fmt.Errorf("connection %q path is only supported for path-backed connections", name)
+		return c, fmt.Errorf("connection %q path is only supported for path-backed connections", name)
 	}
-	if c.Secret != "" {
-		if err := validateSemanticIdentifier(c.Secret); err != nil {
-			return fmt.Errorf("connection %q secret %q is invalid: %w", name, c.Secret, err)
-		}
+	auth, err := validateConnectionAuth(name, c, connectionSpec)
+	if err != nil {
+		return c, err
 	}
-	if c.Auth.Method != "" && !supportsAuthMethod(c.Auth.Method) {
-		return fmt.Errorf("connection %q has unsupported auth method %q", name, c.Auth.Method)
-	}
-	for key := range c.Auth.Params {
-		if err := validateSemanticIdentifier(key); err != nil {
-			return fmt.Errorf("connection %q auth param %q is invalid: %w", name, key, err)
-		}
-	}
+	c.Auth = auth
 	for key := range c.Options {
 		if !connectionAllowsOption(connectionSpec, key) {
-			return fmt.Errorf("connection %q has unsupported option %q", name, key)
+			return c, fmt.Errorf("connection %q has unsupported option %q", name, key)
 		}
 	}
 	for key := range c.Defaults.Options {
 		if err := validateSemanticIdentifier(key); err != nil {
-			return fmt.Errorf("connection %q default option %q is invalid: %w", name, key, err)
+			return c, fmt.Errorf("connection %q default option %q is invalid: %w", name, key, err)
 		}
 	}
-	return nil
+	return c, nil
 }
 
 func (s Source) Description() string {
@@ -418,20 +408,108 @@ func (s Source) Kind() string {
 	return kind
 }
 
-func supportsAuthMethod(method string) bool {
-	switch method {
-	case "credential_chain", "config":
-		return true
-	default:
-		return false
-	}
-}
-
 func connectionAllowsOption(connection sourcereg.Connection, option string) bool {
 	for _, allowed := range connection.AllowedOptions {
 		if option == allowed {
 			return true
 		}
+	}
+	return false
+}
+
+func validateConnectionAuth(name string, connection Connection, spec sourcereg.Connection) (ConnectionAuth, error) {
+	if len(connection.Auth) == 0 {
+		if connection.Kind == "ducklake" && duckLakeNeedsAuth(connection) {
+			return nil, fmt.Errorf("connection %q ducklake remote path requires auth", name)
+		}
+		if connection.Kind == "sqlite" && connection.Options["path"] != nil {
+			return nil, nil
+		}
+		if spec.AllowNoAuth {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("connection %q %s requires auth", name, connection.Kind)
+	}
+	resolved := make(ConnectionAuth, len(connection.Auth))
+	for key, value := range connection.Auth {
+		if err := validateSemanticIdentifier(key); err != nil {
+			return nil, fmt.Errorf("connection %q auth key %q is invalid: %w", name, key, err)
+		}
+		if !connectionAllowsAuthKey(spec, key) {
+			return nil, fmt.Errorf("connection %q has unsupported auth key %q", name, key)
+		}
+		resolvedValue, err := resolveAuthValue(name, key, value)
+		if err != nil {
+			return nil, err
+		}
+		resolved[key] = resolvedValue
+	}
+	if !connectionHasRequiredAuth(resolved, spec.RequiredAuthSets) {
+		return nil, fmt.Errorf("connection %q %s auth is missing required credentials", name, connection.Kind)
+	}
+	return resolved, nil
+}
+
+func connectionAllowsAuthKey(connection sourcereg.Connection, key string) bool {
+	for _, allowed := range connection.AuthKeys {
+		if key == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func connectionHasRequiredAuth(auth ConnectionAuth, requiredSets [][]string) bool {
+	if len(requiredSets) == 0 {
+		return true
+	}
+	for _, required := range requiredSets {
+		missing := false
+		for _, key := range required {
+			value, ok := auth[key]
+			if !ok || fmt.Sprint(value) == "" {
+				missing = true
+				break
+			}
+		}
+		if !missing {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveAuthValue(connectionName, key string, value any) (any, error) {
+	switch typed := value.(type) {
+	case string:
+		if matches := envReferencePattern.FindStringSubmatch(typed); matches != nil {
+			envName := matches[1]
+			resolved, ok := os.LookupEnv(envName)
+			if !ok || resolved == "" {
+				return nil, fmt.Errorf("connection %q auth key %q references missing environment variable %s", connectionName, key, envName)
+			}
+			return resolved, nil
+		}
+		if typed == "" {
+			return nil, fmt.Errorf("connection %q auth key %q cannot be empty", connectionName, key)
+		}
+		return typed, nil
+	case bool, int, int64, float64:
+		return typed, nil
+	default:
+		return nil, fmt.Errorf("connection %q auth key %q has unsupported value type %T", connectionName, key, value)
+	}
+}
+
+func duckLakeNeedsAuth(connection Connection) bool {
+	if connection.Scope != "" && !sourcereg.IsLocalPath(connection.Scope) {
+		return true
+	}
+	if connection.Path != "" && !sourcereg.IsLocalPath(connection.Path) {
+		return true
+	}
+	if dataPath, ok := connection.Options["data_path"]; ok && !sourcereg.IsLocalPath(fmt.Sprint(dataPath)) {
+		return true
 	}
 	return false
 }

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -3,23 +3,51 @@ package semantic
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
+var semanticIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 type Model struct {
-	Name          string             `yaml:"name"`
-	Title         string             `yaml:"title"`
-	Description   string             `yaml:"description"`
-	Sources       map[string]Source  `yaml:"sources"`
-	Cache         Cache              `yaml:"cache"`
-	Datasets      map[string]Dataset `yaml:"datasets"`
-	Relationships []Relationship     `yaml:"relationships"`
+	Name          string                `yaml:"name"`
+	Title         string                `yaml:"title"`
+	Description   string                `yaml:"description"`
+	Connections   map[string]Connection `yaml:"connections"`
+	Sources       map[string]Source     `yaml:"sources"`
+	Cache         Cache                 `yaml:"cache"`
+	Datasets      map[string]Dataset    `yaml:"datasets"`
+	Relationships []Relationship        `yaml:"relationships"`
+}
+
+type Connection struct {
+	Type    string         `yaml:"type"`
+	Secret  string         `yaml:"secret"`
+	Scope   string         `yaml:"scope"`
+	Auth    ConnectionAuth `yaml:"auth"`
+	Options map[string]any `yaml:"options"`
+}
+
+type ConnectionAuth struct {
+	Method  string         `yaml:"method"`
+	Profile string         `yaml:"profile"`
+	Chain   string         `yaml:"chain"`
+	Account string         `yaml:"account"`
+	Params  map[string]any `yaml:"params"`
 }
 
 type Source struct {
-	File string `yaml:"file"`
+	Type       string         `yaml:"type"`
+	Format     string         `yaml:"format"`
+	Location   string         `yaml:"location"`
+	Connection string         `yaml:"connection"`
+	Engine     string         `yaml:"engine"`
+	Object     string         `yaml:"object"`
+	Query      string         `yaml:"query"`
+	Options    map[string]any `yaml:"options"`
 }
 
 type Cache struct {
@@ -94,9 +122,14 @@ func (m *Model) Validate() error {
 	if len(m.Cache.Tables) == 0 {
 		return fmt.Errorf("semantic model %q has no cache tables", m.Name)
 	}
+	for name, connection := range m.Connections {
+		if err := connection.Validate(name); err != nil {
+			return err
+		}
+	}
 	for name, source := range m.Sources {
-		if source.File == "" {
-			return fmt.Errorf("source %q is missing file", name)
+		if err := source.Validate(name, m.Connections); err != nil {
+			return err
 		}
 	}
 	for name, table := range m.Cache.Tables {
@@ -184,9 +217,195 @@ func (v *MetricView) Validate(model *Model) error {
 func (m *Model) SourceFiles() map[string]string {
 	files := make(map[string]string, len(m.Sources))
 	for name, source := range m.Sources {
-		files[name] = source.File
+		if source.Type == "file" && isLocalLocation(source.Location) {
+			files[name] = source.Location
+		}
 	}
 	return files
+}
+
+func (s Source) Validate(name string, connections map[string]Connection) error {
+	if err := validateSemanticIdentifier(name); err != nil {
+		return fmt.Errorf("source %q has invalid name: %w", name, err)
+	}
+	if s.Type == "" {
+		return fmt.Errorf("source %q requires type", name)
+	}
+	for key := range s.Options {
+		if err := validateSemanticIdentifier(key); err != nil {
+			return fmt.Errorf("source %q option %q is invalid: %w", name, key, err)
+		}
+	}
+	switch s.Type {
+	case "file":
+		if s.Format == "" || s.Location == "" {
+			return fmt.Errorf("source %q type file requires format and location", name)
+		}
+		if !supportsFileFormat(s.Format) {
+			return fmt.Errorf("source %q has unsupported file format %q", name, s.Format)
+		}
+	case "lakehouse":
+		if s.Format == "" || s.Location == "" {
+			return fmt.Errorf("source %q type lakehouse requires format and location", name)
+		}
+		if !supportsLakehouseFormat(s.Format) {
+			return fmt.Errorf("source %q has unsupported lakehouse format %q", name, s.Format)
+		}
+	case "database":
+		if s.Engine == "" || s.Connection == "" || s.Object == "" {
+			return fmt.Errorf("source %q type database requires engine, connection, and object", name)
+		}
+		if !supportsDatabaseEngine(s.Engine) {
+			return fmt.Errorf("source %q has unsupported database engine %q", name, s.Engine)
+		}
+	case "query":
+		if s.Query == "" {
+			return fmt.Errorf("source %q type query requires query", name)
+		}
+	default:
+		return fmt.Errorf("source %q has unsupported type %q", name, s.Type)
+	}
+	if s.Connection != "" {
+		connection, ok := connections[s.Connection]
+		if !ok {
+			return fmt.Errorf("source %q references unknown connection %q", name, s.Connection)
+		}
+		if s.Type == "database" && connection.Type != s.Engine {
+			return fmt.Errorf("source %q database engine %q does not match connection %q type %q", name, s.Engine, s.Connection, connection.Type)
+		}
+	}
+	return nil
+}
+
+func (c Connection) Validate(name string) error {
+	if err := validateSemanticIdentifier(name); err != nil {
+		return fmt.Errorf("connection %q has invalid name: %w", name, err)
+	}
+	if c.Type == "" {
+		return fmt.Errorf("connection %q requires type", name)
+	}
+	if !supportsConnectionType(c.Type) {
+		return fmt.Errorf("connection %q has unsupported type %q", name, c.Type)
+	}
+	if c.Secret != "" {
+		if err := validateSemanticIdentifier(c.Secret); err != nil {
+			return fmt.Errorf("connection %q secret %q is invalid: %w", name, c.Secret, err)
+		}
+	}
+	if c.Auth.Method != "" && !supportsAuthMethod(c.Auth.Method) {
+		return fmt.Errorf("connection %q has unsupported auth method %q", name, c.Auth.Method)
+	}
+	for key := range c.Auth.Params {
+		if err := validateSemanticIdentifier(key); err != nil {
+			return fmt.Errorf("connection %q auth param %q is invalid: %w", name, key, err)
+		}
+	}
+	for key := range c.Options {
+		if !supportsConnectionOption(key) {
+			return fmt.Errorf("connection %q has unsupported option %q", name, key)
+		}
+	}
+	return nil
+}
+
+func (s Source) Description() string {
+	switch s.Type {
+	case "file":
+		return s.Format + " file: " + s.Location
+	case "lakehouse":
+		return s.Format + " table: " + s.Location
+	case "database":
+		return s.Engine + " table: " + s.Object
+	case "query":
+		return "trusted query source"
+	default:
+		return s.Type
+	}
+}
+
+func (s Source) Role() string {
+	switch s.Type {
+	case "file":
+		return s.Format
+	case "lakehouse":
+		return s.Format
+	case "database":
+		return s.Engine
+	case "query":
+		return "query"
+	default:
+		return s.Type
+	}
+}
+
+func isLocalLocation(location string) bool {
+	for _, prefix := range []string{"s3://", "r2://", "gcs://", "gs://", "az://", "azure://", "abfss://", "http://", "https://", "file://"} {
+		if strings.HasPrefix(location, prefix) {
+			return false
+		}
+	}
+	return !strings.Contains(location, "://")
+}
+
+func supportsConnectionType(connectionType string) bool {
+	switch connectionType {
+	case "s3", "r2", "gcs", "azure", "http", "postgres", "mysql", "sqlite":
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsAuthMethod(method string) bool {
+	switch method {
+	case "credential_chain", "config":
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsConnectionOption(option string) bool {
+	switch option {
+	case "connection_string", "uri", "path", "database":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateSemanticIdentifier(value string) error {
+	if !semanticIdentifierPattern.MatchString(value) {
+		return fmt.Errorf("must match %s", semanticIdentifierPattern.String())
+	}
+	return nil
+}
+
+func supportsFileFormat(format string) bool {
+	switch format {
+	case "csv", "json", "parquet", "excel":
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsLakehouseFormat(format string) bool {
+	switch format {
+	case "delta", "iceberg":
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsDatabaseEngine(engine string) bool {
+	switch engine {
+	case "postgres", "mysql", "sqlite":
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *Model) CacheTableNames() []string {

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -13,14 +13,15 @@ import (
 var semanticIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 type Model struct {
-	Name          string                `yaml:"name"`
-	Title         string                `yaml:"title"`
-	Description   string                `yaml:"description"`
-	Connections   map[string]Connection `yaml:"connections"`
-	Sources       map[string]Source     `yaml:"sources"`
-	Cache         Cache                 `yaml:"cache"`
-	Datasets      map[string]Dataset    `yaml:"datasets"`
-	Relationships []Relationship        `yaml:"relationships"`
+	Name           string                `yaml:"name"`
+	Title          string                `yaml:"title"`
+	Description    string                `yaml:"description"`
+	Connections    map[string]Connection `yaml:"connections"`
+	SourceDefaults Source                `yaml:"source_defaults"`
+	Sources        map[string]Source     `yaml:"sources"`
+	Cache          Cache                 `yaml:"cache"`
+	Datasets       map[string]Dataset    `yaml:"datasets"`
+	Relationships  []Relationship        `yaml:"relationships"`
 }
 
 type Connection struct {
@@ -48,6 +49,20 @@ type Source struct {
 	Object     string         `yaml:"object"`
 	Query      string         `yaml:"query"`
 	Options    map[string]any `yaml:"options"`
+}
+
+func (s *Source) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode && value.Tag == "!!str" {
+		s.Location = value.Value
+		return nil
+	}
+	type source Source
+	var decoded source
+	if err := value.Decode(&decoded); err != nil {
+		return err
+	}
+	*s = Source(decoded)
+	return nil
 }
 
 type Cache struct {
@@ -113,6 +128,7 @@ func Load(path string) (*Model, error) {
 }
 
 func (m *Model) Validate() error {
+	m.applySourceDefaults()
 	if m.Name == "" {
 		return fmt.Errorf("semantic model name is required")
 	}
@@ -159,6 +175,50 @@ func (m *Model) Validate() error {
 		seenRelationships[relationship.ID] = struct{}{}
 	}
 	return nil
+}
+
+func (m *Model) applySourceDefaults() {
+	if len(m.Sources) == 0 {
+		return
+	}
+	for name, source := range m.Sources {
+		m.Sources[name] = applySourceDefault(source, m.SourceDefaults)
+	}
+}
+
+func applySourceDefault(source, defaults Source) Source {
+	if source.Type == "" {
+		source.Type = defaults.Type
+	}
+	if source.Format == "" {
+		source.Format = defaults.Format
+	}
+	if source.Location == "" {
+		source.Location = defaults.Location
+	}
+	if source.Connection == "" {
+		source.Connection = defaults.Connection
+	}
+	if source.Engine == "" {
+		source.Engine = defaults.Engine
+	}
+	if source.Object == "" {
+		source.Object = defaults.Object
+	}
+	if source.Query == "" {
+		source.Query = defaults.Query
+	}
+	if len(defaults.Options) > 0 {
+		options := make(map[string]any, len(defaults.Options)+len(source.Options))
+		for key, value := range defaults.Options {
+			options[key] = value
+		}
+		for key, value := range source.Options {
+			options[key] = value
+		}
+		source.Options = options
+	}
+	return source
 }
 
 func LoadMetricView(path string, model *Model) (*MetricView, error) {

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -1,6 +1,7 @@
 package semantic
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"regexp"
@@ -13,22 +14,29 @@ import (
 var semanticIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 type Model struct {
-	Name           string                `yaml:"name"`
-	Title          string                `yaml:"title"`
-	Description    string                `yaml:"description"`
-	Connections    map[string]Connection `yaml:"connections"`
-	SourceDefaults Source                `yaml:"source_defaults"`
-	Sources        map[string]Source     `yaml:"sources"`
-	Cache          Cache                 `yaml:"cache"`
-	Datasets       map[string]Dataset    `yaml:"datasets"`
-	Relationships  []Relationship        `yaml:"relationships"`
+	Name              string                `yaml:"name"`
+	Title             string                `yaml:"title"`
+	Description       string                `yaml:"description"`
+	DefaultConnection string                `yaml:"default_connection"`
+	Connections       map[string]Connection `yaml:"connections"`
+	Sources           map[string]Source     `yaml:"sources"`
+	Cache             Cache                 `yaml:"cache"`
+	Datasets          map[string]Dataset    `yaml:"datasets"`
+	Relationships     []Relationship        `yaml:"relationships"`
 }
 
 type Connection struct {
-	Type    string         `yaml:"type"`
-	Secret  string         `yaml:"secret"`
-	Scope   string         `yaml:"scope"`
-	Auth    ConnectionAuth `yaml:"auth"`
+	Kind     string             `yaml:"kind"`
+	Root     string             `yaml:"root"`
+	Secret   string             `yaml:"secret"`
+	Scope    string             `yaml:"scope"`
+	Auth     ConnectionAuth     `yaml:"auth"`
+	Options  map[string]any     `yaml:"options"`
+	Defaults ConnectionDefaults `yaml:"defaults"`
+}
+
+type ConnectionDefaults struct {
+	Format  string         `yaml:"format"`
 	Options map[string]any `yaml:"options"`
 }
 
@@ -41,28 +49,12 @@ type ConnectionAuth struct {
 }
 
 type Source struct {
-	Type       string         `yaml:"type"`
 	Format     string         `yaml:"format"`
 	Location   string         `yaml:"location"`
 	Connection string         `yaml:"connection"`
-	Engine     string         `yaml:"engine"`
 	Object     string         `yaml:"object"`
 	Query      string         `yaml:"query"`
 	Options    map[string]any `yaml:"options"`
-}
-
-func (s *Source) UnmarshalYAML(value *yaml.Node) error {
-	if value.Kind == yaml.ScalarNode && value.Tag == "!!str" {
-		s.Location = value.Value
-		return nil
-	}
-	type source Source
-	var decoded source
-	if err := value.Decode(&decoded); err != nil {
-		return err
-	}
-	*s = Source(decoded)
-	return nil
 }
 
 type Cache struct {
@@ -113,12 +105,14 @@ type Relationship struct {
 }
 
 func Load(path string) (*Model, error) {
-	bytes, err := os.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 	var model Model
-	if err := yaml.Unmarshal(bytes, &model); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&model); err != nil {
 		return nil, err
 	}
 	if err := model.Validate(); err != nil {
@@ -128,7 +122,6 @@ func Load(path string) (*Model, error) {
 }
 
 func (m *Model) Validate() error {
-	m.applySourceDefaults()
 	if m.Name == "" {
 		return fmt.Errorf("semantic model name is required")
 	}
@@ -143,10 +136,23 @@ func (m *Model) Validate() error {
 			return err
 		}
 	}
+	if m.DefaultConnection != "" {
+		if err := validateSemanticIdentifier(m.DefaultConnection); err != nil {
+			return fmt.Errorf("default_connection %q is invalid: %w", m.DefaultConnection, err)
+		}
+		if _, ok := m.Connections[m.DefaultConnection]; !ok {
+			return fmt.Errorf("default_connection %q references unknown connection", m.DefaultConnection)
+		}
+	}
 	for name, source := range m.Sources {
-		if err := source.Validate(name, m.Connections); err != nil {
+		resolved, err := m.resolveSource(source)
+		if err != nil {
+			return fmt.Errorf("source %q: %w", name, err)
+		}
+		if err := resolved.Validate(name, m.Connections); err != nil {
 			return err
 		}
+		m.Sources[name] = resolved
 	}
 	for name, table := range m.Cache.Tables {
 		if table.SQL == "" {
@@ -177,48 +183,47 @@ func (m *Model) Validate() error {
 	return nil
 }
 
-func (m *Model) applySourceDefaults() {
-	if len(m.Sources) == 0 {
-		return
-	}
-	for name, source := range m.Sources {
-		m.Sources[name] = applySourceDefault(source, m.SourceDefaults)
-	}
-}
-
-func applySourceDefault(source, defaults Source) Source {
-	if source.Type == "" {
-		source.Type = defaults.Type
-	}
-	if source.Format == "" {
-		source.Format = defaults.Format
-	}
-	if source.Location == "" {
-		source.Location = defaults.Location
-	}
-	if source.Connection == "" {
-		source.Connection = defaults.Connection
-	}
-	if source.Engine == "" {
-		source.Engine = defaults.Engine
-	}
-	if source.Object == "" {
-		source.Object = defaults.Object
-	}
-	if source.Query == "" {
-		source.Query = defaults.Query
-	}
-	if len(defaults.Options) > 0 {
-		options := make(map[string]any, len(defaults.Options)+len(source.Options))
-		for key, value := range defaults.Options {
-			options[key] = value
+func (m *Model) resolveSource(source Source) (Source, error) {
+	switch source.Kind() {
+	case "query":
+		return source, nil
+	case "location", "database":
+		if source.Connection == "" {
+			source.Connection = m.DefaultConnection
 		}
-		for key, value := range source.Options {
-			options[key] = value
+		if source.Connection == "" {
+			return source, fmt.Errorf("requires connection")
 		}
-		source.Options = options
+		connection, ok := m.Connections[source.Connection]
+		if !ok {
+			return source, fmt.Errorf("references unknown connection %q", source.Connection)
+		}
+		if source.Location != "" {
+			if source.Format == "" {
+				source.Format = connection.Defaults.Format
+			}
+			if len(connection.Defaults.Options) > 0 {
+				options := make(map[string]any, len(connection.Defaults.Options)+len(source.Options))
+				for key, value := range connection.Defaults.Options {
+					options[key] = value
+				}
+				for key, value := range source.Options {
+					options[key] = value
+				}
+				source.Options = options
+			}
+			if source.Format == "" {
+				format, ok := inferSourceFormat(source.Location)
+				if !ok {
+					return source, fmt.Errorf("location %q requires format", source.Location)
+				}
+				source.Format = format
+			}
+		}
+		return source, nil
+	default:
+		return source, nil
 	}
-	return source
 }
 
 func LoadMetricView(path string, model *Model) (*MetricView, error) {
@@ -274,65 +279,62 @@ func (v *MetricView) Validate(model *Model) error {
 	return nil
 }
 
-func (m *Model) SourceFiles() map[string]string {
-	files := make(map[string]string, len(m.Sources))
-	for name, source := range m.Sources {
-		if source.Type == "file" && isLocalLocation(source.Location) {
-			files[name] = source.Location
-		}
-	}
-	return files
-}
-
 func (s Source) Validate(name string, connections map[string]Connection) error {
 	if err := validateSemanticIdentifier(name); err != nil {
 		return fmt.Errorf("source %q has invalid name: %w", name, err)
-	}
-	if s.Type == "" {
-		return fmt.Errorf("source %q requires type", name)
 	}
 	for key := range s.Options {
 		if err := validateSemanticIdentifier(key); err != nil {
 			return fmt.Errorf("source %q option %q is invalid: %w", name, key, err)
 		}
 	}
-	switch s.Type {
-	case "file":
-		if s.Format == "" || s.Location == "" {
-			return fmt.Errorf("source %q type file requires format and location", name)
+	switch s.Kind() {
+	case "location":
+		if s.Connection == "" {
+			return fmt.Errorf("source %q requires connection", name)
 		}
-		if !supportsFileFormat(s.Format) {
-			return fmt.Errorf("source %q has unsupported file format %q", name, s.Format)
-		}
-	case "lakehouse":
-		if s.Format == "" || s.Location == "" {
-			return fmt.Errorf("source %q type lakehouse requires format and location", name)
-		}
-		if !supportsLakehouseFormat(s.Format) {
-			return fmt.Errorf("source %q has unsupported lakehouse format %q", name, s.Format)
-		}
-	case "database":
-		if s.Engine == "" || s.Connection == "" || s.Object == "" {
-			return fmt.Errorf("source %q type database requires engine, connection, and object", name)
-		}
-		if !supportsDatabaseEngine(s.Engine) {
-			return fmt.Errorf("source %q has unsupported database engine %q", name, s.Engine)
-		}
-	case "query":
-		if s.Query == "" {
-			return fmt.Errorf("source %q type query requires query", name)
-		}
-	default:
-		return fmt.Errorf("source %q has unsupported type %q", name, s.Type)
-	}
-	if s.Connection != "" {
 		connection, ok := connections[s.Connection]
 		if !ok {
 			return fmt.Errorf("source %q references unknown connection %q", name, s.Connection)
 		}
-		if s.Type == "database" && connection.Type != s.Engine {
-			return fmt.Errorf("source %q database engine %q does not match connection %q type %q", name, s.Engine, s.Connection, connection.Type)
+		if !supportsLocationConnection(connection.Kind) {
+			return fmt.Errorf("source %q location cannot use %s connection %q", name, connection.Kind, s.Connection)
 		}
+		if connection.Kind == "local" && !isLocalLocation(s.Location) {
+			return fmt.Errorf("source %q local connection %q cannot use remote location %q", name, s.Connection, s.Location)
+		}
+		if isRemoteConnection(connection.Kind) && isLocalLocation(s.Location) && connection.Scope == "" {
+			return fmt.Errorf("source %q remote connection %q requires scope for relative location %q", name, s.Connection, s.Location)
+		}
+		if s.Format == "" {
+			return fmt.Errorf("source %q location requires format", name)
+		}
+		if !supportsSourceFormat(s.Format) {
+			return fmt.Errorf("source %q has unsupported format %q", name, s.Format)
+		}
+	case "database":
+		if s.Connection == "" {
+			return fmt.Errorf("source %q database object requires connection", name)
+		}
+		if s.Format != "" || len(s.Options) > 0 {
+			return fmt.Errorf("source %q database object cannot set format or options", name)
+		}
+		connection, ok := connections[s.Connection]
+		if !ok {
+			return fmt.Errorf("source %q references unknown connection %q", name, s.Connection)
+		}
+		if !supportsDatabaseConnection(connection.Kind) {
+			return fmt.Errorf("source %q object cannot use %s connection %q", name, connection.Kind, s.Connection)
+		}
+	case "query":
+		if s.Query == "" {
+			return fmt.Errorf("source %q query requires query", name)
+		}
+		if s.Connection != "" || s.Location != "" || s.Object != "" || s.Format != "" || len(s.Options) > 0 {
+			return fmt.Errorf("source %q query cannot set connection, location, object, format, or options", name)
+		}
+	default:
+		return fmt.Errorf("source %q requires exactly one of location, object, or query", name)
 	}
 	return nil
 }
@@ -341,11 +343,11 @@ func (c Connection) Validate(name string) error {
 	if err := validateSemanticIdentifier(name); err != nil {
 		return fmt.Errorf("connection %q has invalid name: %w", name, err)
 	}
-	if c.Type == "" {
-		return fmt.Errorf("connection %q requires type", name)
+	if c.Kind == "" {
+		return fmt.Errorf("connection %q requires kind", name)
 	}
-	if !supportsConnectionType(c.Type) {
-		return fmt.Errorf("connection %q has unsupported type %q", name, c.Type)
+	if !supportsConnectionKind(c.Kind) {
+		return fmt.Errorf("connection %q has unsupported kind %q", name, c.Kind)
 	}
 	if c.Secret != "" {
 		if err := validateSemanticIdentifier(c.Secret); err != nil {
@@ -365,37 +367,65 @@ func (c Connection) Validate(name string) error {
 			return fmt.Errorf("connection %q has unsupported option %q", name, key)
 		}
 	}
+	if c.Defaults.Format != "" && !supportsSourceFormat(c.Defaults.Format) {
+		return fmt.Errorf("connection %q has unsupported default format %q", name, c.Defaults.Format)
+	}
+	for key := range c.Defaults.Options {
+		if err := validateSemanticIdentifier(key); err != nil {
+			return fmt.Errorf("connection %q default option %q is invalid: %w", name, key, err)
+		}
+	}
 	return nil
 }
 
 func (s Source) Description() string {
-	switch s.Type {
-	case "file":
+	switch s.Kind() {
+	case "location":
+		if supportsLakehouseFormat(s.Format) {
+			return s.Format + " table: " + s.Location
+		}
 		return s.Format + " file: " + s.Location
-	case "lakehouse":
-		return s.Format + " table: " + s.Location
 	case "database":
-		return s.Engine + " table: " + s.Object
+		return "database object: " + s.Object
 	case "query":
 		return "trusted query source"
 	default:
-		return s.Type
+		return "source"
 	}
 }
 
 func (s Source) Role() string {
-	switch s.Type {
-	case "file":
-		return s.Format
-	case "lakehouse":
+	switch s.Kind() {
+	case "location":
 		return s.Format
 	case "database":
-		return s.Engine
+		return "database"
 	case "query":
 		return "query"
 	default:
-		return s.Type
+		return "source"
 	}
+}
+
+func (s Source) Kind() string {
+	count := 0
+	kind := ""
+	if s.Location != "" {
+		count++
+		kind = "location"
+	}
+	if s.Object != "" {
+		count++
+		kind = "database"
+	}
+	if s.Query != "" {
+		count++
+		kind = "query"
+	}
+	if count != 1 {
+		return ""
+	}
+	return kind
 }
 
 func isLocalLocation(location string) bool {
@@ -407,9 +437,9 @@ func isLocalLocation(location string) bool {
 	return !strings.Contains(location, "://")
 }
 
-func supportsConnectionType(connectionType string) bool {
-	switch connectionType {
-	case "s3", "r2", "gcs", "azure", "http", "postgres", "mysql", "sqlite":
+func supportsConnectionKind(kind string) bool {
+	switch kind {
+	case "local", "s3", "r2", "gcs", "http", "azure_blob", "postgres", "mysql", "sqlite":
 		return true
 	default:
 		return false
@@ -459,13 +489,55 @@ func supportsLakehouseFormat(format string) bool {
 	}
 }
 
-func supportsDatabaseEngine(engine string) bool {
-	switch engine {
+func supportsSourceFormat(format string) bool {
+	return supportsFileFormat(format) || supportsLakehouseFormat(format)
+}
+
+func supportsLocationConnection(kind string) bool {
+	switch kind {
+	case "local", "s3", "r2", "gcs", "http", "azure_blob":
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsDatabaseConnection(kind string) bool {
+	switch kind {
 	case "postgres", "mysql", "sqlite":
 		return true
 	default:
 		return false
 	}
+}
+
+func isRemoteConnection(kind string) bool {
+	return supportsLocationConnection(kind) && kind != "local"
+}
+
+func inferSourceFormat(location string) (string, bool) {
+	switch strings.ToLower(filepathExt(location)) {
+	case ".csv":
+		return "csv", true
+	case ".json", ".jsonl":
+		return "json", true
+	case ".parquet":
+		return "parquet", true
+	case ".xlsx":
+		return "excel", true
+	default:
+		return "", false
+	}
+}
+
+func filepathExt(location string) string {
+	if index := strings.LastIndexAny(location, `/\`); index >= 0 {
+		location = location[index+1:]
+	}
+	if index := strings.LastIndex(location, "."); index >= 0 {
+		return location[index:]
+	}
+	return ""
 }
 
 func (m *Model) CacheTableNames() []string {

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -27,6 +27,7 @@ type Model struct {
 
 type Connection struct {
 	Kind     string             `yaml:"kind"`
+	Path     string             `yaml:"path"`
 	Root     string             `yaml:"root"`
 	Secret   string             `yaml:"secret"`
 	Scope    string             `yaml:"scope"`
@@ -49,7 +50,7 @@ type ConnectionAuth struct {
 
 type Source struct {
 	Format     string         `yaml:"format"`
-	Location   string         `yaml:"location"`
+	Path       string         `yaml:"path"`
 	Connection string         `yaml:"connection"`
 	Object     string         `yaml:"object"`
 	Options    map[string]any `yaml:"options"`
@@ -183,7 +184,7 @@ func (m *Model) Validate() error {
 
 func (m *Model) resolveSource(source Source) (Source, error) {
 	switch source.Kind() {
-	case "location", "database":
+	case "path", "database":
 		if source.Connection == "" {
 			source.Connection = m.DefaultConnection
 		}
@@ -194,7 +195,7 @@ func (m *Model) resolveSource(source Source) (Source, error) {
 		if !ok {
 			return source, fmt.Errorf("references unknown connection %q", source.Connection)
 		}
-		if source.Location != "" {
+		if source.Path != "" {
 			if len(connection.Defaults.Options) > 0 {
 				options := make(map[string]any, len(connection.Defaults.Options)+len(source.Options))
 				for key, value := range connection.Defaults.Options {
@@ -206,9 +207,9 @@ func (m *Model) resolveSource(source Source) (Source, error) {
 				source.Options = options
 			}
 			if source.Format == "" {
-				format, ok := inferSourceFormat(source.Location)
+				format, ok := inferSourceFormat(source.Path)
 				if !ok {
-					return source, fmt.Errorf("location %q requires format", source.Location)
+					return source, fmt.Errorf("path %q requires format", source.Path)
 				}
 				source.Format = format
 			}
@@ -282,7 +283,7 @@ func (s Source) Validate(name string, connections map[string]Connection) error {
 		}
 	}
 	switch s.Kind() {
-	case "location":
+	case "path":
 		if s.Connection == "" {
 			return fmt.Errorf("source %q requires connection", name)
 		}
@@ -291,19 +292,22 @@ func (s Source) Validate(name string, connections map[string]Connection) error {
 			return fmt.Errorf("source %q references unknown connection %q", name, s.Connection)
 		}
 		if !supportsLocationConnection(connection.Kind) {
-			return fmt.Errorf("source %q location cannot use %s connection %q", name, connection.Kind, s.Connection)
+			return fmt.Errorf("source %q path cannot use %s connection %q", name, connection.Kind, s.Connection)
 		}
-		if connection.Kind == "local" && !isLocalLocation(s.Location) {
-			return fmt.Errorf("source %q local connection %q cannot use remote location %q", name, s.Connection, s.Location)
+		if connection.Kind == "local" && !isLocalLocation(s.Path) {
+			return fmt.Errorf("source %q local connection %q cannot use remote path %q", name, s.Connection, s.Path)
 		}
-		if isRemoteConnection(connection.Kind) && isLocalLocation(s.Location) && connection.Scope == "" {
-			return fmt.Errorf("source %q remote connection %q requires scope for relative location %q", name, s.Connection, s.Location)
+		if isRemoteConnection(connection.Kind) && isLocalLocation(s.Path) && connection.Scope == "" {
+			return fmt.Errorf("source %q remote connection %q requires scope for relative path %q", name, s.Connection, s.Path)
 		}
 		if s.Format == "" {
-			return fmt.Errorf("source %q location requires format", name)
+			return fmt.Errorf("source %q path requires format", name)
 		}
 		if !supportsSourceFormat(s.Format) {
 			return fmt.Errorf("source %q has unsupported format %q", name, s.Format)
+		}
+		if s.Format == "lance" && len(s.Options) > 0 {
+			return fmt.Errorf("source %q lance path cannot set options", name)
 		}
 	case "database":
 		if s.Connection == "" {
@@ -320,7 +324,7 @@ func (s Source) Validate(name string, connections map[string]Connection) error {
 			return fmt.Errorf("source %q object cannot use %s connection %q", name, connection.Kind, s.Connection)
 		}
 	default:
-		return fmt.Errorf("source %q requires exactly one of location or object", name)
+		return fmt.Errorf("source %q requires exactly one of path or object", name)
 	}
 	return nil
 }
@@ -334,6 +338,13 @@ func (c Connection) Validate(name string) error {
 	}
 	if !supportsConnectionKind(c.Kind) {
 		return fmt.Errorf("connection %q has unsupported kind %q", name, c.Kind)
+	}
+	if c.Kind == "ducklake" {
+		if c.Path == "" {
+			return fmt.Errorf("connection %q ducklake requires path", name)
+		}
+	} else if c.Path != "" {
+		return fmt.Errorf("connection %q path is only supported for ducklake", name)
 	}
 	if c.Secret != "" {
 		if err := validateSemanticIdentifier(c.Secret); err != nil {
@@ -349,7 +360,7 @@ func (c Connection) Validate(name string) error {
 		}
 	}
 	for key := range c.Options {
-		if !supportsConnectionOption(key) {
+		if !supportsConnectionOption(c.Kind, key) {
 			return fmt.Errorf("connection %q has unsupported option %q", name, key)
 		}
 	}
@@ -363,11 +374,11 @@ func (c Connection) Validate(name string) error {
 
 func (s Source) Description() string {
 	switch s.Kind() {
-	case "location":
+	case "path":
 		if supportsLakehouseFormat(s.Format) {
-			return s.Format + " table: " + s.Location
+			return s.Format + " table: " + s.Path
 		}
-		return s.Format + " file: " + s.Location
+		return s.Format + " file: " + s.Path
 	case "database":
 		return "database object: " + s.Object
 	default:
@@ -377,7 +388,7 @@ func (s Source) Description() string {
 
 func (s Source) Role() string {
 	switch s.Kind() {
-	case "location":
+	case "path":
 		return s.Format
 	case "database":
 		return "database"
@@ -389,9 +400,9 @@ func (s Source) Role() string {
 func (s Source) Kind() string {
 	count := 0
 	kind := ""
-	if s.Location != "" {
+	if s.Path != "" {
 		count++
-		kind = "location"
+		kind = "path"
 	}
 	if s.Object != "" {
 		count++
@@ -414,7 +425,7 @@ func isLocalLocation(location string) bool {
 
 func supportsConnectionKind(kind string) bool {
 	switch kind {
-	case "local", "s3", "r2", "gcs", "http", "azure_blob", "postgres", "mysql", "sqlite":
+	case "local", "s3", "r2", "gcs", "http", "azure_blob", "postgres", "mysql", "sqlite", "ducklake":
 		return true
 	default:
 		return false
@@ -430,10 +441,17 @@ func supportsAuthMethod(method string) bool {
 	}
 }
 
-func supportsConnectionOption(option string) bool {
-	switch option {
-	case "connection_string", "uri", "path", "database":
-		return true
+func supportsConnectionOption(kind, option string) bool {
+	switch kind {
+	case "ducklake":
+		return option == "data_path"
+	case "postgres", "mysql", "sqlite":
+		switch option {
+		case "connection_string", "uri", "path", "database":
+			return true
+		default:
+			return false
+		}
 	default:
 		return false
 	}
@@ -448,7 +466,7 @@ func validateSemanticIdentifier(value string) error {
 
 func supportsFileFormat(format string) bool {
 	switch format {
-	case "csv", "json", "parquet", "excel", "text", "blob", "vortex":
+	case "csv", "json", "parquet", "excel", "text", "blob", "vortex", "lance":
 		return true
 	default:
 		return false
@@ -457,7 +475,7 @@ func supportsFileFormat(format string) bool {
 
 func supportsLakehouseFormat(format string) bool {
 	switch format {
-	case "delta", "iceberg":
+	case "delta", "iceberg", "lance":
 		return true
 	default:
 		return false
@@ -479,7 +497,7 @@ func supportsLocationConnection(kind string) bool {
 
 func supportsDatabaseConnection(kind string) bool {
 	switch kind {
-	case "postgres", "mysql", "sqlite":
+	case "postgres", "mysql", "sqlite", "ducklake":
 		return true
 	default:
 		return false
@@ -508,6 +526,8 @@ func inferSourceFormat(location string) (string, bool) {
 		return "blob", true
 	case ext == ".vortex":
 		return "vortex", true
+	case ext == ".lance":
+		return "lance", true
 	default:
 		return "", false
 	}

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -36,7 +36,6 @@ type Connection struct {
 }
 
 type ConnectionDefaults struct {
-	Format  string         `yaml:"format"`
 	Options map[string]any `yaml:"options"`
 }
 
@@ -53,7 +52,6 @@ type Source struct {
 	Location   string         `yaml:"location"`
 	Connection string         `yaml:"connection"`
 	Object     string         `yaml:"object"`
-	Query      string         `yaml:"query"`
 	Options    map[string]any `yaml:"options"`
 }
 
@@ -185,8 +183,6 @@ func (m *Model) Validate() error {
 
 func (m *Model) resolveSource(source Source) (Source, error) {
 	switch source.Kind() {
-	case "query":
-		return source, nil
 	case "location", "database":
 		if source.Connection == "" {
 			source.Connection = m.DefaultConnection
@@ -199,9 +195,6 @@ func (m *Model) resolveSource(source Source) (Source, error) {
 			return source, fmt.Errorf("references unknown connection %q", source.Connection)
 		}
 		if source.Location != "" {
-			if source.Format == "" {
-				source.Format = connection.Defaults.Format
-			}
 			if len(connection.Defaults.Options) > 0 {
 				options := make(map[string]any, len(connection.Defaults.Options)+len(source.Options))
 				for key, value := range connection.Defaults.Options {
@@ -326,15 +319,8 @@ func (s Source) Validate(name string, connections map[string]Connection) error {
 		if !supportsDatabaseConnection(connection.Kind) {
 			return fmt.Errorf("source %q object cannot use %s connection %q", name, connection.Kind, s.Connection)
 		}
-	case "query":
-		if s.Query == "" {
-			return fmt.Errorf("source %q query requires query", name)
-		}
-		if s.Connection != "" || s.Location != "" || s.Object != "" || s.Format != "" || len(s.Options) > 0 {
-			return fmt.Errorf("source %q query cannot set connection, location, object, format, or options", name)
-		}
 	default:
-		return fmt.Errorf("source %q requires exactly one of location, object, or query", name)
+		return fmt.Errorf("source %q requires exactly one of location or object", name)
 	}
 	return nil
 }
@@ -367,9 +353,6 @@ func (c Connection) Validate(name string) error {
 			return fmt.Errorf("connection %q has unsupported option %q", name, key)
 		}
 	}
-	if c.Defaults.Format != "" && !supportsSourceFormat(c.Defaults.Format) {
-		return fmt.Errorf("connection %q has unsupported default format %q", name, c.Defaults.Format)
-	}
 	for key := range c.Defaults.Options {
 		if err := validateSemanticIdentifier(key); err != nil {
 			return fmt.Errorf("connection %q default option %q is invalid: %w", name, key, err)
@@ -387,8 +370,6 @@ func (s Source) Description() string {
 		return s.Format + " file: " + s.Location
 	case "database":
 		return "database object: " + s.Object
-	case "query":
-		return "trusted query source"
 	default:
 		return "source"
 	}
@@ -400,8 +381,6 @@ func (s Source) Role() string {
 		return s.Format
 	case "database":
 		return "database"
-	case "query":
-		return "query"
 	default:
 		return "source"
 	}
@@ -417,10 +396,6 @@ func (s Source) Kind() string {
 	if s.Object != "" {
 		count++
 		kind = "database"
-	}
-	if s.Query != "" {
-		count++
-		kind = "query"
 	}
 	if count != 1 {
 		return ""
@@ -473,7 +448,7 @@ func validateSemanticIdentifier(value string) error {
 
 func supportsFileFormat(format string) bool {
 	switch format {
-	case "csv", "json", "parquet", "excel":
+	case "csv", "json", "parquet", "excel", "text", "blob", "vortex":
 		return true
 	default:
 		return false
@@ -516,18 +491,33 @@ func isRemoteConnection(kind string) bool {
 }
 
 func inferSourceFormat(location string) (string, bool) {
-	switch strings.ToLower(filepathExt(location)) {
-	case ".csv":
+	base, compression := splitCompressionSuffix(location)
+	ext := strings.ToLower(filepathExt(base))
+	switch {
+	case ext == ".csv" && (compression == "" || compression == ".gz"):
 		return "csv", true
-	case ".json", ".jsonl":
+	case ext == ".json", ext == ".jsonl", ext == ".ndjson":
 		return "json", true
-	case ".parquet":
+	case ext == ".parquet":
 		return "parquet", true
-	case ".xlsx":
+	case ext == ".xlsx":
 		return "excel", true
+	case ext == ".txt":
+		return "text", true
+	case ext == ".blob":
+		return "blob", true
+	case ext == ".vortex":
+		return "vortex", true
 	default:
 		return "", false
 	}
+}
+
+func splitCompressionSuffix(location string) (string, string) {
+	if strings.HasSuffix(strings.ToLower(location), ".gz") {
+		return location[:len(location)-3], ".gz"
+	}
+	return location, ""
 }
 
 func filepathExt(location string) string {

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"regexp"
 	"sort"
-	"strings"
 
+	sourcereg "github.com/Yacobolo/libredash/internal/source"
 	"gopkg.in/yaml.v3"
 )
 
@@ -184,7 +184,7 @@ func (m *Model) Validate() error {
 
 func (m *Model) resolveSource(source Source) (Source, error) {
 	switch source.Kind() {
-	case "path", "database":
+	case sourcereg.KindPath, sourcereg.KindObject:
 		if source.Connection == "" {
 			source.Connection = m.DefaultConnection
 		}
@@ -207,7 +207,7 @@ func (m *Model) resolveSource(source Source) (Source, error) {
 				source.Options = options
 			}
 			if source.Format == "" {
-				format, ok := inferSourceFormat(source.Path)
+				format, ok := sourcereg.InferFormat(source.Path)
 				if !ok {
 					return source, fmt.Errorf("path %q requires format", source.Path)
 				}
@@ -283,7 +283,7 @@ func (s Source) Validate(name string, connections map[string]Connection) error {
 		}
 	}
 	switch s.Kind() {
-	case "path":
+	case sourcereg.KindPath:
 		if s.Connection == "" {
 			return fmt.Errorf("source %q requires connection", name)
 		}
@@ -291,36 +291,39 @@ func (s Source) Validate(name string, connections map[string]Connection) error {
 		if !ok {
 			return fmt.Errorf("source %q references unknown connection %q", name, s.Connection)
 		}
-		if !supportsLocationConnection(connection.Kind) {
+		connectionSpec, ok := sourcereg.LookupConnection(connection.Kind)
+		if !ok || !connectionSpec.AllowsPathSource {
 			return fmt.Errorf("source %q path cannot use %s connection %q", name, connection.Kind, s.Connection)
 		}
-		if connection.Kind == "local" && !isLocalLocation(s.Path) {
+		if connection.Kind == "local" && !sourcereg.IsLocalPath(s.Path) {
 			return fmt.Errorf("source %q local connection %q cannot use remote path %q", name, s.Connection, s.Path)
 		}
-		if isRemoteConnection(connection.Kind) && isLocalLocation(s.Path) && connection.Scope == "" {
+		if connectionSpec.AllowsPathSource && connection.Kind != "local" && sourcereg.IsLocalPath(s.Path) && connection.Scope == "" {
 			return fmt.Errorf("source %q remote connection %q requires scope for relative path %q", name, s.Connection, s.Path)
 		}
 		if s.Format == "" {
 			return fmt.Errorf("source %q path requires format", name)
 		}
-		if !supportsSourceFormat(s.Format) {
+		formatSpec, ok := sourcereg.LookupFormat(s.Format)
+		if !ok {
 			return fmt.Errorf("source %q has unsupported format %q", name, s.Format)
 		}
-		if s.Format == "lance" && len(s.Options) > 0 {
-			return fmt.Errorf("source %q lance path cannot set options", name)
+		if !formatSpec.AllowsOptions && len(s.Options) > 0 {
+			return fmt.Errorf("source %q %s path cannot set options", name, s.Format)
 		}
-	case "database":
+	case sourcereg.KindObject:
 		if s.Connection == "" {
-			return fmt.Errorf("source %q database object requires connection", name)
+			return fmt.Errorf("source %q object requires connection", name)
 		}
 		if s.Format != "" || len(s.Options) > 0 {
-			return fmt.Errorf("source %q database object cannot set format or options", name)
+			return fmt.Errorf("source %q object cannot set format or options", name)
 		}
 		connection, ok := connections[s.Connection]
 		if !ok {
 			return fmt.Errorf("source %q references unknown connection %q", name, s.Connection)
 		}
-		if !supportsDatabaseConnection(connection.Kind) {
+		connectionSpec, ok := sourcereg.LookupConnection(connection.Kind)
+		if !ok || !connectionSpec.AllowsObjectSource {
 			return fmt.Errorf("source %q object cannot use %s connection %q", name, connection.Kind, s.Connection)
 		}
 	default:
@@ -336,15 +339,16 @@ func (c Connection) Validate(name string) error {
 	if c.Kind == "" {
 		return fmt.Errorf("connection %q requires kind", name)
 	}
-	if !supportsConnectionKind(c.Kind) {
+	connectionSpec, ok := sourcereg.LookupConnection(c.Kind)
+	if !ok {
 		return fmt.Errorf("connection %q has unsupported kind %q", name, c.Kind)
 	}
-	if c.Kind == "ducklake" {
+	if connectionSpec.RequiresPath {
 		if c.Path == "" {
-			return fmt.Errorf("connection %q ducklake requires path", name)
+			return fmt.Errorf("connection %q %s requires path", name, c.Kind)
 		}
-	} else if c.Path != "" {
-		return fmt.Errorf("connection %q path is only supported for ducklake", name)
+	} else if c.Path != "" && !connectionSpec.AllowsPath {
+		return fmt.Errorf("connection %q path is only supported for path-backed connections", name)
 	}
 	if c.Secret != "" {
 		if err := validateSemanticIdentifier(c.Secret); err != nil {
@@ -360,7 +364,7 @@ func (c Connection) Validate(name string) error {
 		}
 	}
 	for key := range c.Options {
-		if !supportsConnectionOption(c.Kind, key) {
+		if !connectionAllowsOption(connectionSpec, key) {
 			return fmt.Errorf("connection %q has unsupported option %q", name, key)
 		}
 	}
@@ -374,13 +378,13 @@ func (c Connection) Validate(name string) error {
 
 func (s Source) Description() string {
 	switch s.Kind() {
-	case "path":
-		if supportsLakehouseFormat(s.Format) {
+	case sourcereg.KindPath:
+		if formatSpec, ok := sourcereg.LookupFormat(s.Format); ok && formatSpec.TableLike {
 			return s.Format + " table: " + s.Path
 		}
 		return s.Format + " file: " + s.Path
-	case "database":
-		return "database object: " + s.Object
+	case sourcereg.KindObject:
+		return "object: " + s.Object
 	default:
 		return "source"
 	}
@@ -388,10 +392,10 @@ func (s Source) Description() string {
 
 func (s Source) Role() string {
 	switch s.Kind() {
-	case "path":
+	case sourcereg.KindPath:
 		return s.Format
-	case "database":
-		return "database"
+	case sourcereg.KindObject:
+		return "object"
 	default:
 		return "source"
 	}
@@ -402,34 +406,16 @@ func (s Source) Kind() string {
 	kind := ""
 	if s.Path != "" {
 		count++
-		kind = "path"
+		kind = sourcereg.KindPath
 	}
 	if s.Object != "" {
 		count++
-		kind = "database"
+		kind = sourcereg.KindObject
 	}
 	if count != 1 {
 		return ""
 	}
 	return kind
-}
-
-func isLocalLocation(location string) bool {
-	for _, prefix := range []string{"s3://", "r2://", "gcs://", "gs://", "az://", "azure://", "abfss://", "http://", "https://", "file://"} {
-		if strings.HasPrefix(location, prefix) {
-			return false
-		}
-	}
-	return !strings.Contains(location, "://")
-}
-
-func supportsConnectionKind(kind string) bool {
-	switch kind {
-	case "local", "s3", "r2", "gcs", "http", "azure_blob", "postgres", "mysql", "sqlite", "ducklake":
-		return true
-	default:
-		return false
-	}
 }
 
 func supportsAuthMethod(method string) bool {
@@ -441,20 +427,13 @@ func supportsAuthMethod(method string) bool {
 	}
 }
 
-func supportsConnectionOption(kind, option string) bool {
-	switch kind {
-	case "ducklake":
-		return option == "data_path"
-	case "postgres", "mysql", "sqlite":
-		switch option {
-		case "connection_string", "uri", "path", "database":
+func connectionAllowsOption(connection sourcereg.Connection, option string) bool {
+	for _, allowed := range connection.AllowedOptions {
+		if option == allowed {
 			return true
-		default:
-			return false
 		}
-	default:
-		return false
 	}
+	return false
 }
 
 func validateSemanticIdentifier(value string) error {
@@ -462,92 +441,6 @@ func validateSemanticIdentifier(value string) error {
 		return fmt.Errorf("must match %s", semanticIdentifierPattern.String())
 	}
 	return nil
-}
-
-func supportsFileFormat(format string) bool {
-	switch format {
-	case "csv", "json", "parquet", "excel", "text", "blob", "vortex", "lance":
-		return true
-	default:
-		return false
-	}
-}
-
-func supportsLakehouseFormat(format string) bool {
-	switch format {
-	case "delta", "iceberg", "lance":
-		return true
-	default:
-		return false
-	}
-}
-
-func supportsSourceFormat(format string) bool {
-	return supportsFileFormat(format) || supportsLakehouseFormat(format)
-}
-
-func supportsLocationConnection(kind string) bool {
-	switch kind {
-	case "local", "s3", "r2", "gcs", "http", "azure_blob":
-		return true
-	default:
-		return false
-	}
-}
-
-func supportsDatabaseConnection(kind string) bool {
-	switch kind {
-	case "postgres", "mysql", "sqlite", "ducklake":
-		return true
-	default:
-		return false
-	}
-}
-
-func isRemoteConnection(kind string) bool {
-	return supportsLocationConnection(kind) && kind != "local"
-}
-
-func inferSourceFormat(location string) (string, bool) {
-	base, compression := splitCompressionSuffix(location)
-	ext := strings.ToLower(filepathExt(base))
-	switch {
-	case ext == ".csv" && (compression == "" || compression == ".gz"):
-		return "csv", true
-	case ext == ".json", ext == ".jsonl", ext == ".ndjson":
-		return "json", true
-	case ext == ".parquet":
-		return "parquet", true
-	case ext == ".xlsx":
-		return "excel", true
-	case ext == ".txt":
-		return "text", true
-	case ext == ".blob":
-		return "blob", true
-	case ext == ".vortex":
-		return "vortex", true
-	case ext == ".lance":
-		return "lance", true
-	default:
-		return "", false
-	}
-}
-
-func splitCompressionSuffix(location string) (string, string) {
-	if strings.HasSuffix(strings.ToLower(location), ".gz") {
-		return location[:len(location)-3], ".gz"
-	}
-	return location, ""
-}
-
-func filepathExt(location string) string {
-	if index := strings.LastIndexAny(location, `/\`); index >= 0 {
-		location = location[index+1:]
-	}
-	if index := strings.LastIndex(location, "."); index >= 0 {
-		return location[index:]
-	}
-	return ""
 }
 
 func (m *Model) CacheTableNames() []string {

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -100,11 +100,17 @@ func TestLoadOlistModel(t *testing.T) {
 	if len(model.Sources) != 7 {
 		t.Fatalf("source count = %d, want 7", len(model.Sources))
 	}
-	if got := model.Sources["orders"].Type; got != "file" {
-		t.Fatalf("orders source type = %q, want file", got)
+	if got := model.DefaultConnection; got != "olist" {
+		t.Fatalf("default connection = %q, want olist", got)
+	}
+	if got := model.Connections["olist"].Kind; got != "local" {
+		t.Fatalf("olist connection kind = %q, want local", got)
 	}
 	if got := model.Sources["orders"].Format; got != "csv" {
 		t.Fatalf("orders source format = %q, want csv", got)
+	}
+	if got := model.Sources["orders"].Connection; got != "olist" {
+		t.Fatalf("orders source connection = %q, want olist", got)
 	}
 	if got := model.Sources["orders"].Location; got != "olist_orders_dataset.csv" {
 		t.Fatalf("orders source location = %q, want olist_orders_dataset.csv", got)
@@ -119,48 +125,48 @@ func TestLoadOlistModel(t *testing.T) {
 
 func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 	model := minimalSourceModel()
+	model.DefaultConnection = "local_files"
 	model.Connections = map[string]Connection{
+		"local_files": {
+			Kind: "local",
+			Defaults: ConnectionDefaults{
+				Format:  "csv",
+				Options: map[string]any{"header": true},
+			},
+		},
 		"prod_lake": {
-			Type:  "s3",
+			Kind:  "s3",
 			Scope: "s3://analytics-prod/",
 			Auth:  ConnectionAuth{Method: "credential_chain", Profile: "analytics"},
 		},
 		"azure_lake": {
-			Type: "azure",
+			Kind: "azure_blob",
 			Auth: ConnectionAuth{Method: "credential_chain", Account: "mystorageaccount"},
 		},
 		"crm": {
-			Type:   "postgres",
+			Kind:   "postgres",
 			Secret: "crm_readonly",
 		},
 	}
 	model.Sources = map[string]Source{
 		"orders": {
-			Type:     "file",
-			Format:   "csv",
 			Location: "olist_orders_dataset.csv",
-			Options:  map[string]any{"header": true},
 		},
 		"sales_events": {
-			Type:       "file",
 			Format:     "parquet",
-			Location:   "s3://analytics-prod/events/*.parquet",
+			Location:   "events/*",
 			Connection: "prod_lake",
 		},
 		"delta_orders": {
-			Type:       "lakehouse",
 			Format:     "delta",
 			Location:   "az://warehouse/tables/orders",
 			Connection: "azure_lake",
 		},
 		"crm_accounts": {
-			Type:       "database",
-			Engine:     "postgres",
 			Connection: "crm",
 			Object:     "public.accounts",
 		},
 		"custom": {
-			Type:  "query",
 			Query: "SELECT 1 AS id",
 		},
 	}
@@ -168,124 +174,94 @@ func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 	if err := model.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil", err)
 	}
-}
-
-func TestModelValidateAppliesSourceDefaults(t *testing.T) {
-	model := minimalSourceModel()
-	model.SourceDefaults = Source{
-		Type:    "file",
-		Format:  "csv",
-		Options: map[string]any{"header": true, "sample_size": 1000},
-	}
-	model.Sources = map[string]Source{
-		"orders":   {Location: "orders.csv"},
-		"products": {Location: "products.csv", Options: map[string]any{"sample_size": 2000}},
-	}
-
-	if err := model.Validate(); err != nil {
-		t.Fatalf("Validate() error = %v, want nil", err)
-	}
-	if got := model.Sources["orders"].Type; got != "file" {
-		t.Fatalf("orders source type = %q, want file", got)
-	}
 	if got := model.Sources["orders"].Format; got != "csv" {
 		t.Fatalf("orders source format = %q, want csv", got)
 	}
 	if got := model.Sources["orders"].Options["header"]; got != true {
 		t.Fatalf("orders header option = %#v, want true", got)
 	}
-	if got := model.Sources["products"].Options["sample_size"]; got != 2000 {
-		t.Fatalf("products sample_size option = %#v, want 2000", got)
-	}
 }
 
-func TestLoadModelAcceptsScalarSourceLocations(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "model.yaml")
-	content := strings.ReplaceAll(`name: test
-title: Test
-source_defaults:
-  type: file
-  format: csv
-  options:
-    header: true
-sources:
-  orders: orders.csv
-cache:
-  tables:
-    orders_cache:
-      sql: SELECT * FROM raw.orders
-datasets:
-  orders:
-    source: orders_cache
-`, "\t", "  ")
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
+func TestModelValidateInfersFileFormats(t *testing.T) {
+	cases := map[string]struct {
+		location string
+		want     string
+	}{
+		"csv":     {location: "orders.csv", want: "csv"},
+		"json":    {location: "orders.json", want: "json"},
+		"jsonl":   {location: "orders.jsonl", want: "json"},
+		"parquet": {location: "orders.parquet", want: "parquet"},
+		"excel":   {location: "orders.xlsx", want: "excel"},
 	}
-
-	model, err := Load(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	source := model.Sources["orders"]
-	if source.Type != "file" || source.Format != "csv" || source.Location != "orders.csv" {
-		t.Fatalf("orders source = %#v, want csv file orders.csv", source)
-	}
-	if got := source.Options["header"]; got != true {
-		t.Fatalf("orders header option = %#v, want true", got)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			model := minimalSourceModel()
+			model.Connections["local_files"] = Connection{Kind: "local"}
+			model.Sources = map[string]Source{"orders": {Location: tc.location}}
+			if err := model.Validate(); err != nil {
+				t.Fatal(err)
+			}
+			if got := model.Sources["orders"].Format; got != tc.want {
+				t.Fatalf("format = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
 func TestModelValidateRejectsInvalidSources(t *testing.T) {
 	cases := map[string]struct {
-		source   Source
-		contains string
+		source    Source
+		contains  string
+		noDefault bool
 	}{
-		"missing_type": {
-			source:   Source{Format: "csv", Location: "orders.csv"},
-			contains: "requires type",
+		"missing_source_shape": {
+			source:   Source{Format: "csv"},
+			contains: "exactly one of location, object, or query",
 		},
-		"file_missing_format": {
-			source:   Source{Type: "file", Location: "orders.csv"},
-			contains: "requires format and location",
+		"multiple_source_shapes": {
+			source:   Source{Location: "orders.csv", Object: "public.orders"},
+			contains: "exactly one of location, object, or query",
 		},
-		"file_bad_format": {
-			source:   Source{Type: "file", Format: "orc", Location: "orders.orc"},
-			contains: "unsupported file format",
+		"location_bad_format": {
+			source:   Source{Format: "orc", Location: "orders.orc", Connection: "local_files"},
+			contains: "unsupported format",
 		},
-		"lakehouse_bad_format": {
-			source:   Source{Type: "lakehouse", Format: "hudi", Location: "s3://bucket/table"},
-			contains: "unsupported lakehouse format",
+		"ambiguous_location_missing_format": {
+			source:   Source{Location: "events/*", Connection: "local_files"},
+			contains: "requires format",
 		},
-		"database_missing_fields": {
-			source:   Source{Type: "database", Engine: "postgres", Connection: "crm"},
-			contains: "requires engine, connection, and object",
+		"database_missing_connection": {
+			source:    Source{Object: "public.accounts"},
+			contains:  "requires connection",
+			noDefault: true,
 		},
-		"database_bad_engine": {
-			source:   Source{Type: "database", Engine: "oracle", Connection: "crm", Object: "public.accounts"},
-			contains: "unsupported database engine",
-		},
-		"query_missing_query": {
-			source:   Source{Type: "query"},
-			contains: "requires query",
+		"database_wrong_connection_kind": {
+			source:   Source{Connection: "local_files", Object: "public.accounts"},
+			contains: "object cannot use local connection",
 		},
 		"unknown_connection": {
-			source:   Source{Type: "file", Format: "parquet", Location: "s3://bucket/*.parquet", Connection: "missing"},
+			source:   Source{Format: "parquet", Location: "s3://bucket/*.parquet", Connection: "missing"},
 			contains: "unknown connection",
 		},
-		"database_connection_type_mismatch": {
-			source:   Source{Type: "database", Engine: "postgres", Connection: "crm", Object: "public.accounts"},
-			contains: "does not match connection",
+		"query_with_connection": {
+			source:   Source{Query: "SELECT 1", Connection: "crm"},
+			contains: "query cannot set",
 		},
 		"bad_source_option_key": {
-			source:   Source{Type: "file", Format: "csv", Location: "orders.csv", Options: map[string]any{"bad-key": true}},
+			source:   Source{Format: "csv", Location: "orders.csv", Connection: "local_files", Options: map[string]any{"bad-key": true}},
 			contains: "option",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			model := minimalSourceModel()
-			model.Connections = map[string]Connection{"crm": {Type: "mysql"}}
+			if tc.noDefault {
+				model.DefaultConnection = ""
+			}
+			model.Connections = map[string]Connection{
+				"local_files": {Kind: "local"},
+				"crm":         {Kind: "mysql"},
+			}
 			model.Sources = map[string]Source{"orders": tc.source}
 			assertModelValidateError(t, model, tc.contains)
 		})
@@ -298,20 +274,24 @@ func TestModelValidateRejectsInvalidConnections(t *testing.T) {
 		contains   string
 	}{
 		"bad_auth_method": {
-			connection: Connection{Type: "s3", Auth: ConnectionAuth{Method: "shell"}},
+			connection: Connection{Kind: "s3", Auth: ConnectionAuth{Method: "shell"}},
 			contains:   "unsupported auth method",
 		},
 		"bad_auth_param": {
-			connection: Connection{Type: "s3", Auth: ConnectionAuth{Method: "config", Params: map[string]any{"bad-key": "value"}}},
+			connection: Connection{Kind: "s3", Auth: ConnectionAuth{Method: "config", Params: map[string]any{"bad-key": "value"}}},
 			contains:   "auth param",
 		},
 		"bad_attach_option": {
-			connection: Connection{Type: "postgres", Options: map[string]any{"password": "secret"}},
+			connection: Connection{Kind: "postgres", Options: map[string]any{"password": "secret"}},
 			contains:   "unsupported option",
 		},
 		"bad_secret_name": {
-			connection: Connection{Type: "postgres", Secret: "bad-secret"},
+			connection: Connection{Kind: "postgres", Secret: "bad-secret"},
 			contains:   "secret",
+		},
+		"bad_default_option": {
+			connection: Connection{Kind: "local", Defaults: ConnectionDefaults{Format: "csv", Options: map[string]any{"bad-key": true}}},
+			contains:   "default option",
 		},
 	}
 	for name, tc := range cases {
@@ -319,9 +299,65 @@ func TestModelValidateRejectsInvalidConnections(t *testing.T) {
 			model := minimalSourceModel()
 			model.Connections = map[string]Connection{"crm": tc.connection}
 			model.Sources = map[string]Source{
-				"orders": {Type: "file", Format: "csv", Location: "orders.csv"},
+				"orders": {Format: "csv", Location: "orders.csv", Connection: "crm"},
 			}
 			assertModelValidateError(t, model, tc.contains)
+		})
+	}
+}
+
+func TestLoadModelRejectsRemovedSourceFields(t *testing.T) {
+	cases := map[string]string{
+		"source_defaults": `
+source_defaults:
+  format: csv
+`,
+		"source_type": `
+sources:
+  orders:
+    type: file
+    location: orders.csv
+`,
+		"source_engine": `
+sources:
+  orders:
+    engine: postgres
+    object: public.orders
+`,
+		"scalar_source": `
+sources:
+  orders: orders.csv
+`,
+	}
+	for name, fragment := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "model.yaml")
+			content := strings.ReplaceAll(`name: test
+title: Test
+default_connection: local_files
+connections:
+  local_files:
+    kind: local
+    defaults:
+      format: csv
+sources:
+  products:
+    location: products.csv
+cache:
+  tables:
+    orders_cache:
+      sql: SELECT * FROM raw.orders
+datasets:
+  orders:
+    source: orders_cache
+`+fragment, "\t", "  ")
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Load(path); err == nil {
+				t.Fatal("Load() error = nil, want removed field rejection")
+			}
 		})
 	}
 }
@@ -894,11 +930,18 @@ func loadOlistDashboard(t *testing.T, model *Model) *Dashboard {
 
 func minimalSourceModel() *Model {
 	return &Model{
-		Name:        "test",
-		Title:       "Test",
-		Description: "Test semantic model",
+		Name:              "test",
+		Title:             "Test",
+		Description:       "Test semantic model",
+		DefaultConnection: "local_files",
+		Connections: map[string]Connection{
+			"local_files": {
+				Kind:     "local",
+				Defaults: ConnectionDefaults{Format: "csv"},
+			},
+		},
 		Sources: map[string]Source{
-			"orders": {Type: "file", Format: "csv", Location: "orders.csv"},
+			"orders": {Location: "orders.csv"},
 		},
 		Cache: Cache{Tables: map[string]CacheTable{
 			"orders_cache": {SQL: "SELECT * FROM raw.orders"},

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -100,11 +100,163 @@ func TestLoadOlistModel(t *testing.T) {
 	if len(model.Sources) != 7 {
 		t.Fatalf("source count = %d, want 7", len(model.Sources))
 	}
+	if got := model.Sources["orders"].Type; got != "file" {
+		t.Fatalf("orders source type = %q, want file", got)
+	}
+	if got := model.Sources["orders"].Format; got != "csv" {
+		t.Fatalf("orders source format = %q, want csv", got)
+	}
+	if got := model.Sources["orders"].Location; got != "olist_orders_dataset.csv" {
+		t.Fatalf("orders source location = %q, want olist_orders_dataset.csv", got)
+	}
 	if got := model.Datasets["orders"].Source; got != "orders_enriched" {
 		t.Fatalf("orders dataset source = %q, want orders_enriched", got)
 	}
 	if len(model.Relationships) != 6 {
 		t.Fatalf("relationship count = %d, want 6", len(model.Relationships))
+	}
+}
+
+func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
+	model := minimalSourceModel()
+	model.Connections = map[string]Connection{
+		"prod_lake": {
+			Type:  "s3",
+			Scope: "s3://analytics-prod/",
+			Auth:  ConnectionAuth{Method: "credential_chain", Profile: "analytics"},
+		},
+		"azure_lake": {
+			Type: "azure",
+			Auth: ConnectionAuth{Method: "credential_chain", Account: "mystorageaccount"},
+		},
+		"crm": {
+			Type:   "postgres",
+			Secret: "crm_readonly",
+		},
+	}
+	model.Sources = map[string]Source{
+		"orders": {
+			Type:     "file",
+			Format:   "csv",
+			Location: "olist_orders_dataset.csv",
+			Options:  map[string]any{"header": true},
+		},
+		"sales_events": {
+			Type:       "file",
+			Format:     "parquet",
+			Location:   "s3://analytics-prod/events/*.parquet",
+			Connection: "prod_lake",
+		},
+		"delta_orders": {
+			Type:       "lakehouse",
+			Format:     "delta",
+			Location:   "az://warehouse/tables/orders",
+			Connection: "azure_lake",
+		},
+		"crm_accounts": {
+			Type:       "database",
+			Engine:     "postgres",
+			Connection: "crm",
+			Object:     "public.accounts",
+		},
+		"custom": {
+			Type:  "query",
+			Query: "SELECT 1 AS id",
+		},
+	}
+
+	if err := model.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestModelValidateRejectsInvalidSources(t *testing.T) {
+	cases := map[string]struct {
+		source   Source
+		contains string
+	}{
+		"missing_type": {
+			source:   Source{Format: "csv", Location: "orders.csv"},
+			contains: "requires type",
+		},
+		"file_missing_format": {
+			source:   Source{Type: "file", Location: "orders.csv"},
+			contains: "requires format and location",
+		},
+		"file_bad_format": {
+			source:   Source{Type: "file", Format: "orc", Location: "orders.orc"},
+			contains: "unsupported file format",
+		},
+		"lakehouse_bad_format": {
+			source:   Source{Type: "lakehouse", Format: "hudi", Location: "s3://bucket/table"},
+			contains: "unsupported lakehouse format",
+		},
+		"database_missing_fields": {
+			source:   Source{Type: "database", Engine: "postgres", Connection: "crm"},
+			contains: "requires engine, connection, and object",
+		},
+		"database_bad_engine": {
+			source:   Source{Type: "database", Engine: "oracle", Connection: "crm", Object: "public.accounts"},
+			contains: "unsupported database engine",
+		},
+		"query_missing_query": {
+			source:   Source{Type: "query"},
+			contains: "requires query",
+		},
+		"unknown_connection": {
+			source:   Source{Type: "file", Format: "parquet", Location: "s3://bucket/*.parquet", Connection: "missing"},
+			contains: "unknown connection",
+		},
+		"database_connection_type_mismatch": {
+			source:   Source{Type: "database", Engine: "postgres", Connection: "crm", Object: "public.accounts"},
+			contains: "does not match connection",
+		},
+		"bad_source_option_key": {
+			source:   Source{Type: "file", Format: "csv", Location: "orders.csv", Options: map[string]any{"bad-key": true}},
+			contains: "option",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			model := minimalSourceModel()
+			model.Connections = map[string]Connection{"crm": {Type: "mysql"}}
+			model.Sources = map[string]Source{"orders": tc.source}
+			assertModelValidateError(t, model, tc.contains)
+		})
+	}
+}
+
+func TestModelValidateRejectsInvalidConnections(t *testing.T) {
+	cases := map[string]struct {
+		connection Connection
+		contains   string
+	}{
+		"bad_auth_method": {
+			connection: Connection{Type: "s3", Auth: ConnectionAuth{Method: "shell"}},
+			contains:   "unsupported auth method",
+		},
+		"bad_auth_param": {
+			connection: Connection{Type: "s3", Auth: ConnectionAuth{Method: "config", Params: map[string]any{"bad-key": "value"}}},
+			contains:   "auth param",
+		},
+		"bad_attach_option": {
+			connection: Connection{Type: "postgres", Options: map[string]any{"password": "secret"}},
+			contains:   "unsupported option",
+		},
+		"bad_secret_name": {
+			connection: Connection{Type: "postgres", Secret: "bad-secret"},
+			contains:   "secret",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			model := minimalSourceModel()
+			model.Connections = map[string]Connection{"crm": tc.connection}
+			model.Sources = map[string]Source{
+				"orders": {Type: "file", Format: "csv", Location: "orders.csv"},
+			}
+			assertModelValidateError(t, model, tc.contains)
+		})
 	}
 }
 
@@ -672,6 +824,23 @@ func loadOlistDashboard(t *testing.T, model *Model) *Dashboard {
 		t.Fatal(err)
 	}
 	return report
+}
+
+func minimalSourceModel() *Model {
+	return &Model{
+		Name:        "test",
+		Title:       "Test",
+		Description: "Test semantic model",
+		Sources: map[string]Source{
+			"orders": {Type: "file", Format: "csv", Location: "orders.csv"},
+		},
+		Cache: Cache{Tables: map[string]CacheTable{
+			"orders_cache": {SQL: "SELECT * FROM raw.orders"},
+		}},
+		Datasets: map[string]Dataset{
+			"orders": {Source: "orders_cache"},
+		},
+	}
 }
 
 func assertModelValidateError(t *testing.T, model *Model, contains string) {

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -170,6 +170,72 @@ func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 	}
 }
 
+func TestModelValidateAppliesSourceDefaults(t *testing.T) {
+	model := minimalSourceModel()
+	model.SourceDefaults = Source{
+		Type:    "file",
+		Format:  "csv",
+		Options: map[string]any{"header": true, "sample_size": 1000},
+	}
+	model.Sources = map[string]Source{
+		"orders":   {Location: "orders.csv"},
+		"products": {Location: "products.csv", Options: map[string]any{"sample_size": 2000}},
+	}
+
+	if err := model.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+	if got := model.Sources["orders"].Type; got != "file" {
+		t.Fatalf("orders source type = %q, want file", got)
+	}
+	if got := model.Sources["orders"].Format; got != "csv" {
+		t.Fatalf("orders source format = %q, want csv", got)
+	}
+	if got := model.Sources["orders"].Options["header"]; got != true {
+		t.Fatalf("orders header option = %#v, want true", got)
+	}
+	if got := model.Sources["products"].Options["sample_size"]; got != 2000 {
+		t.Fatalf("products sample_size option = %#v, want 2000", got)
+	}
+}
+
+func TestLoadModelAcceptsScalarSourceLocations(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.yaml")
+	content := strings.ReplaceAll(`name: test
+title: Test
+source_defaults:
+  type: file
+  format: csv
+  options:
+    header: true
+sources:
+  orders: orders.csv
+cache:
+  tables:
+    orders_cache:
+      sql: SELECT * FROM raw.orders
+datasets:
+  orders:
+    source: orders_cache
+`, "\t", "  ")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	model, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := model.Sources["orders"]
+	if source.Type != "file" || source.Format != "csv" || source.Location != "orders.csv" {
+		t.Fatalf("orders source = %#v, want csv file orders.csv", source)
+	}
+	if got := source.Options["header"]; got != true {
+		t.Fatalf("orders header option = %#v, want true", got)
+	}
+}
+
 func TestModelValidateRejectsInvalidSources(t *testing.T) {
 	cases := map[string]struct {
 		source   Source

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -136,15 +136,19 @@ func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 		"prod_lake": {
 			Kind:  "s3",
 			Scope: "s3://analytics-prod/",
-			Auth:  ConnectionAuth{Method: "credential_chain", Profile: "analytics"},
+			Auth: ConnectionAuth{
+				"access_key_id":     "key",
+				"secret_access_key": "secret",
+				"region":            "us-east-1",
+			},
 		},
 		"azure_lake": {
 			Kind: "azure_blob",
-			Auth: ConnectionAuth{Method: "credential_chain", Account: "mystorageaccount"},
+			Auth: ConnectionAuth{"connection_string": "DefaultEndpointsProtocol=https;AccountName=mystorageaccount"},
 		},
 		"crm": {
-			Kind:   "postgres",
-			Secret: "crm_readonly",
+			Kind: "postgres",
+			Auth: ConnectionAuth{"connection_string": "postgres://crm"},
 		},
 		"lakehouse": {
 			Kind: "ducklake",
@@ -188,6 +192,45 @@ func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 	if got := model.Sources["orders"].Options["header"]; got != true {
 		t.Fatalf("orders header option = %#v, want true", got)
 	}
+}
+
+func TestModelValidateResolvesConnectionAuthEnv(t *testing.T) {
+	t.Setenv("LIBREDASH_TEST_S3_KEY", "env-key")
+	t.Setenv("LIBREDASH_TEST_S3_SECRET", "env-secret")
+	model := minimalSourceModel()
+	model.Connections["prod_lake"] = Connection{
+		Kind:  "s3",
+		Scope: "s3://analytics-prod/",
+		Auth: ConnectionAuth{
+			"access_key_id":     "${LIBREDASH_TEST_S3_KEY}",
+			"secret_access_key": "${LIBREDASH_TEST_S3_SECRET}",
+		},
+	}
+	model.Sources = map[string]Source{
+		"orders": {Connection: "prod_lake", Path: "orders.parquet"},
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if got := model.Connections["prod_lake"].Auth["access_key_id"]; got != "env-key" {
+		t.Fatalf("resolved access key = %#v, want env-key", got)
+	}
+}
+
+func TestModelValidateRejectsMissingConnectionAuthEnv(t *testing.T) {
+	model := minimalSourceModel()
+	model.Connections["prod_lake"] = Connection{
+		Kind:  "s3",
+		Scope: "s3://analytics-prod/",
+		Auth: ConnectionAuth{
+			"access_key_id":     "${LIBREDASH_TEST_MISSING_KEY}",
+			"secret_access_key": "secret",
+		},
+	}
+	model.Sources = map[string]Source{
+		"orders": {Connection: "prod_lake", Path: "orders.parquet"},
+	}
+	assertModelValidateError(t, model, "missing environment variable")
 }
 
 func TestModelValidateInfersFileFormats(t *testing.T) {
@@ -278,7 +321,7 @@ func TestModelValidateRejectsInvalidSources(t *testing.T) {
 			}
 			model.Connections = map[string]Connection{
 				"local_files": {Kind: "local"},
-				"crm":         {Kind: "mysql"},
+				"crm":         {Kind: "mysql", Auth: ConnectionAuth{"connection_string": "mysql://crm"}},
 				"lakehouse":   {Kind: "ducklake", Path: "metadata.ducklake"},
 			}
 			model.Sources = map[string]Source{"orders": tc.source}
@@ -293,20 +336,20 @@ func TestModelValidateRejectsInvalidConnections(t *testing.T) {
 		contains   string
 	}{
 		"bad_auth_method": {
-			connection: Connection{Kind: "s3", Auth: ConnectionAuth{Method: "shell"}},
-			contains:   "unsupported auth method",
+			connection: Connection{Kind: "s3", Auth: ConnectionAuth{"method": "credential_chain"}},
+			contains:   "unsupported auth key",
 		},
 		"bad_auth_param": {
-			connection: Connection{Kind: "s3", Auth: ConnectionAuth{Method: "config", Params: map[string]any{"bad-key": "value"}}},
-			contains:   "auth param",
+			connection: Connection{Kind: "s3", Auth: ConnectionAuth{"bad-key": "value"}},
+			contains:   "auth key",
 		},
 		"bad_attach_option": {
-			connection: Connection{Kind: "postgres", Options: map[string]any{"password": "secret"}},
+			connection: Connection{Kind: "postgres", Auth: ConnectionAuth{"connection_string": "postgres://crm"}, Options: map[string]any{"password": "secret"}},
 			contains:   "unsupported option",
 		},
-		"bad_secret_name": {
-			connection: Connection{Kind: "postgres", Secret: "bad-secret"},
-			contains:   "secret",
+		"missing_required_auth": {
+			connection: Connection{Kind: "s3", Auth: ConnectionAuth{"access_key_id": "key"}},
+			contains:   "missing required credentials",
 		},
 		"bad_default_option": {
 			connection: Connection{Kind: "local", Defaults: ConnectionDefaults{Options: map[string]any{"bad-key": true}}},
@@ -321,7 +364,7 @@ func TestModelValidateRejectsInvalidConnections(t *testing.T) {
 			contains:   "unsupported option",
 		},
 		"non_ducklake_path": {
-			connection: Connection{Kind: "s3", Path: "s3://bucket/"},
+			connection: Connection{Kind: "s3", Path: "s3://bucket/", Auth: ConnectionAuth{"access_key_id": "key", "secret_access_key": "secret"}},
 			contains:   "path is only supported for path-backed connections",
 		},
 	}
@@ -361,6 +404,27 @@ connections:
     kind: local
     defaults:
       format: csv
+`,
+		"connection_secret": `
+connections:
+  crm:
+    kind: postgres
+    secret: crm_readonly
+`,
+		"auth_method": `
+connections:
+  prod_lake:
+    kind: s3
+    auth:
+      method: credential_chain
+`,
+		"auth_params": `
+connections:
+  prod_lake:
+    kind: s3
+    auth:
+      params:
+        region: us-east-1
 `,
 		"source_query": `
 sources:

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -112,8 +112,8 @@ func TestLoadOlistModel(t *testing.T) {
 	if got := model.Sources["orders"].Connection; got != "olist" {
 		t.Fatalf("orders source connection = %q, want olist", got)
 	}
-	if got := model.Sources["orders"].Location; got != "olist_orders_dataset.csv" {
-		t.Fatalf("orders source location = %q, want olist_orders_dataset.csv", got)
+	if got := model.Sources["orders"].Path; got != "olist_orders_dataset.csv" {
+		t.Fatalf("orders source path = %q, want olist_orders_dataset.csv", got)
 	}
 	if got := model.Datasets["orders"].Source; got != "orders_enriched" {
 		t.Fatalf("orders dataset source = %q, want orders_enriched", got)
@@ -146,24 +146,36 @@ func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 			Kind:   "postgres",
 			Secret: "crm_readonly",
 		},
+		"lakehouse": {
+			Kind: "ducklake",
+			Path: "metadata.ducklake",
+		},
 	}
 	model.Sources = map[string]Source{
 		"orders": {
-			Location: "olist_orders_dataset.csv",
+			Path: "olist_orders_dataset.csv",
 		},
 		"sales_events": {
 			Format:     "parquet",
-			Location:   "events/*",
+			Path:       "events/*",
 			Connection: "prod_lake",
 		},
 		"delta_orders": {
 			Format:     "delta",
-			Location:   "az://warehouse/tables/orders",
+			Path:       "az://warehouse/tables/orders",
 			Connection: "azure_lake",
 		},
 		"crm_accounts": {
 			Connection: "crm",
 			Object:     "public.accounts",
+		},
+		"embeddings": {
+			Connection: "prod_lake",
+			Path:       "vectors/products.lance",
+		},
+		"ducklake_orders": {
+			Connection: "lakehouse",
+			Object:     "main.orders",
 		},
 	}
 
@@ -180,25 +192,26 @@ func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 
 func TestModelValidateInfersFileFormats(t *testing.T) {
 	cases := map[string]struct {
-		location string
-		want     string
+		path string
+		want string
 	}{
-		"csv":     {location: "orders.csv", want: "csv"},
-		"csv_gz":  {location: "orders.csv.gz", want: "csv"},
-		"json":    {location: "orders.json", want: "json"},
-		"jsonl":   {location: "orders.jsonl", want: "json"},
-		"ndjson":  {location: "orders.ndjson", want: "json"},
-		"parquet": {location: "orders.parquet", want: "parquet"},
-		"excel":   {location: "orders.xlsx", want: "excel"},
-		"text":    {location: "orders.txt", want: "text"},
-		"blob":    {location: "orders.blob", want: "blob"},
-		"vortex":  {location: "orders.vortex", want: "vortex"},
+		"csv":     {path: "orders.csv", want: "csv"},
+		"csv_gz":  {path: "orders.csv.gz", want: "csv"},
+		"json":    {path: "orders.json", want: "json"},
+		"jsonl":   {path: "orders.jsonl", want: "json"},
+		"ndjson":  {path: "orders.ndjson", want: "json"},
+		"parquet": {path: "orders.parquet", want: "parquet"},
+		"excel":   {path: "orders.xlsx", want: "excel"},
+		"text":    {path: "orders.txt", want: "text"},
+		"blob":    {path: "orders.blob", want: "blob"},
+		"vortex":  {path: "orders.vortex", want: "vortex"},
+		"lance":   {path: "products.lance", want: "lance"},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			model := minimalSourceModel()
 			model.Connections["local_files"] = Connection{Kind: "local"}
-			model.Sources = map[string]Source{"orders": {Location: tc.location}}
+			model.Sources = map[string]Source{"orders": {Path: tc.path}}
 			if err := model.Validate(); err != nil {
 				t.Fatal(err)
 			}
@@ -217,19 +230,27 @@ func TestModelValidateRejectsInvalidSources(t *testing.T) {
 	}{
 		"missing_source_shape": {
 			source:   Source{Format: "csv"},
-			contains: "exactly one of location or object",
+			contains: "exactly one of path or object",
 		},
 		"multiple_source_shapes": {
-			source:   Source{Location: "orders.csv", Object: "public.orders"},
-			contains: "exactly one of location or object",
+			source:   Source{Path: "orders.csv", Object: "public.orders"},
+			contains: "exactly one of path or object",
 		},
-		"location_bad_format": {
-			source:   Source{Format: "orc", Location: "orders.orc", Connection: "local_files"},
+		"path_bad_format": {
+			source:   Source{Format: "orc", Path: "orders.orc", Connection: "local_files"},
 			contains: "unsupported format",
 		},
-		"ambiguous_location_missing_format": {
-			source:   Source{Location: "events/*", Connection: "local_files"},
+		"ambiguous_path_missing_format": {
+			source:   Source{Path: "events/*", Connection: "local_files"},
 			contains: "requires format",
+		},
+		"lance_with_options": {
+			source:   Source{Path: "vectors/products.lance", Connection: "local_files", Options: map[string]any{"sample_size": 1000}},
+			contains: "lance path cannot set options",
+		},
+		"ducklake_path_source": {
+			source:   Source{Path: "main.orders", Connection: "lakehouse", Format: "parquet"},
+			contains: "path cannot use ducklake connection",
 		},
 		"database_missing_connection": {
 			source:    Source{Object: "public.accounts"},
@@ -241,11 +262,11 @@ func TestModelValidateRejectsInvalidSources(t *testing.T) {
 			contains: "object cannot use local connection",
 		},
 		"unknown_connection": {
-			source:   Source{Format: "parquet", Location: "s3://bucket/*.parquet", Connection: "missing"},
+			source:   Source{Format: "parquet", Path: "s3://bucket/*.parquet", Connection: "missing"},
 			contains: "unknown connection",
 		},
 		"bad_source_option_key": {
-			source:   Source{Format: "csv", Location: "orders.csv", Connection: "local_files", Options: map[string]any{"bad-key": true}},
+			source:   Source{Format: "csv", Path: "orders.csv", Connection: "local_files", Options: map[string]any{"bad-key": true}},
 			contains: "option",
 		},
 	}
@@ -258,6 +279,7 @@ func TestModelValidateRejectsInvalidSources(t *testing.T) {
 			model.Connections = map[string]Connection{
 				"local_files": {Kind: "local"},
 				"crm":         {Kind: "mysql"},
+				"lakehouse":   {Kind: "ducklake", Path: "metadata.ducklake"},
 			}
 			model.Sources = map[string]Source{"orders": tc.source}
 			assertModelValidateError(t, model, tc.contains)
@@ -290,13 +312,25 @@ func TestModelValidateRejectsInvalidConnections(t *testing.T) {
 			connection: Connection{Kind: "local", Defaults: ConnectionDefaults{Options: map[string]any{"bad-key": true}}},
 			contains:   "default option",
 		},
+		"ducklake_missing_path": {
+			connection: Connection{Kind: "ducklake"},
+			contains:   "ducklake requires path",
+		},
+		"ducklake_bad_option": {
+			connection: Connection{Kind: "ducklake", Path: "metadata.ducklake", Options: map[string]any{"read_only": true}},
+			contains:   "unsupported option",
+		},
+		"non_ducklake_path": {
+			connection: Connection{Kind: "s3", Path: "s3://bucket/"},
+			contains:   "path is only supported for ducklake",
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			model := minimalSourceModel()
 			model.Connections = map[string]Connection{"crm": tc.connection}
 			model.Sources = map[string]Source{
-				"orders": {Format: "csv", Location: "orders.csv", Connection: "crm"},
+				"orders": {Format: "csv", Path: "orders.csv", Connection: "crm"},
 			}
 			assertModelValidateError(t, model, tc.contains)
 		})
@@ -313,7 +347,7 @@ source_defaults:
 sources:
   orders:
     type: file
-    location: orders.csv
+    path: orders.csv
 `,
 		"source_engine": `
 sources:
@@ -333,6 +367,11 @@ sources:
   orders:
     query: SELECT 1 AS id
 `,
+		"source_location": `
+sources:
+  orders:
+    location: orders.csv
+`,
 		"scalar_source": `
 sources:
   orders: orders.csv
@@ -350,7 +389,7 @@ connections:
     kind: local
 sources:
   products:
-    location: products.csv
+    path: products.csv
 cache:
   tables:
     orders_cache:
@@ -947,7 +986,7 @@ func minimalSourceModel() *Model {
 			},
 		},
 		Sources: map[string]Source{
-			"orders": {Location: "orders.csv"},
+			"orders": {Path: "orders.csv"},
 		},
 		Cache: Cache{Tables: map[string]CacheTable{
 			"orders_cache": {SQL: "SELECT * FROM raw.orders"},

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -130,7 +130,6 @@ func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 		"local_files": {
 			Kind: "local",
 			Defaults: ConnectionDefaults{
-				Format:  "csv",
 				Options: map[string]any{"header": true},
 			},
 		},
@@ -166,9 +165,6 @@ func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 			Connection: "crm",
 			Object:     "public.accounts",
 		},
-		"custom": {
-			Query: "SELECT 1 AS id",
-		},
 	}
 
 	if err := model.Validate(); err != nil {
@@ -188,10 +184,15 @@ func TestModelValidateInfersFileFormats(t *testing.T) {
 		want     string
 	}{
 		"csv":     {location: "orders.csv", want: "csv"},
+		"csv_gz":  {location: "orders.csv.gz", want: "csv"},
 		"json":    {location: "orders.json", want: "json"},
 		"jsonl":   {location: "orders.jsonl", want: "json"},
+		"ndjson":  {location: "orders.ndjson", want: "json"},
 		"parquet": {location: "orders.parquet", want: "parquet"},
 		"excel":   {location: "orders.xlsx", want: "excel"},
+		"text":    {location: "orders.txt", want: "text"},
+		"blob":    {location: "orders.blob", want: "blob"},
+		"vortex":  {location: "orders.vortex", want: "vortex"},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -216,11 +217,11 @@ func TestModelValidateRejectsInvalidSources(t *testing.T) {
 	}{
 		"missing_source_shape": {
 			source:   Source{Format: "csv"},
-			contains: "exactly one of location, object, or query",
+			contains: "exactly one of location or object",
 		},
 		"multiple_source_shapes": {
 			source:   Source{Location: "orders.csv", Object: "public.orders"},
-			contains: "exactly one of location, object, or query",
+			contains: "exactly one of location or object",
 		},
 		"location_bad_format": {
 			source:   Source{Format: "orc", Location: "orders.orc", Connection: "local_files"},
@@ -242,10 +243,6 @@ func TestModelValidateRejectsInvalidSources(t *testing.T) {
 		"unknown_connection": {
 			source:   Source{Format: "parquet", Location: "s3://bucket/*.parquet", Connection: "missing"},
 			contains: "unknown connection",
-		},
-		"query_with_connection": {
-			source:   Source{Query: "SELECT 1", Connection: "crm"},
-			contains: "query cannot set",
 		},
 		"bad_source_option_key": {
 			source:   Source{Format: "csv", Location: "orders.csv", Connection: "local_files", Options: map[string]any{"bad-key": true}},
@@ -290,7 +287,7 @@ func TestModelValidateRejectsInvalidConnections(t *testing.T) {
 			contains:   "secret",
 		},
 		"bad_default_option": {
-			connection: Connection{Kind: "local", Defaults: ConnectionDefaults{Format: "csv", Options: map[string]any{"bad-key": true}}},
+			connection: Connection{Kind: "local", Defaults: ConnectionDefaults{Options: map[string]any{"bad-key": true}}},
 			contains:   "default option",
 		},
 	}
@@ -324,6 +321,18 @@ sources:
     engine: postgres
     object: public.orders
 `,
+		"connection_default_format": `
+connections:
+  other_files:
+    kind: local
+    defaults:
+      format: csv
+`,
+		"source_query": `
+sources:
+  orders:
+    query: SELECT 1 AS id
+`,
 		"scalar_source": `
 sources:
   orders: orders.csv
@@ -339,8 +348,6 @@ default_connection: local_files
 connections:
   local_files:
     kind: local
-    defaults:
-      format: csv
 sources:
   products:
     location: products.csv
@@ -936,8 +943,7 @@ func minimalSourceModel() *Model {
 		DefaultConnection: "local_files",
 		Connections: map[string]Connection{
 			"local_files": {
-				Kind:     "local",
-				Defaults: ConnectionDefaults{Format: "csv"},
+				Kind: "local",
 			},
 		},
 		Sources: map[string]Source{

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -322,7 +322,7 @@ func TestModelValidateRejectsInvalidConnections(t *testing.T) {
 		},
 		"non_ducklake_path": {
 			connection: Connection{Kind: "s3", Path: "s3://bucket/"},
-			contains:   "path is only supported for ducklake",
+			contains:   "path is only supported for path-backed connections",
 		},
 	}
 	for name, tc := range cases {

--- a/internal/source/registry.go
+++ b/internal/source/registry.go
@@ -36,6 +36,9 @@ type Connection struct {
 	AllowsPath         bool
 	RequiresPath       bool
 	AllowedOptions     []string
+	AuthKeys           []string
+	RequiredAuthSets   [][]string
+	AllowNoAuth        bool
 	AttachKind         string
 }
 
@@ -121,43 +124,54 @@ var connections = map[string]Connection{
 	"local": {
 		Kind:             "local",
 		AllowsPathSource: true,
+		AllowNoAuth:      true,
 	},
 	"s3": {
 		Kind:              "s3",
 		SecretType:        "s3",
 		RequiredExtension: "httpfs",
 		AllowsPathSource:  true,
+		AuthKeys:          []string{"access_key_id", "secret_access_key", "session_token", "region", "endpoint", "url_style", "use_ssl"},
+		RequiredAuthSets:  [][]string{{"access_key_id", "secret_access_key"}},
 	},
 	"r2": {
 		Kind:              "r2",
 		SecretType:        "r2",
 		RequiredExtension: "httpfs",
 		AllowsPathSource:  true,
+		AuthKeys:          []string{"access_key_id", "secret_access_key", "account_id", "region"},
+		RequiredAuthSets:  [][]string{{"access_key_id", "secret_access_key", "account_id"}},
 	},
 	"gcs": {
 		Kind:              "gcs",
 		SecretType:        "gcs",
 		RequiredExtension: "httpfs",
 		AllowsPathSource:  true,
+		AuthKeys:          []string{"access_key_id", "secret_access_key", "endpoint"},
+		RequiredAuthSets:  [][]string{{"access_key_id", "secret_access_key"}},
 	},
 	"http": {
 		Kind:              "http",
 		SecretType:        "http",
 		RequiredExtension: "httpfs",
 		AllowsPathSource:  true,
+		AllowNoAuth:       true,
 	},
 	"azure_blob": {
 		Kind:              "azure_blob",
 		SecretType:        "azure",
 		RequiredExtension: "azure",
 		AllowsPathSource:  true,
+		AuthKeys:          []string{"connection_string", "account_name", "tenant_id", "client_id", "client_secret"},
+		RequiredAuthSets:  [][]string{{"connection_string"}, {"account_name", "tenant_id", "client_id", "client_secret"}},
 	},
 	"postgres": {
 		Kind:               "postgres",
 		SecretType:         "postgres",
 		RequiredExtension:  "postgres",
 		AllowsObjectSource: true,
-		AllowedOptions:     []string{"connection_string", "uri", "path", "database"},
+		AuthKeys:           []string{"connection_string"},
+		RequiredAuthSets:   [][]string{{"connection_string"}},
 		AttachKind:         AttachDatabase,
 	},
 	"mysql": {
@@ -165,7 +179,8 @@ var connections = map[string]Connection{
 		SecretType:         "mysql",
 		RequiredExtension:  "mysql",
 		AllowsObjectSource: true,
-		AllowedOptions:     []string{"connection_string", "uri", "path", "database"},
+		AuthKeys:           []string{"connection_string"},
+		RequiredAuthSets:   [][]string{{"connection_string"}},
 		AttachKind:         AttachDatabase,
 	},
 	"sqlite": {
@@ -173,7 +188,10 @@ var connections = map[string]Connection{
 		SecretType:         "sqlite",
 		RequiredExtension:  "sqlite",
 		AllowsObjectSource: true,
-		AllowedOptions:     []string{"connection_string", "uri", "path", "database"},
+		AllowedOptions:     []string{"path"},
+		AuthKeys:           []string{"path"},
+		RequiredAuthSets:   [][]string{{"path"}},
+		AllowNoAuth:        true,
 		AttachKind:         AttachDatabase,
 	},
 	"ducklake": {
@@ -184,6 +202,9 @@ var connections = map[string]Connection{
 		AllowsPath:         true,
 		RequiresPath:       true,
 		AllowedOptions:     []string{"data_path"},
+		AuthKeys:           []string{"access_key_id", "secret_access_key", "session_token", "region", "endpoint", "url_style", "use_ssl", "account_id", "connection_string", "account_name", "tenant_id", "client_id", "client_secret"},
+		RequiredAuthSets:   [][]string{{"access_key_id", "secret_access_key"}, {"connection_string"}, {"account_name", "tenant_id", "client_id", "client_secret"}},
+		AllowNoAuth:        true,
 		AttachKind:         AttachDuckLake,
 	},
 }

--- a/internal/source/registry.go
+++ b/internal/source/registry.go
@@ -1,0 +1,259 @@
+package source
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	KindPath   = "path"
+	KindObject = "object"
+
+	ScanTableFunction = "table_function"
+	ScanReplacement   = "replacement"
+
+	AttachDatabase = "database"
+	AttachDuckLake = "ducklake"
+)
+
+type Format struct {
+	Name              string
+	Extensions        []string
+	ScanKind          string
+	ScanFunction      string
+	RequiredExtension string
+	AllowsOptions     bool
+	SourceSecretType  string
+	TableLike         bool
+}
+
+type Connection struct {
+	Kind               string
+	SecretType         string
+	RequiredExtension  string
+	AllowsPathSource   bool
+	AllowsObjectSource bool
+	AllowsPath         bool
+	RequiresPath       bool
+	AllowedOptions     []string
+	AttachKind         string
+}
+
+var formats = map[string]Format{
+	"csv": {
+		Name:          "csv",
+		Extensions:    []string{".csv", ".csv.gz"},
+		ScanKind:      ScanTableFunction,
+		ScanFunction:  "read_csv",
+		AllowsOptions: true,
+	},
+	"json": {
+		Name:          "json",
+		Extensions:    []string{".json", ".jsonl", ".ndjson"},
+		ScanKind:      ScanTableFunction,
+		ScanFunction:  "read_json",
+		AllowsOptions: true,
+	},
+	"parquet": {
+		Name:          "parquet",
+		Extensions:    []string{".parquet"},
+		ScanKind:      ScanTableFunction,
+		ScanFunction:  "read_parquet",
+		AllowsOptions: true,
+	},
+	"excel": {
+		Name:              "excel",
+		Extensions:        []string{".xlsx"},
+		ScanKind:          ScanTableFunction,
+		ScanFunction:      "read_xlsx",
+		RequiredExtension: "excel",
+		AllowsOptions:     true,
+	},
+	"text": {
+		Name:          "text",
+		Extensions:    []string{".txt"},
+		ScanKind:      ScanTableFunction,
+		ScanFunction:  "read_text",
+		AllowsOptions: true,
+	},
+	"blob": {
+		Name:          "blob",
+		Extensions:    []string{".blob"},
+		ScanKind:      ScanTableFunction,
+		ScanFunction:  "read_blob",
+		AllowsOptions: true,
+	},
+	"vortex": {
+		Name:              "vortex",
+		Extensions:        []string{".vortex"},
+		ScanKind:          ScanTableFunction,
+		ScanFunction:      "read_vortex",
+		RequiredExtension: "vortex",
+		AllowsOptions:     true,
+	},
+	"delta": {
+		Name:              "delta",
+		ScanKind:          ScanTableFunction,
+		ScanFunction:      "delta_scan",
+		RequiredExtension: "delta",
+		AllowsOptions:     true,
+		TableLike:         true,
+	},
+	"iceberg": {
+		Name:              "iceberg",
+		ScanKind:          ScanTableFunction,
+		ScanFunction:      "iceberg_scan",
+		RequiredExtension: "iceberg",
+		AllowsOptions:     true,
+		TableLike:         true,
+	},
+	"lance": {
+		Name:              "lance",
+		Extensions:        []string{".lance"},
+		ScanKind:          ScanReplacement,
+		RequiredExtension: "lance",
+		SourceSecretType:  "lance",
+		TableLike:         true,
+	},
+}
+
+var connections = map[string]Connection{
+	"local": {
+		Kind:             "local",
+		AllowsPathSource: true,
+	},
+	"s3": {
+		Kind:              "s3",
+		SecretType:        "s3",
+		RequiredExtension: "httpfs",
+		AllowsPathSource:  true,
+	},
+	"r2": {
+		Kind:              "r2",
+		SecretType:        "r2",
+		RequiredExtension: "httpfs",
+		AllowsPathSource:  true,
+	},
+	"gcs": {
+		Kind:              "gcs",
+		SecretType:        "gcs",
+		RequiredExtension: "httpfs",
+		AllowsPathSource:  true,
+	},
+	"http": {
+		Kind:              "http",
+		SecretType:        "http",
+		RequiredExtension: "httpfs",
+		AllowsPathSource:  true,
+	},
+	"azure_blob": {
+		Kind:              "azure_blob",
+		SecretType:        "azure",
+		RequiredExtension: "azure",
+		AllowsPathSource:  true,
+	},
+	"postgres": {
+		Kind:               "postgres",
+		SecretType:         "postgres",
+		RequiredExtension:  "postgres",
+		AllowsObjectSource: true,
+		AllowedOptions:     []string{"connection_string", "uri", "path", "database"},
+		AttachKind:         AttachDatabase,
+	},
+	"mysql": {
+		Kind:               "mysql",
+		SecretType:         "mysql",
+		RequiredExtension:  "mysql",
+		AllowsObjectSource: true,
+		AllowedOptions:     []string{"connection_string", "uri", "path", "database"},
+		AttachKind:         AttachDatabase,
+	},
+	"sqlite": {
+		Kind:               "sqlite",
+		SecretType:         "sqlite",
+		RequiredExtension:  "sqlite",
+		AllowsObjectSource: true,
+		AllowedOptions:     []string{"connection_string", "uri", "path", "database"},
+		AttachKind:         AttachDatabase,
+	},
+	"ducklake": {
+		Kind:               "ducklake",
+		SecretType:         "ducklake",
+		RequiredExtension:  "ducklake",
+		AllowsObjectSource: true,
+		AllowsPath:         true,
+		RequiresPath:       true,
+		AllowedOptions:     []string{"data_path"},
+		AttachKind:         AttachDuckLake,
+	},
+}
+
+func LookupFormat(name string) (Format, bool) {
+	spec, ok := formats[name]
+	return spec, ok
+}
+
+func LookupConnection(kind string) (Connection, bool) {
+	spec, ok := connections[kind]
+	return spec, ok
+}
+
+func FormatNames() []string {
+	return sortedKeys(formats)
+}
+
+func ConnectionKinds() []string {
+	return sortedKeys(connections)
+}
+
+func InferFormat(path string) (string, bool) {
+	lower := strings.ToLower(path)
+	for _, format := range FormatNames() {
+		spec := formats[format]
+		for _, ext := range spec.Extensions {
+			if strings.HasSuffix(lower, ext) {
+				return spec.Name, true
+			}
+		}
+	}
+	return "", false
+}
+
+func IsLocalPath(path string) bool {
+	for _, prefix := range []string{"s3://", "r2://", "gcs://", "gs://", "az://", "azure://", "abfss://", "http://", "https://", "file://"} {
+		if strings.HasPrefix(path, prefix) {
+			return false
+		}
+	}
+	return !strings.Contains(path, "://")
+}
+
+func JoinScope(scope, path string) string {
+	return strings.TrimRight(scope, "/") + "/" + strings.TrimLeft(path, "/")
+}
+
+func WithinScope(scope, path string) bool {
+	scope = strings.TrimRight(scope, "/")
+	path = strings.TrimRight(path, "/")
+	return path == scope || strings.HasPrefix(path, scope+"/")
+}
+
+func StorageExtension(path string) (string, bool) {
+	switch {
+	case strings.HasPrefix(path, "s3://"), strings.HasPrefix(path, "r2://"), strings.HasPrefix(path, "gcs://"), strings.HasPrefix(path, "gs://"), strings.HasPrefix(path, "http://"), strings.HasPrefix(path, "https://"):
+		return "httpfs", true
+	case strings.HasPrefix(path, "az://"), strings.HasPrefix(path, "azure://"), strings.HasPrefix(path, "abfss://"):
+		return "azure", true
+	default:
+		return "", false
+	}
+}
+
+func sortedKeys[T any](items map[string]T) []string {
+	keys := make([]string, 0, len(items))
+	for key := range items {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/source/registry_test.go
+++ b/internal/source/registry_test.go
@@ -68,6 +68,26 @@ func TestRegistrySpecializedCapabilities(t *testing.T) {
 	}
 }
 
+func TestRegistryConnectionAuthPolicy(t *testing.T) {
+	s3, _ := LookupConnection("s3")
+	if !contains(s3.AuthKeys, "access_key_id") || !contains(s3.AuthKeys, "secret_access_key") {
+		t.Fatalf("s3 auth keys = %#v, want access key fields", s3.AuthKeys)
+	}
+	if len(s3.RequiredAuthSets) != 1 || len(s3.RequiredAuthSets[0]) != 2 {
+		t.Fatalf("s3 required auth sets = %#v, want key pair", s3.RequiredAuthSets)
+	}
+
+	azure, _ := LookupConnection("azure_blob")
+	if len(azure.RequiredAuthSets) != 2 {
+		t.Fatalf("azure required auth sets = %#v, want connection string or service principal", azure.RequiredAuthSets)
+	}
+
+	local, _ := LookupConnection("local")
+	if !local.AllowNoAuth || len(local.AuthKeys) != 0 {
+		t.Fatalf("local auth policy = %#v, want no-auth only", local)
+	}
+}
+
 func TestPathHelpers(t *testing.T) {
 	if !IsLocalPath("orders.csv") {
 		t.Fatal("orders.csv should be local")
@@ -90,4 +110,13 @@ func TestPathHelpers(t *testing.T) {
 	if extension, ok := StorageExtension("https://example.com/data.parquet"); !ok || extension != "httpfs" {
 		t.Fatalf("StorageExtension https = %q, %v", extension, ok)
 	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/source/registry_test.go
+++ b/internal/source/registry_test.go
@@ -1,0 +1,93 @@
+package source
+
+import "testing"
+
+func TestRegistryIncludesSupportedFormats(t *testing.T) {
+	expected := []string{"csv", "json", "parquet", "excel", "text", "blob", "vortex", "delta", "iceberg", "lance"}
+	for _, name := range expected {
+		format, ok := LookupFormat(name)
+		if !ok {
+			t.Fatalf("format %q missing from registry", name)
+		}
+		if format.Name != name {
+			t.Fatalf("format %q registered with name %q", name, format.Name)
+		}
+	}
+}
+
+func TestRegistryIncludesSupportedConnectionKinds(t *testing.T) {
+	expected := []string{"local", "s3", "r2", "gcs", "http", "azure_blob", "postgres", "mysql", "sqlite", "ducklake"}
+	for _, kind := range expected {
+		connection, ok := LookupConnection(kind)
+		if !ok {
+			t.Fatalf("connection kind %q missing from registry", kind)
+		}
+		if connection.Kind != kind {
+			t.Fatalf("connection kind %q registered with kind %q", kind, connection.Kind)
+		}
+	}
+}
+
+func TestInferFormat(t *testing.T) {
+	cases := map[string]string{
+		"orders.csv":       "csv",
+		"orders.csv.gz":    "csv",
+		"orders.json":      "json",
+		"orders.jsonl":     "json",
+		"orders.ndjson":    "json",
+		"orders.parquet":   "parquet",
+		"orders.xlsx":      "excel",
+		"orders.txt":       "text",
+		"orders.blob":      "blob",
+		"orders.vortex":    "vortex",
+		"products.lance":   "lance",
+		"nested/a/b/c.CSV": "csv",
+	}
+	for path, want := range cases {
+		got, ok := InferFormat(path)
+		if !ok || got != want {
+			t.Fatalf("InferFormat(%q) = %q, %v; want %q, true", path, got, ok, want)
+		}
+	}
+}
+
+func TestRegistrySpecializedCapabilities(t *testing.T) {
+	lance, _ := LookupFormat("lance")
+	if lance.ScanKind != ScanReplacement || lance.SourceSecretType != "lance" || lance.AllowsOptions {
+		t.Fatalf("lance registry = %#v, want replacement scan with lance source secret and no options", lance)
+	}
+
+	ducklake, _ := LookupConnection("ducklake")
+	if ducklake.AttachKind != AttachDuckLake || !ducklake.AllowsObjectSource || !ducklake.RequiresPath {
+		t.Fatalf("ducklake registry = %#v, want object attach with required path", ducklake)
+	}
+
+	s3, _ := LookupConnection("s3")
+	if s3.RequiredExtension != "httpfs" || s3.SecretType != "s3" || !s3.AllowsPathSource {
+		t.Fatalf("s3 registry = %#v, want httpfs path source", s3)
+	}
+}
+
+func TestPathHelpers(t *testing.T) {
+	if !IsLocalPath("orders.csv") {
+		t.Fatal("orders.csv should be local")
+	}
+	if IsLocalPath("s3://bucket/orders.csv") {
+		t.Fatal("s3 URI should be remote")
+	}
+	if got := JoinScope("s3://bucket/root/", "events/*"); got != "s3://bucket/root/events/*" {
+		t.Fatalf("JoinScope = %q", got)
+	}
+	if !WithinScope("s3://bucket/root/", "s3://bucket/root/events/1.parquet") {
+		t.Fatal("path should be inside scope")
+	}
+	if WithinScope("s3://bucket/root/", "s3://bucket/root-other/events.parquet") {
+		t.Fatal("prefix sibling should not be inside scope")
+	}
+	if extension, ok := StorageExtension("az://warehouse/table"); !ok || extension != "azure" {
+		t.Fatalf("StorageExtension azure = %q, %v", extension, ok)
+	}
+	if extension, ok := StorageExtension("https://example.com/data.parquet"); !ok || extension != "httpfs" {
+		t.Fatalf("StorageExtension https = %q, %v", extension, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- replace the CSV-only source contract with connection-centric `connections` and object-only `sources`
- infer source readers from `path` extensions, with explicit `format` only for ambiguous paths and table formats
- support DuckDB-native file/table integrations including CSV, JSON, Parquet, Excel, text, blob, Vortex, Delta, Iceberg, Lance, and DuckLake
- compile source declarations into DuckDB extension setup, generated secrets, read-only object attaches, and `raw.*` views
- make credentials LibreDash-managed: direct `auth` config with `${ENV_VAR}` resolution, per-kind validation, and internal DuckDB secret generation
- centralize source/connection capabilities in the internal source registry and update docs/tests for the new YAML contract

## Breaking Changes
- removed backward compatibility for `sources.*.file`, `sources.*.location`, scalar sources, `source_defaults`, source `type`/`engine`, query sources, connection `secret`, and public `auth.method` flows such as `credential_chain`
- renamed source locations to `path`; sources must define exactly one of `path` or `object`
- database connections now use LibreDash `auth.connection_string` instead of DuckDB named secrets or connection-string options

## Tests
- `go test ./...`
- `task test`
