### PR TITLE
Add browserless Datastar integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,11 @@ The current product goal is to feel like a small Power BI-style workspace: dashb
 
 - `task dev`
 - `task bootstrap`
+- `task ci`
 - `task test`
 - `task build`
 - `task dev:stop`
 - `task dev:status`
 - `task dev:logs`
+
+Use `task ci` as the default full verification command before handing off substantial changes.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,6 +64,11 @@ tasks:
       - npm run test:table-selection
       - go test ./...
 
+  ci:
+    desc: Run the full CI test suite
+    deps:
+      - test
+
   agent:e2e:
     desc: Run opt-in DeepSeek-backed headless agent E2E
     cmds:

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -12,6 +12,7 @@ import (
 	semanticmodel "github.com/Yacobolo/libredash/internal/analytics/model"
 	"github.com/Yacobolo/libredash/internal/dashboard"
 	reportdef "github.com/Yacobolo/libredash/internal/dashboard/report"
+	"github.com/Yacobolo/libredash/internal/testutil/ssetest"
 )
 
 func fieldRefs(fields ...string) []reportdef.FieldRef {
@@ -468,14 +469,42 @@ func TestUpdatesStreamsDatastarPatchSignals(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !strings.Contains(body, "event: datastar-patch-signals") {
+	patches := ssetest.PatchSignals(t, body)
+	if len(patches) == 0 {
 		t.Fatalf("body does not contain Datastar patch signal event:\n%s", body)
 	}
-	if !strings.Contains(body, `"values":["SP"]`) {
-		t.Fatalf("body does not include decoded filter state:\n%s", body)
-	}
-	if strings.Contains(body, `"category"`) {
-		t.Fatalf("body streamed off-page category filter:\n%s", body)
+	ssetest.RequirePatchSignal(t, body, func(patch map[string]any) bool {
+		status, ok := patch["status"].(map[string]any)
+		return ok && status["loading"] == true
+	})
+	ssetest.RequirePatchSignal(t, body, func(patch map[string]any) bool {
+		filters, ok := patch["filters"].(map[string]any)
+		if !ok {
+			return false
+		}
+		controls, ok := filters["controls"].(map[string]any)
+		if !ok {
+			return false
+		}
+		state, ok := controls["state"].(map[string]any)
+		if !ok {
+			return false
+		}
+		values, ok := state["values"].([]any)
+		return ok && len(values) == 1 && values[0] == "SP"
+	})
+	for _, patch := range patches {
+		filters, ok := patch["filters"].(map[string]any)
+		if !ok {
+			continue
+		}
+		controls, ok := filters["controls"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := controls["category"]; ok {
+			t.Fatalf("patch streamed off-page category filter: %#v", patch)
+		}
 	}
 }
 

--- a/internal/dashboard/stream/broker_test.go
+++ b/internal/dashboard/stream/broker_test.go
@@ -1,0 +1,18 @@
+package stream
+
+import "testing"
+
+func TestBrokerUnsubscribeRemovesSubscriber(t *testing.T) {
+	broker := NewBroker()
+	_, unsubscribe := broker.Subscribe("client:dashboard:page")
+
+	if got := broker.SubscriberCount("client:dashboard:page"); got != 1 {
+		t.Fatalf("subscriber count = %d, want 1", got)
+	}
+
+	unsubscribe()
+
+	if got := broker.SubscriberCount("client:dashboard:page"); got != 0 {
+		t.Fatalf("subscriber count after unsubscribe = %d, want 0", got)
+	}
+}

--- a/internal/integration/commands_test.go
+++ b/internal/integration/commands_test.go
@@ -1,0 +1,282 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Yacobolo/libredash/internal/dashboard"
+	dashboardruntime "github.com/Yacobolo/libredash/internal/dashboard/runtime"
+)
+
+func TestCommandsPublishReloadPatchesToOpenStream(t *testing.T) {
+	h := newHarness(t)
+
+	tests := []struct {
+		name    string
+		path    string
+		signals map[string]any
+		assert  func(t *testing.T, patches []map[string]any)
+	}{
+		{
+			name: "/commands/select",
+			path: "/commands/select",
+			signals: mergeSignals(runtimeSignals("cmd-select", "overview"), map[string]any{
+				"interactionCommand": pointSelectionCommand("orders", "orders.status", "delivered"),
+				"tableCommand":       tableCommand("orders_table", "all", 0, 50, 3, 0),
+			}),
+			assert: func(t *testing.T, patches []map[string]any) {
+				t.Helper()
+				requireStatusLoading(t, patches, true)
+				requireSelection(t, patches, "orders", "orders.status", "delivered")
+				requireTable(t, patches, "orders_table")
+			},
+		},
+		{
+			name: "/commands/clear-selection",
+			path: "/commands/clear-selection",
+			signals: mergeSignals(runtimeSignals("cmd-clear", "overview"), map[string]any{
+				"filters": map[string]any{
+					"selections": []map[string]any{selectionSignal("orders", "orders.status", "delivered")},
+				},
+				"tableCommand": tableCommand("orders_table", "all", 0, 50, 4, 0),
+			}),
+			assert: func(t *testing.T, patches []map[string]any) {
+				t.Helper()
+				requireStatusLoading(t, patches, true)
+				requireNoSelection(t, patches)
+				requireTable(t, patches, "orders_table")
+			},
+		},
+		{
+			name: "/commands/reset-filters",
+			path: "/commands/reset-filters",
+			signals: mergeSignals(runtimeSignals("cmd-reset", "overview"), map[string]any{
+				"filters": map[string]any{
+					"controls": map[string]any{
+						"state": map[string]any{
+							"type":     "multi_select",
+							"operator": "in",
+							"values":   []string{"SP"},
+						},
+					},
+				},
+				"tableCommand": tableCommand("orders_table", "all", 50, 50, 5, 2),
+			}),
+			assert: func(t *testing.T, patches []map[string]any) {
+				t.Helper()
+				requireStatusLoading(t, patches, true)
+				requireFilterValues(t, patches, "state")
+				requireTableResetVersion(t, patches, "orders_table", 3)
+			},
+		},
+		{
+			name: "/commands/refresh-materializations",
+			path: "/commands/refresh-materializations",
+			signals: mergeSignals(runtimeSignals("cmd-refresh", "overview"), map[string]any{
+				"tableCommand": tableCommand("orders_table", "all", 0, 50, 6, 0),
+			}),
+			assert: func(t *testing.T, patches []map[string]any) {
+				t.Helper()
+				requireStatusLoading(t, patches, true)
+				requireVisual(t, patches, "total_orders")
+				requireTable(t, patches, "orders_table")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := h.openUpdatesStream(t, "executive-sales", "overview", runtimeSignals(clientIDFromSignals(tt.signals), "overview"))
+			drainInitialSnapshot(t, stream)
+
+			if got := h.postCommand(t, tt.path, tt.signals); got != http.StatusNoContent {
+				t.Fatalf("status = %d, want %d", got, http.StatusNoContent)
+			}
+
+			tt.assert(t, nextPatches(t, stream, 3))
+		})
+	}
+}
+
+func TestTableWindowCommandPublishesOnlyRequestedTablePatch(t *testing.T) {
+	h := newHarness(t)
+	stream := h.openUpdatesStream(t, "executive-sales", "overview", runtimeSignals("cmd-table", "overview"))
+	drainInitialSnapshot(t, stream)
+
+	status := h.postCommand(t, "/commands/table-window", mergeSignals(runtimeSignals("cmd-table", "overview"), map[string]any{
+		"tableCommand": tableCommand("orders_table", "a", 0, 1, 7, 0),
+	}))
+	if status != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", status, http.StatusNoContent)
+	}
+
+	patch := stream.nextPatch(t)
+	requireTableBlock(t, []map[string]any{patch}, "orders_table", "a", 0, 7)
+	if hasKey(patch, "status") || hasKey(patch, "visuals") || hasKey(patch, "filters") {
+		t.Fatalf("table-window command streamed non-table patch: %#v", patch)
+	}
+	stream.expectNoPatch(t, 150*time.Millisecond)
+}
+
+func TestTableWindowCommandDoesNotPublishCanceledTablePatch(t *testing.T) {
+	h := newHarness(t, withMetricsWrapper(func(metrics *dashboardruntime.Service) integrationMetrics {
+		return canceledTableWindowMetrics{integrationMetrics: metrics}
+	}))
+	stream := h.openUpdatesStream(t, "executive-sales", "overview", runtimeSignals("cmd-table-canceled", "overview"))
+	drainInitialSnapshot(t, stream)
+
+	status := h.postCommand(t, "/commands/table-window", mergeSignals(runtimeSignals("cmd-table-canceled", "overview"), map[string]any{
+		"tableCommand": tableCommand("orders_table", "a", 0, 1, 8, 0),
+	}))
+	if status != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", status, http.StatusNoContent)
+	}
+
+	stream.expectNoPatch(t, 500*time.Millisecond)
+}
+
+func TestRefreshMaterializationsCommandPublishesErrorPatch(t *testing.T) {
+	h := newHarness(t, withOlistFixture(func(t *testing.T, dir string) {}))
+	stream := h.openUpdatesStream(t, "executive-sales", "overview", runtimeSignals("cmd-refresh-error", "overview"))
+	drainInitialSnapshot(t, stream)
+
+	signals := runtimeSignals("cmd-refresh-error", "overview")
+	runtime := signals["runtime"].(map[string]any)
+	runtime["modelId"] = "olist"
+	status := h.postCommand(t, "/commands/refresh-materializations", signals)
+	if status != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", status, http.StatusNoContent)
+	}
+
+	patches := nextPatches(t, stream, 2)
+	requireStatusLoading(t, patches, true)
+	requireStatusError(t, patches, true)
+}
+
+func TestCommandRejectsMalformedDatastarBody(t *testing.T) {
+	h := newHarness(t)
+	req, err := http.NewRequest(http.MethodPost, h.serverURL(t)+"/commands/select", strings.NewReader("{not-json"))
+	if err != nil {
+		t.Fatalf("create command request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /commands/select: %v", err)
+	}
+	defer res.Body.Close()
+	body := new(bytes.Buffer)
+	_, _ = body.ReadFrom(res.Body)
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body:\n%s", res.StatusCode, http.StatusBadRequest, body.String())
+	}
+}
+
+type canceledTableWindowMetrics struct {
+	integrationMetrics
+}
+
+func (m canceledTableWindowMetrics) QueryTable(_ context.Context, dashboardID string, filters dashboard.Filters, request dashboard.TableRequest) (dashboard.Table, error) {
+	return m.QueryTablePage(context.Background(), dashboardID, "", filters, request)
+}
+
+func (m canceledTableWindowMetrics) QueryTablePage(_ context.Context, _ string, _ string, _ dashboard.Filters, request dashboard.TableRequest) (dashboard.Table, error) {
+	return dashboard.EmptyTable(request.WithDefaults(), context.Canceled), nil
+}
+
+func drainInitialSnapshot(t *testing.T, stream *streamClient) []map[string]any {
+	t.Helper()
+	patches := []map[string]any{}
+	for len(patches) < 6 {
+		patch := stream.nextPatch(t)
+		patches = append(patches, patch)
+		if _, ok := patch["tables"]; ok {
+			return patches
+		}
+	}
+	t.Fatalf("initial stream did not include tables patch: %#v", patches)
+	return nil
+}
+
+func nextPatches(t *testing.T, stream *streamClient, count int) []map[string]any {
+	t.Helper()
+	patches := make([]map[string]any, 0, count)
+	for i := 0; i < count; i++ {
+		patches = append(patches, stream.nextPatch(t))
+	}
+	return patches
+}
+
+func runtimeSignals(clientID, pageID string) map[string]any {
+	return map[string]any{
+		"runtime": map[string]any{
+			"clientId":    clientID,
+			"dashboardId": "executive-sales",
+			"pageId":      pageID,
+		},
+	}
+}
+
+func clientIDFromSignals(signals map[string]any) string {
+	runtime, _ := signals["runtime"].(map[string]any)
+	clientID, _ := runtime["clientId"].(string)
+	return clientID
+}
+
+func pointSelectionCommand(sourceID, field, value string) map[string]any {
+	return map[string]any{
+		"sourceKind":      "visual",
+		"sourceId":        sourceID,
+		"interactionKind": "point_selection",
+		"action":          "set",
+		"toggle":          true,
+		"mappings": []map[string]any{{
+			"field": field,
+			"value": value,
+			"label": value,
+		}},
+	}
+}
+
+func selectionSignal(sourceID, field, value string) map[string]any {
+	return map[string]any{
+		"id":              "visual:" + sourceID + ":point_selection",
+		"sourceKind":      "visual",
+		"sourceId":        sourceID,
+		"interactionKind": "point_selection",
+		"entries": []map[string]any{{
+			"mappings": []map[string]any{{
+				"field": field,
+				"value": value,
+				"label": value,
+			}},
+		}},
+	}
+}
+
+func tableCommand(table, block string, start, count, requestSeq, resetVersion int) map[string]any {
+	return map[string]any{
+		"table":        table,
+		"block":        block,
+		"start":        start,
+		"count":        count,
+		"requestSeq":   requestSeq,
+		"resetVersion": resetVersion,
+	}
+}
+
+func mergeSignals(base map[string]any, extra map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range base {
+		out[key] = value
+	}
+	for key, value := range extra {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/integration/harness_test.go
+++ b/internal/integration/harness_test.go
@@ -1,8 +1,13 @@
 package integration
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -14,7 +19,9 @@ import (
 
 	analyticsduckdb "github.com/Yacobolo/libredash/internal/analytics/duckdb"
 	materializeruntime "github.com/Yacobolo/libredash/internal/analytics/materialize"
+	semanticmodel "github.com/Yacobolo/libredash/internal/analytics/model"
 	"github.com/Yacobolo/libredash/internal/app"
+	"github.com/Yacobolo/libredash/internal/dashboard"
 	reportdef "github.com/Yacobolo/libredash/internal/dashboard/report"
 	dashboardruntime "github.com/Yacobolo/libredash/internal/dashboard/runtime"
 	"github.com/Yacobolo/libredash/internal/testutil/ssetest"
@@ -22,14 +29,32 @@ import (
 
 type harness struct {
 	handler http.Handler
+	server  *httptest.Server
 }
 
 type harnessConfig struct {
 	catalogPath string
 	fixture     func(t *testing.T, dir string)
+	wrapMetrics func(*dashboardruntime.Service) integrationMetrics
 }
 
 type harnessOption func(*harnessConfig)
+
+type integrationMetrics interface {
+	Catalog() dashboard.Catalog
+	DefaultDashboardID() string
+	ModelIDForDashboard(dashboardID string) string
+	Report(dashboardID string) (reportdef.Dashboard, *semanticmodel.Model, bool)
+	DefaultFilters(dashboardID string) dashboard.Filters
+	NormalizeTableRequest(dashboardID string, request dashboard.TableRequest) dashboard.TableRequest
+	QueryDashboard(ctx context.Context, dashboardID string, filters dashboard.Filters) (dashboard.Patch, error)
+	QueryDashboardPage(ctx context.Context, dashboardID, pageID string, filters dashboard.Filters) (dashboard.Patch, error)
+	QueryTable(ctx context.Context, dashboardID string, filters dashboard.Filters, request dashboard.TableRequest) (dashboard.Table, error)
+	QueryTablePage(ctx context.Context, dashboardID, pageID string, filters dashboard.Filters, request dashboard.TableRequest) (dashboard.Table, error)
+	RefreshMaterializations(ctx context.Context, modelID string) error
+	DataDir() string
+	Pages(dashboardID string) []dashboard.Page
+}
 
 func withCatalog(path string) harnessOption {
 	return func(config *harnessConfig) {
@@ -40,6 +65,12 @@ func withCatalog(path string) harnessOption {
 func withOlistFixture(fixture func(t *testing.T, dir string)) harnessOption {
 	return func(config *harnessConfig) {
 		config.fixture = fixture
+	}
+}
+
+func withMetricsWrapper(wrapper func(*dashboardruntime.Service) integrationMetrics) harnessOption {
+	return func(config *harnessConfig) {
+		config.wrapMetrics = wrapper
 	}
 }
 
@@ -66,9 +97,17 @@ func newHarness(t *testing.T, opts ...harnessOption) *harness {
 	}
 	t.Cleanup(func() { _ = metrics.Close() })
 
-	return &harness{
-		handler: app.New(metrics).Routes(),
+	metricsForApp := integrationMetrics(metrics)
+	if config.wrapMetrics != nil {
+		metricsForApp = config.wrapMetrics(metrics)
 	}
+
+	h := &harness{
+		handler: app.New(metricsForApp).Routes(),
+	}
+	h.server = httptest.NewServer(h.handler)
+	t.Cleanup(h.server.Close)
+	return h
 }
 
 func (h *harness) getUpdates(t *testing.T, dashboardID, pageID string, signals map[string]any) string {
@@ -107,6 +146,168 @@ func (h *harness) getUpdatesSignals(t *testing.T, dashboardID, pageID string, si
 		t.Fatalf("GET /updates did not stream Datastar patch signals:\n%s", body)
 	}
 	return patches
+}
+
+func (h *harness) openUpdatesStream(t *testing.T, dashboardID, pageID string, signals map[string]any) *streamClient {
+	t.Helper()
+
+	serverURL := h.serverURL(t)
+	encodedSignals, err := json.Marshal(signals)
+	if err != nil {
+		t.Fatalf("marshal Datastar signals: %v", err)
+	}
+	values := url.Values{}
+	values.Set("dashboard", dashboardID)
+	values.Set("page", pageID)
+	values.Set("datastar", string(encodedSignals))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, serverURL+"/updates?"+values.Encode(), nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("create updates request: %v", err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cancel()
+		t.Fatalf("open updates stream: %v", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		defer res.Body.Close()
+		body, _ := io.ReadAll(res.Body)
+		cancel()
+		t.Fatalf("GET /updates status = %d, body:\n%s", res.StatusCode, string(body))
+	}
+	if got := res.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		_ = res.Body.Close()
+		cancel()
+		t.Fatalf("GET /updates content type = %q, want text/event-stream", got)
+	}
+
+	client := &streamClient{
+		cancel:  cancel,
+		body:    res.Body,
+		patches: make(chan map[string]any, 16),
+		errs:    make(chan error, 1),
+	}
+	go client.read()
+	t.Cleanup(client.close)
+	return client
+}
+
+func (h *harness) postCommand(t *testing.T, path string, signals map[string]any) int {
+	t.Helper()
+
+	encodedSignals, err := json.Marshal(signals)
+	if err != nil {
+		t.Fatalf("marshal Datastar signals: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, h.serverURL(t)+path, bytes.NewReader(encodedSignals))
+	if err != nil {
+		t.Fatalf("create command request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode >= 400 {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("POST %s status = %d, body:\n%s", path, res.StatusCode, string(body))
+	}
+	return res.StatusCode
+}
+
+func (h *harness) serverURL(t *testing.T) string {
+	t.Helper()
+	return h.server.URL
+}
+
+type streamClient struct {
+	cancel  context.CancelFunc
+	body    io.ReadCloser
+	patches chan map[string]any
+	errs    chan error
+}
+
+func (c *streamClient) nextPatch(t *testing.T) map[string]any {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case patch, ok := <-c.patches:
+		if !ok {
+			t.Fatal("updates stream closed before next patch")
+		}
+		return patch
+	case err := <-c.errs:
+		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, http.ErrAbortHandler) {
+			t.Fatal("updates stream closed before next patch")
+		}
+		t.Fatalf("read updates stream: %v", err)
+	case <-timer.C:
+		t.Fatal("timed out waiting for next updates patch")
+	}
+	return nil
+}
+
+func (c *streamClient) expectNoPatch(t *testing.T, duration time.Duration) {
+	t.Helper()
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case patch, ok := <-c.patches:
+		if !ok {
+			return
+		}
+		t.Fatalf("unexpected updates patch: %#v", patch)
+	case err := <-c.errs:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("read updates stream: %v", err)
+		}
+	case <-timer.C:
+	}
+}
+
+func (c *streamClient) close() {
+	c.cancel()
+	_ = c.body.Close()
+}
+
+func (c *streamClient) read() {
+	defer close(c.patches)
+
+	reader := bufio.NewReader(c.body)
+	var event strings.Builder
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			event.WriteString(line)
+			if line == "\n" || line == "\r\n" {
+				events := ssetest.ParseEvents(event.String())
+				event.Reset()
+				for _, evt := range events {
+					patch, ok, err := ssetest.DecodePatchSignalEvent(evt)
+					if err != nil {
+						c.errs <- err
+						return
+					}
+					if ok {
+						c.patches <- patch
+					}
+				}
+			}
+		}
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		c.errs <- fmt.Errorf("read SSE event: %w", err)
+		return
+	}
 }
 
 func discoverCatalogPath(t *testing.T) string {

--- a/internal/integration/harness_test.go
+++ b/internal/integration/harness_test.go
@@ -1,0 +1,225 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	analyticsduckdb "github.com/Yacobolo/libredash/internal/analytics/duckdb"
+	materializeruntime "github.com/Yacobolo/libredash/internal/analytics/materialize"
+	"github.com/Yacobolo/libredash/internal/app"
+	reportdef "github.com/Yacobolo/libredash/internal/dashboard/report"
+	dashboardruntime "github.com/Yacobolo/libredash/internal/dashboard/runtime"
+	"github.com/Yacobolo/libredash/internal/testutil/ssetest"
+)
+
+type harness struct {
+	handler http.Handler
+}
+
+type harnessConfig struct {
+	catalogPath string
+	fixture     func(t *testing.T, dir string)
+}
+
+type harnessOption func(*harnessConfig)
+
+func withCatalog(path string) harnessOption {
+	return func(config *harnessConfig) {
+		config.catalogPath = path
+	}
+}
+
+func withOlistFixture(fixture func(t *testing.T, dir string)) harnessOption {
+	return func(config *harnessConfig) {
+		config.fixture = fixture
+	}
+}
+
+func newHarness(t *testing.T, opts ...harnessOption) *harness {
+	t.Helper()
+
+	config := harnessConfig{
+		fixture: writeMinimalOlistFixture,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	if config.catalogPath == "" {
+		config.catalogPath = discoverCatalogPath(t)
+	}
+
+	dataDir := t.TempDir()
+	duckDBDir := t.TempDir()
+	config.fixture(t, dataDir)
+
+	metrics, err := dashboardruntime.NewFromCatalog(dataDir, config.catalogPath, duckDBDir, integrationDataRuntimeFactory{})
+	if err != nil {
+		t.Fatalf("create dashboard runtime: %v", err)
+	}
+	t.Cleanup(func() { _ = metrics.Close() })
+
+	return &harness{
+		handler: app.New(metrics).Routes(),
+	}
+}
+
+func (h *harness) getUpdates(t *testing.T, dashboardID, pageID string, signals map[string]any) string {
+	t.Helper()
+
+	encodedSignals, err := json.Marshal(signals)
+	if err != nil {
+		t.Fatalf("marshal Datastar signals: %v", err)
+	}
+	values := url.Values{}
+	values.Set("dashboard", dashboardID)
+	values.Set("page", pageID)
+	values.Set("datastar", string(encodedSignals))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/updates?"+values.Encode(), nil)
+	rec := httptest.NewRecorder()
+
+	h.handler.ServeHTTP(rec, req)
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("GET /updates status = %d, body:\n%s", got, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("GET /updates content type = %q, want text/event-stream", got)
+	}
+	return rec.Body.String()
+}
+
+func (h *harness) getUpdatesSignals(t *testing.T, dashboardID, pageID string, signals map[string]any) []map[string]any {
+	t.Helper()
+
+	body := h.getUpdates(t, dashboardID, pageID, signals)
+	patches := ssetest.PatchSignals(t, body)
+	if len(patches) == 0 {
+		t.Fatalf("GET /updates did not stream Datastar patch signals:\n%s", body)
+	}
+	return patches
+}
+
+func discoverCatalogPath(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	for {
+		candidate := filepath.Join(dir, "dashboards", "catalog.yaml")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find dashboards/catalog.yaml")
+		}
+		dir = parent
+	}
+}
+
+func writeMinimalOlistFixture(t *testing.T, dir string) {
+	t.Helper()
+
+	writeFixture(t, dir, "olist_orders_dataset.csv", `order_id,customer_id,order_status,order_purchase_timestamp,order_delivered_customer_date
+o1,c1,delivered,2018-01-10 10:00:00,2018-01-14 10:00:00
+o2,c2,shipped,2017-06-10 10:00:00,2017-06-20 10:00:00
+`)
+	writeFixture(t, dir, "olist_order_items_dataset.csv", `order_id,order_item_id,product_id,price,freight_value
+o1,1,p1,100.00,10.00
+o2,1,p2,50.00,5.00
+`)
+	writeFixture(t, dir, "olist_order_payments_dataset.csv", `order_id,payment_value
+o1,110.00
+o2,55.00
+`)
+	writeFixture(t, dir, "olist_products_dataset.csv", `product_id,product_category_name
+p1,beleza_saude
+p2,relogios_presentes
+`)
+	writeFixture(t, dir, "olist_customers_dataset.csv", `customer_id,customer_state
+c1,SP
+c2,RJ
+`)
+	writeFixture(t, dir, "olist_order_reviews_dataset.csv", `review_id,order_id,review_score
+r1,o1,5
+r2,o2,3
+`)
+	writeFixture(t, dir, "product_category_name_translation.csv", `product_category_name,product_category_name_english
+beleza_saude,health_beauty
+relogios_presentes,watches_gifts
+`)
+}
+
+func writeFixture(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", name, err)
+	}
+}
+
+type integrationDataRuntimeFactory struct{}
+
+func (integrationDataRuntimeFactory) OpenDashboardDataRuntime(ctx context.Context, config dashboardruntime.DataRuntimeConfig) (dashboardruntime.DataRuntime, error) {
+	runtime, err := analyticsduckdb.OpenMaterializeRuntime(ctx, materializeruntime.RuntimeConfig{
+		ModelID: config.ModelID,
+		Model:   config.Model,
+		DataDir: config.DataDir,
+		DBDir:   config.DBDir,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return integrationDataRuntime{
+		runtime: runtime,
+		data:    reportdef.NewAnalyticsDataService(runtime.Queries()),
+	}, nil
+}
+
+type integrationDataRuntime struct {
+	runtime *materializeruntime.Runtime
+	data    reportdef.DataService
+}
+
+func (r integrationDataRuntime) Query(ctx context.Context, request reportdef.AggregateQuery) (reportdef.QueryRows, error) {
+	return r.data.Query(ctx, request)
+}
+
+func (r integrationDataRuntime) Rows(ctx context.Context, request reportdef.RowQuery) (reportdef.QueryRows, error) {
+	return r.data.Rows(ctx, request)
+}
+
+func (r integrationDataRuntime) Count(ctx context.Context, request reportdef.CountQuery) (int, error) {
+	return r.data.Count(ctx, request)
+}
+
+func (r integrationDataRuntime) Histogram(ctx context.Context, request reportdef.RawValueQuery, binCount int) ([]reportdef.HistogramBin, error) {
+	return r.data.Histogram(ctx, request, binCount)
+}
+
+func (r integrationDataRuntime) Distribution(ctx context.Context, request reportdef.RawValueQuery, sort []reportdef.QuerySort, limit int) (reportdef.QueryRows, error) {
+	return r.data.Distribution(ctx, request, sort, limit)
+}
+
+func (r integrationDataRuntime) Refresh(ctx context.Context) error {
+	return r.runtime.Refresh(ctx)
+}
+
+func (r integrationDataRuntime) Close() error {
+	return r.runtime.Close()
+}
+
+func (r integrationDataRuntime) LastRefresh() time.Time {
+	return r.runtime.LastRefresh()
+}

--- a/internal/integration/routing_test.go
+++ b/internal/integration/routing_test.go
@@ -1,0 +1,48 @@
+package integration
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestCommandPatchesAreScopedToClientAndPage(t *testing.T) {
+	h := newHarness(t)
+	target := h.openUpdatesStream(t, "executive-sales", "overview", runtimeSignals("route-target", "overview"))
+	otherClient := h.openUpdatesStream(t, "executive-sales", "overview", runtimeSignals("route-other", "overview"))
+	otherPage := h.openUpdatesStream(t, "executive-sales", "chart-line", runtimeSignals("route-target", "chart-line"))
+	drainInitialSnapshot(t, target)
+	drainInitialSnapshot(t, otherClient)
+	drainInitialSnapshot(t, otherPage)
+
+	status := h.postCommand(t, "/commands/select", mergeSignals(runtimeSignals("route-target", "overview"), map[string]any{
+		"interactionCommand": pointSelectionCommand("orders", "orders.status", "delivered"),
+		"tableCommand":       tableCommand("orders_table", "all", 0, 50, 12, 0),
+	}))
+	if status != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", status, http.StatusNoContent)
+	}
+
+	requireStatusLoading(t, []map[string]any{target.nextPatch(t)}, true)
+	otherClient.expectNoPatch(t, 150*time.Millisecond)
+	otherPage.expectNoPatch(t, 150*time.Millisecond)
+}
+
+func TestUpdatesQueryParamsTakePrecedenceOverRuntimeSignalIDs(t *testing.T) {
+	h := newHarness(t)
+
+	patches := h.getUpdatesSignals(t, "executive-sales", "overview", map[string]any{
+		"runtime": map[string]any{
+			"clientId":    "route-precedence",
+			"dashboardId": "executive-sales",
+			"pageId":      "chart-line",
+		},
+	})
+
+	requireVisual(t, patches, "total_orders")
+	requireTable(t, patches, "orders_table")
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		visuals := mapAt(patch, "visuals")
+		return len(visuals) > 0 && !hasKey(visuals, "revenue_line")
+	})
+}

--- a/internal/integration/updates_test.go
+++ b/internal/integration/updates_test.go
@@ -1,6 +1,11 @@
 package integration
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 func TestUpdatesStreamsRealRuntimeSignals(t *testing.T) {
 	h := newHarness(t)
@@ -33,12 +38,15 @@ func TestUpdatesStreamsRealRuntimeSignals(t *testing.T) {
 			assert: func(t *testing.T, patches []map[string]any) {
 				t.Helper()
 
+				requireFirstStatusLoading(t, patches)
 				requireStatusLoading(t, patches, true)
 				requireStatusLoading(t, patches, false)
 				requireFilterValues(t, patches, "state", "SP")
+				requireFilterOptions(t, patches, "state")
 				requireVisual(t, patches, "total_orders")
 				requireTable(t, patches, "orders_table")
 				requireNoFilter(t, patches, "category")
+				requireNoTopLevelSignal(t, patches, "kpis")
 			},
 		},
 		{
@@ -62,6 +70,7 @@ func TestUpdatesStreamsRealRuntimeSignals(t *testing.T) {
 						!hasKey(visuals, "orders") &&
 						!hasKey(patch, "kpis")
 				})
+				requireEmptyTables(t, patches)
 				requireNoTopLevelSignal(t, patches, "kpis")
 			},
 		},
@@ -75,6 +84,44 @@ func TestUpdatesStreamsRealRuntimeSignals(t *testing.T) {
 	}
 }
 
+func TestUpdatesStreamsSetupRequiredPatchForMissingData(t *testing.T) {
+	h := newHarness(t, withOlistFixture(func(t *testing.T, dir string) {}))
+
+	patches := h.getUpdatesSignals(t, "executive-sales", "overview", map[string]any{})
+
+	requireFirstStatusLoading(t, patches)
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		status := mapAt(patch, "status")
+		return status["setupRequired"] == true && strings.TrimSpace(stringValue(status["error"])) != ""
+	})
+}
+
+func TestUpdatesRejectsMalformedDatastarSignals(t *testing.T) {
+	h := newHarness(t)
+	req := httptest.NewRequest(http.MethodGet, "/updates?dashboard=executive-sales&page=overview&datastar=%7Bnot-json", nil)
+	rec := httptest.NewRecorder()
+
+	h.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body:\n%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("malformed Datastar request opened SSE stream with content type %q", got)
+	}
+}
+
+func requireFirstStatusLoading(t *testing.T, patches []map[string]any) {
+	t.Helper()
+	if len(patches) == 0 {
+		t.Fatal("no patches streamed")
+	}
+	status := mapAt(patches[0], "status")
+	if status["loading"] != true {
+		t.Fatalf("first patch status = %#v, want loading=true; patch=%#v", status, patches[0])
+	}
+}
+
 func requireStatusLoading(t *testing.T, patches []map[string]any, loading bool) {
 	t.Helper()
 	requirePatch(t, patches, func(patch map[string]any) bool {
@@ -83,11 +130,22 @@ func requireStatusLoading(t *testing.T, patches []map[string]any, loading bool) 
 	})
 }
 
+func requireStatusError(t *testing.T, patches []map[string]any, setupRequired bool) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		status := mapAt(patch, "status")
+		return stringValue(status["error"]) != "" && status["setupRequired"] == setupRequired
+	})
+}
+
 func requireFilterValues(t *testing.T, patches []map[string]any, filterID string, want ...string) {
 	t.Helper()
 	requirePatch(t, patches, func(patch map[string]any) bool {
 		filter := mapAt(patch, "filters", "controls", filterID)
 		values, ok := filter["values"].([]any)
+		if len(want) == 0 && !ok {
+			return true
+		}
 		if !ok || len(values) != len(want) {
 			return false
 		}
@@ -97,6 +155,18 @@ func requireFilterValues(t *testing.T, patches []map[string]any, filterID string
 			}
 		}
 		return true
+	})
+}
+
+func requireFilterOptions(t *testing.T, patches []map[string]any, filterID string) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		options, ok := patch["filterOptions"].(map[string]any)
+		if !ok {
+			return false
+		}
+		values, ok := options[filterID].([]any)
+		return ok && len(values) > 0
 	})
 }
 
@@ -114,6 +184,14 @@ func requireTable(t *testing.T, patches []map[string]any, tableID string) {
 	})
 }
 
+func requireEmptyTables(t *testing.T, patches []map[string]any) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		tables, ok := patch["tables"].(map[string]any)
+		return ok && len(tables) == 0
+	})
+}
+
 func requireNoFilter(t *testing.T, patches []map[string]any, filterID string) {
 	t.Helper()
 	for _, patch := range patches {
@@ -123,6 +201,67 @@ func requireNoFilter(t *testing.T, patches []map[string]any, filterID string) {
 	}
 }
 
+func requireNoSelection(t *testing.T, patches []map[string]any) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		selections, ok := mapAt(patch, "filters")["selections"].([]any)
+		return ok && len(selections) == 0
+	})
+}
+
+func requireSelection(t *testing.T, patches []map[string]any, sourceID, field, value string) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		selections, ok := mapAt(patch, "filters")["selections"].([]any)
+		if !ok {
+			return false
+		}
+		for _, rawSelection := range selections {
+			selection, ok := rawSelection.(map[string]any)
+			if !ok || selection["sourceId"] != sourceID {
+				continue
+			}
+			entries, ok := selection["entries"].([]any)
+			if !ok {
+				continue
+			}
+			for _, rawEntry := range entries {
+				entry, ok := rawEntry.(map[string]any)
+				if !ok {
+					continue
+				}
+				mappings, ok := entry["mappings"].([]any)
+				if !ok {
+					continue
+				}
+				for _, rawMapping := range mappings {
+					mapping, ok := rawMapping.(map[string]any)
+					if ok && mapping["field"] == field && mapping["value"] == value {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	})
+}
+
+func requireTableBlock(t *testing.T, patches []map[string]any, tableID, blockID string, start, requestSeq int) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		block := tableBlock(patch, tableID, blockID)
+		return numberValue(block["start"]) == float64(start) && numberValue(block["requestSeq"]) == float64(requestSeq)
+	})
+}
+
+func requireTableResetVersion(t *testing.T, patches []map[string]any, tableID string, resetVersion int) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		table := mapAt(patch, "tables", tableID)
+		return numberValue(table["resetVersion"]) == float64(resetVersion)
+	})
+}
+
 func requireNoTopLevelSignal(t *testing.T, patches []map[string]any, signal string) {
 	t.Helper()
 	for _, patch := range patches {
@@ -130,6 +269,10 @@ func requireNoTopLevelSignal(t *testing.T, patches []map[string]any, signal stri
 			t.Fatalf("patch streamed unexpected top-level signal %q: %#v", signal, patch)
 		}
 	}
+}
+
+func tableBlock(patch map[string]any, tableID, blockID string) map[string]any {
+	return mapAt(patch, "tables", tableID, "blocks", blockID)
 }
 
 func requirePatch(t *testing.T, patches []map[string]any, match func(map[string]any) bool) map[string]any {
@@ -149,6 +292,19 @@ func hasKey(source map[string]any, key string) bool {
 	}
 	_, ok := source[key]
 	return ok
+}
+
+func stringValue(value any) string {
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+func numberValue(value any) float64 {
+	number, _ := value.(float64)
+	return number
 }
 
 func mapAt(source map[string]any, path ...string) map[string]any {

--- a/internal/integration/updates_test.go
+++ b/internal/integration/updates_test.go
@@ -1,0 +1,164 @@
+package integration
+
+import "testing"
+
+func TestUpdatesStreamsRealRuntimeSignals(t *testing.T) {
+	h := newHarness(t)
+
+	tests := []struct {
+		name    string
+		pageID  string
+		signals map[string]any
+		assert  func(t *testing.T, patches []map[string]any)
+	}{
+		{
+			name:   "overview filtered to SP",
+			pageID: "overview",
+			signals: map[string]any{
+				"filters": map[string]any{
+					"controls": map[string]any{
+						"state": map[string]any{
+							"type":     "multi_select",
+							"operator": "in",
+							"values":   []string{"SP"},
+						},
+						"category": map[string]any{
+							"type":     "text",
+							"operator": "contains",
+							"value":    "ignored",
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, patches []map[string]any) {
+				t.Helper()
+
+				requireStatusLoading(t, patches, true)
+				requireStatusLoading(t, patches, false)
+				requireFilterValues(t, patches, "state", "SP")
+				requireVisual(t, patches, "total_orders")
+				requireTable(t, patches, "orders_table")
+				requireNoFilter(t, patches, "category")
+			},
+		},
+		{
+			name:   "chart line page scoped",
+			pageID: "chart-line",
+			signals: map[string]any{
+				"runtime": map[string]any{
+					"clientId":    "integration-client",
+					"dashboardId": "executive-sales",
+					"pageId":      "chart-line",
+				},
+			},
+			assert: func(t *testing.T, patches []map[string]any) {
+				t.Helper()
+
+				requirePatch(t, patches, func(patch map[string]any) bool {
+					visuals := mapAt(patch, "visuals")
+					return len(visuals) > 0 &&
+						hasKey(visuals, "revenue_line") &&
+						!hasKey(visuals, "total_orders") &&
+						!hasKey(visuals, "orders") &&
+						!hasKey(patch, "kpis")
+				})
+				requireNoTopLevelSignal(t, patches, "kpis")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := h.getUpdatesSignals(t, "executive-sales", tt.pageID, tt.signals)
+			tt.assert(t, patches)
+		})
+	}
+}
+
+func requireStatusLoading(t *testing.T, patches []map[string]any, loading bool) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		status := mapAt(patch, "status")
+		return status["loading"] == loading
+	})
+}
+
+func requireFilterValues(t *testing.T, patches []map[string]any, filterID string, want ...string) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		filter := mapAt(patch, "filters", "controls", filterID)
+		values, ok := filter["values"].([]any)
+		if !ok || len(values) != len(want) {
+			return false
+		}
+		for i := range want {
+			if values[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func requireVisual(t *testing.T, patches []map[string]any, visualID string) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		return hasKey(mapAt(patch, "visuals"), visualID)
+	})
+}
+
+func requireTable(t *testing.T, patches []map[string]any, tableID string) {
+	t.Helper()
+	requirePatch(t, patches, func(patch map[string]any) bool {
+		return hasKey(mapAt(patch, "tables"), tableID)
+	})
+}
+
+func requireNoFilter(t *testing.T, patches []map[string]any, filterID string) {
+	t.Helper()
+	for _, patch := range patches {
+		if hasKey(mapAt(patch, "filters", "controls"), filterID) {
+			t.Fatalf("patch streamed unexpected filter %q: %#v", filterID, patch)
+		}
+	}
+}
+
+func requireNoTopLevelSignal(t *testing.T, patches []map[string]any, signal string) {
+	t.Helper()
+	for _, patch := range patches {
+		if hasKey(patch, signal) {
+			t.Fatalf("patch streamed unexpected top-level signal %q: %#v", signal, patch)
+		}
+	}
+}
+
+func requirePatch(t *testing.T, patches []map[string]any, match func(map[string]any) bool) map[string]any {
+	t.Helper()
+	for _, patch := range patches {
+		if match(patch) {
+			return patch
+		}
+	}
+	t.Fatalf("no patch matched predicate; patches: %#v", patches)
+	return nil
+}
+
+func hasKey(source map[string]any, key string) bool {
+	if source == nil {
+		return false
+	}
+	_, ok := source[key]
+	return ok
+}
+
+func mapAt(source map[string]any, path ...string) map[string]any {
+	current := source
+	for _, key := range path {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = next
+	}
+	return current
+}

--- a/internal/testutil/ssetest/ssetest.go
+++ b/internal/testutil/ssetest/ssetest.go
@@ -2,6 +2,7 @@ package ssetest
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -17,7 +18,10 @@ type Event struct {
 
 func Events(t testing.TB, body string) []Event {
 	t.Helper()
+	return ParseEvents(body)
+}
 
+func ParseEvents(body string) []Event {
 	var events []Event
 	var current Event
 	var data []string
@@ -74,21 +78,42 @@ func Events(t testing.TB, body string) []Event {
 func PatchSignals(t testing.TB, body string) []map[string]any {
 	t.Helper()
 
-	var patches []map[string]any
-	for _, event := range Events(t, body) {
-		if event.Event != datastarPatchSignalsEvent {
-			continue
-		}
+	patches, err := DecodePatchSignals(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return patches
+}
 
-		payload := datastarSignalsPayload(t, event.Data)
-		var patch map[string]any
-		if err := json.Unmarshal([]byte(payload), &patch); err != nil {
-			t.Fatalf("unmarshal Datastar patch signals payload %q: %v", payload, err)
+func DecodePatchSignals(body string) ([]map[string]any, error) {
+	var patches []map[string]any
+	for _, event := range ParseEvents(body) {
+		patch, ok, err := DecodePatchSignalEvent(event)
+		if err != nil {
+			return nil, err
 		}
-		patches = append(patches, patch)
+		if ok {
+			patches = append(patches, patch)
+		}
 	}
 
-	return patches
+	return patches, nil
+}
+
+func DecodePatchSignalEvent(event Event) (map[string]any, bool, error) {
+	if event.Event != datastarPatchSignalsEvent {
+		return nil, false, nil
+	}
+
+	payload, err := datastarSignalsPayload(event.Data)
+	if err != nil {
+		return nil, true, err
+	}
+	var patch map[string]any
+	if err := json.Unmarshal([]byte(payload), &patch); err != nil {
+		return nil, true, fmt.Errorf("unmarshal Datastar patch signals payload %q: %w", payload, err)
+	}
+	return patch, true, nil
 }
 
 func RequirePatchSignal(t testing.TB, body string, match func(map[string]any) bool) map[string]any {
@@ -104,9 +129,7 @@ func RequirePatchSignal(t testing.TB, body string, match func(map[string]any) bo
 	return nil
 }
 
-func datastarSignalsPayload(t testing.TB, data string) string {
-	t.Helper()
-
+func datastarSignalsPayload(data string) (string, error) {
 	lines := strings.Split(data, "\n")
 	payload := make([]string, 0, len(lines))
 	for _, line := range lines {
@@ -114,12 +137,12 @@ func datastarSignalsPayload(t testing.TB, data string) string {
 			continue
 		}
 		if !strings.HasPrefix(line, "signals ") {
-			t.Fatalf("Datastar patch-signal data line %q is missing signals prefix", line)
+			return "", fmt.Errorf("Datastar patch-signal data line %q is missing signals prefix", line)
 		}
 		payload = append(payload, strings.TrimPrefix(line, "signals "))
 	}
 	if len(payload) == 0 {
-		t.Fatal("Datastar patch-signal event did not include a signals payload")
+		return "", fmt.Errorf("Datastar patch-signal event did not include a signals payload")
 	}
-	return strings.Join(payload, "\n")
+	return strings.Join(payload, "\n"), nil
 }

--- a/internal/testutil/ssetest/ssetest.go
+++ b/internal/testutil/ssetest/ssetest.go
@@ -1,0 +1,125 @@
+package ssetest
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const datastarPatchSignalsEvent = "datastar-patch-signals"
+
+type Event struct {
+	Event string
+	ID    string
+	Retry string
+	Data  string
+}
+
+func Events(t testing.TB, body string) []Event {
+	t.Helper()
+
+	var events []Event
+	var current Event
+	var data []string
+	hasField := false
+
+	flush := func() {
+		if !hasField {
+			return
+		}
+		current.Data = strings.Join(data, "\n")
+		events = append(events, current)
+		current = Event{}
+		data = nil
+		hasField = false
+	}
+
+	for _, rawLine := range strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n") {
+		if rawLine == "" {
+			flush()
+			continue
+		}
+		if strings.HasPrefix(rawLine, ":") {
+			continue
+		}
+
+		name, value, ok := strings.Cut(rawLine, ":")
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(value, " ") {
+			value = strings.TrimPrefix(value, " ")
+		}
+
+		switch name {
+		case "event":
+			current.Event = value
+			hasField = true
+		case "id":
+			current.ID = value
+			hasField = true
+		case "retry":
+			current.Retry = value
+			hasField = true
+		case "data":
+			data = append(data, value)
+			hasField = true
+		}
+	}
+	flush()
+
+	return events
+}
+
+func PatchSignals(t testing.TB, body string) []map[string]any {
+	t.Helper()
+
+	var patches []map[string]any
+	for _, event := range Events(t, body) {
+		if event.Event != datastarPatchSignalsEvent {
+			continue
+		}
+
+		payload := datastarSignalsPayload(t, event.Data)
+		var patch map[string]any
+		if err := json.Unmarshal([]byte(payload), &patch); err != nil {
+			t.Fatalf("unmarshal Datastar patch signals payload %q: %v", payload, err)
+		}
+		patches = append(patches, patch)
+	}
+
+	return patches
+}
+
+func RequirePatchSignal(t testing.TB, body string, match func(map[string]any) bool) map[string]any {
+	t.Helper()
+
+	patches := PatchSignals(t, body)
+	for _, patch := range patches {
+		if match(patch) {
+			return patch
+		}
+	}
+	t.Fatalf("no Datastar patch signal matched predicate; patches: %#v", patches)
+	return nil
+}
+
+func datastarSignalsPayload(t testing.TB, data string) string {
+	t.Helper()
+
+	lines := strings.Split(data, "\n")
+	payload := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(line, "onlyIfMissing ") {
+			continue
+		}
+		if !strings.HasPrefix(line, "signals ") {
+			t.Fatalf("Datastar patch-signal data line %q is missing signals prefix", line)
+		}
+		payload = append(payload, strings.TrimPrefix(line, "signals "))
+	}
+	if len(payload) == 0 {
+		t.Fatal("Datastar patch-signal event did not include a signals payload")
+	}
+	return strings.Join(payload, "\n")
+}

--- a/internal/testutil/ssetest/ssetest_test.go
+++ b/internal/testutil/ssetest/ssetest_test.go
@@ -1,0 +1,77 @@
+package ssetest
+
+import "testing"
+
+func TestEventsParsesMultipleEvents(t *testing.T) {
+	body := ": ignored comment\n" +
+		"event: first\n" +
+		"id: 1\n" +
+		"retry: 250\n" +
+		"data: hello\n" +
+		"data: world\n" +
+		"unknown: ignored\n" +
+		"\n" +
+		"event: second\n" +
+		"data: done\n" +
+		"\n"
+
+	events := Events(t, body)
+	if len(events) != 2 {
+		t.Fatalf("events = %#v, want 2 events", events)
+	}
+	if got := events[0]; got.Event != "first" || got.ID != "1" || got.Retry != "250" || got.Data != "hello\nworld" {
+		t.Fatalf("first event = %#v", got)
+	}
+	if got := events[1]; got.Event != "second" || got.Data != "done" {
+		t.Fatalf("second event = %#v", got)
+	}
+}
+
+func TestPatchSignalsDecodesDatastarEvents(t *testing.T) {
+	body := "event: datastar-patch-elements\n" +
+		"data: elements <div></div>\n" +
+		"\n" +
+		"event: datastar-patch-signals\n" +
+		"data: signals {\"status\":{\"loading\":true}}\n" +
+		"\n" +
+		"event: datastar-patch-signals\n" +
+		"data: onlyIfMissing true\n" +
+		"data: signals {\n" +
+		"data: signals \"filters\":{\"controls\":{\"state\":{\"values\":[\"SP\"]}}}\n" +
+		"data: signals }\n" +
+		"\n"
+
+	patches := PatchSignals(t, body)
+	if len(patches) != 2 {
+		t.Fatalf("patches = %#v, want 2 patches", patches)
+	}
+	status := patches[0]["status"].(map[string]any)
+	if status["loading"] != true {
+		t.Fatalf("status patch = %#v", patches[0])
+	}
+	filters := patches[1]["filters"].(map[string]any)
+	controls := filters["controls"].(map[string]any)
+	state := controls["state"].(map[string]any)
+	values := state["values"].([]any)
+	if len(values) != 1 || values[0] != "SP" {
+		t.Fatalf("state values = %#v", values)
+	}
+}
+
+func TestRequirePatchSignalReturnsMatchingPatch(t *testing.T) {
+	body := "event: datastar-patch-signals\n" +
+		"data: signals {\"status\":{\"loading\":true}}\n" +
+		"\n" +
+		"event: datastar-patch-signals\n" +
+		"data: signals {\"status\":{\"loading\":false}}\n" +
+		"\n"
+
+	patch := RequirePatchSignal(t, body, func(patch map[string]any) bool {
+		status := patch["status"].(map[string]any)
+		return status["loading"] == false
+	})
+	status := patch["status"].(map[string]any)
+	if status["loading"] != false {
+		t.Fatalf("matched patch = %#v", patch)
+	}
+}


### PR DESCRIPTION
## Summary
- add reusable SSE/Datastar patch-signal test helpers
- add an internal integration harness using real Olist fixtures, DuckDB materialization, dashboard runtime, and app /updates routing
- convert the focused /updates app test to structural signal assertions

## Tests
- go test ./internal/testutil/ssetest ./internal/integration -count=1
- go test ./internal/app ./internal/dashboard/runtime ./internal/integration -count=1