### PR TITLE
Number collapsed report page rail

### DIFF
--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -254,6 +254,9 @@ func TestPageRouteRendersRequestedYamlPage(t *testing.T) {
 		t.Fatalf("report header still rendered page tabs:\n%s", body)
 	}
 	decoded := html.UnescapeString(body)
+	if !strings.Contains(decoded, `2 Operations`) {
+		t.Fatalf("report header did not include numbered active page title:\n%s", decoded)
+	}
 	if !strings.Contains(decoded, `"visuals":{"ops_pipeline"`) {
 		t.Fatalf("operations page did not seed active page chart only:\n%s", decoded)
 	}

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -254,7 +254,7 @@ func TestPageRouteRendersRequestedYamlPage(t *testing.T) {
 		t.Fatalf("report header still rendered page tabs:\n%s", body)
 	}
 	decoded := html.UnescapeString(body)
-	if !strings.Contains(decoded, `2 Operations`) {
+	if !strings.Contains(decoded, `2. Operations`) {
 		t.Fatalf("report header did not include numbered active page title:\n%s", decoded)
 	}
 	if !strings.Contains(decoded, `"visuals":{"ops_pipeline"`) {

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -116,7 +116,7 @@ func Page(dataDir, clientID, csrfToken string, catalog dashboard.Catalog, report
 						workspaceHeader(
 							"",
 							report.Title,
-							activePage.Title,
+							reportPageHeaderDetail(pages, activePage),
 							reportActions(model.Name, report.ID),
 						),
 						h.Div(h.Class("grid min-h-0 min-w-0 grid-cols-report-dashboard items-stretch overflow-hidden max-sm:grid-cols-1 max-sm:overflow-auto"),
@@ -745,6 +745,27 @@ func defaultPage() dashboard.Page {
 		Canvas: dashboard.PageCanvas{Width: 1366, Height: 940},
 		Grid:   dashboard.PageGrid{Columns: 12, RowHeight: 48, Gap: 16, Padding: 16},
 	}
+}
+
+func reportPageHeaderDetail(pages []dashboard.Page, activePage dashboard.Page) string {
+	title := displayLabel(activePage.Title, activePage.ID)
+	for index, page := range pages {
+		if page.ID == activePage.ID {
+			return formatReportPageNumber(index, len(pages)) + " " + title
+		}
+	}
+	return title
+}
+
+func formatReportPageNumber(index, pageCount int) string {
+	pageNumber := strconv.Itoa(index + 1)
+	if pageCount >= 10 {
+		width := len(strconv.Itoa(pageCount))
+		if len(pageNumber) < width {
+			return strings.Repeat("0", width-len(pageNumber)) + pageNumber
+		}
+	}
+	return pageNumber
 }
 
 func modelStats(stats dashboard.ModelStats) g.Node {

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -751,7 +751,7 @@ func reportPageHeaderDetail(pages []dashboard.Page, activePage dashboard.Page) s
 	title := displayLabel(activePage.Title, activePage.ID)
 	for index, page := range pages {
 		if page.ID == activePage.ID {
-			return formatReportPageNumber(index, len(pages)) + " " + title
+			return formatReportPageNumber(index, len(pages)) + ". " + title
 		}
 	}
 	return title

--- a/web/components/report-sidebar.ts
+++ b/web/components/report-sidebar.ts
@@ -187,15 +187,15 @@ class ReportSidebar extends LitElement {
       position: relative;
       display: grid;
       grid-template-columns: 24px minmax(0, 1fr);
-      min-height: 30px;
+      min-height: 29px;
       align-items: center;
       gap: 6px;
       border: var(--ld-border-transparent);
       border-radius: var(--ld-radius-default);
-      color: var(--fgColor-muted);
+      color: color-mix(in srgb, var(--fgColor-muted), transparent 8%);
       padding: 0 9px;
       font-size: var(--ld-font-size-caption);
-      font-weight: var(--ld-font-weight-800);
+      font-weight: var(--ld-font-weight-760);
     }
 
     .page-link:hover,
@@ -207,7 +207,7 @@ class ReportSidebar extends LitElement {
 
     .page-link[aria-current='page'] {
       border-color: transparent;
-      background: color-mix(in srgb, var(--bgColor-muted), var(--bgColor-default) 30%);
+      background: color-mix(in srgb, var(--bgColor-muted), var(--bgColor-default) 42%);
       color: var(--fgColor-default);
     }
 
@@ -226,7 +226,7 @@ class ReportSidebar extends LitElement {
       width: 24px;
       height: 24px;
       place-items: center;
-      color: color-mix(in srgb, var(--fgColor-muted), transparent 12%);
+      color: color-mix(in srgb, var(--fgColor-muted), transparent 24%);
       font-size: var(--ld-font-size-caption);
       font-variant-numeric: tabular-nums;
       font-weight: var(--ld-font-weight-850);
@@ -244,6 +244,12 @@ class ReportSidebar extends LitElement {
       min-width: 0;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+
+    .page-link:hover .link-text,
+    .page-link:focus-visible .link-text,
+    .page-link[aria-current='page'] .link-text {
+      font-weight: var(--ld-font-weight-850);
     }
 
     :host([data-collapsed]) header {
@@ -281,7 +287,6 @@ class ReportSidebar extends LitElement {
     }
 
     :host([data-collapsed]) .page-index {
-      color: color-mix(in srgb, var(--fgColor-muted), transparent 24%);
       background: transparent;
     }
 
@@ -295,12 +300,12 @@ class ReportSidebar extends LitElement {
     }
 
     :host([data-collapsed]) .page-link {
-      min-height: 28px;
+      min-height: 29px;
     }
 
     :host([data-collapsed]) .page-link[aria-current='page']::before {
       content: '';
-      inset-block: 6px;
+      inset-block: 7px;
       left: 0;
       width: 2px;
     }
@@ -313,7 +318,7 @@ class ReportSidebar extends LitElement {
       position: absolute;
       z-index: 40;
       left: 7px;
-      min-height: 28px;
+      min-height: 29px;
       max-width: 12rem;
       display: inline-flex;
       align-items: center;
@@ -333,7 +338,7 @@ class ReportSidebar extends LitElement {
     :host([data-collapsed]) .hover-title[data-active]::before {
       content: '';
       position: absolute;
-      inset-block: 6px;
+      inset-block: 7px;
       left: -2px;
       width: 2px;
       border-radius: var(--ld-radius-full);

--- a/web/components/report-sidebar.ts
+++ b/web/components/report-sidebar.ts
@@ -180,7 +180,7 @@ class ReportSidebar extends LitElement {
       background: var(--ld-accent);
     }
 
-    .page-dot {
+    .page-index {
       display: none;
     }
 
@@ -215,37 +215,28 @@ class ReportSidebar extends LitElement {
       padding-inline: 0;
     }
 
-    :host([data-collapsed]) .page-dot {
+    :host([data-collapsed]) .page-index {
       display: grid;
       width: 24px;
       height: 24px;
       place-items: center;
-    }
-
-    :host([data-collapsed]) .page-dot::before {
-      content: '';
-      display: block;
-      width: 6px;
-      height: 6px;
-      border: 1px solid var(--fgColor-muted);
       border-radius: var(--ld-radius-full);
+      color: var(--fgColor-muted);
       background: transparent;
-      opacity: 0.74;
+      font-size: var(--ld-font-size-caption);
+      font-weight: var(--ld-font-weight-850);
+      line-height: var(--ld-line-height-none);
     }
 
-    :host([data-collapsed]) .page-link:hover .page-dot::before,
-    :host([data-collapsed]) .page-link:focus-visible .page-dot::before {
-      border-color: var(--fgColor-default);
-      background: var(--fgColor-muted);
-      opacity: 1;
+    :host([data-collapsed]) .page-link:hover .page-index,
+    :host([data-collapsed]) .page-link:focus-visible .page-index {
+      color: var(--fgColor-default);
+      background: var(--bgColor-muted);
     }
 
-    :host([data-collapsed]) .page-link[aria-current='page'] .page-dot::before {
-      width: 7px;
-      height: 7px;
-      border-color: var(--fgColor-accent);
+    :host([data-collapsed]) .page-link[aria-current='page'] .page-index {
+      color: var(--fgColor-onEmphasis);
       background: var(--fgColor-accent);
-      opacity: 1;
     }
 
     :host([data-collapsed]) .page-link {
@@ -301,18 +292,18 @@ class ReportSidebar extends LitElement {
 
         <nav aria-label="Report pages">
           <span class="rail-label" aria-hidden="true">Pages</span>
-          ${pages.map((page) => this.renderPageLink(page))}
+          ${pages.map((page, index) => this.renderPageLink(page, index))}
         </nav>
       </aside>
     `
   }
 
-  private renderPageLink(page: ReportPage) {
+  private renderPageLink(page: ReportPage, index: number) {
     const active = Boolean(page.active || page.id === this.config.pageId)
     const title = page.title || page.id
     return html`
       <a class="page-link" href=${page.href} aria-current=${active ? 'page' : 'false'} title=${title}>
-        <span class="page-dot" aria-hidden="true"></span>
+        <span class="page-index" aria-hidden="true">${index + 1}</span>
         <span class="link-text">${title}</span>
       </a>
     `

--- a/web/components/report-sidebar.ts
+++ b/web/components/report-sidebar.ts
@@ -16,6 +16,12 @@ type ReportSidebarConfig = {
   pages?: ReportPage[]
 }
 
+type HoverTitle = {
+  index: number
+  title: string
+  top: number
+}
+
 const defaultConfig: ReportSidebarConfig = {
   pageTitle: 'Page',
   pages: [],
@@ -38,6 +44,7 @@ const configConverter = {
 class ReportSidebar extends LitElement {
   @property({ attribute: 'config', converter: configConverter }) config: ReportSidebarConfig = defaultConfig
   @state() private collapsed = storedCollapsed()
+  @state() private hoverTitle?: HoverTitle
 
   static styles = css`
     :host {
@@ -54,6 +61,12 @@ class ReportSidebar extends LitElement {
 
     :host([data-collapsed]) {
       --ld-report-sidebar-width: 38px;
+      z-index: 30;
+      overflow: visible;
+    }
+
+    :host([data-collapsed]) aside {
+      overflow: visible;
     }
 
     aside {
@@ -283,6 +296,42 @@ class ReportSidebar extends LitElement {
       width: 2px;
     }
 
+    .hover-title {
+      display: none;
+    }
+
+    :host([data-collapsed]) .hover-title {
+      position: absolute;
+      z-index: 40;
+      left: calc(var(--ld-report-sidebar-width) - 1px);
+      min-height: 28px;
+      max-width: 12rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 0 9px 0 8px;
+      border-left: 1px solid color-mix(in srgb, var(--borderColor-muted), transparent 36%);
+      border-right: 2px solid var(--ld-accent);
+      background: color-mix(in srgb, var(--bgColor-muted), var(--bgColor-default) 56%);
+      color: var(--fgColor-default);
+      font-size: var(--ld-font-size-caption);
+      font-weight: var(--ld-font-weight-850);
+      line-height: var(--ld-line-height-none);
+      pointer-events: none;
+      transform: translateY(-50%);
+      white-space: nowrap;
+    }
+
+    .hover-title-index {
+      color: var(--fgColor-muted);
+      font-weight: var(--ld-font-weight-850);
+    }
+
+    .hover-title-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     .rail-label {
       display: none;
     }
@@ -329,10 +378,16 @@ class ReportSidebar extends LitElement {
           </div>
         </header>
 
-        <nav aria-label="Report pages">
+        <nav aria-label="Report pages" @scroll=${this.hideHoverTitle}>
           <span class="rail-label" aria-hidden="true">Pages</span>
           ${pages.map((page, index) => this.renderPageLink(page, index))}
         </nav>
+        ${this.collapsed && this.hoverTitle ? html`
+          <div class="hover-title" style=${`top:${this.hoverTitle.top}px`}>
+            <span class="hover-title-index" aria-hidden="true">${this.hoverTitle.index}</span>
+            <span class="hover-title-name">${this.hoverTitle.title}</span>
+          </div>
+        ` : null}
       </aside>
     `
   }
@@ -341,7 +396,16 @@ class ReportSidebar extends LitElement {
     const active = Boolean(page.active || page.id === this.config.pageId)
     const title = page.title || page.id
     return html`
-      <a class="page-link" href=${page.href} aria-current=${active ? 'page' : 'false'} title=${title}>
+      <a
+        class="page-link"
+        href=${page.href}
+        aria-current=${active ? 'page' : 'false'}
+        title=${title}
+        @mouseenter=${(event: MouseEvent) => this.showHoverTitle(event, title, index + 1)}
+        @mouseleave=${this.hideHoverTitle}
+        @focus=${(event: FocusEvent) => this.showHoverTitle(event, title, index + 1)}
+        @blur=${this.hideHoverTitle}
+      >
         <span class="page-index" aria-hidden="true">${index + 1}</span>
         <span class="link-text">${title}</span>
       </a>
@@ -362,6 +426,24 @@ class ReportSidebar extends LitElement {
       const active = this.renderRoot.querySelector<HTMLElement>('.page-link[aria-current="page"]')
       active?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
     })
+  }
+
+  private showHoverTitle(event: MouseEvent | FocusEvent, title: string, index: number): void {
+    if (!this.collapsed) return
+    const target = event.currentTarget
+    const aside = this.renderRoot.querySelector<HTMLElement>('aside')
+    if (!(target instanceof HTMLElement) || !aside) return
+    const targetRect = target.getBoundingClientRect()
+    const asideRect = aside.getBoundingClientRect()
+    this.hoverTitle = {
+      index,
+      title,
+      top: targetRect.top - asideRect.top + targetRect.height / 2,
+    }
+  }
+
+  private hideHoverTitle = (): void => {
+    this.hoverTitle = undefined
   }
 }
 

--- a/web/components/report-sidebar.ts
+++ b/web/components/report-sidebar.ts
@@ -220,7 +220,6 @@ class ReportSidebar extends LitElement {
       width: 24px;
       height: 24px;
       place-items: center;
-      border-radius: var(--ld-radius-full);
       color: var(--fgColor-muted);
       background: transparent;
       font-size: var(--ld-font-size-caption);
@@ -231,12 +230,10 @@ class ReportSidebar extends LitElement {
     :host([data-collapsed]) .page-link:hover .page-index,
     :host([data-collapsed]) .page-link:focus-visible .page-index {
       color: var(--fgColor-default);
-      background: var(--bgColor-muted);
     }
 
     :host([data-collapsed]) .page-link[aria-current='page'] .page-index {
-      color: var(--fgColor-onEmphasis);
-      background: var(--fgColor-accent);
+      color: var(--fgColor-default);
     }
 
     :host([data-collapsed]) .page-link {
@@ -244,7 +241,10 @@ class ReportSidebar extends LitElement {
     }
 
     :host([data-collapsed]) .page-link[aria-current='page']::before {
-      content: none;
+      content: '';
+      inset-block: 6px;
+      left: 0;
+      width: 2px;
     }
 
     .rail-label {

--- a/web/components/report-sidebar.ts
+++ b/web/components/report-sidebar.ts
@@ -303,14 +303,13 @@ class ReportSidebar extends LitElement {
     :host([data-collapsed]) .hover-title {
       position: absolute;
       z-index: 40;
-      left: calc(var(--ld-report-sidebar-width) - 1px);
+      left: 5px;
       min-height: 28px;
       max-width: 12rem;
       display: inline-flex;
       align-items: center;
       gap: 6px;
-      padding: 0 9px 0 8px;
-      border-left: 1px solid color-mix(in srgb, var(--borderColor-muted), transparent 36%);
+      padding: 0 9px 0 0;
       border-right: 2px solid var(--ld-accent);
       background: color-mix(in srgb, var(--bgColor-muted), var(--bgColor-default) 56%);
       color: var(--fgColor-default);
@@ -319,10 +318,28 @@ class ReportSidebar extends LitElement {
       line-height: var(--ld-line-height-none);
       pointer-events: none;
       transform: translateY(-50%);
+      transform-origin: left center;
+      animation: rail-title-fold-out 120ms var(--ld-ease-out);
       white-space: nowrap;
     }
 
+    @keyframes rail-title-fold-out {
+      from {
+        opacity: 0;
+        transform: translateY(-50%) scaleX(0.72);
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(-50%) scaleX(1);
+      }
+    }
+
     .hover-title-index {
+      display: grid;
+      width: 24px;
+      height: 24px;
+      place-items: center;
       color: var(--fgColor-muted);
       font-weight: var(--ld-font-weight-850);
     }
@@ -400,7 +417,7 @@ class ReportSidebar extends LitElement {
         class="page-link"
         href=${page.href}
         aria-current=${active ? 'page' : 'false'}
-        title=${title}
+        aria-label=${title}
         @mouseenter=${(event: MouseEvent) => this.showHoverTitle(event, title, index + 1)}
         @mouseleave=${this.hideHoverTitle}
         @focus=${(event: FocusEvent) => this.showHoverTitle(event, title, index + 1)}

--- a/web/components/report-sidebar.ts
+++ b/web/components/report-sidebar.ts
@@ -17,9 +17,10 @@ type ReportSidebarConfig = {
 }
 
 type HoverTitle = {
-  index: number
+  index: string
   title: string
   top: number
+  active: boolean
 }
 
 const defaultConfig: ReportSidebarConfig = {
@@ -185,9 +186,10 @@ class ReportSidebar extends LitElement {
     .page-link {
       position: relative;
       display: grid;
-      grid-template-columns: minmax(0, 1fr);
+      grid-template-columns: 24px minmax(0, 1fr);
       min-height: 30px;
       align-items: center;
+      gap: 6px;
       border: var(--ld-border-transparent);
       border-radius: var(--ld-radius-default);
       color: var(--fgColor-muted);
@@ -220,7 +222,21 @@ class ReportSidebar extends LitElement {
     }
 
     .page-index {
-      display: none;
+      display: grid;
+      width: 24px;
+      height: 24px;
+      place-items: center;
+      color: color-mix(in srgb, var(--fgColor-muted), transparent 12%);
+      font-size: var(--ld-font-size-caption);
+      font-variant-numeric: tabular-nums;
+      font-weight: var(--ld-font-weight-850);
+      line-height: var(--ld-line-height-none);
+    }
+
+    .page-link:hover .page-index,
+    .page-link:focus-visible .page-index,
+    .page-link[aria-current='page'] .page-index {
+      color: var(--fgColor-default);
     }
 
     .link-text {
@@ -265,15 +281,8 @@ class ReportSidebar extends LitElement {
     }
 
     :host([data-collapsed]) .page-index {
-      display: grid;
-      width: 24px;
-      height: 24px;
-      place-items: center;
-      color: var(--fgColor-muted);
+      color: color-mix(in srgb, var(--fgColor-muted), transparent 24%);
       background: transparent;
-      font-size: var(--ld-font-size-caption);
-      font-weight: var(--ld-font-weight-850);
-      line-height: var(--ld-line-height-none);
     }
 
     :host([data-collapsed]) .page-link:hover .page-index,
@@ -303,14 +312,13 @@ class ReportSidebar extends LitElement {
     :host([data-collapsed]) .hover-title {
       position: absolute;
       z-index: 40;
-      left: 5px;
+      left: 7px;
       min-height: 28px;
       max-width: 12rem;
       display: inline-flex;
       align-items: center;
       gap: 6px;
       padding: 0 9px 0 0;
-      border-right: 2px solid var(--ld-accent);
       background: color-mix(in srgb, var(--bgColor-muted), var(--bgColor-default) 56%);
       color: var(--fgColor-default);
       font-size: var(--ld-font-size-caption);
@@ -318,20 +326,27 @@ class ReportSidebar extends LitElement {
       line-height: var(--ld-line-height-none);
       pointer-events: none;
       transform: translateY(-50%);
-      transform-origin: left center;
-      animation: rail-title-fold-out 120ms var(--ld-ease-out);
+      animation: rail-title-fade-in 90ms var(--ld-ease-out);
       white-space: nowrap;
     }
 
-    @keyframes rail-title-fold-out {
+    :host([data-collapsed]) .hover-title[data-active]::before {
+      content: '';
+      position: absolute;
+      inset-block: 6px;
+      left: -2px;
+      width: 2px;
+      border-radius: var(--ld-radius-full);
+      background: var(--ld-accent);
+    }
+
+    @keyframes rail-title-fade-in {
       from {
         opacity: 0;
-        transform: translateY(-50%) scaleX(0.72);
       }
 
       to {
         opacity: 1;
-        transform: translateY(-50%) scaleX(1);
       }
     }
 
@@ -340,13 +355,28 @@ class ReportSidebar extends LitElement {
       width: 24px;
       height: 24px;
       place-items: center;
-      color: var(--fgColor-muted);
+      color: var(--fgColor-default);
+      font-variant-numeric: tabular-nums;
       font-weight: var(--ld-font-weight-850);
     }
 
     .hover-title-name {
       overflow: hidden;
       text-overflow: ellipsis;
+      animation: rail-title-name-fold-out 120ms var(--ld-ease-out);
+      transform-origin: left center;
+    }
+
+    @keyframes rail-title-name-fold-out {
+      from {
+        opacity: 0;
+        transform: translateX(-4px) scaleX(0.86);
+      }
+
+      to {
+        opacity: 1;
+        transform: translateX(0) scaleX(1);
+      }
     }
 
     .rail-label {
@@ -397,10 +427,14 @@ class ReportSidebar extends LitElement {
 
         <nav aria-label="Report pages" @scroll=${this.hideHoverTitle}>
           <span class="rail-label" aria-hidden="true">Pages</span>
-          ${pages.map((page, index) => this.renderPageLink(page, index))}
+          ${pages.map((page, index) => this.renderPageLink(page, index, pages.length))}
         </nav>
         ${this.collapsed && this.hoverTitle ? html`
-          <div class="hover-title" style=${`top:${this.hoverTitle.top}px`}>
+          <div
+            class="hover-title"
+            style=${`top:${this.hoverTitle.top}px`}
+            ?data-active=${this.hoverTitle.active}
+          >
             <span class="hover-title-index" aria-hidden="true">${this.hoverTitle.index}</span>
             <span class="hover-title-name">${this.hoverTitle.title}</span>
           </div>
@@ -409,8 +443,9 @@ class ReportSidebar extends LitElement {
     `
   }
 
-  private renderPageLink(page: ReportPage, index: number) {
+  private renderPageLink(page: ReportPage, index: number, pageCount: number) {
     const active = Boolean(page.active || page.id === this.config.pageId)
+    const pageNumber = formatPageNumber(index, pageCount)
     const title = page.title || page.id
     return html`
       <a
@@ -418,12 +453,12 @@ class ReportSidebar extends LitElement {
         href=${page.href}
         aria-current=${active ? 'page' : 'false'}
         aria-label=${title}
-        @mouseenter=${(event: MouseEvent) => this.showHoverTitle(event, title, index + 1)}
+        @mouseenter=${(event: MouseEvent) => this.showHoverTitle(event, title, pageNumber, active)}
         @mouseleave=${this.hideHoverTitle}
-        @focus=${(event: FocusEvent) => this.showHoverTitle(event, title, index + 1)}
+        @focus=${(event: FocusEvent) => this.showHoverTitle(event, title, pageNumber, active)}
         @blur=${this.hideHoverTitle}
       >
-        <span class="page-index" aria-hidden="true">${index + 1}</span>
+        <span class="page-index" aria-hidden="true">${pageNumber}</span>
         <span class="link-text">${title}</span>
       </a>
     `
@@ -445,7 +480,7 @@ class ReportSidebar extends LitElement {
     })
   }
 
-  private showHoverTitle(event: MouseEvent | FocusEvent, title: string, index: number): void {
+  private showHoverTitle(event: MouseEvent | FocusEvent, title: string, index: string, active: boolean): void {
     if (!this.collapsed) return
     const target = event.currentTarget
     const aside = this.renderRoot.querySelector<HTMLElement>('aside')
@@ -456,6 +491,7 @@ class ReportSidebar extends LitElement {
       index,
       title,
       top: targetRect.top - asideRect.top + targetRect.height / 2,
+      active,
     }
   }
 
@@ -470,6 +506,11 @@ function storedCollapsed(): boolean {
   } catch {
     return false
   }
+}
+
+function formatPageNumber(index: number, pageCount: number): string {
+  const pageNumber = String(index + 1)
+  return pageCount >= 10 ? pageNumber.padStart(2, '0') : pageNumber
 }
 
 function icon(name: 'chevron-left' | 'chevron-right') {

--- a/web/components/report-sidebar.ts
+++ b/web/components/report-sidebar.ts
@@ -144,6 +144,25 @@ class ReportSidebar extends LitElement {
       overflow-y: auto;
       padding: 7px 5px;
       scrollbar-gutter: stable;
+      scrollbar-color: color-mix(in srgb, var(--fgColor-muted), transparent 42%) transparent;
+      scrollbar-width: thin;
+    }
+
+    nav::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    nav::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    nav::-webkit-scrollbar-thumb {
+      border-radius: var(--ld-radius-full);
+      background: color-mix(in srgb, var(--fgColor-muted), transparent 42%);
+    }
+
+    nav::-webkit-scrollbar-thumb:hover {
+      background: color-mix(in srgb, var(--fgColor-muted), transparent 20%);
     }
 
     a {
@@ -214,6 +233,16 @@ class ReportSidebar extends LitElement {
 
     :host([data-collapsed]) .collapse {
       margin-left: 0;
+    }
+
+    :host([data-collapsed]) nav {
+      scrollbar-gutter: auto;
+      scrollbar-width: none;
+    }
+
+    :host([data-collapsed]) nav::-webkit-scrollbar {
+      display: none;
+      width: 0;
     }
 
     :host([data-collapsed]) .page-link {

--- a/web/components/report-sidebar.ts
+++ b/web/components/report-sidebar.ts
@@ -1,4 +1,4 @@
-import { LitElement, css, html, svg as svgTemplate } from 'lit'
+import { LitElement, css, html, svg as svgTemplate, type PropertyValues } from 'lit'
 import { property, state } from 'lit/decorators.js'
 
 type ReportPage = {
@@ -44,7 +44,9 @@ class ReportSidebar extends LitElement {
       --ld-report-sidebar-width: 144px;
       display: block;
       width: var(--ld-report-sidebar-width);
-      min-height: 100svh;
+      height: 100svh;
+      min-height: 0;
+      overflow: hidden;
       color: var(--fgColor-default);
       font-family: var(--fontStack-system);
       transition: width 180ms var(--ld-ease-out);
@@ -59,8 +61,11 @@ class ReportSidebar extends LitElement {
       top: 0;
       display: grid;
       width: var(--ld-report-sidebar-width);
-      min-height: 100svh;
+      height: 100svh;
+      min-height: 0;
+      max-height: 100svh;
       grid-template-rows: auto minmax(0, 1fr);
+      overflow: hidden;
       border-right: 1px solid color-mix(in srgb, var(--borderColor-muted), transparent 36%);
       background: color-mix(in srgb, var(--bgColor-muted), var(--bgColor-default) 56%);
       transition: width 180ms var(--ld-ease-out);
@@ -135,8 +140,10 @@ class ReportSidebar extends LitElement {
       gap: 2px;
       min-width: 0;
       min-height: 0;
-      overflow: auto;
+      overflow-x: hidden;
+      overflow-y: auto;
       padding: 7px 5px;
+      scrollbar-gutter: stable;
     }
 
     a {
@@ -266,8 +273,11 @@ class ReportSidebar extends LitElement {
     }
   `
 
-  updated(): void {
+  updated(changed: PropertyValues<this>): void {
     this.toggleAttribute('data-collapsed', this.collapsed)
+    if (changed.has('config') || changed.has('collapsed')) {
+      this.scrollActivePageIntoView()
+    }
   }
 
   render() {
@@ -316,6 +326,13 @@ class ReportSidebar extends LitElement {
     } catch {
       // Session state still updates when storage is unavailable.
     }
+  }
+
+  private scrollActivePageIntoView(): void {
+    requestAnimationFrame(() => {
+      const active = this.renderRoot.querySelector<HTMLElement>('.page-link[aria-current="page"]')
+      active?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    })
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace collapsed report page dots with numbered page markers.
- Keep page titles on each rail link so hover exposes the page title.
- Preserve active/hover styling with existing Primer-backed tokens.

## Test Plan
- task test
- Verified in the in-app browser that the collapsed rail shows numbered markers and link titles.