### PR TITLE
feat(analytics): enforce fanout-safe relationships

### DIFF
--- a/docs/articles/build/semantic-model.md
+++ b/docs/articles/build/semantic-model.md
@@ -79,7 +79,7 @@ Metrics compose named semantic values. `safe_divide` makes the denominator-zero 
 
 ### Validate relationships
 
-For `many_to_one`, confirm the `to` field is unique and type-compatible with the `from` field. Sample the data, not just the schema. A duplicate customer key can multiply order rows and inflate every order measure that traverses the relationship.
+For `many_to_one`, the `to` field must be the target table's declared primary key and must be type-compatible with the `from` field. For `one_to_one`, both endpoints must be their tables' declared primary keys. LeapView rejects `one_to_many` and `many_to_many` relationships because they do not preserve the fact grain. Sample the data, not just the schema: a declared key that contains duplicates can still multiply fact rows and inflate every measure that traverses the relationship.
 
 Prefer one unambiguous relationship path. If the model needs role-playing dimensions or several paths between the same tables, give each path an explicit design rather than relying on query order.
 

--- a/docs/articles/concepts/semantic-models.md
+++ b/docs/articles/concepts/semantic-models.md
@@ -59,7 +59,7 @@ relationships:
     cardinality: many_to_one
 ```
 
-LeapView supports the cardinalities documented by the generated schema. The declared direction matters: the `to` side of a `many_to_one` relationship should be unique for the join field. A false cardinality declaration can duplicate fact rows and corrupt measures, so confirm it from data rather than naming convention.
+LeapView accepts only cardinalities that provably preserve the fact grain. For `many_to_one`, the `to` field must be the target table's declared primary key. For `one_to_one`, both fields must be their tables' declared primary keys, which makes the relationship safe in either direction. Reverse `many_to_one`, `one_to_many`, and `many_to_many` traversal is rejected because it can duplicate fact rows and corrupt measures. Primary-key declarations must still match the real data, so confirm uniqueness from data rather than naming convention.
 
 Avoid multiple plausible paths between the same facts and dimensions. Ambiguous paths should be redesigned or rejected instead of letting query order determine results.
 
@@ -73,7 +73,7 @@ Before publishing a model, verify that:
 
 - every table exists in the workspace;
 - relationship fields have compatible types;
-- declared cardinalities match observed uniqueness;
+- every relationship's `one` endpoint is the table's declared primary key, and those keys are unique in the data;
 - measures identify the correct fact and aggregation;
 - empty-result and formatting behavior are intentional;
 - labels and descriptions are understandable outside the authoring team;

--- a/internal/analytics/model/model.go
+++ b/internal/analytics/model/model.go
@@ -700,16 +700,49 @@ func sameStringSet(left []string, right []string) bool {
 func (m *Model) validateSemanticGraph() error {
 	for _, relationship := range m.Relationships {
 		if relationship.Cardinality != "many_to_one" && relationship.Cardinality != "one_to_one" {
-			return fmt.Errorf("unsafe relationship path: cardinality %q from %q to %q", relationship.Cardinality, relationship.From, relationship.To)
+			return fmt.Errorf(
+				"relationship %q has unsafe cardinality %q from %q to %q",
+				relationship.ID,
+				relationship.Cardinality,
+				relationship.From,
+				relationship.To,
+			)
 		}
-		if _, err := m.validateRelationshipEndpoint("from", relationship.From); err != nil {
+		fromTable, err := m.validateRelationshipEndpoint("from", relationship.From)
+		if err != nil {
 			return err
 		}
-		if _, err := m.validateRelationshipEndpoint("to", relationship.To); err != nil {
+		toTable, err := m.validateRelationshipEndpoint("to", relationship.To)
+		if err != nil {
+			return err
+		}
+		_, fromField, _ := splitSemanticField(relationship.From)
+		_, toField, _ := splitSemanticField(relationship.To)
+		if relationship.Cardinality == "one_to_one" {
+			if err := m.requireRelationshipPrimaryKey(relationship, fromTable, fromField); err != nil {
+				return err
+			}
+		}
+		if err := m.requireRelationshipPrimaryKey(relationship, toTable, toField); err != nil {
 			return err
 		}
 	}
 	return m.validateSemanticDefinitions()
+}
+
+func (m *Model) requireRelationshipPrimaryKey(relationship Relationship, tableName, fieldName string) error {
+	primaryKey := m.Tables[tableName].PrimaryKey
+	if fieldName == primaryKey {
+		return nil
+	}
+	return fmt.Errorf(
+		"relationship %q %s endpoint %q must be primary key %q of table %q",
+		relationship.ID,
+		relationship.Cardinality,
+		tableName+"."+fieldName,
+		primaryKey,
+		tableName,
+	)
 }
 
 func (m *Model) validateRelationshipEndpoint(role string, endpoint string) (string, error) {

--- a/internal/analytics/model/relationships.go
+++ b/internal/analytics/model/relationships.go
@@ -5,6 +5,12 @@ import (
 	"sort"
 )
 
+// SafeRelationshipPath resolves joins that preserve the base table's grain.
+// A many-to-one relationship is traversable only from its many side, while a
+// one-to-one relationship is traversable in either direction. Model validation
+// proves every "one" endpoint with the table's declared primary key; reverse
+// many-to-one, one-to-many, and many-to-many paths are deliberately unavailable
+// because they can multiply measures.
 func (m *Model) SafeRelationshipPath(base, target string) ([]Relationship, error) {
 	if base == target {
 		return nil, nil

--- a/internal/analytics/model/relationships_test.go
+++ b/internal/analytics/model/relationships_test.go
@@ -1,0 +1,136 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRelationshipCardinalityMatrixRequiresKeyedOneEndpoints(t *testing.T) {
+	tests := []struct {
+		name         string
+		relationship Relationship
+		wantErr      string
+	}{
+		{
+			name: "many to one targets primary key",
+			relationship: Relationship{
+				ID: "orders_customers", From: "orders.customer_id", To: "customers.customer_id", Cardinality: "many_to_one",
+			},
+		},
+		{
+			name: "many to one rejects non key target",
+			relationship: Relationship{
+				ID: "orders_customers_by_region", From: "orders.region", To: "customers.region", Cardinality: "many_to_one",
+			},
+			wantErr: `relationship "orders_customers_by_region" many_to_one endpoint "customers.region" must be primary key "customer_id"`,
+		},
+		{
+			name: "one to one requires both primary keys",
+			relationship: Relationship{
+				ID: "customers_profiles", From: "customers.customer_id", To: "profiles.customer_id", Cardinality: "one_to_one",
+			},
+		},
+		{
+			name: "one to one rejects non key source",
+			relationship: Relationship{
+				ID: "customers_profiles_by_region", From: "customers.region", To: "profiles.customer_id", Cardinality: "one_to_one",
+			},
+			wantErr: `relationship "customers_profiles_by_region" one_to_one endpoint "customers.region" must be primary key "customer_id"`,
+		},
+		{
+			name: "one to one rejects non key target",
+			relationship: Relationship{
+				ID: "customers_profiles_by_tier", From: "customers.customer_id", To: "profiles.tier", Cardinality: "one_to_one",
+			},
+			wantErr: `relationship "customers_profiles_by_tier" one_to_one endpoint "profiles.tier" must be primary key "customer_id"`,
+		},
+		{
+			name: "one to many is unsafe",
+			relationship: Relationship{
+				ID: "customers_orders", From: "customers.customer_id", To: "orders.customer_id", Cardinality: "one_to_many",
+			},
+			wantErr: `relationship "customers_orders" has unsafe cardinality "one_to_many"`,
+		},
+		{
+			name: "many to many is unsafe",
+			relationship: Relationship{
+				ID: "orders_tags", From: "orders.order_id", To: "tags.order_id", Cardinality: "many_to_many",
+			},
+			wantErr: `relationship "orders_tags" has unsafe cardinality "many_to_many"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := relationshipMatrixModel()
+			model.Relationships = []Relationship{test.relationship}
+			err := model.validateSemanticGraph()
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateSemanticGraph() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("validateSemanticGraph() error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestSafeRelationshipPathRejectsCyclicAlternativePaths(t *testing.T) {
+	model := relationshipMatrixModel()
+	model.Relationships = []Relationship{
+		{ID: "customers_profiles", From: "customers.customer_id", To: "profiles.customer_id", Cardinality: "one_to_one"},
+		{ID: "profiles_accounts", From: "profiles.customer_id", To: "accounts.customer_id", Cardinality: "one_to_one"},
+		{ID: "accounts_customers", From: "accounts.customer_id", To: "customers.customer_id", Cardinality: "one_to_one"},
+	}
+
+	_, err := model.SafeRelationshipPath("customers", "accounts")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous relationship path") {
+		t.Fatalf("SafeRelationshipPath() error = %v, want cyclic ambiguity rejection", err)
+	}
+	_, err = model.SafeRelationshipPath("customers", "tags")
+	if err == nil || !strings.Contains(err.Error(), "no safe relationship path") {
+		t.Fatalf("SafeRelationshipPath() error = %v, want unreachable target rejection", err)
+	}
+}
+
+func relationshipMatrixModel() *Model {
+	return &Model{
+		Name: "fanout_matrix",
+		Tables: map[string]Table{
+			"orders": {
+				PrimaryKey: "order_id",
+				Dimensions: map[string]MetricDimension{
+					"order_id": {Type: "string"}, "customer_id": {Type: "string"}, "region": {Type: "string"},
+				},
+			},
+			"customers": {
+				PrimaryKey: "customer_id",
+				Dimensions: map[string]MetricDimension{
+					"customer_id": {Type: "string"}, "region": {Type: "string"},
+				},
+			},
+			"profiles": {
+				PrimaryKey: "customer_id",
+				Dimensions: map[string]MetricDimension{
+					"customer_id": {Type: "string"}, "tier": {Type: "string"},
+				},
+			},
+			"accounts": {
+				PrimaryKey: "customer_id",
+				Dimensions: map[string]MetricDimension{"customer_id": {Type: "string"}},
+			},
+			"tags": {
+				PrimaryKey: "tag_id",
+				Dimensions: map[string]MetricDimension{
+					"tag_id": {Type: "string"}, "order_id": {Type: "string"},
+				},
+			},
+		},
+		Dimensions: map[string]SemanticDimension{},
+		Measures:   map[string]MetricMeasure{},
+		Metrics:    map[string]Metric{},
+	}
+}

--- a/internal/analytics/query/fanout_integration_test.go
+++ b/internal/analytics/query/fanout_integration_test.go
@@ -1,0 +1,291 @@
+package query
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+)
+
+func TestFanoutMatrixSafeRelationshipPathsPreserveFactGrain(t *testing.T) {
+	db := openFanoutDatabase(t, []string{
+		"CREATE TABLE model.orders(order_id VARCHAR, customer_id VARCHAR, revenue DOUBLE)",
+		"INSERT INTO model.orders VALUES ('o1', 'a', 10), ('o2', 'a', 20), ('o3', 'b', 30)",
+		"CREATE TABLE model.customers(customer_id VARCHAR, region VARCHAR)",
+		"INSERT INTO model.customers VALUES ('a', 'north'), ('b', 'south')",
+		"CREATE TABLE model.profiles(customer_id VARCHAR, tier VARCHAR)",
+		"INSERT INTO model.profiles VALUES ('a', 'gold'), ('b', 'silver')",
+	})
+	defer db.Close()
+
+	planner := NewPlanner(singleFactFanoutModel())
+	plan, err := planner.Plan(Request{
+		Dimensions: []Field{{Field: "region"}, {Field: "tier"}},
+		Measures:   []Field{{Field: "order_count"}, {Field: "revenue"}},
+		Sort:       []Sort{{Field: "region", Direction: "asc"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := db.Query(plan.SQL, plan.Args...)
+	if err != nil {
+		t.Fatalf("execute many-to-one plus one-to-one plan:\n%s\n%v", plan.SQL, err)
+	}
+	got := map[string]struct {
+		count   int
+		revenue float64
+	}{}
+	for rows.Next() {
+		var region, tier string
+		var count int
+		var revenue float64
+		if err := rows.Scan(&region, &tier, &count, &revenue); err != nil {
+			rows.Close()
+			t.Fatal(err)
+		}
+		got[region+"/"+tier] = struct {
+			count   int
+			revenue float64
+		}{count: count, revenue: revenue}
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]struct {
+		count   int
+		revenue float64
+	}{
+		"north/gold":   {count: 2, revenue: 30},
+		"south/silver": {count: 1, revenue: 30},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("joined measures = %#v, want %#v", got, want)
+	}
+
+	reverse, err := planner.Plan(Request{
+		Dimensions: []Field{{Field: "profile_region"}},
+		Measures:   []Field{{Field: "profile_count"}},
+		Sort:       []Sort{{Field: "profile_region", Direction: "asc"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reverseRows, err := db.Query(reverse.SQL, reverse.Args...)
+	if err != nil {
+		t.Fatalf("execute reverse one-to-one plan:\n%s\n%v", reverse.SQL, err)
+	}
+	reverseGot := map[string]int{}
+	for reverseRows.Next() {
+		var region string
+		var count int
+		if err := reverseRows.Scan(&region, &count); err != nil {
+			reverseRows.Close()
+			t.Fatal(err)
+		}
+		reverseGot[region] = count
+	}
+	if err := reverseRows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if reverseGot["north"] != 1 || reverseGot["south"] != 1 || len(reverseGot) != 2 {
+		t.Fatalf("reverse one-to-one counts = %#v", reverseGot)
+	}
+}
+
+func TestFanoutMatrixMultiFactPlansAggregateBeforeStitching(t *testing.T) {
+	db := openFanoutDatabase(t, []string{
+		"CREATE TABLE model.orders(order_id VARCHAR, customer_id VARCHAR)",
+		"INSERT INTO model.orders VALUES ('o1', 'a'), ('o2', 'a'), ('o3', 'b')",
+		"CREATE TABLE model.returns(return_id VARCHAR, customer_id VARCHAR)",
+		"INSERT INTO model.returns VALUES ('r1', 'a'), ('r2', 'c')",
+		"CREATE TABLE model.clicks(click_id VARCHAR, customer_id VARCHAR)",
+		"INSERT INTO model.clicks VALUES ('c1', 'a'), ('c2', 'c'), ('c3', 'c'), ('c4', 'c')",
+		"CREATE TABLE model.customers(customer_id VARCHAR, region VARCHAR)",
+		"INSERT INTO model.customers VALUES ('a', 'north'), ('b', 'south'), ('c', 'north')",
+	})
+	defer db.Close()
+
+	planner := NewPlanner(multiFactFanoutModel())
+	tests := []struct {
+		name     string
+		measures []Field
+		want     map[string][]int
+	}{
+		{
+			name:     "two facts",
+			measures: []Field{{Field: "order_count"}, {Field: "return_count"}},
+			want: map[string][]int{
+				"north": {2, 2},
+				"south": {1, 0},
+			},
+		},
+		{
+			name:     "three facts",
+			measures: []Field{{Field: "order_count"}, {Field: "return_count"}, {Field: "click_count"}},
+			want: map[string][]int{
+				"north": {2, 2, 4},
+				"south": {1, 0, 0},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plan, err := planner.Plan(Request{
+				Dimensions: []Field{{Field: "region"}},
+				Measures:   test.measures,
+				Sort:       []Sort{{Field: "region", Direction: "asc"}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.Mode != "multi_fact" {
+				t.Fatalf("plan mode = %q, want multi_fact", plan.Mode)
+			}
+			rows, err := db.Query(plan.SQL, plan.Args...)
+			if err != nil {
+				t.Fatalf("execute %s plan:\n%s\n%v", test.name, plan.SQL, err)
+			}
+			got := map[string][]int{}
+			for rows.Next() {
+				var region string
+				values := make([]int, len(test.measures))
+				destinations := make([]any, 0, len(values)+1)
+				destinations = append(destinations, &region)
+				for index := range values {
+					destinations = append(destinations, &values[index])
+				}
+				if err := rows.Scan(destinations...); err != nil {
+					rows.Close()
+					t.Fatal(err)
+				}
+				got[region] = values
+			}
+			if err := rows.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("%s results = %#v, want %#v", test.name, got, test.want)
+			}
+		})
+	}
+}
+
+func openFanoutDatabase(t *testing.T, statements []string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("CREATE SCHEMA model"); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			db.Close()
+			t.Fatalf("execute %q: %v", statement, err)
+		}
+	}
+	return db
+}
+
+func singleFactFanoutModel() *semanticmodel.Model {
+	return &semanticmodel.Model{
+		Name: "single_fact_fanout",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				PrimaryKey: "order_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"order_id": {Type: "string"}, "customer_id": {Type: "string"}, "revenue": {Type: "number"},
+				},
+			},
+			"customers": {
+				PrimaryKey: "customer_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"customer_id": {Type: "string"}, "region": {Type: "string"},
+				},
+			},
+			"profiles": {
+				PrimaryKey: "customer_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"customer_id": {Type: "string"}, "tier": {Type: "string"},
+				},
+			},
+		},
+		Relationships: []semanticmodel.Relationship{
+			{ID: "orders_customers", From: "orders.customer_id", To: "customers.customer_id", Cardinality: "many_to_one"},
+			{ID: "customers_profiles", From: "customers.customer_id", To: "profiles.customer_id", Cardinality: "one_to_one"},
+		},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"region": {Type: "string", Bindings: map[string]semanticmodel.DimensionBinding{
+				"orders": {Field: "customers.region", Path: []string{"orders_customers"}},
+			}},
+			"tier": {Type: "string", Bindings: map[string]semanticmodel.DimensionBinding{
+				"orders": {Field: "profiles.tier", Path: []string{"orders_customers", "customers_profiles"}},
+			}},
+			"profile_region": {Type: "string", Bindings: map[string]semanticmodel.DimensionBinding{
+				"profiles": {Field: "customers.region", Path: []string{"customers_profiles"}},
+			}},
+		},
+		Measures: map[string]semanticmodel.MetricMeasure{
+			"order_count":   {Fact: "orders", Aggregation: "count", Empty: "zero"},
+			"revenue":       {Fact: "orders", Aggregation: "sum", Input: semanticmodel.MeasureInput{Field: "orders.revenue"}, Empty: "zero"},
+			"profile_count": {Fact: "profiles", Aggregation: "count", Empty: "zero"},
+		},
+		Metrics: map[string]semanticmodel.Metric{},
+	}
+}
+
+func multiFactFanoutModel() *semanticmodel.Model {
+	return &semanticmodel.Model{
+		Name: "multi_fact_fanout",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				PrimaryKey: "order_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"order_id": {Type: "string"}, "customer_id": {Type: "string"},
+				},
+			},
+			"returns": {
+				PrimaryKey: "return_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"return_id": {Type: "string"}, "customer_id": {Type: "string"},
+				},
+			},
+			"clicks": {
+				PrimaryKey: "click_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"click_id": {Type: "string"}, "customer_id": {Type: "string"},
+				},
+			},
+			"customers": {
+				PrimaryKey: "customer_id",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"customer_id": {Type: "string"}, "region": {Type: "string"},
+				},
+			},
+		},
+		Relationships: []semanticmodel.Relationship{
+			{ID: "orders_customers", From: "orders.customer_id", To: "customers.customer_id", Cardinality: "many_to_one"},
+			{ID: "returns_customers", From: "returns.customer_id", To: "customers.customer_id", Cardinality: "many_to_one"},
+			{ID: "clicks_customers", From: "clicks.customer_id", To: "customers.customer_id", Cardinality: "many_to_one"},
+		},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"region": {Type: "string", Bindings: map[string]semanticmodel.DimensionBinding{
+				"orders":  {Field: "customers.region", Path: []string{"orders_customers"}},
+				"returns": {Field: "customers.region", Path: []string{"returns_customers"}},
+				"clicks":  {Field: "customers.region", Path: []string{"clicks_customers"}},
+			}},
+		},
+		Measures: map[string]semanticmodel.MetricMeasure{
+			"order_count":  {Fact: "orders", Aggregation: "count", Empty: "zero"},
+			"return_count": {Fact: "returns", Aggregation: "count", Empty: "zero"},
+			"click_count":  {Fact: "clicks", Aggregation: "count", Empty: "zero"},
+		},
+		Metrics: map[string]semanticmodel.Metric{},
+	}
+}

--- a/internal/analytics/query/multi_fact.go
+++ b/internal/analytics/query/multi_fact.go
@@ -44,6 +44,10 @@ type aggregateResolution struct {
 	Masks      columnMaskSet
 }
 
+// planAggregate preserves fact grain by compiling every fact through only safe
+// relationship paths, aggregating each fact independently, and stitching the
+// resulting grouped rows. Facts are never joined to each other before their
+// measures have been reduced to the requested conformed dimensions.
 func (p *Planner) planAggregate(request Request) (Plan, error) {
 	resolved, err := p.resolveAggregate(request)
 	if err != nil {


### PR DESCRIPTION
Stack 1/7. Implements LEA-297.

Summary:
- require primary-key proof for every relationship one endpoint
- reject fanout-unsafe cardinalities with actionable diagnostics
- add executable single-fact and two-/three-fact correctness matrices
- document the enforced semantic relationship contract

Inspired by Cube JoinGraph multiplication-factor and primary-key checks at Sourcebook revision 9052c686ed4e.

Validation:
- go test -tags=duckdb_arrow ./internal/analytics/model ./internal/analytics/query ./internal/project/compiler ./docs
- focused race tests
- generated-contract checks

Linear: https://linear.app/leapstack/issue/LEA-297/add-a-semantic-query-fanout-correctness-matrix