### PR TITLE
LEA-141: publish immutable public site image

### DIFF
--- a/.github/workflows/site-image.yml
+++ b/.github/workflows/site-image.yml
@@ -1,0 +1,286 @@
+name: Publish public site image
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      image_reference:
+        description: Immutable public site image reference
+        value: ${{ jobs.image.outputs.image_reference }}
+      image_digest:
+        description: Public site image manifest digest
+        value: ${{ jobs.image.outputs.image_digest }}
+      revision:
+        description: Published source revision
+        value: ${{ jobs.image.outputs.revision }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-site-image-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/yacobolo/leapview-site
+
+jobs:
+  identity:
+    name: Resolve public site identity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.identity.outputs.version }}
+      revision: ${{ steps.identity.outputs.revision }}
+      build_time: ${{ steps.identity.outputs.build_time }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Resolve authoritative site identity
+        id: identity
+        run: |
+          test "$GITHUB_REF" = refs/heads/main
+          git fetch --no-tags origin main
+          revision="$(git rev-parse HEAD)"
+          test "$revision" = "$(git rev-parse FETCH_HEAD)"
+          canonical_version="$(tr -d '[:space:]' < VERSION)"
+          test -n "$canonical_version"
+          build_time="$(git show -s --format=%cI HEAD)"
+          version="${canonical_version}+site.${revision:0:12}"
+          {
+            echo "version=$version"
+            echo "revision=$revision"
+            echo "build_time=$build_time"
+          } >> "$GITHUB_OUTPUT"
+
+  platform:
+    name: Build public site image (${{ matrix.arch }})
+    needs: identity
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout published source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish native site image
+        id: publish
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: Dockerfile.site
+          platforms: linux/${{ matrix.arch }}
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:candidate-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.identity.outputs.version }}
+            org.opencontainers.image.revision=${{ needs.identity.outputs.revision }}
+            org.opencontainers.image.created=${{ needs.identity.outputs.build_time }}
+            dev.leapview.build.dirty=false
+          build-args: |
+            BUILD_VERSION=${{ needs.identity.outputs.version }}
+            BUILD_REVISION=${{ needs.identity.outputs.revision }}
+          cache-from: type=gha,scope=public-site-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=public-site-${{ matrix.arch }}
+          sbom: true
+          provenance: mode=max
+
+      - name: Attest native site image provenance
+        uses: actions/attest@f6bf1532d7d6793fce74eac584813a8eee607999 # v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.publish.outputs.digest }}
+          push-to-registry: true
+
+      - name: Record native site image digest
+        env:
+          IMAGE_DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          mkdir -p platform-digests
+          printf '%s@%s\n' "$IMAGE_NAME" "$IMAGE_DIGEST" > "platform-digests/${{ matrix.arch }}.txt"
+
+      - name: Upload native site image digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-site-platform-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
+          retention-days: 7
+          if-no-files-found: error
+          path: platform-digests/${{ matrix.arch }}.txt
+
+  image:
+    name: Assemble and verify public site image
+    needs: [identity, platform]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    outputs:
+      image_reference: ${{ steps.assemble.outputs.image_reference }}
+      image_digest: ${{ steps.assemble.outputs.digest }}
+      revision: ${{ needs.identity.outputs.revision }}
+
+    steps:
+      - name: Checkout published source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download native site image digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: public-site-platform-${{ github.run_id }}-${{ github.run_attempt }}-*
+          path: platform-digests
+          merge-multiple: true
+
+      - name: Assemble multi-platform site image
+        id: assemble
+        env:
+          REVISION: ${{ needs.identity.outputs.revision }}
+        run: |
+          mapfile -t image_references < <(sort -u platform-digests/*.txt)
+          test "${#image_references[@]}" -eq 2
+          image_tag="${IMAGE_NAME}:sha-${REVISION}"
+          docker buildx imagetools create --tag "$image_tag" "${image_references[@]}"
+          digest="sha256:$(docker buildx imagetools inspect --raw "$image_tag" | sha256sum | awk '{print $1}')"
+          image_reference="${IMAGE_NAME}@${digest}"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
+
+      - name: Attest multi-platform site image provenance
+        uses: actions/attest@f6bf1532d7d6793fce74eac584813a8eee607999 # v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.assemble.outputs.digest }}
+          push-to-registry: true
+
+      - name: Verify anonymous multi-platform image access
+        env:
+          IMAGE_REFERENCE: ${{ steps.assemble.outputs.image_reference }}
+        run: |
+          docker logout ghcr.io
+          inspected=false
+          for _ in $(seq 1 12); do
+            if docker buildx imagetools inspect "$IMAGE_REFERENCE"; then
+              inspected=true
+              break
+            fi
+            sleep 5
+          done
+          test "$inspected" = true
+          manifest="$(docker buildx imagetools inspect --raw "$IMAGE_REFERENCE")"
+          platform_count="$(
+            jq '[.manifests[] | select(
+              .platform.os == "linux" and
+              (.platform.architecture == "amd64" or .platform.architecture == "arm64")
+            )] | length' <<< "$manifest"
+          )"
+          test "$platform_count" -eq 2
+
+      - name: Verify published site runtime
+        env:
+          EXPECTED_VERSION: ${{ needs.identity.outputs.version }}
+          EXPECTED_REVISION: ${{ needs.identity.outputs.revision }}
+          IMAGE_REFERENCE: ${{ steps.assemble.outputs.image_reference }}
+        run: |
+          docker pull "$IMAGE_REFERENCE"
+          label_version="$(docker image inspect "$IMAGE_REFERENCE" --format '{{index .Config.Labels "org.opencontainers.image.version"}}')"
+          label_revision="$(docker image inspect "$IMAGE_REFERENCE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+          runtime_user="$(docker image inspect "$IMAGE_REFERENCE" --format '{{.Config.User}}')"
+          test "$label_version" = "$EXPECTED_VERSION"
+          test "$label_revision" = "$EXPECTED_REVISION"
+          test -n "$runtime_user"
+          test "$runtime_user" != root
+          test "$runtime_user" != 0
+
+          docker run --detach \
+            --name leapview-site-publication \
+            --publish 127.0.0.1:8081:8081 \
+            --env LEAPVIEW_SITE_BASE_URL=https://leapview.dev \
+            "$IMAGE_REFERENCE"
+          trap 'docker rm --force leapview-site-publication >/dev/null 2>&1 || true' EXIT
+
+          ready=false
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error http://127.0.0.1:8081/healthz >/dev/null && \
+              curl --fail --silent --show-error http://127.0.0.1:8081/readyz >/dev/null; then
+              ready=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != true ]; then
+            docker logs leapview-site-publication
+            exit 1
+          fi
+
+          curl --fail --silent --show-error http://127.0.0.1:8081/release.json > deployed-release.json
+          cmp docs/public-release.json deployed-release.json
+          curl --fail --silent --show-error http://127.0.0.1:8081/docs/installation > installation.html
+          while IFS= read -r required; do
+            grep --fixed-strings --quiet -- "$required" installation.html
+          done < <(jq --raw-output '
+            .version,
+            .tag,
+            .revision,
+            .image,
+            .releaseUrl,
+            (.artifacts[] | .archiveUrl, .checksumUrl)
+          ' docs/public-release.json)
+
+      - name: Record immutable public site image
+        env:
+          IMAGE_REFERENCE: ${{ steps.assemble.outputs.image_reference }}
+          REVISION: ${{ needs.identity.outputs.revision }}
+        run: |
+          printf '%s\n' "$IMAGE_REFERENCE" > site-image-reference.txt
+          {
+            echo "### Public site image"
+            echo
+            echo "\`$IMAGE_REFERENCE\`"
+            echo
+            echo "Source revision: \`$REVISION\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload immutable public site image reference
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-site-image-${{ needs.identity.outputs.revision }}
+          retention-days: 30
+          if-no-files-found: error
+          path: site-image-reference.txt

--- a/deploy/hetzner/deployment_test.go
+++ b/deploy/hetzner/deployment_test.go
@@ -91,6 +91,53 @@ func TestReleaseWorkflowPublishesComposeArchiveAndAttestedImage(t *testing.T) {
 	}
 }
 
+func TestPublicSiteImagePublicationContract(t *testing.T) {
+	workflow := readFile(t, filepath.Join("..", "..", ".github", "workflows", "site-image.yml"))
+	for _, fragment := range []string{
+		"name: Publish public site image",
+		"workflow_dispatch:",
+		"workflow_call:",
+		"IMAGE_NAME: ghcr.io/yacobolo/leapview-site",
+		"packages: write",
+		"attestations: write",
+		"id-token: write",
+		"runner: ubuntu-24.04",
+		"runner: ubuntu-24.04-arm",
+		"platforms: linux/${{ matrix.arch }}",
+		"file: Dockerfile.site",
+		"push: true",
+		"sbom: true",
+		"provenance: mode=max",
+		"org.opencontainers.image.version=",
+		"org.opencontainers.image.revision=",
+		"actions/attest@",
+		"docker buildx imagetools create",
+		"site-image-reference.txt",
+		"GITHUB_STEP_SUMMARY",
+		"docker logout ghcr.io",
+		`docker buildx imagetools inspect "$IMAGE_REFERENCE"`,
+		`docker image inspect "$IMAGE_REFERENCE"`,
+		"docker run --detach",
+		"/healthz",
+		"/readyz",
+		"/release.json",
+		"/docs/installation",
+		"refs/heads/main",
+	} {
+		requireContains(t, workflow, fragment)
+	}
+	for _, forbidden := range []string{
+		"pull_request:",
+		"docker/setup-qemu-action@",
+		"ghcr.io/yacobolo/leapview-site:latest",
+		"git clone",
+	} {
+		if strings.Contains(workflow, forbidden) {
+			t.Errorf("public site image publication contains forbidden fragment %q", forbidden)
+		}
+	}
+}
+
 func TestSupplyChainInputsArePinned(t *testing.T) {
 	for _, name := range []string{"Dockerfile", "Dockerfile.site"} {
 		dockerfile := readFile(t, filepath.Join("..", "..", name))


### PR DESCRIPTION
## Summary

- publish a dedicated `ghcr.io/yacobolo/leapview-site` image from authoritative `main` revisions only
- build natively for linux/amd64 and linux/arm64, then assemble an immutable multi-platform manifest
- attach SBOM and provenance attestations and record the digest-qualified image reference
- verify anonymous registry access, OCI identity labels, non-root runtime, health/readiness, release manifest, and installation guidance
- add a repository contract test that prevents weakening the publication workflow

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/site-image.yml`
- `go test ./deploy/hetzner -count=1`
- `task deploy:check`
- `task ci`

Linear: LEA-141