### PR TITLE
LEA-142: move site state to HCP Terraform

### DIFF
--- a/.github/workflows/site-infrastructure.yml
+++ b/.github/workflows/site-infrastructure.yml
@@ -32,12 +32,7 @@ jobs:
     outputs:
       revision: ${{ steps.identity.outputs.revision }}
     env:
-      TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
-      AWS_REGION: ${{ vars.TF_STATE_REGION }}
-      AWS_DEFAULT_REGION: ${{ vars.TF_STATE_REGION }}
-      AWS_ENDPOINT_URL_S3: ${{ vars.TF_STATE_ENDPOINT }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_SECRET_KEY }}
+      TF_TOKEN_app_terraform_io: ${{ secrets.HCP_API_TOKEN }}
       TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
       TF_VAR_ssh_allowed_cidrs: ${{ vars.SITE_SSH_ALLOWED_CIDRS }}
       TF_VAR_operator_ssh_public_key: ${{ secrets.SITE_SSH_PUBLIC_KEY }}
@@ -54,11 +49,7 @@ jobs:
 
       - name: Validate protected configuration
         run: |
-          test -n "$TF_STATE_BUCKET"
-          test -n "$AWS_REGION"
-          test -n "$AWS_ENDPOINT_URL_S3"
-          test -n "$AWS_ACCESS_KEY_ID"
-          test -n "$AWS_SECRET_ACCESS_KEY"
+          test -n "$TF_TOKEN_app_terraform_io"
           test -n "$TF_VAR_hcloud_token"
           test -n "$TF_VAR_ssh_allowed_cidrs"
           test -n "$TF_VAR_operator_ssh_public_key"
@@ -66,20 +57,9 @@ jobs:
             test "$GITHUB_REF" = refs/heads/main
           fi
 
-      - name: Verify durable state storage
-        run: |
-          versioning="$(
-            aws s3api get-bucket-versioning \
-              --bucket "$TF_STATE_BUCKET" \
-              --endpoint-url "$AWS_ENDPOINT_URL_S3" \
-              --query Status \
-              --output text
-          )"
-          test "$versioning" = Enabled
-
       - name: Initialize locked remote state
         working-directory: deploy/hetzner-site
-        run: terraform init -input=false -backend-config="bucket=$TF_STATE_BUCKET"
+        run: terraform init -input=false
 
       - name: Validate infrastructure contracts
         working-directory: deploy/hetzner-site
@@ -129,7 +109,7 @@ jobs:
             echo
             echo "- Revision: \`$(git rev-parse HEAD)\`"
             echo "- Operation: \`${{ inputs.operation }}\`"
-            echo "- Remote state key: \`leapview/site/production.tfstate\`"
+            echo "- Remote state: \`Flid/leapview-site-production\`"
             echo "- Plan artifact retained for 90 days"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -141,12 +121,7 @@ jobs:
     timeout-minutes: 25
     environment: leapview-site-production
     env:
-      TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
-      AWS_REGION: ${{ vars.TF_STATE_REGION }}
-      AWS_DEFAULT_REGION: ${{ vars.TF_STATE_REGION }}
-      AWS_ENDPOINT_URL_S3: ${{ vars.TF_STATE_ENDPOINT }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.TF_STATE_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_STATE_SECRET_KEY }}
+      TF_TOKEN_app_terraform_io: ${{ secrets.HCP_API_TOKEN }}
       TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
       TF_VAR_ssh_allowed_cidrs: ${{ vars.SITE_SSH_ALLOWED_CIDRS }}
       TF_VAR_operator_ssh_public_key: ${{ secrets.SITE_SSH_PUBLIC_KEY }}
@@ -177,7 +152,7 @@ jobs:
 
       - name: Initialize locked remote state
         working-directory: deploy/hetzner-site
-        run: terraform init -input=false -backend-config="bucket=$TF_STATE_BUCKET"
+        run: terraform init -input=false
 
       - name: Apply reviewed plan
         working-directory: deploy/hetzner-site

--- a/deploy/hetzner-site/README.md
+++ b/deploy/hetzner-site/README.md
@@ -22,29 +22,19 @@ bounded deployment channel and never applies or destroys infrastructure.
 
 ## Remote state
 
-Production state uses the S3 backend in `backend.tf`, including native lock-file
-locking. Provision a versioned Hetzner Object Storage bucket outside this root
-so the state remains available even if the site infrastructure is unavailable.
-Keep the bucket private, enable its deletion protection in Hetzner Console, and
-use a dedicated Hetzner project because S3 credentials can otherwise access
-every bucket in their project. The workflow verifies that versioning is enabled
-before Terraform can read or mutate production state. The credentials require:
-
-- the configured bucket listing;
-- `leapview/site/production.tfstate` for read/write;
-- `leapview/site/production.tfstate.tflock` for read/write/delete.
+Production state uses the HCP Terraform workspace
+`Flid/leapview-site-production`. The workspace is configured for local
+execution: the protected GitHub workflow still creates and applies the reviewed
+plan, while HCP Terraform provides encrypted remote state, locking, and state
+history without a dedicated Object Storage service.
 
 The protected `leapview-site-production` GitHub environment must provide:
 
 | Kind | Name | Purpose |
 | --- | --- | --- |
+| secret | `HCP_API_TOKEN` | HCP Terraform workspace state access |
 | secret | `HCLOUD_TOKEN` | Hetzner Cloud resource management |
-| secret | `TF_STATE_ACCESS_KEY` | Object Storage access key |
-| secret | `TF_STATE_SECRET_KEY` | Object Storage secret |
 | secret | `SITE_SSH_PUBLIC_KEY` | Production deployment public key |
-| variable | `TF_STATE_BUCKET` | Versioned state bucket |
-| variable | `TF_STATE_REGION` | Object Storage region, such as `fsn1` |
-| variable | `TF_STATE_ENDPOINT` | S3 endpoint, such as `https://fsn1.your-objectstorage.com` |
 | variable | `SITE_SSH_ALLOWED_CIDRS` | JSON list of restricted operator CIDRs |
 
 Configure required reviewers and prevent administrators from bypassing the
@@ -92,5 +82,5 @@ Destruction requires a reviewed source change that:
 4. obtains a second review before issuing a targeted destroy;
 5. removes DNS only after the retirement is verified.
 
-Never remove the Object Storage state or its versions as part of an origin
-retirement.
+Never delete the HCP Terraform workspace or its state history as part of an
+origin retirement.

--- a/deploy/hetzner-site/backend.tf
+++ b/deploy/hetzner-site/backend.tf
@@ -1,15 +1,9 @@
 terraform {
-  backend "s3" {
-    key          = "leapview/site/production.tfstate"
-    use_lockfile = true
+  cloud {
+    organization = "Flid"
 
-    # Hetzner Object Storage is S3-compatible but does not expose the AWS
-    # identity and metadata APIs. Bucket, region, endpoint, and credentials are
-    # supplied by the protected workflow during terraform init.
-    skip_credentials_validation = true
-    skip_region_validation      = true
-    skip_requesting_account_id  = true
-    skip_metadata_api_check     = true
-    skip_s3_checksum            = true
+    workspaces {
+      name = "leapview-site-production"
+    }
   }
 }

--- a/deploy/hetzner-site/deployment_test.go
+++ b/deploy/hetzner-site/deployment_test.go
@@ -136,9 +136,9 @@ func TestRemoteStateAndReviewedApplyWorkflow(t *testing.T) {
 	backend := readFile(t, "backend.tf")
 	workflow := readFile(t, filepath.Join("..", "..", ".github", "workflows", "site-infrastructure.yml"))
 	for _, fragment := range []string{
-		`backend "s3"`,
-		`key          = "leapview/site/production.tfstate"`,
-		"use_lockfile = true",
+		`cloud {`,
+		`organization = "Flid"`,
+		`name = "leapview-site-production"`,
 	} {
 		requireContains(t, backend, fragment)
 	}
@@ -149,20 +149,20 @@ func TestRemoteStateAndReviewedApplyWorkflow(t *testing.T) {
 		"environment: leapview-site-production",
 		"terraform plan",
 		"terraform show -no-color",
-		"aws s3api get-bucket-versioning",
 		"actions/upload-artifact@",
 		"retention-days: 90",
 		"needs: plan",
 		"terraform apply",
 		"terraform plan -detailed-exitcode",
-		"TF_STATE_BUCKET",
-		"AWS_ENDPOINT_URL_S3",
+		"TF_TOKEN_app_terraform_io",
+		"secrets.HCP_API_TOKEN",
 		"TF_VAR_hcloud_token",
 	} {
 		requireContains(t, workflow, fragment)
 	}
 	for _, forbidden := range []string{
 		"terraform destroy", "pull_request:", "-auto-approve",
+		"aws s3api", "TF_STATE_", "AWS_ENDPOINT_URL_S3",
 	} {
 		if strings.Contains(workflow, forbidden) {
 			t.Errorf("permanent infrastructure workflow contains forbidden fragment %q", forbidden)


### PR DESCRIPTION
## Summary
- replace the paid Hetzner Object Storage backend with the free HCP Terraform workspace `Flid/leapview-site-production`
- keep execution local to the reviewed GitHub plan/apply workflow while HCP provides encrypted state, locking, and history
- update deployment documentation and contract tests to reject the retired S3 configuration

## Verification
- `go test ./deploy/hetzner-site`
- `terraform fmt -check -recursive`
- `terraform init -backend=false -input=false`
- `terraform validate`
- `terraform test` (6 passed)
- real HCP-backed plan: 4 add, 0 change, 0 destroy
- exact plan applied: 4 added
- post-apply plan: no changes
- cloud-init completed; Compose has two running containers with zero restarts
- `/healthz` and `/readyz` return `ok`
- full `task ci` passed all changed-surface tests; two unrelated integration cases failed under parallel resource contention and both passed immediately in isolation

DNS was not changed.
