### PR TITLE
Scope sources under connections

### DIFF
--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -459,7 +459,7 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"Connections", "Global", "data-connection-toolbar", "Local CSV files for the Olist ecommerce demo dataset."} {
+	for _, want := range []string{"Connections", "Connection", "Source", "data-connection-toolbar", "Local CSV files for the Olist ecommerce demo dataset.", "Raw Olist order lifecycle records."} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("connections page missing %q:\n%s", want, body)
 		}
@@ -467,11 +467,40 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 	if !strings.Contains(body, `/connections/asset_`) || !strings.Contains(body, `/details`) {
 		t.Fatalf("connections page did not link to canonical connection details:\n%s", body)
 	}
+	if !strings.Contains(body, `/sources/asset_`) {
+		t.Fatalf("connections page did not link to canonical source details:\n%s", body)
+	}
 	if strings.Contains(body, `/workspaces/test/assets/asset_`) {
 		t.Fatalf("connections page linked to workspace asset details:\n%s", body)
 	}
 	if strings.Contains(body, `data-workspace-asset-toolbar`) {
 		t.Fatalf("connections page rendered workspace asset toolbar:\n%s", body)
+	}
+}
+
+func TestConnectionsPageFiltersSources(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	req := httptest.NewRequest(http.MethodGet, "/connections?type=source&q=orders", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Source", "orders", `/connections/`, `/sources/`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("source-filtered connections page missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "Local CSV files for the Olist ecommerce demo dataset.") {
+		t.Fatalf("source-filtered connections page included connection row:\n%s", body)
 	}
 }
 
@@ -525,6 +554,65 @@ func TestConnectionAssetRoutesUseConnectionSurface(t *testing.T) {
 	}
 }
 
+func TestConnectionSourceAssetRoutesUseConnectionScopedSurface(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+	connectionID := activeAssetID(t, store, "test", "connection", "olist.olist")
+	sourceID := activeAssetID(t, store, "test", "source", "olist.orders")
+
+	redirectReq := httptest.NewRequest(http.MethodGet, "/connections/"+connectionID+"/sources/"+sourceID, nil)
+	redirectReq.Header.Set("Authorization", "Bearer dev")
+	redirectRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(redirectRec, redirectReq)
+	if redirectRec.Code != http.StatusFound {
+		t.Fatalf("source canonical redirect status = %d body=%s", redirectRec.Code, redirectRec.Body.String())
+	}
+	if got := redirectRec.Header().Get("Location"); got != "/connections/"+connectionID+"/sources/"+sourceID+"/details" {
+		t.Fatalf("source redirect Location = %q, want canonical source details", got)
+	}
+
+	detailReq := httptest.NewRequest(http.MethodGet, "/connections/"+connectionID+"/sources/"+sourceID+"/details", nil)
+	detailReq.Header.Set("Authorization", "Bearer dev")
+	detailRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(detailRec, detailReq)
+	if detailRec.Code != http.StatusOK {
+		t.Fatalf("source detail status = %d body=%s", detailRec.Code, detailRec.Body.String())
+	}
+	detailBody := detailRec.Body.String()
+	for _, want := range []string{"Connections", "Sources", "orders", "Fields", "Physical type", "Lineage"} {
+		if !strings.Contains(detailBody, want) {
+			t.Fatalf("source detail missing %q:\n%s", want, detailBody)
+		}
+	}
+	for _, notWant := range []string{`Workspaces /`, `Back to workspace`, `/workspaces/test/assets/` + sourceID + `/details`} {
+		if strings.Contains(detailBody, notWant) {
+			t.Fatalf("source detail rendered workspace chrome %q:\n%s", notWant, detailBody)
+		}
+	}
+
+	lineageReq := httptest.NewRequest(http.MethodGet, "/connections/"+connectionID+"/sources/"+sourceID+"/lineage", nil)
+	lineageReq.Header.Set("Authorization", "Bearer dev")
+	lineageRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(lineageRec, lineageReq)
+	if lineageRec.Code != http.StatusOK {
+		t.Fatalf("source lineage status = %d body=%s", lineageRec.Code, lineageRec.Body.String())
+	}
+	if !strings.Contains(lineageRec.Body.String(), "ld-asset-lineage-graph") {
+		t.Fatalf("source lineage did not render lineage graph:\n%s", lineageRec.Body.String())
+	}
+
+	invalidReq := httptest.NewRequest(http.MethodGet, "/connections/"+sourceID+"/sources/"+sourceID+"/details", nil)
+	invalidReq.Header.Set("Authorization", "Bearer dev")
+	invalidRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(invalidRec, invalidReq)
+	if invalidRec.Code != http.StatusNotFound {
+		t.Fatalf("invalid source/connection pair status = %d, want 404 body=%s", invalidRec.Code, invalidRec.Body.String())
+	}
+}
+
 func TestWorkspaceConnectionAssetRedirectsToConnectionSurface(t *testing.T) {
 	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
@@ -543,6 +631,28 @@ func TestWorkspaceConnectionAssetRedirectsToConnectionSurface(t *testing.T) {
 	}
 	if got := rec.Header().Get("Location"); got != "/connections/"+connectionID+"/details" {
 		t.Fatalf("workspace connection detail Location = %q, want /connections/%s/details", got, connectionID)
+	}
+}
+
+func TestWorkspaceSourceAssetRedirectsToConnectionScopedSourceSurface(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+	connectionID := activeAssetID(t, store, "test", "connection", "olist.olist")
+	sourceID := activeAssetID(t, store, "test", "source", "olist.orders")
+
+	req := httptest.NewRequest(http.MethodGet, "/workspaces/test/assets/"+sourceID+"/details", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("workspace source detail status = %d, want redirect body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != "/connections/"+connectionID+"/sources/"+sourceID+"/details" {
+		t.Fatalf("workspace source detail Location = %q, want canonical source route", got)
 	}
 }
 

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -443,6 +443,26 @@ func TestWorkspaceConnectionFilterRedirectsToGlobalConnections(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSourceFilterRedirectsToConnectionSources(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	req := httptest.NewRequest(http.MethodGet, "/workspaces/test?type=source&q=orders", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusFound, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != "/connections?type=source&q=orders" {
+		t.Fatalf("Location = %q, want /connections?type=source&q=orders", got)
+	}
+}
+
 func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
@@ -610,6 +630,14 @@ func TestConnectionSourceAssetRoutesUseConnectionScopedSurface(t *testing.T) {
 	server.Routes().ServeHTTP(invalidRec, invalidReq)
 	if invalidRec.Code != http.StatusNotFound {
 		t.Fatalf("invalid source/connection pair status = %d, want 404 body=%s", invalidRec.Code, invalidRec.Body.String())
+	}
+
+	invalidRedirectReq := httptest.NewRequest(http.MethodGet, "/connections/"+sourceID+"/sources/"+sourceID, nil)
+	invalidRedirectReq.Header.Set("Authorization", "Bearer dev")
+	invalidRedirectRec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(invalidRedirectRec, invalidRedirectReq)
+	if invalidRedirectRec.Code != http.StatusNotFound {
+		t.Fatalf("invalid source/connection redirect status = %d, want 404 body=%s", invalidRedirectRec.Code, invalidRedirectRec.Body.String())
 	}
 }
 

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -33,6 +33,8 @@ func (s *Server) Routes() http.Handler {
 		r.Post("/workspaces/{workspace}/permissions", s.protected(access.PermissionRBACManage, s.updateWorkspacePermission))
 		r.Post("/workspaces/{workspace}/permissions/remove", s.protected(access.PermissionRBACManage, s.removeWorkspacePermission))
 		r.Get("/connections", s.protected(access.PermissionDashboardView, s.connections))
+		r.Get("/connections/{connection}/sources/{source}", s.protected(access.PermissionDashboardView, s.connectionSourceAsset))
+		r.Get("/connections/{connection}/sources/{source}/{section}", s.protected(access.PermissionDashboardView, s.connectionSourceAssetSection))
 		r.Get("/connections/{asset}", s.protected(access.PermissionDashboardView, s.connectionAsset))
 		r.Get("/connections/{asset}/{section}", s.protected(access.PermissionDashboardView, s.connectionAssetSection))
 		dashboardHTTP := s.dashboardHTTP()

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/Yacobolo/libredash/internal/access"
 	"github.com/Yacobolo/libredash/internal/api"
+	"github.com/Yacobolo/libredash/internal/assetnav"
 	"github.com/Yacobolo/libredash/internal/dashboard"
 	"github.com/Yacobolo/libredash/internal/ui"
 	"github.com/Yacobolo/libredash/internal/workspace"
@@ -38,8 +38,12 @@ func (s *Server) workspaces(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) workspaceAssets(w http.ResponseWriter, r *http.Request) {
 	workspaceID := s.workspaceID(chi.URLParam(r, "workspace"))
-	if r.URL.Query().Get("type") == "connection" {
-		http.Redirect(w, r, connectionsHref(r.URL.Query().Get("q")), http.StatusFound)
+	switch r.URL.Query().Get("type") {
+	case "connection":
+		http.Redirect(w, r, assetnav.ConnectionsHref(r.URL.Query().Get("q")), http.StatusFound)
+		return
+	case "source":
+		http.Redirect(w, r, assetnav.ConnectionsHrefWithType("source", r.URL.Query().Get("q")), http.StatusFound)
 		return
 	}
 	assets, _, err := s.workspaceAssetsAndEdges(r, workspaceID)
@@ -94,11 +98,11 @@ func (s *Server) workspaceAsset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if selected.Type == "connection" {
-		http.Redirect(w, r, connectionAssetSectionHref(assetID, "details"), http.StatusFound)
+		http.Redirect(w, r, assetnav.ConnectionAssetSectionHref(assetID, "details"), http.StatusFound)
 		return
 	}
 	if selected.Type == "source" {
-		http.Redirect(w, r, canonicalSourceAssetSectionHref(workspaceID, selected.ID, "details", edges), http.StatusFound)
+		http.Redirect(w, r, assetnav.CanonicalSourceAssetSectionHref(workspaceID, selected.ID, "details", edges), http.StatusFound)
 		return
 	}
 	http.Redirect(w, r, "/workspaces/"+workspaceID+"/assets/"+assetID+"/details", http.StatusFound)
@@ -134,11 +138,11 @@ func (s *Server) workspaceAssetSection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if selected.Type == "connection" {
-		http.Redirect(w, r, connectionAssetSectionHref(assetID, section), http.StatusFound)
+		http.Redirect(w, r, assetnav.ConnectionAssetSectionHref(assetID, section), http.StatusFound)
 		return
 	}
 	if selected.Type == "source" {
-		http.Redirect(w, r, canonicalSourceAssetSectionHref(workspaceID, selected.ID, section, edges), http.StatusFound)
+		http.Redirect(w, r, assetnav.CanonicalSourceAssetSectionHref(workspaceID, selected.ID, section, edges), http.StatusFound)
 		return
 	}
 	if redirectToDetails {
@@ -155,19 +159,29 @@ func (s *Server) workspaceAssetSection(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) connectionAsset(w http.ResponseWriter, r *http.Request) {
 	assetID := chi.URLParam(r, "asset")
-	http.Redirect(w, r, connectionAssetSectionHref(assetID, "details"), http.StatusFound)
+	http.Redirect(w, r, assetnav.ConnectionAssetSectionHref(assetID, "details"), http.StatusFound)
 }
 
 func (s *Server) connectionSourceAsset(w http.ResponseWriter, r *http.Request) {
 	connectionID := chi.URLParam(r, "connection")
 	sourceID := chi.URLParam(r, "source")
-	http.Redirect(w, r, connectionSourceAssetSectionHref(connectionID, sourceID, "details"), http.StatusFound)
+	workspaceID := s.workspaceID("")
+	assets, edges, err := s.workspaceAssetsAndEdges(r, workspaceID)
+	if err != nil {
+		http.Error(w, err.Error(), statusForNotFound(err))
+		return
+	}
+	if _, _, ok := connectionSourcePair(assets, edges, connectionID, sourceID); !ok {
+		http.NotFound(w, r)
+		return
+	}
+	http.Redirect(w, r, assetnav.ConnectionSourceAssetSectionHref(connectionID, sourceID, "details"), http.StatusFound)
 }
 
 func (s *Server) connectionSourceAssetSection(w http.ResponseWriter, r *http.Request) {
 	section := chi.URLParam(r, "section")
 	if section == "definition" {
-		http.Redirect(w, r, connectionSourceAssetSectionHref(chi.URLParam(r, "connection"), chi.URLParam(r, "source"), "details"), http.StatusFound)
+		http.Redirect(w, r, assetnav.ConnectionSourceAssetSectionHref(chi.URLParam(r, "connection"), chi.URLParam(r, "source"), "details"), http.StatusFound)
 		return
 	}
 	if !ui.ValidWorkspaceAssetSection(section) {
@@ -180,13 +194,8 @@ func (s *Server) connectionSourceAssetSection(w http.ResponseWriter, r *http.Req
 		http.Error(w, err.Error(), statusForNotFound(err))
 		return
 	}
-	connection, ok := assetByID(assets, chi.URLParam(r, "connection"))
-	if !ok || connection.Type != "connection" {
-		http.NotFound(w, r)
-		return
-	}
-	source, ok := assetByID(assets, chi.URLParam(r, "source"))
-	if !ok || source.Type != "source" || sourceConnectionID(source.ID, edges) != connection.ID {
+	connection, source, ok := connectionSourcePair(assets, edges, chi.URLParam(r, "connection"), chi.URLParam(r, "source"))
+	if !ok {
 		http.NotFound(w, r)
 		return
 	}
@@ -198,10 +207,22 @@ func (s *Server) connectionSourceAssetSection(w http.ResponseWriter, r *http.Req
 	}
 }
 
+func connectionSourcePair(assets []api.AssetResponse, edges []api.AssetEdgeResponse, connectionID, sourceID string) (api.AssetResponse, api.AssetResponse, bool) {
+	connection, ok := assetByID(assets, connectionID)
+	if !ok || connection.Type != "connection" {
+		return api.AssetResponse{}, api.AssetResponse{}, false
+	}
+	source, ok := assetByID(assets, sourceID)
+	if !ok || source.Type != "source" || assetnav.SourceConnectionID(source.ID, edges) != connection.ID {
+		return api.AssetResponse{}, api.AssetResponse{}, false
+	}
+	return connection, source, true
+}
+
 func (s *Server) connectionAssetSection(w http.ResponseWriter, r *http.Request) {
 	section := chi.URLParam(r, "section")
 	if section == "definition" {
-		http.Redirect(w, r, connectionAssetSectionHref(chi.URLParam(r, "asset"), "details"), http.StatusFound)
+		http.Redirect(w, r, assetnav.ConnectionAssetSectionHref(chi.URLParam(r, "asset"), "details"), http.StatusFound)
 		return
 	}
 	if !ui.ValidWorkspaceAssetSection(section) {
@@ -1007,40 +1028,6 @@ func normalizeConnectionAssetType(typ string) string {
 	default:
 		return ""
 	}
-}
-
-func connectionsHref(query string) string {
-	href := "/connections"
-	if strings.TrimSpace(query) == "" {
-		return href
-	}
-	values := url.Values{}
-	values.Set("q", query)
-	return href + "?" + values.Encode()
-}
-
-func connectionAssetSectionHref(assetID, section string) string {
-	return "/connections/" + assetID + "/" + section
-}
-
-func connectionSourceAssetSectionHref(connectionID, sourceID, section string) string {
-	return "/connections/" + connectionID + "/sources/" + sourceID + "/" + section
-}
-
-func canonicalSourceAssetSectionHref(workspaceID, sourceID, section string, edges []api.AssetEdgeResponse) string {
-	if connectionID := sourceConnectionID(sourceID, edges); connectionID != "" {
-		return connectionSourceAssetSectionHref(connectionID, sourceID, section)
-	}
-	return "/workspaces/" + workspaceID + "/assets/" + sourceID + "/" + section
-}
-
-func sourceConnectionID(sourceID string, edges []api.AssetEdgeResponse) string {
-	for _, edge := range edges {
-		if edge.Type == string(workspace.AssetEdgeUsesConnection) && edge.FromAssetID == sourceID {
-			return edge.ToAssetID
-		}
-	}
-	return ""
 }
 
 func assetByID(assets []api.AssetResponse, id string) (api.AssetResponse, bool) {

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -60,15 +60,16 @@ func (s *Server) workspaceAssets(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) connections(w http.ResponseWriter, r *http.Request) {
 	workspaceID := s.workspaceID("")
-	assets, _, err := s.workspaceAssetsAndEdges(r, workspaceID)
+	assets, edges, err := s.workspaceAssetsAndEdges(r, workspaceID)
 	if err != nil {
 		http.Error(w, err.Error(), statusForNotFound(err))
 		return
 	}
-	filtered := filterAssets(assets, "connection", r.URL.Query().Get("q"))
+	activeType := normalizeConnectionAssetType(r.URL.Query().Get("type"))
+	filtered := filterConnectionAssets(assets, activeType, r.URL.Query().Get("q"))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if err := ui.ConnectionsPage(s.metrics.Catalog(), workspaceID, filtered, r.URL.Query().Get("q"), s.currentRoleLabel(r)).Render(w); err != nil {
+	if err := ui.ConnectionsPage(s.metrics.Catalog(), workspaceID, filtered, edges, activeType, r.URL.Query().Get("q"), s.currentRoleLabel(r)).Render(w); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -76,7 +77,7 @@ func (s *Server) connections(w http.ResponseWriter, r *http.Request) {
 func (s *Server) workspaceAsset(w http.ResponseWriter, r *http.Request) {
 	workspaceID := s.workspaceID(chi.URLParam(r, "workspace"))
 	assetID := chi.URLParam(r, "asset")
-	assets, _, err := s.workspaceAssetsAndEdges(r, workspaceID)
+	assets, edges, err := s.workspaceAssetsAndEdges(r, workspaceID)
 	if err != nil {
 		http.Error(w, err.Error(), statusForNotFound(err))
 		return
@@ -94,6 +95,10 @@ func (s *Server) workspaceAsset(w http.ResponseWriter, r *http.Request) {
 	}
 	if selected.Type == "connection" {
 		http.Redirect(w, r, connectionAssetSectionHref(assetID, "details"), http.StatusFound)
+		return
+	}
+	if selected.Type == "source" {
+		http.Redirect(w, r, canonicalSourceAssetSectionHref(workspaceID, selected.ID, "details", edges), http.StatusFound)
 		return
 	}
 	http.Redirect(w, r, "/workspaces/"+workspaceID+"/assets/"+assetID+"/details", http.StatusFound)
@@ -132,6 +137,10 @@ func (s *Server) workspaceAssetSection(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, connectionAssetSectionHref(assetID, section), http.StatusFound)
 		return
 	}
+	if selected.Type == "source" {
+		http.Redirect(w, r, canonicalSourceAssetSectionHref(workspaceID, selected.ID, section, edges), http.StatusFound)
+		return
+	}
 	if redirectToDetails {
 		http.Redirect(w, r, "/workspaces/"+workspaceID+"/assets/"+assetID+"/details", http.StatusFound)
 		return
@@ -147,6 +156,46 @@ func (s *Server) workspaceAssetSection(w http.ResponseWriter, r *http.Request) {
 func (s *Server) connectionAsset(w http.ResponseWriter, r *http.Request) {
 	assetID := chi.URLParam(r, "asset")
 	http.Redirect(w, r, connectionAssetSectionHref(assetID, "details"), http.StatusFound)
+}
+
+func (s *Server) connectionSourceAsset(w http.ResponseWriter, r *http.Request) {
+	connectionID := chi.URLParam(r, "connection")
+	sourceID := chi.URLParam(r, "source")
+	http.Redirect(w, r, connectionSourceAssetSectionHref(connectionID, sourceID, "details"), http.StatusFound)
+}
+
+func (s *Server) connectionSourceAssetSection(w http.ResponseWriter, r *http.Request) {
+	section := chi.URLParam(r, "section")
+	if section == "definition" {
+		http.Redirect(w, r, connectionSourceAssetSectionHref(chi.URLParam(r, "connection"), chi.URLParam(r, "source"), "details"), http.StatusFound)
+		return
+	}
+	if !ui.ValidWorkspaceAssetSection(section) {
+		http.NotFound(w, r)
+		return
+	}
+	workspaceID := s.workspaceID("")
+	assets, edges, err := s.workspaceAssetsAndEdges(r, workspaceID)
+	if err != nil {
+		http.Error(w, err.Error(), statusForNotFound(err))
+		return
+	}
+	connection, ok := assetByID(assets, chi.URLParam(r, "connection"))
+	if !ok || connection.Type != "connection" {
+		http.NotFound(w, r)
+		return
+	}
+	source, ok := assetByID(assets, chi.URLParam(r, "source"))
+	if !ok || source.Type != "source" || sourceConnectionID(source.ID, edges) != connection.ID {
+		http.NotFound(w, r)
+		return
+	}
+	workspace := s.workspaceResponse(r, workspaceID)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if err := ui.ConnectionSourceAssetPage(s.metrics.Catalog(), workspace, connection, source, assets, edges, section, s.currentRoleLabel(r)).Render(w); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func (s *Server) connectionAssetSection(w http.ResponseWriter, r *http.Request) {
@@ -931,6 +980,35 @@ func filterWorkspaceAssets(assets []api.AssetResponse, typ, query string) []api.
 	return out
 }
 
+func filterConnectionAssets(assets []api.AssetResponse, typ, query string) []api.AssetResponse {
+	typ = normalizeConnectionAssetType(typ)
+	query = strings.ToLower(strings.TrimSpace(query))
+	out := make([]api.AssetResponse, 0, len(assets))
+	for _, asset := range assets {
+		if asset.Type != "connection" && asset.Type != "source" {
+			continue
+		}
+		if typ != "" && asset.Type != typ {
+			continue
+		}
+		haystack := strings.ToLower(asset.Type + " " + asset.Key + " " + asset.Title + " " + asset.Description)
+		if query != "" && !strings.Contains(haystack, query) {
+			continue
+		}
+		out = append(out, asset)
+	}
+	return out
+}
+
+func normalizeConnectionAssetType(typ string) string {
+	switch strings.TrimSpace(typ) {
+	case "connection", "source":
+		return strings.TrimSpace(typ)
+	default:
+		return ""
+	}
+}
+
 func connectionsHref(query string) string {
 	href := "/connections"
 	if strings.TrimSpace(query) == "" {
@@ -943,6 +1021,35 @@ func connectionsHref(query string) string {
 
 func connectionAssetSectionHref(assetID, section string) string {
 	return "/connections/" + assetID + "/" + section
+}
+
+func connectionSourceAssetSectionHref(connectionID, sourceID, section string) string {
+	return "/connections/" + connectionID + "/sources/" + sourceID + "/" + section
+}
+
+func canonicalSourceAssetSectionHref(workspaceID, sourceID, section string, edges []api.AssetEdgeResponse) string {
+	if connectionID := sourceConnectionID(sourceID, edges); connectionID != "" {
+		return connectionSourceAssetSectionHref(connectionID, sourceID, section)
+	}
+	return "/workspaces/" + workspaceID + "/assets/" + sourceID + "/" + section
+}
+
+func sourceConnectionID(sourceID string, edges []api.AssetEdgeResponse) string {
+	for _, edge := range edges {
+		if edge.Type == string(workspace.AssetEdgeUsesConnection) && edge.FromAssetID == sourceID {
+			return edge.ToAssetID
+		}
+	}
+	return ""
+}
+
+func assetByID(assets []api.AssetResponse, id string) (api.AssetResponse, bool) {
+	for _, asset := range assets {
+		if asset.ID == id {
+			return asset, true
+		}
+	}
+	return api.AssetResponse{}, false
 }
 
 func isWorkspaceLandingAsset(typ string) bool {

--- a/internal/assetnav/hrefs.go
+++ b/internal/assetnav/hrefs.go
@@ -1,0 +1,66 @@
+package assetnav
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/Yacobolo/libredash/internal/api"
+	"github.com/Yacobolo/libredash/internal/workspace"
+)
+
+func ConnectionsHref(query string) string {
+	return ConnectionsHrefWithType("", query)
+}
+
+func ConnectionsHrefWithType(typ, query string) string {
+	params := []string{}
+	if typ = strings.TrimSpace(typ); typ != "" {
+		params = append(params, "type="+url.QueryEscape(typ))
+	}
+	if query = strings.TrimSpace(query); query != "" {
+		params = append(params, "q="+url.QueryEscape(query))
+	}
+	if len(params) == 0 {
+		return "/connections"
+	}
+	return "/connections?" + strings.Join(params, "&")
+}
+
+func WorkspaceAssetSectionHref(workspaceID, assetID, section string) string {
+	return "/workspaces/" + workspaceID + "/assets/" + assetID + "/" + section
+}
+
+func ConnectionAssetSectionHref(assetID, section string) string {
+	return "/connections/" + assetID + "/" + section
+}
+
+func ConnectionSourceAssetSectionHref(connectionID, sourceID, section string) string {
+	return "/connections/" + connectionID + "/sources/" + sourceID + "/" + section
+}
+
+func CanonicalAssetSectionHref(workspaceID string, asset api.AssetResponse, section string, edges []api.AssetEdgeResponse) string {
+	switch asset.Type {
+	case "connection":
+		return ConnectionAssetSectionHref(asset.ID, section)
+	case "source":
+		return CanonicalSourceAssetSectionHref(workspaceID, asset.ID, section, edges)
+	default:
+		return WorkspaceAssetSectionHref(workspaceID, asset.ID, section)
+	}
+}
+
+func CanonicalSourceAssetSectionHref(workspaceID, sourceID, section string, edges []api.AssetEdgeResponse) string {
+	if connectionID := SourceConnectionID(sourceID, edges); connectionID != "" {
+		return ConnectionSourceAssetSectionHref(connectionID, sourceID, section)
+	}
+	return WorkspaceAssetSectionHref(workspaceID, sourceID, section)
+}
+
+func SourceConnectionID(sourceID string, edges []api.AssetEdgeResponse) string {
+	for _, edge := range edges {
+		if edge.Type == string(workspace.AssetEdgeUsesConnection) && edge.FromAssetID == sourceID {
+			return edge.ToAssetID
+		}
+	}
+	return ""
+}

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -528,7 +528,7 @@ func assetRow(workspaceID string, asset api.AssetResponse, assetIndex map[string
 		),
 		assetCell("w-40 text-body-sm font-medium text-fg-muted", h.Span(g.Text(assetTypeLabel(asset.Type)))),
 		assetCell("w-56 max-md:hidden", h.Code(h.Class("block truncate text-caption font-medium text-fg-muted"), g.Text(asset.Key))),
-		assetCell("w-48 max-lg:hidden", assetParentTableLink(workspaceID, asset, assetIndex)),
+		assetCell("w-48 max-lg:hidden", assetParentTableLink(workspaceID, asset, assetIndex, edges)),
 		assetCell("w-24",
 			h.Div(h.Class("inline-flex w-full justify-end gap-2"),
 				h.A(h.Class(metricActionButtonClass), h.Href(detailHref), h.Title("View details"), h.Aria("label", "View details"), lucide.FileText(metricActionIconAttrs()...)),
@@ -538,7 +538,16 @@ func assetRow(workspaceID string, asset api.AssetResponse, assetIndex map[string
 	)
 }
 
-func assetParentTableLink(workspaceID string, asset api.AssetResponse, assetIndex map[string]api.AssetResponse) g.Node {
+func assetParentTableLink(workspaceID string, asset api.AssetResponse, assetIndex map[string]api.AssetResponse, edges []api.AssetEdgeResponse) g.Node {
+	if asset.Type == "source" {
+		if connection, ok := assetIndex[assetnav.SourceConnectionID(asset.ID, edges)]; ok && connection.Type == "connection" {
+			return h.A(
+				h.Class("block truncate text-body-sm font-medium text-fg-accent no-underline hover:underline"),
+				h.Href(assetnav.ConnectionAssetSectionHref(connection.ID, "details")),
+				g.Text(assetTitle(connection)),
+			)
+		}
+	}
 	parent, ok := assetIndex[asset.ParentID]
 	if !ok {
 		return h.Span(h.Class("text-caption font-medium text-fg-muted"), g.Text(emptyDash("")))

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Yacobolo/libredash/internal/api"
+	"github.com/Yacobolo/libredash/internal/assetnav"
 	"github.com/Yacobolo/libredash/internal/dashboard"
 	lucide "github.com/eduardolat/gomponents-lucide"
 	g "maragu.dev/gomponents"
@@ -230,7 +231,7 @@ func connectionSourceBreadcrumbHeader(connection, source api.AssetResponse) g.No
 			h.Ol(h.Class("flex min-w-0 flex-wrap items-center gap-1.5 text-body-sm font-medium leading-snug"),
 				breadcrumbLink("Connections", "/connections"),
 				breadcrumbSeparator(),
-				breadcrumbLink(assetTitle(connection), connectionAssetSectionHref(connection.ID, "details")),
+				breadcrumbLink(assetTitle(connection), assetnav.ConnectionAssetSectionHref(connection.ID, "details")),
 				breadcrumbSeparator(),
 				breadcrumbLink("Sources", "/connections?type=source"),
 				breadcrumbSeparator(),
@@ -510,7 +511,7 @@ func assetCell(className string, children ...g.Node) g.Node {
 }
 
 func assetRow(workspaceID string, asset api.AssetResponse, assetIndex map[string]api.AssetResponse, edges []api.AssetEdgeResponse) g.Node {
-	detailHref := assetCanonicalSectionHref(workspaceID, asset, "details", edges)
+	detailHref := assetnav.CanonicalAssetSectionHref(workspaceID, asset, "details", edges)
 	openHref := detailHref
 	if asset.Href != "" {
 		openHref = asset.Href
@@ -544,7 +545,7 @@ func assetParentTableLink(workspaceID string, asset api.AssetResponse, assetInde
 	}
 	return h.A(
 		h.Class("block truncate text-body-sm font-medium text-fg-accent no-underline hover:underline"),
-		h.Href(workspaceAssetSectionHref(workspaceID, parent.ID, "details")),
+		h.Href(assetnav.WorkspaceAssetSectionHref(workspaceID, parent.ID, "details")),
 		g.Text(assetTitle(parent)),
 	)
 }
@@ -570,22 +571,22 @@ func connectionSourceAssetActions() g.Node {
 
 func assetDetailTabs(workspaceID, assetID, activeSection string, relatedCount int) g.Node {
 	return h.Nav(h.Class("flex min-w-0 gap-6 border-b border-outline-variant bg-app px-3"), h.Aria("label", "Workspace asset sections"),
-		assetDetailTabLink(workspaceAssetSectionHref(workspaceID, assetID, "details"), activeSection == "details", "Details", nil),
-		assetDetailTabLink(workspaceAssetSectionHref(workspaceID, assetID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
+		assetDetailTabLink(assetnav.WorkspaceAssetSectionHref(workspaceID, assetID, "details"), activeSection == "details", "Details", nil),
+		assetDetailTabLink(assetnav.WorkspaceAssetSectionHref(workspaceID, assetID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
 	)
 }
 
 func connectionAssetDetailTabs(assetID, activeSection string, relatedCount int) g.Node {
 	return h.Nav(h.Class("flex min-w-0 gap-6 border-b border-outline-variant bg-app px-3"), h.Aria("label", "Connection asset sections"),
-		assetDetailTabLink(connectionAssetSectionHref(assetID, "details"), activeSection == "details", "Details", nil),
-		assetDetailTabLink(connectionAssetSectionHref(assetID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
+		assetDetailTabLink(assetnav.ConnectionAssetSectionHref(assetID, "details"), activeSection == "details", "Details", nil),
+		assetDetailTabLink(assetnav.ConnectionAssetSectionHref(assetID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
 	)
 }
 
 func connectionSourceAssetDetailTabs(connectionID, sourceID, activeSection string, relatedCount int) g.Node {
 	return h.Nav(h.Class("flex min-w-0 gap-6 border-b border-outline-variant bg-app px-3"), h.Aria("label", "Connection source sections"),
-		assetDetailTabLink(connectionSourceAssetSectionHref(connectionID, sourceID, "details"), activeSection == "details", "Details", nil),
-		assetDetailTabLink(connectionSourceAssetSectionHref(connectionID, sourceID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
+		assetDetailTabLink(assetnav.ConnectionSourceAssetSectionHref(connectionID, sourceID, "details"), activeSection == "details", "Details", nil),
+		assetDetailTabLink(assetnav.ConnectionSourceAssetSectionHref(connectionID, sourceID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
 	)
 }
 
@@ -1338,40 +1339,7 @@ func absInt(value int) int {
 }
 
 func lineageAssetHref(workspaceID string, asset api.AssetResponse, edges []api.AssetEdgeResponse) string {
-	return assetCanonicalSectionHref(workspaceID, asset, "details", edges)
-}
-
-func workspaceAssetSectionHref(workspaceID, assetID, section string) string {
-	return "/workspaces/" + workspaceID + "/assets/" + assetID + "/" + section
-}
-
-func connectionAssetSectionHref(assetID, section string) string {
-	return "/connections/" + assetID + "/" + section
-}
-
-func connectionSourceAssetSectionHref(connectionID, sourceID, section string) string {
-	return "/connections/" + connectionID + "/sources/" + sourceID + "/" + section
-}
-
-func assetCanonicalSectionHref(workspaceID string, asset api.AssetResponse, section string, edges []api.AssetEdgeResponse) string {
-	if asset.Type == "connection" {
-		return connectionAssetSectionHref(asset.ID, section)
-	}
-	if asset.Type == "source" {
-		if connectionID := sourceConnectionID(asset.ID, edges); connectionID != "" {
-			return connectionSourceAssetSectionHref(connectionID, asset.ID, section)
-		}
-	}
-	return workspaceAssetSectionHref(workspaceID, asset.ID, section)
-}
-
-func sourceConnectionID(sourceID string, edges []api.AssetEdgeResponse) string {
-	for _, edge := range edges {
-		if edge.Type == "uses_connection" && edge.FromAssetID == sourceID {
-			return edge.ToAssetID
-		}
-	}
-	return ""
+	return assetnav.CanonicalAssetSectionHref(workspaceID, asset, "details", edges)
 }
 
 type assetDetailModel struct {
@@ -1885,7 +1853,7 @@ func dashboardPagesGrid(parent api.AssetResponse, pages []api.AssetResponse) met
 		key := assetChildName(parent, page)
 		rows = append(rows, map[string]any{
 			"page":        assetTitle(page),
-			"pageHref":    workspaceAssetSectionHref(parent.WorkspaceID, page.ID, "details"),
+			"pageHref":    assetnav.WorkspaceAssetSectionHref(parent.WorkspaceID, page.ID, "details"),
 			"key":         key,
 			"description": emptyDash(page.Description),
 			"runtime":     "Open",
@@ -1911,7 +1879,7 @@ func dashboardFiltersGrid(parent api.AssetResponse, filters []api.AssetResponse)
 	for _, filter := range filters {
 		rows = append(rows, map[string]any{
 			"filter":     assetTitle(filter),
-			"filterHref": workspaceAssetSectionHref(parent.WorkspaceID, filter.ID, "details"),
+			"filterHref": assetnav.WorkspaceAssetSectionHref(parent.WorkspaceID, filter.ID, "details"),
 			"key":        assetChildName(parent, filter),
 			"field":      emptyDash(metaString(filter.Meta, "Dimension", "dimension", "Field", "field")),
 			"type":       emptyDash(metaString(filter.Meta, "Type", "type", "Kind", "kind")),
@@ -1937,7 +1905,7 @@ func dashboardVisualsGrid(parent api.AssetResponse, visuals []api.AssetResponse)
 		query := metaMap(visual.Meta, "Query", "query")
 		rows = append(rows, map[string]any{
 			"visual":     assetTitle(visual),
-			"visualHref": workspaceAssetSectionHref(parent.WorkspaceID, visual.ID, "details"),
+			"visualHref": assetnav.WorkspaceAssetSectionHref(parent.WorkspaceID, visual.ID, "details"),
 			"key":        assetChildName(parent, visual),
 			"type":       emptyDash(firstNonEmpty(metaString(visual.Meta, "Shape", "shape"), metaString(visual.Meta, "Type", "type"), metaString(visual.Meta, "Kind", "kind"))),
 			"measures":   emptyDash(strings.Join(stringSlice(metaValue(query, "Measures", "measures")), ", ")),
@@ -1964,7 +1932,7 @@ func dashboardTablesGrid(parent api.AssetResponse, tables []api.AssetResponse) m
 	for _, table := range tables {
 		rows = append(rows, map[string]any{
 			"table":     assetTitle(table),
-			"tableHref": workspaceAssetSectionHref(parent.WorkspaceID, table.ID, "details"),
+			"tableHref": assetnav.WorkspaceAssetSectionHref(parent.WorkspaceID, table.ID, "details"),
 			"key":       assetChildName(parent, table),
 			"baseTable": emptyDash(metaString(metaMap(table.Meta, "Query", "query"), "Table", "table")),
 			"rows":      emptyDash(strings.Join(stringSlice(metaValue(table.Meta, "Rows", "rows")), ", ")),
@@ -2151,7 +2119,7 @@ func childAssetGrid(workspaceID string, assets []api.AssetResponse, edges []api.
 	for _, asset := range assets {
 		rows = append(rows, map[string]any{
 			"name":        assetTitle(asset),
-			"nameHref":    assetCanonicalSectionHref(workspaceID, asset, "details", edges),
+			"nameHref":    assetnav.CanonicalAssetSectionHref(workspaceID, asset, "details", edges),
 			"key":         asset.Key,
 			"type":        assetTypeLabel(asset.Type),
 			"description": emptyDash(asset.Description),
@@ -2191,7 +2159,7 @@ func childDependencyGrid(workspaceID, assetID string, assets []api.AssetResponse
 			"direction": direction,
 			"relation":  labelFromKey(edge.Type),
 			"asset":     assetTitle(peer),
-			"assetHref": assetCanonicalSectionHref(workspaceID, peer, "details", edges),
+			"assetHref": assetnav.CanonicalAssetSectionHref(workspaceID, peer, "details", edges),
 			"type":      assetTypeLabel(peer.Type),
 		})
 	}
@@ -2476,7 +2444,7 @@ func childHref(workspaceID string, asset api.AssetResponse) string {
 	if asset.ID == "" {
 		return ""
 	}
-	return assetCanonicalSectionHref(workspaceID, asset, "details", nil)
+	return assetnav.CanonicalAssetSectionHref(workspaceID, asset, "details", nil)
 }
 
 func assetsByID(assets []api.AssetResponse) map[string]api.AssetResponse {

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -49,21 +49,21 @@ func WorkspacePage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, a
 			assetToolbar(workspace.ID, activeType, query, assets),
 			h.Div(h.Class(workspacePanelClass),
 				g.If(len(assets) == 0, h.Div(h.Class("p-3"), emptyState("No assets match this view."))),
-				g.If(len(assets) > 0, assetTable(workspace.ID, assets)),
+				g.If(len(assets) > 0, assetTable(workspace.ID, assets, nil)),
 			),
 		),
 		extraHead...,
 	)
 }
 
-func ConnectionsPage(catalog dashboard.Catalog, workspaceID string, assets []api.AssetResponse, query, roleLabel string) g.Node {
+func ConnectionsPage(catalog dashboard.Catalog, workspaceID string, assets []api.AssetResponse, edges []api.AssetEdgeResponse, activeType, query, roleLabel string) g.Node {
 	return workspaceDocument("Connections", catalog, "connections", roleLabel, nil,
-		h.Section(h.Class(workspaceMainClass), h.Aria("label", "Global connections"),
-			workspaceHeader("Global", "Connections", "Read-only connection assets used by published semantic models.", nil),
-			connectionToolbar(query),
+		h.Section(h.Class(workspaceMainClass), h.Aria("label", "Connections and sources"),
+			workspaceHeader("Data access", "Connections", "Connection-scoped data assets used by published semantic models.", nil),
+			connectionToolbar(activeType, query),
 			h.Div(h.Class(workspacePanelClass),
-				g.If(len(assets) == 0, h.Div(h.Class("p-3"), emptyState("No connections match this view."))),
-				g.If(len(assets) > 0, assetTable(workspaceID, assets)),
+				g.If(len(assets) == 0, h.Div(h.Class("p-3"), emptyState("No connection assets match this view."))),
+				g.If(len(assets) > 0, assetTable(workspaceID, assets, edges)),
 			),
 		),
 	)
@@ -167,6 +167,35 @@ func ConnectionAssetPage(catalog dashboard.Catalog, workspace api.WorkspaceRespo
 	)
 }
 
+func ConnectionSourceAssetPage(catalog dashboard.Catalog, workspace api.WorkspaceResponse, connection api.AssetResponse, source api.AssetResponse, assets []api.AssetResponse, edges []api.AssetEdgeResponse, activeSection, roleLabel string) g.Node {
+	activeSection = normalizeWorkspaceAssetSection(activeSection)
+	lineage := assetLineage(workspace.ID, source, assets, edges)
+	extraHead := []g.Node{
+		h.Script(h.Type("module"), h.Src(staticAsset("/static/data-grid.js"))),
+	}
+	if activeSection == "lineage" {
+		extraHead = append(extraHead,
+			h.Link(h.Rel("stylesheet"), h.Href(staticAsset("/static/asset-lineage-graph.css"))),
+			h.Script(h.Type("module"), h.Src(staticAsset("/static/asset-lineage-graph.js"))),
+		)
+	}
+	return workspaceDocument(source.Title, catalog, "connections", roleLabel, workspaceAssetSignals(workspace, source, assets, edges, lineage, activeSection),
+		h.Section(h.Class(metricMainClass), h.Aria("label", "Connection source detail"),
+			connectionSourceBreadcrumbHeader(connection, source),
+			h.Div(h.Class(metricContentColumnClass),
+				connectionSourceAssetDetailTabs(connection.ID, source.ID, activeSection, lineage.Count),
+				h.Div(h.Class(assetDetailBodyClass(activeSection)),
+					g.If(activeSection == "details",
+						assetDetailsSection(workspace, source, assets, edges),
+					),
+					g.If(activeSection == "lineage", assetLineageSection(lineage)),
+				),
+			),
+		),
+		extraHead...,
+	)
+}
+
 func assetBreadcrumbHeader(workspace api.WorkspaceResponse, asset api.AssetResponse) g.Node {
 	return h.Header(h.Class("grid min-w-0 grid-cols-workspace-header items-center gap-2 border-b border-outline-muted px-4 py-2.5"),
 		h.Nav(h.Class("min-w-0"), h.Aria("label", "Breadcrumb"),
@@ -192,6 +221,23 @@ func connectionBreadcrumbHeader(asset api.AssetResponse) g.Node {
 			),
 		),
 		h.Div(h.Class("inline-flex min-w-0 items-center justify-end gap-2"), connectionAssetActions()),
+	)
+}
+
+func connectionSourceBreadcrumbHeader(connection, source api.AssetResponse) g.Node {
+	return h.Header(h.Class("grid min-w-0 grid-cols-workspace-header items-center gap-2 border-b border-outline-muted px-4 py-2.5"),
+		h.Nav(h.Class("min-w-0"), h.Aria("label", "Breadcrumb"),
+			h.Ol(h.Class("flex min-w-0 flex-wrap items-center gap-1.5 text-body-sm font-medium leading-snug"),
+				breadcrumbLink("Connections", "/connections"),
+				breadcrumbSeparator(),
+				breadcrumbLink(assetTitle(connection), connectionAssetSectionHref(connection.ID, "details")),
+				breadcrumbSeparator(),
+				breadcrumbLink("Sources", "/connections?type=source"),
+				breadcrumbSeparator(),
+				assetBreadcrumbCurrent(source),
+			),
+		),
+		h.Div(h.Class("inline-flex min-w-0 items-center justify-end gap-2"), connectionSourceAssetActions()),
 	)
 }
 
@@ -332,13 +378,49 @@ func assetToolbar(workspaceID, activeType, query string, assets []api.AssetRespo
 	)
 }
 
-func connectionToolbar(query string) g.Node {
+func connectionToolbar(activeType, query string) g.Node {
+	types := []string{"", "connection", "source"}
 	return h.Div(h.Class("grid min-w-0 gap-3 border-b border-outline-variant bg-app px-3 pt-3"), g.Attr("data-connection-toolbar", ""),
 		h.Form(h.Method("get"), h.Action("/connections"), h.Class("flex min-w-0 max-w-workspace-search items-center gap-2"),
-			h.Input(h.Type("search"), h.Name("q"), h.Value(query), h.Placeholder("Search connections..."), h.Class("min-h-control-md w-full rounded-small border border-outline-variant bg-control px-3 text-body-sm font-medium text-fg-default placeholder:text-fg-muted")),
+			h.Input(h.Type("search"), h.Name("q"), h.Value(query), h.Placeholder("Search connections and sources..."), h.Class("min-h-control-md w-full rounded-small border border-outline-variant bg-control px-3 text-body-sm font-medium text-fg-default placeholder:text-fg-muted")),
+			g.If(activeType != "", h.Input(h.Type("hidden"), h.Name("type"), h.Value(activeType))),
 			h.Button(h.Type("submit"), h.Class(metricActionButtonClass), h.Title("Search"), h.Aria("label", "Search"), lucide.Search(metricActionIconAttrs()...)),
 		),
+		h.Nav(h.Class("flex min-w-0 flex-wrap gap-x-6"), h.Aria("label", "Connection asset type filters"),
+			g.Map(types, func(typ string) g.Node {
+				label := "All"
+				if typ != "" {
+					label = assetTypeLabel(typ)
+				}
+				return connectionTabLink(typ, activeType, query, label)
+			}),
+		),
 	)
+}
+
+func connectionTabLink(typ, activeType, query, label string) g.Node {
+	className := "relative -mb-px inline-flex min-h-control-xl items-center whitespace-nowrap border-b-2 px-1 text-body-sm font-medium no-underline transition-colors duration-micro ease-hover"
+	if typ == activeType {
+		className += " border-fg-accent font-semibold text-fg-default"
+	} else {
+		className += " border-transparent text-fg-muted hover:border-outline-muted hover:text-fg-default"
+	}
+	return h.A(h.Class(className), h.Href(connectionAssetListHref(typ, query)), g.If(typ == activeType, h.Aria("current", "page")), g.Text(label))
+}
+
+func connectionAssetListHref(typ, query string) string {
+	href := "/connections"
+	values := url.Values{}
+	if typ != "" {
+		values.Set("type", typ)
+	}
+	if strings.TrimSpace(query) != "" {
+		values.Set("q", query)
+	}
+	if encoded := values.Encode(); encoded != "" {
+		href += "?" + encoded
+	}
+	return href
 }
 
 func hasAssetType(assets []api.AssetResponse, typ string) bool {
@@ -391,7 +473,7 @@ func normalizeWorkspaceAssetSection(section string) string {
 	return "details"
 }
 
-func assetTable(workspaceID string, assets []api.AssetResponse) g.Node {
+func assetTable(workspaceID string, assets []api.AssetResponse, edges []api.AssetEdgeResponse) g.Node {
 	assetIndex := map[string]api.AssetResponse{}
 	for _, asset := range assets {
 		assetIndex[asset.ID] = asset
@@ -409,7 +491,7 @@ func assetTable(workspaceID string, assets []api.AssetResponse) g.Node {
 			),
 			h.TBody(
 				g.Map(assets, func(asset api.AssetResponse) g.Node {
-					return assetRow(workspaceID, asset, assetIndex)
+					return assetRow(workspaceID, asset, assetIndex, edges)
 				}),
 			),
 		),
@@ -427,8 +509,8 @@ func assetCell(className string, children ...g.Node) g.Node {
 	return h.Td(nodes...)
 }
 
-func assetRow(workspaceID string, asset api.AssetResponse, assetIndex map[string]api.AssetResponse) g.Node {
-	detailHref := assetCanonicalSectionHref(workspaceID, asset, "details")
+func assetRow(workspaceID string, asset api.AssetResponse, assetIndex map[string]api.AssetResponse, edges []api.AssetEdgeResponse) g.Node {
+	detailHref := assetCanonicalSectionHref(workspaceID, asset, "details", edges)
 	openHref := detailHref
 	if asset.Href != "" {
 		openHref = asset.Href
@@ -480,6 +562,12 @@ func connectionAssetActions() g.Node {
 	)
 }
 
+func connectionSourceAssetActions() g.Node {
+	return h.Div(h.Class("inline-flex min-w-0 items-center justify-end gap-2"),
+		h.A(h.Class(metricActionButtonClass), h.Href("/connections?type=source"), h.Title("Back to sources"), h.Aria("label", "Back to sources"), lucide.ArrowLeft(metricActionIconAttrs()...)),
+	)
+}
+
 func assetDetailTabs(workspaceID, assetID, activeSection string, relatedCount int) g.Node {
 	return h.Nav(h.Class("flex min-w-0 gap-6 border-b border-outline-variant bg-app px-3"), h.Aria("label", "Workspace asset sections"),
 		assetDetailTabLink(workspaceAssetSectionHref(workspaceID, assetID, "details"), activeSection == "details", "Details", nil),
@@ -491,6 +579,13 @@ func connectionAssetDetailTabs(assetID, activeSection string, relatedCount int) 
 	return h.Nav(h.Class("flex min-w-0 gap-6 border-b border-outline-variant bg-app px-3"), h.Aria("label", "Connection asset sections"),
 		assetDetailTabLink(connectionAssetSectionHref(assetID, "details"), activeSection == "details", "Details", nil),
 		assetDetailTabLink(connectionAssetSectionHref(assetID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
+	)
+}
+
+func connectionSourceAssetDetailTabs(connectionID, sourceID, activeSection string, relatedCount int) g.Node {
+	return h.Nav(h.Class("flex min-w-0 gap-6 border-b border-outline-variant bg-app px-3"), h.Aria("label", "Connection source sections"),
+		assetDetailTabLink(connectionSourceAssetSectionHref(connectionID, sourceID, "details"), activeSection == "details", "Details", nil),
+		assetDetailTabLink(connectionSourceAssetSectionHref(connectionID, sourceID, "lineage"), activeSection == "lineage", "Lineage", metricTabCount(relatedCount)),
 	)
 }
 
@@ -589,7 +684,7 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 	outgoing := edgesByFromAsset(edges)
 	incoming := edgesByToAsset(edges)
 	graph := assetLineageGraph{
-		Nodes: []assetLineageNode{lineageNode(workspaceID, selected, 0, true)},
+		Nodes: []assetLineageNode{lineageNode(workspaceID, selected, 0, true, edges)},
 	}
 	nodeIndex := map[string]int{selected.ID: 0}
 	seenEdges := map[string]struct{}{}
@@ -611,7 +706,7 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 			return
 		}
 		nodeIndex[asset.ID] = len(graph.Nodes)
-		graph.Nodes = append(graph.Nodes, lineageNode(workspaceID, asset, rank, selected))
+		graph.Nodes = append(graph.Nodes, lineageNode(workspaceID, asset, rank, selected, edges))
 	}
 	addEdge := func(edge api.AssetEdgeResponse) {
 		if edge.FromAssetID == "" || edge.ToAssetID == "" {
@@ -700,9 +795,9 @@ func assetLineage(workspaceID string, selected api.AssetResponse, assets []api.A
 
 	sortLineageNodes(graph.Nodes)
 	sortLineageGraphEdges(graph.Edges)
-	collapsedGraph := collapsedAssetLineageGraph(workspaceID, selected, graph, byID)
+	collapsedGraph := collapsedAssetLineageGraph(workspaceID, selected, graph, byID, edges)
 	enrichAssetLineageGraph(collapsedGraph, byID, edges)
-	usesRows, usedByRows := lineageTablesFromGraph(workspaceID, selected, collapsedGraph, byID)
+	usesRows, usedByRows := lineageTablesFromGraph(workspaceID, selected, collapsedGraph, byID, edges)
 	return assetLineageModel{
 		Count:  len(usesRows) + len(usedByRows),
 		Graph:  collapsedGraph,
@@ -788,7 +883,7 @@ func pluralAssetTypeLabel(typ string, count int) string {
 	return label + "s"
 }
 
-func collapsedAssetLineageGraph(workspaceID string, selected api.AssetResponse, graph assetLineageGraph, assets map[string]api.AssetResponse) assetLineageGraph {
+func collapsedAssetLineageGraph(workspaceID string, selected api.AssetResponse, graph assetLineageGraph, assets map[string]api.AssetResponse, edges []api.AssetEdgeResponse) assetLineageGraph {
 	if selected.Type == "catalog" {
 		return graph
 	}
@@ -804,7 +899,7 @@ func collapsedAssetLineageGraph(workspaceID string, selected api.AssetResponse, 
 		}
 		selectedNode := selectedAnchorOK && asset.ID == selectedAnchor.ID
 		nodeIndex[asset.ID] = len(out.Nodes)
-		out.Nodes = append(out.Nodes, lineageNode(workspaceID, asset, lineageVisualLayer(asset.Type), selectedNode))
+		out.Nodes = append(out.Nodes, lineageNode(workspaceID, asset, lineageVisualLayer(asset.Type), selectedNode, edges))
 	}
 
 	type collapsedEdge struct {
@@ -895,7 +990,7 @@ func sortLineageRows(rows []map[string]any) {
 	})
 }
 
-func lineageTablesFromGraph(workspaceID string, selected api.AssetResponse, graph assetLineageGraph, assets map[string]api.AssetResponse) ([]map[string]any, []map[string]any) {
+func lineageTablesFromGraph(workspaceID string, selected api.AssetResponse, graph assetLineageGraph, assets map[string]api.AssetResponse, edges []api.AssetEdgeResponse) ([]map[string]any, []map[string]any) {
 	anchorID := selected.ID
 	if selected.Type != "catalog" {
 		if anchor, ok := lineageVisibleAnchor(selected, assets); ok {
@@ -918,24 +1013,24 @@ func lineageTablesFromGraph(workspaceID string, selected api.AssetResponse, grap
 			}
 			if edge.Target == anchorID {
 				if peer, ok := assets[edge.Source]; ok {
-					usesRows = append(usesRows, lineageGraphTableRow(workspaceID, edge, peer))
+					usesRows = append(usesRows, lineageGraphTableRow(workspaceID, edge, peer, edges))
 				}
 			}
 			if edge.Source == anchorID {
 				if peer, ok := assets[edge.Target]; ok {
-					usedByRows = append(usedByRows, lineageGraphTableRow(workspaceID, edge, peer))
+					usedByRows = append(usedByRows, lineageGraphTableRow(workspaceID, edge, peer, edges))
 				}
 			}
 			continue
 		}
 		if edge.Source == anchorID {
 			if peer, ok := assets[edge.Target]; ok {
-				usesRows = append(usesRows, lineageGraphTableRow(workspaceID, edge, peer))
+				usesRows = append(usesRows, lineageGraphTableRow(workspaceID, edge, peer, edges))
 			}
 		}
 		if edge.Target == anchorID {
 			if peer, ok := assets[edge.Source]; ok {
-				usedByRows = append(usedByRows, lineageGraphTableRow(workspaceID, edge, peer))
+				usedByRows = append(usedByRows, lineageGraphTableRow(workspaceID, edge, peer, edges))
 			}
 		}
 	}
@@ -944,11 +1039,11 @@ func lineageTablesFromGraph(workspaceID string, selected api.AssetResponse, grap
 	return usesRows, usedByRows
 }
 
-func lineageGraphTableRow(workspaceID string, edge assetLineageEdge, peer api.AssetResponse) map[string]any {
+func lineageGraphTableRow(workspaceID string, edge assetLineageEdge, peer api.AssetResponse, edges []api.AssetEdgeResponse) map[string]any {
 	return map[string]any{
 		"relation":  firstNonEmpty(edge.Label, labelFromKey(edge.Kind)),
 		"asset":     assetTitle(peer),
-		"assetHref": lineageAssetHref(workspaceID, peer),
+		"assetHref": lineageAssetHref(workspaceID, peer, edges),
 		"type":      assetTypeLabel(peer.Type),
 		"key":       peer.Key,
 	}
@@ -968,13 +1063,13 @@ func lineageTable(rows []map[string]any, empty string) metricGrid {
 	}
 }
 
-func lineageNode(workspaceID string, asset api.AssetResponse, rank int, selected bool) assetLineageNode {
+func lineageNode(workspaceID string, asset api.AssetResponse, rank int, selected bool, edges []api.AssetEdgeResponse) assetLineageNode {
 	return assetLineageNode{
 		ID:       asset.ID,
 		Label:    assetTitle(asset),
 		Kind:     asset.Type,
 		Meta:     asset.Key,
-		Href:     lineageAssetHref(workspaceID, asset),
+		Href:     lineageAssetHref(workspaceID, asset, edges),
 		Side:     lineageSideForRank(rank),
 		Rank:     rank,
 		Selected: selected,
@@ -1242,8 +1337,8 @@ func absInt(value int) int {
 	return value
 }
 
-func lineageAssetHref(workspaceID string, asset api.AssetResponse) string {
-	return assetCanonicalSectionHref(workspaceID, asset, "details")
+func lineageAssetHref(workspaceID string, asset api.AssetResponse, edges []api.AssetEdgeResponse) string {
+	return assetCanonicalSectionHref(workspaceID, asset, "details", edges)
 }
 
 func workspaceAssetSectionHref(workspaceID, assetID, section string) string {
@@ -1254,11 +1349,29 @@ func connectionAssetSectionHref(assetID, section string) string {
 	return "/connections/" + assetID + "/" + section
 }
 
-func assetCanonicalSectionHref(workspaceID string, asset api.AssetResponse, section string) string {
+func connectionSourceAssetSectionHref(connectionID, sourceID, section string) string {
+	return "/connections/" + connectionID + "/sources/" + sourceID + "/" + section
+}
+
+func assetCanonicalSectionHref(workspaceID string, asset api.AssetResponse, section string, edges []api.AssetEdgeResponse) string {
 	if asset.Type == "connection" {
 		return connectionAssetSectionHref(asset.ID, section)
 	}
+	if asset.Type == "source" {
+		if connectionID := sourceConnectionID(asset.ID, edges); connectionID != "" {
+			return connectionSourceAssetSectionHref(connectionID, asset.ID, section)
+		}
+	}
 	return workspaceAssetSectionHref(workspaceID, asset.ID, section)
+}
+
+func sourceConnectionID(sourceID string, edges []api.AssetEdgeResponse) string {
+	for _, edge := range edges {
+		if edge.Type == "uses_connection" && edge.FromAssetID == sourceID {
+			return edge.ToAssetID
+		}
+	}
+	return ""
 }
 
 type assetDetailModel struct {
@@ -1880,7 +1993,7 @@ func connectionDetailModel(model *assetDetailModel, workspace api.WorkspaceRespo
 		assetDetailSection{
 			Title:  fmt.Sprintf("Sources (%d)", len(sources)),
 			Signal: "assetDetailsConnectionSourcesGrid",
-			Grid:   childAssetGrid(workspace.ID, sources, "No sources use this connection."),
+			Grid:   childAssetGrid(workspace.ID, sources, edges, "No sources use this connection."),
 		},
 	)
 }
@@ -2030,7 +2143,7 @@ func definitionSignalGrid(title, signal string) g.Node {
 	)
 }
 
-func childAssetGrid(workspaceID string, assets []api.AssetResponse, empty string) metricGrid {
+func childAssetGrid(workspaceID string, assets []api.AssetResponse, edges []api.AssetEdgeResponse, empty string) metricGrid {
 	sort.Slice(assets, func(i, j int) bool {
 		return assetTitle(assets[i]) < assetTitle(assets[j])
 	})
@@ -2038,7 +2151,7 @@ func childAssetGrid(workspaceID string, assets []api.AssetResponse, empty string
 	for _, asset := range assets {
 		rows = append(rows, map[string]any{
 			"name":        assetTitle(asset),
-			"nameHref":    assetCanonicalSectionHref(workspaceID, asset, "details"),
+			"nameHref":    assetCanonicalSectionHref(workspaceID, asset, "details", edges),
 			"key":         asset.Key,
 			"type":        assetTypeLabel(asset.Type),
 			"description": emptyDash(asset.Description),
@@ -2078,7 +2191,7 @@ func childDependencyGrid(workspaceID, assetID string, assets []api.AssetResponse
 			"direction": direction,
 			"relation":  labelFromKey(edge.Type),
 			"asset":     assetTitle(peer),
-			"assetHref": assetCanonicalSectionHref(workspaceID, peer, "details"),
+			"assetHref": assetCanonicalSectionHref(workspaceID, peer, "details", edges),
 			"type":      assetTypeLabel(peer.Type),
 		})
 	}
@@ -2363,7 +2476,7 @@ func childHref(workspaceID string, asset api.AssetResponse) string {
 	if asset.ID == "" {
 		return ""
 	}
-	return assetCanonicalSectionHref(workspaceID, asset, "details")
+	return assetCanonicalSectionHref(workspaceID, asset, "details", nil)
 }
 
 func assetsByID(assets []api.AssetResponse) map[string]api.AssetResponse {

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -607,6 +607,7 @@ func TestConnectionsPageUsesConnectionAssetTabs(t *testing.T) {
 		`href="/connections?type=connection"`,
 		`href="/connections?type=source" aria-current="page"`,
 		`href="/connections/connection/sources/source/details"`,
+		`href="/connections/connection/details">Olist connection</a>`,
 		`>Source<`,
 	} {
 		if !strings.Contains(rendered, want) {

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -532,7 +532,7 @@ func TestCollapsedAssetLineageCollapsesMeasureUsageToSemanticModel(t *testing.T)
 		},
 	}
 
-	lineage := collapsedAssetLineageGraph(workspaceID, assets["dashboard-b"], graph, assets)
+	lineage := collapsedAssetLineageGraph(workspaceID, assets["dashboard-b"], graph, assets, nil)
 
 	assertLineageHasEdge(t, lineage, "model-a", "dashboard-a", "lineage_semantic_model_dashboard")
 	assertLineageMissingNode(t, lineage, "measure-a")
@@ -567,6 +567,7 @@ func TestConnectionAssetDetailsRenderConnectionSurface(t *testing.T) {
 		"Sources",
 		`Back to connections`,
 		`href="/connections/connection/lineage"`,
+		`/connections/connection/sources/source/details`,
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("connection details did not render %q:\n%s", want, rendered)
@@ -580,6 +581,75 @@ func TestConnectionAssetDetailsRenderConnectionSurface(t *testing.T) {
 	} {
 		if strings.Contains(rendered, notWant) {
 			t.Fatalf("connection details rendered workspace-only content %q:\n%s", notWant, rendered)
+		}
+	}
+}
+
+func TestConnectionsPageUsesConnectionAssetTabs(t *testing.T) {
+	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
+	visibleAssets := []api.AssetResponse{}
+	for _, asset := range assets {
+		if asset.Type == "connection" || asset.Type == "source" {
+			visibleAssets = append(visibleAssets, asset)
+		}
+	}
+
+	var out strings.Builder
+	err := ConnectionsPage(catalog, workspace.ID, visibleAssets, edges, "source", "", "Owner").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, want := range []string{
+		`data-connection-toolbar`,
+		`href="/connections"`,
+		`href="/connections?type=connection"`,
+		`href="/connections?type=source" aria-current="page"`,
+		`href="/connections/connection/sources/source/details"`,
+		`>Source<`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("connections page did not render %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, `data-workspace-asset-toolbar`) {
+		t.Fatalf("connections page rendered workspace toolbar:\n%s", rendered)
+	}
+}
+
+func TestConnectionSourceAssetDetailsRenderConnectionChrome(t *testing.T) {
+	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
+	source := testAssetByID(t, assets, "source")
+	connection := testAssetByID(t, assets, "connection")
+
+	var out strings.Builder
+	err := ConnectionSourceAssetPage(catalog, workspace, connection, source, assets, edges, "details", "Owner").Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+
+	for _, want := range []string{
+		"Connections",
+		"Olist connection",
+		"Sources",
+		"orders",
+		"Fields",
+		`href="/connections?type=source"`,
+		`href="/connections/connection/sources/source/lineage"`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("connection-scoped source details did not render %q:\n%s", want, rendered)
+		}
+	}
+	for _, notWant := range []string{
+		"Workspaces /",
+		"Back to workspace",
+		`href="/workspaces/libredash/assets/source/details"`,
+	} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("connection-scoped source details rendered workspace content %q:\n%s", notWant, rendered)
 		}
 	}
 }
@@ -626,7 +696,7 @@ func TestWorkspaceAssetRowsUseDetailLinksForModelAndMetricAssets(t *testing.T) {
 
 	for _, typ := range []string{"semantic_model", "dashboard"} {
 		var out strings.Builder
-		if err := assetRow(workspace.ID, byType[typ], byID).Render(&out); err != nil {
+		if err := assetRow(workspace.ID, byType[typ], byID, nil).Render(&out); err != nil {
 			t.Fatal(err)
 		}
 		rendered := html.UnescapeString(out.String())


### PR DESCRIPTION
## Summary
- Make `/connections` a connection/source asset browser with source filtering and canonical source links.
- Add connection-scoped source routes under `/connections/{connectionID}/sources/{sourceID}` and redirect workspace source URLs to them.
- Centralize canonical asset href generation in `internal/assetnav` so app redirects and UI links share the same connection/source routing logic.
- Keep Workspace focused on BI workspace assets by redirecting explicit source/connection filters to the Connections surface.
- Show each source's owning connection in the Connections table Parent column.

## Details
- Validates connection/source pairs for connection-scoped source detail and lineage routes.
- Updates lineage/table links to use canonical connection/source hrefs.
- Preserves existing workspace asset compatibility through redirects.
- Adds regression coverage for source filters, canonical source routes, invalid connection/source pairs, and source parent rendering.

## Tests
- `go test ./internal/app`
- `go test ./internal/ui`
- `task test`