### PR TITLE
Add deployment-backed asset versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ For file and table paths, LibreDash infers `format` from clear extensions such a
 
 ## Deploy
 
+Development and production use the same deployment path. Start the dev server, then explicitly deploy the project to it:
+
+```sh
+task dev
+task deploy:dev
+```
+
+After YAML changes, run `task deploy:dev` again and refresh or navigate the UI. The server reads workspace assets, details, lineage, and versions from the active deployment records.
+
 Production mode serves the active deployed BI-as-code bundle from `.libredash` by default:
 
 ```sh
@@ -242,8 +251,10 @@ export LIBREDASH_API_TOKEN_ONLY_AUTH=1 # or configure Azure below
 export LIBREDASH_CSRF_KEY=<32+ byte secret>
 libredash serve --production
 libredash admin bootstrap
-libredash deploy --target http://localhost:8080 --token <token> --workspace sales --catalog dashboards/libredash.yaml --auto-approve
+libredash deploy --project dashboards/libredash.yaml --target http://localhost:8080 --token <token> --environment prod --all-workspaces --auto-approve
 ```
+
+Use `--workspace <id>` instead of `--all-workspaces` for a targeted deployment.
 
 Useful env vars:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,15 @@ tasks:
     cmds:
       - ./scripts/dev-server.sh status
 
+  deploy:dev:
+    desc: Deploy all project workspaces to the managed dev server
+    cmds:
+      - |
+        test -f .tmp/dev-server.port || { echo "Dev server port file missing. Run task dev first."; exit 1; }
+        PORT="$(cat .tmp/dev-server.port)"
+        curl -fsS "http://localhost:${PORT}/workspaces" >/dev/null || { echo "Dev server is not running on http://localhost:${PORT}. Run task dev first."; exit 1; }
+        go run ./cmd/libredash deploy --project dashboards/libredash.yaml --target "http://localhost:${PORT}" --token dev --environment dev --all-workspaces --auto-approve
+
   dev:quack:status:
     desc: Show managed LibreDash dev server status with the local Quack profile
     cmds:

--- a/internal/app/agent_tools_test.go
+++ b/internal/app/agent_tools_test.go
@@ -444,7 +444,11 @@ func TestAPIGenAgentToolsExposeTypeSpecArgumentNamesAndBodyFields(t *testing.T) 
 }
 
 func TestAPIGenAgentToolDispatchesThroughGeneratedOperation(t *testing.T) {
-	server := NewWithOptions(manyEdgesMetrics{}, Options{DefaultWorkspaceID: "test"})
+	catalog := testAgentAssetCatalogFromProvider(t, manyEdgesMetrics{})
+	server := NewWithOptions(manyEdgesMetrics{}, Options{
+		AssetCatalog:       fakeAssetCatalogReader{catalog: catalog},
+		DefaultWorkspaceID: "test",
+	})
 	tools := server.agentAPIGenToolDefinitions(agentapp.Scope{WorkspaceID: "test", PrincipalID: "principal"})
 	var listAssets agent.ToolDefinition
 	for _, tool := range tools {
@@ -562,7 +566,11 @@ func TestAPIGenAgentAssetDescribeAndLineageToolsUseTypeSpecContracts(t *testing.
 }
 
 func TestAPIGenAgentListToolInjectsDefaultLimit(t *testing.T) {
-	server := NewWithOptions(manyEdgesMetrics{}, Options{DefaultWorkspaceID: "test"})
+	catalog := testAgentAssetCatalogFromProvider(t, manyEdgesMetrics{})
+	server := NewWithOptions(manyEdgesMetrics{}, Options{
+		AssetCatalog:       fakeAssetCatalogReader{catalog: catalog},
+		DefaultWorkspaceID: "test",
+	})
 	tools := server.agentAPIGenToolDefinitions(agentapp.Scope{WorkspaceID: "test", PrincipalID: "principal"})
 	var listEdges agent.ToolDefinition
 	for _, tool := range tools {
@@ -853,6 +861,19 @@ func testAgentAssetCatalog(t *testing.T) workspace.AssetCatalog {
 		},
 	}
 	catalog, err := workspace.DecodeAssetCatalog(graph)
+	if err != nil {
+		t.Fatalf("decode asset catalog: %v", err)
+	}
+	return catalog
+}
+
+func testAgentAssetCatalogFromProvider(t *testing.T, provider workspaceAssetGraphProvider) workspace.AssetCatalog {
+	t.Helper()
+	assets, edges, ok := provider.WorkspaceAssets("test", "deploy_a")
+	if !ok {
+		t.Fatal("workspace assets unavailable")
+	}
+	catalog, err := workspace.DecodeAssetCatalog(workspace.AssetGraph{Assets: assets, Edges: edges})
 	if err != nil {
 		t.Fatalf("decode asset catalog: %v", err)
 	}

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"html"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -57,6 +58,10 @@ type testRuntimeProvider struct {
 type testWorkspaceAssetRuntime struct {
 	assets []workspace.Asset
 	edges  []workspace.AssetEdge
+}
+
+type workspaceAssetGraphProvider interface {
+	WorkspaceAssets(workspaceID, deploymentID string) ([]workspace.Asset, []workspace.AssetEdge, bool)
 }
 
 func (runtimeAssetMetrics) WorkspaceAssets(workspaceID, deploymentID string) ([]workspace.Asset, []workspace.AssetEdge, bool) {
@@ -755,7 +760,7 @@ func TestWorkspacePageDefaultsToTopLevelAssets(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
-	body := rec.Body.String()
+	body := html.UnescapeString(rec.Body.String())
 	for _, want := range []string{"Executive Sales", "Sales Semantic Model", "orders"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("workspace page missing top-level asset %q:\n%s", want, body)
@@ -845,7 +850,7 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
-	body := rec.Body.String()
+	body := html.UnescapeString(rec.Body.String())
 	for _, want := range []string{"<ld-connections-page", "Connections", "Connection", "Source", "assetList", "Local CSV files for the Olist ecommerce demo dataset.", "orders"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("connections page missing %q:\n%s", want, body)
@@ -880,7 +885,7 @@ func TestConnectionsPageFiltersSources(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
-	body := rec.Body.String()
+	body := html.UnescapeString(rec.Body.String())
 	for _, want := range []string{"Source", "orders", `/connections/`, `/sources/`} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("source-filtered connections page missing %q:\n%s", want, body)
@@ -1055,7 +1060,47 @@ func TestWorkspaceSourceAssetRedirectsToConnectionScopedSourceSurface(t *testing
 	}
 }
 
-func TestConnectionsPageFallsBackToRuntimeAssetsWithoutActiveDeployment(t *testing.T) {
+func TestWorkspaceAssetVersionsRouteRendersDeploymentBackedVersions(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+	assetID := activeAssetIDByType(t, store, "test", "dashboard")
+
+	req := httptest.NewRequest(http.MethodGet, "/workspaces/test/assets/"+assetID+"/versions", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("versions status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := html.UnescapeString(rec.Body.String())
+	for _, want := range []string{
+		`"activeSection":"versions"`,
+		`"label":"Versions"`,
+		`"currentDeploymentId":"dep_`,
+		`"header":"Asset hash"`,
+		`"header":"Deployment digest"`,
+		`"label":"current"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("versions page missing %q:\n%s", want, body)
+		}
+	}
+	for _, forbidden := range []string{
+		`"version":"local"`,
+		`"label":"local"`,
+		`/updates?section=versions`,
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("versions page rendered forbidden %q:\n%s", forbidden, body)
+		}
+	}
+}
+
+func TestConnectionsPageDoesNotFallbackToRuntimeAssetsWithoutActiveDeployment(t *testing.T) {
 	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
 	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
@@ -1070,9 +1115,12 @@ func TestConnectionsPageFallsBackToRuntimeAssetsWithoutActiveDeployment(t *testi
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"Connections", "remote_quack", "Runtime connection"} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("connections page missing runtime asset %q:\n%s", want, body)
+	if !strings.Contains(body, "Connections") {
+		t.Fatalf("connections page missing heading:\n%s", body)
+	}
+	for _, forbidden := range []string{"remote_quack", "Runtime connection"} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("connections page rendered runtime-only asset %q without active deployment:\n%s", forbidden, body)
 		}
 	}
 }
@@ -1564,6 +1612,35 @@ func seedActiveDeployment(t *testing.T, store *platform.Store, workspaceID strin
 	}
 }
 
+func seedActiveDeploymentFromWorkspaceAssets(t *testing.T, store *platform.Store, workspaceID string, provider workspaceAssetGraphProvider) deployment.ID {
+	t.Helper()
+	ctx := context.Background()
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(ctx, workspace.EnsureInput{ID: workspace.WorkspaceID(workspaceID), Title: workspaceID}); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+	deploymentRepo := deploymentsqlite.NewRepository(store.SQLDB())
+	created, err := deploymentRepo.Create(ctx, deployment.CreateInput{WorkspaceID: deployment.WorkspaceID(workspaceID), CreatedBy: "tester"})
+	if err != nil {
+		t.Fatalf("create deployment: %v", err)
+	}
+	assets, edges, ok := provider.WorkspaceAssets(workspaceID, string(created.ID))
+	if !ok {
+		t.Fatal("workspace asset graph unavailable")
+	}
+	validation := deployment.Validation{
+		Digest:       "digest-" + string(created.ID),
+		ManifestJSON: "{}",
+		Graph:        workspace.AssetGraph{Assets: assets, Edges: edges},
+	}
+	if _, err := deploymentRepo.SaveValidated(ctx, created.ID, validation, zeroArtifact(created.ID, workspaceID)); err != nil {
+		t.Fatalf("validate deployment: %v", err)
+	}
+	if _, err := deploymentRepo.Activate(ctx, deployment.WorkspaceID(workspaceID), deployment.DefaultEnvironment, created.ID); err != nil {
+		t.Fatalf("activate deployment: %v", err)
+	}
+	return created.ID
+}
+
 func seedEnvironmentAssetDeployment(t *testing.T, store *platform.Store, workspaceID string, environment deployment.Environment, dashboardTitle, connectionTitle string) {
 	t.Helper()
 	ctx := context.Background()
@@ -1626,6 +1703,25 @@ func activeAssetID(t *testing.T, store *platform.Store, workspaceID, typ, key st
 		}
 	}
 	t.Fatalf("asset %s %q not found in active graph", typ, key)
+	return ""
+}
+
+func activeAssetIDByType(t *testing.T, store *platform.Store, workspaceID, typ string) string {
+	t.Helper()
+	repo := workspacesqlite.NewRepository(store.SQLDB())
+	graph, ok, err := repo.ActiveDeploymentGraph(context.Background(), workspace.WorkspaceID(workspaceID), string(deployment.DefaultEnvironment))
+	if err != nil {
+		t.Fatalf("active deployment graph: %v", err)
+	}
+	if !ok {
+		t.Fatalf("workspace %q has no active deployment graph", workspaceID)
+	}
+	for _, asset := range graph.Assets {
+		if string(asset.Type) == typ {
+			return string(asset.ID)
+		}
+	}
+	t.Fatalf("asset type %s not found in active graph", typ)
 	return ""
 }
 

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -927,6 +927,7 @@ func TestDashboardRefreshCommandPersistsMaterializationRun(t *testing.T) {
 
 func TestWorkspaceAssetUpdatesStreamsInitialRefreshState(t *testing.T) {
 	store := testStore(t)
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", emptyPageRuntimeAssetMetrics{})
 	server := NewWithOptions(emptyPageRuntimeAssetMetrics{}, Options{Store: store, DefaultWorkspaceID: "test"})
 	repo := materialize.NewSQLRunRepository(store.SQLDB())
 	queued, err := repo.CreateRun(context.Background(), materialize.RunInput{WorkspaceID: "test", ModelID: "olist"})
@@ -971,6 +972,7 @@ func TestWorkspaceAssetUpdatesStreamsInitialRefreshState(t *testing.T) {
 
 func TestWorkspaceAssetDetailsUpdatesExcludeRefreshesTableAndUnusedRefreshFields(t *testing.T) {
 	store := testStore(t)
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", emptyPageRuntimeAssetMetrics{})
 	server := NewWithOptions(emptyPageRuntimeAssetMetrics{}, Options{Store: store, DefaultWorkspaceID: "test"})
 	assetID := workspace.NewAssetID(workspace.AssetTypeSemanticModel, "olist")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
@@ -1011,6 +1013,7 @@ func TestWorkspaceAssetDetailsUpdatesExcludeRefreshesTableAndUnusedRefreshFields
 func TestWorkspaceAssetRefreshCommandPublishesRunningAndFinalState(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", emptyPageRuntimeAssetMetrics{})
 	principal := testPrincipal(t, ctx, store, "owner@example.com", "Owner", "owner")
 	token := testAPIToken(t, ctx, store, principal.ID, "workspace-refresh")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
@@ -1050,8 +1053,10 @@ func TestWorkspaceAssetRefreshCommandPublishesRunningAndFinalState(t *testing.T)
 
 func TestWorkspaceAssetRefreshCommandPublishesFailedError(t *testing.T) {
 	store := testStore(t)
+	metrics := failingRefreshAssetMetrics{}
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", metrics)
 	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
-	server := NewWithOptions(failingRefreshAssetMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
+	server := NewWithOptions(metrics, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
 	assetID := workspace.NewAssetID(workspace.AssetTypeSemanticModel, "olist")
 	updates, unsubscribe := server.broker.Subscribe(workspaceAssetStreamID("test", string(assetID), "refreshes"))
 	defer unsubscribe()
@@ -1082,10 +1087,11 @@ func TestWorkspaceAssetRefreshCommandPublishesFailedError(t *testing.T) {
 func TestWorkspaceModelTableRefreshCommandPersistsDirectAndDependencyRuns(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
+	metrics := &dependentModelTableMetrics{}
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", metrics)
 	principal := testPrincipal(t, ctx, store, "owner@example.com", "Owner", "owner")
 	token := testAPIToken(t, ctx, store, principal.ID, "workspace-table-refresh")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
-	metrics := &dependentModelTableMetrics{}
 	server := NewWithOptions(metrics, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
 	assetID := workspace.NewAssetID(workspace.AssetTypeModelTable, "olist.order_summary")
 	path := "/workspaces/test/assets/" + string(assetID) + "/refresh-materializations"
@@ -1214,10 +1220,12 @@ func TestMaterializationRunAPIMalformedModelTableTargetFailsPersistedRun(t *test
 func TestWorkspaceSemanticModelRefreshFailsWhenGraphMissing(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
+	metrics := missingSemanticModelAssetMetrics{}
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", metrics)
 	principal := testPrincipal(t, ctx, store, "owner@example.com", "Owner", "owner")
 	token := testAPIToken(t, ctx, store, principal.ID, "workspace-semantic-refresh-missing-graph")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
-	server := NewWithOptions(missingSemanticModelAssetMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
+	server := NewWithOptions(metrics, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
 	assetID := workspace.NewAssetID(workspace.AssetTypeSemanticModel, "olist")
 	path := "/workspaces/test/assets/" + string(assetID) + "/refresh-materializations"
 	req := httptest.NewRequest(http.MethodPost, path, nil)
@@ -1242,10 +1250,11 @@ func TestWorkspaceSemanticModelRefreshFailsWhenGraphMissing(t *testing.T) {
 func TestWorkspaceModelTableRefreshMarksDependencyAndRootFailedWhenDependencyFails(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
+	metrics := &failingDependencyModelTableMetrics{}
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", metrics)
 	principal := testPrincipal(t, ctx, store, "owner@example.com", "Owner", "owner")
 	token := testAPIToken(t, ctx, store, principal.ID, "workspace-table-refresh-failure")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
-	metrics := &failingDependencyModelTableMetrics{}
 	server := NewWithOptions(metrics, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
 	assetID := workspace.NewAssetID(workspace.AssetTypeModelTable, "olist.order_summary")
 	path := "/workspaces/test/assets/" + string(assetID) + "/refresh-materializations"
@@ -1281,10 +1290,11 @@ func TestWorkspaceModelTableRefreshMarksDependencyAndRootFailedWhenDependencyFai
 func TestWorkspaceSemanticModelRefreshCommandPersistsTableChildRuns(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
+	metrics := &dependentModelTableMetrics{}
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", metrics)
 	principal := testPrincipal(t, ctx, store, "owner@example.com", "Owner", "owner")
 	token := testAPIToken(t, ctx, store, principal.ID, "workspace-semantic-refresh")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
-	metrics := &dependentModelTableMetrics{}
 	server := NewWithOptions(metrics, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
 	assetID := workspace.NewAssetID(workspace.AssetTypeSemanticModel, "olist")
 	path := "/workspaces/test/assets/" + string(assetID) + "/refresh-materializations"

--- a/internal/app/workspace_metrics.go
+++ b/internal/app/workspace_metrics.go
@@ -127,7 +127,7 @@ func (m multiWorkspaceMetrics) WorkspaceAssets(workspaceID, deploymentID string)
 	if !ok {
 		return nil, nil, false
 	}
-	provider, ok := metrics.(workspace.RuntimeAssetGraphProvider)
+	provider, ok := metrics.(workspaceAssetRuntime)
 	if !ok {
 		return nil, nil, false
 	}
@@ -251,7 +251,7 @@ func (m *dynamicRuntimeMetrics) WorkspaceAssets(workspaceID, deploymentID string
 	if !ok {
 		return nil, nil, false
 	}
-	provider, ok := metrics.(workspace.RuntimeAssetGraphProvider)
+	provider, ok := metrics.(workspaceAssetRuntime)
 	if !ok {
 		return nil, nil, false
 	}

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -159,9 +159,14 @@ func (s *Server) workspaceAssetSection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	refresh.CSRFToken = csrfToken(r, s.auth)
+	versions, err := s.assetVersionsStateForSection(r.Context(), workspaceID, string(s.requestDeploymentEnvironment(r)), selected, section)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if err := ui.WorkspaceAssetPageWithRefresh(s.metrics.Catalog(), workspace, selected, assets, edges, section, s.currentRoleLabel(r), refresh).Render(w); err != nil {
+	if err := ui.WorkspaceAssetPageWithRefreshAndVersions(s.metrics.Catalog(), workspace, selected, assets, edges, section, s.currentRoleLabel(r), refresh, versions).Render(w); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -387,6 +392,37 @@ func (s *Server) assetRefreshStateForContext(ctx context.Context, workspaceID st
 	return state, nil
 }
 
+func (s *Server) assetVersionsStateForSection(ctx context.Context, workspaceID, environment string, asset workspace.AssetView, section string) (ui.AssetVersionsState, error) {
+	state := ui.AssetVersionsState{CurrentDeploymentID: asset.DeploymentID}
+	if section != "versions" {
+		return state, nil
+	}
+	if s.store == nil {
+		return state, nil
+	}
+	repo, err := s.workspaceRepository()
+	if err != nil || repo == nil {
+		return state, err
+	}
+	versions, err := repo.AssetVersions(ctx, workspace.WorkspaceID(workspaceID), environment, workspace.AssetID(asset.ID))
+	if err != nil {
+		return state, err
+	}
+	state.Versions = make([]ui.AssetVersionState, 0, len(versions))
+	for _, version := range versions {
+		state.Versions = append(state.Versions, ui.AssetVersionState{
+			DeploymentID: string(version.DeploymentID),
+			Status:       version.Status,
+			Digest:       version.Digest,
+			CreatedBy:    version.CreatedBy,
+			CreatedAt:    version.CreatedAt,
+			ActivatedAt:  version.ActivatedAt,
+			ContentHash:  version.ContentHash,
+		})
+	}
+	return state, nil
+}
+
 func uiRefreshRuns(runs []materialize.RunRecord) []ui.AssetRefreshRun {
 	out := make([]ui.AssetRefreshRun, 0, len(runs))
 	for _, run := range runs {
@@ -487,9 +523,14 @@ func (s *Server) connectionSourceAssetSection(w http.ResponseWriter, r *http.Req
 		return
 	}
 	workspace := platformAssetWorkspaceView()
+	versions, err := s.assetVersionsStateForSection(r.Context(), source.WorkspaceID, string(s.requestDeploymentEnvironment(r)), source, section)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if err := ui.ConnectionSourceAssetPage(s.metrics.Catalog(), workspace, connection, source, assets, edges, section, s.currentRoleLabel(r)).Render(w); err != nil {
+	if err := ui.ConnectionSourceAssetPageWithVersions(s.metrics.Catalog(), workspace, connection, source, assets, edges, section, s.currentRoleLabel(r), versions).Render(w); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -538,9 +579,14 @@ func (s *Server) connectionAssetSection(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	workspace := platformAssetWorkspaceView()
+	versions, err := s.assetVersionsStateForSection(r.Context(), selected.WorkspaceID, string(s.requestDeploymentEnvironment(r)), selected, section)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if err := ui.ConnectionAssetPage(s.metrics.Catalog(), workspace, selected, assets, edges, section, s.currentRoleLabel(r)).Render(w); err != nil {
+	if err := ui.ConnectionAssetPageWithVersions(s.metrics.Catalog(), workspace, selected, assets, edges, section, s.currentRoleLabel(r), versions).Render(w); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -956,9 +1002,6 @@ func (s *Server) workspaceAssetCatalogReader() (workspace.AssetCatalogReader, er
 		return nil, err
 	}
 	service := workspace.NewAssetCatalogService(repo)
-	if provider, ok := s.metrics.(workspace.RuntimeAssetGraphProvider); ok {
-		service.WithRuntimeProvider(provider)
-	}
 	s.assetCatalog = service
 	return s.assetCatalog, nil
 }

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -10,12 +10,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/Yacobolo/libredash/internal/api"
 	"github.com/Yacobolo/libredash/internal/deployment"
 	deploymentfs "github.com/Yacobolo/libredash/internal/deployment/filesystem"
+	"github.com/Yacobolo/libredash/internal/workspace"
 	workspacecompiler "github.com/Yacobolo/libredash/internal/workspace/compiler"
 	"github.com/spf13/cobra"
 )
@@ -32,6 +34,7 @@ func deployCommand(ctx context.Context, opts *rootOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.token, "token", "", "API token")
 	cmd.Flags().StringVar(&opts.catalog, "project", filepath.Join("dashboards", "libredash.yaml"), "project path")
 	cmd.Flags().StringVar(&opts.environment, "environment", "dev", "deployment environment")
+	cmd.Flags().BoolVar(&opts.allWorkspaces, "all-workspaces", false, "deploy every workspace in the project")
 	cmd.Flags().BoolVar(&opts.autoApprove, "auto-approve", false, "approve and activate the deployment without prompting")
 	return cmd
 }
@@ -79,9 +82,18 @@ func rollbackCommand(ctx context.Context, opts *rootOptions) *cobra.Command {
 	return cmd
 }
 
+type workspaceDeployPlan struct {
+	workspaceID    string
+	workspaceTitle string
+	activeGraph    workspace.AssetGraph
+}
+
 func runDeploy(ctx context.Context, opts *rootOptions) error {
-	if opts.workspaceID == "" {
-		return fmt.Errorf("deploy requires --workspace")
+	if opts.workspaceID != "" && opts.allWorkspaces {
+		return fmt.Errorf("deploy accepts either --workspace or --all-workspaces, not both")
+	}
+	if opts.workspaceID == "" && !opts.allWorkspaces {
+		return fmt.Errorf("deploy requires --workspace or --all-workspaces")
 	}
 	target, token, err := clientTargetAndToken(opts)
 	if err != nil {
@@ -91,30 +103,60 @@ func runDeploy(ctx context.Context, opts *rootOptions) error {
 	if err != nil {
 		return err
 	}
-	workspaceProject, ok := project.Workspaces[opts.workspaceID]
-	if !ok {
-		return fmt.Errorf("project %q has no workspace %q", opts.catalog, opts.workspaceID)
-	}
-	activeGraph, err := fetchActiveWorkspaceGraph(ctx, opts)
-	if err != nil {
-		return err
-	}
-	plan, err := workspacecompiler.PlanProjectAgainstGraph(opts.catalog, opts.workspaceID, activeGraph)
-	if err != nil {
-		return err
-	}
-	if err := renderProjectPlan(os.Stdout, plan); err != nil {
-		return err
+	workspaceIDs := deployWorkspaceIDs(opts, project.Workspaces)
+	plans := make([]workspaceDeployPlan, 0, len(workspaceIDs))
+	for _, workspaceID := range workspaceIDs {
+		workspaceProject, ok := project.Workspaces[workspaceID]
+		if !ok {
+			return fmt.Errorf("project %q has no workspace %q", opts.catalog, workspaceID)
+		}
+		activeGraph, err := fetchActiveWorkspaceGraphForWorkspace(ctx, opts, workspaceID)
+		if err != nil {
+			return err
+		}
+		plan, err := workspacecompiler.PlanProjectAgainstGraph(opts.catalog, workspaceID, activeGraph)
+		if err != nil {
+			return err
+		}
+		if err := renderProjectPlan(os.Stdout, plan); err != nil {
+			return err
+		}
+		plans = append(plans, workspaceDeployPlan{
+			workspaceID:    workspaceID,
+			workspaceTitle: workspaceProject.Title,
+			activeGraph:    activeGraph,
+		})
 	}
 	if err := confirmDeploy(opts, os.Stdin, os.Stdout); err != nil {
 		return err
 	}
+	for _, plan := range plans {
+		if err := deployWorkspace(ctx, opts, target, token, plan); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deployWorkspaceIDs(opts *rootOptions, projectWorkspaces map[string]*workspacecompiler.WorkspaceProject) []string {
+	if !opts.allWorkspaces {
+		return []string{opts.workspaceID}
+	}
+	workspaceIDs := make([]string, 0, len(projectWorkspaces))
+	for workspaceID := range projectWorkspaces {
+		workspaceIDs = append(workspaceIDs, workspaceID)
+	}
+	sort.Strings(workspaceIDs)
+	return workspaceIDs
+}
+
+func deployWorkspace(ctx context.Context, opts *rootOptions, target, token string, plan workspaceDeployPlan) error {
 	createBody, _ := json.Marshal(map[string]any{
-		"title":       workspaceProject.Title,
+		"title":       plan.workspaceTitle,
 		"environment": cliEnvironment(opts),
 	})
 	var created api.DeploymentResponse
-	workspacePathParams := map[string]string{"workspace": opts.workspaceID}
+	workspacePathParams := map[string]string{"workspace": plan.workspaceID}
 	createURL, err := apiOperationURL(target, "createDeployment", workspacePathParams, environmentQuery(opts, nil))
 	if err != nil {
 		return err
@@ -124,11 +166,11 @@ func runDeploy(ctx context.Context, opts *rootOptions) error {
 	}
 	var buf bytes.Buffer
 	var digest string
-	_, digest, err = deploymentfs.PackProjectAgainstGraphForEnvironment(opts.catalog, opts.workspaceID, deployment.Environment(cliEnvironment(opts)), deployment.ID(created.ID), activeGraph, &buf)
+	_, digest, err = deploymentfs.PackProjectAgainstGraphForEnvironment(opts.catalog, plan.workspaceID, deployment.Environment(cliEnvironment(opts)), deployment.ID(created.ID), plan.activeGraph, &buf)
 	if err != nil {
 		return err
 	}
-	uploadURL, err := apiOperationURL(target, "uploadDeploymentArtifact", map[string]string{"workspace": opts.workspaceID, "deployment": created.ID}, environmentQuery(opts, nil))
+	uploadURL, err := apiOperationURL(target, "uploadDeploymentArtifact", map[string]string{"workspace": plan.workspaceID, "deployment": created.ID}, environmentQuery(opts, nil))
 	if err != nil {
 		return err
 	}
@@ -136,7 +178,7 @@ func runDeploy(ctx context.Context, opts *rootOptions) error {
 		return err
 	}
 	var validated api.DeploymentResponse
-	validateURL, err := apiOperationURL(target, "validateDeployment", map[string]string{"workspace": opts.workspaceID, "deployment": created.ID}, environmentQuery(opts, nil))
+	validateURL, err := apiOperationURL(target, "validateDeployment", map[string]string{"workspace": plan.workspaceID, "deployment": created.ID}, environmentQuery(opts, nil))
 	if err != nil {
 		return err
 	}
@@ -144,14 +186,14 @@ func runDeploy(ctx context.Context, opts *rootOptions) error {
 		return err
 	}
 	var activated api.DeploymentResponse
-	activateURL, err := apiOperationURL(target, "activateDeployment", map[string]string{"workspace": opts.workspaceID, "deployment": created.ID}, environmentQuery(opts, nil))
+	activateURL, err := apiOperationURL(target, "activateDeployment", map[string]string{"workspace": plan.workspaceID, "deployment": created.ID}, environmentQuery(opts, nil))
 	if err != nil {
 		return err
 	}
 	if err := doJSON(ctx, http.MethodPost, activateURL, token, nil, &activated); err != nil {
 		return err
 	}
-	fmt.Printf("deployed %s environment=%s digest=%s localDigest=%s status=%s\n", activated.ID, activated.Environment, activated.Digest, digest, activated.Status)
+	fmt.Printf("deployed %s environment=%s workspace=%s digest=%s localDigest=%s status=%s\n", activated.ID, activated.Environment, plan.workspaceID, activated.Digest, digest, activated.Status)
 	return nil
 }
 

--- a/internal/cli/deploy_test.go
+++ b/internal/cli/deploy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -94,4 +95,262 @@ func TestDeployAutoApproveActivatesAfterPlan(t *testing.T) {
 			t.Fatalf("sequence = %#v, want prefix %#v", sequence, wantPrefix)
 		}
 	}
+}
+
+func TestDeployRequiresExactlyOneWorkspaceSelection(t *testing.T) {
+	err := runDeploy(context.Background(), &rootOptions{})
+	if err == nil || !strings.Contains(err.Error(), "--workspace or --all-workspaces") {
+		t.Fatalf("runDeploy() error = %v, want missing workspace selection error", err)
+	}
+
+	err = runDeploy(context.Background(), &rootOptions{workspaceID: "sales", allWorkspaces: true})
+	if err == nil || !strings.Contains(err.Error(), "either --workspace or --all-workspaces") {
+		t.Fatalf("runDeploy() error = %v, want mutually exclusive selection error", err)
+	}
+}
+
+func TestDeployAllWorkspacesDeploysSortedWorkspaces(t *testing.T) {
+	var sequence []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sequence = append(sequence, r.Method+" "+r.URL.Path)
+		workspaceID := workspaceIDFromPath(r.URL.Path)
+		deploymentID := "dep_" + workspaceID
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/assets"):
+			writeCLIJSON(t, w, map[string]any{"items": []map[string]any{}, "page": map[string]any{"nextCursor": ""}})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/asset-edges"):
+			writeCLIJSON(t, w, map[string]any{"items": []map[string]any{}, "page": map[string]any{"nextCursor": ""}})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/deployments"):
+			writeCLIJSON(t, w, map[string]any{"id": deploymentID, "workspaceId": workspaceID, "environment": "dev", "status": "pending"})
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/deployments/"+deploymentID+"/artifact"):
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/deployments/"+deploymentID+"/validate"):
+			writeCLIJSON(t, w, map[string]any{"id": deploymentID, "workspaceId": workspaceID, "environment": "dev", "status": "validated", "digest": "sha256:remote"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/deployments/"+deploymentID+"/activate"):
+			writeCLIJSON(t, w, map[string]any{"id": deploymentID, "workspaceId": workspaceID, "environment": "dev", "status": "active", "digest": "sha256:remote"})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	output := captureStdout(t, func() {
+		if err := runDeploy(context.Background(), &rootOptions{
+			target:        server.URL,
+			token:         "token",
+			catalog:       writeDeployProjectFixture(t),
+			allWorkspaces: true,
+			autoApprove:   true,
+		}); err != nil {
+			t.Fatalf("runDeploy() error = %v", err)
+		}
+	})
+	for _, want := range []string{"workspace operations", "workspace sales", "deployed dep_operations", "deployed dep_sales"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("deploy output missing %q:\n%s", want, output)
+		}
+	}
+	wantPrefix := []string{
+		"GET /api/v1/workspaces/operations/assets",
+		"GET /api/v1/workspaces/operations/asset-edges",
+		"GET /api/v1/workspaces/sales/assets",
+		"GET /api/v1/workspaces/sales/asset-edges",
+		"POST /api/v1/workspaces/operations/deployments",
+		"PUT /api/v1/workspaces/operations/deployments/dep_operations/artifact",
+		"POST /api/v1/workspaces/operations/deployments/dep_operations/validate",
+		"POST /api/v1/workspaces/operations/deployments/dep_operations/activate",
+		"POST /api/v1/workspaces/sales/deployments",
+		"PUT /api/v1/workspaces/sales/deployments/dep_sales/artifact",
+		"POST /api/v1/workspaces/sales/deployments/dep_sales/validate",
+		"POST /api/v1/workspaces/sales/deployments/dep_sales/activate",
+	}
+	for i, want := range wantPrefix {
+		if len(sequence) <= i || sequence[i] != want {
+			t.Fatalf("sequence = %#v, want prefix %#v", sequence, wantPrefix)
+		}
+	}
+}
+
+func writeDeployProjectFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	files := map[string]string{
+		"libredash.yaml": `
+apiVersion: libredash.dev/v1
+kind: Project
+metadata:
+  name: cli-test
+spec:
+  connections:
+    include:
+      - connections/*.yaml
+  sources:
+    include:
+      - sources/*.yaml
+  workspaces:
+    include:
+      - workspaces/*/workspace.yaml
+`,
+		"connections/olist.yaml": `
+apiVersion: libredash.dev/v1
+kind: Connection
+metadata:
+  name: olist
+spec:
+  kind: local
+`,
+		"sources/olist.orders.yaml": `
+apiVersion: libredash.dev/v1
+kind: Source
+metadata:
+  name: olist.orders
+spec:
+  connection: olist
+  path: orders.csv
+  fields:
+    order_id:
+      type: string
+    order_status:
+      type: string
+`,
+		"workspaces/operations/workspace.yaml": deployWorkspaceYAML("operations"),
+		"workspaces/operations/models/orders.yaml": `
+apiVersion: libredash.dev/v1
+kind: ModelTable
+metadata:
+  workspace: operations
+  name: orders
+spec:
+  primaryKey: order_id
+  sources:
+    - olist.orders
+  fields:
+    order_id:
+      label: ID
+      type: string
+  transform:
+    sql: |
+      SELECT order_id, order_status FROM source."olist.orders"
+`,
+		"workspaces/operations/semantic-models/operations.yaml": deploySemanticModelYAML("operations"),
+		"workspaces/operations/dashboards/operations.yaml":      deployDashboardYAML("operations"),
+		"workspaces/sales/workspace.yaml":                       deployWorkspaceYAML("sales"),
+		"workspaces/sales/models/orders.yaml": `
+apiVersion: libredash.dev/v1
+kind: ModelTable
+metadata:
+  workspace: sales
+  name: orders
+spec:
+  primaryKey: order_id
+  sources:
+    - olist.orders
+  fields:
+    order_id:
+      label: ID
+      type: string
+  transform:
+    sql: |
+      SELECT order_id, order_status FROM source."olist.orders"
+`,
+		"workspaces/sales/semantic-models/sales.yaml": deploySemanticModelYAML("sales"),
+		"workspaces/sales/dashboards/sales.yaml":      deployDashboardYAML("sales"),
+	}
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return filepath.Join(dir, "libredash.yaml")
+}
+
+func deployWorkspaceYAML(workspaceID string) string {
+	return `
+apiVersion: libredash.dev/v1
+kind: Workspace
+metadata:
+  name: ` + workspaceID + `
+  title: ` + workspaceID + `
+spec:
+  uses:
+    sources:
+      - olist.orders
+  models:
+    include:
+      - models/*.yaml
+  semanticModels:
+    include:
+      - semantic-models/*.yaml
+  dashboards:
+    include:
+      - dashboards/*.yaml
+  access:
+    include: []
+  agentPolicy:
+    include: []
+`
+}
+
+func deploySemanticModelYAML(workspaceID string) string {
+	return `
+apiVersion: libredash.dev/v1
+kind: SemanticModel
+metadata:
+  workspace: ` + workspaceID + `
+  name: ` + workspaceID + `
+spec:
+  baseTable: orders
+  tables:
+    - orders
+  measures:
+    defaults:
+      table: orders
+    order_count:
+      expression: count(orders.order_id)
+`
+}
+
+func deployDashboardYAML(workspaceID string) string {
+	return `
+apiVersion: libredash.dev/v1
+kind: Dashboard
+metadata:
+  workspace: ` + workspaceID + `
+  name: ` + workspaceID + `
+  title: ` + workspaceID + `
+spec:
+  semanticModel: ` + workspaceID + `
+  visuals:
+    total:
+      kind: kpi
+      query:
+        measures:
+          order_count:
+  pages:
+    - name: overview
+      title: Overview
+      visuals:
+        - id: total
+          kind: kpi_card
+          visual: total
+          placement:
+            col: 1
+            row: 1
+            col_span: 3
+            row_span: 2
+`
+}
+
+func workspaceIDFromPath(path string) string {
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if part == "workspaces" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,28 +8,29 @@ import (
 )
 
 type rootOptions struct {
-	addr         string
-	dataDir      string
-	localCatalog string
-	production   bool
-	workspaceID  string
-	environment  string
-	target       string
-	token        string
-	catalog      string
-	deployment   string
-	conversation string
-	jsonOutput   bool
-	pageID       string
-	count        int
-	filtersJSON  string
-	bodyJSON     string
-	schemaFormat string
-	schemaOut    string
-	limit        int
-	pageToken    string
-	searchTypes  []string
-	autoApprove  bool
+	addr          string
+	dataDir       string
+	projectPath   string
+	production    bool
+	workspaceID   string
+	environment   string
+	target        string
+	token         string
+	catalog       string
+	deployment    string
+	conversation  string
+	jsonOutput    bool
+	pageID        string
+	count         int
+	filtersJSON   string
+	bodyJSON      string
+	schemaFormat  string
+	schemaOut     string
+	limit         int
+	pageToken     string
+	searchTypes   []string
+	autoApprove   bool
+	allWorkspaces bool
 }
 
 func Execute(ctx context.Context) error {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -35,7 +35,7 @@ func serveCommand(ctx context.Context, opts *rootOptions) *cobra.Command {
 	cfg := config.MustLoad()
 	cmd.Flags().StringVar(&opts.addr, "addr", cfg.ListenAddr(), "listen address")
 	cmd.Flags().StringVar(&opts.dataDir, "data-dir", cfg.DataDir, "dashboard source data directory")
-	cmd.Flags().StringVar(&opts.localCatalog, "local-project", "", "serve a filesystem project instead of active deployments")
+	cmd.Flags().StringVar(&opts.projectPath, "project", "", "project path override for dev serve")
 	cmd.Flags().StringVar(&opts.environment, "environment", string(deployment.DefaultEnvironment), "deployment environment")
 	cmd.Flags().BoolVar(&opts.production, "production", cfg.Production, "serve active deployment from the platform DB")
 	return cmd
@@ -55,14 +55,14 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 		dataDir = cfg.DataDir
 	}
 	if !opts.production {
-		catalogPath := opts.localCatalog
-		if catalogPath == "" {
-			catalogPath, err = dashboardruntime.DiscoverCatalogPath()
+		projectPath := opts.projectPath
+		if projectPath == "" {
+			projectPath, err = dashboardruntime.DiscoverCatalogPath()
 			if err != nil {
 				return err
 			}
 		} else {
-			if err := os.Setenv("LIBREDASH_CATALOG_PATH", catalogPath); err != nil {
+			if err := os.Setenv("LIBREDASH_CATALOG_PATH", projectPath); err != nil {
 				return err
 			}
 		}
@@ -70,7 +70,7 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 			metrics   app.QueryMetrics
 			closeFunc func()
 		)
-		projectMetrics, err := dashboardruntime.NewFromProject(dataDir, catalogPath, duckDBDirPath(cfg), dashboardDataRuntimeFactory{})
+		projectMetrics, err := dashboardruntime.NewFromProject(dataDir, projectPath, duckDBDirPath(cfg), dashboardDataRuntimeFactory{})
 		if err != nil {
 			return fmt.Errorf("initializing DuckDB metrics: %w", err)
 		}
@@ -93,7 +93,7 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 		}
 		opts.workspaceID = defaultWorkspaceID
 		defer closeFunc()
-		server, cleanup, err := localDevServer(ctx, metrics, cfg, opts.workspaceID)
+		server, cleanup, err := localDevServer(ctx, metrics, cfg, opts.workspaceID, deployment.NormalizeEnvironment(deployment.Environment(opts.environment)))
 		if err != nil {
 			return err
 		}
@@ -161,9 +161,6 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 		return registry.ProviderForWorkspace(deployment.WorkspaceID(workspaceID))
 	})
 	assetCatalog := workspace.NewAssetCatalogService(workspaceRepo)
-	if provider, ok := runtimeMetrics.(workspace.RuntimeAssetGraphProvider); ok {
-		assetCatalog.WithRuntimeProvider(provider)
-	}
 	auth := app.NewAuth(accessRepo, defaultWorkspaceID, app.AuthConfig{
 		DevBypass:       cfg.DevAuthBypass,
 		APITokenOnly:    cfg.APITokenOnlyAuth,
@@ -199,13 +196,18 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 	return http.ListenAndServe(addr, server.Routes())
 }
 
-func localDevServer(ctx context.Context, metrics app.QueryMetrics, cfg config.Config, workspaceID string) (*app.Server, func(), error) {
+func localDevServer(ctx context.Context, metrics app.QueryMetrics, cfg config.Config, workspaceID string, environment deployment.Environment) (*app.Server, func(), error) {
 	duckDBDir := ""
 	if metrics != nil {
 		duckDBDir = metrics.DataDir()
 	}
 	if cfg.DuckDBDir != "" {
 		duckDBDir = cfg.DuckDBDirPath()
+	}
+	for _, dir := range []string{cfg.ArtifactDir(), cfg.DuckDBDirPath(), cfg.RuntimeDir()} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, nil, err
+		}
 	}
 	store, err := platform.Open(ctx, cfg.DBPath())
 	if err != nil {
@@ -223,11 +225,9 @@ func localDevServer(ctx context.Context, metrics app.QueryMetrics, cfg config.Co
 		cleanup()
 		return nil, nil, err
 	}
+	deploymentRepo := deploymentsqlite.NewRepository(store.SQLDB())
 	agentRepo := agentappsqlite.NewRepository(store.SQLDB())
 	assetCatalog := workspace.NewAssetCatalogService(workspaceRepo)
-	if provider, ok := metrics.(workspace.RuntimeAssetGraphProvider); ok {
-		assetCatalog = assetCatalog.WithRuntimeProvider(provider)
-	}
 	auth := app.NewAuth(accessRepo, workspaceID, app.AuthConfig{
 		DevBypass:    true,
 		CSRFKey:      cfg.CSRFKey,
@@ -240,13 +240,16 @@ func localDevServer(ctx context.Context, metrics app.QueryMetrics, cfg config.Co
 	}
 	server := app.NewWithOptions(metrics, app.Options{
 		Store:              store,
+		DeploymentRepo:     deploymentRepo,
 		WorkspaceRepo:      workspaceRepo,
 		AssetCatalog:       assetCatalog,
 		AccessRepo:         accessRepo,
 		Agent:              agent,
 		Auth:               auth,
+		ArtifactDir:        cfg.ArtifactDir(),
 		DuckDBDir:          duckDBDir,
 		DefaultWorkspaceID: workspaceID,
+		DefaultEnvironment: string(environment),
 	})
 	return server, cleanup, nil
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/Yacobolo/libredash/internal/access"
 	accesssqlite "github.com/Yacobolo/libredash/internal/access/sqlite"
 	"github.com/Yacobolo/libredash/internal/config"
+	"github.com/Yacobolo/libredash/internal/deployment"
+	deploymentsqlite "github.com/Yacobolo/libredash/internal/deployment/sqlite"
 	"github.com/Yacobolo/libredash/internal/platform"
 )
 
 func TestLocalDevServerAlwaysOpensPlatformStore(t *testing.T) {
 	home := t.TempDir()
-	_, cleanup, err := localDevServer(context.Background(), nil, config.Config{HomeDir: home}, "test")
+	_, cleanup, err := localDevServer(context.Background(), nil, config.Config{HomeDir: home}, "test", deployment.DefaultEnvironment)
 	if err != nil {
 		t.Fatalf("local dev server: %v", err)
 	}
@@ -23,12 +25,15 @@ func TestLocalDevServerAlwaysOpensPlatformStore(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(home, "libredash.db")); err != nil {
 		t.Fatalf("platform store was not created: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(home, "artifacts")); err != nil {
+		t.Fatalf("artifact directory was not created: %v", err)
+	}
 }
 
 func TestLocalDevServerSeedsPlatformAdminPrincipal(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
-	_, cleanup, err := localDevServer(ctx, nil, config.Config{HomeDir: home}, "test")
+	_, cleanup, err := localDevServer(ctx, nil, config.Config{HomeDir: home}, "test", deployment.DefaultEnvironment)
 	if err != nil {
 		t.Fatalf("local dev server: %v", err)
 	}
@@ -53,5 +58,29 @@ func TestLocalDevServerSeedsPlatformAdminPrincipal(t *testing.T) {
 	}
 	if !allowed {
 		t.Fatal("local dev principal missing platform admin permission")
+	}
+}
+
+func TestLocalDevServerDoesNotCreateDeployments(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	_, cleanup, err := localDevServer(ctx, nil, config.Config{HomeDir: home}, "test", deployment.DefaultEnvironment)
+	if err != nil {
+		t.Fatalf("local dev server: %v", err)
+	}
+	defer cleanup()
+
+	store, err := platform.Open(ctx, filepath.Join(home, "libredash.db"))
+	if err != nil {
+		t.Fatalf("open platform store: %v", err)
+	}
+	defer store.Close()
+	deploymentRepo := deploymentsqlite.NewRepository(store.SQLDB())
+	deployments, err := deploymentRepo.List(ctx, deployment.WorkspaceID("test"), deployment.DefaultEnvironment)
+	if err != nil {
+		t.Fatalf("list deployments: %v", err)
+	}
+	if len(deployments) != 0 {
+		t.Fatalf("deployments = %#v, want none before explicit deploy", deployments)
 	}
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -180,15 +180,19 @@ func renderProjectPlan(out io.Writer, plan workspacecompiler.ProjectPlan) error 
 }
 
 func fetchActiveWorkspaceGraph(ctx context.Context, opts *rootOptions) (workspace.AssetGraph, error) {
+	return fetchActiveWorkspaceGraphForWorkspace(ctx, opts, opts.workspaceID)
+}
+
+func fetchActiveWorkspaceGraphForWorkspace(ctx context.Context, opts *rootOptions, workspaceID string) (workspace.AssetGraph, error) {
 	target, token, err := clientTargetAndToken(opts)
 	if err != nil {
 		return workspace.AssetGraph{}, err
 	}
-	assets, err := fetchAllWorkspaceAssets(ctx, target, token, opts.workspaceID, cliEnvironment(opts))
+	assets, err := fetchAllWorkspaceAssets(ctx, target, token, workspaceID, cliEnvironment(opts))
 	if err != nil {
 		return workspace.AssetGraph{}, err
 	}
-	edges, err := fetchAllWorkspaceAssetEdges(ctx, target, token, opts.workspaceID, cliEnvironment(opts))
+	edges, err := fetchAllWorkspaceAssetEdges(ctx, target, token, workspaceID, cliEnvironment(opts))
 	if err != nil {
 		return workspace.AssetGraph{}, err
 	}

--- a/internal/integration/public_docs_contract_test.go
+++ b/internal/integration/public_docs_contract_test.go
@@ -43,7 +43,7 @@ func TestPublicDocsAndScriptsDoNotAdvertiseRemovedCaCSurfaces(t *testing.T) {
 	script := readRepoFile(t, root, filepath.Join("scripts", "agent_e2e.sh"))
 	for _, want := range []string{
 		"--workspace sales",
-		"--catalog dashboards/libredash.yaml",
+		"--project dashboards/libredash.yaml",
 		"--auto-approve",
 	} {
 		if !strings.Contains(script, want) {

--- a/internal/platform/db/queries.sql
+++ b/internal/platform/db/queries.sql
@@ -91,6 +91,30 @@ SELECT * FROM assets WHERE deployment_id = ? ORDER BY asset_type, asset_key;
 -- name: ListAssetEdgesByDeployment :many
 SELECT * FROM asset_edges WHERE deployment_id = ? ORDER BY edge_type, from_logical_asset_id, to_logical_asset_id;
 
+-- name: ListAssetVersions :many
+SELECT
+  d.id AS deployment_id,
+  d.workspace_id,
+  d.environment,
+  d.status,
+  d.digest,
+  d.created_by,
+  d.created_at,
+  d.activated_at,
+  a.snapshot_id,
+  a.logical_asset_id,
+  a.content_hash
+FROM deployments d
+JOIN assets a ON a.deployment_id = d.id
+WHERE d.workspace_id = ?
+  AND d.environment = ?
+  AND a.logical_asset_id = ?
+  AND d.status IN ('active', 'inactive', 'validated')
+ORDER BY
+  COALESCE(d.activated_at, d.created_at) DESC,
+  d.created_at DESC,
+  d.id DESC;
+
 -- name: UpsertPrincipal :exec
 INSERT INTO principals (id, email, display_name, updated_at)
 VALUES (?, ?, ?, CURRENT_TIMESTAMP)

--- a/internal/platform/db/queries.sql.go
+++ b/internal/platform/db/queries.sql.go
@@ -1318,6 +1318,86 @@ func (q *Queries) ListAssetEdgesByDeployment(ctx context.Context, deploymentID s
 	return items, nil
 }
 
+const listAssetVersions = `-- name: ListAssetVersions :many
+SELECT
+  d.id AS deployment_id,
+  d.workspace_id,
+  d.environment,
+  d.status,
+  d.digest,
+  d.created_by,
+  d.created_at,
+  d.activated_at,
+  a.snapshot_id,
+  a.logical_asset_id,
+  a.content_hash
+FROM deployments d
+JOIN assets a ON a.deployment_id = d.id
+WHERE d.workspace_id = ?
+  AND d.environment = ?
+  AND a.logical_asset_id = ?
+  AND d.status IN ('active', 'inactive', 'validated')
+ORDER BY
+  COALESCE(d.activated_at, d.created_at) DESC,
+  d.created_at DESC,
+  d.id DESC
+`
+
+type ListAssetVersionsParams struct {
+	WorkspaceID    string `json:"workspace_id"`
+	Environment    string `json:"environment"`
+	LogicalAssetID string `json:"logical_asset_id"`
+}
+
+type ListAssetVersionsRow struct {
+	DeploymentID   string         `json:"deployment_id"`
+	WorkspaceID    string         `json:"workspace_id"`
+	Environment    string         `json:"environment"`
+	Status         string         `json:"status"`
+	Digest         string         `json:"digest"`
+	CreatedBy      string         `json:"created_by"`
+	CreatedAt      string         `json:"created_at"`
+	ActivatedAt    sql.NullString `json:"activated_at"`
+	SnapshotID     string         `json:"snapshot_id"`
+	LogicalAssetID string         `json:"logical_asset_id"`
+	ContentHash    string         `json:"content_hash"`
+}
+
+func (q *Queries) ListAssetVersions(ctx context.Context, arg ListAssetVersionsParams) ([]ListAssetVersionsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAssetVersions, arg.WorkspaceID, arg.Environment, arg.LogicalAssetID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAssetVersionsRow{}
+	for rows.Next() {
+		var i ListAssetVersionsRow
+		if err := rows.Scan(
+			&i.DeploymentID,
+			&i.WorkspaceID,
+			&i.Environment,
+			&i.Status,
+			&i.Digest,
+			&i.CreatedBy,
+			&i.CreatedAt,
+			&i.ActivatedAt,
+			&i.SnapshotID,
+			&i.LogicalAssetID,
+			&i.ContentHash,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAssetsByDeployment = `-- name: ListAssetsByDeployment :many
 SELECT snapshot_id, logical_asset_id, workspace_id, deployment_id, asset_type, asset_key, parent_logical_asset_id, title, description, source_file, payload_schema, payload_json, content_hash, created_at FROM assets WHERE deployment_id = ? ORDER BY asset_type, asset_key
 `

--- a/internal/platform/migrations/001_platform.sql
+++ b/internal/platform/migrations/001_platform.sql
@@ -14,7 +14,6 @@ CREATE TABLE IF NOT EXISTS workspaces (
 CREATE TABLE IF NOT EXISTS deployments (
   id TEXT PRIMARY KEY,
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-  environment TEXT NOT NULL DEFAULT 'dev',
   status TEXT NOT NULL,
   digest TEXT NOT NULL DEFAULT '',
   manifest_json TEXT NOT NULL DEFAULT '{}',
@@ -24,19 +23,10 @@ CREATE TABLE IF NOT EXISTS deployments (
   error TEXT NOT NULL DEFAULT ''
 );
 
-CREATE TABLE IF NOT EXISTS workspace_active_deployments (
-  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-  environment TEXT NOT NULL,
-  deployment_id TEXT NOT NULL REFERENCES deployments(id) ON DELETE CASCADE,
-  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY(workspace_id, environment)
-);
-
 CREATE TABLE IF NOT EXISTS deployment_artifacts (
   id TEXT PRIMARY KEY,
   deployment_id TEXT NOT NULL UNIQUE REFERENCES deployments(id) ON DELETE CASCADE,
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-  environment TEXT NOT NULL DEFAULT 'dev',
   digest TEXT NOT NULL,
   format TEXT NOT NULL,
   path TEXT NOT NULL,
@@ -55,7 +45,6 @@ CREATE TABLE IF NOT EXISTS assets (
   parent_logical_asset_id TEXT NOT NULL DEFAULT '',
   title TEXT NOT NULL DEFAULT '',
   description TEXT NOT NULL DEFAULT '',
-  source_file TEXT NOT NULL DEFAULT '',
   payload_schema TEXT NOT NULL,
   payload_json TEXT NOT NULL DEFAULT '{}',
   content_hash TEXT NOT NULL,

--- a/internal/platform/migrations/010_deployment_environments.sql
+++ b/internal/platform/migrations/010_deployment_environments.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- Add deployment environments and active-deployment pointers for stores that
+-- applied the original platform migration before multi-environment deployments.
+
+ALTER TABLE deployments ADD COLUMN environment TEXT NOT NULL DEFAULT 'dev';
+
+CREATE TABLE IF NOT EXISTS workspace_active_deployments (
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  environment TEXT NOT NULL,
+  deployment_id TEXT NOT NULL REFERENCES deployments(id) ON DELETE CASCADE,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(workspace_id, environment)
+);
+
+ALTER TABLE deployment_artifacts ADD COLUMN environment TEXT NOT NULL DEFAULT 'dev';
+
+INSERT OR IGNORE INTO workspace_active_deployments (workspace_id, environment, deployment_id, updated_at)
+SELECT workspace_id, environment, id, COALESCE(activated_at, CURRENT_TIMESTAMP)
+FROM deployments
+WHERE status = 'active';

--- a/internal/platform/migrations/011_asset_source_file.sql
+++ b/internal/platform/migrations/011_asset_source_file.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+-- Preserve source file metadata for asset detail/debug surfaces.
+
+ALTER TABLE assets ADD COLUMN source_file TEXT NOT NULL DEFAULT '';

--- a/internal/ui/signals/types.go
+++ b/internal/ui/signals/types.go
@@ -214,18 +214,19 @@ type WorkspaceAssetPageEnvelope struct {
 }
 
 type WorkspaceAssetPageSignal struct {
-	Kind          RouteKind                   `json:"kind"`
-	Title         string                      `json:"title"`
-	WorkspaceID   string                      `json:"workspaceId"`
-	AssetID       string                      `json:"assetId"`
-	ActiveSection string                      `json:"activeSection"`
-	Asset         WorkspaceAssetSummarySignal `json:"asset"`
-	Breadcrumbs   []WorkspaceBreadcrumbSignal `json:"breadcrumbs"`
-	Actions       []WorkspaceActionSignal     `json:"actions,omitempty"`
-	Tabs          []WorkspaceTabSignal        `json:"tabs"`
-	Details       WorkspaceAssetDetailsSignal `json:"details,omitempty"`
-	Lineage       WorkspaceAssetLineageSignal `json:"lineage,omitempty"`
-	Refresh       WorkspaceAssetRefreshSignal `json:"refresh,omitempty"`
+	Kind          RouteKind                    `json:"kind"`
+	Title         string                       `json:"title"`
+	WorkspaceID   string                       `json:"workspaceId"`
+	AssetID       string                       `json:"assetId"`
+	ActiveSection string                       `json:"activeSection"`
+	Asset         WorkspaceAssetSummarySignal  `json:"asset"`
+	Breadcrumbs   []WorkspaceBreadcrumbSignal  `json:"breadcrumbs"`
+	Actions       []WorkspaceActionSignal      `json:"actions,omitempty"`
+	Tabs          []WorkspaceTabSignal         `json:"tabs"`
+	Details       WorkspaceAssetDetailsSignal  `json:"details,omitempty"`
+	Lineage       WorkspaceAssetLineageSignal  `json:"lineage,omitempty"`
+	Refresh       WorkspaceAssetRefreshSignal  `json:"refresh,omitempty"`
+	Versions      WorkspaceAssetVersionsSignal `json:"versions,omitempty"`
 }
 
 type ConnectionsPageEnvelope struct {
@@ -359,10 +360,15 @@ type WorkspaceAssetLineageSignal struct {
 }
 
 type WorkspaceAssetRefreshSignal struct {
-	Status         string            `json:"status"`
-	Running        bool              `json:"running"`
-	LastSuccessful string            `json:"lastSuccessful"`
+	Status         string             `json:"status"`
+	Running        bool               `json:"running"`
+	LastSuccessful string             `json:"lastSuccessful"`
 	RunsTable      *RecordTableSignal `json:"runsTable,omitempty"`
+}
+
+type WorkspaceAssetVersionsSignal struct {
+	CurrentDeploymentID string            `json:"currentDeploymentId"`
+	Table               RecordTableSignal `json:"table"`
 }
 
 type AssetLineageGraphSignal struct {

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -269,7 +269,11 @@ func workspaceAssetPageSignal(workspace workspaceview.WorkspaceView, asset works
 }
 
 func workspaceAssetPageSignalWithRefresh(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, refresh AssetRefreshState) uisignals.WorkspaceAssetPageSignal {
-	page := baseWorkspaceAssetPageSignalWithRefresh(workspace, asset, assets, edges, activeSection, lineage, refresh)
+	return workspaceAssetPageSignalWithRefreshAndVersions(workspace, asset, assets, edges, activeSection, lineage, refresh, AssetVersionsState{})
+}
+
+func workspaceAssetPageSignalWithRefreshAndVersions(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, refresh AssetRefreshState, versions AssetVersionsState) uisignals.WorkspaceAssetPageSignal {
+	page := baseWorkspaceAssetPageSignalWithRefreshAndVersions(workspace, asset, assets, edges, activeSection, lineage, refresh, versions)
 	page.Kind = uisignals.RouteWorkspaceAsset
 	page.Breadcrumbs = []uisignals.WorkspaceBreadcrumbSignal{
 		{Label: "Workspaces", Href: "/workspaces"},
@@ -295,11 +299,16 @@ func workspaceAssetPageSignalWithRefresh(workspace workspaceview.WorkspaceView, 
 		page.Tabs = append(page.Tabs, uisignals.WorkspaceTabSignal{ID: "refreshes", Label: "Refreshes", Href: assetnav.WorkspaceAssetSectionHref(workspace.ID, asset.ID, "refreshes"), Active: activeSection == "refreshes"})
 	}
 	page.Tabs = append(page.Tabs, uisignals.WorkspaceTabSignal{ID: "lineage", Label: "Lineage", Href: assetnav.WorkspaceAssetSectionHref(workspace.ID, asset.ID, "lineage"), Active: activeSection == "lineage", Count: lineage.Count})
+	page.Tabs = append(page.Tabs, uisignals.WorkspaceTabSignal{ID: "versions", Label: "Versions", Href: assetnav.WorkspaceAssetSectionHref(workspace.ID, asset.ID, "versions"), Active: activeSection == "versions"})
 	return page
 }
 
 func connectionAssetPageSignal(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel) uisignals.WorkspaceAssetPageSignal {
-	page := baseWorkspaceAssetPageSignal(workspace, asset, assets, edges, activeSection, lineage)
+	return connectionAssetPageSignalWithVersions(workspace, asset, assets, edges, activeSection, lineage, AssetVersionsState{})
+}
+
+func connectionAssetPageSignalWithVersions(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, versions AssetVersionsState) uisignals.WorkspaceAssetPageSignal {
+	page := baseWorkspaceAssetPageSignalWithRefreshAndVersions(workspace, asset, assets, edges, activeSection, lineage, AssetRefreshState{}, versions)
 	page.Kind = uisignals.RouteConnectionAsset
 	page.Breadcrumbs = []uisignals.WorkspaceBreadcrumbSignal{
 		{Label: "Connections", Href: "/connections"},
@@ -309,12 +318,17 @@ func connectionAssetPageSignal(workspace workspaceview.WorkspaceView, asset work
 	page.Tabs = []uisignals.WorkspaceTabSignal{
 		{ID: "details", Label: "Details", Href: assetnav.ConnectionAssetSectionHref(asset.ID, "details"), Active: activeSection == "details"},
 		{ID: "lineage", Label: "Lineage", Href: assetnav.ConnectionAssetSectionHref(asset.ID, "lineage"), Active: activeSection == "lineage", Count: lineage.Count},
+		{ID: "versions", Label: "Versions", Href: assetnav.ConnectionAssetSectionHref(asset.ID, "versions"), Active: activeSection == "versions"},
 	}
 	return page
 }
 
 func connectionSourceAssetPageSignal(workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel) uisignals.WorkspaceAssetPageSignal {
-	page := baseWorkspaceAssetPageSignal(workspace, source, assets, edges, activeSection, lineage)
+	return connectionSourceAssetPageSignalWithVersions(workspace, connection, source, assets, edges, activeSection, lineage, AssetVersionsState{})
+}
+
+func connectionSourceAssetPageSignalWithVersions(workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, versions AssetVersionsState) uisignals.WorkspaceAssetPageSignal {
+	page := baseWorkspaceAssetPageSignalWithRefreshAndVersions(workspace, source, assets, edges, activeSection, lineage, AssetRefreshState{}, versions)
 	page.Kind = uisignals.RouteConnectionAsset
 	page.Breadcrumbs = []uisignals.WorkspaceBreadcrumbSignal{
 		{Label: "Connections", Href: "/connections"},
@@ -326,6 +340,7 @@ func connectionSourceAssetPageSignal(workspace workspaceview.WorkspaceView, conn
 	page.Tabs = []uisignals.WorkspaceTabSignal{
 		{ID: "details", Label: "Details", Href: assetnav.ConnectionSourceAssetSectionHref(connection.ID, source.ID, "details"), Active: activeSection == "details"},
 		{ID: "lineage", Label: "Lineage", Href: assetnav.ConnectionSourceAssetSectionHref(connection.ID, source.ID, "lineage"), Active: activeSection == "lineage", Count: lineage.Count},
+		{ID: "versions", Label: "Versions", Href: assetnav.ConnectionSourceAssetSectionHref(connection.ID, source.ID, "versions"), Active: activeSection == "versions"},
 	}
 	return page
 }
@@ -335,6 +350,10 @@ func baseWorkspaceAssetPageSignal(workspace workspaceview.WorkspaceView, asset w
 }
 
 func baseWorkspaceAssetPageSignalWithRefresh(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, refresh AssetRefreshState) uisignals.WorkspaceAssetPageSignal {
+	return baseWorkspaceAssetPageSignalWithRefreshAndVersions(workspace, asset, assets, edges, activeSection, lineage, refresh, AssetVersionsState{})
+}
+
+func baseWorkspaceAssetPageSignalWithRefreshAndVersions(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, refresh AssetRefreshState, versions AssetVersionsState) uisignals.WorkspaceAssetPageSignal {
 	activeSection = normalizeWorkspaceAssetSection(activeSection)
 	page := uisignals.WorkspaceAssetPageSignal{
 		Title:         assetTitle(asset),
@@ -351,8 +370,8 @@ func baseWorkspaceAssetPageSignalWithRefresh(workspace workspaceview.WorkspaceVi
 	}
 	if activeSection == "lineage" {
 		page.Lineage = uisignals.WorkspaceAssetLineageSignal{
-			Count:      lineage.Count,
-			Graph:      lineage.Graph,
+			Count:       lineage.Count,
+			Graph:       lineage.Graph,
 			UsesTable:   lineage.Uses,
 			UsedByTable: lineage.UsedBy,
 		}
@@ -360,6 +379,9 @@ func baseWorkspaceAssetPageSignalWithRefresh(workspace workspaceview.WorkspaceVi
 	if activeSection == "refreshes" && assetRefreshable(asset.Type) {
 		runsTable := assetRefreshesTable(refresh)
 		page.Refresh.RunsTable = &runsTable
+	}
+	if activeSection == "versions" {
+		page.Versions = assetVersionsSignal(versions)
 	}
 	return page
 }
@@ -375,7 +397,7 @@ func workspaceAssetDetailsSignalWithRefresh(workspace workspaceview.WorkspaceVie
 		sections = append(sections, uisignals.WorkspaceDetailSectionSignal{
 			Title: section.Title,
 			Facts: definitionFactSignals(section.Facts),
-			Table:  section.Table,
+			Table: section.Table,
 			Code:  section.Code,
 			Lang:  section.Lang,
 		})
@@ -403,9 +425,13 @@ func WorkspaceAssetPage(catalog dashboard.Catalog, workspace workspaceview.Works
 }
 
 func WorkspaceAssetPageWithRefresh(catalog dashboard.Catalog, workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, roleLabel string, refresh AssetRefreshState) g.Node {
+	return WorkspaceAssetPageWithRefreshAndVersions(catalog, workspace, asset, assets, edges, activeSection, roleLabel, refresh, AssetVersionsState{})
+}
+
+func WorkspaceAssetPageWithRefreshAndVersions(catalog dashboard.Catalog, workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, roleLabel string, refresh AssetRefreshState, versions AssetVersionsState) g.Node {
 	activeSection = normalizeWorkspaceAssetSection(activeSection)
 	lineage := assetLineage(workspace.ID, asset, assets, edges)
-	page := workspaceAssetPageSignalWithRefresh(workspace, asset, assets, edges, activeSection, lineage, refresh)
+	page := workspaceAssetPageSignalWithRefreshAndVersions(workspace, asset, assets, edges, activeSection, lineage, refresh, versions)
 	extraSignals := map[string]any{}
 	attrs := []g.Node{
 		g.Attr("slot", "page"),
@@ -419,10 +445,35 @@ func WorkspaceAssetPageWithRefresh(catalog dashboard.Catalog, workspace workspac
 		attrs = append(attrs,
 			g.Attr("data-on:ld-refresh-materializations", "$page.refresh.status = 'running'; $page.refresh.running = true; "+postActionWithCSRFSignal(refreshPath, "$csrfToken")),
 		)
+		if activeSection == "versions" {
+			return workspaceAssetRouteDocument(asset, catalog, "workspaces", roleLabel, page, uisignals.RouteWorkspaceAsset, g.El("ld-workspace-asset-page", attrs...), extraSignals, activeSection)
+		}
 		extraHeadInit := ds.Init("@get('" + updatesURL + "', {openWhenHidden: true})")
 		return workspaceAssetRouteDocument(asset, catalog, "workspaces", roleLabel, page, uisignals.RouteWorkspaceAsset, g.El("ld-workspace-asset-page", attrs...), extraSignals, activeSection, extraHeadInit)
 	}
 	return workspaceAssetRouteDocument(asset, catalog, "workspaces", roleLabel, page, uisignals.RouteWorkspaceAsset, g.El("ld-workspace-asset-page", attrs...), nil, activeSection)
+}
+
+func ConnectionAssetPageWithVersions(catalog dashboard.Catalog, workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, roleLabel string, versions AssetVersionsState) g.Node {
+	activeSection = normalizeWorkspaceAssetSection(activeSection)
+	lineage := assetLineage(workspace.ID, asset, assets, edges)
+	page := connectionAssetPageSignalWithVersions(workspace, asset, assets, edges, activeSection, lineage, versions)
+	return workspaceAssetRouteDocument(asset, catalog, "connections", roleLabel, page, uisignals.RouteConnectionAsset, g.El("ld-workspace-asset-page",
+		g.Attr("slot", "page"),
+		g.Attr("page", jsonString(page)),
+		g.Attr("data-attr:page", "JSON.stringify($page)"),
+	), nil, activeSection)
+}
+
+func ConnectionSourceAssetPageWithVersions(catalog dashboard.Catalog, workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, roleLabel string, versions AssetVersionsState) g.Node {
+	activeSection = normalizeWorkspaceAssetSection(activeSection)
+	lineage := assetLineage(workspace.ID, source, assets, edges)
+	page := connectionSourceAssetPageSignalWithVersions(workspace, connection, source, assets, edges, activeSection, lineage, versions)
+	return workspaceAssetRouteDocument(source, catalog, "connections", roleLabel, page, uisignals.RouteConnectionAsset, g.El("ld-workspace-asset-page",
+		g.Attr("slot", "page"),
+		g.Attr("page", jsonString(page)),
+		g.Attr("data-attr:page", "JSON.stringify($page)"),
+	), nil, activeSection)
 }
 
 func workspaceAssetRouteDocument(asset workspaceview.AssetView, catalog dashboard.Catalog, active, roleLabel string, page any, routeKind uisignals.RouteKind, routeRoot g.Node, extraSignals map[string]any, activeSection string, bodyExtras ...g.Node) g.Node {
@@ -561,7 +612,7 @@ func workspaceRouteDocumentWithBodyExtras(title string, catalog dashboard.Catalo
 
 func activeDeploymentLabel(workspace workspaceview.WorkspaceView) string {
 	if workspace.ActiveDeploymentID == "" {
-		return "Local catalog"
+		return "No active deployment"
 	}
 	return "Published deployment"
 }
@@ -598,7 +649,7 @@ func workspaceAssetHref(workspaceID, typ, query string) string {
 
 func ValidWorkspaceAssetSection(section string) bool {
 	switch section {
-	case "details", "lineage", "refreshes":
+	case "details", "lineage", "refreshes", "versions":
 		return true
 	default:
 		return false
@@ -629,6 +680,21 @@ type AssetRefreshRun struct {
 	Error                string
 }
 
+type AssetVersionsState struct {
+	CurrentDeploymentID string
+	Versions            []AssetVersionState
+}
+
+type AssetVersionState struct {
+	DeploymentID string
+	Status       string
+	Digest       string
+	CreatedBy    string
+	CreatedAt    string
+	ActivatedAt  string
+	ContentHash  string
+}
+
 func WorkspaceAssetRefreshSignals(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, refresh AssetRefreshState, activeSection string) map[string]any {
 	lineage := assetLineage(workspace.ID, asset, assets, edges)
 	return map[string]any{
@@ -646,6 +712,79 @@ func assetRefreshSignal(refresh AssetRefreshState) uisignals.WorkspaceAssetRefre
 		Running:        status == "queued" || status == "running",
 		LastSuccessful: refresh.LatestSuccessful.FinishedAt,
 	}
+}
+
+func assetVersionsSignal(state AssetVersionsState) uisignals.WorkspaceAssetVersionsSignal {
+	return uisignals.WorkspaceAssetVersionsSignal{
+		CurrentDeploymentID: state.CurrentDeploymentID,
+		Table:               assetVersionsTable(state),
+	}
+}
+
+func assetVersionsTable(state AssetVersionsState) recordTable {
+	rows := make([]map[string]any, 0, len(state.Versions))
+	current := strings.TrimSpace(state.CurrentDeploymentID)
+	for _, version := range state.Versions {
+		status := version.Status
+		if current != "" && version.DeploymentID == current {
+			status = "current"
+		}
+		rows = append(rows, map[string]any{
+			"version":           shortVersionID(version.DeploymentID),
+			"created":           emptyDash(version.CreatedAt),
+			"activated":         emptyDash(version.ActivatedAt),
+			"status":            recordTableBadge{Label: status, Tone: versionStatusTone(status)},
+			"asset_hash":        shortHash(version.ContentHash),
+			"deployment_digest": shortHash(version.Digest),
+			"created_by":        emptyDash(version.CreatedBy),
+		})
+	}
+	return recordTable{
+		Columns: []recordTableColumn{
+			{ID: "version", Header: "Version", Kind: "code", Width: "150px"},
+			{ID: "created", Header: "Created", Width: "180px"},
+			{ID: "activated", Header: "Activated", Width: "180px"},
+			{ID: "status", Header: "Status", Kind: "badge", Width: "120px"},
+			{ID: "asset_hash", Header: "Asset hash", Kind: "code", Width: "130px"},
+			{ID: "deployment_digest", Header: "Deployment digest", Kind: "code", Width: "160px"},
+			{ID: "created_by", Header: "Created by", Width: "150px"},
+		},
+		Rows:     rows,
+		Empty:    "No versions recorded for this asset yet.",
+		MinWidth: "1070px",
+	}
+}
+
+func versionStatusTone(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "current":
+		return "success"
+	case "active", "validated":
+		return "accent"
+	case "inactive":
+		return "muted"
+	default:
+		return "muted"
+	}
+}
+
+func shortVersionID(id string) string {
+	id = strings.TrimSpace(id)
+	if len(id) <= 18 {
+		return id
+	}
+	return id[:18]
+}
+
+func shortHash(hash string) string {
+	hash = strings.TrimSpace(hash)
+	if len(hash) == 0 {
+		return "-"
+	}
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:12]
 }
 
 func assetRefreshesTable(refresh AssetRefreshState) recordTable {
@@ -1438,7 +1577,7 @@ type assetDetailModel struct {
 type assetDetailSection struct {
 	Title  string
 	Signal string
-	Table   recordTable
+	Table  recordTable
 	Facts  []definitionFact
 	Code   string
 	Lang   string
@@ -2226,7 +2365,7 @@ func connectionDetailModel(model *assetDetailModel, workspace workspaceview.Work
 		assetDetailSection{
 			Title:  fmt.Sprintf("Sources (%d)", len(sources)),
 			Signal: "assetDetailsConnectionSourcesTable",
-			Table:   childAssetGrid(workspace.ID, sources, edges, "No sources use this connection."),
+			Table:  childAssetGrid(workspace.ID, sources, edges, "No sources use this connection."),
 		},
 	)
 }

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -113,6 +113,76 @@ func TestWorkspaceAssetDetailSignalsUseSharedGridShape(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAssetVersionsSignalUsesRecordTable(t *testing.T) {
+	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
+	asset := testAssetByID(t, assets, "dashboard")
+	versions := AssetVersionsState{
+		CurrentDeploymentID: "dep_current123456",
+		Versions: []AssetVersionState{{
+			DeploymentID: "dep_current123456",
+			Status:       "active",
+			Digest:       "digest_current1234567890",
+			ContentHash:  "asset_hash_current123456",
+			CreatedAt:    "2026-07-01 10:00:00",
+			ActivatedAt:  "2026-07-01 10:01:00",
+			CreatedBy:    "tester",
+		}},
+	}
+
+	page := workspaceAssetPageSignalWithRefreshAndVersions(workspace, asset, assets, edges, "versions", assetLineage(workspace.ID, asset, assets, edges), AssetRefreshState{}, versions)
+	if page.ActiveSection != "versions" || page.Versions.CurrentDeploymentID != "dep_current123456" {
+		t.Fatalf("versions page = %#v", page)
+	}
+	assertTab(t, page.Tabs, "versions", "/workspaces/libredash/assets/dashboard:executive-sales/versions", true)
+	assertTableHeaders(t, page.Versions.Table, []string{"Version", "Created", "Activated", "Status", "Asset hash", "Deployment digest", "Created by"})
+	if len(page.Versions.Table.Rows) != 1 {
+		t.Fatalf("versions rows = %#v, want one row", page.Versions.Table.Rows)
+	}
+	status, ok := page.Versions.Table.Rows[0]["status"].(uisignals.RecordTableBadgeSignal)
+	if !ok || status.Label != "current" {
+		t.Fatalf("versions status = %#v, want current badge", page.Versions.Table.Rows[0]["status"])
+	}
+
+	var out strings.Builder
+	err := WorkspaceAssetPageWithRefreshAndVersions(catalog, workspace, asset, assets, edges, "versions", "Owner", AssetRefreshState{}, versions).Render(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := html.UnescapeString(out.String())
+	for _, want := range []string{
+		`"activeSection":"versions"`,
+		`"label":"Versions"`,
+		`"header":"Deployment digest"`,
+		`"currentDeploymentId":"dep_current123456"`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("versions page did not render %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, `/updates?section=versions`) {
+		t.Fatalf("versions page started asset update stream:\n%s", rendered)
+	}
+}
+
+func TestConnectionAssetVersionsTabsUseConnectionRoutes(t *testing.T) {
+	workspace, _, assets, edges := testWorkspaceAssetFixtures()
+	connection := testAssetByID(t, assets, "connection")
+	source := testAssetByID(t, assets, "source")
+	versions := AssetVersionsState{CurrentDeploymentID: "dep_connection", Versions: []AssetVersionState{{DeploymentID: "dep_connection", Status: "active"}}}
+
+	connectionPage := connectionAssetPageSignalWithVersions(workspace, connection, assets, edges, "versions", assetLineage(workspace.ID, connection, assets, edges), versions)
+	assertTab(t, connectionPage.Tabs, "versions", "/connections/connection:olist.olist/versions", true)
+	if connectionPage.Versions.CurrentDeploymentID != "dep_connection" {
+		t.Fatalf("connection versions = %#v", connectionPage.Versions)
+	}
+
+	sourcePage := connectionSourceAssetPageSignalWithVersions(workspace, connection, source, assets, edges, "versions", assetLineage(workspace.ID, source, assets, edges), versions)
+	assertTab(t, sourcePage.Tabs, "versions", "/connections/connection:olist.olist/sources/source:olist.orders/versions", true)
+	if sourcePage.Versions.CurrentDeploymentID != "dep_connection" {
+		t.Fatalf("source versions = %#v", sourcePage.Versions)
+	}
+}
+
 func TestSemanticModelDetailsSignalIncludesModelGraph(t *testing.T) {
 	workspace := workspaceview.WorkspaceView{ID: "libredash", Title: "LibreDash Workspace"}
 	asset := workspaceview.AssetView{
@@ -1038,6 +1108,20 @@ func assertTableHeaders(t *testing.T, grid recordTable, expected []string) {
 	if strings.Join(got, "|") != strings.Join(expected, "|") {
 		t.Fatalf("grid headers = %#v, want %#v", got, expected)
 	}
+}
+
+func assertTab(t *testing.T, tabs []uisignals.WorkspaceTabSignal, id, href string, active bool) {
+	t.Helper()
+	for _, tab := range tabs {
+		if tab.ID != id {
+			continue
+		}
+		if tab.Href != href || tab.Active != active {
+			t.Fatalf("tab %q = %#v, want href %q active %v", id, tab, href, active)
+		}
+		return
+	}
+	t.Fatalf("tab %q not found in %#v", id, tabs)
 }
 
 func assertTableMissingHeaders(t *testing.T, grid recordTable, unexpected []string) {

--- a/internal/workspace/asset_catalog.go
+++ b/internal/workspace/asset_catalog.go
@@ -37,49 +37,32 @@ type AssetEdgeRecord struct {
 }
 
 type AssetCatalogService struct {
-	repo    Repository
-	runtime RuntimeAssetGraphProvider
+	repo Repository
 }
 
 func NewAssetCatalogService(repo Repository) *AssetCatalogService {
 	return &AssetCatalogService{repo: repo}
 }
 
-type RuntimeAssetGraphProvider interface {
-	WorkspaceAssets(workspaceID, deploymentID string) ([]Asset, []AssetEdge, bool)
-}
-
 type AssetCatalogReader interface {
 	ActiveAssetCatalog(ctx context.Context, id WorkspaceID, environment string) (AssetCatalog, bool, error)
-}
-
-func (s *AssetCatalogService) WithRuntimeProvider(provider RuntimeAssetGraphProvider) *AssetCatalogService {
-	s.runtime = provider
-	return s
 }
 
 func (s *AssetCatalogService) ActiveAssetCatalog(ctx context.Context, id WorkspaceID, environment string) (AssetCatalog, bool, error) {
 	if s == nil {
 		return AssetCatalog{}, false, nil
 	}
-	if s.repo != nil {
-		graph, ok, err := s.repo.ActiveDeploymentGraph(ctx, id, environment)
-		if err != nil {
-			return AssetCatalog{}, false, err
-		}
-		if ok {
-			catalog, err := DecodeAssetCatalog(graph)
-			return catalog, true, err
-		}
-	}
-	if s.runtime == nil {
+	if s.repo == nil {
 		return AssetCatalog{}, false, nil
 	}
-	assets, edges, ok := s.runtime.WorkspaceAssets(string(id), "local")
+	graph, ok, err := s.repo.ActiveDeploymentGraph(ctx, id, environment)
+	if err != nil {
+		return AssetCatalog{}, false, err
+	}
 	if !ok {
 		return AssetCatalog{}, false, nil
 	}
-	catalog, err := DecodeAssetCatalog(AssetGraph{Assets: assets, Edges: edges})
+	catalog, err := DecodeAssetCatalog(graph)
 	return catalog, true, err
 }
 

--- a/internal/workspace/asset_catalog_test.go
+++ b/internal/workspace/asset_catalog_test.go
@@ -5,16 +5,12 @@ import (
 	"testing"
 )
 
-func TestAssetCatalogServiceReadsActiveDeploymentBeforeRuntimeFallback(t *testing.T) {
+func TestAssetCatalogServiceReadsActiveDeployment(t *testing.T) {
 	ctx := context.Background()
 	persisted := mustCatalogTestAsset(t, "test", "dep_active", AssetTypeDashboard, "sales")
-	runtime := mustCatalogTestAsset(t, "test", "local", AssetTypeDashboard, "local-sales")
 	service := NewAssetCatalogService(fakeCatalogRepo{
 		graph: AssetGraph{Assets: []Asset{persisted}},
 		ok:    true,
-	}).WithRuntimeProvider(fakeRuntimeAssetGraphProvider{
-		assets: []Asset{runtime},
-		ok:     true,
 	})
 
 	catalog, ok, err := service.ActiveAssetCatalog(ctx, "test", "dev")
@@ -29,27 +25,7 @@ func TestAssetCatalogServiceReadsActiveDeploymentBeforeRuntimeFallback(t *testin
 	}
 }
 
-func TestAssetCatalogServiceFallsBackToRuntimeGraph(t *testing.T) {
-	ctx := context.Background()
-	runtime := mustCatalogTestAsset(t, "test", "local", AssetTypeDashboard, "local-sales")
-	service := NewAssetCatalogService(fakeCatalogRepo{}).WithRuntimeProvider(fakeRuntimeAssetGraphProvider{
-		assets: []Asset{runtime},
-		ok:     true,
-	})
-
-	catalog, ok, err := service.ActiveAssetCatalog(ctx, "test", "dev")
-	if err != nil {
-		t.Fatalf("ActiveAssetCatalog() error = %v", err)
-	}
-	if !ok {
-		t.Fatal("ActiveAssetCatalog() ok = false")
-	}
-	if len(catalog.Assets) != 1 || catalog.Assets[0].ID != runtime.ID || catalog.Assets[0].Payload["key"] != "local-sales" {
-		t.Fatalf("catalog assets = %#v, want decoded runtime asset", catalog.Assets)
-	}
-}
-
-func TestAssetCatalogServiceReturnsFalseWithoutActiveOrRuntimeGraph(t *testing.T) {
+func TestAssetCatalogServiceReturnsFalseWithoutActiveDeploymentGraph(t *testing.T) {
 	catalog, ok, err := NewAssetCatalogService(fakeCatalogRepo{}).ActiveAssetCatalog(context.Background(), "test", "dev")
 	if err != nil {
 		t.Fatalf("ActiveAssetCatalog() error = %v", err)
@@ -81,14 +57,8 @@ func (r fakeCatalogRepo) ActiveDeploymentGraph(context.Context, WorkspaceID, str
 	return r.graph, r.ok, r.err
 }
 
-type fakeRuntimeAssetGraphProvider struct {
-	assets []Asset
-	edges  []AssetEdge
-	ok     bool
-}
-
-func (p fakeRuntimeAssetGraphProvider) WorkspaceAssets(string, string) ([]Asset, []AssetEdge, bool) {
-	return p.assets, p.edges, p.ok
+func (r fakeCatalogRepo) AssetVersions(context.Context, WorkspaceID, string, AssetID) ([]AssetVersion, error) {
+	return nil, r.err
 }
 
 func mustCatalogTestAsset(t *testing.T, workspaceID WorkspaceID, deploymentID DeploymentID, typ AssetType, key string) Asset {

--- a/internal/workspace/repository.go
+++ b/internal/workspace/repository.go
@@ -11,6 +11,20 @@ type Summary struct {
 	UpdatedAt          string
 }
 
+type AssetVersion struct {
+	DeploymentID DeploymentID
+	WorkspaceID  WorkspaceID
+	Environment  string
+	Status       string
+	Digest       string
+	CreatedBy    string
+	CreatedAt    string
+	ActivatedAt  string
+	SnapshotID   AssetSnapshotID
+	AssetID      AssetID
+	ContentHash  string
+}
+
 type EnsureInput struct {
 	ID          WorkspaceID
 	Title       string
@@ -22,4 +36,5 @@ type Repository interface {
 	List(ctx context.Context) ([]Summary, error)
 	ByID(ctx context.Context, id WorkspaceID) (Summary, error)
 	ActiveDeploymentGraph(ctx context.Context, id WorkspaceID, environment string) (AssetGraph, bool, error)
+	AssetVersions(ctx context.Context, workspaceID WorkspaceID, environment string, assetID AssetID) ([]AssetVersion, error)
 }

--- a/internal/workspace/sqlite/repository.go
+++ b/internal/workspace/sqlite/repository.go
@@ -87,6 +87,37 @@ func (r *Repository) ActiveDeploymentGraph(ctx context.Context, id workspace.Wor
 	return graph, true, nil
 }
 
+func (r *Repository) AssetVersions(ctx context.Context, workspaceID workspace.WorkspaceID, environment string, assetID workspace.AssetID) ([]workspace.AssetVersion, error) {
+	rows, err := r.q.ListAssetVersions(ctx, platformdb.ListAssetVersionsParams{
+		WorkspaceID:    string(workspaceID),
+		Environment:    string(deployment.NormalizeEnvironment(deployment.Environment(environment))),
+		LogicalAssetID: string(assetID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]workspace.AssetVersion, 0, len(rows))
+	for _, row := range rows {
+		version := workspace.AssetVersion{
+			DeploymentID: workspace.DeploymentID(row.DeploymentID),
+			WorkspaceID:  workspace.WorkspaceID(row.WorkspaceID),
+			Environment:  row.Environment,
+			Status:       row.Status,
+			Digest:       row.Digest,
+			CreatedBy:    row.CreatedBy,
+			CreatedAt:    row.CreatedAt,
+			SnapshotID:   workspace.AssetSnapshotID(row.SnapshotID),
+			AssetID:      workspace.AssetID(row.LogicalAssetID),
+			ContentHash:  row.ContentHash,
+		}
+		if row.ActivatedAt.Valid {
+			version.ActivatedAt = row.ActivatedAt.String
+		}
+		versions = append(versions, version)
+	}
+	return versions, nil
+}
+
 func mapWorkspace(row platformdb.Workspace) workspace.Summary {
 	out := workspace.Summary{
 		ID:          workspace.WorkspaceID(row.ID),

--- a/internal/workspace/sqlite/repository_test.go
+++ b/internal/workspace/sqlite/repository_test.go
@@ -80,9 +80,122 @@ func TestRepositoryActiveDeploymentGraphUsesLogicalAssetIDs(t *testing.T) {
 	}
 }
 
+func TestRepositoryAssetVersionsAreEnvironmentScopedSuccessfulDeployments(t *testing.T) {
+	ctx := context.Background()
+	store, err := platform.Open(ctx, filepath.Join(t.TempDir(), "libredash.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
+	deploymentRepo := deploymentsqlite.NewRepository(store.SQLDB())
+	if err := workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: "test", Title: "Test"}); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+	if err := workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: "other", Title: "Other"}); err != nil {
+		t.Fatalf("ensure other workspace: %v", err)
+	}
+
+	inactive := seedVersionDeployment(t, ctx, deploymentRepo, "test", "dev", deployment.StatusActive)
+	current := seedVersionDeployment(t, ctx, deploymentRepo, "test", "dev", deployment.StatusActive)
+	validated := seedVersionDeployment(t, ctx, deploymentRepo, "test", "dev", deployment.StatusValidated)
+	_ = seedVersionDeployment(t, ctx, deploymentRepo, "test", "prod", deployment.StatusActive)
+	_ = seedVersionDeployment(t, ctx, deploymentRepo, "other", "dev", deployment.StatusActive)
+	failed := seedVersionDeployment(t, ctx, deploymentRepo, "test", "dev", deployment.StatusFailed)
+	pending, err := deploymentRepo.Create(ctx, deployment.CreateInput{WorkspaceID: "test", Environment: "dev", CreatedBy: "tester"})
+	if err != nil {
+		t.Fatalf("create pending deployment: %v", err)
+	}
+	_ = pending
+	_ = failed
+	_ = inactive
+
+	versions, err := workspaceRepo.AssetVersions(ctx, "test", "dev", workspace.NewAssetID(workspace.AssetTypeDashboard, "sales"))
+	if err != nil {
+		t.Fatalf("asset versions: %v", err)
+	}
+	if len(versions) != 3 {
+		t.Fatalf("versions len = %d, want 3 successful dev versions: %#v", len(versions), versions)
+	}
+	seen := map[workspace.DeploymentID]string{}
+	for _, version := range versions {
+		if version.WorkspaceID != "test" || version.Environment != "dev" || version.AssetID != "dashboard:sales" {
+			t.Fatalf("unexpected version scope: %#v", version)
+		}
+		seen[version.DeploymentID] = version.Status
+	}
+	if seen[workspace.DeploymentID(current.ID)] != string(deployment.StatusActive) {
+		t.Fatalf("current deployment missing or not active: %#v", seen)
+	}
+	if seen[workspace.DeploymentID(validated.ID)] != string(deployment.StatusValidated) {
+		t.Fatalf("validated deployment missing: %#v", seen)
+	}
+	if _, ok := seen[workspace.DeploymentID(failed.ID)]; ok {
+		t.Fatalf("failed deployment included: %#v", seen)
+	}
+	if _, ok := seen[workspace.DeploymentID(pending.ID)]; ok {
+		t.Fatalf("pending deployment included: %#v", seen)
+	}
+}
+
+func seedVersionDeployment(t *testing.T, ctx context.Context, repo *deploymentsqlite.Repository, workspaceID deployment.WorkspaceID, environment deployment.Environment, finalStatus deployment.Status) deployment.Deployment {
+	t.Helper()
+	created, err := repo.Create(ctx, deployment.CreateInput{WorkspaceID: workspaceID, Environment: environment, CreatedBy: "tester"})
+	if err != nil {
+		t.Fatalf("create deployment: %v", err)
+	}
+	assetWorkspaceID := workspace.WorkspaceID(workspaceID)
+	asset := mustAssetForWorkspace(t, assetWorkspaceID, workspace.AssetTypeDashboard, "sales", "", created.ID)
+	validation := deployment.Validation{
+		Digest:       "digest-" + string(created.ID),
+		ManifestJSON: "{}",
+		Graph:        workspace.AssetGraph{Assets: []workspace.Asset{asset}},
+	}
+	artifact := deployment.Artifact{ID: "artifact_" + string(created.ID), DeploymentID: created.ID, WorkspaceID: workspaceID, Environment: environment, Digest: validation.Digest, Format: "tar.gz", Path: "artifact.tar.gz", ManifestJSON: "{}"}
+	if _, err := repo.SaveValidated(ctx, created.ID, validation, artifact); err != nil {
+		t.Fatalf("save validated deployment: %v", err)
+	}
+	switch finalStatus {
+	case deployment.StatusActive:
+		active, err := repo.Activate(ctx, workspaceID, environment, created.ID)
+		if err != nil {
+			t.Fatalf("activate deployment: %v", err)
+		}
+		return active
+	case deployment.StatusValidated:
+		validated, err := repo.ByID(ctx, created.ID)
+		if err != nil {
+			t.Fatalf("get validated deployment: %v", err)
+		}
+		return validated
+	case deployment.StatusFailed:
+		if err := repo.MarkFailed(ctx, created.ID, errVersionFailure{}); err != nil {
+			t.Fatalf("mark failed: %v", err)
+		}
+		failed, err := repo.ByID(ctx, created.ID)
+		if err != nil {
+			t.Fatalf("get failed deployment: %v", err)
+		}
+		return failed
+	default:
+		t.Fatalf("unsupported final status %q", finalStatus)
+		return deployment.Deployment{}
+	}
+}
+
+type errVersionFailure struct{}
+
+func (errVersionFailure) Error() string { return "failed" }
+
 func mustAsset(t *testing.T, typ workspace.AssetType, key string, parent workspace.AssetID, deploymentID deployment.ID) workspace.Asset {
 	t.Helper()
-	asset, err := workspace.NewAssetWithSourceFile("test", workspace.DeploymentID(deploymentID), typ, key, parent, key, "", "testdata/"+string(typ)+"-"+key+".yaml", string(typ)+".v1", map[string]any{"key": key})
+	return mustAssetForWorkspace(t, "test", typ, key, parent, deploymentID)
+}
+
+func mustAssetForWorkspace(t *testing.T, workspaceID workspace.WorkspaceID, typ workspace.AssetType, key string, parent workspace.AssetID, deploymentID deployment.ID) workspace.Asset {
+	t.Helper()
+	asset, err := workspace.NewAssetWithSourceFile(workspaceID, workspace.DeploymentID(deploymentID), typ, key, parent, key, "", "testdata/"+string(typ)+"-"+key+".yaml", string(typ)+".v1", map[string]any{"key": key})
 	if err != nil {
 		t.Fatalf("new asset: %v", err)
 	}

--- a/schemas/signals/ui-signals.schema.json
+++ b/schemas/signals/ui-signals.schema.json
@@ -2753,6 +2753,9 @@
         "title": {
           "type": "string"
         },
+        "versions": {
+          "$ref": "#/$defs/WorkspaceAssetVersionsSignal"
+        },
         "workspaceId": {
           "type": "string"
         }
@@ -2834,6 +2837,22 @@
         "title",
         "type",
         "typeLabel"
+      ],
+      "type": "object"
+    },
+    "WorkspaceAssetVersionsSignal": {
+      "additionalProperties": false,
+      "properties": {
+        "currentDeploymentId": {
+          "type": "string"
+        },
+        "table": {
+          "$ref": "#/$defs/RecordTableSignal"
+        }
+      },
+      "required": [
+        "currentDeploymentId",
+        "table"
       ],
       "type": "object"
     },

--- a/scripts/agent_e2e.sh
+++ b/scripts/agent_e2e.sh
@@ -64,7 +64,7 @@ for _ in {1..80}; do
   sleep 0.25
 done
 
-"$BIN" deploy --target "$TARGET" --token "$TOKEN" --workspace sales --catalog dashboards/libredash.yaml --auto-approve
+"$BIN" deploy --target "$TARGET" --token "$TOKEN" --workspace sales --project dashboards/libredash.yaml --auto-approve
 
 OUTPUT="$("$BIN" agent ask "List the dashboards I can use in this workspace and mention the Olist context." --target "$TARGET" --token "$TOKEN" --workspace sales --json)"
 echo "$OUTPUT"

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -327,6 +327,77 @@ test('workspace asset refresh page renders refresh tab and emits refresh events'
   }
 })
 
+test('workspace asset versions page renders record table', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('ld-workspace-asset-page') && customElements.get('ld-record-table'))
+
+    const state = await page.evaluate(async () => {
+      const asset = document.querySelector('ld-workspace-asset-page') as any
+      asset.page = {
+        kind: 'workspace_asset',
+        title: 'Executive Sales Dashboard',
+        workspaceId: 'libredash',
+        assetId: 'dashboard:executive-sales',
+        activeSection: 'versions',
+        asset: {
+          id: 'dashboard:executive-sales',
+          title: 'Executive Sales Dashboard',
+          type: 'dashboard',
+          typeLabel: 'Dashboard',
+          key: 'executive-sales',
+          detailHref: '/workspaces/libredash/assets/dashboard:executive-sales/details',
+          openHref: '/dashboards/executive-sales',
+        },
+        breadcrumbs: [
+          { label: 'Workspaces', href: '/workspaces' },
+          { label: 'LibreDash Workspace', href: '/workspaces/libredash' },
+          { label: 'Executive Sales Dashboard', current: true },
+        ],
+        actions: [],
+        tabs: [
+          { id: 'details', label: 'Details', href: '/workspaces/libredash/assets/dashboard:executive-sales/details', active: false },
+          { id: 'lineage', label: 'Lineage', href: '/workspaces/libredash/assets/dashboard:executive-sales/lineage', active: false, count: 1 },
+          { id: 'versions', label: 'Versions', href: '/workspaces/libredash/assets/dashboard:executive-sales/versions', active: true },
+        ],
+        versions: {
+          currentDeploymentId: 'dep_current123456',
+          table: {
+            columns: [
+              { id: 'version', header: 'Version', kind: 'code' },
+              { id: 'status', header: 'Status', kind: 'badge' },
+              { id: 'asset_hash', header: 'Asset hash', kind: 'code' },
+              { id: 'deployment_digest', header: 'Deployment digest', kind: 'code' },
+            ],
+            rows: [{
+              version: 'dep_current1',
+              status: { label: 'current', tone: 'success' },
+              asset_hash: 'asset_hash_c',
+              deployment_digest: 'digest_curre',
+            }],
+            empty: 'No versions recorded for this asset yet.',
+          },
+        },
+      }
+      await asset.updateComplete
+      const table = asset.shadowRoot.querySelector('ld-record-table') as HTMLElement | null
+      return {
+        activeTab: asset.shadowRoot.querySelector('.tabs a.active')?.textContent?.trim(),
+        sectionTitle: asset.shadowRoot.querySelector('.detail-section h2')?.textContent?.trim(),
+        tableText: table?.textContent ?? '',
+      }
+    })
+
+    expect(state.activeTab).toBe('Versions')
+    expect(state.sectionTitle).toBe('Versions')
+    expect(state.tableText).toMatch(/Deployment digest/)
+    expect(state.tableText).toMatch(/current/)
+  } finally {
+    await page.close()
+  }
+})
+
 function testDocument(): string {
   const assetList = {
     workspaceId: 'libredash',

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -218,7 +218,9 @@ class LibreDashWorkspaceAssetPage extends LitElement {
               ? this.renderLineage(page)
               : page.activeSection === 'refreshes'
                 ? this.renderRefreshes(page)
-                : this.renderDetails(page)}
+                : page.activeSection === 'versions'
+                  ? this.renderVersions(page)
+                  : this.renderDetails(page)}
           </div>
         </div>
       </section>
@@ -276,6 +278,14 @@ class LibreDashWorkspaceAssetPage extends LitElement {
     return html`
       <section class="details" id="refreshes" aria-label="Refresh runs">
         ${renderRecordTableSection('Refreshes', page.refresh?.runsTable)}
+      </section>
+    `
+  }
+
+  private renderVersions(page: WorkspaceAssetPageSignal) {
+    return html`
+      <section class="details" id="versions" aria-label="Asset versions">
+        ${renderRecordTableSection('Versions', page.versions?.table)}
       </section>
     `
   }

--- a/web/generated/signals/index.ts
+++ b/web/generated/signals/index.ts
@@ -767,6 +767,7 @@ export interface WorkspaceAssetPageSignal {
   details?: WorkspaceAssetDetailsSignal
   lineage?: WorkspaceAssetLineageSignal
   refresh?: WorkspaceAssetRefreshSignal
+  versions?: WorkspaceAssetVersionsSignal
 }
 
 export interface WorkspaceAssetRefreshSignal {
@@ -787,6 +788,11 @@ export interface WorkspaceAssetSummarySignal {
   parentHref?: string
   detailHref: string
   openHref: string
+}
+
+export interface WorkspaceAssetVersionsSignal {
+  currentDeploymentId: string
+  table: RecordTableSignal
 }
 
 export interface WorkspaceBreadcrumbSignal {


### PR DESCRIPTION
## Summary

This PR makes workspace asset metadata and asset version history deployment-backed across the new multi-workspace architecture. It removes the old runtime/local asset metadata fallback and makes dev follow the same deployment model as production: the server reads active deployment records, and project changes are published through the normal deployment API.

## What Changed

### Asset Versions tab
- Adds a `Versions` tab to workspace asset detail pages.
- Renders versions through the shared `ld-record-table` surface.
- Shows deployment snapshot metadata for the logical asset:
  - Version/deployment id
  - Created timestamp
  - Activated timestamp
  - Status, with the active deployment displayed as `current`
  - Asset content hash
  - Deployment digest
  - Created by
- Uses only persisted deployment/assets rows as the source of truth.
- Filters history by workspace, environment, logical asset id, and successful deployment statuses.
- Supports connection and source asset version pages as well as normal workspace assets.

### Deployment-backed workspace metadata
- Removes runtime/local asset graph fallback from the asset catalog reader.
- Workspace pages, asset details, lineage, refreshes, and versions now read from active deployment graphs.
- Runtime metrics remain available for dashboard/query execution, but not as workspace metadata.
- Updates agent/tool tests and workspace tests to seed or use persisted deployment graphs.

### Explicit dev deploy workflow
- Adds `libredash deploy --all-workspaces` to deploy every workspace in a project in deterministic order.
- Keeps `--workspace <id>` for targeted deployments.
- Enforces explicit selection: exactly one of `--workspace` or `--all-workspaces` is required.
- Adds `task deploy:dev`, which reads the managed dev server port and deploys `dashboards/libredash.yaml` to the running dev server with `--all-workspaces`.
- Changes dev startup so `task dev` starts the server only; it does not create or refresh deployments.
- Updates docs and the agent E2E script from the removed `--catalog` flag to `--project`.

### Schema and generated artifacts
- Adds deployment environment/source-file migration files for the current dev schema shape.
- Adds the asset versions UI signal payload and regenerates signal schemas/types.
- Adds repository queries for asset version history.

## Dev Workflow

First run:

```sh
task dev
task deploy:dev
```

After YAML/project changes:

```sh
task deploy:dev
```

Then refresh or navigate the UI. The UI is a reflection of the active deployment records in the platform DB.

Production uses the same mechanism:

```sh
libredash deploy --project dashboards/libredash.yaml --target https://... --environment prod --all-workspaces --auto-approve
```

Use `--workspace <id>` for targeted deployments.

## Compatibility Note

LibreDash is still pre-release/dev-only, so this PR does not preserve backward compatibility with older local SQLite schemas. If a local dev DB has stale deployment shape or legacy `libredash` workspace data, reset the dev DB and run `task deploy:dev` again.

## E2E Check

Verified the canonical multi-workspace route:

`/workspaces/sales/assets/dashboard:sales.executive-sales/versions`

It rendered multiple version rows from persisted deployments. The old legacy route `/workspaces/libredash/assets/dashboard:executive-sales/versions` points at stale single-workspace data and is not the canonical route after the multi-workspace change.

## Verification

- `go test ./internal/cli ./internal/workspace/... ./internal/ui/... ./internal/app/...`
- `bun run test:workspace-page`
- `task deploy:dev` against `localhost:8179`
- `task ci`
