### PR TITLE
Clean up workspace asset table

### DIFF
--- a/api/signals/main.tsp
+++ b/api/signals/main.tsp
@@ -1270,14 +1270,29 @@ model WorkspaceAccessCommand {
   `subjectType`: string;
 }
 
+model WorkspaceAccessCandidate {
+  `detail`: string;
+  `label`: string;
+  `subjectId`: string;
+  `subjectType`: string;
+}
+
+model WorkspaceAccessSearchStatus {
+  `error`: string;
+  `loading`: boolean;
+}
+
 model WorkspaceAccessResponse {
   `bindings`: unknown[];
+  `candidates`: WorkspaceAccessCandidate[];
   `canManage`: boolean;
   `mode`?: string;
   `objectId`?: string;
   `objectTitle`?: string;
   `objectType`?: string;
   `roles`: unknown[];
+  `search`: string;
+  `searchStatus`: WorkspaceAccessSearchStatus;
   `status`: WorkspaceAccessStatus;
   `workspace`: unknown;
 }
@@ -1286,6 +1301,7 @@ model WorkspaceAccessResponse {
 @apigen.`metadata`(#{ `x-libredash-contract-role`: "signal", `x-libredash-surface`: "workspace" })
 model WorkspaceAccessSignal {
   `bindings`: unknown[];
+  `candidates`: WorkspaceAccessCandidate[];
   `canManage`: boolean;
   `command`: WorkspaceAccessCommand;
   `mode`?: string;
@@ -1294,6 +1310,7 @@ model WorkspaceAccessSignal {
   `objectType`?: string;
   `roles`: unknown[];
   `search`: string;
+  `searchStatus`: WorkspaceAccessSearchStatus;
   `status`: WorkspaceAccessStatus;
   `workspace`: unknown;
 }

--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -608,6 +608,7 @@ type AuditEvent struct {
 type Repository interface {
 	PrincipalByID(ctx context.Context, id string) (Principal, error)
 	ListPrincipals(ctx context.Context, filter PrincipalFilter) ([]Principal, error)
+	SearchPrincipals(ctx context.Context, query string, limit int) ([]Principal, error)
 	UpsertPrincipal(ctx context.Context, input PrincipalInput) (Principal, error)
 	CreateLocalUser(ctx context.Context, input LocalUserInput) (LocalPasswordReset, error)
 	VerifyLocalPassword(ctx context.Context, email, password string) (Principal, LocalCredential, error)
@@ -655,6 +656,7 @@ type Repository interface {
 	DisableSCIMUser(ctx context.Context, principalID string) (SCIMUser, error)
 	UpsertGroup(ctx context.Context, input GroupInput) (Group, error)
 	ListGroups(ctx context.Context, workspaceID string) ([]Group, error)
+	SearchGroups(ctx context.Context, workspaceID, query string, limit int) ([]Group, error)
 	ListAllGroups(ctx context.Context) ([]Group, error)
 	DeleteGroup(ctx context.Context, workspaceID, groupID string) error
 	AddGroupMember(ctx context.Context, workspaceID, groupID, principalID string) error

--- a/internal/access/sqlite/identity.go
+++ b/internal/access/sqlite/identity.go
@@ -35,6 +35,25 @@ func (r *Repository) ListPrincipals(ctx context.Context, filter access.Principal
 	return out, nil
 }
 
+func (r *Repository) SearchPrincipals(ctx context.Context, query string, limit int) ([]access.Principal, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return []access.Principal{}, nil
+	}
+	if limit <= 0 {
+		limit = 8
+	}
+	rows, err := r.q.SearchPrincipals(ctx, platformdb.SearchPrincipalsParams{Search: query, ResultLimit: int64(limit)})
+	if err != nil {
+		return nil, err
+	}
+	principals := make([]access.Principal, 0, len(rows))
+	for _, row := range rows {
+		principals = append(principals, mapPrincipal(row))
+	}
+	return principals, nil
+}
+
 func (r *Repository) principalDisabled(ctx context.Context, principalID string) (bool, error) {
 	row, err := r.q.GetPrincipal(ctx, principalID)
 	if err != nil {

--- a/internal/access/sqlite/provisioning.go
+++ b/internal/access/sqlite/provisioning.go
@@ -308,6 +308,29 @@ func (r *Repository) ListGroups(ctx context.Context, workspaceID string) ([]acce
 	return groups, nil
 }
 
+func (r *Repository) SearchGroups(ctx context.Context, workspaceID, query string, limit int) ([]access.Group, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return []access.Group{}, nil
+	}
+	if limit <= 0 {
+		limit = 8
+	}
+	rows, err := r.q.SearchGroups(ctx, platformdb.SearchGroupsParams{
+		WorkspaceID: workspaceID,
+		Search:      query,
+		ResultLimit: int64(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	groups := make([]access.Group, 0, len(rows))
+	for _, row := range rows {
+		groups = append(groups, mapGroup(row))
+	}
+	return groups, nil
+}
+
 func (r *Repository) ListAllGroups(ctx context.Context) ([]access.Group, error) {
 	rows, err := r.q.ListAllGroups(ctx)
 	if err != nil {

--- a/internal/app/deployment_candidates_test.go
+++ b/internal/app/deployment_candidates_test.go
@@ -1416,7 +1416,21 @@ func TestWorkspaceAccessCommandUpsertsAndPatchesSignals(t *testing.T) {
 		t.Fatalf("role binding missing after command:\n%s", listRec.Body.String())
 	}
 
-	removeSignals := `{"workspaceAccess":{"command":{"principalId":"` + analyst.ID + `"}}}`
+	bindings, err := testAccessRepository(store).ListRoleBindings(ctx, "test")
+	if err != nil {
+		t.Fatalf("list role bindings: %v", err)
+	}
+	bindingID := ""
+	for _, binding := range bindings {
+		if binding.SubjectType == access.SubjectPrincipal && binding.SubjectID == analyst.ID {
+			bindingID = binding.ID
+			break
+		}
+	}
+	if bindingID == "" {
+		t.Fatalf("analyst role binding missing: %#v", bindings)
+	}
+	removeSignals := `{"workspaceAccess":{"command":{"bindingId":"` + bindingID + `"}}}`
 	removeReq := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/remove", bytes.NewBufferString(removeSignals))
 	removeReq.Header.Set("Authorization", "Bearer "+token)
 	removeRec := httptest.NewRecorder()

--- a/internal/app/deployment_candidates_test.go
+++ b/internal/app/deployment_candidates_test.go
@@ -1384,11 +1384,12 @@ func TestWorkspaceAccessCommandUpsertsAndPatchesSignals(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
 	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", "owner")
+	analyst := testPrincipal(t, ctx, store, "analyst@example.com", "Analyst", "")
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
 
-	signals := `{"workspaceAccess":{"command":{"email":"analyst@example.com","role":"viewer"}}}`
+	signals := `{"workspaceAccess":{"command":{"email":"","role":"data_deployer","subjectType":"principal","subjectId":"` + analyst.ID + `"}}}`
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/upsert", bytes.NewBufferString(signals))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
@@ -1411,11 +1412,11 @@ func TestWorkspaceAccessCommandUpsertsAndPatchesSignals(t *testing.T) {
 	if listRec.Code != http.StatusOK {
 		t.Fatalf("list status = %d body=%s", listRec.Code, listRec.Body.String())
 	}
-	if !strings.Contains(listRec.Body.String(), `"email":"analyst@example.com"`) {
+	if !strings.Contains(listRec.Body.String(), `"email":"analyst@example.com"`) || !strings.Contains(listRec.Body.String(), `"role":"data_deployer"`) {
 		t.Fatalf("role binding missing after command:\n%s", listRec.Body.String())
 	}
 
-	removeSignals := `{"workspaceAccess":{"command":{"principalId":"` + access.PrincipalIDForEmail("analyst@example.com") + `"}}}`
+	removeSignals := `{"workspaceAccess":{"command":{"principalId":"` + analyst.ID + `"}}}`
 	removeReq := httptest.NewRequest(http.MethodPost, "/workspaces/test/access/remove", bytes.NewBufferString(removeSignals))
 	removeReq.Header.Set("Authorization", "Bearer "+token)
 	removeRec := httptest.NewRecorder()

--- a/internal/app/deployment_candidates_test.go
+++ b/internal/app/deployment_candidates_test.go
@@ -1437,6 +1437,53 @@ func TestWorkspaceAccessCommandUpsertsAndPatchesSignals(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAccessSearchReturnsPrincipalsAndGroups(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	owner := testPrincipal(t, ctx, store, "owner@example.com", "Owner", "owner")
+	financePrincipal := testPrincipal(t, ctx, store, "finance@example.com", "Finance Analyst", "")
+	repo := testAccessRepository(store)
+	if _, err := repo.UpsertGroup(ctx, access.GroupInput{ID: "group_finance", WorkspaceID: "test", Name: "Finance Team"}); err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	if _, err := repo.CreateServicePrincipal(ctx, access.ServicePrincipalInput{ID: "sp_finance", DisplayName: "Finance Bot"}); err != nil {
+		t.Fatalf("seed service principal: %v", err)
+	}
+	token := testAPIToken(t, ctx, store, owner.ID, "test")
+	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
+	server := NewWithOptions(fakeMetrics{}, Options{Store: store, Auth: auth, ArtifactDir: t.TempDir(), DefaultWorkspaceID: "test"})
+
+	signals := `{"workspaceAccess":{"search":"finance"}}`
+	req := httptest.NewRequest(http.MethodGet, "/workspaces/test/access/search", nil)
+	query := req.URL.Query()
+	query.Set("datastar", signals)
+	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	server.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("search status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"event: datastar-patch-signals",
+		`"search":"finance"`,
+		`"subjectType":"principal"`,
+		`"subjectId":"` + financePrincipal.ID + `"`,
+		`"label":"Finance Analyst"`,
+		`"subjectType":"group"`,
+		`"subjectId":"group_finance"`,
+		`"label":"Finance Team"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("workspace access search did not patch %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "Finance Bot") || strings.Contains(body, `"subjectType":"service_principal"`) {
+		t.Fatalf("workspace access search included a service principal:\n%s", body)
+	}
+}
+
 func TestWorkspaceAssetAccessCommandCreatesAndRemovesGrant(t *testing.T) {
 	store := testStore(t)
 	seedActiveDeployment(t, store, "test")

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -71,6 +71,7 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/admin/queries", s.protected(access.PrivilegeViewAudit, adminHTTP.Queries))
 		r.Post("/admin/queries/command", s.protected(access.PrivilegeViewAudit, adminHTTP.QueryCommand))
 		r.Post("/workspaces/{workspace}/access/upsert", s.protected(access.PrivilegeManageGrants, workspaceHTTP.AccessUpsert))
+		r.Get("/workspaces/{workspace}/access/search", s.protected(access.PrivilegeManageGrants, workspaceHTTP.AccessSearch))
 		r.Post("/workspaces/{workspace}/access/remove", s.protected(access.PrivilegeManageGrants, workspaceHTTP.AccessRemove))
 		r.Post("/workspaces/{workspace}/assets/{asset}/access/upsert", s.protectedWithObjects(access.PrivilegeManageGrants, workspacehttp.AssetObjectRefs, workspaceHTTP.AccessUpsert))
 		r.Post("/workspaces/{workspace}/assets/{asset}/access/remove", s.protectedWithObjects(access.PrivilegeManageGrants, workspacehttp.AssetObjectRefs, workspaceHTTP.AccessRemove))

--- a/internal/platform/db/queries/access.sql
+++ b/internal/platform/db/queries/access.sql
@@ -371,6 +371,17 @@ WHERE (params.email = '' OR lower(principals.email) = lower(params.email))
        OR lower(display_name) LIKE '%' || lower(params.search) || '%')
 ORDER BY principals.email, principals.id;
 
+-- name: SearchPrincipals :many
+SELECT principals.id, principals.email, principals.display_name,
+       principals.created_at, principals.updated_at, principals.kind, principals.disabled_at
+FROM principals
+WHERE principals.kind = 'user'
+  AND (principals.disabled_at IS NULL OR principals.disabled_at = '')
+  AND (lower(principals.email) LIKE '%' || lower(sqlc.arg(search)) || '%'
+       OR lower(principals.display_name) LIKE '%' || lower(sqlc.arg(search)) || '%')
+ORDER BY lower(principals.display_name), principals.email, principals.id
+LIMIT sqlc.arg(result_limit);
+
 -- name: ChangeLocalCredentialPassword :exec
 UPDATE local_user_credentials
 SET password_verifier = sqlc.arg(password_verifier), must_change_password = 0,
@@ -420,6 +431,16 @@ UPDATE principals SET disabled_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE i
 -- name: ListAllGroups :many
 SELECT id, workspace_id, provider, external_id, name, created_at
 FROM groups ORDER BY workspace_id, name, id;
+
+-- name: SearchGroups :many
+SELECT id, workspace_id, provider, external_id, name, created_at
+FROM groups
+WHERE (workspace_id = sqlc.arg(workspace_id) OR (workspace_id = '' AND provider = 'scim'))
+  AND (lower(name) LIKE '%' || lower(sqlc.arg(search)) || '%'
+       OR lower(id) LIKE '%' || lower(sqlc.arg(search)) || '%'
+       OR lower(external_id) LIKE '%' || lower(sqlc.arg(search)) || '%')
+ORDER BY lower(name), id
+LIMIT sqlc.arg(result_limit);
 
 -- name: ListGroupMembersByGroup :many
 SELECT gm.group_id, g.workspace_id, gm.principal_id, p.email, p.display_name, gm.created_at

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 )
 
+func Get(path string, signalPaths ...string) string {
+	return request("get", path, signalPaths)
+}
+
 func Post(path string, signalPaths ...string) string {
 	return request("post", path, signalPaths)
 }

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -11,6 +11,9 @@ func TestRequestEscapesPathAndSignalPatterns(t *testing.T) {
 }
 
 func TestRequestWithoutSignalFilter(t *testing.T) {
+	if got, want := Get("/search"), `@get('/search', {headers: window.LibreDashCommand.headers()})`; got != want {
+		t.Fatalf("Get() = %q, want %q", got, want)
+	}
 	if got, want := Patch("/api/config"), `@patch('/api/config', {headers: window.LibreDashCommand.headers()})`; got != want {
 		t.Fatalf("Patch() = %q, want %q", got, want)
 	}

--- a/internal/ui/signals.go
+++ b/internal/ui/signals.go
@@ -8,6 +8,8 @@ import (
 type WorkspaceAccessResponse = uisignals.WorkspaceAccessResponse
 type WorkspaceAccessStatus = uisignals.WorkspaceAccessStatus
 type WorkspaceAccessCommand = uisignals.WorkspaceAccessCommand
+type WorkspaceAccessCandidate = uisignals.WorkspaceAccessCandidate
+type WorkspaceAccessSearchStatus = uisignals.WorkspaceAccessSearchStatus
 type ChatSignal = uisignals.ChatSignal
 type ChatViewState = uisignals.ChatViewState
 type ChatConversationSummary = uisignals.ChatConversationSummary

--- a/internal/ui/signals/types.go
+++ b/internal/ui/signals/types.go
@@ -150,15 +150,18 @@ type AdminStorageServingState struct {
 }
 
 type WorkspaceAccessResponse struct {
-	Workspace   workspaceview.WorkspaceView     `json:"workspace"`
-	ObjectType  string                          `json:"objectType,omitempty"`
-	ObjectID    string                          `json:"objectId,omitempty"`
-	ObjectTitle string                          `json:"objectTitle,omitempty"`
-	Mode        string                          `json:"mode,omitempty"`
-	Roles       []workspaceview.RoleView        `json:"roles"`
-	Bindings    []workspaceview.RoleBindingView `json:"bindings"`
-	CanManage   bool                            `json:"canManage"`
-	Status      WorkspaceAccessStatus           `json:"status"`
+	Workspace    workspaceview.WorkspaceView     `json:"workspace"`
+	ObjectType   string                          `json:"objectType,omitempty"`
+	ObjectID     string                          `json:"objectId,omitempty"`
+	ObjectTitle  string                          `json:"objectTitle,omitempty"`
+	Mode         string                          `json:"mode,omitempty"`
+	Roles        []workspaceview.RoleView        `json:"roles"`
+	Bindings     []workspaceview.RoleBindingView `json:"bindings"`
+	Candidates   []WorkspaceAccessCandidate      `json:"candidates"`
+	CanManage    bool                            `json:"canManage"`
+	Search       string                          `json:"search"`
+	SearchStatus WorkspaceAccessSearchStatus     `json:"searchStatus"`
+	Status       WorkspaceAccessStatus           `json:"status"`
 }
 
 type ChatViewState struct {
@@ -325,18 +328,24 @@ func WorkspaceAccessSignals(access WorkspaceAccessResponse) WorkspaceAccessSigna
 	for index := range access.Bindings {
 		bindings[index] = access.Bindings[index]
 	}
+	candidates := access.Candidates
+	if candidates == nil {
+		candidates = []WorkspaceAccessCandidate{}
+	}
 	return WorkspaceAccessSignal{
-		Workspace:   access.Workspace,
-		ObjectType:  optionalValue(access.ObjectType),
-		ObjectID:    optionalValue(access.ObjectID),
-		ObjectTitle: optionalValue(access.ObjectTitle),
-		Mode:        optionalValue(access.Mode),
-		Roles:       roles,
-		Bindings:    bindings,
-		CanManage:   access.CanManage,
-		Status:      access.Status,
-		Command:     WorkspaceAccessCommand{},
-		Search:      "",
+		Workspace:    access.Workspace,
+		ObjectType:   optionalValue(access.ObjectType),
+		ObjectID:     optionalValue(access.ObjectID),
+		ObjectTitle:  optionalValue(access.ObjectTitle),
+		Mode:         optionalValue(access.Mode),
+		Roles:        roles,
+		Bindings:     bindings,
+		Candidates:   candidates,
+		CanManage:    access.CanManage,
+		Status:       access.Status,
+		Command:      WorkspaceAccessCommand{},
+		Search:       access.Search,
+		SearchStatus: access.SearchStatus,
 	}
 }
 

--- a/internal/ui/workspace.go
+++ b/internal/ui/workspace.go
@@ -116,14 +116,12 @@ func catalogWithoutWorkspaceContext(catalog dashboard.Catalog) dashboard.Catalog
 type workspaceAccessSignalState struct {
 	WorkspaceAccessResponse
 	Command WorkspaceAccessCommand `json:"command"`
-	Search  string                 `json:"search"`
 }
 
 func WorkspaceAccessSignals(access WorkspaceAccessResponse) workspaceAccessSignalState {
 	return workspaceAccessSignalState{
 		WorkspaceAccessResponse: access,
 		Command:                 WorkspaceAccessCommand{},
-		Search:                  "",
 	}
 }
 
@@ -138,10 +136,11 @@ func workspaceAccessRouteBridge(workspaceID string, access WorkspaceAccessRespon
 		return nil, workspaceDocumentExtras{}
 	}
 	accessSignal := WorkspaceAccessSignals(access)
+	search := "$workspaceAccess.search = evt.detail.search; $workspaceAccess.searchStatus = {loading: true, error: ''}; $workspaceAccess.status = {loading: false, error: '', message: ''}; " + uiactions.Get("/workspaces/"+workspaceID+"/access/search")
 	upsert := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccess.command = evt.detail; " + uiactions.Post("/workspaces/"+workspaceID+"/access/upsert")
 	remove := "$workspaceAccess.status = {loading: true, error: '', message: ''}; $workspaceAccess.command = evt.detail; " + uiactions.Post("/workspaces/"+workspaceID+"/access/remove")
 	return []g.Node{
-			g.Attr("data-on:ld-workspace-access-search__debounce.200ms", "$workspaceAccess.search = evt.detail.search"),
+			g.Attr("data-on:ld-workspace-access-search__debounce.200ms", search),
 			g.Attr("data-on:ld-workspace-access-upsert", upsert),
 			g.Attr("data-on:ld-workspace-access-remove", remove),
 		}, workspaceDocumentExtras{

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -949,6 +949,7 @@ func TestWorkspaceAccessControlRendersForManagers(t *testing.T) {
 	for _, want := range []string{
 		`<ld-workspace-page`,
 		`data-on:ld-workspace-access-search__debounce.200ms=`,
+		`/workspaces/libredash/access/search`,
 		`data-on:ld-workspace-access-upsert=`,
 		`data-on:ld-workspace-access-remove=`,
 		`workspaceAccess`,

--- a/internal/workspace/http/handler.go
+++ b/internal/workspace/http/handler.go
@@ -711,6 +711,10 @@ func (h Handler) AccessRemove(w nethttp.ResponseWriter, r *nethttp.Request) {
 		if err := repo.DeleteGrant(r.Context(), workspaceID, command.BindingID); err != nil {
 			status = ui.WorkspaceAccessStatus{Error: err.Error()}
 		}
+	} else if bindingID := strings.TrimSpace(command.BindingID); bindingID != "" {
+		if err := repo.DeleteRoleBinding(r.Context(), workspaceID, bindingID); err != nil {
+			status = ui.WorkspaceAccessStatus{Error: err.Error()}
+		}
 	} else if err := repo.RemovePrincipalRoles(r.Context(), workspaceID, command.PrincipalID); err != nil {
 		status = ui.WorkspaceAccessStatus{Error: err.Error()}
 	}

--- a/internal/workspace/http/handler.go
+++ b/internal/workspace/http/handler.go
@@ -40,8 +40,28 @@ type Handler struct {
 type workspaceAccessSignalPayload struct {
 	WorkspaceAccess struct {
 		Command ui.WorkspaceAccessCommand `json:"command"`
+		Search  string                    `json:"search"`
 	} `json:"workspaceAccess"`
 	WorkspaceAccessCommand ui.WorkspaceAccessCommand `json:"workspaceAccessCommand"`
+}
+
+func (h Handler) AccessSearch(w nethttp.ResponseWriter, r *nethttp.Request) {
+	signals := workspaceAccessSignalPayload{}
+	if err := pagestream.ReadSignals(r, &signals); err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	workspaceID := h.workspaceID(chi.URLParam(r, "workspace"))
+	workspaceView := h.workspaceResponse(r, workspaceID)
+	response := h.workspaceAccess(r, workspaceView, true, ui.WorkspaceAccessStatus{})
+	response.Search = strings.TrimSpace(signals.WorkspaceAccess.Search)
+	candidates, err := h.ReadModel.WorkspaceAccessCandidates(r, workspaceID, response.Search, 8)
+	if err != nil {
+		response.SearchStatus.Error = err.Error()
+	} else {
+		response.Candidates = candidates
+	}
+	_ = pagestream.PatchResponse(w, r, pagestream.SignalPatch{"workspaceAccess": ui.WorkspaceAccessSignals(response)})
 }
 
 func (signals workspaceAccessSignalPayload) command() ui.WorkspaceAccessCommand {

--- a/internal/workspace/http/read_model.go
+++ b/internal/workspace/http/read_model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	nethttp "net/http"
 	"sort"
+	"strings"
 
 	"github.com/Yacobolo/libredash/internal/access"
 	"github.com/Yacobolo/libredash/internal/dashboard"
@@ -234,6 +235,112 @@ func (m ReadModel) WorkspaceAccess(r *nethttp.Request, workspaceView workspace.W
 		Bindings:  bindings,
 		CanManage: canManage,
 		Status:    status,
+	}
+}
+
+func (m ReadModel) WorkspaceAccessCandidates(r *nethttp.Request, workspaceID, query string, limit int) ([]ui.WorkspaceAccessCandidate, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return []ui.WorkspaceAccessCandidate{}, nil
+	}
+	if limit < 1 {
+		limit = 8
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	repo, err := m.accessRepository()
+	if err != nil {
+		return nil, err
+	}
+	if repo == nil {
+		return []ui.WorkspaceAccessCandidate{}, nil
+	}
+	bindings, err := repo.ListRoleBindings(r.Context(), workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	bound := make(map[string]struct{}, len(bindings))
+	for _, binding := range bindings {
+		subjectType := binding.SubjectType
+		subjectID := binding.SubjectID
+		if subjectType == "" {
+			subjectType = access.SubjectPrincipal
+			subjectID = binding.PrincipalID
+		}
+		bound[string(subjectType)+":"+subjectID] = struct{}{}
+	}
+	principals, err := repo.SearchPrincipals(r.Context(), query, limit)
+	if err != nil {
+		return nil, err
+	}
+	groups, err := repo.SearchGroups(r.Context(), workspaceID, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]ui.WorkspaceAccessCandidate, 0, len(principals)+len(groups))
+	for _, principal := range principals {
+		if _, exists := bound[string(access.SubjectPrincipal)+":"+principal.ID]; exists {
+			continue
+		}
+		label := firstNonEmpty(principal.DisplayName, principal.Email, principal.ID)
+		candidates = append(candidates, ui.WorkspaceAccessCandidate{
+			SubjectType: string(access.SubjectPrincipal),
+			SubjectID:   principal.ID,
+			Label:       label,
+			Detail:      principal.Email,
+		})
+	}
+	normalizedQuery := strings.ToLower(query)
+	for _, group := range groups {
+		label := firstNonEmpty(group.Name, group.ID)
+		if !strings.Contains(strings.ToLower(label+" "+group.ID), normalizedQuery) {
+			continue
+		}
+		if _, exists := bound[string(access.SubjectGroup)+":"+group.ID]; exists {
+			continue
+		}
+		candidates = append(candidates, ui.WorkspaceAccessCandidate{
+			SubjectType: string(access.SubjectGroup),
+			SubjectID:   group.ID,
+			Label:       label,
+			Detail:      "Group",
+		})
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		leftRank := workspaceAccessCandidateRank(candidates[i], normalizedQuery)
+		rightRank := workspaceAccessCandidateRank(candidates[j], normalizedQuery)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		leftLabel := strings.ToLower(candidates[i].Label)
+		rightLabel := strings.ToLower(candidates[j].Label)
+		if leftLabel != rightLabel {
+			return leftLabel < rightLabel
+		}
+		if candidates[i].SubjectType != candidates[j].SubjectType {
+			return candidates[i].SubjectType < candidates[j].SubjectType
+		}
+		return candidates[i].SubjectID < candidates[j].SubjectID
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	return candidates, nil
+}
+
+func workspaceAccessCandidateRank(candidate ui.WorkspaceAccessCandidate, query string) int {
+	label := strings.ToLower(candidate.Label)
+	detail := strings.ToLower(candidate.Detail)
+	switch {
+	case strings.HasPrefix(label, query):
+		return 0
+	case strings.HasPrefix(detail, query):
+		return 1
+	case strings.Contains(label, query):
+		return 2
+	default:
+		return 3
 	}
 }
 

--- a/web/components/admin/admin-page.dom.test.ts
+++ b/web/components/admin/admin-page.dom.test.ts
@@ -472,7 +472,7 @@ test('query audit page filters table rows and exposes optional metadata columns'
       const expandedQueryText = expandedCodeBlock?.shadowRoot?.querySelector('code')?.textContent
         ?? table.querySelector('.record-query-expanded-cell')?.textContent
         ?? ''
-      const drawerAfterExpand = root.querySelector('.query-detail-drawer')?.textContent ?? ''
+      const drawerAfterExpand = root.querySelector('ld-drawer')?.textContent ?? ''
       table.querySelector<HTMLButtonElement>('.record-query-expand')?.click()
       await table.updateComplete
       table.querySelector<HTMLElement>('tbody tr.record-row')?.click()
@@ -480,12 +480,13 @@ test('query audit page filters table rows and exposes optional metadata columns'
       const detailCommand = (window as any).queryHistoryCommands.at(-1)
       mergePatch({ adminQueryDetail: fixture.queryDetail })
       await element.updateComplete
-      const drawer = root.querySelector('.query-detail-drawer') as HTMLElement | null
+      const drawer = root.querySelector('ld-drawer') as any
+      const drawerPanel = drawer?.shadowRoot?.querySelector('.drawer') as HTMLElement | null
       const drawerText = drawer?.textContent ?? ''
       const drawerCodeBlock = drawer?.querySelector('ld-code-block') as (HTMLElement & { updateComplete: Promise<boolean> }) | null
       await drawerCodeBlock?.updateComplete
       const drawerCode = drawerCodeBlock?.shadowRoot?.querySelector('code')?.textContent ?? drawerCodeBlock?.querySelector('code')?.textContent ?? ''
-      const drawerAnimationName = drawer ? getComputedStyle(drawer).animationName : ''
+      const drawerAnimationName = drawerPanel ? getComputedStyle(drawerPanel).animationName : ''
       const status = drawer?.querySelector('.query-detail-status') as HTMLElement | null
       const statusIcon = status?.querySelector('svg') as SVGElement | null
       const statusText = status?.querySelector('span') as HTMLElement | null
@@ -493,12 +494,20 @@ test('query audit page filters table rows and exposes optional metadata columns'
       const statusTextColor = statusText ? getComputedStyle(statusText).color : ''
       const statusIconColor = statusIcon ? getComputedStyle(statusIcon).color : ''
       const hasSubtitle = Boolean(drawer?.querySelector('.query-detail-subtitle'))
-      root.querySelector<HTMLButtonElement>('.query-detail-close')?.click()
+      const usesSharedDrawer = drawer?.tagName === 'LD-DRAWER'
+      const drawerIsModal = drawer?.modal
+      const drawerModal = drawerPanel?.getAttribute('aria-modal') ?? null
+      const drawerClose = drawer?.shadowRoot?.querySelector<HTMLButtonElement>('.close')
+      drawerClose?.focus()
+      const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true, composed: true })
+      drawerClose?.dispatchEvent(tabEvent)
+      const nonModalAllowsTab = !tabEvent.defaultPrevented
+      drawerClose?.click()
       await element.updateComplete
       const closeCommand = (window as any).queryHistoryCommands.at(-1)
       mergePatch({ adminQueryDetail: { eventId: '', loading: false, error: '' } })
       await element.updateComplete
-      const hasDrawerAfterClose = Boolean(root.querySelector('.query-detail-drawer'))
+      const hasDrawerAfterClose = Boolean(root.querySelector('ld-drawer'))
       table.querySelector<HTMLElement>('tbody tr.record-row')?.click()
       await element.updateComplete
       mergePatch({ adminQueryDetail: fixture.queryDetail })
@@ -508,7 +517,7 @@ test('query audit page filters table rows and exposes optional metadata columns'
       const escapeCommand = (window as any).queryHistoryCommands.at(-1)
       mergePatch({ adminQueryDetail: { eventId: '', loading: false, error: '' } })
       await element.updateComplete
-      const hasDrawerAfterEscape = Boolean(root.querySelector('.query-detail-drawer'))
+      const hasDrawerAfterEscape = Boolean(root.querySelector('ld-drawer'))
       Array.from(table.querySelectorAll('label'))
         .find((label) => label.textContent?.includes('Operation'))
         ?.querySelector('input')
@@ -547,6 +556,10 @@ test('query audit page filters table rows and exposes optional metadata columns'
         drawerHasCodeBlock: Boolean(drawerCodeBlock),
         drawerCode,
         drawerAnimationName,
+        usesSharedDrawer,
+        drawerIsModal,
+        drawerModal,
+        nonModalAllowsTab,
         statusColor,
         statusTextColor,
         statusIconColor,
@@ -607,7 +620,11 @@ test('query audit page filters table rows and exposes optional metadata columns'
     expect(state.drawerText).toMatch(/semantic_aggregate/)
     expect(state.drawerText).toMatch(/semantic_dataset:sales:orders/)
     expect(state.drawerText).toMatch(/Rows returned/)
-    expect(state.drawerAnimationName).toContain('query-detail-slide-in')
+    expect(state.drawerAnimationName).toContain('drawer-slide-in')
+    expect(state.usesSharedDrawer).toBe(true)
+    expect(state.drawerIsModal).toBe(false)
+    expect(state.drawerModal).toBeNull()
+    expect(state.nonModalAllowsTab).toBe(true)
     expect(state.closeCommand).toMatchObject({ action: 'close_detail' })
     expect(state.escapeCommand).toMatchObject({ action: 'close_detail' })
     expect(state.hasDrawerAfterClose).toBe(false)
@@ -700,15 +717,19 @@ test('query audit detail drawer behaves as a mobile overlay', async () => {
       await element.updateComplete
       mergePatch({ adminQueryDetail: fixture.queryDetail })
       await element.updateComplete
-      const drawer = root.querySelector('.query-detail-drawer') as HTMLElement
-      const drawerRect = drawer.getBoundingClientRect()
+      const drawer = root.querySelector('ld-drawer') as any
+      const overlay = drawer.shadowRoot.querySelector('.overlay') as HTMLElement
+      const drawerPanel = drawer.shadowRoot.querySelector('.drawer') as HTMLElement
+      const overlayRect = overlay.getBoundingClientRect()
+      const drawerRect = drawerPanel.getBoundingClientRect()
       const tableRect = table.getBoundingClientRect()
       return {
         drawerText: drawer.textContent ?? '',
-        drawerPosition: getComputedStyle(drawer).position,
+        drawerPosition: getComputedStyle(overlay).position,
         drawerWidth: Math.round(drawerRect.width),
         viewportWidth: window.innerWidth,
-        drawerCoversTableHorizontally: drawerRect.left <= tableRect.left && drawerRect.right >= tableRect.right,
+        drawerCoversTableHorizontally: overlayRect.left <= Math.max(0, tableRect.left) && overlayRect.right >= Math.min(window.innerWidth, tableRect.right),
+        drawerModal: drawerPanel.getAttribute('aria-modal'),
       }
     }, queryAuditFixturePage())
 
@@ -716,6 +737,7 @@ test('query audit detail drawer behaves as a mobile overlay', async () => {
     expect(state.drawerPosition).toBe('fixed')
     expect(state.drawerWidth).toBe(state.viewportWidth)
     expect(state.drawerCoversTableHorizontally).toBe(true)
+    expect(state.drawerModal).toBeNull()
   } finally {
     await page.close()
   }
@@ -739,8 +761,11 @@ test('query audit drawer does not block selecting another row', async () => {
       await element.updateComplete
       mergePatch({ adminQueryDetail: fixture.queryDetail })
       await element.updateComplete
-      const firstDrawerText = root.querySelector('.query-detail-drawer')?.textContent ?? ''
-      const hasBackdrop = Boolean(root.querySelector('.query-detail-backdrop'))
+      const firstDrawer = root.querySelector('ld-drawer') as any
+      const firstDrawerText = firstDrawer?.textContent ?? ''
+      const firstOverlay = firstDrawer?.shadowRoot?.querySelector('.overlay') as HTMLElement | null
+      const overlayPointerEvents = firstOverlay ? getComputedStyle(firstOverlay).pointerEvents : ''
+      const overlayBackground = firstOverlay ? getComputedStyle(firstOverlay).backgroundColor : ''
       rows[1]?.click()
       await element.updateComplete
       mergePatch({ adminQueryDetail: {
@@ -768,15 +793,17 @@ test('query audit drawer does not block selecting another row', async () => {
         createdAt: '2026-07-02T10:01:00Z',
       } })
       await element.updateComplete
-      const secondDrawerText = root.querySelector('.query-detail-drawer')?.textContent ?? ''
+      const secondDrawerText = root.querySelector('ld-drawer')?.textContent ?? ''
       return {
-        hasBackdrop,
         firstDrawerText,
         secondDrawerText,
+        overlayPointerEvents,
+        overlayBackground,
       }
     }, queryAuditFixturePage())
 
-    expect(state.hasBackdrop).toBe(false)
+    expect(state.overlayPointerEvents).toBe('none')
+    expect(state.overlayBackground).toBe('rgba(0, 0, 0, 0)')
     expect(state.firstDrawerText).toMatch(/queryevent_1/)
     expect(state.firstDrawerText).toMatch(/analyst/)
     expect(state.secondDrawerText).toMatch(/queryevent_2/)
@@ -1689,7 +1716,7 @@ function testDocument(): string {
       <head>
         <style>
           html, body { margin: 0; min-height: 100%; }
-          body { --fontStack-system: system-ui; --ld-bg-app: #f6f8fa; --ld-bg-panel: #fff; --ld-bg-panel-muted: #f6f8fa; --ld-bg-control: #f6f8fa; --ld-bg-control-hover: #f3f4f6; --ld-bg-accent: #0969da; --ld-bg-accent-muted: #ddf4ff; --ld-sidebar-bg: #f1f3f5; --ld-report-rail-bg: #ffffff; --ld-fg-default: #24292f; --ld-fg-muted: #57606a; --ld-fg-accent: #0969da; --ld-fg-link: #0969da; --ld-fg-success: #1a7f37; --ld-fg-warning: #9a6700; --ld-fg-danger: #d1242f; --ld-fg-on-accent: #fff; --ld-icon-muted: #57606a; --ld-line-muted: #d8dee4; --ld-border-width: 1px; --ld-border-default: 1px solid #d0d7de; --ld-border-muted: 1px solid #d8dee4; --ld-radius-default: 6px; --ld-radius-full: 999px; --ld-page-content-max-width: 72rem; --ld-workspace-detail-max-width: 72rem; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-12: 12px; --base-size-16: 16px; --ld-font-size-caption: 12px; --ld-font-size-body-sm: 14px; --ld-font-size-body-md: 16px; --ld-font-size-title-sm: 18px; --ld-font-size-title-md: 22px; --ld-font-weight-medium: 500; --ld-font-weight-strong: 600; --ld-line-height-tight: 1.2; --ld-line-height-compact: 1.3; --ld-line-height-normal: 1.5; }
+          body { --fontStack-system: system-ui; --ld-bg-app: #f6f8fa; --ld-bg-panel: #fff; --ld-bg-panel-muted: #f6f8fa; --ld-bg-control: #f6f8fa; --ld-bg-control-hover: #f3f4f6; --ld-bg-accent: #0969da; --ld-bg-accent-muted: #ddf4ff; --ld-sidebar-bg: #f1f3f5; --ld-report-rail-bg: #ffffff; --ld-fg-default: #24292f; --ld-fg-muted: #57606a; --ld-fg-accent: #0969da; --ld-fg-link: #0969da; --ld-fg-success: #1a7f37; --ld-fg-warning: #9a6700; --ld-fg-danger: #d1242f; --ld-fg-on-accent: #fff; --ld-icon-muted: #57606a; --ld-line-muted: #d8dee4; --ld-border-width: 1px; --ld-border-default: 1px solid #d0d7de; --ld-border-muted: 1px solid #d8dee4; --ld-radius-default: 6px; --ld-radius-full: 999px; --ld-page-content-max-width: 72rem; --ld-workspace-detail-max-width: 72rem; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-12: 12px; --base-size-16: 16px; --ld-font-size-caption: 12px; --ld-font-size-body-sm: 14px; --ld-font-size-body-md: 16px; --ld-font-size-title-sm: 18px; --ld-font-size-title-md: 22px; --ld-font-weight-medium: 500; --ld-font-weight-strong: 600; --ld-line-height-tight: 1.2; --ld-line-height-compact: 1.3; --ld-line-height-normal: 1.5; --ld-transition-fast: 160ms ease; }
           ld-admin-page { min-height: 720px; }
         </style>
       </head>

--- a/web/components/admin/admin-page.ts
+++ b/web/components/admin/admin-page.ts
@@ -1,12 +1,13 @@
 import { LitElement, css, html, nothing } from 'lit'
 import { state } from 'lit/decorators.js'
-import { CheckCircle2, Clock3, Copy, X, XCircle } from 'lucide'
+import { CheckCircle2, Clock3, Copy, XCircle } from 'lucide'
 import type { AdminPageSignal, AdminContentSectionSignal, AdminQueryDetailSignal, AdminQueryHistoryFilters, AdminQueryHistorySignal, AdminStorageSignal, FilterMenuCommand, FilterMenuSignal, RecordTableSignal } from '../../generated/signals'
 import { DatastarLit } from '../shared/datastar-lit'
 import { lucideIcon } from '../shared/lucide-icons'
 import { checkSignalContract } from '../shared/signal-contract'
 import '../navigation/sub-sidebar'
 import '../shared/code-block'
+import '../shared/drawer'
 import '../shared/filter-menu'
 import '../shared/record-table'
 import './agent-tools'
@@ -370,35 +371,11 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
       opacity: 0.64;
     }
 
-    .query-detail-drawer {
-      position: fixed;
-      z-index: 31;
-      inset: 0 0 0 auto;
-      display: grid;
-      width: min(34rem, 100vw);
-      grid-template-rows: auto minmax(0, 1fr);
-      border-left: var(--ld-border-muted);
-      background: var(--ld-bg-panel);
-      box-shadow: var(--ld-shadow-floating-lg);
-      color: var(--ld-fg-default);
-      animation: query-detail-slide-in 180ms cubic-bezier(0.2, 0, 0, 1) both;
-    }
-
-    .query-detail-header {
-      border-bottom: var(--ld-border-muted);
-      padding: var(--base-size-16);
-    }
-
-    .query-detail-header-row,
     .query-detail-copy-row {
       display: flex;
       min-width: 0;
       align-items: center;
       gap: var(--base-size-8);
-    }
-
-    .query-detail-header-row {
-      justify-content: space-between;
     }
 
     .query-detail-status {
@@ -432,7 +409,6 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
       color: var(--ld-fg-muted);
     }
 
-    .query-detail-close,
     .query-detail-copy {
       display: inline-flex;
       align-items: center;
@@ -445,11 +421,6 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
       font: inherit;
     }
 
-    .query-detail-close {
-      width: var(--ld-control-medium);
-      height: var(--ld-control-medium);
-    }
-
     .query-detail-copy {
       width: var(--base-size-20);
       height: var(--base-size-20);
@@ -457,8 +428,6 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
       padding: 0;
     }
 
-    .query-detail-close:hover,
-    .query-detail-close:focus-visible,
     .query-detail-copy:hover,
     .query-detail-copy:focus-visible {
       border-color: var(--ld-line-muted);
@@ -472,8 +441,6 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
       align-content: start;
       gap: var(--base-size-16);
       min-width: 0;
-      overflow: auto;
-      padding: var(--base-size-16);
     }
 
     .query-detail-section {
@@ -548,30 +515,6 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
       cursor: pointer;
     }
 
-    @keyframes query-detail-slide-in {
-      from {
-        transform: translateX(100%);
-      }
-      to {
-        transform: translateX(0);
-      }
-    }
-
-    @keyframes query-detail-mobile-slide-in {
-      from {
-        transform: translateY(100%);
-      }
-      to {
-        transform: translateY(0);
-      }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      .query-detail-drawer {
-        animation-duration: 1ms;
-      }
-    }
-
     @media (max-width: 640px) {
       .route {
         grid-template-columns: 1fr;
@@ -586,26 +529,10 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
       .main {
         padding: var(--base-size-12);
       }
-
-      .query-detail-drawer {
-        inset: auto 0 0 0;
-        width: 100vw;
-        height: min(88svh, 44rem);
-        border-top: var(--ld-border-muted);
-        border-left: 0;
-        box-shadow: var(--ld-shadow-floating-lg);
-        animation-name: query-detail-mobile-slide-in;
-      }
     }
   `
 
-  connectedCallback(): void {
-    super.connectedCallback()
-    window.addEventListener('keydown', this.handleWindowKeydown)
-  }
-
   disconnectedCallback(): void {
-    window.removeEventListener('keydown', this.handleWindowKeydown)
     if (this.queryFilterTimer) clearTimeout(this.queryFilterTimer)
     super.disconnectedCallback()
   }
@@ -852,27 +779,20 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
     this.emitQueryHistoryCommand('close_detail', this.currentQueryHistory().filters, '')
   }
 
-  private handleWindowKeydown = (event: KeyboardEvent) => {
-    const detail = this.queryDetail ?? emptyQueryDetail
-    if (event.key !== 'Escape' || (!detail.eventId && !detail.loading && !detail.error)) return
-    this.closeQueryDetail()
-  }
-
   private renderQueryDetail(event: AdminQueryDetailSignal) {
     const statusTone = queryEventStatusTone(event.status ?? '')
     return html`
-      <aside class="query-detail-drawer" role="dialog" aria-modal="true" aria-label="Query event detail">
-        <header class="query-detail-header">
-          <div class="query-detail-header-row">
-            <div class=${`query-detail-status query-detail-status-${statusTone}`}>
-              ${lucideIcon(queryEventStatusIconComponent(event.status ?? ''), { size: 16, strokeWidth: 2 })}
-              <span>${event.loading ? 'Loading' : event.statusLabel || queryEventStatusLabel(event.status ?? '')}</span>
-            </div>
-            <button class="query-detail-close" type="button" aria-label="Close query details" @click=${this.closeQueryDetail}>
-              ${lucideIcon(X, { size: 18, strokeWidth: 2 })}
-            </button>
-          </div>
-        </header>
+      <ld-drawer
+        open
+        size="wide"
+        label="Query event detail"
+        .modal=${false}
+        @ld-drawer-close=${this.closeQueryDetail}
+      >
+        <div slot="title" class=${`query-detail-status query-detail-status-${statusTone}`}>
+          ${lucideIcon(queryEventStatusIconComponent(event.status ?? ''), { size: 16, strokeWidth: 2 })}
+          <span>${event.loading ? 'Loading' : event.statusLabel || queryEventStatusLabel(event.status ?? '')}</span>
+        </div>
         <div class="query-detail-body">
           ${event.loading ? html`<section class="query-detail-section"><p class="detail">Loading query details...</p></section>` : nothing}
           ${event.error && !event.status ? html`<section class="query-detail-section"><pre class="query-detail-code query-detail-error"><code>${event.error}</code></pre></section>` : nothing}
@@ -927,7 +847,7 @@ class LibreDashAdminPage extends DatastarLit(LitElement) {
             </details>
           ` : nothing}
         </div>
-      </aside>
+      </ld-drawer>
     `
   }
 

--- a/web/components/shared/drawer.ts
+++ b/web/components/shared/drawer.ts
@@ -14,7 +14,9 @@ const focusableSelector = [
 
 class LibreDashDrawer extends LitElement {
   @property({ type: Boolean, reflect: true }) open = false
+  @property({ type: Boolean, reflect: true }) modal = true
   @property() label = 'Drawer'
+  @property({ reflect: true }) size: 'default' | 'wide' = 'default'
 
   static styles = css`
     :host {
@@ -35,6 +37,15 @@ class LibreDashDrawer extends LitElement {
       background: var(--ld-modal-backdrop);
     }
 
+    .overlay-nonmodal {
+      background: transparent;
+      pointer-events: none;
+    }
+
+    .overlay-nonmodal .drawer {
+      pointer-events: auto;
+    }
+
     .drawer {
       display: grid;
       width: min(30rem, 100vw);
@@ -45,7 +56,11 @@ class LibreDashDrawer extends LitElement {
       border-left: var(--ld-border-default);
       background: var(--ld-bg-panel);
       box-shadow: var(--ld-shadow-floating-lg);
-      animation: drawer-slide-in var(--ld-transition-fast) ease;
+      animation: drawer-slide-in var(--ld-transition-fast);
+    }
+
+    :host([size='wide']) .drawer {
+      width: min(34rem, 100vw);
     }
 
     .header {
@@ -110,6 +125,12 @@ class LibreDashDrawer extends LitElement {
       }
     }
 
+    @media (prefers-reduced-motion: reduce) {
+      .drawer {
+        animation-duration: 1ms;
+      }
+    }
+
     @keyframes drawer-slide-in {
       from {
         transform: translateX(var(--base-size-16));
@@ -122,14 +143,24 @@ class LibreDashDrawer extends LitElement {
     }
   `
 
+  connectedCallback(): void {
+    super.connectedCallback()
+    window.addEventListener('keydown', this.handleWindowKeyDown)
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener('keydown', this.handleWindowKeyDown)
+    super.disconnectedCallback()
+  }
+
   render() {
     if (!this.open) return nothing
     return html`
-      <div class="overlay" @click=${this.handleOverlayClick}>
+      <div class=${this.modal ? 'overlay' : 'overlay overlay-nonmodal'} @click=${this.handleOverlayClick}>
         <aside
           class="drawer"
           role="dialog"
-          aria-modal="true"
+          aria-modal=${this.modal ? 'true' : nothing}
           aria-label=${this.label}
           @keydown=${this.handleKeyDown}
         >
@@ -161,7 +192,13 @@ class LibreDashDrawer extends LitElement {
   }
 
   private readonly handleOverlayClick = (event: Event): void => {
-    if (event.target === event.currentTarget) this.close()
+    if (this.modal && event.target === event.currentTarget) this.close()
+  }
+
+  private readonly handleWindowKeyDown = (event: KeyboardEvent): void => {
+    if (!this.open || event.defaultPrevented || event.key !== 'Escape') return
+    event.preventDefault()
+    this.close()
   }
 
   private readonly handleKeyDown = (event: KeyboardEvent): void => {
@@ -170,7 +207,7 @@ class LibreDashDrawer extends LitElement {
       this.close()
       return
     }
-    if (event.key !== 'Tab') return
+    if (event.key !== 'Tab' || !this.modal) return
     const focusable = this.focusableElements()
     if (focusable.length === 0) return
     const first = focusable[0]

--- a/web/components/shared/record-table.ts
+++ b/web/components/shared/record-table.ts
@@ -903,7 +903,7 @@ const recordTableStyles = `
 
   ld-record-table .variant-primary .record-table th,
   ld-record-table .variant-compact .record-table th {
-    padding: var(--base-size-12) var(--base-size-16);
+    padding: var(--base-size-8) var(--base-size-12);
     background: var(--ld-bg-panel-muted);
     font-size: var(--ld-font-size-body-sm);
     font-weight: var(--ld-font-weight-strong);
@@ -922,9 +922,9 @@ const recordTableStyles = `
   }
 
   ld-record-table .variant-primary .record-table td {
-    padding: var(--base-size-12) var(--base-size-16);
-    font-size: var(--ld-font-size-body-md);
-    vertical-align: top;
+    padding: var(--base-size-6) var(--base-size-12);
+    font-size: var(--ld-font-size-body-sm);
+    vertical-align: middle;
   }
 
   ld-record-table .variant-compact .record-table td {
@@ -942,7 +942,7 @@ const recordTableStyles = `
   }
 
   ld-record-table .variant-primary .record-table tbody tr {
-    min-height: 4rem;
+    min-height: 3rem;
   }
 
   ld-record-table .record-table th.is-right,
@@ -1382,8 +1382,20 @@ const recordTableStyles = `
   }
 
   ld-record-table .variant-primary .record-entity-label {
-    font-size: var(--ld-font-size-title-sm);
-    line-height: var(--ld-line-height-compact);
+    overflow: hidden;
+    overflow-wrap: normal;
+    font-size: var(--ld-font-size-body-md);
+    line-height: var(--ld-line-height-tight);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  ld-record-table .variant-primary .record-entity-description {
+    overflow: hidden;
+    overflow-wrap: normal;
+    line-height: var(--ld-line-height-tight);
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   ld-record-table .record-entity-description {

--- a/web/components/shared/record-table.ts
+++ b/web/components/shared/record-table.ts
@@ -506,9 +506,10 @@ class RecordTable extends LitElement {
     const href = cellHref(column, value, row)
     const label = cellLabel(value)
     const description = cellDescription(value)
+    const icon = cellIcon(value)
     const content = html`
-      <span class="record-entity">
-        ${this.renderIcon(cellIcon(value), `record-entity-icon record-icon-${iconToken(cellIcon(value))}`)}
+      <span class=${icon ? 'record-entity' : 'record-entity record-entity-no-icon'}>
+        ${icon ? this.renderIcon(icon, `record-entity-icon record-icon-${iconToken(icon)}`) : nothing}
         <span class="record-entity-copy">
           <span class="record-entity-label">${label}</span>
           ${description ? html`<span class="record-entity-description">${description}</span>` : nothing}
@@ -1322,6 +1323,11 @@ const recordTableStyles = `
     grid-template-columns: auto minmax(0, 1fr);
     align-items: start;
     gap: var(--base-size-8);
+  }
+
+  ld-record-table .record-entity-no-icon {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0;
   }
 
   ld-record-table .record-entity-icon,

--- a/web/components/shared/record-table.ts
+++ b/web/components/shared/record-table.ts
@@ -1395,7 +1395,7 @@ const recordTableStyles = `
     overflow: hidden;
     overflow-wrap: normal;
     font-size: var(--ld-font-size-body-sm);
-    font-weight: var(--ld-font-weight-regular);
+    font-weight: var(--ld-font-weight-strong);
     line-height: var(--ld-line-height-normal);
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/web/components/shared/record-table.ts
+++ b/web/components/shared/record-table.ts
@@ -1330,6 +1330,10 @@ const recordTableStyles = `
     gap: 0;
   }
 
+  ld-record-table .variant-primary .record-entity {
+    align-items: center;
+  }
+
   ld-record-table .record-entity-icon,
   ld-record-table .record-button-icon {
     display: inline-flex;
@@ -1390,8 +1394,9 @@ const recordTableStyles = `
   ld-record-table .variant-primary .record-entity-label {
     overflow: hidden;
     overflow-wrap: normal;
-    font-size: var(--ld-font-size-body-md);
-    line-height: var(--ld-line-height-tight);
+    font-size: var(--ld-font-size-body-sm);
+    font-weight: var(--ld-font-weight-regular);
+    line-height: var(--ld-line-height-normal);
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/web/components/shared/workspace-access-control.ts
+++ b/web/components/shared/workspace-access-control.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html, nothing } from 'lit'
 import { property, state } from 'lit/decorators.js'
-import { Search, Trash2, UserRound, Users } from 'lucide'
+import { Plus, Search, Trash2, UserRound, Users } from 'lucide'
 import { lucideIcon } from './lucide-icons'
 import './drawer'
 
@@ -94,9 +94,8 @@ class WorkspaceAccessControl extends LitElement {
   @property({ attribute: 'search' }) searchAttribute = ''
 
   @state() private open = false
-  @state() private selectedRole = 'viewer'
+  @state() private selectedRole = ''
   @state() private query = ''
-  @state() private selectedCandidate: AccessCandidate | null = null
 
   private previousFocus: HTMLElement | null = null
 
@@ -256,6 +255,20 @@ class WorkspaceAccessControl extends LitElement {
       min-height: var(--ld-control-large);
     }
 
+    .access-search input:disabled {
+      cursor: not-allowed;
+      opacity: var(--opacity-disabled);
+    }
+
+    .role-field {
+      display: grid;
+      gap: var(--base-size-6);
+    }
+
+    .assignment-role {
+      width: 100%;
+    }
+
     .candidate-list {
       display: grid;
       overflow: hidden;
@@ -267,27 +280,21 @@ class WorkspaceAccessControl extends LitElement {
     .candidate {
       display: grid;
       min-width: 0;
-      grid-template-columns: var(--base-size-32) minmax(0, 1fr);
+      grid-template-columns: var(--base-size-32) minmax(0, 1fr) auto;
       align-items: center;
       gap: var(--ld-space-control);
-      border: 0;
       border-bottom: var(--ld-border-muted);
       background: transparent;
       color: var(--ld-fg-default);
-      cursor: pointer;
       padding: var(--ld-space-control) var(--base-size-12);
-      text-align: left;
     }
 
     .candidate:last-child {
       border-bottom: 0;
     }
 
-    .candidate:hover,
-    .candidate:focus-visible,
-    .candidate-selected {
+    .candidate:hover {
       background: var(--ld-bg-control-hover);
-      outline: 0;
     }
 
     .subject-icon {
@@ -350,58 +357,6 @@ class WorkspaceAccessControl extends LitElement {
       color: var(--ld-fg-danger);
     }
 
-    .assignment {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(8rem, 10rem) auto;
-      align-items: center;
-      gap: var(--ld-space-control);
-      border: var(--ld-border-muted);
-      border-radius: var(--ld-radius-default);
-      background: var(--ld-bg-panel-muted);
-      padding: var(--base-size-12);
-    }
-
-    .selected-subject {
-      display: grid;
-      min-width: 0;
-      grid-template-columns: var(--base-size-32) minmax(0, 1fr);
-      align-items: center;
-      gap: var(--ld-space-control);
-    }
-
-    .assignment-role {
-      width: 100%;
-    }
-
-    .submit {
-      min-height: var(--ld-button-height);
-      min-width: var(--base-size-80);
-      border: var(--borderWidth-default) solid var(--ld-button-accent-border-rest);
-      border-radius: var(--ld-button-radius);
-      background: var(--ld-button-accent-bg-rest);
-      color: var(--ld-button-accent-fg-rest);
-      cursor: pointer;
-      font-size: var(--ld-font-size-body-sm);
-      font-weight: var(--ld-font-weight-strong);
-      line-height: var(--ld-line-height-tight);
-      padding: 0 var(--ld-button-padding-inline-spacious);
-    }
-
-    .submit:hover,
-    .submit:focus-visible {
-      border-color: var(--ld-button-accent-border-hover);
-      background: var(--ld-button-accent-bg-hover);
-      outline: var(--focus-outline, var(--ld-border-default));
-      outline-color: var(--borderColor-accent-emphasis, var(--ld-line-accent));
-      outline-offset: var(--focus-outline-offset, var(--base-size-2));
-    }
-
-    .submit:disabled {
-      border-color: var(--ld-button-accent-border-disabled);
-      background: var(--ld-button-accent-bg-disabled);
-      color: var(--ld-button-accent-fg-disabled);
-    }
-
     .row-action {
       display: inline-flex;
       width: var(--ld-control-medium);
@@ -429,7 +384,10 @@ class WorkspaceAccessControl extends LitElement {
       outline: 0;
     }
 
-    .submit:disabled,
+    .candidate-add {
+      color: var(--ld-fg-accent);
+    }
+
     .row-action:disabled {
       cursor: not-allowed;
       opacity: var(--opacity-disabled);
@@ -496,13 +454,8 @@ class WorkspaceAccessControl extends LitElement {
     }
 
     @media (max-width: 44rem) {
-      .assignment,
       .row {
         grid-template-columns: minmax(0, 1fr);
-      }
-
-      .submit {
-        justify-self: stretch;
       }
     }
   `
@@ -510,10 +463,6 @@ class WorkspaceAccessControl extends LitElement {
   updated(changed: Map<string, unknown>): void {
     if (changed.has('access') || changed.has('accessAttribute')) {
       this.ensureRole()
-      const status = this.resolvedAccess.status
-      if (status?.message && !status.error && !status.loading) {
-        this.selectedCandidate = null
-      }
     }
     if (changed.has('searchAttribute') && this.searchAttribute !== this.query) {
       this.query = this.searchAttribute
@@ -544,6 +493,19 @@ class WorkspaceAccessControl extends LitElement {
             <div class="label">Add people or groups</div>
             ${status.error ? html`<div class="status status-error" role="alert">${status.error}</div>` : nothing}
             ${status.message && !status.error ? html`<div class="status status-message" role="status">${status.message}</div>` : nothing}
+            <label class="role-field">
+              <span class="label">${this.modeIsObject(access) ? 'Privilege' : 'Role'}</span>
+              <select
+                class="assignment-role"
+                aria-label=${this.modeIsObject(access) ? 'Privilege to grant' : 'Role to assign'}
+                .value=${this.selectedRole}
+                ?disabled=${status.loading}
+                @change=${(event: Event) => { this.selectedRole = (event.currentTarget as HTMLSelectElement).value }}
+              >
+                <option value="">${this.modeIsObject(access) ? 'Select a privilege' : 'Select a role'}</option>
+                ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
+              </select>
+            </label>
             <label class="field-shell access-search">
               ${searchIcon()}
               <input
@@ -553,11 +515,11 @@ class WorkspaceAccessControl extends LitElement {
                 aria-controls="workspace-access-candidates"
                 placeholder="Search people and groups..."
                 .value=${this.query}
+                ?disabled=${!this.selectedRole || status.loading}
                 @input=${this.handleSearchInput}
               >
             </label>
-            ${this.renderCandidates(access)}
-            ${this.selectedCandidate ? this.renderAssignment(access, this.selectedCandidate, status) : nothing}
+            ${this.renderCandidates(access, status)}
           </section>
           <section class="card" aria-label="Current workspace access">
             <h3 class="section-title">${this.modeIsObject(access) ? 'Direct grants' : 'People with access'}</h3>
@@ -568,7 +530,10 @@ class WorkspaceAccessControl extends LitElement {
     `
   }
 
-  private renderCandidates(access: WorkspaceAccess) {
+  private renderCandidates(access: WorkspaceAccess, status: AccessStatus) {
+    if (!this.selectedRole) {
+      return html`<div class="search-state">Select a ${this.modeIsObject(access) ? 'privilege' : 'role'} to search people and groups.</div>`
+    }
     const searchStatus = access.searchStatus ?? {}
     if (!this.query.trim()) {
       return html`<div class="search-state">Search by name or email.</div>`
@@ -584,47 +549,30 @@ class WorkspaceAccessControl extends LitElement {
       return html`<div class="search-state">No people or groups found.</div>`
     }
     return html`
-      <div id="workspace-access-candidates" class="candidate-list" role="listbox" aria-label="People and groups">
+      <div id="workspace-access-candidates" class="candidate-list" role="list" aria-label="People and groups">
         ${candidates.map((candidate) => {
-          const selected = sameCandidate(candidate, this.selectedCandidate)
           return html`
-            <button
-              class=${selected ? 'candidate candidate-selected' : 'candidate'}
-              type="button"
-              role="option"
-              aria-selected=${String(selected)}
+            <div
+              class="candidate"
+              role="listitem"
               data-subject-type=${candidate.subjectType}
-              @click=${() => { this.selectedCandidate = candidate }}
             >
               ${subjectIcon(candidate.subjectType)}
               ${subjectCopy(candidate.label, candidate.detail)}
-            </button>
+              <button
+                class="row-action candidate-add"
+                type="button"
+                aria-label=${`Add ${candidate.label} as ${roleLabel(this.selectedRole)}`}
+                title=${`Add as ${roleLabel(this.selectedRole)}`}
+                ?disabled=${status.loading}
+                @click=${() => this.addCandidate(candidate)}
+              >
+                ${plusIcon()}
+              </button>
+            </div>
           `
         })}
       </div>
-    `
-  }
-
-  private renderAssignment(access: WorkspaceAccess, candidate: AccessCandidate, status: AccessStatus) {
-    return html`
-      <form class="assignment" @submit=${this.handleSubmit}>
-        <div class="selected-subject">
-          ${subjectIcon(candidate.subjectType)}
-          ${subjectCopy(candidate.label, candidate.detail)}
-        </div>
-        <select
-          class="assignment-role"
-          aria-label=${this.modeIsObject(access) ? 'Privilege to grant' : 'Role to assign'}
-          .value=${this.selectedRole}
-          ?disabled=${status.loading}
-          @change=${(event: Event) => { this.selectedRole = (event.currentTarget as HTMLSelectElement).value }}
-        >
-          ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
-        </select>
-        <button class="submit assign" type="submit" ?disabled=${status.loading || !this.selectedRole}>
-          ${status.loading ? 'Saving' : this.modeIsObject(access) ? 'Grant' : 'Assign'}
-        </button>
-      </form>
     `
   }
 
@@ -690,7 +638,7 @@ class WorkspaceAccessControl extends LitElement {
   private ensureRole(): void {
     const roles = this.roles
     if (roles.some((role) => role.name === this.selectedRole)) return
-    this.selectedRole = roles.find((role) => role.name === 'viewer')?.name ?? roles[0]?.name ?? ''
+    this.selectedRole = ''
   }
 
   private modeIsObject(access = this.resolvedAccess): boolean {
@@ -707,7 +655,6 @@ class WorkspaceAccessControl extends LitElement {
 
   private readonly handleSearchInput = (event: Event): void => {
     this.query = (event.currentTarget as HTMLInputElement).value
-    this.selectedCandidate = null
     this.dispatchEvent(new CustomEvent('ld-workspace-access-search', {
       bubbles: true,
       composed: true,
@@ -731,14 +678,13 @@ class WorkspaceAccessControl extends LitElement {
     }, 0)
   }
 
-  private readonly handleSubmit = (event: Event): void => {
-    event.preventDefault()
-    const candidate = this.selectedCandidate
-    if (!candidate || !this.selectedRole) return
+  private addCandidate(candidate: AccessCandidate): void {
+    const role = (this.renderRoot.querySelector('.assignment-role') as HTMLSelectElement | null)?.value.trim() ?? ''
+    if (!role) return
     const command: AccessCommand = {
       email: '',
-      role: this.modeIsObject() ? '' : this.selectedRole,
-      privilege: this.modeIsObject() ? this.selectedRole : '',
+      role: this.modeIsObject() ? '' : role,
+      privilege: this.modeIsObject() ? role : '',
       subjectType: candidate.subjectType,
       subjectId: candidate.subjectId,
     }
@@ -890,10 +836,6 @@ function displayLabel(binding: Binding): string {
   return binding.displayName || binding.groupName || binding.email || binding.subjectId || 'Principal'
 }
 
-function sameCandidate(left: AccessCandidate, right: AccessCandidate | null): boolean {
-  return Boolean(right && left.subjectType === right.subjectType && left.subjectId === right.subjectId)
-}
-
 function roleLabel(role: string): string {
   return role.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
 }
@@ -915,6 +857,10 @@ function subjectIcon(subjectType: 'principal' | 'group', extraClass = '') {
 
 function trashIcon() {
   return html`<span class="icon" aria-hidden="true">${lucideIcon(Trash2, { size: 16 })}</span>`
+}
+
+function plusIcon() {
+  return html`<span class="icon" aria-hidden="true">${lucideIcon(Plus, { size: 16 })}</span>`
 }
 
 function searchIcon() {

--- a/web/components/shared/workspace-access-control.ts
+++ b/web/components/shared/workspace-access-control.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html, nothing } from 'lit'
 import { property, state } from 'lit/decorators.js'
-import { Mail, Search, Trash2, Users } from 'lucide'
+import { Search, Trash2, UserRound, Users } from 'lucide'
 import { lucideIcon } from './lucide-icons'
 import './drawer'
 
@@ -24,10 +24,22 @@ type Binding = {
   role: string
 }
 
+type AccessCandidate = {
+  subjectType: 'principal' | 'group'
+  subjectId: string
+  label: string
+  detail: string
+}
+
 type AccessStatus = {
   loading?: boolean
   error?: string
   message?: string
+}
+
+type SearchStatus = {
+  loading?: boolean
+  error?: string
 }
 
 type WorkspaceAccess = {
@@ -38,7 +50,10 @@ type WorkspaceAccess = {
   mode?: string
   roles?: Role[]
   bindings?: Binding[]
+  candidates?: AccessCandidate[]
   canManage?: boolean
+  search?: string
+  searchStatus?: SearchStatus
   status?: AccessStatus
 }
 
@@ -46,7 +61,10 @@ type WorkspaceAccessInput = {
   workspace?: unknown
   roles?: unknown
   bindings?: unknown
+  candidates?: unknown
   canManage?: unknown
+  search?: unknown
+  searchStatus?: unknown
   status?: unknown
 }
 
@@ -63,7 +81,10 @@ type AccessCommand = {
 const emptyAccess: WorkspaceAccess = {
   roles: [],
   bindings: [],
+  candidates: [],
   canManage: false,
+  search: '',
+  searchStatus: {},
   status: {},
 }
 
@@ -73,13 +94,11 @@ class WorkspaceAccessControl extends LitElement {
   @property({ attribute: 'search' }) searchAttribute = ''
 
   @state() private open = false
-  @state() private email = ''
-  @state() private subjectType = 'principal'
   @state() private selectedRole = 'viewer'
   @state() private query = ''
+  @state() private selectedCandidate: AccessCandidate | null = null
 
   private previousFocus: HTMLElement | null = null
-  private searchTimer: number | null = null
 
   static styles = css`
     :host {
@@ -150,33 +169,6 @@ class WorkspaceAccessControl extends LitElement {
       line-height: var(--ld-line-height-snug);
     }
 
-    .row-action {
-      display: inline-flex;
-      width: var(--ld-control-medium);
-      height: var(--ld-control-medium);
-      flex: 0 0 auto;
-      align-items: center;
-      justify-content: center;
-      border: var(--ld-border-transparent);
-      border-radius: var(--ld-radius-default);
-      background: transparent;
-      color: var(--ld-fg-muted);
-      cursor: pointer;
-      padding: 0;
-      transition:
-        color var(--ld-transition-fast),
-        background-color var(--ld-transition-fast),
-        border-color var(--ld-transition-fast);
-    }
-
-    .row-action:hover,
-    .row-action:focus-visible {
-      border-color: var(--ld-line-muted);
-      background: var(--ld-bg-control-hover);
-      color: var(--ld-fg-default);
-      outline: 0;
-    }
-
     .drawer-body {
       display: grid;
       gap: var(--base-size-24);
@@ -225,39 +217,6 @@ class WorkspaceAccessControl extends LitElement {
       background: var(--ld-bg-control-hover);
     }
 
-    .composer {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
-      gap: var(--base-size-8);
-      align-items: center;
-    }
-
-    .composer-shell {
-      min-height: var(--ld-control-medium);
-      border-radius: var(--ld-radius-tight);
-      padding: var(--base-size-4) var(--base-size-6) var(--base-size-4) var(--base-size-12);
-    }
-
-    .composer-shell input {
-      flex: 1 1 12rem;
-    }
-
-    .composer-role {
-      width: auto;
-      min-width: 7rem;
-      flex: 0 0 auto;
-      border: 0;
-      border-left: var(--ld-border-muted);
-      border-radius: 0;
-      background: transparent;
-      color: var(--ld-fg-default);
-      padding-left: var(--base-size-12);
-    }
-
-    .composer-role:focus {
-      outline-offset: var(--base-size-2);
-    }
-
     input,
     select {
       min-height: var(--ld-control-medium);
@@ -272,18 +231,14 @@ class WorkspaceAccessControl extends LitElement {
       padding: 0 var(--base-size-8);
     }
 
-    .field-shell input,
-    .field-shell select {
+    .field-shell input {
       min-height: auto;
+      flex: 1 1 auto;
       border: 0;
       border-radius: 0;
       background: transparent;
       padding: 0;
       outline: 0;
-    }
-
-    .field-shell input {
-      flex: 1 1 auto;
     }
 
     input::placeholder {
@@ -293,8 +248,129 @@ class WorkspaceAccessControl extends LitElement {
     input:focus,
     select:focus {
       border-color: var(--ld-line-accent);
-      outline: 2px solid var(--ld-line-accent-muted);
+      outline: var(--ld-border-width-focus) solid var(--ld-line-accent-muted);
       outline-offset: 0;
+    }
+
+    .access-search {
+      min-height: var(--ld-control-large);
+    }
+
+    .candidate-list {
+      display: grid;
+      overflow: hidden;
+      border: var(--ld-border-muted);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-panel);
+    }
+
+    .candidate {
+      display: grid;
+      min-width: 0;
+      grid-template-columns: var(--base-size-32) minmax(0, 1fr);
+      align-items: center;
+      gap: var(--ld-space-control);
+      border: 0;
+      border-bottom: var(--ld-border-muted);
+      background: transparent;
+      color: var(--ld-fg-default);
+      cursor: pointer;
+      padding: var(--ld-space-control) var(--base-size-12);
+      text-align: left;
+    }
+
+    .candidate:last-child {
+      border-bottom: 0;
+    }
+
+    .candidate:hover,
+    .candidate:focus-visible,
+    .candidate-selected {
+      background: var(--ld-bg-control-hover);
+      outline: 0;
+    }
+
+    .subject-icon {
+      display: inline-flex;
+      width: var(--base-size-32);
+      height: var(--base-size-32);
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--ld-radius-full);
+      background: var(--ld-bg-control);
+      color: var(--ld-fg-muted);
+    }
+
+    .subject-icon-group {
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-accent-muted);
+      color: var(--ld-fg-accent);
+    }
+
+    .subject-copy {
+      display: grid;
+      min-width: 0;
+    }
+
+    .subject-label,
+    .subject-detail {
+      overflow: hidden;
+      margin: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .subject-label {
+      color: var(--ld-fg-default);
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-strong);
+      line-height: var(--ld-line-height-snug);
+    }
+
+    .subject-detail {
+      margin-top: var(--base-size-2);
+      color: var(--ld-fg-muted);
+      font-size: var(--ld-font-size-caption);
+      font-weight: var(--ld-font-weight-normal);
+      line-height: var(--ld-line-height-tight);
+    }
+
+    .search-state {
+      border: var(--ld-border-muted);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-panel);
+      color: var(--ld-fg-muted);
+      font-size: var(--ld-font-size-body-sm);
+      font-weight: var(--ld-font-weight-medium);
+      padding: var(--base-size-16);
+      text-align: center;
+    }
+
+    .search-state-error {
+      color: var(--ld-fg-danger);
+    }
+
+    .assignment {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(8rem, 10rem) auto;
+      align-items: center;
+      gap: var(--ld-space-control);
+      border: var(--ld-border-muted);
+      border-radius: var(--ld-radius-default);
+      background: var(--ld-bg-panel-muted);
+      padding: var(--base-size-12);
+    }
+
+    .selected-subject {
+      display: grid;
+      min-width: 0;
+      grid-template-columns: var(--base-size-32) minmax(0, 1fr);
+      align-items: center;
+      gap: var(--ld-space-control);
+    }
+
+    .assignment-role {
+      width: 100%;
     }
 
     .submit {
@@ -326,6 +402,33 @@ class WorkspaceAccessControl extends LitElement {
       color: var(--ld-button-accent-fg-disabled);
     }
 
+    .row-action {
+      display: inline-flex;
+      width: var(--ld-control-medium);
+      height: var(--ld-control-medium);
+      flex: 0 0 auto;
+      align-items: center;
+      justify-content: center;
+      border: var(--ld-border-transparent);
+      border-radius: var(--ld-radius-default);
+      background: transparent;
+      color: var(--ld-fg-muted);
+      cursor: pointer;
+      padding: 0;
+      transition:
+        color var(--ld-transition-fast),
+        background-color var(--ld-transition-fast),
+        border-color var(--ld-transition-fast);
+    }
+
+    .row-action:hover,
+    .row-action:focus-visible {
+      border-color: var(--ld-line-muted);
+      background: var(--ld-bg-control-hover);
+      color: var(--ld-fg-default);
+      outline: 0;
+    }
+
     .submit:disabled,
     .row-action:disabled {
       cursor: not-allowed;
@@ -347,20 +450,9 @@ class WorkspaceAccessControl extends LitElement {
     }
 
     .status-message {
-      border: 1px solid var(--ld-line-success-muted);
+      border: var(--borderWidth-default) solid var(--ld-line-success-muted);
       background: var(--ld-bg-success-muted);
       color: var(--ld-fg-success);
-    }
-
-    .toolbar {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(12rem, 18rem);
-      align-items: center;
-      gap: var(--base-size-12);
-    }
-
-    .search {
-      width: 100%;
     }
 
     .list {
@@ -380,54 +472,16 @@ class WorkspaceAccessControl extends LitElement {
       padding: var(--ld-space-control) var(--base-size-12);
     }
 
+    .row:last-child {
+      border-bottom: 0;
+    }
+
     .person {
       display: grid;
+      min-width: 0;
       grid-template-columns: var(--base-size-32) minmax(0, 1fr);
       align-items: center;
       gap: var(--base-size-8);
-      min-width: 0;
-    }
-
-    .principal-copy {
-      min-width: 0;
-    }
-
-    .avatar {
-      display: inline-flex;
-      width: var(--base-size-28);
-      height: var(--base-size-28);
-      align-items: center;
-      justify-content: center;
-      border: var(--ld-border-muted);
-      border-radius: 999px;
-      background: var(--ld-bg-control);
-      color: var(--ld-fg-muted);
-      font-size: var(--ld-font-size-caption);
-      font-weight: var(--ld-font-weight-strong);
-      line-height: 1;
-      text-transform: uppercase;
-    }
-
-    .name {
-      overflow: hidden;
-      margin: 0;
-      color: var(--ld-fg-default);
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      font-size: var(--ld-font-size-body-sm);
-      font-weight: var(--ld-font-weight-strong);
-      line-height: var(--ld-line-height-snug);
-    }
-
-    .email {
-      overflow: hidden;
-      margin: var(--base-size-2) 0 0;
-      color: var(--ld-fg-muted);
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      font-size: var(--ld-font-size-caption);
-      font-weight: var(--ld-font-weight-normal);
-      line-height: var(--ld-line-height-tight);
     }
 
     .empty {
@@ -442,23 +496,9 @@ class WorkspaceAccessControl extends LitElement {
     }
 
     @media (max-width: 44rem) {
-      .composer,
-      .row,
-      .toolbar {
+      .assignment,
+      .row {
         grid-template-columns: minmax(0, 1fr);
-      }
-
-      .composer-shell {
-        align-items: stretch;
-        flex-wrap: wrap;
-        padding: var(--base-size-8);
-      }
-
-      .composer-role {
-        min-width: 100%;
-        border-top: var(--ld-border-muted);
-        border-left: 0;
-        padding-left: var(--base-size-8);
       }
 
       .submit {
@@ -472,7 +512,7 @@ class WorkspaceAccessControl extends LitElement {
       this.ensureRole()
       const status = this.resolvedAccess.status
       if (status?.message && !status.error && !status.loading) {
-        this.email = ''
+        this.selectedCandidate = null
       }
     }
     if (changed.has('searchAttribute') && this.searchAttribute !== this.query) {
@@ -500,103 +540,133 @@ class WorkspaceAccessControl extends LitElement {
         <h2 class="title" slot="title" id="workspace-access-title">Manage access</h2>
         <p class="subtitle" slot="subtitle">${this.drawerSubtitle(access)}</p>
         <div class="drawer-body">
-            <section class="card" aria-label="Add workspace access">
-              <div class="label">Add people by email</div>
-              ${status.error ? html`<div class="status status-error" role="alert">${status.error}</div>` : nothing}
-              ${status.message && !status.error ? html`<div class="status status-message" role="status">${status.message}</div>` : nothing}
-              <form class="composer" @submit=${this.handleSubmit}>
-                <span class="field-shell composer-shell">
-                    ${mailIcon()}
-                    <select
-                      class="composer-role composer-subject-type"
-                      aria-label="Subject type"
-                      .value=${this.subjectType}
-                      ?disabled=${status.loading}
-                      @change=${(event: Event) => { this.subjectType = (event.currentTarget as HTMLSelectElement).value }}
-                    >
-                      <option value="principal">User</option>
-                      <option value="group">Group</option>
-                      <option value="service_principal">Service principal</option>
-                    </select>
-                    <input
-                      type=${this.subjectType === 'principal' ? 'email' : 'text'}
-                      autocomplete=${this.subjectType === 'principal' ? 'email' : 'off'}
-                      placeholder=${this.subjectType === 'principal' ? 'Search by email...' : 'Subject ID...'}
-                    aria-label=${this.subjectType === 'principal' ? 'Email principal' : 'Subject ID'}
-                    .value=${this.email}
-                    ?disabled=${status.loading}
-                      @input=${(event: Event) => { this.email = (event.currentTarget as HTMLInputElement).value }}
-                    >
-                    <select
-                      class="composer-role composer-grant-role"
-                      aria-label=${this.modeIsObject(access) ? 'Privilege to grant' : 'Role to assign'}
-                      .value=${this.selectedRole}
-                      ?disabled=${status.loading}
-                      @change=${(event: Event) => { this.selectedRole = (event.currentTarget as HTMLSelectElement).value }}
-                  >
-                    ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
-                  </select>
-                </span>
-                <button class="submit" type="submit" ?disabled=${status.loading || !this.email.trim() || !this.selectedRole}>
-                  ${status.loading ? 'Saving' : this.modeIsObject(access) ? 'Grant' : 'Assign'}
-                </button>
-              </form>
-            </section>
-            <section class="card" aria-label="Current workspace access">
-              <div class="toolbar">
-                <h3 class="section-title">${this.modeIsObject(access) ? 'Direct grants' : 'People with access'}</h3>
-                <span class="field-shell search">
-                  ${searchIcon()}
-                  <input
-                    type="search"
-                    placeholder="Search principals..."
-                    .value=${this.query}
-                    @input=${this.handleSearchInput}
-                  >
-                </span>
-              </div>
-              ${this.renderBindings(access)}
-            </section>
-          </div>
+          <section class="card" aria-label="Add workspace access">
+            <div class="label">Add people or groups</div>
+            ${status.error ? html`<div class="status status-error" role="alert">${status.error}</div>` : nothing}
+            ${status.message && !status.error ? html`<div class="status status-message" role="status">${status.message}</div>` : nothing}
+            <label class="field-shell access-search">
+              ${searchIcon()}
+              <input
+                type="search"
+                autocomplete="off"
+                aria-label="Search people and groups"
+                aria-controls="workspace-access-candidates"
+                placeholder="Search people and groups..."
+                .value=${this.query}
+                @input=${this.handleSearchInput}
+              >
+            </label>
+            ${this.renderCandidates(access)}
+            ${this.selectedCandidate ? this.renderAssignment(access, this.selectedCandidate, status) : nothing}
+          </section>
+          <section class="card" aria-label="Current workspace access">
+            <h3 class="section-title">${this.modeIsObject(access) ? 'Direct grants' : 'People with access'}</h3>
+            ${this.renderBindings(access)}
+          </section>
+        </div>
       </ld-drawer>
     `
   }
 
+  private renderCandidates(access: WorkspaceAccess) {
+    const searchStatus = access.searchStatus ?? {}
+    if (!this.query.trim()) {
+      return html`<div class="search-state">Search by name or email.</div>`
+    }
+    if (searchStatus.loading) {
+      return html`<div class="search-state" role="status">Searching...</div>`
+    }
+    if (searchStatus.error) {
+      return html`<div class="search-state search-state-error" role="alert">${searchStatus.error}</div>`
+    }
+    const candidates = access.candidates ?? []
+    if (candidates.length === 0) {
+      return html`<div class="search-state">No people or groups found.</div>`
+    }
+    return html`
+      <div id="workspace-access-candidates" class="candidate-list" role="listbox" aria-label="People and groups">
+        ${candidates.map((candidate) => {
+          const selected = sameCandidate(candidate, this.selectedCandidate)
+          return html`
+            <button
+              class=${selected ? 'candidate candidate-selected' : 'candidate'}
+              type="button"
+              role="option"
+              aria-selected=${String(selected)}
+              data-subject-type=${candidate.subjectType}
+              @click=${() => { this.selectedCandidate = candidate }}
+            >
+              ${subjectIcon(candidate.subjectType)}
+              ${subjectCopy(candidate.label, candidate.detail)}
+            </button>
+          `
+        })}
+      </div>
+    `
+  }
+
+  private renderAssignment(access: WorkspaceAccess, candidate: AccessCandidate, status: AccessStatus) {
+    return html`
+      <form class="assignment" @submit=${this.handleSubmit}>
+        <div class="selected-subject">
+          ${subjectIcon(candidate.subjectType)}
+          ${subjectCopy(candidate.label, candidate.detail)}
+        </div>
+        <select
+          class="assignment-role"
+          aria-label=${this.modeIsObject(access) ? 'Privilege to grant' : 'Role to assign'}
+          .value=${this.selectedRole}
+          ?disabled=${status.loading}
+          @change=${(event: Event) => { this.selectedRole = (event.currentTarget as HTMLSelectElement).value }}
+        >
+          ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
+        </select>
+        <button class="submit assign" type="submit" ?disabled=${status.loading || !this.selectedRole}>
+          ${status.loading ? 'Saving' : this.modeIsObject(access) ? 'Grant' : 'Assign'}
+        </button>
+      </form>
+    `
+  }
+
   private renderBindings(access: WorkspaceAccess) {
-    const rows = this.filteredBindings(access.bindings ?? [])
+    const rows = access.bindings ?? []
     if (rows.length === 0) {
-      return html`<div class="empty">${this.query ? 'No access entries match this search.' : 'No role bindings yet.'}</div>`
+      return html`<div class="empty">No role bindings yet.</div>`
     }
     return html`
       <div class="list">
-        ${rows.map((binding) => html`
-          <div class="row">
-            <div class="person">
-              <span class="avatar" aria-hidden="true">${principalInitial(binding)}</span>
-              <span class="principal-copy">
-                <p class="name">${displayLabel(binding)}</p>
-                <p class="email">${binding.email}</p>
-              </span>
+        ${rows.map((binding) => {
+          const subjectType = binding.subjectType === 'group' ? 'group' : 'principal'
+          const detail = subjectType === 'group' ? 'Group' : binding.email
+          return html`
+            <div class="row">
+              <div class="person">
+                ${subjectIcon(subjectType)}
+                <span class="subject-copy">
+                  <p class="name subject-label">${displayLabel(binding)}</p>
+                  <p class="email subject-detail">${detail}</p>
+                </span>
+              </div>
+              <select
+                aria-label=${`${this.modeIsObject(access) ? 'Privilege' : 'Role'} for ${displayLabel(binding)}`}
+                .value=${binding.role}
+                ?disabled=${access.status?.loading}
+                @change=${(event: Event) => this.updateBindingRole(binding, (event.currentTarget as HTMLSelectElement).value)}
+              >
+                ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
+              </select>
+              <button
+                class="row-action"
+                type="button"
+                aria-label=${`Remove ${displayLabel(binding)}`}
+                ?disabled=${access.status?.loading}
+                @click=${() => this.removeBinding(binding)}
+              >
+                ${trashIcon()}
+              </button>
             </div>
-            <select
-              aria-label=${`${this.modeIsObject(access) ? 'Privilege' : 'Role'} for ${displayLabel(binding)}`}
-              .value=${binding.role}
-              ?disabled=${access.status?.loading}
-              @change=${(event: Event) => this.updateBindingRole(binding, (event.currentTarget as HTMLSelectElement).value)}
-            >
-              ${this.roles.map((role) => html`<option value=${role.name}>${roleLabel(role.name)}</option>`)}
-            </select>
-            <button
-              class="row-action"
-              type="button"
-              aria-label=${`Remove ${displayLabel(binding)}`}
-              ?disabled=${access.status?.loading}
-              @click=${() => this.removeBinding(binding)}
-            >
-              ${trashIcon()}
-            </button>
-          </div>
-        `)}
+          `
+        })}
       </div>
     `
   }
@@ -635,24 +705,14 @@ class WorkspaceAccessControl extends LitElement {
     return `${access.workspace?.title ?? 'Workspace'} roles apply to every published asset in this workspace.`
   }
 
-  private filteredBindings(bindings: Binding[]): Binding[] {
-    const query = this.query.trim().toLowerCase()
-    if (!query) return bindings
-    return bindings.filter((binding) => {
-      return `${displayLabel(binding)} ${binding.email} ${binding.groupName ?? ''} ${binding.subjectId ?? ''} ${binding.subjectType ?? ''} ${binding.role}`.toLowerCase().includes(query)
-    })
-  }
-
   private readonly handleSearchInput = (event: Event): void => {
     this.query = (event.currentTarget as HTMLInputElement).value
-    if (this.searchTimer !== null) window.clearTimeout(this.searchTimer)
-    this.searchTimer = window.setTimeout(() => {
-      this.dispatchEvent(new CustomEvent('ld-workspace-access-search', {
-        bubbles: true,
-        composed: true,
-        detail: { search: this.query },
-      }))
-    }, 200)
+    this.selectedCandidate = null
+    this.dispatchEvent(new CustomEvent('ld-workspace-access-search', {
+      bubbles: true,
+      composed: true,
+      detail: { search: this.query },
+    }))
   }
 
   private readonly openDialog = (): void => {
@@ -665,10 +725,6 @@ class WorkspaceAccessControl extends LitElement {
 
   private readonly closeDialog = (): void => {
     this.open = false
-    if (this.searchTimer !== null) {
-      window.clearTimeout(this.searchTimer)
-      this.searchTimer = null
-    }
     window.setTimeout(() => {
       if (this.previousFocus?.isConnected) this.previousFocus.focus()
       this.previousFocus = null
@@ -677,15 +733,15 @@ class WorkspaceAccessControl extends LitElement {
 
   private readonly handleSubmit = (event: Event): void => {
     event.preventDefault()
-    const subjectID = this.email.trim()
+    const candidate = this.selectedCandidate
+    if (!candidate || !this.selectedRole) return
     const command: AccessCommand = {
-      email: this.subjectType === 'principal' ? subjectID : '',
+      email: '',
       role: this.modeIsObject() ? '' : this.selectedRole,
       privilege: this.modeIsObject() ? this.selectedRole : '',
-      subjectType: this.subjectType,
-      subjectId: this.subjectType === 'principal' ? '' : subjectID,
+      subjectType: candidate.subjectType,
+      subjectId: candidate.subjectId,
     }
-    if (!subjectID || (!command.role && !command.privilege)) return
     this.dispatchEvent(new CustomEvent('ld-workspace-access-upsert', {
       bubbles: true,
       composed: true,
@@ -704,7 +760,7 @@ class WorkspaceAccessControl extends LitElement {
         privilege: this.modeIsObject() ? role : '',
         bindingId: binding.id,
         subjectType: binding.subjectType || 'principal',
-        subjectId: binding.subjectId,
+        subjectId: binding.subjectId || binding.principalId,
       },
     }))
   }
@@ -734,7 +790,10 @@ function normalizeAccess(access: WorkspaceAccessInput): WorkspaceAccess {
     mode: stringValue(raw.mode ?? raw.Mode),
     roles: Array.isArray(access.roles) ? access.roles.map(normalizeRole).filter(isRole) : [],
     bindings: Array.isArray(access.bindings) ? access.bindings.map(normalizeBinding).filter(isBinding) : [],
+    candidates: Array.isArray(access.candidates) ? access.candidates.map(normalizeCandidate).filter(isCandidate) : [],
     canManage: Boolean(access.canManage ?? raw.CanManage),
+    search: stringValue(access.search ?? raw.Search),
+    searchStatus: normalizeSearchStatus(access.searchStatus ?? raw.SearchStatus),
     status: normalizeStatus(access.status ?? raw.Status),
   }
 }
@@ -776,6 +835,20 @@ function normalizeBinding(binding: unknown): Binding | null {
   }
 }
 
+function normalizeCandidate(candidate: unknown): AccessCandidate | null {
+  const raw = recordValue(candidate)
+  const subjectType = stringValue(raw.subjectType ?? raw.SubjectType)
+  const subjectId = stringValue(raw.subjectId ?? raw.SubjectID)
+  const label = stringValue(raw.label ?? raw.Label)
+  if ((subjectType !== 'principal' && subjectType !== 'group') || !subjectId || !label) return null
+  return {
+    subjectType,
+    subjectId,
+    label,
+    detail: stringValue(raw.detail ?? raw.Detail),
+  }
+}
+
 function normalizeStatus(status: unknown): AccessStatus {
   const raw = recordValue(status)
   return {
@@ -785,12 +858,24 @@ function normalizeStatus(status: unknown): AccessStatus {
   }
 }
 
+function normalizeSearchStatus(status: unknown): SearchStatus {
+  const raw = recordValue(status)
+  return {
+    loading: Boolean(raw.loading ?? raw.Loading),
+    error: stringValue(raw.error ?? raw.Error),
+  }
+}
+
 function isRole(role: Role | null): role is Role {
   return role !== null
 }
 
 function isBinding(binding: Binding | null): binding is Binding {
   return binding !== null
+}
+
+function isCandidate(candidate: AccessCandidate | null): candidate is AccessCandidate {
+  return candidate !== null
 }
 
 function recordValue(value: unknown): Record<string, unknown> {
@@ -805,17 +890,27 @@ function displayLabel(binding: Binding): string {
   return binding.displayName || binding.groupName || binding.email || binding.subjectId || 'Principal'
 }
 
-function principalInitial(binding: Binding): string {
-  const label = displayLabel(binding).trim()
-  return label ? label[0] : '?'
+function sameCandidate(left: AccessCandidate, right: AccessCandidate | null): boolean {
+  return Boolean(right && left.subjectType === right.subjectType && left.subjectId === right.subjectId)
 }
 
 function roleLabel(role: string): string {
   return role.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
 }
 
-function usersIcon() {
-  return html`<span class="icon" aria-hidden="true">${lucideIcon(Users, { size: 16 })}</span>`
+function subjectCopy(label: string, detail: string) {
+  return html`
+    <span class="subject-copy">
+      <span class="subject-label">${label}</span>
+      <span class="subject-detail">${detail}</span>
+    </span>
+  `
+}
+
+function subjectIcon(subjectType: 'principal' | 'group', extraClass = '') {
+  const className = `${extraClass} subject-icon subject-icon-${subjectType}`.trim()
+  const icon = subjectType === 'group' ? Users : UserRound
+  return html`<span class=${className} aria-hidden="true">${lucideIcon(icon, { size: 16 })}</span>`
 }
 
 function trashIcon() {
@@ -826,11 +921,11 @@ function searchIcon() {
   return html`<span class="icon" aria-hidden="true">${lucideIcon(Search, { size: 16 })}</span>`
 }
 
-function mailIcon() {
-  return html`<span class="icon" aria-hidden="true">${lucideIcon(Mail, { size: 16 })}</span>`
+function usersIcon() {
+  return html`<span class="icon" aria-hidden="true">${lucideIcon(Users, { size: 16 })}</span>`
 }
 
-customElements.define('ld-workspace-access-control', WorkspaceAccessControl)
+if (!customElements.get('ld-workspace-access-control')) customElements.define('ld-workspace-access-control', WorkspaceAccessControl)
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -334,7 +334,7 @@ test('workspace asset search filters the current asset rows', async () => {
   }
 })
 
-test('workspace access drawer normalizes Go-shaped access signals', async () => {
+test('workspace access drawer searches principals and groups before assigning a role', async () => {
   const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
   try {
     await page.goto(baseURL)
@@ -344,21 +344,44 @@ test('workspace access drawer normalizes Go-shaped access signals', async () => 
     const state = await page.evaluate(async () => {
       const workspace = document.querySelector('ld-workspace-page') as any
       const accessControl = workspace.shadowRoot.querySelector('ld-workspace-access-control') as any
+      const searchEvents: unknown[] = []
+      const upsertEvents: unknown[] = []
+      accessControl.addEventListener('ld-workspace-access-search', (event: CustomEvent) => searchEvents.push(event.detail))
+      accessControl.addEventListener('ld-workspace-access-upsert', (event: CustomEvent) => upsertEvents.push(event.detail))
       accessControl.shadowRoot.querySelector('.trigger').click()
       await accessControl.updateComplete
       const drawer = accessControl.shadowRoot.querySelector('ld-drawer') as any
       const dialog = drawer?.shadowRoot?.querySelector('[role="dialog"]')
-      const roleOptions = Array.from(accessControl.shadowRoot.querySelectorAll('.composer-role option')).map((option) => ({
+      const search = accessControl.shadowRoot.querySelector('.access-search input') as HTMLInputElement
+      search.value = 'finance'
+      search.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }))
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      const candidates = Array.from(accessControl.shadowRoot.querySelectorAll<HTMLButtonElement>('.candidate'))
+      const candidateTypes = candidates.map((candidate) => candidate.dataset.subjectType)
+      candidates[0]?.click()
+      await accessControl.updateComplete
+      const rolePicker = accessControl.shadowRoot.querySelector('.assignment-role') as HTMLSelectElement
+      const roleOptions = Array.from(rolePicker.options).map((option) => ({
         value: (option as HTMLOptionElement).value,
         label: option.textContent?.trim(),
       }))
+      rolePicker.value = 'workspace_admin'
+      rolePicker.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
+      accessControl.shadowRoot.querySelector<HTMLButtonElement>('.assign')?.click()
       const rowRole = accessControl.shadowRoot.querySelector('.row select') as HTMLSelectElement | null
       return {
         hasDrawer: Boolean(drawer),
         hasDialog: Boolean(dialog),
         modal: dialog?.getAttribute('aria-modal'),
         title: accessControl.shadowRoot.querySelector('.subtitle')?.textContent?.trim(),
+        hasSubjectTypePicker: Boolean(accessControl.shadowRoot.querySelector('.composer-subject-type')),
+        searchPlaceholder: search.placeholder,
+        searchEvents,
+        candidateTypes,
+        candidateLabels: candidates.map((candidate) => candidate.textContent?.replace(/\s+/g, ' ').trim()),
+        selectedSubject: accessControl.shadowRoot.querySelector('.selected-subject')?.textContent?.replace(/\s+/g, ' ').trim(),
         roleOptions,
+        upsertEvents,
         rowRoleValue: rowRole?.value,
         principal: accessControl.shadowRoot.querySelector('.name')?.textContent?.trim(),
       }
@@ -369,13 +392,23 @@ test('workspace access drawer normalizes Go-shaped access signals', async () => 
       hasDialog: true,
       modal: 'true',
       title: 'LibreDash Workspace roles apply to every published asset in this workspace.',
+      hasSubjectTypePicker: false,
+      searchPlaceholder: 'Search people and groups...',
+      searchEvents: [{ search: 'finance' }],
+      candidateTypes: ['principal', 'group'],
+      candidateLabels: ['Ana Analyst ana@example.com', 'Analytics Group'],
+      selectedSubject: 'Ana Analyst ana@example.com',
       roleOptions: [
-        { value: 'principal', label: 'User' },
-        { value: 'group', label: 'Group' },
-        { value: 'service_principal', label: 'Service principal' },
         { value: 'viewer', label: 'Viewer' },
         { value: 'workspace_admin', label: 'Workspace Admin' },
       ],
+      upsertEvents: [{
+        email: '',
+        role: 'workspace_admin',
+        privilege: '',
+        subjectType: 'principal',
+        subjectId: 'principal_ana',
+      }],
       rowRoleValue: 'viewer',
       principal: 'analyst@example.com',
     })
@@ -640,10 +673,15 @@ function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
       DisplayName: '',
       Role: 'viewer',
     }],
+    candidates: [
+      { subjectType: 'principal', subjectId: 'principal_ana', label: 'Ana Analyst', detail: 'ana@example.com' },
+      { subjectType: 'group', subjectId: 'group_analytics', label: 'Analytics', detail: 'Group' },
+    ],
     canManage: true,
     status: { loading: false, error: '', message: '' },
     command: { email: '', role: '', principalId: '' },
-    search: '',
+    search: 'ana',
+    searchStatus: { loading: false, error: '' },
   }
   const route = root === 'connections'
     ? { signals: { page: connectionsPage }, element: '<ld-connections-page></ld-connections-page>' }

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -71,6 +71,8 @@ for (const viewport of [
         const workspacePage = workspace.shadowRoot.querySelector('.page') as HTMLElement
         const workspaceToolbar = workspace.shadowRoot.querySelector('.toolbar') as HTMLElement
         const workspaceRecordTable = workspace.shadowRoot.querySelector('ld-record-table') as HTMLElement
+        const workspaceGlyph = workspace.shadowRoot.querySelector('.record-entity-icon') as HTMLElement | null
+        const workspaceDashboardGlyph = workspace.shadowRoot.querySelector('.record-icon-dashboard') as HTMLElement | null
         const workspaceRowActionIcon = workspace.shadowRoot.querySelector('.record-actions svg') as SVGElement
         const workspaceRowActionLink = workspace.shadowRoot.querySelector('.record-actions .record-icon-action') as HTMLElement
         const workspaceNameCell = workspace.shadowRoot.querySelector('tbody tr:first-child td:first-child') as HTMLElement
@@ -97,7 +99,10 @@ for (const viewport of [
           workspaceToolbarDisplay: getComputedStyle(workspaceToolbar).display,
           workspaceHasGlyphs: Boolean(workspace.shadowRoot.querySelector('.record-entity-icon')),
           workspaceHasDescriptions: Boolean(workspace.shadowRoot.querySelector('.record-entity-description')),
-          workspaceNamesUseFullWidth: Array.from(workspace.shadowRoot.querySelectorAll('.record-entity')).every((entity) => entity.classList.contains('record-entity-no-icon')),
+          workspaceNamesUseIconTrack: Array.from(workspace.shadowRoot.querySelectorAll('.record-entity')).every((entity) => !entity.classList.contains('record-entity-no-icon')),
+          workspaceGlyphHasIcon: Boolean(workspaceGlyph?.querySelector('svg')),
+          workspaceGlyphBackground: workspaceGlyph ? getComputedStyle(workspaceGlyph).backgroundColor : '',
+          workspaceDashboardGlyphBorderColor: workspaceDashboardGlyph ? getComputedStyle(workspaceDashboardGlyph).borderTopColor : '',
           workspaceRowActionIconWidth: getComputedStyle(workspaceRowActionIcon).width,
           workspaceRowActionBorderColor: getComputedStyle(workspaceRowActionLink).borderTopColor,
           workspaceSearchFontSize: getComputedStyle(workspaceSearch).fontSize,
@@ -123,9 +128,12 @@ for (const viewport of [
         workspacePageCentered: true,
         workspacePageConstrained: true,
         workspaceToolbarDisplay: 'grid',
-        workspaceHasGlyphs: false,
+        workspaceHasGlyphs: true,
         workspaceHasDescriptions: false,
-        workspaceNamesUseFullWidth: true,
+        workspaceNamesUseIconTrack: true,
+        workspaceGlyphHasIcon: true,
+        workspaceGlyphBackground: 'rgb(221, 244, 255)',
+        workspaceDashboardGlyphBorderColor: 'rgb(210, 191, 255)',
         workspaceRowActionIconWidth: '16px',
         workspaceRowActionBorderColor: 'rgba(0, 0, 0, 0)',
         workspaceSearchFontSize: '14px',

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -80,6 +80,7 @@ for (const viewport of [
         const workspaceHeaderCell = workspace.shadowRoot.querySelector('thead th') as HTMLElement
         const workspaceFirstRow = workspace.shadowRoot.querySelector('tbody tr:first-child') as HTMLElement
         const workspaceSearch = workspace.shadowRoot.querySelector('.search input[type="search"]') as HTMLInputElement
+        const workspaceSearchForm = workspace.shadowRoot.querySelector('.search') as HTMLElement
         const workspaceAssetTitle = workspace.shadowRoot.querySelector('tbody tr:first-child .record-entity-label') as HTMLElement
         const workspaceAssetEntity = workspace.shadowRoot.querySelector('tbody tr:first-child .record-entity') as HTMLElement
         const nameCellRight = workspaceNameCell.getBoundingClientRect().right
@@ -108,6 +109,7 @@ for (const viewport of [
           workspaceRowActionBorderColor: getComputedStyle(workspaceRowActionLink).borderTopColor,
           workspaceSearchFontSize: getComputedStyle(workspaceSearch).fontSize,
           workspaceSearchHeight: Math.round(workspaceSearch.getBoundingClientRect().height),
+          workspaceSearchSpansToolbar: Math.abs(workspaceSearchForm.getBoundingClientRect().width - workspaceToolbar.getBoundingClientRect().width) <= 1,
           workspaceHeaderFontSize: getComputedStyle(workspaceHeaderCell).fontSize,
           workspaceCellFontSize: getComputedStyle(workspaceTypeCell).fontSize,
           workspaceTitleFontSize: getComputedStyle(workspaceAssetTitle).fontSize,
@@ -141,6 +143,7 @@ for (const viewport of [
         workspaceRowActionBorderColor: 'rgba(0, 0, 0, 0)',
         workspaceSearchFontSize: '14px',
         workspaceSearchHeight: 32,
+        workspaceSearchSpansToolbar: true,
         workspaceHeaderFontSize: '12px',
         workspaceCellFontSize: '12px',
         workspaceTitleFontSize: '12px',

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -334,7 +334,7 @@ test('workspace asset search filters the current asset rows', async () => {
   }
 })
 
-test('workspace access drawer searches principals and groups before assigning a role', async () => {
+test('workspace access drawer selects a role before searching and adds each result directly', async () => {
   const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
   try {
     await page.goto(baseURL)
@@ -352,22 +352,24 @@ test('workspace access drawer searches principals and groups before assigning a 
       await accessControl.updateComplete
       const drawer = accessControl.shadowRoot.querySelector('ld-drawer') as any
       const dialog = drawer?.shadowRoot?.querySelector('[role="dialog"]')
-      const search = accessControl.shadowRoot.querySelector('.access-search input') as HTMLInputElement
-      search.value = 'finance'
-      search.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }))
-      await new Promise((resolve) => setTimeout(resolve, 250))
-      const candidates = Array.from(accessControl.shadowRoot.querySelectorAll<HTMLButtonElement>('.candidate'))
-      const candidateTypes = candidates.map((candidate) => candidate.dataset.subjectType)
-      candidates[0]?.click()
-      await accessControl.updateComplete
       const rolePicker = accessControl.shadowRoot.querySelector('.assignment-role') as HTMLSelectElement
+      const search = accessControl.shadowRoot.querySelector('.access-search input') as HTMLInputElement
+      const rolePrecedesSearch = Boolean(rolePicker.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING)
+      const searchDisabledBeforeRole = search.disabled
       const roleOptions = Array.from(rolePicker.options).map((option) => ({
         value: (option as HTMLOptionElement).value,
         label: option.textContent?.trim(),
       }))
-      rolePicker.value = 'workspace_admin'
+      rolePicker.value = 'data_deployer'
       rolePicker.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
-      accessControl.shadowRoot.querySelector<HTMLButtonElement>('.assign')?.click()
+      await accessControl.updateComplete
+      search.value = 'finance'
+      search.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }))
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      const candidates = Array.from(accessControl.shadowRoot.querySelectorAll<HTMLElement>('.candidate'))
+      const candidateTypes = candidates.map((candidate) => candidate.dataset.subjectType)
+      const addButtons = Array.from(accessControl.shadowRoot.querySelectorAll<HTMLButtonElement>('.candidate-add'))
+      addButtons[0]?.click()
       const rowRole = accessControl.shadowRoot.querySelector('.row select') as HTMLSelectElement | null
       return {
         hasDrawer: Boolean(drawer),
@@ -375,11 +377,15 @@ test('workspace access drawer searches principals and groups before assigning a 
         modal: dialog?.getAttribute('aria-modal'),
         title: accessControl.shadowRoot.querySelector('.subtitle')?.textContent?.trim(),
         hasSubjectTypePicker: Boolean(accessControl.shadowRoot.querySelector('.composer-subject-type')),
+        rolePrecedesSearch,
+        searchDisabledBeforeRole,
+        searchDisabledAfterRole: search.disabled,
         searchPlaceholder: search.placeholder,
         searchEvents,
         candidateTypes,
         candidateLabels: candidates.map((candidate) => candidate.textContent?.replace(/\s+/g, ' ').trim()),
-        selectedSubject: accessControl.shadowRoot.querySelector('.selected-subject')?.textContent?.replace(/\s+/g, ' ').trim(),
+        addButtonLabels: addButtons.map((button) => button.getAttribute('aria-label')),
+        hasSelectedSubject: Boolean(accessControl.shadowRoot.querySelector('.selected-subject')),
         roleOptions,
         upsertEvents,
         rowRoleValue: rowRole?.value,
@@ -393,18 +399,24 @@ test('workspace access drawer searches principals and groups before assigning a 
       modal: 'true',
       title: 'LibreDash Workspace roles apply to every published asset in this workspace.',
       hasSubjectTypePicker: false,
+      rolePrecedesSearch: true,
+      searchDisabledBeforeRole: true,
+      searchDisabledAfterRole: false,
       searchPlaceholder: 'Search people and groups...',
       searchEvents: [{ search: 'finance' }],
       candidateTypes: ['principal', 'group'],
       candidateLabels: ['Ana Analyst ana@example.com', 'Analytics Group'],
-      selectedSubject: 'Ana Analyst ana@example.com',
+      addButtonLabels: ['Add Ana Analyst as Data Deployer', 'Add Analytics as Data Deployer'],
+      hasSelectedSubject: false,
       roleOptions: [
+        { value: '', label: 'Select a role' },
         { value: 'viewer', label: 'Viewer' },
         { value: 'workspace_admin', label: 'Workspace Admin' },
+        { value: 'data_deployer', label: 'Data Deployer' },
       ],
       upsertEvents: [{
         email: '',
-        role: 'workspace_admin',
+        role: 'data_deployer',
         privilege: '',
         subjectType: 'principal',
         subjectId: 'principal_ana',
@@ -666,7 +678,7 @@ function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
   }
   const access = {
     workspace: { ID: 'libredash', Title: 'LibreDash Workspace' },
-    roles: [{ Name: 'viewer' }, { Name: 'workspace_admin' }],
+    roles: [{ Name: 'viewer' }, { Name: 'workspace_admin' }, { Name: 'data_deployer' }],
     bindings: [{
       PrincipalID: 'principal:analyst@example.com',
       Email: 'analyst@example.com',

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -77,6 +77,9 @@ for (const viewport of [
         const workspaceRowActionLink = workspace.shadowRoot.querySelector('.record-actions .record-icon-action') as HTMLElement
         const workspaceNameCell = workspace.shadowRoot.querySelector('tbody tr:first-child td:first-child') as HTMLElement
         const workspaceTypeCell = workspace.shadowRoot.querySelector('tbody tr:first-child td:nth-child(2)') as HTMLElement
+        const workspaceHeaderCell = workspace.shadowRoot.querySelector('thead th') as HTMLElement
+        const workspaceFirstRow = workspace.shadowRoot.querySelector('tbody tr:first-child') as HTMLElement
+        const workspaceSearch = workspace.shadowRoot.querySelector('.search input[type="search"]') as HTMLInputElement
         const workspaceAssetTitle = workspace.shadowRoot.querySelector('tbody tr:first-child .record-entity-label') as HTMLElement
         const workspaceAssetDescription = workspace.shadowRoot.querySelector('tbody tr:first-child .record-entity-description') as HTMLElement
         const nameCellRight = workspaceNameCell.getBoundingClientRect().right
@@ -99,6 +102,13 @@ for (const viewport of [
           workspaceDashboardGlyphBorderColor: getComputedStyle(workspaceDashboardGlyph).borderTopColor,
           workspaceRowActionIconWidth: getComputedStyle(workspaceRowActionIcon).width,
           workspaceRowActionBorderColor: getComputedStyle(workspaceRowActionLink).borderTopColor,
+          workspaceSearchFontSize: getComputedStyle(workspaceSearch).fontSize,
+          workspaceSearchHeight: Math.round(workspaceSearch.getBoundingClientRect().height),
+          workspaceHeaderFontSize: getComputedStyle(workspaceHeaderCell).fontSize,
+          workspaceCellFontSize: getComputedStyle(workspaceTypeCell).fontSize,
+          workspaceTitleFontSize: getComputedStyle(workspaceAssetTitle).fontSize,
+          workspaceDescriptionFontSize: getComputedStyle(workspaceAssetDescription).fontSize,
+          workspaceRowHeight: Math.round(workspaceFirstRow.getBoundingClientRect().height),
           workspaceTitleFitsNameColumn: workspaceAssetTitle.getBoundingClientRect().right <= nameCellRight,
           workspaceDescriptionFitsNameColumn: workspaceAssetDescription.getBoundingClientRect().right <= nameCellRight,
         }
@@ -121,6 +131,13 @@ for (const viewport of [
         workspaceDashboardGlyphBorderColor: 'rgb(210, 191, 255)',
         workspaceRowActionIconWidth: '16px',
         workspaceRowActionBorderColor: 'rgba(0, 0, 0, 0)',
+        workspaceSearchFontSize: '14px',
+        workspaceSearchHeight: 32,
+        workspaceHeaderFontSize: '12px',
+        workspaceCellFontSize: '12px',
+        workspaceTitleFontSize: '14px',
+        workspaceDescriptionFontSize: '12px',
+        workspaceRowHeight: 48,
         workspaceTitleFitsNameColumn: true,
         workspaceDescriptionFitsNameColumn: true,
       })
@@ -617,7 +634,7 @@ function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
       <head>
         <style>
           html, body { margin: 0; min-height: 100%; }
-          body { --fontStack-system: system-ui; --ld-bg-app: #f6f8fa; --ld-bg-panel: #fff; --ld-bg-panel-muted: #f6f8fa; --ld-bg-control: #f6f8fa; --ld-bg-control-hover: #f3f4f6; --ld-fg-default: #24292f; --ld-fg-muted: #57606a; --ld-fg-link: #0969da; --ld-accent: #0969da; --ld-accent-fg: #fff; --ld-line-muted: #d8dee4; --ld-line-accent: #0969da; --ld-border-default: 1px solid #d0d7de; --ld-border-muted: 1px solid #d8dee4; --ld-border-transparent: 1px solid transparent; --ld-radius-default: 6px; --ld-radius-tight: 4px; --ld-radius-full: 999px; --ld-page-content-max-width: 72rem; --ld-workspace-detail-max-width: 72rem; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-10: 10px; --base-size-12: 12px; --base-size-16: 16px; --base-size-20: 20px; --base-size-24: 24px; --ld-space-control: 10px; --control-medium-size: 32px; --control-xlarge-size: 40px; --ld-font-size-caption: 12px; --ld-font-size-body-sm: 14px; --ld-font-size-title-sm: 16px; --ld-font-weight-medium: 500; --ld-font-weight-strong: 600; --ld-line-height-tight: 1.2; --ld-line-height-compact: 1.3; --ld-asset-dashboard-bg: #fbefff; --ld-asset-dashboard-accent: #8250df; --ld-asset-dashboard-border: #d2bfff; --ld-asset-semantic-model-bg: #ddf4ff; --ld-asset-semantic-model-accent: #0969da; --ld-asset-semantic-model-border: #b6e3ff; --z-index-inspector: 1000; --ld-modal-backdrop: rgb(0 0 0 / .28); }
+          body { --fontStack-system: system-ui; --ld-bg-app: #f6f8fa; --ld-bg-panel: #fff; --ld-bg-panel-muted: #f6f8fa; --ld-bg-control: #f6f8fa; --ld-bg-control-hover: #f3f4f6; --ld-fg-default: #24292f; --ld-fg-muted: #57606a; --ld-fg-link: #0969da; --ld-accent: #0969da; --ld-accent-fg: #fff; --ld-line-muted: #d8dee4; --ld-line-accent: #0969da; --ld-border-default: 1px solid #d0d7de; --ld-border-muted: 1px solid #d8dee4; --ld-border-transparent: 1px solid transparent; --ld-radius-default: 6px; --ld-radius-tight: 4px; --ld-radius-full: 999px; --ld-page-content-max-width: 72rem; --ld-workspace-detail-max-width: 72rem; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-10: 10px; --base-size-12: 12px; --base-size-16: 16px; --base-size-20: 20px; --base-size-24: 24px; --ld-space-control: 10px; --control-medium-size: 32px; --control-xlarge-size: 40px; --ld-font-size-caption: 12px; --ld-font-size-body-sm: 12px; --ld-font-size-body-md: 14px; --ld-font-size-title-sm: 16px; --ld-font-weight-regular: 400; --ld-font-weight-medium: 500; --ld-font-weight-strong: 600; --ld-line-height-tight: 1.2; --ld-line-height-compact: 1.3; --ld-line-height-normal: 1.5; --ld-asset-dashboard-bg: #fbefff; --ld-asset-dashboard-accent: #8250df; --ld-asset-dashboard-border: #d2bfff; --ld-asset-semantic-model-bg: #ddf4ff; --ld-asset-semantic-model-accent: #0969da; --ld-asset-semantic-model-border: #b6e3ff; --z-index-inspector: 1000; --ld-modal-backdrop: rgb(0 0 0 / .28); }
           ld-workspace-page, ld-connections-page, ld-workspace-asset-page { display: block; min-height: 720px; }
         </style>
       </head>

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -346,8 +346,10 @@ test('workspace access drawer selects a role before searching and adds each resu
       const accessControl = workspace.shadowRoot.querySelector('ld-workspace-access-control') as any
       const searchEvents: unknown[] = []
       const upsertEvents: unknown[] = []
+      const removeEvents: unknown[] = []
       accessControl.addEventListener('ld-workspace-access-search', (event: CustomEvent) => searchEvents.push(event.detail))
       accessControl.addEventListener('ld-workspace-access-upsert', (event: CustomEvent) => upsertEvents.push(event.detail))
+      accessControl.addEventListener('ld-workspace-access-remove', (event: CustomEvent) => removeEvents.push(event.detail))
       accessControl.shadowRoot.querySelector('.trigger').click()
       await accessControl.updateComplete
       const drawer = accessControl.shadowRoot.querySelector('ld-drawer') as any
@@ -370,6 +372,7 @@ test('workspace access drawer selects a role before searching and adds each resu
       const candidateTypes = candidates.map((candidate) => candidate.dataset.subjectType)
       const addButtons = Array.from(accessControl.shadowRoot.querySelectorAll<HTMLButtonElement>('.candidate-add'))
       addButtons[0]?.click()
+      accessControl.shadowRoot.querySelector<HTMLButtonElement>('button[aria-label="Remove Operations Group"]')?.click()
       const rowRole = accessControl.shadowRoot.querySelector('.row select') as HTMLSelectElement | null
       return {
         hasDrawer: Boolean(drawer),
@@ -388,6 +391,7 @@ test('workspace access drawer selects a role before searching and adds each resu
         hasSelectedSubject: Boolean(accessControl.shadowRoot.querySelector('.selected-subject')),
         roleOptions,
         upsertEvents,
+        removeEvents,
         rowRoleValue: rowRole?.value,
         principal: accessControl.shadowRoot.querySelector('.name')?.textContent?.trim(),
       }
@@ -420,6 +424,12 @@ test('workspace access drawer selects a role before searching and adds each resu
         privilege: '',
         subjectType: 'principal',
         subjectId: 'principal_ana',
+      }],
+      removeEvents: [{
+        principalId: '',
+        bindingId: 'rolebinding_operations',
+        subjectType: 'group',
+        subjectId: 'group_operations',
       }],
       rowRoleValue: 'viewer',
       principal: 'analyst@example.com',
@@ -680,9 +690,21 @@ function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
     workspace: { ID: 'libredash', Title: 'LibreDash Workspace' },
     roles: [{ Name: 'viewer' }, { Name: 'workspace_admin' }, { Name: 'data_deployer' }],
     bindings: [{
+      ID: 'rolebinding_analyst',
+      SubjectType: 'principal',
+      SubjectID: 'principal:analyst@example.com',
       PrincipalID: 'principal:analyst@example.com',
       Email: 'analyst@example.com',
       DisplayName: '',
+      Role: 'viewer',
+    }, {
+      ID: 'rolebinding_operations',
+      SubjectType: 'group',
+      SubjectID: 'group_operations',
+      PrincipalID: '',
+      GroupID: 'group_operations',
+      Email: '',
+      GroupName: 'Operations Group',
       Role: 'viewer',
     }],
     candidates: [

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -71,8 +71,6 @@ for (const viewport of [
         const workspacePage = workspace.shadowRoot.querySelector('.page') as HTMLElement
         const workspaceToolbar = workspace.shadowRoot.querySelector('.toolbar') as HTMLElement
         const workspaceRecordTable = workspace.shadowRoot.querySelector('ld-record-table') as HTMLElement
-        const workspaceGlyph = workspace.shadowRoot.querySelector('.record-entity-icon') as HTMLElement
-        const workspaceDashboardGlyph = workspace.shadowRoot.querySelector('.record-icon-dashboard') as HTMLElement
         const workspaceRowActionIcon = workspace.shadowRoot.querySelector('.record-actions svg') as SVGElement
         const workspaceRowActionLink = workspace.shadowRoot.querySelector('.record-actions .record-icon-action') as HTMLElement
         const workspaceNameCell = workspace.shadowRoot.querySelector('tbody tr:first-child td:first-child') as HTMLElement
@@ -81,7 +79,6 @@ for (const viewport of [
         const workspaceFirstRow = workspace.shadowRoot.querySelector('tbody tr:first-child') as HTMLElement
         const workspaceSearch = workspace.shadowRoot.querySelector('.search input[type="search"]') as HTMLInputElement
         const workspaceAssetTitle = workspace.shadowRoot.querySelector('tbody tr:first-child .record-entity-label') as HTMLElement
-        const workspaceAssetDescription = workspace.shadowRoot.querySelector('tbody tr:first-child .record-entity-description') as HTMLElement
         const nameCellRight = workspaceNameCell.getBoundingClientRect().right
         const workspacePageRect = workspacePage.getBoundingClientRect()
         const isMobile = window.innerWidth <= 720
@@ -98,10 +95,9 @@ for (const viewport of [
           workspacePageCentered: isMobile || Math.abs((workspacePageRect.left + workspacePageRect.width / 2) - window.innerWidth / 2) <= 1,
           workspacePageConstrained: isMobile || Math.round(workspacePageRect.width) < window.innerWidth,
           workspaceToolbarDisplay: getComputedStyle(workspaceToolbar).display,
-          workspaceGlyphText: workspaceGlyph.textContent?.trim(),
-          workspaceGlyphBackground: getComputedStyle(workspaceGlyph).backgroundColor,
-          workspaceGlyphHasIcon: Boolean(workspaceGlyph.querySelector('svg')),
-          workspaceDashboardGlyphBorderColor: getComputedStyle(workspaceDashboardGlyph).borderTopColor,
+          workspaceHasGlyphs: Boolean(workspace.shadowRoot.querySelector('.record-entity-icon')),
+          workspaceHasDescriptions: Boolean(workspace.shadowRoot.querySelector('.record-entity-description')),
+          workspaceNamesUseFullWidth: Array.from(workspace.shadowRoot.querySelectorAll('.record-entity')).every((entity) => entity.classList.contains('record-entity-no-icon')),
           workspaceRowActionIconWidth: getComputedStyle(workspaceRowActionIcon).width,
           workspaceRowActionBorderColor: getComputedStyle(workspaceRowActionLink).borderTopColor,
           workspaceSearchFontSize: getComputedStyle(workspaceSearch).fontSize,
@@ -109,10 +105,8 @@ for (const viewport of [
           workspaceHeaderFontSize: getComputedStyle(workspaceHeaderCell).fontSize,
           workspaceCellFontSize: getComputedStyle(workspaceTypeCell).fontSize,
           workspaceTitleFontSize: getComputedStyle(workspaceAssetTitle).fontSize,
-          workspaceDescriptionFontSize: getComputedStyle(workspaceAssetDescription).fontSize,
           workspaceRowHeight: Math.round(workspaceFirstRow.getBoundingClientRect().height),
           workspaceTitleFitsNameColumn: workspaceAssetTitle.getBoundingClientRect().right <= nameCellRight,
-          workspaceDescriptionFitsNameColumn: workspaceAssetDescription.getBoundingClientRect().right <= nameCellRight,
         }
       })
 
@@ -129,10 +123,9 @@ for (const viewport of [
         workspacePageCentered: true,
         workspacePageConstrained: true,
         workspaceToolbarDisplay: 'grid',
-        workspaceGlyphText: '',
-        workspaceGlyphBackground: 'rgb(221, 244, 255)',
-        workspaceGlyphHasIcon: true,
-        workspaceDashboardGlyphBorderColor: 'rgb(210, 191, 255)',
+        workspaceHasGlyphs: false,
+        workspaceHasDescriptions: false,
+        workspaceNamesUseFullWidth: true,
         workspaceRowActionIconWidth: '16px',
         workspaceRowActionBorderColor: 'rgba(0, 0, 0, 0)',
         workspaceSearchFontSize: '14px',
@@ -140,10 +133,8 @@ for (const viewport of [
         workspaceHeaderFontSize: '12px',
         workspaceCellFontSize: '12px',
         workspaceTitleFontSize: '14px',
-        workspaceDescriptionFontSize: '12px',
-        workspaceRowHeight: 48,
+        workspaceRowHeight: 47,
         workspaceTitleFitsNameColumn: true,
-        workspaceDescriptionFitsNameColumn: true,
       })
 
       await page.goto(`${baseURL}/connections`)

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -144,7 +144,7 @@ for (const viewport of [
         workspaceHeaderFontSize: '12px',
         workspaceCellFontSize: '12px',
         workspaceTitleFontSize: '12px',
-        workspaceTitleFontWeight: '400',
+        workspaceTitleFontWeight: '600',
         workspaceAssetVerticalAlignment: 'center',
         workspaceRowHeight: 47,
         workspaceTitleFitsNameColumn: true,

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -334,7 +334,7 @@ test('workspace asset search filters the current asset rows', async () => {
   }
 })
 
-test('workspace access modal normalizes Go-shaped access signals', async () => {
+test('workspace access drawer normalizes Go-shaped access signals', async () => {
   const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
   try {
     await page.goto(baseURL)
@@ -346,14 +346,17 @@ test('workspace access modal normalizes Go-shaped access signals', async () => {
       const accessControl = workspace.shadowRoot.querySelector('ld-workspace-access-control') as any
       accessControl.shadowRoot.querySelector('.trigger').click()
       await accessControl.updateComplete
-      const dialog = accessControl.shadowRoot.querySelector('[role="dialog"]')
+      const drawer = accessControl.shadowRoot.querySelector('ld-drawer') as any
+      const dialog = drawer?.shadowRoot?.querySelector('[role="dialog"]')
       const roleOptions = Array.from(accessControl.shadowRoot.querySelectorAll('.composer-role option')).map((option) => ({
         value: (option as HTMLOptionElement).value,
         label: option.textContent?.trim(),
       }))
       const rowRole = accessControl.shadowRoot.querySelector('.row select') as HTMLSelectElement | null
       return {
+        hasDrawer: Boolean(drawer),
         hasDialog: Boolean(dialog),
+        modal: dialog?.getAttribute('aria-modal'),
         title: accessControl.shadowRoot.querySelector('.subtitle')?.textContent?.trim(),
         roleOptions,
         rowRoleValue: rowRole?.value,
@@ -361,16 +364,18 @@ test('workspace access modal normalizes Go-shaped access signals', async () => {
       }
     })
 
-	expect(state).toEqual({
-		hasDialog: false,
-		title: 'LibreDash Workspace roles apply to every published asset in this workspace.',
-		roleOptions: [
-			{ value: 'principal', label: 'User' },
-			{ value: 'group', label: 'Group' },
-			{ value: 'service_principal', label: 'Service principal' },
-			{ value: 'viewer', label: 'Viewer' },
-			{ value: 'workspace_admin', label: 'Workspace Admin' },
-		],
+    expect(state).toEqual({
+      hasDrawer: true,
+      hasDialog: true,
+      modal: 'true',
+      title: 'LibreDash Workspace roles apply to every published asset in this workspace.',
+      roleOptions: [
+        { value: 'principal', label: 'User' },
+        { value: 'group', label: 'Group' },
+        { value: 'service_principal', label: 'Service principal' },
+        { value: 'viewer', label: 'Viewer' },
+        { value: 'workspace_admin', label: 'Workspace Admin' },
+      ],
       rowRoleValue: 'viewer',
       principal: 'analyst@example.com',
     })

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -81,6 +81,7 @@ for (const viewport of [
         const workspaceFirstRow = workspace.shadowRoot.querySelector('tbody tr:first-child') as HTMLElement
         const workspaceSearch = workspace.shadowRoot.querySelector('.search input[type="search"]') as HTMLInputElement
         const workspaceAssetTitle = workspace.shadowRoot.querySelector('tbody tr:first-child .record-entity-label') as HTMLElement
+        const workspaceAssetEntity = workspace.shadowRoot.querySelector('tbody tr:first-child .record-entity') as HTMLElement
         const nameCellRight = workspaceNameCell.getBoundingClientRect().right
         const workspacePageRect = workspacePage.getBoundingClientRect()
         const isMobile = window.innerWidth <= 720
@@ -110,6 +111,8 @@ for (const viewport of [
           workspaceHeaderFontSize: getComputedStyle(workspaceHeaderCell).fontSize,
           workspaceCellFontSize: getComputedStyle(workspaceTypeCell).fontSize,
           workspaceTitleFontSize: getComputedStyle(workspaceAssetTitle).fontSize,
+          workspaceTitleFontWeight: getComputedStyle(workspaceAssetTitle).fontWeight,
+          workspaceAssetVerticalAlignment: getComputedStyle(workspaceAssetEntity).alignItems,
           workspaceRowHeight: Math.round(workspaceFirstRow.getBoundingClientRect().height),
           workspaceTitleFitsNameColumn: workspaceAssetTitle.getBoundingClientRect().right <= nameCellRight,
         }
@@ -140,7 +143,9 @@ for (const viewport of [
         workspaceSearchHeight: 32,
         workspaceHeaderFontSize: '12px',
         workspaceCellFontSize: '12px',
-        workspaceTitleFontSize: '14px',
+        workspaceTitleFontSize: '12px',
+        workspaceTitleFontWeight: '400',
+        workspaceAssetVerticalAlignment: 'center',
         workspaceRowHeight: 47,
         workspaceTitleFitsNameColumn: true,
       })

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -90,6 +90,8 @@ for (const viewport of [
           workspaceHasAsset: Boolean(workspaceRecordTable && workspace.shadowRoot.querySelector('.record-entity-label')),
           workspaceTableVariant: workspaceRecordTable.getAttribute('variant'),
           workspaceTableHeaders: Array.from(workspaceRecordTable.querySelectorAll('thead th button span:first-child')).map((header) => header.textContent?.trim()),
+          workspaceTableMinWidth: getComputedStyle(workspaceRecordTable.querySelector('table') as HTMLElement).minWidth,
+          workspaceRowActionCounts: Array.from(workspaceRecordTable.querySelectorAll('tbody tr')).map((row) => row.querySelectorAll('.record-icon-action').length),
           workspaceTableHeaderBackground: getComputedStyle(workspaceRecordTable.querySelector('thead th') as HTMLElement).backgroundColor,
           workspaceHasAccess: Boolean(workspace.shadowRoot.querySelector('ld-workspace-access-control')),
           workspaceIsStyled: getComputedStyle(workspacePage).paddingTop !== '0px',
@@ -118,7 +120,9 @@ for (const viewport of [
         workspaceTitle: 'LibreDash Workspace',
         workspaceHasAsset: true,
         workspaceTableVariant: 'primary',
-        workspaceTableHeaders: ['Name', 'Type', 'Key', 'Actions'],
+        workspaceTableHeaders: ['Name', 'Type', 'Actions'],
+        workspaceTableMinWidth: '640px',
+        workspaceRowActionCounts: [1, 2],
         workspaceTableHeaderBackground: 'rgb(246, 248, 250)',
         workspaceHasAccess: true,
         workspaceIsStyled: true,
@@ -294,9 +298,14 @@ test('workspace asset search filters the current asset rows', async () => {
       input.focus()
       const focusedStyle = getComputedStyle(input)
       const after = Array.from(root.querySelectorAll('.record-entity-label')).map((link) => link.textContent?.trim())
+      input.value = 'olist'
+      input.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      await workspace.updateComplete
+      const afterKeySearch = Array.from(root.querySelectorAll('.record-entity-label')).map((link) => link.textContent?.trim())
       return {
         before,
         after,
+        afterKeySearch,
         focusedBorderColor: focusedStyle.borderTopColor,
         focusedOutlineStyle: focusedStyle.outlineStyle,
         hasSubmitButton: Boolean(root.querySelector('.toolbar .search button[type="submit"]')),
@@ -307,6 +316,7 @@ test('workspace asset search filters the current asset rows', async () => {
 
     expect(state.before).toEqual(['Executive Sales Dashboard', 'Customer Segments'])
     expect(state.after).toEqual(['Customer Segments'])
+    expect(state.afterKeySearch).toEqual(['Executive Sales Dashboard'])
     expect(state.focusedBorderColor).toBe('rgb(9, 105, 218)')
     expect(state.focusedOutlineStyle).toBe('solid')
     expect(state.hasSubmitButton).toBe(false)

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -731,8 +731,8 @@ const workspaceStyles = css`
   .search {
     position: relative;
     display: block;
-    max-width: 34rem;
     min-width: 0;
+    width: 100%;
   }
 
   input[type='search'] {

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -49,10 +49,12 @@ const emptyWorkspaceAccess: WorkspaceAccessSignal = {
   workspace: {},
   roles: [],
   bindings: [],
+  candidates: [],
   canManage: false,
   status: { loading: false, error: '', message: '' },
   command: { bindingId: '', email: '', principalId: '', privilege: '', role: '', subjectId: '', subjectType: '' },
   search: '',
+  searchStatus: { loading: false, error: '' },
 }
 
 class LibreDashWorkspacePage extends DatastarLit(LitElement) {

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -744,6 +744,8 @@ const workspaceStyles = css`
     background: var(--ld-bg-control);
     color: var(--ld-fg-default);
     padding: 0 calc(var(--base-size-24) + var(--base-size-12)) 0 var(--base-size-12);
+    font-size: var(--ld-font-size-body-md);
+    line-height: var(--ld-line-height-compact);
   }
 
   input[type='search']:focus {

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -367,9 +367,7 @@ function renderAssetTable(assets: WorkspaceAssetSummarySignal[], empty: string) 
       return {
         name: {
           label: asset.title,
-          description: asset.description,
           href: asset.detailHref,
-          icon: asset.type,
         },
         type: asset.typeLabel,
         actions,

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -368,6 +368,7 @@ function renderAssetTable(assets: WorkspaceAssetSummarySignal[], empty: string) 
         name: {
           label: asset.title,
           href: asset.detailHref,
+          icon: asset.type,
         },
         type: asset.typeLabel,
         actions,

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -355,27 +355,28 @@ function renderAssetTable(assets: WorkspaceAssetSummarySignal[], empty: string) 
   if (!assets.length) return html`<div class="panel"><div class="empty">${empty}</div></div>`
   const table: RecordTableSignal = {
     columns: [
-      { id: 'name', header: 'Name', kind: 'entity', width: '42%' },
+      { id: 'name', header: 'Name', kind: 'entity' },
       { id: 'type', header: 'Type', width: '150px' },
-      { id: 'key', header: 'Key', kind: 'code', width: '180px' },
       { id: 'actions', header: 'Actions', kind: 'actions', align: 'right', width: '104px', sortable: false } as any,
     ],
-    rows: assets.map((asset) => ({
-      name: {
-        label: asset.title,
-        description: asset.description,
-        href: asset.detailHref,
-        icon: asset.type,
-      },
-      type: asset.typeLabel,
-      key: asset.key,
-      actions: [
-        { label: 'View details', href: asset.detailHref, icon: 'details' },
-        { label: 'Open asset', href: asset.openHref, icon: 'open' },
-      ],
-    })),
+    rows: assets.map((asset) => {
+      const actions = [{ label: 'View details', href: asset.detailHref, icon: 'details' }]
+      if (asset.openHref && asset.openHref !== asset.detailHref) {
+        actions.push({ label: 'Open asset', href: asset.openHref, icon: 'open' })
+      }
+      return {
+        name: {
+          label: asset.title,
+          description: asset.description,
+          href: asset.detailHref,
+          icon: asset.type,
+        },
+        type: asset.typeLabel,
+        actions,
+      }
+    }),
     empty,
-    minWidth: '840px',
+    minWidth: '640px',
   }
   return html`
     <div class="panel">


### PR DESCRIPTION
## Summary

- tighten workspace asset search and table typography for a denser, full-width list
- remove the visible key column while keeping key-based filtering
- keep compact asset icons and emphasize names while simplifying row actions
- show a details action for every asset and a second open action only for dashboards
- share the drawer shell between workspace access management and query history
- redesign access assignment around one debounced Datastar search for people and groups
- require an explicit role or privilege before searching, with a direct add action on every result
- show distinct principal and group icons and preserve the exact selected role through persistence
- delete the exact workspace role binding so principal and group removal use the same reliable path
- add bounded server-side candidate search that excludes service principals and existing assignments

## Testing

- task ci

Stacked on #105.