### PR TITLE
Make runtime activation failure-atomic

### DIFF
--- a/internal/app/deployment_candidates.go
+++ b/internal/app/deployment_candidates.go
@@ -14,9 +14,8 @@ import (
 )
 
 type runtimeReloader interface {
-	Reload(ctx context.Context) error
 	PrepareServingState(ctx context.Context, servingStateID string) (servingstate.PreparedRuntime, error)
-	CommitPrepared(prepared servingstate.PreparedRuntime) error
+	ActivatePrepared(prepared servingstate.PreparedRuntime, activate func() error) error
 }
 
 type servingStateRepository interface {

--- a/internal/app/deployment_candidates_test.go
+++ b/internal/app/deployment_candidates_test.go
@@ -184,11 +184,11 @@ func testWorkspaceAsset(workspaceID workspace.WorkspaceID, servingStateID worksp
 	return workspace.NewAssetWithSourceFile(workspaceID, servingStateID, typ, key, parentID, title, description, sourceFile, payloadSchema, payload)
 }
 
-func (p testRuntimeProvider) Active(context.Context) (runtimehost.Runtime, error) {
+func (p testRuntimeProvider) Acquire(context.Context) (runtimehost.Lease, error) {
 	if p.err != nil {
 		return nil, p.err
 	}
-	return p.runtime, nil
+	return &recordingLease{runtime: p.runtime}, nil
 }
 
 func (r testWorkspaceAssetRuntime) Close() error {
@@ -199,12 +199,6 @@ func (r testWorkspaceAssetRuntime) WorkspaceAssets(string, string) ([]workspace.
 	return r.assets, r.edges, true
 }
 
-func (r *fakeReloader) Reload(context.Context) error {
-	r.prepareCalls++
-	r.commitCalls++
-	return nil
-}
-
 func (r *fakeReloader) PrepareServingState(context.Context, string) (servingstate.PreparedRuntime, error) {
 	r.prepareCalls++
 	if r.prepareErr != nil {
@@ -213,9 +207,9 @@ func (r *fakeReloader) PrepareServingState(context.Context, string) (servingstat
 	return fakePreparedRuntime{}, nil
 }
 
-func (r *fakeReloader) CommitPrepared(servingstate.PreparedRuntime) error {
+func (r *fakeReloader) ActivatePrepared(_ servingstate.PreparedRuntime, activate func() error) error {
 	r.commitCalls++
-	return nil
+	return activate()
 }
 
 type fakePreparedRuntime struct{}

--- a/internal/app/runtime_metrics.go
+++ b/internal/app/runtime_metrics.go
@@ -16,18 +16,8 @@ import (
 	"github.com/Yacobolo/leapview/internal/workspace"
 )
 
-type RuntimeProvider interface {
-	Active(ctx context.Context) (runtimehost.Runtime, error)
-}
-
-type runtimeProvider = RuntimeProvider
-
-type runtimeLeaseProvider interface {
-	Acquire(ctx context.Context) (runtimehost.Lease, error)
-}
-
 type runtimeMetrics struct {
-	provider    runtimeProvider
+	provider    runtimehost.Provider
 	workspaceID string
 }
 
@@ -40,7 +30,7 @@ type dashboardRefreshRuntime struct {
 
 type dynamicRuntimeMetrics struct {
 	defaultID string
-	factory   func(workspaceID string) RuntimeProvider
+	factory   func(workspaceID string) runtimehost.Provider
 	mu        sync.Mutex
 	metrics   map[string]QueryMetrics
 }
@@ -77,11 +67,11 @@ type semanticQueryRuntime interface {
 	PreviewSemantic(ctx context.Context, modelID string, request reportdef.RowQuery) (reportdef.QueryRows, error)
 }
 
-func NewRuntimeMetrics(provider runtimeProvider, workspaceID string) QueryMetrics {
+func NewRuntimeMetrics(provider runtimehost.Provider, workspaceID string) QueryMetrics {
 	return runtimeMetrics{provider: provider, workspaceID: workspaceID}
 }
 
-func NewDynamicRuntimeMetrics(defaultWorkspaceID string, factory func(workspaceID string) RuntimeProvider) QueryMetrics {
+func NewDynamicRuntimeMetrics(defaultWorkspaceID string, factory func(workspaceID string) runtimehost.Provider) QueryMetrics {
 	return &dynamicRuntimeMetrics{
 		defaultID: defaultWorkspaceID,
 		factory:   factory,
@@ -397,13 +387,9 @@ func (m runtimeMetrics) active(ctx context.Context) (runtimehost.Runtime, func()
 	if m.provider == nil {
 		return nil, func() {}, fmt.Errorf("runtime provider is not configured")
 	}
-	if provider, ok := m.provider.(runtimeLeaseProvider); ok {
-		lease, err := provider.Acquire(ctx)
-		if err != nil {
-			return nil, func() {}, err
-		}
-		return lease.Runtime(), lease.Release, nil
+	lease, err := m.provider.Acquire(ctx)
+	if err != nil {
+		return nil, func() {}, err
 	}
-	runtime, err := m.provider.Active(ctx)
-	return runtime, func() {}, err
+	return lease.Runtime(), lease.Release, nil
 }

--- a/internal/app/runtime_metrics_test.go
+++ b/internal/app/runtime_metrics_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/Yacobolo/leapview/internal/dashboard"
@@ -28,6 +29,19 @@ func TestRuntimeMetricsQueryDashboardUsesRuntimeLease(t *testing.T) {
 	}
 	if provider.runtime.releasedDuringCall {
 		t.Fatal("runtime lease was released before query completed")
+	}
+}
+
+func TestRuntimeMetricsReleasesRuntimeLeaseWhenQueryFails(t *testing.T) {
+	wantErr := errors.New("query failed")
+	provider := &leaseRecordingProvider{runtime: leaseRecordingRuntime{queryErr: wantErr}}
+	metrics := NewRuntimeMetrics(provider, "test")
+
+	if _, err := metrics.QueryDashboardPage(context.Background(), "dashboard", "page", dashboard.Filters{}); !errors.Is(err, wantErr) {
+		t.Fatalf("query dashboard error = %v, want %v", err, wantErr)
+	}
+	if provider.lease == nil || !provider.lease.released {
+		t.Fatal("runtime lease was not released after query failure")
 	}
 }
 
@@ -70,10 +84,6 @@ type switchingLeaseProvider struct {
 	acquires int
 }
 
-func (p *switchingLeaseProvider) Active(context.Context) (runtimehost.Runtime, error) {
-	return p.current, nil
-}
-
 func (p *switchingLeaseProvider) Acquire(context.Context) (runtimehost.Lease, error) {
 	p.acquires++
 	p.lease = &recordingLease{runtime: p.current, snapshotID: 42}
@@ -100,10 +110,6 @@ type leaseRecordingProvider struct {
 	lease   *recordingLease
 }
 
-func (p *leaseRecordingProvider) Active(context.Context) (runtimehost.Runtime, error) {
-	return &p.runtime, nil
-}
-
 func (p *leaseRecordingProvider) Acquire(context.Context) (runtimehost.Lease, error) {
 	p.lease = &recordingLease{runtime: &p.runtime, snapshotID: 42}
 	p.runtime.lease = p.lease
@@ -114,6 +120,7 @@ type leaseRecordingRuntime struct {
 	lease              *recordingLease
 	called             bool
 	releasedDuringCall bool
+	queryErr           error
 }
 
 func (r *leaseRecordingRuntime) Close() error {
@@ -125,7 +132,7 @@ func (r *leaseRecordingRuntime) QueryDashboardPage(context.Context, string, stri
 	if r.lease != nil && r.lease.released {
 		r.releasedDuringCall = true
 	}
-	return dashboard.Patch{}, nil
+	return dashboard.Patch{}, r.queryErr
 }
 
 type recordingLease struct {

--- a/internal/app/workspace_refresh_adapters.go
+++ b/internal/app/workspace_refresh_adapters.go
@@ -115,38 +115,22 @@ type appRefreshRuntimeHost struct {
 
 func (h appRefreshRuntimeHost) PrepareServingState(ctx context.Context, servingStateID string) (servingstate.PreparedRuntime, error) {
 	if h.reloader == nil {
-		return nil, nil
+		return nil, fmt.Errorf("runtime host is not configured")
 	}
 	return h.reloader.PrepareServingState(ctx, servingStateID)
 }
 
-func (h appRefreshRuntimeHost) CommitPrepared(prepared servingstate.PreparedRuntime) error {
-	if h.reloader == nil || prepared == nil {
-		return nil
-	}
-	return h.reloader.CommitPrepared(prepared)
-}
-
-func (h appRefreshRuntimeHost) CommitPreparedWithActivation(prepared servingstate.PreparedRuntime, activate func() error) error {
-	if h.reloader == nil || prepared == nil {
-		return activate()
-	}
-	if atomic, ok := h.reloader.(interface {
-		CommitPreparedWithActivation(servingstate.PreparedRuntime, func() error) error
-	}); ok {
-		return atomic.CommitPreparedWithActivation(prepared, activate)
-	}
-	if err := activate(); err != nil {
-		return err
-	}
-	return h.reloader.CommitPrepared(prepared)
-}
-
-func (h appRefreshRuntimeHost) Reload(ctx context.Context) error {
+func (h appRefreshRuntimeHost) ActivatePrepared(prepared servingstate.PreparedRuntime, activate func() error) error {
 	if h.reloader == nil {
-		return nil
+		return fmt.Errorf("runtime host is not configured")
 	}
-	return h.reloader.Reload(ctx)
+	if prepared == nil {
+		return fmt.Errorf("prepared runtime is required")
+	}
+	if activate == nil {
+		return fmt.Errorf("metadata activation is required")
+	}
+	return h.reloader.ActivatePrepared(prepared, activate)
 }
 
 type appRefreshRetention struct {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -334,7 +334,7 @@ func servingStateBackedServer(ctx context.Context, cfg config.Config, production
 		_ = registry.Close()
 		cleanup()
 	}
-	runtimeMetrics := app.NewDynamicRuntimeMetrics("", func(workspaceID string) app.RuntimeProvider {
+	runtimeMetrics := app.NewDynamicRuntimeMetrics("", func(workspaceID string) runtimehost.Provider {
 		return registry.ProviderForWorkspace(servingstate.WorkspaceID(workspaceID))
 	})
 	assetCatalog := workspace.NewAssetCatalogService(workspaceRepo)

--- a/internal/deployment/service.go
+++ b/internal/deployment/service.go
@@ -44,7 +44,7 @@ type Prepared interface {
 
 type Runtime interface {
 	Prepare(context.Context, []runtimehost.ServingStateCandidate) (Prepared, error)
-	Commit(Prepared, func() error) error
+	Activate(Prepared, func() error) error
 }
 
 type registryRuntime struct{ registry *runtimehost.Registry }
@@ -65,12 +65,12 @@ func (r registryRuntime) Prepare(ctx context.Context, candidates []runtimehost.S
 	return registryPrepared{set: set}, nil
 }
 
-func (r registryRuntime) Commit(prepared Prepared, activate func() error) error {
+func (r registryRuntime) Activate(prepared Prepared, activate func() error) error {
 	value, ok := prepared.(registryPrepared)
 	if !ok || value.set == nil {
 		return fmt.Errorf("prepared runtimes belong to a different deployment coordinator")
 	}
-	return r.registry.CommitPreparedSet(value.set, activate)
+	return r.registry.ActivatePreparedSet(value.set, activate)
 }
 
 func (p registryPrepared) Snapshots() []runtimehost.PreparedSnapshot { return p.set.Snapshots() }
@@ -161,7 +161,7 @@ func (s *Service) Activate(ctx context.Context, scope Scope) (Deployment, error)
 	}
 
 	var activated Deployment
-	err = s.runtime.Commit(prepared, func() error {
+	err = s.runtime.Activate(prepared, func() error {
 		var activateErr error
 		activated, activateErr = s.repository.ActivateDeployment(ctx, row.ID)
 		return activateErr

--- a/internal/deployment/service_test.go
+++ b/internal/deployment/service_test.go
@@ -172,7 +172,7 @@ func (r *fakeRuntime) Prepare(_ context.Context, candidates []runtimehost.Servin
 	r.candidates = append([]runtimehost.ServingStateCandidate(nil), candidates...)
 	return r.prepared, r.prepareErr
 }
-func (r *fakeRuntime) Commit(_ Prepared, activate func() error) error {
+func (r *fakeRuntime) Activate(_ Prepared, activate func() error) error {
 	if err := activate(); err != nil {
 		return err
 	}

--- a/internal/deployment/sqlite/repository_test.go
+++ b/internal/deployment/sqlite/repository_test.go
@@ -13,6 +13,9 @@ import (
 
 	"github.com/Yacobolo/leapview/internal/deployment"
 	refreshpipelinesqlite "github.com/Yacobolo/leapview/internal/refreshpipeline/sqlite"
+	"github.com/Yacobolo/leapview/internal/runtimehost"
+	servingstate "github.com/Yacobolo/leapview/internal/servingstate"
+	servingstatesqlite "github.com/Yacobolo/leapview/internal/servingstate/sqlite"
 	"github.com/Yacobolo/leapview/internal/workspace"
 	"github.com/pressly/goose/v3"
 	_ "modernc.org/sqlite"
@@ -239,6 +242,85 @@ func TestActivateDeploymentAtomicallyUpdatesAllWorkspaceAndManagedPointers(t *te
 	}
 }
 
+func TestServiceActivationKeepsDurableAndRuntimeStateConsistentWhenRetiredRuntimeCleanupFails(t *testing.T) {
+	ctx, db, repository := testRepository(t)
+	insertWorkspaceCandidate(t, ctx, db, "sales", "sales_old", "sales_new", "prod")
+	insertWorkspaceCandidate(t, ctx, db, "support", "support_old", "support_new", "prod")
+	if _, err := db.ExecContext(ctx, `UPDATE serving_states SET ducklake_snapshot_id = 1 WHERE id IN ('sales_old', 'sales_new', 'support_old', 'support_new')`); err != nil {
+		t.Fatal(err)
+	}
+	insertRuntimeArtifacts(t, ctx, db, "prod", "sales_old", "sales_new", "support_old", "support_new")
+	created := createDeployment(t, ctx, repository, "deployment_cutover", []deployment.TargetInput{
+		{WorkspaceID: "sales", ServingStateID: "sales_new"},
+		{WorkspaceID: "support", ServingStateID: "support_new"},
+	})
+	states := servingstatesqlite.NewRepository(db)
+	factory := &cutoverRuntimeFactory{runtimes: map[servingstate.ID]*cutoverRuntime{}}
+	var cleanupFailures []runtimehost.CleanupFailure
+	registry := runtimehost.NewRegistryWithFactory(runtimehost.RegistryOptions{
+		Repo: states, WorkspaceIDs: []servingstate.WorkspaceID{"sales", "support"}, Environment: "prod", Factory: factory,
+		OnCleanupFailure: func(failure runtimehost.CleanupFailure) { cleanupFailures = append(cleanupFailures, failure) },
+	})
+	if err := registry.Reload(ctx); err != nil {
+		t.Fatal(err)
+	}
+	wantCleanupErr := errors.New("retired runtime close failed")
+	factory.runtimes["sales_old"].closeErr = wantCleanupErr
+	coordinator, err := deployment.NewRegistryRuntime(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := deployment.New(repository, states, coordinator, emptyManagedDataResolver{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	activated, err := service.Activate(ctx, deployment.Scope{ProjectID: "project", DeploymentID: created.ID})
+	if err != nil {
+		t.Fatalf("activate deployment: %v", err)
+	}
+	if activated.Status != deployment.StatusActive {
+		t.Fatalf("deployment status = %q", activated.Status)
+	}
+	assertActiveState(t, ctx, db, "sales", "prod", "sales_new")
+	assertActiveState(t, ctx, db, "support", "prod", "support_new")
+	for _, workspaceID := range []servingstate.WorkspaceID{"sales", "support"} {
+		lease, acquireErr := registry.AcquireForWorkspace(ctx, workspaceID)
+		if acquireErr != nil {
+			t.Fatalf("acquire %s: %v", workspaceID, acquireErr)
+		}
+		wantStateID := servingstate.ID(string(workspaceID) + "_new")
+		if lease.ServingStateID() != wantStateID {
+			t.Fatalf("%s runtime state = %q, want %q", workspaceID, lease.ServingStateID(), wantStateID)
+		}
+		lease.Release()
+	}
+	if len(cleanupFailures) != 1 || !errors.Is(cleanupFailures[0].Err, wantCleanupErr) {
+		t.Fatalf("cleanup failures = %#v", cleanupFailures)
+	}
+	if err := registry.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted := runtimehost.NewRegistryWithFactory(runtimehost.RegistryOptions{
+		Repo: states, WorkspaceIDs: []servingstate.WorkspaceID{"sales", "support"}, Environment: "prod", Factory: &cutoverRuntimeFactory{runtimes: map[servingstate.ID]*cutoverRuntime{}},
+	})
+	defer restarted.Close()
+	if err := restarted.Reload(ctx); err != nil {
+		t.Fatalf("reload after activation: %v", err)
+	}
+	for _, workspaceID := range []servingstate.WorkspaceID{"sales", "support"} {
+		lease, acquireErr := restarted.AcquireForWorkspace(ctx, workspaceID)
+		if acquireErr != nil {
+			t.Fatalf("acquire restarted %s: %v", workspaceID, acquireErr)
+		}
+		if lease.ServingStateID() != servingstate.ID(string(workspaceID)+"_new") {
+			t.Fatalf("restarted %s runtime state = %q", workspaceID, lease.ServingStateID())
+		}
+		lease.Release()
+	}
+}
+
 func TestActivateDeploymentRollsBackOnWorkspacePointerConflict(t *testing.T) {
 	ctx, db, repository := testRepository(t)
 	insertWorkspaceCandidate(t, ctx, db, "sales", "sales_old", "sales_new", "prod")
@@ -377,6 +459,39 @@ func insertWorkspaceCandidate(t *testing.T, ctx context.Context, db *sql.DB, wor
 		t.Fatal(err)
 	}
 	setActiveState(t, ctx, db, workspaceID, environment, oldID)
+}
+
+func insertRuntimeArtifacts(t *testing.T, ctx context.Context, db *sql.DB, environment string, stateIDs ...string) {
+	t.Helper()
+	for _, stateID := range stateIDs {
+		workspaceID := strings.TrimSuffix(strings.TrimSuffix(stateID, "_old"), "_new")
+		if _, err := db.ExecContext(ctx, `INSERT INTO serving_state_artifacts (id, serving_state_id, workspace_id, environment, digest, format, path, manifest_json) VALUES (?, ?, ?, ?, ?, 'test', ?, '{}')`,
+			"artifact_"+stateID, stateID, workspaceID, environment, "digest_"+stateID, "/tmp/"+stateID); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+type cutoverRuntimeFactory struct {
+	runtimes map[servingstate.ID]*cutoverRuntime
+}
+
+func (f *cutoverRuntimeFactory) Prepare(_ context.Context, input runtimehost.RuntimeInput) (runtimehost.Runtime, error) {
+	runtime := &cutoverRuntime{}
+	f.runtimes[input.State.ID] = runtime
+	return runtime, nil
+}
+
+type cutoverRuntime struct {
+	closeErr error
+}
+
+func (r *cutoverRuntime) Close() error { return r.closeErr }
+
+type emptyManagedDataResolver struct{}
+
+func (emptyManagedDataResolver) ResolveManagedData(context.Context, servingstate.ID) (runtimehost.ManagedDataResolution, error) {
+	return runtimehost.ManagedDataResolution{Roots: map[string]string{}}, nil
 }
 
 func insertReadyRevision(t *testing.T, ctx context.Context, db *sql.DB, collectionID, projectID, connectionName, revisionID string) {

--- a/internal/integration/ducklake_execution_test.go
+++ b/internal/integration/ducklake_execution_test.go
@@ -117,7 +117,7 @@ func newDuckLakeHarness(t *testing.T, opts ...func(*app.Options)) *duckLakeHarne
 		t.Fatalf("reload registry for %s: %v", initial.ID, err)
 	}
 	t.Cleanup(func() { _ = registry.Close() })
-	runtimeMetrics := app.NewDynamicRuntimeMetrics("", func(workspaceID string) app.RuntimeProvider {
+	runtimeMetrics := app.NewDynamicRuntimeMetrics("", func(workspaceID string) runtimehost.Provider {
 		return registry.ProviderForWorkspace(servingstate.WorkspaceID(workspaceID))
 	})
 	auth := app.NewAuth(accessRepo, "", app.AuthConfig{DevBypass: true})
@@ -793,7 +793,7 @@ func (h *duckLakeHarness) startReplacementRegistry(t *testing.T) {
 		t.Fatalf("reload replacement registry: %v", err)
 	}
 	h.registry = registry
-	server := app.NewWithOptions(app.NewDynamicRuntimeMetrics("", func(workspaceID string) app.RuntimeProvider {
+	server := app.NewWithOptions(app.NewDynamicRuntimeMetrics("", func(workspaceID string) runtimehost.Provider {
 		return registry.ProviderForWorkspace(servingstate.WorkspaceID(workspaceID))
 	}), app.Options{
 		Store:               h.store,

--- a/internal/runtimehost/manager.go
+++ b/internal/runtimehost/manager.go
@@ -34,6 +34,29 @@ type Lease interface {
 	Release()
 }
 
+// Provider exposes an active runtime only through a lifetime-bearing lease.
+type Provider interface {
+	Acquire(ctx context.Context) (Lease, error)
+}
+
+type CleanupResource string
+
+const (
+	CleanupResourceRuntime       CleanupResource = "runtime"
+	CleanupResourceManagedData   CleanupResource = "managed_data"
+	CleanupResourceSnapshotLease CleanupResource = "snapshot_lease"
+)
+
+// CleanupFailure describes a post-publication retirement failure. Such a
+// failure is operationally significant, but never reverses an activation.
+type CleanupFailure struct {
+	WorkspaceID        servingstate.WorkspaceID
+	ServingStateID     servingstate.ID
+	DuckLakeSnapshotID int64
+	Resource           CleanupResource
+	Err                error
+}
+
 type RuntimeFactory interface {
 	Prepare(ctx context.Context, input RuntimeInput) (Runtime, error)
 }
@@ -79,6 +102,7 @@ type Manager struct {
 	leaseOwner            string
 	logger                *slog.Logger
 	onLeaseRenewalFailure func(error)
+	onCleanupFailure      func(CleanupFailure)
 	leaseRenewalErrors    map[string]error
 	activeServingStateID  servingstate.ID
 	activeDigest          string
@@ -99,9 +123,13 @@ type ManagerOptions struct {
 	LeaseOwner            string
 	Logger                *slog.Logger
 	OnLeaseRenewalFailure func(error)
+	OnCleanupFailure      func(CleanupFailure)
 }
 
 type Prepared struct {
+	mu              sync.Mutex
+	owner           *Manager
+	state           preparedState
 	servingStateID  servingstate.ID
 	digest          string
 	managedRevision string
@@ -112,10 +140,25 @@ type Prepared struct {
 	snapshotID      int64
 }
 
+type preparedState uint8
+
+const (
+	preparedStateOpen preparedState = iota
+	preparedStateSealed
+	preparedStatePublished
+	preparedStateClosed
+)
+
 func (p *Prepared) Close() error {
 	if p == nil {
 		return nil
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.state != preparedStateOpen {
+		return nil
+	}
+	p.state = preparedStateClosed
 	var runtimeErr error
 	if p.runtime != nil {
 		runtimeErr = p.runtime.Close()
@@ -132,6 +175,8 @@ func (p *Prepared) DuckLakeSnapshotID() int64 {
 	if p == nil {
 		return 0
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.snapshotID
 }
 
@@ -150,6 +195,7 @@ func NewManagerWithFactory(options ManagerOptions) *Manager {
 		leaseTTL:              normalizedLeaseTTL(options.LeaseTTL),
 		logger:                logger,
 		onLeaseRenewalFailure: options.OnLeaseRenewalFailure,
+		onCleanupFailure:      options.OnCleanupFailure,
 		leaseRenewalErrors:    map[string]error{},
 		leaseOwner:            firstNonEmpty(options.LeaseOwner, "runtimehost"),
 	}
@@ -215,7 +261,7 @@ func (m *Manager) ReloadBeforePrepare(ctx context.Context, beforePrepare func() 
 			return err
 		}
 	}
-	return m.CommitPrepared(prepared)
+	return m.PublishPrepared(prepared)
 }
 
 func (m *Manager) needsArtifactPrepare(current servingstate.State, artifact servingstate.Artifact) bool {
@@ -274,7 +320,7 @@ func (m *Manager) prepareResolved(ctx context.Context, current servingstate.Stat
 		if err := releaseManagedDataLifetime(managedData.Lifetime); err != nil {
 			return nil, err
 		}
-		return &Prepared{servingStateID: current.ID, digest: artifact.Digest, managedRevision: managedData.RevisionID, noChange: true}, nil
+		return &Prepared{owner: m, servingStateID: current.ID, digest: artifact.Digest, managedRevision: managedData.RevisionID, noChange: true}, nil
 	}
 	m.mu.RUnlock()
 	factoryManagedData := managedData
@@ -298,43 +344,120 @@ func (m *Manager) prepareResolved(ctx context.Context, current servingstate.Stat
 		return nil, errors.Join(err, runtime.Close(), releaseManagedDataLifetime(managedData.Lifetime))
 	}
 	return &Prepared{
+		owner: m,
 		servingStateID: current.ID, digest: artifact.Digest, managedRevision: managedData.RevisionID,
 		runtime: runtime, managedData: managedData.Lifetime, snapshotLease: snapshotLease, snapshotID: snapshotID,
 	}, nil
 }
 
-func (m *Manager) CommitPrepared(candidate servingstate.PreparedRuntime) error {
-	prepared, ok := candidate.(*Prepared)
-	if !ok {
-		return fmt.Errorf("prepared runtime belongs to a different host")
+// PublishPrepared publishes an already-durable serving state. Cleanup of the
+// retired generation is observed separately and cannot fail publication.
+func (m *Manager) PublishPrepared(candidate servingstate.PreparedRuntime) error {
+	sealed, err := m.sealPrepared(candidate)
+	if err != nil {
+		return err
 	}
-	if prepared == nil {
-		return fmt.Errorf("prepared runtime is nil")
-	}
-	if prepared.noChange {
-		return nil
-	}
+	retired := sealed.publish()
+	m.cleanupRetired(retired)
+	return nil
+}
 
-	m.mu.Lock()
-	old := m.current
-	m.current = &managedRuntime{
-		servingStateID: prepared.servingStateID,
-		digest:         prepared.digest,
-		runtime:        prepared.runtime,
-		managedData:    prepared.managedData,
-		snapshotLease:  prepared.snapshotLease,
-		snapshotID:     prepared.snapshotID,
+type sealedPrepared struct {
+	manager         *Manager
+	source          *Prepared
+	servingStateID  servingstate.ID
+	digest          string
+	managedRevision string
+	runtime         Runtime
+	managedData     ManagedDataLifetime
+	snapshotLease   *persistentSnapshotLease
+	snapshotID      int64
+	noChange        bool
+}
+
+func (m *Manager) sealPrepared(candidate servingstate.PreparedRuntime) (*sealedPrepared, error) {
+	prepared, ok := candidate.(*Prepared)
+	if !ok || prepared == nil {
+		return nil, fmt.Errorf("prepared runtime belongs to a different host")
 	}
-	m.activeServingStateID = prepared.servingStateID
-	m.activeDigest = prepared.digest
-	m.activeManagedRevision = prepared.managedRevision
-	m.activeSnapshotID = prepared.snapshotID
+	prepared.mu.Lock()
+	defer prepared.mu.Unlock()
+	if prepared.owner != m {
+		return nil, fmt.Errorf("prepared runtime belongs to a different host")
+	}
+	if prepared.state != preparedStateOpen {
+		return nil, fmt.Errorf("prepared runtime is already consumed")
+	}
+	if !prepared.noChange && prepared.runtime == nil {
+		return nil, fmt.Errorf("prepared runtime is incomplete")
+	}
+	sealed := &sealedPrepared{
+		manager: m, source: prepared,
+		servingStateID: prepared.servingStateID, digest: prepared.digest, managedRevision: prepared.managedRevision,
+		runtime: prepared.runtime, managedData: prepared.managedData, snapshotLease: prepared.snapshotLease,
+		snapshotID: prepared.snapshotID, noChange: prepared.noChange,
+	}
 	prepared.runtime = nil
 	prepared.managedData = nil
 	prepared.snapshotLease = nil
-	oldToClose := m.retireLocked(old)
-	m.mu.Unlock()
-	return m.closeManaged(oldToClose)
+	prepared.state = preparedStateSealed
+	return sealed, nil
+}
+
+func (p *sealedPrepared) publish() *managedRuntime {
+	if p == nil {
+		return nil
+	}
+	if p.noChange {
+		p.finish(preparedStatePublished)
+		return nil
+	}
+	managed := &managedRuntime{
+		servingStateID: p.servingStateID,
+		digest:         p.digest,
+		runtime:        p.runtime,
+		managedData:    p.managedData,
+		snapshotLease:  p.snapshotLease,
+		snapshotID:     p.snapshotID,
+	}
+	p.manager.mu.Lock()
+	old := p.manager.current
+	p.manager.current = managed
+	p.manager.activeServingStateID = p.servingStateID
+	p.manager.activeDigest = p.digest
+	p.manager.activeManagedRevision = p.managedRevision
+	p.manager.activeSnapshotID = p.snapshotID
+	retired := p.manager.retireLocked(old)
+	p.manager.mu.Unlock()
+	p.runtime = nil
+	p.managedData = nil
+	p.snapshotLease = nil
+	p.finish(preparedStatePublished)
+	return retired
+}
+
+func (p *sealedPrepared) abort() error {
+	if p == nil {
+		return nil
+	}
+	managed := &managedRuntime{
+		servingStateID: p.servingStateID, runtime: p.runtime, managedData: p.managedData,
+		snapshotLease: p.snapshotLease, snapshotID: p.snapshotID,
+	}
+	p.runtime = nil
+	p.managedData = nil
+	p.snapshotLease = nil
+	p.finish(preparedStateClosed)
+	return p.manager.closeManaged(managed)
+}
+
+func (p *sealedPrepared) finish(state preparedState) {
+	if p == nil || p.source == nil {
+		return
+	}
+	p.source.mu.Lock()
+	p.source.state = state
+	p.source.mu.Unlock()
 }
 
 func (m *Manager) Close() error {
@@ -351,16 +474,6 @@ func (m *Manager) Close() error {
 		return nil
 	}
 	return m.closeManaged(currentToClose)
-}
-
-func (m *Manager) Active() (Runtime, error) {
-	lease, err := m.Acquire()
-	if err != nil {
-		return nil, err
-	}
-	runtime := lease.Runtime()
-	lease.Release()
-	return runtime, nil
 }
 
 func (m *Manager) Acquire() (Lease, error) {
@@ -411,7 +524,7 @@ func (m *Manager) release(runtime *managedRuntime) {
 		}
 	}
 	m.mu.Unlock()
-	_ = m.closeManaged(drained)
+	m.cleanupRetired(drained)
 }
 
 func releaseSnapshotLease(repo SnapshotLeaseRepository, leaseID string) error {
@@ -444,22 +557,60 @@ func (m *Manager) removeRetiredLocked(runtime *managedRuntime) {
 }
 
 func (m *Manager) closeManaged(runtime *managedRuntime) error {
+	results := m.closeManagedResources(runtime)
+	errs := make([]error, 0, len(results))
+	for _, result := range results {
+		errs = append(errs, result.err)
+	}
+	return errors.Join(errs...)
+}
+
+type cleanupResult struct {
+	resource CleanupResource
+	err      error
+}
+
+func (m *Manager) closeManagedResources(runtime *managedRuntime) []cleanupResult {
 	if runtime == nil {
 		return nil
 	}
-	var runtimeErr error
+	results := make([]cleanupResult, 0, 3)
 	if runtime.runtime != nil {
-		runtimeErr = runtime.runtime.Close()
+		if err := runtime.runtime.Close(); err != nil {
+			results = append(results, cleanupResult{resource: CleanupResourceRuntime, err: err})
+		}
 		runtime.runtime = nil
 	}
-	managedDataErr := releaseManagedDataLifetime(runtime.managedData)
+	if err := releaseManagedDataLifetime(runtime.managedData); err != nil {
+		results = append(results, cleanupResult{resource: CleanupResourceManagedData, err: err})
+	}
 	runtime.managedData = nil
-	snapshotLeaseErr := runtime.snapshotLease.Close()
+	if err := runtime.snapshotLease.Close(); err != nil {
+		results = append(results, cleanupResult{resource: CleanupResourceSnapshotLease, err: err})
+	}
 	runtime.snapshotLease = nil
 	if runtime.closing && m.onDrained != nil {
 		m.onDrained(runtime.servingStateID, runtime.snapshotID)
 	}
-	return errors.Join(runtimeErr, managedDataErr, snapshotLeaseErr)
+	return results
+}
+
+func (m *Manager) cleanupRetired(runtime *managedRuntime) {
+	if runtime == nil {
+		return
+	}
+	for _, result := range m.closeManagedResources(runtime) {
+		failure := CleanupFailure{
+			WorkspaceID: m.workspaceID, ServingStateID: runtime.servingStateID,
+			DuckLakeSnapshotID: runtime.snapshotID, Resource: result.resource, Err: result.err,
+		}
+		m.logger.Error("retired runtime cleanup failed",
+			"workspace_id", failure.WorkspaceID, "serving_state_id", failure.ServingStateID,
+			"ducklake_snapshot_id", failure.DuckLakeSnapshotID, "resource", failure.Resource, "error", failure.Err)
+		if m.onCleanupFailure != nil {
+			m.onCleanupFailure(failure)
+		}
+	}
 }
 
 type managedRuntime struct {

--- a/internal/runtimehost/manager_test.go
+++ b/internal/runtimehost/manager_test.go
@@ -36,7 +36,7 @@ func TestManagerReloadClearsStaleRuntimeWhenActiveDeploymentMissing(t *testing.T
 	if err := manager.Reload(ctx); err != nil {
 		t.Fatalf("reload missing active: %v", err)
 	}
-	if _, err := manager.Active(); err == nil {
+	if _, err := manager.Acquire(); err == nil {
 		t.Fatal("active runtime survived missing active deployment")
 	}
 }
@@ -69,13 +69,15 @@ func TestManagerPrepareCommitSwapsRuntimeAndClosesOld(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare: %v", err)
 	}
-	if err := manager.CommitPrepared(prepared); err != nil {
+	if err := manager.PublishPrepared(prepared); err != nil {
 		t.Fatalf("commit: %v", err)
 	}
-	active, err := manager.Active()
+	lease, err := manager.Acquire()
 	if err != nil {
 		t.Fatalf("active: %v", err)
 	}
+	defer lease.Release()
+	active := lease.Runtime()
 	if active == nil {
 		t.Fatal("active runtime is nil")
 	}
@@ -84,7 +86,7 @@ func TestManagerPrepareCommitSwapsRuntimeAndClosesOld(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare second: %v", err)
 	}
-	if err := manager.CommitPrepared(second); err != nil {
+	if err := manager.PublishPrepared(second); err != nil {
 		t.Fatalf("commit second: %v", err)
 	}
 	if factory.prepareCalls != 1 {
@@ -545,10 +547,11 @@ func TestManagerReloadRoutesWhenOnlyActiveDeploymentPointerChanges(t *testing.T)
 	if err := manager.Reload(ctx); err != nil {
 		t.Fatalf("first reload: %v", err)
 	}
-	active, err := manager.Active()
+	lease, err := manager.Acquire()
 	if err != nil {
 		t.Fatalf("first active: %v", err)
 	}
+	active := lease.Runtime()
 	if got := active.(RuntimeSnapshot).DuckLakeSnapshotID(); got != 11 {
 		t.Fatalf("first active snapshot = %d, want 11", got)
 	}
@@ -558,10 +561,13 @@ func TestManagerReloadRoutesWhenOnlyActiveDeploymentPointerChanges(t *testing.T)
 	if err := manager.Reload(ctx); err != nil {
 		t.Fatalf("second reload: %v", err)
 	}
-	active, err = manager.Active()
+	lease.Release()
+	lease, err = manager.Acquire()
 	if err != nil {
 		t.Fatalf("second active: %v", err)
 	}
+	defer lease.Release()
+	active = lease.Runtime()
 	if got := active.(RuntimeSnapshot).DuckLakeSnapshotID(); got != 22 {
 		t.Fatalf("second active snapshot = %d, want 22", got)
 	}
@@ -586,10 +592,12 @@ func TestManagerReloadRoutesWhenOnlyDuckLakeSnapshotPointerChanges(t *testing.T)
 	if err := manager.Reload(ctx); err != nil {
 		t.Fatalf("second reload: %v", err)
 	}
-	active, err := manager.Active()
+	lease, err := manager.Acquire()
 	if err != nil {
 		t.Fatalf("active: %v", err)
 	}
+	defer lease.Release()
+	active := lease.Runtime()
 	if got := active.(RuntimeSnapshot).DuckLakeSnapshotID(); got != 22 {
 		t.Fatalf("active snapshot = %d, want 22", got)
 	}
@@ -620,7 +628,7 @@ func TestManagerReloadReusesRuntimeWhenDeploymentDigestAndSnapshotMatch(t *testi
 
 func TestManagerRejectsPreparedFromDifferentHost(t *testing.T) {
 	manager := NewManagerWithFactory(ManagerOptions{Repo: &fakeRepo{}, WorkspaceID: "test", Environment: "dev", Factory: &fakeFactory{}})
-	if err := manager.CommitPrepared(fakePrepared{}); err == nil {
+	if err := manager.PublishPrepared(fakePrepared{}); err == nil {
 		t.Fatal("expected wrong prepared runtime error")
 	}
 }
@@ -636,14 +644,14 @@ func TestManagerCloseClearsActiveRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare: %v", err)
 	}
-	if err := manager.CommitPrepared(prepared); err != nil {
+	if err := manager.PublishPrepared(prepared); err != nil {
 		t.Fatalf("commit: %v", err)
 	}
 
 	if err := manager.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if _, err := manager.Active(); err == nil {
+	if _, err := manager.Acquire(); err == nil {
 		t.Fatal("expected no active runtime after close")
 	}
 }
@@ -676,13 +684,17 @@ func TestRegistryReloadLoadsConfiguredEnvironmentForEachWorkspace(t *testing.T) 
 	if got := repo.activeCalls; !equalStrings(got, []string{"empty/prod", "operations/prod", "sales/prod"}) {
 		t.Fatalf("active calls = %#v, want configured prod workspaces only", got)
 	}
-	if _, err := registry.ActiveForWorkspace(context.Background(), "sales"); err != nil {
+	if lease, err := registry.AcquireForWorkspace(context.Background(), "sales"); err != nil {
 		t.Fatalf("sales active: %v", err)
+	} else {
+		lease.Release()
 	}
-	if _, err := registry.ActiveForWorkspace(context.Background(), "operations"); err != nil {
+	if lease, err := registry.AcquireForWorkspace(context.Background(), "operations"); err != nil {
 		t.Fatalf("operations active: %v", err)
+	} else {
+		lease.Release()
 	}
-	if _, err := registry.ActiveForWorkspace(context.Background(), "empty"); err == nil {
+	if _, err := registry.AcquireForWorkspace(context.Background(), "empty"); err == nil {
 		t.Fatal("empty workspace active error = nil, want no active deployment")
 	}
 	if got := factory.inputs; !equalStrings(got, []string{"operations/prod/dep_ops_prod", "sales/prod/dep_sales_prod"}) {
@@ -706,17 +718,19 @@ func TestRegistryPrepareCommitRoutesDeploymentByWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare: %v", err)
 	}
-	if err := registry.CommitPrepared(prepared); err != nil {
+	if err := registry.ActivatePrepared(prepared, func() error { return nil }); err != nil {
 		t.Fatalf("commit: %v", err)
 	}
 	repo.active["operations/prod"] = registryDeploymentArtifact{
 		deployment: servingstate.State{ID: "dep_ops_prod", WorkspaceID: "operations", Environment: "prod", Status: servingstate.StatusActive},
 		artifact:   servingstate.Artifact{ServingStateID: "dep_ops_prod", WorkspaceID: "operations", Environment: "prod", Digest: "ops-prod"},
 	}
-	if _, err := registry.ActiveForWorkspace(context.Background(), "operations"); err != nil {
+	if lease, err := registry.AcquireForWorkspace(context.Background(), "operations"); err != nil {
 		t.Fatalf("operations active after commit: %v", err)
+	} else {
+		lease.Release()
 	}
-	if _, err := registry.ActiveForWorkspace(context.Background(), "sales"); err == nil {
+	if _, err := registry.AcquireForWorkspace(context.Background(), "sales"); err == nil {
 		t.Fatal("sales active error = nil, want only operations runtime committed")
 	}
 	if got := factory.inputs; !equalStrings(got, []string{"operations/prod/dep_ops_prod"}) {
@@ -735,10 +749,10 @@ func TestRegistryPreparedRuntimeDoesNotCommitWhenMetadataActivationFails(t *test
 	}
 	defer prepared.Close()
 	wantErr := errors.New("activation failed")
-	if err := registry.CommitPreparedWithActivation(prepared, func() error { return wantErr }); !errors.Is(err, wantErr) {
+	if err := registry.ActivatePrepared(prepared, func() error { return wantErr }); !errors.Is(err, wantErr) {
 		t.Fatalf("commit error = %v, want %v", err, wantErr)
 	}
-	if _, err := registry.managerForWorkspace("sales").Active(); err == nil {
+	if _, err := registry.managerForWorkspace("sales").Acquire(); err == nil {
 		t.Fatal("runtime committed after metadata activation failed")
 	}
 }
@@ -774,11 +788,13 @@ func TestRegistryPreparedSetActivatesAndCommitsEveryWorkspaceTogether(t *testing
 	if len(factory.runtimes) != 4 || factory.runtimes[0].closed || factory.runtimes[1].closed {
 		t.Fatalf("active generation was not retained during prepare: %#v", factory.runtimes)
 	}
-	if runtime, err := registry.managerForWorkspace("operations").Active(); err != nil || runtime != factory.runtimes[0] {
-		t.Fatalf("operations active during prepare = %#v, %v", runtime, err)
+	activeLease, err := registry.managerForWorkspace("operations").Acquire()
+	if err != nil || activeLease.Runtime() != factory.runtimes[0] {
+		t.Fatalf("operations active during prepare = %#v, %v", activeLease.Runtime(), err)
 	}
+	activeLease.Release()
 	activated := false
-	err = registry.CommitPreparedSet(prepared, func() error {
+	err = registry.ActivatePreparedSet(prepared, func() error {
 		activated = true
 		for _, workspaceID := range []servingstate.WorkspaceID{"operations", "sales"} {
 			id := servingstate.ID("dep_" + string(workspaceID) + "_prod")
@@ -793,8 +809,10 @@ func TestRegistryPreparedSetActivatesAndCommitsEveryWorkspaceTogether(t *testing
 		t.Fatal("metadata activation was not called")
 	}
 	for _, workspaceID := range []servingstate.WorkspaceID{"operations", "sales"} {
-		if _, err := registry.ActiveForWorkspace(context.Background(), workspaceID); err != nil {
+		if lease, err := registry.AcquireForWorkspace(context.Background(), workspaceID); err != nil {
 			t.Fatalf("%s active: %v", workspaceID, err)
+		} else {
+			lease.Release()
 		}
 	}
 	if got := factory.inputs; !equalStrings(got, []string{"operations/prod/dep_operations_active", "sales/prod/dep_sales_active", "operations/prod/dep_operations_prod", "sales/prod/dep_sales_prod"}) {
@@ -815,11 +833,221 @@ func TestRegistryPreparedSetDoesNotCommitWhenMetadataActivationFails(t *testing.
 	}
 	defer prepared.Close()
 	wantErr := errors.New("activation failed")
-	if err := registry.CommitPreparedSet(prepared, func() error { return wantErr }); !errors.Is(err, wantErr) {
+	if err := registry.ActivatePreparedSet(prepared, func() error { return wantErr }); !errors.Is(err, wantErr) {
 		t.Fatalf("commit error = %v, want %v", err, wantErr)
 	}
-	if _, err := registry.managerForWorkspace("sales").Active(); err == nil {
+	if _, err := registry.managerForWorkspace("sales").Acquire(); err == nil {
 		t.Fatal("runtime committed after metadata activation failed")
+	}
+}
+
+func TestRegistryActivatePreparedSetReportsCleanupFailureAfterPublishingEveryWorkspace(t *testing.T) {
+	repo := newFakeRegistryRepo()
+	for _, workspaceID := range []servingstate.WorkspaceID{"operations", "sales"} {
+		activeID := servingstate.ID("dep_" + string(workspaceID) + "_active")
+		repo.active[string(workspaceID)+"/prod"] = registryDeploymentArtifact{
+			deployment: servingstate.State{ID: activeID, WorkspaceID: workspaceID, Environment: "prod", Status: servingstate.StatusActive, DuckLakeSnapshotID: 1},
+			artifact:   servingstate.Artifact{ServingStateID: activeID, WorkspaceID: workspaceID, Environment: "prod", Digest: string(workspaceID) + "-active"},
+		}
+		nextID := servingstate.ID("dep_" + string(workspaceID) + "_next")
+		repo.deployments[nextID] = servingstate.State{ID: nextID, WorkspaceID: workspaceID, Environment: "prod", Status: servingstate.StatusValidated}
+		repo.artifacts[nextID] = servingstate.Artifact{ServingStateID: nextID, WorkspaceID: workspaceID, Environment: "prod", Digest: string(workspaceID) + "-next"}
+	}
+	factory := &recordingRegistryFactory{}
+	var failures []CleanupFailure
+	registry := NewRegistryWithFactory(RegistryOptions{
+		Repo: repo, WorkspaceIDs: []servingstate.WorkspaceID{"operations", "sales"}, Environment: "prod", Factory: factory,
+		OnCleanupFailure: func(failure CleanupFailure) { failures = append(failures, failure) },
+	})
+	if err := registry.Reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	wantCleanupErr := errors.New("old runtime close failed")
+	factory.runtimes[0].closeErr = wantCleanupErr
+	prepared, err := registry.PrepareServingStates(context.Background(), []string{"dep_sales_next", "dep_operations_next"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.Close()
+
+	err = registry.ActivatePreparedSet(prepared, func() error {
+		for _, workspaceID := range []servingstate.WorkspaceID{"operations", "sales"} {
+			nextID := servingstate.ID("dep_" + string(workspaceID) + "_next")
+			repo.active[string(workspaceID)+"/prod"] = registryDeploymentArtifact{deployment: repo.deployments[nextID], artifact: repo.artifacts[nextID]}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("activate prepared set: %v", err)
+	}
+	for index, workspaceID := range []servingstate.WorkspaceID{"operations", "sales"} {
+		lease, acquireErr := registry.AcquireForWorkspace(context.Background(), workspaceID)
+		if acquireErr != nil {
+			t.Fatalf("acquire %s: %v", workspaceID, acquireErr)
+		}
+		if lease.Runtime() != factory.runtimes[index+2] {
+			t.Fatalf("%s runtime was not published", workspaceID)
+		}
+		lease.Release()
+	}
+	if len(failures) != 1 || !errors.Is(failures[0].Err, wantCleanupErr) {
+		t.Fatalf("cleanup failures = %#v, want runtime close failure", failures)
+	}
+	if failures[0].WorkspaceID != "operations" || failures[0].Resource != CleanupResourceRuntime {
+		t.Fatalf("cleanup failure context = %#v", failures[0])
+	}
+}
+
+func TestRegistryActivatePreparedSetRejectsDuplicateTargetBeforeActivation(t *testing.T) {
+	repo := newFakeRegistryRepo()
+	repo.deployments["dep_sales_next"] = servingstate.State{ID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Status: servingstate.StatusValidated}
+	repo.artifacts["dep_sales_next"] = servingstate.Artifact{ServingStateID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Digest: "sales-next"}
+	registry := NewRegistryWithFactory(RegistryOptions{Repo: repo, Environment: "prod", Factory: &recordingRegistryFactory{}})
+	prepared, err := registry.PrepareServingStates(context.Background(), []string{"dep_sales_next"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.Close()
+	prepared.items = append(prepared.items, prepared.items[0])
+	activated := false
+	if err := registry.ActivatePreparedSet(prepared, func() error { activated = true; return nil }); err == nil {
+		t.Fatal("duplicate target activation error = nil")
+	}
+	if activated {
+		t.Fatal("durable activation ran before candidate validation")
+	}
+}
+
+func TestRegistryDelayedDrainReportsCleanupFailureAfterLeaseRelease(t *testing.T) {
+	repo := newFakeRegistryRepo()
+	repo.active["sales/prod"] = registryDeploymentArtifact{
+		deployment: servingstate.State{ID: "dep_sales_active", WorkspaceID: "sales", Environment: "prod", Status: servingstate.StatusActive},
+		artifact:   servingstate.Artifact{ServingStateID: "dep_sales_active", WorkspaceID: "sales", Environment: "prod", Digest: "sales-active"},
+	}
+	repo.deployments["dep_sales_next"] = servingstate.State{ID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Status: servingstate.StatusValidated}
+	repo.artifacts["dep_sales_next"] = servingstate.Artifact{ServingStateID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Digest: "sales-next"}
+	factory := &recordingRegistryFactory{}
+	failures := make(chan CleanupFailure, 1)
+	registry := NewRegistryWithFactory(RegistryOptions{
+		Repo: repo, WorkspaceIDs: []servingstate.WorkspaceID{"sales"}, Environment: "prod", Factory: factory,
+		OnCleanupFailure: func(failure CleanupFailure) { failures <- failure },
+	})
+	if err := registry.Reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := registry.AcquireForWorkspace(context.Background(), "sales")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCleanupErr := errors.New("delayed close failed")
+	factory.runtimes[0].closeErr = wantCleanupErr
+	prepared, err := registry.PrepareServingState(context.Background(), "dep_sales_next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.Close()
+	if err := registry.ActivatePrepared(prepared, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if factory.runtimes[0].closed {
+		t.Fatal("leased runtime closed during activation")
+	}
+	lease.Release()
+	select {
+	case failure := <-failures:
+		if !errors.Is(failure.Err, wantCleanupErr) || failure.ServingStateID != "dep_sales_active" {
+			t.Fatalf("cleanup failure = %#v", failure)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cleanup failure was not reported after lease release")
+	}
+}
+
+func TestRegistryAcquireWaitsForCompleteCutover(t *testing.T) {
+	repo := newFakeRegistryRepo()
+	repo.active["sales/prod"] = registryDeploymentArtifact{
+		deployment: servingstate.State{ID: "dep_sales_active", WorkspaceID: "sales", Environment: "prod", Status: servingstate.StatusActive, DuckLakeSnapshotID: 1},
+		artifact:   servingstate.Artifact{ServingStateID: "dep_sales_active", WorkspaceID: "sales", Environment: "prod", Digest: "active"},
+	}
+	repo.deployments["dep_sales_next"] = servingstate.State{ID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Status: servingstate.StatusValidated}
+	repo.artifacts["dep_sales_next"] = servingstate.Artifact{ServingStateID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Digest: "next"}
+	registry := NewRegistryWithFactory(RegistryOptions{Repo: repo, WorkspaceIDs: []servingstate.WorkspaceID{"sales"}, Environment: "prod", Factory: &recordingRegistryFactory{}})
+	if err := registry.Reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := registry.PrepareServingState(context.Background(), "dep_sales_next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.Close()
+	activationStarted := make(chan struct{})
+	allowActivation := make(chan struct{})
+	activationDone := make(chan error, 1)
+	go func() {
+		activationDone <- registry.ActivatePrepared(prepared, func() error {
+			close(activationStarted)
+			<-allowActivation
+			return nil
+		})
+	}()
+	<-activationStarted
+	leaseResult := make(chan Lease, 1)
+	acquireErr := make(chan error, 1)
+	go func() {
+		lease, err := registry.AcquireForWorkspace(context.Background(), "sales")
+		leaseResult <- lease
+		acquireErr <- err
+	}()
+	select {
+	case err := <-acquireErr:
+		t.Fatalf("acquire completed during cutover: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(allowActivation)
+	if err := <-activationDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-acquireErr; err != nil {
+		t.Fatal(err)
+	}
+	lease := <-leaseResult
+	defer lease.Release()
+	if lease.ServingStateID() != "dep_sales_next" {
+		t.Fatalf("serving state = %q, want dep_sales_next", lease.ServingStateID())
+	}
+}
+
+func TestRegistryRejectsConsumedAndForeignPreparedRuntimeBeforeActivation(t *testing.T) {
+	repo := newFakeRegistryRepo()
+	repo.deployments["dep_sales_next"] = servingstate.State{ID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Status: servingstate.StatusValidated}
+	repo.artifacts["dep_sales_next"] = servingstate.Artifact{ServingStateID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Digest: "next"}
+	registry := NewRegistryWithFactory(RegistryOptions{Repo: repo, Environment: "prod", Factory: &recordingRegistryFactory{}})
+	prepared, err := registry.PrepareServingState(context.Background(), "dep_sales_next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.ActivatePrepared(prepared, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	activated := false
+	if err := registry.ActivatePrepared(prepared, func() error { activated = true; return nil }); err == nil {
+		t.Fatal("consumed prepared runtime error = nil")
+	}
+	if activated {
+		t.Fatal("activation ran for consumed candidate")
+	}
+
+	foreignPrepared, err := registry.PrepareServingState(context.Background(), "dep_sales_next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer foreignPrepared.Close()
+	foreignRegistry := NewRegistryWithFactory(RegistryOptions{Repo: repo, Environment: "prod", Factory: &recordingRegistryFactory{}})
+	if err := foreignRegistry.ActivatePrepared(foreignPrepared, func() error { activated = true; return nil }); err == nil {
+		t.Fatal("foreign prepared runtime error = nil")
+	}
+	if activated {
+		t.Fatal("activation ran for foreign candidate")
 	}
 }
 
@@ -1366,12 +1594,13 @@ func (f *recordingRegistryFactory) Prepare(_ context.Context, input RuntimeInput
 }
 
 type recordingRuntime struct {
-	closed bool
+	closed   bool
+	closeErr error
 }
 
 func (r *recordingRuntime) Close() error {
 	r.closed = true
-	return nil
+	return r.closeErr
 }
 
 type overlapDetectingRegistryFactory struct {

--- a/internal/runtimehost/registry.go
+++ b/internal/runtimehost/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"sync"
 
@@ -11,27 +12,32 @@ import (
 )
 
 type RegistryOptions struct {
-	Repo         ServingStateRepository
-	WorkspaceIDs []servingstate.WorkspaceID
-	Environment  servingstate.Environment
-	Factory      RuntimeFactory
-	ManagedData  ManagedDataResolver
-	OnDrained    func(servingstate.ID, int64)
+	Repo             ServingStateRepository
+	WorkspaceIDs     []servingstate.WorkspaceID
+	Environment      servingstate.Environment
+	Factory          RuntimeFactory
+	ManagedData      ManagedDataResolver
+	OnDrained        func(servingstate.ID, int64)
+	Logger           *slog.Logger
+	OnCleanupFailure func(CleanupFailure)
 }
 
 type Registry struct {
-	mu          sync.RWMutex
-	prepareMu   sync.Mutex
-	cutoverMu   sync.RWMutex
-	repo        ServingStateRepository
-	environment servingstate.Environment
-	factory     RuntimeFactory
-	managedData ManagedDataResolver
-	onDrained   func(servingstate.ID, int64)
-	managers    map[servingstate.WorkspaceID]*Manager
+	mu               sync.RWMutex
+	prepareMu        sync.Mutex
+	cutoverMu        sync.RWMutex
+	repo             ServingStateRepository
+	environment      servingstate.Environment
+	factory          RuntimeFactory
+	managedData      ManagedDataResolver
+	onDrained        func(servingstate.ID, int64)
+	logger           *slog.Logger
+	onCleanupFailure func(CleanupFailure)
+	managers         map[servingstate.WorkspaceID]*Manager
 }
 
 type RegistryPrepared struct {
+	registry    *Registry
 	workspaceID servingstate.WorkspaceID
 	manager     *Manager
 	prepared    servingstate.PreparedRuntime
@@ -39,9 +45,11 @@ type RegistryPrepared struct {
 
 // PreparedSet contains candidate runtimes that must become visible as one rollout.
 type PreparedSet struct {
+	mu        sync.Mutex
 	registry  *Registry
 	items     []*RegistryPrepared
 	committed bool
+	consumed  bool
 }
 
 // PreparedSnapshot identifies durable snapshot metadata produced while a
@@ -58,6 +66,8 @@ func (p *PreparedSet) Snapshots() []PreparedSnapshot {
 	if p == nil {
 		return nil
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	out := make([]PreparedSnapshot, 0, len(p.items))
 	for _, item := range p.items {
 		if item == nil {
@@ -87,6 +97,8 @@ func (p *PreparedSet) Close() error {
 	if p == nil {
 		return nil
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	var first error
 	for _, item := range p.items {
 		if err := item.Close(); err != nil && first == nil {
@@ -110,12 +122,14 @@ type WorkspaceProvider struct {
 
 func NewRegistryWithFactory(options RegistryOptions) *Registry {
 	registry := &Registry{
-		repo:        options.Repo,
-		environment: servingstate.NormalizeEnvironment(options.Environment),
-		factory:     options.Factory,
-		managedData: options.ManagedData,
-		onDrained:   options.OnDrained,
-		managers:    map[servingstate.WorkspaceID]*Manager{},
+		repo:             options.Repo,
+		environment:      servingstate.NormalizeEnvironment(options.Environment),
+		factory:          options.Factory,
+		managedData:      options.ManagedData,
+		onDrained:        options.OnDrained,
+		logger:           options.Logger,
+		onCleanupFailure: options.OnCleanupFailure,
+		managers:         map[servingstate.WorkspaceID]*Manager{},
 	}
 	for _, workspaceID := range options.WorkspaceIDs {
 		registry.managerForWorkspace(workspaceID)
@@ -155,7 +169,7 @@ func (r *Registry) PrepareServingState(ctx context.Context, servingStateID strin
 	if err != nil {
 		return nil, err
 	}
-	return &RegistryPrepared{workspaceID: current.WorkspaceID, manager: manager, prepared: prepared}, nil
+	return &RegistryPrepared{registry: r, workspaceID: current.WorkspaceID, manager: manager, prepared: prepared}, nil
 }
 
 // PrepareServingStates prepares one candidate per workspace without exposing a
@@ -169,7 +183,7 @@ func (r *Registry) PrepareServingStates(ctx context.Context, servingStateIDs []s
 }
 
 // PrepareServingStateCandidates prepares runtime generations against data
-// that is not durable yet. CommitPreparedSet must persist the corresponding
+// that is not durable yet. ActivatePreparedSet must persist the corresponding
 // bindings in its activation callback before exposing these runtimes.
 func (r *Registry) PrepareServingStateCandidates(ctx context.Context, inputs []ServingStateCandidate) (*PreparedSet, error) {
 	candidates := make([]servingStateCandidate, 0, len(inputs))
@@ -239,76 +253,115 @@ func (r *Registry) prepareServingStateCandidates(ctx context.Context, inputs []s
 			_ = set.Close()
 			return nil, err
 		}
-		set.items = append(set.items, &RegistryPrepared{workspaceID: candidate.state.WorkspaceID, manager: manager, prepared: prepared})
+		set.items = append(set.items, &RegistryPrepared{registry: r, workspaceID: candidate.state.WorkspaceID, manager: manager, prepared: prepared})
 	}
 	return set, nil
 }
 
-func (r *Registry) CommitPrepared(candidate servingstate.PreparedRuntime) error {
-	prepared, ok := candidate.(*RegistryPrepared)
-	if !ok {
-		return fmt.Errorf("prepared runtime belongs to a different host")
-	}
-	if prepared == nil || prepared.manager == nil || prepared.prepared == nil {
-		return fmt.Errorf("prepared runtime is nil")
-	}
-	return prepared.manager.CommitPrepared(prepared.prepared)
-}
-
-// CommitPreparedWithActivation serializes a single-workspace durable pointer
+// ActivatePrepared serializes a single-workspace durable pointer
 // update with its in-memory runtime swap.
-func (r *Registry) CommitPreparedWithActivation(candidate servingstate.PreparedRuntime, activate func() error) error {
-	prepared, ok := candidate.(*RegistryPrepared)
-	if !ok {
-		return fmt.Errorf("prepared runtime belongs to a different host")
-	}
-	if prepared == nil || prepared.manager == nil || prepared.prepared == nil {
-		return fmt.Errorf("prepared runtime is nil")
-	}
+func (r *Registry) ActivatePrepared(candidate servingstate.PreparedRuntime, activate func() error) error {
 	if activate == nil {
 		return fmt.Errorf("metadata activation is required")
 	}
-	r.cutoverMu.Lock()
-	defer r.cutoverMu.Unlock()
-	if err := activate(); err != nil {
+	prepared, err := r.sealPrepared(candidate)
+	if err != nil {
 		return err
 	}
-	return prepared.manager.CommitPrepared(prepared.prepared)
+	r.cutoverMu.Lock()
+	if err := activate(); err != nil {
+		r.cutoverMu.Unlock()
+		return errors.Join(err, prepared.abort())
+	}
+	retired := prepared.publish()
+	r.cutoverMu.Unlock()
+	prepared.manager.cleanupRetired(retired)
+	return nil
 }
 
-// CommitPreparedSet serializes the durable pointer transaction with the
+// ActivatePreparedSet serializes the durable pointer transaction with the
 // in-memory swap, so requests cannot observe a mixture of rollout revisions.
-func (r *Registry) CommitPreparedSet(set *PreparedSet, activate func() error) error {
+func (r *Registry) ActivatePreparedSet(set *PreparedSet, activate func() error) error {
 	if set == nil || set.registry != r {
 		return fmt.Errorf("prepared set belongs to a different host")
 	}
+	set.mu.Lock()
+	defer set.mu.Unlock()
 	if set.committed {
 		return fmt.Errorf("prepared set is already committed")
+	}
+	if set.consumed {
+		return fmt.Errorf("prepared set is already consumed")
 	}
 	if activate == nil {
 		return fmt.Errorf("metadata activation is required")
 	}
+	workspaces := make(map[servingstate.WorkspaceID]struct{}, len(set.items))
 	for _, item := range set.items {
-		if item == nil || item.manager == nil || item.prepared == nil {
+		if item == nil || item.registry != r || item.manager == nil || item.prepared == nil {
 			return fmt.Errorf("prepared runtime is nil")
 		}
-		if _, ok := item.prepared.(*Prepared); !ok {
-			return fmt.Errorf("prepared runtime belongs to a different host")
+		if _, duplicate := workspaces[item.workspaceID]; duplicate {
+			return fmt.Errorf("multiple prepared runtimes supplied for workspace %s", item.workspaceID)
 		}
+		workspaces[item.workspaceID] = struct{}{}
 	}
+	batch := make([]*sealedPrepared, 0, len(set.items))
+	for _, item := range set.items {
+		sealed, err := r.sealRegistryPrepared(item)
+		if err != nil {
+			return errors.Join(err, abortSealed(batch))
+		}
+		batch = append(batch, sealed)
+	}
+	set.consumed = true
 
 	r.cutoverMu.Lock()
-	defer r.cutoverMu.Unlock()
 	if err := activate(); err != nil {
-		return err
+		r.cutoverMu.Unlock()
+		return errors.Join(err, abortSealed(batch))
 	}
-	for _, item := range set.items {
-		if err := item.manager.CommitPrepared(item.prepared); err != nil {
-			return err
-		}
+	retired := make([]struct {
+		manager *Manager
+		runtime *managedRuntime
+	}, 0, len(batch))
+	for _, item := range batch {
+		retired = append(retired, struct {
+			manager *Manager
+			runtime *managedRuntime
+		}{manager: item.manager, runtime: item.publish()})
 	}
 	set.committed = true
+	r.cutoverMu.Unlock()
+	for _, item := range retired {
+		item.manager.cleanupRetired(item.runtime)
+	}
 	return nil
+}
+
+func (r *Registry) sealPrepared(candidate servingstate.PreparedRuntime) (*sealedPrepared, error) {
+	prepared, ok := candidate.(*RegistryPrepared)
+	if !ok || prepared == nil {
+		return nil, fmt.Errorf("prepared runtime belongs to a different host")
+	}
+	return r.sealRegistryPrepared(prepared)
+}
+
+func (r *Registry) sealRegistryPrepared(prepared *RegistryPrepared) (*sealedPrepared, error) {
+	if prepared == nil || prepared.registry != r || prepared.manager == nil || prepared.prepared == nil {
+		return nil, fmt.Errorf("prepared runtime belongs to a different host")
+	}
+	return prepared.manager.sealPrepared(prepared.prepared)
+}
+
+func abortSealed(items []*sealedPrepared) error {
+	errs := make([]error, 0, len(items))
+	for _, item := range items {
+		if err := item.abort(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (r *Registry) Close() error {
@@ -319,16 +372,6 @@ func (r *Registry) Close() error {
 		}
 	}
 	return first
-}
-
-func (r *Registry) ActiveForWorkspace(ctx context.Context, workspaceID servingstate.WorkspaceID) (Runtime, error) {
-	lease, err := r.AcquireForWorkspace(ctx, workspaceID)
-	if err != nil {
-		return nil, err
-	}
-	runtime := lease.Runtime()
-	lease.Release()
-	return runtime, nil
 }
 
 func (r *Registry) AcquireForWorkspace(ctx context.Context, workspaceID servingstate.WorkspaceID) (Lease, error) {
@@ -349,13 +392,6 @@ func (r *Registry) AcquireForWorkspace(ctx context.Context, workspaceID servings
 func (r *Registry) ProviderForWorkspace(workspaceID servingstate.WorkspaceID) *WorkspaceProvider {
 	r.managerForWorkspace(workspaceID)
 	return &WorkspaceProvider{registry: r, workspaceID: workspaceID}
-}
-
-func (p *WorkspaceProvider) Active(ctx context.Context) (Runtime, error) {
-	if p == nil || p.registry == nil {
-		return nil, fmt.Errorf("runtime provider is not configured")
-	}
-	return p.registry.ActiveForWorkspace(ctx, p.workspaceID)
 }
 
 func (p *WorkspaceProvider) Acquire(ctx context.Context) (Lease, error) {
@@ -388,12 +424,14 @@ func (r *Registry) managerForWorkspace(workspaceID servingstate.WorkspaceID) *Ma
 		return manager
 	}
 	manager := NewManagerWithFactory(ManagerOptions{
-		Repo:        r.repo,
-		WorkspaceID: workspaceID,
-		Environment: r.environment,
-		Factory:     r.factory,
-		ManagedData: r.managedData,
-		OnDrained:   r.onDrained,
+		Repo:             r.repo,
+		WorkspaceID:      workspaceID,
+		Environment:      r.environment,
+		Factory:          r.factory,
+		ManagedData:      r.managedData,
+		OnDrained:        r.onDrained,
+		Logger:           r.logger,
+		OnCleanupFailure: r.onCleanupFailure,
 	})
 	r.managers[workspaceID] = manager
 	return manager

--- a/internal/workspace/refresh/service.go
+++ b/internal/workspace/refresh/service.go
@@ -57,12 +57,7 @@ type MaterializeInput struct {
 
 type RuntimeHost interface {
 	PrepareServingState(ctx context.Context, servingStateID string) (servingstate.PreparedRuntime, error)
-	CommitPrepared(prepared servingstate.PreparedRuntime) error
-	Reload(ctx context.Context) error
-}
-
-type atomicRuntimeHost interface {
-	CommitPreparedWithActivation(servingstate.PreparedRuntime, func() error) error
+	ActivatePrepared(prepared servingstate.PreparedRuntime, activate func() error) error
 }
 
 type RetentionRunner interface {
@@ -301,13 +296,20 @@ func (s Service) ExecuteClaimedJob(ctx context.Context, job materialize.JobRecor
 		s.failJob(ctx, job, childRuns, candidate, err)
 		return err
 	}
-	var prepared servingstate.PreparedRuntime
-	if s.Runtime != nil {
-		prepared, err = s.Runtime.PrepareServingState(ctx, string(candidateState.ID))
-		if err != nil {
-			s.failJob(ctx, job, childRuns, candidate, err)
-			return err
-		}
+	if s.Runtime == nil {
+		err = fmt.Errorf("runtime host is required for refresh activation")
+		s.failJob(ctx, job, childRuns, candidate, err)
+		return err
+	}
+	prepared, err := s.Runtime.PrepareServingState(ctx, string(candidateState.ID))
+	if err != nil {
+		s.failJob(ctx, job, childRuns, candidate, err)
+		return err
+	}
+	if prepared == nil {
+		err = fmt.Errorf("runtime host returned a nil prepared runtime")
+		s.failJob(ctx, job, childRuns, candidate, err)
+		return err
 	}
 	now := time.Now()
 	if s.Now != nil {
@@ -318,26 +320,12 @@ func (s Service) ExecuteClaimedJob(ctx context.Context, job materialize.JobRecor
 		SnapshotID: snapshotID, ServingStateID: string(candidateState.ID), RefreshedAt: now.UTC(),
 		Source: refreshpipeline.DataVersionSourceRefresh, PipelineID: pipelineID, RunID: job.RunID,
 	}
-	if prepared != nil {
-		activate := func() error { return s.activateRefresh(ctx, candidate, dataVersion) }
-		if atomic, ok := s.Runtime.(atomicRuntimeHost); ok {
-			err = atomic.CommitPreparedWithActivation(prepared, activate)
-		} else if err = activate(); err == nil {
-			err = s.Runtime.CommitPrepared(prepared)
-		}
-		if err != nil {
-			_ = prepared.Close()
-			s.failJob(ctx, job, childRuns, candidate, err)
-			return err
-		}
-	} else {
-		if err := s.activateRefresh(ctx, candidate, dataVersion); err != nil {
-			s.failJob(ctx, job, childRuns, candidate, err)
-			return err
-		}
-		if s.Runtime != nil {
-			_ = s.Runtime.Reload(ctx)
-		}
+	activate := func() error { return s.activateRefresh(ctx, candidate, dataVersion) }
+	err = s.Runtime.ActivatePrepared(prepared, activate)
+	if err != nil {
+		_ = prepared.Close()
+		s.failJob(ctx, job, childRuns, candidate, err)
+		return err
 	}
 	if job.TargetType == materialize.TargetRefreshPipeline && s.DataVersions != nil {
 		if publisher, ok := s.Publisher.(interface {

--- a/internal/workspace/refresh/service_test.go
+++ b/internal/workspace/refresh/service_test.go
@@ -135,6 +135,59 @@ func TestServiceExecuteClaimedJobRuntimePrepareFailureDoesNotActivate(t *testing
 	}
 }
 
+func TestServiceExecuteClaimedJobRuntimeActivationFailureDoesNotPublishOrActivate(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	wantErr := errors.New("runtime activation failed")
+	runtime := &fakeRuntimeHost{activateErr: wantErr}
+	service := Service{
+		ServingStates: repo,
+		Runs:          repo,
+		Artifacts:     fakeArtifactLoader{definition: refreshTestDefinition()},
+		Materializer:  &fakeMaterializer{snapshotID: 42},
+		Runtime:       runtime,
+	}
+
+	err := service.ExecuteClaimedJob(ctx, materialize.JobRecord{
+		ID: "job_1", WorkspaceID: "sales", ServingStateID: "dep_candidate", RunID: "run_root", ModelID: "sales",
+		TargetType: materialize.TargetRefreshPipeline, TargetID: "sales.sales-refresh", Kind: materialize.JobKindRefreshPipeline,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("execute claimed job error = %v, want %v", err, wantErr)
+	}
+	if repo.activatedDeployment != "" {
+		t.Fatalf("activated deployment = %s, want none", repo.activatedDeployment)
+	}
+	if runtime.committed {
+		t.Fatal("runtime was published after atomic activation failed")
+	}
+	if repo.failedDeployment != "dep_candidate" {
+		t.Fatalf("failed deployment = %s, want dep_candidate", repo.failedDeployment)
+	}
+}
+
+func TestServiceExecuteClaimedJobRequiresAtomicRuntimeHost(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeRepo()
+	service := Service{
+		ServingStates: repo,
+		Runs:          repo,
+		Artifacts:     fakeArtifactLoader{definition: refreshTestDefinition()},
+		Materializer:  &fakeMaterializer{snapshotID: 42},
+	}
+
+	err := service.ExecuteClaimedJob(ctx, materialize.JobRecord{
+		ID: "job_1", WorkspaceID: "sales", ServingStateID: "dep_candidate", RunID: "run_root", ModelID: "sales",
+		TargetType: materialize.TargetRefreshPipeline, TargetID: "sales.sales-refresh", Kind: materialize.JobKindRefreshPipeline,
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime host is required") {
+		t.Fatalf("execute claimed job error = %v, want required runtime host", err)
+	}
+	if repo.activatedDeployment != "" {
+		t.Fatalf("activated deployment = %s, want none", repo.activatedDeployment)
+	}
+}
+
 func TestServiceQueuePipelineRefreshCreatesFullSemanticModelRun(t *testing.T) {
 	repo := newFakeRepo()
 	service := Service{
@@ -469,9 +522,10 @@ func (m *fakeMaterializer) Materialize(_ context.Context, input MaterializeInput
 }
 
 type fakeRuntimeHost struct {
-	prepared   bool
-	committed  bool
-	prepareErr error
+	prepared    bool
+	committed   bool
+	prepareErr  error
+	activateErr error
 }
 
 func (h *fakeRuntimeHost) PrepareServingState(context.Context, string) (servingstate.PreparedRuntime, error) {
@@ -482,12 +536,16 @@ func (h *fakeRuntimeHost) PrepareServingState(context.Context, string) (servings
 	return fakePrepared{}, nil
 }
 
-func (h *fakeRuntimeHost) CommitPrepared(servingstate.PreparedRuntime) error {
+func (h *fakeRuntimeHost) ActivatePrepared(_ servingstate.PreparedRuntime, activate func() error) error {
+	if h.activateErr != nil {
+		return h.activateErr
+	}
+	if err := activate(); err != nil {
+		return err
+	}
 	h.committed = true
 	return nil
 }
-
-func (h *fakeRuntimeHost) Reload(context.Context) error { return nil }
 
 type fakePrepared struct{}
 

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,23 @@
-# LeapView Architecture Spec
+# LeapView Target Architecture
 
-This document defines the target architecture for LeapView: a feature-oriented modular monolith with ports and adapters. The goal is cohesive product capabilities, explicit infrastructure boundaries, and a codebase that grows without turning `internal/app`, `platform`, or global service objects into new monoliths.
+This document is the architectural north star for LeapView. It defines the intended product boundaries, dependency rules, runtime model, storage ownership, and scaling model. It is normative: implementation choices are evaluated against this architecture.
+
+LeapView is a feature-oriented modular monolith with ports and adapters. One LeapView deployment is a complete, vertically scalable, single-node product and the unit of ownership, operation, failure isolation, backup, and recovery.
+
+## Architecture Thesis
+
+LeapView optimizes for local correctness and operational independence:
+
+- One process owns the HTTP server, background work, runtime generations, and lifecycle coordination for one node.
+- One SQLite database owns node-local control-plane state.
+- One DuckLake catalog owns node-local analytical metadata and snapshots.
+- DuckDB executes governed analytical work against immutable runtime generations.
+- Authored YAML in Git is the source of truth for product assets.
+- Capability boundaries are explicit even though capabilities share one process and deployment.
+- Vertical scaling is the primary scaling mechanism within a node.
+- Product scale-out uses multiple independent LeapView deployments, partitioned by tenant, data domain, or operational boundary.
+
+LeapView is not a distributed database, clustered application, or cross-node query engine. Independent deployments do not share control-plane transactions, runtime state, DuckLake snapshots, page streams, or refresh coordination.
 
 ## Core Rules
 
@@ -10,11 +27,17 @@ This document defines the target architecture for LeapView: a feature-oriented m
 - Let adapters import external systems and generated code; never let domain or use-case packages import adapters.
 - Split packages by cohesion, workflow, dependency pressure, or test friction, not by generic layers.
 - Prefer explicit composition over hidden service locators or broad runtime objects.
+- Make immutable serving and compiler outputs immutable by construction, not merely by convention.
+- Use typed Go ports and direct calls for synchronous invariants. Do not insert brokers, serialization, service discovery, or RPC to simulate distribution within a node.
+- Use process-local fan-out only for ephemeral, reconstructible notifications. Represent durable asynchronous work in SQLite jobs or transactional outbox records.
+- Potential extraction boundaries use coarse, transport-neutral contracts. Extraction adds an adapter; it does not introduce transport concerns into domain or use-case code.
+- Every operation has explicit authorization, resource bounds, cancellation, idempotency, and audit behavior where applicable.
+- No capability reaches through another capability's repository or storage schema.
 
 Dependencies point inward:
 
 ```text
-HTTP / CLI / Datastar / SQLite / DuckDB / filesystem / OpenAI
+HTTP / CLI / Datastar / SQLite / DuckDB / filesystem / object storage / OpenAI
         -> capability adapters
         -> capability use cases
         -> capability domain types and ports
@@ -23,55 +46,160 @@ HTTP / CLI / Datastar / SQLite / DuckDB / filesystem / OpenAI
 Allowed:
 
 ```text
-servingstate/http       -> servingstate/activate
-servingstate/http       -> servingstate/filesystem
-servingstate/sqlite     -> servingstate
+deployment/http       -> deployment
+deployment            -> release
+deployment            -> servingstate
+deployment            -> runtimehost ports
+project/compiler      -> analytics/model
+project/compiler      -> dashboard/report
 dashboard/http        -> dashboard/stream
-dashboard/datastar    -> dashboard
+dashboard             -> analytics/query contracts
 analytics/duckdb      -> analytics/query
-analytics/connectors  -> analytics/model
+refresh               -> analytics/materialize ports
+refresh               -> manageddata ports
 ```
 
 Forbidden outside adapters and composition:
 
 ```text
-servingstate/activate -> servingstate/filesystem
-servingstate          -> chi
+servingstate          -> servingstate/filesystem
+servingstate          -> runtimehost implementation
 servingstate          -> sqlc rows
-dashboard/report    -> datastar
-analytics/query     -> duckdb connection details
-workspace           -> http.Request
-agent               -> OpenAI request payloads
+dashboard/report      -> Datastar
+analytics/query       -> DuckDB connection details
+workspace             -> http.Request
+agent                 -> OpenAI request payloads
+capability A          -> capability B's SQLite adapter
 ```
+
+## Deployment And Scaling Model
+
+One LeapView deployment is a self-contained node:
+
+```text
+LeapView node
+  process
+    HTTP, API, CLI-facing server
+    Datastar page streams
+    compiler and deployment coordination
+    governed query execution
+    refresh and maintenance workers
+
+  state
+    SQLite control-plane database
+    DuckLake catalog
+    Parquet analytical data
+    immutable artifacts
+    ephemeral runtime files
+```
+
+Node invariants:
+
+- A node can build, deploy, refresh, govern, query, back up, restore, and serve its assets without another LeapView service.
+- A node serves exactly one configured environment; environment isolation is achieved with separate deployments, not shared runtime state inside one node.
+- SQLite and the local DuckLake catalog are never mounted as writable shared state across hosts.
+- Process-local brokers, runtime registries, caches, and locks coordinate only the node that owns them.
+- Node-local operations never require a cross-node transaction.
+- A node continues serving known routes and active assets without a global control plane.
+- Backup and recovery cover the complete node state, including SQLite, DuckLake metadata, analytical files, artifacts, and required secrets or configuration.
+
+Vertical scaling rules:
+
+- Query, refresh, stream, cache, and control-plane resources have explicit node-wide limits.
+- Workload admission provides bulkheads by workload class and workspace.
+- Interactive reads, exports and agent work, refresh writes, and maintenance work have separate limits.
+- A workspace cannot consume the entire node queue, memory budget, or refresh capacity.
+- Capacity limits are measurable and validated with load tests at the maximum supported node size.
+- Overload is rejected or shed before unbounded work reaches DuckDB, SQLite, page streams, or external connectors.
+
+Fleet scale is achieved by adding independent LeapView deployments. Placement by tenant, data domain, or operational boundary is external to a node. Each deployment retains its own source of truth, authorization, serving state, analytical catalog, and failure domain.
 
 ## Capability Map
 
-Long-term package ownership:
+Top-level capability ownership:
 
 ```text
 internal/
+  project/
   workspace/
-  servingstate/
   access/
+  manageddata/
   analytics/
   dashboard/
   agent/
+  release/
+  deployment/
+  servingstate/
+  refresh/
   runtimehost/
   platform/
 ```
 
-- `workspace`: workspace identity, catalog surface, asset discovery, asset graph views, workspace-level read models.
-- `servingstate`: bundle lifecycle, validation, artifact identity, activation, rollback, serving state status, immutable asset snapshots.
-- `access`: principals, groups, roles, permissions, authorization decisions, tokens, sessions, audit access.
-- `analytics`: source and connection contracts, semantic model tables, semantic models, query planning, query execution, materialization, connectors, DuckDB adapters.
-- `dashboard`: report pages, filters, visuals, BI tables, interactions, page state, typed query intents, signal contracts.
-- `agent`: conversations, runs, transcripts, tools, policy-filtered operation exposure, model interaction ports.
-- `runtimehost`: active runtime lifecycle, prepared runtime swap, runtime closure, active runtime ports.
-- `platform`: low-level infrastructure: SQLite setup, migrations, shared DB plumbing, process-level storage paths.
+- `project`: authored project manifest, cross-capability compilation, normalized immutable workspace bundles, and stable asset graph extraction.
+- `workspace`: workspace identity, node-local catalog surface, asset discovery, asset graph views, and workspace read models.
+- `access`: principals, groups, roles, permissions, authorization decisions, credentials, tokens, sessions, and access auditing.
+- `manageddata`: upload protocols, ingestion, connection revisions, source bindings, retained blobs, runtime views, and managed-data lifecycle.
+- `analytics`: source and connection contracts, model tables, semantic models, query planning, query execution, materialization, connectors, and DuckDB adapters.
+- `dashboard`: report pages, filters, visuals, BI tables, interactions, page state, typed query intents, and dashboard signal contracts.
+- `agent`: conversations, runs, transcripts, tools, policy-filtered operation exposure, and model interaction ports.
+- `release`: immutable project release manifests, workspace artifact intake, content verification, and release finalization.
+- `deployment`: environment rollout of a release, multi-workspace activation coordination, rollback intent, and deployment status.
+- `servingstate`: one workspace's immutable serving generation, artifact identity, validation state, analytical snapshot reference, and lifecycle invariants.
+- `refresh`: refresh definitions, schedules, jobs, generations, materialization orchestration, data-version cutover, and supersession behavior.
+- `runtimehost`: process-local active runtime lifecycle, prepared runtime publication, leases, draining, and closure.
+- `platform`: low-level node infrastructure: SQLite opening and migrations, process-level paths, backup primitives, and shared infrastructure configuration.
 
-`admin` is not a domain capability. It is an interface surface over capabilities and infrastructure. `admin/http` may aggregate read models from `access`, `workspace`, `servingstate`, `agent`, `analytics`, `runtimehost`, and `platform`, but it must not own their business workflows.
+`admin` is not a domain capability. It is an interface surface over capability-owned use cases and read models. `admin/http` may compose read models but must not own their business workflows.
 
-Historical or legacy vocabulary must not define long-term ownership when it conflicts with product capabilities.
+`internal/api` contains framework-neutral public wire contracts. `internal/ui` contains shared render primitives and typed UI transport contracts. Neither is a business capability.
+
+## Capability Context Map
+
+The capability graph is directed. Package-level acyclicity is necessary but not sufficient; reciprocal dependencies between top-level capabilities are forbidden unless both depend on a smaller neutral contract owned by neither implementation.
+
+Primary relationships:
+
+```text
+project/compiler
+  -> workspace contracts
+  -> analytics/model contracts
+  -> dashboard/report contracts
+  -> access policy contracts
+  -> refresh definition contracts
+
+release
+  -> project artifact validation port
+  -> workspace identity port
+  -> servingstate creation port
+
+deployment
+  -> release read port
+  -> servingstate activation ports
+  -> manageddata binding port
+  -> runtimehost publication port
+
+refresh
+  -> servingstate read/create ports
+  -> manageddata resolution port
+  -> analytics materialization port
+  -> runtimehost publication port
+
+dashboard
+  -> analytics query contracts
+
+agent
+  -> governed product-operation ports
+```
+
+Rules:
+
+- `analytics` never imports dashboard or workspace implementations.
+- `dashboard` never constructs analytics adapters.
+- `workspace` never owns analytics or dashboard behavior.
+- `project/compiler` is the integration boundary allowed to understand multiple authored contract families.
+- Bridge adapters belong to the consuming capability or the composition root, not to the provider's domain package.
+- Cross-capability DTOs are explicit contracts; arbitrary domain structs are not shared as convenience models.
+- Every top-level package is declared in the context map and has one accountable owner.
 
 ## Product Contract
 
@@ -81,37 +209,44 @@ The authored product contract is:
 sources -> models -> semantic model -> dashboards
 ```
 
-LeapView is assets-as-code. Authored YAML in Git is the source of truth. The compiler turns authored contracts into a normalized workspace and stable asset graph. Serving states publish immutable graph snapshots. Runtime stores never become authoring sources.
+LeapView is assets-as-code. Authored YAML in Git is the source of truth. The project compiler turns authored contracts into immutable normalized workspace bundles and stable asset graphs. Serving states publish those bundles. Runtime stores never become authoring sources.
 
-Not product/schema concepts in the v1 contract:
+The public product schema does not contain:
 
 - metric views
 - cache tables
 - generated serving tables
+- DuckDB secrets or attach statements
+- physical runtime relation names
 
-If those appear in code, they are internal runtime implementation details, legacy rejection paths, or tests proving old vocabulary does not leak into user-facing surfaces.
+Those concepts are internal runtime implementation details or invalid authored input.
 
-`semantic dataset` is allowed only as a headless API and agent-facing alias for a semantic model table. Go domain code should prefer `model table` or `table` unless it is translating the public BI API contract. Do not introduce a separate dataset domain model parallel to `analytics/model.Table`.
+`semantic dataset` is allowed only as a headless API and agent-facing alias for a semantic model table. Domain code uses `model table` or `table` unless translating the public BI API contract. There is no parallel dataset domain model.
 
 YAML contract ownership:
 
-- `workspace` owns catalog discovery and workspace asset surfacing.
+- `project` owns the project entrypoint and resource discovery.
 - `analytics/model` owns source contracts, connection contracts, model table contracts, semantic model contracts, fields, relationships, measures, and materialization definitions.
-- `dashboard/report` owns dashboard, page, filter, visual, and table contracts.
-- `servingstate` owns bundle-level validation, artifact identity, activation, rollback, and artifact storage.
+- `dashboard/report` owns dashboards, pages, filters, visuals, tables, and interactions.
+- `access` owns authored access policy contracts.
+- `refresh` owns authored refresh definitions and schedules.
+- `project/compiler` owns validation and normalization spanning multiple contract families.
 
-## Target Package Shape
+## Package Shape
 
-Use flat capability packages until cohesion breaks. Then split by workflow or adapter.
-
-Target examples:
+Use flat capability packages until cohesion breaks. Split by workflow or adapter, never by generic horizontal layer.
 
 ```text
+project/
+  manifest/       project entrypoint contract
+  compiler/       loading, cross-contract validation, normalization, graph extraction
+  artifact/       immutable compiled bundle contract
+
 analytics/
   model/          semantic contracts, fields, relationships, measures
-  query/          semantic query requests, planning, path safety, SQL plans
-  materialize/    refresh and materialization behavior
-  connectors/     connector registry, source capabilities, option schemas
+  query/          governed query requests, planning, path safety, SQL plans
+  materialize/    materialization behavior and analytical write ports
+  connectors/     connector registry, capabilities, option schemas
   duckdb/         DuckDB execution adapter
 
 dashboard/
@@ -120,22 +255,43 @@ dashboard/
   command/        filter, selection, table-window, refresh command handling
   datastar/       signal decoding, patch keys, SSE serialization
   http/           route handlers
-  ui/             HTML/gomponents rendering adapter
+  ui/             HTML and gomponents rendering adapter
+
+manageddata/
+  control/        upload and revision use cases
+  binding/        serving-state binding resolution
+  storage/        blob and multipart storage ports
+  filesystem/     local storage adapter
+  s3/             object storage adapter
+  sqlite/         control-plane persistence adapter
+
+release/
+  finalize/       release verification and finalization
+  sqlite/         release persistence adapter
+  http/           release API adapter
+
+deployment/
+  activate/       multi-workspace activation use case
+  rollback/       rollback intent and validation
+  sqlite/         deployment persistence adapter
+  http/           deployment API adapter
 
 servingstate/
-  state.go   shared domain language
-  activate/       activation use case
-  validate/       validation use case
-  sqlite/         SQLite persistence adapter
-  filesystem/     artifact storage and bundle adapter
-  http/           route handlers
+  state.go        shared domain language and lifecycle invariants
+  validate/       bundle validation use case
+  sqlite/         serving-state persistence adapter
+  filesystem/     artifact storage adapter
+
+refresh/
+  plan/           dependency-aware refresh planning
+  schedule/       schedule evaluation
+  run/            durable job and generation behavior
+  sqlite/         refresh persistence adapter
 
 workspace/
-  catalog/        catalog discovery and workspace identity
-  compiler/       cross-contract loading, validation, normalization, graph extraction
-  refresh/        workspace asset refresh use cases
-  sqlite/         SQLite read models and repositories
-  http/           REST/UI handlers
+  catalog/        node-local asset discovery and workspace identity
+  sqlite/         read models and repositories
+  http/           REST and UI handlers
   datastar/       workspace signal patches
 ```
 
@@ -150,79 +306,161 @@ utils
 helpers
 ```
 
-These names are acceptable only inside a capability and only when they stay narrow.
+These names are acceptable only inside a capability and only when the package remains narrow and cohesive.
 
-## Asset Compiler
+Shared contracts belong to the capability that owns their meaning. For example, a governed query request belongs to `analytics/query`; it does not belong in a generic root-level `dataquery` package.
+
+## Project Compiler
 
 Authored YAML contracts have one compilation boundary:
 
 ```text
-workspace/catalog + analytics/model + dashboard/report
-        -> workspace/compiler
-        -> normalized workspace + stable asset graph
-        -> immutable asset configuration snapshot
+project/manifest
+  + workspace contracts
+  + analytics/model
+  + dashboard/report
+  + access policy
+  + refresh definitions
+        -> project/compiler
+        -> immutable compiled workspace bundles
+        -> stable asset graphs
+        -> versioned capability projections
 ```
 
 The compiler owns cross-contract validation and normalization:
 
+- Project resources resolve to declared workspaces.
 - Catalog entries resolve to semantic models and dashboards.
-- Dashboard `semantic_model` references resolve to loaded semantic models.
-- Dashboard fields, measures, filters, tables, and visuals resolve against the semantic model.
-- Legacy vocabulary such as metric views is rejected at the boundary.
-- Runtime consumers receive a normalized workspace without re-parsing YAML.
-- Serving state, UI, API, agents, and storage adapters consume the compiler-produced asset graph instead of rediscovering lineage by walking semantic or dashboard internals.
+- Dashboard semantic-model references resolve to loaded semantic models.
+- Dashboard fields, measures, filters, tables, and visuals resolve against semantic contracts.
+- Access policy references resolve to stable securable asset IDs.
+- Refresh targets resolve to model tables or semantic models.
+- Unsupported vocabulary is rejected at the compilation boundary.
+- Runtime consumers never re-parse authored YAML.
+- Serving state, UI, API, agents, and storage adapters consume compiler-produced projections instead of rediscovering lineage by walking arbitrary domain internals.
 
-Capability packages own local contracts and validation. The compiler owns validation spanning multiple contracts.
+Compiled workspace bundles are immutable by construction:
+
+- Collections are private and exposed through read-only lookup or iteration methods.
+- Constructors defensively copy caller-owned slices, maps, pointers, and raw payloads.
+- Capability projections expose only the data required by their consumer.
+- A digest covers the canonical compiled representation and referenced managed-data pins.
+- Runtime code cannot mutate compiled configuration.
 
 Asset graph rules:
 
 - Every authored object users can discover, govern, diff, or trace is an asset.
 - Logical asset IDs are stable across serving states, such as `semantic_model:olist` or `visual:executive-sales.revenue`.
-- Serving state-scoped snapshot IDs may change per serving state.
+- Serving-state-scoped snapshot IDs may change per serving state.
 - Asset payloads are explicit versioned projections, such as `semantic_model.v1`, `model_table.v1`, `measure.v1`, `dashboard.v1`, and `visual.v1`.
-- Persisted payloads must not be raw `json.Marshal` output of arbitrary Go structs.
-- The full authored YAML remains in the serving state artifact.
-- Read paths may load asset snapshots but must not repair, migrate, or reinterpret stale graph shapes during ordinary HTTP requests.
+- Persisted payloads are never raw `json.Marshal` output of arbitrary domain structs.
+- The complete authored YAML is retained in the immutable artifact.
+- Read paths load exact supported projections; they do not repair, migrate, or reinterpret stored graph shapes.
+
+## Release, Deployment, And Serving Lifecycle
+
+The publication lifecycle is explicit:
+
+```text
+authored project
+  -> compiled workspace artifacts
+  -> immutable release
+  -> deployment candidate for one environment
+  -> prepared workspace runtimes
+  -> durable activation transaction
+  -> atomic in-process runtime publication
+  -> old generations drain
+  -> retention cleanup
+```
+
+Ownership:
+
+- `release` verifies artifact membership, content digests, completeness, and immutability.
+- `servingstate` represents one workspace generation and validates its legal state transitions.
+- `deployment` coordinates one release across all targeted workspaces in an environment.
+- `runtimehost` prepares and publishes process-local executable generations.
+- `manageddata` resolves and retains the exact source revisions required by each candidate.
+- `analytics` prepares executable query and materialization services.
+
+Activation invariants:
+
+- Every candidate runtime is fully prepared before durable activation begins.
+- Durable activation changes all targeted workspace pointers in one SQLite transaction.
+- Runtime publication cannot fail after durable activation commits.
+- Runtime publication installs all target pointers while request acquisition is excluded from the cutover.
+- Closing retired runtimes, releasing leases, deleting files, and other cleanup happen after publication and cannot change a successful activation into a failed activation.
+- If cleanup fails, the new deployment remains active and the failure is retried and surfaced operationally.
+- Requests resolve one serving generation once and hold its runtime lease until work completes.
+- A deployment response always reflects the durable state of the deployment.
+
+Serving-state lifecycle:
+
+```text
+pending -> uploaded -> validated -> active -> draining -> delete_scheduled -> deleted
+                         \-> failed
+```
+
+Rollback is a new deployment of a previously validated immutable release or serving artifact. It does not mutate historical artifacts.
 
 ## Source And Connector Boundaries
 
-Source and connection support crosses contracts, security, and execution.
+Source and connection support crosses authored contracts, security, managed data, and execution.
 
 - `analytics/model` owns authored source and connection contracts.
 - `analytics/connectors` owns supported connection/source kinds, formats, option schemas, and capability metadata.
+- `manageddata` owns uploaded data, revisions, bindings, and retained physical source material.
 - Credential and environment resolution belongs to infrastructure adapters.
-- Path-scope and object-scope validation belongs at the compiler/runtime boundary before execution.
-- DuckDB scan, secret, attach, and extension statements belong in `analytics/duckdb`.
+- Path-scope and object-scope validation occurs before execution.
+- DuckDB scan, secret, attach, and extension statements live only in `analytics/duckdb`.
 
-Authored YAML describes what source to read and which governed connection to use. It must not expose DuckDB secret plumbing, internal `raw.*` relations, or scan implementation details.
+Authored YAML describes what source to read and which governed connection to use. It never exposes DuckDB secret plumbing, internal relations, or scan implementation details.
+
+Connector execution rules:
+
+- Every connector declares capabilities and supported credential modes.
+- Resolved credentials are short-lived, scoped, and never persisted in compiled asset payloads.
+- Source access is constrained to declared path or object scope.
+- Connector calls honor context cancellation, timeouts, and bounded retries.
+- Errors returned to users are safe projections that do not leak credentials or infrastructure internals.
 
 ## Storage Ownership
 
-- SQLite is the control-plane store for workspaces, serving states, immutable asset graph snapshots, roles, sessions, agent conversations, and audit data.
-- SQLite asset tables are indexed read models of compiled code assets, not authoring storage.
-- DuckDB is the analytical data plane for imported/cache data, semantic query execution, dashboard data, and materializations.
-- Generated sqlc code is private to SQLite adapter packages or narrow platform infrastructure.
-- `platform.Store` must not expose raw `Queries()` or direct SQL access to handlers, use cases, runtime managers, or domain packages.
-- `platform` may own migrations and DB setup. It must not accumulate workspace, serving state, access, session, asset, or agent business workflows.
+SQLite is the node-local control-plane store. DuckLake and Parquet form the node-local analytical data plane.
 
-Capability repositories wrap control-plane persistence:
+- SQLite stores workspaces, releases, deployments, serving states, immutable asset graph projections, principals, roles, sessions, managed-data metadata, refresh jobs, agent conversations, idempotency records, leases, and audit data.
+- DuckLake stores analytical table metadata, snapshots, statistics, schema evolution, and physical-file ownership.
+- Parquet stores materialized analytical data.
+- DuckDB executes analytical queries and materialization against the selected DuckLake snapshot.
+- Runtime caches are disposable projections and never authoritative state.
+- Asset tables are indexed read models of compiled code assets, not authoring storage.
+- Message brokers, streams, and key-value transports are never authoritative node-local product storage. They may deliver notifications or external integration messages; SQLite remains the durable coordinator.
+
+SQLite rules:
+
+- Transactions are short and bounded.
+- WAL mode permits concurrent reads while preserving SQLite's single-writer model.
+- Long-running analytical or network work never executes inside a SQLite transaction.
+- Busy handling, checkpointing, integrity checks, backup, restore, and retention are explicit operational behavior.
+- Repositories expose capability types, not `database/sql`, sqlc rows, or raw queries.
+- Capability adapters own capability-private generated query packages.
+- `platform` owns database opening, migrations, and node-level maintenance primitives, not business workflows.
+
+Capability persistence shape:
 
 ```text
-servingstate.Repository
-servingstate.ArtifactRepository
-workspace.AssetRepository
-access.RoleBindingRepository
-agent.ConversationRepository
+access/sqlite/internal/db
+workspace/sqlite/internal/db
+manageddata/sqlite/internal/db
+release/sqlite/internal/db
+deployment/sqlite/internal/db
+servingstate/sqlite/internal/db
+refresh/sqlite/internal/db
+agent/sqlite/internal/db
 ```
 
-SQLite implementations live under adapter packages:
+Migrations remain globally ordered because the node has one SQLite database. Query APIs and row mappings remain private to the capability that owns the tables.
 
-```text
-servingstate/sqlite.Repository
-workspace/sqlite.AssetRepository
-access/sqlite.RoleBindingRepository
-agent/sqlite.ConversationRepository
-```
+When a workflow needs atomic writes spanning capabilities, its coordinating use case defines a unit-of-work port. The SQLite adapter implements that port without exposing `*sql.Tx` or capability-private generated clients.
 
 ## Domain And Use Cases
 
@@ -235,19 +473,17 @@ Domain code defines capability language:
 - business errors
 - shared business-shaped ports
 
-Domain and use-case packages must not contain:
+Domain and use-case packages never contain:
 
 - `http.Request` or `http.ResponseWriter`
-- `chi`, Datastar, or gomponents details
+- chi, Datastar, or gomponents details
 - sqlc row types
 - `sql.NullString`
 - DuckDB connection details
-- OpenAI request/response payloads
-- filesystem layout assumptions, unless the capability is explicitly a filesystem adapter
+- OpenAI request or response payloads
+- filesystem layout assumptions
 
-Use-case services orchestrate one workflow. They may load domain objects, call domain methods, coordinate repositories, call ports, and return capability-level results. They must not decode HTTP, render HTML, emit Datastar patches, return sqlc structs, or construct infrastructure clients.
-
-When a workflow needs atomic writes across repositories, define a capability-level unit-of-work port. Do not expose `*sql.Tx` or sqlc transaction types to use-case code.
+Use-case services orchestrate one workflow. They may load domain objects, call domain methods, coordinate repositories, invoke ports, and return capability-level results. They never decode HTTP, render HTML, emit Datastar patches, return sqlc structs, or construct infrastructure clients.
 
 ## Ports And Interfaces
 
@@ -259,19 +495,29 @@ Use-case-specific dependency:
 package activate
 
 type Repository interface {
-    ByID(ctx context.Context, id servingstate.ID) (servingstate.State, error)
-    Activate(ctx context.Context, workspaceID servingstate.WorkspaceID, servingStateID servingstate.ID) error
+    Deployment(ctx context.Context, id deployment.ID) (deployment.Deployment, error)
+    Activate(ctx context.Context, id deployment.ID) error
 }
 ```
 
-Shared business concept:
+Shared business concepts live at the capability root:
 
 ```text
 servingstate.State
 servingstate.Status
 servingstate.Artifact
-servingstate.Repository
+deployment.Deployment
+release.Release
 ```
+
+Interface ownership:
+
+- Shared business language lives in the owning capability.
+- Single-use dependencies live beside the consuming use case.
+- Adapter implementation details stay inside adapters.
+- Adapters implement ports; they do not define business-facing ports for their consumers.
+- Broad interfaces split when consumers require different subsets or lifecycle guarantees.
+- Runtime access is lease-based. No API returns an unleased runtime that can be closed while a caller still uses it.
 
 Avoid generic infrastructure interfaces in domain or use-case packages:
 
@@ -280,15 +526,6 @@ type Store interface {
     Queries() *db.Queries
 }
 ```
-
-Interface ownership:
-
-- Shared business language lives in the capability root.
-- Single-use dependencies live beside the consuming use case.
-- Adapter implementation details stay inside adapters.
-- Adapters implement ports; they do not own business-facing port definitions.
-
-Broad interfaces must split when consumers diverge. Dashboard streaming, semantic query APIs, workspace asset views, and refresh orchestration should not share one cross-cutting runtime interface unless they truly need the same capability set.
 
 ## Product Interfaces
 
@@ -301,43 +538,38 @@ built-in agent and MCP tools
 UI / HTML / Datastar
 ```
 
-None of these owns product behavior. They translate transport contracts into capability use cases.
+None owns product behavior. Each translates its transport contract into capability use cases.
 
 Rules:
 
 - TypeSpec/APIGen owns the canonical headless REST contract and generator metadata.
 - API DTOs live in `internal/api` as framework-neutral wire contracts only.
-- CLI commands should use generated APIGen operation metadata where possible, with small UX wrappers only when needed.
-- The built-in agent and MCP should consume one governed tool catalog derived from APIGen operation metadata, with shared risk, permission, explicit workspace argument, credential, execution, projection, audit, and error behavior.
-- UI routes may render HTML and Datastar patches, but must call the same capability use cases as API, CLI, and agent interfaces for the same behavior.
-- Datastar signal shapes are UI-private adapter contracts. They must not become headless API DTOs.
+- CLI commands call capability use cases or generated API operations; they do not implement parallel business workflows.
+- The built-in agent and MCP consume one governed tool catalog derived from product-operation metadata, with shared risk, permission, workspace, credential, execution, projection, audit, and error behavior.
+- UI routes call the same capability use cases as API, CLI, and agent interfaces for equivalent behavior.
+- Datastar signal shapes are UI-private adapter contracts and never become headless API DTOs.
+- A versioned, paginated asset catalog API exposes node-local discovery without exposing storage internals.
 
 Avoid a single cross-capability `internal/api/http` package.
 
 ## UI And Datastar
 
-HTTP handlers are adapters. They may parse route parameters, query strings, forms, JSON bodies, and Datastar signals; call one use case; translate results; and map errors to status codes.
+HTTP handlers are adapters. They parse route parameters, query strings, forms, JSON bodies, and Datastar signals; call one use case; translate results; and map errors to status codes.
 
-Handlers must not own business workflows such as serving state activation, workspace access mutation, artifact validation, or dashboard query orchestration.
+Handlers do not own business workflows such as deployment activation, workspace access mutation, artifact validation, or dashboard query orchestration.
 
-Datastar-specific logic belongs in adapter packages near the owning capability:
+Datastar-specific logic lives near the owning capability:
 
 - signal decoding
 - patch keys
 - SSE serialization
-- compatibility with client-side signal shape
+- client signal compatibility
 
-Domain and analytics packages speak in typed commands, snapshots, events, query intents, and result structs.
+Domain and analytics packages speak in typed commands, snapshots, events, query intents, and results.
 
-Gomponents renderers are edge adapters. A shared `internal/ui` package may exist, but it must stay render-only:
+Gomponents renderers are edge adapters. Shared `internal/ui` contains only design-system primitives, document shells, and generated signal contracts. Capability-specific pages live under capability `ui` packages.
 
-- no workflow orchestration
-- no storage access
-- no semantic query planning
-- no cross-contract validation
-- no domain mutation
-
-REST JSON handlers and UI/Datastar handlers may live beside the same capability, but their transport contracts must stay separate.
+Shared UI code performs no workflow orchestration, storage access, semantic planning, cross-contract validation, or domain mutation.
 
 ## Dashboard Runtime
 
@@ -347,71 +579,96 @@ Dashboard owns report-page behavior:
 - `PageSnapshot`
 - `FilterState`
 - `InteractionSelection`
-- table window command intents
-- chart selection command intents
+- table-window command intents
+- chart-selection command intents
 - typed analytics query intents
 
-Dashboard streaming services must:
+Dashboard streaming services:
 
 - accept `context.Context` and stop promptly on cancellation
 - treat repeated requests and stale client updates as safe to ignore or replace
 - produce immutable page snapshots or typed patch intents
-- keep cache invalidation and refresh behavior explicit
+- make cache invalidation and refresh behavior explicit
 - treat Datastar as serialization and transport, not business state
+- use bounded mailboxes with explicit coalescing and overflow behavior
 
-Dashboard may describe what data a page needs. Analytics owns semantic query planning and execution. Dashboard queries analytics through typed semantic query ports.
+Dashboard describes what data a page needs. Analytics owns semantic query planning and execution. Dashboard queries analytics through typed semantic query ports.
 
-Visual renderer plugins adapt renderer-neutral visual intent to concrete libraries such as ECharts. Renderer plugins must not own semantic query planning, dashboard filter behavior, or backend data contracts.
+Visual renderer plugins adapt renderer-neutral visual intent to concrete libraries such as ECharts. Renderer plugins never own semantic query planning, dashboard filter behavior, or backend data contracts.
+
+Page streams are node-local. Reconnection reconstructs canonical state from the active runtime and server-owned page state; correctness never depends on replaying an in-memory stream history.
 
 ## Analytics Runtime
 
 `analytics` owns:
 
 - semantic model validation
-- source and connection resolution
+- source and connection resolution contracts
 - relationship validation
 - semantic query planning
 - path safety
 - SQL plan generation
 - DuckDB execution adapters
-- materialization and refresh behavior
+- materialization behavior
+- query result normalization
 
 DuckDB runtime construction belongs in analytics adapters. Workspace, dashboard, serving state, API, CLI, and agent code use typed analytics ports rather than constructing DuckDB runtimes directly.
 
-## Serving State And Runtime Host
+Execution rules:
 
-Serving state owns published workspace artifacts:
+- Every query has queue and execution deadlines.
+- Request cancellation interrupts queued and running work.
+- Result row, byte, and cardinality limits are enforced before serialization.
+- DuckDB memory, temporary storage, threads, and external access are explicitly bounded.
+- Interactive reads and analytical writes have separate admission paths.
+- Admission control is fair across workspaces and prevents starvation.
+- Query caches have per-runtime, per-workspace, and node-wide memory budgets.
+- Cache keys include every security, policy, serving-generation, source-revision, and query input that affects results.
 
-- bundle envelope and manifest
-- artifact identity and digest
-- serving state status transitions
-- upload, validation, activation, rollback, and failure marking
-- persistence of compiler-produced asset snapshots
+DuckLake writes may run concurrently only when their changesets cannot violate product invariants. Coordination is keyed by workspace and affected table set; transaction conflict handling is bounded and observable. There is no unconditional node-global writer mutex.
 
-Serving state depends on ports for:
+## Refresh Runtime
 
-- workspace compilation
-- artifact storage
-- runtime preparation
-- artifact persistence
-- access policy reconciliation
+`refresh` owns durable analytical refresh workflows:
 
-Serving state must not walk semantic/dashboard internals directly, construct DuckDB services, or call sqlc queries directly.
+- authored schedules and manual triggers
+- dependency-aware table plans
+- job claims and renewable leases
+- refresh generations and supersession
+- materialization orchestration
+- candidate snapshot validation
+- data-version activation
+- failure and cancellation state
 
-`runtimehost` owns active runtime lifecycle:
+Refresh invariants:
 
-- track the active serving state/runtime for each workspace
-- prepare candidate runtimes before activation commits
-- atomically swap the active runtime after activation succeeds
-- close replaced runtimes safely
-- expose typed runtime ports to dashboard and agent use cases
+- Work is restart-aware, idempotent, attributable, and bounded.
+- A job lease includes an owner and fencing generation; a stale worker cannot publish after losing its lease.
+- A later refresh generation supersedes earlier unfinished generations.
+- Failed or canceled refreshes never replace active data.
+- Materialization writes isolated candidate state before activation.
+- The active data version changes through the same prepared-publication discipline as deployments.
+- Scheduled, API, CLI, UI, and agent triggers converge on the same use case.
+
+## Runtime Host
+
+`runtimehost` owns process-local executable generation lifecycle:
+
+- prepare candidate runtimes without exposing them
+- track one active runtime per workspace and environment
+- acquire and release typed runtime leases
+- publish prepared runtimes atomically after durable activation
+- drain and close replaced runtimes safely
+- expose lease-backed runtime ports to dashboard, agent, refresh, and API use cases
 
 Boundary rules:
 
-- Serving state requests activation through a runtime host port.
-- Analytics prepares executable engines and query/materialization services.
-- Dashboard and agent use active runtime ports.
-- Runtime host must not own serving state status transitions, semantic query planning, dashboard patch construction, or sqlc persistence.
+- Runtime host never owns release, deployment, serving-state, or refresh status transitions.
+- Runtime host never plans semantic queries or constructs dashboard patches.
+- Runtime host never calls sqlc or raw SQL.
+- Persistent snapshot leases are repository ports supplied by serving state.
+- Losing a required persistent lease makes the affected runtime unavailable for new work until protection is re-established.
+- Cleanup errors are retryable maintenance failures, not activation rollback signals.
 
 ## Composition Root
 
@@ -421,20 +678,35 @@ It may:
 
 - load configuration
 - open infrastructure adapters
-- construct repositories, services, handlers, and background workers
+- construct capability repositories, services, handlers, and workers
 - register routes
-- manage lifecycle, logging, shutdown, health checks, and shared middleware
-- wire adapters into use cases
-- mount generated APIGen routing and delegate operations to capability-owned adapters
+- manage process lifecycle, logging, shutdown, health checks, and shared middleware
+- mount generated APIGen routing and delegate operations to capability adapters
 
-It must not:
+It never:
 
-- own business workflows
-- contain capability DTO mapping
-- contain domain validation
-- call sqlc or raw SQL directly
-- become the long-term owner of REST, CLI, agent, or UI adapters
-- pass `*app.Server`, `*platform.Store`, or broad runtime objects into capability adapters when narrow ports are enough
+- owns business workflows
+- contains capability DTO mapping
+- contains domain validation
+- calls sqlc or raw SQL directly
+- owns REST, CLI, agent, or UI behavior
+- stores `*platform.Store` for lazy repository construction
+- passes `*app.Server`, `*platform.Store`, or broad runtime objects into capability adapters
+
+Capability-local composition adapters expose narrow module surfaces:
+
+```text
+workspace/module.Module
+access/module.Module
+dashboard/module.Module
+agent/module.Module
+release/module.Module
+deployment/module.Module
+manageddata/module.Module
+refresh/module.Module
+```
+
+A module package may import its capability's adapters and use cases. It may expose route mounting, worker lifecycle, and explicitly named ports. Modules do not expose their internal dependency container and are treated as composition packages by architecture guardrails.
 
 Target route ownership:
 
@@ -442,12 +714,70 @@ Target route ownership:
 internal/app
   -> workspace/http
   -> access/http
-  -> servingstate/http
+  -> release/http
+  -> deployment/http
+  -> manageddata/http
   -> analytics/query/http
+  -> analytics/materialize/http
   -> dashboard/http
   -> agent/http
   -> admin/http
 ```
+
+The CLI is a transport and process entrypoint. Server assembly is defined once and reused by CLI startup rather than duplicated across `internal/cli` and `internal/app`.
+
+## Reliability And Consistency
+
+Every durable workflow documents:
+
+- source of truth
+- transaction boundary
+- idempotency key
+- state machine
+- retry policy
+- timeout and cancellation behavior
+- crash recovery behavior
+- supersession or fencing rule
+- audit record
+- cleanup ownership
+
+Use a transactional outbox only when a durable state change must trigger asynchronous work. In-process domain events are not used to hide required synchronous consistency.
+
+Exactly-once delivery is not assumed. Consumers are idempotent, sequence-aware where ordering matters, and safe under duplicate execution.
+
+Background workers:
+
+- claim durable jobs before execution
+- renew leases while working
+- stop publication after lease loss
+- never hold SQLite transactions during analytical or network work
+- recover abandoned work after process restart
+- expose queue depth, age, attempts, lease state, and terminal outcome
+
+## Independent Deployments And External Federation
+
+Multiple LeapView deployments are independent data-product nodes. Each node owns its workspaces, authorization, asset catalog, serving state, and analytical data.
+
+LeapView provides stable seams for external integrations:
+
+- durable node identity
+- stable workspace and asset identifiers within the node
+- versioned asset graph projections
+- versioned, paginated catalog APIs
+- artifact and serving-generation digests
+- explicit ownership and lineage metadata
+
+A cross-node catalog is a separate future product, not a LeapView subsystem. It may discover and index published metadata from independent LeapView nodes, but LeapView does not depend on it for local operation.
+
+The external federation boundary obeys these rules:
+
+- A federated catalog is discovery metadata, never the authoring source for node assets.
+- Node-local authorization remains authoritative.
+- A federated catalog does not own node serving pointers, query leases, refresh state, dashboard sessions, or analytical files.
+- Catalog unavailability does not stop a node from serving known workspaces and assets.
+- Cross-node publication is asynchronous and cannot participate in local deployment activation.
+- Cross-node analytical queries and transactions are outside LeapView's product boundary.
+- Nodes never share writable SQLite files, DuckLake catalogs, runtime directories, or in-memory coordination.
 
 ## Package Splitting Rules
 
@@ -457,47 +787,55 @@ Split when cohesion breaks:
 - tests for one behavior need unrelated setup
 - a service has methods with different dependency sets
 - a package imports several unrelated external systems
-- one product change risks accidental edits in another
+- one product change risks accidental edits in another capability
 - domain language diverges
+- a package becomes a de facto dependency container
 
 Split by use case before generic layer:
 
 ```text
-servingstate/activate
+deployment/activate
 servingstate/validate
-servingstate/upload
+release/finalize
+refresh/run
 ```
 
 Prefer this over:
 
 ```text
-servingstate/services
+deployment/services
 ```
 
 Create adapter subpackages when code imports or exposes:
 
 - sqlc generated packages
 - `database/sql`
-- DuckDB-specific SQL/runtime details
+- DuckDB-specific SQL or runtime details
 - `net/http`
-- `chi`
-- Datastar SSE/signal machinery
-- filesystem artifact layout
+- chi
+- Datastar SSE or signal machinery
+- filesystem layout
+- object-storage SDKs
 - model-provider API payloads
 
-Line count is only a hint. Cohesion, dependency direction, and test friction are the real split criteria.
+Line count is only a signal. Cohesion, dependency direction, ownership, and test friction determine package boundaries.
 
 ## Naming Rules
 
 Prefer capability names:
 
 ```text
-servingstate
+project
 workspace
 access
+manageddata
 analytics
 dashboard
 agent
+release
+deployment
+servingstate
+refresh
 runtimehost
 platform
 ```
@@ -505,6 +843,8 @@ platform
 Prefer use-case names:
 
 ```text
+compile
+finalize
 activate
 validate
 materialize
@@ -521,6 +861,7 @@ http
 sqlite
 duckdb
 filesystem
+s3
 datastar
 openai
 ```
@@ -538,27 +879,38 @@ helpers
 
 ## Architecture Guardrails
 
-The target architecture should be enforceable with package boundary tests.
+The architecture is enforced with package-boundary and contract tests.
 
-Use-case packages must not import adapter packages such as:
+Guardrails include:
 
-```text
-/sqlite
-/filesystem
-/duckdb
-/datastar
-/http
-/openai
-```
+- A declarative list of top-level capabilities and their allowed dependency edges.
+- No reciprocal capability dependencies.
+- Domain and use-case packages cannot import adapter packages.
+- Domain and use-case packages cannot import `net/http`, chi, Datastar, gomponents, sqlc generated packages, DuckDB adapters, filesystem adapters, object-storage adapters, or model-provider adapters.
+- Capabilities import another capability only through its declared public contract packages.
+- Capability-private `internal` packages prevent unauthorized imports where Go visibility rules can enforce the boundary.
+- `internal/api` remains transport-contract only.
+- shared `internal/ui` remains render-only and capability-neutral.
+- `platform.Store`, `database/sql`, and sqlc types do not leak into handlers, use cases, runtime managers, or domain packages.
+- SQL query generation is capability-private even though migrations are globally ordered.
+- Compiled artifact types are immutable by construction.
+- Runtime access is always lease-backed.
+- Activation tests inject cleanup failures and prove durable and in-memory state remain consistent.
+- Restart tests prove abandoned jobs recover safely and stale workers cannot publish.
+- Capacity tests prove workload isolation at the maximum supported node size.
 
-Exceptions are allowed only when the package is itself an adapter or composition package.
+String matching for known function names is not a sufficient architecture boundary. Import classification, capability dependency matrices, Go visibility, contract tests, and failure-injection tests enforce structural and behavioral invariants.
 
-Architecture tests should assert:
+## Success Criteria
 
-- use-case packages do not import adapter packages
-- domain and use-case packages do not import `net/http`, `chi`, Datastar, gomponents, sqlc generated packages, DuckDB adapters, filesystem adapters, or model-provider adapters
-- `internal/api` remains transport-contract only
-- `internal/ui` remains render-only
-- `platform.Store` and sqlc generated types do not leak into handlers, use cases, runtime managers, or domain packages
+The architecture succeeds when:
 
-The architecture is successful when a developer can understand and test one capability without loading the whole application into their head.
+- A developer can understand and test one capability without loading the whole application into their head.
+- A capability's business behavior is reusable from HTTP, CLI, UI, and agent interfaces without duplication.
+- A deployment either becomes durably and visibly active for every target or remains inactive.
+- Every request executes against one immutable serving generation and protected analytical snapshot.
+- One workspace cannot starve other workspaces or exhaust unbounded node resources.
+- A node reaches a documented, load-tested capacity envelope and fails predictably beyond it.
+- Independent LeapView deployments operate without shared runtime or transactional state.
+- External federation can consume versioned node metadata without becoming a dependency of local serving.
+- External transports and providers can change behind adapters without changing domain behavior; node-local capability collaboration remains direct.


### PR DESCRIPTION
## Summary

- seal and validate prepared runtime sets before durable activation, then publish every target atomically under the registry cutover lock
- expose runtimes only through leases and separate successful publication from observable, best-effort retirement cleanup
- remove refresh’s non-atomic fallback and route deployment, refresh, app, CLI, integration, and metrics consumers through the new contracts
- revise the architecture north star around independent single-node deployments, explicit capability ownership, direct node-local collaboration, and SQLite-owned durable work

## Verification

- `task ci`
  - Go and browser test suites
  - generated artifact checks and type checks
  - `go vet` and runtime-host race tests
  - live deployment and Datastar route QA
  - Terraform format, validation, and contract tests