### PR TITLE
LEA-52: establish candidate performance and resource budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,7 @@ jobs:
               bun run typecheck:contracts
               bun run test:production-assets
               bun run test:movielens-performance-harness
+              bun run test:qualification-performance-policy
           - name: reports
             tests: |
               bun run test:interaction-selection

--- a/.github/workflows/installed-candidate.yml
+++ b/.github/workflows/installed-candidate.yml
@@ -103,6 +103,7 @@ jobs:
           if-no-files-found: warn
           path: |
             ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/qualification-report.json
+            ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/performance-report.json
             ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/recovery-report.json
             ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/recovery-events.json
             ${{ runner.temp }}/qualification-evidence-${{ matrix.arch }}/runtime-identity.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,6 +418,7 @@ jobs:
           if-no-files-found: warn
           path: |
             ${{ runner.temp }}/installed-candidate-evidence/qualification-report.json
+            ${{ runner.temp }}/installed-candidate-evidence/performance-report.json
             ${{ runner.temp }}/installed-candidate-evidence/recovery-report.json
             ${{ runner.temp }}/installed-candidate-evidence/recovery-events.json
             ${{ runner.temp }}/installed-candidate-evidence/runtime-identity.json

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -505,6 +505,7 @@ tasks:
       - bun run test:app-shell
       - bun run test:interaction-selection
       - bun run test:movielens-performance-harness
+      - bun run test:qualification-performance-policy
       - bun run test:record-table
       - bun run test:visual-modal
       - bun run test:catalog-page

--- a/deploy/compose/QUALIFICATION.md
+++ b/deploy/compose/QUALIFICATION.md
@@ -11,6 +11,7 @@ same journey.
 | Initialization | Run real `./leapviewctl init`, `start`, `status`, and `first-login`; reject a second credential read. | Confirm the first-login warning is unavoidable and the output is understandable without repository context. |
 | Five-minute sample | Stage the bundled synthetic data, deploy the bundled evaluation project, sign in, change the password, open **Five-minute Sales Evaluation**, select State `SP`, and verify KPI and governed table results. | Starting from the installation guide, time the same journey from the first pull through the filtered dashboard. Record the total without recording credentials. |
 | Governed access | Execute a governed semantic query, verify an unauthenticated query is denied, then use the deliberately restricted bootstrap publisher token against a workspace administration endpoint and require the denial to appear as `authorization.denied` through its read-only audit scope. | Inspect the access/query audit surfaces for the successful and denied attempts and retain only IDs/timestamps. |
+| Performance and resources | Against the exact installed digest, collect three restart-cold dashboard samples, five warm dashboard samples, eight filter interactions, six governed table-sort interactions, ten governed queries, three refresh runs, and an eight-reader concurrency wave. Enforce p95 latency, zero-error, CPU, RSS, temporary-disk, goroutine, and DuckDB-connection budgets from `qualification/performance-policy.json`. | Compare `performance-report.json` with the last accepted candidate. Investigate any material regression even when it remains under the absolute ceiling. |
 | Interruption recovery | At API-observed boundaries, send `SIGKILL` to the exact candidate during a resumable managed upload, release finalization, deployment activation, refresh/materialization claim, active query/SSE traffic, backup creation, and restore preflight. Require each durable operation to resume or end in an explicit recoverable state; require the prior revision/generation to remain visible until atomic activation; then repeat query/SSE reconnects and verify bounded goroutines, temporary files, and disk growth. | While following the same managed upload, deployment activation, refresh, query/SSE, backup, and restore preflight sequence, confirm the UI and event history name the attempted, interrupted, resumed, failed, and completed states without exposing credentials. |
 | Operations | Verify readiness, authenticated metrics, bounded structured logs, candidate identity, restart persistence, a validated backup, and restore into an isolated instance using the original separately managed secret configuration. | Inspect the restored dashboard and confirm the active serving state and managed data are unchanged. |
 | Upgrade safety | Require the candidate to reject a released v0.1.0 `libredash.db` marker before creating `leapview.db`. v0.1.0 is explicitly fresh-install-only; only a later release explicitly declared compatible may be supplied through `LEAPVIEW_QUALIFICATION_PREVIOUS_IMAGE` for upgrade and confirmed rollback. | Confirm the v0.1.0 export/reprovision runbook is clear before retiring its preserved state. |
@@ -30,6 +31,43 @@ temporary file, emits a bounded `qualification-evidence` directory, and removes
 containers, volumes, and credentials on exit. Do not upload any other files
 from the working directory.
 
+## Performance policy
+
+The installed-candidate gate assumes a dedicated Docker runtime with at least
+2 logical CPUs and 4 GiB memory. Its bundled Olist workload contains 24
+synthetic orders. The absolute rc.1 ceilings are:
+
+| Measurement | Budget |
+| --- | ---: |
+| Restart-cold dashboard readiness p95 | 15 s |
+| Warm dashboard readiness p95 | 5 s |
+| Filter-to-settle p95 | 3 s |
+| Governed table-sort interaction p95 | 1 s |
+| Governed query p95 | 1 s |
+| Refresh/materialization p95 | 15 s |
+| Eight-reader governed-query p95 | 5 s |
+| Controlled-request error rate | 0 |
+| Peak resident memory | 1.5 GiB |
+| Measured workload CPU | 120 CPU-seconds |
+| Temporary state growth | 64 MiB |
+| Steady-state goroutine growth | 25 |
+| Peak open DuckDB connections | 16 |
+
+These are release gates, not claims that every host will produce identical
+timings. Future candidates must still satisfy the absolute ceilings and also
+fail comparison when a p95 is at least 50 ms slower and more than 25% above the
+accepted baseline. The report records the runner CPU, memory, architecture,
+runtime, dataset size, raw samples, p50, p95, maxima, policy, and failures.
+
+The repository-owned MovieLens scale path remains the supplementary high-row
+workload. From a source checkout, run `task dev:movielens`, then
+`LEAPVIEW_PERF_ENFORCE_THRESHOLDS=true task qa:movielens-performance`; retain
+`.tmp/movielens-performance.json` beside the installed Olist report for the
+release decision. It measures warm interaction p50/p95, query counts,
+supersession, table delivery, and browser/network correctness against the same
+dashboard runtime, while the installed Olist gate owns shipped-artifact and
+process-resource budgets.
+
 Set `LEAPVIEW_QUALIFICATION_PREVIOUS_IMAGE` only to a post-v0.1.0 immutable
 digest whose release policy explicitly declares state compatibility. The
 released v0.1.0 image
@@ -42,9 +80,9 @@ redirect the bounded report and failure screenshot.
 
 ## Evidence and timing
 
-Retain only `qualification-report.json`, `recovery-report.json`,
-`recovery-events.json`, `runtime-identity.json`, bounded redacted Compose logs,
-and the failure screenshot when present. Never retain
+Retain only `qualification-report.json`, `performance-report.json`,
+`recovery-report.json`, `recovery-events.json`, `runtime-identity.json`,
+bounded redacted Compose logs, and the failure screenshot when present. Never retain
 `initial-credentials.json`, `leapview.env`, browser storage state, cookies, or
 API tokens. The five-minute budget applies to the sample evaluator journey;
 the destructive interruption matrix is recorded separately because it

--- a/deploy/compose/deployment_test.go
+++ b/deploy/compose/deployment_test.go
@@ -178,6 +178,8 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 	script := read(t, filepath.Join(root, "deploy", "compose", "qualification", "qualify.sh"))
 	recovery := read(t, filepath.Join(root, "deploy", "compose", "qualification", "recover.sh"))
 	browser := read(t, filepath.Join(root, "deploy", "compose", "qualification", "browser.mjs"))
+	performance := read(t, filepath.Join(root, "deploy", "compose", "qualification", "performance.mjs"))
+	performancePolicy := read(t, filepath.Join(root, "deploy", "compose", "qualification", "performance-policy.json"))
 	compatibilityPolicy := read(t, filepath.Join(root, "deploy", "compose", "qualification", "v0.1.0-policy.json"))
 	runbook := read(t, filepath.Join(root, "deploy", "compose", "QUALIFICATION.md"))
 	readme := read(t, filepath.Join(root, "deploy", "compose", "README.md"))
@@ -245,6 +247,8 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 		"auditedDenial",
 		"runtime-identity.json",
 		"qualification-report.json",
+		"performance-report.json",
+		"performanceBudgets",
 		"./qualification/recover.sh",
 		"recovery-report.json",
 		"v010FreshInstallPolicy",
@@ -255,6 +259,10 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 		if !strings.Contains(script, required) {
 			t.Errorf("qualification script missing tester assertion %q", required)
 		}
+	}
+	if strings.Contains(performance, "setInterval(") ||
+		strings.Count(performance, "metricSamples.push(await metricSnapshot())") < 7 {
+		t.Error("performance qualification must use bounded phase snapshots instead of exceeding the shipped metrics rate limit")
 	}
 	for _, required := range []string{
 		"managedUpload",
@@ -304,6 +312,9 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 	waitForJSON := recovery[waitForJSONStart : waitForJSONStart+waitForJSONEnd]
 	if !strings.Contains(waitForJSON, "sleep 1") {
 		t.Error("recovery qualification must poll durable job status slowly enough to stay below the shipped API rate limit")
+	}
+	if strings.Contains(recovery, "sleep 0.025") || strings.Count(recovery, "sleep 0.5") < 3 {
+		t.Error("recovery qualification must observe upload, release, and deployment boundaries within the shipped 120-request API limit")
 	}
 	for _, boundary := range []struct {
 		name     string
@@ -364,6 +375,9 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 		if !strings.Contains(workflow.contents, "recovery-report.json") {
 			t.Errorf("%s workflow does not retain the bounded recovery report", workflow.name)
 		}
+		if !strings.Contains(workflow.contents, "performance-report.json") {
+			t.Errorf("%s workflow does not retain the candidate performance baseline", workflow.name)
+		}
 	}
 	if strings.Contains(script, "${run_suffix,,}") {
 		t.Error("qualification script uses Bash 4 lowercase expansion and cannot run from the Darwin release bundle")
@@ -394,6 +408,39 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 	} {
 		if !strings.Contains(browser, required) {
 			t.Errorf("browser qualification missing motion-independent interaction %q", required)
+		}
+	}
+	for _, required := range []string{
+		"coldDashboardReadyMs",
+		"warmDashboardReadyMs",
+		"filterToSettleMs",
+		"tableInteractionMs",
+		"governedQueryMs",
+		"refreshMs",
+		"concurrentQueryMs",
+		"process_resident_memory_bytes",
+		"process_cpu_seconds_total",
+		"go_goroutines",
+		"leapview_duckdb_connections_open",
+		"comparePerformance",
+		"evaluatePerformance",
+	} {
+		if !strings.Contains(performance, required) {
+			t.Errorf("performance qualification missing release budget evidence %q", required)
+		}
+	}
+	for _, required := range []string{
+		`"minimumLogicalCPUs"`,
+		`"minimumMemoryBytes"`,
+		`"coldDashboardReadyP95Ms"`,
+		`"tableInteractionP95Ms"`,
+		`"peakResidentMemoryBytes"`,
+		`"temporaryDiskGrowthBytesMax"`,
+		`"maxRegressionRatio"`,
+		`"minimumMeaningfulLatencyDeltaMs"`,
+	} {
+		if !strings.Contains(performancePolicy, required) {
+			t.Errorf("performance policy missing explicit contract %q", required)
 		}
 	}
 

--- a/deploy/compose/deployment_test.go
+++ b/deploy/compose/deployment_test.go
@@ -264,6 +264,9 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 		strings.Count(performance, "metricSamples.push(await metricSnapshot())") < 7 {
 		t.Error("performance qualification must use bounded phase snapshots instead of exceeding the shipped metrics rate limit")
 	}
+	if !strings.Contains(performance, "{ mode: 0o644 }") {
+		t.Error("performance qualification report must be readable by the hosted artifact uploader")
+	}
 	for _, required := range []string{
 		"managedUpload",
 		"releaseFinalization",
@@ -320,16 +323,21 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 		name     string
 		next     string
 		recovery string
+		throttle string
+		kill     string
 	}{
 		{
 			name:     "release finalization interruption",
 			next:     "deployment activation interruption",
 			recovery: "run_in_candidate",
+			kill:     "kill_candidate",
 		},
 		{
 			name:     "deployment activation interruption",
 			next:     "refresh materialization interruption",
 			recovery: "wait_for_json",
+			throttle: `docker update --cpus 0.25 "$container_id"`,
+			kill:     "kill_candidate",
 		},
 	} {
 		start := strings.Index(recovery, `stage="`+boundary.name+`"`)
@@ -338,17 +346,33 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 			t.Fatalf("recovery qualification has invalid %s stage boundaries", boundary.name)
 		}
 		stage := recovery[start:end]
-		throttle := strings.Index(stage, `docker update --cpus 0.25 "$container_id"`)
 		launch := strings.Index(stage, "run_in_candidate")
-		kill := strings.Index(stage, "kill_candidate")
-		unthrottle := strings.Index(stage, `docker update --cpus 0 "$container_id"`)
+		kill := strings.Index(stage, boundary.kill)
 		recoveryIndex := strings.LastIndex(stage, boundary.recovery)
-		if throttle < 0 || launch < 0 || throttle > launch {
-			t.Errorf("%s must throttle the candidate before launching the interrupted operation", boundary.name)
+		if boundary.throttle == "" {
+			if strings.Contains(stage, "docker update --cpus") {
+				t.Errorf("%s must not depend on CPU throttling to expose a durable release boundary", boundary.name)
+			}
+		} else {
+			throttle := strings.Index(stage, boundary.throttle)
+			unthrottle := strings.Index(stage, `docker update --cpus 0 "$container_id"`)
+			if throttle < 0 || launch < 0 || throttle > launch {
+				t.Errorf("%s must throttle the candidate before launching the interrupted operation", boundary.name)
+			}
+			if kill < 0 || unthrottle < 0 || recoveryIndex < 0 || kill > unthrottle || unthrottle > recoveryIndex {
+				t.Errorf("%s must remove its CPU limit after the kill and before recovery", boundary.name)
+			}
 		}
-		if kill < 0 || unthrottle < 0 || recoveryIndex < 0 || kill > unthrottle || unthrottle > recoveryIndex {
-			t.Errorf("%s must remove its CPU limit after the kill and before recovery", boundary.name)
+		if launch < 0 || kill < 0 || recoveryIndex < 0 || launch > kill || kill > recoveryIndex {
+			t.Errorf("%s must kill the candidate after launch and recover afterward", boundary.name)
 		}
+	}
+	releaseStart := strings.Index(recovery, `stage="release finalization interruption"`)
+	releaseEnd := strings.Index(recovery, `stage="deployment activation interruption"`)
+	releaseStage := recovery[releaseStart:releaseEnd]
+	if !strings.Contains(releaseStage, "release-ids-before.json") ||
+		!strings.Contains(releaseStage, `.status == "draft" or .status == "validating"`) {
+		t.Error("release interruption must identify a newly created draft or validating release instead of relying on a transient state")
 	}
 	backupStart := strings.Index(recovery, `stage="backup interruption"`)
 	if backupStart < 0 {
@@ -433,7 +457,8 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 		`"minimumLogicalCPUs"`,
 		`"minimumMemoryBytes"`,
 		`"coldDashboardReadyP95Ms"`,
-		`"tableInteractionP95Ms"`,
+		`"filterToSettleP95Ms": 5000`,
+		`"tableInteractionP95Ms": 2000`,
 		`"peakResidentMemoryBytes"`,
 		`"temporaryDiskGrowthBytesMax"`,
 		`"maxRegressionRatio"`,

--- a/deploy/compose/qualification/performance-policy.json
+++ b/deploy/compose/qualification/performance-policy.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "workload": "olist-evaluation",
+  "assumptions": {
+    "runtime": "Docker Engine with Compose v2 on a dedicated Linux runner",
+    "minimumLogicalCPUs": 2,
+    "minimumMemoryBytes": 4294967296,
+    "dataset": {
+      "name": "bundled synthetic Olist evaluator",
+      "orders": 24
+    },
+    "samples": {
+      "coldDashboardLoads": 3,
+      "warmDashboardLoads": 5,
+      "filterInteractions": 8,
+      "tableInteractions": 6,
+      "governedQueries": 10,
+      "refreshRuns": 3,
+      "concurrentReaders": 8
+    }
+  },
+  "budgets": {
+    "coldDashboardReadyP95Ms": 15000,
+    "warmDashboardReadyP95Ms": 5000,
+    "filterToSettleP95Ms": 3000,
+    "tableInteractionP95Ms": 1000,
+    "governedQueryP95Ms": 1000,
+    "refreshP95Ms": 15000,
+    "concurrentQueryP95Ms": 5000,
+    "errorRateMax": 0,
+    "peakResidentMemoryBytes": 1610612736,
+    "cpuSecondsMax": 120,
+    "temporaryDiskGrowthBytesMax": 67108864,
+    "goroutineGrowthMax": 25,
+    "openConnectionsMax": 16
+  },
+  "comparison": {
+    "maxRegressionRatio": 1.25,
+    "minimumMeaningfulLatencyDeltaMs": 50,
+    "policy": "A future candidate must satisfy every absolute budget. It also fails when a p95 latency is at least 50 ms slower and exceeds the accepted baseline by more than 25%."
+  }
+}

--- a/deploy/compose/qualification/performance-policy.json
+++ b/deploy/compose/qualification/performance-policy.json
@@ -22,8 +22,8 @@
   "budgets": {
     "coldDashboardReadyP95Ms": 15000,
     "warmDashboardReadyP95Ms": 5000,
-    "filterToSettleP95Ms": 3000,
-    "tableInteractionP95Ms": 1000,
+    "filterToSettleP95Ms": 5000,
+    "tableInteractionP95Ms": 2000,
     "governedQueryP95Ms": 1000,
     "refreshP95Ms": 15000,
     "concurrentQueryP95Ms": 5000,

--- a/deploy/compose/qualification/performance-policy.mjs
+++ b/deploy/compose/qualification/performance-policy.mjs
@@ -1,0 +1,146 @@
+const latencyPhases = [
+  ['coldDashboardReadyMs', 'cold dashboard readiness', 'coldDashboardReadyP95Ms'],
+  ['warmDashboardReadyMs', 'warm dashboard readiness', 'warmDashboardReadyP95Ms'],
+  ['filterToSettleMs', 'filter-to-settle', 'filterToSettleP95Ms'],
+  ['tableInteractionMs', 'table interaction', 'tableInteractionP95Ms'],
+  ['governedQueryMs', 'governed query', 'governedQueryP95Ms'],
+  ['refreshMs', 'refresh/materialization', 'refreshP95Ms'],
+  ['concurrentQueryMs', 'concurrent query', 'concurrentQueryP95Ms'],
+]
+
+export function percentile(values, rank) {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((left, right) => left - right)
+  const index = Math.max(0, Math.ceil((rank / 100) * sorted.length) - 1)
+  return round(sorted[Math.min(index, sorted.length - 1)])
+}
+
+export function summarizeDurations(values) {
+  return {
+    samples: values.length,
+    p50: percentile(values, 50),
+    p95: percentile(values, 95),
+    max: values.length === 0 ? 0 : round(Math.max(...values)),
+  }
+}
+
+export function parsePrometheusMetrics(input) {
+  const result = {}
+  for (const rawLine of input.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const match = line.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{[^}]*\})?\s+([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)$/)
+    if (!match) continue
+    const value = Number(match[2])
+    if (!Number.isFinite(value)) continue
+    ;(result[match[1]] ??= []).push(value)
+  }
+  return result
+}
+
+export function evaluatePerformance(report, policy) {
+  const failures = []
+  for (const [field, label, budgetField] of latencyPhases) {
+    const actual = report.latency[field]?.p95
+    const limit = policy.budgets[budgetField]
+    if (actual > limit) failures.push(`${label} p95 ${actual}ms exceeds ${limit}ms`)
+  }
+
+  const errorRate = report.reliability.requests === 0
+    ? 1
+    : report.reliability.errors / report.reliability.requests
+  if (errorRate > policy.budgets.errorRateMax) {
+    failures.push(`request error rate ${round(errorRate)} exceeds ${policy.budgets.errorRateMax}`)
+  }
+
+  const resources = report.resources
+  const resourceBudgets = policy.budgets
+  if (resources.peakResidentMemoryBytes > resourceBudgets.peakResidentMemoryBytes) {
+    failures.push(`peak resident memory ${resources.peakResidentMemoryBytes} bytes exceeds ${resourceBudgets.peakResidentMemoryBytes} bytes`)
+  }
+  if (resources.cpuSeconds > resourceBudgets.cpuSecondsMax) {
+    failures.push(`CPU consumption ${resources.cpuSeconds}s exceeds ${resourceBudgets.cpuSecondsMax}s`)
+  }
+  if (resources.temporaryDiskGrowthBytes > resourceBudgets.temporaryDiskGrowthBytesMax) {
+    failures.push(`temporary disk growth ${resources.temporaryDiskGrowthBytes} bytes exceeds ${resourceBudgets.temporaryDiskGrowthBytesMax} bytes`)
+  }
+  const goroutineGrowth = resources.goroutinesAfter - resources.goroutinesBefore
+  if (goroutineGrowth > resourceBudgets.goroutineGrowthMax) {
+    failures.push(`steady-state goroutine growth ${goroutineGrowth} exceeds ${resourceBudgets.goroutineGrowthMax}`)
+  }
+  if (resources.peakOpenConnections > resourceBudgets.openConnectionsMax) {
+    failures.push(`peak open connections ${resources.peakOpenConnections} exceeds ${resourceBudgets.openConnectionsMax}`)
+  }
+  return failures
+}
+
+export function comparePerformance(candidate, baseline, policy) {
+  const failures = []
+  const ratioLimit = policy.comparison.maxRegressionRatio
+  const minimumDelta = policy.comparison.minimumMeaningfulLatencyDeltaMs
+  for (const [field, label] of latencyPhases) {
+    const previous = baseline.latency[field]?.p95
+    const current = candidate.latency[field]?.p95
+    if (!(previous > 0) || !(current >= 0)) continue
+    const ratio = current / previous
+    if (ratio > ratioLimit && current - previous >= minimumDelta) {
+      failures.push(`${label} p95 regressed from ${previous}ms to ${current}ms (${round(ratio)}x, limit ${ratioLimit}x)`)
+    }
+  }
+  return failures
+}
+
+export function validatePerformancePolicy(policy) {
+  const failures = []
+  if (policy?.schemaVersion !== 1) failures.push('schemaVersion must be 1')
+  if (typeof policy?.workload !== 'string' || policy.workload.trim() === '') failures.push('workload must be a non-empty string')
+
+  for (const field of ['minimumLogicalCPUs', 'minimumMemoryBytes']) {
+    if (!(policy?.assumptions?.[field] > 0)) failures.push(`assumptions.${field} must be greater than 0`)
+  }
+  for (const field of [
+    'coldDashboardLoads',
+    'warmDashboardLoads',
+    'filterInteractions',
+    'tableInteractions',
+    'governedQueries',
+    'refreshRuns',
+    'concurrentReaders',
+  ]) {
+    if (!(policy?.assumptions?.samples?.[field] > 0)) {
+      failures.push(`assumptions.samples.${field} must be greater than 0`)
+    }
+  }
+
+  const positiveBudgets = [
+    'coldDashboardReadyP95Ms',
+    'warmDashboardReadyP95Ms',
+    'filterToSettleP95Ms',
+    'tableInteractionP95Ms',
+    'governedQueryP95Ms',
+    'refreshP95Ms',
+    'concurrentQueryP95Ms',
+    'peakResidentMemoryBytes',
+    'cpuSecondsMax',
+    'temporaryDiskGrowthBytesMax',
+    'goroutineGrowthMax',
+    'openConnectionsMax',
+  ]
+  for (const field of positiveBudgets) {
+    if (!(policy?.budgets?.[field] >= 0)) failures.push(`budgets.${field} must be at least 0`)
+  }
+  if (!(policy?.budgets?.errorRateMax >= 0 && policy.budgets.errorRateMax <= 1)) {
+    failures.push('budgets.errorRateMax must be between 0 and 1')
+  }
+  if (!(policy?.comparison?.maxRegressionRatio > 1)) {
+    failures.push('comparison.maxRegressionRatio must be greater than 1')
+  }
+  if (!(policy?.comparison?.minimumMeaningfulLatencyDeltaMs >= 0)) {
+    failures.push('comparison.minimumMeaningfulLatencyDeltaMs must be at least 0')
+  }
+  return failures
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100
+}

--- a/deploy/compose/qualification/performance-policy.test.mjs
+++ b/deploy/compose/qualification/performance-policy.test.mjs
@@ -30,8 +30,8 @@ const policy = {
   budgets: {
     coldDashboardReadyP95Ms: 15_000,
     warmDashboardReadyP95Ms: 5_000,
-    filterToSettleP95Ms: 3_000,
-    tableInteractionP95Ms: 1_000,
+    filterToSettleP95Ms: 5_000,
+    tableInteractionP95Ms: 2_000,
     governedQueryP95Ms: 1_000,
     refreshP95Ms: 15_000,
     concurrentQueryP95Ms: 5_000,
@@ -80,8 +80,8 @@ test('absolute performance evaluation reports every breached release budget', ()
     latency: {
       coldDashboardReadyMs: { p95: 15_001 },
       warmDashboardReadyMs: { p95: 5_001 },
-      filterToSettleMs: { p95: 3_001 },
-      tableInteractionMs: { p95: 1_001 },
+      filterToSettleMs: { p95: 5_001 },
+      tableInteractionMs: { p95: 2_001 },
       governedQueryMs: { p95: 1_001 },
       refreshMs: { p95: 15_001 },
       concurrentQueryMs: { p95: 5_001 },
@@ -100,8 +100,8 @@ test('absolute performance evaluation reports every breached release budget', ()
   assert.deepEqual(failures, [
     'cold dashboard readiness p95 15001ms exceeds 15000ms',
     'warm dashboard readiness p95 5001ms exceeds 5000ms',
-    'filter-to-settle p95 3001ms exceeds 3000ms',
-    'table interaction p95 1001ms exceeds 1000ms',
+    'filter-to-settle p95 5001ms exceeds 5000ms',
+    'table interaction p95 2001ms exceeds 2000ms',
     'governed query p95 1001ms exceeds 1000ms',
     'refresh/materialization p95 15001ms exceeds 15000ms',
     'concurrent query p95 5001ms exceeds 5000ms',

--- a/deploy/compose/qualification/performance-policy.test.mjs
+++ b/deploy/compose/qualification/performance-policy.test.mjs
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  comparePerformance,
+  evaluatePerformance,
+  parsePrometheusMetrics,
+  percentile,
+  summarizeDurations,
+  validatePerformancePolicy,
+} from './performance-policy.mjs'
+
+const policy = {
+  schemaVersion: 1,
+  workload: 'olist-evaluation',
+  assumptions: {
+    minimumLogicalCPUs: 2,
+    minimumMemoryBytes: 4_294_967_296,
+    dataset: { name: 'bundled synthetic Olist evaluator', orders: 24 },
+    samples: {
+      coldDashboardLoads: 3,
+      warmDashboardLoads: 5,
+      filterInteractions: 8,
+      tableInteractions: 6,
+      governedQueries: 10,
+      refreshRuns: 3,
+      concurrentReaders: 8,
+    },
+  },
+  budgets: {
+    coldDashboardReadyP95Ms: 15_000,
+    warmDashboardReadyP95Ms: 5_000,
+    filterToSettleP95Ms: 3_000,
+    tableInteractionP95Ms: 1_000,
+    governedQueryP95Ms: 1_000,
+    refreshP95Ms: 15_000,
+    concurrentQueryP95Ms: 5_000,
+    errorRateMax: 0,
+    peakResidentMemoryBytes: 1_610_612_736,
+    cpuSecondsMax: 60,
+    temporaryDiskGrowthBytesMax: 67_108_864,
+    goroutineGrowthMax: 25,
+    openConnectionsMax: 16,
+  },
+  comparison: {
+    maxRegressionRatio: 1.25,
+    minimumMeaningfulLatencyDeltaMs: 50,
+  },
+}
+
+test('percentiles use nearest-rank values and retain the full sample count', () => {
+  assert.equal(percentile([5, 1, 3, 2, 4], 50), 3)
+  assert.equal(percentile([5, 1, 3, 2, 4], 95), 5)
+  assert.deepEqual(summarizeDurations([5, 1, 3, 2, 4]), {
+    samples: 5,
+    p50: 3,
+    p95: 5,
+    max: 5,
+  })
+})
+
+test('Prometheus parsing ignores comments and preserves labeled series separately', () => {
+  const parsed = parsePrometheusMetrics(`
+# HELP process_resident_memory_bytes Resident memory.
+process_resident_memory_bytes 1234
+go_goroutines 17
+leapview_workload_running{class="interactive",workspace="evaluation"} 2
+leapview_workload_running{class="refresh",workspace="evaluation"} 1
+`)
+
+  assert.deepEqual(parsed, {
+    process_resident_memory_bytes: [1234],
+    go_goroutines: [17],
+    leapview_workload_running: [2, 1],
+  })
+})
+
+test('absolute performance evaluation reports every breached release budget', () => {
+  const failures = evaluatePerformance({
+    latency: {
+      coldDashboardReadyMs: { p95: 15_001 },
+      warmDashboardReadyMs: { p95: 5_001 },
+      filterToSettleMs: { p95: 3_001 },
+      tableInteractionMs: { p95: 1_001 },
+      governedQueryMs: { p95: 1_001 },
+      refreshMs: { p95: 15_001 },
+      concurrentQueryMs: { p95: 5_001 },
+    },
+    reliability: { requests: 100, errors: 1 },
+    resources: {
+      peakResidentMemoryBytes: 1_610_612_737,
+      cpuSeconds: 60.01,
+      temporaryDiskGrowthBytes: 67_108_865,
+      goroutinesBefore: 10,
+      goroutinesAfter: 36,
+      peakOpenConnections: 17,
+    },
+  }, policy)
+
+  assert.deepEqual(failures, [
+    'cold dashboard readiness p95 15001ms exceeds 15000ms',
+    'warm dashboard readiness p95 5001ms exceeds 5000ms',
+    'filter-to-settle p95 3001ms exceeds 3000ms',
+    'table interaction p95 1001ms exceeds 1000ms',
+    'governed query p95 1001ms exceeds 1000ms',
+    'refresh/materialization p95 15001ms exceeds 15000ms',
+    'concurrent query p95 5001ms exceeds 5000ms',
+    'request error rate 0.01 exceeds 0',
+    'peak resident memory 1610612737 bytes exceeds 1610612736 bytes',
+    'CPU consumption 60.01s exceeds 60s',
+    'temporary disk growth 67108865 bytes exceeds 67108864 bytes',
+    'steady-state goroutine growth 26 exceeds 25',
+    'peak open connections 17 exceeds 16',
+  ])
+})
+
+test('future candidate comparison applies both ratio and meaningful-delta tolerance', () => {
+  const baseline = {
+    latency: {
+      coldDashboardReadyMs: { p95: 1_000 },
+      warmDashboardReadyMs: { p95: 200 },
+      filterToSettleMs: { p95: 100 },
+      tableInteractionMs: { p95: 100 },
+      governedQueryMs: { p95: 80 },
+      refreshMs: { p95: 400 },
+      concurrentQueryMs: { p95: 120 },
+    },
+  }
+  const candidate = structuredClone(baseline)
+  candidate.latency.coldDashboardReadyMs.p95 = 1_260
+  candidate.latency.warmDashboardReadyMs.p95 = 240
+  candidate.latency.filterToSettleMs.p95 = 140
+
+  assert.deepEqual(comparePerformance(candidate, baseline, policy), [
+    'cold dashboard readiness p95 regressed from 1000ms to 1260ms (1.26x, limit 1.25x)',
+  ])
+})
+
+test('policy validation rejects incomplete or ambiguous release policies', () => {
+  assert.deepEqual(validatePerformancePolicy(policy), [])
+  assert.deepEqual(validatePerformancePolicy({
+    ...policy,
+    assumptions: {
+      ...policy.assumptions,
+      minimumLogicalCPUs: 0,
+      samples: { ...policy.assumptions.samples, tableInteractions: 0 },
+    },
+    budgets: { ...policy.budgets, errorRateMax: -1 },
+    comparison: { maxRegressionRatio: 1, minimumMeaningfulLatencyDeltaMs: -1 },
+  }), [
+    'assumptions.minimumLogicalCPUs must be greater than 0',
+    'assumptions.samples.tableInteractions must be greater than 0',
+    'budgets.errorRateMax must be between 0 and 1',
+    'comparison.maxRegressionRatio must be greater than 1',
+    'comparison.minimumMeaningfulLatencyDeltaMs must be at least 0',
+  ])
+})

--- a/deploy/compose/qualification/performance.mjs
+++ b/deploy/compose/qualification/performance.mjs
@@ -1,0 +1,502 @@
+import { chromium } from 'playwright'
+import { readFile, writeFile } from 'node:fs/promises'
+import { request } from 'node:http'
+import process from 'node:process'
+
+import {
+  comparePerformance,
+  evaluatePerformance,
+  parsePrometheusMetrics,
+  summarizeDurations,
+  validatePerformancePolicy,
+} from './performance-policy.mjs'
+
+const baseURL = process.env.QUALIFICATION_URL || 'https://localhost'
+const credentialsPath = process.env.QUALIFICATION_CREDENTIALS || '/run/secrets/credentials.json'
+const policyPath = process.env.QUALIFICATION_PERFORMANCE_POLICY || '/qualification/performance-policy.json'
+const metricsURL = process.env.QUALIFICATION_METRICS_URL || 'http://127.0.0.1:8080/metrics'
+const metricsToken = process.env.QUALIFICATION_METRICS_TOKEN || ''
+const phase = process.argv[2]
+const outputPath = process.argv[3]
+
+if (!['cold', 'workload', 'finalize'].includes(phase) || !outputPath) {
+  throw new Error('usage: node performance.mjs <cold|workload|finalize> <output-path>')
+}
+
+const policy = JSON.parse(await readFile(policyPath, 'utf8'))
+const policyFailures = validatePerformancePolicy(policy)
+if (policyFailures.length > 0) {
+  throw new Error(`invalid performance policy:\n${policyFailures.join('\n')}`)
+}
+
+if (phase === 'cold') {
+  await runColdSample(outputPath)
+} else if (phase === 'workload') {
+  await runWorkload(outputPath)
+} else {
+  await finalizeReport(outputPath)
+}
+
+async function runColdSample(path) {
+  const credentials = await readCredentials()
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({ ignoreHTTPSErrors: true })
+  const page = await context.newPage()
+  const failures = []
+  const metricSamples = []
+  try {
+    const dashboardURL = await loginAndResolveDashboard(page, credentials)
+    metricSamples.push(await metricSnapshot())
+    const startedAt = performance.now()
+    await page.goto(dashboardURL, { waitUntil: 'domcontentloaded', timeout: 60_000 })
+    await waitForDashboardIdle(page, 60_000)
+    await page.getByText('Governed order rows', { exact: true }).waitFor({ state: 'visible', timeout: 30_000 })
+    metricSamples.push(await metricSnapshot())
+    await writeJSON(path, {
+      durationMs: round(performance.now() - startedAt),
+      resources: coldResourceDelta(metricSamples),
+      failures,
+    })
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error))
+    await writeJSON(path, { durationMs: 0, resources: emptyResourceDelta(), failures })
+    throw error
+  } finally {
+    await context.close()
+    await browser.close()
+  }
+}
+
+async function runWorkload(path) {
+  const credentials = await readCredentials()
+  const coldPaths = JSON.parse(process.env.QUALIFICATION_COLD_RESULTS || '[]')
+  const coldResults = await Promise.all(coldPaths.map(async (coldPath) => JSON.parse(await readFile(coldPath, 'utf8'))))
+  if (coldResults.length !== policy.assumptions.samples.coldDashboardLoads) {
+    throw new Error(`performance workload received ${coldResults.length} cold samples, expected ${policy.assumptions.samples.coldDashboardLoads}`)
+  }
+  const coldFailures = coldResults.flatMap((result) => result.failures || [])
+  if (coldFailures.length > 0) throw new Error(`cold performance samples failed:\n${coldFailures.join('\n')}`)
+
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({ ignoreHTTPSErrors: true })
+  const page = await context.newPage({ viewport: { width: 1440, height: 960 } })
+  const controlled = { requests: 0, errors: 0, failures: [] }
+  const warmDashboardReadyMs = []
+  const filterToSettleMs = []
+  const tableInteractionMs = []
+  const governedQueryMs = []
+  const refreshMs = []
+  const concurrentQueryMs = []
+  let concurrentWaveMs = 0
+  const metricSamples = []
+
+  page.on('console', (message) => {
+    if (message.type() === 'error' || (message.type() === 'warning' && message.text().includes('[LeapView]'))) {
+      controlled.failures.push(`browser console: ${message.text()}`)
+      controlled.errors += 1
+    }
+  })
+  page.on('response', (response) => {
+    if (response.status() >= 400) {
+      controlled.failures.push(`browser response: ${response.status()} ${response.request().method()} ${response.url()}`)
+      controlled.errors += 1
+    }
+  })
+
+  try {
+    const dashboardURL = await loginAndResolveDashboard(page, credentials)
+    metricSamples.push(await metricSnapshot())
+
+    for (let index = 0; index < policy.assumptions.samples.warmDashboardLoads; index += 1) {
+      const startedAt = performance.now()
+      await page.goto(dashboardURL, { waitUntil: 'domcontentloaded', timeout: 60_000 })
+      await waitForDashboardIdle(page, 60_000)
+      warmDashboardReadyMs.push(round(performance.now() - startedAt))
+      controlled.requests += 1
+    }
+    metricSamples.push(await metricSnapshot())
+
+    const filterValues = ['SP', 'RJ', 'MG', 'PR']
+    const filter = page.getByRole('combobox', { name: 'State' })
+    for (let index = 0; index < policy.assumptions.samples.filterInteractions; index += 1) {
+      const value = filterValues[index % filterValues.length]
+      const generation = await dashboardGeneration(page)
+      const startedAt = performance.now()
+      await filter.selectOption({ label: value })
+      await waitForDashboardGeneration(page, generation, 30_000)
+      await page.getByRole('cell', { name: value, exact: true }).first().waitFor({ state: 'visible', timeout: 30_000 })
+      filterToSettleMs.push(round(performance.now() - startedAt))
+      controlled.requests += 1
+    }
+    metricSamples.push(await metricSnapshot())
+
+    const table = page.locator('lv-report-table')
+    const orderSort = table.getByRole('button', { name: /^Order/ })
+    for (let index = 0; index < policy.assumptions.samples.tableInteractions; index += 1) {
+      const previous = await tableSort(table)
+      const startedAt = performance.now()
+      await orderSort.click({ force: true })
+      await waitForTableSort(table, previous, 'order_id', 30_000)
+      tableInteractionMs.push(round(performance.now() - startedAt))
+      controlled.requests += 1
+    }
+    metricSamples.push(await metricSnapshot())
+
+    const queryBody = {
+      dimensions: [{ field: 'state' }],
+      measures: [{ field: 'order_count' }, { field: 'revenue' }],
+      limit: 10,
+    }
+    const queryURL = new URL('/api/v1/workspaces/evaluation/semantic-models/sales/query', baseURL).href
+    for (let index = 0; index < policy.assumptions.samples.governedQueries; index += 1) {
+      const startedAt = performance.now()
+      const response = await context.request.post(queryURL, {
+        headers: { Authorization: `Bearer ${credentials.publisherToken}` },
+        data: queryBody,
+      })
+      controlled.requests += 1
+      if (!response.ok()) {
+        controlled.errors += 1
+        controlled.failures.push(`governed query returned ${response.status()}`)
+      } else {
+        const result = await response.json()
+        if (!Array.isArray(result.rows) || result.rows.length !== 4) {
+          controlled.errors += 1
+          controlled.failures.push('governed query did not return four state rows')
+        }
+      }
+      governedQueryMs.push(round(performance.now() - startedAt))
+    }
+    metricSamples.push(await metricSnapshot())
+
+    const refreshURL = new URL('/api/v1/workspaces/evaluation/refresh-runs', baseURL).href
+    for (let index = 0; index < policy.assumptions.samples.refreshRuns; index += 1) {
+      const startedAt = performance.now()
+      const response = await context.request.post(refreshURL, {
+        headers: {
+          Authorization: `Bearer ${credentials.publisherToken}`,
+          'Idempotency-Key': `qualification-performance-refresh-${Date.now()}-${index}`,
+        },
+        data: { pipelineId: 'evaluation-refresh' },
+      })
+      controlled.requests += 1
+      if (!response.ok()) {
+        controlled.errors += 1
+        controlled.failures.push(`refresh creation returned ${response.status()}`)
+        continue
+      }
+      const refresh = await response.json()
+      const terminal = await waitForRefresh(context, refresh.id, credentials.publisherToken, controlled)
+      if (terminal.status !== 'succeeded') {
+        controlled.errors += 1
+        controlled.failures.push(`refresh ${refresh.id} ended ${terminal.status}`)
+      }
+      refreshMs.push(round(performance.now() - startedAt))
+    }
+    metricSamples.push(await metricSnapshot())
+
+    const concurrentStartedAt = performance.now()
+    const concurrentPromise = Promise.all(Array.from(
+      { length: policy.assumptions.samples.concurrentReaders },
+      async () => {
+        const requestStartedAt = performance.now()
+        const response = await context.request.post(queryURL, {
+          headers: { Authorization: `Bearer ${credentials.publisherToken}` },
+          data: queryBody,
+        })
+        controlled.requests += 1
+        if (!response.ok()) {
+          controlled.errors += 1
+          controlled.failures.push(`concurrent governed query returned ${response.status()}`)
+        } else {
+          const result = await response.json()
+          if (!Array.isArray(result.rows) || result.rows.length !== 4) {
+            controlled.errors += 1
+            controlled.failures.push('concurrent governed query did not return four state rows')
+          }
+        }
+        return round(performance.now() - requestStartedAt)
+      },
+    ))
+    metricSamples.push(await metricSnapshot())
+    const concurrent = await concurrentPromise
+    concurrentQueryMs.push(...concurrent)
+    concurrentWaveMs = round(performance.now() - concurrentStartedAt)
+
+    await page.waitForTimeout(2_000)
+    metricSamples.push(await metricSnapshot())
+  } finally {
+    await context.close()
+    await browser.close()
+  }
+
+  const coldResources = coldResults.map((result) => result.resources)
+  const resources = summarizeResources(metricSamples, coldResources)
+  await writeJSON(path, {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    policy,
+    latency: {
+      coldDashboardReadyMs: summarizeDurations(coldResults.map((result) => result.durationMs)),
+      warmDashboardReadyMs: summarizeDurations(warmDashboardReadyMs),
+      filterToSettleMs: summarizeDurations(filterToSettleMs),
+      tableInteractionMs: summarizeDurations(tableInteractionMs),
+      governedQueryMs: summarizeDurations(governedQueryMs),
+      refreshMs: summarizeDurations(refreshMs),
+      concurrentQueryMs: summarizeDurations(concurrentQueryMs),
+    },
+    reliability: {
+      requests: controlled.requests,
+      errors: controlled.errors,
+      failures: controlled.failures,
+    },
+    resources,
+    samples: {
+      coldDashboardReadyMs: coldResults.map((result) => result.durationMs),
+      warmDashboardReadyMs,
+      filterToSettleMs,
+      tableInteractionMs,
+      governedQueryMs,
+      refreshMs,
+      concurrentQueryMs,
+    },
+    concurrency: {
+      readers: policy.assumptions.samples.concurrentReaders,
+      waveMs: concurrentWaveMs,
+    },
+  })
+}
+
+async function finalizeReport(path) {
+  const report = JSON.parse(await readFile(path, 'utf8'))
+  const diskBefore = positiveEnvironment('QUALIFICATION_DISK_BEFORE_BYTES')
+  const diskAfter = positiveEnvironment('QUALIFICATION_DISK_AFTER_BYTES')
+  report.resources.temporaryDiskBeforeBytes = diskBefore
+  report.resources.temporaryDiskAfterBytes = diskAfter
+  report.resources.temporaryDiskGrowthBytes = Math.max(0, diskAfter - diskBefore)
+  report.environment = JSON.parse(process.env.QUALIFICATION_PERFORMANCE_ENVIRONMENT || '{}')
+  report.image = process.env.QUALIFICATION_IMAGE || ''
+  report.architecture = process.env.QUALIFICATION_ARCHITECTURE || ''
+
+  const absoluteFailures = evaluatePerformance(report, policy)
+  let baseline = null
+  let comparisonFailures = []
+  const baselinePath = process.env.QUALIFICATION_PERFORMANCE_BASELINE || ''
+  if (baselinePath) {
+    baseline = JSON.parse(await readFile(baselinePath, 'utf8'))
+    comparisonFailures = comparePerformance(report, baseline, policy)
+  }
+  const environmentFailures = []
+  if ((report.environment.logicalCPUs || 0) < policy.assumptions.minimumLogicalCPUs) {
+    environmentFailures.push(`runner has ${report.environment.logicalCPUs || 0} logical CPUs, requires ${policy.assumptions.minimumLogicalCPUs}`)
+  }
+  if ((report.environment.memoryBytes || 0) < policy.assumptions.minimumMemoryBytes) {
+    environmentFailures.push(`runner has ${report.environment.memoryBytes || 0} bytes of memory, requires ${policy.assumptions.minimumMemoryBytes}`)
+  }
+  const failures = [...environmentFailures, ...absoluteFailures, ...comparisonFailures, ...report.reliability.failures]
+  report.comparison = {
+    baseline: baselinePath || null,
+    maxRegressionRatio: policy.comparison.maxRegressionRatio,
+    minimumMeaningfulLatencyDeltaMs: policy.comparison.minimumMeaningfulLatencyDeltaMs,
+    failures: comparisonFailures,
+  }
+  report.assertions = {
+    environment: environmentFailures.length === 0,
+    absoluteBudgets: absoluteFailures.length === 0,
+    comparisonTolerance: comparisonFailures.length === 0,
+    errorFree: report.reliability.errors === 0 && report.reliability.failures.length === 0,
+  }
+  report.failures = failures
+  report.result = failures.length === 0 ? 'success' : 'failure'
+  await writeJSON(path, report)
+  if (failures.length > 0) throw new Error(`installed-candidate performance budgets failed:\n${failures.join('\n')}`)
+}
+
+async function loginAndResolveDashboard(page, credentials) {
+  await page.goto(baseURL, { waitUntil: 'domcontentloaded', timeout: 60_000 })
+  await page.getByLabel('Email').fill(credentials.email)
+  await page.getByLabel('Password').fill(credentials.qualificationPassword)
+  await page.getByLabel('Password').press('Enter')
+  const dashboard = page.getByRole('link', { name: /Five-minute Sales Evaluation/i })
+  await dashboard.waitFor({ state: 'visible', timeout: 60_000 })
+  const href = await dashboard.getAttribute('href')
+  if (!href) throw new Error('evaluation dashboard has no navigation target')
+  return new URL(href, baseURL).href
+}
+
+async function waitForDashboardIdle(page, timeoutMs) {
+  await page.locator('lv-dashboard-page').waitFor({ state: 'attached', timeout: timeoutMs })
+  await waitForDashboardStatus(
+    page,
+    (status) => status.generation > 0 && !status.loading,
+    timeoutMs,
+  )
+}
+
+async function dashboardGeneration(page) {
+  return page.locator('lv-dashboard-page').evaluate((element) => Number(element.status?.generation || 0))
+}
+
+async function waitForDashboardGeneration(page, previous, timeoutMs) {
+  await waitForDashboardStatus(
+    page,
+    (status) => status.generation > previous && !status.loading,
+    timeoutMs,
+  )
+}
+
+async function waitForDashboardStatus(page, predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const status = await page.locator('lv-dashboard-page').evaluate((element) => ({
+      generation: Number(element.status?.generation || 0),
+      loading: Boolean(element.status?.loading),
+    }))
+    if (predicate(status)) return status
+    await page.waitForTimeout(25)
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for dashboard status`)
+}
+
+async function tableSort(table) {
+  return table.evaluate((element) => ({
+    key: String(element.table?.sort?.key || ''),
+    direction: String(element.table?.sort?.direction || ''),
+  }))
+}
+
+async function waitForTableSort(table, previous, expectedKey, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const current = await tableSort(table)
+    if (current.key === expectedKey && (
+      current.key !== previous.key ||
+      current.direction !== previous.direction
+    )) {
+      return current
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for governed table sort`)
+}
+
+async function waitForRefresh(context, id, token, controlled) {
+  const url = new URL(`/api/v1/workspaces/evaluation/refresh-runs/${id}`, baseURL).href
+  const deadline = Date.now() + 60_000
+  while (Date.now() < deadline) {
+    const response = await context.request.get(url, { headers: { Authorization: `Bearer ${token}` } })
+    controlled.requests += 1
+    if (!response.ok()) {
+      controlled.errors += 1
+      controlled.failures.push(`refresh ${id} lookup returned ${response.status()}`)
+      throw new Error(`refresh ${id} lookup returned ${response.status()}`)
+    }
+    const refresh = await response.json()
+    if (['succeeded', 'failed', 'canceled'].includes(refresh.status)) return refresh
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`timed out waiting for refresh ${id}`)
+}
+
+async function metricSnapshot() {
+  if (!metricsToken) throw new Error('QUALIFICATION_METRICS_TOKEN is required')
+  const body = await requestMetrics()
+  const values = parsePrometheusMetrics(body)
+  return {
+    cpuSeconds: metric(values, 'process_cpu_seconds_total'),
+    residentMemoryBytes: metric(values, 'process_resident_memory_bytes'),
+    goroutines: metric(values, 'go_goroutines'),
+    openConnections: metric(values, 'leapview_duckdb_connections_open'),
+  }
+}
+
+function requestMetrics() {
+  const target = new URL(metricsURL)
+  if (target.protocol !== 'http:') throw new Error('qualification metrics URL must use http')
+  return new Promise((resolve, reject) => {
+    const operation = request({
+      protocol: target.protocol,
+      hostname: target.hostname,
+      port: target.port,
+      path: `${target.pathname}${target.search}`,
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${metricsToken}`,
+        Host: 'localhost',
+      },
+    }, (response) => {
+      const chunks = []
+      response.on('data', (chunk) => chunks.push(chunk))
+      response.on('end', () => {
+        if (response.statusCode !== 200) {
+          reject(new Error(`metrics returned ${response.statusCode}`))
+          return
+        }
+        resolve(Buffer.concat(chunks).toString('utf8'))
+      })
+    })
+    operation.setTimeout(5_000, () => operation.destroy(new Error('metrics request timed out')))
+    operation.on('error', reject)
+    operation.end()
+  })
+}
+
+function metric(values, name) {
+  const samples = values[name] || []
+  if (samples.length === 0) throw new Error(`metrics omitted ${name}`)
+  return Math.max(...samples)
+}
+
+function summarizeResources(samples, coldResources) {
+  if (samples.length === 0) throw new Error('performance workload captured no resource samples')
+  const first = samples[0]
+  const last = samples.at(-1)
+  const coldCPU = coldResources.reduce((sum, sample) => sum + sample.cpuSeconds, 0)
+  return {
+    peakResidentMemoryBytes: Math.max(
+      ...samples.map((sample) => sample.residentMemoryBytes),
+      ...coldResources.map((sample) => sample.peakResidentMemoryBytes),
+    ),
+    cpuSeconds: round(coldCPU + Math.max(0, last.cpuSeconds - first.cpuSeconds)),
+    temporaryDiskGrowthBytes: 0,
+    goroutinesBefore: first.goroutines,
+    goroutinesAfter: last.goroutines,
+    peakOpenConnections: Math.max(...samples.map((sample) => sample.openConnections)),
+    metricSamples: samples.length,
+  }
+}
+
+function coldResourceDelta(samples) {
+  const before = samples[0]
+  const after = samples.at(-1)
+  return {
+    cpuSeconds: round(Math.max(0, after.cpuSeconds - before.cpuSeconds)),
+    peakResidentMemoryBytes: Math.max(...samples.map((sample) => sample.residentMemoryBytes)),
+  }
+}
+
+function emptyResourceDelta() {
+  return { cpuSeconds: 0, peakResidentMemoryBytes: 0 }
+}
+
+async function readCredentials() {
+  const credentials = JSON.parse(await readFile(credentialsPath, 'utf8'))
+  if (!credentials.email || !credentials.qualificationPassword || !credentials.publisherToken) {
+    throw new Error('qualification performance credentials are incomplete')
+  }
+  return credentials
+}
+
+async function writeJSON(path, value) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+}
+
+function positiveEnvironment(name) {
+  const value = Number(process.env[name])
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${name} must be a non-negative number`)
+  return value
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100
+}

--- a/deploy/compose/qualification/performance.mjs
+++ b/deploy/compose/qualification/performance.mjs
@@ -488,7 +488,7 @@ async function readCredentials() {
 }
 
 async function writeJSON(path, value) {
-  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o644 })
 }
 
 function positiveEnvironment(name) {

--- a/deploy/compose/qualification/qualify.sh
+++ b/deploy/compose/qualification/qualify.sh
@@ -16,6 +16,7 @@ restore_root=""
 primary_project=""
 restore_project=""
 legacy_volume=""
+browser_container=""
 success=false
 
 mkdir -p "$evidence_dir"
@@ -24,6 +25,8 @@ rm -f \
   "$evidence_dir/browser-failure.png" \
   "$evidence_dir/compose.log" \
   "$evidence_dir/qualification-report.json" \
+  "$evidence_dir/performance-report.json" \
+  "$evidence_dir"/performance-cold-*.json \
   "$evidence_dir/recovery-events.json" \
   "$evidence_dir/recovery-report.json" \
   "$evidence_dir/restore-compose.log" \
@@ -74,6 +77,7 @@ set_qualification_job_lease() {
 cleanup() {
   local result=$?
   set +e
+  [[ -n "$browser_container" ]] && docker rm --force "$browser_container" >/dev/null 2>&1
   if [[ -n "$primary_project" ]]; then
     compose_in "$bundle_root" logs --no-color --tail 500 2>&1 | redact > "$evidence_dir/compose.log"
     compose_in "$bundle_root" down --volumes --remove-orphans >/dev/null 2>&1
@@ -258,9 +262,11 @@ docker exec \
     --environment qualification \
     --auto-approve >/dev/null
 
+metrics_token="$(sed -n 's/^LEAPVIEW_METRICS_BEARER_TOKEN=//p' "$bundle_root/leapview.env")"
 browser_image="mcr.microsoft.com/playwright:v1.61.1-noble"
 docker pull "$browser_image" >/dev/null
-docker run --rm --network host \
+browser_container="$(printf '%s-browser' "$primary_project")"
+docker run --detach --name "$browser_container" --network host \
   --volume "$qualification_root:/qualification:ro" \
   --volume "$credentials_file:/run/secrets/credentials.json:ro" \
   --volume "$evidence_dir:/evidence" \
@@ -268,7 +274,77 @@ docker run --rm --network host \
   --env QUALIFICATION_CREDENTIALS=/run/secrets/credentials.json \
   --env QUALIFICATION_SCREENSHOT=/evidence/browser-failure.png \
   "$browser_image" \
-  bash -euc 'cd /tmp; cp /qualification/package.json /qualification/browser.mjs .; npm install --no-audit --no-fund --silent; node browser.mjs'
+  sleep infinity >/dev/null
+docker exec "$browser_container" \
+  bash -euc '
+    mkdir -p /work
+    cd /work
+    cp /qualification/package.json \
+      /qualification/browser.mjs \
+      /qualification/performance.mjs \
+      /qualification/performance-policy.mjs \
+      /qualification/performance-policy.json \
+      .
+    npm install --no-audit --no-fund --silent
+  '
+docker exec "$browser_container" bash -euc 'cd /work; node browser.mjs'
+
+performance_disk_before="$(
+  docker exec "$container_id" du -sb /var/lib/leapview | awk '{print $1}'
+)"
+[[ "$performance_disk_before" =~ ^[0-9]+$ ]]
+performance_cold_count="$(jq -er '.assumptions.samples.coldDashboardLoads' "$qualification_root/performance-policy.json")"
+[[ "$performance_cold_count" =~ ^[1-9][0-9]*$ ]]
+performance_cold_paths=()
+for index in $(seq 1 "$performance_cold_count"); do
+  docker restart "$container_id" >/dev/null
+  for _ in $(seq 1 120); do
+    [[ "$(docker inspect --format '{{.State.Health.Status}}' "$container_id")" == healthy ]] && break
+    sleep 1
+  done
+  [[ "$(docker inspect --format '{{.State.Health.Status}}' "$container_id")" == healthy ]]
+  cold_path="/evidence/performance-cold-$index.json"
+  performance_cold_paths+=("$cold_path")
+  docker exec \
+    -e QUALIFICATION_METRICS_TOKEN="$metrics_token" \
+    "$browser_container" \
+    bash -euc "cd /work; node performance.mjs cold $cold_path"
+done
+performance_cold_json="$(
+  printf '%s\n' "${performance_cold_paths[@]}" |
+    jq --raw-input --slurp 'split("\n") | map(select(length > 0))'
+)"
+docker exec \
+  -e QUALIFICATION_METRICS_TOKEN="$metrics_token" \
+  -e QUALIFICATION_COLD_RESULTS="$performance_cold_json" \
+  "$browser_container" \
+  bash -euc 'cd /work; node performance.mjs workload /evidence/performance-report.json'
+performance_disk_after="$(
+  docker exec "$container_id" du -sb /var/lib/leapview | awk '{print $1}'
+)"
+[[ "$performance_disk_after" =~ ^[0-9]+$ ]]
+performance_environment="$(
+  jq -cn \
+    --arg runtime "Docker Engine $(docker version --format '{{.Server.Version}}')" \
+    --argjson logicalCPUs "$(docker info --format '{{.NCPU}}')" \
+    --argjson memoryBytes "$(docker info --format '{{.MemTotal}}')" \
+    --argjson orderRows "$(
+      docker exec "$container_id" sh -euc \
+        'rows=$(wc -l < /app/evaluation/data/orders.csv); printf "%s" "$((rows - 1))"'
+    )" \
+    '{runtime:$runtime,logicalCPUs:$logicalCPUs,memoryBytes:$memoryBytes,dataset:{orders:$orderRows}}'
+)"
+docker exec \
+  -e QUALIFICATION_DISK_BEFORE_BYTES="$performance_disk_before" \
+  -e QUALIFICATION_DISK_AFTER_BYTES="$performance_disk_after" \
+  -e QUALIFICATION_PERFORMANCE_ENVIRONMENT="$performance_environment" \
+  -e QUALIFICATION_IMAGE="$image_reference" \
+  -e QUALIFICATION_ARCHITECTURE="$(uname -m)" \
+  "$browser_container" \
+  bash -euc 'cd /work; node performance.mjs finalize /evidence/performance-report.json'
+rm -f "$evidence_dir"/performance-cold-*.json
+docker rm --force "$browser_container" >/dev/null
+browser_container=""
 
 query_body='{"dimensions":[{"field":"state"}],"measures":[{"field":"order_count"},{"field":"revenue"}],"limit":10}'
 query_output="$(
@@ -289,7 +365,6 @@ unauthorized_status="$(
 )"
 [[ "$unauthorized_status" == 401 ]]
 
-metrics_token="$(sed -n 's/^LEAPVIEW_METRICS_BEARER_TOKEN=//p' "$bundle_root/leapview.env")"
 unauthenticated_metrics="$(
   curl --silent --output /dev/null --write-out '%{http_code}' \
     --header 'Host: localhost' \
@@ -386,6 +461,7 @@ jq -n \
   --argjson elapsedSeconds "$elapsed_seconds" \
   --argjson oneTimeCredentials true \
   --argjson browserJourney true \
+  --argjson performanceBudgets true \
   --argjson governedQuery true \
   --argjson auditedDenial true \
   --argjson interruptionRecovery true \
@@ -402,6 +478,7 @@ jq -n \
     assertions:{
       oneTimeCredentials:$oneTimeCredentials,
       browserJourney:$browserJourney,
+      performanceBudgets:$performanceBudgets,
       governedQuery:$governedQuery,
       auditedDenial:$auditedDenial,
       interruptionRecovery:$interruptionRecovery,

--- a/deploy/compose/qualification/recover.sh
+++ b/deploy/compose/qualification/recover.sh
@@ -298,7 +298,9 @@ managedUpload=true
 
 stage="release finalization interruption"
 deploy_a_log="$evidence_dir/recovery-release-finalization.log"
-docker update --cpus 0.25 "$container_id" >/dev/null
+release_ids_before_file="$work_dir/release-ids-before.json"
+api GET "/api/v1/projects/$project_id/releases?limit=100" "$release_ids_before_file"
+release_ids_before="$(jq -c '[.items[].id]' "$release_ids_before_file")"
 run_in_candidate \
   leapview deploy \
   --project /var/lib/leapview/qualification-recovery/project-a/leapview.yaml \
@@ -312,7 +314,15 @@ releases="$work_dir/releases.json"
 release_id=""
 for _ in $(seq 1 1200); do
   if api GET "/api/v1/projects/$project_id/releases?limit=100" "$releases" 2>/dev/null; then
-    release_id="$(jq -r '[.items[] | select(.status == "validating")][0].id // empty' "$releases")"
+    release_id="$(
+      jq -r --argjson existing "$release_ids_before" '
+        [
+          .items[] |
+          select(.status == "draft" or .status == "validating") |
+          select(.id as $id | $existing | index($id) | not)
+        ][0].id // empty
+      ' "$releases"
+    )"
     [[ -n "$release_id" ]] && break
   fi
   if ! kill -0 "$deploy_a_pid" 2>/dev/null; then
@@ -321,14 +331,13 @@ for _ in $(seq 1 1200); do
   sleep 0.5
 done
 if [[ -z "$release_id" ]]; then
-  printf 'release did not remain validating long enough to observe the interruption boundary\n' >&2
+  printf 'new release did not remain draft or validating long enough to observe the interruption boundary\n' >&2
   exit 1
 fi
 interrupted_release_id="$release_id"
 kill_candidate
 wait_for_process_exit "$deploy_a_pid"
 
-docker update --cpus 0 "$container_id" >/dev/null
 run_in_candidate \
   leapview deploy \
   --project /var/lib/leapview/qualification-recovery/project-a/leapview.yaml \

--- a/deploy/compose/qualification/recover.sh
+++ b/deploy/compose/qualification/recover.sh
@@ -260,7 +260,7 @@ for _ in $(seq 1 1200); do
   if ! kill -0 "$sync_pid" 2>/dev/null; then
     break
   fi
-  sleep 0.025
+  sleep 0.5
 done
 [[ -n "$interrupted_session" && "$interrupted_offset" -gt 0 ]]
 kill_candidate
@@ -318,9 +318,13 @@ for _ in $(seq 1 1200); do
   if ! kill -0 "$deploy_a_pid" 2>/dev/null; then
     break
   fi
-  sleep 0.025
+  sleep 0.5
 done
-[[ -n "$release_id" ]]
+if [[ -z "$release_id" ]]; then
+  printf 'release did not remain validating long enough to observe the interruption boundary\n' >&2
+  exit 1
+fi
+interrupted_release_id="$release_id"
 kill_candidate
 wait_for_process_exit "$deploy_a_pid"
 
@@ -333,8 +337,8 @@ run_in_candidate \
   --auto-approve \
   >> "$deploy_a_log" 2>&1
 release_after="$work_dir/release-after.json"
-wait_for_json "/api/v1/projects/$project_id/releases/$release_id" '.status == "ready"' "$release_after"
-wait_for_json "/api/v1/projects/$project_id/releases/$release_id/events?limit=100" '
+wait_for_json "/api/v1/projects/$project_id/releases/$interrupted_release_id" '.status == "ready"' "$release_after"
+wait_for_json "/api/v1/projects/$project_id/releases/$interrupted_release_id/events?limit=100" '
   ([.items[].event] | index("release.created")) != null and
   ([.items[].event] | index("release.validating")) != null and
   ([.items[].event] | index("release.ready")) != null
@@ -365,20 +369,24 @@ for _ in $(seq 1 1200); do
   if ! kill -0 "$deploy_b_pid" 2>/dev/null; then
     break
   fi
-  sleep 0.025
+  sleep 0.5
 done
-[[ -n "$deployment_id" ]]
+if [[ -z "$deployment_id" ]]; then
+  printf 'deployment did not remain queued or running long enough to observe the interruption boundary\n' >&2
+  exit 1
+fi
+interrupted_deployment_id="$deployment_id"
 kill_candidate
 wait_for_process_exit "$deploy_b_pid"
 
 docker update --cpus 0 "$container_id" >/dev/null
 deployment_after="$work_dir/deployment-after.json"
 wait_for_json \
-  "/api/v1/projects/$project_id/deployments/$deployment_id" \
+  "/api/v1/projects/$project_id/deployments/$interrupted_deployment_id" \
   '.status == "active"' \
   "$deployment_after"
 wait_for_json \
-  "/api/v1/projects/$project_id/deployments/$deployment_id/events?limit=100" \
+  "/api/v1/projects/$project_id/deployments/$interrupted_deployment_id/events?limit=100" \
   '
   ([.items[].event] | index("deployment.queued")) != null and
   ([.items[].event] | index("deployment.active")) != null

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:table-selection": "bun test web/components/dashboard/table/selection.test.ts",
     "test:interaction-selection": "bun test web/components/dashboard/interaction-selection.test.ts web/components/dashboard/visualization/interaction-command.test.ts web/components/dashboard/visualization/adapters/echarts.test.ts web/components/dashboard/visualization/adapters/maplibre.test.ts web/components/dashboard/table/selection.test.ts web/components/dashboard/filters/filter-controller.test.ts",
     "test:movielens-performance-harness": "bun test scripts/movielens_performance.test.ts",
+    "test:qualification-performance-policy": "node --test deploy/compose/qualification/performance-policy.test.mjs",
     "test:visual-modal": "playwright install chromium && bun scripts/build_test_assets.ts visual-modal && bun test web/components/dashboard/visual-modal-focus.test.ts web/components/dashboard/visual-modal.dom.test.ts",
     "test:catalog-page": "playwright install chromium && bun scripts/build_test_assets.ts catalog-page && bun test web/components/app/catalog-page.dom.test.ts",
     "test:dashboard-page": "playwright install chromium && bun scripts/build_test_assets.ts dashboard-page && bun test web/components/dashboard/dashboard-page.dom.test.ts",


### PR DESCRIPTION
## Summary

- add a machine-readable installed-candidate performance policy and retained report
- measure restart-cold and warm dashboard readiness, filter settling, governed table sorting, governed queries, refresh/materialization, and eight concurrent readers
- enforce zero-error, RSS, CPU, temporary-disk, goroutine, and DuckDB-connection budgets
- exercise managed upload, release finalization, deployment activation, refresh, SSE reconnect, backup, and restore interruption recovery
- keep metrics and interruption-boundary polling within shipped rate limits and identify release faults from newly persisted draft/validating releases
- retain evidence from release and installed-candidate workflows and document the supplementary MovieLens scale path

## Hosted immutable-candidate evidence

[Release workflow attempt 3](https://github.com/Yacobolo/leapview/actions/runs/30355993212/attempts/3) qualified revision `1f5a65697b85209e0e9797f6e5accd222705bf29` on native amd64 and arm64 runners against:

`ghcr.io/yacobolo/leapview@sha256:1890db78a1e325fef21839021b01571c720de49cdc10b34c62143502f29ab2f9`

| Measure | amd64 | arm64 |
| --- | ---: | ---: |
| Full qualification | 373s | 324s |
| Cold dashboard p95 | 918.14ms | 895.36ms |
| Warm dashboard p95 | 866.39ms | 828.70ms |
| Filter-to-settle p95 | 682.95ms | 659.38ms |
| Governed table-sort p95 | 241.53ms | 279.66ms |
| Governed query p95 | 296.00ms | 305.45ms |
| Refresh/materialization p95 | 419.98ms | 422.85ms |
| Eight-reader query p95 | 197.96ms | 258.10ms |
| Peak RSS | 420,122,624 bytes | 357,494,784 bytes |
| CPU | 19.68s | 18.57s |
| Temporary disk growth | 5,244,274 bytes | 5,248,370 bytes |
| Goroutines | 34 → 38 | 33 → 38 |
| Peak open DuckDB connections | 5 | 5 |

- controlled requests: 46 per architecture, zero errors
- recovery matrix: 8/8 assertions per architecture
- recovery disk growth: 3,740 KiB amd64; 3,768 KiB arm64
- stale recovery, restore, backup, and checkpoint artifacts: zero
- evaluator, one-time credentials, governed denial/audit, restart persistence, v0.1 policy, backup, and isolated restore: all passed

## Local immutable-candidate evidence

The Darwin arm64 bundle also passed the complete evaluator and recovery journey in 569s under an idle 8-CPU/8-GiB Docker environment: every performance assertion passed, 46 controlled requests had zero errors, the recovery matrix passed 8/8, and bounded recovery growth was 4,016 KiB with zero stale artifacts.

## Verification

- `task ci`
- PR CI: [all 19 jobs green](https://github.com/Yacobolo/leapview/actions/runs/30355969010)
- hosted native amd64 and arm64 installed-candidate qualification
- local full installed-candidate qualification
- red-green policy and Compose contract tests

## Accepted limitations

- The release gate uses the bundled 24-order Olist evaluator for deterministic installation and interaction coverage; MovieLens remains the supplementary scale harness.
- Absolute timings are runner-dependent, so every report records hardware/runtime assumptions.
- A future accepted candidate report can be supplied as the comparison baseline; the policy then enforces both every absolute ceiling and a 1.25x/50ms regression tolerance.

Closes LEA-52
