### PR TITLE
Add model-owned schema discovery

### DIFF
--- a/dashboards/olist/executive-sales.yaml
+++ b/dashboards/olist/executive-sales.yaml
@@ -5,6 +5,7 @@ filters:
   purchase_date:
     type: date_range
     label: Period
+    description: Filters dashboard content by order purchase date.
     url_param: period
     from_url_param: from
     to_url_param: to
@@ -29,6 +30,7 @@ filters:
   state:
     type: multi_select
     label: State
+    description: Filters dashboard content by customer state.
     url_param: state
     operator: in
     values:
@@ -38,6 +40,7 @@ filters:
   category:
     type: text
     label: Category
+    description: Filters dashboard content by product category text.
     url_param: category
     operator_url_param: category_op
     default_operator: contains
@@ -50,6 +53,7 @@ filters:
 visuals:
   total_orders:
     kind: kpi
+    description: Shows the filtered count of distinct orders.
     shape: single_value
     query:
       measures:
@@ -59,6 +63,7 @@ visuals:
       tone: ink
   revenue_kpi:
     kind: kpi
+    description: Shows filtered total payment revenue.
     shape: single_value
     query:
       measures:
@@ -68,6 +73,7 @@ visuals:
       tone: green
   aov_kpi:
     kind: kpi
+    description: Shows average order value for the current filters.
     shape: single_value
     query:
       measures:
@@ -77,6 +83,7 @@ visuals:
       tone: amber
   review_kpi:
     kind: kpi
+    description: Shows average review score for the current filters.
     shape: single_value
     query:
       measures:
@@ -86,6 +93,7 @@ visuals:
       tone: coral
   revenue:
     title: Revenue by month
+    description: Tracks monthly revenue over the selected period.
     type: area
     query:
       dimensions:
@@ -110,6 +118,7 @@ visuals:
         - orders_table
   orders:
     title: Orders by status
+    description: Breaks down orders by lifecycle status.
     type: donut
     query:
       dimensions:
@@ -133,6 +142,7 @@ visuals:
         - orders_table
   orders_by_month_status:
     title: Orders by month and status
+    description: Compares monthly order volume split by status.
     shape: category_series_value
     renderer: echarts
     type: column
@@ -164,6 +174,7 @@ visuals:
         - orders_table
   categories:
     title: Top product categories
+    description: Ranks product categories by revenue.
     type: bar
     query:
       dimensions:
@@ -188,6 +199,7 @@ visuals:
         - orders_table
   delivery:
     title: Delivery speed
+    description: Compares order volume across delivery-speed buckets.
     type: bar
     query:
       dimensions:
@@ -211,6 +223,7 @@ visuals:
         - orders_table
   state_status_heatmap:
     title: State by order status
+    description: Shows order status concentration by customer state.
     shape: matrix
     renderer: echarts
     type: heatmap
@@ -228,6 +241,7 @@ visuals:
       limit: 120
   status_delivery_flow:
     title: Status to delivery speed
+    description: Shows flow from order status to delivery-speed bucket.
     shape: graph
     renderer: echarts
     type: sankey
@@ -243,6 +257,7 @@ visuals:
       limit: 40
   delivery_distribution:
     title: Delivery day distribution
+    description: Summarizes delivery-day distribution by speed bucket.
     shape: distribution
     renderer: echarts
     type: boxplot
@@ -256,6 +271,7 @@ visuals:
         direction: asc
   state_order_map:
     title: Orders by state
+    description: Maps order count by customer state.
     shape: geo
     renderer: echarts
     type: map
@@ -272,6 +288,7 @@ visuals:
       limit: 27
   status_delivery_graph:
     title: Status and delivery network
+    description: Shows status and delivery-speed relationships as a network.
     shape: graph
     renderer: echarts
     type: graph
@@ -287,6 +304,7 @@ visuals:
       limit: 40
   revenue_orders_combo:
     title: Revenue and orders by month
+    description: Compares monthly revenue and order volume together.
     shape: category_multi_measure
     renderer: echarts
     type: combo
@@ -306,6 +324,7 @@ visuals:
       limit: 30
   revenue_waterfall:
     title: Monthly revenue contribution
+    description: Shows each month contribution to total revenue.
     shape: category_delta
     renderer: echarts
     type: waterfall
@@ -320,6 +339,7 @@ visuals:
       limit: 18
   delivery_histogram:
     title: Delivery days histogram
+    description: Buckets order volume by delivery duration.
     shape: binned_measure
     renderer: echarts
     type: histogram
@@ -330,6 +350,7 @@ visuals:
         delivery_days:
   status_radar:
     title: Order status radar
+    description: Compares order status counts on a radar chart.
     shape: category_value
     renderer: echarts
     type: radar
@@ -344,6 +365,7 @@ visuals:
       limit: 8
   category_status_sunburst:
     title: Category and status hierarchy
+    description: Shows category and status hierarchy by order count.
     shape: hierarchy
     renderer: echarts
     type: sunburst
@@ -359,6 +381,7 @@ visuals:
       limit: 80
   state_status_tree:
     title: State and status tree
+    description: Shows customer state and order status as a hierarchy.
     shape: hierarchy
     renderer: echarts
     type: tree
@@ -1127,6 +1150,7 @@ tables:
   orders_table:
     kind: data_table
     title: Orders
+    description: Detailed order records with status, geography, revenue, review, and delivery columns.
     interaction:
       row_selection:
         toggle: true
@@ -1204,6 +1228,7 @@ tables:
   orders_compact:
     kind: data_table
     title: Orders compact
+    description: Compact order table for dense scanning.
     style:
       density: compact
       zebra: false
@@ -1251,6 +1276,7 @@ tables:
   orders_spacious:
     kind: data_table
     title: Orders spacious
+    description: Spacious order table focused on date, category, revenue, and delivery.
     style:
       density: spacious
       zebra: true
@@ -1298,6 +1324,7 @@ tables:
   orders_full_grid:
     kind: data_table
     title: Orders full grid
+    description: Full-grid order table with visible row and column borders.
     style:
       density: comfortable
       zebra: true
@@ -1351,6 +1378,7 @@ tables:
   orders_conditional:
     kind: data_table
     title: Orders conditional formatting
+    description: Order table demonstrating badges, data bars, and threshold formatting.
     style:
       density: comfortable
       zebra: true
@@ -1430,6 +1458,7 @@ tables:
   state_status_matrix:
     kind: matrix_table
     title: State status matrix
+    description: Matrix of orders and revenue by customer state and order status.
     default_sort:
       key: state
       direction: asc
@@ -1444,6 +1473,7 @@ tables:
   category_status_pivot:
     kind: pivot_table
     title: Category status pivot
+    description: Pivot of order count by product category and order status.
     default_sort:
       key: category
       direction: asc
@@ -1457,6 +1487,7 @@ tables:
   state_status_matrix_formatted:
     kind: matrix_table
     title: State/category matrix formatted
+    description: Formatted matrix combining geography, category, status, and measures.
     style:
       density: comfortable
       zebra: true
@@ -1504,6 +1535,7 @@ tables:
   category_status_pivot_heat:
     kind: pivot_table
     title: Category status pivot heat
+    description: Heat-formatted pivot of category and status performance.
     style:
       density: compact
       zebra: true
@@ -1540,6 +1572,7 @@ pages:
   - id: period-filter
     kind: filter_card
     filter: purchase_date
+    description: Period filter placement in the overview header.
     placement:
       col: 1
       row: 1
@@ -1548,6 +1581,7 @@ pages:
   - id: state-filter
     kind: filter_card
     filter: state
+    description: State filter placement in the overview header.
     placement:
       col: 4
       row: 1
@@ -1556,6 +1590,7 @@ pages:
   - id: total-orders
     kind: kpi_card
     visual: total_orders
+    description: Total orders KPI placement on the overview page.
     placement:
       col: 1
       row: 2
@@ -1564,6 +1599,7 @@ pages:
   - id: revenue-kpi
     kind: kpi_card
     visual: revenue_kpi
+    description: Revenue KPI placement on the overview page.
     placement:
       col: 4
       row: 2
@@ -1572,6 +1608,7 @@ pages:
   - id: aov-kpi
     kind: kpi_card
     visual: aov_kpi
+    description: Average order value KPI placement on the overview page.
     placement:
       col: 7
       row: 2
@@ -1580,6 +1617,7 @@ pages:
   - id: review-kpi
     kind: kpi_card
     visual: review_kpi
+    description: Review score KPI placement on the overview page.
     placement:
       col: 10
       row: 2
@@ -1588,6 +1626,7 @@ pages:
   - id: revenue
     kind: line_chart
     visual: revenue
+    description: Revenue trend chart placement on the overview page.
     placement:
       col: 1
       row: 4
@@ -1596,6 +1635,7 @@ pages:
   - id: orders
     kind: bar_chart
     visual: orders
+    description: Order status chart placement on the overview page.
     placement:
       col: 7
       row: 4
@@ -1604,6 +1644,7 @@ pages:
   - id: delivery
     kind: bar_chart
     visual: delivery
+    description: Delivery speed chart placement on the overview page.
     placement:
       col: 10
       row: 4
@@ -1612,6 +1653,7 @@ pages:
   - id: categories
     kind: bar_chart
     visual: categories
+    description: Product category chart placement on the overview page.
     placement:
       col: 1
       row: 9
@@ -1620,6 +1662,7 @@ pages:
   - id: orders-table
     kind: table
     table: orders_table
+    description: Orders table placement on the overview page.
     placement:
       col: 7
       row: 9

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -7,36 +7,215 @@ default_connection: olist
 connections:
   olist:
     kind: local
+    description: Local CSV files for the Olist ecommerce demo dataset.
     defaults:
       options:
         header: true
 
 sources:
   orders:
+    description: Raw Olist order lifecycle records.
     connection: olist
     path: olist_orders_dataset.csv
+    fields:
+      order_id:
+        label: Order ID
+        description: Raw order identifier.
+      customer_id:
+        label: Customer ID
+        description: Customer identifier attached to the order.
+      order_status:
+        label: Order status
+        description: Raw lifecycle status from the order system.
+      order_purchase_timestamp:
+        label: Purchase timestamp
+        description: Timestamp when the order was placed.
+      order_approved_at:
+        label: Approved at
+        description: Timestamp when the order was approved.
+      order_delivered_carrier_date:
+        label: Delivered to carrier
+        description: Timestamp when the order was handed to the carrier.
+      order_delivered_customer_date:
+        label: Delivered to customer
+        description: Timestamp when the order reached the customer.
+      order_estimated_delivery_date:
+        label: Estimated delivery
+        description: Estimated delivery timestamp.
   order_items:
+    description: Raw order item records with product and seller identifiers.
     connection: olist
     path: olist_order_items_dataset.csv
+    fields:
+      order_id:
+        label: Order ID
+        description: Order identifier for the item row.
+      order_item_id:
+        label: Order item ID
+        description: Item sequence within the order.
+      product_id:
+        label: Product ID
+        description: Product identifier purchased in the order.
+      seller_id:
+        label: Seller ID
+        description: Seller identifier for the item.
+      shipping_limit_date:
+        label: Shipping limit date
+        description: Deadline for seller shipment.
+      price:
+        label: Price
+        description: Item price before freight.
+      freight_value:
+        label: Freight value
+        description: Freight value charged for the item.
   payments:
+    description: Raw payment transactions by order.
     connection: olist
     path: olist_order_payments_dataset.csv
+    fields:
+      order_id:
+        label: Order ID
+        description: Order identifier for the payment.
+      payment_sequential:
+        label: Payment sequence
+        description: Payment sequence number within the order.
+      payment_type:
+        label: Payment type
+        description: Payment method used for the transaction.
+      payment_installments:
+        label: Payment installments
+        description: Number of installments for the payment.
+      payment_value:
+        label: Payment value
+        description: Payment amount for the transaction.
   products:
+    description: Raw product catalog records.
     connection: olist
     path: olist_products_dataset.csv
+    fields:
+      product_id:
+        label: Product ID
+        description: Stable product identifier.
+      product_category_name:
+        label: Product category
+        description: Product category name in the source language.
+      product_name_lenght:
+        label: Product name length
+        description: Source-provided product name length.
+      product_description_lenght:
+        label: Product description length
+        description: Source-provided product description length.
+      product_photos_qty:
+        label: Product photos
+        description: Number of product photos.
+      product_weight_g:
+        label: Product weight
+        description: Product weight in grams.
+      product_length_cm:
+        label: Product length
+        description: Product length in centimeters.
+      product_height_cm:
+        label: Product height
+        description: Product height in centimeters.
+      product_width_cm:
+        label: Product width
+        description: Product width in centimeters.
   customers:
+    description: Raw customer records with customer geography.
     connection: olist
     path: olist_customers_dataset.csv
+    fields:
+      customer_id:
+        label: Customer ID
+        description: Customer identifier used by orders.
+      customer_unique_id:
+        label: Unique customer ID
+        description: Stable unique customer identifier.
+      customer_zip_code_prefix:
+        label: ZIP code prefix
+        description: Customer ZIP code prefix.
+      customer_city:
+        label: City
+        description: Customer city.
+      customer_state:
+        label: State
+        description: Customer state.
   reviews:
+    description: Raw customer review scores by order.
     connection: olist
     path: olist_order_reviews_dataset.csv
+    fields:
+      review_id:
+        label: Review ID
+        description: Stable review identifier.
+      order_id:
+        label: Order ID
+        description: Order identifier associated with the review.
+      review_score:
+        label: Review score
+        description: Customer review score.
+      review_comment_title:
+        label: Review title
+        description: Optional review comment title.
+      review_comment_message:
+        label: Review message
+        description: Optional review comment body.
+      review_creation_date:
+        label: Review creation date
+        description: Date when the review was created.
+      review_answer_timestamp:
+        label: Review answer timestamp
+        description: Timestamp when the review was answered.
   translations:
+    description: Product category translations from Portuguese to English.
     connection: olist
     path: product_category_name_translation.csv
+    fields:
+      product_category_name:
+        label: Product category
+        description: Product category name in Portuguese.
+      product_category_name_english:
+        label: Product category English
+        description: English product category name.
 
 models:
   orders:
     description: Order-grain model table with deliberately grain-aligned category, revenue, review, and delivery fields.
+    primary_key: order_id
+    fields:
+      order_id:
+        label: Order ID
+        description: Stable order identifier from the Olist orders dataset.
+      customer_id:
+        label: Customer ID
+        description: Customer identifier associated with the order.
+      purchase_month:
+        label: Purchase month
+        description: Calendar month when the order was purchased.
+      purchase_timestamp:
+        label: Purchase timestamp
+        description: Timestamp when the customer placed the order.
+      purchase_date:
+        label: Purchase date
+        description: Calendar date when the customer placed the order.
+      status:
+        label: Status
+        description: Current order lifecycle status.
+      category:
+        label: Category
+        description: English product category associated with the order.
+      revenue:
+        label: Revenue
+        description: Total payment revenue attributed to the order.
+      review_score:
+        label: Review
+        description: Average customer review score for the order.
+      delivery_days:
+        label: Delivery days
+        description: Days between purchase and customer delivery.
+      delivery_bucket:
+        label: Delivery speed
+        description: Delivery speed bucket derived from delivery days.
     sources:
       - orders
       - payments
@@ -92,67 +271,33 @@ models:
         LEFT JOIN review ON review.order_id = o.order_id
         LEFT JOIN category ON category.order_id = o.order_id
   customers:
-    source: customers
+    description: Customer model table with stable BI-facing customer fields.
+    primary_key: customer_id
+    fields:
+      customer_id:
+        label: Customer ID
+        description: Stable customer identifier from the Olist customers dataset.
+      state:
+        label: State
+        description: Brazilian state for the customer.
+    sources:
+      - customers
+    transform:
+      sql: |
+        SELECT
+          customer_id,
+          customer_state AS state
+        FROM source.customers
 
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id:
-            label: Order ID
-            expr: order_id
-          customer_id:
-            label: Customer ID
-            expr: customer_id
-          purchase_month:
-            label: Purchase month
-            expr: purchase_month
-          purchase_timestamp:
-            label: Purchase timestamp
-            expr: purchase_timestamp
-            type: time
-          purchase_date:
-            label: Purchase date
-            expr: purchase_date
-          status:
-            label: Status
-            expr: status
-          category:
-            label: Category
-            expr: category
-          revenue:
-            label: Revenue
-            expr: revenue
-            type: number
-          review_score:
-            label: Review
-            expr: review_score
-            type: number
-          delivery_days:
-            label: Delivery days
-            expr: delivery_days
-            type: number
-          delivery_bucket:
-            label: Delivery speed
-            expr: delivery_bucket
-            where: delivery_bucket IS NOT NULL
-            order_expr: MIN(delivery_days)
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id:
-            label: Customer ID
-            expr: customer_id
-          state:
-            label: State
-            expr: customer_state
+      - orders
+      - customers
     relationships:
       - id: orders_customers
+        description: Links each order to the customer who placed it.
         from: orders.customer_id
         to: customers.customer_id
         cardinality: many_to_one
@@ -165,60 +310,73 @@ semantic_models:
         grains: [day, week, month, quarter, year]
       order_count:
         label: Orders
+        description: Distinct order count.
         expression: COUNT(DISTINCT orders.order_id)
         unit: orders
         format: integer
       revenue:
         label: Revenue
+        description: Total payment revenue.
         expression: SUM(orders.revenue)
         unit: R$
         format: currency
       revenue_min:
         label: Revenue min
+        description: Minimum order revenue.
         expression: MIN(orders.revenue)
         unit: R$
         format: currency
       revenue_q1:
         label: Revenue q1
+        description: First quartile of order revenue.
         expression: quantile_cont(orders.revenue, 0.25)
         unit: R$
         format: currency
       revenue_q3:
         label: Revenue q3
+        description: Third quartile of order revenue.
         expression: quantile_cont(orders.revenue, 0.75)
         unit: R$
         format: currency
       revenue_max:
         label: Revenue max
+        description: Maximum order revenue.
         expression: MAX(orders.revenue)
         unit: R$
         format: currency
       aov:
         label: AOV
+        description: Average order value.
         expression: SUM(orders.revenue) / NULLIF(COUNT(DISTINCT orders.order_id), 0)
         unit: R$
         format: currency
       review_score:
         label: Review
+        description: Average order review score.
         expression: AVG(orders.review_score)
         format: decimal
       delivery_days:
         label: Delivery days
+        description: Average delivery duration in days.
         expression: AVG(orders.delivery_days)
         format: decimal
       delivery_days_min:
         label: Delivery min
+        description: Minimum delivery duration in days.
         expression: MIN(orders.delivery_days)
         format: decimal
       delivery_days_q1:
         label: Delivery q1
+        description: First quartile of delivery duration in days.
         expression: quantile_cont(orders.delivery_days, 0.25)
         format: decimal
       delivery_days_q3:
         label: Delivery q3
+        description: Third quartile of delivery duration in days.
         expression: quantile_cont(orders.delivery_days, 0.75)
         format: decimal
       delivery_days_max:
         label: Delivery max
+        description: Maximum delivery duration in days.
         expression: MAX(orders.delivery_days)
         format: decimal

--- a/dashboards/olist/model.yaml
+++ b/dashboards/olist/model.yaml
@@ -19,28 +19,20 @@ sources:
     path: olist_orders_dataset.csv
     fields:
       order_id:
-        label: Order ID
         description: Raw order identifier.
       customer_id:
-        label: Customer ID
         description: Customer identifier attached to the order.
       order_status:
-        label: Order status
         description: Raw lifecycle status from the order system.
       order_purchase_timestamp:
-        label: Purchase timestamp
         description: Timestamp when the order was placed.
       order_approved_at:
-        label: Approved at
         description: Timestamp when the order was approved.
       order_delivered_carrier_date:
-        label: Delivered to carrier
         description: Timestamp when the order was handed to the carrier.
       order_delivered_customer_date:
-        label: Delivered to customer
         description: Timestamp when the order reached the customer.
       order_estimated_delivery_date:
-        label: Estimated delivery
         description: Estimated delivery timestamp.
   order_items:
     description: Raw order item records with product and seller identifiers.
@@ -48,25 +40,18 @@ sources:
     path: olist_order_items_dataset.csv
     fields:
       order_id:
-        label: Order ID
         description: Order identifier for the item row.
       order_item_id:
-        label: Order item ID
         description: Item sequence within the order.
       product_id:
-        label: Product ID
         description: Product identifier purchased in the order.
       seller_id:
-        label: Seller ID
         description: Seller identifier for the item.
       shipping_limit_date:
-        label: Shipping limit date
         description: Deadline for seller shipment.
       price:
-        label: Price
         description: Item price before freight.
       freight_value:
-        label: Freight value
         description: Freight value charged for the item.
   payments:
     description: Raw payment transactions by order.
@@ -74,19 +59,14 @@ sources:
     path: olist_order_payments_dataset.csv
     fields:
       order_id:
-        label: Order ID
         description: Order identifier for the payment.
       payment_sequential:
-        label: Payment sequence
         description: Payment sequence number within the order.
       payment_type:
-        label: Payment type
         description: Payment method used for the transaction.
       payment_installments:
-        label: Payment installments
         description: Number of installments for the payment.
       payment_value:
-        label: Payment value
         description: Payment amount for the transaction.
   products:
     description: Raw product catalog records.
@@ -94,31 +74,22 @@ sources:
     path: olist_products_dataset.csv
     fields:
       product_id:
-        label: Product ID
         description: Stable product identifier.
       product_category_name:
-        label: Product category
         description: Product category name in the source language.
       product_name_lenght:
-        label: Product name length
         description: Source-provided product name length.
       product_description_lenght:
-        label: Product description length
         description: Source-provided product description length.
       product_photos_qty:
-        label: Product photos
         description: Number of product photos.
       product_weight_g:
-        label: Product weight
         description: Product weight in grams.
       product_length_cm:
-        label: Product length
         description: Product length in centimeters.
       product_height_cm:
-        label: Product height
         description: Product height in centimeters.
       product_width_cm:
-        label: Product width
         description: Product width in centimeters.
   customers:
     description: Raw customer records with customer geography.
@@ -126,19 +97,14 @@ sources:
     path: olist_customers_dataset.csv
     fields:
       customer_id:
-        label: Customer ID
         description: Customer identifier used by orders.
       customer_unique_id:
-        label: Unique customer ID
         description: Stable unique customer identifier.
       customer_zip_code_prefix:
-        label: ZIP code prefix
         description: Customer ZIP code prefix.
       customer_city:
-        label: City
         description: Customer city.
       customer_state:
-        label: State
         description: Customer state.
   reviews:
     description: Raw customer review scores by order.
@@ -146,25 +112,18 @@ sources:
     path: olist_order_reviews_dataset.csv
     fields:
       review_id:
-        label: Review ID
         description: Stable review identifier.
       order_id:
-        label: Order ID
         description: Order identifier associated with the review.
       review_score:
-        label: Review score
         description: Customer review score.
       review_comment_title:
-        label: Review title
         description: Optional review comment title.
       review_comment_message:
-        label: Review message
         description: Optional review comment body.
       review_creation_date:
-        label: Review creation date
         description: Date when the review was created.
       review_answer_timestamp:
-        label: Review answer timestamp
         description: Timestamp when the review was answered.
   translations:
     description: Product category translations from Portuguese to English.
@@ -172,10 +131,8 @@ sources:
     path: product_category_name_translation.csv
     fields:
       product_category_name:
-        label: Product category
         description: Product category name in Portuguese.
       product_category_name_english:
-        label: Product category English
         description: English product category name.
 
 models:

--- a/internal/analytics/duckdb/schema.go
+++ b/internal/analytics/duckdb/schema.go
@@ -1,0 +1,86 @@
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+
+	semanticmodel "github.com/Yacobolo/libredash/internal/analytics/model"
+)
+
+func DiscoverSchemas(ctx context.Context, db *Database, model *semanticmodel.Model) error {
+	if db == nil || db.SQLDB() == nil {
+		return fmt.Errorf("schema discovery requires a DuckDB database")
+	}
+	if model == nil {
+		return fmt.Errorf("schema discovery requires a semantic model")
+	}
+	rows, err := db.SQLDB().QueryContext(ctx, `
+SELECT schema_name, table_name, column_name, column_index, data_type, is_nullable, column_default, comment
+FROM duckdb_columns()
+WHERE schema_name IN ('source', 'model')
+ORDER BY schema_name, table_name, column_index`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	sourceColumns := map[string][]semanticmodel.ColumnSchema{}
+	tableColumns := map[string][]semanticmodel.ColumnSchema{}
+	for rows.Next() {
+		var schemaName, tableName, columnName, dataType string
+		var ordinal int
+		var nullable bool
+		var defaultValue, comment sql.NullString
+		if err := rows.Scan(&schemaName, &tableName, &columnName, &ordinal, &dataType, &nullable, &defaultValue, &comment); err != nil {
+			return err
+		}
+		column := semanticmodel.ColumnSchema{
+			Name:         columnName,
+			Ordinal:      ordinal,
+			PhysicalType: dataType,
+			Nullable:     nullable,
+			Default:      defaultValue.String,
+			Comment:      comment.String,
+		}
+		switch schemaName {
+		case "source":
+			sourceColumns[tableName] = append(sourceColumns[tableName], column)
+		case "model":
+			tableColumns[tableName] = append(tableColumns[tableName], column)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for name, source := range model.Sources {
+		source.Schema = semanticmodel.TableSchema{Columns: sortedColumns(sourceColumns[name])}
+		model.Sources[name] = source
+	}
+	for name, table := range model.Tables {
+		columns := sortedColumns(tableColumns[name])
+		for index := range columns {
+			columns[index].PrimaryKey = columns[index].Name == table.PrimaryKey
+		}
+		table.Schema = semanticmodel.TableSchema{Columns: columns}
+		model.Tables[name] = table
+	}
+	return model.ValidateDiscoveredSchemas()
+}
+
+func (db *Database) DiscoverSchemas(ctx context.Context, model *semanticmodel.Model) error {
+	return DiscoverSchemas(ctx, db, model)
+}
+
+func sortedColumns(columns []semanticmodel.ColumnSchema) []semanticmodel.ColumnSchema {
+	out := append([]semanticmodel.ColumnSchema{}, columns...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Ordinal != out[j].Ordinal {
+			return out[i].Ordinal < out[j].Ordinal
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/internal/analytics/duckdb/schema.go
+++ b/internal/analytics/duckdb/schema.go
@@ -16,11 +16,15 @@ func DiscoverSchemas(ctx context.Context, db *Database, model *semanticmodel.Mod
 	if model == nil {
 		return fmt.Errorf("schema discovery requires a semantic model")
 	}
+	var databaseName string
+	if err := db.SQLDB().QueryRowContext(ctx, `SELECT current_database()`).Scan(&databaseName); err != nil {
+		return err
+	}
 	rows, err := db.SQLDB().QueryContext(ctx, `
 SELECT schema_name, table_name, column_name, column_index, data_type, is_nullable, column_default, comment
 FROM duckdb_columns()
-WHERE schema_name IN ('source', 'model')
-ORDER BY schema_name, table_name, column_index`)
+WHERE database_name = ? AND schema_name IN ('source', 'model')
+ORDER BY schema_name, table_name, column_index`, databaseName)
 	if err != nil {
 		return err
 	}
@@ -31,16 +35,21 @@ ORDER BY schema_name, table_name, column_index`)
 	for rows.Next() {
 		var schemaName, tableName, columnName, dataType string
 		var ordinal int
-		var nullable bool
+		var nullable sql.NullBool
 		var defaultValue, comment sql.NullString
 		if err := rows.Scan(&schemaName, &tableName, &columnName, &ordinal, &dataType, &nullable, &defaultValue, &comment); err != nil {
 			return err
+		}
+		var nullableValue *bool
+		if nullable.Valid {
+			value := nullable.Bool
+			nullableValue = &value
 		}
 		column := semanticmodel.ColumnSchema{
 			Name:         columnName,
 			Ordinal:      ordinal,
 			PhysicalType: dataType,
-			Nullable:     nullable,
+			Nullable:     nullableValue,
 			Default:      defaultValue.String,
 			Comment:      comment.String,
 		}

--- a/internal/analytics/duckdb/source_test.go
+++ b/internal/analytics/duckdb/source_test.go
@@ -9,9 +9,127 @@ import (
 	"strings"
 	"testing"
 
+	analyticsmaterialize "github.com/Yacobolo/libredash/internal/analytics/materialize"
 	semanticmodel "github.com/Yacobolo/libredash/internal/analytics/model"
 	_ "github.com/duckdb/duckdb-go/v2"
 )
+
+func TestDiscoverSchemasCapturesSourceAndModelColumns(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "orders.csv"), []byte("order_id,revenue\n1,10.5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	db, err := Open(ctx, filepath.Join(dir, "test.duckdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	model := &semanticmodel.Model{
+		Name:              "olist",
+		DefaultConnection: "local",
+		Connections:       map[string]semanticmodel.Connection{"local": {Kind: "local"}},
+		Sources: map[string]semanticmodel.Source{"orders": {
+			Connection: "local",
+			Path:       "orders.csv",
+			Format:     "csv",
+			Fields: map[string]semanticmodel.MetricDimension{
+				"order_id": {Label: "Order ID", Description: "Raw order identifier."},
+			},
+		}},
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				Source:     "orders",
+				PrimaryKey: "order_id",
+				Grain:      "order_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"order_id": {Label: "Order ID"},
+					"revenue":  {Label: "Revenue"},
+				},
+			},
+		},
+		BaseTable: "orders",
+		Measures: map[string]semanticmodel.MetricMeasure{
+			"revenue": {Table: "orders", Grain: "order_id", Expression: "SUM(orders.revenue)", Label: "Revenue"},
+		},
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := analyticsmaterialize.Refresh(ctx, db, NewSourceRuntime(db, dir), model); err != nil {
+		t.Fatal(err)
+	}
+	if err := DiscoverSchemas(ctx, db, model); err != nil {
+		t.Fatal(err)
+	}
+	if got := model.Sources["orders"].Schema.Columns; len(got) != 2 || got[0].Name != "order_id" || got[0].Ordinal != 1 {
+		t.Fatalf("source schema = %#v, want ordered source columns", got)
+	}
+	if got := model.Sources["orders"].Fields["order_id"].Description; got != "Raw order identifier." {
+		t.Fatalf("source field description = %q, want docs preserved", got)
+	}
+	columns := model.Tables["orders"].Schema.Columns
+	if len(columns) != 2 {
+		t.Fatalf("model schema column count = %d, want 2: %#v", len(columns), columns)
+	}
+	if columns[0].Name != "order_id" || columns[0].PhysicalType == "" || !columns[0].PrimaryKey {
+		t.Fatalf("model order_id column = %#v, want physical type and primary key marker", columns[0])
+	}
+	if columns[1].Name != "revenue" || columns[1].PhysicalType == "" {
+		t.Fatalf("model revenue column = %#v, want physical type", columns[1])
+	}
+}
+
+func TestDiscoverSchemasRejectsMissingDocumentedSourceField(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "orders.csv"), []byte("order_id,revenue\n1,10.5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	db, err := Open(ctx, filepath.Join(dir, "test.duckdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	model := &semanticmodel.Model{
+		Name:              "olist",
+		DefaultConnection: "local",
+		Connections:       map[string]semanticmodel.Connection{"local": {Kind: "local"}},
+		Sources: map[string]semanticmodel.Source{"orders": {
+			Connection: "local",
+			Path:       "orders.csv",
+			Format:     "csv",
+			Fields: map[string]semanticmodel.MetricDimension{
+				"missing": {Label: "Missing"},
+			},
+		}},
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				Source:     "orders",
+				PrimaryKey: "order_id",
+				Grain:      "order_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"order_id": {Label: "Order ID"},
+					"revenue":  {Label: "Revenue"},
+				},
+			},
+		},
+		BaseTable: "orders",
+		Measures: map[string]semanticmodel.MetricMeasure{
+			"revenue": {Table: "orders", Grain: "order_id", Expression: "SUM(orders.revenue)", Label: "Revenue"},
+		},
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := analyticsmaterialize.Refresh(ctx, db, NewSourceRuntime(db, dir), model); err != nil {
+		t.Fatal(err)
+	}
+	err = DiscoverSchemas(ctx, db, model)
+	if err == nil || !strings.Contains(err.Error(), `source "orders" field "missing" is not in discovered schema`) {
+		t.Fatalf("DiscoverSchemas() error = %v, want missing source field validation", err)
+	}
+}
 
 func TestCompileSourceRelation(t *testing.T) {
 	cases := map[string]struct {

--- a/internal/analytics/duckdb/source_test.go
+++ b/internal/analytics/duckdb/source_test.go
@@ -33,8 +33,8 @@ func TestDiscoverSchemasCapturesSourceAndModelColumns(t *testing.T) {
 			Connection: "local",
 			Path:       "orders.csv",
 			Format:     "csv",
-			Fields: map[string]semanticmodel.MetricDimension{
-				"order_id": {Label: "Order ID", Description: "Raw order identifier."},
+			Fields: map[string]semanticmodel.SourceField{
+				"order_id": {Description: "Raw order identifier."},
 			},
 		}},
 		Tables: map[string]semanticmodel.Table{
@@ -163,8 +163,8 @@ func TestDiscoverSchemasRejectsMissingDocumentedSourceField(t *testing.T) {
 			Connection: "local",
 			Path:       "orders.csv",
 			Format:     "csv",
-			Fields: map[string]semanticmodel.MetricDimension{
-				"missing": {Label: "Missing"},
+			Fields: map[string]semanticmodel.SourceField{
+				"missing": {Description: "Missing source field."},
 			},
 		}},
 		Tables: map[string]semanticmodel.Table{

--- a/internal/analytics/duckdb/source_test.go
+++ b/internal/analytics/duckdb/source_test.go
@@ -72,11 +72,75 @@ func TestDiscoverSchemasCapturesSourceAndModelColumns(t *testing.T) {
 	if len(columns) != 2 {
 		t.Fatalf("model schema column count = %d, want 2: %#v", len(columns), columns)
 	}
-	if columns[0].Name != "order_id" || columns[0].PhysicalType == "" || !columns[0].PrimaryKey {
+	if columns[0].Name != "order_id" || columns[0].PhysicalType == "" || !columns[0].PrimaryKey || columns[0].Nullable == nil {
 		t.Fatalf("model order_id column = %#v, want physical type and primary key marker", columns[0])
 	}
-	if columns[1].Name != "revenue" || columns[1].PhysicalType == "" {
+	if columns[1].Name != "revenue" || columns[1].PhysicalType == "" || columns[1].Nullable == nil {
 		t.Fatalf("model revenue column = %#v, want physical type", columns[1])
+	}
+}
+
+func TestDiscoverSchemasIgnoresAttachedDatabaseSchemas(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "orders.csv"), []byte("order_id,revenue\n1,10.5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	db, err := Open(ctx, filepath.Join(dir, "test.duckdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	model := &semanticmodel.Model{
+		Name:              "olist",
+		DefaultConnection: "local",
+		Connections:       map[string]semanticmodel.Connection{"local": {Kind: "local"}},
+		Sources: map[string]semanticmodel.Source{"orders": {
+			Connection: "local",
+			Path:       "orders.csv",
+			Format:     "csv",
+		}},
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				Source:     "orders",
+				PrimaryKey: "order_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"order_id": {Label: "Order ID"},
+					"revenue":  {Label: "Revenue"},
+				},
+			},
+		},
+		BaseTable: "orders",
+		Measures:  map[string]semanticmodel.MetricMeasure{},
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := analyticsmaterialize.Refresh(ctx, db, NewSourceRuntime(db, dir), model); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.SQLDB().ExecContext(ctx, `
+ATTACH ':memory:' AS attached_catalog;
+CREATE SCHEMA attached_catalog.source;
+CREATE TABLE attached_catalog.source.orders (attached_only INTEGER);
+CREATE SCHEMA attached_catalog.model;
+CREATE TABLE attached_catalog.model.orders (attached_only INTEGER);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := DiscoverSchemas(ctx, db, model); err != nil {
+		t.Fatal(err)
+	}
+	sourceColumns := model.Sources["orders"].Schema.Columns
+	for _, column := range sourceColumns {
+		if column.Name == "attached_only" {
+			t.Fatalf("source schema included attached database column: %#v", sourceColumns)
+		}
+	}
+	tableColumns := model.Tables["orders"].Schema.Columns
+	for _, column := range tableColumns {
+		if column.Name == "attached_only" {
+			t.Fatalf("model schema included attached database column: %#v", tableColumns)
+		}
 	}
 }
 

--- a/internal/analytics/materialize/runtime.go
+++ b/internal/analytics/materialize/runtime.go
@@ -37,6 +37,10 @@ type Database interface {
 	Path() string
 }
 
+type schemaDiscoverer interface {
+	DiscoverSchemas(context.Context, *semanticmodel.Model) error
+}
+
 func OpenRuntime(ctx context.Context, config RuntimeConfig) (*Runtime, error) {
 	if config.Model == nil {
 		return nil, fmt.Errorf("semantic model is required")
@@ -85,6 +89,11 @@ func (r *Runtime) Refresh(ctx context.Context) error {
 	lastRefresh, err := Refresh(ctx, r.db, r.sources, r.model)
 	if err != nil {
 		return err
+	}
+	if discoverer, ok := r.db.(schemaDiscoverer); ok {
+		if err := discoverer.DiscoverSchemas(ctx, r.model); err != nil {
+			return err
+		}
 	}
 	r.lastRefresh = lastRefresh
 	return nil

--- a/internal/analytics/model/fields.go
+++ b/internal/analytics/model/fields.go
@@ -16,13 +16,7 @@ func (m *Model) ResolveDimension(ref string) (MetricDimension, error) {
 	}
 	dimension, ok := table.Dimensions[fieldName]
 	if !ok {
-		if len(table.Dimensions) > 0 {
-			return MetricDimension{}, fmt.Errorf("unknown dimension %q", fieldName)
-		}
-		if err := validateSemanticIdentifier(fieldName); err != nil {
-			return MetricDimension{}, fmt.Errorf("unknown dimension %q", fieldName)
-		}
-		dimension = MetricDimension{Expr: fieldName}
+		return MetricDimension{}, fmt.Errorf("unknown field %q on table %q", fieldName, tableName)
 	}
 	dimension.Field = ref
 	dimension.Table = tableName
@@ -44,9 +38,6 @@ func (m *Model) ResolveRelationshipEndpoint(ref string) (MetricDimension, error)
 		dimension.Table = tableName
 		dimension.Name = fieldName
 		return dimension, nil
-	}
-	if fieldName == table.PrimaryKey {
-		return MetricDimension{Field: ref, Table: tableName, Name: fieldName, Expr: fieldName}, nil
 	}
 	return MetricDimension{}, fmt.Errorf("unknown relationship endpoint field %q on table %q", fieldName, tableName)
 }
@@ -103,10 +94,7 @@ func splitSemanticField(ref string) (string, string, error) {
 }
 
 func (d MetricDimension) SQLExpression() string {
-	if strings.TrimSpace(d.Expr) != "" {
-		return d.Expr
-	}
-	return d.Expression
+	return d.Name
 }
 
 func (m MetricMeasure) SQLExpression() string {

--- a/internal/analytics/model/model.go
+++ b/internal/analytics/model/model.go
@@ -37,6 +37,18 @@ func (m *Model) Validate() error {
 		if err := resolved.Validate(name, m.Connections); err != nil {
 			return err
 		}
+		for field, dimension := range resolved.Fields {
+			if err := validateSemanticIdentifier(field); err != nil {
+				return fmt.Errorf("source %q field %q is invalid: %w", name, field, err)
+			}
+			dimension.Field = name + "." + field
+			dimension.Table = name
+			dimension.Name = field
+			if dimension.Label == "" {
+				dimension.Label = titleFromIdentifier(field)
+			}
+			resolved.Fields[field] = dimension
+		}
 		m.Sources[name] = resolved
 	}
 	if len(m.Tables) == 0 {
@@ -79,11 +91,15 @@ func (m *Model) Validate() error {
 		}
 		for field, dimension := range table.Dimensions {
 			if err := validateSemanticIdentifier(field); err != nil {
-				return fmt.Errorf("model table %q dimension %q is invalid: %w", name, field, err)
+				return fmt.Errorf("model table %q field %q is invalid: %w", name, field, err)
 			}
-			if dimension.SQLExpression() == "" {
-				return fmt.Errorf("model table %q dimension %q requires expr", name, field)
+			dimension.Field = name + "." + field
+			dimension.Table = name
+			dimension.Name = field
+			if dimension.Label == "" {
+				dimension.Label = titleFromIdentifier(field)
 			}
+			table.Dimensions[field] = dimension
 		}
 		for field, measure := range table.Measures {
 			if err := validateSemanticIdentifier(field); err != nil {
@@ -648,9 +664,6 @@ func (m *Model) validateRelationshipEndpoint(role string, endpoint string) (stri
 	if !ok {
 		return "", fmt.Errorf("relationship %s %q references unknown table %q", role, endpoint, tableName)
 	}
-	if fieldName == table.PrimaryKey {
-		return tableName, nil
-	}
 	if _, ok := table.Dimensions[fieldName]; !ok {
 		return "", fmt.Errorf("relationship %s %q references unknown field %q on table %q", role, endpoint, fieldName, tableName)
 	}
@@ -815,20 +828,6 @@ func (c Connection) Validate(name string) (Connection, error) {
 		}
 	}
 	return c, nil
-}
-
-func (s Source) Description() string {
-	switch s.Kind() {
-	case KindPath:
-		if formatSpec, ok := LookupFormat(s.Format); ok && formatSpec.TableLike {
-			return s.Format + " table: " + s.Path
-		}
-		return s.Format + " file: " + s.Path
-	case KindObject:
-		return "object: " + s.Object
-	default:
-		return "source"
-	}
 }
 
 func (s Source) Role() string {

--- a/internal/analytics/model/model.go
+++ b/internal/analytics/model/model.go
@@ -37,17 +37,14 @@ func (m *Model) Validate() error {
 		if err := resolved.Validate(name, m.Connections); err != nil {
 			return err
 		}
-		for field, dimension := range resolved.Fields {
+		for field, sourceField := range resolved.Fields {
 			if err := validateSemanticIdentifier(field); err != nil {
 				return fmt.Errorf("source %q field %q is invalid: %w", name, field, err)
 			}
-			dimension.Field = name + "." + field
-			dimension.Table = name
-			dimension.Name = field
-			if dimension.Label == "" {
-				dimension.Label = titleFromIdentifier(field)
-			}
-			resolved.Fields[field] = dimension
+			sourceField.Field = name + "." + field
+			sourceField.Table = name
+			sourceField.Name = field
+			resolved.Fields[field] = sourceField
 		}
 		m.Sources[name] = resolved
 	}

--- a/internal/analytics/model/schema.go
+++ b/internal/analytics/model/schema.go
@@ -1,0 +1,71 @@
+package model
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var discoveredFieldRefPattern = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\b`)
+
+func (m *Model) ValidateDiscoveredSchemas() error {
+	if m == nil {
+		return fmt.Errorf("semantic model is required")
+	}
+	for sourceName, source := range m.Sources {
+		columns := map[string]struct{}{}
+		for _, column := range source.Schema.Columns {
+			columns[column.Name] = struct{}{}
+		}
+		if len(columns) == 0 {
+			return fmt.Errorf("source %q has no discovered schema", sourceName)
+		}
+		for field := range source.Fields {
+			if _, ok := columns[field]; !ok {
+				return fmt.Errorf("source %q field %q is not in discovered schema", sourceName, field)
+			}
+		}
+	}
+	for tableName, table := range m.Tables {
+		columns := map[string]struct{}{}
+		for _, column := range table.Schema.Columns {
+			columns[column.Name] = struct{}{}
+		}
+		if len(columns) == 0 {
+			return fmt.Errorf("model table %q has no discovered schema", tableName)
+		}
+		if _, ok := columns[table.PrimaryKey]; !ok {
+			return fmt.Errorf("model table %q primary_key %q is not in discovered schema", tableName, table.PrimaryKey)
+		}
+		for field := range table.Dimensions {
+			if _, ok := columns[field]; !ok {
+				return fmt.Errorf("model table %q field %q is not in discovered schema", tableName, field)
+			}
+		}
+	}
+	for measureName, measure := range m.Measures {
+		for _, ref := range discoveredFieldRefs(measure.SQLExpression()) {
+			if _, err := m.ResolveDimension(ref); err != nil {
+				return fmt.Errorf("measure %q references unknown field %q", measureName, ref)
+			}
+		}
+	}
+	return nil
+}
+
+func discoveredFieldRefs(expression string) []string {
+	matches := discoveredFieldRefPattern.FindAllStringSubmatch(expression, -1)
+	seen := map[string]struct{}{}
+	refs := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) != 3 {
+			continue
+		}
+		ref := match[1] + "." + match[2]
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	return refs
+}

--- a/internal/analytics/model/types.go
+++ b/internal/analytics/model/types.go
@@ -21,13 +21,14 @@ type Model struct {
 }
 
 type Connection struct {
-	Kind     string             `yaml:"kind"`
-	Path     string             `yaml:"path"`
-	Root     string             `yaml:"root"`
-	Scope    string             `yaml:"scope"`
-	Auth     ConnectionAuth     `yaml:"auth"`
-	Options  map[string]any     `yaml:"options"`
-	Defaults ConnectionDefaults `yaml:"defaults"`
+	Kind        string             `yaml:"kind"`
+	Description string             `yaml:"description"`
+	Path        string             `yaml:"path"`
+	Root        string             `yaml:"root"`
+	Scope       string             `yaml:"scope"`
+	Auth        ConnectionAuth     `yaml:"auth"`
+	Options     map[string]any     `yaml:"options"`
+	Defaults    ConnectionDefaults `yaml:"defaults"`
 }
 
 type ConnectionDefaults struct {
@@ -37,11 +38,15 @@ type ConnectionDefaults struct {
 type ConnectionAuth map[string]any
 
 type Source struct {
-	Format     string         `yaml:"format"`
-	Path       string         `yaml:"path"`
-	Connection string         `yaml:"connection"`
-	Object     string         `yaml:"object"`
-	Options    map[string]any `yaml:"options"`
+	Format       string                     `yaml:"format"`
+	Description  string                     `yaml:"description"`
+	Path         string                     `yaml:"path"`
+	Connection   string                     `yaml:"connection"`
+	Object       string                     `yaml:"object"`
+	Options      map[string]any             `yaml:"options"`
+	Fields       map[string]MetricDimension `yaml:"fields"`
+	Schema       TableSchema                `yaml:"-"`
+	AssetVersion int                        `yaml:"-" json:"assetVersion,omitempty"`
 }
 
 type Table struct {
@@ -52,9 +57,10 @@ type Table struct {
 	Transform          Transform                  `yaml:"transform"`
 	PrimaryKey         string                     `yaml:"primary_key"`
 	Grain              string                     `yaml:"grain"`
-	Dimensions         map[string]MetricDimension `yaml:"dimensions"`
+	Dimensions         map[string]MetricDimension `yaml:"fields"`
 	Measures           map[string]MetricMeasure   `yaml:"measures"`
 	Description        string                     `yaml:"description"`
+	Schema             TableSchema                `yaml:"-"`
 	SourceDependencies []string                   `yaml:"-"`
 }
 
@@ -70,15 +76,27 @@ type MeasureDefaults struct {
 }
 
 type MetricDimension struct {
-	Field      string `yaml:"-"`
-	Table      string `yaml:"-"`
-	Name       string `yaml:"-"`
-	Label      string `yaml:"label"`
-	Expr       string `yaml:"expr"`
-	Expression string `yaml:"expression"`
-	Where      string `yaml:"where"`
-	OrderExpr  string `yaml:"order_expr"`
-	Type       string `yaml:"type"`
+	Field       string `yaml:"-"`
+	Table       string `yaml:"-"`
+	Name        string `yaml:"-"`
+	Label       string `yaml:"label"`
+	Description string `yaml:"description"`
+	Expr        string `yaml:"-" json:"-"`
+	Expression  string `yaml:"-" json:"-"`
+}
+
+type TableSchema struct {
+	Columns []ColumnSchema `json:"columns,omitempty"`
+}
+
+type ColumnSchema struct {
+	Name         string `json:"name"`
+	Ordinal      int    `json:"ordinal"`
+	PhysicalType string `json:"physicalType"`
+	Nullable     bool   `json:"nullable"`
+	Default      string `json:"default,omitempty"`
+	Comment      string `json:"comment,omitempty"`
+	PrimaryKey   bool   `json:"primaryKey,omitempty"`
 }
 
 type MetricMeasure struct {
@@ -98,6 +116,7 @@ type MetricMeasure struct {
 
 type Relationship struct {
 	ID          string `yaml:"id"`
+	Description string `yaml:"description"`
 	From        string `yaml:"from"`
 	To          string `yaml:"to"`
 	Cardinality string `yaml:"cardinality"`

--- a/internal/analytics/model/types.go
+++ b/internal/analytics/model/types.go
@@ -38,15 +38,14 @@ type ConnectionDefaults struct {
 type ConnectionAuth map[string]any
 
 type Source struct {
-	Format       string                     `yaml:"format"`
-	Description  string                     `yaml:"description"`
-	Path         string                     `yaml:"path"`
-	Connection   string                     `yaml:"connection"`
-	Object       string                     `yaml:"object"`
-	Options      map[string]any             `yaml:"options"`
-	Fields       map[string]MetricDimension `yaml:"fields"`
-	Schema       TableSchema                `yaml:"-"`
-	AssetVersion int                        `yaml:"-" json:"assetVersion,omitempty"`
+	Format      string                     `yaml:"format"`
+	Description string                     `yaml:"description"`
+	Path        string                     `yaml:"path"`
+	Connection  string                     `yaml:"connection"`
+	Object      string                     `yaml:"object"`
+	Options     map[string]any             `yaml:"options"`
+	Fields      map[string]MetricDimension `yaml:"fields"`
+	Schema      TableSchema                `yaml:"-"`
 }
 
 type Table struct {
@@ -93,7 +92,7 @@ type ColumnSchema struct {
 	Name         string `json:"name"`
 	Ordinal      int    `json:"ordinal"`
 	PhysicalType string `json:"physicalType"`
-	Nullable     bool   `json:"nullable"`
+	Nullable     *bool  `json:"nullable,omitempty"`
 	Default      string `json:"default,omitempty"`
 	Comment      string `json:"comment,omitempty"`
 	PrimaryKey   bool   `json:"primaryKey,omitempty"`

--- a/internal/analytics/model/types.go
+++ b/internal/analytics/model/types.go
@@ -38,14 +38,14 @@ type ConnectionDefaults struct {
 type ConnectionAuth map[string]any
 
 type Source struct {
-	Format      string                     `yaml:"format"`
-	Description string                     `yaml:"description"`
-	Path        string                     `yaml:"path"`
-	Connection  string                     `yaml:"connection"`
-	Object      string                     `yaml:"object"`
-	Options     map[string]any             `yaml:"options"`
-	Fields      map[string]MetricDimension `yaml:"fields"`
-	Schema      TableSchema                `yaml:"-"`
+	Format      string                 `yaml:"format"`
+	Description string                 `yaml:"description"`
+	Path        string                 `yaml:"path"`
+	Connection  string                 `yaml:"connection"`
+	Object      string                 `yaml:"object"`
+	Options     map[string]any         `yaml:"options"`
+	Fields      map[string]SourceField `yaml:"fields"`
+	Schema      TableSchema            `yaml:"-"`
 }
 
 type Table struct {
@@ -65,6 +65,13 @@ type Table struct {
 
 type Transform struct {
 	SQL string `yaml:"sql"`
+}
+
+type SourceField struct {
+	Field       string `yaml:"-"`
+	Table       string `yaml:"-"`
+	Name        string `yaml:"-"`
+	Description string `yaml:"description"`
 }
 
 type MeasureDefaults struct {

--- a/internal/analytics/query/planner_test.go
+++ b/internal/analytics/query/planner_test.go
@@ -33,34 +33,13 @@ func TestPlannerSafeManyToOneDimensionJoin(t *testing.T) {
 	if !strings.Contains(plan.SQL, "LEFT JOIN model.customers t1 ON t0.customer_id = t1.customer_id") {
 		t.Fatalf("plan SQL missing customer join:\n%s", plan.SQL)
 	}
-	if !strings.Contains(plan.SQL, "t1.customer_state AS state") {
+	if !strings.Contains(plan.SQL, "t1.state AS state") {
 		t.Fatalf("plan SQL missing related dimension:\n%s", plan.SQL)
 	}
 }
 
-func TestPlannerRelationshipJoinUsesSemanticEndpointExpression(t *testing.T) {
+func TestPlannerRelationshipJoinUsesIdentityEndpointColumns(t *testing.T) {
 	model := testModel()
-	orders := model.Tables["orders"]
-	orders.Dimensions["customer_id"] = semanticmodel.MetricDimension{Expr: "raw_customer_id"}
-	model.Tables["orders"] = orders
-
-	plan, err := NewPlanner(model).Plan(Request{
-		Dimensions: []Field{{Field: "customers.state", Alias: "state"}},
-		Measures:   []Field{{Field: "revenue", Alias: "revenue"}},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(plan.SQL, "LEFT JOIN model.customers t1 ON t0.raw_customer_id = t1.customer_id") {
-		t.Fatalf("plan SQL should join through semantic endpoint expression:\n%s", plan.SQL)
-	}
-}
-
-func TestPlannerRelationshipJoinFallsBackToPhysicalPrimaryKey(t *testing.T) {
-	model := testModel()
-	customers := model.Tables["customers"]
-	delete(customers.Dimensions, "customer_id")
-	model.Tables["customers"] = customers
 
 	plan, err := NewPlanner(model).Plan(Request{
 		Dimensions: []Field{{Field: "customers.state", Alias: "state"}},
@@ -70,7 +49,22 @@ func TestPlannerRelationshipJoinFallsBackToPhysicalPrimaryKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(plan.SQL, "LEFT JOIN model.customers t1 ON t0.customer_id = t1.customer_id") {
-		t.Fatalf("plan SQL should join through physical primary key fallback:\n%s", plan.SQL)
+		t.Fatalf("plan SQL should join through identity endpoint columns:\n%s", plan.SQL)
+	}
+}
+
+func TestPlannerRelationshipJoinRejectsMissingEndpointField(t *testing.T) {
+	model := testModel()
+	customers := model.Tables["customers"]
+	delete(customers.Dimensions, "customer_id")
+	model.Tables["customers"] = customers
+
+	_, err := NewPlanner(model).Plan(Request{
+		Dimensions: []Field{{Field: "customers.state", Alias: "state"}},
+		Measures:   []Field{{Field: "revenue", Alias: "revenue"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown relationship endpoint field") {
+		t.Fatalf("Plan() error = %v, want missing relationship endpoint field rejection", err)
 	}
 }
 
@@ -96,7 +90,7 @@ func TestPlannerFilters(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(plan.SQL, "t1.customer_state IN (?, ?)") {
+	if !strings.Contains(plan.SQL, "t1.state IN (?, ?)") {
 		t.Fatalf("plan SQL missing semantic filter:\n%s", plan.SQL)
 	}
 	if len(plan.Args) != 2 {
@@ -124,7 +118,7 @@ func TestPlannerGroupedFiltersUseOROfANDPredicates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "((t0.order_id = ? AND t1.customer_state = ?) OR (t0.order_id = ? AND t1.customer_state = ?))"
+	want := "((t0.order_id = ? AND t1.state = ?) OR (t0.order_id = ? AND t1.state = ?))"
 	if !strings.Contains(plan.SQL, want) {
 		t.Fatalf("plan SQL missing grouped tuple predicate %q:\n%s", want, plan.SQL)
 	}
@@ -153,7 +147,7 @@ func TestPlannerRowQueryWithRelatedDimension(t *testing.T) {
 	if !strings.Contains(plan.SQL, "LEFT JOIN model.customers t1 ON t0.customer_id = t1.customer_id") {
 		t.Fatalf("row plan SQL missing customer join:\n%s", plan.SQL)
 	}
-	if !strings.Contains(plan.SQL, "t0.order_id AS order_id") || !strings.Contains(plan.SQL, "t1.customer_state AS state") {
+	if !strings.Contains(plan.SQL, "t0.order_id AS order_id") || !strings.Contains(plan.SQL, "t1.state AS state") {
 		t.Fatalf("row plan SQL missing selected dimensions:\n%s", plan.SQL)
 	}
 	if !strings.Contains(plan.SQL, "t0.revenue AS revenue") {
@@ -170,10 +164,10 @@ func TestPlannerRawValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(plan.SQL, "t1.customer_state AS label") || !strings.Contains(plan.SQL, "CAST(t0.revenue AS DOUBLE) AS value") {
+	if !strings.Contains(plan.SQL, "t1.state AS label") || !strings.Contains(plan.SQL, "CAST(t0.revenue AS DOUBLE) AS value") {
 		t.Fatalf("raw value plan SQL missing fields:\n%s", plan.SQL)
 	}
-	if !strings.Contains(plan.SQL, "t1.customer_state = ?") {
+	if !strings.Contains(plan.SQL, "t1.state = ?") {
 		t.Fatalf("raw value plan SQL missing filter:\n%s", plan.SQL)
 	}
 }
@@ -317,7 +311,7 @@ func TestPlannerRejectsUnknownFields(t *testing.T) {
 		field string
 		want  string
 	}{
-		{field: "orders.missing", want: "unknown dimension"},
+		{field: "orders.missing", want: "unknown field"},
 		{field: "missing.state", want: "unknown table"},
 	} {
 		_, err := planner.Plan(Request{

--- a/internal/analytics/query/sql.go
+++ b/internal/analytics/query/sql.go
@@ -99,11 +99,7 @@ func dimensionExpr(dimension semanticmodel.MetricDimension, aliases map[string]t
 }
 
 func dimensionWhereExpr(dimension semanticmodel.MetricDimension, aliases map[string]tableAlias) string {
-	if strings.TrimSpace(dimension.Where) == "" {
-		return ""
-	}
-	alias := aliases[dimension.Table].Alias
-	return applyAliases(dimension.Where, aliases, alias)
+	return ""
 }
 
 func measureExpr(measure ResolvedMeasure, aliases map[string]tableAlias) string {

--- a/internal/app/deployments.go
+++ b/internal/app/deployments.go
@@ -115,7 +115,11 @@ func (s *Server) validateDeployment(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, err, http.StatusInternalServerError)
 		return
 	}
-	service := validate.NewService(repo, deploymentfs.NewArtifactStore(s.artifactDir), deploymentfs.Validator{})
+	dataDir := ""
+	if s.metrics != nil {
+		dataDir = s.metrics.DataDir()
+	}
+	service := validate.NewService(repo, deploymentfs.NewArtifactStore(s.artifactDir), deploymentfs.Validator{DataDir: dataDir})
 	deployment, err := service.Validate(r.Context(), deployment.ID(deploymentID))
 	if err != nil {
 		writeJSONError(w, err, http.StatusBadRequest)

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -459,7 +459,7 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"Connections", "Global", "data-connection-toolbar", "local connection"} {
+	for _, want := range []string{"Connections", "Global", "data-connection-toolbar", "Local CSV files for the Olist ecommerce demo dataset."} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("connections page missing %q:\n%s", want, body)
 		}
@@ -569,10 +569,10 @@ func TestConnectionsPageFallsBackToRuntimeAssetsWithoutActiveDeployment(t *testi
 }
 
 func TestStaleActiveLineageGraphDetectsPartialCleanGraphs(t *testing.T) {
+	workspaceID := workspace.WorkspaceID("test")
+	deploymentID := workspace.DeploymentID("dep_test")
 	graph := func(modelContent, dashboardContent any, includeRelationship, includePageItem bool, rollupEdge workspace.AssetEdgeType) workspace.AssetGraph {
 		t.Helper()
-		workspaceID := workspace.WorkspaceID("test")
-		deploymentID := workspace.DeploymentID("dep_test")
 		catalog := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeCatalog, "test", "", "Catalog", map[string]any{})
 		model := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSemanticModel, "olist", catalog.ID, "Olist", modelContent)
 		semanticTable := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSemanticTable, "olist.orders", model.ID, "Orders", map[string]any{})
@@ -610,8 +610,48 @@ func TestStaleActiveLineageGraphDetectsPartialCleanGraphs(t *testing.T) {
 	if !staleActiveLineageGraph(graph(map[string]any{}, map[string]any{}, true, true, workspace.AssetEdgeUsesMeasure)) {
 		t.Fatal("persisted dashboard rollup dependency edges should be stale")
 	}
+	sourceWithGeneratedDescription := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.customers", "", "customers", map[string]any{
+		"Format": "csv",
+		"Path":   "olist_customers_dataset.csv",
+	})
+	sourceWithGeneratedDescription.Description = "csv file: olist_customers_dataset.csv"
+	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{sourceWithGeneratedDescription}}) {
+		t.Fatal("source asset with legacy generated description should be stale")
+	}
+	connectionWithGeneratedDescription := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeConnection, "olist.olist", "", "olist", map[string]any{
+		"Kind": "local",
+	})
+	connectionWithGeneratedDescription.Description = "local connection"
+	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{connectionWithGeneratedDescription}}) {
+		t.Fatal("connection asset with legacy generated description should be stale")
+	}
 	if staleActiveLineageGraph(graph(map[string]any{}, map[string]any{}, true, false, "")) {
 		t.Fatal("clean graph without relationships or page placements should not be stale")
+	}
+	authoredSource := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.customers", "", "customers", map[string]any{})
+	authoredSource.Description = "Raw customer records with customer geography."
+	if staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{authoredSource}}) {
+		t.Fatal("source asset with authored description should not be stale")
+	}
+	sourceWithoutMetadataVersion := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.orders", "", "orders", map[string]any{
+		"Schema": map[string]any{"Columns": []any{map[string]any{"Name": "order_id"}}},
+	})
+	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{sourceWithoutMetadataVersion}}) {
+		t.Fatal("source asset with discovered schema and no asset version should be stale")
+	}
+	sourceWithMetadataVersion := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.orders", "", "orders", map[string]any{
+		"Schema":       map[string]any{"Columns": []any{map[string]any{"Name": "order_id"}}},
+		"AssetVersion": 1,
+	})
+	if staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{sourceWithMetadataVersion}}) {
+		t.Fatal("source asset with metadata version should not be stale")
+	}
+	sourceWithFieldsWithoutSchema := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.orders", "", "orders", map[string]any{
+		"Fields":       map[string]any{"order_id": map[string]any{"Label": "Order ID"}},
+		"AssetVersion": 1,
+	})
+	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{sourceWithFieldsWithoutSchema}}) {
+		t.Fatal("source asset with field docs and no schema should be stale")
 	}
 }
 
@@ -632,7 +672,12 @@ func TestReconcileActiveLineageGraphReplacesStaleGraphFromActiveRuntime(t *testi
 	catalog := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeCatalog, "test", "", "Catalog", map[string]any{})
 	model := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSemanticModel, "olist", catalog.ID, "Olist", map[string]any{})
 	dashboard := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeDashboard, "sales", catalog.ID, "Sales", map[string]any{})
-	staleAssets := []workspace.Asset{catalog, model, dashboard}
+	staleSource := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.customers", catalog.ID, "customers", map[string]any{
+		"Format": "csv",
+		"Path":   "olist_customers_dataset.csv",
+	})
+	staleSource.Description = "csv file: olist_customers_dataset.csv"
+	staleAssets := []workspace.Asset{catalog, model, dashboard, staleSource}
 	staleEdges := []workspace.AssetEdge{
 		workspace.NewAssetEdge(workspaceID, deploymentID, catalog.ID, model.ID, workspace.AssetEdgeContains),
 		workspace.NewAssetEdge(workspaceID, deploymentID, catalog.ID, dashboard.ID, workspace.AssetEdgeContains),
@@ -641,6 +686,13 @@ func TestReconcileActiveLineageGraphReplacesStaleGraphFromActiveRuntime(t *testi
 	if !ok {
 		t.Fatal("runtime graph unavailable")
 	}
+	cleanSource := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.customers", cleanAssets[0].ID, "customers", map[string]any{
+		"Format":       "csv",
+		"Path":         "olist_customers_dataset.csv",
+		"AssetVersion": 1,
+	})
+	cleanSource.Description = "Raw customer records with customer geography."
+	cleanAssets = append(cleanAssets, cleanSource)
 	validation := deployment.Validation{
 		Digest:       "digest",
 		ManifestJSON: "{}",
@@ -670,6 +722,10 @@ func TestReconcileActiveLineageGraphReplacesStaleGraphFromActiveRuntime(t *testi
 	}
 	if !graphHasAssetType(graph, workspace.AssetTypeSemanticTable) {
 		t.Fatalf("reconciled graph missing semantic table asset: %#v", graph.Assets)
+	}
+	source := graphAssetByTypeAndKey(t, graph, workspace.AssetTypeSource, "olist.customers")
+	if source.Description != "Raw customer records with customer geography." {
+		t.Fatalf("source description = %q, want authored runtime description", source.Description)
 	}
 	active, err := deploymentRepo.ByID(ctx, created.ID)
 	if err != nil {
@@ -748,6 +804,17 @@ func graphHasAssetType(graph workspace.AssetGraph, typ workspace.AssetType) bool
 		}
 	}
 	return false
+}
+
+func graphAssetByTypeAndKey(t *testing.T, graph workspace.AssetGraph, typ workspace.AssetType, key string) workspace.Asset {
+	t.Helper()
+	for _, asset := range graph.Assets {
+		if asset.Type == typ && asset.Key == key {
+			return asset
+		}
+	}
+	t.Fatalf("graph missing asset %s %q", typ, key)
+	return workspace.Asset{}
 }
 
 func TestWorkspacePermissionsRejectViewer(t *testing.T) {

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -628,30 +628,45 @@ func TestStaleActiveLineageGraphDetectsPartialCleanGraphs(t *testing.T) {
 	if staleActiveLineageGraph(graph(map[string]any{}, map[string]any{}, true, false, "")) {
 		t.Fatal("clean graph without relationships or page placements should not be stale")
 	}
+	currentVersionAsset := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.orders", "", "orders", map[string]any{
+		"Fields": map[string]any{"order_id": map[string]any{"Label": "Order ID"}},
+		"Schema": map[string]any{"Columns": []any{map[string]any{"Name": "order_id"}}},
+	})
+	currentVersionAsset.ContentVersion = workspace.CurrentAssetContentVersion
+	if staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{currentVersionAsset}}) {
+		t.Fatal("asset with current content version should not be stale")
+	}
+	oldVersionAsset := currentVersionAsset
+	oldVersionAsset.ContentVersion = workspace.CurrentAssetContentVersion - 1
+	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{oldVersionAsset}}) {
+		t.Fatal("asset with old content version should be stale")
+	}
 	authoredSource := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.customers", "", "customers", map[string]any{})
+	authoredSource.ContentVersion = workspace.CurrentAssetContentVersion
 	authoredSource.Description = "Raw customer records with customer geography."
 	if staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{authoredSource}}) {
 		t.Fatal("source asset with authored description should not be stale")
 	}
-	sourceWithoutMetadataVersion := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.orders", "", "orders", map[string]any{
+	sourceWithOldContentVersion := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.orders", "", "orders", map[string]any{
 		"Schema": map[string]any{"Columns": []any{map[string]any{"Name": "order_id"}}},
 	})
-	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{sourceWithoutMetadataVersion}}) {
-		t.Fatal("source asset with discovered schema and no asset version should be stale")
-	}
-	sourceWithMetadataVersion := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.orders", "", "orders", map[string]any{
-		"Schema":       map[string]any{"Columns": []any{map[string]any{"Name": "order_id"}}},
-		"AssetVersion": 1,
-	})
-	if staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{sourceWithMetadataVersion}}) {
-		t.Fatal("source asset with metadata version should not be stale")
+	sourceWithOldContentVersion.ContentVersion = workspace.CurrentAssetContentVersion - 1
+	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{sourceWithOldContentVersion}}) {
+		t.Fatal("source asset with old content version should be stale")
 	}
 	sourceWithFieldsWithoutSchema := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.orders", "", "orders", map[string]any{
-		"Fields":       map[string]any{"order_id": map[string]any{"Label": "Order ID"}},
-		"AssetVersion": 1,
+		"Fields": map[string]any{"order_id": map[string]any{"Label": "Order ID"}},
 	})
+	sourceWithFieldsWithoutSchema.ContentVersion = workspace.CurrentAssetContentVersion
 	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{sourceWithFieldsWithoutSchema}}) {
 		t.Fatal("source asset with field docs and no schema should be stale")
+	}
+	modelTableWithFieldsWithoutSchema := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeModelTable, "olist.orders", "", "orders", map[string]any{
+		"Dimensions": map[string]any{"order_id": map[string]any{"Label": "Order ID"}},
+	})
+	modelTableWithFieldsWithoutSchema.ContentVersion = workspace.CurrentAssetContentVersion
+	if !staleActiveLineageGraph(workspace.AssetGraph{Assets: []workspace.Asset{modelTableWithFieldsWithoutSchema}}) {
+		t.Fatal("model table asset with field docs and no schema should be stale")
 	}
 }
 
@@ -687,10 +702,10 @@ func TestReconcileActiveLineageGraphReplacesStaleGraphFromActiveRuntime(t *testi
 		t.Fatal("runtime graph unavailable")
 	}
 	cleanSource := mustWorkspaceAsset(t, workspaceID, deploymentID, workspace.AssetTypeSource, "olist.customers", cleanAssets[0].ID, "customers", map[string]any{
-		"Format":       "csv",
-		"Path":         "olist_customers_dataset.csv",
-		"AssetVersion": 1,
+		"Format": "csv",
+		"Path":   "olist_customers_dataset.csv",
 	})
+	cleanSource.ContentVersion = workspace.CurrentAssetContentVersion
 	cleanSource.Description = "Raw customer records with customer geography."
 	cleanAssets = append(cleanAssets, cleanSource)
 	validation := deployment.Validation{
@@ -1097,16 +1112,17 @@ func deploymentAssets(rows []workspace.Asset) []deployment.Asset {
 	assets := make([]deployment.Asset, 0, len(rows))
 	for _, row := range rows {
 		assets = append(assets, deployment.Asset{
-			ID:           string(row.ID),
-			WorkspaceID:  deployment.WorkspaceID(row.WorkspaceID),
-			DeploymentID: deployment.ID(row.DeploymentID),
-			Type:         string(row.Type),
-			Key:          row.Key,
-			ParentID:     string(row.ParentID),
-			Title:        row.Title,
-			Description:  row.Description,
-			ContentJSON:  row.ContentJSON,
-			ContentHash:  row.ContentHash,
+			ID:             string(row.ID),
+			WorkspaceID:    deployment.WorkspaceID(row.WorkspaceID),
+			DeploymentID:   deployment.ID(row.DeploymentID),
+			Type:           string(row.Type),
+			Key:            row.Key,
+			ParentID:       string(row.ParentID),
+			Title:          row.Title,
+			Description:    row.Description,
+			ContentJSON:    row.ContentJSON,
+			ContentHash:    row.ContentHash,
+			ContentVersion: row.ContentVersion,
 		})
 	}
 	return assets

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -57,7 +57,7 @@ func (fakeMetrics) ModelIDForDashboard(dashboardID string) string {
 }
 
 func (fakeMetrics) DataDir() string {
-	return ".data/olist"
+	return "../../.data/olist"
 }
 
 func (fakeMetrics) Report(dashboardID string) (reportdef.Dashboard, *semanticmodel.Model, bool) {

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -489,6 +489,12 @@ func staleActiveLineageGraph(graph workspace.AssetGraph) bool {
 	assets := map[workspace.AssetID]workspace.Asset{}
 	for _, asset := range graph.Assets {
 		assets[asset.ID] = asset
+		if assetHasLegacyGeneratedDescription(asset) {
+			return true
+		}
+		if assetHasStaleSourceMetadata(asset) {
+			return true
+		}
 		switch asset.Type {
 		case "semantic_model", "dashboard":
 			hasLegacyModel = true
@@ -529,6 +535,71 @@ func staleActiveLineageGraph(graph workspace.AssetGraph) bool {
 		}
 	}
 	return false
+}
+
+func assetHasStaleSourceMetadata(asset workspace.Asset) bool {
+	if asset.Type != workspace.AssetTypeSource {
+		return false
+	}
+	var content map[string]any
+	if err := json.Unmarshal([]byte(asset.ContentJSON), &content); err != nil {
+		return false
+	}
+	if !assetContentHasItems(asset.ContentJSON, "Schema", "schema") {
+		return assetContentHasItems(asset.ContentJSON, "Fields", "fields")
+	}
+	if _, ok := content["AssetVersion"]; ok {
+		return false
+	}
+	if _, ok := content["assetVersion"]; ok {
+		return false
+	}
+	return true
+}
+
+func assetHasLegacyGeneratedDescription(asset workspace.Asset) bool {
+	description := strings.TrimSpace(asset.Description)
+	if description == "" {
+		return false
+	}
+	switch asset.Type {
+	case workspace.AssetTypeConnection:
+		var content map[string]any
+		if err := json.Unmarshal([]byte(asset.ContentJSON), &content); err != nil {
+			return false
+		}
+		kind, _ := content["Kind"].(string)
+		if kind == "" {
+			kind, _ = content["kind"].(string)
+		}
+		return kind != "" && description == kind+" connection"
+	case workspace.AssetTypeSource:
+		var content map[string]any
+		if err := json.Unmarshal([]byte(asset.ContentJSON), &content); err != nil {
+			return false
+		}
+		format, _ := content["Format"].(string)
+		if format == "" {
+			format, _ = content["format"].(string)
+		}
+		path, _ := content["Path"].(string)
+		if path == "" {
+			path, _ = content["path"].(string)
+		}
+		object, _ := content["Object"].(string)
+		if object == "" {
+			object, _ = content["object"].(string)
+		}
+		if object != "" && description == "object: "+object {
+			return true
+		}
+		if format == "" || path == "" {
+			return false
+		}
+		return description == format+" file: "+path || description == format+" table: "+path
+	default:
+		return false
+	}
 }
 
 func assetContentHasItems(raw string, keys ...string) bool {
@@ -750,7 +821,7 @@ func safeAssetMeta(assetType, raw string) map[string]any {
 	case "connection":
 		content["credentials_configured"] = authConfigured
 	case "source":
-		return pickMeta(content, "format", "Format", "path", "Path", "connection", "Connection", "object", "Object", "options", "Options")
+		return pickMeta(content, "format", "Format", "path", "Path", "connection", "Connection", "object", "Object", "options", "Options", "fields", "Fields", "schema", "Schema")
 	case "model_table":
 		return pickMeta(content,
 			"source", "Source",
@@ -762,6 +833,7 @@ func safeAssetMeta(assetType, raw string) map[string]any {
 			"grain", "Grain",
 			"dimensions", "Dimensions",
 			"fields", "Fields",
+			"schema", "Schema",
 		)
 	case "measure":
 		return pickMeta(content, "expression", "Expression", "unit", "Unit", "format", "Format")

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -489,10 +489,13 @@ func staleActiveLineageGraph(graph workspace.AssetGraph) bool {
 	assets := map[workspace.AssetID]workspace.Asset{}
 	for _, asset := range graph.Assets {
 		assets[asset.ID] = asset
+		if asset.ContentVersion < workspace.CurrentAssetContentVersion {
+			return true
+		}
 		if assetHasLegacyGeneratedDescription(asset) {
 			return true
 		}
-		if assetHasStaleSourceMetadata(asset) {
+		if assetHasDocumentedFieldsWithoutSchema(asset) {
 			return true
 		}
 		switch asset.Type {
@@ -537,24 +540,17 @@ func staleActiveLineageGraph(graph workspace.AssetGraph) bool {
 	return false
 }
 
-func assetHasStaleSourceMetadata(asset workspace.Asset) bool {
-	if asset.Type != workspace.AssetTypeSource {
+func assetHasDocumentedFieldsWithoutSchema(asset workspace.Asset) bool {
+	if asset.Type != workspace.AssetTypeSource && asset.Type != workspace.AssetTypeModelTable {
 		return false
 	}
-	var content map[string]any
-	if err := json.Unmarshal([]byte(asset.ContentJSON), &content); err != nil {
+	if assetContentHasItems(asset.ContentJSON, "Schema", "schema") {
 		return false
 	}
-	if !assetContentHasItems(asset.ContentJSON, "Schema", "schema") {
-		return assetContentHasItems(asset.ContentJSON, "Fields", "fields")
+	if asset.Type == workspace.AssetTypeModelTable {
+		return assetContentHasItems(asset.ContentJSON, "Dimensions", "dimensions", "Fields", "fields")
 	}
-	if _, ok := content["AssetVersion"]; ok {
-		return false
-	}
-	if _, ok := content["assetVersion"]; ok {
-		return false
-	}
-	return true
+	return assetContentHasItems(asset.ContentJSON, "Fields", "fields")
 }
 
 func assetHasLegacyGeneratedDescription(asset workspace.Asset) bool {

--- a/internal/dashboard/report/contracts_types.go
+++ b/internal/dashboard/report/contracts_types.go
@@ -23,6 +23,7 @@ type Dashboard struct {
 type FilterDefinition struct {
 	Type             string         `yaml:"type" json:"type"`
 	Label            string         `yaml:"label" json:"label"`
+	Description      string         `yaml:"description" json:"description,omitempty"`
 	Dimension        string         `yaml:"field" json:"dimension"`
 	Default          FilterDefault  `yaml:"default" json:"default"`
 	Custom           bool           `yaml:"custom" json:"custom,omitempty"`
@@ -73,6 +74,7 @@ type FilterValues struct {
 
 type Visual struct {
 	Title           string            `yaml:"title"`
+	Description     string            `yaml:"description"`
 	Kind            string            `yaml:"kind"`
 	Shape           string            `yaml:"shape"`
 	Renderer        string            `yaml:"renderer"`
@@ -365,6 +367,7 @@ func (s SelectionInteraction) IsZero() bool {
 type TableVisual struct {
 	Kind              string                                     `yaml:"kind"`
 	Title             string                                     `yaml:"title"`
+	Description       string                                     `yaml:"description"`
 	Query             TableQuery                                 `yaml:"query"`
 	DefaultSort       dashboard.TableSort                        `yaml:"default_sort"`
 	Style             dashboard.TableStyle                       `yaml:"style"`

--- a/internal/dashboard/runtime/runtime_dashboard_test.go
+++ b/internal/dashboard/runtime/runtime_dashboard_test.go
@@ -44,22 +44,22 @@ func TestServiceTableInteractiveCap(t *testing.T) {
 	dir := t.TempDir()
 	const rows = dashboard.TableInteractiveRowCap + 5
 	var orders, items, payments, customers, reviews strings.Builder
-	orders.WriteString("order_id,customer_id,order_status,order_purchase_timestamp,order_delivered_customer_date\n")
-	items.WriteString("order_id,order_item_id,product_id,price,freight_value\n")
-	payments.WriteString("order_id,payment_value\n")
-	customers.WriteString("customer_id,customer_state\n")
-	reviews.WriteString("review_id,order_id,review_score\n")
+	orders.WriteString("order_id,customer_id,order_status,order_purchase_timestamp,order_approved_at,order_delivered_carrier_date,order_delivered_customer_date,order_estimated_delivery_date\n")
+	items.WriteString("order_id,order_item_id,product_id,seller_id,shipping_limit_date,price,freight_value\n")
+	payments.WriteString("order_id,payment_sequential,payment_type,payment_installments,payment_value\n")
+	customers.WriteString("customer_id,customer_unique_id,customer_zip_code_prefix,customer_city,customer_state\n")
+	reviews.WriteString("review_id,order_id,review_score,review_comment_title,review_comment_message,review_creation_date,review_answer_timestamp\n")
 	for i := 0; i < rows; i++ {
-		fmt.Fprintf(&orders, "o%d,c%d,delivered,2018-01-10 10:00:00,2018-01-14 10:00:00\n", i, i)
-		fmt.Fprintf(&items, "o%d,1,p1,100.00,10.00\n", i)
-		fmt.Fprintf(&payments, "o%d,110.00\n", i)
-		fmt.Fprintf(&customers, "c%d,SP\n", i)
-		fmt.Fprintf(&reviews, "r%d,o%d,5\n", i, i)
+		fmt.Fprintf(&orders, "o%d,c%d,delivered,2018-01-10 10:00:00,2018-01-10 11:00:00,2018-01-11 10:00:00,2018-01-14 10:00:00,2018-01-20 10:00:00\n", i, i)
+		fmt.Fprintf(&items, "o%d,1,p1,s1,2018-01-12 10:00:00,100.00,10.00\n", i)
+		fmt.Fprintf(&payments, "o%d,1,credit_card,1,110.00\n", i)
+		fmt.Fprintf(&customers, "c%d,u%d,01001,Sao Paulo,SP\n", i, i)
+		fmt.Fprintf(&reviews, "r%d,o%d,5,,,,2018-01-15 10:00:00\n", i, i)
 	}
 	writeFixture(t, dir, "olist_orders_dataset.csv", orders.String())
 	writeFixture(t, dir, "olist_order_items_dataset.csv", items.String())
 	writeFixture(t, dir, "olist_order_payments_dataset.csv", payments.String())
-	writeFixture(t, dir, "olist_products_dataset.csv", "product_id,product_category_name\np1,beleza_saude\n")
+	writeFixture(t, dir, "olist_products_dataset.csv", "product_id,product_category_name,product_name_lenght,product_description_lenght,product_photos_qty,product_weight_g,product_length_cm,product_height_cm,product_width_cm\np1,beleza_saude,10,20,1,500,20,10,15\n")
 	writeFixture(t, dir, "olist_customers_dataset.csv", customers.String())
 	writeFixture(t, dir, "olist_order_reviews_dataset.csv", reviews.String())
 	writeFixture(t, dir, "product_category_name_translation.csv", "product_category_name,product_category_name_english\nbeleza_saude,health_beauty\n")
@@ -96,29 +96,29 @@ func TestServiceTableInteractiveCap(t *testing.T) {
 
 func TestServiceQueryFixture(t *testing.T) {
 	dir := t.TempDir()
-	writeFixture(t, dir, "olist_orders_dataset.csv", `order_id,customer_id,order_status,order_purchase_timestamp,order_delivered_customer_date
-o1,c1,delivered,2018-01-10 10:00:00,2018-01-14 10:00:00
-o2,c2,shipped,2017-06-10 10:00:00,2017-06-20 10:00:00
+	writeFixture(t, dir, "olist_orders_dataset.csv", `order_id,customer_id,order_status,order_purchase_timestamp,order_approved_at,order_delivered_carrier_date,order_delivered_customer_date,order_estimated_delivery_date
+o1,c1,delivered,2018-01-10 10:00:00,2018-01-10 11:00:00,2018-01-11 10:00:00,2018-01-14 10:00:00,2018-01-20 10:00:00
+o2,c2,shipped,2017-06-10 10:00:00,2017-06-10 11:00:00,2017-06-11 10:00:00,2017-06-20 10:00:00,2017-06-25 10:00:00
 `)
-	writeFixture(t, dir, "olist_order_items_dataset.csv", `order_id,order_item_id,product_id,price,freight_value
-o1,1,p1,100.00,10.00
-o2,1,p2,50.00,5.00
+	writeFixture(t, dir, "olist_order_items_dataset.csv", `order_id,order_item_id,product_id,seller_id,shipping_limit_date,price,freight_value
+o1,1,p1,s1,2018-01-12 10:00:00,100.00,10.00
+o2,1,p2,s2,2017-06-12 10:00:00,50.00,5.00
 `)
-	writeFixture(t, dir, "olist_order_payments_dataset.csv", `order_id,payment_value
-o1,110.00
-o2,55.00
+	writeFixture(t, dir, "olist_order_payments_dataset.csv", `order_id,payment_sequential,payment_type,payment_installments,payment_value
+o1,1,credit_card,1,110.00
+o2,1,credit_card,1,55.00
 `)
-	writeFixture(t, dir, "olist_products_dataset.csv", `product_id,product_category_name
-p1,beleza_saude
-p2,relogios_presentes
+	writeFixture(t, dir, "olist_products_dataset.csv", `product_id,product_category_name,product_name_lenght,product_description_lenght,product_photos_qty,product_weight_g,product_length_cm,product_height_cm,product_width_cm
+p1,beleza_saude,10,20,1,500,20,10,15
+p2,relogios_presentes,12,24,1,600,22,11,16
 `)
-	writeFixture(t, dir, "olist_customers_dataset.csv", `customer_id,customer_state
-c1,SP
-c2,RJ
+	writeFixture(t, dir, "olist_customers_dataset.csv", `customer_id,customer_unique_id,customer_zip_code_prefix,customer_city,customer_state
+c1,u1,01001,Sao Paulo,SP
+c2,u2,20000,Rio de Janeiro,RJ
 `)
-	writeFixture(t, dir, "olist_order_reviews_dataset.csv", `review_id,order_id,review_score
-r1,o1,5
-r2,o2,3
+	writeFixture(t, dir, "olist_order_reviews_dataset.csv", `review_id,order_id,review_score,review_comment_title,review_comment_message,review_creation_date,review_answer_timestamp
+r1,o1,5,,,2018-01-15,2018-01-15 10:00:00
+r2,o2,3,,,2017-06-21,2017-06-21 10:00:00
 `)
 	writeFixture(t, dir, "product_category_name_translation.csv", `product_category_name,product_category_name_english
 beleza_saude,health_beauty
@@ -671,39 +671,39 @@ relogios_presentes,watches_gifts
 
 func TestServiceInteractionSelectionPreservesCompositeTuples(t *testing.T) {
 	dir := t.TempDir()
-	writeFixture(t, dir, "olist_orders_dataset.csv", `order_id,customer_id,order_status,order_purchase_timestamp,order_delivered_customer_date
-o1,c1,delivered,2018-01-10 10:00:00,2018-01-14 10:00:00
-o2,c2,delivered,2018-01-11 10:00:00,2018-01-15 10:00:00
-o3,c3,shipped,2018-01-12 10:00:00,2018-01-16 10:00:00
-o4,c4,shipped,2018-01-13 10:00:00,2018-01-17 10:00:00
+	writeFixture(t, dir, "olist_orders_dataset.csv", `order_id,customer_id,order_status,order_purchase_timestamp,order_approved_at,order_delivered_carrier_date,order_delivered_customer_date,order_estimated_delivery_date
+o1,c1,delivered,2018-01-10 10:00:00,2018-01-10 11:00:00,2018-01-11 10:00:00,2018-01-14 10:00:00,2018-01-20 10:00:00
+o2,c2,delivered,2018-01-11 10:00:00,2018-01-11 11:00:00,2018-01-12 10:00:00,2018-01-15 10:00:00,2018-01-20 10:00:00
+o3,c3,shipped,2018-01-12 10:00:00,2018-01-12 11:00:00,2018-01-13 10:00:00,2018-01-16 10:00:00,2018-01-20 10:00:00
+o4,c4,shipped,2018-01-13 10:00:00,2018-01-13 11:00:00,2018-01-14 10:00:00,2018-01-17 10:00:00,2018-01-20 10:00:00
 `)
-	writeFixture(t, dir, "olist_order_items_dataset.csv", `order_id,order_item_id,product_id,price,freight_value
-o1,1,p1,100.00,10.00
-o2,1,p2,150.00,15.00
-o3,1,p1,50.00,5.00
-o4,1,p2,200.00,20.00
+	writeFixture(t, dir, "olist_order_items_dataset.csv", `order_id,order_item_id,product_id,seller_id,shipping_limit_date,price,freight_value
+o1,1,p1,s1,2018-01-12 10:00:00,100.00,10.00
+o2,1,p2,s2,2018-01-13 10:00:00,150.00,15.00
+o3,1,p1,s1,2018-01-14 10:00:00,50.00,5.00
+o4,1,p2,s2,2018-01-15 10:00:00,200.00,20.00
 `)
-	writeFixture(t, dir, "olist_order_payments_dataset.csv", `order_id,payment_value
-o1,110.00
-o2,165.00
-o3,55.00
-o4,220.00
+	writeFixture(t, dir, "olist_order_payments_dataset.csv", `order_id,payment_sequential,payment_type,payment_installments,payment_value
+o1,1,credit_card,1,110.00
+o2,1,credit_card,1,165.00
+o3,1,credit_card,1,55.00
+o4,1,credit_card,1,220.00
 `)
-	writeFixture(t, dir, "olist_products_dataset.csv", `product_id,product_category_name
-p1,beleza_saude
-p2,relogios_presentes
+	writeFixture(t, dir, "olist_products_dataset.csv", `product_id,product_category_name,product_name_lenght,product_description_lenght,product_photos_qty,product_weight_g,product_length_cm,product_height_cm,product_width_cm
+p1,beleza_saude,10,20,1,500,20,10,15
+p2,relogios_presentes,12,24,1,600,22,11,16
 `)
-	writeFixture(t, dir, "olist_customers_dataset.csv", `customer_id,customer_state
-c1,SP
-c2,SP
-c3,RJ
-c4,RJ
+	writeFixture(t, dir, "olist_customers_dataset.csv", `customer_id,customer_unique_id,customer_zip_code_prefix,customer_city,customer_state
+c1,u1,01001,Sao Paulo,SP
+c2,u2,01002,Sao Paulo,SP
+c3,u3,20000,Rio de Janeiro,RJ
+c4,u4,20001,Rio de Janeiro,RJ
 `)
-	writeFixture(t, dir, "olist_order_reviews_dataset.csv", `review_id,order_id,review_score
-r1,o1,5
-r2,o2,4
-r3,o3,3
-r4,o4,4
+	writeFixture(t, dir, "olist_order_reviews_dataset.csv", `review_id,order_id,review_score,review_comment_title,review_comment_message,review_creation_date,review_answer_timestamp
+r1,o1,5,,,2018-01-15,2018-01-15 10:00:00
+r2,o2,4,,,2018-01-16,2018-01-16 10:00:00
+r3,o3,3,,,2018-01-17,2018-01-17 10:00:00
+r4,o4,4,,,2018-01-18,2018-01-18 10:00:00
 `)
 	writeFixture(t, dir, "product_category_name_translation.csv", `product_category_name,product_category_name_english
 beleza_saude,health_beauty
@@ -769,29 +769,29 @@ relogios_presentes,watches_gifts
 
 func TestServicePowerFilters(t *testing.T) {
 	dir := t.TempDir()
-	writeFixture(t, dir, "olist_orders_dataset.csv", `order_id,customer_id,order_status,order_purchase_timestamp,order_delivered_customer_date
-o1,c1,delivered,2018-01-10 10:00:00,2018-01-14 10:00:00
-o2,c2,shipped,2017-06-10 10:00:00,2017-06-20 10:00:00
+	writeFixture(t, dir, "olist_orders_dataset.csv", `order_id,customer_id,order_status,order_purchase_timestamp,order_approved_at,order_delivered_carrier_date,order_delivered_customer_date,order_estimated_delivery_date
+o1,c1,delivered,2018-01-10 10:00:00,2018-01-10 11:00:00,2018-01-11 10:00:00,2018-01-14 10:00:00,2018-01-20 10:00:00
+o2,c2,shipped,2017-06-10 10:00:00,2017-06-10 11:00:00,2017-06-11 10:00:00,2017-06-20 10:00:00,2017-06-25 10:00:00
 `)
-	writeFixture(t, dir, "olist_order_items_dataset.csv", `order_id,order_item_id,product_id,price,freight_value
-o1,1,p1,100.00,10.00
-o2,1,p2,50.00,5.00
+	writeFixture(t, dir, "olist_order_items_dataset.csv", `order_id,order_item_id,product_id,seller_id,shipping_limit_date,price,freight_value
+o1,1,p1,s1,2018-01-12 10:00:00,100.00,10.00
+o2,1,p2,s2,2017-06-12 10:00:00,50.00,5.00
 `)
-	writeFixture(t, dir, "olist_order_payments_dataset.csv", `order_id,payment_value
-o1,110.00
-o2,55.00
+	writeFixture(t, dir, "olist_order_payments_dataset.csv", `order_id,payment_sequential,payment_type,payment_installments,payment_value
+o1,1,credit_card,1,110.00
+o2,1,credit_card,1,55.00
 `)
-	writeFixture(t, dir, "olist_products_dataset.csv", `product_id,product_category_name
-p1,beleza_saude
-p2,relogios_presentes
+	writeFixture(t, dir, "olist_products_dataset.csv", `product_id,product_category_name,product_name_lenght,product_description_lenght,product_photos_qty,product_weight_g,product_length_cm,product_height_cm,product_width_cm
+p1,beleza_saude,10,20,1,500,20,10,15
+p2,relogios_presentes,12,24,1,600,22,11,16
 `)
-	writeFixture(t, dir, "olist_customers_dataset.csv", `customer_id,customer_state
-c1,SP
-c2,RJ
+	writeFixture(t, dir, "olist_customers_dataset.csv", `customer_id,customer_unique_id,customer_zip_code_prefix,customer_city,customer_state
+c1,u1,01001,Sao Paulo,SP
+c2,u2,20000,Rio de Janeiro,RJ
 `)
-	writeFixture(t, dir, "olist_order_reviews_dataset.csv", `review_id,order_id,review_score
-r1,o1,5
-r2,o2,3
+	writeFixture(t, dir, "olist_order_reviews_dataset.csv", `review_id,order_id,review_score,review_comment_title,review_comment_message,review_creation_date,review_answer_timestamp
+r1,o1,5,,,2018-01-15,2018-01-15 10:00:00
+r2,o2,3,,,2017-06-21,2017-06-21 10:00:00
 `)
 	writeFixture(t, dir, "product_category_name_translation.csv", `product_category_name,product_category_name_english
 beleza_saude,health_beauty

--- a/internal/dashboard/runtime/semantic_model_design_test.go
+++ b/internal/dashboard/runtime/semantic_model_design_test.go
@@ -87,26 +87,24 @@ sources:
 models:
   orders:
     source: olist_orders
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
+      customer_id: {label: Customer ID}
+      purchase_timestamp: {label: Purchase timestamp}
+      revenue: {label: Revenue}
   customers:
     source: olist_customers
+    primary_key: customer_id
+    fields:
+      customer_id: {label: Customer ID}
+      state: {label: State}
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
-          customer_id: {expr: customer_id}
-          purchase_timestamp: {expr: purchase_timestamp, type: time}
-          revenue: {expr: revenue, type: number}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id: {expr: customer_id}
-          state: {expr: state}
+      - orders
+      - customers
     relationships:
       - from: orders.customer_id
         to: customers.customer_id

--- a/internal/dashboard/types.go
+++ b/internal/dashboard/types.go
@@ -129,20 +129,21 @@ func (p PagePlacement) IsZero() bool {
 }
 
 type PageVisual struct {
-	ID        string        `json:"id" yaml:"id"`
-	Kind      string        `json:"kind" yaml:"kind"`
-	Visual    string        `json:"visual,omitempty" yaml:"visual"`
-	Table     string        `json:"table,omitempty" yaml:"table"`
-	Filter    string        `json:"filter,omitempty" yaml:"filter"`
-	Placement PagePlacement `json:"placement" yaml:"placement"`
-	X         float64       `json:"x" yaml:"-"`
-	Y         float64       `json:"y" yaml:"-"`
-	Width     float64       `json:"width" yaml:"-"`
-	Height    float64       `json:"height" yaml:"-"`
-	Eyebrow   string        `json:"eyebrow,omitempty" yaml:"eyebrow"`
-	Title     string        `json:"title,omitempty" yaml:"title"`
-	Subtitle  string        `json:"subtitle,omitempty" yaml:"subtitle"`
-	Badges    []string      `json:"badges,omitempty" yaml:"badges"`
+	ID          string        `json:"id" yaml:"id"`
+	Kind        string        `json:"kind" yaml:"kind"`
+	Visual      string        `json:"visual,omitempty" yaml:"visual"`
+	Table       string        `json:"table,omitempty" yaml:"table"`
+	Filter      string        `json:"filter,omitempty" yaml:"filter"`
+	Description string        `json:"description,omitempty" yaml:"description"`
+	Placement   PagePlacement `json:"placement" yaml:"placement"`
+	X           float64       `json:"x" yaml:"-"`
+	Y           float64       `json:"y" yaml:"-"`
+	Width       float64       `json:"width" yaml:"-"`
+	Height      float64       `json:"height" yaml:"-"`
+	Eyebrow     string        `json:"eyebrow,omitempty" yaml:"eyebrow"`
+	Title       string        `json:"title,omitempty" yaml:"title"`
+	Subtitle    string        `json:"subtitle,omitempty" yaml:"subtitle"`
+	Badges      []string      `json:"badges,omitempty" yaml:"badges"`
 }
 
 type Filters struct {

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -58,16 +58,17 @@ type Artifact struct {
 }
 
 type Asset struct {
-	ID           string
-	WorkspaceID  WorkspaceID
-	DeploymentID ID
-	Type         string
-	Key          string
-	ParentID     string
-	Title        string
-	Description  string
-	ContentJSON  string
-	ContentHash  string
+	ID             string
+	WorkspaceID    WorkspaceID
+	DeploymentID   ID
+	Type           string
+	Key            string
+	ParentID       string
+	Title          string
+	Description    string
+	ContentJSON    string
+	ContentHash    string
+	ContentVersion int
 }
 
 type AssetEdge struct {

--- a/internal/deployment/filesystem/bundle.go
+++ b/internal/deployment/filesystem/bundle.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -13,6 +14,8 @@ import (
 	"sort"
 	"strings"
 
+	analyticsduckdb "github.com/Yacobolo/libredash/internal/analytics/duckdb"
+	analyticsmaterialize "github.com/Yacobolo/libredash/internal/analytics/materialize"
 	"github.com/Yacobolo/libredash/internal/deployment"
 	"github.com/Yacobolo/libredash/internal/platform"
 	"github.com/Yacobolo/libredash/internal/workspace"
@@ -33,6 +36,11 @@ type ManifestFile struct {
 	Path   string `json:"path"`
 	SHA256 string `json:"sha256"`
 	Size   int64  `json:"size"`
+}
+
+type ValidateOptions struct {
+	DataDir   string
+	DuckDBDir string
 }
 
 func PackCatalog(catalogPath string, out io.Writer) (Manifest, string, error) {
@@ -126,6 +134,10 @@ func PackCatalog(catalogPath string, out io.Writer) (Manifest, string, error) {
 }
 
 func ValidateArtifact(path string, workspaceID deployment.WorkspaceID, deploymentID deployment.ID) (deployment.Validation, error) {
+	return ValidateArtifactWithOptions(path, workspaceID, deploymentID, ValidateOptions{})
+}
+
+func ValidateArtifactWithOptions(path string, workspaceID deployment.WorkspaceID, deploymentID deployment.ID, options ValidateOptions) (deployment.Validation, error) {
 	digest, err := fileDigest(path)
 	if err != nil {
 		return deployment.Validation{}, err
@@ -159,6 +171,18 @@ func ValidateArtifact(path string, workspaceID deployment.WorkspaceID, deploymen
 	if err != nil {
 		os.RemoveAll(root)
 		return deployment.Validation{}, err
+	}
+	if options.DataDir != "" {
+		if err := discoverSchemasForDefinition(context.Background(), compiled.Definition, options); err != nil {
+			os.RemoveAll(root)
+			return deployment.Validation{}, err
+		}
+		graph, err := workspacecompiler.ExtractLineage(workspace.WorkspaceID(workspaceID), workspace.DeploymentID(deploymentID), compiled.Definition)
+		if err != nil {
+			os.RemoveAll(root)
+			return deployment.Validation{}, err
+		}
+		compiled.Workspace.Graph = graph
 	}
 	assets := make([]deployment.Asset, 0, len(compiled.Workspace.Graph.Assets))
 	for _, asset := range compiled.Workspace.Graph.Assets {
@@ -198,6 +222,47 @@ func ValidateArtifact(path string, workspaceID deployment.WorkspaceID, deploymen
 		Assets:       assets,
 		Edges:        edges,
 	}, nil
+}
+
+func discoverSchemasForDefinition(ctx context.Context, definition *workspace.Definition, options ValidateOptions) error {
+	duckDBRoot := options.DuckDBDir
+	removeDuckDBRoot := false
+	if duckDBRoot == "" {
+		var err error
+		duckDBRoot, err = os.MkdirTemp("", "libredash-schema-*")
+		if err != nil {
+			return err
+		}
+		removeDuckDBRoot = true
+	}
+	if removeDuckDBRoot {
+		defer os.RemoveAll(duckDBRoot)
+	}
+	for _, entry := range definition.Catalog.SemanticModels {
+		model := definition.Models[entry.ID]
+		dbDir := filepath.Join(duckDBRoot, entry.ID)
+		dbPath := analyticsmaterialize.DatabasePath(dbDir, entry.ID)
+		if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+			return err
+		}
+		db, err := analyticsduckdb.Open(ctx, dbPath)
+		if err != nil {
+			return err
+		}
+		sources := analyticsduckdb.NewSourceRuntime(db, options.DataDir)
+		if _, err := analyticsmaterialize.Refresh(ctx, db, sources, model); err != nil {
+			db.Close()
+			return err
+		}
+		if err := analyticsduckdb.DiscoverSchemas(ctx, db, model); err != nil {
+			db.Close()
+			return err
+		}
+		if err := db.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func ExtractArtifact(path, dest string) error {

--- a/internal/deployment/filesystem/bundle.go
+++ b/internal/deployment/filesystem/bundle.go
@@ -187,16 +187,17 @@ func ValidateArtifactWithOptions(path string, workspaceID deployment.WorkspaceID
 	assets := make([]deployment.Asset, 0, len(compiled.Workspace.Graph.Assets))
 	for _, asset := range compiled.Workspace.Graph.Assets {
 		assets = append(assets, deployment.Asset{
-			ID:           string(asset.ID),
-			WorkspaceID:  deployment.WorkspaceID(asset.WorkspaceID),
-			DeploymentID: deployment.ID(asset.DeploymentID),
-			Type:         string(asset.Type),
-			Key:          asset.Key,
-			ParentID:     string(asset.ParentID),
-			Title:        asset.Title,
-			Description:  asset.Description,
-			ContentJSON:  asset.ContentJSON,
-			ContentHash:  asset.ContentHash,
+			ID:             string(asset.ID),
+			WorkspaceID:    deployment.WorkspaceID(asset.WorkspaceID),
+			DeploymentID:   deployment.ID(asset.DeploymentID),
+			Type:           string(asset.Type),
+			Key:            asset.Key,
+			ParentID:       string(asset.ParentID),
+			Title:          asset.Title,
+			Description:    asset.Description,
+			ContentJSON:    asset.ContentJSON,
+			ContentHash:    asset.ContentHash,
+			ContentVersion: asset.ContentVersion,
 		})
 	}
 	edges := make([]deployment.AssetEdge, 0, len(compiled.Workspace.Graph.Edges))

--- a/internal/deployment/filesystem/validator.go
+++ b/internal/deployment/filesystem/validator.go
@@ -6,10 +6,16 @@ import (
 	"github.com/Yacobolo/libredash/internal/deployment"
 )
 
-type Validator struct{}
+type Validator struct {
+	DataDir   string
+	DuckDBDir string
+}
 
-func (Validator) ValidateArtifact(path string, workspaceID deployment.WorkspaceID, deploymentID deployment.ID) (deployment.Validation, error) {
-	return ValidateArtifact(path, workspaceID, deploymentID)
+func (v Validator) ValidateArtifact(path string, workspaceID deployment.WorkspaceID, deploymentID deployment.ID) (deployment.Validation, error) {
+	return ValidateArtifactWithOptions(path, workspaceID, deploymentID, ValidateOptions{
+		DataDir:   v.DataDir,
+		DuckDBDir: v.DuckDBDir,
+	})
 }
 
 func (Validator) Cleanup(validation deployment.Validation) error {

--- a/internal/deployment/sqlite/repository.go
+++ b/internal/deployment/sqlite/repository.go
@@ -90,16 +90,17 @@ func (r *Repository) SaveValidated(ctx context.Context, deploymentID deployment.
 	}
 	for _, asset := range validation.Assets {
 		if err := q.InsertAsset(ctx, platformdb.InsertAssetParams{
-			ID:            asset.ID,
-			WorkspaceID:   string(asset.WorkspaceID),
-			DeploymentID:  string(asset.DeploymentID),
-			AssetType:     asset.Type,
-			AssetKey:      asset.Key,
-			ParentAssetID: sql.NullString{String: asset.ParentID, Valid: asset.ParentID != ""},
-			Title:         asset.Title,
-			Description:   asset.Description,
-			ContentJson:   asset.ContentJSON,
-			ContentHash:   asset.ContentHash,
+			ID:             asset.ID,
+			WorkspaceID:    string(asset.WorkspaceID),
+			DeploymentID:   string(asset.DeploymentID),
+			AssetType:      asset.Type,
+			AssetKey:       asset.Key,
+			ParentAssetID:  sql.NullString{String: asset.ParentID, Valid: asset.ParentID != ""},
+			Title:          asset.Title,
+			Description:    asset.Description,
+			ContentJson:    asset.ContentJSON,
+			ContentHash:    asset.ContentHash,
+			ContentVersion: int64(asset.ContentVersion),
 		}); err != nil {
 			return deployment.Deployment{}, err
 		}

--- a/internal/platform/db/models.go
+++ b/internal/platform/db/models.go
@@ -71,17 +71,18 @@ type ApiToken struct {
 }
 
 type Asset struct {
-	ID            string         `json:"id"`
-	WorkspaceID   string         `json:"workspace_id"`
-	DeploymentID  string         `json:"deployment_id"`
-	AssetType     string         `json:"asset_type"`
-	AssetKey      string         `json:"asset_key"`
-	ParentAssetID sql.NullString `json:"parent_asset_id"`
-	Title         string         `json:"title"`
-	Description   string         `json:"description"`
-	ContentJson   string         `json:"content_json"`
-	ContentHash   string         `json:"content_hash"`
-	CreatedAt     string         `json:"created_at"`
+	ID             string         `json:"id"`
+	WorkspaceID    string         `json:"workspace_id"`
+	DeploymentID   string         `json:"deployment_id"`
+	AssetType      string         `json:"asset_type"`
+	AssetKey       string         `json:"asset_key"`
+	ParentAssetID  sql.NullString `json:"parent_asset_id"`
+	Title          string         `json:"title"`
+	Description    string         `json:"description"`
+	ContentJson    string         `json:"content_json"`
+	ContentHash    string         `json:"content_hash"`
+	ContentVersion int64          `json:"content_version"`
+	CreatedAt      string         `json:"created_at"`
 }
 
 type AssetEdge struct {

--- a/internal/platform/db/queries.sql
+++ b/internal/platform/db/queries.sql
@@ -72,8 +72,8 @@ SELECT * FROM deployment_artifacts WHERE deployment_id = ?;
 DELETE FROM assets WHERE deployment_id = ?;
 
 -- name: InsertAsset :exec
-INSERT INTO assets (id, workspace_id, deployment_id, asset_type, asset_key, parent_asset_id, title, description, content_json, content_hash)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO assets (id, workspace_id, deployment_id, asset_type, asset_key, parent_asset_id, title, description, content_json, content_hash, content_version)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: InsertAssetEdge :exec
 INSERT INTO asset_edges (id, workspace_id, deployment_id, from_asset_id, to_asset_id, edge_type)

--- a/internal/platform/db/queries.sql.go
+++ b/internal/platform/db/queries.sql.go
@@ -651,21 +651,22 @@ func (q *Queries) GetWorkspace(ctx context.Context, id string) (Workspace, error
 }
 
 const insertAsset = `-- name: InsertAsset :exec
-INSERT INTO assets (id, workspace_id, deployment_id, asset_type, asset_key, parent_asset_id, title, description, content_json, content_hash)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO assets (id, workspace_id, deployment_id, asset_type, asset_key, parent_asset_id, title, description, content_json, content_hash, content_version)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type InsertAssetParams struct {
-	ID            string         `json:"id"`
-	WorkspaceID   string         `json:"workspace_id"`
-	DeploymentID  string         `json:"deployment_id"`
-	AssetType     string         `json:"asset_type"`
-	AssetKey      string         `json:"asset_key"`
-	ParentAssetID sql.NullString `json:"parent_asset_id"`
-	Title         string         `json:"title"`
-	Description   string         `json:"description"`
-	ContentJson   string         `json:"content_json"`
-	ContentHash   string         `json:"content_hash"`
+	ID             string         `json:"id"`
+	WorkspaceID    string         `json:"workspace_id"`
+	DeploymentID   string         `json:"deployment_id"`
+	AssetType      string         `json:"asset_type"`
+	AssetKey       string         `json:"asset_key"`
+	ParentAssetID  sql.NullString `json:"parent_asset_id"`
+	Title          string         `json:"title"`
+	Description    string         `json:"description"`
+	ContentJson    string         `json:"content_json"`
+	ContentHash    string         `json:"content_hash"`
+	ContentVersion int64          `json:"content_version"`
 }
 
 func (q *Queries) InsertAsset(ctx context.Context, arg InsertAssetParams) error {
@@ -680,6 +681,7 @@ func (q *Queries) InsertAsset(ctx context.Context, arg InsertAssetParams) error 
 		arg.Description,
 		arg.ContentJson,
 		arg.ContentHash,
+		arg.ContentVersion,
 	)
 	return err
 }
@@ -1032,7 +1034,7 @@ func (q *Queries) ListAssetEdgesByDeployment(ctx context.Context, deploymentID s
 }
 
 const listAssetsByDeployment = `-- name: ListAssetsByDeployment :many
-SELECT id, workspace_id, deployment_id, asset_type, asset_key, parent_asset_id, title, description, content_json, content_hash, created_at FROM assets WHERE deployment_id = ? ORDER BY asset_type, asset_key
+SELECT id, workspace_id, deployment_id, asset_type, asset_key, parent_asset_id, title, description, content_json, content_hash, content_version, created_at FROM assets WHERE deployment_id = ? ORDER BY asset_type, asset_key
 `
 
 func (q *Queries) ListAssetsByDeployment(ctx context.Context, deploymentID string) ([]Asset, error) {
@@ -1055,6 +1057,7 @@ func (q *Queries) ListAssetsByDeployment(ctx context.Context, deploymentID strin
 			&i.Description,
 			&i.ContentJson,
 			&i.ContentHash,
+			&i.ContentVersion,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/internal/platform/db/schema.sql
+++ b/internal/platform/db/schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS assets (
   description TEXT NOT NULL DEFAULT '',
   content_json TEXT NOT NULL DEFAULT '{}',
   content_hash TEXT NOT NULL,
+  content_version INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE(deployment_id, asset_type, asset_key)
 );

--- a/internal/platform/migrations/004_asset_content_version.sql
+++ b/internal/platform/migrations/004_asset_content_version.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE assets ADD COLUMN content_version INTEGER NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE assets DROP COLUMN content_version;

--- a/internal/semantic/contracts_test.go
+++ b/internal/semantic/contracts_test.go
@@ -7,6 +7,7 @@ import (
 
 type Model = semanticmodel.Model
 type Source = semanticmodel.Source
+type SourceField = semanticmodel.SourceField
 type Connection = semanticmodel.Connection
 type ConnectionAuth = semanticmodel.ConnectionAuth
 type ConnectionDefaults = semanticmodel.ConnectionDefaults

--- a/internal/semantic/model.go
+++ b/internal/semantic/model.go
@@ -122,22 +122,17 @@ func (file modelFile) compile() (*model.Model, error) {
 		return nil, fmt.Errorf("semantic model %q requires models", file.Name)
 	}
 	tables := map[string]model.Table{}
-	for tableName, tableRef := range spec.Tables {
+	for _, tableName := range spec.Tables {
 		if err := validateSemanticIdentifier(tableName); err != nil {
 			return nil, fmt.Errorf("semantic model table %q is invalid: %w", tableName, err)
 		}
-		modelName := tableRef.Model
-		if modelName == "" {
-			modelName = tableName
-		}
-		modelTable, ok := file.Models[modelName]
+		modelTable, ok := file.Models[tableName]
 		if !ok {
-			return nil, fmt.Errorf("semantic model table %q references unknown model %q", tableName, modelName)
+			return nil, fmt.Errorf("semantic model table %q references unknown model", tableName)
 		}
 		if modelTable.SQL != "" && modelTable.Transform.SQL == "" {
 			modelTable.Transform.SQL = modelTable.SQL
 		}
-		modelTable.PrimaryKey = tableRef.PrimaryKey
 		modelTable.Kind = defaultString(modelTable.Kind, "model")
 		if modelTable.Grain == "" {
 			modelTable.Grain = modelTable.PrimaryKey
@@ -145,12 +140,9 @@ func (file modelFile) compile() (*model.Model, error) {
 		if modelTable.Dimensions == nil {
 			modelTable.Dimensions = map[string]model.MetricDimension{}
 		}
-		for field, dimension := range tableRef.Fields {
+		for field, dimension := range modelTable.Dimensions {
 			if err := validateSemanticIdentifier(field); err != nil {
 				return nil, fmt.Errorf("semantic model table %q field %q is invalid: %w", tableName, field, err)
-			}
-			if dimension.Expr == "" && dimension.Expression == "" {
-				dimension.Expr = field
 			}
 			dimension.Table = tableName
 			dimension.Name = field

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -43,6 +43,41 @@ func TestLoadOlistModel(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsLegacyFieldTransformKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.yaml")
+	if err := os.WriteFile(path, []byte(`
+name: olist
+connections:
+  local: {kind: local}
+sources:
+  orders:
+    connection: local
+    path: orders.csv
+models:
+  orders:
+    source: orders
+    primary_key: order_id
+    fields:
+      order_id:
+        expr: order_id
+semantic_models:
+  olist:
+    base_table: orders
+    tables:
+      - orders
+    measures:
+      defaults: {table: orders, grain: order_id}
+      order_count: {expr: COUNT(DISTINCT orders.order_id)}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := semantic.Load(path)
+	if err == nil || !strings.Contains(err.Error(), "field expr not found") {
+		t.Fatalf("semantic.Load() error = %v, want legacy expr rejection", err)
+	}
+}
+
 func TestModelValidateRejectsMeasureOnUnreachableTable(t *testing.T) {
 	model := minimalSourceModel()
 	model.Sources["customers"] = Source{Path: "customers.csv"}

--- a/internal/semantic/model_test.go
+++ b/internal/semantic/model_test.go
@@ -465,6 +465,14 @@ sources:
 sources:
   orders: orders.csv
 `,
+		"source_field_label": `
+sources:
+  orders:
+    path: orders.csv
+    fields:
+      order_id:
+        label: Order ID
+`,
 	}
 	for name, fragment := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/semantic/model_types.go
+++ b/internal/semantic/model_types.go
@@ -20,16 +20,10 @@ type modelFile struct {
 }
 
 type semanticModelSpec struct {
-	BaseTable     string                        `yaml:"base_table"`
-	Tables        map[string]semanticModelTable `yaml:"tables"`
-	Relationships []model.Relationship          `yaml:"relationships"`
-	Measures      semanticModelMeasures         `yaml:"measures"`
-}
-
-type semanticModelTable struct {
-	Model      string                           `yaml:"model"`
-	PrimaryKey string                           `yaml:"primary_key"`
-	Fields     map[string]model.MetricDimension `yaml:"fields"`
+	BaseTable     string                `yaml:"base_table"`
+	Tables        []string              `yaml:"tables"`
+	Relationships []model.Relationship  `yaml:"relationships"`
+	Measures      semanticModelMeasures `yaml:"measures"`
 }
 
 type semanticModelMeasures struct {

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -1311,7 +1311,7 @@ func assetDetailModelForAsset(workspace api.WorkspaceResponse, asset api.AssetRe
 	case "connection":
 		connectionDetailModel(&model, workspace, asset, assets, edges)
 	case "source":
-		model.Overview = append(model.Overview, sourceFacts(asset)...)
+		sourceDetailModel(&model, asset)
 	case "measure":
 		model.Overview = append(model.Overview, metricLeafFacts(asset)...)
 	case "field":
@@ -1504,7 +1504,7 @@ func modelTableDetailModel(model *assetDetailModel, workspace api.WorkspaceRespo
 		definitionFact{Label: "Mode", Value: mode},
 	)
 	model.Sections = append(model.Sections,
-		assetDetailSection{Title: fmt.Sprintf("Fields (%d)", len(fields)), Signal: "assetDetailsModelTableFieldsGrid", Grid: modelTableFieldsGrid(workspace.ID, modelKey, tableName, fields, assets)},
+		assetDetailSection{Title: fmt.Sprintf("Fields (%d)", len(fields)), Signal: "assetDetailsModelTableFieldsGrid", Grid: modelTableFieldsGrid(workspace.ID, modelKey, tableName, fields, metaMap(asset.Meta, "Schema", "schema"), assets)},
 	)
 	if sql := modelTableSQL(asset.Meta); sql != "" {
 		model.Sections = append(model.Sections, assetDetailSection{Title: "SQL", Lang: "sql", Code: sql})
@@ -1521,6 +1521,17 @@ func modelTableKeyParts(asset api.AssetResponse) (string, string) {
 
 func modelTableFields(meta map[string]any) map[string]any {
 	return metaMap(meta, "Dimensions", "dimensions", "Fields", "fields")
+}
+
+func sourceDetailModel(model *assetDetailModel, asset api.AssetResponse) {
+	fields := metaMap(asset.Meta, "Fields", "fields")
+	schema := metaMap(asset.Meta, "Schema", "schema")
+	columns := modelTableSchemaColumns(fields, schema)
+	model.Overview = append(model.Overview, sourceFacts(asset)...)
+	model.Overview = append(model.Overview, definitionFact{Label: "Fields", Value: fmt.Sprint(len(columns))})
+	model.Sections = append(model.Sections,
+		assetDetailSection{Title: fmt.Sprintf("Fields (%d)", len(columns)), Signal: "assetDetailsSourceFieldsGrid", Grid: sourceFieldsGrid(fields, schema)},
+	)
 }
 
 func modelTableSourceNames(meta map[string]any) []string {
@@ -1547,26 +1558,94 @@ func modelTableSQL(meta map[string]any) string {
 	)
 }
 
-func modelTableFieldsGrid(workspaceID, modelKey, tableName string, fields map[string]any, assets []api.AssetResponse) metricGrid {
-	rows := make([]map[string]any, 0, len(fields))
-	for _, name := range sortedMapKeys(fields) {
+func modelTableFieldsGrid(workspaceID, modelKey, tableName string, fields, schema map[string]any, assets []api.AssetResponse) metricGrid {
+	schemaColumns := modelTableSchemaColumns(fields, schema)
+	rows := make([]map[string]any, 0, len(schemaColumns))
+	for _, column := range schemaColumns {
+		name := metaString(column, "Name", "name")
 		field := asMap(fields[name])
 		child := assetByTypeKey("field", modelKey+"."+tableName+"."+name, assets)
+		key := ""
+		if metaBool(column, "PrimaryKey", "primaryKey") {
+			key = "Primary key"
+		}
 		rows = append(rows, map[string]any{
-			"name":     name,
-			"nameHref": childHref(workspaceID, child),
-			"type":     metricGridBadgeValue(metaString(field, "Type", "type"), "muted"),
+			"name":          name,
+			"nameHref":      childHref(workspaceID, child),
+			"label":         firstNonEmpty(metaString(field, "Label", "label"), labelFromKey(name)),
+			"physical_type": metricGridBadgeValue(metaString(column, "PhysicalType", "physicalType"), "muted"),
+			"nullable":      boolLabel(metaBool(column, "Nullable", "nullable")),
+			"key":           key,
+			"description":   emptyDash(metaString(field, "Description", "description")),
 		})
 	}
 	return metricGrid{
 		Columns: []metricGridColumn{
 			{ID: "name", Header: "Name", Kind: "link", HrefKey: "nameHref", Width: "170px"},
-			{ID: "type", Header: "Type", Kind: "badge", Width: "110px"},
+			{ID: "label", Header: "Label", Width: "180px"},
+			{ID: "physical_type", Header: "Physical type", Kind: "badge", Width: "140px"},
+			{ID: "nullable", Header: "Nullable", Width: "100px"},
+			{ID: "key", Header: "Key", Width: "130px"},
+			{ID: "description", Header: "Description"},
 		},
 		Rows:     rows,
-		Empty:    "No fields are defined for this model table.",
-		MinWidth: "420px",
+		Empty:    "No schema is available for this model table.",
+		MinWidth: "900px",
 	}
+}
+
+func sourceFieldsGrid(fields, schema map[string]any) metricGrid {
+	schemaColumns := modelTableSchemaColumns(fields, schema)
+	rows := make([]map[string]any, 0, len(schemaColumns))
+	for _, column := range schemaColumns {
+		name := metaString(column, "Name", "name")
+		field := asMap(fields[name])
+		key := ""
+		if metaBool(column, "PrimaryKey", "primaryKey") {
+			key = "Primary key"
+		}
+		rows = append(rows, map[string]any{
+			"name":          name,
+			"label":         firstNonEmpty(metaString(field, "Label", "label"), labelFromKey(name)),
+			"physical_type": metricGridBadgeValue(metaString(column, "PhysicalType", "physicalType"), "muted"),
+			"nullable":      boolLabel(metaBool(column, "Nullable", "nullable")),
+			"key":           key,
+			"description":   emptyDash(metaString(field, "Description", "description")),
+		})
+	}
+	return metricGrid{
+		Columns: []metricGridColumn{
+			{ID: "name", Header: "Name", Kind: "code", Width: "170px"},
+			{ID: "label", Header: "Label", Width: "180px"},
+			{ID: "physical_type", Header: "Physical type", Kind: "badge", Width: "140px"},
+			{ID: "nullable", Header: "Nullable", Width: "100px"},
+			{ID: "key", Header: "Key", Width: "130px"},
+			{ID: "description", Header: "Description"},
+		},
+		Rows:     rows,
+		Empty:    "No schema is available for this source.",
+		MinWidth: "900px",
+	}
+}
+
+func modelTableSchemaColumns(fields map[string]any, schema map[string]any) []map[string]any {
+	if schema != nil {
+		if raw := metaSlice(schema, "Columns", "columns"); len(raw) > 0 {
+			columns := make([]map[string]any, 0, len(raw))
+			for _, item := range raw {
+				columns = append(columns, asMap(item))
+			}
+			sort.Slice(columns, func(i, j int) bool {
+				return metaInt(columns[i], "Ordinal", "ordinal") < metaInt(columns[j], "Ordinal", "ordinal")
+			})
+			return columns
+		}
+	}
+	columns := make([]map[string]any, 0, len(fields))
+	for _, name := range sortedMapKeys(fields) {
+		columns = append(columns, map[string]any{"name": name})
+	}
+	return columns
 }
 
 func semanticFieldsGrid(workspaceID string, parent api.AssetResponse, assets []api.AssetResponse, meta map[string]any) metricGrid {
@@ -2125,6 +2204,17 @@ func metaBool(meta map[string]any, keys ...string) bool {
 		return strings.EqualFold(typed, "true") || strings.EqualFold(typed, "yes")
 	default:
 		return false
+	}
+}
+
+func metaInt(meta map[string]any, keys ...string) int {
+	switch typed := metaValue(meta, keys...).(type) {
+	case int:
+		return typed
+	case float64:
+		return int(typed)
+	default:
+		return 0
 	}
 }
 

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -1574,7 +1574,7 @@ func modelTableFieldsGrid(workspaceID, modelKey, tableName string, fields, schem
 			"nameHref":      childHref(workspaceID, child),
 			"label":         firstNonEmpty(metaString(field, "Label", "label"), labelFromKey(name)),
 			"physical_type": metricGridBadgeValue(metaString(column, "PhysicalType", "physicalType"), "muted"),
-			"nullable":      boolLabel(metaBool(column, "Nullable", "nullable")),
+			"nullable":      nullableLabel(column, "Nullable", "nullable"),
 			"key":           key,
 			"description":   emptyDash(metaString(field, "Description", "description")),
 		})
@@ -1608,7 +1608,7 @@ func sourceFieldsGrid(fields, schema map[string]any) metricGrid {
 			"name":          name,
 			"label":         firstNonEmpty(metaString(field, "Label", "label"), labelFromKey(name)),
 			"physical_type": metricGridBadgeValue(metaString(column, "PhysicalType", "physicalType"), "muted"),
-			"nullable":      boolLabel(metaBool(column, "Nullable", "nullable")),
+			"nullable":      nullableLabel(column, "Nullable", "nullable"),
 			"key":           key,
 			"description":   emptyDash(metaString(field, "Description", "description")),
 		})
@@ -2264,6 +2264,25 @@ func boolLabel(value bool) string {
 		return "Yes"
 	}
 	return "No"
+}
+
+func nullableLabel(meta map[string]any, keys ...string) string {
+	value := metaValue(meta, keys...)
+	if value == nil {
+		return "-"
+	}
+	switch typed := value.(type) {
+	case bool:
+		return boolLabel(typed)
+	case string:
+		if strings.EqualFold(typed, "true") || strings.EqualFold(typed, "yes") {
+			return "Yes"
+		}
+		if strings.EqualFold(typed, "false") || strings.EqualFold(typed, "no") {
+			return "No"
+		}
+	}
+	return "-"
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -1600,27 +1600,19 @@ func sourceFieldsGrid(fields, schema map[string]any) metricGrid {
 	for _, column := range schemaColumns {
 		name := metaString(column, "Name", "name")
 		field := asMap(fields[name])
-		key := ""
-		if metaBool(column, "PrimaryKey", "primaryKey") {
-			key = "Primary key"
-		}
 		rows = append(rows, map[string]any{
 			"name":          name,
-			"label":         firstNonEmpty(metaString(field, "Label", "label"), labelFromKey(name)),
+			"description":   emptyDash(metaString(field, "Description", "description")),
 			"physical_type": metricGridBadgeValue(metaString(column, "PhysicalType", "physicalType"), "muted"),
 			"nullable":      nullableLabel(column, "Nullable", "nullable"),
-			"key":           key,
-			"description":   emptyDash(metaString(field, "Description", "description")),
 		})
 	}
 	return metricGrid{
 		Columns: []metricGridColumn{
 			{ID: "name", Header: "Name", Kind: "code", Width: "170px"},
-			{ID: "label", Header: "Label", Width: "180px"},
+			{ID: "description", Header: "Description"},
 			{ID: "physical_type", Header: "Physical type", Kind: "badge", Width: "140px"},
 			{ID: "nullable", Header: "Nullable", Width: "100px"},
-			{ID: "key", Header: "Key", Width: "130px"},
-			{ID: "description", Header: "Description"},
 		},
 		Rows:     rows,
 		Empty:    "No schema is available for this source.",

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -176,13 +176,45 @@ func TestWorkspaceAssetDetailsRenderDirectSourceModelTableWithoutSQL(t *testing.
 	}
 }
 
+func TestWorkspaceAssetDetailsRenderSourceSchema(t *testing.T) {
+	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
+	asset := testAssetByID(t, assets, "source")
+
+	var out strings.Builder
+	err := WorkspaceAssetPage(catalog, workspace, asset, assets, edges, "details", "Owner").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, want := range []string{
+		"Overview",
+		"Fields (2)",
+		`data-attr:grid="$assetDetailsSourceFieldsGrid"`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("source details did not render %q:\n%s", want, rendered)
+		}
+	}
+	signals := workspaceAssetSignals(workspace, asset, assets, edges, assetLineage(workspace.ID, asset, assets, edges), "details")
+	grid := signalMetricGrid(t, signals, "assetDetailsSourceFieldsGrid")
+	assertGridHeaders(t, grid, []string{"Name", "Label", "Physical type", "Nullable", "Key", "Description"})
+	if len(grid.Rows) != 2 {
+		t.Fatalf("source field rows = %#v, want 2 rows", grid.Rows)
+	}
+	state := grid.Rows[1]
+	if state["name"] != "customer_id" || state["label"] != "Customer ID" || fmt.Sprint(state["description"]) != "Raw customer identifier." {
+		t.Fatalf("unexpected source field row: %#v", state)
+	}
+}
+
 func TestWorkspaceAssetDetailSignalsIncludeModelTableDefinition(t *testing.T) {
 	workspace, _, assets, edges := testWorkspaceAssetFixtures()
 
 	directAsset := testAssetByID(t, assets, "table-model")
 	directSignals := workspaceAssetSignals(workspace, directAsset, assets, edges, assetLineage(workspace.ID, directAsset, assets, edges), "details")
 	directFields := signalMetricGrid(t, directSignals, "assetDetailsModelTableFieldsGrid")
-	assertGridHeaders(t, directFields, []string{"Name", "Type"})
+	assertGridHeaders(t, directFields, []string{"Name", "Label", "Physical type", "Nullable", "Key", "Description"})
 	assertGridMissingHeaders(t, directFields, []string{"Expression", "Filter", "Order", "Model table", "Measures"})
 	if _, ok := directSignals["assetDetailsModelTableDefinitionGrid"]; ok {
 		t.Fatalf("direct source model table seeded source definition grid: %#v", directSignals)
@@ -929,16 +961,32 @@ func testWorkspaceAssetFixtures() (api.WorkspaceResponse, dashboard.Catalog, []a
 			},
 		},
 		{ID: "connection", WorkspaceID: workspace.ID, Type: "connection", Key: "olist.olist", ParentID: "catalog", Title: "Olist connection", Meta: map[string]any{"Kind": "local", "credentials_configured": false}},
-		{ID: "source", WorkspaceID: workspace.ID, Type: "source", Key: "olist.orders", ParentID: "catalog", Title: "orders", Meta: map[string]any{"Connection": "olist", "Format": "csv", "Path": "orders.csv"}},
+		{ID: "source", WorkspaceID: workspace.ID, Type: "source", Key: "olist.orders", ParentID: "catalog", Title: "orders", Meta: map[string]any{
+			"Connection": "olist",
+			"Format":     "csv",
+			"Path":       "orders.csv",
+			"Fields": map[string]any{
+				"order_id":    map[string]any{"Label": "Order ID", "Description": "Raw order identifier."},
+				"customer_id": map[string]any{"Label": "Customer ID", "Description": "Raw customer identifier."},
+			},
+			"Schema": map[string]any{"columns": []any{
+				map[string]any{"name": "order_id", "ordinal": float64(1), "physicalType": "VARCHAR", "nullable": false},
+				map[string]any{"name": "customer_id", "ordinal": float64(2), "physicalType": "VARCHAR", "nullable": true},
+			}},
+		}},
 		{ID: "source-payments", WorkspaceID: workspace.ID, Type: "source", Key: "olist.payments", ParentID: "catalog", Title: "payments", Meta: map[string]any{"Connection": "olist", "Format": "csv", "Path": "payments.csv"}},
 		{ID: "table-model", WorkspaceID: workspace.ID, Type: "model_table", Key: "olist.orders", ParentID: "catalog", Title: "orders", Meta: map[string]any{
 			"Source":     "orders",
 			"PrimaryKey": "order_id",
 			"Grain":      "order_id",
 			"Dimensions": map[string]any{
-				"order_id": map[string]any{"Expr": "order_id"},
-				"state":    map[string]any{"Expr": "state"},
+				"order_id": map[string]any{"Label": "Order ID"},
+				"state":    map[string]any{"Label": "State"},
 			},
+			"Schema": map[string]any{"columns": []any{
+				map[string]any{"name": "order_id", "ordinal": float64(1), "physicalType": "VARCHAR", "nullable": false, "primaryKey": true},
+				map[string]any{"name": "state", "ordinal": float64(2), "physicalType": "VARCHAR", "nullable": true},
+			}},
 		}},
 		{ID: "table-transform", WorkspaceID: workspace.ID, Type: "model_table", Key: "olist.payments", ParentID: "catalog", Title: "payments", Meta: map[string]any{
 			"Sources":            []any{"payments"},
@@ -947,12 +995,16 @@ func testWorkspaceAssetFixtures() (api.WorkspaceResponse, dashboard.Catalog, []a
 			"Grain":              "order_id",
 			"Transform":          map[string]any{"SQL": "SELECT order_id, SUM(payment_value) AS revenue FROM source.payments GROUP BY order_id"},
 			"Dimensions": map[string]any{
-				"order_id": map[string]any{"Expr": "order_id"},
-				"revenue":  map[string]any{"Expr": "revenue", "Type": "number"},
+				"order_id": map[string]any{"Label": "Order ID"},
+				"revenue":  map[string]any{"Label": "Revenue"},
 			},
+			"Schema": map[string]any{"columns": []any{
+				map[string]any{"name": "order_id", "ordinal": float64(1), "physicalType": "VARCHAR", "nullable": false, "primaryKey": true},
+				map[string]any{"name": "revenue", "ordinal": float64(2), "physicalType": "DOUBLE", "nullable": true},
+			}},
 		}},
 		{ID: "semantic-table", WorkspaceID: workspace.ID, Type: "semantic_table", Key: "olist.orders", ParentID: "model", Title: "Orders semantic table", Meta: map[string]any{"Table": "orders"}},
-		{ID: "field", WorkspaceID: workspace.ID, Type: "field", Key: "olist.orders.state", ParentID: "semantic-table", Title: "State", Meta: map[string]any{"Expr": "state"}},
+		{ID: "field", WorkspaceID: workspace.ID, Type: "field", Key: "olist.orders.state", ParentID: "semantic-table", Title: "State", Meta: map[string]any{"Label": "State"}},
 		{ID: "measure", WorkspaceID: workspace.ID, Type: "measure", Key: "olist.revenue", ParentID: "model", Title: "Revenue", Meta: map[string]any{"Table": "orders", "Expression": "SUM(orders.revenue)", "Format": "currency"}},
 		{ID: "relationship", WorkspaceID: workspace.ID, Type: "relationship", Key: "olist.orders_customers", ParentID: "model", Title: "Orders to customers", Meta: map[string]any{"From": "orders.customer_id", "To": "customers.customer_id"}},
 		{ID: "dashboard", WorkspaceID: workspace.ID, Type: "dashboard", Key: "executive-sales", ParentID: "catalog", Title: "Executive Sales Dashboard", Description: "Sales overview.", Href: "/dashboards/executive-sales", Meta: map[string]any{"SemanticModel": "olist", "Tags": []any{"sales"}}},

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -233,6 +233,33 @@ func TestWorkspaceAssetDetailSignalsIncludeModelTableDefinition(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAssetDetailsRenderUnknownNullableAsDash(t *testing.T) {
+	workspace, _, assets, edges := testWorkspaceAssetFixtures()
+
+	source := testAssetByID(t, assets, "source-payments")
+	source.Meta["Fields"] = map[string]any{
+		"order_id": map[string]any{"Label": "Order ID"},
+	}
+	signals := workspaceAssetSignals(workspace, source, assets, edges, assetLineage(workspace.ID, source, assets, edges), "details")
+	sourceGrid := signalMetricGrid(t, signals, "assetDetailsSourceFieldsGrid")
+	if len(sourceGrid.Rows) != 1 {
+		t.Fatalf("source fallback rows = %#v, want 1", sourceGrid.Rows)
+	}
+	if got := fmt.Sprint(sourceGrid.Rows[0]["nullable"]); got != "-" {
+		t.Fatalf("source fallback nullable = %q, want -", got)
+	}
+
+	modelTable := testAssetByID(t, assets, "table-model")
+	modelTable.Meta["Schema"] = map[string]any{"columns": []any{
+		map[string]any{"name": "order_id", "ordinal": float64(1), "physicalType": "VARCHAR", "primaryKey": true},
+	}}
+	signals = workspaceAssetSignals(workspace, modelTable, assets, edges, assetLineage(workspace.ID, modelTable, assets, edges), "details")
+	modelGrid := signalMetricGrid(t, signals, "assetDetailsModelTableFieldsGrid")
+	if got := fmt.Sprint(modelGrid.Rows[0]["nullable"]); got != "-" {
+		t.Fatalf("model table missing nullable = %q, want -", got)
+	}
+}
+
 func TestAssetLineageProjectsRecursiveDependenciesAndContext(t *testing.T) {
 	workspace, _, assets, edges := testWorkspaceAssetFixtures()
 	asset := testAssetByID(t, assets, "page-item")

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -198,12 +198,12 @@ func TestWorkspaceAssetDetailsRenderSourceSchema(t *testing.T) {
 	}
 	signals := workspaceAssetSignals(workspace, asset, assets, edges, assetLineage(workspace.ID, asset, assets, edges), "details")
 	grid := signalMetricGrid(t, signals, "assetDetailsSourceFieldsGrid")
-	assertGridHeaders(t, grid, []string{"Name", "Label", "Physical type", "Nullable", "Key", "Description"})
+	assertGridHeaders(t, grid, []string{"Name", "Description", "Physical type", "Nullable"})
 	if len(grid.Rows) != 2 {
 		t.Fatalf("source field rows = %#v, want 2 rows", grid.Rows)
 	}
 	state := grid.Rows[1]
-	if state["name"] != "customer_id" || state["label"] != "Customer ID" || fmt.Sprint(state["description"]) != "Raw customer identifier." {
+	if state["name"] != "customer_id" || fmt.Sprint(state["description"]) != "Raw customer identifier." {
 		t.Fatalf("unexpected source field row: %#v", state)
 	}
 }
@@ -238,7 +238,7 @@ func TestWorkspaceAssetDetailsRenderUnknownNullableAsDash(t *testing.T) {
 
 	source := testAssetByID(t, assets, "source-payments")
 	source.Meta["Fields"] = map[string]any{
-		"order_id": map[string]any{"Label": "Order ID"},
+		"order_id": map[string]any{"Description": "Raw order identifier."},
 	}
 	signals := workspaceAssetSignals(workspace, source, assets, edges, assetLineage(workspace.ID, source, assets, edges), "details")
 	sourceGrid := signalMetricGrid(t, signals, "assetDetailsSourceFieldsGrid")
@@ -993,8 +993,8 @@ func testWorkspaceAssetFixtures() (api.WorkspaceResponse, dashboard.Catalog, []a
 			"Format":     "csv",
 			"Path":       "orders.csv",
 			"Fields": map[string]any{
-				"order_id":    map[string]any{"Label": "Order ID", "Description": "Raw order identifier."},
-				"customer_id": map[string]any{"Label": "Customer ID", "Description": "Raw customer identifier."},
+				"order_id":    map[string]any{"Description": "Raw order identifier."},
+				"customer_id": map[string]any{"Description": "Raw customer identifier."},
 			},
 			"Schema": map[string]any{"columns": []any{
 				map[string]any{"name": "order_id", "ordinal": float64(1), "physicalType": "VARCHAR", "nullable": false},

--- a/internal/workspace/asset.go
+++ b/internal/workspace/asset.go
@@ -7,16 +7,17 @@ import (
 )
 
 type Asset struct {
-	ID           AssetID
-	WorkspaceID  WorkspaceID
-	DeploymentID DeploymentID
-	Type         AssetType
-	Key          string
-	ParentID     AssetID
-	Title        string
-	Description  string
-	ContentJSON  string
-	ContentHash  string
+	ID             AssetID
+	WorkspaceID    WorkspaceID
+	DeploymentID   DeploymentID
+	Type           AssetType
+	Key            string
+	ParentID       AssetID
+	Title          string
+	Description    string
+	ContentJSON    string
+	ContentHash    string
+	ContentVersion int
 }
 
 type AssetEdge struct {
@@ -33,6 +34,8 @@ type AssetGraph struct {
 	Edges  []AssetEdge
 }
 
+const CurrentAssetContentVersion = 2
+
 func NewAsset(workspaceID WorkspaceID, deploymentID DeploymentID, typ AssetType, key string, parentID AssetID, title, description string, content any) (Asset, error) {
 	bytes, err := json.Marshal(content)
 	if err != nil {
@@ -40,16 +43,17 @@ func NewAsset(workspaceID WorkspaceID, deploymentID DeploymentID, typ AssetType,
 	}
 	sum := sha256.Sum256(bytes)
 	return Asset{
-		ID:           NewAssetID(deploymentID, typ, key),
-		WorkspaceID:  workspaceID,
-		DeploymentID: deploymentID,
-		Type:         typ,
-		Key:          key,
-		ParentID:     parentID,
-		Title:        title,
-		Description:  description,
-		ContentJSON:  string(bytes),
-		ContentHash:  hex.EncodeToString(sum[:]),
+		ID:             NewAssetID(deploymentID, typ, key),
+		WorkspaceID:    workspaceID,
+		DeploymentID:   deploymentID,
+		Type:           typ,
+		Key:            key,
+		ParentID:       parentID,
+		Title:          title,
+		Description:    description,
+		ContentJSON:    string(bytes),
+		ContentHash:    hex.EncodeToString(sum[:]),
+		ContentVersion: CurrentAssetContentVersion,
 	}, nil
 }
 

--- a/internal/workspace/compiler/compiler_test.go
+++ b/internal/workspace/compiler/compiler_test.go
@@ -216,15 +216,15 @@ sources:
 models:
   orders:
     source: orders
+    primary_key: order_id
+    fields:
+      status: {label: Status}
+      revenue: {label: Revenue}
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          status: {expr: status}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       revenue: {expr: SUM(orders.revenue), format: currency}

--- a/internal/workspace/compiler/lineage.go
+++ b/internal/workspace/compiler/lineage.go
@@ -54,7 +54,7 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 		model := definition.Models[modelEntry.ID]
 		for _, connectionName := range sortedMapKeys(model.Connections) {
 			connection := model.Connections[connectionName]
-			id, err := add(workspace.AssetTypeConnection, modelEntry.ID+"."+connectionName, catalogID, connectionName, connectionDescription(connection), connection)
+			id, err := add(workspace.AssetTypeConnection, modelEntry.ID+"."+connectionName, catalogID, connectionName, connection.Description, connection)
 			if err != nil {
 				return workspace.AssetGraph{}, err
 			}
@@ -62,7 +62,8 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 		}
 		for _, sourceName := range sortedMapKeys(model.Sources) {
 			source := model.Sources[sourceName]
-			id, err := add(workspace.AssetTypeSource, modelEntry.ID+"."+sourceName, catalogID, sourceName, source.Description(), source)
+			source.AssetVersion = 1
+			id, err := add(workspace.AssetTypeSource, modelEntry.ID+"."+sourceName, catalogID, sourceName, source.Description, source)
 			if err != nil {
 				return workspace.AssetGraph{}, err
 			}
@@ -107,13 +108,10 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 			edge(semanticTableID, modelTableID, workspace.AssetEdgeUsesModelTable)
 			if table.PrimaryKey != "" {
 				field := table.Dimensions[table.PrimaryKey]
-				if field.Expr == "" && field.Expression == "" {
-					field.Expr = table.PrimaryKey
-				}
 				field.Field = tableName + "." + table.PrimaryKey
 				field.Table = tableName
 				field.Name = table.PrimaryKey
-				fieldID, err := add(workspace.AssetTypeField, modelEntry.ID+"."+tableName+"."+table.PrimaryKey, semanticTableID, dimensionLabel(table.PrimaryKey, field.Label), "", field)
+				fieldID, err := add(workspace.AssetTypeField, modelEntry.ID+"."+tableName+"."+table.PrimaryKey, semanticTableID, dimensionLabel(table.PrimaryKey, field.Label), field.Description, field)
 				if err != nil {
 					return workspace.AssetGraph{}, err
 				}
@@ -124,7 +122,7 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 				if fieldName == table.PrimaryKey {
 					continue
 				}
-				fieldID, err := add(workspace.AssetTypeField, modelEntry.ID+"."+tableName+"."+fieldName, semanticTableID, dimensionLabel(fieldName, field.Label), "", field)
+				fieldID, err := add(workspace.AssetTypeField, modelEntry.ID+"."+tableName+"."+fieldName, semanticTableID, dimensionLabel(fieldName, field.Label), field.Description, field)
 				if err != nil {
 					return workspace.AssetGraph{}, err
 				}
@@ -132,7 +130,7 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 			}
 		}
 		for _, relationship := range model.Relationships {
-			id, err := add(workspace.AssetTypeRelationship, modelEntry.ID+"."+relationship.ID, modelID, relationship.ID, "", relationship)
+			id, err := add(workspace.AssetTypeRelationship, modelEntry.ID+"."+relationship.ID, modelID, relationship.ID, relationship.Description, relationship)
 			if err != nil {
 				return workspace.AssetGraph{}, err
 			}
@@ -240,7 +238,7 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 		}
 		for _, filterName := range sortedMapKeys(report.Filters) {
 			filter := report.Filters[filterName]
-			filterID, err := add(workspace.AssetTypeFilter, report.ID+"."+filterName, reportID, filter.Label, "", filter)
+			filterID, err := add(workspace.AssetTypeFilter, report.ID+"."+filterName, reportID, filter.Label, filter.Description, filter)
 			if err != nil {
 				return workspace.AssetGraph{}, err
 			}
@@ -251,7 +249,7 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 		}
 		for _, visualName := range sortedMapKeys(report.Visuals) {
 			visual := report.Visuals[visualName]
-			visualID, err := add(workspace.AssetTypeVisual, report.ID+"."+visualName, reportID, visual.Title, "", visual)
+			visualID, err := add(workspace.AssetTypeVisual, report.ID+"."+visualName, reportID, visual.Title, visual.Description, visual)
 			if err != nil {
 				return workspace.AssetGraph{}, err
 			}
@@ -279,7 +277,7 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 		}
 		for _, tableName := range sortedMapKeys(report.Tables) {
 			table := report.Tables[tableName]
-			tableID, err := add(workspace.AssetTypeTable, report.ID+"."+tableName, reportID, table.Title, "", table)
+			tableID, err := add(workspace.AssetTypeTable, report.ID+"."+tableName, reportID, table.Title, table.Description, table)
 			if err != nil {
 				return workspace.AssetGraph{}, err
 			}
@@ -316,7 +314,7 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 				if itemKey == "" {
 					itemKey = strconv.Itoa(index)
 				}
-				itemID, err := add(workspace.AssetTypePageItem, report.ID+"."+page.ID+"."+itemKey, pageID, pageItemTitle(item), item.Subtitle, item)
+				itemID, err := add(workspace.AssetTypePageItem, report.ID+"."+page.ID+"."+itemKey, pageID, pageItemTitle(item), item.Description, item)
 				if err != nil {
 					return workspace.AssetGraph{}, err
 				}
@@ -395,13 +393,6 @@ func pageItemTitle(item dashboard.PageVisual) string {
 		return item.ID
 	}
 	return item.Kind
-}
-
-func connectionDescription(connection semanticmodel.Connection) string {
-	if connection.Kind == "" {
-		return "connection"
-	}
-	return connection.Kind + " connection"
 }
 
 func dimensionLabel(name, label string) string {

--- a/internal/workspace/compiler/lineage.go
+++ b/internal/workspace/compiler/lineage.go
@@ -62,7 +62,6 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 		}
 		for _, sourceName := range sortedMapKeys(model.Sources) {
 			source := model.Sources[sourceName]
-			source.AssetVersion = 1
 			id, err := add(workspace.AssetTypeSource, modelEntry.ID+"."+sourceName, catalogID, sourceName, source.Description, source)
 			if err != nil {
 				return workspace.AssetGraph{}, err

--- a/internal/workspace/compiler/lineage_test.go
+++ b/internal/workspace/compiler/lineage_test.go
@@ -48,6 +48,62 @@ func TestExtractLineageCleanOwnership(t *testing.T) {
 	requireLineageEdge(t, graph, page, pageTable, workspace.AssetEdgeContains)
 }
 
+func TestExtractLineageUsesAuthoredDescriptions(t *testing.T) {
+	compiled := compileLineageWorkspace(t)
+	graph := compiled.Workspace.Graph
+
+	cases := []struct {
+		typ         workspace.AssetType
+		key         string
+		description string
+	}{
+		{workspace.AssetTypeConnection, "olist.olist", "Local CSV files for the Olist demo workspace."},
+		{workspace.AssetTypeSource, "olist.orders", "Raw order lifecycle events from the Olist dataset."},
+		{workspace.AssetTypeModelTable, "olist.orders", "Order-grain model table for sales analysis."},
+		{workspace.AssetTypeSemanticTable, "olist.orders", "Order-grain model table for sales analysis."},
+		{workspace.AssetTypeField, "olist.orders.revenue", "Order revenue after payment aggregation."},
+		{workspace.AssetTypeRelationship, "olist.orders_customers", "Links each order to the purchasing customer."},
+		{workspace.AssetTypeMeasure, "olist.revenue", "Total order revenue."},
+		{workspace.AssetTypeFilter, "sales.status", "Filters dashboard content by order status."},
+		{workspace.AssetTypeVisual, "sales.revenue_by_status", "Compares revenue across order statuses."},
+		{workspace.AssetTypeTable, "sales.order_rows", "Detailed order rows for auditing sales records."},
+		{workspace.AssetTypePage, "sales.overview", "Executive sales summary."},
+		{workspace.AssetTypePageItem, "sales.overview.revenue_card", "Revenue chart placement on the overview page."},
+	}
+	for _, tc := range cases {
+		asset := requireLineageAsset(t, graph, tc.typ, tc.key)
+		if asset.Description != tc.description {
+			t.Fatalf("%s %q description = %q, want %q", tc.typ, tc.key, asset.Description, tc.description)
+		}
+	}
+}
+
+func TestExtractLineageLeavesMissingDescriptionsBlank(t *testing.T) {
+	dir := t.TempDir()
+	writeCompilerFixture(t, filepath.Join(dir, "catalog.yaml"), validCompilerCatalogYAML())
+	writeCompilerFixture(t, filepath.Join(dir, "model.yaml"), validCompilerModelYAML())
+	writeCompilerFixture(t, filepath.Join(dir, "dashboard.yaml"), validCompilerDashboardYAML())
+
+	compiled, err := Compile(filepath.Join(dir, "catalog.yaml"), Options{WorkspaceID: "libredash", DeploymentID: "dep_test"})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	graph := compiled.Workspace.Graph
+	for _, tc := range []struct {
+		typ workspace.AssetType
+		key string
+	}{
+		{workspace.AssetTypeConnection, "olist.olist"},
+		{workspace.AssetTypeSource, "olist.orders"},
+		{workspace.AssetTypeVisual, "sales.revenue"},
+	} {
+		asset := requireLineageAsset(t, graph, tc.typ, tc.key)
+		if asset.Description != "" {
+			t.Fatalf("%s %q description = %q, want blank", tc.typ, tc.key, asset.Description)
+		}
+	}
+}
+
 func TestExtractLineageCleanDependencies(t *testing.T) {
 	compiled := compileLineageWorkspace(t)
 	graph := compiled.Workspace.Graph
@@ -124,22 +180,22 @@ sources:
 models:
   orders:
     source: orders
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
+      customer_id: {label: Customer ID}
   customers:
     source: customers
+    primary_key: customer_id
+    fields:
+      customer_id: {label: Customer ID}
+      state: {label: State}
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          customer_id: {expr: customer_id}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          state: {expr: customer_state}
+      - orders
+      - customers
     relationships:
       - id: order_customer
         from: orders.customer_id
@@ -175,47 +231,53 @@ title: Olist
 connections:
   olist:
     kind: local
+    description: Local CSV files for the Olist demo workspace.
 sources:
   orders:
     connection: olist
     path: orders.csv
     format: csv
+    description: Raw order lifecycle events from the Olist dataset.
   customers:
     connection: olist
     path: customers.csv
     format: csv
+    description: Raw customer profile records from the Olist dataset.
 models:
   orders:
     source: orders
+    description: Order-grain model table for sales analysis.
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
+      customer_id: {label: Customer ID}
+      status: {label: Status}
+      revenue: {label: Revenue, description: Order revenue after payment aggregation.}
   customers:
-    source: customers
+    sources: [customers]
+    description: Customer lookup model table for geographic slicing.
+    transform:
+      sql: SELECT customer_id, customer_state AS state FROM source.customers
+    primary_key: customer_id
+    fields:
+      customer_id: {label: Customer ID}
+      state: {label: State}
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
-          customer_id: {expr: customer_id}
-          status: {expr: status}
-          revenue: {expr: revenue}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id: {expr: customer_id}
-          state: {expr: customer_state}
+      - orders
+      - customers
     relationships:
       - id: orders_customers
+        description: Links each order to the purchasing customer.
         from: orders.customer_id
         to: customers.customer_id
         cardinality: many_to_one
         active: true
     measures:
       defaults: {table: orders, grain: order_id}
-      revenue: {expr: SUM(orders.revenue), format: currency}
+      revenue: {expr: SUM(orders.revenue), description: Total order revenue., format: currency}
 `)
 	writeCompilerFixture(t, filepath.Join(dir, "dashboard.yaml"), `
 id: sales
@@ -225,12 +287,14 @@ filters:
   status:
     type: multi_select
     label: Status
+    description: Filters dashboard content by order status.
     url_param: status
     operator: in
     field: orders.status
 visuals:
   revenue_by_status:
     title: Revenue by status
+    description: Compares revenue across order statuses.
     type: bar
     query:
       dimensions:
@@ -240,6 +304,7 @@ visuals:
 tables:
   order_rows:
     title: Order rows
+    description: Detailed order rows for auditing sales records.
     query:
       table: orders
       fields:
@@ -248,18 +313,22 @@ tables:
 pages:
   - id: overview
     title: Overview
+    description: Executive sales summary.
     visuals:
       - id: status_card
         kind: filter_card
         filter: status
+        description: Status filter placement on the overview page.
         placement: {col: 1, row: 1, col_span: 3, row_span: 2}
       - id: revenue_card
         kind: bar_chart
         visual: revenue_by_status
+        description: Revenue chart placement on the overview page.
         placement: {col: 4, row: 1, col_span: 5, row_span: 4}
       - id: orders_table
         kind: table
         table: order_rows
+        description: Order table placement on the overview page.
         placement: {col: 1, row: 5, col_span: 8, row_span: 4}
 `)
 

--- a/internal/workspace/compiler/semantic_model_design_test.go
+++ b/internal/workspace/compiler/semantic_model_design_test.go
@@ -67,14 +67,13 @@ sources:
 models:
   orders:
     source: olist_orders
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
 semantic_models:
   olist:
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -96,15 +95,14 @@ sources:
 models:
   orders:
     source: olist_orders
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
 semantic_models:
   olist:
     base_table: missing
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -140,17 +138,14 @@ semantic_models:
   olist:
     base_table: orders
     tables:
-      missing:
-        primary_key: id
-        fields:
-          id: {expr: id}
+      - missing
     measures:
       defaults: {table: missing, grain: id}
       count: {expr: COUNT(DISTINCT missing.id)}
 `)
 
 	_, err := CompileDefinition(catalogPath)
-	if err == nil || !strings.Contains(err.Error(), `references unknown model "missing"`) {
+	if err == nil || !strings.Contains(err.Error(), `semantic model table "missing" references unknown model`) {
 		t.Fatalf("CompileDefinition() error = %v, want missing model rejection", err)
 	}
 }
@@ -161,18 +156,8 @@ semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
-          customer_id: {expr: customer_id}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id: {expr: customer_id}
-          state: {expr: state}
+      - orders
+      - customers
     relationships:
       - from: orders.customer_id
         to: customers.customer_id
@@ -196,11 +181,7 @@ semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     relationships:
       - from: orders.order_id
         to: missing.id
@@ -215,16 +196,8 @@ semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id: {expr: customer_id}
+      - orders
+      - customers
     relationships:
       - from: orders.missing_customer_id
         to: customers.customer_id
@@ -265,30 +238,29 @@ sources:
 models:
   orders:
     source: olist_orders
+    primary_key: order_id
+    fields:
+      customer_id: {label: Customer ID}
+      revenue: {label: Revenue}
   customers:
     source: olist_customers
+    primary_key: customer_id
+    fields:
+      customer_id: {label: Customer ID}
   refunds:
     source: olist_refunds
+    primary_key: refund_id
+    fields:
+      refund_id: {label: Refund ID}
+      amount: {label: Amount}
 
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          customer_id: {expr: customer_id}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id: {expr: customer_id}
-      refunds:
-        model: refunds
-        primary_key: refund_id
-        fields:
-          refund_id: {expr: refund_id}
+      - orders
+      - customers
+      - refunds
     relationships:
       - from: orders.customer_id
         to: customers.customer_id
@@ -341,16 +313,15 @@ sources:
 models:
   orders:
     source: orders
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
+      revenue: {label: Revenue}
 semantic_models:
   orders:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
-          revenue: {expr: revenue}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       revenue: {expr: SUM(orders.revenue)}
@@ -369,16 +340,15 @@ sources:
 models:
   refunds:
     source: refunds
+    primary_key: refund_id
+    fields:
+      refund_id: {label: Refund ID}
+      amount: {label: Amount}
 semantic_models:
   refunds:
     base_table: refunds
     tables:
-      refunds:
-        model: refunds
-        primary_key: refund_id
-        fields:
-          refund_id: {expr: refund_id}
-          amount: {expr: amount}
+      - refunds
     measures:
       defaults: {table: refunds, grain: refund_id}
       refund_amount: {expr: SUM(refunds.amount)}
@@ -420,17 +390,16 @@ sources:
     format: csv
 models:
   orders:
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: SELECT order_id FROM source.olist_orders
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -457,26 +426,24 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
+      customer_id: {label: Customer ID}
     transform:
       sql: SELECT order_id, customer_id FROM source.olist_orders
   customers:
     source: olist_customers
+    primary_key: customer_id
+    fields:
+      customer_id: {label: Customer ID}
+      state: {label: State}
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
-          customer_id: {expr: customer_id}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id: {expr: customer_id}
-          state: {expr: state}
+      - orders
+      - customers
     relationships:
       - from: orders.customer_id
         to: customers.customer_id
@@ -507,26 +474,24 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
+      customer_id: {label: Customer ID}
     transform:
       sql: SELECT order_id, customer_id FROM "source"."olist_orders"
   customers:
     source: olist_customers
+    primary_key: customer_id
+    fields:
+      customer_id: {label: Customer ID}
+      state: {label: State}
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
-          customer_id: {expr: customer_id}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id: {expr: customer_id}
-          state: {expr: state}
+      - orders
+      - customers
     relationships:
       - from: orders.customer_id
         to: customers.customer_id
@@ -553,17 +518,16 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: SELECT order_id FROM raw.olist_orders
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -586,17 +550,16 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: SELECT order_id FROM "raw"."olist_orders"
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -642,17 +605,16 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: SELECT order_id FROM source.olist_customers
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -674,17 +636,16 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: SELECT order_id FROM olist_orders
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -706,17 +667,16 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: SELECT o.order_id FROM source.olist_orders o JOIN leaked_table l ON l.order_id = o.order_id
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -738,17 +698,16 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: SELECT 1 AS order_id
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -775,6 +734,9 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: |
         WITH cleaned AS (
@@ -785,11 +747,7 @@ semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -812,17 +770,16 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: UPDATE source.olist_orders SET order_id = order_id
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -849,17 +806,16 @@ sources:
 models:
   orders:
     sources: [olist_orders]
+    primary_key: order_id
+    fields:
+      order_id: {label: Order ID}
     transform:
       sql: SELECT order_id FROM (SELECT order_id FROM source.olist_orders) orders
 semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
+      - orders
     measures:
       defaults: {table: orders, grain: order_id}
       order_count: {expr: COUNT(DISTINCT orders.order_id)}
@@ -878,23 +834,9 @@ semantic_models:
   olist:
     base_table: orders
     tables:
-      orders:
-        model: orders
-        primary_key: order_id
-        fields:
-          order_id: {expr: order_id}
-          customer_id: {expr: customer_id}
-      customers:
-        model: customers
-        primary_key: customer_id
-        fields:
-          customer_id: {expr: customer_id}
-          state: {expr: state}
-      items:
-        model: items
-        primary_key: item_id
-        fields:
-          item_id: {expr: item_id}
+      - orders
+      - customers
+      - items
     relationships:
       - from: orders.customer_id
         to: customers.customer_id
@@ -931,22 +873,20 @@ sources:
 models:
   products:
     source: products
+    primary_key: product_id
+    fields:
+      product_id: {label: Product ID}
   warehouses:
     source: warehouses
+    primary_key: warehouse_id
+    fields:
+      warehouse_id: {label: Warehouse ID}
 semantic_models:
   inventory:
     base_table: products
     tables:
-      products:
-        model: products
-        primary_key: product_id
-        fields:
-          product_id: {expr: product_id}
-      warehouses:
-        model: warehouses
-        primary_key: warehouse_id
-        fields:
-          warehouse_id: {expr: warehouse_id}
+      - products
+      - warehouses
 `)
 
 	_, err := semantic.Load(modelPath)
@@ -966,16 +906,8 @@ func TestSemanticModelDesignRejectsAmbiguousAndUnsafeRelationshipPaths(t *testin
 	  olist:
 	    base_table: orders
 	    tables:
-	      orders:
-	        model: orders
-	        primary_key: order_id
-	        fields:
-	          order_id: {expr: order_id}
-	      items:
-	        model: items
-	        primary_key: item_id
-	        fields:
-	          order_id: {expr: order_id}
+	      - orders
+	      - items
     relationships:
       - from: orders.order_id
         to: items.order_id
@@ -993,16 +925,8 @@ func TestSemanticModelDesignRejectsAmbiguousAndUnsafeRelationshipPaths(t *testin
 	  olist:
 	    base_table: orders
 	    tables:
-	      orders:
-	        model: orders
-	        primary_key: order_id
-	        fields:
-	          customer_id: {expr: customer_id}
-	      customers:
-	        model: customers
-	        primary_key: customer_id
-	        fields:
-	          customer_id: {expr: customer_id}
+	      - orders
+	      - customers
     relationships:
       - from: orders.customer_id
         to: customers.customer_id
@@ -1020,17 +944,8 @@ func TestSemanticModelDesignRejectsAmbiguousAndUnsafeRelationshipPaths(t *testin
 	  olist:
 	    base_table: orders
 	    tables:
-	      orders:
-	        model: orders
-	        primary_key: order_id
-	        fields:
-	          customer_id: {expr: customer_id}
-	          customer_id_alt: {expr: customer_id}
-	      customers:
-	        model: customers
-	        primary_key: customer_id
-	        fields:
-	          customer_id: {expr: customer_id}
+	      - orders
+	      - customers
     relationships:
       - from: orders.customer_id
         to: customers.customer_id
@@ -1052,23 +967,9 @@ func TestSemanticModelDesignRejectsAmbiguousAndUnsafeRelationshipPaths(t *testin
 	  olist:
 	    base_table: orders
 	    tables:
-	      orders:
-	        model: orders
-	        primary_key: order_id
-	        fields:
-	          customer_id: {expr: customer_id}
-	          item_id: {expr: item_id}
-	      items:
-	        model: items
-	        primary_key: item_id
-	        fields:
-	          item_id: {expr: item_id}
-	          customer_id: {expr: customer_id}
-	      customers:
-	        model: customers
-	        primary_key: customer_id
-	        fields:
-	          customer_id: {expr: customer_id}
+	      - orders
+	      - items
+	      - customers
 	    relationships:
 	      - from: orders.customer_id
 	        to: customers.customer_id
@@ -1107,20 +1008,8 @@ func writeSemanticModelDesignWorkspace(t *testing.T) string {
 	  olist:
 	    base_table: orders
 	    tables:
-	      orders:
-	        model: orders
-	        primary_key: order_id
-	        fields:
-	          order_id: {expr: order_id}
-	          customer_id: {expr: customer_id}
-	          purchase_timestamp: {expr: purchase_timestamp, type: time}
-	          revenue: {expr: revenue, type: number}
-	      customers:
-	        model: customers
-	        primary_key: customer_id
-	        fields:
-	          customer_id: {expr: customer_id}
-	          state: {expr: state}
+	      - orders
+	      - customers
     relationships:
       - from: orders.customer_id
         to: customers.customer_id
@@ -1161,14 +1050,31 @@ sources:
 	models:
 	  orders:
 	    sources: [olist_orders]
+	    primary_key: order_id
+	    fields:
+	      order_id: {label: Order ID}
+	      customer_id: {label: Customer ID}
+	      customer_id_alt: {label: Alternate customer ID}
+	      item_id: {label: Item ID}
+	      purchase_timestamp: {label: Purchase timestamp}
+	      revenue: {label: Revenue}
 	    transform:
 	      sql: |
 	        SELECT order_id, customer_id, purchase_timestamp, revenue
 	        FROM source.olist_orders
 	  customers:
 	    source: olist_customers
+	    primary_key: customer_id
+	    fields:
+	      customer_id: {label: Customer ID}
+	      state: {label: State}
 	  items:
 	    source: olist_items
+	    primary_key: item_id
+	    fields:
+	      item_id: {label: Item ID}
+	      order_id: {label: Order ID}
+	      customer_id: {label: Customer ID}
 	`+semanticFragment)
 }
 

--- a/internal/workspace/sqlite/repository.go
+++ b/internal/workspace/sqlite/repository.go
@@ -103,16 +103,17 @@ func (r *Repository) ReplaceActiveDeploymentGraph(ctx context.Context, id worksp
 			continue
 		}
 		if err := q.InsertAsset(ctx, platformdb.InsertAssetParams{
-			ID:            string(asset.ID),
-			WorkspaceID:   string(asset.WorkspaceID),
-			DeploymentID:  string(asset.DeploymentID),
-			AssetType:     string(asset.Type),
-			AssetKey:      asset.Key,
-			ParentAssetID: sql.NullString{String: string(asset.ParentID), Valid: asset.ParentID != ""},
-			Title:         asset.Title,
-			Description:   asset.Description,
-			ContentJson:   asset.ContentJSON,
-			ContentHash:   asset.ContentHash,
+			ID:             string(asset.ID),
+			WorkspaceID:    string(asset.WorkspaceID),
+			DeploymentID:   string(asset.DeploymentID),
+			AssetType:      string(asset.Type),
+			AssetKey:       asset.Key,
+			ParentAssetID:  sql.NullString{String: string(asset.ParentID), Valid: asset.ParentID != ""},
+			Title:          asset.Title,
+			Description:    asset.Description,
+			ContentJson:    asset.ContentJSON,
+			ContentHash:    asset.ContentHash,
+			ContentVersion: int64(asset.ContentVersion),
 		}); err != nil {
 			return err
 		}
@@ -155,16 +156,17 @@ func mapAsset(row platformdb.Asset) workspace.Asset {
 		parentID = workspace.AssetID(row.ParentAssetID.String)
 	}
 	return workspace.Asset{
-		ID:           workspace.AssetID(row.ID),
-		WorkspaceID:  workspace.WorkspaceID(row.WorkspaceID),
-		DeploymentID: workspace.DeploymentID(row.DeploymentID),
-		Type:         workspace.AssetType(row.AssetType),
-		Key:          row.AssetKey,
-		ParentID:     parentID,
-		Title:        row.Title,
-		Description:  row.Description,
-		ContentJSON:  row.ContentJson,
-		ContentHash:  row.ContentHash,
+		ID:             workspace.AssetID(row.ID),
+		WorkspaceID:    workspace.WorkspaceID(row.WorkspaceID),
+		DeploymentID:   workspace.DeploymentID(row.DeploymentID),
+		Type:           workspace.AssetType(row.AssetType),
+		Key:            row.AssetKey,
+		ParentID:       parentID,
+		Title:          row.Title,
+		Description:    row.Description,
+		ContentJSON:    row.ContentJson,
+		ContentHash:    row.ContentHash,
+		ContentVersion: int(row.ContentVersion),
 	}
 }
 

--- a/internal/workspace/sqlite/repository_test.go
+++ b/internal/workspace/sqlite/repository_test.go
@@ -74,6 +74,9 @@ func TestRepositoryReplaceActiveDeploymentGraph(t *testing.T) {
 		if asset.ContentHash != "new" {
 			t.Fatalf("asset %s content hash = %q, want replacement graph only", asset.ID, asset.ContentHash)
 		}
+		if asset.ContentVersion != workspace.CurrentAssetContentVersion {
+			t.Fatalf("asset %s content version = %d, want %d", asset.ID, asset.ContentVersion, workspace.CurrentAssetContentVersion)
+		}
 	}
 	after, err := deploymentRepo.ByID(ctx, created.ID)
 	if err != nil {
@@ -87,14 +90,15 @@ func TestRepositoryReplaceActiveDeploymentGraph(t *testing.T) {
 func mustAsset(t *testing.T, id workspace.AssetID, typ workspace.AssetType, key string, parent workspace.AssetID, deploymentID deployment.ID) workspace.Asset {
 	t.Helper()
 	return workspace.Asset{
-		ID:           id,
-		WorkspaceID:  "test",
-		DeploymentID: workspace.DeploymentID(deploymentID),
-		Type:         typ,
-		Key:          key,
-		ParentID:     parent,
-		Title:        key,
-		ContentJSON:  "{}",
-		ContentHash:  "new",
+		ID:             id,
+		WorkspaceID:    "test",
+		DeploymentID:   workspace.DeploymentID(deploymentID),
+		Type:           typ,
+		Key:            key,
+		ParentID:       parent,
+		Title:          key,
+		ContentJSON:    "{}",
+		ContentHash:    "new",
+		ContentVersion: workspace.CurrentAssetContentVersion,
 	}
 }


### PR DESCRIPTION
## Summary
This PR cleans up the governed asset model and schema metadata flow so the UI shows authored composition on detail pages, keeps lineage focused on dependencies/consumers, and relies on DuckDB-discovered facts for physical schema instead of duplicating types in YAML.

## Product / IA changes
- Treat Connections as their own top-level surface with canonical `/connections/{assetID}/details` and `/connections/{assetID}/lineage` routes.
- Keep Workspace landing focused on BI workspace assets: model tables, semantic models, and dashboards.
- Keep sources and lower-level composition assets discoverable through detail pages, lineage, and explicit links instead of top-level lists.
- Refine detail pages around composition:
  - `semantic_model`: model tables, measures, relationships.
  - `model_table`: overview, fields/schema, SQL block for transform tables.
  - `source`: source facts and raw schema fields.
  - `connection`: connection facts and sources using the connection.
  - `dashboard`: pages, visuals, tables, filters.

## Lineage changes
- Preserve the complete internal lineage graph, including composition assets such as fields, semantic tables, relationships, pages, page items, visuals, tables, and filters.
- Render the default detail-page DAG as progressive disclosure over major assets only: connection -> source -> model_table -> semantic_model -> measure -> dashboard.
- Collapse hidden composition assets into their visible owners for graph display while keeping full-fidelity lineage available internally.
- Keep Uses / Used By tables aligned with the rendered lineage view instead of dumping composition-level edges into the core lineage table.
- Add selectable DAG nodes, selected-node inspector context, explicit Open details navigation, and upstream/downstream path highlighting.

## Schema/YAML contract changes
- Move field documentation ownership to model/source tables rather than semantic model table remapping.
- Make SQL the only transformation/renaming layer for model tables.
- Simplify model table field YAML to `label` and `description`; physical types come from DuckDB discovery.
- Simplify source field YAML to `description` only; source labels were removed because source fields are raw contracts and are not used in visuals.
- Reject removed/old YAML keys instead of silently accepting legacy field expressions/types/order/filter/meta/label-on-source-field patterns.
- Update Olist YAML with authored descriptions for sources, model fields, measures, relationships, dashboard assets, and relevant low-level assets while avoiding autogenerated descriptions.

## DuckDB discovery and validation
- Discover `source.*` and `model.*` schemas after source registration/model materialization.
- Attach discovered column name, ordinal, physical type, nullable, default/comment where available, and primary-key facts to source/model-table assets.
- Scope discovery to `current_database()` so attached DuckDB catalogs cannot leak similarly named `source` or `model` schemas.
- Validate documented source/model fields, primary keys, relationships, measures, dashboard dimensions, filters, and table columns against discovered model/source schemas.
- Preserve unknown nullable state so UI can render `-` rather than incorrectly showing `No`.

## Asset graph/reconciliation hardening
- Add internal `content_version` on persisted asset rows and a workspace-level `CurrentAssetContentVersion`.
- Use row-level content versioning to reconcile stale active deployment graphs instead of source-specific JSON sentinels.
- Remove the temporary `Source.AssetVersion` domain-field leak and its JSON marker from compiled assets.
- Add symmetric staleness detection for source and model-table field docs without discovered schema.
- Recompile/replace stale active deployment asset graphs without changing deployment identity or active status.

## UI details
- Model table fields grid now shows `Name`, `Label`, `Physical type`, `Nullable`, `Key`, `Description`.
- Source fields grid now shows `Name`, `Description`, `Physical type`, `Nullable`.
- Transform model tables render authored SQL via reusable `ld-code-block` with Shiki/GitHub themes; direct-source tables omit SQL.
- Semantic model details no longer show raw connection/source/flat-field dumps; those are detail or lineage concerns.
- Connection rows link to the canonical Connections detail surface.

## Tests
- `task test`
- `go test ./internal/analytics/...`
- `go test ./internal/workspace/...`
- `go test ./internal/ui`
- `go test ./internal/app`
- `go test ./internal/deployment/... ./internal/platform/...`
- Focused coverage added for:
  - source/model schema discovery and attached database isolation
  - missing documented source/model fields
  - removed YAML keys and source-field label rejection
  - model-table/source detail grids and nullable unknown display
  - active graph replacement with row-level content versions
  - connection canonical routes and workspace asset surface behavior
  - progressive lineage graph projection and interaction behavior

## Notes
- Public asset/edge API wire shape remains unchanged; this introduces new internal values/metadata only.
- Existing active deployments may be reconciled automatically from runtime artifacts when their stored asset graph is stale.
- Local untracked `plan.md` is intentionally left out of the PR.
