### PR TITLE
Simplify generate task wiring

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,9 +68,9 @@ tasks:
   generate:
     desc: Generate all checked-out derived code needed for local development
     cmds:
-      - task api:generate
-      - task schema:generate
-      - task ui-signals:generate
+      - task: api:generate
+      - task: schema:generate
+      - task: ui-signals:generate
 
   api:generate:
     desc: Generate headless API contract artifacts and APIGen Go surfaces


### PR DESCRIPTION
## Summary
- replace shell-style nested Task calls in `generate` with native Task subtask entries
- preserve the existing sequential generation order and checksum up-to-date behavior

## Verification
- `task --dry generate`
- `/usr/bin/time -p task generate` -> warm `real 0.02`
- `git diff --check`