### PR TITLE
Add local Quack dev profile task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,6 +9,13 @@ tasks:
     cmds:
       - ./scripts/dev-server.sh start
 
+  dev:quack:
+    desc: Start the managed LibreDash dev server with the local Quack profile
+    deps:
+      - build
+    cmds:
+      - ./scripts/dev-profile.sh quack start
+
   bootstrap:
     desc: Download/sync Olist CSVs if missing
     cmds:
@@ -19,15 +26,30 @@ tasks:
     cmds:
       - ./scripts/dev-server.sh stop
 
+  dev:quack:stop:
+    desc: Stop the managed LibreDash dev server with the local Quack profile
+    cmds:
+      - ./scripts/dev-profile.sh quack stop
+
   dev:status:
     desc: Show managed LibreDash dev server status
     cmds:
       - ./scripts/dev-server.sh status
 
+  dev:quack:status:
+    desc: Show managed LibreDash dev server status with the local Quack profile
+    cmds:
+      - ./scripts/dev-profile.sh quack status
+
   dev:logs:
     desc: Tail managed LibreDash dev server logs
     cmds:
       - ./scripts/dev-server.sh logs
+
+  dev:quack:logs:
+    desc: Tail managed LibreDash dev server logs with the local Quack profile
+    cmds:
+      - ./scripts/dev-profile.sh quack logs
 
   build:
     desc: Build browser assets

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -33,6 +33,27 @@ type fakeReloader struct {
 	prepareErr   error
 }
 
+type runtimeAssetMetrics struct {
+	fakeMetrics
+}
+
+func (runtimeAssetMetrics) WorkspaceAssets(workspaceID, deploymentID string) ([]workspace.Asset, []workspace.AssetEdge, bool) {
+	connection, err := workspace.NewAsset(
+		workspace.WorkspaceID(workspaceID),
+		workspace.DeploymentID(deploymentID),
+		workspace.AssetTypeConnection,
+		"quack.remote_quack",
+		"",
+		"remote_quack",
+		"Runtime connection",
+		map[string]any{"Kind": "quack"},
+	)
+	if err != nil {
+		return nil, nil, false
+	}
+	return []workspace.Asset{connection}, nil, true
+}
+
 func (r *fakeReloader) Reload(context.Context) error {
 	r.prepareCalls++
 	r.commitCalls++
@@ -390,6 +411,28 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 	}
 	if strings.Contains(body, `data-workspace-asset-toolbar`) {
 		t.Fatalf("connections page rendered workspace asset toolbar:\n%s", body)
+	}
+}
+
+func TestConnectionsPageFallsBackToRuntimeAssetsWithoutActiveDeployment(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	auth := NewAuth(accesssqlite.NewRepository(store.SQLDB()), "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(runtimeAssetMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	req := httptest.NewRequest(http.MethodGet, "/connections", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Connections", "remote_quack", "Runtime connection"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("connections page missing runtime asset %q:\n%s", want, body)
+		}
 	}
 }
 

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -376,19 +376,8 @@ func (s *Server) workspaceResponse(r *http.Request, workspaceID string) api.Work
 
 func (s *Server) workspaceAssetsAndEdges(r *http.Request, workspaceID string) ([]api.AssetResponse, []api.AssetEdgeResponse, error) {
 	if s.store == nil {
-		if provider, ok := s.metrics.(workspaceAssetProvider); ok {
-			assetRows, edgeRows, ok := provider.WorkspaceAssets(workspaceID, "local")
-			if ok {
-				assets := make([]api.AssetResponse, 0, len(assetRows))
-				for _, row := range assetRows {
-					assets = append(assets, assetDTOFromWorkspace(row))
-				}
-				edges := make([]api.AssetEdgeResponse, 0, len(edgeRows))
-				for _, row := range edgeRows {
-					edges = append(edges, assetEdgeDTOFromWorkspace(row))
-				}
-				return assets, edges, nil
-			}
+		if assets, edges, ok := s.workspaceAssetsFromRuntime(workspaceID); ok {
+			return assets, edges, nil
 		}
 		return fallbackAssets(s.metrics.Catalog(), workspaceID), nil, nil
 	}
@@ -401,6 +390,9 @@ func (s *Server) workspaceAssetsAndEdges(r *http.Request, workspaceID string) ([
 		return nil, nil, err
 	}
 	if !ok {
+		if assets, edges, ok := s.workspaceAssetsFromRuntime(workspaceID); ok {
+			return assets, edges, nil
+		}
 		return nil, nil, nil
 	}
 	assets := make([]api.AssetResponse, 0, len(graph.Assets))
@@ -412,6 +404,26 @@ func (s *Server) workspaceAssetsAndEdges(r *http.Request, workspaceID string) ([
 		edges = append(edges, assetEdgeDTOFromWorkspace(row))
 	}
 	return assets, edges, nil
+}
+
+func (s *Server) workspaceAssetsFromRuntime(workspaceID string) ([]api.AssetResponse, []api.AssetEdgeResponse, bool) {
+	provider, ok := s.metrics.(workspaceAssetProvider)
+	if !ok {
+		return nil, nil, false
+	}
+	assetRows, edgeRows, ok := provider.WorkspaceAssets(workspaceID, "local")
+	if !ok {
+		return nil, nil, false
+	}
+	assets := make([]api.AssetResponse, 0, len(assetRows))
+	for _, row := range assetRows {
+		assets = append(assets, assetDTOFromWorkspace(row))
+	}
+	edges := make([]api.AssetEdgeResponse, 0, len(edgeRows))
+	for _, row := range edgeRows {
+		edges = append(edges, assetEdgeDTOFromWorkspace(row))
+	}
+	return assets, edges, true
 }
 
 func (s *Server) roleBindingsAndRoles(r *http.Request, workspaceID string) ([]api.RoleBindingResponse, []api.RoleResponse, error) {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -63,7 +63,11 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 			return fmt.Errorf("initializing DuckDB metrics: %w", err)
 		}
 		defer metrics.Close()
-		server := app.New(metrics)
+		server, cleanup, err := localDevServer(ctx, metrics, cfg, opts.workspaceID)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
 		slog.Info("LibreDash listening", "url", "http://localhost"+addr)
 		return http.ListenAndServe(addr, server.Routes())
 	}
@@ -135,4 +139,47 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 	})
 	slog.Info("LibreDash listening", "url", "http://localhost"+addr)
 	return http.ListenAndServe(addr, server.Routes())
+}
+
+func localDevServer(ctx context.Context, metrics *dashboardruntime.Service, cfg config.Config, workspaceID string) (*app.Server, func(), error) {
+	config := agentConfig(cfg)
+	if !config.Enabled() {
+		return app.New(metrics), func() {}, nil
+	}
+
+	store, err := platform.Open(ctx, cfg.DBPath())
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() { _ = store.Close() }
+
+	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
+	if err := workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: workspace.WorkspaceID(workspaceID), Title: workspaceID}); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	accessRepo := accesssqlite.NewRepository(store.SQLDB())
+	agentRepo := agentappsqlite.NewRepository(store.SQLDB())
+	auth := app.NewAuth(accessRepo, workspaceID, app.AuthConfig{
+		DevBypass:    true,
+		CSRFKey:      cfg.CSRFKey,
+		CookieSecure: false,
+	})
+	server := app.NewWithOptions(metrics, app.Options{
+		Store:              store,
+		WorkspaceRepo:      workspaceRepo,
+		AccessRepo:         accessRepo,
+		Agent:              agentapp.NewService(metrics, agentRepo, config),
+		Auth:               auth,
+		DefaultWorkspaceID: workspaceID,
+	})
+	return server, cleanup, nil
+}
+
+func agentConfig(cfg config.Config) agentapp.Config {
+	return agentapp.Config{
+		APIKey:  cfg.AgentAPIKey,
+		BaseURL: cfg.AgentBaseURL,
+		Model:   cfg.AgentModel,
+	}
 }

--- a/scripts/dev-profile.sh
+++ b/scripts/dev-profile.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROFILE_ROOT="/Users/yacobolo/.config/libredash/profiles"
+
+usage() {
+  echo "Usage: $0 quack start|stop|status|logs" >&2
+}
+
+profile="${1:-}"
+action="${2:-}"
+
+if [[ -z "$profile" || -z "$action" ]]; then
+  usage
+  exit 2
+fi
+
+case "$profile" in
+  quack) ;;
+  *)
+    echo "Unsupported LibreDash dev profile: $profile" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+case "$action" in
+  start|stop|status|logs) ;;
+  *)
+    echo "Unsupported LibreDash dev profile action: $action" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+profile_dir="$PROFILE_ROOT/$profile"
+env_file="$profile_dir/env"
+secrets_file="$profile_dir/secrets.env"
+
+if [[ ! -f "$env_file" ]]; then
+  echo "Missing LibreDash dev profile env: $env_file" >&2
+  exit 1
+fi
+
+existing_quack_token="${LIBREDASH_QUACK_TOKEN:-}"
+existing_agent_api_key="${LIBREDASH_AGENT_API_KEY:-}"
+
+set -a
+# shellcheck source=/dev/null
+source "$env_file"
+if [[ -f "$secrets_file" ]]; then
+  # shellcheck source=/dev/null
+  source "$secrets_file"
+fi
+set +a
+
+if [[ -z "${LIBREDASH_QUACK_TOKEN:-}" && -n "$existing_quack_token" ]]; then
+  export LIBREDASH_QUACK_TOKEN="$existing_quack_token"
+fi
+if [[ -z "${LIBREDASH_AGENT_API_KEY:-}" && -n "$existing_agent_api_key" ]]; then
+  export LIBREDASH_AGENT_API_KEY="$existing_agent_api_key"
+fi
+
+for dir in "${LIBREDASH_HOME:-}" "${LIBREDASH_DUCKDB_DIR:-}" "${LIBREDASH_DATA_DIR:-}"; do
+  if [[ -n "$dir" ]]; then
+    mkdir -p "$dir"
+  fi
+done
+
+if [[ "$profile" == "quack" && "$action" == "start" ]]; then
+  if [[ -z "${LIBREDASH_QUACK_TOKEN:-}" ]]; then
+    echo "Missing LIBREDASH_QUACK_TOKEN. Add it to $secrets_file before running task dev:quack." >&2
+    exit 1
+  fi
+  if [[ -z "${LIBREDASH_AGENT_API_KEY:-}" ]]; then
+    echo "Missing LIBREDASH_AGENT_API_KEY. Add it to $secrets_file before running task dev:quack." >&2
+    exit 1
+  fi
+  if grep -q "replace-with-quack-host" "$profile_dir/model.yaml"; then
+    echo "Missing real Quack host. Update $profile_dir/model.yaml before running task dev:quack." >&2
+    exit 1
+  fi
+fi
+
+exec "$ROOT/scripts/dev-server.sh" "$action"

--- a/scripts/dev-profile.sh
+++ b/scripts/dev-profile.sh
@@ -68,6 +68,65 @@ for dir in "${LIBREDASH_HOME:-}" "${LIBREDASH_DUCKDB_DIR:-}" "${LIBREDASH_DATA_D
   fi
 done
 
+pid_cwd() {
+  local pid="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
+  elif [[ -e "/proc/$pid/cwd" ]]; then
+    readlink "/proc/$pid/cwd" 2>/dev/null || true
+  fi
+}
+
+stop_pid() {
+  local pid="$1"
+  local label="${2:-process}"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  echo "Stopping $label (pid $pid)"
+  kill "$pid" 2>/dev/null || true
+  for _ in {1..30}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "Force stopping $label (pid $pid)"
+  kill -KILL "$pid" 2>/dev/null || true
+}
+
+stop_profile_duckdb_locks() {
+  if [[ -z "${LIBREDASH_DUCKDB_DIR:-}" ]]; then
+    return 0
+  fi
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local db_file="$LIBREDASH_DUCKDB_DIR/libredash-$profile.duckdb"
+  [[ -e "$db_file" ]] || return 0
+
+  local pids
+  pids="$(lsof -t "$db_file" 2>/dev/null | sort -u || true)"
+  [[ -n "$pids" ]] || return 0
+
+  while read -r pid; do
+    [[ -n "$pid" ]] || continue
+    if [[ "$(pid_cwd "$pid")" == "$ROOT" ]]; then
+      stop_pid "$pid" "stale LibreDash $profile DuckDB lock holder"
+    fi
+  done <<< "$pids"
+
+  local remaining
+  remaining="$(lsof -t "$db_file" 2>/dev/null | sort -u || true)"
+  if [[ -n "$remaining" ]]; then
+    echo "LibreDash profile '$profile' DuckDB is still locked by another process: $remaining" >&2
+    echo "DuckDB file: $db_file" >&2
+    exit 1
+  fi
+}
+
 if [[ "$profile" == "quack" && "$action" == "start" ]]; then
   if [[ -z "${LIBREDASH_QUACK_TOKEN:-}" ]]; then
     echo "Missing LIBREDASH_QUACK_TOKEN. Add it to $secrets_file before running task dev:quack." >&2
@@ -83,4 +142,16 @@ if [[ "$profile" == "quack" && "$action" == "start" ]]; then
   fi
 fi
 
-exec "$ROOT/scripts/dev-server.sh" "$action"
+case "$action" in
+  start)
+    stop_profile_duckdb_locks
+    exec "$ROOT/scripts/dev-server.sh" "$action"
+    ;;
+  stop)
+    "$ROOT/scripts/dev-server.sh" "$action"
+    stop_profile_duckdb_locks
+    ;;
+  status|logs)
+    exec "$ROOT/scripts/dev-server.sh" "$action"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add hardcoded `task dev:quack` lifecycle tasks for the local Quack profile
- add `scripts/dev-profile.sh` to source profile env/secrets and run the managed dev server
- enable agent-backed local dev serving when agent credentials are configured

## Validation
- `bash -n scripts/dev-profile.sh`
- `task --list-all | rg 'dev:quack|^\\* dev:'`\n- `go test ./...`\n- verified Quack dashboard cross-filtering locally against real DuckLake-backed metadata\n\nNote: the actual Quack profile YAML and secrets remain local-only under `~/.config/libredash/profiles/quack` and are not included in this PR.