### PR TITLE
Extract Refresh APIGen into its capability package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,7 @@ internal/app/api/gen
 internal/app/cli/gen
 internal/platform/http/api/gen
 internal/project/api/gen
+internal/refresh/api/gen
 internal/app/config/config_gen.go
 internal/app/config/spec/names_gen.go
 internal/platform/db/db.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
             internal/app/config/spec/names_gen.go
             internal/platform/http/api/gen
             internal/project/api/gen
+            internal/refresh/api/gen
             internal/platform/db/db.go
             internal/platform/db/models.go
             internal/platform/db/*.sql.go
@@ -123,6 +124,7 @@ jobs:
             internal/app/cli/gen \
             internal/platform/http/api/gen \
             internal/project/api/gen \
+            internal/refresh/api/gen \
             schemas/config \
             schemas/json \
             web/generated
@@ -172,6 +174,7 @@ jobs:
             internal/app/config/spec/names_gen.go
             internal/platform/http/api/gen/
             internal/project/api/gen/
+            internal/refresh/api/gen/
             internal/platform/db/db.go
             internal/platform/db/models.go
             internal/platform/db/*.sql.go

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ internal/workspace/ui/signals/models.gen.go
 internal/app/cli/gen/
 internal/platform/http/api/gen/
 internal/project/api/gen/
+internal/refresh/api/gen/
 internal/platform/db/db.go
 internal/platform/db/models.go
 internal/platform/db/*.sql.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ COPY --from=sourcegen /src/internal/app/api/aggregate ./internal/app/api/aggrega
 COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen
 COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/http/api/gen
 COPY --from=sourcegen /src/internal/project/api/gen ./internal/project/api/gen
+COPY --from=sourcegen /src/internal/refresh/api/gen ./internal/refresh/api/gen
 COPY --from=sourcegen /src/internal/app/cli/gen ./internal/app/cli/gen
 COPY --from=sourcegen /src/internal/app/config/config_gen.go ./internal/app/config/config_gen.go
 COPY --from=sourcegen /src/internal/app/config/spec/names_gen.go ./internal/app/config/spec/names_gen.go

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -378,6 +378,8 @@ tasks:
       - internal/platform/http/api/gen/request_models.gen.go
       - internal/project/api/gen/request_models.gen.go
       - internal/project/api/gen/server.apigen.gen.go
+      - internal/refresh/api/gen/request_models.gen.go
+      - internal/refresh/api/gen/server.apigen.gen.go
       - docs/api/catalog.json
       - docs/api/openapi.yaml
       - docs/api/operations.json

--- a/api/apigen.yaml
+++ b/api/apigen.yaml
@@ -37,7 +37,10 @@ targets:
           dir: ../internal/platform/http/api/gen
           package: gen
           import_path: github.com/Yacobolo/leapview/internal/platform/http/api/gen
-        LeapViewAPI.Refresh: *leapview_api_go_package
+        LeapViewAPI.Refresh:
+          dir: ../internal/refresh/api/gen
+          package: gen
+          import_path: github.com/Yacobolo/leapview/internal/refresh/api/gen
         LeapViewAPI.Release: *leapview_api_go_package
         LeapViewAPI.Workspace: *leapview_api_go_package
     cli_out:

--- a/internal/app/api_apigen.go
+++ b/internal/app/api_apigen.go
@@ -12,7 +12,6 @@ import (
 	manageddatamodule "github.com/Yacobolo/leapview/internal/manageddata/module"
 	"github.com/Yacobolo/leapview/internal/platform/buildinfo"
 	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
-	refreshmodule "github.com/Yacobolo/leapview/internal/refresh/module"
 	releasemodule "github.com/Yacobolo/leapview/internal/release/module"
 	workspacemodule "github.com/Yacobolo/leapview/internal/workspace/module"
 	"github.com/go-chi/chi/v5"
@@ -51,7 +50,6 @@ type apiGenDispatcher struct {
 	dashboardModule    *dashboardmodule.Module
 	deploymentModule   *deploymentmodule.Module
 	managedDataModule  *manageddatamodule.Module
-	refreshModule      *refreshmodule.Module
 	releaseModule      *releasemodule.Module
 	workspaceModule    *workspacemodule.Module
 	defaultEnvironment string
@@ -221,18 +219,6 @@ func (a apiGenDispatcher) QueryDashboardVisualData(w http.ResponseWriter, r *htt
 
 func (a apiGenDispatcher) ListDashboardFilterValues(w http.ResponseWriter, r *http.Request, workspaceID, _, _, _ string, params apigenapi.GenListDashboardFilterValuesParams) {
 	a.dashboardModule.ListDashboardFilterValues(w, r, workspaceID)
-}
-
-func (a apiGenDispatcher) CreateRefreshRun(w http.ResponseWriter, r *http.Request, workspaceID string, headers apigenapi.GenCreateRefreshRunHeaders) {
-	a.refreshModule.CreateRefreshRun(w, r, workspaceID)
-}
-
-func (a apiGenDispatcher) ListRefreshRuns(w http.ResponseWriter, r *http.Request, workspaceID string, params apigenapi.GenListRefreshRunsParams) {
-	a.refreshModule.ListRefreshRuns(w, r, workspaceID)
-}
-
-func (a apiGenDispatcher) GetRefreshRun(w http.ResponseWriter, r *http.Request, workspaceID, runID string) {
-	a.refreshModule.GetRefreshRun(w, r, workspaceID, runID)
 }
 
 func (a apiGenDispatcher) ListSemanticModels(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListSemanticModelsParams) {

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -15,6 +15,7 @@ import (
 	apiaggregate "github.com/Yacobolo/leapview/internal/app/api/aggregate"
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
 	projectgen "github.com/Yacobolo/leapview/internal/project/api/gen"
+	refreshgen "github.com/Yacobolo/leapview/internal/refresh/api/gen"
 	"github.com/Yacobolo/leapview/internal/workspace"
 )
 
@@ -323,6 +324,53 @@ func TestAPIGenProjectCapabilityOwnsItsOperationSurface(t *testing.T) {
 		}
 		if _, exists := appContracts[operationID]; exists {
 			t.Errorf("Project operation %q is still emitted by the application package", operationID)
+		}
+	}
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
+		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
+	}
+}
+
+func TestAPIGenRefreshCapabilityOwnsItsGeneratedPackage(t *testing.T) {
+	root := projectRoot(t)
+	manifest, err := os.ReadFile(filepath.Join(root, "api", "apigen.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	manifestText := string(manifest)
+	want := "LeapViewAPI.Refresh:\n          dir: ../internal/refresh/api/gen\n          package: gen\n          import_path: github.com/Yacobolo/leapview/internal/refresh/api/gen"
+	if !strings.Contains(manifestText, want) {
+		t.Fatalf("manifest missing Refresh capability package plan %q", want)
+	}
+	if strings.Contains(manifestText, "LeapViewAPI.Refresh: *leapview_api_go_package") {
+		t.Fatal("Refresh namespace is still coalesced into the application generated package")
+	}
+	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	if err != nil {
+		t.Fatalf("read Taskfile.yml: %v", err)
+	}
+	for _, path := range []string{
+		"internal/refresh/api/gen/request_models.gen.go",
+		"internal/refresh/api/gen/server.apigen.gen.go",
+	} {
+		if !strings.Contains(string(taskfile), path) {
+			t.Fatalf("Taskfile.yml does not track generated Refresh artifact %q", path)
+		}
+	}
+}
+
+func TestAPIGenRefreshCapabilityOwnsItsOperationSurface(t *testing.T) {
+	refreshContracts := refreshgen.GetAPIGenOperationContracts()
+	if got, want := len(refreshContracts), 5; got != want {
+		t.Fatalf("Refresh generated operations = %d, want %d", got, want)
+	}
+	appContracts := apigenapi.GetAPIGenOperationContracts()
+	for operationID, contract := range refreshContracts {
+		if len(contract.Tags) != 1 || contract.Tags[0] != "Refresh Runs" {
+			t.Errorf("Refresh operation %q tags = %v, want [Refresh Runs]", operationID, contract.Tags)
+		}
+		if _, exists := appContracts[operationID]; exists {
+			t.Errorf("Refresh operation %q is still emitted by the application package", operationID)
 		}
 	}
 	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {

--- a/internal/app/api_v1_supplemental.go
+++ b/internal/app/api_v1_supplemental.go
@@ -27,11 +27,3 @@ func (a apiGenDispatcher) ListManagedDataUploadSessionEvents(w http.ResponseWrit
 func (a apiGenDispatcher) GetWorkspace(w http.ResponseWriter, r *http.Request, workspaceID string) {
 	a.workspaceModule.GetWorkspace(w, r, workspaceID)
 }
-
-func (a apiGenDispatcher) CancelRefreshRun(w http.ResponseWriter, r *http.Request, workspaceID, runID string, headers apigenapi.GenCancelRefreshRunHeaders) {
-	a.refreshModule.CancelRefreshRun(w, r, workspaceID, runID)
-}
-
-func (a apiGenDispatcher) ListRefreshRunEvents(w http.ResponseWriter, r *http.Request, workspaceID, runID string, params apigenapi.GenListRefreshRunEventsParams, headers apigenapi.GenListRefreshRunEventsHeaders) {
-	a.refreshModule.ListRefreshRunEvents(w, r, workspaceID, runID, params.Limit, params.PageToken)
-}

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -806,6 +806,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if routes.releaseModule != nil && projecthttp.DispatchAPIGenOperation(operationID, routes.releaseModule, platform.logger, writer, request) {
 					return true
 				}
+				if routes.refreshModule != nil && routes.refreshModule.DispatchAPIGenOperation(operationID, platform.logger, writer, request) {
+					return true
+				}
 				return apigenapi.DispatchAPIGenOperation(operationID, apiDispatcher, apiprotocol.TransportErrorResponder{Logger: platform.logger}, writer, request)
 			},
 			QueryContext: func(ctx context.Context, scope agentmodule.Scope) context.Context {
@@ -922,8 +925,8 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	}
 	apiDispatcher = &apiGenDispatcher{
 		dashboardModule: routes.dashboardModule, deploymentModule: routes.deploymentModule,
-		managedDataModule: routes.managedDataModule, refreshModule: routes.refreshModule,
-		releaseModule: routes.releaseModule, workspaceModule: routes.workspaceModule,
+		managedDataModule: routes.managedDataModule,
+		releaseModule:     routes.releaseModule, workspaceModule: routes.workspaceModule,
 		defaultEnvironment: policy.defaultEnvironment, managedDataTus: policy.managedDataTus,
 		buildIdentity: platform.buildIdentity,
 	}
@@ -966,9 +969,15 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	if err != nil {
 		return fmt.Errorf("build Project APIGen transport: %w", err)
 	}
+	refreshAPIHandler, err := apiapigenruntime.Build(apiGenAuthorizer, func(operationID string, w http.ResponseWriter, r *http.Request) bool {
+		return routes.refreshModule.DispatchAPIGenOperation(operationID, platform.logger, w, r)
+	})
+	if err != nil {
+		return fmt.Errorf("build Refresh APIGen transport: %w", err)
+	}
 	platform.apiGenServers = apiaggregate.Servers{
 		Access: accessAPIHandler, Agent: agentAPIHandler, Analytics: analyticsAPIHandler,
-		Gen: appAPIHandler, Project: projectAPIHandler,
+		Gen: appAPIHandler, Project: projectAPIHandler, Refresh: refreshAPIHandler,
 	}
 	configurePageStream(routes, runtime, platform, policy)
 	platform.health = newHealth(healthConfig{

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -130,8 +130,8 @@ func newAppTestHarness(metrics QueryMetrics) *appTestHarness {
 func apiGenDispatcherForTest(server *appTestHarness) apiGenDispatcher {
 	return apiGenDispatcher{
 		dashboardModule: server.routes.dashboardModule, deploymentModule: server.routes.deploymentModule,
-		managedDataModule: server.routes.managedDataModule, refreshModule: server.routes.refreshModule,
-		releaseModule: server.routes.releaseModule, workspaceModule: server.routes.workspaceModule,
+		managedDataModule: server.routes.managedDataModule,
+		releaseModule:     server.routes.releaseModule, workspaceModule: server.routes.workspaceModule,
 		defaultEnvironment: server.policy.defaultEnvironment, managedDataTus: server.policy.managedDataTus,
 		buildIdentity: server.platform.buildIdentity,
 	}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -117,6 +117,16 @@ func TestProjectTransportContractsAreCapabilityOwned(t *testing.T) {
 	}
 }
 
+func TestRefreshGeneratedAPIIsCapabilityOwned(t *testing.T) {
+	rule, ok := ClassifyPackage("internal/refresh/api/gen")
+	if !ok {
+		t.Fatal("Refresh generated API package is not classified")
+	}
+	if rule.Capability != "refresh" || rule.Layer != LayerAdapter {
+		t.Fatalf("Refresh generated API classification = %#v, want refresh adapter", rule)
+	}
+}
+
 func TestApplicationOwnsProductConfigurationContract(t *testing.T) {
 	root := repoRoot(t)
 	if !packageDirExists(root, "internal/app/config/spec") {
@@ -1339,6 +1349,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen",
 		"COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/http/api/gen",
 		"COPY --from=sourcegen /src/internal/project/api/gen ./internal/project/api/gen",
+		"COPY --from=sourcegen /src/internal/refresh/api/gen ./internal/refresh/api/gen",
 		"COPY --from=sourcegen /src/internal/access/ui/signals/models.gen.go ./internal/access/ui/signals/models.gen.go",
 		"COPY --from=sourcegen /src/internal/admin/ui/signals/models.gen.go ./internal/admin/ui/signals/models.gen.go",
 		"COPY --from=sourcegen /src/internal/agent/ui/signals/models.gen.go ./internal/agent/ui/signals/models.gen.go",
@@ -1369,7 +1380,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	ignoreText := string(ignored)
 	for _, want := range []string{
 		".data", ".leapview", "node_modules", "api/gen", "internal/access/api/gen", "internal/agent/api/gen", "internal/analytics/api/gen",
-		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "internal/project/api/gen", "static/chunks",
+		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "internal/project/api/gen", "internal/refresh/api/gen", "static/chunks",
 	} {
 		if !strings.Contains(ignoreText, want) {
 			t.Fatalf(".dockerignore missing generated or runtime path %q", want)

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -169,6 +169,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/agent/api/gen", Capability: "agent", Layer: LayerAdapter},
 	{Prefix: "internal/analytics/api/gen", Capability: "analytics", Layer: LayerAdapter},
 	{Prefix: "internal/project/api/gen", Capability: "project", Layer: LayerAdapter},
+	{Prefix: "internal/refresh/api/gen", Capability: "refresh", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/aggregate", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/gen", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/platform/architecture", Capability: "platform", Layer: LayerPlatform},

--- a/internal/refresh/http/apigen.go
+++ b/internal/refresh/http/apigen.go
@@ -1,0 +1,67 @@
+package http
+
+import (
+	"context"
+	"log/slog"
+	stdhttp "net/http"
+
+	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
+	refreshgen "github.com/Yacobolo/leapview/internal/refresh/api/gen"
+)
+
+type APIGenHandler interface {
+	ListRefreshRuns(stdhttp.ResponseWriter, *stdhttp.Request, string)
+	CreateRefreshRun(stdhttp.ResponseWriter, *stdhttp.Request, string)
+	GetRefreshRun(stdhttp.ResponseWriter, *stdhttp.Request, string, string)
+	CancelRefreshRun(stdhttp.ResponseWriter, *stdhttp.Request, string, string)
+	ListRefreshRunEvents(stdhttp.ResponseWriter, *stdhttp.Request, string, string, *int32, *string)
+}
+
+type APIGenDispatcher struct {
+	handler APIGenHandler
+}
+
+func NewAPIGenDispatcher(handler APIGenHandler) *APIGenDispatcher {
+	return &APIGenDispatcher{handler: handler}
+}
+
+func (d *APIGenDispatcher) ListRefreshRuns(w stdhttp.ResponseWriter, r *stdhttp.Request, workspace string, _ refreshgen.GenListRefreshRunsParams) {
+	d.handler.ListRefreshRuns(w, r, workspace)
+}
+
+func (d *APIGenDispatcher) CreateRefreshRun(w stdhttp.ResponseWriter, r *stdhttp.Request, workspace string, _ refreshgen.GenCreateRefreshRunHeaders) {
+	d.handler.CreateRefreshRun(w, r, workspace)
+}
+
+func (d *APIGenDispatcher) GetRefreshRun(w stdhttp.ResponseWriter, r *stdhttp.Request, workspace, run string) {
+	d.handler.GetRefreshRun(w, r, workspace, run)
+}
+
+func (d *APIGenDispatcher) CancelRefreshRun(w stdhttp.ResponseWriter, r *stdhttp.Request, workspace, run string, _ refreshgen.GenCancelRefreshRunHeaders) {
+	d.handler.CancelRefreshRun(w, r, workspace, run)
+}
+
+func (d *APIGenDispatcher) ListRefreshRunEvents(w stdhttp.ResponseWriter, r *stdhttp.Request, workspace, run string, params refreshgen.GenListRefreshRunEventsParams, _ refreshgen.GenListRefreshRunEventsHeaders) {
+	d.handler.ListRefreshRunEvents(w, r, workspace, run, params.Limit, params.PageToken)
+}
+
+type APIGenTransportErrorResponder struct {
+	Logger *slog.Logger
+}
+
+func (responder APIGenTransportErrorResponder) RespondTransportError(ctx context.Context, w stdhttp.ResponseWriter, r *stdhttp.Request, failure refreshgen.GenTransportError) {
+	apitransport.WriteAPIGenFailure(ctx, w, r, responder.Logger, apitransport.APIGenFailure{
+		OperationID: failure.OperationID, Kind: failure.Kind, StatusCode: failure.StatusCode,
+		Code: failure.Code, PublicDetail: failure.PublicDetail, Cause: failure.Cause,
+	})
+}
+
+func DispatchAPIGenOperation(operationID string, handler APIGenHandler, logger *slog.Logger, w stdhttp.ResponseWriter, r *stdhttp.Request) bool {
+	return refreshgen.DispatchAPIGenOperation(
+		operationID,
+		NewAPIGenDispatcher(handler),
+		APIGenTransportErrorResponder{Logger: logger},
+		w,
+		r,
+	)
+}

--- a/internal/refresh/http/apigen_test.go
+++ b/internal/refresh/http/apigen_test.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	refreshgen "github.com/Yacobolo/leapview/internal/refresh/api/gen"
+)
+
+var _ refreshgen.GenOperationDispatcher = (*APIGenDispatcher)(nil)
+var _ refreshgen.GenTransportErrorResponder = APIGenTransportErrorResponder{}
+
+func TestAPIGenDispatcherMapsRefreshEventPagination(t *testing.T) {
+	limit := int32(10)
+	token := "next"
+	handler := &recordingRefreshHandler{}
+	NewAPIGenDispatcher(handler).ListRefreshRunEvents(
+		httptest.NewRecorder(),
+		httptest.NewRequest(stdhttp.MethodGet, "/api/v1/workspaces/sales/refresh-runs/run-1/events", nil),
+		"sales",
+		"run-1",
+		refreshgen.GenListRefreshRunEventsParams{Limit: &limit, PageToken: &token},
+		refreshgen.GenListRefreshRunEventsHeaders{},
+	)
+	if handler.limit != &limit || handler.pageToken != &token {
+		t.Fatalf("pagination = (%v, %v), want (%v, %v)", handler.limit, handler.pageToken, &limit, &token)
+	}
+}
+
+type recordingRefreshHandler struct {
+	limit     *int32
+	pageToken *string
+}
+
+func (*recordingRefreshHandler) ListRefreshRuns(stdhttp.ResponseWriter, *stdhttp.Request, string) {
+}
+func (*recordingRefreshHandler) CreateRefreshRun(stdhttp.ResponseWriter, *stdhttp.Request, string) {
+}
+func (*recordingRefreshHandler) GetRefreshRun(stdhttp.ResponseWriter, *stdhttp.Request, string, string) {
+}
+func (*recordingRefreshHandler) CancelRefreshRun(stdhttp.ResponseWriter, *stdhttp.Request, string, string) {
+}
+func (h *recordingRefreshHandler) ListRefreshRunEvents(_ stdhttp.ResponseWriter, _ *stdhttp.Request, _, _ string, limit *int32, pageToken *string) {
+	h.limit, h.pageToken = limit, pageToken
+}

--- a/internal/refresh/module/api.go
+++ b/internal/refresh/module/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
@@ -132,6 +133,10 @@ func (m *Module) ListRefreshRunEvents(w http.ResponseWriter, r *http.Request, wo
 		return
 	}
 	jobhttp.WriteEventPage(w, r, m.events, "refresh", runID, limit, pageToken, "refresh:"+workspaceID+":"+runID)
+}
+
+func (m *Module) DispatchAPIGenOperation(operationID string, logger *slog.Logger, w http.ResponseWriter, r *http.Request) bool {
+	return materializehttp.DispatchAPIGenOperation(operationID, m, logger, w, r)
 }
 
 func (m *Module) workspaceID(workspaceID string) string {


### PR DESCRIPTION
## Summary

- Generate all five Refresh operations into `internal/refresh/api/gen`.
- Add a Refresh-owned APIGen dispatcher in `internal/refresh/http`.
- Expose generated dispatch through the existing Refresh module boundary.
- Remove all five Refresh forwarding methods and the Refresh dependency from the application dispatcher.
- Compose the generated Refresh server in the application aggregate.
- Add generation, Docker, CI, and architecture enforcement.

## Architecture

This is stack position 3 of 8 under [LEA-98](https://linear.app/leapstack/issue/LEA-98/complete-capability-owned-apigen-module-migrations), based on PR #141.

```text
LeapViewAPI.Refresh
        |
        v
internal/refresh/api/gen
        |
        v
internal/refresh/http/APIGenDispatcher
        |
        v
internal/refresh/module
```

The adapter preserves event pagination while the existing module retains authorization, lifecycle, and event-store behavior. Application code now only constructs the shared authorized transport and aggregates the server.

## Compatibility and validation

- Refresh owns exactly 5 operations; the application emits none.
- The aggregate remains exactly 132 operations.
- Public routes, operation IDs, OpenAPI, authorization metadata, and snapshots are unchanged.
- Dispatcher pagination test and focused Refresh/module/app/architecture tests pass.
- `GOFLAGS=-tags=duckdb_arrow task generated:check`

Linear: [LEA-101](https://linear.app/leapstack/issue/LEA-101/extract-refresh-apigen-output-into-its-capability-package)

Stack base: PR #141. This PR is intentionally open and unmerged.
