### PR TITLE
Remove default workspace dev fallback

### DIFF
--- a/dashboards/workspaces/operations/semantic-models/operations.yaml
+++ b/dashboards/workspaces/operations/semantic-models/operations.yaml
@@ -21,7 +21,7 @@ spec:
       grain: order_id
     order_count:
       label: Orders
-      expression: count_distinct(orders.order_id)
+      expression: COUNT(DISTINCT orders.order_id)
     review_score:
       label: Review score
       expression: avg(orders.review_score)

--- a/internal/app/access_api_test.go
+++ b/internal/app/access_api_test.go
@@ -83,8 +83,8 @@ func TestAPITokenWorkspaceAndPermissionAllowlistAreEnforced(t *testing.T) {
 func TestCurrentAPITokenRevocationIsScopedToAuthenticatedPrincipal(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "token-revoke-owner@example.com", "Token Owner", access.RoleOwner)
-	foreign := testPrincipal(t, ctx, store, "token-revoke-foreign@example.com", "Token Foreign", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "token-revoke-owner@example.com", "Token Owner", access.RoleAdmin)
+	foreign := testPlatformPrincipal(t, ctx, store, "token-revoke-foreign@example.com", "Token Foreign", access.RoleAdmin)
 	authSecret, _ := testScopedAPIToken(t, ctx, store, access.APITokenInput{
 		PrincipalID: owner.ID,
 		WorkspaceID: "test",
@@ -124,8 +124,8 @@ func TestCurrentSessionRevocationIsScopedToAuthenticatedPrincipal(t *testing.T) 
 	store := testStore(t)
 	ctx := context.Background()
 	repo := testAccessRepository(store)
-	owner := testPrincipal(t, ctx, store, "session-revoke-owner@example.com", "Session Owner", access.RoleOwner)
-	foreign := testPrincipal(t, ctx, store, "session-revoke-foreign@example.com", "Session Foreign", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "session-revoke-owner@example.com", "Session Owner", access.RoleAdmin)
+	foreign := testPlatformPrincipal(t, ctx, store, "session-revoke-foreign@example.com", "Session Foreign", access.RoleAdmin)
 	authSecret, _ := testScopedAPIToken(t, ctx, store, access.APITokenInput{
 		PrincipalID: owner.ID,
 		WorkspaceID: "test",

--- a/internal/app/admin_test.go
+++ b/internal/app/admin_test.go
@@ -49,7 +49,7 @@ func TestAdminRouteRejectsViewer(t *testing.T) {
 func TestAdminPagesRenderReadOnlyAccessData(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
 	analyst := testPrincipal(t, ctx, store, "analyst@example.com", "Analyst", access.RoleViewer)
 	repo := testAccessRepository(store)
 	group, err := repo.UpsertGroup(ctx, access.GroupInput{ID: "group_finance", WorkspaceID: "test", Provider: "local", ExternalID: "finance", Name: "Finance"})
@@ -104,7 +104,7 @@ func TestAdminPagesRenderReadOnlyAccessData(t *testing.T) {
 func TestAdminStorageDetailRouteIsDropped(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test", DuckDBDir: seedAdminStorageDuckDB(t)})
@@ -122,7 +122,7 @@ func TestAdminStorageDetailRouteIsDropped(t *testing.T) {
 func TestAdminStorageUpdatesSubscribesWithoutInitialRescan(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test", DuckDBDir: seedAdminStorageDuckDB(t)})
@@ -171,7 +171,7 @@ func TestAdminStorageUpdatesSubscribesWithoutInitialRescan(t *testing.T) {
 func TestAdminStorageSelectTablePublishesSelectedTablePatch(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test", DuckDBDir: seedAdminStorageDuckDB(t)})
@@ -213,7 +213,7 @@ func TestAdminStorageSelectTablePublishesSelectedTablePatch(t *testing.T) {
 func TestAdminStorageSelectTableRejectsInvalidCommand(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test", DuckDBDir: seedAdminStorageDuckDB(t)})
@@ -241,7 +241,7 @@ func TestAdminStorageSelectTableRejectsInvalidCommand(t *testing.T) {
 func TestAdminAccessRouteIsDropped(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
@@ -259,7 +259,7 @@ func TestAdminAccessRouteIsDropped(t *testing.T) {
 func TestAdminPrincipalDetailReturnsNotFoundForMissingPrincipal(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})
@@ -277,7 +277,7 @@ func TestAdminPrincipalDetailReturnsNotFoundForMissingPrincipal(t *testing.T) {
 func TestAdminGroupDetailReturnsNotFoundForMissingGroup(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleOwner)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, DefaultWorkspaceID: "test"})

--- a/internal/app/deployments.go
+++ b/internal/app/deployments.go
@@ -17,7 +17,6 @@ import (
 	deploymentfs "github.com/Yacobolo/libredash/internal/deployment/filesystem"
 	deploymentsqlite "github.com/Yacobolo/libredash/internal/deployment/sqlite"
 	"github.com/Yacobolo/libredash/internal/deployment/validate"
-	"github.com/Yacobolo/libredash/internal/platform"
 	"github.com/Yacobolo/libredash/internal/workspace"
 	"github.com/go-chi/chi/v5"
 )
@@ -220,13 +219,7 @@ func (s *Server) deploymentByIDForRequestWorkspace(r *http.Request, repo deploym
 }
 
 func (s *Server) workspaceID(candidate string) string {
-	if candidate != "" {
-		return candidate
-	}
-	if s.defaultWorkspaceID != "" {
-		return s.defaultWorkspaceID
-	}
-	return platform.DefaultWorkspaceID
+	return candidate
 }
 
 func (s *Server) deploymentRepository() (deploymentRepository, error) {

--- a/internal/app/deployments_test.go
+++ b/internal/app/deployments_test.go
@@ -899,6 +899,35 @@ func TestWorkspaceListUsesRepositoryActiveMetadataWithoutGraphLoads(t *testing.T
 	}
 }
 
+func TestWorkspaceListPageDoesNotRenderWorkspaceScopedChat(t *testing.T) {
+	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
+	store := testStore(t)
+	seedActiveDeployment(t, store, "test")
+	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	req := httptest.NewRequest(http.MethodGet, "/workspaces", nil)
+	req.Header.Set("Authorization", "Bearer dev")
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	rendered := html.UnescapeString(rec.Body.String())
+	for _, notWant := range []string{`/workspaces/test/chat`, `"workspaceTitle":"LibreDash Workspace"`} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("workspace list rendered workspace-scoped chat %q:\n%s", notWant, rec.Body.String())
+		}
+	}
+	if !strings.Contains(rendered, `"id":"chat"`) || !strings.Contains(rendered, `"href":"/chat"`) {
+		t.Fatalf("workspace list did not render global chat navigation:\n%s", rec.Body.String())
+	}
+	if !strings.Contains(rendered, `"workspaceTitle":"LibreDash"`) {
+		t.Fatalf("workspace list did not render global app chrome:\n%s", rec.Body.String())
+	}
+}
+
 type metadataWorkspaceRepo struct {
 	graphCalls int
 }
@@ -1723,6 +1752,19 @@ func testPrincipal(t *testing.T, ctx context.Context, store *platform.Store, ema
 	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{Email: email, DisplayName: displayName})
 	if err != nil {
 		t.Fatalf("upsert principal: %v", err)
+	}
+	return principal
+}
+
+func testPlatformPrincipal(t *testing.T, ctx context.Context, store *platform.Store, email, displayName, role string) access.Principal {
+	t.Helper()
+	principal, err := testAccessRepository(store).SetPlatformRole(ctx, access.PlatformRoleInput{
+		Email:       email,
+		DisplayName: displayName,
+		Role:        role,
+	})
+	if err != nil {
+		t.Fatalf("bind platform role: %v", err)
 	}
 	return principal
 }

--- a/internal/app/runtime_metrics.go
+++ b/internal/app/runtime_metrics.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	semanticmodel "github.com/Yacobolo/libredash/internal/analytics/model"
@@ -26,11 +27,10 @@ type runtimeMetrics struct {
 }
 
 type dynamicRuntimeMetrics struct {
-	defaultID string
-	dataDir   string
-	factory   func(workspaceID string) RuntimeProvider
-	mu        sync.Mutex
-	metrics   map[string]QueryMetrics
+	dataDir string
+	factory func(workspaceID string) RuntimeProvider
+	mu      sync.Mutex
+	metrics map[string]QueryMetrics
 }
 
 type catalogRuntime interface {
@@ -78,17 +78,13 @@ func NewRuntimeMetrics(provider runtimeProvider, dataDir, workspaceID string) Qu
 
 func NewDynamicRuntimeMetrics(defaultWorkspaceID, dataDir string, factory func(workspaceID string) RuntimeProvider) QueryMetrics {
 	return &dynamicRuntimeMetrics{
-		defaultID: defaultWorkspaceID,
-		dataDir:   dataDir,
-		factory:   factory,
-		metrics:   map[string]QueryMetrics{},
+		dataDir: dataDir,
+		factory: factory,
+		metrics: map[string]QueryMetrics{},
 	}
 }
 
 func (m *dynamicRuntimeMetrics) MetricsForWorkspace(workspaceID string) (QueryMetrics, bool) {
-	if workspaceID == "" {
-		workspaceID = m.defaultID
-	}
 	if workspaceID == "" || m.factory == nil {
 		return nil, false
 	}
@@ -107,17 +103,18 @@ func (m *dynamicRuntimeMetrics) MetricsForWorkspace(workspaceID string) (QueryMe
 }
 
 func (m *dynamicRuntimeMetrics) defaultMetrics() QueryMetrics {
-	if metrics, ok := m.MetricsForWorkspace(m.defaultID); ok {
-		return metrics
-	}
 	return nil
 }
 
 func (m runtimeMetrics) Catalog() dashboard.Catalog {
 	runtime, err := m.catalogRuntime()
 	if err != nil {
+		title := strings.TrimSpace(m.workspaceID)
+		if title == "" {
+			title = "LibreDash"
+		}
 		return dashboard.Catalog{
-			Workspace: dashboard.CatalogWorkspace{ID: m.workspaceID, Title: "LibreDash Workspace", Description: "No active deployment."},
+			Workspace: dashboard.CatalogWorkspace{ID: m.workspaceID, Title: title, Description: "No active deployment."},
 		}
 	}
 	return runtime.Catalog()

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -61,7 +61,7 @@ func NewMultiWorkspaceMetrics(defaultWorkspaceID string, workspaces map[string]Q
 
 func (m multiWorkspaceMetrics) MetricsForWorkspace(workspaceID string) (QueryMetrics, bool) {
 	if workspaceID == "" {
-		workspaceID = m.defaultID
+		return nil, false
 	}
 	metrics, ok := m.workspaces[workspaceID]
 	return metrics, ok
@@ -249,16 +249,16 @@ func (s *Server) dashboardHTTP() dashboardhttp.Handler {
 }
 
 func (s *Server) metricsForWorkspace(workspaceID string) (QueryMetrics, bool) {
+	if workspaceID == "" {
+		return nil, false
+	}
 	if provider, ok := s.metrics.(workspaceMetrics); ok {
 		return provider.MetricsForWorkspace(workspaceID)
-	}
-	if workspaceID == "" {
-		return s.metrics, s.metrics != nil
 	}
 	if s.metrics == nil {
 		return nil, false
 	}
-	if workspaceID == s.defaultWorkspaceID {
+	if s.defaultWorkspaceID != "" && workspaceID == s.defaultWorkspaceID {
 		return s.metrics, true
 	}
 	catalog := s.metrics.Catalog()
@@ -281,7 +281,7 @@ func (m dashboardCommandMetrics) RefreshMaterializations(ctx context.Context, mo
 }
 
 func (s *Server) refreshMaterializationsWithRun(ctx context.Context, modelID string) error {
-	return s.refreshMaterializationsWithRunForWorkspace(ctx, s.workspaceID(""), modelID)
+	return s.refreshMaterializationsWithRunForWorkspace(ctx, "", modelID)
 }
 
 func (s *Server) refreshMaterializationsWithRunForWorkspace(ctx context.Context, workspaceID, modelID string) error {

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -427,10 +427,13 @@ func TestHomeRouteRendersDashboardCatalog(t *testing.T) {
 			t.Fatalf("home sidebar missing %q:\n%s", want, body)
 		}
 	}
-	for _, notWant := range []string{`Metric Views`, `/metrics`, `Semantic Models`, `/models`, `Settings`, `/workspaces/test-workspace/permissions`} {
+	for _, notWant := range []string{`Metric Views`, `/metrics`, `Semantic Models`, `/models`, `Settings`, `/workspaces/test-workspace/permissions`, `/workspaces/test-workspace/chat`} {
 		if strings.Contains(rendered, notWant) {
 			t.Fatalf("home sidebar rendered removed navigation %q:\n%s", notWant, body)
 		}
+	}
+	if !strings.Contains(rendered, `"id":"chat"`) || !strings.Contains(rendered, `"href":"/chat"`) {
+		t.Fatalf("home sidebar did not render global chat navigation:\n%s", body)
 	}
 	if strings.Contains(rendered, `<ld-sub-sidebar`) {
 		t.Fatalf("dashboard catalog should not render sub sidebar:\n%s", body)
@@ -517,6 +520,17 @@ func TestDashboardRouteRedirectsToFirstPage(t *testing.T) {
 	}
 	if got := rec.Header().Get("Location"); got != "/workspaces/test-workspace/dashboards/executive-sales/pages/overview" {
 		t.Fatalf("Location = %q, want first page", got)
+	}
+}
+
+func TestServerDoesNotResolveBlankWorkspaceToDefault(t *testing.T) {
+	server := NewWithOptions(fakeMetrics{}, Options{DefaultWorkspaceID: "test"})
+
+	if got := server.workspaceID(""); got != "" {
+		t.Fatalf("workspaceID(\"\") = %q, want blank", got)
+	}
+	if _, ok := server.metricsForWorkspace(""); ok {
+		t.Fatal("metricsForWorkspace(\"\") returned metrics, want no implicit workspace")
 	}
 }
 

--- a/internal/app/workspaces.go
+++ b/internal/app/workspaces.go
@@ -999,8 +999,11 @@ func (s *Server) workspaceResponse(r *http.Request, workspaceID string) workspac
 
 func (s *Server) workspaceAssetsAndEdges(r *http.Request, workspaceID string) ([]workspace.AssetView, []workspace.AssetEdgeView, error) {
 	catalog, ok, err := s.workspaceAssetCatalog(r.Context(), workspaceID, string(s.requestDeploymentEnvironment(r)))
-	if err != nil || !ok {
+	if err != nil {
 		return nil, nil, err
+	}
+	if !ok {
+		return []workspace.AssetView{}, []workspace.AssetEdgeView{}, nil
 	}
 	return assetCatalogViews(catalog), assetCatalogEdgeViews(catalog), nil
 }

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -8,8 +8,6 @@ import (
 	accesssqlite "github.com/Yacobolo/libredash/internal/access/sqlite"
 	"github.com/Yacobolo/libredash/internal/config"
 	"github.com/Yacobolo/libredash/internal/platform"
-	"github.com/Yacobolo/libredash/internal/workspace"
-	workspacesqlite "github.com/Yacobolo/libredash/internal/workspace/sqlite"
 	"github.com/spf13/cobra"
 )
 
@@ -29,15 +27,8 @@ func adminCommand(ctx context.Context, opts *rootOptions) *cobra.Command {
 			if email == "" {
 				email = "admin@localhost"
 			}
-			workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
-			if err := workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: workspace.WorkspaceID(opts.workspaceID), Title: opts.workspaceID}); err != nil {
-				return err
-			}
 			accessRepo := accesssqlite.NewRepository(store.SQLDB())
-			if err := accessRepo.BootstrapAdmin(ctx, opts.workspaceID, email); err != nil {
-				return err
-			}
-			principal, err := accessRepo.PrincipalByID(ctx, access.PrincipalIDForEmail(email))
+			principal, err := accessRepo.SetPlatformRole(ctx, access.PlatformRoleInput{Email: email, DisplayName: email, Role: access.RoleAdmin})
 			if err != nil {
 				return err
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -10,7 +10,6 @@ import (
 type rootOptions struct {
 	addr         string
 	dataDir      string
-	projectPath  string
 	production   bool
 	workspaceID  string
 	environment  string

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -2,19 +2,15 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
-	"path/filepath"
-	"sort"
 
 	accesssqlite "github.com/Yacobolo/libredash/internal/access/sqlite"
 	"github.com/Yacobolo/libredash/internal/agentapp"
 	agentappsqlite "github.com/Yacobolo/libredash/internal/agentapp/sqlite"
 	"github.com/Yacobolo/libredash/internal/app"
 	"github.com/Yacobolo/libredash/internal/config"
-	dashboardruntime "github.com/Yacobolo/libredash/internal/dashboard/runtime"
 	"github.com/Yacobolo/libredash/internal/deployment"
 	deploymentsqlite "github.com/Yacobolo/libredash/internal/deployment/sqlite"
 	"github.com/Yacobolo/libredash/internal/platform"
@@ -35,7 +31,6 @@ func serveCommand(ctx context.Context, opts *rootOptions) *cobra.Command {
 	cfg := config.MustLoad()
 	cmd.Flags().StringVar(&opts.addr, "addr", cfg.ListenAddr(), "listen address")
 	cmd.Flags().StringVar(&opts.dataDir, "data-dir", cfg.DataDir, "dashboard source data directory")
-	cmd.Flags().StringVar(&opts.projectPath, "project", "", "project path override for dev serve")
 	cmd.Flags().StringVar(&opts.environment, "environment", string(deployment.DefaultEnvironment), "deployment environment")
 	cmd.Flags().BoolVar(&opts.production, "production", cfg.Production, "serve active deployment from the platform DB")
 	return cmd
@@ -54,89 +49,49 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 	if dataDir == "" {
 		dataDir = cfg.DataDir
 	}
-	if !opts.production {
-		projectPath := opts.projectPath
-		if projectPath == "" {
-			projectPath, err = dashboardruntime.DiscoverCatalogPath()
-			if err != nil {
-				return err
-			}
-		} else {
-			if err := os.Setenv("LIBREDASH_CATALOG_PATH", projectPath); err != nil {
-				return err
-			}
-		}
-		var (
-			metrics   app.QueryMetrics
-			closeFunc func()
-		)
-		projectMetrics, err := dashboardruntime.NewFromProject(dataDir, projectPath, duckDBDirPath(cfg), dashboardDataRuntimeFactory{})
-		if err != nil {
-			return fmt.Errorf("initializing DuckDB metrics: %w", err)
-		}
-		workspaceMetrics := make(map[string]app.QueryMetrics, len(projectMetrics))
-		workspaceIDs := make([]string, 0, len(projectMetrics))
-		for workspaceID, service := range projectMetrics {
-			workspaceIDs = append(workspaceIDs, workspaceID)
-			workspaceMetrics[workspaceID] = service
-		}
-		sort.Strings(workspaceIDs)
-		defaultWorkspaceID := opts.workspaceID
-		if len(workspaceIDs) > 0 && defaultWorkspaceID == "" {
-			defaultWorkspaceID = workspaceIDs[0]
-		}
-		metrics = app.NewMultiWorkspaceMetrics(defaultWorkspaceID, workspaceMetrics)
-		closeFunc = func() {
-			for _, service := range projectMetrics {
-				_ = service.Close()
-			}
-		}
-		opts.workspaceID = defaultWorkspaceID
-		defer closeFunc()
-		server, cleanup, err := localDevServer(ctx, metrics, cfg, opts.workspaceID, deployment.NormalizeEnvironment(deployment.Environment(opts.environment)))
-		if err != nil {
+	if opts.production {
+		if err := cfg.ValidateProductionAuth(); err != nil {
 			return err
 		}
-		defer cleanup()
-		slog.Info("LibreDash listening", "url", "http://localhost"+addr)
-		return http.ListenAndServe(addr, server.Routes())
 	}
-
-	if err := cfg.ValidateProductionAuth(); err != nil {
-		return err
-	}
-	environment := deployment.NormalizeEnvironment(deployment.Environment(opts.environment))
-	cookieSecure, err := cfg.CookieSecure()
+	server, cleanup, err := deploymentBackedServer(ctx, cfg, dataDir, opts.production, deployment.NormalizeEnvironment(deployment.Environment(opts.environment)))
 	if err != nil {
 		return err
 	}
+	defer cleanup()
+	slog.Info("LibreDash listening", "url", "http://localhost"+addr)
+	return http.ListenAndServe(addr, server.Routes())
+}
+
+func deploymentBackedServer(ctx context.Context, cfg config.Config, dataDir string, production bool, environment deployment.Environment) (*app.Server, func(), error) {
+	cookieSecure, err := cfg.CookieSecure()
+	if err != nil {
+		return nil, nil, err
+	}
 	for _, dir := range []string{cfg.ArtifactDir(), cfg.DuckDBDirPath(), cfg.RuntimeDir()} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return err
+			return nil, nil, err
 		}
 	}
 	store, err := platform.Open(ctx, cfg.DBPath())
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	defer store.Close()
+	cleanup := func() { _ = store.Close() }
 	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
-	defaultWorkspaceID := opts.workspaceID
-	if defaultWorkspaceID == "" {
-		defaultWorkspaceID = platform.DefaultWorkspaceID
-	}
-	if err := workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: workspace.WorkspaceID(defaultWorkspaceID), Title: defaultWorkspaceID}); err != nil {
-		return err
-	}
 	accessRepo := accesssqlite.NewRepository(store.SQLDB())
-	if err := accessRepo.BootstrapAdmin(ctx, defaultWorkspaceID, cfg.BootstrapEmail); err != nil {
-		return err
+	if !production {
+		if err := app.SeedLocalDeveloperPlatformAdmin(ctx, accessRepo); err != nil {
+			cleanup()
+			return nil, nil, err
+		}
 	}
 	deploymentRepo := deploymentsqlite.NewRepository(store.SQLDB())
 	agentRepo := agentappsqlite.NewRepository(store.SQLDB())
 	summaries, err := workspaceRepo.List(ctx)
 	if err != nil {
-		return err
+		cleanup()
+		return nil, nil, err
 	}
 	workspaceIDs := make([]deployment.WorkspaceID, 0, len(summaries))
 	for _, summary := range summaries {
@@ -154,26 +109,34 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 		},
 	})
 	if err := registry.Reload(ctx); err != nil {
-		return err
+		cleanup()
+		return nil, nil, err
 	}
-	defer registry.Close()
-	runtimeMetrics := app.NewDynamicRuntimeMetrics(defaultWorkspaceID, dataDir, func(workspaceID string) app.RuntimeProvider {
+	cleanupWithRegistry := func() {
+		_ = registry.Close()
+		cleanup()
+	}
+	runtimeMetrics := app.NewDynamicRuntimeMetrics("", dataDir, func(workspaceID string) app.RuntimeProvider {
 		return registry.ProviderForWorkspace(deployment.WorkspaceID(workspaceID))
 	})
 	assetCatalog := workspace.NewAssetCatalogService(workspaceRepo)
-	auth := app.NewAuth(accessRepo, defaultWorkspaceID, app.AuthConfig{
-		DevBypass:       cfg.DevAuthBypass,
-		APITokenOnly:    cfg.APITokenOnlyAuth,
-		AzureClientID:   cfg.AzureClientID,
-		AzureSecret:     cfg.AzureSecret,
-		AzureCallback:   cfg.AzureCallbackURL,
-		AzureTenant:     cfg.AzureTenant,
-		CSRFKey:         cfg.CSRFKey,
-		CookieSecure:    cookieSecure,
-		BootstrapTenant: cfg.AzureTenant,
-	})
+	authConfig := app.AuthConfig{DevBypass: true, CSRFKey: cfg.CSRFKey, CookieSecure: false}
+	if production {
+		authConfig = app.AuthConfig{
+			DevBypass:       cfg.DevAuthBypass,
+			APITokenOnly:    cfg.APITokenOnlyAuth,
+			AzureClientID:   cfg.AzureClientID,
+			AzureSecret:     cfg.AzureSecret,
+			AzureCallback:   cfg.AzureCallbackURL,
+			AzureTenant:     cfg.AzureTenant,
+			CSRFKey:         cfg.CSRFKey,
+			CookieSecure:    cookieSecure,
+			BootstrapTenant: cfg.AzureTenant,
+		}
+	}
+	auth := app.NewAuth(accessRepo, "", authConfig)
 	rateLimits := app.ProductionRateLimitConfig()
-	rateLimits.Enabled = cfg.RateLimitingEnabled()
+	rateLimits.Enabled = production && cfg.RateLimitingEnabled()
 	server := app.NewWithOptions(runtimeMetrics, app.Options{
 		Store:              store,
 		DeploymentRepo:     deploymentRepo,
@@ -185,86 +148,11 @@ func runServe(ctx context.Context, opts *rootOptions) error {
 		Reloader:           registry,
 		ArtifactDir:        cfg.ArtifactDir(),
 		DuckDBDir:          cfg.DuckDBDirPath(),
-		DefaultWorkspaceID: defaultWorkspaceID,
 		DefaultEnvironment: string(environment),
 		RateLimits:         rateLimits,
-		SecurityHeaders:    app.SecurityHeaders(cfg.HSTSEnabled(cookieSecure)),
-		RequestLogging:     cfg.RequestLoggingEnabled(),
+		SecurityHeaders:    app.SecurityHeaders(production && cfg.HSTSEnabled(cookieSecure)),
+		RequestLogging:     production && cfg.RequestLoggingEnabled(),
 		Logger:             slog.Default(),
 	})
-	slog.Info("LibreDash listening", "url", "http://localhost"+addr)
-	return http.ListenAndServe(addr, server.Routes())
-}
-
-func localDevServer(ctx context.Context, metrics app.QueryMetrics, cfg config.Config, workspaceID string, environment deployment.Environment) (*app.Server, func(), error) {
-	duckDBDir := ""
-	if metrics != nil {
-		duckDBDir = metrics.DataDir()
-	}
-	if cfg.DuckDBDir != "" {
-		duckDBDir = cfg.DuckDBDirPath()
-	}
-	for _, dir := range []string{cfg.ArtifactDir(), cfg.DuckDBDirPath(), cfg.RuntimeDir()} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return nil, nil, err
-		}
-	}
-	store, err := platform.Open(ctx, cfg.DBPath())
-	if err != nil {
-		return nil, nil, err
-	}
-	cleanup := func() { _ = store.Close() }
-
-	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
-	if err := workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: workspace.WorkspaceID(workspaceID), Title: workspaceID}); err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	accessRepo := accesssqlite.NewRepository(store.SQLDB())
-	if err := app.SeedLocalDeveloperPlatformAdmin(ctx, accessRepo); err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	deploymentRepo := deploymentsqlite.NewRepository(store.SQLDB())
-	agentRepo := agentappsqlite.NewRepository(store.SQLDB())
-	assetCatalog := workspace.NewAssetCatalogService(workspaceRepo)
-	auth := app.NewAuth(accessRepo, workspaceID, app.AuthConfig{
-		DevBypass:    true,
-		CSRFKey:      cfg.CSRFKey,
-		CookieSecure: false,
-	})
-	config := agentConfig(cfg)
-	var agent *agentapp.Service
-	if config.Enabled() {
-		agent = agentapp.NewService(metrics, agentRepo, config)
-	}
-	server := app.NewWithOptions(metrics, app.Options{
-		Store:              store,
-		DeploymentRepo:     deploymentRepo,
-		WorkspaceRepo:      workspaceRepo,
-		AssetCatalog:       assetCatalog,
-		AccessRepo:         accessRepo,
-		Agent:              agent,
-		Auth:               auth,
-		ArtifactDir:        cfg.ArtifactDir(),
-		DuckDBDir:          duckDBDir,
-		DefaultWorkspaceID: workspaceID,
-		DefaultEnvironment: string(environment),
-	})
-	return server, cleanup, nil
-}
-
-func duckDBDirPath(cfg config.Config) string {
-	if cfg.DuckDBDir != "" {
-		return cfg.DuckDBDirPath()
-	}
-	return filepath.Join(cfg.DataDir, ".duckdb")
-}
-
-func agentConfig(cfg config.Config) agentapp.Config {
-	return agentapp.Config{
-		APIKey:  cfg.AgentAPIKey,
-		BaseURL: cfg.AgentBaseURL,
-		Model:   cfg.AgentModel,
-	}
+	return server, cleanupWithRegistry, nil
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -12,13 +12,14 @@ import (
 	"github.com/Yacobolo/libredash/internal/deployment"
 	deploymentsqlite "github.com/Yacobolo/libredash/internal/deployment/sqlite"
 	"github.com/Yacobolo/libredash/internal/platform"
+	workspacesqlite "github.com/Yacobolo/libredash/internal/workspace/sqlite"
 )
 
-func TestLocalDevServerAlwaysOpensPlatformStore(t *testing.T) {
+func TestDeploymentBackedDevServerAlwaysOpensPlatformStore(t *testing.T) {
 	home := t.TempDir()
-	_, cleanup, err := localDevServer(context.Background(), nil, config.Config{HomeDir: home}, "test", deployment.DefaultEnvironment)
+	_, cleanup, err := deploymentBackedServer(context.Background(), config.Config{HomeDir: home}, "", false, deployment.DefaultEnvironment)
 	if err != nil {
-		t.Fatalf("local dev server: %v", err)
+		t.Fatalf("deployment-backed dev server: %v", err)
 	}
 	defer cleanup()
 
@@ -30,12 +31,12 @@ func TestLocalDevServerAlwaysOpensPlatformStore(t *testing.T) {
 	}
 }
 
-func TestLocalDevServerSeedsPlatformAdminPrincipal(t *testing.T) {
+func TestDeploymentBackedDevServerSeedsPlatformAdminPrincipal(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
-	_, cleanup, err := localDevServer(ctx, nil, config.Config{HomeDir: home}, "test", deployment.DefaultEnvironment)
+	_, cleanup, err := deploymentBackedServer(ctx, config.Config{HomeDir: home}, "", false, deployment.DefaultEnvironment)
 	if err != nil {
-		t.Fatalf("local dev server: %v", err)
+		t.Fatalf("deployment-backed dev server: %v", err)
 	}
 	defer cleanup()
 
@@ -61,12 +62,12 @@ func TestLocalDevServerSeedsPlatformAdminPrincipal(t *testing.T) {
 	}
 }
 
-func TestLocalDevServerDoesNotCreateDeployments(t *testing.T) {
+func TestDeploymentBackedDevServerDoesNotCreateWorkspacesOrDeployments(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
-	_, cleanup, err := localDevServer(ctx, nil, config.Config{HomeDir: home}, "test", deployment.DefaultEnvironment)
+	_, cleanup, err := deploymentBackedServer(ctx, config.Config{HomeDir: home}, "", false, deployment.DefaultEnvironment)
 	if err != nil {
-		t.Fatalf("local dev server: %v", err)
+		t.Fatalf("deployment-backed dev server: %v", err)
 	}
 	defer cleanup()
 
@@ -75,6 +76,14 @@ func TestLocalDevServerDoesNotCreateDeployments(t *testing.T) {
 		t.Fatalf("open platform store: %v", err)
 	}
 	defer store.Close()
+	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
+	workspaces, err := workspaceRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(workspaces) != 0 {
+		t.Fatalf("workspaces = %#v, want none before explicit deploy", workspaces)
+	}
 	deploymentRepo := deploymentsqlite.NewRepository(store.SQLDB())
 	deployments, err := deploymentRepo.List(ctx, deployment.WorkspaceID("test"), deployment.DefaultEnvironment)
 	if err != nil {

--- a/internal/dashboard/runtime/catalog.go
+++ b/internal/dashboard/runtime/catalog.go
@@ -105,12 +105,15 @@ func workspaceID(workspace workspace.CatalogWorkspace) string {
 	if strings.TrimSpace(workspace.ID) != "" {
 		return workspace.ID
 	}
-	return "libredash"
+	return ""
 }
 
 func workspaceTitle(workspace workspace.CatalogWorkspace) string {
 	if strings.TrimSpace(workspace.Title) != "" {
 		return workspace.Title
 	}
-	return "LibreDash Workspace"
+	if strings.TrimSpace(workspace.ID) != "" {
+		return workspace.ID
+	}
+	return "LibreDash"
 }

--- a/internal/dashboard/runtime/runtime_dashboard_test.go
+++ b/internal/dashboard/runtime/runtime_dashboard_test.go
@@ -30,6 +30,20 @@ func newLegacyRuntime(t *testing.T, dataDir string) (*Service, error) {
 	return service, nil
 }
 
+func newOperationsRuntime(t *testing.T, dataDir string) (*Service, error) {
+	t.Helper()
+	projectPath := filepath.Join("..", "..", "..", "dashboards", "libredash.yaml")
+	services, err := NewFromProject(dataDir, projectPath, dataDir, testDataRuntimeFactory{})
+	if err != nil {
+		return nil, err
+	}
+	service, ok := services["operations"]
+	if !ok {
+		return nil, fmt.Errorf("showcase project has no operations workspace")
+	}
+	return service, nil
+}
+
 func TestMissingDataReturnsSetupPatch(t *testing.T) {
 	dir := t.TempDir()
 	metrics, err := newLegacyRuntime(t, dir)
@@ -51,6 +65,43 @@ func TestMissingDataReturnsSetupPatch(t *testing.T) {
 	var missing *materializeruntime.MissingDataError
 	if !errors.As(metrics.runtimes["sales"].missing, &missing) {
 		t.Fatalf("missing error type = %T, want *MissingDataError", metrics.runtimes["sales"].missing)
+	}
+}
+
+func TestOperationsFulfillmentDashboardQueryFixture(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "olist_orders_dataset.csv", `order_id,customer_id,order_status,order_purchase_timestamp,order_delivered_customer_date
+o1,c1,delivered,2018-01-01 10:00:00,2018-01-03 10:00:00
+o2,c2,shipped,2018-01-05 10:00:00,2018-01-15 10:00:00
+`)
+	writeFixture(t, dir, "olist_order_reviews_dataset.csv", `order_id,review_score
+o1,5
+o2,3
+`)
+	writeFixture(t, dir, "olist_customers_dataset.csv", `customer_id,customer_state
+c1,SP
+c2,RJ
+`)
+
+	metrics, err := newOperationsRuntime(t, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer metrics.Close()
+
+	patch, err := metrics.QueryDashboardPage(context.Background(), "fulfillment-operations", "overview", dashboard.Filters{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patch.Status.Error != "" {
+		t.Fatalf("unexpected status error: %s", patch.Status.Error)
+	}
+	assertVisualKeys(t, patch, []string{"delivery_days", "delivery_speed", "orders_by_status", "review_by_status", "review_score", "total_orders"})
+	if got := datumInt(patch.Visuals["total_orders"].Data[0], "value"); got != 2 {
+		t.Fatalf("orders KPI value = %d, want 2", got)
+	}
+	if len(patch.Visuals["orders_by_status"].Data) == 0 {
+		t.Fatal("orders by status chart has no data")
 	}
 }
 

--- a/internal/deployment/filesystem/bundle.go
+++ b/internal/deployment/filesystem/bundle.go
@@ -725,10 +725,3 @@ func safeBundlePath(path string) (string, error) {
 	}
 	return clean, nil
 }
-
-func workspaceTitle(value string) string {
-	if strings.TrimSpace(value) != "" {
-		return value
-	}
-	return "LibreDash Workspace"
-}

--- a/internal/ui/signals/types.go
+++ b/internal/ui/signals/types.go
@@ -850,11 +850,11 @@ func SidebarConfigForCatalog(catalog dashboard.Catalog) SidebarSignal {
 		modelID = catalog.Models[0].ID
 		modelTitle = catalog.Models[0].Title
 	}
-	return SidebarConfig(catalog, "dashboards", "", workspaceDisplayTitle(catalog), "Dashboards", "Discovery", modelID, modelTitle, false, "")
+	return sidebarConfig(catalog, "dashboards", "", "LibreDash", "Dashboards", "Discovery", modelID, modelTitle, false, "", false)
 }
 
 func SidebarConfigForWorkspace(catalog dashboard.Catalog, active, roleLabel string) SidebarSignal {
-	return SidebarConfig(catalog, active, "", workspaceDisplayTitle(catalog), "Workspace", "Published assets", "", "", false, roleLabel)
+	return sidebarConfig(catalog, active, "", workspaceDisplayTitle(catalog), "Workspace", "Published assets", "", "", false, roleLabel, strings.TrimSpace(catalog.Workspace.ID) != "")
 }
 
 func SidebarConfigForChat(catalog dashboard.Catalog, workspaceID, roleLabel, view string) SidebarSignal {
@@ -870,6 +870,10 @@ func SidebarConfigForChat(catalog dashboard.Catalog, workspaceID, roleLabel, vie
 }
 
 func SidebarConfig(catalog dashboard.Catalog, active, dashboardID, workspaceTitle, dashboardTitle, pageTitle, modelID, modelTitle string, compact bool, roleLabel string) SidebarSignal {
+	return sidebarConfig(catalog, active, dashboardID, workspaceTitle, dashboardTitle, pageTitle, modelID, modelTitle, compact, roleLabel, strings.TrimSpace(catalog.Workspace.ID) != "")
+}
+
+func sidebarConfig(catalog dashboard.Catalog, active, dashboardID, workspaceTitle, dashboardTitle, pageTitle, modelID, modelTitle string, compact bool, roleLabel string, includeWorkspaceScoped bool) SidebarSignal {
 	return SidebarSignal{
 		WorkspaceTitle: workspaceTitle,
 		Active:         active,
@@ -880,7 +884,7 @@ func SidebarConfig(catalog dashboard.Catalog, active, dashboardID, workspaceTitl
 		ModelTitle:     modelTitle,
 		Compact:        compact,
 		UserRole:       roleLabel,
-		Groups:         sidebarGroups(catalog),
+		Groups:         sidebarGroups(catalog, includeWorkspaceScoped),
 	}
 }
 
@@ -1066,7 +1070,7 @@ func dashboardComponents(page dashboard.Page) []DashboardComponentSignal {
 	return components
 }
 
-func sidebarGroups(catalog dashboard.Catalog) []SidebarGroupSignal {
+func sidebarGroups(catalog dashboard.Catalog, includeWorkspaceScoped bool) []SidebarGroupSignal {
 	return []SidebarGroupSignal{
 		{
 			Label: "Navigation",
@@ -1097,7 +1101,10 @@ func workspaceDisplayTitle(catalog dashboard.Catalog) string {
 	if strings.TrimSpace(catalog.Workspace.Title) != "" {
 		return catalog.Workspace.Title
 	}
-	return "LibreDash Workspace"
+	if strings.TrimSpace(catalog.Workspace.ID) != "" {
+		return catalog.Workspace.ID
+	}
+	return "LibreDash"
 }
 
 func pageVisualIDs(page dashboard.Page) []string {

--- a/internal/ui/signals/types_test.go
+++ b/internal/ui/signals/types_test.go
@@ -120,6 +120,59 @@ func TestChatInitialEnvelopeOnlyListActivatesChatNav(t *testing.T) {
 	}
 }
 
+func TestCatalogSidebarUsesGlobalChat(t *testing.T) {
+	sidebar := SidebarConfigForCatalog(dashboard.Catalog{
+		Workspace: dashboard.CatalogWorkspace{ID: "operations", Title: "Operations"},
+	})
+
+	item, ok := sidebarItem(sidebar, "chat")
+	if !ok {
+		t.Fatalf("catalog sidebar missing chat item: %#v", sidebar.Groups)
+	}
+	if item.Href != "/chat" {
+		t.Fatalf("catalog chat href = %q, want global chat", item.Href)
+	}
+}
+
+func TestWorkspaceSidebarUsesGlobalChat(t *testing.T) {
+	sidebar := SidebarConfigForWorkspace(dashboard.Catalog{
+		Workspace: dashboard.CatalogWorkspace{ID: "operations", Title: "Operations"},
+	}, "workspaces", "Viewer")
+
+	item, ok := sidebarItem(sidebar, "chat")
+	if !ok {
+		t.Fatalf("workspace sidebar missing chat item: %#v", sidebar.Groups)
+	}
+	if item.Href != "/chat" {
+		t.Fatalf("chat href = %q, want global chat", item.Href)
+	}
+}
+
+func TestSidebarWorkspaceTitleDoesNotInventDefaultWorkspace(t *testing.T) {
+	global := SidebarConfigForCatalog(dashboard.Catalog{})
+	if global.WorkspaceTitle != "LibreDash" {
+		t.Fatalf("global workspace title = %q, want app title", global.WorkspaceTitle)
+	}
+
+	workspace := SidebarConfigForWorkspace(dashboard.Catalog{
+		Workspace: dashboard.CatalogWorkspace{ID: "operations"},
+	}, "workspaces", "Viewer")
+	if workspace.WorkspaceTitle != "operations" {
+		t.Fatalf("workspace title = %q, want workspace id fallback", workspace.WorkspaceTitle)
+	}
+}
+
+func sidebarItem(sidebar SidebarSignal, id string) (SidebarItemSignal, bool) {
+	for _, group := range sidebar.Groups {
+		for _, item := range group.Items {
+			if item.ID == id {
+				return item, true
+			}
+		}
+	}
+	return SidebarItemSignal{}, false
+}
+
 func testDashboardReport() reportdef.Dashboard {
 	return reportdef.Dashboard{
 		ID:            "report",

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -20,6 +20,7 @@ import (
 
 func WorkspacesPage(catalog dashboard.Catalog, workspaces []workspaceview.WorkspaceView, roleLabel string, chromeOptions ...ChromeOption) g.Node {
 	page := workspaceCatalogPageSignal(workspaces)
+	catalog = catalogWithoutWorkspaceContext(catalog)
 	return workspaceRouteDocument("LibreDash Workspaces", catalog, "workspaces", roleLabel, page, uisignals.RouteWorkspace,
 		g.El("ld-workspace-page",
 			g.Attr("slot", "page"),
@@ -49,6 +50,9 @@ func WorkspacePage(catalog dashboard.Catalog, workspace workspaceview.WorkspaceV
 
 func ConnectionsPage(catalog dashboard.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeType, query, roleLabel string, chromeOptions ...ChromeOption) g.Node {
 	page := connectionsPageSignal(workspaceID, assets, edges, activeType, query)
+	if strings.TrimSpace(workspaceID) == "" {
+		catalog = catalogWithoutWorkspaceContext(catalog)
+	}
 	return workspaceRouteDocument("Connections", catalog, "connections", roleLabel, page, uisignals.RouteConnections,
 		g.El("ld-connections-page",
 			g.Attr("slot", "page"),
@@ -58,6 +62,11 @@ func ConnectionsPage(catalog dashboard.Catalog, workspaceID string, assets []wor
 		nil,
 		chromeOptions,
 	)
+}
+
+func catalogWithoutWorkspaceContext(catalog dashboard.Catalog) dashboard.Catalog {
+	catalog.Workspace = dashboard.CatalogWorkspace{}
+	return catalog
 }
 
 type workspaceAccessSignalState struct {

--- a/internal/workspace/compiler/compiler.go
+++ b/internal/workspace/compiler/compiler.go
@@ -2,7 +2,6 @@ package compiler
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/Yacobolo/libredash/internal/workspace"
@@ -25,7 +24,7 @@ func Compile(projectPath string, opts Options) (CompiledWorkspace, error) {
 	}
 	workspaceID := opts.WorkspaceID
 	if workspaceID == "" {
-		return firstCompiledWorkspace(projectPath, compiled)
+		return CompiledWorkspace{}, fmt.Errorf("workspace id is required")
 	}
 	selected, ok := compiled.Workspaces[string(workspaceID)]
 	if !ok {
@@ -34,28 +33,12 @@ func Compile(projectPath string, opts Options) (CompiledWorkspace, error) {
 	return selected, nil
 }
 
-func firstCompiledWorkspace(projectPath string, compiled CompiledProject) (CompiledWorkspace, error) {
-	ids := make([]string, 0, len(compiled.Workspaces))
-	for id := range compiled.Workspaces {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	if len(ids) == 0 {
-		return CompiledWorkspace{}, fmt.Errorf("project %q has no workspaces", projectPath)
-	}
-	return compiled.Workspaces[ids[0]], nil
-}
-
-func workspaceIDOrDefault(value string) string {
+func workspaceTitle(value, workspaceID string) string {
 	if strings.TrimSpace(value) != "" {
 		return value
 	}
-	return "libredash"
-}
-
-func workspaceTitle(value string) string {
-	if strings.TrimSpace(value) != "" {
-		return value
+	if strings.TrimSpace(workspaceID) != "" {
+		return workspaceID
 	}
-	return "LibreDash Workspace"
+	return "LibreDash"
 }

--- a/internal/workspace/compiler/lineage.go
+++ b/internal/workspace/compiler/lineage.go
@@ -72,7 +72,7 @@ func ExtractLineage(workspaceID workspace.WorkspaceID, deploymentID workspace.De
 		return id, nil
 	}
 
-	catalogID, err := add(workspace.AssetTypeCatalog, string(workspaceID), "", workspaceTitle(definition.Catalog.Workspace.Title), definition.Catalog.Workspace.Description, catalogPayload(definition))
+	catalogID, err := add(workspace.AssetTypeCatalog, string(workspaceID), "", workspaceTitle(definition.Catalog.Workspace.Title, string(workspaceID)), definition.Catalog.Workspace.Description, catalogPayload(definition))
 	if err != nil {
 		return workspace.AssetGraph{}, err
 	}

--- a/internal/workspace/compiler/payload_builders.go
+++ b/internal/workspace/compiler/payload_builders.go
@@ -11,7 +11,7 @@ func catalogPayload(definition *workspace.Definition) catalogPayloadV1 {
 	return catalogPayloadV1{
 		Workspace: catalogWorkspacePayloadV1{
 			ID:          definition.Catalog.Workspace.ID,
-			Title:       workspaceTitle(definition.Catalog.Workspace.Title),
+			Title:       workspaceTitle(definition.Catalog.Workspace.Title, definition.Catalog.Workspace.ID),
 			Description: definition.Catalog.Workspace.Description,
 		},
 		SemanticModels: catalogModelsPayload(definition.Catalog.SemanticModels),

--- a/internal/workspace/compiler/project_test.go
+++ b/internal/workspace/compiler/project_test.go
@@ -94,6 +94,32 @@ spec:
 	}
 }
 
+func TestCompileRequiresExplicitWorkspaceID(t *testing.T) {
+	projectPath := writeProjectFixture(t, map[string]string{
+		"libredash.yaml":                                   projectYAML(),
+		"connections/olist.yaml":                           connectionYAML("olist"),
+		"sources/olist.orders.yaml":                        sourceYAML("olist.orders", "orders.csv", "order_id"),
+		"sources/olist.customers.yaml":                     sourceYAML("olist.customers", "customers.csv", "customer_id"),
+		"workspaces/sales/workspace.yaml":                  workspaceYAML("sales"),
+		"workspaces/sales/models/orders.yaml":              modelTableYAML("sales", "orders", "olist.orders", "order_id", "SELECT order_id, order_status AS status FROM source.\"olist.orders\""),
+		"workspaces/sales/semantic-models/sales.yaml":      semanticModelYAML("sales", "orders", "order_count"),
+		"workspaces/sales/dashboards/executive-sales.yaml": dashboardYAML("sales", "executive-sales", "sales"),
+	})
+
+	_, err := Compile(projectPath, Options{DeploymentID: "dep_test"})
+	if err == nil || !strings.Contains(err.Error(), "workspace id is required") {
+		t.Fatalf("Compile(blank workspace) error = %v, want workspace id required", err)
+	}
+
+	compiled, err := Compile(projectPath, Options{WorkspaceID: "sales", DeploymentID: "dep_test"})
+	if err != nil {
+		t.Fatalf("Compile(sales) error = %v", err)
+	}
+	if got := compiled.Workspace.ID; got != "sales" {
+		t.Fatalf("compiled workspace = %q, want sales", got)
+	}
+}
+
 func TestCompileProjectCompilesWorkspaceAgentPolicy(t *testing.T) {
 	projectPath := writeProjectFixture(t, map[string]string{
 		"libredash.yaml":                                   projectYAML(),

--- a/internal/workspace/sqlite/repository.go
+++ b/internal/workspace/sqlite/repository.go
@@ -23,7 +23,7 @@ func NewRepository(sqlDB *sql.DB) *Repository {
 func (r *Repository) Ensure(ctx context.Context, input workspace.EnsureInput) error {
 	id := strings.TrimSpace(string(input.ID))
 	if id == "" {
-		id = "libredash"
+		return fmt.Errorf("workspace id is required")
 	}
 	title := strings.TrimSpace(input.Title)
 	if title == "" {

--- a/internal/workspace/sqlite/repository_test.go
+++ b/internal/workspace/sqlite/repository_test.go
@@ -3,6 +3,7 @@ package sqlite_test
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Yacobolo/libredash/internal/deployment"
@@ -11,6 +12,29 @@ import (
 	"github.com/Yacobolo/libredash/internal/workspace"
 	workspacesqlite "github.com/Yacobolo/libredash/internal/workspace/sqlite"
 )
+
+func TestRepositoryEnsureRejectsBlankWorkspaceID(t *testing.T) {
+	ctx := context.Background()
+	store, err := platform.Open(ctx, filepath.Join(t.TempDir(), "libredash.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
+	err = workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: " \t\n", Title: "Fallback"})
+	if err == nil || !strings.Contains(err.Error(), "workspace id is required") {
+		t.Fatalf("Ensure(blank) error = %v, want workspace id required", err)
+	}
+
+	workspaces, err := workspaceRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	if len(workspaces) != 0 {
+		t.Fatalf("workspaces = %#v, want none", workspaces)
+	}
+}
 
 func TestRepositoryActiveDeploymentGraphUsesLogicalAssetIDs(t *testing.T) {
 	ctx := context.Background()

--- a/internal/workspace/view.go
+++ b/internal/workspace/view.go
@@ -1,6 +1,9 @@
 package workspace
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 type WorkspaceView struct {
 	ID                 string
@@ -86,7 +89,7 @@ func AssetViewFromCatalogRecord(row AssetRecord) AssetView {
 		PayloadSchema: row.PayloadSchema,
 		Payload:       row.Payload,
 		ContentHash:   row.ContentHash,
-		Href:          AssetHref(string(row.WorkspaceID), string(row.Type), row.Key),
+		Href:          AssetHrefForAsset(string(row.WorkspaceID), string(row.Type), row.Key, row.Payload),
 	}
 }
 
@@ -102,12 +105,33 @@ func AssetEdgeViewFromCatalogRecord(row AssetEdgeRecord) AssetEdgeView {
 }
 
 func AssetHref(workspaceID, assetType, key string) string {
+	return AssetHrefForAsset(workspaceID, assetType, key, nil)
+}
+
+func AssetHrefForAsset(workspaceID, assetType, key string, payload map[string]any) string {
 	switch assetType {
 	case string(AssetTypeDashboard):
-		return "/workspaces/" + workspaceID + "/dashboards/" + key
+		return "/workspaces/" + url.PathEscape(workspaceID) + "/dashboards/" + url.PathEscape(dashboardRouteID(workspaceID, key, payload))
 	default:
 		return ""
 	}
+}
+
+func dashboardRouteID(workspaceID, key string, payload map[string]any) string {
+	if payload != nil {
+		if id, ok := payload["ID"].(string); ok && strings.TrimSpace(id) != "" {
+			return id
+		}
+		if id, ok := payload["id"].(string); ok && strings.TrimSpace(id) != "" {
+			return id
+		}
+	}
+	if workspaceID != "" {
+		if routeID, ok := strings.CutPrefix(key, workspaceID+"."); ok {
+			return routeID
+		}
+	}
+	return key
 }
 
 func FilterAssets(assets []AssetView, typ, query string) []AssetView {

--- a/internal/workspace/view_test.go
+++ b/internal/workspace/view_test.go
@@ -45,3 +45,11 @@ func TestAssetViewFromCatalogRecordKeepsPayloadContract(t *testing.T) {
 		t.Fatalf("asset view payload = %#v", view)
 	}
 }
+
+func TestDashboardAssetHrefUsesRuntimeDashboardID(t *testing.T) {
+	got := AssetHref("operations", string(AssetTypeDashboard), "operations.fulfillment-operations")
+	want := "/workspaces/operations/dashboards/fulfillment-operations"
+	if got != want {
+		t.Fatalf("dashboard asset href = %q, want %q", got, want)
+	}
+}

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -202,6 +202,56 @@ runner_name() {
   fi
 }
 
+wait_ready() {
+  local port="$1"
+  local pid="$2"
+
+  for _ in {1..150}; do
+    if curl -fsS "http://localhost:$port/workspaces" >/dev/null 2>&1; then
+      return 0
+    fi
+    if ! is_alive "$pid"; then
+      echo "LibreDash dev server exited before it became ready" >&2
+      return 1
+    fi
+    sleep 0.2
+  done
+
+  echo "LibreDash dev server did not become ready on http://localhost:$port" >&2
+  return 1
+}
+
+deploy_project() {
+  local port="$1"
+  go run ./cmd/libredash deploy --project dashboards/libredash.yaml --target "http://localhost:${port}" --token dev --environment dev --auto-approve
+}
+
+attach_server() {
+  local pid="$1"
+  local port="$2"
+  local tail_pid=""
+
+  touch "$LOG_FILE"
+  tail -n "${LIBREDASH_DEV_LOG_LINES:-120}" -f "$LOG_FILE" &
+  tail_pid="$!"
+
+  cleanup_attach() {
+    [[ -n "$tail_pid" ]] && kill "$tail_pid" 2>/dev/null || true
+    if is_alive "$pid"; then
+      stop_pid "$pid" "LibreDash dev server"
+    fi
+    stop_port "$port"
+  }
+  trap cleanup_attach INT TERM
+
+  while is_alive "$pid"; do
+    sleep 1
+  done
+  [[ -n "$tail_pid" ]] && kill "$tail_pid" 2>/dev/null || true
+  stop_port "$port"
+  trap - INT TERM
+}
+
 start() {
   if [[ "${LIBREDASH_DEV_RESTART:-}" != "1" ]]; then
     local existing_pid
@@ -213,7 +263,10 @@ start() {
       echo "PID: $existing_pid"
       echo "URL: http://localhost:$existing_port"
       echo "Logs: $LOG_FILE"
-      echo "Set LIBREDASH_DEV_RESTART=1 to force a restart."
+      echo "Deploying project to existing server..."
+      deploy_project "$existing_port"
+      echo "Attached to LibreDash logs. Press Ctrl-C to stop."
+      attach_server "$existing_pid" "$existing_port"
       return 0
     fi
   fi
@@ -235,18 +288,35 @@ start() {
   else
     echo "Runner: go run (install air for hot reload)"
   fi
-  echo "Press Ctrl-C to stop."
+  echo "Deploying project after startup. Press Ctrl-C to stop."
 
   cd "$ROOT"
   export PORT="$port"
   export LIBREDASH_ADDR=":$port"
   export LIBREDASH_DEV_WORKTREE="$ROOT"
 
+  : > "$LOG_FILE"
   if [[ "$runner" == "air" ]]; then
-    exec air -c .air.toml
+    air -c .air.toml >> "$LOG_FILE" 2>&1 &
   else
-    exec go run ./cmd/libredash
+    go run ./cmd/libredash >> "$LOG_FILE" 2>&1 &
   fi
+  local pid="$!"
+  echo "$pid" > "$PID_FILE"
+
+  if ! wait_ready "$port" "$pid"; then
+    stop_pid "$pid" "LibreDash dev server"
+    exit 1
+  fi
+
+  if ! deploy_project "$port"; then
+    stop_pid "$pid" "LibreDash dev server"
+    exit 1
+  fi
+
+  echo "LibreDash listening at http://localhost:$port"
+  echo "Attached to LibreDash logs. Press Ctrl-C to stop."
+  attach_server "$pid" "$port"
 }
 
 stop() {


### PR DESCRIPTION
## Summary

This removes the remaining default-workspace assumptions from local/dev runtime behavior and makes `task dev` mirror production deployment semantics.

The server now starts from platform/config state, does not seed or infer a workspace, and workspace assets become visible only through an active deployment. `task dev` starts the managed server, waits for readiness, runs the idempotent project deploy, then stays attached to the server logs.

## What changed

- Removed runtime/server fallback behavior that silently resolved blank workspace IDs to `libredash`, the first workspace, or a configured default workspace.
- Switched normal non-production `serve` onto the deployment-backed platform DB/runtime registry path used by production.
- Removed automatic workspace creation from serve/admin startup paths.
- Made blank workspace IDs invalid at persistence/compiler boundaries:
  - `workspace/sqlite.Repository.Ensure` now rejects blank IDs.
  - `workspace/compiler.Compile` now requires an explicit workspace ID.
- Kept global pages global:
  - `/`, `/workspaces`, `/connections`, and admin/global pages render app chrome with `LibreDash`, not `LibreDash Workspace`.
  - Rebased onto global chat from `main`; global chrome now links to `/chat`, and old workspace chat routes redirect to global chat.
- Preserved workspace-scoped behavior where it is explicit:
  - Workspace pages still show the real workspace title, falling back to workspace ID only when title is blank.
  - Dashboard/runtime lookup remains keyed by the explicit workspace route param.
- Fixed operations dashboard SQL by treating measure expressions as DuckDB SQL: `COUNT(DISTINCT orders.order_id)`.
- Fixed dashboard asset open links so logical keys like `operations.fulfillment-operations` route to `/workspaces/operations/dashboards/fulfillment-operations` without changing asset IDs/catalog keys.
- Added regression coverage for no-default workspace behavior, deployment-backed dev startup semantics, operations dashboard runtime queries, global chat/sidebar behavior, and dashboard asset href generation.

## Manual QA

Validated after rebasing onto current `origin/main`:

- Forced a fresh `task dev` restart on `http://localhost:8164`.
- Confirmed `task dev` deployed/skipped the configured project workspaces idempotently: `operations`, `sales`, and `visuals`.
- Confirmed global chat is active:
  - `/chat/new` returns `200`.
  - `/workspaces/operations/chat/new` redirects to `/chat/new`.
- Confirmed the operations dashboard loads cleanly at `/workspaces/operations/dashboards/fulfillment-operations/pages/overview` with populated KPI/chart data and no `Refresh failed` / SQL error.
- Confirmed `/` and `/workspaces` use global app chrome and do not invent a default workspace identity.
- Confirmed the operations workspace dashboard asset open link resolves to `/workspaces/operations/dashboards/fulfillment-operations`.
- Confirmed `task deploy:dev` skips unchanged workspaces.

## Verification

- `go test ./internal/ui/signals ./internal/app ./internal/workspace/sqlite ./internal/workspace/compiler`
- `task ci`

## Notes

This branch is rebased on current `main`, including the global chat work from PR #55. The QA URL for chat is now `/chat/new`; workspace chat routes are compatibility redirects rather than the primary surface.
