### PR TITLE
ci: parallelize tests and cache image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,10 +212,24 @@ jobs:
             site/static/
 
   go-tests:
-    name: Go tests
+    name: Go tests (${{ matrix.name }})
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: packages
+            app_shard: ''
+          - name: app 1/4
+            app_shard: '0'
+          - name: app 2/4
+            app_shard: '1'
+          - name: app 3/4
+            app_shard: '2'
+          - name: app 4/4
+            app_shard: '3'
 
     steps:
       - name: Checkout
@@ -234,6 +248,7 @@ jobs:
           path: .
 
       - name: Start MinIO source integration service
+        if: matrix.app_shard != ''
         run: |
           docker run --detach --name leapview-minio \
             --publish 127.0.0.1:9000:9000 \
@@ -251,10 +266,24 @@ jobs:
             sleep 1
           done
 
-      - name: Run Go tests
+      - name: Run Go package tests
+        if: matrix.app_shard == ''
+        run: |
+          mapfile -t packages < <(go list ./... | grep -v '/internal/app$')
+          go test -p 2 "${packages[@]}"
+
+      - name: Run internal/app test shard
+        if: matrix.app_shard != ''
         env:
           LEAPVIEW_TEST_MINIO_ENDPOINT: http://127.0.0.1:9000
-        run: go test -p 2 ./...
+        run: |
+          pattern="$(
+            go run ./internal/app/tools/testshard \
+              --package ./internal/app \
+              --shard-index '${{ matrix.app_shard }}' \
+              --shard-count 4
+          )"
+          go test ./internal/app -run "$pattern"
 
   site-image:
     name: Public site image
@@ -265,8 +294,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
       - name: Build production site image
-        run: docker build --file Dockerfile.site --tag leapview-site:ci .
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: Dockerfile.site
+          load: true
+          tags: leapview-site:ci
+          cache-from: type=gha,scope=site-image
+          cache-to: type=gha,mode=max,scope=site-image
 
   frontend-tests:
     name: Frontend tests (${{ matrix.name }})
@@ -338,6 +377,13 @@ jobs:
 
       - name: Install JavaScript dependencies
         run: bun install --frozen-lockfile
+
+      - name: Restore pinned documentation basemap
+        if: matrix.name == 'site'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .data/map-assets
+          key: map-assets-${{ runner.os }}-${{ hashFiles('internal/app/tools/mapassets/main.go', 'internal/dashboard/visualization/mapasset/*.go', 'static/map-assets/leapview-streets/style.json') }}
 
       - name: Install pinned documentation basemap
         if: matrix.name == 'site'
@@ -414,6 +460,12 @@ jobs:
           bun install --frozen-lockfile
           bunx playwright install --with-deps chromium
 
+      - name: Restore pinned documentation basemap
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .data/map-assets
+          key: map-assets-${{ runner.os }}-${{ hashFiles('internal/app/tools/mapassets/main.go', 'internal/dashboard/visualization/mapasset/*.go', 'static/map-assets/leapview-streets/style.json') }}
+
       - name: Download generated assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -427,7 +479,6 @@ jobs:
     name: JavaScript dependency audit
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    needs: prepare
 
     steps:
       - name: Checkout
@@ -473,14 +524,23 @@ jobs:
     name: Production image
     runs-on: ubuntu-24.04
     timeout-minutes: 35
-    needs: prepare
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
       - name: Build production image
-        run: docker build --pull --tag leapview:ci .
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          load: true
+          pull: true
+          tags: leapview:ci
+          cache-from: type=gha,scope=production-image
+          cache-to: type=gha,mode=max,scope=production-image
 
       - name: Smoke test production image
         run: ./scripts/smoke_production_image.sh leapview:ci
@@ -498,7 +558,9 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
-          cache: true
+          # Prepare owns the shared setup-go cache. This independent, short job
+          # used to finish first and permanently seed the key with a partial cache.
+          cache: false
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
@@ -577,8 +639,8 @@ jobs:
             BUILD_TIME=${{ steps.candidate_identity.outputs.build_time }}
             BUILD_DIRTY=false
             BUILD_RELEASE=false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=production-image
+          cache-to: type=gha,mode=max,scope=production-image
           sbom: true
           provenance: mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,23 @@ FROM node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930
 # basemap.pmtiles. The generator verifies the pinned digest before accepting it.
 FROM scratch AS mapassetseed
 
-FROM golang:1.25-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 AS sourcegen
+FROM golang:1.25-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 AS go-deps
 WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+FROM go-deps AS sourcegen
 
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-COPY go.mod go.sum ./
-RUN go mod download
-
 COPY . .
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked \
     ./scripts/generate_build_sources.sh && \
     go run ./internal/app/tools/clidocgen && \
     go run ./internal/app/tools/schemadocgen && \
@@ -30,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Keep the large, network-backed map extraction separate so a transient remote
 # failure can be retried without repeating deterministic source generation.
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked \
     --mount=type=bind,from=mapassetseed,source=/,target=/mapasset-seed,ro \
     if [ -f /mapasset-seed/basemap.pmtiles ]; then \
       go run ./internal/app/tools/mapassets --out .data/map-assets --seed-archive /mapasset-seed/basemap.pmtiles; \
@@ -54,17 +56,13 @@ RUN bun scripts/generate_visualization_validator.ts && \
     bun scripts/generate_vega_lite_validator.ts && \
     bun run build
 
-FROM golang:1.25-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 AS build
-WORKDIR /src
+FROM go-deps AS build
 
 ARG BUILD_VERSION=development
 ARG BUILD_REVISION=unknown
 ARG BUILD_TIME=unknown
 ARG BUILD_DIRTY=true
 ARG BUILD_RELEASE=false
-
-COPY go.mod go.sum ./
-RUN go mod download
 
 COPY . .
 COPY --from=sourcegen /src/api/gen ./api/gen
@@ -98,7 +96,7 @@ COPY --from=sourcegen /src/web/generated ./web/generated
 COPY --from=web /src/static ./static
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked \
     BUILD_LDFLAGS="-s -w \
       -X github.com/Yacobolo/leapview/internal/platform/buildinfo.version=${BUILD_VERSION} \
       -X github.com/Yacobolo/leapview/internal/platform/buildinfo.revision=${BUILD_REVISION} \

--- a/Dockerfile.site
+++ b/Dockerfile.site
@@ -2,21 +2,23 @@
 
 FROM node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989 AS node
 
-FROM golang:1.25-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 AS sourcegen
+FROM golang:1.25-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 AS go-deps
 WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+FROM go-deps AS sourcegen
 
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-COPY go.mod go.sum ./
-RUN go mod download
-
 COPY . .
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked \
     ./scripts/generate_build_sources.sh && \
     go run ./internal/app/tools/mapassets --out .data/map-assets && \
     go run ./internal/app/tools/clidocgen && \
@@ -45,7 +47,7 @@ FROM sourcegen AS build
 COPY --from=web /src/site/static ./site/static
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked \
     test -f docs/catalog.json && \
     test -f docs/search-index.sqlite3 && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/leapview-site ./cmd/leapview-site

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -531,8 +531,43 @@ tasks:
       # CUE-heavy compiler/application packages can each saturate a core and
       # starve timing-sensitive integration tests when every package runs at
       # once. Bound package parallelism while retaining Go's in-package
-      # parallelism so local and hosted CI exercise the same reliable suite.
-      - go test -p 2 ./...
+      # parallelism, and isolate the application package into the same stable
+      # shards used by hosted CI.
+      - task: test:go
+
+  test:go:
+    desc: Run Go tests with bounded package parallelism and stable application shards
+    cmds:
+      - task: generate
+      - task --parallel test:go:packages test:go:app:0 test:go:app:1 test:go:app:2 test:go:app:3
+
+  test:go:packages:
+    cmds:
+      - go list ./... | grep -v '/internal/app$' | xargs go test -p 2
+
+  test:go:app:0:
+    cmds:
+      - |
+        pattern="$(go run ./internal/app/tools/testshard --package ./internal/app --shard-index 0 --shard-count 4)"
+        go test ./internal/app -run "$pattern"
+
+  test:go:app:1:
+    cmds:
+      - |
+        pattern="$(go run ./internal/app/tools/testshard --package ./internal/app --shard-index 1 --shard-count 4)"
+        go test ./internal/app -run "$pattern"
+
+  test:go:app:2:
+    cmds:
+      - |
+        pattern="$(go run ./internal/app/tools/testshard --package ./internal/app --shard-index 2 --shard-count 4)"
+        go test ./internal/app -run "$pattern"
+
+  test:go:app:3:
+    cmds:
+      - |
+        pattern="$(go run ./internal/app/tools/testshard --package ./internal/app --shard-index 3 --shard-count 4)"
+        go test ./internal/app -run "$pattern"
 
   ci:
     desc: Run the full CI test suite

--- a/internal/app/tools/testshard/main.go
+++ b/internal/app/tools/testshard/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/Yacobolo/leapview/internal/platform/testing/testshard"
+)
+
+func main() {
+	packageName := flag.String("package", "", "Go package whose top-level tests should be listed")
+	shardIndex := flag.Int("shard-index", -1, "zero-based shard index")
+	shardCount := flag.Int("shard-count", 0, "total number of shards")
+	flag.Parse()
+
+	if *packageName == "" {
+		fail(fmt.Errorf("package is required"))
+	}
+	command := exec.Command("go", "test", "-list", "^Test", *packageName)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		fail(fmt.Errorf("list tests in %s: %w\n%s", *packageName, err, output))
+	}
+	selected, err := testshard.Select(testshard.ParseList(string(output)), *shardIndex, *shardCount)
+	if err != nil {
+		fail(err)
+	}
+	pattern, err := testshard.Pattern(selected)
+	if err != nil {
+		fail(err)
+	}
+	fmt.Println(pattern)
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -1374,6 +1374,8 @@ func TestProductionContainerContractExists(t *testing.T) {
 	for _, want := range []string{
 		"FROM node:24-bookworm@sha256:",
 		"FROM golang:1.25-bookworm@sha256:",
+		"AS go-deps",
+		"FROM go-deps AS sourcegen",
 		"COPY --from=node /usr/local/bin/node /usr/local/bin/node",
 		"COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules",
 		"ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm",
@@ -1391,7 +1393,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"bun scripts/generate_visualization_validator.ts",
 		"bun scripts/generate_vega_lite_validator.ts",
 		"bun run build",
-		"FROM golang:1.25-bookworm@sha256:",
+		"FROM go-deps AS build",
 		"COPY --from=sourcegen /src/internal/access/api/gen ./internal/access/api/gen",
 		"COPY --from=sourcegen /src/internal/agent/api/gen ./internal/agent/api/gen",
 		"COPY --from=sourcegen /src/internal/analytics/api/gen ./internal/analytics/api/gen",
@@ -1426,6 +1428,13 @@ func TestProductionContainerContractExists(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("Dockerfile missing production container contract fragment %q", want)
 		}
+	}
+	if count := strings.Count(text, "RUN go mod download"); count != 1 {
+		t.Fatalf("Dockerfile downloads Go modules %d times, want one shared dependency stage", count)
+	}
+	const seededModuleCache = "type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked"
+	if count := strings.Count(text, seededModuleCache); count != 3 {
+		t.Fatalf("Dockerfile uses the seeded persistent Go module cache %d times, want source generation, map extraction, and compilation", count)
 	}
 
 	ignored, err := os.ReadFile(filepath.Join(root, ".dockerignore"))
@@ -1647,9 +1656,11 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 		"actions/upload-artifact@",
 		"name: generated-assets",
 		"go-tests:",
-		"name: Go tests",
+		"name: Go tests (${{ matrix.name }})",
 		"needs: prepare",
-		"go test -p 2 ./...",
+		"app_shard:",
+		"go test -p 2 \"${packages[@]}\"",
+		"go run ./internal/app/tools/testshard",
 		"frontend-tests:",
 		"name: Frontend tests",
 		"bun run test:semantic-model-graph",
@@ -1664,12 +1675,27 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 		"golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...",
 		"production-image:",
 		"name: Production image",
-		"docker build --pull --tag leapview:ci .",
+		"docker/setup-buildx-action@",
+		"docker/build-push-action@",
+		"cache-from: type=gha,scope=production-image",
+		"cache-to: type=gha,mode=max,scope=production-image",
 		"./scripts/smoke_production_image.sh leapview:ci",
+		"cache-from: type=gha,scope=site-image",
+		"cache-to: type=gha,mode=max,scope=site-image",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("CI workflow missing production gate fragment %q", want)
 		}
+	}
+	for _, job := range []string{"node-audit", "production-image"} {
+		block := workflowJobBlock(t, text, job)
+		if strings.Contains(block, "needs: prepare") {
+			t.Fatalf("%s must not wait for unrelated generated assets", job)
+		}
+	}
+	deploymentContracts := workflowJobBlock(t, text, "deployment-contracts")
+	if !strings.Contains(deploymentContracts, "cache: false") {
+		t.Fatal("deployment-contracts must not race prepare to populate the shared Go cache")
 	}
 	taskText := string(taskfile)
 	for _, want := range []string{
@@ -1681,6 +1707,10 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 		"bun audit",
 		"vuln:",
 		"golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...",
+		"test:go:",
+		"task --parallel test:go:packages test:go:app:0 test:go:app:1 test:go:app:2 test:go:app:3",
+		"go list ./... | grep -v '/internal/app$' | xargs go test -p 2",
+		"--shard-count 4",
 	} {
 		if !strings.Contains(taskText, want) {
 			t.Fatalf("Taskfile missing vulnerability gate fragment %q", want)
@@ -1716,6 +1746,31 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 			t.Fatalf("production image smoke script missing fragment %q", want)
 		}
 	}
+}
+
+func workflowJobBlock(t *testing.T, workflow, job string) string {
+	t.Helper()
+	startMarker := "  " + job + ":"
+	lines := strings.Split(workflow, "\n")
+	start := -1
+	for index, line := range lines {
+		if line == startMarker {
+			start = index
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("workflow job %q not found", job)
+	}
+	end := len(lines)
+	for index := start + 1; index < len(lines); index++ {
+		line := lines[index]
+		if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "    ") && strings.HasSuffix(line, ":") {
+			end = index
+			break
+		}
+	}
+	return strings.Join(lines[start:end], "\n")
 }
 
 func TestSQLCOutputsAreGeneratedBuildInputs(t *testing.T) {
@@ -1803,7 +1858,8 @@ func TestDerivedArtifactsAreGeneratedBuildInputs(t *testing.T) {
 			"Check generation is deterministic",
 		},
 		"Dockerfile.site": {
-			"AS sourcegen",
+			"AS go-deps",
+			"FROM go-deps AS sourcegen",
 			"./scripts/generate_build_sources.sh",
 			"go run ./internal/app/tools/clidocgen",
 			"go run ./internal/app/tools/schemadocgen",
@@ -1835,6 +1891,17 @@ func TestDerivedArtifactsAreGeneratedBuildInputs(t *testing.T) {
 				t.Errorf("%s missing generated-input contract fragment %q", name, fragment)
 			}
 		}
+	}
+	siteDockerfile, err := os.ReadFile(filepath.Join(root, "Dockerfile.site"))
+	if err != nil {
+		t.Fatalf("read Dockerfile.site: %v", err)
+	}
+	if count := strings.Count(string(siteDockerfile), "RUN go mod download"); count != 1 {
+		t.Fatalf("Dockerfile.site downloads Go modules %d times, want one shared dependency stage", count)
+	}
+	const seededModuleCache = "type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked"
+	if count := strings.Count(string(siteDockerfile), seededModuleCache); count != 2 {
+		t.Fatalf("Dockerfile.site uses the seeded persistent Go module cache %d times, want source generation and compilation", count)
 	}
 
 	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))

--- a/internal/platform/testing/testshard/shard.go
+++ b/internal/platform/testing/testshard/shard.go
@@ -1,0 +1,53 @@
+package testshard
+
+import (
+	"fmt"
+	"go/token"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ParseList extracts top-level Go test names from go test -list output.
+func ParseList(output string) []string {
+	var tests []string
+	for line := range strings.Lines(output) {
+		name := strings.TrimSpace(line)
+		if strings.HasPrefix(name, "Test") && token.IsIdentifier(name) {
+			tests = append(tests, name)
+		}
+	}
+	return tests
+}
+
+// Select assigns sorted test names to stable, count-balanced shards.
+func Select(tests []string, index, total int) ([]string, error) {
+	if total < 1 {
+		return nil, fmt.Errorf("shard count must be positive")
+	}
+	if index < 0 || index >= total {
+		return nil, fmt.Errorf("shard index %d must be between 0 and %d", index, total-1)
+	}
+
+	sorted := append([]string(nil), tests...)
+	sort.Strings(sorted)
+	selected := make([]string, 0, (len(sorted)+total-1)/total)
+	for position, name := range sorted {
+		if position%total == index {
+			selected = append(selected, name)
+		}
+	}
+	return selected, nil
+}
+
+// Pattern returns an exact go test -run expression for the selected tests.
+func Pattern(tests []string) (string, error) {
+	if len(tests) == 0 {
+		return "", fmt.Errorf("test shard is empty")
+	}
+	escaped := make([]string, len(tests))
+	for index, name := range tests {
+		escaped[index] = regexp.QuoteMeta(name)
+	}
+	return "^(?:" + strings.Join(escaped, "|") + ")$", nil
+}

--- a/internal/platform/testing/testshard/shard_test.go
+++ b/internal/platform/testing/testshard/shard_test.go
@@ -1,0 +1,86 @@
+package testshard
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestParseListReturnsOnlyTopLevelTests(t *testing.T) {
+	output := `TestZulu
+BenchmarkIgnored
+TestAlpha
+ok  	github.com/Yacobolo/leapview/internal/app	0.123s
+`
+
+	if got, want := ParseList(output), []string{"TestZulu", "TestAlpha"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseList() = %v, want %v", got, want)
+	}
+}
+
+func TestSelectSortsAndBalancesTestsAcrossShards(t *testing.T) {
+	tests := []string{"TestGolf", "TestBravo", "TestEcho", "TestAlpha", "TestFoxtrot", "TestCharlie", "TestDelta"}
+	wants := [][]string{
+		{"TestAlpha", "TestDelta", "TestGolf"},
+		{"TestBravo", "TestEcho"},
+		{"TestCharlie", "TestFoxtrot"},
+	}
+
+	seen := map[string]int{}
+	for index, want := range wants {
+		got, err := Select(tests, index, len(wants))
+		if err != nil {
+			t.Fatalf("Select(%d) error: %v", index, err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Select(%d) = %v, want %v", index, got, want)
+		}
+		for _, name := range got {
+			seen[name]++
+		}
+	}
+	for _, name := range tests {
+		if seen[name] != 1 {
+			t.Fatalf("%s selected %d times, want exactly once", name, seen[name])
+		}
+	}
+}
+
+func TestSelectRejectsInvalidShardConfiguration(t *testing.T) {
+	for _, test := range []struct {
+		index int
+		total int
+	}{
+		{index: 0, total: 0},
+		{index: -1, total: 2},
+		{index: 2, total: 2},
+	} {
+		if _, err := Select([]string{"TestOne"}, test.index, test.total); err == nil {
+			t.Fatalf("Select(index=%d, total=%d) succeeded, want error", test.index, test.total)
+		}
+	}
+}
+
+func TestPatternMatchesOnlySelectedTopLevelTests(t *testing.T) {
+	pattern, err := Pattern([]string{"TestAlpha", "TestName_WithUnderscore"})
+	if err != nil {
+		t.Fatalf("Pattern() error: %v", err)
+	}
+	expression := regexp.MustCompile(pattern)
+	for _, name := range []string{"TestAlpha", "TestName_WithUnderscore"} {
+		if !expression.MatchString(name) {
+			t.Fatalf("pattern %q does not match %q", pattern, name)
+		}
+	}
+	for _, name := range []string{"Test", "TestAlphaSuffix", "PrefixTestAlpha"} {
+		if expression.MatchString(name) {
+			t.Fatalf("pattern %q unexpectedly matches %q", pattern, name)
+		}
+	}
+}
+
+func TestPatternRejectsEmptySelection(t *testing.T) {
+	if _, err := Pattern(nil); err == nil {
+		t.Fatal("Pattern(nil) succeeded, want error")
+	}
+}


### PR DESCRIPTION
## Summary

- split the oversized Go test lane into one package lane and four deterministic `internal/app` shards
- run the same bounded, parallel shard layout through `task test:go` locally
- add scoped GitHub Actions caches for both production images and remove unnecessary job dependencies
- seed persistent Go module caches in both Dockerfiles so generator tools survive layer eviction
- add architecture contracts and unit tests for the CI and Docker cache topology

## Baseline

- recent successful GitHub workflow: 13m19s end to end
- Go tests: 8m23s
- production image: 7m13s
- public site image: 5m55s
- UI route QA: 7m28s after the prepare dependency

The PR run is the first authoritative measurement of the optimized workflow. UI route QA remains the likely next critical-path target.

## Validation

- `task ci`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- `docker build --check --file Dockerfile .`
- `docker build --check --file Dockerfile.site .`
- production and public-site image builds
- `./scripts/smoke_production_image.sh leapview:ci`
- all four application shards run independently
