### PR TITLE
Fix streamed chat activity state

### DIFF
--- a/internal/agent/http/chat.go
+++ b/internal/agent/http/chat.go
@@ -160,7 +160,7 @@ func (h *Handler) completeDraftChatTurn(service *agent.Service, scope agent.Scop
 		ClientID:           clientID,
 		Emit: func(signal ui.ChatViewState) error {
 			if h.options.Broker != nil {
-				h.options.Broker.Publish(chatStreamID(scope, clientID), chatSignalPatch(signal))
+				h.options.Broker.Publish(chatStreamID(scope, clientID), ui.ChatSignalPatch(signal))
 			}
 			return nil
 		},
@@ -188,7 +188,7 @@ func (h *Handler) runChatTurn(w nethttp.ResponseWriter, r *nethttp.Request, serv
 		Input:          input,
 	})
 	if err != nil {
-		_ = updates.Patch(chatSignalPatch(h.chatSignalWith(r.Context(), scope, conversationID, transcript, streamArtifacts, chatTurnStatusError(err), false)))
+		_ = updates.Patch(ui.ChatSignalPatch(h.chatSignalWith(r.Context(), scope, conversationID, transcript, streamArtifacts, chatTurnStatusError(err), false)))
 		return
 	}
 	if h.options.ExecuteStartedChatTurn == nil {
@@ -198,7 +198,7 @@ func (h *Handler) runChatTurn(w nethttp.ResponseWriter, r *nethttp.Request, serv
 	_, _ = h.options.ExecuteStartedChatTurn(r.Context(), service, scope, started, ChatTurnExecution{
 		LiveConversations: h.chatConversations(r.Context(), scope),
 		Emit: func(signal ui.ChatViewState) error {
-			return updates.Patch(chatSignalPatch(signal))
+			return updates.Patch(ui.ChatSignalPatch(signal))
 		},
 	})
 }
@@ -291,13 +291,6 @@ func chatTurnStatusError(err error) string {
 		return "A turn is already running for this conversation."
 	}
 	return err.Error()
-}
-
-func chatSignalPatch(signal ui.ChatViewState) pagestream.SignalPatch {
-	return pagestream.SignalPatch{
-		"agent":   signal.Agent,
-		"visuals": signal.Visuals,
-	}
 }
 
 func chatRoutePath(parts ...string) string {

--- a/internal/app/chat_signals.go
+++ b/internal/app/chat_signals.go
@@ -125,13 +125,6 @@ func isChatVisualType(value string) bool {
 	}
 }
 
-func chatSignalPatch(signal ui.ChatViewState) map[string]any {
-	return map[string]any{
-		"agent":   signal.Agent,
-		"visuals": signal.Visuals,
-	}
-}
-
 func (s *Server) chatConversations(ctx context.Context, scope agent.Scope) []ui.ChatConversationSummary {
 	conversations := []ui.ChatConversationSummary{}
 	if s.agent == nil || scope.PrincipalID == "" {
@@ -143,7 +136,7 @@ func (s *Server) chatConversations(ctx context.Context, scope agent.Scope) []ui.
 	}
 	for _, row := range rows {
 		out := chatConversationSummary(row)
-		out.TitlePending = uisignals.Optional(s.isChatTitlePending(row.ID))
+		out.TitlePending = uisignals.Pointer(s.isChatTitlePending(row.ID))
 		conversations = append(conversations, out)
 	}
 	return conversations

--- a/internal/app/chat_test.go
+++ b/internal/app/chat_test.go
@@ -668,16 +668,17 @@ func TestChatDraftTurnRedirectsAndStreamsThroughUpdates(t *testing.T) {
 	close(release)
 	waitForConversationMessage(t, service, principal.ID, conversationID, "Background complete.")
 	waitForRecorderBodyContains(t, updatesRec, `"running":false`)
+	waitForAgentConversationTitle(t, store, "test", principal.ID, conversationID, "Background complete")
+	waitForRecorderBodyContains(t, updatesRec, `"pending":false`)
 	cancelUpdates()
 	<-done
 
 	updatesBody := updatesRec.BodyString()
-	for _, want := range []string{`"running":true`, "Background complete.", `"running":false`} {
+	for _, want := range []string{`"running":true`, "Background complete.", `"running":false`, `"pending":true`, `"pending":false`} {
 		if !strings.Contains(updatesBody, want) {
 			t.Fatalf("updates stream missing %q:\n%s", want, updatesBody)
 		}
 	}
-	waitForAgentConversationTitle(t, store, "test", principal.ID, conversationID, "Background complete")
 }
 
 func TestChatTurnWithActiveConversationDoesNotReplaceURL(t *testing.T) {

--- a/internal/app/chat_titles.go
+++ b/internal/app/chat_titles.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/Yacobolo/libredash/internal/agent"
-	"github.com/Yacobolo/libredash/pkg/pagestream"
+	"github.com/Yacobolo/libredash/internal/ui"
 )
 
 func (s *Server) generateConversationTitleAsync(scope agent.Scope, conversationID, clientID string) {
@@ -21,11 +21,9 @@ func (s *Server) generateConversationTitleAsync(scope agent.Scope, conversationI
 			s.logger.DebugContext(ctx, "agent title generation failed", "conversation_id", conversationID, "error", err)
 		}
 		s.clearChatTitlePending(conversationID)
-		s.broker.Publish(chatStreamID(scope, clientID), pagestream.SignalPatch{
-			"agent": map[string]any{
-				"conversations": s.chatConversations(ctx, scope),
-			},
-		})
+		s.broker.Publish(chatStreamID(scope, clientID), ui.ChatConversationsPatch(
+			s.chatConversations(ctx, scope), conversationID,
+		))
 	}()
 }
 

--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -54,3 +54,34 @@ func ChatBootstrapSignals(catalog dashboard.Catalog, workspaceID, roleLabel, vie
 		"visuals": envelope.Visuals,
 	}
 }
+
+// ChatSignalPatch keeps the chat body and the sidebar history synchronized.
+// The sidebar renders from the chrome signal, so conversation changes must be
+// streamed to both roots in the same patch.
+func ChatSignalPatch(state ChatViewState) pagestream.SignalPatch {
+	patch := ChatConversationsPatch(state.Agent.Conversations, state.Agent.ActiveConversationID)
+	patch["agent"] = state.Agent
+	patch["visuals"] = state.Visuals
+	return patch
+}
+
+// ChatConversationsPatch updates conversation state without replacing the
+// rest of the agent or chrome signal trees.
+func ChatConversationsPatch(conversations []ChatConversationSummary, activeConversationID string) pagestream.SignalPatch {
+	agent := ChatSignal{
+		ActiveConversationID: activeConversationID,
+		Conversations:        conversations,
+	}
+	return pagestream.SignalPatch{
+		"agent": map[string]any{
+			"conversations": conversations,
+		},
+		"chrome": map[string]any{
+			"sidebar": map[string]any{
+				"history": map[string]any{
+					"items": uisignals.ChatHistoryItems(agent),
+				},
+			},
+		},
+	}
+}

--- a/internal/ui/chat_test.go
+++ b/internal/ui/chat_test.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"testing"
+
+	uisignals "github.com/Yacobolo/libredash/internal/ui/signals"
+)
+
+func TestChatSignalPatchStreamsSidebarHistoryState(t *testing.T) {
+	pending := true
+	state := ChatViewState{Agent: ChatSignal{
+		ActiveConversationID: "agentconv_1",
+		Conversations: []ChatConversationSummary{{
+			ID:           "agentconv_1",
+			Title:        "New conversation",
+			TitlePending: &pending,
+		}},
+	}}
+
+	patch := ChatSignalPatch(state)
+	assertChatHistoryPatch(t, patch, true)
+}
+
+func TestChatConversationsPatchStreamsCompletedSidebarHistoryState(t *testing.T) {
+	pending := false
+	patch := ChatConversationsPatch([]ChatConversationSummary{{
+		ID:           "agentconv_1",
+		Title:        "Quick check-in",
+		TitlePending: &pending,
+	}}, "agentconv_1")
+
+	assertChatHistoryPatch(t, patch, false)
+}
+
+func assertChatHistoryPatch(t *testing.T, patch map[string]any, wantPending bool) {
+	t.Helper()
+	chrome, ok := patch["chrome"].(map[string]any)
+	if !ok {
+		t.Fatalf("chat patch chrome = %#v, want object", patch["chrome"])
+	}
+	sidebar, ok := chrome["sidebar"].(map[string]any)
+	if !ok {
+		t.Fatalf("chat patch sidebar = %#v, want object", chrome["sidebar"])
+	}
+	history, ok := sidebar["history"].(map[string]any)
+	if !ok {
+		t.Fatalf("chat patch history = %#v, want object", sidebar["history"])
+	}
+	items, ok := history["items"].([]uisignals.SidebarHistoryItemSignal)
+	if !ok || len(items) != 1 {
+		t.Fatalf("chat patch history items = %#v, want one typed item", history["items"])
+	}
+	if items[0].Pending == nil || *items[0].Pending != wantPending || !items[0].Active {
+		t.Fatalf("chat patch history item = %#v, want pending=%t active=true", items[0], wantPending)
+	}
+}

--- a/web/components/chat/chat-thread.dom.test.ts
+++ b/web/components/chat/chat-thread.dom.test.ts
@@ -41,6 +41,7 @@ beforeAll(async () => {
               --ld-border-default: 2px solid rgb(4, 5, 6);
               --fontStack-system: system-ui;
               --fontStack-monospace: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+              --ld-bg-app: rgb(11, 12, 13);
               --ld-bg-page: #fff;
               --ld-bg-panel: #fff;
               --ld-bg-panel-muted: #f6f8fa;
@@ -108,6 +109,20 @@ afterAll(async () => {
 	await browser?.close()
 	await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
 }, 15_000)
+
+test('chat thread uses the surrounding app surface background', async () => {
+  const page = await browser.newPage()
+  await page.goto(baseURL)
+  await page.waitForFunction(() => customElements.get('ld-chat-thread'))
+
+  const background = await page.locator('ld-chat-thread').evaluate((element: any) => {
+    const thread = element.shadowRoot.querySelector('.thread') as HTMLElement
+    return getComputedStyle(thread).backgroundColor
+  })
+
+  expect(background).toBe('rgb(11, 12, 13)')
+  await page.close()
+})
 
 test('chat thread preserves plain user message text without template whitespace', async () => {
   const page = await browser.newPage()

--- a/web/components/chat/chat-thread.ts
+++ b/web/components/chat/chat-thread.ts
@@ -64,7 +64,7 @@ class ChatThread extends LitElement {
       min-height: 0;
       grid-template-rows: minmax(0, 1fr);
       overflow: hidden;
-      background: var(--ld-bg-page);
+      background: var(--ld-bg-app);
     }
 
     .scroll {


### PR DESCRIPTION
## Summary

- stream conversation title activity to both the agent and sidebar chrome signals
- emit explicit title completion state so pending spinners stop reliably
- use the shared app background token for the conversation thread
- add SSE integration and browser DOM regression coverage

## Validation

- `task ci`