### PR TITLE
Fix login theme toggle timing

### DIFF
--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -159,24 +159,24 @@ func LoginPage() g.Node {
 			h.Script(h.Type("module"), h.Src("https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js")),
 		},
 		Body: []g.Node{
-			h.Main(h.Class("relative grid min-h-svh place-items-center overflow-hidden bg-login p-8 text-login-fg max-sm:p-6"), h.Aria("label", "LibreDash login"),
+			h.Main(h.Class("relative grid h-svh min-h-svh place-items-center overflow-hidden bg-app p-6 text-fg-default"), h.Aria("label", "LibreDash login"),
 				g.El("ld-topology-background",
-					h.Class("absolute inset-0 block bg-login"),
+					h.Class("absolute inset-0 block bg-app"),
 					g.Attr("data-login-background", ""),
 					g.Attr("data-module-src", staticAsset("/static/topology-background.js")),
-					ds.Init("document.dispatchEvent(new CustomEvent('libredash-login-background-init'))", ds.ModifierDelay, ds.Duration(100*time.Millisecond)),
+					ds.Init("document.dispatchEvent(new CustomEvent('libredash-login-background-init'))", ds.ModifierDelay, ds.Duration(900*time.Millisecond)),
 				),
-				h.Div(h.Class("pointer-events-none absolute inset-0 z-login-shade bg-login-shade"), h.Aria("hidden", "true")),
-				h.Button(h.Type("button"), h.Class("absolute right-4 top-4 z-login-panel inline-grid size-8 place-items-center rounded-default border border-login-outline bg-login-panel text-login-fg shadow-resting-sm transition-colors duration-fast hover:bg-login-control-hover focus-visible:border-login-accent-strong focus-visible:bg-login-control-hover focus-visible:outline-0 max-sm:right-3 max-sm:top-3"), g.Attr("data-theme-toggle", ""),
+				h.Div(h.Class("pointer-events-none absolute inset-0 z-10 bg-app/80"), h.Aria("hidden", "true")),
+				h.Button(h.Type("button"), h.Class("absolute right-4 top-4 z-20 inline-grid size-8 appearance-none place-items-center rounded-default border border-outline-variant bg-control text-fg-muted shadow-resting-sm hover:bg-control-hover hover:text-fg-default focus-visible:border-outline-accent focus-visible:bg-control-hover focus-visible:text-fg-default focus-visible:outline-0 max-sm:right-3 max-sm:top-3"), g.Attr("data-theme-toggle", ""),
 					lucide.Monitor(loginThemeIconAttrs("system")...),
 					lucide.Sun(loginThemeIconAttrs("light")...),
 					lucide.Moon(loginThemeIconAttrs("dark")...),
 				),
-				h.Section(h.Class("relative z-login-panel grid w-full max-w-login-panel justify-items-center gap-6 rounded-large border border-login-outline bg-login-panel p-8 text-center shadow-login-panel backdrop-blur-md max-sm:gap-5 max-sm:px-6 max-sm:py-7"),
+				h.Section(h.Class("relative z-20 grid w-full max-w-login-panel justify-items-center gap-5 rounded-default border border-outline-variant bg-panel p-6 text-center shadow-resting-md max-sm:px-5 max-sm:py-6"),
 					h.Div(h.Class("grid justify-items-center"), h.Aria("hidden", "true"),
-						h.H1(h.Class("m-0 text-display font-semibold leading-tight text-login-fg"), g.Text("LibreDash")),
+						h.H1(h.Class("m-0 text-title-md font-semibold leading-snug text-fg-default"), g.Text("LibreDash")),
 					),
-					h.Button(h.Type("button"), h.Class("inline-grid min-h-control-xl w-full grid-cols-login-button items-center gap-3 rounded-large border border-login-accent bg-login-control px-5 text-body-md font-medium text-login-fg shadow-login-button hover:border-login-accent-strong hover:bg-login-control-hover focus-visible:border-login-accent-strong focus-visible:bg-login-control-hover focus-visible:outline-0"),
+					h.Button(h.Type("button"), h.Class("inline-grid min-h-control-xl w-full appearance-none grid-cols-login-button items-center gap-3 rounded-default border border-outline-variant bg-control px-4 text-body-md font-medium text-fg-default shadow-resting-sm hover:border-outline-accent hover:bg-control-hover focus-visible:border-outline-accent focus-visible:bg-control-hover focus-visible:outline-0"),
 						h.Span(h.Class("grid size-5 grid-cols-2 grid-rows-2 gap-px"), h.Aria("hidden", "true"),
 							h.Span(h.Class("block bg-danger")),
 							h.Span(h.Class("block bg-success")),
@@ -186,7 +186,7 @@ func LoginPage() g.Node {
 						h.Span(g.Text("Sign in with Azure Active Directory")),
 					),
 				),
-				inspectorElement(),
+				h.Div(h.Class("absolute"), inspectorElement()),
 			),
 		},
 	})
@@ -638,7 +638,7 @@ func metricDetailRailStateScript() g.Node {
 }
 
 func loginBackgroundLoaderScript() g.Node {
-	return h.Script(g.Raw(`(()=>{const schedule=(task)=>{if("requestIdleCallback"in window){requestIdleCallback(task,{timeout:500});return}requestAnimationFrame(()=>requestAnimationFrame(task))};document.addEventListener("libredash-login-background-init",()=>schedule(()=>{const el=document.querySelector("[data-login-background]");if(!el)return;const state=el.dataset.backgroundState;if(state==="loading"||state==="loaded")return;const src=el.dataset.moduleSrc;if(!src)return;el.dataset.backgroundState="loading";import(src).then(()=>{el.dataset.backgroundState="loaded"}).catch((error)=>{el.dataset.backgroundState="error";console.error("LibreDash login background failed to load",error)})}))})();`))
+	return h.Script(g.Raw(`(()=>{const schedule=(task)=>{const run=()=>{"requestIdleCallback"in window?requestIdleCallback(task,{timeout:1600}):setTimeout(task,600)};document.readyState==="complete"?run():window.addEventListener("load",run,{once:true})};document.addEventListener("libredash-login-background-init",()=>schedule(()=>{const el=document.querySelector("[data-login-background]");if(!el)return;const state=el.dataset.backgroundState;if(state==="loading"||state==="loaded")return;const src=el.dataset.moduleSrc;if(!src)return;el.dataset.backgroundState="loading";import(src).then(()=>{el.dataset.backgroundState="loaded"}).catch((error)=>{el.dataset.backgroundState="error";console.error("LibreDash login background failed to load",error)})}))})();`))
 }
 
 func displayLabel(label, fallback string) string {

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -128,8 +128,6 @@
   --shadow-resting-sm: var(--shadow-resting-small);
   --shadow-resting-md: var(--shadow-resting-medium);
   --shadow-floating: var(--shadow-floating-small);
-  --shadow-login-button: var(--shadow-floating-small);
-  --shadow-login-panel: var(--shadow-floating-large);
 
   --ease-*: initial;
   --ease-ld: var(--base-easing-easeOut);
@@ -169,8 +167,6 @@
 
   --z-index-sidebar: 20;
   --z-index-report-sidebar: 19;
-  --z-index-login-shade: 1;
-  --z-index-login-panel: 2;
   --z-index-inspector: 99999;
 
   --opacity-disabled: 0.62;
@@ -273,15 +269,6 @@
   --color-chart-6: var(--ld-data-6);
   --color-chart-6-muted: var(--ld-data-6-muted);
 
-  --color-login: var(--ld-login-bg);
-  --color-login-fg: var(--ld-login-fg);
-  --color-login-shade: var(--ld-login-shade);
-  --color-login-panel: var(--ld-login-panel);
-  --color-login-outline: var(--ld-login-outline);
-  --color-login-control: var(--ld-login-control);
-  --color-login-control-hover: var(--ld-login-control-hover);
-  --color-login-accent: var(--ld-login-accent);
-  --color-login-accent-strong: var(--ld-login-accent-strong);
 }
 
 @layer base {
@@ -361,9 +348,9 @@
     --ld-bg-panel: var(--card-bgColor, var(--bgColor-default));
     --ld-bg-panel-muted: var(--bgColor-muted);
     --ld-bg-panel-subtle: var(--bgColor-muted);
-    --ld-bg-control: var(--control-bgColor-rest);
-    --ld-bg-control-hover: var(--control-bgColor-hover);
-    --ld-bg-control-active: var(--control-bgColor-active);
+    --ld-bg-control: var(--ld-bg-panel-muted);
+    --ld-bg-control-hover: var(--ld-bg-hover);
+    --ld-bg-control-active: var(--ld-bg-selected);
     --ld-bg-selected: var(--bgColor-accent-muted);
     --ld-bg-overlay: var(--overlay-bgColor, var(--bgColor-default));
     --ld-bg-accent-muted: var(--bgColor-accent-muted);
@@ -478,27 +465,8 @@
     --ld-asset-visual-bg: var(--data-red-color-muted);
     --ld-asset-visual-accent: var(--data-red-color-emphasis);
     --ld-asset-visual-border: var(--borderColor-danger-muted);
-    --ld-login-bg: var(--bgColor-default);
-    --ld-login-fg: var(--fgColor-default);
-    --ld-login-shade: color-mix(in srgb, var(--ld-login-bg), transparent 72%);
-    --ld-login-panel: color-mix(in srgb, var(--bgColor-muted) 92%, var(--fgColor-muted));
-    --ld-login-outline: var(--borderColor-default);
-    --ld-login-control: var(--control-bgColor-rest);
-    --ld-login-control-hover: var(--control-bgColor-hover);
-    --ld-login-accent: color-mix(in srgb, var(--bgColor-accent-emphasis), transparent 34%);
-    --ld-login-accent-strong: color-mix(in srgb, var(--bgColor-accent-emphasis), transparent 18%);
-    --ld-topology-bg: var(--ld-login-bg);
+    --ld-topology-bg: var(--ld-bg-app);
     --ld-modal-backdrop: color-mix(in srgb, var(--bgColor-inverse), transparent 44%);
-  }
-
-  [data-color-mode="dark"] {
-    --ld-login-panel: var(--bgColor-inset);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    [data-color-mode="auto"] {
-      --ld-login-panel: var(--bgColor-inset);
-    }
   }
 
   html {

--- a/static/theme.js
+++ b/static/theme.js
@@ -1,10 +1,9 @@
 const storageKey = 'libredash-color-mode';
 const root = document.documentElement;
-const buttons = [...document.querySelectorAll('[data-theme-value]')];
-const toggles = [...document.querySelectorAll('[data-theme-toggle]')];
 const media = window.matchMedia?.('(prefers-color-scheme: dark)');
 const nextModes = { system: 'light', light: 'dark', dark: 'system' };
 const modeLabels = { system: 'System theme', light: 'Light theme', dark: 'Dark theme' };
+let lastAppliedEvent = 0;
 
 function storedMode() {
   const saved = localStorage.getItem(storageKey);
@@ -20,10 +19,10 @@ function setMode(mode) {
   root.dataset.darkTheme = 'dark';
   root.style.colorScheme = resolved;
   localStorage.setItem(storageKey, next);
-  for (const button of buttons) {
+  for (const button of document.querySelectorAll('[data-theme-value]')) {
     button.setAttribute('aria-pressed', String(button.dataset.themeValue === next));
   }
-  for (const toggle of toggles) {
+  for (const toggle of document.querySelectorAll('[data-theme-toggle]')) {
     const nextMode = nextModes[next] || 'system';
     const label = `${modeLabels[next] || 'System theme'}. Switch to ${modeLabels[nextMode] || 'system theme'}.`;
     toggle.dataset.themeMode = next;
@@ -35,16 +34,24 @@ function setMode(mode) {
       icon.classList.toggle('hidden', !active);
     }
   }
-  document.dispatchEvent(new CustomEvent('libredash-theme-applied', { detail: { mode: next, resolvedMode: resolved } }));
+
+  const eventID = ++lastAppliedEvent;
+  requestAnimationFrame(() => {
+    if (eventID !== lastAppliedEvent) return;
+    document.dispatchEvent(new CustomEvent('libredash-theme-applied', { detail: { mode: next, resolvedMode: resolved } }));
+  });
 }
 
-for (const button of buttons) {
-  button.addEventListener('click', () => setMode(button.dataset.themeValue));
-}
+document.addEventListener('click', (event) => {
+  const button = event.target.closest?.('[data-theme-value]');
+  if (button) {
+    setMode(button.dataset.themeValue);
+    return;
+  }
 
-for (const toggle of toggles) {
-  toggle.addEventListener('click', () => setMode(nextModes[storedMode()] || 'system'));
-}
+  const toggle = event.target.closest?.('[data-theme-toggle]');
+  if (toggle) setMode(nextModes[storedMode()] || 'system');
+});
 
 document.addEventListener('libredash-theme-change', (event) => {
   setMode(event.detail?.mode);


### PR DESCRIPTION
## Summary
- normalize the login card and controls onto shared design tokens
- remove the transient theme-color lag on login controls during theme switches
- keep the lazy topology background from blocking visible theme updates

## Verification
- npm run build
- task test
- restarted task dev and verified immediate light-to-dark login control colors before the lazy background loads