### PR TITLE
Improve compact agent tool output

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -146,6 +146,7 @@ tasks:
       - bun run test:chat-composer
       - bun run test:chat-page
       - bun run test:chat-thread
+      - bun run test:code-block
       - bun run test:workspace-page
       - bun run test:admin-page
       - bun run test:code-editor

--- a/api/typespec/bi.tsp
+++ b/api/typespec/bi.tsp
@@ -316,7 +316,7 @@ model DashboardFilterOptionListResponse {
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_dashboards", risk: "read", tags: #["dashboard", "catalog"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_dashboards", risk: "read", tags: #["dashboard", "catalog"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["id", "title", "description", "pageCount"], cursorPath: "page.nextCursor", count: true } })
 op listDashboards(@path workspace: string, @query limit?: int32, @query pageToken?: string): OkJson<DashboardListResponse> | CommonErrors;
 
 @tag("BI")
@@ -325,7 +325,7 @@ op listDashboards(@path workspace: string, @query limit?: int32, @query pageToke
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "describe_dashboard", risk: "read", tags: #["dashboard", "catalog"] })
+@extension("x-agent", #{ enabled: true, name: "describe_dashboard", risk: "read", tags: #["dashboard", "catalog"], output: #{ rootFields: #["id", "title", "description", "semantic_model", "model", "counts", "pages", "detail_tools"] } })
 op getDashboard(@path workspace: string, @path dashboard: string): OkJson<DashboardManifestResponse> | CommonErrors;
 
 @tag("BI")
@@ -334,7 +334,7 @@ op getDashboard(@path workspace: string, @path dashboard: string): OkJson<Dashbo
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "components"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_dashboard_components", risk: "read", tags: #["dashboard", "visual"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_dashboard_components", risk: "read", tags: #["dashboard", "visual"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["id", "kind", "ref", "title"], cursorPath: "page.nextCursor", count: true } })
 op listDashboardComponents(@path workspace: string, @path dashboard: string, @path page: string, @query limit?: int32, @query pageToken?: string): OkJson<DashboardComponentListResponse> | CommonErrors;
 
 @tag("BI")
@@ -343,7 +343,7 @@ op listDashboardComponents(@path workspace: string, @path dashboard: string, @pa
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "visual"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "visual", displayName: "visual" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "describe_dashboard_visual", risk: "read", tags: #["dashboard", "visual"] })
+@extension("x-agent", #{ enabled: true, name: "describe_dashboard_visual", risk: "read", tags: #["dashboard", "visual"], output: #{ rootFields: #["id", "title", "description", "kind", "shape", "type", "query"] } })
 op getDashboardVisual(@path workspace: string, @path dashboard: string, @path page: string, @path visual: string): OkJson<DashboardVisualDescribeResponse> | CommonErrors;
 
 @tag("BI")
@@ -352,7 +352,7 @@ op getDashboardVisual(@path workspace: string, @path dashboard: string, @path pa
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_semantic_models", risk: "read", tags: #["semantic-model", "catalog"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_semantic_models", risk: "read", tags: #["semantic-model", "catalog"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["id", "title", "description"], cursorPath: "page.nextCursor", count: true } })
 op listSemanticModels(@path workspace: string, @query limit?: int32, @query pageToken?: string): OkJson<SemanticModelListResponse> | CommonErrors;
 
 @tag("BI")
@@ -361,7 +361,7 @@ op listSemanticModels(@path workspace: string, @query limit?: int32, @query page
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "describe_model", risk: "read", tags: #["semantic-model", "catalog"] })
+@extension("x-agent", #{ enabled: true, name: "describe_model", risk: "read", tags: #["semantic-model", "catalog"], output: #{ rootFields: #["id", "title", "description", "dashboards", "counts", "tables"] } })
 op getSemanticModel(@path workspace: string, @path("model") modelName: string): OkJson<SemanticModelDescriptionResponse> | CommonErrors;
 
 @tag("BI")
@@ -370,7 +370,7 @@ op getSemanticModel(@path workspace: string, @path("model") modelName: string): 
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "datasets"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_semantic_datasets", risk: "read", tags: #["semantic-model", "dataset"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_semantic_datasets", risk: "read", tags: #["semantic-model", "dataset"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["id", "kind", "description"], cursorPath: "page.nextCursor", count: true } })
 op listSemanticDatasets(@path workspace: string, @path("model") modelName: string, @query limit?: int32, @query pageToken?: string): OkJson<SemanticDatasetListResponse> | CommonErrors;
 
 @tag("BI")
@@ -379,7 +379,7 @@ op listSemanticDatasets(@path workspace: string, @path("model") modelName: strin
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "dataset"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "describe_semantic_dataset", risk: "read", tags: #["semantic-model", "dataset"] })
+@extension("x-agent", #{ enabled: true, name: "describe_semantic_dataset", risk: "read", tags: #["semantic-model", "dataset"], output: #{ rootFields: #["id", "kind", "source", "sources", "description", "primaryKey", "grain", "fieldCount", "measureCount"] } })
 op getSemanticDataset(@path workspace: string, @path("model") modelName: string, @path dataset: string): OkJson<SemanticDatasetResponse> | CommonErrors;
 
 @tag("BI")
@@ -388,7 +388,7 @@ op getSemanticDataset(@path workspace: string, @path("model") modelName: string,
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "fields"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_semantic_fields", risk: "read", tags: #["semantic-model", "dataset", "field"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_semantic_fields", risk: "read", tags: #["semantic-model", "dataset", "field"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["kind", "id", "label", "description"], cursorPath: "page.nextCursor", count: true } })
 op listSemanticFields(@path workspace: string, @path("model") modelName: string, @path dataset: string, @query limit?: int32, @query pageToken?: string): OkJson<SemanticFieldListResponse> | CommonErrors;
 
 @tag("BI")
@@ -397,7 +397,7 @@ op listSemanticFields(@path workspace: string, @path("model") modelName: string,
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "query"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "query_semantic_dataset", risk: "read", tags: #["semantic-model", "dataset", "query"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "query_semantic_dataset", risk: "read", tags: #["semantic-model", "dataset", "query"], defaultLimit: 25, output: #{ rootFields: #["columns"], collections: #[#{ path: "items", as: "items", count: true }], cursorPath: "page.nextCursor" } })
 op querySemanticDataset(@path workspace: string, @path("model") modelName: string, @path dataset: string, @body body?: SemanticQueryRequest): OkJson<SemanticQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -406,7 +406,7 @@ op querySemanticDataset(@path workspace: string, @path("model") modelName: strin
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "preview"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "preview_semantic_dataset", risk: "read", tags: #["semantic-model", "dataset", "query"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "preview_semantic_dataset", risk: "read", tags: #["semantic-model", "dataset", "query"], defaultLimit: 25, output: #{ rootFields: #["columns"], collections: #[#{ path: "items", as: "items", count: true }], cursorPath: "page.nextCursor" } })
 op previewSemanticDataset(@path workspace: string, @path("model") modelName: string, @path dataset: string, @body body?: SemanticPreviewRequest): OkJson<SemanticQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -415,7 +415,7 @@ op previewSemanticDataset(@path workspace: string, @path("model") modelName: str
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "explain-query"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "explain_semantic_query", risk: "read", tags: #["semantic-model", "dataset", "query"] })
+@extension("x-agent", #{ enabled: true, name: "explain_semantic_query", risk: "read", tags: #["semantic-model", "dataset", "query"], output: #{ rootFields: #["mode", "sql", "args", "columns", "warnings"] } })
 op explainSemanticQuery(@path workspace: string, @path("model") modelName: string, @path dataset: string, @body body?: SemanticQueryRequest): OkJson<SemanticExplainResponse> | CommonErrors;
 
 @tag("BI")
@@ -424,7 +424,7 @@ op explainSemanticQuery(@path workspace: string, @path("model") modelName: strin
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["semantic-models", "explain-preview"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "explain_semantic_preview", risk: "read", tags: #["semantic-model", "dataset", "query"] })
+@extension("x-agent", #{ enabled: true, name: "explain_semantic_preview", risk: "read", tags: #["semantic-model", "dataset", "query"], output: #{ rootFields: #["mode", "sql", "args", "columns", "warnings"] } })
 op explainSemanticPreview(@path workspace: string, @path("model") modelName: string, @path dataset: string, @body body?: SemanticPreviewRequest): OkJson<SemanticExplainResponse> | CommonErrors;
 
 @tag("BI")
@@ -433,7 +433,7 @@ op explainSemanticPreview(@path workspace: string, @path("model") modelName: str
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "query-page"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "query_dashboard_page", risk: "read", tags: #["dashboard", "query"] })
+@extension("x-agent", #{ enabled: true, name: "query_dashboard_page", risk: "read", tags: #["dashboard", "query"], output: #{ maps: #[#{ path: "visuals", as: "visuals", fields: #["id", "title", "kind", "shape", "type", "unit", "format", "dimensions", "measure", "measures", "series"], collection: #{ path: "data", as: "data", count: true } }] } })
 op queryDashboardPage(@path workspace: string, @path dashboard: string, @path page: string, @body body?: DashboardPageQueryRequest): OkJson<DashboardPageQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -442,7 +442,7 @@ op queryDashboardPage(@path workspace: string, @path dashboard: string, @path pa
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "visual-data"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "visual", displayName: "visual" }], output: #{ mode: "collection" }, pagination: #{ itemsField: "data" } })
-@extension("x-agent", #{ enabled: true, name: "query_dashboard_visual_data", risk: "read", tags: #["dashboard", "visual", "query"] })
+@extension("x-agent", #{ enabled: true, name: "query_dashboard_visual_data", risk: "read", tags: #["dashboard", "visual", "query"], output: #{ rootFields: #["title", "type", "shape", "unit", "format", "dimensions", "measure", "measures", "series"], collections: #[#{ path: "data", as: "data", count: true }] } })
 op queryDashboardVisualData(@path workspace: string, @path dashboard: string, @path page: string, @path visual: string, @body body?: DashboardPageQueryRequest): OkJson<DashboardVisualDataResponse> | CommonErrors;
 
 @tag("BI")
@@ -451,7 +451,7 @@ op queryDashboardVisualData(@path workspace: string, @path dashboard: string, @p
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "query-table"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "table", displayName: "table" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "query_table", risk: "read", tags: #["dashboard", "query", "table"] })
+@extension("x-agent", #{ enabled: true, name: "query_table", risk: "read", tags: #["dashboard", "query", "table"], output: #{ rootFields: #["title", "availableRows"], collections: #[#{ path: "columns", as: "columns", fields: #["key", "label", "role", "format"] }, #{ path: "blocks.a.rows", as: "rows", count: true }] } })
 op queryDashboardTable(@path workspace: string, @path dashboard: string, @path table: string, @body body?: DashboardTableQueryRequest): OkJson<DashboardTableQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -460,7 +460,7 @@ op queryDashboardTable(@path workspace: string, @path dashboard: string, @path t
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "table-data"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "table", displayName: "table" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "query_dashboard_table_data", risk: "read", tags: #["dashboard", "query", "table"] })
+@extension("x-agent", #{ enabled: true, name: "query_dashboard_table_data", risk: "read", tags: #["dashboard", "query", "table"], output: #{ rootFields: #["title", "availableRows"], collections: #[#{ path: "columns", as: "columns", fields: #["key", "label", "role", "format"] }, #{ path: "blocks.a.rows", as: "rows", count: true }] } })
 op queryDashboardTableData(@path workspace: string, @path dashboard: string, @path page: string, @path table: string, @body body?: DashboardTableDataRequest): OkJson<DashboardTableQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -469,5 +469,5 @@ op queryDashboardTableData(@path workspace: string, @path dashboard: string, @pa
 @post
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["dashboards", "filter-options"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "filter", displayName: "filter" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_dashboard_filter_options", risk: "read", tags: #["dashboard", "filter"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_dashboard_filter_options", risk: "read", tags: #["dashboard", "filter"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["value", "label"], cursorPath: "page.nextCursor", count: true } })
 op listDashboardFilterOptions(@path workspace: string, @path dashboard: string, @path page: string, @path filter: string, @query limit?: int32, @query pageToken?: string, @body body?: DashboardPageQueryRequest): OkJson<DashboardFilterOptionListResponse> | CommonErrors;

--- a/api/typespec/deployments.tsp
+++ b/api/typespec/deployments.tsp
@@ -37,7 +37,7 @@ model DeploymentListResponse {
 @get
 @apigen.authz(#{ mode: "permission", permission: "deployment:read" })
 @apigen.cli(#{ command: #["deployments", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_deployments", risk: "read", tags: #["deployment"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_deployments", risk: "read", tags: #["deployment"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["id", "environment", "status", "createdAt"], cursorPath: "page.nextCursor", count: true } })
 op listDeployments(@path workspace: string, @query environment?: string, @query limit?: int32, @query pageToken?: string): OkJson<DeploymentListResponse> | CommonErrors;
 
 @tag("Deployments")
@@ -52,7 +52,7 @@ op createDeployment(@path workspace: string, @body body?: DeploymentCreateReques
 @route("/workspaces/{workspace}/deployments/{deployment}")
 @get
 @apigen.authz(#{ mode: "permission", permission: "deployment:read" })
-@extension("x-agent", #{ enabled: true, name: "get_deployment", risk: "read", tags: #["deployment"] })
+@extension("x-agent", #{ enabled: true, name: "get_deployment", risk: "read", tags: #["deployment"], output: #{ rootFields: #["id", "environment", "status", "createdAt", "activatedAt", "error"] } })
 op getDeployment(@path workspace: string, @path deployment: string, @query environment?: string): OkJson<DeploymentResponse> | CommonErrors;
 
 @tag("Deployments")

--- a/api/typespec/materializations.tsp
+++ b/api/typespec/materializations.tsp
@@ -43,7 +43,7 @@ alias ListMaterializationRunsOK = OkJson<MaterializationRunListResponse>;
 @route("/workspaces/{workspace}/materialization-runs")
 @get
 @apigen.authz(#{ mode: "permission", permission: "materialization:run" })
-@extension("x-agent", #{ enabled: true, name: "list_materialization_runs", risk: "read", tags: #["materialization"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_materialization_runs", risk: "read", tags: #["materialization"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["id", "modelId", "status", "createdAt"], cursorPath: "page.nextCursor", count: true } })
 op listMaterializationRuns(@path workspace: string, @query limit?: int32, @query pageToken?: string): ListMaterializationRunsOK | CommonErrors;
 
 alias CreateMaterializationRunAccepted = AcceptedJson<MaterializationRunResponse>;
@@ -62,5 +62,5 @@ alias GetMaterializationRunOK = OkJson<MaterializationRunResponse>;
 @route("/workspaces/{workspace}/materialization-runs/{run}")
 @get
 @apigen.authz(#{ mode: "permission", permission: "materialization:run" })
-@extension("x-agent", #{ enabled: true, name: "get_materialization_run", risk: "read", tags: #["materialization"] })
+@extension("x-agent", #{ enabled: true, name: "get_materialization_run", risk: "read", tags: #["materialization"], output: #{ rootFields: #["id", "modelId", "deploymentId", "targetType", "targetId", "status", "error", "createdAt", "startedAt", "finishedAt"] } })
 op getMaterializationRun(@path workspace: string, @path run: string): GetMaterializationRunOK | CommonErrors;

--- a/api/typespec/search.tsp
+++ b/api/typespec/search.tsp
@@ -33,5 +33,5 @@ alias SearchWorkspaceOK = OkJson<SearchResponse>;
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["search"], args: #[#{ source: "query", name: "q", displayName: "query" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "search_workspace", risk: "read", tags: #["search", "discovery"], defaultLimit: 10 })
+@extension("x-agent", #{ enabled: true, name: "search_workspace", risk: "read", tags: #["search", "discovery"], defaultLimit: 10, output: #{ itemsPath: "items", fields: #["type", "id", "name", "description"], cursorPath: "page.nextCursor", count: true } })
 op searchWorkspace(@path workspace: string, @query q?: string, @query types?: string, @query limit?: int32, @query pageToken?: string): SearchWorkspaceOK | CommonErrors;

--- a/api/typespec/workspaces.tsp
+++ b/api/typespec/workspaces.tsp
@@ -104,7 +104,7 @@ alias ListWorkspacesOK = OkJson<WorkspaceListResponse>;
 @get
 @apigen.authz(#{ mode: "permission", permission: "workspace:read" })
 @apigen.cli(#{ command: #["workspaces", "list"], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_workspaces", risk: "read", tags: #["workspace"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_workspaces", risk: "read", tags: #["workspace"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["id", "title", "description"], cursorPath: "page.nextCursor", count: true } })
 op listWorkspaces(@query environment?: string, @query limit?: int32, @query pageToken?: string): ListWorkspacesOK | CommonErrors;
 
 alias ListWorkspaceAssetEdgesOK = OkJson<AssetEdgeListResponse>;
@@ -115,7 +115,7 @@ alias ListWorkspaceAssetEdgesOK = OkJson<AssetEdgeListResponse>;
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["assets", "edges"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_workspace_asset_edges", risk: "read", tags: #["workspace", "lineage"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_workspace_asset_edges", risk: "read", tags: #["workspace", "lineage"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["fromAssetId", "toAssetId", "type"], cursorPath: "page.nextCursor", count: true } })
 op listWorkspaceAssetEdges(@path workspace: string, @query limit?: int32, @query pageToken?: string): ListWorkspaceAssetEdgesOK | CommonErrors;
 
 alias ListWorkspaceAssetsOK = OkJson<AssetListResponse>;
@@ -126,7 +126,7 @@ alias ListWorkspaceAssetsOK = OkJson<AssetListResponse>;
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["assets", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "list_assets", risk: "read", tags: #["workspace", "asset", "lineage"], defaultLimit: 25 })
+@extension("x-agent", #{ enabled: true, name: "list_assets", risk: "read", tags: #["workspace", "asset", "lineage"], defaultLimit: 25, output: #{ itemsPath: "items", fields: #["id", "type", "title", "description"], cursorPath: "page.nextCursor", count: true } })
 op listWorkspaceAssets(@path workspace: string, @query type?: string, @query q?: string, @query limit?: int32, @query pageToken?: string): ListWorkspaceAssetsOK | CommonErrors;
 
 @tag("Workspaces")
@@ -142,7 +142,7 @@ op getWorkspaceActiveDeploymentGraph(@path workspace: string, @query environment
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["assets", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "assetId", displayName: "asset-id" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "describe_asset", risk: "read", tags: #["workspace", "asset"] })
+@extension("x-agent", #{ enabled: true, name: "describe_asset", risk: "read", tags: #["workspace", "asset"], output: #{ rootFields: #["id", "type", "title", "description", "payloadSchema", "href"] } })
 op getWorkspaceAsset(@path workspace: string, @path assetId: string): OkJson<AssetResponse> | CommonErrors;
 
 @tag("Workspaces")
@@ -151,5 +151,5 @@ op getWorkspaceAsset(@path workspace: string, @path assetId: string): OkJson<Ass
 @get
 @apigen.authz(#{ mode: "permission", permission: "asset:read" })
 @apigen.cli(#{ command: #["assets", "lineage"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "assetId", displayName: "asset-id" }], output: #{ mode: "raw" } })
-@extension("x-agent", #{ enabled: true, name: "asset_lineage", risk: "read", tags: #["workspace", "asset", "lineage"] })
+@extension("x-agent", #{ enabled: true, name: "asset_lineage", risk: "read", tags: #["workspace", "asset", "lineage"], output: #{ rootFields: #["assetId", "upstream", "downstream"] } })
 op getWorkspaceAssetLineage(@path workspace: string, @path assetId: string): OkJson<AssetLineageResponse> | CommonErrors;

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/starfederation/datastar-go v1.2.2
+	github.com/toon-format/toon-go v0.0.0-20251202084852-7ca0e27c4e8c
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 	maragu.dev/gomponents v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/toon-format/toon-go v0.0.0-20251202084852-7ca0e27c4e8c h1:D8lDFovBMZywze1eh9iwMLcYor5f11mHBocLhO7cBe8=
+github.com/toon-format/toon-go v0.0.0-20251202084852-7ca0e27c4e8c/go.mod h1:j/BOnpF2ihnz4lELs99h9mwGJBx/zdleOUCnLLRPCsc=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/internal/agentapp/signals.go
+++ b/internal/agentapp/signals.go
@@ -12,8 +12,10 @@ type ChatTranscriptItem struct {
 	Summary        string        `json:"summary,omitempty"`
 	ResultSummary  string        `json:"resultSummary,omitempty"`
 	InputJSON      string        `json:"inputJson,omitempty"`
+	InputFormat    string        `json:"inputFormat,omitempty"`
 	ArgumentsJSON  string        `json:"argumentsJson,omitempty"`
 	ResultJSON     string        `json:"resultJson,omitempty"`
+	ResultFormat   string        `json:"resultFormat,omitempty"`
 	Artifact       *ChatArtifact `json:"artifact,omitempty"`
 	Error          string        `json:"error,omitempty"`
 	ConversationID string        `json:"conversationId,omitempty"`

--- a/internal/agentapp/transcript.go
+++ b/internal/agentapp/transcript.go
@@ -53,6 +53,7 @@ func transcriptStateFromMessages(conversationID string, messages []Message) Chat
 					Title:          toolTitle(call.Name),
 					Status:         "running",
 					InputJSON:      formatToolCallPreview(call),
+					InputFormat:    "json",
 					ArgumentsJSON:  formatJSONPreview(string(call.Arguments), maxToolArgumentsPreviewBytes),
 					ConversationID: conversationID,
 					RunID:          message.RunID,
@@ -62,10 +63,11 @@ func transcriptStateFromMessages(conversationID string, messages []Message) Chat
 		case MessageRoleTool:
 			artifact, artifactSignals, compactArtifactResult := toolArtifact(message.ContentText, message.ContentJSON)
 			mergeChatArtifactSignals(&artifacts, artifactSignals)
-			resultJSON := formatJSONPreview(message.ContentText, maxToolResultPreviewBytes)
+			resultContent := message.ContentText
 			if compactArtifactResult != "" {
-				resultJSON = formatJSONPreview(compactArtifactResult, maxToolResultPreviewBytes)
+				resultContent = compactArtifactResult
 			}
+			resultJSON := formatJSONPreview(resultContent, maxToolResultPreviewBytes)
 			item := ChatTranscriptItem{
 				ID:             message.ID,
 				Kind:           "tool",
@@ -76,6 +78,7 @@ func transcriptStateFromMessages(conversationID string, messages []Message) Chat
 				Summary:        toolSummary(message.ContentText),
 				ResultSummary:  toolSummary(message.ContentText),
 				ResultJSON:     resultJSON,
+				ResultFormat:   toolPreviewFormat(resultContent),
 				Artifact:       artifact,
 				ConversationID: conversationID,
 				RunID:          message.RunID,
@@ -119,11 +122,15 @@ func mergeToolTranscriptItem(started, finished ChatTranscriptItem) ChatTranscrip
 	started.Summary = finished.Summary
 	started.ResultSummary = finished.ResultSummary
 	started.ResultJSON = finished.ResultJSON
+	started.ResultFormat = finished.ResultFormat
 	started.Artifact = finished.Artifact
 	started.Error = finished.Error
 	started.RunID = finished.RunID
 	if started.InputJSON == "" {
 		started.InputJSON = finished.InputJSON
+	}
+	if started.InputFormat == "" {
+		started.InputFormat = finished.InputFormat
 	}
 	if started.ArgumentsJSON == "" {
 		started.ArgumentsJSON = finished.ArgumentsJSON
@@ -281,6 +288,14 @@ func formatJSONPreview(raw string, limit int) string {
 		}
 	}
 	return truncateDisplayText(raw, limit)
+}
+
+func toolPreviewFormat(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw != "" && json.Valid([]byte(raw)) {
+		return "json"
+	}
+	return "toon"
 }
 
 func toolSummary(raw string) string {

--- a/internal/agentapp/transcript_test.go
+++ b/internal/agentapp/transcript_test.go
@@ -1,0 +1,58 @@
+package agentapp
+
+import "testing"
+
+func TestTranscriptFormatsToolInputAndToonResult(t *testing.T) {
+	transcript := transcriptFromMessages("conv_1", []Message{
+		{
+			ID:          "assistant_1",
+			Role:        MessageRoleAssistant,
+			ContentJSON: `{"tool_calls":[{"id":"call_1","name":"list_workspaces","arguments":{"limit":2}}]}`,
+		},
+		{
+			ID:          "tool_1",
+			Role:        MessageRoleTool,
+			ToolCallID:  "call_1",
+			ToolName:    "list_workspaces",
+			ContentText: "items[2]{id,title}:\n  sales,Sales\n  ops,Operations\ncount: 2",
+		},
+	})
+
+	if len(transcript) != 1 {
+		t.Fatalf("transcript len = %d, want merged tool item: %#v", len(transcript), transcript)
+	}
+	if transcript[0].InputFormat != "json" {
+		t.Fatalf("input format = %q, want json", transcript[0].InputFormat)
+	}
+	if transcript[0].ResultFormat != "toon" {
+		t.Fatalf("result format = %q, want toon", transcript[0].ResultFormat)
+	}
+}
+
+func TestTranscriptFormatsJSONToolAndArtifactResults(t *testing.T) {
+	transcript := transcriptFromMessages("conv_1", []Message{
+		{
+			ID:          "tool_json",
+			Role:        MessageRoleTool,
+			ToolCallID:  "call_json",
+			ToolName:    "list_dashboards",
+			ContentText: `{"summary":"Found dashboards"}`,
+		},
+		{
+			ID:          "tool_artifact",
+			Role:        MessageRoleTool,
+			ToolCallID:  "call_artifact",
+			ToolName:    "query_visual",
+			ContentText: `{"kind":"chart","id":"agent_chart_123","signal":"visuals.agent_chart_123","summary":"Created chart."}`,
+		},
+	})
+
+	if len(transcript) != 2 {
+		t.Fatalf("transcript len = %d, want 2: %#v", len(transcript), transcript)
+	}
+	for _, item := range transcript {
+		if item.ResultFormat != "json" {
+			t.Fatalf("%s result format = %q, want json", item.ID, item.ResultFormat)
+		}
+	}
+}

--- a/internal/agenttools/registry.go
+++ b/internal/agenttools/registry.go
@@ -18,6 +18,31 @@ type Extension struct {
 	Risk         string
 	Tags         []string
 	DefaultLimit int
+	Output       Output
+}
+
+type Output struct {
+	ItemsPath   string
+	Fields      []string
+	CursorPath  string
+	Count       bool
+	RootFields  []string
+	Collections []OutputCollection
+	Maps        []OutputMap
+}
+
+type OutputCollection struct {
+	Path   string
+	As     string
+	Fields []string
+	Count  bool
+}
+
+type OutputMap struct {
+	Path       string
+	As         string
+	Fields     []string
+	Collection OutputCollection
 }
 
 type APIGenOperation struct {
@@ -85,6 +110,7 @@ func ParseExtension(value any) (Extension, bool) {
 		Name:         stringFromMap(raw, "name"),
 		Risk:         stringFromMap(raw, "risk"),
 		DefaultLimit: intFromMap(raw, "defaultLimit"),
+		Output:       outputFromMap(raw, "output"),
 	}
 	if tags, ok := raw["tags"].([]any); ok {
 		for _, tag := range tags {
@@ -94,6 +120,77 @@ func ParseExtension(value any) (Extension, bool) {
 		}
 	}
 	return extension, true
+}
+
+func outputFromMap(values map[string]any, key string) Output {
+	raw, ok := values[key].(map[string]any)
+	if !ok {
+		return Output{}
+	}
+	output := Output{
+		ItemsPath:   stringFromMap(raw, "itemsPath"),
+		Fields:      stringsFromMap(raw, "fields"),
+		CursorPath:  stringFromMap(raw, "cursorPath"),
+		Count:       boolFromMap(raw, "count"),
+		RootFields:  stringsFromMap(raw, "rootFields"),
+		Collections: outputCollectionsFromMap(raw, "collections"),
+		Maps:        outputMapsFromMap(raw, "maps"),
+	}
+	return output
+}
+
+func outputCollectionsFromMap(values map[string]any, key string) []OutputCollection {
+	raw, ok := values[key].([]any)
+	if !ok {
+		return nil
+	}
+	collections := make([]OutputCollection, 0, len(raw))
+	for _, value := range raw {
+		object, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		collection := outputCollectionFromMap(object)
+		if collection.Path != "" && collection.As != "" {
+			collections = append(collections, collection)
+		}
+	}
+	return collections
+}
+
+func outputMapsFromMap(values map[string]any, key string) []OutputMap {
+	raw, ok := values[key].([]any)
+	if !ok {
+		return nil
+	}
+	maps := make([]OutputMap, 0, len(raw))
+	for _, value := range raw {
+		object, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		outputMap := OutputMap{
+			Path:   stringFromMap(object, "path"),
+			As:     stringFromMap(object, "as"),
+			Fields: stringsFromMap(object, "fields"),
+		}
+		if collection, ok := object["collection"].(map[string]any); ok {
+			outputMap.Collection = outputCollectionFromMap(collection)
+		}
+		if outputMap.Path != "" && outputMap.As != "" {
+			maps = append(maps, outputMap)
+		}
+	}
+	return maps
+}
+
+func outputCollectionFromMap(values map[string]any) OutputCollection {
+	return OutputCollection{
+		Path:   stringFromMap(values, "path"),
+		As:     stringFromMap(values, "as"),
+		Fields: stringsFromMap(values, "fields"),
+		Count:  boolFromMap(values, "count"),
+	}
 }
 
 func operationAllowed(contract apigenapi.GenOperationContract, extension Extension) bool {
@@ -136,6 +233,20 @@ func boolFromMap(values map[string]any, key string) bool {
 func stringFromMap(values map[string]any, key string) string {
 	value, _ := values[key].(string)
 	return value
+}
+
+func stringsFromMap(values map[string]any, key string) []string {
+	raw, ok := values[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, value := range raw {
+		if text, ok := value.(string); ok && text != "" {
+			out = append(out, text)
+		}
+	}
+	return out
 }
 
 func intFromMap(values map[string]any, key string) int {

--- a/internal/agenttools/registry_test.go
+++ b/internal/agenttools/registry_test.go
@@ -1,0 +1,94 @@
+package agenttools
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseExtensionOutputMetadata(t *testing.T) {
+	extension, ok := ParseExtension(map[string]any{
+		"enabled":      true,
+		"name":         "list_workspaces",
+		"risk":         "read",
+		"tags":         []any{"workspace"},
+		"defaultLimit": float64(25),
+		"output": map[string]any{
+			"itemsPath":  "items",
+			"fields":     []any{"id", "title", "description"},
+			"cursorPath": "page.nextCursor",
+			"count":      true,
+		},
+	})
+	if !ok {
+		t.Fatal("ParseExtension returned ok=false")
+	}
+	if !extension.Enabled || extension.Name != "list_workspaces" || extension.Risk != "read" || extension.DefaultLimit != 25 {
+		t.Fatalf("extension scalar fields = %#v", extension)
+	}
+	if got, want := extension.Tags, []string{"workspace"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("tags = %#v, want %#v", got, want)
+	}
+	if extension.Output.ItemsPath != "items" || extension.Output.CursorPath != "page.nextCursor" || !extension.Output.Count {
+		t.Fatalf("output scalar fields = %#v", extension.Output)
+	}
+	if got, want := extension.Output.Fields, []string{"id", "title", "description"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("output fields = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseExtensionRichOutputMetadata(t *testing.T) {
+	extension, ok := ParseExtension(map[string]any{
+		"enabled": true,
+		"name":    "query_dashboard_page",
+		"risk":    "read",
+		"output": map[string]any{
+			"rootFields": []any{"title", "availableRows"},
+			"collections": []any{
+				map[string]any{
+					"path":   "blocks.a.rows",
+					"as":     "rows",
+					"fields": []any{"order_id", "status"},
+					"count":  true,
+				},
+			},
+			"maps": []any{
+				map[string]any{
+					"path":   "visuals",
+					"as":     "visuals",
+					"fields": []any{"id", "title", "type"},
+					"collection": map[string]any{
+						"path":  "data",
+						"as":    "data",
+						"count": true,
+					},
+				},
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("ParseExtension returned ok=false")
+	}
+	if got, want := extension.Output.RootFields, []string{"title", "availableRows"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("root fields = %#v, want %#v", got, want)
+	}
+	if len(extension.Output.Collections) != 1 {
+		t.Fatalf("collections = %#v, want one collection", extension.Output.Collections)
+	}
+	collection := extension.Output.Collections[0]
+	if collection.Path != "blocks.a.rows" || collection.As != "rows" || !collection.Count {
+		t.Fatalf("collection scalar fields = %#v", collection)
+	}
+	if got, want := collection.Fields, []string{"order_id", "status"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("collection fields = %#v, want %#v", got, want)
+	}
+	if len(extension.Output.Maps) != 1 {
+		t.Fatalf("maps = %#v, want one map", extension.Output.Maps)
+	}
+	outputMap := extension.Output.Maps[0]
+	if outputMap.Path != "visuals" || outputMap.As != "visuals" || outputMap.Collection.Path != "data" || outputMap.Collection.As != "data" || !outputMap.Collection.Count {
+		t.Fatalf("map metadata = %#v", outputMap)
+	}
+	if got, want := outputMap.Fields, []string{"id", "title", "type"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("map fields = %#v, want %#v", got, want)
+	}
+}

--- a/internal/app/agent_tools.go
+++ b/internal/app/agent_tools.go
@@ -332,7 +332,7 @@ func (s *Server) runAPIGenAgentTool(ctx context.Context, scope agentapp.Scope, o
 	if ok := apigenapi.DispatchAPIGenOperation(operation.Contract.OperationID, apiGenAdapter{server: s}, recorder, request); !ok {
 		return apigenAgentToolError("operation_not_found", "APIGen operation is not dispatchable")
 	}
-	return apigenAgentToolResult(recorder.Result())
+	return apigenAgentToolResult(operation.Extension, recorder.Result())
 }
 
 func (s *Server) authorizeAPIGenAgentTool(ctx context.Context, scope agentapp.Scope, operation apigenAgentOperation) (agent.ToolResult, bool) {
@@ -525,7 +525,7 @@ func apigenAgentStringArgument(name string, args map[string]any) (string, bool, 
 	}
 }
 
-func apigenAgentToolResult(response *http.Response) agent.ToolResult {
+func apigenAgentToolResult(extension agenttools.Extension, response *http.Response) agent.ToolResult {
 	defer response.Body.Close()
 	body, _ := io.ReadAll(response.Body)
 	content := map[string]any{
@@ -543,9 +543,203 @@ func apigenAgentToolResult(response *http.Response) agent.ToolResult {
 		return agent.ToolResult{Content: content, IsError: true}
 	}
 	if body, ok := content["body"]; ok {
-		return agent.ToolResult{Content: body}
+		return agent.ToolResult{Content: shapeAPIGenAgentToolContent(body, extension.Output)}
 	}
 	return agent.ToolResult{Content: content}
+}
+
+func shapeAPIGenAgentToolContent(content any, output agenttools.Output) any {
+	if apigenAgentOutputEmpty(output) {
+		return content
+	}
+	shaped := map[string]any{}
+	for _, field := range output.RootFields {
+		if value, ok := valueAtPath(content, field); ok {
+			shaped[agentOutputFieldName(field)] = value
+		}
+	}
+	if output.ItemsPath != "" {
+		applyAPIGenAgentCollection(shaped, content, agenttools.OutputCollection{
+			Path:   output.ItemsPath,
+			As:     "items",
+			Fields: output.Fields,
+			Count:  output.Count,
+		})
+	}
+	for _, collection := range output.Collections {
+		applyAPIGenAgentCollection(shaped, content, collection)
+	}
+	for _, outputMap := range output.Maps {
+		applyAPIGenAgentMap(shaped, content, outputMap)
+	}
+	if output.CursorPath != "" {
+		cursor := stringValueAtPath(content, output.CursorPath)
+		if cursor != "" {
+			shaped["nextCursor"] = cursor
+			shaped["hasMore"] = true
+		} else {
+			shaped["hasMore"] = false
+		}
+	}
+	if _, ok := shaped["hasMore"]; !ok {
+		deriveAPIGenAgentHasMore(shaped)
+	}
+	return shaped
+}
+
+func apigenAgentOutputEmpty(output agenttools.Output) bool {
+	return output.ItemsPath == "" &&
+		len(output.Fields) == 0 &&
+		output.CursorPath == "" &&
+		!output.Count &&
+		len(output.RootFields) == 0 &&
+		len(output.Collections) == 0 &&
+		len(output.Maps) == 0
+}
+
+func applyAPIGenAgentCollection(shaped map[string]any, content any, collection agenttools.OutputCollection) {
+	if collection.Path == "" || collection.As == "" {
+		return
+	}
+	value, ok := valueAtPath(content, collection.Path)
+	if !ok {
+		return
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return
+	}
+	shaped[collection.As] = projectAPIGenAgentItems(items, collection.Fields)
+	if collection.Count {
+		shaped["count"] = len(items)
+	}
+}
+
+func applyAPIGenAgentMap(shaped map[string]any, content any, outputMap agenttools.OutputMap) {
+	if outputMap.Path == "" || outputMap.As == "" {
+		return
+	}
+	value, ok := valueAtPath(content, outputMap.Path)
+	if !ok {
+		return
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	out := make(map[string]any, len(object))
+	for key, value := range object {
+		projected := projectAPIGenAgentObject(value, outputMap.Fields)
+		if outputMap.Collection.Path != "" && outputMap.Collection.As != "" {
+			applyAPIGenAgentCollection(projected, value, outputMap.Collection)
+		}
+		out[key] = projected
+	}
+	shaped[outputMap.As] = out
+}
+
+func projectAPIGenAgentItems(items []any, fields []string) []any {
+	if len(fields) == 0 {
+		out := make([]any, len(items))
+		copy(out, items)
+		return out
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		object, ok := item.(map[string]any)
+		if !ok {
+			out = append(out, item)
+			continue
+		}
+		projected := map[string]any{}
+		for _, field := range fields {
+			if value, ok := object[field]; ok {
+				projected[field] = value
+			}
+		}
+		out = append(out, projected)
+	}
+	return out
+}
+
+func projectAPIGenAgentObject(value any, fields []string) map[string]any {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	if len(fields) == 0 {
+		out := make(map[string]any, len(object))
+		for key, value := range object {
+			out[key] = value
+		}
+		return out
+	}
+	projected := map[string]any{}
+	for _, field := range fields {
+		if value, ok := valueAtPath(object, field); ok {
+			projected[agentOutputFieldName(field)] = value
+		}
+	}
+	return projected
+}
+
+func deriveAPIGenAgentHasMore(shaped map[string]any) {
+	count, ok := intFromAny(shaped["count"])
+	if !ok {
+		return
+	}
+	availableRows, ok := intFromAny(shaped["availableRows"])
+	if !ok {
+		return
+	}
+	shaped["hasMore"] = availableRows > count
+}
+
+func intFromAny(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int32:
+		return int(typed), true
+	case int64:
+		return int(typed), true
+	case float64:
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
+func agentOutputFieldName(path string) string {
+	parts := strings.Split(path, ".")
+	return parts[len(parts)-1]
+}
+
+func valueAtPath(value any, path string) (any, bool) {
+	current := value
+	for _, part := range strings.Split(path, ".") {
+		if part == "" {
+			return nil, false
+		}
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = object[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func stringValueAtPath(value any, path string) string {
+	raw, ok := valueAtPath(value, path)
+	if !ok {
+		return ""
+	}
+	text, _ := raw.(string)
+	return strings.TrimSpace(text)
 }
 
 func apigenAgentToolError(code, message string) agent.ToolResult {

--- a/internal/app/agent_tools_test.go
+++ b/internal/app/agent_tools_test.go
@@ -385,18 +385,26 @@ func TestAPIGenAgentSearchToolInjectsDefaultLimit(t *testing.T) {
 		t.Fatalf("marshal result content: %v", err)
 	}
 	var decoded struct {
-		Items []map[string]any `json:"items"`
-		Page  struct {
-			NextCursor string `json:"nextCursor"`
-		} `json:"page"`
+		Count      int              `json:"count"`
+		Items      []map[string]any `json:"items"`
+		HasMore    bool             `json:"hasMore"`
+		NextCursor string           `json:"nextCursor"`
 	}
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("decode result: %v body=%s", err, body)
 	}
-	if len(decoded.Items) == 0 || len(decoded.Items) > 10 {
+	if decoded.Count != len(decoded.Items) || len(decoded.Items) == 0 || len(decoded.Items) > 10 {
 		t.Fatalf("search result count = %d, want 1..10: %#v", len(decoded.Items), decoded.Items)
 	}
+	if decoded.HasMore || decoded.NextCursor != "" {
+		t.Fatalf("search should not expose empty cursor metadata: %#v", decoded)
+	}
 	for _, item := range decoded.Items {
+		for _, forbidden := range []string{"dashboardId", "pageId", "visualId", "tableId", "filterId", "modelId", "datasetId", "fieldId", "assetId"} {
+			if _, ok := item[forbidden]; ok {
+				t.Fatalf("search item kept metadata field %q: %#v", forbidden, item)
+			}
+		}
 		if _, ok := item["name"]; !ok {
 			t.Fatalf("search item missing concise name: %#v", item)
 		}
@@ -406,6 +414,178 @@ func TestAPIGenAgentSearchToolInjectsDefaultLimit(t *testing.T) {
 		if _, ok := item["type"]; !ok {
 			t.Fatalf("search item missing concise type: %#v", item)
 		}
+	}
+}
+
+func TestAPIGenAgentListWorkspacesUsesDeclarativeOutputShape(t *testing.T) {
+	server := NewWithOptions(fakeMetrics{}, Options{DefaultWorkspaceID: "test"})
+	tools := server.agentAPIGenToolDefinitions(agentapp.Scope{WorkspaceID: "test", PrincipalID: "principal"})
+	var listWorkspaces agent.ToolDefinition
+	for _, tool := range tools {
+		if tool.Name == "list_workspaces" {
+			listWorkspaces = tool
+			break
+		}
+	}
+	if listWorkspaces.Handler == nil {
+		t.Fatal("list_workspaces tool missing")
+	}
+	result, err := listWorkspaces.Handler.Run(context.Background(), agent.ToolCall{
+		ID:        "call_1",
+		Name:      "list_workspaces",
+		Arguments: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("run list_workspaces: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %#v", result.Content)
+	}
+	body, err := json.Marshal(result.Content)
+	if err != nil {
+		t.Fatalf("marshal result content: %v", err)
+	}
+	var decoded struct {
+		Count      int              `json:"count"`
+		Items      []map[string]any `json:"items"`
+		HasMore    bool             `json:"hasMore"`
+		NextCursor string           `json:"nextCursor"`
+		Page       any              `json:"page"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode result: %v body=%s", err, body)
+	}
+	if decoded.Count != len(decoded.Items) || decoded.Count == 0 || decoded.HasMore || decoded.NextCursor != "" || decoded.Page != nil {
+		t.Fatalf("workspace shaped result metadata = %#v body=%s", decoded, body)
+	}
+	for _, item := range decoded.Items {
+		if _, ok := item["id"]; !ok {
+			t.Fatalf("workspace item missing id: %#v", item)
+		}
+		if _, ok := item["title"]; !ok {
+			t.Fatalf("workspace item missing title: %#v", item)
+		}
+		if _, ok := item["description"]; !ok {
+			t.Fatalf("workspace item missing description: %#v", item)
+		}
+		for _, forbidden := range []string{"activeDeploymentId", "createdAt", "updatedAt"} {
+			if _, ok := item[forbidden]; ok {
+				t.Fatalf("workspace item kept noisy metadata field %q: %#v", forbidden, item)
+			}
+		}
+	}
+}
+
+func TestAPIGenAgentOutputShapeKeepsNonEmptyCursor(t *testing.T) {
+	shaped := shapeAPIGenAgentToolContent(map[string]any{
+		"items": []any{
+			map[string]any{"id": "one", "title": "One", "description": "First", "createdAt": "ignored"},
+		},
+		"page": map[string]any{"nextCursor": "cursor-1"},
+	}, agenttools.Output{
+		ItemsPath:  "items",
+		Fields:     []string{"id", "title"},
+		CursorPath: "page.nextCursor",
+		Count:      true,
+	})
+	decoded, ok := shaped.(map[string]any)
+	if !ok {
+		t.Fatalf("shaped content type = %T", shaped)
+	}
+	if decoded["count"] != 1 || decoded["hasMore"] != true || decoded["nextCursor"] != "cursor-1" {
+		t.Fatalf("shaped cursor metadata = %#v", decoded)
+	}
+	if _, ok := decoded["page"]; ok {
+		t.Fatalf("shaped output kept raw page metadata: %#v", decoded)
+	}
+}
+
+func TestAPIGenAgentOutputShapeProjectsRootsCollectionsAndMaps(t *testing.T) {
+	shaped := shapeAPIGenAgentToolContent(map[string]any{
+		"title":         "Orders",
+		"availableRows": 7,
+		"style":         map[string]any{"density": "compact"},
+		"blocks": map[string]any{
+			"a": map[string]any{
+				"rows": []any{
+					map[string]any{"order_id": "o1", "status": "delivered", "internal": true},
+					map[string]any{"order_id": "o2", "status": "shipped", "internal": false},
+				},
+			},
+		},
+		"visuals": map[string]any{
+			"orders": map[string]any{
+				"id":              "orders",
+				"title":           "Orders",
+				"type":            "bar",
+				"rendererOptions": map[string]any{"hidden": true},
+				"data": []any{
+					map[string]any{"label": "delivered", "value": 1, "extra": "ignored"},
+				},
+			},
+		},
+	}, agenttools.Output{
+		RootFields: []string{"title", "availableRows"},
+		Collections: []agenttools.OutputCollection{{
+			Path:   "blocks.a.rows",
+			As:     "rows",
+			Fields: []string{"order_id", "status"},
+			Count:  true,
+		}},
+		Maps: []agenttools.OutputMap{{
+			Path:   "visuals",
+			As:     "visuals",
+			Fields: []string{"id", "title", "type"},
+			Collection: agenttools.OutputCollection{
+				Path:  "data",
+				As:    "data",
+				Count: true,
+			},
+		}},
+	})
+	decoded, ok := shaped.(map[string]any)
+	if !ok {
+		t.Fatalf("shaped content type = %T", shaped)
+	}
+	if decoded["title"] != "Orders" || decoded["availableRows"] != 7 || decoded["count"] != 2 || decoded["hasMore"] != true {
+		t.Fatalf("root/count metadata = %#v", decoded)
+	}
+	rows, ok := decoded["rows"].([]any)
+	if !ok || len(rows) != 2 {
+		t.Fatalf("rows = %#v", decoded["rows"])
+	}
+	firstRow := rows[0].(map[string]any)
+	if firstRow["order_id"] != "o1" || firstRow["status"] != "delivered" {
+		t.Fatalf("projected row = %#v", firstRow)
+	}
+	if _, ok := firstRow["internal"]; ok {
+		t.Fatalf("row kept noisy field: %#v", firstRow)
+	}
+	visuals := decoded["visuals"].(map[string]any)
+	orders := visuals["orders"].(map[string]any)
+	if orders["id"] != "orders" || orders["title"] != "Orders" || orders["type"] != "bar" || orders["count"] != 1 {
+		t.Fatalf("projected visual = %#v", orders)
+	}
+	if _, ok := orders["rendererOptions"]; ok {
+		t.Fatalf("visual kept renderer options: %#v", orders)
+	}
+}
+
+func TestAPIGenAgentOutputShapeOmitsMissingPathsAndFallbackRawWithoutMetadata(t *testing.T) {
+	raw := map[string]any{"body": "raw"}
+	if shaped := shapeAPIGenAgentToolContent(raw, agenttools.Output{}); !reflect.DeepEqual(shaped, raw) {
+		t.Fatalf("empty output metadata should preserve raw content: %#v", shaped)
+	}
+	shaped := shapeAPIGenAgentToolContent(raw, agenttools.Output{
+		RootFields:  []string{"missing"},
+		Collections: []agenttools.OutputCollection{{Path: "items", As: "items", Count: true}},
+	})
+	decoded, ok := shaped.(map[string]any)
+	if !ok {
+		t.Fatalf("shaped missing-path content type = %T", shaped)
+	}
+	if len(decoded) != 0 {
+		t.Fatalf("missing paths should be omitted without falling back to raw: %#v", decoded)
 	}
 }
 
@@ -455,6 +635,14 @@ func TestAPIGenAgentToolsExposeTypeSpecArgumentNamesAndBodyFields(t *testing.T) 
 	}
 }
 
+func TestAPIGenAgentOperationsDeclareOutputMetadata(t *testing.T) {
+	for _, operation := range agenttools.APIGenOperations() {
+		if outputMetadataEmpty(operation.Extension.Output) {
+			t.Fatalf("agent operation %s (%s) does not declare x-agent.output metadata", operation.Contract.OperationID, operation.Extension.Name)
+		}
+	}
+}
+
 func TestAPIGenAgentToolDispatchesThroughGeneratedOperation(t *testing.T) {
 	catalog := testAgentAssetCatalogFromProvider(t, manyEdgesMetrics{})
 	server := NewWithOptions(manyEdgesMetrics{}, Options{
@@ -489,21 +677,63 @@ func TestAPIGenAgentToolDispatchesThroughGeneratedOperation(t *testing.T) {
 		t.Fatalf("marshal result content: %v", err)
 	}
 	var decoded struct {
+		Count int `json:"count"`
 		Items []struct {
 			ID          string `json:"id"`
-			WorkspaceID string `json:"workspaceId"`
 			Type        string `json:"type"`
-			Payload     any    `json:"payload"`
+			Title       string `json:"title"`
+			Description string `json:"description"`
 		} `json:"items"`
 	}
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("decode result: %v\n%s", err, body)
 	}
-	if len(decoded.Items) != 1 || decoded.Items[0].ID != "dashboard:dashboard-0" || decoded.Items[0].WorkspaceID != "test" || decoded.Items[0].Type != "dashboard" {
-		t.Fatalf("tool result = %#v", decoded.Items)
+	if decoded.Count != 1 || len(decoded.Items) != 1 || decoded.Items[0].ID != "dashboard:dashboard-0" || decoded.Items[0].Type != "dashboard" || decoded.Items[0].Title == "" {
+		t.Fatalf("tool result = %#v", decoded)
 	}
-	if decoded.Items[0].Payload != nil {
-		t.Fatalf("list_assets returned payload in summary row: %#v", decoded.Items[0])
+}
+
+func TestAPIGenAgentDescribeDashboardVisualUsesDeclarativeOutputShape(t *testing.T) {
+	server := NewWithOptions(fakeMetrics{}, Options{DefaultWorkspaceID: "test"})
+	tools := server.agentAPIGenToolDefinitions(agentapp.Scope{WorkspaceID: "test", PrincipalID: "principal"})
+	var describeVisual agent.ToolDefinition
+	for _, tool := range tools {
+		if tool.Name == "describe_dashboard_visual" {
+			describeVisual = tool
+			break
+		}
+	}
+	if describeVisual.Handler == nil {
+		t.Fatal("describe_dashboard_visual tool missing")
+	}
+	result, err := describeVisual.Handler.Run(context.Background(), agent.ToolCall{
+		ID:        "call_1",
+		Name:      "describe_dashboard_visual",
+		Arguments: json.RawMessage(`{"dashboard":"executive-sales","page":"overview","visual":"orders"}`),
+	})
+	if err != nil {
+		t.Fatalf("run describe_dashboard_visual: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %#v", result.Content)
+	}
+	body, err := json.Marshal(result.Content)
+	if err != nil {
+		t.Fatalf("marshal result content: %v", err)
+	}
+	var visual map[string]any
+	if err := json.Unmarshal(body, &visual); err != nil {
+		t.Fatalf("decode visual result: %v body=%s", err, body)
+	}
+	for _, want := range []string{"id", "title", "kind", "type", "query"} {
+		if _, ok := visual[want]; !ok {
+			t.Fatalf("visual result missing %q: %#v", want, visual)
+		}
+	}
+	for _, forbidden := range []string{"componentId", "renderer", "rendererOptions", "options", "interaction", "placement", "x", "y", "width", "height"} {
+		if _, ok := visual[forbidden]; ok {
+			t.Fatalf("visual result kept noisy field %q: %#v", forbidden, visual)
+		}
 	}
 }
 
@@ -537,19 +767,26 @@ func TestAPIGenAgentAssetDescribeAndLineageToolsUseTypeSpecContracts(t *testing.
 		t.Fatalf("marshal describe_asset: %v", err)
 	}
 	var described struct {
-		ID            string         `json:"id"`
-		SnapshotID    string         `json:"snapshotId"`
-		PayloadSchema string         `json:"payloadSchema"`
-		Payload       map[string]any `json:"payload"`
+		ID            string `json:"id"`
+		Type          string `json:"type"`
+		Title         string `json:"title"`
+		Description   string `json:"description"`
+		PayloadSchema string `json:"payloadSchema"`
 	}
 	if err := json.Unmarshal(body, &described); err != nil {
 		t.Fatalf("decode describe_asset: %v body=%s", err, body)
 	}
-	if described.ID != "visual:executive-sales.revenue" || described.SnapshotID == "" || described.PayloadSchema != "visual.v1" || described.Payload["query_kind"] != "aggregate" {
+	if described.ID != "visual:executive-sales.revenue" || described.Type != "visual" || described.Title != "Revenue" || described.PayloadSchema != "visual.v1" {
 		t.Fatalf("describe_asset result = %#v", described)
 	}
-	if _, ok := described.Payload["auth"]; ok {
-		t.Fatalf("describe_asset leaked auth payload: %#v", described.Payload)
+	var describedMap map[string]any
+	if err := json.Unmarshal(body, &describedMap); err != nil {
+		t.Fatalf("decode describe_asset map: %v", err)
+	}
+	for _, forbidden := range []string{"snapshotId", "workspaceId", "deploymentId", "payload", "key", "sourceFile"} {
+		if _, ok := describedMap[forbidden]; ok {
+			t.Fatalf("describe_asset kept noisy field %q: %#v", forbidden, describedMap)
+		}
 	}
 
 	result, err = names["asset_lineage"].Handler.Run(context.Background(), agent.ToolCall{
@@ -574,6 +811,58 @@ func TestAPIGenAgentAssetDescribeAndLineageToolsUseTypeSpecContracts(t *testing.
 	}
 	if lineage.AssetID != "visual:executive-sales.revenue" || !stringSliceHas(lineage.Upstream, "dashboard:executive-sales") || !stringSliceHas(lineage.Downstream, "measure:olist.revenue") {
 		t.Fatalf("asset_lineage result = %#v", lineage)
+	}
+}
+
+func TestAPIGenAgentQueryDashboardPageUsesDeclarativeOutputShape(t *testing.T) {
+	server := NewWithOptions(fakeMetrics{}, Options{DefaultWorkspaceID: "test"})
+	tools := server.agentAPIGenToolDefinitions(agentapp.Scope{WorkspaceID: "test", PrincipalID: "principal"})
+	var queryPage agent.ToolDefinition
+	for _, tool := range tools {
+		if tool.Name == "query_dashboard_page" {
+			queryPage = tool
+			break
+		}
+	}
+	if queryPage.Handler == nil {
+		t.Fatal("query_dashboard_page tool missing")
+	}
+	result, err := queryPage.Handler.Run(context.Background(), agent.ToolCall{
+		ID:        "call_1",
+		Name:      "query_dashboard_page",
+		Arguments: json.RawMessage(`{"dashboard":"executive-sales","page":"overview"}`),
+	})
+	if err != nil {
+		t.Fatalf("run query_dashboard_page: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %#v", result.Content)
+	}
+	body, err := json.Marshal(result.Content)
+	if err != nil {
+		t.Fatalf("marshal result content: %v", err)
+	}
+	var page map[string]any
+	if err := json.Unmarshal(body, &page); err != nil {
+		t.Fatalf("decode page result: %v body=%s", err, body)
+	}
+	visuals, ok := page["visuals"].(map[string]any)
+	if !ok || len(visuals) == 0 {
+		t.Fatalf("page result missing compact visuals map: %#v", page)
+	}
+	orders := visuals["orders"].(map[string]any)
+	if orders["title"] != "Orders" || orders["count"] != float64(1) {
+		t.Fatalf("compact visual = %#v", orders)
+	}
+	for _, forbidden := range []string{"filters", "filterOptions", "status"} {
+		if _, ok := page[forbidden]; ok {
+			t.Fatalf("page result kept noisy field %q: %#v", forbidden, page)
+		}
+	}
+	for _, forbidden := range []string{"rendererOptions", "options", "interaction", "selection", "version"} {
+		if _, ok := orders[forbidden]; ok {
+			t.Fatalf("compact visual kept noisy field %q: %#v", forbidden, orders)
+		}
 	}
 }
 
@@ -610,16 +899,26 @@ func TestAPIGenAgentListToolInjectsDefaultLimit(t *testing.T) {
 		t.Fatalf("marshal result content: %v", err)
 	}
 	var decoded struct {
-		Items []map[string]any `json:"items"`
-		Page  struct {
-			NextCursor string `json:"nextCursor"`
-		} `json:"page"`
+		Count      int              `json:"count"`
+		Items      []map[string]any `json:"items"`
+		HasMore    bool             `json:"hasMore"`
+		NextCursor string           `json:"nextCursor"`
 	}
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("decode result: %v body=%s", err, body)
 	}
-	if len(decoded.Items) != 25 || decoded.Page.NextCursor == "" {
-		t.Fatalf("default-limited edge result = count %d cursor %q", len(decoded.Items), decoded.Page.NextCursor)
+	if decoded.Count != 25 || len(decoded.Items) != 25 || !decoded.HasMore || decoded.NextCursor == "" {
+		t.Fatalf("default-limited edge result = %#v", decoded)
+	}
+	for _, item := range decoded.Items {
+		for _, want := range []string{"fromAssetId", "toAssetId", "type"} {
+			if _, ok := item[want]; !ok {
+				t.Fatalf("edge item missing %q: %#v", want, item)
+			}
+		}
+		if _, ok := item["deploymentId"]; ok {
+			t.Fatalf("edge item kept noisy metadata: %#v", item)
+		}
 	}
 
 	result, err = listEdges.Handler.Run(context.Background(), agent.ToolCall{
@@ -634,8 +933,8 @@ func TestAPIGenAgentListToolInjectsDefaultLimit(t *testing.T) {
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("decode explicit result: %v body=%s", err, body)
 	}
-	if len(decoded.Items) != 3 {
-		t.Fatalf("explicit-limited edge count = %d, want 3", len(decoded.Items))
+	if decoded.Count != 3 || len(decoded.Items) != 3 {
+		t.Fatalf("explicit-limited edge result = %#v", decoded)
 	}
 }
 
@@ -668,16 +967,26 @@ func TestAPIGenAgentToolDispatchesJSONBodyOperation(t *testing.T) {
 		t.Fatalf("marshal result content: %v", err)
 	}
 	var table struct {
-		AvailableRows int `json:"availableRows"`
-		Blocks        map[string]struct {
-			Rows []map[string]any `json:"rows"`
-		} `json:"blocks"`
+		AvailableRows int              `json:"availableRows"`
+		Count         int              `json:"count"`
+		HasMore       bool             `json:"hasMore"`
+		Columns       []map[string]any `json:"columns"`
+		Rows          []map[string]any `json:"rows"`
 	}
 	if err := json.Unmarshal(body, &table); err != nil {
 		t.Fatalf("decode table result: %v\n%s", err, body)
 	}
-	if table.AvailableRows != 50 || len(table.Blocks["a"].Rows) != 50 {
+	if table.AvailableRows != 50 || table.Count != 50 || len(table.Rows) != 50 || len(table.Columns) == 0 {
 		t.Fatalf("table result was not capped to 50: %#v", table)
+	}
+	var tableMap map[string]any
+	if err := json.Unmarshal(body, &tableMap); err != nil {
+		t.Fatalf("decode table map: %v", err)
+	}
+	for _, forbidden := range []string{"blocks", "style", "interaction", "selection", "chunkSize", "rowHeight", "resetVersion", "loadingBlock"} {
+		if _, ok := tableMap[forbidden]; ok {
+			t.Fatalf("table result kept noisy field %q: %#v", forbidden, tableMap)
+		}
 	}
 }
 
@@ -711,13 +1020,23 @@ func TestAPIGenAgentToolFetchesSingleDashboardVisualData(t *testing.T) {
 	}
 	var visual struct {
 		Title string           `json:"title"`
+		Count int              `json:"count"`
 		Data  []map[string]any `json:"data"`
 	}
 	if err := json.Unmarshal(body, &visual); err != nil {
 		t.Fatalf("decode visual result: %v body=%s", err, body)
 	}
-	if visual.Title != "Orders" || len(visual.Data) != 1 {
+	if visual.Title != "Orders" || visual.Count != 1 || len(visual.Data) != 1 {
 		t.Fatalf("visual result = %#v", visual)
+	}
+	var visualMap map[string]any
+	if err := json.Unmarshal(body, &visualMap); err != nil {
+		t.Fatalf("decode visual map: %v", err)
+	}
+	for _, forbidden := range []string{"renderer", "rendererOptions", "options", "interaction", "selection", "version"} {
+		if _, ok := visualMap[forbidden]; ok {
+			t.Fatalf("visual result kept noisy field %q: %#v", forbidden, visualMap)
+		}
 	}
 }
 
@@ -750,16 +1069,24 @@ func TestAPIGenAgentSemanticQueryToolInjectsBodyDefaultLimit(t *testing.T) {
 		t.Fatalf("marshal result content: %v", err)
 	}
 	var decoded struct {
-		Items []map[string]any `json:"items"`
-		Page  struct {
-			NextCursor string `json:"nextCursor"`
-		} `json:"page"`
+		Columns    []string         `json:"columns"`
+		Items      []map[string]any `json:"items"`
+		Count      int              `json:"count"`
+		HasMore    bool             `json:"hasMore"`
+		NextCursor string           `json:"nextCursor"`
 	}
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("decode semantic result: %v body=%s", err, body)
 	}
-	if len(decoded.Items) != 25 || decoded.Page.NextCursor == "" {
+	if len(decoded.Columns) == 0 || len(decoded.Items) != 25 || decoded.Count != 25 || !decoded.HasMore || decoded.NextCursor == "" {
 		t.Fatalf("semantic default-limited result = %#v", decoded)
+	}
+	var decodedMap map[string]any
+	if err := json.Unmarshal(body, &decodedMap); err != nil {
+		t.Fatalf("decode semantic map: %v", err)
+	}
+	if _, ok := decodedMap["page"]; ok {
+		t.Fatalf("semantic result kept raw page metadata: %#v", decodedMap)
 	}
 }
 
@@ -830,6 +1157,16 @@ func sortedToolNames(tools []agent.ToolDefinition) []string {
 	names := toolNames(tools)
 	sort.Strings(names)
 	return names
+}
+
+func outputMetadataEmpty(output agenttools.Output) bool {
+	return output.ItemsPath == "" &&
+		len(output.Fields) == 0 &&
+		output.CursorPath == "" &&
+		!output.Count &&
+		len(output.RootFields) == 0 &&
+		len(output.Collections) == 0 &&
+		len(output.Maps) == 0
 }
 
 type fakeAssetCatalogReader struct {

--- a/internal/app/bi_api_test.go
+++ b/internal/app/bi_api_test.go
@@ -336,6 +336,7 @@ func (manyRowsMetrics) QueryTablePage(_ context.Context, _ string, _ string, _ d
 	}
 	return dashboard.Table{
 		Title:         "Orders",
+		Columns:       []dashboard.TableColumn{{Key: "order_id", Label: "Order"}},
 		AvailableRows: len(rows),
 		Blocks:        map[string]dashboard.TableBlock{"a": {Rows: rows}},
 	}, nil

--- a/internal/ui/signals/types.go
+++ b/internal/ui/signals/types.go
@@ -646,8 +646,10 @@ type ChatTranscriptItemSignal struct {
 	Summary        string              `json:"summary,omitempty"`
 	ResultSummary  string              `json:"resultSummary,omitempty"`
 	InputJSON      string              `json:"inputJson,omitempty"`
+	InputFormat    string              `json:"inputFormat,omitempty"`
 	ArgumentsJSON  string              `json:"argumentsJson,omitempty"`
 	ResultJSON     string              `json:"resultJson,omitempty"`
+	ResultFormat   string              `json:"resultFormat,omitempty"`
 	Artifact       *ChatArtifactSignal `json:"artifact,omitempty"`
 	Error          string              `json:"error,omitempty"`
 	ConversationID string              `json:"conversationId,omitempty"`
@@ -682,8 +684,10 @@ func ChatTranscriptItem(item agentapp.ChatTranscriptItem) ChatTranscriptItemSign
 		Summary:        item.Summary,
 		ResultSummary:  item.ResultSummary,
 		InputJSON:      item.InputJSON,
+		InputFormat:    item.InputFormat,
 		ArgumentsJSON:  item.ArgumentsJSON,
 		ResultJSON:     item.ResultJSON,
+		ResultFormat:   item.ResultFormat,
 		Error:          item.Error,
 		ConversationID: item.ConversationID,
 		RunID:          item.RunID,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:chat-composer": "playwright install chromium && bun scripts/build_test_assets.ts chat-composer && bun test web/components/chat/chat-composer.dom.test.ts",
     "test:chat-page": "playwright install chromium && bun scripts/build_test_assets.ts chat-page && bun test web/components/chat/chat-page.dom.test.ts",
     "test:chat-thread": "playwright install chromium && bun scripts/build_test_assets.ts chat-thread && bun test web/components/chat/chat-thread.dom.test.ts",
+    "test:code-block": "playwright install chromium && bun scripts/build_test_assets.ts code-block && bun test web/components/shared/code-block.dom.test.ts",
     "test:workspace-page": "playwright install chromium && bun scripts/build_test_assets.ts workspace-page && bun test web/components/workspace/workspace-page.dom.test.ts",
     "test:admin-page": "playwright install chromium && bun scripts/build_test_assets.ts admin-page && bun test web/components/admin/admin-page.dom.test.ts",
     "test:code-editor": "playwright install chromium && bun scripts/build_test_assets.ts code-editor && bun test web/components/shared/code-editor.dom.test.ts",

--- a/pkg/agent/README.md
+++ b/pkg/agent/README.md
@@ -168,9 +168,13 @@ The harness validates tool calls before handlers run:
 - malformed JSON arguments
 - JSON Schema failures
 - non-serializable outputs
-- overlarge outputs
+- outputs that remain overlarge after truncation
 
-Validation and ordinary handler failures become model-visible tool-result
+Successful tool results are normalized, truncated, and serialized as TOON by
+default before they are sent back to the model. Set
+`Definition.ToolOutput.Format` to `ToolOutputJSON` only when an embedding
+application needs JSON model-visible tool results. Validation and ordinary
+handler failures use the same formatter and become model-visible tool-result
 messages, allowing the model to repair the next call. Fatal tool outcomes stop
 the run after appending the tool result:
 
@@ -231,11 +235,18 @@ Default limits are intentionally conservative:
 - `MaxToolCalls`: 64 per run
 - `MaxConcurrentTools`: 4 per assistant turn
 - `ToolTimeout`: 30 seconds
-- `MaxToolResultBytes`: 64 KiB after JSON serialization
+- `MaxToolResultBytes`: 64 KiB after tool-output formatting and truncation
 - `ContextWindowTokens`: 128000
 - `ReserveOutputTokens`: 4096
 
 Set limits in `agent.Definition` when constructing the harness.
+
+Default tool-output policy:
+
+- `Format`: `ToolOutputTOON`
+- `MaxStringChars`: 2000
+- `MaxArrayItems`: 50
+- `MaxObjectDepth`: 8
 
 ## Boundaries
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -58,6 +58,9 @@ func New(def Definition) (*Agent, error) {
 	if err := validateLimits(def.Limits); err != nil {
 		return nil, err
 	}
+	if err := validateToolOutputConfig(def.ToolOutput); err != nil {
+		return nil, err
+	}
 	tools, specs, err := compileTools(def.Tools)
 	if err != nil {
 		return nil, err

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -41,6 +41,9 @@ func TestNewAppliesDefaultsAndValidatesDefinition(t *testing.T) {
 	if a.def.Limits.MaxToolDisplayBytes != 1024*1024 {
 		t.Fatalf("MaxToolDisplayBytes = %d, want 1MiB", a.def.Limits.MaxToolDisplayBytes)
 	}
+	if a.def.ToolOutput.Format != ToolOutputTOON || a.def.ToolOutput.MaxStringChars != 2000 || a.def.ToolOutput.MaxArrayItems != 50 || a.def.ToolOutput.MaxObjectDepth != 8 {
+		t.Fatalf("ToolOutput defaults = %#v", a.def.ToolOutput)
+	}
 	if a.def.Compaction.KeepLastTurns != 8 {
 		t.Fatalf("KeepLastTurns = %d, want 8", a.def.Compaction.KeepLastTurns)
 	}
@@ -95,6 +98,16 @@ func TestNewAppliesDefaultsAndValidatesDefinition(t *testing.T) {
 				SystemPrompt: "x",
 				Model:        model,
 				Limits:       Limits{MaxTurns: -1},
+			},
+			want: ErrorCodeInvalidArgument,
+		},
+		{
+			name: "bad tool output format",
+			def: Definition{
+				Name:         "bad",
+				SystemPrompt: "x",
+				Model:        model,
+				ToolOutput:   ToolOutputConfig{Format: "xml"},
 			},
 			want: ErrorCodeInvalidArgument,
 		},

--- a/pkg/agent/definition.go
+++ b/pkg/agent/definition.go
@@ -18,6 +18,7 @@ type Definition struct {
 
 	Tools             []ToolDefinition
 	Limits            Limits
+	ToolOutput        ToolOutputConfig
 	Compaction        CompactionConfig
 	InitialTranscript []Message
 
@@ -28,6 +29,7 @@ type Definition struct {
 
 func (d Definition) withDefaults() Definition {
 	d.Limits = defaultLimits(d.Limits)
+	d.ToolOutput = defaultToolOutputConfig(d.ToolOutput)
 	d.Compaction = defaultCompaction(d.Compaction)
 	if d.Events == nil {
 		d.Events = noopEventSink{}

--- a/pkg/agent/spec.md
+++ b/pkg/agent/spec.md
@@ -27,7 +27,7 @@ The package is designed for LibreDash first, but it must be generic enough to li
 - OpenAI-compatible provider contract: model requests and responses follow the OpenAI-compatible chat/tool API used by providers such as OpenAI and DeepSeek.
 - Provider flexibility through compatibility: OpenAI, DeepSeek, OpenAI-compatible gateways, local compatible endpoints, and test fakes can sit behind the same client interface. Non-compatible providers must adapt to the OpenAI-compatible API outside the core.
 - Tool schema convention: tool inputs use JSON Schema-compatible objects because that is the OpenAI tool contract.
-- Tool validation is part of the harness: unknown tools, malformed JSON arguments, schema validation failures, handler failures, and overlarge outputs are converted into clear model-visible tool results.
+- Tool validation is part of the harness: unknown tools, malformed JSON arguments, schema validation failures, handler failures, and outputs that remain overlarge after truncation are converted into clear model-visible tool results.
 - Compaction is part of the harness: keep the last configured turns verbatim and summarize older turns into a model-visible summary message.
 - Context-first cancellation: all model calls and tool calls receive `context.Context`.
 - Deterministic state boundaries: one run uses the harness configuration supplied at construction time.
@@ -111,6 +111,7 @@ type Definition struct {
 
 	Tools      []ToolDefinition
 	Limits     Limits
+	ToolOutput ToolOutputConfig
 	Compaction CompactionConfig
 
 	Events EventSink
@@ -141,7 +142,7 @@ Default limits:
 - `MaxToolCalls`: 64 per run
 - `MaxConcurrentTools`: 4 per assistant turn
 - `ToolTimeout`: 30 seconds
-- `MaxToolResultBytes`: 64 KiB after JSON serialization
+- `MaxToolResultBytes`: 64 KiB after tool-output formatting and truncation
 - `ReserveOutputTokens`: 4096
 - `HardInputLimitTokens`: `ContextWindowTokens - ReserveOutputTokens`
 
@@ -289,7 +290,8 @@ Validation rules:
 - Tool arguments must be valid JSON.
 - Tool arguments must satisfy the tool input schema.
 - Tool output must be JSON-serializable.
-- Tool output must fit the configured result-size limit after serialization.
+- Tool output is normalized, truncated, and serialized as TOON by default.
+- Tool output must fit the configured result-size limit after formatting and truncation.
 
 If validation fails, the harness does not call the handler. It appends a tool-result message with `is_error=true` and a concise, model-readable payload.
 

--- a/pkg/agent/tool_output.go
+++ b/pkg/agent/tool_output.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
-	"unicode"
+
+	toon "github.com/toon-format/toon-go"
 )
 
 type ToolOutputFormat string
@@ -92,7 +92,7 @@ func formatToolOutput(value any, config ToolOutputConfig) (string, error) {
 		}
 		return string(body), nil
 	default:
-		return serializeTOON(truncated), nil
+		return toon.MarshalString(truncated)
 	}
 }
 
@@ -178,166 +178,6 @@ func truncationsAsValues(truncations []toolOutputTruncation) []any {
 		out[i] = item
 	}
 	return out
-}
-
-func serializeTOON(value any) string {
-	var b strings.Builder
-	writeTOONValue(&b, "", value, 0, true)
-	return strings.TrimRight(b.String(), "\n")
-}
-
-func writeTOONValue(b *strings.Builder, key string, value any, indent int, root bool) {
-	prefix := strings.Repeat("  ", indent)
-	switch typed := value.(type) {
-	case map[string]any:
-		if !root && key != "" {
-			b.WriteString(prefix)
-			b.WriteString(key)
-			b.WriteString(":\n")
-			indent++
-			prefix = strings.Repeat("  ", indent)
-		}
-		for _, childKey := range sortedToolOutputKeys(typed) {
-			writeTOONValue(b, childKey, typed[childKey], indent, false)
-		}
-	case []any:
-		writeTOONArray(b, key, typed, indent)
-	default:
-		b.WriteString(prefix)
-		if key != "" {
-			b.WriteString(key)
-			b.WriteString(": ")
-		}
-		b.WriteString(toTOONScalar(typed))
-		b.WriteByte('\n')
-	}
-}
-
-func writeTOONArray(b *strings.Builder, key string, values []any, indent int) {
-	prefix := strings.Repeat("  ", indent)
-	if len(values) == 0 {
-		b.WriteString(prefix)
-		b.WriteString(key)
-		b.WriteString("[0]:\n")
-		return
-	}
-	fields, objects := toonArrayFields(values)
-	if objects {
-		b.WriteString(prefix)
-		b.WriteString(key)
-		b.WriteString("[")
-		b.WriteString(strconv.Itoa(len(values)))
-		b.WriteString("]{")
-		b.WriteString(strings.Join(fields, ","))
-		b.WriteString("}:\n")
-		for _, value := range values {
-			object := value.(map[string]any)
-			b.WriteString(prefix)
-			b.WriteString("  ")
-			for i, field := range fields {
-				if i > 0 {
-					b.WriteByte(',')
-				}
-				b.WriteString(toTOONScalar(object[field]))
-			}
-			b.WriteByte('\n')
-		}
-		return
-	}
-	b.WriteString(prefix)
-	b.WriteString(key)
-	b.WriteString("[")
-	b.WriteString(strconv.Itoa(len(values)))
-	b.WriteString("]:\n")
-	for _, value := range values {
-		switch typed := value.(type) {
-		case map[string]any:
-			b.WriteString(prefix)
-			b.WriteString("  -\n")
-			for _, childKey := range sortedToolOutputKeys(typed) {
-				writeTOONValue(b, childKey, typed[childKey], indent+2, false)
-			}
-		case []any:
-			b.WriteString(prefix)
-			b.WriteString("  -\n")
-			writeTOONArray(b, "items", typed, indent+2)
-		default:
-			b.WriteString(prefix)
-			b.WriteString("  ")
-			b.WriteString(toTOONScalar(value))
-			b.WriteByte('\n')
-		}
-	}
-}
-
-func toonArrayFields(values []any) ([]string, bool) {
-	var fields []string
-	for i, value := range values {
-		object, ok := value.(map[string]any)
-		if !ok {
-			return nil, false
-		}
-		fieldSet := map[string]struct{}{}
-		for key := range object {
-			if _, nestedObject := object[key].(map[string]any); nestedObject {
-				return nil, false
-			}
-			if _, nestedArray := object[key].([]any); nestedArray {
-				return nil, false
-			}
-			fieldSet[key] = struct{}{}
-		}
-		current := make([]string, 0, len(fieldSet))
-		for field := range fieldSet {
-			current = append(current, field)
-		}
-		sort.Strings(current)
-		if i == 0 {
-			fields = current
-			continue
-		}
-		if len(current) != len(fields) {
-			return nil, false
-		}
-		for j := range current {
-			if current[j] != fields[j] {
-				return nil, false
-			}
-		}
-	}
-	return fields, true
-}
-
-func toTOONScalar(value any) string {
-	switch typed := value.(type) {
-	case nil:
-		return "null"
-	case string:
-		return quoteTOONString(typed)
-	case bool:
-		return strconv.FormatBool(typed)
-	case json.Number:
-		return typed.String()
-	case float64:
-		return strconv.FormatFloat(typed, 'f', -1, 64)
-	default:
-		return quoteTOONString(fmt.Sprint(typed))
-	}
-}
-
-func quoteTOONString(value string) string {
-	if value == "" {
-		return strconv.Quote(value)
-	}
-	for _, r := range value {
-		if r == ',' || r == ':' || r == '\n' || r == '\r' || r == '[' || r == ']' || r == '{' || r == '}' || unicode.IsControl(r) {
-			return strconv.Quote(value)
-		}
-	}
-	if strings.TrimSpace(value) != value {
-		return strconv.Quote(value)
-	}
-	return value
 }
 
 func sortedToolOutputKeys(object map[string]any) []string {

--- a/pkg/agent/tool_output.go
+++ b/pkg/agent/tool_output.go
@@ -1,0 +1,350 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type ToolOutputFormat string
+
+const (
+	ToolOutputTOON ToolOutputFormat = "toon"
+	ToolOutputJSON ToolOutputFormat = "json"
+)
+
+type ToolOutputConfig struct {
+	Format         ToolOutputFormat
+	MaxStringChars int
+	MaxArrayItems  int
+	MaxObjectDepth int
+}
+
+type toolOutputTruncation struct {
+	Path       string `json:"path"`
+	Kind       string `json:"kind"`
+	Shown      int    `json:"shown,omitempty"`
+	Total      int    `json:"total,omitempty"`
+	ShownChars int    `json:"shown_chars,omitempty"`
+	TotalChars int    `json:"total_chars,omitempty"`
+	MaxDepth   int    `json:"max_depth,omitempty"`
+}
+
+func defaultToolOutputConfig(config ToolOutputConfig) ToolOutputConfig {
+	if config.Format == "" {
+		config.Format = ToolOutputTOON
+	}
+	if config.MaxStringChars == 0 {
+		config.MaxStringChars = 2000
+	}
+	if config.MaxArrayItems == 0 {
+		config.MaxArrayItems = 50
+	}
+	if config.MaxObjectDepth == 0 {
+		config.MaxObjectDepth = 8
+	}
+	return config
+}
+
+func validateToolOutputConfig(config ToolOutputConfig) error {
+	switch config.Format {
+	case ToolOutputTOON, ToolOutputJSON:
+	default:
+		return NewError(ErrorCodeInvalidArgument, fmt.Sprintf("unsupported tool output format %q", config.Format), nil)
+	}
+	if config.MaxStringChars <= 0 {
+		return NewError(ErrorCodeInvalidArgument, "max tool output string chars must be positive", nil)
+	}
+	if config.MaxArrayItems <= 0 {
+		return NewError(ErrorCodeInvalidArgument, "max tool output array items must be positive", nil)
+	}
+	if config.MaxObjectDepth <= 0 {
+		return NewError(ErrorCodeInvalidArgument, "max tool output object depth must be positive", nil)
+	}
+	return nil
+}
+
+func formatToolOutput(value any, config ToolOutputConfig) (string, error) {
+	normalized, err := normalizeToolOutput(value)
+	if err != nil {
+		return "", err
+	}
+	normalized = wrapTopLevelToolOutput(normalized)
+	var truncations []toolOutputTruncation
+	truncated := truncateToolOutput(normalized, "$", 0, config, &truncations)
+	if len(truncations) > 0 {
+		if object, ok := truncated.(map[string]any); ok {
+			object["_meta"] = map[string]any{
+				"truncated":   true,
+				"truncations": truncationsAsValues(truncations),
+			}
+		}
+	}
+	switch config.Format {
+	case ToolOutputJSON:
+		body, err := json.Marshal(truncated)
+		if err != nil {
+			return "", err
+		}
+		return string(body), nil
+	default:
+		return serializeTOON(truncated), nil
+	}
+}
+
+func normalizeToolOutput(value any) (any, error) {
+	body, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var out any
+	if err := decoder.Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func wrapTopLevelToolOutput(value any) any {
+	switch typed := value.(type) {
+	case []any:
+		return map[string]any{"count": json.Number(strconv.Itoa(len(typed))), "items": typed}
+	case map[string]any:
+		return typed
+	default:
+		return map[string]any{"value": typed}
+	}
+}
+
+func truncateToolOutput(value any, path string, depth int, config ToolOutputConfig, truncations *[]toolOutputTruncation) any {
+	if depth >= config.MaxObjectDepth {
+		*truncations = append(*truncations, toolOutputTruncation{Path: path, Kind: "depth", MaxDepth: config.MaxObjectDepth})
+		return fmt.Sprintf("[truncated: max depth %d]", config.MaxObjectDepth)
+	}
+	switch typed := value.(type) {
+	case string:
+		runes := []rune(typed)
+		if len(runes) <= config.MaxStringChars {
+			return typed
+		}
+		*truncations = append(*truncations, toolOutputTruncation{Path: path, Kind: "string", ShownChars: config.MaxStringChars, TotalChars: len(runes)})
+		return string(runes[:config.MaxStringChars])
+	case []any:
+		total := len(typed)
+		shown := total
+		if shown > config.MaxArrayItems {
+			shown = config.MaxArrayItems
+			*truncations = append(*truncations, toolOutputTruncation{Path: path, Kind: "array", Shown: shown, Total: total})
+		}
+		out := make([]any, shown)
+		for i := 0; i < shown; i++ {
+			out[i] = truncateToolOutput(typed[i], fmt.Sprintf("%s[%d]", path, i), depth+1, config, truncations)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for _, key := range sortedToolOutputKeys(typed) {
+			out[key] = truncateToolOutput(typed[key], path+"."+key, depth+1, config, truncations)
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func truncationsAsValues(truncations []toolOutputTruncation) []any {
+	out := make([]any, len(truncations))
+	for i, truncation := range truncations {
+		item := map[string]any{
+			"kind": truncation.Kind,
+			"path": truncation.Path,
+		}
+		if truncation.Shown > 0 || truncation.Total > 0 {
+			item["shown"] = truncation.Shown
+			item["total"] = truncation.Total
+		}
+		if truncation.ShownChars > 0 || truncation.TotalChars > 0 {
+			item["shown_chars"] = truncation.ShownChars
+			item["total_chars"] = truncation.TotalChars
+		}
+		if truncation.MaxDepth > 0 {
+			item["max_depth"] = truncation.MaxDepth
+		}
+		out[i] = item
+	}
+	return out
+}
+
+func serializeTOON(value any) string {
+	var b strings.Builder
+	writeTOONValue(&b, "", value, 0, true)
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func writeTOONValue(b *strings.Builder, key string, value any, indent int, root bool) {
+	prefix := strings.Repeat("  ", indent)
+	switch typed := value.(type) {
+	case map[string]any:
+		if !root && key != "" {
+			b.WriteString(prefix)
+			b.WriteString(key)
+			b.WriteString(":\n")
+			indent++
+			prefix = strings.Repeat("  ", indent)
+		}
+		for _, childKey := range sortedToolOutputKeys(typed) {
+			writeTOONValue(b, childKey, typed[childKey], indent, false)
+		}
+	case []any:
+		writeTOONArray(b, key, typed, indent)
+	default:
+		b.WriteString(prefix)
+		if key != "" {
+			b.WriteString(key)
+			b.WriteString(": ")
+		}
+		b.WriteString(toTOONScalar(typed))
+		b.WriteByte('\n')
+	}
+}
+
+func writeTOONArray(b *strings.Builder, key string, values []any, indent int) {
+	prefix := strings.Repeat("  ", indent)
+	if len(values) == 0 {
+		b.WriteString(prefix)
+		b.WriteString(key)
+		b.WriteString("[0]:\n")
+		return
+	}
+	fields, objects := toonArrayFields(values)
+	if objects {
+		b.WriteString(prefix)
+		b.WriteString(key)
+		b.WriteString("[")
+		b.WriteString(strconv.Itoa(len(values)))
+		b.WriteString("]{")
+		b.WriteString(strings.Join(fields, ","))
+		b.WriteString("}:\n")
+		for _, value := range values {
+			object := value.(map[string]any)
+			b.WriteString(prefix)
+			b.WriteString("  ")
+			for i, field := range fields {
+				if i > 0 {
+					b.WriteByte(',')
+				}
+				b.WriteString(toTOONScalar(object[field]))
+			}
+			b.WriteByte('\n')
+		}
+		return
+	}
+	b.WriteString(prefix)
+	b.WriteString(key)
+	b.WriteString("[")
+	b.WriteString(strconv.Itoa(len(values)))
+	b.WriteString("]:\n")
+	for _, value := range values {
+		switch typed := value.(type) {
+		case map[string]any:
+			b.WriteString(prefix)
+			b.WriteString("  -\n")
+			for _, childKey := range sortedToolOutputKeys(typed) {
+				writeTOONValue(b, childKey, typed[childKey], indent+2, false)
+			}
+		case []any:
+			b.WriteString(prefix)
+			b.WriteString("  -\n")
+			writeTOONArray(b, "items", typed, indent+2)
+		default:
+			b.WriteString(prefix)
+			b.WriteString("  ")
+			b.WriteString(toTOONScalar(value))
+			b.WriteByte('\n')
+		}
+	}
+}
+
+func toonArrayFields(values []any) ([]string, bool) {
+	var fields []string
+	for i, value := range values {
+		object, ok := value.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		fieldSet := map[string]struct{}{}
+		for key := range object {
+			if _, nestedObject := object[key].(map[string]any); nestedObject {
+				return nil, false
+			}
+			if _, nestedArray := object[key].([]any); nestedArray {
+				return nil, false
+			}
+			fieldSet[key] = struct{}{}
+		}
+		current := make([]string, 0, len(fieldSet))
+		for field := range fieldSet {
+			current = append(current, field)
+		}
+		sort.Strings(current)
+		if i == 0 {
+			fields = current
+			continue
+		}
+		if len(current) != len(fields) {
+			return nil, false
+		}
+		for j := range current {
+			if current[j] != fields[j] {
+				return nil, false
+			}
+		}
+	}
+	return fields, true
+}
+
+func toTOONScalar(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return "null"
+	case string:
+		return quoteTOONString(typed)
+	case bool:
+		return strconv.FormatBool(typed)
+	case json.Number:
+		return typed.String()
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	default:
+		return quoteTOONString(fmt.Sprint(typed))
+	}
+}
+
+func quoteTOONString(value string) string {
+	if value == "" {
+		return strconv.Quote(value)
+	}
+	for _, r := range value {
+		if r == ',' || r == ':' || r == '\n' || r == '\r' || r == '[' || r == ']' || r == '{' || r == '}' || unicode.IsControl(r) {
+			return strconv.Quote(value)
+		}
+	}
+	if strings.TrimSpace(value) != value {
+		return strconv.Quote(value)
+	}
+	return value
+}
+
+func sortedToolOutputKeys(object map[string]any) []string {
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/agent/tools.go
+++ b/pkg/agent/tools.go
@@ -58,11 +58,11 @@ func (a *Agent) executeToolCalls(ctx context.Context, run *runState, turnID stri
 	valid := make([]int, 0, len(calls))
 	for i, call := range calls {
 		if call.ID == "" {
-			results[i] = toolExecutionResult{message: toolErrorMessage(call, "invalid_tool_arguments", "Tool call ID is required.", nil, true)}
+			results[i] = toolExecutionResult{message: a.toolErrorMessage(call, "invalid_tool_arguments", "Tool call ID is required.", nil, true)}
 			continue
 		}
 		if _, ok := seen[call.ID]; ok {
-			results[i] = toolExecutionResult{message: toolErrorMessage(call, "invalid_tool_arguments", "Tool call ID must be unique within an assistant message.", nil, true)}
+			results[i] = toolExecutionResult{message: a.toolErrorMessage(call, "invalid_tool_arguments", "Tool call ID must be unique within an assistant message.", nil, true)}
 			continue
 		}
 		seen[call.ID] = struct{}{}
@@ -127,17 +127,17 @@ func eventSeverityForToolResult(message Message) Severity {
 func (a *Agent) validateToolCall(call ToolCall) (Message, bool) {
 	tool, ok := a.tools[call.Name]
 	if !ok {
-		return toolErrorMessage(call, "unknown_tool", fmt.Sprintf("Tool %q is not configured.", call.Name), nil, true), false
+		return a.toolErrorMessage(call, "unknown_tool", fmt.Sprintf("Tool %q is not configured.", call.Name), nil, true), false
 	}
 	if !json.Valid(call.Arguments) {
-		return toolErrorMessage(call, "invalid_tool_arguments", "Tool arguments must be valid JSON.", nil, true), false
+		return a.toolErrorMessage(call, "invalid_tool_arguments", "Tool arguments must be valid JSON.", nil, true), false
 	}
 	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(call.Arguments))
 	if err != nil {
-		return toolErrorMessage(call, "invalid_tool_arguments", "Tool arguments must be valid JSON.", []string{err.Error()}, true), false
+		return a.toolErrorMessage(call, "invalid_tool_arguments", "Tool arguments must be valid JSON.", []string{err.Error()}, true), false
 	}
 	if err := tool.schema.Validate(instance); err != nil {
-		return toolErrorMessage(call, "invalid_tool_arguments", "Tool arguments did not match the schema.", []string{err.Error()}, true), false
+		return a.toolErrorMessage(call, "invalid_tool_arguments", "Tool arguments did not match the schema.", []string{err.Error()}, true), false
 	}
 	return Message{}, true
 }
@@ -147,7 +147,7 @@ func (a *Agent) runOneTool(ctx context.Context, call ToolCall, tool *compiledToo
 	defer cancel()
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			result.message = toolErrorMessage(call, "tool_panic", "Tool handler panicked.", []string{fmt.Sprint(recovered), string(debug.Stack())}, false)
+			result.message = a.toolErrorMessage(call, "tool_panic", "Tool handler panicked.", []string{fmt.Sprint(recovered), string(debug.Stack())}, false)
 		}
 	}()
 
@@ -155,47 +155,47 @@ func (a *Agent) runOneTool(ctx context.Context, call ToolCall, tool *compiledToo
 	if err != nil {
 		var fatal fatalToolError
 		if ctxErr := toolCtx.Err(); ctxErr != nil {
-			result.message = toolErrorMessage(call, "tool_timeout", "Tool execution timed out or was canceled.", []string{ctxErr.Error()}, true)
+			result.message = a.toolErrorMessage(call, "tool_timeout", "Tool execution timed out or was canceled.", []string{ctxErr.Error()}, true)
 			return result
 		}
-		result.message = toolErrorMessage(call, "tool_execution_failed", "Tool execution failed.", []string{err.Error()}, true)
+		result.message = a.toolErrorMessage(call, "tool_execution_failed", "Tool execution failed.", []string{err.Error()}, true)
 		if isFatalToolError(err, &fatal) {
 			result.fatal = NewError(ErrorCodeTool, "fatal tool error", fatal.err)
 		}
 		return result
 	}
 	if toolCtx.Err() != nil {
-		result.message = toolErrorMessage(call, "tool_timeout", "Tool execution timed out or was canceled.", []string{toolCtx.Err().Error()}, true)
+		result.message = a.toolErrorMessage(call, "tool_timeout", "Tool execution timed out or was canceled.", []string{toolCtx.Err().Error()}, true)
 		return result
 	}
 	if toolResult.Content == nil {
-		result.message = toolErrorMessage(call, "tool_result_invalid", "Tool returned no JSON-serializable result.", nil, false)
+		result.message = a.toolErrorMessage(call, "tool_result_invalid", "Tool returned no JSON-serializable result.", nil, false)
 		return result
 	}
-	body, err := json.Marshal(toolResult.Content)
+	body, err := formatToolOutput(toolResult.Content, a.def.ToolOutput)
 	if err != nil {
-		result.message = toolErrorMessage(call, "tool_result_invalid", "Tool output was not JSON-serializable.", []string{err.Error()}, false)
+		result.message = a.toolErrorMessage(call, "tool_result_invalid", "Tool output was not JSON-serializable.", []string{err.Error()}, false)
 		return result
 	}
 	if toolResult.DisplayContent != nil {
 		displayBody, err := json.Marshal(toolResult.DisplayContent)
 		if err != nil {
-			result.message = toolErrorMessage(call, "tool_result_invalid", "Tool display output was not JSON-serializable.", []string{err.Error()}, false)
+			result.message = a.toolErrorMessage(call, "tool_result_invalid", "Tool display output was not JSON-serializable.", []string{err.Error()}, false)
 			return result
 		}
 		if len(displayBody) > a.def.Limits.MaxToolDisplayBytes {
-			result.message = toolErrorMessage(call, "tool_display_output_too_large", "Tool display output exceeded the configured size limit.", nil, false)
+			result.message = a.toolErrorMessage(call, "tool_display_output_too_large", "Tool display output exceeded the configured size limit.", nil, false)
 			return result
 		}
 	}
 	if len(body) > a.def.Limits.MaxToolResultBytes {
-		result.message = toolErrorMessage(call, "tool_output_too_large", "Tool output exceeded the configured size limit.", nil, false)
+		result.message = a.toolErrorMessage(call, "tool_output_too_large", "Tool output exceeded the configured size limit.", nil, false)
 		return result
 	}
 	result.message = Message{
 		ID:             a.def.IDGenerator.NewID("msg"),
 		Role:           RoleTool,
-		Content:        string(body),
+		Content:        body,
 		DisplayContent: toolResult.DisplayContent,
 		ToolCallID:     call.ID,
 		ToolName:       call.Name,
@@ -222,7 +222,7 @@ func isFatalToolError(err error, target *fatalToolError) bool {
 	return false
 }
 
-func toolErrorMessage(call ToolCall, code, message string, details []string, retryable bool) Message {
+func (a *Agent) toolErrorMessage(call ToolCall, code, message string, details []string, retryable bool) Message {
 	payload := map[string]any{
 		"error": map[string]any{
 			"code":      code,
@@ -233,10 +233,14 @@ func toolErrorMessage(call ToolCall, code, message string, details []string, ret
 	if len(details) > 0 {
 		payload["error"].(map[string]any)["details"] = details
 	}
-	body, _ := json.Marshal(payload)
+	body, err := formatToolOutput(payload, a.def.ToolOutput)
+	if err != nil {
+		fallback, _ := json.Marshal(payload)
+		body = string(fallback)
+	}
 	return Message{
 		Role:       RoleTool,
-		Content:    string(body),
+		Content:    body,
 		ToolCallID: call.ID,
 		ToolName:   call.Name,
 		IsError:    true,

--- a/pkg/agent/tools_test.go
+++ b/pkg/agent/tools_test.go
@@ -350,6 +350,45 @@ func TestToolResultTruncatesArraysAndStrings(t *testing.T) {
 	}
 }
 
+func TestToolResultTOONQuotesAmbiguousScalarsAndKeys(t *testing.T) {
+	model := &fakeModel{responses: []ModelResponse{
+		{ToolCalls: []ToolCall{{ID: "call_1", Name: "lookup", Arguments: json.RawMessage(`{}`)}}, FinishReason: FinishReasonToolCalls},
+		{Content: "done", FinishReason: FinishReasonStop},
+	}}
+	a := mustAgent(t, Definition{
+		Name:         "test",
+		SystemPrompt: "x",
+		Model:        model,
+		Tools: []ToolDefinition{{
+			Name:        "lookup",
+			Description: "lookup",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Handler: ToolHandlerFunc(func(context.Context, ToolCall) (ToolResult, error) {
+				return ToolResult{Content: map[string]any{
+					"quoted:key": `He said "hi" \ ok`,
+					"items": []any{
+						map[string]any{"name": "true", "value": "123", "bad,field": "a,b"},
+					},
+				}}, nil
+			}),
+		}},
+	})
+
+	if _, err := a.Prompt(context.Background(), PromptRequest{Input: "go"}); err != nil {
+		t.Fatalf("Prompt returned error: %v", err)
+	}
+	tool := onlyToolMessage(t, a.Transcript())
+	for _, want := range []string{
+		`"quoted:key": "He said \"hi\" \\ ok"`,
+		`items[1]{"bad,field",name,value}:`,
+		`"a,b","true","123"`,
+	} {
+		if !strings.Contains(tool.Content, want) {
+			t.Fatalf("tool result missing quoted fragment %q:\n%s", want, tool.Content)
+		}
+	}
+}
+
 func TestToolResultTopLevelEmptyArrayIsExplicit(t *testing.T) {
 	model := &fakeModel{responses: []ModelResponse{
 		{ToolCalls: []ToolCall{{ID: "call_1", Name: "lookup", Arguments: json.RawMessage(`{}`)}}, FinishReason: FinishReasonToolCalls},

--- a/pkg/agent/tools_test.go
+++ b/pkg/agent/tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -243,6 +244,180 @@ func TestToolExecutionIsBoundedParallelAndOrdered(t *testing.T) {
 	}
 }
 
+func TestToolResultContentDefaultsToTOON(t *testing.T) {
+	model := &fakeModel{responses: []ModelResponse{
+		{ToolCalls: []ToolCall{{ID: "call_1", Name: "lookup", Arguments: json.RawMessage(`{}`)}}, FinishReason: FinishReasonToolCalls},
+		{Content: "done", FinishReason: FinishReasonStop},
+	}}
+	a := mustAgent(t, Definition{
+		Name:         "test",
+		SystemPrompt: "x",
+		Model:        model,
+		Tools: []ToolDefinition{{
+			Name:        "lookup",
+			Description: "lookup",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Handler: ToolHandlerFunc(func(context.Context, ToolCall) (ToolResult, error) {
+				return ToolResult{Content: map[string]any{"ok": true, "id": "agent_table_1"}}, nil
+			}),
+		}},
+	})
+
+	if _, err := a.Prompt(context.Background(), PromptRequest{Input: "go"}); err != nil {
+		t.Fatalf("Prompt returned error: %v", err)
+	}
+	tool := onlyToolMessage(t, a.Transcript())
+	if strings.Contains(tool.Content, `"ok":true`) || !strings.Contains(tool.Content, "ok: true") || !strings.Contains(tool.Content, "id: agent_table_1") {
+		t.Fatalf("tool result should be TOON by default: %s", tool.Content)
+	}
+}
+
+func TestToolResultContentCanUseJSON(t *testing.T) {
+	model := &fakeModel{responses: []ModelResponse{
+		{ToolCalls: []ToolCall{{ID: "call_1", Name: "lookup", Arguments: json.RawMessage(`{}`)}}, FinishReason: FinishReasonToolCalls},
+		{Content: "done", FinishReason: FinishReasonStop},
+	}}
+	a := mustAgent(t, Definition{
+		Name:         "test",
+		SystemPrompt: "x",
+		Model:        model,
+		ToolOutput:   ToolOutputConfig{Format: ToolOutputJSON},
+		Tools: []ToolDefinition{{
+			Name:        "lookup",
+			Description: "lookup",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Handler: ToolHandlerFunc(func(context.Context, ToolCall) (ToolResult, error) {
+				return ToolResult{Content: map[string]any{"ok": true, "id": "agent_table_1"}}, nil
+			}),
+		}},
+	})
+
+	if _, err := a.Prompt(context.Background(), PromptRequest{Input: "go"}); err != nil {
+		t.Fatalf("Prompt returned error: %v", err)
+	}
+	tool := onlyToolMessage(t, a.Transcript())
+	if !strings.Contains(tool.Content, `"ok":true`) || !strings.Contains(tool.Content, `"id":"agent_table_1"`) {
+		t.Fatalf("tool result should honor JSON output config: %s", tool.Content)
+	}
+}
+
+func TestToolResultTruncatesArraysAndStrings(t *testing.T) {
+	rows := make([]map[string]any, 0, 5)
+	for i := range 5 {
+		rows = append(rows, map[string]any{"id": i + 1, "name": fmt.Sprintf("row-%d", i+1)})
+	}
+	model := &fakeModel{responses: []ModelResponse{
+		{ToolCalls: []ToolCall{{ID: "call_1", Name: "lookup", Arguments: json.RawMessage(`{}`)}}, FinishReason: FinishReasonToolCalls},
+		{Content: "done", FinishReason: FinishReasonStop},
+	}}
+	a := mustAgent(t, Definition{
+		Name:         "test",
+		SystemPrompt: "x",
+		Model:        model,
+		ToolOutput:   ToolOutputConfig{MaxArrayItems: 2, MaxStringChars: 5},
+		Tools: []ToolDefinition{{
+			Name:        "lookup",
+			Description: "lookup",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Handler: ToolHandlerFunc(func(context.Context, ToolCall) (ToolResult, error) {
+				return ToolResult{Content: map[string]any{"body": "abcdefghij", "items": rows}}, nil
+			}),
+		}},
+	})
+
+	if _, err := a.Prompt(context.Background(), PromptRequest{Input: "go"}); err != nil {
+		t.Fatalf("Prompt returned error: %v", err)
+	}
+	tool := onlyToolMessage(t, a.Transcript())
+	for _, want := range []string{
+		"body: abcde",
+		"items[2]{id,name}:",
+		"1,row-1",
+		"_meta:",
+		"truncated: true",
+		"$.body",
+		"$.items",
+		"total: 5",
+		"shown_chars: 5",
+		"total_chars: 10",
+	} {
+		if !strings.Contains(tool.Content, want) {
+			t.Fatalf("tool result missing %q:\n%s", want, tool.Content)
+		}
+	}
+	if strings.Contains(tool.Content, "row-3") || strings.Contains(tool.Content, "fghij") {
+		t.Fatalf("tool result was not truncated:\n%s", tool.Content)
+	}
+}
+
+func TestToolResultTopLevelEmptyArrayIsExplicit(t *testing.T) {
+	model := &fakeModel{responses: []ModelResponse{
+		{ToolCalls: []ToolCall{{ID: "call_1", Name: "lookup", Arguments: json.RawMessage(`{}`)}}, FinishReason: FinishReasonToolCalls},
+		{Content: "done", FinishReason: FinishReasonStop},
+	}}
+	a := mustAgent(t, Definition{
+		Name:         "test",
+		SystemPrompt: "x",
+		Model:        model,
+		Tools: []ToolDefinition{{
+			Name:        "lookup",
+			Description: "lookup",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Handler: ToolHandlerFunc(func(context.Context, ToolCall) (ToolResult, error) {
+				return ToolResult{Content: []any{}}, nil
+			}),
+		}},
+	})
+
+	if _, err := a.Prompt(context.Background(), PromptRequest{Input: "go"}); err != nil {
+		t.Fatalf("Prompt returned error: %v", err)
+	}
+	tool := onlyToolMessage(t, a.Transcript())
+	if !strings.Contains(tool.Content, "count: 0") || !strings.Contains(tool.Content, "items[0]:") {
+		t.Fatalf("empty array should be explicit:\n%s", tool.Content)
+	}
+}
+
+func TestToolResultOrderingAndDepthTruncationAreDeterministic(t *testing.T) {
+	content := map[string]any{
+		"z": "last",
+		"a": map[string]any{"b": map[string]any{"c": map[string]any{"d": "too deep"}}},
+		"m": "middle",
+	}
+	model := &fakeModel{responses: []ModelResponse{
+		{ToolCalls: []ToolCall{{ID: "call_1", Name: "lookup", Arguments: json.RawMessage(`{}`)}}, FinishReason: FinishReasonToolCalls},
+		{Content: "done", FinishReason: FinishReasonStop},
+	}}
+	a := mustAgent(t, Definition{
+		Name:         "test",
+		SystemPrompt: "x",
+		Model:        model,
+		ToolOutput:   ToolOutputConfig{MaxObjectDepth: 2},
+		Tools: []ToolDefinition{{
+			Name:        "lookup",
+			Description: "lookup",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Handler: ToolHandlerFunc(func(context.Context, ToolCall) (ToolResult, error) {
+				return ToolResult{Content: content}, nil
+			}),
+		}},
+	})
+
+	if _, err := a.Prompt(context.Background(), PromptRequest{Input: "go"}); err != nil {
+		t.Fatalf("Prompt returned error: %v", err)
+	}
+	tool := onlyToolMessage(t, a.Transcript())
+	aIndex := strings.Index(tool.Content, "a:")
+	mIndex := strings.Index(tool.Content, "m: middle")
+	zIndex := strings.Index(tool.Content, "z: last")
+	if aIndex < 0 || mIndex < 0 || zIndex < 0 || !(aIndex < mIndex && mIndex < zIndex) {
+		t.Fatalf("object keys should be sorted deterministically:\n%s", tool.Content)
+	}
+	if !strings.Contains(tool.Content, "max_depth") || strings.Contains(tool.Content, "too deep") {
+		t.Fatalf("deep object should be truncated with metadata:\n%s", tool.Content)
+	}
+}
+
 func TestToolDisplayContentIsNotSentBackToModel(t *testing.T) {
 	model := &fakeModel{responses: []ModelResponse{
 		{ToolCalls: []ToolCall{{ID: "call_1", Name: "visual", Arguments: json.RawMessage(`{}`)}}, FinishReason: FinishReasonToolCalls},
@@ -280,7 +455,7 @@ func TestToolDisplayContentIsNotSentBackToModel(t *testing.T) {
 	if tool.DisplayContent == nil {
 		t.Fatalf("tool transcript missing display content: %#v", tool)
 	}
-	if !strings.Contains(tool.Content, `"ok":true`) || strings.Contains(tool.Content, "row-data") {
+	if !strings.Contains(tool.Content, `ok: true`) || strings.Contains(tool.Content, "row-data") {
 		t.Fatalf("tool model content should be compact: %s", tool.Content)
 	}
 	if len(model.requests) != 2 {

--- a/schemas/signals/ui-signals.schema.json
+++ b/schemas/signals/ui-signals.schema.json
@@ -747,6 +747,9 @@
         "id": {
           "type": "string"
         },
+        "inputFormat": {
+          "type": "string"
+        },
         "inputJson": {
           "type": "string"
         },
@@ -757,6 +760,9 @@
           "type": "string"
         },
         "name": {
+          "type": "string"
+        },
+        "resultFormat": {
           "type": "string"
         },
         "resultJson": {

--- a/scripts/build_test_assets.ts
+++ b/scripts/build_test_assets.ts
@@ -29,6 +29,7 @@ const fixtures = new Map<string, FixtureBuild>([
     single('chat-composer', 'web/components/chat/chat-composer.ts', '.tmp/chat-composer-test/chat-composer-under-test.js'),
   ],
   ['chat-thread', split('chat-thread', 'web/components/chat/chat-page.ts', '.tmp/chat-thread-test', 'chat-under-test.js', 'chunks/[name]-[hash].[ext]')],
+  ['code-block', single('code-block', 'web/components/shared/code-block.ts', '.tmp/code-block-test/code-block-under-test.js')],
   ['workspace-page', single('workspace-page', 'web/components/workspace/workspace-page.ts', '.tmp/workspace-page-test/workspace-page-under-test.js')],
   ['admin-page', pageWithMonacoWorker('admin-page', 'web/components/admin/admin-page.ts', '.tmp/admin-page-test', 'admin-page-under-test.js')],
   ['code-editor', pageWithMonacoWorker('code-editor', 'web/components/shared/code-editor.ts', '.tmp/code-editor-test', 'code-editor-under-test.js')],

--- a/web/components/chat/chat-thread.dom.test.ts
+++ b/web/components/chat/chat-thread.dom.test.ts
@@ -318,6 +318,57 @@ test('chat thread renders visual artifacts with dashboard web components', async
   await page.close()
 })
 
+test('chat thread renders tool details with compact json and toon code blocks', async () => {
+  const page = await browser.newPage()
+  await page.goto(baseURL)
+  await page.evaluate(async () => {
+    await customElements.whenDefined('ld-chat-thread')
+    const thread = document.querySelector('ld-chat-thread') as any
+    thread.transcript = [
+      {
+        id: 'tool-toon',
+        kind: 'tool',
+        name: 'list_workspaces',
+        status: 'complete',
+        inputJson: '{\n  "name": "list_workspaces",\n  "arguments": "{}"\n}',
+        inputFormat: 'json',
+        resultJson: 'items[2]{id,title}:\n  sales,Sales\n  ops,Operations\ncount: 2\nhasMore: false',
+        resultFormat: 'toon',
+      },
+      {
+        id: 'tool-json',
+        kind: 'tool',
+        name: 'query_visual',
+        status: 'complete',
+        resultJson: '{\n  "ok": true,\n  "kind": "chart"\n}',
+      },
+    ]
+    await thread.updateComplete
+    for (const trigger of Array.from(thread.shadowRoot.querySelectorAll('.tool-trigger')) as HTMLButtonElement[]) {
+      trigger.click()
+    }
+    await thread.updateComplete
+  })
+
+  const state = await page.locator('ld-chat-thread').evaluate((element: any) => {
+    const blocks = Array.from(element.shadowRoot.querySelectorAll('ld-code-block')) as any[]
+    return {
+      blockCount: blocks.length,
+      languages: blocks.map((block) => block.language),
+      compact: blocks.map((block) => block.compact),
+      text: element.shadowRoot.querySelector('.tool-details')?.textContent || '',
+      hasRawPre: Boolean(element.shadowRoot.querySelector('.tool-detail-block > pre')),
+    }
+  })
+
+  expect(state.blockCount).toBe(3)
+  expect(state.languages).toEqual(['json', 'toon', 'json'])
+  expect(state.compact).toEqual([true, true, true])
+  expect(state.text).toContain('items[2]{id,title}:')
+  expect(state.hasRawPre).toBe(false)
+  await page.close()
+})
+
 test('chat thread renders assistant markdown through shared markdown view', async () => {
   const page = await browser.newPage()
   await page.goto(baseURL)

--- a/web/components/chat/chat-thread.ts
+++ b/web/components/chat/chat-thread.ts
@@ -3,6 +3,7 @@ import { property, state } from 'lit/decorators.js'
 import { Box, ChevronRight, FileText, LayoutDashboard, LayoutPanelTop, Table2, Wrench, type IconNode } from 'lucide'
 import type { ChatArtifactSignal, ChatStatus, ChatTranscriptItemSignal, DashboardTable, DashboardVisual } from '../../generated/signals'
 import { lucideIcon } from '../shared/lucide-icons'
+import '../shared/code-block'
 import '../shared/markdown-view'
 import '../shared/visual-artifact'
 
@@ -15,6 +16,12 @@ type LegacyArtifact = ChatArtifactSignal & {
     visuals?: Record<string, DashboardVisual>
     tables?: Record<string, DashboardTable>
   }
+}
+
+type ToolPreviewLanguage = 'json' | 'toon' | 'text'
+type ChatTranscriptItemWithFormats = ChatTranscriptItemSignal & {
+  inputFormat?: string
+  resultFormat?: string
 }
 
 const jsonConverter = <T,>(fallback: T) => ({
@@ -319,6 +326,10 @@ class ChatThread extends LitElement {
       white-space: pre-wrap;
     }
 
+    .tool-detail-block ld-code-block {
+      max-width: 100%;
+    }
+
     .tool-error {
       color: var(--ld-fg-danger);
     }
@@ -506,18 +517,18 @@ class ChatThread extends LitElement {
     const status = item.status || 'running'
     return html`
       <div class="tool-details" id=${detailsID}>
-        ${item.inputJson || item.argumentsJson ? this.renderToolJSON('Input', item.inputJson || item.argumentsJson || '') : nothing}
-        ${item.resultJson ? this.renderToolJSON(status === 'error' ? 'Error result' : 'Result', item.resultJson) : nothing}
+        ${item.inputJson || item.argumentsJson ? this.renderToolCode('Input', item.inputJson || item.argumentsJson || '', toolInputLanguage(item)) : nothing}
+        ${item.resultJson ? this.renderToolCode(status === 'error' ? 'Error result' : 'Result', item.resultJson, toolResultLanguage(item)) : nothing}
         ${!item.resultJson && item.error ? html`<div class="tool-error">${item.error}</div>` : nothing}
       </div>
     `
   }
 
-  private renderToolJSON(label: string, value: string) {
+  private renderToolCode(label: string, value: string, language: ToolPreviewLanguage) {
     return html`
       <div class="tool-detail-block">
         <div class="tool-detail-label">${label}</div>
-        <pre><code>${value}</code></pre>
+        <ld-code-block compact language=${language} .code=${value}></ld-code-block>
       </div>
     `
   }
@@ -594,6 +605,32 @@ function toolCallKey(item: ChatTranscriptItemSignal): string {
 
 function toolDetailsID(key: string): string {
   return `tool-details-${key.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+}
+
+function toolInputLanguage(item: ChatTranscriptItemSignal): ToolPreviewLanguage {
+  return previewLanguage((item as ChatTranscriptItemWithFormats).inputFormat, item.inputJson || item.argumentsJson || '', 'json')
+}
+
+function toolResultLanguage(item: ChatTranscriptItemSignal): ToolPreviewLanguage {
+  return previewLanguage((item as ChatTranscriptItemWithFormats).resultFormat, item.resultJson || '', 'toon')
+}
+
+function previewLanguage(format: string | undefined, value: string, fallback: ToolPreviewLanguage): ToolPreviewLanguage {
+  const normalized = (format || '').trim().toLowerCase()
+  if (normalized === 'json' || normalized === 'toon' || normalized === 'text') return normalized
+  if (isJSON(value)) return 'json'
+  return fallback
+}
+
+function isJSON(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed || !['{', '['].includes(trimmed[0])) return false
+  try {
+    JSON.parse(trimmed)
+    return true
+  } catch {
+    return false
+  }
 }
 
 function statusLabel(status: string): string {

--- a/web/components/shared/code-block.dom.test.ts
+++ b/web/components/shared/code-block.dom.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import { createServer, type Server } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { join, normalize } from 'node:path'
+import { chromium, type Browser } from '@playwright/test'
+
+let server: Server
+let baseURL = ''
+let browser: Browser
+
+const root = join(process.cwd(), '.tmp/code-block-test')
+
+beforeAll(async () => {
+  server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+    if (url.pathname === '/') {
+      response.setHeader('content-type', 'text/html')
+      response.end(testDocument())
+      return
+    }
+    const file = normalize(join(root, url.pathname))
+    if (!file.startsWith(root)) {
+      response.writeHead(404)
+      response.end('not found')
+      return
+    }
+    try {
+      response.setHeader('content-type', 'text/javascript')
+      response.end(await readFile(file))
+    } catch {
+      response.writeHead(404)
+      response.end('not found')
+    }
+  })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('test server did not bind to a port')
+  baseURL = `http://127.0.0.1:${address.port}`
+  browser = await chromium.launch()
+})
+
+afterAll(async () => {
+  await browser?.close()
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+})
+
+test('code block highlights json and toon, and falls back plainly for text and unknown languages', async () => {
+  const page = await browser.newPage({ viewport: { width: 900, height: 700 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('ld-code-block'))
+
+    const state = await page.evaluate(async () => {
+      const waitFor = async (predicate: () => boolean, timeoutMs = 5000): Promise<void> => {
+        const started = performance.now()
+        while (!predicate()) {
+          if (performance.now() - started > timeoutMs) throw new Error('timed out waiting for condition')
+          await new Promise((resolve) => setTimeout(resolve, 20))
+        }
+      }
+      const json = document.createElement('ld-code-block') as any
+      json.language = 'json'
+      json.code = '{\n  "ok": true,\n  "count": 3\n}'
+      document.body.append(json)
+      await waitFor(() => Boolean(json.querySelector('.shiki')))
+
+      const toon = document.createElement('ld-code-block') as any
+      toon.language = 'toon'
+      toon.code = 'items[2]{id,title}:\n  1,Sales\n  2,Ops\ncount: 2'
+      document.body.append(toon)
+      await waitFor(() => Boolean(toon.querySelector('.shiki')))
+
+      const text = document.createElement('ld-code-block') as any
+      text.language = 'text'
+      text.code = 'plain text'
+      document.body.append(text)
+      await text.updateComplete
+
+      const unknown = document.createElement('ld-code-block') as any
+      unknown.language = 'made-up'
+      unknown.code = 'fallback text'
+      document.body.append(unknown)
+      await unknown.updateComplete
+
+      const compact = document.createElement('ld-code-block') as any
+      compact.compact = true
+      compact.language = 'json'
+      compact.code = '{"compact":true}'
+      document.body.append(compact)
+      await compact.updateComplete
+      const compactPre = compact.querySelector('pre') as HTMLElement
+
+      return {
+        jsonHighlighted: Boolean(json.querySelector('.shiki')),
+        toonHighlighted: Boolean(toon.querySelector('.shiki')),
+        jsonText: json.textContent || '',
+        toonText: toon.textContent || '',
+        textFallback: Boolean(text.querySelector('.code-block-fallback')),
+        textError: Boolean(text.querySelector('.code-block-error')),
+        unknownFallback: Boolean(unknown.querySelector('.code-block-fallback')),
+        unknownError: Boolean(unknown.querySelector('.code-block-error')),
+        compactAttr: compact.hasAttribute('compact'),
+        compactWhiteSpace: getComputedStyle(compactPre).whiteSpace,
+        compactOverflowX: getComputedStyle(compactPre).overflowX,
+      }
+    })
+
+    expect(state.jsonHighlighted).toBe(true)
+    expect(state.toonHighlighted).toBe(true)
+    expect(state.jsonText).toContain('"ok"')
+    expect(state.toonText).toContain('items[2]{id,title}:')
+    expect(state.textFallback).toBe(true)
+    expect(state.textError).toBe(false)
+    expect(state.unknownFallback).toBe(true)
+    expect(state.unknownError).toBe(false)
+    expect(state.compactAttr).toBe(true)
+    expect(state.compactWhiteSpace).toBe('pre')
+    expect(state.compactOverflowX).toBe('auto')
+  } finally {
+    await page.close()
+  }
+})
+
+function testDocument(): string {
+  return `
+    <!doctype html>
+    <html>
+      <head>
+        <style>
+          html, body { margin: 0; min-height: 100%; }
+          body { --fontStack-monospace: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; --ld-bg-panel-muted: #f6f8fa; --ld-fg-default: #24292f; --ld-fg-muted: #57606a; --ld-border-muted: 1px solid #d8dee4; --borderRadius-medium: 6px; --base-size-8: 8px; --base-size-12: 12px; --base-size-16: 16px; --ld-font-size-caption: 12px; --ld-font-size-body-sm: 14px; --ld-line-height-snug: 1.35; }
+          ld-code-block { display: block; width: 760px; margin: 24px; }
+        </style>
+      </head>
+      <body>
+        <script type="module" src="/code-block-under-test.js"></script>
+      </body>
+    </html>
+  `
+}

--- a/web/components/shared/code-block.ts
+++ b/web/components/shared/code-block.ts
@@ -1,13 +1,7 @@
 import { LitElement, html, nothing } from 'lit'
 import { property, state } from 'lit/decorators.js'
 import { unsafeHTML } from 'lit/directives/unsafe-html.js'
-import { createHighlighterCore, type HighlighterCore } from 'shiki/core'
-import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
-import sql from '@shikijs/langs/sql'
-import json from '@shikijs/langs/json'
-import githubDark from '@shikijs/themes/github-dark'
-import githubLight from '@shikijs/themes/github-light'
-import { toonLanguage } from './toon-language'
+import type { HighlighterCore } from 'shiki/core'
 
 type CodeTheme = 'github-light' | 'github-dark'
 type SupportedLanguage = 'json' | 'sql' | 'toon'
@@ -15,11 +9,30 @@ type SupportedLanguage = 'json' | 'sql' | 'toon'
 let highlighterPromise: Promise<HighlighterCore> | null = null
 
 function loadHighlighter(): Promise<HighlighterCore> {
-  highlighterPromise ??= createHighlighterCore({
-    themes: [githubLight, githubDark],
-    langs: [json, sql, toonLanguage],
-    engine: createJavaScriptRegexEngine(),
-  })
+  highlighterPromise ??= (async () => {
+    const [
+      { createHighlighterCore },
+      { createJavaScriptRegexEngine },
+      { default: sql },
+      { default: json },
+      { default: githubDark },
+      { default: githubLight },
+      { toonLanguage },
+    ] = await Promise.all([
+      import('shiki/core'),
+      import('shiki/engine/javascript'),
+      import('@shikijs/langs/sql'),
+      import('@shikijs/langs/json'),
+      import('@shikijs/themes/github-dark'),
+      import('@shikijs/themes/github-light'),
+      import('./toon-language'),
+    ])
+    return createHighlighterCore({
+      themes: [githubLight, githubDark],
+      langs: [json, sql, toonLanguage],
+      engine: createJavaScriptRegexEngine(),
+    })
+  })()
   return highlighterPromise
 }
 

--- a/web/components/shared/code-block.ts
+++ b/web/components/shared/code-block.ts
@@ -4,20 +4,29 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js'
 import { createHighlighterCore, type HighlighterCore } from 'shiki/core'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import sql from '@shikijs/langs/sql'
+import json from '@shikijs/langs/json'
 import githubDark from '@shikijs/themes/github-dark'
 import githubLight from '@shikijs/themes/github-light'
+import { toonLanguage } from './toon-language'
 
 type CodeTheme = 'github-light' | 'github-dark'
+type SupportedLanguage = 'json' | 'sql' | 'toon'
 
-const highlighterPromise: Promise<HighlighterCore> = createHighlighterCore({
-  themes: [githubLight, githubDark],
-  langs: [sql],
-  engine: createJavaScriptRegexEngine(),
-})
+let highlighterPromise: Promise<HighlighterCore> | null = null
+
+function loadHighlighter(): Promise<HighlighterCore> {
+  highlighterPromise ??= createHighlighterCore({
+    themes: [githubLight, githubDark],
+    langs: [json, sql, toonLanguage],
+    engine: createJavaScriptRegexEngine(),
+  })
+  return highlighterPromise
+}
 
 class CodeBlock extends LitElement {
   @property({ type: String }) code = ''
   @property({ type: String }) language = 'sql'
+  @property({ type: Boolean, reflect: true }) compact = false
   @state() private highlighted = ''
   @state() private error = ''
   private renderToken = 0
@@ -47,7 +56,7 @@ class CodeBlock extends LitElement {
   }
 
   render() {
-    const code = this.code.trim()
+    const code = this.code
     return html`
       <style>
         ${codeBlockStyles}
@@ -69,17 +78,18 @@ class CodeBlock extends LitElement {
 
   private async highlight(): Promise<void> {
     const token = ++this.renderToken
-    const code = this.code.trim()
-    if (!code) {
+    const code = this.code
+    const language = supportedLanguage(this.language)
+    if (!code.trim() || !language) {
       this.highlighted = ''
       this.error = ''
       return
     }
     try {
-      const highlighter = await highlighterPromise
+      const highlighter = await loadHighlighter()
       if (token !== this.renderToken) return
       this.highlighted = highlighter.codeToHtml(code, {
-        lang: this.language || 'sql',
+        lang: language,
         theme: this.theme,
       })
       this.error = ''
@@ -95,6 +105,12 @@ class CodeBlock extends LitElement {
     if (colorScheme === 'dark') return 'github-dark'
     return 'github-light'
   }
+}
+
+function supportedLanguage(language: string): SupportedLanguage | '' {
+  const normalized = language.trim().toLowerCase()
+  if (normalized === 'json' || normalized === 'sql' || normalized === 'toon') return normalized
+  return ''
 }
 
 const codeBlockStyles = `
@@ -125,6 +141,15 @@ const codeBlockStyles = `
     font-size: var(--ld-font-size-body-sm, 0.875rem);
     line-height: 1.65;
     tab-size: 2;
+  }
+
+  ld-code-block[compact] .shiki,
+  ld-code-block[compact] .code-block-fallback {
+    max-height: var(--ld-chat-tool-max-height, 18rem);
+    padding: var(--ld-chat-pre-padding-block, var(--base-size-8)) var(--ld-chat-pre-padding-inline, var(--base-size-12));
+    font-size: var(--ld-font-size-caption, 0.75rem);
+    line-height: var(--ld-line-height-snug, 1.35);
+    white-space: pre;
   }
 
   ld-code-block .shiki code,

--- a/web/components/shared/toon-language.ts
+++ b/web/components/shared/toon-language.ts
@@ -1,0 +1,111 @@
+// TOON TextMate grammar adapted from VishalRaut2106/vscode-toon.
+// Source: https://github.com/VishalRaut2106/vscode-toon/blob/main/syntaxes/toon.tmLanguage.json
+// License: MIT, Copyright (c) 2025 Vishal Raut.
+export const toonLanguage = {
+  name: 'toon',
+  displayName: 'TOON',
+  scopeName: 'source.toon',
+  patterns: [
+    { include: '#comments' },
+    { include: '#array-header' },
+    { include: '#list-item' },
+    { include: '#key-value' },
+    { include: '#values' },
+  ],
+  repository: {
+    comments: {
+      patterns: [
+        {
+          name: 'comment.line.number-sign.toon',
+          match: '#.*$',
+        },
+      ],
+    },
+    'array-header': {
+      patterns: [
+        {
+          name: 'meta.array-header.toon',
+          match: '^(\\s*)([\\w."]+)?\\[(#)?(\\d+)([,\\t|])?\\](\\{([^}]+)\\})?(:)',
+          captures: {
+            '2': { name: 'variable.other.property.toon' },
+            '3': { name: 'keyword.operator.length-marker.toon' },
+            '4': { name: 'constant.numeric.array-length.toon' },
+            '5': { name: 'keyword.operator.delimiter.toon' },
+            '7': { name: 'entity.name.type.fields.toon' },
+            '8': { name: 'punctuation.separator.colon.toon' },
+          },
+        },
+      ],
+    },
+    'list-item': {
+      patterns: [
+        {
+          name: 'meta.list-item.toon',
+          match: '^(\\s*)(-)(\\s+)',
+          captures: {
+            '2': { name: 'punctuation.definition.list.toon' },
+          },
+        },
+      ],
+    },
+    'key-value': {
+      patterns: [
+        {
+          name: 'meta.key-value.toon',
+          match: '^(\\s*)("[^"]+"|[\\w._-]+)(:)',
+          captures: {
+            '2': { name: 'variable.other.property.toon' },
+            '3': { name: 'punctuation.separator.colon.toon' },
+          },
+        },
+      ],
+    },
+    values: {
+      patterns: [
+        { include: '#string' },
+        { include: '#number' },
+        { include: '#boolean' },
+        { include: '#null' },
+      ],
+    },
+    string: {
+      patterns: [
+        {
+          name: 'string.quoted.double.toon',
+          begin: '"',
+          end: '"',
+          patterns: [
+            {
+              name: 'constant.character.escape.toon',
+              match: '\\\\(["\\\\nrt])',
+            },
+          ],
+        },
+      ],
+    },
+    number: {
+      patterns: [
+        {
+          name: 'constant.numeric.toon',
+          match: '\\b-?\\d+(\\.\\d+)?([eE][+-]?\\d+)?\\b',
+        },
+      ],
+    },
+    boolean: {
+      patterns: [
+        {
+          name: 'constant.language.boolean.toon',
+          match: '\\b(true|false)\\b',
+        },
+      ],
+    },
+    null: {
+      patterns: [
+        {
+          name: 'constant.language.null.toon',
+          match: '\\bnull\\b',
+        },
+      ],
+    },
+  },
+} as const

--- a/web/generated/signals/index.ts
+++ b/web/generated/signals/index.ts
@@ -214,8 +214,10 @@ export interface ChatTranscriptItemSignal {
   summary?: string
   resultSummary?: string
   inputJson?: string
+  inputFormat?: string
   argumentsJson?: string
   resultJson?: string
+  resultFormat?: string
   artifact?: ChatArtifactSignal
   error?: string
   conversationId?: string


### PR DESCRIPTION
## Summary

This PR makes agent tool output more compact, deterministic, and readable across the model-facing pipeline and the chat UI.

The main behavioral change is that successful `pkg/agent` tool results are normalized, truncated, and serialized as TOON by default before they are sent back to the model. JSON remains available through `ToolOutputConfig`. The final TOON serialization now uses the official `github.com/toon-format/toon-go` library instead of a local hand-rolled formatter.

## What Changed

### Generic tool output handling in `pkg/agent`

- Added `ToolOutputConfig` to `agent.Definition` with defaults for:
  - `Format`: `toon`
  - `MaxStringChars`: `2000`
  - `MaxArrayItems`: `50`
  - `MaxObjectDepth`: `8`
- Added canonical model-visible tool output processing:
  - JSON-normalizes arbitrary tool content.
  - Rejects unserializable content such as funcs/channels/cycles.
  - Sorts object keys deterministically during truncation.
  - Truncates strings, arrays, and deep objects before byte-limit enforcement.
  - Adds `_meta.truncated` and `_meta.truncations` when content is shortened.
  - Keeps `MaxToolResultBytes` as a hard post-truncation backstop.
- Preserved `DisplayContent` behavior:
  - Validated and size-limited separately.
  - Kept out of model requests and token estimation.
- Kept tool schemas and tool-call arguments as JSON.
- Formatted structured tool errors through the same output path.

### Official TOON serializer

- Added `github.com/toon-format/toon-go` as the TOON encoder.
- Removed the custom TOON writer/escaping implementation from `pkg/agent`.
- Added regression coverage for quoted keys and ambiguous scalar strings, including boolean-like strings, numeric-like strings, commas, quotes, and backslashes.

### Declarative APIGen output shaping

- Extended `x-agent.output` TypeSpec metadata for APIGen-backed agent tools.
- Added output shaping support for:
  - `itemsPath`, `fields`, `cursorPath`, and `count` compatibility fields.
  - `rootFields` projections.
  - `collections` projections with dotted paths, aliases, field projection, and count support.
  - `maps` projections for map-of-object outputs such as dashboard page visual data.
- Shaped successful APIGen tool results before returning `agent.ToolResult.Content`.
- Kept raw output fallback only for operations without output metadata.
- Added output metadata for enabled list, discovery, describe, lineage, query, preview, explain, visual, table, and page tools so model-facing data is intentionally compact.
- Suppressed empty cursor noise and converted non-empty cursors to `nextCursor` plus `hasMore: true`.

### Transcript format metadata

- Added transcript format signals for tool details:
  - `inputFormat: "json"`
  - `resultFormat: "toon"` or `"json"`
- Preserved existing `inputJson`, `argumentsJson`, and `resultJson` compatibility fields.

### Chat tool detail rendering

- Switched tool input/result/error blocks to the shared `ld-code-block` renderer.
- Added compact syntax highlighting for:
  - JSON tool inputs.
  - TOON or JSON tool results based on transcript metadata and compatibility fallback detection.
- Vendored a TOON TextMate grammar for Shiki with attribution.
- Added horizontal scrolling for compact code blocks so TOON table output remains readable.
- Made Shiki, themes, languages, and the TOON grammar load lazily on first highlight instead of through static imports.
- Preserved existing SQL code block usage.

### Supporting cleanup

- Updated generated UI signal schema/types.
- Removed obsolete Primer alignment scripts and adjusted related styling/tests from the prior feature work.

## Why

Agent tools often return valid data that is too verbose for the model. Hard-failing large successful outputs is less useful than returning a compact, explicitly truncated representation. TOON gives the model a denser, readable format, while declarative TypeSpec output metadata keeps domain-specific field selection out of `pkg/agent`.

Using the official TOON Go package also improves long-term maintainability because quoting, escaping, number handling, tabular output, and future spec alignment are maintained upstream instead of duplicated locally.

## Validation

Ran the full test task successfully:

```sh
task test
```

Also ran focused checks while developing:

```sh
go test ./pkg/agent
bun run test:code-block
bun run test:chat-thread
```

## Notes / Follow-ups

- `toon-go` currently resolves as a pseudo-version because the upstream module has not published semver tags. We should move to a tagged release if one becomes available.
- `pkg/agent` remains intentionally generic. Tool-specific relevance decisions should continue to live in TypeSpec `x-agent.output` metadata and the APIGen agent adapter.
