### PR TITLE
Add workspace asset portal and semantic model cleanup

### DIFF
--- a/SEMANTIC_MODEL_DESIGN.md
+++ b/SEMANTIC_MODEL_DESIGN.md
@@ -1,0 +1,240 @@
+# Semantic Model Design
+
+LibreDash should feel like a Power BI semantic model without DAX or Power Query.
+
+The product shape is:
+
+```text
+sources -> models -> semantic model -> dashboards
+```
+
+## Layers
+
+### Sources
+
+Sources describe raw physical data only: where rows come from and how to read them.
+
+```yaml
+sources:
+  olist_orders:
+    connection: olist
+    path: olist_orders_dataset.csv
+    format: csv
+
+  olist_customers:
+    connection: olist
+    path: olist_customers_dataset.csv
+    format: csv
+```
+
+Sources do not define business fields, joins, measures, or dashboard-facing semantics.
+
+### Models
+
+Models are DuckDB-backed model tables prepared for semantic consumption.
+
+Each model can point directly at a source or apply light SQL. This is where casts, cleanup, naming, and grain-alignment preparation live.
+
+```yaml
+models:
+  orders:
+    source: olist_orders
+    sql: |
+      SELECT
+        order_id,
+        customer_id,
+        CAST(order_purchase_timestamp AS TIMESTAMP) AS purchase_timestamp,
+        order_status AS status
+      FROM source.olist_orders
+
+  customers:
+    source: olist_customers
+```
+
+LibreDash is not a transformation framework. Heavy ETL and long model chains belong upstream.
+
+### Semantic Models
+
+Semantic models define the governed data model: tables and relationships.
+
+Tables are not required to be labeled as facts or dimensions. A table becomes fact-like when a measure uses it as its base table. A table becomes dimension-like when it is reached through a safe relationship path.
+
+```yaml
+semantic_models:
+  olist:
+    tables:
+      orders:
+        model: orders
+        primary_key: order_id
+
+      customers:
+        model: customers
+        primary_key: customer_id
+
+    relationships:
+      - from: orders.customer_id
+        to: customers.customer_id
+        cardinality: many_to_one
+        active: true
+```
+
+The semantic model owns table identity, relationships, and measures.
+
+### Measures
+
+Measures are governed reusable analytics definitions.
+
+They live on the semantic model and reuse the same query metadata a visual can define inline: table, grain/scope, expression, time behavior, and formatting.
+
+```yaml
+semantic_models:
+  olist:
+    measures:
+      defaults:
+        table: orders
+        grain: order_id
+        time: orders.purchase_timestamp
+        grains: [day, week, month, quarter, year]
+
+      revenue:
+        expr: SUM(orders.revenue)
+        format: currency
+
+      order_count:
+        expr: COUNT(DISTINCT orders.order_id)
+        format: integer
+```
+
+This keeps the model close to Power BI: dashboards query the semantic model, and measures are the simplified DAX-like contract. LibreDash measures are SQL aggregate expressions with explicit semantic evaluation metadata, not full DAX.
+
+Named measures are preferred for governed dashboards. Inline measures are allowed for one-off visual authoring and can later be promoted into the semantic model.
+
+If repeated field sets or curated subsets become painful, LibreDash can add optional views later. Views should be a DRY/permission/curation layer, not a required v1 modeling layer.
+
+### Dashboards
+
+Dashboards consume semantic models. Visuals ask for dimensions, measures, filters, sort, and limits.
+
+```yaml
+semantic_model: olist
+
+visuals:
+  revenue_by_state:
+    query:
+      dimensions:
+        state: customers.state
+      measures:
+        revenue:
+    encode:
+      x: state
+      y: revenue
+```
+
+Dashboards do not reference SQL joins, source files, physical cache tables, or internal materialization names.
+
+### Inline Queries
+
+The visual query shape is the primitive contract. A visual may use named measures or define inline measures with the same metadata.
+
+```yaml
+semantic_model: olist
+
+visuals:
+  orders_by_state:
+    query:
+      table: orders
+      grain: order_id
+      dimensions:
+        state: customers.state
+      measures:
+        order_count:
+          expr: COUNT(DISTINCT orders.order_id)
+          time: orders.purchase_timestamp
+          grains: [day, week, month, quarter, year]
+          format: integer
+```
+
+In query `measures`, the key is the local output name. A blank value uses the named semantic-model measure with the same name. Use `measure` to alias an existing measure, or `expr` to define an inline measure.
+
+```yaml
+query:
+  measures:
+    revenue:
+    orders:
+      measure: order_count
+    one_off_orders:
+      expr: COUNT(DISTINCT orders.order_id)
+      table: orders
+      grain: order_id
+      time: orders.purchase_timestamp
+      grains: [day, week, month, quarter, year]
+      format: integer
+```
+
+Inline measures are useful for quick dashboards and experiments. Named semantic-model measures are the governance path.
+
+Use expanded objects when a query field needs local metadata:
+
+```yaml
+query:
+  dimensions:
+    state:
+      field: customers.state
+      label: Customer state
+  measures:
+    revenue:
+      measure: revenue
+      label: Revenue
+```
+
+Row/detail visuals can query fields directly without measures, but must declare a table.
+
+```yaml
+semantic_model: olist
+
+tables:
+  orders:
+    query:
+      table: orders
+      fields:
+        - orders.order_id
+        - orders.purchase_timestamp
+        - customers.state
+        - orders.status
+      sort:
+        - field: orders.purchase_timestamp
+          direction: desc
+      limit: 100
+```
+
+## Guardrails
+
+- Measures declare one table.
+- Measures declare their query grain/scope.
+- Inline visual measures follow the same rules as named semantic-model measures.
+- Multiple measures in one query must have a compatible table and grain.
+- Row/detail queries must declare a table when they do not include a measure.
+- Dimensions may come from the base table.
+- Dimensions may come from related tables through active many-to-one or one-to-one paths.
+- One-to-many, many-to-many, circular, ambiguous, inactive, or missing paths are rejected for dashboard queries.
+- Cross-fact measures are not supported in v1.
+- Unsafe analysis requires a new model at the correct grain or an explicit future view.
+
+## Naming
+
+Use these names in product language:
+
+- Source
+- Model
+- Semantic model
+- Relationship
+- Measure
+- Dashboard
+
+Avoid these as primary user-facing concepts:
+
+- Dataset
+- Cache table
+- OBT
+
+Those are implementation or compatibility terms. If physical optimization is shown, call it a materialization.

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -30,7 +30,7 @@ sources:
 tables:
   orders:
     kind: fact
-    description: One row per order with reusable order grain measures.
+    description: One row per order with explicit order-grain derived fields for v1 metric-view measures.
     transform:
       sql: |
         WITH revenue AS (

--- a/decision.md
+++ b/decision.md
@@ -838,8 +838,7 @@ Current LibreDash already has pieces of this model:
 
 - Connections.
 - Sources.
-- Cache tables.
-- Datasets.
+- Model tables.
 - Relationships.
 - Metric views.
 - Dashboards.
@@ -847,16 +846,16 @@ Current LibreDash already has pieces of this model:
 The current runtime effectively does:
 
 ```text
-source -> raw DuckDB view -> cache table -> dataset -> metric view -> dashboard
+source -> raw DuckDB view -> model table -> metric view -> dashboard
 ```
 
 The long-term migration should reinterpret these concepts:
 
 - `source` remains source.
-- `cache table` becomes an implementation detail or is renamed to backing materialization.
-- `dataset` evolves into model table or public semantic table.
+- `model table` is the authored semantic fact/dimension table.
+- Physical cache tables, OBTs, and rollups become implementation details or backing materializations.
 - `relationships` become active query-planning metadata.
-- `metric view` moves from one physical dataset to one base table plus related dimensions/measures.
+- `metric view` remains anchored on one base table plus safe related dimensions.
 
 ## Non-Goals
 

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -292,6 +292,74 @@ func TestWorkspacePageDefaultsToTopLevelAssets(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAssetSearchStaysWorkspaceFacing(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := NewAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	req := httptest.NewRequest(http.MethodGet, "/workspaces/test?q=orders_enriched", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	for _, notWant := range []string{"Cache table", "Dataset", `>orders_enriched<`} {
+		if strings.Contains(rec.Body.String(), notWant) {
+			t.Fatalf("workspace search rendered internal asset vocabulary %q:\n%s", notWant, rec.Body.String())
+		}
+	}
+}
+
+func TestWorkspaceConnectionFilterRedirectsToGlobalConnections(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := NewAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	req := httptest.NewRequest(http.MethodGet, "/workspaces/test?type=connection&q=olist", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusFound, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != "/connections?q=olist" {
+		t.Fatalf("Location = %q, want /connections?q=olist", got)
+	}
+}
+
+func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := NewAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	req := httptest.NewRequest(http.MethodGet, "/connections?q=olist", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Connections", "Global", "data-connection-toolbar", "local connection"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("connections page missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, `data-workspace-asset-toolbar`) {
+		t.Fatalf("connections page rendered workspace asset toolbar:\n%s", body)
+	}
+}
+
 func TestWorkspacePermissionsRejectViewer(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -250,7 +250,7 @@ func (s *Server) apiWorkspaceAssets(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, err, statusForNotFound(err))
 		return
 	}
-	writeJSON(w, http.StatusOK, filterWorkspaceAssets(assets, r.URL.Query().Get("type"), r.URL.Query().Get("q")))
+	writeJSON(w, http.StatusOK, filterAssets(assets, r.URL.Query().Get("type"), r.URL.Query().Get("q")))
 }
 
 func (s *Server) apiWorkspaceAssetEdges(w http.ResponseWriter, r *http.Request) {
@@ -639,15 +639,23 @@ func filterAssets(assets []api.AssetResponse, typ, query string) []api.AssetResp
 
 func filterWorkspaceAssets(assets []api.AssetResponse, typ, query string) []api.AssetResponse {
 	typ = strings.TrimSpace(typ)
-	query = strings.TrimSpace(query)
-	if typ != "" || query != "" {
-		return filterAssets(assets, typ, query)
+	query = strings.ToLower(strings.TrimSpace(query))
+	if typ != "" && !isWorkspaceLandingAsset(typ) {
+		return nil
 	}
 	out := make([]api.AssetResponse, 0, len(assets))
 	for _, asset := range assets {
-		if isWorkspaceLandingAsset(asset.Type) {
-			out = append(out, asset)
+		if !isWorkspaceLandingAsset(asset.Type) {
+			continue
 		}
+		if typ != "" && asset.Type != typ {
+			continue
+		}
+		haystack := strings.ToLower(asset.Type + " " + asset.Key + " " + asset.Title + " " + asset.Description)
+		if query != "" && !strings.Contains(haystack, query) {
+			continue
+		}
+		out = append(out, asset)
 	}
 	return out
 }

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Yacobolo/libredash/internal/api"
@@ -34,6 +35,14 @@ func (s *Server) workspaces(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) workspaceAssets(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("type") == "connection" {
+		target := "/connections"
+		if query := strings.TrimSpace(r.URL.Query().Get("q")); query != "" {
+			target += "?q=" + url.QueryEscape(query)
+		}
+		http.Redirect(w, r, target, http.StatusFound)
+		return
+	}
 	workspaceID := s.workspaceID(chi.URLParam(r, "workspace"))
 	assets, _, err := s.workspaceAssetsAndEdges(r, workspaceID)
 	if err != nil {
@@ -52,7 +61,19 @@ func (s *Server) workspaceAssets(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) connections(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/workspaces/"+s.workspaceID("")+"?type=connection", http.StatusFound)
+	workspaceID := s.workspaceID("")
+	assets, _, err := s.workspaceAssetsAndEdges(r, workspaceID)
+	if err != nil {
+		http.Error(w, err.Error(), statusForNotFound(err))
+		return
+	}
+	connections := filterAssets(assets, "connection", r.URL.Query().Get("q"))
+	workspace := s.workspaceResponse(r, workspaceID)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if err := ui.ConnectionsPage(s.metrics.Catalog(), workspace, connections, r.URL.Query().Get("q"), s.currentRoleLabel(r)).Render(w); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func (s *Server) workspaceAsset(w http.ResponseWriter, r *http.Request) {
@@ -530,7 +551,7 @@ func safeAssetMeta(assetType, raw string) map[string]any {
 	case "source":
 		return pickMeta(content, "format", "Format", "path", "Path", "connection", "Connection", "object", "Object", "options", "Options")
 	case "metric_view":
-		return pickMeta(content, "semantic_model", "SemanticModel", "dataset", "Dataset", "timeseries", "Timeseries")
+		return pickMeta(content, "semantic_model", "SemanticModel", "base_table", "BaseTable", "timeseries", "Timeseries")
 	case "measure":
 		return pickMeta(content, "expression", "Expression", "unit", "Unit", "format", "Format")
 	case "dimension":

--- a/internal/deploy/assets.go
+++ b/internal/deploy/assets.go
@@ -1,6 +1,9 @@
 package deploy
 
 import (
+	"regexp"
+	"sort"
+
 	"github.com/Yacobolo/libredash/internal/platform"
 	"github.com/Yacobolo/libredash/internal/semantic"
 )
@@ -59,6 +62,10 @@ func ExtractAssets(workspaceID, deploymentID string, workspace *semantic.Workspa
 			edge(modelID, id, "contains")
 			if table.Source != "" {
 				edge(id, byKey["source:"+modelEntry.ID+"."+table.Source], "reads_source")
+			} else {
+				for _, sourceName := range transformSourceRefs(table.Transform.SQL, model.Sources) {
+					edge(id, byKey["source:"+modelEntry.ID+"."+sourceName], "reads_source")
+				}
 			}
 		}
 	}
@@ -142,6 +149,25 @@ func ExtractAssets(workspaceID, deploymentID string, workspace *semantic.Workspa
 		}
 	}
 	return assets, edges, nil
+}
+
+func transformSourceRefs(sql string, sources map[string]semantic.Source) []string {
+	if sql == "" || len(sources) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(sources))
+	for name := range sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		pattern := regexp.MustCompile(`(?i)\braw\.` + regexp.QuoteMeta(name) + `\b`)
+		if pattern.MatchString(sql) {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func connectionDescription(connection semantic.Connection) string {

--- a/internal/deploy/bundle_test.go
+++ b/internal/deploy/bundle_test.go
@@ -44,15 +44,32 @@ func TestPackValidateAndExtractAssets(t *testing.T) {
 	if len(validation.Edges) == 0 {
 		t.Fatal("expected lineage edges")
 	}
+	assetTypes := map[string]string{}
+	for _, asset := range validation.Assets {
+		assetTypes[asset.ID] = asset.Type
+	}
 	hasSourceConnectionEdge := false
+	hasMetricModelTableEdge := false
+	hasModelTableSourceEdge := false
 	for _, edge := range validation.Edges {
 		if edge.Type == "uses_connection" {
 			hasSourceConnectionEdge = true
-			break
+		}
+		if edge.Type == "uses_model_table" {
+			hasMetricModelTableEdge = true
+		}
+		if edge.Type == "reads_source" && assetTypes[edge.FromAssetID] == "model_table" && assetTypes[edge.ToAssetID] == "source" {
+			hasModelTableSourceEdge = true
 		}
 	}
 	if !hasSourceConnectionEdge {
 		t.Fatal("expected source to connection lineage edge")
+	}
+	if !hasMetricModelTableEdge {
+		t.Fatal("expected metric view to model table lineage edge")
+	}
+	if !hasModelTableSourceEdge {
+		t.Fatal("expected model table to source lineage edge")
 	}
 }
 

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -41,6 +41,41 @@ func TestLoadOlistModel(t *testing.T) {
 	}
 }
 
+func TestMetricViewRejectsMeasureOutsideBaseTable(t *testing.T) {
+	model := minimalSourceModel()
+	model.Sources["customers"] = Source{Path: "customers.csv"}
+	model.Tables["customers"] = ModelTable{
+		Kind:       "dimension",
+		Source:     "customers",
+		PrimaryKey: "customer_id",
+		Grain:      "customer_id",
+		Dimensions: map[string]MetricDimension{
+			"customer_id": {Expr: "customer_id"},
+			"state":       {Expr: "customer_state"},
+		},
+		Measures: map[string]MetricMeasure{
+			"customer_count": {Label: "Customers", Expression: "COUNT(DISTINCT customers.customer_id)"},
+		},
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+	view := &MetricView{
+		ID:            "orders",
+		Title:         "Orders",
+		SemanticModel: "test",
+		BaseTable:     "orders",
+		Grain:         "order_id",
+		Time:          ViewTime{DefaultField: "orders.order_id"},
+		DimensionRefs: []string{"orders.order_id", "customers.state"},
+		MeasureRefs:   []string{"orders.order_count", "customers.customer_count"},
+	}
+	err := view.Validate(model)
+	if err == nil || !strings.Contains(err.Error(), `is owned by "customers", want base table "orders"`) {
+		t.Fatalf("Validate() error = %v, want non-base measure rejection", err)
+	}
+}
+
 func TestModelValidateAcceptsNativeSourceFamilies(t *testing.T) {
 	model := minimalSourceModel()
 	model.DefaultConnection = "local_files"

--- a/internal/ui/asset_icons.go
+++ b/internal/ui/asset_icons.go
@@ -16,11 +16,9 @@ type assetPresentation struct {
 }
 
 var assetPresentationByType = map[string]assetPresentation{
-	"cache_table":     assetPresentationFor(lucide.TableProperties, "cache-table"),
 	"catalog":         assetPresentationFor(lucide.BookOpen, "catalog"),
 	"connection":      assetPresentationFor(lucide.Plug, "connection"),
 	"dashboard":       assetPresentationFor(lucide.LayoutDashboard, "dashboard"),
-	"dataset":         assetPresentationFor(lucide.Database, "dataset"),
 	"dimension":       assetPresentationFor(lucide.Ruler, "dimension"),
 	"filter":          assetPresentationFor(lucide.ListFilter, "filter"),
 	"measure":         assetPresentationFor(lucide.Sigma, "measure"),
@@ -34,6 +32,10 @@ var assetPresentationByType = map[string]assetPresentation{
 	"visual_element":  assetPresentationFor(lucide.SquareDashedMousePointer, "visual"),
 	"workspace":       assetPresentationFor(lucide.Boxes, "catalog"),
 	"workspace_group": assetPresentationFor(lucide.GalleryVerticalEnd, "catalog"),
+	// Compatibility-only asset types. They should render with the model-table
+	// presentation until the legacy deployment/API vocabulary can be removed.
+	"cache_table": assetPresentationFor(lucide.TableProperties, "model-table"),
+	"dataset":     assetPresentationFor(lucide.TableProperties, "model-table"),
 }
 
 func assetTypeIcon(typ string) g.Node {

--- a/internal/ui/asset_icons.go
+++ b/internal/ui/asset_icons.go
@@ -24,6 +24,7 @@ var assetPresentationByType = map[string]assetPresentation{
 	"dimension":       assetPresentationFor(lucide.Ruler, "dimension"),
 	"filter":          assetPresentationFor(lucide.ListFilter, "filter"),
 	"measure":         assetPresentationFor(lucide.Sigma, "measure"),
+	"model_table":     assetPresentationFor(lucide.TableProperties, "model-table"),
 	"metric_view":     assetPresentationFor(lucide.ChartNoAxesCombined, "metric-view"),
 	"page":            assetPresentationFor(lucide.PanelTop, "page"),
 	"semantic_model":  assetPresentationFor(lucide.Box, "semantic-model"),

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -1757,6 +1757,10 @@ func assetTypeLabel(typ string) string {
 		return "Metric view"
 	case "cache_table":
 		return "Materialization"
+	case "dataset":
+		// Compatibility-only deployment/API type. User-facing workspace pages use
+		// "Model table" as the semantic vocabulary.
+		return "Model table"
 	case "model_table":
 		return "Model table"
 	default:

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -56,6 +56,24 @@ func WorkspacePage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, a
 	)
 }
 
+func ConnectionsPage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, assets []api.AssetResponse, query, roleLabel string) g.Node {
+	return workspaceDocument("Connections", catalog, "connections", roleLabel, nil,
+		h.Section(h.Class(workspaceMainClass), h.Aria("label", "Connections"),
+			workspaceHeader(
+				"Global",
+				"Connections",
+				"Connection assets are managed globally and referenced by semantic models.",
+				nil,
+			),
+			connectionToolbar(query),
+			h.Div(h.Class(workspacePanelClass),
+				g.If(len(assets) == 0, h.Div(h.Class("p-3"), emptyState("No connections match this view."))),
+				g.If(len(assets) > 0, assetTable(workspace.ID, assets)),
+			),
+		),
+	)
+}
+
 func workspacePageSignals(access api.WorkspaceAccessResponse, csrfToken string) map[string]any {
 	return map[string]any{
 		"workspaceAccess": WorkspaceAccessSignals(access, csrfToken),
@@ -256,9 +274,6 @@ func activeDeploymentLabel(workspace api.WorkspaceResponse) string {
 
 func assetToolbar(workspaceID, activeType, query string) g.Node {
 	types := []string{"", "dashboard", "semantic_model", "metric_view"}
-	if activeType == "connection" {
-		types = append(types, "connection")
-	}
 	return h.Div(h.Class("grid min-w-0 gap-3 border-b border-outline-variant bg-app px-3 pt-3"), g.Attr("data-workspace-asset-toolbar", ""),
 		h.Form(h.Method("get"), h.Action("/workspaces/"+workspaceID), h.Class("flex min-w-0 max-w-workspace-search items-center gap-2"),
 			h.Input(h.Type("search"), h.Name("q"), h.Value(query), h.Placeholder("Search workspace assets..."), h.Class("min-h-control-md w-full rounded-small border border-outline-variant bg-control px-3 text-body-sm font-medium text-fg-default placeholder:text-fg-muted")),
@@ -273,6 +288,15 @@ func assetToolbar(workspaceID, activeType, query string) g.Node {
 				}
 				return assetTabLink(workspaceID, typ, activeType, query, label)
 			}),
+		),
+	)
+}
+
+func connectionToolbar(query string) g.Node {
+	return h.Div(h.Class("grid min-w-0 gap-3 border-b border-outline-variant bg-app px-3 py-3"), g.Attr("data-connection-toolbar", ""),
+		h.Form(h.Method("get"), h.Action("/connections"), h.Class("flex min-w-0 max-w-workspace-search items-center gap-2"),
+			h.Input(h.Type("search"), h.Name("q"), h.Value(query), h.Placeholder("Search connections..."), h.Class("min-h-control-md w-full rounded-small border border-outline-variant bg-control px-3 text-body-sm font-medium text-fg-default placeholder:text-fg-muted")),
+			h.Button(h.Type("submit"), h.Class(metricActionButtonClass), h.Title("Search"), h.Aria("label", "Search"), lucide.Search(metricActionIconAttrs()...)),
 		),
 	)
 }
@@ -635,50 +659,38 @@ func dashboardAssetLineage(workspaceID string, selected api.AssetResponse, asset
 			addEdge(semanticEdge)
 		}
 
-		for _, datasetEdge := range outgoing[metricView.ID] {
-			if datasetEdge.Type != "uses_dataset" {
+		for _, tableEdge := range outgoing[metricView.ID] {
+			if tableEdge.Type != "uses_model_table" {
 				continue
 			}
-			dataset, ok := byID[datasetEdge.ToAssetID]
-			if !ok || dataset.Type != "dataset" {
+			modelTable, ok := byID[tableEdge.ToAssetID]
+			if !ok || modelTable.Type != "model_table" {
 				continue
 			}
-			addAsset(3, labelFromKey(datasetEdge.Type), dataset)
-			addEdge(datasetEdge)
+			addAsset(3, labelFromKey(tableEdge.Type), modelTable)
+			addEdge(tableEdge)
 
-			for _, cacheEdge := range outgoing[dataset.ID] {
-				if cacheEdge.Type != "uses_cache_table" {
+			for _, sourceEdge := range outgoing[modelTable.ID] {
+				if sourceEdge.Type != "reads_source" {
 					continue
 				}
-				cacheTable, ok := byID[cacheEdge.ToAssetID]
-				if !ok || cacheTable.Type != "cache_table" {
+				source, ok := byID[sourceEdge.ToAssetID]
+				if !ok || source.Type != "source" {
 					continue
 				}
-				addAsset(4, labelFromKey(cacheEdge.Type), cacheTable)
-				addEdge(cacheEdge)
+				addAsset(4, labelFromKey(sourceEdge.Type), source)
+				addEdge(sourceEdge)
 
-				for _, sourceEdge := range outgoing[cacheTable.ID] {
-					if sourceEdge.Type != "reads_source" {
+				for _, connectionEdge := range outgoing[source.ID] {
+					if connectionEdge.Type != "uses_connection" {
 						continue
 					}
-					source, ok := byID[sourceEdge.ToAssetID]
-					if !ok || source.Type != "source" {
+					connection, ok := byID[connectionEdge.ToAssetID]
+					if !ok || connection.Type != "connection" {
 						continue
 					}
-					addAsset(5, labelFromKey(sourceEdge.Type), source)
-					addEdge(sourceEdge)
-
-					for _, connectionEdge := range outgoing[source.ID] {
-						if connectionEdge.Type != "uses_connection" {
-							continue
-						}
-						connection, ok := byID[connectionEdge.ToAssetID]
-						if !ok || connection.Type != "connection" {
-							continue
-						}
-						addAsset(6, labelFromKey(connectionEdge.Type), connection)
-						addEdge(connectionEdge)
-					}
+					addAsset(5, labelFromKey(connectionEdge.Type), connection)
+					addEdge(connectionEdge)
 				}
 			}
 		}
@@ -909,23 +921,20 @@ func semanticModelDetailModel(model *assetDetailModel, workspace api.WorkspaceRe
 	meta := asset.Meta
 	connections := sortedMapKeys(metaMap(meta, "Connections", "connections"))
 	sources := sortedMapKeys(metaMap(meta, "Sources", "sources"))
-	cacheTables := sortedMapKeys(metaMap(metaMap(meta, "Cache", "cache"), "Tables", "tables"))
-	datasets := sortedMapKeys(metaMap(meta, "Datasets", "datasets"))
+	modelTables := sortedMapKeys(metaMap(meta, "Tables", "tables"))
 	relationships := metaSlice(meta, "Relationships", "relationships")
 
 	model.Overview = append(model.Overview,
 		definitionFact{Label: "Default connection", Value: metaString(meta, "DefaultConnection", "default_connection")},
 		definitionFact{Label: "Connections", Value: fmt.Sprint(len(connections))},
 		definitionFact{Label: "Sources", Value: fmt.Sprint(len(sources))},
-		definitionFact{Label: "Cache tables", Value: fmt.Sprint(len(cacheTables))},
-		definitionFact{Label: "Datasets", Value: fmt.Sprint(len(datasets))},
+		definitionFact{Label: "Model tables", Value: fmt.Sprint(len(modelTables))},
 		definitionFact{Label: "Relationships", Value: fmt.Sprint(len(relationships))},
 	)
 	model.Sections = append(model.Sections,
 		assetDetailSection{Title: fmt.Sprintf("Connections (%d)", len(connections)), Signal: "assetDetailsSemanticConnectionsGrid", Grid: semanticConnectionsGrid(workspace.ID, asset, assets, meta)},
 		assetDetailSection{Title: fmt.Sprintf("Sources (%d)", len(sources)), Signal: "assetDetailsSemanticSourcesGrid", Grid: semanticSourcesGrid(workspace.ID, asset, assets, meta)},
-		assetDetailSection{Title: fmt.Sprintf("Cache tables (%d)", len(cacheTables)), Signal: "assetDetailsSemanticCacheTablesGrid", Grid: semanticCacheGrid(workspace.ID, asset, assets, edges, meta)},
-		assetDetailSection{Title: fmt.Sprintf("Datasets (%d)", len(datasets)), Signal: "assetDetailsSemanticDatasetsGrid", Grid: semanticDatasetsGrid(workspace.ID, asset, assets, meta)},
+		assetDetailSection{Title: fmt.Sprintf("Model tables (%d)", len(modelTables)), Signal: "assetDetailsSemanticModelTablesGrid", Grid: semanticModelTablesGrid(workspace.ID, asset, assets, edges, meta)},
 		assetDetailSection{Title: fmt.Sprintf("Relationships (%d)", len(relationships)), Signal: "assetDetailsSemanticRelationshipsGrid", Grid: semanticRelationshipsGrid(meta)},
 	)
 }
@@ -946,8 +955,7 @@ func semanticModelDetails(asset api.AssetResponse) []g.Node {
 	meta := asset.Meta
 	connections := sortedMapKeys(metaMap(meta, "Connections", "connections"))
 	sources := sortedMapKeys(metaMap(meta, "Sources", "sources"))
-	cacheTables := sortedMapKeys(metaMap(metaMap(meta, "Cache", "cache"), "Tables", "tables"))
-	datasets := sortedMapKeys(metaMap(meta, "Datasets", "datasets"))
+	modelTables := sortedMapKeys(metaMap(meta, "Tables", "tables"))
 	relationships := metaSlice(meta, "Relationships", "relationships")
 
 	return []g.Node{
@@ -955,8 +963,7 @@ func semanticModelDetails(asset api.AssetResponse) []g.Node {
 			{Label: "Default connection", Value: metaString(meta, "DefaultConnection", "default_connection")},
 			{Label: "Connections", Value: fmt.Sprint(len(connections))},
 			{Label: "Sources", Value: fmt.Sprint(len(sources))},
-			{Label: "Cache tables", Value: fmt.Sprint(len(cacheTables))},
-			{Label: "Datasets", Value: fmt.Sprint(len(datasets))},
+			{Label: "Model tables", Value: fmt.Sprint(len(modelTables))},
 			{Label: "Relationships", Value: fmt.Sprint(len(relationships))},
 		}),
 	}
@@ -1016,56 +1023,44 @@ func semanticSourcesGrid(workspaceID string, parent api.AssetResponse, assets []
 	}
 }
 
-func semanticCacheGrid(workspaceID string, parent api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse, meta map[string]any) metricGrid {
-	tables := metaMap(metaMap(meta, "Cache", "cache"), "Tables", "tables")
+func semanticModelTablesGrid(workspaceID string, parent api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse, meta map[string]any) metricGrid {
+	tables := metaMap(meta, "Tables", "tables")
 	rows := make([]map[string]any, 0, len(tables))
 	for _, name := range sortedMapKeys(tables) {
 		table := asMap(tables[name])
-		child := childAssetByName(parent.ID, "cache_table", name, assets)
+		child := childAssetByName(parent.ID, "model_table", name, assets)
+		source := metaString(table, "Source", "source")
+		backing := "Transform SQL"
+		if source != "" {
+			backing = source
+		}
+		transform := metaMap(table, "Transform", "transform")
 		rows = append(rows, map[string]any{
 			"name":        name,
 			"nameHref":    childHref(workspaceID, child),
+			"kind":        metricGridBadgeValue(metaString(table, "Kind", "kind"), "muted"),
+			"grain":       emptyDash(metaString(table, "Grain", "grain")),
+			"primaryKey":  emptyDash(metaString(table, "PrimaryKey", "primary_key")),
+			"backing":     backing,
 			"description": emptyDash(metaString(table, "Description", "description")),
 			"reads":       strings.Join(dependentAssetNames(child.ID, "reads_source", assets, edges), ", "),
-			"sql":         sqlPreview(metaString(table, "SQL", "sql")),
+			"sql":         sqlPreview(metaString(transform, "SQL", "sql")),
 		})
 	}
 	return metricGrid{
 		Columns: []metricGridColumn{
 			{ID: "name", Header: "Name", Kind: "link", HrefKey: "nameHref", Width: "180px"},
-			{ID: "description", Header: "Description", Width: "320px"},
+			{ID: "kind", Header: "Kind", Kind: "badge", Width: "110px"},
+			{ID: "grain", Header: "Grain", Kind: "code", Width: "140px"},
+			{ID: "primaryKey", Header: "Primary key", Kind: "code", Width: "150px"},
+			{ID: "backing", Header: "Source / transform", Kind: "expression", Width: "190px"},
 			{ID: "reads", Header: "Reads", Kind: "expression", Width: "220px"},
-			{ID: "sql", Header: "SQL preview", Kind: "expression"},
+			{ID: "description", Header: "Description", Width: "260px"},
+			{ID: "sql", Header: "SQL preview", Kind: "expression", Width: "320px"},
 		},
 		Rows:     rows,
-		Empty:    "No cache tables are defined for this semantic model.",
-		MinWidth: "980px",
-	}
-}
-
-func semanticDatasetsGrid(workspaceID string, parent api.AssetResponse, assets []api.AssetResponse, meta map[string]any) metricGrid {
-	datasets := metaMap(meta, "Datasets", "datasets")
-	rows := make([]map[string]any, 0, len(datasets))
-	for _, name := range sortedMapKeys(datasets) {
-		dataset := asMap(datasets[name])
-		child := childAssetByName(parent.ID, "dataset", name, assets)
-		sourceName := metaString(dataset, "Source", "source")
-		source := childAssetByName(parent.ID, "cache_table", sourceName, assets)
-		rows = append(rows, map[string]any{
-			"name":       name,
-			"nameHref":   childHref(workspaceID, child),
-			"source":     emptyDash(sourceName),
-			"sourceHref": childHref(workspaceID, source),
-		})
-	}
-	return metricGrid{
-		Columns: []metricGridColumn{
-			{ID: "name", Header: "Name", Kind: "link", HrefKey: "nameHref", Width: "220px"},
-			{ID: "source", Header: "Source cache table", Kind: "link", HrefKey: "sourceHref"},
-		},
-		Rows:     rows,
-		Empty:    "No datasets are defined for this semantic model.",
-		MinWidth: "520px",
+		Empty:    "No model tables are defined for this semantic model.",
+		MinWidth: "1370px",
 	}
 }
 
@@ -1105,7 +1100,7 @@ func metricViewDetailModel(model *assetDetailModel, asset api.AssetResponse, ass
 	}
 	model.Overview = append(model.Overview,
 		definitionFact{Label: "Semantic model", Value: semanticModel},
-		definitionFact{Label: "Dataset", Value: metaString(asset.Meta, "Dataset", "dataset")},
+		definitionFact{Label: "Base table", Value: metaString(asset.Meta, "BaseTable", "base_table")},
 		definitionFact{Label: "Timeseries", Value: metaString(asset.Meta, "Timeseries", "timeseries")},
 	)
 	model.Sections = append(model.Sections,
@@ -1761,7 +1756,9 @@ func assetTypeLabel(typ string) string {
 	case "metric_view":
 		return "Metric view"
 	case "cache_table":
-		return "Cache table"
+		return "Materialization"
+	case "model_table":
+		return "Model table"
 	default:
 		return strings.Title(strings.ReplaceAll(typ, "_", " "))
 	}

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -47,6 +47,15 @@ func TestWorkspaceAssetDetailsRenderSharedShapeForSemanticModel(t *testing.T) {
 	}
 }
 
+func TestLegacyAssetTypesUseCurrentProductVocabulary(t *testing.T) {
+	if got := assetTypeLabel("dataset"); got != "Model table" {
+		t.Fatalf("dataset label = %q, want Model table", got)
+	}
+	if got := assetTypeLabel("cache_table"); got != "Materialization" {
+		t.Fatalf("cache_table label = %q, want Materialization", got)
+	}
+}
+
 func TestWorkspaceAssetDetailSignalsUseSharedGridShape(t *testing.T) {
 	workspace, _, assets, edges := testWorkspaceAssetFixtures()
 	byType := map[string]api.AssetResponse{}

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -31,13 +31,11 @@ func TestWorkspaceAssetDetailsRenderSharedShapeForSemanticModel(t *testing.T) {
 		"Default connection",
 		"Connections (1)",
 		"Sources (1)",
-		"Cache tables (1)",
-		"Datasets (1)",
+		"Model tables (1)",
 		"Relationships (1)",
 		`data-attr:grid="$assetDetailsSemanticConnectionsGrid"`,
 		`data-attr:grid="$assetDetailsSemanticSourcesGrid"`,
-		`data-attr:grid="$assetDetailsSemanticCacheTablesGrid"`,
-		`data-attr:grid="$assetDetailsSemanticDatasetsGrid"`,
+		`data-attr:grid="$assetDetailsSemanticModelTablesGrid"`,
 		`data-attr:grid="$assetDetailsSemanticRelationshipsGrid"`,
 	} {
 		if !strings.Contains(rendered, want) {
@@ -62,8 +60,7 @@ func TestWorkspaceAssetDetailSignalsUseSharedGridShape(t *testing.T) {
 	for _, key := range []string{
 		"assetDetailsSemanticConnectionsGrid",
 		"assetDetailsSemanticSourcesGrid",
-		"assetDetailsSemanticCacheTablesGrid",
-		"assetDetailsSemanticDatasetsGrid",
+		"assetDetailsSemanticModelTablesGrid",
 		"assetDetailsSemanticRelationshipsGrid",
 	} {
 		if _, ok := semanticSignals[key]; !ok {
@@ -151,7 +148,7 @@ func TestWorkspaceAssetDetailsRenderSharedShapeForMetricView(t *testing.T) {
 		"Breadcrumb",
 		"Orders Metrics",
 		"Overview",
-		"Dataset",
+		"Base table",
 		"orders",
 		"Timeseries",
 		"purchase_timestamp",
@@ -197,7 +194,13 @@ func TestWorkspaceAssetRowsUseDetailLinksForModelAndMetricAssets(t *testing.T) {
 
 func TestWorkspaceAssetRowsRenderTokenBackedIconColors(t *testing.T) {
 	workspace, catalog, assets, _ := testWorkspaceAssetFixtures()
-	visibleAssets := []api.AssetResponse{assets[0], assets[5], assets[8]}
+	byType := map[string]api.AssetResponse{}
+	for _, asset := range assets {
+		if _, ok := byType[asset.Type]; !ok {
+			byType[asset.Type] = asset
+		}
+	}
+	visibleAssets := []api.AssetResponse{byType["semantic_model"], byType["metric_view"], byType["dashboard"]}
 
 	var out strings.Builder
 	err := WorkspacePage(catalog, workspace, visibleAssets, "", "", "Owner", testWorkspaceAccess(workspace, true), "csrf").Render(&out)
@@ -313,20 +316,22 @@ func testWorkspaceAssetFixtures() (api.WorkspaceResponse, dashboard.Catalog, []a
 				"Sources": map[string]any{
 					"orders": map[string]any{"Connection": "olist", "Format": "csv", "Path": "orders.csv"},
 				},
-				"Cache": map[string]any{
-					"Tables": map[string]any{"orders_enriched": map[string]any{"Description": "One row per order.", "SQL": "select * from raw.orders"}},
-				},
-				"Datasets": map[string]any{
-					"orders": map[string]any{"Source": "orders_enriched"},
+				"Tables": map[string]any{
+					"orders": map[string]any{
+						"Kind":        "fact",
+						"Source":      "orders",
+						"PrimaryKey":  "order_id",
+						"Grain":       "order_id",
+						"Description": "One row per order.",
+					},
 				},
 				"Relationships": []any{map[string]any{"ID": "orders_customers", "From": "raw.orders.customer_id", "To": "raw.customers.customer_id", "Cardinality": "many_to_one", "Active": true}},
 			},
 		},
 		{ID: "connection", WorkspaceID: workspace.ID, Type: "connection", Key: "olist.olist", ParentID: "model", Title: "Olist connection", Meta: map[string]any{"Kind": "local", "credentials_configured": false}},
 		{ID: "source", WorkspaceID: workspace.ID, Type: "source", Key: "olist.orders", ParentID: "model", Title: "orders", Meta: map[string]any{"Connection": "olist", "Format": "csv", "Path": "orders.csv"}},
-		{ID: "cache", WorkspaceID: workspace.ID, Type: "cache_table", Key: "olist.orders_enriched", ParentID: "model", Title: "orders_enriched"},
-		{ID: "dataset", WorkspaceID: workspace.ID, Type: "dataset", Key: "olist.orders", ParentID: "model", Title: "orders"},
-		{ID: "metric", WorkspaceID: workspace.ID, Type: "metric_view", Key: "orders", ParentID: "model", Title: "Orders Metrics", Description: "Order metrics.", Meta: map[string]any{"Dataset": "orders", "Timeseries": "purchase_timestamp"}},
+		{ID: "model-table", WorkspaceID: workspace.ID, Type: "model_table", Key: "olist.orders", ParentID: "model", Title: "orders"},
+		{ID: "metric", WorkspaceID: workspace.ID, Type: "metric_view", Key: "orders", ParentID: "model", Title: "Orders Metrics", Description: "Order metrics.", Meta: map[string]any{"BaseTable": "orders", "Timeseries": "purchase_timestamp"}},
 		{ID: "measure", WorkspaceID: workspace.ID, Type: "measure", Key: "orders.revenue", ParentID: "metric", Title: "Revenue", Meta: map[string]any{"Expression": "SUM(revenue)", "Format": "currency"}},
 		{ID: "dimension", WorkspaceID: workspace.ID, Type: "dimension", Key: "orders.state", ParentID: "metric", Title: "State", Meta: map[string]any{"Expr": "customer_state"}},
 		{ID: "dashboard", WorkspaceID: workspace.ID, Type: "dashboard", Key: "executive-sales", Title: "Executive Sales Dashboard", Description: "Sales overview.", Href: "/dashboards/executive-sales", Meta: map[string]any{"MetricViews": []any{"orders"}, "Tags": []any{"sales"}}},
@@ -337,9 +342,8 @@ func testWorkspaceAssetFixtures() (api.WorkspaceResponse, dashboard.Catalog, []a
 	}
 	edges := []api.AssetEdgeResponse{
 		{ID: "model-metric", FromAssetID: "model", ToAssetID: "metric", Type: "contains"},
-		{ID: "metric-dataset", FromAssetID: "metric", ToAssetID: "dataset", Type: "uses_dataset"},
-		{ID: "dataset-cache", FromAssetID: "dataset", ToAssetID: "cache", Type: "uses_cache_table"},
-		{ID: "cache-source", FromAssetID: "cache", ToAssetID: "source", Type: "reads_source"},
+		{ID: "metric-model-table", FromAssetID: "metric", ToAssetID: "model-table", Type: "uses_model_table"},
+		{ID: "model-table-source", FromAssetID: "model-table", ToAssetID: "source", Type: "reads_source"},
 		{ID: "source-connection", FromAssetID: "source", ToAssetID: "connection", Type: "uses_connection"},
 		{ID: "dashboard-metric", FromAssetID: "dashboard", ToAssetID: "metric", Type: "uses_metric_view"},
 	}

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -490,9 +490,6 @@
     --report-chart-surface: var(--ld-chart-surface);
     --report-table-stripe: var(--ld-table-stripe);
     --report-grid-dot: transparent;
-    --ld-asset-cache-table-bg: var(--data-auburn-color-muted);
-    --ld-asset-cache-table-accent: var(--data-auburn-color-emphasis);
-    --ld-asset-cache-table-border: var(--borderColor-attention-muted);
     --ld-asset-catalog-bg: var(--data-pink-color-muted);
     --ld-asset-catalog-accent: var(--data-pink-color-emphasis);
     --ld-asset-catalog-border: var(--borderColor-accent-muted);
@@ -502,9 +499,6 @@
     --ld-asset-dashboard-bg: var(--data-purple-color-muted);
     --ld-asset-dashboard-accent: var(--data-purple-color-emphasis);
     --ld-asset-dashboard-border: var(--borderColor-accent-muted);
-    --ld-asset-dataset-bg: var(--data-auburn-color-muted);
-    --ld-asset-dataset-accent: var(--data-auburn-color-emphasis);
-    --ld-asset-dataset-border: var(--borderColor-attention-muted);
     --ld-asset-dimension-bg: var(--data-lemon-color-muted);
     --ld-asset-dimension-accent: var(--data-lemon-color-emphasis);
     --ld-asset-dimension-border: var(--borderColor-attention-muted);

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -514,6 +514,9 @@
     --ld-asset-measure-bg: var(--data-green-color-muted);
     --ld-asset-measure-accent: var(--data-green-color-emphasis);
     --ld-asset-measure-border: var(--borderColor-success-muted);
+    --ld-asset-model-table-bg: var(--data-auburn-color-muted);
+    --ld-asset-model-table-accent: var(--data-auburn-color-emphasis);
+    --ld-asset-model-table-border: var(--borderColor-attention-muted);
     --ld-asset-metric-view-bg: var(--data-yellow-color-muted);
     --ld-asset-metric-view-accent: var(--data-yellow-color-emphasis);
     --ld-asset-metric-view-border: var(--borderColor-attention-muted);

--- a/web/components/asset-lineage-graph.ts
+++ b/web/components/asset-lineage-graph.ts
@@ -287,11 +287,9 @@ function LineageNodeComponent({ data }: { data: LineageNode }) {
 
 function nodeStyle(node: LineageNode): Record<string, string> {
   const palette: Record<string, [string, string, string]> = {
-    cache_table: ['var(--ld-asset-cache-table-bg)', 'var(--ld-asset-cache-table-accent)', 'var(--ld-asset-cache-table-border)'],
     catalog: ['var(--ld-asset-catalog-bg)', 'var(--ld-asset-catalog-accent)', 'var(--ld-asset-catalog-border)'],
     connection: ['var(--ld-asset-connection-bg)', 'var(--ld-asset-connection-accent)', 'var(--ld-asset-connection-border)'],
     dashboard: ['var(--ld-asset-dashboard-bg)', 'var(--ld-asset-dashboard-accent)', 'var(--ld-asset-dashboard-border)'],
-    dataset: ['var(--ld-asset-dataset-bg)', 'var(--ld-asset-dataset-accent)', 'var(--ld-asset-dataset-border)'],
     dimension: ['var(--ld-asset-dimension-bg)', 'var(--ld-asset-dimension-accent)', 'var(--ld-asset-dimension-border)'],
     filter: ['var(--ld-asset-filter-bg)', 'var(--ld-asset-filter-accent)', 'var(--ld-asset-filter-border)'],
     measure: ['var(--ld-asset-measure-bg)', 'var(--ld-asset-measure-accent)', 'var(--ld-asset-measure-border)'],
@@ -302,6 +300,10 @@ function nodeStyle(node: LineageNode): Record<string, string> {
     source: ['var(--ld-asset-source-bg)', 'var(--ld-asset-source-accent)', 'var(--ld-asset-source-border)'],
     table: ['var(--ld-asset-table-bg)', 'var(--ld-asset-table-accent)', 'var(--ld-asset-table-border)'],
     visual: ['var(--ld-asset-visual-bg)', 'var(--ld-asset-visual-accent)', 'var(--ld-asset-visual-border)'],
+    // Compatibility-only asset kinds share the model-table palette so old
+    // deployment/API data does not reintroduce separate product concepts.
+    cache_table: ['var(--ld-asset-model-table-bg)', 'var(--ld-asset-model-table-accent)', 'var(--ld-asset-model-table-border)'],
+    dataset: ['var(--ld-asset-model-table-bg)', 'var(--ld-asset-model-table-accent)', 'var(--ld-asset-model-table-border)'],
   }
   const [bg, accent, border] = palette[node.kind] ?? palette.semantic_model
   return {
@@ -322,6 +324,8 @@ function kindLabel(kind: string): string {
   switch (kind) {
     case 'cache_table':
       return 'Materialization'
+    case 'dataset':
+      return 'Model table'
     case 'model_table':
       return 'Model table'
     case 'metric_view':

--- a/web/components/asset-lineage-graph.ts
+++ b/web/components/asset-lineage-graph.ts
@@ -256,9 +256,8 @@ function dashboardDataPositionFor(node: LineageNode, nodes: LineageNode[]): { x:
   const xByKind: Record<string, number> = {
     connection: 96,
     source: 336,
-    cache_table: 576,
-    dataset: 816,
-    semantic_model: 1056,
+    model_table: 576,
+    semantic_model: 816,
     metric_view: 1200,
   }
   const x = xByKind[node.kind] ?? 576
@@ -296,6 +295,7 @@ function nodeStyle(node: LineageNode): Record<string, string> {
     dimension: ['var(--ld-asset-dimension-bg)', 'var(--ld-asset-dimension-accent)', 'var(--ld-asset-dimension-border)'],
     filter: ['var(--ld-asset-filter-bg)', 'var(--ld-asset-filter-accent)', 'var(--ld-asset-filter-border)'],
     measure: ['var(--ld-asset-measure-bg)', 'var(--ld-asset-measure-accent)', 'var(--ld-asset-measure-border)'],
+    model_table: ['var(--ld-asset-model-table-bg)', 'var(--ld-asset-model-table-accent)', 'var(--ld-asset-model-table-border)'],
     metric_view: ['var(--ld-asset-metric-view-bg)', 'var(--ld-asset-metric-view-accent)', 'var(--ld-asset-metric-view-border)'],
     page: ['var(--ld-asset-page-bg)', 'var(--ld-asset-page-accent)', 'var(--ld-asset-page-border)'],
     semantic_model: ['var(--ld-asset-semantic-model-bg)', 'var(--ld-asset-semantic-model-accent)', 'var(--ld-asset-semantic-model-border)'],
@@ -321,7 +321,9 @@ function edgeStroke(kind: string): string {
 function kindLabel(kind: string): string {
   switch (kind) {
     case 'cache_table':
-      return 'Cache table'
+      return 'Materialization'
+    case 'model_table':
+      return 'Model table'
     case 'metric_view':
       return 'Metric view'
     case 'semantic_model':


### PR DESCRIPTION
## Summary
- add workspace-first asset browsing with shared asset details and lineage views
- align workspace vocabulary around sources, model tables, relationships, metric views, and dashboards
- keep connections on the global `/connections` surface while preserving compatibility detail links
- tighten workspace search/filtering to workspace-facing assets and add compatibility fallbacks for legacy dataset/cache-table asset types

## Tests
- `go test ./internal/semantic ./internal/query ./internal/ui ./internal/app ./internal/deploy`
- `npm run build`
- `task test`

## Notes
- Existing untracked local files were left untouched: `manage-access-modal.html`, `static/metric-usage-graph.css`, `static/model-graph.css`.
