### PR TITLE
perf: optimize Arrow result ownership boundary

### DIFF
--- a/internal/analytics/arrowresult/decode.go
+++ b/internal/analytics/arrowresult/decode.go
@@ -17,14 +17,19 @@ func DecodeRows(lease *Lease) ([]map[string]any, error) {
 	}
 	rows := make([]map[string]any, 0, lease.Rows())
 	err := lease.VisitRecords(func(record arrow.RecordBatch) error {
+		decoders := make([]columnDecoder, int(record.NumCols()))
+		for columnIndex := range decoders {
+			name := record.ColumnName(columnIndex)
+			decode, err := compileValueDecoder(record.Column(columnIndex))
+			if err != nil {
+				return fmt.Errorf("decode Arrow column %q: %w", name, err)
+			}
+			decoders[columnIndex] = columnDecoder{name: name, value: decode}
+		}
 		for rowIndex := 0; rowIndex < int(record.NumRows()); rowIndex++ {
-			row := make(map[string]any, int(record.NumCols()))
-			for columnIndex := 0; columnIndex < int(record.NumCols()); columnIndex++ {
-				value, err := decodeValue(record.Column(columnIndex), rowIndex)
-				if err != nil {
-					return fmt.Errorf("decode Arrow column %q: %w", record.ColumnName(columnIndex), err)
-				}
-				row[record.ColumnName(columnIndex)] = value
+			row := make(map[string]any, len(decoders))
+			for _, decoder := range decoders {
+				row[decoder.name] = decoder.value(rowIndex)
 			}
 			rows = append(rows, row)
 		}
@@ -34,71 +39,140 @@ func DecodeRows(lease *Lease) ([]map[string]any, error) {
 }
 
 type marshalValue interface{ GetOneForMarshal(int) interface{} }
+type valueDecoder func(int) any
 
-func decodeValue(values arrow.Array, index int) (any, error) {
-	if values == nil || values.IsNull(index) {
-		return nil, nil
+type columnDecoder struct {
+	name  string
+	value valueDecoder
+}
+
+func compileValueDecoder(values arrow.Array) (valueDecoder, error) {
+	if values == nil {
+		return func(int) any { return nil }, nil
 	}
+	var decode valueDecoder
 	switch values := values.(type) {
 	case *array.Boolean:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Int8:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Int16:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Int32:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Int64:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Uint8:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Uint16:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Uint32:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Uint64:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Float32:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.Float64:
-		return values.Value(index), nil
+		decode = func(index int) any { return values.Value(index) }
 	case *array.String:
-		return values.Value(index), nil
+		decode = ownedStringDecoder(values)
 	case *array.LargeString:
-		return values.Value(index), nil
+		decode = ownedLargeStringDecoder(values)
 	case *array.Binary:
-		return append([]byte{}, values.Value(index)...), nil
+		decode = ownedBinaryDecoder(values)
 	case *array.LargeBinary:
-		return append([]byte{}, values.Value(index)...), nil
+		decode = ownedLargeBinaryDecoder(values)
 	case *array.Date32:
-		return values.Value(index).ToTime(), nil
+		decode = func(index int) any { return values.Value(index).ToTime() }
 	case *array.Date64:
-		return values.Value(index).ToTime(), nil
+		decode = func(index int) any { return values.Value(index).ToTime() }
 	case *array.Timestamp:
 		typeInfo, ok := values.DataType().(*arrow.TimestampType)
 		if !ok {
 			return nil, fmt.Errorf("timestamp has invalid data type %T", values.DataType())
 		}
-		return values.Value(index).ToTime(typeInfo.Unit).In(time.UTC), nil
+		decode = func(index int) any { return values.Value(index).ToTime(typeInfo.Unit).In(time.UTC) }
 	case *array.Decimal32:
 		typeInfo := values.DataType().(*arrow.Decimal32Type)
-		return decodeDecimal(values.Value(index).ToString(typeInfo.Scale), typeInfo.Scale), nil
+		decode = func(index int) any {
+			return decodeDecimal(values.Value(index).ToString(typeInfo.Scale), typeInfo.Scale)
+		}
 	case *array.Decimal64:
 		typeInfo := values.DataType().(*arrow.Decimal64Type)
-		return decodeDecimal(values.Value(index).ToString(typeInfo.Scale), typeInfo.Scale), nil
+		decode = func(index int) any {
+			return decodeDecimal(values.Value(index).ToString(typeInfo.Scale), typeInfo.Scale)
+		}
 	case *array.Decimal128:
 		typeInfo := values.DataType().(*arrow.Decimal128Type)
-		return decodeDecimal(values.Value(index).ToString(typeInfo.Scale), typeInfo.Scale), nil
+		decode = func(index int) any {
+			return decodeDecimal(values.Value(index).ToString(typeInfo.Scale), typeInfo.Scale)
+		}
 	case *array.Decimal256:
 		typeInfo := values.DataType().(*arrow.Decimal256Type)
-		return decodeDecimal(values.Value(index).ToString(typeInfo.Scale), typeInfo.Scale), nil
+		decode = func(index int) any {
+			return decodeDecimal(values.Value(index).ToString(typeInfo.Scale), typeInfo.Scale)
+		}
 	case *array.Dictionary:
-		return decodeValue(values.Dictionary(), values.GetValueIndex(index))
+		dictionary, err := compileValueDecoder(values.Dictionary())
+		if err != nil {
+			return nil, err
+		}
+		decode = func(index int) any { return dictionary(values.GetValueIndex(index)) }
 	default:
 		if marshal, ok := values.(marshalValue); ok {
-			return marshal.GetOneForMarshal(index), nil
+			decode = func(index int) any { return marshal.GetOneForMarshal(index) }
+			break
 		}
 		return nil, fmt.Errorf("unsupported Arrow type %s", values.DataType())
+	}
+	if values.NullN() == 0 {
+		return decode, nil
+	}
+	return func(index int) any {
+		if values.IsNull(index) {
+			return nil
+		}
+		return decode(index)
+	}, nil
+}
+
+func ownedStringDecoder(values *array.String) valueDecoder {
+	offsets := values.ValueOffsets()
+	base := int(offsets[0])
+	owned := string(values.ValueBytes())
+	return func(index int) any {
+		start, end := int(offsets[index])-base, int(offsets[index+1])-base
+		return owned[start:end]
+	}
+}
+
+func ownedLargeStringDecoder(values *array.LargeString) valueDecoder {
+	offsets := values.ValueOffsets()
+	base := int(offsets[0])
+	owned := string(values.ValueBytes())
+	return func(index int) any {
+		start, end := int(offsets[index])-base, int(offsets[index+1])-base
+		return owned[start:end]
+	}
+}
+
+func ownedBinaryDecoder(values *array.Binary) valueDecoder {
+	offsets := values.ValueOffsets()
+	base := int(offsets[0])
+	owned := append([]byte(nil), values.ValueBytes()...)
+	return func(index int) any {
+		start, end := int(offsets[index])-base, int(offsets[index+1])-base
+		return owned[start:end:end]
+	}
+}
+
+func ownedLargeBinaryDecoder(values *array.LargeBinary) valueDecoder {
+	offsets := values.ValueOffsets()
+	base := int(offsets[0])
+	owned := append([]byte(nil), values.ValueBytes()...)
+	return func(index int) any {
+		start, end := int(offsets[index])-base, int(offsets[index+1])-base
+		return owned[start:end:end]
 	}
 }
 

--- a/internal/analytics/arrowresult/decode_test.go
+++ b/internal/analytics/arrowresult/decode_test.go
@@ -9,6 +9,64 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 )
 
+func TestDecodeRowsOwnsVariableWidthValues(t *testing.T) {
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer allocator.AssertSize(t, 0)
+
+	stringsBuilder := array.NewStringBuilder(allocator)
+	stringsBuilder.Append("alpha")
+	stringsArray := stringsBuilder.NewArray()
+	stringsBuilder.Release()
+	binaryBuilder := array.NewBinaryBuilder(allocator, arrow.BinaryTypes.Binary)
+	binaryBuilder.Append([]byte("bravo"))
+	binaryArray := binaryBuilder.NewArray()
+	binaryBuilder.Release()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "text", Type: arrow.BinaryTypes.String},
+		{Name: "bytes", Type: arrow.BinaryTypes.Binary},
+	}, nil)
+	record := array.NewRecordBatch(schema, []arrow.Array{stringsArray, binaryArray}, 1)
+	stringsArray.Release()
+	binaryArray.Release()
+
+	collector := NewBuilderWithAllocator(allocator)
+	if err := collector.WriteSchema(schema); err != nil {
+		t.Fatal(err)
+	}
+	if err := collector.WriteRecord(record); err != nil {
+		t.Fatal(err)
+	}
+	record.Release()
+	result, err := collector.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := result.Acquire()
+	result.Release()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := DecodeRows(lease)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.VisitRecords(func(record arrow.RecordBatch) error {
+		record.Column(0).Data().Buffers()[2].Bytes()[0] = 'z'
+		record.Column(1).Data().Buffers()[2].Bytes()[0] = 'z'
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	lease.Release()
+
+	if got := rows[0]["text"]; got != "alpha" {
+		t.Fatalf("decoded string changed with Arrow buffer: %q", got)
+	}
+	if got := string(rows[0]["bytes"].([]byte)); got != "bravo" {
+		t.Fatalf("decoded binary changed with Arrow buffer: %q", got)
+	}
+}
+
 func TestDecodeRowsPreservesPhysicalValuesAndNulls(t *testing.T) {
 	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer allocator.AssertSize(t, 0)

--- a/internal/analytics/arrowresult/result.go
+++ b/internal/analytics/arrowresult/result.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	arrowutil "github.com/apache/arrow-go/v18/arrow/util"
@@ -47,12 +48,10 @@ func Stats() StatsSnapshot {
 type Builder struct {
 	mu        sync.Mutex
 	schema    *arrow.Schema
-	buffer    bytes.Buffer
-	writer    *ipc.Writer
+	records   []arrow.RecordBatch
 	allocator memory.Allocator
 	rows      int64
 	transient int64
-	decoded   int64
 	finished  bool
 }
 
@@ -82,8 +81,6 @@ func (b *Builder) WriteSchema(schema *arrow.Schema) error {
 	}
 	metadata := schema.Metadata()
 	b.schema = arrow.NewSchema(append([]arrow.Field{}, schema.Fields()...), &metadata)
-	b.writer = ipc.NewWriter(&b.buffer, ipc.WithSchema(b.schema), ipc.WithAllocator(b.allocator))
-	b.updateTransientLocked()
 	return nil
 }
 
@@ -107,15 +104,90 @@ func (b *Builder) WriteRecord(record arrow.RecordBatch) error {
 	}
 	// duckdb-go's record references memory owned by the current DuckDB data
 	// chunk. Arrow Retain pins the Go array object but not that chunk after the
-	// reader advances. IPC materialization is the type-complete deep-copy
-	// boundary into Go-owned Arrow buffers.
-	if err := b.writer.Write(record); err != nil {
-		b.updateTransientLocked()
-		return fmt.Errorf("copy Arrow record: %w", err)
+	// reader advances, so every accepted batch crosses a deep-copy boundary.
+	// Concatenation copies the common scalar buffers directly. Complex layouts
+	// whose concatenation may retain child buffers use IPC as the safe fallback.
+	copied, err := copyRecord(record, b.schema, b.allocator)
+	if err != nil {
+		return err
 	}
-	b.updateTransientLocked()
+	recordBytes := arrowutil.TotalRecordSize(copied)
+	b.records = append(b.records, copied)
 	b.rows += record.NumRows()
+	b.transient += recordBytes
+	globalStats.transientBytes.Add(recordBytes)
 	return nil
+}
+
+func copyRecord(record arrow.RecordBatch, schema *arrow.Schema, allocator memory.Allocator) (arrow.RecordBatch, error) {
+	for index := 0; index < int(record.NumCols()); index++ {
+		if !concatenateDeepCopies(record.Column(index).DataType()) {
+			return copyRecordIPC(record, allocator)
+		}
+	}
+	columns := make([]arrow.Array, int(record.NumCols()))
+	for index := range columns {
+		copied, err := array.Concatenate([]arrow.Array{record.Column(index)}, allocator)
+		if err != nil {
+			for _, column := range columns[:index] {
+				column.Release()
+			}
+			return nil, fmt.Errorf("copy Arrow column %q: %w", record.ColumnName(index), err)
+		}
+		columns[index] = copied
+	}
+	copied := array.NewRecordBatch(schema, columns, record.NumRows())
+	for _, column := range columns {
+		column.Release()
+	}
+	return copied, nil
+}
+
+func concatenateDeepCopies(dataType arrow.DataType) bool {
+	switch dataType.ID() {
+	case arrow.DICTIONARY, arrow.EXTENSION, arrow.STRING_VIEW, arrow.BINARY_VIEW:
+		return false
+	}
+	switch dataType.(type) {
+	case *arrow.NullType, *arrow.BooleanType, arrow.FixedWidthDataType, arrow.BinaryDataType:
+		return true
+	default:
+		return false
+	}
+}
+
+func copyRecordIPC(record arrow.RecordBatch, allocator memory.Allocator) (arrow.RecordBatch, error) {
+	var buffer bytes.Buffer
+	writer := ipc.NewWriter(&buffer, ipc.WithSchema(record.Schema()), ipc.WithAllocator(allocator))
+	if err := writer.Write(record); err != nil {
+		_ = writer.Close()
+		return nil, fmt.Errorf("copy Arrow record: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("finish copied Arrow record: %w", err)
+	}
+	reader, err := ipc.NewReader(bytes.NewReader(buffer.Bytes()), ipc.WithAllocator(allocator))
+	if err != nil {
+		return nil, fmt.Errorf("open copied Arrow record: %w", err)
+	}
+	defer reader.Release()
+	if !reader.Next() {
+		if err := reader.Err(); err != nil {
+			return nil, fmt.Errorf("decode copied Arrow record: %w", err)
+		}
+		return nil, fmt.Errorf("copied Arrow record stream is empty")
+	}
+	copied := reader.RecordBatch()
+	copied.Retain()
+	if reader.Next() {
+		copied.Release()
+		return nil, fmt.Errorf("copied Arrow record stream contains multiple batches")
+	}
+	if err := reader.Err(); err != nil {
+		copied.Release()
+		return nil, fmt.Errorf("decode copied Arrow record: %w", err)
+	}
+	return copied, nil
 }
 
 func (b *Builder) Finish() (*Result, error) {
@@ -130,63 +202,27 @@ func (b *Builder) Finish() (*Result, error) {
 	if b.schema == nil {
 		return nil, ErrSchemaRequired
 	}
-	if err := b.writer.Close(); err != nil {
-		b.finished = true
-		b.releaseTransientLocked()
-		return nil, fmt.Errorf("finish Arrow result stream: %w", err)
-	}
-	b.updateTransientLocked()
 	b.finished = true
-	defer b.releaseTransientLocked()
-	reader, err := ipc.NewReader(bytes.NewReader(b.buffer.Bytes()), ipc.WithAllocator(b.allocator))
-	if err != nil {
-		return nil, fmt.Errorf("open copied Arrow result: %w", err)
-	}
-	records := make([]arrow.RecordBatch, 0)
-	retainedBytes := SchemaBytes(reader.Schema())
-	for reader.Next() {
-		record := reader.RecordBatch()
-		record.Retain()
-		records = append(records, record)
-		recordBytes := arrowutil.TotalRecordSize(record)
-		retainedBytes += recordBytes
-		b.decoded += recordBytes
-		globalStats.transientBytes.Add(recordBytes)
-	}
-	if err := reader.Err(); err != nil {
-		for _, record := range records {
-			record.Release()
-		}
-		reader.Release()
-		return nil, fmt.Errorf("decode copied Arrow result: %w", err)
-	}
-	resultSchema := reader.Schema()
-	reader.Release()
-	result := &Result{schema: resultSchema, records: records, rows: b.rows, bytes: retainedBytes}
+	retainedBytes := SchemaBytes(b.schema) + b.transient
+	result := &Result{schema: b.schema, records: b.records, rows: b.rows, bytes: retainedBytes}
 	result.refs.Store(1)
 	globalStats.results.Add(1)
 	globalStats.bytes.Add(retainedBytes)
-	globalStats.transientBytes.Add(-b.decoded)
-	b.decoded = 0
+	globalStats.transientBytes.Add(-b.transient)
+	b.schema = nil
+	b.records = nil
+	b.transient = 0
 	return result, nil
 }
 
-func (b *Builder) updateTransientLocked() {
-	// Capacity is the memory retained by bytes.Buffer; Len would under-report
-	// allocation after geometric growth.
-	current := int64(b.buffer.Cap())
-	globalStats.transientBytes.Add(current - b.transient)
-	b.transient = current
-}
-
 func (b *Builder) releaseTransientLocked() {
-	globalStats.transientBytes.Add(-b.transient - b.decoded)
+	for _, record := range b.records {
+		record.Release()
+	}
+	globalStats.transientBytes.Add(-b.transient)
 	b.transient = 0
-	b.decoded = 0
-	b.schema, b.writer = nil, nil
-	// Reset keeps the backing allocation. Replace the buffer so a completed or
-	// aborted builder cannot retain the complete IPC copy until garbage collection.
-	b.buffer = bytes.Buffer{}
+	b.schema = nil
+	b.records = nil
 }
 
 // SchemaBytes conservatively accounts the stable Arrow schema retained with a
@@ -222,9 +258,6 @@ func (b *Builder) Abort() {
 		return
 	}
 	b.finished = true
-	if b.writer != nil {
-		_ = b.writer.Close()
-	}
 	b.releaseTransientLocked()
 }
 

--- a/internal/analytics/arrowresult/result_test.go
+++ b/internal/analytics/arrowresult/result_test.go
@@ -128,6 +128,9 @@ func TestBuilderOwnsSlicedDictionaryBuffers(t *testing.T) {
 	if err := collector.WriteRecord(record); err != nil {
 		t.Fatal(err)
 	}
+	// A retained dictionary array is not sufficient for duckdb-go batches: its
+	// values can still point at the reader's reusable native chunk.
+	record.Column(0).(*array.Dictionary).Dictionary().(*array.String).Data().Buffers()[2].Bytes()[0] = 'z'
 	record.Release()
 	result, err := collector.Finish()
 	if err != nil {


### PR DESCRIPTION
## Summary

- replace the common scalar Arrow IPC round-trip with allocator-owned direct buffer copies
- retain IPC as the correctness fallback for nested, dictionary, extension, and view layouts that may retain borrowed child buffers
- compile one decoder per column and bulk-own variable-width data instead of dispatching and copying per cell
- ensure decoded strings and binary values no longer alias Arrow-owned buffers after lease release

## Benchmark

Apple M2, Go 1.25.12, `GOMAXPROCS=5`; median of five 750 ms samples over 10,000 rows and five mixed columns.

| Path | Before | After | Change |
|---|---:|---:|---:|
| Uncached domain result | 10.23 ms | 2.38 ms | 76.7% faster |
| Dashboard cache miss | 11.25 ms | 2.27 ms | 79.8% faster |
| Dashboard cache hit | 6.09 ms | 2.08 ms | 65.8% faster |
| Parallel cache hit | 5.51 ms | 1.18 ms | 78.6% faster |
| Five coalesced callers | 13.94 ms | 6.64 ms | 52.3% faster |

Allocations fall about 14.5% across the 10k-row paths. Miss heap allocation falls about 20%. Retained cache size remains effectively unchanged at 402.5 KB.

## Correctness

- dictionary mutation coverage proves retained borrowed child buffers cannot leak through the ownership boundary
- variable-width mutation coverage proves decoded domain strings and byte slices survive Arrow lease release independently
- complex layouts continue through the type-complete IPC fallback

## Verification

- `go test -race ./internal/analytics/arrowquery ./internal/analytics/arrowresult ./internal/analytics/resultcache ./internal/analytics/materialize`
- `task ci`
- `git diff --check`