### PR TITLE
ci: update Autback to v0.1.12

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -52,9 +52,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@00f1d4814a2c7505b4d8021b590ee07d15fa09d6
+        uses: flidai/autback/action/setup-autback@238fef7b2d2f145a4b8a96cb0051d65ad26909aa
         with:
-          version: 0.1.11
+          version: 0.1.12
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/autback.yml
+++ b/.github/workflows/autback.yml
@@ -33,9 +33,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@00f1d4814a2c7505b4d8021b590ee07d15fa09d6
+        uses: flidai/autback/action/setup-autback@238fef7b2d2f145a4b8a96cb0051d65ad26909aa
         with:
-          version: 0.1.11
+          version: 0.1.12
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@00f1d4814a2c7505b4d8021b590ee07d15fa09d6
+        uses: flidai/autback/action/setup-autback@238fef7b2d2f145a4b8a96cb0051d65ad26909aa
         with:
-          version: 0.1.11
+          version: 0.1.12
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -53,9 +53,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Autback
-        uses: flidai/autback/action/setup-autback@00f1d4814a2c7505b4d8021b590ee07d15fa09d6
+        uses: flidai/autback/action/setup-autback@238fef7b2d2f145a4b8a96cb0051d65ad26909aa
         with:
-          version: 0.1.11
+          version: 0.1.12
           service-url: ${{ vars.AUTBACK_SERVICE_URL }}
           project: leapview
           ca-certificate: ${{ vars.AUTBACK_CA_CERTIFICATE }}


### PR DESCRIPTION
## Summary
- pin all Autback-backed workflows to the merged durable capacity-queue implementation
- install Autback CLI v0.1.12 to match the deployed server

## Verification
- `git diff --check`
- production server reports v0.1.12 and passes `autback doctor`
- low-capacity production smoke entered `Waiting for worker capacity...` instead of returning `RESOURCE_EXHAUSTED`