### PR TITLE
LEA-214: Add pinned rtest distribution and controlled benchmarks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 .playwright-cli
 .task
 .tmp
+**/.tmp
 .venv
 
 .data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,8 @@ jobs:
       - name: Set up rtest with GitHub OIDC
         uses: ./rtest/action/setup-rtest
         with:
+          version: 0.7.0
+          allow-source-fallback: true
           service-url: ${{ vars.RTEST_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.RTEST_CA_CERTIFICATE }}
@@ -745,6 +747,8 @@ jobs:
       - name: Set up rtest with GitHub OIDC
         uses: ./rtest/action/setup-rtest
         with:
+          version: 0.7.0
+          allow-source-fallback: true
           service-url: ${{ vars.RTEST_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.RTEST_CA_CERTIFICATE }}

--- a/.github/workflows/rtest-poc.yml
+++ b/.github/workflows/rtest-poc.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Set up rtest
         uses: ./rtest/action/setup-rtest
         with:
+          version: 0.7.0
+          allow-source-fallback: true
           service-url: ${{ vars.RTEST_SERVICE_URL }}
           project: poc
           image: ${{ vars.RTEST_PROJECT_IMAGE }}

--- a/.github/workflows/rtest-release.yml
+++ b/.github/workflows/rtest-release.yml
@@ -1,0 +1,69 @@
+name: Rtest release
+
+on:
+  push:
+    tags:
+      - rtest-v*
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: github.repository == 'flidai/leapview'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: rtest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: rtest/go.mod
+          cache: false
+
+      - name: Build portable release archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#rtest-v}"
+          source_version="$(go run ./cmd/rtest version)"
+          if [[ "${tag}" != "rtest-v${version}" || "${source_version}" != "${version}" ]]; then
+            printf 'tag %s does not match source version %s\n' "${tag}" "${source_version}" >&2
+            exit 1
+          fi
+
+          targets=(
+            "linux amd64"
+            "linux arm64"
+            "darwin amd64"
+            "darwin arm64"
+          )
+          mkdir -p dist
+          for target in "${targets[@]}"; do
+            read -r os arch <<< "${target}"
+            package="rtest_${version}_${os}_${arch}"
+            stage="$(mktemp -d)"
+            CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" \
+              go build -trimpath -ldflags='-s -w' -o "${stage}/rtest" ./cmd/rtest
+            tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+              -czf "dist/${package}.tar.gz" -C "${stage}" rtest
+            rm -rf "${stage}"
+          done
+          (cd dist && sha256sum ./*.tar.gz > checksums.txt)
+
+      - name: Publish immutable GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}"
+          dist/*.tar.gz dist/checksums.txt
+          --repo "${GITHUB_REPOSITORY}"
+          --verify-tag
+          --generate-notes

--- a/.rtest/benchmarks/minio-refresh.json
+++ b/.rtest/benchmarks/minio-refresh.json
@@ -5,20 +5,17 @@
   "warmup_runs": 1,
   "measured_runs": 5,
   "require_clean": true,
-  "arguments": [
-    "./internal/app",
-    "-run", "^TestMinIOParquetSourceRefreshContract$",
-    "-count=1"
-  ],
+  "isolate_worktree": true,
+  "arguments": [],
   "candidates": [
     {
       "name": "local",
-      "prefix": ["env", "CI=1", "GOFLAGS=-tags=duckdb_arrow", "go", "test"],
+      "prefix": ["task", "benchmark:testcontainers:minio"],
       "version_command": ["go", "version"]
     },
     {
       "name": "rtest",
-      "prefix": ["rtest", "exec", "--", "env", "CI=1", "GOFLAGS=-tags=duckdb_arrow", "go", "test"],
+      "prefix": ["rtest", "exec", "--", "task", "benchmark:testcontainers:minio"],
       "version_command": ["rtest", "version"]
     }
   ]

--- a/.rtest/benchmarks/minio-refresh.json
+++ b/.rtest/benchmarks/minio-refresh.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "name": "leapview-minio-refresh",
+  "project_dir": "../..",
+  "warmup_runs": 1,
+  "measured_runs": 5,
+  "require_clean": true,
+  "arguments": [
+    "./internal/app",
+    "-run", "^TestMinIOParquetSourceRefreshContract$",
+    "-count=1"
+  ],
+  "candidates": [
+    {
+      "name": "local",
+      "prefix": ["env", "CI=1", "GOFLAGS=-tags=duckdb_arrow", "go", "test"],
+      "version_command": ["go", "version"]
+    },
+    {
+      "name": "rtest",
+      "prefix": ["rtest", "exec", "--", "env", "CI=1", "GOFLAGS=-tags=duckdb_arrow", "go", "test"],
+      "version_command": ["rtest", "version"]
+    }
+  ]
+}

--- a/.rtest/benchmarks/minio-refresh.json
+++ b/.rtest/benchmarks/minio-refresh.json
@@ -15,7 +15,16 @@
     },
     {
       "name": "rtest",
-      "prefix": ["rtest", "exec", "--", "task", "benchmark:testcontainers:minio"],
+      "prefix": [
+        "rtest", "exec",
+        "--cpus", "3.5",
+        "--memory", "6g",
+        "--cache", "go-build=/root/.cache/go-build",
+        "--cache", "go-mod=/go/pkg/mod",
+        "--cache", "bun=/root/.bun/install/cache",
+        "--cache", "terraform=/root/.cache/terraform",
+        "--", "task", "benchmark:testcontainers:minio"
+      ],
       "version_command": ["rtest", "version"]
     }
   ]

--- a/.rtest/benchmarks/production-image.json
+++ b/.rtest/benchmarks/production-image.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "name": "leapview-production-image",
+  "project_dir": "../..",
+  "warmup_runs": 1,
+  "measured_runs": 5,
+  "require_clean": true,
+  "arguments": [
+    "--file", "Dockerfile",
+    "--platform", "linux/amd64",
+    "--load",
+    "--pull",
+    "--tag", "leapview-benchmark:production",
+    "."
+  ],
+  "candidates": [
+    {
+      "name": "local",
+      "prefix": ["docker", "buildx", "build"],
+      "version_command": ["docker", "buildx", "version"]
+    },
+    {
+      "name": "rtest",
+      "prefix": ["rtest", "build", "--"],
+      "version_command": ["rtest", "version"]
+    },
+    {
+      "name": "depot",
+      "prefix": ["depot", "build", "--project", "${DEPOT_PROJECT_ID}"],
+      "version_command": ["depot", "version"],
+      "required_env": ["DEPOT_PROJECT_ID"]
+    }
+  ]
+}

--- a/.rtest/benchmarks/production-image.json
+++ b/.rtest/benchmarks/production-image.json
@@ -5,7 +5,7 @@
   "warmup_runs": 1,
   "measured_runs": 5,
   "require_clean": true,
-  "isolate_worktree": true,
+  "isolate_worktree": false,
   "arguments": [
     "--file", "Dockerfile",
     "--platform", "linux/amd64",

--- a/.rtest/benchmarks/production-image.json
+++ b/.rtest/benchmarks/production-image.json
@@ -5,6 +5,7 @@
   "warmup_runs": 1,
   "measured_runs": 5,
   "require_clean": true,
+  "isolate_worktree": true,
   "arguments": [
     "--file", "Dockerfile",
     "--platform", "linux/amd64",

--- a/.rtest/benchmarks/site-image.json
+++ b/.rtest/benchmarks/site-image.json
@@ -5,7 +5,7 @@
   "warmup_runs": 1,
   "measured_runs": 5,
   "require_clean": true,
-  "isolate_worktree": true,
+  "isolate_worktree": false,
   "arguments": [
     "--file", "Dockerfile.site",
     "--platform", "linux/amd64",

--- a/.rtest/benchmarks/site-image.json
+++ b/.rtest/benchmarks/site-image.json
@@ -5,6 +5,7 @@
   "warmup_runs": 1,
   "measured_runs": 5,
   "require_clean": true,
+  "isolate_worktree": true,
   "arguments": [
     "--file", "Dockerfile.site",
     "--platform", "linux/amd64",

--- a/.rtest/benchmarks/site-image.json
+++ b/.rtest/benchmarks/site-image.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "name": "leapview-site-image",
+  "project_dir": "../..",
+  "warmup_runs": 1,
+  "measured_runs": 5,
+  "require_clean": true,
+  "arguments": [
+    "--file", "Dockerfile.site",
+    "--platform", "linux/amd64",
+    "--load",
+    "--tag", "leapview-benchmark:site",
+    "."
+  ],
+  "candidates": [
+    {
+      "name": "local",
+      "prefix": ["docker", "buildx", "build"],
+      "version_command": ["docker", "buildx", "version"]
+    },
+    {
+      "name": "rtest",
+      "prefix": ["rtest", "build", "--"],
+      "version_command": ["rtest", "version"]
+    },
+    {
+      "name": "depot",
+      "prefix": ["depot", "build", "--project", "${DEPOT_PROJECT_ID}"],
+      "version_command": ["depot", "version"],
+      "required_env": ["DEPOT_PROJECT_ID"]
+    }
+  ]
+}

--- a/.rtest/benchmarks/testcontainers-lifecycle.json
+++ b/.rtest/benchmarks/testcontainers-lifecycle.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "name": "leapview-testcontainers-lifecycle",
+  "project_dir": "../..",
+  "warmup_runs": 1,
+  "measured_runs": 5,
+  "require_clean": true,
+  "arguments": [
+    "./internal/app/cli/composectl",
+    "-run", "^TestQualificationContainerRuntimeLifecycle/testcontainers$",
+    "-count=1"
+  ],
+  "candidates": [
+    {
+      "name": "local",
+      "prefix": ["env", "GOFLAGS=-tags=duckdb_arrow", "LEAPVIEW_TEST_CONTAINERS=1", "go", "test"],
+      "version_command": ["go", "version"]
+    },
+    {
+      "name": "rtest",
+      "prefix": ["rtest", "exec", "--", "env", "GOFLAGS=-tags=duckdb_arrow", "LEAPVIEW_TEST_CONTAINERS=1", "go", "test"],
+      "version_command": ["rtest", "version"]
+    }
+  ]
+}

--- a/.rtest/benchmarks/testcontainers-lifecycle.json
+++ b/.rtest/benchmarks/testcontainers-lifecycle.json
@@ -5,20 +5,17 @@
   "warmup_runs": 1,
   "measured_runs": 5,
   "require_clean": true,
-  "arguments": [
-    "./internal/app/cli/composectl",
-    "-run", "^TestQualificationContainerRuntimeLifecycle/testcontainers$",
-    "-count=1"
-  ],
+  "isolate_worktree": true,
+  "arguments": [],
   "candidates": [
     {
       "name": "local",
-      "prefix": ["env", "GOFLAGS=-tags=duckdb_arrow", "LEAPVIEW_TEST_CONTAINERS=1", "go", "test"],
+      "prefix": ["task", "benchmark:testcontainers:lifecycle"],
       "version_command": ["go", "version"]
     },
     {
       "name": "rtest",
-      "prefix": ["rtest", "exec", "--", "env", "GOFLAGS=-tags=duckdb_arrow", "LEAPVIEW_TEST_CONTAINERS=1", "go", "test"],
+      "prefix": ["rtest", "exec", "--", "task", "benchmark:testcontainers:lifecycle"],
       "version_command": ["rtest", "version"]
     }
   ]

--- a/.rtest/benchmarks/testcontainers-lifecycle.json
+++ b/.rtest/benchmarks/testcontainers-lifecycle.json
@@ -15,7 +15,16 @@
     },
     {
       "name": "rtest",
-      "prefix": ["rtest", "exec", "--", "task", "benchmark:testcontainers:lifecycle"],
+      "prefix": [
+        "rtest", "exec",
+        "--cpus", "3.5",
+        "--memory", "6g",
+        "--cache", "go-build=/root/.cache/go-build",
+        "--cache", "go-mod=/go/pkg/mod",
+        "--cache", "bun=/root/.bun/install/cache",
+        "--cache", "terraform=/root/.cache/terraform",
+        "--", "task", "benchmark:testcontainers:lifecycle"
+      ],
       "version_command": ["rtest", "version"]
     }
   ]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -635,6 +635,23 @@ tasks:
         rtest image build --tag {{.RTEST_RUNNER_IMAGE | quote}}
         --file Dockerfile.rtest -- --platform linux/amd64
 
+  benchmark:testcontainers:lifecycle:
+    desc: Generate sources and run the focused Testcontainers lifecycle benchmark workload
+    cmds:
+      - task --force generate
+      - >-
+        env GOFLAGS=-tags=duckdb_arrow LEAPVIEW_TEST_CONTAINERS=1
+        go test ./internal/app/cli/composectl
+        -run '^TestQualificationContainerRuntimeLifecycle/testcontainers$' -count=1
+
+  benchmark:testcontainers:minio:
+    desc: Generate sources and run the focused MinIO refresh benchmark workload
+    cmds:
+      - task --force generate
+      - >-
+        env CI=1 GOFLAGS=-tags=duckdb_arrow
+        go test ./internal/app -run '^TestMinIOParquetSourceRefreshContract$' -count=1
+
   test:go:
     desc: Run Go tests with bounded package parallelism and stable application shards
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -638,7 +638,7 @@ tasks:
   benchmark:testcontainers:lifecycle:
     desc: Generate sources and run the focused Testcontainers lifecycle benchmark workload
     cmds:
-      - task --force generate
+      - task generate
       - >-
         env GOFLAGS=-tags=duckdb_arrow LEAPVIEW_TEST_CONTAINERS=1
         go test ./internal/app/cli/composectl
@@ -647,7 +647,7 @@ tasks:
   benchmark:testcontainers:minio:
     desc: Generate sources and run the focused MinIO refresh benchmark workload
     cmds:
-      - task --force generate
+      - task generate
       - >-
         env CI=1 GOFLAGS=-tags=duckdb_arrow
         go test ./internal/app -run '^TestMinIOParquetSourceRefreshContract$' -count=1

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2090,7 +2090,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	}
 	ignoreText := string(ignored)
 	for _, want := range []string{
-		".data", ".leapview", "node_modules", "api/gen", "internal/access/api/gen", "internal/agent/api/gen", "internal/analytics/api/gen", "internal/dashboard/api/gen", "internal/deployment/api/gen", "internal/manageddata/api/gen",
+		".data", ".leapview", "node_modules", "**/.tmp", "api/gen", "internal/access/api/gen", "internal/agent/api/gen", "internal/analytics/api/gen", "internal/dashboard/api/gen", "internal/deployment/api/gen", "internal/manageddata/api/gen",
 		"internal/app/api/aggregate", "internal/app/api/gen", "internal/platform/http/api/gen", "internal/project/api/gen", "internal/refresh/api/gen", "internal/release/api/gen", "internal/workspace/api/gen", "static/chunks",
 	} {
 		if !strings.Contains(ignoreText, want) {

--- a/rtest/.gitignore
+++ b/rtest/.gitignore
@@ -26,3 +26,6 @@ evidence/benchmarks/leapview-minio-warm/**
 !evidence/benchmarks/leapview-testcontainers-lifecycle-warm/
 evidence/benchmarks/leapview-testcontainers-lifecycle-warm/**
 !evidence/benchmarks/leapview-testcontainers-lifecycle-warm/summary.json
+!evidence/benchmarks/leapview-provider-comparison/
+evidence/benchmarks/leapview-provider-comparison/**
+!evidence/benchmarks/leapview-provider-comparison/summary.json

--- a/rtest/README.md
+++ b/rtest/README.md
@@ -107,6 +107,9 @@ unchanged, reports end-to-end CLI and remote execution time, and rejects a warm 
 if any measured source transfer is non-zero.
 The current CPX32 warm-cache baseline and methodology are documented in
 [benchmarks](docs/benchmarks.md).
+For controlled provider comparisons, `task benchmark:compare -- --spec ... --output ...`
+runs the same checked-in argv contract serially across available local, rtest, and Depot
+candidates while preserving raw logs and an exact source fingerprint.
 
 ## Layout
 
@@ -119,6 +122,7 @@ The current CPX32 warm-cache baseline and methodology are documented in
 - `cmd/rtest-job-entrypoint`: CAS materialization, timeout, process-group, and result boundary.
 - `host`: idempotent existing-host installation and systemd units.
 - `action/setup-rtest`: GitHub composite action that installs and configures the CLI.
+- `cmd/rtest-benchmark`: generic controlled command-comparison harness.
 - `scripts`: deployment and reproducible E2E proof.
 - `infra`: vendor-specific Terraform for an optional dedicated Hetzner worker.
 

--- a/rtest/Taskfile.yml
+++ b/rtest/Taskfile.yml
@@ -93,3 +93,8 @@ tasks:
     desc: Prime and measure a real project command through rtest
     cmds:
       - ./scripts/benchmark.zsh {{.CLI_ARGS}}
+
+  benchmark:compare:
+    desc: Run a controlled multi-candidate command benchmark from a JSON specification
+    cmds:
+      - go run ./cmd/rtest-benchmark {{.CLI_ARGS}}

--- a/rtest/action/setup-rtest/action.yml
+++ b/rtest/action/setup-rtest/action.yml
@@ -1,7 +1,19 @@
 name: Set up rtest
-description: Build rtest and configure GitHub OIDC access to a shared rtest service.
+description: Install a verified rtest release and configure GitHub OIDC access to a shared service.
 
 inputs:
+  version:
+    description: Exact rtest release version to install.
+    required: false
+    default: "0.7.0"
+  repository:
+    description: GitHub repository that owns rtest-v* release assets.
+    required: false
+    default: flidai/leapview
+  allow-source-fallback:
+    description: Build the checked-out rtest source only when the pinned release is not published yet.
+    required: false
+    default: "false"
   service-url:
     description: HTTPS URL of the rtest control plane.
     required: true
@@ -26,10 +38,40 @@ inputs:
     required: false
     default: 4g
 
+outputs:
+  install-source:
+    description: Whether the CLI came from cache, a verified release, or the source fallback.
+    value: ${{ steps.install.outputs.source }}
+
 runs:
   using: composite
   steps:
-    - name: Build and configure rtest
+    - name: Restore pinned rtest CLI
+      id: cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/rtest/bin
+        key: rtest-cli-${{ inputs.repository }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
+    - name: Install pinned rtest CLI
+      id: install
+      shell: bash
+      env:
+        RTEST_VERSION: ${{ inputs.version }}
+        RTEST_REPOSITORY: ${{ inputs.repository }}
+        RTEST_ALLOW_SOURCE_FALLBACK: ${{ inputs.allow-source-fallback }}
+        RTEST_INSTALL_ROOT: ${{ runner.temp }}/rtest
+        RTEST_ACTION_ROOT: ${{ github.action_path }}/../..
+      run: "${GITHUB_ACTION_PATH}/install-release.sh"
+
+    - name: Cache verified rtest release
+      if: steps.cache.outputs.cache-hit != 'true' && steps.install.outputs.source == 'release'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/rtest/bin
+        key: rtest-cli-${{ inputs.repository }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
+    - name: Configure rtest
       shell: bash
       env:
         INPUT_SERVICE_URL: ${{ inputs.service-url }}
@@ -45,10 +87,6 @@ runs:
         bin_dir="${install_root}/bin"
         config_file="${install_root}/config.json"
         ca_file=""
-        install -d -m 0700 "${bin_dir}"
-
-        action_root="$(cd "${GITHUB_ACTION_PATH}/../.." && pwd)"
-        (cd "${action_root}" && go build -trimpath -o "${bin_dir}/rtest" ./cmd/rtest)
 
         if [[ -n "${INPUT_CA_CERTIFICATE}" ]]; then
           ca_file="${install_root}/ca.pem"
@@ -75,6 +113,6 @@ runs:
           }' > "${config_file}"
         chmod 0600 "${config_file}"
 
-        printf '%s\n' "${bin_dir}" >> "$GITHUB_PATH"
-        printf 'RTEST_CONFIG=%s\n' "${config_file}" >> "$GITHUB_ENV"
-        printf 'RTEST_PROJECT=%s\n' "${INPUT_PROJECT}" >> "$GITHUB_ENV"
+        printf '%s\n' "${bin_dir}" >> "${GITHUB_PATH}"
+        printf 'RTEST_CONFIG=%s\n' "${config_file}" >> "${GITHUB_ENV}"
+        printf 'RTEST_PROJECT=%s\n' "${INPUT_PROJECT}" >> "${GITHUB_ENV}"

--- a/rtest/action/setup-rtest/install-release.sh
+++ b/rtest/action/setup-rtest/install-release.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${RTEST_VERSION:?RTEST_VERSION is required}"
+: "${RTEST_REPOSITORY:?RTEST_REPOSITORY is required}"
+: "${RTEST_INSTALL_ROOT:?RTEST_INSTALL_ROOT is required}"
+
+if [[ ! "${RTEST_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+  printf 'invalid rtest version: %s\n' "${RTEST_VERSION}" >&2
+  exit 2
+fi
+if [[ ! "${RTEST_REPOSITORY}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  printf 'invalid rtest release repository: %s\n' "${RTEST_REPOSITORY}" >&2
+  exit 2
+fi
+
+runner_os="${RUNNER_OS:-$(uname -s)}"
+case "${runner_os}" in
+  Linux) os=linux ;;
+  macOS|Darwin) os=darwin ;;
+  *) printf 'unsupported rtest release OS: %s\n' "${runner_os}" >&2; exit 2 ;;
+esac
+
+runner_arch="${RUNNER_ARCH:-$(uname -m)}"
+case "${runner_arch}" in
+  X64|x86_64|amd64) arch=amd64 ;;
+  ARM64|aarch64|arm64) arch=arm64 ;;
+  *) printf 'unsupported rtest release architecture: %s\n' "${runner_arch}" >&2; exit 2 ;;
+esac
+
+bin_dir="${RTEST_INSTALL_ROOT}/bin"
+binary="${bin_dir}/rtest"
+output_file="${GITHUB_OUTPUT:-}"
+install -d -m 0755 "${bin_dir}"
+
+record_source() {
+  printf 'source=%s\n' "$1"
+  if [[ -n "${output_file}" ]]; then
+    printf 'source=%s\n' "$1" >> "${output_file}"
+  fi
+}
+
+if [[ -x "${binary}" ]] && [[ "$("${binary}" version 2>/dev/null)" == "${RTEST_VERSION}" ]]; then
+  record_source cache
+  exit 0
+fi
+rm -f "${binary}"
+
+asset="rtest_${RTEST_VERSION}_${os}_${arch}.tar.gz"
+release_base="${RTEST_RELEASE_BASE_URL:-https://github.com/${RTEST_REPOSITORY}/releases/download}"
+release_url="${release_base}/rtest-v${RTEST_VERSION}"
+temporary="$(mktemp -d)"
+trap 'rm -rf "${temporary}"' EXIT
+
+downloaded=true
+curl --fail --location --silent --show-error --retry 3 \
+  --output "${temporary}/${asset}" "${release_url}/${asset}" || downloaded=false
+if [[ "${downloaded}" == true ]]; then
+  curl --fail --location --silent --show-error --retry 3 \
+    --output "${temporary}/checksums.txt" "${release_url}/checksums.txt" || downloaded=false
+fi
+
+if [[ "${downloaded}" == true ]]; then
+  expected="$(awk -v asset="${asset}" '$2 == asset || $2 == "*" asset {print $1; exit}' "${temporary}/checksums.txt")"
+  if [[ ! "${expected}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    printf 'rtest release checksum is missing for %s\n' "${asset}" >&2
+    exit 1
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "${temporary}/${asset}" | awk '{print $1}')"
+  else
+    actual="$(shasum -a 256 "${temporary}/${asset}" | awk '{print $1}')"
+  fi
+  if [[ "${actual}" != "${expected}" ]]; then
+    printf 'rtest release checksum verification failed for %s\n' "${asset}" >&2
+    exit 1
+  fi
+  tar -xzf "${temporary}/${asset}" -C "${temporary}" rtest
+  if [[ "$("${temporary}/rtest" version)" != "${RTEST_VERSION}" ]]; then
+    printf 'rtest release binary does not report version %s\n' "${RTEST_VERSION}" >&2
+    exit 1
+  fi
+  install -m 0755 "${temporary}/rtest" "${binary}"
+  record_source release
+  exit 0
+fi
+
+if [[ "${RTEST_ALLOW_SOURCE_FALLBACK:-false}" != true ]]; then
+  printf 'rtest release %s is unavailable and source fallback is disabled\n' "${RTEST_VERSION}" >&2
+  exit 1
+fi
+: "${RTEST_ACTION_ROOT:?RTEST_ACTION_ROOT is required for source fallback}"
+go -C "${RTEST_ACTION_ROOT}" build -trimpath -o "${binary}" ./cmd/rtest
+if [[ "$("${binary}" version)" != "${RTEST_VERSION}" ]]; then
+  printf 'checked-out rtest source does not report requested version %s\n' "${RTEST_VERSION}" >&2
+  rm -f "${binary}"
+  exit 1
+fi
+record_source source

--- a/rtest/cmd/rtest-benchmark/main.go
+++ b/rtest/cmd/rtest-benchmark/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+
+	"github.com/flidai/leapview/rtest/internal/benchmark"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var specPath string
+	var outputPath string
+	flag.StringVar(&specPath, "spec", "", "benchmark JSON specification")
+	flag.StringVar(&outputPath, "output", "", "directory for raw logs and summary.json")
+	flag.Parse()
+	if specPath == "" || outputPath == "" || flag.NArg() != 0 {
+		return fmt.Errorf("usage: rtest-benchmark --spec <file.json> --output <directory>")
+	}
+
+	file, err := os.Open(specPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	var spec benchmark.Spec
+	if err := decoder.Decode(&spec); err != nil {
+		return fmt.Errorf("decode benchmark spec: %w", err)
+	}
+	if !filepath.IsAbs(spec.ProjectDir) {
+		spec.ProjectDir = filepath.Join(filepath.Dir(specPath), spec.ProjectDir)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	summary, err := benchmark.RunWithProgress(ctx, spec, outputPath, os.Stdout)
+	for _, candidate := range summary.Candidates {
+		if candidate.Status == "completed" {
+			fmt.Printf("%s: median=%.3fs p95=%.3fs\n", candidate.Name, candidate.WallSeconds.Median, candidate.WallSeconds.P95)
+		} else {
+			fmt.Printf("%s: %s (%s)\n", candidate.Name, candidate.Status, candidate.Reason)
+		}
+	}
+	return err
+}

--- a/rtest/docs/benchmarks.md
+++ b/rtest/docs/benchmarks.md
@@ -42,6 +42,42 @@ force normal source generation before `go test` on both local and remote candida
 rtest itself has no LeapView preparation hook and ignored generated files are never added
 to its generic source-transfer contract.
 
+## Controlled provider result
+
+The controlled run on 2026-08-02 used one excluded warmup and five serial measured runs.
+Both candidates in each comparison used the same clean commit, source fingerprint,
+Dockerfile arguments, platform, tag, and `--load` output contract.
+
+| Workload | Candidate | Median | p95 | Measured values |
+| --- | --- | ---: | ---: | --- |
+| Generated Testcontainers lifecycle | local | 43.88 s | 44.46 s | 43.46, 44.19, 43.88, 44.46, 42.87 s |
+| Generated Testcontainers lifecycle | rtest | 72.90 s | 75.53 s | 71.13, 74.78, 72.90, 75.53, 72.51 s |
+| Public site image | rtest | 15.13 s | 16.90 s | 16.90, 15.13, 14.93, 14.62, 15.34 s |
+| Public site image | Depot | 13.17 s | 199.45 s | 130.70, 199.45, 13.17, 7.88, 7.26 s |
+| Production image | rtest | 29.19 s | 30.34 s | 30.34, 29.19, 29.23, 28.82, 28.72 s |
+| Production image | Depot | 31.00 s | 138.68 s | 138.68, 34.00, 31.00, 7.40, 7.80 s |
+
+Every measured rtest test run transferred `0 B` of source. The CPX32 was approximately
+1.66 times slower than the laptop for the generated Testcontainers command, reflecting
+the worker's 3.5-vCPU job reservation plus the remote boundary. The result still moves
+the sustained CPU load off the laptop, which is the product objective.
+
+rtest's BuildKit cache was immediately stable after its excluded warmup. Depot produced
+the fastest eventual hot image loads—about 7 to 8 seconds—but its first measured runs
+continued rebuilding while cache state settled, creating high p95 values in this sample.
+The production/site difference in rtest (29 versus 15 seconds) indicates that native
+remote Buildx `--load` remains sensitive to output image size. Depot's optimized load
+path largely removes that cost once fully hot.
+
+No local image median is reported. OrbStack repeatedly rebuilt the source-generation
+layer for an unchanged commit instead of producing a valid warm hit, so the runs were
+stopped rather than mislabeled as cached performance. During diagnosis, adding `**/.tmp`
+to `.dockerignore` reduced the context from 304 MB to 108 MB, but the constrained local
+builder still did not retain the expensive layer reliably.
+
+The compact machine-readable evidence is
+[`leapview-provider-comparison/summary.json`](../evidence/benchmarks/leapview-provider-comparison/summary.json).
+
 ## Shared-service local proof
 
 The generic service E2E on 2026-08-01 ran a project-selected pinned Go image through

--- a/rtest/docs/benchmarks.md
+++ b/rtest/docs/benchmarks.md
@@ -9,10 +9,12 @@ The checked-in LeapView specifications live under `.rtest/benchmarks/` and compa
 - local Go and generic `rtest exec` for the two focused Testcontainers workloads.
 
 Every specification uses one excluded warmup followed by five serial measured runs. It
-passes identical trailing build/test arguments to every candidate, requires a clean
-source worktree, and executes every sample in a new detached worktree so ignored derived
-files and mutations from an earlier candidate cannot influence a later one. It records
-the Git commit and a content fingerprint, preserves a log for every run, and writes
+passes identical trailing build/test arguments to every candidate and requires a clean
+source worktree. Test samples execute in new detached worktrees so ignored derived files
+and mutations from an earlier candidate cannot influence a later one. Image samples stay
+in the same read-only source worktree because changing local-context paths defeats the
+cache identity used by BuildKit and does not represent normal repeated builds. The runner
+records the Git commit and a content fingerprint, preserves a log for every run, and writes
 median plus nearest-rank p95 to `summary.json`. An unavailable optional
 candidate is labeled `unavailable`; it is never replaced with an estimate or an older
 cross-commit measurement.

--- a/rtest/docs/benchmarks.md
+++ b/rtest/docs/benchmarks.md
@@ -10,8 +10,10 @@ The checked-in LeapView specifications live under `.rtest/benchmarks/` and compa
 
 Every specification uses one excluded warmup followed by five serial measured runs. It
 passes identical trailing build/test arguments to every candidate, requires a clean
-worktree, records the Git commit and a content fingerprint, preserves a log for every
-run, and writes median plus nearest-rank p95 to `summary.json`. An unavailable optional
+source worktree, and executes every sample in a new detached worktree so ignored derived
+files and mutations from an earlier candidate cannot influence a later one. It records
+the Git commit and a content fingerprint, preserves a log for every run, and writes
+median plus nearest-rank p95 to `summary.json`. An unavailable optional
 candidate is labeled `unavailable`; it is never replaced with an estimate or an older
 cross-commit measurement.
 
@@ -32,6 +34,11 @@ the current CI smoke tests consume the resulting image from the caller's Docker 
 The runner records end-to-end command latency. Provider-internal phase timing remains in
 each raw log and must not be presented as a directly comparable metric unless all three
 providers expose the same boundary.
+
+The focused test specifications call repository-owned Taskfile workloads. Those tasks
+force normal source generation before `go test` on both local and remote candidates.
+rtest itself has no LeapView preparation hook and ignored generated files are never added
+to its generic source-transfer contract.
 
 ## Shared-service local proof
 

--- a/rtest/docs/benchmarks.md
+++ b/rtest/docs/benchmarks.md
@@ -1,5 +1,38 @@
 # Benchmarks
 
+## Controlled comparison harness
+
+`rtest-benchmark` measures multiple argv-based candidates against one exact worktree.
+The checked-in LeapView specifications live under `.rtest/benchmarks/` and compare:
+
+- native Docker Buildx, rtest Buildx, and Depot for `Dockerfile` and `Dockerfile.site`;
+- local Go and generic `rtest exec` for the two focused Testcontainers workloads.
+
+Every specification uses one excluded warmup followed by five serial measured runs. It
+passes identical trailing build/test arguments to every candidate, requires a clean
+worktree, records the Git commit and a content fingerprint, preserves a log for every
+run, and writes median plus nearest-rank p95 to `summary.json`. An unavailable optional
+candidate is labeled `unavailable`; it is never replaced with an estimate or an older
+cross-commit measurement.
+
+Run a specification from the `rtest` module, choosing an untracked output directory:
+
+```console
+task benchmark:compare -- \
+  --spec ../.rtest/benchmarks/testcontainers-lifecycle.json \
+  --output .tmp/benchmarks/testcontainers-lifecycle
+
+DEPOT_PROJECT_ID=<project-id> task benchmark:compare -- \
+  --spec ../.rtest/benchmarks/production-image.json \
+  --output .tmp/benchmarks/production-image
+```
+
+Image comparisons intentionally include `--load`, because both local development and
+the current CI smoke tests consume the resulting image from the caller's Docker daemon.
+The runner records end-to-end command latency. Provider-internal phase timing remains in
+each raw log and must not be presented as a directly comparable metric unless all three
+providers expose the same boundary.
+
 ## Shared-service local proof
 
 The generic service E2E on 2026-08-01 ran a project-selected pinned Go image through

--- a/rtest/docs/github-actions.md
+++ b/rtest/docs/github-actions.md
@@ -43,6 +43,21 @@ rely on a user-wide default. Before a long build records completion or activates
 result, the CLI requests a fresh OIDC identity and project session; a short-lived bootstrap
 session therefore never becomes the lifetime limit for an otherwise healthy build.
 
+## CLI distribution
+
+`action/setup-rtest` installs an exact `version` from the repository's `rtest-v*` GitHub
+release. Release archives cover Linux and macOS on amd64 and arm64. The action downloads
+the release checksum manifest, verifies SHA-256 before extraction, verifies the binary's
+reported version, and caches only that verified release under an OS/architecture/version
+key. A restored cache entry must report the requested version before it is trusted.
+
+The `allow-source-fallback` input exists only for the transition before a requested tag
+has been published. It compiles the checked-out module after a release download failure,
+requires the resulting binary to report the requested version, and deliberately does not
+save that binary under the release cache key. Disable the fallback after the first stable
+release is available. Publishing a `rtest-v0.7.0` tag runs `rtest-release.yml`; the job
+refuses a tag that disagrees with `rtest version` and publishes checksummed archives.
+
 The POC stays `workflow_dispatch`-only until its manual hosted proof passes. For a
 `pull_request` trust, rtest requires an `--environment`; configure that GitHub environment
 with required reviewers or an equally strong deployment protection rule. GitHub's signed

--- a/rtest/evidence/README.md
+++ b/rtest/evidence/README.md
@@ -9,6 +9,9 @@ This directory commits only compact, reviewed, machine-readable evidence:
   and Depot cutover proof for LeapView;
 - benchmark `summary.json` files record the five-run warm-cache samples used
   by `docs/benchmarks.md`.
+- `benchmarks/leapview-provider-comparison/summary.json` records the controlled local,
+  rtest, and Depot comparison, including explicit absence of a valid local image-cache
+  sample.
 
 The E2E and benchmark scripts also produce raw logs, job responses, Docker
 status, and intermediate measurements. Those files are intentionally ignored:

--- a/rtest/evidence/benchmarks/leapview-provider-comparison/summary.json
+++ b/rtest/evidence/benchmarks/leapview-provider-comparison/summary.json
@@ -1,0 +1,76 @@
+{
+  "benchmark": "leapview-provider-comparison",
+  "completed_at": "2026-08-02T05:48:51Z",
+  "methodology": {
+    "warmup_runs": 1,
+    "measured_runs": 5,
+    "serial": true,
+    "image_output": "--load",
+    "platform": "linux/amd64",
+    "host": "darwin/arm64",
+    "rtest_worker": "Hetzner CPX32, 4 vCPU, 8 GiB",
+    "rtest_version": "0.7.0",
+    "depot_version": "2.101.75"
+  },
+  "testcontainers_lifecycle": {
+    "commit": "9500f68a4edb70902c6f5295231a03128490a9dc",
+    "worktree_fingerprint": "sha256:1be29f796338a4ac067dcc7d630815b1e279d36b5bc84fec2f8fed1cf4e4cebf",
+    "isolated_worktrees": true,
+    "repository_command": "task benchmark:testcontainers:lifecycle",
+    "local": {
+      "values_seconds": [43.455423459, 44.193859375, 43.881739208, 44.458811125, 42.874824209],
+      "median_seconds": 43.881739208,
+      "p95_seconds": 44.458811125
+    },
+    "rtest": {
+      "values_seconds": [71.125352917, 74.783256458, 72.904134458, 75.526767167, 72.513474125],
+      "median_seconds": 72.904134458,
+      "p95_seconds": 75.526767167,
+      "all_measured_source_transfers_zero": true
+    }
+  },
+  "images": {
+    "commit": "6d9fab892cfc048cbb6b6e50bf9042e1e58cf09f",
+    "worktree_fingerprint": "sha256:8d47624715eea732b8630d51b617a1e6de1f1430b7f91b458c035fdc1549d5db",
+    "source_context": {
+      "before_nested_tmp_exclusion_bytes": 304290000,
+      "after_nested_tmp_exclusion_bytes": 107570000
+    },
+    "local": {
+      "status": "no_valid_warm_sample",
+      "reason": "OrbStack rebuilt the source-generation layer on immediate unchanged repeats; runs were stopped rather than reporting cache-miss latency as a warm-cache median"
+    },
+    "site": {
+      "dockerfile": "Dockerfile.site",
+      "rtest": {
+        "warmup_seconds": 142.856478459,
+        "values_seconds": [16.902550459, 15.126460833, 14.932877042, 14.6204845, 15.34088125],
+        "median_seconds": 15.126460833,
+        "p95_seconds": 16.902550459
+      },
+      "depot": {
+        "warmup_seconds": 140.059390917,
+        "values_seconds": [130.697723709, 199.447666209, 13.172721958, 7.883085084, 7.256550625],
+        "median_seconds": 13.172721958,
+        "p95_seconds": 199.447666209,
+        "last_two_values_seconds": [7.883085084, 7.256550625]
+      }
+    },
+    "production": {
+      "dockerfile": "Dockerfile",
+      "rtest": {
+        "warmup_seconds": 181.177986084,
+        "values_seconds": [30.336555, 29.189962292, 29.227004042, 28.815016666, 28.723027666],
+        "median_seconds": 29.189962292,
+        "p95_seconds": 30.336555
+      },
+      "depot": {
+        "warmup_seconds": 144.61632875,
+        "values_seconds": [138.680524791, 34.000447334, 30.995924958, 7.397829083, 7.796902625],
+        "median_seconds": 30.995924958,
+        "p95_seconds": 138.680524791,
+        "last_two_values_seconds": [7.397829083, 7.796902625]
+      }
+    }
+  }
+}

--- a/rtest/internal/benchmark/runner.go
+++ b/rtest/internal/benchmark/runner.go
@@ -22,14 +22,15 @@ import (
 )
 
 type Spec struct {
-	SchemaVersion int         `json:"schema_version"`
-	Name          string      `json:"name"`
-	ProjectDir    string      `json:"project_dir"`
-	WarmupRuns    int         `json:"warmup_runs"`
-	MeasuredRuns  int         `json:"measured_runs"`
-	RequireClean  bool        `json:"require_clean"`
-	Arguments     []string    `json:"arguments"`
-	Candidates    []Candidate `json:"candidates"`
+	SchemaVersion   int         `json:"schema_version"`
+	Name            string      `json:"name"`
+	ProjectDir      string      `json:"project_dir"`
+	WarmupRuns      int         `json:"warmup_runs"`
+	MeasuredRuns    int         `json:"measured_runs"`
+	RequireClean    bool        `json:"require_clean"`
+	IsolateWorktree bool        `json:"isolate_worktree"`
+	Arguments       []string    `json:"arguments"`
+	Candidates      []Candidate `json:"candidates"`
 }
 
 type Candidate struct {
@@ -50,6 +51,7 @@ type Summary struct {
 	Host                Host              `json:"host"`
 	WarmupRuns          int               `json:"warmup_runs"`
 	MeasuredRuns        int               `json:"measured_runs"`
+	IsolatedWorktrees   bool              `json:"isolated_worktrees"`
 	Arguments           []string          `json:"arguments"`
 	Candidates          []CandidateResult `json:"candidates"`
 }
@@ -125,6 +127,7 @@ func RunWithProgress(ctx context.Context, spec Spec, outputDirectory string, pro
 		Host:                Host{OS: runtime.GOOS, Arch: runtime.GOARCH},
 		WarmupRuns:          spec.WarmupRuns,
 		MeasuredRuns:        spec.MeasuredRuns,
+		IsolatedWorktrees:   spec.IsolateWorktree,
 		Arguments:           expand(spec.Arguments),
 	}
 	if err := os.MkdirAll(outputDirectory, 0o755); err != nil {
@@ -171,7 +174,15 @@ func RunWithProgress(ctx context.Context, spec Spec, outputDirectory string, pro
 			logName := fmt.Sprintf("%s-%d.log", phase, phaseIndex)
 			logPath := filepath.Join(candidateDirectory, logName)
 			fmt.Fprintf(progress, "%s %s %d: running\n", candidate.Name, phase, phaseIndex)
-			run, runErr := runOnce(ctx, project, result.Command, logPath)
+			runDirectory, cleanup, prepareErr := prepareRunDirectory(ctx, project, summary.Commit, spec.IsolateWorktree)
+			if prepareErr != nil {
+				return summary, prepareErr
+			}
+			run, runErr := runOnce(ctx, runDirectory, result.Command, logPath)
+			cleanupErr := cleanup()
+			if runErr == nil && cleanupErr != nil {
+				runErr = cleanupErr
+			}
 			run.Phase, run.Index, run.Log = phase, phaseIndex, filepath.ToSlash(filepath.Join(candidate.Name, logName))
 			fmt.Fprintf(progress, "%s %s %d: %.3fs\n", candidate.Name, phase, phaseIndex, run.WallSeconds)
 			result.Runs = append(result.Runs, run)
@@ -198,6 +209,34 @@ func RunWithProgress(ctx context.Context, spec Spec, outputDirectory string, pro
 		return summary, err
 	}
 	return summary, nil
+}
+
+func prepareRunDirectory(ctx context.Context, project, commit string, isolate bool) (string, func() error, error) {
+	if !isolate {
+		return project, func() error { return nil }, nil
+	}
+	root, err := os.MkdirTemp("", "rtest-benchmark-worktree-")
+	if err != nil {
+		return "", nil, err
+	}
+	worktree := filepath.Join(root, "worktree")
+	command := exec.CommandContext(ctx, "git", "worktree", "add", "--detach", "--quiet", worktree, commit)
+	command.Dir = project
+	if output, addErr := command.CombinedOutput(); addErr != nil {
+		os.RemoveAll(root)
+		return "", nil, fmt.Errorf("create isolated benchmark worktree: %w: %s", addErr, output)
+	}
+	cleanup := func() error {
+		remove := exec.Command("git", "worktree", "remove", "--force", worktree)
+		remove.Dir = project
+		output, removeErr := remove.CombinedOutput()
+		filesystemErr := os.RemoveAll(root)
+		if removeErr != nil {
+			return fmt.Errorf("remove isolated benchmark worktree: %w: %s", removeErr, output)
+		}
+		return filesystemErr
+	}
+	return worktree, cleanup, nil
 }
 
 func validate(spec Spec) error {

--- a/rtest/internal/benchmark/runner.go
+++ b/rtest/internal/benchmark/runner.go
@@ -1,0 +1,386 @@
+// Package benchmark runs controlled, repeatable command comparisons.
+package benchmark
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Spec struct {
+	SchemaVersion int         `json:"schema_version"`
+	Name          string      `json:"name"`
+	ProjectDir    string      `json:"project_dir"`
+	WarmupRuns    int         `json:"warmup_runs"`
+	MeasuredRuns  int         `json:"measured_runs"`
+	RequireClean  bool        `json:"require_clean"`
+	Arguments     []string    `json:"arguments"`
+	Candidates    []Candidate `json:"candidates"`
+}
+
+type Candidate struct {
+	Name           string   `json:"name"`
+	Prefix         []string `json:"prefix"`
+	VersionCommand []string `json:"version_command,omitempty"`
+	RequiredEnv    []string `json:"required_env,omitempty"`
+	Required       bool     `json:"required,omitempty"`
+}
+
+type Summary struct {
+	SchemaVersion       int               `json:"schema_version"`
+	Name                string            `json:"name"`
+	Commit              string            `json:"commit"`
+	WorktreeFingerprint string            `json:"worktree_fingerprint"`
+	Clean               bool              `json:"clean"`
+	CompletedAt         string            `json:"completed_at"`
+	Host                Host              `json:"host"`
+	WarmupRuns          int               `json:"warmup_runs"`
+	MeasuredRuns        int               `json:"measured_runs"`
+	Arguments           []string          `json:"arguments"`
+	Candidates          []CandidateResult `json:"candidates"`
+}
+
+type Host struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+}
+
+type CandidateResult struct {
+	Name        string       `json:"name"`
+	Status      string       `json:"status"`
+	Reason      string       `json:"reason,omitempty"`
+	Command     []string     `json:"command"`
+	Version     string       `json:"version,omitempty"`
+	Runs        []RunResult  `json:"runs"`
+	WallSeconds Distribution `json:"wall_seconds"`
+}
+
+type RunResult struct {
+	Phase       string  `json:"phase"`
+	Index       int     `json:"index"`
+	WallSeconds float64 `json:"wall_seconds"`
+	ExitCode    int     `json:"exit_code"`
+	Log         string  `json:"log"`
+}
+
+type Distribution struct {
+	Values []float64 `json:"values"`
+	Min    float64   `json:"min"`
+	Median float64   `json:"median"`
+	P95    float64   `json:"p95"`
+	Max    float64   `json:"max"`
+}
+
+var candidateName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+
+func Run(ctx context.Context, spec Spec, outputDirectory string) (Summary, error) {
+	return RunWithProgress(ctx, spec, outputDirectory, io.Discard)
+}
+
+func RunWithProgress(ctx context.Context, spec Spec, outputDirectory string, progress io.Writer) (Summary, error) {
+	if err := validate(spec); err != nil {
+		return Summary{}, err
+	}
+	project, err := filepath.Abs(spec.ProjectDir)
+	if err != nil {
+		return Summary{}, fmt.Errorf("resolve benchmark project: %w", err)
+	}
+	commit, err := gitOutput(ctx, project, "rev-parse", "HEAD")
+	if err != nil {
+		return Summary{}, err
+	}
+	status, err := gitBytes(ctx, project, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err != nil {
+		return Summary{}, err
+	}
+	clean := len(status) == 0
+	if spec.RequireClean && !clean {
+		return Summary{}, errors.New("benchmark requires a clean project worktree")
+	}
+	fingerprint, err := fingerprint(ctx, project)
+	if err != nil {
+		return Summary{}, err
+	}
+
+	summary := Summary{
+		SchemaVersion:       1,
+		Name:                spec.Name,
+		Commit:              strings.TrimSpace(commit),
+		WorktreeFingerprint: fingerprint,
+		Clean:               clean,
+		Host:                Host{OS: runtime.GOOS, Arch: runtime.GOARCH},
+		WarmupRuns:          spec.WarmupRuns,
+		MeasuredRuns:        spec.MeasuredRuns,
+		Arguments:           expand(spec.Arguments),
+	}
+	if err := os.MkdirAll(outputDirectory, 0o755); err != nil {
+		return Summary{}, fmt.Errorf("create benchmark output: %w", err)
+	}
+
+	for _, candidate := range spec.Candidates {
+		result := CandidateResult{Name: candidate.Name, Status: "pending"}
+		prefix := expand(candidate.Prefix)
+		result.Command = append(slices.Clone(prefix), summary.Arguments...)
+		reason := unavailable(candidate, prefix)
+		if reason != "" {
+			result.Status, result.Reason = "unavailable", reason
+			summary.Candidates = append(summary.Candidates, result)
+			if candidate.Required {
+				summary.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+				_ = writeSummary(outputDirectory, summary)
+				return summary, fmt.Errorf("required candidate %q is unavailable: %s", candidate.Name, reason)
+			}
+			continue
+		}
+		if len(candidate.VersionCommand) > 0 {
+			version, versionErr := commandOutput(ctx, project, expand(candidate.VersionCommand))
+			if versionErr != nil {
+				result.Status, result.Reason = "unavailable", "version command failed: "+versionErr.Error()
+				summary.Candidates = append(summary.Candidates, result)
+				if candidate.Required {
+					return summary, fmt.Errorf("required candidate %q version: %w", candidate.Name, versionErr)
+				}
+				continue
+			}
+			result.Version = strings.TrimSpace(version)
+		}
+
+		candidateDirectory := filepath.Join(outputDirectory, candidate.Name)
+		if err := os.MkdirAll(candidateDirectory, 0o755); err != nil {
+			return summary, err
+		}
+		for index := 1; index <= spec.WarmupRuns+spec.MeasuredRuns; index++ {
+			phase, phaseIndex := "warmup", index
+			if index > spec.WarmupRuns {
+				phase, phaseIndex = "measured", index-spec.WarmupRuns
+			}
+			logName := fmt.Sprintf("%s-%d.log", phase, phaseIndex)
+			logPath := filepath.Join(candidateDirectory, logName)
+			fmt.Fprintf(progress, "%s %s %d: running\n", candidate.Name, phase, phaseIndex)
+			run, runErr := runOnce(ctx, project, result.Command, logPath)
+			run.Phase, run.Index, run.Log = phase, phaseIndex, filepath.ToSlash(filepath.Join(candidate.Name, logName))
+			fmt.Fprintf(progress, "%s %s %d: %.3fs\n", candidate.Name, phase, phaseIndex, run.WallSeconds)
+			result.Runs = append(result.Runs, run)
+			if runErr != nil {
+				result.Status, result.Reason = "failed", runErr.Error()
+				summary.Candidates = append(summary.Candidates, result)
+				summary.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+				_ = writeSummary(outputDirectory, summary)
+				return summary, fmt.Errorf("candidate %q %s %d failed: %w", candidate.Name, phase, phaseIndex, runErr)
+			}
+		}
+		values := make([]float64, 0, spec.MeasuredRuns)
+		for _, run := range result.Runs {
+			if run.Phase == "measured" {
+				values = append(values, run.WallSeconds)
+			}
+		}
+		result.Status = "completed"
+		result.WallSeconds = distribution(values)
+		summary.Candidates = append(summary.Candidates, result)
+	}
+	summary.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := writeSummary(outputDirectory, summary); err != nil {
+		return summary, err
+	}
+	return summary, nil
+}
+
+func validate(spec Spec) error {
+	if spec.SchemaVersion != 1 {
+		return fmt.Errorf("unsupported benchmark schema version %d", spec.SchemaVersion)
+	}
+	if !candidateName.MatchString(spec.Name) {
+		return errors.New("benchmark name must contain only letters, numbers, dot, dash, and underscore")
+	}
+	if spec.ProjectDir == "" {
+		return errors.New("benchmark project_dir is required")
+	}
+	if spec.WarmupRuns < 0 || spec.MeasuredRuns < 1 {
+		return errors.New("benchmark needs non-negative warmup_runs and at least one measured_run")
+	}
+	if len(spec.Candidates) == 0 {
+		return errors.New("benchmark needs at least one candidate")
+	}
+	seen := map[string]bool{}
+	for _, candidate := range spec.Candidates {
+		if !candidateName.MatchString(candidate.Name) || len(candidate.Prefix) == 0 {
+			return fmt.Errorf("invalid benchmark candidate %q", candidate.Name)
+		}
+		if seen[candidate.Name] {
+			return fmt.Errorf("duplicate benchmark candidate %q", candidate.Name)
+		}
+		seen[candidate.Name] = true
+	}
+	return nil
+}
+
+func unavailable(candidate Candidate, prefix []string) string {
+	for _, name := range candidate.RequiredEnv {
+		if value, ok := os.LookupEnv(name); !ok || value == "" {
+			return "required environment variable " + name + " is not set"
+		}
+	}
+	if _, err := exec.LookPath(prefix[0]); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func expand(values []string) []string {
+	result := make([]string, len(values))
+	for index, value := range values {
+		result[index] = os.ExpandEnv(value)
+	}
+	return result
+}
+
+func runOnce(ctx context.Context, directory string, arguments []string, logPath string) (RunResult, error) {
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return RunResult{}, err
+	}
+	defer logFile.Close()
+	command := exec.CommandContext(ctx, arguments[0], arguments[1:]...)
+	command.Dir, command.Stdout, command.Stderr = directory, logFile, logFile
+	started := time.Now()
+	err = command.Run()
+	elapsed := time.Since(started).Seconds()
+	exitCode := 0
+	if err != nil {
+		exitCode = 1
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
+			exitCode = exit.ExitCode()
+		}
+	}
+	return RunResult{WallSeconds: elapsed, ExitCode: exitCode}, err
+}
+
+func commandOutput(ctx context.Context, directory string, arguments []string) (string, error) {
+	command := exec.CommandContext(ctx, arguments[0], arguments[1:]...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+
+func distribution(values []float64) Distribution {
+	sorted := slices.Clone(values)
+	sort.Float64s(sorted)
+	result := Distribution{Values: slices.Clone(values)}
+	if len(sorted) == 0 {
+		return result
+	}
+	result.Min, result.Max = sorted[0], sorted[len(sorted)-1]
+	middle := len(sorted) / 2
+	if len(sorted)%2 == 0 {
+		result.Median = (sorted[middle-1] + sorted[middle]) / 2
+	} else {
+		result.Median = sorted[middle]
+	}
+	p95Index := (len(sorted)*95 + 99) / 100
+	result.P95 = sorted[p95Index-1]
+	return result
+}
+
+func fingerprint(ctx context.Context, directory string) (string, error) {
+	paths, err := gitBytes(ctx, directory, "ls-files", "-co", "--exclude-standard", "-z")
+	if err != nil {
+		return "", err
+	}
+	items := bytes.Split(bytes.TrimSuffix(paths, []byte{0}), []byte{0})
+	slices.SortFunc(items, bytes.Compare)
+	hash := sha256.New()
+	for _, item := range items {
+		if len(item) == 0 {
+			continue
+		}
+		hash.Write(item)
+		hash.Write([]byte{0})
+		path := filepath.Join(directory, filepath.FromSlash(string(item)))
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				hash.Write([]byte("<deleted>"))
+				continue
+			}
+			return "", statErr
+		}
+		fmt.Fprintf(hash, "%s\x00", info.Mode())
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, readErr := os.Readlink(path)
+			if readErr != nil {
+				return "", readErr
+			}
+			hash.Write([]byte(target))
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		file, openErr := os.Open(path)
+		if openErr != nil {
+			return "", openErr
+		}
+		_, copyErr := io.Copy(hash, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return "", copyErr
+		}
+		if closeErr != nil {
+			return "", closeErr
+		}
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func gitOutput(ctx context.Context, directory string, arguments ...string) (string, error) {
+	output, err := gitBytes(ctx, directory, arguments...)
+	return string(output), err
+}
+
+func gitBytes(ctx context.Context, directory string, arguments ...string) ([]byte, error) {
+	command := exec.CommandContext(ctx, "git", arguments...)
+	command.Dir = directory
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w", strings.Join(arguments, " "), err)
+	}
+	return output, nil
+}
+
+func writeSummary(directory string, summary Summary) error {
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	temporary, err := os.CreateTemp(directory, "summary-*.json")
+	if err != nil {
+		return err
+	}
+	name := temporary.Name()
+	defer os.Remove(name)
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(name, filepath.Join(directory, "summary.json"))
+}

--- a/rtest/internal/benchmark/runner_test.go
+++ b/rtest/internal/benchmark/runner_test.go
@@ -1,0 +1,118 @@
+package benchmark
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunMeasuresAvailableCandidatesAndLabelsMissingOnes(t *testing.T) {
+	project := gitProject(t)
+	output := filepath.Join(t.TempDir(), "results")
+	spec := Spec{
+		SchemaVersion: 1,
+		Name:          "controlled",
+		ProjectDir:    project,
+		WarmupRuns:    1,
+		MeasuredRuns:  2,
+		Arguments:     []string{"measured"},
+		Candidates: []Candidate{
+			{Name: "local", Prefix: []string{"sh", "-c", "printf '%s\\n' \"$1\"", "benchmark"}},
+			{Name: "missing", Prefix: []string{"rtest-benchmark-command-that-does-not-exist"}},
+		},
+	}
+
+	summary, err := Run(t.Context(), spec, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Commit == "" || summary.WorktreeFingerprint == "" {
+		t.Fatalf("summary does not identify exact source state: %#v", summary)
+	}
+	if got := summary.Candidates[0]; got.Status != "completed" || len(got.Runs) != 3 || got.WallSeconds.Median < 0 {
+		t.Fatalf("available candidate = %#v", got)
+	}
+	if got := summary.Candidates[1]; got.Status != "unavailable" || got.Reason == "" {
+		t.Fatalf("missing candidate = %#v", got)
+	}
+	data, err := os.ReadFile(filepath.Join(output, "summary.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted Summary
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Name != spec.Name {
+		t.Fatalf("persisted name = %q, want %q", persisted.Name, spec.Name)
+	}
+	if _, err := os.Stat(filepath.Join(output, "local", "measured-2.log")); err != nil {
+		t.Fatalf("raw log was not preserved: %v", err)
+	}
+}
+
+func TestRunRejectsDirtyProjectWhenCleanSourceIsRequired(t *testing.T) {
+	project := gitProject(t)
+	if err := os.WriteFile(filepath.Join(project, "dirty.txt"), []byte("dirty"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Run(t.Context(), Spec{
+		SchemaVersion: 1,
+		Name:          "clean-only",
+		ProjectDir:    project,
+		MeasuredRuns:  1,
+		RequireClean:  true,
+		Candidates:    []Candidate{{Name: "local", Prefix: []string{"true"}}},
+	}, t.TempDir())
+	if err == nil {
+		t.Fatal("dirty benchmark project unexpectedly accepted")
+	}
+}
+
+func TestRunFailsOnRequiredUnavailableCandidate(t *testing.T) {
+	project := gitProject(t)
+	_, err := Run(t.Context(), Spec{
+		SchemaVersion: 1,
+		Name:          "required",
+		ProjectDir:    project,
+		MeasuredRuns:  1,
+		Candidates: []Candidate{{
+			Name: "remote", Prefix: []string{"missing-required-command"}, Required: true,
+		}},
+	}, t.TempDir())
+	if err == nil {
+		t.Fatal("required unavailable candidate unexpectedly accepted")
+	}
+}
+
+func TestDistributionUsesMedianAndNearestRankP95(t *testing.T) {
+	got := distribution([]float64{5, 1, 4, 2, 3})
+	if got.Min != 1 || got.Median != 3 || got.P95 != 5 || got.Max != 5 {
+		t.Fatalf("distribution = %#v", got)
+	}
+}
+
+func gitProject(t *testing.T) string {
+	t.Helper()
+	directory := t.TempDir()
+	runCommand(t, directory, "git", "init", "--quiet")
+	runCommand(t, directory, "git", "config", "user.email", "benchmark@example.test")
+	runCommand(t, directory, "git", "config", "user.name", "Benchmark Test")
+	if err := os.WriteFile(filepath.Join(directory, "tracked.txt"), []byte("source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runCommand(t, directory, "git", "add", "tracked.txt")
+	runCommand(t, directory, "git", "commit", "--quiet", "-m", "source")
+	return directory
+}
+
+func runCommand(t *testing.T, directory, name string, arguments ...string) {
+	t.Helper()
+	command := exec.Command(name, arguments...)
+	command.Dir = directory
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("%v failed: %v\n%s", command.Args, err, output)
+	}
+}

--- a/rtest/internal/benchmark/runner_test.go
+++ b/rtest/internal/benchmark/runner_test.go
@@ -71,6 +71,34 @@ func TestRunRejectsDirtyProjectWhenCleanSourceIsRequired(t *testing.T) {
 	}
 }
 
+func TestRunCanIsolateEverySampleInAFreshDetachedWorktree(t *testing.T) {
+	project := gitProject(t)
+	summary, err := Run(t.Context(), Spec{
+		SchemaVersion:   1,
+		Name:            "isolated",
+		ProjectDir:      project,
+		WarmupRuns:      1,
+		MeasuredRuns:    2,
+		RequireClean:    true,
+		IsolateWorktree: true,
+		Candidates: []Candidate{{
+			Name: "local",
+			Prefix: []string{
+				"sh", "-c", "test ! -e generated && touch generated",
+			},
+		}},
+	}, filepath.Join(t.TempDir(), "results"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !summary.IsolatedWorktrees {
+		t.Fatal("summary does not record isolated worktrees")
+	}
+	if _, err := os.Stat(filepath.Join(project, "generated")); !os.IsNotExist(err) {
+		t.Fatalf("benchmark mutated source project: %v", err)
+	}
+}
+
 func TestRunFailsOnRequiredUnavailableCandidate(t *testing.T) {
 	project := gitProject(t)
 	_, err := Run(t.Context(), Spec{

--- a/rtest/internal/benchmark/runner_test.go
+++ b/rtest/internal/benchmark/runner_test.go
@@ -34,7 +34,7 @@ func TestRunMeasuresAvailableCandidatesAndLabelsMissingOnes(t *testing.T) {
 	if got := summary.Candidates[0]; got.Status != "completed" || len(got.Runs) != 3 || got.WallSeconds.Median < 0 {
 		t.Fatalf("available candidate = %#v", got)
 	}
-	if got := summary.Candidates[1]; got.Status != "unavailable" || got.Reason == "" {
+	if got := summary.Candidates[1]; got.Status != "unavailable" || len(got.Reason) == 0 {
 		t.Fatalf("missing candidate = %#v", got)
 	}
 	data, err := os.ReadFile(filepath.Join(output, "summary.json"))

--- a/rtest/internal/cli/service.go
+++ b/rtest/internal/cli/service.go
@@ -501,11 +501,11 @@ func parseExec(settings config.Config, project string, args []string) (execOptio
 }
 
 func defaultExecWorkingDirectory(root, directory string) (string, error) {
-	absoluteRoot, err := filepath.Abs(root)
+	absoluteRoot, err := canonicalDirectory(root)
 	if err != nil {
 		return "", fmt.Errorf("resolve repository root: %w", err)
 	}
-	absoluteDirectory, err := filepath.Abs(directory)
+	absoluteDirectory, err := canonicalDirectory(directory)
 	if err != nil {
 		return "", fmt.Errorf("resolve invocation directory: %w", err)
 	}
@@ -517,6 +517,14 @@ func defaultExecWorkingDirectory(root, directory string) (string, error) {
 		return "", errors.New("invocation directory is outside the Git worktree")
 	}
 	return filepath.ToSlash(relative), nil
+}
+
+func canonicalDirectory(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(absolute)
 }
 
 func serviceImage(ctx context.Context, api rtestv1connect.ControlServiceClient, settings config.Config, project string, args []string, streams IO) int {

--- a/rtest/internal/cli/service_internal_test.go
+++ b/rtest/internal/cli/service_internal_test.go
@@ -74,6 +74,25 @@ func TestDefaultExecWorkingDirectoryFollowsInvocationDirectory(t *testing.T) {
 	}
 }
 
+func TestDefaultExecWorkingDirectoryCanonicalizesSymlinkedInvocationPath(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "services", "api")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "linked-worktree")
+	if err := os.Symlink(root, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	got, err := defaultExecWorkingDirectory(root, filepath.Join(link, "services", "api"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Join("services", "api") {
+		t.Fatalf("working directory = %q", got)
+	}
+}
+
 func TestImageActivateUsesRepositoryProjectAndPinnedImage(t *testing.T) {
 	service := &projectListService{projects: []*rtestv1.Project{{Id: "prj1", Slug: "example", Name: "Example"}}}
 	client, closeServer := testServiceClient(t, service)

--- a/rtest/internal/githubaction/action_test.go
+++ b/rtest/internal/githubaction/action_test.go
@@ -1,8 +1,11 @@
 package githubaction_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -11,19 +14,191 @@ func TestSetupActionHasSecureProjectAwareContract(t *testing.T) {
 	data := read(t, filepath.Join("..", "..", "action", "setup-rtest", "action.yml"))
 	for _, want := range []string{
 		"using: composite",
+		"version:",
+		"repository:",
+		"allow-source-fallback:",
 		"service-url:",
 		"project:",
 		"image:",
 		"ca-certificate:",
 		"oidc-audience:",
 		"backend: \"service\"",
-		"go build -trimpath",
+		"actions/cache/restore@",
+		"actions/cache/save@",
+		"install-release.sh",
 		"chmod 0600",
 		"RTEST_CONFIG",
-		"$GITHUB_PATH",
+		"GITHUB_PATH",
 	} {
 		if !strings.Contains(data, want) {
 			t.Fatalf("action.yml missing %q", want)
+		}
+	}
+	if strings.Contains(data, "go build -trimpath -o \"${bin_dir}/rtest\"") {
+		t.Fatal("action.yml must not unconditionally compile rtest")
+	}
+}
+
+func TestReleaseInstallerDownloadsAndVerifiesPinnedArchive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("release installer targets POSIX GitHub runners")
+	}
+	releaseRoot := t.TempDir()
+	installRoot := t.TempDir()
+	version := "9.8.7"
+	asset := "rtest_" + version + "_" + installerOS(runtime.GOOS) + "_" + installerArch(runtime.GOARCH) + ".tar.gz"
+	assetDir := filepath.Join(releaseRoot, "rtest-v"+version)
+	if err := os.MkdirAll(filepath.Join(assetDir, "payload"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(assetDir, "payload", "rtest")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nprintf '%s\\n' '"+version+"'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, assetDir, "tar", "-czf", asset, "-C", "payload", "rtest")
+	archive, err := os.ReadFile(filepath.Join(assetDir, asset))
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(archive)
+	checksums := hex.EncodeToString(digest[:]) + "  " + asset + "\n"
+	if err := os.WriteFile(filepath.Join(assetDir, "checksums.txt"), []byte(checksums), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := runInstaller(t, map[string]string{
+		"RTEST_VERSION":          version,
+		"RTEST_REPOSITORY":       "example/rtest",
+		"RTEST_RELEASE_BASE_URL": "file://" + releaseRoot,
+		"RTEST_INSTALL_ROOT":     installRoot,
+	})
+	if !strings.Contains(result, "source=release") {
+		t.Fatalf("installer output = %q, want release source", result)
+	}
+	got := run(t, t.TempDir(), filepath.Join(installRoot, "bin", "rtest"), "version")
+	if strings.TrimSpace(got) != version {
+		t.Fatalf("installed version = %q, want %q", strings.TrimSpace(got), version)
+	}
+	cached := runInstaller(t, map[string]string{
+		"RTEST_VERSION":          version,
+		"RTEST_REPOSITORY":       "example/rtest",
+		"RTEST_RELEASE_BASE_URL": "file://" + t.TempDir(),
+		"RTEST_INSTALL_ROOT":     installRoot,
+	})
+	if !strings.Contains(cached, "source=cache") {
+		t.Fatalf("second installer output = %q, want cache source", cached)
+	}
+}
+
+func TestReleaseInstallerRejectsChecksumMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("release installer targets POSIX GitHub runners")
+	}
+	releaseRoot := t.TempDir()
+	version := "9.8.7"
+	asset := "rtest_" + version + "_" + installerOS(runtime.GOOS) + "_" + installerArch(runtime.GOARCH) + ".tar.gz"
+	assetDir := filepath.Join(releaseRoot, "rtest-v"+version)
+	if err := os.MkdirAll(assetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assetDir, asset), []byte("corrupt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assetDir, "checksums.txt"), []byte(strings.Repeat("0", 64)+"  "+asset+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := installerCommand(map[string]string{
+		"RTEST_VERSION":          version,
+		"RTEST_REPOSITORY":       "example/rtest",
+		"RTEST_RELEASE_BASE_URL": "file://" + releaseRoot,
+		"RTEST_INSTALL_ROOT":     t.TempDir(),
+	}).CombinedOutput()
+	if err == nil {
+		t.Fatalf("installer unexpectedly accepted mismatched checksum: %s", output)
+	}
+	if !strings.Contains(string(output), "checksum") {
+		t.Fatalf("installer error %q does not identify checksum failure", output)
+	}
+}
+
+func TestReleaseInstallerUsesExplicitSourceFallbackWithoutRelease(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("release installer targets POSIX GitHub runners")
+	}
+	source := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(source, "cmd", "rtest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "go.mod"), []byte("module example.test/rtest\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	program := "package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"9.8.7\") }\n"
+	if err := os.WriteFile(filepath.Join(source, "cmd", "rtest", "main.go"), []byte(program), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result := runInstaller(t, map[string]string{
+		"RTEST_VERSION":               "9.8.7",
+		"RTEST_REPOSITORY":            "example/rtest",
+		"RTEST_RELEASE_BASE_URL":      "file://" + t.TempDir(),
+		"RTEST_INSTALL_ROOT":          t.TempDir(),
+		"RTEST_ACTION_ROOT":           source,
+		"RTEST_ALLOW_SOURCE_FALLBACK": "true",
+	})
+	if !strings.Contains(result, "source=source") {
+		t.Fatalf("installer output = %q, want source fallback", result)
+	}
+}
+
+func TestReleaseInstallerSelectsGitHubRunnerPlatform(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("release installer targets POSIX GitHub runners")
+	}
+	releaseRoot := t.TempDir()
+	version := "9.8.7"
+	asset := "rtest_" + version + "_linux_arm64.tar.gz"
+	assetDir := filepath.Join(releaseRoot, "rtest-v"+version)
+	if err := os.MkdirAll(filepath.Join(assetDir, "payload"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assetDir, "payload", "rtest"), []byte("#!/bin/sh\necho "+version+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, assetDir, "tar", "-czf", asset, "-C", "payload", "rtest")
+	archive, err := os.ReadFile(filepath.Join(assetDir, asset))
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(archive)
+	if err := os.WriteFile(filepath.Join(assetDir, "checksums.txt"), []byte(hex.EncodeToString(digest[:])+"  "+asset+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result := runInstaller(t, map[string]string{
+		"RUNNER_OS":              "Linux",
+		"RUNNER_ARCH":            "ARM64",
+		"RTEST_VERSION":          version,
+		"RTEST_REPOSITORY":       "example/rtest",
+		"RTEST_RELEASE_BASE_URL": "file://" + releaseRoot,
+		"RTEST_INSTALL_ROOT":     t.TempDir(),
+	})
+	if !strings.Contains(result, "source=release") {
+		t.Fatalf("installer output = %q, want linux/arm64 release", result)
+	}
+}
+
+func TestReleaseWorkflowPackagesPortableChecksummedAssets(t *testing.T) {
+	data := read(t, filepath.Join("..", "..", "..", ".github", "workflows", "rtest-release.yml"))
+	for _, want := range []string{
+		"rtest-v*",
+		"linux amd64",
+		"linux arm64",
+		"darwin amd64",
+		"darwin arm64",
+		"checksums.txt",
+		"gh release create",
+	} {
+		if !strings.Contains(data, want) {
+			t.Fatalf("rtest-release.yml missing %q", want)
 		}
 	}
 }

--- a/rtest/internal/githubaction/install_test.go
+++ b/rtest/internal/githubaction/install_test.go
@@ -1,0 +1,53 @@
+package githubaction_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func installerCommand(environment map[string]string) *exec.Cmd {
+	path := filepath.Join("..", "..", "action", "setup-rtest", "install-release.sh")
+	command := exec.Command("bash", path)
+	command.Env = os.Environ()
+	for key, value := range environment {
+		command.Env = append(command.Env, key+"="+value)
+	}
+	return command
+}
+
+func runInstaller(t *testing.T, environment map[string]string) string {
+	t.Helper()
+	output, err := installerCommand(environment).CombinedOutput()
+	if err != nil {
+		t.Fatalf("installer failed: %v\n%s", err, output)
+	}
+	return string(output)
+}
+
+func run(t *testing.T, directory, name string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command(name, arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", strings.Join(command.Args, " "), err, output)
+	}
+	return string(output)
+}
+
+func installerOS(value string) string {
+	if value == "darwin" {
+		return "darwin"
+	}
+	return "linux"
+}
+
+func installerArch(value string) string {
+	if value == "arm64" {
+		return "arm64"
+	}
+	return "amd64"
+}


### PR DESCRIPTION
## Summary

- install checksum-verified, version-pinned rtest release binaries with a non-cacheable source fallback until the first tag is published
- publish portable Linux/macOS amd64/arm64 release archives from `rtest-v*` tags
- add a generic controlled benchmark runner with exact source fingerprints, clean/isolated worktrees, raw logs, and median/p95 summaries
- record local versus rtest Testcontainers results and rtest versus Depot image results
- exclude nested `.tmp` state from Docker build contexts

## Stacking

This PR is stacked on #205 and must not be merged before its base.

## Verification

- `task --taskfile rtest/Taskfile.yml --dir rtest test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `go test ./internal/platform/architecture -run TestProductionContainerContract -count=1`
- controlled one-warmup/five-measured-run provider benchmarks on the existing CPX32, local OrbStack, and Depot
