### PR TITLE
ci: add selective monorepo planning

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -1,0 +1,87 @@
+name: CI health
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  report:
+    name: Weekly CI health report
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Set up Depot
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+
+      - name: Read Depot build usage
+        run: depot list builds --output json --project 9x73gxjcf5 > depot-builds.json
+
+      - name: Build trailing health report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          go run ./internal/app/tools/cireport
+          --repo "$GITHUB_REPOSITORY"
+          --days 7
+          --depot-builds depot-builds.json
+          --output ci-health.json
+          --summary ci-health.md
+
+      - name: Publish workflow summary
+        run: cat ci-health.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload health report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-health
+          retention-days: 30
+          if-no-files-found: error
+          path: |
+            ci-health.json
+            ci-health.md
+
+      - name: Open or update CI health alert
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          issue="$(
+            gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --search '"CI health thresholds exceeded" in:title' \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+          alerts="$(jq '.alerts | length' ci-health.json)"
+          if [ "$alerts" -gt 0 ]; then
+            if [ -n "$issue" ]; then
+              gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body-file ci-health.md
+            else
+              gh issue create \
+                --repo "$GITHUB_REPOSITORY" \
+                --title "CI health thresholds exceeded" \
+                --body-file ci-health.md
+            fi
+          elif [ -n "$issue" ]; then
+            gh issue comment "$issue" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "The latest weekly report is healthy; closing this alert."
+            gh issue close "$issue" --repo "$GITHUB_REPOSITORY"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,13 @@ name: CI
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
   push:
     branches:
       - main
@@ -18,10 +25,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify:
+    name: Classify changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      prepare: ${{ steps.plan.outputs.prepare }}
+      frontend_prepare: ${{ steps.plan.outputs.frontend_prepare }}
+      docs: ${{ steps.plan.outputs.docs }}
+      go_tests: ${{ steps.plan.outputs.go_tests }}
+      frontend_tests: ${{ steps.plan.outputs.frontend_tests }}
+      go_analysis: ${{ steps.plan.outputs.go_analysis }}
+      ui_route_qa: ${{ steps.plan.outputs.ui_route_qa }}
+      node_audit: ${{ steps.plan.outputs.node_audit }}
+      go_vuln: ${{ steps.plan.outputs.go_vuln }}
+      site_image: ${{ steps.plan.outputs.site_image }}
+      production_image: ${{ steps.plan.outputs.production_image }}
+      deployment_contracts: ${{ steps.plan.outputs.deployment_contracts }}
+      go_matrix: ${{ steps.plan.outputs.go_matrix }}
+      frontend_matrix: ${{ steps.plan.outputs.frontend_matrix }}
+      effective_json: ${{ steps.plan.outputs.effective_json }}
+      nominal_json: ${{ steps.plan.outputs.nominal_json }}
+      audit: ${{ steps.plan.outputs.audit }}
+
+    steps:
+      - name: Checkout with change history
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Plan CI jobs
+        id: plan
+        env:
+          CI_EVENT: ${{ github.event_name }}
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+          CI_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: >-
+          go run ./internal/app/tools/ciplan
+          --event "$CI_EVENT"
+          --base "$CI_BASE_SHA"
+          --head "$CI_HEAD_SHA"
+          --pr-number "$CI_PR_NUMBER"
+          --labels "$CI_PR_LABELS"
+          --output ci-plan.json
+          --github-output "$GITHUB_OUTPUT"
+          --github-summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload CI plan
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-plan
+          retention-days: 30
+          if-no-files-found: error
+          path: ci-plan.json
+
   prepare:
     name: Prepare generated assets
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    needs: classify
+    if: ${{ !cancelled() && needs.classify.outputs.prepare == 'true' }}
 
     steps:
       - name: Checkout
@@ -211,25 +282,97 @@ jobs:
             static/
             site/static/
 
+  frontend-prepare:
+    name: Prepare frontend assets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: classify
+    if: ${{ !cancelled() && needs.classify.outputs.frontend_prepare == 'true' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.7
+
+      - name: Install Task
+        run: |
+          go install github.com/go-task/task/v3/cmd/task@v3.50.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Generate frontend contracts and assets
+        run: task ci:prepare:frontend
+
+      - name: Upload frontend assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: frontend-assets
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            web/generated/
+            static/
+
+  docs:
+    name: Documentation and public site
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    needs: classify
+    if: ${{ !cancelled() && needs.classify.outputs.docs == 'true' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.7
+
+      - name: Install Task
+        run: |
+          go install github.com/go-task/task/v3/cmd/task@v3.50.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Restore pinned documentation basemap
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .data/map-assets
+          key: map-assets-${{ runner.os }}-${{ hashFiles('internal/app/tools/mapassets/main.go', 'internal/dashboard/visualization/mapasset/*.go', 'static/map-assets/leapview-streets/style.json') }}
+
+      - name: Install pinned documentation basemap
+        run: go run ./internal/app/tools/mapassets --out .data/map-assets
+
+      - name: Install browser dependencies
+        run: bunx playwright install --with-deps chromium
+
+      - name: Validate documentation and site
+        run: task ci:test:docs-site
+
   go-tests:
     name: Go tests (${{ matrix.name }})
     runs-on: ubuntu-24.04
     timeout-minutes: 35
-    needs: prepare
+    needs: [classify, prepare]
+    if: ${{ !cancelled() && needs.classify.outputs.go_tests == 'true' && needs.prepare.result == 'success' }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: packages
-            app_shard: ''
-          - name: app 1/4
-            app_shard: '0'
-          - name: app 2/4
-            app_shard: '1'
-          - name: app 3/4
-            app_shard: '2'
-          - name: app 4/4
-            app_shard: '3'
+      matrix: ${{ fromJSON(needs.classify.outputs.go_matrix) }}
 
     steps:
       - name: Checkout
@@ -289,6 +432,13 @@ jobs:
     name: Public site image
     runs-on: ubuntu-24.04
     timeout-minutes: 25
+    needs: classify
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.classify.outputs.site_image == 'true' &&
+        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      }}
     permissions:
       contents: read
       id-token: write
@@ -300,10 +450,40 @@ jobs:
       - name: Set up Depot
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
 
-      - name: Build production site image
+      - name: Build production site image with Depot
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1
         with:
           project: 9x73gxjcf5
+          context: .
+          file: Dockerfile.site
+          platforms: linux/amd64
+          tags: leapview-site:ci
+
+  site-image-fork:
+    name: Public site image (external pull request)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    needs: classify
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.classify.outputs.site_image == 'true' &&
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository
+      }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build production site image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
           context: .
           file: Dockerfile.site
           platforms: linux/amd64
@@ -313,54 +493,16 @@ jobs:
     name: Frontend tests (${{ matrix.name }})
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    needs: prepare
+    needs: [classify, prepare, frontend-prepare]
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.classify.outputs.frontend_tests == 'true' &&
+        (needs.prepare.result == 'success' || needs['frontend-prepare'].result == 'success')
+      }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: core
-            tests: |
-              bun run test:primer-primitives
-              bun run test:primer-alignment
-              bun run test:theme
-              bun run test:datastar-lit
-              bun run test:app-shell
-              bun run typecheck:app
-              bun run typecheck:contracts
-              bun run test:production-assets
-              bun run test:movielens-performance-harness
-              bun run test:qualification-performance-policy
-          - name: reports
-            tests: |
-              bun run test:interaction-selection
-              bun run test:record-table
-              bun run test:visual-modal
-              bun run test:catalog-page
-              bun run test:dashboard-page
-              bun run test:windowed-table
-              bun run test:filter-menu
-          - name: chat
-            tests: |
-              bun run test:chat-composer
-              bun run test:chat-page
-              bun run test:chat-thread
-              bun run test:code-block
-              bun run test:markdown-view
-          - name: workspace
-            tests: |
-              bun run test:workspace-page
-              bun run test:data-explorer
-              bun run test:admin-page
-              bun run test:code-editor
-              bun run test:login-page
-              bun run test:asset-lineage
-              bun run test:semantic-model-graph
-              bun run test:datastar-inspector
-              bun run test:topology-background
-          - name: site
-            tests: |
-              bun run test:docs-diagrams
-              bun run test:site
+      matrix: ${{ fromJSON(needs.classify.outputs.frontend_matrix) }}
 
     steps:
       - name: Checkout
@@ -396,19 +538,79 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Download generated assets
+        if: needs.prepare.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: generated-assets
           path: .
 
+      - name: Download frontend assets
+        if: needs['frontend-prepare'].result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: frontend-assets
+          path: .
+
       - name: Run frontend tests
-        run: ${{ matrix.tests }}
+        env:
+          FRONTEND_SHARD: ${{ matrix.name }}
+        run: |
+          case "$FRONTEND_SHARD" in
+            core)
+              bun run test:primer-primitives
+              bun run test:primer-alignment
+              bun run test:theme
+              bun run test:datastar-lit
+              bun run test:app-shell
+              bun run typecheck:app
+              bun run typecheck:contracts
+              bun run test:production-assets
+              bun run test:movielens-performance-harness
+              bun run test:qualification-performance-policy
+              ;;
+            reports)
+              bun run test:interaction-selection
+              bun run test:record-table
+              bun run test:visual-modal
+              bun run test:catalog-page
+              bun run test:dashboard-page
+              bun run test:windowed-table
+              bun run test:filter-menu
+              ;;
+            chat)
+              bun run test:chat-composer
+              bun run test:chat-page
+              bun run test:chat-thread
+              bun run test:code-block
+              bun run test:markdown-view
+              ;;
+            workspace)
+              bun run test:workspace-page
+              bun run test:data-explorer
+              bun run test:admin-page
+              bun run test:code-editor
+              bun run test:login-page
+              bun run test:asset-lineage
+              bun run test:semantic-model-graph
+              bun run test:datastar-inspector
+              bun run test:topology-background
+              ;;
+            site)
+              bun run test:docs-diagrams
+              bun run test:site
+              ;;
+            *)
+              printf 'unknown frontend shard %s\n' "$FRONTEND_SHARD" >&2
+              exit 1
+              ;;
+          esac
 
   go-analysis:
     name: Go static and race analysis
     runs-on: ubuntu-24.04
     timeout-minutes: 25
-    needs: prepare
+    needs: [classify, prepare]
+    if: ${{ !cancelled() && needs.classify.outputs.go_analysis == 'true' && needs.prepare.result == 'success' }}
 
     steps:
       - name: Checkout
@@ -436,7 +638,8 @@ jobs:
     name: UI route QA
     runs-on: ubuntu-24.04
     timeout-minutes: 25
-    needs: prepare
+    needs: [classify, prepare]
+    if: ${{ !cancelled() && needs.classify.outputs.ui_route_qa == 'true' && needs.prepare.result == 'success' }}
 
     steps:
       - name: Checkout
@@ -482,6 +685,8 @@ jobs:
     name: JavaScript dependency audit
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: classify
+    if: ${{ !cancelled() && needs.classify.outputs.node_audit == 'true' }}
 
     steps:
       - name: Checkout
@@ -502,7 +707,8 @@ jobs:
     name: Go vulnerability scan
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    needs: prepare
+    needs: [classify, prepare]
+    if: ${{ !cancelled() && needs.classify.outputs.go_vuln == 'true' && needs.prepare.result == 'success' }}
 
     steps:
       - name: Checkout
@@ -527,6 +733,13 @@ jobs:
     name: Production image
     runs-on: ubuntu-24.04
     timeout-minutes: 35
+    needs: classify
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.classify.outputs.production_image == 'true' &&
+        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      }}
     permissions:
       contents: read
       id-token: write
@@ -538,10 +751,44 @@ jobs:
       - name: Set up Depot
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
 
-      - name: Build production image
+      - name: Build production image with Depot
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1
         with:
           project: 9x73gxjcf5
+          context: .
+          platforms: linux/amd64
+          load: true
+          pull: true
+          tags: leapview:ci
+
+      - name: Smoke test production image
+        run: ./scripts/smoke_production_image.sh leapview:ci
+
+  production-image-fork:
+    name: Production image (external pull request)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs: classify
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.classify.outputs.production_image == 'true' &&
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository
+      }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build production image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
           context: .
           platforms: linux/amd64
           load: true
@@ -555,6 +802,8 @@ jobs:
     name: Deployment contracts
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    needs: classify
+    if: ${{ !cancelled() && needs.classify.outputs.deployment_contracts == 'true' }}
 
     steps:
       - name: Checkout
@@ -574,8 +823,16 @@ jobs:
           terraform_version: 1.15.8
           terraform_wrapper: false
 
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.7
+
       - name: Test deployment lifecycle
         run: go test ./deploy/compose ./deploy/hetzner
+
+      - name: Test deployment performance policy
+        run: bun run test:qualification-performance-policy
 
       - name: Lint workflow definitions
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
@@ -603,10 +860,10 @@ jobs:
 
   candidate-image:
     name: Publish candidate image
-    if: github.event_name == 'workflow_dispatch'
+    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' && needs.prepare.result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    needs: prepare
+    needs: [classify, prepare]
     permissions:
       contents: read
       packages: write
@@ -659,3 +916,108 @@ jobs:
 
       - name: Record immutable candidate reference
         run: echo 'ghcr.io/yacobolo/leapview@${{ steps.publish.outputs.digest }}' >> "$GITHUB_STEP_SUMMARY"
+
+  ci-gate:
+    name: CI gate
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs:
+      - classify
+      - prepare
+      - frontend-prepare
+      - docs
+      - go-tests
+      - site-image
+      - site-image-fork
+      - frontend-tests
+      - go-analysis
+      - ui-route-qa
+      - node-audit
+      - go-vuln
+      - production-image
+      - production-image-fork
+      - deployment-contracts
+      - candidate-image
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Download CI plan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ci-plan
+          path: .
+
+      - name: Record job results
+        env:
+          RESULT_PREPARE: ${{ needs.prepare.result }}
+          RESULT_FRONTEND_PREPARE: ${{ needs['frontend-prepare'].result }}
+          RESULT_DOCS: ${{ needs.docs.result }}
+          RESULT_GO_TESTS: ${{ needs['go-tests'].result }}
+          RESULT_SITE_IMAGE: ${{ needs['site-image'].result }}
+          RESULT_SITE_IMAGE_FORK: ${{ needs['site-image-fork'].result }}
+          RESULT_FRONTEND_TESTS: ${{ needs['frontend-tests'].result }}
+          RESULT_GO_ANALYSIS: ${{ needs['go-analysis'].result }}
+          RESULT_UI_ROUTE_QA: ${{ needs['ui-route-qa'].result }}
+          RESULT_NODE_AUDIT: ${{ needs['node-audit'].result }}
+          RESULT_GO_VULN: ${{ needs['go-vuln'].result }}
+          RESULT_PRODUCTION_IMAGE: ${{ needs['production-image'].result }}
+          RESULT_PRODUCTION_IMAGE_FORK: ${{ needs['production-image-fork'].result }}
+          RESULT_DEPLOYMENT_CONTRACTS: ${{ needs['deployment-contracts'].result }}
+        run: |
+          if [ "$RESULT_SITE_IMAGE" = "skipped" ]; then
+            RESULT_SITE_IMAGE="$RESULT_SITE_IMAGE_FORK"
+          fi
+          if [ "$RESULT_PRODUCTION_IMAGE" = "skipped" ]; then
+            RESULT_PRODUCTION_IMAGE="$RESULT_PRODUCTION_IMAGE_FORK"
+          fi
+          jq -n \
+            --arg prepare "$RESULT_PREPARE" \
+            --arg frontend_prepare "$RESULT_FRONTEND_PREPARE" \
+            --arg docs "$RESULT_DOCS" \
+            --arg go_tests "$RESULT_GO_TESTS" \
+            --arg site_image "$RESULT_SITE_IMAGE" \
+            --arg frontend_tests "$RESULT_FRONTEND_TESTS" \
+            --arg go_analysis "$RESULT_GO_ANALYSIS" \
+            --arg ui_route_qa "$RESULT_UI_ROUTE_QA" \
+            --arg node_audit "$RESULT_NODE_AUDIT" \
+            --arg go_vuln "$RESULT_GO_VULN" \
+            --arg production_image "$RESULT_PRODUCTION_IMAGE" \
+            --arg deployment_contracts "$RESULT_DEPLOYMENT_CONTRACTS" \
+            '{
+              "prepare": $prepare,
+              "frontend-prepare": $frontend_prepare,
+              "docs": $docs,
+              "go-tests": $go_tests,
+              "site-image": $site_image,
+              "frontend-tests": $frontend_tests,
+              "go-analysis": $go_analysis,
+              "ui-route-qa": $ui_route_qa,
+              "node-audit": $node_audit,
+              "go-vuln": $go_vuln,
+              "production-image": $production_image,
+              "deployment-contracts": $deployment_contracts
+            }' > ci-results.json
+
+      - name: Enforce selected CI plan
+        run: >-
+          go run ./internal/app/tools/ciplan gate
+          --plan ci-plan.json
+          --results ci-results.json
+          --github-summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce candidate publication
+        if: ${{ github.event_name == 'workflow_dispatch' && needs['candidate-image'].result != 'success' }}
+        env:
+          CANDIDATE_RESULT: ${{ needs['candidate-image'].result }}
+        run: |
+          printf 'candidate image concluded %s\n' "$CANDIDATE_RESULT" >&2
+          exit 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -121,6 +121,25 @@ tasks:
       - task: node:deps
       - bun run build:site
 
+  ci:prepare:frontend:
+    desc: Generate only the contracts and assets required by frontend CI
+    cmds:
+      - task: ui-signals:generate
+      - task: visualization-ir:generate
+      - task: build
+
+  ci:test:docs-site:
+    desc: Validate authored documentation and the independently deployable public site
+    cmds:
+      - task: docs:generate
+      - task: docs:check
+      - |
+        changed="$(git status --porcelain -- .env.example docs/api/openapi.yaml docs/llms.txt docs/reference/agent-tools internal/agent/contracts schemas/config schemas/json)"
+        test -z "$changed" || { printf 'public contract snapshots are stale:\n%s\n' "$changed" >&2; exit 1; }
+      - task: site:build
+      - bun run test:docs-diagrams
+      - bun run test:site
+
   site:binary:
     desc: Build the independently deployable public site from generated documentation
     cmds:

--- a/internal/app/tools/ciplan/main.go
+++ b/internal/app/tools/ciplan/main.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	platformci "github.com/Yacobolo/leapview/internal/platform/ci"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "gate" {
+		if err := runGate(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+	if err := runPlan(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func runPlan(args []string) error {
+	flags := flag.NewFlagSet("ciplan", flag.ContinueOnError)
+	event := flags.String("event", "", "GitHub event name")
+	base := flags.String("base", "", "base commit")
+	head := flags.String("head", "", "head commit")
+	prNumber := flags.Int("pr-number", 0, "pull request number")
+	labels := flags.String("labels", "", "comma-separated pull request labels")
+	output := flags.String("output", "ci-plan.json", "plan JSON output")
+	githubOutput := flags.String("github-output", "", "GitHub Actions output file")
+	githubSummary := flags.String("github-summary", "", "GitHub Actions summary file")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *event == "" {
+		return errors.New("--event is required")
+	}
+
+	var changes []platformci.Change
+	if *event == "pull_request" {
+		if *base == "" || *head == "" {
+			return errors.New("--base and --head are required for pull_request")
+		}
+		diff, err := gitDiff(*base, *head)
+		if err != nil {
+			return err
+		}
+		changes, err = platformci.ParseNameStatusZ(diff)
+		if err != nil {
+			return err
+		}
+	}
+	plan := platformci.PlanChanges(platformci.Input{
+		Event:             *event,
+		PullRequestNumber: *prNumber,
+		Labels:            splitLabels(*labels),
+	}, changes)
+	planJSON, err := plan.JSON()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(*output, append(planJSON, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write plan: %w", err)
+	}
+	if *githubOutput != "" {
+		if err := writeGitHubOutputs(*githubOutput, plan); err != nil {
+			return err
+		}
+	}
+	if *githubSummary != "" {
+		if err := appendSummary(*githubSummary, plan); err != nil {
+			return err
+		}
+	}
+	fmt.Println(string(planJSON))
+	return nil
+}
+
+func runGate(args []string) error {
+	flags := flag.NewFlagSet("ciplan gate", flag.ContinueOnError)
+	planPath := flags.String("plan", "ci-plan.json", "plan JSON")
+	resultsPath := flags.String("results", "", "job results JSON")
+	githubSummary := flags.String("github-summary", "", "GitHub Actions summary file")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *resultsPath == "" {
+		return errors.New("--results is required")
+	}
+	var plan platformci.Plan
+	if err := readJSON(*planPath, &plan); err != nil {
+		return fmt.Errorf("read plan: %w", err)
+	}
+	results := map[string]string{}
+	if err := readJSON(*resultsPath, &results); err != nil {
+		return fmt.Errorf("read results: %w", err)
+	}
+	report := platformci.EvaluatePlanGate(plan, results)
+	if *githubSummary != "" {
+		if err := appendGateSummary(*githubSummary, report); err != nil {
+			return err
+		}
+	}
+	if report.OK {
+		fmt.Println("CI gate passed")
+		return nil
+	}
+	message := "CI gate rejected workflow:\n- " + strings.Join(report.Problems, "\n- ")
+	if len(report.AuditMisses) > 0 {
+		message += "\nselection audit misses: " + strings.Join(report.AuditMisses, ", ")
+	}
+	return errors.New(message)
+}
+
+func gitDiff(base, head string) ([]byte, error) {
+	command := exec.Command("git", "diff", "--name-status", "-z", "--find-renames", base, head)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff %s..%s: %w: %s", base, head, err, strings.TrimSpace(stderr.String()))
+	}
+	return output, nil
+}
+
+func writeGitHubOutputs(filename string, plan platformci.Plan) error {
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open GitHub output: %w", err)
+	}
+	defer file.Close()
+
+	selected := plan.Effective.Selected()
+	for _, name := range []string{
+		"prepare", "frontend-prepare", "docs", "go-tests", "frontend-tests",
+		"go-analysis", "ui-route-qa", "node-audit", "go-vuln", "site-image",
+		"production-image", "deployment-contracts",
+	} {
+		key := strings.ReplaceAll(name, "-", "_")
+		if _, err := fmt.Fprintf(file, "%s=%s\n", key, strconv.FormatBool(selected[name])); err != nil {
+			return err
+		}
+	}
+	goInclude := plan.Effective.GoMatrix
+	if len(goInclude) == 0 {
+		goInclude = []platformci.GoShard{{Name: "not-selected"}}
+	}
+	goMatrix, err := json.Marshal(map[string]any{"include": goInclude})
+	if err != nil {
+		return err
+	}
+	frontendInclude := make([]map[string]string, 0, len(plan.Effective.Frontend))
+	for _, name := range plan.Effective.Frontend {
+		frontendInclude = append(frontendInclude, map[string]string{"name": name})
+	}
+	if len(frontendInclude) == 0 {
+		frontendInclude = append(frontendInclude, map[string]string{"name": "not-selected"})
+	}
+	frontendMatrix, err := json.Marshal(map[string]any{"include": frontendInclude})
+	if err != nil {
+		return err
+	}
+	effective, err := json.Marshal(plan.Effective)
+	if err != nil {
+		return err
+	}
+	nominal, err := json.Marshal(plan.Nominal)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(
+		file,
+		"go_matrix=%s\nfrontend_matrix=%s\neffective_json=%s\nnominal_json=%s\naudit=%s\n",
+		goMatrix,
+		frontendMatrix,
+		effective,
+		nominal,
+		strconv.FormatBool(plan.Audit),
+	)
+	return err
+}
+
+func appendSummary(filename string, plan platformci.Plan) error {
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open GitHub summary: %w", err)
+	}
+	defer file.Close()
+
+	selected := plan.Effective.Selected()
+	var run, skip []string
+	for _, name := range sortedJobNames(selected) {
+		if selected[name] {
+			run = append(run, name)
+		} else {
+			skip = append(skip, name)
+		}
+	}
+	_, err = fmt.Fprintf(file,
+		"## CI plan\n\n**Reason:** %s\n\n**Audit:** %t\n\n**Run:** %s\n\n**Skip:** %s\n\n",
+		plan.Reason,
+		plan.Audit,
+		strings.Join(run, ", "),
+		strings.Join(skip, ", "),
+	)
+	return err
+}
+
+func appendGateSummary(filename string, report platformci.GateReport) error {
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if report.OK {
+		_, err = fmt.Fprintln(file, "## CI gate\n\nAll selected jobs passed.")
+		return err
+	}
+	_, err = fmt.Fprintf(file, "## CI gate\n\n- %s\n", strings.Join(report.Problems, "\n- "))
+	if err == nil && len(report.AuditMisses) > 0 {
+		_, err = fmt.Fprintf(file, "\n**Selection audit misses:** %s\n", strings.Join(report.AuditMisses, ", "))
+	}
+	return err
+}
+
+func readJSON(filename string, destination any) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, destination)
+}
+
+func splitLabels(value string) []string {
+	var labels []string
+	for _, label := range strings.Split(value, ",") {
+		if label = strings.TrimSpace(label); label != "" {
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}
+
+func sortedJobNames(selected map[string]bool) []string {
+	order := []string{
+		"prepare", "frontend-prepare", "docs", "go-tests", "frontend-tests",
+		"go-analysis", "ui-route-qa", "node-audit", "go-vuln", "site-image",
+		"production-image", "deployment-contracts",
+	}
+	return order
+}

--- a/internal/app/tools/ciplan/main_test.go
+++ b/internal/app/tools/ciplan/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	platformci "github.com/Yacobolo/leapview/internal/platform/ci"
+)
+
+func TestWriteGitHubOutputsUsesNonEmptySentinelMatrices(t *testing.T) {
+	t.Parallel()
+
+	output := filepath.Join(t.TempDir(), "github-output")
+	if err := os.WriteFile(output, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeGitHubOutputs(output, platformci.Plan{}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`go_matrix={"include":[{"name":"not-selected","app_shard":""}]}`,
+		`frontend_matrix={"include":[{"name":"not-selected"}]}`,
+		"go_tests=false",
+		"frontend_tests=false",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("GitHub output missing %q:\n%s", want, text)
+		}
+	}
+}

--- a/internal/app/tools/cireport/main.go
+++ b/internal/app/tools/cireport/main.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	platformci "github.com/Yacobolo/leapview/internal/platform/ci"
+)
+
+type githubRun struct {
+	ID         int64     `json:"id"`
+	Event      string    `json:"event"`
+	Attempt    int       `json:"run_attempt"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	Conclusion string    `json:"conclusion"`
+}
+
+type githubJob struct {
+	Name       string     `json:"name"`
+	Conclusion string     `json:"conclusion"`
+	StartedAt  *time.Time `json:"started_at"`
+}
+
+type githubArtifact struct {
+	Name               string `json:"name"`
+	ArchiveDownloadURL string `json:"archive_download_url"`
+	Expired            bool   `json:"expired"`
+}
+
+type client struct {
+	http  *http.Client
+	token string
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	repo := flag.String("repo", os.Getenv("GITHUB_REPOSITORY"), "owner/repository")
+	token := flag.String("token", os.Getenv("GITHUB_TOKEN"), "GitHub token")
+	days := flag.Int("days", 7, "reporting window in days")
+	depotBuildsPath := flag.String("depot-builds", "", "Depot builds JSON")
+	output := flag.String("output", "ci-health.json", "health report JSON")
+	summary := flag.String("summary", "", "Markdown summary output")
+	flag.Parse()
+	if *repo == "" || *token == "" {
+		return errors.New("--repo and --token are required")
+	}
+	if *days < 1 || *days > 30 {
+		return errors.New("--days must be between 1 and 30")
+	}
+
+	since := time.Now().UTC().Add(-time.Duration(*days) * 24 * time.Hour)
+	api := &client{http: &http.Client{Timeout: 30 * time.Second}, token: *token}
+	runs, err := api.healthRuns(context.Background(), *repo, since)
+	if err != nil {
+		return err
+	}
+	builds, err := readDepotBuilds(*depotBuildsPath, since)
+	if err != nil {
+		return err
+	}
+	report := platformci.AnalyzeHealth(runs, builds)
+	reportJSON, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(*output, append(reportJSON, '\n'), 0o644); err != nil {
+		return err
+	}
+	markdown := renderMarkdown(report, *days)
+	if *summary != "" {
+		if err := os.WriteFile(*summary, []byte(markdown), 0o644); err != nil {
+			return err
+		}
+	}
+	fmt.Print(markdown)
+	return nil
+}
+
+func (c *client) healthRuns(ctx context.Context, repo string, since time.Time) ([]platformci.HealthRun, error) {
+	var listedRuns []githubRun
+	for page := 1; page <= 10; page++ {
+		endpoint := fmt.Sprintf(
+			"https://api.github.com/repos/%s/actions/workflows/ci.yml/runs?per_page=100&page=%d&created=%%3E%%3D%s",
+			repo,
+			page,
+			since.Format("2006-01-02"),
+		)
+		var response struct {
+			Runs []githubRun `json:"workflow_runs"`
+		}
+		if err := c.getJSON(ctx, endpoint, &response); err != nil {
+			return nil, fmt.Errorf("list CI runs page %d: %w", page, err)
+		}
+		listedRuns = append(listedRuns, response.Runs...)
+		if len(response.Runs) < 100 {
+			break
+		}
+	}
+
+	var candidates []githubRun
+	for _, run := range listedRuns {
+		if run.Conclusion == "" || run.CreatedAt.Before(since) {
+			continue
+		}
+		candidates = append(candidates, run)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	work := make(chan githubRun)
+	var (
+		runs     []platformci.HealthRun
+		firstErr error
+		mutex    sync.Mutex
+		group    sync.WaitGroup
+	)
+	workers := 8
+	if len(candidates) < workers {
+		workers = len(candidates)
+	}
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for run := range work {
+				healthRun, err := c.healthRun(ctx, repo, run)
+				mutex.Lock()
+				if err != nil && firstErr == nil {
+					firstErr = err
+					cancel()
+				}
+				if err == nil {
+					runs = append(runs, healthRun)
+				}
+				mutex.Unlock()
+			}
+		}()
+	}
+	for _, run := range candidates {
+		select {
+		case work <- run:
+		case <-ctx.Done():
+			break
+		}
+	}
+	close(work)
+	group.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	sort.Slice(runs, func(i, j int) bool { return runs[i].ID < runs[j].ID })
+	return runs, nil
+}
+
+func (c *client) healthRun(ctx context.Context, repo string, run githubRun) (platformci.HealthRun, error) {
+	jobs, err := c.jobs(ctx, repo, run.ID)
+	if err != nil {
+		return platformci.HealthRun{}, err
+	}
+	results := jobResults(jobs)
+	plan, err := c.plan(ctx, repo, run.ID)
+	if err != nil {
+		return platformci.HealthRun{}, err
+	}
+	if plan.Version == 0 {
+		plan = inferPlan(results)
+	}
+	queue := int64(-1)
+	if started := earliestStart(jobs); run.Attempt <= 1 && !started.IsZero() && started.After(run.CreatedAt) {
+		queue = int64(started.Sub(run.CreatedAt).Seconds())
+	}
+	return platformci.HealthRun{
+		ID:              run.ID,
+		Event:           run.Event,
+		Attempt:         run.Attempt,
+		Conclusion:      run.Conclusion,
+		DurationSeconds: int64(run.UpdatedAt.Sub(run.CreatedAt).Seconds()),
+		QueueSeconds:    queue,
+		Plan:            plan,
+		Results:         results,
+	}, nil
+}
+
+func (c *client) jobs(ctx context.Context, repo string, runID int64) ([]githubJob, error) {
+	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/actions/runs/%d/jobs?per_page=100", repo, runID)
+	var response struct {
+		Jobs []githubJob `json:"jobs"`
+	}
+	if err := c.getJSON(ctx, endpoint, &response); err != nil {
+		return nil, fmt.Errorf("list jobs for run %d: %w", runID, err)
+	}
+	return response.Jobs, nil
+}
+
+func (c *client) plan(ctx context.Context, repo string, runID int64) (platformci.Plan, error) {
+	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/actions/runs/%d/artifacts?per_page=100", repo, runID)
+	var response struct {
+		Artifacts []githubArtifact `json:"artifacts"`
+	}
+	if err := c.getJSON(ctx, endpoint, &response); err != nil {
+		return platformci.Plan{}, fmt.Errorf("list artifacts for run %d: %w", runID, err)
+	}
+	for _, artifact := range response.Artifacts {
+		if artifact.Name != "ci-plan" || artifact.Expired {
+			continue
+		}
+		data, err := c.get(ctx, artifact.ArchiveDownloadURL)
+		if err != nil {
+			return platformci.Plan{}, fmt.Errorf("download plan for run %d: %w", runID, err)
+		}
+		return decodePlanArchive(data)
+	}
+	return platformci.Plan{}, nil
+}
+
+func (c *client) getJSON(ctx context.Context, endpoint string, destination any) error {
+	data, err := c.get(ctx, endpoint)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, destination)
+}
+
+func (c *client) get(ctx context.Context, endpoint string) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("Authorization", "Bearer "+c.token)
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	response, err := c.http.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s returned %s: %s", endpoint, response.Status, strings.TrimSpace(string(data)))
+	}
+	return data, nil
+}
+
+func decodePlanArchive(data []byte) (platformci.Plan, error) {
+	archive, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return platformci.Plan{}, err
+	}
+	for _, file := range archive.File {
+		if file.Name != "ci-plan.json" {
+			continue
+		}
+		reader, err := file.Open()
+		if err != nil {
+			return platformci.Plan{}, err
+		}
+		defer reader.Close()
+		var plan platformci.Plan
+		if err := json.NewDecoder(reader).Decode(&plan); err != nil {
+			return platformci.Plan{}, err
+		}
+		return plan, nil
+	}
+	return platformci.Plan{}, errors.New("ci-plan.json missing from artifact")
+}
+
+func jobResults(jobs []githubJob) map[string]string {
+	results := map[string]string{}
+	for _, job := range jobs {
+		name := normalizedJobName(job.Name)
+		if name == "" {
+			continue
+		}
+		results[name] = combineConclusion(results[name], job.Conclusion)
+	}
+	return results
+}
+
+func normalizedJobName(name string) string {
+	switch {
+	case name == "Prepare generated assets":
+		return "prepare"
+	case name == "Prepare frontend assets":
+		return "frontend-prepare"
+	case name == "Documentation and public site":
+		return "docs"
+	case strings.HasPrefix(name, "Go tests ("):
+		return "go-tests"
+	case name == "Public site image", name == "Public site image (external pull request)":
+		return "site-image"
+	case strings.HasPrefix(name, "Frontend tests ("):
+		return "frontend-tests"
+	case name == "Go static and race analysis":
+		return "go-analysis"
+	case name == "UI route QA":
+		return "ui-route-qa"
+	case name == "JavaScript dependency audit":
+		return "node-audit"
+	case name == "Go vulnerability scan":
+		return "go-vuln"
+	case name == "Production image", name == "Production image (external pull request)":
+		return "production-image"
+	case name == "Deployment contracts":
+		return "deployment-contracts"
+	default:
+		return ""
+	}
+}
+
+func combineConclusion(current, next string) string {
+	rank := map[string]int{"": 0, "skipped": 1, "success": 2, "cancelled": 3, "failure": 4}
+	if rank[next] > rank[current] {
+		return next
+	}
+	return current
+}
+
+func inferPlan(results map[string]string) platformci.Plan {
+	jobs := platformci.FullJobs()
+	return platformci.Plan{Version: platformci.PlanVersion, Reason: "legacy full-CI run", Nominal: jobs, Effective: jobs}
+}
+
+func earliestStart(jobs []githubJob) time.Time {
+	var earliest time.Time
+	for _, job := range jobs {
+		if job.StartedAt == nil {
+			continue
+		}
+		if earliest.IsZero() || job.StartedAt.Before(earliest) {
+			earliest = *job.StartedAt
+		}
+	}
+	return earliest
+}
+
+func readDepotBuilds(filename string, since time.Time) ([]platformci.DepotBuild, error) {
+	if filename == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var builds []platformci.DepotBuild
+	if err := json.Unmarshal(data, &builds); err != nil {
+		return nil, err
+	}
+	filtered := builds[:0]
+	for _, build := range builds {
+		if !build.StartTime.Before(since) {
+			filtered = append(filtered, build)
+		}
+	}
+	return filtered, nil
+}
+
+func renderMarkdown(report platformci.HealthReport, days int) string {
+	var output strings.Builder
+	fmt.Fprintf(&output, "# CI health — trailing %d days\n\n", days)
+	fmt.Fprintf(&output, "| Metric | Value |\n|---|---:|\n")
+	fmt.Fprintf(&output, "| Runs | %d |\n", report.RunCount)
+	fmt.Fprintf(&output, "| Success / failure / cancelled | %d / %d / %d |\n", report.Successes, report.Failures, report.Cancellations)
+	fmt.Fprintf(&output, "| Full CI p50 / p95 | %s / %s |\n", formatSeconds(report.Full.P50Seconds), formatSeconds(report.Full.P95Seconds))
+	fmt.Fprintf(&output, "| Selective PR p50 / p95 | %s / %s |\n", formatSeconds(report.Selective.P50Seconds), formatSeconds(report.Selective.P95Seconds))
+	fmt.Fprintf(&output, "| Queue p50 / p95 | %s / %s |\n", formatSeconds(report.Queue.P50Seconds), formatSeconds(report.Queue.P95Seconds))
+	fmt.Fprintf(&output, "| Reruns | %.1f%% |\n", report.RerunPercent)
+	fmt.Fprintf(&output, "| Selection audit misses | %d |\n", report.AuditMisses)
+	fmt.Fprintf(&output, "| Depot builds / total / p95 | %d / %s / %s |\n\n", report.Depot.BuildCount, formatSeconds(report.Depot.TotalSeconds), formatSeconds(report.Depot.P95Seconds))
+
+	output.WriteString("## Job selection\n\n| Job | Selected | Rate |\n|---|---:|---:|\n")
+	names := make([]string, 0, len(report.Selection))
+	for name := range report.Selection {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		metric := report.Selection[name]
+		fmt.Fprintf(&output, "| %s | %d | %.1f%% |\n", name, metric.Selected, metric.Percent)
+	}
+	if len(report.Alerts) > 0 {
+		output.WriteString("\n## Alerts\n\n")
+		for _, alert := range report.Alerts {
+			fmt.Fprintf(&output, "- %s\n", alert)
+		}
+	} else {
+		output.WriteString("\nNo CI health thresholds were exceeded.\n")
+	}
+	return output.String()
+}
+
+func formatSeconds(seconds int64) string {
+	return (time.Duration(seconds) * time.Second).String()
+}

--- a/internal/app/tools/cireport/main_test.go
+++ b/internal/app/tools/cireport/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	platformci "github.com/Yacobolo/leapview/internal/platform/ci"
+)
+
+func TestJobResultsAggregatesMatrixFailures(t *testing.T) {
+	t.Parallel()
+
+	got := jobResults([]githubJob{
+		{Name: "Go tests (packages)", Conclusion: "success"},
+		{Name: "Go tests (app 1/4)", Conclusion: "failure"},
+		{Name: "Frontend tests (core)", Conclusion: "success"},
+		{Name: "CI gate", Conclusion: "failure"},
+	})
+	want := map[string]string{
+		"go-tests":       "failure",
+		"frontend-tests": "success",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("results = %#v, want %#v", got, want)
+	}
+}
+
+func TestDecodePlanArchive(t *testing.T) {
+	t.Parallel()
+
+	want := platformci.Plan{
+		Version:   platformci.PlanVersion,
+		Reason:    "test",
+		Nominal:   platformci.Jobs{Docs: true},
+		Effective: platformci.Jobs{Docs: true},
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	file, err := writer.Create("ci-plan.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := decodePlanArchive(archive.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("plan = %#v, want %#v", got, want)
+	}
+}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -1722,10 +1722,21 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 		"task build",
 		"actions/upload-artifact@",
 		"name: generated-assets",
+		"classify:",
+		"name: Classify changes",
+		"go run ./internal/app/tools/ciplan",
+		"fetch-depth: 0",
+		"name: ci-plan",
+		"retention-days: 30",
+		"frontend-prepare:",
+		"name: Prepare frontend assets",
+		"task ci:prepare:frontend",
+		"docs:",
+		"name: Documentation and public site",
+		"task ci:test:docs-site",
 		"go-tests:",
 		"name: Go tests (${{ matrix.name }})",
-		"needs: prepare",
-		"app_shard:",
+		"matrix: ${{ fromJSON(needs.classify.outputs.go_matrix) }}",
 		"go test -p 2 \"${packages[@]}\"",
 		"go run ./internal/app/tools/testshard",
 		"frontend-tests:",
@@ -1748,9 +1759,37 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 		"platforms: linux/amd64",
 		"id-token: write",
 		"./scripts/smoke_production_image.sh leapview:ci",
+		"site-image-fork:",
+		"production-image-fork:",
+		"ci-gate:",
+		"name: CI gate",
+		"go run ./internal/app/tools/ciplan gate",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("CI workflow missing production gate fragment %q", want)
+		}
+	}
+	if strings.Contains(text, "paths-ignore:") || strings.Contains(text, "\n    paths:") {
+		t.Fatal("required CI workflow must classify paths in a job instead of suppressing the workflow trigger")
+	}
+	for _, job := range []string{
+		"prepare",
+		"frontend-prepare",
+		"docs",
+		"go-tests",
+		"frontend-tests",
+		"go-analysis",
+		"ui-route-qa",
+		"node-audit",
+		"go-vuln",
+		"site-image",
+		"production-image",
+		"deployment-contracts",
+	} {
+		block := workflowJobBlock(t, text, job)
+		if !strings.Contains(block, "needs: classify") &&
+			!strings.Contains(block, "needs: [classify,") {
+			t.Fatalf("%s must depend on the authoritative change plan", job)
 		}
 	}
 	for _, job := range []string{"node-audit", "production-image"} {
@@ -1780,6 +1819,15 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 			t.Fatalf("%s must use Depot's persistent cache instead of transferring a GitHub Actions cache", block.name)
 		}
 	}
+	for _, job := range []string{"site-image-fork", "production-image-fork"} {
+		block := workflowJobBlock(t, text, job)
+		if strings.Contains(block, "id-token: write") || strings.Contains(block, "depot/") {
+			t.Fatalf("%s must execute fork-controlled build inputs without Depot or OIDC permission", job)
+		}
+		if !strings.Contains(block, "docker/build-push-action@") {
+			t.Fatalf("%s must retain a GitHub-hosted Buildx fallback", job)
+		}
+	}
 	deploymentContracts := workflowJobBlock(t, text, "deployment-contracts")
 	if !strings.Contains(deploymentContracts, "cache: false") {
 		t.Fatal("deployment-contracts must not race prepare to populate the shared Go cache")
@@ -1794,6 +1842,8 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 		"bun audit",
 		"vuln:",
 		"golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...",
+		"ci:prepare:frontend:",
+		"ci:test:docs-site:",
 		"test:go:",
 		"task --parallel test:go:packages test:go:app:0 test:go:app:1 test:go:app:2 test:go:app:3",
 		"go list ./... | grep -v '/internal/app$' | xargs go test -p 2",
@@ -1831,6 +1881,34 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 	} {
 		if !strings.Contains(scriptText, want) {
 			t.Fatalf("production image smoke script missing fragment %q", want)
+		}
+	}
+}
+
+func TestContinuousIntegrationHealthWorkflowReportsAndAlerts(t *testing.T) {
+	root := repoRoot(t)
+	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci-health.yml"))
+	if err != nil {
+		t.Fatalf("read CI health workflow: %v", err)
+	}
+	text := string(workflow)
+	for _, want := range []string{
+		"name: CI health",
+		"schedule:",
+		"workflow_dispatch:",
+		"actions: read",
+		"id-token: write",
+		"issues: write",
+		"depot/setup-action@",
+		"depot list builds --output json --project 9x73gxjcf5",
+		"go run ./internal/app/tools/cireport",
+		"--days 7",
+		"name: ci-health",
+		"retention-days: 30",
+		"CI health thresholds exceeded",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("CI health workflow missing fragment %q", want)
 		}
 	}
 }

--- a/internal/platform/ci/gate.go
+++ b/internal/platform/ci/gate.go
@@ -1,0 +1,62 @@
+package ci
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type GateReport struct {
+	OK          bool     `json:"ok"`
+	Problems    []string `json:"problems,omitempty"`
+	AuditMisses []string `json:"audit_misses,omitempty"`
+}
+
+func EvaluateGate(plan Jobs, results map[string]string) error {
+	report := evaluateJobs(plan, results)
+	if report.OK {
+		return nil
+	}
+	return fmt.Errorf("CI gate rejected workflow:\n- %s", strings.Join(report.Problems, "\n- "))
+}
+
+func EvaluatePlanGate(plan Plan, results map[string]string) GateReport {
+	report := evaluateJobs(plan.Effective, results)
+	if !plan.Audit {
+		return report
+	}
+	nominal := plan.Nominal.Selected()
+	for job, selected := range plan.Effective.Selected() {
+		if selected && !nominal[job] && results[job] != "success" {
+			report.AuditMisses = append(report.AuditMisses, job)
+		}
+	}
+	sort.Strings(report.AuditMisses)
+	return report
+}
+
+func evaluateJobs(plan Jobs, results map[string]string) GateReport {
+	selected := plan.Selected()
+	var problems []string
+	for job, expected := range selected {
+		result, present := results[job]
+		if expected {
+			if !present {
+				problems = append(problems, fmt.Sprintf("%s has no result", job))
+				continue
+			}
+			if result != "success" {
+				problems = append(problems, fmt.Sprintf("%s was selected but concluded %s", job, result))
+			}
+			continue
+		}
+		if present && result != "skipped" {
+			problems = append(problems, fmt.Sprintf("%s was not selected but concluded %s", job, result))
+		}
+	}
+	if len(problems) == 0 {
+		return GateReport{OK: true}
+	}
+	sort.Strings(problems)
+	return GateReport{Problems: problems}
+}

--- a/internal/platform/ci/gate_test.go
+++ b/internal/platform/ci/gate_test.go
@@ -1,0 +1,100 @@
+package ci
+
+import "testing"
+
+func TestEvaluateGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		plan    Jobs
+		results map[string]string
+		wantErr bool
+	}{
+		{
+			name: "selected jobs pass and unselected jobs skip",
+			plan: Jobs{Docs: true, SiteImage: true},
+			results: map[string]string{
+				"docs":             "success",
+				"site-image":       "success",
+				"prepare":          "skipped",
+				"production-image": "skipped",
+			},
+		},
+		{
+			name: "selected failure fails",
+			plan: Jobs{Docs: true},
+			results: map[string]string{
+				"docs": "failure",
+			},
+			wantErr: true,
+		},
+		{
+			name: "selected skip fails",
+			plan: Jobs{ProductionImage: true},
+			results: map[string]string{
+				"production-image": "skipped",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unselected success fails",
+			plan: Jobs{},
+			results: map[string]string{
+				"production-image": "success",
+			},
+			wantErr: true,
+		},
+		{
+			name: "cancellation fails",
+			plan: Jobs{Docs: true},
+			results: map[string]string{
+				"docs": "cancelled",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := EvaluateGate(tt.plan, tt.results)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("EvaluateGate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEvaluatePlanGateIdentifiesAuditMiss(t *testing.T) {
+	t.Parallel()
+
+	plan := Plan{
+		Audit:     true,
+		Nominal:   Jobs{Docs: true},
+		Effective: FullJobs(),
+	}
+	results := successfulResults(FullJobs())
+	results["production-image"] = "failure"
+
+	report := EvaluatePlanGate(plan, results)
+	if report.OK {
+		t.Fatal("audit failure unexpectedly passed")
+	}
+	if len(report.AuditMisses) != 1 || report.AuditMisses[0] != "production-image" {
+		t.Fatalf("audit misses = %v, want production-image", report.AuditMisses)
+	}
+}
+
+func successfulResults(jobs Jobs) map[string]string {
+	results := map[string]string{}
+	for job, selected := range jobs.Selected() {
+		if selected {
+			results[job] = "success"
+		} else {
+			results[job] = "skipped"
+		}
+	}
+	return results
+}

--- a/internal/platform/ci/health.go
+++ b/internal/platform/ci/health.go
@@ -1,0 +1,187 @@
+package ci
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"time"
+)
+
+type HealthRun struct {
+	ID              int64             `json:"id"`
+	Event           string            `json:"event"`
+	Attempt         int               `json:"attempt"`
+	Conclusion      string            `json:"conclusion"`
+	DurationSeconds int64             `json:"duration_seconds"`
+	QueueSeconds    int64             `json:"queue_seconds"`
+	Plan            Plan              `json:"plan"`
+	Results         map[string]string `json:"results"`
+}
+
+type DepotBuild struct {
+	ID        string    `json:"id"`
+	Status    string    `json:"status"`
+	StartTime time.Time `json:"startTime"`
+	Duration  int64     `json:"duration"`
+}
+
+type DurationMetric struct {
+	Count      int   `json:"count"`
+	P50Seconds int64 `json:"p50_seconds"`
+	P95Seconds int64 `json:"p95_seconds"`
+}
+
+type SelectionMetric struct {
+	Selected int     `json:"selected"`
+	Percent  float64 `json:"percent"`
+}
+
+type DepotMetric struct {
+	BuildCount   int   `json:"build_count"`
+	TotalSeconds int64 `json:"total_seconds"`
+	P95Seconds   int64 `json:"p95_seconds"`
+}
+
+type HealthReport struct {
+	GeneratedAt   time.Time                  `json:"generated_at"`
+	RunCount      int                        `json:"run_count"`
+	Successes     int                        `json:"successes"`
+	Failures      int                        `json:"failures"`
+	Cancellations int                        `json:"cancellations"`
+	Full          DurationMetric             `json:"full"`
+	Selective     DurationMetric             `json:"selective"`
+	Queue         DurationMetric             `json:"queue"`
+	RerunPercent  float64                    `json:"rerun_percent"`
+	AuditMisses   int                        `json:"audit_misses"`
+	Selection     map[string]SelectionMetric `json:"selection"`
+	Depot         DepotMetric                `json:"depot"`
+	Alerts        []string                   `json:"alerts"`
+}
+
+func AnalyzeHealth(runs []HealthRun, builds []DepotBuild) HealthReport {
+	report := HealthReport{
+		GeneratedAt: time.Now().UTC(),
+		RunCount:    len(runs),
+		Selection:   map[string]SelectionMetric{},
+	}
+	var fullDurations, selectiveDurations, queues []int64
+	var reruns int
+	selectedCounts := map[string]int{}
+	for _, run := range runs {
+		switch run.Conclusion {
+		case "success":
+			report.Successes++
+		case "failure":
+			report.Failures++
+		case "cancelled":
+			report.Cancellations++
+		}
+		if run.Attempt > 1 {
+			reruns++
+		}
+		if run.QueueSeconds >= 0 {
+			queues = append(queues, run.QueueSeconds)
+		}
+		if reflect.DeepEqual(run.Plan.Effective, FullJobs()) {
+			fullDurations = append(fullDurations, run.DurationSeconds)
+		} else if run.Event == "pull_request" && !run.Plan.Audit {
+			selectiveDurations = append(selectiveDurations, run.DurationSeconds)
+		}
+		for job, selected := range run.Plan.Effective.Selected() {
+			if selected {
+				selectedCounts[job]++
+			}
+		}
+		report.AuditMisses += len(EvaluatePlanGate(run.Plan, run.Results).AuditMisses)
+	}
+	report.Full = durationMetric(fullDurations)
+	report.Selective = durationMetric(selectiveDurations)
+	report.Queue = durationMetric(queues)
+	if len(runs) > 0 {
+		report.RerunPercent = float64(reruns) * 100 / float64(len(runs))
+	}
+	for job, count := range selectedCounts {
+		percent := 0.0
+		if len(runs) > 0 {
+			percent = float64(count) * 100 / float64(len(runs))
+		}
+		report.Selection[job] = SelectionMetric{Selected: count, Percent: percent}
+	}
+
+	var depotDurations []int64
+	for _, build := range builds {
+		depotDurations = append(depotDurations, build.Duration)
+		report.Depot.TotalSeconds += build.Duration
+	}
+	report.Depot.BuildCount = len(depotDurations)
+	report.Depot.P95Seconds = percentile(depotDurations, 0.95)
+
+	if report.Full.Count > 0 && report.Full.P95Seconds > int64((12*time.Minute).Seconds()) {
+		report.Alerts = append(report.Alerts, fmt.Sprintf(
+			"full CI p95 is %s (limit %s)",
+			duration(report.Full.P95Seconds),
+			12*time.Minute,
+		))
+	}
+	if report.Selective.Count > 0 && report.Selective.P95Seconds > int64((6*time.Minute).Seconds()) {
+		report.Alerts = append(report.Alerts, fmt.Sprintf(
+			"selective PR p95 is %s (limit %s)",
+			duration(report.Selective.P95Seconds),
+			6*time.Minute,
+		))
+	}
+	if report.Queue.Count > 0 && report.Queue.P95Seconds > int64((2*time.Minute).Seconds()) {
+		report.Alerts = append(report.Alerts, fmt.Sprintf(
+			"queue p95 is %s (limit %s)",
+			duration(report.Queue.P95Seconds),
+			2*time.Minute,
+		))
+	}
+	if report.RerunPercent > 3 {
+		report.Alerts = append(report.Alerts, fmt.Sprintf(
+			"rerun rate is %.1f%% (limit 3.0%%)",
+			report.RerunPercent,
+		))
+	}
+	if report.AuditMisses > 0 {
+		report.Alerts = append(report.Alerts, fmt.Sprintf(
+			"selection audit detected %d miss%s",
+			report.AuditMisses,
+			plural(report.AuditMisses),
+		))
+	}
+	return report
+}
+
+func durationMetric(values []int64) DurationMetric {
+	return DurationMetric{
+		Count:      len(values),
+		P50Seconds: percentile(values, 0.50),
+		P95Seconds: percentile(values, 0.95),
+	}
+}
+
+func percentile(values []int64, p float64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	index := int(math.Ceil(p*float64(len(sorted)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	return sorted[index]
+}
+
+func duration(seconds int64) time.Duration {
+	return time.Duration(seconds) * time.Second
+}
+
+func plural(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "es"
+}

--- a/internal/platform/ci/health_test.go
+++ b/internal/platform/ci/health_test.go
@@ -1,0 +1,102 @@
+package ci
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestAnalyzeHealth(t *testing.T) {
+	t.Parallel()
+
+	full := FullJobs()
+	selective := Jobs{Docs: true, SiteImage: true}
+	runs := []HealthRun{
+		{
+			Event: "push", DurationSeconds: 600, QueueSeconds: 20, Conclusion: "success",
+			Plan:    Plan{Nominal: full, Effective: full},
+			Results: successfulResults(full),
+		},
+		{
+			Event: "push", DurationSeconds: 700, QueueSeconds: 30, Conclusion: "success",
+			Plan:    Plan{Nominal: full, Effective: full},
+			Results: successfulResults(full),
+		},
+		{
+			Event: "push", DurationSeconds: 800, QueueSeconds: 140, Conclusion: "failure",
+			Plan:    Plan{Nominal: full, Effective: full},
+			Results: successfulResults(full),
+		},
+		{
+			Event: "pull_request", DurationSeconds: 240, QueueSeconds: 10, Conclusion: "success",
+			Plan:    Plan{Nominal: selective, Effective: selective},
+			Results: successfulResults(selective),
+		},
+		{
+			Event: "pull_request", DurationSeconds: 300, QueueSeconds: 15, Conclusion: "success", Attempt: 2,
+			Plan: Plan{Nominal: selective, Effective: full, Audit: true},
+			Results: func() map[string]string {
+				results := successfulResults(full)
+				results["production-image"] = "failure"
+				return results
+			}(),
+		},
+	}
+	builds := []DepotBuild{
+		{Status: "finished", StartTime: time.Now(), Duration: 60},
+		{Status: "finished", StartTime: time.Now(), Duration: 180},
+	}
+
+	got := AnalyzeHealth(runs, builds)
+	if got.RunCount != 5 {
+		t.Fatalf("run count = %d, want 5", got.RunCount)
+	}
+	if got.Full.P95Seconds != 800 {
+		t.Fatalf("full p95 = %d, want 800", got.Full.P95Seconds)
+	}
+	if got.Selective.P95Seconds != 240 {
+		t.Fatalf("selective p95 = %d, want 240", got.Selective.P95Seconds)
+	}
+	if got.Queue.P95Seconds != 140 {
+		t.Fatalf("queue p95 = %d, want 140", got.Queue.P95Seconds)
+	}
+	if got.RerunPercent != 20 {
+		t.Fatalf("rerun percentage = %.1f, want 20", got.RerunPercent)
+	}
+	if got.AuditMisses != 1 {
+		t.Fatalf("audit misses = %d, want 1", got.AuditMisses)
+	}
+	if got.Depot.BuildCount != 2 || got.Depot.TotalSeconds != 240 || got.Depot.P95Seconds != 180 {
+		t.Fatalf("Depot metrics = %#v", got.Depot)
+	}
+	for _, alert := range []string{
+		"full CI p95 is 13m20s (limit 12m0s)",
+		"queue p95 is 2m20s (limit 2m0s)",
+		"rerun rate is 20.0% (limit 3.0%)",
+		"selection audit detected 1 miss",
+	} {
+		if !slices.Contains(got.Alerts, alert) {
+			t.Errorf("alerts %v do not contain %q", got.Alerts, alert)
+		}
+	}
+	if got.Selection["docs"].Selected != 1 {
+		t.Fatalf("docs selected count = %d, want 1", got.Selection["docs"].Selected)
+	}
+}
+
+func TestAnalyzeHealthHealthyReportHasNoAlerts(t *testing.T) {
+	t.Parallel()
+
+	jobs := Jobs{Docs: true}
+	got := AnalyzeHealth([]HealthRun{{
+		Event:           "pull_request",
+		DurationSeconds: 120,
+		QueueSeconds:    5,
+		Conclusion:      "success",
+		Plan:            Plan{Nominal: jobs, Effective: jobs},
+		Results:         successfulResults(jobs),
+	}}, nil)
+	if len(got.Alerts) != 0 {
+		t.Fatalf("alerts = %v, want none", got.Alerts)
+	}
+}

--- a/internal/platform/ci/planner.go
+++ b/internal/platform/ci/planner.go
@@ -1,0 +1,458 @@
+package ci
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"slices"
+	"sort"
+	"strings"
+)
+
+const PlanVersion = 1
+
+type Change struct {
+	Status string   `json:"status"`
+	Paths  []string `json:"paths"`
+}
+
+type Input struct {
+	Event             string
+	PullRequestNumber int
+	Labels            []string
+}
+
+type GoShard struct {
+	Name     string `json:"name"`
+	AppShard string `json:"app_shard"`
+}
+
+type Jobs struct {
+	Prepare             bool      `json:"prepare"`
+	FrontendPrepare     bool      `json:"frontend_prepare"`
+	Docs                bool      `json:"docs"`
+	GoMatrix            []GoShard `json:"go_matrix"`
+	Frontend            []string  `json:"frontend"`
+	GoAnalysis          bool      `json:"go_analysis"`
+	UIRouteQA           bool      `json:"ui_route_qa"`
+	NodeAudit           bool      `json:"node_audit"`
+	GoVuln              bool      `json:"go_vuln"`
+	SiteImage           bool      `json:"site_image"`
+	ProductionImage     bool      `json:"production_image"`
+	DeploymentContracts bool      `json:"deployment_contracts"`
+}
+
+type Plan struct {
+	Version   int      `json:"version"`
+	Reason    string   `json:"reason"`
+	Audit     bool     `json:"audit"`
+	Changes   []Change `json:"changes"`
+	Nominal   Jobs     `json:"nominal"`
+	Effective Jobs     `json:"effective"`
+}
+
+func PlanChanges(input Input, changes []Change) Plan {
+	plan := Plan{
+		Version: PlanVersion,
+		Changes: changes,
+	}
+	if input.Event != "pull_request" {
+		plan.Nominal = FullJobs()
+		plan.Effective = FullJobs()
+		plan.Reason = input.Event + " event"
+		return plan
+	}
+	if slices.Contains(input.Labels, "ci:full") {
+		plan.Nominal = FullJobs()
+		plan.Effective = FullJobs()
+		plan.Reason = "ci:full label"
+		return plan
+	}
+
+	jobs, reasons, forceReason := classify(changes)
+	if forceReason != "" {
+		plan.Nominal = FullJobs()
+		plan.Effective = FullJobs()
+		plan.Reason = forceReason
+		return plan
+	}
+	normalizeJobs(&jobs)
+	plan.Nominal = jobs
+	plan.Effective = jobs
+	plan.Reason = strings.Join(sortedKeys(reasons), ", ")
+
+	if input.PullRequestNumber > 0 && input.PullRequestNumber%5 == 0 {
+		plan.Audit = true
+		plan.Effective = FullJobs()
+		plan.Reason = "20% deterministic PR audit"
+	}
+	return plan
+}
+
+func FullJobs() Jobs {
+	return Jobs{
+		Prepare:             true,
+		GoMatrix:            allGoShards(),
+		Frontend:            []string{"core", "reports", "chat", "workspace", "site"},
+		GoAnalysis:          true,
+		UIRouteQA:           true,
+		NodeAudit:           true,
+		GoVuln:              true,
+		SiteImage:           true,
+		ProductionImage:     true,
+		DeploymentContracts: true,
+	}
+}
+
+func fullGoJobs() Jobs {
+	return Jobs{
+		Prepare:         true,
+		GoMatrix:        allGoShards(),
+		GoAnalysis:      true,
+		GoVuln:          true,
+		ProductionImage: true,
+	}
+}
+
+func ParseNameStatusZ(data []byte) ([]Change, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	fields := strings.Split(string(data), "\x00")
+	if fields[len(fields)-1] != "" {
+		return nil, errors.New("git diff name-status output is not NUL terminated")
+	}
+	fields = fields[:len(fields)-1]
+
+	var changes []Change
+	for index := 0; index < len(fields); {
+		status := fields[index]
+		index++
+		pathCount := 1
+		if strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C") {
+			pathCount = 2
+		}
+		if status == "" || index+pathCount > len(fields) {
+			return nil, fmt.Errorf("malformed git diff name-status record %q", status)
+		}
+		paths := append([]string(nil), fields[index:index+pathCount]...)
+		index += pathCount
+		for _, changedPath := range paths {
+			if changedPath == "" {
+				return nil, fmt.Errorf("empty path in git diff record %q", status)
+			}
+		}
+		changes = append(changes, Change{Status: status, Paths: paths})
+	}
+	return changes, nil
+}
+
+func (p Plan) JSON() ([]byte, error) {
+	return json.MarshalIndent(p, "", "  ")
+}
+
+func (j Jobs) Selected() map[string]bool {
+	return map[string]bool{
+		"prepare":              j.Prepare,
+		"frontend-prepare":     j.FrontendPrepare,
+		"docs":                 j.Docs,
+		"go-tests":             len(j.GoMatrix) > 0,
+		"frontend-tests":       len(j.Frontend) > 0,
+		"go-analysis":          j.GoAnalysis,
+		"ui-route-qa":          j.UIRouteQA,
+		"node-audit":           j.NodeAudit,
+		"go-vuln":              j.GoVuln,
+		"site-image":           j.SiteImage,
+		"production-image":     j.ProductionImage,
+		"deployment-contracts": j.DeploymentContracts,
+	}
+}
+
+func classify(changes []Change) (Jobs, map[string]struct{}, string) {
+	if len(changes) == 0 {
+		return Jobs{}, nil, "no changed paths"
+	}
+	var jobs Jobs
+	reasons := map[string]struct{}{}
+	for _, change := range changes {
+		for _, changedPath := range change.Paths {
+			if reason := classifyPath(changedPath, &jobs, reasons); reason != "" {
+				return Jobs{}, nil, reason
+			}
+		}
+	}
+	return jobs, reasons, ""
+}
+
+func classifyPath(changedPath string, jobs *Jobs, reasons map[string]struct{}) string {
+	changedPath = strings.TrimPrefix(path.Clean(changedPath), "./")
+	if isCrossCutting(changedPath) {
+		return "cross-cutting build or contract input"
+	}
+	if isRootDocumentation(changedPath) {
+		jobs.Docs = true
+		reasons["repository documentation"] = struct{}{}
+		return ""
+	}
+	if strings.HasPrefix(changedPath, "docs/") || strings.HasPrefix(changedPath, "site/") {
+		jobs.Docs = true
+		jobs.SiteImage = true
+		reasons["published documentation or site"] = struct{}{}
+		return ""
+	}
+	if changedPath == "Dockerfile" {
+		jobs.ProductionImage = true
+		jobs.DeploymentContracts = true
+		reasons["production image"] = struct{}{}
+		return ""
+	}
+	if changedPath == "Dockerfile.site" {
+		jobs.SiteImage = true
+		reasons["published documentation or site"] = struct{}{}
+		return ""
+	}
+	if strings.HasPrefix(changedPath, "deploy/") {
+		if strings.HasSuffix(strings.ToLower(changedPath), ".md") {
+			jobs.Docs = true
+			reasons["repository documentation"] = struct{}{}
+			return ""
+		}
+		jobs.DeploymentContracts = true
+		reasons["deployment"] = struct{}{}
+		return ""
+	}
+	if strings.HasPrefix(changedPath, "dashboards/") ||
+		strings.HasPrefix(changedPath, "evaluation/") ||
+		strings.HasPrefix(changedPath, "schemas/") {
+		jobs.Prepare = true
+		jobs.GoMatrix = unionGoShards(jobs.GoMatrix, allGoShards())
+		jobs.UIRouteQA = true
+		jobs.ProductionImage = true
+		reasons["runtime project"] = struct{}{}
+		return ""
+	}
+	if strings.HasPrefix(changedPath, "web/") {
+		classifyFrontend(changedPath, jobs)
+		if isFrontendTest(changedPath) {
+			reasons["frontend tests"] = struct{}{}
+		} else {
+			jobs.ProductionImage = true
+			reasons["frontend"] = struct{}{}
+		}
+		return ""
+	}
+	if strings.HasPrefix(changedPath, "static/") {
+		classifySharedFrontend(jobs)
+		jobs.ProductionImage = true
+		reasons["frontend"] = struct{}{}
+		return ""
+	}
+	if strings.HasPrefix(changedPath, "scripts/") {
+		if isFrontendTest(changedPath) {
+			jobs.FrontendPrepare = true
+			jobs.Frontend = unionStrings(jobs.Frontend, []string{"core"})
+			reasons["frontend tests"] = struct{}{}
+			return ""
+		}
+		return "cross-cutting build or contract input"
+	}
+	if isGoPath(changedPath) {
+		if strings.HasSuffix(changedPath, "_test.go") {
+			jobs.Prepare = true
+			if strings.HasPrefix(changedPath, "internal/app/") {
+				jobs.GoMatrix = unionGoShards(jobs.GoMatrix, appGoShards())
+			} else {
+				jobs.GoMatrix = unionGoShards(jobs.GoMatrix, []GoShard{{Name: "packages"}})
+			}
+			reasons["Go tests"] = struct{}{}
+		} else {
+			mergeJobs(jobs, fullGoJobs())
+			reasons["Go/backend"] = struct{}{}
+		}
+		if strings.HasPrefix(changedPath, "cmd/leapview-site/") ||
+			strings.HasPrefix(changedPath, "internal/app/site/") ||
+			strings.HasPrefix(changedPath, "internal/app/tools/docsitegen/") {
+			jobs.Docs = true
+			jobs.SiteImage = true
+		}
+		return ""
+	}
+	return "unknown path: " + changedPath
+}
+
+func isCrossCutting(changedPath string) bool {
+	switch changedPath {
+	case "Taskfile.yml", "go.mod", "go.sum", "package.json", "bun.lock", "sqlc.yaml",
+		".dockerignore", ".gitignore", ".env.example", "depot.json", "VERSION",
+		"tsconfig.json", "tsconfig.app.json", "tsconfig.contracts.json":
+		return true
+	}
+	return strings.HasPrefix(changedPath, ".github/workflows/") ||
+		strings.HasPrefix(changedPath, "api/") ||
+		strings.HasPrefix(changedPath, "internal/platform/ci/")
+}
+
+func isRootDocumentation(changedPath string) bool {
+	if strings.Contains(changedPath, "/") {
+		return strings.HasPrefix(changedPath, ".github/") &&
+			strings.HasSuffix(strings.ToLower(changedPath), ".md")
+	}
+	lower := strings.ToLower(changedPath)
+	return strings.HasSuffix(lower, ".md") || changedPath == "LICENSE" || changedPath == "AGENTS.md"
+}
+
+func isGoPath(changedPath string) bool {
+	if !strings.HasSuffix(changedPath, ".go") {
+		return false
+	}
+	return strings.HasPrefix(changedPath, "cmd/") ||
+		strings.HasPrefix(changedPath, "internal/") ||
+		strings.HasPrefix(changedPath, "pkg/")
+}
+
+func isFrontendTest(changedPath string) bool {
+	return strings.HasSuffix(changedPath, ".test.ts") ||
+		strings.HasSuffix(changedPath, ".test.tsx") ||
+		strings.HasSuffix(changedPath, ".spec.ts")
+}
+
+func classifyFrontend(changedPath string, jobs *Jobs) {
+	jobs.FrontendPrepare = true
+	jobs.Frontend = unionStrings(jobs.Frontend, []string{"core"})
+	switch {
+	case strings.HasPrefix(changedPath, "web/components/shared/"),
+		strings.Contains(changedPath, "/visualization/"),
+		strings.Contains(changedPath, "datastar"):
+		classifySharedFrontend(jobs)
+	case strings.HasPrefix(changedPath, "web/components/dashboard/"):
+		jobs.Frontend = unionStrings(jobs.Frontend, []string{"reports"})
+	case strings.HasPrefix(changedPath, "web/components/chat/"):
+		jobs.Frontend = unionStrings(jobs.Frontend, []string{"chat"})
+	case strings.HasPrefix(changedPath, "web/components/workspace/"),
+		strings.HasPrefix(changedPath, "web/components/data/"),
+		strings.HasPrefix(changedPath, "web/components/admin/"),
+		strings.HasPrefix(changedPath, "web/components/login/"),
+		strings.HasPrefix(changedPath, "web/components/inspector/"):
+		jobs.Frontend = unionStrings(jobs.Frontend, []string{"workspace"})
+	default:
+		classifySharedFrontend(jobs)
+	}
+}
+
+func classifySharedFrontend(jobs *Jobs) {
+	jobs.Prepare = true
+	jobs.FrontendPrepare = true
+	jobs.Frontend = unionStrings(jobs.Frontend, []string{"core", "reports", "chat", "workspace"})
+	jobs.UIRouteQA = true
+	jobs.Docs = true
+	jobs.SiteImage = true
+}
+
+func mergeJobs(target *Jobs, source Jobs) {
+	target.Prepare = target.Prepare || source.Prepare
+	target.FrontendPrepare = target.FrontendPrepare || source.FrontendPrepare
+	target.Docs = target.Docs || source.Docs
+	target.GoMatrix = unionGoShards(target.GoMatrix, source.GoMatrix)
+	target.Frontend = unionStrings(target.Frontend, source.Frontend)
+	target.GoAnalysis = target.GoAnalysis || source.GoAnalysis
+	target.UIRouteQA = target.UIRouteQA || source.UIRouteQA
+	target.NodeAudit = target.NodeAudit || source.NodeAudit
+	target.GoVuln = target.GoVuln || source.GoVuln
+	target.SiteImage = target.SiteImage || source.SiteImage
+	target.ProductionImage = target.ProductionImage || source.ProductionImage
+	target.DeploymentContracts = target.DeploymentContracts || source.DeploymentContracts
+}
+
+func normalizeJobs(jobs *Jobs) {
+	if jobs.Prepare {
+		jobs.FrontendPrepare = false
+	}
+	jobs.Frontend = orderedStrings(jobs.Frontend, []string{"core", "reports", "chat", "workspace", "site"})
+	jobs.GoMatrix = orderedGoShards(jobs.GoMatrix)
+}
+
+func allGoShards() []GoShard {
+	return append([]GoShard{{Name: "packages"}}, appGoShards()...)
+}
+
+func appGoShards() []GoShard {
+	return []GoShard{
+		{Name: "app 1/4", AppShard: "0"},
+		{Name: "app 2/4", AppShard: "1"},
+		{Name: "app 3/4", AppShard: "2"},
+		{Name: "app 4/4", AppShard: "3"},
+	}
+}
+
+func unionStrings(current, additions []string) []string {
+	seen := make(map[string]struct{}, len(current)+len(additions))
+	for _, value := range append(append([]string(nil), current...), additions...) {
+		seen[value] = struct{}{}
+	}
+	values := make([]string, 0, len(seen))
+	for value := range seen {
+		values = append(values, value)
+	}
+	return values
+}
+
+func orderedStrings(values, order []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	var result []string
+	for _, value := range order {
+		if _, ok := seen[value]; ok {
+			result = append(result, value)
+			delete(seen, value)
+		}
+	}
+	extra := sortedKeys(seen)
+	return append(result, extra...)
+}
+
+func unionGoShards(current, additions []GoShard) []GoShard {
+	seen := map[string]GoShard{}
+	for _, shard := range append(append([]GoShard(nil), current...), additions...) {
+		seen[shard.Name] = shard
+	}
+	result := make([]GoShard, 0, len(seen))
+	for _, shard := range seen {
+		result = append(result, shard)
+	}
+	return result
+}
+
+func orderedGoShards(values []GoShard) []GoShard {
+	seen := map[string]GoShard{}
+	for _, value := range values {
+		seen[value.Name] = value
+	}
+	var result []GoShard
+	for _, candidate := range allGoShards() {
+		if value, ok := seen[candidate.Name]; ok {
+			result = append(result, value)
+			delete(seen, candidate.Name)
+		}
+	}
+	var names []string
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		result = append(result, seen[name])
+	}
+	return result
+}
+
+func sortedKeys[T any](values map[string]T) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/platform/ci/planner_test.go
+++ b/internal/platform/ci/planner_test.go
@@ -1,0 +1,265 @@
+package ci
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPlanChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   Input
+		changes []Change
+		want    Jobs
+		reason  string
+		audit   bool
+	}{
+		{
+			name:    "repository markdown",
+			input:   Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{Status: "M", Paths: []string{"README.md"}}},
+			want:    Jobs{Docs: true},
+			reason:  "repository documentation",
+		},
+		{
+			name:    "published documentation",
+			input:   Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{Status: "M", Paths: []string{"docs/articles/start/installation.md"}}},
+			want:    Jobs{Docs: true, SiteImage: true},
+			reason:  "published documentation or site",
+		},
+		{
+			name:  "frontend report source",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "M",
+				Paths:  []string{"web/components/dashboard/dashboard-page.ts"},
+			}},
+			want: Jobs{
+				FrontendPrepare: true,
+				Frontend:        []string{"core", "reports"},
+				ProductionImage: true,
+			},
+			reason: "frontend",
+		},
+		{
+			name:  "shared frontend source",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "M",
+				Paths:  []string{"web/components/shared/datastar-lit.ts"},
+			}},
+			want: Jobs{
+				Prepare:         true,
+				Frontend:        []string{"core", "reports", "chat", "workspace"},
+				UIRouteQA:       true,
+				Docs:            true,
+				SiteImage:       true,
+				ProductionImage: true,
+			},
+			reason: "frontend",
+		},
+		{
+			name:  "frontend test only",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "M",
+				Paths:  []string{"web/components/chat/chat-page.dom.test.ts"},
+			}},
+			want: Jobs{
+				FrontendPrepare: true,
+				Frontend:        []string{"core", "chat"},
+			},
+			reason: "frontend tests",
+		},
+		{
+			name:  "production go",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "M",
+				Paths:  []string{"internal/analytics/query/planner.go"},
+			}},
+			want:   fullGoJobs(),
+			reason: "Go/backend",
+		},
+		{
+			name:  "non app go test only",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "M",
+				Paths:  []string{"internal/analytics/query/planner_test.go"},
+			}},
+			want: Jobs{
+				Prepare:  true,
+				GoMatrix: []GoShard{{Name: "packages"}},
+			},
+			reason: "Go tests",
+		},
+		{
+			name:  "app go test only",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "M",
+				Paths:  []string{"internal/app/router_test.go"},
+			}},
+			want: Jobs{
+				Prepare:  true,
+				GoMatrix: appGoShards(),
+			},
+			reason: "Go tests",
+		},
+		{
+			name:  "deployment",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "M",
+				Paths:  []string{"deploy/hetzner/main.tf"},
+			}},
+			want:   Jobs{DeploymentContracts: true},
+			reason: "deployment",
+		},
+		{
+			name:  "runtime project",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "M",
+				Paths:  []string{"dashboards/workspaces/sales/workspace.yaml"},
+			}},
+			want: Jobs{
+				Prepare:         true,
+				GoMatrix:        allGoShards(),
+				UIRouteQA:       true,
+				ProductionImage: true,
+			},
+			reason: "runtime project",
+		},
+		{
+			name:  "mixed union",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{
+				{Status: "M", Paths: []string{"docs/articles/start/installation.md"}},
+				{Status: "M", Paths: []string{"deploy/hetzner/main.tf"}},
+			},
+			want: Jobs{
+				Docs:                true,
+				SiteImage:           true,
+				DeploymentContracts: true,
+			},
+			reason: "deployment, published documentation or site",
+		},
+		{
+			name:  "rename classifies old and new paths",
+			input: Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{
+				Status: "R100",
+				Paths: []string{
+					"web/components/chat/old.ts",
+					"docs/articles/new.md",
+				},
+			}},
+			want: Jobs{
+				FrontendPrepare: true,
+				Frontend:        []string{"core", "chat"},
+				ProductionImage: true,
+				Docs:            true,
+				SiteImage:       true,
+			},
+			reason: "frontend, published documentation or site",
+		},
+		{
+			name:    "unknown forces full",
+			input:   Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{Status: "M", Paths: []string{"mystery/file.xyz"}}},
+			want:    FullJobs(),
+			reason:  "unknown path: mystery/file.xyz",
+		},
+		{
+			name:    "workflow forces full",
+			input:   Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{Status: "M", Paths: []string{".github/workflows/ci.yml"}}},
+			want:    FullJobs(),
+			reason:  "cross-cutting build or contract input",
+		},
+		{
+			name:    "label forces full",
+			input:   Input{Event: "pull_request", PullRequestNumber: 1, Labels: []string{"ci:full"}},
+			changes: []Change{{Status: "M", Paths: []string{"README.md"}}},
+			want:    FullJobs(),
+			reason:  "ci:full label",
+		},
+		{
+			name:    "main push forces full",
+			input:   Input{Event: "push"},
+			changes: nil,
+			want:    FullJobs(),
+			reason:  "push event",
+		},
+		{
+			name:    "manual run forces full",
+			input:   Input{Event: "workflow_dispatch"},
+			changes: nil,
+			want:    FullJobs(),
+			reason:  "workflow_dispatch event",
+		},
+		{
+			name:    "deterministic audit forces effective full",
+			input:   Input{Event: "pull_request", PullRequestNumber: 10},
+			changes: []Change{{Status: "M", Paths: []string{"README.md"}}},
+			want:    FullJobs(),
+			reason:  "20% deterministic PR audit",
+			audit:   true,
+		},
+		{
+			name:    "unusual known filename remains selective",
+			input:   Input{Event: "pull_request", PullRequestNumber: 1},
+			changes: []Change{{Status: "M", Paths: []string{"docs/articles/file with spaces.md"}}},
+			want:    Jobs{Docs: true, SiteImage: true},
+			reason:  "published documentation or site",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := PlanChanges(tt.input, tt.changes)
+			if !reflect.DeepEqual(got.Effective, tt.want) {
+				t.Fatalf("effective jobs = %#v, want %#v", got.Effective, tt.want)
+			}
+			if got.Reason != tt.reason {
+				t.Fatalf("reason = %q, want %q", got.Reason, tt.reason)
+			}
+			if got.Audit != tt.audit {
+				t.Fatalf("audit = %v, want %v", got.Audit, tt.audit)
+			}
+		})
+	}
+}
+
+func TestParseNameStatusZ(t *testing.T) {
+	t.Parallel()
+
+	input := []byte("M\x00README.md\x00R100\x00old name.md\x00docs/new name.md\x00D\x00site/old.ts\x00")
+	got, err := ParseNameStatusZ(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Change{
+		{Status: "M", Paths: []string{"README.md"}},
+		{Status: "R100", Paths: []string{"old name.md", "docs/new name.md"}},
+		{Status: "D", Paths: []string{"site/old.ts"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("changes = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseNameStatusZRejectsMalformedInput(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ParseNameStatusZ([]byte("R100\x00only-old\x00")); err == nil {
+		t.Fatal("expected malformed rename to fail")
+	}
+}


### PR DESCRIPTION
## Summary

- add a tested, versioned CI planner that classifies NUL-safe Git diffs and unions impacted monorepo lanes
- run full CI on `main`, manual dispatch, `ci:full`, unknown/cross-cutting changes, and a deterministic 20% PR audit
- add minimal frontend and independent docs/site preparation lanes, dynamic Go/frontend matrices, and a stable `CI gate`
- keep Depot for trusted builds and isolate external-fork Buildx fallbacks from OIDC permissions
- add a weekly GitHub Actions + Depot health report with p50/p95, selection, rerun, queue, audit-miss, and usage alerts

## Validation

- `task ci`
- `task ci:prepare:frontend`
- `task ci:test:docs-site`
- targeted planner, gate, health, CLI, and architecture tests
- actionlint for `ci.yml` and `ci-health.yml`
- live read-only GitHub/Depot health-report run

## Last 30 merged PR replay

The replay uses each merge commit's first-parent diff, matching the merged change rather than historical branch drift.

<details>
<summary>Planner result for each PR</summary>

| PR | Nominal classification |
|---:|---|
| #165 | docs + deployment; deterministic audit makes effective plan full |
| #164 | full — CI/build policy |
| #163 | Go tests + Go/backend |
| #162 | Go tests + deployment + repository docs |
| #161 | full — CI/build policy |
| #160 | full — CI/build policy |
| #156 | full — cross-cutting inputs |
| #155 | full — cross-cutting inputs |
| #153 | full — cross-cutting inputs |
| #152 | full — cross-cutting inputs |
| #149 | full — cross-cutting inputs |
| #148 | full — API/build contract |
| #147 | full — API/build contract |
| #146 | full — API/build contract |
| #145 | full — API/build contract |
| #144 | Go tests + Go/backend |
| #143 | full — API/build contract |
| #142 | full — API/build contract |
| #141 | full — API/build contract |
| #140 | full — API/build contract |
| #139 | full — API/build contract |
| #138 | Go tests + Go/backend |
| #137 | full — API/build contract |
| #136 | Go tests + Go/backend + deployment + docs/site |
| #135 | full — visualization/API contract |
| #134 | full — API/build contract |
| #133 | Go tests + Go/backend |
| #132 | full — cross-cutting inputs |
| #131 | full — cross-cutting inputs |
| #130 | full — cross-cutting inputs |

</details>

## Rollout

This PR intentionally forces full CI because it changes the workflow and planner. After merge, wait for the first successful `main` run before making `CI gate` the required check in the `main-ci` ruleset.
