### PR TITLE
Close visual correctness release blockers

### DIFF
--- a/api/visualization/main.tsp
+++ b/api/visualization/main.tsp
@@ -399,6 +399,7 @@ model HierarchyVisualizationPresentation extends VisualizationPresentation {
 model PolarVisualizationPresentation extends VisualizationPresentation {
   `minimum`?: float64;
   `maximum`?: float64;
+  `target`?: float64;
   `showPointer`: boolean;
   `area`?: boolean;
   `progressWidth`?: float64;

--- a/dashboards/workspaces/visuals/dashboards/visual-showcase.yaml
+++ b/dashboards/workspaces/visuals/dashboards/visual-showcase.yaml
@@ -766,12 +766,20 @@ spec:
     total_orders_gauge:
       title: Total orders gauge
       type: gauge
+      presentation:
+        minimum: 0
+        maximum: 120000
+        target: 100000
       query:
         measures:
           order_count: null
     review_gauge:
       title: Average review gauge
       type: gauge
+      presentation:
+        minimum: 0
+        maximum: 5
+        target: 4.5
       query:
         measures:
           review_score: null
@@ -781,6 +789,7 @@ spec:
       presentation:
         minimum: 0
         maximum: 5
+        target: 4.5
         progress_width: 16
         thresholds:
           - value: 3

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -43725,6 +43725,10 @@ components:
           type: number
           format: double
           example: !!float 1
+        target:
+          type: number
+          format: double
+          example: !!float 1
         showPointer:
           type: boolean
           example: true
@@ -43748,6 +43752,7 @@ components:
         minimum: !!float 1
         progressWidth: !!float 1
         showPointer: true
+        target: !!float 1
         thresholds:
           - tone: neutral
             value: !!float 1
@@ -43788,6 +43793,7 @@ components:
           minimum: !!float 1
           progressWidth: !!float 1
           showPointer: true
+          target: !!float 1
           thresholds:
             - tone: neutral
               value: !!float 1

--- a/docs/visuals/gauge.md
+++ b/docs/visuals/gauge.md
@@ -6,7 +6,7 @@ Every preview on this page is generated from the YAML shown below it using a fix
 
 ## Basic
 
-Use the `single_value` shape with one measure when the value is meaningful against an implied range.
+Use the `single_value` shape with one measure and an explicit meaningful range.
 
 {{< visual id="total_orders_gauge" >}}
 
@@ -15,6 +15,10 @@ visuals:
   total_orders_gauge:
     title: Total orders gauge
     type: gauge
+    presentation:
+      minimum: 0
+      maximum: 120000
+      target: 100000
     query:
       measures:
         order_count: null
@@ -31,6 +35,10 @@ visuals:
   review_gauge:
     title: Average review gauge
     type: gauge
+    presentation:
+      minimum: 0
+      maximum: 5
+      target: 4.5
     query:
       measures:
         review_score: null
@@ -50,6 +58,7 @@ visuals:
     presentation:
       minimum: 0
       maximum: 5
+      target: 4.5
       progress_width: 16
       thresholds:
         - value: 3

--- a/internal/app/tools/visualdocgen/reference_fields.go
+++ b/internal/app/tools/visualdocgen/reference_fields.go
@@ -53,8 +53,8 @@ var presentationFieldReferences = map[string]visualdocs.FieldReference{
 	"label_position": field("string", "renderer default", []string{"top", "bottom", "left", "right", "inside", "outside"}, "Positions value labels relative to their marks."),
 	"layout":         field("string", "force", []string{"force", "circular"}, "Selects the graph node layout algorithm."),
 	"legend":         field("boolean | string", "false", []string{"true", "false", "top", "bottom", "left", "right"}, "Shows the legend and optionally selects its position."),
-	"maximum":        field("number", "automatic", nil, "Sets the upper bound of a gauge scale."),
-	"minimum":        field("number", "0", nil, "Sets the lower bound of a gauge scale."),
+	"maximum":        field("number", "required for gauges", nil, "Sets the explicit upper bound of a gauge scale."),
+	"minimum":        field("number", "required for gauges", nil, "Sets the explicit lower bound of a gauge scale."),
 	"node_gap":       field("number", "8", []string{"0 or greater"}, "Sets the vertical gap between Sankey nodes."),
 	"note":           field("string", "none", nil, "Adds supporting context below a KPI value."),
 	"orientation":    field("string", "renderer default", []string{"horizontal", "vertical"}, "Controls the direction of tree or Sankey layout."),
@@ -71,6 +71,7 @@ var presentationFieldReferences = map[string]visualdocs.FieldReference{
 	"stacked":        booleanOption("false", "Stacks compatible bar, column, line, or area series."),
 	"step":           booleanOption("false", "Draws line segments as discrete steps."),
 	"symbol_size":    field("number", "renderer default", []string{"positive number"}, "Sets point symbol size for line, area, and scatter series."),
+	"target":         field("number", "none", nil, "Adds a labeled gauge target that must fall within the configured domain."),
 	"thresholds":     field("threshold list", "none", nil, "Maps gauge thresholds to scale positions and colors."),
 	"tone":           field("string", "neutral", []string{"neutral", "ink", "success", "warning", "danger"}, "Sets the semantic accent tone of a KPI card."),
 }

--- a/internal/dashboard/report/contracts_presentation_test.go
+++ b/internal/dashboard/report/contracts_presentation_test.go
@@ -47,3 +47,59 @@ func TestValidateVisualPresentationAcceptsEChartsTypedValues(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateGaugePresentationRequiresTruthfulDomain(t *testing.T) {
+	t.Parallel()
+
+	minimum, maximum, below, above := 0.0, 5.0, -1.0, 6.0
+	tests := []struct {
+		name         string
+		presentation VisualPresentation
+		want         string
+	}{
+		{name: "missing domain", presentation: VisualPresentation{}, want: "requires presentation.minimum and presentation.maximum"},
+		{name: "missing maximum", presentation: VisualPresentation{Minimum: &minimum}, want: "requires presentation.minimum and presentation.maximum"},
+		{name: "missing minimum", presentation: VisualPresentation{Maximum: &maximum}, want: "requires presentation.minimum and presentation.maximum"},
+		{name: "threshold below domain", presentation: VisualPresentation{Minimum: &minimum, Maximum: &maximum, Thresholds: []VisualThreshold{{Value: -1, Tone: "danger"}}}, want: "threshold -1 must be within"},
+		{name: "threshold above domain", presentation: VisualPresentation{Minimum: &minimum, Maximum: &maximum, Thresholds: []VisualThreshold{{Value: 6, Tone: "success"}}}, want: "threshold 6 must be within"},
+		{name: "target below domain", presentation: VisualPresentation{Minimum: &minimum, Maximum: &maximum, Target: &below}, want: "target -1 must be within"},
+		{name: "target above domain", presentation: VisualPresentation{Minimum: &minimum, Maximum: &maximum, Target: &above}, want: "target 6 must be within"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateVisualPresentation("gauge", Visual{Type: "gauge", Presentation: test.presentation})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateVisualPresentation() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateGaugePresentationAcceptsExplicitDomain(t *testing.T) {
+	t.Parallel()
+
+	minimum, maximum, target := 0.0, 5.0, 4.5
+	visual := Visual{Type: "gauge", Presentation: VisualPresentation{
+		Minimum: &minimum,
+		Maximum: &maximum,
+		Target:  &target,
+		Thresholds: []VisualThreshold{
+			{Value: 3, Tone: "danger"},
+			{Value: 4, Tone: "warning"},
+			{Value: 5, Tone: "success"},
+		},
+	}}
+	if err := validateVisualPresentation("gauge", visual); err != nil {
+		t.Fatalf("validateVisualPresentation(): %v", err)
+	}
+}
+
+func TestValidateVisualPresentationRejectsGaugeTargetOnOtherVisuals(t *testing.T) {
+	t.Parallel()
+
+	target := 4.5
+	err := validateVisualPresentation("line", Visual{Type: "line", Presentation: VisualPresentation{Target: &target}})
+	if err == nil || !strings.Contains(err.Error(), "only valid for gauge") {
+		t.Fatalf("validateVisualPresentation() error = %v, want gauge-only target error", err)
+	}
+}

--- a/internal/dashboard/report/contracts_types.go
+++ b/internal/dashboard/report/contracts_types.go
@@ -161,6 +161,7 @@ type VisualPresentation struct {
 	Focus         string            `yaml:"focus" json:"focus,omitempty"`
 	Minimum       *float64          `yaml:"minimum" json:"minimum,omitempty"`
 	Maximum       *float64          `yaml:"maximum" json:"maximum,omitempty"`
+	Target        *float64          `yaml:"target" json:"target,omitempty"`
 	ProgressWidth float64           `yaml:"progress_width" json:"progressWidth,omitempty"`
 	Thresholds    []VisualThreshold `yaml:"thresholds" json:"thresholds,omitempty"`
 	Note          string            `yaml:"note" json:"note,omitempty"`

--- a/internal/dashboard/report/contracts_validation.go
+++ b/internal/dashboard/report/contracts_validation.go
@@ -390,8 +390,17 @@ func validateVisualPresentation(name string, visual Visual) error {
 	if (presentation.Minimum != nil || presentation.Maximum != nil || presentation.ProgressWidth > 0 || len(presentation.Thresholds) > 0) && visual.Type != "gauge" && visual.Type != "kpi" {
 		return fmt.Errorf("visual %q threshold presentation is only valid for gauge or kpi", name)
 	}
+	if presentation.Target != nil && visual.Type != "gauge" {
+		return fmt.Errorf("visual %q presentation.target is only valid for gauge", name)
+	}
+	if visual.Type == "gauge" && (presentation.Minimum == nil || presentation.Maximum == nil) {
+		return fmt.Errorf("visual %q type gauge requires presentation.minimum and presentation.maximum", name)
+	}
 	if presentation.Minimum != nil && presentation.Maximum != nil && *presentation.Minimum >= *presentation.Maximum {
 		return fmt.Errorf("visual %q presentation.minimum must be less than maximum", name)
+	}
+	if visual.Type == "gauge" && presentation.Target != nil && (*presentation.Target < *presentation.Minimum || *presentation.Target > *presentation.Maximum) {
+		return fmt.Errorf("visual %q presentation target %v must be within [%v, %v]", name, *presentation.Target, *presentation.Minimum, *presentation.Maximum)
 	}
 	previous := -1.0e308
 	for _, threshold := range presentation.Thresholds {
@@ -400,6 +409,9 @@ func validateVisualPresentation(name string, visual Visual) error {
 		}
 		if !oneOf(threshold.Tone, "neutral", "ink", "success", "warning", "danger") {
 			return fmt.Errorf("visual %q has unsupported threshold tone %q", name, threshold.Tone)
+		}
+		if visual.Type == "gauge" && (threshold.Value < *presentation.Minimum || threshold.Value > *presentation.Maximum) {
+			return fmt.Errorf("visual %q presentation threshold %v must be within [%v, %v]", name, threshold.Value, *presentation.Minimum, *presentation.Maximum)
 		}
 		previous = threshold.Value
 	}

--- a/internal/dashboard/visualization/ir/models.gen.go
+++ b/internal/dashboard/visualization/ir/models.gen.go
@@ -168,6 +168,7 @@ type PolarVisualizationPresentation struct {
 	VisualizationPresentation
 	Minimum       *float64                  `json:"minimum,omitempty"`
 	Maximum       *float64                  `json:"maximum,omitempty"`
+	Target        *float64                  `json:"target,omitempty"`
 	ShowPointer   bool                      `json:"showPointer"`
 	Area          *bool                     `json:"area,omitempty"`
 	ProgressWidth *float64                  `json:"progressWidth,omitempty"`

--- a/internal/project/compiler/visualization_builtin_compile.go
+++ b/internal/project/compiler/visualization_builtin_compile.go
@@ -111,7 +111,7 @@ func compileBuiltInVisualizationSpec(id string, authored reportdef.Visual, model
 		base.Kind = "polar"
 		return visualizationir.VisualizationSpec{Value: &visualizationir.PolarVisualizationSpec{
 			VisualizationSpecBase: base, Kind: "polar", Mark: visualizationir.VisualizationPolarMark(authored.Type), Category: optionalRef("label"), Value: ref("value"), Series: optionalRef("series"),
-			Presentation: visualizationir.PolarVisualizationPresentation{VisualizationPresentation: common, Minimum: presentation.Minimum, Maximum: presentation.Maximum, ShowPointer: true, Area: presentation.Area, ProgressWidth: optionalPositiveFloat(presentation.ProgressWidth), Thresholds: compiledThresholds(presentation.Thresholds)},
+			Presentation: visualizationir.PolarVisualizationPresentation{VisualizationPresentation: common, Minimum: presentation.Minimum, Maximum: presentation.Maximum, Target: presentation.Target, ShowPointer: true, Area: presentation.Area, ProgressWidth: optionalPositiveFloat(presentation.ProgressWidth), Thresholds: compiledThresholds(presentation.Thresholds)},
 		}}, nil
 	default:
 		mark := visualizationir.VisualizationCartesianMark(authored.Type)

--- a/internal/project/compiler/visualization_field_types_test.go
+++ b/internal/project/compiler/visualization_field_types_test.go
@@ -58,6 +58,39 @@ func TestCompiledCategoricalFieldRetainsStringType(t *testing.T) {
 	}
 }
 
+func TestCompiledGaugeRetainsTruthfulDomainAndTarget(t *testing.T) {
+	minimum, maximum, target := 0.0, 5.0, 4.5
+	authored := reportdef.Visual{
+		Type: "gauge",
+		Presentation: reportdef.VisualPresentation{
+			Minimum: &minimum,
+			Maximum: &maximum,
+			Target:  &target,
+		},
+		Query: reportdef.VisualQuery{
+			Measures: []reportdef.FieldRef{{Field: "review_score"}},
+		},
+	}
+
+	spec, err := compileBuiltInVisualizationSpec("review", authored, nil)
+	if err != nil {
+		t.Fatalf("compileBuiltInVisualizationSpec() error = %v", err)
+	}
+	gauge, ok := spec.Value.(*visualizationir.PolarVisualizationSpec)
+	if !ok {
+		t.Fatalf("spec = %T, want PolarVisualizationSpec", spec.Value)
+	}
+	if gauge.Presentation.Minimum == nil || *gauge.Presentation.Minimum != minimum {
+		t.Fatalf("minimum = %v, want %v", gauge.Presentation.Minimum, minimum)
+	}
+	if gauge.Presentation.Maximum == nil || *gauge.Presentation.Maximum != maximum {
+		t.Fatalf("maximum = %v, want %v", gauge.Presentation.Maximum, maximum)
+	}
+	if gauge.Presentation.Target == nil || *gauge.Presentation.Target != target {
+		t.Fatalf("target = %v, want %v", gauge.Presentation.Target, target)
+	}
+}
+
 func TestCompiledMultiMeasureValueDoesNotClaimOneMeasureFormat(t *testing.T) {
 	model := &semanticmodel.Model{
 		Tables: map[string]semanticmodel.Table{"orders": {Dimensions: map[string]semanticmodel.MetricDimension{"month": {Type: "string"}}}},

--- a/internal/project/schema/contracts/contracts.cue
+++ b/internal/project/schema/contracts/contracts.cue
@@ -525,6 +525,7 @@ package contracts
 	#PresentationCommon
 	minimum?:       number
 	maximum?:       number
+	target?:        number
 	area?:          bool
 	progress_width?: number & >0
 	thresholds?: [...#Threshold]

--- a/schemas/json/dashboard.schema.json
+++ b/schemas/json/dashboard.schema.json
@@ -1741,6 +1741,9 @@
           "exclusiveMinimum": 0,
           "type": "number"
         },
+        "target": {
+          "type": "number"
+        },
         "thresholds": {
           "items": {
             "$ref": "#/$defs/%23Threshold"

--- a/web/components/dashboard/visualization/adapters/echarts.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.test.ts
@@ -328,17 +328,42 @@ test('ECharts incremental plans commit data synchronously, preserve interaction 
   expect(context.option.dataZoom).toBeUndefined()
 })
 
-test('ECharts first-frame readiness resolves on finished and removes its listener', async () => {
+test('ECharts first-frame readiness resolves on the first valid rendered frame and removes its listener', async () => {
   let listener: (() => void) | undefined
   let removed = false
   const chart = {
-    on(event: string, callback: () => void) { expect(event).toBe('finished'); listener = callback },
-    off(event: string, callback: () => void) { expect(event).toBe('finished'); removed = callback === listener },
+    on(event: string, callback: () => void) { expect(event).toBe('rendered'); listener = callback },
+    off(event: string, callback: () => void) { expect(event).toBe('rendered'); removed = callback === listener },
+    getWidth: () => 640,
+    getHeight: () => 360,
   }
   const ready = waitForEChartsFrame(chart as any, 100)
   listener?.()
   await ready
   expect(removed).toBe(true)
+})
+
+test('ECharts first-frame readiness ignores zero-sized renders until layout is valid', async () => {
+  let listener: (() => void) | undefined
+  let width = 0
+  let height = 0
+  const chart = {
+    on(_event: string, callback: () => void) { listener = callback },
+    off() {},
+    getWidth: () => width,
+    getHeight: () => height,
+  }
+  let settled = false
+  const ready = waitForEChartsFrame(chart as any, 100).then(() => { settled = true })
+  listener?.()
+  await Promise.resolve()
+  expect(settled).toBe(false)
+
+  width = 640
+  height = 360
+  listener?.()
+  await ready
+  expect(settled).toBe(true)
 })
 
 test('ECharts first-frame readiness fails closed on timeout and removes its listener', async () => {
@@ -347,8 +372,26 @@ test('ECharts first-frame readiness fails closed on timeout and removes its list
   const chart = {
     on(_event: string, callback: () => void) { listener = callback },
     off(_event: string, callback: () => void) { removed = callback === listener },
+    getWidth: () => 640,
+    getHeight: () => 360,
   }
   await expect(waitForEChartsFrame(chart as any, 1)).rejects.toThrow(/did not complete/)
+  expect(removed).toBe(true)
+})
+
+test('ECharts first-frame readiness exits cleanly when its mount is disposed', async () => {
+  let listener: (() => void) | undefined
+  let removed = false
+  const abort = new AbortController()
+  const chart = {
+    on(_event: string, callback: () => void) { listener = callback },
+    off(_event: string, callback: () => void) { removed = callback === listener },
+    getWidth: () => 640,
+    getHeight: () => 360,
+  }
+  const ready = waitForEChartsFrame(chart as any, 100, abort.signal)
+  abort.abort()
+  await ready
   expect(removed).toBe(true)
 })
 
@@ -423,6 +466,39 @@ test('ECharts owns the complete gauge color scale when thresholds are omitted', 
   envelope.spec.presentation.thresholds = undefined
   const option = echartsOption(envelope, defaultRendererContext) as any
   expect(option.series[0].axisLine.lineStyle.color).toEqual([[1, defaultRendererContext.colors.accent]])
+})
+
+test('ECharts rejects gauge envelopes without an explicit truthful domain', () => {
+  const envelope = gaugeFixture() as any
+  envelope.spec.presentation.minimum = undefined
+  envelope.spec.presentation.maximum = undefined
+  expect(() => echartsOption(envelope, defaultRendererContext)).toThrow(/explicit minimum and maximum/)
+})
+
+test('ECharts renders an explicit labeled target independently from the measured value', () => {
+  const envelope = gaugeFixture() as any
+  envelope.spec.presentation.target = 0.8
+  const option = echartsOption(envelope, defaultRendererContext) as any
+  expect(option.series).toHaveLength(2)
+  expect(option.series[1]).toMatchObject({
+    id: 'series:polar:gauge:target',
+    type: 'gauge',
+    min: 0,
+    max: 1,
+    axisLine: { show: false },
+    progress: { show: false },
+    detail: { show: false },
+  })
+  expect(option.series[1].data[0]).toMatchObject({ value: 0.8, name: 'Target 80.0%' })
+  expect(option.series[1].data[0].pointer.width).toBeGreaterThan(0)
+})
+
+test('ECharts renders a visible diagnostic instead of clipping an out-of-domain gauge value', () => {
+  const envelope = gaugeFixture() as any
+  envelope.dataState.datasets[0].rows = [[1.2]]
+  const option = echartsOption(envelope, defaultRendererContext) as any
+  expect(option.series).toEqual([])
+  expect(option.graphic[0].style.text).toContain('outside configured gauge domain 0.0%–100.0%')
 })
 
 function cartesianFixture(mark: string, columns = ['label', 'value']): VisualizationEnvelope {

--- a/web/components/dashboard/visualization/adapters/echarts.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.ts
@@ -32,7 +32,7 @@ export const adapter: RendererAdapter = {
     const chart = echarts.init(frame, undefined, { renderer: 'canvas', devicePixelRatio: context.devicePixelRatio })
     const handle = new EChartsHandle(container, frame, chart)
     try {
-      await handle.mount(envelope, context)
+      handle.mount(envelope, context)
       return handle
     } catch (error) {
       handle.dispose()
@@ -55,17 +55,22 @@ export function removeEChartsRendererFrame(container: ParentNode, frame: HTMLEle
 class EChartsHandle implements RendererHandle {
   private envelope?: VisualizationEnvelope
   private disposed = false
+  private readiness: Promise<void> = Promise.resolve()
+  private readinessAbort?: AbortController
 
   constructor(private readonly container: HTMLElement, private readonly frame: HTMLElement, private readonly chart: ECharts) {
     this.chart.on('click', this.handleClick)
   }
 
-  async mount(envelope: VisualizationEnvelope, context: RendererContext): Promise<void> {
+  mount(envelope: VisualizationEnvelope, context: RendererContext): void {
     this.envelope = envelope
-    const ready = waitForEChartsFrame(this.chart)
+    this.readinessAbort?.abort()
+    this.readinessAbort = new AbortController()
+    this.readiness = waitForEChartsFrame(this.chart, 5_000, this.readinessAbort.signal)
     this.chart.setOption(echartsOption(envelope, context), { notMerge: true, lazyUpdate: false })
-    await ready
   }
+
+  whenReady(): Promise<void> { return this.readiness }
 
   update(envelope: VisualizationEnvelope, change: Change, context: RendererContext): void {
     if (this.disposed) return
@@ -85,6 +90,8 @@ class EChartsHandle implements RendererHandle {
   dispose(): void {
     if (this.disposed) return
     this.disposed = true
+    this.readinessAbort?.abort()
+    this.readinessAbort = undefined
     this.chart.off('click', this.handleClick)
     this.chart.dispose()
     removeEChartsRendererFrame(this.container, this.frame)
@@ -160,18 +167,49 @@ function echartsContextPatch(option: Record<string, any>): Record<string, any> {
   return patch
 }
 
-export function waitForEChartsFrame(chart: Pick<ECharts, 'on' | 'off'>, timeoutMs = 5_000): Promise<void> {
+type EChartsFrameChart = Pick<ECharts, 'on' | 'off' | 'getWidth' | 'getHeight'>
+
+export class EChartsReadinessError extends Error {
+  constructor(readonly reason: 'timeout' | 'invalid_layout', readonly width: number, readonly height: number) {
+    super(reason === 'invalid_layout'
+      ? `ECharts cannot render its first frame with invalid layout ${width}x${height}`
+      : 'ECharts did not complete its first frame')
+    this.name = 'EChartsReadinessError'
+  }
+}
+
+export function waitForEChartsFrame(chart: EChartsFrameChart, timeoutMs = 5_000, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     let timer: ReturnType<typeof setTimeout> | undefined
-    const finish = () => {
+    let settled = false
+    const cleanup = () => {
       if (timer !== undefined) clearTimeout(timer)
-      chart.off('finished', finish)
-      resolve()
+      chart.off('rendered', rendered)
+      signal?.removeEventListener('abort', aborted)
     }
-    chart.on('finished', finish)
+    const complete = (action: () => void) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      action()
+    }
+    const rendered = () => {
+      const width = chart.getWidth()
+      const height = chart.getHeight()
+      if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return
+      complete(resolve)
+    }
+    const aborted = () => { complete(resolve) }
+    chart.on('rendered', rendered)
+    if (signal?.aborted) {
+      aborted()
+      return
+    }
+    signal?.addEventListener('abort', aborted, { once: true })
     timer = setTimeout(() => {
-      chart.off('finished', finish)
-      reject(new Error('ECharts did not complete its first frame'))
+      const width = chart.getWidth()
+      const height = chart.getHeight()
+      complete(() => reject(new EChartsReadinessError(width > 0 && height > 0 ? 'timeout' : 'invalid_layout', width, height)))
     }, timeoutMs)
   })
 }

--- a/web/components/dashboard/visualization/adapters/echarts/polar.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/polar.ts
@@ -6,20 +6,71 @@ export function polarOption(envelope: VisualizationEnvelope, context: RendererCo
   const spec = envelope.spec
   if (spec.kind !== 'polar') return {}
   if (spec.mark === 'gauge') {
+    if (spec.presentation.minimum === undefined || spec.presentation.maximum === undefined) {
+      throw new Error('Gauge rendering requires an explicit minimum and maximum')
+    }
     const dataset = inlineDataset(envelope, spec.value.dataset)
     const valueIndex = dataset?.columns.indexOf(spec.value.field) ?? -1
     const value = valueIndex >= 0 ? dataset?.rows[0]?.[valueIndex] : undefined
-    const minimum = spec.presentation.minimum ?? 0, maximum = spec.presentation.maximum ?? 100
+    const minimum = spec.presentation.minimum, maximum = spec.presentation.maximum
+    if (typeof value === 'number' && Number.isFinite(value) && (value < minimum || value > maximum)) {
+      const formattedValue = formatField(envelope, spec.value, value, context)
+      const formattedMinimum = formatField(envelope, spec.value, minimum, context)
+      const formattedMaximum = formatField(envelope, spec.value, maximum, context)
+      return {
+        series: [],
+        graphic: [{
+          type: 'text',
+          left: 'center',
+          top: 'middle',
+          silent: true,
+          style: {
+            text: `Value ${formattedValue} is outside configured gauge domain ${formattedMinimum}–${formattedMaximum}`,
+            fill: context.colors.danger,
+            fontFamily: context.fontFamily,
+            textAlign: 'center',
+          },
+        }],
+      }
+    }
     const span = maximum - minimum
     const authoredColors = (spec.presentation.thresholds ?? []).map((threshold) => [Math.max(0, Math.min(1, span > 0 ? (threshold.value - minimum) / span : 1)), toneColor(threshold.tone, context)])
     const colors = authoredColors.length ? authoredColors : [[1, context.colors.accent]]
+    const series: Record<string, any>[] = [{
+      id: 'series:polar:gauge', type: 'gauge', min: minimum, max: maximum,
+      data: [{ value, __lv_dataset: dataset?.id ?? 'primary', __lv_row_index: 0 }], pointer: { show: spec.presentation.showPointer },
+      progress: { show: true, width: spec.presentation.progressWidth }, axisLine: { lineStyle: { color: colors } },
+      detail: { formatter: (raw: unknown) => formatField(envelope, spec.value, raw, context), color: context.colors.foreground },
+    }]
+    if (spec.presentation.target !== undefined) {
+      const targetLabel = `Target ${formatField(envelope, spec.value, spec.presentation.target, context)}`
+      series.push({
+        id: 'series:polar:gauge:target',
+        name: 'Target',
+        type: 'gauge',
+        min: minimum,
+        max: maximum,
+        silent: true,
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: { show: false },
+        axisLabel: { show: false },
+        progress: { show: false },
+        pointer: { show: true, length: '72%', width: 4, itemStyle: { color: context.colors.foreground } },
+        anchor: { show: false },
+        title: { show: true, offsetCenter: [0, '64%'], color: context.colors.muted, fontFamily: context.fontFamily },
+        detail: { show: false },
+        data: [{
+          value: spec.presentation.target,
+          name: targetLabel,
+          pointer: { show: true, length: '72%', width: 4, itemStyle: { color: context.colors.foreground } },
+          title: { show: true },
+          detail: { show: false },
+        }],
+      })
+    }
     return {
-      series: [{
-        id: 'series:polar:gauge', type: 'gauge', min: minimum, max: maximum,
-        data: [{ value, __lv_dataset: dataset?.id ?? 'primary', __lv_row_index: 0 }], pointer: { show: spec.presentation.showPointer },
-        progress: { show: true, width: spec.presentation.progressWidth }, axisLine: { lineStyle: { color: colors } },
-        detail: { formatter: (raw: unknown) => formatField(envelope, spec.value, raw, context), color: context.colors.foreground },
-      }],
+      series,
     }
   }
   const dataset = inlineDataset(envelope, spec.value.dataset)

--- a/web/components/dashboard/visualization/host-controller.ts
+++ b/web/components/dashboard/visualization/host-controller.ts
@@ -57,6 +57,7 @@ export type RendererCapabilities = Readonly<{
 }>
 
 export interface RendererHandle {
+  whenReady?(): Promise<void>
   update(envelope: VisualizationEnvelope, change: Change, context: RendererContext): void | Promise<void>
   resize(width: number, height: number, devicePixelRatio: number): void
   snapshot(): Promise<Blob>
@@ -188,12 +189,31 @@ export class VisualizationController {
         this.#record('adapter_error', now() - mountStarted, next)
         throw error
       }
-      this.#record('mount', now() - mountStarted, next)
       if (this.#disposed || generation !== this.#loadGeneration) {
-		handle.dispose()
+        handle.dispose()
         return false
       }
       this.#handle = handle
+      this.#flushResize()
+      try {
+        await handle.whenReady?.()
+      } catch (error) {
+        if (this.#handle === handle) {
+          handle.dispose()
+          this.#handle = undefined
+        }
+        if (this.#disposed || generation !== this.#loadGeneration) return false
+        this.#record('adapter_error', now() - mountStarted, next)
+        throw error
+      }
+      this.#record('mount', now() - mountStarted, next)
+      if (this.#disposed || generation !== this.#loadGeneration || this.#handle !== handle) {
+        if (this.#handle === handle) {
+          handle.dispose()
+          this.#handle = undefined
+        }
+        return false
+      }
       if (this.#pendingViewState) {
         const pending = this.#pendingViewState
         await handle.restoreViewState?.(pending.value)
@@ -201,7 +221,6 @@ export class VisualizationController {
       }
       this.#envelope = next
       this.#context = context
-      this.#flushResize()
       return true
     }
 

--- a/web/components/dashboard/visualization/host.test.ts
+++ b/web/components/dashboard/visualization/host.test.ts
@@ -288,3 +288,42 @@ test('repeated mount and dispose cycles release every renderer exactly once', as
   expect(mounts).toBe(100)
   expect(disposals).toBe(100)
 })
+
+test('controller owns and cancels a renderer while first-frame readiness is pending', async () => {
+  let releaseReady = () => {}
+  let disposals = 0
+  const resizes: Array<readonly [number, number, number]> = []
+  const handle = {
+    whenReady: () => new Promise<void>((resolve) => { releaseReady = resolve }),
+    update: () => {},
+    resize: (width: number, height: number, ratio: number) => { resizes.push([width, height, ratio]) },
+    snapshot: async () => new Blob(),
+    dispose: () => {
+      disposals++
+      releaseReady()
+    },
+  }
+  const registry = new RendererRegistry()
+  registry.register({
+    id: 'test', version: '1.0.0', schemaVersion: currentVisualizationSchemaVersion, kinds: ['kpi'],
+    capabilities: { snapshot: true, windowed: false, interactive: false },
+    load: async () => ({ mount: () => handle }),
+  })
+  const controller = new VisualizationController(registry, {} as HTMLElement)
+  controller.resize(640, 360, 2)
+  let settled = false
+  const applying = controller.apply(envelope(1)).then((applied) => {
+    settled = true
+    return applied
+  })
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(resizes).toEqual([[640, 360, 2]])
+  expect(settled).toBe(false)
+
+  controller.dispose()
+  expect(await applying).toBe(false)
+  expect(disposals).toBe(1)
+})


### PR DESCRIPTION
## Summary

- make ECharts first-frame readiness follow the rendered lifecycle and remain cancellable across disposal
- require explicit truthful gauge domains, validate thresholds and targets, and surface out-of-domain data
- add labeled gauge targets and update the showcase, docs, generated IR, OpenAPI, and JSON Schema contracts

## Validation

- task test
- task generated:check
- task ci
- 900 focused lifecycle/adapter stress-test passes
- browser requalification: fresh load, hard reload, resize, ten rapid page round trips, and tab restoration with zero browser errors

## Linear

- LEA-55: https://linear.app/leapstack/issue/LEA-55/close-and-requalify-release-blocking-visual-correctness-defects
- LEA-27: https://linear.app/leapstack/issue/LEA-27/fix-echarts-first-frame-readiness-lifecycle
- LEA-28: https://linear.app/leapstack/issue/LEA-28/require-truthful-gauge-domains-and-targets