### PR TITLE
Refine asset detail surfaces

### DIFF
--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -389,7 +389,7 @@ func TestWorkspacePageDefaultsToTopLevelAssets(t *testing.T) {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"Executive Sales Dashboard", "Olist Commerce"} {
+	for _, want := range []string{"Executive Sales Dashboard", "Olist Commerce", "orders"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("workspace page missing top-level asset %q:\n%s", want, body)
 		}
@@ -464,8 +464,85 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 			t.Fatalf("connections page missing %q:\n%s", want, body)
 		}
 	}
+	if !strings.Contains(body, `/connections/asset_`) || !strings.Contains(body, `/details`) {
+		t.Fatalf("connections page did not link to canonical connection details:\n%s", body)
+	}
+	if strings.Contains(body, `/workspaces/test/assets/asset_`) {
+		t.Fatalf("connections page linked to workspace asset details:\n%s", body)
+	}
 	if strings.Contains(body, `data-workspace-asset-toolbar`) {
 		t.Fatalf("connections page rendered workspace asset toolbar:\n%s", body)
+	}
+}
+
+func TestConnectionAssetRoutesUseConnectionSurface(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+	connectionID := activeAssetID(t, store, "test", "connection", "olist.olist")
+
+	redirectReq := httptest.NewRequest(http.MethodGet, "/connections/"+connectionID, nil)
+	redirectReq.Header.Set("Authorization", "Bearer dev")
+	redirectRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(redirectRec, redirectReq)
+	if redirectRec.Code != http.StatusFound {
+		t.Fatalf("connection canonical redirect status = %d body=%s", redirectRec.Code, redirectRec.Body.String())
+	}
+	if got := redirectRec.Header().Get("Location"); got != "/connections/"+connectionID+"/details" {
+		t.Fatalf("connection redirect Location = %q, want /connections/%s/details", got, connectionID)
+	}
+
+	detailReq := httptest.NewRequest(http.MethodGet, "/connections/"+connectionID+"/details", nil)
+	detailReq.Header.Set("Authorization", "Bearer dev")
+	detailRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(detailRec, detailReq)
+	if detailRec.Code != http.StatusOK {
+		t.Fatalf("connection detail status = %d body=%s", detailRec.Code, detailRec.Body.String())
+	}
+	detailBody := detailRec.Body.String()
+	for _, want := range []string{"Connections", "olist", "Sources", "order_items", "Lineage"} {
+		if !strings.Contains(detailBody, want) {
+			t.Fatalf("connection detail missing %q:\n%s", want, detailBody)
+		}
+	}
+	for _, notWant := range []string{`Workspaces /`, `Back to workspace`} {
+		if strings.Contains(detailBody, notWant) {
+			t.Fatalf("connection detail rendered workspace chrome %q:\n%s", notWant, detailBody)
+		}
+	}
+
+	lineageReq := httptest.NewRequest(http.MethodGet, "/connections/"+connectionID+"/lineage", nil)
+	lineageReq.Header.Set("Authorization", "Bearer dev")
+	lineageRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(lineageRec, lineageReq)
+	if lineageRec.Code != http.StatusOK {
+		t.Fatalf("connection lineage status = %d body=%s", lineageRec.Code, lineageRec.Body.String())
+	}
+	if !strings.Contains(lineageRec.Body.String(), "ld-asset-lineage-graph") {
+		t.Fatalf("connection lineage did not render lineage graph:\n%s", lineageRec.Body.String())
+	}
+}
+
+func TestWorkspaceConnectionAssetRedirectsToConnectionSurface(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+	connectionID := activeAssetID(t, store, "test", "connection", "olist.olist")
+
+	req := httptest.NewRequest(http.MethodGet, "/workspaces/test/assets/"+connectionID+"/details", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("workspace connection detail status = %d, want redirect body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != "/connections/"+connectionID+"/details" {
+		t.Fatalf("workspace connection detail Location = %q, want /connections/%s/details", got, connectionID)
 	}
 }
 
@@ -916,6 +993,25 @@ func seedActiveDeployment(t *testing.T, store *platform.Store, workspaceID strin
 	if _, err := deploymentRepo.Activate(ctx, deployment.WorkspaceID(workspaceID), created.ID); err != nil {
 		t.Fatalf("activate deployment: %v", err)
 	}
+}
+
+func activeAssetID(t *testing.T, store *platform.Store, workspaceID, typ, key string) string {
+	t.Helper()
+	repo := workspacesqlite.NewRepository(store.SQLDB())
+	graph, ok, err := repo.ActiveDeploymentGraph(context.Background(), workspace.WorkspaceID(workspaceID))
+	if err != nil {
+		t.Fatalf("active deployment graph: %v", err)
+	}
+	if !ok {
+		t.Fatalf("workspace %q has no active deployment graph", workspaceID)
+	}
+	for _, asset := range graph.Assets {
+		if string(asset.Type) == typ && asset.Key == key {
+			return string(asset.ID)
+		}
+	}
+	t.Fatalf("asset %s %q not found in active graph", typ, key)
+	return ""
 }
 
 func zeroArtifact(deploymentID deployment.ID, workspaceID string) deployment.Artifact {

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -33,6 +33,8 @@ func (s *Server) Routes() http.Handler {
 		r.Post("/workspaces/{workspace}/permissions", s.protected(access.PermissionRBACManage, s.updateWorkspacePermission))
 		r.Post("/workspaces/{workspace}/permissions/remove", s.protected(access.PermissionRBACManage, s.removeWorkspacePermission))
 		r.Get("/connections", s.protected(access.PermissionDashboardView, s.connections))
+		r.Get("/connections/{asset}", s.protected(access.PermissionDashboardView, s.connectionAsset))
+		r.Get("/connections/{asset}/{section}", s.protected(access.PermissionDashboardView, s.connectionAssetSection))
 		dashboardHTTP := s.dashboardHTTP()
 		r.Get("/dashboards/{dashboard}", s.protected(access.PermissionDashboardView, dashboardHTTP.Dashboard))
 		r.Get("/dashboards/{dashboard}/pages/{page}", s.protected(access.PermissionDashboardView, dashboardHTTP.Page))

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -752,7 +752,17 @@ func safeAssetMeta(assetType, raw string) map[string]any {
 	case "source":
 		return pickMeta(content, "format", "Format", "path", "Path", "connection", "Connection", "object", "Object", "options", "Options")
 	case "model_table":
-		return pickMeta(content, "source", "Source", "primary_key", "PrimaryKey", "grain", "Grain")
+		return pickMeta(content,
+			"source", "Source",
+			"sources", "Sources",
+			"source_dependencies", "SourceDependencies",
+			"transform", "Transform",
+			"sql", "SQL",
+			"primary_key", "PrimaryKey",
+			"grain", "Grain",
+			"dimensions", "Dimensions",
+			"fields", "Fields",
+		)
 	case "measure":
 		return pickMeta(content, "expression", "Expression", "unit", "Unit", "format", "Format")
 	case "field":

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -92,16 +92,19 @@ func (s *Server) workspaceAsset(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if selected.Type == "connection" {
+		http.Redirect(w, r, connectionAssetSectionHref(assetID, "details"), http.StatusFound)
+		return
+	}
 	http.Redirect(w, r, "/workspaces/"+workspaceID+"/assets/"+assetID+"/details", http.StatusFound)
 }
 
 func (s *Server) workspaceAssetSection(w http.ResponseWriter, r *http.Request) {
 	section := chi.URLParam(r, "section")
+	redirectToDetails := false
 	if section == "definition" {
-		workspaceID := s.workspaceID(chi.URLParam(r, "workspace"))
-		assetID := chi.URLParam(r, "asset")
-		http.Redirect(w, r, "/workspaces/"+workspaceID+"/assets/"+assetID+"/details", http.StatusFound)
-		return
+		section = "details"
+		redirectToDetails = true
 	}
 	if !ui.ValidWorkspaceAssetSection(section) {
 		http.NotFound(w, r)
@@ -125,10 +128,59 @@ func (s *Server) workspaceAssetSection(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if selected.Type == "connection" {
+		http.Redirect(w, r, connectionAssetSectionHref(assetID, section), http.StatusFound)
+		return
+	}
+	if redirectToDetails {
+		http.Redirect(w, r, "/workspaces/"+workspaceID+"/assets/"+assetID+"/details", http.StatusFound)
+		return
+	}
 	workspace := s.workspaceResponse(r, workspaceID)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	if err := ui.WorkspaceAssetPage(s.metrics.Catalog(), workspace, selected, assets, edges, section, s.currentRoleLabel(r)).Render(w); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) connectionAsset(w http.ResponseWriter, r *http.Request) {
+	assetID := chi.URLParam(r, "asset")
+	http.Redirect(w, r, connectionAssetSectionHref(assetID, "details"), http.StatusFound)
+}
+
+func (s *Server) connectionAssetSection(w http.ResponseWriter, r *http.Request) {
+	section := chi.URLParam(r, "section")
+	if section == "definition" {
+		http.Redirect(w, r, connectionAssetSectionHref(chi.URLParam(r, "asset"), "details"), http.StatusFound)
+		return
+	}
+	if !ui.ValidWorkspaceAssetSection(section) {
+		http.NotFound(w, r)
+		return
+	}
+	workspaceID := s.workspaceID("")
+	assets, edges, err := s.workspaceAssetsAndEdges(r, workspaceID)
+	if err != nil {
+		http.Error(w, err.Error(), statusForNotFound(err))
+		return
+	}
+	assetID := chi.URLParam(r, "asset")
+	var selected api.AssetResponse
+	for _, asset := range assets {
+		if asset.ID == assetID {
+			selected = asset
+			break
+		}
+	}
+	if selected.ID == "" || selected.Type != "connection" {
+		http.NotFound(w, r)
+		return
+	}
+	workspace := s.workspaceResponse(r, workspaceID)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if err := ui.ConnectionAssetPage(s.metrics.Catalog(), workspace, selected, assets, edges, section, s.currentRoleLabel(r)).Render(w); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -811,9 +863,13 @@ func connectionsHref(query string) string {
 	return href + "?" + values.Encode()
 }
 
+func connectionAssetSectionHref(assetID, section string) string {
+	return "/connections/" + assetID + "/" + section
+}
+
 func isWorkspaceLandingAsset(typ string) bool {
 	switch typ {
-	case "dashboard", "semantic_model":
+	case "model_table", "semantic_model", "dashboard":
 		return true
 	default:
 		return false

--- a/internal/app/workspaces_test.go
+++ b/internal/app/workspaces_test.go
@@ -1,0 +1,29 @@
+package app
+
+import "testing"
+
+func TestSafeAssetMetaKeepsModelTableDefinition(t *testing.T) {
+	meta := safeAssetMeta("model_table", `{
+		"Source": "orders",
+		"Sources": ["orders", "payments"],
+		"SourceDependencies": ["orders", "payments"],
+		"Transform": {"SQL": "SELECT * FROM source.orders"},
+		"PrimaryKey": "order_id",
+		"Grain": "order_id",
+		"Dimensions": {"order_id": {"Expr": "order_id"}},
+		"Measures": {"revenue": {"Expression": "SUM(revenue)"}},
+		"Auth": {"token": "secret"}
+	}`)
+
+	for _, key := range []string{"Source", "Sources", "SourceDependencies", "Transform", "PrimaryKey", "Grain", "Dimensions"} {
+		if _, ok := meta[key]; !ok {
+			t.Fatalf("model table meta missing %s: %#v", key, meta)
+		}
+	}
+	if _, ok := meta["Measures"]; ok {
+		t.Fatalf("model table meta should not expose measures: %#v", meta)
+	}
+	if _, ok := meta["Auth"]; ok {
+		t.Fatalf("model table meta should not expose auth: %#v", meta)
+	}
+}

--- a/internal/ui/semantic_model_design_test.go
+++ b/internal/ui/semantic_model_design_test.go
@@ -42,12 +42,12 @@ func TestSemanticModelDesignDetailsVocabulary(t *testing.T) {
 	}
 	rendered := html.UnescapeString(out.String())
 
-	for _, want := range []string{"Model tables (1)", "Sources (1)", "Measures (1)", "Relationships (1)"} {
+	for _, want := range []string{"Model tables (1)", "Measures (1)", "Relationships (1)", "From table", "From field", "To table", "To field"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("semantic model details missing %q:\n%s", want, rendered)
 		}
 	}
-	for _, notWant := range []string{"Metric view", "Datasets", "Cache tables", "Cache table"} {
+	for _, notWant := range []string{"Sources (1)", "Connections (", "Fields (", "Metric view", "Datasets", "Cache tables", "Cache table"} {
 		if strings.Contains(rendered, notWant) {
 			t.Fatalf("semantic model details rendered legacy vocabulary %q:\n%s", notWant, rendered)
 		}

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -588,13 +588,8 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 	graph := assetLineageGraph{
 		Nodes: []assetLineageNode{lineageNode(workspaceID, selected, 0, true)},
 	}
-	usesRows := []map[string]any{}
-	usedByRows := []map[string]any{}
-
 	nodeIndex := map[string]int{selected.ID: 0}
 	seenEdges := map[string]struct{}{}
-	seenUseRows := map[string]struct{}{}
-	seenUsedByRows := map[string]struct{}{}
 
 	addNode := func(asset api.AssetResponse, rank int, selected bool) {
 		if asset.ID == "" {
@@ -640,11 +635,9 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 	}
 
 	type lineageWalkConfig struct {
-		edges    func(string) []api.AssetEdgeResponse
-		peerID   func(api.AssetEdgeResponse) string
-		rank     func(int) int
-		rows     *[]map[string]any
-		seenRows map[string]struct{}
+		edges  func(string) []api.AssetEdgeResponse
+		peerID func(api.AssetEdgeResponse) string
+		rank   func(int) int
 	}
 	var walkDependencyEdges func(assetID string, depth int, visiting map[string]struct{}, config lineageWalkConfig)
 	walkDependencyEdges = func(assetID string, depth int, visiting map[string]struct{}, config lineageWalkConfig) {
@@ -663,13 +656,6 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 			}
 			addNode(asset, config.rank(depth), false)
 			addEdge(edge)
-			if config.rows != nil {
-				key := lineageRelationRowKey(edge.Type, asset.ID)
-				if _, ok := config.seenRows[key]; !ok {
-					*config.rows = append(*config.rows, lineageTableRow(workspaceID, edge, asset))
-					config.seenRows[key] = struct{}{}
-				}
-			}
 			walkDependencyEdges(asset.ID, depth+1, visiting, config)
 		}
 	}
@@ -684,8 +670,6 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 		rank: func(depth int) int {
 			return -depth
 		},
-		rows:     &usesRows,
-		seenRows: seenUseRows,
 	}
 	downstreamWalk := lineageWalkConfig{
 		edges: func(assetID string) []api.AssetEdgeResponse {
@@ -697,12 +681,7 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 		rank: func(depth int) int {
 			return depth
 		},
-		rows:     &usedByRows,
-		seenRows: seenUsedByRows,
 	}
-	downstreamGraphWalk := downstreamWalk
-	downstreamGraphWalk.rows = nil
-	downstreamGraphWalk.seenRows = nil
 
 	for _, rootID := range lineageDependencyRootIDs(selected, outgoing, byID) {
 		if rootID != selected.ID {
@@ -710,39 +689,17 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 		}
 		walkDependencyEdges(rootID, 1, map[string]struct{}{}, upstreamWalk)
 		if rootID != selected.ID {
-			walkDependencyEdges(rootID, 1, map[string]struct{}{}, downstreamGraphWalk)
+			walkDependencyEdges(rootID, 1, map[string]struct{}{}, downstreamWalk)
 		}
 	}
 	walkDependencyEdges(selected.ID, 1, map[string]struct{}{}, downstreamWalk)
 	addContainsContext(selected.ID, &graph, nodeIndex, byID, edges, addNode, addEdge)
 
-	if len(usesRows)+len(usedByRows) == 0 {
-		for _, edge := range sortedLineageEdges(outgoing[selected.ID], byID) {
-			if !isContainsEdge(edge) {
-				continue
-			}
-			asset, ok := byID[edge.ToAssetID]
-			if ok {
-				usesRows = append(usesRows, lineageTableRow(workspaceID, edge, asset))
-			}
-		}
-		for _, edge := range sortedLineageEdges(incoming[selected.ID], byID) {
-			if !isContainsEdge(edge) {
-				continue
-			}
-			asset, ok := byID[edge.FromAssetID]
-			if ok {
-				usedByRows = append(usedByRows, lineageTableRow(workspaceID, edge, asset))
-			}
-		}
-	}
-
 	sortLineageNodes(graph.Nodes)
 	sortLineageGraphEdges(graph.Edges)
-	sortLineageRows(usesRows)
-	sortLineageRows(usedByRows)
 	collapsedGraph := collapsedAssetLineageGraph(workspaceID, selected, graph, byID)
 	enrichAssetLineageGraph(collapsedGraph, byID, edges)
+	usesRows, usedByRows := lineageTablesFromGraph(workspaceID, selected, collapsedGraph, byID)
 	return assetLineageModel{
 		Count:  len(usesRows) + len(usedByRows),
 		Graph:  collapsedGraph,
@@ -888,30 +845,10 @@ func collapsedAssetLineageGraph(workspaceID string, selected api.AssetResponse, 
 		})
 	}
 
-	measureDashboardPairs := map[string]struct{}{}
-	for _, edge := range candidates {
-		if edge.source == "" || edge.target == "" {
-			continue
-		}
-		source := assets[edge.source]
-		target := assets[edge.target]
-		if source.Type == "measure" && target.Type == "dashboard" {
-			semanticModel, ok := assets[source.ParentID]
-			if ok && semanticModel.Type == "semantic_model" {
-				measureDashboardPairs[lineageProjectionPairKey(semanticModel.ID, target.ID)] = struct{}{}
-			}
-		}
-	}
-
 	seenEdges := map[string]struct{}{}
 	for _, edge := range candidates {
 		source := assets[edge.source]
 		target := assets[edge.target]
-		if source.Type == "semantic_model" && target.Type == "dashboard" {
-			if _, ok := measureDashboardPairs[lineageProjectionPairKey(source.ID, target.ID)]; ok {
-				continue
-			}
-		}
 		if lineageVisualLayer(source.Type) >= lineageVisualLayer(target.Type) {
 			continue
 		}
@@ -931,10 +868,6 @@ func collapsedAssetLineageGraph(workspaceID string, selected api.AssetResponse, 
 	sortLineageNodes(out.Nodes)
 	sortLineageGraphEdges(out.Edges)
 	return out
-}
-
-func lineageProjectionPairKey(sourceID, targetID string) string {
-	return sourceID + "|" + targetID
 }
 
 func edgesByFromAsset(edges []api.AssetEdgeResponse) map[string][]api.AssetEdgeResponse {
@@ -959,9 +892,58 @@ func sortLineageRows(rows []map[string]any) {
 	})
 }
 
-func lineageTableRow(workspaceID string, edge api.AssetEdgeResponse, peer api.AssetResponse) map[string]any {
+func lineageTablesFromGraph(workspaceID string, selected api.AssetResponse, graph assetLineageGraph, assets map[string]api.AssetResponse) ([]map[string]any, []map[string]any) {
+	anchorID := selected.ID
+	if selected.Type != "catalog" {
+		if anchor, ok := lineageVisibleAnchor(selected, assets); ok {
+			anchorID = anchor.ID
+		}
+	}
+	usesRows := []map[string]any{}
+	usedByRows := []map[string]any{}
+	hasDependencyEdges := false
+	for _, edge := range graph.Edges {
+		if edge.Kind != "contains" {
+			hasDependencyEdges = true
+			break
+		}
+	}
+	for _, edge := range graph.Edges {
+		if hasDependencyEdges {
+			if edge.Kind == "contains" {
+				continue
+			}
+			if edge.Target == anchorID {
+				if peer, ok := assets[edge.Source]; ok {
+					usesRows = append(usesRows, lineageGraphTableRow(workspaceID, edge, peer))
+				}
+			}
+			if edge.Source == anchorID {
+				if peer, ok := assets[edge.Target]; ok {
+					usedByRows = append(usedByRows, lineageGraphTableRow(workspaceID, edge, peer))
+				}
+			}
+			continue
+		}
+		if edge.Source == anchorID {
+			if peer, ok := assets[edge.Target]; ok {
+				usesRows = append(usesRows, lineageGraphTableRow(workspaceID, edge, peer))
+			}
+		}
+		if edge.Target == anchorID {
+			if peer, ok := assets[edge.Source]; ok {
+				usedByRows = append(usedByRows, lineageGraphTableRow(workspaceID, edge, peer))
+			}
+		}
+	}
+	sortLineageRows(usesRows)
+	sortLineageRows(usedByRows)
+	return usesRows, usedByRows
+}
+
+func lineageGraphTableRow(workspaceID string, edge assetLineageEdge, peer api.AssetResponse) map[string]any {
 	return map[string]any{
-		"relation":  labelFromKey(edge.Type),
+		"relation":  firstNonEmpty(edge.Label, labelFromKey(edge.Kind)),
 		"asset":     assetTitle(peer),
 		"assetHref": lineageAssetHref(workspaceID, peer),
 		"type":      assetTypeLabel(peer.Type),
@@ -1072,8 +1054,7 @@ var lineageProjectionLayers = []lineageProjectionLayerPolicy{
 	{assetType: "source", layer: 1},
 	{assetType: "model_table", layer: 2},
 	{assetType: "semantic_model", layer: 3},
-	{assetType: "measure", layer: 4},
-	{assetType: "dashboard", layer: 5},
+	{assetType: "dashboard", layer: 4},
 }
 
 func lineageVisualLayer(typ string) int {
@@ -1111,16 +1092,6 @@ var lineageProjectionEdges = []lineageProjectionEdgePolicy{
 		key:   lineageProjectionEdgeKey{sourceType: "model_table", targetType: "semantic_model"},
 		kind:  "lineage_model_table_semantic_model",
 		label: "Feeds semantic model",
-	},
-	{
-		key:   lineageProjectionEdgeKey{sourceType: "semantic_model", targetType: "measure"},
-		kind:  "lineage_semantic_model_measure",
-		label: "Defines measure",
-	},
-	{
-		key:   lineageProjectionEdgeKey{sourceType: "measure", targetType: "dashboard"},
-		kind:  "lineage_measure_dashboard",
-		label: "Used in dashboard",
 	},
 	{
 		key:   lineageProjectionEdgeKey{sourceType: "semantic_model", targetType: "dashboard"},
@@ -1211,10 +1182,6 @@ func lineageEdgeKey(edge api.AssetEdgeResponse) string {
 		return edge.ID
 	}
 	return edge.FromAssetID + "|" + edge.ToAssetID + "|" + edge.Type
-}
-
-func lineageRelationRowKey(edgeType, peerID string) string {
-	return edgeType + "|" + peerID
 }
 
 func sortedLineageEdges(edges []api.AssetEdgeResponse, assets map[string]api.AssetResponse) []api.AssetEdgeResponse {
@@ -1324,7 +1291,7 @@ func assetDetailModelForAsset(workspace api.WorkspaceResponse, asset api.AssetRe
 	}
 	switch asset.Type {
 	case "semantic_model":
-		semanticModelDetailModel(&model, workspace, asset, assets, edges)
+		semanticModelDetailModel(&model, workspace, asset, assets)
 	case "dashboard":
 		dashboardDetailModel(&model, asset, assets)
 	case "connection":
@@ -1362,30 +1329,20 @@ func shouldShowParentFact(typ string) bool {
 	}
 }
 
-func semanticModelDetailModel(model *assetDetailModel, workspace api.WorkspaceResponse, asset api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse) {
+func semanticModelDetailModel(model *assetDetailModel, workspace api.WorkspaceResponse, asset api.AssetResponse, assets []api.AssetResponse) {
 	meta := asset.Meta
-	connections := sortedMapKeys(metaMap(meta, "Connections", "connections"))
-	sources := sortedMapKeys(metaMap(meta, "Sources", "sources"))
 	modelTableMeta := metaMap(meta, "Tables", "tables", "Models", "models")
 	modelTables := sortedMapKeys(modelTableMeta)
-	fields := semanticFieldCount(modelTableMeta)
 	measures := sortedMapKeys(metaMap(meta, "Measures", "measures"))
 	relationships := metaSlice(meta, "Relationships", "relationships")
 
 	model.Overview = append(model.Overview,
-		definitionFact{Label: "Default connection", Value: metaString(meta, "DefaultConnection", "default_connection")},
-		definitionFact{Label: "Connections", Value: fmt.Sprint(len(connections))},
-		definitionFact{Label: "Sources", Value: fmt.Sprint(len(sources))},
 		definitionFact{Label: "Model tables", Value: fmt.Sprint(len(modelTables))},
-		definitionFact{Label: "Fields", Value: fmt.Sprint(fields)},
 		definitionFact{Label: "Measures", Value: fmt.Sprint(len(measures))},
 		definitionFact{Label: "Relationships", Value: fmt.Sprint(len(relationships))},
 	)
 	model.Sections = append(model.Sections,
-		assetDetailSection{Title: fmt.Sprintf("Connections (%d)", len(connections)), Signal: "assetDetailsSemanticConnectionsGrid", Grid: semanticConnectionsGrid(workspace.ID, asset, assets, meta)},
-		assetDetailSection{Title: fmt.Sprintf("Sources (%d)", len(sources)), Signal: "assetDetailsSemanticSourcesGrid", Grid: semanticSourcesGrid(workspace.ID, asset, assets, meta)},
-		assetDetailSection{Title: fmt.Sprintf("Model tables (%d)", len(modelTables)), Signal: "assetDetailsSemanticModelTablesGrid", Grid: semanticModelTablesGrid(workspace.ID, asset, assets, edges, meta)},
-		assetDetailSection{Title: fmt.Sprintf("Fields (%d)", fields), Signal: "assetDetailsSemanticFieldsGrid", Grid: semanticFieldsGrid(workspace.ID, asset, assets, meta)},
+		assetDetailSection{Title: fmt.Sprintf("Model tables (%d)", len(modelTables)), Signal: "assetDetailsSemanticModelTablesGrid", Grid: semanticModelTablesGrid(workspace.ID, asset, assets, meta)},
 		assetDetailSection{Title: fmt.Sprintf("Measures (%d)", len(measures)), Signal: "assetDetailsSemanticMeasuresGrid", Grid: semanticMeasuresGrid(workspace.ID, asset, assets, meta)},
 		assetDetailSection{Title: fmt.Sprintf("Relationships (%d)", len(relationships)), Signal: "assetDetailsSemanticRelationshipsGrid", Grid: semanticRelationshipsGrid(workspace.ID, asset, assets, meta)},
 	)
@@ -1466,35 +1423,51 @@ func semanticSourcesGrid(workspaceID string, parent api.AssetResponse, assets []
 	}
 }
 
-func semanticModelTablesGrid(workspaceID string, parent api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse, meta map[string]any) metricGrid {
+func semanticModelTablesGrid(workspaceID string, parent api.AssetResponse, assets []api.AssetResponse, meta map[string]any) metricGrid {
 	tables := metaMap(meta, "Tables", "tables", "Models", "models")
+	measureCounts := semanticMeasureCountsByTable(metaMap(meta, "Measures", "measures"))
 	rows := make([]map[string]any, 0, len(tables))
 	for _, name := range sortedMapKeys(tables) {
 		table := asMap(tables[name])
 		child := semanticAssetByName(parent.Key, "model_table", name, assets)
-		sourceName := metaString(table, "Source", "source")
 		rows = append(rows, map[string]any{
 			"name":        name,
 			"nameHref":    childHref(workspaceID, child),
-			"source":      emptyDash(sourceName),
 			"primary_key": emptyDash(metaString(table, "PrimaryKey", "primary_key")),
+			"fields":      len(metaMap(table, "Dimensions", "dimensions", "Fields", "fields")),
+			"measures":    measureCounts[name],
 			"description": emptyDash(metaString(table, "Description", "description")),
-			"reads":       strings.Join(dependentAssetNames(child.ID, "reads_source", assets, edges), ", "),
-			"sql":         sqlPreview(firstNonEmpty(metaString(table, "SQL", "sql"), metaString(asMap(metaValue(table, "Transform", "transform")), "SQL", "sql"))),
 		})
 	}
 	return metricGrid{
 		Columns: []metricGridColumn{
 			{ID: "name", Header: "Name", Kind: "link", HrefKey: "nameHref", Width: "180px"},
-			{ID: "source", Header: "Source", Kind: "code", Width: "160px"},
 			{ID: "primary_key", Header: "Primary key", Kind: "code", Width: "150px"},
-			{ID: "reads", Header: "Reads", Kind: "expression", Width: "220px"},
-			{ID: "sql", Header: "SQL preview", Kind: "expression"},
+			{ID: "fields", Header: "Fields", Width: "100px"},
+			{ID: "measures", Header: "Measures", Width: "110px"},
+			{ID: "description", Header: "Description"},
 		},
 		Rows:     rows,
 		Empty:    "No model tables are defined for this semantic model.",
-		MinWidth: "980px",
+		MinWidth: "860px",
 	}
+}
+
+func semanticMeasureCountsByTable(measures map[string]any) map[string]int {
+	counts := map[string]int{}
+	defaultTable := metaString(asMap(metaValue(measures, "Defaults", "defaults")), "Table", "table")
+	for _, name := range sortedMapKeys(measures) {
+		if strings.EqualFold(name, "defaults") {
+			continue
+		}
+		measure := asMap(measures[name])
+		table := firstNonEmpty(metaString(measure, "Table", "table"), defaultTable)
+		if table == "" {
+			continue
+		}
+		counts[table]++
+	}
+	return counts
 }
 
 func semanticFieldsGrid(workspaceID string, parent api.AssetResponse, assets []api.AssetResponse, meta map[string]any) metricGrid {
@@ -1569,27 +1542,41 @@ func semanticRelationshipsGrid(workspaceID string, parent api.AssetResponse, ass
 		relationship := asMap(item)
 		id := metaString(relationship, "ID", "id")
 		child := semanticAssetByName(parent.Key, "relationship", id, assets)
+		fromTable, fromField := splitSemanticFieldRef(metaString(relationship, "From", "from"))
+		toTable, toField := splitSemanticFieldRef(metaString(relationship, "To", "to"))
 		rows = append(rows, map[string]any{
 			"id":          id,
 			"idHref":      childHref(workspaceID, child),
-			"from":        metaString(relationship, "From", "from"),
-			"to":          metaString(relationship, "To", "to"),
+			"from_table":  emptyDash(fromTable),
+			"from_field":  emptyDash(fromField),
+			"to_table":    emptyDash(toTable),
+			"to_field":    emptyDash(toField),
 			"cardinality": metricGridBadgeValue(metaString(relationship, "Cardinality", "cardinality"), "muted"),
 			"active":      metricGridBadgeValue(boolLabel(metaBool(relationship, "Active", "active")), "success"),
 		})
 	}
 	return metricGrid{
 		Columns: []metricGridColumn{
-			{ID: "id", Header: "ID", Kind: "link", HrefKey: "idHref", Width: "190px"},
-			{ID: "from", Header: "From", Kind: "code", Width: "240px"},
-			{ID: "to", Header: "To", Kind: "code", Width: "240px"},
+			{ID: "id", Header: "ID", Kind: "link", HrefKey: "idHref", Width: "180px"},
+			{ID: "from_table", Header: "From table", Kind: "code", Width: "140px"},
+			{ID: "from_field", Header: "From field", Kind: "code", Width: "160px"},
+			{ID: "to_table", Header: "To table", Kind: "code", Width: "140px"},
+			{ID: "to_field", Header: "To field", Kind: "code", Width: "160px"},
 			{ID: "cardinality", Header: "Cardinality", Kind: "badge", Width: "140px"},
 			{ID: "active", Header: "Active", Kind: "badge", Width: "90px"},
 		},
 		Rows:     rows,
 		Empty:    "No relationships are defined for this semantic model.",
-		MinWidth: "900px",
+		MinWidth: "1010px",
 	}
+}
+
+func splitSemanticFieldRef(ref string) (string, string) {
+	parts := strings.SplitN(strings.TrimSpace(ref), ".", 2)
+	if len(parts) != 2 {
+		return strings.TrimSpace(ref), ""
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 }
 
 func dashboardDetailModel(model *assetDetailModel, asset api.AssetResponse, assets []api.AssetResponse) {

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -112,6 +112,9 @@ func WorkspaceAssetPage(catalog dashboard.Catalog, workspace api.WorkspaceRespon
 	extraHead := []g.Node{
 		h.Script(h.Type("module"), h.Src(staticAsset("/static/data-grid.js"))),
 	}
+	if activeSection == "details" && assetDetailUsesCodeBlock(asset) {
+		extraHead = append(extraHead, h.Script(h.Type("module"), h.Src(staticAsset("/static/code-block.js"))))
+	}
 	if activeSection == "lineage" {
 		extraHead = append(extraHead,
 			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/asset-lineage-graph.css"))),
@@ -1268,6 +1271,8 @@ type assetDetailSection struct {
 	Signal string
 	Grid   metricGrid
 	Facts  []definitionFact
+	Code   string
+	Lang   string
 }
 
 func assetDetailsSection(workspace api.WorkspaceResponse, asset api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse) g.Node {
@@ -1279,10 +1284,17 @@ func assetDetailsSection(workspace api.WorkspaceResponse, asset api.AssetRespons
 }
 
 func assetDetailSectionNode(section assetDetailSection) g.Node {
+	if section.Code != "" {
+		return definitionCodeBlock(section.Title, section.Lang, section.Code)
+	}
 	if section.Signal != "" {
 		return definitionSignalGrid(section.Title, section.Signal)
 	}
 	return definitionFacts(section.Title, section.Facts)
+}
+
+func assetDetailUsesCodeBlock(asset api.AssetResponse) bool {
+	return asset.Type == "model_table" && modelTableSQL(asset.Meta) != ""
 }
 
 func assetDetailModelForAsset(workspace api.WorkspaceResponse, asset api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse) assetDetailModel {
@@ -1292,6 +1304,8 @@ func assetDetailModelForAsset(workspace api.WorkspaceResponse, asset api.AssetRe
 	switch asset.Type {
 	case "semantic_model":
 		semanticModelDetailModel(&model, workspace, asset, assets)
+	case "model_table":
+		modelTableDetailModel(&model, workspace, asset, assets)
 	case "dashboard":
 		dashboardDetailModel(&model, asset, assets)
 	case "connection":
@@ -1322,7 +1336,7 @@ func commonAssetOverviewFacts(asset api.AssetResponse, assets []api.AssetRespons
 
 func shouldShowParentFact(typ string) bool {
 	switch typ {
-	case "catalog", "connection", "dashboard", "semantic_model":
+	case "catalog", "connection", "dashboard", "model_table", "semantic_model":
 		return false
 	default:
 		return true
@@ -1468,6 +1482,91 @@ func semanticMeasureCountsByTable(measures map[string]any) map[string]int {
 		counts[table]++
 	}
 	return counts
+}
+
+func modelTableDetailModel(model *assetDetailModel, workspace api.WorkspaceResponse, asset api.AssetResponse, assets []api.AssetResponse) {
+	modelKey, tableName := modelTableKeyParts(asset)
+	fields := modelTableFields(asset.Meta)
+	sources := modelTableSourceNames(asset.Meta)
+	mode := "Unspecified"
+	if modelTableSQL(asset.Meta) != "" {
+		mode = "Transform"
+	} else if metaString(asset.Meta, "Source", "source") != "" {
+		mode = "Direct source"
+	}
+	semanticModel := assetByTypeKey("semantic_model", modelKey, assets)
+	model.Overview = append(model.Overview,
+		definitionFact{Label: "Semantic model", Value: assetTitle(semanticModel)},
+		definitionFact{Label: "Primary key", Value: metaString(asset.Meta, "PrimaryKey", "primary_key"), Code: true},
+		definitionFact{Label: "Grain", Value: metaString(asset.Meta, "Grain", "grain"), Code: true},
+		definitionFact{Label: "Fields", Value: fmt.Sprint(len(fields))},
+		definitionFact{Label: "Input sources", Value: fmt.Sprint(len(sources))},
+		definitionFact{Label: "Mode", Value: mode},
+	)
+	model.Sections = append(model.Sections,
+		assetDetailSection{Title: fmt.Sprintf("Fields (%d)", len(fields)), Signal: "assetDetailsModelTableFieldsGrid", Grid: modelTableFieldsGrid(workspace.ID, modelKey, tableName, fields, assets)},
+	)
+	if sql := modelTableSQL(asset.Meta); sql != "" {
+		model.Sections = append(model.Sections, assetDetailSection{Title: "SQL", Lang: "sql", Code: sql})
+	}
+}
+
+func modelTableKeyParts(asset api.AssetResponse) (string, string) {
+	parts := strings.SplitN(asset.Key, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", asset.Key
+}
+
+func modelTableFields(meta map[string]any) map[string]any {
+	return metaMap(meta, "Dimensions", "dimensions", "Fields", "fields")
+}
+
+func modelTableSourceNames(meta map[string]any) []string {
+	if source := metaString(meta, "Source", "source"); source != "" {
+		return []string{source}
+	}
+	for _, value := range []any{
+		metaValue(meta, "SourceDependencies", "source_dependencies"),
+		metaValue(meta, "Sources", "sources"),
+	} {
+		sources := stringSlice(value)
+		if len(sources) > 0 {
+			sort.Strings(sources)
+			return sources
+		}
+	}
+	return nil
+}
+
+func modelTableSQL(meta map[string]any) string {
+	return firstNonEmpty(
+		metaString(metaMap(meta, "Transform", "transform"), "SQL", "sql"),
+		metaString(meta, "SQL", "sql"),
+	)
+}
+
+func modelTableFieldsGrid(workspaceID, modelKey, tableName string, fields map[string]any, assets []api.AssetResponse) metricGrid {
+	rows := make([]map[string]any, 0, len(fields))
+	for _, name := range sortedMapKeys(fields) {
+		field := asMap(fields[name])
+		child := assetByTypeKey("field", modelKey+"."+tableName+"."+name, assets)
+		rows = append(rows, map[string]any{
+			"name":     name,
+			"nameHref": childHref(workspaceID, child),
+			"type":     metricGridBadgeValue(metaString(field, "Type", "type"), "muted"),
+		})
+	}
+	return metricGrid{
+		Columns: []metricGridColumn{
+			{ID: "name", Header: "Name", Kind: "link", HrefKey: "nameHref", Width: "170px"},
+			{ID: "type", Header: "Type", Kind: "badge", Width: "110px"},
+		},
+		Rows:     rows,
+		Empty:    "No fields are defined for this model table.",
+		MinWidth: "420px",
+	}
 }
 
 func semanticFieldsGrid(workspaceID string, parent api.AssetResponse, assets []api.AssetResponse, meta map[string]any) metricGrid {
@@ -1800,6 +1899,16 @@ func definitionFacts(title string, facts []definitionFact) g.Node {
 	)
 }
 
+func definitionCodeBlock(title, lang, code string) g.Node {
+	return h.Section(h.Class("grid min-w-0 content-start gap-3 border-b border-outline-muted pb-5 last:border-b-0"), h.Aria("label", title),
+		h.H2(h.Class("m-0 text-body-sm font-semibold text-fg-default"), g.Text(title)),
+		g.El("ld-code-block",
+			g.Attr("language", firstNonEmpty(lang, "text")),
+			g.Attr("code", code),
+		),
+	)
+}
+
 func definitionStats(title string, facts []definitionFact) g.Node {
 	filtered := make([]definitionFact, 0, len(facts))
 	for _, fact := range facts {
@@ -2074,14 +2183,6 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func sqlPreview(sql string) string {
-	sql = strings.Join(strings.Fields(sql), " ")
-	if len(sql) > 160 {
-		return sql[:157] + "..."
-	}
-	return sql
 }
 
 func childAssetByName(parentID, typ, name string, assets []api.AssetResponse) api.AssetResponse {

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -135,6 +135,35 @@ func WorkspaceAssetPage(catalog dashboard.Catalog, workspace api.WorkspaceRespon
 	)
 }
 
+func ConnectionAssetPage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, asset api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse, activeSection, roleLabel string) g.Node {
+	activeSection = normalizeWorkspaceAssetSection(activeSection)
+	lineage := assetLineage(workspace.ID, asset, assets, edges)
+	extraHead := []g.Node{
+		h.Script(h.Type("module"), h.Src(staticAsset("/static/data-grid.js"))),
+	}
+	if activeSection == "lineage" {
+		extraHead = append(extraHead,
+			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/asset-lineage-graph.css"))),
+			h.Script(h.Type("module"), h.Src(staticAsset("/static/asset-lineage-graph.js"))),
+		)
+	}
+	return workspaceDocument(asset.Title, catalog, "connections", roleLabel, workspaceAssetSignals(workspace, asset, assets, edges, lineage, activeSection),
+		h.Section(h.Class(metricMainClass), h.Aria("label", "Connection asset detail"),
+			connectionBreadcrumbHeader(asset),
+			h.Div(h.Class(metricContentColumnClass),
+				connectionAssetDetailTabs(asset.ID, activeSection, lineage.Count),
+				h.Div(h.Class(assetDetailBodyClass(activeSection)),
+					g.If(activeSection == "details",
+						assetDetailsSection(workspace, asset, assets, edges),
+					),
+					g.If(activeSection == "lineage", assetLineageSection(lineage)),
+				),
+			),
+		),
+		extraHead...,
+	)
+}
+
 func assetBreadcrumbHeader(workspace api.WorkspaceResponse, asset api.AssetResponse) g.Node {
 	return h.Header(h.Class("grid min-w-0 grid-cols-workspace-header items-center gap-2 border-b border-outline-muted px-4 py-2.5"),
 		h.Nav(h.Class("min-w-0"), h.Aria("label", "Breadcrumb"),
@@ -147,6 +176,19 @@ func assetBreadcrumbHeader(workspace api.WorkspaceResponse, asset api.AssetRespo
 			),
 		),
 		h.Div(h.Class("inline-flex min-w-0 items-center justify-end gap-2"), assetActions(workspace.ID, asset)),
+	)
+}
+
+func connectionBreadcrumbHeader(asset api.AssetResponse) g.Node {
+	return h.Header(h.Class("grid min-w-0 grid-cols-workspace-header items-center gap-2 border-b border-outline-muted px-4 py-2.5"),
+		h.Nav(h.Class("min-w-0"), h.Aria("label", "Breadcrumb"),
+			h.Ol(h.Class("flex min-w-0 flex-wrap items-center gap-1.5 text-body-sm font-medium leading-snug"),
+				breadcrumbLink("Connections", "/connections"),
+				breadcrumbSeparator(),
+				assetBreadcrumbCurrent(asset),
+			),
+		),
+		h.Div(h.Class("inline-flex min-w-0 items-center justify-end gap-2"), connectionAssetActions()),
 	)
 }
 
@@ -268,7 +310,7 @@ func activeDeploymentLabel(workspace api.WorkspaceResponse) string {
 }
 
 func assetToolbar(workspaceID, activeType, query string, assets []api.AssetResponse) g.Node {
-	types := []string{"", "dashboard", "semantic_model"}
+	types := []string{"", "model_table", "semantic_model", "dashboard"}
 	return h.Div(h.Class("grid min-w-0 gap-3 border-b border-outline-variant bg-app px-3 pt-3"), g.Attr("data-workspace-asset-toolbar", ""),
 		h.Form(h.Method("get"), h.Action("/workspaces/"+workspaceID), h.Class("flex min-w-0 max-w-workspace-search items-center gap-2"),
 			h.Input(h.Type("search"), h.Name("q"), h.Value(query), h.Placeholder("Search workspace assets..."), h.Class("min-h-control-md w-full rounded-small border border-outline-variant bg-control px-3 text-body-sm font-medium text-fg-default placeholder:text-fg-muted")),
@@ -383,7 +425,7 @@ func assetCell(className string, children ...g.Node) g.Node {
 }
 
 func assetRow(workspaceID string, asset api.AssetResponse, assetIndex map[string]api.AssetResponse) g.Node {
-	detailHref := workspaceAssetSectionHref(workspaceID, asset.ID, "details")
+	detailHref := assetCanonicalSectionHref(workspaceID, asset, "details")
 	openHref := detailHref
 	if asset.Href != "" {
 		openHref = asset.Href
@@ -429,10 +471,23 @@ func assetActions(workspaceID string, asset api.AssetResponse) g.Node {
 	)
 }
 
+func connectionAssetActions() g.Node {
+	return h.Div(h.Class("inline-flex min-w-0 items-center justify-end gap-2"),
+		h.A(h.Class(metricActionButtonClass), h.Href("/connections"), h.Title("Back to connections"), h.Aria("label", "Back to connections"), lucide.ArrowLeft(metricActionIconAttrs()...)),
+	)
+}
+
 func assetDetailTabs(workspaceID, assetID, activeSection string, relatedCount int) g.Node {
 	return h.Nav(h.Class("flex min-w-0 gap-6 border-b border-outline-variant bg-app px-3"), h.Aria("label", "Workspace asset sections"),
 		assetDetailTabLink(workspaceAssetSectionHref(workspaceID, assetID, "details"), activeSection == "details", "Details", nil),
 		assetDetailTabLink(workspaceAssetSectionHref(workspaceID, assetID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
+	)
+}
+
+func connectionAssetDetailTabs(assetID, activeSection string, relatedCount int) g.Node {
+	return h.Nav(h.Class("flex min-w-0 gap-6 border-b border-outline-variant bg-app px-3"), h.Aria("label", "Connection asset sections"),
+		assetDetailTabLink(connectionAssetSectionHref(assetID, "details"), activeSection == "details", "Details", nil),
+		assetDetailTabLink(connectionAssetSectionHref(assetID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
 	)
 }
 
@@ -1218,11 +1273,22 @@ func absInt(value int) int {
 }
 
 func lineageAssetHref(workspaceID string, asset api.AssetResponse) string {
-	return workspaceAssetSectionHref(workspaceID, asset.ID, "details")
+	return assetCanonicalSectionHref(workspaceID, asset, "details")
 }
 
 func workspaceAssetSectionHref(workspaceID, assetID, section string) string {
 	return "/workspaces/" + workspaceID + "/assets/" + assetID + "/" + section
+}
+
+func connectionAssetSectionHref(assetID, section string) string {
+	return "/connections/" + assetID + "/" + section
+}
+
+func assetCanonicalSectionHref(workspaceID string, asset api.AssetResponse, section string) string {
+	if asset.Type == "connection" {
+		return connectionAssetSectionHref(asset.ID, section)
+	}
+	return workspaceAssetSectionHref(workspaceID, asset.ID, section)
 }
 
 type assetDetailModel struct {
@@ -1262,7 +1328,7 @@ func assetDetailModelForAsset(workspace api.WorkspaceResponse, asset api.AssetRe
 	case "dashboard":
 		dashboardDetailModel(&model, asset, assets)
 	case "connection":
-		model.Overview = append(model.Overview, connectionFacts(asset)...)
+		connectionDetailModel(&model, workspace, asset, assets, edges)
 	case "source":
 		model.Overview = append(model.Overview, sourceFacts(asset)...)
 	case "measure":
@@ -1289,7 +1355,7 @@ func commonAssetOverviewFacts(asset api.AssetResponse, assets []api.AssetRespons
 
 func shouldShowParentFact(typ string) bool {
 	switch typ {
-	case "catalog", "dashboard", "semantic_model":
+	case "catalog", "connection", "dashboard", "semantic_model":
 		return false
 	default:
 		return true
@@ -1649,6 +1715,43 @@ func dashboardTablesGrid(parent api.AssetResponse, tables []api.AssetResponse) m
 	}
 }
 
+func connectionDetailModel(model *assetDetailModel, workspace api.WorkspaceResponse, asset api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse) {
+	sources := sourcesUsingConnection(asset.ID, assets, edges)
+	model.Overview = append(model.Overview, connectionFacts(asset)...)
+	model.Overview = append(model.Overview, definitionFact{Label: "Sources", Value: fmt.Sprint(len(sources))})
+	model.Sections = append(model.Sections,
+		assetDetailSection{
+			Title:  fmt.Sprintf("Sources (%d)", len(sources)),
+			Signal: "assetDetailsConnectionSourcesGrid",
+			Grid:   childAssetGrid(workspace.ID, sources, "No sources use this connection."),
+		},
+	)
+}
+
+func sourcesUsingConnection(connectionID string, assets []api.AssetResponse, edges []api.AssetEdgeResponse) []api.AssetResponse {
+	byID := assetsByID(assets)
+	sources := []api.AssetResponse{}
+	seen := map[string]struct{}{}
+	for _, edge := range edges {
+		if edge.Type != "uses_connection" || edge.ToAssetID != connectionID {
+			continue
+		}
+		source, ok := byID[edge.FromAssetID]
+		if !ok || source.Type != "source" {
+			continue
+		}
+		if _, ok := seen[source.ID]; ok {
+			continue
+		}
+		seen[source.ID] = struct{}{}
+		sources = append(sources, source)
+	}
+	sort.Slice(sources, func(i, j int) bool {
+		return assetTitle(sources[i]) < assetTitle(sources[j])
+	})
+	return sources
+}
+
 func connectionFacts(asset api.AssetResponse) []definitionFact {
 	return []definitionFact{
 		{Label: "Kind", Value: metaString(asset.Meta, "Kind", "kind")},
@@ -1768,7 +1871,7 @@ func childAssetGrid(workspaceID string, assets []api.AssetResponse, empty string
 	for _, asset := range assets {
 		rows = append(rows, map[string]any{
 			"name":        assetTitle(asset),
-			"nameHref":    workspaceAssetSectionHref(workspaceID, asset.ID, "details"),
+			"nameHref":    assetCanonicalSectionHref(workspaceID, asset, "details"),
 			"key":         asset.Key,
 			"type":        assetTypeLabel(asset.Type),
 			"description": emptyDash(asset.Description),
@@ -1808,7 +1911,7 @@ func childDependencyGrid(workspaceID, assetID string, assets []api.AssetResponse
 			"direction": direction,
 			"relation":  labelFromKey(edge.Type),
 			"asset":     assetTitle(peer),
-			"assetHref": workspaceAssetSectionHref(workspaceID, peer.ID, "details"),
+			"assetHref": assetCanonicalSectionHref(workspaceID, peer, "details"),
 			"type":      assetTypeLabel(peer.Type),
 		})
 	}
@@ -2071,7 +2174,7 @@ func childHref(workspaceID string, asset api.AssetResponse) string {
 	if asset.ID == "" {
 		return ""
 	}
-	return workspaceAssetSectionHref(workspaceID, asset.ID, "details")
+	return assetCanonicalSectionHref(workspaceID, asset, "details")
 }
 
 func assetsByID(assets []api.AssetResponse) map[string]api.AssetResponse {

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -29,22 +29,28 @@ func TestWorkspaceAssetDetailsRenderSharedShapeForSemanticModel(t *testing.T) {
 		"Details",
 		"Lineage",
 		"Overview",
-		"Default connection",
-		"Connections (1)",
-		"Sources (1)",
 		"Model tables (1)",
-		"Fields (1)",
 		"Measures (1)",
 		"Relationships (1)",
-		`data-attr:grid="$assetDetailsSemanticConnectionsGrid"`,
-		`data-attr:grid="$assetDetailsSemanticSourcesGrid"`,
 		`data-attr:grid="$assetDetailsSemanticModelTablesGrid"`,
-		`data-attr:grid="$assetDetailsSemanticFieldsGrid"`,
 		`data-attr:grid="$assetDetailsSemanticMeasuresGrid"`,
 		`data-attr:grid="$assetDetailsSemanticRelationshipsGrid"`,
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("semantic model details did not render %q:\n%s", want, rendered)
+		}
+	}
+	for _, notWant := range []string{
+		"Default connection",
+		"Connections (1)",
+		"Sources (1)",
+		"Fields (1)",
+		`data-attr:grid="$assetDetailsSemanticConnectionsGrid"`,
+		`data-attr:grid="$assetDetailsSemanticSourcesGrid"`,
+		`data-attr:grid="$assetDetailsSemanticFieldsGrid"`,
+	} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("semantic model details rendered non-composition content %q:\n%s", notWant, rendered)
 		}
 	}
 	if strings.Contains(rendered, "Published from Git/YAML") {
@@ -63,10 +69,7 @@ func TestWorkspaceAssetDetailSignalsUseSharedGridShape(t *testing.T) {
 
 	semanticSignals := workspaceAssetSignals(workspace, byType["semantic_model"], assets, edges, assetLineage(workspace.ID, byType["semantic_model"], assets, edges), "details")
 	for _, key := range []string{
-		"assetDetailsSemanticConnectionsGrid",
-		"assetDetailsSemanticSourcesGrid",
 		"assetDetailsSemanticModelTablesGrid",
-		"assetDetailsSemanticFieldsGrid",
 		"assetDetailsSemanticMeasuresGrid",
 		"assetDetailsSemanticRelationshipsGrid",
 	} {
@@ -74,6 +77,20 @@ func TestWorkspaceAssetDetailSignalsUseSharedGridShape(t *testing.T) {
 			t.Fatalf("semantic model details did not seed %s: %#v", key, semanticSignals)
 		}
 	}
+	for _, key := range []string{
+		"assetDetailsSemanticConnectionsGrid",
+		"assetDetailsSemanticSourcesGrid",
+		"assetDetailsSemanticFieldsGrid",
+	} {
+		if _, ok := semanticSignals[key]; ok {
+			t.Fatalf("semantic model details seeded non-composition grid %s: %#v", key, semanticSignals)
+		}
+	}
+	modelTablesGrid := signalMetricGrid(t, semanticSignals, "assetDetailsSemanticModelTablesGrid")
+	relationshipsGrid := signalMetricGrid(t, semanticSignals, "assetDetailsSemanticRelationshipsGrid")
+	assertGridHeaders(t, modelTablesGrid, []string{"Name", "Primary key", "Fields", "Measures", "Description"})
+	assertGridHeaders(t, relationshipsGrid, []string{"ID", "From table", "From field", "To table", "To field", "Cardinality", "Active"})
+	assertGridMissingHeaders(t, modelTablesGrid, []string{"Source", "Reads", "SQL preview"})
 
 	dashboardSignals := workspaceAssetSignals(workspace, byType["dashboard"], assets, edges, assetLineage(workspace.ID, byType["dashboard"], assets, edges), "details")
 	for _, key := range []string{"assetDetailsPagesGrid", "assetDetailsFiltersGrid", "assetDetailsVisualsGrid", "assetDetailsTablesGrid"} {
@@ -98,7 +115,6 @@ func TestAssetLineageProjectsRecursiveDependenciesAndContext(t *testing.T) {
 
 	assertLineageNodeKindsExact(t, lineage.Graph, []string{
 		"connection",
-		"measure",
 		"model_table",
 		"dashboard",
 		"semantic_model",
@@ -108,28 +124,20 @@ func TestAssetLineageProjectsRecursiveDependenciesAndContext(t *testing.T) {
 		"lineage_connection_source",
 		"lineage_source_model_table",
 		"lineage_model_table_semantic_model",
-		"lineage_semantic_model_measure",
-		"lineage_measure_dashboard",
+		"lineage_semantic_model_dashboard",
 	})
 	assertLineageEdgesMoveLeftToRight(t, lineage.Graph)
 	assertLineageSelectedNode(t, lineage.Graph, "dashboard")
-	assertGridRelations(t, lineage.Uses, []string{
-		"Reads source",
-		"Uses connection",
-		"Uses field",
-		"Uses filter",
-		"Uses measure",
-		"Uses model table",
-		"Uses semantic table",
-		"Uses table",
-		"Uses visual",
-	})
+	assertGridRelations(t, lineage.Uses, []string{"Powers dashboard"})
 	assertGridRelations(t, lineage.UsedBy, nil)
 	if gridHasRelation(lineage.Uses, "Contains") || gridHasRelation(lineage.UsedBy, "Contains") {
 		t.Fatalf("dependency grids included contains edges: uses=%#v usedBy=%#v", lineage.Uses.Rows, lineage.UsedBy.Rows)
 	}
-	if lineage.Count != 10 {
-		t.Fatalf("lineage count included context edges, got %d", lineage.Count)
+	if gridHasRelation(lineage.Uses, "Uses measure") || gridHasRelation(lineage.UsedBy, "Uses measure") {
+		t.Fatalf("lineage tables included hidden measure edge: uses=%#v usedBy=%#v", lineage.Uses.Rows, lineage.UsedBy.Rows)
+	}
+	if lineage.Count != 1 {
+		t.Fatalf("lineage count included non-graph edges, got %d", lineage.Count)
 	}
 }
 
@@ -142,25 +150,19 @@ func TestAssetLineageProjectsRecursiveConsumers(t *testing.T) {
 	assertLineageNodeKindsExact(t, lineage.Graph, []string{
 		"connection",
 		"dashboard",
-		"measure",
 		"model_table",
 		"semantic_model",
 		"source",
 	})
 	assertLineageEdgesMoveLeftToRight(t, lineage.Graph)
 	assertLineageSelectedNode(t, lineage.Graph, "semantic_model")
-	assertGridRelations(t, lineage.Uses, []string{
-		"Reads source",
-		"Uses connection",
-		"Uses model table",
-	})
-	assertGridRelations(t, lineage.UsedBy, []string{
-		"Uses semantic table",
-		"Uses table",
-		"Uses visual",
-	})
+	assertGridRelations(t, lineage.Uses, []string{"Feeds semantic model"})
+	assertGridRelations(t, lineage.UsedBy, []string{"Powers dashboard"})
 	if gridHasRelation(lineage.Uses, "Contains") || gridHasRelation(lineage.UsedBy, "Contains") {
 		t.Fatalf("consumer/dependency grids included contains edges: uses=%#v usedBy=%#v", lineage.Uses.Rows, lineage.UsedBy.Rows)
+	}
+	if gridHasRelation(lineage.Uses, "Uses semantic table") || gridHasRelation(lineage.UsedBy, "Uses semantic table") {
+		t.Fatalf("lineage tables included hidden semantic table edge: uses=%#v usedBy=%#v", lineage.Uses.Rows, lineage.UsedBy.Rows)
 	}
 }
 
@@ -173,18 +175,12 @@ func TestAssetLineageDashboardDerivesMeasureConsumers(t *testing.T) {
 	assertLineageNodeKindsExact(t, lineage.Graph, []string{
 		"connection",
 		"dashboard",
-		"measure",
 		"model_table",
 		"semantic_model",
 		"source",
 	})
-	assertLineageEdgeKinds(t, lineage.Graph, []string{"lineage_measure_dashboard"})
+	assertLineageEdgeKinds(t, lineage.Graph, []string{"lineage_semantic_model_dashboard"})
 	assertLineageEdgesMoveLeftToRight(t, lineage.Graph)
-	for _, edge := range lineage.Graph.Edges {
-		if edge.Source == "model" && edge.Target == "dashboard" {
-			t.Fatalf("semantic model dashboard shortcut should be suppressed when measure usage exists: %#v", lineage.Graph.Edges)
-		}
-	}
 	node := assertLineageNode(t, lineage.Graph, "dashboard")
 	if node.VisibleUpstream != 1 || node.VisibleDownstream != 0 {
 		t.Fatalf("dashboard visible counts = upstream %d downstream %d, want 1/0: %#v", node.VisibleUpstream, node.VisibleDownstream, node)
@@ -195,6 +191,8 @@ func TestAssetLineageDashboardDerivesMeasureConsumers(t *testing.T) {
 	if node.ContainedCount != 4 || node.ContainedSummary != "1 filter, 1 page, 1 table, 1 visual" {
 		t.Fatalf("dashboard contained summary = %d %q, want 4 dashboard children: %#v", node.ContainedCount, node.ContainedSummary, node)
 	}
+	assertGridRelations(t, lineage.Uses, []string{"Powers dashboard"})
+	assertGridRelations(t, lineage.UsedBy, nil)
 }
 
 func TestAssetLineageSemanticModelDerivesMeasureDashboardPath(t *testing.T) {
@@ -206,18 +204,12 @@ func TestAssetLineageSemanticModelDerivesMeasureDashboardPath(t *testing.T) {
 	assertLineageNodeKindsExact(t, lineage.Graph, []string{
 		"connection",
 		"dashboard",
-		"measure",
 		"model_table",
 		"semantic_model",
 		"source",
 	})
-	assertLineageEdgeKinds(t, lineage.Graph, []string{"lineage_measure_dashboard"})
+	assertLineageEdgeKinds(t, lineage.Graph, []string{"lineage_semantic_model_dashboard"})
 	assertLineageEdgesMoveLeftToRight(t, lineage.Graph)
-	for _, edge := range lineage.Graph.Edges {
-		if edge.Source == "model" && edge.Target == "dashboard" {
-			t.Fatalf("semantic model dashboard shortcut should be suppressed when measure usage exists: %#v", lineage.Graph.Edges)
-		}
-	}
 	node := assertLineageNode(t, lineage.Graph, "model")
 	if node.VisibleUpstream != 1 || node.VisibleDownstream != 1 {
 		t.Fatalf("semantic model visible counts = upstream %d downstream %d, want 1/1: %#v", node.VisibleUpstream, node.VisibleDownstream, node)
@@ -228,6 +220,8 @@ func TestAssetLineageSemanticModelDerivesMeasureDashboardPath(t *testing.T) {
 	if node.ContainedCount != 3 || node.ContainedSummary != "1 measure, 1 relationship, 1 semantic table" {
 		t.Fatalf("semantic model contained summary = %d %q, want 3 semantic children: %#v", node.ContainedCount, node.ContainedSummary, node)
 	}
+	assertGridRelations(t, lineage.Uses, []string{"Feeds semantic model"})
+	assertGridRelations(t, lineage.UsedBy, []string{"Powers dashboard"})
 }
 
 func TestAssetLineageFallsBackToContainsWhenNoDependenciesExist(t *testing.T) {
@@ -254,8 +248,8 @@ func TestLineageProjectionPolicy(t *testing.T) {
 		{typ: "source", want: 1, visible: true},
 		{typ: "model_table", want: 2, visible: true},
 		{typ: "semantic_model", want: 3, visible: true},
-		{typ: "measure", want: 4, visible: true},
-		{typ: "dashboard", want: 5, visible: true},
+		{typ: "dashboard", want: 4, visible: true},
+		{typ: "measure", want: -1, visible: false},
 		{typ: "field", want: -1, visible: false},
 	}
 	for _, tt := range layerTests {
@@ -302,22 +296,6 @@ func TestLineageProjectionPolicy(t *testing.T) {
 			wantLabel:  "Feeds semantic model",
 		},
 		{
-			name:       "semantic model measure",
-			sourceType: "semantic_model",
-			targetType: "measure",
-			fallback:   "uses_semantic_table",
-			wantKind:   "lineage_semantic_model_measure",
-			wantLabel:  "Defines measure",
-		},
-		{
-			name:       "measure dashboard",
-			sourceType: "measure",
-			targetType: "dashboard",
-			fallback:   "uses_measure",
-			wantKind:   "lineage_measure_dashboard",
-			wantLabel:  "Used in dashboard",
-		},
-		{
 			name:       "semantic model dashboard",
 			sourceType: "semantic_model",
 			targetType: "dashboard",
@@ -346,7 +324,7 @@ func TestLineageProjectionPolicy(t *testing.T) {
 	}
 }
 
-func TestCollapsedAssetLineageSuppressesSemanticDashboardShortcutByPair(t *testing.T) {
+func TestCollapsedAssetLineageCollapsesMeasureUsageToSemanticModel(t *testing.T) {
 	workspaceID := "libredash"
 	assets := map[string]api.AssetResponse{
 		"model-a": {
@@ -403,8 +381,8 @@ func TestCollapsedAssetLineageSuppressesSemanticDashboardShortcutByPair(t *testi
 
 	lineage := collapsedAssetLineageGraph(workspaceID, assets["dashboard-b"], graph, assets)
 
-	assertLineageHasEdge(t, lineage, "measure-a", "dashboard-a", "lineage_measure_dashboard")
-	assertLineageMissingEdge(t, lineage, "model-a", "dashboard-a", "lineage_semantic_model_dashboard")
+	assertLineageHasEdge(t, lineage, "model-a", "dashboard-a", "lineage_semantic_model_dashboard")
+	assertLineageMissingNode(t, lineage, "measure-a")
 	assertLineageHasEdge(t, lineage, "model-b", "dashboard-b", "lineage_semantic_model_dashboard")
 }
 
@@ -622,6 +600,15 @@ func testAssetByID(t *testing.T, assets []api.AssetResponse, id string) api.Asse
 	return api.AssetResponse{}
 }
 
+func signalMetricGrid(t *testing.T, signals map[string]any, key string) metricGrid {
+	t.Helper()
+	grid, ok := signals[key].(metricGrid)
+	if !ok {
+		t.Fatalf("signal %s = %#v, want metricGrid", key, signals[key])
+	}
+	return grid
+}
+
 func assertLineageNodeKinds(t *testing.T, graph assetLineageGraph, expected []string) {
 	t.Helper()
 	got := map[string]struct{}{}
@@ -664,6 +651,30 @@ func assertLineageEdgeKinds(t *testing.T, graph assetLineageGraph, expected []st
 	}
 }
 
+func assertGridHeaders(t *testing.T, grid metricGrid, expected []string) {
+	t.Helper()
+	got := make([]string, 0, len(grid.Columns))
+	for _, column := range grid.Columns {
+		got = append(got, column.Header)
+	}
+	if strings.Join(got, "|") != strings.Join(expected, "|") {
+		t.Fatalf("grid headers = %#v, want %#v", got, expected)
+	}
+}
+
+func assertGridMissingHeaders(t *testing.T, grid metricGrid, unexpected []string) {
+	t.Helper()
+	got := map[string]struct{}{}
+	for _, column := range grid.Columns {
+		got[column.Header] = struct{}{}
+	}
+	for _, header := range unexpected {
+		if _, ok := got[header]; ok {
+			t.Fatalf("grid unexpectedly includes header %q: %#v", header, grid.Columns)
+		}
+	}
+}
+
 func assertLineageEdgesMoveLeftToRight(t *testing.T, graph assetLineageGraph) {
 	t.Helper()
 	ranks := map[string]int{}
@@ -699,6 +710,15 @@ func assertLineageNode(t *testing.T, graph assetLineageGraph, id string) assetLi
 	}
 	t.Fatalf("lineage graph missing node %q: %#v", id, graph.Nodes)
 	return assetLineageNode{}
+}
+
+func assertLineageMissingNode(t *testing.T, graph assetLineageGraph, id string) {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.ID == id {
+			t.Fatalf("lineage graph included unwanted node %q: %#v", id, graph.Nodes)
+		}
+	}
 }
 
 func assertLineageHasEdge(t *testing.T, graph assetLineageGraph, source, target, kind string) {

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -107,6 +107,100 @@ func TestWorkspaceAssetDetailSignalsUseSharedGridShape(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAssetDetailsRenderModelTableComposition(t *testing.T) {
+	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
+	asset := testAssetByID(t, assets, "table-transform")
+
+	var out strings.Builder
+	err := WorkspaceAssetPage(catalog, workspace, asset, assets, edges, "details", "Owner").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, want := range []string{
+		"Overview",
+		"Fields (2)",
+		"SQL",
+		"/static/code-block.js",
+		`data-attr:grid="$assetDetailsModelTableFieldsGrid"`,
+		`<ld-code-block language="sql"`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("model table details did not render %q:\n%s", want, rendered)
+		}
+	}
+	for _, notWant := range []string{
+		"Source / transform",
+		`data-attr:grid="$assetDetailsModelTableDefinitionGrid"`,
+	} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("model table details rendered source definition content %q:\n%s", notWant, rendered)
+		}
+	}
+	if strings.Contains(rendered, "Measures (") || strings.Contains(rendered, `data-attr:grid="$assetDetailsModelTableMeasuresGrid"`) {
+		t.Fatalf("model table details rendered measures:\n%s", rendered)
+	}
+}
+
+func TestWorkspaceAssetDetailsRenderDirectSourceModelTableWithoutSQL(t *testing.T) {
+	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
+	asset := testAssetByID(t, assets, "table-model")
+
+	var out strings.Builder
+	err := WorkspaceAssetPage(catalog, workspace, asset, assets, edges, "details", "Owner").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, want := range []string{
+		"Overview",
+		"Fields (2)",
+		`data-attr:grid="$assetDetailsModelTableFieldsGrid"`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("direct source model table details did not render %q:\n%s", want, rendered)
+		}
+	}
+	for _, notWant := range []string{
+		"SQL",
+		"Source / transform",
+		"/static/code-block.js",
+		`<ld-code-block language="sql"`,
+		`data-attr:grid="$assetDetailsModelTableDefinitionGrid"`,
+	} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("direct source model table details rendered %q:\n%s", notWant, rendered)
+		}
+	}
+}
+
+func TestWorkspaceAssetDetailSignalsIncludeModelTableDefinition(t *testing.T) {
+	workspace, _, assets, edges := testWorkspaceAssetFixtures()
+
+	directAsset := testAssetByID(t, assets, "table-model")
+	directSignals := workspaceAssetSignals(workspace, directAsset, assets, edges, assetLineage(workspace.ID, directAsset, assets, edges), "details")
+	directFields := signalMetricGrid(t, directSignals, "assetDetailsModelTableFieldsGrid")
+	assertGridHeaders(t, directFields, []string{"Name", "Type"})
+	assertGridMissingHeaders(t, directFields, []string{"Expression", "Filter", "Order", "Model table", "Measures"})
+	if _, ok := directSignals["assetDetailsModelTableDefinitionGrid"]; ok {
+		t.Fatalf("direct source model table seeded source definition grid: %#v", directSignals)
+	}
+	if _, ok := directSignals["assetDetailsModelTableSQL"]; ok {
+		t.Fatalf("direct source model table seeded SQL signal: %#v", directSignals)
+	}
+
+	transformAsset := testAssetByID(t, assets, "table-transform")
+	transformSignals := workspaceAssetSignals(workspace, transformAsset, assets, edges, assetLineage(workspace.ID, transformAsset, assets, edges), "details")
+	if _, ok := transformSignals["assetDetailsModelTableDefinitionGrid"]; ok {
+		t.Fatalf("transform model table seeded source definition grid: %#v", transformSignals)
+	}
+	if _, ok := transformSignals["assetDetailsModelTableMeasuresGrid"]; ok {
+		t.Fatalf("model table details seeded measures grid: %#v", transformSignals)
+	}
+}
+
 func TestAssetLineageProjectsRecursiveDependenciesAndContext(t *testing.T) {
 	workspace, _, assets, edges := testWorkspaceAssetFixtures()
 	asset := testAssetByID(t, assets, "page-item")
@@ -675,6 +769,35 @@ func assertGridMissingHeaders(t *testing.T, grid metricGrid, unexpected []string
 	}
 }
 
+func assertGridRowValue(t *testing.T, grid metricGrid, column, expected string) {
+	t.Helper()
+	for _, row := range grid.Rows {
+		if fmt.Sprint(row[column]) == expected {
+			return
+		}
+	}
+	t.Fatalf("grid missing row with %s=%q: %#v", column, expected, grid.Rows)
+}
+
+func assertGridNoRowValue(t *testing.T, grid metricGrid, column, unexpected string) {
+	t.Helper()
+	for _, row := range grid.Rows {
+		if fmt.Sprint(row[column]) == unexpected {
+			t.Fatalf("grid unexpectedly includes row with %s=%q: %#v", column, unexpected, grid.Rows)
+		}
+	}
+}
+
+func assertGridRowContains(t *testing.T, grid metricGrid, column, expected string) {
+	t.Helper()
+	for _, row := range grid.Rows {
+		if strings.Contains(fmt.Sprint(row[column]), expected) {
+			return
+		}
+	}
+	t.Fatalf("grid missing row with %s containing %q: %#v", column, expected, grid.Rows)
+}
+
 func assertLineageEdgesMoveLeftToRight(t *testing.T, graph assetLineageGraph) {
 	t.Helper()
 	ranks := map[string]int{}
@@ -807,7 +930,27 @@ func testWorkspaceAssetFixtures() (api.WorkspaceResponse, dashboard.Catalog, []a
 		},
 		{ID: "connection", WorkspaceID: workspace.ID, Type: "connection", Key: "olist.olist", ParentID: "catalog", Title: "Olist connection", Meta: map[string]any{"Kind": "local", "credentials_configured": false}},
 		{ID: "source", WorkspaceID: workspace.ID, Type: "source", Key: "olist.orders", ParentID: "catalog", Title: "orders", Meta: map[string]any{"Connection": "olist", "Format": "csv", "Path": "orders.csv"}},
-		{ID: "table-model", WorkspaceID: workspace.ID, Type: "model_table", Key: "olist.orders", ParentID: "catalog", Title: "orders", Meta: map[string]any{"Source": "orders", "PrimaryKey": "order_id"}},
+		{ID: "source-payments", WorkspaceID: workspace.ID, Type: "source", Key: "olist.payments", ParentID: "catalog", Title: "payments", Meta: map[string]any{"Connection": "olist", "Format": "csv", "Path": "payments.csv"}},
+		{ID: "table-model", WorkspaceID: workspace.ID, Type: "model_table", Key: "olist.orders", ParentID: "catalog", Title: "orders", Meta: map[string]any{
+			"Source":     "orders",
+			"PrimaryKey": "order_id",
+			"Grain":      "order_id",
+			"Dimensions": map[string]any{
+				"order_id": map[string]any{"Expr": "order_id"},
+				"state":    map[string]any{"Expr": "state"},
+			},
+		}},
+		{ID: "table-transform", WorkspaceID: workspace.ID, Type: "model_table", Key: "olist.payments", ParentID: "catalog", Title: "payments", Meta: map[string]any{
+			"Sources":            []any{"payments"},
+			"SourceDependencies": []any{"payments"},
+			"PrimaryKey":         "order_id",
+			"Grain":              "order_id",
+			"Transform":          map[string]any{"SQL": "SELECT order_id, SUM(payment_value) AS revenue FROM source.payments GROUP BY order_id"},
+			"Dimensions": map[string]any{
+				"order_id": map[string]any{"Expr": "order_id"},
+				"revenue":  map[string]any{"Expr": "revenue", "Type": "number"},
+			},
+		}},
 		{ID: "semantic-table", WorkspaceID: workspace.ID, Type: "semantic_table", Key: "olist.orders", ParentID: "model", Title: "Orders semantic table", Meta: map[string]any{"Table": "orders"}},
 		{ID: "field", WorkspaceID: workspace.ID, Type: "field", Key: "olist.orders.state", ParentID: "semantic-table", Title: "State", Meta: map[string]any{"Expr": "state"}},
 		{ID: "measure", WorkspaceID: workspace.ID, Type: "measure", Key: "olist.revenue", ParentID: "model", Title: "Revenue", Meta: map[string]any{"Table": "orders", "Expression": "SUM(orders.revenue)", "Format": "currency"}},

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -408,7 +408,7 @@ func TestCollapsedAssetLineageSuppressesSemanticDashboardShortcutByPair(t *testi
 	assertLineageHasEdge(t, lineage, "model-b", "dashboard-b", "lineage_semantic_model_dashboard")
 }
 
-func TestWorkspaceAssetDetailsRenderSharedShapeForLeafAsset(t *testing.T) {
+func TestConnectionAssetDetailsRenderConnectionSurface(t *testing.T) {
 	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
 	var connection api.AssetResponse
 	for _, asset := range assets {
@@ -419,7 +419,7 @@ func TestWorkspaceAssetDetailsRenderSharedShapeForLeafAsset(t *testing.T) {
 	}
 
 	var out strings.Builder
-	err := WorkspaceAssetPage(catalog, workspace, connection, assets, edges, "details", "Owner").Render(&out)
+	err := ConnectionAssetPage(catalog, workspace, connection, assets, edges, "details", "Owner").Render(&out)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -431,17 +431,54 @@ func TestWorkspaceAssetDetailsRenderSharedShapeForLeafAsset(t *testing.T) {
 		"Overview",
 		"Type",
 		"Connection",
-		"Parent",
-		"LibreDash Workspace",
 		"Kind",
 		"Credentials",
+		"Sources",
+		`Back to connections`,
+		`href="/connections/connection/lineage"`,
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("connection details did not render %q:\n%s", want, rendered)
 		}
 	}
-	if strings.Contains(rendered, "Published from Git/YAML") {
-		t.Fatalf("connection details rendered hardcoded publication source:\n%s", rendered)
+	for _, notWant := range []string{
+		"Published from Git/YAML",
+		">Parent</span>",
+		"Back to workspace",
+		`href="/workspaces/libredash/assets/connection/details"`,
+	} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("connection details rendered workspace-only content %q:\n%s", notWant, rendered)
+		}
+	}
+}
+
+func TestWorkspaceAssetTabsUseWorkspaceAssetTypes(t *testing.T) {
+	workspace, catalog, assets, _ := testWorkspaceAssetFixtures()
+
+	var out strings.Builder
+	err := WorkspacePage(catalog, workspace, assets, "", "", "Owner", testWorkspaceAccess(workspace, true), "csrf").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, want := range []string{
+		`href="/workspaces/libredash"`,
+		`>All</a>`,
+		`href="/workspaces/libredash?type=model_table"`,
+		`>Model table</a>`,
+		`href="/workspaces/libredash?type=semantic_model"`,
+		`>Semantic model</a>`,
+		`href="/workspaces/libredash?type=dashboard"`,
+		`>Dashboard</a>`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("workspace tabs did not render %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, `type=connection`) {
+		t.Fatalf("workspace tabs rendered connection filter:\n%s", rendered)
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "dompurify": "^3.4.11",
         "lucide": "^1.21.0",
         "markdown-it": "^14.2.0",
-        "p5": "^1.11.13"
+        "p5": "^1.11.13",
+        "shiki": "^4.2.0"
       },
       "devDependencies": {
         "@fontsource-variable/inter": "^5.2.8",
@@ -896,6 +897,106 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+      "integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+      "integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+      "integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+      "integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/cli": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.3.1.tgz",
@@ -1317,6 +1418,15 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -1333,6 +1443,15 @@
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/mdurl": {
@@ -1368,6 +1487,18 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "license": "ISC"
     },
     "node_modules/@xyflow/react": {
       "version": "12.11.0",
@@ -1432,12 +1563,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1560,6 +1731,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -1571,6 +1751,19 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dompurify": {
@@ -1680,6 +1873,52 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2103,10 +2342,120 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -2140,6 +2489,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/p5": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/p5/-/p5-1.11.13.tgz",
@@ -2164,6 +2530,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/punycode.js": {
@@ -2198,12 +2574,55 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/shiki": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+      "integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.2.0",
+        "@shikijs/engine-javascript": "4.2.0",
+        "@shikijs/engine-oniguruma": "4.2.0",
+        "@shikijs/langs": "4.2.0",
+        "@shikijs/themes": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2213,6 +2632,30 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tailwindcss": {
@@ -2249,6 +2692,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -2262,6 +2715,74 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -2270,6 +2791,34 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/zrender": {
@@ -2309,6 +2858,16 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "npm run build:css && npm run build:url-sync && npm run build:sidebar && npm run build:sub-sidebar && npm run build:filters && npm run build:filter-panel && npm run build:filter-card && npm run build:inspector && npm run build:table && npm run build:data-grid && npm run build:workspace-access && npm run build:canvas && npm run build:footer && npm run build:charts && npm run build:visual-modal && npm run build:login-background && npm run build:asset-lineage && npm run build:chat",
+    "build": "npm run build:css && npm run build:url-sync && npm run build:sidebar && npm run build:sub-sidebar && npm run build:filters && npm run build:filter-panel && npm run build:filter-card && npm run build:inspector && npm run build:table && npm run build:data-grid && npm run build:code-block && npm run build:workspace-access && npm run build:canvas && npm run build:footer && npm run build:charts && npm run build:visual-modal && npm run build:login-background && npm run build:asset-lineage && npm run build:chat",
     "build:css": "tailwindcss -i ./static/app.input.css -o ./static/app.css",
     "build:url-sync": "esbuild web/components/url-sync.ts --bundle --format=esm --outfile=static/url-sync.js",
     "build:sidebar": "esbuild web/components/sidebar.ts --bundle --format=esm --outfile=static/sidebar.js",
@@ -15,6 +15,7 @@
     "build:inspector": "esbuild web/components/datastar-inspector/index.ts --bundle --format=esm --outfile=static/datastar-inspector.js",
     "build:table": "esbuild web/components/data-table.ts --bundle --format=esm --outfile=static/table.js",
     "build:data-grid": "esbuild web/components/data-grid.ts --bundle --format=esm --outfile=static/data-grid.js",
+    "build:code-block": "esbuild web/components/code-block.ts --bundle --format=esm --outfile=static/code-block.js",
     "build:workspace-access": "esbuild web/components/workspace-access-control.ts --bundle --format=esm --outfile=static/workspace-access-control.js",
     "build:canvas": "esbuild web/components/report-canvas.ts --bundle --format=esm --outfile=static/report-canvas.js",
     "build:footer": "esbuild web/components/report-footer.ts --bundle --format=esm --outfile=static/report-footer.js",
@@ -47,6 +48,7 @@
     "dompurify": "^3.4.11",
     "lucide": "^1.21.0",
     "markdown-it": "^14.2.0",
-    "p5": "^1.11.13"
+    "p5": "^1.11.13",
+    "shiki": "^4.2.0"
   }
 }

--- a/web/components/code-block.ts
+++ b/web/components/code-block.ts
@@ -1,0 +1,152 @@
+import { LitElement, html, nothing } from 'lit'
+import { property, state } from 'lit/decorators.js'
+import { unsafeHTML } from 'lit/directives/unsafe-html.js'
+import { createHighlighterCore, type HighlighterCore } from 'shiki/core'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+import sql from '@shikijs/langs/sql'
+import githubDark from '@shikijs/themes/github-dark'
+import githubLight from '@shikijs/themes/github-light'
+
+type CodeTheme = 'github-light' | 'github-dark'
+
+const highlighterPromise: Promise<HighlighterCore> = createHighlighterCore({
+  themes: [githubLight, githubDark],
+  langs: [sql],
+  engine: createJavaScriptRegexEngine(),
+})
+
+class CodeBlock extends LitElement {
+  @property({ type: String }) code = ''
+  @property({ type: String }) language = 'sql'
+  @state() private highlighted = ''
+  @state() private error = ''
+  private renderToken = 0
+
+  createRenderRoot(): HTMLElement {
+    return this
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback()
+    document.addEventListener('libredash-theme-applied', this.handleThemeApplied)
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener('libredash-theme-applied', this.handleThemeApplied)
+    super.disconnectedCallback()
+  }
+
+  firstUpdated(): void {
+    void this.highlight()
+  }
+
+  updated(changed: Map<string, unknown>): void {
+    if (changed.has('code') || changed.has('language')) {
+      void this.highlight()
+    }
+  }
+
+  render() {
+    const code = this.code.trim()
+    return html`
+      <style>
+        ${codeBlockStyles}
+      </style>
+      <div class="code-block-shell">
+        ${this.error
+          ? html`<pre class="code-block-fallback"><code>${code}</code></pre>`
+          : this.highlighted
+            ? unsafeHTML(this.highlighted)
+            : html`<pre class="code-block-fallback"><code>${code || 'Loading...'}</code></pre>`}
+        ${this.error ? html`<p class="code-block-error">${this.error}</p>` : nothing}
+      </div>
+    `
+  }
+
+  private handleThemeApplied = (): void => {
+    void this.highlight()
+  }
+
+  private async highlight(): Promise<void> {
+    const token = ++this.renderToken
+    const code = this.code.trim()
+    if (!code) {
+      this.highlighted = ''
+      this.error = ''
+      return
+    }
+    try {
+      const highlighter = await highlighterPromise
+      if (token !== this.renderToken) return
+      this.highlighted = highlighter.codeToHtml(code, {
+        lang: this.language || 'sql',
+        theme: this.theme,
+      })
+      this.error = ''
+    } catch {
+      if (token !== this.renderToken) return
+      this.highlighted = ''
+      this.error = 'Syntax highlighting is unavailable.'
+    }
+  }
+
+  private get theme(): CodeTheme {
+    const colorScheme = document.documentElement.style.colorScheme
+    if (colorScheme === 'dark') return 'github-dark'
+    return 'github-light'
+  }
+}
+
+const codeBlockStyles = `
+  ld-code-block {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  ld-code-block .code-block-shell {
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    border: var(--ld-border-muted);
+    border-radius: var(--borderRadius-medium, 6px);
+    background: var(--ld-bg-panel-muted);
+  }
+
+  ld-code-block .shiki,
+  ld-code-block .code-block-fallback {
+    box-sizing: border-box;
+    max-width: 100%;
+    max-height: min(44rem, 68vh);
+    margin: 0;
+    overflow: auto;
+    padding: var(--base-size-16);
+    font-family: var(--fontStack-monospace, ui-monospace, SFMono-Regular, SFMono-Regular, Consolas, Liberation Mono, monospace);
+    font-size: var(--ld-font-size-body-sm, 0.875rem);
+    line-height: 1.65;
+    tab-size: 2;
+  }
+
+  ld-code-block .shiki code,
+  ld-code-block .code-block-fallback code {
+    font-family: inherit;
+  }
+
+  ld-code-block .code-block-fallback {
+    color: var(--ld-fg-default);
+    background: var(--ld-bg-panel-muted);
+    white-space: pre;
+  }
+
+  ld-code-block .code-block-error {
+    margin: 0;
+    border-top: var(--ld-border-muted);
+    padding: var(--base-size-8) var(--base-size-16);
+    color: var(--ld-fg-muted);
+    font-size: var(--ld-font-size-caption);
+  }
+`
+
+if (!customElements.get('ld-code-block')) {
+  customElements.define('ld-code-block', CodeBlock)
+}


### PR DESCRIPTION
## Summary
- move connection assets into their own canonical Connections detail/lineage surface
- refine semantic model details to show authored composition only: model tables, measures, and relationships
- add model table details with schema fields and SQL code blocks powered by Shiki

## Tests
- npm run build:code-block
- npm run build
- go test ./internal/ui
- go test ./internal/app
- task test