### PR TITLE
Wait for Hetzner HTTPS readiness

### DIFF
--- a/.github/workflows/hetzner-deploy.yml
+++ b/.github/workflows/hetzner-deploy.yml
@@ -78,8 +78,21 @@ jobs:
         run: |
           url="$(terraform output -raw url)"
           server_ip="$(terraform output -raw server_ipv4)"
-          curl -fsS "$url/healthz"
-          curl -fsS "$url/readyz"
+          public_ready=false
+          for _ in $(seq 1 60); do
+            if curl -fsS --connect-timeout 5 --max-time 10 "$url/healthz" >/dev/null 2>&1 && \
+              curl -fsS --connect-timeout 5 --max-time 10 "$url/readyz" >/dev/null 2>&1; then
+              public_ready=true
+              break
+            fi
+            sleep 5
+          done
+          if [[ "$public_ready" != "true" ]]; then
+            echo "Public HTTPS did not become ready" >&2
+            ssh -i "$RUNNER_TEMP/libredash-ci" root@"$server_ip" 'libredashctl status' || true
+            ssh -i "$RUNNER_TEMP/libredash-ci" root@"$server_ip" 'libredashctl logs caddy' || true
+            exit 1
+          fi
           curl -fsS -L "$url/" >/dev/null
           ssh -i "$RUNNER_TEMP/libredash-ci" root@"$server_ip" 'libredashctl status'
 

--- a/deploy/hetzner/deployment_test.go
+++ b/deploy/hetzner/deployment_test.go
@@ -115,6 +115,20 @@ func TestEphemeralDeploymentWorkflowAlwaysDestroysInfrastructure(t *testing.T) {
 	}
 }
 
+func TestEphemeralDeploymentWaitsForPublicHTTPS(t *testing.T) {
+	workflow := readFile(t, filepath.Join("..", "..", ".github", "workflows", "hetzner-deploy.yml"))
+
+	for _, fragment := range []string{
+		"public_ready=false",
+		"for _ in $(seq 1 60)",
+		"--connect-timeout 5",
+		"Public HTTPS did not become ready",
+		"libredashctl logs caddy",
+	} {
+		requireContains(t, workflow, fragment)
+	}
+}
+
 func TestOperationsScriptSyntaxAndCommands(t *testing.T) {
 	script := filepath.Join("files", "libredashctl")
 	contents := readFile(t, script)


### PR DESCRIPTION
## Summary

- poll the public health and readiness endpoints while Caddy completes certificate issuance
- bound the wait to five minutes with per-request timeouts
- print container status and Caddy logs when HTTPS never becomes ready
- add a deployment contract test for the readiness behavior

## Context

The first post-merge ephemeral deployment reached completed cloud-init, then the immediate HTTPS probe failed with OpenSSL exit 35 while Caddy was still obtaining the certificate. Infrastructure destruction still completed through the existing `if: always()` step.

## Verification

- `go test ./deploy/hetzner -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`