### PR TITLE
Fix runtime contracts after single-DuckDB migration

### DIFF
--- a/api/typespec/bi.tsp
+++ b/api/typespec/bi.tsp
@@ -697,6 +697,7 @@ op listSemanticModelFields(@path workspace: string, @path("model") modelName: st
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "QUERY_DATA" })
 @extension("x-leapview-object-scope", "semantic-model")
+@extension("x-leapview-response-trailers", #["X-Next-Cursor"])
 @apigen.cli(#{ command: #["semantic-models", "model-query"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
 @apigen.tool(#{
   name: "query_semantic_model", effect: "read", tags: #["semantic-model", "query"],
@@ -767,6 +768,7 @@ op listSemanticFields(@path workspace: string, @path("model") modelName: string,
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "PREVIEW_DATA" })
 @extension("x-leapview-object-scope", "semantic-model")
+@extension("x-leapview-response-trailers", #["X-Next-Cursor"])
 @apigen.cli(#{ command: #["semantic-models", "preview"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
 @apigen.tool(#{
   name: "preview_semantic_dataset", effect: "read", tags: #["semantic-model", "dataset", "query"],
@@ -809,6 +811,7 @@ op queryDashboardPage(@path workspace: string, @path dashboard: string, @path pa
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "QUERY_DATA" })
 @extension("x-leapview-object-scope", "dashboard")
+@extension("x-leapview-response-trailers", #["X-Next-Cursor"])
 @apigen.cli(#{ command: #["dashboards", "visual-data"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "visual", displayName: "visual" }], output: #{ mode: "raw" } })
 @apigen.tool(#{
   name: "query_dashboard_visual", effect: "read", tags: #["dashboard", "visual", "query"],

--- a/api/typespec/common.tsp
+++ b/api/typespec/common.tsp
@@ -100,13 +100,14 @@ model AcceptedJson<T> {
   ...Body<T>;
 }
 
+@extension("x-leapview-response-trailers", #["X-Next-Cursor"])
 model ArrowStreamResponse {
   ...OkResponse;
   @header contentType: "application/vnd.apache.arrow.stream";
   @header("X-Query-ID") queryId: string;
   @header("X-Serving-Snapshot") servingSnapshot: string;
   @header("X-LeapView-Arrow-Contract") arrowContract: "native-v1";
-  @header("X-Next-Cursor") nextCursor?: string;
+  @header("Trailer") trailers: "X-Next-Cursor";
   @header cacheControl: "no-store";
   @body body: bytes;
 }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -25767,6 +25767,8 @@ paths:
         mode: privilege
         privilege: QUERY_DATA
       x-leapview-object-scope: dashboard
+      x-leapview-response-trailers:
+        - X-Next-Cursor
   /api/v1/workspaces/{workspace}/data-policies:
     get:
       operationId: listDataPolicies
@@ -36927,6 +36929,8 @@ paths:
         mode: privilege
         privilege: PREVIEW_DATA
       x-leapview-object-scope: semantic-model
+      x-leapview-response-trailers:
+        - X-Next-Cursor
   /api/v1/workspaces/{workspace}/semantic-models/{model}/datasets/{dataset}/preview/explain:
     post:
       operationId: explainSemanticPreview
@@ -37930,6 +37934,8 @@ paths:
         mode: privilege
         privilege: QUERY_DATA
       x-leapview-object-scope: semantic-model
+      x-leapview-response-trailers:
+        - X-Next-Cursor
   /api/v1/workspaces/{workspace}/semantic-models/{model}/query/explain:
     post:
       operationId: explainSemanticModelQuery

--- a/docs/articles/operate/upgrades.md
+++ b/docs/articles/operate/upgrades.md
@@ -41,6 +41,12 @@ For another topology, preserve the same invariants: one controlled writer for pe
 
 Do not run two application versions against shared writable state unless the release explicitly declares mixed-version compatibility.
 
+### SQLite-backed DuckLake catalogs
+
+The first release using the process-owned DuckDB runtime automatically migrates the former SQLite-backed DuckLake metadata catalog before opening analytical storage. With the default layout, `ducklake/catalog.sqlite` is copied atomically to `ducklake/catalog.duckdb` and the SQLite source remains in place as a rollback backup. If `LEAPVIEW_DUCKLAKE_CATALOG_PATH` still names a SQLite file, LeapView converts that path in place and preserves the source beside it with the suffix `.legacy.sqlite`.
+
+Budget disk space for both catalog files during the upgrade. Keep the legacy file until snapshot validation, representative queries, refresh, backup, and restore have all passed. The migration never replaces an existing DuckDB target; if an earlier failed start already created `catalog.duckdb`, preserve both files and resolve that partial upgrade before retrying.
+
 ## Verify after startup
 
 Check more than readiness:

--- a/docs/storage-architecture-spec.md
+++ b/docs/storage-architecture-spec.md
@@ -12,6 +12,7 @@ Runtime generations do not own DuckDB engines or catalog attachments. They own i
 .leapview/
   leapview.db               # node-local control-plane state
   ducklake/catalog.duckdb   # DuckDB-backed DuckLake metadata catalog
+  ducklake/catalog.sqlite   # retained legacy migration backup, when present
   data/                     # DuckLake-managed Parquet files
   artifacts/                # immutable workspace bundles
   runtime/                  # ephemeral extracted artifacts

--- a/internal/analytics/ducklake/catalog_migration.go
+++ b/internal/analytics/ducklake/catalog_migration.go
@@ -1,0 +1,165 @@
+package ducklake
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const sqliteCatalogHeader = "SQLite format 3\x00"
+
+// migrateLegacySQLiteCatalog upgrades the previous local SQLite-backed
+// DuckLake metadata catalog before the process-owned DuckDB environment opens
+// its catalog. The source remains as a backup when the target path changed.
+func migrateLegacySQLiteCatalog(ctx context.Context, targetPath string) (bool, error) {
+	targetPath = filepath.Clean(strings.TrimSpace(targetPath))
+	if targetPath == "." || targetPath == "" {
+		return false, fmt.Errorf("DuckLake catalog path is required")
+	}
+	targetSQLite, targetExists, err := sqliteCatalogFile(targetPath)
+	if err != nil {
+		return false, err
+	}
+	if targetExists && !targetSQLite {
+		return false, nil
+	}
+
+	sourcePath := targetPath
+	inPlace := targetExists && targetSQLite
+	if !targetExists {
+		if filepath.Base(targetPath) != "catalog.duckdb" {
+			return false, nil
+		}
+		sourcePath = filepath.Join(filepath.Dir(targetPath), "catalog.sqlite")
+		sourceSQLite, sourceExists, sourceErr := sqliteCatalogFile(sourcePath)
+		if sourceErr != nil {
+			return false, sourceErr
+		}
+		if !sourceExists {
+			return false, nil
+		}
+		if !sourceSQLite {
+			return false, fmt.Errorf("legacy DuckLake catalog %q is not a SQLite database", sourcePath)
+		}
+	}
+
+	unlock := lockCatalogWrites(targetPath)
+	defer unlock()
+	// Recheck after acquiring the process-wide catalog lock in case another
+	// environment completed migration while this caller was waiting.
+	if targetSQLite, targetExists, err = sqliteCatalogFile(targetPath); err != nil {
+		return false, err
+	} else if targetExists && !targetSQLite {
+		return false, nil
+	}
+
+	temporary, err := os.CreateTemp(filepath.Dir(targetPath), ".catalog-migration-*.duckdb")
+	if err != nil {
+		return false, fmt.Errorf("create DuckLake catalog migration target: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	if err := temporary.Close(); err != nil {
+		_ = os.Remove(temporaryPath)
+		return false, err
+	}
+	if err := os.Remove(temporaryPath); err != nil {
+		return false, err
+	}
+	defer os.Remove(temporaryPath)
+
+	if err := copySQLiteCatalogToDuckDB(ctx, sourcePath, temporaryPath); err != nil {
+		return false, err
+	}
+	if err := os.Chmod(temporaryPath, catalogFileMode); err != nil {
+		return false, fmt.Errorf("secure migrated DuckLake catalog: %w", err)
+	}
+	if err := syncFile(temporaryPath); err != nil {
+		return false, err
+	}
+
+	if inPlace {
+		backupPath := targetPath + ".legacy.sqlite"
+		if _, err := os.Stat(backupPath); err == nil {
+			return false, fmt.Errorf("legacy DuckLake catalog backup already exists at %q", backupPath)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		if err := os.Rename(targetPath, backupPath); err != nil {
+			return false, fmt.Errorf("preserve legacy DuckLake catalog: %w", err)
+		}
+		if err := os.Rename(temporaryPath, targetPath); err != nil {
+			_ = os.Rename(backupPath, targetPath)
+			return false, fmt.Errorf("activate migrated DuckLake catalog: %w", err)
+		}
+	} else if err := os.Rename(temporaryPath, targetPath); err != nil {
+		return false, fmt.Errorf("activate migrated DuckLake catalog: %w", err)
+	}
+	if err := syncCatalogDirectory(filepath.Dir(targetPath)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func copySQLiteCatalogToDuckDB(ctx context.Context, sourcePath, targetPath string) error {
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		return err
+	}
+	db.SetMaxOpenConns(1)
+	statements := []string{
+		"LOAD sqlite",
+		fmt.Sprintf("ATTACH '%s' AS legacy_catalog (TYPE sqlite)", sqlLiteral(sourcePath)),
+		fmt.Sprintf("ATTACH '%s' AS migrated_catalog", sqlLiteral(targetPath)),
+		"COPY FROM DATABASE legacy_catalog TO migrated_catalog",
+		"CHECKPOINT migrated_catalog",
+	}
+	for _, statement := range statements {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			_ = db.Close()
+			return fmt.Errorf("migrate legacy DuckLake catalog: %w", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		return fmt.Errorf("close migrated DuckLake catalog: %w", err)
+	}
+	return nil
+}
+
+func sqliteCatalogFile(path string) (sqlite bool, exists bool, err error) {
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	defer file.Close()
+	header := make([]byte, len(sqliteCatalogHeader))
+	if _, err := io.ReadFull(file, header); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return false, true, err
+	}
+	return string(header) == sqliteCatalogHeader, true, nil
+}
+
+func syncFile(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	err = file.Sync()
+	return errors.Join(err, file.Close())
+}
+
+func syncCatalogDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	err = directory.Sync()
+	return errors.Join(err, directory.Close())
+}

--- a/internal/analytics/ducklake/environment.go
+++ b/internal/analytics/ducklake/environment.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -208,6 +209,13 @@ func Open(ctx context.Context, config Config) (*Environment, error) {
 	}
 	if err := prepareLayout(layout); err != nil {
 		return nil, err
+	}
+	migrated, err := migrateLegacySQLiteCatalog(ctx, layout.CatalogPath)
+	if err != nil {
+		return nil, err
+	}
+	if migrated {
+		slog.InfoContext(ctx, "migrated legacy SQLite-backed DuckLake catalog", "catalog_path", layout.CatalogPath)
 	}
 	if strings.TrimSpace(config.TempDir) != "" {
 		if err := securefs.EnsurePrivateDir(config.TempDir); err != nil {

--- a/internal/analytics/ducklake/environment_test.go
+++ b/internal/analytics/ducklake/environment_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -26,6 +27,97 @@ func TestLayoutUsesOneCatalogAndDataStore(t *testing.T) {
 	}
 	if _, ok := reflect.TypeOf(layout).FieldByName("LegacyDuckDBPath"); ok {
 		t.Fatal("Layout still exposes LegacyDuckDBPath")
+	}
+}
+
+func TestOpenMigratesSiblingLegacySQLiteCatalog(t *testing.T) {
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "ducklake")
+	legacyPath := filepath.Join(root, "catalog.sqlite")
+	targetPath := filepath.Join(root, "catalog.duckdb")
+	dataPath := filepath.Join(root, "data")
+	createLegacySQLiteCatalog(t, ctx, legacyPath, dataPath)
+
+	env, err := Open(ctx, Config{RootDir: root, CatalogPath: targetPath, DataPath: dataPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = env.Close() })
+	assertMigratedCatalogReadWrite(t, ctx, env)
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy catalog backup missing: %v", err)
+	}
+}
+
+func TestOpenMigratesConfiguredSQLiteCatalogInPlace(t *testing.T) {
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "ducklake")
+	catalogPath := filepath.Join(root, "metadata.sqlite")
+	dataPath := filepath.Join(root, "data")
+	createLegacySQLiteCatalog(t, ctx, catalogPath, dataPath)
+
+	env, err := Open(ctx, Config{RootDir: root, CatalogPath: catalogPath, DataPath: dataPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = env.Close() })
+	assertMigratedCatalogReadWrite(t, ctx, env)
+	if _, err := os.Stat(catalogPath + ".legacy.sqlite"); err != nil {
+		t.Fatalf("in-place legacy catalog backup missing: %v", err)
+	}
+	if sqlite, exists, err := sqliteCatalogFile(catalogPath); err != nil || !exists || sqlite {
+		t.Fatalf("migrated configured catalog: sqlite=%t exists=%t error=%v", sqlite, exists, err)
+	}
+}
+
+func createLegacySQLiteCatalog(t *testing.T, ctx context.Context, catalogPath, dataPath string) {
+	t.Helper()
+	if err := os.MkdirAll(dataPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyAttach := fmt.Sprintf("ATTACH 'ducklake:sqlite:%s' AS legacy (DATA_PATH '%s')", sqlLiteral(catalogPath), sqlLiteral(dataPath))
+	for _, statement := range []string{
+		"LOAD ducklake",
+		"LOAD sqlite",
+		legacyAttach,
+		"CREATE SCHEMA legacy.model",
+		"CREATE TABLE legacy.model.orders(id BIGINT, amount DOUBLE)",
+		"INSERT INTO legacy.model.orders VALUES (1, 10.5), (2, 20.25)",
+	} {
+		if _, err := legacy.ExecContext(ctx, statement); err != nil {
+			_ = legacy.Close()
+			t.Fatalf("legacy statement %q: %v", statement, err)
+		}
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertMigratedCatalogReadWrite(t *testing.T, ctx context.Context, env *Environment) {
+	t.Helper()
+	var count int
+	if err := env.db.QueryRowContext(ctx, "SELECT count(*) FROM lake.model.orders").Scan(&count); err != nil {
+		t.Fatalf("query migrated DuckLake table: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("migrated row count = %d, want 2", count)
+	}
+	if _, err := env.Commit(ctx, "post_migration", nil, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "INSERT INTO model.orders VALUES (3, 30.75)")
+		return err
+	}); err != nil {
+		t.Fatalf("commit after catalog migration: %v", err)
+	}
+	if err := env.db.QueryRowContext(ctx, "SELECT count(*) FROM lake.model.orders").Scan(&count); err != nil {
+		t.Fatalf("query after post-migration commit: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("post-migration row count = %d, want 3", count)
 	}
 }
 

--- a/internal/analytics/materialize/query_cache_test.go
+++ b/internal/analytics/materialize/query_cache_test.go
@@ -403,6 +403,37 @@ func TestRuntimeBundleCacheAllHitExecutesZeroAdditionalSQL(t *testing.T) {
 	}
 }
 
+func TestRuntimeBundleChargesLogicalRowsOnceOnCacheMiss(t *testing.T) {
+	database := &budgetConsumingBundleDatabase{}
+	runtime := bundleCacheRuntime(database)
+	runtime.resultLimits = dataquery.ResultLimits{MaxRows: 2, MaxBytes: 1 << 20}
+
+	result, err := runtime.ExecuteDataQueryBundle(context.Background(), bundleCacheRequests())
+	if err != nil {
+		t.Fatalf("bundle within logical row limit: %v", err)
+	}
+	if got := result.Results["orders"].RowsReturned + result.Results["events"].RowsReturned; got != 2 {
+		t.Fatalf("logical rows = %d, want 2", got)
+	}
+}
+
+type budgetConsumingBundleDatabase struct{ bundleCountingDatabase }
+
+func (d *budgetConsumingBundleDatabase) Query(ctx context.Context, plan semanticquery.Plan) (semanticquery.Rows, error) {
+	rows, err := d.bundleCountingDatabase.Query(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+	if budget, ok := dataquery.ResultBudgetFromContext(ctx); ok {
+		for _, row := range rows {
+			if err := budget.ConsumeRow(row); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return rows, nil
+}
+
 func TestRuntimeBundleRejectsNonDashboardBranchesBeforeFlightCoalescing(t *testing.T) {
 	database := &bundleCountingDatabase{}
 	runtime := bundleCacheRuntime(database)

--- a/internal/analytics/materialize/runtime.go
+++ b/internal/analytics/materialize/runtime.go
@@ -607,7 +607,7 @@ func (r *Runtime) ExecuteDataQueryBundle(ctx context.Context, requests []dataque
 		return dataquery.BundleResult{}, fmt.Errorf("encode aggregate bundle flight identity: %w", err)
 	}
 	flight, shared, err := r.queryCache.coalesce(ctx, string(flightKey), func() (any, error) {
-		execCtx, statements := withPhysicalStatementCounter(dataquery.WithResultBudget(ctx, r.queryResultLimits()))
+		execCtx, statements := withPhysicalStatementCounter(dataquery.WithIndependentResultBudget(ctx, r.queryResultLimits()))
 		var decoded map[string]semanticquery.Rows
 		summary, executeErr := admitPhysicalQuery(execCtx, representative, func(queryCtx context.Context) (dataquery.Result, error) {
 			queryResult, rows, queryErr := execute(queryCtx)

--- a/internal/analytics/query/authz/arrow_audit_test.go
+++ b/internal/analytics/query/authz/arrow_audit_test.go
@@ -1,0 +1,150 @@
+package authz
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/Yacobolo/leapview/internal/access"
+	accesssqlite "github.com/Yacobolo/leapview/internal/access/sqlite"
+	"github.com/Yacobolo/leapview/internal/analytics/arrowquery"
+	semanticmodel "github.com/Yacobolo/leapview/internal/analytics/model"
+	"github.com/Yacobolo/leapview/internal/dataquery"
+	"github.com/Yacobolo/leapview/internal/platform"
+	"github.com/Yacobolo/leapview/internal/queryruntime"
+	"github.com/Yacobolo/leapview/internal/workspace"
+	workspacesqlite "github.com/Yacobolo/leapview/internal/workspace/sqlite"
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+func TestPublicationArrowFailsBeforeStreamingWhenAuditCannotPersist(t *testing.T) {
+	ctx := context.Background()
+	store, err := platform.Open(ctx, filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(ctx, workspace.EnsureInput{ID: "test", Title: "Test"}); err != nil {
+		t.Fatal(err)
+	}
+
+	model := governanceTestModel()
+	backend := &publicationArrowMetrics{model: model}
+	metrics := New(backend, Options{Repo: accesssqlite.NewRepository(store.SQLDB()), DefaultWorkspaceID: "test"})
+	ctx = WithDashboardPublicationCapability(ctx, DashboardPublicationCapability{
+		WorkspaceID: "test", Publication: "website", Dashboard: "dashboard", ModelID: model.Name,
+		DependencyAssetIDs: []string{
+			"dashboard:test.dashboard", "semantic_model:test.activity", "semantic_table:test.activity.ratings",
+			"field:test.activity.ratings.rating",
+		},
+	})
+	sink := &recordingArrowSink{}
+	_, err = metrics.ExecuteDataQueryArrow(ctx, dataquery.Query{
+		WorkspaceID: "test", Surface: dataquery.SurfacePublicDashboard, Operation: dataquery.OperationDashboardRows,
+		ModelID: model.Name, Kind: dataquery.KindSemanticRows, Target: "ratings", Fields: []dataquery.Field{{Field: "ratings.rating"}},
+	}, sink)
+	if err == nil {
+		t.Fatal("publication Arrow query succeeded without a durable pre-stream audit")
+	}
+	if backend.executed || sink.schemas != 0 || sink.records != 0 {
+		t.Fatalf("stream started before durable audit: executed=%t schemas=%d records=%d", backend.executed, sink.schemas, sink.records)
+	}
+}
+
+func TestPublicationArrowPersistsStartedAuditBeforeStreaming(t *testing.T) {
+	ctx := context.Background()
+	store, err := platform.Open(ctx, filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(ctx, workspace.EnsureInput{ID: "test", Title: "Test"}); err != nil {
+		t.Fatal(err)
+	}
+	baseRepo := accesssqlite.NewRepository(store.SQLDB())
+	principalID := access.DashboardPublicationSubjectID("test", "website")
+	if _, err := baseRepo.UpsertPrincipal(ctx, access.PrincipalInput{ID: principalID, DisplayName: "Website", Kind: access.PrincipalKindDashboardPublication}); err != nil {
+		t.Fatal(err)
+	}
+	repo := &orderedAuditRepository{Repository: baseRepo}
+	model := governanceTestModel()
+	backend := &publicationArrowMetrics{model: model, beforeExecute: func() error {
+		if len(repo.statuses) != 1 || repo.statuses[0] != "started" {
+			return fmt.Errorf("audit statuses before execution = %v, want [started]", repo.statuses)
+		}
+		return nil
+	}}
+	metrics := New(backend, Options{Repo: repo, DefaultWorkspaceID: "test"})
+	ctx = WithDashboardPublicationCapability(ctx, DashboardPublicationCapability{
+		WorkspaceID: "test", Publication: "website", Dashboard: "dashboard", ModelID: model.Name,
+		DependencyAssetIDs: []string{
+			"dashboard:test.dashboard", "semantic_model:test.activity", "semantic_table:test.activity.ratings",
+			"field:test.activity.ratings.rating",
+		},
+	})
+	if _, err := metrics.ExecuteDataQueryArrow(ctx, dataquery.Query{
+		WorkspaceID: "test", Surface: dataquery.SurfacePublicDashboard, Operation: dataquery.OperationDashboardRows,
+		ModelID: model.Name, Kind: dataquery.KindSemanticRows, Target: "ratings", Fields: []dataquery.Field{{Field: "ratings.rating"}},
+	}, &recordingArrowSink{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(repo.statuses) != 2 || repo.statuses[0] != "started" || repo.statuses[1] != "success" {
+		t.Fatalf("publication Arrow audit statuses = %v, want [started success]", repo.statuses)
+	}
+}
+
+type orderedAuditRepository struct {
+	access.Repository
+	statuses []string
+}
+
+func (r *orderedAuditRepository) RecordAuditEvent(ctx context.Context, input access.AuditEventInput) error {
+	if err := r.Repository.RecordAuditEvent(ctx, input); err != nil {
+		return err
+	}
+	r.statuses = append(r.statuses, input.Status)
+	return nil
+}
+
+type publicationArrowMetrics struct {
+	queryruntime.Metrics
+	model         *semanticmodel.Model
+	executed      bool
+	beforeExecute func() error
+}
+
+func (m *publicationArrowMetrics) SemanticModel(modelID string) (*semanticmodel.Model, bool) {
+	return m.model, modelID == m.model.Name
+}
+
+func (m *publicationArrowMetrics) ExecuteDataQueryArrow(_ context.Context, _ dataquery.Query, sink arrowquery.Sink) (dataquery.Result, error) {
+	m.executed = true
+	if m.beforeExecute != nil {
+		if err := m.beforeExecute(); err != nil {
+			return dataquery.Result{}, err
+		}
+	}
+	if err := sink.WriteSchema(arrow.NewSchema(nil, nil)); err != nil {
+		return dataquery.Result{}, err
+	}
+	return dataquery.Result{Status: dataquery.StatusSuccess}, nil
+}
+
+type recordingArrowSink struct {
+	schemas int
+	records int
+}
+
+func (s *recordingArrowSink) WriteSchema(*arrow.Schema) error {
+	s.schemas++
+	return nil
+}
+
+func (s *recordingArrowSink) WriteRecord(arrow.RecordBatch) error {
+	s.records++
+	return nil
+}
+
+var _ arrowquery.Executor = (*publicationArrowMetrics)(nil)
+var _ arrowquery.Sink = (*recordingArrowSink)(nil)

--- a/internal/analytics/query/authz/data_authorization.go
+++ b/internal/analytics/query/authz/data_authorization.go
@@ -131,10 +131,24 @@ func (m Metrics) ExecuteDataQueryArrow(ctx context.Context, request dataquery.Qu
 	if err != nil {
 		return rejectedDataQueryResult(err)
 	}
+	_, publicationQuery := dashboardPublicationCapabilityFromContext(ctx)
+	if publicationQuery {
+		// Arrow transports release records as the executor runs, so persist a
+		// durable access identity before the sink can write its schema. The
+		// completion event below enriches the audit trail with the final outcome; a
+		// sustained completion-write failure is logged by PersistAuditEvent, but
+		// cannot retroactively turn an already delivered stream into a rejection.
+		if err := m.recordDataAccessAudit(ctx, governed, access.PrivilegeQueryData, dataQueryObjects(governed), "started", nil); err != nil {
+			return rejectedDataQueryResult(err)
+		}
+	}
 	ctx = dataquery.WithGovernanceApplied(ctx)
 	result, err := executor.ExecuteDataQueryArrow(ctx, governed, sink)
 	if transform != nil {
 		if transformErr := transform(&result, err); transformErr != nil {
+			if publicationQuery {
+				return result, err
+			}
 			return rejectedDataQueryResult(transformErr)
 		}
 	}

--- a/internal/analytics/query/http/handler_test.go
+++ b/internal/analytics/query/http/handler_test.go
@@ -203,6 +203,9 @@ func TestWriteSemanticArrowResponseUsesNativeExecutorAndStreamsPaginationProbe(t
 	if response.Header.Get("X-LeapView-Arrow-Contract") != "native-v1" {
 		t.Fatalf("contract header = %q", response.Header.Get("X-LeapView-Arrow-Contract"))
 	}
+	if response.Header.Get("Trailer") != "X-Next-Cursor" {
+		t.Fatalf("declared response trailers = %q", response.Header.Get("Trailer"))
+	}
 	reader, err := ipc.NewReader(response.Body)
 	if err != nil {
 		t.Fatalf("open streamed Arrow: %v", err)

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -943,6 +943,40 @@ func TestDerivedArtifactsAreGeneratedBuildInputs(t *testing.T) {
 	}
 }
 
+func TestArrowResponseContractDeclaresCursorTrailer(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "api", "typespec", "common.tsp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract := string(body)
+	for _, fragment := range []string{
+		`@extension("x-leapview-response-trailers", #["X-Next-Cursor"])`,
+		`@header("Trailer") trailers: "X-Next-Cursor";`,
+	} {
+		if !strings.Contains(contract, fragment) {
+			t.Errorf("Arrow response contract missing trailer declaration %q", fragment)
+		}
+	}
+	if strings.Contains(contract, `@header("X-Next-Cursor")`) {
+		t.Error("Arrow response contract still advertises X-Next-Cursor as an initial header")
+	}
+	operations, err := os.ReadFile(filepath.Join(root, "api", "typespec", "bi.tsp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(operations), `@extension("x-leapview-response-trailers", #["X-Next-Cursor"])`); got != 3 {
+		t.Errorf("Arrow operation trailer declarations = %d, want 3", got)
+	}
+	openAPI, err := os.ReadFile(filepath.Join(root, "docs", "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(openAPI), "x-leapview-response-trailers:"); got != 3 {
+		t.Errorf("generated OpenAPI trailer declarations = %d, want 3", got)
+	}
+}
+
 func workflowStep(workflow, startMarker, endMarker string) string {
 	start := strings.Index(workflow, startMarker)
 	if start < 0 {

--- a/internal/dataquery/result_budget.go
+++ b/internal/dataquery/result_budget.go
@@ -54,6 +54,14 @@ func WithResultBudget(ctx context.Context, limits ResultLimits) context.Context 
 	if _, ok := ResultBudgetFromContext(ctx); ok {
 		return ctx
 	}
+	return WithIndependentResultBudget(ctx, limits)
+}
+
+// WithIndependentResultBudget starts a distinct accounting scope even when the
+// parent operation already owns a logical result budget. Physical coalesced
+// work uses this to bound its retained rows without charging one caller's
+// logical result before the shared result is distributed.
+func WithIndependentResultBudget(ctx context.Context, limits ResultLimits) context.Context {
 	return context.WithValue(ctx, resultBudgetKey{}, &ResultBudget{limits: limits})
 }
 func ResultBudgetFromContext(ctx context.Context) (*ResultBudget, bool) {

--- a/internal/dataquery/result_budget_test.go
+++ b/internal/dataquery/result_budget_test.go
@@ -32,6 +32,22 @@ func TestWithResultBudgetReusesLogicalBudget(t *testing.T) {
 	}
 }
 
+func TestWithIndependentResultBudgetStartsNewAccountingScope(t *testing.T) {
+	ctx := WithResultBudget(context.Background(), ResultLimits{MaxRows: 1, MaxBytes: 1024})
+	parent, _ := ResultBudgetFromContext(ctx)
+	childCtx := WithIndependentResultBudget(ctx, ResultLimits{MaxRows: 2, MaxBytes: 2048})
+	child, _ := ResultBudgetFromContext(childCtx)
+	if child == parent {
+		t.Fatal("independent result budget reused parent accounting scope")
+	}
+	if err := child.ConsumeRows([]Row{{"v": 1}, {"v": 2}}); err != nil {
+		t.Fatal(err)
+	}
+	if rows, _ := parent.Usage(); rows != 0 {
+		t.Fatalf("parent usage = %d, want 0", rows)
+	}
+}
+
 func TestResultBudgetConsumesBatchSize(t *testing.T) {
 	budget := &ResultBudget{limits: ResultLimits{MaxRows: 2, MaxBytes: 1 << 20}}
 	if err := budget.ConsumeSize(2, 128); err != nil {


### PR DESCRIPTION
Follow-up to #122.

## Summary

- persist a fail-closed publication audit before native Arrow streaming begins
- migrate legacy SQLite-backed DuckLake catalogs atomically to DuckDB while retaining rollback backups
- publish X-Next-Cursor as an HTTP response trailer in TypeSpec and OpenAPI
- isolate physical bundle accounting from each caller’s logical result budget
- add regression, migration read/write, contract, and accounting coverage

## Verification

- `GOFLAGS="-tags=duckdb_arrow -p=2" task ci`
- focused race tests for dataquery, DuckLake, materialization, query authorization, and query HTTP
- focused `go vet` for all changed Go packages
- `task generated:check`
- `git diff --check`