### PR TITLE
Fix CLI, API, and responsive UI bug-pass regressions

### DIFF
--- a/api/typespec/managed_data.tsp
+++ b/api/typespec/managed_data.tsp
@@ -219,7 +219,8 @@ model ManagedDataUploadNegotiation {
 model ManagedDataFileUploadResponse {
   file: ManagedDataFileMetadata;
   status: ManagedDataFileUploadStatus;
-  negotiation: ManagedDataUploadNegotiation;
+  @doc("Upload instructions, present only while the file can still be uploaded.")
+  negotiation?: ManagedDataUploadNegotiation;
   error?: ManagedDataErrorMessage;
 }
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -41293,7 +41293,6 @@ components:
       required:
         - file
         - status
-        - negotiation
       properties:
         file:
           $ref: '#/components/schemas/ManagedDataFileMetadata'
@@ -41301,6 +41300,7 @@ components:
           $ref: '#/components/schemas/ManagedDataFileUploadStatus'
         negotiation:
           $ref: '#/components/schemas/ManagedDataUploadNegotiation'
+          description: Upload instructions, present only while the file can still be uploaded.
         error:
           type: string
           minLength: 1

--- a/internal/access/http/handler.go
+++ b/internal/access/http/handler.go
@@ -2219,7 +2219,7 @@ func pageSliceForRequest[T any](w stdhttp.ResponseWriter, r *stdhttp.Request, it
 	if end < len(items) {
 		nextCursor = encodeKeyCursor(apiItemPageKey(items[end-1]))
 	}
-	return append([]T(nil), items[start:end]...), nextCursor, true
+	return append(make([]T, 0, end-start), items[start:end]...), nextCursor, true
 }
 
 const (

--- a/internal/access/http/pagination_internal_test.go
+++ b/internal/access/http/pagination_internal_test.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"encoding/json"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPageSliceForRequestPreservesEmptyArray(t *testing.T) {
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(stdhttp.MethodGet, "/api/v1/principals", nil)
+	items, _, ok := pageSliceForRequest[string](response, request, nil)
+	encoded, err := json.Marshal(items)
+	if err != nil || !ok || string(encoded) != "[]" {
+		t.Fatalf("empty page = %s, ok=%v, error=%v; want []", encoded, ok, err)
+	}
+}

--- a/internal/analytics/query/http/handler.go
+++ b/internal/analytics/query/http/handler.go
@@ -1130,7 +1130,7 @@ func pageSliceForRequest[T any](w nethttp.ResponseWriter, r *nethttp.Request, it
 	if end < len(items) {
 		nextCursor = encodeListKeysetCursor(listPageItemKey(items[end-1]), scope, snapshot)
 	}
-	return append([]T(nil), items[start:end]...), nextCursor, true
+	return append(make([]T, 0, end-start), items[start:end]...), nextCursor, true
 }
 
 type listKeysetCursor struct {

--- a/internal/analytics/query/http/pagination_internal_test.go
+++ b/internal/analytics/query/http/pagination_internal_test.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"encoding/json"
+	nethttp "net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPageSliceForRequestPreservesEmptyArray(t *testing.T) {
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(nethttp.MethodGet, "/api/v1/workspaces/sales/semantic-models", nil)
+	items, _, ok := pageSliceForRequest[string](response, request, nil)
+	encoded, err := json.Marshal(items)
+	if err != nil || !ok || string(encoded) != "[]" {
+		t.Fatalf("empty page = %s, ok=%v, error=%v; want []", encoded, ok, err)
+	}
+}

--- a/internal/app/api_apigen.go
+++ b/internal/app/api_apigen.go
@@ -274,6 +274,22 @@ func (w *apiGenResponseBuffer) normalizedBody(status int) []byte {
 	if err := json.Unmarshal(w.body.Bytes(), &value); err != nil {
 		return w.body.Bytes()
 	}
+	if strings.HasPrefix(w.header.Get("Content-Type"), "application/problem+json") {
+		if instance, _ := value["instance"].(string); strings.TrimSpace(instance) == "" {
+			value["instance"] = w.request.URL.Path
+		}
+		if requestID, _ := value["requestId"].(string); strings.TrimSpace(requestID) == "" {
+			value["requestId"] = w.request.Header.Get("X-Request-ID")
+		}
+		if errorsValue, present := value["errors"]; !present || errorsValue == nil {
+			value["errors"] = []apigenapi.ProblemFieldError{}
+		}
+		out, err := json.Marshal(value)
+		if err != nil {
+			return w.body.Bytes()
+		}
+		return append(out, '\n')
+	}
 	if _, ok := value["code"]; !ok {
 		return w.body.Bytes()
 	}

--- a/internal/app/api_protocol.go
+++ b/internal/app/api_protocol.go
@@ -43,21 +43,10 @@ const apiCursorSnapshotHeader = "X-LibreDash-Cursor-Snapshot"
 
 func (s *Server) publicProtocolMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestID := strings.TrimSpace(r.Header.Get("X-Request-ID"))
-		if requestID == "" {
-			requestID = newAPIRequestID()
-			r.Header.Set("X-Request-ID", requestID)
+		if !s.authenticatePublicAPIRequest(w, r) {
+			return
 		}
-		w.Header().Set("X-Request-ID", requestID)
 		r.Header.Set(apiCursorSnapshotHeader, s.cursorSnapshot(r))
-		if bearerToken(r) == "" {
-			writeAPIProblem(w, r, http.StatusUnauthorized, "BEARER_REQUIRED", "The public API accepts bearer credentials only", nil)
-			return
-		}
-		if s.auth != nil && !s.auth.acceptsPublicBearer(r) {
-			writeAPIProblem(w, r, http.StatusUnauthorized, "INVALID_BEARER", "The bearer credential is invalid", nil)
-			return
-		}
 		if !unwrapAPIPageCursor(w, r) {
 			return
 		}
@@ -67,6 +56,28 @@ func (s *Server) publicProtocolMiddleware(next http.Handler) http.Handler {
 		}
 		s.serveIdempotent(w, r, next)
 	})
+}
+
+func (s *Server) authenticatePublicAPIRequest(w http.ResponseWriter, r *http.Request) bool {
+	preparePublicAPIRequest(w, r)
+	if bearerToken(r) == "" {
+		writeAPIProblem(w, r, http.StatusUnauthorized, "BEARER_REQUIRED", "The public API accepts bearer credentials only", nil)
+		return false
+	}
+	if s.auth != nil && !s.auth.acceptsPublicBearer(r) {
+		writeAPIProblem(w, r, http.StatusUnauthorized, "INVALID_BEARER", "The bearer credential is invalid", nil)
+		return false
+	}
+	return true
+}
+
+func preparePublicAPIRequest(w http.ResponseWriter, r *http.Request) {
+	requestID := strings.TrimSpace(r.Header.Get("X-Request-ID"))
+	if requestID == "" {
+		requestID = newAPIRequestID()
+		r.Header.Set("X-Request-ID", requestID)
+	}
+	w.Header().Set("X-Request-ID", requestID)
 }
 
 func unwrapAPIPageCursor(w http.ResponseWriter, r *http.Request) bool {

--- a/internal/app/api_protocol_test.go
+++ b/internal/app/api_protocol_test.go
@@ -82,9 +82,10 @@ func TestPublicAPIRouterErrorsUseAuthenticatedProblemDetails(t *testing.T) {
 		authorization string
 		wantStatus    int
 		wantCode      string
+		wantAllow     string
 	}{
 		{name: "unknown route", method: http.MethodGet, path: "/api/v1/not-a-route", authorization: "Bearer dev", wantStatus: http.StatusNotFound, wantCode: "API_ROUTE_NOT_FOUND"},
-		{name: "unsupported method", method: http.MethodPost, path: "/api/v1/workspaces", authorization: "Bearer dev", wantStatus: http.StatusMethodNotAllowed, wantCode: "METHOD_NOT_ALLOWED"},
+		{name: "unsupported method", method: http.MethodPost, path: "/api/v1/workspaces", authorization: "Bearer dev", wantStatus: http.StatusMethodNotAllowed, wantCode: "METHOD_NOT_ALLOWED", wantAllow: http.MethodGet},
 		{name: "unknown route does not disclose authentication", method: http.MethodGet, path: "/api/v1/not-a-route", wantStatus: http.StatusNotFound, wantCode: "API_ROUTE_NOT_FOUND"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -95,6 +96,9 @@ func TestPublicAPIRouterErrorsUseAuthenticatedProblemDetails(t *testing.T) {
 
 			if response.Code != tc.wantStatus || response.Header().Get("Content-Type") != "application/problem+json" {
 				t.Fatalf("response = %d %q body=%s", response.Code, response.Header().Get("Content-Type"), response.Body.String())
+			}
+			if got := response.Header().Get("Allow"); got != tc.wantAllow {
+				t.Errorf("Allow = %q, want %q", got, tc.wantAllow)
 			}
 			var problem apigenapi.ProblemDetails
 			if err := json.Unmarshal(response.Body.Bytes(), &problem); err != nil {

--- a/internal/app/api_protocol_test.go
+++ b/internal/app/api_protocol_test.go
@@ -52,6 +52,61 @@ func TestAPIGenResponseBufferNormalizesLegacyErrorsAsProblemDetails(t *testing.T
 	}
 }
 
+func TestAPIGenResponseBufferCompletesProblemDetailsIdentifiers(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces?limit=bad", nil)
+	req.Header.Set("X-Request-ID", "req_existing_problem")
+	recorder := httptest.NewRecorder()
+	buffer := newAPIGenResponseBuffer(recorder, req)
+	buffer.Header().Set("Content-Type", "application/problem+json")
+	buffer.WriteHeader(http.StatusBadRequest)
+	_, _ = buffer.Write([]byte(`{"type":"https://libredash.dev/problems/invalid","title":"Bad Request","status":400,"detail":"invalid limit","instance":"","code":"INVALID_LIMIT","requestId":"","errors":null}`))
+	buffer.flush()
+
+	var problem apigenapi.ProblemDetails
+	if err := json.Unmarshal(recorder.Body.Bytes(), &problem); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if problem.Instance != "/api/v1/workspaces" || problem.RequestId != "req_existing_problem" || problem.Errors == nil {
+		t.Fatalf("problem identifiers were not completed: %#v", problem)
+	}
+}
+
+func TestPublicAPIRouterErrorsUseAuthenticatedProblemDetails(t *testing.T) {
+	server := NewWithOptions(fakeMetrics{}, Options{Store: testStore(t)})
+	handler := server.Routes()
+
+	for _, tc := range []struct {
+		name          string
+		method        string
+		path          string
+		authorization string
+		wantStatus    int
+		wantCode      string
+	}{
+		{name: "unknown route", method: http.MethodGet, path: "/api/v1/not-a-route", authorization: "Bearer dev", wantStatus: http.StatusNotFound, wantCode: "API_ROUTE_NOT_FOUND"},
+		{name: "unsupported method", method: http.MethodPost, path: "/api/v1/workspaces", authorization: "Bearer dev", wantStatus: http.StatusMethodNotAllowed, wantCode: "METHOD_NOT_ALLOWED"},
+		{name: "unknown route does not disclose authentication", method: http.MethodGet, path: "/api/v1/not-a-route", wantStatus: http.StatusNotFound, wantCode: "API_ROUTE_NOT_FOUND"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := httptest.NewRequest(tc.method, tc.path, nil)
+			request.Header.Set("Authorization", tc.authorization)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+
+			if response.Code != tc.wantStatus || response.Header().Get("Content-Type") != "application/problem+json" {
+				t.Fatalf("response = %d %q body=%s", response.Code, response.Header().Get("Content-Type"), response.Body.String())
+			}
+			var problem apigenapi.ProblemDetails
+			if err := json.Unmarshal(response.Body.Bytes(), &problem); err != nil {
+				t.Fatalf("decode problem: %v", err)
+			}
+			if problem.Code != tc.wantCode || problem.Instance != tc.path || problem.RequestId == "" || problem.RequestId != response.Header().Get("X-Request-ID") || problem.Errors == nil {
+				t.Fatalf("problem = %#v headers=%#v", problem, response.Header())
+			}
+		})
+	}
+}
+
 func TestAPIGenTransportErrorsUseProblemDetailsWithoutLeakingCause(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects?limit=bad", nil)
 	req.Header.Set("X-Request-ID", "req_transport")

--- a/internal/app/keyset_pagination.go
+++ b/internal/app/keyset_pagination.go
@@ -43,7 +43,7 @@ func keysetPage[T any](items []T, limitValue *int32, tokenValue *string, key fun
 	if end > len(items) {
 		end = len(items)
 	}
-	page := append([]T(nil), items[start:end]...)
+	page := append(make([]T, 0, end-start), items[start:end]...)
 	var next *string
 	if end < len(items) && len(page) > 0 {
 		value := encodeKeysetCursor(key(page[len(page)-1]))

--- a/internal/app/keyset_pagination_test.go
+++ b/internal/app/keyset_pagination_test.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestKeysetPagePreservesEmptyArray(t *testing.T) {
+	items, next, err := keysetPage([]string(nil), nil, nil, func(value string) string { return value })
+	encoded, marshalErr := json.Marshal(items)
+	if err != nil || marshalErr != nil || next != nil || string(encoded) != "[]" {
+		t.Fatalf("empty page = %s, next=%v, error=%v/%v; want []", encoded, next, err, marshalErr)
+	}
+}

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -143,7 +144,9 @@ func (s *Server) Routes() http.Handler {
 		}
 		http.NotFound(w, r)
 	})
+	registeredMethods := registeredRouteMethods(mux)
 	mux.MethodNotAllowed(func(w http.ResponseWriter, r *http.Request) {
+		setAllowedMethods(w.Header(), mux, registeredMethods, r.URL.Path)
 		if isPublicAPIPath(r.URL.Path) {
 			if s.authenticatePublicAPIRequest(w, r) {
 				writeAPIProblem(w, r, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "The requested method is not supported for this API route", nil)
@@ -154,6 +157,30 @@ func (s *Server) Routes() http.Handler {
 	})
 
 	return mux
+}
+
+func registeredRouteMethods(routes chi.Routes) []string {
+	registered := make(map[string]struct{})
+	_ = chi.Walk(routes, func(method, _ string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		if method != "*" {
+			registered[method] = struct{}{}
+		}
+		return nil
+	})
+	methods := make([]string, 0, len(registered))
+	for method := range registered {
+		methods = append(methods, method)
+	}
+	sort.Strings(methods)
+	return methods
+}
+
+func setAllowedMethods(header http.Header, routes chi.Routes, methods []string, path string) {
+	for _, method := range methods {
+		if routes.Match(chi.NewRouteContext(), method, path) {
+			header.Add("Allow", method)
+		}
+	}
 }
 
 func isPublicAPIPath(path string) bool {

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -135,8 +135,29 @@ func (s *Server) Routes() http.Handler {
 		})
 	}
 	mux.Handle("/static/*", staticAssetCache(http.StripPrefix("/static/", http.FileServer(http.Dir("static")))))
+	mux.NotFound(func(w http.ResponseWriter, r *http.Request) {
+		if isPublicAPIPath(r.URL.Path) {
+			preparePublicAPIRequest(w, r)
+			writeAPIProblem(w, r, http.StatusNotFound, "API_ROUTE_NOT_FOUND", "The requested API route does not exist", nil)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	mux.MethodNotAllowed(func(w http.ResponseWriter, r *http.Request) {
+		if isPublicAPIPath(r.URL.Path) {
+			if s.authenticatePublicAPIRequest(w, r) {
+				writeAPIProblem(w, r, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "The requested method is not supported for this API route", nil)
+			}
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	})
 
 	return mux
+}
+
+func isPublicAPIPath(path string) bool {
+	return path == "/api/v1" || strings.HasPrefix(path, "/api/v1/") || path == "/upload-protocols" || strings.HasPrefix(path, "/upload-protocols/")
 }
 
 func redirectLegacyChat(w http.ResponseWriter, r *http.Request) {

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -568,6 +568,7 @@ func TestDevelopmentServerTracksCompiledFallbackProcess(t *testing.T) {
 	for _, want := range []string{
 		`go build -o "$TMP_DIR/libredash-dev" ./cmd/libredash`,
 		`"$TMP_DIR/libredash-dev" >> "$LOG_FILE" 2>&1 &`,
+		`LIBREDASH_MANAGED_DATA_MIN_FREE_BYTES="${LIBREDASH_MANAGED_DATA_MIN_FREE_BYTES:-67108864}"`,
 	} {
 		if !strings.Contains(serverText, want) {
 			t.Fatalf("development server script missing tracked binary fragment %q", want)

--- a/internal/cli/data_sync.go
+++ b/internal/cli/data_sync.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -113,6 +114,29 @@ func runDataSync(ctx context.Context, request dataSyncRequest) error {
 	if err := validateSyncSession(session, request.ProjectID, request.Connection, request.Plan.Manifest); err != nil {
 		return err
 	}
+	if session.Status != apigenapi.ManagedDataUploadSessionStatusCompleted {
+		session, err = client.getUploadSession(ctx, request.ProjectID, request.Connection, session.Id)
+		if err != nil {
+			return err
+		}
+		if err := validateSyncSession(session, request.ProjectID, request.Connection, request.Plan.Manifest); err != nil {
+			return err
+		}
+	}
+	if terminalUploadSessionStatus(session.Status) {
+		recoveryID, recoveryErr := newDataSyncRecoveryID()
+		if recoveryErr != nil {
+			return recoveryErr
+		}
+		recoveryKey := dataSyncIdempotencyKey("recover", request.ProjectID, request.Connection, revisionID, recoveryID)
+		session, err = client.createUploadSession(ctx, request.ProjectID, request.Connection, recoveryKey, apigenapi.ManagedDataUploadSessionCreateRequest{Manifest: wireManifest})
+		if err != nil {
+			return err
+		}
+		if err := validateSyncSession(session, request.ProjectID, request.Connection, request.Plan.Manifest); err != nil {
+			return err
+		}
+	}
 	if session.Status == apigenapi.ManagedDataUploadSessionStatusFinalizing {
 		session, err = waitForUploadFinalization(ctx, client, request.ProjectID, request.Connection, session.Id, request.Plan.Manifest, session)
 		if err != nil {
@@ -154,6 +178,23 @@ func runDataSync(ctx context.Context, request dataSyncRequest) error {
 	}
 	_, err = fmt.Fprintf(out, "staged %s\n", revisionID)
 	return err
+}
+
+func terminalUploadSessionStatus(status apigenapi.ManagedDataUploadSessionStatus) bool {
+	switch status {
+	case apigenapi.ManagedDataUploadSessionStatusCancelled, apigenapi.ManagedDataUploadSessionStatusFailed, apigenapi.ManagedDataUploadSessionStatusExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+func newDataSyncRecoveryID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate managed data recovery identity: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
 }
 
 func waitForUploadFinalization(ctx context.Context, client *managedDataCLIClient, project, connection, uploadID string, manifest manageddata.Manifest, current apigenapi.ManagedDataUploadSessionResponse) (apigenapi.ManagedDataUploadSessionResponse, error) {
@@ -203,6 +244,9 @@ func waitForUploadFinalization(ctx context.Context, client *managedDataCLIClient
 func transferManagedDataFile(ctx context.Context, client *managedDataCLIClient, request dataSyncRequest, uploadID string, file manageddata.File, upload apigenapi.ManagedDataFileUploadResponse) error {
 	if upload.File.Path != file.Path || int64(upload.File.Size) != file.Size || upload.File.Sha256 != file.SHA256 {
 		return fmt.Errorf("upload session file metadata does not match %q", file.Path)
+	}
+	if upload.Negotiation == nil {
+		return fmt.Errorf("upload instructions are unavailable for %q", file.Path)
 	}
 	switch upload.Negotiation.Protocol {
 	case apigenapi.ManagedDataUploadProtocolAlreadyPresent:
@@ -616,9 +660,6 @@ func validateSyncSession(session apigenapi.ManagedDataUploadSessionResponse, pro
 		if session.Manifest.Files[index] != wire.Files[index] {
 			return fmt.Errorf("upload session manifest does not match the planned revision")
 		}
-	}
-	if session.Status != apigenapi.ManagedDataUploadSessionStatusOpen && session.Status != apigenapi.ManagedDataUploadSessionStatusFinalizing && session.Status != apigenapi.ManagedDataUploadSessionStatusCompleted {
-		return fmt.Errorf("upload session is not usable")
 	}
 	if len(session.Files) != len(manifest.Files) {
 		return fmt.Errorf("upload session file set does not match the planned revision")

--- a/internal/cli/data_sync_test.go
+++ b/internal/cli/data_sync_test.go
@@ -34,7 +34,7 @@ func TestDataSyncDeduplicatesAndUsesStableIdempotencyKey(t *testing.T) {
 		keys = append(keys, r.Header.Get("Idempotency-Key"))
 		writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusCompleted, []apigenapi.ManagedDataFileUploadResponse{{
 			File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusSkipped,
-			Negotiation: apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolAlreadyPresent},
+			Negotiation: uploadNegotiation(apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolAlreadyPresent}),
 		}})
 	}))
 	defer server.Close()
@@ -67,10 +67,11 @@ func TestDataSyncResumesTusFromHEADOffset(t *testing.T) {
 	var patched []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/upload-sessions"):
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/upload-sessions"),
+			r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/upload-sessions/upload-1"):
 			writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusOpen, []apigenapi.ManagedDataFileUploadResponse{{
 				File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusUploading,
-				Negotiation: apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolTus, Tus: &apigenapi.ManagedDataTusUploadNegotiation{Endpoint: "/tus", UploadId: "blob-1", Offset: 0, ExpiresAt: "2030-01-01T00:00:00Z"}},
+				Negotiation: uploadNegotiation(apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolTus, Tus: &apigenapi.ManagedDataTusUploadNegotiation{Endpoint: "/tus", UploadId: "blob-1", Offset: 0, ExpiresAt: "2030-01-01T00:00:00Z"}}),
 			}})
 		case r.URL.Path == "/tus/blob-1" && r.Method == http.MethodHead:
 			mu.Lock()
@@ -102,7 +103,7 @@ func TestDataSyncResumesTusFromHEADOffset(t *testing.T) {
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/finalize"):
 			writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusCompleted, []apigenapi.ManagedDataFileUploadResponse{{
 				File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusVerified,
-				Negotiation: apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolAlreadyPresent},
+				Negotiation: uploadNegotiation(apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolAlreadyPresent}),
 			}})
 		default:
 			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
@@ -127,7 +128,7 @@ func TestDataSyncWaitsForAsynchronousFinalization(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		files := []apigenapi.ManagedDataFileUploadResponse{{
 			File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusSkipped,
-			Negotiation: apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolAlreadyPresent},
+			Negotiation: uploadNegotiation(apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolAlreadyPresent}),
 		}}
 		switch {
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/upload-sessions"):
@@ -153,6 +154,44 @@ func TestDataSyncWaitsForAsynchronousFinalization(t *testing.T) {
 	}
 	if getCalls != 2 {
 		t.Fatalf("upload status GET calls = %d, want 2", getCalls)
+	}
+}
+
+func TestDataSyncReplacesAReplayedTerminalUploadSession(t *testing.T) {
+	root := t.TempDir()
+	file := writeSyncFile(t, root, "orders.csv", []byte("order_id\n1\n"))
+	plan := syncPlan(root, file)
+	var createKeys []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/upload-sessions"):
+			createKeys = append(createKeys, r.Header.Get("Idempotency-Key"))
+			if len(createKeys) == 1 {
+				writeUploadSession(t, w, plan, "upload-stale", apigenapi.ManagedDataUploadSessionStatusOpen, []apigenapi.ManagedDataFileUploadResponse{{
+					File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusUploading,
+					Negotiation: uploadNegotiation(apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolTus, Tus: &apigenapi.ManagedDataTusUploadNegotiation{Endpoint: "/tus", UploadId: "missing", ExpiresAt: "2030-01-01T00:00:00Z"}}),
+				}})
+				return
+			}
+			writeUploadSession(t, w, plan, "upload-replacement", apigenapi.ManagedDataUploadSessionStatusCompleted, []apigenapi.ManagedDataFileUploadResponse{{
+				File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusSkipped,
+			}})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/upload-sessions/upload-stale"):
+			writeUploadSession(t, w, plan, "upload-stale", apigenapi.ManagedDataUploadSessionStatusCancelled, []apigenapi.ManagedDataFileUploadResponse{{
+				File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusSkipped,
+			}})
+		default:
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	err := runDataSync(context.Background(), dataSyncRequest{ProjectID: "demo", Connection: "orders", Root: root, Target: server.URL, Token: "secret-token", Plan: plan, Out: io.Discard, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("runDataSync() error = %v", err)
+	}
+	if len(createKeys) != 2 || createKeys[0] == "" || createKeys[1] == "" || createKeys[0] == createKeys[1] {
+		t.Fatalf("create idempotency keys = %#v", createKeys)
 	}
 }
 
@@ -192,6 +231,16 @@ func TestDataSyncRetriesTusCapacityFailureAndReportsHTTPStatus(t *testing.T) {
 	}
 }
 
+func TestDataSyncRejectsMissingUploadInstructionsWithoutPanicking(t *testing.T) {
+	file := manageddata.File{Path: "orders.csv", Size: 3, SHA256: strings.Repeat("a", 64)}
+	err := transferManagedDataFile(context.Background(), nil, dataSyncRequest{}, "upload-1", file, apigenapi.ManagedDataFileUploadResponse{
+		File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusPending,
+	})
+	if err == nil || !strings.Contains(err.Error(), "upload instructions are unavailable") {
+		t.Fatalf("missing negotiation error = %v", err)
+	}
+}
+
 func TestDataSyncUploadsDeterministicS3PartsWithoutBearerToken(t *testing.T) {
 	root := t.TempDir()
 	body := []byte("abcdefghij")
@@ -204,11 +253,14 @@ func TestDataSyncUploadsDeterministicS3PartsWithoutBearerToken(t *testing.T) {
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/upload-sessions"):
-			mutationKeys = append(mutationKeys, r.Header.Get("Idempotency-Key"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/upload-sessions"),
+			r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/upload-sessions/upload-1"):
+			if r.Method == http.MethodPost {
+				mutationKeys = append(mutationKeys, r.Header.Get("Idempotency-Key"))
+			}
 			writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusOpen, []apigenapi.ManagedDataFileUploadResponse{{
 				File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusPending,
-				Negotiation: apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolS3Multipart, S3Multipart: &apigenapi.ManagedDataS3MultipartNegotiation{CreateEndpoint: "/unused", MinimumPartSize: 4, MaximumPartSize: 6, MaximumParts: 3}},
+				Negotiation: uploadNegotiation(apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolS3Multipart, S3Multipart: &apigenapi.ManagedDataS3MultipartNegotiation{CreateEndpoint: "/unused", MinimumPartSize: 4, MaximumPartSize: 6, MaximumParts: 3}}),
 			}})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/s3-multipart-uploads"):
 			mutationKeys = append(mutationKeys, r.Header.Get("Idempotency-Key"))
@@ -236,7 +288,7 @@ func TestDataSyncUploadsDeterministicS3PartsWithoutBearerToken(t *testing.T) {
 			writeJSONTest(t, w, http.StatusOK, apigenapi.ManagedDataS3MultipartUploadResponse{Id: "multipart-1", UploadSessionId: "upload-1", File: wireFile(t, file), Status: apigenapi.ManagedDataS3MultipartStatusCompleted, CreatedAt: "2026-01-01T00:00:00Z"})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/finalize"):
 			mutationKeys = append(mutationKeys, r.Header.Get("Idempotency-Key"))
-			writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusCompleted, []apigenapi.ManagedDataFileUploadResponse{{File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusVerified, Negotiation: apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolAlreadyPresent}}})
+			writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusCompleted, []apigenapi.ManagedDataFileUploadResponse{{File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusVerified, Negotiation: uploadNegotiation(apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolAlreadyPresent})}})
 		default:
 			t.Fatalf("request = %s %s", r.Method, r.URL.String())
 		}
@@ -276,8 +328,9 @@ func TestDataSyncDetectsMutationAndSanitizesSignedURL(t *testing.T) {
 	var aborted bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/upload-sessions"):
-			writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusOpen, []apigenapi.ManagedDataFileUploadResponse{{File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusPending, Negotiation: apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolS3Multipart, S3Multipart: &apigenapi.ManagedDataS3MultipartNegotiation{MinimumPartSize: 4, MaximumPartSize: 6, MaximumParts: 3}}}})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/upload-sessions"),
+			r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/upload-sessions/upload-1"):
+			writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusOpen, []apigenapi.ManagedDataFileUploadResponse{{File: wireFile(t, file), Status: apigenapi.ManagedDataFileUploadStatusPending, Negotiation: uploadNegotiation(apigenapi.ManagedDataUploadNegotiation{Protocol: apigenapi.ManagedDataUploadProtocolS3Multipart, S3Multipart: &apigenapi.ManagedDataS3MultipartNegotiation{MinimumPartSize: 4, MaximumPartSize: 6, MaximumParts: 3}})}})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/cancel"):
 			aborted = true
 			writeUploadSession(t, w, plan, "upload-1", apigenapi.ManagedDataUploadSessionStatusCancelled, nil)
@@ -319,6 +372,10 @@ func TestSignedPartFailureDoesNotExposeSignedURL(t *testing.T) {
 
 func syncPlan(root string, file manageddata.File) localplan.Result {
 	return localplan.Result{Connection: "orders", Root: root, Manifest: manageddata.Manifest{Files: []manageddata.File{file}}}
+}
+
+func uploadNegotiation(value apigenapi.ManagedDataUploadNegotiation) *apigenapi.ManagedDataUploadNegotiation {
+	return &value
 }
 
 func writeSyncFile(t *testing.T, root, name string, body []byte) manageddata.File {

--- a/internal/manageddata/http/handler.go
+++ b/internal/manageddata/http/handler.go
@@ -698,10 +698,18 @@ func uploadResponse(result control.UploadResult, project, connection, expectedID
 		fileStatus := apigenapi.ManagedDataFileUploadStatusPending
 		if file.Status == control.FileStatusVerified {
 			fileStatus = apigenapi.ManagedDataFileUploadStatusVerified
+		} else if result.Status == manageddata.UploadStatusFailed {
+			fileStatus = apigenapi.ManagedDataFileUploadStatusFailed
+		} else if result.Status == manageddata.UploadStatusAborted || result.Status == manageddata.UploadStatusExpired {
+			fileStatus = apigenapi.ManagedDataFileUploadStatusSkipped
 		}
-		negotiation, err := negotiationToWire(file.Transport)
-		if err != nil {
-			return apigenapi.ManagedDataUploadSessionResponse{}, err
+		var negotiation *apigenapi.ManagedDataUploadNegotiation
+		if file.Transport.Protocol != "" {
+			value, negotiationErr := negotiationToWire(file.Transport)
+			if negotiationErr != nil {
+				return apigenapi.ManagedDataUploadSessionResponse{}, negotiationErr
+			}
+			negotiation = &value
 		}
 		files[i] = apigenapi.ManagedDataFileUploadResponse{File: metadata, Status: fileStatus, Negotiation: negotiation}
 	}
@@ -846,7 +854,7 @@ func pageSlice[T any](items []T, limitValue *int32, tokenValue *string, scope st
 	if end < len(items) {
 		next = stringPointer(encodePageToken(scope, key(items[end-1])))
 	}
-	return append([]T(nil), items[start:end]...), next, nil
+	return append(make([]T, 0, end-start), items[start:end]...), next, nil
 }
 
 type pageToken struct {

--- a/internal/manageddata/http/handler_test.go
+++ b/internal/manageddata/http/handler_test.go
@@ -138,6 +138,30 @@ func TestUploadSessionsAreListedFromCollectionMetadata(t *testing.T) {
 	}
 }
 
+func TestCancelledUploadSessionResponseDoesNotRequireActiveNegotiation(t *testing.T) {
+	repo := metadataFixture()
+	repo.uploadSessions = []manageddata.UploadSession{{ID: "upload-a", CollectionID: "collection-a", CreatedAt: "2026-01-01T00:00:00Z"}}
+	result := uploadFixture()
+	result.Status = manageddata.UploadStatusAborted
+	result.Files[0].Transport = control.TransportDescription{}
+	handler := newHandler(repo, &fakeUploads{result: result}, nil)
+
+	recorder := call(t, ``, func(w http.ResponseWriter, r *http.Request) {
+		handler.ListManagedDataUploadSessions(w, r, "project-a", "orders", apigenapi.GenListManagedDataUploadSessionsParams{})
+	})
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response map[string]any
+	decodeResponse(t, recorder, &response)
+	items := response["items"].([]any)
+	files := items[0].(map[string]any)["files"].([]any)
+	file := files[0].(map[string]any)
+	if _, present := file["negotiation"]; present {
+		t.Fatalf("terminal file retained upload negotiation: %#v", file)
+	}
+}
+
 func TestMultipartOperationsAreSDKFreeAndScopedToUpload(t *testing.T) {
 	uploadResult := uploadFixture()
 	uploadResult.Files[0].Transport = control.TransportDescription{Protocol: control.ProtocolS3Multipart, S3Multipart: &control.S3MultipartDescription{CreateEndpoint: "/multipart", MinimumPartSize: 1, MaximumPartSize: 1024, MaximumParts: 100}}

--- a/internal/manageddata/http/pagination_internal_test.go
+++ b/internal/manageddata/http/pagination_internal_test.go
@@ -1,0 +1,14 @@
+package http
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPageSliceForRequestPreservesEmptyArray(t *testing.T) {
+	items, _, pageErr := pageSlice([]string(nil), nil, nil, "test", func(value string) string { return value })
+	encoded, err := json.Marshal(items)
+	if err != nil || pageErr != nil || string(encoded) != "[]" {
+		t.Fatalf("empty page = %s, error=%v/%v; want []", encoded, pageErr, err)
+	}
+}

--- a/internal/manageddata/storage/tus/engine_test.go
+++ b/internal/manageddata/storage/tus/engine_test.go
@@ -147,6 +147,13 @@ func TestHTTPHandlerCompletesTusUploadIntoBlobStore(t *testing.T) {
 	if _, err := blobs.Stat(t.Context(), expected.SHA256); err != nil {
 		t.Fatalf("completed tus upload was not finalized: %v", err)
 	}
+	uploadID := filepath.Base(location.Path)
+	if err := engine.Abort(t.Context(), uploadID); err != nil {
+		t.Fatalf("Abort() after HTTP completion = %v", err)
+	}
+	if err := engine.Abort(t.Context(), uploadID); err != nil {
+		t.Fatalf("idempotent Abort() after HTTP completion = %v", err)
+	}
 }
 
 func TestHTTPHandlerRejectsMissingOrInvalidDigestMetadata(t *testing.T) {

--- a/internal/workspace/http/handler.go
+++ b/internal/workspace/http/handler.go
@@ -1338,7 +1338,7 @@ func pageSliceForRequest[T any](w nethttp.ResponseWriter, r *nethttp.Request, it
 	if end < len(items) {
 		nextCursor = encodeKeysetCursor(workspacePageItemKey(items[end-1]))
 	}
-	return append([]T(nil), items[start:end]...), nextCursor, true
+	return append(make([]T, 0, end-start), items[start:end]...), nextCursor, true
 }
 
 const (

--- a/internal/workspace/http/pagination_internal_test.go
+++ b/internal/workspace/http/pagination_internal_test.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"encoding/json"
+	nethttp "net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPageSliceForRequestPreservesEmptyArray(t *testing.T) {
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(nethttp.MethodGet, "/api/v1/workspaces", nil)
+	items, _, ok := pageSliceForRequest[string](response, request, nil)
+	assertEmptyJSONArray(t, items, ok)
+}
+
+func assertEmptyJSONArray[T any](t *testing.T, items []T, ok bool) {
+	t.Helper()
+	encoded, err := json.Marshal(items)
+	if err != nil || !ok || string(encoded) != "[]" {
+		t.Fatalf("empty page = %s, ok=%v, error=%v; want []", encoded, ok, err)
+	}
+}

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -330,6 +330,7 @@ start() {
   export PORT="$port"
   export LIBREDASH_ADDR=":$port"
   export LIBREDASH_DEV_WORKTREE="$ROOT"
+  export LIBREDASH_MANAGED_DATA_MIN_FREE_BYTES="${LIBREDASH_MANAGED_DATA_MIN_FREE_BYTES:-67108864}"
 
   : > "$LOG_FILE"
   if [[ "$runner" == "air" ]]; then

--- a/web/components/admin/admin-page.dom.test.ts
+++ b/web/components/admin/admin-page.dom.test.ts
@@ -82,6 +82,10 @@ for (const viewport of [
           mainConstrained: isMobile || Math.round(mainRect.width) < Math.round(availableRight - availableLeft),
           hasRecordTable: Boolean(root.querySelector('ld-record-table')),
           recordTableVariant: root.querySelector('ld-record-table')?.getAttribute('variant'),
+          documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+          mainRight: Math.round(mainRect.right),
+          sidebarRight: Math.round(sidebarRect.right),
+          formRight: Math.round((root.querySelector('.local-user-form') as HTMLElement).getBoundingClientRect().right),
           text: root.textContent,
         }
       })
@@ -97,6 +101,12 @@ for (const viewport of [
       expect(state.hasRecordTable).toBe(true)
       expect(state.recordTableVariant).toBe('compact')
       expect(state.text ?? '').toMatch(/analyst@example\.com/)
+      if (viewport.width <= 640) {
+        expect(state.documentOverflow).toBe(0)
+        expect(state.mainRight).toBeLessThanOrEqual(viewport.width)
+        expect(state.sidebarRight).toBeLessThanOrEqual(viewport.width)
+        expect(state.formRight).toBeLessThanOrEqual(viewport.width)
+      }
     } finally {
       await page.close()
     }
@@ -1665,6 +1675,9 @@ function testDocument(): string {
         { id: 'general', title: 'General', href: '/admin', active: false },
         { id: 'principals', title: 'Principals', href: '/admin/principals', active: true },
         { id: 'groups', title: 'Groups', href: '/admin/groups', active: false },
+        { id: 'agent', title: 'Agent', href: '/admin/agent', active: false },
+        { id: 'storage', title: 'Storage', href: '/admin/storage', active: false },
+        { id: 'queries', title: 'Queries', href: '/admin/queries', active: false },
       ],
     },
     headerTitle: 'Principals',
@@ -1676,8 +1689,11 @@ function testDocument(): string {
           { id: 'name', header: 'Name', kind: 'link', hrefKey: 'name_href' },
           { id: 'email', header: 'Email' },
           { id: 'roles', header: 'Direct roles', kind: 'tags' },
+          { id: 'kind', header: 'Kind' },
+          { id: 'status', header: 'Status' },
+          { id: 'created', header: 'Created' },
         ],
-        rows: [{ name: 'Analyst', name_href: '/admin/principals/p1', email: 'analyst@example.com', roles: ['viewer'] }],
+        rows: [{ name: 'Analyst', name_href: '/admin/principals/p1', email: 'analyst@example.com', roles: ['viewer'], kind: 'local user', status: 'active', created: '2026-07-20' }],
         empty: 'No principals found.',
       },
     }],

--- a/web/components/admin/admin-page.ts
+++ b/web/components/admin/admin-page.ts
@@ -268,6 +268,10 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
       padding: 0 var(--base-size-12);
     }
 
+    .section {
+      min-width: 0;
+    }
+
     .local-user-action:hover,
     .local-user-action:focus-visible {
       background: var(--ld-bg-control-hover);
@@ -585,6 +589,14 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
 
       .main {
         padding: var(--base-size-12);
+      }
+
+      .local-user-form {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .local-user-action {
+        width: 100%;
       }
 
       .query-detail-drawer {

--- a/web/components/app/catalog-page.dom.test.ts
+++ b/web/components/app/catalog-page.dom.test.ts
@@ -78,6 +78,28 @@ test('catalog page composes dashboard cards', async () => {
   }
 })
 
+test('catalog page explains an empty dashboard collection', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('ld-catalog-page'))
+    const state = await page.locator('ld-catalog-page').evaluate(async (element: any) => {
+      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev') as any
+      mergePatch({ page: { ...element.page, dashboards: [] } })
+      await element.updateComplete
+      return {
+        empty: element.shadowRoot.querySelector('[role="status"]')?.textContent?.trim(),
+        cards: element.shadowRoot.querySelectorAll('article').length,
+      }
+    })
+
+    expect(state.empty).toContain('No dashboards')
+    expect(state.cards).toBe(0)
+  } finally {
+    await page.close()
+  }
+})
+
 function testDocument(): string {
   const page = {
     kind: 'catalog',

--- a/web/components/app/catalog-page.ts
+++ b/web/components/app/catalog-page.ts
@@ -64,6 +64,24 @@ class LibreDashCatalogPage extends DatastarLit(LitElement) {
       justify-content: start;
     }
 
+    .empty {
+      display: grid;
+      min-height: 10rem;
+      place-content: center;
+      gap: var(--base-size-4);
+      border: var(--ld-border-muted);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-panel);
+      color: var(--ld-fg-muted);
+      padding: var(--base-size-20);
+      text-align: center;
+    }
+
+    .empty strong {
+      color: var(--ld-fg-default);
+      font-size: var(--ld-font-size-body-md);
+    }
+
     article {
       display: grid;
       min-height: 10rem;
@@ -162,7 +180,7 @@ class LibreDashCatalogPage extends DatastarLit(LitElement) {
           <h1>${page.title}</h1>
           <p class="detail">${page.description}</p>
         </header>
-        <div class="grid">
+        ${page.dashboards.length ? html`<div class="grid">
           ${page.dashboards.map((dashboard) => html`
             <article>
               <div>
@@ -179,7 +197,12 @@ class LibreDashCatalogPage extends DatastarLit(LitElement) {
               </footer>
             </article>
           `)}
-        </div>
+        </div>` : html`
+          <div class="empty" role="status">
+            <strong>No dashboards are available.</strong>
+            <span>Deploy a project with a dashboard to see it here.</span>
+          </div>
+        `}
       </section>
     `
   }


### PR DESCRIPTION
## Summary

- make development managed-data sync recover from low disk reserves and replayed terminal upload sessions
- fix terminal upload serialization, empty pagination arrays, and consistent API problem responses
- add dashboard empty-state guidance and contain the mobile admin layout
- add focused regression coverage across CLI, API, managed data, pagination, and browser DOM tests

## Verification

- go test ./...
- go vet ./...
- go test -race ./pkg/... ./internal/access ./internal/runtimehost
- task generated:check
- task qa:ui-framework
- task deploy:check
- live task dev sync and deployment
- desktop and 390px browser dogfood pass