### PR TITLE
ci: pin Autback 0.1.9

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -52,9 +52,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@5c75e5f8097dcd1ec6da5291098c3208372d4135
+        uses: flidai/autback/action/setup-autback@64e43ddf1f2b3a0ab902bcf41cd76f119905d254
         with:
-          version: 0.1.8
+          version: 0.1.9
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/autback.yml
+++ b/.github/workflows/autback.yml
@@ -33,9 +33,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@5c75e5f8097dcd1ec6da5291098c3208372d4135
+        uses: flidai/autback/action/setup-autback@64e43ddf1f2b3a0ab902bcf41cd76f119905d254
         with:
-          version: 0.1.8
+          version: 0.1.9
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@5c75e5f8097dcd1ec6da5291098c3208372d4135
+        uses: flidai/autback/action/setup-autback@64e43ddf1f2b3a0ab902bcf41cd76f119905d254
         with:
-          version: 0.1.8
+          version: 0.1.9
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -53,9 +53,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@5c75e5f8097dcd1ec6da5291098c3208372d4135
+        uses: flidai/autback/action/setup-autback@64e43ddf1f2b3a0ab902bcf41cd76f119905d254
         with:
-          version: 0.1.8
+          version: 0.1.9
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2335,8 +2335,8 @@ func TestContinuousIntegrationWorkflowsAreStackAndMergeQueueAware(t *testing.T) 
 		"github.event.pull_request.stack.position == github.event.pull_request.stack.size",
 		"environment: autback",
 		"id-token: write",
-		"uses: flidai/autback/action/setup-autback@5c75e5f8097dcd1ec6da5291098c3208372d4135",
-		"version: 0.1.8",
+		"uses: flidai/autback/action/setup-autback@64e43ddf1f2b3a0ab902bcf41cd76f119905d254",
+		"version: 0.1.9",
 		"service-url: ${{ vars.AUTBACK_SERVICE_URL }}",
 		"project: leapview",
 		"ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}",
@@ -2544,8 +2544,8 @@ func TestAutbackWorkflowsPinHeartbeatCapableRelease(t *testing.T) {
 		}
 		text := string(data)
 		for _, want := range []string{
-			"uses: flidai/autback/action/setup-autback@5c75e5f8097dcd1ec6da5291098c3208372d4135",
-			"version: 0.1.8",
+			"uses: flidai/autback/action/setup-autback@64e43ddf1f2b3a0ab902bcf41cd76f119905d254",
+			"version: 0.1.9",
 		} {
 			if !strings.Contains(text, want) {
 				t.Fatalf("%s must pin the heartbeat-capable Autback release: missing %q", name, want)
@@ -2639,8 +2639,8 @@ func TestLeapViewDeclaresGenericAutbackConsumerContract(t *testing.T) {
 		"environment: autback",
 		"packages: write",
 		"docker/login-action@",
-		"uses: flidai/autback/action/setup-autback@5c75e5f8097dcd1ec6da5291098c3208372d4135",
-		"version: 0.1.8",
+		"uses: flidai/autback/action/setup-autback@64e43ddf1f2b3a0ab902bcf41cd76f119905d254",
+		"version: 0.1.9",
 		"autback image build",
 		"--file Dockerfile.autback",
 		"--platform linux/amd64",


### PR DESCRIPTION
Pins all workflows to Autback v0.1.9 and its immutable action commit. v0.1.9 acknowledges durable terminal build state before asynchronous capacity reclaim/FIFO advancement, preventing successful pushes from failing with a control-plane deadline.

Validated with the architecture contract and actionlint.