### PR TITLE
Fix concurrent APIGen cache corruption in CI

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -491,7 +491,11 @@ tasks:
       - docs/api/openapi.yaml
       - docs/api/operations.json
     cmds:
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 typespec-compile -manifest api/apigen.yaml -target leapview-v1
+      - |
+        set -eu
+        cache_dir="$(mktemp -d)"
+        trap 'rm -rf "${cache_dir}"' EXIT
+        XDG_CACHE_HOME="${cache_dir}" go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 typespec-compile -manifest api/apigen.yaml -target leapview-v1
       - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 all -manifest api/apigen.yaml -target leapview-v1
       - go run ./internal/app/tools/openapidocgen
 
@@ -509,7 +513,11 @@ tasks:
       - internal/agent/contracts/models.gen.go
       - internal/agent/contracts/schemas.gen.go
     cmds:
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 typespec-compile -manifest api/apigen.yaml -target agent-tool-contracts
+      - |
+        set -eu
+        cache_dir="$(mktemp -d)"
+        trap 'rm -rf "${cache_dir}"' EXIT
+        XDG_CACHE_HOME="${cache_dir}" go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 typespec-compile -manifest api/apigen.yaml -target agent-tool-contracts
       - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 all -manifest api/apigen.yaml -target agent-tool-contracts
       - go run ./internal/agent/contracts/generate
 
@@ -557,7 +565,11 @@ tasks:
       - internal/workspace/ui/signals/models.gen.go
       - web/generated/signals/index.ts
     cmds:
-      - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 typespec-compile -manifest api/apigen.yaml -target ui-signals
+      - |
+        set -eu
+        cache_dir="$(mktemp -d)"
+        trap 'rm -rf "${cache_dir}"' EXIT
+        XDG_CACHE_HOME="${cache_dir}" go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 typespec-compile -manifest api/apigen.yaml -target ui-signals
       - go run github.com/Yacobolo/toolbelt/apigen/cmd/apigen@v0.7.3 all -manifest api/apigen.yaml -target ui-signals
       - go run ./internal/app/tools/signalcontracts
 


### PR DESCRIPTION
## Summary

Fixes the deterministic documentation CI race where parallel TypeSpec generators delete and rebuild the same APIGen package cache.

APIGen v0.7.3 resolves its managed emitter under `os.UserCacheDir()` and, when the marker is absent, calls `RemoveAll(packageDir)` before rebuilding it. LeapView runs `api:generate`, `ui-signals:generate`, and `agent-contracts:generate` concurrently, so clean GitHub runners can corrupt that shared directory (`directory not empty`, `uv_cwd`, or missing emitter errors).

Each TypeSpec compilation now gets a private temporary `XDG_CACHE_HOME`, removed on exit. This preserves parallel generation and eliminates shared mutable cache state.

## Verification

- `task --force --parallel api:generate ui-signals:generate agent-contracts:generate`
- `task ci:test:docs-site`
- generated outputs remain unchanged

This PR is independent of the rtest feature stack and should be reviewed separately. It does not merge any existing PR.
