### PR TITLE
Pin Hetzner site bootstrap to org image

### DIFF
--- a/deploy/hetzner-site/terraform.tfvars.example
+++ b/deploy/hetzner-site/terraform.tfvars.example
@@ -7,4 +7,4 @@ operator_ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIReplaceWithThePr
 
 # Routine releases must not change this value through Terraform. LEA-143
 # updates /opt/leapview-site/deployment.env over the bounded deployment channel.
-bootstrap_site_image = "ghcr.io/yacobolo/leapview-site@sha256:1f4c7ac7fbaa332f96a907ff7daec10d49c26b3bbe5d3a16a7d48c274c5f168a"
+bootstrap_site_image = "ghcr.io/flidai/leapview-site@sha256:48d6bdc758efd6f86af6fa53e3e58ad3dfff94d707d213fc4e39fd2a25b74e0f"

--- a/deploy/hetzner-site/variables.tf
+++ b/deploy/hetzner-site/variables.tf
@@ -65,16 +65,13 @@ variable "operator_ssh_public_key" {
 variable "bootstrap_site_image" {
   description = "Initial public-site image. Routine digest changes are deployed by the release workflow, not Terraform."
   type        = string
-  default     = "ghcr.io/yacobolo/leapview-site@sha256:1f4c7ac7fbaa332f96a907ff7daec10d49c26b3bbe5d3a16a7d48c274c5f168a"
+  default     = "ghcr.io/flidai/leapview-site@sha256:48d6bdc758efd6f86af6fa53e3e58ad3dfff94d707d213fc4e39fd2a25b74e0f"
 
   validation {
-    condition = (
-      can(regex(
-        "^ghcr\\.io/flidai/leapview-site@sha256:[0-9a-f]{64}$",
-        var.bootstrap_site_image,
-      )) ||
-      var.bootstrap_site_image == "ghcr.io/yacobolo/leapview-site@sha256:1f4c7ac7fbaa332f96a907ff7daec10d49c26b3bbe5d3a16a7d48c274c5f168a"
-    )
+    condition = can(regex(
+      "^ghcr\\.io/flidai/leapview-site@sha256:[0-9a-f]{64}$",
+      var.bootstrap_site_image,
+    ))
     error_message = "bootstrap_site_image must be the canonical public-site image pinned by sha256 digest."
   }
 }

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -51,11 +51,9 @@ func TestRepositoryIdentityUsesOrganizationNamespace(t *testing.T) {
 	legacyRepository := "github.com/" + "Yacobolo" + "/leapview"
 	legacyImages := "ghcr.io/" + "yacobolo" + "/leapview"
 	legacyImageAllowlist := map[string]struct{}{
-		"deploy/hetzner-site/terraform.tfvars.example": {},
-		"deploy/hetzner-site/variables.tf":             {},
-		"docs/articles/start/installation.md":          {},
-		"docs/public-release.json":                     {},
-		"scripts/public_site_smoke.test.ts":            {},
+		"docs/articles/start/installation.md": {},
+		"docs/public-release.json":            {},
+		"scripts/public_site_smoke.test.ts":   {},
 	}
 	root := repoRoot(t)
 	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {


### PR DESCRIPTION
## Summary
- pin replacement-server bootstrap to the verified `flidai/leapview-site` digest
- remove the temporary legacy personal-image validation exception
- tighten the repository namespace architecture contract

## Verification
- `go test ./internal/platform/architecture -run TestRepositoryIdentityUsesOrganizationNamespace -count=1`
- `terraform -chdir=deploy/hetzner-site fmt -check -recursive`
- `terraform -chdir=deploy/hetzner-site validate`
- `terraform -chdir=deploy/hetzner-site test`
- deployed digest health and public adoption smoke passed