### PR TITLE
Rename workspace catalog signal items

### DIFF
--- a/api/signals/main.tsp
+++ b/api/signals/main.tsp
@@ -1412,11 +1412,10 @@ model WorkspaceBreadcrumbSignal {
 
 @apigen.contract(#{ kind: "ui-signal", tags: #["workspace", "signal"] })
 @apigen.`metadata`(#{ `x-libredash-contract-role`: "signal", `x-libredash-surface`: "workspace" })
-model WorkspaceCardSignal {
+model WorkspaceCatalogItemSignal {
   `description`: string;
   `href`: string;
   `id`: string;
-  `servingLabel`: string;
   `title`: string;
 }
 
@@ -1449,12 +1448,12 @@ model WorkspacePageEnvelope {
 @apigen.`metadata`(#{ `x-libredash-contract-role`: "signal", `x-libredash-surface`: "workspace" })
 model WorkspacePageSignal {
   `assetList`?: WorkspaceAssetListSignal;
-  `cards`?: WorkspaceCardSignal[];
   `description`?: string;
   `environment`?: string;
   `kind`: RouteKind;
   `title`: string;
   `workspaceId`?: string;
+  `workspaces`?: WorkspaceCatalogItemSignal[];
 }
 
 @apigen.contract(#{ kind: "ui-signal", tags: #["workspace", "signal"] })

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -155,7 +155,7 @@ func workspaceCatalogPageSignal(workspaces []workspaceview.WorkspaceView) uisign
 		Kind:        uisignals.RouteWorkspace,
 		Title:       "Workspaces",
 		Description: uisignals.Pointer("View published BI workspaces. Authoring lives in Git."),
-		Cards:       uisignals.OptionalSlice(workspaceCardSignals(workspaces)),
+		Workspaces:  uisignals.OptionalSlice(workspaceCatalogItemSignals(workspaces)),
 	}
 }
 
@@ -199,22 +199,21 @@ func connectionsPageSignal(workspaceID string, assets []workspaceview.AssetView,
 	}
 }
 
-func workspaceCardSignals(workspaces []workspaceview.WorkspaceView) []uisignals.WorkspaceCardSignal {
-	cards := make([]uisignals.WorkspaceCardSignal, 0, len(workspaces))
+func workspaceCatalogItemSignals(workspaces []workspaceview.WorkspaceView) []uisignals.WorkspaceCatalogItemSignal {
+	items := make([]uisignals.WorkspaceCatalogItemSignal, 0, len(workspaces))
 	for _, workspace := range workspaces {
 		description := workspace.Description
 		if strings.TrimSpace(description) == "" {
 			description = "Published workspace assets."
 		}
-		cards = append(cards, uisignals.WorkspaceCardSignal{
-			ID:           workspace.ID,
-			Title:        workspace.Title,
-			Description:  description,
-			Href:         "/workspaces/" + workspace.ID,
-			ServingLabel: workspaceServingLabel(workspace),
+		items = append(items, uisignals.WorkspaceCatalogItemSignal{
+			ID:          workspace.ID,
+			Title:       workspace.Title,
+			Description: description,
+			Href:        "/workspaces/" + workspace.ID,
 		})
 	}
-	return cards
+	return items
 }
 
 func workspaceAssetListSignal(workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeType, query string, tabs []uisignals.WorkspaceTabSignal, empty, searchHref string) uisignals.WorkspaceAssetListSignal {
@@ -760,13 +759,6 @@ func workspaceRouteUpdatesURL(routeKind uisignals.RouteKind, catalog dashboard.C
 	default:
 		return updatesURL(routeKind)
 	}
-}
-
-func workspaceServingLabel(workspace workspaceview.WorkspaceView) string {
-	if workspace.ActiveServingStateID == "" {
-		return "Not serving"
-	}
-	return "Serving"
 }
 
 func connectionAssetListHref(typ, query string) string {

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"encoding/json"
 	"fmt"
 	"html"
 	"strings"
@@ -10,6 +11,29 @@ import (
 	uisignals "github.com/Yacobolo/libredash/internal/ui/signals"
 	workspaceview "github.com/Yacobolo/libredash/internal/workspace"
 )
+
+func TestWorkspaceCatalogSignalUsesWorkspaceItems(t *testing.T) {
+	page := workspaceCatalogPageSignal([]workspaceview.WorkspaceView{{
+		ID:                   "operations",
+		Title:                "Operations Workspace",
+		Description:          "Fulfillment and delivery analysis.",
+		ActiveServingStateID: "serving-state",
+	}})
+
+	items := uisignals.ValueOrZero(page.Workspaces)
+	if len(items) != 1 || items[0].ID != "operations" {
+		t.Fatalf("workspace catalog items = %#v, want operations workspace", items)
+	}
+	payload, err := json.Marshal(page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, stale := range []string{`"cards"`, `"servingLabel"`} {
+		if strings.Contains(string(payload), stale) {
+			t.Fatalf("workspace catalog payload contains stale field %s: %s", stale, payload)
+		}
+	}
+}
 
 func TestWorkspaceAssetDetailsRenderSharedShapeForSemanticModel(t *testing.T) {
 	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -212,10 +212,10 @@ for (const viewport of [
           kind: 'workspace',
           title: 'Workspaces',
           description: 'View published BI workspaces.',
-          cards: [
-            { id: 'operations', title: 'Operations Workspace', description: 'Fulfillment and delivery analysis.', href: '/workspaces/operations', servingLabel: 'Serving' },
-            { id: 'sales', title: 'Sales Workspace', description: 'Revenue, orders, and product category analysis.', href: '/workspaces/sales', servingLabel: 'Serving' },
-            { id: 'visuals', title: 'Visuals Workspace', description: 'Developer QA workspace for exhaustive dashboard visual and table renderer coverage.', href: '/workspaces/visuals', servingLabel: 'Serving' },
+          workspaces: [
+            { id: 'operations', title: 'Operations Workspace', description: 'Fulfillment and delivery analysis.', href: '/workspaces/operations' },
+            { id: 'sales', title: 'Sales Workspace', description: 'Revenue, orders, and product category analysis.', href: '/workspaces/sales' },
+            { id: 'visuals', title: 'Visuals Workspace', description: 'Developer QA workspace for exhaustive dashboard visual and table renderer coverage.', href: '/workspaces/visuals' },
           ],
         } })
       })
@@ -235,7 +235,6 @@ for (const viewport of [
           fullWidth: rows.every((row) => Math.abs(row.getBoundingClientRect().width - listRect.width) <= 1),
           maxRowHeight: Math.max(...rows.map((row) => Math.round(row.getBoundingClientRect().height))),
           totalListHeight: Math.round(listRect.height),
-          hasCardGrid: Boolean(element.shadowRoot.querySelector('.cards, article.card')),
           hasOpenButton: Boolean(element.shadowRoot.querySelector('.primary-link')),
         }
       })
@@ -250,7 +249,6 @@ for (const viewport of [
         fullWidth: true,
         maxRowHeight: 72,
         totalListHeight: 216,
-        hasCardGrid: false,
         hasOpenButton: false,
       })
     } finally {

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -88,7 +88,7 @@ class LibreDashWorkspacePage extends DatastarLit(LitElement) {
   render() {
     const page = this.page
     if (!page) return html`<slot></slot>`
-    if (page.cards?.length) return this.renderCatalog(page)
+    if (page.workspaces?.length) return this.renderCatalog(page)
     if (!page.assetList?.searchHref && this.workspaceAccess?.canManage) return this.renderAccessPage(page)
     return this.renderAssetList(page, 'Workspace', 'Workspace assets')
   }
@@ -98,13 +98,13 @@ class LibreDashWorkspacePage extends DatastarLit(LitElement) {
       <section class="page catalog" aria-label="LibreDash workspaces">
         ${this.renderHeader('', page.title, page.description)}
         <ul class="catalog-list workspace-list" aria-label="Published workspaces">
-          ${page.cards?.map((card) => html`
+          ${page.workspaces?.map((workspace) => html`
             <li>
-              <a class="catalog-row workspace-row" href=${card.href}>
+              <a class="catalog-row workspace-row" href=${workspace.href}>
                 <span class="catalog-icon workspace-icon">${lucideIcon(Boxes)}</span>
                 <span class="catalog-copy workspace-copy">
-                  <span class="catalog-title workspace-title">${card.title}</span>
-                  <span class="catalog-description workspace-description">${card.description}</span>
+                  <span class="catalog-title workspace-title">${workspace.title}</span>
+                  <span class="catalog-description workspace-description">${workspace.description}</span>
                 </span>
                 <span class="catalog-trailing">
                   <span class="catalog-chevron workspace-chevron">${lucideIcon(ChevronRight)}</span>


### PR DESCRIPTION
## Summary
- rename the workspace catalog payload from `cards` to `workspaces`
- replace `WorkspaceCardSignal` with `WorkspaceCatalogItemSignal`
- remove the unused `servingLabel` contract field and backend computation
- add backend serialization and responsive browser regression coverage

## Verification
- `task generate`
- `bun run test:workspace-page`
- `task ci`

## Dependency
Stacked on #105, which introduces the shared workspace/dashboard list UI.