### PR TITLE
ci: make validation stack aware

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,119 @@
+name: Main artifacts
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+concurrency:
+  group: main-artifacts
+  cancel-in-progress: true
+
+jobs:
+  qualify:
+    name: Qualify main artifacts
+    if: github.repository == 'flidai/leapview' && github.ref == 'refs/heads/main'
+    environment: autback
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify runner contract
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          if [[ "${EVENT_NAME}" == "push" ]] &&
+             ! git diff --quiet "${BEFORE_SHA}" "${GITHUB_SHA}" -- Dockerfile.autback; then
+            echo "runner=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "runner=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Autback
+        uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0
+        with:
+          version: 0.1.6
+          service-url: ${{ vars.AUTBACK_SERVICE_URL }}
+          project: leapview
+          ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}
+
+      - name: Check shared worker
+        run: autback doctor
+
+      - name: Build and activate the project runner
+        if: ${{ steps.changes.outputs.runner == 'true' }}
+        env:
+          AUTBACK_RUNNER_IMAGE: ghcr.io/flidai/leapview:autback-${{ github.sha }}
+        run: >-
+          autback image build --tag "${AUTBACK_RUNNER_IMAGE}"
+          --file Dockerfile.autback -- --platform linux/amd64
+
+      - name: Build and qualify the production image remotely
+        env:
+          IMAGE_REPOSITORY: ghcr.io/flidai/leapview
+        run: |
+          set -euo pipefail
+          metadata_file="${RUNNER_TEMP}/leapview-image.json"
+          image_tag="${IMAGE_REPOSITORY}:main-${GITHUB_SHA}"
+          autback build -- \
+            --file Dockerfile \
+            --platform linux/amd64 \
+            --push \
+            --pull \
+            --provenance=mode=max \
+            --sbom=true \
+            --metadata-file "${metadata_file}" \
+            --tag "${image_tag}" \
+            .
+          digest="$(jq -er '."containerimage.digest" | select(startswith("sha256:"))' "${metadata_file}")"
+          immutable_image="${IMAGE_REPOSITORY}@${digest}"
+          autback exec --timeout 30m \
+            --cache go-build=/root/.cache/go-build \
+            --cache go-mod=/go/pkg/mod \
+            --cache bun=/root/.bun/install/cache \
+            -- task image:qualify:production IMAGE="${immutable_image}"
+          printf 'Production image: `%s`\n' "${immutable_image}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Build and smoke-test the public site image remotely
+        env:
+          IMAGE_REPOSITORY: ghcr.io/flidai/leapview-site
+        run: |
+          set -euo pipefail
+          metadata_file="${RUNNER_TEMP}/leapview-site-image.json"
+          image_tag="${IMAGE_REPOSITORY}:main-${GITHUB_SHA}"
+          autback build -- \
+            --file Dockerfile.site \
+            --platform linux/amd64 \
+            --push \
+            --provenance=mode=max \
+            --sbom=true \
+            --metadata-file "${metadata_file}" \
+            --tag "${image_tag}" \
+            .
+          digest="$(jq -er '."containerimage.digest" | select(startswith("sha256:"))' "${metadata_file}")"
+          immutable_image="${IMAGE_REPOSITORY}@${digest}"
+          autback exec --timeout 15m -- \
+            task image:qualify:site IMAGE="${immutable_image}"
+          printf 'Public site image: `%s`\n' "${immutable_image}" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -16,12 +14,18 @@ concurrency:
 
 jobs:
   autback-ci:
-    name: Autback CI
+    name: Autback preflight
     if: >-
       ${{
-        github.event_name != 'pull_request' ||
-        (github.event.pull_request.head.repo.full_name == github.repository &&
-          github.actor != 'dependabot[bot]')
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]' &&
+          (
+            github.event.pull_request.stack == null ||
+            github.event.pull_request.stack.position == github.event.pull_request.stack.size
+          )
+        )
       }}
     environment: autback
     runs-on: ubuntu-24.04
@@ -34,11 +38,28 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify runner contract
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.stack.base.sha || github.event.pull_request.base.sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "pull_request" ]] &&
+             ! git diff --quiet "${BASE_SHA}" "${GITHUB_SHA}" -- Dockerfile.autback; then
+            echo "runner=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "runner=false" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Set up Buildx
+        if: ${{ steps.changes.outputs.runner == 'true' }}
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
+        if: ${{ steps.changes.outputs.runner == 'true' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
@@ -56,8 +77,9 @@ jobs:
       - name: Check shared worker
         run: autback doctor
 
-      - name: Build the immutable CI environment
+      - name: Build candidate runner
         id: runner
+        if: ${{ steps.changes.outputs.runner == 'true' }}
         env:
           IMAGE_REPOSITORY: ghcr.io/flidai/leapview
         run: |
@@ -72,78 +94,39 @@ jobs:
             --tag "${image_tag}" \
             .
           digest="$(jq -er '."containerimage.digest" | select(startswith("sha256:"))' "${metadata_file}")"
-          immutable_image="${IMAGE_REPOSITORY}@${digest}"
-          printf 'image=%s\n' "${immutable_image}" >> "${GITHUB_OUTPUT}"
-          printf 'CI environment: `%s`\n' "${immutable_image}" >> "${GITHUB_STEP_SUMMARY}"
+          printf 'image=%s@%s\n' "${IMAGE_REPOSITORY}" "${digest}" >> "${GITHUB_OUTPUT}"
 
       - name: Run the complete CI contract remotely
         env:
-          AUTBACK_RUNNER_IMAGE: ${{ steps.runner.outputs.image }}
-        run: >-
-          autback exec --image "${AUTBACK_RUNNER_IMAGE}" --timeout 90m
-          --cache go-build=/root/.cache/go-build
-          --cache go-mod=/go/pkg/mod
-          --cache bun=/root/.bun/install/cache
-          --cache terraform=/root/.cache/terraform
-          -- task ci:local
-
-      - name: Build and qualify the production image remotely
-        env:
-          AUTBACK_RUNNER_IMAGE: ${{ steps.runner.outputs.image }}
-          IMAGE_REPOSITORY: ghcr.io/flidai/leapview
+          CANDIDATE_RUNNER: ${{ steps.runner.outputs.image }}
         run: |
           set -euo pipefail
-          metadata_file="${RUNNER_TEMP}/leapview-image.json"
-          image_tag="${IMAGE_REPOSITORY}:ci-${GITHUB_SHA}"
-          autback build -- \
-            --file Dockerfile \
-            --platform linux/amd64 \
-            --push \
-            --pull \
-            --provenance=mode=max \
-            --sbom=true \
-            --metadata-file "${metadata_file}" \
-            --tag "${image_tag}" \
-            .
-          digest="$(jq -er '."containerimage.digest" | select(startswith("sha256:"))' "${metadata_file}")"
-          immutable_image="${IMAGE_REPOSITORY}@${digest}"
-          autback exec --image "${AUTBACK_RUNNER_IMAGE}" --timeout 30m \
-            --cache go-build=/root/.cache/go-build \
-            --cache go-mod=/go/pkg/mod \
-            --cache bun=/root/.bun/install/cache \
-            -- task image:qualify:production IMAGE="${immutable_image}"
-          printf 'Production image: `%s`\n' "${immutable_image}" >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Build and smoke-test the public site image remotely
-        env:
-          AUTBACK_RUNNER_IMAGE: ${{ steps.runner.outputs.image }}
-          IMAGE_REPOSITORY: ghcr.io/flidai/leapview-site
-        run: |
-          set -euo pipefail
-          metadata_file="${RUNNER_TEMP}/leapview-site-image.json"
-          image_tag="${IMAGE_REPOSITORY}:ci-${GITHUB_SHA}"
-          autback build -- \
-            --file Dockerfile.site \
-            --platform linux/amd64 \
-            --push \
-            --provenance=mode=max \
-            --sbom=true \
-            --metadata-file "${metadata_file}" \
-            --tag "${image_tag}" \
-            .
-          digest="$(jq -er '."containerimage.digest" | select(startswith("sha256:"))' "${metadata_file}")"
-          immutable_image="${IMAGE_REPOSITORY}@${digest}"
-          autback exec --image "${AUTBACK_RUNNER_IMAGE}" --timeout 15m -- \
-            task image:qualify:site IMAGE="${immutable_image}"
-          printf 'Public site image: `%s`\n' "${immutable_image}" >> "${GITHUB_STEP_SUMMARY}"
+          command=(autback exec --timeout 90m)
+          if [[ -n "${CANDIDATE_RUNNER}" ]]; then
+            command+=(--image "${CANDIDATE_RUNNER}")
+          fi
+          command+=(
+            --cache go-build=/root/.cache/go-build
+            --cache go-mod=/go/pkg/mod
+            --cache bun=/root/.bun/install/cache
+            --cache terraform=/root/.cache/terraform
+            -- task ci:local
+          )
+          "${command[@]}"
 
   github-ci:
     name: GitHub CI (external pull request)
     if: >-
       ${{
         github.event_name == 'pull_request' &&
-        (github.event.pull_request.head.repo.full_name != github.repository ||
-          github.actor == 'dependabot[bot]')
+        (
+          github.event.pull_request.head.repo.full_name != github.repository ||
+          github.actor == 'dependabot[bot]'
+        ) &&
+        (
+          github.event.pull_request.stack == null ||
+          github.event.pull_request.stack.position == github.event.pull_request.stack.size
+        )
       }}
     runs-on: ubuntu-24.04
     timeout-minutes: 120
@@ -179,12 +162,23 @@ jobs:
     needs: [autback-ci, github-ci]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    env:
+      EXPENSIVE_REQUIRED: >-
+        ${{
+          github.event_name == 'workflow_dispatch' ||
+          github.event.pull_request.stack == null ||
+          github.event.pull_request.stack.position == github.event.pull_request.stack.size
+        }}
     steps:
       - name: Require the applicable trust path
         env:
           AUTBACK_RESULT: ${{ needs.autback-ci.result }}
           GITHUB_RESULT: ${{ needs.github-ci.result }}
         run: |
+          if [[ "${EXPENSIVE_REQUIRED}" != "true" ]]; then
+            echo "Validation is deferred to the top of this stack." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
           case "${AUTBACK_RESULT}:${GITHUB_RESULT}" in
             success:skipped|skipped:success) exit 0 ;;
             *)

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -1,0 +1,101 @@
+name: Merge validation
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: merge-validation-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  ci-gate:
+    name: CI gate
+    if: github.repository == 'flidai/leapview'
+    environment: autback
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Check out merge group
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify runner contract
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          if ! git diff --quiet "${BASE_SHA}" "${GITHUB_SHA}" -- Dockerfile.autback; then
+            echo "runner=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "runner=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Set up Buildx
+        if: ${{ steps.changes.outputs.runner == 'true' }}
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ steps.changes.outputs.runner == 'true' }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Autback
+        uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0
+        with:
+          version: 0.1.6
+          service-url: ${{ vars.AUTBACK_SERVICE_URL }}
+          project: leapview
+          ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}
+
+      - name: Check shared worker
+        run: autback doctor
+
+      - name: Build candidate runner
+        id: runner
+        if: ${{ steps.changes.outputs.runner == 'true' }}
+        env:
+          IMAGE_REPOSITORY: ghcr.io/flidai/leapview
+        run: |
+          set -euo pipefail
+          metadata_file="${RUNNER_TEMP}/autback-runner-image.json"
+          image_tag="${IMAGE_REPOSITORY}:autback-merge-${GITHUB_SHA}"
+          autback build -- \
+            --file Dockerfile.autback \
+            --platform linux/amd64 \
+            --push \
+            --metadata-file "${metadata_file}" \
+            --tag "${image_tag}" \
+            .
+          digest="$(jq -er '."containerimage.digest" | select(startswith("sha256:"))' "${metadata_file}")"
+          printf 'image=%s@%s\n' "${IMAGE_REPOSITORY}" "${digest}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate the exact merge group remotely
+        env:
+          CANDIDATE_RUNNER: ${{ steps.runner.outputs.image }}
+        run: |
+          set -euo pipefail
+          command=(autback exec --timeout 90m)
+          if [[ -n "${CANDIDATE_RUNNER}" ]]; then
+            command+=(--image "${CANDIDATE_RUNNER}")
+          fi
+          command+=(
+            --cache go-build=/root/.cache/go-build
+            --cache go-mod=/go/pkg/mod
+            --cache bun=/root/.bun/install/cache
+            --cache terraform=/root/.cache/terraform
+            -- task ci:local
+          )
+          "${command[@]}"

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,8 @@
   ],
   "overrides": {
     "dompurify": "3.4.12",
+    "fast-uri": "3.1.5",
+    "undici": "7.29.0",
   },
   "packages": {
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
@@ -525,7 +527,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
@@ -791,7 +793,7 @@
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.28.0", "", {}, "sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ=="],
 

--- a/deploy/compose/deployment_test.go
+++ b/deploy/compose/deployment_test.go
@@ -401,6 +401,7 @@ func TestInstalledCandidateQualificationContract(t *testing.T) {
 func TestEnterpriseAuthoringGoldenJourneyContract(t *testing.T) {
 	root := filepath.Join("..", "..")
 	ci := read(t, filepath.Join(root, ".github", "workflows", "ci.yml"))
+	artifacts := read(t, filepath.Join(root, ".github", "workflows", "artifacts.yml"))
 	installed := read(t, filepath.Join(root, "internal", "app", "cli", "composectl", "qualification_installed.go"))
 	authoring := read(t, filepath.Join(root, "internal", "app", "cli", "composectl", "qualification_authoring.go"))
 	client := read(t, filepath.Join(root, "internal", "app", "cli", "composectl", "qualification_client.go"))
@@ -412,8 +413,8 @@ func TestEnterpriseAuthoringGoldenJourneyContract(t *testing.T) {
 		t.Error("external pull requests must not qualify or publish production images")
 	}
 	for _, required := range []string{"task image:qualify:production IMAGE=\"${immutable_image}\"", "qualify image", "--image {{.IMAGE | quote}}"} {
-		if !strings.Contains(ci+read(t, filepath.Join(root, "Taskfile.yml")), required) {
-			t.Errorf("trusted production image job must qualify its immutable digest remotely: missing %q", required)
+		if !strings.Contains(artifacts+read(t, filepath.Join(root, "Taskfile.yml")), required) {
+			t.Errorf("main artifact job must qualify its immutable digest remotely: missing %q", required)
 		}
 	}
 	if !strings.Contains(installed, "runQualificationAuthoring") {

--- a/deploy/hetzner-site/deployment_test.go
+++ b/deploy/hetzner-site/deployment_test.go
@@ -335,7 +335,7 @@ func TestRepositoryCIValidatesPermanentSiteInfrastructure(t *testing.T) {
 		requireContains(t, taskfile, fragment)
 	}
 	for _, fragment := range []string{
-		"autback exec --image \"${AUTBACK_RUNNER_IMAGE}\" --timeout 90m",
+		"command=(autback exec --timeout 90m)",
 		"-- task ci:local",
 		"run: task ci:local",
 	} {

--- a/docs/articles/architecture/autback.md
+++ b/docs/articles/architecture/autback.md
@@ -47,11 +47,11 @@ would configure only GitHub-hosted invocations and leave local project selection
 
 ## GitHub authentication
 
-Trusted pushes and internal pull requests run the complete `task ci:local` contract and
-release-image qualification on Autback. The GitHub environment `autback` supplies the public
-`AUTBACK_SERVICE_URL` and `AUTBACK_CA_CERTIFICATE` values. The setup action receives
-`project: leapview` because it must select the trust scope before exchanging the GitHub OIDC
-identity; it then exports `AUTBACK_PROJECT` for that workflow.
+Trusted internal pull requests and merge groups run the complete `task ci:local` contract on
+Autback. The GitHub environment `autback` supplies the public `AUTBACK_SERVICE_URL` and
+`AUTBACK_CA_CERTIFICATE` values. The setup action receives `project: leapview` because it must
+select the trust scope before exchanging the GitHub OIDC identity; it then exports
+`AUTBACK_PROJECT` for that workflow.
 
 The action input and `autback.json` have distinct bootstrap roles. The former establishes the
 OIDC trust scope in GitHub Actions, while the latter provides repository-owned selection for
@@ -60,12 +60,39 @@ normal CLI use. No long-lived Autback credential is stored in GitHub.
 External and Dependabot pull requests do not receive Autback OIDC access because their code
 is untrusted. They run the same `task ci:local` contract on a GitHub-hosted runner.
 
+## Stacked pull requests
+
+GitHub evaluates every native stack entry against the stack's ultimate base branch. Running
+the complete contract for every cumulative prefix makes a stack update consume the worker
+once per layer. LeapView instead runs the automatic review preflight only for a standalone
+pull request or the top entry in a native stack. The top entry contains the complete combined
+tree. Lower entries receive the stable `CI gate` check without entering Autback.
+
+The required merge boundary is the GitHub merge queue. Its `merge_group` event represents the
+exact candidate constructed from the current base and the queued stack. The
+`merge-validation.yml` workflow runs `task ci:local` for that candidate and reports the same
+`CI gate` context required by the `main` ruleset. Stack reviews therefore get one early full
+preflight, while the merge queue retains one authoritative validation immediately before the
+stack lands.
+
+The merge queue admits one candidate at a time because Autback intentionally executes one
+job at a time on the shared worker. It may combine up to ten pull requests into that candidate;
+`HEADGREEN` validation checks the resulting head commit once. Parallelism stays inside the
+single `task ci:local` operation, where the project can use the worker's full capacity without
+competing full-suite jobs.
+
+The preflight and merge-group workflows normally use the project's activated runner image.
+When `Dockerfile.autback` differs from the stack base, they build an immutable candidate runner
+and execute the contract inside it. A successful change merged to `main` is then built and
+activated before post-merge artifact qualification.
+
 ## Image lifecycle
 
-Trusted image jobs use Autback's Buildx bridge with `--push` and `--metadata-file`. The
-workflow captures Buildx's immutable digest, forms a `repository@sha256:...` reference, and
-qualifies that exact production or site image remotely. The complete image is never
-transferred back to the GitHub runner.
+The `artifacts.yml` workflow runs once for the resulting `main` tree rather than once for
+every review iteration. It uses Autback's Buildx bridge with `--push` and `--metadata-file`,
+captures the immutable digest, forms a `repository@sha256:...` reference, and qualifies that
+exact production or site image remotely. The complete image is never transferred back to the
+GitHub runner.
 
 The independently published project runner can be built and activated with:
 

--- a/internal/app/tools/cireport/main.go
+++ b/internal/app/tools/cireport/main.go
@@ -92,22 +92,25 @@ func run() error {
 
 func (c *client) healthRuns(ctx context.Context, repo string, since time.Time) ([]platformci.HealthRun, error) {
 	var listedRuns []githubRun
-	for page := 1; page <= 10; page++ {
-		endpoint := fmt.Sprintf(
-			"https://api.github.com/repos/%s/actions/workflows/ci.yml/runs?per_page=100&page=%d&created=%%3E%%3D%s",
-			repo,
-			page,
-			since.Format("2006-01-02"),
-		)
-		var response struct {
-			Runs []githubRun `json:"workflow_runs"`
-		}
-		if err := c.getJSON(ctx, endpoint, &response); err != nil {
-			return nil, fmt.Errorf("list CI runs page %d: %w", page, err)
-		}
-		listedRuns = append(listedRuns, response.Runs...)
-		if len(response.Runs) < 100 {
-			break
+	for _, workflow := range []string{"ci.yml", "merge-validation.yml"} {
+		for page := 1; page <= 10; page++ {
+			endpoint := fmt.Sprintf(
+				"https://api.github.com/repos/%s/actions/workflows/%s/runs?per_page=100&page=%d&created=%%3E%%3D%s",
+				repo,
+				workflow,
+				page,
+				since.Format("2006-01-02"),
+			)
+			var response struct {
+				Runs []githubRun `json:"workflow_runs"`
+			}
+			if err := c.getJSON(ctx, endpoint, &response); err != nil {
+				return nil, fmt.Errorf("list %s runs page %d: %w", workflow, page, err)
+			}
+			listedRuns = append(listedRuns, response.Runs...)
+			if len(response.Runs) < 100 {
+				break
+			}
 		}
 	}
 
@@ -190,9 +193,20 @@ func (c *client) healthRun(ctx context.Context, repo string, run githubRun) (pla
 		Conclusion:      run.Conclusion,
 		DurationSeconds: int64(run.UpdatedAt.Sub(run.CreatedAt).Seconds()),
 		QueueSeconds:    queue,
+		Deferred:        deferredStackRun(jobs),
 		Plan:            plan,
 		Results:         results,
 	}, nil
+}
+
+func deferredStackRun(jobs []githubJob) bool {
+	conclusions := make(map[string]string, len(jobs))
+	for _, job := range jobs {
+		conclusions[job.Name] = job.Conclusion
+	}
+	return conclusions["Autback preflight"] == "skipped" &&
+		conclusions["GitHub CI (external pull request)"] == "skipped" &&
+		conclusions["CI gate"] == "success"
 }
 
 func (c *client) jobs(ctx context.Context, repo string, runID int64) ([]githubJob, error) {
@@ -356,6 +370,7 @@ func renderMarkdown(report platformci.HealthReport, days int) string {
 	fmt.Fprintf(&output, "| Metric | Value |\n|---|---:|\n")
 	fmt.Fprintf(&output, "| Runs | %d |\n", report.RunCount)
 	fmt.Fprintf(&output, "| Success / failure / cancelled | %d / %d / %d |\n", report.Successes, report.Failures, report.Cancellations)
+	fmt.Fprintf(&output, "| Deferred stack layers | %d |\n", report.Deferred)
 	fmt.Fprintf(&output, "| Full CI p50 / p95 | %s / %s |\n", formatSeconds(report.Full.P50Seconds), formatSeconds(report.Full.P95Seconds))
 	fmt.Fprintf(&output, "| Selective PR p50 / p95 | %s / %s |\n", formatSeconds(report.Selective.P50Seconds), formatSeconds(report.Selective.P95Seconds))
 	fmt.Fprintf(&output, "| Queue p50 / p95 | %s / %s |\n", formatSeconds(report.Queue.P50Seconds), formatSeconds(report.Queue.P95Seconds))

--- a/internal/app/tools/cireport/main_test.go
+++ b/internal/app/tools/cireport/main_test.go
@@ -28,6 +28,25 @@ func TestJobResultsAggregatesMatrixFailures(t *testing.T) {
 	}
 }
 
+func TestDeferredStackRunIsExcludedFromExecutionMetrics(t *testing.T) {
+	t.Parallel()
+
+	if !deferredStackRun([]githubJob{
+		{Name: "Autback preflight", Conclusion: "skipped"},
+		{Name: "GitHub CI (external pull request)", Conclusion: "skipped"},
+		{Name: "CI gate", Conclusion: "success"},
+	}) {
+		t.Fatal("non-top stack gate was not recognized as deferred")
+	}
+	if deferredStackRun([]githubJob{
+		{Name: "Autback preflight", Conclusion: "success"},
+		{Name: "GitHub CI (external pull request)", Conclusion: "skipped"},
+		{Name: "CI gate", Conclusion: "success"},
+	}) {
+		t.Fatal("executed top-stack preflight was classified as deferred")
+	}
+}
+
 func TestDecodePlanArchive(t *testing.T) {
 	t.Parallel()
 

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2306,11 +2306,19 @@ func TestDevelopmentServerTracksCompiledFallbackProcess(t *testing.T) {
 	}
 }
 
-func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
+func TestContinuousIntegrationWorkflowsAreStackAndMergeQueueAware(t *testing.T) {
 	root := repoRoot(t)
 	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
 	if err != nil {
 		t.Fatalf("read CI workflow: %v", err)
+	}
+	mergeWorkflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "merge-validation.yml"))
+	if err != nil {
+		t.Fatalf("read merge validation workflow: %v", err)
+	}
+	artifactWorkflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "artifacts.yml"))
+	if err != nil {
+		t.Fatalf("read main artifact workflow: %v", err)
 	}
 	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
 	if err != nil {
@@ -2320,35 +2328,30 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 	for _, want := range []string{
 		"name: CI",
 		"pull_request:",
-		"push:",
 		"workflow_dispatch:",
 		"autback-ci:",
-		"name: Autback CI",
+		"name: Autback preflight",
+		"github.event.pull_request.stack == null",
+		"github.event.pull_request.stack.position == github.event.pull_request.stack.size",
 		"environment: autback",
 		"id-token: write",
-		"packages: write",
 		"uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0",
 		"version: 0.1.6",
 		"service-url: ${{ vars.AUTBACK_SERVICE_URL }}",
 		"project: leapview",
 		"ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}",
 		"autback doctor",
+		"name: Classify runner contract",
+		"github.event.pull_request.stack.base.sha || github.event.pull_request.base.sha",
+		"name: Build candidate runner",
 		"--file Dockerfile.autback",
-		"autback build --",
-		"--platform linux/amd64",
-		"--push",
-		"--metadata-file",
-		"containerimage.digest",
-		"autback exec --image \"${AUTBACK_RUNNER_IMAGE}\" --timeout 90m",
+		"CANDIDATE_RUNNER: ${{ steps.runner.outputs.image }}",
+		"autback exec --timeout 90m",
 		"-- task ci:local",
 		"--cache go-build=/root/.cache/go-build",
 		"--cache go-mod=/go/pkg/mod",
 		"--cache bun=/root/.bun/install/cache",
 		"--cache terraform=/root/.cache/terraform",
-		"--file Dockerfile",
-		"task image:qualify:production IMAGE=\"${immutable_image}\"",
-		"--file Dockerfile.site",
-		"task image:qualify:site IMAGE=\"${immutable_image}\"",
 		"github-ci:",
 		"name: GitHub CI (external pull request)",
 		"github.event.pull_request.head.repo.full_name != github.repository",
@@ -2362,14 +2365,66 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 		"ci-gate:",
 		"name: CI gate",
 		"needs: [autback-ci, github-ci]",
+		"EXPENSIVE_REQUIRED:",
+		"Validation is deferred to the top of this stack",
 		"success:skipped|skipped:success",
 	} {
 		if !strings.Contains(text, want) {
-			t.Fatalf("CI workflow missing production gate fragment %q", want)
+			t.Fatalf("CI workflow missing stack-aware fragment %q", want)
 		}
 	}
 	autbackCI := workflowJobBlock(t, text, "autback-ci")
 	githubCI := workflowJobBlock(t, text, "github-ci")
+	for _, forbidden := range []string{
+		"push:",
+		"Build and qualify the production image remotely",
+		"Build and smoke-test the public site image remotely",
+		"--file Dockerfile.site",
+		"task image:qualify:production",
+		"task image:qualify:site",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("PR CI retains post-merge artifact responsibility %q", forbidden)
+		}
+	}
+	mergeText := string(mergeWorkflow)
+	for _, want := range []string{
+		"name: Merge validation",
+		"merge_group:",
+		"types: [checks_requested]",
+		"name: CI gate",
+		"environment: autback",
+		"id-token: write",
+		"BASE_SHA: ${{ github.event.merge_group.base_sha }}",
+		"name: Build candidate runner",
+		"--file Dockerfile.autback",
+		"CANDIDATE_RUNNER: ${{ steps.runner.outputs.image }}",
+		"autback exec --timeout 90m",
+		"-- task ci:local",
+	} {
+		if !strings.Contains(mergeText, want) {
+			t.Fatalf("merge validation workflow missing %q", want)
+		}
+	}
+	artifactText := string(artifactWorkflow)
+	for _, want := range []string{
+		"name: Main artifacts",
+		"push:",
+		"branches: [main]",
+		"name: Build and activate the project runner",
+		"if: ${{ steps.changes.outputs.runner == 'true' }}",
+		"autback image build",
+		"name: Build and qualify the production image remotely",
+		"--file Dockerfile",
+		"task image:qualify:production IMAGE=\"${immutable_image}\"",
+		"name: Build and smoke-test the public site image remotely",
+		"--file Dockerfile.site",
+		"task image:qualify:site IMAGE=\"${immutable_image}\"",
+	} {
+		if !strings.Contains(artifactText, want) {
+			t.Fatalf("main artifact workflow missing %q", want)
+		}
+	}
 	for _, forbidden := range []string{
 		"allow-source-fallback",
 		"autback-poc",
@@ -2380,16 +2435,16 @@ func TestContinuousIntegrationWorkflowRunsProductionGates(t *testing.T) {
 		"--memory",
 		"actions/upload-artifact@",
 	} {
-		if strings.Contains(text, forbidden) {
-			t.Fatalf("CI workflow retains superseded runner fragment %q", forbidden)
+		if strings.Contains(text+mergeText+artifactText, forbidden) {
+			t.Fatalf("CI workflows retain superseded runner fragment %q", forbidden)
 		}
 	}
 	if strings.Contains(githubCI, "id-token: write") || strings.Contains(githubCI, "setup-autback") {
 		t.Fatal("untrusted pull requests must not receive Autback OIDC access")
 	}
-	for _, want := range []string{"task ci:local", "Dockerfile.autback", "Dockerfile.site", "task image:qualify:production", "task image:qualify:site"} {
+	for _, want := range []string{"task ci:local", "autback exec --timeout 90m"} {
 		if !strings.Contains(autbackCI, want) {
-			t.Fatalf("trusted Autback CI must own the complete build contract: missing %q", want)
+			t.Fatalf("trusted Autback preflight must own the logical test contract: missing %q", want)
 		}
 	}
 	if _, err := os.Stat(filepath.Join(root, "scripts", "autback_exec.sh")); !os.IsNotExist(err) {

--- a/internal/platform/ci/health.go
+++ b/internal/platform/ci/health.go
@@ -15,6 +15,7 @@ type HealthRun struct {
 	Conclusion      string            `json:"conclusion"`
 	DurationSeconds int64             `json:"duration_seconds"`
 	QueueSeconds    int64             `json:"queue_seconds"`
+	Deferred        bool              `json:"deferred,omitempty"`
 	Plan            Plan              `json:"plan"`
 	Results         map[string]string `json:"results"`
 }
@@ -36,6 +37,7 @@ type HealthReport struct {
 	Successes     int                        `json:"successes"`
 	Failures      int                        `json:"failures"`
 	Cancellations int                        `json:"cancellations"`
+	Deferred      int                        `json:"deferred"`
 	Full          DurationMetric             `json:"full"`
 	Selective     DurationMetric             `json:"selective"`
 	Queue         DurationMetric             `json:"queue"`
@@ -63,6 +65,10 @@ func AnalyzeHealth(runs []HealthRun) HealthReport {
 		case "cancelled":
 			report.Cancellations++
 		}
+		if run.Deferred {
+			report.Deferred++
+			continue
+		}
 		if run.Attempt > 1 {
 			reruns++
 		}
@@ -84,13 +90,14 @@ func AnalyzeHealth(runs []HealthRun) HealthReport {
 	report.Full = durationMetric(fullDurations)
 	report.Selective = durationMetric(selectiveDurations)
 	report.Queue = durationMetric(queues)
-	if len(runs) > 0 {
-		report.RerunPercent = float64(reruns) * 100 / float64(len(runs))
+	executedRuns := len(runs) - report.Deferred
+	if executedRuns > 0 {
+		report.RerunPercent = float64(reruns) * 100 / float64(executedRuns)
 	}
 	for job, count := range selectedCounts {
 		percent := 0.0
-		if len(runs) > 0 {
-			percent = float64(count) * 100 / float64(len(runs))
+		if executedRuns > 0 {
+			percent = float64(count) * 100 / float64(executedRuns)
 		}
 		report.Selection[job] = SelectionMetric{Selected: count, Percent: percent}
 	}

--- a/internal/platform/ci/health_test.go
+++ b/internal/platform/ci/health_test.go
@@ -12,6 +12,9 @@ func TestAnalyzeHealth(t *testing.T) {
 	selective := Jobs{Docs: true, SiteImage: true}
 	runs := []HealthRun{
 		{
+			Event: "pull_request", Attempt: 2, DurationSeconds: 4, QueueSeconds: 2, Conclusion: "success", Deferred: true,
+		},
+		{
 			Event: "push", DurationSeconds: 600, QueueSeconds: 20, Conclusion: "success",
 			Plan:    Plan{Nominal: full, Effective: full},
 			Results: successfulResults(full),
@@ -42,8 +45,8 @@ func TestAnalyzeHealth(t *testing.T) {
 		},
 	}
 	got := AnalyzeHealth(runs)
-	if got.RunCount != 5 {
-		t.Fatalf("run count = %d, want 5", got.RunCount)
+	if got.RunCount != 6 || got.Deferred != 1 {
+		t.Fatalf("run count/deferred = %d/%d, want 6/1", got.RunCount, got.Deferred)
 	}
 	if got.Full.P95Seconds != 800 {
 		t.Fatalf("full p95 = %d, want 800", got.Full.P95Seconds)

--- a/package.json
+++ b/package.json
@@ -90,7 +90,9 @@
     "sql-formatter": "^15.8.2"
   },
   "overrides": {
-    "dompurify": "3.4.12"
+    "dompurify": "3.4.12",
+    "fast-uri": "3.1.5",
+    "undici": "7.29.0"
   },
   "trustedDependencies": [
     "@parcel/watcher"


### PR DESCRIPTION
## Summary

- run the complete Autback preflight only for standalone pull requests and the top entry in a native GitHub PR stack
- validate the exact merge candidate through a merge-queue `merge_group` workflow using the stable `CI gate` context
- move production and public-site image builds and qualification to one post-merge `main` workflow
- use the activated project runner by default and build an immutable candidate only when `Dockerfile.autback` changes
- exclude deferred lower stack layers from CI duration, queue, and rerun metrics
- document the stack, queue, and image lifecycle

## Worker model

The merge queue is designed for one candidate build at a time and can group up to ten pull requests. Parallelism remains inside the single `task ci:local` Autback operation so it can use the full shared VM.

## Validation

- `go test ./internal/app/tools/cireport ./internal/platform/ci ./internal/platform/architecture -count=1`
- `task ci:test:docs-site`
- `task generate`
- actionlint 1.7.7 on all changed workflows
- `git diff --check`
- canonical `task ci` job: `job01943ce4be7e39064980218e` (queued behind the existing five-layer stack workload)

## Rollout

The required Autback OIDC trusts for `merge-validation.yml` and `artifacts.yml` are installed. The repository ruleset remains disabled until this workflow is present on `main`; after merge it can safely require `CI gate` and activate the one-at-a-time merge queue.