### PR TITLE
Fix durable job shutdown teardown

### DIFF
--- a/internal/platform/jobs/runner.go
+++ b/internal/platform/jobs/runner.go
@@ -122,8 +122,16 @@ func (r *Runner) runPump(ctx context.Context, owner, class string) {
 	poll := time.NewTicker(r.pollInterval)
 	defer poll.Stop()
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		candidates, err := r.repository.Candidates(ctx, string(class), 16)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			r.logger.WarnContext(ctx, "list async job candidates failed", "class", class, "error", err)
 		} else {
 			var batch sync.WaitGroup

--- a/internal/platform/jobs/runner_test.go
+++ b/internal/platform/jobs/runner_test.go
@@ -1,9 +1,12 @@
 package jobs
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -110,6 +113,77 @@ func TestRunnerLeavesClaimRecoverableWhenWorkerContextStops(t *testing.T) {
 	}
 }
 
+func TestRunnerShutdownDoesNotStartOrWarnAboutCandidatePolling(t *testing.T) {
+	controller, err := workload.New(workload.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer controller.Close()
+	repository := &countingRunnerRepository{}
+	var logs bytes.Buffer
+	runner, err := NewRunner(RunnerConfig{
+		Repository: repository,
+		Admission:  testAdmitter(controller),
+		Logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	runner.Run(ctx)
+
+	if calls := repository.candidateCalls.Load(); calls != 0 {
+		t.Fatalf("candidate polls after shutdown = %d, want 0", calls)
+	}
+	if output := logs.String(); output != "" {
+		t.Fatalf("shutdown logs = %q, want none", output)
+	}
+}
+
+func TestRunnerShutdownDoesNotWarnWhenCandidatePollingIsCanceled(t *testing.T) {
+	controller, err := workload.New(workload.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer controller.Close()
+	repository := &blockingRunnerRepository{started: make(chan struct{}, 2)}
+	var logs bytes.Buffer
+	runner, err := NewRunner(RunnerConfig{
+		Repository: repository,
+		Admission:  testAdmitter(controller),
+		Logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		runner.Run(ctx)
+	}()
+	for range 2 {
+		select {
+		case <-repository.started:
+		case <-time.After(time.Second):
+			t.Fatal("candidate poll did not start")
+		}
+	}
+
+	cancel()
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not stop after cancellation")
+	}
+
+	if output := logs.String(); output != "" {
+		t.Fatalf("shutdown logs = %q, want none", output)
+	}
+}
+
 type runnerTestRepository struct{}
 
 func (*runnerTestRepository) Enqueue(context.Context, EnqueueInput) (Job, error) { return Job{}, nil }
@@ -130,6 +204,27 @@ func (*runnerTestRepository) AppendEvent(context.Context, string, string, string
 }
 func (*runnerTestRepository) ListEvents(context.Context, string, string, int64, int) ([]Event, error) {
 	return nil, nil
+}
+
+type countingRunnerRepository struct {
+	runnerTestRepository
+	candidateCalls atomic.Int64
+}
+
+func (r *countingRunnerRepository) Candidates(context.Context, string, int) ([]Job, error) {
+	r.candidateCalls.Add(1)
+	return nil, nil
+}
+
+type blockingRunnerRepository struct {
+	runnerTestRepository
+	started chan struct{}
+}
+
+func (r *blockingRunnerRepository) Candidates(ctx context.Context, _ string, _ int) ([]Job, error) {
+	r.started <- struct{}{}
+	<-ctx.Done()
+	return nil, ctx.Err()
 }
 
 type recordingRunnerRepository struct {

--- a/internal/platform/store.go
+++ b/internal/platform/store.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/Yacobolo/leapview/internal/platform/db"
 	"github.com/Yacobolo/leapview/internal/platform/filesystem"
@@ -24,8 +26,10 @@ const (
 )
 
 type Store struct {
-	db *sql.DB
-	q  *db.Queries
+	db        *sql.DB
+	q         *db.Queries
+	closeOnce sync.Once
+	closeErr  error
 }
 
 func Open(ctx context.Context, path string) (*Store, error) {
@@ -40,11 +44,11 @@ func Open(ctx context.Context, path string) (*Store, error) {
 	conn.SetMaxIdleConns(0)
 	store := &Store{db: conn, q: db.New(conn)}
 	if err := store.migrate(ctx); err != nil {
-		conn.Close()
+		_ = store.Close()
 		return nil, err
 	}
 	if err := chmodDatabaseFile(path); err != nil {
-		conn.Close()
+		_ = store.Close()
 		return nil, err
 	}
 	return store, nil
@@ -63,7 +67,18 @@ func sqliteString(value string) string {
 }
 
 func (s *Store) Close() error {
-	return s.db.Close()
+	s.closeOnce.Do(func() {
+		// Normal operation intentionally keeps no idle SQLite connections. At
+		// shutdown, retain the barrier connection so Ping cannot return while a
+		// database/sql opener is still completing in the background. DB.Close
+		// then closes that sole idle connection before this method returns.
+		s.db.SetMaxIdleConns(1)
+		if err := s.db.PingContext(context.Background()); err != nil {
+			s.closeErr = fmt.Errorf("drain platform db connections: %w", err)
+		}
+		s.closeErr = errors.Join(s.closeErr, s.db.Close())
+	})
+	return s.closeErr
 }
 
 func (s *Store) SQLDB() *sql.DB {

--- a/internal/platform/store_test.go
+++ b/internal/platform/store_test.go
@@ -169,6 +169,30 @@ func TestStoreOpenMakesDatabasePrivate(t *testing.T) {
 	assertExistingSQLiteSidecarsPrivate(t, dbPath)
 }
 
+func TestStoreUsesPerOperationConnectionsAndDrainsOnClose(t *testing.T) {
+	store, err := Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.Ping(t.Context()); err != nil {
+		t.Fatalf("ping store: %v", err)
+	}
+	stats := store.SQLDB().Stats()
+	if stats.OpenConnections != 0 || stats.Idle != 0 {
+		t.Fatalf("connections after operation = %d idle = %d, want per-operation connections", stats.OpenConnections, stats.Idle)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store twice: %v", err)
+	}
+	stats = store.SQLDB().Stats()
+	if stats.OpenConnections != 0 {
+		t.Fatalf("connections after close = %d, want 0", stats.OpenConnections)
+	}
+}
+
 func TestStoreBackupCreatesReadableSQLiteCopy(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- stop durable job admission and polling immediately when the runner context is canceled
- suppress expected cancellation warnings during runner shutdown
- add a shutdown-only SQLite barrier that drains `database/sql`'s asynchronous connection opener while preserving normal per-operation connection behavior
- make store close idempotent and join shutdown errors

## Why

Durable jobs could be admitted after shutdown began, and store teardown could return before an asynchronously opened SQLite connection had been closed. That made restart recovery and temporary database cleanup nondeterministic.

## Validation

- durable recovery regression: 500 consecutive runs
- store per-operation semantics: 100 consecutive runs
- refresh visibility integration: 20 consecutive runs
- chat draft acceptance comparison: 100/100 on this branch and 100/100 on untouched `main`
- `internal/platform/jobs` under race detection
- tagged platform store and DuckLake lifecycle tests under race detection
- canonical `task ci` green, including generated checks, browser tests, live Datastar route QA, Go race checks, and deployment validation

One unrelated suite-load-sensitive chat draft failure encountered during an earlier full run is tracked separately as [LEA-71](https://linear.app/leapstack/issue/LEA-71/eliminate-chat-draft-background-turn-acceptance-nondeterminism); focused branch/control stress showed no association with this change.

Linear: [LEA-53](https://linear.app/leapstack/issue/LEA-53/make-durable-job-restart-recovery-teardown-deterministic)
