### PR TITLE
Extract Access APIGen into its capability package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ node_modules
 infisical-export.*
 
 api/gen
+internal/access/api/gen
 internal/agent/api/gen
 internal/app/api/aggregate
 internal/app/api/gen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
             docs/reference/config
             docs/search-index.sqlite3
             docs/visuals/examples.gen.json
+            internal/access/api/gen
             internal/agent/api/gen
             internal/app/api/aggregate
             internal/app/api/gen
@@ -112,6 +113,7 @@ jobs:
             api/gen \
             docs/reference/cli \
             docs/reference/config \
+            internal/access/api/gen \
             internal/agent/api/gen \
             internal/app/api/aggregate \
             internal/app/api/gen \
@@ -156,6 +158,7 @@ jobs:
           if-no-files-found: error
           path: |
             api/gen/
+            internal/access/api/gen/
             internal/agent/api/gen/
             internal/app/api/aggregate/
             internal/app/api/gen/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/
 coverage.out
 api/gen/
 api/.apigen/
+internal/access/api/gen/
 internal/agent/contracts/gen/
 internal/agent/api/gen/
 internal/app/api/aggregate/

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN go mod download
 
 COPY . .
 COPY --from=sourcegen /src/api/gen ./api/gen
+COPY --from=sourcegen /src/internal/access/api/gen ./internal/access/api/gen
 COPY --from=sourcegen /src/internal/agent/api/gen ./internal/agent/api/gen
 COPY --from=sourcegen /src/internal/app/api/aggregate ./internal/app/api/aggregate
 COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -365,6 +365,8 @@ tasks:
     generates:
       - api/gen/json-ir.json
       - api/gen/openapi.yaml
+      - internal/access/api/gen/request_models.gen.go
+      - internal/access/api/gen/server.apigen.gen.go
       - internal/agent/api/gen/request_models.gen.go
       - internal/agent/api/gen/server.apigen.gen.go
       - internal/app/api/aggregate/server.apigen.gen.go

--- a/api/apigen.yaml
+++ b/api/apigen.yaml
@@ -14,11 +14,15 @@ targets:
           dir: ../internal/app/api/gen
           package: gen
           import_path: github.com/Yacobolo/leapview/internal/app/api/gen
-        LeapViewAPI.Access: *leapview_api_go_package
+        LeapViewAPI.Access:
+          dir: ../internal/access/api/gen
+          package: gen
+          import_path: github.com/Yacobolo/leapview/internal/access/api/gen
         LeapViewAPI.Agent:
           dir: ../internal/agent/api/gen
           package: gen
           import_path: github.com/Yacobolo/leapview/internal/agent/api/gen
+        LeapViewAPI.Analytics: *leapview_api_go_package
         LeapViewAPI.Dashboard: *leapview_api_go_package
         LeapViewAPI.Deployment: *leapview_api_go_package
         LeapViewAPI.ManagedData: *leapview_api_go_package

--- a/api/typespec/audit.tsp
+++ b/api/typespec/audit.tsp
@@ -24,37 +24,7 @@ model AuditEventListResponse {
   page: PageInfo;
 }
 
-model QueryEventResponse {
-  id: string;
-  workspaceId: string;
-  principalId?: string;
-  surface: string;
-  operation: string;
-  queryKind: string;
-  modelId: string;
-  target: string;
-  objectType: string;
-  objectId: string;
-  requestId: string;
-  correlationId: string;
-  status: string;
-  durationMs: int64;
-  rowsReturned: int32;
-  bytesEstimate: int64;
-  error?: string;
-  sql?: string;
-  planText?: string;
-  query: Record<unknown>;
-  createdAt: utcDateTime;
-}
-
-model QueryEventListResponse {
-  items: QueryEventResponse[];
-  page: PageInfo;
-}
-
 alias ListAuditEventsOK = OkJson<AuditEventListResponse>;
-alias ListQueryEventsOK = OkJson<QueryEventListResponse>;
 
 @tag("Audit")
 @summary("List workspace audit events")
@@ -63,11 +33,3 @@ alias ListQueryEventsOK = OkJson<QueryEventListResponse>;
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
 @operationId("listAuditEvents")
 op listAuditEvents(@path workspace: string, @query actor?: string, @query action?: string, @query targetType?: string, @query targetId?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListAuditEventsOK | CommonErrors;
-
-@tag("Audit")
-@summary("List workspace query audit events")
-@route("/workspaces/{workspace}/query-events")
-@get
-@apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
-@operationId("listQueryEvents")
-op listQueryEvents(@path workspace: string, @query principal?: string, @query surface?: string, @query operation?: string, @query kind?: string, @query modelId?: string, @query target?: string, @query status?: string, @query search?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListQueryEventsOK | CommonErrors;

--- a/api/typespec/main.tsp
+++ b/api/typespec/main.tsp
@@ -14,6 +14,7 @@ import "./refresh_runs.tsp";
 import "./agent.tsp";
 import "./access.tsp";
 import "./audit.tsp";
+import "./query_audit.tsp";
 import "./dashboard_publications.tsp";
 import "./managed_data.tsp";
 import "./upload_tus.tsp";

--- a/api/typespec/query_audit.tsp
+++ b/api/typespec/query_audit.tsp
@@ -1,0 +1,44 @@
+using Http;
+using TypeSpec.OpenAPI;
+using LeapViewAPI.Protocol;
+
+namespace LeapViewAPI.Analytics;
+
+model QueryEventResponse {
+  id: string;
+  workspaceId: string;
+  principalId?: string;
+  surface: string;
+  operation: string;
+  queryKind: string;
+  modelId: string;
+  target: string;
+  objectType: string;
+  objectId: string;
+  requestId: string;
+  correlationId: string;
+  status: string;
+  durationMs: int64;
+  rowsReturned: int32;
+  bytesEstimate: int64;
+  error?: string;
+  sql?: string;
+  planText?: string;
+  query: Record<unknown>;
+  createdAt: utcDateTime;
+}
+
+model QueryEventListResponse {
+  items: QueryEventResponse[];
+  page: PageInfo;
+}
+
+alias ListQueryEventsOK = OkJson<QueryEventListResponse>;
+
+@tag("Audit")
+@summary("List workspace query audit events")
+@route("/workspaces/{workspace}/query-events")
+@get
+@apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
+@operationId("listQueryEvents")
+op listQueryEvents(@path workspace: string, @query principal?: string, @query surface?: string, @query operation?: string, @query kind?: string, @query modelId?: string, @query target?: string, @query status?: string, @query search?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListQueryEventsOK | CommonErrors;

--- a/internal/access/http/apigen.go
+++ b/internal/access/http/apigen.go
@@ -1,0 +1,238 @@
+package http
+
+import (
+	"context"
+	"log/slog"
+	stdhttp "net/http"
+
+	accessgen "github.com/Yacobolo/leapview/internal/access/api/gen"
+	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
+)
+
+// APIGenDispatcher adapts Access's HTTP handler to its generated transport
+// contract. It lives with the capability transport instead of application
+// composition.
+type APIGenDispatcher struct {
+	handler Handler
+}
+
+func NewAPIGenDispatcher(handler Handler) *APIGenDispatcher {
+	return &APIGenDispatcher{handler: handler}
+}
+
+type APIGenTransportErrorResponder struct {
+	Logger *slog.Logger
+}
+
+func (responder APIGenTransportErrorResponder) RespondTransportError(ctx context.Context, w stdhttp.ResponseWriter, r *stdhttp.Request, failure accessgen.GenTransportError) {
+	apitransport.WriteAPIGenFailure(ctx, w, r, responder.Logger, apitransport.APIGenFailure{
+		OperationID: failure.OperationID, Kind: failure.Kind, StatusCode: failure.StatusCode,
+		Code: failure.Code, PublicDetail: failure.PublicDetail, Cause: failure.Cause,
+	})
+}
+
+func (d *APIGenDispatcher) GetCurrentPrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	d.handler.GetCurrentPrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) ListCurrentAPITokens(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenListCurrentAPITokensParams) {
+	d.handler.ListCurrentAPITokens(w, r)
+}
+
+func (d *APIGenDispatcher) CreateCurrentAPIToken(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenCreateCurrentAPITokenHeaders) {
+	d.handler.CreateCurrentAPIToken(w, r)
+}
+
+func (d *APIGenDispatcher) RevokeCurrentAPIToken(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.RevokeCurrentAPIToken(w, r)
+}
+
+func (d *APIGenDispatcher) ListCurrentEffectivePrivileges(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenListCurrentEffectivePrivilegesParams) {
+	d.handler.ListCurrentEffectivePrivileges(w, r)
+}
+
+func (d *APIGenDispatcher) ListCurrentSessions(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenListCurrentSessionsParams) {
+	d.handler.ListCurrentSessions(w, r)
+}
+
+func (d *APIGenDispatcher) RevokeCurrentSession(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.RevokeCurrentSession(w, r)
+}
+
+func (d *APIGenDispatcher) ListPrincipals(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenListPrincipalsParams) {
+	d.handler.ListPrincipals(w, r)
+}
+
+func (d *APIGenDispatcher) CreatePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenCreatePrincipalHeaders) {
+	d.handler.CreatePrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) DeletePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.DeletePrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) GetPrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.GetPrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) UpdatePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, headers accessgen.GenUpdatePrincipalHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	d.handler.UpdatePrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) ResetPrincipalPassword(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenResetPrincipalPasswordHeaders) {
+	d.handler.ResetPrincipalPassword(w, r)
+}
+
+func (d *APIGenDispatcher) ListServicePrincipals(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenListServicePrincipalsParams) {
+	d.handler.ListServicePrincipals(w, r)
+}
+
+func (d *APIGenDispatcher) CreateServicePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenCreateServicePrincipalHeaders) {
+	d.handler.CreateServicePrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) DeleteServicePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.DeleteServicePrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) GetServicePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.GetServicePrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) UpdateServicePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, headers accessgen.GenUpdateServicePrincipalHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	d.handler.UpdateServicePrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) ListServicePrincipalSecrets(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListServicePrincipalSecretsParams) {
+	d.handler.ListServicePrincipalSecrets(w, r)
+}
+
+func (d *APIGenDispatcher) CreateServicePrincipalSecret(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenCreateServicePrincipalSecretHeaders) {
+	d.handler.CreateServicePrincipalSecret(w, r)
+}
+
+func (d *APIGenDispatcher) RevokeServicePrincipalSecret(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.RevokeServicePrincipalSecret(w, r)
+}
+
+func (d *APIGenDispatcher) GetServicePrincipalSecret(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.GetServicePrincipalSecret(w, r)
+}
+
+func (d *APIGenDispatcher) ListAuditEvents(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListAuditEventsParams) {
+	d.handler.ListAuditEvents(w, r)
+}
+
+func (d *APIGenDispatcher) CheckAuthorizationBatch(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.CheckAuthorizationBatch(w, r)
+}
+
+func (d *APIGenDispatcher) ListDataPolicies(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListDataPoliciesParams) {
+	d.handler.ListDataPolicies(w, r)
+}
+
+func (d *APIGenDispatcher) CreateDataPolicy(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenCreateDataPolicyHeaders) {
+	d.handler.CreateDataPolicy(w, r)
+}
+
+func (d *APIGenDispatcher) DeleteDataPolicy(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.DeleteDataPolicy(w, r)
+}
+
+func (d *APIGenDispatcher) GetDataPolicy(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.GetDataPolicy(w, r)
+}
+
+func (d *APIGenDispatcher) UpdateDataPolicy(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenUpdateDataPolicyHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	d.handler.UpdateDataPolicy(w, r)
+}
+
+func (d *APIGenDispatcher) ListEffectivePrivileges(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListEffectivePrivilegesParams) {
+	d.handler.ListEffectivePrivileges(w, r)
+}
+
+func (d *APIGenDispatcher) ListGrants(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListGrantsParams) {
+	d.handler.ListGrants(w, r)
+}
+
+func (d *APIGenDispatcher) CreateGrant(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenCreateGrantHeaders) {
+	d.handler.CreateGrant(w, r)
+}
+
+func (d *APIGenDispatcher) DeleteGrant(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.DeleteGrant(w, r)
+}
+
+func (d *APIGenDispatcher) GetGrant(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.GetGrant(w, r)
+}
+
+func (d *APIGenDispatcher) UpdateGrant(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenUpdateGrantHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	d.handler.UpdateGrant(w, r)
+}
+
+func (d *APIGenDispatcher) ListGroups(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListGroupsParams) {
+	d.handler.ListGroups(w, r)
+}
+
+func (d *APIGenDispatcher) CreateGroup(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenCreateGroupHeaders) {
+	d.handler.CreateGroup(w, r)
+}
+
+func (d *APIGenDispatcher) DeleteGroup(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.DeleteGroup(w, r)
+}
+
+func (d *APIGenDispatcher) GetGroup(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.GetGroup(w, r)
+}
+
+func (d *APIGenDispatcher) UpdateGroup(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenUpdateGroupHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	d.handler.UpdateGroup(w, r)
+}
+
+func (d *APIGenDispatcher) ListGroupMembers(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, _ accessgen.GenListGroupMembersParams) {
+	d.handler.ListGroupMembers(w, r)
+}
+
+func (d *APIGenDispatcher) RemoveGroupMember(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _, _ string) {
+	d.handler.RemoveGroupMember(w, r)
+}
+
+func (d *APIGenDispatcher) AddGroupMember(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _, _ string) {
+	d.handler.AddGroupMember(w, r)
+}
+
+func (d *APIGenDispatcher) TransferOwnership(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenTransferOwnershipHeaders) {
+	d.handler.TransferOwnership(w, r)
+}
+
+func (d *APIGenDispatcher) ListRoleBindings(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListRoleBindingsParams) {
+	d.handler.ListRoleBindings(w, r)
+}
+
+func (d *APIGenDispatcher) CreateRoleBinding(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenCreateRoleBindingHeaders) {
+	d.handler.CreateRoleBinding(w, r)
+}
+
+func (d *APIGenDispatcher) DeleteRoleBinding(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.DeleteRoleBinding(w, r)
+}
+
+func (d *APIGenDispatcher) GetRoleBinding(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.GetRoleBinding(w, r)
+}
+
+func (d *APIGenDispatcher) UpdateRoleBinding(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenUpdateRoleBindingHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	d.handler.UpdateRoleBinding(w, r)
+}
+
+func (d *APIGenDispatcher) ListWorkspaceRoles(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListWorkspaceRolesParams) {
+	d.handler.ListWorkspaceRoles(w, r)
+}

--- a/internal/access/http/apigen_test.go
+++ b/internal/access/http/apigen_test.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"errors"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Yacobolo/leapview/internal/access"
+	accessgen "github.com/Yacobolo/leapview/internal/access/api/gen"
+)
+
+var _ accessgen.GenOperationDispatcher = (*APIGenDispatcher)(nil)
+var _ accessgen.GenTransportErrorResponder = APIGenTransportErrorResponder{}
+
+func TestAPIGenDispatcherPreservesGeneratedIfMatchHeader(t *testing.T) {
+	request := httptest.NewRequest(stdhttp.MethodPatch, "/api/v1/principals/principal-1", strings.NewReader(`{}`))
+	dispatcher := NewAPIGenDispatcher(Handler{
+		Repository: func() (access.Repository, error) {
+			return nil, errors.New("stop after generated header adaptation")
+		},
+	})
+
+	dispatcher.UpdatePrincipal(
+		httptest.NewRecorder(),
+		request,
+		"principal-1",
+		accessgen.GenUpdatePrincipalHeaders{IfMatch: `"revision-1"`},
+	)
+
+	if got, want := request.Header.Get("If-Match"), `"revision-1"`; got != want {
+		t.Fatalf("If-Match = %q, want %q", got, want)
+	}
+}

--- a/internal/access/module/api.go
+++ b/internal/access/module/api.go
@@ -2,34 +2,17 @@ package module
 
 import (
 	"net/http"
+
+	accessgen "github.com/Yacobolo/leapview/internal/access/api/gen"
+	accesshttp "github.com/Yacobolo/leapview/internal/access/http"
 )
 
-func (m *Module) UpdatePrincipal(w http.ResponseWriter, r *http.Request, ifMatch string) {
-	r.Header.Set("If-Match", ifMatch)
-	m.handler.UpdatePrincipal(w, r)
-}
-
-func (m *Module) UpdateServicePrincipal(w http.ResponseWriter, r *http.Request, ifMatch string) {
-	r.Header.Set("If-Match", ifMatch)
-	m.handler.UpdateServicePrincipal(w, r)
-}
-
-func (m *Module) UpdateGrant(w http.ResponseWriter, r *http.Request, ifMatch string) {
-	r.Header.Set("If-Match", ifMatch)
-	m.handler.UpdateGrant(w, r)
-}
-
-func (m *Module) UpdateDataPolicy(w http.ResponseWriter, r *http.Request, ifMatch string) {
-	r.Header.Set("If-Match", ifMatch)
-	m.handler.UpdateDataPolicy(w, r)
-}
-
-func (m *Module) UpdateGroup(w http.ResponseWriter, r *http.Request, ifMatch string) {
-	r.Header.Set("If-Match", ifMatch)
-	m.handler.UpdateGroup(w, r)
-}
-
-func (m *Module) UpdateRoleBinding(w http.ResponseWriter, r *http.Request, ifMatch string) {
-	r.Header.Set("If-Match", ifMatch)
-	m.handler.UpdateRoleBinding(w, r)
+func (m *Module) DispatchAPIGenOperation(operationID string, w http.ResponseWriter, r *http.Request) bool {
+	return accessgen.DispatchAPIGenOperation(
+		operationID,
+		accesshttp.NewAPIGenDispatcher(m.handler),
+		accesshttp.APIGenTransportErrorResponder{Logger: m.logger},
+		w,
+		r,
+	)
 }

--- a/internal/app/api_apigen.go
+++ b/internal/app/api_apigen.go
@@ -47,7 +47,6 @@ func registerAPIGenRoutes(routes *capabilityRoutes, runtime *runtimeServices, pl
 }
 
 type apiGenDispatcher struct {
-	accessModule       *accessmodule.Module
 	dashboardModule    *dashboardmodule.Module
 	deploymentModule   *deploymentmodule.Module
 	managedDataModule  *manageddatamodule.Module
@@ -62,30 +61,6 @@ type apiGenDispatcher struct {
 
 func (a apiGenDispatcher) GetInstance(w http.ResponseWriter, _ *http.Request) {
 	apitransport.WriteJSON(w, http.StatusOK, apigenapi.InstanceResponse{Environment: a.defaultEnvironment})
-}
-
-func (a apiGenDispatcher) GetCurrentPrincipal(w http.ResponseWriter, r *http.Request) {
-	a.accessModule.HTTP().GetCurrentPrincipal(w, r)
-}
-
-func (a apiGenDispatcher) ListCurrentEffectivePrivileges(w http.ResponseWriter, r *http.Request, _ apigenapi.GenListCurrentEffectivePrivilegesParams) {
-	a.accessModule.HTTP().ListCurrentEffectivePrivileges(w, r)
-}
-
-func (a apiGenDispatcher) ListCurrentAPITokens(w http.ResponseWriter, r *http.Request, _ apigenapi.GenListCurrentAPITokensParams) {
-	a.accessModule.HTTP().ListCurrentAPITokens(w, r)
-}
-
-func (a apiGenDispatcher) CreateCurrentAPIToken(w http.ResponseWriter, r *http.Request, _ apigenapi.GenCreateCurrentAPITokenHeaders) {
-	a.accessModule.HTTP().CreateCurrentAPIToken(w, r)
-}
-
-func (a apiGenDispatcher) RevokeCurrentAPIToken(w http.ResponseWriter, r *http.Request, _ string) {
-	a.accessModule.HTTP().RevokeCurrentAPIToken(w, r)
-}
-
-func (a apiGenDispatcher) ListCurrentSessions(w http.ResponseWriter, r *http.Request, _ apigenapi.GenListCurrentSessionsParams) {
-	a.accessModule.HTTP().ListCurrentSessions(w, r)
 }
 
 func (a apiGenDispatcher) GetActiveManagedDataRevision(w http.ResponseWriter, r *http.Request, project, connection string) {
@@ -134,10 +109,6 @@ func (a apiGenDispatcher) CompleteManagedDataS3MultipartUpload(w http.ResponseWr
 
 func (a apiGenDispatcher) SignManagedDataS3MultipartPart(w http.ResponseWriter, r *http.Request, project, connection, uploadSession, multipartUpload string, partNumber int32, _ apigenapi.GenSignManagedDataS3MultipartPartHeaders) {
 	a.managedDataModule.HTTP().SignManagedDataS3MultipartPart(w, r, project, connection, uploadSession, multipartUpload, partNumber)
-}
-
-func (a apiGenDispatcher) RevokeCurrentSession(w http.ResponseWriter, r *http.Request, _ string) {
-	a.accessModule.HTTP().RevokeCurrentSession(w, r)
 }
 
 func (a apiGenDispatcher) ListWorkspaces(w http.ResponseWriter, r *http.Request, _ apigenapi.GenListWorkspacesParams) {
@@ -264,184 +235,12 @@ func (a apiGenDispatcher) GetRefreshRun(w http.ResponseWriter, r *http.Request, 
 	a.refreshModule.GetRefreshRun(w, r, workspaceID, runID)
 }
 
-func (a apiGenDispatcher) ListPrincipals(w http.ResponseWriter, r *http.Request, _ apigenapi.GenListPrincipalsParams) {
-	a.accessModule.HTTP().ListPrincipals(w, r)
-}
-
-func (a apiGenDispatcher) CreatePrincipal(w http.ResponseWriter, r *http.Request, _ apigenapi.GenCreatePrincipalHeaders) {
-	a.accessModule.HTTP().CreatePrincipal(w, r)
-}
-
-func (a apiGenDispatcher) GetPrincipal(w http.ResponseWriter, r *http.Request, _ string) {
-	a.accessModule.HTTP().GetPrincipal(w, r)
-}
-
-func (a apiGenDispatcher) UpdatePrincipal(w http.ResponseWriter, r *http.Request, _ string, headers apigenapi.GenUpdatePrincipalHeaders) {
-	a.accessModule.UpdatePrincipal(w, r, headers.IfMatch)
-}
-
-func (a apiGenDispatcher) DeletePrincipal(w http.ResponseWriter, r *http.Request, _ string) {
-	a.accessModule.HTTP().DeletePrincipal(w, r)
-}
-
-func (a apiGenDispatcher) ResetPrincipalPassword(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenResetPrincipalPasswordHeaders) {
-	a.accessModule.HTTP().ResetPrincipalPassword(w, r)
-}
-
-func (a apiGenDispatcher) ListServicePrincipals(w http.ResponseWriter, r *http.Request, _ apigenapi.GenListServicePrincipalsParams) {
-	a.accessModule.HTTP().ListServicePrincipals(w, r)
-}
-
-func (a apiGenDispatcher) CreateServicePrincipal(w http.ResponseWriter, r *http.Request, _ apigenapi.GenCreateServicePrincipalHeaders) {
-	a.accessModule.HTTP().CreateServicePrincipal(w, r)
-}
-
-func (a apiGenDispatcher) GetServicePrincipal(w http.ResponseWriter, r *http.Request, _ string) {
-	a.accessModule.HTTP().GetServicePrincipal(w, r)
-}
-
-func (a apiGenDispatcher) UpdateServicePrincipal(w http.ResponseWriter, r *http.Request, _ string, headers apigenapi.GenUpdateServicePrincipalHeaders) {
-	a.accessModule.UpdateServicePrincipal(w, r, headers.IfMatch)
-}
-
-func (a apiGenDispatcher) DeleteServicePrincipal(w http.ResponseWriter, r *http.Request, _ string) {
-	a.accessModule.HTTP().DeleteServicePrincipal(w, r)
-}
-
-func (a apiGenDispatcher) CreateServicePrincipalSecret(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenCreateServicePrincipalSecretHeaders) {
-	a.accessModule.HTTP().CreateServicePrincipalSecret(w, r)
-}
-
-func (a apiGenDispatcher) ListServicePrincipalSecrets(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListServicePrincipalSecretsParams) {
-	a.accessModule.HTTP().ListServicePrincipalSecrets(w, r)
-}
-
-func (a apiGenDispatcher) GetServicePrincipalSecret(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().GetServicePrincipalSecret(w, r)
-}
-
-func (a apiGenDispatcher) RevokeServicePrincipalSecret(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().RevokeServicePrincipalSecret(w, r)
-}
-
-func (a apiGenDispatcher) ListWorkspaceRoles(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListWorkspaceRolesParams) {
-	a.accessModule.HTTP().ListWorkspaceRoles(w, r)
-}
-
-func (a apiGenDispatcher) ListEffectivePrivileges(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListEffectivePrivilegesParams) {
-	a.accessModule.HTTP().ListEffectivePrivileges(w, r)
-}
-
-func (a apiGenDispatcher) ListGrants(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListGrantsParams) {
-	a.accessModule.HTTP().ListGrants(w, r)
-}
-
-func (a apiGenDispatcher) CreateGrant(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenCreateGrantHeaders) {
-	a.accessModule.HTTP().CreateGrant(w, r)
-}
-
-func (a apiGenDispatcher) GetGrant(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().GetGrant(w, r)
-}
-
-func (a apiGenDispatcher) UpdateGrant(w http.ResponseWriter, r *http.Request, _, _ string, headers apigenapi.GenUpdateGrantHeaders) {
-	a.accessModule.UpdateGrant(w, r, headers.IfMatch)
-}
-
-func (a apiGenDispatcher) DeleteGrant(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().DeleteGrant(w, r)
-}
-
-func (a apiGenDispatcher) ListDataPolicies(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListDataPoliciesParams) {
-	a.accessModule.HTTP().ListDataPolicies(w, r)
-}
-
-func (a apiGenDispatcher) CreateDataPolicy(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenCreateDataPolicyHeaders) {
-	a.accessModule.HTTP().CreateDataPolicy(w, r)
-}
-
-func (a apiGenDispatcher) GetDataPolicy(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().GetDataPolicy(w, r)
-}
-
-func (a apiGenDispatcher) UpdateDataPolicy(w http.ResponseWriter, r *http.Request, _, _ string, headers apigenapi.GenUpdateDataPolicyHeaders) {
-	a.accessModule.UpdateDataPolicy(w, r, headers.IfMatch)
-}
-
-func (a apiGenDispatcher) CheckAuthorizationBatch(w http.ResponseWriter, r *http.Request, _ string) {
-	a.accessModule.HTTP().CheckAuthorizationBatch(w, r)
-}
-
-func (a apiGenDispatcher) DeleteDataPolicy(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().DeleteDataPolicy(w, r)
-}
-
-func (a apiGenDispatcher) TransferOwnership(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenTransferOwnershipHeaders) {
-	a.accessModule.HTTP().TransferOwnership(w, r)
-}
-
 func (a apiGenDispatcher) ListSemanticModels(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListSemanticModelsParams) {
 	a.dashboardModule.SemanticAPI().ListSemanticModels(w, r)
 }
 
 func (a apiGenDispatcher) GetSemanticModel(w http.ResponseWriter, r *http.Request, _, _ string) {
 	a.dashboardModule.SemanticAPI().GetSemanticModel(w, r)
-}
-
-func (a apiGenDispatcher) ListGroups(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListGroupsParams) {
-	a.accessModule.HTTP().ListGroups(w, r)
-}
-
-func (a apiGenDispatcher) CreateGroup(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenCreateGroupHeaders) {
-	a.accessModule.HTTP().CreateGroup(w, r)
-}
-
-func (a apiGenDispatcher) GetGroup(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().GetGroup(w, r)
-}
-
-func (a apiGenDispatcher) UpdateGroup(w http.ResponseWriter, r *http.Request, _, _ string, headers apigenapi.GenUpdateGroupHeaders) {
-	a.accessModule.UpdateGroup(w, r, headers.IfMatch)
-}
-
-func (a apiGenDispatcher) DeleteGroup(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().DeleteGroup(w, r)
-}
-
-func (a apiGenDispatcher) ListGroupMembers(w http.ResponseWriter, r *http.Request, _, _ string, _ apigenapi.GenListGroupMembersParams) {
-	a.accessModule.HTTP().ListGroupMembers(w, r)
-}
-
-func (a apiGenDispatcher) AddGroupMember(w http.ResponseWriter, r *http.Request, _, _, _ string) {
-	a.accessModule.HTTP().AddGroupMember(w, r)
-}
-
-func (a apiGenDispatcher) RemoveGroupMember(w http.ResponseWriter, r *http.Request, _, _, _ string) {
-	a.accessModule.HTTP().RemoveGroupMember(w, r)
-}
-
-func (a apiGenDispatcher) ListRoleBindings(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListRoleBindingsParams) {
-	a.accessModule.HTTP().ListRoleBindings(w, r)
-}
-
-func (a apiGenDispatcher) CreateRoleBinding(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenCreateRoleBindingHeaders) {
-	a.accessModule.HTTP().CreateRoleBinding(w, r)
-}
-
-func (a apiGenDispatcher) GetRoleBinding(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().GetRoleBinding(w, r)
-}
-
-func (a apiGenDispatcher) UpdateRoleBinding(w http.ResponseWriter, r *http.Request, _, _ string, headers apigenapi.GenUpdateRoleBindingHeaders) {
-	a.accessModule.UpdateRoleBinding(w, r, headers.IfMatch)
-}
-
-func (a apiGenDispatcher) DeleteRoleBinding(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.accessModule.HTTP().DeleteRoleBinding(w, r)
-}
-
-func (a apiGenDispatcher) ListAuditEvents(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListAuditEventsParams) {
-	a.accessModule.HTTP().ListAuditEvents(w, r)
 }
 
 func (a apiGenDispatcher) ListQueryEvents(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListQueryEventsParams) {

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Yacobolo/leapview/internal/access"
+	accessgen "github.com/Yacobolo/leapview/internal/access/api/gen"
 	agentgen "github.com/Yacobolo/leapview/internal/agent/api/gen"
 	apiaggregate "github.com/Yacobolo/leapview/internal/app/api/aggregate"
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
@@ -66,6 +67,7 @@ func TestAPIGenUsesTypeSpecV072(t *testing.T) {
 		"LeapViewAPI:",
 		"LeapViewAPI.Access:",
 		"LeapViewAPI.Agent:",
+		"LeapViewAPI.Analytics:",
 		"LeapViewAPI.Dashboard:",
 		"LeapViewAPI.Deployment:",
 		"LeapViewAPI.ManagedData:",
@@ -197,6 +199,65 @@ func TestAPIGenAgentCapabilityOwnsItsOperationSurface(t *testing.T) {
 	}
 }
 
+func TestAPIGenAccessCapabilityOwnsItsGeneratedPackage(t *testing.T) {
+	root := projectRoot(t)
+	manifest, err := os.ReadFile(filepath.Join(root, "api", "apigen.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	manifestText := string(manifest)
+	for _, want := range []string{
+		"LeapViewAPI.Access:\n          dir: ../internal/access/api/gen\n          package: gen\n          import_path: github.com/Yacobolo/leapview/internal/access/api/gen",
+		"LeapViewAPI.Analytics: *leapview_api_go_package",
+	} {
+		if !strings.Contains(manifestText, want) {
+			t.Fatalf("manifest missing Access capability package plan %q", want)
+		}
+	}
+	if strings.Contains(manifestText, "LeapViewAPI.Access: *leapview_api_go_package") {
+		t.Fatal("Access namespace is still coalesced into the application generated package")
+	}
+
+	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	if err != nil {
+		t.Fatalf("read Taskfile.yml: %v", err)
+	}
+	for _, want := range []string{
+		"internal/access/api/gen/request_models.gen.go",
+		"internal/access/api/gen/server.apigen.gen.go",
+	} {
+		if !strings.Contains(string(taskfile), want) {
+			t.Fatalf("Taskfile.yml does not track generated Access artifact %q", want)
+		}
+	}
+}
+
+func TestAPIGenAccessCapabilityOwnsItsOperationSurface(t *testing.T) {
+	accessContracts := accessgen.GetAPIGenOperationContracts()
+	if got, want := len(accessContracts), 50; got != want {
+		t.Fatalf("Access generated operations = %d, want %d", got, want)
+	}
+	allowedTags := map[string]bool{"Access": true, "Audit": true, "Current User": true}
+	appContracts := apigenapi.GetAPIGenOperationContracts()
+	for operationID, contract := range accessContracts {
+		if len(contract.Tags) != 1 || !allowedTags[contract.Tags[0]] {
+			t.Errorf("Access operation %q tags = %v", operationID, contract.Tags)
+		}
+		if _, exists := appContracts[operationID]; exists {
+			t.Errorf("Access operation %q is still emitted by the application package", operationID)
+		}
+	}
+	if _, exists := accessContracts["listQueryEvents"]; exists {
+		t.Fatal("Analytics-owned listQueryEvents is emitted by the Access package")
+	}
+	if _, exists := appContracts["listQueryEvents"]; !exists {
+		t.Fatal("Analytics-owned listQueryEvents is missing from the coalesced application package")
+	}
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
+		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
+	}
+}
+
 func TestAPIGenIRAssignsCapabilityNamespaces(t *testing.T) {
 	root := projectRoot(t)
 	content, err := os.ReadFile(filepath.Join(root, "api", "gen", "json-ir.json"))
@@ -248,6 +309,9 @@ func TestAPIGenIRAssignsCapabilityNamespaces(t *testing.T) {
 			t.Errorf("endpoint %q has unmapped ownership tag %q", endpoint.OperationID, endpoint.Tags[0])
 			continue
 		}
+		if endpoint.OperationID == "listQueryEvents" {
+			want = "LeapViewAPI.Analytics"
+		}
 		if endpoint.Namespace != want {
 			t.Errorf("endpoint %q namespace = %q, want %q for tag %q", endpoint.OperationID, endpoint.Namespace, want, endpoint.Tags[0])
 		}
@@ -257,6 +321,7 @@ func TestAPIGenIRAssignsCapabilityNamespaces(t *testing.T) {
 		"LeapViewAPI":             {},
 		"LeapViewAPI.Access":      {},
 		"LeapViewAPI.Agent":       {},
+		"LeapViewAPI.Analytics":   {},
 		"LeapViewAPI.Dashboard":   {},
 		"LeapViewAPI.Deployment":  {},
 		"LeapViewAPI.ManagedData": {},

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -792,6 +792,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if apiDispatcher == nil {
 					return false
 				}
+				if routes.accessModule != nil && routes.accessModule.DispatchAPIGenOperation(operationID, writer, request) {
+					return true
+				}
 				if routes.agentModule != nil && routes.agentModule.DispatchAPIGenOperation(operationID, writer, request, platform.logger) {
 					return true
 				}
@@ -910,7 +913,6 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 		return fmt.Errorf("register workspace securables: %w", err)
 	}
 	apiDispatcher = &apiGenDispatcher{
-		accessModule:    routes.accessModule,
 		dashboardModule: routes.dashboardModule, deploymentModule: routes.deploymentModule,
 		managedDataModule: routes.managedDataModule, refreshModule: routes.refreshModule,
 		releaseModule: routes.releaseModule, workspaceModule: routes.workspaceModule,
@@ -933,13 +935,19 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	if err != nil {
 		return fmt.Errorf("build application APIGen transport: %w", err)
 	}
+	accessAPIHandler, err := apiapigenruntime.Build(apiGenAuthorizer, func(operationID string, w http.ResponseWriter, r *http.Request) bool {
+		return routes.accessModule.DispatchAPIGenOperation(operationID, w, r)
+	})
+	if err != nil {
+		return fmt.Errorf("build Access APIGen transport: %w", err)
+	}
 	agentAPIHandler, err := apiapigenruntime.Build(apiGenAuthorizer, func(operationID string, w http.ResponseWriter, r *http.Request) bool {
 		return routes.agentModule.DispatchAPIGenOperation(operationID, w, r, platform.logger)
 	})
 	if err != nil {
 		return fmt.Errorf("build Agent APIGen transport: %w", err)
 	}
-	platform.apiGenServers = apiaggregate.Servers{Agent: agentAPIHandler, Gen: appAPIHandler}
+	platform.apiGenServers = apiaggregate.Servers{Access: accessAPIHandler, Agent: agentAPIHandler, Gen: appAPIHandler}
 	configurePageStream(routes, runtime, platform, policy)
 	platform.health = newHealth(healthConfig{
 		Platform: func(ctx context.Context) error {

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -129,7 +129,6 @@ func newAppTestHarness(metrics QueryMetrics) *appTestHarness {
 
 func apiGenDispatcherForTest(server *appTestHarness) apiGenDispatcher {
 	return apiGenDispatcher{
-		accessModule:    server.routes.accessModule,
 		dashboardModule: server.routes.dashboardModule, deploymentModule: server.routes.deploymentModule,
 		managedDataModule: server.routes.managedDataModule, refreshModule: server.routes.refreshModule,
 		releaseModule: server.routes.releaseModule, workspaceModule: server.routes.workspaceModule,

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -69,6 +69,16 @@ func TestAgentGeneratedAPIIsCapabilityOwned(t *testing.T) {
 	}
 }
 
+func TestAccessGeneratedAPIIsCapabilityOwned(t *testing.T) {
+	rule, ok := ClassifyPackage("internal/access/api/gen")
+	if !ok {
+		t.Fatal("Access generated API package is not classified")
+	}
+	if rule.Capability != "access" || rule.Layer != LayerAdapter {
+		t.Fatalf("Access generated API classification = %#v, want access adapter", rule)
+	}
+}
+
 func TestApplicationOwnsProductConfigurationContract(t *testing.T) {
 	root := repoRoot(t)
 	if !packageDirExists(root, "internal/app/config/spec") {
@@ -1279,6 +1289,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"bun scripts/generate_vega_lite_validator.ts",
 		"bun run build",
 		"FROM golang:1.25-bookworm@sha256:",
+		"COPY --from=sourcegen /src/internal/access/api/gen ./internal/access/api/gen",
 		"COPY --from=sourcegen /src/internal/agent/api/gen ./internal/agent/api/gen",
 		"COPY --from=sourcegen /src/internal/app/api/aggregate ./internal/app/api/aggregate",
 		"COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen",
@@ -1312,7 +1323,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	}
 	ignoreText := string(ignored)
 	for _, want := range []string{
-		".data", ".leapview", "node_modules", "api/gen", "internal/agent/api/gen",
+		".data", ".leapview", "node_modules", "api/gen", "internal/access/api/gen", "internal/agent/api/gen",
 		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "static/chunks",
 	} {
 		if !strings.Contains(ignoreText, want) {

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -165,6 +165,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/refresh/schedule", Capability: "refresh", Layer: LayerUseCase},
 	{Prefix: "internal/platform/http/idempotency", Capability: "platform", Layer: LayerAdapter},
 	{Prefix: "internal/platform/http/api/gen", Capability: "platform", Layer: LayerAdapter},
+	{Prefix: "internal/access/api/gen", Capability: "access", Layer: LayerAdapter},
 	{Prefix: "internal/agent/api/gen", Capability: "agent", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/aggregate", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/gen", Capability: "composition", Layer: LayerAdapter},


### PR DESCRIPTION
## Summary

- Generate the 50 Access-owned operations into `internal/access/api/gen` instead of the application-level generated package.
- Add an Access-owned APIGen dispatcher and transport-error adapter beside the capability HTTP adapter.
- Route generated Access requests through `internal/access/module`, leaving `internal/app` responsible only for composition.
- Reclassify `listQueryEvents` under the Analytics TypeSpec namespace because query auditing is an analytics concern, not an access-control concern.
- Compose the Access, Agent, and remaining application generated servers behind the existing aggregate server without changing the public API.

## Architecture

Before this change, the Access TypeSpec namespace generated into `internal/app/api/gen`, and `internal/app/api_apigen.go` contained 50 forwarding methods that reached back into the Access module. That made application composition the physical owner of an Access transport contract.

This change establishes the intended capability boundary:

```text
api/typespec/access + audit
            |
            v
internal/access/api/gen
            |
            v
internal/access/http/APIGenDispatcher
            |
            v
internal/access/module
```

`internal/app` now constructs the shared authorization transport and aggregates capability servers, but it no longer implements Access's generated operation interface.

Conditional operations continue to propagate APIGen's parsed `If-Match` header to the existing Access handlers. A focused adapter test protects that behavior.

## Ownership correction

The old `LeapViewAPI.Access` namespace contained 51 operations because `listQueryEvents` lived in `audit.tsp` next to access audit events. Query events describe governed analytics execution and are implemented by the query-audit subsystem, so the operation and its models now live in `LeapViewAPI.Analytics`.

The resulting partition is:

- Access: 50 operations
- Analytics (currently application-composed): 1 operation
- Aggregate public surface: 132 operations

This is an internal generation/ownership change only. Routes, operation IDs, tags, schemas, authorization metadata, and generated OpenAPI remain unchanged.

## Build and enforcement

- Track the Access generated request/server files in Task generation inputs.
- Include the capability-generated package in Docker build contexts and CI generated-artifact handling.
- Classify `internal/access/api/gen` as an Access adapter in architecture rules.
- Add tests that enforce namespace-to-package mapping, exact operation ownership, aggregate operation count, TypeSpec namespace ownership, container inclusion, and absence of Access generated imports back into `internal/app`.

## Validation

- `GOFLAGS=-tags=duckdb_arrow task generate`
- `GOFLAGS=-tags=duckdb_arrow task generated:check`
- `GOFLAGS=-tags=duckdb_arrow task ci`
- Post-rebase focused Access/APIGen/architecture tests
- No diff in public OpenAPI or other generated public contract snapshots

Linear: [LEA-82](https://linear.app/leapstack/issue/LEA-82/extract-access-apigen-output-into-its-capability-package)
