### PR TITLE
test(access): avoid expired initialization fixture

### DIFF
--- a/internal/access/sqlite/repository_test.go
+++ b/internal/access/sqlite/repository_test.go
@@ -124,7 +124,7 @@ func TestRepositoryInitializeInstanceRollsBackWhenCredentialPreparationFails(t *
 	_, err := repo.InitializeInstance(ctx, access.InstanceInitializationInput{
 		Email:       "admin@example.com",
 		Environment: "production",
-		Now:         time.Date(2026, time.July, 29, 12, 0, 0, 0, time.UTC),
+		Now:         time.Now().UTC(),
 	}, func(access.InitialInstanceCredentials) error {
 		return prepareErr
 	})


### PR DESCRIPTION
## Why

`TestRepositoryInitializeInstanceRollsBackWhenCredentialPreparationFails` hard-coded July 29, 2026 as its initialization clock. The derived 24-hour publisher token expired on July 30, causing the package test shard—and unrelated feature PRs—to fail before reaching the rollback callback.

## Change

Use the test execution clock for this rollback-only fixture. The production expiry remains 24 hours and the test still proves that credential-preparation failure rolls back the setting, principal, and audit event.

## Validation

- `GOFLAGS=-tags=duckdb_arrow go test ./internal/access/sqlite -run TestRepositoryInitializeInstanceRollsBackWhenCredentialPreparationFails -count=20`