### PR TITLE
Reuse visuals in fullscreen focus

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,6 +82,7 @@ tasks:
       - build
     cmds:
       - npm run test:table-selection
+      - npm run test:visual-modal
       - go test ./...
 
   ci:

--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -21,6 +21,8 @@ import (
 type principalContextKey struct{}
 type apiCredentialContextKey struct{}
 
+const csrfCookieName = "ld_csrf"
+
 var (
 	errUnauthorized = errors.New("unauthorized")
 	errForbidden    = errors.New("forbidden")
@@ -73,6 +75,8 @@ func NewAuth(repo access.Repository, workspaceID string, cfg AuthConfig) *Auth {
 	}
 	auth.csrf = csrf.Protect(
 		csrfKey(cfg.CSRFKey),
+		csrf.CookieName(csrfCookieName),
+		csrf.Path("/"),
 		csrf.Secure(cfg.CookieSecure),
 		csrf.SameSite(csrf.SameSiteLaxMode),
 		csrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -206,6 +206,54 @@ func TestCSRFMiddlewareAllowsBrowserPostWithToken(t *testing.T) {
 	}
 }
 
+func TestCSRFMiddlewareCookieCoversDashboardCommands(t *testing.T) {
+	store := testStore(t)
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	handler := auth.CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(csrf.Token(r)))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	getReq := httptest.NewRequest(http.MethodGet, "http://localhost:8120/dashboards/executive-sales/pages/overview", nil)
+	getRec := httptest.NewRecorder()
+	handler.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d", getRec.Code, http.StatusOK)
+	}
+	cookies := getRec.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("GET did not set CSRF cookie")
+	}
+	foundCSRF := false
+	for _, cookie := range cookies {
+		if cookie.Name != csrfCookieName {
+			continue
+		}
+		foundCSRF = true
+		if cookie.Path != "/" {
+			t.Fatalf("CSRF cookie path = %q, want /", cookie.Path)
+		}
+	}
+	if !foundCSRF {
+		t.Fatalf("GET did not set %s cookie", csrfCookieName)
+	}
+
+	postReq := httptest.NewRequest(http.MethodPost, "http://localhost:8120/commands/table-window", nil)
+	postReq.Header.Set("X-CSRF-Token", getRec.Body.String())
+	postReq.Header.Set("Referer", "http://localhost:8120/dashboards/executive-sales/pages/overview")
+	for _, cookie := range cookies {
+		postReq.AddCookie(cookie)
+	}
+	postRec := httptest.NewRecorder()
+	handler.ServeHTTP(postRec, postReq)
+	if postRec.Code != http.StatusNoContent {
+		t.Fatalf("POST status = %d, want %d, body=%s", postRec.Code, http.StatusNoContent, postRec.Body.String())
+	}
+}
+
 func TestCSRFMiddlewareAllowsPlainHTTPPostWithToken(t *testing.T) {
 	store := testStore(t)
 	auth := testAuth(store, "test", AuthConfig{DevBypass: true, CookieSecure: false})

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@fontsource-variable/inter": "^5.2.8",
+        "@playwright/test": "^1.61.1",
         "@primer/primitives": "11.9.0",
         "@tailwindcss/cli": "4.3.1",
         "@tanstack/lit-table": "^9.0.0-beta.12",
@@ -888,6 +889,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@primer/primitives": {
@@ -1867,6 +1884,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2530,6 +2562,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/property-information": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "build:chat": "esbuild web/components/chat.ts --bundle --format=esm --outfile=static/chat.js",
     "watch:css": "tailwindcss -i ./static/app.input.css -o ./static/app.css --watch",
     "test:table-selection": "mkdir -p .tmp && esbuild web/components/table/selection.test.ts --bundle --platform=node --format=esm --outfile=.tmp/table-selection.test.mjs && node --test .tmp/table-selection.test.mjs",
-    "test:visual-modal": "mkdir -p .tmp && esbuild web/components/visual-modal-focus.test.ts --bundle --platform=node --format=esm --outfile=.tmp/visual-modal-focus.test.mjs && node --test .tmp/visual-modal-focus.test.mjs"
+    "test:visual-modal": "mkdir -p .tmp && npx playwright install chromium && esbuild web/components/visual-modal.ts --bundle --format=esm --outfile=.tmp/visual-modal-under-test.js && esbuild web/components/visual-modal-focus.test.ts --bundle --platform=node --format=esm --outfile=.tmp/visual-modal-focus.test.mjs && esbuild web/components/visual-modal.dom.test.ts --bundle --platform=node --format=esm --external:@playwright/test --outfile=.tmp/visual-modal.dom.test.mjs && node --test .tmp/visual-modal-focus.test.mjs .tmp/visual-modal.dom.test.mjs"
   },
   "devDependencies": {
     "@fontsource-variable/inter": "^5.2.8",
+    "@playwright/test": "^1.61.1",
     "@primer/primitives": "11.9.0",
     "@tailwindcss/cli": "4.3.1",
     "@tanstack/lit-table": "^9.0.0-beta.12",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build:asset-lineage": "esbuild web/components/asset-lineage-graph.ts --bundle --format=esm --outfile=static/asset-lineage-graph.js",
     "build:chat": "esbuild web/components/chat.ts --bundle --format=esm --outfile=static/chat.js",
     "watch:css": "tailwindcss -i ./static/app.input.css -o ./static/app.css --watch",
-    "test:table-selection": "mkdir -p .tmp && esbuild web/components/table/selection.test.ts --bundle --platform=node --format=esm --outfile=.tmp/table-selection.test.mjs && node --test .tmp/table-selection.test.mjs"
+    "test:table-selection": "mkdir -p .tmp && esbuild web/components/table/selection.test.ts --bundle --platform=node --format=esm --outfile=.tmp/table-selection.test.mjs && node --test .tmp/table-selection.test.mjs",
+    "test:visual-modal": "mkdir -p .tmp && esbuild web/components/visual-modal-focus.test.ts --bundle --platform=node --format=esm --outfile=.tmp/visual-modal-focus.test.mjs && node --test .tmp/visual-modal-focus.test.mjs"
   },
   "devDependencies": {
     "@fontsource-variable/inter": "^5.2.8",

--- a/web/components/charts.ts
+++ b/web/components/charts.ts
@@ -3,6 +3,7 @@ import { property } from 'lit/decorators.js'
 import { EllipsisVertical } from 'lucide'
 import { lucideIcon } from './lucide-icons'
 import { visualMenuIcon } from './visual-menu-icons'
+import { visualActionStyles } from './visual-action-styles'
 import './chart/renderers'
 import { chartInteractionDetailForDatum } from './chart/interactions'
 import { chartRenderer } from './chart/registry'
@@ -67,29 +68,6 @@ const chartStyles = css`
     flex: 0 0 auto;
   }
 
-  .visual-actions {
-    display: flex;
-    flex: 0 0 auto;
-    align-items: center;
-    gap: var(--base-size-4);
-  }
-
-  .icon-action {
-    display: grid;
-    width: var(--control-xsmall-size);
-    height: var(--control-xsmall-size);
-    min-height: var(--control-xsmall-size);
-    place-items: center;
-    border: var(--ld-border-transparent);
-    border-radius: var(--ld-radius-tight);
-    background: transparent;
-    color: var(--ld-icon-muted);
-    cursor: pointer;
-    padding: 0;
-    font: inherit;
-    line-height: var(--ld-line-height-none);
-  }
-
   .options summary {
     display: grid;
     width: var(--control-xsmall-size);
@@ -114,13 +92,6 @@ const chartStyles = css`
     height: var(--base-size-16);
   }
 
-  .icon-action svg {
-    width: var(--base-size-16);
-    height: var(--base-size-16);
-  }
-
-  .icon-action:hover,
-  .icon-action:focus-visible,
   .options summary:hover,
   .options summary:focus-visible,
   .options[open] summary {
@@ -220,7 +191,7 @@ class ChartVisual extends LitElement {
   @property({ type: String }) type: ChartType | string = 'bar'
   @property({ type: Array }) selection: string[] = []
 
-  static styles = chartStyles
+  static styles = [visualActionStyles, chartStyles]
 
   private rendererHandle?: ChartRendererHandle
   private rendererName = ''

--- a/web/components/charts.ts
+++ b/web/components/charts.ts
@@ -67,6 +67,29 @@ const chartStyles = css`
     flex: 0 0 auto;
   }
 
+  .visual-actions {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: var(--base-size-4);
+  }
+
+  .icon-action {
+    display: grid;
+    width: var(--control-xsmall-size);
+    height: var(--control-xsmall-size);
+    min-height: var(--control-xsmall-size);
+    place-items: center;
+    border: var(--ld-border-transparent);
+    border-radius: var(--ld-radius-tight);
+    background: transparent;
+    color: var(--ld-icon-muted);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    line-height: var(--ld-line-height-none);
+  }
+
   .options summary {
     display: grid;
     width: var(--control-xsmall-size);
@@ -91,6 +114,13 @@ const chartStyles = css`
     height: var(--base-size-16);
   }
 
+  .icon-action svg {
+    width: var(--base-size-16);
+    height: var(--base-size-16);
+  }
+
+  .icon-action:hover,
+  .icon-action:focus-visible,
   .options summary:hover,
   .options summary:focus-visible,
   .options[open] summary {
@@ -210,6 +240,12 @@ class ChartVisual extends LitElement {
     this.observer = new ResizeObserver(() => this.rendererHandle?.resize())
     document.addEventListener('pointerdown', this.handleOutsidePointerDown)
     document.addEventListener('keydown', this.handleDocumentKeyDown)
+    if (this.hasUpdated) {
+      queueMicrotask(() => {
+        this.observer?.observe(this)
+        this.renderChart()
+      })
+    }
   }
 
   firstUpdated(): void {
@@ -226,6 +262,8 @@ class ChartVisual extends LitElement {
     document.removeEventListener('keydown', this.handleDocumentKeyDown)
     this.observer?.disconnect()
     this.rendererHandle?.dispose()
+    this.rendererHandle = undefined
+    this.rendererName = ''
     super.disconnectedCallback()
   }
 
@@ -239,16 +277,18 @@ class ChartVisual extends LitElement {
             <h2>${payload.title ?? 'Chart'}</h2>
             <span class="unit">${payload.unit ?? ''}</span>
           </div>
-          <details class="options">
-            <summary aria-label="Visual options" title="Visual options">${lucideIcon(EllipsisVertical)}</summary>
-            <div class="menu" role="menu">
-              <button type="button" role="menuitem" @click=${() => this.runAction('focus')}>${visualMenuIcon('focus')}<span>Focus mode</span></button>
-              <button type="button" role="menuitem" @click=${() => this.runAction('show-data')}>${visualMenuIcon('show-data')}<span>Show data</span></button>
-              <button type="button" role="menuitem" @click=${() => this.runAction('copy-data')}>${visualMenuIcon('copy-data')}<span>Copy data</span></button>
-              <button type="button" role="menuitem" @click=${() => this.runAction('export-csv')}>${visualMenuIcon('export-csv')}<span>Export CSV</span></button>
-              <button type="button" role="menuitem" ?disabled=${!this.hasSelection(payload)} @click=${() => this.runAction('clear-selection')}>${visualMenuIcon('clear-selection')}<span>Clear selection</span></button>
-            </div>
-          </details>
+          <div class="visual-actions">
+            <button class="icon-action" type="button" aria-label="Expand visual" title="Expand visual" @click=${() => this.runAction('focus')}>${visualMenuIcon('focus')}</button>
+            <details class="options">
+              <summary aria-label="Visual options" title="Visual options">${lucideIcon(EllipsisVertical)}</summary>
+              <div class="menu" role="menu">
+                <button type="button" role="menuitem" @click=${() => this.runAction('show-data')}>${visualMenuIcon('show-data')}<span>Show data</span></button>
+                <button type="button" role="menuitem" @click=${() => this.runAction('copy-data')}>${visualMenuIcon('copy-data')}<span>Copy data</span></button>
+                <button type="button" role="menuitem" @click=${() => this.runAction('export-csv')}>${visualMenuIcon('export-csv')}<span>Export CSV</span></button>
+                <button type="button" role="menuitem" ?disabled=${!this.hasSelection(payload)} @click=${() => this.runAction('clear-selection')}>${visualMenuIcon('clear-selection')}<span>Clear selection</span></button>
+              </div>
+            </details>
+          </div>
         </header>
         <div class=${data.length === 0 ? 'canvas idle' : 'canvas'}></div>
         ${data.length === 0 ? html`<div class="empty">Waiting for signal data</div>` : null}

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -305,7 +305,7 @@ class DataTable extends LitElement {
       pointer-events: none;
     }
 
-    .toolbar > div {
+    .toolbar-title {
       position: relative;
       z-index: calc(var(--zIndex-default) + 2);
       flex: 1 1 auto;
@@ -328,6 +328,31 @@ class DataTable extends LitElement {
       position: relative;
       z-index: calc(var(--zIndex-default) + 2);
       flex: 0 0 auto;
+    }
+
+    .visual-actions {
+      position: relative;
+      z-index: calc(var(--zIndex-default) + 2);
+      display: flex;
+      flex: 0 0 auto;
+      align-items: center;
+      gap: var(--base-size-4);
+    }
+
+    .icon-action {
+      display: grid;
+      width: var(--control-xsmall-size);
+      height: var(--control-xsmall-size);
+      min-height: var(--control-xsmall-size);
+      place-items: center;
+      border: var(--ld-border-transparent);
+      border-radius: var(--ld-radius-tight);
+      background: transparent;
+      color: var(--ld-fg-muted);
+      cursor: pointer;
+      padding: 0;
+      font: inherit;
+      line-height: var(--ld-line-height-none);
     }
 
     .visual-options summary {
@@ -355,6 +380,13 @@ class DataTable extends LitElement {
       height: var(--base-size-16);
     }
 
+    .icon-action svg {
+      width: var(--base-size-16);
+      height: var(--base-size-16);
+    }
+
+    .icon-action:hover,
+    .icon-action:focus-visible,
     .visual-options summary:hover,
     .visual-options summary:focus-visible,
     .visual-options[open] summary {
@@ -993,11 +1025,17 @@ class DataTable extends LitElement {
     super.connectedCallback()
     document.addEventListener('pointerdown', this.handleOutsidePointerDown)
     document.addEventListener('keydown', this.handleDocumentKeyDown)
+    if (this.hasUpdated) queueMicrotask(() => this.startViewportObserver())
   }
 
   firstUpdated(): void {
+    this.startViewportObserver()
+  }
+
+  private startViewportObserver(): void {
     const viewport = this.bodyViewportRef.value
     if (!viewport) return
+    this.resizeObserver?.disconnect()
     this.viewportHeight = viewport.clientHeight
     this.resizeObserver = new ResizeObserver(() => {
       this.viewportHeight = viewport.clientHeight
@@ -1011,7 +1049,10 @@ class DataTable extends LitElement {
     document.removeEventListener('pointerdown', this.handleOutsidePointerDown)
     document.removeEventListener('keydown', this.handleDocumentKeyDown)
     this.resizeObserver?.disconnect()
-    if (this.scrollFrame) cancelAnimationFrame(this.scrollFrame)
+    if (this.scrollFrame) {
+      cancelAnimationFrame(this.scrollFrame)
+      this.scrollFrame = 0
+    }
     this.clearResizeGuide()
     this.clearJumpTimer()
     super.disconnectedCallback()
@@ -1556,39 +1597,41 @@ class DataTable extends LitElement {
     return html`
       <section class=${shellClass} style=${shellStyle}>
         <div class="toolbar">
-          <div>
+          <div class="toolbar-title">
             <h2>${this.table?.title ?? 'Orders'}</h2>
           </div>
-          <details class="visual-options">
-            <summary aria-label="Visual options" title="Visual options">${lucideIcon(EllipsisVertical)}</summary>
-            <div class="menu" role="menu">
-              <button type="button" role="menuitem" @click=${() => this.runAction('focus')}>${visualMenuIcon('focus')}<span>Focus mode</span></button>
-              <button type="button" role="menuitem" @click=${() => this.runAction('show-data')}>${visualMenuIcon('show-data')}<span>Show data</span></button>
-              <button type="button" role="menuitem" @click=${() => this.runAction('copy-data')}>${visualMenuIcon('copy-data')}<span>Copy data</span></button>
-              <button type="button" role="menuitem" @click=${() => this.runAction('export-csv')}>${visualMenuIcon('export-csv')}<span>Export CSV</span></button>
-              <button type="button" role="menuitem" ?disabled=${!hasSelection} @click=${() => this.runAction('clear-selection')}>${visualMenuIcon('clear-selection')}<span>Clear selection</span></button>
-              <div class="menu-divider"></div>
-              <div class="column-menu" @click=${(event: Event) => event.stopPropagation()}>
-                <span>Columns</span>
-                ${columnModels.map((column: any) => {
-                  const checked = columnIsVisible(column, this.columnVisibility)
-                  return html`
-                    <label>
-                      <input
-                        type="checkbox"
-                        .checked=${checked}
-                        ?disabled=${!columnCanHide(column) || checked && columns.length <= 1}
-                        @change=${columnVisibilityHandler(column, (next) => {
-                          this.columnVisibility = { ...this.columnVisibility, [column.id]: next }
-                        })}
-                      />
-                      ${column.columnDef.header}
-                    </label>
-                  `
-                })}
+          <div class="visual-actions">
+            <button class="icon-action" type="button" aria-label="Expand table" title="Expand table" @click=${() => this.runAction('focus')}>${visualMenuIcon('focus')}</button>
+            <details class="visual-options">
+              <summary aria-label="Visual options" title="Visual options">${lucideIcon(EllipsisVertical)}</summary>
+              <div class="menu" role="menu">
+                <button type="button" role="menuitem" @click=${() => this.runAction('show-data')}>${visualMenuIcon('show-data')}<span>Show data</span></button>
+                <button type="button" role="menuitem" @click=${() => this.runAction('copy-data')}>${visualMenuIcon('copy-data')}<span>Copy data</span></button>
+                <button type="button" role="menuitem" @click=${() => this.runAction('export-csv')}>${visualMenuIcon('export-csv')}<span>Export CSV</span></button>
+                <button type="button" role="menuitem" ?disabled=${!hasSelection} @click=${() => this.runAction('clear-selection')}>${visualMenuIcon('clear-selection')}<span>Clear selection</span></button>
+                <div class="menu-divider"></div>
+                <div class="column-menu" @click=${(event: Event) => event.stopPropagation()}>
+                  <span>Columns</span>
+                  ${columnModels.map((column: any) => {
+                    const checked = columnIsVisible(column, this.columnVisibility)
+                    return html`
+                      <label>
+                        <input
+                          type="checkbox"
+                          .checked=${checked}
+                          ?disabled=${!columnCanHide(column) || checked && columns.length <= 1}
+                          @change=${columnVisibilityHandler(column, (next) => {
+                            this.columnVisibility = { ...this.columnVisibility, [column.id]: next }
+                          })}
+                        />
+                        ${column.columnDef.header}
+                      </label>
+                    `
+                  })}
+                </div>
               </div>
-            </div>
-          </details>
+            </details>
+          </div>
         </div>
         ${this.table?.error ? html`<div class="error">${this.table.error}</div>` : nothing}
         <div class="table-frame" role="table" aria-label=${this.table?.title ?? 'Orders'}>

--- a/web/components/data-table.ts
+++ b/web/components/data-table.ts
@@ -31,6 +31,7 @@ import {
   table_getAllLeafColumns,
 } from '@tanstack/table-core/static-functions'
 import { visualMenuIcon } from './visual-menu-icons'
+import { visualActionStyles } from './visual-action-styles'
 import { defaultDirection, formatCell, rowKey } from './table/format'
 import { blockStartsForAll, emptyBlocks, emptyTable, sameSort, sortedBlockRows, tableConverter } from './table/block-source'
 import {
@@ -258,7 +259,7 @@ class DataTable extends LitElement {
     this.clearResizeGuide()
   }
 
-  static styles = css`
+  static styles = [visualActionStyles, css`
     :host {
       display: block;
       height: 100%;
@@ -333,26 +334,6 @@ class DataTable extends LitElement {
     .visual-actions {
       position: relative;
       z-index: calc(var(--zIndex-default) + 2);
-      display: flex;
-      flex: 0 0 auto;
-      align-items: center;
-      gap: var(--base-size-4);
-    }
-
-    .icon-action {
-      display: grid;
-      width: var(--control-xsmall-size);
-      height: var(--control-xsmall-size);
-      min-height: var(--control-xsmall-size);
-      place-items: center;
-      border: var(--ld-border-transparent);
-      border-radius: var(--ld-radius-tight);
-      background: transparent;
-      color: var(--ld-fg-muted);
-      cursor: pointer;
-      padding: 0;
-      font: inherit;
-      line-height: var(--ld-line-height-none);
     }
 
     .visual-options summary {
@@ -380,13 +361,6 @@ class DataTable extends LitElement {
       height: var(--base-size-16);
     }
 
-    .icon-action svg {
-      width: var(--base-size-16);
-      height: var(--base-size-16);
-    }
-
-    .icon-action:hover,
-    .icon-action:focus-visible,
     .visual-options summary:hover,
     .visual-options summary:focus-visible,
     .visual-options[open] summary {
@@ -1019,7 +993,7 @@ class DataTable extends LitElement {
         min-height: 360px;
       }
     }
-  `
+  `]
 
   connectedCallback(): void {
     super.connectedCallback()

--- a/web/components/visual-action-styles.ts
+++ b/web/components/visual-action-styles.ts
@@ -1,0 +1,39 @@
+import { css } from 'lit'
+
+export const visualActionStyles = css`
+  .visual-actions {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: var(--base-size-4);
+  }
+
+  .icon-action {
+    display: grid;
+    width: var(--control-xsmall-size);
+    height: var(--control-xsmall-size);
+    min-height: var(--control-xsmall-size);
+    place-items: center;
+    border: var(--ld-border-transparent);
+    border-radius: var(--ld-radius-tight);
+    background: transparent;
+    color: var(--ld-icon-muted, var(--ld-fg-muted));
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    line-height: var(--ld-line-height-none);
+  }
+
+  .icon-action svg {
+    width: var(--base-size-16);
+    height: var(--base-size-16);
+  }
+
+  .icon-action:hover,
+  .icon-action:focus-visible {
+    border-color: var(--ld-line-default);
+    background: var(--ld-bg-panel-muted);
+    color: var(--ld-icon-default, var(--ld-fg-default));
+    outline: 0;
+  }
+`

--- a/web/components/visual-modal-focus.test.ts
+++ b/web/components/visual-modal-focus.test.ts
@@ -1,0 +1,200 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mountVisualFocus, restoreVisualFocus, visualSourceFromEvent } from './visual-modal-focus'
+
+class FakeDocument {
+  createComment(value: string): FakeNode {
+    return new FakeNode(`#comment:${value}`)
+  }
+}
+
+class FakeNode {
+  children: FakeNode[] = []
+  parentNode: FakeNode | null = null
+  ownerDocument = fakeDocument
+  private attributes = new Map<string, string>()
+
+  constructor(readonly name: string) {}
+
+  get nextSibling(): FakeNode | null {
+    if (!this.parentNode) return null
+    const index = this.parentNode.children.indexOf(this)
+    return index >= 0 ? this.parentNode.children[index + 1] ?? null : null
+  }
+
+  appendChild(node: FakeNode): FakeNode {
+    this.detach(node)
+    this.children.push(node)
+    node.parentNode = this
+    return node
+  }
+
+  insertBefore(node: FakeNode, before: FakeNode | null): FakeNode {
+    this.detach(node)
+    const index = before ? this.children.indexOf(before) : -1
+    if (index >= 0) {
+      this.children.splice(index, 0, node)
+    } else {
+      this.children.push(node)
+    }
+    node.parentNode = this
+    return node
+  }
+
+  remove(): void {
+    if (!this.parentNode) return
+    this.parentNode.children = this.parentNode.children.filter((child) => child !== this)
+    this.parentNode = null
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value)
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name)
+  }
+
+  private detach(node: FakeNode): void {
+    if (!node.parentNode) return
+    node.parentNode.children = node.parentNode.children.filter((child) => child !== node)
+    node.parentNode = null
+  }
+}
+
+const fakeDocument = new FakeDocument()
+
+function childNames(node: FakeNode): string[] {
+  return node.children.map((child) => child.name)
+}
+
+test('mountVisualFocus moves the source element into the target and leaves a placeholder', () => {
+  const source = new FakeNode('source')
+  const after = new FakeNode('after')
+  const parent = new FakeNode('parent')
+  const target = new FakeNode('target')
+  parent.appendChild(source)
+  parent.appendChild(after)
+
+  const mount = mountVisualFocus(source as unknown as Element, target as unknown as Node)
+
+  assert.ok(mount)
+  assert.equal(target.children[0], source)
+  assert.equal(source.parentNode, target)
+  assert.deepEqual(childNames(parent), ['#comment:ld-visual-focus-placeholder', 'after'])
+})
+
+test('mountVisualFocus can slot the source as a light DOM child of the modal host', () => {
+  const source = new FakeNode('source')
+  const parent = new FakeNode('parent')
+  const modalHost = new FakeNode('ld-visual-modal')
+  parent.appendChild(source)
+
+  const mount = mountVisualFocus(source as unknown as Element, modalHost as unknown as Node, { slot: 'focus-visual' })
+
+  assert.ok(mount)
+  assert.equal(source.parentNode, modalHost)
+  assert.equal(source.getAttribute('slot'), 'focus-visual')
+  assert.deepEqual(childNames(parent), ['#comment:ld-visual-focus-placeholder'])
+
+  restoreVisualFocus(mount)
+
+  assert.equal(source.parentNode, parent)
+  assert.equal(source.getAttribute('slot'), null)
+  assert.deepEqual(childNames(parent), ['source'])
+})
+
+test('restoreVisualFocus restores a previous slot value after fullscreen focus', () => {
+  const source = new FakeNode('source')
+  const parent = new FakeNode('parent')
+  const modalHost = new FakeNode('ld-visual-modal')
+  source.setAttribute('slot', 'dashboard-cell')
+  parent.appendChild(source)
+
+  const mount = mountVisualFocus(source as unknown as Element, modalHost as unknown as Node, { slot: 'focus-visual' })
+  assert.ok(mount)
+  assert.equal(source.getAttribute('slot'), 'focus-visual')
+
+  restoreVisualFocus(mount)
+
+  assert.equal(source.parentNode, parent)
+  assert.equal(source.getAttribute('slot'), 'dashboard-cell')
+})
+
+test('restoreVisualFocus restores the same source element before the placeholder', () => {
+  const before = new FakeNode('before')
+  const source = new FakeNode('source')
+  const after = new FakeNode('after')
+  const parent = new FakeNode('parent')
+  const target = new FakeNode('target')
+  parent.appendChild(before)
+  parent.appendChild(source)
+  parent.appendChild(after)
+  const mount = mountVisualFocus(source as unknown as Element, target as unknown as Node)
+  assert.ok(mount)
+
+  restoreVisualFocus(mount)
+
+  assert.equal(source.parentNode, parent)
+  assert.deepEqual(childNames(parent), ['before', 'source', 'after'])
+  assert.deepEqual(childNames(target), [])
+})
+
+test('restoreVisualFocus falls back to the original next sibling when placeholder is gone', () => {
+  const source = new FakeNode('source')
+  const after = new FakeNode('after')
+  const parent = new FakeNode('parent')
+  const target = new FakeNode('target')
+  parent.appendChild(source)
+  parent.appendChild(after)
+  const mount = mountVisualFocus(source as unknown as Element, target as unknown as Node)
+  assert.ok(mount)
+  mount.placeholder.remove()
+
+  restoreVisualFocus(mount)
+
+  assert.deepEqual(childNames(parent), ['source', 'after'])
+  assert.deepEqual(childNames(target), [])
+})
+
+test('focus can move from one source element to another after restoring the first', () => {
+  const first = new FakeNode('first')
+  const firstParent = new FakeNode('first-parent')
+  const second = new FakeNode('second')
+  const secondParent = new FakeNode('second-parent')
+  const target = new FakeNode('target')
+  firstParent.appendChild(first)
+  secondParent.appendChild(second)
+  const firstMount = mountVisualFocus(first as unknown as Element, target as unknown as Node)
+  assert.ok(firstMount)
+
+  restoreVisualFocus(firstMount)
+  const secondMount = mountVisualFocus(second as unknown as Element, target as unknown as Node)
+
+  assert.ok(secondMount)
+  assert.deepEqual(childNames(firstParent), ['first'])
+  assert.deepEqual(childNames(secondParent), ['#comment:ld-visual-focus-placeholder'])
+  assert.deepEqual(childNames(target), ['second'])
+})
+
+test('visualSourceFromEvent returns the first focusable visual in the composed path', () => {
+  const originalHTMLElement = globalThis.HTMLElement
+  class TestHTMLElement {
+    constructor(readonly localName: string) {}
+  }
+  globalThis.HTMLElement = TestHTMLElement as unknown as typeof HTMLElement
+  try {
+    const button = new TestHTMLElement('button')
+    const chart = new TestHTMLElement('ld-echart')
+    const table = new TestHTMLElement('ld-data-table')
+    const event = { composedPath: () => [button, chart, table] } as unknown as Event
+
+    assert.equal(visualSourceFromEvent(event), chart)
+  } finally {
+    globalThis.HTMLElement = originalHTMLElement
+  }
+})

--- a/web/components/visual-modal-focus.ts
+++ b/web/components/visual-modal-focus.ts
@@ -1,0 +1,51 @@
+export type VisualFocusMount<T extends Element = Element> = {
+  element: T
+  placeholder: Comment
+  sourceParent: Node
+  nextSibling: ChildNode | null
+  previousSlot?: string | null
+}
+
+export function mountVisualFocus<T extends Element>(element: T, target: Node, options: { slot?: string } = {}): VisualFocusMount<T> | null {
+  const sourceParent = element.parentNode
+  if (!sourceParent) return null
+
+  const previousSlot = options.slot ? element.getAttribute('slot') : undefined
+  const placeholder = element.ownerDocument.createComment('ld-visual-focus-placeholder')
+  const nextSibling = element.nextSibling
+  if (options.slot) element.setAttribute('slot', options.slot)
+  sourceParent.insertBefore(placeholder, element)
+  target.appendChild(element)
+
+  return { element, placeholder, sourceParent, nextSibling, previousSlot }
+}
+
+export function restoreVisualFocus(mount: VisualFocusMount): void {
+  const restoreParent = mount.placeholder.parentNode ?? mount.sourceParent
+  const restoreBefore = mount.placeholder.parentNode
+    ? mount.placeholder
+    : mount.nextSibling?.parentNode === restoreParent
+      ? mount.nextSibling
+      : null
+
+  restoreParent.insertBefore(mount.element, restoreBefore)
+  mount.placeholder.remove()
+  if (mount.previousSlot !== undefined) {
+    if (mount.previousSlot === null) {
+      mount.element.removeAttribute('slot')
+    } else {
+      mount.element.setAttribute('slot', mount.previousSlot)
+    }
+  }
+}
+
+export function visualSourceFromEvent(event: Event): HTMLElement | null {
+  for (const target of event.composedPath()) {
+    if (target instanceof HTMLElement && isFocusableVisual(target)) return target
+  }
+  return null
+}
+
+function isFocusableVisual(element: HTMLElement): boolean {
+  return element.localName === 'ld-echart' || element.localName === 'ld-data-table'
+}

--- a/web/components/visual-modal.dom.test.ts
+++ b/web/components/visual-modal.dom.test.ts
@@ -1,0 +1,184 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { chromium, type Browser } from '@playwright/test'
+
+let server: Server
+let baseURL = ''
+let browser: Browser
+
+test.before(async () => {
+  const root = join(process.cwd(), '.tmp')
+  server = createServer(async (request, response) => {
+    const url = request.url ?? '/'
+    if (url === '/visual-modal-under-test.js') {
+      response.setHeader('content-type', 'text/javascript')
+      response.end(await readFile(join(root, 'visual-modal-under-test.js'), 'utf8'))
+      return
+    }
+    response.setHeader('content-type', 'text/html')
+    response.end(`
+      <!doctype html>
+      <html>
+        <body>
+          <button id="trigger">Expand</button>
+          <section id="parent">
+            <ld-echart id="first"></ld-echart>
+            <ld-data-table id="second"></ld-data-table>
+          </section>
+          <ld-visual-modal id="modal"></ld-visual-modal>
+          <script type="module" src="/visual-modal-under-test.js"></script>
+        </body>
+      </html>
+    `)
+  })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('test server did not bind to a port')
+  baseURL = `http://127.0.0.1:${address.port}`
+  browser = await chromium.launch()
+})
+
+test.after(async () => {
+  await browser?.close()
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+})
+
+async function setupPage() {
+  const page = await browser.newPage()
+  await page.goto(baseURL)
+  await page.waitForFunction(() => customElements.get('ld-visual-modal'))
+  return page
+}
+
+async function dispatchVisualAction(page: Awaited<ReturnType<typeof setupPage>>, sourceId: string, action: string): Promise<void> {
+  await page.evaluate(({ sourceId, action }) => {
+    const source = document.getElementById(sourceId)
+    if (!source) throw new Error(`missing source ${sourceId}`)
+    source.dispatchEvent(new CustomEvent('ld-visual-action', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        action,
+        visualType: source.localName === 'ld-data-table' ? 'table' : 'chart',
+        visualId: sourceId,
+        title: sourceId,
+        columns: [{ key: 'label', label: 'Label' }],
+        rows: [{ label: 'A' }],
+        selection: [],
+      },
+    }))
+  }, { sourceId, action })
+  await page.locator('ld-visual-modal').evaluate((modal: any) => modal.updateComplete)
+}
+
+test('focus action moves the original source into the modal and close restores it', async () => {
+  const page = await setupPage()
+  try {
+    await page.locator('#trigger').focus()
+    await dispatchVisualAction(page, 'first', 'focus')
+
+    const focusedState = await page.evaluate(() => {
+      const modal = document.querySelector('ld-visual-modal')!
+      const first = document.getElementById('first')!
+      const parent = document.getElementById('parent')!
+      return {
+        sourceParent: first.parentElement?.localName,
+        slot: first.getAttribute('slot'),
+        placeholderAtSource: Array.from(parent.childNodes).some((node) => node.nodeType === Node.COMMENT_NODE),
+        activeInModal: modal.shadowRoot?.activeElement?.classList.contains('focus-close') ?? false,
+      }
+    })
+
+    assert.deepEqual(focusedState, {
+      sourceParent: 'ld-visual-modal',
+      slot: 'focus-visual',
+      placeholderAtSource: true,
+      activeInModal: true,
+    })
+
+    await page.keyboard.press('Tab')
+    assert.equal(await page.locator('ld-visual-modal').evaluate((modal: any) => (
+      modal.shadowRoot.activeElement?.classList.contains('focus-close') ?? false
+    )), true)
+
+    await page.locator('ld-visual-modal').evaluate((modal: any) => modal.shadowRoot.querySelector('.focus-close').click())
+    await page.locator('ld-visual-modal').evaluate((modal: any) => modal.updateComplete)
+
+    const restoredState = await page.evaluate(() => {
+      const first = document.getElementById('first')!
+      const parent = document.getElementById('parent')!
+      return {
+        sourceParent: first.parentElement?.id,
+        slot: first.getAttribute('slot'),
+        restoredPosition: parent.children[0] === first,
+        activeId: document.activeElement?.id,
+      }
+    })
+
+    assert.deepEqual(restoredState, {
+      sourceParent: 'parent',
+      slot: null,
+      restoredPosition: true,
+      activeId: 'trigger',
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('opening another focused source restores the previous element first', async () => {
+  const page = await setupPage()
+  try {
+    await dispatchVisualAction(page, 'first', 'focus')
+    await dispatchVisualAction(page, 'second', 'focus')
+
+    const state = await page.evaluate(() => {
+      const parent = document.getElementById('parent')!
+      const first = document.getElementById('first')!
+      const second = document.getElementById('second')!
+      return {
+        firstParent: first.parentElement?.id,
+        firstPosition: parent.children[0] === first,
+        secondParent: second.parentElement?.localName,
+        secondSlot: second.getAttribute('slot'),
+      }
+    })
+
+    assert.deepEqual(state, {
+      firstParent: 'parent',
+      firstPosition: true,
+      secondParent: 'ld-visual-modal',
+      secondSlot: 'focus-visual',
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('non-focus visual actions do not move the source element', async () => {
+  const page = await setupPage()
+  try {
+    await dispatchVisualAction(page, 'first', 'show-data')
+
+    const state = await page.evaluate(() => {
+      const first = document.getElementById('first')!
+      const modal = document.querySelector('ld-visual-modal')!
+      return {
+        sourceParent: first.parentElement?.id,
+        slot: first.getAttribute('slot'),
+        hasFocusSlot: Boolean(modal.shadowRoot?.querySelector('slot[name="focus-visual"]')),
+      }
+    })
+
+    assert.deepEqual(state, {
+      sourceParent: 'parent',
+      slot: null,
+      hasFocusSlot: false,
+    })
+  } finally {
+    await page.close()
+  }
+})

--- a/web/components/visual-modal.ts
+++ b/web/components/visual-modal.ts
@@ -2,6 +2,7 @@ import { LitElement, css, html, nothing } from 'lit'
 import { state } from 'lit/decorators.js'
 import { X } from 'lucide'
 import { lucideIcon } from './lucide-icons'
+import { mountVisualFocus, restoreVisualFocus, visualSourceFromEvent, type VisualFocusMount } from './visual-modal-focus'
 
 type VisualActionName = 'focus' | 'show-data' | 'copy-data' | 'export-csv' | 'clear-selection'
 
@@ -31,6 +32,8 @@ class VisualModal extends LitElement {
   @state() private mode: ModalMode | '' = ''
   @state() private detail: VisualActionDetail | null = null
   @state() private notice = ''
+  private focusMount: VisualFocusMount<HTMLElement> | null = null
+  private focusSource: HTMLElement | null = null
 
   static styles = css`
     :host {
@@ -59,6 +62,16 @@ class VisualModal extends LitElement {
       background: var(--ld-bg-overlay);
       box-shadow: var(--shadow-floating-large);
       overflow: hidden;
+    }
+
+    .focus-dialog {
+      position: relative;
+      width: min(1420px, 100%);
+      height: min(920px, calc(100vh - 56px));
+      max-height: calc(100vh - 56px);
+      min-height: min(520px, calc(100vh - 56px));
+      grid-template-rows: minmax(0, 1fr);
+      background: var(--ld-chart-surface);
     }
 
     header {
@@ -125,6 +138,17 @@ class VisualModal extends LitElement {
       padding: 0;
     }
 
+    .focus-close {
+      position: absolute;
+      top: var(--ld-space-md);
+      right: var(--ld-space-md);
+      z-index: var(--zIndex-popover);
+      display: grid;
+      place-items: center;
+      background: var(--ld-bg-overlay);
+      box-shadow: var(--shadow-floating-small);
+    }
+
     .close svg {
       width: var(--base-size-16);
       height: var(--base-size-16);
@@ -134,6 +158,29 @@ class VisualModal extends LitElement {
       min-height: 0;
       overflow: hidden;
       background: var(--ld-chart-surface);
+    }
+
+    .focus-slot {
+      display: block;
+      min-height: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: var(--ld-chart-surface);
+    }
+
+    .focus-slot > * {
+      display: block;
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+    }
+
+    ::slotted([slot='focus-visual']) {
+      display: block;
+      width: 100%;
+      height: 100%;
+      min-height: 0;
     }
 
     .focus-chart,
@@ -229,6 +276,7 @@ class VisualModal extends LitElement {
   disconnectedCallback(): void {
     window.removeEventListener('ld-visual-action', this.handleVisualAction as EventListener)
     window.removeEventListener('keydown', this.handleKeydown)
+    this.restoreFocusedVisual()
     super.disconnectedCallback()
   }
 
@@ -240,12 +288,13 @@ class VisualModal extends LitElement {
   }
 
   private renderDialog(detail: VisualActionDetail, mode: ModalMode) {
+    if (mode === 'focus') return this.renderFocusDialog(detail)
     return html`
       <div class="backdrop" @click=${this.closeFromBackdrop}>
         <section class="dialog" role="dialog" aria-modal="true" aria-label=${detail.title}>
           <header>
             <div class="title">
-              <p class="eyebrow">${mode === 'focus' ? 'Focus mode' : 'Show data'} · ${detail.visualType}</p>
+              <p class="eyebrow">Show data · ${detail.visualType}</p>
               <h2>${detail.title}</h2>
             </div>
             <div class="actions">
@@ -255,19 +304,22 @@ class VisualModal extends LitElement {
             </div>
           </header>
           <div class="body">
-            ${mode === 'focus' ? this.renderFocus(detail) : this.renderData(detail)}
+            ${this.renderData(detail)}
           </div>
         </section>
       </div>
     `
   }
 
-  private renderFocus(detail: VisualActionDetail) {
-    if (detail.visualType === 'chart') {
-      const chart = detail.chart ?? chartPayloadFromRows(detail)
-      return html`<ld-echart class="focus-chart" .chart=${chart}></ld-echart>`
-    }
-    return html`<div class="focus-table">${this.renderData(detail)}</div>`
+  private renderFocusDialog(detail: VisualActionDetail) {
+    return html`
+      <div class="backdrop" @click=${this.closeFromBackdrop}>
+        <section class="dialog focus-dialog" role="dialog" aria-modal="true" aria-label=${detail.title}>
+          <button class="close focus-close" type="button" aria-label="Close visual modal" @click=${this.close}>${lucideIcon(X)}</button>
+          <div class="focus-slot"><slot name="focus-visual"></slot></div>
+        </section>
+      </div>
+    `
   }
 
   private renderData(detail: VisualActionDetail) {
@@ -308,9 +360,14 @@ class VisualModal extends LitElement {
       this.exportCSV(detail)
       return
     }
-    if (detail.action === 'focus' || detail.action === 'show-data') {
+    if (detail.action === 'focus') {
+      this.openFocus(detail, event)
+      return
+    }
+    if (detail.action === 'show-data') {
+      this.restoreFocusedVisual()
       this.detail = detail
-      this.mode = detail.action === 'focus' ? 'focus' : 'show-data'
+      this.mode = 'show-data'
     }
   }
 
@@ -323,8 +380,36 @@ class VisualModal extends LitElement {
   }
 
   private close = (): void => {
+    this.restoreFocusedVisual()
     this.mode = ''
     this.detail = null
+  }
+
+  private openFocus(detail: VisualActionDetail, event: Event): void {
+    const source = visualSourceFromEvent(event)
+    if (!source) return
+    if (this.mode === 'focus' && this.focusMount?.element === source) return
+
+    this.restoreFocusedVisual()
+    this.detail = detail
+    this.mode = 'focus'
+    this.focusSource = source
+    void this.updateComplete.then(() => this.mountFocusedVisual(source))
+  }
+
+  private mountFocusedVisual(source: HTMLElement): void {
+    if (this.mode !== 'focus' || this.focusSource !== source || this.focusMount?.element === source) return
+    const mount = mountVisualFocus(source, this, { slot: 'focus-visual' })
+    if (!mount) return
+    this.focusMount = mount
+  }
+
+  private restoreFocusedVisual(): void {
+    if (this.focusMount) {
+      restoreVisualFocus(this.focusMount)
+    }
+    this.focusMount = null
+    this.focusSource = null
   }
 
   private async copy(detail: VisualActionDetail): Promise<void> {
@@ -368,19 +453,6 @@ class VisualModal extends LitElement {
     window.setTimeout(() => {
       if (this.notice === message) this.notice = ''
     }, 1800)
-  }
-}
-
-function chartPayloadFromRows(detail: VisualActionDetail): Record<string, unknown> {
-  return {
-    id: detail.visualId,
-    title: detail.title,
-    type: 'bar',
-    data: detail.rows.map((row) => ({
-      label: stringValue(row.label),
-      series: stringValue(row.series),
-      value: Number(row.value) || 0,
-    })),
   }
 }
 

--- a/web/components/visual-modal.ts
+++ b/web/components/visual-modal.ts
@@ -34,6 +34,7 @@ class VisualModal extends LitElement {
   @state() private notice = ''
   private focusMount: VisualFocusMount<HTMLElement> | null = null
   private focusSource: HTMLElement | null = null
+  private restoreFocusTo: HTMLElement | null = null
 
   static styles = css`
     :host {
@@ -276,7 +277,7 @@ class VisualModal extends LitElement {
   disconnectedCallback(): void {
     window.removeEventListener('ld-visual-action', this.handleVisualAction as EventListener)
     window.removeEventListener('keydown', this.handleKeydown)
-    this.restoreFocusedVisual()
+    this.restoreFocusedVisual(false)
     super.disconnectedCallback()
   }
 
@@ -365,14 +366,18 @@ class VisualModal extends LitElement {
       return
     }
     if (detail.action === 'show-data') {
-      this.restoreFocusedVisual()
+      this.restoreFocusedVisual(false)
       this.detail = detail
       this.mode = 'show-data'
     }
   }
 
   private handleKeydown = (event: KeyboardEvent): void => {
-    if (event.key === 'Escape') this.close()
+    if (event.key === 'Escape') {
+      this.close()
+      return
+    }
+    if (event.key === 'Tab' && this.mode === 'focus') this.trapFocus(event)
   }
 
   private closeFromBackdrop = (event: Event): void => {
@@ -380,7 +385,7 @@ class VisualModal extends LitElement {
   }
 
   private close = (): void => {
-    this.restoreFocusedVisual()
+    this.restoreFocusedVisual(true)
     this.mode = ''
     this.detail = null
   }
@@ -390,11 +395,16 @@ class VisualModal extends LitElement {
     if (!source) return
     if (this.mode === 'focus' && this.focusMount?.element === source) return
 
-    this.restoreFocusedVisual()
+    const focusToRestore = this.deepActiveElement()
+    this.restoreFocusedVisual(false)
+    this.restoreFocusTo = focusToRestore
     this.detail = detail
     this.mode = 'focus'
     this.focusSource = source
-    void this.updateComplete.then(() => this.mountFocusedVisual(source))
+    void this.updateComplete.then(() => {
+      this.mountFocusedVisual(source)
+      this.focusInitialControl()
+    })
   }
 
   private mountFocusedVisual(source: HTMLElement): void {
@@ -404,12 +414,76 @@ class VisualModal extends LitElement {
     this.focusMount = mount
   }
 
-  private restoreFocusedVisual(): void {
+  private restoreFocusedVisual(restoreFocus: boolean): void {
+    const focusToRestore = this.restoreFocusTo
     if (this.focusMount) {
       restoreVisualFocus(this.focusMount)
     }
     this.focusMount = null
     this.focusSource = null
+    this.restoreFocusTo = null
+    if (restoreFocus && focusToRestore?.isConnected) {
+      queueMicrotask(() => focusToRestore.focus({ preventScroll: true }))
+    }
+  }
+
+  private focusInitialControl(): void {
+    this.renderRoot.querySelector<HTMLButtonElement>('.focus-close')?.focus({ preventScroll: true })
+  }
+
+  private trapFocus(event: KeyboardEvent): void {
+    const focusable = this.focusableElements()
+    if (focusable.length === 0) {
+      event.preventDefault()
+      return
+    }
+
+    const active = this.deepActiveElement()
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const activeInsideModal = Boolean(active && focusable.includes(active))
+    if (event.shiftKey && (!activeInsideModal || active === first)) {
+      event.preventDefault()
+      last.focus({ preventScroll: true })
+      return
+    }
+    if (!event.shiftKey && (!activeInsideModal || active === last)) {
+      event.preventDefault()
+      first.focus({ preventScroll: true })
+    }
+  }
+
+  private focusableElements(): HTMLElement[] {
+    return [
+      ...this.deepFocusableElements(this.renderRoot),
+      ...(this.focusMount ? this.deepFocusableElements(this.focusMount.element) : []),
+    ]
+  }
+
+  private deepFocusableElements(root: ParentNode): HTMLElement[] {
+    const selector = [
+      'button:not([disabled])',
+      'a[href]',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(',')
+    const elements: HTMLElement[] = []
+    root.querySelectorAll<HTMLElement>(selector).forEach((element) => {
+      elements.push(element)
+      if (element.shadowRoot) elements.push(...this.deepFocusableElements(element.shadowRoot))
+    })
+    root.querySelectorAll<HTMLElement>('*').forEach((element) => {
+      if (element.shadowRoot) elements.push(...this.deepFocusableElements(element.shadowRoot))
+    })
+    return [...new Set(elements)]
+  }
+
+  private deepActiveElement(): HTMLElement | null {
+    let active = document.activeElement
+    while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement
+    return active instanceof HTMLElement ? active : null
   }
 
   private async copy(detail: VisualActionDetail): Promise<void> {


### PR DESCRIPTION
## Summary
- Reparent the exact chart/table element into focus mode and restore it in place on close
- Add first-class expand buttons beside the visual/table overflow menus
- Restart chart/table observers after reparenting and fix the focused table row-window CSRF path

## Testing
- npm run build:charts
- npm run build:table
- npm run build:visual-modal
- npm run test:visual-modal
- task ci
- Playwright E2E: expanded chart renders, expanded table scrolls from 1-25 to 9,977-10,000 and /commands/table-window returns 204
