### PR TITLE
feat(rtest): harden shared-worker isolation and recovery

### DIFF
--- a/rtest/README.md
+++ b/rtest/README.md
@@ -10,7 +10,7 @@ GitHub-hosted runners without defining a proprietary execution protocol:
 - Testcontainers owns integration-test dependencies.
 
 ```console
-rtest exec -- go test -count=1 -race ./...
+rtest exec --cache go-build=/root/.cache/go-build --cache go-mod=/go/pkg/mod -- go test -count=1 -race ./...
 rtest exec -- task test
 rtest build -- --push -t ghcr.io/example/service:sha .
 rtest image build --tag ghcr.io/example/ci:rtest --file Dockerfile.rtest
@@ -19,8 +19,10 @@ rtest image build --tag ghcr.io/example/ci:rtest --file Dockerfile.rtest
 Git selects tracked and untracked non-ignored files from the exact worktree. The REAPI CAS
 uploads only missing content, so a repeated action transfers zero unchanged file bytes.
 Test action results are deliberately not cached because Testcontainers and other external
-services make them non-hermetic. Go module/build caches and Docker/BuildKit layers remain
-persistent on the worker.
+services make them non-hermetic. Projects may explicitly declare persistent OCI-directory
+caches with repeatable `--cache NAME=/absolute/container/path` flags. The server scopes
+each writable directory to the immutable project ID; cache names never imply a language
+or tool. Docker/BuildKit layers remain persistent on the worker.
 
 The target service does not supply a language runner. Each project selects a
 digest-pinned OCI image, while rtest injects only its static CAS/materialization

--- a/rtest/api/rtest/v1/control.proto
+++ b/rtest/api/rtest/v1/control.proto
@@ -201,6 +201,12 @@ message Job {
   string error_message = 16;
   bool cancel_requested = 17;
   string worker_id = 18;
+  repeated CacheMount caches = 19;
+}
+
+message CacheMount {
+  string name = 1;
+  string target = 2;
 }
 
 message PrepareJobRequest {
@@ -213,6 +219,7 @@ message PrepareJobRequest {
   string cpus = 7;
   string memory = 8;
   string idempotency_key = 9;
+  repeated CacheMount caches = 10;
 }
 
 message DataPlaneConnection {

--- a/rtest/cmd/rtest-job-entrypoint/main.go
+++ b/rtest/cmd/rtest-job-entrypoint/main.go
@@ -12,10 +12,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/flidai/leapview/rtest/internal/cas"
+	"golang.org/x/sys/unix"
 )
 
 type result struct {
@@ -77,6 +79,15 @@ func run() int {
 			return finish(jobDirectory, "failed", 1)
 		}
 	}
+	releaseWorker, err := acquireWorkerSlot(ctx, required("RTEST_WORKER_LOCK"), stderr)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		if ctx.Err() != nil {
+			return finish(jobDirectory, "cancelled", 130)
+		}
+		return finish(jobDirectory, "failed", 1)
+	}
+	defer releaseWorker()
 	command := exec.CommandContext(ctx, os.Args[1], os.Args[2:]...)
 	workingDirectory, err := resolveWorkingDirectory(workspace, os.Getenv("RTEST_WORKING_DIRECTORY"))
 	if err != nil {
@@ -110,6 +121,53 @@ func run() int {
 	}
 	fmt.Fprintln(stderr, err)
 	return finish(jobDirectory, "failed", 1)
+}
+
+func acquireWorkerSlot(ctx context.Context, path string, output io.Writer) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, errors.New("RTEST_WORKER_LOCK is required")
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open worker lock: %w", err)
+	}
+	closeWithError := func(err error) (func(), error) {
+		_ = file.Close()
+		return nil, err
+	}
+
+	waitingLogged := false
+	for {
+		err = unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			var once sync.Once
+			return func() {
+				once.Do(func() {
+					_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+					_ = file.Close()
+				})
+			}, nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) && !errors.Is(err, unix.EINTR) {
+			return closeWithError(fmt.Errorf("acquire worker lock: %w", err))
+		}
+		if !waitingLogged {
+			fmt.Fprintln(output, "Waiting for exclusive worker slot")
+			waitingLogged = true
+		}
+		timer := time.NewTimer(50 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return closeWithError(ctx.Err())
+		case <-timer.C:
+		}
+	}
 }
 
 func resolveWorkingDirectory(workspace, relative string) (string, error) {

--- a/rtest/cmd/rtest-job-entrypoint/main.go
+++ b/rtest/cmd/rtest-job-entrypoint/main.go
@@ -40,8 +40,21 @@ func run() int {
 		fmt.Fprintln(os.Stderr, "rtest-job-entrypoint: RTEST_WORKSPACE is required")
 		return 2
 	}
+	hostUID, hostGID, err := hostIdentityFromEnvironment()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
 	jobDirectory := filepath.Dir(workspace)
 	if err := os.MkdirAll(jobDirectory, 0o700); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := os.Chown(jobDirectory, hostUID, hostGID); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := os.Chmod(jobDirectory, 0o700); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
@@ -52,6 +65,11 @@ func run() int {
 	logFile, err := os.OpenFile(filepath.Join(jobDirectory, "job.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := logFile.Chown(hostUID, hostGID); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		_ = logFile.Close()
 		return 1
 	}
 	defer logFile.Close()
@@ -121,6 +139,18 @@ func run() int {
 	}
 	fmt.Fprintln(stderr, err)
 	return finish(jobDirectory, "failed", 1)
+}
+
+func hostIdentityFromEnvironment() (int, int, error) {
+	uid, err := strconv.Atoi(os.Getenv("RTEST_HOST_UID"))
+	if err != nil || uid < 0 {
+		return 0, 0, errors.New("RTEST_HOST_UID must be a non-negative integer")
+	}
+	gid, err := strconv.Atoi(os.Getenv("RTEST_HOST_GID"))
+	if err != nil || gid < 0 {
+		return 0, 0, errors.New("RTEST_HOST_GID must be a non-negative integer")
+	}
+	return uid, gid, nil
 }
 
 func acquireWorkerSlot(ctx context.Context, path string, output io.Writer) (func(), error) {

--- a/rtest/cmd/rtest-job-entrypoint/main_test.go
+++ b/rtest/cmd/rtest-job-entrypoint/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWorkerSlotSerializesJobs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "worker.lock")
+	releaseFirst, err := acquireWorkerSlot(context.Background(), path, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acquired := make(chan func(), 1)
+	errs := make(chan error, 1)
+	go func() {
+		release, err := acquireWorkerSlot(context.Background(), path, io.Discard)
+		if err != nil {
+			errs <- err
+			return
+		}
+		acquired <- release
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second job acquired the worker slot before the first released it")
+	case err := <-errs:
+		t.Fatal(err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseFirst()
+	select {
+	case release := <-acquired:
+		release()
+	case err := <-errs:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("second job did not acquire the released worker slot")
+	}
+}
+
+func TestWorkerSlotWaitHonorsCancellation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "worker.lock")
+	release, err := acquireWorkerSlot(context.Background(), path, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = acquireWorkerSlot(ctx, path, io.Discard)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled", err)
+	}
+}

--- a/rtest/cmd/rtest-job-entrypoint/main_test.go
+++ b/rtest/cmd/rtest-job-entrypoint/main_test.go
@@ -61,3 +61,16 @@ func TestWorkerSlotWaitHonorsCancellation(t *testing.T) {
 		t.Fatalf("error = %v, want context canceled", err)
 	}
 }
+
+func TestHostIdentityFromEnvironment(t *testing.T) {
+	t.Setenv("RTEST_HOST_UID", "123")
+	t.Setenv("RTEST_HOST_GID", "456")
+	uid, gid, err := hostIdentityFromEnvironment()
+	if err != nil || uid != 123 || gid != 456 {
+		t.Fatalf("uid=%d gid=%d err=%v", uid, gid, err)
+	}
+	t.Setenv("RTEST_HOST_UID", "invalid")
+	if _, _, err := hostIdentityFromEnvironment(); err == nil {
+		t.Fatal("invalid host identity was accepted")
+	}
+}

--- a/rtest/cmd/rtest-server/main.go
+++ b/rtest/cmd/rtest-server/main.go
@@ -70,6 +70,7 @@ func serve() {
 	scheduler := swarmscheduler.New(swarmscheduler.Config{
 		Client: docker, CASAddress: casInternal, CASInstance: casInstance, JobsRoot: env("RTEST_JOBS_ROOT", "/var/lib/rtest/jobs"),
 		EntrypointHostPath: env("RTEST_JOB_ENTRYPOINT", "/usr/local/lib/rtest/rtest-job-entrypoint"),
+		CacheRoot:          env("RTEST_CACHE_ROOT", "/var/lib/rtest/cache"),
 	})
 	var verifier controlapi.OIDCVerifier
 	if audience := os.Getenv("RTEST_GITHUB_OIDC_AUDIENCE"); audience != "" {

--- a/rtest/cmd/rtest-server/main.go
+++ b/rtest/cmd/rtest-server/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/flidai/leapview/rtest/internal/control/githuboidc"
 	"github.com/flidai/leapview/rtest/internal/control/mtlsproxy"
 	"github.com/flidai/leapview/rtest/internal/control/pki"
+	"github.com/flidai/leapview/rtest/internal/control/reconciler"
+	"github.com/flidai/leapview/rtest/internal/control/recovery"
 	"github.com/flidai/leapview/rtest/internal/control/secret"
 	controlsqlite "github.com/flidai/leapview/rtest/internal/control/sqlite"
 	"github.com/flidai/leapview/rtest/internal/control/swarmscheduler"
@@ -28,12 +30,18 @@ import (
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "bootstrap" {
-		bootstrap(os.Args[2:])
-		return
-	}
 	if len(os.Args) > 1 {
-		log.Fatalf("unknown command %q", os.Args[1])
+		switch os.Args[1] {
+		case "bootstrap":
+			bootstrap(os.Args[2:])
+		case "backup":
+			backupState(os.Args[2:])
+		case "restore":
+			restoreState(os.Args[2:])
+		default:
+			log.Fatalf("unknown command %q", os.Args[1])
+		}
+		return
 	}
 	serve()
 }
@@ -72,6 +80,14 @@ func serve() {
 		EntrypointHostPath: env("RTEST_JOB_ENTRYPOINT", "/usr/local/lib/rtest/rtest-job-entrypoint"),
 		CacheRoot:          env("RTEST_CACHE_ROOT", "/var/lib/rtest/cache"),
 	})
+	reconcile := reconciler.New(reconciler.Config{
+		Store: store, Scheduler: scheduler,
+		ServiceRetention: durationEnv("RTEST_SERVICE_RETENTION", time.Hour),
+	})
+	if err := reconcile.RunOnce(ctx); err != nil {
+		log.Printf("initial reconciliation: %v", err)
+	}
+	go runReconciler(ctx, reconcile, durationEnv("RTEST_RECONCILE_INTERVAL", 30*time.Second))
 	var verifier controlapi.OIDCVerifier
 	if audience := os.Getenv("RTEST_GITHUB_OIDC_AUDIENCE"); audience != "" {
 		verifier, err = githuboidc.New(ctx, env("RTEST_GITHUB_OIDC_ISSUER", githuboidc.Issuer), audience)
@@ -121,6 +137,25 @@ func serve() {
 	}
 }
 
+type reconciliationRunner interface {
+	RunOnce(context.Context) error
+}
+
+func runReconciler(ctx context.Context, runner reconciliationRunner, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := runner.RunOnce(ctx); err != nil && ctx.Err() == nil {
+				log.Printf("reconciliation: %v", err)
+			}
+		}
+	}
+}
+
 func bootstrap(args []string) {
 	flags := flag.NewFlagSet("rtest-server bootstrap", flag.ExitOnError)
 	dataDir := flags.String("data-dir", env("RTEST_DATA_DIR", "/var/lib/rtest"), "persistent rtest data directory")
@@ -141,6 +176,36 @@ func bootstrap(args []string) {
 		log.Fatal(err)
 	}
 	fmt.Printf("Project: %s (%s)\nUser: %s (%s)\nToken: %s\n", result.Project.Slug, result.Project.ID, result.User.Name, result.User.ID, result.Token)
+}
+
+func backupState(args []string) {
+	flags := flag.NewFlagSet("rtest-server backup", flag.ExitOnError)
+	dataDir := flags.String("data-dir", env("RTEST_DATA_DIR", "/var/lib/rtest"), "persistent rtest data directory")
+	output := flags.String("output", "", "new private backup directory")
+	_ = flags.Parse(args)
+	if *output == "" {
+		log.Fatal("--output is required")
+	}
+	store := openStore(*dataDir)
+	defer store.Close()
+	if err := recovery.Create(context.Background(), store, *dataDir, *output); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Backup: %s\n", *output)
+}
+
+func restoreState(args []string) {
+	flags := flag.NewFlagSet("rtest-server restore", flag.ExitOnError)
+	input := flags.String("input", "", "validated rtest backup directory")
+	dataDir := flags.String("data-dir", env("RTEST_DATA_DIR", "/var/lib/rtest"), "new persistent rtest data directory")
+	_ = flags.Parse(args)
+	if *input == "" {
+		log.Fatal("--input is required")
+	}
+	if err := recovery.Restore(*input, *dataDir); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Restored: %s\n", *dataDir)
 }
 
 func openStore(dataDir string) *controlsqlite.Store {

--- a/rtest/cmd/rtest-server/main.go
+++ b/rtest/cmd/rtest-server/main.go
@@ -84,9 +84,6 @@ func serve() {
 		Store: store, Scheduler: scheduler,
 		ServiceRetention: durationEnv("RTEST_SERVICE_RETENTION", time.Hour),
 	})
-	if err := reconcile.RunOnce(ctx); err != nil {
-		log.Printf("initial reconciliation: %v", err)
-	}
 	go runReconciler(ctx, reconcile, durationEnv("RTEST_RECONCILE_INTERVAL", 30*time.Second))
 	var verifier controlapi.OIDCVerifier
 	if audience := os.Getenv("RTEST_GITHUB_OIDC_AUDIENCE"); audience != "" {
@@ -142,6 +139,12 @@ type reconciliationRunner interface {
 }
 
 func runReconciler(ctx context.Context, runner reconciliationRunner, interval time.Duration) {
+	if err := runner.RunOnce(ctx); err != nil && ctx.Err() == nil {
+		log.Printf("initial reconciliation: %v", err)
+	}
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {

--- a/rtest/cmd/rtest-server/main.go
+++ b/rtest/cmd/rtest-server/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -79,6 +80,7 @@ func serve() {
 		Client: docker, CASAddress: casInternal, CASInstance: casInstance, JobsRoot: env("RTEST_JOBS_ROOT", "/var/lib/rtest/jobs"),
 		EntrypointHostPath: env("RTEST_JOB_ENTRYPOINT", "/usr/local/lib/rtest/rtest-job-entrypoint"),
 		CacheRoot:          env("RTEST_CACHE_ROOT", "/var/lib/rtest/cache"),
+		HostUID:            strconv.Itoa(os.Getuid()), HostGID: strconv.Itoa(os.Getgid()),
 	})
 	reconcile := reconciler.New(reconciler.Config{
 		Store: store, Scheduler: scheduler,

--- a/rtest/cmd/rtest-server/main_test.go
+++ b/rtest/cmd/rtest-server/main_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
 
 func TestEndpointUsesThePublicServerNameAndListenerPort(t *testing.T) {
 	for _, test := range []struct {
@@ -14,4 +18,23 @@ func TestEndpointUsesThePublicServerNameAndListenerPort(t *testing.T) {
 			t.Errorf("endpoint(%q, %q) = %q, want %q", test.name, test.listen, got, test.want)
 		}
 	}
+}
+
+func TestReconcilerRunsImmediatelyWithoutBlockingStartup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runner := &recordingReconciler{called: make(chan struct{}, 1)}
+	go runReconciler(ctx, runner, time.Hour)
+	select {
+	case <-runner.called:
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not run immediately")
+	}
+}
+
+type recordingReconciler struct{ called chan struct{} }
+
+func (r *recordingReconciler) RunOnce(context.Context) error {
+	r.called <- struct{}{}
+	return nil
 }

--- a/rtest/docs/operations.md
+++ b/rtest/docs/operations.md
@@ -53,6 +53,11 @@ independent because Swarm does not expose the task completion timestamp in `serv
 `RTEST_CACHE_HIGH_BYTES`, `RTEST_CACHE_LOW_BYTES`, and `RTEST_DISK_HIGH_PERCENT` override
 these defaults for a larger worker.
 
+The CPX32 hardening exercise—including two projects, two device identities, hosted OIDC,
+cache isolation, serialized execution, restart convergence, durable logs, closed Docker
+ports, and a backup/restore drill—is recorded in
+[`../evidence/service/hardening.json`](../evidence/service/hardening.json).
+
 ## Deployment and first login
 
 `task deploy:swarm` (also exposed as `task deploy:service`) requires an explicit existing

--- a/rtest/docs/operations.md
+++ b/rtest/docs/operations.md
@@ -25,11 +25,15 @@ live under `/var/lib/rtest` with service-user-only permissions.
 ## Capacity
 
 The reused CPX32 has 4 vCPU and 8 GB RAM. Jobs default to 2 CPU and 4 GB RAM; reservations
-equal limits, so insufficient capacity leaves work queued instead of overcommitting the
-host. BuildKit is capped separately at 3 GB. Avoid intentionally overlapping a large
-build and memory-heavy test until measurements justify a larger or additional worker.
+equal limits. The single-worker service also holds an exclusive host-backed admission lock
+while a project command runs. This intentionally serializes Docker/Testcontainers-heavy
+jobs across projects instead of relying only on Swarm's memory arithmetic. Jobs may
+materialize source concurrently but wait before executing. BuildKit is capped separately
+at 3 GB; do not overlap a large image build and a memory-heavy test until measurements
+justify a larger or additional worker.
 
 CAS data lives under `/var/lib/rtest/cas`; workspaces live under `/var/lib/rtest/jobs`;
+explicit project caches live under `/var/lib/rtest/cache/<project-id>/<cache-name>`;
 BuildKit uses `rtest-buildkit-state`. CAS and BuildKit content caches are intentionally
 shared by mutually trusted projects in the initial single-VM deployment. Control-plane
 authorization and accounting remain project-scoped, but the service does not claim cache

--- a/rtest/docs/operations.md
+++ b/rtest/docs/operations.md
@@ -10,6 +10,7 @@ rtest doctor
 ssh <worker> sudo systemctl status rtest-server rtest-cas rtest-buildkit rtest-maintenance.timer
 ssh <worker> sudo journalctl -u rtest-server -u rtest-cas -u rtest-buildkit --since today
 ssh <worker> docker service ls --filter label=rtest.managed=true
+curl --fail --cacert <ca.pem> https://<worker>/readyz
 ```
 
 The public endpoints are:
@@ -21,6 +22,9 @@ The public endpoints are:
 The actual bazel-remote and BuildKit daemons listen only on `127.0.0.1:50051` and
 `127.0.0.1:1234`. The private CA key, token pepper, SQLite control state, and audit data
 live under `/var/lib/rtest` with service-user-only permissions.
+
+`/healthz` is process liveness. `/readyz` returns success only when both SQLite and
+Docker Swarm respond, so it is the endpoint to use for alerts and deployment verification.
 
 ## Capacity
 
@@ -38,6 +42,16 @@ BuildKit uses `rtest-buildkit-state`. CAS and BuildKit content caches are intent
 shared by mutually trusted projects in the initial single-VM deployment. Control-plane
 authorization and accounting remain project-scoped, but the service does not claim cache
 confidentiality between these projects.
+
+The hourly maintenance job keeps completed Swarm services for one hour and durable job
+logs/workspaces for seven days. Project caches use a 12 GiB high watermark and are pruned
+oldest-first to 8 GiB, but only while the exclusive worker lock is idle. At 85% filesystem
+use, the same cache pruning runs and BuildKit retention tightens from 10 GiB to 4 GiB.
+The shell fallback removes only terminal services older than 24 hours. Its cutoff is
+independent because Swarm does not expose the task completion timestamp in `service ls`.
+`RTEST_SERVICE_FALLBACK_RETENTION_SECONDS`, `RTEST_JOB_RETENTION_MINUTES`,
+`RTEST_CACHE_HIGH_BYTES`, `RTEST_CACHE_LOW_BYTES`, and `RTEST_DISK_HIGH_PERCENT` override
+these defaults for a larger worker.
 
 ## Deployment and first login
 
@@ -94,6 +108,37 @@ For emergency CA rotation, schedule control-plane downtime, back up `/var/lib/rt
 the service to generate a new CA/server identity, and redistribute the new `ca.pem` to
 client configuration. Verify control, CAS, and BuildKit TLS before deleting the recovery
 copy. Every old operation certificate becomes invalid at the gateway after the restart.
+
+## Backup and restore
+
+Create a consistent, private recovery bundle without copying SQLite WAL files directly:
+
+```console
+sudo install -d -o rtest -g rtest -m 0700 /var/backups/rtest
+sudo -u rtest rtest-server backup \
+  --data-dir /var/lib/rtest \
+  --output /var/backups/rtest/2026-08-01T120000Z
+```
+
+The bundle contains a SQLite `VACUUM INTO` snapshot, token pepper, private PKI, and a
+SHA-256 manifest. Copy it to storage outside the worker and apply separate retention and
+encryption there. It deliberately excludes rebuildable CAS, BuildKit layers, job
+workspaces, and project caches.
+
+Restore is offline and refuses to overwrite a data directory. Stop the service, move the
+old directory to a dated recovery path, restore, fix ownership, and start the service:
+
+```console
+sudo systemctl stop rtest-server
+sudo mv /var/lib/rtest /var/lib/rtest.failed-20260801
+sudo rtest-server restore --input /var/backups/rtest/2026-08-01T120000Z --data-dir /var/lib/rtest
+sudo chown -R rtest:rtest /var/lib/rtest
+sudo systemctl start rtest-server
+curl --fail --cacert /var/lib/rtest/pki/ca.pem https://localhost/readyz
+```
+
+Restore validates every declared path and checksum before writing. Keep the moved state
+until device login, OIDC exchange, CAS credentials, and a real job have been verified.
 
 ## Troubleshooting
 

--- a/rtest/docs/repository-configuration.md
+++ b/rtest/docs/repository-configuration.md
@@ -39,7 +39,7 @@ Repositories keep orchestration in existing Taskfiles, scripts, Makefiles, or CI
 
 ```console
 rtest exec -- task test
-rtest exec -- go test -count=1 -race ./...
+rtest exec --cache go-build=/root/.cache/go-build --cache go-mod=/go/pkg/mod -- go test -count=1 -race ./...
 rtest exec --workdir services/api --env CI=true -- npm test
 rtest build -- --push -t ghcr.io/example/service:sha .
 ```
@@ -47,6 +47,21 @@ rtest build -- --push -t ghcr.io/example/service:sha .
 `rtest exec` preserves the caller's directory relative to the Git worktree, so invoking it
 from a nested module runs there remotely. `--workdir` remains available when a command
 should deliberately run somewhere else in the uploaded worktree.
+
+Persistent dependency and compiler caches are explicit OCI bind mounts:
+
+```console
+rtest exec \
+  --cache go-build=/root/.cache/go-build \
+  --cache go-mod=/go/pkg/mod \
+  -- task test
+```
+
+`NAME` is a safe project-local identifier and the target is an absolute path inside the
+runner container. The control plane validates and persists the declaration, while the
+worker resolves it beneath `/var/lib/rtest/cache/<immutable-project-id>/`. Projects cannot
+name host paths or mount another project's writable cache. rtest does not prescribe Go,
+npm, Cargo, or another cache convention.
 
 The server-side project owns its default runner image. An administrator can activate an
 existing digest, build and activate from a normal Dockerfile, inspect history, or roll back:

--- a/rtest/docs/repository-configuration.md
+++ b/rtest/docs/repository-configuration.md
@@ -80,6 +80,12 @@ the existing native Buildx/BuildKit path: it pushes the tag, reads Buildx's stan
 `containerimage.digest` metadata, and activates the immutable `repository@sha256:...`
 reference. No rtest-specific image or installation format is involved.
 
+The worker starts the injected entrypoint as root even when the selected OCI image declares
+a different default user. Root is required for the trusted Docker-socket boundary and lets
+the entrypoint assign the durable job directory and log back to the unprivileged host
+control UID/GID. The project command therefore also runs as root; select a dedicated CI
+image and do not treat this runner as a multi-tenant sandbox.
+
 `--project`, `--cpus`, and `--memory` can override repository or local defaults. `--image`
 is an explicit migration/debugging override and can be disabled per project. Every image
 scheduled by the service must be pinned by SHA-256 digest. Commands are transmitted as

--- a/rtest/evidence/service/hardening.json
+++ b/rtest/evidence/service/hardening.json
@@ -1,0 +1,74 @@
+{
+  "completed_at": "2026-08-01T23:07:30Z",
+  "server_ipv4": "62.238.54.70",
+  "rtest_version": "0.7.0",
+  "commit": "d3bf1018",
+  "existing_host_reused": true,
+  "new_resources_provisioned": false,
+  "readiness_http_status": 204,
+  "project_cache": {
+    "first_project_id": "prj1928e851bdaf6135037d4603",
+    "second_project_id": "prj65f77bfe512df46a2c06ee43",
+    "cache_name": "proof",
+    "first_project_values": [1, 2],
+    "second_project_first_value": 1,
+    "host_directory_mode": "0700",
+    "writable_isolation": true
+  },
+  "exclusive_admission": {
+    "first_job": "jobcfd34d3b85629dc616a64439",
+    "second_job": "jobb029f1cefc44f33cc05b97dd",
+    "first_finished_unix_millis": 1785625299324,
+    "second_started_unix_millis": 1785625299330,
+    "second_waited_for_worker_slot": true,
+    "serialized": true
+  },
+  "remote_race_suite": {
+    "command": "go test -race ./...",
+    "cold_job": "jobd058cbccd170e6d65f1ae57b",
+    "cold_seconds": 92.888,
+    "warm_job": "jobd9141fcde920876eb1d99d3a",
+    "warm_seconds": 30.131,
+    "warm_transfer_bytes": 0,
+    "passed": true
+  },
+  "restart_reconciliation": {
+    "job": "jobf4fd8e959fe004483da49e40",
+    "swarm_service_forcibly_removed": true,
+    "control_service_restarted": true,
+    "durable_status": "lost",
+    "service_leaked": false
+  },
+  "durable_logs": {
+    "job": "job8c1d80786e02ebbe344f8458",
+    "swarm_service_removed": true,
+    "job_directory_owner": "rtest:rtest",
+    "job_directory_mode": "0700",
+    "log_owner": "rtest:rtest",
+    "log_mode": "0600",
+    "logs_readable_after_removal": true
+  },
+  "recovery": {
+    "sqlite_snapshot": true,
+    "manifest_sha256_validation": true,
+    "token_pepper_restored": true,
+    "private_pki_restored": true,
+    "temporary_proof_assets_removed": true
+  },
+  "identity": {
+    "owner_device": true,
+    "second_device_token_id": "tok09aa8189e737512d3f8f6dd5",
+    "second_device_project_scope_validated": true,
+    "second_device_revoked": true,
+    "revoked_device_rejected": true,
+    "github_oidc_job": "job64537a82e5a007b3be3fe053",
+    "github_oidc_hosted_proof": true
+  },
+  "network": {
+    "control_tls_port": 443,
+    "cas_mtls_port": 50052,
+    "buildkit_mtls_port": 1235,
+    "public_docker_2375_closed": true,
+    "public_docker_2376_closed": true
+  }
+}

--- a/rtest/host/install-swarm.sh
+++ b/rtest/host/install-swarm.sh
@@ -15,7 +15,7 @@ fi
 usermod -aG docker rtest
 
 install -d -o root -g root -m 0700 /etc/rtest
-install -d -o rtest -g rtest -m 0700 /var/lib/rtest /var/lib/rtest/control /var/lib/rtest/pki /var/lib/rtest/jobs
+install -d -o rtest -g rtest -m 0700 /var/lib/rtest /var/lib/rtest/control /var/lib/rtest/pki /var/lib/rtest/jobs /var/lib/rtest/cache
 install -d -o 65532 -g 65532 -m 0700 /var/lib/rtest/cas
 install -d -o root -g root -m 0755 /usr/local/lib/rtest
 install -o root -g root -m 0755 /tmp/rtest-server /usr/local/bin/rtest-server

--- a/rtest/host/maintain.sh
+++ b/rtest/host/maintain.sh
@@ -2,15 +2,45 @@
 
 set -euo pipefail
 
-cutoff="$(( $(date +%s) - 86400 ))"
+service_retention_seconds="${RTEST_SERVICE_FALLBACK_RETENTION_SECONDS:-86400}"
+job_retention_minutes="${RTEST_JOB_RETENTION_MINUTES:-10080}"
+cache_high_bytes="${RTEST_CACHE_HIGH_BYTES:-12884901888}"
+cache_low_bytes="${RTEST_CACHE_LOW_BYTES:-8589934592}"
+disk_high_percent="${RTEST_DISK_HIGH_PERCENT:-85}"
+
+cutoff="$(( $(date +%s) - service_retention_seconds ))"
 while IFS= read -r service; do
   [[ -n "$service" ]] || continue
+  task_state="$(docker service ps --no-trunc --format '{{.CurrentState}}' "$service" | head -1)"
+  case "$task_state" in
+    Complete*|Failed*|Rejected*|Shutdown*|Orphaned*) ;;
+    *) continue ;;
+  esac
   created="$(docker service inspect --format '{{.CreatedAt}}' "$service")"
   if (( $(date -d "$created" +%s) < cutoff )); then
     docker service rm "$service" >/dev/null
   fi
 done < <(docker service ls --filter 'label=rtest.managed=true' --format '{{.Name}}')
 
-find /var/lib/rtest/jobs -mindepth 1 -maxdepth 1 -type d -mmin +1440 -exec rm -rf -- {} +
+exec 9>/var/lib/rtest/jobs/.worker.lock
+if flock --nonblock 9; then
+  find /var/lib/rtest/jobs -mindepth 1 -maxdepth 1 -type d -mmin "+${job_retention_minutes}" -exec rm -rf -- {} +
+
+  cache_bytes="$(du --summarize --bytes /var/lib/rtest/cache | awk '{print $1}')"
+  disk_percent="$(df --output=pcent /var/lib/rtest | tail -1 | tr -cd '0-9')"
+  if (( cache_bytes > cache_high_bytes || disk_percent >= disk_high_percent )); then
+    while IFS= read -r -d '' cache_record; do
+      cache_path="${cache_record#* }"
+      rm -rf -- "$cache_path"
+      cache_bytes="$(du --summarize --bytes /var/lib/rtest/cache | awk '{print $1}')"
+      (( cache_bytes <= cache_low_bytes )) && break
+    done < <(find /var/lib/rtest/cache -mindepth 2 -maxdepth 2 -type d -printf '%T@ %p\0' | sort --zero-terminated --numeric-sort)
+  fi
+fi
+
 docker container prune --force --filter 'label=org.testcontainers=true' --filter 'until=24h' >/dev/null
-docker builder prune --force --filter 'until=336h' --keep-storage 10GB >/dev/null
+if (( $(df --output=pcent /var/lib/rtest | tail -1 | tr -cd '0-9') >= disk_high_percent )); then
+  docker builder prune --force --filter 'until=24h' --keep-storage 4GB >/dev/null
+else
+  docker builder prune --force --filter 'until=336h' --keep-storage 10GB >/dev/null
+fi

--- a/rtest/internal/cli/cli.go
+++ b/rtest/internal/cli/cli.go
@@ -27,7 +27,7 @@ import (
 	"github.com/flidai/leapview/rtest/internal/workspace"
 )
 
-const version = "0.6.0"
+const version = "0.7.0"
 
 type IO struct {
 	Stdin   io.Reader

--- a/rtest/internal/cli/cli.go
+++ b/rtest/internal/cli/cli.go
@@ -708,7 +708,7 @@ func defaults(streams IO) IO {
 func usage(output io.Writer) {
 	fmt.Fprintln(output, `Usage:
   rtest init [--project <project>]
-  rtest [--token <token>] exec [--project <project>] [--image <digest>] [--detach] [--timeout 15m] [--cpus 2] [--memory 4g] [--workdir <path>] [--env KEY=VALUE] -- <command> [arguments...]
+  rtest [--token <token>] exec [--project <project>] [--image <digest>] [--detach] [--timeout 15m] [--cpus 2] [--memory 4g] [--workdir <path>] [--env KEY=VALUE] [--cache NAME=/absolute/path] -- <command> [arguments...]
   rtest [--token <token>] build [--project <project>] [-- <buildx arguments...>]
   rtest [--token <token>] image show [--project <project>]
   rtest [--token <token>] image activate [--project <project>] --image <digest>

--- a/rtest/internal/cli/service.go
+++ b/rtest/internal/cli/service.go
@@ -351,6 +351,7 @@ type execOptions struct {
 	detach                                bool
 	environment                           map[string]string
 	command                               []string
+	caches                                []*rtestv1.CacheMount
 }
 
 func serviceExec(ctx context.Context, api rtestv1connect.ControlServiceClient, settings config.Config, project string, args []string, streams IO) int {
@@ -382,7 +383,7 @@ func serviceExec(ctx context.Context, api rtestv1connect.ControlServiceClient, s
 	prepared, err := api.PrepareJob(ctx, connect.NewRequest(&rtestv1.PrepareJobRequest{
 		Project: options.project, Image: options.image, Command: options.command, WorkingDirectory: options.workdir,
 		Environment: options.environment, Timeout: durationpb.New(options.timeout), Cpus: options.cpus, Memory: options.memory,
-		IdempotencyKey: idempotencyKey,
+		IdempotencyKey: idempotencyKey, Caches: options.caches,
 	}))
 	if err != nil {
 		return fail(streams.Stderr, fmt.Errorf("prepare remote job: %w", err))
@@ -421,7 +422,7 @@ func parseExec(settings config.Config, project string, args []string) (execOptio
 		switch args[0] {
 		case "--detach":
 			options.detach, args = true, args[1:]
-		case "--project", "--image", "--cpus", "--memory", "--workdir", "--timeout", "--env":
+		case "--project", "--image", "--cpus", "--memory", "--workdir", "--timeout", "--env", "--cache":
 			if len(args) < 2 {
 				return execOptions{}, errors.New(args[0] + " requires a value")
 			}
@@ -450,6 +451,12 @@ func parseExec(settings config.Config, project string, args []string) (execOptio
 					return execOptions{}, errors.New("--env requires KEY=VALUE")
 				}
 				options.environment[key] = item
+			case "--cache":
+				name, target, ok := strings.Cut(value, "=")
+				if !ok || name == "" || target == "" {
+					return execOptions{}, errors.New("--cache requires NAME=/absolute/container/path")
+				}
+				options.caches = append(options.caches, &rtestv1.CacheMount{Name: name, Target: target})
 			}
 		default:
 			return execOptions{}, errors.New("unknown exec option " + args[0])

--- a/rtest/internal/cli/service_internal_test.go
+++ b/rtest/internal/cli/service_internal_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestParseExecUsesGenericProjectImageAndArbitraryArgv(t *testing.T) {
 	settings := config.Config{Service: &config.Service{Project: "example", Image: "image@sha256:digest", CPUs: "2", Memory: "4g"}}
-	got, err := parseExec(settings, "example", []string{"--timeout", "5m", "--workdir", "service", "--env", "CI=true", "--", "task", "test", "--race"})
+	got, err := parseExec(settings, "example", []string{"--timeout", "5m", "--workdir", "service", "--env", "CI=true", "--cache", "go-build=/root/.cache/go-build", "--cache", "modules=/go/pkg/mod", "--", "task", "test", "--race"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,6 +32,9 @@ func TestParseExecUsesGenericProjectImageAndArbitraryArgv(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.command, []string{"task", "test", "--race"}) {
 		t.Fatalf("command = %#v", got.command)
+	}
+	if len(got.caches) != 2 || got.caches[0].Name != "go-build" || got.caches[0].Target != "/root/.cache/go-build" || got.caches[1].Name != "modules" || got.caches[1].Target != "/go/pkg/mod" {
+		t.Fatalf("caches = %#v", got.caches)
 	}
 }
 

--- a/rtest/internal/control/controlapi/server.go
+++ b/rtest/internal/control/controlapi/server.go
@@ -67,6 +67,19 @@ func New(config Config) (http.Handler, error) {
 	mux := http.NewServeMux()
 	mux.Handle(path, handler)
 	mux.HandleFunc("GET /healthz", func(response http.ResponseWriter, _ *http.Request) { response.WriteHeader(http.StatusNoContent) })
+	mux.HandleFunc("GET /readyz", func(response http.ResponseWriter, request *http.Request) {
+		ctx, cancel := context.WithTimeout(request.Context(), 2*time.Second)
+		defer cancel()
+		if err := config.Store.Check(ctx); err != nil {
+			http.Error(response, "control store unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if err := config.Scheduler.Check(ctx); err != nil {
+			http.Error(response, "worker unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		response.WriteHeader(http.StatusNoContent)
+	})
 	return securityHeaders(mux), nil
 }
 

--- a/rtest/internal/control/controlapi/server.go
+++ b/rtest/internal/control/controlapi/server.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const Version = "0.6.0"
+const Version = "0.7.0"
 
 type OIDCVerifier interface {
 	Verify(context.Context, string) (control.GitHubClaims, error)
@@ -94,7 +94,7 @@ func securityHeaders(next http.Handler) http.Handler {
 
 func (s *Server) GetServiceInfo(context.Context, *connect.Request[rtestv1.GetServiceInfoRequest]) (*connect.Response[rtestv1.GetServiceInfoResponse], error) {
 	return connect.NewResponse(&rtestv1.GetServiceInfoResponse{Version: Version, Capabilities: []string{
-		"connect", "projects", "project-images", "device-tokens", "device-enrollment", "github-oidc", "reapi-cas-mtls", "swarm-jobs", "buildkit-mtls",
+		"connect", "projects", "project-images", "project-caches", "device-tokens", "device-enrollment", "github-oidc", "reapi-cas-mtls", "swarm-jobs", "single-worker-admission", "buildkit-mtls",
 	}}), nil
 }
 

--- a/rtest/internal/control/controlapi/server.go
+++ b/rtest/internal/control/controlapi/server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -747,6 +748,7 @@ var (
 	rootDigestPattern     = regexp.MustCompile(`^[0-9a-f]{64}/[1-9][0-9]*$`)
 	environmentKey        = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 	idempotencyKeyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$`)
+	cacheNamePattern      = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,62}$`)
 )
 
 func (s *Server) validateJob(projectID string, message *rtestv1.PrepareJobRequest) (control.PrepareJob, error) {
@@ -772,6 +774,10 @@ func (s *Server) validateJob(projectID string, message *rtestv1.PrepareJobReques
 	if len(message.Environment) > 128 {
 		return control.PrepareJob{}, errors.New("environment may contain at most 128 values")
 	}
+	caches, err := validateCaches(message.Caches)
+	if err != nil {
+		return control.PrepareJob{}, err
+	}
 	for key, value := range message.Environment {
 		if !environmentKey.MatchString(key) || strings.ContainsRune(value, 0) {
 			return control.PrepareJob{}, fmt.Errorf("invalid environment value %q", key)
@@ -796,8 +802,45 @@ func (s *Server) validateJob(projectID string, message *rtestv1.PrepareJobReques
 	return control.PrepareJob{
 		ProjectID: projectID, Image: message.Image, Command: append([]string(nil), message.Command...),
 		WorkingDirectory: clean, Environment: cloneMap(message.Environment), Timeout: timeout,
-		CPUs: message.Cpus, Memory: message.Memory,
+		CPUs: message.Cpus, Memory: message.Memory, Caches: caches,
 	}, nil
+}
+
+func validateCaches(input []*rtestv1.CacheMount) ([]control.CacheMount, error) {
+	if len(input) > 16 {
+		return nil, errors.New("a job may declare at most 16 caches")
+	}
+	result := make([]control.CacheMount, 0, len(input))
+	names, targets := map[string]bool{}, map[string]bool{}
+	reserved := []string{"/var/run/docker.sock", "/usr/local/bin/rtest-job-entrypoint"}
+	for _, item := range input {
+		if item == nil || !cacheNamePattern.MatchString(item.Name) {
+			return nil, errors.New("cache name must contain 1 to 63 lowercase safe characters")
+		}
+		target := path.Clean(item.Target)
+		if !path.IsAbs(item.Target) || target == "/" || strings.ContainsRune(item.Target, 0) {
+			return nil, fmt.Errorf("cache %q target must be an absolute container path below /", item.Name)
+		}
+		if names[item.Name] {
+			return nil, fmt.Errorf("cache name %q is declared more than once", item.Name)
+		}
+		if targets[target] {
+			return nil, fmt.Errorf("cache target %q is declared more than once", target)
+		}
+		for _, protected := range reserved {
+			if pathsOverlap(target, protected) {
+				return nil, fmt.Errorf("cache target %q overlaps protected runtime path %q", target, protected)
+			}
+		}
+		names[item.Name], targets[target] = true, true
+		result = append(result, control.CacheMount{Name: item.Name, Target: target})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, nil
+}
+
+func pathsOverlap(first, second string) bool {
+	return first == second || strings.HasPrefix(first, second+"/") || strings.HasPrefix(second, first+"/")
 }
 
 type streamWriter struct {
@@ -857,6 +900,9 @@ func jobProto(job control.Job) *rtestv1.Job {
 		WorkingDirectory: job.WorkingDirectory, Environment: cloneMap(job.Environment), RootDigest: job.RootDigest,
 		Status: jobStatusProto(job.Status), Timeout: durationpb.New(job.Timeout), Cpus: job.CPUs, Memory: job.Memory,
 		CreatedAt: timestamppb.New(job.CreatedAt), ErrorMessage: job.ErrorMessage, CancelRequested: job.CancelRequested, WorkerId: job.WorkerID,
+	}
+	for _, cache := range job.Caches {
+		result.Caches = append(result.Caches, &rtestv1.CacheMount{Name: cache.Name, Target: cache.Target})
 	}
 	result.StartedAt, result.FinishedAt = timestamp(job.StartedAt), timestamp(job.FinishedAt)
 	if job.ExitCode != nil {

--- a/rtest/internal/control/controlapi/server_test.go
+++ b/rtest/internal/control/controlapi/server_test.go
@@ -619,6 +619,28 @@ func newFixtureWithVerifier(t *testing.T, verifier controlapi.OIDCVerifier) *fix
 	return &fixture{store: store, bootstrap: bootstrap, scheduler: scheduler, server: server}
 }
 
+func TestReadinessChecksStoreAndScheduler(t *testing.T) {
+	fixture := newFixture(t)
+	response, err := http.Get(fixture.server.URL + "/readyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("ready status = %d", response.StatusCode)
+	}
+
+	fixture.scheduler.checkErr = errors.New("swarm unavailable")
+	response, err = http.Get(fixture.server.URL + "/readyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("unready status = %d", response.StatusCode)
+	}
+}
+
 func (f *fixture) client(token string) rtestv1connect.ControlServiceClient {
 	transport := roundTripper(func(request *http.Request) (*http.Response, error) {
 		if token != "" {
@@ -640,9 +662,10 @@ type fakeScheduler struct {
 	blockFollowingLogs bool
 	logsStarted        chan struct{}
 	validateErr        error
+	checkErr           error
 }
 
-func (f *fakeScheduler) Check(context.Context) error { return nil }
+func (f *fakeScheduler) Check(context.Context) error { return f.checkErr }
 
 func (f *fakeScheduler) ValidateImage(context.Context, string) error { return f.validateErr }
 

--- a/rtest/internal/control/controlapi/server_test.go
+++ b/rtest/internal/control/controlapi/server_test.go
@@ -181,6 +181,46 @@ func TestProjectImageOverridePolicyIsEnforcedAtAdmission(t *testing.T) {
 	}
 }
 
+func TestJobAdmissionValidatesAndPersistsGenericProjectCaches(t *testing.T) {
+	fixture := newFixture(t)
+	client := fixture.client(fixture.bootstrap.Token)
+	ctx := context.Background()
+	request := &rtestv1.PrepareJobRequest{
+		IdempotencyKey: "generic-cache-job", Project: "example",
+		Image:   "ghcr.io/example/ci@sha256:" + strings.Repeat("a", 64),
+		Command: []string{"go", "test", "./..."}, Timeout: durationpb.New(time.Minute), Cpus: "1", Memory: "1g",
+		Caches: []*rtestv1.CacheMount{{Name: "modules", Target: "/go/pkg/mod"}, {Name: "go-build", Target: "/root/.cache/go-build"}},
+	}
+	prepared, err := client.PrepareJob(ctx, connect.NewRequest(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prepared.Msg.Job.Caches) != 2 || prepared.Msg.Job.Caches[0].Name != "go-build" || prepared.Msg.Job.Caches[1].Name != "modules" {
+		t.Fatalf("caches = %#v", prepared.Msg.Job.Caches)
+	}
+
+	invalid := []struct {
+		name   string
+		caches []*rtestv1.CacheMount
+	}{
+		{name: "unsafe name", caches: []*rtestv1.CacheMount{{Name: "../shared", Target: "/cache"}}},
+		{name: "relative target", caches: []*rtestv1.CacheMount{{Name: "cache", Target: "cache"}}},
+		{name: "duplicate name", caches: []*rtestv1.CacheMount{{Name: "cache", Target: "/one"}, {Name: "cache", Target: "/two"}}},
+		{name: "duplicate target", caches: []*rtestv1.CacheMount{{Name: "one", Target: "/cache"}, {Name: "two", Target: "/cache"}}},
+		{name: "docker socket overlap", caches: []*rtestv1.CacheMount{{Name: "socket", Target: "/var/run"}}},
+	}
+	for index, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			copyRequest := *request
+			copyRequest.IdempotencyKey = fmt.Sprintf("invalid-cache-%02d", index)
+			copyRequest.Caches = test.caches
+			if _, err := client.PrepareJob(ctx, connect.NewRequest(&copyRequest)); connect.CodeOf(err) != connect.CodeInvalidArgument {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
 func TestOneTimeEnrollmentExchangeNeedsNoExistingCredential(t *testing.T) {
 	fixture := newFixture(t)
 	admin := fixture.client(fixture.bootstrap.Token)

--- a/rtest/internal/control/model.go
+++ b/rtest/internal/control/model.go
@@ -158,6 +158,12 @@ type Job struct {
 	ErrorMessage     string
 	CancelRequested  bool
 	WorkerID         string
+	Caches           []CacheMount
+}
+
+type CacheMount struct {
+	Name   string
+	Target string
 }
 
 type PrepareJob struct {
@@ -169,6 +175,7 @@ type PrepareJob struct {
 	Timeout          time.Duration
 	CPUs             string
 	Memory           string
+	Caches           []CacheMount
 }
 
 type Idempotency struct {

--- a/rtest/internal/control/reconciler/reconciler.go
+++ b/rtest/internal/control/reconciler/reconciler.go
@@ -1,0 +1,97 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/flidai/leapview/rtest/internal/control"
+	"github.com/flidai/leapview/rtest/internal/protocol"
+)
+
+type Store interface {
+	ScheduledJobs(context.Context) ([]control.Job, error)
+	Job(context.Context, string) (control.Job, error)
+	SyncJob(context.Context, string, protocol.Job) (control.Job, error)
+}
+
+type Scheduler interface {
+	ManagedJobs(context.Context) ([]protocol.Job, error)
+	Remove(context.Context, string) error
+}
+
+type Config struct {
+	Store            Store
+	Scheduler        Scheduler
+	ServiceRetention time.Duration
+	Now              func() time.Time
+}
+
+type Reconciler struct {
+	config Config
+}
+
+func New(config Config) *Reconciler {
+	if config.ServiceRetention <= 0 {
+		config.ServiceRetention = time.Hour
+	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	return &Reconciler{config: config}
+}
+
+func (r *Reconciler) RunOnce(ctx context.Context) error {
+	scheduled, err := r.config.Store.ScheduledJobs(ctx)
+	if err != nil {
+		return fmt.Errorf("list scheduled jobs: %w", err)
+	}
+	managed, err := r.config.Scheduler.ManagedJobs(ctx)
+	if err != nil {
+		return fmt.Errorf("list managed jobs: %w", err)
+	}
+	remoteByID := make(map[string]protocol.Job, len(managed))
+	for _, job := range managed {
+		remoteByID[job.ID] = job
+	}
+	now := r.config.Now().UTC()
+	for _, job := range scheduled {
+		remote, ok := remoteByID[job.ID]
+		if !ok {
+			finished, exitCode := now, 1
+			remote = protocol.Job{ID: job.ID, Status: protocol.StatusLost, FinishedAt: &finished, ExitCode: &exitCode, ErrorMessage: "managed Swarm service is missing"}
+		}
+		if _, err := r.config.Store.SyncJob(ctx, job.ID, remote); err != nil {
+			return fmt.Errorf("synchronize job %s: %w", job.ID, err)
+		}
+	}
+
+	cutoff := now.Add(-r.config.ServiceRetention)
+	for _, remote := range managed {
+		stored, err := r.config.Store.Job(ctx, remote.ID)
+		if err != nil && !errors.Is(err, control.ErrNotFound) {
+			return fmt.Errorf("read managed job %s: %w", remote.ID, err)
+		}
+		removeAfter := remote.CreatedAt
+		if err == nil {
+			if !stored.Status.Terminal() {
+				continue
+			}
+			if stored.FinishedAt != nil {
+				removeAfter = *stored.FinishedAt
+			} else if remote.FinishedAt != nil {
+				removeAfter = *remote.FinishedAt
+			}
+		} else if remote.FinishedAt != nil {
+			removeAfter = *remote.FinishedAt
+		}
+		if removeAfter.IsZero() || removeAfter.After(cutoff) {
+			continue
+		}
+		if err := r.config.Scheduler.Remove(ctx, remote.ID); err != nil {
+			return fmt.Errorf("remove managed job %s: %w", remote.ID, err)
+		}
+	}
+	return nil
+}

--- a/rtest/internal/control/reconciler/reconciler_test.go
+++ b/rtest/internal/control/reconciler/reconciler_test.go
@@ -1,0 +1,106 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/rtest/internal/control"
+	"github.com/flidai/leapview/rtest/internal/protocol"
+)
+
+func TestRunOnceConvergesTerminalOrphanAndMissingJobs(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	finished := now.Add(-time.Hour)
+	store := &fakeStore{jobs: map[string]control.Job{
+		"job-finished": {ID: "job-finished", ProjectID: "project-one", Status: protocol.StatusRunning},
+		"job-live":     {ID: "job-live", ProjectID: "project-two", Status: protocol.StatusRunning},
+		"job-missing":  {ID: "job-missing", ProjectID: "project-one", Status: protocol.StatusRunning},
+	}}
+	scheduler := &fakeScheduler{managed: []protocol.Job{
+		{ID: "job-finished", Status: protocol.StatusSucceeded, FinishedAt: &finished, CreatedAt: now.Add(-2 * time.Hour)},
+		{ID: "job-live", Status: protocol.StatusRunning, CreatedAt: now.Add(-time.Minute)},
+		{ID: "orphan", Status: protocol.StatusRunning, CreatedAt: now.Add(-2 * time.Hour)},
+	}}
+
+	reconciler := New(Config{Store: store, Scheduler: scheduler, ServiceRetention: 30 * time.Minute, Now: func() time.Time { return now }})
+	if err := reconciler.RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := store.jobs["job-finished"].Status; got != protocol.StatusSucceeded {
+		t.Fatalf("finished status = %s", got)
+	}
+	if got := store.jobs["job-live"].Status; got != protocol.StatusRunning {
+		t.Fatalf("live status = %s", got)
+	}
+	if got := store.jobs["job-missing"].Status; got != protocol.StatusLost {
+		t.Fatalf("missing status = %s", got)
+	}
+	if len(scheduler.removed) != 2 || scheduler.removed[0] != "job-finished" || scheduler.removed[1] != "orphan" {
+		t.Fatalf("removed = %#v", scheduler.removed)
+	}
+}
+
+type fakeStore struct {
+	jobs map[string]control.Job
+}
+
+func (f *fakeStore) ScheduledJobs(context.Context) ([]control.Job, error) {
+	var jobs []control.Job
+	for _, job := range f.jobs {
+		if job.Status == protocol.StatusQueued || job.Status == protocol.StatusRunning {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+func (f *fakeStore) Job(_ context.Context, id string) (control.Job, error) {
+	job, ok := f.jobs[id]
+	if !ok {
+		return control.Job{}, control.ErrNotFound
+	}
+	return job, nil
+}
+
+func (f *fakeStore) SyncJob(_ context.Context, id string, remote protocol.Job) (control.Job, error) {
+	job, ok := f.jobs[id]
+	if !ok {
+		return control.Job{}, control.ErrNotFound
+	}
+	job.Status, job.FinishedAt, job.ExitCode, job.ErrorMessage = remote.Status, remote.FinishedAt, remote.ExitCode, remote.ErrorMessage
+	f.jobs[id] = job
+	return job, nil
+}
+
+type fakeScheduler struct {
+	managed []protocol.Job
+	removed []string
+}
+
+func (f *fakeScheduler) ManagedJobs(context.Context) ([]protocol.Job, error) {
+	return append([]protocol.Job(nil), f.managed...), nil
+}
+
+func (f *fakeScheduler) Remove(_ context.Context, id string) error {
+	f.removed = append(f.removed, id)
+	return nil
+}
+
+func TestRunOnceReturnsDependencyErrors(t *testing.T) {
+	want := errors.New("unavailable")
+	reconciler := New(Config{Store: errorStore{err: want}, Scheduler: &fakeScheduler{}})
+	if err := reconciler.RunOnce(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+type errorStore struct{ err error }
+
+func (e errorStore) ScheduledJobs(context.Context) ([]control.Job, error) { return nil, e.err }
+func (e errorStore) Job(context.Context, string) (control.Job, error)     { return control.Job{}, e.err }
+func (e errorStore) SyncJob(context.Context, string, protocol.Job) (control.Job, error) {
+	return control.Job{}, e.err
+}

--- a/rtest/internal/control/recovery/recovery.go
+++ b/rtest/internal/control/recovery/recovery.go
@@ -1,0 +1,229 @@
+package recovery
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Snapshotter interface {
+	Backup(context.Context, string) error
+}
+
+type manifest struct {
+	Format    int               `json:"format"`
+	CreatedAt time.Time         `json:"created_at"`
+	Files     map[string]string `json:"files"`
+}
+
+func Create(ctx context.Context, snapshotter Snapshotter, dataDir, output string) error {
+	if snapshotter == nil || dataDir == "" || output == "" {
+		return errors.New("snapshotter, data directory, and output are required")
+	}
+	if _, err := os.Stat(output); err == nil {
+		return errors.New("backup output already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	parent := filepath.Dir(output)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return err
+	}
+	temporary, err := os.MkdirTemp(parent, ".rtest-backup-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temporary)
+	if err := os.Chmod(temporary, 0o700); err != nil {
+		return err
+	}
+	database := filepath.Join(temporary, "control", "control.db")
+	if err := os.MkdirAll(filepath.Dir(database), 0o700); err != nil {
+		return err
+	}
+	if err := snapshotter.Backup(ctx, database); err != nil {
+		return err
+	}
+	if err := copyRegular(filepath.Join(dataDir, "control", "token-pepper"), filepath.Join(temporary, "control", "token-pepper")); err != nil {
+		return fmt.Errorf("copy token pepper: %w", err)
+	}
+	if err := copyTree(filepath.Join(dataDir, "pki"), filepath.Join(temporary, "pki")); err != nil {
+		return fmt.Errorf("copy PKI: %w", err)
+	}
+
+	files, err := hashes(temporary)
+	if err != nil {
+		return err
+	}
+	for _, required := range []string{"control/control.db", "control/token-pepper", "pki/ca.pem", "pki/ca-key.pem"} {
+		if _, ok := files[required]; !ok {
+			return fmt.Errorf("backup source is missing %s", required)
+		}
+	}
+	data, err := json.MarshalIndent(manifest{Format: 1, CreatedAt: time.Now().UTC(), Files: files}, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(temporary, "manifest.json"), data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(temporary, output)
+}
+
+func Restore(input, dataDir string) error {
+	if input == "" || dataDir == "" {
+		return errors.New("backup input and data directory are required")
+	}
+	if _, err := os.Stat(dataDir); err == nil {
+		return errors.New("restore data directory already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	data, err := os.ReadFile(filepath.Join(input, "manifest.json"))
+	if err != nil {
+		return err
+	}
+	var manifest manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("decode backup manifest: %w", err)
+	}
+	if manifest.Format != 1 || len(manifest.Files) == 0 {
+		return errors.New("unsupported or empty backup manifest")
+	}
+	for name, want := range manifest.Files {
+		if !safeRelative(name) {
+			return fmt.Errorf("unsafe backup path %q", name)
+		}
+		got, err := hashFile(filepath.Join(input, filepath.FromSlash(name)))
+		if err != nil {
+			return err
+		}
+		if got != want {
+			return fmt.Errorf("backup checksum mismatch for %s", name)
+		}
+	}
+	for _, required := range []string{"control/control.db", "control/token-pepper", "pki/ca.pem", "pki/ca-key.pem"} {
+		if _, ok := manifest.Files[required]; !ok {
+			return fmt.Errorf("backup is missing %s", required)
+		}
+	}
+	parent := filepath.Dir(dataDir)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return err
+	}
+	temporary, err := os.MkdirTemp(parent, ".rtest-restore-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temporary)
+	if err := os.Chmod(temporary, 0o700); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(manifest.Files))
+	for name := range manifest.Files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := copyRegular(filepath.Join(input, filepath.FromSlash(name)), filepath.Join(temporary, filepath.FromSlash(name))); err != nil {
+			return err
+		}
+	}
+	return os.Rename(temporary, dataDir)
+}
+
+func copyTree(source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, relative)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o700)
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() {
+			return fmt.Errorf("backup source contains non-regular file %s", path)
+		}
+		return copyRegular(path, target)
+	})
+}
+
+func copyRegular(source, destination string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", source)
+	}
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return err
+	}
+	output, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(output, input)
+	closeErr := output.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+func hashes(root string) (map[string]string, error) {
+	result := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("backup contains non-regular file %s", path)
+		}
+		name, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		result[filepath.ToSlash(name)], err = hashFile(path)
+		return err
+	})
+	return result, err
+}
+
+func hashFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func safeRelative(name string) bool {
+	clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(name)))
+	return name != "" && clean == name && !filepath.IsAbs(name) && name != ".." && !strings.HasPrefix(name, "../")
+}

--- a/rtest/internal/control/recovery/recovery_test.go
+++ b/rtest/internal/control/recovery/recovery_test.go
@@ -1,0 +1,63 @@
+package recovery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type fakeSnapshot struct{ data []byte }
+
+func (f fakeSnapshot) Backup(_ context.Context, output string) error {
+	return os.WriteFile(output, f.data, 0o600)
+}
+
+func TestCreateAndRestoreValidatedBundle(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "state")
+	writeFile(t, filepath.Join(source, "control", "token-pepper"), "pepper")
+	writeFile(t, filepath.Join(source, "pki", "ca.pem"), "authority")
+	writeFile(t, filepath.Join(source, "pki", "ca-key.pem"), "private")
+	bundle := filepath.Join(t.TempDir(), "backup")
+	if err := Create(context.Background(), fakeSnapshot{data: []byte("database")}, source, bundle); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := filepath.Join(t.TempDir(), "restored")
+	if err := Restore(bundle, restored); err != nil {
+		t.Fatal(err)
+	}
+	for name, want := range map[string]string{
+		"control/control.db": "database", "control/token-pepper": "pepper", "pki/ca.pem": "authority", "pki/ca-key.pem": "private",
+	} {
+		data, err := os.ReadFile(filepath.Join(restored, filepath.FromSlash(name)))
+		if err != nil || string(data) != want {
+			t.Fatalf("%s = %q, %v", name, data, err)
+		}
+	}
+}
+
+func TestRestoreRejectsTamperedBundle(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "state")
+	writeFile(t, filepath.Join(source, "control", "token-pepper"), "pepper")
+	writeFile(t, filepath.Join(source, "pki", "ca.pem"), "authority")
+	writeFile(t, filepath.Join(source, "pki", "ca-key.pem"), "private")
+	bundle := filepath.Join(t.TempDir(), "backup")
+	if err := Create(context.Background(), fakeSnapshot{data: []byte("database")}, source, bundle); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(bundle, "control", "control.db"), "tampered")
+	if err := Restore(bundle, filepath.Join(t.TempDir(), "restored")); err == nil {
+		t.Fatal("tampered bundle was restored")
+	}
+}
+
+func writeFile(t *testing.T, path, value string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/rtest/internal/control/sqlite/store.go
+++ b/rtest/internal/control/sqlite/store.go
@@ -157,6 +157,7 @@ CREATE TABLE IF NOT EXISTS control_jobs (
   command_json TEXT NOT NULL,
   working_directory TEXT NOT NULL,
   environment_json TEXT NOT NULL,
+  caches_json TEXT NOT NULL DEFAULT '[]',
   root_digest TEXT NOT NULL DEFAULT '',
   status TEXT NOT NULL,
   timeout_millis INTEGER NOT NULL,
@@ -192,6 +193,7 @@ CREATE INDEX IF NOT EXISTS control_builds_project_idx ON control_builds(project_
 		table, name string
 	}{
 		{"control_jobs", "idempotency_key"}, {"control_jobs", "request_hash"},
+		{"control_jobs", "caches_json"},
 		{"control_builds", "idempotency_key"}, {"control_builds", "request_hash"},
 		{"projects", "active_image"}, {"projects", "previous_image"},
 	} {
@@ -212,6 +214,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS control_builds_idempotency_idx ON control_buil
 func (s *Store) ensureTextColumn(ctx context.Context, table, column string) error {
 	allowed := map[string]bool{
 		"control_jobs.idempotency_key": true, "control_jobs.request_hash": true,
+		"control_jobs.caches_json":       true,
 		"control_builds.idempotency_key": true, "control_builds.request_hash": true,
 		"projects.active_image": true, "projects.previous_image": true,
 	}
@@ -239,7 +242,11 @@ func (s *Store) ensureTextColumn(ctx context.Context, table, column string) erro
 	if found {
 		return nil
 	}
-	_, err = s.db.ExecContext(ctx, `ALTER TABLE `+table+` ADD COLUMN `+column+` TEXT NOT NULL DEFAULT ''`)
+	defaultValue := `''`
+	if table == "control_jobs" && column == "caches_json" {
+		defaultValue = `'[]'`
+	}
+	_, err = s.db.ExecContext(ctx, `ALTER TABLE `+table+` ADD COLUMN `+column+` TEXT NOT NULL DEFAULT `+defaultValue)
 	return err
 }
 
@@ -854,12 +861,16 @@ func (s *Store) CreatePreparedJob(ctx context.Context, input control.PrepareJob,
 	if err != nil {
 		return control.Job{}, false, err
 	}
+	caches, err := json.Marshal(input.Caches)
+	if err != nil {
+		return control.Job{}, false, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return control.Job{}, false, err
 	}
 	defer tx.Rollback()
-	row := tx.QueryRowContext(ctx, `SELECT id,project_id,image,command_json,working_directory,environment_json,root_digest,status,timeout_millis,cpus,memory,created_at,started_at,finished_at,exit_code,error_message,cancel_requested,worker_id,request_hash FROM control_jobs WHERE project_id=? AND idempotency_key=?`, input.ProjectID, idempotency.Key)
+	row := tx.QueryRowContext(ctx, `SELECT id,project_id,image,command_json,working_directory,environment_json,caches_json,root_digest,status,timeout_millis,cpus,memory,created_at,started_at,finished_at,exit_code,error_message,cancel_requested,worker_id,request_hash FROM control_jobs WHERE project_id=? AND idempotency_key=?`, input.ProjectID, idempotency.Key)
 	job, storedHash, err := scanIdempotentJob(row)
 	if err == nil {
 		if storedHash != idempotency.RequestHash {
@@ -879,10 +890,10 @@ func (s *Store) CreatePreparedJob(ctx context.Context, input control.PrepareJob,
 		ID: id, ProjectID: input.ProjectID, Image: input.Image,
 		Command: append([]string(nil), input.Command...), WorkingDirectory: input.WorkingDirectory,
 		Environment: cloneMap(input.Environment), Status: protocol.StatusPreparing, Timeout: input.Timeout,
-		CPUs: input.CPUs, Memory: input.Memory, CreatedAt: now,
+		CPUs: input.CPUs, Memory: input.Memory, Caches: cloneCaches(input.Caches), CreatedAt: now,
 	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO control_jobs(id,project_id,image,command_json,working_directory,environment_json,status,timeout_millis,cpus,memory,created_at,idempotency_key,request_hash) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-		job.ID, job.ProjectID, job.Image, string(command), job.WorkingDirectory, string(environment), job.Status,
+	_, err = tx.ExecContext(ctx, `INSERT INTO control_jobs(id,project_id,image,command_json,working_directory,environment_json,caches_json,status,timeout_millis,cpus,memory,created_at,idempotency_key,request_hash) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		job.ID, job.ProjectID, job.Image, string(command), job.WorkingDirectory, string(environment), string(caches), job.Status,
 		job.Timeout.Milliseconds(), job.CPUs, job.Memory, unix(now), idempotency.Key, idempotency.RequestHash)
 	if err != nil {
 		return control.Job{}, false, err
@@ -906,7 +917,7 @@ func (s *Store) StartJob(ctx context.Context, id, rootDigest string) (control.Jo
 }
 
 func (s *Store) Job(ctx context.Context, id string) (control.Job, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id,project_id,image,command_json,working_directory,environment_json,root_digest,status,timeout_millis,cpus,memory,created_at,started_at,finished_at,exit_code,error_message,cancel_requested,worker_id FROM control_jobs WHERE id=?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT id,project_id,image,command_json,working_directory,environment_json,caches_json,root_digest,status,timeout_millis,cpus,memory,created_at,started_at,finished_at,exit_code,error_message,cancel_requested,worker_id FROM control_jobs WHERE id=?`, id)
 	return scanJob(row)
 }
 
@@ -914,7 +925,7 @@ func (s *Store) ListJobs(ctx context.Context, projectID string, pageSize int, pa
 	if pageSize < 1 || pageSize > 100 {
 		return control.JobPage{}, errors.New("job page size must be between 1 and 100")
 	}
-	query := `SELECT id,project_id,image,command_json,working_directory,environment_json,root_digest,status,timeout_millis,cpus,memory,created_at,started_at,finished_at,exit_code,error_message,cancel_requested,worker_id FROM control_jobs WHERE project_id=?`
+	query := `SELECT id,project_id,image,command_json,working_directory,environment_json,caches_json,root_digest,status,timeout_millis,cpus,memory,created_at,started_at,finished_at,exit_code,error_message,cancel_requested,worker_id FROM control_jobs WHERE project_id=?`
 	arguments := []any{projectID}
 	if pageToken != "" {
 		cursor, err := s.decodeJobCursor(projectID, pageToken)
@@ -1117,11 +1128,11 @@ func scanTrust(row interface{ Scan(...any) error }) (control.GitHubTrust, error)
 
 func scanJob(row interface{ Scan(...any) error }) (control.Job, error) {
 	var job control.Job
-	var command, environment, status string
+	var command, environment, caches, status string
 	var timeoutMillis, created int64
 	var started, finished, exitCode sql.NullInt64
 	var cancelled int
-	if err := row.Scan(&job.ID, &job.ProjectID, &job.Image, &command, &job.WorkingDirectory, &environment,
+	if err := row.Scan(&job.ID, &job.ProjectID, &job.Image, &command, &job.WorkingDirectory, &environment, &caches,
 		&job.RootDigest, &status, &timeoutMillis, &job.CPUs, &job.Memory, &created, &started, &finished,
 		&exitCode, &job.ErrorMessage, &cancelled, &job.WorkerID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1135,6 +1146,9 @@ func scanJob(row interface{ Scan(...any) error }) (control.Job, error) {
 	if err := json.Unmarshal([]byte(environment), &job.Environment); err != nil {
 		return control.Job{}, err
 	}
+	if err := json.Unmarshal([]byte(caches), &job.Caches); err != nil {
+		return control.Job{}, err
+	}
 	job.Status, job.Timeout, job.CreatedAt = protocol.Status(status), time.Duration(timeoutMillis)*time.Millisecond, fromUnix(created)
 	job.StartedAt, job.FinishedAt, job.CancelRequested = nullableTime(started), nullableTime(finished), cancelled != 0
 	if exitCode.Valid {
@@ -1146,11 +1160,11 @@ func scanJob(row interface{ Scan(...any) error }) (control.Job, error) {
 
 func scanIdempotentJob(row interface{ Scan(...any) error }) (control.Job, string, error) {
 	var job control.Job
-	var command, environment, status, requestHash string
+	var command, environment, caches, status, requestHash string
 	var timeoutMillis, created int64
 	var started, finished, exitCode sql.NullInt64
 	var cancelled int
-	if err := row.Scan(&job.ID, &job.ProjectID, &job.Image, &command, &job.WorkingDirectory, &environment,
+	if err := row.Scan(&job.ID, &job.ProjectID, &job.Image, &command, &job.WorkingDirectory, &environment, &caches,
 		&job.RootDigest, &status, &timeoutMillis, &job.CPUs, &job.Memory, &created, &started, &finished,
 		&exitCode, &job.ErrorMessage, &cancelled, &job.WorkerID, &requestHash); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1162,6 +1176,9 @@ func scanIdempotentJob(row interface{ Scan(...any) error }) (control.Job, string
 		return control.Job{}, "", err
 	}
 	if err := json.Unmarshal([]byte(environment), &job.Environment); err != nil {
+		return control.Job{}, "", err
+	}
+	if err := json.Unmarshal([]byte(caches), &job.Caches); err != nil {
 		return control.Job{}, "", err
 	}
 	job.Status, job.Timeout, job.CreatedAt = protocol.Status(status), time.Duration(timeoutMillis)*time.Millisecond, fromUnix(created)
@@ -1311,4 +1328,8 @@ func cloneMap(input map[string]string) map[string]string {
 		result[key] = value
 	}
 	return result
+}
+
+func cloneCaches(input []control.CacheMount) []control.CacheMount {
+	return append([]control.CacheMount(nil), input...)
 }

--- a/rtest/internal/control/sqlite/store.go
+++ b/rtest/internal/control/sqlite/store.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -59,6 +60,29 @@ func ensurePrivateDir(root string) error {
 func (s *Store) Root() string { return s.root }
 
 func (s *Store) Close() error { return s.db.Close() }
+
+func (s *Store) Check(ctx context.Context) error { return s.db.PingContext(ctx) }
+
+func (s *Store) Backup(ctx context.Context, output string) error {
+	if output == "" {
+		return errors.New("backup output path is required")
+	}
+	if _, err := os.Stat(output); err == nil {
+		return errors.New("backup output already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(output), 0o700); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `VACUUM INTO ?`, output); err != nil {
+		return fmt.Errorf("snapshot control database: %w", err)
+	}
+	if err := os.Chmod(output, 0o600); err != nil {
+		return err
+	}
+	return nil
+}
 
 func (s *Store) Initialized(ctx context.Context) (bool, error) {
 	var count int
@@ -919,6 +943,23 @@ func (s *Store) StartJob(ctx context.Context, id, rootDigest string) (control.Jo
 func (s *Store) Job(ctx context.Context, id string) (control.Job, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT id,project_id,image,command_json,working_directory,environment_json,caches_json,root_digest,status,timeout_millis,cpus,memory,created_at,started_at,finished_at,exit_code,error_message,cancel_requested,worker_id FROM control_jobs WHERE id=?`, id)
 	return scanJob(row)
+}
+
+func (s *Store) ScheduledJobs(ctx context.Context) ([]control.Job, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id,project_id,image,command_json,working_directory,environment_json,caches_json,root_digest,status,timeout_millis,cpus,memory,created_at,started_at,finished_at,exit_code,error_message,cancel_requested,worker_id FROM control_jobs WHERE status IN (?,?) ORDER BY created_at,id`, protocol.StatusQueued, protocol.StatusRunning)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var jobs []control.Job
+	for rows.Next() {
+		job, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
 }
 
 func (s *Store) ListJobs(ctx context.Context, projectID string, pageSize int, pageToken string) (control.JobPage, error) {

--- a/rtest/internal/control/sqlite/store_test.go
+++ b/rtest/internal/control/sqlite/store_test.go
@@ -66,7 +66,7 @@ CREATE TABLE control_builds (
 			columns[name] = true
 		}
 		_ = rows.Close()
-		if !columns["idempotency_key"] || !columns["request_hash"] {
+		if !columns["idempotency_key"] || !columns["request_hash"] || table == "control_jobs" && !columns["caches_json"] {
 			t.Fatalf("%s columns = %#v", table, columns)
 		}
 	}

--- a/rtest/internal/control/sqlite/store_test.go
+++ b/rtest/internal/control/sqlite/store_test.go
@@ -131,6 +131,27 @@ func TestBootstrapTokenAuthenticatesWithoutPersistingSecret(t *testing.T) {
 	}
 }
 
+func TestBackupProducesAConsistentStandaloneDatabase(t *testing.T) {
+	store := openStore(t)
+	ctx := context.Background()
+	if _, err := store.Bootstrap(ctx, control.Bootstrap{UserName: "Owner", ProjectSlug: "example", ProjectName: "Example", TokenName: "device"}); err != nil {
+		t.Fatal(err)
+	}
+	backup := filepath.Join(t.TempDir(), "control.db")
+	if err := store.Backup(ctx, backup); err != nil {
+		t.Fatal(err)
+	}
+	copy, err := controlsqlite.Open(filepath.Dir(backup), []byte("test-pepper-that-is-at-least-32-bytes"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer copy.Close()
+	initialized, err := copy.Initialized(ctx)
+	if err != nil || !initialized {
+		t.Fatalf("initialized=%v err=%v", initialized, err)
+	}
+}
+
 func TestDeviceTokensAreIndependentlyRevocable(t *testing.T) {
 	store := openStore(t)
 	ctx := context.Background()

--- a/rtest/internal/control/swarmscheduler/logs_test.go
+++ b/rtest/internal/control/swarmscheduler/logs_test.go
@@ -1,0 +1,30 @@
+package swarmscheduler
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flidai/leapview/rtest/internal/swarm"
+)
+
+func TestCompletedLogsPreferDurableJobFile(t *testing.T) {
+	root := t.TempDir()
+	directory := filepath.Join(root, "job-one")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, "job.log"), []byte("durable output\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	scheduler := New(Config{Client: swarm.New(swarm.Config{Binary: "does-not-exist"}), JobsRoot: root})
+	var output bytes.Buffer
+	if err := scheduler.Logs(context.Background(), "job-one", false, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.String() != "durable output\n" {
+		t.Fatalf("output = %q", output.String())
+	}
+}

--- a/rtest/internal/control/swarmscheduler/scheduler.go
+++ b/rtest/internal/control/swarmscheduler/scheduler.go
@@ -2,7 +2,10 @@ package swarmscheduler
 
 import (
 	"context"
+	"errors"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/flidai/leapview/rtest/internal/control"
 	"github.com/flidai/leapview/rtest/internal/protocol"
@@ -15,6 +18,7 @@ type Config struct {
 	CASInstance        string
 	JobsRoot           string
 	EntrypointHostPath string
+	CacheRoot          string
 }
 
 type Scheduler struct {
@@ -30,15 +34,53 @@ func (s *Scheduler) ValidateImage(ctx context.Context, image string) error {
 }
 
 func (s *Scheduler) Create(ctx context.Context, job control.Job) error {
-	_, err := s.config.Client.Create(ctx, swarm.Spec{
-		ID: job.ID, Repository: job.ProjectID, Suite: "exec", Runner: "oci",
-		Image: job.Image, CASAddress: s.config.CASAddress, CASInstance: s.config.CASInstance,
-		RootDigest: job.RootDigest, JobsRoot: s.config.JobsRoot, Command: job.Command,
-		WorkingDirectory: job.WorkingDirectory, Environment: job.Environment,
-		EntrypointHostPath: s.config.EntrypointHostPath,
-		Timeout:            job.Timeout, CPUs: job.CPUs, Memory: job.Memory,
-	})
+	if err := prepareCacheDirectories(s.config.CacheRoot, job.ProjectID, job.Caches); err != nil {
+		return err
+	}
+	_, err := s.config.Client.Create(ctx, specForJob(s.config, job))
 	return err
+}
+
+func specForJob(config Config, job control.Job) swarm.Spec {
+	caches := make([]swarm.CacheMount, 0, len(job.Caches))
+	for _, cache := range job.Caches {
+		caches = append(caches, swarm.CacheMount{Name: cache.Name, Target: cache.Target})
+	}
+	return swarm.Spec{
+		ID: job.ID, Repository: job.ProjectID, Suite: "exec", Runner: "oci",
+		Image: job.Image, CASAddress: config.CASAddress, CASInstance: config.CASInstance,
+		RootDigest: job.RootDigest, JobsRoot: config.JobsRoot, Command: job.Command,
+		WorkingDirectory: job.WorkingDirectory, Environment: job.Environment,
+		EntrypointHostPath: config.EntrypointHostPath,
+		Timeout:            job.Timeout, CPUs: job.CPUs, Memory: job.Memory,
+		CacheRoot: config.CacheRoot, ProjectID: job.ProjectID, Caches: caches,
+	}
+}
+
+func prepareCacheDirectories(root, projectID string, caches []control.CacheMount) error {
+	if len(caches) == 0 {
+		return nil
+	}
+	if root == "" || !safeComponent(projectID) {
+		return errors.New("cache root and safe project ID are required")
+	}
+	for _, cache := range caches {
+		if !safeComponent(cache.Name) {
+			return errors.New("cache name is not a safe path component")
+		}
+		directory := filepath.Join(root, projectID, cache.Name)
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			return err
+		}
+		if err := os.Chmod(directory, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func safeComponent(value string) bool {
+	return value != "" && value != "." && value != ".." && filepath.Base(value) == value
 }
 
 func (s *Scheduler) Status(ctx context.Context, id string) (protocol.Job, error) {

--- a/rtest/internal/control/swarmscheduler/scheduler.go
+++ b/rtest/internal/control/swarmscheduler/scheduler.go
@@ -88,11 +88,30 @@ func (s *Scheduler) Status(ctx context.Context, id string) (protocol.Job, error)
 }
 
 func (s *Scheduler) Logs(ctx context.Context, id string, follow bool, output io.Writer) error {
+	if !follow {
+		file, err := os.Open(filepath.Join(s.config.JobsRoot, id, "job.log"))
+		if err == nil {
+			defer file.Close()
+			_, err = io.Copy(output, file)
+			return err
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
 	return s.config.Client.Logs(ctx, id, follow, output)
 }
 
 func (s *Scheduler) Cancel(ctx context.Context, id string) error {
 	return s.config.Client.Cancel(ctx, id)
+}
+
+func (s *Scheduler) ManagedJobs(ctx context.Context) ([]protocol.Job, error) {
+	return s.config.Client.List(ctx, "", 0)
+}
+
+func (s *Scheduler) Remove(ctx context.Context, id string) error {
+	return s.config.Client.Remove(ctx, id)
 }
 
 var _ control.Scheduler = (*Scheduler)(nil)

--- a/rtest/internal/control/swarmscheduler/scheduler.go
+++ b/rtest/internal/control/swarmscheduler/scheduler.go
@@ -19,6 +19,8 @@ type Config struct {
 	JobsRoot           string
 	EntrypointHostPath string
 	CacheRoot          string
+	HostUID            string
+	HostGID            string
 }
 
 type Scheduler struct {
@@ -54,6 +56,7 @@ func specForJob(config Config, job control.Job) swarm.Spec {
 		EntrypointHostPath: config.EntrypointHostPath,
 		Timeout:            job.Timeout, CPUs: job.CPUs, Memory: job.Memory,
 		CacheRoot: config.CacheRoot, ProjectID: job.ProjectID, Caches: caches,
+		HostUID: config.HostUID, HostGID: config.HostGID,
 	}
 }
 

--- a/rtest/internal/control/swarmscheduler/scheduler_test.go
+++ b/rtest/internal/control/swarmscheduler/scheduler_test.go
@@ -1,0 +1,37 @@
+package swarmscheduler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flidai/leapview/rtest/internal/control"
+)
+
+func TestProjectCachesUseIndependentPrivateDirectories(t *testing.T) {
+	root := t.TempDir()
+	caches := []control.CacheMount{{Name: "modules", Target: "/go/pkg/mod"}}
+	for _, project := range []string{"project-one", "project-two"} {
+		if err := prepareCacheDirectories(root, project, caches); err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(filepath.Join(root, project, "modules"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Fatalf("cache mode = %o", info.Mode().Perm())
+		}
+	}
+	one := specForJob(Config{CacheRoot: root}, control.Job{ID: "job-one", ProjectID: "project-one", Caches: caches})
+	two := specForJob(Config{CacheRoot: root}, control.Job{ID: "job-two", ProjectID: "project-two", Caches: caches})
+	if filepath.Join(one.CacheRoot, one.ProjectID, one.Caches[0].Name) == filepath.Join(two.CacheRoot, two.ProjectID, two.Caches[0].Name) {
+		t.Fatal("two projects resolved to the same writable cache")
+	}
+}
+
+func TestCacheDirectoriesRejectUnsafeComponents(t *testing.T) {
+	if err := prepareCacheDirectories(t.TempDir(), "project", []control.CacheMount{{Name: "../shared", Target: "/cache"}}); err == nil {
+		t.Fatal("unsafe cache name was accepted")
+	}
+}

--- a/rtest/internal/gen/rtest/v1/control.pb.go
+++ b/rtest/internal/gen/rtest/v1/control.pb.go
@@ -1541,6 +1541,7 @@ type Job struct {
 	ErrorMessage     string                 `protobuf:"bytes,16,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
 	CancelRequested  bool                   `protobuf:"varint,17,opt,name=cancel_requested,json=cancelRequested,proto3" json:"cancel_requested,omitempty"`
 	WorkerId         string                 `protobuf:"bytes,18,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`
+	Caches           []*CacheMount          `protobuf:"bytes,19,rep,name=caches,proto3" json:"caches,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -1701,6 +1702,65 @@ func (x *Job) GetWorkerId() string {
 	return ""
 }
 
+func (x *Job) GetCaches() []*CacheMount {
+	if x != nil {
+		return x.Caches
+	}
+	return nil
+}
+
+type CacheMount struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Target        string                 `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CacheMount) Reset() {
+	*x = CacheMount{}
+	mi := &file_rtest_v1_control_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CacheMount) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CacheMount) ProtoMessage() {}
+
+func (x *CacheMount) ProtoReflect() protoreflect.Message {
+	mi := &file_rtest_v1_control_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CacheMount.ProtoReflect.Descriptor instead.
+func (*CacheMount) Descriptor() ([]byte, []int) {
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *CacheMount) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CacheMount) GetTarget() string {
+	if x != nil {
+		return x.Target
+	}
+	return ""
+}
+
 type PrepareJobRequest struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Project          string                 `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
@@ -1712,13 +1772,14 @@ type PrepareJobRequest struct {
 	Cpus             string                 `protobuf:"bytes,7,opt,name=cpus,proto3" json:"cpus,omitempty"`
 	Memory           string                 `protobuf:"bytes,8,opt,name=memory,proto3" json:"memory,omitempty"`
 	IdempotencyKey   string                 `protobuf:"bytes,9,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
+	Caches           []*CacheMount          `protobuf:"bytes,10,rep,name=caches,proto3" json:"caches,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PrepareJobRequest) Reset() {
 	*x = PrepareJobRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[27]
+	mi := &file_rtest_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1730,7 +1791,7 @@ func (x *PrepareJobRequest) String() string {
 func (*PrepareJobRequest) ProtoMessage() {}
 
 func (x *PrepareJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[27]
+	mi := &file_rtest_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1743,7 +1804,7 @@ func (x *PrepareJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareJobRequest.ProtoReflect.Descriptor instead.
 func (*PrepareJobRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *PrepareJobRequest) GetProject() string {
@@ -1809,6 +1870,13 @@ func (x *PrepareJobRequest) GetIdempotencyKey() string {
 	return ""
 }
 
+func (x *PrepareJobRequest) GetCaches() []*CacheMount {
+	if x != nil {
+		return x.Caches
+	}
+	return nil
+}
+
 type DataPlaneConnection struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Endpoint       string                 `protobuf:"bytes,1,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
@@ -1824,7 +1892,7 @@ type DataPlaneConnection struct {
 
 func (x *DataPlaneConnection) Reset() {
 	*x = DataPlaneConnection{}
-	mi := &file_rtest_v1_control_proto_msgTypes[28]
+	mi := &file_rtest_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1836,7 +1904,7 @@ func (x *DataPlaneConnection) String() string {
 func (*DataPlaneConnection) ProtoMessage() {}
 
 func (x *DataPlaneConnection) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[28]
+	mi := &file_rtest_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1849,7 +1917,7 @@ func (x *DataPlaneConnection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataPlaneConnection.ProtoReflect.Descriptor instead.
 func (*DataPlaneConnection) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *DataPlaneConnection) GetEndpoint() string {
@@ -1911,7 +1979,7 @@ type PrepareJobResponse struct {
 
 func (x *PrepareJobResponse) Reset() {
 	*x = PrepareJobResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[29]
+	mi := &file_rtest_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1923,7 +1991,7 @@ func (x *PrepareJobResponse) String() string {
 func (*PrepareJobResponse) ProtoMessage() {}
 
 func (x *PrepareJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[29]
+	mi := &file_rtest_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1936,7 +2004,7 @@ func (x *PrepareJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareJobResponse.ProtoReflect.Descriptor instead.
 func (*PrepareJobResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{29}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PrepareJobResponse) GetJob() *Job {
@@ -1963,7 +2031,7 @@ type StartJobRequest struct {
 
 func (x *StartJobRequest) Reset() {
 	*x = StartJobRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[30]
+	mi := &file_rtest_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1975,7 +2043,7 @@ func (x *StartJobRequest) String() string {
 func (*StartJobRequest) ProtoMessage() {}
 
 func (x *StartJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[30]
+	mi := &file_rtest_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1988,7 +2056,7 @@ func (x *StartJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartJobRequest.ProtoReflect.Descriptor instead.
 func (*StartJobRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{30}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *StartJobRequest) GetId() string {
@@ -2014,7 +2082,7 @@ type StartJobResponse struct {
 
 func (x *StartJobResponse) Reset() {
 	*x = StartJobResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[31]
+	mi := &file_rtest_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2026,7 +2094,7 @@ func (x *StartJobResponse) String() string {
 func (*StartJobResponse) ProtoMessage() {}
 
 func (x *StartJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[31]
+	mi := &file_rtest_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2039,7 +2107,7 @@ func (x *StartJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartJobResponse.ProtoReflect.Descriptor instead.
 func (*StartJobResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{31}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *StartJobResponse) GetJob() *Job {
@@ -2058,7 +2126,7 @@ type GetJobRequest struct {
 
 func (x *GetJobRequest) Reset() {
 	*x = GetJobRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[32]
+	mi := &file_rtest_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2070,7 +2138,7 @@ func (x *GetJobRequest) String() string {
 func (*GetJobRequest) ProtoMessage() {}
 
 func (x *GetJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[32]
+	mi := &file_rtest_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2083,7 +2151,7 @@ func (x *GetJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetJobRequest.ProtoReflect.Descriptor instead.
 func (*GetJobRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{32}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetJobRequest) GetId() string {
@@ -2102,7 +2170,7 @@ type GetJobResponse struct {
 
 func (x *GetJobResponse) Reset() {
 	*x = GetJobResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[33]
+	mi := &file_rtest_v1_control_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2114,7 +2182,7 @@ func (x *GetJobResponse) String() string {
 func (*GetJobResponse) ProtoMessage() {}
 
 func (x *GetJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[33]
+	mi := &file_rtest_v1_control_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2127,7 +2195,7 @@ func (x *GetJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetJobResponse.ProtoReflect.Descriptor instead.
 func (*GetJobResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{33}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetJobResponse) GetJob() *Job {
@@ -2150,7 +2218,7 @@ type ListJobsRequest struct {
 
 func (x *ListJobsRequest) Reset() {
 	*x = ListJobsRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[34]
+	mi := &file_rtest_v1_control_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2162,7 +2230,7 @@ func (x *ListJobsRequest) String() string {
 func (*ListJobsRequest) ProtoMessage() {}
 
 func (x *ListJobsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[34]
+	mi := &file_rtest_v1_control_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2175,7 +2243,7 @@ func (x *ListJobsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListJobsRequest.ProtoReflect.Descriptor instead.
 func (*ListJobsRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{34}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListJobsRequest) GetProject() string {
@@ -2217,7 +2285,7 @@ type ListJobsResponse struct {
 
 func (x *ListJobsResponse) Reset() {
 	*x = ListJobsResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[35]
+	mi := &file_rtest_v1_control_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2229,7 +2297,7 @@ func (x *ListJobsResponse) String() string {
 func (*ListJobsResponse) ProtoMessage() {}
 
 func (x *ListJobsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[35]
+	mi := &file_rtest_v1_control_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2242,7 +2310,7 @@ func (x *ListJobsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListJobsResponse.ProtoReflect.Descriptor instead.
 func (*ListJobsResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{35}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ListJobsResponse) GetJobs() []*Job {
@@ -2268,7 +2336,7 @@ type CancelJobRequest struct {
 
 func (x *CancelJobRequest) Reset() {
 	*x = CancelJobRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[36]
+	mi := &file_rtest_v1_control_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2280,7 +2348,7 @@ func (x *CancelJobRequest) String() string {
 func (*CancelJobRequest) ProtoMessage() {}
 
 func (x *CancelJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[36]
+	mi := &file_rtest_v1_control_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2293,7 +2361,7 @@ func (x *CancelJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelJobRequest.ProtoReflect.Descriptor instead.
 func (*CancelJobRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{36}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CancelJobRequest) GetId() string {
@@ -2312,7 +2380,7 @@ type CancelJobResponse struct {
 
 func (x *CancelJobResponse) Reset() {
 	*x = CancelJobResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[37]
+	mi := &file_rtest_v1_control_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2324,7 +2392,7 @@ func (x *CancelJobResponse) String() string {
 func (*CancelJobResponse) ProtoMessage() {}
 
 func (x *CancelJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[37]
+	mi := &file_rtest_v1_control_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2337,7 +2405,7 @@ func (x *CancelJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelJobResponse.ProtoReflect.Descriptor instead.
 func (*CancelJobResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{37}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CancelJobResponse) GetJob() *Job {
@@ -2357,7 +2425,7 @@ type StreamJobLogsRequest struct {
 
 func (x *StreamJobLogsRequest) Reset() {
 	*x = StreamJobLogsRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[38]
+	mi := &file_rtest_v1_control_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2369,7 +2437,7 @@ func (x *StreamJobLogsRequest) String() string {
 func (*StreamJobLogsRequest) ProtoMessage() {}
 
 func (x *StreamJobLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[38]
+	mi := &file_rtest_v1_control_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2382,7 +2450,7 @@ func (x *StreamJobLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamJobLogsRequest.ProtoReflect.Descriptor instead.
 func (*StreamJobLogsRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{38}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *StreamJobLogsRequest) GetId() string {
@@ -2410,7 +2478,7 @@ type StreamJobLogsResponse struct {
 
 func (x *StreamJobLogsResponse) Reset() {
 	*x = StreamJobLogsResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[39]
+	mi := &file_rtest_v1_control_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2422,7 +2490,7 @@ func (x *StreamJobLogsResponse) String() string {
 func (*StreamJobLogsResponse) ProtoMessage() {}
 
 func (x *StreamJobLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[39]
+	mi := &file_rtest_v1_control_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2435,7 +2503,7 @@ func (x *StreamJobLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamJobLogsResponse.ProtoReflect.Descriptor instead.
 func (*StreamJobLogsResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{39}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *StreamJobLogsResponse) GetData() []byte {
@@ -2473,7 +2541,7 @@ type Build struct {
 
 func (x *Build) Reset() {
 	*x = Build{}
-	mi := &file_rtest_v1_control_proto_msgTypes[40]
+	mi := &file_rtest_v1_control_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2485,7 +2553,7 @@ func (x *Build) String() string {
 func (*Build) ProtoMessage() {}
 
 func (x *Build) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[40]
+	mi := &file_rtest_v1_control_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2498,7 +2566,7 @@ func (x *Build) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Build.ProtoReflect.Descriptor instead.
 func (*Build) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{40}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *Build) GetId() string {
@@ -2553,7 +2621,7 @@ type PrepareBuildRequest struct {
 
 func (x *PrepareBuildRequest) Reset() {
 	*x = PrepareBuildRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[41]
+	mi := &file_rtest_v1_control_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2565,7 +2633,7 @@ func (x *PrepareBuildRequest) String() string {
 func (*PrepareBuildRequest) ProtoMessage() {}
 
 func (x *PrepareBuildRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[41]
+	mi := &file_rtest_v1_control_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2578,7 +2646,7 @@ func (x *PrepareBuildRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBuildRequest.ProtoReflect.Descriptor instead.
 func (*PrepareBuildRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{41}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *PrepareBuildRequest) GetProject() string {
@@ -2605,7 +2673,7 @@ type PrepareBuildResponse struct {
 
 func (x *PrepareBuildResponse) Reset() {
 	*x = PrepareBuildResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[42]
+	mi := &file_rtest_v1_control_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2617,7 +2685,7 @@ func (x *PrepareBuildResponse) String() string {
 func (*PrepareBuildResponse) ProtoMessage() {}
 
 func (x *PrepareBuildResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[42]
+	mi := &file_rtest_v1_control_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2630,7 +2698,7 @@ func (x *PrepareBuildResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBuildResponse.ProtoReflect.Descriptor instead.
 func (*PrepareBuildResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{42}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *PrepareBuildResponse) GetBuild() *Build {
@@ -2658,7 +2726,7 @@ type FinishBuildRequest struct {
 
 func (x *FinishBuildRequest) Reset() {
 	*x = FinishBuildRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[43]
+	mi := &file_rtest_v1_control_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2670,7 +2738,7 @@ func (x *FinishBuildRequest) String() string {
 func (*FinishBuildRequest) ProtoMessage() {}
 
 func (x *FinishBuildRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[43]
+	mi := &file_rtest_v1_control_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2683,7 +2751,7 @@ func (x *FinishBuildRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinishBuildRequest.ProtoReflect.Descriptor instead.
 func (*FinishBuildRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{43}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *FinishBuildRequest) GetId() string {
@@ -2716,7 +2784,7 @@ type FinishBuildResponse struct {
 
 func (x *FinishBuildResponse) Reset() {
 	*x = FinishBuildResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[44]
+	mi := &file_rtest_v1_control_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2728,7 +2796,7 @@ func (x *FinishBuildResponse) String() string {
 func (*FinishBuildResponse) ProtoMessage() {}
 
 func (x *FinishBuildResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[44]
+	mi := &file_rtest_v1_control_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2741,7 +2809,7 @@ func (x *FinishBuildResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinishBuildResponse.ProtoReflect.Descriptor instead.
 func (*FinishBuildResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{44}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *FinishBuildResponse) GetBuild() *Build {
@@ -2761,7 +2829,7 @@ type ExchangeGitHubOIDCRequest struct {
 
 func (x *ExchangeGitHubOIDCRequest) Reset() {
 	*x = ExchangeGitHubOIDCRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[45]
+	mi := &file_rtest_v1_control_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2773,7 +2841,7 @@ func (x *ExchangeGitHubOIDCRequest) String() string {
 func (*ExchangeGitHubOIDCRequest) ProtoMessage() {}
 
 func (x *ExchangeGitHubOIDCRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[45]
+	mi := &file_rtest_v1_control_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2786,7 +2854,7 @@ func (x *ExchangeGitHubOIDCRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExchangeGitHubOIDCRequest.ProtoReflect.Descriptor instead.
 func (*ExchangeGitHubOIDCRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{45}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ExchangeGitHubOIDCRequest) GetProject() string {
@@ -2813,7 +2881,7 @@ type ExchangeGitHubOIDCResponse struct {
 
 func (x *ExchangeGitHubOIDCResponse) Reset() {
 	*x = ExchangeGitHubOIDCResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[46]
+	mi := &file_rtest_v1_control_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2825,7 +2893,7 @@ func (x *ExchangeGitHubOIDCResponse) String() string {
 func (*ExchangeGitHubOIDCResponse) ProtoMessage() {}
 
 func (x *ExchangeGitHubOIDCResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[46]
+	mi := &file_rtest_v1_control_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2838,7 +2906,7 @@ func (x *ExchangeGitHubOIDCResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExchangeGitHubOIDCResponse.ProtoReflect.Descriptor instead.
 func (*ExchangeGitHubOIDCResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{46}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ExchangeGitHubOIDCResponse) GetToken() string {
@@ -2873,7 +2941,7 @@ type GitHubTrust struct {
 
 func (x *GitHubTrust) Reset() {
 	*x = GitHubTrust{}
-	mi := &file_rtest_v1_control_proto_msgTypes[47]
+	mi := &file_rtest_v1_control_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2885,7 +2953,7 @@ func (x *GitHubTrust) String() string {
 func (*GitHubTrust) ProtoMessage() {}
 
 func (x *GitHubTrust) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[47]
+	mi := &file_rtest_v1_control_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2898,7 +2966,7 @@ func (x *GitHubTrust) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitHubTrust.ProtoReflect.Descriptor instead.
 func (*GitHubTrust) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{47}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GitHubTrust) GetId() string {
@@ -2986,7 +3054,7 @@ type CreateGitHubTrustRequest struct {
 
 func (x *CreateGitHubTrustRequest) Reset() {
 	*x = CreateGitHubTrustRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[48]
+	mi := &file_rtest_v1_control_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2998,7 +3066,7 @@ func (x *CreateGitHubTrustRequest) String() string {
 func (*CreateGitHubTrustRequest) ProtoMessage() {}
 
 func (x *CreateGitHubTrustRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[48]
+	mi := &file_rtest_v1_control_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3011,7 +3079,7 @@ func (x *CreateGitHubTrustRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateGitHubTrustRequest.ProtoReflect.Descriptor instead.
 func (*CreateGitHubTrustRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{48}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *CreateGitHubTrustRequest) GetProject() string {
@@ -3072,7 +3140,7 @@ type CreateGitHubTrustResponse struct {
 
 func (x *CreateGitHubTrustResponse) Reset() {
 	*x = CreateGitHubTrustResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[49]
+	mi := &file_rtest_v1_control_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3084,7 +3152,7 @@ func (x *CreateGitHubTrustResponse) String() string {
 func (*CreateGitHubTrustResponse) ProtoMessage() {}
 
 func (x *CreateGitHubTrustResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[49]
+	mi := &file_rtest_v1_control_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3097,7 +3165,7 @@ func (x *CreateGitHubTrustResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateGitHubTrustResponse.ProtoReflect.Descriptor instead.
 func (*CreateGitHubTrustResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{49}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *CreateGitHubTrustResponse) GetTrust() *GitHubTrust {
@@ -3116,7 +3184,7 @@ type ListGitHubTrustsRequest struct {
 
 func (x *ListGitHubTrustsRequest) Reset() {
 	*x = ListGitHubTrustsRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[50]
+	mi := &file_rtest_v1_control_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3128,7 +3196,7 @@ func (x *ListGitHubTrustsRequest) String() string {
 func (*ListGitHubTrustsRequest) ProtoMessage() {}
 
 func (x *ListGitHubTrustsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[50]
+	mi := &file_rtest_v1_control_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3141,7 +3209,7 @@ func (x *ListGitHubTrustsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGitHubTrustsRequest.ProtoReflect.Descriptor instead.
 func (*ListGitHubTrustsRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{50}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ListGitHubTrustsRequest) GetProject() string {
@@ -3160,7 +3228,7 @@ type ListGitHubTrustsResponse struct {
 
 func (x *ListGitHubTrustsResponse) Reset() {
 	*x = ListGitHubTrustsResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[51]
+	mi := &file_rtest_v1_control_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3172,7 +3240,7 @@ func (x *ListGitHubTrustsResponse) String() string {
 func (*ListGitHubTrustsResponse) ProtoMessage() {}
 
 func (x *ListGitHubTrustsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[51]
+	mi := &file_rtest_v1_control_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3185,7 +3253,7 @@ func (x *ListGitHubTrustsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGitHubTrustsResponse.ProtoReflect.Descriptor instead.
 func (*ListGitHubTrustsResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{51}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ListGitHubTrustsResponse) GetTrusts() []*GitHubTrust {
@@ -3204,7 +3272,7 @@ type RevokeGitHubTrustRequest struct {
 
 func (x *RevokeGitHubTrustRequest) Reset() {
 	*x = RevokeGitHubTrustRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[52]
+	mi := &file_rtest_v1_control_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3216,7 +3284,7 @@ func (x *RevokeGitHubTrustRequest) String() string {
 func (*RevokeGitHubTrustRequest) ProtoMessage() {}
 
 func (x *RevokeGitHubTrustRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[52]
+	mi := &file_rtest_v1_control_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3229,7 +3297,7 @@ func (x *RevokeGitHubTrustRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeGitHubTrustRequest.ProtoReflect.Descriptor instead.
 func (*RevokeGitHubTrustRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{52}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *RevokeGitHubTrustRequest) GetId() string {
@@ -3247,7 +3315,7 @@ type RevokeGitHubTrustResponse struct {
 
 func (x *RevokeGitHubTrustResponse) Reset() {
 	*x = RevokeGitHubTrustResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[53]
+	mi := &file_rtest_v1_control_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3259,7 +3327,7 @@ func (x *RevokeGitHubTrustResponse) String() string {
 func (*RevokeGitHubTrustResponse) ProtoMessage() {}
 
 func (x *RevokeGitHubTrustResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[53]
+	mi := &file_rtest_v1_control_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3272,7 +3340,7 @@ func (x *RevokeGitHubTrustResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeGitHubTrustResponse.ProtoReflect.Descriptor instead.
 func (*RevokeGitHubTrustResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{53}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{54}
 }
 
 type DeviceToken struct {
@@ -3290,7 +3358,7 @@ type DeviceToken struct {
 
 func (x *DeviceToken) Reset() {
 	*x = DeviceToken{}
-	mi := &file_rtest_v1_control_proto_msgTypes[54]
+	mi := &file_rtest_v1_control_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3302,7 +3370,7 @@ func (x *DeviceToken) String() string {
 func (*DeviceToken) ProtoMessage() {}
 
 func (x *DeviceToken) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[54]
+	mi := &file_rtest_v1_control_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3315,7 +3383,7 @@ func (x *DeviceToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceToken.ProtoReflect.Descriptor instead.
 func (*DeviceToken) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{54}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *DeviceToken) GetId() string {
@@ -3378,7 +3446,7 @@ type CreateDeviceTokenRequest struct {
 
 func (x *CreateDeviceTokenRequest) Reset() {
 	*x = CreateDeviceTokenRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[55]
+	mi := &file_rtest_v1_control_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3390,7 +3458,7 @@ func (x *CreateDeviceTokenRequest) String() string {
 func (*CreateDeviceTokenRequest) ProtoMessage() {}
 
 func (x *CreateDeviceTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[55]
+	mi := &file_rtest_v1_control_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3403,7 +3471,7 @@ func (x *CreateDeviceTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDeviceTokenRequest.ProtoReflect.Descriptor instead.
 func (*CreateDeviceTokenRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{55}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *CreateDeviceTokenRequest) GetName() string {
@@ -3437,7 +3505,7 @@ type CreateDeviceTokenResponse struct {
 
 func (x *CreateDeviceTokenResponse) Reset() {
 	*x = CreateDeviceTokenResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[56]
+	mi := &file_rtest_v1_control_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3449,7 +3517,7 @@ func (x *CreateDeviceTokenResponse) String() string {
 func (*CreateDeviceTokenResponse) ProtoMessage() {}
 
 func (x *CreateDeviceTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[56]
+	mi := &file_rtest_v1_control_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3462,7 +3530,7 @@ func (x *CreateDeviceTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDeviceTokenResponse.ProtoReflect.Descriptor instead.
 func (*CreateDeviceTokenResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{56}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *CreateDeviceTokenResponse) GetTokenMetadata() *DeviceToken {
@@ -3487,7 +3555,7 @@ type ListDeviceTokensRequest struct {
 
 func (x *ListDeviceTokensRequest) Reset() {
 	*x = ListDeviceTokensRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[57]
+	mi := &file_rtest_v1_control_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3499,7 +3567,7 @@ func (x *ListDeviceTokensRequest) String() string {
 func (*ListDeviceTokensRequest) ProtoMessage() {}
 
 func (x *ListDeviceTokensRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[57]
+	mi := &file_rtest_v1_control_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3512,7 +3580,7 @@ func (x *ListDeviceTokensRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDeviceTokensRequest.ProtoReflect.Descriptor instead.
 func (*ListDeviceTokensRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{57}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{58}
 }
 
 type ListDeviceTokensResponse struct {
@@ -3524,7 +3592,7 @@ type ListDeviceTokensResponse struct {
 
 func (x *ListDeviceTokensResponse) Reset() {
 	*x = ListDeviceTokensResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[58]
+	mi := &file_rtest_v1_control_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3536,7 +3604,7 @@ func (x *ListDeviceTokensResponse) String() string {
 func (*ListDeviceTokensResponse) ProtoMessage() {}
 
 func (x *ListDeviceTokensResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[58]
+	mi := &file_rtest_v1_control_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3549,7 +3617,7 @@ func (x *ListDeviceTokensResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDeviceTokensResponse.ProtoReflect.Descriptor instead.
 func (*ListDeviceTokensResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{58}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ListDeviceTokensResponse) GetTokens() []*DeviceToken {
@@ -3568,7 +3636,7 @@ type RevokeDeviceTokenRequest struct {
 
 func (x *RevokeDeviceTokenRequest) Reset() {
 	*x = RevokeDeviceTokenRequest{}
-	mi := &file_rtest_v1_control_proto_msgTypes[59]
+	mi := &file_rtest_v1_control_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3580,7 +3648,7 @@ func (x *RevokeDeviceTokenRequest) String() string {
 func (*RevokeDeviceTokenRequest) ProtoMessage() {}
 
 func (x *RevokeDeviceTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[59]
+	mi := &file_rtest_v1_control_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3593,7 +3661,7 @@ func (x *RevokeDeviceTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeDeviceTokenRequest.ProtoReflect.Descriptor instead.
 func (*RevokeDeviceTokenRequest) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{59}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *RevokeDeviceTokenRequest) GetId() string {
@@ -3611,7 +3679,7 @@ type RevokeDeviceTokenResponse struct {
 
 func (x *RevokeDeviceTokenResponse) Reset() {
 	*x = RevokeDeviceTokenResponse{}
-	mi := &file_rtest_v1_control_proto_msgTypes[60]
+	mi := &file_rtest_v1_control_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3623,7 +3691,7 @@ func (x *RevokeDeviceTokenResponse) String() string {
 func (*RevokeDeviceTokenResponse) ProtoMessage() {}
 
 func (x *RevokeDeviceTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_rtest_v1_control_proto_msgTypes[60]
+	mi := &file_rtest_v1_control_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3636,7 +3704,7 @@ func (x *RevokeDeviceTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeDeviceTokenResponse.ProtoReflect.Descriptor instead.
 func (*RevokeDeviceTokenResponse) Descriptor() ([]byte, []int) {
-	return file_rtest_v1_control_proto_rawDescGZIP(), []int{60}
+	return file_rtest_v1_control_proto_rawDescGZIP(), []int{61}
 }
 
 var File_rtest_v1_control_proto protoreflect.FileDescriptor
@@ -3736,7 +3804,7 @@ const file_rtest_v1_control_proto_rawDesc = "" +
 	"\x1eListProjectImageHistoryRequest\x12\x18\n" +
 	"\aproject\x18\x01 \x01(\tR\aproject\"V\n" +
 	"\x1fListProjectImageHistoryResponse\x123\n" +
-	"\x06events\x18\x01 \x03(\v2\x1b.rtest.v1.ProjectImageEventR\x06events\"\x92\x06\n" +
+	"\x06events\x18\x01 \x03(\v2\x1b.rtest.v1.ProjectImageEventR\x06events\"\xc0\x06\n" +
 	"\x03Job\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -3761,12 +3829,17 @@ const file_rtest_v1_control_proto_rawDesc = "" +
 	"\texit_code\x18\x0f \x01(\x05H\x00R\bexitCode\x88\x01\x01\x12#\n" +
 	"\rerror_message\x18\x10 \x01(\tR\ferrorMessage\x12)\n" +
 	"\x10cancel_requested\x18\x11 \x01(\bR\x0fcancelRequested\x12\x1b\n" +
-	"\tworker_id\x18\x12 \x01(\tR\bworkerId\x1a>\n" +
+	"\tworker_id\x18\x12 \x01(\tR\bworkerId\x12,\n" +
+	"\x06caches\x18\x13 \x03(\v2\x14.rtest.v1.CacheMountR\x06caches\x1a>\n" +
 	"\x10EnvironmentEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\f\n" +
 	"\n" +
-	"_exit_code\"\xa4\x03\n" +
+	"_exit_code\"8\n" +
+	"\n" +
+	"CacheMount\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x06target\x18\x02 \x01(\tR\x06target\"\xd2\x03\n" +
 	"\x11PrepareJobRequest\x12\x18\n" +
 	"\aproject\x18\x01 \x01(\tR\aproject\x12\x14\n" +
 	"\x05image\x18\x02 \x01(\tR\x05image\x12\x18\n" +
@@ -3776,7 +3849,9 @@ const file_rtest_v1_control_proto_rawDesc = "" +
 	"\atimeout\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\atimeout\x12\x12\n" +
 	"\x04cpus\x18\a \x01(\tR\x04cpus\x12\x16\n" +
 	"\x06memory\x18\b \x01(\tR\x06memory\x12'\n" +
-	"\x0fidempotency_key\x18\t \x01(\tR\x0eidempotencyKey\x1a>\n" +
+	"\x0fidempotency_key\x18\t \x01(\tR\x0eidempotencyKey\x12,\n" +
+	"\x06caches\x18\n" +
+	" \x03(\v2\x14.rtest.v1.CacheMountR\x06caches\x1a>\n" +
 	"\x10EnvironmentEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9a\x02\n" +
@@ -3972,7 +4047,7 @@ func file_rtest_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_rtest_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_rtest_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
+var file_rtest_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 64)
 var file_rtest_v1_control_proto_goTypes = []any{
 	(JobStatus)(0),                          // 0: rtest.v1.JobStatus
 	(BuildStatus)(0),                        // 1: rtest.v1.BuildStatus
@@ -4003,153 +4078,156 @@ var file_rtest_v1_control_proto_goTypes = []any{
 	(*ListProjectImageHistoryRequest)(nil),  // 26: rtest.v1.ListProjectImageHistoryRequest
 	(*ListProjectImageHistoryResponse)(nil), // 27: rtest.v1.ListProjectImageHistoryResponse
 	(*Job)(nil),                             // 28: rtest.v1.Job
-	(*PrepareJobRequest)(nil),               // 29: rtest.v1.PrepareJobRequest
-	(*DataPlaneConnection)(nil),             // 30: rtest.v1.DataPlaneConnection
-	(*PrepareJobResponse)(nil),              // 31: rtest.v1.PrepareJobResponse
-	(*StartJobRequest)(nil),                 // 32: rtest.v1.StartJobRequest
-	(*StartJobResponse)(nil),                // 33: rtest.v1.StartJobResponse
-	(*GetJobRequest)(nil),                   // 34: rtest.v1.GetJobRequest
-	(*GetJobResponse)(nil),                  // 35: rtest.v1.GetJobResponse
-	(*ListJobsRequest)(nil),                 // 36: rtest.v1.ListJobsRequest
-	(*ListJobsResponse)(nil),                // 37: rtest.v1.ListJobsResponse
-	(*CancelJobRequest)(nil),                // 38: rtest.v1.CancelJobRequest
-	(*CancelJobResponse)(nil),               // 39: rtest.v1.CancelJobResponse
-	(*StreamJobLogsRequest)(nil),            // 40: rtest.v1.StreamJobLogsRequest
-	(*StreamJobLogsResponse)(nil),           // 41: rtest.v1.StreamJobLogsResponse
-	(*Build)(nil),                           // 42: rtest.v1.Build
-	(*PrepareBuildRequest)(nil),             // 43: rtest.v1.PrepareBuildRequest
-	(*PrepareBuildResponse)(nil),            // 44: rtest.v1.PrepareBuildResponse
-	(*FinishBuildRequest)(nil),              // 45: rtest.v1.FinishBuildRequest
-	(*FinishBuildResponse)(nil),             // 46: rtest.v1.FinishBuildResponse
-	(*ExchangeGitHubOIDCRequest)(nil),       // 47: rtest.v1.ExchangeGitHubOIDCRequest
-	(*ExchangeGitHubOIDCResponse)(nil),      // 48: rtest.v1.ExchangeGitHubOIDCResponse
-	(*GitHubTrust)(nil),                     // 49: rtest.v1.GitHubTrust
-	(*CreateGitHubTrustRequest)(nil),        // 50: rtest.v1.CreateGitHubTrustRequest
-	(*CreateGitHubTrustResponse)(nil),       // 51: rtest.v1.CreateGitHubTrustResponse
-	(*ListGitHubTrustsRequest)(nil),         // 52: rtest.v1.ListGitHubTrustsRequest
-	(*ListGitHubTrustsResponse)(nil),        // 53: rtest.v1.ListGitHubTrustsResponse
-	(*RevokeGitHubTrustRequest)(nil),        // 54: rtest.v1.RevokeGitHubTrustRequest
-	(*RevokeGitHubTrustResponse)(nil),       // 55: rtest.v1.RevokeGitHubTrustResponse
-	(*DeviceToken)(nil),                     // 56: rtest.v1.DeviceToken
-	(*CreateDeviceTokenRequest)(nil),        // 57: rtest.v1.CreateDeviceTokenRequest
-	(*CreateDeviceTokenResponse)(nil),       // 58: rtest.v1.CreateDeviceTokenResponse
-	(*ListDeviceTokensRequest)(nil),         // 59: rtest.v1.ListDeviceTokensRequest
-	(*ListDeviceTokensResponse)(nil),        // 60: rtest.v1.ListDeviceTokensResponse
-	(*RevokeDeviceTokenRequest)(nil),        // 61: rtest.v1.RevokeDeviceTokenRequest
-	(*RevokeDeviceTokenResponse)(nil),       // 62: rtest.v1.RevokeDeviceTokenResponse
-	nil,                                     // 63: rtest.v1.Job.EnvironmentEntry
-	nil,                                     // 64: rtest.v1.PrepareJobRequest.EnvironmentEntry
-	(*timestamppb.Timestamp)(nil),           // 65: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),             // 66: google.protobuf.Duration
+	(*CacheMount)(nil),                      // 29: rtest.v1.CacheMount
+	(*PrepareJobRequest)(nil),               // 30: rtest.v1.PrepareJobRequest
+	(*DataPlaneConnection)(nil),             // 31: rtest.v1.DataPlaneConnection
+	(*PrepareJobResponse)(nil),              // 32: rtest.v1.PrepareJobResponse
+	(*StartJobRequest)(nil),                 // 33: rtest.v1.StartJobRequest
+	(*StartJobResponse)(nil),                // 34: rtest.v1.StartJobResponse
+	(*GetJobRequest)(nil),                   // 35: rtest.v1.GetJobRequest
+	(*GetJobResponse)(nil),                  // 36: rtest.v1.GetJobResponse
+	(*ListJobsRequest)(nil),                 // 37: rtest.v1.ListJobsRequest
+	(*ListJobsResponse)(nil),                // 38: rtest.v1.ListJobsResponse
+	(*CancelJobRequest)(nil),                // 39: rtest.v1.CancelJobRequest
+	(*CancelJobResponse)(nil),               // 40: rtest.v1.CancelJobResponse
+	(*StreamJobLogsRequest)(nil),            // 41: rtest.v1.StreamJobLogsRequest
+	(*StreamJobLogsResponse)(nil),           // 42: rtest.v1.StreamJobLogsResponse
+	(*Build)(nil),                           // 43: rtest.v1.Build
+	(*PrepareBuildRequest)(nil),             // 44: rtest.v1.PrepareBuildRequest
+	(*PrepareBuildResponse)(nil),            // 45: rtest.v1.PrepareBuildResponse
+	(*FinishBuildRequest)(nil),              // 46: rtest.v1.FinishBuildRequest
+	(*FinishBuildResponse)(nil),             // 47: rtest.v1.FinishBuildResponse
+	(*ExchangeGitHubOIDCRequest)(nil),       // 48: rtest.v1.ExchangeGitHubOIDCRequest
+	(*ExchangeGitHubOIDCResponse)(nil),      // 49: rtest.v1.ExchangeGitHubOIDCResponse
+	(*GitHubTrust)(nil),                     // 50: rtest.v1.GitHubTrust
+	(*CreateGitHubTrustRequest)(nil),        // 51: rtest.v1.CreateGitHubTrustRequest
+	(*CreateGitHubTrustResponse)(nil),       // 52: rtest.v1.CreateGitHubTrustResponse
+	(*ListGitHubTrustsRequest)(nil),         // 53: rtest.v1.ListGitHubTrustsRequest
+	(*ListGitHubTrustsResponse)(nil),        // 54: rtest.v1.ListGitHubTrustsResponse
+	(*RevokeGitHubTrustRequest)(nil),        // 55: rtest.v1.RevokeGitHubTrustRequest
+	(*RevokeGitHubTrustResponse)(nil),       // 56: rtest.v1.RevokeGitHubTrustResponse
+	(*DeviceToken)(nil),                     // 57: rtest.v1.DeviceToken
+	(*CreateDeviceTokenRequest)(nil),        // 58: rtest.v1.CreateDeviceTokenRequest
+	(*CreateDeviceTokenResponse)(nil),       // 59: rtest.v1.CreateDeviceTokenResponse
+	(*ListDeviceTokensRequest)(nil),         // 60: rtest.v1.ListDeviceTokensRequest
+	(*ListDeviceTokensResponse)(nil),        // 61: rtest.v1.ListDeviceTokensResponse
+	(*RevokeDeviceTokenRequest)(nil),        // 62: rtest.v1.RevokeDeviceTokenRequest
+	(*RevokeDeviceTokenResponse)(nil),       // 63: rtest.v1.RevokeDeviceTokenResponse
+	nil,                                     // 64: rtest.v1.Job.EnvironmentEntry
+	nil,                                     // 65: rtest.v1.PrepareJobRequest.EnvironmentEntry
+	(*timestamppb.Timestamp)(nil),           // 66: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),             // 67: google.protobuf.Duration
 }
 var file_rtest_v1_control_proto_depIdxs = []int32{
-	65, // 0: rtest.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	66, // 0: rtest.v1.User.created_at:type_name -> google.protobuf.Timestamp
 	4,  // 1: rtest.v1.CreateUserResponse.user:type_name -> rtest.v1.User
-	65, // 2: rtest.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	66, // 2: rtest.v1.Project.created_at:type_name -> google.protobuf.Timestamp
 	7,  // 3: rtest.v1.CreateProjectResponse.project:type_name -> rtest.v1.Project
 	7,  // 4: rtest.v1.ListProjectsResponse.projects:type_name -> rtest.v1.Project
-	65, // 5: rtest.v1.EnrollmentCode.created_at:type_name -> google.protobuf.Timestamp
-	65, // 6: rtest.v1.EnrollmentCode.expires_at:type_name -> google.protobuf.Timestamp
-	65, // 7: rtest.v1.EnrollmentCode.consumed_at:type_name -> google.protobuf.Timestamp
-	65, // 8: rtest.v1.CreateEnrollmentCodeRequest.expires_at:type_name -> google.protobuf.Timestamp
+	66, // 5: rtest.v1.EnrollmentCode.created_at:type_name -> google.protobuf.Timestamp
+	66, // 6: rtest.v1.EnrollmentCode.expires_at:type_name -> google.protobuf.Timestamp
+	66, // 7: rtest.v1.EnrollmentCode.consumed_at:type_name -> google.protobuf.Timestamp
+	66, // 8: rtest.v1.CreateEnrollmentCodeRequest.expires_at:type_name -> google.protobuf.Timestamp
 	14, // 9: rtest.v1.CreateEnrollmentCodeResponse.enrollment:type_name -> rtest.v1.EnrollmentCode
-	56, // 10: rtest.v1.ExchangeEnrollmentCodeResponse.device_token:type_name -> rtest.v1.DeviceToken
+	57, // 10: rtest.v1.ExchangeEnrollmentCodeResponse.device_token:type_name -> rtest.v1.DeviceToken
 	7,  // 11: rtest.v1.ActivateProjectImageResponse.project:type_name -> rtest.v1.Project
 	7,  // 12: rtest.v1.RollbackProjectImageResponse.project:type_name -> rtest.v1.Project
 	7,  // 13: rtest.v1.SetProjectImagePolicyResponse.project:type_name -> rtest.v1.Project
-	65, // 14: rtest.v1.ProjectImageEvent.created_at:type_name -> google.protobuf.Timestamp
+	66, // 14: rtest.v1.ProjectImageEvent.created_at:type_name -> google.protobuf.Timestamp
 	25, // 15: rtest.v1.ListProjectImageHistoryResponse.events:type_name -> rtest.v1.ProjectImageEvent
-	63, // 16: rtest.v1.Job.environment:type_name -> rtest.v1.Job.EnvironmentEntry
+	64, // 16: rtest.v1.Job.environment:type_name -> rtest.v1.Job.EnvironmentEntry
 	0,  // 17: rtest.v1.Job.status:type_name -> rtest.v1.JobStatus
-	66, // 18: rtest.v1.Job.timeout:type_name -> google.protobuf.Duration
-	65, // 19: rtest.v1.Job.created_at:type_name -> google.protobuf.Timestamp
-	65, // 20: rtest.v1.Job.started_at:type_name -> google.protobuf.Timestamp
-	65, // 21: rtest.v1.Job.finished_at:type_name -> google.protobuf.Timestamp
-	64, // 22: rtest.v1.PrepareJobRequest.environment:type_name -> rtest.v1.PrepareJobRequest.EnvironmentEntry
-	66, // 23: rtest.v1.PrepareJobRequest.timeout:type_name -> google.protobuf.Duration
-	65, // 24: rtest.v1.DataPlaneConnection.expires_at:type_name -> google.protobuf.Timestamp
-	28, // 25: rtest.v1.PrepareJobResponse.job:type_name -> rtest.v1.Job
-	30, // 26: rtest.v1.PrepareJobResponse.cas:type_name -> rtest.v1.DataPlaneConnection
-	28, // 27: rtest.v1.StartJobResponse.job:type_name -> rtest.v1.Job
-	28, // 28: rtest.v1.GetJobResponse.job:type_name -> rtest.v1.Job
-	28, // 29: rtest.v1.ListJobsResponse.jobs:type_name -> rtest.v1.Job
-	28, // 30: rtest.v1.CancelJobResponse.job:type_name -> rtest.v1.Job
-	28, // 31: rtest.v1.StreamJobLogsResponse.terminal_job:type_name -> rtest.v1.Job
-	1,  // 32: rtest.v1.Build.status:type_name -> rtest.v1.BuildStatus
-	65, // 33: rtest.v1.Build.created_at:type_name -> google.protobuf.Timestamp
-	65, // 34: rtest.v1.Build.finished_at:type_name -> google.protobuf.Timestamp
-	42, // 35: rtest.v1.PrepareBuildResponse.build:type_name -> rtest.v1.Build
-	30, // 36: rtest.v1.PrepareBuildResponse.buildkit:type_name -> rtest.v1.DataPlaneConnection
-	42, // 37: rtest.v1.FinishBuildResponse.build:type_name -> rtest.v1.Build
-	65, // 38: rtest.v1.ExchangeGitHubOIDCResponse.expires_at:type_name -> google.protobuf.Timestamp
-	65, // 39: rtest.v1.GitHubTrust.created_at:type_name -> google.protobuf.Timestamp
-	65, // 40: rtest.v1.GitHubTrust.revoked_at:type_name -> google.protobuf.Timestamp
-	49, // 41: rtest.v1.CreateGitHubTrustResponse.trust:type_name -> rtest.v1.GitHubTrust
-	49, // 42: rtest.v1.ListGitHubTrustsResponse.trusts:type_name -> rtest.v1.GitHubTrust
-	65, // 43: rtest.v1.DeviceToken.created_at:type_name -> google.protobuf.Timestamp
-	65, // 44: rtest.v1.DeviceToken.expires_at:type_name -> google.protobuf.Timestamp
-	65, // 45: rtest.v1.DeviceToken.last_used_at:type_name -> google.protobuf.Timestamp
-	65, // 46: rtest.v1.DeviceToken.revoked_at:type_name -> google.protobuf.Timestamp
-	65, // 47: rtest.v1.CreateDeviceTokenRequest.expires_at:type_name -> google.protobuf.Timestamp
-	56, // 48: rtest.v1.CreateDeviceTokenResponse.token_metadata:type_name -> rtest.v1.DeviceToken
-	56, // 49: rtest.v1.ListDeviceTokensResponse.tokens:type_name -> rtest.v1.DeviceToken
-	2,  // 50: rtest.v1.ControlService.GetServiceInfo:input_type -> rtest.v1.GetServiceInfoRequest
-	5,  // 51: rtest.v1.ControlService.CreateUser:input_type -> rtest.v1.CreateUserRequest
-	8,  // 52: rtest.v1.ControlService.CreateProject:input_type -> rtest.v1.CreateProjectRequest
-	10, // 53: rtest.v1.ControlService.ListProjects:input_type -> rtest.v1.ListProjectsRequest
-	12, // 54: rtest.v1.ControlService.AddProjectMember:input_type -> rtest.v1.AddProjectMemberRequest
-	19, // 55: rtest.v1.ControlService.ActivateProjectImage:input_type -> rtest.v1.ActivateProjectImageRequest
-	21, // 56: rtest.v1.ControlService.RollbackProjectImage:input_type -> rtest.v1.RollbackProjectImageRequest
-	23, // 57: rtest.v1.ControlService.SetProjectImagePolicy:input_type -> rtest.v1.SetProjectImagePolicyRequest
-	26, // 58: rtest.v1.ControlService.ListProjectImageHistory:input_type -> rtest.v1.ListProjectImageHistoryRequest
-	29, // 59: rtest.v1.ControlService.PrepareJob:input_type -> rtest.v1.PrepareJobRequest
-	32, // 60: rtest.v1.ControlService.StartJob:input_type -> rtest.v1.StartJobRequest
-	34, // 61: rtest.v1.ControlService.GetJob:input_type -> rtest.v1.GetJobRequest
-	36, // 62: rtest.v1.ControlService.ListJobs:input_type -> rtest.v1.ListJobsRequest
-	38, // 63: rtest.v1.ControlService.CancelJob:input_type -> rtest.v1.CancelJobRequest
-	40, // 64: rtest.v1.ControlService.StreamJobLogs:input_type -> rtest.v1.StreamJobLogsRequest
-	43, // 65: rtest.v1.ControlService.PrepareBuild:input_type -> rtest.v1.PrepareBuildRequest
-	45, // 66: rtest.v1.ControlService.FinishBuild:input_type -> rtest.v1.FinishBuildRequest
-	47, // 67: rtest.v1.ControlService.ExchangeGitHubOIDC:input_type -> rtest.v1.ExchangeGitHubOIDCRequest
-	50, // 68: rtest.v1.ControlService.CreateGitHubTrust:input_type -> rtest.v1.CreateGitHubTrustRequest
-	52, // 69: rtest.v1.ControlService.ListGitHubTrusts:input_type -> rtest.v1.ListGitHubTrustsRequest
-	54, // 70: rtest.v1.ControlService.RevokeGitHubTrust:input_type -> rtest.v1.RevokeGitHubTrustRequest
-	57, // 71: rtest.v1.ControlService.CreateDeviceToken:input_type -> rtest.v1.CreateDeviceTokenRequest
-	59, // 72: rtest.v1.ControlService.ListDeviceTokens:input_type -> rtest.v1.ListDeviceTokensRequest
-	61, // 73: rtest.v1.ControlService.RevokeDeviceToken:input_type -> rtest.v1.RevokeDeviceTokenRequest
-	15, // 74: rtest.v1.ControlService.CreateEnrollmentCode:input_type -> rtest.v1.CreateEnrollmentCodeRequest
-	17, // 75: rtest.v1.ControlService.ExchangeEnrollmentCode:input_type -> rtest.v1.ExchangeEnrollmentCodeRequest
-	3,  // 76: rtest.v1.ControlService.GetServiceInfo:output_type -> rtest.v1.GetServiceInfoResponse
-	6,  // 77: rtest.v1.ControlService.CreateUser:output_type -> rtest.v1.CreateUserResponse
-	9,  // 78: rtest.v1.ControlService.CreateProject:output_type -> rtest.v1.CreateProjectResponse
-	11, // 79: rtest.v1.ControlService.ListProjects:output_type -> rtest.v1.ListProjectsResponse
-	13, // 80: rtest.v1.ControlService.AddProjectMember:output_type -> rtest.v1.AddProjectMemberResponse
-	20, // 81: rtest.v1.ControlService.ActivateProjectImage:output_type -> rtest.v1.ActivateProjectImageResponse
-	22, // 82: rtest.v1.ControlService.RollbackProjectImage:output_type -> rtest.v1.RollbackProjectImageResponse
-	24, // 83: rtest.v1.ControlService.SetProjectImagePolicy:output_type -> rtest.v1.SetProjectImagePolicyResponse
-	27, // 84: rtest.v1.ControlService.ListProjectImageHistory:output_type -> rtest.v1.ListProjectImageHistoryResponse
-	31, // 85: rtest.v1.ControlService.PrepareJob:output_type -> rtest.v1.PrepareJobResponse
-	33, // 86: rtest.v1.ControlService.StartJob:output_type -> rtest.v1.StartJobResponse
-	35, // 87: rtest.v1.ControlService.GetJob:output_type -> rtest.v1.GetJobResponse
-	37, // 88: rtest.v1.ControlService.ListJobs:output_type -> rtest.v1.ListJobsResponse
-	39, // 89: rtest.v1.ControlService.CancelJob:output_type -> rtest.v1.CancelJobResponse
-	41, // 90: rtest.v1.ControlService.StreamJobLogs:output_type -> rtest.v1.StreamJobLogsResponse
-	44, // 91: rtest.v1.ControlService.PrepareBuild:output_type -> rtest.v1.PrepareBuildResponse
-	46, // 92: rtest.v1.ControlService.FinishBuild:output_type -> rtest.v1.FinishBuildResponse
-	48, // 93: rtest.v1.ControlService.ExchangeGitHubOIDC:output_type -> rtest.v1.ExchangeGitHubOIDCResponse
-	51, // 94: rtest.v1.ControlService.CreateGitHubTrust:output_type -> rtest.v1.CreateGitHubTrustResponse
-	53, // 95: rtest.v1.ControlService.ListGitHubTrusts:output_type -> rtest.v1.ListGitHubTrustsResponse
-	55, // 96: rtest.v1.ControlService.RevokeGitHubTrust:output_type -> rtest.v1.RevokeGitHubTrustResponse
-	58, // 97: rtest.v1.ControlService.CreateDeviceToken:output_type -> rtest.v1.CreateDeviceTokenResponse
-	60, // 98: rtest.v1.ControlService.ListDeviceTokens:output_type -> rtest.v1.ListDeviceTokensResponse
-	62, // 99: rtest.v1.ControlService.RevokeDeviceToken:output_type -> rtest.v1.RevokeDeviceTokenResponse
-	16, // 100: rtest.v1.ControlService.CreateEnrollmentCode:output_type -> rtest.v1.CreateEnrollmentCodeResponse
-	18, // 101: rtest.v1.ControlService.ExchangeEnrollmentCode:output_type -> rtest.v1.ExchangeEnrollmentCodeResponse
-	76, // [76:102] is the sub-list for method output_type
-	50, // [50:76] is the sub-list for method input_type
-	50, // [50:50] is the sub-list for extension type_name
-	50, // [50:50] is the sub-list for extension extendee
-	0,  // [0:50] is the sub-list for field type_name
+	67, // 18: rtest.v1.Job.timeout:type_name -> google.protobuf.Duration
+	66, // 19: rtest.v1.Job.created_at:type_name -> google.protobuf.Timestamp
+	66, // 20: rtest.v1.Job.started_at:type_name -> google.protobuf.Timestamp
+	66, // 21: rtest.v1.Job.finished_at:type_name -> google.protobuf.Timestamp
+	29, // 22: rtest.v1.Job.caches:type_name -> rtest.v1.CacheMount
+	65, // 23: rtest.v1.PrepareJobRequest.environment:type_name -> rtest.v1.PrepareJobRequest.EnvironmentEntry
+	67, // 24: rtest.v1.PrepareJobRequest.timeout:type_name -> google.protobuf.Duration
+	29, // 25: rtest.v1.PrepareJobRequest.caches:type_name -> rtest.v1.CacheMount
+	66, // 26: rtest.v1.DataPlaneConnection.expires_at:type_name -> google.protobuf.Timestamp
+	28, // 27: rtest.v1.PrepareJobResponse.job:type_name -> rtest.v1.Job
+	31, // 28: rtest.v1.PrepareJobResponse.cas:type_name -> rtest.v1.DataPlaneConnection
+	28, // 29: rtest.v1.StartJobResponse.job:type_name -> rtest.v1.Job
+	28, // 30: rtest.v1.GetJobResponse.job:type_name -> rtest.v1.Job
+	28, // 31: rtest.v1.ListJobsResponse.jobs:type_name -> rtest.v1.Job
+	28, // 32: rtest.v1.CancelJobResponse.job:type_name -> rtest.v1.Job
+	28, // 33: rtest.v1.StreamJobLogsResponse.terminal_job:type_name -> rtest.v1.Job
+	1,  // 34: rtest.v1.Build.status:type_name -> rtest.v1.BuildStatus
+	66, // 35: rtest.v1.Build.created_at:type_name -> google.protobuf.Timestamp
+	66, // 36: rtest.v1.Build.finished_at:type_name -> google.protobuf.Timestamp
+	43, // 37: rtest.v1.PrepareBuildResponse.build:type_name -> rtest.v1.Build
+	31, // 38: rtest.v1.PrepareBuildResponse.buildkit:type_name -> rtest.v1.DataPlaneConnection
+	43, // 39: rtest.v1.FinishBuildResponse.build:type_name -> rtest.v1.Build
+	66, // 40: rtest.v1.ExchangeGitHubOIDCResponse.expires_at:type_name -> google.protobuf.Timestamp
+	66, // 41: rtest.v1.GitHubTrust.created_at:type_name -> google.protobuf.Timestamp
+	66, // 42: rtest.v1.GitHubTrust.revoked_at:type_name -> google.protobuf.Timestamp
+	50, // 43: rtest.v1.CreateGitHubTrustResponse.trust:type_name -> rtest.v1.GitHubTrust
+	50, // 44: rtest.v1.ListGitHubTrustsResponse.trusts:type_name -> rtest.v1.GitHubTrust
+	66, // 45: rtest.v1.DeviceToken.created_at:type_name -> google.protobuf.Timestamp
+	66, // 46: rtest.v1.DeviceToken.expires_at:type_name -> google.protobuf.Timestamp
+	66, // 47: rtest.v1.DeviceToken.last_used_at:type_name -> google.protobuf.Timestamp
+	66, // 48: rtest.v1.DeviceToken.revoked_at:type_name -> google.protobuf.Timestamp
+	66, // 49: rtest.v1.CreateDeviceTokenRequest.expires_at:type_name -> google.protobuf.Timestamp
+	57, // 50: rtest.v1.CreateDeviceTokenResponse.token_metadata:type_name -> rtest.v1.DeviceToken
+	57, // 51: rtest.v1.ListDeviceTokensResponse.tokens:type_name -> rtest.v1.DeviceToken
+	2,  // 52: rtest.v1.ControlService.GetServiceInfo:input_type -> rtest.v1.GetServiceInfoRequest
+	5,  // 53: rtest.v1.ControlService.CreateUser:input_type -> rtest.v1.CreateUserRequest
+	8,  // 54: rtest.v1.ControlService.CreateProject:input_type -> rtest.v1.CreateProjectRequest
+	10, // 55: rtest.v1.ControlService.ListProjects:input_type -> rtest.v1.ListProjectsRequest
+	12, // 56: rtest.v1.ControlService.AddProjectMember:input_type -> rtest.v1.AddProjectMemberRequest
+	19, // 57: rtest.v1.ControlService.ActivateProjectImage:input_type -> rtest.v1.ActivateProjectImageRequest
+	21, // 58: rtest.v1.ControlService.RollbackProjectImage:input_type -> rtest.v1.RollbackProjectImageRequest
+	23, // 59: rtest.v1.ControlService.SetProjectImagePolicy:input_type -> rtest.v1.SetProjectImagePolicyRequest
+	26, // 60: rtest.v1.ControlService.ListProjectImageHistory:input_type -> rtest.v1.ListProjectImageHistoryRequest
+	30, // 61: rtest.v1.ControlService.PrepareJob:input_type -> rtest.v1.PrepareJobRequest
+	33, // 62: rtest.v1.ControlService.StartJob:input_type -> rtest.v1.StartJobRequest
+	35, // 63: rtest.v1.ControlService.GetJob:input_type -> rtest.v1.GetJobRequest
+	37, // 64: rtest.v1.ControlService.ListJobs:input_type -> rtest.v1.ListJobsRequest
+	39, // 65: rtest.v1.ControlService.CancelJob:input_type -> rtest.v1.CancelJobRequest
+	41, // 66: rtest.v1.ControlService.StreamJobLogs:input_type -> rtest.v1.StreamJobLogsRequest
+	44, // 67: rtest.v1.ControlService.PrepareBuild:input_type -> rtest.v1.PrepareBuildRequest
+	46, // 68: rtest.v1.ControlService.FinishBuild:input_type -> rtest.v1.FinishBuildRequest
+	48, // 69: rtest.v1.ControlService.ExchangeGitHubOIDC:input_type -> rtest.v1.ExchangeGitHubOIDCRequest
+	51, // 70: rtest.v1.ControlService.CreateGitHubTrust:input_type -> rtest.v1.CreateGitHubTrustRequest
+	53, // 71: rtest.v1.ControlService.ListGitHubTrusts:input_type -> rtest.v1.ListGitHubTrustsRequest
+	55, // 72: rtest.v1.ControlService.RevokeGitHubTrust:input_type -> rtest.v1.RevokeGitHubTrustRequest
+	58, // 73: rtest.v1.ControlService.CreateDeviceToken:input_type -> rtest.v1.CreateDeviceTokenRequest
+	60, // 74: rtest.v1.ControlService.ListDeviceTokens:input_type -> rtest.v1.ListDeviceTokensRequest
+	62, // 75: rtest.v1.ControlService.RevokeDeviceToken:input_type -> rtest.v1.RevokeDeviceTokenRequest
+	15, // 76: rtest.v1.ControlService.CreateEnrollmentCode:input_type -> rtest.v1.CreateEnrollmentCodeRequest
+	17, // 77: rtest.v1.ControlService.ExchangeEnrollmentCode:input_type -> rtest.v1.ExchangeEnrollmentCodeRequest
+	3,  // 78: rtest.v1.ControlService.GetServiceInfo:output_type -> rtest.v1.GetServiceInfoResponse
+	6,  // 79: rtest.v1.ControlService.CreateUser:output_type -> rtest.v1.CreateUserResponse
+	9,  // 80: rtest.v1.ControlService.CreateProject:output_type -> rtest.v1.CreateProjectResponse
+	11, // 81: rtest.v1.ControlService.ListProjects:output_type -> rtest.v1.ListProjectsResponse
+	13, // 82: rtest.v1.ControlService.AddProjectMember:output_type -> rtest.v1.AddProjectMemberResponse
+	20, // 83: rtest.v1.ControlService.ActivateProjectImage:output_type -> rtest.v1.ActivateProjectImageResponse
+	22, // 84: rtest.v1.ControlService.RollbackProjectImage:output_type -> rtest.v1.RollbackProjectImageResponse
+	24, // 85: rtest.v1.ControlService.SetProjectImagePolicy:output_type -> rtest.v1.SetProjectImagePolicyResponse
+	27, // 86: rtest.v1.ControlService.ListProjectImageHistory:output_type -> rtest.v1.ListProjectImageHistoryResponse
+	32, // 87: rtest.v1.ControlService.PrepareJob:output_type -> rtest.v1.PrepareJobResponse
+	34, // 88: rtest.v1.ControlService.StartJob:output_type -> rtest.v1.StartJobResponse
+	36, // 89: rtest.v1.ControlService.GetJob:output_type -> rtest.v1.GetJobResponse
+	38, // 90: rtest.v1.ControlService.ListJobs:output_type -> rtest.v1.ListJobsResponse
+	40, // 91: rtest.v1.ControlService.CancelJob:output_type -> rtest.v1.CancelJobResponse
+	42, // 92: rtest.v1.ControlService.StreamJobLogs:output_type -> rtest.v1.StreamJobLogsResponse
+	45, // 93: rtest.v1.ControlService.PrepareBuild:output_type -> rtest.v1.PrepareBuildResponse
+	47, // 94: rtest.v1.ControlService.FinishBuild:output_type -> rtest.v1.FinishBuildResponse
+	49, // 95: rtest.v1.ControlService.ExchangeGitHubOIDC:output_type -> rtest.v1.ExchangeGitHubOIDCResponse
+	52, // 96: rtest.v1.ControlService.CreateGitHubTrust:output_type -> rtest.v1.CreateGitHubTrustResponse
+	54, // 97: rtest.v1.ControlService.ListGitHubTrusts:output_type -> rtest.v1.ListGitHubTrustsResponse
+	56, // 98: rtest.v1.ControlService.RevokeGitHubTrust:output_type -> rtest.v1.RevokeGitHubTrustResponse
+	59, // 99: rtest.v1.ControlService.CreateDeviceToken:output_type -> rtest.v1.CreateDeviceTokenResponse
+	61, // 100: rtest.v1.ControlService.ListDeviceTokens:output_type -> rtest.v1.ListDeviceTokensResponse
+	63, // 101: rtest.v1.ControlService.RevokeDeviceToken:output_type -> rtest.v1.RevokeDeviceTokenResponse
+	16, // 102: rtest.v1.ControlService.CreateEnrollmentCode:output_type -> rtest.v1.CreateEnrollmentCodeResponse
+	18, // 103: rtest.v1.ControlService.ExchangeEnrollmentCode:output_type -> rtest.v1.ExchangeEnrollmentCodeResponse
+	78, // [78:104] is the sub-list for method output_type
+	52, // [52:78] is the sub-list for method input_type
+	52, // [52:52] is the sub-list for extension type_name
+	52, // [52:52] is the sub-list for extension extendee
+	0,  // [0:52] is the sub-list for field type_name
 }
 
 func init() { file_rtest_v1_control_proto_init() }
@@ -4158,14 +4236,14 @@ func file_rtest_v1_control_proto_init() {
 		return
 	}
 	file_rtest_v1_control_proto_msgTypes[26].OneofWrappers = []any{}
-	file_rtest_v1_control_proto_msgTypes[40].OneofWrappers = []any{}
+	file_rtest_v1_control_proto_msgTypes[41].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_rtest_v1_control_proto_rawDesc), len(file_rtest_v1_control_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   63,
+			NumMessages:   64,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rtest/internal/swarm/client.go
+++ b/rtest/internal/swarm/client.go
@@ -201,6 +201,13 @@ func (c *Client) Cancel(ctx context.Context, id string) error {
 	return nil
 }
 
+func (c *Client) Remove(ctx context.Context, id string) error {
+	if err := c.commands.Run(ctx, io.Discard, io.Discard, "service", "rm", id); err != nil {
+		return fmt.Errorf("remove job %s: %w", id, err)
+	}
+	return nil
+}
+
 func (c *Client) List(ctx context.Context, repository string, limit int) ([]protocol.Job, error) {
 	data, err := c.commands.Output(ctx, "service", "ls", "--filter", "label="+managedLabel+"=true", "--format", "{{.Name}}")
 	if err != nil {

--- a/rtest/internal/swarm/spec.go
+++ b/rtest/internal/swarm/spec.go
@@ -35,6 +35,8 @@ type Spec struct {
 	CacheRoot          string
 	ProjectID          string
 	Caches             []CacheMount
+	HostUID            string
+	HostGID            string
 }
 
 type CacheMount struct {
@@ -57,6 +59,7 @@ func CreateArgs(spec Spec) []string {
 		"--mode", "replicated-job", "--replicas", "1", "--max-concurrent", "1",
 		"--restart-condition", "none", "--stop-grace-period", "15s",
 		"--network", "host",
+		"--user", "0:0",
 		"--limit-cpu", fallback(spec.CPUs, "1.5"), "--limit-memory", fallback(spec.Memory, "2500m"),
 		"--reserve-cpu", fallback(spec.CPUs, "1.5"), "--reserve-memory", fallback(spec.Memory, "2500m"),
 		"--mount", "type=bind,src=" + spec.JobsRoot + ",dst=" + spec.JobsRoot,
@@ -64,6 +67,8 @@ func CreateArgs(spec Spec) []string {
 		"--env", "RTEST_JOB_ID=" + spec.ID,
 		"--env", "RTEST_WORKSPACE=" + workspace,
 		"--env", "RTEST_WORKER_LOCK=" + filepath.Join(spec.JobsRoot, ".worker.lock"),
+		"--env", "RTEST_HOST_UID=" + spec.HostUID,
+		"--env", "RTEST_HOST_GID=" + spec.HostGID,
 		"--env", "RTEST_CAS_ADDRESS=" + spec.CASAddress,
 		"--env", "RTEST_CAS_INSTANCE=" + fallback(spec.CASInstance, "rtest"),
 		"--env", "RTEST_ROOT_DIGEST=" + spec.RootDigest,

--- a/rtest/internal/swarm/spec.go
+++ b/rtest/internal/swarm/spec.go
@@ -32,6 +32,14 @@ type Spec struct {
 	Timeout            time.Duration
 	CPUs               string
 	Memory             string
+	CacheRoot          string
+	ProjectID          string
+	Caches             []CacheMount
+}
+
+type CacheMount struct {
+	Name   string
+	Target string
 }
 
 func CreateArgs(spec Spec) []string {
@@ -39,6 +47,8 @@ func CreateArgs(spec Spec) []string {
 	args := []string{
 		"service", "create", "--detach", "--quiet", "--name", spec.ID, "--init",
 		"--label", managedLabel + "=true",
+		"--label", "rtest.project=" + spec.ProjectID,
+		"--label", "rtest.job=" + spec.ID,
 		"--label", "rtest.repository=" + encodeLabel(spec.Repository),
 		"--label", "rtest.suite=" + encodeLabel(spec.Suite),
 		"--label", "rtest.runner=" + encodeLabel(spec.Runner),
@@ -51,10 +61,9 @@ func CreateArgs(spec Spec) []string {
 		"--reserve-cpu", fallback(spec.CPUs, "1.5"), "--reserve-memory", fallback(spec.Memory, "2500m"),
 		"--mount", "type=bind,src=" + spec.JobsRoot + ",dst=" + spec.JobsRoot,
 		"--mount", "type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock",
-		"--mount", "type=volume,src=rtest-go-build-cache,dst=/root/.cache/go-build",
-		"--mount", "type=volume,src=rtest-go-mod-cache,dst=/go/pkg/mod",
 		"--env", "RTEST_JOB_ID=" + spec.ID,
 		"--env", "RTEST_WORKSPACE=" + workspace,
+		"--env", "RTEST_WORKER_LOCK=" + filepath.Join(spec.JobsRoot, ".worker.lock"),
 		"--env", "RTEST_CAS_ADDRESS=" + spec.CASAddress,
 		"--env", "RTEST_CAS_INSTANCE=" + fallback(spec.CASInstance, "rtest"),
 		"--env", "RTEST_ROOT_DIGEST=" + spec.RootDigest,
@@ -66,6 +75,17 @@ func CreateArgs(spec Spec) []string {
 		"--env", "TMPDIR=" + filepath.Join(spec.JobsRoot, spec.ID, "tmp"),
 		"--env", "TEST_DATA_DIR=" + filepath.Join(workspace, ".rtest", "data"),
 		"--entrypoint", "/usr/local/bin/rtest-job-entrypoint",
+	}
+	caches := append([]CacheMount(nil), spec.Caches...)
+	sort.Slice(caches, func(i, j int) bool {
+		if caches[i].Name == caches[j].Name {
+			return caches[i].Target < caches[j].Target
+		}
+		return caches[i].Name < caches[j].Name
+	})
+	for _, cache := range caches {
+		source := filepath.Join(spec.CacheRoot, spec.ProjectID, cache.Name)
+		args = append(args, "--mount", "type=bind,src="+source+",dst="+cache.Target)
 	}
 	if spec.EntrypointHostPath != "" {
 		args = append(args, "--mount", "type=bind,src="+spec.EntrypointHostPath+",dst=/usr/local/bin/rtest-job-entrypoint,readonly")

--- a/rtest/internal/swarm/spec_test.go
+++ b/rtest/internal/swarm/spec_test.go
@@ -17,7 +17,8 @@ func TestCreateArgsUseReplicatedJobAndSamePathWorkspace(t *testing.T) {
 		Timeout: 15 * time.Minute, CPUs: "2", Memory: "4g",
 		WorkingDirectory: "cmd/service", Environment: map[string]string{"RTEST_PROOF": "generic-oci"},
 		EntrypointHostPath: "/usr/local/lib/rtest/rtest-job-entrypoint",
-		CacheRoot:          "/var/lib/rtest/cache", ProjectID: "prj-example",
+		HostUID:            "123", HostGID: "456",
+		CacheRoot: "/var/lib/rtest/cache", ProjectID: "prj-example",
 		Caches: []CacheMount{{Name: "go-build", Target: "/root/.cache/go-build"}, {Name: "modules", Target: "/go/pkg/mod"}},
 	}
 	args := CreateArgs(spec)
@@ -35,10 +36,13 @@ func TestCreateArgsUseReplicatedJobAndSamePathWorkspace(t *testing.T) {
 		{"--label", "rtest.job=rtest-job-1"},
 		{"--env", "RTEST_WORKSPACE=/var/lib/rtest/jobs/rtest-job-1/workspace"},
 		{"--env", "RTEST_WORKER_LOCK=/var/lib/rtest/jobs/.worker.lock"},
+		{"--env", "RTEST_HOST_UID=123"},
+		{"--env", "RTEST_HOST_GID=456"},
 		{"--env", "RTEST_ROOT_DIGEST=abc/123"},
 		{"--env", "RTEST_WORKING_DIRECTORY=cmd/service"},
 		{"--env", "RTEST_PROOF=generic-oci"},
 		{"--entrypoint", "/usr/local/bin/rtest-job-entrypoint"},
+		{"--user", "0:0"},
 		{"runner:test", "go", "test", "./..."},
 	} {
 		if !containsSequence(args, sequence) {

--- a/rtest/internal/swarm/spec_test.go
+++ b/rtest/internal/swarm/spec_test.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,8 @@ func TestCreateArgsUseReplicatedJobAndSamePathWorkspace(t *testing.T) {
 		Timeout: 15 * time.Minute, CPUs: "2", Memory: "4g",
 		WorkingDirectory: "cmd/service", Environment: map[string]string{"RTEST_PROOF": "generic-oci"},
 		EntrypointHostPath: "/usr/local/lib/rtest/rtest-job-entrypoint",
+		CacheRoot:          "/var/lib/rtest/cache", ProjectID: "prj-example",
+		Caches: []CacheMount{{Name: "go-build", Target: "/root/.cache/go-build"}, {Name: "modules", Target: "/go/pkg/mod"}},
 	}
 	args := CreateArgs(spec)
 	for _, sequence := range [][]string{
@@ -25,8 +28,13 @@ func TestCreateArgsUseReplicatedJobAndSamePathWorkspace(t *testing.T) {
 		{"--reserve-cpu", "2"},
 		{"--reserve-memory", "4g"},
 		{"--mount", "type=bind,src=/var/lib/rtest/jobs,dst=/var/lib/rtest/jobs"},
+		{"--mount", "type=bind,src=/var/lib/rtest/cache/prj-example/go-build,dst=/root/.cache/go-build"},
+		{"--mount", "type=bind,src=/var/lib/rtest/cache/prj-example/modules,dst=/go/pkg/mod"},
 		{"--mount", "type=bind,src=/usr/local/lib/rtest/rtest-job-entrypoint,dst=/usr/local/bin/rtest-job-entrypoint,readonly"},
+		{"--label", "rtest.project=prj-example"},
+		{"--label", "rtest.job=rtest-job-1"},
 		{"--env", "RTEST_WORKSPACE=/var/lib/rtest/jobs/rtest-job-1/workspace"},
+		{"--env", "RTEST_WORKER_LOCK=/var/lib/rtest/jobs/.worker.lock"},
 		{"--env", "RTEST_ROOT_DIGEST=abc/123"},
 		{"--env", "RTEST_WORKING_DIRECTORY=cmd/service"},
 		{"--env", "RTEST_PROOF=generic-oci"},
@@ -35,6 +43,11 @@ func TestCreateArgsUseReplicatedJobAndSamePathWorkspace(t *testing.T) {
 	} {
 		if !containsSequence(args, sequence) {
 			t.Fatalf("args %#v missing sequence %#v", args, sequence)
+		}
+	}
+	for _, forbidden := range []string{"rtest-go-build-cache", "rtest-go-mod-cache"} {
+		if strings.Contains(strings.Join(args, "\n"), forbidden) {
+			t.Fatalf("args %#v contain global cache %q", args, forbidden)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- add generic, API-declared project-scoped OCI cache mounts
- serialize trusted Docker/Testcontainers-heavy commands on the single worker
- reconcile durable job state with Swarm after restarts and retire owned services
- retain project-authorized logs after Swarm service cleanup
- add readiness, bounded disk/cache retention, and checksummed backup/restore
- record an inspectable CPX32 hardening proof across two projects and device identities

## Stack

This PR is stacked on #203 (`codex/lea-206-github-oidc`). It must be reviewed and merged after its parent; no existing PR was merged while preparing it.

## Verification

- `cd rtest && task test`
- `cd rtest && go test -race ./...`
- remote `go test -race ./...` through rtest: cold 1m32.888s; warm 30.131s; warm source transfer 0 B
- CPX32 cache isolation: project A observed 1 then 2; project B observed 1 with the same cache name/path
- CPX32 admission: second overlapping job waited and began 6 ms after the first ended
- forced service removal + control restart converged the job to `lost` with no leaked service
- completed logs remained readable after explicit Swarm service removal
- checksummed backup/restore drill passed and temporary private proof assets were removed
- second device project scope and revocation passed; hosted OIDC proof remains linked from #203
- public Docker ports 2375/2376 are closed

Evidence: `rtest/evidence/service/hardening.json`

Linear: LEA-208