### PR TITLE
perf: streamline runtime activation and dashboard queries

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -107,14 +107,14 @@ tasks:
       - bun scripts/qa_ui_framework.ts
 
   qa:movielens-performance:
-    desc: Run the generic dashboard performance runner with the MovieLens scenario
+    desc: Run the local/nightly dashboard performance runner with the MovieLens scenario (not part of CI)
     deps:
       - node:deps
     cmds:
       - bun run qa:movielens-performance
 
   qa:dashboard-performance:
-    desc: Run a configured dashboard performance scenario against a running dev server
+    desc: Run a configured local/nightly performance scenario against a running dev server (not part of CI)
     deps:
       - node:deps
     cmds:

--- a/internal/analytics/query/bundle.go
+++ b/internal/analytics/query/bundle.go
@@ -15,9 +15,9 @@ type bundleDimension struct {
 }
 
 // PlanBundle fuses independently shaped aggregates with identical governed
-// scope and participating facts. Single-fact bundles scan their fact once;
-// multi-fact bundles scan each fact once and retain the regular outer-stitch
-// semantics before decoding consumer branches.
+// scope. Single-fact bundles scan their fact once; heterogeneous and
+// multi-fact bundles materialize one statement-local projection per fact and
+// retain the regular outer-stitch semantics before decoding consumer branches.
 func (p *Planner) PlanBundle(requests []BundleRequest) (BundlePlan, error) {
 	if len(requests) == 0 {
 		return BundlePlan{}, fmt.Errorf("aggregate bundle requires at least one request")
@@ -25,6 +25,8 @@ func (p *Planner) PlanBundle(requests []BundleRequest) (BundlePlan, error) {
 	resolutions := make([]aggregateResolution, len(requests))
 	fact := ""
 	factSignature := ""
+	heterogeneousFacts := false
+	containsMultiFact := false
 	ids := map[string]bool{}
 	for i, item := range requests {
 		if item.ID == "" || ids[item.ID] {
@@ -51,16 +53,16 @@ func (p *Planner) PlanBundle(requests []BundleRequest) (BundlePlan, error) {
 		if factSignature == "" {
 			factSignature = branchFacts
 			fact = resolved.Facts[0]
+		} else if branchFacts != factSignature {
+			heterogeneousFacts = true
 		}
-		if branchFacts != factSignature {
-			return BundlePlan{}, fmt.Errorf("bundle branch %q has facts %q; bundle facts are %q", item.ID, branchFacts, factSignature)
-		}
+		containsMultiFact = containsMultiFact || resolved.MultiFact
 		if i > 0 && (!reflect.DeepEqual(item.Request.Filters, requests[0].Request.Filters) || !reflect.DeepEqual(item.Request.ColumnMasks, requests[0].Request.ColumnMasks)) {
 			return BundlePlan{}, fmt.Errorf("bundle branch %q has a different governed scope", item.ID)
 		}
 		resolutions[i] = resolved
 	}
-	if resolutions[0].MultiFact {
+	if containsMultiFact || heterogeneousFacts {
 		return p.planMultiFactBundle(requests, resolutions)
 	}
 

--- a/internal/analytics/query/bundle_test.go
+++ b/internal/analytics/query/bundle_test.go
@@ -48,7 +48,7 @@ func TestPlanBundleRejectsDifferentGovernedScopes(t *testing.T) {
 	}
 }
 
-func TestPlanBundleRejectsMultiFactBranch(t *testing.T) {
+func TestPlanBundleScansEachFactOnceForMultiFactBranches(t *testing.T) {
 	bundle, err := NewPlanner(executableMultiFactModel()).PlanBundle([]BundleRequest{
 		{ID: "by_customer", Request: Request{Dimensions: []Field{{Field: "customer", Alias: "label"}}, Measures: []Field{{Field: "tags_per_order", Alias: "value"}}}},
 		{ID: "by_segment", Request: Request{Dimensions: []Field{{Field: "segment", Alias: "label"}}, Measures: []Field{{Field: "tags_per_order", Alias: "value"}}}},
@@ -63,6 +63,86 @@ func TestPlanBundleRejectsMultiFactBranch(t *testing.T) {
 		if !strings.Contains(bundle.Plan.SQL, want) {
 			t.Fatalf("multi-fact bundle missing %q:\n%s", want, bundle.Plan.SQL)
 		}
+	}
+}
+
+func TestPlanBundleSharesFactScansAcrossSingleAndMultiFactBranches(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	for _, statement := range []string{
+		"CREATE SCHEMA model",
+		"CREATE TABLE model.orders(customer_id VARCHAR, segment VARCHAR, amount DOUBLE)",
+		"INSERT INTO model.orders VALUES ('a', 'consumer', 10), ('a', 'consumer', 20), ('b', 'business', 30)",
+		"CREATE TABLE model.tags(customer_id VARCHAR, segment VARCHAR, tag VARCHAR)",
+		"INSERT INTO model.tags VALUES ('a', 'consumer', 'new'), ('c', 'consumer', 'vip'), ('c', 'consumer', 'repeat')",
+		"CREATE TABLE model.clicks(customer_id VARCHAR, segment VARCHAR)",
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bundle, err := NewPlanner(executableMultiFactModel()).PlanBundle([]BundleRequest{
+		{
+			ID: "orders_by_local_segment",
+			Request: Request{
+				Table:      "orders",
+				Dimensions: []Field{{Field: "orders.segment", Alias: "label"}},
+				Measures:   []Field{{Field: "revenue", Alias: "value"}},
+				Sort:       []Sort{{Field: "label", Direction: "asc"}},
+			},
+		},
+		{
+			ID: "orders_by_customer",
+			Request: Request{
+				Table:      "orders",
+				Dimensions: []Field{{Field: "customer", Alias: "label"}},
+				Measures:   []Field{{Field: "revenue", Alias: "value"}},
+				Sort:       []Sort{{Field: "label", Direction: "asc"}},
+			},
+		},
+		{
+			ID: "ratio_by_customer",
+			Request: Request{
+				Dimensions: []Field{{Field: "customer", Alias: "label"}},
+				Measures:   []Field{{Field: "tags_per_order", Alias: "value"}},
+				Sort:       []Sort{{Field: "label", Direction: "asc"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(bundle.Plan.SQL, "FROM model.orders"); got != 1 {
+		t.Fatalf("orders scans = %d, want 1:\n%s", got, bundle.Plan.SQL)
+	}
+	if got := strings.Count(bundle.Plan.SQL, "FROM model.tags"); got != 1 {
+		t.Fatalf("tags scans = %d, want 1:\n%s", got, bundle.Plan.SQL)
+	}
+	if !strings.Contains(bundle.Plan.SQL, "AS MATERIALIZED") || strings.Contains(bundle.Plan.SQL, "CROSS JOIN UNNEST") {
+		t.Fatalf("heterogeneous bundle did not reuse a statement-local governed projection:\n%s", bundle.Plan.SQL)
+	}
+	rows, err := queryBundlePlan(db, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := bundle.Decode(rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	segments := decoded["orders_by_local_segment"]
+	if len(segments) != 2 || segments[0]["label"] != "business" || segments[0]["value"] != float64(30) || segments[1]["label"] != "consumer" || segments[1]["value"] != float64(30) {
+		t.Fatalf("single-fact local branch = %#v", segments)
+	}
+	orderCustomers := decoded["orders_by_customer"]
+	if len(orderCustomers) != 2 || orderCustomers[0]["label"] != "a" || orderCustomers[0]["value"] != float64(30) || orderCustomers[1]["label"] != "b" || orderCustomers[1]["value"] != float64(30) {
+		t.Fatalf("single-fact conformed branch leaked multi-fact-only groups: %#v", orderCustomers)
+	}
+	customers := decoded["ratio_by_customer"]
+	if len(customers) != 3 || customers[0]["label"] != "a" || customers[0]["value"] != 0.5 || customers[1]["label"] != "b" || customers[1]["value"] != 0.0 || customers[2]["label"] != "c" || customers[2]["value"] != nil {
+		t.Fatalf("multi-fact branch = %#v", customers)
 	}
 }
 

--- a/internal/analytics/query/multi_fact_bundle.go
+++ b/internal/analytics/query/multi_fact_bundle.go
@@ -8,15 +8,17 @@ import (
 	semanticmodel "github.com/Yacobolo/libredash/internal/analytics/model"
 )
 
-// planMultiFactBundle builds one expanded grouping aggregate per participating
-// fact, then applies the ordinary null-safe full-outer stitch before decoding
-// consumer branches. Each governed fact relation is scanned exactly once.
+// planMultiFactBundle builds one statement-local governed projection and
+// independently pruned grouping aggregates per participating fact, then
+// applies the ordinary null-safe full-outer stitch before decoding consumer
+// branches. Each governed fact relation is scanned exactly once.
 func (p *Planner) planMultiFactBundle(requests []BundleRequest, resolutions []aggregateResolution) (BundlePlan, error) {
 	dimensions, branchDimensions, err := multiFactBundleDimensions(resolutions)
 	if err != nil {
 		return BundlePlan{}, err
 	}
-	groupSets, branchGroups := bundleGroups(branchDimensions)
+	facts := bundleFacts(resolutions)
+	groupSets, branchGroups := bundleGroupsByFacts(branchDimensions, resolutions)
 	measures := map[string]ResolvedMeasure{}
 	metrics := map[string]semanticmodel.Expression{}
 	for _, resolved := range resolutions {
@@ -36,8 +38,9 @@ func (p *Planner) planMultiFactBundle(requests []BundleRequest, resolutions []ag
 	ctes := []string{}
 	args := []any{}
 	dependencies := map[string]struct{}{}
-	for factIndex, fact := range resolutions[0].Facts {
-		factCTEs, factArgs, factDependencies, compileErr := p.compileMultiFactBundleFact(requests, resolutions, dimensions, groupSets, branchGroups, measures, measureNames, measureColumns, fact, factIndex)
+	filterResolution := aggregateResolution{Facts: append([]string{}, facts...), MultiFact: len(facts) > 1}
+	for factIndex, fact := range facts {
+		factCTEs, factArgs, factDependencies, compileErr := p.compileMultiFactBundleFact(requests, resolutions, filterResolution, dimensions, groupSets, branchGroups, branchDimensions, measures, measureNames, measureColumns, fact, factIndex)
 		if compileErr != nil {
 			return BundlePlan{}, compileErr
 		}
@@ -47,7 +50,7 @@ func (p *Planner) planMultiFactBundle(requests []BundleRequest, resolutions []ag
 			dependencies[dependency] = struct{}{}
 		}
 	}
-	stitched, stitchCTEs := stitchBundleFacts(resolutions[0].Facts, dimensions, measures, measureNames, measureColumns)
+	stitched, stitchCTEs := stitchBundleFacts(facts, dimensions, measures, measureNames, measureColumns)
 	ctes = append(ctes, stitchCTEs...)
 
 	memberNames, memberColumns := bundleMemberColumns(resolutions)
@@ -71,7 +74,7 @@ func (p *Planner) planMultiFactBundle(requests []BundleRequest, resolutions []ag
 	}
 	sort.Strings(deps)
 	sql := "WITH " + strings.Join(ctes, ",\n") + "\n" + bundleUnionSQL(branchSQL) + "\nORDER BY " + BundleBranchColumn + " ASC, " + BundleRowColumn + " ASC"
-	return BundlePlan{Plan: Plan{SQL: sql, Args: args, Columns: physicalColumns, Mode: "multi_fact", Facts: append([]string{}, resolutions[0].Facts...), PhysicalDependencies: deps}, Branches: branches}, nil
+	return BundlePlan{Plan: Plan{SQL: sql, Args: args, Columns: physicalColumns, Mode: "multi_fact", Facts: append([]string{}, facts...), PhysicalDependencies: deps}, Branches: branches}, nil
 }
 
 func multiFactBundleDimensions(resolutions []aggregateResolution) ([]bundleDimension, [][]int, error) {
@@ -80,9 +83,6 @@ func multiFactBundleDimensions(resolutions []aggregateResolution) ([]bundleDimen
 	branches := make([][]int, len(resolutions))
 	for branchIndex, resolved := range resolutions {
 		for _, dimension := range resolved.Dimensions {
-			if !dimension.Semantic {
-				return nil, nil, fmt.Errorf("multi-fact bundle dimension %q is not conformed", dimension.Name)
-			}
 			key := bundleDimensionKey(dimension)
 			index, ok := indexes[key]
 			if !ok {
@@ -96,7 +96,22 @@ func multiFactBundleDimensions(resolutions []aggregateResolution) ([]bundleDimen
 	return dimensions, branches, nil
 }
 
-func bundleGroups(branchDimensions [][]int) ([][]int, []int) {
+func bundleFacts(resolutions []aggregateResolution) []string {
+	set := map[string]bool{}
+	for _, resolved := range resolutions {
+		for _, fact := range resolved.Facts {
+			set[fact] = true
+		}
+	}
+	facts := make([]string, 0, len(set))
+	for fact := range set {
+		facts = append(facts, fact)
+	}
+	sort.Strings(facts)
+	return facts
+}
+
+func bundleGroupsByFacts(branchDimensions [][]int, resolutions []aggregateResolution) ([][]int, []int) {
 	groups := [][]int{}
 	byKey := map[string]int{}
 	branchGroups := make([]int, len(branchDimensions))
@@ -105,7 +120,7 @@ func bundleGroups(branchDimensions [][]int) ([][]int, []int) {
 		for i, index := range indexes {
 			parts[i] = fmt.Sprint(index)
 		}
-		key := strings.Join(parts, ",")
+		key := strings.Join(resolutions[branchIndex].Facts, ",") + "|" + strings.Join(parts, ",")
 		group, ok := byKey[key]
 		if !ok {
 			group = len(groups)
@@ -117,10 +132,28 @@ func bundleGroups(branchDimensions [][]int) ([][]int, []int) {
 	return groups, branchGroups
 }
 
-func (p *Planner) compileMultiFactBundleFact(requests []BundleRequest, resolutions []aggregateResolution, dimensions []bundleDimension, groupSets [][]int, branchGroups []int, measures map[string]ResolvedMeasure, measureNames []string, measureColumns map[string]string, fact string, factIndex int) ([]string, []any, []string, error) {
+func (p *Planner) compileMultiFactBundleFact(requests []BundleRequest, resolutions []aggregateResolution, filterResolution aggregateResolution, dimensions []bundleDimension, groupSets [][]int, branchGroups []int, branchDimensions [][]int, measures map[string]ResolvedMeasure, measureNames []string, measureColumns map[string]string, fact string, factIndex int) ([]string, []any, []string, error) {
 	bindings := []physicalFieldBinding{}
 	dependencies := map[string]struct{}{fact: {}}
-	for _, item := range dimensions {
+	factGroupSet := map[int]bool{}
+	dimensionGroups := make([]map[int]bool, len(dimensions))
+	for branchIndex, resolved := range resolutions {
+		if !bundleFactParticipates(resolved, fact) {
+			continue
+		}
+		group := branchGroups[branchIndex]
+		factGroupSet[group] = true
+		for _, dimensionIndex := range branchDimensions[branchIndex] {
+			if dimensionGroups[dimensionIndex] == nil {
+				dimensionGroups[dimensionIndex] = map[int]bool{}
+			}
+			dimensionGroups[dimensionIndex][group] = true
+		}
+	}
+	for dimensionIndex, item := range dimensions {
+		if len(dimensionGroups[dimensionIndex]) == 0 {
+			continue
+		}
 		field, path, err := p.aggregateDimensionBinding(fact, item.dimension)
 		if err != nil {
 			return nil, nil, nil, err
@@ -147,7 +180,7 @@ func (p *Planner) compileMultiFactBundleFact(requests []BundleRequest, resolutio
 			addPathDependencies(dependencies, path)
 		}
 	}
-	filterBindings, err := p.factFilterFields(requests[0].Request.Filters, resolutions[0], fact)
+	filterBindings, err := p.factFilterFields(requests[0].Request.Filters, filterResolution, fact)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -167,6 +200,9 @@ func (p *Planner) compileMultiFactBundleFact(requests []BundleRequest, resolutio
 	baseSelects := []string{}
 	baseArgs := []any{}
 	for dimensionIndex, item := range dimensions {
+		if len(dimensionGroups[dimensionIndex]) == 0 {
+			continue
+		}
 		field, path, err := p.aggregateDimensionBinding(fact, item.dimension)
 		if err != nil {
 			return nil, nil, nil, err
@@ -234,80 +270,116 @@ func (p *Planner) compileMultiFactBundleFact(requests []BundleRequest, resolutio
 	if len(baseSelects) == 0 {
 		baseSelects = append(baseSelects, "1 AS __row")
 	}
-	where, whereArgs, err := p.factWhereParts(requests[0].Request.Filters, resolutions[0], fact, aliases)
+	where, whereArgs, err := p.factWhereParts(requests[0].Request.Filters, filterResolution, fact, aliases)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	baseArgs = append(baseArgs, whereArgs...)
 	baseName := fmt.Sprintf("bundle_base_%d", factIndex)
-	expandedName := fmt.Sprintf("bundle_expanded_%d", factIndex)
 	aggregateName := fmt.Sprintf("bundle_fact_%d", factIndex)
-	base := baseName + " AS (\n  SELECT " + strings.Join(baseSelects, ", ") + "\n  FROM " + strings.ReplaceAll(from, "\n", "\n  ")
+	base := baseName + " AS MATERIALIZED (\n  SELECT " + strings.Join(baseSelects, ", ") + "\n  FROM " + strings.ReplaceAll(from, "\n", "\n  ")
 	if len(where) > 0 {
 		base += "\n  WHERE " + strings.Join(where, " AND ")
 	}
 	base += "\n)"
-	groupIDs := make([]string, len(groupSets))
-	for i := range groupSets {
-		groupIDs[i] = fmt.Sprint(i)
-	}
-	expanded := expandedName + " AS (\n  SELECT " + baseName + ".*, __bundle_group\n  FROM " + baseName + "\n  CROSS JOIN UNNEST([" + strings.Join(groupIDs, ", ") + "]) AS groups(__bundle_group)\n)"
-	selects := []string{"__bundle_group"}
-	for dimensionIndex := range dimensions {
-		groups := []int{}
-		for groupIndex, indexes := range groupSets {
-			if containsInt(indexes, dimensionIndex) {
-				groups = append(groups, groupIndex)
-			}
-		}
-		selects = append(selects, fmt.Sprintf("CASE WHEN %s THEN __d%d END AS __d%d", integerPredicate("__bundle_group", groups), dimensionIndex, dimensionIndex))
-	}
-	for measureIndex, name := range measureNames {
-		measure := measures[name]
-		if measure.Fact != fact {
+	groupCTEs := make([]string, 0, len(factGroupSet))
+	groupNames := make([]string, 0, len(factGroupSet))
+	for groupIndex := range groupSets {
+		if !factGroupSet[groupIndex] {
 			continue
 		}
-		input := fmt.Sprintf("__v%d", measureIndex)
-		expr := ""
-		switch measure.Aggregation {
-		case "count":
-			expr = "COUNT(*)"
-		case "count_distinct":
-			expr = "COUNT(DISTINCT " + input + ")"
-		case "sum", "avg", "min", "max":
-			expr = strings.ToUpper(measure.Aggregation) + "(" + input + ")"
-		default:
-			return nil, nil, nil, fmt.Errorf("measure %q has unsupported aggregation %q", name, measure.Aggregation)
-		}
-		groups := []int{}
-		seen := map[int]bool{}
-		for branchIndex, resolved := range resolutions {
-			if _, selected := resolved.Measures[name]; selected && !seen[branchGroups[branchIndex]] {
-				seen[branchGroups[branchIndex]] = true
-				groups = append(groups, branchGroups[branchIndex])
+		selects := []string{fmt.Sprintf("%d AS __bundle_group", groupIndex)}
+		groupBy := []string{}
+		for dimensionIndex := range dimensions {
+			if containsInt(groupSets[groupIndex], dimensionIndex) {
+				selects = append(selects, fmt.Sprintf("__d%d", dimensionIndex))
+				groupBy = append(groupBy, fmt.Sprintf("__d%d", dimensionIndex))
+			} else {
+				selects = append(selects, fmt.Sprintf("NULL AS __d%d", dimensionIndex))
 			}
 		}
-		filterParts := []string{integerPredicate("__bundle_group", groups)}
-		if len(measure.Filters) > 0 {
-			filterParts = append(filterParts, fmt.Sprintf("__f%d", measureIndex))
+		for measureIndex, name := range measureNames {
+			measure := measures[name]
+			if measure.Fact != fact {
+				continue
+			}
+			selected := false
+			for branchIndex, resolved := range resolutions {
+				if branchGroups[branchIndex] != groupIndex {
+					continue
+				}
+				if _, selected = resolved.Measures[name]; selected {
+					break
+				}
+			}
+			if !selected {
+				selects = append(selects, "NULL AS "+measureColumns[name])
+				continue
+			}
+			expr, aggregateErr := bundleFactMeasureAggregate(measure, measureIndex)
+			if aggregateErr != nil {
+				return nil, nil, nil, fmt.Errorf("measure %q: %w", name, aggregateErr)
+			}
+			selects = append(selects, expr+" AS "+measureColumns[name])
 		}
-		expr += " FILTER (WHERE " + strings.Join(filterParts, " AND ") + ")"
-		if measure.Empty == "zero" && measure.Aggregation != "count" && measure.Aggregation != "count_distinct" {
-			expr = "COALESCE(" + expr + ", 0)"
+		groupName := fmt.Sprintf("bundle_group_%d_%d", factIndex, groupIndex)
+		groupNames = append(groupNames, groupName)
+		groupSQL := groupName + " AS (\n  SELECT " + strings.Join(selects, ", ") + "\n  FROM " + baseName
+		if len(groupBy) > 0 {
+			groupSQL += "\n  GROUP BY " + strings.Join(groupBy, ", ")
 		}
-		selects = append(selects, expr+" AS "+measureColumns[name])
+		groupCTEs = append(groupCTEs, groupSQL+"\n)")
 	}
-	positions := make([]string, len(dimensions)+1)
-	for i := range positions {
-		positions[i] = fmt.Sprint(i + 1)
+	groupSelects := make([]string, len(groupNames))
+	for i, groupName := range groupNames {
+		groupSelects[i] = "SELECT * FROM " + groupName
 	}
-	aggregate := aggregateName + " AS (\n  SELECT " + strings.Join(selects, ", ") + "\n  FROM " + expandedName + "\n  GROUP BY " + strings.Join(positions, ", ") + "\n)"
+	aggregate := aggregateName + " AS (\n  " + strings.Join(groupSelects, "\n  UNION ALL\n  ") + "\n)"
 	deps := make([]string, 0, len(dependencies))
 	for dependency := range dependencies {
 		deps = append(deps, dependency)
 	}
 	sort.Strings(deps)
-	return []string{base, expanded, aggregate}, baseArgs, deps, nil
+	ctes := append([]string{base}, groupCTEs...)
+	ctes = append(ctes, aggregate)
+	return ctes, baseArgs, deps, nil
+}
+
+func bundleFactMeasureAggregate(measure ResolvedMeasure, measureIndex int) (string, error) {
+	input := fmt.Sprintf("__v%d", measureIndex)
+	expr := ""
+	switch measure.Aggregation {
+	case "count":
+		expr = "COUNT(*)"
+	case "count_distinct":
+		expr = "COUNT(DISTINCT " + input + ")"
+	case "sum", "avg", "min", "max":
+		expr = strings.ToUpper(measure.Aggregation) + "(" + input + ")"
+	default:
+		return "", fmt.Errorf("unsupported aggregation %q", measure.Aggregation)
+	}
+	if len(measure.Filters) > 0 {
+		expr += fmt.Sprintf(" FILTER (WHERE __f%d)", measureIndex)
+	}
+	if measure.Empty == "zero" && measure.Aggregation != "count" && measure.Aggregation != "count_distinct" {
+		expr = "COALESCE(" + expr + ", 0)"
+	}
+	return expr, nil
+}
+
+func bundleFactParticipates(resolved aggregateResolution, fact string) bool {
+	if hasFactMeasures(resolved.Measures, fact) {
+		return true
+	}
+	if len(resolved.Measures) != 0 {
+		return false
+	}
+	for _, candidate := range resolved.Facts {
+		if candidate == fact {
+			return true
+		}
+	}
+	return false
 }
 
 func stitchBundleFacts(facts []string, dimensions []bundleDimension, measures map[string]ResolvedMeasure, measureNames []string, measureColumns map[string]string) (string, []string) {

--- a/internal/app/dashboard_observability_test.go
+++ b/internal/app/dashboard_observability_test.go
@@ -147,7 +147,10 @@ func TestDashboardTelemetryUsesBoundedLabelsAndRecordsRefreshLifecycle(t *testin
 	if got := dashboardCacheLabel("coalesced"); got != "coalesced" {
 		t.Fatalf("coalesced cache label = %q, want coalesced", got)
 	}
-	if got := dashboardStageLabel("targetExecution"); got != "target_execution" {
-		t.Fatalf("target execution stage label = %q, want target_execution", got)
+	if got := dashboardStageLabel("targetWorkSum"); got != "target_work_sum" {
+		t.Fatalf("target work sum stage label = %q, want target_work_sum", got)
+	}
+	if got := dashboardStageLabel("targetCriticalPath"); got != "target_critical_path" {
+		t.Fatalf("target critical path stage label = %q, want target_critical_path", got)
 	}
 }

--- a/internal/app/observability.go
+++ b/internal/app/observability.go
@@ -182,7 +182,7 @@ func dashboardOutcomeLabel(value string) string {
 func dashboardStageLabel(value string) string {
 	value = normalizedMetricLabel(value)
 	switch value {
-	case "end_to_end", "target_execution", "admission_wait", "connection_wait", "planning", "database", "execution":
+	case "end_to_end", "target_work_sum", "target_critical_path", "admission_wait", "connection_wait", "planning", "database", "execution":
 		return value
 	default:
 		return "other"
@@ -230,8 +230,10 @@ func normalizedMetricLabel(value string) string {
 		return "admission_wait"
 	case "connectionwait":
 		return "connection_wait"
-	case "targetexecution":
-		return "target_execution"
+	case "targetworksum":
+		return "target_work_sum"
+	case "targetcriticalpath":
+		return "target_critical_path"
 	default:
 		return value
 	}

--- a/internal/dashboard/consumer/consumer.go
+++ b/internal/dashboard/consumer/consumer.go
@@ -36,8 +36,10 @@ type Request struct {
 }
 
 type Progress struct {
-	Completed int
-	Total     int
+	Completed            int
+	Total                int
+	WorkDuration         time.Duration
+	CriticalPathDuration time.Duration
 }
 
 type ProgressPublisher func(Progress)

--- a/internal/dashboard/consumer/optimizer.go
+++ b/internal/dashboard/consumer/optimizer.go
@@ -52,8 +52,6 @@ type analyzedQuery struct {
 	facts     string
 	scalar    bool
 	grouped   bool
-	additive  map[string]bool
-	atomic    map[string]bool
 	aggregate bool
 }
 
@@ -69,6 +67,18 @@ func Optimize(model *semanticmodel.Model, queries []LogicalQuery) (Plan, error) 
 }
 
 func (o *Optimizer) Optimize(queries []LogicalQuery) (Plan, error) {
+	return o.optimize(queries, true)
+}
+
+// OptimizeForConcurrency chooses between one heterogeneous shared projection
+// and independent fact-signature bundles. A serial executor benefits from one
+// governed fact scan; concurrent readers can execute the smaller bundles in
+// parallel without paying projection materialization on the critical path.
+func (o *Optimizer) OptimizeForConcurrency(queries []LogicalQuery, concurrency int) (Plan, error) {
+	return o.optimize(queries, concurrency <= 1)
+}
+
+func (o *Optimizer) optimize(queries []LogicalQuery, fuseHeterogeneousFacts bool) (Plan, error) {
 	planner := o.planner
 	if planner == nil || planner.Model == nil {
 		return Plan{}, fmt.Errorf("compiled semantic planner is required")
@@ -86,19 +96,6 @@ func (o *Optimizer) Optimize(queries []LogicalQuery) (Plan, error) {
 			item.scalar = len(logical.Query.Fields) == 0 && logical.Query.Time.Field == ""
 			item.grouped = !item.scalar
 			item.facts = strings.Join(analysis.Facts, ",")
-			item.atomic = stringSet(analysis.AtomicMeasures)
-			item.additive = map[string]bool{}
-			for _, member := range logical.Query.Measures {
-				dependencies, additive, err := planner.AdditiveMeasureDependencies(member.Field)
-				if err != nil {
-					return Plan{}, fmt.Errorf("consumer %s:%s: %w", logical.Target.Kind, logical.Target.ID, err)
-				}
-				if additive {
-					for _, dependency := range dependencies {
-						item.additive[dependency] = true
-					}
-				}
-			}
 		}
 		scope, err := physicalScopeKey(logical.Query)
 		if err != nil {
@@ -123,9 +120,10 @@ func (o *Optimizer) Optimize(queries []LogicalQuery) (Plan, error) {
 			if candidateIndex == sourceIndex || assigned[candidateIndex] || !candidate.aggregate || candidate.scope != source.scope {
 				continue
 			}
-			if candidate.grouped && candidate.facts == source.facts || candidate.scalar && setContains(source.atomic, candidate.additive) && len(candidate.additive) > 0 {
-				members = append(members, candidateIndex)
+			if !fuseHeterogeneousFacts && candidate.facts != source.facts {
+				continue
 			}
+			members = append(members, candidateIndex)
 		}
 		if len(members) < 2 {
 			continue
@@ -211,10 +209,9 @@ func (o *Optimizer) Optimize(queries []LogicalQuery) (Plan, error) {
 func physicalScopeKey(query dataquery.Query) (string, error) {
 	encoded, err := json.Marshal(struct {
 		ModelID     string                 `json:"modelId"`
-		Target      string                 `json:"target"`
 		Filters     []dataquery.Filter     `json:"filters"`
 		ColumnMasks []dataquery.ColumnMask `json:"columnMasks"`
-	}{ModelID: query.ModelID, Target: query.Target, Filters: query.Filters, ColumnMasks: query.ColumnMasks})
+	}{ModelID: query.ModelID, Filters: query.Filters, ColumnMasks: query.ColumnMasks})
 	if err != nil {
 		return "", fmt.Errorf("encode governed query scope: %w", err)
 	}
@@ -254,23 +251,6 @@ func semanticFilter(filter dataquery.Filter) semanticquery.Filter {
 		}
 	}
 	return semanticquery.Filter{Field: filter.Field, Fact: filter.Fact, Operator: filter.Operator, Values: append([]any{}, filter.Values...), Groups: groups}
-}
-
-func stringSet(values []string) map[string]bool {
-	result := make(map[string]bool, len(values))
-	for _, value := range values {
-		result[value] = true
-	}
-	return result
-}
-
-func setContains(haystack, needles map[string]bool) bool {
-	for needle := range needles {
-		if !haystack[needle] {
-			return false
-		}
-	}
-	return true
 }
 
 func consumerKindPriority(kind Kind) int {

--- a/internal/dashboard/consumer/optimizer_test.go
+++ b/internal/dashboard/consumer/optimizer_test.go
@@ -59,11 +59,84 @@ func TestOptimizerBatchesScalarConsumersAcrossFacts(t *testing.T) {
 	}
 }
 
+func TestOptimizerBundlesSameFactNonAdditiveScalarWithGroupedConsumers(t *testing.T) {
+	plan, err := Optimize(optimizerTestModel(), []LogicalQuery{
+		{
+			Target: Target{Kind: KindVisual, ID: "orders_by_customer"},
+			Query: dataquery.Query{
+				Kind:     dataquery.KindSemanticAggregate,
+				Fields:   []dataquery.Field{{Field: "customer", Alias: "label"}},
+				Measures: []dataquery.Field{{Field: "order_count", Alias: "value"}},
+			},
+		},
+		{
+			Target: Target{Kind: KindVisual, ID: "unique_customers"},
+			Query: dataquery.Query{
+				Kind:     dataquery.KindSemanticAggregate,
+				Measures: []dataquery.Field{{Field: "unique_customers", Alias: "value"}},
+			},
+		},
+		{
+			Target: Target{Kind: KindVisual, ID: "average_order_value"},
+			Query: dataquery.Query{
+				Kind:     dataquery.KindSemanticAggregate,
+				Measures: []dataquery.Field{{Field: "average_order_value", Alias: "value"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Jobs) != 1 || plan.Jobs[0].Strategy != StrategyBundle || len(plan.Jobs[0].Queries) != 3 {
+		t.Fatalf("same-fact non-additive plan = %#v, want one exact grouping-set bundle", plan)
+	}
+}
+
+func TestOptimizerBundlesGroupedConsumersAcrossFactSignatures(t *testing.T) {
+	queries := []LogicalQuery{
+		{
+			Target: Target{Kind: KindVisual, ID: "orders_by_customer"},
+			Query: dataquery.Query{
+				Kind:     dataquery.KindSemanticAggregate,
+				Target:   "orders",
+				Fields:   []dataquery.Field{{Field: "orders.customer", Alias: "label"}},
+				Measures: []dataquery.Field{{Field: "order_count", Alias: "value"}},
+			},
+		},
+		{
+			Target: Target{Kind: KindVisual, ID: "tags_per_order_by_customer"},
+			Query: dataquery.Query{
+				Kind:     dataquery.KindSemanticAggregate,
+				Fields:   []dataquery.Field{{Field: "customer", Alias: "label"}},
+				Measures: []dataquery.Field{{Field: "tags_per_order", Alias: "value"}},
+			},
+		},
+	}
+	optimizer, err := NewOptimizer(optimizerTestModel())
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := optimizer.OptimizeForConcurrency(queries, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Jobs) != 1 || plan.Jobs[0].Strategy != StrategyBundle || len(plan.Jobs[0].Queries) != 2 {
+		t.Fatalf("heterogeneous fact plan = %#v, want one shared-scan bundle", plan)
+	}
+	plan, err = optimizer.OptimizeForConcurrency(queries, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Jobs) != 2 {
+		t.Fatalf("concurrent heterogeneous fact plan = %#v, want independent fact-signature bundles", plan)
+	}
+}
+
 func optimizerTestModel() *semanticmodel.Model {
 	return &semanticmodel.Model{
 		Name: "commerce",
 		Tables: map[string]semanticmodel.Table{
-			"orders": {Dimensions: map[string]semanticmodel.MetricDimension{"customer": {Field: "orders.customer_id", Table: "orders", Name: "customer"}, "segment": {Field: "orders.segment", Table: "orders", Name: "segment"}}},
+			"orders": {Dimensions: map[string]semanticmodel.MetricDimension{"customer": {Field: "orders.customer_id", Table: "orders", Name: "customer"}, "segment": {Field: "orders.segment", Table: "orders", Name: "segment"}, "amount": {Field: "orders.amount", Table: "orders", Name: "amount"}}},
 			"tags":   {Dimensions: map[string]semanticmodel.MetricDimension{"customer": {Field: "tags.customer_id", Table: "tags", Name: "customer"}, "segment": {Field: "tags.segment", Table: "tags", Name: "segment"}}},
 		},
 		Dimensions: map[string]semanticmodel.SemanticDimension{
@@ -71,8 +144,10 @@ func optimizerTestModel() *semanticmodel.Model {
 			"segment":  {Type: "string", Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.segment"}, "tags": {Field: "tags.segment"}}},
 		},
 		Measures: map[string]semanticmodel.MetricMeasure{
-			"order_count": {Fact: "orders", Aggregation: "count", Empty: "zero"},
-			"tag_count":   {Fact: "tags", Aggregation: "count", Empty: "zero"},
+			"order_count":         {Fact: "orders", Aggregation: "count", Empty: "zero"},
+			"unique_customers":    {Fact: "orders", Aggregation: "count_distinct", Input: semanticmodel.MeasureInput{Field: "orders.customer_id"}, Empty: "zero"},
+			"average_order_value": {Fact: "orders", Aggregation: "avg", Input: semanticmodel.MeasureInput{Field: "orders.amount"}, Empty: "null"},
+			"tag_count":           {Fact: "tags", Aggregation: "count", Empty: "zero"},
 		},
 		Metrics: map[string]semanticmodel.Metric{
 			"tags_per_order": {Expression: "safe_divide(${tag_count}, ${order_count})"},

--- a/internal/dashboard/runtime/consumers.go
+++ b/internal/dashboard/runtime/consumers.go
@@ -72,13 +72,14 @@ func (s *QueryService) ExecuteConsumersPage(ctx context.Context, request consume
 		}
 		logical = append(logical, item)
 	}
-	plan, err := runtime.optimizer.Optimize(logical)
+	plan, err := runtime.optimizer.OptimizeForConcurrency(logical, request.Concurrency)
 	if err != nil {
 		return err
 	}
 	if request.Progress != nil {
 		request.Progress(consumer.Progress{Total: len(plan.Jobs)})
 	}
+	executionStarted := time.Now()
 	limit := request.Concurrency
 	if limit <= 0 {
 		limit = 1
@@ -87,7 +88,7 @@ func (s *QueryService) ExecuteConsumersPage(ctx context.Context, request consume
 	var group sync.WaitGroup
 	var progressMu sync.Mutex
 	completedJobs := 0
-	publishProgress := func() {
+	publishProgress := func(workDuration time.Duration) {
 		if request.Progress == nil || ctx.Err() != nil {
 			return
 		}
@@ -97,7 +98,11 @@ func (s *QueryService) ExecuteConsumersPage(ctx context.Context, request consume
 			return
 		}
 		completedJobs++
-		request.Progress(consumer.Progress{Completed: completedJobs, Total: len(plan.Jobs)})
+		progress := consumer.Progress{Completed: completedJobs, Total: len(plan.Jobs), WorkDuration: workDuration}
+		if completedJobs == len(plan.Jobs) {
+			progress.CriticalPathDuration = time.Since(executionStarted)
+		}
+		request.Progress(progress)
 	}
 jobLoop:
 	for _, job := range plan.Jobs {
@@ -114,8 +119,9 @@ jobLoop:
 		go func() {
 			defer group.Done()
 			defer func() { <-semaphore }()
+			startedAt := time.Now()
 			s.executeConsumerJob(ctx, request, job, publish)
-			publishProgress()
+			publishProgress(time.Since(startedAt))
 		}()
 	}
 	group.Wait()

--- a/internal/dashboard/runtime/runtime_dashboard_test.go
+++ b/internal/dashboard/runtime/runtime_dashboard_test.go
@@ -353,7 +353,7 @@ c2,RJ
 	if len(recorder.queries) != 1 || len(recorder.queries[0].Measures) != 3 {
 		t.Fatalf("targeted KPI queries = %#v, want one three-measure query", recorder.queries)
 	}
-	if len(progress) != 2 || progress[0] != (consumer.Progress{Total: 1}) || progress[1] != (consumer.Progress{Completed: 1, Total: 1}) {
+	if len(progress) != 2 || progress[0] != (consumer.Progress{Total: 1}) || progress[1].Completed != 1 || progress[1].Total != 1 || progress[1].WorkDuration <= 0 || progress[1].CriticalPathDuration <= 0 {
 		t.Fatalf("optimizer job progress = %#v", progress)
 	}
 }

--- a/internal/dashboard/stream/coordinator.go
+++ b/internal/dashboard/stream/coordinator.go
@@ -119,7 +119,7 @@ type activeRefresh struct {
 	setupRequiredErr error
 	refreshError     error
 	cacheOutcomes    map[string]int
-	targetDuration   time.Duration
+	targetWork       time.Duration
 	stageTimingsMs   map[string]float64
 	progressPercent  *float64
 }
@@ -318,7 +318,9 @@ func (c *Coordinator) emitCurrent(refresh Refresh, event RefreshEvent) bool {
 			c.active.progressPercent = dashboard.NormalizeProgressPercent(nil, false)
 			event.ProgressPercent = cloneProgressPercent(c.active.progressPercent)
 		}
-		c.active.targetDuration += event.Duration
+		if event.Type == RefreshEventProgress {
+			c.active.targetWork += event.Duration
+		}
 		if len(event.StageTimingsMs) > 0 {
 			if c.active.stageTimingsMs == nil {
 				c.active.stageTimingsMs = map[string]float64{}
@@ -397,7 +399,7 @@ func (c *Coordinator) summaryLocked(active *activeRefresh, outcome string, cance
 		stageTimings[stage] = duration
 	}
 	stageTimings["endToEnd"] = float64(time.Since(active.startedAt).Microseconds()) / 1000
-	stageTimings["targetExecution"] = float64(active.targetDuration.Microseconds()) / 1000
+	stageTimings["targetWorkSum"] = float64(active.targetWork.Microseconds()) / 1000
 	cacheOutcomes := make(map[string]int, len(active.cacheOutcomes))
 	for cacheOutcome, count := range active.cacheOutcomes {
 		cacheOutcomes[cacheOutcome] = count

--- a/internal/dashboard/stream/coordinator_test.go
+++ b/internal/dashboard/stream/coordinator_test.go
@@ -354,6 +354,31 @@ func TestCoordinatorSummaryIncludesTargetsCachesAndCancellationReason(t *testing
 	}
 }
 
+func TestCoordinatorSummarySeparatesTargetWorkSumFromCriticalPath(t *testing.T) {
+	summaries := make(chan RefreshSummary, 1)
+	coordinator := NewCoordinator(context.Background(), func(RefreshEvent) {})
+	coordinator.SetObserver(func(summary RefreshSummary) { summaries <- summary })
+	t.Cleanup(coordinator.Close)
+
+	if _, err := coordinator.Begin(nil, func(_ context.Context, publish RefreshPublisher) {
+		publish(RefreshEvent{Type: RefreshEventProgress, Duration: 30 * time.Millisecond})
+		publish(RefreshEvent{Type: RefreshEventVisual, Target: "a", Duration: 90 * time.Millisecond})
+		publish(RefreshEvent{Type: RefreshEventProgress, Duration: 20 * time.Millisecond, StageTimingsMs: map[string]float64{"targetCriticalPath": 35}})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary := <-summaries
+	if got := summary.StageTimingsMs["targetWorkSum"]; got != 50 {
+		t.Fatalf("target work sum = %v, want 50", got)
+	}
+	if got := summary.StageTimingsMs["targetCriticalPath"]; got != 35 {
+		t.Fatalf("target critical path = %v, want 35", got)
+	}
+	if _, legacy := summary.StageTimingsMs["targetExecution"]; legacy {
+		t.Fatalf("summary retained misleading targetExecution: %#v", summary.StageTimingsMs)
+	}
+}
+
 type setupRequiredTestError struct{}
 
 func (setupRequiredTestError) Error() string       { return "source data is missing" }

--- a/internal/dashboard/stream/executor.go
+++ b/internal/dashboard/stream/executor.go
@@ -93,9 +93,17 @@ func executeConsumers(ctx context.Context, executor consumer.Executor, request W
 		Targets:     append([]consumer.Target{}, request.Plan.Targets...),
 		Concurrency: refreshConcurrencyFromExecutor(executor),
 		Progress: func(progress consumer.Progress) {
+			stageTimings := map[string]float64(nil)
+			if progress.CriticalPathDuration > 0 {
+				stageTimings = map[string]float64{
+					"targetCriticalPath": float64(progress.CriticalPathDuration.Microseconds()) / 1000,
+				}
+			}
 			publish(RefreshEvent{
 				Type:            RefreshEventProgress,
 				ProgressPercent: consumerProgressPercent(progress),
+				Duration:        progress.WorkDuration,
+				StageTimingsMs:  stageTimings,
 			})
 		},
 	}

--- a/internal/dashboard/stream/executor_test.go
+++ b/internal/dashboard/stream/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Yacobolo/libredash/internal/dashboard"
 	"github.com/Yacobolo/libredash/internal/dashboard/command"
@@ -36,9 +37,9 @@ func TestTargetWorkPublishesProgressiveConsumerResultsWithoutPresentationKnowled
 		request.Progress(consumer.Progress{Total: 2})
 		publish(consumer.Result{Target: request.Targets[1], Table: dashboard.Table{Title: "Orders"}})
 		publish(consumer.Result{Target: request.Targets[1], Table: dashboard.Table{Title: "Orders", Cardinality: dashboard.ExactCardinality(42)}, TableMetadata: true})
-		request.Progress(consumer.Progress{Completed: 1, Total: 2})
+		request.Progress(consumer.Progress{Completed: 1, Total: 2, WorkDuration: 20 * time.Millisecond})
 		publish(consumer.Result{Target: request.Targets[0], Visual: dashboard.Visual{ID: "revenue"}})
-		request.Progress(consumer.Progress{Completed: 2, Total: 2})
+		request.Progress(consumer.Progress{Completed: 2, Total: 2, WorkDuration: 30 * time.Millisecond, CriticalPathDuration: 40 * time.Millisecond})
 		return nil
 	}}
 	events := runTargetWork(t, executor, command.RefreshPlan{Targets: []command.Target{
@@ -52,6 +53,9 @@ func TestTargetWorkPublishesProgressiveConsumerResultsWithoutPresentationKnowled
 		events[4].Type != RefreshEventVisual ||
 		events[5].Type != RefreshEventProgress || events[5].ProgressPercent == nil || *events[5].ProgressPercent != 100 {
 		t.Fatalf("progressive events = %#v", events)
+	}
+	if events[3].Duration != 20*time.Millisecond || events[5].Duration != 30*time.Millisecond || events[5].StageTimingsMs["targetCriticalPath"] != 40 {
+		t.Fatalf("progress timing events = %#v", events)
 	}
 	if executor.leases.Load() != 1 {
 		t.Fatalf("refresh leases = %d", executor.leases.Load())

--- a/internal/runtimehost/manager.go
+++ b/internal/runtimehost/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -100,6 +101,7 @@ type Prepared struct {
 	managedRevision string
 	runtime         Runtime
 	managedData     ManagedDataLifetime
+	snapshotLease   *persistentSnapshotLease
 	noChange        bool
 	snapshotID      int64
 }
@@ -115,7 +117,9 @@ func (p *Prepared) Close() error {
 	}
 	managedDataErr := releaseManagedDataLifetime(p.managedData)
 	p.managedData = nil
-	return errors.Join(runtimeErr, managedDataErr)
+	snapshotLeaseErr := p.snapshotLease.Close()
+	p.snapshotLease = nil
+	return errors.Join(runtimeErr, managedDataErr, snapshotLeaseErr)
 }
 
 func (p *Prepared) DuckLakeSnapshotID() int64 {
@@ -256,7 +260,14 @@ func (m *Manager) prepareResolved(ctx context.Context, current servingstate.Stat
 	if snapshotID == 0 {
 		snapshotID = current.DuckLakeSnapshotID
 	}
-	return &Prepared{servingStateID: current.ID, digest: artifact.Digest, managedRevision: managedData.RevisionID, runtime: runtime, managedData: managedData.Lifetime, snapshotID: snapshotID}, nil
+	snapshotLease, err := m.createPersistentLease(ctx, current.ID, snapshotID)
+	if err != nil {
+		return nil, errors.Join(err, runtime.Close(), releaseManagedDataLifetime(managedData.Lifetime))
+	}
+	return &Prepared{
+		servingStateID: current.ID, digest: artifact.Digest, managedRevision: managedData.RevisionID,
+		runtime: runtime, managedData: managedData.Lifetime, snapshotLease: snapshotLease, snapshotID: snapshotID,
+	}, nil
 }
 
 func (m *Manager) CommitPrepared(candidate servingstate.PreparedRuntime) error {
@@ -278,6 +289,7 @@ func (m *Manager) CommitPrepared(candidate servingstate.PreparedRuntime) error {
 		digest:         prepared.digest,
 		runtime:        prepared.runtime,
 		managedData:    prepared.managedData,
+		snapshotLease:  prepared.snapshotLease,
 		snapshotID:     prepared.snapshotID,
 	}
 	m.activeServingStateID = prepared.servingStateID
@@ -286,6 +298,7 @@ func (m *Manager) CommitPrepared(candidate servingstate.PreparedRuntime) error {
 	m.activeSnapshotID = prepared.snapshotID
 	prepared.runtime = nil
 	prepared.managedData = nil
+	prepared.snapshotLease = nil
 	oldToClose := m.retireLocked(old)
 	m.mu.Unlock()
 	return m.closeManaged(oldToClose)
@@ -323,23 +336,19 @@ func (m *Manager) Acquire() (Lease, error) {
 	if m.current == nil || m.current.closing {
 		return nil, fmt.Errorf("no active LibreDash serving state")
 	}
-	leaseID, heartbeatCancel, err := m.createPersistentLeaseLocked()
-	if err != nil {
-		return nil, err
-	}
 	m.current.refs++
-	return &runtimeLease{manager: m, managed: m.current, leaseID: leaseID, heartbeatCancel: heartbeatCancel}, nil
+	return &runtimeLease{manager: m, managed: m.current}, nil
 }
 
 func (m *Manager) LeasedSnapshots() []int64 {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	snapshots := map[int64]struct{}{}
-	if m.current != nil && m.current.refs > 0 && m.current.snapshotID > 0 {
+	if m.current != nil && m.current.snapshotLease != nil && m.current.snapshotID > 0 {
 		snapshots[m.current.snapshotID] = struct{}{}
 	}
 	for _, runtime := range m.retired {
-		if runtime.refs > 0 && runtime.snapshotID > 0 {
+		if runtime.snapshotLease != nil && runtime.snapshotID > 0 {
 			snapshots[runtime.snapshotID] = struct{}{}
 		}
 	}
@@ -358,15 +367,7 @@ func (m *Manager) retireLocked(runtime *managedRuntime) *managedRuntime {
 	return runtime
 }
 
-func (m *Manager) release(runtime *managedRuntime, leaseID string, heartbeatCancel context.CancelFunc) {
-	if heartbeatCancel != nil {
-		heartbeatCancel()
-	}
-	if leaseID != "" {
-		if repo, ok := m.repo.(SnapshotLeaseRepository); ok {
-			releaseSnapshotLease(repo, leaseID)
-		}
-	}
+func (m *Manager) release(runtime *managedRuntime) {
 	var drained *managedRuntime
 	m.mu.Lock()
 	if runtime != nil && runtime.refs > 0 {
@@ -380,22 +381,24 @@ func (m *Manager) release(runtime *managedRuntime, leaseID string, heartbeatCanc
 	_ = m.closeManaged(drained)
 }
 
-func releaseSnapshotLease(repo SnapshotLeaseRepository, leaseID string) {
+func releaseSnapshotLease(repo SnapshotLeaseRepository, leaseID string) error {
 	if repo == nil || leaseID == "" {
-		return
+		return nil
 	}
 	delay := 25 * time.Millisecond
+	var lastErr error
 	for attempt := 0; attempt < 5; attempt++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		err := repo.ReleaseQuerySnapshotLease(ctx, leaseID)
 		cancel()
 		if err == nil {
-			return
+			return nil
 		}
+		lastErr = err
 		time.Sleep(delay)
 		delay *= 2
 	}
-	_ = repo.ReleaseQuerySnapshotLease(context.Background(), leaseID)
+	return lastErr
 }
 
 func (m *Manager) removeRetiredLocked(runtime *managedRuntime) {
@@ -418,10 +421,12 @@ func (m *Manager) closeManaged(runtime *managedRuntime) error {
 	}
 	managedDataErr := releaseManagedDataLifetime(runtime.managedData)
 	runtime.managedData = nil
+	snapshotLeaseErr := runtime.snapshotLease.Close()
+	runtime.snapshotLease = nil
 	if runtime.closing && m.onDrained != nil {
 		m.onDrained(runtime.servingStateID, runtime.snapshotID)
 	}
-	return errors.Join(runtimeErr, managedDataErr)
+	return errors.Join(runtimeErr, managedDataErr, snapshotLeaseErr)
 }
 
 type managedRuntime struct {
@@ -429,6 +434,7 @@ type managedRuntime struct {
 	digest         string
 	runtime        Runtime
 	managedData    ManagedDataLifetime
+	snapshotLease  *persistentSnapshotLease
 	snapshotID     int64
 	refs           int
 	closing        bool
@@ -442,11 +448,9 @@ func releaseManagedDataLifetime(lifetime ManagedDataLifetime) error {
 }
 
 type runtimeLease struct {
-	manager         *Manager
-	managed         *managedRuntime
-	leaseID         string
-	heartbeatCancel context.CancelFunc
-	once            sync.Once
+	manager *Manager
+	managed *managedRuntime
+	once    sync.Once
 }
 
 func (l *runtimeLease) Runtime() Runtime {
@@ -475,30 +479,51 @@ func (l *runtimeLease) Release() {
 		return
 	}
 	l.once.Do(func() {
-		l.manager.release(l.managed, l.leaseID, l.heartbeatCancel)
+		l.manager.release(l.managed)
 	})
 }
 
-func (m *Manager) createPersistentLeaseLocked() (string, context.CancelFunc, error) {
+type persistentSnapshotLease struct {
+	repo   SnapshotLeaseRepository
+	id     string
+	cancel context.CancelFunc
+	once   sync.Once
+	err    error
+}
+
+func (l *persistentSnapshotLease) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.once.Do(func() {
+		if l.cancel != nil {
+			l.cancel()
+		}
+		l.err = releaseSnapshotLease(l.repo, l.id)
+	})
+	return l.err
+}
+
+func (m *Manager) createPersistentLease(ctx context.Context, servingStateID servingstate.ID, snapshotID int64) (*persistentSnapshotLease, error) {
 	repo, ok := m.repo.(SnapshotLeaseRepository)
-	if !ok || m.current == nil || m.current.snapshotID <= 0 {
-		return "", nil, nil
+	if !ok || snapshotID <= 0 {
+		return nil, nil
 	}
 	expiresAt := time.Now().Add(m.leaseTTL)
-	leaseID, err := repo.CreateQuerySnapshotLease(context.Background(), servingstate.SnapshotLeaseInput{
+	leaseID, err := repo.CreateQuerySnapshotLease(ctx, servingstate.SnapshotLeaseInput{
 		WorkspaceID:        m.workspaceID,
 		Environment:        m.environment,
-		ServingStateID:     m.current.servingStateID,
-		DuckLakeSnapshotID: m.current.snapshotID,
+		ServingStateID:     servingStateID,
+		DuckLakeSnapshotID: snapshotID,
 		OwnerID:            m.leaseOwner,
 		ExpiresAt:          expiresAt,
 	})
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 	heartbeatCtx, cancel := context.WithCancel(context.Background())
 	go m.heartbeatLease(heartbeatCtx, repo, leaseID)
-	return leaseID, cancel, nil
+	return &persistentSnapshotLease{repo: repo, id: leaseID, cancel: cancel}, nil
 }
 
 func (m *Manager) heartbeatLease(ctx context.Context, repo SnapshotLeaseRepository, leaseID string) {
@@ -542,5 +567,6 @@ func snapshotKeys(values map[int64]struct{}) []int64 {
 	for value := range values {
 		keys = append(keys, value)
 	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 	return keys
 }

--- a/internal/runtimehost/manager_test.go
+++ b/internal/runtimehost/manager_test.go
@@ -216,8 +216,8 @@ func TestManagerKeepsOldRuntimeOpenUntilLeaseRelease(t *testing.T) {
 	if got := oldLease.DuckLakeSnapshotID(); got != 11 {
 		t.Fatalf("old lease snapshot = %d, want 11", got)
 	}
-	if got := manager.LeasedSnapshots(); !equalInt64s(got, []int64{11}) {
-		t.Fatalf("leased snapshots = %#v, want old snapshot only", got)
+	if got := manager.LeasedSnapshots(); !equalInt64s(got, []int64{11, 22}) {
+		t.Fatalf("leased snapshots = %#v, want active and draining generations", got)
 	}
 
 	oldLease.Release()
@@ -295,7 +295,29 @@ func TestPreparedReleasesManagedDataLifetimeOnFailureAndAbandonment(t *testing.T
 	}
 }
 
-func TestManagerPersistsSnapshotLeaseOnAcquireAndRelease(t *testing.T) {
+func TestManagerPreparationFailsClosedWhenGenerationLeaseCannotPersist(t *testing.T) {
+	state := servingstate.State{ID: "dep_1", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusValidated}
+	artifact := servingstate.Artifact{ServingStateID: state.ID, WorkspaceID: state.WorkspaceID, Environment: state.Environment, Digest: "digest"}
+	repo := &fakeRepo{deployment: state, artifact: artifact, createLeaseErr: errors.New("lease unavailable")}
+	lifetime := &fakeManagedDataLifetime{}
+	factory := &fakeFactory{snapshotID: 42}
+	manager := NewManagerWithFactory(ManagerOptions{
+		Repo: repo, WorkspaceID: "test", Environment: "dev", Factory: factory,
+		ManagedData: fakeManagedDataResolver{resolution: ManagedDataResolution{Lifetime: lifetime}},
+	})
+
+	if _, err := manager.PrepareServingState(t.Context(), "dep_1"); err == nil {
+		t.Fatal("prepare error = nil, want durable generation lease failure")
+	}
+	if factory.runtime == nil || !factory.runtime.closed {
+		t.Fatalf("prepared runtime = %#v, want closed after lease failure", factory.runtime)
+	}
+	if lifetime.releases != 1 {
+		t.Fatalf("managed-data lifetime releases = %d, want 1", lifetime.releases)
+	}
+}
+
+func TestManagerPersistsOneSnapshotLeaseForRuntimeGeneration(t *testing.T) {
 	ctx := context.Background()
 	repo := &fakeRepo{
 		deployment: servingstate.State{ID: "dep_1", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive, DuckLakeSnapshotID: 11},
@@ -312,10 +334,6 @@ func TestManagerPersistsSnapshotLeaseOnAcquireAndRelease(t *testing.T) {
 	if err := manager.Reload(ctx); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	lease, err := manager.Acquire()
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
 	if len(repo.createdLeases) != 1 {
 		t.Fatalf("created leases = %#v, want one", repo.createdLeases)
 	}
@@ -323,13 +341,57 @@ func TestManagerPersistsSnapshotLeaseOnAcquireAndRelease(t *testing.T) {
 	if created.WorkspaceID != "test" || created.Environment != "dev" || created.ServingStateID != "dep_1" || created.DuckLakeSnapshotID != 11 || created.OwnerID != "test-owner" {
 		t.Fatalf("created lease = %#v", created)
 	}
-	lease.Release()
-	if got := repo.releasedLeases; len(got) != 1 || got[0] != "lease_1" {
-		t.Fatalf("released leases = %#v, want [lease_1]", got)
+	for range 3 {
+		lease, err := manager.Acquire()
+		if err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+		lease.Release()
 	}
-	lease.Release()
-	if got := repo.releasedLeases; len(got) != 1 {
-		t.Fatalf("released leases after second release = %#v, want one release", got)
+	if len(repo.createdLeases) != 1 || len(repo.releasedLeases) != 0 {
+		t.Fatalf("request acquisitions changed durable leases: created=%d released=%d", len(repo.createdLeases), len(repo.releasedLeases))
+	}
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := repo.releasedLeases; len(got) != 1 || got[0] != "lease_1" {
+		t.Fatalf("released leases = %#v, want [lease_1] after generation close", got)
+	}
+}
+
+func TestManagerRetiredGenerationKeepsSnapshotLeaseUntilReadersDrain(t *testing.T) {
+	ctx := context.Background()
+	repo := &fakeRepo{
+		deployment: servingstate.State{ID: "dep_1", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive, DuckLakeSnapshotID: 11},
+		artifact:   servingstate.Artifact{ServingStateID: "dep_1", WorkspaceID: "test", Environment: "dev", Digest: "digest-1"},
+	}
+	manager := NewManagerWithFactory(ManagerOptions{Repo: repo, WorkspaceID: "test", Environment: "dev", Factory: &fakeFactory{}})
+	if err := manager.Reload(ctx); err != nil {
+		t.Fatalf("first reload: %v", err)
+	}
+	reader, err := manager.Acquire()
+	if err != nil {
+		t.Fatalf("acquire old generation: %v", err)
+	}
+
+	repo.deployment = servingstate.State{ID: "dep_2", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive, DuckLakeSnapshotID: 22}
+	repo.artifact = servingstate.Artifact{ServingStateID: "dep_2", WorkspaceID: "test", Environment: "dev", Digest: "digest-2"}
+	if err := manager.Reload(ctx); err != nil {
+		t.Fatalf("second reload: %v", err)
+	}
+	if len(repo.createdLeases) != 2 || len(repo.releasedLeases) != 0 {
+		t.Fatalf("leases after cutover: created=%d released=%d, want 2 and 0", len(repo.createdLeases), len(repo.releasedLeases))
+	}
+
+	reader.Release()
+	if got := repo.releasedLeases; len(got) != 1 || got[0] != "lease_1" {
+		t.Fatalf("released leases after old reader drained = %#v, want [lease_1]", got)
+	}
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close current generation: %v", err)
+	}
+	if got := repo.releasedLeases; len(got) != 2 || got[1] != "lease_2" {
+		t.Fatalf("released leases after close = %#v, want [lease_1 lease_2]", got)
 	}
 }
 
@@ -350,12 +412,9 @@ func TestManagerRetriesPersistentLeaseRelease(t *testing.T) {
 	if err := manager.Reload(ctx); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	lease, err := manager.Acquire()
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close: %v", err)
 	}
-
-	lease.Release()
 
 	if got := len(repo.releasedLeases); got != 3 {
 		t.Fatalf("release attempts = %d, want retry until success", got)
@@ -923,7 +982,7 @@ func TestRegistryPrepareServingStateClosesLoadedRuntimesBeforePrepare(t *testing
 	}
 }
 
-func TestRegistryAcquireForWorkspaceClosesLoadedRuntimesBeforeLazyPrepare(t *testing.T) {
+func TestRegistryAcquireForWorkspaceDoesNotDiscoverRepositoryChanges(t *testing.T) {
 	repo := newFakeRegistryRepo()
 	repo.active["operations/prod"] = registryDeploymentArtifact{
 		deployment: servingstate.State{ID: "dep_ops_prod", WorkspaceID: "operations", Environment: "prod", Status: servingstate.StatusActive, DuckLakeSnapshotID: 7},
@@ -951,20 +1010,19 @@ func TestRegistryAcquireForWorkspaceClosesLoadedRuntimesBeforeLazyPrepare(t *tes
 		artifact:   servingstate.Artifact{ServingStateID: "dep_visuals_prod", WorkspaceID: "visuals", Environment: "prod", Digest: "visuals-prod"},
 	}
 
-	lease, err := registry.AcquireForWorkspace(context.Background(), "visuals")
-	if err != nil {
-		t.Fatalf("acquire visuals: %v", err)
+	activeCalls := len(repo.activeCalls)
+	if _, err := registry.AcquireForWorkspace(context.Background(), "visuals"); err == nil {
+		t.Fatal("acquire visuals error = nil, want explicit activation requirement")
 	}
-	defer lease.Release()
-	if !factory.runtimes[0].closed || !factory.runtimes[1].closed {
-		t.Fatalf("previous active runtimes were not closed before lazy prepare: %#v", factory.runtimes)
+	if len(repo.activeCalls) != activeCalls {
+		t.Fatalf("repository active calls = %d, want unchanged %d", len(repo.activeCalls), activeCalls)
 	}
-	if len(factory.runtimes) != 3 || factory.runtimes[2].closed {
-		t.Fatalf("prepared runtime = %#v, want new open runtime", factory.runtimes)
+	if len(factory.runtimes) != 2 || factory.runtimes[0].closed || factory.runtimes[1].closed {
+		t.Fatalf("acquisition mutated loaded runtimes: %#v", factory.runtimes)
 	}
 }
 
-func TestRegistryAcquireForWorkspaceKeepsLoadedRuntimesOpenOnNoChangeReload(t *testing.T) {
+func TestRegistryAcquireForWorkspaceIsMemoryOnly(t *testing.T) {
 	repo := newFakeRegistryRepo()
 	repo.active["operations/prod"] = registryDeploymentArtifact{
 		deployment: servingstate.State{ID: "dep_ops_prod", WorkspaceID: "operations", Environment: "prod", Status: servingstate.StatusActive, DuckLakeSnapshotID: 7},
@@ -984,12 +1042,16 @@ func TestRegistryAcquireForWorkspaceKeepsLoadedRuntimesOpenOnNoChangeReload(t *t
 	if err := registry.Reload(context.Background()); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
+	activeCalls := len(repo.activeCalls)
 
 	lease, err := registry.AcquireForWorkspace(context.Background(), "sales")
 	if err != nil {
 		t.Fatalf("acquire sales: %v", err)
 	}
 	lease.Release()
+	if len(repo.activeCalls) != activeCalls {
+		t.Fatalf("repository active calls = %d, want unchanged %d", len(repo.activeCalls), activeCalls)
+	}
 	if len(factory.runtimes) != 2 {
 		t.Fatalf("runtime count = %d, want no new prepare", len(factory.runtimes))
 	}
@@ -1041,6 +1103,7 @@ type fakeRepo struct {
 	extendedLeases         []string
 	releaseFailures        int
 	releaseFailureErr      error
+	createLeaseErr         error
 }
 
 func (r *fakeRepo) ActiveArtifact(_ context.Context, _ servingstate.WorkspaceID, environment servingstate.Environment) (servingstate.State, servingstate.Artifact, error) {
@@ -1073,6 +1136,9 @@ func (r *fakeRepo) RecordDuckLakeSnapshot(_ context.Context, servingStateID serv
 }
 
 func (r *fakeRepo) CreateQuerySnapshotLease(_ context.Context, input servingstate.SnapshotLeaseInput) (string, error) {
+	if r.createLeaseErr != nil {
+		return "", r.createLeaseErr
+	}
 	r.createdLeases = append(r.createdLeases, input)
 	return fmt.Sprintf("lease_%d", len(r.createdLeases)), nil
 }
@@ -1099,6 +1165,7 @@ type fakeFactory struct {
 	err          error
 	snapshotID   int64
 	input        RuntimeInput
+	runtime      *fakeRuntime
 }
 
 func (f *fakeFactory) Prepare(_ context.Context, input RuntimeInput) (Runtime, error) {
@@ -1107,10 +1174,12 @@ func (f *fakeFactory) Prepare(_ context.Context, input RuntimeInput) (Runtime, e
 	if f.err != nil {
 		return nil, f.err
 	}
+	snapshotID := f.snapshotID
 	if input.State.DuckLakeSnapshotID > 0 {
-		return &fakeRuntime{snapshotID: input.State.DuckLakeSnapshotID}, nil
+		snapshotID = input.State.DuckLakeSnapshotID
 	}
-	return &fakeRuntime{snapshotID: f.snapshotID}, nil
+	f.runtime = &fakeRuntime{snapshotID: snapshotID}
+	return f.runtime, nil
 }
 
 type fakeManagedDataResolver struct {

--- a/internal/runtimehost/registry.go
+++ b/internal/runtimehost/registry.go
@@ -311,6 +311,9 @@ func (r *Registry) ActiveForWorkspace(ctx context.Context, workspaceID servingst
 }
 
 func (r *Registry) AcquireForWorkspace(ctx context.Context, workspaceID servingstate.WorkspaceID) (Lease, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	r.cutoverMu.RLock()
 	defer r.cutoverMu.RUnlock()
 	r.mu.RLock()
@@ -318,13 +321,6 @@ func (r *Registry) AcquireForWorkspace(ctx context.Context, workspaceID servings
 	r.mu.RUnlock()
 	if manager == nil {
 		return nil, fmt.Errorf("no active LibreDash serving state")
-	}
-	if r.prepareMu.TryLock() {
-		err := manager.ReloadBeforePrepare(ctx, r.closePreparedRuntimes)
-		r.prepareMu.Unlock()
-		if err != nil {
-			return nil, err
-		}
 	}
 	return manager.Acquire()
 }

--- a/scripts/movielens_performance.test.ts
+++ b/scripts/movielens_performance.test.ts
@@ -7,12 +7,19 @@ import {
   logTextAfterCursor,
   parseRefreshSummaries,
   percentile,
+  refreshWasAccepted,
 } from './movielens_performance'
 
 test('percentile uses nearest-rank values', () => {
   expect(percentile([5, 1, 3, 2, 4], 50)).toBe(3)
   expect(percentile([5, 1, 3, 2, 4], 95)).toBe(5)
   expect(percentile([], 95)).toBe(0)
+})
+
+test('refresh acceptance does not require observing a transient loading state', () => {
+  expect(refreshWasAccepted(7, { refreshId: 'refresh-8', generation: 8, loading: true })).toBe(true)
+  expect(refreshWasAccepted(7, { refreshId: 'refresh-8', generation: 8, loading: false })).toBe(true)
+  expect(refreshWasAccepted(7, { refreshId: 'refresh-7', generation: 7, loading: false })).toBe(false)
 })
 
 test('log cursor excludes refresh IDs from earlier server processes', () => {

--- a/scripts/movielens_performance.ts
+++ b/scripts/movielens_performance.ts
@@ -385,8 +385,10 @@ async function runInteraction(page: Page, visualId: string, datumOffset: number)
   }, input.command)
 
   await page.waitForFunction(() => (window as any).__ldPerfObserver?.active?.optimisticAt !== null, undefined, { timeout: 10_000 })
-  const feedback = await waitForStatus(page, (status) => status.generation > before.generation && status.loading, 10_000)
-  const settled = await waitForStatus(page, (status) => status.generation === feedback.generation && !status.loading, 600_000)
+  const accepted = await waitForStatus(page, (status) => refreshWasAccepted(before.generation, status), 10_000)
+  const settled = accepted.loading
+    ? await waitForStatus(page, (status) => status.generation === accepted.generation && !status.loading, 600_000)
+    : accepted
   const trace = await finishPerformanceTrace(page)
   return {
     refreshId: settled.refreshId,
@@ -683,7 +685,11 @@ async function waitForDashboardIdle(page: Page, timeoutMs: number): Promise<void
   await waitForStatus(page, (status) => status.generation > 0 && !status.loading, timeoutMs)
 }
 
-type DashboardStatusSnapshot = { refreshId: string; generation: number; loading: boolean }
+export type DashboardStatusSnapshot = { refreshId: string; generation: number; loading: boolean }
+
+export function refreshWasAccepted(beforeGeneration: number, status: DashboardStatusSnapshot): boolean {
+  return status.generation > beforeGeneration
+}
 
 async function dashboardStatus(page: Page): Promise<DashboardStatusSnapshot> {
   return page.locator('ld-dashboard-page').evaluate((element: any) => ({


### PR DESCRIPTION
## Summary

- make runtime acquisition memory-only and move durable snapshot leases to runtime generations
- report target work sum separately from the true refresh critical path
- fuse compatible same-fact aggregates and add resource-aware heterogeneous fact bundling
- use statement-local governed projections for serial readers while preserving parallel fact-signature bundles for concurrent readers
- keep large MovieLens performance QA local/nightly and fix its fast-refresh observation race

## Performance

MovieLens 32M local benchmark after the resource-aware strategy:

- release decade p95: 546 ms
- activity month p95: 172 ms
- rating bucket: 843 ms median, 1.17 s p95
- rapid supersession: 180 ms
- zero deterministic, browser, or network failures

Serial readers use a two-statement shared-projection plan. Concurrent readers retain three smaller statements where parallel execution gives a shorter critical path.

## Verification

- full Go test suite
- focused race tests for runtime host, query planner, dashboard consumer/runtime, and stream coordinator
- DuckDB bundle integration tests covering local dimensions, conformed dimensions, and one-sided groups
- frontend performance-harness tests
- five-iteration MovieLens performance benchmark
- Datastar route QA and deployment checks
- generated artifact and diff checks