### PR TITLE
LEA-138: move offline Admin use cases into capability

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,6 +118,7 @@ tasks:
     desc: Build the LeapView public site assets from generated contracts
     cmds:
       - task: ui-signals:generate
+      - task: visualization-ir:generate
       - task: node:deps
       - bun run build:site
 

--- a/docs/articles/architecture/overview.md
+++ b/docs/articles/architecture/overview.md
@@ -24,6 +24,8 @@ All capability modules are peers. Some—especially `access`, `analytics`, `proj
 
 `admin` is an interface module over capability-owned reads and mutations rather than a separate domain owner. Product HTTP, API, UI, worker, and persistence adapters live with the capability whose language they express. Generic protocol mechanics live in `platform`; global dispatch and application assembly live in `app`.
 
+Offline initialization, retention, analytical cleanup, backup, and restore are Admin-owned use cases under `internal/admin/offline`. They depend on explicit Access, instance-state, retention, storage, archive, locking, and credential-recovery ports. `internal/app/adminoffline` only translates process configuration and wires those ports to concrete capability adapters and platform mechanisms.
+
 `cmd/leapview` starts the application and CLI. Transport adapters parse HTTP or Datastar commands and invoke capability use cases. Capability code enforces authorization and lifecycle invariants through explicit ports. Capability-owned adapters implement SQLite, DuckLake, object-storage, filesystem, and external-connector behavior.
 
 Avoid introducing a second path around capability use cases. Browser, CLI-backed API, and agent tools should converge on the same authorization and semantic boundaries.

--- a/internal/access/instance_initialization.go
+++ b/internal/access/instance_initialization.go
@@ -1,0 +1,44 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var ErrInstanceAlreadyInitialized = errors.New("LeapView instance is already initialized")
+
+const InstanceInitializedSetting = "instance.initialized"
+
+type InstanceInitializationInput struct {
+	Email       string
+	Environment string
+	Now         time.Time
+}
+
+type InitialInstanceCredentials struct {
+	Email                   string
+	TemporaryPassword       string
+	PublisherToken          string
+	PublisherTokenExpiresAt time.Time
+}
+
+// InstanceInitializer owns the atomic, audited Access mutation used by
+// offline Admin initialization.
+type InstanceInitializer interface {
+	InitializeInstance(context.Context, InstanceInitializationInput, func(InitialInstanceCredentials) error) (InitialInstanceCredentials, error)
+}
+
+func InitialPublisherPrivileges() []Privilege {
+	return []Privilege{
+		PrivilegeUseWorkspace,
+		PrivilegeViewItem,
+		PrivilegeQueryData,
+		PrivilegeRefreshData,
+		PrivilegeDeploy,
+		PrivilegeActivateDeployment,
+		PrivilegeViewData,
+		PrivilegeIngestData,
+		PrivilegeViewAudit,
+	}
+}

--- a/internal/access/sqlite/instance_initialization.go
+++ b/internal/access/sqlite/instance_initialization.go
@@ -1,0 +1,79 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yacobolo/leapview/internal/access"
+)
+
+func (r *Repository) InitializeInstance(
+	ctx context.Context,
+	input access.InstanceInitializationInput,
+	prepare func(access.InitialInstanceCredentials) error,
+) (access.InitialInstanceCredentials, error) {
+	var result access.InitialInstanceCredentials
+	err := r.RunAuditedMutationBatch(ctx, func(txRepo access.Repository) ([]access.AuditEventInput, error) {
+		sqliteRepo, ok := txRepo.(*Repository)
+		if !ok {
+			return nil, fmt.Errorf("initialize access transaction is unavailable")
+		}
+		inserted, err := sqliteRepo.InsertPlatformSettingIfMissing(
+			ctx,
+			access.InstanceInitializedSetting,
+			input.Now.UTC().Format(time.RFC3339),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if !inserted {
+			return nil, access.ErrInstanceAlreadyInitialized
+		}
+		created, err := txRepo.CreateLocalUser(ctx, access.LocalUserInput{
+			Email: input.Email, DisplayName: input.Email, MustChange: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		principal, err := txRepo.SetPlatformRole(ctx, access.PlatformRoleInput{
+			PrincipalID: created.Principal.ID,
+			Email:       input.Email,
+			DisplayName: input.Email,
+			Role:        access.RolePlatformAdmin,
+		})
+		if err != nil {
+			return nil, err
+		}
+		expires := input.Now.UTC().Add(24 * time.Hour).Truncate(time.Second)
+		token, _, err := txRepo.CreateAPITokenWithMetadata(ctx, access.APITokenInput{
+			PrincipalID: principal.ID,
+			Name:        access.APITokenNameInitialPublisher,
+			Privileges:  access.InitialPublisherPrivileges(),
+			ExpiresAt:   expires,
+		})
+		if err != nil {
+			return nil, err
+		}
+		result = access.InitialInstanceCredentials{
+			Email:                   input.Email,
+			TemporaryPassword:       created.Password,
+			PublisherToken:          token,
+			PublisherTokenExpiresAt: expires,
+		}
+		if prepare != nil {
+			if err := prepare(result); err != nil {
+				return nil, err
+			}
+		}
+		return []access.AuditEventInput{{
+			PrincipalID: principal.ID,
+			Action:      "instance.initialized",
+			TargetType:  "instance",
+			TargetID:    input.Environment,
+			Privilege:   access.PrivilegeManagePlatform,
+			Status:      "success",
+		}}, nil
+	})
+	return result, err
+}

--- a/internal/access/sqlite/repository_test.go
+++ b/internal/access/sqlite/repository_test.go
@@ -116,6 +116,41 @@ func TestRepositoryRunAuditedMutationBatchCommitsEveryAuditEvent(t *testing.T) {
 	}
 }
 
+func TestRepositoryInitializeInstanceRollsBackWhenCredentialPreparationFails(t *testing.T) {
+	ctx := context.Background()
+	store, repo := openAccessRepo(t, ctx)
+	prepareErr := errors.New("write recovery credentials")
+
+	_, err := repo.InitializeInstance(ctx, access.InstanceInitializationInput{
+		Email:       "admin@example.com",
+		Environment: "production",
+		Now:         time.Date(2026, time.July, 29, 12, 0, 0, 0, time.UTC),
+	}, func(access.InitialInstanceCredentials) error {
+		return prepareErr
+	})
+	if !errors.Is(err, prepareErr) {
+		t.Fatalf("initialize instance error = %v, want %v", err, prepareErr)
+	}
+
+	if _, err := store.GetSetting(ctx, access.InstanceInitializedSetting); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("instance initialization setting error = %v, want sql.ErrNoRows", err)
+	}
+	principals, err := repo.ListPrincipals(ctx, access.PrincipalFilter{Email: "admin@example.com"})
+	if err != nil {
+		t.Fatalf("list principals: %v", err)
+	}
+	if len(principals) != 0 {
+		t.Fatalf("principals = %#v, want none", principals)
+	}
+	events, err := repo.ListAuditEvents(ctx, access.AuditEventFilter{Action: "instance.initialized"})
+	if err != nil {
+		t.Fatalf("list audit events: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("audit events = %#v, want none", events)
+	}
+}
+
 func TestRepositoryLocalUserPasswordLifecycle(t *testing.T) {
 	ctx := context.Background()
 	_, repo := openAccessRepo(t, ctx)

--- a/internal/admin/cli/command.go
+++ b/internal/admin/cli/command.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	adminoffline "github.com/Yacobolo/leapview/internal/admin/offline"
 	"github.com/spf13/cobra"
 )
 
@@ -34,12 +35,12 @@ type Options struct {
 // Application composition implements this contract because it owns process
 // configuration and construction of cross-capability resources.
 type Operations interface {
-	Initialize(context.Context, string, io.Writer) error
+	Initialize(context.Context, adminoffline.InitializeRequest, io.Writer) error
 	AcknowledgeInitialCredentials(context.Context) error
-	StorageCleanup(context.Context, Options, io.Writer) error
-	Maintenance(context.Context, Options, io.Writer) error
-	Backup(context.Context, Options, io.Writer) error
-	Restore(context.Context, Options, io.Reader, io.Writer) error
+	StorageCleanup(context.Context, adminoffline.StorageCleanupRequest, io.Writer) error
+	Maintenance(context.Context, adminoffline.MaintenanceRequest, io.Writer) error
+	Backup(context.Context, adminoffline.BackupRequest, io.Writer) error
+	Restore(context.Context, adminoffline.RestoreRequest, io.Reader, io.Writer) error
 }
 
 // Command constructs the offline Admin command tree.
@@ -60,7 +61,7 @@ func Command(ctx context.Context, operations Operations) *cobra.Command {
 			if acknowledgeCredentials {
 				return operations.AcknowledgeInitialCredentials(ctx)
 			}
-			return operations.Initialize(ctx, initializeFormat, command.OutOrStdout())
+			return operations.Initialize(ctx, adminoffline.InitializeRequest{Format: initializeFormat}, command.OutOrStdout())
 		},
 	}
 	initialize.Flags().StringVar(&initializeFormat, "format", "json", "output format (json)")
@@ -68,13 +69,16 @@ func Command(ctx context.Context, operations Operations) *cobra.Command {
 
 	storage := &cobra.Command{Use: "storage", Short: "Maintain analytical storage"}
 	cleanup := operationCommand(operations, "cleanup", "Reconcile serving-state snapshots and clean DuckLake storage", func(command *cobra.Command) error {
-		return operations.StorageCleanup(ctx, values, command.OutOrStdout())
+		return operations.StorageCleanup(ctx, adminoffline.StorageCleanupRequest{Apply: values.Apply}, command.OutOrStdout())
 	})
 	cleanup.Flags().BoolVar(&values.Apply, "apply", false, "perform destructive cleanup instead of dry-run")
 	storage.AddCommand(cleanup)
 
 	maintenance := operationCommand(operations, "maintenance", "Prune bounded operational history", func(command *cobra.Command) error {
-		return operations.Maintenance(ctx, values, command.OutOrStdout())
+		return operations.Maintenance(ctx, adminoffline.MaintenanceRequest{
+			Apply: values.Apply, AuditDays: values.AuditDays, QueryDays: values.QueryDays,
+			ArchivedAgentDays: values.ArchivedAgentDays, AuthStateDays: values.AuthStateDays,
+		}, command.OutOrStdout())
 	})
 	maintenance.Flags().BoolVar(&values.Apply, "apply", false, "delete rows instead of dry-run")
 	maintenance.Flags().IntVar(&values.AuditDays, "audit-days", defaultAuditRetentionDays, "audit event retention in days; 0 disables audit pruning")
@@ -83,13 +87,18 @@ func Command(ctx context.Context, operations Operations) *cobra.Command {
 	maintenance.Flags().IntVar(&values.AuthStateDays, "auth-state-days", defaultAuthStateRetentionDays, "expired or revoked auth state retention in days; 0 disables auth-state pruning")
 
 	backup := operationCommand(operations, "backup", "Create a consistent LeapView instance backup", func(command *cobra.Command) error {
-		return operations.Backup(ctx, values, command.OutOrStdout())
+		return operations.Backup(ctx, adminoffline.BackupRequest{
+			Out: values.BackupOut, DatabaseOnly: values.DatabaseOnly,
+		}, command.OutOrStdout())
 	})
 	backup.Flags().StringVar(&values.BackupOut, "out", "", "backup archive output path")
 	backup.Flags().BoolVar(&values.DatabaseOnly, "database-only", false, "backup only the platform SQLite database")
 
 	restore := operationCommand(operations, "restore", "Restore LeapView from a validated instance backup", func(command *cobra.Command) error {
-		return operations.Restore(ctx, values, command.InOrStdin(), command.OutOrStdout())
+		return operations.Restore(ctx, adminoffline.RestoreRequest{
+			From: values.RestoreFrom, CurrentBackup: values.RestoreBefore,
+			Confirm: values.ConfirmRestore, DatabaseOnly: values.DatabaseOnly,
+		}, command.InOrStdin(), command.OutOrStdout())
 	})
 	restore.Flags().StringVar(&values.RestoreFrom, "from", "", "backup archive path to restore")
 	restore.Flags().StringVar(&values.RestoreBefore, "current-out", "", "path for a backup of the current instance before replacement; - creates and discards a validated temporary checkpoint")

--- a/internal/admin/cli/command_test.go
+++ b/internal/admin/cli/command_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	adminoffline "github.com/Yacobolo/leapview/internal/admin/offline"
 )
 
 type fakeOperations struct {
@@ -12,7 +14,7 @@ type fakeOperations struct {
 	options Options
 }
 
-func (operations *fakeOperations) Initialize(context.Context, string, io.Writer) error {
+func (operations *fakeOperations) Initialize(context.Context, adminoffline.InitializeRequest, io.Writer) error {
 	operations.called = "initialize"
 	return nil
 }
@@ -20,20 +22,27 @@ func (operations *fakeOperations) AcknowledgeInitialCredentials(context.Context)
 	operations.called = "acknowledge"
 	return nil
 }
-func (operations *fakeOperations) StorageCleanup(_ context.Context, options Options, _ io.Writer) error {
-	operations.called, operations.options = "cleanup", options
+func (operations *fakeOperations) StorageCleanup(_ context.Context, request adminoffline.StorageCleanupRequest, _ io.Writer) error {
+	operations.called, operations.options.Apply = "cleanup", request.Apply
 	return nil
 }
-func (operations *fakeOperations) Maintenance(_ context.Context, options Options, _ io.Writer) error {
-	operations.called, operations.options = "maintenance", options
+func (operations *fakeOperations) Maintenance(_ context.Context, request adminoffline.MaintenanceRequest, _ io.Writer) error {
+	operations.called = "maintenance"
+	operations.options = Options{
+		Apply: request.Apply, AuditDays: request.AuditDays, QueryDays: request.QueryDays,
+		ArchivedAgentDays: request.ArchivedAgentDays, AuthStateDays: request.AuthStateDays,
+	}
 	return nil
 }
-func (operations *fakeOperations) Backup(_ context.Context, options Options, _ io.Writer) error {
-	operations.called, operations.options = "backup", options
+func (operations *fakeOperations) Backup(_ context.Context, request adminoffline.BackupRequest, _ io.Writer) error {
+	operations.called = "backup"
+	operations.options.BackupOut, operations.options.DatabaseOnly = request.Out, request.DatabaseOnly
 	return nil
 }
-func (operations *fakeOperations) Restore(_ context.Context, options Options, _ io.Reader, _ io.Writer) error {
-	operations.called, operations.options = "restore", options
+func (operations *fakeOperations) Restore(_ context.Context, request adminoffline.RestoreRequest, _ io.Reader, _ io.Writer) error {
+	operations.called = "restore"
+	operations.options.RestoreFrom, operations.options.RestoreBefore = request.From, request.CurrentBackup
+	operations.options.ConfirmRestore, operations.options.DatabaseOnly = request.Confirm, request.DatabaseOnly
 	return nil
 }
 

--- a/internal/admin/offline/archive.go
+++ b/internal/admin/offline/archive.go
@@ -1,0 +1,193 @@
+package offline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+func (service *Service) Backup(ctx context.Context, request BackupRequest, out io.Writer) error {
+	if request.Out == "" {
+		return fmt.Errorf("admin backup requires --out")
+	}
+	lock, err := service.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+	options := BackupOptions{Path: request.Out}
+	if request.Out == "-" {
+		options.Path = ""
+		options.Writer = out
+	}
+	if request.DatabaseOnly {
+		if err := service.deps.Archive.BackupDatabase(ctx, options); err != nil {
+			return err
+		}
+		if request.Out != "-" {
+			fmt.Fprintf(out, "database backup written: %s\n", request.Out)
+		}
+		return nil
+	}
+	if err := service.validateFullInstanceArchiveLayout(); err != nil {
+		return err
+	}
+	options.ExcludeRelativePaths, err = service.FullInstanceDerivedPaths()
+	if err != nil {
+		return err
+	}
+	if err := service.deps.Archive.BackupInstance(ctx, options); err != nil {
+		return err
+	}
+	if request.Out != "-" {
+		fmt.Fprintf(out, "instance backup written: %s\n", request.Out)
+	}
+	return nil
+}
+
+func (service *Service) Restore(ctx context.Context, request RestoreRequest, in io.Reader, out io.Writer) error {
+	if request.From == "" {
+		return fmt.Errorf("admin restore requires --from")
+	}
+	if !request.Confirm {
+		return fmt.Errorf("admin restore requires --confirm")
+	}
+	if request.From == "-" && in == nil {
+		return fmt.Errorf("admin restore --from - requires standard input")
+	}
+	lock, err := service.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+	environment, err := service.restoreTargetEnvironment(ctx)
+	if err != nil {
+		return err
+	}
+	options := RestoreOptions{
+		Path:                request.From,
+		CurrentBackup:       request.CurrentBackup,
+		ExpectedEnvironment: environment,
+	}
+	if request.From == "-" {
+		options.Path = ""
+		options.Reader = in
+	}
+	if request.CurrentBackup == "-" {
+		options.CurrentBackup = ""
+		options.DiscardCurrentBackup = true
+	}
+	label := request.From
+	if label == "-" {
+		label = "stdin"
+	}
+	if request.DatabaseOnly {
+		if err := service.deps.Archive.RestoreDatabase(ctx, options); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "database restored from: %s\n", label)
+		if request.CurrentBackup != "" && request.CurrentBackup != "-" {
+			fmt.Fprintf(out, "previous database backup: %s\n", request.CurrentBackup)
+		}
+		return nil
+	}
+	if err := service.validateFullInstanceArchiveLayout(); err != nil {
+		return err
+	}
+	options.ResetRelativePaths, err = service.FullInstanceDerivedPaths()
+	if err != nil {
+		return err
+	}
+	if err := service.deps.Archive.RestoreInstance(ctx, options); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "instance restored from: %s\n", label)
+	if request.CurrentBackup != "" && request.CurrentBackup != "-" {
+		fmt.Fprintf(out, "previous instance backup: %s\n", request.CurrentBackup)
+	}
+	return nil
+}
+
+func (service *Service) restoreTargetEnvironment(ctx context.Context) (string, error) {
+	environment, exists, err := service.deps.State.ExistingEnvironment(ctx)
+	if exists && errors.Is(err, ErrStateNotFound) {
+		environment = service.configuredEnvironment()
+		if bindErr := service.deps.State.BindEnvironment(ctx, environment); bindErr != nil {
+			return "", bindErr
+		}
+		return environment, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		requested := strings.TrimSpace(service.config.Environment)
+		if requested != "" && requested != environment {
+			return "", fmt.Errorf("LeapView instance is bound to environment %q, not %q", environment, requested)
+		}
+		return environment, nil
+	}
+	return service.configuredEnvironment(), nil
+}
+
+func (service *Service) validateFullInstanceArchiveLayout() error {
+	homeAbs, err := filepath.Abs(service.config.HomeDir)
+	if err != nil {
+		return err
+	}
+	paths := map[string]string{
+		"DuckLake catalog": service.config.DuckLakeCatalog,
+		"DuckLake data":    service.config.DuckLakeData,
+		"artifact":         service.config.ArtifactDir,
+		"runtime":          service.config.RuntimeDir,
+	}
+	if service.config.ManagedDataBackend == "local" || service.config.ManagedDataBackend == "" {
+		paths["managed-data"] = service.config.ManagedDataDir
+	}
+	for label, path := range paths {
+		pathAbs, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(homeAbs, pathAbs)
+		if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("full instance backup/restore requires %s path inside LEAPVIEW_HOME; got %s outside %s", label, path, service.config.HomeDir)
+		}
+	}
+	return nil
+}
+
+func (service *Service) FullInstanceDerivedPaths() ([]string, error) {
+	homeAbs, err := filepath.Abs(service.config.HomeDir)
+	if err != nil {
+		return nil, err
+	}
+	managedDataAbs, err := filepath.Abs(service.config.ManagedDataDir)
+	if err != nil {
+		return nil, err
+	}
+	backend := strings.TrimSpace(service.config.ManagedDataBackend)
+	var derivedPath string
+	switch backend {
+	case "", "local":
+		derivedPath = filepath.Join(managedDataAbs, "objects", "revisions")
+	case "s3":
+		derivedPath = filepath.Join(managedDataAbs, "runtime")
+	default:
+		return nil, fmt.Errorf("unsupported managed-data backend %q", backend)
+	}
+	relative, err := filepath.Rel(homeAbs, derivedPath)
+	if err != nil {
+		return nil, err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		if backend == "s3" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("local managed-data derived path %s is outside %s", derivedPath, service.config.HomeDir)
+	}
+	return []string{filepath.ToSlash(relative)}, nil
+}

--- a/internal/admin/offline/service.go
+++ b/internal/admin/offline/service.go
@@ -1,0 +1,233 @@
+package offline
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/mail"
+	"os"
+	"strings"
+	"time"
+)
+
+var ErrInstanceAlreadyInitialized = errors.New("LeapView instance is already initialized")
+
+func (service *Service) Initialize(ctx context.Context, request InitializeRequest, out io.Writer) error {
+	if request.Format != "json" {
+		return fmt.Errorf("admin initialize supports only --format json")
+	}
+	email, err := service.initialAdminEmail()
+	if err != nil {
+		return err
+	}
+	lock, err := service.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+
+	environment, err := service.resolveEnvironment(ctx)
+	if err != nil {
+		return err
+	}
+	initialized, err := service.deps.State.Initialized(ctx)
+	if err != nil {
+		return err
+	}
+	if initialized {
+		credentials, readErr := service.deps.Recovery.Read()
+		if readErr == nil {
+			if _, decodeErr := DecodeInitialCredentials(credentials); decodeErr != nil {
+				return decodeErr
+			}
+			return writeAll(out, credentials)
+		}
+		if os.IsNotExist(readErr) {
+			return ErrInstanceAlreadyInitialized
+		}
+		return readErr
+	}
+	if err := service.deps.Recovery.Remove(); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale initialization credentials: %w", err)
+	}
+
+	var encoded []byte
+	_, err = service.deps.Initializer.Initialize(ctx, InitializationInput{
+		Email: email, Environment: environment, Now: service.deps.Now().UTC(),
+	}, func(credentials InitialCredentials) error {
+		encoded, err = json.Marshal(credentials)
+		if err != nil {
+			return err
+		}
+		encoded = append(encoded, '\n')
+		return service.deps.Recovery.Write(encoded)
+	})
+	if err != nil {
+		_ = service.deps.Recovery.Remove()
+		return err
+	}
+	return writeAll(out, encoded)
+}
+
+func DecodeInitialCredentials(contents []byte) (InitialCredentials, error) {
+	var credentials InitialCredentials
+	if err := json.Unmarshal(contents, &credentials); err != nil ||
+		credentials.Email == "" ||
+		credentials.TemporaryPassword == "" ||
+		credentials.PublisherToken == "" ||
+		credentials.PublisherTokenExpiresAt == "" {
+		return InitialCredentials{}, fmt.Errorf("initialization credential recovery file is invalid")
+	}
+	return credentials, nil
+}
+
+func (service *Service) AcknowledgeInitialCredentials(ctx context.Context) error {
+	lock, err := service.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+	if _, err := service.resolveEnvironment(ctx); err != nil {
+		return err
+	}
+	initialized, err := service.deps.State.Initialized(ctx)
+	if err != nil {
+		return err
+	}
+	if !initialized {
+		return fmt.Errorf("LeapView instance has not been initialized")
+	}
+	if err := service.deps.Recovery.Remove(); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("acknowledge initialization credentials: %w", err)
+	}
+	return nil
+}
+
+func (service *Service) StorageCleanup(ctx context.Context, request StorageCleanupRequest, out io.Writer) error {
+	release, err := service.acquireIf(ctx, request.Apply)
+	if err != nil {
+		return err
+	}
+	defer release.Release()
+	environment, err := service.resolveEnvironment(ctx)
+	if err != nil {
+		return err
+	}
+	if err := service.deps.Storage.Cleanup(ctx, environment, !request.Apply, out); err != nil {
+		return fmt.Errorf("storage cleanup: %w", err)
+	}
+	return nil
+}
+
+func (service *Service) Maintenance(ctx context.Context, request MaintenanceRequest, out io.Writer) error {
+	if request.AuditDays < 0 || request.QueryDays < 0 || request.ArchivedAgentDays < 0 || request.AuthStateDays < 0 {
+		return fmt.Errorf("retention days must be zero or greater")
+	}
+	release, err := service.acquireIf(ctx, request.Apply)
+	if err != nil {
+		return err
+	}
+	defer release.Release()
+	result, err := service.deps.Retention.Prune(ctx, RetentionPolicy{
+		AuditEventsMaxAge:             days(request.AuditDays),
+		QueryEventsMaxAge:             days(request.QueryDays),
+		ArchivedAgentConversationsAge: days(request.ArchivedAgentDays),
+		AuthStateMaxAge:               days(request.AuthStateDays),
+		DryRun:                        !request.Apply,
+	})
+	if err != nil {
+		return fmt.Errorf("operational maintenance: %w", err)
+	}
+	mode := "dry-run"
+	if request.Apply {
+		mode = "apply"
+	}
+	fmt.Fprintf(out, "mode: %s\n", mode)
+	fmt.Fprintf(out, "audit events: %d\n", result.AuditEventsDeleted)
+	fmt.Fprintf(out, "query events: %d\n", result.QueryEventsDeleted)
+	fmt.Fprintf(out, "archived agent conversations: %d\n", result.ArchivedAgentConversationsDeleted)
+	fmt.Fprintf(out, "expired oauth states: %d\n", result.ExpiredOAuthStatesDeleted)
+	fmt.Fprintf(out, "stale sessions: %d\n", result.StaleSessionsDeleted)
+	fmt.Fprintf(out, "stale api tokens: %d\n", result.StaleAPITokensDeleted)
+	fmt.Fprintf(out, "stale service principal secrets: %d\n", result.StaleServicePrincipalSecretsDeleted)
+	return nil
+}
+
+func (service *Service) resolveEnvironment(ctx context.Context) (string, error) {
+	requested := strings.TrimSpace(service.config.Environment)
+	bound, err := service.deps.State.Environment(ctx)
+	if err == nil {
+		if requested != "" && requested != bound {
+			return "", fmt.Errorf("LeapView instance is bound to environment %q, not %q", bound, requested)
+		}
+		return bound, nil
+	}
+	if !errors.Is(err, ErrStateNotFound) {
+		return "", fmt.Errorf("read instance environment: %w", err)
+	}
+	environment := service.configuredEnvironment()
+	if err := service.deps.State.BindEnvironment(ctx, environment); err != nil {
+		return "", err
+	}
+	return environment, nil
+}
+
+func (service *Service) configuredEnvironment() string {
+	if value := strings.TrimSpace(service.config.Environment); value != "" {
+		return value
+	}
+	if service.config.Production {
+		return "prod"
+	}
+	return "dev"
+}
+
+func (service *Service) initialAdminEmail() (string, error) {
+	email := strings.TrimSpace(service.config.BootstrapEmail)
+	if email == "" {
+		if service.config.Production {
+			return "", fmt.Errorf("production instance initialization requires LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL")
+		}
+		email = "admin@localhost"
+	}
+	parsed, err := mail.ParseAddress(email)
+	if err != nil || parsed.Address == "" {
+		return "", fmt.Errorf("instance initialization requires a valid LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL")
+	}
+	return parsed.Address, nil
+}
+
+func (service *Service) acquire(ctx context.Context) (Lock, error) {
+	if service == nil || service.deps.Locker == nil {
+		return nil, fmt.Errorf("offline Admin locker is required")
+	}
+	return service.deps.Locker.Acquire(ctx)
+}
+
+type noopLock struct{}
+
+func (noopLock) Release() error { return nil }
+
+func (service *Service) acquireIf(ctx context.Context, required bool) (Lock, error) {
+	if !required {
+		return noopLock{}, nil
+	}
+	return service.acquire(ctx)
+}
+
+func days(value int) time.Duration {
+	if value <= 0 {
+		return 0
+	}
+	return time.Duration(value) * 24 * time.Hour
+}
+
+func writeAll(out io.Writer, contents []byte) error {
+	written, err := out.Write(contents)
+	if err == nil && written != len(contents) {
+		return io.ErrShortWrite
+	}
+	return err
+}

--- a/internal/admin/offline/service_test.go
+++ b/internal/admin/offline/service_test.go
@@ -1,0 +1,312 @@
+package offline
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeLock struct {
+	released int
+}
+
+func (lock *fakeLock) Release() error {
+	lock.released++
+	return nil
+}
+
+type fakeLocker struct {
+	acquired int
+	lock     fakeLock
+}
+
+func (locker *fakeLocker) Acquire(context.Context) (Lock, error) {
+	locker.acquired++
+	return &locker.lock, nil
+}
+
+type fakeState struct {
+	environment    string
+	environmentErr error
+	existing       bool
+	initialized    bool
+	bound          string
+}
+
+func (state *fakeState) Environment(context.Context) (string, error) {
+	return state.environment, state.environmentErr
+}
+
+func (state *fakeState) ExistingEnvironment(context.Context) (string, bool, error) {
+	return state.environment, state.existing, state.environmentErr
+}
+
+func (state *fakeState) BindEnvironment(_ context.Context, environment string) error {
+	state.environment, state.bound, state.environmentErr = environment, environment, nil
+	return nil
+}
+
+func (state *fakeState) Initialized(context.Context) (bool, error) {
+	return state.initialized, nil
+}
+
+type memoryRecovery struct {
+	contents []byte
+	removed  int
+}
+
+func (recovery *memoryRecovery) Read() ([]byte, error) {
+	if recovery.contents == nil {
+		return nil, os.ErrNotExist
+	}
+	return append([]byte(nil), recovery.contents...), nil
+}
+
+func (recovery *memoryRecovery) Write(contents []byte) error {
+	recovery.contents = append([]byte(nil), contents...)
+	return nil
+}
+
+func (recovery *memoryRecovery) Remove() error {
+	recovery.removed++
+	if recovery.contents == nil {
+		return os.ErrNotExist
+	}
+	recovery.contents = nil
+	return nil
+}
+
+type fakeInitializer struct {
+	calls  int
+	input  InitializationInput
+	result InitialCredentials
+}
+
+func (initializer *fakeInitializer) Initialize(
+	_ context.Context,
+	input InitializationInput,
+	prepare func(InitialCredentials) error,
+) (InitialCredentials, error) {
+	initializer.calls++
+	initializer.input = input
+	if err := prepare(initializer.result); err != nil {
+		return InitialCredentials{}, err
+	}
+	return initializer.result, nil
+}
+
+type fakeRetention struct {
+	calls  int
+	policy RetentionPolicy
+	result RetentionResult
+}
+
+func (retention *fakeRetention) Prune(_ context.Context, policy RetentionPolicy) (RetentionResult, error) {
+	retention.calls++
+	retention.policy = policy
+	return retention.result, nil
+}
+
+type fakeStorage struct {
+	environment string
+	dryRun      bool
+}
+
+func (storage *fakeStorage) Cleanup(_ context.Context, environment string, dryRun bool, _ io.Writer) error {
+	storage.environment, storage.dryRun = environment, dryRun
+	return nil
+}
+
+type fakeArchive struct {
+	backupDatabase  BackupOptions
+	backupInstance  BackupOptions
+	restoreDatabase RestoreOptions
+	restoreInstance RestoreOptions
+}
+
+func (archive *fakeArchive) BackupDatabase(_ context.Context, options BackupOptions) error {
+	archive.backupDatabase = options
+	return nil
+}
+func (archive *fakeArchive) BackupInstance(_ context.Context, options BackupOptions) error {
+	archive.backupInstance = options
+	return nil
+}
+func (archive *fakeArchive) RestoreDatabase(_ context.Context, options RestoreOptions) error {
+	archive.restoreDatabase = options
+	return nil
+}
+func (archive *fakeArchive) RestoreInstance(_ context.Context, options RestoreOptions) error {
+	archive.restoreInstance = options
+	return nil
+}
+
+func TestInitializeOwnsValidationRecoveryAndAccessSequencing(t *testing.T) {
+	now := time.Date(2026, 7, 29, 7, 0, 0, 0, time.UTC)
+	locker := &fakeLocker{}
+	state := &fakeState{environmentErr: ErrStateNotFound}
+	recovery := &memoryRecovery{}
+	initializer := &fakeInitializer{result: InitialCredentials{
+		Email: "owner@example.com", TemporaryPassword: "temporary",
+		PublisherToken: "publisher", PublisherTokenExpiresAt: now.Add(24 * time.Hour).Format(time.RFC3339),
+	}}
+	service := New(Config{
+		HomeDir: "/instance", Production: true, BootstrapEmail: "owner@example.com", Environment: "prod",
+	}, Dependencies{
+		Locker: locker, State: state, Recovery: recovery, Initializer: initializer,
+		Now: func() time.Time { return now },
+	})
+	var out bytes.Buffer
+	if err := service.Initialize(context.Background(), InitializeRequest{Format: "json"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if locker.acquired != 1 || locker.lock.released != 1 {
+		t.Fatalf("lock lifecycle = acquired %d released %d", locker.acquired, locker.lock.released)
+	}
+	if state.bound != "prod" {
+		t.Fatalf("bound environment = %q", state.bound)
+	}
+	if initializer.calls != 1 || initializer.input.Email != "owner@example.com" ||
+		initializer.input.Environment != "prod" || !initializer.input.Now.Equal(now) {
+		t.Fatalf("initialization input = %#v calls=%d", initializer.input, initializer.calls)
+	}
+	if !bytes.Equal(out.Bytes(), recovery.contents) {
+		t.Fatalf("delivered credentials and recovery differ:\nout=%s\nrecovery=%s", out.Bytes(), recovery.contents)
+	}
+	if _, err := DecodeInitialCredentials(out.Bytes()); err != nil {
+		t.Fatalf("decode initialized credentials: %v", err)
+	}
+}
+
+func TestInitializeReplaysPreparedCredentialsWithoutMutatingAccess(t *testing.T) {
+	contents := []byte(`{"email":"owner@example.com","temporaryPassword":"temporary","publisherToken":"publisher","publisherTokenExpiresAt":"2026-07-30T07:00:00Z"}` + "\n")
+	locker := &fakeLocker{}
+	initializer := &fakeInitializer{}
+	service := New(Config{Production: true, BootstrapEmail: "owner@example.com"}, Dependencies{
+		Locker:      locker,
+		State:       &fakeState{environment: "prod", initialized: true},
+		Recovery:    &memoryRecovery{contents: contents},
+		Initializer: initializer,
+	})
+	var out bytes.Buffer
+	if err := service.Initialize(context.Background(), InitializeRequest{Format: "json"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if initializer.calls != 0 || !bytes.Equal(out.Bytes(), contents) {
+		t.Fatalf("initializer calls=%d output=%q", initializer.calls, out.String())
+	}
+}
+
+func TestMaintenanceOwnsPolicyAndExclusiveApplySemantics(t *testing.T) {
+	locker := &fakeLocker{}
+	retention := &fakeRetention{result: RetentionResult{
+		AuditEventsDeleted: 1, QueryEventsDeleted: 2, ArchivedAgentConversationsDeleted: 3,
+		ExpiredOAuthStatesDeleted: 4, StaleSessionsDeleted: 5,
+		StaleAPITokensDeleted: 6, StaleServicePrincipalSecretsDeleted: 7,
+	}}
+	service := New(Config{}, Dependencies{Locker: locker, Retention: retention})
+	var out bytes.Buffer
+	request := MaintenanceRequest{AuditDays: 10, QueryDays: 11, ArchivedAgentDays: 12, AuthStateDays: 13}
+	if err := service.Maintenance(context.Background(), request, &out); err != nil {
+		t.Fatal(err)
+	}
+	if locker.acquired != 0 || !retention.policy.DryRun ||
+		retention.policy.AuditEventsMaxAge != 10*24*time.Hour ||
+		retention.policy.AuthStateMaxAge != 13*24*time.Hour {
+		t.Fatalf("dry-run policy = %#v lock=%d", retention.policy, locker.acquired)
+	}
+	if !strings.Contains(out.String(), "mode: dry-run") || !strings.Contains(out.String(), "stale service principal secrets: 7") {
+		t.Fatalf("maintenance output = %q", out.String())
+	}
+	request.Apply = true
+	if err := service.Maintenance(context.Background(), request, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if locker.acquired != 1 || locker.lock.released != 1 || retention.policy.DryRun {
+		t.Fatalf("apply policy = %#v lock=%d/%d", retention.policy, locker.acquired, locker.lock.released)
+	}
+}
+
+func TestStorageCleanupResolvesEnvironmentAndLocksOnlyForApply(t *testing.T) {
+	locker := &fakeLocker{}
+	storage := &fakeStorage{}
+	service := New(Config{Environment: "prod"}, Dependencies{
+		Locker: locker, State: &fakeState{environment: "prod"}, Storage: storage,
+	})
+	if err := service.StorageCleanup(context.Background(), StorageCleanupRequest{}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if storage.environment != "prod" || !storage.dryRun || locker.acquired != 0 {
+		t.Fatalf("dry-run cleanup = environment %q dry=%v lock=%d", storage.environment, storage.dryRun, locker.acquired)
+	}
+	if err := service.StorageCleanup(context.Background(), StorageCleanupRequest{Apply: true}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if storage.dryRun || locker.acquired != 1 || locker.lock.released != 1 {
+		t.Fatalf("apply cleanup = dry=%v lock=%d/%d", storage.dryRun, locker.acquired, locker.lock.released)
+	}
+}
+
+func TestArchiveUseCasesOwnLayoutAndOutputMapping(t *testing.T) {
+	home := t.TempDir()
+	locker := &fakeLocker{}
+	archive := &fakeArchive{}
+	service := New(Config{
+		HomeDir: home, DBPath: filepath.Join(home, "leapview.db"),
+		DuckLakeCatalog:    filepath.Join(home, "ducklake", "catalog.duckdb"),
+		DuckLakeData:       filepath.Join(home, "ducklake", "data"),
+		ArtifactDir:        filepath.Join(home, "artifacts"),
+		RuntimeDir:         filepath.Join(home, "runtime"),
+		ManagedDataDir:     filepath.Join(home, "managed-data"),
+		ManagedDataBackend: "local",
+	}, Dependencies{
+		Locker: locker, State: &fakeState{environment: "prod", existing: true}, Archive: archive,
+	})
+	var out bytes.Buffer
+	backupPath := filepath.Join(t.TempDir(), "backup.tar.gz")
+	if err := service.Backup(context.Background(), BackupRequest{Out: backupPath}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if archive.backupInstance.Path != backupPath ||
+		len(archive.backupInstance.ExcludeRelativePaths) != 1 ||
+		!strings.Contains(out.String(), "instance backup written: "+backupPath) {
+		t.Fatalf("backup options=%#v output=%q", archive.backupInstance, out.String())
+	}
+	out.Reset()
+	if err := service.Restore(context.Background(), RestoreRequest{
+		From: backupPath, CurrentBackup: "-", Confirm: true,
+	}, nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !archive.restoreInstance.DiscardCurrentBackup ||
+		archive.restoreInstance.ExpectedEnvironment != "prod" ||
+		!strings.Contains(out.String(), "instance restored from: "+backupPath) {
+		t.Fatalf("restore options=%#v output=%q", archive.restoreInstance, out.String())
+	}
+}
+
+func TestMaintenanceRejectsNegativeRetentionBeforeDependencies(t *testing.T) {
+	service := New(Config{}, Dependencies{})
+	err := service.Maintenance(context.Background(), MaintenanceRequest{AuditDays: -1}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "zero or greater") {
+		t.Fatalf("maintenance error = %v", err)
+	}
+}
+
+func TestResolveEnvironmentPropagatesUnexpectedStateFailures(t *testing.T) {
+	service := New(Config{}, Dependencies{State: &fakeState{environmentErr: errors.New("broken")}})
+	if _, err := service.resolveEnvironment(context.Background()); err == nil || !strings.Contains(err.Error(), "broken") {
+		t.Fatalf("resolve environment error = %v", err)
+	}
+	service = New(Config{}, Dependencies{State: &fakeState{environmentErr: sql.ErrNoRows}})
+	if _, err := service.resolveEnvironment(context.Background()); !strings.Contains(err.Error(), sql.ErrNoRows.Error()) {
+		t.Fatalf("raw sql sentinel must not cross the port: %v", err)
+	}
+}

--- a/internal/admin/offline/types.go
+++ b/internal/admin/offline/types.go
@@ -1,0 +1,174 @@
+// Package offline owns offline administrative use cases and the ports they
+// require from application composition.
+package offline
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+const (
+	CredentialRecoveryFileName = ".initial-credentials.json"
+)
+
+var ErrStateNotFound = errors.New("offline Admin state was not found")
+
+// Config is the normalized immutable process configuration required by
+// offline Admin use cases.
+type Config struct {
+	HomeDir            string
+	DBPath             string
+	Environment        string
+	Production         bool
+	BootstrapEmail     string
+	DuckLakeCatalog    string
+	DuckLakeData       string
+	ArtifactDir        string
+	RuntimeDir         string
+	ManagedDataDir     string
+	ManagedDataBackend string
+}
+
+type InitializeRequest struct {
+	Format string
+}
+
+type StorageCleanupRequest struct {
+	Apply bool
+}
+
+type MaintenanceRequest struct {
+	Apply             bool
+	AuditDays         int
+	QueryDays         int
+	ArchivedAgentDays int
+	AuthStateDays     int
+}
+
+type BackupRequest struct {
+	Out          string
+	DatabaseOnly bool
+}
+
+type RestoreRequest struct {
+	From          string
+	CurrentBackup string
+	Confirm       bool
+	DatabaseOnly  bool
+}
+
+// InitialCredentials are the one-time credentials returned by instance
+// initialization.
+type InitialCredentials struct {
+	Email                   string `json:"email"`
+	TemporaryPassword       string `json:"temporaryPassword"`
+	PublisherToken          string `json:"publisherToken"`
+	PublisherTokenExpiresAt string `json:"publisherTokenExpiresAt"`
+}
+
+type InitializationInput struct {
+	Email       string
+	Environment string
+	Now         time.Time
+}
+
+// Initializer owns the audited Access mutation used to initialize an instance.
+// prepare runs inside the same transaction, before commit, so recovery material
+// is durable before credentials become active.
+type Initializer interface {
+	Initialize(context.Context, InitializationInput, func(InitialCredentials) error) (InitialCredentials, error)
+}
+
+type InstanceState interface {
+	Environment(context.Context) (string, error)
+	ExistingEnvironment(context.Context) (string, bool, error)
+	BindEnvironment(context.Context, string) error
+	Initialized(context.Context) (bool, error)
+}
+
+type CredentialRecovery interface {
+	Read() ([]byte, error)
+	Write([]byte) error
+	Remove() error
+}
+
+type Lock interface {
+	Release() error
+}
+
+type Locker interface {
+	Acquire(context.Context) (Lock, error)
+}
+
+type RetentionPolicy struct {
+	AuditEventsMaxAge             time.Duration
+	QueryEventsMaxAge             time.Duration
+	ArchivedAgentConversationsAge time.Duration
+	AuthStateMaxAge               time.Duration
+	DryRun                        bool
+}
+
+type RetentionResult struct {
+	AuditEventsDeleted                  int64
+	QueryEventsDeleted                  int64
+	ArchivedAgentConversationsDeleted   int64
+	ExpiredOAuthStatesDeleted           int64
+	StaleSessionsDeleted                int64
+	StaleAPITokensDeleted               int64
+	StaleServicePrincipalSecretsDeleted int64
+}
+
+type Retention interface {
+	Prune(context.Context, RetentionPolicy) (RetentionResult, error)
+}
+
+type StorageCleaner interface {
+	Cleanup(context.Context, string, bool, io.Writer) error
+}
+
+type BackupOptions struct {
+	Path                 string
+	Writer               io.Writer
+	ExcludeRelativePaths []string
+}
+
+type RestoreOptions struct {
+	Path                 string
+	Reader               io.Reader
+	CurrentBackup        string
+	DiscardCurrentBackup bool
+	ExpectedEnvironment  string
+	ResetRelativePaths   []string
+}
+
+type Archive interface {
+	BackupDatabase(context.Context, BackupOptions) error
+	BackupInstance(context.Context, BackupOptions) error
+	RestoreDatabase(context.Context, RestoreOptions) error
+	RestoreInstance(context.Context, RestoreOptions) error
+}
+
+type Dependencies struct {
+	Locker      Locker
+	State       InstanceState
+	Initializer Initializer
+	Recovery    CredentialRecovery
+	Retention   Retention
+	Storage     StorageCleaner
+	Archive     Archive
+	Now         func() time.Time
+}
+
+type Service struct {
+	config Config
+	deps   Dependencies
+}
+
+func New(config Config, dependencies Dependencies) *Service {
+	if dependencies.Now == nil {
+		dependencies.Now = time.Now
+	}
+	return &Service{config: config, deps: dependencies}
+}

--- a/internal/app/adminoffline/adapters.go
+++ b/internal/app/adminoffline/adapters.go
@@ -1,0 +1,292 @@
+package adminoffline
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Yacobolo/leapview/internal/access"
+	accesssqlite "github.com/Yacobolo/leapview/internal/access/sqlite"
+	adminoffline "github.com/Yacobolo/leapview/internal/admin/offline"
+	adminsqlite "github.com/Yacobolo/leapview/internal/admin/sqlite"
+	analyticsducklake "github.com/Yacobolo/leapview/internal/analytics/ducklake"
+	"github.com/Yacobolo/leapview/internal/platform"
+	"github.com/Yacobolo/leapview/internal/platform/filesystem"
+	"github.com/Yacobolo/leapview/internal/platform/locking"
+	storagemaintenance "github.com/Yacobolo/leapview/internal/servingstate/retention"
+	servingstatesqlite "github.com/Yacobolo/leapview/internal/servingstate/sqlite"
+)
+
+type lockHandle struct {
+	lock *instancelock.Lock
+}
+
+func (handle lockHandle) Release() error { return handle.lock.Release() }
+
+type instanceLocker struct {
+	home string
+}
+
+func (locker instanceLocker) Acquire(context.Context) (adminoffline.Lock, error) {
+	lock, err := instancelock.Acquire(locker.home)
+	if err != nil {
+		return nil, err
+	}
+	return lockHandle{lock: lock}, nil
+}
+
+type instanceState struct {
+	dbPath string
+}
+
+func (state instanceState) withStore(ctx context.Context, operation func(*platform.Store) error) error {
+	store, err := platform.Open(ctx, state.dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	return operation(store)
+}
+
+func (state instanceState) Environment(ctx context.Context) (string, error) {
+	var environment string
+	err := state.withStore(ctx, func(store *platform.Store) error {
+		var err error
+		environment, err = store.InstanceEnvironment(ctx)
+		if errors.Is(err, sql.ErrNoRows) {
+			return adminoffline.ErrStateNotFound
+		}
+		return err
+	})
+	return environment, err
+}
+
+func (state instanceState) ExistingEnvironment(ctx context.Context) (string, bool, error) {
+	if _, err := os.Stat(state.dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	environment, err := state.Environment(ctx)
+	if errors.Is(err, adminoffline.ErrStateNotFound) {
+		return "", true, err
+	}
+	return environment, err == nil, err
+}
+
+func (state instanceState) BindEnvironment(ctx context.Context, environment string) error {
+	return state.withStore(ctx, func(store *platform.Store) error {
+		return store.BindInstanceEnvironment(ctx, environment)
+	})
+}
+
+func (state instanceState) Initialized(ctx context.Context) (bool, error) {
+	initialized := false
+	err := state.withStore(ctx, func(store *platform.Store) error {
+		_, err := store.GetSetting(ctx, access.InstanceInitializedSetting)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		initialized = err == nil
+		return err
+	})
+	return initialized, err
+}
+
+type instanceInitializer struct {
+	dbPath string
+}
+
+func (initializer instanceInitializer) Initialize(
+	ctx context.Context,
+	input adminoffline.InitializationInput,
+	prepare func(adminoffline.InitialCredentials) error,
+) (adminoffline.InitialCredentials, error) {
+	store, err := platform.Open(ctx, initializer.dbPath)
+	if err != nil {
+		return adminoffline.InitialCredentials{}, err
+	}
+	defer store.Close()
+	repository := accesssqlite.NewRepository(store.SQLDB())
+	result, err := repository.InitializeInstance(ctx, access.InstanceInitializationInput{
+		Email: input.Email, Environment: input.Environment, Now: input.Now,
+	}, func(credentials access.InitialInstanceCredentials) error {
+		return prepare(adminoffline.InitialCredentials{
+			Email:                   credentials.Email,
+			TemporaryPassword:       credentials.TemporaryPassword,
+			PublisherToken:          credentials.PublisherToken,
+			PublisherTokenExpiresAt: credentials.PublisherTokenExpiresAt.Format(time.RFC3339),
+		})
+	})
+	if errors.Is(err, access.ErrInstanceAlreadyInitialized) {
+		err = adminoffline.ErrInstanceAlreadyInitialized
+	}
+	return adminoffline.InitialCredentials{
+		Email:                   result.Email,
+		TemporaryPassword:       result.TemporaryPassword,
+		PublisherToken:          result.PublisherToken,
+		PublisherTokenExpiresAt: result.PublisherTokenExpiresAt.Format(time.RFC3339),
+	}, err
+}
+
+type credentialRecovery struct {
+	path string
+}
+
+func (recovery credentialRecovery) Read() ([]byte, error) {
+	return securefs.ReadPrivateFile(recovery.path)
+}
+
+func (recovery credentialRecovery) Write(contents []byte) error {
+	return securefs.WritePrivateFileAtomic(recovery.path, contents)
+}
+
+func (recovery credentialRecovery) Remove() error {
+	return os.Remove(recovery.path)
+}
+
+type operationalRetention struct {
+	dbPath string
+}
+
+func (retention operationalRetention) Prune(ctx context.Context, policy adminoffline.RetentionPolicy) (adminoffline.RetentionResult, error) {
+	store, err := platform.Open(ctx, retention.dbPath)
+	if err != nil {
+		return adminoffline.RetentionResult{}, err
+	}
+	defer store.Close()
+	result, err := adminsqlite.PruneOperationalHistory(ctx, store.SQLDB(), adminsqlite.RetentionOptions{
+		AuditEventsMaxAge:             policy.AuditEventsMaxAge,
+		QueryEventsMaxAge:             policy.QueryEventsMaxAge,
+		ArchivedAgentConversationsAge: policy.ArchivedAgentConversationsAge,
+		AuthStateMaxAge:               policy.AuthStateMaxAge,
+		DryRun:                        policy.DryRun,
+	})
+	return adminoffline.RetentionResult{
+		AuditEventsDeleted:                  result.AuditEventsDeleted,
+		QueryEventsDeleted:                  result.QueryEventsDeleted,
+		ArchivedAgentConversationsDeleted:   result.ArchivedAgentConversationsDeleted,
+		ExpiredOAuthStatesDeleted:           result.ExpiredOAuthStatesDeleted,
+		StaleSessionsDeleted:                result.StaleSessionsDeleted,
+		StaleAPITokensDeleted:               result.StaleAPITokensDeleted,
+		StaleServicePrincipalSecretsDeleted: result.StaleServicePrincipalSecretsDeleted,
+	}, err
+}
+
+type storageCleaner struct {
+	dbPath      string
+	home        string
+	catalogPath string
+	dataPath    string
+}
+
+func (cleaner storageCleaner) Cleanup(ctx context.Context, environment string, dryRun bool, out io.Writer) error {
+	store, err := platform.Open(ctx, cleaner.dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	snapshots, err := analyticsducklake.Open(ctx, analyticsducklake.Config{
+		RootDir: cleaner.home, CatalogPath: cleaner.catalogPath, DataPath: cleaner.dataPath,
+	})
+	if err != nil {
+		return err
+	}
+	defer snapshots.Close()
+	_, err = storagemaintenance.Run(ctx, servingstatesqlite.NewRepository(store.SQLDB()), storagemaintenance.Options{
+		Environment: environment,
+		Snapshots:   snapshots,
+		CatalogPath: cleaner.catalogPath,
+		DataPath:    cleaner.dataPath,
+		DryRun:      dryRun,
+		Out:         out,
+	})
+	return err
+}
+
+type instanceArchive struct {
+	home   string
+	dbPath string
+}
+
+func (archive instanceArchive) BackupDatabase(ctx context.Context, options adminoffline.BackupOptions) error {
+	path := options.Path
+	if options.Writer != nil {
+		var err error
+		path, err = securefs.UnusedTemporaryPath(filepath.Dir(archive.home), "leapview-backup-*.db")
+		if err != nil {
+			return err
+		}
+		defer os.Remove(path)
+	}
+	store, err := platform.Open(ctx, archive.dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	if err := store.Backup(ctx, path); err != nil {
+		return err
+	}
+	if options.Writer != nil {
+		return securefs.CopyFile(options.Writer, path)
+	}
+	return nil
+}
+
+func (archive instanceArchive) BackupInstance(ctx context.Context, options adminoffline.BackupOptions) error {
+	platformOptions := platform.InstanceBackupOptions{
+		HomeDir: archive.home, DBPath: archive.dbPath, OutPath: options.Path,
+		ExcludeRelativePaths: options.ExcludeRelativePaths,
+	}
+	if options.Writer != nil {
+		return platform.BackupInstanceToWriter(ctx, platformOptions, options.Writer)
+	}
+	return platform.BackupInstance(ctx, platformOptions)
+}
+
+func (archive instanceArchive) RestoreDatabase(ctx context.Context, options adminoffline.RestoreOptions) error {
+	path := options.Path
+	if options.Reader != nil {
+		var err error
+		path, err = securefs.CopyPrivateTemporaryFile(options.Reader, filepath.Dir(archive.home), "leapview-restore-*.db")
+		if err != nil {
+			return err
+		}
+		defer os.Remove(path)
+	}
+	current := options.CurrentBackup
+	if options.DiscardCurrentBackup {
+		var err error
+		current, err = securefs.UnusedTemporaryPath(filepath.Dir(archive.home), platform.InstanceRestoreCheckpointPattern)
+		if err != nil {
+			return err
+		}
+		defer os.Remove(current)
+	}
+	if err := platform.ValidateDatabaseInstanceEnvironment(ctx, path, options.ExpectedEnvironment); err != nil {
+		return err
+	}
+	return platform.Restore(ctx, archive.dbPath, path, current)
+}
+
+func (archive instanceArchive) RestoreInstance(ctx context.Context, options adminoffline.RestoreOptions) error {
+	platformOptions := platform.InstanceRestoreOptions{
+		TargetHomeDir:        archive.home,
+		BackupPath:           options.Path,
+		CurrentBackupOut:     options.CurrentBackup,
+		DiscardCurrentBackup: options.DiscardCurrentBackup,
+		ExpectedEnvironment:  options.ExpectedEnvironment,
+		PreserveRelativeFile: instancelock.FileName,
+		ResetRelativePaths:   options.ResetRelativePaths,
+	}
+	if options.Reader != nil {
+		platformOptions.BackupPath = ""
+		return platform.RestoreInstanceFromReader(ctx, platformOptions, options.Reader)
+	}
+	return platform.RestoreInstance(ctx, platformOptions)
+}

--- a/internal/app/adminoffline/compat_test.go
+++ b/internal/app/adminoffline/compat_test.go
@@ -1,0 +1,57 @@
+package adminoffline
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+
+	admincli "github.com/Yacobolo/leapview/internal/admin/cli"
+	offline "github.com/Yacobolo/leapview/internal/admin/offline"
+	"github.com/Yacobolo/leapview/internal/app/config"
+)
+
+type initialInstanceCredentials = offline.InitialCredentials
+
+func runAdminInitialize(ctx context.Context, format string, out io.Writer) error {
+	return (Operations{}).Initialize(ctx, offline.InitializeRequest{Format: format}, out)
+}
+
+func acknowledgeInitialCredentials(ctx context.Context) error {
+	return (Operations{}).AcknowledgeInitialCredentials(ctx)
+}
+
+func initialCredentialRecoveryPath(home string) string {
+	return filepath.Join(home, offline.CredentialRecoveryFileName)
+}
+
+func fullInstanceDerivedPaths(cfg config.Config) ([]string, error) {
+	return offline.New(offline.Config{
+		HomeDir:            cfg.HomeDir,
+		ManagedDataDir:     cfg.ManagedDataDir,
+		ManagedDataBackend: cfg.ManagedDataBackend,
+	}, offline.Dependencies{}).FullInstanceDerivedPaths()
+}
+
+func runAdminBackup(ctx context.Context, options admincli.Options, out io.Writer) error {
+	return (Operations{}).Backup(ctx, offline.BackupRequest{
+		Out: options.BackupOut, DatabaseOnly: options.DatabaseOnly,
+	}, out)
+}
+
+func runAdminRestore(ctx context.Context, options admincli.Options, in io.Reader, out io.Writer) error {
+	return (Operations{}).Restore(ctx, offline.RestoreRequest{
+		From: options.RestoreFrom, CurrentBackup: options.RestoreBefore,
+		Confirm: options.ConfirmRestore, DatabaseOnly: options.DatabaseOnly,
+	}, in, out)
+}
+
+func runAdminMaintenance(ctx context.Context, options admincli.Options, out io.Writer) error {
+	return (Operations{}).Maintenance(ctx, offline.MaintenanceRequest{
+		Apply: options.Apply, AuditDays: options.AuditDays, QueryDays: options.QueryDays,
+		ArchivedAgentDays: options.ArchivedAgentDays, AuthStateDays: options.AuthStateDays,
+	}, out)
+}
+
+func runAdminStorageCleanup(ctx context.Context, options admincli.Options, out io.Writer) error {
+	return (Operations{}).StorageCleanup(ctx, offline.StorageCleanupRequest{Apply: options.Apply}, out)
+}

--- a/internal/app/adminoffline/operations.go
+++ b/internal/app/adminoffline/operations.go
@@ -1,729 +1,96 @@
-// Package adminoffline composes offline administrative operations from
-// capability-owned adapters and application configuration.
+// Package adminoffline composes Admin-owned offline use cases from concrete
+// capability adapters, platform mechanisms, and process configuration.
 package adminoffline
 
 import (
 	"context"
-	"database/sql"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
-	"net/mail"
-	"os"
 	"path/filepath"
-	"strings"
-	"time"
 
-	"github.com/Yacobolo/leapview/internal/access"
-	accesssqlite "github.com/Yacobolo/leapview/internal/access/sqlite"
-	admincli "github.com/Yacobolo/leapview/internal/admin/cli"
-	adminsqlite "github.com/Yacobolo/leapview/internal/admin/sqlite"
-	analyticsducklake "github.com/Yacobolo/leapview/internal/analytics/ducklake"
+	adminoffline "github.com/Yacobolo/leapview/internal/admin/offline"
 	"github.com/Yacobolo/leapview/internal/app/config"
-	"github.com/Yacobolo/leapview/internal/platform"
-	"github.com/Yacobolo/leapview/internal/platform/filesystem"
-	"github.com/Yacobolo/leapview/internal/platform/locking"
-	servingstate "github.com/Yacobolo/leapview/internal/servingstate"
-	storagemaintenance "github.com/Yacobolo/leapview/internal/servingstate/retention"
-	servingstatesqlite "github.com/Yacobolo/leapview/internal/servingstate/sqlite"
 )
 
-// Operations implements the Admin capability's offline operation contract.
 type Operations struct{}
 
-func (Operations) Initialize(ctx context.Context, format string, out io.Writer) error {
-	return runAdminInitialize(ctx, format, out)
+func (Operations) Initialize(ctx context.Context, request adminoffline.InitializeRequest, out io.Writer) error {
+	service, err := newService()
+	if err != nil {
+		return err
+	}
+	return service.Initialize(ctx, request, out)
 }
 
 func (Operations) AcknowledgeInitialCredentials(ctx context.Context) error {
-	return acknowledgeInitialCredentials(ctx)
-}
-
-func (Operations) StorageCleanup(ctx context.Context, values admincli.Options, out io.Writer) error {
-	return runAdminStorageCleanup(ctx, values, out)
-}
-
-func (Operations) Maintenance(ctx context.Context, values admincli.Options, out io.Writer) error {
-	return runAdminMaintenance(ctx, values, out)
-}
-
-func (Operations) Backup(ctx context.Context, values admincli.Options, out io.Writer) error {
-	return runAdminBackup(ctx, values, out)
-}
-
-func (Operations) Restore(ctx context.Context, values admincli.Options, in io.Reader, out io.Writer) error {
-	return runAdminRestore(ctx, values, in, out)
-}
-
-var errInstanceAlreadyInitialized = errors.New("LeapView instance is already initialized")
-
-const (
-	instanceInitializedSetting        = "instance.initialized"
-	initialCredentialRecoveryFileName = ".initial-credentials.json"
-)
-
-// InitialInstanceCredentials are the one-time credentials returned by
-// initialization and evaluation bootstrap.
-type InitialInstanceCredentials struct {
-	Email                   string `json:"email"`
-	TemporaryPassword       string `json:"temporaryPassword"`
-	PublisherToken          string `json:"publisherToken"`
-	PublisherTokenExpiresAt string `json:"publisherTokenExpiresAt"`
-}
-
-type initialInstanceCredentials = InitialInstanceCredentials
-
-func runAdminInitialize(ctx context.Context, format string, out io.Writer) error {
-	if format != "json" {
-		return fmt.Errorf("admin initialize supports only --format json")
+	service, err := newService()
+	if err != nil {
+		return err
 	}
+	return service.AcknowledgeInitialCredentials(ctx)
+}
+
+func (Operations) StorageCleanup(ctx context.Context, request adminoffline.StorageCleanupRequest, out io.Writer) error {
+	service, err := newService()
+	if err != nil {
+		return err
+	}
+	return service.StorageCleanup(ctx, request, out)
+}
+
+func (Operations) Maintenance(ctx context.Context, request adminoffline.MaintenanceRequest, out io.Writer) error {
+	service, err := newService()
+	if err != nil {
+		return err
+	}
+	return service.Maintenance(ctx, request, out)
+}
+
+func (Operations) Backup(ctx context.Context, request adminoffline.BackupRequest, out io.Writer) error {
+	service, err := newService()
+	if err != nil {
+		return err
+	}
+	return service.Backup(ctx, request, out)
+}
+
+func (Operations) Restore(ctx context.Context, request adminoffline.RestoreRequest, in io.Reader, out io.Writer) error {
+	service, err := newService()
+	if err != nil {
+		return err
+	}
+	return service.Restore(ctx, request, in, out)
+}
+
+func newService() (*adminoffline.Service, error) {
 	cfg, err := config.Load()
 	if err != nil {
-		return err
-	}
-	lock, err := instancelock.Acquire(cfg.HomeDir)
-	if err != nil {
-		return err
-	}
-	defer lock.Release()
-	store, err := platform.Open(ctx, cfg.DBPath())
-	if err != nil {
-		return err
-	}
-	defer store.Close()
-	environment := configuredEnvironment(cfg)
-	if err := store.BindInstanceEnvironment(ctx, string(environment)); err != nil {
-		return err
-	}
-	recoveryPath := initialCredentialRecoveryPath(cfg.HomeDir)
-	if _, err := store.GetSetting(ctx, instanceInitializedSetting); err == nil {
-		credentials, readErr := readInitialCredentialRecovery(recoveryPath)
-		if readErr == nil {
-			return writeAll(out, credentials)
-		}
-		if os.IsNotExist(readErr) {
-			return errInstanceAlreadyInitialized
-		}
-		return readErr
-	} else if !errors.Is(err, sql.ErrNoRows) {
-		return err
-	}
-	if err := os.Remove(recoveryPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove stale initialization credentials: %w", err)
-	}
-	email, err := initialAdminEmail(cfg)
-	if err != nil {
-		return err
-	}
-	repo := accesssqlite.NewRepository(store.SQLDB())
-	var result initialInstanceCredentials
-	var encodedResult []byte
-	err = repo.RunAuditedMutationBatch(ctx, func(txRepo access.Repository) ([]access.AuditEventInput, error) {
-		sqliteRepo, ok := txRepo.(*accesssqlite.Repository)
-		if !ok {
-			return nil, fmt.Errorf("initialize access transaction is unavailable")
-		}
-		inserted, err := sqliteRepo.InsertPlatformSettingIfMissing(ctx, instanceInitializedSetting, time.Now().UTC().Format(time.RFC3339))
-		if err != nil {
-			return nil, err
-		}
-		if !inserted {
-			return nil, errInstanceAlreadyInitialized
-		}
-		created, err := txRepo.CreateLocalUser(ctx, access.LocalUserInput{Email: email, DisplayName: email, MustChange: true})
-		if err != nil {
-			return nil, err
-		}
-		principal, err := txRepo.SetPlatformRole(ctx, access.PlatformRoleInput{PrincipalID: created.Principal.ID, Email: email, DisplayName: email, Role: access.RolePlatformAdmin})
-		if err != nil {
-			return nil, err
-		}
-		expires := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
-		token, _, err := txRepo.CreateAPITokenWithMetadata(ctx, access.APITokenInput{
-			PrincipalID: principal.ID,
-			Name:        access.APITokenNameInitialPublisher,
-			Privileges: []access.Privilege{
-				access.PrivilegeUseWorkspace, access.PrivilegeViewItem, access.PrivilegeQueryData,
-				access.PrivilegeRefreshData, access.PrivilegeDeploy, access.PrivilegeActivateDeployment,
-				access.PrivilegeViewData, access.PrivilegeIngestData, access.PrivilegeViewAudit,
-			},
-			ExpiresAt: expires,
-		})
-		if err != nil {
-			return nil, err
-		}
-		result = initialInstanceCredentials{Email: email, TemporaryPassword: created.Password, PublisherToken: token, PublisherTokenExpiresAt: expires.Format(time.RFC3339)}
-		encodedResult, err = json.Marshal(result)
-		if err != nil {
-			return nil, err
-		}
-		encodedResult = append(encodedResult, '\n')
-		if err := writeInitialCredentialRecovery(recoveryPath, encodedResult); err != nil {
-			return nil, err
-		}
-		return []access.AuditEventInput{{PrincipalID: principal.ID, Action: "instance.initialized", TargetType: "instance", TargetID: string(environment), Privilege: access.PrivilegeManagePlatform, Status: "success"}}, nil
-	})
-	if err != nil {
-		_ = os.Remove(recoveryPath)
-		return err
-	}
-	return writeAll(out, encodedResult)
-}
-
-func acknowledgeInitialCredentials(ctx context.Context) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return err
-	}
-	lock, err := instancelock.Acquire(cfg.HomeDir)
-	if err != nil {
-		return err
-	}
-	defer lock.Release()
-	store, err := platform.Open(ctx, cfg.DBPath())
-	if err != nil {
-		return err
-	}
-	defer store.Close()
-	if _, err := offlineInstanceEnvironment(ctx, store, cfg); err != nil {
-		return err
-	}
-	if _, err := store.GetSetting(ctx, instanceInitializedSetting); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("LeapView instance has not been initialized")
-		}
-		return err
-	}
-	if err := os.Remove(initialCredentialRecoveryPath(cfg.HomeDir)); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("acknowledge initialization credentials: %w", err)
-	}
-	return nil
-}
-
-func initialCredentialRecoveryPath(homeDir string) string {
-	return filepath.Join(homeDir, initialCredentialRecoveryFileName)
-}
-
-// InitialCredentialRecoveryPath returns the protected recovery bundle path.
-func InitialCredentialRecoveryPath(homeDir string) string {
-	return initialCredentialRecoveryPath(homeDir)
-}
-
-func readInitialCredentialRecovery(path string) ([]byte, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
 		return nil, err
 	}
-	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
-		return nil, fmt.Errorf("initialization credential recovery file %q must be a private regular file", path)
-	}
-	contents, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var credentials initialInstanceCredentials
-	if err := json.Unmarshal(contents, &credentials); err != nil || credentials.Email == "" || credentials.TemporaryPassword == "" || credentials.PublisherToken == "" {
-		return nil, fmt.Errorf("initialization credential recovery file %q is invalid", path)
-	}
-	return contents, nil
-}
-
-// ReadInitialCredentialRecovery reads and validates a protected recovery
-// bundle.
-func ReadInitialCredentialRecovery(path string) ([]byte, error) {
-	return readInitialCredentialRecovery(path)
-}
-
-func writeInitialCredentialRecovery(path string, contents []byte) error {
-	if err := securefs.EnsurePrivateDir(filepath.Dir(path)); err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".initial-credentials-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(securefs.PrivateFileMode); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(contents); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return err
-	}
-	directory, err := os.Open(filepath.Dir(path))
-	if err != nil {
-		return err
-	}
-	defer directory.Close()
-	if err := directory.Sync(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// WriteInitialCredentialRecovery atomically writes a protected recovery
-// bundle.
-func WriteInitialCredentialRecovery(path string, contents []byte) error {
-	return writeInitialCredentialRecovery(path, contents)
-}
-
-func writeAll(out io.Writer, contents []byte) error {
-	written, err := out.Write(contents)
-	if err == nil && written != len(contents) {
-		return io.ErrShortWrite
-	}
-	return err
-}
-
-// WriteAll writes a complete credential response or returns an error.
-func WriteAll(out io.Writer, contents []byte) error {
-	return writeAll(out, contents)
-}
-
-const (
-	defaultAuditRetentionDays         = 365
-	defaultQueryRetentionDays         = 90
-	defaultArchivedAgentRetentionDays = 180
-	defaultAuthStateRetentionDays     = 30
-)
-
-func initialAdminEmail(cfg config.Config) (string, error) {
-	email := strings.TrimSpace(cfg.BootstrapEmail)
-	if email == "" {
-		if cfg.Production {
-			return "", fmt.Errorf("production instance initialization requires LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL")
-		}
-		email = "admin@localhost"
-	}
-	parsed, err := mail.ParseAddress(email)
-	if err != nil || parsed.Address == "" {
-		return "", fmt.Errorf("instance initialization requires a valid LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL")
-	}
-	return parsed.Address, nil
-}
-
-func runAdminBackup(ctx context.Context, opts admincli.Options, out io.Writer) error {
-	if opts.BackupOut == "" {
-		return fmt.Errorf("admin backup requires --out")
-	}
-	backupPath := opts.BackupOut
-	stream := backupPath == "-"
-	cfg := config.MustLoad()
-	if stream && opts.DatabaseOnly {
-		var err error
-		backupPath, err = unusedTemporaryPathIn(filepath.Dir(cfg.HomeDir), "leapview-backup-*.db")
-		if err != nil {
-			return err
-		}
-		defer os.Remove(backupPath)
-	}
-	lock, err := instancelock.Acquire(cfg.HomeDir)
-	if err != nil {
-		return err
-	}
-	defer lock.Release()
-	if opts.DatabaseOnly {
-		store, err := platform.Open(ctx, cfg.DBPath())
-		if err != nil {
-			return err
-		}
-		defer store.Close()
-		if err := store.Backup(ctx, backupPath); err != nil {
-			return err
-		}
-		if stream {
-			return copyFile(out, backupPath)
-		}
-		fmt.Fprintf(out, "database backup written: %s\n", backupPath)
-		return nil
-	}
-	if err := validateFullInstanceArchiveLayout(cfg); err != nil {
-		return err
-	}
-	derivedPaths, err := fullInstanceDerivedPaths(cfg)
-	if err != nil {
-		return err
-	}
-	backupOptions := platform.InstanceBackupOptions{
-		HomeDir:              cfg.HomeDir,
-		DBPath:               cfg.DBPath(),
-		OutPath:              backupPath,
-		ExcludeRelativePaths: derivedPaths,
-	}
-	if stream {
-		return platform.BackupInstanceToWriter(ctx, backupOptions, out)
-	}
-	if err := platform.BackupInstance(ctx, backupOptions); err != nil {
-		return err
-	}
-	fmt.Fprintf(out, "instance backup written: %s\n", backupPath)
-	return nil
-}
-
-func runAdminRestore(ctx context.Context, opts admincli.Options, in io.Reader, out io.Writer) error {
-	if opts.RestoreFrom == "" {
-		return fmt.Errorf("admin restore requires --from")
-	}
-	if !opts.ConfirmRestore {
-		return fmt.Errorf("admin restore requires --confirm")
-	}
-	cfg := config.MustLoad()
-	restorePath := opts.RestoreFrom
-	restoreLabel := restorePath
-	stream := restorePath == "-"
-	if stream {
-		restoreLabel = "stdin"
-	}
-	if stream && opts.DatabaseOnly {
-		if in == nil {
-			return fmt.Errorf("admin restore --from - requires standard input")
-		}
-		var err error
-		restorePath, err = copyReaderToTemporaryFile(in, filepath.Dir(cfg.HomeDir), "leapview-restore-*.db")
-		if err != nil {
-			return err
-		}
-		defer os.Remove(restorePath)
-	}
-	if stream && !opts.DatabaseOnly && in == nil {
-		return fmt.Errorf("admin restore --from - requires standard input")
-	}
-	restoreBefore := opts.RestoreBefore
-	if restoreBefore == "-" {
-		var err error
-		restoreBefore, err = unusedTemporaryPathIn(filepath.Dir(cfg.HomeDir), platform.InstanceRestoreCheckpointPattern)
-		if err != nil {
-			return err
-		}
-		defer os.Remove(restoreBefore)
-	}
-	lock, err := instancelock.Acquire(cfg.HomeDir)
-	if err != nil {
-		return err
-	}
-	defer lock.Release()
-	expectedEnvironment, err := restoreTargetEnvironment(ctx, cfg)
-	if err != nil {
-		return err
-	}
-	if opts.DatabaseOnly {
-		if err := platform.ValidateDatabaseInstanceEnvironment(ctx, restorePath, string(expectedEnvironment)); err != nil {
-			return err
-		}
-		if err := platform.Restore(ctx, cfg.DBPath(), restorePath, restoreBefore); err != nil {
-			return err
-		}
-		fmt.Fprintf(out, "database restored from: %s\n", restoreLabel)
-		if restoreBefore != "" && opts.RestoreBefore != "-" {
-			fmt.Fprintf(out, "previous database backup: %s\n", restoreBefore)
-		}
-		return nil
-	}
-	if err := validateFullInstanceArchiveLayout(cfg); err != nil {
-		return err
-	}
-	derivedPaths, err := fullInstanceDerivedPaths(cfg)
-	if err != nil {
-		return err
-	}
-	restoreOptions := platform.InstanceRestoreOptions{
-		TargetHomeDir:        cfg.HomeDir,
-		BackupPath:           restorePath,
-		CurrentBackupOut:     restoreBefore,
-		DiscardCurrentBackup: opts.RestoreBefore == "-",
-		ExpectedEnvironment:  string(expectedEnvironment),
-		PreserveRelativeFile: instancelock.FileName,
-		ResetRelativePaths:   derivedPaths,
-	}
-	if stream {
-		restoreOptions.BackupPath = ""
-		err = platform.RestoreInstanceFromReader(ctx, restoreOptions, in)
-	} else {
-		err = platform.RestoreInstance(ctx, restoreOptions)
-	}
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(out, "instance restored from: %s\n", restoreLabel)
-	if restoreBefore != "" && opts.RestoreBefore != "-" {
-		fmt.Fprintf(out, "previous instance backup: %s\n", restoreBefore)
-	}
-	return nil
-}
-
-func unusedTemporaryPathIn(directory, pattern string) (string, error) {
-	if err := os.MkdirAll(directory, securefs.PrivateDirMode); err != nil {
-		return "", err
-	}
-	file, err := os.CreateTemp(directory, pattern)
-	if err != nil {
-		return "", err
-	}
-	path := file.Name()
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
-		return "", err
-	}
-	if err := os.Remove(path); err != nil {
-		return "", err
-	}
-	return path, nil
-}
-
-func copyFile(out io.Writer, path string) error {
-	file, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	_, err = io.Copy(out, file)
-	return err
-}
-
-func copyReaderToTemporaryFile(in io.Reader, directory, pattern string) (string, error) {
-	if err := os.MkdirAll(directory, securefs.PrivateDirMode); err != nil {
-		return "", err
-	}
-	file, err := os.CreateTemp(directory, pattern)
-	if err != nil {
-		return "", err
-	}
-	path := file.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(path)
-		}
-	}()
-	if err := file.Chmod(securefs.PrivateFileMode); err != nil {
-		_ = file.Close()
-		return "", err
-	}
-	if _, err := io.Copy(file, in); err != nil {
-		_ = file.Close()
-		return "", err
-	}
-	if err := file.Sync(); err != nil {
-		_ = file.Close()
-		return "", err
-	}
-	if err := file.Close(); err != nil {
-		return "", err
-	}
-	cleanup = false
-	return path, nil
-}
-
-func restoreTargetEnvironment(ctx context.Context, cfg config.Config) (servingstate.Environment, error) {
-	if _, err := os.Stat(cfg.DBPath()); err == nil {
-		store, err := platform.Open(ctx, cfg.DBPath())
-		if err != nil {
-			return "", err
-		}
-		environment, environmentErr := offlineInstanceEnvironment(ctx, store, cfg)
-		closeErr := store.Close()
-		if environmentErr != nil {
-			return "", environmentErr
-		}
-		if closeErr != nil {
-			return "", closeErr
-		}
-		return environment, nil
-	} else if !os.IsNotExist(err) {
-		return "", err
-	}
-	return configuredEnvironment(cfg), nil
-}
-
-func validateFullInstanceArchiveLayout(cfg config.Config) error {
-	homeAbs, err := filepath.Abs(cfg.HomeDir)
-	if err != nil {
-		return err
-	}
-	paths := map[string]string{"DuckLake catalog": cfg.DuckLakeCatalogPath(), "DuckLake data": cfg.DuckLakeDataDir(), "artifact": cfg.ArtifactDir(), "runtime": cfg.RuntimeDir()}
-	if cfg.ManagedDataBackend == "local" || cfg.ManagedDataBackend == "" {
-		paths["managed-data"] = cfg.ManagedDataDir
-	}
-	for label, path := range paths {
-		pathAbs, err := filepath.Abs(path)
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(homeAbs, pathAbs)
-		if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return fmt.Errorf("full instance backup/restore requires %s path inside LEAPVIEW_HOME; got %s outside %s", label, path, cfg.HomeDir)
-		}
-	}
-	return nil
-}
-
-func fullInstanceDerivedPaths(cfg config.Config) ([]string, error) {
-	homeAbs, err := filepath.Abs(cfg.HomeDir)
-	if err != nil {
-		return nil, err
-	}
-	managedDataAbs, err := filepath.Abs(cfg.ManagedDataDir)
-	if err != nil {
-		return nil, err
-	}
-	backend := strings.TrimSpace(cfg.ManagedDataBackend)
-	var derivedPath string
-	switch backend {
-	case "", "local":
-		derivedPath = filepath.Join(managedDataAbs, "objects", "revisions")
-	case "s3":
-		derivedPath = filepath.Join(managedDataAbs, "runtime")
-	default:
-		return nil, fmt.Errorf("unsupported managed-data backend %q", backend)
-	}
-	relative, err := filepath.Rel(homeAbs, derivedPath)
-	if err != nil {
-		return nil, err
-	}
-	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		if backend == "s3" {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("local managed-data derived path %s is outside %s", derivedPath, cfg.HomeDir)
-	}
-	return []string{filepath.ToSlash(relative)}, nil
-}
-
-// FullInstanceDerivedPaths returns regenerable instance paths excluded from
-// backups.
-func FullInstanceDerivedPaths(cfg config.Config) ([]string, error) {
-	return fullInstanceDerivedPaths(cfg)
-}
-
-func runAdminStorageCleanup(ctx context.Context, opts admincli.Options, out io.Writer) error {
-	cfg := config.MustLoad()
-	lock, err := acquireDestructiveMaintenanceLock(cfg, opts.Apply)
-	if err != nil {
-		return err
-	}
-	defer lock.Release()
-	store, err := platform.Open(ctx, cfg.DBPath())
-	if err != nil {
-		return err
-	}
-	defer store.Close()
-	repo := servingstatesqlite.NewRepository(store.SQLDB())
-	environment, err := offlineInstanceEnvironment(ctx, store, cfg)
-	if err != nil {
-		return err
-	}
-	snapshots, err := analyticsducklake.Open(ctx, analyticsducklake.Config{
-		RootDir: cfg.HomeDir, CatalogPath: cfg.DuckLakeCatalogPath(), DataPath: cfg.DuckLakeDataDir(),
-	})
-	if err != nil {
-		return err
-	}
-	defer snapshots.Close()
-	_, err = storagemaintenance.Run(ctx, repo, storagemaintenance.Options{
-		Environment: string(environment),
-		Snapshots:   snapshots,
-		CatalogPath: cfg.DuckLakeCatalogPath(),
-		DataPath:    cfg.DuckLakeDataDir(),
-		DryRun:      !opts.Apply,
-		Out:         out,
-	})
-	if err != nil {
-		return fmt.Errorf("storage cleanup: %w", err)
-	}
-	return nil
-}
-
-func offlineInstanceEnvironment(ctx context.Context, store *platform.Store, cfg config.Config) (servingstate.Environment, error) {
-	bound, err := store.InstanceEnvironment(ctx)
-	if err == nil {
-		if requested := strings.TrimSpace(cfg.Environment); requested != "" && requested != bound {
-			return "", fmt.Errorf("LeapView instance is bound to environment %q, not %q", bound, requested)
-		}
-		return servingstate.Environment(bound), nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("read instance environment: %w", err)
-	}
-	environment := configuredEnvironment(cfg)
-	if err := store.BindInstanceEnvironment(ctx, string(environment)); err != nil {
-		return "", err
-	}
-	return environment, nil
-}
-
-func runAdminMaintenance(ctx context.Context, opts admincli.Options, out io.Writer) error {
-	if opts.AuditDays < 0 || opts.QueryDays < 0 || opts.ArchivedAgentDays < 0 || opts.AuthStateDays < 0 {
-		return fmt.Errorf("retention days must be zero or greater")
-	}
-	cfg := config.MustLoad()
-	lock, err := acquireDestructiveMaintenanceLock(cfg, opts.Apply)
-	if err != nil {
-		return err
-	}
-	defer lock.Release()
-	store, err := platform.Open(ctx, cfg.DBPath())
-	if err != nil {
-		return err
-	}
-	defer store.Close()
-	result, err := adminsqlite.PruneOperationalHistory(ctx, store.SQLDB(), adminsqlite.RetentionOptions{
-		AuditEventsMaxAge:             days(opts.AuditDays),
-		QueryEventsMaxAge:             days(opts.QueryDays),
-		ArchivedAgentConversationsAge: days(opts.ArchivedAgentDays),
-		AuthStateMaxAge:               days(opts.AuthStateDays),
-		DryRun:                        !opts.Apply,
-	})
-	if err != nil {
-		return fmt.Errorf("operational maintenance: %w", err)
-	}
-	mode := "dry-run"
-	if opts.Apply {
-		mode = "apply"
-	}
-	fmt.Fprintf(out, "mode: %s\n", mode)
-	fmt.Fprintf(out, "audit events: %d\n", result.AuditEventsDeleted)
-	fmt.Fprintf(out, "query events: %d\n", result.QueryEventsDeleted)
-	fmt.Fprintf(out, "archived agent conversations: %d\n", result.ArchivedAgentConversationsDeleted)
-	fmt.Fprintf(out, "expired oauth states: %d\n", result.ExpiredOAuthStatesDeleted)
-	fmt.Fprintf(out, "stale sessions: %d\n", result.StaleSessionsDeleted)
-	fmt.Fprintf(out, "stale api tokens: %d\n", result.StaleAPITokensDeleted)
-	fmt.Fprintf(out, "stale service principal secrets: %d\n", result.StaleServicePrincipalSecretsDeleted)
-	return nil
-}
-
-func acquireDestructiveMaintenanceLock(cfg config.Config, apply bool) (*instancelock.Lock, error) {
-	if !apply {
-		return nil, nil
-	}
-	return instancelock.Acquire(cfg.HomeDir)
-}
-
-func days(value int) time.Duration {
-	if value <= 0 {
-		return 0
-	}
-	return time.Duration(value) * 24 * time.Hour
-}
-
-func configuredEnvironment(cfg config.Config) servingstate.Environment {
-	if value := strings.TrimSpace(cfg.Environment); value != "" {
-		return servingstate.NormalizeEnvironment(servingstate.Environment(value))
-	}
-	if cfg.Production {
-		return servingstate.Environment("prod")
-	}
-	return servingstate.DefaultEnvironment
+	normalized := adminoffline.Config{
+		HomeDir:            cfg.HomeDir,
+		DBPath:             cfg.DBPath(),
+		Environment:        cfg.Environment,
+		Production:         cfg.Production,
+		BootstrapEmail:     cfg.BootstrapEmail,
+		DuckLakeCatalog:    cfg.DuckLakeCatalogPath(),
+		DuckLakeData:       cfg.DuckLakeDataDir(),
+		ArtifactDir:        cfg.ArtifactDir(),
+		RuntimeDir:         cfg.RuntimeDir(),
+		ManagedDataDir:     cfg.ManagedDataDir,
+		ManagedDataBackend: cfg.ManagedDataBackend,
+	}
+	return adminoffline.New(normalized, adminoffline.Dependencies{
+		Locker:      instanceLocker{home: cfg.HomeDir},
+		State:       instanceState{dbPath: cfg.DBPath()},
+		Initializer: instanceInitializer{dbPath: cfg.DBPath()},
+		Recovery: credentialRecovery{
+			path: filepath.Join(cfg.HomeDir, adminoffline.CredentialRecoveryFileName),
+		},
+		Retention: operationalRetention{dbPath: cfg.DBPath()},
+		Storage: storageCleaner{
+			dbPath: cfg.DBPath(), home: cfg.HomeDir,
+			catalogPath: cfg.DuckLakeCatalogPath(), dataPath: cfg.DuckLakeDataDir(),
+		},
+		Archive: instanceArchive{home: cfg.HomeDir, dbPath: cfg.DBPath()},
+	}), nil
 }

--- a/internal/app/cli/evaluation.go
+++ b/internal/app/cli/evaluation.go
@@ -15,10 +15,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Yacobolo/leapview/internal/app/adminoffline"
+	adminoffline "github.com/Yacobolo/leapview/internal/admin/offline"
+	appadminoffline "github.com/Yacobolo/leapview/internal/app/adminoffline"
 	"github.com/Yacobolo/leapview/internal/app/config"
 	manageddatacli "github.com/Yacobolo/leapview/internal/manageddata/cli"
 	"github.com/Yacobolo/leapview/internal/manageddata/localplan"
+	"github.com/Yacobolo/leapview/internal/platform/filesystem"
 	instancelock "github.com/Yacobolo/leapview/internal/platform/locking"
 	"github.com/spf13/cobra"
 )
@@ -263,7 +265,7 @@ func writeEvaluationCompletion(home string, completion evaluationCompletion) err
 	if err != nil {
 		return err
 	}
-	if err := adminoffline.WriteInitialCredentialRecovery(evaluationCompletePath(home), append(contents, '\n')); err != nil {
+	if err := securefs.WritePrivateFileAtomic(evaluationCompletePath(home), append(contents, '\n')); err != nil {
 		return fmt.Errorf("write evaluation completion: %w", err)
 	}
 	return nil
@@ -314,7 +316,7 @@ func configureEvaluationEnvironment(home string) error {
 				return encodeErr
 			}
 			encoded = append(encoded, '\n')
-			err = adminoffline.WriteInitialCredentialRecovery(evaluationRuntimeConfigPath(home), encoded)
+			err = securefs.WritePrivateFileAtomic(evaluationRuntimeConfigPath(home), encoded)
 		}
 	}
 	if err != nil {
@@ -395,8 +397,8 @@ func readEvaluationRuntimeConfig(home string) (evaluationRuntimeConfig, error) {
 func prepareEvaluationCredentials(ctx context.Context, home string) (string, error) {
 	token, err := readEvaluationBootstrapToken(home)
 	if err == nil {
-		if _, statErr := os.Stat(adminoffline.InitialCredentialRecoveryPath(home)); statErr == nil {
-			if ackErr := (adminoffline.Operations{}).AcknowledgeInitialCredentials(ctx); ackErr != nil {
+		if _, statErr := os.Stat(filepath.Join(home, adminoffline.CredentialRecoveryFileName)); statErr == nil {
+			if ackErr := (appadminoffline.Operations{}).AcknowledgeInitialCredentials(ctx); ackErr != nil {
 				return "", ackErr
 			}
 		} else if !os.IsNotExist(statErr) {
@@ -409,24 +411,24 @@ func prepareEvaluationCredentials(ctx context.Context, home string) (string, err
 	}
 
 	var output bytes.Buffer
-	if err := (adminoffline.Operations{}).Initialize(ctx, "json", &output); err != nil {
+	if err := (appadminoffline.Operations{}).Initialize(ctx, adminoffline.InitializeRequest{Format: "json"}, &output); err != nil {
 		return "", fmt.Errorf("initialize evaluation administrator: %w", err)
 	}
-	var credentials adminoffline.InitialInstanceCredentials
+	var credentials adminoffline.InitialCredentials
 	if err := json.Unmarshal(output.Bytes(), &credentials); err != nil || credentials.PublisherToken == "" {
 		return "", fmt.Errorf("evaluation initialization returned invalid credentials")
 	}
-	if err := adminoffline.WriteInitialCredentialRecovery(evaluationFirstLoginPath(home), output.Bytes()); err != nil {
+	if err := securefs.WritePrivateFileAtomic(evaluationFirstLoginPath(home), output.Bytes()); err != nil {
 		return "", fmt.Errorf("store evaluation first-login credentials: %w", err)
 	}
 	bootstrap, err := json.Marshal(evaluationBootstrapCredentials{PublisherToken: credentials.PublisherToken})
 	if err != nil {
 		return "", err
 	}
-	if err := adminoffline.WriteInitialCredentialRecovery(evaluationBootstrapPath(home), append(bootstrap, '\n')); err != nil {
+	if err := securefs.WritePrivateFileAtomic(evaluationBootstrapPath(home), append(bootstrap, '\n')); err != nil {
 		return "", fmt.Errorf("store evaluation bootstrap credential: %w", err)
 	}
-	if err := (adminoffline.Operations{}).AcknowledgeInitialCredentials(ctx); err != nil {
+	if err := (appadminoffline.Operations{}).AcknowledgeInitialCredentials(ctx); err != nil {
 		return "", fmt.Errorf("acknowledge evaluation initialization credentials: %w", err)
 	}
 	return credentials.PublisherToken, nil
@@ -450,14 +452,21 @@ func consumeEvaluationFirstLogin(home string, out io.Writer) error {
 		return fmt.Errorf("acquire evaluation first-login lock: %w", err)
 	}
 	defer lock.Release()
-	contents, err := adminoffline.ReadInitialCredentialRecovery(evaluationFirstLoginPath(home))
+	contents, err := securefs.ReadPrivateFile(evaluationFirstLoginPath(home))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("evaluation first-login credentials have already been consumed or were never created")
 		}
 		return err
 	}
-	if err := adminoffline.WriteAll(out, contents); err != nil {
+	if _, err := adminoffline.DecodeInitialCredentials(contents); err != nil {
+		return err
+	}
+	written, err := out.Write(contents)
+	if err == nil && written != len(contents) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
 		return err
 	}
 	if err := os.Remove(evaluationFirstLoginPath(home)); err != nil {
@@ -467,14 +476,7 @@ func consumeEvaluationFirstLogin(home string, out io.Writer) error {
 }
 
 func readPrivateRegularFile(path string) ([]byte, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		return nil, err
-	}
-	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
-		return nil, fmt.Errorf("private file %q must be a private regular file", path)
-	}
-	return os.ReadFile(path)
+	return securefs.ReadPrivateFile(path)
 }
 
 func syncEvaluationDirectory(path string) error {

--- a/internal/app/cli/evaluation_test.go
+++ b/internal/app/cli/evaluation_test.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Yacobolo/leapview/internal/app/adminoffline"
+	adminoffline "github.com/Yacobolo/leapview/internal/admin/offline"
 	"github.com/Yacobolo/leapview/internal/app/config"
 	"github.com/Yacobolo/leapview/internal/manageddata/localplan"
+	"github.com/Yacobolo/leapview/internal/platform/filesystem"
 	workspacecompiler "github.com/Yacobolo/leapview/internal/project/compiler"
 )
 
@@ -81,7 +82,7 @@ func TestEvaluationCredentialHandoffIsPrivateRecoverableAndOneTime(t *testing.T)
 	if strings.TrimSpace(token) == "" {
 		t.Fatal("evaluation bootstrap token is empty")
 	}
-	if _, err := os.Stat(adminoffline.InitialCredentialRecoveryPath(home)); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(home, adminoffline.CredentialRecoveryFileName)); !os.IsNotExist(err) {
 		t.Fatalf("platform recovery bundle still exists: %v", err)
 	}
 	info, err := os.Stat(evaluationFirstLoginPath(home))
@@ -96,7 +97,7 @@ func TestEvaluationCredentialHandoffIsPrivateRecoverableAndOneTime(t *testing.T)
 	if err := consumeEvaluationFirstLogin(home, &out); err != nil {
 		t.Fatal(err)
 	}
-	var credentials adminoffline.InitialInstanceCredentials
+	var credentials adminoffline.InitialCredentials
 	if err := json.Unmarshal(out.Bytes(), &credentials); err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +118,7 @@ func TestEvaluationCredentialHandoffIsPrivateRecoverableAndOneTime(t *testing.T)
 func TestEvaluationFirstLoginRetainedWhenDeliveryFails(t *testing.T) {
 	home := t.TempDir()
 	contents := []byte(`{"email":"admin@localhost","temporaryPassword":"temporary","publisherToken":"publisher","publisherTokenExpiresAt":"2026-07-28T00:00:00Z"}` + "\n")
-	if err := adminoffline.WriteInitialCredentialRecovery(evaluationFirstLoginPath(home), contents); err != nil {
+	if err := securefs.WritePrivateFileAtomic(evaluationFirstLoginPath(home), contents); err != nil {
 		t.Fatal(err)
 	}
 	if err := consumeEvaluationFirstLogin(home, evaluationErrorWriter{}); err == nil {

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -195,6 +195,68 @@ func TestApplicationCLIAdminOnlyComposesAdminOperations(t *testing.T) {
 	}
 }
 
+func TestOfflineAdminUseCasesAreCapabilityOwned(t *testing.T) {
+	rule, ok := ClassifyPackage("internal/admin/offline")
+	if !ok {
+		t.Fatal("Admin offline package is not classified")
+	}
+	if rule.Capability != "admin" || rule.Layer != LayerUseCase {
+		t.Fatalf("Admin offline classification = %#v, want admin use-case", rule)
+	}
+
+	forbiddenImports := map[string]bool{
+		modulePath + "/internal/access/sqlite":          true,
+		modulePath + "/internal/admin/sqlite":           true,
+		modulePath + "/internal/analytics/ducklake":     true,
+		modulePath + "/internal/app/config":             true,
+		modulePath + "/internal/platform":               true,
+		modulePath + "/internal/platform/locking":       true,
+		modulePath + "/internal/servingstate/retention": true,
+		modulePath + "/internal/servingstate/sqlite":    true,
+	}
+	found := false
+	for _, file := range productionGoFiles(t) {
+		if file.pkgDir != "internal/admin/offline" {
+			continue
+		}
+		found = true
+		for _, imported := range file.imports {
+			if forbiddenImports[imported] {
+				t.Errorf("%s imports concrete application/infrastructure dependency %s", file.path, imported)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("internal/admin/offline production package was not found")
+	}
+
+	compositionFound := false
+	for _, file := range productionGoFiles(t) {
+		if file.pkgDir != "internal/app/adminoffline" {
+			continue
+		}
+		compositionFound = true
+		if !importListContains(file.imports, modulePath+"/internal/admin/offline") {
+			t.Errorf("%s does not compose Admin-owned offline use cases", file.path)
+		}
+		for _, forbidden := range []string{
+			"mail.ParseAddress(",
+			"json.Marshal(",
+			"fmt.Fprintf(",
+			"retention days must be zero or greater",
+			"admin restore requires --confirm",
+			"admin backup requires --out",
+		} {
+			if strings.Contains(file.body, forbidden) {
+				t.Errorf("%s retains offline Admin product behavior %q", file.path, forbidden)
+			}
+		}
+	}
+	if !compositionFound {
+		t.Fatal("internal/app/adminoffline composition package was not found")
+	}
+}
+
 func TestAccessGeneratedAPIIsCapabilityOwned(t *testing.T) {
 	rule, ok := ClassifyPackage("internal/access/api/gen")
 	if !ok {

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2206,6 +2206,23 @@ func TestContinuousIntegrationHealthWorkflowReportsAndAlerts(t *testing.T) {
 	}
 }
 
+func TestPublicSiteBuildGeneratesIgnoredBrowserContracts(t *testing.T) {
+	root := repoRoot(t)
+	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	if err != nil {
+		t.Fatalf("read Taskfile.yml: %v", err)
+	}
+	block := taskfileTaskBlock(t, string(taskfile), "site:build")
+	for _, dependency := range []string{
+		"- task: ui-signals:generate",
+		"- task: visualization-ir:generate",
+	} {
+		if !strings.Contains(block, dependency) {
+			t.Errorf("site:build must generate ignored browser contract %q in a clean checkout", dependency)
+		}
+	}
+}
+
 func workflowJobBlock(t *testing.T, workflow, job string) string {
 	t.Helper()
 	startMarker := "  " + job + ":"
@@ -2219,6 +2236,31 @@ func workflowJobBlock(t *testing.T, workflow, job string) string {
 	}
 	if start < 0 {
 		t.Fatalf("workflow job %q not found", job)
+	}
+	end := len(lines)
+	for index := start + 1; index < len(lines); index++ {
+		line := lines[index]
+		if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "    ") && strings.HasSuffix(line, ":") {
+			end = index
+			break
+		}
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
+func taskfileTaskBlock(t *testing.T, taskfile, task string) string {
+	t.Helper()
+	startMarker := "  " + task + ":"
+	lines := strings.Split(taskfile, "\n")
+	start := -1
+	for index, line := range lines {
+		if line == startMarker {
+			start = index
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("Taskfile task %q not found", task)
 	}
 	end := len(lines)
 	for index := start + 1; index < len(lines); index++ {

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -210,6 +210,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/app/site/visualdocs", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "internal/dashboard/semanticapi", Capability: "dashboard", Layer: LayerAdapter},
 	{Prefix: "internal/access/ui/signals", Capability: "access", Layer: LayerContract},
+	{Prefix: "internal/admin/offline", Capability: "admin", Layer: LayerUseCase},
 	{Prefix: "internal/admin/ui/signals", Capability: "admin", Layer: LayerContract},
 	{Prefix: "internal/agent/ui/signals", Capability: "agent", Layer: LayerContract},
 	{Prefix: "internal/dashboard/ui/signals", Capability: "dashboard", Layer: LayerContract},

--- a/internal/platform/ci/health_test.go
+++ b/internal/platform/ci/health_test.go
@@ -79,8 +79,8 @@ func TestAnalyzeHealth(t *testing.T) {
 			t.Errorf("alerts %v do not contain %q", got.Alerts, alert)
 		}
 	}
-	if got.Selection["docs"].Selected != 1 {
-		t.Fatalf("docs selected count = %d, want 1", got.Selection["docs"].Selected)
+	if got.Selection["docs"].Selected != 5 {
+		t.Fatalf("docs selected count = %d, want 5", got.Selection["docs"].Selected)
 	}
 }
 

--- a/internal/platform/ci/planner.go
+++ b/internal/platform/ci/planner.go
@@ -93,6 +93,7 @@ func PlanChanges(input Input, changes []Change) Plan {
 func FullJobs() Jobs {
 	return Jobs{
 		Prepare:             true,
+		Docs:                true,
 		GoMatrix:            allGoShards(),
 		Frontend:            []string{"core", "reports", "chat", "workspace", "site"},
 		GoAnalysis:          true,

--- a/internal/platform/ci/planner_test.go
+++ b/internal/platform/ci/planner_test.go
@@ -287,6 +287,22 @@ func TestPlanChanges(t *testing.T) {
 	}
 }
 
+func TestFullJobsIncludesIndependentDocumentationGate(t *testing.T) {
+	t.Parallel()
+
+	plan := PlanChanges(Input{Event: "workflow_dispatch"}, nil)
+	if !plan.Effective.Docs {
+		t.Fatal("full CI omits the independent documentation and public-site gate")
+	}
+	if !plan.Effective.Prepare || plan.Effective.FrontendPrepare {
+		t.Fatalf(
+			"full CI generation jobs = prepare %v, frontend-prepare %v; full preparation must subsume the selective frontend preparation job",
+			plan.Effective.Prepare,
+			plan.Effective.FrontendPrepare,
+		)
+	}
+}
+
 func TestParseNameStatusZ(t *testing.T) {
 	t.Parallel()
 

--- a/internal/platform/filesystem/private_file.go
+++ b/internal/platform/filesystem/private_file.go
@@ -1,0 +1,118 @@
+package securefs
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func ReadPrivateFile(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("private file %q must be a private regular file", path)
+	}
+	return os.ReadFile(path)
+}
+
+func WritePrivateFileAtomic(path string, contents []byte) error {
+	if err := EnsurePrivateDir(filepath.Dir(path)); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+"-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(PrivateFileMode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(contents); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+func CopyPrivateTemporaryFile(in io.Reader, directory, pattern string) (string, error) {
+	if err := EnsurePrivateDir(directory); err != nil {
+		return "", err
+	}
+	file, err := os.CreateTemp(directory, pattern)
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(path)
+		}
+	}()
+	if err := file.Chmod(PrivateFileMode); err != nil {
+		_ = file.Close()
+		return "", err
+	}
+	if _, err := io.Copy(file, in); err != nil {
+		_ = file.Close()
+		return "", err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	cleanup = false
+	return path, nil
+}
+
+func UnusedTemporaryPath(directory, pattern string) (string, error) {
+	if err := EnsurePrivateDir(directory); err != nil {
+		return "", err
+	}
+	file, err := os.CreateTemp(directory, pattern)
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := os.Remove(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func CopyFile(out io.Writer, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = io.Copy(out, file)
+	return err
+}

--- a/internal/platform/filesystem/private_file_test.go
+++ b/internal/platform/filesystem/private_file_test.go
@@ -1,0 +1,40 @@
+package securefs
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWritePrivateFileAtomicRoundTripsWithPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "credentials.json")
+	contents := []byte("secret\n")
+	if err := WritePrivateFileAtomic(path, contents); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPrivateFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, contents) {
+		t.Fatalf("contents = %q", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != PrivateFileMode {
+		t.Fatalf("mode = %o", info.Mode().Perm())
+	}
+}
+
+func TestReadPrivateFileRejectsBroadPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadPrivateFile(path); err == nil {
+		t.Fatal("broadly readable private file was accepted")
+	}
+}

--- a/spec.md
+++ b/spec.md
@@ -616,6 +616,7 @@ Rules:
 - Generic wire models such as pagination, problem details, and asynchronous event envelopes live under `platform/http`; capabilities may depend on them without depending on application composition.
 - `app/api` owns only application-wide protocol assembly and the generated aggregate that composes capability route fragments and canonical metadata. It owns no capability dispatcher or behavior.
 - CLI commands call capability use cases or capability-owned generated client methods; they do not repeat operation identifiers, accept untyped request bodies, or implement parallel business workflows.
+- Offline Admin commands call Admin-owned use cases for initialization, retention, analytical cleanup, backup, and restore. Those use cases own validation, sequencing, recovery, and output projection behind explicit capability and platform ports; application composition only injects normalized configuration and concrete adapters.
 - `platform/cliapi` owns only generic credential, target, environment, and transport ports. The application transport owns authentication, HTTP execution, error decoding, and retries; its generic encoding boundary is not exposed to capability CLI adapters.
 - The built-in agent and MCP consume one governed tool catalog derived from product-operation metadata, with shared risk, permission, workspace, credential, execution, projection, audit, and error behavior.
 - UI routes call the same capability use cases as API, CLI, and agent interfaces for equivalent behavior.


### PR DESCRIPTION
## Summary

Moves offline administrative workflows out of application composition and into the Admin capability boundary.

- Adds `internal/admin/offline` as the owner of initialization, credential acknowledgement, operational retention, analytical storage cleanup, backup, and restore use cases.
- Defines explicit ports for Access initialization, instance state, retention, storage cleanup, archives, locking, and credential recovery.
- Reduces `internal/app/adminoffline` to configuration normalization and concrete adapter wiring.
- Moves the atomic audited instance-initialization mutation into Access, including initial user, platform role, publisher token, initialization flag, and audit event.
- Moves generic private-file and temporary-file mechanics into `internal/platform/filesystem`.
- Updates Admin CLI and evaluation bootstrap callers to use capability-owned request and credential contracts.
- Documents and enforces the ownership boundary in the architecture rules and specification.

## Design and invariants

The Admin service owns product policy: request validation, environment binding checks, destructive-operation locking, dry-run/apply semantics, recovery replay, archive layout rules, sequencing, and user-facing output projection. Application composition owns only process configuration and construction of concrete cross-capability adapters.

Instance initialization preserves the recovery invariant: the protected credential recovery file is prepared from inside the same Access transaction before the new credentials become active. If credential preparation fails, the initialization setting, principal, credentials, token, and audit event all roll back together. A repository test covers this failure path.

Architecture tests prevent `internal/admin/offline` from importing concrete SQLite, DuckLake, application configuration, locking, or serving-state implementations, and prevent product workflow behavior from drifting back into `internal/app/adminoffline`.

## Test coverage

- Admin offline unit tests cover validation, recovery/replay, environment resolution, dry-run/apply locking, retention policy mapping, archive layout, restore checkpoint semantics, and output mapping.
- Access SQLite coverage verifies atomic rollback when recovery preparation fails.
- Platform filesystem coverage verifies private permissions and atomic file handling.
- Existing application integration tests remain as cross-capability composition coverage.

## Validation

- `task generated:check`
- Focused Go tests for Access SQLite, Admin offline/CLI, Platform filesystem/architecture, App adminoffline, and App CLI
- `task ci`, including all Go and browser tests, generated checks, `go vet`, race tests, live deployment, Datastar route QA, and Terraform validation/tests

Linear: [LEA-138](https://linear.app/leapstack/issue/LEA-138/move-offline-admin-use-cases-out-of-application-composition)