### PR TITLE
Extract Release APIGen into its capability package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,7 @@ internal/app/cli/gen
 internal/platform/http/api/gen
 internal/project/api/gen
 internal/refresh/api/gen
+internal/release/api/gen
 internal/app/config/config_gen.go
 internal/app/config/spec/names_gen.go
 internal/platform/db/db.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
             internal/platform/http/api/gen
             internal/project/api/gen
             internal/refresh/api/gen
+            internal/release/api/gen
             internal/platform/db/db.go
             internal/platform/db/models.go
             internal/platform/db/*.sql.go
@@ -127,6 +128,7 @@ jobs:
             internal/platform/http/api/gen \
             internal/project/api/gen \
             internal/refresh/api/gen \
+            internal/release/api/gen \
             schemas/config \
             schemas/json \
             web/generated
@@ -178,6 +180,7 @@ jobs:
             internal/platform/http/api/gen/
             internal/project/api/gen/
             internal/refresh/api/gen/
+            internal/release/api/gen/
             internal/platform/db/db.go
             internal/platform/db/models.go
             internal/platform/db/*.sql.go

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ internal/app/cli/gen/
 internal/platform/http/api/gen/
 internal/project/api/gen/
 internal/refresh/api/gen/
+internal/release/api/gen/
 internal/platform/db/db.go
 internal/platform/db/models.go
 internal/platform/db/*.sql.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=sourcegen /src/internal/app/api/gen ./internal/app/api/gen
 COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/http/api/gen
 COPY --from=sourcegen /src/internal/project/api/gen ./internal/project/api/gen
 COPY --from=sourcegen /src/internal/refresh/api/gen ./internal/refresh/api/gen
+COPY --from=sourcegen /src/internal/release/api/gen ./internal/release/api/gen
 COPY --from=sourcegen /src/internal/app/cli/gen ./internal/app/cli/gen
 COPY --from=sourcegen /src/internal/app/config/config_gen.go ./internal/app/config/config_gen.go
 COPY --from=sourcegen /src/internal/app/config/spec/names_gen.go ./internal/app/config/spec/names_gen.go

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -382,6 +382,8 @@ tasks:
       - internal/project/api/gen/server.apigen.gen.go
       - internal/refresh/api/gen/request_models.gen.go
       - internal/refresh/api/gen/server.apigen.gen.go
+      - internal/release/api/gen/request_models.gen.go
+      - internal/release/api/gen/server.apigen.gen.go
       - docs/api/catalog.json
       - docs/api/openapi.yaml
       - docs/api/operations.json

--- a/api/apigen.yaml
+++ b/api/apigen.yaml
@@ -44,7 +44,10 @@ targets:
           dir: ../internal/refresh/api/gen
           package: gen
           import_path: github.com/Yacobolo/leapview/internal/refresh/api/gen
-        LeapViewAPI.Release: *leapview_api_go_package
+        LeapViewAPI.Release:
+          dir: ../internal/release/api/gen
+          package: gen
+          import_path: github.com/Yacobolo/leapview/internal/release/api/gen
         LeapViewAPI.Workspace: *leapview_api_go_package
     cli_out:
       dir: ../internal/app/cli/gen

--- a/internal/app/api_apigen_managed_data_test.go
+++ b/internal/app/api_apigen_managed_data_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
+	releasegen "github.com/Yacobolo/leapview/internal/release/api/gen"
 )
 
 func TestManagedDataGeneratedByteCountsAreInt64(t *testing.T) {
@@ -28,7 +29,7 @@ func TestManagedDataGeneratedByteCountsAreInt64(t *testing.T) {
 }
 
 func TestReleaseArtifactGeneratedSizeIsInt64(t *testing.T) {
-	typeOf := reflect.TypeOf(apigenapi.ReleaseArtifactResponse{})
+	typeOf := reflect.TypeOf(releasegen.ReleaseArtifactResponse{})
 	field, ok := typeOf.FieldByName("SizeBytes")
 	if !ok || field.Type.Kind() != reflect.Int64 {
 		t.Fatalf("%s.SizeBytes type = %v, want int64", typeOf.Name(), field.Type)

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -17,6 +17,7 @@ import (
 	deploymentgen "github.com/Yacobolo/leapview/internal/deployment/api/gen"
 	projectgen "github.com/Yacobolo/leapview/internal/project/api/gen"
 	refreshgen "github.com/Yacobolo/leapview/internal/refresh/api/gen"
+	releasegen "github.com/Yacobolo/leapview/internal/release/api/gen"
 	"github.com/Yacobolo/leapview/internal/workspace"
 )
 
@@ -419,6 +420,53 @@ func TestAPIGenDeploymentCapabilityOwnsItsOperationSurface(t *testing.T) {
 		}
 		if _, exists := appContracts[operationID]; exists {
 			t.Errorf("Deployment operation %q is still emitted by the application package", operationID)
+		}
+	}
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
+		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
+	}
+}
+
+func TestAPIGenReleaseCapabilityOwnsItsGeneratedPackage(t *testing.T) {
+	root := projectRoot(t)
+	manifest, err := os.ReadFile(filepath.Join(root, "api", "apigen.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	manifestText := string(manifest)
+	want := "LeapViewAPI.Release:\n          dir: ../internal/release/api/gen\n          package: gen\n          import_path: github.com/Yacobolo/leapview/internal/release/api/gen"
+	if !strings.Contains(manifestText, want) {
+		t.Fatalf("manifest missing Release capability package plan %q", want)
+	}
+	if strings.Contains(manifestText, "LeapViewAPI.Release: *leapview_api_go_package") {
+		t.Fatal("Release namespace is still coalesced into the application generated package")
+	}
+	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	if err != nil {
+		t.Fatalf("read Taskfile.yml: %v", err)
+	}
+	for _, path := range []string{
+		"internal/release/api/gen/request_models.gen.go",
+		"internal/release/api/gen/server.apigen.gen.go",
+	} {
+		if !strings.Contains(string(taskfile), path) {
+			t.Fatalf("Taskfile.yml does not track generated Release artifact %q", path)
+		}
+	}
+}
+
+func TestAPIGenReleaseCapabilityOwnsItsOperationSurface(t *testing.T) {
+	contracts := releasegen.GetAPIGenOperationContracts()
+	if got, want := len(contracts), 6; got != want {
+		t.Fatalf("Release generated operations = %d, want %d", got, want)
+	}
+	appContracts := apigenapi.GetAPIGenOperationContracts()
+	for operationID, contract := range contracts {
+		if len(contract.Tags) != 1 || contract.Tags[0] != "Releases" {
+			t.Errorf("Release operation %q tags = %v, want [Releases]", operationID, contract.Tags)
+		}
+		if _, exists := appContracts[operationID]; exists {
+			t.Errorf("Release operation %q is still emitted by the application package", operationID)
 		}
 	}
 	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
@@ -863,7 +911,7 @@ func TestAPIGenUploadArtifactUsesNativeOctetStreamBody(t *testing.T) {
 		if content.ContentType != "application/octet-stream" || content.BodyKind != "binary" {
 			t.Fatalf("upload IR content = %#v, want application/octet-stream binary", content)
 		}
-		var generatedBody apigenapi.GenUploadReleaseArtifactBody
+		var generatedBody releasegen.GenUploadReleaseArtifactBody
 		_ = []byte(generatedBody)
 		return
 	}

--- a/internal/app/cli/data_http_client.go
+++ b/internal/app/cli/data_http_client.go
@@ -13,6 +13,7 @@ import (
 
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
 	deploymentgen "github.com/Yacobolo/leapview/internal/deployment/api/gen"
+	releasegen "github.com/Yacobolo/leapview/internal/release/api/gen"
 )
 
 type managedDataCLIClient struct {
@@ -100,20 +101,20 @@ func (c *managedDataCLIClient) capabilities(ctx context.Context) (apigenapi.Capa
 	return response, err
 }
 
-func (c *managedDataCLIClient) createRelease(ctx context.Context, project, key string, body apigenapi.ReleaseCreateRequest) (apigenapi.ReleaseResponse, error) {
-	var response apigenapi.ReleaseResponse
+func (c *managedDataCLIClient) createRelease(ctx context.Context, project, key string, body releasegen.ReleaseCreateRequest) (releasegen.ReleaseResponse, error) {
+	var response releasegen.ReleaseResponse
 	err := c.json(ctx, http.MethodPost, "createRelease", map[string]string{"project": project}, nil, key, body, &response)
 	return response, err
 }
 
-func (c *managedDataCLIClient) uploadReleaseArtifact(ctx context.Context, project, releaseID, workspaceID, contentDigest string, body io.Reader) (apigenapi.ReleaseArtifactResponse, error) {
+func (c *managedDataCLIClient) uploadReleaseArtifact(ctx context.Context, project, releaseID, workspaceID, contentDigest string, body io.Reader) (releasegen.ReleaseArtifactResponse, error) {
 	endpoint, err := apiOperationURL(c.target, "uploadReleaseArtifact", map[string]string{"project": project, "release": releaseID, "workspace": workspaceID}, nil)
 	if err != nil {
-		return apigenapi.ReleaseArtifactResponse{}, err
+		return releasegen.ReleaseArtifactResponse{}, err
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, body)
 	if err != nil {
-		return apigenapi.ReleaseArtifactResponse{}, err
+		return releasegen.ReleaseArtifactResponse{}, err
 	}
 	request.Header.Set("Authorization", "Bearer "+c.token)
 	request.Header.Set("Accept", "application/json")
@@ -121,28 +122,28 @@ func (c *managedDataCLIClient) uploadReleaseArtifact(ctx context.Context, projec
 	request.Header.Set("Content-Digest", contentDigest)
 	response, err := c.http.Do(request)
 	if err != nil {
-		return apigenapi.ReleaseArtifactResponse{}, fmt.Errorf("upload release artifact could not reach the server")
+		return releasegen.ReleaseArtifactResponse{}, fmt.Errorf("upload release artifact could not reach the server")
 	}
 	defer response.Body.Close()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, response.Body)
-		return apigenapi.ReleaseArtifactResponse{}, fmt.Errorf("upload release artifact failed with HTTP %d", response.StatusCode)
+		return releasegen.ReleaseArtifactResponse{}, fmt.Errorf("upload release artifact failed with HTTP %d", response.StatusCode)
 	}
-	var result apigenapi.ReleaseArtifactResponse
+	var result releasegen.ReleaseArtifactResponse
 	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
-		return apigenapi.ReleaseArtifactResponse{}, err
+		return releasegen.ReleaseArtifactResponse{}, err
 	}
 	return result, nil
 }
 
-func (c *managedDataCLIClient) finalizeRelease(ctx context.Context, project, releaseID, key string) (apigenapi.ReleaseResponse, error) {
-	var response apigenapi.ReleaseResponse
+func (c *managedDataCLIClient) finalizeRelease(ctx context.Context, project, releaseID, key string) (releasegen.ReleaseResponse, error) {
+	var response releasegen.ReleaseResponse
 	err := c.json(ctx, http.MethodPost, "finalizeRelease", map[string]string{"project": project, "release": releaseID}, nil, key, nil, &response)
 	return response, err
 }
 
-func (c *managedDataCLIClient) getRelease(ctx context.Context, project, releaseID string) (apigenapi.ReleaseResponse, error) {
-	var response apigenapi.ReleaseResponse
+func (c *managedDataCLIClient) getRelease(ctx context.Context, project, releaseID string) (releasegen.ReleaseResponse, error) {
+	var response releasegen.ReleaseResponse
 	err := c.json(ctx, http.MethodGet, "getRelease", map[string]string{"project": project, "release": releaseID}, nil, "", nil, &response)
 	return response, err
 }

--- a/internal/app/cli/deploy.go
+++ b/internal/app/cli/deploy.go
@@ -16,10 +16,10 @@ import (
 	"strings"
 	"time"
 
-	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
 	deploymentgen "github.com/Yacobolo/leapview/internal/deployment/api/gen"
 	projectbundle "github.com/Yacobolo/leapview/internal/project/bundle"
 	workspacecompiler "github.com/Yacobolo/leapview/internal/project/compiler"
+	releasegen "github.com/Yacobolo/leapview/internal/release/api/gen"
 	"github.com/Yacobolo/leapview/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -151,10 +151,10 @@ func runDeploy(ctx context.Context, request deployRequest) error {
 		artifacts = append(artifacts, artifact{workspaceID: item.workspaceID, digest: digest, content: append([]byte(nil), content.Bytes()...)})
 	}
 
-	createBody := apigenapi.ReleaseCreateRequest{ProjectDigest: projectDigest, Workspaces: make([]apigenapi.ReleaseWorkspaceManifest, 0, len(artifacts)), Connections: []apigenapi.ReleaseConnectionPin{}}
+	createBody := releasegen.ReleaseCreateRequest{ProjectDigest: projectDigest, Workspaces: make([]releasegen.ReleaseWorkspaceManifest, 0, len(artifacts)), Connections: []releasegen.ReleaseConnectionPin{}}
 	keyValues := []string{project.Name, projectDigest}
 	for _, item := range artifacts {
-		createBody.Workspaces = append(createBody.Workspaces, apigenapi.ReleaseWorkspaceManifest{Workspace: item.workspaceID, ArtifactDigest: item.digest})
+		createBody.Workspaces = append(createBody.Workspaces, releasegen.ReleaseWorkspaceManifest{Workspace: item.workspaceID, ArtifactDigest: item.digest})
 		keyValues = append(keyValues, item.workspaceID, item.digest)
 	}
 	connectionIDs := make([]string, 0, len(request.Revisions))
@@ -163,7 +163,7 @@ func runDeploy(ctx context.Context, request deployRequest) error {
 	}
 	sort.Strings(connectionIDs)
 	for _, connection := range connectionIDs {
-		createBody.Connections = append(createBody.Connections, apigenapi.ReleaseConnectionPin{Connection: connection, RevisionId: request.Revisions[connection]})
+		createBody.Connections = append(createBody.Connections, releasegen.ReleaseConnectionPin{Connection: connection, RevisionId: request.Revisions[connection]})
 		keyValues = append(keyValues, connection, request.Revisions[connection])
 	}
 	releaseKey := deploymentIdempotencyKey("release", keyValues...)
@@ -176,7 +176,7 @@ func runDeploy(ctx context.Context, request deployRequest) error {
 	}
 	finalized := created
 	switch created.Status {
-	case apigenapi.ReleaseStatusDraft:
+	case releasegen.ReleaseStatusDraft:
 		for _, item := range artifacts {
 			digestBytes, _ := hex.DecodeString(item.digest)
 			contentDigest := "sha-256=:" + base64.StdEncoding.EncodeToString(digestBytes) + ":"
@@ -188,15 +188,15 @@ func runDeploy(ctx context.Context, request deployRequest) error {
 		if err != nil {
 			return fmt.Errorf("finalize project release failed")
 		}
-	case apigenapi.ReleaseStatusValidating:
+	case releasegen.ReleaseStatusValidating:
 		// Reissuing finalize is idempotent and restarts validation if a prior
 		// server process stopped after persisting the validating state.
 		finalized, err = client.finalizeRelease(ctx, project.Name, created.Id, deploymentIdempotencyKey("finalize", project.Name, created.Id))
 		if err != nil {
 			return fmt.Errorf("resume project release validation failed")
 		}
-	case apigenapi.ReleaseStatusReady:
-	case apigenapi.ReleaseStatusFailed:
+	case releasegen.ReleaseStatusReady:
+	case releasegen.ReleaseStatusFailed:
 		return fmt.Errorf("existing project release validation failed; create a new release")
 	default:
 		return fmt.Errorf("project release returned unexpected status %q", created.Status)
@@ -220,34 +220,34 @@ func runDeploy(ctx context.Context, request deployRequest) error {
 	return err
 }
 
-func waitForProjectRelease(ctx context.Context, client *managedDataCLIClient, projectID, releaseID string, release apigenapi.ReleaseResponse) (apigenapi.ReleaseResponse, error) {
+func waitForProjectRelease(ctx context.Context, client *managedDataCLIClient, projectID, releaseID string, release releasegen.ReleaseResponse) (releasegen.ReleaseResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 	for {
 		if release.Id != releaseID || release.ProjectId != projectID {
-			return apigenapi.ReleaseResponse{}, fmt.Errorf("project release returned inconsistent scope")
+			return releasegen.ReleaseResponse{}, fmt.Errorf("project release returned inconsistent scope")
 		}
 		switch release.Status {
-		case apigenapi.ReleaseStatusReady:
+		case releasegen.ReleaseStatusReady:
 			return release, nil
-		case apigenapi.ReleaseStatusValidating:
-		case apigenapi.ReleaseStatusFailed:
+		case releasegen.ReleaseStatusValidating:
+		case releasegen.ReleaseStatusFailed:
 			detail := ""
 			if release.Error != nil {
 				detail = ": " + *release.Error
 			}
-			return apigenapi.ReleaseResponse{}, fmt.Errorf("project release validation failed%s", detail)
+			return releasegen.ReleaseResponse{}, fmt.Errorf("project release validation failed%s", detail)
 		default:
-			return apigenapi.ReleaseResponse{}, fmt.Errorf("project release validation returned unexpected status %q", release.Status)
+			return releasegen.ReleaseResponse{}, fmt.Errorf("project release validation returned unexpected status %q", release.Status)
 		}
 		select {
 		case <-ctx.Done():
-			return apigenapi.ReleaseResponse{}, fmt.Errorf("wait for project release validation: %w", ctx.Err())
+			return releasegen.ReleaseResponse{}, fmt.Errorf("wait for project release validation: %w", ctx.Err())
 		case <-time.After(100 * time.Millisecond):
 		}
 		next, err := client.getRelease(ctx, projectID, releaseID)
 		if err != nil {
-			return apigenapi.ReleaseResponse{}, fmt.Errorf("get project release failed")
+			return releasegen.ReleaseResponse{}, fmt.Errorf("get project release failed")
 		}
 		release = next
 	}

--- a/internal/app/cli/project_deploy_test.go
+++ b/internal/app/cli/project_deploy_test.go
@@ -17,6 +17,7 @@ import (
 
 	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
 	projectbundle "github.com/Yacobolo/leapview/internal/project/bundle"
+	releasegen "github.com/Yacobolo/leapview/internal/release/api/gen"
 	"github.com/Yacobolo/leapview/internal/workspace/api"
 )
 
@@ -41,22 +42,22 @@ func TestDeployPreparesCompleteProjectBeforeOneAtomicActivation(t *testing.T) {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/active-asset-graph"):
 			writeCLIJSON(t, w, activeGraphResponse(nil, nil))
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/leapview-showcase/releases":
-			var request apigenapi.ReleaseCreateRequest
+			var request releasegen.ReleaseCreateRequest
 			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 				t.Fatal(err)
 			}
-			writeCLIJSON(t, w, apigenapi.ReleaseResponse{Id: "release-1", ProjectId: "leapview-showcase", ProjectDigest: request.ProjectDigest, Status: apigenapi.ReleaseStatusDraft, CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z", Workspaces: request.Workspaces, Connections: request.Connections})
+			writeCLIJSON(t, w, releasegen.ReleaseResponse{Id: "release-1", ProjectId: "leapview-showcase", ProjectDigest: request.ProjectDigest, Status: releasegen.ReleaseStatusDraft, CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z", Workspaces: request.Workspaces, Connections: request.Connections})
 		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/artifact"):
 			pins, digest := readManagedDataPinsFromUpload(t, r.Body)
 			if len(pins) != 1 || pins["olist"] != revision {
 				t.Fatalf("%s managed pins = %#v", workspaceID, pins)
 			}
 			artifactDigests[workspaceID] = digest
-			writeCLIJSON(t, w, apigenapi.ReleaseArtifactResponse{ReleaseId: "release-1", WorkspaceId: workspaceID, Digest: digest, SizeBytes: 1})
+			writeCLIJSON(t, w, releasegen.ReleaseArtifactResponse{ReleaseId: "release-1", WorkspaceId: workspaceID, Digest: digest, SizeBytes: 1})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/releases/release-1/finalize"):
-			writeCLIJSON(t, w, apigenapi.ReleaseResponse{Id: "release-1", ProjectId: "leapview-showcase", ProjectDigest: "ready", Status: apigenapi.ReleaseStatusValidating, CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z", Workspaces: []apigenapi.ReleaseWorkspaceManifest{}, Connections: []apigenapi.ReleaseConnectionPin{}})
+			writeCLIJSON(t, w, releasegen.ReleaseResponse{Id: "release-1", ProjectId: "leapview-showcase", ProjectDigest: "ready", Status: releasegen.ReleaseStatusValidating, CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z", Workspaces: []releasegen.ReleaseWorkspaceManifest{}, Connections: []releasegen.ReleaseConnectionPin{}})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/leapview-showcase/releases/release-1":
-			writeCLIJSON(t, w, apigenapi.ReleaseResponse{Id: "release-1", ProjectId: "leapview-showcase", ProjectDigest: "ready", Status: apigenapi.ReleaseStatusReady, CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z", Workspaces: []apigenapi.ReleaseWorkspaceManifest{}, Connections: []apigenapi.ReleaseConnectionPin{}})
+			writeCLIJSON(t, w, releasegen.ReleaseResponse{Id: "release-1", ProjectId: "leapview-showcase", ProjectDigest: "ready", Status: releasegen.ReleaseStatusReady, CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z", Workspaces: []releasegen.ReleaseWorkspaceManifest{}, Connections: []releasegen.ReleaseConnectionPin{}})
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/leapview-showcase/deployments":
 			writeCLIJSON(t, w, map[string]any{
 				"id": "deployment-1", "projectId": "leapview-showcase", "releaseId": "release-1", "environment": "prod", "status": "queued", "createdBy": "test", "createdAt": "2026-01-01T00:00:00Z",

--- a/internal/app/releases_api.go
+++ b/internal/app/releases_api.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 
 	apicapabilities "github.com/Yacobolo/leapview/internal/app/api/capabilities"
-	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
-	releasemodule "github.com/Yacobolo/leapview/internal/release/module"
 )
 
 func (a apiGenDispatcher) GetCapabilities(w http.ResponseWriter, _ *http.Request) {
@@ -15,28 +13,4 @@ func (a apiGenDispatcher) GetCapabilities(w http.ResponseWriter, _ *http.Request
 		TUS:           a.managedDataTus != nil,
 		S3Multipart:   a.managedDataModule != nil && a.managedDataModule.SupportsS3Multipart(),
 	})
-}
-
-func (a apiGenDispatcher) CreateRelease(w http.ResponseWriter, r *http.Request, project string, headers apigenapi.GenCreateReleaseHeaders) {
-	a.releaseModule.CreateRelease(w, r, project, headers.IdempotencyKey)
-}
-
-func (a apiGenDispatcher) ListReleases(w http.ResponseWriter, r *http.Request, project string, params apigenapi.GenListReleasesParams) {
-	a.releaseModule.ListReleases(w, r, project, releasemodule.PageParams{Limit: params.Limit, PageToken: params.PageToken})
-}
-
-func (a apiGenDispatcher) GetRelease(w http.ResponseWriter, r *http.Request, project, releaseID string) {
-	a.releaseModule.GetRelease(w, r, project, releaseID)
-}
-
-func (a apiGenDispatcher) UploadReleaseArtifact(w http.ResponseWriter, r *http.Request, project, releaseID, workspaceID string, headers apigenapi.GenUploadReleaseArtifactHeaders) {
-	a.releaseModule.UploadReleaseArtifact(w, r, project, releaseID, workspaceID, headers.ContentType, headers.ContentDigest)
-}
-
-func (a apiGenDispatcher) FinalizeRelease(w http.ResponseWriter, r *http.Request, project, releaseID string, headers apigenapi.GenFinalizeReleaseHeaders) {
-	a.releaseModule.FinalizeRelease(w, r, project, releaseID)
-}
-
-func (a apiGenDispatcher) ListReleaseEvents(w http.ResponseWriter, r *http.Request, project, releaseID string, params apigenapi.GenListReleaseEventsParams, headers apigenapi.GenListReleaseEventsHeaders) {
-	a.releaseModule.ListReleaseEvents(w, r, project, releaseID, releasemodule.PageParams{Limit: params.Limit, PageToken: params.PageToken})
 }

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -812,6 +812,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if routes.deploymentModule != nil && routes.deploymentModule.DispatchAPIGenOperation(operationID, platform.logger, writer, request) {
 					return true
 				}
+				if routes.releaseModule != nil && routes.releaseModule.DispatchAPIGenOperation(operationID, platform.logger, writer, request) {
+					return true
+				}
 				return apigenapi.DispatchAPIGenOperation(operationID, apiDispatcher, apiprotocol.TransportErrorResponder{Logger: platform.logger}, writer, request)
 			},
 			QueryContext: func(ctx context.Context, scope agentmodule.Scope) context.Context {
@@ -983,9 +986,16 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	if err != nil {
 		return fmt.Errorf("build Deployment APIGen transport: %w", err)
 	}
+	releaseAPIHandler, err := apiapigenruntime.Build(apiGenAuthorizer, func(operationID string, w http.ResponseWriter, r *http.Request) bool {
+		return routes.releaseModule.DispatchAPIGenOperation(operationID, platform.logger, w, r)
+	})
+	if err != nil {
+		return fmt.Errorf("build Release APIGen transport: %w", err)
+	}
 	platform.apiGenServers = apiaggregate.Servers{
 		Access: accessAPIHandler, Agent: agentAPIHandler, Analytics: analyticsAPIHandler,
-		Deployment: deploymentAPIHandler, Gen: appAPIHandler, Project: projectAPIHandler, Refresh: refreshAPIHandler,
+		Deployment: deploymentAPIHandler, Gen: appAPIHandler, Project: projectAPIHandler,
+		Refresh: refreshAPIHandler, Release: releaseAPIHandler,
 	}
 	configurePageStream(routes, runtime, platform, policy)
 	platform.health = newHealth(healthConfig{

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -137,6 +137,16 @@ func TestDeploymentGeneratedAPIIsCapabilityOwned(t *testing.T) {
 	}
 }
 
+func TestReleaseGeneratedAPIIsCapabilityOwned(t *testing.T) {
+	rule, ok := ClassifyPackage("internal/release/api/gen")
+	if !ok {
+		t.Fatal("Release generated API package is not classified")
+	}
+	if rule.Capability != "release" || rule.Layer != LayerAdapter {
+		t.Fatalf("Release generated API classification = %#v, want release adapter", rule)
+	}
+}
+
 func TestApplicationOwnsProductConfigurationContract(t *testing.T) {
 	root := repoRoot(t)
 	if !packageDirExists(root, "internal/app/config/spec") {
@@ -1361,6 +1371,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/http/api/gen",
 		"COPY --from=sourcegen /src/internal/project/api/gen ./internal/project/api/gen",
 		"COPY --from=sourcegen /src/internal/refresh/api/gen ./internal/refresh/api/gen",
+		"COPY --from=sourcegen /src/internal/release/api/gen ./internal/release/api/gen",
 		"COPY --from=sourcegen /src/internal/access/ui/signals/models.gen.go ./internal/access/ui/signals/models.gen.go",
 		"COPY --from=sourcegen /src/internal/admin/ui/signals/models.gen.go ./internal/admin/ui/signals/models.gen.go",
 		"COPY --from=sourcegen /src/internal/agent/ui/signals/models.gen.go ./internal/agent/ui/signals/models.gen.go",
@@ -1391,7 +1402,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	ignoreText := string(ignored)
 	for _, want := range []string{
 		".data", ".leapview", "node_modules", "api/gen", "internal/access/api/gen", "internal/agent/api/gen", "internal/analytics/api/gen", "internal/deployment/api/gen",
-		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "internal/project/api/gen", "internal/refresh/api/gen", "static/chunks",
+		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "internal/project/api/gen", "internal/refresh/api/gen", "internal/release/api/gen", "static/chunks",
 	} {
 		if !strings.Contains(ignoreText, want) {
 			t.Fatalf(".dockerignore missing generated or runtime path %q", want)

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -171,6 +171,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/deployment/api/gen", Capability: "deployment", Layer: LayerAdapter},
 	{Prefix: "internal/project/api/gen", Capability: "project", Layer: LayerAdapter},
 	{Prefix: "internal/refresh/api/gen", Capability: "refresh", Layer: LayerAdapter},
+	{Prefix: "internal/release/api/gen", Capability: "release", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/aggregate", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/gen", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/platform/architecture", Capability: "platform", Layer: LayerPlatform},

--- a/internal/release/http/apigen.go
+++ b/internal/release/http/apigen.go
@@ -1,0 +1,64 @@
+package http
+
+import (
+	"context"
+	"log/slog"
+	stdhttp "net/http"
+
+	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
+	releasegen "github.com/Yacobolo/leapview/internal/release/api/gen"
+)
+
+type APIGenHandler interface {
+	CreateRelease(stdhttp.ResponseWriter, *stdhttp.Request, string, string)
+	ListReleases(stdhttp.ResponseWriter, *stdhttp.Request, string, *int32, *string)
+	GetRelease(stdhttp.ResponseWriter, *stdhttp.Request, string, string)
+	UploadReleaseArtifact(stdhttp.ResponseWriter, *stdhttp.Request, string, string, string, string, string)
+	FinalizeRelease(stdhttp.ResponseWriter, *stdhttp.Request, string, string, string)
+	ListReleaseEvents(stdhttp.ResponseWriter, *stdhttp.Request, string, string, *int32, *string)
+}
+
+type APIGenDispatcher struct{ handler APIGenHandler }
+
+func NewAPIGenDispatcher(handler APIGenHandler) *APIGenDispatcher {
+	return &APIGenDispatcher{handler: handler}
+}
+
+func (d *APIGenDispatcher) CreateRelease(w stdhttp.ResponseWriter, r *stdhttp.Request, project string, headers releasegen.GenCreateReleaseHeaders) {
+	d.handler.CreateRelease(w, r, project, headers.IdempotencyKey)
+}
+
+func (d *APIGenDispatcher) ListReleases(w stdhttp.ResponseWriter, r *stdhttp.Request, project string, params releasegen.GenListReleasesParams) {
+	d.handler.ListReleases(w, r, project, params.Limit, params.PageToken)
+}
+
+func (d *APIGenDispatcher) GetRelease(w stdhttp.ResponseWriter, r *stdhttp.Request, project, releaseID string) {
+	d.handler.GetRelease(w, r, project, releaseID)
+}
+
+func (d *APIGenDispatcher) UploadReleaseArtifact(w stdhttp.ResponseWriter, r *stdhttp.Request, project, releaseID, workspaceID string, headers releasegen.GenUploadReleaseArtifactHeaders) {
+	d.handler.UploadReleaseArtifact(w, r, project, releaseID, workspaceID, headers.ContentType, headers.ContentDigest)
+}
+
+func (d *APIGenDispatcher) FinalizeRelease(w stdhttp.ResponseWriter, r *stdhttp.Request, project, releaseID string, headers releasegen.GenFinalizeReleaseHeaders) {
+	d.handler.FinalizeRelease(w, r, project, releaseID, headers.IdempotencyKey)
+}
+
+func (d *APIGenDispatcher) ListReleaseEvents(w stdhttp.ResponseWriter, r *stdhttp.Request, project, releaseID string, params releasegen.GenListReleaseEventsParams, _ releasegen.GenListReleaseEventsHeaders) {
+	d.handler.ListReleaseEvents(w, r, project, releaseID, params.Limit, params.PageToken)
+}
+
+type APIGenTransportErrorResponder struct{ Logger *slog.Logger }
+
+func (responder APIGenTransportErrorResponder) RespondTransportError(ctx context.Context, w stdhttp.ResponseWriter, r *stdhttp.Request, failure releasegen.GenTransportError) {
+	apitransport.WriteAPIGenFailure(ctx, w, r, responder.Logger, apitransport.APIGenFailure{
+		OperationID: failure.OperationID, Kind: failure.Kind, StatusCode: failure.StatusCode,
+		Code: failure.Code, PublicDetail: failure.PublicDetail, Cause: failure.Cause,
+	})
+}
+
+func DispatchAPIGenOperation(operationID string, handler APIGenHandler, logger *slog.Logger, w stdhttp.ResponseWriter, r *stdhttp.Request) bool {
+	return releasegen.DispatchAPIGenOperation(
+		operationID, NewAPIGenDispatcher(handler), APIGenTransportErrorResponder{Logger: logger}, w, r,
+	)
+}

--- a/internal/release/http/apigen_test.go
+++ b/internal/release/http/apigen_test.go
@@ -1,0 +1,86 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	releasegen "github.com/Yacobolo/leapview/internal/release/api/gen"
+)
+
+var _ releasegen.GenOperationDispatcher = (*APIGenDispatcher)(nil)
+var _ releasegen.GenTransportErrorResponder = APIGenTransportErrorResponder{}
+
+func TestAPIGenDispatcherMapsReleaseTransportInputs(t *testing.T) {
+	handler := &recordingReleaseHandler{}
+	dispatcher := NewAPIGenDispatcher(handler)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/projects/p1/releases", nil)
+
+	dispatcher.CreateRelease(recorder, request, "p1", releasegen.GenCreateReleaseHeaders{IdempotencyKey: "create-1"})
+	dispatcher.ListReleases(recorder, request, "p1", releasegen.GenListReleasesParams{Limit: int32Ptr(25), PageToken: stringPtr("page-1")})
+	dispatcher.UploadReleaseArtifact(recorder, request, "p1", "r1", "w1", releasegen.GenUploadReleaseArtifactHeaders{
+		ContentType: "application/octet-stream", ContentDigest: "sha256:artifact",
+	})
+	dispatcher.FinalizeRelease(recorder, request, "p1", "r1", releasegen.GenFinalizeReleaseHeaders{IdempotencyKey: "finalize-1"})
+	dispatcher.ListReleaseEvents(recorder, request, "p1", "r1", releasegen.GenListReleaseEventsParams{
+		Limit: int32Ptr(10), PageToken: stringPtr("event-page"),
+	}, releasegen.GenListReleaseEventsHeaders{})
+
+	if got, want := handler.createKey, "create-1"; got != want {
+		t.Fatalf("create idempotency key = %q, want %q", got, want)
+	}
+	if got, want := *handler.listLimit, int32(25); got != want {
+		t.Fatalf("list limit = %d, want %d", got, want)
+	}
+	if got, want := *handler.listPageToken, "page-1"; got != want {
+		t.Fatalf("list page token = %q, want %q", got, want)
+	}
+	if got, want := handler.contentType, "application/octet-stream"; got != want {
+		t.Fatalf("artifact content type = %q, want %q", got, want)
+	}
+	if got, want := handler.contentDigest, "sha256:artifact"; got != want {
+		t.Fatalf("artifact content digest = %q, want %q", got, want)
+	}
+	if got, want := handler.finalizeKey, "finalize-1"; got != want {
+		t.Fatalf("finalize idempotency key = %q, want %q", got, want)
+	}
+	if got, want := *handler.eventLimit, int32(10); got != want {
+		t.Fatalf("event limit = %d, want %d", got, want)
+	}
+	if got, want := *handler.eventPageToken, "event-page"; got != want {
+		t.Fatalf("event page token = %q, want %q", got, want)
+	}
+}
+
+type recordingReleaseHandler struct {
+	createKey, contentType, contentDigest, finalizeKey string
+	listLimit, eventLimit                              *int32
+	listPageToken, eventPageToken                      *string
+}
+
+func (h *recordingReleaseHandler) CreateRelease(_ stdhttp.ResponseWriter, _ *stdhttp.Request, _, key string) {
+	h.createKey = key
+}
+
+func (h *recordingReleaseHandler) ListReleases(_ stdhttp.ResponseWriter, _ *stdhttp.Request, _ string, limit *int32, pageToken *string) {
+	h.listLimit, h.listPageToken = limit, pageToken
+}
+
+func (*recordingReleaseHandler) GetRelease(stdhttp.ResponseWriter, *stdhttp.Request, string, string) {
+}
+
+func (h *recordingReleaseHandler) UploadReleaseArtifact(_ stdhttp.ResponseWriter, _ *stdhttp.Request, _, _, _, contentType, contentDigest string) {
+	h.contentType, h.contentDigest = contentType, contentDigest
+}
+
+func (h *recordingReleaseHandler) FinalizeRelease(_ stdhttp.ResponseWriter, _ *stdhttp.Request, _, _, key string) {
+	h.finalizeKey = key
+}
+
+func (h *recordingReleaseHandler) ListReleaseEvents(_ stdhttp.ResponseWriter, _ *stdhttp.Request, _, _ string, limit *int32, pageToken *string) {
+	h.eventLimit, h.eventPageToken = limit, pageToken
+}
+
+func int32Ptr(value int32) *int32    { return &value }
+func stringPtr(value string) *string { return &value }

--- a/internal/release/module/api.go
+++ b/internal/release/module/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
@@ -12,6 +13,7 @@ import (
 	"github.com/Yacobolo/leapview/internal/release"
 	releaseapi "github.com/Yacobolo/leapview/internal/release/api"
 	releasefilesystem "github.com/Yacobolo/leapview/internal/release/filesystem"
+	releasehttp "github.com/Yacobolo/leapview/internal/release/http"
 )
 
 type Principal struct {
@@ -63,7 +65,7 @@ func (m *Module) CreateRelease(w http.ResponseWriter, r *http.Request, project, 
 	apitransport.WriteJSON(w, http.StatusCreated, response(created))
 }
 
-func (m *Module) ListReleases(w http.ResponseWriter, r *http.Request, project string, params releaseapi.PageParams) {
+func (m *Module) ListReleases(w http.ResponseWriter, r *http.Request, project string, limit *int32, pageToken *string) {
 	rows, err := m.service.List(r.Context(), project)
 	if err != nil {
 		writeError(w, r, err)
@@ -73,7 +75,7 @@ func (m *Module) ListReleases(w http.ResponseWriter, r *http.Request, project st
 	for _, row := range rows {
 		items = append(items, response(row))
 	}
-	page, next, err := apitransport.KeysetPage(items, params.Limit, params.PageToken, func(item releaseapi.Response) string { return item.CreatedAt + "\x00" + item.ID })
+	page, next, err := apitransport.KeysetPage(items, limit, pageToken, func(item releaseapi.Response) string { return item.CreatedAt + "\x00" + item.ID })
 	if err != nil {
 		apitransport.WriteProblem(w, r, http.StatusBadRequest, "INVALID_CURSOR", err.Error(), nil)
 		return
@@ -105,7 +107,7 @@ func (m *Module) UploadReleaseArtifact(w http.ResponseWriter, r *http.Request, p
 	apitransport.WriteJSON(w, http.StatusCreated, releaseapi.ArtifactResponse{ReleaseID: releaseID, WorkspaceID: workspaceID, Digest: artifact.ExpectedDigest, SizeBytes: artifact.SizeBytes})
 }
 
-func (m *Module) FinalizeRelease(w http.ResponseWriter, r *http.Request, project, releaseID string) {
+func (m *Module) FinalizeRelease(w http.ResponseWriter, r *http.Request, project, releaseID, _ string) {
 	payload, err := json.Marshal(FinalizeJob{Project: project, Release: releaseID})
 	if err != nil {
 		apitransport.WriteProblem(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "Release finalization could not be queued", nil)
@@ -139,7 +141,7 @@ func (m *Module) FinalizeRelease(w http.ResponseWriter, r *http.Request, project
 	apitransport.WriteJSON(w, http.StatusAccepted, response(row))
 }
 
-func (m *Module) ListReleaseEvents(w http.ResponseWriter, r *http.Request, project, releaseID string, params releaseapi.PageParams) {
+func (m *Module) ListReleaseEvents(w http.ResponseWriter, r *http.Request, project, releaseID string, limit *int32, pageToken *string) {
 	if _, err := m.service.Get(r.Context(), project, releaseID); err != nil {
 		writeError(w, r, err)
 		return
@@ -148,7 +150,11 @@ func (m *Module) ListReleaseEvents(w http.ResponseWriter, r *http.Request, proje
 		apitransport.WriteProblem(w, r, http.StatusServiceUnavailable, "ASYNC_EVENT_STORE_UNAVAILABLE", "Release events are unavailable", nil)
 		return
 	}
-	jobhttp.WriteEventPage(w, r, m.api.Jobs, "release", releaseID, params.Limit, params.PageToken, "release:"+project+":"+releaseID)
+	jobhttp.WriteEventPage(w, r, m.api.Jobs, "release", releaseID, limit, pageToken, "release:"+project+":"+releaseID)
+}
+
+func (m *Module) DispatchAPIGenOperation(operationID string, logger *slog.Logger, w http.ResponseWriter, r *http.Request) bool {
+	return releasehttp.DispatchAPIGenOperation(operationID, m, logger, w, r)
 }
 
 func (m *Module) currentPrincipal(r *http.Request) (Principal, bool) {


### PR DESCRIPTION
## Summary

Moves the six LeapViewAPI.Release operations from the application generated package into internal/release/api/gen. The Release module now owns generated dispatch through a small HTTP adapter, while internal/app only composes the authorized server into the aggregate.

This is stack position 5 of 8 for LEA-98 and is based on the Deployment migration branch so the review diff contains only Release ownership changes.

## Design

- Adds an explicit APIGen manifest partition for LeapViewAPI.Release.
- Adds internal/release/http as the adapter between generated headers and query parameters and the Release module API.
- Routes agent-tool and HTTP dispatch through the Release module surface.
- Removes the six Release forwarding methods from the application dispatcher.
- Moves CLI consumers of generated Release request, response, artifact, and status types to internal/release/api/gen.
- Tracks the new generated package in Task generation, CI reproducibility checks, Docker source generation, ignore rules, and architecture classification.
- Preserves the aggregate 132-operation contract and keeps public OpenAPI output unchanged.

## TDD and verification

The slice began with failing ownership, architecture, and adapter mapping tests. The final branch passes:

- go test ./internal/platform/architecture
- go test ./internal/release/http ./internal/release/module ./internal/app/cli
- focused application APIGen and generated numeric-width tests
- task generated:check
- git diff --check

The adapter tests cover create and finalize idempotency headers, artifact content headers, and list/event pagination inputs.

## Stack

Depends on #143. This PR is intentionally open and must not be merged until the stacked migration is reviewed and rebased as needed.

Linear: LEA-103