### PR TITLE
ci: pin Autback 0.1.7

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -52,9 +52,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0
+        uses: flidai/autback/action/setup-autback@6aa834ba184e18ea2d4fef4b785332fa500f8871
         with:
-          version: 0.1.6
+          version: 0.1.7
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/autback.yml
+++ b/.github/workflows/autback.yml
@@ -33,9 +33,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0
+        uses: flidai/autback/action/setup-autback@6aa834ba184e18ea2d4fef4b785332fa500f8871
         with:
-          version: 0.1.6
+          version: 0.1.7
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0
+        uses: flidai/autback/action/setup-autback@6aa834ba184e18ea2d4fef4b785332fa500f8871
         with:
-          version: 0.1.6
+          version: 0.1.7
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -53,9 +53,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0
+        uses: flidai/autback/action/setup-autback@6aa834ba184e18ea2d4fef4b785332fa500f8871
         with:
-          version: 0.1.6
+          version: 0.1.7
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2335,8 +2335,8 @@ func TestContinuousIntegrationWorkflowsAreStackAndMergeQueueAware(t *testing.T) 
 		"github.event.pull_request.stack.position == github.event.pull_request.stack.size",
 		"environment: autback",
 		"id-token: write",
-		"uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0",
-		"version: 0.1.6",
+		"uses: flidai/autback/action/setup-autback@6aa834ba184e18ea2d4fef4b785332fa500f8871",
+		"version: 0.1.7",
 		"service-url: ${{ vars.AUTBACK_SERVICE_URL }}",
 		"project: leapview",
 		"ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}",
@@ -2535,6 +2535,25 @@ func TestContinuousIntegrationWorkflowsAreStackAndMergeQueueAware(t *testing.T) 
 	}
 }
 
+func TestAutbackWorkflowsPinHeartbeatCapableRelease(t *testing.T) {
+	root := repoRoot(t)
+	for _, name := range []string{"ci.yml", "merge-validation.yml", "artifacts.yml", "autback.yml"} {
+		data, err := os.ReadFile(filepath.Join(root, ".github", "workflows", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		text := string(data)
+		for _, want := range []string{
+			"uses: flidai/autback/action/setup-autback@6aa834ba184e18ea2d4fef4b785332fa500f8871",
+			"version: 0.1.7",
+		} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("%s must pin the heartbeat-capable Autback release: missing %q", name, want)
+			}
+		}
+	}
+}
+
 func TestContinuousIntegrationHealthWorkflowReportsAndAlerts(t *testing.T) {
 	root := repoRoot(t)
 	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci-health.yml"))
@@ -2620,8 +2639,8 @@ func TestLeapViewDeclaresGenericAutbackConsumerContract(t *testing.T) {
 		"environment: autback",
 		"packages: write",
 		"docker/login-action@",
-		"uses: flidai/autback/action/setup-autback@e3e9668cc4e5d81a2204fa014bb9de228fa510d0",
-		"version: 0.1.6",
+		"uses: flidai/autback/action/setup-autback@6aa834ba184e18ea2d4fef4b785332fa500f8871",
+		"version: 0.1.7",
 		"autback image build",
 		"--file Dockerfile.autback",
 		"--platform linux/amd64",


### PR DESCRIPTION
## Summary
- pin every Autback workflow to the merged heartbeat-capable action commit
- install the immutable Autback 0.1.7 release
- enforce the pin across preflight, merge validation, artifact qualification, and runner publication

## Why
Autback 0.1.6 did not renew a running BuildKit lease. The server correctly reaped the record after two minutes while BuildKit continued on its existing connection. Autback 0.1.7 heartbeats throughout Buildx and rejects incompatible clients before admission.

## Validation
- architecture regression tests
- actionlint
- Autback 0.1.7 release installer checksum verification
- 150-second live BuildKit lease probe