### PR TITLE
Add workspace portal asset views and access modal

### DIFF
--- a/internal/api/workspaces.go
+++ b/internal/api/workspaces.go
@@ -51,3 +51,24 @@ type RoleBindingUpsertRequest struct {
 	DisplayName string `json:"displayName"`
 	Role        string `json:"role"`
 }
+
+type WorkspaceAccessResponse struct {
+	Workspace WorkspaceResponse     `json:"workspace"`
+	Roles     []RoleResponse        `json:"roles"`
+	Bindings  []RoleBindingResponse `json:"bindings"`
+	CanManage bool                  `json:"canManage"`
+	Status    WorkspaceAccessStatus `json:"status"`
+}
+
+type WorkspaceAccessStatus struct {
+	Loading bool   `json:"loading"`
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
+type WorkspaceAccessCommand struct {
+	Email       string `json:"email"`
+	DisplayName string `json:"displayName"`
+	Role        string `json:"role"`
+	PrincipalID string `json:"principalId"`
+}

--- a/internal/api/workspaces.go
+++ b/internal/api/workspaces.go
@@ -68,7 +68,6 @@ type WorkspaceAccessStatus struct {
 
 type WorkspaceAccessCommand struct {
 	Email       string `json:"email"`
-	DisplayName string `json:"displayName"`
 	Role        string `json:"role"`
 	PrincipalID string `json:"principalId"`
 }

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -370,6 +370,140 @@ func TestWorkspaceRoleBindingAPIUpsertsPrincipalRole(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAccessCommandUpsertsAndPatchesSignals(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	owner, err := store.UpsertPrincipal(ctx, platform.PrincipalInput{Email: "owner@example.com", DisplayName: "Owner"})
+	if err != nil {
+		t.Fatalf("upsert owner: %v", err)
+	}
+	if err := store.BindRole(ctx, "test", owner.ID, "owner"); err != nil {
+		t.Fatalf("bind owner: %v", err)
+	}
+	token, err := store.CreateAPIToken(ctx, owner.ID, "test")
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	signals := `{"workspaceAccessCommand":{"email":"analyst@example.com","displayName":"Analyst","role":"viewer"}}`
+	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upsert status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"event: datastar-patch-signals", "workspaceAccess", "analyst@example.com", "Access updated."} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("workspace access upsert did not patch %q:\n%s", want, body)
+		}
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/workspaces/test/role-bindings", nil)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listReq.Header.Set("Accept", "application/json")
+	listRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", listRec.Code, listRec.Body.String())
+	}
+	if !strings.Contains(listRec.Body.String(), `"email":"analyst@example.com"`) {
+		t.Fatalf("role binding missing after command:\n%s", listRec.Body.String())
+	}
+
+	removeSignals := `{"workspaceAccessCommand":{"principalId":"` + platform.PrincipalIDForEmail("analyst@example.com") + `"}}`
+	removeReq := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/remove", bytes.NewBufferString(removeSignals))
+	removeReq.Header.Set("Authorization", "Bearer "+token)
+	removeRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(removeRec, removeReq)
+	if removeRec.Code != http.StatusOK {
+		t.Fatalf("remove status = %d body=%s", removeRec.Code, removeRec.Body.String())
+	}
+	if !strings.Contains(removeRec.Body.String(), "Access removed.") {
+		t.Fatalf("workspace access remove did not patch success:\n%s", removeRec.Body.String())
+	}
+
+	removedListReq := httptest.NewRequest(http.MethodGet, "/api/workspaces/test/role-bindings", nil)
+	removedListReq.Header.Set("Authorization", "Bearer "+token)
+	removedListReq.Header.Set("Accept", "application/json")
+	removedListRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(removedListRec, removedListReq)
+	if strings.Contains(removedListRec.Body.String(), `"email":"analyst@example.com"`) {
+		t.Fatalf("role binding remained after remove command:\n%s", removedListRec.Body.String())
+	}
+}
+
+func TestWorkspaceAccessCommandRejectsViewer(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	viewer, err := store.UpsertPrincipal(ctx, platform.PrincipalInput{Email: "viewer@example.com", DisplayName: "Viewer"})
+	if err != nil {
+		t.Fatalf("upsert viewer: %v", err)
+	}
+	if err := store.BindRole(ctx, "test", viewer.ID, "viewer"); err != nil {
+		t.Fatalf("bind viewer: %v", err)
+	}
+	token, err := store.CreateAPIToken(ctx, viewer.ID, "test")
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	signals := `{"workspaceAccessCommand":{"email":"analyst@example.com","displayName":"Analyst","role":"viewer"}}`
+	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+}
+
+func TestWorkspaceAccessCommandPatchesInvalidInput(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	owner, err := store.UpsertPrincipal(ctx, platform.PrincipalInput{Email: "owner@example.com", DisplayName: "Owner"})
+	if err != nil {
+		t.Fatalf("upsert owner: %v", err)
+	}
+	if err := store.BindRole(ctx, "test", owner.ID, "owner"); err != nil {
+		t.Fatalf("bind owner: %v", err)
+	}
+	token, err := store.CreateAPIToken(ctx, owner.ID, "test")
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	signals := `{"workspaceAccessCommand":{"email":"","displayName":"Analyst","role":"viewer"}}`
+	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("invalid status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "email is required") {
+		t.Fatalf("invalid access command did not patch validation error:\n%s", body)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/workspaces/test/role-bindings", nil)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listReq.Header.Set("Accept", "application/json")
+	listRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(listRec, listReq)
+	if strings.Contains(listRec.Body.String(), "Analyst") {
+		t.Fatalf("invalid command changed bindings:\n%s", listRec.Body.String())
+	}
+}
+
 func testStore(t *testing.T) *platform.Store {
 	t.Helper()
 	store, err := platform.Open(context.Background(), filepath.Join(t.TempDir(), "libredash.db"))

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -387,7 +387,7 @@ func TestWorkspaceAccessCommandUpsertsAndPatchesSignals(t *testing.T) {
 	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
-	signals := `{"workspaceAccessCommand":{"email":"analyst@example.com","role":"viewer"}}`
+	signals := `{"workspaceAccess":{"command":{"email":"analyst@example.com","role":"viewer"}}}`
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
@@ -414,7 +414,7 @@ func TestWorkspaceAccessCommandUpsertsAndPatchesSignals(t *testing.T) {
 		t.Fatalf("role binding missing after command:\n%s", listRec.Body.String())
 	}
 
-	removeSignals := `{"workspaceAccessCommand":{"principalId":"` + platform.PrincipalIDForEmail("analyst@example.com") + `"}}`
+	removeSignals := `{"workspaceAccess":{"command":{"principalId":"` + platform.PrincipalIDForEmail("analyst@example.com") + `"}}}`
 	removeReq := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/remove", bytes.NewBufferString(removeSignals))
 	removeReq.Header.Set("Authorization", "Bearer "+token)
 	removeRec := httptest.NewRecorder()
@@ -453,7 +453,7 @@ func TestWorkspaceAccessCommandRejectsViewer(t *testing.T) {
 	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
-	signals := `{"workspaceAccessCommand":{"email":"analyst@example.com","role":"viewer"}}`
+	signals := `{"workspaceAccess":{"command":{"email":"analyst@example.com","role":"viewer"}}}`
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
@@ -481,7 +481,7 @@ func TestWorkspaceAccessCommandPatchesInvalidInput(t *testing.T) {
 	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
-	signals := `{"workspaceAccessCommand":{"email":"","role":"viewer"}}`
+	signals := `{"workspaceAccess":{"command":{"email":"","role":"viewer"}}}`
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -387,7 +387,7 @@ func TestWorkspaceAccessCommandUpsertsAndPatchesSignals(t *testing.T) {
 	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
-	signals := `{"workspaceAccessCommand":{"email":"analyst@example.com","displayName":"Analyst","role":"viewer"}}`
+	signals := `{"workspaceAccessCommand":{"email":"analyst@example.com","role":"viewer"}}`
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
@@ -453,7 +453,7 @@ func TestWorkspaceAccessCommandRejectsViewer(t *testing.T) {
 	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
-	signals := `{"workspaceAccessCommand":{"email":"analyst@example.com","displayName":"Analyst","role":"viewer"}}`
+	signals := `{"workspaceAccessCommand":{"email":"analyst@example.com","role":"viewer"}}`
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
@@ -481,7 +481,7 @@ func TestWorkspaceAccessCommandPatchesInvalidInput(t *testing.T) {
 	auth := NewAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
-	signals := `{"workspaceAccessCommand":{"email":"","displayName":"Analyst","role":"viewer"}}`
+	signals := `{"workspaceAccessCommand":{"email":"","role":"viewer"}}`
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
@@ -499,7 +499,7 @@ func TestWorkspaceAccessCommandPatchesInvalidInput(t *testing.T) {
 	listReq.Header.Set("Accept", "application/json")
 	listRec := httptest.NewRecorder()
 	server.Routes().ServeHTTP(listRec, listReq)
-	if strings.Contains(listRec.Body.String(), "Analyst") {
+	if strings.Contains(listRec.Body.String(), "analyst@example.com") {
 		t.Fatalf("invalid command changed bindings:\n%s", listRec.Body.String())
 	}
 }

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -22,6 +22,8 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/workspaces/{workspace}", s.protected(platform.PermissionDashboardView, s.workspaceAssets))
 		r.Get("/workspaces/{workspace}/assets/{asset}", s.protected(platform.PermissionDashboardView, s.workspaceAsset))
 		r.Get("/workspaces/{workspace}/assets/{asset}/{section}", s.protected(platform.PermissionDashboardView, s.workspaceAssetSection))
+		r.Post("/workspaces/{workspace}/access/upsert", s.protected(platform.PermissionRBACManage, s.upsertWorkspaceAccess))
+		r.Post("/workspaces/{workspace}/access/remove", s.protected(platform.PermissionRBACManage, s.removeWorkspaceAccess))
 		r.Get("/workspaces/{workspace}/permissions", s.protected(platform.PermissionRBACManage, s.workspacePermissions))
 		r.Post("/workspaces/{workspace}/permissions", s.protected(platform.PermissionRBACManage, s.updateWorkspacePermission))
 		r.Post("/workspaces/{workspace}/permissions/remove", s.protected(platform.PermissionRBACManage, s.removeWorkspacePermission))

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -169,7 +169,7 @@ func (s *Server) upsertWorkspaceAccess(w http.ResponseWriter, r *http.Request) {
 	status := api.WorkspaceAccessStatus{Message: "Access updated."}
 	if s.store == nil {
 		status = api.WorkspaceAccessStatus{Error: "Workspace RBAC store is not configured."}
-	} else if _, err := s.store.SetPrincipalRole(r.Context(), workspaceID, signals.WorkspaceAccessCommand.Email, signals.WorkspaceAccessCommand.DisplayName, signals.WorkspaceAccessCommand.Role); err != nil {
+	} else if _, err := s.store.SetPrincipalRole(r.Context(), workspaceID, signals.WorkspaceAccessCommand.Email, "", signals.WorkspaceAccessCommand.Role); err != nil {
 		status = api.WorkspaceAccessStatus{Error: err.Error()}
 	}
 	s.patchWorkspaceAccess(w, r, workspaceID, status)

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -156,7 +156,18 @@ func (s *Server) removeWorkspacePermission(w http.ResponseWriter, r *http.Reques
 }
 
 type workspaceAccessSignalPayload struct {
+	WorkspaceAccess struct {
+		Command api.WorkspaceAccessCommand `json:"command"`
+	} `json:"workspaceAccess"`
 	WorkspaceAccessCommand api.WorkspaceAccessCommand `json:"workspaceAccessCommand"`
+}
+
+func (signals workspaceAccessSignalPayload) command() api.WorkspaceAccessCommand {
+	command := signals.WorkspaceAccess.Command
+	if command.Email == "" && command.Role == "" && command.PrincipalID == "" {
+		command = signals.WorkspaceAccessCommand
+	}
+	return command
 }
 
 func (s *Server) upsertWorkspaceAccess(w http.ResponseWriter, r *http.Request) {
@@ -166,10 +177,11 @@ func (s *Server) upsertWorkspaceAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaceID := s.workspaceID(chi.URLParam(r, "workspace"))
+	command := signals.command()
 	status := api.WorkspaceAccessStatus{Message: "Access updated."}
 	if s.store == nil {
 		status = api.WorkspaceAccessStatus{Error: "Workspace RBAC store is not configured."}
-	} else if _, err := s.store.SetPrincipalRole(r.Context(), workspaceID, signals.WorkspaceAccessCommand.Email, "", signals.WorkspaceAccessCommand.Role); err != nil {
+	} else if _, err := s.store.SetPrincipalRole(r.Context(), workspaceID, command.Email, "", command.Role); err != nil {
 		status = api.WorkspaceAccessStatus{Error: err.Error()}
 	}
 	s.patchWorkspaceAccess(w, r, workspaceID, status)
@@ -182,10 +194,11 @@ func (s *Server) removeWorkspaceAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaceID := s.workspaceID(chi.URLParam(r, "workspace"))
+	command := signals.command()
 	status := api.WorkspaceAccessStatus{Message: "Access removed."}
 	if s.store == nil {
 		status = api.WorkspaceAccessStatus{Error: "Workspace RBAC store is not configured."}
-	} else if err := s.store.RemovePrincipalRoles(r.Context(), workspaceID, signals.WorkspaceAccessCommand.PrincipalID); err != nil {
+	} else if err := s.store.RemovePrincipalRoles(r.Context(), workspaceID, command.PrincipalID); err != nil {
 		status = api.WorkspaceAccessStatus{Error: err.Error()}
 	}
 	s.patchWorkspaceAccess(w, r, workspaceID, status)
@@ -196,8 +209,7 @@ func (s *Server) patchWorkspaceAccess(w http.ResponseWriter, r *http.Request, wo
 	access := s.workspaceAccessResponse(r, workspace, true, status)
 	sse := datastar.NewSSE(w, r)
 	_ = sse.MarshalAndPatchSignals(map[string]any{
-		"workspaceAccess":        access,
-		"workspaceAccessCommand": api.WorkspaceAccessCommand{},
+		"workspaceAccess": ui.WorkspaceAccessSignals(access, csrfToken(r, s.auth)),
 	})
 }
 

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Yacobolo/libredash/internal/ui"
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/csrf"
+	"github.com/starfederation/datastar-go/datastar"
 )
 
 type workspaceAssetProvider interface {
@@ -41,9 +42,11 @@ func (s *Server) workspaceAssets(w http.ResponseWriter, r *http.Request) {
 	}
 	filtered := filterWorkspaceAssets(assets, r.URL.Query().Get("type"), r.URL.Query().Get("q"))
 	workspace := s.workspaceResponse(r, workspaceID)
+	canManage := s.canManageWorkspaceAccess(r, workspaceID)
+	access := s.workspaceAccessResponse(r, workspace, canManage, api.WorkspaceAccessStatus{})
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if err := ui.WorkspacePage(s.metrics.Catalog(), workspace, filtered, r.URL.Query().Get("type"), r.URL.Query().Get("q"), s.currentRoleLabel(r)).Render(w); err != nil {
+	if err := ui.WorkspacePage(s.metrics.Catalog(), workspace, filtered, r.URL.Query().Get("type"), r.URL.Query().Get("q"), s.currentRoleLabel(r), access, csrfToken(r, s.auth)).Render(w); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -150,6 +153,52 @@ func (s *Server) removeWorkspacePermission(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	http.Redirect(w, r, "/workspaces/"+workspaceID+"/permissions", http.StatusFound)
+}
+
+type workspaceAccessSignalPayload struct {
+	WorkspaceAccessCommand api.WorkspaceAccessCommand `json:"workspaceAccessCommand"`
+}
+
+func (s *Server) upsertWorkspaceAccess(w http.ResponseWriter, r *http.Request) {
+	signals := workspaceAccessSignalPayload{}
+	if err := datastar.ReadSignals(r, &signals); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	workspaceID := s.workspaceID(chi.URLParam(r, "workspace"))
+	status := api.WorkspaceAccessStatus{Message: "Access updated."}
+	if s.store == nil {
+		status = api.WorkspaceAccessStatus{Error: "Workspace RBAC store is not configured."}
+	} else if _, err := s.store.SetPrincipalRole(r.Context(), workspaceID, signals.WorkspaceAccessCommand.Email, signals.WorkspaceAccessCommand.DisplayName, signals.WorkspaceAccessCommand.Role); err != nil {
+		status = api.WorkspaceAccessStatus{Error: err.Error()}
+	}
+	s.patchWorkspaceAccess(w, r, workspaceID, status)
+}
+
+func (s *Server) removeWorkspaceAccess(w http.ResponseWriter, r *http.Request) {
+	signals := workspaceAccessSignalPayload{}
+	if err := datastar.ReadSignals(r, &signals); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	workspaceID := s.workspaceID(chi.URLParam(r, "workspace"))
+	status := api.WorkspaceAccessStatus{Message: "Access removed."}
+	if s.store == nil {
+		status = api.WorkspaceAccessStatus{Error: "Workspace RBAC store is not configured."}
+	} else if err := s.store.RemovePrincipalRoles(r.Context(), workspaceID, signals.WorkspaceAccessCommand.PrincipalID); err != nil {
+		status = api.WorkspaceAccessStatus{Error: err.Error()}
+	}
+	s.patchWorkspaceAccess(w, r, workspaceID, status)
+}
+
+func (s *Server) patchWorkspaceAccess(w http.ResponseWriter, r *http.Request, workspaceID string, status api.WorkspaceAccessStatus) {
+	workspace := s.workspaceResponse(r, workspaceID)
+	access := s.workspaceAccessResponse(r, workspace, true, status)
+	sse := datastar.NewSSE(w, r)
+	_ = sse.MarshalAndPatchSignals(map[string]any{
+		"workspaceAccess":        access,
+		"workspaceAccessCommand": api.WorkspaceAccessCommand{},
+	})
 }
 
 func (s *Server) apiWorkspaces(w http.ResponseWriter, r *http.Request) {
@@ -295,7 +344,7 @@ func (s *Server) workspaceAssetsAndEdges(r *http.Request, workspaceID string) ([
 
 func (s *Server) roleBindingsAndRoles(r *http.Request, workspaceID string) ([]api.RoleBindingResponse, []api.RoleResponse, error) {
 	if s.store == nil {
-		return nil, nil, nil
+		return nil, defaultWorkspaceRoles(), nil
 	}
 	bindingRows, err := s.store.Queries().ListRoleBindingsByWorkspace(r.Context(), workspaceID)
 	if err != nil {
@@ -314,6 +363,48 @@ func (s *Server) roleBindingsAndRoles(r *http.Request, workspaceID string) ([]ap
 		roles = append(roles, roleDTO(row))
 	}
 	return bindings, roles, nil
+}
+
+func (s *Server) workspaceAccessResponse(r *http.Request, workspace api.WorkspaceResponse, canManage bool, status api.WorkspaceAccessStatus) api.WorkspaceAccessResponse {
+	bindings, roles, err := s.roleBindingsAndRoles(r, workspace.ID)
+	if err != nil && status.Error == "" {
+		status.Error = err.Error()
+	}
+	return api.WorkspaceAccessResponse{
+		Workspace: workspace,
+		Roles:     roles,
+		Bindings:  bindings,
+		CanManage: canManage,
+		Status:    status,
+	}
+}
+
+func (s *Server) canManageWorkspaceAccess(r *http.Request, workspaceID string) bool {
+	if s.auth == nil {
+		return true
+	}
+	if s.store == nil {
+		return false
+	}
+	principal, ok := s.auth.Principal(r)
+	if !ok {
+		return false
+	}
+	if principal.DevBypass {
+		return true
+	}
+	allowed, err := s.store.HasPermission(r.Context(), workspaceID, principal.ID, platform.PermissionRBACManage)
+	return err == nil && allowed
+}
+
+func defaultWorkspaceRoles() []api.RoleResponse {
+	return []api.RoleResponse{
+		{Name: "viewer"},
+		{Name: "editor"},
+		{Name: "deployer"},
+		{Name: "admin"},
+		{Name: "owner"},
+	}
 }
 
 func workspaceDTO(row platformdb.Workspace) api.WorkspaceResponse {

--- a/internal/ui/asset_icons.go
+++ b/internal/ui/asset_icons.go
@@ -8,38 +8,83 @@ import (
 
 type assetIconFactory func(children ...g.Node) g.Node
 
-var assetIconByType = map[string]assetIconFactory{
-	"cache_table":     lucide.TableProperties,
-	"catalog":         lucide.BookOpen,
-	"connection":      lucide.Plug,
-	"dashboard":       lucide.LayoutDashboard,
-	"dataset":         lucide.Database,
-	"dimension":       lucide.Ruler,
-	"filter":          lucide.ListFilter,
-	"measure":         lucide.Sigma,
-	"metric_view":     lucide.ChartNoAxesCombined,
-	"page":            lucide.PanelTop,
-	"semantic_model":  lucide.Box,
-	"source":          lucide.Cable,
-	"table":           lucide.Table2,
-	"visual":          lucide.ChartColumn,
-	"visual_element":  lucide.SquareDashedMousePointer,
-	"workspace":       lucide.Boxes,
-	"workspace_group": lucide.GalleryVerticalEnd,
+type assetPresentation struct {
+	Icon        assetIconFactory
+	Background  string
+	Accent      string
+	BorderColor string
+}
+
+var assetPresentationByType = map[string]assetPresentation{
+	"cache_table":     assetPresentationFor(lucide.TableProperties, "cache-table"),
+	"catalog":         assetPresentationFor(lucide.BookOpen, "catalog"),
+	"connection":      assetPresentationFor(lucide.Plug, "connection"),
+	"dashboard":       assetPresentationFor(lucide.LayoutDashboard, "dashboard"),
+	"dataset":         assetPresentationFor(lucide.Database, "dataset"),
+	"dimension":       assetPresentationFor(lucide.Ruler, "dimension"),
+	"filter":          assetPresentationFor(lucide.ListFilter, "filter"),
+	"measure":         assetPresentationFor(lucide.Sigma, "measure"),
+	"metric_view":     assetPresentationFor(lucide.ChartNoAxesCombined, "metric-view"),
+	"page":            assetPresentationFor(lucide.PanelTop, "page"),
+	"semantic_model":  assetPresentationFor(lucide.Box, "semantic-model"),
+	"source":          assetPresentationFor(lucide.Cable, "source"),
+	"table":           assetPresentationFor(lucide.Table2, "table"),
+	"visual":          assetPresentationFor(lucide.ChartColumn, "visual"),
+	"visual_element":  assetPresentationFor(lucide.SquareDashedMousePointer, "visual"),
+	"workspace":       assetPresentationFor(lucide.Boxes, "catalog"),
+	"workspace_group": assetPresentationFor(lucide.GalleryVerticalEnd, "catalog"),
 }
 
 func assetTypeIcon(typ string) g.Node {
-	icon := assetIconByType[typ]
-	if icon == nil {
-		icon = lucide.Component
-	}
+	presentation := assetPresentationForType(typ)
 	return h.Span(
-		h.Class("inline-flex size-8 shrink-0 items-center justify-center rounded-small text-icon-muted"),
+		h.Class("inline-flex size-8 shrink-0 items-center justify-center rounded-small border"),
+		h.Style(assetPresentationStyle(presentation)),
 		g.Attr("aria-hidden", "true"),
-		icon(assetIconAttrs()...),
+		presentation.Icon(assetIconAttrs()...),
 	)
+}
+
+func assetTypeInlineIcon(typ string) g.Node {
+	presentation := assetPresentationForType(typ)
+	return h.Span(
+		h.Class("inline-flex size-5 shrink-0 items-center justify-center rounded-small border"),
+		h.Style(assetPresentationStyle(presentation)),
+		g.Attr("aria-hidden", "true"),
+		presentation.Icon(assetInlineIconAttrs()...),
+	)
+}
+
+func assetPresentationFor(icon assetIconFactory, tokenName string) assetPresentation {
+	return assetPresentation{
+		Icon:        icon,
+		Background:  "--ld-asset-" + tokenName + "-bg",
+		Accent:      "--ld-asset-" + tokenName + "-accent",
+		BorderColor: "--ld-asset-" + tokenName + "-border",
+	}
+}
+
+func assetPresentationForType(typ string) assetPresentation {
+	presentation, ok := assetPresentationByType[typ]
+	if ok {
+		return presentation
+	}
+	return assetPresentation{
+		Icon:        lucide.Component,
+		Background:  "--ld-bg-panel-muted",
+		Accent:      "--ld-fg-muted",
+		BorderColor: "--ld-line-muted",
+	}
+}
+
+func assetPresentationStyle(presentation assetPresentation) string {
+	return "background-color: var(" + presentation.Background + "); border-color: var(" + presentation.BorderColor + "); color: var(" + presentation.Accent + ")"
 }
 
 func assetIconAttrs() []g.Node {
 	return []g.Node{h.Class("size-4 shrink-0"), h.Style("stroke-width: 1.75")}
+}
+
+func assetInlineIconAttrs() []g.Node {
+	return []g.Node{h.Class("size-3.5 shrink-0"), h.Style("stroke-width: 1.75")}
 }

--- a/internal/ui/page.go
+++ b/internal/ui/page.go
@@ -24,6 +24,10 @@ func postAction(path string) string {
 	return "@post('" + path + "', {headers: {'X-CSRF-Token': $csrfToken}})"
 }
 
+func postActionWithCSRFSignal(path, signal string) string {
+	return "@post('" + path + "', {headers: {'X-CSRF-Token': " + signal + "}})"
+}
+
 func staticAsset(path string) string {
 	return path + "?v=dev"
 }

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -61,6 +61,7 @@ func workspacePageSignals(access api.WorkspaceAccessResponse, csrfToken string) 
 		"csrfToken":              csrfToken,
 		"workspaceAccess":        access,
 		"workspaceAccessCommand": api.WorkspaceAccessCommand{},
+		"workspaceAccessSearch":  "",
 	}
 }
 
@@ -72,6 +73,8 @@ func workspaceAccessControl(workspaceID string, canManage bool) g.Node {
 	remove := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccessCommand = evt.detail; " + postAction("/workspaces/"+workspaceID+"/access/remove")
 	return g.El("ld-workspace-access-control",
 		g.Attr("data-attr:access", "$workspaceAccess"),
+		g.Attr("data-attr:search", "$workspaceAccessSearch"),
+		g.Attr("data-on:ld-workspace-access-search__debounce.200ms", "$workspaceAccessSearch = evt.detail.search"),
 		g.Attr("data-on:ld-workspace-access-upsert", upsert),
 		g.Attr("data-on:ld-workspace-access-remove", remove),
 	)

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -58,10 +58,23 @@ func WorkspacePage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, a
 
 func workspacePageSignals(access api.WorkspaceAccessResponse, csrfToken string) map[string]any {
 	return map[string]any{
-		"csrfToken":              csrfToken,
-		"workspaceAccess":        access,
-		"workspaceAccessCommand": api.WorkspaceAccessCommand{},
-		"workspaceAccessSearch":  "",
+		"workspaceAccess": WorkspaceAccessSignals(access, csrfToken),
+	}
+}
+
+type workspaceAccessSignalState struct {
+	api.WorkspaceAccessResponse
+	CSRFToken string                     `json:"csrfToken"`
+	Command   api.WorkspaceAccessCommand `json:"command"`
+	Search    string                     `json:"search"`
+}
+
+func WorkspaceAccessSignals(access api.WorkspaceAccessResponse, csrfToken string) workspaceAccessSignalState {
+	return workspaceAccessSignalState{
+		WorkspaceAccessResponse: access,
+		CSRFToken:               csrfToken,
+		Command:                 api.WorkspaceAccessCommand{},
+		Search:                  "",
 	}
 }
 
@@ -69,12 +82,12 @@ func workspaceAccessControl(workspaceID string, canManage bool) g.Node {
 	if !canManage {
 		return nil
 	}
-	upsert := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccessCommand = evt.detail; " + postAction("/workspaces/"+workspaceID+"/access/upsert")
-	remove := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccessCommand = evt.detail; " + postAction("/workspaces/"+workspaceID+"/access/remove")
+	upsert := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccess.command = evt.detail; " + postActionWithCSRFSignal("/workspaces/"+workspaceID+"/access/upsert", "$workspaceAccess.csrfToken")
+	remove := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccess.command = evt.detail; " + postActionWithCSRFSignal("/workspaces/"+workspaceID+"/access/remove", "$workspaceAccess.csrfToken")
 	return g.El("ld-workspace-access-control",
 		g.Attr("data-attr:access", "$workspaceAccess"),
-		g.Attr("data-attr:search", "$workspaceAccessSearch"),
-		g.Attr("data-on:ld-workspace-access-search__debounce.200ms", "$workspaceAccessSearch = evt.detail.search"),
+		g.Attr("data-attr:search", "$workspaceAccess.search"),
+		g.Attr("data-on:ld-workspace-access-search__debounce.200ms", "$workspaceAccess.search = evt.detail.search"),
 		g.Attr("data-on:ld-workspace-access-upsert", upsert),
 		g.Attr("data-on:ld-workspace-access-remove", remove),
 	)

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -33,14 +33,18 @@ func WorkspacesPage(catalog dashboard.Catalog, workspaces []api.WorkspaceRespons
 	)
 }
 
-func WorkspacePage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, assets []api.AssetResponse, activeType, query, roleLabel string) g.Node {
-	return workspaceDocument(workspace.Title, catalog, "workspaces", roleLabel, nil,
+func WorkspacePage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, assets []api.AssetResponse, activeType, query, roleLabel string, access api.WorkspaceAccessResponse, csrfToken string) g.Node {
+	extraHead := []g.Node{}
+	if access.CanManage {
+		extraHead = append(extraHead, h.Script(h.Type("module"), h.Src(staticAsset("/static/workspace-access-control.js"))))
+	}
+	return workspaceDocument(workspace.Title, catalog, "workspaces", roleLabel, workspacePageSignals(access, csrfToken),
 		h.Section(h.Class(workspaceMainClass), h.Aria("label", "Workspace assets"),
 			workspaceHeader(
 				"Workspace",
 				workspace.Title,
 				workspace.Description,
-				h.A(h.Class(metricActionButtonClass), h.Href("/workspaces/"+workspace.ID+"/permissions"), h.Title("Workspace permissions"), h.Aria("label", "Workspace permissions"), lucide.Shield(metricActionIconAttrs()...)),
+				workspaceAccessControl(workspace.ID, access.CanManage),
 			),
 			assetToolbar(workspace.ID, activeType, query),
 			h.Div(h.Class(workspacePanelClass),
@@ -48,6 +52,28 @@ func WorkspacePage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, a
 				g.If(len(assets) > 0, assetTable(workspace.ID, assets)),
 			),
 		),
+		extraHead...,
+	)
+}
+
+func workspacePageSignals(access api.WorkspaceAccessResponse, csrfToken string) map[string]any {
+	return map[string]any{
+		"csrfToken":              csrfToken,
+		"workspaceAccess":        access,
+		"workspaceAccessCommand": api.WorkspaceAccessCommand{},
+	}
+}
+
+func workspaceAccessControl(workspaceID string, canManage bool) g.Node {
+	if !canManage {
+		return nil
+	}
+	upsert := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccessCommand = evt.detail; " + postAction("/workspaces/"+workspaceID+"/access/upsert")
+	remove := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccessCommand = evt.detail; " + postAction("/workspaces/"+workspaceID+"/access/remove")
+	return g.El("ld-workspace-access-control",
+		g.Attr("data-attr:access", "$workspaceAccess"),
+		g.Attr("data-on:ld-workspace-access-upsert", upsert),
+		g.Attr("data-on:ld-workspace-access-remove", remove),
 	)
 }
 

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -18,8 +18,8 @@ import (
 
 const (
 	workspaceMainClass  = "grid min-w-0 min-h-svh content-start gap-3 bg-app px-4 py-4 max-sm:min-h-0 max-sm:p-3"
-	workspacePanelClass = "grid min-w-0 rounded-default border border-outline-muted bg-panel"
-	assetRowClass       = "grid min-w-0 grid-cols-asset-row items-center gap-3 border-b border-outline-muted px-3 py-2 last:border-b-0 hover:bg-control-hover"
+	workspacePanelClass = "min-w-0 overflow-hidden rounded-default border border-outline-muted bg-panel"
+	assetRowClass       = "border-b border-outline-muted last:border-b-0 hover:bg-control-hover"
 )
 
 func WorkspacesPage(catalog dashboard.Catalog, workspaces []api.WorkspaceResponse, roleLabel string) g.Node {
@@ -44,10 +44,8 @@ func WorkspacePage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, a
 			),
 			assetToolbar(workspace.ID, activeType, query),
 			h.Div(h.Class(workspacePanelClass),
-				g.If(len(assets) == 0, emptyState("No assets match this view.")),
-				g.Map(assets, func(asset api.AssetResponse) g.Node {
-					return assetRow(workspace.ID, asset)
-				}),
+				g.If(len(assets) == 0, h.Div(h.Class("p-3"), emptyState("No assets match this view."))),
+				g.If(len(assets) > 0, assetTable(workspace.ID, assets)),
 			),
 		),
 	)
@@ -110,15 +108,9 @@ func breadcrumbSeparator() g.Node {
 }
 
 func assetBreadcrumbCurrent(asset api.AssetResponse) g.Node {
-	icon := assetIconByType[asset.Type]
-	if icon == nil {
-		icon = lucide.Component
-	}
 	return h.Li(h.Class("min-w-0"),
 		h.H1(h.Class("m-0 inline-flex min-w-0 items-center gap-2 text-title-sm font-semibold leading-snug text-fg-default"),
-			h.Span(h.Class("inline-flex size-5 shrink-0 items-center justify-center text-icon-muted"), h.Aria("hidden", "true"),
-				icon(assetIconAttrs()...),
-			),
+			assetTypeInlineIcon(asset.Type),
 			h.Span(h.Class("min-w-0 truncate"), g.Text(assetTitle(asset))),
 		),
 	)
@@ -284,24 +276,79 @@ func normalizeWorkspaceAssetSection(section string) string {
 	return "details"
 }
 
-func assetRow(workspaceID string, asset api.AssetResponse) g.Node {
+func assetTable(workspaceID string, assets []api.AssetResponse) g.Node {
+	assetIndex := map[string]api.AssetResponse{}
+	for _, asset := range assets {
+		assetIndex[asset.ID] = asset
+	}
+	return h.Div(h.Class("min-w-0 overflow-x-auto"),
+		h.Table(h.Class("w-full border-collapse text-left"),
+			h.THead(h.Class("border-b border-outline-muted bg-panel-muted"),
+				h.Tr(
+					assetHeaderCell("Name", ""),
+					assetHeaderCell("Type", "w-40"),
+					assetHeaderCell("Key", "w-56 max-md:hidden"),
+					assetHeaderCell("Parent", "w-48 max-lg:hidden"),
+					assetHeaderCell("Actions", "w-24 text-right"),
+				),
+			),
+			h.TBody(
+				g.Map(assets, func(asset api.AssetResponse) g.Node {
+					return assetRow(workspaceID, asset, assetIndex)
+				}),
+			),
+		),
+	)
+}
+
+func assetHeaderCell(label, className string) g.Node {
+	classes := strings.TrimSpace("px-3 py-2 text-caption font-medium uppercase text-fg-muted " + className)
+	return h.Th(h.Class(classes), g.Attr("scope", "col"), g.Text(label))
+}
+
+func assetCell(className string, children ...g.Node) g.Node {
+	classes := strings.TrimSpace("px-3 py-2 align-middle " + className)
+	nodes := append([]g.Node{h.Class(classes)}, children...)
+	return h.Td(nodes...)
+}
+
+func assetRow(workspaceID string, asset api.AssetResponse, assetIndex map[string]api.AssetResponse) g.Node {
 	detailHref := workspaceAssetSectionHref(workspaceID, asset.ID, "details")
 	openHref := detailHref
 	if asset.Href != "" {
 		openHref = asset.Href
 	}
-	return h.Article(h.Class(assetRowClass),
-		assetTypeIcon(asset.Type),
-		h.Div(h.Class("min-w-0"),
-			h.P(h.Class("m-0 text-caption font-medium uppercase text-fg-muted"), g.Text(assetTypeLabel(asset.Type))),
-			h.A(h.Class("mt-0.5 block truncate text-body-sm font-semibold text-fg-default no-underline hover:underline"), h.Href(detailHref), g.Text(assetTitle(asset))),
-			g.If(asset.Description != "", h.P(h.Class("m-0 mt-1 truncate text-caption font-normal text-fg-muted"), g.Text(asset.Description))),
+	return h.Tr(h.Class(assetRowClass),
+		assetCell("min-w-0",
+			h.Div(h.Class("flex min-w-0 items-center gap-3"),
+				assetTypeIcon(asset.Type),
+				h.Div(h.Class("min-w-0"),
+					h.A(h.Class("block truncate text-body-sm font-semibold text-fg-default no-underline hover:underline"), h.Href(detailHref), g.Text(assetTitle(asset))),
+					g.If(asset.Description != "", h.P(h.Class("m-0 mt-1 truncate text-caption font-normal text-fg-muted"), g.Text(asset.Description))),
+				),
+			),
 		),
-		h.Code(h.Class("truncate text-caption font-medium text-fg-muted"), g.Text(asset.Key)),
-		h.Div(h.Class("inline-flex justify-end gap-2"),
-			h.A(h.Class(metricActionButtonClass), h.Href(detailHref), h.Title("View details"), h.Aria("label", "View details"), lucide.FileText(metricActionIconAttrs()...)),
-			h.A(h.Class(metricActionButtonClass), h.Href(openHref), h.Title("Open asset"), h.Aria("label", "Open asset"), lucide.ExternalLink(metricActionIconAttrs()...)),
+		assetCell("w-40 text-body-sm font-medium text-fg-muted", h.Span(g.Text(assetTypeLabel(asset.Type)))),
+		assetCell("w-56 max-md:hidden", h.Code(h.Class("block truncate text-caption font-medium text-fg-muted"), g.Text(asset.Key))),
+		assetCell("w-48 max-lg:hidden", assetParentTableLink(workspaceID, asset, assetIndex)),
+		assetCell("w-24",
+			h.Div(h.Class("inline-flex w-full justify-end gap-2"),
+				h.A(h.Class(metricActionButtonClass), h.Href(detailHref), h.Title("View details"), h.Aria("label", "View details"), lucide.FileText(metricActionIconAttrs()...)),
+				h.A(h.Class(metricActionButtonClass), h.Href(openHref), h.Title("Open asset"), h.Aria("label", "Open asset"), lucide.ExternalLink(metricActionIconAttrs()...)),
+			),
 		),
+	)
+}
+
+func assetParentTableLink(workspaceID string, asset api.AssetResponse, assetIndex map[string]api.AssetResponse) g.Node {
+	parent, ok := assetIndex[asset.ParentID]
+	if !ok {
+		return h.Span(h.Class("text-caption font-medium text-fg-muted"), g.Text(emptyDash("")))
+	}
+	return h.A(
+		h.Class("block truncate text-body-sm font-medium text-fg-accent no-underline hover:underline"),
+		h.Href(workspaceAssetSectionHref(workspaceID, parent.ID, "details")),
+		g.Text(assetTitle(parent)),
 	)
 }
 

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -233,10 +233,13 @@ func TestWorkspaceAccessControlRendersForManagers(t *testing.T) {
 	for _, want := range []string{
 		`/static/workspace-access-control.js?v=dev`,
 		`<ld-workspace-access-control data-attr:access="$workspaceAccess"`,
+		`data-attr:search="$workspaceAccessSearch"`,
+		`data-on:ld-workspace-access-search__debounce.200ms=`,
 		`data-on:ld-workspace-access-upsert=`,
 		`data-on:ld-workspace-access-remove=`,
 		`workspaceAccess`,
 		`workspaceAccessCommand`,
+		`workspaceAccessSearch`,
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("workspace access control did not render %q:\n%s", want, rendered)

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -198,7 +198,7 @@ func TestWorkspaceAssetRowsRenderTokenBackedIconColors(t *testing.T) {
 	visibleAssets := []api.AssetResponse{assets[0], assets[5], assets[8]}
 
 	var out strings.Builder
-	err := WorkspacePage(catalog, workspace, visibleAssets, "", "", "Owner").Render(&out)
+	err := WorkspacePage(catalog, workspace, visibleAssets, "", "", "Owner", testWorkspaceAccess(workspace, true), "csrf").Render(&out)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,6 +217,66 @@ func TestWorkspaceAssetRowsRenderTokenBackedIconColors(t *testing.T) {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("workspace asset rows did not render token-backed icon style %q:\n%s", want, rendered)
 		}
+	}
+}
+
+func TestWorkspaceAccessControlRendersForManagers(t *testing.T) {
+	workspace, catalog, assets, _ := testWorkspaceAssetFixtures()
+
+	var out strings.Builder
+	err := WorkspacePage(catalog, workspace, []api.AssetResponse{assets[0]}, "", "", "Owner", testWorkspaceAccess(workspace, true), "csrf").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, want := range []string{
+		`/static/workspace-access-control.js?v=dev`,
+		`<ld-workspace-access-control data-attr:access="$workspaceAccess"`,
+		`data-on:ld-workspace-access-upsert=`,
+		`data-on:ld-workspace-access-remove=`,
+		`workspaceAccess`,
+		`workspaceAccessCommand`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("workspace access control did not render %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestWorkspaceAccessControlDoesNotRenderForViewers(t *testing.T) {
+	workspace, catalog, assets, _ := testWorkspaceAssetFixtures()
+
+	var out strings.Builder
+	err := WorkspacePage(catalog, workspace, []api.AssetResponse{assets[0]}, "", "", "Viewer", testWorkspaceAccess(workspace, false), "").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, notWant := range []string{
+		`/static/workspace-access-control.js?v=dev`,
+		`<ld-workspace-access-control`,
+		`data-on:ld-workspace-access-upsert=`,
+	} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("workspace access control rendered for viewer %q:\n%s", notWant, rendered)
+		}
+	}
+}
+
+func testWorkspaceAccess(workspace api.WorkspaceResponse, canManage bool) api.WorkspaceAccessResponse {
+	return api.WorkspaceAccessResponse{
+		Workspace: workspace,
+		Roles: []api.RoleResponse{
+			{Name: "viewer"},
+			{Name: "editor"},
+			{Name: "admin"},
+		},
+		Bindings: []api.RoleBindingResponse{
+			{PrincipalID: "principal_1", WorkspaceID: workspace.ID, Email: "owner@example.com", DisplayName: "Owner", Role: "owner"},
+		},
+		CanManage: canManage,
 	}
 }
 

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -233,16 +233,25 @@ func TestWorkspaceAccessControlRendersForManagers(t *testing.T) {
 	for _, want := range []string{
 		`/static/workspace-access-control.js?v=dev`,
 		`<ld-workspace-access-control data-attr:access="$workspaceAccess"`,
-		`data-attr:search="$workspaceAccessSearch"`,
+		`data-attr:search="$workspaceAccess.search"`,
 		`data-on:ld-workspace-access-search__debounce.200ms=`,
 		`data-on:ld-workspace-access-upsert=`,
 		`data-on:ld-workspace-access-remove=`,
 		`workspaceAccess`,
-		`workspaceAccessCommand`,
-		`workspaceAccessSearch`,
+		`command`,
+		`search`,
+		`csrfToken`,
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("workspace access control did not render %q:\n%s", want, rendered)
+		}
+	}
+	for _, notWant := range []string{
+		`workspaceAccessCommand`,
+		`workspaceAccessSearch`,
+	} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("workspace access control rendered root-level access signal %q:\n%s", notWant, rendered)
 		}
 	}
 }

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -172,7 +172,9 @@ func TestWorkspaceAssetDetailsRenderSharedShapeForMetricView(t *testing.T) {
 func TestWorkspaceAssetRowsUseDetailLinksForModelAndMetricAssets(t *testing.T) {
 	workspace, _, assets, _ := testWorkspaceAssetFixtures()
 	byType := map[string]api.AssetResponse{}
+	byID := map[string]api.AssetResponse{}
 	for _, asset := range assets {
+		byID[asset.ID] = asset
 		if _, ok := byType[asset.Type]; !ok {
 			byType[asset.Type] = asset
 		}
@@ -180,7 +182,7 @@ func TestWorkspaceAssetRowsUseDetailLinksForModelAndMetricAssets(t *testing.T) {
 
 	for _, typ := range []string{"semantic_model", "metric_view"} {
 		var out strings.Builder
-		if err := assetRow(workspace.ID, byType[typ]).Render(&out); err != nil {
+		if err := assetRow(workspace.ID, byType[typ], byID).Render(&out); err != nil {
 			t.Fatal(err)
 		}
 		rendered := html.UnescapeString(out.String())

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -193,6 +193,33 @@ func TestWorkspaceAssetRowsUseDetailLinksForModelAndMetricAssets(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAssetRowsRenderTokenBackedIconColors(t *testing.T) {
+	workspace, catalog, assets, _ := testWorkspaceAssetFixtures()
+	visibleAssets := []api.AssetResponse{assets[0], assets[5], assets[8]}
+
+	var out strings.Builder
+	err := WorkspacePage(catalog, workspace, visibleAssets, "", "", "Owner").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, want := range []string{
+		`<th class="px-3 py-2 text-caption font-medium uppercase text-fg-muted" scope="col">Name</th>`,
+		`<th class="px-3 py-2 text-caption font-medium uppercase text-fg-muted w-40" scope="col">Type</th>`,
+		`<th class="px-3 py-2 text-caption font-medium uppercase text-fg-muted w-56 max-md:hidden" scope="col">Key</th>`,
+		`<th class="px-3 py-2 text-caption font-medium uppercase text-fg-muted w-48 max-lg:hidden" scope="col">Parent</th>`,
+		"background-color: var(--ld-asset-semantic-model-bg); border-color: var(--ld-asset-semantic-model-border); color: var(--ld-asset-semantic-model-accent)",
+		"background-color: var(--ld-asset-metric-view-bg); border-color: var(--ld-asset-metric-view-border); color: var(--ld-asset-metric-view-accent)",
+		"background-color: var(--ld-asset-dashboard-bg); border-color: var(--ld-asset-dashboard-border); color: var(--ld-asset-dashboard-accent)",
+		`href="/workspaces/libredash/assets/model/details">Olist Commerce</a>`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("workspace asset rows did not render token-backed icon style %q:\n%s", want, rendered)
+		}
+	}
+}
+
 func testWorkspaceAssetFixtures() (api.WorkspaceResponse, dashboard.Catalog, []api.AssetResponse, []api.AssetEdgeResponse) {
 	workspace := api.WorkspaceResponse{ID: "libredash", Title: "LibreDash Workspace", Description: "Local BI workspace."}
 	catalog := dashboard.Catalog{Workspace: dashboard.CatalogWorkspace{ID: workspace.ID, Title: workspace.Title, Description: workspace.Description}}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "npm run build:css && npm run build:url-sync && npm run build:sidebar && npm run build:report-sidebar && npm run build:filters && npm run build:filter-panel && npm run build:filter-card && npm run build:inspector && npm run build:table && npm run build:data-grid && npm run build:canvas && npm run build:footer && npm run build:charts && npm run build:visual-modal && npm run build:login-background && npm run build:asset-lineage",
+    "build": "npm run build:css && npm run build:url-sync && npm run build:sidebar && npm run build:report-sidebar && npm run build:filters && npm run build:filter-panel && npm run build:filter-card && npm run build:inspector && npm run build:table && npm run build:data-grid && npm run build:workspace-access && npm run build:canvas && npm run build:footer && npm run build:charts && npm run build:visual-modal && npm run build:login-background && npm run build:asset-lineage",
     "build:css": "tailwindcss -i ./static/app.input.css -o ./static/app.css",
     "build:url-sync": "esbuild web/components/url-sync.ts --bundle --format=esm --outfile=static/url-sync.js",
     "build:sidebar": "esbuild web/components/sidebar.ts --bundle --format=esm --outfile=static/sidebar.js",
@@ -15,6 +15,7 @@
     "build:inspector": "esbuild web/components/datastar-inspector/index.ts --bundle --format=esm --outfile=static/datastar-inspector.js",
     "build:table": "esbuild web/components/data-table.ts --bundle --format=esm --outfile=static/table.js",
     "build:data-grid": "esbuild web/components/data-grid.ts --bundle --format=esm --outfile=static/data-grid.js",
+    "build:workspace-access": "esbuild web/components/workspace-access-control.ts --bundle --format=esm --outfile=static/workspace-access-control.js",
     "build:canvas": "esbuild web/components/report-canvas.ts --bundle --format=esm --outfile=static/report-canvas.js",
     "build:footer": "esbuild web/components/report-footer.ts --bundle --format=esm --outfile=static/report-footer.js",
     "build:charts": "esbuild web/components/charts.ts --bundle --format=esm --outfile=static/charts.js",

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -193,7 +193,6 @@
   --grid-template-columns-login-button: 1.375rem minmax(0, 1fr);
   --grid-template-columns-metric-workspace: minmax(0, 1fr) 18rem;
   --grid-template-columns-metric-workspace-collapsed: minmax(0, 1fr) 3rem;
-  --grid-template-columns-asset-row: auto minmax(0, 1fr) minmax(8rem, 16rem) auto;
   --grid-template-columns-role-row: minmax(0, 1fr) auto auto;
   --grid-template-columns-workspace-detail: minmax(0, 1.2fr) minmax(18rem, 0.8fr);
   --grid-template-columns-workspace-header: minmax(0, 1fr) auto;

--- a/web/components/workspace-access-control.ts
+++ b/web/components/workspace-access-control.ts
@@ -129,7 +129,7 @@ class WorkspaceAccessControl extends LitElement {
 
     .dialog {
       display: grid;
-      width: min(36rem, calc(100vw - var(--base-size-32)));
+      width: min(38rem, calc(100vw - var(--base-size-32)));
       max-height: calc(100vh - var(--base-size-64));
       grid-template-rows: auto minmax(0, 1fr);
       overflow: hidden;
@@ -200,19 +200,15 @@ class WorkspaceAccessControl extends LitElement {
 
     .body {
       display: grid;
-      gap: var(--base-size-16);
+      gap: var(--base-size-20);
       min-height: 0;
       overflow: auto;
-      padding: var(--base-size-16);
+      padding: var(--base-size-16) var(--base-size-20) var(--base-size-20);
     }
 
     .card {
       display: grid;
-      gap: var(--base-size-12);
-      border: var(--ld-border-muted);
-      border-radius: var(--ld-radius-default);
-      background: var(--ld-bg-panel-muted);
-      padding: var(--base-size-12);
+      gap: var(--base-size-8);
     }
 
     .section-title {
@@ -227,6 +223,11 @@ class WorkspaceAccessControl extends LitElement {
       display: grid;
       grid-template-columns: minmax(0, 1fr) minmax(8rem, auto) auto;
       gap: var(--base-size-8);
+      align-items: end;
+      border: var(--ld-border-muted);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-panel-muted);
+      padding: var(--base-size-8);
     }
 
     label {
@@ -242,7 +243,7 @@ class WorkspaceAccessControl extends LitElement {
 
     .field-shell {
       display: flex;
-      min-height: var(--ld-control-large);
+      min-height: var(--ld-control-medium);
       min-width: 0;
       align-items: center;
       gap: var(--base-size-8);
@@ -343,14 +344,14 @@ class WorkspaceAccessControl extends LitElement {
     }
 
     .toolbar {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(12rem, 18rem);
+      align-items: end;
       gap: var(--base-size-12);
     }
 
     .search {
-      width: min(18rem, 100%);
+      width: 100%;
     }
 
     .list {
@@ -421,13 +422,14 @@ class WorkspaceAccessControl extends LitElement {
     }
 
     .empty {
-      border: 1px dashed var(--ld-line-muted);
+      border: var(--ld-border-muted);
       border-radius: var(--ld-radius-default);
-      background: var(--ld-bg-panel-muted);
+      background: var(--ld-bg-panel);
       color: var(--ld-fg-muted);
       font-size: var(--ld-font-size-body-sm);
       font-weight: var(--ld-font-weight-medium);
-      padding: var(--base-size-16);
+      padding: var(--base-size-24) var(--base-size-16);
+      text-align: center;
     }
 
     @media (max-width: 44rem) {
@@ -442,7 +444,8 @@ class WorkspaceAccessControl extends LitElement {
       }
 
       .form,
-      .row {
+      .row,
+      .toolbar {
         grid-template-columns: minmax(0, 1fr);
       }
 
@@ -471,8 +474,8 @@ class WorkspaceAccessControl extends LitElement {
 
     return html`
       <button class="trigger" type="button" aria-haspopup="dialog" aria-expanded=${String(this.open)} @click=${this.openDialog}>
-        ${shieldIcon()}
-        <span>Access</span>
+        ${usersIcon()}
+        <span>Manage access</span>
       </button>
       ${this.open ? this.renderModal(access) : nothing}
     `
@@ -747,8 +750,8 @@ function roleLabel(role: string): string {
   return role.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
 }
 
-function shieldIcon() {
-  return html`<span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.7 8.9a1 1 0 0 1-.6 0C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.2-2.7a1.2 1.2 0 0 1 1.6 0C14.5 3.8 17 5 19 5a1 1 0 0 1 1 1z"></path></svg></span>`
+function usersIcon() {
+  return html`<span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path><path d="M16 3.128a4 4 0 0 1 0 7.744"></path><path d="M22 21v-2a4 4 0 0 0-3-3.87"></path><circle cx="9" cy="7" r="4"></circle></svg></span>`
 }
 
 function xIcon() {

--- a/web/components/workspace-access-control.ts
+++ b/web/components/workspace-access-control.ts
@@ -33,7 +33,6 @@ type WorkspaceAccess = {
 
 type AccessCommand = {
   email?: string
-  displayName?: string
   role?: string
   principalId?: string
 }
@@ -57,14 +56,15 @@ const focusableSelector = [
 class WorkspaceAccessControl extends LitElement {
   @property({ attribute: false }) access: WorkspaceAccess | null = null
   @property({ attribute: 'access' }) accessAttribute = ''
+  @property({ attribute: 'search' }) searchAttribute = ''
 
   @state() private open = false
   @state() private email = ''
-  @state() private displayName = ''
   @state() private selectedRole = 'viewer'
   @state() private query = ''
 
   private previousFocus: HTMLElement | null = null
+  private searchTimer: number | null = null
 
   static styles = css`
     :host {
@@ -129,7 +129,7 @@ class WorkspaceAccessControl extends LitElement {
 
     .dialog {
       display: grid;
-      width: min(34rem, calc(100vw - var(--base-size-32)));
+      width: min(36rem, calc(100vw - var(--base-size-32)));
       max-height: calc(100vh - var(--base-size-64));
       grid-template-rows: auto minmax(0, 1fr);
       overflow: hidden;
@@ -199,20 +199,20 @@ class WorkspaceAccessControl extends LitElement {
     }
 
     .body {
+      display: grid;
+      gap: var(--base-size-16);
       min-height: 0;
       overflow: auto;
       padding: var(--base-size-16);
     }
 
-    .section {
+    .card {
       display: grid;
       gap: var(--base-size-12);
-    }
-
-    .section + .section {
-      margin-top: var(--base-size-20);
-      border-top: var(--ld-border-muted);
-      padding-top: var(--base-size-16);
+      border: var(--ld-border-muted);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-panel-muted);
+      padding: var(--base-size-12);
     }
 
     .section-title {
@@ -225,7 +225,7 @@ class WorkspaceAccessControl extends LitElement {
 
     .form {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(8rem, auto) auto;
+      grid-template-columns: minmax(0, 1fr) minmax(8rem, auto) auto;
       gap: var(--base-size-8);
     }
 
@@ -240,6 +240,28 @@ class WorkspaceAccessControl extends LitElement {
       text-transform: uppercase;
     }
 
+    .field-shell {
+      display: flex;
+      min-height: var(--ld-control-large);
+      min-width: 0;
+      align-items: center;
+      gap: var(--base-size-8);
+      border: var(--ld-border-default);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-control);
+      color: var(--ld-fg-muted);
+      padding: 0 var(--base-size-10);
+      transition:
+        background-color var(--ld-transition-fast),
+        border-color var(--ld-transition-fast);
+    }
+
+    .field-shell:focus-within,
+    .field-shell:hover {
+      border-color: var(--ld-line-accent);
+      background: var(--ld-bg-control-hover);
+    }
+
     input,
     select {
       min-height: var(--ld-control-medium);
@@ -252,6 +274,15 @@ class WorkspaceAccessControl extends LitElement {
       font-weight: var(--ld-font-weight-medium);
       line-height: var(--ld-line-height-snug);
       padding: 0 var(--base-size-8);
+    }
+
+    .field-shell input {
+      min-height: auto;
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+      padding: 0;
+      outline: 0;
     }
 
     input::placeholder {
@@ -324,7 +355,10 @@ class WorkspaceAccessControl extends LitElement {
 
     .list {
       display: grid;
-      border-top: var(--ld-border-muted);
+      overflow: hidden;
+      border: var(--ld-border-muted);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-panel);
     }
 
     .row {
@@ -333,11 +367,35 @@ class WorkspaceAccessControl extends LitElement {
       align-items: center;
       gap: var(--base-size-12);
       border-bottom: var(--ld-border-muted);
-      padding: var(--base-size-10) 0;
+      padding: var(--base-size-10) var(--base-size-12);
     }
 
     .person {
+      display: grid;
+      grid-template-columns: var(--base-size-32) minmax(0, 1fr);
+      align-items: center;
+      gap: var(--base-size-8);
       min-width: 0;
+    }
+
+    .principal-copy {
+      min-width: 0;
+    }
+
+    .avatar {
+      display: inline-flex;
+      width: var(--base-size-28);
+      height: var(--base-size-28);
+      align-items: center;
+      justify-content: center;
+      border: var(--ld-border-muted);
+      border-radius: 999px;
+      background: var(--ld-bg-control);
+      color: var(--ld-fg-muted);
+      font-size: var(--ld-font-size-caption);
+      font-weight: var(--ld-font-weight-strong);
+      line-height: 1;
+      text-transform: uppercase;
     }
 
     .name {
@@ -400,8 +458,10 @@ class WorkspaceAccessControl extends LitElement {
       const status = this.resolvedAccess.status
       if (status?.message && !status.error && !status.loading) {
         this.email = ''
-        this.displayName = ''
       }
+    }
+    if (changed.has('searchAttribute') && this.searchAttribute !== this.query) {
+      this.query = this.searchAttribute
     }
   }
 
@@ -439,32 +499,24 @@ class WorkspaceAccessControl extends LitElement {
             </button>
           </header>
           <div class="body">
-            <section class="section" aria-label="Add workspace access">
+            <section class="card" aria-label="Add workspace access">
               <h3 class="section-title">Assign role</h3>
               ${status.error ? html`<div class="status status-error" role="alert">${status.error}</div>` : nothing}
               ${status.message && !status.error ? html`<div class="status status-message" role="status">${status.message}</div>` : nothing}
               <form class="form" @submit=${this.handleSubmit}>
                 <label>
-                  Email
-                  <input
-                    type="email"
-                    autocomplete="email"
-                    placeholder="person@example.com"
-                    .value=${this.email}
-                    ?disabled=${status.loading}
-                    @input=${(event: Event) => { this.email = (event.currentTarget as HTMLInputElement).value }}
-                  >
-                </label>
-                <label>
-                  Display name
-                  <input
-                    type="text"
-                    autocomplete="name"
-                    placeholder="Optional"
-                    .value=${this.displayName}
-                    ?disabled=${status.loading}
-                    @input=${(event: Event) => { this.displayName = (event.currentTarget as HTMLInputElement).value }}
-                  >
+                  Principal
+                  <span class="field-shell">
+                    ${mailIcon()}
+                    <input
+                      type="email"
+                      autocomplete="email"
+                      placeholder="person@example.com"
+                      .value=${this.email}
+                      ?disabled=${status.loading}
+                      @input=${(event: Event) => { this.email = (event.currentTarget as HTMLInputElement).value }}
+                    >
+                  </span>
                 </label>
                 <label>
                   Role
@@ -481,16 +533,18 @@ class WorkspaceAccessControl extends LitElement {
                 </button>
               </form>
             </section>
-            <section class="section" aria-label="Current workspace access">
+            <section class="card" aria-label="Current workspace access">
               <div class="toolbar">
-                <h3 class="section-title">Current access</h3>
-                <input
-                  class="search"
-                  type="search"
-                  placeholder="Search access..."
-                  .value=${this.query}
-                  @input=${(event: Event) => { this.query = (event.currentTarget as HTMLInputElement).value }}
-                >
+                <h3 class="section-title">People with access</h3>
+                <span class="field-shell search">
+                  ${searchIcon()}
+                  <input
+                    type="search"
+                    placeholder="Search principals..."
+                    .value=${this.query}
+                    @input=${this.handleSearchInput}
+                  >
+                </span>
               </div>
               ${this.renderBindings(access)}
             </section>
@@ -510,8 +564,11 @@ class WorkspaceAccessControl extends LitElement {
         ${rows.map((binding) => html`
           <div class="row">
             <div class="person">
-              <p class="name">${displayLabel(binding)}</p>
-              <p class="email">${binding.email}</p>
+              <span class="avatar" aria-hidden="true">${principalInitial(binding)}</span>
+              <span class="principal-copy">
+                <p class="name">${displayLabel(binding)}</p>
+                <p class="email">${binding.email}</p>
+              </span>
             </div>
             <select
               aria-label=${`Role for ${displayLabel(binding)}`}
@@ -562,8 +619,20 @@ class WorkspaceAccessControl extends LitElement {
     const query = this.query.trim().toLowerCase()
     if (!query) return bindings
     return bindings.filter((binding) => {
-      return `${binding.displayName ?? ''} ${binding.email} ${binding.role}`.toLowerCase().includes(query)
+      return `${binding.email} ${binding.role}`.toLowerCase().includes(query)
     })
+  }
+
+  private readonly handleSearchInput = (event: Event): void => {
+    this.query = (event.currentTarget as HTMLInputElement).value
+    if (this.searchTimer !== null) window.clearTimeout(this.searchTimer)
+    this.searchTimer = window.setTimeout(() => {
+      this.dispatchEvent(new CustomEvent('ld-workspace-access-search', {
+        bubbles: true,
+        composed: true,
+        detail: { search: this.query },
+      }))
+    }, 200)
   }
 
   private readonly openDialog = (): void => {
@@ -577,6 +646,10 @@ class WorkspaceAccessControl extends LitElement {
 
   private readonly closeDialog = (): void => {
     this.open = false
+    if (this.searchTimer !== null) {
+      window.clearTimeout(this.searchTimer)
+      this.searchTimer = null
+    }
     window.setTimeout(() => {
       if (this.previousFocus?.isConnected) this.previousFocus.focus()
       this.previousFocus = null
@@ -617,7 +690,6 @@ class WorkspaceAccessControl extends LitElement {
     event.preventDefault()
     const command: AccessCommand = {
       email: this.email.trim(),
-      displayName: this.displayName.trim(),
       role: this.selectedRole,
     }
     if (!command.email || !command.role) return
@@ -635,7 +707,6 @@ class WorkspaceAccessControl extends LitElement {
       composed: true,
       detail: {
         email: binding.email,
-        displayName: binding.displayName,
         role,
       },
     }))
@@ -664,7 +735,12 @@ function normalizeAccess(access: WorkspaceAccess): WorkspaceAccess {
 }
 
 function displayLabel(binding: Binding): string {
-  return binding.displayName?.trim() || binding.email || 'Principal'
+  return binding.email || 'Principal'
+}
+
+function principalInitial(binding: Binding): string {
+  const label = displayLabel(binding).trim()
+  return label ? label[0] : '?'
 }
 
 function roleLabel(role: string): string {
@@ -681,6 +757,14 @@ function xIcon() {
 
 function trashIcon() {
   return html`<span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 11v6"></path><path d="M14 11v6"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path><path d="M3 6h18"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg></span>`
+}
+
+function searchIcon() {
+  return html`<span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 21-4.34-4.34"></path><circle cx="11" cy="11" r="8"></circle></svg></span>`
+}
+
+function mailIcon() {
+  return html`<span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"></path><rect x="2" y="4" width="20" height="16" rx="2"></rect></svg></span>`
 }
 
 customElements.define('ld-workspace-access-control', WorkspaceAccessControl)

--- a/web/components/workspace-access-control.ts
+++ b/web/components/workspace-access-control.ts
@@ -1,0 +1,692 @@
+import { LitElement, css, html, nothing } from 'lit'
+import { property, state } from 'lit/decorators.js'
+
+type Workspace = {
+  id?: string
+  title?: string
+}
+
+type Role = {
+  name: string
+}
+
+type Binding = {
+  principalId: string
+  email: string
+  displayName?: string
+  role: string
+}
+
+type AccessStatus = {
+  loading?: boolean
+  error?: string
+  message?: string
+}
+
+type WorkspaceAccess = {
+  workspace?: Workspace
+  roles?: Role[]
+  bindings?: Binding[]
+  canManage?: boolean
+  status?: AccessStatus
+}
+
+type AccessCommand = {
+  email?: string
+  displayName?: string
+  role?: string
+  principalId?: string
+}
+
+const emptyAccess: WorkspaceAccess = {
+  roles: [],
+  bindings: [],
+  canManage: false,
+  status: {},
+}
+
+const focusableSelector = [
+  'a[href]:not([tabindex="-1"])',
+  'button:not([disabled]):not([tabindex="-1"])',
+  'input:not([disabled]):not([tabindex="-1"])',
+  'select:not([disabled]):not([tabindex="-1"])',
+  'textarea:not([disabled]):not([tabindex="-1"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+class WorkspaceAccessControl extends LitElement {
+  @property({ attribute: false }) access: WorkspaceAccess | null = null
+  @property({ attribute: 'access' }) accessAttribute = ''
+
+  @state() private open = false
+  @state() private email = ''
+  @state() private displayName = ''
+  @state() private selectedRole = 'viewer'
+  @state() private query = ''
+
+  private previousFocus: HTMLElement | null = null
+
+  static styles = css`
+    :host {
+      display: inline-block;
+      color: var(--ld-fg-default);
+      font-family: var(--ld-font-family-ui);
+    }
+
+    button,
+    input,
+    select {
+      font: inherit;
+    }
+
+    .trigger {
+      display: inline-flex;
+      min-height: var(--ld-control-medium);
+      align-items: center;
+      justify-content: center;
+      gap: var(--ld-space-sm);
+      border: var(--ld-border-transparent);
+      border-radius: var(--ld-radius-default);
+      background: transparent;
+      color: var(--ld-fg-muted);
+      cursor: pointer;
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-medium);
+      line-height: var(--ld-line-height-tight);
+      padding: 0 var(--ld-space-lg);
+      transition:
+        color var(--ld-transition-fast),
+        background-color var(--ld-transition-fast),
+        border-color var(--ld-transition-fast);
+    }
+
+    .trigger:hover,
+    .trigger:focus-visible {
+      border-color: var(--ld-line-muted);
+      background: var(--ld-bg-control-hover);
+      color: var(--ld-fg-default);
+      outline: 0;
+    }
+
+    .icon {
+      display: inline-flex;
+      width: var(--ld-icon-sm);
+      height: var(--ld-icon-sm);
+      align-items: center;
+      justify-content: center;
+      color: currentColor;
+    }
+
+    .overlay {
+      position: fixed;
+      inset: 0;
+      z-index: calc(var(--z-index-inspector) - 1);
+      display: grid;
+      place-items: start center;
+      background: var(--ld-modal-backdrop);
+      padding: var(--base-size-32) var(--base-size-16);
+    }
+
+    .dialog {
+      display: grid;
+      width: min(34rem, calc(100vw - var(--base-size-32)));
+      max-height: calc(100vh - var(--base-size-64));
+      grid-template-rows: auto minmax(0, 1fr);
+      overflow: hidden;
+      border: var(--ld-border-default);
+      border-radius: var(--ld-radius-large);
+      background: var(--ld-bg-panel);
+      box-shadow: var(--ld-shadow-floating-lg);
+    }
+
+    .header,
+    .footer {
+      border-bottom: var(--ld-border-muted);
+      padding: var(--base-size-16);
+    }
+
+    .header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: var(--base-size-16);
+    }
+
+    .title {
+      margin: 0;
+      color: var(--ld-fg-default);
+      font-size: var(--ld-font-size-title-sm);
+      font-weight: var(--ld-font-weight-strong);
+      line-height: var(--ld-line-height-snug);
+    }
+
+    .subtitle {
+      margin: var(--base-size-4) 0 0;
+      color: var(--ld-fg-muted);
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-normal);
+      line-height: var(--ld-line-height-snug);
+    }
+
+    .close,
+    .row-action {
+      display: inline-flex;
+      width: var(--ld-control-medium);
+      height: var(--ld-control-medium);
+      flex: 0 0 auto;
+      align-items: center;
+      justify-content: center;
+      border: var(--ld-border-transparent);
+      border-radius: var(--ld-radius-default);
+      background: transparent;
+      color: var(--ld-fg-muted);
+      cursor: pointer;
+      padding: 0;
+      transition:
+        color var(--ld-transition-fast),
+        background-color var(--ld-transition-fast),
+        border-color var(--ld-transition-fast);
+    }
+
+    .close:hover,
+    .close:focus-visible,
+    .row-action:hover,
+    .row-action:focus-visible {
+      border-color: var(--ld-line-muted);
+      background: var(--ld-bg-control-hover);
+      color: var(--ld-fg-default);
+      outline: 0;
+    }
+
+    .body {
+      min-height: 0;
+      overflow: auto;
+      padding: var(--base-size-16);
+    }
+
+    .section {
+      display: grid;
+      gap: var(--base-size-12);
+    }
+
+    .section + .section {
+      margin-top: var(--base-size-20);
+      border-top: var(--ld-border-muted);
+      padding-top: var(--base-size-16);
+    }
+
+    .section-title {
+      margin: 0;
+      color: var(--ld-fg-default);
+      font-size: var(--ld-font-size-body-md);
+      font-weight: var(--ld-font-weight-strong);
+      line-height: var(--ld-line-height-snug);
+    }
+
+    .form {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(8rem, auto) auto;
+      gap: var(--base-size-8);
+    }
+
+    label {
+      display: grid;
+      min-width: 0;
+      gap: var(--base-size-4);
+      color: var(--ld-fg-muted);
+      font-size: var(--ld-font-size-caption);
+      font-weight: var(--ld-font-weight-medium);
+      line-height: var(--ld-line-height-tight);
+      text-transform: uppercase;
+    }
+
+    input,
+    select {
+      min-height: var(--ld-control-medium);
+      min-width: 0;
+      border: var(--ld-border-default);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-control);
+      color: var(--ld-fg-default);
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-medium);
+      line-height: var(--ld-line-height-snug);
+      padding: 0 var(--base-size-8);
+    }
+
+    input::placeholder {
+      color: var(--ld-fg-muted);
+    }
+
+    input:focus,
+    select:focus {
+      border-color: var(--ld-line-accent);
+      outline: 2px solid var(--ld-line-accent-muted);
+      outline-offset: 0;
+    }
+
+    .submit {
+      align-self: end;
+      min-height: var(--ld-control-medium);
+      border: 0;
+      border-radius: var(--ld-radius-default);
+      background: var(--button-primary-bgColor-rest);
+      color: var(--button-primary-fgColor-rest);
+      cursor: pointer;
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-strong);
+      line-height: var(--ld-line-height-tight);
+      padding: 0 var(--base-size-12);
+    }
+
+    .submit:hover,
+    .submit:focus-visible {
+      background: var(--button-primary-bgColor-hover);
+      outline: 0;
+    }
+
+    .submit:disabled,
+    .row-action:disabled {
+      cursor: not-allowed;
+      opacity: var(--opacity-disabled);
+    }
+
+    .status {
+      border-radius: var(--ld-radius-default);
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-medium);
+      line-height: var(--ld-line-height-snug);
+      padding: var(--base-size-8) var(--base-size-12);
+    }
+
+    .status-error {
+      border: var(--ld-border-danger);
+      background: var(--ld-bg-danger-muted);
+      color: var(--ld-fg-danger);
+    }
+
+    .status-message {
+      border: 1px solid var(--ld-line-success-muted);
+      background: var(--ld-bg-success-muted);
+      color: var(--ld-fg-success);
+    }
+
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--base-size-12);
+    }
+
+    .search {
+      width: min(18rem, 100%);
+    }
+
+    .list {
+      display: grid;
+      border-top: var(--ld-border-muted);
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(8rem, 10rem) auto;
+      align-items: center;
+      gap: var(--base-size-12);
+      border-bottom: var(--ld-border-muted);
+      padding: var(--base-size-10) 0;
+    }
+
+    .person {
+      min-width: 0;
+    }
+
+    .name {
+      overflow: hidden;
+      margin: 0;
+      color: var(--ld-fg-default);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-strong);
+      line-height: var(--ld-line-height-snug);
+    }
+
+    .email {
+      overflow: hidden;
+      margin: var(--base-size-2) 0 0;
+      color: var(--ld-fg-muted);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: var(--ld-font-size-caption);
+      font-weight: var(--ld-font-weight-normal);
+      line-height: var(--ld-line-height-tight);
+    }
+
+    .empty {
+      border: 1px dashed var(--ld-line-muted);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-panel-muted);
+      color: var(--ld-fg-muted);
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-medium);
+      padding: var(--base-size-16);
+    }
+
+    @media (max-width: 44rem) {
+      .overlay {
+        align-items: end;
+        padding: var(--base-size-8);
+      }
+
+      .dialog {
+        width: 100%;
+        max-height: calc(100vh - var(--base-size-16));
+      }
+
+      .form,
+      .row {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .submit {
+        justify-self: start;
+      }
+    }
+  `
+
+  updated(changed: Map<string, unknown>): void {
+    if (changed.has('access') || changed.has('accessAttribute')) {
+      this.ensureRole()
+      const status = this.resolvedAccess.status
+      if (status?.message && !status.error && !status.loading) {
+        this.email = ''
+        this.displayName = ''
+      }
+    }
+  }
+
+  render() {
+    const access = this.resolvedAccess
+    if (!access.canManage) return nothing
+
+    return html`
+      <button class="trigger" type="button" aria-haspopup="dialog" aria-expanded=${String(this.open)} @click=${this.openDialog}>
+        ${shieldIcon()}
+        <span>Access</span>
+      </button>
+      ${this.open ? this.renderModal(access) : nothing}
+    `
+  }
+
+  private renderModal(access: WorkspaceAccess) {
+    const status = access.status ?? {}
+    return html`
+      <div class="overlay" @click=${this.handleOverlayClick}>
+        <section
+          class="dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="workspace-access-title"
+          @keydown=${this.handleKeyDown}
+        >
+          <header class="header">
+            <div>
+              <h2 class="title" id="workspace-access-title">Manage access</h2>
+              <p class="subtitle">${access.workspace?.title ?? 'Workspace'} roles apply to every published asset in this workspace.</p>
+            </div>
+            <button class="close" type="button" aria-label="Close workspace access" @click=${this.closeDialog}>
+              ${xIcon()}
+            </button>
+          </header>
+          <div class="body">
+            <section class="section" aria-label="Add workspace access">
+              <h3 class="section-title">Assign role</h3>
+              ${status.error ? html`<div class="status status-error" role="alert">${status.error}</div>` : nothing}
+              ${status.message && !status.error ? html`<div class="status status-message" role="status">${status.message}</div>` : nothing}
+              <form class="form" @submit=${this.handleSubmit}>
+                <label>
+                  Email
+                  <input
+                    type="email"
+                    autocomplete="email"
+                    placeholder="person@example.com"
+                    .value=${this.email}
+                    ?disabled=${status.loading}
+                    @input=${(event: Event) => { this.email = (event.currentTarget as HTMLInputElement).value }}
+                  >
+                </label>
+                <label>
+                  Display name
+                  <input
+                    type="text"
+                    autocomplete="name"
+                    placeholder="Optional"
+                    .value=${this.displayName}
+                    ?disabled=${status.loading}
+                    @input=${(event: Event) => { this.displayName = (event.currentTarget as HTMLInputElement).value }}
+                  >
+                </label>
+                <label>
+                  Role
+                  <select
+                    .value=${this.selectedRole}
+                    ?disabled=${status.loading}
+                    @change=${(event: Event) => { this.selectedRole = (event.currentTarget as HTMLSelectElement).value }}
+                  >
+                    ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
+                  </select>
+                </label>
+                <button class="submit" type="submit" ?disabled=${status.loading || !this.email.trim() || !this.selectedRole}>
+                  ${status.loading ? 'Saving' : 'Assign'}
+                </button>
+              </form>
+            </section>
+            <section class="section" aria-label="Current workspace access">
+              <div class="toolbar">
+                <h3 class="section-title">Current access</h3>
+                <input
+                  class="search"
+                  type="search"
+                  placeholder="Search access..."
+                  .value=${this.query}
+                  @input=${(event: Event) => { this.query = (event.currentTarget as HTMLInputElement).value }}
+                >
+              </div>
+              ${this.renderBindings(access)}
+            </section>
+          </div>
+        </section>
+      </div>
+    `
+  }
+
+  private renderBindings(access: WorkspaceAccess) {
+    const rows = this.filteredBindings(access.bindings ?? [])
+    if (rows.length === 0) {
+      return html`<div class="empty">${this.query ? 'No access entries match this search.' : 'No role bindings yet.'}</div>`
+    }
+    return html`
+      <div class="list">
+        ${rows.map((binding) => html`
+          <div class="row">
+            <div class="person">
+              <p class="name">${displayLabel(binding)}</p>
+              <p class="email">${binding.email}</p>
+            </div>
+            <select
+              aria-label=${`Role for ${displayLabel(binding)}`}
+              .value=${binding.role}
+              ?disabled=${access.status?.loading}
+              @change=${(event: Event) => this.updateBindingRole(binding, (event.currentTarget as HTMLSelectElement).value)}
+            >
+              ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
+            </select>
+            <button
+              class="row-action"
+              type="button"
+              aria-label=${`Remove ${displayLabel(binding)}`}
+              ?disabled=${access.status?.loading}
+              @click=${() => this.removeBinding(binding)}
+            >
+              ${trashIcon()}
+            </button>
+          </div>
+        `)}
+      </div>
+    `
+  }
+
+  private get resolvedAccess(): WorkspaceAccess {
+    if (this.access) return normalizeAccess(this.access)
+    if (this.accessAttribute) {
+      try {
+        return normalizeAccess(JSON.parse(this.accessAttribute) as WorkspaceAccess)
+      } catch {
+        return emptyAccess
+      }
+    }
+    return emptyAccess
+  }
+
+  private get roles(): Role[] {
+    return this.resolvedAccess.roles ?? []
+  }
+
+  private ensureRole(): void {
+    const roles = this.roles
+    if (roles.some((role) => role.name === this.selectedRole)) return
+    this.selectedRole = roles.find((role) => role.name === 'viewer')?.name ?? roles[0]?.name ?? ''
+  }
+
+  private filteredBindings(bindings: Binding[]): Binding[] {
+    const query = this.query.trim().toLowerCase()
+    if (!query) return bindings
+    return bindings.filter((binding) => {
+      return `${binding.displayName ?? ''} ${binding.email} ${binding.role}`.toLowerCase().includes(query)
+    })
+  }
+
+  private readonly openDialog = (): void => {
+    this.previousFocus = document.activeElement as HTMLElement | null
+    this.open = true
+    window.setTimeout(() => {
+      const first = this.focusableElements()[0]
+      first?.focus()
+    }, 0)
+  }
+
+  private readonly closeDialog = (): void => {
+    this.open = false
+    window.setTimeout(() => {
+      if (this.previousFocus?.isConnected) this.previousFocus.focus()
+      this.previousFocus = null
+    }, 0)
+  }
+
+  private readonly handleOverlayClick = (event: Event): void => {
+    if (event.target === event.currentTarget) this.closeDialog()
+  }
+
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      this.closeDialog()
+      return
+    }
+    if (event.key !== 'Tab') return
+    const focusable = this.focusableElements()
+    if (focusable.length === 0) return
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (event.shiftKey && this.shadowRoot?.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && this.shadowRoot?.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  private focusableElements(): HTMLElement[] {
+    const dialog = this.renderRoot.querySelector<HTMLElement>('.dialog')
+    if (!dialog) return []
+    return Array.from(dialog.querySelectorAll<HTMLElement>(focusableSelector))
+  }
+
+  private readonly handleSubmit = (event: Event): void => {
+    event.preventDefault()
+    const command: AccessCommand = {
+      email: this.email.trim(),
+      displayName: this.displayName.trim(),
+      role: this.selectedRole,
+    }
+    if (!command.email || !command.role) return
+    this.dispatchEvent(new CustomEvent('ld-workspace-access-upsert', {
+      bubbles: true,
+      composed: true,
+      detail: command,
+    }))
+  }
+
+  private updateBindingRole(binding: Binding, role: string): void {
+    if (!binding.email || !role || role === binding.role) return
+    this.dispatchEvent(new CustomEvent('ld-workspace-access-upsert', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        email: binding.email,
+        displayName: binding.displayName,
+        role,
+      },
+    }))
+  }
+
+  private removeBinding(binding: Binding): void {
+    if (!binding.principalId) return
+    this.dispatchEvent(new CustomEvent('ld-workspace-access-remove', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        principalId: binding.principalId,
+      },
+    }))
+  }
+}
+
+function normalizeAccess(access: WorkspaceAccess): WorkspaceAccess {
+  return {
+    workspace: access.workspace ?? {},
+    roles: access.roles ?? [],
+    bindings: access.bindings ?? [],
+    canManage: Boolean(access.canManage),
+    status: access.status ?? {},
+  }
+}
+
+function displayLabel(binding: Binding): string {
+  return binding.displayName?.trim() || binding.email || 'Principal'
+}
+
+function roleLabel(role: string): string {
+  return role.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function shieldIcon() {
+  return html`<span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.7 8.9a1 1 0 0 1-.6 0C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.2-2.7a1.2 1.2 0 0 1 1.6 0C14.5 3.8 17 5 19 5a1 1 0 0 1 1 1z"></path></svg></span>`
+}
+
+function xIcon() {
+  return html`<span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></span>`
+}
+
+function trashIcon() {
+  return html`<span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 11v6"></path><path d="M14 11v6"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path><path d="M3 6h18"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg></span>`
+}
+
+customElements.define('ld-workspace-access-control', WorkspaceAccessControl)
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ld-workspace-access-control': WorkspaceAccessControl
+  }
+}

--- a/web/components/workspace-access-control.ts
+++ b/web/components/workspace-access-control.ts
@@ -84,16 +84,16 @@ class WorkspaceAccessControl extends LitElement {
       min-height: var(--ld-control-medium);
       align-items: center;
       justify-content: center;
-      gap: var(--ld-space-sm);
-      border: var(--ld-border-transparent);
+      gap: var(--base-size-6);
+      border: var(--ld-border-muted);
       border-radius: var(--ld-radius-default);
-      background: transparent;
-      color: var(--ld-fg-muted);
+      background: var(--ld-bg-panel);
+      color: var(--ld-fg-default);
       cursor: pointer;
       font-size: var(--ld-font-size-body-sm);
-      font-weight: var(--ld-font-weight-medium);
+      font-weight: var(--ld-font-weight-strong);
       line-height: var(--ld-line-height-tight);
-      padding: 0 var(--ld-space-lg);
+      padding: 0 var(--base-size-10);
       transition:
         color var(--ld-transition-fast),
         background-color var(--ld-transition-fast),
@@ -102,7 +102,7 @@ class WorkspaceAccessControl extends LitElement {
 
     .trigger:hover,
     .trigger:focus-visible {
-      border-color: var(--ld-line-muted);
+      border-color: var(--ld-line-default);
       background: var(--ld-bg-control-hover);
       color: var(--ld-fg-default);
       outline: 0;
@@ -122,7 +122,7 @@ class WorkspaceAccessControl extends LitElement {
       inset: 0;
       z-index: calc(var(--z-index-inspector) - 1);
       display: grid;
-      place-items: start center;
+      place-items: center;
       background: var(--ld-modal-backdrop);
       padding: var(--base-size-32) var(--base-size-16);
     }
@@ -142,7 +142,7 @@ class WorkspaceAccessControl extends LitElement {
     .header,
     .footer {
       border-bottom: var(--ld-border-muted);
-      padding: var(--base-size-16);
+      padding: var(--base-size-16) var(--base-size-20);
     }
 
     .header {
@@ -200,15 +200,15 @@ class WorkspaceAccessControl extends LitElement {
 
     .body {
       display: grid;
-      gap: var(--base-size-20);
+      gap: var(--base-size-24);
       min-height: 0;
       overflow: auto;
-      padding: var(--base-size-16) var(--base-size-20) var(--base-size-20);
+      padding: var(--base-size-20);
     }
 
     .card {
       display: grid;
-      gap: var(--base-size-8);
+      gap: var(--base-size-10);
     }
 
     .section-title {
@@ -219,26 +219,11 @@ class WorkspaceAccessControl extends LitElement {
       line-height: var(--ld-line-height-snug);
     }
 
-    .form {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(8rem, auto) auto;
-      gap: var(--base-size-8);
-      align-items: end;
-      border: var(--ld-border-muted);
-      border-radius: var(--ld-radius-default);
-      background: var(--ld-bg-panel-muted);
-      padding: var(--base-size-8);
-    }
-
-    label {
-      display: grid;
-      min-width: 0;
-      gap: var(--base-size-4);
+    .label {
       color: var(--ld-fg-muted);
       font-size: var(--ld-font-size-caption);
       font-weight: var(--ld-font-weight-medium);
       line-height: var(--ld-line-height-tight);
-      text-transform: uppercase;
     }
 
     .field-shell {
@@ -263,6 +248,39 @@ class WorkspaceAccessControl extends LitElement {
       background: var(--ld-bg-control-hover);
     }
 
+    .composer {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: var(--base-size-8);
+      align-items: center;
+    }
+
+    .composer-shell {
+      min-height: var(--ld-control-medium);
+      border-radius: var(--ld-radius-tight);
+      padding: var(--base-size-4) var(--base-size-6) var(--base-size-4) var(--base-size-12);
+    }
+
+    .composer-shell input {
+      flex: 1 1 12rem;
+    }
+
+    .composer-role {
+      width: auto;
+      min-width: 7rem;
+      flex: 0 0 auto;
+      border: 0;
+      border-left: var(--ld-border-muted);
+      border-radius: 0;
+      background: transparent;
+      color: var(--ld-fg-default);
+      padding-left: var(--base-size-12);
+    }
+
+    .composer-role:focus {
+      outline-offset: var(--base-size-2);
+    }
+
     input,
     select {
       min-height: var(--ld-control-medium);
@@ -277,13 +295,18 @@ class WorkspaceAccessControl extends LitElement {
       padding: 0 var(--base-size-8);
     }
 
-    .field-shell input {
+    .field-shell input,
+    .field-shell select {
       min-height: auto;
       border: 0;
       border-radius: 0;
       background: transparent;
       padding: 0;
       outline: 0;
+    }
+
+    .field-shell input {
+      flex: 1 1 auto;
     }
 
     input::placeholder {
@@ -298,17 +321,17 @@ class WorkspaceAccessControl extends LitElement {
     }
 
     .submit {
-      align-self: end;
       min-height: var(--ld-control-medium);
+      min-width: var(--base-size-80);
       border: 0;
-      border-radius: var(--ld-radius-default);
+      border-radius: var(--ld-radius-tight);
       background: var(--button-primary-bgColor-rest);
       color: var(--button-primary-fgColor-rest);
       cursor: pointer;
       font-size: var(--ld-font-size-body-sm);
       font-weight: var(--ld-font-weight-strong);
       line-height: var(--ld-line-height-tight);
-      padding: 0 var(--base-size-12);
+      padding: 0 var(--base-size-16);
     }
 
     .submit:hover,
@@ -346,7 +369,7 @@ class WorkspaceAccessControl extends LitElement {
     .toolbar {
       display: grid;
       grid-template-columns: minmax(0, 1fr) minmax(12rem, 18rem);
-      align-items: end;
+      align-items: center;
       gap: var(--base-size-12);
     }
 
@@ -358,7 +381,7 @@ class WorkspaceAccessControl extends LitElement {
       display: grid;
       overflow: hidden;
       border: var(--ld-border-muted);
-      border-radius: var(--ld-radius-default);
+      border-radius: var(--ld-radius-tight);
       background: var(--ld-bg-panel);
     }
 
@@ -423,12 +446,12 @@ class WorkspaceAccessControl extends LitElement {
 
     .empty {
       border: var(--ld-border-muted);
-      border-radius: var(--ld-radius-default);
+      border-radius: var(--ld-radius-tight);
       background: var(--ld-bg-panel);
       color: var(--ld-fg-muted);
       font-size: var(--ld-font-size-body-sm);
       font-weight: var(--ld-font-weight-medium);
-      padding: var(--base-size-24) var(--base-size-16);
+      padding: var(--base-size-20) var(--base-size-16);
       text-align: center;
     }
 
@@ -443,14 +466,27 @@ class WorkspaceAccessControl extends LitElement {
         max-height: calc(100vh - var(--base-size-16));
       }
 
-      .form,
+      .composer,
       .row,
       .toolbar {
         grid-template-columns: minmax(0, 1fr);
       }
 
+      .composer-shell {
+        align-items: stretch;
+        flex-wrap: wrap;
+        padding: var(--base-size-8);
+      }
+
+      .composer-role {
+        min-width: 100%;
+        border-top: var(--ld-border-muted);
+        border-left: 0;
+        padding-left: var(--base-size-8);
+      }
+
       .submit {
-        justify-self: start;
+        justify-self: stretch;
       }
     }
   `
@@ -503,34 +539,31 @@ class WorkspaceAccessControl extends LitElement {
           </header>
           <div class="body">
             <section class="card" aria-label="Add workspace access">
-              <h3 class="section-title">Assign role</h3>
+              <div class="label">Add people by email</div>
               ${status.error ? html`<div class="status status-error" role="alert">${status.error}</div>` : nothing}
               ${status.message && !status.error ? html`<div class="status status-message" role="status">${status.message}</div>` : nothing}
-              <form class="form" @submit=${this.handleSubmit}>
-                <label>
-                  Principal
-                  <span class="field-shell">
-                    ${mailIcon()}
-                    <input
-                      type="email"
-                      autocomplete="email"
-                      placeholder="person@example.com"
-                      .value=${this.email}
-                      ?disabled=${status.loading}
-                      @input=${(event: Event) => { this.email = (event.currentTarget as HTMLInputElement).value }}
-                    >
-                  </span>
-                </label>
-                <label>
-                  Role
+              <form class="composer" @submit=${this.handleSubmit}>
+                <span class="field-shell composer-shell">
+                  ${mailIcon()}
+                  <input
+                    type="email"
+                    autocomplete="email"
+                    placeholder="Search by email..."
+                    aria-label="Email principal"
+                    .value=${this.email}
+                    ?disabled=${status.loading}
+                    @input=${(event: Event) => { this.email = (event.currentTarget as HTMLInputElement).value }}
+                  >
                   <select
+                    class="composer-role"
+                    aria-label="Role to assign"
                     .value=${this.selectedRole}
                     ?disabled=${status.loading}
                     @change=${(event: Event) => { this.selectedRole = (event.currentTarget as HTMLSelectElement).value }}
                   >
                     ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
                   </select>
-                </label>
+                </span>
                 <button class="submit" type="submit" ?disabled=${status.loading || !this.email.trim() || !this.selectedRole}>
                   ${status.loading ? 'Saving' : 'Assign'}
                 </button>


### PR DESCRIPTION
## Summary
- add workspace-first asset browsing/detail/lineage views
- normalize workspace asset rows and detail sections with token-backed styling
- add a signal-bound workspace access modal web component and command endpoints

## Tests
- go test ./internal/ui ./internal/app
- task test

## Notes
- Workspace access mutation remains server-owned through Datastar command signals.
- Existing permissions routes remain for compatibility.