### PR TITLE
feat(access): define data policy composition algebra

### DIFF
--- a/docs/articles/security/authorization.md
+++ b/docs/articles/security/authorization.md
@@ -57,6 +57,34 @@ Policy expressions are part of the governed server query boundary. Apply them co
 
 Test policies with representative users, including aggregates. Row filtering can change totals, distinct counts, relationship behavior, and whether an empty result is expected. Column masking must preserve safe types and must not leak the raw value through labels, tooltips, exports, or alternative datasets.
 
+### Policy composition
+
+LeapView composes every applicable policy before planning a raw, aggregate,
+spatial, or multi-fact query. The composition rules are independent of query
+surface and repository traversal order:
+
+| Applicable policies | Effective restriction |
+| --- | --- |
+| Multiple row filters for the same subject on the same protected object | AND |
+| Row filters for different applicable subjects on the same protected object | OR |
+| A global row filter plus subject-specific filters | Global filter AND subject alternatives |
+| Row filters inherited from different protected objects | AND |
+| A subject group containing only `{"allowAll": true}` | That subject alternative adds no row restriction; global and parent restrictions still apply |
+| No applicable row policy | No additional row restriction |
+| Candidate or preview restriction | AND with all active policy results |
+| Equivalent masks on the same selected field | One mask |
+| Different masks on the same selected field | Query rejected with the conflicting policy IDs |
+
+Within one row-policy expression, entries in `filters` are also ANDed. Use
+separate subject policies to express alternative entitlements; do not encode
+authorization alternatives in reader-controlled dashboard filters. `allowAll`
+is explicit so an empty or malformed expression cannot accidentally broaden
+access.
+
+Policy IDs remain part of the effective-policy fingerprint and query audit
+identity. Composition errors name the relevant IDs, allowing an administrator
+to resolve contradictory masks without relying on policy load order.
+
 ## Owners and administration
 
 Ownership and platform administration are distinct from ordinary workspace use. Keep platform-wide `MANAGE_PLATFORM`, workspace `MANAGE_GRANTS`, deployment, refresh, query, and view privileges separated according to operational responsibility.

--- a/internal/dashboard/queryauthz/data_authorization.go
+++ b/internal/dashboard/queryauthz/data_authorization.go
@@ -708,7 +708,11 @@ func (m Metrics) applyDataPolicies(ctx context.Context, request dataquery.Query,
 	if err != nil {
 		return request, nil, err
 	}
-	request.Filters = append(request.Filters, m.resolvePolicyFilterFacts(request, composition.Filters)...)
+	policyFilters, err := m.resolvePolicyFilterFacts(request, composition.Filters)
+	if err != nil {
+		return request, nil, err
+	}
+	request.Filters = append(request.Filters, policyFilters...)
 	columnMasks, err := selectedColumnMasks(request, composition.Masks)
 	if err != nil {
 		return request, nil, err
@@ -717,45 +721,101 @@ func (m Metrics) applyDataPolicies(ctx context.Context, request dataquery.Query,
 	return request, policies.all(), nil
 }
 
-func (m Metrics) resolvePolicyFilterFacts(request dataquery.Query, filters []dataquery.Filter) []dataquery.Filter {
+func (m Metrics) resolvePolicyFilterFacts(request dataquery.Query, filters []dataquery.Filter) ([]dataquery.Filter, error) {
 	if request.Kind != dataquery.KindSemanticAggregate || request.Target != "" {
-		return filters
+		return filters, nil
 	}
 	model, ok := m.Metrics.SemanticModel(request.ModelID)
 	if !ok || model == nil {
-		return filters
+		return filters, nil
 	}
 	dependencies, err := semanticquery.ResolveDependencies(model, semanticquery.Request{
 		Dimensions: dataFieldsToSemanticFields(request.Fields), Measures: dataFieldsToSemanticFields(request.Measures),
 		Time: semanticquery.Time{Field: request.Time.Field, Grain: request.Time.Grain, Alias: request.Time.Alias},
 	})
 	if err != nil {
-		return filters
+		return nil, fmt.Errorf("resolve policy filter facts: %w", err)
 	}
-	out := []dataquery.Filter{}
+	out := make([]dataquery.Filter, 0, len(filters))
 	for _, filter := range filters {
-		if filter.Field == "" || filter.Fact != "" || len(filter.Groups) > 0 {
-			out = append(out, filter)
-			continue
-		}
-		if _, conformed := model.Dimensions[filter.Field]; conformed {
-			out = append(out, filter)
-			continue
-		}
-		physical, err := model.ResolveDimension(filter.Field)
+		resolved, err := resolvePolicyFilterFact(model, dependencies.Facts, filter)
 		if err != nil {
-			out = append(out, filter)
+			return nil, err
+		}
+		out = append(out, resolved...)
+	}
+	return out, nil
+}
+
+func resolvePolicyFilterFact(model *semanticmodel.Model, facts []string, filter dataquery.Filter) ([]dataquery.Filter, error) {
+	if len(filter.Groups) > 0 {
+		resolved := filter
+		resolved.Groups = make([]dataquery.FilterGroup, len(filter.Groups))
+		for groupIndex, group := range filter.Groups {
+			children := make([]dataquery.Filter, 0, len(group.Filters))
+			for _, child := range group.Filters {
+				resolvedChildren, err := resolvePolicyFilterFact(model, facts, child)
+				if err != nil {
+					return nil, err
+				}
+				children = append(children, resolvedChildren...)
+			}
+			resolved.Groups[groupIndex] = dataquery.FilterGroup{Filters: children}
+		}
+		return []dataquery.Filter{resolved}, nil
+	}
+	if filter.Fact != "" || (filter.Field == "" && filter.Spatial == nil) {
+		return []dataquery.Filter{filter}, nil
+	}
+
+	refs := []string{filter.Field}
+	if filter.Spatial != nil {
+		if filter.Spatial.Fact != "" {
+			return []dataquery.Filter{filter}, nil
+		}
+		refs = []string{filter.Spatial.LatitudeField, filter.Spatial.LongitudeField}
+	}
+	tables := map[string]struct{}{}
+	for _, ref := range refs {
+		if _, conformed := model.Dimensions[ref]; conformed {
 			continue
 		}
-		for _, fact := range dependencies.Facts {
-			if _, err := model.SafeRelationshipPath(fact, physical.Table); err == nil {
-				copy := filter
-				copy.Fact = fact
-				out = append(out, copy)
+		physical, err := model.ResolveDimension(ref)
+		if err != nil {
+			return nil, fmt.Errorf("resolve policy filter field %q: %w", ref, err)
+		}
+		tables[physical.Table] = struct{}{}
+	}
+	if len(tables) == 0 {
+		return []dataquery.Filter{filter}, nil
+	}
+
+	resolved := make([]dataquery.Filter, 0, len(facts))
+	for _, fact := range facts {
+		compatible := true
+		for table := range tables {
+			if _, err := model.SafeRelationshipPath(fact, table); err != nil {
+				compatible = false
+				break
 			}
 		}
+		if !compatible {
+			continue
+		}
+		copy := filter
+		if copy.Spatial != nil {
+			spatial := *copy.Spatial
+			spatial.Fact = fact
+			copy.Spatial = &spatial
+		} else {
+			copy.Fact = fact
+		}
+		resolved = append(resolved, copy)
 	}
-	return out
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("policy filter fields %s are not reachable from participating facts %s", strings.Join(refs, ", "), strings.Join(facts, ", "))
+	}
+	return resolved, nil
 }
 
 func uniqueStrings(values []string) []string {
@@ -999,7 +1059,15 @@ func rowFiltersFromExpression(policyID string, expression dataPolicyExpression) 
 		return nil, fmt.Errorf("row_filter data policy %q cannot combine field with filters", policyID)
 	}
 	if len(expression.Filters) > 0 {
-		return expression.Filters, nil
+		filters := make([]dataquery.Filter, len(expression.Filters))
+		for index, filter := range expression.Filters {
+			normalized, err := normalizePolicyFilter(policyID, filter)
+			if err != nil {
+				return nil, err
+			}
+			filters[index] = normalized
+		}
+		return filters, nil
 	}
 	if strings.TrimSpace(expression.Field) == "" {
 		return nil, fmt.Errorf("row_filter data policy %q requires field or filters", policyID)
@@ -1015,7 +1083,91 @@ func rowFiltersFromExpression(policyID string, expression dataPolicyExpression) 
 	if len(values) == 0 {
 		return nil, fmt.Errorf("row_filter data policy %q requires values", policyID)
 	}
-	return []dataquery.Filter{{Field: expression.Field, Operator: operator, Values: values}}, nil
+	return []dataquery.Filter{{Field: strings.TrimSpace(expression.Field), Operator: operator, Values: values}}, nil
+}
+
+func normalizePolicyFilter(policyID string, filter dataquery.Filter) (dataquery.Filter, error) {
+	field := strings.TrimSpace(filter.Field)
+	hasField := field != ""
+	hasGroups := len(filter.Groups) > 0
+	hasSpatial := filter.Spatial != nil
+	forms := 0
+	for _, present := range []bool{hasField, hasGroups, hasSpatial} {
+		if present {
+			forms++
+		}
+	}
+	if forms != 1 {
+		return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q filter requires exactly one of field, groups, or spatial", policyID)
+	}
+
+	if hasGroups {
+		if strings.TrimSpace(filter.Fact) != "" || strings.TrimSpace(filter.Operator) != "" || len(filter.Values) != 0 {
+			return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q grouped filter cannot combine scalar fields", policyID)
+		}
+		normalized := dataquery.Filter{Groups: make([]dataquery.FilterGroup, len(filter.Groups))}
+		for groupIndex, group := range filter.Groups {
+			if len(group.Filters) == 0 {
+				return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q contains an empty filter group", policyID)
+			}
+			children := make([]dataquery.Filter, len(group.Filters))
+			for childIndex, child := range group.Filters {
+				resolved, err := normalizePolicyFilter(policyID, child)
+				if err != nil {
+					return dataquery.Filter{}, err
+				}
+				children[childIndex] = resolved
+			}
+			normalized.Groups[groupIndex] = dataquery.FilterGroup{Filters: children}
+		}
+		return normalized, nil
+	}
+
+	if hasSpatial {
+		if strings.TrimSpace(filter.Fact) != "" || strings.TrimSpace(filter.Operator) != "" || len(filter.Values) != 0 {
+			return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q spatial filter cannot combine scalar fields", policyID)
+		}
+		spatial := *filter.Spatial
+		spatial.Kind = strings.ToLower(strings.TrimSpace(spatial.Kind))
+		spatial.LatitudeField = strings.TrimSpace(spatial.LatitudeField)
+		spatial.LongitudeField = strings.TrimSpace(spatial.LongitudeField)
+		spatial.Fact = strings.TrimSpace(spatial.Fact)
+		if spatial.LatitudeField == "" || spatial.LongitudeField == "" {
+			return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q spatial filter requires coordinate fields", policyID)
+		}
+		if err := semanticquery.ValidateSpatialFilter(*dataSpatialFilterToSemantic(&spatial)); err != nil {
+			return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q spatial filter is invalid: %w", policyID, err)
+		}
+		return dataquery.Filter{Spatial: &spatial}, nil
+	}
+
+	if len(filter.Groups) != 0 || filter.Spatial != nil {
+		return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q scalar filter cannot combine other forms", policyID)
+	}
+	operator := strings.ToLower(strings.TrimSpace(filter.Operator))
+	if operator == "" {
+		operator = "equals"
+	}
+	valueCount := len(filter.Values)
+	switch operator {
+	case "equals", "not_equals", "contains", "not_contains", "starts_with", "ends_with", "greater_than", "greater_than_or_equal", "less_than", "less_than_or_equal":
+		if valueCount != 1 {
+			return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q operator %q requires exactly one value", policyID, operator)
+		}
+	case "in", "not_in":
+		if valueCount == 0 {
+			return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q operator %q requires at least one value", policyID, operator)
+		}
+	case "is_null", "is_not_null":
+		if valueCount != 0 {
+			return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q operator %q does not accept values", policyID, operator)
+		}
+	default:
+		return dataquery.Filter{}, fmt.Errorf("row_filter data policy %q has unsupported operator %q", policyID, operator)
+	}
+	return dataquery.Filter{
+		Field: field, Fact: strings.TrimSpace(filter.Fact), Operator: operator, Values: append([]any(nil), filter.Values...),
+	}, nil
 }
 
 type columnMaskPolicy struct {

--- a/internal/dashboard/queryauthz/data_authorization.go
+++ b/internal/dashboard/queryauthz/data_authorization.go
@@ -704,29 +704,17 @@ func (m Metrics) applyDataPolicies(ctx context.Context, request dataquery.Query,
 	if err != nil {
 		return request, nil, err
 	}
-	for _, policy := range policies {
-		switch policy.PolicyType {
-		case "row_filter":
-			filters, err := rowFiltersFromPolicy(policy)
-			if err != nil {
-				return request, nil, err
-			}
-			request.Filters = append(request.Filters, m.resolvePolicyFilterFacts(request, filters)...)
-		case "column_mask":
-			mask, err := columnMaskFromPolicy(policy)
-			if err != nil {
-				return request, nil, err
-			}
-			maskedFields := selectedMaskedFields(request, mask)
-			if request.Kind == dataquery.KindSemanticAggregate || request.Kind == dataquery.KindSemanticSpatial {
-				maskedFields = append(maskedFields, mask.Fields...)
-			}
-			for _, field := range uniqueStrings(maskedFields) {
-				request.ColumnMasks = append(request.ColumnMasks, dataquery.ColumnMask{Field: field, Mask: mask.Mask})
-			}
-		}
+	composition, err := composeDataPolicies(policies.active, policies.mandatory)
+	if err != nil {
+		return request, nil, err
 	}
-	return request, policies, nil
+	request.Filters = append(request.Filters, m.resolvePolicyFilterFacts(request, composition.Filters)...)
+	columnMasks, err := selectedColumnMasks(request, composition.Masks)
+	if err != nil {
+		return request, nil, err
+	}
+	request.ColumnMasks = append(request.ColumnMasks, columnMasks...)
+	return request, policies.all(), nil
 }
 
 func (m Metrics) resolvePolicyFilterFacts(request dataquery.Query, filters []dataquery.Filter) []dataquery.Filter {
@@ -782,10 +770,19 @@ func uniqueStrings(values []string) []string {
 	return out
 }
 
-func (m Metrics) effectiveDataPolicies(ctx context.Context, request dataquery.Query, objects []access.ObjectRef) ([]access.DataPolicy, error) {
+type effectiveDataPolicySet struct {
+	active    []access.DataPolicy
+	mandatory []access.DataPolicy
+}
+
+func (set effectiveDataPolicySet) all() []access.DataPolicy {
+	return append(append([]access.DataPolicy(nil), set.active...), set.mandatory...)
+}
+
+func (m Metrics) effectiveDataPolicies(ctx context.Context, request dataquery.Query, objects []access.ObjectRef) (effectiveDataPolicySet, error) {
 	seenObjects := map[string]struct{}{}
 	seenPolicies := map[string]struct{}{}
-	out := []access.DataPolicy{}
+	out := effectiveDataPolicySet{}
 	addObject := func(object access.ObjectRef) error {
 		if object.Type == "" {
 			return nil
@@ -804,18 +801,18 @@ func (m Metrics) effectiveDataPolicies(ctx context.Context, request dataquery.Qu
 				continue
 			}
 			seenPolicies[policy.ID] = struct{}{}
-			out = append(out, policy)
+			out.active = append(out.active, policy)
 		}
 		return nil
 	}
 	for _, object := range objects {
 		if err := addObject(object); err != nil {
-			return nil, err
+			return effectiveDataPolicySet{}, err
 		}
 	}
 	for _, object := range dataQueryColumnObjects(request) {
 		if err := addObject(object); err != nil {
-			return nil, err
+			return effectiveDataPolicySet{}, err
 		}
 	}
 	if candidate, ok := candidateQueryCapabilityFromContext(ctx); ok {
@@ -830,11 +827,11 @@ func (m Metrics) effectiveDataPolicies(ctx context.Context, request dataquery.Qu
 		}
 		for _, restriction := range candidate.Restrictions {
 			if restriction.ObjectID == "" {
-				out = append(out, restriction)
+				out.mandatory = append(out.mandatory, restriction)
 				continue
 			}
 			if _, ok := relevant[restriction.ObjectID]; ok {
-				out = append(out, restriction)
+				out.mandatory = append(out.mandatory, restriction)
 			}
 		}
 	}
@@ -979,6 +976,7 @@ func dataQuerySelectedFields(request dataquery.Query) []string {
 }
 
 type dataPolicyExpression struct {
+	AllowAll bool               `json:"allowAll"`
 	Field    string             `json:"field"`
 	Columns  []string           `json:"columns"`
 	Operator string             `json:"operator"`
@@ -988,16 +986,23 @@ type dataPolicyExpression struct {
 	Mask     string             `json:"mask"`
 }
 
-func rowFiltersFromPolicy(policy access.DataPolicy) ([]dataquery.Filter, error) {
+func parseDataPolicyExpression(policy access.DataPolicy) (dataPolicyExpression, error) {
 	var expression dataPolicyExpression
 	if err := json.Unmarshal([]byte(policy.ExpressionJSON), &expression); err != nil {
-		return nil, fmt.Errorf("data policy %q expression is invalid: %w", policy.ID, err)
+		return dataPolicyExpression{}, fmt.Errorf("data policy %q expression is invalid: %w", policy.ID, err)
+	}
+	return expression, nil
+}
+
+func rowFiltersFromExpression(policyID string, expression dataPolicyExpression) ([]dataquery.Filter, error) {
+	if len(expression.Filters) > 0 && strings.TrimSpace(expression.Field) != "" {
+		return nil, fmt.Errorf("row_filter data policy %q cannot combine field with filters", policyID)
 	}
 	if len(expression.Filters) > 0 {
 		return expression.Filters, nil
 	}
 	if strings.TrimSpace(expression.Field) == "" {
-		return nil, fmt.Errorf("row_filter data policy %q requires field or filters", policy.ID)
+		return nil, fmt.Errorf("row_filter data policy %q requires field or filters", policyID)
 	}
 	operator := strings.TrimSpace(expression.Operator)
 	if operator == "" {
@@ -1008,21 +1013,24 @@ func rowFiltersFromPolicy(policy access.DataPolicy) ([]dataquery.Filter, error) 
 		values = append(values, expression.Value)
 	}
 	if len(values) == 0 {
-		return nil, fmt.Errorf("row_filter data policy %q requires values", policy.ID)
+		return nil, fmt.Errorf("row_filter data policy %q requires values", policyID)
 	}
 	return []dataquery.Filter{{Field: expression.Field, Operator: operator, Values: values}}, nil
 }
 
 type columnMaskPolicy struct {
-	PolicyID string
-	Fields   []string
-	Mask     string
+	PolicyIDs []string
+	Fields    []string
+	Mask      string
 }
 
 func columnMaskFromPolicy(policy access.DataPolicy) (columnMaskPolicy, error) {
-	var expression dataPolicyExpression
-	if err := json.Unmarshal([]byte(policy.ExpressionJSON), &expression); err != nil {
-		return columnMaskPolicy{}, fmt.Errorf("data policy %q expression is invalid: %w", policy.ID, err)
+	expression, err := parseDataPolicyExpression(policy)
+	if err != nil {
+		return columnMaskPolicy{}, err
+	}
+	if expression.AllowAll {
+		return columnMaskPolicy{}, fmt.Errorf("column_mask data policy %q cannot use allowAll", policy.ID)
 	}
 	fields := append([]string{}, expression.Columns...)
 	if strings.TrimSpace(expression.Field) != "" {
@@ -1035,7 +1043,7 @@ func columnMaskFromPolicy(policy access.DataPolicy) (columnMaskPolicy, error) {
 	if mask == "" {
 		mask = "null"
 	}
-	return columnMaskPolicy{PolicyID: policy.ID, Fields: fields, Mask: mask}, nil
+	return columnMaskPolicy{PolicyIDs: []string{policy.ID}, Fields: fields, Mask: mask}, nil
 }
 
 func selectedMaskedFields(request dataquery.Query, mask columnMaskPolicy) []string {

--- a/internal/dashboard/queryauthz/policy_composition.go
+++ b/internal/dashboard/queryauthz/policy_composition.go
@@ -1,0 +1,289 @@
+package authz
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+)
+
+// dataPolicyComposition is the executable result of the policy algebra. Its
+// filters are conjunctive at the top level; alternatives are represented by a
+// single filter containing OR groups.
+type dataPolicyComposition struct {
+	Filters   []dataquery.Filter
+	Masks     []columnMaskPolicy
+	PolicyIDs []string
+}
+
+type rowPolicyGroup struct {
+	filters []dataquery.Filter
+}
+
+type rowPolicyBoundary struct {
+	global  rowPolicyGroup
+	subject map[string]*rowPolicyGroup
+}
+
+type maskComposition struct {
+	field     string
+	mask      string
+	policyIDs []string
+}
+
+// composeDataPolicies applies the authorization algebra before a query reaches
+// any planner:
+//   - policies for the same subject and protected object are ANDed;
+//   - applicable subjects on the same protected object are ORed;
+//   - global policies and different protected objects are ANDed; and
+//   - candidate restrictions are always ANDed as a separate mandatory layer.
+//
+// Column masks are cumulative. Equivalent masks collapse, while contradictory
+// masks fail closed instead of relying on repository or traversal order.
+func composeDataPolicies(active, mandatory []access.DataPolicy) (dataPolicyComposition, error) {
+	composition := dataPolicyComposition{}
+	all := append(append([]access.DataPolicy(nil), active...), mandatory...)
+	policyIDs := map[string]struct{}{}
+	for _, policy := range all {
+		if id := strings.TrimSpace(policy.ID); id != "" {
+			policyIDs[id] = struct{}{}
+		}
+	}
+	for id := range policyIDs {
+		composition.PolicyIDs = append(composition.PolicyIDs, id)
+	}
+	sort.Strings(composition.PolicyIDs)
+
+	boundaries := map[string]*rowPolicyBoundary{}
+	for _, policy := range sortedPolicies(active) {
+		switch policy.PolicyType {
+		case "row_filter":
+			clause, err := rowClauseFromPolicy(policy)
+			if err != nil {
+				return dataPolicyComposition{}, err
+			}
+			boundaryKey := policyBoundaryKey(policy)
+			boundary := boundaries[boundaryKey]
+			if boundary == nil {
+				boundary = &rowPolicyBoundary{subject: map[string]*rowPolicyGroup{}}
+				boundaries[boundaryKey] = boundary
+			}
+			if policy.SubjectType == "" {
+				boundary.global.filters = append(boundary.global.filters, clause...)
+				continue
+			}
+			groupKey := string(policy.SubjectType) + ":" + strings.TrimSpace(policy.SubjectID)
+			group := boundary.subject[groupKey]
+			if group == nil {
+				group = &rowPolicyGroup{}
+				boundary.subject[groupKey] = group
+			}
+			group.filters = append(group.filters, clause...)
+		case "column_mask":
+		case "":
+			return dataPolicyComposition{}, fmt.Errorf("data policy %q requires policy type", policy.ID)
+		default:
+			return dataPolicyComposition{}, fmt.Errorf("data policy %q has unsupported type %q", policy.ID, policy.PolicyType)
+		}
+	}
+
+	boundaryKeys := make([]string, 0, len(boundaries))
+	for key := range boundaries {
+		boundaryKeys = append(boundaryKeys, key)
+	}
+	sort.Strings(boundaryKeys)
+	for _, key := range boundaryKeys {
+		boundary := boundaries[key]
+		composition.Filters = append(composition.Filters, boundary.global.filters...)
+		if len(boundary.subject) == 0 {
+			continue
+		}
+		subjectKeys := make([]string, 0, len(boundary.subject))
+		for subject := range boundary.subject {
+			subjectKeys = append(subjectKeys, subject)
+		}
+		sort.Strings(subjectKeys)
+		if len(subjectKeys) == 1 {
+			composition.Filters = append(composition.Filters, boundary.subject[subjectKeys[0]].filters...)
+			continue
+		}
+		groups := make([]dataquery.FilterGroup, 0, len(subjectKeys))
+		allowAll := false
+		for _, subject := range subjectKeys {
+			filters := boundary.subject[subject].filters
+			if len(filters) == 0 {
+				allowAll = true
+				break
+			}
+			groups = append(groups, dataquery.FilterGroup{Filters: filters})
+		}
+		if !allowAll {
+			composition.Filters = append(composition.Filters, dataquery.Filter{Groups: groups})
+		}
+	}
+
+	for _, policy := range sortedPolicies(mandatory) {
+		switch policy.PolicyType {
+		case "row_filter":
+			clause, err := rowClauseFromPolicy(policy)
+			if err != nil {
+				return dataPolicyComposition{}, err
+			}
+			composition.Filters = append(composition.Filters, clause...)
+		case "column_mask":
+		case "":
+			return dataPolicyComposition{}, fmt.Errorf("data policy %q requires policy type", policy.ID)
+		default:
+			return dataPolicyComposition{}, fmt.Errorf("data policy %q has unsupported type %q", policy.ID, policy.PolicyType)
+		}
+	}
+
+	masks, err := composeColumnMasks(all)
+	if err != nil {
+		return dataPolicyComposition{}, err
+	}
+	composition.Masks = masks
+	return composition, nil
+}
+
+func sortedPolicies(policies []access.DataPolicy) []access.DataPolicy {
+	out := append([]access.DataPolicy(nil), policies...)
+	sort.SliceStable(out, func(i, j int) bool {
+		left := policyBoundaryKey(out[i]) + "\x00" + string(out[i].SubjectType) + "\x00" + out[i].SubjectID + "\x00" + out[i].ID
+		right := policyBoundaryKey(out[j]) + "\x00" + string(out[j].SubjectType) + "\x00" + out[j].SubjectID + "\x00" + out[j].ID
+		return left < right
+	})
+	return out
+}
+
+func policyBoundaryKey(policy access.DataPolicy) string {
+	if objectID := strings.TrimSpace(policy.ObjectID); objectID != "" {
+		return "object:" + objectID
+	}
+	return "workspace:" + strings.TrimSpace(policy.WorkspaceID)
+}
+
+func rowClauseFromPolicy(policy access.DataPolicy) ([]dataquery.Filter, error) {
+	expression, err := parseDataPolicyExpression(policy)
+	if err != nil {
+		return nil, err
+	}
+	hasFilter := len(expression.Filters) > 0 || strings.TrimSpace(expression.Field) != ""
+	if expression.AllowAll {
+		if hasFilter {
+			return nil, fmt.Errorf("row_filter data policy %q cannot combine allowAll with field or filters", policy.ID)
+		}
+		return nil, nil
+	}
+	return rowFiltersFromExpression(policy.ID, expression)
+}
+
+func composeColumnMasks(policies []access.DataPolicy) ([]columnMaskPolicy, error) {
+	byField := map[string]*maskComposition{}
+	for _, policy := range sortedPolicies(policies) {
+		if policy.PolicyType != "column_mask" {
+			continue
+		}
+		mask, err := columnMaskFromPolicy(policy)
+		if err != nil {
+			return nil, err
+		}
+		normalizedMask := normalizeColumnMask(mask.Mask)
+		if normalizedMask == "" {
+			return nil, fmt.Errorf("column_mask data policy %q has unsupported mask %q", policy.ID, mask.Mask)
+		}
+		for _, field := range mask.Fields {
+			key := strings.ToLower(strings.TrimSpace(field))
+			if key == "" {
+				return nil, fmt.Errorf("column_mask data policy %q requires non-empty fields", policy.ID)
+			}
+			current := byField[key]
+			if current == nil {
+				byField[key] = &maskComposition{field: strings.TrimSpace(field), mask: normalizedMask, policyIDs: []string{policy.ID}}
+				continue
+			}
+			current.policyIDs = append(current.policyIDs, policy.ID)
+			if current.mask != normalizedMask {
+				ids := uniqueSortedStrings(current.policyIDs)
+				return nil, fmt.Errorf("column mask conflict for %q between policies %s", current.field, strings.Join(ids, ", "))
+			}
+		}
+	}
+	keys := make([]string, 0, len(byField))
+	for key := range byField {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]columnMaskPolicy, 0, len(keys))
+	for _, key := range keys {
+		mask := byField[key]
+		out = append(out, columnMaskPolicy{PolicyIDs: uniqueSortedStrings(mask.policyIDs), Fields: []string{mask.field}, Mask: mask.mask})
+	}
+	return out, nil
+}
+
+func normalizeColumnMask(mask string) string {
+	switch strings.ToLower(strings.TrimSpace(mask)) {
+	case "", "null":
+		return "null"
+	case "redact", "redacted":
+		return "redact"
+	case "zero":
+		return "zero"
+	default:
+		return ""
+	}
+}
+
+func selectedColumnMasks(request dataquery.Query, masks []columnMaskPolicy) ([]dataquery.ColumnMask, error) {
+	resolved := map[string]*maskComposition{}
+	for _, mask := range masks {
+		fields := selectedMaskedFields(request, mask)
+		if request.Kind == dataquery.KindSemanticAggregate || request.Kind == dataquery.KindSemanticSpatial {
+			fields = append(fields, mask.Fields...)
+		}
+		for _, field := range uniqueStrings(fields) {
+			key := strings.ToLower(strings.TrimSpace(field))
+			current := resolved[key]
+			if current == nil {
+				resolved[key] = &maskComposition{field: field, mask: mask.Mask, policyIDs: append([]string(nil), mask.PolicyIDs...)}
+				continue
+			}
+			current.policyIDs = append(current.policyIDs, mask.PolicyIDs...)
+			if current.mask != mask.Mask {
+				return nil, fmt.Errorf("column mask conflict for selected field %q between policies %s", current.field, strings.Join(uniqueSortedStrings(current.policyIDs), ", "))
+			}
+		}
+	}
+	keys := make([]string, 0, len(resolved))
+	for key := range resolved {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]dataquery.ColumnMask, 0, len(keys))
+	for _, key := range keys {
+		mask := resolved[key]
+		out = append(out, dataquery.ColumnMask{Field: mask.field, Mask: mask.mask})
+	}
+	return out, nil
+}
+
+func uniqueSortedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/dashboard/queryauthz/policy_composition_test.go
+++ b/internal/dashboard/queryauthz/policy_composition_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flidai/leapview/internal/access"
 	"github.com/flidai/leapview/internal/analytics/dataquery"
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,6 +66,19 @@ func TestApplyDataPoliciesUsesOneAlgebraAcrossQueryKinds(t *testing.T) {
 			require.Len(t, governed.Filters, 2)
 			require.Equal(t, "ratings.status", governed.Filters[0].Field)
 			require.Len(t, governed.Filters[1].Groups, 2)
+			if tt.name == "multi-fact aggregate" {
+				_, err = semanticquery.NewPlanner(model).Plan(semanticquery.Request{
+					Measures: dataFieldsToSemanticFields(governed.Measures),
+					Filters:  dataFiltersToSemanticFilters(governed.Filters),
+				})
+				require.NoError(t, err)
+				for _, group := range governed.Filters[1].Groups {
+					require.NotEmpty(t, group.Filters)
+					for _, filter := range group.Filters {
+						require.Equal(t, "ratings", filter.Fact)
+					}
+				}
+			}
 		})
 	}
 }
@@ -237,6 +251,29 @@ func TestComposeDataPoliciesRejectsAmbiguousExpressions(t *testing.T) {
 			_, err := composeDataPolicies([]access.DataPolicy{policy}, nil)
 			require.Error(t, err)
 			require.ErrorContains(t, err, policy.ID)
+		})
+	}
+}
+
+func TestComposeDataPoliciesRejectsMalformedNestedFilters(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+	}{
+		{name: "empty field", expression: `{"filters":[{"field":"","operator":"equals","values":["DK"]}]}`},
+		{name: "empty in", expression: `{"filters":[{"field":"ratings.country","operator":"in","values":[]}]}`},
+		{name: "mixed field and groups", expression: `{"filters":[{"field":"ratings.country","groups":[{"filters":[{"field":"ratings.region","operator":"equals","values":["EU"]}]}]}]}`},
+		{name: "empty group", expression: `{"filters":[{"groups":[{"filters":[]}]}]}`},
+		{name: "unsupported operator", expression: `{"filters":[{"field":"ratings.country","operator":"matches","values":["DK"]}]}`},
+		{name: "null operator with value", expression: `{"filters":[{"field":"ratings.country","operator":"is_null","values":["DK"]}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := composeDataPolicies([]access.DataPolicy{{
+				ID: "nested", WorkspaceID: "sales", PolicyType: "row_filter", ExpressionJSON: tt.expression,
+			}}, nil)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "nested")
 		})
 	}
 }

--- a/internal/dashboard/queryauthz/policy_composition_test.go
+++ b/internal/dashboard/queryauthz/policy_composition_test.go
@@ -1,0 +1,242 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDataPoliciesUsesOneAlgebraAcrossQueryKinds(t *testing.T) {
+	repository := &candidateAuthorizationRepository{policies: []access.DataPolicy{
+		{
+			ID: "published", WorkspaceID: "sales", ObjectID: "ratings", PolicyType: "row_filter",
+			ExpressionJSON: `{"field":"ratings.status","operator":"equals","values":["published"]}`,
+		},
+		{
+			ID: "country-dk", WorkspaceID: "sales", ObjectID: "ratings", SubjectType: access.SubjectGroup, SubjectID: "dk",
+			PolicyType: "row_filter", ExpressionJSON: `{"field":"ratings.country","operator":"equals","values":["DK"]}`,
+		},
+		{
+			ID: "country-se", WorkspaceID: "sales", ObjectID: "ratings", SubjectType: access.SubjectGroup, SubjectID: "se",
+			PolicyType: "row_filter", ExpressionJSON: `{"field":"ratings.country","operator":"equals","values":["SE"]}`,
+		},
+	}}
+	model := governanceTestModel()
+	ratings := model.Tables["ratings"]
+	ratings.Dimensions["country"] = semanticDimension("string")
+	model.Tables["ratings"] = ratings
+	metrics := New(semanticModelMetrics{model: model}, Options{Repo: repository, DefaultWorkspaceID: "sales"})
+
+	tests := []struct {
+		name    string
+		request dataquery.Query
+	}{
+		{
+			name: "raw rows",
+			request: dataquery.Query{WorkspaceID: "sales", ModelID: model.Name, Kind: dataquery.KindSemanticRows, Target: "ratings",
+				Fields: []dataquery.Field{{Field: "ratings.rating"}}},
+		},
+		{
+			name: "semantic aggregate",
+			request: dataquery.Query{WorkspaceID: "sales", ModelID: model.Name, Kind: dataquery.KindSemanticAggregate, Target: "ratings",
+				Measures: []dataquery.Field{{Field: "rating_count"}}},
+		},
+		{
+			name: "spatial",
+			request: dataquery.Query{WorkspaceID: "sales", ModelID: model.Name, Kind: dataquery.KindSemanticSpatial, Target: "ratings",
+				Fields: []dataquery.Field{{Field: "ratings.rating"}}},
+		},
+		{
+			name: "multi-fact aggregate",
+			request: dataquery.Query{WorkspaceID: "sales", ModelID: model.Name, Kind: dataquery.KindSemanticAggregate,
+				Measures: []dataquery.Field{{Field: "rating_count"}, {Field: "tag_count"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			governed, policies, err := metrics.applyDataPolicies(context.Background(), tt.request, []access.ObjectRef{access.WorkspaceObject("sales")})
+			require.NoError(t, err)
+			require.Len(t, policies, 3)
+			require.Len(t, governed.Filters, 2)
+			require.Equal(t, "ratings.status", governed.Filters[0].Field)
+			require.Len(t, governed.Filters[1].Groups, 2)
+		})
+	}
+}
+
+func semanticDimension(kind string) semanticmodel.MetricDimension {
+	return semanticmodel.MetricDimension{Type: kind}
+}
+
+func TestComposeDataPoliciesRowFilterAlgebra(t *testing.T) {
+	policy := func(id, object string, subjectType access.SubjectType, subjectID, field, value string) access.DataPolicy {
+		return access.DataPolicy{
+			ID: id, WorkspaceID: "sales", ObjectID: object,
+			SubjectType: subjectType, SubjectID: subjectID, PolicyType: "row_filter",
+			ExpressionJSON: `{"field":"` + field + `","operator":"equals","values":["` + value + `"]}`,
+		}
+	}
+	allowAll := func(id, object string, subjectType access.SubjectType, subjectID string) access.DataPolicy {
+		return access.DataPolicy{
+			ID: id, WorkspaceID: "sales", ObjectID: object,
+			SubjectType: subjectType, SubjectID: subjectID, PolicyType: "row_filter",
+			ExpressionJSON: `{"allowAll":true}`,
+		}
+	}
+	filter := func(field, value string) dataquery.Filter {
+		return dataquery.Filter{Field: field, Operator: "equals", Values: []any{value}}
+	}
+
+	tests := []struct {
+		name      string
+		active    []access.DataPolicy
+		mandatory []access.DataPolicy
+		want      []dataquery.Filter
+	}{
+		{
+			name: "same subject group is conjunctive",
+			active: []access.DataPolicy{
+				policy("country", "dataset-ratings", access.SubjectGroup, "analysts", "ratings.country", "DK"),
+				policy("status", "dataset-ratings", access.SubjectGroup, "analysts", "ratings.status", "published"),
+			},
+			want: []dataquery.Filter{filter("ratings.country", "DK"), filter("ratings.status", "published")},
+		},
+		{
+			name: "different subject groups are alternatives",
+			active: []access.DataPolicy{
+				policy("country", "dataset-ratings", access.SubjectGroup, "nordics", "ratings.country", "DK"),
+				policy("region", "dataset-ratings", access.SubjectGroup, "emea", "ratings.region", "EU"),
+			},
+			want: []dataquery.Filter{{Groups: []dataquery.FilterGroup{
+				{Filters: []dataquery.Filter{filter("ratings.region", "EU")}},
+				{Filters: []dataquery.Filter{filter("ratings.country", "DK")}},
+			}}},
+		},
+		{
+			name: "global restrictions intersect subject alternatives",
+			active: []access.DataPolicy{
+				policy("published", "dataset-ratings", "", "", "ratings.status", "published"),
+				policy("country", "dataset-ratings", access.SubjectGroup, "nordics", "ratings.country", "DK"),
+				policy("region", "dataset-ratings", access.SubjectGroup, "emea", "ratings.region", "EU"),
+			},
+			want: []dataquery.Filter{
+				filter("ratings.status", "published"),
+				{Groups: []dataquery.FilterGroup{
+					{Filters: []dataquery.Filter{filter("ratings.region", "EU")}},
+					{Filters: []dataquery.Filter{filter("ratings.country", "DK")}},
+				}},
+			},
+		},
+		{
+			name: "allow-all subject makes subject alternatives neutral",
+			active: []access.DataPolicy{
+				policy("published", "dataset-ratings", "", "", "ratings.status", "published"),
+				policy("country", "dataset-ratings", access.SubjectGroup, "nordics", "ratings.country", "DK"),
+				allowAll("executives", "dataset-ratings", access.SubjectGroup, "executives"),
+			},
+			want: []dataquery.Filter{filter("ratings.status", "published")},
+		},
+		{
+			name: "different protected objects are conjunctive boundaries",
+			active: []access.DataPolicy{
+				policy("country", "dataset-ratings", access.SubjectGroup, "analysts", "ratings.country", "DK"),
+				policy("status", "workspace-sales", access.SubjectGroup, "auditors", "ratings.status", "published"),
+			},
+			want: []dataquery.Filter{filter("ratings.country", "DK"), filter("ratings.status", "published")},
+		},
+		{
+			name: "candidate restrictions are always mandatory",
+			active: []access.DataPolicy{
+				allowAll("executives", "dataset-ratings", access.SubjectGroup, "executives"),
+			},
+			mandatory: []access.DataPolicy{
+				policy("candidate", "dataset-ratings", "", "", "ratings.region", "Hovedstaden"),
+			},
+			want: []dataquery.Filter{filter("ratings.region", "Hovedstaden")},
+		},
+		{name: "no applicable policy is neutral"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			composition, err := composeDataPolicies(tt.active, tt.mandatory)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, composition.Filters)
+		})
+	}
+}
+
+func TestComposeDataPoliciesPreservesPolicyIDs(t *testing.T) {
+	policies := []access.DataPolicy{
+		{ID: "z-policy", WorkspaceID: "sales", ObjectID: "ratings", PolicyType: "row_filter", ExpressionJSON: `{"allowAll":true}`},
+		{ID: "a-policy", WorkspaceID: "sales", ObjectID: "ratings", PolicyType: "column_mask", ExpressionJSON: `{"field":"ratings.email","mask":"null"}`},
+	}
+
+	composition, err := composeDataPolicies(policies, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a-policy", "z-policy"}, composition.PolicyIDs)
+}
+
+func TestComposeDataPoliciesRejectsConflictingColumnMasks(t *testing.T) {
+	policies := []access.DataPolicy{
+		{ID: "mask-null", WorkspaceID: "sales", ObjectID: "ratings.email", PolicyType: "column_mask", ExpressionJSON: `{"field":"ratings.email","mask":"null"}`},
+		{ID: "mask-redact", WorkspaceID: "sales", ObjectID: "ratings.email", PolicyType: "column_mask", ExpressionJSON: `{"field":"ratings.email","mask":"redact"}`},
+	}
+
+	_, err := composeDataPolicies(policies, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ratings.email")
+	require.ErrorContains(t, err, "mask-null")
+	require.ErrorContains(t, err, "mask-redact")
+}
+
+func TestComposeDataPoliciesDeduplicatesEquivalentColumnMasks(t *testing.T) {
+	policies := []access.DataPolicy{
+		{ID: "mask-group", WorkspaceID: "sales", ObjectID: "ratings.email", SubjectType: access.SubjectGroup, SubjectID: "analysts", PolicyType: "column_mask", ExpressionJSON: `{"field":"ratings.email","mask":"null"}`},
+		{ID: "mask-global", WorkspaceID: "sales", ObjectID: "ratings.email", PolicyType: "column_mask", ExpressionJSON: `{"columns":["ratings.email"],"mask":"null"}`},
+	}
+
+	composition, err := composeDataPolicies(policies, nil)
+	require.NoError(t, err)
+	require.Equal(t, []columnMaskPolicy{{
+		PolicyIDs: []string{"mask-global", "mask-group"},
+		Fields:    []string{"ratings.email"},
+		Mask:      "null",
+	}}, composition.Masks)
+}
+
+func TestSelectedColumnMasksRejectsOverlappingFieldReferences(t *testing.T) {
+	composition, err := composeDataPolicies([]access.DataPolicy{
+		{ID: "mask-leaf", WorkspaceID: "sales", ObjectID: "ratings.email", PolicyType: "column_mask", ExpressionJSON: `{"field":"email","mask":"null"}`},
+		{ID: "mask-qualified", WorkspaceID: "sales", ObjectID: "ratings.email", PolicyType: "column_mask", ExpressionJSON: `{"field":"ratings.email","mask":"redact"}`},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = selectedColumnMasks(dataquery.Query{
+		Kind: dataquery.KindSemanticRows, Fields: []dataquery.Field{{Field: "ratings.email"}},
+	}, composition.Masks)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ratings.email")
+	require.ErrorContains(t, err, "mask-leaf")
+	require.ErrorContains(t, err, "mask-qualified")
+}
+
+func TestComposeDataPoliciesRejectsAmbiguousExpressions(t *testing.T) {
+	tests := []access.DataPolicy{
+		{ID: "row", WorkspaceID: "sales", PolicyType: "row_filter", ExpressionJSON: `{"field":"ratings.country","filters":[{"field":"ratings.region","values":["EU"]}]}`},
+		{ID: "mask", WorkspaceID: "sales", PolicyType: "column_mask", ExpressionJSON: `{"allowAll":true,"field":"ratings.email"}`},
+		{ID: "empty-mask-field", WorkspaceID: "sales", PolicyType: "column_mask", ExpressionJSON: `{"columns":[""],"mask":"null"}`},
+	}
+	for _, policy := range tests {
+		t.Run(policy.ID, func(t *testing.T) {
+			_, err := composeDataPolicies([]access.DataPolicy{policy}, nil)
+			require.Error(t, err)
+			require.ErrorContains(t, err, policy.ID)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- define a deterministic row-policy algebra: AND within a subject/object boundary, OR across applicable subjects, and AND across global, inherited-object, and candidate restrictions
- collapse equivalent column masks and reject conflicting or overlapping masks with the contributing policy IDs
- exercise one composition path across raw rows, semantic aggregates, spatial requests, and multi-fact aggregates
- document the operator truth table, explicit `allowAll`, and audit/fingerprint guarantees

## Inspiration
This adapts Cube's explicit security-context policy combination from Sourcebook revision `9052c686ed4e`, especially:
- `packages/cubejs-schema-compiler/src/compiler/CompilerApi.ts` for grouping applicable policies before query planning
- `packages/cubejs-testing/test/smoke-rbac.test.ts` and `birdbox-fixtures/rbac/model/cubes/policy_overlap_test.yaml` for overlap and multi-group characterization

LeapView keeps its stricter restriction model: global and inherited object policies remain mandatory, candidate policies can only narrow access, and contradictory masks fail closed.

## LeapView files
- `internal/dashboard/queryauthz/policy_composition.go`
- `internal/dashboard/queryauthz/policy_composition_test.go`
- `internal/dashboard/queryauthz/data_authorization.go`
- `docs/articles/security/authorization.md`

## Validation
- `go test -tags=duckdb_arrow ./internal/dashboard/queryauthz`
- `go test -race -tags=duckdb_arrow ./internal/dashboard/queryauthz`
- `go vet -tags=duckdb_arrow ./internal/dashboard/queryauthz`
- `task generated:check`
- `git diff --check`

Stack: 2/7. Depends on #234 (LEA-297).
