### PR TITLE
Add table showcase variants

### DIFF
--- a/dashboards/olist/executive-sales.yaml
+++ b/dashboards/olist/executive-sales.yaml
@@ -1002,23 +1002,199 @@ tables:
     columns:
       - key: order_id
         label: Order
+        width: 240
+        format: text
       - key: purchase_date
         label: Purchased
+        width: 126
+        format: text
       - key: status
         label: Status
+        width: 128
+        format: text
       - key: state
         label: State
+        width: 78
+        format: text
       - key: category
         label: Category
+        width: 210
+        format: text
       - key: revenue
         label: Revenue
         align: right
+        width: 130
+        format: currency
       - key: review_score
         label: Review
         align: right
+        width: 104
+        format: decimal
       - key: delivery_days
         label: Delivery
         align: right
+        width: 108
+        format: days
+  orders_compact:
+    kind: data_table
+    title: Orders compact
+    metrics_view: orders
+    style: { density: compact, zebra: false, grid: rows }
+    default_sort:
+      key: purchase_date
+      direction: desc
+    columns:
+      - key: order_id
+        label: Order
+        width: 200
+        format: text
+      - key: status
+        label: Status
+        width: 116
+        format: text
+      - key: state
+        label: State
+        width: 70
+        format: text
+      - key: revenue
+        label: Revenue
+        align: right
+        width: 116
+        format: currency
+      - key: review_score
+        label: Review
+        align: right
+        width: 92
+        format: decimal
+  orders_spacious:
+    kind: data_table
+    title: Orders spacious
+    metrics_view: orders
+    style: { density: spacious, zebra: true, grid: rows }
+    default_sort:
+      key: purchase_date
+      direction: desc
+    columns:
+      - key: order_id
+        label: Order
+        width: 250
+        format: text
+      - key: purchase_date
+        label: Purchased
+        width: 136
+        format: text
+      - key: category
+        label: Category
+        width: 230
+        format: text
+      - key: revenue
+        label: Revenue
+        align: right
+        width: 140
+        format: currency
+      - key: delivery_days
+        label: Delivery
+        align: right
+        width: 116
+        format: days
+  orders_full_grid:
+    kind: data_table
+    title: Orders full grid
+    metrics_view: orders
+    style: { density: comfortable, zebra: true, grid: full }
+    default_sort:
+      key: revenue
+      direction: desc
+    columns:
+      - key: order_id
+        label: Order
+        width: 220
+        format: text
+      - key: status
+        label: Status
+        width: 122
+        format: text
+      - key: state
+        label: State
+        width: 76
+        format: text
+      - key: category
+        label: Category
+        width: 190
+        format: text
+      - key: revenue
+        label: Revenue
+        align: right
+        width: 128
+        format: currency
+      - key: delivery_days
+        label: Delivery
+        align: right
+        width: 110
+        format: days
+  orders_conditional:
+    kind: data_table
+    title: Orders conditional formatting
+    metrics_view: orders
+    style: { density: comfortable, zebra: true, grid: full }
+    default_sort:
+      key: revenue
+      direction: desc
+    columns:
+      - key: order_id
+        label: Order
+        width: 212
+        format: text
+      - key: status
+        label: Status
+        width: 132
+        format: text
+        formatting:
+          - kind: badge
+            values:
+              delivered: success
+              shipped: accent
+              invoiced: muted
+              processing: accent
+              approved: accent
+              unavailable: warning
+              canceled: danger
+      - key: revenue
+        label: Revenue
+        align: right
+        width: 136
+        format: currency
+        formatting:
+          - kind: data_bar
+            min: 0
+            max: 500
+            color: accent
+      - key: review_score
+        label: Review
+        align: right
+        width: 102
+        format: decimal
+        formatting:
+          - kind: text_color
+            min: 4
+            color: success
+          - kind: text_color
+            max: 2.99
+            color: danger
+          - kind: text_color
+            min: 3
+            max: 3.99
+            color: warning
+      - key: delivery_days
+        label: Delivery
+        align: right
+        width: 112
+        format: days
+        formatting:
+          - kind: background_scale
+            min: 0
+            max: 30
+            high_color: danger
   state_status_matrix:
     kind: matrix_table
     title: State status matrix
@@ -1036,6 +1212,63 @@ tables:
     rows: [category]
     columns: [status]
     measures: [order_count]
+    default_sort:
+      key: category
+      direction: asc
+  state_status_matrix_formatted:
+    kind: matrix_table
+    title: State/category matrix formatted
+    metrics_view: orders
+    style: { density: comfortable, zebra: true, grid: full }
+    rows: [state, category]
+    measures: [order_count, revenue]
+    columns:
+      - key: state
+        label: State
+        width: 76
+        format: text
+      - key: category
+        label: Category
+        width: 190
+        format: text
+      - key: order_count
+        label: Orders
+        group: Measures
+        width: 120
+        format: integer
+      - key: revenue
+        label: Revenue
+        group: Measures
+        width: 132
+        format: currency
+    measure_formatting:
+      order_count:
+        - kind: data_bar
+          min: 0
+          max: 250
+          color: accent
+      revenue:
+        - kind: data_bar
+          min: 0
+          max: 20000
+          color: success
+    default_sort:
+      key: state
+      direction: asc
+  category_status_pivot_heat:
+    kind: pivot_table
+    title: Category status pivot heat
+    metrics_view: orders
+    style: { density: compact, zebra: true, grid: full }
+    rows: [category]
+    columns: [status]
+    measures: [order_count]
+    measure_formatting:
+      order_count:
+        - kind: background_scale
+          min: 0
+          max: 200
+          high_color: accent
     default_sort:
       key: category
       direction: asc
@@ -1670,7 +1903,7 @@ pages:
     description: Detail, matrix, and pivot table variations
     canvas:
       width: 1366
-      height: 1248
+      height: 2560
     grid:
       columns: 12
       row_height: 48
@@ -1688,12 +1921,36 @@ pages:
       - id: orders-table
         kind: table
         table: orders
-        placement: { col: 1, row: 2, col_span: 12, row_span: 8 }
+        placement: { col: 1, row: 2, col_span: 12, row_span: 7 }
+      - id: orders-compact
+        kind: table
+        table: orders_compact
+        placement: { col: 1, row: 9, col_span: 6, row_span: 6 }
+      - id: orders-spacious
+        kind: table
+        table: orders_spacious
+        placement: { col: 7, row: 9, col_span: 6, row_span: 6 }
+      - id: orders-full-grid
+        kind: table
+        table: orders_full_grid
+        placement: { col: 1, row: 15, col_span: 6, row_span: 7 }
+      - id: orders-conditional
+        kind: table
+        table: orders_conditional
+        placement: { col: 7, row: 15, col_span: 6, row_span: 7 }
       - id: state-status-matrix
         kind: table
         table: state_status_matrix
-        placement: { col: 1, row: 10, col_span: 6, row_span: 7 }
+        placement: { col: 1, row: 22, col_span: 6, row_span: 7 }
       - id: category-status-pivot
         kind: table
         table: category_status_pivot
-        placement: { col: 7, row: 10, col_span: 6, row_span: 7 }
+        placement: { col: 7, row: 22, col_span: 6, row_span: 7 }
+      - id: state-status-matrix-formatted
+        kind: table
+        table: state_status_matrix_formatted
+        placement: { col: 1, row: 29, col_span: 6, row_span: 8 }
+      - id: category-status-pivot-heat
+        kind: table
+        table: category_status_pivot_heat
+        placement: { col: 7, row: 29, col_span: 6, row_span: 8 }

--- a/internal/dashboard/types.go
+++ b/internal/dashboard/types.go
@@ -445,6 +445,39 @@ const (
 	TableMaxRequestCount   = 1000
 )
 
+type TableStyle struct {
+	Density string `json:"density" yaml:"density"`
+	Zebra   *bool  `json:"zebra" yaml:"zebra"`
+	Grid    string `json:"grid" yaml:"grid"`
+}
+
+func (s TableStyle) WithDefaults() TableStyle {
+	if s.Density != "compact" && s.Density != "spacious" {
+		s.Density = "comfortable"
+	}
+	if s.Zebra == nil {
+		zebra := true
+		s.Zebra = &zebra
+	}
+	switch s.Grid {
+	case "none", "columns", "full":
+	default:
+		s.Grid = "rows"
+	}
+	return s
+}
+
+func (s TableStyle) RowHeight() int {
+	switch s.WithDefaults().Density {
+	case "compact":
+		return 28
+	case "spacious":
+		return 42
+	default:
+		return TableRowHeight
+	}
+}
+
 func DefaultTableRequest() TableRequest {
 	return TableRequest{
 		Table: "orders",
@@ -505,6 +538,7 @@ type Table struct {
 	Version       int                   `json:"version"`
 	Kind          string                `json:"kind"`
 	Title         string                `json:"title"`
+	Style         TableStyle            `json:"style"`
 	Columns       []TableColumn         `json:"columns"`
 	TotalRows     int                   `json:"totalRows"`
 	AvailableRows int                   `json:"availableRows"`
@@ -528,13 +562,27 @@ type TableBlock struct {
 }
 
 type TableColumn struct {
-	Key         string `json:"key"`
-	Label       string `json:"label"`
-	Align       string `json:"align,omitempty"`
-	Role        string `json:"role,omitempty"`
-	Group       string `json:"group,omitempty"`
-	Measure     string `json:"measure,omitempty"`
-	ColumnValue string `json:"columnValue,omitempty"`
+	Key         string                `json:"key" yaml:"key"`
+	Label       string                `json:"label" yaml:"label"`
+	Align       string                `json:"align,omitempty" yaml:"align,omitempty"`
+	Role        string                `json:"role,omitempty" yaml:"role,omitempty"`
+	Group       string                `json:"group,omitempty" yaml:"group,omitempty"`
+	Measure     string                `json:"measure,omitempty" yaml:"measure,omitempty"`
+	ColumnValue string                `json:"columnValue,omitempty" yaml:"column_value,omitempty"`
+	Width       int                   `json:"width,omitempty" yaml:"width,omitempty"`
+	Format      string                `json:"format,omitempty" yaml:"format,omitempty"`
+	Formatting  []TableFormattingRule `json:"formatting,omitempty" yaml:"formatting,omitempty"`
+}
+
+type TableFormattingRule struct {
+	Kind       string            `json:"kind" yaml:"kind"`
+	Values     map[string]string `json:"values,omitempty" yaml:"values,omitempty"`
+	Min        *float64          `json:"min,omitempty" yaml:"min,omitempty"`
+	Max        *float64          `json:"max,omitempty" yaml:"max,omitempty"`
+	Color      string            `json:"color,omitempty" yaml:"color,omitempty"`
+	Background string            `json:"background,omitempty" yaml:"background,omitempty"`
+	LowColor   string            `json:"lowColor,omitempty" yaml:"low_color,omitempty"`
+	HighColor  string            `json:"highColor,omitempty" yaml:"high_color,omitempty"`
 }
 
 func OrdersTableColumns() []TableColumn {
@@ -560,13 +608,14 @@ func EmptyTable(request TableRequest, err error) Table {
 		Version:       2,
 		Kind:          "data_table",
 		Title:         "Orders",
+		Style:         TableStyle{}.WithDefaults(),
 		Columns:       OrdersTableColumns(),
 		TotalRows:     0,
 		AvailableRows: 0,
 		IsCapped:      false,
 		RowCap:        TableInteractiveRowCap,
 		ChunkSize:     TableChunkSize,
-		RowHeight:     TableRowHeight,
+		RowHeight:     TableStyle{}.RowHeight(),
 		ResetVersion:  request.ResetVersion,
 		Sort:          request.Sort,
 		Blocks:        emptyTableBlocks(),

--- a/internal/data/service.go
+++ b/internal/data/service.go
@@ -562,17 +562,19 @@ func (m *DuckDBMetrics) QueryTablePage(ctx context.Context, dashboardID, pageID 
 		return dashboard.EmptyTable(request, err), nil
 	}
 
+	style := tableModel.Style.WithDefaults()
 	return dashboard.Table{
 		Version:       2,
 		Kind:          tableModel.KindOrDefault(),
 		Title:         tableModel.Title,
+		Style:         style,
 		Columns:       tableModel.Columns,
 		TotalRows:     totalRows,
 		AvailableRows: availableRows,
 		IsCapped:      totalRows > availableRows,
 		RowCap:        dashboard.TableInteractiveRowCap,
 		ChunkSize:     dashboard.TableChunkSize,
-		RowHeight:     dashboard.TableRowHeight,
+		RowHeight:     style.RowHeight(),
 		ResetVersion:  request.ResetVersion,
 		Sort:          request.Sort,
 		Blocks:        blocks,

--- a/internal/data/service_test.go
+++ b/internal/data/service_test.go
@@ -953,6 +953,27 @@ relogios_presentes,watches_gifts
 	if got := table.Blocks["a"].Sort; got.Key != "revenue" || got.Direction != "asc" {
 		t.Fatalf("single block sort = %#v, want revenue asc", got)
 	}
+	if got := table.Columns[5].Format; got != "currency" {
+		t.Fatalf("orders revenue format = %q, want currency", got)
+	}
+
+	conditionalTable, err := metrics.QueryTable(context.Background(), "executive-sales", dashboard.Filters{}, dashboard.TableRequest{
+		Table: "orders_conditional",
+		Block: "all",
+		Count: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := conditionalTable.Style.Grid; got != "full" {
+		t.Fatalf("conditional table grid = %q, want full", got)
+	}
+	if conditionalTable.RowHeight != dashboard.TableRowHeight {
+		t.Fatalf("conditional table row height = %d, want %d", conditionalTable.RowHeight, dashboard.TableRowHeight)
+	}
+	if !tableColumnHasFormatting(conditionalTable.Columns, "status", "badge") {
+		t.Fatalf("conditional table status column missing badge formatting: %#v", conditionalTable.Columns)
+	}
 
 	filteredTable, err := metrics.QueryTable(context.Background(), "executive-sales", dashboard.Filters{
 		VisualSelections: []dashboard.VisualSelection{
@@ -1018,6 +1039,37 @@ relogios_presentes,watches_gifts
 	}
 	if got := pivotTable.Columns[1].Group; got != "Orders" {
 		t.Fatalf("pivot first value column group = %q, want Orders", got)
+	}
+
+	formattedMatrix, err := metrics.QueryTable(context.Background(), "executive-sales", dashboard.Filters{}, dashboard.TableRequest{
+		Table: "state_status_matrix_formatted",
+		Block: "all",
+		Count: 10,
+		Sort:  dashboard.TableSort{Key: "state", Direction: "asc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if formattedMatrix.RowHeight != dashboard.TableRowHeight {
+		t.Fatalf("formatted matrix row height = %d, want %d", formattedMatrix.RowHeight, dashboard.TableRowHeight)
+	}
+	if !tableColumnHasFormatting(formattedMatrix.Columns, "revenue", "data_bar") {
+		t.Fatalf("formatted matrix revenue column missing data bar formatting: %#v", formattedMatrix.Columns)
+	}
+
+	heatPivot, err := metrics.QueryTable(context.Background(), "executive-sales", dashboard.Filters{}, dashboard.TableRequest{
+		Table: "category_status_pivot_heat",
+		Block: "all",
+		Count: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if heatPivot.RowHeight != 28 {
+		t.Fatalf("heat pivot row height = %d, want 28", heatPivot.RowHeight)
+	}
+	if !tableHasAnyFormatting(heatPivot.Columns, "background_scale") {
+		t.Fatalf("heat pivot generated columns missing background scale formatting: %#v", heatPivot.Columns)
 	}
 
 	if err := metrics.RefreshCache(context.Background(), "olist"); err != nil {
@@ -1193,6 +1245,31 @@ func tableRowsHaveKey(rows []map[string]any, key string) bool {
 	for _, row := range rows {
 		if _, ok := row[key]; ok {
 			return true
+		}
+	}
+	return false
+}
+
+func tableColumnHasFormatting(columns []dashboard.TableColumn, key, kind string) bool {
+	for _, column := range columns {
+		if column.Key != key {
+			continue
+		}
+		for _, rule := range column.Formatting {
+			if rule.Kind == kind {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func tableHasAnyFormatting(columns []dashboard.TableColumn, kind string) bool {
+	for _, column := range columns {
+		for _, rule := range column.Formatting {
+			if rule.Kind == kind {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/data/tables.go
+++ b/internal/data/tables.go
@@ -76,17 +76,19 @@ func (m *DuckDBMetrics) queryAggregateTable(ctx context.Context, runtime *modelR
 		rows = rows[:dashboard.TableInteractiveRowCap]
 	}
 	chunkSize := max(dashboard.TableChunkSize, len(rows))
+	style := table.Style.WithDefaults()
 	return dashboard.Table{
 		Version:       2,
 		Kind:          table.KindOrDefault(),
 		Title:         table.Title,
+		Style:         style,
 		Columns:       columns,
 		TotalRows:     totalRows,
 		AvailableRows: len(rows),
 		IsCapped:      isCapped,
 		RowCap:        dashboard.TableInteractiveRowCap,
 		ChunkSize:     chunkSize,
-		RowHeight:     dashboard.TableRowHeight,
+		RowHeight:     style.RowHeight(),
 		ResetVersion:  request.ResetVersion,
 		Sort:          request.Sort,
 		Blocks: map[string]dashboard.TableBlock{
@@ -115,7 +117,8 @@ func (m *DuckDBMetrics) matrixTableRows(ctx context.Context, runtime *modelRunti
 		dimension := metricView.Dimensions[dimensionName]
 		selects = append(selects, fmt.Sprintf("%s AS %s", dimensionExpression(dimension, "e"), dimensionName))
 		groupBy = append(groupBy, dimensionName)
-		columns = append(columns, dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header"})
+		column := dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header", Format: "text"}
+		columns = append(columns, mergeTableColumn(column, tableColumnOverride(table, dimensionName)))
 	}
 	for _, measureName := range table.Measures {
 		measure := metricView.Measures[measureName]
@@ -124,7 +127,8 @@ func (m *DuckDBMetrics) matrixTableRows(ctx context.Context, runtime *modelRunti
 			return nil, nil, err
 		}
 		selects = append(selects, fmt.Sprintf("%s AS %s", expr, measureName))
-		columns = append(columns, dashboard.TableColumn{Key: measureName, Label: measureLabel(measureName, measure), Align: "right", Role: "measure", Measure: measureName})
+		column := dashboard.TableColumn{Key: measureName, Label: measureLabel(measureName, measure), Align: "right", Role: "measure", Measure: measureName, Format: tableMeasureFormat(measure), Formatting: tableMeasureFormatting(table, measureName)}
+		columns = append(columns, mergeTableColumn(column, tableColumnOverride(table, measureName)))
 	}
 	where, args := m.filterWhere("e", runtime, report, table.MetricView, filters, "table", request.Table)
 	orderBy := strings.Join(groupBy, ", ")
@@ -164,7 +168,8 @@ func (m *DuckDBMetrics) crossTabTableRows(ctx context.Context, runtime *modelRun
 		dimension := metricView.Dimensions[dimensionName]
 		rowSelects = append(rowSelects, fmt.Sprintf("%s AS %s", dimensionExpression(dimension, "e"), dimensionName))
 		groupBy = append(groupBy, dimensionName)
-		baseColumns = append(baseColumns, dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header"})
+		column := dashboard.TableColumn{Key: dimensionName, Label: dimensionLabel(dimensionName, dimension), Role: "row_header", Format: "text"}
+		baseColumns = append(baseColumns, mergeTableColumn(column, tableColumnOverride(table, dimensionName)))
 	}
 	columnDimensionName := table.ColumnDims[0]
 	columnDimension := metricView.Dimensions[columnDimensionName]
@@ -240,7 +245,7 @@ LIMIT ?`, strings.Join(rowSelects, ", "), dimensionExpression(columnDimension, "
 				columnKey = uniqueTableColumnKey(candidate, usedKeys)
 				columnKeys[columnIdentity] = columnKey
 				usedKeys[columnKey] = columnKey
-				columns = append(columns, dashboard.TableColumn{
+				column := dashboard.TableColumn{
 					Key:         columnKey,
 					Label:       columnLabel,
 					Align:       "right",
@@ -248,7 +253,10 @@ LIMIT ?`, strings.Join(rowSelects, ", "), dimensionExpression(columnDimension, "
 					Group:       groupLabel,
 					Measure:     measureName,
 					ColumnValue: label,
-				})
+					Format:      tableMeasureFormat(measure),
+					Formatting:  tableMeasureFormatting(table, measureName),
+				}
+				columns = append(columns, mergeTableColumn(column, tableColumnOverride(table, measureName)))
 			}
 			row[columnKey] = raw[measureName]
 		}
@@ -366,6 +374,53 @@ func dimensionLabel(name string, dimension semantic.MetricDimension) string {
 		return dimension.Label
 	}
 	return name
+}
+
+func tableMeasureFormat(measure semantic.MetricMeasure) string {
+	switch measure.Format {
+	case "integer", "decimal", "currency":
+		return measure.Format
+	default:
+		return "decimal"
+	}
+}
+
+func tableMeasureFormatting(table semantic.TableVisual, measure string) []dashboard.TableFormattingRule {
+	if len(table.MeasureFormatting[measure]) == 0 {
+		return nil
+	}
+	return append([]dashboard.TableFormattingRule{}, table.MeasureFormatting[measure]...)
+}
+
+func tableColumnOverride(table semantic.TableVisual, key string) dashboard.TableColumn {
+	for _, column := range table.Columns {
+		if column.Key == key {
+			return column
+		}
+	}
+	return dashboard.TableColumn{}
+}
+
+func mergeTableColumn(column, override dashboard.TableColumn) dashboard.TableColumn {
+	if override.Label != "" {
+		column.Label = override.Label
+	}
+	if override.Align != "" {
+		column.Align = override.Align
+	}
+	if override.Group != "" {
+		column.Group = override.Group
+	}
+	if override.Width > 0 {
+		column.Width = override.Width
+	}
+	if override.Format != "" {
+		column.Format = override.Format
+	}
+	if len(override.Formatting) > 0 {
+		column.Formatting = append([]dashboard.TableFormattingRule{}, override.Formatting...)
+	}
+	return column
 }
 
 func sanitizeTableKey(value string) string {

--- a/internal/semantic/dashboard.go
+++ b/internal/semantic/dashboard.go
@@ -111,24 +111,28 @@ type InteractionTargets struct {
 }
 
 type TableVisual struct {
-	Kind        string                  `yaml:"kind"`
-	Title       string                  `yaml:"title"`
-	MetricView  string                  `yaml:"metrics_view"`
-	DefaultSort dashboard.TableSort     `yaml:"default_sort"`
-	Columns     []dashboard.TableColumn `yaml:"columns"`
-	Rows        []string                `yaml:"rows"`
-	Measures    []string                `yaml:"measures"`
-	ColumnDims  []string                `yaml:"-"`
+	Kind              string                                     `yaml:"kind"`
+	Title             string                                     `yaml:"title"`
+	MetricView        string                                     `yaml:"metrics_view"`
+	DefaultSort       dashboard.TableSort                        `yaml:"default_sort"`
+	Style             dashboard.TableStyle                       `yaml:"style"`
+	Columns           []dashboard.TableColumn                    `yaml:"columns"`
+	Rows              []string                                   `yaml:"rows"`
+	Measures          []string                                   `yaml:"measures"`
+	MeasureFormatting map[string][]dashboard.TableFormattingRule `yaml:"measure_formatting"`
+	ColumnDims        []string                                   `yaml:"-"`
 }
 
 func (t *TableVisual) UnmarshalYAML(value *yaml.Node) error {
 	type rawTableVisual struct {
-		Kind        string              `yaml:"kind"`
-		Title       string              `yaml:"title"`
-		MetricView  string              `yaml:"metrics_view"`
-		DefaultSort dashboard.TableSort `yaml:"default_sort"`
-		Rows        []string            `yaml:"rows"`
-		Measures    []string            `yaml:"measures"`
+		Kind              string                                     `yaml:"kind"`
+		Title             string                                     `yaml:"title"`
+		MetricView        string                                     `yaml:"metrics_view"`
+		DefaultSort       dashboard.TableSort                        `yaml:"default_sort"`
+		Style             dashboard.TableStyle                       `yaml:"style"`
+		Rows              []string                                   `yaml:"rows"`
+		Measures          []string                                   `yaml:"measures"`
+		MeasureFormatting map[string][]dashboard.TableFormattingRule `yaml:"measure_formatting"`
 	}
 	var raw rawTableVisual
 	if err := value.Decode(&raw); err != nil {
@@ -138,8 +142,10 @@ func (t *TableVisual) UnmarshalYAML(value *yaml.Node) error {
 	t.Title = raw.Title
 	t.MetricView = raw.MetricView
 	t.DefaultSort = raw.DefaultSort
+	t.Style = raw.Style
 	t.Rows = raw.Rows
 	t.Measures = raw.Measures
+	t.MeasureFormatting = raw.MeasureFormatting
 
 	columnsNode := mappingValue(value, "columns")
 	if columnsNode == nil {
@@ -506,9 +512,27 @@ func (d *Dashboard) Validate(metricViews map[string]*MetricView) error {
 		if table.Title == "" || table.MetricView == "" {
 			return fmt.Errorf("table %q requires title and metrics_view", name)
 		}
+		if err := validateTableStyle(name, table.Style); err != nil {
+			return err
+		}
+		for _, column := range table.Columns {
+			if err := validateTableColumn(name, column); err != nil {
+				return err
+			}
+		}
 		view, ok := allowedViews[table.MetricView]
 		if !ok {
 			return fmt.Errorf("table %q references unknown metrics view %q", name, table.MetricView)
+		}
+		for measure, rules := range table.MeasureFormatting {
+			if _, ok := view.Measures[measure]; !ok {
+				return fmt.Errorf("table %q measure_formatting references unknown measure %q", name, measure)
+			}
+			for _, rule := range rules {
+				if err := validateTableFormattingRule(name, measure, rule); err != nil {
+					return err
+				}
+			}
 		}
 		switch table.KindOrDefault() {
 		case "data_table":
@@ -619,6 +643,43 @@ func (d *Dashboard) Validate(metricViews map[string]*MetricView) error {
 				return fmt.Errorf("page %q visual %q has unsupported kind %q", page.ID, visual.ID, visual.Kind)
 			}
 		}
+	}
+	return nil
+}
+
+func validateTableStyle(name string, style dashboard.TableStyle) error {
+	switch style.Density {
+	case "", "compact", "comfortable", "spacious":
+	default:
+		return fmt.Errorf("table %q has unsupported density %q", name, style.Density)
+	}
+	switch style.Grid {
+	case "", "none", "rows", "columns", "full":
+	default:
+		return fmt.Errorf("table %q has unsupported grid %q", name, style.Grid)
+	}
+	return nil
+}
+
+func validateTableColumn(tableName string, column dashboard.TableColumn) error {
+	switch column.Format {
+	case "", "text", "integer", "decimal", "currency", "days":
+	default:
+		return fmt.Errorf("table %q column %q has unsupported format %q", tableName, column.Key, column.Format)
+	}
+	for _, rule := range column.Formatting {
+		if err := validateTableFormattingRule(tableName, column.Key, rule); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateTableFormattingRule(tableName, field string, rule dashboard.TableFormattingRule) error {
+	switch rule.Kind {
+	case "badge", "text_color", "background_scale", "data_bar":
+	default:
+		return fmt.Errorf("table %q column %q has unsupported formatting kind %q", tableName, field, rule.Kind)
 	}
 	return nil
 }

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -529,6 +529,19 @@ func TestLoadOlistDashboard(t *testing.T) {
 	if got := report.Tables["category_status_pivot"].ColumnDims[0]; got != "status" {
 		t.Fatalf("category_status_pivot column dimension = %q, want status", got)
 	}
+	if got := report.Tables["orders_compact"].Style.RowHeight(); got != 28 {
+		t.Fatalf("orders_compact row height = %d, want 28", got)
+	}
+	conditional := report.Tables["orders_conditional"]
+	if !hasTableColumnFormatting(conditional.Columns, "status", "badge") {
+		t.Fatalf("orders_conditional status column missing badge formatting: %#v", conditional.Columns)
+	}
+	if !hasTableColumnFormatting(conditional.Columns, "revenue", "data_bar") {
+		t.Fatalf("orders_conditional revenue column missing data bar formatting: %#v", conditional.Columns)
+	}
+	if len(report.Tables["category_status_pivot_heat"].MeasureFormatting["order_count"]) == 0 {
+		t.Fatalf("category_status_pivot_heat missing order_count measure formatting")
+	}
 	if len(report.Pages) != 24 {
 		t.Fatalf("page count = %d, want 24", len(report.Pages))
 	}
@@ -552,8 +565,8 @@ func TestLoadOlistDashboard(t *testing.T) {
 			tableVisualCount++
 		}
 	}
-	if tableVisualCount != 3 {
-		t.Fatalf("tables page table visual count = %d, want 3", tableVisualCount)
+	if tableVisualCount != 9 {
+		t.Fatalf("tables page table visual count = %d, want 9", tableVisualCount)
 	}
 	page := report.Pages[0].WithDefaults()
 	if page.Grid.Columns != 12 || page.Grid.RowHeight != 48 {
@@ -633,13 +646,23 @@ func TestOlistDashboardChartShowcaseContract(t *testing.T) {
 	if !ok {
 		t.Fatal("tables showcase page missing")
 	}
-	gotTables := make([]string, 0, 3)
+	gotTables := make([]string, 0, 9)
 	for _, pageVisual := range tablePage.Visuals {
 		if pageVisual.Kind == "table" {
 			gotTables = append(gotTables, pageVisual.Table)
 		}
 	}
-	wantTables := []string{"category_status_pivot", "orders", "state_status_matrix"}
+	wantTables := []string{
+		"category_status_pivot",
+		"category_status_pivot_heat",
+		"orders",
+		"orders_compact",
+		"orders_conditional",
+		"orders_full_grid",
+		"orders_spacious",
+		"state_status_matrix",
+		"state_status_matrix_formatted",
+	}
 	sort.Strings(gotTables)
 	if !reflect.DeepEqual(gotTables, wantTables) {
 		t.Fatalf("tables showcase tables = %#v, want %#v", gotTables, wantTables)
@@ -1292,6 +1315,20 @@ func chartPageVisualIDs(page dashboard.Page) []string {
 		}
 	}
 	return visualIDs
+}
+
+func hasTableColumnFormatting(columns []dashboard.TableColumn, key, kind string) bool {
+	for _, column := range columns {
+		if column.Key != key {
+			continue
+		}
+		for _, rule := range column.Formatting {
+			if rule.Kind == kind {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func assertModelValidateError(t *testing.T, model *Model, contains string) {

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -1012,9 +1012,11 @@ func tableSignals(report semantic.Dashboard, page dashboard.Page, request dashbo
 		if !ok {
 			continue
 		}
+		style := table.Style.WithDefaults()
 		tables[name] = map[string]any{
 			"kind":          table.KindOrDefault(),
 			"title":         table.Title,
+			"style":         style,
 			"columns":       table.Columns,
 			"version":       2,
 			"totalRows":     0,
@@ -1022,7 +1024,7 @@ func tableSignals(report semantic.Dashboard, page dashboard.Page, request dashbo
 			"isCapped":      false,
 			"rowCap":        dashboard.TableInteractiveRowCap,
 			"chunkSize":     dashboard.TableChunkSize,
-			"rowHeight":     dashboard.TableRowHeight,
+			"rowHeight":     style.RowHeight(),
 			"resetVersion":  request.ResetVersion,
 			"sort": map[string]any{
 				"key":       table.DefaultSort.Key,

--- a/internal/ui/page_test.go
+++ b/internal/ui/page_test.go
@@ -24,7 +24,7 @@ func TestPageInitialSignalsArePageScoped(t *testing.T) {
 			"off_page_chart": {Title: "Off Page", Type: "bar", MetricView: "orders", Query: semantic.VisualQuery{Dimensions: []string{"status"}, Measures: []string{"order_count"}}},
 		},
 		Tables: map[string]semantic.TableVisual{
-			"orders":   {Title: "Orders", MetricView: "orders", Columns: []dashboard.TableColumn{{Key: "order_id", Label: "Order"}}},
+			"orders":   {Title: "Orders", MetricView: "orders", Style: dashboard.TableStyle{Density: "compact", Grid: "full"}, Columns: []dashboard.TableColumn{{Key: "order_id", Label: "Order", Width: 220, Format: "text"}}},
 			"matrix":   {Title: "Matrix", Kind: "matrix_table", MetricView: "orders", Columns: []dashboard.TableColumn{{Key: "status", Label: "Status"}}},
 			"pivot":    {Title: "Pivot", Kind: "pivot_table", MetricView: "orders", Columns: []dashboard.TableColumn{{Key: "status", Label: "Status"}}},
 			"off_page": {Title: "Off Page", MetricView: "orders", Columns: []dashboard.TableColumn{{Key: "order_id", Label: "Order"}}},
@@ -89,6 +89,9 @@ func TestPageInitialSignalsArePageScoped(t *testing.T) {
 	tables := renderPageForTest(t, report, model, report.Pages[1])
 	if !strings.Contains(tables, `"orders":{"availableRows"`) || !strings.Contains(tables, `"matrix":{"availableRows"`) || !strings.Contains(tables, `"pivot":{"availableRows"`) {
 		t.Fatalf("tables page did not seed its three tables:\n%s", tables)
+	}
+	if !strings.Contains(tables, `"style":{"density":"compact"`) || !strings.Contains(tables, `"rowHeight":28`) || !strings.Contains(tables, `"width":220`) {
+		t.Fatalf("tables page did not seed table style and column display metadata:\n%s", tables)
 	}
 	if strings.Contains(tables, `"off_page"`) {
 		t.Fatalf("tables page seeded off-page table:\n%s", tables)

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -320,7 +320,7 @@
     --report-panel: var(--card-bgColor, var(--bgColor-default));
     --report-panel-subtle: var(--bgColor-muted);
     --report-chart-surface: var(--card-bgColor, var(--bgColor-default));
-    --report-table-stripe: var(--bgColor-muted);
+    --report-table-stripe: color-mix(in srgb, var(--bgColor-accent-muted), var(--bgColor-neutral-muted) 40%);
     --report-grid-dot: transparent;
     --ld-login-bg: var(--bgColor-default);
     --ld-login-fg: var(--fgColor-default);

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -320,7 +320,7 @@
     --report-panel: var(--card-bgColor, var(--bgColor-default));
     --report-panel-subtle: var(--bgColor-muted);
     --report-chart-surface: var(--card-bgColor, var(--bgColor-default));
-    --report-table-stripe: color-mix(in srgb, var(--bgColor-accent-muted), var(--bgColor-neutral-muted) 40%);
+    --report-table-stripe: color-mix(in srgb, var(--fgColor-muted), var(--bgColor-default) 88%);
     --report-grid-dot: transparent;
     --ld-login-bg: var(--bgColor-default);
     --ld-login-fg: var(--fgColor-default);

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -42,6 +42,7 @@ import {
   type TableBlock,
   type TableBlockCommand,
   type TableColumn,
+  type TableFormattingRule,
   type TableRow,
   type TableSignal,
   type TanStackTableRow,
@@ -61,6 +62,8 @@ const dataTableFeatures = tableFeatures({
 const groupHeaderHeight = 26
 
 function defaultColumnSize(column: TableColumn): number {
+  const configuredWidth = Number(column.width)
+  if (Number.isFinite(configuredWidth) && configuredWidth > 0) return configuredWidth
   const widths: Record<string, number> = {
     order_id: 240,
     purchase_date: 126,
@@ -74,6 +77,67 @@ function defaultColumnSize(column: TableColumn): number {
   if (widths[column.key]) return widths[column.key]
   if (column.align === 'right') return 120
   return 140
+}
+
+function tableTone(value: string | undefined, fallback = 'accent'): string {
+  const normalized = String(value || fallback).toLowerCase().replace(/[^a-z0-9_-]/g, '')
+  return normalized || fallback
+}
+
+function toneColor(value: string | undefined, fallback = 'accent'): string {
+  switch (tableTone(value, fallback)) {
+    case 'success':
+    case 'green':
+      return 'var(--fgColor-success)'
+    case 'danger':
+    case 'red':
+      return 'var(--fgColor-danger)'
+    case 'warning':
+    case 'yellow':
+      return 'var(--fgColor-attention)'
+    case 'muted':
+    case 'gray':
+      return 'var(--fgColor-muted)'
+    default:
+      return 'var(--fgColor-accent)'
+  }
+}
+
+function numericValue(value: unknown): number | null {
+  const next = Number(value)
+  return Number.isFinite(next) ? next : null
+}
+
+function ruleMatches(value: unknown, rule: TableFormattingRule): boolean {
+  const next = numericValue(value)
+  if (next === null) return false
+  if (typeof rule.min === 'number' && next < rule.min) return false
+  if (typeof rule.max === 'number' && next > rule.max) return false
+  return true
+}
+
+function scalePercent(value: unknown, rule: TableFormattingRule): number {
+  const next = numericValue(value)
+  if (next === null) return 0
+  const min = typeof rule.min === 'number' ? rule.min : 0
+  const max = typeof rule.max === 'number' && rule.max > min ? rule.max : Math.max(min + 1, next)
+  return Math.max(0, Math.min(100, ((next - min) / (max - min)) * 100))
+}
+
+function badgeRule(column: TableColumn): TableFormattingRule | undefined {
+  return column.formatting?.find((rule) => rule.kind === 'badge')
+}
+
+function dataBarRule(column: TableColumn): TableFormattingRule | undefined {
+  return column.formatting?.find((rule) => rule.kind === 'data_bar')
+}
+
+function backgroundRule(value: unknown, column: TableColumn): TableFormattingRule | undefined {
+  return column.formatting?.find((rule) => rule.kind === 'background_scale' && ruleMatches(value, rule))
+}
+
+function textColorRule(value: unknown, column: TableColumn): TableFormattingRule | undefined {
+  return column.formatting?.find((rule) => rule.kind === 'text_color' && ruleMatches(value, rule))
 }
 
 function applyUpdater<T>(updater: unknown, current: T): T {
@@ -628,13 +692,17 @@ class DataTable extends LitElement {
       inset-inline: 0;
       z-index: 1;
       height: var(--ld-row-height, 34px);
-      border-bottom: var(--ld-border-muted);
       background: var(--report-chart-surface, var(--card-bgColor, var(--bgColor-default)));
       color: var(--fgColor-default);
     }
 
-    .row:nth-child(even) {
+    .zebra .row:nth-child(even) {
       background: color-mix(in srgb, var(--report-table-stripe, var(--bgColor-muted)), var(--report-chart-surface, var(--bgColor-default)) 45%);
+    }
+
+    .grid-rows .row,
+    .grid-full .row {
+      border-bottom: var(--ld-border-muted);
     }
 
     .row:hover {
@@ -663,7 +731,6 @@ class DataTable extends LitElement {
       align-items: center;
       min-width: 0;
       border: 0;
-      border-right: var(--ld-border-muted);
       background: transparent;
       color: inherit;
       cursor: default;
@@ -672,6 +739,21 @@ class DataTable extends LitElement {
       font-size: var(--ld-font-size-body-md);
       font-weight: var(--base-text-weight-semibold);
       text-align: left;
+    }
+
+    .density-compact .cell {
+      padding: 0 7px;
+      font-size: var(--ld-font-size-caption);
+    }
+
+    .density-spacious .cell {
+      padding: 0 12px;
+      font-size: var(--ld-font-size-body-lg);
+    }
+
+    .grid-columns .cell,
+    .grid-full .cell {
+      border-right: var(--ld-border-muted);
     }
 
     .cell:last-child {
@@ -686,6 +768,72 @@ class DataTable extends LitElement {
 
     .skeleton-cell {
       cursor: default;
+    }
+
+    .cell.has-background {
+      background: color-mix(in srgb, var(--ld-cell-bg-color), transparent var(--ld-cell-bg-fade, 78%));
+    }
+
+    .cell.has-data-bar {
+      position: relative;
+      isolation: isolate;
+    }
+
+    .cell-data-bar {
+      position: absolute;
+      inset-block: 5px;
+      left: 6px;
+      z-index: -1;
+      width: var(--ld-cell-bar-width, 0%);
+      border-radius: var(--ld-radius-tight);
+      background: color-mix(in srgb, var(--ld-cell-bar-color, var(--fgColor-accent)), transparent 74%);
+    }
+
+    .cell-badge {
+      display: inline-flex;
+      max-width: 100%;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      border: 1px solid currentColor;
+      border-radius: var(--ld-radius-full);
+      padding: 1px 7px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: var(--ld-font-size-caption);
+      font-weight: var(--ld-font-weight-850);
+      line-height: 1.45;
+    }
+
+    .cell-badge.tone-success {
+      background: var(--bgColor-success-muted);
+      color: var(--fgColor-success);
+    }
+
+    .cell-badge.tone-danger {
+      background: var(--bgColor-danger-muted);
+      color: var(--fgColor-danger);
+    }
+
+    .cell-badge.tone-warning {
+      background: var(--bgColor-attention-muted);
+      color: var(--fgColor-attention);
+    }
+
+    .cell-badge.tone-muted {
+      background: var(--bgColor-muted);
+      color: var(--fgColor-muted);
+    }
+
+    .cell-badge.tone-accent,
+    .cell-badge.tone-blue {
+      background: var(--bgColor-accent-muted);
+      color: var(--fgColor-accent);
+    }
+
+    .grid-none .grid-lines,
+    .grid-rows .grid-lines {
+      display: none;
     }
 
     .skeleton-line {
@@ -922,7 +1070,7 @@ class DataTable extends LitElement {
       review_score: 104,
       delivery_days: 108,
     }
-    return columns.map((column) => Math.max(44, this.columnSizing[column.key] ?? widths[column.key] ?? defaultColumnSize(column)))
+    return columns.map((column) => Math.max(44, this.columnSizing[column.key] ?? defaultColumnSize(column) ?? widths[column.key] ?? 140))
   }
 
   private tanstackRowsForSlots(slots: VisibleRowSlot[]): TanStackTableRow[] {
@@ -1131,6 +1279,51 @@ class DataTable extends LitElement {
     `
   }
 
+  private cellStyle(row: TableRow, column: TableColumn, pinnedColumn: any): string {
+    const styles = [this.pinnedCellStyle(pinnedColumn)].filter(Boolean)
+    const value = row[column.key]
+    const background = backgroundRule(value, column)
+    if (background) {
+      const percent = scalePercent(value, background)
+      const color = toneColor(background.highColor || background.background || background.color, 'warning')
+      styles.push(`--ld-cell-bg-color:${color}`)
+      styles.push(`--ld-cell-bg-fade:${Math.max(66, 92 - Math.round(percent * 0.22))}%`)
+    }
+    const text = textColorRule(value, column)
+    if (text?.color) styles.push(`color:${toneColor(text.color)}`)
+    const bar = dataBarRule(column)
+    if (bar) {
+      styles.push(`--ld-cell-bar-width:${scalePercent(value, bar)}%`)
+      styles.push(`--ld-cell-bar-color:${toneColor(bar.color || bar.highColor || 'accent')}`)
+    }
+    return styles.join(';')
+  }
+
+  private cellClass(column: TableColumn, cellKey: string, row: TableRow, pinnedColumn: any): string {
+    const value = row[column.key]
+    return [
+      'cell',
+      column.align === 'right' ? 'right' : '',
+      column.role === 'row_header' ? 'row-header' : '',
+      this.pinnedCellClass(pinnedColumn),
+      cellKey === this.selectedCellKey ? 'active' : '',
+      backgroundRule(value, column) ? 'has-background' : '',
+      dataBarRule(column) ? 'has-data-bar' : '',
+    ].filter(Boolean).join(' ')
+  }
+
+  private renderCellValue(row: TableRow, column: TableColumn, formatted: unknown) {
+    const value = row[column.key]
+    const badge = badgeRule(column)
+    if (badge?.values) {
+      const tone = badge.values[String(value)] ?? badge.values[String(value).toLowerCase()]
+      if (tone) {
+        return html`<span class=${`cell-badge tone-${tableTone(tone)}`}>${formatted}</span>`
+      }
+    }
+    return html`${formatted}`
+  }
+
   private renderRowSegment(cells: any[], row: TableRow, index: number, key: string) {
     const selected = key === this.selectedRowId
     const hovered = key === this.hoveredRowId
@@ -1148,18 +1341,20 @@ class DataTable extends LitElement {
           const column = cell.column.columnDef.meta?.column ?? this.columns.find((item) => item.key === cell.column.id)
           if (!column) return nothing
           const cellKey = `${key}:${cell.column.id}`
+          const formatted = flexRender(cell.column.columnDef.cell, cell.getContext())
           return html`
             <button
-              class=${`cell ${column.align === 'right' ? 'right' : ''} ${column.role === 'row_header' ? 'row-header' : ''} ${this.pinnedCellClass(cell.column)} ${cellKey === this.selectedCellKey ? 'active' : ''}`}
+              class=${this.cellClass(column, cellKey, row, cell.column)}
               role="cell"
               title=${String(row[cell.column.id] ?? '')}
-              style=${this.pinnedCellStyle(cell.column)}
+              style=${this.cellStyle(row, column, cell.column)}
               @click=${(event: Event) => {
                 event.stopPropagation()
                 this.selectCell(row, column, index)
               }}
             >
-              <span class="cell-value">${flexRender(cell.column.columnDef.cell, cell.getContext())}</span>
+              ${dataBarRule(column) ? html`<span class="cell-data-bar" aria-hidden="true"></span>` : nothing}
+              <span class="cell-value">${this.renderCellValue(row, column, formatted)}</span>
             </button>
           `
         })}
@@ -1189,9 +1384,16 @@ class DataTable extends LitElement {
       `--ld-group-head-height:${groupHeaderHeight}px`,
       `--ld-head-top:${hasGroupHeaderRow ? groupHeaderHeight : 0}px`,
     ].join(';')
+    const style = this.table.style
+    const shellClass = [
+      'shell',
+      `density-${style.density}`,
+      `grid-${style.grid}`,
+      style.zebra ? 'zebra' : '',
+    ].filter(Boolean).join(' ')
 
     return html`
-      <section class="shell" style=${shellStyle}>
+      <section class=${shellClass} style=${shellStyle}>
         <div class="toolbar">
           <div>
             <h2>${this.table?.title ?? 'Orders'}</h2>

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -50,6 +50,13 @@ import {
   type VisibleRowSlot,
 } from './table/types'
 
+type ResizeDrag = {
+  columnKey: string
+  startClientX: number
+  startSize: number
+  minSize: number
+}
+
 const dataTableFeatures = tableFeatures({
   columnPinningFeature,
   columnResizingFeature,
@@ -198,6 +205,7 @@ class DataTable extends LitElement {
     columnSizing: { state: true },
     rowSelection: { state: true },
     hoveredRowId: { state: true },
+    resizeGuideX: { state: true },
   }
 
   tableId = 'orders'
@@ -210,6 +218,7 @@ class DataTable extends LitElement {
   private columnSizing: ColumnSizingState = {}
   private rowSelection: RowSelectionState = {}
   private hoveredRowId = ''
+  private resizeGuideX = -1
   private lastResetVersion = -1
   private shouldResetScroll = false
   private requestSeq = 0
@@ -221,6 +230,8 @@ class DataTable extends LitElement {
   private blockCache: Record<BlockID, TableBlock> = emptyBlocks()
   private bodyViewportRef: Ref<HTMLDivElement> = createRef()
   private resizeObserver?: ResizeObserver
+  private resizeGuideFrame = 0
+  private resizeDrag?: ResizeDrag
   private tableController = new TableController<typeof dataTableFeatures, TanStackTableRow>(this)
   private handleOutsidePointerDown = (event: PointerEvent) => {
     const details = this.renderRoot.querySelector<HTMLDetailsElement>('.visual-options')
@@ -230,6 +241,12 @@ class DataTable extends LitElement {
   private handleDocumentKeyDown = (event: KeyboardEvent) => {
     if (event.key !== 'Escape') return
     this.renderRoot.querySelector<HTMLDetailsElement>('.visual-options')?.removeAttribute('open')
+  }
+  private handleResizeGuideMove = (event: MouseEvent | TouchEvent) => {
+    this.scheduleResizeGuideUpdate(event)
+  }
+  private handleResizeGuideEnd = () => {
+    this.clearResizeGuide()
   }
 
   static styles = css`
@@ -687,6 +704,18 @@ class DataTable extends LitElement {
       background: var(--borderColor-muted);
     }
 
+    .resize-guide {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: var(--ld-resize-guide-x, -9999px);
+      z-index: 45;
+      width: 0;
+      border-left: 2px solid var(--fgColor-accent);
+      box-shadow: 0 0 0 1px color-mix(in srgb, var(--fgColor-accent), transparent 74%);
+      pointer-events: none;
+    }
+
     .row {
       position: absolute;
       inset-inline: 0;
@@ -962,6 +991,7 @@ class DataTable extends LitElement {
     document.removeEventListener('keydown', this.handleDocumentKeyDown)
     this.resizeObserver?.disconnect()
     if (this.scrollFrame) cancelAnimationFrame(this.scrollFrame)
+    this.clearResizeGuide()
     this.clearJumpTimer()
     super.disconnectedCallback()
   }
@@ -1059,18 +1089,15 @@ class DataTable extends LitElement {
   }
 
   private columnPixelWidths(columns: TableColumn[]): number[] {
-    const widths: Record<string, number> = {
-      __select: 34,
-      order_id: 240,
-      purchase_date: 126,
-      status: 128,
-      state: 78,
-      category: 210,
-      revenue: 130,
-      review_score: 104,
-      delivery_days: 108,
-    }
-    return columns.map((column) => Math.max(44, this.columnSizing[column.key] ?? defaultColumnSize(column) ?? widths[column.key] ?? 140))
+    return columns.map((column) => this.columnPixelWidth(column))
+  }
+
+  private columnPixelWidth(column: TableColumn): number {
+    return Math.max(this.minColumnSize(column), this.columnSizing[column.key] ?? defaultColumnSize(column) ?? 140)
+  }
+
+  private minColumnSize(column: TableColumn): number {
+    return column.key === 'order_id' || column.key === 'category' ? 160 : 64
   }
 
   private tanstackRowsForSlots(slots: VisibleRowSlot[]): TanStackTableRow[] {
@@ -1110,7 +1137,7 @@ class DataTable extends LitElement {
       header: column.label,
       cell: (info: any) => formatCell(info.getValue(), column),
       size: defaultColumnSize(column),
-      minSize: column.key === 'order_id' || column.key === 'category' ? 160 : 64,
+      minSize: this.minColumnSize(column),
       enableResizing: true,
       meta: { align: column.align, column },
     })) as Array<ColumnDef<TanStackTableRow, unknown>>
@@ -1204,6 +1231,65 @@ class DataTable extends LitElement {
     return `--ld-pin-left:${Math.max(0, Number(offset) || 0)}px`
   }
 
+  private beginColumnResize(event: MouseEvent | TouchEvent, header: any): void {
+    event.preventDefault()
+    event.stopPropagation()
+    const clientX = this.resizeClientX(event)
+    const column = header.column.columnDef.meta?.column as TableColumn | undefined
+    if (clientX === null || !column) return
+    this.resizeDrag = {
+      columnKey: column.key,
+      startClientX: clientX,
+      startSize: this.columnPixelWidth(column),
+      minSize: this.minColumnSize(column),
+    }
+    this.scheduleResizeGuideUpdate(event)
+    document.addEventListener('mousemove', this.handleResizeGuideMove)
+    document.addEventListener('mouseup', this.handleResizeGuideEnd, { once: true })
+    document.addEventListener('touchmove', this.handleResizeGuideMove, { passive: true })
+    document.addEventListener('touchend', this.handleResizeGuideEnd, { once: true })
+    document.addEventListener('touchcancel', this.handleResizeGuideEnd, { once: true })
+  }
+
+  private scheduleResizeGuideUpdate(event: MouseEvent | TouchEvent): void {
+    const clientX = this.resizeClientX(event)
+    if (clientX === null) return
+    if (this.resizeGuideFrame) cancelAnimationFrame(this.resizeGuideFrame)
+    this.resizeGuideFrame = requestAnimationFrame(() => {
+      this.resizeGuideFrame = 0
+      const plane = this.renderRoot.querySelector<HTMLElement>('.table-plane')
+      if (!plane) return
+      const rect = plane.getBoundingClientRect()
+      const scaleX = rect.width > 0 && plane.offsetWidth > 0 ? rect.width / plane.offsetWidth : 1
+      const localX = scaleX > 0 ? (clientX - rect.left) / scaleX : clientX - rect.left
+      this.resizeGuideX = Math.max(0, Math.min(plane.scrollWidth, localX))
+      if (this.resizeDrag) {
+        const delta = scaleX > 0 ? (clientX - this.resizeDrag.startClientX) / scaleX : clientX - this.resizeDrag.startClientX
+        const nextSize = Math.max(this.resizeDrag.minSize, Math.round(this.resizeDrag.startSize + delta))
+        this.columnSizing = { ...this.columnSizing, [this.resizeDrag.columnKey]: nextSize }
+      }
+    })
+  }
+
+  private resizeClientX(event: MouseEvent | TouchEvent): number | null {
+    if ('touches' in event) {
+      return event.touches[0]?.clientX ?? event.changedTouches[0]?.clientX ?? null
+    }
+    return event.clientX
+  }
+
+  private clearResizeGuide(): void {
+    document.removeEventListener('mousemove', this.handleResizeGuideMove)
+    document.removeEventListener('mouseup', this.handleResizeGuideEnd)
+    document.removeEventListener('touchmove', this.handleResizeGuideMove)
+    document.removeEventListener('touchend', this.handleResizeGuideEnd)
+    document.removeEventListener('touchcancel', this.handleResizeGuideEnd)
+    if (this.resizeGuideFrame) cancelAnimationFrame(this.resizeGuideFrame)
+    this.resizeGuideFrame = 0
+    this.resizeDrag = undefined
+    this.resizeGuideX = -1
+  }
+
   private renderGroupHeaderRows(headers: any[], force = false) {
     const groupHeaders = this.groupHeaderSegments(headers, force)
     if (!groupHeaders.length) return nothing
@@ -1242,9 +1328,9 @@ class DataTable extends LitElement {
               </button>
               ${header.column.getCanResize?.() ? html`
                 <span
-                  class=${`column-resizer ${header.column.getIsResizing?.() ? 'resizing' : ''}`}
-                  @mousedown=${header.getResizeHandler?.()}
-                  @touchstart=${header.getResizeHandler?.()}
+                  class=${`column-resizer ${this.resizeDrag?.columnKey === column.key ? 'resizing' : ''}`}
+                  @mousedown=${(event: MouseEvent) => this.beginColumnResize(event, header)}
+                  @touchstart=${(event: TouchEvent) => this.beginColumnResize(event, header)}
                 ></span>
               ` : nothing}
             </div>
@@ -1434,6 +1520,7 @@ class DataTable extends LitElement {
           ${loading ? html`<div class="loading" aria-hidden="true"></div>` : nothing}
           <div class="table-scrollport" ${ref(this.bodyViewportRef)} @scroll=${this.handleScroll}>
             <div class="table-plane">
+              ${this.resizeGuideX >= 0 ? html`<span class="resize-guide" style=${`--ld-resize-guide-x:${this.resizeGuideX}px`}></span>` : nothing}
               ${this.renderGroupHeaderRows(headers)}
               ${this.renderHeaderRow(headers)}
               ${this.availableRows === 0 && !loading ? html`<div class="empty">Waiting for table data</div>` : html`

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -603,15 +603,10 @@ class DataTable extends LitElement {
     }
 
     button.header-button:hover,
-    button.header-button:focus-visible,
-    .sorted button.header-button {
+    button.header-button:focus-visible {
       background: color-mix(in srgb, var(--fgColor-accent), transparent 92%);
       color: var(--fgColor-default);
       outline: 0;
-    }
-
-    .sorted button.header-button {
-      border-bottom-color: var(--fgColor-accent);
     }
 
     .sort {

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -697,7 +697,7 @@ class DataTable extends LitElement {
     }
 
     .zebra .row:nth-child(even) {
-      background: color-mix(in srgb, var(--report-table-stripe, var(--bgColor-muted)), var(--report-chart-surface, var(--bgColor-default)) 45%);
+      background: color-mix(in srgb, var(--report-table-stripe, var(--bgColor-accent-muted)), var(--report-chart-surface, var(--bgColor-default)) 18%);
     }
 
     .grid-rows .row,

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -697,7 +697,7 @@ class DataTable extends LitElement {
     }
 
     .zebra .row:nth-child(even) {
-      background: color-mix(in srgb, var(--report-table-stripe, var(--bgColor-accent-muted)), var(--report-chart-surface, var(--bgColor-default)) 18%);
+      background: color-mix(in srgb, var(--report-table-stripe, var(--bgColor-neutral-muted)), var(--report-chart-surface, var(--bgColor-default)) 18%);
     }
 
     .grid-rows .row,

--- a/web/components/table/block-source.ts
+++ b/web/components/table/block-source.ts
@@ -3,9 +3,11 @@ import {
   defaultChunkSize,
   defaultRowHeight,
   defaultSort,
+  defaultTableStyle,
   type BlockID,
   type TableBlock,
   type TableSignal,
+  type TableStyle,
   type TableSort,
 } from './types'
 
@@ -21,6 +23,7 @@ export const emptyTable: TableSignal = {
   version: 2,
   kind: 'data_table',
   title: 'Orders',
+  style: defaultTableStyle,
   columns: [],
   totalRows: 0,
   availableRows: 0,
@@ -56,6 +59,7 @@ export function normalizeTable(value: Partial<TableSignal>): TableSignal {
     ...value,
     version: 2,
     kind: value.kind === 'matrix_table' || value.kind === 'pivot_table' ? value.kind : 'data_table',
+    style: normalizeStyle(value.style),
     totalRows: positiveNumber(value.totalRows, 0),
     availableRows: positiveNumber(value.availableRows, positiveNumber(value.totalRows, 0)),
     rowCap: positiveNumber(value.rowCap, 10000),
@@ -71,6 +75,16 @@ export function normalizeTable(value: Partial<TableSignal>): TableSignal {
     },
     loadingBlock: value.loadingBlock ?? '',
     error: value.error ?? '',
+  }
+}
+
+export function normalizeStyle(style: Partial<TableStyle> | undefined): TableStyle {
+  const density = style?.density === 'compact' || style?.density === 'spacious' ? style.density : defaultTableStyle.density
+  const grid = style?.grid === 'none' || style?.grid === 'columns' || style?.grid === 'full' ? style.grid : defaultTableStyle.grid
+  return {
+    density,
+    grid,
+    zebra: typeof style?.zebra === 'boolean' ? style.zebra : defaultTableStyle.zebra,
   }
 }
 

--- a/web/components/table/format.ts
+++ b/web/components/table/format.ts
@@ -2,19 +2,30 @@ import type { TableColumn, TableRow } from './types'
 
 export function formatCell(value: unknown, column: TableColumn): string {
   if (value === null || value === undefined || value === '') return '-'
-  if ((column.key === 'revenue' || column.measure === 'revenue') && Number.isFinite(Number(value))) {
+  const format = column.format || inferredFormat(column)
+  if (format === 'currency' && Number.isFinite(Number(value))) {
     return `R$ ${Number(value).toLocaleString(undefined, { maximumFractionDigits: 2 })}`
   }
-  if (column.key === 'review_score' && Number.isFinite(Number(value))) {
+  if (format === 'integer' && Number.isFinite(Number(value))) {
+    return Number(value).toLocaleString(undefined, { maximumFractionDigits: 0 })
+  }
+  if (format === 'decimal' && Number.isFinite(Number(value))) {
     return Number(value).toFixed(2)
   }
-  if (column.key === 'delivery_days' && Number.isFinite(Number(value))) {
+  if (format === 'days' && Number.isFinite(Number(value))) {
     return `${Number(value)}d`
   }
   if (Number.isFinite(Number(value)) && column.align === 'right') {
     return Number(value).toLocaleString(undefined, { maximumFractionDigits: 2 })
   }
   return String(value)
+}
+
+function inferredFormat(column: TableColumn): string {
+  if (column.key === 'revenue' || column.measure === 'revenue') return 'currency'
+  if (column.key === 'review_score') return 'decimal'
+  if (column.key === 'delivery_days') return 'days'
+  return ''
 }
 
 export function defaultDirection(column: TableColumn): 'asc' | 'desc' {

--- a/web/components/table/types.ts
+++ b/web/components/table/types.ts
@@ -15,6 +15,26 @@ export interface TableColumn {
   group?: string
   measure?: string
   columnValue?: string
+  width?: number
+  format?: 'text' | 'integer' | 'decimal' | 'currency' | 'days'
+  formatting?: TableFormattingRule[]
+}
+
+export interface TableFormattingRule {
+  kind: 'badge' | 'text_color' | 'background_scale' | 'data_bar'
+  values?: Record<string, string>
+  min?: number
+  max?: number
+  color?: string
+  background?: string
+  lowColor?: string
+  highColor?: string
+}
+
+export interface TableStyle {
+  density: 'compact' | 'comfortable' | 'spacious'
+  zebra: boolean
+  grid: 'none' | 'rows' | 'columns' | 'full'
 }
 
 export type TableRow = Record<string, unknown>
@@ -31,6 +51,7 @@ export interface TableSignal {
   version: number
   kind: TableKind
   title: string
+  style: TableStyle
   columns: TableColumn[]
   totalRows: number
   availableRows: number
@@ -74,3 +95,4 @@ export const blockIDs: BlockID[] = ['a', 'b', 'c']
 export const defaultChunkSize = 50
 export const defaultRowHeight = 34
 export const defaultSort: TableSort = { key: 'purchase_date', direction: 'desc' }
+export const defaultTableStyle: TableStyle = { density: 'comfortable', zebra: true, grid: 'rows' }


### PR DESCRIPTION
## Summary
- Add a reusable table presentation contract for density, zebra striping, grid modes, column widths, formats, and conditional-formatting rules.
- Expand the Tables page into a review gallery with baseline, compact, spacious, full-grid, conditional-formatting, matrix, and pivot variants.
- Render table formatting in Lit: status badges, revenue data bars, review text colors, delivery heat backgrounds, neutral zebra stripes, and generated matrix/pivot measure formatting.
- Improve table interactions with scale-aware column resize feedback: a full-height accent guide tracks the drag and live column resizing matches pointer movement under report-canvas zoom.
- Simplify sorted headers so sorting is indicated by the arrow only, without accent background or underline.

## Tests
- task test
- task build
- npm run build:table
- go test ./internal/dashboard ./internal/semantic ./internal/ui ./internal/data ./internal/app
- Browser verification on the live Tables page for populated variants, zebra styling, conditional formatting, and resize guide/width tracking