### PR TITLE
Use Infisical for ephemeral Hetzner qualification

### DIFF
--- a/.github/workflows/hetzner-deploy.yml
+++ b/.github/workflows/hetzner-deploy.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ephemeral-hetzner-deployment
@@ -20,10 +21,9 @@ jobs:
     name: Deploy, recover, and destroy
     runs-on: ubuntu-24.04
     timeout-minutes: 35
-    environment: hetzner-deployment
+    environment: leapview-ephemeral-qualification
     env:
       TF_IN_AUTOMATION: "true"
-      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
       TF_VAR_name: leapview-ci-${{ github.run_id }}
       TF_VAR_admin_email: ci-${{ github.run_id }}@leapview.local
       TF_VAR_leapview_image: ${{ inputs.image_digest }}
@@ -32,6 +32,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Fetch ephemeral infrastructure secrets
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
+        with:
+          method: "oidc"
+          identity-id: "6aac9c3e-4f33-45b5-aa4e-884839b950a7"
+          oidc-audience: "https://github.com/flidai"
+          domain: "https://us.infisical.com"
+          project-slug: "leapview"
+          env-slug: "prod"
+          secret-path: "/hetzner-qualification/infrastructure"
+
+      - name: Configure Terraform credentials
+        run: |
+          test -n "$HCLOUD_TOKEN"
+          echo "TF_VAR_hcloud_token=$HCLOUD_TOKEN" >> "$GITHUB_ENV"
+          echo "HCLOUD_TOKEN=" >> "$GITHUB_ENV"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -37,6 +37,19 @@ lifecycle controller and files as the generic self-hosting package.
 When `domain` is empty, the deployment uses an HTTPS `sslip.io` hostname. That
 is useful for evaluation. Set a domain you control for a durable installation.
 
+## Hosted qualification
+
+The manually dispatched `Ephemeral Hetzner deployment` workflow exercises this
+topology from an immutable application image. It creates an isolated server,
+qualifies public health, consumes the one-time first-login credentials, proves
+backup and restore, and destroys the server even when an earlier step fails.
+
+The job is protected by the `leapview-ephemeral-qualification` GitHub
+environment and authenticates to Infisical through GitHub OIDC. The dedicated
+project identity can read `prod:/hetzner-qualification/infrastructure`, which
+contains only `HCLOUD_TOKEN`. No long-lived Hetzner or Infisical credential is
+stored in GitHub.
+
 ## First Login
 
 Provisioning creates a local platform administrator, a forced-change temporary

--- a/deploy/hetzner/deployment_test.go
+++ b/deploy/hetzner/deployment_test.go
@@ -196,14 +196,31 @@ func assertDockerfileImagesPinned(t *testing.T, name, dockerfile string) {
 func TestEphemeralDeploymentExercisesPublicAndBackupContracts(t *testing.T) {
 	workflow := readFile(t, filepath.Join("..", "..", ".github", "workflows", "hetzner-deploy.yml"))
 	for _, fragment := range []string{
-		"workflow_dispatch:", "environment: hetzner-deployment", "terraform apply",
+		"workflow_dispatch:", "environment: leapview-ephemeral-qualification", "terraform apply",
 		"public_ready=false", "--connect-timeout 5", "leapviewctl backup", "leapviewctl restore",
 		`.publisherToken`, "if: always()", "terraform destroy",
+		"id-token: write",
+		"Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16",
+		`method: "oidc"`,
+		`identity-id: "6aac9c3e-4f33-45b5-aa4e-884839b950a7"`,
+		`oidc-audience: "https://github.com/flidai"`,
+		`domain: "https://us.infisical.com"`,
+		`project-slug: "leapview"`,
+		`env-slug: "prod"`,
+		`secret-path: "/hetzner-qualification/infrastructure"`,
 	} {
 		requireContains(t, workflow, fragment)
 	}
 	if strings.Contains(workflow, "pull_request:") {
 		t.Fatal("cloud deployment must require an explicit, environment-protected dispatch")
+	}
+	for _, forbidden := range []string{
+		"environment: hetzner-deployment",
+		"secrets.HCLOUD_TOKEN",
+	} {
+		if strings.Contains(workflow, forbidden) {
+			t.Errorf("ephemeral deployment workflow contains forbidden fragment %q", forbidden)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the ephemeral Hetzner workflow's GitHub `HCLOUD_TOKEN` with GitHub OIDC and a dedicated Infisical project identity
- bind the workflow to `leapview-ephemeral-qualification` and read only `prod:/hetzner-qualification/infrastructure`
- document the hosted create/qualify/restore/destroy lifecycle and enforce the secretless GitHub contract

## Evidence
- red-green contract test for the environment, identity, path, and forbidden GitHub secret
- `go test ./deploy/hetzner -count=1`
- Terraform validate and all 4 Terraform contract tests
- actionlint v1.7.12

## Admin prerequisite before merge/live qualification
Create the GitHub environment `leapview-ephemeral-qualification`, restrict it to `main`, and do not add any secrets. The Infisical path and OIDC identity are already configured.