### PR TITLE
Refine table chunking and header seams

### DIFF
--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -738,7 +738,7 @@ func TestUpdatesStreamsPageScopedChartSignals(t *testing.T) {
 }
 
 func TestRefreshCacheCommandAcceptsDatastarSignals(t *testing.T) {
-	body := strings.NewReader(`{"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}}},"runtime":{"clientId":"test-client"},"tableCommand":{"table":"orders","block":"all","start":0,"count":200}}`)
+	body := strings.NewReader(`{"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}}},"runtime":{"clientId":"test-client"},"tableCommand":{"table":"orders","block":"all","start":0,"count":50}}`)
 	req := httptest.NewRequest(http.MethodPost, "/commands/refresh-cache", body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -751,7 +751,7 @@ func TestRefreshCacheCommandAcceptsDatastarSignals(t *testing.T) {
 }
 
 func TestChartSelectCommandAcceptsDatastarSignals(t *testing.T) {
-	body := strings.NewReader(`{"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}},"visualSelections":[]},"runtime":{"clientId":"test-client"},"visualCommand":{"visualId":"orders","field":"status","value":"delivered","label":"delivered"},"tableCommand":{"table":"orders","block":"all","start":0,"count":200}}`)
+	body := strings.NewReader(`{"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}},"visualSelections":[]},"runtime":{"clientId":"test-client"},"visualCommand":{"visualId":"orders","field":"status","value":"delivered","label":"delivered"},"tableCommand":{"table":"orders","block":"all","start":0,"count":50}}`)
 	req := httptest.NewRequest(http.MethodPost, "/commands/chart-select", body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -772,22 +772,22 @@ func TestPageCommandsQueryActivePage(t *testing.T) {
 		{
 			name: "chart select",
 			path: "/commands/chart-select",
-			body: `{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"operations"},"filters":{"visualSelections":[]},"visualCommand":{"visualId":"ops_pipeline","field":"status","value":"delivered","label":"delivered"},"tableCommand":{"block":"all","start":0,"count":200}}`,
+			body: `{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"operations"},"filters":{"visualSelections":[]},"visualCommand":{"visualId":"ops_pipeline","field":"status","value":"delivered","label":"delivered"},"tableCommand":{"block":"all","start":0,"count":50}}`,
 		},
 		{
 			name: "clear selection",
 			path: "/commands/clear-selection",
-			body: `{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"operations"},"filters":{"visualSelections":[{"visualId":"ops_pipeline","field":"status","values":["delivered"]}]},"tableCommand":{"block":"all","start":0,"count":200}}`,
+			body: `{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"operations"},"filters":{"visualSelections":[{"visualId":"ops_pipeline","field":"status","values":["delivered"]}]},"tableCommand":{"block":"all","start":0,"count":50}}`,
 		},
 		{
 			name: "reset filters",
 			path: "/commands/reset-filters",
-			body: `{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"operations"},"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}}},"tableCommand":{"block":"all","start":200,"count":200}}`,
+			body: `{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"operations"},"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}}},"tableCommand":{"block":"all","start":200,"count":50}}`,
 		},
 		{
 			name: "refresh cache",
 			path: "/commands/refresh-cache",
-			body: `{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"operations","modelId":"test"},"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}}},"tableCommand":{"block":"all","start":0,"count":200}}`,
+			body: `{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"operations","modelId":"test"},"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}}},"tableCommand":{"block":"all","start":0,"count":50}}`,
 		},
 	}
 
@@ -811,7 +811,7 @@ func TestPageCommandsQueryActivePage(t *testing.T) {
 }
 
 func TestClearSelectionCommandAcceptsDatastarSignals(t *testing.T) {
-	body := strings.NewReader(`{"filters":{"visualSelections":[{"visualId":"orders","field":"status","values":["delivered"]}]},"runtime":{"clientId":"test-client"},"tableCommand":{"table":"orders","block":"all","start":0,"count":200}}`)
+	body := strings.NewReader(`{"filters":{"visualSelections":[{"visualId":"orders","field":"status","values":["delivered"]}]},"runtime":{"clientId":"test-client"},"tableCommand":{"table":"orders","block":"all","start":0,"count":50}}`)
 	req := httptest.NewRequest(http.MethodPost, "/commands/clear-selection", body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -824,7 +824,7 @@ func TestClearSelectionCommandAcceptsDatastarSignals(t *testing.T) {
 }
 
 func TestResetFiltersCommandAcceptsDatastarSignals(t *testing.T) {
-	body := strings.NewReader(`{"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}},"visualSelections":[{"visualId":"orders","field":"status","values":["delivered"]}]},"runtime":{"clientId":"test-client"},"tableCommand":{"table":"orders","block":"all","start":200,"count":200}}`)
+	body := strings.NewReader(`{"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}},"visualSelections":[{"visualId":"orders","field":"status","values":["delivered"]}]},"runtime":{"clientId":"test-client"},"tableCommand":{"table":"orders","block":"all","start":200,"count":50}}`)
 	req := httptest.NewRequest(http.MethodPost, "/commands/reset-filters", body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -837,7 +837,7 @@ func TestResetFiltersCommandAcceptsDatastarSignals(t *testing.T) {
 }
 
 func TestTableWindowCommandAcceptsDatastarSignals(t *testing.T) {
-	body := strings.NewReader(`{"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}}},"runtime":{"clientId":"test-client"},"tableCommand":{"table":"orders","block":"a","start":400,"count":200,"requestSeq":42,"sort":{"key":"revenue","direction":"desc"}}}`)
+	body := strings.NewReader(`{"filters":{"controls":{"state":{"type":"multi_select","operator":"in","values":["SP"]}}},"runtime":{"clientId":"test-client"},"tableCommand":{"table":"orders","block":"a","start":400,"count":50,"requestSeq":42,"sort":{"key":"revenue","direction":"desc"}}}`)
 	req := httptest.NewRequest(http.MethodPost, "/commands/table-window", body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -854,7 +854,7 @@ func TestTableWindowCommandDoesNotPublishCanceledQueries(t *testing.T) {
 	updates, unsubscribe := server.broker.subscribe("test-client:executive-sales:overview")
 	defer unsubscribe()
 
-	body := strings.NewReader(`{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"overview"},"tableCommand":{"table":"orders","block":"all","start":400,"count":200,"requestSeq":42}}`)
+	body := strings.NewReader(`{"runtime":{"clientId":"test-client","dashboardId":"executive-sales","pageId":"overview"},"tableCommand":{"table":"orders","block":"all","start":400,"count":50,"requestSeq":42}}`)
 	req := httptest.NewRequest(http.MethodPost, "/commands/table-window", body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()

--- a/internal/dashboard/types.go
+++ b/internal/dashboard/types.go
@@ -439,7 +439,7 @@ type TableRequest struct {
 }
 
 const (
-	TableChunkSize         = 200
+	TableChunkSize         = 50
 	TableInteractiveRowCap = 10000
 	TableRowHeight         = 34
 	TableMaxRequestCount   = 1000

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -349,12 +349,14 @@
     font-family: var(--font-sans);
     background: var(--bgColor-default);
     color: var(--fgColor-default);
+    overscroll-behavior: none;
   }
 
   body {
     min-width: 320px;
     margin: 0;
     background: var(--bgColor-inset);
+    overscroll-behavior: none;
   }
 
   button,

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -1175,6 +1175,7 @@ class DataTable extends LitElement {
     const columnModels = allTableColumns(tanstack)
     const tanstackRows = new Map((tanstack.getRowModel?.().rows ?? []).map((row: any) => [row.id, row]))
     const totalHeight = this.availableRows * this.rowHeight
+    const hasGroupHeaderRow = headers.some((header: any) => header.column.columnDef.meta?.column?.group)
     const rowRange = this.rowRangeText()
     const selectedText = this.selectedRowId ? '1 row selected' : 'No selection'
     const loading = Boolean(this.table.loadingBlock) || this.visibleLoading
@@ -1186,7 +1187,7 @@ class DataTable extends LitElement {
       `--ld-table-width:${tableWidth}px`,
       `--ld-row-height:${this.rowHeight}px`,
       `--ld-group-head-height:${groupHeaderHeight}px`,
-      `--ld-head-top:${groupHeaderHeight}px`,
+      `--ld-head-top:${hasGroupHeaderRow ? groupHeaderHeight : 0}px`,
     ].join(';')
 
     return html`
@@ -1231,7 +1232,7 @@ class DataTable extends LitElement {
           ${loading ? html`<div class="loading" aria-hidden="true"></div>` : nothing}
           <div class="table-scrollport" ${ref(this.bodyViewportRef)} @scroll=${this.handleScroll}>
             <div class="table-plane">
-              ${this.renderGroupHeaderRows(headers, true)}
+              ${this.renderGroupHeaderRows(headers)}
               ${this.renderHeaderRow(headers)}
               ${this.availableRows === 0 && !loading ? html`<div class="empty">Waiting for table data</div>` : html`
                 <div class="canvas" role="rowgroup" style=${`height:${totalHeight}px`}>

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -58,6 +58,8 @@ const dataTableFeatures = tableFeatures({
   rowSortingFeature,
 })
 
+const groupHeaderHeight = 26
+
 function defaultColumnSize(column: TableColumn): number {
   const widths: Record<string, number> = {
     order_id: 240,
@@ -182,9 +184,12 @@ class DataTable extends LitElement {
       min-height: 0;
       min-width: 0;
       background: var(--report-chart-surface, var(--card-bgColor, var(--bgColor-default)));
+      isolation: isolate;
     }
 
     .toolbar {
+      position: relative;
+      z-index: 40;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -195,7 +200,20 @@ class DataTable extends LitElement {
       padding: 6px 8px 5px 10px;
     }
 
+    .toolbar::after {
+      content: '';
+      position: absolute;
+      inset-inline: 0;
+      bottom: -2px;
+      z-index: 1;
+      height: 3px;
+      background: inherit;
+      pointer-events: none;
+    }
+
     .toolbar > div {
+      position: relative;
+      z-index: 2;
       flex: 1 1 auto;
       min-width: 0;
     }
@@ -214,6 +232,7 @@ class DataTable extends LitElement {
 
     .visual-options {
       position: relative;
+      z-index: 2;
       flex: 0 0 auto;
     }
 
@@ -374,9 +393,10 @@ class DataTable extends LitElement {
       display: flex;
       align-items: center;
       min-width: 0;
-      min-height: 26px;
+      min-height: var(--ld-group-head-height, 26px);
       overflow: hidden;
       border-right: var(--ld-border-default);
+      background: inherit;
       padding: 0 9px;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -557,6 +577,8 @@ class DataTable extends LitElement {
       flex-direction: column;
       min-height: 0;
       min-width: 0;
+      margin-top: -1px;
+      overflow: hidden;
       border-top: 1px solid var(--borderColor-default);
       background: var(--report-chart-surface, var(--card-bgColor, var(--bgColor-default)));
     }
@@ -568,17 +590,20 @@ class DataTable extends LitElement {
       min-height: 0;
       min-width: 0;
       background: var(--report-chart-surface, var(--card-bgColor, var(--bgColor-default)));
+      overscroll-behavior: none;
       scrollbar-gutter: stable;
     }
 
     .table-plane {
       position: relative;
+      isolation: isolate;
       width: var(--ld-table-width, 1080px);
       min-width: var(--ld-table-width, 1080px);
     }
 
     .canvas {
       position: relative;
+      z-index: 0;
       width: var(--ld-table-width, 1080px);
       min-width: var(--ld-table-width, 1080px);
     }
@@ -1150,16 +1175,22 @@ class DataTable extends LitElement {
     const columnModels = allTableColumns(tanstack)
     const tanstackRows = new Map((tanstack.getRowModel?.().rows ?? []).map((row: any) => [row.id, row]))
     const totalHeight = this.availableRows * this.rowHeight
-    const hasGroupHeaderRow = headers.some((header: any) => header.column.columnDef.meta?.column?.group)
     const rowRange = this.rowRangeText()
     const selectedText = this.selectedRowId ? '1 row selected' : 'No selection'
     const loading = Boolean(this.table.loadingBlock) || this.visibleLoading
     const gridTemplate = this.gridTemplateFor(columns)
     const tableWidth = this.tableWidthFor(columns)
     const columnLineOffsets = this.columnLineOffsetsFor(columns)
+    const shellStyle = [
+      `--ld-table-columns:${gridTemplate}`,
+      `--ld-table-width:${tableWidth}px`,
+      `--ld-row-height:${this.rowHeight}px`,
+      `--ld-group-head-height:${groupHeaderHeight}px`,
+      `--ld-head-top:${groupHeaderHeight}px`,
+    ].join(';')
 
     return html`
-      <section class="shell" style=${`--ld-table-columns:${gridTemplate};--ld-table-width:${tableWidth}px;--ld-row-height:${this.rowHeight}px;--ld-head-top:${hasGroupHeaderRow ? '26px' : '0px'}`}>
+      <section class="shell" style=${shellStyle}>
         <div class="toolbar">
           <div>
             <h2>${this.table?.title ?? 'Orders'}</h2>
@@ -1200,7 +1231,7 @@ class DataTable extends LitElement {
           ${loading ? html`<div class="loading" aria-hidden="true"></div>` : nothing}
           <div class="table-scrollport" ${ref(this.bodyViewportRef)} @scroll=${this.handleScroll}>
             <div class="table-plane">
-              ${this.renderGroupHeaderRows(headers)}
+              ${this.renderGroupHeaderRows(headers, true)}
               ${this.renderHeaderRow(headers)}
               ${this.availableRows === 0 && !loading ? html`<div class="empty">Waiting for table data</div>` : html`
                 <div class="canvas" role="rowgroup" style=${`height:${totalHeight}px`}>

--- a/web/components/table/types.ts
+++ b/web/components/table/types.ts
@@ -71,6 +71,6 @@ export type TanStackTableRow = TableRow & {
 }
 
 export const blockIDs: BlockID[] = ['a', 'b', 'c']
-export const defaultChunkSize = 200
+export const defaultChunkSize = 50
 export const defaultRowHeight = 34
 export const defaultSort: TableSort = { key: 'purchase_date', direction: 'desc' }


### PR DESCRIPTION
## Summary
- lowers table block chunk size from 200 rows to 50 rows across backend defaults, frontend fallback defaults, and app command fixtures
- disables overscroll/rubber-band behavior at the app root and table scrollport so dashboard/table edge scrolling feels more like a workspace surface
- fixes table header/title seam leakage caused by fractional zoom/subpixel rounding by clipping the table frame and adding an opaque toolbar lip over the seam
- keeps matrix/pivot grouped headers intact while restoring the plain Orders data table to a single column-header row
- preserves the existing table signal and command API shape: `tables.<id>.blocks`, `tableCommand`, `/commands/table-window`, and block IDs `a/b/c` are unchanged

## Context
The tables page was still showing row text through a tiny seam between the table toolbar/title area and the sticky header row at certain scroll positions and zoom levels. The earlier forced blank group header made the data table behave more like matrix/pivot, but it was visually unnecessary once the real seam was identified as a toolbar-to-header subpixel gap.

This PR keeps the durable parts of the fix:
- the toolbar paints a small opaque lip past its bottom edge
- the table frame clips scrollport overflow
- the table plane is isolated so virtual rows stay below sticky headers
- plain data tables only render their normal column header row

## Implementation Notes
- `dashboard.TableChunkSize` and `defaultChunkSize` are now `50`.
- Server command tests now post `count: 50` where they exercise default table command payloads.
- `html`/`body` and `.table-scrollport` use `overscroll-behavior: none`.
- `.toolbar::after` paints a 3px inherited-background lip with a 2px overlap to cover fractional cracks.
- `.table-frame` uses `margin-top: -1px` and `overflow: hidden` to close and clip the toolbar/header boundary.
- `.table-plane` uses `isolation: isolate`; `.canvas` stays behind sticky layers with `z-index: 0`.
- `renderGroupHeaderRows(headers)` is no longer forced for non-grouped data tables.

## Testing
- `go test ./internal/dashboard ./internal/data ./internal/app ./internal/ui`
- `npm run build:table`
- `git diff --check`
- browser smoke on `http://localhost:8184/dashboards/executive-sales/pages/tables`
  - Orders data table renders a single header row
  - matrix and pivot still render grouped headers
  - row text no longer leaks through the toolbar/header seam while scrolling
  - table command defaults and live page signals use `count/chunkSize = 50`
