### PR TITLE
Fix Compose public URL initialization contract

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -14,8 +14,11 @@ cp deployment.env.example deployment.env
 ```
 
 Set the released `LEAPVIEW_IMAGE` digest before initialization. HTTPS is
-enabled by default through the Caddy overlay. Use `--no-https` only when a
-trusted external HTTPS proxy fronts the localhost-bound application port.
+enabled by default through the Caddy overlay. Initialization derives
+`LEAPVIEW_PUBLIC_URL=https://<domain>`, the allowed host, and the Caddy domain
+from the validated `--domain` hostname. Use `--no-https` only when a trusted
+external HTTPS proxy fronts the localhost-bound application port; it disables
+the Caddy overlay but preserves the HTTPS public URL and secure cookies.
 
 Pulling and running the public image does not require this package or the
 controller; see the installation guide for the localhost evaluation path. For

--- a/deploy/compose/deployment_test.go
+++ b/deploy/compose/deployment_test.go
@@ -1,12 +1,40 @@
 package compose
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
+
+var (
+	generateConfigOnce   sync.Once
+	generateConfigOutput []byte
+	generateConfigError  error
+)
+
+const configValidatorTestProgram = `package configvalidator
+
+import (
+	"testing"
+
+	"github.com/Yacobolo/leapview/internal/app/config"
+)
+
+func TestProductionConfigValidator(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Production = true
+	if err := cfg.Validate(config.ProfileServe); err != nil {
+		t.Fatal(err)
+	}
+}
+`
 
 func TestComposeSingleInstanceContract(t *testing.T) {
 	compose := read(t, "compose.yaml")
@@ -27,8 +55,16 @@ func TestComposeSingleInstanceContract(t *testing.T) {
 	if strings.Contains(compose, "./backups:/backups") {
 		t.Fatal("backup archives must cross the container boundary as streams, not through a host bind with incompatible ownership")
 	}
-	if !strings.Contains(read(t, "leapview.env.example"), "LEAPVIEW_HOME=/var/lib/leapview/home") {
-		t.Fatal("leapview.env.example must place LEAPVIEW_HOME beneath the mounted volume so restore can replace it")
+	appEnvironment := read(t, "leapview.env.example")
+	for _, required := range []string{
+		"LEAPVIEW_HOME=/var/lib/leapview/home",
+		"LEAPVIEW_PUBLIC_URL=https://dash.example.com",
+		"LEAPVIEW_ALLOWED_HOSTS=dash.example.com",
+		"LEAPVIEW_TRUST_PROXY_HEADERS=true",
+	} {
+		if !strings.Contains(appEnvironment, required) {
+			t.Fatalf("leapview.env.example missing %q", required)
+		}
 	}
 	https := read(t, "compose.https.yaml")
 	if !strings.Contains(https, "CADDY_IMAGE") || !strings.Contains(https, "443:443/udp") {
@@ -87,6 +123,68 @@ func TestControllerBuildAndLifecycleCommands(t *testing.T) {
 	}
 }
 
+func TestControllerInitializationGeneratesValidPublicOrigin(t *testing.T) {
+	binaryDir := t.TempDir()
+	validator := buildConfigValidator(t, binaryDir)
+	image := "example.com/leapview@sha256:" + strings.Repeat("a", 64)
+
+	for _, test := range []struct {
+		name       string
+		args       []string
+		composeTLS string
+	}{
+		{name: "built-in Caddy", composeTLS: "1"},
+		{name: "trusted external HTTPS proxy", args: []string{"--no-https"}, composeTLS: "0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			buildController(t, root)
+			copyDeploymentFile(t, root, "deployment.env.example", 0o600)
+			fakeDocker := filepath.Join(root, "fake-docker")
+			script := fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+root="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+if [[ " $* " == *" config validate --production "* ]]; then
+  set -a
+  source "$root/leapview.env"
+  set +a
+  exec %q config validate --production
+fi
+if [[ " $* " == *" admin initialize --format json "* ]]; then
+  printf '{"email":"admin@example.com","temporaryPassword":"temporary","publisherToken":"publisher","publisherTokenExpiresAt":"2026-07-19T00:00:00Z"}\n'
+fi
+`, validator)
+			if err := os.WriteFile(fakeDocker, []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+
+			args := []string{"init", "--admin-email", "admin@example.com", "--domain", "dash.example.com", "--image", image}
+			args = append(args, test.args...)
+			runController(t, root, fakeDocker, "", args...)
+
+			appEnvironment := readFile(t, filepath.Join(root, "leapview.env"))
+			for _, required := range []string{
+				"LEAPVIEW_PUBLIC_URL=https://dash.example.com\n",
+				"LEAPVIEW_ALLOWED_HOSTS=dash.example.com\n",
+				"LEAPVIEW_TRUST_PROXY_HEADERS=true\n",
+			} {
+				if !strings.Contains(appEnvironment, required) {
+					t.Errorf("leapview.env missing %q:\n%s", required, appEnvironment)
+				}
+			}
+			deploymentEnvironment := readFile(t, filepath.Join(root, "deployment.env"))
+			for _, required := range []string{
+				"CADDY_DOMAIN=dash.example.com\n",
+				"COMPOSE_HTTPS=" + test.composeTLS + "\n",
+			} {
+				if !strings.Contains(deploymentEnvironment, required) {
+					t.Errorf("deployment.env missing %q:\n%s", required, deploymentEnvironment)
+				}
+			}
+		})
+	}
+}
+
 func TestControllerReleasePackagingContract(t *testing.T) {
 	release := read(t, filepath.Join("..", "..", ".github", "workflows", "release.yml"))
 	for _, required := range []string{
@@ -110,6 +208,7 @@ func TestControllerReleasePackagingContract(t *testing.T) {
 func TestControllerLifecycleWithStateAwareUpgradeRollback(t *testing.T) {
 	root := t.TempDir()
 	buildController(t, root)
+	buildConfigValidator(t, root)
 	copyDeploymentFile(t, root, "deployment.env.example", 0o600)
 	fakeDocker := filepath.Join(root, "fake-docker")
 	if err := os.WriteFile(fakeDocker, []byte(`#!/usr/bin/env bash
@@ -139,7 +238,12 @@ done
 case "${command:-}" in
   ps) [[ " $* " == *' -q '* ]] && printf 'fake-container\n' ;;
   run)
-    if [[ " $* " == *' admin initialize --format json '* ]]; then
+    if [[ " $* " == *' config validate --production '* ]]; then
+      set -a
+      source "$root/leapview.env"
+      set +a
+      exec "$root/config-validator"
+    elif [[ " $* " == *' admin initialize --format json '* ]]; then
       printf '{"email":"admin@example.com","temporaryPassword":"temporary","publisherToken":"publisher","publisherTokenExpiresAt":"2026-07-19T00:00:00Z"}\n'
     elif [[ " $* " == *' admin backup '* ]]; then
       output=""
@@ -222,13 +326,19 @@ func TestControllerInitializationIsRetryableAndRequiresPinnedProxy(t *testing.T)
 		t.Helper()
 		root := t.TempDir()
 		buildController(t, root)
+		buildConfigValidator(t, root)
 		copyDeploymentFile(t, root, "deployment.env.example", 0o600)
 		fakeDocker := filepath.Join(root, "fake-docker")
 		if err := os.WriteFile(fakeDocker, []byte(`#!/usr/bin/env bash
 set -euo pipefail
 root="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 if [[ -f "$root/fail-validation" && " $* " == *" config validate "* ]]; then exit 42; fi
-if [[ " $* " == *" admin initialize --format json "* ]]; then
+if [[ " $* " == *" config validate --production "* ]]; then
+  set -a
+  source "$root/leapview.env"
+  set +a
+  exec "$root/config-validator"
+elif [[ " $* " == *" admin initialize --format json "* ]]; then
   printf '{"email":"admin@example.com","temporaryPassword":"temporary","publisherToken":"publisher","publisherTokenExpiresAt":"2026-07-19T00:00:00Z"}\n'
 fi
 `), 0o700); err != nil {
@@ -300,6 +410,47 @@ func buildController(t *testing.T, targetDir string) string {
 	return target
 }
 
+func buildConfigValidator(t *testing.T, targetDir string) string {
+	t.Helper()
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	generateConfigOnce.Do(func() {
+		command := exec.Command("go", "run", "./internal/app/tools/configgen")
+		command.Dir = repositoryRoot
+		generateConfigOutput, generateConfigError = command.CombinedOutput()
+	})
+	if generateConfigError != nil {
+		t.Fatalf("generate configuration contract: %v\n%s", generateConfigError, generateConfigOutput)
+	}
+
+	temporaryRoot := filepath.Join(repositoryRoot, ".tmp")
+	if err := os.MkdirAll(temporaryRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sourceDir, err := os.MkdirTemp(temporaryRoot, "compose-config-validator-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sourceDir) })
+	if err := os.WriteFile(filepath.Join(sourceDir, "validator_test.go"), []byte(configValidatorTestProgram), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	relativeSourceDir, err := filepath.Rel(repositoryRoot, sourceDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(targetDir, "config-validator")
+	command := exec.Command("go", "test", "-c", "-o", target, "./"+filepath.ToSlash(relativeSourceDir))
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build production config validator: %v\n%s", err, output)
+	}
+	return target
+}
+
 func runController(t *testing.T, root, docker, failImage string, args ...string) string {
 	t.Helper()
 	output, err := runControllerResult(root, docker, failImage, args...)
@@ -326,6 +477,11 @@ func requireDeploymentImage(t *testing.T, root, image string) {
 }
 
 func read(t *testing.T, name string) string {
+	t.Helper()
+	return readFile(t, name)
+}
+
+func readFile(t *testing.T, name string) string {
 	t.Helper()
 	value, err := os.ReadFile(name)
 	if err != nil {

--- a/deploy/compose/leapview.env.example
+++ b/deploy/compose/leapview.env.example
@@ -7,6 +7,7 @@ LEAPVIEW_MANAGED_DATA_DIR=/var/lib/leapview/home/managed-data
 LEAPVIEW_LOCAL_AUTH=1
 LEAPVIEW_COOKIE_SECURE=true
 LEAPVIEW_TRUST_PROXY_HEADERS=true
+LEAPVIEW_PUBLIC_URL=https://dash.example.com
 LEAPVIEW_ALLOWED_HOSTS=dash.example.com
 LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL=admin@example.com
 LEAPVIEW_CSRF_KEY=<generated-by-leapviewctl>

--- a/docs/articles/operate/self-hosting.md
+++ b/docs/articles/operate/self-hosting.md
@@ -31,7 +31,7 @@ cp deployment.env.example deployment.env
 ./leapviewctl first-login
 ```
 
-For an existing reverse proxy, pass `--no-https`, keep the application bound to localhost, and forward the original scheme and host. Do not expose the unencrypted application port publicly.
+Initialization derives `LEAPVIEW_PUBLIC_URL=https://<domain>`, the allowed host, and the Caddy domain from the validated `--domain` hostname. For an existing reverse proxy, pass `--no-https`, keep the application bound to localhost, and forward the original HTTPS scheme and host from that trusted proxy. `--no-https` disables only the bundled Caddy overlay; it does not make the public origin HTTP. Do not expose the unencrypted application port publicly.
 
 The controller is optional if an existing container platform already provides equivalent secret management, health checks, graceful shutdown, backup validation, and image-and-state rollback. Those contracts remain required even when Compose is not used.
 

--- a/docs/articles/start/installation.md
+++ b/docs/articles/start/installation.md
@@ -71,11 +71,11 @@ cp deployment.env.example deployment.env
 ./leapviewctl first-login
 ```
 
-Initialization generates production secrets, creates the persistent volume, validates configuration, and atomically creates a forced-change local administrator plus a restricted publisher token. `first-login` prints and deletes that one-time credential file.
+Initialization treats `--domain` as the canonical public hostname and derives `LEAPVIEW_PUBLIC_URL=https://<domain>`, the allowed host, and the Caddy domain from it. It also generates production secrets, creates the persistent volume, validates the resulting production configuration, and atomically creates a forced-change local administrator plus a restricted publisher token. `first-login` prints and deletes that one-time credential file.
 
 `leapviewctl` is an optional production operations controller, not a prerequisite for pulling or running LeapView. It invokes the installed Docker Compose CLI and does not require Bash or direct access to the Docker socket API. You may manage the image with your existing container platform if it preserves the same single-process, persistent-home, initialization, backup, and environment contracts.
 
-The Caddy overlay is enabled by default. Pass `--no-https` only when an existing trusted HTTPS proxy fronts the localhost-bound application port. Keep secure cookies and the public allowed host configured for that proxy.
+The Caddy overlay is enabled by default. Pass `--no-https` only when an existing trusted HTTPS proxy fronts the localhost-bound application port. This changes where TLS terminates, not the external scheme: the generated public URL remains HTTPS, secure cookies remain enabled, and forwarded host and scheme headers must come only from that trusted proxy.
 
 ## Understand the instance boundary
 

--- a/internal/app/cli/composectl/command.go
+++ b/internal/app/cli/composectl/command.go
@@ -30,10 +30,10 @@ func Command(ctx context.Context, controller *Controller) *cobra.Command {
 		},
 	}
 	initialize.Flags().StringVar(&initOptions.AdminEmail, "admin-email", "", "initial platform administrator email")
-	initialize.Flags().StringVar(&initOptions.Domain, "domain", "", "public application host")
+	initialize.Flags().StringVar(&initOptions.Domain, "domain", "", "canonical public application hostname")
 	initialize.Flags().StringVar(&initOptions.Environment, "environment", defaultEnvironment, "instance environment")
 	initialize.Flags().StringVar(&initOptions.Image, "image", "", "immutable LeapView image reference")
-	initialize.Flags().BoolVar(&initOptions.NoHTTPS, "no-https", false, "disable the Caddy HTTPS overlay")
+	initialize.Flags().BoolVar(&initOptions.NoHTTPS, "no-https", false, "use a trusted external HTTPS proxy instead of the Caddy overlay")
 
 	start := &cobra.Command{
 		Use:   "start",

--- a/internal/app/cli/composectl/controller.go
+++ b/internal/app/cli/composectl/controller.go
@@ -18,16 +18,20 @@ import (
 )
 
 const (
-	deploymentEnvName   = "deployment.env"
-	appEnvName          = "leapview.env"
-	credentialsName     = "initial-credentials.json"
-	rollbackEnvName     = "rollback.env"
-	controllerLockName  = ".leapviewctl.lock"
-	defaultEnvironment  = "prod"
-	defaultHealthChecks = 120
+	deploymentEnvName    = "deployment.env"
+	appEnvName           = "leapview.env"
+	credentialsName      = "initial-credentials.json"
+	rollbackEnvName      = "rollback.env"
+	controllerLockName   = ".leapviewctl.lock"
+	defaultEnvironment   = "prod"
+	defaultHealthChecks  = 120
+	publicDomainHelpText = "--domain must be a hostname without a scheme, path, port, wildcard, or credentials"
 )
 
-var digestPattern = regexp.MustCompile(`^[A-Za-z0-9._:/-]+@sha256:[0-9a-f]{64}$`)
+var (
+	digestPattern      = regexp.MustCompile(`^[A-Za-z0-9._:/-]+@sha256:[0-9a-f]{64}$`)
+	domainLabelPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
+)
 
 type Options struct {
 	Root      string
@@ -116,6 +120,11 @@ func (c *Controller) Initialize(ctx context.Context, options InitOptions) error 
 			return err
 		}
 	}
+	domain, err := canonicalPublicDomain(options.Domain)
+	if err != nil {
+		return err
+	}
+	options.Domain = domain
 	if err := c.ensureDeploymentEnvironment(); err != nil {
 		return err
 	}
@@ -189,7 +198,7 @@ func (c *Controller) Initialize(ctx context.Context, options InitOptions) error 
 	appEnvironment := fmt.Sprintf("LEAPVIEW_PRODUCTION=1\nLEAPVIEW_ENVIRONMENT=%s\nLEAPVIEW_ADDR=:8080\n", options.Environment) +
 		"LEAPVIEW_HOME=/var/lib/leapview/home\nLEAPVIEW_MANAGED_DATA_BACKEND=local\nLEAPVIEW_MANAGED_DATA_DIR=/var/lib/leapview/home/managed-data\n" +
 		"LEAPVIEW_LOCAL_AUTH=1\nLEAPVIEW_COOKIE_SECURE=true\nLEAPVIEW_TRUST_PROXY_HEADERS=true\n" +
-		fmt.Sprintf("LEAPVIEW_ALLOWED_HOSTS=%s\nLEAPVIEW_BOOTSTRAP_ADMIN_EMAIL=%s\n", options.Domain, options.AdminEmail) +
+		fmt.Sprintf("LEAPVIEW_PUBLIC_URL=https://%s\nLEAPVIEW_ALLOWED_HOSTS=%s\nLEAPVIEW_BOOTSTRAP_ADMIN_EMAIL=%s\n", options.Domain, options.Domain, options.AdminEmail) +
 		fmt.Sprintf("LEAPVIEW_CSRF_KEY=%s\nLEAPVIEW_METRICS_BEARER_TOKEN=%s\n", csrfKey, metricsToken)
 	if err := writePrivateAtomic(c.path(appEnvName), []byte(appEnvironment)); err != nil {
 		return err
@@ -746,6 +755,19 @@ func validateEnvLineValue(label, value string) error {
 		return fmt.Errorf("%s must be a single environment-file value", label)
 	}
 	return nil
+}
+
+func canonicalPublicDomain(raw string) (string, error) {
+	domain := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(raw), "."))
+	if domain == "" || len(domain) > 253 {
+		return "", fmt.Errorf("%s: %q", publicDomainHelpText, raw)
+	}
+	for _, label := range strings.Split(domain, ".") {
+		if !domainLabelPattern.MatchString(label) {
+			return "", fmt.Errorf("%s: %q", publicDomainHelpText, raw)
+		}
+	}
+	return domain, nil
 }
 
 func randomHex(size int) (string, error) {

--- a/internal/app/cli/composectl/controller_test.go
+++ b/internal/app/cli/composectl/controller_test.go
@@ -2,6 +2,7 @@ package composectl
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -94,6 +95,67 @@ func TestEnvironmentLineValuesRejectConfigurationInjection(t *testing.T) {
 	}
 	if err := validateEnvLineValue("domain", "dash.example.com"); err != nil {
 		t.Fatalf("ordinary value rejected: %v", err)
+	}
+}
+
+func TestInitializeRejectsInvalidPublicDomainBeforeStateMutation(t *testing.T) {
+	root := t.TempDir()
+	example := "LEAPVIEW_IMAGE=example.com/leapview@sha256:" + strings.Repeat("a", 64) +
+		"\nCADDY_IMAGE=example.com/caddy@sha256:" + strings.Repeat("b", 64) +
+		"\nCADDY_DOMAIN=dash.example.com\nCOMPOSE_HTTPS=1\n"
+	if err := os.WriteFile(filepath.Join(root, "deployment.env.example"), []byte(example), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	controller, err := New(Options{Root: root, DockerBin: "/bin/false"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = controller.Initialize(context.Background(), InitOptions{
+		AdminEmail: "admin@example.com",
+		Domain:     "https://dash.example.com",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--domain must be a hostname") {
+		t.Fatalf("invalid public domain error = %v", err)
+	}
+	for _, name := range []string{deploymentEnvName, appEnvName, credentialsName, controllerLockName} {
+		if _, err := os.Stat(filepath.Join(root, name)); !os.IsNotExist(err) {
+			t.Errorf("invalid public domain mutated %s: %v", name, err)
+		}
+	}
+}
+
+func TestCanonicalPublicDomain(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: "dash.example.com", want: "dash.example.com"},
+		{input: " Dash.Example.COM. ", want: "dash.example.com"},
+		{input: "localhost", want: "localhost"},
+	} {
+		t.Run(test.input, func(t *testing.T) {
+			got, err := canonicalPublicDomain(test.input)
+			if err != nil || got != test.want {
+				t.Fatalf("canonicalPublicDomain(%q) = %q, %v; want %q", test.input, got, err, test.want)
+			}
+		})
+	}
+	for _, input := range []string{
+		"https://dash.example.com",
+		"dash.example.com/path",
+		"dash.example.com:8443",
+		"user@dash.example.com",
+		"*.example.com",
+		"-dash.example.com",
+		"dash..example.com",
+		"dash_example.com",
+	} {
+		t.Run("reject "+input, func(t *testing.T) {
+			if got, err := canonicalPublicDomain(input); err == nil {
+				t.Fatalf("canonicalPublicDomain(%q) = %q, nil", input, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- derive a canonical HTTPS `LEAPVIEW_PUBLIC_URL` from the validated `--domain` hostname
- keep public URL, allowed host, Caddy domain, and trusted-proxy behavior coherent for built-in Caddy and `--no-https`
- reject invalid public-domain inputs before creating locks or environment state
- make Compose lifecycle fakes execute the real production config validator
- align the shipped environment example, CLI help, and installation/self-hosting guidance

## TDD evidence

- Red: real-validator integration failed in both modes with `production serve requires LEAPVIEW_PUBLIC_URL`
- Green: built-in Caddy and trusted external HTTPS proxy initialization both pass the real production validator
- Invalid URL-shaped domains fail before `deployment.env`, `leapview.env`, credentials, or lock creation

## Validation

- `task deploy:check`
- `task ci`
- focused real-validator and domain-contract tests

Closes LEA-75