### PR TITLE
Extract Workspace APIGen into its capability package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,7 @@ internal/platform/http/api/gen
 internal/project/api/gen
 internal/refresh/api/gen
 internal/release/api/gen
+internal/workspace/api/gen
 internal/app/config/config_gen.go
 internal/app/config/spec/names_gen.go
 internal/platform/db/db.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
             internal/project/api/gen
             internal/refresh/api/gen
             internal/release/api/gen
+            internal/workspace/api/gen
             internal/platform/db/db.go
             internal/platform/db/models.go
             internal/platform/db/*.sql.go
@@ -129,6 +130,7 @@ jobs:
             internal/project/api/gen \
             internal/refresh/api/gen \
             internal/release/api/gen \
+            internal/workspace/api/gen \
             schemas/config \
             schemas/json \
             web/generated
@@ -181,6 +183,7 @@ jobs:
             internal/project/api/gen/
             internal/refresh/api/gen/
             internal/release/api/gen/
+            internal/workspace/api/gen/
             internal/platform/db/db.go
             internal/platform/db/models.go
             internal/platform/db/*.sql.go

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ internal/platform/http/api/gen/
 internal/project/api/gen/
 internal/refresh/api/gen/
 internal/release/api/gen/
+internal/workspace/api/gen/
 internal/platform/db/db.go
 internal/platform/db/models.go
 internal/platform/db/*.sql.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ COPY --from=sourcegen /src/internal/platform/http/api/gen ./internal/platform/ht
 COPY --from=sourcegen /src/internal/project/api/gen ./internal/project/api/gen
 COPY --from=sourcegen /src/internal/refresh/api/gen ./internal/refresh/api/gen
 COPY --from=sourcegen /src/internal/release/api/gen ./internal/release/api/gen
+COPY --from=sourcegen /src/internal/workspace/api/gen ./internal/workspace/api/gen
 COPY --from=sourcegen /src/internal/app/cli/gen ./internal/app/cli/gen
 COPY --from=sourcegen /src/internal/app/config/config_gen.go ./internal/app/config/config_gen.go
 COPY --from=sourcegen /src/internal/app/config/spec/names_gen.go ./internal/app/config/spec/names_gen.go

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -384,6 +384,8 @@ tasks:
       - internal/refresh/api/gen/server.apigen.gen.go
       - internal/release/api/gen/request_models.gen.go
       - internal/release/api/gen/server.apigen.gen.go
+      - internal/workspace/api/gen/request_models.gen.go
+      - internal/workspace/api/gen/server.apigen.gen.go
       - docs/api/catalog.json
       - docs/api/openapi.yaml
       - docs/api/operations.json

--- a/api/apigen.yaml
+++ b/api/apigen.yaml
@@ -48,7 +48,10 @@ targets:
           dir: ../internal/release/api/gen
           package: gen
           import_path: github.com/Yacobolo/leapview/internal/release/api/gen
-        LeapViewAPI.Workspace: *leapview_api_go_package
+        LeapViewAPI.Workspace:
+          dir: ../internal/workspace/api/gen
+          package: gen
+          import_path: github.com/Yacobolo/leapview/internal/workspace/api/gen
     cli_out:
       dir: ../internal/app/cli/gen
       package: gen

--- a/internal/app/api/boundary_test.go
+++ b/internal/app/api/boundary_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	apiaggregate "github.com/Yacobolo/leapview/internal/app/api/aggregate"
-	apigen "github.com/Yacobolo/leapview/internal/app/api/gen"
+	workspacegen "github.com/Yacobolo/leapview/internal/workspace/api/gen"
 )
 
 func TestAPIPackageStaysTransportContractOnly(t *testing.T) {
@@ -34,7 +34,7 @@ func TestAgentDoesNotDependOnHeadlessAPIContract(t *testing.T) {
 }
 
 func TestGeneratedAssetResponseRequiresSnapshotAndPayload(t *testing.T) {
-	typ := reflect.TypeOf(apigen.AssetResponse{})
+	typ := reflect.TypeOf(workspacegen.AssetResponse{})
 	for _, name := range []string{"SnapshotId", "Payload"} {
 		field, ok := typ.FieldByName(name)
 		if !ok {
@@ -50,15 +50,15 @@ func TestGeneratedAssetResponseRequiresSnapshotAndPayload(t *testing.T) {
 }
 
 func TestGeneratedAssetListUsesSummaryWithoutPayload(t *testing.T) {
-	listTyp := reflect.TypeOf(apigen.AssetListResponse{})
+	listTyp := reflect.TypeOf(workspacegen.AssetListResponse{})
 	items, ok := listTyp.FieldByName("Items")
 	if !ok {
 		t.Fatal("AssetListResponse.Items missing")
 	}
-	if items.Type.Kind() != reflect.Slice || items.Type.Elem() != reflect.TypeOf(apigen.AssetSummaryResponse{}) {
+	if items.Type.Kind() != reflect.Slice || items.Type.Elem() != reflect.TypeOf(workspacegen.AssetSummaryResponse{}) {
 		t.Fatalf("AssetListResponse.Items type = %s, want []AssetSummaryResponse", items.Type)
 	}
-	if _, ok := reflect.TypeOf(apigen.AssetSummaryResponse{}).FieldByName("Payload"); ok {
+	if _, ok := reflect.TypeOf(workspacegen.AssetSummaryResponse{}).FieldByName("Payload"); ok {
 		t.Fatal("AssetSummaryResponse unexpectedly includes Payload")
 	}
 }

--- a/internal/app/api/managed_data_contract_test.go
+++ b/internal/app/api/managed_data_contract_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	apiaggregate "github.com/Yacobolo/leapview/internal/app/api/aggregate"
-	apigen "github.com/Yacobolo/leapview/internal/app/api/gen"
 	cligen "github.com/Yacobolo/leapview/internal/app/cli/gen"
 )
 
@@ -177,7 +176,7 @@ func TestManagedDataAPIModelsAreBoundedAndBackendNeutral(t *testing.T) {
 
 func TestManagedDataAPIDoesNotGenerateHighLevelCLICommands(t *testing.T) {
 	managedOperationIDs := map[string]bool{}
-	for operationID := range apigen.GetAPIGenOperationContracts() {
+	for operationID := range apiaggregate.GetAPIGenOperationContracts() {
 		if strings.Contains(operationID, "ManagedData") {
 			managedOperationIDs[operationID] = true
 		}

--- a/internal/app/api_apigen.go
+++ b/internal/app/api_apigen.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Yacobolo/leapview/internal/platform/buildinfo"
 	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
 	releasemodule "github.com/Yacobolo/leapview/internal/release/module"
-	workspacemodule "github.com/Yacobolo/leapview/internal/workspace/module"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -49,7 +48,6 @@ type apiGenDispatcher struct {
 	dashboardModule    *dashboardmodule.Module
 	managedDataModule  *manageddatamodule.Module
 	releaseModule      *releasemodule.Module
-	workspaceModule    *workspacemodule.Module
 	defaultEnvironment string
 	buildIdentity      buildinfo.Identity
 	managedDataTus     http.Handler
@@ -105,46 +103,6 @@ func (a apiGenDispatcher) CompleteManagedDataS3MultipartUpload(w http.ResponseWr
 
 func (a apiGenDispatcher) SignManagedDataS3MultipartPart(w http.ResponseWriter, r *http.Request, project, connection, uploadSession, multipartUpload string, partNumber int32, _ apigenapi.GenSignManagedDataS3MultipartPartHeaders) {
 	a.managedDataModule.HTTP().SignManagedDataS3MultipartPart(w, r, project, connection, uploadSession, multipartUpload, partNumber)
-}
-
-func (a apiGenDispatcher) ListWorkspaces(w http.ResponseWriter, r *http.Request, _ apigenapi.GenListWorkspacesParams) {
-	a.workspaceModule.HTTP().Workspaces(w, r)
-}
-
-func (a apiGenDispatcher) Search(w http.ResponseWriter, r *http.Request, params apigenapi.GenSearchParams) {
-	var types *[]string
-	if params.Type != nil {
-		values := make([]string, len(*params.Type))
-		for i, value := range *params.Type {
-			values[i] = string(value)
-		}
-		types = &values
-	}
-	a.workspaceModule.SearchAPI(w, r, workspacemodule.SearchParams{
-		Query: params.Q, Workspaces: params.Workspace, Types: types,
-		ContextWorkspace: params.ContextWorkspace, ContextDashboard: params.ContextDashboard,
-		ContextPage: params.ContextPage, Limit: params.Limit, PageToken: params.PageToken,
-	})
-}
-
-func (a apiGenDispatcher) ListWorkspaceAssets(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListWorkspaceAssetsParams) {
-	a.workspaceModule.HTTP().Assets(w, r)
-}
-
-func (a apiGenDispatcher) GetWorkspaceActiveAssetGraph(w http.ResponseWriter, r *http.Request, _ string) {
-	a.workspaceModule.HTTP().ActiveDeploymentGraph(w, r)
-}
-
-func (a apiGenDispatcher) GetWorkspaceAsset(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.workspaceModule.HTTP().Asset(w, r)
-}
-
-func (a apiGenDispatcher) GetWorkspaceAssetLineage(w http.ResponseWriter, r *http.Request, _, _ string) {
-	a.workspaceModule.HTTP().AssetLineage(w, r)
-}
-
-func (a apiGenDispatcher) ListWorkspaceAssetEdges(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListWorkspaceAssetEdgesParams) {
-	a.workspaceModule.HTTP().AssetEdges(w, r)
 }
 
 func (a apiGenDispatcher) ListDashboards(w http.ResponseWriter, r *http.Request, _ string, _ apigenapi.GenListDashboardsParams) {

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -19,6 +19,7 @@ import (
 	refreshgen "github.com/Yacobolo/leapview/internal/refresh/api/gen"
 	releasegen "github.com/Yacobolo/leapview/internal/release/api/gen"
 	"github.com/Yacobolo/leapview/internal/workspace"
+	workspacegen "github.com/Yacobolo/leapview/internal/workspace/api/gen"
 )
 
 type apiSnapshotWorkspaceRepository struct{ summary workspace.Summary }
@@ -467,6 +468,54 @@ func TestAPIGenReleaseCapabilityOwnsItsOperationSurface(t *testing.T) {
 		}
 		if _, exists := appContracts[operationID]; exists {
 			t.Errorf("Release operation %q is still emitted by the application package", operationID)
+		}
+	}
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {
+		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
+	}
+}
+
+func TestAPIGenWorkspaceCapabilityOwnsItsGeneratedPackage(t *testing.T) {
+	root := projectRoot(t)
+	manifest, err := os.ReadFile(filepath.Join(root, "api", "apigen.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	manifestText := string(manifest)
+	want := "LeapViewAPI.Workspace:\n          dir: ../internal/workspace/api/gen\n          package: gen\n          import_path: github.com/Yacobolo/leapview/internal/workspace/api/gen"
+	if !strings.Contains(manifestText, want) {
+		t.Fatalf("manifest missing Workspace capability package plan %q", want)
+	}
+	if strings.Contains(manifestText, "LeapViewAPI.Workspace: *leapview_api_go_package") {
+		t.Fatal("Workspace namespace is still coalesced into the application generated package")
+	}
+	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	if err != nil {
+		t.Fatalf("read Taskfile.yml: %v", err)
+	}
+	for _, path := range []string{
+		"internal/workspace/api/gen/request_models.gen.go",
+		"internal/workspace/api/gen/server.apigen.gen.go",
+	} {
+		if !strings.Contains(string(taskfile), path) {
+			t.Fatalf("Taskfile.yml does not track generated Workspace artifact %q", path)
+		}
+	}
+}
+
+func TestAPIGenWorkspaceCapabilityOwnsItsOperationSurface(t *testing.T) {
+	contracts := workspacegen.GetAPIGenOperationContracts()
+	if got, want := len(contracts), 8; got != want {
+		t.Fatalf("Workspace generated operations = %d, want %d", got, want)
+	}
+	allowedTags := map[string]bool{"Search": true, "Workspaces": true}
+	appContracts := apigenapi.GetAPIGenOperationContracts()
+	for operationID, contract := range contracts {
+		if len(contract.Tags) != 1 || !allowedTags[contract.Tags[0]] {
+			t.Errorf("Workspace operation %q tags = %v", operationID, contract.Tags)
+		}
+		if _, exists := appContracts[operationID]; exists {
+			t.Errorf("Workspace operation %q is still emitted by the application package", operationID)
 		}
 	}
 	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 132; got != want {

--- a/internal/app/api_v1_supplemental.go
+++ b/internal/app/api_v1_supplemental.go
@@ -23,7 +23,3 @@ func (a apiGenDispatcher) ListManagedDataUploadSessionEvents(w http.ResponseWrit
 		manageddatamodule.EventHeaders{Accept: headers.Accept, LastEventID: headers.LastEventID},
 	)
 }
-
-func (a apiGenDispatcher) GetWorkspace(w http.ResponseWriter, r *http.Request, workspaceID string) {
-	a.workspaceModule.GetWorkspace(w, r, workspaceID)
-}

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -815,6 +815,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if routes.releaseModule != nil && routes.releaseModule.DispatchAPIGenOperation(operationID, platform.logger, writer, request) {
 					return true
 				}
+				if routes.workspaceModule != nil && routes.workspaceModule.DispatchAPIGenOperation(operationID, platform.logger, writer, request) {
+					return true
+				}
 				return apigenapi.DispatchAPIGenOperation(operationID, apiDispatcher, apiprotocol.TransportErrorResponder{Logger: platform.logger}, writer, request)
 			},
 			QueryContext: func(ctx context.Context, scope agentmodule.Scope) context.Context {
@@ -931,7 +934,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	}
 	apiDispatcher = &apiGenDispatcher{
 		dashboardModule: routes.dashboardModule, managedDataModule: routes.managedDataModule,
-		releaseModule: routes.releaseModule, workspaceModule: routes.workspaceModule,
+		releaseModule:      routes.releaseModule,
 		defaultEnvironment: policy.defaultEnvironment, managedDataTus: policy.managedDataTus,
 		buildIdentity: platform.buildIdentity,
 	}
@@ -992,10 +995,16 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	if err != nil {
 		return fmt.Errorf("build Release APIGen transport: %w", err)
 	}
+	workspaceAPIHandler, err := apiapigenruntime.Build(apiGenAuthorizer, func(operationID string, w http.ResponseWriter, r *http.Request) bool {
+		return routes.workspaceModule.DispatchAPIGenOperation(operationID, platform.logger, w, r)
+	})
+	if err != nil {
+		return fmt.Errorf("build Workspace APIGen transport: %w", err)
+	}
 	platform.apiGenServers = apiaggregate.Servers{
 		Access: accessAPIHandler, Agent: agentAPIHandler, Analytics: analyticsAPIHandler,
 		Deployment: deploymentAPIHandler, Gen: appAPIHandler, Project: projectAPIHandler,
-		Refresh: refreshAPIHandler, Release: releaseAPIHandler,
+		Refresh: refreshAPIHandler, Release: releaseAPIHandler, Workspace: workspaceAPIHandler,
 	}
 	configurePageStream(routes, runtime, platform, policy)
 	platform.health = newHealth(healthConfig{

--- a/internal/app/search_api_test.go
+++ b/internal/app/search_api_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/Yacobolo/leapview/internal/access"
-	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
 	servingstate "github.com/Yacobolo/leapview/internal/servingstate"
+	workspacegen "github.com/Yacobolo/leapview/internal/workspace/api/gen"
 )
 
 func TestGlobalSearchReturnsStructuredResultsAcrossWorkspaces(t *testing.T) {
@@ -33,7 +33,7 @@ func TestGlobalSearchReturnsStructuredResultsAcrossWorkspaces(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
-	var body apigenapi.SearchResponse
+	var body workspacegen.SearchResponse
 	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode search response: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestGlobalSearchReturnsStructuredResultsAcrossWorkspaces(t *testing.T) {
 	seen := map[string]bool{}
 	for _, item := range body.Items {
 		seen[item.Reference.WorkspaceId] = true
-		if item.Reference.Type != apigenapi.SearchResultTypeDashboard || item.Reference.Id == "" || item.Href == "" || len(item.Locations) == 0 {
+		if item.Reference.Type != workspacegen.SearchResultTypeDashboard || item.Reference.Id == "" || item.Href == "" || len(item.Locations) == 0 {
 			t.Fatalf("incomplete structured search result: %#v", item)
 		}
 	}
@@ -64,7 +64,7 @@ func TestGlobalSearchRepeatedFiltersAndCursor(t *testing.T) {
 	if firstResponse.Code != http.StatusOK {
 		t.Fatalf("first status=%d body=%s", firstResponse.Code, firstResponse.Body.String())
 	}
-	var first apigenapi.SearchResponse
+	var first workspacegen.SearchResponse
 	if err := json.Unmarshal(firstResponse.Body.Bytes(), &first); err != nil {
 		t.Fatalf("decode first response: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestGlobalSearchRepeatedFiltersAndCursor(t *testing.T) {
 	if nextResponse.Code != http.StatusOK {
 		t.Fatalf("next status=%d body=%s", nextResponse.Code, nextResponse.Body.String())
 	}
-	var next apigenapi.SearchResponse
+	var next workspacegen.SearchResponse
 	if err := json.Unmarshal(nextResponse.Body.Bytes(), &next); err != nil {
 		t.Fatalf("decode next response: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestGlobalSearchDoesNotExposeOtherWorkspacesToScopedCredential(t *testing.T
 	if response.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
-	var body apigenapi.SearchResponse
+	var body workspacegen.SearchResponse
 	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -130,7 +130,7 @@ func newAppTestHarness(metrics QueryMetrics) *appTestHarness {
 func apiGenDispatcherForTest(server *appTestHarness) apiGenDispatcher {
 	return apiGenDispatcher{
 		dashboardModule: server.routes.dashboardModule, managedDataModule: server.routes.managedDataModule,
-		releaseModule: server.routes.releaseModule, workspaceModule: server.routes.workspaceModule,
+		releaseModule:      server.routes.releaseModule,
 		defaultEnvironment: server.policy.defaultEnvironment, managedDataTus: server.policy.managedDataTus,
 		buildIdentity: server.platform.buildIdentity,
 	}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -147,6 +147,16 @@ func TestReleaseGeneratedAPIIsCapabilityOwned(t *testing.T) {
 	}
 }
 
+func TestWorkspaceGeneratedAPIIsCapabilityOwned(t *testing.T) {
+	rule, ok := ClassifyPackage("internal/workspace/api/gen")
+	if !ok {
+		t.Fatal("Workspace generated API package is not classified")
+	}
+	if rule.Capability != "workspace" || rule.Layer != LayerAdapter {
+		t.Fatalf("Workspace generated API classification = %#v, want workspace adapter", rule)
+	}
+}
+
 func TestApplicationOwnsProductConfigurationContract(t *testing.T) {
 	root := repoRoot(t)
 	if !packageDirExists(root, "internal/app/config/spec") {
@@ -1372,6 +1382,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"COPY --from=sourcegen /src/internal/project/api/gen ./internal/project/api/gen",
 		"COPY --from=sourcegen /src/internal/refresh/api/gen ./internal/refresh/api/gen",
 		"COPY --from=sourcegen /src/internal/release/api/gen ./internal/release/api/gen",
+		"COPY --from=sourcegen /src/internal/workspace/api/gen ./internal/workspace/api/gen",
 		"COPY --from=sourcegen /src/internal/access/ui/signals/models.gen.go ./internal/access/ui/signals/models.gen.go",
 		"COPY --from=sourcegen /src/internal/admin/ui/signals/models.gen.go ./internal/admin/ui/signals/models.gen.go",
 		"COPY --from=sourcegen /src/internal/agent/ui/signals/models.gen.go ./internal/agent/ui/signals/models.gen.go",
@@ -1402,7 +1413,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	ignoreText := string(ignored)
 	for _, want := range []string{
 		".data", ".leapview", "node_modules", "api/gen", "internal/access/api/gen", "internal/agent/api/gen", "internal/analytics/api/gen", "internal/deployment/api/gen",
-		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "internal/project/api/gen", "internal/refresh/api/gen", "internal/release/api/gen", "static/chunks",
+		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "internal/project/api/gen", "internal/refresh/api/gen", "internal/release/api/gen", "internal/workspace/api/gen", "static/chunks",
 	} {
 		if !strings.Contains(ignoreText, want) {
 			t.Fatalf(".dockerignore missing generated or runtime path %q", want)

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -172,6 +172,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/project/api/gen", Capability: "project", Layer: LayerAdapter},
 	{Prefix: "internal/refresh/api/gen", Capability: "refresh", Layer: LayerAdapter},
 	{Prefix: "internal/release/api/gen", Capability: "release", Layer: LayerAdapter},
+	{Prefix: "internal/workspace/api/gen", Capability: "workspace", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/aggregate", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/app/api/gen", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/platform/architecture", Capability: "platform", Layer: LayerPlatform},

--- a/internal/workspace/http/apigen.go
+++ b/internal/workspace/http/apigen.go
@@ -1,0 +1,89 @@
+package http
+
+import (
+	"context"
+	"log/slog"
+	stdhttp "net/http"
+
+	apitransport "github.com/Yacobolo/leapview/internal/platform/http/transport"
+	workspaceapi "github.com/Yacobolo/leapview/internal/workspace/api"
+	workspacegen "github.com/Yacobolo/leapview/internal/workspace/api/gen"
+)
+
+type APIGenSearchParams = workspaceapi.SearchParams
+
+type APIGenHandler interface {
+	Search(stdhttp.ResponseWriter, *stdhttp.Request, APIGenSearchParams)
+	ListWorkspaces(stdhttp.ResponseWriter, *stdhttp.Request)
+	GetWorkspace(stdhttp.ResponseWriter, *stdhttp.Request, string)
+	GetWorkspaceActiveAssetGraph(stdhttp.ResponseWriter, *stdhttp.Request)
+	ListWorkspaceAssetEdges(stdhttp.ResponseWriter, *stdhttp.Request)
+	ListWorkspaceAssets(stdhttp.ResponseWriter, *stdhttp.Request)
+	GetWorkspaceAsset(stdhttp.ResponseWriter, *stdhttp.Request)
+	GetWorkspaceAssetLineage(stdhttp.ResponseWriter, *stdhttp.Request)
+}
+
+type APIGenDispatcher struct{ handler APIGenHandler }
+
+func NewAPIGenDispatcher(handler APIGenHandler) *APIGenDispatcher {
+	return &APIGenDispatcher{handler: handler}
+}
+
+func (d *APIGenDispatcher) Search(w stdhttp.ResponseWriter, r *stdhttp.Request, params workspacegen.GenSearchParams) {
+	var types *[]string
+	if params.Type != nil {
+		values := make([]string, len(*params.Type))
+		for i, value := range *params.Type {
+			values[i] = string(value)
+		}
+		types = &values
+	}
+	d.handler.Search(w, r, APIGenSearchParams{
+		Query: params.Q, Workspaces: params.Workspace, Types: types,
+		ContextWorkspace: params.ContextWorkspace, ContextDashboard: params.ContextDashboard,
+		ContextPage: params.ContextPage, Limit: params.Limit, PageToken: params.PageToken,
+	})
+}
+
+func (d *APIGenDispatcher) ListWorkspaces(w stdhttp.ResponseWriter, r *stdhttp.Request, _ workspacegen.GenListWorkspacesParams) {
+	d.handler.ListWorkspaces(w, r)
+}
+
+func (d *APIGenDispatcher) GetWorkspace(w stdhttp.ResponseWriter, r *stdhttp.Request, workspace string) {
+	d.handler.GetWorkspace(w, r, workspace)
+}
+
+func (d *APIGenDispatcher) GetWorkspaceActiveAssetGraph(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.GetWorkspaceActiveAssetGraph(w, r)
+}
+
+func (d *APIGenDispatcher) ListWorkspaceAssetEdges(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ workspacegen.GenListWorkspaceAssetEdgesParams) {
+	d.handler.ListWorkspaceAssetEdges(w, r)
+}
+
+func (d *APIGenDispatcher) ListWorkspaceAssets(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ workspacegen.GenListWorkspaceAssetsParams) {
+	d.handler.ListWorkspaceAssets(w, r)
+}
+
+func (d *APIGenDispatcher) GetWorkspaceAsset(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.GetWorkspaceAsset(w, r)
+}
+
+func (d *APIGenDispatcher) GetWorkspaceAssetLineage(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
+	d.handler.GetWorkspaceAssetLineage(w, r)
+}
+
+type APIGenTransportErrorResponder struct{ Logger *slog.Logger }
+
+func (responder APIGenTransportErrorResponder) RespondTransportError(ctx context.Context, w stdhttp.ResponseWriter, r *stdhttp.Request, failure workspacegen.GenTransportError) {
+	apitransport.WriteAPIGenFailure(ctx, w, r, responder.Logger, apitransport.APIGenFailure{
+		OperationID: failure.OperationID, Kind: failure.Kind, StatusCode: failure.StatusCode,
+		Code: failure.Code, PublicDetail: failure.PublicDetail, Cause: failure.Cause,
+	})
+}
+
+func DispatchAPIGenOperation(operationID string, handler APIGenHandler, logger *slog.Logger, w stdhttp.ResponseWriter, r *stdhttp.Request) bool {
+	return workspacegen.DispatchAPIGenOperation(
+		operationID, NewAPIGenDispatcher(handler), APIGenTransportErrorResponder{Logger: logger}, w, r,
+	)
+}

--- a/internal/workspace/http/apigen_test.go
+++ b/internal/workspace/http/apigen_test.go
@@ -1,0 +1,65 @@
+package http
+
+import (
+	stdhttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	workspacegen "github.com/Yacobolo/leapview/internal/workspace/api/gen"
+)
+
+var _ workspacegen.GenOperationDispatcher = (*APIGenDispatcher)(nil)
+var _ workspacegen.GenTransportErrorResponder = APIGenTransportErrorResponder{}
+
+func TestAPIGenDispatcherMapsSearchParameters(t *testing.T) {
+	handler := &recordingAPIGenHandler{}
+	types := []workspacegen.SearchResultType{workspacegen.SearchResultTypeDashboard, workspacegen.SearchResultTypePage}
+	workspaces := []string{"sales", "operations"}
+	dispatcher := NewAPIGenDispatcher(handler)
+	dispatcher.Search(
+		httptest.NewRecorder(),
+		httptest.NewRequest(stdhttp.MethodGet, "/api/v1/search", nil),
+		workspacegen.GenSearchParams{
+			Q: stringPointer("revenue"), Workspace: &workspaces, Type: &types,
+			ContextWorkspace: stringPointer("sales"), ContextDashboard: stringPointer("executive"),
+			ContextPage: stringPointer("overview"), Limit: int32Pointer(20), PageToken: stringPointer("next"),
+		},
+	)
+
+	if got, want := *handler.search.Query, "revenue"; got != want {
+		t.Fatalf("query = %q, want %q", got, want)
+	}
+	if got, want := *handler.search.Types, []string{"dashboard", "page"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("types = %v, want %v", got, want)
+	}
+	if got, want := *handler.search.Workspaces, workspaces; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("workspaces = %v, want %v", got, want)
+	}
+	if got, want := *handler.search.Limit, int32(20); got != want {
+		t.Fatalf("limit = %d, want %d", got, want)
+	}
+	if got, want := *handler.search.PageToken, "next"; got != want {
+		t.Fatalf("page token = %q, want %q", got, want)
+	}
+}
+
+type recordingAPIGenHandler struct {
+	search APIGenSearchParams
+}
+
+func (h *recordingAPIGenHandler) Search(_ stdhttp.ResponseWriter, _ *stdhttp.Request, params APIGenSearchParams) {
+	h.search = params
+}
+
+func (*recordingAPIGenHandler) ListWorkspaces(stdhttp.ResponseWriter, *stdhttp.Request)       {}
+func (*recordingAPIGenHandler) GetWorkspace(stdhttp.ResponseWriter, *stdhttp.Request, string) {}
+func (*recordingAPIGenHandler) GetWorkspaceActiveAssetGraph(stdhttp.ResponseWriter, *stdhttp.Request) {
+}
+func (*recordingAPIGenHandler) ListWorkspaceAssetEdges(stdhttp.ResponseWriter, *stdhttp.Request) {}
+func (*recordingAPIGenHandler) ListWorkspaceAssets(stdhttp.ResponseWriter, *stdhttp.Request)     {}
+func (*recordingAPIGenHandler) GetWorkspaceAsset(stdhttp.ResponseWriter, *stdhttp.Request)       {}
+func (*recordingAPIGenHandler) GetWorkspaceAssetLineage(stdhttp.ResponseWriter, *stdhttp.Request) {
+}
+
+func stringPointer(value string) *string { return &value }
+func int32Pointer(value int32) *int32    { return &value }

--- a/internal/workspace/module/apigen.go
+++ b/internal/workspace/module/apigen.go
@@ -1,0 +1,46 @@
+package module
+
+import (
+	"log/slog"
+	"net/http"
+
+	workspacehttp "github.com/Yacobolo/leapview/internal/workspace/http"
+)
+
+type workspaceAPIGenHandler struct{ module *Module }
+
+func (h workspaceAPIGenHandler) Search(w http.ResponseWriter, r *http.Request, params workspacehttp.APIGenSearchParams) {
+	h.module.SearchAPI(w, r, params)
+}
+
+func (h workspaceAPIGenHandler) ListWorkspaces(w http.ResponseWriter, r *http.Request) {
+	h.module.HTTP().Workspaces(w, r)
+}
+
+func (h workspaceAPIGenHandler) GetWorkspace(w http.ResponseWriter, r *http.Request, workspaceID string) {
+	h.module.GetWorkspace(w, r, workspaceID)
+}
+
+func (h workspaceAPIGenHandler) GetWorkspaceActiveAssetGraph(w http.ResponseWriter, r *http.Request) {
+	h.module.HTTP().ActiveDeploymentGraph(w, r)
+}
+
+func (h workspaceAPIGenHandler) ListWorkspaceAssetEdges(w http.ResponseWriter, r *http.Request) {
+	h.module.HTTP().AssetEdges(w, r)
+}
+
+func (h workspaceAPIGenHandler) ListWorkspaceAssets(w http.ResponseWriter, r *http.Request) {
+	h.module.HTTP().Assets(w, r)
+}
+
+func (h workspaceAPIGenHandler) GetWorkspaceAsset(w http.ResponseWriter, r *http.Request) {
+	h.module.HTTP().Asset(w, r)
+}
+
+func (h workspaceAPIGenHandler) GetWorkspaceAssetLineage(w http.ResponseWriter, r *http.Request) {
+	h.module.HTTP().AssetLineage(w, r)
+}
+
+func (m *Module) DispatchAPIGenOperation(operationID string, logger *slog.Logger, w http.ResponseWriter, r *http.Request) bool {
+	return workspacehttp.DispatchAPIGenOperation(operationID, workspaceAPIGenHandler{module: m}, logger, w, r)
+}

--- a/internal/workspace/module/read_model_test.go
+++ b/internal/workspace/module/read_model_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	apigenapi "github.com/Yacobolo/leapview/internal/app/api/gen"
 	"github.com/Yacobolo/leapview/internal/workspace"
+	workspacegen "github.com/Yacobolo/leapview/internal/workspace/api/gen"
 )
 
 type activeMetadataReadModel struct {
@@ -64,7 +64,7 @@ func TestWorkspaceListUsesActiveMetadataWithoutLoadingGraphs(t *testing.T) {
 		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
 	}
 	var body struct {
-		Items []apigenapi.WorkspaceResponse `json:"items"`
+		Items []workspacegen.WorkspaceResponse `json:"items"`
 	}
 	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode workspaces response: %v body=%s", err, recorder.Body.String())


### PR DESCRIPTION
## Summary

Moves the eight LeapViewAPI.Workspace operations from the application generated package into internal/workspace/api/gen. Workspace now owns generated dispatch for workspace discovery, global search, asset navigation, active graphs, and lineage; internal/app only composes the authorized server.

This is stack position 6 of 8 for LEA-98 and is based on the Release migration branch so the review diff contains only Workspace ownership changes.

## Design

- Adds an explicit APIGen manifest partition for LeapViewAPI.Workspace.
- Adds a Workspace HTTP adapter that converts generated Search enums and parameters into the capability SearchParams contract.
- Adds Workspace module dispatch that delegates to its existing HTTP and search surfaces.
- Removes all eight Workspace forwarding methods and the Workspace dependency from the application dispatcher.
- Moves Workspace/Search generated DTO consumers in tests to internal/workspace/api/gen.
- Tracks the new generated package across Task generation, CI reproducibility, Docker source generation, ignore rules, and architecture classification.
- Preserves all 132 aggregate operations, routes, operation IDs, authorization metadata, and public OpenAPI output.

## TDD and verification

The slice began with failing generated-package ownership, architecture classification, and adapter mapping tests. The final branch passes:

- go test ./internal/platform/architecture
- go test ./internal/workspace/http ./internal/workspace/module
- focused application APIGen, Workspace, and global Search tests
- task generated:check
- git diff --check

The adapter test covers search text, workspace filters, typed result filters, context, limit, and cursor conversion.

## Stack

Depends on #145. This PR is intentionally open and must not be merged until the stack is reviewed and rebased as needed.

Linear: LEA-104