### PR TITLE
Harden grant authorization engine

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -205,6 +205,7 @@ type ObjectRef struct {
 	WorkspaceID string
 	ObjectID    string
 	ParentID    string
+	DisplayName string
 }
 
 func PlatformObject() ObjectRef {

--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -288,7 +288,7 @@ type AuthorizationDecision struct {
 	Allowed       bool
 	Privilege     Privilege
 	Object        ObjectRef
-	Reason        string
+	Reason        AuthorizationReason
 	GrantID       string
 	GrantObjectID string
 	SubjectType   SubjectType
@@ -296,6 +296,25 @@ type AuthorizationDecision struct {
 	Inherited     bool
 	Owner         bool
 	Platform      bool
+}
+
+type AuthorizationReason string
+
+const (
+	ReasonMissingPrincipal  AuthorizationReason = "missing_principal"
+	ReasonMissingPrivilege  AuthorizationReason = "missing_privilege"
+	ReasonPrincipalDisabled AuthorizationReason = "principal_disabled"
+	ReasonUnknownObject     AuthorizationReason = "unknown_object"
+	ReasonOwner             AuthorizationReason = "owner"
+	ReasonPlatformAdmin     AuthorizationReason = "platform_admin"
+	ReasonGrant             AuthorizationReason = "grant"
+	ReasonNoGrant           AuthorizationReason = "no_grant"
+	ReasonMissingObject     AuthorizationReason = "missing_object"
+)
+
+type AuthorizationCheck struct {
+	Privilege Privilege
+	Object    ObjectRef
 }
 
 type SubjectType string
@@ -553,8 +572,10 @@ type Repository interface {
 	ListRoles(ctx context.Context) ([]Role, error)
 	Authorize(ctx context.Context, principalID string, privilege Privilege, object ObjectRef) (AuthorizationDecision, error)
 	AuthorizeAny(ctx context.Context, principalID string, privilege Privilege, objects []ObjectRef) (AuthorizationDecision, error)
+	AuthorizeBatch(ctx context.Context, principalID string, checks []AuthorizationCheck) ([]AuthorizationDecision, error)
 	EffectivePrivileges(ctx context.Context, principalID string, object ObjectRef) ([]Privilege, error)
 	EffectiveAccess(ctx context.Context, principalID string, object ObjectRef) ([]AuthorizationDecision, error)
+	UpsertSecurableObject(ctx context.Context, object ObjectRef, ownerPrincipalID string) (SecurableObject, error)
 	CreateGrant(ctx context.Context, input GrantInput) (Grant, error)
 	GetGrant(ctx context.Context, workspaceID, id string) (Grant, error)
 	DeleteGrant(ctx context.Context, workspaceID, id string) error

--- a/internal/access/authorization_cache.go
+++ b/internal/access/authorization_cache.go
@@ -1,0 +1,60 @@
+package access
+
+import (
+	"context"
+	"sync"
+)
+
+type authorizationCacheContextKey struct{}
+
+type AuthorizationCache struct {
+	mu        sync.Mutex
+	decisions map[authorizationCacheKey]AuthorizationDecision
+}
+
+type authorizationCacheKey struct {
+	PrincipalID string
+	Privilege   Privilege
+	ObjectID    string
+}
+
+func WithAuthorizationCache(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Value(authorizationCacheContextKey{}).(*AuthorizationCache); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, authorizationCacheContextKey{}, &AuthorizationCache{decisions: map[authorizationCacheKey]AuthorizationDecision{}})
+}
+
+func CachedAuthorizationDecision(ctx context.Context, principalID string, privilege Privilege, object ObjectRef) (AuthorizationDecision, bool) {
+	cache, ok := ctx.Value(authorizationCacheContextKey{}).(*AuthorizationCache)
+	if !ok || cache == nil {
+		return AuthorizationDecision{}, false
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	decision, ok := cache.decisions[authorizationCacheKey{PrincipalID: principalID, Privilege: privilege, ObjectID: object.CanonicalID()}]
+	return decision, ok
+}
+
+func StoreAuthorizationDecision(ctx context.Context, principalID string, decision AuthorizationDecision) {
+	cache, ok := ctx.Value(authorizationCacheContextKey{}).(*AuthorizationCache)
+	if !ok || cache == nil {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.decisions[authorizationCacheKey{PrincipalID: principalID, Privilege: decision.Privilege, ObjectID: decision.Object.CanonicalID()}] = decision
+}
+
+func ClearAuthorizationCache(ctx context.Context) {
+	cache, ok := ctx.Value(authorizationCacheContextKey{}).(*AuthorizationCache)
+	if !ok || cache == nil {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	clear(cache.decisions)
+}

--- a/internal/access/authorization_reason_test.go
+++ b/internal/access/authorization_reason_test.go
@@ -1,0 +1,49 @@
+package access_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestAuthorizationReasonComparisonsUseTypedConstants(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	rawReasonComparison := regexp.MustCompile(`\.Reason\s*(?:==|!=)\s*"`)
+	allowedFiles := map[string]bool{
+		filepath.Join("internal", "access", "authorization_reason_test.go"): true,
+	}
+	err := filepath.WalkDir(repoRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "node_modules", "static":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		rel, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		if allowedFiles[rel] {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if rawReasonComparison.Match(body) {
+			t.Errorf("%s compares AuthorizationDecision.Reason to a raw string; use access.Reason* constants", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/access/http/handler.go
+++ b/internal/access/http/handler.go
@@ -1215,7 +1215,7 @@ func securableObjectDTO(row access.SecurableObject) map[string]any {
 func authorizationDecisionDTO(row access.AuthorizationDecision) map[string]any {
 	return map[string]any{
 		"privilege":     string(row.Privilege),
-		"reason":        row.Reason,
+		"reason":        string(row.Reason),
 		"objectType":    string(row.Object.Type),
 		"objectId":      emptyToNil(row.Object.ObjectID),
 		"grantId":       emptyToNil(row.GrantID),

--- a/internal/access/sqlite/repository.go
+++ b/internal/access/sqlite/repository.go
@@ -417,20 +417,50 @@ func (r *Repository) AuthorizeBatch(ctx context.Context, principalID string, che
 	if err != nil {
 		return nil, err
 	}
+	type objectFacts struct {
+		objectID string
+		exists   bool
+		owner    string
+		ancestry []string
+	}
+	factsByObject := map[string]objectFacts{}
+	loadObjectFacts := func(object access.ObjectRef) (objectFacts, error) {
+		objectKey := object.CanonicalID()
+		if facts, ok := factsByObject[objectKey]; ok {
+			return facts, nil
+		}
+		objectID, exists, err := r.lookupSecurableObjectID(ctx, object)
+		if err != nil {
+			return objectFacts{}, err
+		}
+		facts := objectFacts{objectID: objectID, exists: exists}
+		if exists {
+			owner, err := r.objectOwner(ctx, objectID)
+			if err != nil {
+				return objectFacts{}, err
+			}
+			ancestry, err := r.objectAncestry(ctx, objectID)
+			if err != nil {
+				return objectFacts{}, err
+			}
+			facts.owner = owner
+			facts.ancestry = ancestry
+		}
+		factsByObject[objectKey] = facts
+		return facts, nil
+	}
 	for _, i := range pending {
 		check := checks[i]
-		objectID, exists, err := r.lookupSecurableObjectID(ctx, check.Object)
+		facts, err := loadObjectFacts(check.Object)
 		if err != nil {
 			return nil, err
 		}
-		if !exists {
+		if !facts.exists {
 			out[i].Reason = access.ReasonUnknownObject
 			access.StoreAuthorizationDecision(ctx, principalID, out[i])
 			continue
 		}
-		if owner, err := r.objectOwner(ctx, objectID); err != nil {
-			return nil, err
-		} else if owner != "" && owner == principalID {
+		if facts.owner != "" && facts.owner == principalID {
 			out[i].Allowed = true
 			out[i].Owner = true
 			out[i].Reason = access.ReasonOwner
@@ -448,11 +478,7 @@ func (r *Repository) AuthorizeBatch(ctx context.Context, principalID string, che
 			access.StoreAuthorizationDecision(ctx, principalID, out[i])
 			continue
 		}
-		objectIDs, err := r.objectAncestry(ctx, objectID)
-		if err != nil {
-			return nil, err
-		}
-		grantDecision, err := r.authorizeByGrant(ctx, principalID, check.Privilege, objectIDs)
+		grantDecision, err := r.authorizeByGrant(ctx, principalID, check.Privilege, facts.ancestry)
 		if err != nil {
 			return nil, err
 		}
@@ -917,6 +943,9 @@ func grantOrderCase(objectIDs []string) string {
 }
 
 func objectDisplayName(object access.ObjectRef) string {
+	if strings.TrimSpace(object.DisplayName) != "" {
+		return strings.TrimSpace(object.DisplayName)
+	}
 	if object.ObjectID != "" {
 		return object.ObjectID
 	}

--- a/internal/access/sqlite/repository.go
+++ b/internal/access/sqlite/repository.go
@@ -82,6 +82,7 @@ func (r *Repository) principalDisabled(ctx context.Context, principalID string) 
 }
 
 func (r *Repository) UpsertPrincipal(ctx context.Context, input access.PrincipalInput) (access.Principal, error) {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(input.ID) == "" {
 		input.ID = newID("principal")
 	}
@@ -104,6 +105,7 @@ func (r *Repository) UpsertPrincipal(ctx context.Context, input access.Principal
 }
 
 func (r *Repository) SetPrincipalRole(ctx context.Context, input access.PrincipalRoleInput) (access.Principal, error) {
+	access.ClearAuthorizationCache(ctx)
 	email := access.NormalizeEmail(input.Email)
 	if email == "" {
 		return access.Principal{}, fmt.Errorf("email is required")
@@ -148,6 +150,7 @@ func (r *Repository) SetPrincipalRole(ctx context.Context, input access.Principa
 }
 
 func (r *Repository) SetPlatformRole(ctx context.Context, input access.PlatformRoleInput) (access.Principal, error) {
+	access.ClearAuthorizationCache(ctx)
 	principalID := strings.TrimSpace(input.PrincipalID)
 	email := access.NormalizeEmail(input.Email)
 	if principalID == "" && email == "" {
@@ -196,6 +199,7 @@ func (r *Repository) SetPlatformRole(ctx context.Context, input access.PlatformR
 }
 
 func (r *Repository) RemovePrincipalRoles(ctx context.Context, workspaceID, principalID string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(principalID) == "" {
 		return fmt.Errorf("principal id is required")
 	}
@@ -206,6 +210,7 @@ func (r *Repository) RemovePrincipalRoles(ctx context.Context, workspaceID, prin
 }
 
 func (r *Repository) CreateRoleBinding(ctx context.Context, input access.RoleBindingInput) (access.RoleBinding, error) {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(input.ID) == "" {
 		input.ID = newID("rolebinding")
 	}
@@ -243,6 +248,7 @@ func (r *Repository) GetRoleBinding(ctx context.Context, workspaceID, id string)
 }
 
 func (r *Repository) UpdateRoleBinding(ctx context.Context, workspaceID, id string, input access.RoleBindingInput) (access.RoleBinding, error) {
+	access.ClearAuthorizationCache(ctx)
 	input.WorkspaceID = workspaceID
 	role, principalID, groupID, err := r.roleBindingParts(ctx, input)
 	if err != nil {
@@ -267,6 +273,7 @@ func (r *Repository) UpdateRoleBinding(ctx context.Context, workspaceID, id stri
 }
 
 func (r *Repository) DeleteRoleBinding(ctx context.Context, workspaceID, id string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(id) == "" {
 		return fmt.Errorf("role binding id is required")
 	}
@@ -337,81 +344,128 @@ func (r *Repository) ListRoles(ctx context.Context) ([]access.Role, error) {
 }
 
 func (r *Repository) Authorize(ctx context.Context, principalID string, privilege access.Privilege, object access.ObjectRef) (access.AuthorizationDecision, error) {
-	decision := access.AuthorizationDecision{Privilege: privilege, Object: object}
-	principalID = strings.TrimSpace(principalID)
-	if principalID == "" {
-		decision.Reason = "missing_principal"
-		return decision, nil
-	}
-	if strings.TrimSpace(string(privilege)) == "" {
-		decision.Reason = "missing_privilege"
-		return decision, nil
-	}
-	if disabled, err := r.principalDisabled(ctx, principalID); err != nil {
-		return decision, err
-	} else if disabled {
-		decision.Reason = "principal_disabled"
-		return decision, nil
-	}
-	objectID, err := r.ensureSecurableObject(ctx, object)
+	decisions, err := r.AuthorizeBatch(ctx, principalID, []access.AuthorizationCheck{{Privilege: privilege, Object: object}})
 	if err != nil {
-		return decision, err
+		return access.AuthorizationDecision{Privilege: privilege, Object: object}, err
 	}
-	if owner, err := r.objectOwner(ctx, objectID); err != nil {
-		return decision, err
-	} else if owner != "" && owner == principalID {
-		decision.Allowed = true
-		decision.Owner = true
-		decision.Reason = "owner"
-		return decision, nil
+	if len(decisions) == 0 {
+		return access.AuthorizationDecision{Privilege: privilege, Object: object, Reason: access.ReasonMissingObject}, nil
 	}
-	platformDecision, err := r.authorizeByGrant(ctx, principalID, access.PrivilegeManagePlatform, []string{access.PlatformObject().CanonicalID()})
-	if err != nil {
-		return decision, err
-	}
-	if platformDecision.Allowed {
-		decision.Allowed = true
-		decision.Platform = true
-		decision.GrantID = platformDecision.GrantID
-		decision.GrantObjectID = platformDecision.GrantObjectID
-		decision.SubjectType = platformDecision.SubjectType
-		decision.SubjectID = platformDecision.SubjectID
-		decision.Reason = "platform_admin"
-		return decision, nil
-	}
-	objectIDs, err := r.objectAncestry(ctx, objectID)
-	if err != nil {
-		return decision, err
-	}
-	grantDecision, err := r.authorizeByGrant(ctx, principalID, privilege, objectIDs)
-	if err != nil {
-		return decision, err
-	}
-	if grantDecision.Allowed {
-		grantDecision.Privilege = privilege
-		grantDecision.Object = object
-		return grantDecision, nil
-	}
-	decision.Reason = "no_grant"
-	return decision, nil
+	return decisions[0], nil
 }
 
 func (r *Repository) AuthorizeAny(ctx context.Context, principalID string, privilege access.Privilege, objects []access.ObjectRef) (access.AuthorizationDecision, error) {
 	if len(objects) == 0 {
-		return access.AuthorizationDecision{Privilege: privilege, Reason: "missing_object"}, nil
+		return access.AuthorizationDecision{Privilege: privilege, Reason: access.ReasonMissingObject}, nil
+	}
+	checks := make([]access.AuthorizationCheck, 0, len(objects))
+	for _, object := range objects {
+		checks = append(checks, access.AuthorizationCheck{Privilege: privilege, Object: object})
+	}
+	decisions, err := r.AuthorizeBatch(ctx, principalID, checks)
+	if err != nil {
+		return access.AuthorizationDecision{Privilege: privilege}, err
 	}
 	var last access.AuthorizationDecision
-	for _, object := range objects {
-		decision, err := r.Authorize(ctx, principalID, privilege, object)
-		if err != nil {
-			return decision, err
-		}
+	for _, decision := range decisions {
 		if decision.Allowed {
 			return decision, nil
 		}
 		last = decision
 	}
 	return last, nil
+}
+
+func (r *Repository) AuthorizeBatch(ctx context.Context, principalID string, checks []access.AuthorizationCheck) ([]access.AuthorizationDecision, error) {
+	out := make([]access.AuthorizationDecision, len(checks))
+	principalID = strings.TrimSpace(principalID)
+	pending := make([]int, 0, len(checks))
+	for i, check := range checks {
+		decision := access.AuthorizationDecision{Privilege: check.Privilege, Object: check.Object}
+		if principalID == "" {
+			decision.Reason = access.ReasonMissingPrincipal
+			out[i] = decision
+			continue
+		}
+		if strings.TrimSpace(string(check.Privilege)) == "" {
+			decision.Reason = access.ReasonMissingPrivilege
+			out[i] = decision
+			continue
+		}
+		if cached, ok := access.CachedAuthorizationDecision(ctx, principalID, check.Privilege, check.Object); ok {
+			out[i] = cached
+			continue
+		}
+		out[i] = decision
+		pending = append(pending, i)
+	}
+	if len(pending) == 0 {
+		return out, nil
+	}
+	disabled, err := r.principalDisabled(ctx, principalID)
+	if err != nil {
+		return nil, err
+	}
+	if disabled {
+		for _, i := range pending {
+			out[i].Reason = access.ReasonPrincipalDisabled
+			access.StoreAuthorizationDecision(ctx, principalID, out[i])
+		}
+		return out, nil
+	}
+	platformDecision, err := r.authorizeByGrant(ctx, principalID, access.PrivilegeManagePlatform, []string{access.PlatformObject().CanonicalID()})
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range pending {
+		check := checks[i]
+		objectID, exists, err := r.lookupSecurableObjectID(ctx, check.Object)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			out[i].Reason = access.ReasonUnknownObject
+			access.StoreAuthorizationDecision(ctx, principalID, out[i])
+			continue
+		}
+		if owner, err := r.objectOwner(ctx, objectID); err != nil {
+			return nil, err
+		} else if owner != "" && owner == principalID {
+			out[i].Allowed = true
+			out[i].Owner = true
+			out[i].Reason = access.ReasonOwner
+			access.StoreAuthorizationDecision(ctx, principalID, out[i])
+			continue
+		}
+		if platformDecision.Allowed {
+			out[i].Allowed = true
+			out[i].Platform = true
+			out[i].GrantID = platformDecision.GrantID
+			out[i].GrantObjectID = platformDecision.GrantObjectID
+			out[i].SubjectType = platformDecision.SubjectType
+			out[i].SubjectID = platformDecision.SubjectID
+			out[i].Reason = access.ReasonPlatformAdmin
+			access.StoreAuthorizationDecision(ctx, principalID, out[i])
+			continue
+		}
+		objectIDs, err := r.objectAncestry(ctx, objectID)
+		if err != nil {
+			return nil, err
+		}
+		grantDecision, err := r.authorizeByGrant(ctx, principalID, check.Privilege, objectIDs)
+		if err != nil {
+			return nil, err
+		}
+		if grantDecision.Allowed {
+			grantDecision.Privilege = check.Privilege
+			grantDecision.Object = check.Object
+			out[i] = grantDecision
+		} else {
+			out[i].Reason = access.ReasonNoGrant
+		}
+		access.StoreAuthorizationDecision(ctx, principalID, out[i])
+	}
+	return out, nil
 }
 
 func (r *Repository) EffectivePrivileges(ctx context.Context, principalID string, object access.ObjectRef) ([]access.Privilege, error) {
@@ -428,11 +482,16 @@ func (r *Repository) EffectivePrivileges(ctx context.Context, principalID string
 
 func (r *Repository) EffectiveAccess(ctx context.Context, principalID string, object access.ObjectRef) ([]access.AuthorizationDecision, error) {
 	out := []access.AuthorizationDecision{}
-	for _, privilege := range knownPrivileges() {
-		decision, err := r.Authorize(ctx, principalID, privilege, object)
-		if err != nil {
-			return nil, err
-		}
+	privileges := knownPrivileges()
+	checks := make([]access.AuthorizationCheck, 0, len(privileges))
+	for _, privilege := range privileges {
+		checks = append(checks, access.AuthorizationCheck{Privilege: privilege, Object: object})
+	}
+	decisions, err := r.AuthorizeBatch(ctx, principalID, checks)
+	if err != nil {
+		return nil, err
+	}
+	for _, decision := range decisions {
 		if decision.Allowed {
 			out = append(out, decision)
 		}
@@ -440,7 +499,27 @@ func (r *Repository) EffectiveAccess(ctx context.Context, principalID string, ob
 	return out, nil
 }
 
+func (r *Repository) UpsertSecurableObject(ctx context.Context, object access.ObjectRef, ownerPrincipalID string) (access.SecurableObject, error) {
+	access.ClearAuthorizationCache(ctx)
+	objectID, err := r.ensureSecurableObject(ctx, object)
+	if err != nil {
+		return access.SecurableObject{}, err
+	}
+	ownerPrincipalID = strings.TrimSpace(ownerPrincipalID)
+	if ownerPrincipalID != "" {
+		if _, err := r.db.ExecContext(ctx, `
+UPDATE securable_objects
+SET owner_principal_id = COALESCE(NULLIF(owner_principal_id, ''), ?), updated_at = CURRENT_TIMESTAMP
+WHERE id = ?
+`, ownerPrincipalID, objectID); err != nil {
+			return access.SecurableObject{}, err
+		}
+	}
+	return r.securableObjectByID(ctx, objectID)
+}
+
 func (r *Repository) CreateGrant(ctx context.Context, input access.GrantInput) (access.Grant, error) {
+	access.ClearAuthorizationCache(ctx)
 	id := newID("grant")
 	if err := r.upsertGrantWithID(ctx, id, input); err != nil {
 		return access.Grant{}, err
@@ -477,6 +556,7 @@ WHERE g.id = ?
 }
 
 func (r *Repository) DeleteGrant(ctx context.Context, workspaceID, id string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(id) == "" {
 		return fmt.Errorf("grant id is required")
 	}
@@ -492,6 +572,7 @@ WHERE id = ?
 }
 
 func (r *Repository) UpsertDataPolicy(ctx context.Context, input access.DataPolicyInput) (access.DataPolicy, error) {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(input.ID) == "" {
 		input.ID = newID("datapolicy")
 	}
@@ -546,9 +627,9 @@ func (r *Repository) ListDataPolicies(ctx context.Context, object access.ObjectR
 }
 
 func (r *Repository) ListDataPoliciesWithOptions(ctx context.Context, object access.ObjectRef, includeInherited bool) ([]access.DataPolicy, error) {
-	objectID, err := r.ensureSecurableObject(ctx, object)
-	if err != nil {
-		return nil, err
+	objectID, exists, err := r.lookupSecurableObjectID(ctx, object)
+	if err != nil || !exists {
+		return []access.DataPolicy{}, err
 	}
 	objectIDs := []string{objectID}
 	if includeInherited {
@@ -627,6 +708,7 @@ LIMIT 1
 }
 
 func (r *Repository) DeleteDataPolicy(ctx context.Context, workspaceID, id string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(id) == "" {
 		return fmt.Errorf("data policy id is required")
 	}
@@ -635,6 +717,7 @@ func (r *Repository) DeleteDataPolicy(ctx context.Context, workspaceID, id strin
 }
 
 func (r *Repository) SetObjectOwner(ctx context.Context, object access.ObjectRef, ownerPrincipalID string) (access.SecurableObject, error) {
+	access.ClearAuthorizationCache(ctx)
 	ownerPrincipalID = strings.TrimSpace(ownerPrincipalID)
 	if ownerPrincipalID == "" {
 		return access.SecurableObject{}, fmt.Errorf("owner principal id is required")
@@ -666,9 +749,9 @@ func (r *Repository) ListGrants(ctx context.Context, object access.ObjectRef) ([
 }
 
 func (r *Repository) ListGrantsWithOptions(ctx context.Context, object access.ObjectRef, includeInherited bool) ([]access.GrantView, error) {
-	objectID, err := r.ensureSecurableObject(ctx, object)
-	if err != nil {
-		return nil, err
+	objectID, exists, err := r.lookupSecurableObjectID(ctx, object)
+	if err != nil || !exists {
+		return []access.GrantView{}, err
 	}
 	objectIDs := []string{objectID}
 	if includeInherited {
@@ -755,8 +838,24 @@ ORDER BY CASE g.object_id`
 	decision.SubjectType = access.SubjectType(subjectType)
 	decision.SubjectID = subjectID
 	decision.Inherited = len(objectIDs) > 0 && objectID != objectIDs[0]
-	decision.Reason = "grant"
+	decision.Reason = access.ReasonGrant
 	return decision, nil
+}
+
+func (r *Repository) lookupSecurableObjectID(ctx context.Context, object access.ObjectRef) (string, bool, error) {
+	objectID := object.CanonicalID()
+	if strings.TrimSpace(objectID) == "" {
+		return "", false, fmt.Errorf("securable object id is required")
+	}
+	var found string
+	err := r.db.QueryRowContext(ctx, `SELECT id FROM securable_objects WHERE id = ?`, objectID).Scan(&found)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return found, true, nil
 }
 
 func (r *Repository) ensureSecurableObject(ctx context.Context, object access.ObjectRef) (string, error) {
@@ -986,6 +1085,7 @@ func (r *Repository) BootstrapAdmin(ctx context.Context, workspaceID, email stri
 }
 
 func (r *Repository) ResolveExternalPrincipal(ctx context.Context, input access.ExternalIdentityInput) (access.Principal, error) {
+	access.ClearAuthorizationCache(ctx)
 	input.Email = access.NormalizeEmail(input.Email)
 	if input.Provider == "" || input.Subject == "" {
 		return access.Principal{}, fmt.Errorf("external identity requires provider and subject")
@@ -1060,6 +1160,7 @@ func (r *Repository) ResolveExternalPrincipal(ctx context.Context, input access.
 }
 
 func (r *Repository) UpsertSCIMUser(ctx context.Context, input access.SCIMUserInput) (access.SCIMUser, error) {
+	access.ClearAuthorizationCache(ctx)
 	id := strings.TrimSpace(input.ID)
 	existingSubject := ""
 	if id == "" {
@@ -1165,6 +1266,7 @@ func (r *Repository) ListSCIMUsers(ctx context.Context, filter access.SCIMUserFi
 }
 
 func (r *Repository) DisableSCIMUser(ctx context.Context, principalID string) (access.SCIMUser, error) {
+	access.ClearAuthorizationCache(ctx)
 	principalID = strings.TrimSpace(principalID)
 	if principalID == "" {
 		return access.SCIMUser{}, fmt.Errorf("principal id is required")
@@ -1196,6 +1298,7 @@ func (r *Repository) DisableSCIMUser(ctx context.Context, principalID string) (a
 }
 
 func (r *Repository) UpsertGroup(ctx context.Context, input access.GroupInput) (access.Group, error) {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(input.WorkspaceID) == "" {
 		return access.Group{}, fmt.Errorf("workspace id is required")
 	}
@@ -1264,6 +1367,7 @@ ORDER BY workspace_id, name, id
 }
 
 func (r *Repository) DeleteGroup(ctx context.Context, workspaceID, groupID string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(groupID) == "" {
 		return fmt.Errorf("group id is required")
 	}
@@ -1274,6 +1378,7 @@ func (r *Repository) DeleteGroup(ctx context.Context, workspaceID, groupID strin
 }
 
 func (r *Repository) AddGroupMember(ctx context.Context, workspaceID, groupID, principalID string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(groupID) == "" || strings.TrimSpace(principalID) == "" {
 		return fmt.Errorf("group id and principal id are required")
 	}
@@ -1285,6 +1390,7 @@ func (r *Repository) AddGroupMember(ctx context.Context, workspaceID, groupID, p
 }
 
 func (r *Repository) RemoveGroupMember(ctx context.Context, workspaceID, groupID, principalID string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(groupID) == "" || strings.TrimSpace(principalID) == "" {
 		return fmt.Errorf("group id and principal id are required")
 	}
@@ -1342,6 +1448,7 @@ ORDER BY p.email, p.display_name, gm.principal_id
 }
 
 func (r *Repository) UpsertSCIMGroup(ctx context.Context, input access.SCIMGroupInput) (access.Group, error) {
+	access.ClearAuthorizationCache(ctx)
 	externalID := strings.TrimSpace(firstNonEmpty(input.ExternalID, input.ID, input.Name))
 	if externalID == "" {
 		return access.Group{}, fmt.Errorf("scim group requires external id, id, or display name")
@@ -1414,6 +1521,7 @@ func (r *Repository) ListSCIMGroups(ctx context.Context, filter access.SCIMGroup
 }
 
 func (r *Repository) DeleteSCIMGroup(ctx context.Context, groupID string) error {
+	access.ClearAuthorizationCache(ctx)
 	groupID = strings.TrimSpace(groupID)
 	if groupID == "" {
 		return fmt.Errorf("group id is required")
@@ -1425,6 +1533,7 @@ func (r *Repository) DeleteSCIMGroup(ctx context.Context, groupID string) error 
 }
 
 func (r *Repository) AddSCIMGroupMember(ctx context.Context, groupID, principalID string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(groupID) == "" || strings.TrimSpace(principalID) == "" {
 		return fmt.Errorf("group id and principal id are required")
 	}
@@ -1436,6 +1545,7 @@ func (r *Repository) AddSCIMGroupMember(ctx context.Context, groupID, principalI
 }
 
 func (r *Repository) RemoveSCIMGroupMember(ctx context.Context, groupID, principalID string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(groupID) == "" || strings.TrimSpace(principalID) == "" {
 		return fmt.Errorf("group id and principal id are required")
 	}
@@ -1928,6 +2038,7 @@ func (r *Repository) RevokeAPITokenForPrincipal(ctx context.Context, principalID
 }
 
 func (r *Repository) CreateServicePrincipal(ctx context.Context, input access.ServicePrincipalInput) (access.Principal, error) {
+	access.ClearAuthorizationCache(ctx)
 	id := strings.TrimSpace(input.ID)
 	if id == "" {
 		id = newID("sp")
@@ -1956,6 +2067,7 @@ func (r *Repository) ListServicePrincipals(ctx context.Context) ([]access.Princi
 }
 
 func (r *Repository) UpdateServicePrincipal(ctx context.Context, id string, input access.ServicePrincipalInput) (access.Principal, error) {
+	access.ClearAuthorizationCache(ctx)
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return access.Principal{}, fmt.Errorf("service principal id is required")
@@ -1976,6 +2088,7 @@ func (r *Repository) UpdateServicePrincipal(ctx context.Context, id string, inpu
 }
 
 func (r *Repository) DeleteServicePrincipal(ctx context.Context, id string) error {
+	access.ClearAuthorizationCache(ctx)
 	if strings.TrimSpace(id) == "" {
 		return fmt.Errorf("service principal id is required")
 	}

--- a/internal/access/sqlite/repository_bench_test.go
+++ b/internal/access/sqlite/repository_bench_test.go
@@ -1,0 +1,134 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Yacobolo/libredash/internal/access"
+)
+
+func BenchmarkAuthorizeDirectGrant(b *testing.B) {
+	ctx := context.Background()
+	_, repo := openAccessRepo(b, ctx)
+	principal := benchmarkPrincipal(b, ctx, repo, "bench_direct")
+	object := access.ItemObject(access.SecurableDashboard, "test", "exec")
+	benchmarkGrant(b, ctx, repo, object, principal.ID, access.PrivilegeViewItem)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decision, err := repo.Authorize(ctx, principal.ID, access.PrivilegeViewItem, object)
+		if err != nil || !decision.Allowed {
+			b.Fatalf("decision = %#v err=%v, want allowed", decision, err)
+		}
+	}
+}
+
+func BenchmarkAuthorizeGroupGrantFanout(b *testing.B) {
+	ctx := context.Background()
+	_, repo := openAccessRepo(b, ctx)
+	principal := benchmarkPrincipal(b, ctx, repo, "bench_group_member")
+	for i := 0; i < 250; i++ {
+		group, err := repo.UpsertGroup(ctx, access.GroupInput{WorkspaceID: "test", Name: fmt.Sprintf("Group %03d", i)})
+		if err != nil {
+			b.Fatalf("upsert group: %v", err)
+		}
+		if err := repo.AddGroupMember(ctx, "test", group.ID, principal.ID); err != nil {
+			b.Fatalf("add group member: %v", err)
+		}
+	}
+	targetGroup, err := repo.UpsertGroup(ctx, access.GroupInput{WorkspaceID: "test", Name: "Target"})
+	if err != nil {
+		b.Fatalf("upsert target group: %v", err)
+	}
+	if err := repo.AddGroupMember(ctx, "test", targetGroup.ID, principal.ID); err != nil {
+		b.Fatalf("add target group member: %v", err)
+	}
+	object := access.ItemObject(access.SecurableDashboard, "test", "grouped")
+	if _, err := repo.CreateGrant(ctx, access.GrantInput{Object: object, SubjectType: access.SubjectGroup, SubjectID: targetGroup.ID, Privilege: access.PrivilegeViewItem}); err != nil {
+		b.Fatalf("create grant: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decision, err := repo.Authorize(ctx, principal.ID, access.PrivilegeViewItem, object)
+		if err != nil || !decision.Allowed {
+			b.Fatalf("decision = %#v err=%v, want allowed", decision, err)
+		}
+	}
+}
+
+func BenchmarkAuthorizeInheritedGrantDepth(b *testing.B) {
+	ctx := context.Background()
+	_, repo := openAccessRepo(b, ctx)
+	principal := benchmarkPrincipal(b, ctx, repo, "bench_inherited")
+	workspaceObject := access.WorkspaceObject("test")
+	parent := workspaceObject
+	for i := 0; i < 20; i++ {
+		parent = access.ItemObjectWithParent(access.SecurableDataset, "test", fmt.Sprintf("model/table_%02d", i), parent)
+		if _, err := repo.UpsertSecurableObject(ctx, parent, ""); err != nil {
+			b.Fatalf("upsert securable: %v", err)
+		}
+	}
+	benchmarkGrant(b, ctx, repo, workspaceObject, principal.ID, access.PrivilegeQueryData)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decision, err := repo.Authorize(ctx, principal.ID, access.PrivilegeQueryData, parent)
+		if err != nil || !decision.Allowed || !decision.Inherited {
+			b.Fatalf("decision = %#v err=%v, want inherited allowed", decision, err)
+		}
+	}
+}
+
+func BenchmarkAuthorizeAny(b *testing.B) {
+	ctx := context.Background()
+	_, repo := openAccessRepo(b, ctx)
+	principal := benchmarkPrincipal(b, ctx, repo, "bench_any")
+	objects := make([]access.ObjectRef, 0, 25)
+	for i := 0; i < 25; i++ {
+		object := access.ItemObject(access.SecurableDashboard, "test", fmt.Sprintf("dash_%02d", i))
+		if _, err := repo.UpsertSecurableObject(ctx, object, ""); err != nil {
+			b.Fatalf("upsert object: %v", err)
+		}
+		objects = append(objects, object)
+	}
+	benchmarkGrant(b, ctx, repo, objects[len(objects)-1], principal.ID, access.PrivilegeViewItem)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decision, err := repo.AuthorizeAny(ctx, principal.ID, access.PrivilegeViewItem, objects)
+		if err != nil || !decision.Allowed {
+			b.Fatalf("decision = %#v err=%v, want allowed", decision, err)
+		}
+	}
+}
+
+func BenchmarkEffectiveAccess(b *testing.B) {
+	ctx := context.Background()
+	_, repo := openAccessRepo(b, ctx)
+	principal := benchmarkPrincipal(b, ctx, repo, "bench_effective")
+	object := access.ItemObject(access.SecurableDashboard, "test", "effective")
+	for _, privilege := range []access.Privilege{access.PrivilegeViewItem, access.PrivilegeQueryData, access.PrivilegeUseAgent, access.PrivilegeViewAgent} {
+		benchmarkGrant(b, ctx, repo, object, principal.ID, privilege)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decisions, err := repo.EffectiveAccess(ctx, principal.ID, object)
+		if err != nil || len(decisions) != 4 {
+			b.Fatalf("decisions = %#v err=%v, want 4 decisions", decisions, err)
+		}
+	}
+}
+
+func benchmarkPrincipal(tb testing.TB, ctx context.Context, repo *Repository, id string) access.Principal {
+	tb.Helper()
+	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{ID: id, Email: id + "@example.com", DisplayName: id})
+	if err != nil {
+		tb.Fatalf("upsert principal: %v", err)
+	}
+	return principal
+}
+
+func benchmarkGrant(tb testing.TB, ctx context.Context, repo *Repository, object access.ObjectRef, principalID string, privilege access.Privilege) {
+	tb.Helper()
+	if _, err := repo.CreateGrant(ctx, access.GrantInput{Object: object, SubjectType: access.SubjectPrincipal, SubjectID: principalID, Privilege: privilege}); err != nil {
+		tb.Fatalf("create grant: %v", err)
+	}
+}

--- a/internal/access/sqlite/repository_test.go
+++ b/internal/access/sqlite/repository_test.go
@@ -51,6 +51,9 @@ func TestRepositoryChecksPlatformRolePrivileges(t *testing.T) {
 		t.Fatalf("set platform role: %v", err)
 	}
 	for _, workspaceID := range []string{"test", "other"} {
+		if _, err := repo.UpsertSecurableObject(ctx, access.WorkspaceObject(workspaceID), ""); err != nil {
+			t.Fatalf("upsert securable workspace %s: %v", workspaceID, err)
+		}
 		allowed, err := testAuthorize(ctx, repo, workspaceID, principal.ID, access.PrivilegeManageGrants)
 		if err != nil {
 			t.Fatalf("check privilege for %s: %v", workspaceID, err)
@@ -152,16 +155,48 @@ func TestRepositoryResolvesDBBackedObjectInheritance(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create dataset grant: %v", err)
 	}
+	if _, err := repo.UpsertSecurableObject(ctx, column, ""); err != nil {
+		t.Fatalf("upsert column securable: %v", err)
+	}
 
 	decision, err := repo.Authorize(ctx, principal.ID, access.PrivilegeQueryData, column)
 	if err != nil {
 		t.Fatalf("authorize column: %v", err)
 	}
-	if !decision.Allowed || !decision.Inherited || decision.Reason != "grant" {
+	if !decision.Allowed || !decision.Inherited || decision.Reason != access.ReasonGrant {
 		t.Fatalf("decision = %#v, want inherited dataset grant", decision)
 	}
 	if decision.GrantObjectID != dataset.CanonicalID() {
 		t.Fatalf("grant object = %q, want %q", decision.GrantObjectID, dataset.CanonicalID())
+	}
+}
+
+func TestRepositoryAuthorizeDoesNotCreateUnknownSecurableObject(t *testing.T) {
+	ctx := context.Background()
+	store, repo := openAccessRepo(t, ctx)
+
+	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{
+		ID:          "unknown_object_reader",
+		Email:       "unknown@example.com",
+		DisplayName: "Unknown Reader",
+	})
+	if err != nil {
+		t.Fatalf("upsert principal: %v", err)
+	}
+	object := access.ItemObject(access.SecurableDashboard, "test", "missing")
+	decision, err := repo.Authorize(ctx, principal.ID, access.PrivilegeViewItem, object)
+	if err != nil {
+		t.Fatalf("authorize unknown object: %v", err)
+	}
+	if decision.Allowed || decision.Reason != access.ReasonUnknownObject {
+		t.Fatalf("decision = %#v, want denied unknown_object", decision)
+	}
+	var count int
+	if err := store.SQLDB().QueryRowContext(ctx, `SELECT COUNT(*) FROM securable_objects WHERE id = ?`, object.CanonicalID()).Scan(&count); err != nil {
+		t.Fatalf("count securable objects: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("authorize created %d securable object rows, want 0", count)
 	}
 }
 
@@ -202,13 +237,89 @@ func TestRepositoryExplainsEffectiveAccessAndAuthorizeAny(t *testing.T) {
 	for _, row := range effective {
 		if row.Privilege == access.PrivilegeViewItem {
 			found = true
-			if row.Reason != "grant" || row.GrantID == "" || row.GrantObjectID != dashboard.CanonicalID() {
+			if row.Reason != access.ReasonGrant || row.GrantID == "" || row.GrantObjectID != dashboard.CanonicalID() {
 				t.Fatalf("view explanation = %#v, want direct grant provenance", row)
 			}
 		}
 	}
 	if !found {
 		t.Fatalf("effective access = %#v, missing VIEW_ITEM", effective)
+	}
+}
+
+func TestRepositoryAuthorizeBatchMatchesIndividualAuthorize(t *testing.T) {
+	ctx := context.Background()
+	_, repo := openAccessRepo(t, ctx)
+
+	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{ID: "batch_viewer", Email: "batch@example.com"})
+	if err != nil {
+		t.Fatalf("upsert principal: %v", err)
+	}
+	dashboard := access.ItemObject(access.SecurableDashboard, "test", "exec")
+	dataset := access.ItemObjectWithParent(access.SecurableDataset, "test", "sales/orders", access.ItemObject(access.SecurableSemanticModel, "test", "sales"))
+	for _, grant := range []access.GrantInput{
+		{Object: dashboard, SubjectType: access.SubjectPrincipal, SubjectID: principal.ID, Privilege: access.PrivilegeViewItem},
+		{Object: dataset, SubjectType: access.SubjectPrincipal, SubjectID: principal.ID, Privilege: access.PrivilegeQueryData},
+	} {
+		if _, err := repo.CreateGrant(ctx, grant); err != nil {
+			t.Fatalf("create grant: %v", err)
+		}
+	}
+	column := access.ItemObjectWithParent(access.SecurableColumn, "test", "sales/orders/net_revenue", dataset)
+	if _, err := repo.UpsertSecurableObject(ctx, column, ""); err != nil {
+		t.Fatalf("upsert column securable: %v", err)
+	}
+	checks := []access.AuthorizationCheck{
+		{Privilege: access.PrivilegeViewItem, Object: dashboard},
+		{Privilege: access.PrivilegeQueryData, Object: column},
+		{Privilege: access.PrivilegeManageGrants, Object: dashboard},
+	}
+	batch, err := repo.AuthorizeBatch(ctx, principal.ID, checks)
+	if err != nil {
+		t.Fatalf("authorize batch: %v", err)
+	}
+	if len(batch) != len(checks) {
+		t.Fatalf("batch decisions = %d, want %d", len(batch), len(checks))
+	}
+	for i, check := range checks {
+		individual, err := repo.Authorize(ctx, principal.ID, check.Privilege, check.Object)
+		if err != nil {
+			t.Fatalf("authorize individual %d: %v", i, err)
+		}
+		if batch[i] != individual {
+			t.Fatalf("decision %d = %#v, want %#v", i, batch[i], individual)
+		}
+	}
+}
+
+func TestRepositoryAccessMutationsClearRequestAuthorizationCache(t *testing.T) {
+	ctx := access.WithAuthorizationCache(context.Background())
+	_, repo := openAccessRepo(t, ctx)
+
+	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{ID: "cached_denial", Email: "cached@example.com"})
+	if err != nil {
+		t.Fatalf("upsert principal: %v", err)
+	}
+	object := access.ItemObject(access.SecurableDashboard, "test", "cache")
+	if _, err := repo.UpsertSecurableObject(ctx, object, ""); err != nil {
+		t.Fatalf("upsert securable object: %v", err)
+	}
+	denied, err := repo.Authorize(ctx, principal.ID, access.PrivilegeViewItem, object)
+	if err != nil {
+		t.Fatalf("authorize denied: %v", err)
+	}
+	if denied.Allowed || denied.Reason != access.ReasonNoGrant {
+		t.Fatalf("denied decision = %#v, want no_grant", denied)
+	}
+	if _, err := repo.CreateGrant(ctx, access.GrantInput{Object: object, SubjectType: access.SubjectPrincipal, SubjectID: principal.ID, Privilege: access.PrivilegeViewItem}); err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+	allowed, err := repo.Authorize(ctx, principal.ID, access.PrivilegeViewItem, object)
+	if err != nil {
+		t.Fatalf("authorize allowed: %v", err)
+	}
+	if !allowed.Allowed || allowed.Reason != access.ReasonGrant {
+		t.Fatalf("allowed decision = %#v, want grant after cache clear", allowed)
 	}
 }
 
@@ -350,7 +461,7 @@ func TestRepositoryObjectOwnershipGrantsFullControl(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorize owner: %v", err)
 	}
-	if !decision.Allowed || !decision.Owner || decision.Reason != "owner" {
+	if !decision.Allowed || !decision.Owner || decision.Reason != access.ReasonOwner {
 		t.Fatalf("owner decision = %#v", decision)
 	}
 }
@@ -1054,7 +1165,7 @@ func TestRepositoryFiltersAndPaginatesAuditEvents(t *testing.T) {
 	}
 }
 
-func openAccessRepo(t *testing.T, ctx context.Context) (*platform.Store, *Repository) {
+func openAccessRepo(t testing.TB, ctx context.Context) (*platform.Store, *Repository) {
 	t.Helper()
 	store, err := platform.Open(ctx, filepath.Join(t.TempDir(), "libredash.db"))
 	if err != nil {

--- a/internal/analytics/query/authz/data_authorization_bench_test.go
+++ b/internal/analytics/query/authz/data_authorization_bench_test.go
@@ -1,0 +1,81 @@
+package authz
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/Yacobolo/libredash/internal/access"
+	accesssqlite "github.com/Yacobolo/libredash/internal/access/sqlite"
+	"github.com/Yacobolo/libredash/internal/dataquery"
+	"github.com/Yacobolo/libredash/internal/platform"
+	"github.com/Yacobolo/libredash/internal/workspace"
+	workspacesqlite "github.com/Yacobolo/libredash/internal/workspace/sqlite"
+)
+
+func BenchmarkGovernDataQueryWithPolicies(b *testing.B) {
+	ctx := context.Background()
+	store, err := platform.Open(ctx, filepath.Join(b.TempDir(), "libredash.db"))
+	if err != nil {
+		b.Fatalf("open store: %v", err)
+	}
+	b.Cleanup(func() { _ = store.Close() })
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(ctx, workspace.EnsureInput{ID: "test", Title: "Test"}); err != nil {
+		b.Fatalf("ensure workspace: %v", err)
+	}
+	repo := accesssqlite.NewRepository(store.SQLDB())
+	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{ID: "bench_query", Email: "bench-query@example.com"})
+	if err != nil {
+		b.Fatalf("upsert principal: %v", err)
+	}
+	model := access.ItemObject(access.SecurableSemanticModel, "test", "sales")
+	dataset := access.ItemObjectWithParent(access.SecurableDataset, "test", "sales/orders", model)
+	emailColumn := access.ItemObjectWithParent(access.SecurableColumn, "test", "sales/orders/email", dataset)
+	statusColumn := access.ItemObjectWithParent(access.SecurableColumn, "test", "sales/orders/status", dataset)
+	for _, object := range []access.ObjectRef{dataset, emailColumn, statusColumn} {
+		if _, err := repo.UpsertSecurableObject(ctx, object, ""); err != nil {
+			b.Fatalf("upsert securable: %v", err)
+		}
+	}
+	if _, err := repo.CreateGrant(ctx, access.GrantInput{Object: dataset, SubjectType: access.SubjectPrincipal, SubjectID: principal.ID, Privilege: access.PrivilegePreviewData}); err != nil {
+		b.Fatalf("create grant: %v", err)
+	}
+	rowFilter, _ := json.Marshal(map[string]any{"field": "orders.status", "operator": "eq", "values": []any{"complete"}})
+	if _, err := repo.UpsertDataPolicy(ctx, access.DataPolicyInput{Object: dataset, PolicyType: "row_filter", ExpressionJSON: string(rowFilter)}); err != nil {
+		b.Fatalf("upsert row filter: %v", err)
+	}
+	columnMask, _ := json.Marshal(map[string]any{"field": "orders.email", "mask": "redact"})
+	if _, err := repo.UpsertDataPolicy(ctx, access.DataPolicyInput{Object: emailColumn, PolicyType: "column_mask", ExpressionJSON: string(columnMask)}); err != nil {
+		b.Fatalf("upsert column mask: %v", err)
+	}
+	metrics := New(nil, Options{
+		Repo: repo,
+		PrincipalFromContext: func(context.Context) (Principal, bool) {
+			return Principal{ID: principal.ID}, true
+		},
+		DefaultWorkspaceID: "test",
+	})
+	request := dataquery.Query{
+		WorkspaceID: "test",
+		ModelID:     "sales",
+		Kind:        dataquery.KindSemanticRows,
+		Target:      "orders",
+		Operation:   dataquery.OperationAPIPreview,
+		Fields: []dataquery.Field{
+			{Field: "orders.email", Alias: "email"},
+			{Field: "orders.status", Alias: "status"},
+		},
+		Limit: 100,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		governed, _, err := metrics.GovernDataQuery(ctx, request)
+		if err != nil {
+			b.Fatalf("govern data query: %v", err)
+		}
+		if len(governed.Filters) != 1 || len(governed.ColumnMasks) != 1 {
+			b.Fatalf("governed query = %#v, want row filter and column mask", governed)
+		}
+	}
+}

--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -258,6 +258,7 @@ func (a *Auth) MiddlewareWithObjectResolver(privilege access.Privilege, objectRe
 		return next
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(access.WithAuthorizationCache(r.Context()))
 		principal, credential, ok := a.authenticate(r)
 		if !ok {
 			if wantsJSON(r) {

--- a/internal/app/publishes_test.go
+++ b/internal/app/publishes_test.go
@@ -201,6 +201,9 @@ func TestDeploymentAPIRequiresAuthentication(t *testing.T) {
 func TestDeploymentAPIRejectsBrowserPostWithoutCSRF(t *testing.T) {
 	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(context.Background(), workspace.EnsureInput{ID: "path-workspace", Title: "Path Workspace"}); err != nil {
+		t.Fatalf("ensure path workspace: %v", err)
+	}
 	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
@@ -357,6 +360,9 @@ func TestDeploymentAPIRejectsViewer(t *testing.T) {
 func TestDeploymentAPIV1CreateUsesPathWorkspaceAndRejectsMalformedJSON(t *testing.T) {
 	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(context.Background(), workspace.EnsureInput{ID: "path-workspace", Title: "Path Workspace"}); err != nil {
+		t.Fatalf("ensure path workspace: %v", err)
+	}
 	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
@@ -390,6 +396,9 @@ func TestDeploymentAPIV1CreateUsesPathWorkspaceAndRejectsMalformedJSON(t *testin
 func TestDeploymentAPIV1CreateRejectsBodyWorkspaceID(t *testing.T) {
 	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(context.Background(), workspace.EnsureInput{ID: "path-workspace", Title: "Path Workspace"}); err != nil {
+		t.Fatalf("ensure path workspace: %v", err)
+	}
 	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
@@ -499,6 +508,9 @@ func TestDeploymentAPIV1WrongWorkspaceDeploymentReturnsNotFound(t *testing.T) {
 	t.Setenv("LIBREDASH_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
 	ctx := context.Background()
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(ctx, workspace.EnsureInput{ID: "other", Title: "Other"}); err != nil {
+		t.Fatalf("ensure other workspace: %v", err)
+	}
 	servingStateRepo := servingstatesqlite.NewRepository(store.SQLDB())
 	created, err := servingStateRepo.Create(ctx, servingstate.CreateInput{WorkspaceID: "test", CreatedBy: "tester"})
 	if err != nil {

--- a/internal/app/scim_test.go
+++ b/internal/app/scim_test.go
@@ -148,7 +148,7 @@ func TestSCIMDisableRevokesCredentialsAndBlocksAuthorization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorize disabled principal: %v", err)
 	}
-	if decision.Allowed || decision.Reason != "principal_disabled" {
+	if decision.Allowed || decision.Reason != access.ReasonPrincipalDisabled {
 		t.Fatalf("disabled principal decision = %#v, want denied principal_disabled", decision)
 	}
 }

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -183,8 +183,11 @@ func NewWithOptions(metrics QueryMetrics, options Options) *Server {
 	if options.Logger != nil {
 		server.logger = options.Logger
 	}
-	if server.accessRepo != nil && strings.TrimSpace(server.defaultWorkspaceID) != "" {
-		_, _ = server.accessRepo.UpsertSecurableObject(context.Background(), access.WorkspaceObject(server.defaultWorkspaceID), "")
+	if err := server.registerDefaultWorkspaceSecurable(context.Background()); err != nil {
+		server.logger.ErrorContext(context.Background(), "register default workspace securable failed", "workspace", server.defaultWorkspaceID, "error", err)
+	}
+	if err := server.registerStoredWorkspaceSecurables(context.Background()); err != nil {
+		server.logger.ErrorContext(context.Background(), "register stored workspace securables failed", "error", err)
 	}
 	if server.agent != nil {
 		server.agent.ConfigureDefaultModel(func(config agent.Config) agentcore.Model {
@@ -241,7 +244,13 @@ func (s *Server) workspaceRepository() (workspace.Repository, error) {
 	if s.store == nil {
 		return nil, nil
 	}
-	s.workspaceRepo = workspacesqlite.NewRepository(s.store.SQLDB())
+	var securables workspacesqlite.SecurableRegistrar
+	if accessRepo, err := s.accessRepository(); err == nil {
+		securables = accessRepo
+	} else if s.logger != nil {
+		s.logger.ErrorContext(context.Background(), "create access repository for workspace securable registration failed", "error", err)
+	}
+	s.workspaceRepo = workspacesqlite.NewRepositoryWithSecurables(s.store.SQLDB(), securables)
 	return s.workspaceRepo, nil
 }
 
@@ -254,6 +263,47 @@ func (s *Server) accessRepository() (access.Repository, error) {
 	}
 	s.accessRepo = accesssqlite.NewRepository(s.store.SQLDB())
 	return s.accessRepo, nil
+}
+
+func (s *Server) registerDefaultWorkspaceSecurable(ctx context.Context) error {
+	if strings.TrimSpace(s.defaultWorkspaceID) == "" {
+		return nil
+	}
+	repo, err := s.accessRepository()
+	if err != nil {
+		return err
+	}
+	if repo == nil {
+		return nil
+	}
+	_, err = repo.UpsertSecurableObject(ctx, access.WorkspaceObject(s.defaultWorkspaceID), "")
+	return err
+}
+
+func (s *Server) registerStoredWorkspaceSecurables(ctx context.Context) error {
+	workspaceRepo, err := s.workspaceRepository()
+	if err != nil {
+		return err
+	}
+	accessRepo, err := s.accessRepository()
+	if err != nil {
+		return err
+	}
+	if workspaceRepo == nil || accessRepo == nil {
+		return nil
+	}
+	workspaces, err := workspaceRepo.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, row := range workspaces {
+		object := access.WorkspaceObject(string(row.ID))
+		object.DisplayName = row.Title
+		if _, err := accessRepo.UpsertSecurableObject(ctx, object, ""); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func principalFromContext(ctx context.Context) (Principal, bool) {

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -159,6 +160,9 @@ func NewWithOptions(metrics QueryMetrics, options Options) *Server {
 	server.workspaceRepo = options.WorkspaceRepo
 	server.assetCatalog = options.AssetCatalog
 	server.accessRepo = options.AccessRepo
+	if server.accessRepo == nil && dataAccessRepo != nil {
+		server.accessRepo = dataAccessRepo
+	}
 	server.agent = options.Agent
 	server.auth = options.Auth
 	server.reloader = options.Reloader
@@ -178,6 +182,9 @@ func NewWithOptions(metrics QueryMetrics, options Options) *Server {
 	}
 	if options.Logger != nil {
 		server.logger = options.Logger
+	}
+	if server.accessRepo != nil && strings.TrimSpace(server.defaultWorkspaceID) != "" {
+		_, _ = server.accessRepo.UpsertSecurableObject(context.Background(), access.WorkspaceObject(server.defaultWorkspaceID), "")
 	}
 	if server.agent != nil {
 		server.agent.ConfigureDefaultModel(func(config agent.Config) agentcore.Model {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"path/filepath"
 
+	oidcauth "github.com/Yacobolo/libredash/internal/access/oidc"
 	accesssqlite "github.com/Yacobolo/libredash/internal/access/sqlite"
 	"github.com/Yacobolo/libredash/internal/agent"
 	agentsqlite "github.com/Yacobolo/libredash/internal/agent/sqlite"
 	analyticsducklake "github.com/Yacobolo/libredash/internal/analytics/ducklake"
 	materializesqlite "github.com/Yacobolo/libredash/internal/analytics/materialize/sqlite"
 	"github.com/Yacobolo/libredash/internal/app"
-	oidcauth "github.com/Yacobolo/libredash/internal/access/oidc"
 	"github.com/Yacobolo/libredash/internal/config"
 	"github.com/Yacobolo/libredash/internal/platform"
 	"github.com/Yacobolo/libredash/internal/runtimehost"
@@ -90,8 +90,8 @@ func servingStateBackedServer(ctx context.Context, cfg config.Config, dataDir st
 		return nil, nil, err
 	}
 	cleanup := func() { _ = store.Close() }
-	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
 	accessRepo := accesssqlite.NewRepository(store.SQLDB())
+	workspaceRepo := workspacesqlite.NewRepositoryWithSecurables(store.SQLDB(), accessRepo)
 	if !production {
 		if err := app.SeedLocalDeveloperPlatformAdmin(ctx, accessRepo); err != nil {
 			cleanup()

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -76,10 +76,10 @@ func TestDeploymentBackedDevServerSeedsPlatformAdminPrincipal(t *testing.T) {
 		t.Fatalf("open platform store: %v", err)
 	}
 	defer store.Close()
-	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(ctx, workspace.EnsureInput{ID: "other", Title: "Other"}); err != nil {
+	repo := accesssqlite.NewRepository(store.SQLDB())
+	if err := workspacesqlite.NewRepositoryWithSecurables(store.SQLDB(), repo).Ensure(ctx, workspace.EnsureInput{ID: "other", Title: "Other"}); err != nil {
 		t.Fatalf("ensure other workspace: %v", err)
 	}
-	repo := accesssqlite.NewRepository(store.SQLDB())
 	principal, err := repo.PrincipalByID(ctx, "dev")
 	if err != nil {
 		t.Fatalf("lookup dev principal: %v", err)

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Yacobolo/libredash/internal/platform"
 	servingstate "github.com/Yacobolo/libredash/internal/servingstate"
 	servingstatesqlite "github.com/Yacobolo/libredash/internal/servingstate/sqlite"
+	"github.com/Yacobolo/libredash/internal/workspace"
 	workspacesqlite "github.com/Yacobolo/libredash/internal/workspace/sqlite"
 )
 
@@ -75,6 +76,9 @@ func TestDeploymentBackedDevServerSeedsPlatformAdminPrincipal(t *testing.T) {
 		t.Fatalf("open platform store: %v", err)
 	}
 	defer store.Close()
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(ctx, workspace.EnsureInput{ID: "other", Title: "Other"}); err != nil {
+		t.Fatalf("ensure other workspace: %v", err)
+	}
 	repo := accesssqlite.NewRepository(store.SQLDB())
 	principal, err := repo.PrincipalByID(ctx, "dev")
 	if err != nil {

--- a/internal/integration/auth_spec_test.go
+++ b/internal/integration/auth_spec_test.go
@@ -209,7 +209,7 @@ func TestAuthSpecEffectiveAccessExplainsInheritedGrants(t *testing.T) {
 	}
 	for _, grant := range decoded.EffectiveGrants {
 		if grant.Privilege == string(access.PrivilegeQueryData) {
-			if grant.Reason != "grant" || !grant.Inherited || grant.GrantObjectID != "semantic_model:sales:sales" {
+			if grant.Reason != string(access.ReasonGrant) || !grant.Inherited || grant.GrantObjectID != "semantic_model:sales:sales" {
 				t.Fatalf("query grant provenance=%#v, want inherited semantic model grant", grant)
 			}
 			return

--- a/internal/workspace/sqlite/repository.go
+++ b/internal/workspace/sqlite/repository.go
@@ -7,18 +7,28 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Yacobolo/libredash/internal/access"
 	platformdb "github.com/Yacobolo/libredash/internal/platform/db"
 	servingstate "github.com/Yacobolo/libredash/internal/servingstate"
 	"github.com/Yacobolo/libredash/internal/workspace"
 )
 
+type SecurableRegistrar interface {
+	UpsertSecurableObject(ctx context.Context, object access.ObjectRef, ownerPrincipalID string) (access.SecurableObject, error)
+}
+
 type Repository struct {
-	db *sql.DB
-	q  *platformdb.Queries
+	db         *sql.DB
+	q          *platformdb.Queries
+	securables SecurableRegistrar
 }
 
 func NewRepository(sqlDB *sql.DB) *Repository {
 	return &Repository{db: sqlDB, q: platformdb.New(sqlDB)}
+}
+
+func NewRepositoryWithSecurables(sqlDB *sql.DB, securables SecurableRegistrar) *Repository {
+	return &Repository{db: sqlDB, q: platformdb.New(sqlDB), securables: securables}
 }
 
 func (r *Repository) Ensure(ctx context.Context, input workspace.EnsureInput) error {
@@ -37,16 +47,12 @@ func (r *Repository) Ensure(ctx context.Context, input workspace.EnsureInput) er
 	}); err != nil {
 		return err
 	}
-	_, err := r.db.ExecContext(ctx, `
-INSERT INTO securable_objects (id, object_type, workspace_id, parent_id, display_name)
-VALUES (?, 'workspace', ?, 'platform', ?)
-ON CONFLICT(id) DO UPDATE SET
-  object_type = excluded.object_type,
-  workspace_id = excluded.workspace_id,
-  parent_id = excluded.parent_id,
-  display_name = excluded.display_name,
-  updated_at = CURRENT_TIMESTAMP
-`, "workspace:"+id, id, title)
+	if r.securables == nil {
+		return nil
+	}
+	object := access.WorkspaceObject(id)
+	object.DisplayName = title
+	_, err := r.securables.UpsertSecurableObject(ctx, object, "")
 	return err
 }
 

--- a/internal/workspace/sqlite/repository.go
+++ b/internal/workspace/sqlite/repository.go
@@ -13,11 +13,12 @@ import (
 )
 
 type Repository struct {
-	q *platformdb.Queries
+	db *sql.DB
+	q  *platformdb.Queries
 }
 
 func NewRepository(sqlDB *sql.DB) *Repository {
-	return &Repository{q: platformdb.New(sqlDB)}
+	return &Repository{db: sqlDB, q: platformdb.New(sqlDB)}
 }
 
 func (r *Repository) Ensure(ctx context.Context, input workspace.EnsureInput) error {
@@ -29,11 +30,24 @@ func (r *Repository) Ensure(ctx context.Context, input workspace.EnsureInput) er
 	if title == "" {
 		title = id
 	}
-	return r.q.UpsertWorkspace(ctx, platformdb.UpsertWorkspaceParams{
+	if err := r.q.UpsertWorkspace(ctx, platformdb.UpsertWorkspaceParams{
 		ID:          id,
 		Title:       title,
 		Description: input.Description,
-	})
+	}); err != nil {
+		return err
+	}
+	_, err := r.db.ExecContext(ctx, `
+INSERT INTO securable_objects (id, object_type, workspace_id, parent_id, display_name)
+VALUES (?, 'workspace', ?, 'platform', ?)
+ON CONFLICT(id) DO UPDATE SET
+  object_type = excluded.object_type,
+  workspace_id = excluded.workspace_id,
+  parent_id = excluded.parent_id,
+  display_name = excluded.display_name,
+  updated_at = CURRENT_TIMESTAMP
+`, "workspace:"+id, id, title)
+	return err
 }
 
 func (r *Repository) List(ctx context.Context) ([]workspace.Summary, error) {


### PR DESCRIPTION
## Summary

Hardens LibreDash's custom Fabric/Unity-Catalog-style grant authorization engine by borrowing the best internal patterns from Casbin without adopting Casbin's policy model as a dependency.

The grant engine remains the source of truth for runtime authorization. This PR focuses on correctness, explicit read/write boundaries, typed decisions, request-local caching, batch evaluation, and performance coverage.

## Key Changes

- Make authorization read-only:
  - `Authorize`, `AuthorizeAny`, `EffectiveAccess`, and data-query authorization no longer upsert missing securable objects.
  - Unknown/unregistered securables fail closed with the typed `unknown_object` decision reason.
  - Explicit mutation paths still register securables through `UpsertSecurableObject`.

- Add typed authorization reasons:
  - Added `AuthorizationReason` constants for missing principal/privilege, disabled principal, unknown object, owner, platform admin, grant, no grant, and missing object.
  - Public JSON still emits simple reason strings.
  - Added tests that prevent raw reason-string comparisons outside the access package.

- Add batch/effective evaluation:
  - Added `AuthorizeBatch(ctx, principalID, checks)` to the access repository contract.
  - Reworked `Authorize`, `AuthorizeAny`, and `EffectiveAccess` through the shared batch path.
  - Batch evaluation computes principal disabled state and platform-admin grant state once.
  - Added per-batch object-fact caching so repeated checks against the same object reuse securable lookup, owner lookup, and ancestry traversal.

- Add request-scoped decision caching:
  - Added an authorization cache carried in request context by auth middleware.
  - Caches read-only decisions by principal, privilege, and canonical object ID for one request only.
  - Mutation paths clear the request cache after grant, role, group, owner, SCIM, service-principal, and identity changes.

- Tighten securable registration ownership:
  - Removed direct `securable_objects` writes from `internal/workspace/sqlite`.
  - Workspace persistence now uses an injected access-owned securable registrar.
  - App/CLI construction wires workspace repositories with the access SQLite repository as the registrar.
  - Startup reconciles default and stored workspaces into registered securables and logs registration failures instead of silently ignoring them.
  - `ObjectRef` now supports an optional display name so workspace titles are preserved through the access-owned registration path.

- Add performance coverage:
  - Added benchmarks for direct grants, group grants, inherited grants, `AuthorizeAny`, `EffectiveAccess`, and governed data-query authorization with row/column policies.
  - Benchmarks assert successful decisions before timing, so they guard behavior as well as runtime cost.

## Casbin-Inspired Patterns Adopted

- Read-only enforcement paths: authorization evaluates policy state and fails closed; mutation paths own registration/writes.
- Typed decision reasons: structured outcomes replace ad hoc string matching.
- Batch evaluation surface: callers can evaluate many privilege/object checks without duplicating setup work.
- Request-local caching: fast repeat checks without cross-request invalidation complexity.
- Benchmark coverage around common and scaled authorization paths.

## Tests / Verification

Passed:

- `go test ./internal/access/...`
- `go test ./internal/workspace/sqlite ./internal/app ./internal/cli`
- `go test ./...`
- `task ci`

