### PR TITLE
LEA-141: embed generated visual documentation

### DIFF
--- a/Dockerfile.site
+++ b/Dockerfile.site
@@ -21,6 +21,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked \
     ./scripts/generate_build_sources.sh && \
     go run ./internal/app/tools/mapassets --out .data/map-assets && \
+    go run -tags=duckdb_arrow ./internal/app/tools/visualdocgen && \
     go run ./internal/app/tools/clidocgen && \
     go run ./internal/app/tools/schemadocgen && \
     go run ./internal/app/tools/openapidocgen && \
@@ -50,6 +51,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked \
     test -f docs/catalog.json && \
     test -f docs/search-index.sqlite3 && \
+    test -f docs/visuals/examples.gen.json && \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/leapview-site ./cmd/leapview-site
 
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:aef9602f8710ec12bde19d593fed1f76c708531bb7aba205110f1029786ead7b AS runtime

--- a/deploy/hetzner/deployment_test.go
+++ b/deploy/hetzner/deployment_test.go
@@ -138,6 +138,19 @@ func TestPublicSiteImagePublicationContract(t *testing.T) {
 	}
 }
 
+func TestPublicSiteImageGeneratesEmbeddedRuntimeAssets(t *testing.T) {
+	dockerfile := readFile(t, filepath.Join("..", "..", "Dockerfile.site"))
+	generateVisualDocs := strings.Index(dockerfile, "go run -tags=duckdb_arrow ./internal/app/tools/visualdocgen")
+	buildSite := strings.Index(dockerfile, "go build -trimpath")
+	if generateVisualDocs < 0 {
+		t.Fatal("public site image must generate visual documentation with the analytical runtime enabled")
+	}
+	if buildSite < 0 || generateVisualDocs > buildSite {
+		t.Fatal("public site image must generate visual documentation before compiling the server")
+	}
+	requireContains(t, dockerfile, "test -f docs/visuals/examples.gen.json")
+}
+
 func TestSupplyChainInputsArePinned(t *testing.T) {
 	for _, name := range []string{"Dockerfile", "Dockerfile.site"} {
 		dockerfile := readFile(t, filepath.Join("..", "..", name))


### PR DESCRIPTION
## Summary

- generate `docs/visuals/examples.gen.json` inside the public-site Docker build before compiling the embedded server
- fail the image build immediately if the required generated visual artifact is absent
- add an ordering contract that prevents compiling the site before its embedded runtime assets exist

## Production evidence

The first authoritative publication run successfully published and anonymously inspected `ghcr.io/yacobolo/leapview-site@sha256:061b5fdd840bd9cbceba451b5c72a6970e6963cefa325dbf79f1ebc7ee67e76e`, then exposed the missing artifact at runtime:

```
panic: read generated visual documentation: open visuals/examples.gen.json: file does not exist
```

Run: https://github.com/Yacobolo/leapview/actions/runs/30369214879

## Validation

- red: `go test ./deploy/hetzner -run ^'TestPublicSiteImageGeneratesEmbeddedRuntimeAssets$' -count=1`\n- green: same focused test\n- pinned actionlint\n- full `task ci`\n\nLinear: LEA-141