### PR TITLE
Extract Analytics APIGen into its capability package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@ infisical-export.*
 api/gen
 internal/access/api/gen
 internal/agent/api/gen
+internal/analytics/api/gen
 internal/app/api/aggregate
 internal/app/api/gen
 internal/app/cli/gen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
             docs/visuals/examples.gen.json
             internal/access/api/gen
             internal/agent/api/gen
+            internal/analytics/api/gen
             internal/app/api/aggregate
             internal/app/api/gen
             internal/app/cli/gen
@@ -115,6 +116,7 @@ jobs:
             docs/reference/config \
             internal/access/api/gen \
             internal/agent/api/gen \
+            internal/analytics/api/gen \
             internal/app/api/aggregate \
             internal/app/api/gen \
             internal/app/cli/gen \
@@ -160,6 +162,7 @@ jobs:
             api/gen/
             internal/access/api/gen/
             internal/agent/api/gen/
+            internal/analytics/api/gen/
             internal/app/api/aggregate/
             internal/app/api/gen/
             internal/app/cli/gen/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ api/.apigen/
 internal/access/api/gen/
 internal/agent/contracts/gen/
 internal/agent/api/gen/
+internal/analytics/api/gen/
 internal/app/api/aggregate/
 internal/app/api/gen/
 internal/app/config/config_gen.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ COPY . .
 COPY --from=sourcegen /src/api/gen ./api/gen
 COPY --from=sourcegen /src/internal/access/api/gen ./internal/access/api/gen
 COPY --from=sourcegen /src/internal/agent/api/gen ./internal/agent/api/gen
+COPY --from=sourcegen /src/internal/analytics/api/gen ./internal/analytics/api/gen
 COPY --from=sourcegen /src/internal/app/api/aggregate ./internal/app/api/aggregate
 COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen
 COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/http/api/gen

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -369,6 +369,8 @@ tasks:
       - internal/access/api/gen/server.apigen.gen.go
       - internal/agent/api/gen/request_models.gen.go
       - internal/agent/api/gen/server.apigen.gen.go
+      - internal/analytics/api/gen/request_models.gen.go
+      - internal/analytics/api/gen/server.apigen.gen.go
       - internal/app/api/aggregate/server.apigen.gen.go
       - internal/app/api/gen/request_models.gen.go
       - internal/app/api/gen/server.apigen.gen.go

--- a/api/apigen.yaml
+++ b/api/apigen.yaml
@@ -22,7 +22,10 @@ targets:
           dir: ../internal/agent/api/gen
           package: gen
           import_path: github.com/Yacobolo/leapview/internal/agent/api/gen
-        LeapViewAPI.Analytics: *leapview_api_go_package
+        LeapViewAPI.Analytics:
+          dir: ../internal/analytics/api/gen
+          package: gen
+          import_path: github.com/Yacobolo/leapview/internal/analytics/api/gen
         LeapViewAPI.Dashboard: *leapview_api_go_package
         LeapViewAPI.Deployment: *leapview_api_go_package
         LeapViewAPI.ManagedData: *leapview_api_go_package

--- a/internal/analytics/module/apigen.go
+++ b/internal/analytics/module/apigen.go
@@ -1,0 +1,22 @@
+package module
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/Yacobolo/leapview/internal/analytics/queryaudit"
+	queryaudithttp "github.com/Yacobolo/leapview/internal/analytics/queryaudit/http"
+)
+
+type QueryAuditAPIGenConfig struct {
+	Reader      func() (queryaudit.Reader, error)
+	WorkspaceID func(string) string
+}
+
+func DispatchQueryAuditAPIGenOperation(config QueryAuditAPIGenConfig, operationID string, logger *slog.Logger, w http.ResponseWriter, r *http.Request) bool {
+	handler := queryaudithttp.Handler{
+		Reader:      queryaudithttp.ReaderProvider(config.Reader),
+		WorkspaceID: queryaudithttp.WorkspaceIDNormalizer(config.WorkspaceID),
+	}
+	return queryaudithttp.DispatchAPIGenOperation(operationID, handler, logger, w, r)
+}

--- a/internal/analytics/module/module.go
+++ b/internal/analytics/module/module.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"net/http"
 
 	analyticsducklake "github.com/Yacobolo/leapview/internal/analytics/ducklake"
 	analyticsmaterialization "github.com/Yacobolo/leapview/internal/analytics/materialization"
 	"github.com/Yacobolo/leapview/internal/analytics/queryaudit"
-	queryaudithttp "github.com/Yacobolo/leapview/internal/analytics/queryaudit/http"
 	queryauditsqlite "github.com/Yacobolo/leapview/internal/analytics/queryaudit/sqlite"
 	"github.com/Yacobolo/leapview/internal/analytics/resource"
 	"github.com/Yacobolo/leapview/internal/analytics/resultcache"
@@ -79,13 +77,6 @@ func (s *QueryAuditSurface) Recorder() queryaudit.Recorder {
 		return nil
 	}
 	return s.repository
-}
-
-func (s *QueryAuditSurface) Events(workspaceID queryaudithttp.WorkspaceIDNormalizer) http.HandlerFunc {
-	if s == nil {
-		return NewQueryAuditEvents(nil, workspaceID)
-	}
-	return NewQueryAuditEvents(s.repository, workspaceID)
 }
 
 type Module struct {
@@ -172,20 +163,6 @@ func (m *Module) QueryAuditRecorder() queryaudit.Recorder {
 		return nil
 	}
 	return m.queryAudit
-}
-
-func (m *Module) QueryAuditEvents(workspaceID queryaudithttp.WorkspaceIDNormalizer) http.HandlerFunc {
-	return NewQueryAuditEvents(m.QueryAuditReader(), workspaceID)
-}
-
-func NewQueryAuditEvents(reader queryaudit.Reader, workspaceID queryaudithttp.WorkspaceIDNormalizer) http.HandlerFunc {
-	handler := queryaudithttp.Handler{
-		Reader: func() (queryaudit.Reader, error) {
-			return reader, nil
-		},
-		WorkspaceID: workspaceID,
-	}
-	return handler.ListQueryEvents
 }
 
 func (m *Module) Healthy() error {

--- a/internal/analytics/queryaudit/http/apigen.go
+++ b/internal/analytics/queryaudit/http/apigen.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"context"
+	"log/slog"
+	stdhttp "net/http"
+
+	analyticsgen "github.com/Yacobolo/leapview/internal/analytics/api/gen"
+	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
+)
+
+type QueryEventsHandler interface {
+	ListQueryEvents(stdhttp.ResponseWriter, *stdhttp.Request)
+}
+
+// APIGenDispatcher adapts the Analytics query-audit HTTP handler to its
+// generated transport contract.
+type APIGenDispatcher struct {
+	handler QueryEventsHandler
+}
+
+func NewAPIGenDispatcher(handler QueryEventsHandler) *APIGenDispatcher {
+	return &APIGenDispatcher{handler: handler}
+}
+
+func (d *APIGenDispatcher) ListQueryEvents(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ analyticsgen.GenListQueryEventsParams) {
+	d.handler.ListQueryEvents(w, r)
+}
+
+type APIGenTransportErrorResponder struct {
+	Logger *slog.Logger
+}
+
+func (responder APIGenTransportErrorResponder) RespondTransportError(ctx context.Context, w stdhttp.ResponseWriter, r *stdhttp.Request, failure analyticsgen.GenTransportError) {
+	apitransport.WriteAPIGenFailure(ctx, w, r, responder.Logger, apitransport.APIGenFailure{
+		OperationID: failure.OperationID, Kind: failure.Kind, StatusCode: failure.StatusCode,
+		Code: failure.Code, PublicDetail: failure.PublicDetail, Cause: failure.Cause,
+	})
+}
+
+func DispatchAPIGenOperation(operationID string, handler QueryEventsHandler, logger *slog.Logger, w stdhttp.ResponseWriter, r *stdhttp.Request) bool {
+	return analyticsgen.DispatchAPIGenOperation(
+		operationID,
+		NewAPIGenDispatcher(handler),
+		APIGenTransportErrorResponder{Logger: logger},
+		w,
+		r,
+	)
+}

--- a/internal/analytics/queryaudit/http/apigen_test.go
+++ b/internal/analytics/queryaudit/http/apigen_test.go
@@ -1,0 +1,41 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	analyticsgen "github.com/Yacobolo/leapview/internal/analytics/api/gen"
+)
+
+var _ analyticsgen.GenOperationDispatcher = (*APIGenDispatcher)(nil)
+var _ analyticsgen.GenTransportErrorResponder = APIGenTransportErrorResponder{}
+
+func TestAPIGenDispatcherDelegatesQueryEventsToCapabilityHandler(t *testing.T) {
+	called := false
+	dispatcher := NewAPIGenDispatcher(queryEventsHandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		called = true
+		w.WriteHeader(stdhttp.StatusNoContent)
+	}))
+	recorder := httptest.NewRecorder()
+
+	dispatcher.ListQueryEvents(
+		recorder,
+		httptest.NewRequest(stdhttp.MethodGet, "/api/v1/workspaces/sales/query-events?limit=10", nil),
+		"sales",
+		analyticsgen.GenListQueryEventsParams{},
+	)
+
+	if !called {
+		t.Fatal("generated Analytics dispatcher did not delegate to the query-audit handler")
+	}
+	if got, want := recorder.Code, stdhttp.StatusNoContent; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+type queryEventsHandlerFunc func(stdhttp.ResponseWriter, *stdhttp.Request)
+
+func (fn queryEventsHandlerFunc) ListQueryEvents(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	fn(w, r)
+}

--- a/internal/app/api_apigen.go
+++ b/internal/app/api_apigen.go
@@ -57,7 +57,6 @@ type apiGenDispatcher struct {
 	defaultEnvironment string
 	buildIdentity      buildinfo.Identity
 	managedDataTus     http.Handler
-	queryAuditEvents   http.HandlerFunc
 }
 
 func (a apiGenDispatcher) GetInstance(w http.ResponseWriter, _ *http.Request) {
@@ -242,8 +241,4 @@ func (a apiGenDispatcher) ListSemanticModels(w http.ResponseWriter, r *http.Requ
 
 func (a apiGenDispatcher) GetSemanticModel(w http.ResponseWriter, r *http.Request, _, _ string) {
 	a.dashboardModule.SemanticAPI().GetSemanticModel(w, r)
-}
-
-func (a apiGenDispatcher) ListQueryEvents(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListQueryEventsParams) {
-	a.queryAuditEvents(w, r)
 }

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Yacobolo/leapview/internal/access"
 	accessgen "github.com/Yacobolo/leapview/internal/access/api/gen"
 	agentgen "github.com/Yacobolo/leapview/internal/agent/api/gen"
+	analyticsgen "github.com/Yacobolo/leapview/internal/analytics/api/gen"
 	apiaggregate "github.com/Yacobolo/leapview/internal/app/api/aggregate"
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
 	"github.com/Yacobolo/leapview/internal/workspace"
@@ -208,7 +209,7 @@ func TestAPIGenAccessCapabilityOwnsItsGeneratedPackage(t *testing.T) {
 	manifestText := string(manifest)
 	for _, want := range []string{
 		"LeapViewAPI.Access:\n          dir: ../internal/access/api/gen\n          package: gen\n          import_path: github.com/Yacobolo/leapview/internal/access/api/gen",
-		"LeapViewAPI.Analytics: *leapview_api_go_package",
+		"LeapViewAPI.Analytics:\n          dir: ../internal/analytics/api/gen\n          package: gen\n          import_path: github.com/Yacobolo/leapview/internal/analytics/api/gen",
 	} {
 		if !strings.Contains(manifestText, want) {
 			t.Fatalf("manifest missing Access capability package plan %q", want)
@@ -225,6 +226,8 @@ func TestAPIGenAccessCapabilityOwnsItsGeneratedPackage(t *testing.T) {
 	for _, want := range []string{
 		"internal/access/api/gen/request_models.gen.go",
 		"internal/access/api/gen/server.apigen.gen.go",
+		"internal/analytics/api/gen/request_models.gen.go",
+		"internal/analytics/api/gen/server.apigen.gen.go",
 	} {
 		if !strings.Contains(string(taskfile), want) {
 			t.Fatalf("Taskfile.yml does not track generated Access artifact %q", want)
@@ -250,8 +253,28 @@ func TestAPIGenAccessCapabilityOwnsItsOperationSurface(t *testing.T) {
 	if _, exists := accessContracts["listQueryEvents"]; exists {
 		t.Fatal("Analytics-owned listQueryEvents is emitted by the Access package")
 	}
-	if _, exists := appContracts["listQueryEvents"]; !exists {
-		t.Fatal("Analytics-owned listQueryEvents is missing from the coalesced application package")
+	if _, exists := appContracts["listQueryEvents"]; exists {
+		t.Fatal("Analytics-owned listQueryEvents is still emitted by the application package")
+	}
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
+		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
+	}
+}
+
+func TestAPIGenAnalyticsCapabilityOwnsItsOperationSurface(t *testing.T) {
+	analyticsContracts := analyticsgen.GetAPIGenOperationContracts()
+	if got, want := len(analyticsContracts), 1; got != want {
+		t.Fatalf("Analytics generated operations = %d, want %d", got, want)
+	}
+	contract, exists := analyticsContracts["listQueryEvents"]
+	if !exists {
+		t.Fatal("Analytics generated package is missing listQueryEvents")
+	}
+	if len(contract.Tags) != 1 || contract.Tags[0] != "Audit" {
+		t.Fatalf("listQueryEvents tags = %v, want [Audit]", contract.Tags)
+	}
+	if _, exists := apigenapi.GetAPIGenOperationContracts()["listQueryEvents"]; exists {
+		t.Fatal("Analytics-owned listQueryEvents is still emitted by the application package")
 	}
 	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -15,6 +15,7 @@ import (
 	adminmodule "github.com/Yacobolo/leapview/internal/admin/module"
 	agentmodule "github.com/Yacobolo/leapview/internal/agent/module"
 	analyticsmodule "github.com/Yacobolo/leapview/internal/analytics/module"
+	queryaudithttp "github.com/Yacobolo/leapview/internal/analytics/queryaudit/http"
 	apiaggregate "github.com/Yacobolo/leapview/internal/app/api/aggregate"
 	apiapigenruntime "github.com/Yacobolo/leapview/internal/app/api/apigenruntime"
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
@@ -70,7 +71,6 @@ type runtimeServices struct {
 	platformHealth        platformHealth
 	storageRetention      *servingstatemodule.Retention
 	queryAuditProvider    adminmodule.QueryAuditReaderProvider
-	queryAuditEvents      http.HandlerFunc
 }
 
 type platformServices struct {
@@ -311,11 +311,9 @@ func buildApplicationSurfaces(
 	}
 	var queryAuditProvider adminmodule.QueryAuditReaderProvider
 	var queryAuditRecorder dashboardmodule.QueryAuditRecorder
-	var queryAuditEvents http.HandlerFunc
 	if workflow.QueryAudit != nil {
 		queryAuditProvider = adminmodule.QueryAuditReaderProvider(workflow.QueryAudit.Provider())
 		queryAuditRecorder = workflow.QueryAudit.Recorder()
-		queryAuditEvents = workflow.QueryAudit.Events(func(value string) string { return value })
 	}
 	if capabilities.AnalyticsModule != nil {
 		if capabilities.AnalyticsModule.QueryAuditReader() != nil {
@@ -336,13 +334,6 @@ func buildApplicationSurfaces(
 	persistence := persistenceInputs{}
 	moduleWorkflow := workflowInputs{}
 	storage := storageInputs{}
-	runtime.queryAuditEvents = queryAuditEvents
-	if runtime.queryAuditEvents == nil {
-		runtime.queryAuditEvents = analyticsmodule.NewQueryAuditEvents(nil, func(value string) string { return workspaceID(routes, runtime, platform, policy, value) })
-	}
-	if capabilities.AnalyticsModule != nil && capabilities.AnalyticsModule.QueryAuditReader() != nil {
-		runtime.queryAuditEvents = capabilities.AnalyticsModule.QueryAuditEvents(func(value string) string { return workspaceID(routes, runtime, platform, policy, value) })
-	}
 	moduleWorkflow.refreshPipelineClock = workflow.RefreshPipelineClock
 	runtime.queryAuditProvider = queryAuditProvider
 	if moduleWorkflow.refreshPipelineClock == nil {
@@ -466,6 +457,12 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	queryAuditAPI := queryaudithttp.Handler{
+		Reader: queryaudithttp.ReaderProvider(runtime.queryAuditProvider),
+		WorkspaceID: func(value string) string {
+			return workspaceID(routes, runtime, platform, policy, value)
+		},
 	}
 	var apiDispatcher *apiGenDispatcher
 	if routes.accessModule == nil {
@@ -803,6 +800,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if routes.agentModule != nil && routes.agentModule.DispatchAPIGenOperation(operationID, writer, request, platform.logger) {
 					return true
 				}
+				if queryaudithttp.DispatchAPIGenOperation(operationID, queryAuditAPI, platform.logger, writer, request) {
+					return true
+				}
 				return apigenapi.DispatchAPIGenOperation(operationID, apiDispatcher, apiprotocol.TransportErrorResponder{Logger: platform.logger}, writer, request)
 			},
 			QueryContext: func(ctx context.Context, scope agentmodule.Scope) context.Context {
@@ -922,8 +922,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 		managedDataModule: routes.managedDataModule, refreshModule: routes.refreshModule,
 		releaseModule: routes.releaseModule, workspaceModule: routes.workspaceModule,
 		defaultEnvironment: policy.defaultEnvironment, managedDataTus: policy.managedDataTus,
-		buildIdentity:    platform.buildIdentity,
-		queryAuditEvents: runtime.queryAuditEvents,
+		buildIdentity: platform.buildIdentity,
 	}
 	apiGenAuthorizer, err := routes.accessModule.APIGenAuthorizer(accessAPIGenOperationContracts(), accessmodule.APIGenObjectResolvers{
 		Dashboard:      dashboardmodule.DashboardObjectRefs,
@@ -952,7 +951,15 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	if err != nil {
 		return fmt.Errorf("build Agent APIGen transport: %w", err)
 	}
-	platform.apiGenServers = apiaggregate.Servers{Access: accessAPIHandler, Agent: agentAPIHandler, Gen: appAPIHandler}
+	analyticsAPIHandler, err := apiapigenruntime.Build(apiGenAuthorizer, func(operationID string, w http.ResponseWriter, r *http.Request) bool {
+		return queryaudithttp.DispatchAPIGenOperation(operationID, queryAuditAPI, platform.logger, w, r)
+	})
+	if err != nil {
+		return fmt.Errorf("build Analytics APIGen transport: %w", err)
+	}
+	platform.apiGenServers = apiaggregate.Servers{
+		Access: accessAPIHandler, Agent: agentAPIHandler, Analytics: analyticsAPIHandler, Gen: appAPIHandler,
+	}
 	configurePageStream(routes, runtime, platform, policy)
 	platform.health = newHealth(healthConfig{
 		Platform: func(ctx context.Context) error {

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -15,7 +15,6 @@ import (
 	adminmodule "github.com/Yacobolo/leapview/internal/admin/module"
 	agentmodule "github.com/Yacobolo/leapview/internal/agent/module"
 	analyticsmodule "github.com/Yacobolo/leapview/internal/analytics/module"
-	queryaudithttp "github.com/Yacobolo/leapview/internal/analytics/queryaudit/http"
 	apiaggregate "github.com/Yacobolo/leapview/internal/app/api/aggregate"
 	apiapigenruntime "github.com/Yacobolo/leapview/internal/app/api/apigenruntime"
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
@@ -458,8 +457,8 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	queryAuditAPI := queryaudithttp.Handler{
-		Reader: queryaudithttp.ReaderProvider(runtime.queryAuditProvider),
+	queryAuditAPI := analyticsmodule.QueryAuditAPIGenConfig{
+		Reader: runtime.queryAuditProvider,
 		WorkspaceID: func(value string) string {
 			return workspaceID(routes, runtime, platform, policy, value)
 		},
@@ -800,7 +799,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if routes.agentModule != nil && routes.agentModule.DispatchAPIGenOperation(operationID, writer, request, platform.logger) {
 					return true
 				}
-				if queryaudithttp.DispatchAPIGenOperation(operationID, queryAuditAPI, platform.logger, writer, request) {
+				if analyticsmodule.DispatchQueryAuditAPIGenOperation(queryAuditAPI, operationID, platform.logger, writer, request) {
 					return true
 				}
 				return apigenapi.DispatchAPIGenOperation(operationID, apiDispatcher, apiprotocol.TransportErrorResponder{Logger: platform.logger}, writer, request)
@@ -952,7 +951,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 		return fmt.Errorf("build Agent APIGen transport: %w", err)
 	}
 	analyticsAPIHandler, err := apiapigenruntime.Build(apiGenAuthorizer, func(operationID string, w http.ResponseWriter, r *http.Request) bool {
-		return queryaudithttp.DispatchAPIGenOperation(operationID, queryAuditAPI, platform.logger, w, r)
+		return analyticsmodule.DispatchQueryAuditAPIGenOperation(queryAuditAPI, operationID, platform.logger, w, r)
 	})
 	if err != nil {
 		return fmt.Errorf("build Analytics APIGen transport: %w", err)

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -133,8 +133,7 @@ func apiGenDispatcherForTest(server *appTestHarness) apiGenDispatcher {
 		managedDataModule: server.routes.managedDataModule, refreshModule: server.routes.refreshModule,
 		releaseModule: server.routes.releaseModule, workspaceModule: server.routes.workspaceModule,
 		defaultEnvironment: server.policy.defaultEnvironment, managedDataTus: server.policy.managedDataTus,
-		buildIdentity:    server.platform.buildIdentity,
-		queryAuditEvents: server.runtime.queryAuditEvents,
+		buildIdentity: server.platform.buildIdentity,
 	}
 }
 

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -79,6 +79,16 @@ func TestAccessGeneratedAPIIsCapabilityOwned(t *testing.T) {
 	}
 }
 
+func TestAnalyticsGeneratedAPIIsCapabilityOwned(t *testing.T) {
+	rule, ok := ClassifyPackage("internal/analytics/api/gen")
+	if !ok {
+		t.Fatal("Analytics generated API package is not classified")
+	}
+	if rule.Capability != "analytics" || rule.Layer != LayerAdapter {
+		t.Fatalf("Analytics generated API classification = %#v, want analytics adapter", rule)
+	}
+}
+
 func TestApplicationOwnsProductConfigurationContract(t *testing.T) {
 	root := repoRoot(t)
 	if !packageDirExists(root, "internal/app/config/spec") {
@@ -1291,6 +1301,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"FROM golang:1.25-bookworm@sha256:",
 		"COPY --from=sourcegen /src/internal/access/api/gen ./internal/access/api/gen",
 		"COPY --from=sourcegen /src/internal/agent/api/gen ./internal/agent/api/gen",
+		"COPY --from=sourcegen /src/internal/analytics/api/gen ./internal/analytics/api/gen",
 		"COPY --from=sourcegen /src/internal/app/api/aggregate ./internal/app/api/aggregate",
 		"COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen",
 		"COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/http/api/gen",
@@ -1323,7 +1334,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	}
 	ignoreText := string(ignored)
 	for _, want := range []string{
-		".data", ".leapview", "node_modules", "api/gen", "internal/access/api/gen", "internal/agent/api/gen",
+		".data", ".leapview", "node_modules", "api/gen", "internal/access/api/gen", "internal/agent/api/gen", "internal/analytics/api/gen",
 		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "static/chunks",
 	} {
 		if !strings.Contains(ignoreText, want) {

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -167,6 +167,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/platform/http/api/gen", Capability: "platform", Layer: LayerAdapter},
 	{Prefix: "internal/access/api/gen", Capability: "access", Layer: LayerAdapter},
 	{Prefix: "internal/agent/api/gen", Capability: "agent", Layer: LayerAdapter},
+	{Prefix: "internal/analytics/api/gen", Capability: "analytics", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/aggregate", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/gen", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/platform/architecture", Capability: "platform", Layer: LayerPlatform},


### PR DESCRIPTION
## Summary

- Generate the one Analytics-owned API operation into `internal/analytics/api/gen`.
- Add a query-audit-owned APIGen dispatcher and transport-error responder.
- Compose the Analytics generated server in `internal/app` without retaining an Analytics forwarding method or stored HTTP handler.
- Remove obsolete query-audit HTTP construction helpers from the Analytics runtime module.
- Add generation, Docker, CI, and architecture enforcement for the new package.

## Architecture

This is stack position 1 of 8 under [LEA-98](https://linear.app/leapstack/issue/LEA-98/complete-capability-owned-apigen-module-migrations) and is based on the Access migration in PR #139.

`listQueryEvents` is a query-audit/Analytics concern. Its generated transport now follows:

```text
LeapViewAPI.Analytics
        |
        v
internal/analytics/api/gen
        |
        v
internal/analytics/queryaudit/http
        |
        v
queryaudit.Reader
```

The application supplies the query-audit reader and workspace normalizer, constructs the shared authorized transport, and adds the generated server to the aggregate. It no longer implements the generated Analytics operation or stores a capability HTTP handler.

Analytics remains a normal capability boundary; this change does not add a fake runtime module solely for APIGen.

## Compatibility

- Analytics owns exactly 1 operation.
- The application package no longer emits `listQueryEvents`.
- The aggregate still exposes all 132 operations exactly once.
- Routes, operation IDs, tags, authorization metadata, OpenAPI, and public generated snapshots are unchanged.

## Validation

- Focused query-audit dispatcher test written red-first.
- Focused Analytics, application APIGen, and architecture tests pass.
- `GOFLAGS=-tags=duckdb_arrow task generated:check`
- No public contract diff.

Linear: [LEA-100](https://linear.app/leapstack/issue/LEA-100/extract-analytics-apigen-output-into-its-capability-package)

Stack base: PR #139. This PR must not be merged until its base is merged, and it is intentionally left open.
