### PR TITLE
Fix discarded full-instance restore checkpoints

### DIFF
--- a/internal/app/adminoffline/adapters.go
+++ b/internal/app/adminoffline/adapters.go
@@ -275,10 +275,19 @@ func (archive instanceArchive) RestoreDatabase(ctx context.Context, options admi
 }
 
 func (archive instanceArchive) RestoreInstance(ctx context.Context, options adminoffline.RestoreOptions) error {
+	current := options.CurrentBackup
+	if options.DiscardCurrentBackup {
+		var err error
+		current, err = securefs.UnusedTemporaryPath(filepath.Dir(archive.home), platform.InstanceRestoreCheckpointPattern)
+		if err != nil {
+			return err
+		}
+		defer os.Remove(current)
+	}
 	platformOptions := platform.InstanceRestoreOptions{
 		TargetHomeDir:        archive.home,
 		BackupPath:           options.Path,
-		CurrentBackupOut:     options.CurrentBackup,
+		CurrentBackupOut:     current,
 		DiscardCurrentBackup: options.DiscardCurrentBackup,
 		ExpectedEnvironment:  options.ExpectedEnvironment,
 		PreserveRelativeFile: instancelock.FileName,

--- a/internal/app/adminoffline/operations_test.go
+++ b/internal/app/adminoffline/operations_test.go
@@ -116,12 +116,33 @@ func TestAdminBackupStreamsRestorableInstanceArchive(t *testing.T) {
 	}
 	targetHome := filepath.Join(t.TempDir(), "volume", "home")
 	setAdminStorageEnv(t, targetHome)
+	current, err := platform.Open(ctx, filepath.Join(targetHome, "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := current.UpsertSetting(ctx, "stream-test", "current"); err != nil {
+		t.Fatal(err)
+	}
+	if err := current.Close(); err != nil {
+		t.Fatal(err)
+	}
 	var restoreOutput bytes.Buffer
-	if err := runAdminRestore(ctx, admincli.Options{RestoreFrom: "-", ConfirmRestore: true}, bytes.NewReader(archive.Bytes()), &restoreOutput); err != nil {
+	if err := runAdminRestore(ctx, admincli.Options{
+		RestoreFrom:    "-",
+		RestoreBefore:  "-",
+		ConfirmRestore: true,
+	}, bytes.NewReader(archive.Bytes()), &restoreOutput); err != nil {
 		t.Fatalf("restore streamed backup: %v", err)
 	}
 	if !strings.Contains(restoreOutput.String(), "instance restored from: stdin") {
 		t.Fatalf("restore output = %q", restoreOutput.String())
+	}
+	checkpoints, err := filepath.Glob(filepath.Join(filepath.Dir(targetHome), platform.InstanceRestoreCheckpointPattern))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checkpoints) != 0 {
+		t.Fatalf("discarded restore checkpoints remain: %v", checkpoints)
 	}
 	restored, err := platform.Open(ctx, filepath.Join(targetHome, "leapview.db"))
 	if err != nil {


### PR DESCRIPTION
## Summary
- allocate a private temporary full-instance checkpoint when `--current-out -` is requested
- delete the discarded checkpoint after restore
- cover streamed restore into a non-empty instance with an integration regression test

## Evidence
- Reproduced by ephemeral Hetzner qualification: https://github.com/flidai/leapview/actions/runs/30454023732
- Confirmed the failed run destroyed its server and independently verified no matching Hetzner server remains
- Focused red/green regression test
- Full local frontend, documentation, Go, race, static, UI route QA, and Terraform contract suites passed

After merge, publish a fresh candidate image and rerun the full ephemeral Hetzner create/health/first-login/backup/restore/destroy lifecycle.