### PR TITLE
Extract Project APIGen into its capability package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,7 @@ internal/app/api/aggregate
 internal/app/api/gen
 internal/app/cli/gen
 internal/platform/http/api/gen
+internal/project/api/gen
 internal/app/config/config_gen.go
 internal/app/config/spec/names_gen.go
 internal/platform/db/db.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
             internal/app/config/config_gen.go
             internal/app/config/spec/names_gen.go
             internal/platform/http/api/gen
+            internal/project/api/gen
             internal/platform/db/db.go
             internal/platform/db/models.go
             internal/platform/db/*.sql.go
@@ -121,6 +122,7 @@ jobs:
             internal/app/api/gen \
             internal/app/cli/gen \
             internal/platform/http/api/gen \
+            internal/project/api/gen \
             schemas/config \
             schemas/json \
             web/generated
@@ -169,6 +171,7 @@ jobs:
             internal/app/config/config_gen.go
             internal/app/config/spec/names_gen.go
             internal/platform/http/api/gen/
+            internal/project/api/gen/
             internal/platform/db/db.go
             internal/platform/db/models.go
             internal/platform/db/*.sql.go

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ internal/dashboard/ui/signals/models.gen.go
 internal/workspace/ui/signals/models.gen.go
 internal/app/cli/gen/
 internal/platform/http/api/gen/
+internal/project/api/gen/
 internal/platform/db/db.go
 internal/platform/db/models.go
 internal/platform/db/*.sql.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=sourcegen /src/internal/analytics/api/gen ./internal/analytics/api/g
 COPY --from=sourcegen /src/internal/app/api/aggregate ./internal/app/api/aggregate
 COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen
 COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/http/api/gen
+COPY --from=sourcegen /src/internal/project/api/gen ./internal/project/api/gen
 COPY --from=sourcegen /src/internal/app/cli/gen ./internal/app/cli/gen
 COPY --from=sourcegen /src/internal/app/config/config_gen.go ./internal/app/config/config_gen.go
 COPY --from=sourcegen /src/internal/app/config/spec/names_gen.go ./internal/app/config/spec/names_gen.go

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -376,6 +376,8 @@ tasks:
       - internal/app/api/gen/server.apigen.gen.go
       - internal/app/cli/gen/apigen_registry.gen.go
       - internal/platform/http/api/gen/request_models.gen.go
+      - internal/project/api/gen/request_models.gen.go
+      - internal/project/api/gen/server.apigen.gen.go
       - docs/api/catalog.json
       - docs/api/openapi.yaml
       - docs/api/operations.json

--- a/api/apigen.yaml
+++ b/api/apigen.yaml
@@ -29,7 +29,10 @@ targets:
         LeapViewAPI.Dashboard: *leapview_api_go_package
         LeapViewAPI.Deployment: *leapview_api_go_package
         LeapViewAPI.ManagedData: *leapview_api_go_package
-        LeapViewAPI.Project: *leapview_api_go_package
+        LeapViewAPI.Project:
+          dir: ../internal/project/api/gen
+          package: gen
+          import_path: github.com/Yacobolo/leapview/internal/project/api/gen
         LeapViewAPI.Protocol:
           dir: ../internal/platform/http/api/gen
           package: gen

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -14,6 +14,7 @@ import (
 	analyticsgen "github.com/Yacobolo/leapview/internal/analytics/api/gen"
 	apiaggregate "github.com/Yacobolo/leapview/internal/app/api/aggregate"
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
+	projectgen "github.com/Yacobolo/leapview/internal/project/api/gen"
 	"github.com/Yacobolo/leapview/internal/workspace"
 )
 
@@ -275,6 +276,54 @@ func TestAPIGenAnalyticsCapabilityOwnsItsOperationSurface(t *testing.T) {
 	}
 	if _, exists := apigenapi.GetAPIGenOperationContracts()["listQueryEvents"]; exists {
 		t.Fatal("Analytics-owned listQueryEvents is still emitted by the application package")
+	}
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
+		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
+	}
+}
+
+func TestAPIGenProjectCapabilityOwnsItsGeneratedPackage(t *testing.T) {
+	root := projectRoot(t)
+	manifest, err := os.ReadFile(filepath.Join(root, "api", "apigen.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	manifestText := string(manifest)
+	want := "LeapViewAPI.Project:\n          dir: ../internal/project/api/gen\n          package: gen\n          import_path: github.com/Yacobolo/leapview/internal/project/api/gen"
+	if !strings.Contains(manifestText, want) {
+		t.Fatalf("manifest missing Project capability package plan %q", want)
+	}
+	if strings.Contains(manifestText, "LeapViewAPI.Project: *leapview_api_go_package") {
+		t.Fatal("Project namespace is still coalesced into the application generated package")
+	}
+
+	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	if err != nil {
+		t.Fatalf("read Taskfile.yml: %v", err)
+	}
+	for _, path := range []string{
+		"internal/project/api/gen/request_models.gen.go",
+		"internal/project/api/gen/server.apigen.gen.go",
+	} {
+		if !strings.Contains(string(taskfile), path) {
+			t.Fatalf("Taskfile.yml does not track generated Project artifact %q", path)
+		}
+	}
+}
+
+func TestAPIGenProjectCapabilityOwnsItsOperationSurface(t *testing.T) {
+	projectContracts := projectgen.GetAPIGenOperationContracts()
+	if got, want := len(projectContracts), 3; got != want {
+		t.Fatalf("Project generated operations = %d, want %d", got, want)
+	}
+	appContracts := apigenapi.GetAPIGenOperationContracts()
+	for operationID, contract := range projectContracts {
+		if len(contract.Tags) != 1 || contract.Tags[0] != "Projects" {
+			t.Errorf("Project operation %q tags = %v, want [Projects]", operationID, contract.Tags)
+		}
+		if _, exists := appContracts[operationID]; exists {
+			t.Errorf("Project operation %q is still emitted by the application package", operationID)
+		}
 	}
 	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)

--- a/internal/app/api_v1_supplemental.go
+++ b/internal/app/api_v1_supplemental.go
@@ -8,18 +8,6 @@ import (
 	releasemodule "github.com/Yacobolo/leapview/internal/release/module"
 )
 
-func (a apiGenDispatcher) ListProjects(w http.ResponseWriter, r *http.Request, params apigenapi.GenListProjectsParams) {
-	a.releaseModule.ListProjects(w, r, releasemodule.PageParams{Limit: params.Limit, PageToken: params.PageToken})
-}
-
-func (a apiGenDispatcher) GetProject(w http.ResponseWriter, r *http.Request, projectID string) {
-	a.releaseModule.GetProject(w, r, projectID)
-}
-
-func (a apiGenDispatcher) ListProjectWorkspaces(w http.ResponseWriter, r *http.Request, projectID string, params apigenapi.GenListProjectWorkspacesParams) {
-	a.releaseModule.ListProjectWorkspaces(w, r, projectID, releasemodule.PageParams{Limit: params.Limit, PageToken: params.PageToken})
-}
-
 func (a apiGenDispatcher) ListManagedConnections(w http.ResponseWriter, r *http.Request, projectID string, params apigenapi.GenListManagedConnectionsParams) {
 	a.releaseModule.ListManagedConnections(w, r, projectID, releasemodule.PageParams{Limit: params.Limit, PageToken: params.PageToken})
 }

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -33,6 +33,7 @@ import (
 	webpage "github.com/Yacobolo/leapview/internal/platform/web/page"
 	"github.com/Yacobolo/leapview/internal/platform/web/staticasset"
 	uitransport "github.com/Yacobolo/leapview/internal/platform/web/transport"
+	projecthttp "github.com/Yacobolo/leapview/internal/project/http"
 	refreshmodule "github.com/Yacobolo/leapview/internal/refresh/module"
 	releasemodule "github.com/Yacobolo/leapview/internal/release/module"
 	runtimehostmodule "github.com/Yacobolo/leapview/internal/runtimehost/module"
@@ -802,6 +803,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if analyticsmodule.DispatchQueryAuditAPIGenOperation(queryAuditAPI, operationID, platform.logger, writer, request) {
 					return true
 				}
+				if routes.releaseModule != nil && projecthttp.DispatchAPIGenOperation(operationID, routes.releaseModule, platform.logger, writer, request) {
+					return true
+				}
 				return apigenapi.DispatchAPIGenOperation(operationID, apiDispatcher, apiprotocol.TransportErrorResponder{Logger: platform.logger}, writer, request)
 			},
 			QueryContext: func(ctx context.Context, scope agentmodule.Scope) context.Context {
@@ -956,8 +960,15 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	if err != nil {
 		return fmt.Errorf("build Analytics APIGen transport: %w", err)
 	}
+	projectAPIHandler, err := apiapigenruntime.Build(apiGenAuthorizer, func(operationID string, w http.ResponseWriter, r *http.Request) bool {
+		return projecthttp.DispatchAPIGenOperation(operationID, routes.releaseModule, platform.logger, w, r)
+	})
+	if err != nil {
+		return fmt.Errorf("build Project APIGen transport: %w", err)
+	}
 	platform.apiGenServers = apiaggregate.Servers{
-		Access: accessAPIHandler, Agent: agentAPIHandler, Analytics: analyticsAPIHandler, Gen: appAPIHandler,
+		Access: accessAPIHandler, Agent: agentAPIHandler, Analytics: analyticsAPIHandler,
+		Gen: appAPIHandler, Project: projectAPIHandler,
 	}
 	configurePageStream(routes, runtime, platform, policy)
 	platform.health = newHealth(healthConfig{

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -663,6 +663,11 @@ func TestCapabilityModulesRequireDeclaredPublicContractEdges(t *testing.T) {
 }
 
 func TestApplicationImportsProductCapabilitiesOnlyThroughModules(t *testing.T) {
+	// Project is intentionally compile-time-first and has no synthetic runtime
+	// module. Its generated HTTP adapter is therefore a valid composition edge.
+	compositionAdapters := map[string]bool{
+		"internal/project/http": true,
+	}
 	for _, file := range productionGoFiles(t) {
 		if file.pkgDir != "internal/app" {
 			continue
@@ -676,7 +681,7 @@ func TestApplicationImportsProductCapabilitiesOnlyThroughModules(t *testing.T) {
 			if !ok || target.Capability == "platform" || target.Capability == "composition" {
 				continue
 			}
-			if target.Layer != LayerModule {
+			if target.Layer != LayerModule && !compositionAdapters[packagePath] {
 				t.Errorf("%s imports product package %s instead of its module surface", file.path, packagePath)
 			}
 		}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -89,6 +89,34 @@ func TestAnalyticsGeneratedAPIIsCapabilityOwned(t *testing.T) {
 	}
 }
 
+func TestProjectGeneratedAPIIsCapabilityOwned(t *testing.T) {
+	rule, ok := ClassifyPackage("internal/project/api/gen")
+	if !ok {
+		t.Fatal("Project generated API package is not classified")
+	}
+	if rule.Capability != "project" || rule.Layer != LayerAdapter {
+		t.Fatalf("Project generated API classification = %#v, want project adapter", rule)
+	}
+}
+
+func TestProjectTransportContractsAreCapabilityOwned(t *testing.T) {
+	root := repoRoot(t)
+	projectContracts, err := os.ReadFile(filepath.Join(root, "internal", "project", "api", "contracts.go"))
+	if err != nil {
+		t.Fatalf("read Project API contracts: %v", err)
+	}
+	if !strings.Contains(string(projectContracts), "type ProjectResponse struct") {
+		t.Fatal("Project capability does not own its handwritten response contract")
+	}
+	releaseContracts, err := os.ReadFile(filepath.Join(root, "internal", "release", "api", "contracts.go"))
+	if err != nil {
+		t.Fatalf("read Release API contracts: %v", err)
+	}
+	if strings.Contains(string(releaseContracts), "type ProjectResponse struct") {
+		t.Fatal("Release capability still owns the Project response contract")
+	}
+}
+
 func TestApplicationOwnsProductConfigurationContract(t *testing.T) {
 	root := repoRoot(t)
 	if !packageDirExists(root, "internal/app/config/spec") {
@@ -1305,6 +1333,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"COPY --from=sourcegen /src/internal/app/api/aggregate ./internal/app/api/aggregate",
 		"COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen",
 		"COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/http/api/gen",
+		"COPY --from=sourcegen /src/internal/project/api/gen ./internal/project/api/gen",
 		"COPY --from=sourcegen /src/internal/access/ui/signals/models.gen.go ./internal/access/ui/signals/models.gen.go",
 		"COPY --from=sourcegen /src/internal/admin/ui/signals/models.gen.go ./internal/admin/ui/signals/models.gen.go",
 		"COPY --from=sourcegen /src/internal/agent/ui/signals/models.gen.go ./internal/agent/ui/signals/models.gen.go",
@@ -1335,7 +1364,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	ignoreText := string(ignored)
 	for _, want := range []string{
 		".data", ".leapview", "node_modules", "api/gen", "internal/access/api/gen", "internal/agent/api/gen", "internal/analytics/api/gen",
-		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "static/chunks",
+		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "internal/project/api/gen", "static/chunks",
 	} {
 		if !strings.Contains(ignoreText, want) {
 			t.Fatalf(".dockerignore missing generated or runtime path %q", want)

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -38,7 +38,7 @@ var PublicContractPrefixes = map[string][]string{
 	"dashboard":    {"internal/dashboard", "internal/dashboard/api", "internal/dashboard/catalog", "internal/dashboard/definition", "internal/dashboard/filter", "internal/dashboard/publication", "internal/dashboard/report", "internal/dashboard/reportmodel", "internal/dashboard/queryruntime", "internal/dashboard/ui/signals", "internal/dashboard/visualization/definition", "internal/dashboard/visualization/format", "internal/dashboard/visualization/geometry", "internal/dashboard/visualization/ir", "internal/dashboard/visualization/mapasset", "internal/dashboard/visualization/runtime"},
 	"manageddata":  {"internal/manageddata", "internal/manageddata/binding", "internal/manageddata/runtimebinding"},
 	"workspace":    {"internal/workspace", "internal/workspace/api", "internal/workspace/navigation", "internal/workspace/search"},
-	"project":      {"internal/project/schema", "internal/project/artifact", "internal/project/bundle", "internal/project/compiler"},
+	"project":      {"internal/project/api", "internal/project/schema", "internal/project/artifact", "internal/project/bundle", "internal/project/compiler"},
 	"release":      {"internal/release"},
 	"deployment":   {"internal/deployment"},
 	"servingstate": {"internal/servingstate", "internal/servingstate/validate", "internal/servingstate/validation", "internal/servingstate/retention"},

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -168,6 +168,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/access/api/gen", Capability: "access", Layer: LayerAdapter},
 	{Prefix: "internal/agent/api/gen", Capability: "agent", Layer: LayerAdapter},
 	{Prefix: "internal/analytics/api/gen", Capability: "analytics", Layer: LayerAdapter},
+	{Prefix: "internal/project/api/gen", Capability: "project", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/aggregate", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/gen", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/platform/architecture", Capability: "platform", Layer: LayerPlatform},

--- a/internal/project/api/contracts.go
+++ b/internal/project/api/contracts.go
@@ -1,0 +1,31 @@
+package api
+
+type PageInfo struct {
+	NextCursor *string `json:"nextCursor,omitempty"`
+}
+
+type ProjectResponse struct {
+	ActiveDeploymentID *string `json:"activeDeploymentId,omitempty"`
+	CreatedAt          string  `json:"createdAt"`
+	ID                 string  `json:"id"`
+	LatestReleaseID    *string `json:"latestReleaseId,omitempty"`
+	Title              string  `json:"title"`
+	UpdatedAt          string  `json:"updatedAt"`
+}
+
+type ProjectListResponse struct {
+	Items []ProjectResponse `json:"items"`
+	Page  PageInfo          `json:"page"`
+}
+
+type ProjectWorkspaceResponse struct {
+	ActiveServingStateID *string `json:"activeServingStateId,omitempty"`
+	Description          *string `json:"description,omitempty"`
+	ID                   string  `json:"id"`
+	Title                string  `json:"title"`
+}
+
+type ProjectWorkspaceListResponse struct {
+	Items []ProjectWorkspaceResponse `json:"items"`
+	Page  PageInfo                   `json:"page"`
+}

--- a/internal/project/http/apigen.go
+++ b/internal/project/http/apigen.go
@@ -1,0 +1,60 @@
+package http
+
+import (
+	"context"
+	"log/slog"
+	stdhttp "net/http"
+
+	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
+	projectgen "github.com/Yacobolo/leapview/internal/project/api/gen"
+)
+
+// Handler is the runtime port consumed by Project's generated HTTP adapter.
+// A provider may implement it without turning the compile-time Project
+// capability into a synthetic runtime module.
+type Handler interface {
+	ListProjects(stdhttp.ResponseWriter, *stdhttp.Request, *int32, *string)
+	GetProject(stdhttp.ResponseWriter, *stdhttp.Request, string)
+	ListProjectWorkspaces(stdhttp.ResponseWriter, *stdhttp.Request, string, *int32, *string)
+}
+
+type APIGenDispatcher struct {
+	handler Handler
+}
+
+func NewAPIGenDispatcher(handler Handler) *APIGenDispatcher {
+	return &APIGenDispatcher{handler: handler}
+}
+
+func (d *APIGenDispatcher) ListProjects(w stdhttp.ResponseWriter, r *stdhttp.Request, params projectgen.GenListProjectsParams) {
+	d.handler.ListProjects(w, r, params.Limit, params.PageToken)
+}
+
+func (d *APIGenDispatcher) GetProject(w stdhttp.ResponseWriter, r *stdhttp.Request, project string) {
+	d.handler.GetProject(w, r, project)
+}
+
+func (d *APIGenDispatcher) ListProjectWorkspaces(w stdhttp.ResponseWriter, r *stdhttp.Request, project string, params projectgen.GenListProjectWorkspacesParams) {
+	d.handler.ListProjectWorkspaces(w, r, project, params.Limit, params.PageToken)
+}
+
+type APIGenTransportErrorResponder struct {
+	Logger *slog.Logger
+}
+
+func (responder APIGenTransportErrorResponder) RespondTransportError(ctx context.Context, w stdhttp.ResponseWriter, r *stdhttp.Request, failure projectgen.GenTransportError) {
+	apitransport.WriteAPIGenFailure(ctx, w, r, responder.Logger, apitransport.APIGenFailure{
+		OperationID: failure.OperationID, Kind: failure.Kind, StatusCode: failure.StatusCode,
+		Code: failure.Code, PublicDetail: failure.PublicDetail, Cause: failure.Cause,
+	})
+}
+
+func DispatchAPIGenOperation(operationID string, handler Handler, logger *slog.Logger, w stdhttp.ResponseWriter, r *stdhttp.Request) bool {
+	return projectgen.DispatchAPIGenOperation(
+		operationID,
+		NewAPIGenDispatcher(handler),
+		APIGenTransportErrorResponder{Logger: logger},
+		w,
+		r,
+	)
+}

--- a/internal/project/http/apigen_test.go
+++ b/internal/project/http/apigen_test.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	projectgen "github.com/Yacobolo/leapview/internal/project/api/gen"
+)
+
+var _ projectgen.GenOperationDispatcher = (*APIGenDispatcher)(nil)
+var _ projectgen.GenTransportErrorResponder = APIGenTransportErrorResponder{}
+
+func TestAPIGenDispatcherMapsProjectPaginationToCapabilityHandler(t *testing.T) {
+	limit := int32(25)
+	token := "next"
+	handler := &recordingProjectHandler{}
+	dispatcher := NewAPIGenDispatcher(handler)
+
+	dispatcher.ListProjects(
+		httptest.NewRecorder(),
+		httptest.NewRequest(stdhttp.MethodGet, "/api/v1/projects", nil),
+		projectgen.GenListProjectsParams{Limit: &limit, PageToken: &token},
+	)
+
+	if handler.limit != &limit || handler.pageToken != &token {
+		t.Fatalf("pagination = (%v, %v), want (%v, %v)", handler.limit, handler.pageToken, &limit, &token)
+	}
+}
+
+type recordingProjectHandler struct {
+	limit     *int32
+	pageToken *string
+}
+
+func (h *recordingProjectHandler) ListProjects(_ stdhttp.ResponseWriter, _ *stdhttp.Request, limit *int32, pageToken *string) {
+	h.limit, h.pageToken = limit, pageToken
+}
+
+func (*recordingProjectHandler) GetProject(stdhttp.ResponseWriter, *stdhttp.Request, string) {}
+
+func (*recordingProjectHandler) ListProjectWorkspaces(stdhttp.ResponseWriter, *stdhttp.Request, string, *int32, *string) {
+}

--- a/internal/release/api/contracts.go
+++ b/internal/release/api/contracts.go
@@ -53,32 +53,6 @@ type ArtifactResponse struct {
 	WorkspaceID string `json:"workspaceId"`
 }
 
-type ProjectResponse struct {
-	ActiveDeploymentID *string `json:"activeDeploymentId,omitempty"`
-	CreatedAt          string  `json:"createdAt"`
-	ID                 string  `json:"id"`
-	LatestReleaseID    *string `json:"latestReleaseId,omitempty"`
-	Title              string  `json:"title"`
-	UpdatedAt          string  `json:"updatedAt"`
-}
-
-type ProjectListResponse struct {
-	Items []ProjectResponse `json:"items"`
-	Page  PageInfo          `json:"page"`
-}
-
-type ProjectWorkspaceResponse struct {
-	ActiveServingStateID *string `json:"activeServingStateId,omitempty"`
-	Description          *string `json:"description,omitempty"`
-	ID                   string  `json:"id"`
-	Title                string  `json:"title"`
-}
-
-type ProjectWorkspaceListResponse struct {
-	Items []ProjectWorkspaceResponse `json:"items"`
-	Page  PageInfo                   `json:"page"`
-}
-
 type ManagedConnectionResponse struct {
 	ActiveRevisionID *string `json:"activeRevisionId,omitempty"`
 	Description      *string `json:"description,omitempty"`

--- a/internal/release/module/catalog_api.go
+++ b/internal/release/module/catalog_api.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 
 	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
+	projectapi "github.com/Yacobolo/leapview/internal/project/api"
 	releaseapi "github.com/Yacobolo/leapview/internal/release/api"
 )
 
-func (m *Module) ListProjects(w http.ResponseWriter, r *http.Request, params releaseapi.PageParams) {
+func (m *Module) ListProjects(w http.ResponseWriter, r *http.Request, limit *int32, pageToken *string) {
 	if m == nil || m.catalog == nil {
-		apitransport.WriteJSON(w, http.StatusOK, releaseapi.ProjectListResponse{Items: []releaseapi.ProjectResponse{}, Page: releaseapi.PageInfo{}})
+		apitransport.WriteJSON(w, http.StatusOK, projectapi.ProjectListResponse{Items: []projectapi.ProjectResponse{}, Page: projectapi.PageInfo{}})
 		return
 	}
 	rows, err := m.catalog.ListProjects(r.Context())
@@ -17,9 +18,9 @@ func (m *Module) ListProjects(w http.ResponseWriter, r *http.Request, params rel
 		apitransport.WriteProblem(w, r, http.StatusInternalServerError, "PROJECT_LIST_FAILED", "Projects could not be loaded", nil)
 		return
 	}
-	items := make([]releaseapi.ProjectResponse, 0, len(rows))
+	items := make([]projectapi.ProjectResponse, 0, len(rows))
 	for _, row := range rows {
-		item := releaseapi.ProjectResponse{ID: row.ID, Title: row.ID, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+		item := projectapi.ProjectResponse{ID: row.ID, Title: row.ID, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
 		if row.LatestReleaseID != "" {
 			item.LatestReleaseID = &row.LatestReleaseID
 		}
@@ -28,12 +29,12 @@ func (m *Module) ListProjects(w http.ResponseWriter, r *http.Request, params rel
 		}
 		items = append(items, item)
 	}
-	page, next, err := apitransport.KeysetPage(items, params.Limit, params.PageToken, func(item releaseapi.ProjectResponse) string { return item.ID })
+	page, next, err := apitransport.KeysetPage(items, limit, pageToken, func(item projectapi.ProjectResponse) string { return item.ID })
 	if err != nil {
 		apitransport.WriteProblem(w, r, http.StatusBadRequest, "INVALID_CURSOR", err.Error(), nil)
 		return
 	}
-	apitransport.WriteJSON(w, http.StatusOK, releaseapi.ProjectListResponse{Items: page, Page: releaseapi.PageInfo{NextCursor: next}})
+	apitransport.WriteJSON(w, http.StatusOK, projectapi.ProjectListResponse{Items: page, Page: projectapi.PageInfo{NextCursor: next}})
 }
 
 func (m *Module) GetProject(w http.ResponseWriter, r *http.Request, projectID string) {
@@ -46,7 +47,7 @@ func (m *Module) GetProject(w http.ResponseWriter, r *http.Request, projectID st
 		apitransport.WriteProblem(w, r, http.StatusNotFound, "PROJECT_NOT_FOUND", "Project not found", nil)
 		return
 	}
-	item := releaseapi.ProjectResponse{ID: projectID, Title: projectID, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+	item := projectapi.ProjectResponse{ID: projectID, Title: projectID, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
 	if row.LatestReleaseID != "" {
 		item.LatestReleaseID = &row.LatestReleaseID
 	}
@@ -56,7 +57,7 @@ func (m *Module) GetProject(w http.ResponseWriter, r *http.Request, projectID st
 	apitransport.WriteJSON(w, http.StatusOK, item)
 }
 
-func (m *Module) ListProjectWorkspaces(w http.ResponseWriter, r *http.Request, projectID string, params releaseapi.PageParams) {
+func (m *Module) ListProjectWorkspaces(w http.ResponseWriter, r *http.Request, projectID string, limit *int32, pageToken *string) {
 	if m == nil || m.catalog == nil {
 		apitransport.WriteProblem(w, r, http.StatusNotFound, "PROJECT_NOT_FOUND", "Project not found", nil)
 		return
@@ -66,9 +67,9 @@ func (m *Module) ListProjectWorkspaces(w http.ResponseWriter, r *http.Request, p
 		apitransport.WriteProblem(w, r, http.StatusInternalServerError, "PROJECT_WORKSPACES_FAILED", "Project workspaces could not be loaded", nil)
 		return
 	}
-	items := make([]releaseapi.ProjectWorkspaceResponse, 0, len(rows))
+	items := make([]projectapi.ProjectWorkspaceResponse, 0, len(rows))
 	for _, row := range rows {
-		item := releaseapi.ProjectWorkspaceResponse{ID: row.ID, Title: row.Title}
+		item := projectapi.ProjectWorkspaceResponse{ID: row.ID, Title: row.Title}
 		if row.Description != "" {
 			item.Description = &row.Description
 		}
@@ -77,12 +78,12 @@ func (m *Module) ListProjectWorkspaces(w http.ResponseWriter, r *http.Request, p
 		}
 		items = append(items, item)
 	}
-	page, next, err := apitransport.KeysetPage(items, params.Limit, params.PageToken, func(item releaseapi.ProjectWorkspaceResponse) string { return item.ID })
+	page, next, err := apitransport.KeysetPage(items, limit, pageToken, func(item projectapi.ProjectWorkspaceResponse) string { return item.ID })
 	if err != nil {
 		apitransport.WriteProblem(w, r, http.StatusBadRequest, "INVALID_CURSOR", err.Error(), nil)
 		return
 	}
-	apitransport.WriteJSON(w, http.StatusOK, releaseapi.ProjectWorkspaceListResponse{Items: page, Page: releaseapi.PageInfo{NextCursor: next}})
+	apitransport.WriteJSON(w, http.StatusOK, projectapi.ProjectWorkspaceListResponse{Items: page, Page: projectapi.PageInfo{NextCursor: next}})
 }
 
 func (m *Module) ListManagedConnections(w http.ResponseWriter, r *http.Request, projectID string, params releaseapi.PageParams) {

--- a/internal/release/module/catalog_api_test.go
+++ b/internal/release/module/catalog_api_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/Yacobolo/leapview/internal/release"
-	releaseapi "github.com/Yacobolo/leapview/internal/release/api"
 )
 
 type catalogRepository struct {
@@ -31,13 +30,13 @@ func (catalogRepository) GetConnection(context.Context, string, string, string) 
 	return release.ConnectionRecord{}, nil
 }
 
-func TestReleaseModuleOwnsProjectCatalogMapping(t *testing.T) {
+func TestProjectCatalogProjectionMapping(t *testing.T) {
 	module := &Module{catalog: catalogRepository{projects: []release.ProjectRecord{{
 		ID: "project-1", CreatedAt: "2026-07-23T12:00:00Z", UpdatedAt: "2026-07-23T13:00:00Z",
 		LatestReleaseID: "release-1", ActiveDeploymentID: "deployment-1",
 	}}}}
 	recorder := httptest.NewRecorder()
-	module.ListProjects(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil), releaseapi.PageParams{})
+	module.ListProjects(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil), nil, nil)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}


### PR DESCRIPTION
## Summary

- Generate the three Project operations into `internal/project/api/gen`.
- Add a Project-owned APIGen dispatcher around a small runtime provider port.
- Keep Project as a compile-time capability; no synthetic `project/module` package is introduced.
- Move handwritten Project response DTOs out of Release and into `internal/project/api`.
- Remove the three Project forwarding methods from application dispatch.
- Add Project generation, container, CI, and architecture enforcement.

## Architecture

This is stack position 2 of 8 under [LEA-98](https://linear.app/leapstack/issue/LEA-98/complete-capability-owned-apigen-module-migrations). It is based on the Analytics migration in PR #140.

Project is primarily a compile-time capability, so APIGen ownership must not force a fake runtime module. The resulting boundary is:

```text
LeapViewAPI.Project
        |
        v
internal/project/api/gen
        |
        v
internal/project/http.APIGenDispatcher
        |
        v
project HTTP provider port
```

The existing release-backed catalog projection structurally implements that provider port. Application code supplies it to Project's adapter and aggregates the generated server; it no longer implements Project generated methods.

The refactor also moves `ProjectResponse`, `ProjectListResponse`, and Project workspace response contracts from `internal/release/api` to `internal/project/api`, eliminating an adjacent transport-ownership leak.

## Compatibility

- Project owns exactly 3 operations.
- The application package emits no Project operations.
- The aggregate still exposes all 132 operations exactly once.
- Routes, operation IDs, tags, OpenAPI, authorization metadata, and public generated snapshots are unchanged.

## Validation

- Package/operation/architecture tests written red-first.
- Project adapter pagination mapping test.
- Focused Project, Release provider, application APIGen, and architecture tests pass.
- `GOFLAGS=-tags=duckdb_arrow task generated:check`
- No public contract diff.

Linear: [LEA-99](https://linear.app/leapstack/issue/LEA-99/extract-project-apigen-output-into-its-capability-package)

Stack base: PR #140. This PR is intentionally left open and must not be merged out of order.
