### PR TITLE
LEA-54: qualify restart and interruption recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,7 @@ jobs:
           deploy/hetzner/files/leapview-backup-hook
           deploy/hetzner/files/provision.sh.tftpl
           deploy/compose/qualification/qualify.sh
+          deploy/compose/qualification/recover.sh
 
       - name: Initialize Terraform providers
         working-directory: deploy/hetzner

--- a/.github/workflows/installed-candidate.yml
+++ b/.github/workflows/installed-candidate.yml
@@ -61,7 +61,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - name: Remove registry credentials
@@ -103,6 +103,8 @@ jobs:
           if-no-files-found: warn
           path: |
             ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/qualification-report.json
+            ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/recovery-report.json
+            ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/recovery-events.json
             ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/runtime-identity.json
             ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/*.log
             ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/browser-failure.png

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,7 +287,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - name: Download unpublished candidate
@@ -322,6 +322,8 @@ jobs:
           if-no-files-found: warn
           path: |
             ${{ runner.temp }}/installed-candidate-evidence/qualification-report.json
+            ${{ runner.temp }}/installed-candidate-evidence/recovery-report.json
+            ${{ runner.temp }}/installed-candidate-evidence/recovery-events.json
             ${{ runner.temp }}/installed-candidate-evidence/runtime-identity.json
             ${{ runner.temp }}/installed-candidate-evidence/*.log
             ${{ runner.temp }}/installed-candidate-evidence/browser-failure.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@
 
 FROM node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989 AS node
 
+# A caller may override this empty stage with a named build context containing
+# basemap.pmtiles. The generator verifies the pinned digest before accepting it.
+FROM scratch AS mapassetseed
+
 FROM golang:1.25-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 AS sourcegen
 WORKDIR /src
 
@@ -18,11 +22,21 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     ./scripts/generate_build_sources.sh && \
-    go run ./internal/app/tools/mapassets --out .data/map-assets && \
     go run ./internal/app/tools/clidocgen && \
     go run ./internal/app/tools/schemadocgen && \
     go run ./internal/app/tools/openapidocgen && \
     go run ./internal/app/tools/docsitegen
+
+# Keep the large, network-backed map extraction separate so a transient remote
+# failure can be retried without repeating deterministic source generation.
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=bind,from=mapassetseed,source=/,target=/mapasset-seed,ro \
+    if [ -f /mapasset-seed/basemap.pmtiles ]; then \
+      go run ./internal/app/tools/mapassets --out .data/map-assets --seed-archive /mapasset-seed/basemap.pmtiles; \
+    else \
+      go run ./internal/app/tools/mapassets --out .data/map-assets; \
+    fi
 
 FROM oven/bun:1.3.7@sha256:6cd5f00020e48b77a253bc8249f6b6dd3d92b3c04c2607f1f5a6d7dbf0a6fca3 AS web
 WORKDIR /src

--- a/deploy/compose/QUALIFICATION.md
+++ b/deploy/compose/QUALIFICATION.md
@@ -11,6 +11,7 @@ same journey.
 | Initialization | Run real `./leapviewctl init`, `start`, `status`, and `first-login`; reject a second credential read. | Confirm the first-login warning is unavoidable and the output is understandable without repository context. |
 | Five-minute sample | Stage the bundled synthetic data, deploy the bundled evaluation project, sign in, change the password, open **Five-minute Sales Evaluation**, select State `SP`, and verify KPI and governed table results. | Starting from the installation guide, time the same journey from the first pull through the filtered dashboard. Record the total without recording credentials. |
 | Governed access | Execute a governed semantic query, verify an unauthenticated query is denied, then use the deliberately restricted bootstrap publisher token against a workspace administration endpoint and require the denial to appear as `authorization.denied` through its read-only audit scope. | Inspect the access/query audit surfaces for the successful and denied attempts and retain only IDs/timestamps. |
+| Interruption recovery | At API-observed boundaries, send `SIGKILL` to the exact candidate during a resumable managed upload, release finalization, deployment activation, refresh/materialization claim, active query/SSE traffic, backup creation, and restore preflight. Require each durable operation to resume or end in an explicit recoverable state; require the prior revision/generation to remain visible until atomic activation; then repeat query/SSE reconnects and verify bounded goroutines, temporary files, and disk growth. | While following the same managed upload, deployment activation, refresh, query/SSE, backup, and restore preflight sequence, confirm the UI and event history name the attempted, interrupted, resumed, failed, and completed states without exposing credentials. |
 | Operations | Verify readiness, authenticated metrics, bounded structured logs, candidate identity, restart persistence, a validated backup, and restore into an isolated instance using the original separately managed secret configuration. | Inspect the restored dashboard and confirm the active serving state and managed data are unchanged. |
 | Upgrade safety | When a compatible previous digest is supplied, exercise upgrade and confirmed rollback with paired state checkpoints. | Confirm the documented recovery decision is clear before discarding post-upgrade state. |
 
@@ -35,12 +36,13 @@ redirect the bounded report and failure screenshot.
 
 ## Evidence and timing
 
-Retain only `qualification-report.json`, `runtime-identity.json`, bounded
-redacted Compose logs, and the failure screenshot when present. Never retain
+Retain only `qualification-report.json`, `recovery-report.json`,
+`recovery-events.json`, `runtime-identity.json`, bounded redacted Compose logs,
+and the failure screenshot when present. Never retain
 `initial-credentials.json`, `leapview.env`, browser storage state, cookies, or
-API tokens. Five consecutive supported-host runs provide the publication
-median; each must remain under five minutes after the image and browser helper
-are present locally, and the clean public pull duration is recorded separately.
+API tokens. The five-minute budget applies to the sample evaluator journey;
+the destructive interruption matrix is recorded separately because it
+deliberately repeats restarts, backup, and restore.
 
 ## Incident ownership
 

--- a/deploy/compose/deployment_test.go
+++ b/deploy/compose/deployment_test.go
@@ -172,6 +172,7 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 	release := read(t, filepath.Join(root, ".github", "workflows", "release.yml"))
 	qualification := read(t, filepath.Join(root, ".github", "workflows", "installed-candidate.yml"))
 	script := read(t, filepath.Join(root, "deploy", "compose", "qualification", "qualify.sh"))
+	recovery := read(t, filepath.Join(root, "deploy", "compose", "qualification", "recover.sh"))
 	browser := read(t, filepath.Join(root, "deploy", "compose", "qualification", "browser.mjs"))
 	runbook := read(t, filepath.Join(root, "deploy", "compose", "QUALIFICATION.md"))
 
@@ -230,9 +231,70 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 		"auditedDenial",
 		"runtime-identity.json",
 		"qualification-report.json",
+		"./qualification/recover.sh",
+		"recovery-report.json",
 	} {
 		if !strings.Contains(script, required) {
 			t.Errorf("qualification script missing tester assertion %q", required)
+		}
+	}
+	for _, required := range []string{
+		"managedUpload",
+		"releaseFinalization",
+		"deploymentActivation",
+		"refreshRecovery",
+		"queryStreamReconnect",
+		"backupInterruption",
+		"restorePreflight",
+		"boundedDisk",
+		"docker kill --signal KILL",
+		"LEAPVIEW_REFRESH_JOB_LEASE_TIMEOUT",
+		"listManagedDataUploadSessionEvents",
+		"listDeploymentEvents",
+		"listRefreshRunEvents",
+		"exec ./leapviewctl backup interrupted.tar.gz",
+		"exec ./leapviewctl restore backups/recovered.tar.gz",
+	} {
+		if !strings.Contains(recovery, required) {
+			t.Errorf("recovery qualification missing fault assertion %q", required)
+		}
+	}
+	waitForJSONStart := strings.Index(recovery, "wait_for_json() {")
+	if waitForJSONStart < 0 {
+		t.Fatal("recovery qualification is missing its JSON status waiter")
+	}
+	waitForJSONEnd := strings.Index(recovery[waitForJSONStart:], "\n}\n")
+	if waitForJSONEnd < 0 {
+		t.Fatal("recovery qualification JSON status waiter is unterminated")
+	}
+	waitForJSON := recovery[waitForJSONStart : waitForJSONStart+waitForJSONEnd]
+	if !strings.Contains(waitForJSON, "sleep 1") {
+		t.Error("recovery qualification must poll durable job status slowly enough to stay below the shipped API rate limit")
+	}
+	backupStart := strings.Index(recovery, `stage="backup interruption"`)
+	if backupStart < 0 {
+		t.Fatal("recovery qualification is missing the backup interruption stage")
+	}
+	backupStage := recovery[backupStart:]
+	restoreStage := strings.Index(backupStage, `stage="restore preflight interruption"`)
+	if restoreStage < 0 {
+		t.Fatal("recovery qualification is missing the restore preflight stage")
+	}
+	backupStage = backupStage[:restoreStage]
+	unthrottle := strings.Index(backupStage, `docker update --cpus 0 "$container_id"`)
+	restart := strings.Index(backupStage, `./leapviewctl start`)
+	if unthrottle < 0 || restart < 0 || unthrottle > restart {
+		t.Error("backup recovery must remove its fault-injection CPU limit before restarting the service")
+	}
+	for _, workflow := range []struct {
+		name     string
+		contents string
+	}{
+		{name: "release", contents: release},
+		{name: "installed candidate", contents: qualification},
+	} {
+		if !strings.Contains(workflow.contents, "recovery-report.json") {
+			t.Errorf("%s workflow does not retain the bounded recovery report", workflow.name)
 		}
 	}
 	if strings.Contains(script, "${run_suffix,,}") {
@@ -273,6 +335,13 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 		"Five-minute Sales Evaluation",
 		"Anonymous distribution",
 		"Incident ownership",
+		"Interruption recovery",
+		"managed upload",
+		"deployment activation",
+		"refresh",
+		"query/SSE",
+		"backup",
+		"restore preflight",
 	} {
 		if !strings.Contains(runbook, required) {
 			t.Errorf("qualification runbook missing %q", required)

--- a/deploy/compose/qualification/qualify.sh
+++ b/deploy/compose/qualification/qualify.sh
@@ -23,6 +23,8 @@ rm -f \
   "$evidence_dir/browser-failure.png" \
   "$evidence_dir/compose.log" \
   "$evidence_dir/qualification-report.json" \
+  "$evidence_dir/recovery-events.json" \
+  "$evidence_dir/recovery-report.json" \
   "$evidence_dir/restore-compose.log" \
   "$evidence_dir/runtime-identity.json"
 
@@ -53,6 +55,18 @@ set_min_free_bytes() {
     rm -f "$root/leapview.env.bak"
   else
     printf 'LEAPVIEW_MANAGED_DATA_MIN_FREE_BYTES=%s\n' "$local_min_free_bytes" >> "$root/leapview.env"
+  fi
+}
+
+set_qualification_job_lease() {
+  local root="$1"
+  if grep -q '^LEAPVIEW_REFRESH_JOB_LEASE_TIMEOUT=' "$root/leapview.env"; then
+    sed -i.bak \
+      's/^LEAPVIEW_REFRESH_JOB_LEASE_TIMEOUT=.*/LEAPVIEW_REFRESH_JOB_LEASE_TIMEOUT=15s/' \
+      "$root/leapview.env"
+    rm -f "$root/leapview.env.bak"
+  else
+    printf 'LEAPVIEW_REFRESH_JOB_LEASE_TIMEOUT=15s\n' >> "$root/leapview.env"
   fi
 }
 
@@ -158,6 +172,7 @@ cd "$bundle_root"
   --environment qualification \
   --image "$image_reference"
 set_min_free_bytes "$bundle_root"
+set_qualification_job_lease "$bundle_root"
 ./leapviewctl start
 
 credentials_file="$(mktemp "$bundle_root/.qualification-credentials.XXXXXX")"
@@ -247,6 +262,16 @@ grep -q '^# HELP leapview_http_request_duration_seconds ' "$metrics_file"
 rm -f "$metrics_file"
 metrics_file=""
 
+QUALIFICATION_BUNDLE_ROOT="$bundle_root" \
+QUALIFICATION_CONTAINER_ID="$container_id" \
+QUALIFICATION_PUBLISHER_TOKEN="$publisher_token" \
+QUALIFICATION_METRICS_TOKEN="$metrics_token" \
+QUALIFICATION_COMPOSE_PROJECT="$primary_project" \
+QUALIFICATION_PROJECT_ID=leapview-evaluation \
+LEAPVIEW_QUALIFICATION_EVIDENCE_DIR="$evidence_dir" \
+  ./qualification/recover.sh
+container_id="$(compose_in "$bundle_root" ps --quiet leapview)"
+
 docker restart "$container_id" >/dev/null
 for _ in $(seq 1 120); do
   [[ "$(docker inspect --format '{{.State.Health.Status}}' "$container_id")" == healthy ]] && break
@@ -318,6 +343,7 @@ jq -n \
   --argjson browserJourney true \
   --argjson governedQuery true \
   --argjson auditedDenial true \
+  --argjson interruptionRecovery true \
   --argjson restartPersistence true \
   --argjson backupRestore true \
   '{
@@ -332,6 +358,7 @@ jq -n \
       browserJourney:$browserJourney,
       governedQuery:$governedQuery,
       auditedDenial:$auditedDenial,
+      interruptionRecovery:$interruptionRecovery,
       restartPersistence:$restartPersistence,
       backupRestore:$backupRestore
     }

--- a/deploy/compose/qualification/recover.sh
+++ b/deploy/compose/qualification/recover.sh
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script is invoked by qualify.sh after the evaluator workspace is live.
+# It deliberately kills the shipped server at API-observed durability
+# boundaries. No source checkout, test binary, or in-process failpoint is used.
+
+bundle_root="${QUALIFICATION_BUNDLE_ROOT:?QUALIFICATION_BUNDLE_ROOT is required}"
+evidence_dir="${LEAPVIEW_QUALIFICATION_EVIDENCE_DIR:?LEAPVIEW_QUALIFICATION_EVIDENCE_DIR is required}"
+publisher_token="${QUALIFICATION_PUBLISHER_TOKEN:?QUALIFICATION_PUBLISHER_TOKEN is required}"
+metrics_token="${QUALIFICATION_METRICS_TOKEN:?QUALIFICATION_METRICS_TOKEN is required}"
+container_id="${QUALIFICATION_CONTAINER_ID:?QUALIFICATION_CONTAINER_ID is required}"
+project_name="${QUALIFICATION_COMPOSE_PROJECT:?QUALIFICATION_COMPOSE_PROJECT is required}"
+project_id="${QUALIFICATION_PROJECT_ID:?QUALIFICATION_PROJECT_ID is required}"
+api_root="http://127.0.0.1:8080"
+report="$evidence_dir/recovery-report.json"
+events="$evidence_dir/recovery-events.json"
+work_dir="$(mktemp -d "$bundle_root/.qualification-recovery.XXXXXX")"
+stage="initialize"
+success=false
+
+managedUpload=false
+releaseFinalization=false
+deploymentActivation=false
+refreshRecovery=false
+queryStreamReconnect=false
+backupInterruption=false
+restorePreflight=false
+boundedDisk=false
+
+grep -q '^LEAPVIEW_REFRESH_JOB_LEASE_TIMEOUT=15s$' "$bundle_root/leapview.env" || {
+  printf 'recovery qualification requires LEAPVIEW_REFRESH_JOB_LEASE_TIMEOUT=15s\n' >&2
+  exit 1
+}
+
+write_report() {
+  local result="$1"
+  jq -n \
+    --arg result "$result" \
+    --arg stage "$stage" \
+    --arg image "$(tr -d '[:space:]' < "$bundle_root/image-reference.txt")" \
+    --argjson managedUpload "$managedUpload" \
+    --argjson releaseFinalization "$releaseFinalization" \
+    --argjson deploymentActivation "$deploymentActivation" \
+    --argjson refreshRecovery "$refreshRecovery" \
+    --argjson queryStreamReconnect "$queryStreamReconnect" \
+    --argjson backupInterruption "$backupInterruption" \
+    --argjson restorePreflight "$restorePreflight" \
+    --argjson boundedDisk "$boundedDisk" \
+    '{
+      result:$result,
+      stage:$stage,
+      image:$image,
+      assertions:{
+        managedUpload:$managedUpload,
+        releaseFinalization:$releaseFinalization,
+        deploymentActivation:$deploymentActivation,
+        refreshRecovery:$refreshRecovery,
+        queryStreamReconnect:$queryStreamReconnect,
+        backupInterruption:$backupInterruption,
+        restorePreflight:$restorePreflight,
+        boundedDisk:$boundedDisk
+      }
+    }' > "$report"
+}
+
+cleanup() {
+  local result=$?
+  set +e
+  docker update --cpus 0 "$container_id" >/dev/null 2>&1
+  rm -rf "$work_dir"
+  if [[ "$success" != true ]]; then
+    write_report failure
+  fi
+  exit "$result"
+}
+trap cleanup EXIT
+
+api() {
+  local method="$1"
+  local path="$2"
+  local output="$3"
+  local body="${4:-}"
+  local idempotency_key="${5:-}"
+  local args=(
+    --fail --silent --show-error
+    --request "$method"
+    --header "Host: localhost"
+    --header "Authorization: Bearer $publisher_token"
+    --header "Accept: application/json"
+    --output "$output"
+  )
+  if [[ -n "$body" ]]; then
+    args+=(--header "Content-Type: application/json" --data "$body")
+  fi
+  if [[ -n "$idempotency_key" ]]; then
+    args+=(--header "Idempotency-Key: $idempotency_key")
+  fi
+  curl "${args[@]}" "$api_root$path"
+}
+
+wait_healthy() {
+  for _ in $(seq 1 180); do
+    if [[ "$(docker inspect --format '{{.State.Health.Status}}' "$container_id" 2>/dev/null)" == healthy ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  printf 'candidate did not recover health after %s\n' "$stage" >&2
+  return 1
+}
+
+kill_candidate() {
+  docker kill --signal KILL "$container_id" >/dev/null
+  docker start "$container_id" >/dev/null
+  wait_healthy
+}
+
+wait_for_json() {
+  local path="$1"
+  local expression="$2"
+  local output="$3"
+  for _ in $(seq 1 600); do
+    if api GET "$path" "$output" 2>/dev/null && jq -e "$expression" "$output" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  printf 'timed out waiting for %s while %s\n' "$path" "$stage" >&2
+  return 1
+}
+
+wait_for_process_exit() {
+  local pid="$1"
+  for _ in $(seq 1 100); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid" 2>/dev/null || true
+      return 0
+    fi
+    sleep 0.05
+  done
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+compose_oneoff() {
+  local command_pattern="$1"
+  local output="$2"
+  for _ in $(seq 1 1200); do
+    local candidate
+    while IFS= read -r candidate; do
+      [[ -n "$candidate" ]] || continue
+      if docker inspect --format '{{json .Config.Cmd}}' "$candidate" | grep -q "$command_pattern"; then
+        printf '%s\n' "$candidate" > "$output"
+        return 0
+      fi
+    done < <(
+      docker ps \
+        --filter "label=com.docker.compose.project=$project_name" \
+        --filter "label=com.docker.compose.oneoff=True" \
+        --quiet
+    )
+    sleep 0.05
+  done
+  printf 'timed out waiting for Compose one-off command %s\n' "$command_pattern" >&2
+  return 1
+}
+
+run_in_candidate() {
+  docker exec \
+    -e "LEAPVIEW_API_TOKEN=$publisher_token" \
+    -e LEAPVIEW_TARGET=http://localhost:8080 \
+    "$container_id" \
+    "$@"
+}
+
+stage="managed upload interruption"
+baseline_active="$work_dir/baseline-active.json"
+api GET "/api/v1/projects/$project_id/connections/sample/active-revision" "$baseline_active"
+baseline_revision="$(jq -er '.revision.id' "$baseline_active")"
+
+docker exec "$container_id" sh -euc '
+  root=/var/lib/leapview/qualification-recovery
+  rm -rf "$root"
+  mkdir -p "$root/input" "$root/project-a" "$root/project-b"
+  awk -F, '"'"'
+    BEGIN { OFS="," }
+    NR == 1 { print; next }
+    {
+      original=$1
+      for (iteration=1; iteration<=100000; iteration++) {
+        $1=original "-" iteration
+        print
+      }
+    }
+  '"'"' /app/evaluation/data/orders.csv > "$root/input/orders.csv"
+  cp -R /app/evaluation/project/. "$root/project-a/"
+  cp -R /app/evaluation/project/. "$root/project-b/"
+  sed -i "s/title: Evaluation Workspace/title: Recovery Release Workspace/" "$root/project-a/workspaces/evaluation/workspace.yaml"
+  sed -i "s/title: Evaluation Workspace/title: Recovery Deployment Workspace/" "$root/project-b/workspaces/evaluation/workspace.yaml"
+'
+
+docker update --cpus 0.25 "$container_id" >/dev/null
+sync_log="$evidence_dir/recovery-managed-upload.log"
+run_in_candidate \
+  leapview data sync \
+  --project /var/lib/leapview/qualification-recovery/project-a/leapview.yaml \
+  --connection sample \
+  --from /var/lib/leapview/qualification-recovery/input \
+  > "$sync_log" 2>&1 &
+sync_pid=$!
+
+sessions="$work_dir/upload-sessions.json"
+interrupted_session=""
+interrupted_offset=0
+for _ in $(seq 1 1200); do
+  if api GET "/api/v1/projects/$project_id/connections/sample/upload-sessions?limit=100" "$sessions" 2>/dev/null; then
+    interrupted_session="$(
+      jq -r '
+        [
+          .items[] |
+          select(.status == "open") |
+          select(any(.files[]; (.file.size // 0) > 50000000 and (.negotiation.tus.offset // 0) > 0 and (.negotiation.tus.offset // 0) < .file.size))
+        ][0].id // empty
+      ' "$sessions"
+    )"
+    if [[ -n "$interrupted_session" ]]; then
+      interrupted_offset="$(
+        jq -r --arg id "$interrupted_session" '
+          .items[] | select(.id == $id) | [.files[].negotiation.tus.offset // 0] | max
+        ' "$sessions"
+      )"
+      break
+    fi
+  fi
+  if ! kill -0 "$sync_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.025
+done
+[[ -n "$interrupted_session" && "$interrupted_offset" -gt 0 ]]
+kill_candidate
+wait_for_process_exit "$sync_pid"
+
+session_after="$work_dir/upload-session-after.json"
+api GET "/api/v1/projects/$project_id/connections/sample/upload-sessions/$interrupted_session" "$session_after"
+jq -e --argjson offset "$interrupted_offset" '
+  .status == "open" and
+  ([.files[].negotiation.tus.offset // 0] | max) >= $offset
+' "$session_after" >/dev/null
+
+docker update --cpus 0 "$container_id" >/dev/null
+sync_output="$(
+  run_in_candidate \
+    leapview data sync \
+    --project /var/lib/leapview/qualification-recovery/project-a/leapview.yaml \
+    --connection sample \
+    --from /var/lib/leapview/qualification-recovery/input
+)"
+fault_revision="$(awk '$1 == "staged" { print $2 }' <<<"$sync_output")"
+[[ "$fault_revision" =~ ^sha256:[0-9a-f]{64}$ && "$fault_revision" != "$baseline_revision" ]]
+active_after_upload="$work_dir/active-after-upload.json"
+api GET "/api/v1/projects/$project_id/connections/sample/active-revision" "$active_after_upload"
+jq -e --arg baseline "$baseline_revision" '.revision.id == $baseline' "$active_after_upload" >/dev/null
+api GET \
+  "/api/v1/projects/$project_id/connections/sample/upload-sessions/$interrupted_session/events?limit=100" \
+  "$work_dir/managed-upload-events.json"
+jq -e '
+  ([.items[].event] | index("upload_session.created")) != null and
+  ([.items[].event] | index("upload_session.finalizing")) != null and
+  ([.items[].event] | index("upload_session.completed")) != null
+' "$work_dir/managed-upload-events.json" >/dev/null
+managedUpload=true
+
+stage="release finalization interruption"
+deploy_a_log="$evidence_dir/recovery-release-finalization.log"
+run_in_candidate \
+  leapview deploy \
+  --project /var/lib/leapview/qualification-recovery/project-a/leapview.yaml \
+  --revision "sample=$fault_revision" \
+  --environment qualification \
+  --auto-approve \
+  > "$deploy_a_log" 2>&1 &
+deploy_a_pid=$!
+
+releases="$work_dir/releases.json"
+release_id=""
+for _ in $(seq 1 1200); do
+  if api GET "/api/v1/projects/$project_id/releases?limit=100" "$releases" 2>/dev/null; then
+    release_id="$(jq -r '[.items[] | select(.status == "validating")][0].id // empty' "$releases")"
+    [[ -n "$release_id" ]] && break
+  fi
+  if ! kill -0 "$deploy_a_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.025
+done
+[[ -n "$release_id" ]]
+kill_candidate
+wait_for_process_exit "$deploy_a_pid"
+
+run_in_candidate \
+  leapview deploy \
+  --project /var/lib/leapview/qualification-recovery/project-a/leapview.yaml \
+  --revision "sample=$fault_revision" \
+  --environment qualification \
+  --auto-approve \
+  >> "$deploy_a_log" 2>&1
+release_after="$work_dir/release-after.json"
+wait_for_json "/api/v1/projects/$project_id/releases/$release_id" '.status == "ready"' "$release_after"
+wait_for_json "/api/v1/projects/$project_id/releases/$release_id/events?limit=100" '
+  ([.items[].event] | index("release.created")) != null and
+  ([.items[].event] | index("release.validating")) != null and
+  ([.items[].event] | index("release.ready")) != null
+' "$work_dir/release-events.json"
+releaseFinalization=true
+
+stage="deployment activation interruption"
+deploy_b_log="$evidence_dir/recovery-deployment-activation.log"
+run_in_candidate \
+  leapview deploy \
+  --project /var/lib/leapview/qualification-recovery/project-b/leapview.yaml \
+  --revision "sample=$fault_revision" \
+  --environment qualification \
+  --auto-approve \
+  > "$deploy_b_log" 2>&1 &
+deploy_b_pid=$!
+
+deployments="$work_dir/deployments.json"
+deployment_id=""
+for _ in $(seq 1 1200); do
+  if api GET "/api/v1/projects/$project_id/deployments?limit=100" "$deployments" 2>/dev/null; then
+    deployment_id="$(
+      jq -r '[.items[] | select(.status == "queued" or .status == "running")][0].id // empty' "$deployments"
+    )"
+    [[ -n "$deployment_id" ]] && break
+  fi
+  if ! kill -0 "$deploy_b_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.025
+done
+[[ -n "$deployment_id" ]]
+kill_candidate
+wait_for_process_exit "$deploy_b_pid"
+
+deployment_after="$work_dir/deployment-after.json"
+wait_for_json \
+  "/api/v1/projects/$project_id/deployments/$deployment_id" \
+  '.status == "active"' \
+  "$deployment_after"
+wait_for_json \
+  "/api/v1/projects/$project_id/deployments/$deployment_id/events?limit=100" \
+  '
+  ([.items[].event] | index("deployment.queued")) != null and
+  ([.items[].event] | index("deployment.active")) != null
+' \
+  "$work_dir/deployment-events.json"
+deploymentActivation=true
+
+stage="refresh materialization interruption"
+refresh_created="$work_dir/refresh-created.json"
+api POST \
+  /api/v1/workspaces/evaluation/refresh-runs \
+  "$refresh_created" \
+  '{"pipelineId":"evaluation-refresh"}' \
+  "qualification-refresh-$(date +%s)"
+refresh_id="$(jq -er '.id' "$refresh_created")"
+refresh_path="/api/v1/workspaces/evaluation/refresh-runs/$refresh_id"
+wait_for_json "$refresh_path" '.status == "running"' "$work_dir/refresh-running.json"
+kill_candidate
+wait_for_json "$refresh_path" '.status == "succeeded"' "$work_dir/refresh-succeeded.json"
+wait_for_json "$refresh_path/events?limit=100" '
+  ([.items[].event] | index("refresh.queued")) != null and
+  ([.items[].event] | index("refresh.succeeded")) != null
+' "$work_dir/refresh-events.json"
+refreshRecovery=true
+
+stage="query and SSE reconnect"
+disk_before="$(docker exec "$container_id" du -sk /var/lib/leapview | awk '{print $1}')"
+metrics_before="$work_dir/metrics-before.txt"
+curl --fail --silent --show-error \
+  --header 'Host: localhost' \
+  --header "Authorization: Bearer $metrics_token" \
+  --output "$metrics_before" \
+  "$api_root/metrics"
+goroutines_before="$(awk '$1 == "go_goroutines" { print int($2) }' "$metrics_before")"
+[[ "$goroutines_before" =~ ^[0-9]+$ ]]
+
+query_body='{"dimensions":[{"field":"state"}],"measures":[{"field":"order_count"},{"field":"revenue"}],"limit":10}'
+for cycle in 1 2 3; do
+  kill_candidate
+  api POST \
+    /api/v1/workspaces/evaluation/semantic-models/sales/query \
+    "$work_dir/query-$cycle.json" \
+    "$query_body"
+  jq -e '.rows | length == 4' "$work_dir/query-$cycle.json" >/dev/null
+  sse_output="$work_dir/sse-$cycle.txt"
+  curl --fail --silent --show-error \
+    --header 'Host: localhost' \
+    --header "Authorization: Bearer $publisher_token" \
+    --output "$sse_output" \
+    "$api_root/updates?route=dashboard&workspace=evaluation&dashboard=sales-overview&page=overview" &
+  sse_pid=$!
+  sse_observed=false
+  for _ in $(seq 1 200); do
+    if grep -q 'event: datastar-patch-signals' "$sse_output" 2>/dev/null; then
+      sse_observed=true
+      break
+    fi
+    if ! kill -0 "$sse_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.05
+  done
+  kill "$sse_pid" 2>/dev/null || true
+  wait "$sse_pid" 2>/dev/null || true
+  [[ "$sse_observed" == true ]]
+done
+
+metrics_after="$work_dir/metrics-after.txt"
+curl --fail --silent --show-error \
+  --header 'Host: localhost' \
+  --header "Authorization: Bearer $metrics_token" \
+  --output "$metrics_after" \
+  "$api_root/metrics"
+goroutines_after="$(awk '$1 == "go_goroutines" { print int($2) }' "$metrics_after")"
+[[ "$goroutines_after" =~ ^[0-9]+$ ]]
+(( goroutines_after <= goroutines_before + 25 ))
+queryStreamReconnect=true
+
+stage="backup interruption"
+docker update --cpus 0.25 "$container_id" >/dev/null
+rm -f "$bundle_root/backups/interrupted.tar.gz" "$bundle_root/backups/interrupted.tar.gz.sha256"
+(
+  cd "$bundle_root"
+  exec ./leapviewctl backup interrupted.tar.gz
+) > "$evidence_dir/recovery-backup-interruption.log" 2>&1 &
+backup_pid=$!
+compose_oneoff '"admin","backup"' "$work_dir/backup-oneoff"
+backup_oneoff="$(<"$work_dir/backup-oneoff")"
+kill -KILL "$backup_pid" 2>/dev/null || true
+docker kill --signal KILL "$backup_oneoff" >/dev/null 2>&1 || true
+docker rm --force "$backup_oneoff" >/dev/null 2>&1 || true
+wait "$backup_pid" 2>/dev/null || true
+[[ ! -e "$bundle_root/backups/interrupted.tar.gz" ]]
+docker update --cpus 0 "$container_id" >/dev/null
+(
+  cd "$bundle_root"
+  ./leapviewctl start
+  ./leapviewctl backup recovered.tar.gz
+) >> "$evidence_dir/recovery-backup-interruption.log" 2>&1
+container_id="$(
+  docker ps \
+    --filter "label=com.docker.compose.project=$project_name" \
+    --filter "label=com.docker.compose.service=leapview" \
+    --quiet |
+    head -n 1
+)"
+[[ -n "$container_id" ]]
+wait_healthy
+if find "$bundle_root/backups" -maxdepth 1 -name '.leapview-backup-*.tmp' -print -quit | grep -q .; then
+  printf 'interrupted backup left an unbounded temporary archive\n' >&2
+  exit 1
+fi
+backupInterruption=true
+
+stage="restore preflight interruption"
+(
+  cd "$bundle_root"
+  exec ./leapviewctl restore backups/recovered.tar.gz
+) > "$evidence_dir/recovery-restore-preflight.log" 2>&1 &
+restore_pid=$!
+compose_oneoff '"admin","restore"' "$work_dir/restore-oneoff"
+restore_oneoff="$(<"$work_dir/restore-oneoff")"
+kill -KILL "$restore_pid" 2>/dev/null || true
+docker kill --signal KILL "$restore_oneoff" >/dev/null 2>&1 || true
+docker rm --force "$restore_oneoff" >/dev/null 2>&1 || true
+wait "$restore_pid" 2>/dev/null || true
+(
+  cd "$bundle_root"
+  ./leapviewctl start
+  ./leapviewctl restore backups/recovered.tar.gz
+) >> "$evidence_dir/recovery-restore-preflight.log" 2>&1
+container_id="$(
+  docker ps \
+    --filter "label=com.docker.compose.project=$project_name" \
+    --filter "label=com.docker.compose.service=leapview" \
+    --quiet |
+    head -n 1
+)"
+[[ -n "$container_id" ]]
+wait_healthy
+run_in_candidate \
+  leapview semantic-models --workspace evaluation query sales --body-json "$query_body" \
+  > "$work_dir/post-restore-query.json"
+jq -e '.rows | length == 4' "$work_dir/post-restore-query.json" >/dev/null
+restorePreflight=true
+
+stage="bounded recovery state"
+docker update --cpus 0 "$container_id" >/dev/null
+disk_after="$(docker exec "$container_id" du -sk /var/lib/leapview | awk '{print $1}')"
+(( disk_after <= disk_before + 51200 ))
+stale_restore_count="$(
+  docker exec "$container_id" sh -c \
+    'find /var/lib/leapview -maxdepth 1 \( -name ".leapview-restore-*" -o -name ".leapview-instance-backup-*" \) -print | wc -l'
+)"
+[[ "$stale_restore_count" -eq 0 ]]
+boundedDisk=true
+
+# Preserve a bounded, credential-free domain-event audit trail. These are the
+# listManagedDataUploadSessionEvents, listDeploymentEvents, and
+# listRefreshRunEvents results used by the assertions above.
+jq -n \
+  --slurpfile managedUpload "$work_dir/managed-upload-events.json" \
+  --slurpfile releaseFinalization "$work_dir/release-events.json" \
+  --slurpfile deploymentActivation "$work_dir/deployment-events.json" \
+  --slurpfile refreshRecovery "$work_dir/refresh-events.json" \
+  '{
+    managedUpload:$managedUpload[0],
+    releaseFinalization:$releaseFinalization[0],
+    deploymentActivation:$deploymentActivation[0],
+    refreshRecovery:$refreshRecovery[0],
+    timeline:[
+      {operation:"managedUpload",status:"attempted"},
+      {operation:"managedUpload",status:"interrupted"},
+      {operation:"managedUpload",status:"resumed"},
+      {operation:"managedUpload",status:"completed"},
+      {operation:"releaseFinalization",status:"attempted"},
+      {operation:"releaseFinalization",status:"interrupted"},
+      {operation:"releaseFinalization",status:"resumed"},
+      {operation:"releaseFinalization",status:"completed"},
+      {operation:"deploymentActivation",status:"attempted"},
+      {operation:"deploymentActivation",status:"interrupted"},
+      {operation:"deploymentActivation",status:"resumed"},
+      {operation:"deploymentActivation",status:"completed"},
+      {operation:"refreshRecovery",status:"attempted"},
+      {operation:"refreshRecovery",status:"interrupted"},
+      {operation:"refreshRecovery",status:"resumed"},
+      {operation:"refreshRecovery",status:"completed"},
+      {operation:"backupInterruption",status:"interrupted"},
+      {operation:"backupInterruption",status:"completed"},
+      {operation:"restorePreflight",status:"interrupted"},
+      {operation:"restorePreflight",status:"completed"}
+    ]
+  }' > "$events"
+
+stage="complete"
+write_report success
+success=true
+printf 'installed-candidate recovery qualification passed\n'

--- a/deploy/hetzner/deployment_test.go
+++ b/deploy/hetzner/deployment_test.go
@@ -121,7 +121,7 @@ func assertDockerfileImagesPinned(t *testing.T, name, dockerfile string) {
 			continue
 		}
 		image := fields[1]
-		if _, internal := stages[image]; !internal {
+		if _, internal := stages[image]; !internal && image != "scratch" {
 			_, digest, pinned := strings.Cut(image, "@sha256:")
 			if !pinned || !hexDigest.MatchString(digest) {
 				t.Errorf("%s base image is not pinned by a valid SHA-256 digest: %s", name, line)

--- a/evaluation/project/workspaces/evaluation/refresh-pipelines/evaluation-refresh.yaml
+++ b/evaluation/project/workspaces/evaluation/refresh-pipelines/evaluation-refresh.yaml
@@ -1,0 +1,7 @@
+apiVersion: leapview.dev/v1
+kind: RefreshPipeline
+metadata:
+  workspace: evaluation
+  name: evaluation-refresh
+spec:
+  semanticModel: sales

--- a/evaluation/project/workspaces/evaluation/workspace.yaml
+++ b/evaluation/project/workspaces/evaluation/workspace.yaml
@@ -14,6 +14,9 @@ spec:
   semanticModels:
     include:
       - semantic-models/*.yaml
+  refreshPipelines:
+    include:
+      - refresh-pipelines/*.yaml
   dashboards:
     include:
       - dashboards/*.yaml

--- a/internal/app/cli/composectl/controller.go
+++ b/internal/app/cli/composectl/controller.go
@@ -555,6 +555,9 @@ func (c *Controller) backupArchive(ctx context.Context, path string) error {
 	if err := os.Chmod(directory, 0o700); err != nil {
 		return err
 	}
+	if err := removeInterruptedBackupArchives(directory); err != nil {
+		return err
+	}
 	tmp, err := os.CreateTemp(directory, ".leapview-backup-*.tmp")
 	if err != nil {
 		return err
@@ -591,6 +594,23 @@ func (c *Controller) backupArchive(ctx context.Context, path string) error {
 	}
 	cleanup = false
 	return syncDirectory(directory)
+}
+
+func removeInterruptedBackupArchives(directory string) error {
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, ".leapview-backup-") || !strings.HasSuffix(name, ".tmp") {
+			continue
+		}
+		if err := os.Remove(filepath.Join(directory, name)); err != nil {
+			return fmt.Errorf("remove interrupted backup archive %q: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func (c *Controller) restoreArchive(ctx context.Context, archive string) error {

--- a/internal/app/cli/composectl/controller_test.go
+++ b/internal/app/cli/composectl/controller_test.go
@@ -29,6 +29,28 @@ func TestControllerLockRejectsConcurrentOperationAndRecoversAfterRelease(t *test
 	defer second.Release()
 }
 
+func TestRemoveInterruptedBackupArchivesPreservesCompletedBackups(t *testing.T) {
+	directory := t.TempDir()
+	stale := filepath.Join(directory, ".leapview-backup-interrupted.tmp")
+	completed := filepath.Join(directory, "completed.tar.gz")
+	if err := os.WriteFile(stale, []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(completed, []byte("complete"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeInterruptedBackupArchives(directory); err != nil {
+		t.Fatalf("removeInterruptedBackupArchives() error = %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("interrupted backup survived: %v", err)
+	}
+	if contents, err := os.ReadFile(completed); err != nil || string(contents) != "complete" {
+		t.Fatalf("completed backup = %q, %v", contents, err)
+	}
+}
+
 func TestFirstLoginRetainsCredentialsUntilOutputSucceeds(t *testing.T) {
 	root := t.TempDir()
 	credentialsPath := filepath.Join(root, credentialsName)

--- a/internal/app/cli/deploy.go
+++ b/internal/app/cli/deploy.go
@@ -181,12 +181,22 @@ func runDeploy(ctx context.Context, request deployRequest) error {
 			digestBytes, _ := hex.DecodeString(item.digest)
 			contentDigest := "sha-256=:" + base64.StdEncoding.EncodeToString(digestBytes) + ":"
 			if _, err := client.uploadReleaseArtifact(ctx, project.Name, created.Id, item.workspaceID, contentDigest, bytes.NewReader(item.content)); err != nil {
-				return fmt.Errorf("upload workspace %q artifact failed", item.workspaceID)
+				advanced, getErr := client.getRelease(ctx, project.Name, created.Id)
+				if getErr != nil ||
+					advanced.Id != created.Id ||
+					advanced.ProjectId != project.Name ||
+					(advanced.Status != releasegen.ReleaseStatusValidating && advanced.Status != releasegen.ReleaseStatusReady) {
+					return fmt.Errorf("upload workspace %q artifact failed", item.workspaceID)
+				}
+				finalized = advanced
+				break
 			}
 		}
-		finalized, err = client.finalizeRelease(ctx, project.Name, created.Id, deploymentIdempotencyKey("finalize", project.Name, created.Id))
-		if err != nil {
-			return fmt.Errorf("finalize project release failed")
+		if finalized.Status != releasegen.ReleaseStatusReady {
+			finalized, err = client.finalizeRelease(ctx, project.Name, created.Id, deploymentIdempotencyKey("finalize", project.Name, created.Id))
+			if err != nil {
+				return fmt.Errorf("finalize project release failed")
+			}
 		}
 	case releasegen.ReleaseStatusValidating:
 		// Reissuing finalize is idempotent and restarts validation if a prior

--- a/internal/app/cli/project_deploy_test.go
+++ b/internal/app/cli/project_deploy_test.go
@@ -109,6 +109,80 @@ func TestDeployPreparesCompleteProjectBeforeOneAtomicActivation(t *testing.T) {
 	}
 }
 
+func TestDeployRecoversWhenReleaseAdvancesDuringArtifactReplay(t *testing.T) {
+	projectPath := filepath.Join("..", "..", "..", "dashboards", "leapview.yaml")
+	revision := "sha256:" + strings.Repeat("a", 64)
+	projectDigest := ""
+	artifactConflicts := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/instance":
+			writeCLIJSON(t, w, apigenapi.InstanceResponse{Environment: "prod"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/capabilities":
+			writeCLIJSON(t, w, apigenapi.CapabilitiesResponse{
+				ApiVersion: "v1", BuildVersion: "test", Environment: "prod",
+				Authentication:  []apigenapi.AuthenticationMode{apigenapi.AuthenticationModeBearer},
+				QueryFormats:    []apigenapi.QueryFormat{apigenapi.QueryFormatApplicationJson},
+				UploadProtocols: []apigenapi.UploadProtocol{apigenapi.UploadProtocolTus},
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/active-asset-graph"):
+			writeCLIJSON(t, w, activeGraphResponse(nil, nil))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/leapview-showcase/releases":
+			var request releasegen.ReleaseCreateRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			projectDigest = request.ProjectDigest
+			writeCLIJSON(t, w, releasegen.ReleaseResponse{
+				Id: "release-1", ProjectId: "leapview-showcase", ProjectDigest: projectDigest,
+				Status: releasegen.ReleaseStatusDraft, CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z",
+				Workspaces: request.Workspaces, Connections: request.Connections,
+			})
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/artifact"):
+			artifactConflicts++
+			http.Error(w, "release advanced", http.StatusConflict)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/leapview-showcase/releases/release-1":
+			writeCLIJSON(t, w, releasegen.ReleaseResponse{
+				Id: "release-1", ProjectId: "leapview-showcase", ProjectDigest: projectDigest,
+				Status: releasegen.ReleaseStatusReady, CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z",
+				Workspaces: []releasegen.ReleaseWorkspaceManifest{}, Connections: []releasegen.ReleaseConnectionPin{},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/leapview-showcase/deployments":
+			writeCLIJSON(t, w, map[string]any{
+				"id": "deployment-1", "projectId": "leapview-showcase", "releaseId": "release-1",
+				"environment": "prod", "status": "queued", "createdBy": "test",
+				"createdAt": "2026-01-01T00:00:00Z", "targets": []any{}, "connections": []any{},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/leapview-showcase/deployments/deployment-1":
+			writeCLIJSON(t, w, map[string]any{
+				"id": "deployment-1", "projectId": "leapview-showcase", "releaseId": "release-1",
+				"environment": "prod", "status": "active", "createdBy": "test",
+				"createdAt": "2026-01-01T00:00:00Z", "targets": []any{}, "connections": []any{},
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	err := runDeploy(context.Background(), deployRequest{
+		ProjectPath: projectPath,
+		Revisions:   map[string]string{"olist": revision},
+		Target:      server.URL,
+		Token:       "secret-token",
+		AutoApprove: true,
+		Out:         &bytes.Buffer{},
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("runDeploy() error = %v", err)
+	}
+	if artifactConflicts != 1 {
+		t.Fatalf("artifact conflict attempts = %d, want 1", artifactConflicts)
+	}
+}
+
 func TestDeployRejectsIncompleteManagedRevisionSetBeforeNetworkAccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		t.Fatal("invalid deployment reached server")

--- a/internal/app/tools/mapassets/main.go
+++ b/internal/app/tools/mapassets/main.go
@@ -22,13 +22,14 @@ import (
 )
 
 const (
-	planetURL           = "https://build.protomaps.com/20260720.pmtiles"
-	archiveDigest       = visualizationmapasset.ArchiveSHA256
-	globalArchiveDigest = "2d97ee8907670936ab722da7ca06eafec0734392f73fa1cd337d4debd85d676f"
-	regionalBounds      = "-82,-56,-30,14"
-	regionalMinimumZoom = "7"
-	regionalMaximumZoom = "10"
-	basemapAssetsSHA    = visualizationmapasset.BasemapAssetsRevision
+	planetURL              = "https://build.protomaps.com/20260720.pmtiles"
+	archiveDigest          = visualizationmapasset.ArchiveSHA256
+	globalArchiveDigest    = "2d97ee8907670936ab722da7ca06eafec0734392f73fa1cd337d4debd85d676f"
+	regionalBounds         = "-82,-56,-30,14"
+	regionalMinimumZoom    = "7"
+	regionalMaximumZoom    = "10"
+	archiveDownloadThreads = "2"
+	basemapAssetsSHA       = visualizationmapasset.BasemapAssetsRevision
 )
 
 var glyphRanges = []string{
@@ -45,6 +46,7 @@ var glyphRanges = []string{
 
 func main() {
 	out := flag.String("out", ".data/map-assets", "map asset root directory")
+	seedArchive := flag.String("seed-archive", "", "verified pinned archive to reuse instead of extracting it")
 	publishBucket := flag.String("publish-s3-bucket", "", "publish verified assets to this S3 bucket")
 	publishPrefix := flag.String("publish-s3-prefix", "map-assets", "S3 key prefix used for published assets")
 	publishRegion := flag.String("publish-s3-region", "", "AWS region override for map asset publication")
@@ -53,6 +55,12 @@ func main() {
 	verifyBaseURL := flag.String("verify-base-url", "", "verify the installed package through this same-origin HTTP(S) endpoint")
 	flag.Parse()
 	ctx := context.Background()
+	if strings.TrimSpace(*seedArchive) != "" {
+		if err := installSeedArchive(*seedArchive, *out); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
 	if err := install(ctx, *out); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -74,6 +82,32 @@ func main() {
 		}
 		fmt.Printf("verified map asset delivery: files=%d full=%d ranges=%d bytes=%d\n", summary.Files, summary.FullResponses, summary.RangeResponses, summary.Bytes)
 	}
+}
+
+func installSeedArchive(source, out string) error {
+	if err := verifyFile(source, archiveDigest); err != nil {
+		return fmt.Errorf("verify seed map archive: %w", err)
+	}
+	asset, err := visualizationmapasset.Resolve("streets")
+	if err != nil {
+		return err
+	}
+	target, err := assetTarget(out, asset.ArchiveURL)
+	if err != nil {
+		return err
+	}
+	temporary := target + ".seed.partial"
+	if err := os.Remove(temporary); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	defer os.Remove(temporary)
+	if err := copyFile(source, temporary); err != nil {
+		return fmt.Errorf("copy seed map archive: %w", err)
+	}
+	if err := os.Rename(temporary, target); err != nil {
+		return err
+	}
+	return nil
 }
 
 func publishS3(ctx context.Context, root, bucket, prefix, region, endpoint string, pathStyle bool) (visualizationmapasset.PublicationSummary, error) {
@@ -177,7 +211,7 @@ func ensureArchive(ctx context.Context, target, legacy string) error {
 	global := filepath.Join(build, "global-z0-z6.pmtiles")
 	installedGlobal := filepath.Join(filepath.Dir(filepath.Dir(target)), globalArchiveDigest, "basemap.pmtiles")
 	if err := reuseVerifiedArchive(installedGlobal, legacy, globalArchiveDigest, global); err != nil {
-		if err := runPMTiles(ctx, "extract", planetURL, global, "--maxzoom=6", "--download-threads=8", "--quiet"); err != nil {
+		if err := runPMTiles(ctx, "extract", planetURL, global, "--maxzoom=6", "--download-threads="+archiveDownloadThreads); err != nil {
 			return fmt.Errorf("extract pinned global PMTiles: %w", err)
 		}
 		if err := verifyFile(global, globalArchiveDigest); err != nil {
@@ -185,7 +219,7 @@ func ensureArchive(ctx context.Context, target, legacy string) error {
 		}
 	}
 	regional := filepath.Join(build, "south-america-z7-z10.pmtiles")
-	if err := runPMTiles(ctx, "extract", planetURL, regional, "--bbox="+regionalBounds, "--minzoom="+regionalMinimumZoom, "--maxzoom="+regionalMaximumZoom, "--download-threads=8", "--quiet"); err != nil {
+	if err := runPMTiles(ctx, "extract", planetURL, regional, "--bbox="+regionalBounds, "--minzoom="+regionalMinimumZoom, "--maxzoom="+regionalMaximumZoom, "--download-threads="+archiveDownloadThreads); err != nil {
 		return fmt.Errorf("extract pinned regional PMTiles: %w", err)
 	}
 	temporary := target + ".partial"

--- a/internal/app/tools/mapassets/main_test.go
+++ b/internal/app/tools/mapassets/main_test.go
@@ -50,9 +50,31 @@ func TestInstallTargetsContentAddressedPackagePaths(t *testing.T) {
 	}
 }
 
+func TestInstallSeedArchiveRejectsUnverifiedInput(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(t.TempDir(), "basemap.pmtiles")
+	if err := os.WriteFile(source, []byte("not the pinned archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installSeedArchive(source, root); err == nil {
+		t.Fatal("installSeedArchive() accepted an unverified archive")
+	}
+	asset, err := assetTarget(root, "/map-assets/leapview-streets/archives/"+archiveDigest+"/basemap.pmtiles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(asset); !os.IsNotExist(err) {
+		t.Fatalf("seed target exists after failed verification: %v", err)
+	}
+}
+
 func TestRegionalExtractionProfileExtendsTheGlobalArchive(t *testing.T) {
 	if regionalBounds != "-82,-56,-30,14" || regionalMinimumZoom != "7" || regionalMaximumZoom != "10" {
 		t.Fatalf("regional profile = bounds %q zoom %s..%s", regionalBounds, regionalMinimumZoom, regionalMaximumZoom)
+	}
+	if archiveDownloadThreads != "2" {
+		t.Fatalf("archive download threads = %q, want conservative range concurrency", archiveDownloadThreads)
 	}
 	if archiveDigest == globalArchiveDigest {
 		t.Fatal("regional detail was not merged into a distinct immutable archive")

--- a/internal/manageddata/storage/tus/engine.go
+++ b/internal/manageddata/storage/tus/engine.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Yacobolo/leapview/internal/manageddata/storage"
@@ -45,10 +46,36 @@ func New(root string, blobs storage.BlobStore) (*Engine, error) {
 	if err := os.Chmod(root, 0o700); err != nil {
 		return nil, fmt.Errorf("set tus upload root permissions: %w", err)
 	}
+	if err := removeInterruptedLockArtifacts(root); err != nil {
+		return nil, err
+	}
 	store := filestore.New(root)
 	store.DirModePerm = 0o700
 	store.FileModePerm = 0o600
 	return &Engine{store: store, locker: filelocker.New(root), blobs: blobs}, nil
+}
+
+func removeInterruptedLockArtifacts(root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("inspect tus upload locks: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".lock") &&
+			!strings.HasSuffix(name, ".stop") &&
+			!strings.Contains(name, ".lock.") {
+			continue
+		}
+		path := filepath.Join(root, name)
+		if entry.IsDir() {
+			return fmt.Errorf("interrupted tus lock artifact %q is a directory", path)
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove interrupted tus lock artifact %q: %w", path, err)
+		}
+	}
+	return nil
 }
 
 func (e *Engine) Create(ctx context.Context, request storage.CreateUpload) (storage.Upload, error) {

--- a/internal/manageddata/storage/tus/engine_test.go
+++ b/internal/manageddata/storage/tus/engine_test.go
@@ -2,6 +2,7 @@ package tus_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/Yacobolo/leapview/internal/manageddata/storage"
 	"github.com/Yacobolo/leapview/internal/manageddata/storage/filesystem"
@@ -109,6 +111,37 @@ func TestEngineRejectsInvalidRequestsAndAbortIsIdempotent(t *testing.T) {
 	}
 	if _, err := engine.Resume(t.Context(), created.ID); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("Resume() after Abort() error = %v", err)
+	}
+}
+
+func TestEngineStartupRecoversLocksLeftByContainerPIDReuse(t *testing.T) {
+	engine, blobs, uploadRoot := newEngine(t)
+	if _, err := engine.Create(t.Context(), storage.CreateUpload{ID: "upload-1", Size: 1}); err != nil {
+		t.Fatal(err)
+	}
+	for name, contents := range map[string]string{
+		"upload-1.lock":        strconv.Itoa(os.Getpid()) + "\n",
+		"upload-1.stop":        "",
+		"upload-1.lock.orphan": strconv.Itoa(os.Getpid()) + "\n",
+	} {
+		if err := os.WriteFile(filepath.Join(uploadRoot, name), []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	restarted, err := managedtus.New(uploadRoot, blobs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := restarted.Resume(ctx, "upload-1"); err != nil {
+		t.Fatalf("Resume() after container PID reuse = %v", err)
+	}
+	for _, name := range []string{"upload-1.lock", "upload-1.stop", "upload-1.lock.orphan"} {
+		if _, err := os.Stat(filepath.Join(uploadRoot, name)); !os.IsNotExist(err) {
+			t.Fatalf("interrupted lock artifact %q survived restart: %v", name, err)
+		}
 	}
 }
 

--- a/internal/platform/instance_backup.go
+++ b/internal/platform/instance_backup.go
@@ -125,6 +125,9 @@ func writeInstanceBackup(ctx context.Context, options InstanceBackupOptions, out
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return err
 	}
+	if err := removeInterruptedInstanceBackupWork(parent); err != nil {
+		return err
+	}
 	tmpDir, err := os.MkdirTemp(parent, ".leapview-instance-backup-*")
 	if err != nil {
 		return err
@@ -354,12 +357,15 @@ func restoreInstanceFromReader(ctx context.Context, options InstanceRestoreOptio
 		}
 	}
 
-	exists, nonEmpty, err := dirExistsNonEmptyExcept(targetAbs, preserveRelativeFile)
-	if err != nil {
-		return err
-	}
 	parent := filepath.Dir(targetAbs)
 	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	if err := recoverInterruptedInstanceOperations(targetAbs); err != nil {
+		return err
+	}
+	exists, nonEmpty, err := dirExistsNonEmptyExcept(targetAbs, preserveRelativeFile)
+	if err != nil {
 		return err
 	}
 	tmpRestore, err := os.MkdirTemp(parent, ".leapview-restore-*")
@@ -433,6 +439,70 @@ func restoreInstanceFromReader(ctx context.Context, options InstanceRestoreOptio
 	cleanupTmp = false
 	if oldTarget != "" {
 		_ = os.RemoveAll(oldTarget)
+	}
+	return nil
+}
+
+func removeInterruptedInstanceBackupWork(parent string) error {
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), ".leapview-instance-backup-") {
+			if err := os.RemoveAll(filepath.Join(parent, entry.Name())); err != nil {
+				return fmt.Errorf("remove interrupted instance backup %q: %w", entry.Name(), err)
+			}
+		}
+	}
+	return nil
+}
+
+func recoverInterruptedInstanceOperations(target string) error {
+	parent := filepath.Dir(target)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return err
+	}
+	var oldTargets []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".leapview-restore-old-") {
+			oldTargets = append(oldTargets, filepath.Join(parent, entry.Name()))
+		}
+	}
+	sort.Strings(oldTargets)
+	if _, err := os.Lstat(target); os.IsNotExist(err) && len(oldTargets) > 0 {
+		latest := oldTargets[len(oldTargets)-1]
+		info, statErr := os.Lstat(latest)
+		if statErr != nil {
+			return statErr
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("interrupted restore rollback %q is not a directory", latest)
+		}
+		if err := os.Rename(latest, target); err != nil {
+			return fmt.Errorf("roll back interrupted instance restore: %w", err)
+		}
+		oldTargets = oldTargets[:len(oldTargets)-1]
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, stale := range oldTargets {
+		if err := os.RemoveAll(stale); err != nil {
+			return fmt.Errorf("remove interrupted restore rollback %q: %w", stale, err)
+		}
+	}
+	entries, err = os.ReadDir(parent)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && (strings.HasPrefix(entry.Name(), ".leapview-restore-") ||
+			strings.HasPrefix(entry.Name(), ".leapview-instance-backup-")) {
+			if err := os.RemoveAll(filepath.Join(parent, entry.Name())); err != nil {
+				return fmt.Errorf("remove interrupted instance operation %q: %w", entry.Name(), err)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/platform/store_test.go
+++ b/internal/platform/store_test.go
@@ -456,6 +456,49 @@ func TestBackupInstanceArchivesDatabaseAndPersistentFiles(t *testing.T) {
 	}
 }
 
+func TestRecoverInterruptedInstanceOperationsRemovesDisposableWork(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "home")
+	writeTestFile(t, filepath.Join(target, "current"), "current")
+	writeTestFile(t, filepath.Join(parent, ".leapview-instance-backup-stale", "copy"), "backup")
+	writeTestFile(t, filepath.Join(parent, ".leapview-restore-stale", "copy"), "restore")
+	writeTestFile(t, filepath.Join(parent, ".leapview-restore-old-stale", "copy"), "old")
+
+	if err := recoverInterruptedInstanceOperations(target); err != nil {
+		t.Fatalf("recoverInterruptedInstanceOperations() error = %v", err)
+	}
+	for _, stale := range []string{
+		".leapview-instance-backup-stale",
+		".leapview-restore-stale",
+		".leapview-restore-old-stale",
+	} {
+		if _, err := os.Stat(filepath.Join(parent, stale)); !os.IsNotExist(err) {
+			t.Fatalf("stale operation path %q survived: %v", stale, err)
+		}
+	}
+	if got := readTestFile(t, filepath.Join(target, "current")); got != "current" {
+		t.Fatalf("current state = %q, want current", got)
+	}
+}
+
+func TestRecoverInterruptedInstanceOperationsRollsBackMissingTarget(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "home")
+	old := filepath.Join(parent, ".leapview-restore-old-20260727200000")
+	writeTestFile(t, filepath.Join(old, "current"), "recover me")
+	writeTestFile(t, filepath.Join(parent, ".leapview-restore-stale", "candidate"), "discard me")
+
+	if err := recoverInterruptedInstanceOperations(target); err != nil {
+		t.Fatalf("recoverInterruptedInstanceOperations() error = %v", err)
+	}
+	if got := readTestFile(t, filepath.Join(target, "current")); got != "recover me" {
+		t.Fatalf("recovered state = %q, want recover me", got)
+	}
+	if _, err := os.Stat(filepath.Join(parent, ".leapview-restore-stale")); !os.IsNotExist(err) {
+		t.Fatalf("stale restore candidate survived: %v", err)
+	}
+}
+
 func TestBackupInstanceCreatesPrivateArchive(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/refresh/module/module.go
+++ b/internal/refresh/module/module.go
@@ -92,6 +92,7 @@ type Module struct {
 	scheduler          Scheduler
 	reconcileSchedules func(context.Context) error
 	scheduleInterval   time.Duration
+	leaseTimeout       time.Duration
 	logger             *slog.Logger
 	events             EventStore
 
@@ -110,6 +111,10 @@ func Build(ctx context.Context, config Config) (*Module, error) {
 	if interval <= 0 {
 		interval = time.Minute
 	}
+	leaseTimeout := config.LeaseTimeout
+	if leaseTimeout <= 0 {
+		leaseTimeout = 2 * time.Minute
+	}
 	logger := config.Logger
 	if logger == nil {
 		logger = slog.Default()
@@ -121,7 +126,8 @@ func Build(ctx context.Context, config Config) (*Module, error) {
 		},
 		dispatcher: config.Dispatcher, scheduler: config.Scheduler,
 		environment: config.Environment, refreshClock: config.Clock,
-		reconcileSchedules: config.ReconcileSchedules, scheduleInterval: interval, logger: logger,
+		reconcileSchedules: config.ReconcileSchedules, scheduleInterval: interval,
+		leaseTimeout: leaseTimeout, logger: logger,
 		events: config.Events,
 	}
 	m.handler.CurrentPrincipal = func(r *http.Request) (materializehttp.Principal, bool) {
@@ -403,6 +409,10 @@ func (m *Module) Start(ctx context.Context) error {
 		m.wg.Add(1)
 		go m.runScheduler(background)
 	}
+	if m.dispatcher != nil {
+		m.wg.Add(1)
+		go m.runDispatcherRecovery(background)
+	}
 	m.mu.Unlock()
 	m.Dispatch(background)
 	return nil
@@ -458,6 +468,20 @@ func (m *Module) runScheduler(ctx context.Context) {
 			return
 		case <-ticker.C:
 			dispatch()
+		}
+	}
+}
+
+func (m *Module) runDispatcherRecovery(ctx context.Context) {
+	defer m.wg.Done()
+	ticker := time.NewTicker(m.leaseTimeout)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.Dispatch(ctx)
 		}
 	}
 }

--- a/internal/refresh/module/module_test.go
+++ b/internal/refresh/module/module_test.go
@@ -287,6 +287,32 @@ func TestStartOwnsSchedulerLifecycle(t *testing.T) {
 	}
 }
 
+func TestStartRedispatchesAfterLeaseWindow(t *testing.T) {
+	dispatched := make(chan struct{}, 2)
+	module, err := Build(t.Context(), Config{
+		Dispatcher: dispatcherFunc(func(context.Context) {
+			dispatched <- struct{}{}
+		}),
+		LeaseTimeout: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("build module: %v", err)
+	}
+	if err := module.Start(t.Context()); err != nil {
+		t.Fatalf("start module: %v", err)
+	}
+	for attempt := 1; attempt <= 2; attempt++ {
+		select {
+		case <-dispatched:
+		case <-time.After(time.Second):
+			t.Fatalf("dispatcher call %d did not run", attempt)
+		}
+	}
+	if err := module.Stop(t.Context()); err != nil {
+		t.Fatalf("stop module: %v", err)
+	}
+}
+
 func TestStopHonorsCancellationWhileWorkerDrains(t *testing.T) {
 	entered := make(chan struct{})
 	release := make(chan struct{})

--- a/internal/release/filesystem/artifacts.go
+++ b/internal/release/filesystem/artifacts.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
@@ -75,11 +76,8 @@ func (s *ArtifactStore) PromoteUploaded(_ context.Context, servingStateID servin
 	}
 	uploadPath := s.UploadPath(servingStateID)
 	finalPath := filepath.Join(s.dir, digest+".tar.gz")
-	if err := os.Rename(uploadPath, finalPath); err != nil {
-		if copyErr := copyFile(uploadPath, finalPath); copyErr != nil {
-			return servingstate.Artifact{}, copyErr
-		}
-		_ = os.Remove(uploadPath)
+	if err := copyFile(uploadPath, finalPath); err != nil {
+		return servingstate.Artifact{}, err
 	}
 	return servingstate.Artifact{
 		ID:             "artifact_" + string(servingStateID),
@@ -90,6 +88,16 @@ func (s *ArtifactStore) PromoteUploaded(_ context.Context, servingStateID servin
 		ManifestJSON:   manifestJSON,
 		SizeBytes:      fileSize(finalPath),
 	}, nil
+}
+
+func (s *ArtifactStore) DiscardUploaded(_ context.Context, servingStateID servingstate.ID) error {
+	if err := validateArtifactPathComponent(string(servingStateID), "serving state id"); err != nil {
+		return err
+	}
+	if err := os.Remove(s.UploadPath(servingStateID)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func validateArtifactPathComponent(value, label string) error {
@@ -109,24 +117,72 @@ func fileSize(path string) int64 {
 }
 
 func copyFile(source, target string) error {
+	if same, err := sameFileContent(source, target); err == nil && same {
+		return nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	} else if err == nil {
+		return fmt.Errorf("artifact target %s already exists with different content", target)
+	}
 	in, err := os.Open(source)
 	if err != nil {
 		return err
 	}
 	defer in.Close()
-	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, securefs.PrivateFileMode)
+	out, err := os.CreateTemp(filepath.Dir(target), ".artifact-promote-*.tmp")
 	if err != nil {
 		return err
 	}
+	tmpPath := out.Name()
+	cleanup := true
+	defer func() {
+		_ = out.Close()
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := out.Chmod(securefs.PrivateFileMode); err != nil {
+		return err
+	}
 	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
+		return err
+	}
+	if err := out.Sync(); err != nil {
 		return err
 	}
 	if err := out.Close(); err != nil {
 		return fmt.Errorf("closing %s: %w", target, err)
 	}
-	if err := os.Chmod(target, securefs.PrivateFileMode); err != nil {
+	if err := os.Rename(tmpPath, target); err != nil {
 		return err
 	}
+	cleanup = false
 	return nil
+}
+
+func sameFileContent(left, right string) (bool, error) {
+	leftDigest, err := fileDigest(left)
+	if err != nil {
+		return false, err
+	}
+	rightDigest, err := fileDigest(right)
+	if err != nil {
+		return false, err
+	}
+	return leftDigest == rightDigest, nil
+}
+
+func fileDigest(path string) ([sha256.Size]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	var result [sha256.Size]byte
+	copy(result[:], hash.Sum(nil))
+	return result, nil
 }

--- a/internal/release/filesystem/artifacts_test.go
+++ b/internal/release/filesystem/artifacts_test.go
@@ -50,6 +50,30 @@ func TestArtifactStoreCreatesPrivateArtifactState(t *testing.T) {
 	assertArtifactMode(t, artifact.Path, 0o600)
 }
 
+func TestArtifactPromotionKeepsRecoverableUploadUntilValidationIsDurable(t *testing.T) {
+	store := NewArtifactStore(t.TempDir())
+	if _, err := store.SaveUpload(t.Context(), "state_1", &errAfterReader{data: []byte("bundle")}); err != nil {
+		t.Fatal(err)
+	}
+
+	artifact, err := store.PromoteUploaded(t.Context(), "state_1", "abc123", "{}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes, err := os.ReadFile(store.UploadPath("state_1")); err != nil || string(bytes) != "bundle" {
+		t.Fatalf("recoverable upload after promotion = %q, %v", bytes, err)
+	}
+	if bytes, err := os.ReadFile(artifact.Path); err != nil || string(bytes) != "bundle" {
+		t.Fatalf("promoted artifact = %q, %v", bytes, err)
+	}
+	if err := store.DiscardUploaded(t.Context(), "state_1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(store.UploadPath("state_1")); !os.IsNotExist(err) {
+		t.Fatalf("upload after durable validation stat error = %v, want not exist", err)
+	}
+}
+
 func TestArtifactStoreSaveUploadCleansFailedUpload(t *testing.T) {
 	dir := t.TempDir()
 	store := NewArtifactStore(dir)

--- a/internal/release/service.go
+++ b/internal/release/service.go
@@ -139,6 +139,17 @@ func (s *Service) UploadArtifact(ctx context.Context, projectID, releaseID, work
 	if !found || target.ServingStateID == "" {
 		return Artifact{}, ErrNotFound
 	}
+	expectedDigestBytes, err := hex.DecodeString(target.ExpectedDigest)
+	if err != nil || len(expectedDigestBytes) != sha256.Size {
+		return Artifact{}, ErrInvalid
+	}
+	expectedContentDigest := "sha-256=:" + base64.StdEncoding.EncodeToString(expectedDigestBytes) + ":"
+	if strings.TrimSpace(contentDigest) != expectedContentDigest {
+		return Artifact{}, ErrDigest
+	}
+	if target.UploadedAt != "" {
+		return target, nil
+	}
 	hash := sha256.New()
 	size, err := s.artifacts.SaveUpload(ctx, servingstate.ID(target.ServingStateID), io.TeeReader(source, hash))
 	if err != nil {

--- a/internal/release/service_test.go
+++ b/internal/release/service_test.go
@@ -1,14 +1,81 @@
 package release
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"io"
 	"reflect"
 	"testing"
 
 	"github.com/Yacobolo/leapview/internal/platform/jobs"
 	"github.com/Yacobolo/leapview/internal/servingstate"
 )
+
+func TestUploadArtifactReplaysAlreadyRecordedContent(t *testing.T) {
+	content := []byte("compiled workspace artifact")
+	sum := sha256.Sum256(content)
+	digest := fmt.Sprintf("%x", sum[:])
+	repo := &serviceTestReleaseRepository{current: Release{
+		ID: "release-1", ProjectID: "project-a", Status: StatusDraft,
+		Artifacts: []Artifact{{
+			ReleaseID: "release-1", WorkspaceID: "sales", ServingStateID: "state-1",
+			ExpectedDigest: digest, SizeBytes: int64(len(content)), UploadedAt: "2026-07-27T19:00:00Z",
+		}},
+	}}
+	artifacts := &serviceTestArtifactStore{}
+	service := &Service{releases: repo, artifacts: artifacts}
+
+	got, err := service.UploadArtifact(
+		t.Context(),
+		"project-a",
+		"release-1",
+		"sales",
+		"sha-256=:"+base64Digest(content)+":",
+		bytes.NewReader(content),
+	)
+	if err != nil {
+		t.Fatalf("UploadArtifact() error = %v", err)
+	}
+	if got.SizeBytes != int64(len(content)) {
+		t.Fatalf("UploadArtifact() = %#v, saved %q", got, artifacts.saved)
+	}
+	if artifacts.saveCalls != 0 {
+		t.Fatalf("idempotent replay rewrote the retained upload %d times", artifacts.saveCalls)
+	}
+	if repo.recorded {
+		t.Fatal("idempotent replay attempted to record the artifact twice")
+	}
+}
+
+func TestUploadArtifactRejectsDifferentContentAfterArtifactWasRecorded(t *testing.T) {
+	original := []byte("original artifact")
+	replacement := []byte("different artifact")
+	sum := sha256.Sum256(original)
+	repo := &serviceTestReleaseRepository{current: Release{
+		ID: "release-1", ProjectID: "project-a", Status: StatusDraft,
+		Artifacts: []Artifact{{
+			ReleaseID: "release-1", WorkspaceID: "sales", ServingStateID: "state-1",
+			ExpectedDigest: fmt.Sprintf("%x", sum[:]), SizeBytes: int64(len(original)), UploadedAt: "2026-07-27T19:00:00Z",
+		}},
+	}}
+	service := &Service{releases: repo, artifacts: &serviceTestArtifactStore{}}
+
+	_, err := service.UploadArtifact(
+		t.Context(),
+		"project-a",
+		"release-1",
+		"sales",
+		"sha-256=:"+base64Digest(replacement)+":",
+		bytes.NewReader(replacement),
+	)
+	if !errors.Is(err, ErrDigest) {
+		t.Fatalf("UploadArtifact() error = %v, want ErrDigest", err)
+	}
+}
 
 func TestValidateFinalizationRequiresEveryArtifactToMatchReleaseConnectionPins(t *testing.T) {
 	pinErr := errors.New("artifact pins disagree with release manifest")
@@ -43,6 +110,7 @@ func TestValidateFinalizationRequiresEveryArtifactToMatchReleaseConnectionPins(t
 type serviceTestReleaseRepository struct {
 	current   Release
 	completed bool
+	recorded  bool
 }
 
 func (r *serviceTestReleaseRepository) Create(context.Context, CreateInput) (Release, error) {
@@ -57,7 +125,10 @@ func (r *serviceTestReleaseRepository) List(context.Context, string) ([]Release,
 func (r *serviceTestReleaseRepository) AssignArtifactTarget(context.Context, string, string, string, string) error {
 	return nil
 }
-func (r *serviceTestReleaseRepository) RecordArtifact(context.Context, Artifact) error { return nil }
+func (r *serviceTestReleaseRepository) RecordArtifact(context.Context, Artifact) error {
+	r.recorded = true
+	return nil
+}
 func (r *serviceTestReleaseRepository) BeginFinalization(context.Context, string, string, jobs.WorkflowIntent) (Release, error) {
 	return r.current, nil
 }
@@ -93,7 +164,25 @@ func (v *serviceTestPinValidator) ValidateServingStatePins(_ context.Context, st
 	return v.err
 }
 
+type serviceTestArtifactStore struct {
+	saved     string
+	saveCalls int
+}
+
+func (s *serviceTestArtifactStore) SaveUpload(_ context.Context, _ servingstate.ID, source io.Reader) (int64, error) {
+	s.saveCalls++
+	content, err := io.ReadAll(source)
+	s.saved = string(content)
+	return int64(len(content)), err
+}
+
+func base64Digest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
 // Compile-time guards keep the service fakes aligned with the real interfaces.
 var _ Repository = (*serviceTestReleaseRepository)(nil)
 var _ FinalizationUnitOfWork = (*serviceTestReleaseRepository)(nil)
 var _ ArtifactValidator = serviceTestArtifactValidator{}
+var _ ArtifactStore = (*serviceTestArtifactStore)(nil)

--- a/internal/servingstate/validate/service.go
+++ b/internal/servingstate/validate/service.go
@@ -15,6 +15,7 @@ type Repository interface {
 type ArtifactStore interface {
 	UploadPath(servingStateID servingstate.ID) string
 	PromoteUploaded(ctx context.Context, servingStateID servingstate.ID, digest, manifestJSON string) (servingstate.Artifact, error)
+	DiscardUploaded(ctx context.Context, servingStateID servingstate.ID) error
 }
 
 type Validator interface {
@@ -42,6 +43,15 @@ func (s Service) Validate(ctx context.Context, servingStateID servingstate.ID) (
 	if err != nil {
 		return servingstate.State{}, err
 	}
+	// Validation promotion and serving-state persistence complete before the
+	// enclosing release is marked ready. A process may stop between those
+	// durable boundaries, so a reclaimed finalization job must reuse the
+	// immutable validated candidate instead of trying to consume the promoted
+	// upload path a second time.
+	if current.Status == servingstate.StatusValidated {
+		_ = s.artifacts.DiscardUploaded(ctx, current.ID)
+		return current, nil
+	}
 	validation, err := s.validator.ValidateArtifact(s.artifacts.UploadPath(current.ID), current.WorkspaceID, current.Environment, current.ID)
 	if err != nil {
 		_ = s.repo.MarkFailed(ctx, current.ID, err)
@@ -64,5 +74,10 @@ func (s Service) Validate(ctx context.Context, servingStateID servingstate.ID) (
 	}
 	artifact.WorkspaceID = current.WorkspaceID
 	artifact.Environment = current.Environment
-	return s.repo.SaveValidated(ctx, current.ID, validation, artifact)
+	validated, err := s.repo.SaveValidated(ctx, current.ID, validation, artifact)
+	if err != nil {
+		return servingstate.State{}, err
+	}
+	_ = s.artifacts.DiscardUploaded(ctx, current.ID)
+	return validated, nil
 }

--- a/internal/servingstate/validate/service_test.go
+++ b/internal/servingstate/validate/service_test.go
@@ -35,6 +35,33 @@ func TestServiceValidatesPromotesAndSaves(t *testing.T) {
 	}
 }
 
+func TestServiceResumesAlreadyValidatedCandidateWithoutReprocessingArtifact(t *testing.T) {
+	repo := &fakeRepo{
+		deployment: servingstate.State{
+			ID:            "dep_1",
+			WorkspaceID:   "test",
+			ProjectID:     "project",
+			ProjectDigest: "sha256:project",
+			Status:        servingstate.StatusValidated,
+			Digest:        "sha256:artifact",
+		},
+	}
+	artifacts := &fakeArtifacts{}
+	validator := &fakeValidator{err: errors.New("validated artifact must not be reprocessed")}
+	service := NewService(repo, artifacts, validator)
+
+	resumed, err := service.Validate(t.Context(), "dep_1")
+	if err != nil {
+		t.Fatalf("Validate() resumed candidate error = %v", err)
+	}
+	if !reflect.DeepEqual(resumed, repo.deployment) {
+		t.Fatalf("Validate() = %#v, want persisted candidate %#v", resumed, repo.deployment)
+	}
+	if artifacts.promoteCalls != 0 || validator.cleaned || repo.saved {
+		t.Fatalf("resume reprocessed artifact: promote=%d cleaned=%v saved=%v", artifacts.promoteCalls, validator.cleaned, repo.saved)
+	}
+}
+
 func TestServiceMarksFailedWhenValidationFails(t *testing.T) {
 	ctx := context.Background()
 	repo := &fakeRepo{
@@ -71,7 +98,7 @@ func TestServiceRunsHookAfterArtifactValidationBeforePromotion(t *testing.T) {
 	if _, err := service.Validate(t.Context(), "dep_1"); err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"validated", "hook", "promoted", "saved", "cleaned"}
+	want := []string{"validated", "hook", "promoted", "saved", "discarded", "cleaned"}
 	if !reflect.DeepEqual(events, want) {
 		t.Fatalf("events = %#v, want %#v", events, want)
 	}
@@ -132,6 +159,7 @@ func (r *fakeRepo) SaveValidated(_ context.Context, _ servingstate.ID, validatio
 type fakeArtifacts struct {
 	promotedDigest string
 	promoteCalls   int
+	discardCalls   int
 	events         *[]string
 }
 
@@ -144,6 +172,12 @@ func (a *fakeArtifacts) PromoteUploaded(_ context.Context, servingStateID servin
 	appendEvent(a.events, "promoted")
 	a.promotedDigest = digest
 	return servingstate.Artifact{ID: "artifact_" + string(servingStateID), ServingStateID: servingStateID, Digest: digest, ManifestJSON: manifestJSON}, nil
+}
+
+func (a *fakeArtifacts) DiscardUploaded(context.Context, servingstate.ID) error {
+	a.discardCalls++
+	appendEvent(a.events, "discarded")
+	return nil
 }
 
 type fakeValidator struct {


### PR DESCRIPTION
## Summary

- make release upload, artifact promotion, serving-state validation, refresh dispatch, TUS locks, backup, and restore restart-safe
- add a real installed-candidate fault matrix covering managed upload, release finalization, deployment activation, refresh, query/SSE, backup, and restore preflight
- retain bounded recovery evidence in qualification and release workflows
- make the pinned map asset seedable for deterministic local candidate qualification

## Verification

- task ci
- exact candidate: fbd8b8b9d6abf4cc29363ef3b01c9034284319ce
- image: localhost:5058/leapview@sha256:4e6f7ea809c562f01a46f0367fb18cb30010f8aa885dac64de42e9a863bab142
- installed-candidate qualification: passed on arm64 in 412 seconds
- recovery assertions: 8/8 passed

Linear: LEA-54