### PR TITLE
Fix documentation QA findings

### DIFF
--- a/docs/guides/cli/authentication.md
+++ b/docs/guides/cli/authentication.md
@@ -1,11 +1,46 @@
 # Install and authenticate the CLI
 
-Run the CLI from the LeapView release or from a checked-out repository.
+Use a LeapView release for routine operation, or run the CLI from a checked-out repository when developing LeapView itself. Confirm that the command you invoke matches the server contract you intend to operate:
 
-Store an API token for a target before calling remote operations.
+```sh
+leapview --help
+```
+
+## Authenticate an interactive workstation
+
+Create a narrowly scoped API token for the target, then store it with [`leapview login`](/docs/cli/login):
 
 ```sh
 leapview login --target https://dash.example.com --token "$LEAPVIEW_API_TOKEN"
 ```
 
-For automation, provide `LEAPVIEW_TARGET` and `LEAPVIEW_API_TOKEN` through the environment instead of writing credentials to a local target configuration.
+Login verifies the target before writing the credential. The saved token is associated with the exact target URL and the client configuration file is restricted to the current user. Do not commit that file, copy it into an image, or share it between operators.
+
+After login, commands can use the saved token when the same target is supplied:
+
+```sh
+leapview plan \
+  --project dashboards/leapview.yaml \
+  --target https://dash.example.com \
+  --workspace retail
+```
+
+## Authenticate automation
+
+In CI, inject `LEAPVIEW_TARGET` and `LEAPVIEW_API_TOKEN` from the platform's secret manager. Do not run `leapview login`: ephemeral jobs should not persist credentials to a home directory.
+
+```sh
+export LEAPVIEW_TARGET=https://dash.example.com
+export LEAPVIEW_API_TOKEN="$PUBLISHER_TOKEN"
+leapview plan --project dashboards/leapview.yaml --workspace retail --json
+```
+
+Use a dedicated service identity with only the grants required by the job. Scope production credentials to protected branches or approved deployment environments, mask them in logs, and rotate them without changing the project source.
+
+## Diagnose authentication failures
+
+First confirm the target URL is exact and reachable. A token saved for one URL is not reused for a different hostname or scheme. Then check that the credential is present and has not expired or been revoked. An HTTP `401` usually means the credential could not be authenticated; `403` means the authenticated principal lacks permission for that operation.
+
+Do not solve a `403` by immediately granting broad administrative access. Compare the failed operation with the service identity's effective grants and add the narrowest missing privilege.
+
+See [Targets and environments](/docs/cli/targets) for safe target selection, [Automation and CI](/docs/cli/automation) for secret handling in pipelines, and the [CLI troubleshooting guide](/docs/cli/troubleshooting) for a diagnostic sequence.

--- a/docs/guides/cli/automation.md
+++ b/docs/guides/cli/automation.md
@@ -1,11 +1,59 @@
 # Automation and CI
 
-Treat validation and deployment as separate CI steps. Validate every change, generate a plan for review, then deploy only from an approved branch.
+Treat validation, planning, approval, and deployment as separate gates. Build one candidate from an immutable Git revision, review its plan, and deploy that unchanged candidate only from an approved branch or environment.
+
+## Provide bounded credentials
+
+Inject `LEAPVIEW_TARGET` and `LEAPVIEW_API_TOKEN` from the CI secret manager. Use a dedicated service principal, protect production secrets with environment approval, and prevent pull requests from untrusted forks from reading them. The validation job does not need either secret.
+
+Keep the expected environment and workspace in reviewable pipeline configuration:
+
+```sh
+export TARGET_ENVIRONMENT=production
+export TARGET_WORKSPACE=retail
+```
+
+## Validate without network access
+
+Compile the complete project first and retain structured diagnostics as a job artifact:
 
 ```sh
 leapview validate --project dashboards/leapview.yaml --json
-leapview plan --project dashboards/leapview.yaml --target "$LEAPVIEW_TARGET" --json
-leapview deploy --project dashboards/leapview.yaml --target "$LEAPVIEW_TARGET" --auto-approve
 ```
 
-Provide tokens only through the deployment environment or your CI secret manager.
+Stop the pipeline on any non-zero exit status. Do not allow a later deployment job to replace or edit the project after validation.
+
+## Generate a reviewable plan
+
+Plan against the exact target identity and workspace that will receive the deployment:
+
+```sh
+leapview plan \
+  --project dashboards/leapview.yaml \
+  --target "$LEAPVIEW_TARGET" \
+  --environment "$TARGET_ENVIRONMENT" \
+  --workspace "$TARGET_WORKSPACE" \
+  --json > leapview-plan.json
+```
+
+Publish `leapview-plan.json` as a protected artifact. Review removals, access-policy changes, resource identity changes, and managed-data revision pins. Regenerate the plan after any source change.
+
+## Deploy after approval
+
+Run deployment from a protected job using the same project, target, environment, and revision pins that produced the reviewed plan:
+
+```sh
+leapview deploy \
+  --project dashboards/leapview.yaml \
+  --target "$LEAPVIEW_TARGET" \
+  --environment "$TARGET_ENVIRONMENT" \
+  --auto-approve
+```
+
+`--auto-approve` is appropriate only because the pipeline provides the approval gate. Do not use it to bypass review in an unprotected job.
+
+## Preserve evidence and verify
+
+Record the Git revision, target environment, actor, plan artifact, deployment result, and managed-data digests together. After deployment, probe readiness and exercise a representative workspace query or dashboard. A transport retry must reuse the same immutable candidate; never rebuild from a moving branch between attempts.
+
+See [Validate, plan, and deploy](/docs/cli/validate-deploy) for the operational sequence, [Targets and environments](/docs/cli/targets) for environment safeguards, and the generated [`validate`](/docs/cli/validate), [`plan`](/docs/cli/plan), and [`deploy`](/docs/cli/deploy) references for all flags.

--- a/docs/guides/cli/targets.md
+++ b/docs/guides/cli/targets.md
@@ -1,11 +1,46 @@
 # Targets and environments
 
-Use an explicit target and environment for production-like plans and deployments. Keep local development, staging, and production targets separate.
+The target tells the CLI which LeapView instance to contact. The environment is the instance identity that the CLI expects to find there. Use both for production-like work so a valid credential or copied command cannot silently reach the wrong instance.
+
+## Choose explicit boundaries
+
+Give development, staging, and production separate URLs and credentials. A workspace name may exist in more than one instance, so it is not a sufficient deployment boundary by itself.
+
+For a remote plan, name the target, expected environment, and workspace together:
 
 ```sh
 leapview plan --project dashboards/leapview.yaml \
   --target https://dash.staging.example.com \
-  --environment staging
+  --environment staging \
+  --workspace retail
 ```
 
-The same project definition can be validated locally before it is deployed to a remote target.
+LeapView reads the target's environment before planning or deploying. If `--environment staging` reaches an instance that identifies itself as `production`, the command stops instead of continuing.
+
+## Supply a target
+
+For an occasional command, pass `--target` explicitly. For one shell or CI job, set `LEAPVIEW_TARGET`. For repeated local use, [`leapview login`](/docs/cli/login) stores a token under its exact target URL:
+
+```sh
+leapview login \
+  --target https://dash.staging.example.com \
+  --token "$LEAPVIEW_API_TOKEN"
+```
+
+Avoid aliases that can be repointed between environments. Use the same normalized URL when logging in and running later commands so the saved credential can be found.
+
+## Keep local validation separate
+
+[`leapview validate`](/docs/cli/validate) compiles the project locally and does not require a target. Run it before contacting any environment:
+
+```sh
+leapview validate --project dashboards/leapview.yaml
+```
+
+Then use an explicit remote target for the plan and deployment. Keep the project path, environment, target, workspace, and managed-data revision pins unchanged between review and activation.
+
+## Verify before deployment
+
+Check the target URL and asserted environment in reviewable CI configuration, not only in an operator's shell history. Use separate protected environments and secret scopes so a staging job cannot read the production token.
+
+Continue with [Validate, plan, and deploy](/docs/cli/validate-deploy) for the full promotion workflow and [`leapview plan`](/docs/cli/plan) for every targeting option.

--- a/docs/guides/cli/troubleshooting.md
+++ b/docs/guides/cli/troubleshooting.md
@@ -1,10 +1,50 @@
 # CLI troubleshooting
 
-Start with the local validation error: it points to the project file and the invalid field. For remote operations, confirm the target URL, API token, and workspace selection.
+Troubleshoot from the narrowest local check outward. Preserve the exact command, exit status, and sanitized error output before changing configuration; the first failure is usually more useful than errors produced after several speculative changes.
+
+## Validate the local environment
+
+Check process-wide production requirements, then compile the project without contacting a target:
 
 ```sh
 leapview config validate --production
-leapview healthcheck --url https://dash.example.com/healthz
+leapview validate --project dashboards/leapview.yaml
 ```
 
-Use `leapview <command> --help` for a quick reminder, then use the command reference for the complete option list.
+Validation diagnostics identify the source file and invalid field or reference. Fix the earliest root diagnostic first; later missing-resource messages may be consequences of it. If behavior differs in CI, compare the project revision, working directory, generated files, environment variables, and CLI version.
+
+## Check server readiness
+
+If local validation succeeds but a remote command cannot connect, check the instance readiness endpoint directly:
+
+```sh
+leapview healthcheck \
+  --url https://dash.example.com/readyz \
+  --timeout 10s
+```
+
+A connection or TLS error points to DNS, certificates, proxies, or network policy. A non-success readiness response means the instance is reachable but not ready; inspect server logs before retrying a deployment.
+
+## Check target identity and authentication
+
+Confirm the scheme, hostname, expected environment, and workspace. Saved credentials are keyed by the exact target URL. Run a read-only plan with explicit boundaries:
+
+```sh
+leapview plan \
+  --project dashboards/leapview.yaml \
+  --target https://dash.example.com \
+  --environment production \
+  --workspace retail
+```
+
+For `401` responses, verify that a token was supplied for that target and is still valid. For `403`, inspect the authenticated identity's effective grants for the failed operation. Do not broaden the credential until the missing privilege is understood.
+
+## Interpret planning and deployment failures
+
+If a plan shows unexpected removals, stop and inspect workspace discovery patterns and stable resource IDs. If a managed revision is rejected, confirm that its immutable digest was staged on the same target and connection named by the project. If an environment assertion fails, correct the target rather than changing the assertion to match an unintended instance.
+
+Deployment failures should leave the last valid serving state active. Verify that state, preserve the rejected candidate and server diagnostics, then correct and re-run validation and planning. Do not repeatedly submit a changing candidate while diagnosing one failure.
+
+## Find command-specific help
+
+Use `leapview <command> --help` for syntax at the terminal and the [generated CLI reference](/docs/cli/reference) for complete flags and subcommands. Continue with [Authentication](/docs/cli/authentication), [Targets and environments](/docs/cli/targets), or [Validate, plan, and deploy](/docs/cli/validate-deploy) according to the failing stage.

--- a/internal/site/http/docs.go
+++ b/internal/site/http/docs.go
@@ -15,6 +15,8 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
 	g "maragu.dev/gomponents"
 	h "maragu.dev/gomponents/html"
 )
@@ -22,6 +24,7 @@ import (
 var markdownRenderer = goldmark.New(
 	goldmark.WithExtensions(extension.GFM),
 	goldmark.WithParserOptions(parser.WithAttribute()),
+	goldmark.WithRendererOptions(renderer.WithNodeRenderers(util.Prioritized(semanticTableCellRenderer{}, 100))),
 )
 
 type siteDocument struct {

--- a/internal/site/http/markdown_table.go
+++ b/internal/site/http/markdown_table.go
@@ -1,0 +1,55 @@
+package http
+
+import (
+	"fmt"
+
+	goldmarkast "github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	extensionast "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/renderer"
+	renderhtml "github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+// semanticTableCellRenderer treats the first cell in each Markdown table body
+// row as its row header. Documentation tables consistently use that column to
+// name the option, field, status, or resource described by the remaining cells.
+type semanticTableCellRenderer struct{}
+
+func (semanticTableCellRenderer) RegisterFuncs(registerer renderer.NodeRendererFuncRegisterer) {
+	registerer.Register(extensionast.KindTableCell, renderSemanticTableCell)
+}
+
+func renderSemanticTableCell(writer util.BufWriter, _ []byte, node goldmarkast.Node, entering bool) (goldmarkast.WalkStatus, error) {
+	cell := node.(*extensionast.TableCell)
+	isColumnHeader := cell.Parent().Kind() == extensionast.KindTableHeader
+	isRowHeader := cell.Parent().Kind() == extensionast.KindTableRow && cell.PreviousSibling() == nil
+	tag := "td"
+	if isColumnHeader || isRowHeader {
+		tag = "th"
+	}
+
+	if !entering {
+		_, _ = fmt.Fprintf(writer, "</%s>\n", tag)
+		return goldmarkast.WalkContinue, nil
+	}
+
+	_, _ = fmt.Fprintf(writer, "<%s", tag)
+	if isColumnHeader {
+		_, _ = writer.WriteString(` scope="col"`)
+	} else if isRowHeader {
+		_, _ = writer.WriteString(` scope="row"`)
+	}
+	if cell.Alignment != extensionast.AlignNone {
+		_, _ = fmt.Fprintf(writer, ` style="text-align:%s"`, cell.Alignment.String())
+	}
+	if cell.Attributes() != nil {
+		if tag == "th" {
+			renderhtml.RenderAttributes(writer, cell, extension.TableThCellAttributeFilter)
+		} else {
+			renderhtml.RenderAttributes(writer, cell, extension.TableTdCellAttributeFilter)
+		}
+	}
+	_ = writer.WriteByte('>')
+	return goldmarkast.WalkContinue, nil
+}

--- a/internal/site/http/server.go
+++ b/internal/site/http/server.go
@@ -198,6 +198,7 @@ func docsActiveSearch(w http.ResponseWriter, r *http.Request) {
 
 	_ = pagestream.PatchResponse(w, r, pagestream.SignalPatch{
 		"docsSearch": map[string]any{
+			"loading":     false,
 			"resultQuery": query,
 			"results":     results,
 			"total":       len(matches),

--- a/internal/site/http/server_internal_test.go
+++ b/internal/site/http/server_internal_test.go
@@ -684,6 +684,21 @@ func TestSiteDocumentationActiveSearchStreamsRankedResults(t *testing.T) {
 	}
 }
 
+func TestDocumentationMarkdownTablesExposeRowHeaders(t *testing.T) {
+	server := httptest.NewServer(NewHandler())
+	defer server.Close()
+
+	response, err := server.Client().Get(server.URL + "/docs/configuration")
+	if err != nil {
+		t.Fatalf("get configuration documentation: %v", err)
+	}
+	defer response.Body.Close()
+	body := readBody(t, response)
+	if !strings.Contains(body, `<th scope="row">`) {
+		t.Fatalf("configuration table does not expose body row headers")
+	}
+}
+
 func TestEveryCatalogDocumentHasAReachableRoute(t *testing.T) {
 	server := httptest.NewServer(NewHandler())
 	defer server.Close()

--- a/internal/tools/openapidocgen/main.go
+++ b/internal/tools/openapidocgen/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"unicode"
@@ -392,12 +393,16 @@ func renderIndexDocument(catalog generatedCatalog) string {
 
 func renderTagDocument(tag openAPITag, operations []taggedOperation) string {
 	var markdown strings.Builder
+	commonErrors := commonErrorResponses(operations)
 	markdown.WriteString(generatedMarkdownMarker + "\n\n")
 	markdown.WriteString("# " + tag.Name + "\n\n")
 	if tag.Description != "" {
 		markdown.WriteString(strings.TrimSpace(tag.Description) + "\n\n")
 	}
 	markdown.WriteString("## Operations\n\n")
+	if len(commonErrors) > 0 {
+		markdown.WriteString("Each operation lists its specific responses. See [Common error responses](#common-error-responses) for errors shared by every operation on this page.\n\n")
+	}
 	for _, operation := range operations {
 		title := operation.Value.Summary
 		if title == "" {
@@ -411,9 +416,42 @@ func renderTagDocument(tag openAPITag, operations []taggedOperation) string {
 		writeOperationMetadata(&markdown, operation)
 		writeParameters(&markdown, operation.Value.Parameters)
 		writeRequestBody(&markdown, operation.Value.RequestBody)
-		writeResponses(&markdown, operation.Value.Responses)
+		writeResponses(&markdown, operation.Value.Responses, commonErrors)
+	}
+	if len(commonErrors) > 0 {
+		markdown.WriteString("## Common error responses\n\n")
+		markdown.WriteString("These error responses apply to every operation on this page.\n\n")
+		writeResponseTable(&markdown, commonErrors)
 	}
 	return strings.TrimRight(markdown.String(), "\n") + "\n"
+}
+
+func commonErrorResponses(operations []taggedOperation) map[string]response {
+	if len(operations) < 2 {
+		return nil
+	}
+	common := make(map[string]response)
+	for status, candidate := range operations[0].Value.Responses {
+		if !isErrorResponseStatus(status) {
+			continue
+		}
+		shared := true
+		for _, operation := range operations[1:] {
+			other, exists := operation.Value.Responses[status]
+			if !exists || !reflect.DeepEqual(candidate, other) {
+				shared = false
+				break
+			}
+		}
+		if shared {
+			common[status] = candidate
+		}
+	}
+	return common
+}
+
+func isErrorResponseStatus(status string) bool {
+	return status == "default" || (len(status) == 3 && (status[0] == '4' || status[0] == '5'))
 }
 
 func writeOperationMetadata(markdown *strings.Builder, tagged taggedOperation) {
@@ -466,16 +504,28 @@ func writeRequestBody(markdown *strings.Builder, body requestBody) {
 	markdown.WriteString("Content types: `" + strings.Join(contentTypes, "`, `") + "`.\n\n")
 }
 
-func writeResponses(markdown *strings.Builder, responses map[string]response) {
+func writeResponses(markdown *strings.Builder, responses, commonErrors map[string]response) {
 	if len(responses) == 0 {
 		return
 	}
+	operationResponses := make(map[string]response, len(responses))
+	for status, value := range responses {
+		if _, common := commonErrors[status]; !common {
+			operationResponses[status] = value
+		}
+	}
+	markdown.WriteString("#### Responses\n\n")
+	if len(operationResponses) > 0 {
+		writeResponseTable(markdown, operationResponses)
+	}
+}
+
+func writeResponseTable(markdown *strings.Builder, responses map[string]response) {
 	statuses := make([]string, 0, len(responses))
 	for status := range responses {
 		statuses = append(statuses, status)
 	}
 	sort.Strings(statuses)
-	markdown.WriteString("#### Responses\n\n")
 	markdown.WriteString("| Status | Description |\n| --- | --- |\n")
 	for _, status := range statuses {
 		markdown.WriteString(fmt.Sprintf("| `%s` | %s |\n", status, tableText(responses[status].Description)))

--- a/internal/tools/openapidocgen/main_test.go
+++ b/internal/tools/openapidocgen/main_test.go
@@ -115,6 +115,61 @@ components:
 	}
 }
 
+func TestRenderTagDocumentWritesSharedErrorsOnce(t *testing.T) {
+	commonErrors := map[string]response{
+		"401": {Description: "Authentication is required."},
+		"403": {Description: "The caller is not authorized."},
+	}
+	operations := []taggedOperation{
+		{
+			Method: "GET",
+			Path:   "/v1/things",
+			Value: operation{
+				OperationID: "listThings",
+				Summary:     "List things",
+				Responses: map[string]response{
+					"200": {Description: "Things returned."},
+					"401": commonErrors["401"],
+					"403": commonErrors["403"],
+				},
+			},
+		},
+		{
+			Method: "POST",
+			Path:   "/v1/things",
+			Value: operation{
+				OperationID: "createThing",
+				Summary:     "Create a thing",
+				Responses: map[string]response{
+					"201": {Description: "Thing created."},
+					"401": commonErrors["401"],
+					"403": commonErrors["403"],
+				},
+			},
+		},
+	}
+
+	article := renderTagDocument(openAPITag{Name: "Things"}, operations)
+	for _, want := range []string{
+		"## Common error responses",
+		"[Common error responses](#common-error-responses)",
+		"| `200` | Things returned. |",
+		"| `201` | Thing created. |",
+	} {
+		if !strings.Contains(article, want) {
+			t.Errorf("article missing %q:\n%s", want, article)
+		}
+	}
+	for status, wantCount := range map[string]int{"401": 1, "403": 1} {
+		if got := strings.Count(article, "| `"+status+"` |"); got != wantCount {
+			t.Errorf("status %s appears %d times, want %d:\n%s", status, got, wantCount, article)
+		}
+	}
+	if got := strings.Count(article, "[Common error responses](#common-error-responses)"); got != 1 {
+		t.Errorf("common error reference appears %d times, want 1:\n%s", got, article)
+	}
+}
+
 func TestGenerateRejectsOperationWithoutOperationID(t *testing.T) {
 	tempDir := t.TempDir()
 	specPath := filepath.Join(tempDir, "openapi.yaml")

--- a/site/site.dom.test.ts
+++ b/site/site.dom.test.ts
@@ -1090,6 +1090,11 @@ test('documentation articles provide a readable, navigable reference experience'
     expect(page.url()).toBe(`${baseURL}/docs/guides/build`)
     const resultCount = await search.locator('.status').innerText()
     expect(resultCount).toMatch(/^[1-9]\d* results$/)
+    await searchInput.fill('no-document-can-match-this-query-9f83c1')
+    const emptyStatus = search.locator('.status')
+    await page.waitForFunction(() => document.querySelector('lv-site-search')?.shadowRoot?.querySelector('.status')?.textContent?.startsWith('No results'))
+    expect(await emptyStatus.innerText()).toBe('No results for “no-document-can-match-this-query-9f83c1”.')
+    expect(await emptyStatus.getAttribute('role')).toBe('status')
     await search.getByRole('button', { name: 'Close search' }).click()
     await page.keyboard.press('/')
     expect(await search.getByRole('dialog', { name: 'Search documentation' }).isVisible()).toBe(true)
@@ -1505,6 +1510,14 @@ test('compact documentation navigation opens in a drawer', async () => {
     await page.waitForFunction((previousCount) => (window as unknown as { siteDocsRevealCalls: unknown[] }).siteDocsRevealCalls.length > previousCount, revealCount)
     expect(await headerDrawerToggle.evaluate((element) => element.shadowRoot?.querySelector('button')?.getAttribute('aria-expanded'))).toBe('true')
     expect(await sidebar.getAttribute('aria-hidden')).toBe('false')
+    expect(await page.locator('.site-header').evaluate((element) => (element as HTMLElement).inert)).toBe(true)
+    expect(await page.locator('.site-docs-content').evaluate((element) => (element as HTMLElement).inert)).toBe(true)
+    const drawerToggle = page.locator('lv-site-docs-drawer-toggle[placement="drawer"]')
+    await page.waitForFunction(() =>
+      document.querySelector<HTMLElement>('lv-site-docs-drawer-toggle[placement="drawer"]')?.shadowRoot?.activeElement?.matches('button'),
+    )
+    await page.keyboard.press('Shift+Tab')
+    expect(await page.evaluate(() => document.querySelector('.site-docs-sidebar')?.contains(document.activeElement))).toBe(true)
     expect(
       await sidebar
         .locator('.site-docs-link')
@@ -1530,7 +1543,7 @@ test('compact documentation navigation opens in a drawer', async () => {
     })
     expect(await sidebar.evaluate((element) => getComputedStyle(element).transitionDuration)).not.toBe('0s')
 
-    await page.locator('lv-site-docs-drawer-toggle[placement="drawer"]').getByRole('button', { name: 'Close documentation menu' }).click()
+    await drawerToggle.getByRole('button', { name: 'Close documentation menu' }).click()
     await page.waitForFunction(() => !document.querySelector('.site-docs-layout')?.classList.contains('site-docs-drawer-open'))
     expect(await headerDrawerToggle.evaluate((element) => element.shadowRoot?.querySelector('button')?.getAttribute('aria-expanded'))).toBe('false')
   } finally {
@@ -1741,10 +1754,36 @@ test('generated API outlines keep operations and omit repeated operation details
     expect(visibleOutlineLabels).not.toContain('Parameters')
     expect(visibleOutlineLabels).not.toContain('Request body')
     expect(visibleOutlineLabels).not.toContain('Responses')
+
+    const listWorkspaceRoles = article.locator('h3#list-workspace-roles')
+    const listWorkspaceRolesDetail = listWorkspaceRoles.locator('xpath=following-sibling::h4[1]')
+    await listWorkspaceRolesDetail.evaluate((heading) => {
+      document.documentElement.style.scrollBehavior = 'auto'
+      window.scrollTo({ top: heading.getBoundingClientRect().top + window.scrollY - window.innerHeight * 0.2 })
+    })
+    await page.waitForFunction(() => {
+      const toc = document.querySelector<HTMLElement>('lv-site-article-toc')
+      const active = toc?.shadowRoot?.querySelector<HTMLAnchorElement>('a.active')
+      return active?.textContent?.trim() === 'List workspace roles' && active.getClientRects().length > 0 && toc.scrollTop > 0
+    })
+    const activeOutline = await toc.evaluate((element) => {
+      const active = element.shadowRoot?.querySelector<HTMLAnchorElement>('a.active')
+      if (!active) throw new Error('active article outline link is missing')
+      const hostRect = element.getBoundingClientRect()
+      const activeRect = active.getBoundingClientRect()
+      return {
+        label: active.textContent?.trim(),
+        scrollTop: element.scrollTop,
+        visible: activeRect.top >= hostRect.top && activeRect.bottom <= hostRect.bottom,
+      }
+    })
+    expect(activeOutline.label).toBe('List workspace roles')
+    expect(activeOutline.scrollTop).toBeGreaterThan(0)
+    expect(activeOutline.visible).toBe(true)
   } finally {
     await page.close()
   }
-})
+}, 10_000)
 
 test('visual showcase renders every supported visual type', async () => {
   const page = await browser.newPage()

--- a/site/web/site-page.ts
+++ b/site/web/site-page.ts
@@ -465,11 +465,11 @@ class SiteSearch extends DatastarLit(LitElement) {
   }
 
   private renderResults(query: string, results: SiteSearchResult[], total: number, loading: boolean) {
-    if (!query) return html`<p class="status">Start typing to search the documentation.</p>`
-    if (loading) return html`<p class="status">Searching…</p>`
-    if (results.length === 0) return html`<p class="status">No results for “${query}”.</p>`
+    if (!query) return html`<p class="status" role="status">Start typing to search the documentation.</p>`
+    if (loading) return html`<p class="status" role="status">Searching…</p>`
+    if (results.length === 0) return html`<p class="status" role="status">No results for “${query}”.</p>`
     const label = `${total} ${total === 1 ? 'result' : 'results'}`
-    return html`<p class="status">${label}</p>
+    return html`<p class="status" role="status">${label}</p>
       <ul>
         ${results.map(
           (result) =>
@@ -591,10 +591,32 @@ if (!customElements.get('lv-site-docs-drawer-toggle')) {
   customElements.define('lv-site-docs-drawer-toggle', SiteDocsDrawerToggle)
 }
 
+const docsDrawerFocusableSelector = 'a[href], button:not([disabled]), summary, input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function docsDrawerFocusableElements(sidebar: HTMLElement): HTMLElement[] {
+  const focusable: HTMLElement[] = []
+  const collect = (root: ParentNode): void => {
+    for (const element of root.querySelectorAll<HTMLElement>('*')) {
+      if (element.matches(docsDrawerFocusableSelector) && element.getClientRects().length > 0 && !element.closest('[inert]')) focusable.push(element)
+      if (element.shadowRoot) collect(element.shadowRoot)
+    }
+  }
+  collect(sidebar)
+  return focusable
+}
+
+function deepestActiveElement(): Element | null {
+  let active: Element | null = document.activeElement
+  while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement
+  return active
+}
+
 function syncDocsDrawer(open = false): void {
   const layout = document.querySelector<HTMLElement>('.site-docs-layout')
   const sidebar = document.querySelector<HTMLElement>('.site-docs-sidebar')
   if (!layout || !sidebar) return
+  const header = document.querySelector<HTMLElement>('.site-header')
+  const content = layout.querySelector<HTMLElement>('.site-docs-content')
 
   const compact = window.matchMedia('(max-width: 56.25rem)').matches
   const nextOpen = compact && open
@@ -602,13 +624,20 @@ function syncDocsDrawer(open = false): void {
   layout.classList.toggle('site-docs-drawer-open', nextOpen)
   sidebar.inert = compact && !nextOpen
   sidebar.setAttribute('aria-hidden', String(compact && !nextOpen))
+  if (header) header.inert = nextOpen
+  if (content) content.inert = nextOpen
   document.body.classList.toggle('site-docs-drawer-open', nextOpen)
   document.dispatchEvent(
     new CustomEvent('leapview-docs-drawer-state', {
       detail: { open: nextOpen },
     }),
   )
-  if (nextOpen && !wasOpen) requestAnimationFrame(revealCurrentDocsLink)
+  if (nextOpen && !wasOpen) {
+    requestAnimationFrame(() => {
+      revealCurrentDocsLink()
+      docsDrawerFocusableElements(sidebar)[0]?.focus()
+    })
+  }
   if (compact && wasOpen && !nextOpen) {
     document.querySelector<HTMLElement>('lv-site-docs-drawer-toggle:not([placement])')?.shadowRoot?.querySelector<HTMLButtonElement>('button')?.focus()
   }
@@ -625,7 +654,28 @@ document.addEventListener('click', (event) => {
 })
 
 document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape') syncDocsDrawer(false)
+  const layout = document.querySelector<HTMLElement>('.site-docs-layout')
+  if (!layout?.classList.contains('site-docs-drawer-open')) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    syncDocsDrawer(false)
+    return
+  }
+  if (event.key !== 'Tab') return
+  const sidebar = document.querySelector<HTMLElement>('.site-docs-sidebar')
+  if (!sidebar) return
+  const focusable = docsDrawerFocusableElements(sidebar)
+  if (focusable.length === 0) return
+  const active = deepestActiveElement()
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (event.shiftKey && (active === first || !active || !sidebar.contains(active))) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && (active === last || !active || !sidebar.contains(active))) {
+    event.preventDefault()
+    first.focus()
+  }
 })
 
 window.addEventListener('resize', () => syncDocsDrawer(document.querySelector('.site-docs-layout')?.classList.contains('site-docs-drawer-open')))
@@ -1266,6 +1316,7 @@ type ArticleSectionNode = ArticleSection & { children: ArticleSectionNode[] }
 class SiteArticleToc extends LitElement {
   private sections: ArticleSection[] = []
   private activeId = ''
+  private visibleSectionIDs = new Map<string, string>()
   private observer?: IntersectionObserver
 
   static styles = css`
@@ -1379,19 +1430,47 @@ class SiteArticleToc extends LitElement {
         level: Number(heading.tagName.slice(1)),
       }
     })
-    this.activeId = this.sections[0]?.id ?? ''
+    this.visibleSectionIDs = new Map<string, string>()
+    const indexVisibleSections = (nodes: ArticleSectionNode[], depth = 0, visibleAncestor = ''): void => {
+      for (const node of nodes) {
+        const visibleID = depth <= 1 ? node.id : visibleAncestor
+        this.visibleSectionIDs.set(node.id, visibleID)
+        indexVisibleSections(node.children, depth + 1, visibleID)
+      }
+    }
+    indexVisibleSections(this.sectionTree())
+    this.activeId = this.visibleSectionIDs.get(this.sections[0]?.id ?? '') ?? ''
     this.observer = new IntersectionObserver(
       (entries) => {
         const visible = entries.filter((entry) => entry.isIntersecting).sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0]
-        if (visible?.target.id && this.activeId !== visible.target.id) {
-          this.activeId = visible.target.id
-          this.requestUpdate()
+        const visibleID = visible?.target.id ? this.visibleSectionIDs.get(visible.target.id) : undefined
+        if (visibleID && this.activeId !== visibleID) {
+          this.setActiveSection(visibleID)
         }
       },
       { rootMargin: '-18% 0px -70% 0px', threshold: 0 },
     )
     headings.forEach((heading) => this.observer?.observe(heading))
     this.requestUpdate()
+  }
+
+  private setActiveSection(id: string): void {
+    this.activeId = id
+    this.requestUpdate()
+    void this.updateComplete.then(() => this.revealActiveSection())
+  }
+
+  private revealActiveSection(): void {
+    const active = this.renderRoot.querySelector<HTMLElement>('a.active')
+    if (!active || active.getClientRects().length === 0) return
+    const hostBounds = this.getBoundingClientRect()
+    const activeBounds = active.getBoundingClientRect()
+    const revealMargin = 8
+    if (activeBounds.top < hostBounds.top + revealMargin) {
+      this.scrollTop -= hostBounds.top + revealMargin - activeBounds.top
+    } else if (activeBounds.bottom > hostBounds.bottom - revealMargin) {
+      this.scrollTop += activeBounds.bottom - hostBounds.bottom + revealMargin
+    }
   }
 
   private sectionTree(): ArticleSectionNode[] {


### PR DESCRIPTION
## Summary

- keep long article outlines synchronized with visible operation headings and their own scroll position
- make the mobile docs drawer modal, including inert background content, initial focus, focus trapping, and restoration
- render explicit search empty states and semantic Markdown table row headers
- deduplicate common OpenAPI error responses into one shared section per resource page
- expand the four thin CLI guides into linked, task-oriented workflows

## QA

- `task ci`
- real-browser verification on desktop and mobile at `http://localhost:8081`
- Access API response rows reduced from 588 to 55; each common status now appears once