### PR TITLE
Move remaining static SQLite queries to sqlc

### DIFF
--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -648,6 +648,57 @@ func TestSQLCOutputsAreGeneratedBuildInputs(t *testing.T) {
 	}
 }
 
+func TestFixedPlatformSQLiteQueriesUseSQLC(t *testing.T) {
+	root := repoRoot(t)
+	queryContracts := map[string][]string{
+		filepath.Join("internal", "platform", "db", "queries", "access.sql"): {
+			"-- name: DeleteRoleGrantTemplates :exec",
+			"-- name: InsertRoleGrantTemplate :exec",
+		},
+		filepath.Join("internal", "platform", "db", "queries", "platform.sql"): {
+			"-- name: InsertPlatformSettingIfMissing :exec",
+		},
+		filepath.Join("internal", "platform", "db", "queries", "managed_data.sql"): {
+			"-- name: ListManagedDataReachabilitySources :many",
+		},
+	}
+	for name, markers := range queryContracts {
+		body, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, marker := range markers {
+			if !strings.Contains(string(body), marker) {
+				t.Errorf("%s missing sqlc query %q", name, marker)
+			}
+		}
+	}
+
+	handwrittenSQL := map[string][]string{
+		filepath.Join("internal", "platform", "store.go"): {
+			"DELETE FROM role_grant_templates",
+			"INSERT INTO role_grant_templates",
+			"INSERT INTO securable_objects",
+			"INSERT INTO platform_settings",
+		},
+		filepath.Join("internal", "manageddata", "maintenance", "sqlite", "source.go"): {
+			"const reachabilityQuery",
+			"QueryContext(ctx, reachabilityQuery)",
+		},
+	}
+	for name, fragments := range handwrittenSQL {
+		body, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, fragment := range fragments {
+			if strings.Contains(string(body), fragment) {
+				t.Errorf("%s retains fixed-shape SQLite query %q instead of using sqlc", name, fragment)
+			}
+		}
+	}
+}
+
 func TestStorageArchitectureSpecDocumentsGlobalDuckLakeCatalog(t *testing.T) {
 	root := repoRoot(t)
 	spec, err := os.ReadFile(filepath.Join(root, "docs", "storage-architecture-spec.md"))

--- a/internal/manageddata/maintenance/sqlite/source.go
+++ b/internal/manageddata/maintenance/sqlite/source.go
@@ -19,34 +19,8 @@ import (
 	"github.com/Yacobolo/libredash/internal/manageddata"
 	"github.com/Yacobolo/libredash/internal/manageddata/maintenance"
 	"github.com/Yacobolo/libredash/internal/manageddata/storage"
+	platformdb "github.com/Yacobolo/libredash/internal/platform/db"
 )
-
-const reachabilityQuery = `
-SELECT source_type, source_id, source_status, revision_digest, manifest_json, file_count, size_bytes
-FROM (
-  SELECT
-    'revision' AS source_type,
-    id AS source_id,
-    status AS source_status,
-    digest AS revision_digest,
-    manifest_json,
-    file_count,
-    size_bytes
-  FROM managed_data_revisions
-  WHERE status = 'ready'
-  UNION ALL
-  SELECT
-    'upload' AS source_type,
-    id AS source_id,
-    status AS source_status,
-    '' AS revision_digest,
-    manifest_json,
-    expected_file_count AS file_count,
-    expected_size_bytes AS size_bytes
-  FROM managed_data_upload_sessions
-  WHERE status IN ('open', 'committing')
-)
-ORDER BY source_type, source_id`
 
 const transactionCleanupTimeout = 5 * time.Second
 
@@ -70,7 +44,7 @@ func (s *Source) Snapshot(ctx context.Context) (maintenance.ReachabilitySnapshot
 		return maintenance.ReachabilitySnapshot{}, sourceError(ctx, "acquire SQLite connection", err)
 	}
 	defer conn.Close()
-	return readSnapshot(ctx, conn)
+	return readSnapshot(ctx, platformdb.New(conn))
 }
 
 func (s *Source) WithStableSnapshot(
@@ -103,7 +77,7 @@ func (s *Source) WithStableSnapshot(
 		}
 	}()
 
-	snapshot, err := readSnapshot(ctx, conn)
+	snapshot, err := readSnapshot(ctx, platformdb.New(conn))
 	if err != nil {
 		return err
 	}
@@ -123,10 +97,6 @@ func (s *Source) WithStableSnapshot(
 	return nil
 }
 
-type queryer interface {
-	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
-}
-
 type durableManifest struct {
 	sourceType     string
 	id             string
@@ -137,27 +107,23 @@ type durableManifest struct {
 	sizeBytes      int64
 }
 
-func readSnapshot(ctx context.Context, query queryer) (maintenance.ReachabilitySnapshot, error) {
-	rows, err := query.QueryContext(ctx, reachabilityQuery)
+func readSnapshot(ctx context.Context, queries *platformdb.Queries) (maintenance.ReachabilitySnapshot, error) {
+	rows, err := queries.ListManagedDataReachabilitySources(ctx)
 	if err != nil {
 		return maintenance.ReachabilitySnapshot{}, sourceError(ctx, "query managed-data reachability", err)
 	}
-	defer rows.Close()
 
 	digests := make(map[string]struct{})
 	generation := sha256.New()
-	for rows.Next() {
-		var row durableManifest
-		if err := rows.Scan(
-			&row.sourceType,
-			&row.id,
-			&row.status,
-			&row.revisionDigest,
-			&row.manifestJSON,
-			&row.fileCount,
-			&row.sizeBytes,
-		); err != nil {
-			return maintenance.ReachabilitySnapshot{}, sourceError(ctx, "scan managed-data reachability", err)
+	for _, source := range rows {
+		row := durableManifest{
+			sourceType:     source.SourceType,
+			id:             source.SourceID,
+			status:         source.SourceStatus,
+			revisionDigest: source.RevisionDigest,
+			manifestJSON:   source.ManifestJson,
+			fileCount:      source.FileCount,
+			sizeBytes:      source.SizeBytes,
 		}
 		manifest, canonical, err := validateDurableManifest(row)
 		if err != nil {
@@ -168,10 +134,6 @@ func readSnapshot(ctx context.Context, query queryer) (maintenance.ReachabilityS
 			digests[file.SHA256] = struct{}{}
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return maintenance.ReachabilitySnapshot{}, sourceError(ctx, "iterate managed-data reachability", err)
-	}
-
 	sha256s := make([]string, 0, len(digests))
 	for digest := range digests {
 		sha256s = append(sha256s, digest)

--- a/internal/platform/db/queries/access.sql
+++ b/internal/platform/db/queries/access.sql
@@ -64,6 +64,15 @@ INSERT INTO roles (id, name, privileges_json)
 VALUES (?, ?, ?)
 ON CONFLICT(name) DO UPDATE SET privileges_json = excluded.privileges_json;
 
+-- name: DeleteRoleGrantTemplates :exec
+DELETE FROM role_grant_templates
+WHERE role_name = sqlc.arg(role_name);
+
+-- name: InsertRoleGrantTemplate :exec
+INSERT INTO role_grant_templates (role_name, privilege)
+VALUES (sqlc.arg(role_name), sqlc.arg(privilege))
+ON CONFLICT(role_name, privilege) DO NOTHING;
+
 -- name: GetRoleByName :one
 SELECT * FROM roles WHERE name = ?;
 

--- a/internal/platform/db/queries/managed_data.sql
+++ b/internal/platform/db/queries/managed_data.sql
@@ -178,6 +178,33 @@ SELECT * FROM managed_data_revisions
 WHERE collection_id = ?
 ORDER BY sequence DESC;
 
+-- name: ListManagedDataReachabilitySources :many
+SELECT source_type, source_id, source_status, revision_digest, manifest_json, file_count, size_bytes
+FROM (
+  SELECT
+    'revision' AS source_type,
+    id AS source_id,
+    status AS source_status,
+    digest AS revision_digest,
+    manifest_json,
+    file_count,
+    size_bytes
+  FROM managed_data_revisions
+  WHERE status = 'ready'
+  UNION ALL
+  SELECT
+    'upload' AS source_type,
+    id AS source_id,
+    status AS source_status,
+    '' AS revision_digest,
+    manifest_json,
+    expected_file_count AS file_count,
+    expected_size_bytes AS size_bytes
+  FROM managed_data_upload_sessions
+  WHERE status IN ('open', 'committing')
+)
+ORDER BY source_type, source_id;
+
 -- name: GetManagedDataUploadSessionIDByRevision :one
 SELECT id FROM managed_data_upload_sessions
 WHERE revision_id = ? AND status = 'complete';
@@ -186,4 +213,3 @@ WHERE revision_id = ? AND status = 'complete';
 SELECT * FROM managed_data_revision_files
 WHERE revision_id = ?
 ORDER BY logical_path;
-

--- a/internal/platform/db/queries/platform.sql
+++ b/internal/platform/db/queries/platform.sql
@@ -6,3 +6,7 @@ INSERT INTO platform_settings (key, value)
 VALUES (sqlc.arg(key), sqlc.arg(value))
 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP;
 
+-- name: InsertPlatformSettingIfMissing :exec
+INSERT INTO platform_settings (key, value)
+VALUES (sqlc.arg(key), sqlc.arg(value))
+ON CONFLICT(key) DO NOTHING;

--- a/internal/platform/store.go
+++ b/internal/platform/store.go
@@ -335,7 +335,10 @@ func (s *Store) migrate(ctx context.Context) error {
 }
 
 func (s *Store) seedDefaults(ctx context.Context) error {
-	if err := s.insertSettingIfMissing(ctx, agentconfig.SystemPromptSettingKey, agentconfig.DefaultSystemPrompt); err != nil {
+	if err := s.q.InsertPlatformSettingIfMissing(ctx, db.InsertPlatformSettingIfMissingParams{
+		Key:   agentconfig.SystemPromptSettingKey,
+		Value: agentconfig.DefaultSystemPrompt,
+	}); err != nil {
 		return err
 	}
 	for _, role := range access.DefaultRoles() {
@@ -351,34 +354,24 @@ func (s *Store) seedDefaults(ctx context.Context) error {
 		}); err != nil {
 			return err
 		}
-		if _, err := s.db.ExecContext(ctx, `DELETE FROM role_grant_templates WHERE role_name = ?`, role.Name); err != nil {
+		if err := s.q.DeleteRoleGrantTemplates(ctx, role.Name); err != nil {
 			return err
 		}
 		for _, privilege := range role.Privileges {
-			if _, err := s.db.ExecContext(ctx, `
-		INSERT INTO role_grant_templates (role_name, privilege)
-		VALUES (?, ?)
-	ON CONFLICT(role_name, privilege) DO NOTHING
-	`, role.Name, string(privilege)); err != nil {
+			if err := s.q.InsertRoleGrantTemplate(ctx, db.InsertRoleGrantTemplateParams{
+				RoleName:  role.Name,
+				Privilege: string(privilege),
+			}); err != nil {
 				return err
 			}
 		}
 	}
-	if _, err := s.db.ExecContext(ctx, `
-	INSERT INTO securable_objects (id, object_type, display_name)
-	VALUES ('platform', 'platform', 'Platform')
-	ON CONFLICT(id) DO UPDATE SET object_type = excluded.object_type, display_name = excluded.display_name, updated_at = CURRENT_TIMESTAMP
-	`); err != nil {
+	if err := s.q.UpsertSecurableObject(ctx, db.UpsertSecurableObjectParams{
+		ID:          "platform",
+		ObjectType:  "platform",
+		DisplayName: "Platform",
+	}); err != nil {
 		return err
 	}
 	return nil
-}
-
-func (s *Store) insertSettingIfMissing(ctx context.Context, key, value string) error {
-	_, err := s.db.ExecContext(ctx, `
-INSERT INTO platform_settings (key, value)
-VALUES (?, ?)
-ON CONFLICT(key) DO NOTHING
-`, key, value)
-	return err
 }

--- a/internal/platform/store_test.go
+++ b/internal/platform/store_test.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/Yacobolo/libredash/internal/access"
+	agentconfig "github.com/Yacobolo/libredash/internal/agent/config"
 	analyticsducklake "github.com/Yacobolo/libredash/internal/analytics/ducklake"
 )
 
@@ -62,6 +64,79 @@ func TestStoreMigratesAndSeedsRoles(t *testing.T) {
 		if roles[i] != want[i] {
 			t.Fatalf("roles = %#v, want %#v", roles, want)
 		}
+	}
+}
+
+func TestStoreReconcilesDefaultSeedDataWithoutOverwritingSettings(t *testing.T) {
+	ctx := t.Context()
+	dbPath := filepath.Join(t.TempDir(), "libredash.db")
+	store, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	const customPrompt = "Keep this customized prompt."
+	if err := store.UpsertSetting(ctx, agentconfig.SystemPromptSettingKey, customPrompt); err != nil {
+		t.Fatalf("customize system prompt: %v", err)
+	}
+	defaultRole := access.DefaultRoles()[0]
+	if _, err := store.SQLDB().ExecContext(ctx, `DELETE FROM role_grant_templates WHERE role_name = ?`, defaultRole.Name); err != nil {
+		t.Fatalf("remove default role templates: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `INSERT INTO role_grant_templates (role_name, privilege) VALUES (?, 'STALE_PRIVILEGE')`, defaultRole.Name); err != nil {
+		t.Fatalf("insert stale role template: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `UPDATE securable_objects SET object_type = 'stale', display_name = 'Stale' WHERE id = 'platform'`); err != nil {
+		t.Fatalf("corrupt platform object: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	store, err = Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store.Close()
+
+	prompt, err := store.GetSetting(ctx, agentconfig.SystemPromptSettingKey)
+	if err != nil {
+		t.Fatalf("get customized system prompt: %v", err)
+	}
+	if prompt != customPrompt {
+		t.Fatalf("system prompt = %q, want %q", prompt, customPrompt)
+	}
+
+	rows, err := store.SQLDB().QueryContext(ctx, `SELECT privilege FROM role_grant_templates WHERE role_name = ? ORDER BY privilege`, defaultRole.Name)
+	if err != nil {
+		t.Fatalf("list default role templates: %v", err)
+	}
+	defer rows.Close()
+	var privileges []string
+	for rows.Next() {
+		var privilege string
+		if err := rows.Scan(&privilege); err != nil {
+			t.Fatalf("scan default role template: %v", err)
+		}
+		privileges = append(privileges, privilege)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate default role templates: %v", err)
+	}
+	wantPrivileges := make([]string, len(defaultRole.Privileges))
+	for i, privilege := range defaultRole.Privileges {
+		wantPrivileges[i] = string(privilege)
+	}
+	sort.Strings(wantPrivileges)
+	if !slices.Equal(privileges, wantPrivileges) {
+		t.Fatalf("default role privileges = %#v, want %#v", privileges, wantPrivileges)
+	}
+
+	var objectType, workspaceID, parentID, displayName string
+	if err := store.SQLDB().QueryRowContext(ctx, `SELECT object_type, workspace_id, parent_id, display_name FROM securable_objects WHERE id = 'platform'`).Scan(&objectType, &workspaceID, &parentID, &displayName); err != nil {
+		t.Fatalf("get platform object: %v", err)
+	}
+	if objectType != "platform" || workspaceID != "" || parentID != "" || displayName != "Platform" {
+		t.Fatalf("platform object = (%q, %q, %q, %q), want (platform, empty, empty, Platform)", objectType, workspaceID, parentID, displayName)
 	}
 }
 


### PR DESCRIPTION
## Summary

Finish the bounded sqlc adoption work by moving the remaining fixed-shape platform SQLite statements into the existing domain query files.

- generates role-template deletion and insertion from `access.sql`
- generates insert-if-missing platform settings from `platform.sql`
- generates managed-data reachability source loading from `managed_data.sql`
- reuses the existing generated `UpsertSecurableObject` query for the platform object seed
- replaces manual reachability row scanning with the generated typed row contract
- leaves PRAGMAs, Goose migrations, transaction boundaries, backup/VACUUM SQL, dynamic authorization, and DuckDB/DuckLake SQL handwritten

## Why

These statements were static SQLite contracts but lived inside Go strings, outside the schema-checked query boundary used by the other 210 platform queries. That made startup security defaults and managed-data retention reachability easier to drift from the migration-owned schema.

After this change, all sensible fixed-shape platform SQLite queries are compiled by sqlc while operational and genuinely dynamic SQL remains explicit in Go.

## Safety and tests

This was developed red-green-refactor:

- an architecture test first failed on the four missing sqlc query contracts and the remaining production Go SQL fragments
- existing managed-data snapshot and stable-snapshot tests verify ready revisions, nonterminal uploads, deterministic generations, integrity failures, cancellation, and writer exclusion
- new store coverage verifies reopening the database preserves a customized agent prompt, exactly reconciles default-role templates, and repairs the platform securable object
- generated sqlc output remains ignored and is regenerated through the existing Task, CI, and Docker lifecycle

Verification:

- focused platform, managed-data maintenance, and architecture tests
- `task ci` (full Go and frontend tests, generation checks, vet, race analysis, live route QA, and deployment validation)

## Base

This PR targets `main` directly and contains only the static sqlc conversion.
