### PR TITLE
Fix dev scripts to use publish command

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,7 +59,7 @@ tasks:
         test -f .tmp/dev-server.port || { echo "Dev server port file missing. Run task dev first."; exit 1; }
         PORT="$(cat .tmp/dev-server.port)"
         curl -fsS "http://localhost:${PORT}/workspaces" >/dev/null || { echo "Dev server is not running on http://localhost:${PORT}. Run task dev first."; exit 1; }
-        go run ./cmd/libredash deploy --project dashboards/libredash.yaml --target "http://localhost:${PORT}" --token dev --environment dev --auto-approve
+        go run ./cmd/libredash publish --project dashboards/libredash.yaml --target "http://localhost:${PORT}" --token dev --environment dev --auto-approve
 
   dev:quack:status:
     desc: Show managed LibreDash dev server status with the local Quack profile

--- a/scripts/agent_e2e.sh
+++ b/scripts/agent_e2e.sh
@@ -64,7 +64,7 @@ for _ in {1..80}; do
   sleep 0.25
 done
 
-"$BIN" deploy --target "$TARGET" --token "$TOKEN" --workspace sales --project dashboards/libredash.yaml --auto-approve
+"$BIN" publish --target "$TARGET" --token "$TOKEN" --workspace sales --project dashboards/libredash.yaml --auto-approve
 
 OUTPUT="$("$BIN" agent ask "List the dashboards I can use in this workspace and mention the Olist context." --target "$TARGET" --token "$TOKEN" --workspace sales --json)"
 echo "$OUTPUT"

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -223,10 +223,10 @@ wait_ready() {
   return 1
 }
 
-deploy_project() {
+publish_project() {
   local port="$1"
   local project="${LIBREDASH_DEV_PROJECT:-dashboards/libredash.yaml}"
-  go run ./cmd/libredash deploy --project "$project" --target "http://localhost:${port}" --token dev --environment dev --auto-approve
+  go run ./cmd/libredash publish --project "$project" --target "http://localhost:${port}" --token dev --environment dev --auto-approve
 }
 
 attach_server() {
@@ -266,8 +266,8 @@ start() {
       echo "PID: $existing_pid"
       echo "URL: http://localhost:$existing_port"
       echo "Logs: $LOG_FILE"
-      echo "Deploying project to existing server..."
-      deploy_project "$existing_port"
+      echo "Publishing project to existing server..."
+      publish_project "$existing_port"
       echo "Attached to LibreDash logs. Press Ctrl-C to stop."
       attach_server "$existing_pid" "$existing_port"
       return 0
@@ -291,7 +291,7 @@ start() {
   else
     echo "Runner: go run (install air for hot reload)"
   fi
-  echo "Deploying project after startup. Press Ctrl-C to stop."
+  echo "Publishing project after startup. Press Ctrl-C to stop."
 
   cd "$ROOT"
   export PORT="$port"
@@ -312,7 +312,7 @@ start() {
     exit 1
   fi
 
-  if ! deploy_project "$port"; then
+  if ! publish_project "$port"; then
     stop_pid "$pid" "LibreDash dev server"
     exit 1
   fi


### PR DESCRIPTION
## Summary
- update managed dev startup to call `libredash publish` instead of the removed `deploy` command
- update the dev publish task and agent e2e script to use the current CLI command
- rename dev-server helper/log messages from deploy to publish

## Verification
- `task dev` started successfully and published the workspaces to http://localhost:8122
- `./scripts/dev-server.sh status` reports the dev server running
- searched Taskfile/scripts for stale `libredash deploy` invocations