### PR TITLE
Use Infisical for production site secrets

### DIFF
--- a/.github/workflows/site-infrastructure.yml
+++ b/.github/workflows/site-infrastructure.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: leapview-site-infrastructure
@@ -32,14 +33,31 @@ jobs:
     outputs:
       revision: ${{ steps.identity.outputs.revision }}
     env:
-      TF_TOKEN_app_terraform_io: ${{ secrets.HCP_API_TOKEN }}
-      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
       TF_VAR_ssh_allowed_cidrs: ${{ vars.SITE_SSH_ALLOWED_CIDRS }}
-      TF_VAR_operator_ssh_public_key: ${{ secrets.SITE_SSH_PUBLIC_KEY }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Fetch production infrastructure secrets
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+        with:
+          method: "oidc"
+          identity-id: "7e92da75-ac4f-49f2-8924-4561c3547902"
+          oidc-audience: "https://github.com/flidai"
+          project-slug: "leapview"
+          env-slug: "prod"
+          secret-path: "/hetzner-site/infrastructure"
+
+      - name: Configure Terraform inputs
+        run: |
+          test -n "$HCP_API_TOKEN"
+          test -n "$HCLOUD_TOKEN"
+          echo "TF_TOKEN_app_terraform_io=$HCP_API_TOKEN" >> "$GITHUB_ENV"
+          echo "TF_VAR_hcloud_token=$HCLOUD_TOKEN" >> "$GITHUB_ENV"
+          printf 'TF_VAR_operator_ssh_public_key=%s\n' \
+            "$(tr -d '\r\n' < deploy/hetzner-site/operator-ssh-key.pub)" \
+            >> "$GITHUB_ENV"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
@@ -121,16 +139,33 @@ jobs:
     timeout-minutes: 25
     environment: leapview-site-production
     env:
-      TF_TOKEN_app_terraform_io: ${{ secrets.HCP_API_TOKEN }}
-      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
       TF_VAR_ssh_allowed_cidrs: ${{ vars.SITE_SSH_ALLOWED_CIDRS }}
-      TF_VAR_operator_ssh_public_key: ${{ secrets.SITE_SSH_PUBLIC_KEY }}
 
     steps:
       - name: Checkout planned source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.plan.outputs.revision }}
+
+      - name: Fetch production infrastructure secrets
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+        with:
+          method: "oidc"
+          identity-id: "7e92da75-ac4f-49f2-8924-4561c3547902"
+          oidc-audience: "https://github.com/flidai"
+          project-slug: "leapview"
+          env-slug: "prod"
+          secret-path: "/hetzner-site/infrastructure"
+
+      - name: Configure Terraform inputs
+        run: |
+          test -n "$HCP_API_TOKEN"
+          test -n "$HCLOUD_TOKEN"
+          echo "TF_TOKEN_app_terraform_io=$HCP_API_TOKEN" >> "$GITHUB_ENV"
+          echo "TF_VAR_hcloud_token=$HCLOUD_TOKEN" >> "$GITHUB_ENV"
+          printf 'TF_VAR_operator_ssh_public_key=%s\n' \
+            "$(tr -d '\r\n' < deploy/hetzner-site/operator-ssh-key.pub)" \
+            >> "$GITHUB_ENV"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4

--- a/.github/workflows/site-infrastructure.yml
+++ b/.github/workflows/site-infrastructure.yml
@@ -53,11 +53,12 @@ jobs:
         run: |
           test -n "$HCP_API_TOKEN"
           test -n "$HCLOUD_TOKEN"
-          echo "TF_TOKEN_app_terraform_io=$HCP_API_TOKEN" >> "$GITHUB_ENV"
-          echo "TF_VAR_hcloud_token=$HCLOUD_TOKEN" >> "$GITHUB_ENV"
-          printf 'TF_VAR_operator_ssh_public_key=%s\n' \
-            "$(tr -d '\r\n' < deploy/hetzner-site/operator-ssh-key.pub)" \
-            >> "$GITHUB_ENV"
+          {
+            echo "TF_TOKEN_app_terraform_io=$HCP_API_TOKEN"
+            echo "TF_VAR_hcloud_token=$HCLOUD_TOKEN"
+            printf 'TF_VAR_operator_ssh_public_key=%s\n' \
+              "$(tr -d '\r\n' < deploy/hetzner-site/operator-ssh-key.pub)"
+          } >> "$GITHUB_ENV"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
@@ -161,11 +162,12 @@ jobs:
         run: |
           test -n "$HCP_API_TOKEN"
           test -n "$HCLOUD_TOKEN"
-          echo "TF_TOKEN_app_terraform_io=$HCP_API_TOKEN" >> "$GITHUB_ENV"
-          echo "TF_VAR_hcloud_token=$HCLOUD_TOKEN" >> "$GITHUB_ENV"
-          printf 'TF_VAR_operator_ssh_public_key=%s\n' \
-            "$(tr -d '\r\n' < deploy/hetzner-site/operator-ssh-key.pub)" \
-            >> "$GITHUB_ENV"
+          {
+            echo "TF_TOKEN_app_terraform_io=$HCP_API_TOKEN"
+            echo "TF_VAR_hcloud_token=$HCLOUD_TOKEN"
+            printf 'TF_VAR_operator_ssh_public_key=%s\n' \
+              "$(tr -d '\r\n' < deploy/hetzner-site/operator-ssh-key.pub)"
+          } >> "$GITHUB_ENV"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -669,7 +669,12 @@ tasks:
     requires:
       vars: [LEAPVIEW_SITE_IMAGE]
     cmds:
-      - ./scripts/deploy_site.sh
+      - >-
+        infisical run --silent
+        --env prod
+        --path /hetzner-site/operator
+        --projectId c52a0183-fc82-4614-b437-c237a889d79c
+        -- ./scripts/deploy_site.sh
 
   node:audit:
     desc: Scan JavaScript dependencies for known vulnerabilities

--- a/deploy/hetzner-site/README.md
+++ b/deploy/hetzner-site/README.md
@@ -34,10 +34,23 @@ The protected `leapview-site-production` GitHub environment must provide:
 
 | Kind | Name | Purpose |
 | --- | --- | --- |
-| secret | `HCP_API_TOKEN` | HCP Terraform workspace state access |
-| secret | `HCLOUD_TOKEN` | Hetzner Cloud resource management |
-| secret | `SITE_SSH_PUBLIC_KEY` | Production deployment public key |
 | variable | `SITE_SSH_ALLOWED_CIDRS` | JSON list of restricted operator CIDRs |
+
+Production credentials live in the Infisical `leapview` project:
+
+| Environment/path | Secret | Purpose |
+| --- | --- | --- |
+| `prod:/hetzner-site/infrastructure` | `HCP_API_TOKEN` | HCP Terraform workspace state access |
+| `prod:/hetzner-site/infrastructure` | `HCLOUD_TOKEN` | Hetzner Cloud resource management |
+| `prod:/hetzner-site/operator` | `SITE_SSH_PRIVATE_KEY` | Production operator identity for routine site deployments |
+
+GitHub authenticates to Infisical with OIDC; there is no long-lived Infisical
+credential in GitHub. The machine identity is organization-level `no-access`,
+project-level `viewer`, and bound to the `flidai/leapview` repository plus the
+`leapview-site-production` GitHub environment. The current Infisical plan does
+not support a custom folder-scoped role, so the workflow additionally fetches
+only `/hetzner-site/infrastructure`. The non-secret operator public key is
+versioned in `operator-ssh-key.pub`.
 
 Configure required reviewers and prevent administrators from bypassing the
 environment gate. The workflow first creates and retains a readable and binary
@@ -78,11 +91,16 @@ package pinned by digest:
 LEAPVIEW_SITE_IMAGE='ghcr.io/flidai/leapview-site@sha256:<digest>' task site:deploy
 ```
 
-By default it connects to the reserved production IPv4 with
-`~/.ssh/leapview-site-production`. Override that path with
-`LEAPVIEW_SITE_SSH_KEY` when needed. The reviewed, non-secret SSH host-key
-fingerprint is stored in `ssh-host-key.sha256`; change it only after verifying
-a deliberate server replacement against the Hetzner control plane.
+The task uses the authenticated Infisical CLI session to inject
+`prod:/hetzner-site/operator/SITE_SSH_PRIVATE_KEY`. The operator writes it to a
+mode-0600 temporary file for the duration of the command and removes it on
+exit. For break-glass operation, invoke `scripts/deploy_site.sh` directly and
+set `LEAPVIEW_SITE_SSH_KEY` to a readable identity file; without either input,
+the script falls back to `~/.ssh/leapview-site-production`.
+
+The reviewed, non-secret SSH host-key fingerprint is stored in
+`ssh-host-key.sha256`; change it only after verifying a deliberate server
+replacement against the Hetzner control plane.
 
 The operator command scans the presented host key into a temporary
 `known_hosts` file, requires the exact reviewed fingerprint, installs the

--- a/deploy/hetzner-site/deployment_test.go
+++ b/deploy/hetzner-site/deployment_test.go
@@ -230,6 +230,8 @@ func TestOperatorDeploymentPinsTheServerIdentityAndQualifiesThePublicRoute(t *te
 		"StrictHostKeyChecking=yes",
 		"UserKnownHostsFile=",
 		"deploy/hetzner-site/ssh-host-key.sha256",
+		"SITE_SSH_PRIVATE_KEY",
+		"chmod 0600",
 		"/opt/leapview-site/deploy.sh",
 		"https://leapview.dev/healthz",
 		"https://leapview.dev/readyz",
@@ -253,6 +255,9 @@ func TestTaskExposesTheBoundedSiteDeployment(t *testing.T) {
 	for _, fragment := range []string{
 		"site:deploy:",
 		"vars: [LEAPVIEW_SITE_IMAGE]",
+		"infisical run",
+		"--path /hetzner-site/operator",
+		"--projectId c52a0183-fc82-4614-b437-c237a889d79c",
 		"./scripts/deploy_site.sh",
 	} {
 		requireContains(t, taskfile, fragment)
@@ -262,6 +267,7 @@ func TestTaskExposesTheBoundedSiteDeployment(t *testing.T) {
 func TestRemoteStateAndReviewedApplyWorkflow(t *testing.T) {
 	backend := readFile(t, "backend.tf")
 	workflow := readFile(t, filepath.Join("..", "..", ".github", "workflows", "site-infrastructure.yml"))
+	operatorPublicKey := readFile(t, "operator-ssh-key.pub")
 	for _, fragment := range []string{
 		`cloud {`,
 		`organization = "Flid"`,
@@ -282,14 +288,29 @@ func TestRemoteStateAndReviewedApplyWorkflow(t *testing.T) {
 		"terraform apply",
 		"terraform plan -detailed-exitcode",
 		"TF_TOKEN_app_terraform_io",
-		"secrets.HCP_API_TOKEN",
 		"TF_VAR_hcloud_token",
+		"id-token: write",
+		"Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16",
+		`method: "oidc"`,
+		`identity-id: "7e92da75-ac4f-49f2-8924-4561c3547902"`,
+		`oidc-audience: "https://github.com/flidai"`,
+		`project-slug: "leapview"`,
+		`env-slug: "prod"`,
+		`secret-path: "/hetzner-site/infrastructure"`,
+		"deploy/hetzner-site/operator-ssh-key.pub",
 	} {
 		requireContains(t, workflow, fragment)
+	}
+	if got := strings.Count(workflow, "Infisical/secrets-action@"); got != 2 {
+		t.Errorf("expected plan and apply to each fetch Infisical secrets, got %d uses", got)
+	}
+	if !strings.HasPrefix(operatorPublicKey, "ssh-ed25519 ") {
+		t.Errorf("operator public key must be a checked-in Ed25519 public key")
 	}
 	for _, forbidden := range []string{
 		"terraform destroy", "pull_request:", "-auto-approve",
 		"aws s3api", "TF_STATE_", "AWS_ENDPOINT_URL_S3",
+		"secrets.HCP_API_TOKEN", "secrets.HCLOUD_TOKEN", "secrets.SITE_SSH_PUBLIC_KEY",
 	} {
 		if strings.Contains(workflow, forbidden) {
 			t.Errorf("permanent infrastructure workflow contains forbidden fragment %q", forbidden)

--- a/deploy/hetzner-site/operator-ssh-key.pub
+++ b/deploy/hetzner-site/operator-ssh-key.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDPn1gkPGeVRCzpEfTBziOvzPmjFqa/nDrRto6DwSctp leapview-site-production

--- a/scripts/deploy_site.sh
+++ b/scripts/deploy_site.sh
@@ -4,8 +4,21 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 site_image="${LEAPVIEW_SITE_IMAGE:?Set LEAPVIEW_SITE_IMAGE to an immutable ghcr.io/flidai/leapview-site digest}"
 site_host="${LEAPVIEW_SITE_HOST:-178.105.204.14}"
-identity_file="${LEAPVIEW_SITE_SSH_KEY:-${HOME}/.ssh/leapview-site-production}"
 fingerprint_file="$repo_root/deploy/hetzner-site/ssh-host-key.sha256"
+temporary_directory="$(mktemp -d)"
+cleanup() {
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+identity_file="${LEAPVIEW_SITE_SSH_KEY:-}"
+if [[ -z "$identity_file" && -n "${SITE_SSH_PRIVATE_KEY:-}" ]]; then
+  identity_file="$temporary_directory/operator-identity"
+  printf '%s\n' "$SITE_SSH_PRIVATE_KEY" >"$identity_file"
+  chmod 0600 "$identity_file"
+  unset SITE_SSH_PRIVATE_KEY
+fi
+identity_file="${identity_file:-${HOME}/.ssh/leapview-site-production}"
 
 immutable_site_reference='^ghcr\.io/flidai/leapview-site@sha256:[0-9a-f]{64}$'
 if [[ ! "$site_image" =~ $immutable_site_reference ]]; then
@@ -29,12 +42,6 @@ for command in curl scp ssh ssh-keygen ssh-keyscan; do
 done
 
 expected_fingerprint="$(tr -d '[:space:]' <"$fingerprint_file")"
-temporary_directory="$(mktemp -d)"
-cleanup() {
-  rm -rf "$temporary_directory"
-}
-trap cleanup EXIT
-
 scanned_keys="$temporary_directory/scanned-host-keys"
 pinned_known_hosts="$temporary_directory/known-hosts"
 if ! ssh-keyscan -T 10 "$site_host" >"$scanned_keys" 2>"$temporary_directory/ssh-keyscan.log"; then


### PR DESCRIPTION
## Summary

- authenticate the permanent Hetzner infrastructure workflow to Infisical with GitHub OIDC
- keep the operator SSH public key in source and move HCP, Hetzner, and operator credentials into separated Infisical production paths
- fetch the production operator identity into a mode-0600 temporary file for `task site:deploy`
- document the trust and break-glass model and enforce it with deployment contract tests

## External setup completed

- Infisical project: `leapview` with delete protection
- production paths: `/hetzner-site/infrastructure` and `/hetzner-site/operator`
- GitHub OIDC identity: organization `no-access`, project `viewer`, bound to repository `flidai/leapview`, environment `leapview-site-production`, and audience `https://github.com/flidai`
- access token TTL: 15 minutes

## Verification

- production no-op deploy through Infisical-backed `task site:deploy`: passed
- `go test ./deploy/hetzner-site`: passed
- Actionlint v1.7.12: passed
- generated artifact checks: passed
- `go vet ./...`: passed
- race tests for `pkg/...`, `internal/access`, and `internal/runtimehost`: passed
- DatastarLit route QA: passed for 8 routes
- Terraform validation/tests: 4 product + 6 site tests passed

Canonical `task ci` exposed two unrelated existing release-gate flakes and therefore did not complete cleanly:

- `TestChatNewRendersDraftWithoutCreatingConversation` failed under four-shard load, then passed isolated; LEA-71 was reopened.
- the public-site MapLibre documentation test left density/path examples busy; tracked as LEA-167. All 44 other site tests passed.

## Required before workflow dispatch

A repository administrator must recreate the `leapview-site-production` environment, restrict it to `main`, and set environment variable:

```text
SITE_SSH_ALLOWED_CIDRS=["93.165.253.150/32"]
```

No GitHub secrets are required for this workflow.
