### PR TITLE
LEA-71: durably dispatch draft chat turns

### DIFF
--- a/internal/agent/http/chat.go
+++ b/internal/agent/http/chat.go
@@ -7,7 +7,6 @@ import (
 	nethttp "net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/Yacobolo/leapview/internal/agent"
 	"github.com/Yacobolo/leapview/internal/agent/ui"
@@ -220,23 +219,37 @@ func (h *Handler) layout(r *nethttp.Request) webpage.Provider {
 }
 
 func (h *Handler) startDraftChatTurn(w nethttp.ResponseWriter, r *nethttp.Request, service *agent.Service, scope agent.Scope, clientID, input string, turnContext *agent.TurnContext, embedded bool) {
+	if !embedded && h.options.EnqueueChatRun == nil {
+		nethttp.Error(w, "durable chat turn queue is not configured", nethttp.StatusServiceUnavailable)
+		return
+	}
 	conversation, err := service.CreateConversation(r.Context(), scope, "New conversation")
 	if err != nil {
 		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
 		return
 	}
-	started, err := service.StartPrompt(r.Context(), agent.PromptInput{
+	prompt := agent.PromptInput{
 		Scope:          scope,
 		ConversationID: conversation.ID,
 		Input:          input,
 		Context:        turnContext,
-	})
+	}
+	var started *agent.StartedPrompt
+	if embedded {
+		started, err = service.StartPrompt(r.Context(), prompt)
+	} else {
+		started, err = service.StartDurablePrompt(r.Context(), prompt, agent.PromptDispatch{ChatClientID: clientID})
+	}
 	if err != nil {
 		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
 		return
 	}
 	if !embedded {
-		go h.completeDraftChatTurn(service, scope, clientID, started)
+		if err := h.options.EnqueueChatRun(r.Context(), scope, started, clientID); err != nil {
+			_ = started.Abort(context.WithoutCancel(r.Context()), err)
+			nethttp.Error(w, "durable chat turn queue is unavailable", nethttp.StatusServiceUnavailable)
+			return
+		}
 		_ = pagestream.Redirect(w, r, chatRoutePath(conversation.ID))
 		return
 	}
@@ -252,25 +265,6 @@ func (h *Handler) startDraftChatTurn(w nethttp.ResponseWriter, r *nethttp.Reques
 		LiveConversations:  h.chatConversations(r.Context(), scope),
 		Emit: func(signal ui.ChatViewState) error {
 			return updates.Patch(chatSignalPatch(signal, true))
-		},
-	})
-}
-
-func (h *Handler) completeDraftChatTurn(service *agent.Service, scope agent.Scope, clientID string, started *agent.StartedPrompt) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	if h.options.ExecuteStartedChatTurn == nil {
-		return
-	}
-	_, _ = h.options.ExecuteStartedChatTurn(ctx, service, scope, started, ChatTurnExecution{
-		EmitInitialRunning: true,
-		GenerateTitle:      true,
-		ClientID:           clientID,
-		Emit: func(signal ui.ChatViewState) error {
-			if h.options.Broker != nil {
-				h.options.Broker.Publish(chatStreamID(scope, clientID), chatSignalPatch(signal, false))
-			}
-			return nil
 		},
 	})
 }

--- a/internal/agent/http/handler.go
+++ b/internal/agent/http/handler.go
@@ -52,6 +52,7 @@ type Options struct {
 	QueueMissingTitle      func(context.Context, agent.Scope, string, string)
 	ExecuteStartedChatTurn func(context.Context, *agent.Service, agent.Scope, *agent.StartedPrompt, ChatTurnExecution) (agent.PromptResult, error)
 	EnqueueRun             func(context.Context, agent.Scope, *agent.StartedPrompt) error
+	EnqueueChatRun         func(context.Context, agent.Scope, *agent.StartedPrompt, string) error
 	CancelQueuedRun        func(context.Context, agent.Scope, string, string) (bool, error)
 	APIGenToolContracts    map[string]agenttool.Contract
 }
@@ -300,9 +301,9 @@ func (h *Handler) CreateRun(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		writeJSONError(w, err, stdhttp.StatusBadRequest)
 		return
 	}
-	started, err := service.StartPrompt(r.Context(), agent.PromptInput{
+	started, err := service.StartDurablePrompt(r.Context(), agent.PromptInput{
 		Scope: scope, ConversationID: chi.URLParam(r, "conversation"), Input: input.Input, CorrelationID: input.CorrelationID,
-	})
+	}, agent.PromptDispatch{})
 	if err != nil {
 		status := stdhttp.StatusInternalServerError
 		switch {

--- a/internal/agent/module/jobs.go
+++ b/internal/agent/module/jobs.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/Yacobolo/leapview/internal/agent"
+	agenthttp "github.com/Yacobolo/leapview/internal/agent/http"
+	"github.com/Yacobolo/leapview/internal/agent/ui"
 	"github.com/Yacobolo/leapview/internal/platform/jobs"
 )
 
@@ -14,6 +16,7 @@ const RunJobKind = "agent.run"
 type RunJob struct {
 	Scope                            agent.Scope
 	Conversation, Run, CorrelationID string
+	ChatClientID                     string
 }
 
 func (m *Module) JobHandlers(events jobs.EventAppender) []jobs.Handler {
@@ -29,7 +32,21 @@ func (m *Module) JobHandlers(events jobs.EventAppender) []jobs.Handler {
 		if err != nil {
 			return err
 		}
-		_, err = started.Complete(ctx, nil)
+		if payload.ChatClientID == "" {
+			_, err = started.Complete(ctx, nil)
+		} else {
+			_, err = m.executeStartedChatTurn(ctx, m.service, payload.Scope, started, agenthttp.ChatTurnExecution{
+				EmitInitialRunning: true,
+				GenerateTitle:      true,
+				ClientID:           payload.ChatClientID,
+				Emit: func(signal ui.ChatViewState) error {
+					if m.broker != nil {
+						m.broker.Publish(ChatStreamID(payload.Scope, payload.ChatClientID), chatSignalPatch(signal))
+					}
+					return nil
+				},
+			})
+		}
 		event := "agent_run.completed"
 		if err != nil {
 			event = "agent_run.failed"

--- a/internal/agent/module/module.go
+++ b/internal/agent/module/module.go
@@ -238,7 +238,8 @@ func Build(_ context.Context, config Config) (*Module, error) {
 		ChatSignalWith: m.ChatSignalWith, SearchReferences: searchReferences,
 		ResolveTurnContext: resolveTurnContext, QueueMissingTitle: m.queueMissingChatTitle,
 		ExecuteStartedChatTurn: m.executeStartedChatTurn,
-		EnqueueRun:             m.EnqueueRun, CancelQueuedRun: m.CancelQueuedRun,
+		EnqueueRun:             m.EnqueueRun, EnqueueChatRun: m.EnqueueChatRun,
+		CancelQueuedRun:     m.CancelQueuedRun,
 		APIGenToolContracts: apiGenToolContracts(m.apiOperations),
 	})
 	m.configureTools()

--- a/internal/agent/module/producer.go
+++ b/internal/agent/module/producer.go
@@ -16,6 +16,14 @@ type JobStore interface {
 }
 
 func (m *Module) EnqueueRun(ctx context.Context, scope agent.Scope, started *agent.StartedPrompt) error {
+	return m.enqueueRun(ctx, scope, started, "")
+}
+
+func (m *Module) EnqueueChatRun(ctx context.Context, scope agent.Scope, started *agent.StartedPrompt, clientID string) error {
+	return m.enqueueRun(ctx, scope, started, clientID)
+}
+
+func (m *Module) enqueueRun(ctx context.Context, scope agent.Scope, started *agent.StartedPrompt, chatClientID string) error {
 	if m == nil || started == nil {
 		return errors.New("agent run queue is unavailable")
 	}
@@ -33,15 +41,16 @@ func (m *Module) EnqueueRun(ctx context.Context, scope agent.Scope, started *age
 		ResourceKind: "agent_run", ResourceID: started.RunID,
 		Payload: RunJob{
 			Scope: scope, Conversation: started.ConversationID,
-			Run: started.RunID, CorrelationID: started.CorrelationID,
+			Run: started.RunID, CorrelationID: started.CorrelationID, ChatClientID: chatClientID,
 		},
 	})
 }
 
-func (m *Module) runWorkflow(input agent.PromptInput, runID string) jobs.WorkflowIntent {
+func (m *Module) runWorkflow(input agent.PromptInput, runID string, dispatch agent.PromptDispatch) jobs.WorkflowIntent {
 	scope := input.Scope
 	payload, _ := json.Marshal(RunJob{
 		Scope: scope, Conversation: input.ConversationID, Run: runID, CorrelationID: input.CorrelationID,
+		ChatClientID: dispatch.ChatClientID,
 	})
 	event, _ := json.Marshal(map[string]any{
 		"runId": runID, "conversationId": input.ConversationID, "status": "running",

--- a/internal/agent/module/producer_test.go
+++ b/internal/agent/module/producer_test.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/Yacobolo/leapview/internal/agent"
@@ -44,6 +45,44 @@ func TestEnqueueRunOwnsWorkloadAndWorkspaceClassification(t *testing.T) {
 	}
 	if store.event.EventType != "agent_run.queued" {
 		t.Fatalf("event = %#v", store.event)
+	}
+}
+
+func TestEnqueueChatRunPersistsBrowserDelivery(t *testing.T) {
+	store := &runJobStore{}
+	module, err := Build(t.Context(), Config{Jobs: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := &agent.StartedPrompt{ConversationID: "conversation-1", RunID: "run-1"}
+	if err := module.EnqueueChatRun(t.Context(), agent.Scope{}, started, "browser-1"); err != nil {
+		t.Fatal(err)
+	}
+	var payload RunJob
+	if err := json.Unmarshal(store.input.Payload, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.ChatClientID != "browser-1" {
+		t.Fatalf("chat client = %q, want browser-1", payload.ChatClientID)
+	}
+}
+
+func TestRunWorkflowPersistsBrowserDeliveryAtomically(t *testing.T) {
+	module, err := Build(t.Context(), Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	intent := module.runWorkflow(
+		agent.PromptInput{ConversationID: "conversation-1"},
+		"run-1",
+		agent.PromptDispatch{ChatClientID: "browser-1"},
+	)
+	var payload RunJob
+	if err := json.Unmarshal(intent.Job.Payload, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.ChatClientID != "browser-1" || payload.Conversation != "conversation-1" || payload.Run != "run-1" {
+		t.Fatalf("workflow payload = %#v", payload)
 	}
 }
 

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -20,6 +20,11 @@ type PromptInput struct {
 	OnEvent        func(EventEnvelope)
 }
 
+// PromptDispatch describes delivery metadata persisted with a durable prompt.
+type PromptDispatch struct {
+	ChatClientID string
+}
+
 type PromptResult struct {
 	ConversationID string               `json:"conversationId"`
 	RunID          string               `json:"runId"`
@@ -55,6 +60,17 @@ func (s *Service) Prompt(ctx context.Context, input PromptInput) (PromptResult, 
 }
 
 func (s *Service) StartPrompt(ctx context.Context, input PromptInput) (*StartedPrompt, error) {
+	return s.startPrompt(ctx, input, nil)
+}
+
+// StartDurablePrompt persists the prompt and its required workflow as one
+// transition when a workflow recorder is configured. Callers with an external
+// service can inspect DurablyQueued and enqueue the returned prompt themselves.
+func (s *Service) StartDurablePrompt(ctx context.Context, input PromptInput, dispatch PromptDispatch) (*StartedPrompt, error) {
+	return s.startPrompt(ctx, input, &dispatch)
+}
+
+func (s *Service) startPrompt(ctx context.Context, input PromptInput, dispatch *PromptDispatch) (*StartedPrompt, error) {
 	if !s.Enabled() {
 		return nil, ErrDisabled
 	}
@@ -87,8 +103,9 @@ func (s *Service) StartPrompt(ctx context.Context, input PromptInput) (*StartedP
 		return nil, err
 	}
 	runID := newID("run")
+	durable := dispatch != nil && s.promptWorkflow != nil
 	runStatus := RunStatusRunning
-	if s.promptWorkflow != nil {
+	if durable {
 		runStatus = RunStatusPreparing
 	}
 	run, err := s.repo.CreateRun(ctx, RunInput{
@@ -141,14 +158,14 @@ func (s *Service) StartPrompt(ctx context.Context, input PromptInput) (*StartedP
 		return nil, err
 	}
 	durablyQueued := false
-	if s.promptWorkflow != nil {
+	if durable {
 		unit, ok := s.repo.(RunWorkflowUnitOfWork)
 		if !ok {
 			err := fmt.Errorf("agent run workflow unit of work is unavailable")
 			_ = s.finishRun(ctx, input, run.ID, RunStatusFailed, "", agentcore.Usage{}, err)
 			return nil, err
 		}
-		run, err = unit.ActivateRunWorkflow(ctx, input.Scope.PrincipalID, input.ConversationID, run.ID, s.promptWorkflow(input, run.ID))
+		run, err = unit.ActivateRunWorkflow(ctx, input.Scope.PrincipalID, input.ConversationID, run.ID, s.promptWorkflow(input, run.ID, *dispatch))
 		if err != nil {
 			_ = s.finishRun(ctx, input, run.ID, RunStatusFailed, "", agentcore.Usage{}, err)
 			return nil, err

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -55,10 +55,10 @@ type Service struct {
 
 	mu             sync.Mutex
 	running        map[string]runningPrompt
-	promptWorkflow func(PromptInput, string) jobs.WorkflowIntent
+	promptWorkflow func(PromptInput, string, PromptDispatch) jobs.WorkflowIntent
 }
 
-func (s *Service) SetPromptWorkflow(factory func(PromptInput, string) jobs.WorkflowIntent) {
+func (s *Service) SetPromptWorkflow(factory func(PromptInput, string, PromptDispatch) jobs.WorkflowIntent) {
 	if s != nil {
 		s.promptWorkflow = factory
 	}

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -16,9 +16,10 @@ import (
 	"github.com/Yacobolo/leapview/internal/dashboard/catalog"
 	dashboarddefinition "github.com/Yacobolo/leapview/internal/dashboard/definition"
 	reportdef "github.com/Yacobolo/leapview/internal/dashboard/report"
-	"github.com/Yacobolo/leapview/internal/project/testing/dashboardfixture"
 	visualizationir "github.com/Yacobolo/leapview/internal/dashboard/visualization/ir"
 	visualizationruntime "github.com/Yacobolo/leapview/internal/dashboard/visualization/runtime"
+	"github.com/Yacobolo/leapview/internal/platform/jobs"
+	"github.com/Yacobolo/leapview/internal/project/testing/dashboardfixture"
 	agentcore "github.com/Yacobolo/leapview/pkg/agent"
 )
 
@@ -285,6 +286,55 @@ func TestServiceStartPromptPersistsUserBeforeRunCompletes(t *testing.T) {
 	if len(messages) != 2 || messages[0].Role != MessageRoleUser || messages[1].Role != MessageRoleAssistant {
 		t.Fatalf("messages after completion = %#v, want user and assistant only", messages)
 	}
+}
+
+func TestServiceDispatchesOnlyExplicitDurablePrompts(t *testing.T) {
+	ctx := context.Background()
+	store := &workflowAgentStore{testAgentStore: newTestAgentStore()}
+	principal := createAgentAppPrincipal(t, ctx, store.testAgentStore, "dispatch@example.com")
+	scope := Scope{WorkspaceID: "test", PrincipalID: principal.ID}
+	service := NewService(store, Config{APIKey: "key", Model: "fake-model"}, WithModel(newRecordingAgentModel()))
+	service.SetPromptWorkflow(func(_ PromptInput, runID string, dispatch PromptDispatch) jobs.WorkflowIntent {
+		payload, _ := json.Marshal(dispatch)
+		return jobs.WorkflowIntent{Job: jobs.EnqueueInput{ID: runID, Payload: payload}}
+	})
+
+	inlineConversation, err := service.CreateConversation(ctx, scope, "Inline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inline, err := service.StartPrompt(ctx, PromptInput{
+		Scope: scope, ConversationID: inlineConversation.ID, Input: "Run inline",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inline.DurablyQueued() || len(store.workflows) != 0 {
+		t.Fatalf("inline prompt unexpectedly dispatched: %#v", store.workflows)
+	}
+	_ = inline.Abort(ctx, errors.New("test cleanup"))
+
+	durableConversation, err := service.CreateConversation(ctx, scope, "Durable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	durable, err := service.StartDurablePrompt(ctx, PromptInput{
+		Scope: scope, ConversationID: durableConversation.ID, Input: "Run later",
+	}, PromptDispatch{ChatClientID: "browser-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !durable.DurablyQueued() || len(store.workflows) != 1 {
+		t.Fatalf("durable prompt workflows = %#v", store.workflows)
+	}
+	var dispatch PromptDispatch
+	if err := json.Unmarshal(store.workflows[0].Job.Payload, &dispatch); err != nil {
+		t.Fatal(err)
+	}
+	if dispatch.ChatClientID != "browser-1" {
+		t.Fatalf("persisted dispatch = %#v", dispatch)
+	}
+	_ = durable.Abort(ctx, errors.New("test cleanup"))
 }
 
 func TestServiceResumesPersistedPromptAfterProcessRestart(t *testing.T) {
@@ -1158,6 +1208,39 @@ type testAgentStore struct {
 	runs            map[string]Run
 	runConversation map[string]string
 	events          map[string][]Event
+}
+
+type workflowAgentStore struct {
+	*testAgentStore
+	workflows []jobs.WorkflowIntent
+}
+
+func (s *workflowAgentStore) CreateRun(ctx context.Context, input RunInput) (Run, error) {
+	run, err := s.testAgentStore.CreateRun(ctx, input)
+	if err != nil {
+		return Run{}, err
+	}
+	s.mu.Lock()
+	run.Status = input.Status
+	s.runs[run.ID] = run
+	s.mu.Unlock()
+	return run, nil
+}
+
+func (s *workflowAgentStore) ActivateRunWorkflow(_ context.Context, principalID, conversationID, runID string, workflow jobs.WorkflowIntent) (Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.conversationLocked(principalID, conversationID); err != nil {
+		return Run{}, err
+	}
+	run, ok := s.runs[runID]
+	if !ok || s.runConversation[runID] != conversationID {
+		return Run{}, sql.ErrNoRows
+	}
+	run.Status = RunStatusRunning
+	s.runs[run.ID] = run
+	s.workflows = append(s.workflows, workflow)
+	return run, nil
 }
 
 func newTestAgentStore() *testAgentStore {

--- a/internal/app/chat_test.go
+++ b/internal/app/chat_test.go
@@ -24,6 +24,7 @@ import (
 	reportdef "github.com/Yacobolo/leapview/internal/dashboard/report"
 	visualizationruntime "github.com/Yacobolo/leapview/internal/dashboard/visualization/runtime"
 	"github.com/Yacobolo/leapview/internal/platform"
+	"github.com/Yacobolo/leapview/internal/platform/jobs"
 	workspacecompiler "github.com/Yacobolo/leapview/internal/project/compiler"
 	servingstate "github.com/Yacobolo/leapview/internal/servingstate"
 	"github.com/Yacobolo/leapview/internal/workspace"
@@ -916,6 +917,10 @@ func TestChatDraftTurnRedirectsAndStreamsThroughUpdates(t *testing.T) {
 	principal, token := chatPrincipalAndToken(t, ctx, store)
 	started := make(chan struct{}, 1)
 	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseModel := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
 	modelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case started <- struct{}{}:
@@ -924,7 +929,8 @@ func TestChatDraftTurnRedirectsAndStreamsThroughUpdates(t *testing.T) {
 		<-release
 		writeRawJSON(t, w, `{"choices":[{"message":{"role":"assistant","content":"Background complete."},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`)
 	}))
-	defer modelServer.Close()
+	t.Cleanup(modelServer.Close)
+	t.Cleanup(releaseModel)
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	service := agent.NewService(testAgentRepository(store), agent.Config{APIKey: "key", BaseURL: modelServer.URL, Model: "fake-model"})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, Agent: service, DefaultWorkspaceID: "test"}))
@@ -956,9 +962,40 @@ func TestChatDraftTurnRedirectsAndStreamsThroughUpdates(t *testing.T) {
 		t.Fatalf("redirect did not target created conversation %q:\n%s", conversationID, body)
 	}
 
+	runs, err := testAgentRepository(store).ListRuns(ctx, principal.ID, conversationID)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("runs = %#v", runs)
+	}
+	job, err := server.platform.asyncJobs.Get(ctx, "agent:"+runs[0].ID+":run")
+	if err != nil {
+		t.Fatalf("accepted draft turn was not durably dispatched: %v", err)
+	}
+	if job.Status != jobs.StatusQueued {
+		t.Fatalf("accepted draft job status = %q, want %q", job.Status, jobs.StatusQueued)
+	}
 	select {
 	case <-started:
-	case <-time.After(time.Second):
+		t.Fatal("draft model started outside the durable worker")
+	default:
+	}
+
+	backgroundCtx, cancelBackground := context.WithCancel(context.Background())
+	if err := server.StartBackgroundJobs(backgroundCtx); err != nil {
+		t.Fatalf("start background jobs: %v", err)
+	}
+	t.Cleanup(func() {
+		cancelBackground()
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.StopBackgroundJobs(stopCtx)
+	})
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
 		t.Fatal("background turn did not start")
 	}
 
@@ -983,7 +1020,7 @@ func TestChatDraftTurnRedirectsAndStreamsThroughUpdates(t *testing.T) {
 		server.Routes().ServeHTTP(updatesRec, updatesReq)
 	}()
 	waitForBrokerSubscription(t, server, agentmodule.ChatStreamID(agent.Scope{PrincipalID: principal.ID}, "client-draft"))
-	close(release)
+	releaseModel()
 	waitForConversationMessage(t, service, principal.ID, conversationID, "Background complete.")
 	waitForRecorderBodyContains(t, updatesRec, `"running":false`)
 	waitForAgentConversationTitle(t, store, "test", principal.ID, conversationID, "Background complete")


### PR DESCRIPTION
## Summary

- replace the draft-chat raw goroutine with the durable agent job workflow
- persist browser delivery metadata so workers can publish chat signals and generate titles after restart
- make durable prompt startup an explicit service operation, keeping inline turns out of the queue
- reject draft acceptance when durable dispatch is unavailable

## TDD evidence

- red: `TestChatDraftTurnRedirectsAndStreamsThroughUpdates` failed with `accepted draft turn was not durably dispatched: async job not found`
- green: the test now proves the job is queued before worker startup, proves the model cannot start outside the worker, then observes worker startup and SSE completion

## Qualification

- focused end-to-end test: 100 consecutive passes
- scheduler contention: 30 passes across `-cpu=1,2,4`
- related agent/job/app tests under `-race`
- `task test`
- `task ci` twice from clean commit `a88ec56f` (the second successful run rebuilt from an empty Go cache)
