### PR TITLE
refactor(api): assign capability namespaces

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -372,8 +372,8 @@ tasks:
       - docs/api/openapi.yaml
       - docs/api/operations.json
     cmds:
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 typespec-compile -manifest api/apigen.yaml -target leapview-v1
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 all -manifest api/apigen.yaml -target leapview-v1
+      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 typespec-compile -manifest api/apigen.yaml -target leapview-v1
+      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 all -manifest api/apigen.yaml -target leapview-v1
       - go run ./internal/app/tools/openapidocgen
 
   agent-contracts:generate:
@@ -390,8 +390,8 @@ tasks:
       - internal/agent/contracts/models.gen.go
       - internal/agent/contracts/schemas.gen.go
     cmds:
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 typespec-compile -manifest api/apigen.yaml -target agent-tool-contracts
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 all -manifest api/apigen.yaml -target agent-tool-contracts
+      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 typespec-compile -manifest api/apigen.yaml -target agent-tool-contracts
+      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 all -manifest api/apigen.yaml -target agent-tool-contracts
       - go run ./internal/agent/contracts/generate
 
   schema:generate:
@@ -438,8 +438,8 @@ tasks:
       - internal/workspace/ui/signals/models.gen.go
       - web/generated/signals/index.ts
     cmds:
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 typespec-compile -manifest api/apigen.yaml -target ui-signals
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 all -manifest api/apigen.yaml -target ui-signals
+      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 typespec-compile -manifest api/apigen.yaml -target ui-signals
+      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 all -manifest api/apigen.yaml -target ui-signals
       - go run ./internal/app/tools/signalcontracts
 
   visualization-ir:generate:
@@ -463,8 +463,8 @@ tasks:
       - web/generated/vega-lite/validate.ts
       - api/gen/visualization.schema.json
     cmds:
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 typespec-compile -manifest api/apigen.yaml -target visualization-ir
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 all -manifest api/apigen.yaml -target visualization-ir
+      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 typespec-compile -manifest api/apigen.yaml -target visualization-ir
+      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 all -manifest api/apigen.yaml -target visualization-ir
       - bun scripts/generate_visualization_validator.ts
       - bun scripts/generate_vega_lite_validator.ts
 

--- a/api/apigen.yaml
+++ b/api/apigen.yaml
@@ -5,8 +5,21 @@ targets:
     ir_out: gen/json-ir.json
     openapi_out: gen/openapi.yaml
     go_out:
-      dir: ../internal/app/api/gen
-      package: gen
+      unmatched: error
+      packages:
+        LeapViewAPI: &leapview_api_go_package
+          dir: ../internal/app/api/gen
+          package: gen
+          import_path: github.com/Yacobolo/leapview/internal/app/api/gen
+        LeapViewAPI.Access: *leapview_api_go_package
+        LeapViewAPI.Agent: *leapview_api_go_package
+        LeapViewAPI.Dashboard: *leapview_api_go_package
+        LeapViewAPI.Deployment: *leapview_api_go_package
+        LeapViewAPI.ManagedData: *leapview_api_go_package
+        LeapViewAPI.Project: *leapview_api_go_package
+        LeapViewAPI.Refresh: *leapview_api_go_package
+        LeapViewAPI.Release: *leapview_api_go_package
+        LeapViewAPI.Workspace: *leapview_api_go_package
     cli_out:
       dir: ../internal/app/cli/gen
       package: gen

--- a/api/typespec/access.tsp
+++ b/api/typespec/access.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Access;
 
 model PrincipalResponse {
   id: string;
@@ -247,6 +246,7 @@ alias ListPrincipalsOK = OkJson<PrincipalListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "grant-management")
+@operationId("listPrincipals")
 op listPrincipals(@query email?: string, @query q?: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListPrincipalsOK | CommonErrors;
 
 alias CreatePrincipalCreated = CreatedJson<LocalPasswordResetResponse>;
@@ -257,6 +257,7 @@ alias CreatePrincipalCreated = CreatedJson<LocalPasswordResetResponse>;
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "grant-management")
+@operationId("createPrincipal")
 op createPrincipal(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: PrincipalCreateRequest): CreatePrincipalCreated | CommonErrors;
 
 alias GetPrincipalOK = OkJson<PrincipalResponse>;
@@ -267,6 +268,7 @@ alias GetPrincipalOK = OkJson<PrincipalResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "grant-management")
+@operationId("getPrincipal")
 op getPrincipal(@path principal: string): GetPrincipalOK | CommonErrors;
 
 alias UpdatePrincipalOK = OkJson<PrincipalResponse>;
@@ -277,6 +279,7 @@ alias UpdatePrincipalOK = OkJson<PrincipalResponse>;
 @patch
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "grant-management")
+@operationId("updatePrincipal")
 op updatePrincipal(@path principal: string, @header("If-Match") ifMatch: string, @body body: PrincipalPatchRequest): UpdatePrincipalOK | CommonErrors;
 
 @tag("Access")
@@ -285,6 +288,7 @@ op updatePrincipal(@path principal: string, @header("If-Match") ifMatch: string,
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "grant-management")
+@operationId("deletePrincipal")
 op deletePrincipal(@path principal: string): NoContentResponse | CommonErrors;
 
 alias ResetPrincipalPasswordOK = OkJson<LocalPasswordResetResponse>;
@@ -295,6 +299,7 @@ alias ResetPrincipalPasswordOK = OkJson<LocalPasswordResetResponse>;
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "grant-management")
+@operationId("resetPrincipalPassword")
 op resetPrincipalPassword(@path principal: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): ResetPrincipalPasswordOK | CommonErrors;
 
 alias ListServicePrincipalsOK = OkJson<ServicePrincipalListResponse>;
@@ -304,6 +309,7 @@ alias ListServicePrincipalsOK = OkJson<ServicePrincipalListResponse>;
 @route("/service-principals")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("listServicePrincipals")
 op listServicePrincipals(@query limit?: ListLimit, @query pageToken?: PageToken): ListServicePrincipalsOK | CommonErrors;
 
 alias CreateServicePrincipalCreated = CreatedJson<PrincipalResponse>;
@@ -313,6 +319,7 @@ alias CreateServicePrincipalCreated = CreatedJson<PrincipalResponse>;
 @route("/service-principals")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("createServicePrincipal")
 op createServicePrincipal(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: ServicePrincipalCreateRequest): CreateServicePrincipalCreated | CommonErrors;
 
 @tag("Access")
@@ -320,6 +327,7 @@ op createServicePrincipal(@header("Idempotency-Key") idempotencyKey: Idempotency
 @route("/service-principals/{servicePrincipal}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("getServicePrincipal")
 op getServicePrincipal(@path servicePrincipal: string): OkJson<PrincipalResponse> | CommonErrors;
 
 alias UpdateServicePrincipalOK = OkJson<PrincipalResponse>;
@@ -329,6 +337,7 @@ alias UpdateServicePrincipalOK = OkJson<PrincipalResponse>;
 @route("/service-principals/{servicePrincipal}")
 @patch
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("updateServicePrincipal")
 op updateServicePrincipal(@path servicePrincipal: string, @header("If-Match") ifMatch: string, @body body: ServicePrincipalPatchRequest): UpdateServicePrincipalOK | CommonErrors;
 
 @tag("Access")
@@ -336,6 +345,7 @@ op updateServicePrincipal(@path servicePrincipal: string, @header("If-Match") if
 @route("/service-principals/{servicePrincipal}")
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("deleteServicePrincipal")
 op deleteServicePrincipal(@path servicePrincipal: string): NoContentResponse | CommonErrors;
 
 alias CreateServicePrincipalSecretCreated = CreatedJson<ServicePrincipalSecretCreatedResponse>;
@@ -345,6 +355,7 @@ alias CreateServicePrincipalSecretCreated = CreatedJson<ServicePrincipalSecretCr
 @route("/service-principals/{servicePrincipal}/secrets")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("createServicePrincipalSecret")
 op createServicePrincipalSecret(@path servicePrincipal: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: ServicePrincipalSecretCreateRequest): CreateServicePrincipalSecretCreated | CommonErrors;
 
 @tag("Access")
@@ -352,6 +363,7 @@ op createServicePrincipalSecret(@path servicePrincipal: string, @header("Idempot
 @route("/service-principals/{servicePrincipal}/secrets")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("listServicePrincipalSecrets")
 op listServicePrincipalSecrets(@path servicePrincipal: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ServicePrincipalSecretListResponse> | CommonErrors;
 
 @tag("Access")
@@ -359,6 +371,7 @@ op listServicePrincipalSecrets(@path servicePrincipal: string, @query limit?: Li
 @route("/service-principals/{servicePrincipal}/secrets/{secret}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("getServicePrincipalSecret")
 op getServicePrincipalSecret(@path servicePrincipal: string, @path secret: string): OkJson<ServicePrincipalSecretResponse> | CommonErrors;
 
 @tag("Access")
@@ -366,6 +379,7 @@ op getServicePrincipalSecret(@path servicePrincipal: string, @path secret: strin
 @route("/service-principals/{servicePrincipal}/secrets/{secret}")
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@operationId("revokeServicePrincipalSecret")
 op revokeServicePrincipalSecret(@path servicePrincipal: string, @path secret: string): NoContentResponse | CommonErrors;
 
 alias ListGroupsOK = OkJson<GroupListResponse>;
@@ -375,6 +389,7 @@ alias ListGroupsOK = OkJson<GroupListResponse>;
 @route("/workspaces/{workspace}/groups")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("listGroups")
 op listGroups(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListGroupsOK | CommonErrors;
 
 alias CreateGroupCreated = CreatedJson<GroupResponse>;
@@ -384,6 +399,7 @@ alias CreateGroupCreated = CreatedJson<GroupResponse>;
 @route("/workspaces/{workspace}/groups")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("createGroup")
 op createGroup(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: GroupCreateRequest): CreateGroupCreated | CommonErrors;
 
 @tag("Access")
@@ -391,6 +407,7 @@ op createGroup(@path workspace: string, @header("Idempotency-Key") idempotencyKe
 @route("/workspaces/{workspace}/groups/{group}")
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("deleteGroup")
 op deleteGroup(@path workspace: string, @path group: string): NoContentResponse | CommonErrors;
 
 alias GetGroupOK = OkJson<GroupResponse>;
@@ -400,6 +417,7 @@ alias GetGroupOK = OkJson<GroupResponse>;
 @route("/workspaces/{workspace}/groups/{group}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("getGroup")
 op getGroup(@path workspace: string, @path group: string): GetGroupOK | CommonErrors;
 
 alias UpdateGroupOK = OkJson<GroupResponse>;
@@ -409,6 +427,7 @@ alias UpdateGroupOK = OkJson<GroupResponse>;
 @route("/workspaces/{workspace}/groups/{group}")
 @patch
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("updateGroup")
 op updateGroup(@path workspace: string, @path group: string, @header("If-Match") ifMatch: string, @body body: GroupPatchRequest): UpdateGroupOK | CommonErrors;
 
 alias ListGroupMembersOK = OkJson<GroupMemberListResponse>;
@@ -418,6 +437,7 @@ alias ListGroupMembersOK = OkJson<GroupMemberListResponse>;
 @route("/workspaces/{workspace}/groups/{group}/members")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("listGroupMembers")
 op listGroupMembers(@path workspace: string, @path group: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListGroupMembersOK | CommonErrors;
 
 @tag("Access")
@@ -425,6 +445,7 @@ op listGroupMembers(@path workspace: string, @path group: string, @query limit?:
 @route("/workspaces/{workspace}/groups/{group}/members/{principal}")
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("removeGroupMember")
 op removeGroupMember(@path workspace: string, @path group: string, @path principal: string): NoContentResponse | CommonErrors;
 
 alias AddGroupMemberOK = OkJson<StatusResponse>;
@@ -434,6 +455,7 @@ alias AddGroupMemberOK = OkJson<StatusResponse>;
 @route("/workspaces/{workspace}/groups/{group}/members/{principal}")
 @put
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("addGroupMember")
 op addGroupMember(@path workspace: string, @path group: string, @path principal: string): AddGroupMemberOK | CommonErrors;
 
 alias ListRoleBindingsOK = OkJson<RoleBindingListResponse>;
@@ -443,6 +465,7 @@ alias ListRoleBindingsOK = OkJson<RoleBindingListResponse>;
 @route("/workspaces/{workspace}/role-bindings")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("listRoleBindings")
 op listRoleBindings(@path workspace: string, @query subjectType?: string, @query subjectId?: string, @query role?: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListRoleBindingsOK | CommonErrors;
 
 alias CreateRoleBindingCreated = CreatedJson<RoleBindingResponse>;
@@ -452,6 +475,7 @@ alias CreateRoleBindingCreated = CreatedJson<RoleBindingResponse>;
 @route("/workspaces/{workspace}/role-bindings")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("createRoleBinding")
 op createRoleBinding(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: RoleBindingRequest): CreateRoleBindingCreated | CommonErrors;
 
 @tag("Access")
@@ -459,6 +483,7 @@ op createRoleBinding(@path workspace: string, @header("Idempotency-Key") idempot
 @route("/workspaces/{workspace}/role-bindings/{binding}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("getRoleBinding")
 op getRoleBinding(@path workspace: string, @path binding: string): OkJson<RoleBindingResponse> | CommonErrors;
 
 @tag("Access")
@@ -466,6 +491,7 @@ op getRoleBinding(@path workspace: string, @path binding: string): OkJson<RoleBi
 @route("/workspaces/{workspace}/role-bindings/{binding}")
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("deleteRoleBinding")
 op deleteRoleBinding(@path workspace: string, @path binding: string): NoContentResponse | CommonErrors;
 
 alias UpdateRoleBindingOK = OkJson<RoleBindingResponse>;
@@ -475,6 +501,7 @@ alias UpdateRoleBindingOK = OkJson<RoleBindingResponse>;
 @route("/workspaces/{workspace}/role-bindings/{binding}")
 @patch
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("updateRoleBinding")
 op updateRoleBinding(@path workspace: string, @path binding: string, @header("If-Match") ifMatch: string, @body body: RoleBindingRequest): UpdateRoleBindingOK | CommonErrors;
 
 alias ListWorkspaceRolesOK = OkJson<RoleListResponse>;
@@ -484,6 +511,7 @@ alias ListWorkspaceRolesOK = OkJson<RoleListResponse>;
 @route("/workspaces/{workspace}/roles")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("listWorkspaceRoles")
 op listWorkspaceRoles(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListWorkspaceRolesOK | CommonErrors;
 
 alias ListEffectivePrivilegesOK = OkJson<EffectivePrivilegeListResponse>;
@@ -493,6 +521,7 @@ alias ListEffectivePrivilegesOK = OkJson<EffectivePrivilegeListResponse>;
 @route("/workspaces/{workspace}/effective-privileges")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("listEffectivePrivileges")
 op listEffectivePrivileges(@path workspace: string, @query objectType?: string, @query objectId?: string): ListEffectivePrivilegesOK | CommonErrors;
 
 alias ListGrantsOK = OkJson<GrantListResponse>;
@@ -502,6 +531,7 @@ alias ListGrantsOK = OkJson<GrantListResponse>;
 @route("/workspaces/{workspace}/grants")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("listGrants")
 op listGrants(@path workspace: string, @query objectType?: string, @query objectId?: string, @query includeInherited?: boolean, @query limit?: ListLimit, @query pageToken?: PageToken): ListGrantsOK | CommonErrors;
 
 alias CreateGrantCreated = CreatedJson<GrantResponse>;
@@ -511,6 +541,7 @@ alias CreateGrantCreated = CreatedJson<GrantResponse>;
 @route("/workspaces/{workspace}/grants")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("createGrant")
 op createGrant(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: GrantRequest): CreateGrantCreated | CommonErrors;
 
 @tag("Access")
@@ -518,6 +549,7 @@ op createGrant(@path workspace: string, @header("Idempotency-Key") idempotencyKe
 @route("/workspaces/{workspace}/grants/{grant}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("getGrant")
 op getGrant(@path workspace: string, @path grant: string): OkJson<GrantResponse> | CommonErrors;
 
 @tag("Access")
@@ -525,6 +557,7 @@ op getGrant(@path workspace: string, @path grant: string): OkJson<GrantResponse>
 @route("/workspaces/{workspace}/grants/{grant}")
 @patch
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("updateGrant")
 op updateGrant(@path workspace: string, @path grant: string, @header("If-Match") ifMatch: string, @body body: GrantRequest): OkJson<GrantResponse> | CommonErrors;
 
 @tag("Access")
@@ -532,6 +565,7 @@ op updateGrant(@path workspace: string, @path grant: string, @header("If-Match")
 @route("/workspaces/{workspace}/grants/{grant}")
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("deleteGrant")
 op deleteGrant(@path workspace: string, @path grant: string): NoContentResponse | CommonErrors;
 
 alias TransferOwnershipOK = OkJson<SecurableObjectResponse>;
@@ -541,6 +575,7 @@ alias TransferOwnershipOK = OkJson<SecurableObjectResponse>;
 @route("/workspaces/{workspace}/ownership")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_ITEM" })
+@operationId("transferOwnership")
 op transferOwnership(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: OwnershipTransferRequest): TransferOwnershipOK | CommonErrors;
 
 alias ListDataPoliciesOK = OkJson<DataPolicyListResponse>;
@@ -550,6 +585,7 @@ alias ListDataPoliciesOK = OkJson<DataPolicyListResponse>;
 @route("/workspaces/{workspace}/data-policies")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("listDataPolicies")
 op listDataPolicies(@path workspace: string, @query objectType?: string, @query objectId?: string, @query includeInherited?: boolean, @query limit?: ListLimit, @query pageToken?: PageToken): ListDataPoliciesOK | CommonErrors;
 
 alias CreateDataPolicyCreated = CreatedJson<DataPolicyResponse>;
@@ -559,6 +595,7 @@ alias CreateDataPolicyCreated = CreatedJson<DataPolicyResponse>;
 @route("/workspaces/{workspace}/data-policies")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("createDataPolicy")
 op createDataPolicy(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DataPolicyRequest): CreateDataPolicyCreated | CommonErrors;
 
 @tag("Access")
@@ -566,6 +603,7 @@ op createDataPolicy(@path workspace: string, @header("Idempotency-Key") idempote
 @route("/workspaces/{workspace}/data-policies/{policy}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("getDataPolicy")
 op getDataPolicy(@path workspace: string, @path policy: string): OkJson<DataPolicyResponse> | CommonErrors;
 
 @tag("Access")
@@ -573,6 +611,7 @@ op getDataPolicy(@path workspace: string, @path policy: string): OkJson<DataPoli
 @route("/workspaces/{workspace}/data-policies/{policy}")
 @patch
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("updateDataPolicy")
 op updateDataPolicy(@path workspace: string, @path policy: string, @header("If-Match") ifMatch: string, @body body: DataPolicyRequest): OkJson<DataPolicyResponse> | CommonErrors;
 
 @tag("Access")
@@ -580,6 +619,7 @@ op updateDataPolicy(@path workspace: string, @path policy: string, @header("If-M
 @route("/workspaces/{workspace}/data-policies/{policy}")
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@operationId("deleteDataPolicy")
 op deleteDataPolicy(@path workspace: string, @path policy: string): NoContentResponse | CommonErrors;
 
 @tag("Access")
@@ -587,4 +627,5 @@ op deleteDataPolicy(@path workspace: string, @path policy: string): NoContentRes
 @route("/workspaces/{workspace}/authorization-checks")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("checkAuthorizationBatch")
 op checkAuthorizationBatch(@path workspace: string, @body body: AuthorizationBatchCheckRequest): OkJson<AuthorizationBatchCheckResponse> | CommonErrors;

--- a/api/typespec/agent.tsp
+++ b/api/typespec/agent.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Agent;
 
 model AgentConversationCreateRequest {
   title?: string;
@@ -79,6 +78,7 @@ alias ListAgentConversationsOK = OkJson<AgentConversationListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
 @apigen.cli(#{ command: #["agent", "conversations"], output: #{ mode: "raw" } })
+@operationId("listAgentConversations")
 op listAgentConversations(@query limit?: ListLimit, @query pageToken?: PageToken): ListAgentConversationsOK | CommonErrors;
 
 alias CreateAgentConversationCreated = CreatedJson<AgentConversationResponse>;
@@ -88,6 +88,7 @@ alias CreateAgentConversationCreated = CreatedJson<AgentConversationResponse>;
 @route("/agent/conversations")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
+@operationId("createAgentConversation")
 op createAgentConversation(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: AgentConversationCreateRequest): CreateAgentConversationCreated | CommonErrors;
 
 @tag("Agent")
@@ -95,6 +96,7 @@ op createAgentConversation(@header("Idempotency-Key") idempotencyKey: Idempotenc
 @route("/agent/conversations/{conversation}")
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
+@operationId("archiveAgentConversation")
 op archiveAgentConversation(@path conversation: string): NoContentResponse | CommonErrors;
 
 alias GetAgentConversationOK = OkJson<AgentConversationResponse>;
@@ -104,6 +106,7 @@ alias GetAgentConversationOK = OkJson<AgentConversationResponse>;
 @route("/agent/conversations/{conversation}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
+@operationId("getAgentConversation")
 op getAgentConversation(@path conversation: string): GetAgentConversationOK | CommonErrors;
 
 alias UpdateAgentConversationOK = OkJson<AgentConversationResponse>;
@@ -113,6 +116,7 @@ alias UpdateAgentConversationOK = OkJson<AgentConversationResponse>;
 @route("/agent/conversations/{conversation}")
 @patch
 @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
+@operationId("updateAgentConversation")
 op updateAgentConversation(@path conversation: string, @header("If-Match") ifMatch: string, @body body: AgentConversationPatchRequest): UpdateAgentConversationOK | CommonErrors;
 
 alias ListAgentMessagesOK = OkJson<AgentMessageListResponse>;
@@ -122,6 +126,7 @@ alias ListAgentMessagesOK = OkJson<AgentMessageListResponse>;
 @route("/agent/conversations/{conversation}/messages")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
+@operationId("listAgentMessages")
 op listAgentMessages(@path conversation: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListAgentMessagesOK | CommonErrors;
 
 alias ListAgentRunsOK = OkJson<AgentRunListResponse>;
@@ -131,6 +136,7 @@ alias ListAgentRunsOK = OkJson<AgentRunListResponse>;
 @route("/agent/conversations/{conversation}/runs")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
+@operationId("listAgentRuns")
 op listAgentRuns(@path conversation: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListAgentRunsOK | CommonErrors;
 
 alias GetAgentRunOK = OkJson<AgentRunResponse>;
@@ -140,6 +146,7 @@ alias GetAgentRunOK = OkJson<AgentRunResponse>;
 @route("/agent/conversations/{conversation}/runs/{run}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
+@operationId("getAgentRun")
 op getAgentRun(@path conversation: string, @path run: string): GetAgentRunOK | CommonErrors;
 
 alias ListAgentEventsOK = OkJson<AsyncEventListResponse>;
@@ -149,6 +156,7 @@ alias ListAgentEventsOK = OkJson<AsyncEventListResponse>;
 @route("/agent/conversations/{conversation}/runs/{run}/events")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
+@operationId("listAgentEvents")
 op listAgentEvents(@path conversation: string, @path run: string, @header accept?: string, @header("Last-Event-ID") lastEventId?: string, @query limit?: ListLimit, @query pageToken?: PageToken): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;
 
 @tag("Agent")
@@ -156,6 +164,7 @@ op listAgentEvents(@path conversation: string, @path run: string, @header accept
 @route("/agent/conversations/{conversation}/runs")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
+@operationId("createAgentRun")
 op createAgentRun(@path conversation: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: AgentRunCreateRequest): AcceptedJson<AgentRunResponse> | CommonErrors;
 
 @tag("Agent")
@@ -163,4 +172,5 @@ op createAgentRun(@path conversation: string, @header("Idempotency-Key") idempot
 @route("/agent/conversations/{conversation}/runs/{run}/cancel")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
+@operationId("cancelAgentRun")
 op cancelAgentRun(@path conversation: string, @path run: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<AgentRunResponse> | CommonErrors;

--- a/api/typespec/audit.tsp
+++ b/api/typespec/audit.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Access;
 
 model AuditEventResponse {
   id: string;
@@ -61,6 +60,7 @@ alias ListQueryEventsOK = OkJson<QueryEventListResponse>;
 @route("/workspaces/{workspace}/audit-events")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
+@operationId("listAuditEvents")
 op listAuditEvents(@path workspace: string, @query actor?: string, @query action?: string, @query targetType?: string, @query targetId?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListAuditEventsOK | CommonErrors;
 
 @tag("Audit")
@@ -68,4 +68,5 @@ op listAuditEvents(@path workspace: string, @query actor?: string, @query action
 @route("/workspaces/{workspace}/query-events")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
+@operationId("listQueryEvents")
 op listQueryEvents(@path workspace: string, @query principal?: string, @query surface?: string, @query operation?: string, @query kind?: string, @query modelId?: string, @query target?: string, @query status?: string, @query search?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListQueryEventsOK | CommonErrors;

--- a/api/typespec/bi.tsp
+++ b/api/typespec/bi.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Dashboard;
 
 model DashboardSummary {
   id: string;
@@ -652,6 +651,7 @@ model DashboardFilterOptionListResponse {
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @apigen.cli(#{ command: #["dashboards", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
+@operationId("listDashboards")
 op listDashboards(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<DashboardListResponse> | CommonErrors;
 
 @tag("BI")
@@ -661,6 +661,7 @@ op listDashboards(@path workspace: string, @query limit?: ListLimit, @query page
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }], output: #{ mode: "raw" } })
+@operationId("getDashboard")
 op getDashboard(@path workspace: string, @path dashboard: string): OkJson<DashboardManifestResponse> | CommonErrors;
 
 @tag("BI")
@@ -670,6 +671,7 @@ op getDashboard(@path workspace: string, @path dashboard: string): OkJson<Dashbo
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "page"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }], output: #{ mode: "raw" } })
+@operationId("getDashboardPage")
 op getDashboardPage(@path workspace: string, @path dashboard: string, @path page: string): OkJson<DashboardPageResponse> | CommonErrors;
 
 @tag("BI")
@@ -679,6 +681,7 @@ op getDashboardPage(@path workspace: string, @path dashboard: string, @path page
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "visual"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "visual", displayName: "visual" }], output: #{ mode: "raw" } })
+@operationId("getDashboardVisual")
 op getDashboardVisual(@path workspace: string, @path dashboard: string, @path page: string, @path visual: string): OkJson<DashboardVisualDescribeResponse> | CommonErrors;
 
 @tag("BI")
@@ -687,6 +690,7 @@ op getDashboardVisual(@path workspace: string, @path dashboard: string, @path pa
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "dashboard")
+@operationId("getDashboardFilter")
 op getDashboardFilter(@path workspace: string, @path dashboard: string, @path page: string, @path filter: string): OkJson<DashboardFilterDescribeResponse> | CommonErrors;
 
 @tag("BI")
@@ -695,6 +699,7 @@ op getDashboardFilter(@path workspace: string, @path dashboard: string, @path pa
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @apigen.cli(#{ command: #["semantic-models", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
+@operationId("listSemanticModels")
 op listSemanticModels(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticModelListResponse> | CommonErrors;
 
 @tag("BI")
@@ -704,6 +709,7 @@ op listSemanticModels(@path workspace: string, @query limit?: ListLimit, @query 
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
+@operationId("getSemanticModel")
 op getSemanticModel(@path workspace: string, @path("model") modelName: string): OkJson<SemanticModelDescriptionResponse> | CommonErrors;
 
 @tag("BI")
@@ -712,6 +718,7 @@ op getSemanticModel(@path workspace: string, @path("model") modelName: string): 
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
+@operationId("listSemanticRelationships")
 op listSemanticRelationships(@path workspace: string, @path("model") modelName: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticRelationshipListResponse> | CommonErrors;
 
 @tag("BI")
@@ -720,6 +727,7 @@ op listSemanticRelationships(@path workspace: string, @path("model") modelName: 
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
+@operationId("listSemanticSources")
 op listSemanticSources(@path workspace: string, @path("model") modelName: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticSourceListResponse> | CommonErrors;
 
 @tag("BI")
@@ -729,6 +737,7 @@ op listSemanticSources(@path workspace: string, @path("model") modelName: string
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "model-fields"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
+@operationId("listSemanticModelFields")
 op listSemanticModelFields(@path workspace: string, @path("model") modelName: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticFieldListResponse> | CommonErrors;
 
 @tag("BI")
@@ -777,6 +786,7 @@ op listSemanticModelFields(@path workspace: string, @path("model") modelName: st
     cursor: #{ source: "/page/nextCursor" }
   },
 })
+@operationId("querySemanticModel")
 op querySemanticModel(@path workspace: WorkspaceId, @path("model") modelName: string, @header accept?: string, @body body?: SemanticQueryRequest): RowsetResponse<SemanticQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -786,6 +796,7 @@ op querySemanticModel(@path workspace: WorkspaceId, @path("model") modelName: st
 @apigen.authz(#{ mode: "privilege", privilege: "QUERY_DATA" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "model-explain"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
+@operationId("explainSemanticModelQuery")
 op explainSemanticModelQuery(@path workspace: string, @path("model") modelName: string, @body body?: SemanticQueryRequest): OkJson<SemanticExplainResponse> | CommonErrors;
 
 @tag("BI")
@@ -795,6 +806,7 @@ op explainSemanticModelQuery(@path workspace: string, @path("model") modelName: 
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "datasets"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
+@operationId("listSemanticDatasets")
 op listSemanticDatasets(@path workspace: string, @path("model") modelName: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticDatasetListResponse> | CommonErrors;
 
 @tag("BI")
@@ -804,6 +816,7 @@ op listSemanticDatasets(@path workspace: string, @path("model") modelName: strin
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "dataset"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
+@operationId("getSemanticDataset")
 op getSemanticDataset(@path workspace: string, @path("model") modelName: string, @path dataset: string): OkJson<SemanticDatasetResponse> | CommonErrors;
 
 @tag("BI")
@@ -813,6 +826,7 @@ op getSemanticDataset(@path workspace: string, @path("model") modelName: string,
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "fields"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
+@operationId("listSemanticFields")
 op listSemanticFields(@path workspace: string, @path("model") modelName: string, @path dataset: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticFieldListResponse> | CommonErrors;
 
 @tag("BI")
@@ -823,6 +837,7 @@ op listSemanticFields(@path workspace: string, @path("model") modelName: string,
 @extension("x-leapview-object-scope", "semantic-model")
 @extension("x-leapview-response-trailers", #["X-Next-Cursor"])
 @apigen.cli(#{ command: #["semantic-models", "preview"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
+@operationId("previewSemanticDataset")
 op previewSemanticDataset(@path workspace: string, @path("model") modelName: string, @path dataset: string, @header accept?: string, @body body?: SemanticPreviewRequest): RowsetResponse<SemanticQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -832,6 +847,7 @@ op previewSemanticDataset(@path workspace: string, @path("model") modelName: str
 @apigen.authz(#{ mode: "privilege", privilege: "PREVIEW_DATA" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "explain-preview"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
+@operationId("explainSemanticPreview")
 op explainSemanticPreview(@path workspace: string, @path("model") modelName: string, @path dataset: string, @body body?: SemanticPreviewRequest): OkJson<SemanticExplainResponse> | CommonErrors;
 
 @tag("BI")
@@ -841,6 +857,7 @@ op explainSemanticPreview(@path workspace: string, @path("model") modelName: str
 @apigen.authz(#{ mode: "privilege", privilege: "QUERY_DATA" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "query-page"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }], output: #{ mode: "raw" } })
+@operationId("queryDashboardPage")
 op queryDashboardPage(@path workspace: string, @path dashboard: string, @path page: string, @body body?: DashboardPageQueryRequest): OkJson<DashboardPageQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -862,6 +879,7 @@ op queryDashboardPage(@path workspace: string, @path dashboard: string, @path pa
   ] },
   output: #{ mode: "raw" },
 })
+@operationId("queryDashboardVisualData")
 op queryDashboardVisualData(@path workspace: WorkspaceId, @path dashboard: string, @path page: string, @path visual: string, @header accept?: string, @body body?: DashboardVisualQueryRequest): RowsetResponse<LeapViewVisualization.VisualizationEnvelope> | CommonErrors;
 
 @tag("BI")
@@ -871,4 +889,5 @@ op queryDashboardVisualData(@path workspace: WorkspaceId, @path dashboard: strin
 @apigen.authz(#{ mode: "privilege", privilege: "QUERY_DATA" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "filter-options"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "filter", displayName: "filter" }], output: #{ mode: "raw" } })
+@operationId("listDashboardFilterValues")
 op listDashboardFilterValues(@path workspace: string, @path dashboard: string, @path page: string, @path filter: string, @query limit?: ListLimit, @query pageToken?: PageToken, @body body?: DashboardPageQueryRequest): OkJson<DashboardFilterOptionListResponse> | CommonErrors;

--- a/api/typespec/capabilities.tsp
+++ b/api/typespec/capabilities.tsp
@@ -66,4 +66,5 @@ model CapabilitiesResponse {
 @route("/capabilities")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("getCapabilities")
 op getCapabilities(): OkJson<CapabilitiesResponse> | CommonErrors;

--- a/api/typespec/current_user.tsp
+++ b/api/typespec/current_user.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Access;
 
 model EffectivePrivilegesResponse {
   workspaceId: string;
@@ -57,6 +56,7 @@ alias GetCurrentPrincipalOK = OkJson<PrincipalResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @extension("x-leapview-object-scope", "principal")
+@operationId("getCurrentPrincipal")
 op getCurrentPrincipal(): GetCurrentPrincipalOK | CommonErrors;
 
 alias ListCurrentAPITokensOK = OkJson<APITokenListResponse>;
@@ -67,6 +67,7 @@ alias ListCurrentAPITokensOK = OkJson<APITokenListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "principal")
+@operationId("listCurrentAPITokens")
 op listCurrentAPITokens(@query limit?: ListLimit, @query pageToken?: PageToken): ListCurrentAPITokensOK | CommonErrors;
 
 alias CreateCurrentAPITokenCreated = CreatedJson<APITokenCreateResponse>;
@@ -77,6 +78,7 @@ alias CreateCurrentAPITokenCreated = CreatedJson<APITokenCreateResponse>;
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "principal")
+@operationId("createCurrentAPIToken")
 op createCurrentAPIToken(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: APITokenCreateRequest): CreateCurrentAPITokenCreated | CommonErrors;
 
 @tag("Current User")
@@ -85,6 +87,7 @@ op createCurrentAPIToken(@header("Idempotency-Key") idempotencyKey: IdempotencyK
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
 @extension("x-leapview-object-scope", "principal")
+@operationId("revokeCurrentAPIToken")
 op revokeCurrentAPIToken(@path token: string): NoContentResponse | CommonErrors;
 
 alias ListCurrentEffectivePrivilegesOK = OkJson<EffectivePrivilegesResponse>;
@@ -95,6 +98,7 @@ alias ListCurrentEffectivePrivilegesOK = OkJson<EffectivePrivilegesResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @extension("x-leapview-object-scope", "principal")
+@operationId("listCurrentEffectivePrivileges")
 op listCurrentEffectivePrivileges(@query workspace?: string): ListCurrentEffectivePrivilegesOK | CommonErrors;
 
 alias ListCurrentSessionsOK = OkJson<SessionListResponse>;
@@ -105,6 +109,7 @@ alias ListCurrentSessionsOK = OkJson<SessionListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @extension("x-leapview-object-scope", "principal")
+@operationId("listCurrentSessions")
 op listCurrentSessions(@query limit?: ListLimit, @query pageToken?: PageToken): ListCurrentSessionsOK | CommonErrors;
 
 @tag("Current User")
@@ -113,4 +118,5 @@ op listCurrentSessions(@query limit?: ListLimit, @query pageToken?: PageToken): 
 @delete
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @extension("x-leapview-object-scope", "principal")
+@operationId("revokeCurrentSession")
 op revokeCurrentSession(@path session: string): NoContentResponse | CommonErrors;

--- a/api/typespec/dashboard_publications.tsp
+++ b/api/typespec/dashboard_publications.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Dashboard;
 
 enum DashboardPublicationStatus {
   active;
@@ -41,6 +40,7 @@ model DashboardPublicationListResponse {
 @route("/workspaces/{workspace}/dashboard-publications")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
+@operationId("listDashboardPublications")
 op listDashboardPublications(@path workspace: string): OkJson<DashboardPublicationListResponse> | CommonErrors;
 
 @tag("Publications")
@@ -48,6 +48,7 @@ op listDashboardPublications(@path workspace: string): OkJson<DashboardPublicati
 @route("/workspaces/{workspace}/dashboard-publications/{publication}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
+@operationId("getDashboardPublication")
 op getDashboardPublication(@path workspace: string, @path publication: string): OkJson<DashboardPublicationResponse> | CommonErrors;
 
 @tag("Publications")
@@ -55,6 +56,7 @@ op getDashboardPublication(@path workspace: string, @path publication: string): 
 @route("/workspaces/{workspace}/dashboard-publications/{publication}/suspend")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
+@operationId("suspendDashboardPublication")
 op suspendDashboardPublication(@path workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;
 
 @tag("Publications")
@@ -62,6 +64,7 @@ op suspendDashboardPublication(@path workspace: string, @path publication: strin
 @route("/workspaces/{workspace}/dashboard-publications/{publication}/resume")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
+@operationId("resumeDashboardPublication")
 op resumeDashboardPublication(@path workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;
 
 @tag("Publications")
@@ -69,4 +72,5 @@ op resumeDashboardPublication(@path workspace: string, @path publication: string
 @route("/workspaces/{workspace}/dashboard-publications/{publication}/rotate")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
+@operationId("rotateDashboardPublication")
 op rotateDashboardPublication(@path workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;

--- a/api/typespec/deployments.tsp
+++ b/api/typespec/deployments.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Deployment;
 
 enum DeploymentStatus {
   queued;
@@ -63,6 +62,7 @@ model DeploymentListResponse {
 @route("/projects/{project}/deployments")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
+@operationId("listDeployments")
 op listDeployments(@path project: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<DeploymentListResponse> | CommonErrors;
 
 @tag("Deployments")
@@ -70,6 +70,7 @@ op listDeployments(@path project: string, @query limit?: ListLimit, @query pageT
 @route("/projects/{project}/deployments")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "ACTIVATE_DEPLOYMENT" })
+@operationId("createDeployment")
 op createDeployment(@path project: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeploymentCreateRequest): AcceptedJson<DeploymentResponse> | CommonErrors;
 
 @tag("Deployments")
@@ -77,6 +78,7 @@ op createDeployment(@path project: string, @header("Idempotency-Key") idempotenc
 @route("/projects/{project}/deployments/{deployment}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
+@operationId("getDeployment")
 op getDeployment(@path project: string, @path deployment: string): OkJson<DeploymentResponse> | CommonErrors;
 
 @tag("Deployments")
@@ -84,6 +86,7 @@ op getDeployment(@path project: string, @path deployment: string): OkJson<Deploy
 @route("/projects/{project}/deployments/{deployment}/events")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
+@operationId("listDeploymentEvents")
 op listDeploymentEvents(@path project: string, @path deployment: string, @header accept?: string, @header("Last-Event-ID") lastEventId?: string, @query limit?: ListLimit, @query pageToken?: PageToken): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;
 
 @tag("Deployments")
@@ -91,6 +94,7 @@ op listDeploymentEvents(@path project: string, @path deployment: string, @header
 @route("/projects/{project}/deployments/{deployment}/cancel")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "ACTIVATE_DEPLOYMENT" })
+@operationId("cancelDeployment")
 op cancelDeployment(@path project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
 
 @tag("Deployments")
@@ -98,4 +102,5 @@ op cancelDeployment(@path project: string, @path deployment: string, @header("Id
 @route("/projects/{project}/deployments/{deployment}/rollback")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "ACTIVATE_DEPLOYMENT" })
+@operationId("rollbackDeployment")
 op rollbackDeployment(@path project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;

--- a/api/typespec/instance.tsp
+++ b/api/typespec/instance.tsp
@@ -13,4 +13,5 @@ model InstanceResponse {
 @route("/instance")
 @get
 @apigen.authz(#{ mode: "authenticated" })
+@operationId("getInstance")
 op getInstance(): OkJson<InstanceResponse> | CommonErrors;

--- a/api/typespec/managed_data.tsp
+++ b/api/typespec/managed_data.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.ManagedData;
 
 model ManagedConnectionResponse {
   id: string;
@@ -22,6 +21,7 @@ model ManagedConnectionListResponse {
 @route("/projects/{project}/connections")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
+@operationId("listManagedConnections")
 op listManagedConnections(@path project: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ManagedConnectionListResponse> | CommonErrors;
 
 @tag("Managed Data")
@@ -29,10 +29,8 @@ op listManagedConnections(@path project: string, @query limit?: ListLimit, @quer
 @route("/projects/{project}/connections/{connection}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
+@operationId("getManagedConnection")
 op getManagedConnection(@path project: string, @path connection: string): OkJson<ManagedConnectionResponse> | CommonErrors;
-
-@route("/projects/{project}/connections/{connection}")
-namespace ManagedData {
 
 @minLength(1)
 @maxLength(128)
@@ -252,7 +250,7 @@ model ManagedDataUploadSessionListResponse {
 
 @tag("Managed Data")
 @summary("Get the active managed-data revision")
-@route("/active-revision")
+@route("/projects/{project}/connections/{connection}/active-revision")
 @get
 @operationId("getActiveManagedDataRevision")
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
@@ -263,7 +261,7 @@ op getActiveManagedDataRevision(
 
 @tag("Managed Data")
 @summary("List immutable managed-data revisions")
-@route("/revisions")
+@route("/projects/{project}/connections/{connection}/revisions")
 @get
 @operationId("listManagedDataRevisions")
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
@@ -276,7 +274,7 @@ op listManagedDataRevisions(
 
 @tag("Managed Data")
 @summary("Get an immutable managed-data revision")
-@route("/revisions/{revision}")
+@route("/projects/{project}/connections/{connection}/revisions/{revision}")
 @get
 @operationId("getManagedDataRevision")
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
@@ -288,7 +286,7 @@ op getManagedDataRevision(
 
 @tag("Managed Data")
 @summary("Create a managed-data upload session from a canonical manifest")
-@route("/upload-sessions")
+@route("/projects/{project}/connections/{connection}/upload-sessions")
 @post
 @operationId("createManagedDataUploadSession")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -301,7 +299,7 @@ op createManagedDataUploadSession(
 
 @tag("Managed Data")
 @summary("List managed-data upload sessions")
-@route("/upload-sessions")
+@route("/projects/{project}/connections/{connection}/upload-sessions")
 @get
 @operationId("listManagedDataUploadSessions")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -314,7 +312,7 @@ op listManagedDataUploadSessions(
 
 @tag("Managed Data")
 @summary("Get a managed-data upload session")
-@route("/upload-sessions/{uploadSession}")
+@route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}")
 @get
 @operationId("getManagedDataUploadSession")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -326,7 +324,7 @@ op getManagedDataUploadSession(
 
 @tag("Managed Data")
 @summary("Cancel a managed-data upload session")
-@route("/upload-sessions/{uploadSession}/cancel")
+@route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}/cancel")
 @post
 @operationId("cancelManagedDataUploadSession")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -339,7 +337,7 @@ op cancelManagedDataUploadSession(
 
 @tag("Managed Data")
 @summary("Finalize a managed-data upload session")
-@route("/upload-sessions/{uploadSession}/finalize")
+@route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}/finalize")
 @post
 @operationId("finalizeManagedDataUploadSession")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -352,7 +350,7 @@ op finalizeManagedDataUploadSession(
 
 @tag("Managed Data")
 @summary("List or stream upload-session events")
-@route("/upload-sessions/{uploadSession}/events")
+@route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}/events")
 @get
 @operationId("listManagedDataUploadSessionEvents")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -365,5 +363,3 @@ op listManagedDataUploadSessionEvents(
   @query limit?: ManagedDataPageLimit,
   @query pageToken?: ManagedDataPageToken,
 ): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;
-
-}

--- a/api/typespec/projects.tsp
+++ b/api/typespec/projects.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Project;
 
 model ProjectResponse {
   id: string;
@@ -36,6 +35,7 @@ model ProjectWorkspaceListResponse {
 @route("/projects")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("listProjects")
 op listProjects(@query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ProjectListResponse> | CommonErrors;
 
 @tag("Projects")
@@ -43,6 +43,7 @@ op listProjects(@query limit?: ListLimit, @query pageToken?: PageToken): OkJson<
 @route("/projects/{project}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("getProject")
 op getProject(@path project: string): OkJson<ProjectResponse> | CommonErrors;
 
 @tag("Projects")
@@ -50,4 +51,5 @@ op getProject(@path project: string): OkJson<ProjectResponse> | CommonErrors;
 @route("/projects/{project}/workspaces")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
+@operationId("listProjectWorkspaces")
 op listProjectWorkspaces(@path project: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ProjectWorkspaceListResponse> | CommonErrors;

--- a/api/typespec/refresh_runs.tsp
+++ b/api/typespec/refresh_runs.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Refresh;
 
 model RefreshRunCreateRequest {
   pipelineId: string;
@@ -37,6 +36,7 @@ alias ListRefreshRunsOK = OkJson<RefreshRunListResponse>;
 @route("/workspaces/{workspace}/refresh-runs")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("listRefreshRuns")
 op listRefreshRuns(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListRefreshRunsOK | CommonErrors;
 
 alias CreateRefreshRunAccepted = AcceptedJson<RefreshRunResponse>;
@@ -46,6 +46,7 @@ alias CreateRefreshRunAccepted = AcceptedJson<RefreshRunResponse>;
 @route("/workspaces/{workspace}/refresh-runs")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("createRefreshRun")
 op createRefreshRun(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: RefreshRunCreateRequest): CreateRefreshRunAccepted | CommonErrors;
 
 alias GetRefreshRunOK = OkJson<RefreshRunResponse>;
@@ -55,6 +56,7 @@ alias GetRefreshRunOK = OkJson<RefreshRunResponse>;
 @route("/workspaces/{workspace}/refresh-runs/{run}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("getRefreshRun")
 op getRefreshRun(@path workspace: string, @path run: string): GetRefreshRunOK | CommonErrors;
 
 @tag("Refresh Runs")
@@ -62,6 +64,7 @@ op getRefreshRun(@path workspace: string, @path run: string): GetRefreshRunOK | 
 @route("/workspaces/{workspace}/refresh-runs/{run}/events")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("listRefreshRunEvents")
 op listRefreshRunEvents(@path workspace: string, @path run: string, @header accept?: string, @header("Last-Event-ID") lastEventId?: string, @query limit?: ListLimit, @query pageToken?: PageToken): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;
 
 @tag("Refresh Runs")
@@ -69,4 +72,5 @@ op listRefreshRunEvents(@path workspace: string, @path run: string, @header acce
 @route("/workspaces/{workspace}/refresh-runs/{run}/cancel")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("cancelRefreshRun")
 op cancelRefreshRun(@path workspace: string, @path run: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<RefreshRunResponse> | CommonErrors;

--- a/api/typespec/releases.tsp
+++ b/api/typespec/releases.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Release;
 
 enum ReleaseStatus {
   draft;
@@ -58,6 +57,7 @@ model ReleaseArtifactResponse {
 @route("/projects/{project}/releases")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "DEPLOY" })
+@operationId("listReleases")
 op listReleases(@path project: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ReleaseListResponse> | CommonErrors;
 
 @tag("Releases")
@@ -65,6 +65,7 @@ op listReleases(@path project: string, @query limit?: ListLimit, @query pageToke
 @route("/projects/{project}/releases")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "DEPLOY" })
+@operationId("createRelease")
 op createRelease(@path project: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: ReleaseCreateRequest): CreatedJson<ReleaseResponse> | CommonErrors;
 
 @tag("Releases")
@@ -72,6 +73,7 @@ op createRelease(@path project: string, @header("Idempotency-Key") idempotencyKe
 @route("/projects/{project}/releases/{release}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "DEPLOY" })
+@operationId("getRelease")
 op getRelease(@path project: string, @path release: string): OkJson<ReleaseResponse> | CommonErrors;
 
 @tag("Releases")
@@ -80,6 +82,7 @@ op getRelease(@path project: string, @path release: string): OkJson<ReleaseRespo
 @put
 @apigen.authz(#{ mode: "privilege", privilege: "DEPLOY" })
 @apigen.manual
+@operationId("uploadReleaseArtifact")
 op uploadReleaseArtifact(@path project: string, @path release: string, @path workspace: string, @header contentType: "application/octet-stream", @header("Content-Digest") contentDigest: string, @body body: bytes): CreatedJson<ReleaseArtifactResponse> | CommonErrors;
 
 @tag("Releases")
@@ -87,6 +90,7 @@ op uploadReleaseArtifact(@path project: string, @path release: string, @path wor
 @route("/projects/{project}/releases/{release}/finalize")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "DEPLOY" })
+@operationId("finalizeRelease")
 op finalizeRelease(@path project: string, @path release: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<ReleaseResponse> | CommonErrors;
 
 @tag("Releases")
@@ -94,4 +98,5 @@ op finalizeRelease(@path project: string, @path release: string, @header("Idempo
 @route("/projects/{project}/releases/{release}/events")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "DEPLOY" })
+@operationId("listReleaseEvents")
 op listReleaseEvents(@path project: string, @path release: string, @header accept?: string, @header("Last-Event-ID") lastEventId?: string, @query limit?: ListLimit, @query pageToken?: PageToken): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;

--- a/api/typespec/search.tsp
+++ b/api/typespec/search.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Workspace;
 
 enum SearchResultType {
   workspace,
@@ -69,6 +68,7 @@ alias SearchOK = OkJson<SearchResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @apigen.cli(#{ command: #["search"], args: #[#{ source: "query", name: "q", displayName: "query" }], output: #{ mode: "raw" } })
+@operationId("search")
 op search(
   @query q?: string,
   @query workspace?: string[],

--- a/api/typespec/upload_s3_multipart.tsp
+++ b/api/typespec/upload_s3_multipart.tsp
@@ -70,7 +70,7 @@ model ManagedDataS3MultipartCompleteRequest {
 
 @tag("Managed Data")
 @summary("Create an S3 multipart upload for a session file")
-@route("/upload-sessions/{uploadSession}/s3-multipart-uploads")
+@route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}/s3-multipart-uploads")
 @post
 @operationId("createManagedDataS3MultipartUpload")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -84,7 +84,7 @@ op createManagedDataS3MultipartUpload(
 
 @tag("Managed Data")
 @summary("Sign one S3 multipart upload part")
-@route("/upload-sessions/{uploadSession}/s3-multipart-uploads/{multipartUpload}/parts/{partNumber}/sign")
+@route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}/s3-multipart-uploads/{multipartUpload}/parts/{partNumber}/sign")
 @post
 @operationId("signManagedDataS3MultipartPart")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -100,7 +100,7 @@ op signManagedDataS3MultipartPart(
 
 @tag("Managed Data")
 @summary("Complete an S3 multipart upload")
-@route("/upload-sessions/{uploadSession}/s3-multipart-uploads/{multipartUpload}/complete")
+@route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}/s3-multipart-uploads/{multipartUpload}/complete")
 @post
 @operationId("completeManagedDataS3MultipartUpload")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
@@ -115,7 +115,7 @@ op completeManagedDataS3MultipartUpload(
 
 @tag("Managed Data")
 @summary("Abort an S3 multipart upload")
-@route("/upload-sessions/{uploadSession}/s3-multipart-uploads/{multipartUpload}/abort")
+@route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}/s3-multipart-uploads/{multipartUpload}/abort")
 @post
 @operationId("abortManagedDataS3MultipartUpload")
 @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })

--- a/api/typespec/workspaces.tsp
+++ b/api/typespec/workspaces.tsp
@@ -1,8 +1,7 @@
 using Http;
 using TypeSpec.OpenAPI;
 
-@route("/api/v1")
-namespace LeapViewAPI;
+namespace LeapViewAPI.Workspace;
 
 model WorkspaceResponse {
   id: string;
@@ -104,6 +103,7 @@ alias ListWorkspacesOK = OkJson<WorkspaceListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @apigen.cli(#{ command: #["workspaces", "list"], output: #{ mode: "raw" } })
+@operationId("listWorkspaces")
 op listWorkspaces(@query limit?: ListLimit, @query pageToken?: PageToken): ListWorkspacesOK | CommonErrors;
 
 @tag("Workspaces")
@@ -111,6 +111,7 @@ op listWorkspaces(@query limit?: ListLimit, @query pageToken?: PageToken): ListW
 @route("/workspaces/{workspace}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
+@operationId("getWorkspace")
 op getWorkspace(@path workspace: string): OkJson<WorkspaceResponse> | CommonErrors;
 
 alias ListWorkspaceAssetEdgesOK = OkJson<AssetEdgeListResponse>;
@@ -121,6 +122,7 @@ alias ListWorkspaceAssetEdgesOK = OkJson<AssetEdgeListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @apigen.cli(#{ command: #["assets", "edges"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
+@operationId("listWorkspaceAssetEdges")
 op listWorkspaceAssetEdges(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListWorkspaceAssetEdgesOK | CommonErrors;
 
 alias ListWorkspaceAssetsOK = OkJson<AssetListResponse>;
@@ -131,6 +133,7 @@ alias ListWorkspaceAssetsOK = OkJson<AssetListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @apigen.cli(#{ command: #["assets", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
+@operationId("listWorkspaceAssets")
 op listWorkspaceAssets(@path workspace: string, @query type?: string, @query q?: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListWorkspaceAssetsOK | CommonErrors;
 
 @tag("Workspaces")
@@ -138,6 +141,7 @@ op listWorkspaceAssets(@path workspace: string, @query type?: string, @query q?:
 @route("/workspaces/{workspace}/active-asset-graph")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@operationId("getWorkspaceActiveAssetGraph")
 op getWorkspaceActiveAssetGraph(@path workspace: string): OkJson<WorkspaceAssetGraphResponse> | CommonErrors;
 
 @tag("Workspaces")
@@ -147,6 +151,7 @@ op getWorkspaceActiveAssetGraph(@path workspace: string): OkJson<WorkspaceAssetG
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "workspace-asset")
 @apigen.cli(#{ command: #["assets", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "assetId", displayName: "asset-id" }], output: #{ mode: "raw" } })
+@operationId("getWorkspaceAsset")
 op getWorkspaceAsset(@path workspace: string, @path assetId: string): OkJson<AssetResponse> | CommonErrors;
 
 @tag("Workspaces")
@@ -156,4 +161,5 @@ op getWorkspaceAsset(@path workspace: string, @path assetId: string): OkJson<Ass
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "workspace-asset")
 @apigen.cli(#{ command: #["assets", "lineage"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "assetId", displayName: "asset-id" }], output: #{ mode: "raw" } })
+@operationId("getWorkspaceAssetLineage")
 op getWorkspaceAssetLineage(@path workspace: string, @path assetId: string): OkJson<AssetLineageResponse> | CommonErrors;

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.12
 
 require (
 	cuelang.org/go v0.16.1
-	github.com/Yacobolo/toolbelt/apigen v0.6.5
+	github.com/Yacobolo/toolbelt/apigen v0.7.1
 	github.com/alexedwards/argon2id v1.0.0
 	github.com/apache/arrow-go/v18 v18.5.1
 	github.com/aws/aws-sdk-go-v2 v1.42.1
@@ -39,6 +39,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
+	golang.org/x/tools v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 	maragu.dev/gomponents v1.3.0
 	maragu.dev/gomponents-datastar v0.3.3
@@ -168,7 +169,6 @@ require (
 	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
-	golang.org/x/tools v0.47.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/CAFxX/httpcompression v0.0.9 h1:0ue2X8dOLEpxTm8tt+OdHcgA+gbDge0OqFQWGKSqgrg=
 github.com/CAFxX/httpcompression v0.0.9/go.mod h1:XX8oPZA+4IDcfZ0A71Hz0mZsv/YJOgYygkFhizVPilM=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Yacobolo/toolbelt/apigen v0.6.5 h1:aO2u5gIliKcz80Iw3cjGQvih0EaqkcZuHDwZfHsbxL4=
-github.com/Yacobolo/toolbelt/apigen v0.6.5/go.mod h1:iKKpG2gMSuLNegtRpL5la1z5s9YrBsZwdAHaRBsmvtE=
+github.com/Yacobolo/toolbelt/apigen v0.7.1 h1:TcYOnNWwIabNg64LDR+w65PNA8DgPn0gQcbX/b90XAU=
+github.com/Yacobolo/toolbelt/apigen v0.7.1/go.mod h1:iKKpG2gMSuLNegtRpL5la1z5s9YrBsZwdAHaRBsmvtE=
 github.com/alexedwards/argon2id v1.0.0 h1:wJzDx66hqWX7siL/SRUmgz3F8YMrd/nfX/xHHcQQP0w=
 github.com/alexedwards/argon2id v1.0.0/go.mod h1:tYKkqIjzXvZdzPvADMWOEZ+l6+BD6CtBXMj5fnJppiw=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -39,7 +39,7 @@ func (r apiSnapshotWorkspaceRepository) AssetVersions(context.Context, workspace
 	return nil, nil
 }
 
-func TestAPIGenUsesTypeSpecV065(t *testing.T) {
+func TestAPIGenUsesTypeSpecV071(t *testing.T) {
 	root := projectRoot(t)
 	manifest, err := os.ReadFile(filepath.Join(root, "api", "apigen.yaml"))
 	if err != nil {
@@ -59,6 +59,24 @@ func TestAPIGenUsesTypeSpecV065(t *testing.T) {
 	if strings.Contains(manifestText, "cue_dir:") {
 		t.Fatalf("manifest should not use cue_dir after APIGen v0.3.0 migration")
 	}
+	for _, want := range []string{
+		"unmatched: error",
+		"LeapViewAPI:",
+		"LeapViewAPI.Access:",
+		"LeapViewAPI.Agent:",
+		"LeapViewAPI.Dashboard:",
+		"LeapViewAPI.Deployment:",
+		"LeapViewAPI.ManagedData:",
+		"LeapViewAPI.Project:",
+		"LeapViewAPI.Refresh:",
+		"LeapViewAPI.Release:",
+		"LeapViewAPI.Workspace:",
+		"import_path: github.com/Yacobolo/leapview/internal/app/api/gen",
+	} {
+		if !strings.Contains(manifestText, want) {
+			t.Fatalf("manifest should define the coalesced capability package plan setting %q", want)
+		}
+	}
 
 	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
 	if err != nil {
@@ -74,16 +92,16 @@ func TestAPIGenUsesTypeSpecV065(t *testing.T) {
 		}
 	}
 	for _, want := range []string{
-		"github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 typespec-compile",
-		"github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5 all",
+		"github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 typespec-compile",
+		"github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1 all",
 	} {
 		if !strings.Contains(taskText, want) {
 			t.Fatalf("Taskfile.yml missing generation command %q", want)
 		}
 	}
-	for _, forbidden := range []string{"cue-compile", "apigen@v0.2.0", "apigen@v0.3.0", "apigen@v0.3.2", "apigen@v0.3.3", "apigen@v0.4.0", "apigen@v0.5.0", "apigen@v0.5.1", "apigen@v0.5.2", "apigen@v0.5.3", "apigen@v0.6.0", "apigen@v0.6.1", "apigen@v0.6.2", "apigen@v0.6.3", "apigen@v0.6.4", "apigenpostprocess"} {
+	for _, forbidden := range []string{"cue-compile", "apigen@v0.2.0", "apigen@v0.3.0", "apigen@v0.3.2", "apigen@v0.3.3", "apigen@v0.4.0", "apigen@v0.5.0", "apigen@v0.5.1", "apigen@v0.5.2", "apigen@v0.5.3", "apigen@v0.6.0", "apigen@v0.6.1", "apigen@v0.6.2", "apigen@v0.6.3", "apigen@v0.6.4", "apigen@v0.6.5", "apigen@v0.7.0", "apigenpostprocess"} {
 		if strings.Contains(taskText, forbidden) {
-			t.Fatalf("Taskfile.yml should not contain %q after APIGen v0.6.5 migration", forbidden)
+			t.Fatalf("Taskfile.yml should not contain %q after APIGen v0.7.1 migration", forbidden)
 		}
 	}
 
@@ -100,7 +118,7 @@ func TestAPIGenUsesTypeSpecV065(t *testing.T) {
 	}
 
 	if _, err := os.Stat(filepath.Join(root, "internal", "tools", "apigenpostprocess")); !os.IsNotExist(err) {
-		t.Fatalf("APIGen v0.6.5 should not require a postprocessor, stat error = %v", err)
+		t.Fatalf("APIGen v0.7.1 should not require a postprocessor, stat error = %v", err)
 	}
 	for path, forbidden := range map[string]string{
 		filepath.Join(root, "api", "typespec", "bi.tsp"):                        "toolbelt#34",
@@ -111,7 +129,83 @@ func TestAPIGenUsesTypeSpecV065(t *testing.T) {
 			t.Fatalf("read %s: %v", path, err)
 		}
 		if strings.Contains(string(content), forbidden) {
-			t.Fatalf("APIGen v0.6.5 superseded workaround %q in %s", forbidden, path)
+			t.Fatalf("APIGen v0.7.1 superseded workaround %q in %s", forbidden, path)
+		}
+	}
+}
+
+func TestAPIGenIRAssignsCapabilityNamespaces(t *testing.T) {
+	root := projectRoot(t)
+	content, err := os.ReadFile(filepath.Join(root, "api", "gen", "json-ir.json"))
+	if err != nil {
+		t.Fatalf("read APIGen IR: %v", err)
+	}
+
+	var document struct {
+		Endpoints []struct {
+			OperationID string   `json:"operation_id"`
+			Namespace   string   `json:"namespace"`
+			Tags        []string `json:"tags"`
+		} `json:"endpoints"`
+		Schemas map[string]struct {
+			Namespace string `json:"namespace"`
+		} `json:"schemas"`
+	}
+	if err := json.Unmarshal(content, &document); err != nil {
+		t.Fatalf("decode APIGen IR: %v", err)
+	}
+	if got, want := len(document.Endpoints), 132; got != want {
+		t.Fatalf("APIGen IR endpoints = %d, want %d", got, want)
+	}
+
+	namespaceByTag := map[string]string{
+		"System":       "LeapViewAPI",
+		"Instance":     "LeapViewAPI",
+		"Current User": "LeapViewAPI.Access",
+		"Access":       "LeapViewAPI.Access",
+		"Audit":        "LeapViewAPI.Access",
+		"Agent":        "LeapViewAPI.Agent",
+		"BI":           "LeapViewAPI.Dashboard",
+		"Publications": "LeapViewAPI.Dashboard",
+		"Deployments":  "LeapViewAPI.Deployment",
+		"Managed Data": "LeapViewAPI.ManagedData",
+		"Projects":     "LeapViewAPI.Project",
+		"Refresh Runs": "LeapViewAPI.Refresh",
+		"Releases":     "LeapViewAPI.Release",
+		"Search":       "LeapViewAPI.Workspace",
+		"Workspaces":   "LeapViewAPI.Workspace",
+	}
+	for _, endpoint := range document.Endpoints {
+		if len(endpoint.Tags) != 1 {
+			t.Errorf("endpoint %q tags = %v, want exactly one ownership tag", endpoint.OperationID, endpoint.Tags)
+			continue
+		}
+		want, ok := namespaceByTag[endpoint.Tags[0]]
+		if !ok {
+			t.Errorf("endpoint %q has unmapped ownership tag %q", endpoint.OperationID, endpoint.Tags[0])
+			continue
+		}
+		if endpoint.Namespace != want {
+			t.Errorf("endpoint %q namespace = %q, want %q for tag %q", endpoint.OperationID, endpoint.Namespace, want, endpoint.Tags[0])
+		}
+	}
+
+	allowedSchemaNamespaces := map[string]struct{}{
+		"LeapViewAPI":             {},
+		"LeapViewAPI.Access":      {},
+		"LeapViewAPI.Agent":       {},
+		"LeapViewAPI.Dashboard":   {},
+		"LeapViewAPI.Deployment":  {},
+		"LeapViewAPI.ManagedData": {},
+		"LeapViewAPI.Project":     {},
+		"LeapViewAPI.Refresh":     {},
+		"LeapViewAPI.Release":     {},
+		"LeapViewAPI.Workspace":   {},
+		"LeapViewVisualization":   {},
+	}
+	for name, schema := range document.Schemas {
+		if _, ok := allowedSchemaNamespaces[schema.Namespace]; !ok {
+			t.Errorf("schema %q namespace = %q, want an explicit capability, root, or external namespace", name, schema.Namespace)
 		}
 	}
 }

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -104,6 +104,13 @@ func TestAPIGenUsesTypeSpecV071(t *testing.T) {
 			t.Fatalf("Taskfile.yml should not contain %q after APIGen v0.7.1 migration", forbidden)
 		}
 	}
+	buildSources, err := os.ReadFile(filepath.Join(root, "scripts", "generate_build_sources.sh"))
+	if err != nil {
+		t.Fatalf("read container source-generation script: %v", err)
+	}
+	if want := "APIGEN=github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1"; !strings.Contains(string(buildSources), want) {
+		t.Fatalf("container source-generation script missing APIGen pin %q", want)
+	}
 
 	ir, err := os.ReadFile(filepath.Join(root, "api", "gen", "json-ir.json"))
 	if err != nil {

--- a/scripts/generate_build_sources.sh
+++ b/scripts/generate_build_sources.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-APIGEN=github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.6.5
+APIGEN=github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.1
 
 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0 generate
 go run ./internal/app/tools/configgen


### PR DESCRIPTION
## Summary

Assign LeapView's TypeSpec HTTP contracts to capability-owned namespaces while intentionally coalescing every local namespace back into the existing `internal/app/api/gen` package.

This is the compatibility checkpoint for capability-owned APIGen generation: ownership is now explicit in the contract IR, but application imports, generated dispatcher location, routes, operation IDs, OpenAPI, CLI commands, and public tooling inventories remain unchanged.

## Namespace ownership

- `LeapViewAPI.Access`: access control, current-user, and audit contracts
- `LeapViewAPI.Agent`: agent conversations and runs
- `LeapViewAPI.Dashboard`: BI reads and dashboard publications
- `LeapViewAPI.Deployment`: deployments
- `LeapViewAPI.ManagedData`: managed connections, revisions, sessions, TUS, and S3 multipart transport
- `LeapViewAPI.Project`: projects
- `LeapViewAPI.Refresh`: refresh runs
- `LeapViewAPI.Release`: releases
- `LeapViewAPI.Workspace`: workspace discovery and search
- `LeapViewAPI`: service-wide protocol, capabilities, and instance identity
- `LeapViewVisualization`: remains externally owned through `contract_imports`

## Compatibility design

- Replaces flat `go_out` with `unmatched: error` and an explicit mapping for every local namespace.
- Maps all namespaces to the same existing directory, package, import path, and generated filenames.
- Pins every APIGen generation target and the Go module to `v0.7.1`.
- Makes all 132 public operation IDs explicit so namespace changes cannot rename API operations.
- Flattens the previous nested managed-data routing scope into capability-owned declarations while preserving every effective route.
- Adds exhaustive IR tests that map each endpoint tag to its expected capability namespace and reject unexpected schema namespaces.
- Adds manifest assertions for the complete coalesced package plan.

## Deliberately unchanged

- No generated package is moved.
- No aggregate dispatcher is added yet.
- No application import changes are required.
- Canonical `docs/api/openapi.yaml` has no diff after regeneration.
- Public routes, operation IDs, CLI registry, and tool inventory are unchanged.

## Validation

- `task generated:check`
- `task ci`
  - complete Go and browser suites
  - TypeScript typechecks
  - `go vet ./...`
  - selected race suites
  - architecture checks
  - live Datastar route QA
  - deployment checks
  - Terraform validation/tests
- Focused namespace and APIGen pin tests after final metadata assertions
- `git diff --check`

Depends on APIGen v0.7.1 / toolbelt PR #51, which preserves external contract ownership in package plans.

Linear: LEA-73
