### PR TITLE
LEA-294: make retired generation teardown asynchronous and idempotent

### DIFF
--- a/docs/articles/architecture/runtime.md
+++ b/docs/articles/architecture/runtime.md
@@ -18,6 +18,17 @@ The request resolves active state once for its operation. A deployment or refres
 
 Handlers authorize the principal on known securable objects. Effective privilege can combine role binding, explicit grant, ownership, parent inheritance, token restriction, and data policy. Authorization does not create missing securable objects as a side effect of a query.
 
+Serving-state cutover never tears down a retired generation on the request
+release path. The final reader release atomically moves the generation from
+`draining_readers` to `cleanup_pending`; one bounded worker per workspace then
+closes the runtime, managed-data lifetime, persistent snapshot lease, and
+runtime dependencies exactly once. The retired generation remains observable
+as a tombstone, and its snapshot remains leased, until cleanup completes.
+
+Runtime-host shutdown drains already-scheduled cleanup up to a configured
+timeout. Resource-specific failures continue through cleanup callbacks and
+logs without rolling back the already-atomic serving-state publication.
+
 Data policies are applied before governed analytical work. Browser, API, CLI, and agent queries must share this boundary.
 
 ## Dashboard queries

--- a/internal/deployment/sqlite/repository_test.go
+++ b/internal/deployment/sqlite/repository_test.go
@@ -330,10 +330,10 @@ func TestServiceActivationKeepsDurableAndRuntimeStateConsistentWhenRetiredRuntim
 	})
 	states := servingstatesqlite.NewRepository(db)
 	factory := &cutoverRuntimeFactory{runtimes: map[servingstate.ID]*cutoverRuntime{}}
-	var cleanupFailures []runtimehost.CleanupFailure
+	cleanupFailures := make(chan runtimehost.CleanupFailure, 1)
 	registry := runtimehost.NewRegistryWithFactory(runtimehost.RegistryOptions{
 		Repo: states, WorkspaceIDs: []servingstate.WorkspaceID{"sales", "support"}, Environment: "prod", Factory: factory,
-		OnCleanupFailure: func(failure runtimehost.CleanupFailure) { cleanupFailures = append(cleanupFailures, failure) },
+		OnCleanupFailure: func(failure runtimehost.CleanupFailure) { cleanupFailures <- failure },
 	})
 	if err := registry.Reload(ctx); err != nil {
 		t.Fatal(err)
@@ -368,8 +368,13 @@ func TestServiceActivationKeepsDurableAndRuntimeStateConsistentWhenRetiredRuntim
 		}
 		lease.Release()
 	}
-	if len(cleanupFailures) != 1 || !errors.Is(cleanupFailures[0].Err, wantCleanupErr) {
-		t.Fatalf("cleanup failures = %#v", cleanupFailures)
+	select {
+	case failure := <-cleanupFailures:
+		if !errors.Is(failure.Err, wantCleanupErr) {
+			t.Fatalf("cleanup failure = %#v", failure)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for asynchronous cleanup failure")
 	}
 	if err := registry.Close(); err != nil {
 		t.Fatal(err)

--- a/internal/runtimehost/candidates.go
+++ b/internal/runtimehost/candidates.go
@@ -100,6 +100,8 @@ type candidateGeneration struct {
 	managed       *managedRuntime
 	refs          int
 	closing       bool
+	cleanupDone   chan struct{}
+	cleanupOnce   sync.Once
 }
 
 // OwnedCandidateView is server-resolved metadata for an authenticated
@@ -221,7 +223,7 @@ func (r *Registry) consumePreparedCandidate(
 		},
 		ownerID: normalized.OwnerID, expiresAt: normalized.ExpiresAt,
 		compatibility: normalized.Compatibility, fingerprint: fingerprint,
-		manager: sealed.manager, managed: managed,
+		manager: sealed.manager, managed: managed, cleanupDone: make(chan struct{}),
 	}, nil
 }
 
@@ -512,7 +514,18 @@ func (r *Registry) cleanupCandidateGeneration(generation *candidateGeneration) {
 	if generation == nil || generation.manager == nil || generation.managed == nil {
 		return
 	}
-	generation.manager.cleanupRetired(generation.managed)
+	generation.cleanupOnce.Do(func() {
+		generation.manager.cleanupRetired(generation.managed)
+		go func() {
+			generation.manager.mu.RLock()
+			done := generation.managed.cleanupDone
+			generation.manager.mu.RUnlock()
+			if done != nil {
+				<-done
+			}
+			close(generation.cleanupDone)
+		}()
+	})
 }
 
 func (r *candidateRuntimeRegistry) register(
@@ -714,21 +727,29 @@ func (r *candidateRuntimeRegistry) release(generation *candidateGeneration) *can
 	return generation
 }
 
-func (r *candidateRuntimeRegistry) close() []*candidateGeneration {
+func (r *candidateRuntimeRegistry) close() (drained, targets []*candidateGeneration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.closed {
-		return nil
+		return nil, nil
 	}
 	r.closed = true
-	var drained []*candidateGeneration
+	seen := map[*candidateGeneration]struct{}{}
+	for generation := range r.retired {
+		seen[generation] = struct{}{}
+		targets = append(targets, generation)
+	}
 	for key, generation := range r.current {
 		delete(r.current, key)
+		if _, ok := seen[generation]; !ok {
+			seen[generation] = struct{}{}
+			targets = append(targets, generation)
+		}
 		if closed := r.retireLocked(generation); closed != nil {
 			drained = append(drained, closed)
 		}
 	}
-	return drained
+	return drained, targets
 }
 
 func (r *candidateRuntimeRegistry) leasedSnapshots() []int64 {

--- a/internal/runtimehost/candidates_test.go
+++ b/internal/runtimehost/candidates_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ func TestCandidateRuntimeReplacementIsPrivateAndDrainsLeasedGeneration(t *testin
 		CandidateID: "cand_1", OwnerID: "author_1", WorkspaceID: "sales",
 		ExpiresAt: now.Add(time.Hour), Compatibility: candidateCompatibility("two"),
 	}, "candidate_sales_2")
-	if oldRuntime.closed {
+	if oldRuntime.closed.Load() {
 		t.Fatal("replaced candidate runtime closed while a lease was active")
 	}
 	newLease, err := registry.AcquireCandidate(t.Context(), CandidateLeaseRequest{
@@ -72,7 +73,8 @@ func TestCandidateRuntimeReplacementIsPrivateAndDrainsLeasedGeneration(t *testin
 	active.Release()
 
 	oldLease.Release()
-	if !oldRuntime.closed {
+	waitForManagerCleanup(t, registry.managerForWorkspace("sales"))
+	if !oldRuntime.closed.Load() {
 		t.Fatal("replaced candidate runtime remained open after its final lease")
 	}
 }
@@ -178,11 +180,12 @@ func TestCandidateRuntimeExpiryRejectsNewLeasesAndDrainsExistingLease(t *testing
 	if _, err := registry.AcquireCandidate(t.Context(), request); !errors.Is(err, ErrCandidateRuntimeExpired) {
 		t.Fatalf("expired AcquireCandidate() error = %v", err)
 	}
-	if runtime.closed {
+	if runtime.closed.Load() {
 		t.Fatal("expired candidate runtime closed while an existing lease was active")
 	}
 	lease.Release()
-	if !runtime.closed {
+	waitForManagerCleanup(t, registry.managerForWorkspace("sales"))
+	if !runtime.closed.Load() {
 		t.Fatal("expired candidate runtime remained open after its final lease")
 	}
 	if removed := registry.ReapExpiredCandidates(now); removed != 0 {
@@ -222,8 +225,9 @@ func TestCandidateRuntimeRetirementIsSafeWithConcurrentLeaseRelease(t *testing.T
 		registry.RetireCandidate("cand_1")
 	}()
 	wait.Wait()
+	waitForManagerCleanup(t, registry.managerForWorkspace("sales"))
 
-	if !runtime.closed {
+	if !runtime.closed.Load() {
 		t.Fatal("retired candidate runtime remained open after concurrent releases")
 	}
 	if _, err := registry.AcquireCandidate(context.Background(), request); !errors.Is(err, ErrCandidateRuntimeNotFound) {
@@ -255,12 +259,13 @@ func TestCandidateRuntimeOwnsExternalDependenciesUntilGenerationDrains(t *testin
 	})
 	require.NoError(t, err)
 	registry.RetireCandidate(registration.CandidateID)
-	if lifetime.closes != 0 {
+	if lifetime.closes.Load() != 0 {
 		t.Fatal("candidate dependency closed while a runtime lease was active")
 	}
 	lease.Release()
-	if lifetime.closes != 1 {
-		t.Fatalf("candidate dependency closes = %d, want 1 after drain", lifetime.closes)
+	waitForManagerCleanup(t, registry.managerForWorkspace("sales"))
+	if lifetime.closes.Load() != 1 {
+		t.Fatalf("candidate dependency closes = %d, want 1 after drain", lifetime.closes.Load())
 	}
 }
 
@@ -353,11 +358,12 @@ func TestCandidateRuntimeSetReplacesEveryWorkspaceAsOneGeneration(t *testing.T) 
 		}
 		lease.Release()
 	}
-	if oldRuntime.closed {
+	if oldRuntime.closed.Load() {
 		t.Fatal("old workspace runtime closed before its outstanding lease drained")
 	}
 	old.Release()
-	if !oldRuntime.closed {
+	waitForManagerCleanup(t, registry.managerForWorkspace("sales"))
+	if !oldRuntime.closed.Load() {
 		t.Fatal("old workspace runtime remained open after set replacement drained")
 	}
 }
@@ -400,8 +406,8 @@ func TestCandidateRuntimeSetClosesEverySuppliedLifetimeWhenPreparationFails(t *t
 		t.Fatal("PrepareAndRegisterCandidateSet() error = nil, want preparation failure")
 	}
 	for index, lifetime := range lifetimes {
-		if lifetime.closes != 1 {
-			t.Fatalf("lifetime %d closes = %d, want 1", index, lifetime.closes)
+		if lifetime.closes.Load() != 1 {
+			t.Fatalf("lifetime %d closes = %d, want 1", index, lifetime.closes.Load())
 		}
 	}
 }
@@ -572,10 +578,10 @@ func candidateCompatibility(suffix string) CandidateCompatibility {
 }
 
 type candidateTestLifetime struct {
-	closes int
+	closes atomic.Int32
 }
 
 func (lifetime *candidateTestLifetime) Close() error {
-	lifetime.closes++
+	lifetime.closes.Add(1)
 	return nil
 }

--- a/internal/runtimehost/candidates_test.go
+++ b/internal/runtimehost/candidates_test.go
@@ -525,6 +525,33 @@ func TestCandidateRuntimeRefreshRejectsManagedDataConnectionDrift(t *testing.T) 
 	}
 }
 
+func TestRegistryCloseBoundsHeldCandidateLeaseDrain(t *testing.T) {
+	now := time.Date(2026, 7, 29, 17, 0, 0, 0, time.UTC)
+	repo := newFakeRegistryRepo()
+	addCandidateServingState(repo, "candidate_sales_1", "sales", "candidate-1", 21)
+	factory := &recordingRegistryFactory{}
+	registry := NewRegistryWithFactory(RegistryOptions{
+		Repo: repo, Environment: "prod", Factory: factory, Now: func() time.Time { return now },
+		CleanupDrainTimeout: 25 * time.Millisecond,
+	})
+	registration := CandidateRegistration{
+		CandidateID: "cand_1", OwnerID: "author_1", WorkspaceID: "sales", ExpiresAt: now.Add(time.Hour),
+		Compatibility: candidateCompatibility("one"),
+	}
+	registerCandidateRuntime(t, registry, registration, "candidate_sales_1")
+	lease, err := registry.AcquireCandidate(t.Context(), CandidateLeaseRequest{
+		CandidateID: "cand_1", OwnerID: "author_1", WorkspaceID: "sales", Compatibility: registration.Compatibility,
+	})
+	require.NoError(t, err)
+
+	err = registry.Close()
+	require.ErrorContains(t, err, "candidate runtime cleanup did not drain")
+	lease.Release()
+	require.Eventually(t, func() bool {
+		return len(factory.runtimes) == 1 && factory.runtimes[0].closed.Load()
+	}, time.Second, 10*time.Millisecond)
+}
+
 func candidateTestRegistry(t *testing.T, now func() time.Time) *Registry {
 	t.Helper()
 	repo := newFakeRegistryRepo()

--- a/internal/runtimehost/manager.go
+++ b/internal/runtimehost/manager.go
@@ -723,9 +723,6 @@ func (m *Manager) closeManagedResources(runtime *managedRuntime) []cleanupResult
 		if err := closeRuntimeLifetime(runtime.runtimeLifetime); err != nil {
 			results = append(results, cleanupResult{resource: CleanupResourceDependency, err: err})
 		}
-		if runtime.closing && m.onDrained != nil {
-			m.onDrained(runtime.servingStateID, runtime.snapshotID)
-		}
 		runtime.cleanupResults = results
 	})
 	return append([]cleanupResult(nil), runtime.cleanupResults...)
@@ -777,6 +774,9 @@ func (m *Manager) runCleanupWorker() {
 		m.removeRetiredLocked(runtime)
 		close(runtime.cleanupDone)
 		m.mu.Unlock()
+		if runtime.closing && m.onDrained != nil {
+			m.onDrained(runtime.servingStateID, runtime.snapshotID)
+		}
 	}
 }
 

--- a/internal/runtimehost/manager.go
+++ b/internal/runtimehost/manager.go
@@ -124,6 +124,8 @@ type Manager struct {
 	activeSnapshotID      int64
 	current               *managedRuntime
 	retired               []*managedRuntime
+	cleanupWorkerRunning  bool
+	cleanupDrainTimeout   time.Duration
 }
 
 type ManagerOptions struct {
@@ -138,6 +140,9 @@ type ManagerOptions struct {
 	Logger                *slog.Logger
 	OnLeaseRenewalFailure func(error)
 	OnCleanupFailure      func(CleanupFailure)
+	// CleanupDrainTimeout bounds Close while the serialized cleanup worker
+	// drains generations that no longer have readers.
+	CleanupDrainTimeout time.Duration
 }
 
 type Prepared struct {
@@ -220,6 +225,7 @@ func NewManagerWithFactory(options ManagerOptions) *Manager {
 		onCleanupFailure:      options.OnCleanupFailure,
 		leaseRenewalErrors:    map[string]error{},
 		leaseOwner:            firstNonEmpty(options.LeaseOwner, "runtimehost"),
+		cleanupDrainTimeout:   normalizedCleanupDrainTimeout(options.CleanupDrainTimeout),
 	}
 }
 
@@ -585,11 +591,10 @@ func (m *Manager) Close() error {
 	m.activeManagedRevision = ""
 	m.activeSnapshotID = 0
 	currentToClose := m.retireLocked(current)
+	targets := m.scheduledCleanupLocked()
 	m.mu.Unlock()
-	if currentToClose == nil {
-		return nil
-	}
-	return m.closeManaged(currentToClose)
+	m.cleanupRetired(currentToClose)
+	return m.waitForCleanup(targets)
 }
 
 func (m *Manager) Acquire() (Lease, error) {
@@ -621,11 +626,21 @@ func (m *Manager) retireLocked(runtime *managedRuntime) *managedRuntime {
 	if runtime == nil {
 		return nil
 	}
-	runtime.closing = true
-	if runtime.refs > 0 {
-		m.retired = append(m.retired, runtime)
+	if runtime.closing {
+		if runtime.refs == 0 && runtime.cleanupState == generationCleanupDraining {
+			runtime.cleanupState = generationCleanupPending
+			return runtime
+		}
 		return nil
 	}
+	runtime.closing = true
+	runtime.cleanupState = generationCleanupDraining
+	runtime.cleanupDone = make(chan struct{})
+	m.retired = append(m.retired, runtime)
+	if runtime.refs > 0 {
+		return nil
+	}
+	runtime.cleanupState = generationCleanupPending
 	return runtime
 }
 
@@ -636,7 +651,9 @@ func (m *Manager) release(runtime *managedRuntime) {
 		runtime.refs--
 		if runtime.refs == 0 && runtime.closing {
 			drained = runtime
-			m.removeRetiredLocked(runtime)
+			if runtime.cleanupState == generationCleanupDraining {
+				runtime.cleanupState = generationCleanupPending
+			}
 		}
 	}
 	m.mu.Unlock()
@@ -690,36 +707,90 @@ func (m *Manager) closeManagedResources(runtime *managedRuntime) []cleanupResult
 	if runtime == nil {
 		return nil
 	}
-	results := make([]cleanupResult, 0, 4)
-	if runtime.runtime != nil {
-		if err := runtime.runtime.Close(); err != nil {
-			results = append(results, cleanupResult{resource: CleanupResourceRuntime, err: err})
+	runtime.cleanupOnce.Do(func() {
+		results := make([]cleanupResult, 0, 4)
+		if runtime.runtime != nil {
+			if err := runtime.runtime.Close(); err != nil {
+				results = append(results, cleanupResult{resource: CleanupResourceRuntime, err: err})
+			}
 		}
-		runtime.runtime = nil
-	}
-	if err := releaseManagedDataLifetime(runtime.managedData); err != nil {
-		results = append(results, cleanupResult{resource: CleanupResourceManagedData, err: err})
-	}
-	runtime.managedData = nil
-	if err := runtime.snapshotLease.Close(); err != nil {
-		results = append(results, cleanupResult{resource: CleanupResourceSnapshotLease, err: err})
-	}
-	runtime.snapshotLease = nil
-	if err := closeRuntimeLifetime(runtime.runtimeLifetime); err != nil {
-		results = append(results, cleanupResult{resource: CleanupResourceDependency, err: err})
-	}
-	runtime.runtimeLifetime = nil
-	if runtime.closing && m.onDrained != nil {
-		m.onDrained(runtime.servingStateID, runtime.snapshotID)
-	}
-	return results
+		if err := releaseManagedDataLifetime(runtime.managedData); err != nil {
+			results = append(results, cleanupResult{resource: CleanupResourceManagedData, err: err})
+		}
+		if err := runtime.snapshotLease.Close(); err != nil {
+			results = append(results, cleanupResult{resource: CleanupResourceSnapshotLease, err: err})
+		}
+		if err := closeRuntimeLifetime(runtime.runtimeLifetime); err != nil {
+			results = append(results, cleanupResult{resource: CleanupResourceDependency, err: err})
+		}
+		if runtime.closing && m.onDrained != nil {
+			m.onDrained(runtime.servingStateID, runtime.snapshotID)
+		}
+		runtime.cleanupResults = results
+	})
+	return append([]cleanupResult(nil), runtime.cleanupResults...)
 }
 
 func (m *Manager) cleanupRetired(runtime *managedRuntime) {
 	if runtime == nil {
 		return
 	}
-	for _, result := range m.closeManagedResources(runtime) {
+	m.mu.Lock()
+	if runtime.cleanupState == generationCleanupNone {
+		runtime.closing = true
+		runtime.cleanupState = generationCleanupPending
+		runtime.cleanupDone = make(chan struct{})
+		m.retired = append(m.retired, runtime)
+	}
+	if runtime.cleanupState == generationCleanupDraining && runtime.refs == 0 {
+		runtime.cleanupState = generationCleanupPending
+	}
+	if runtime.cleanupState == generationCleanupPending && !m.cleanupWorkerRunning {
+		m.cleanupWorkerRunning = true
+		go m.runCleanupWorker()
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) runCleanupWorker() {
+	for {
+		m.mu.Lock()
+		runtime := m.nextPendingCleanupLocked()
+		if runtime == nil {
+			m.cleanupWorkerRunning = false
+			m.mu.Unlock()
+			return
+		}
+		runtime.cleanupState = generationCleanupRunning
+		m.mu.Unlock()
+
+		results := m.closeManagedResources(runtime)
+		m.reportCleanupFailures(runtime, results)
+		errList := make([]error, 0, len(results))
+		for _, result := range results {
+			errList = append(errList, result.err)
+		}
+
+		m.mu.Lock()
+		runtime.cleanupErr = errors.Join(errList...)
+		runtime.cleanupState = generationCleanupFinished
+		m.removeRetiredLocked(runtime)
+		close(runtime.cleanupDone)
+		m.mu.Unlock()
+	}
+}
+
+func (m *Manager) nextPendingCleanupLocked() *managedRuntime {
+	for _, runtime := range m.retired {
+		if runtime.cleanupState == generationCleanupPending {
+			return runtime
+		}
+	}
+	return nil
+}
+
+func (m *Manager) reportCleanupFailures(runtime *managedRuntime, results []cleanupResult) {
+	for _, result := range results {
 		failure := CleanupFailure{
 			WorkspaceID: m.workspaceID, ServingStateID: runtime.servingStateID,
 			DuckLakeSnapshotID: runtime.snapshotID, Resource: result.resource, Err: result.err,
@@ -733,6 +804,83 @@ func (m *Manager) cleanupRetired(runtime *managedRuntime) {
 	}
 }
 
+func (m *Manager) scheduledCleanupLocked() []*managedRuntime {
+	targets := make([]*managedRuntime, 0, len(m.retired))
+	for _, runtime := range m.retired {
+		if runtime.cleanupState == generationCleanupPending || runtime.cleanupState == generationCleanupRunning {
+			targets = append(targets, runtime)
+		}
+	}
+	return targets
+}
+
+func (m *Manager) waitForCleanup(targets []*managedRuntime) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	timer := time.NewTimer(m.cleanupDrainTimeout)
+	defer timer.Stop()
+	errs := make([]error, 0, len(targets))
+	for _, runtime := range targets {
+		select {
+		case <-runtime.cleanupDone:
+			errs = append(errs, runtime.cleanupErr)
+		case <-timer.C:
+			return errors.Join(errors.Join(errs...), fmt.Errorf("runtime cleanup did not drain within %s", m.cleanupDrainTimeout))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// GenerationCleanupState is the observable lifecycle of a retired runtime.
+type GenerationCleanupState string
+
+const (
+	GenerationCleanupDraining GenerationCleanupState = "draining_readers"
+	GenerationCleanupPending  GenerationCleanupState = "cleanup_pending"
+	GenerationCleanupRunning  GenerationCleanupState = "cleanup_running"
+)
+
+// RetiredGeneration is a tombstone retained until cleanup finishes.
+type RetiredGeneration struct {
+	ServingStateID     servingstate.ID
+	DuckLakeSnapshotID int64
+	Readers            int
+	CleanupState       GenerationCleanupState
+}
+
+// RetiredGenerations returns a consistent snapshot of draining and cleaning
+// generations.
+func (m *Manager) RetiredGenerations() []RetiredGeneration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]RetiredGeneration, 0, len(m.retired))
+	for _, runtime := range m.retired {
+		state := GenerationCleanupDraining
+		switch runtime.cleanupState {
+		case generationCleanupPending:
+			state = GenerationCleanupPending
+		case generationCleanupRunning:
+			state = GenerationCleanupRunning
+		}
+		out = append(out, RetiredGeneration{
+			ServingStateID: runtime.servingStateID, DuckLakeSnapshotID: runtime.snapshotID,
+			Readers: runtime.refs, CleanupState: state,
+		})
+	}
+	return out
+}
+
+type generationCleanupState uint8
+
+const (
+	generationCleanupNone generationCleanupState = iota
+	generationCleanupDraining
+	generationCleanupPending
+	generationCleanupRunning
+	generationCleanupFinished
+)
+
 type managedRuntime struct {
 	servingStateID  servingstate.ID
 	digest          string
@@ -743,6 +891,11 @@ type managedRuntime struct {
 	snapshotID      int64
 	refs            int
 	closing         bool
+	cleanupState    generationCleanupState
+	cleanupDone     chan struct{}
+	cleanupErr      error
+	cleanupOnce     sync.Once
+	cleanupResults  []cleanupResult
 }
 
 func releaseManagedDataLifetime(lifetime ManagedDataLifetime) error {
@@ -902,6 +1055,13 @@ func renewSnapshotLease(ctx context.Context, repo SnapshotLeaseRepository, lease
 func normalizedLeaseTTL(value time.Duration) time.Duration {
 	if value <= 0 {
 		return 5 * time.Minute
+	}
+	return value
+}
+
+func normalizedCleanupDrainTimeout(value time.Duration) time.Duration {
+	if value <= 0 {
+		return 15 * time.Second
 	}
 	return value
 }

--- a/internal/runtimehost/manager_test.go
+++ b/internal/runtimehost/manager_test.go
@@ -203,7 +203,7 @@ func TestManagerKeepsOldRuntimeOpenUntilLeaseRelease(t *testing.T) {
 	if err := manager.Reload(ctx); err != nil {
 		t.Fatalf("reload second: %v", err)
 	}
-	if oldRuntime.closed {
+	if oldRuntime.closed.Load() {
 		t.Fatal("old runtime closed while lease was still active")
 	}
 	newLease, err := manager.Acquire()
@@ -222,11 +222,135 @@ func TestManagerKeepsOldRuntimeOpenUntilLeaseRelease(t *testing.T) {
 	}
 
 	oldLease.Release()
-	if !oldRuntime.closed {
+	waitForManagerCleanup(t, manager)
+	if !oldRuntime.closed.Load() {
 		t.Fatal("old runtime was not closed after final lease release")
 	}
 	if !equalInt64s(drained, []int64{11}) {
 		t.Fatalf("drained snapshots = %#v, want [11]", drained)
+	}
+}
+
+func TestManagerFinalReleaseDoesNotBlockOnRetiredCleanup(t *testing.T) {
+	ctx := context.Background()
+	repo := &fakeRepo{
+		deployment: servingstate.State{ID: "dep_1", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive, DuckLakeSnapshotID: 11},
+		artifact:   servingstate.Artifact{ServingStateID: "dep_1", WorkspaceID: "test", Environment: "dev", Digest: "digest-1"},
+	}
+	factory := &fakeFactory{}
+	manager := NewManagerWithFactory(ManagerOptions{Repo: repo, WorkspaceID: "test", Environment: "dev", Factory: factory})
+	require.NoError(t, manager.Reload(ctx))
+	oldLease, err := manager.Acquire()
+	require.NoError(t, err)
+	oldRuntime := oldLease.Runtime().(*fakeRuntime)
+	oldRuntime.closeStarted = make(chan struct{})
+	oldRuntime.closeBlock = make(chan struct{})
+
+	repo.deployment = servingstate.State{ID: "dep_2", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive, DuckLakeSnapshotID: 22}
+	repo.artifact = servingstate.Artifact{ServingStateID: "dep_2", WorkspaceID: "test", Environment: "dev", Digest: "digest-2"}
+	require.NoError(t, manager.Reload(ctx))
+
+	released := make(chan struct{})
+	go func() {
+		oldLease.Release()
+		close(released)
+	}()
+	select {
+	case <-released:
+	case <-time.After(100 * time.Millisecond):
+		close(oldRuntime.closeBlock)
+		<-released
+		t.Fatal("final lease release blocked on retired runtime cleanup")
+	}
+	select {
+	case <-oldRuntime.closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("retired runtime cleanup was not scheduled")
+	}
+	retired := manager.RetiredGenerations()
+	if len(retired) != 1 || retired[0].ServingStateID != "dep_1" || retired[0].CleanupState != GenerationCleanupRunning {
+		t.Fatalf("cleanup tombstone = %#v, want dep_1 running", retired)
+	}
+	if got := manager.LeasedSnapshots(); !equalInt64s(got, []int64{11, 22}) {
+		t.Fatalf("cleanup tombstone snapshots = %#v, want [11 22]", got)
+	}
+	close(oldRuntime.closeBlock)
+	select {
+	case <-oldRuntime.closedCh:
+	case <-time.After(time.Second):
+		t.Fatal("retired runtime cleanup did not finish")
+	}
+	waitForManagerCleanup(t, manager)
+}
+
+func TestManagerCloseBoundsBlockingCleanup(t *testing.T) {
+	repo := &fakeRepo{
+		deployment: servingstate.State{ID: "dep_1", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive},
+		artifact:   servingstate.Artifact{ServingStateID: "dep_1", WorkspaceID: "test", Environment: "dev", Digest: "digest"},
+	}
+	factory := &fakeFactory{}
+	manager := NewManagerWithFactory(ManagerOptions{
+		Repo: repo, WorkspaceID: "test", Environment: "dev", Factory: factory,
+		CleanupDrainTimeout: 25 * time.Millisecond,
+	})
+	require.NoError(t, manager.Reload(t.Context()))
+	runtime := factory.runtime
+	runtime.closeStarted = make(chan struct{})
+	runtime.closeBlock = make(chan struct{})
+
+	started := time.Now()
+	err := manager.Close()
+	if err == nil || !strings.Contains(err.Error(), "did not drain") {
+		t.Fatalf("Close() error = %v, want bounded cleanup timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("Close() blocked for %s", elapsed)
+	}
+	select {
+	case <-runtime.closeStarted:
+	default:
+		t.Fatal("blocking cleanup never started")
+	}
+	close(runtime.closeBlock)
+	waitForManagerCleanup(t, manager)
+}
+
+func TestManagerConcurrentReleaseAndCloseCleansEachGenerationOnce(t *testing.T) {
+	repo := &fakeRepo{
+		deployment: servingstate.State{ID: "dep_1", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive},
+		artifact:   servingstate.Artifact{ServingStateID: "dep_1", WorkspaceID: "test", Environment: "dev", Digest: "digest-1"},
+	}
+	factory := &fakeFactory{}
+	manager := NewManagerWithFactory(ManagerOptions{Repo: repo, WorkspaceID: "test", Environment: "dev", Factory: factory})
+	require.NoError(t, manager.Reload(t.Context()))
+	oldRuntime := factory.runtime
+	leases := make([]Lease, 32)
+	for index := range leases {
+		lease, err := manager.Acquire()
+		require.NoError(t, err)
+		leases[index] = lease
+	}
+	repo.deployment = servingstate.State{ID: "dep_2", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive}
+	repo.artifact = servingstate.Artifact{ServingStateID: "dep_2", WorkspaceID: "test", Environment: "dev", Digest: "digest-2"}
+	require.NoError(t, manager.Reload(t.Context()))
+	newRuntime := factory.runtime
+
+	var wait sync.WaitGroup
+	wait.Add(len(leases) + 1)
+	for _, lease := range leases {
+		go func() {
+			defer wait.Done()
+			lease.Release()
+		}()
+	}
+	go func() {
+		defer wait.Done()
+		_ = manager.Close()
+	}()
+	wait.Wait()
+	waitForManagerCleanup(t, manager)
+	if oldRuntime.closeCalls.Load() != 1 || newRuntime.closeCalls.Load() != 1 {
+		t.Fatalf("runtime close calls = (%d, %d), want exactly once", oldRuntime.closeCalls.Load(), newRuntime.closeCalls.Load())
 	}
 }
 
@@ -253,15 +377,16 @@ func TestManagerKeepsManagedDataLifetimeUntilRuntimeDrains(t *testing.T) {
 	if err := manager.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if lifetime.releases != 0 {
+	if lifetime.releases.Load() != 0 {
 		t.Fatal("managed-data lifetime released while a query still held the runtime")
 	}
 	queryLease.Release()
-	if !runtime.closed {
+	waitForManagerCleanup(t, manager)
+	if !runtime.closed.Load() {
 		t.Fatal("runtime was not closed after its final query lease")
 	}
-	if lifetime.releases != 1 {
-		t.Fatalf("managed-data lifetime releases = %d, want 1", lifetime.releases)
+	if lifetime.releases.Load() != 1 {
+		t.Fatalf("managed-data lifetime releases = %d, want 1", lifetime.releases.Load())
 	}
 }
 
@@ -276,8 +401,8 @@ func TestPreparedReleasesManagedDataLifetimeOnFailureAndAbandonment(t *testing.T
 	if err == nil {
 		t.Fatal("prepare unexpectedly succeeded")
 	}
-	if failureLifetime.releases != 1 {
-		t.Fatalf("failed preparation releases = %d, want 1", failureLifetime.releases)
+	if failureLifetime.releases.Load() != 1 {
+		t.Fatalf("failed preparation releases = %d, want 1", failureLifetime.releases.Load())
 	}
 
 	abandonedLifetime := &fakeManagedDataLifetime{}
@@ -287,8 +412,8 @@ func TestPreparedReleasesManagedDataLifetimeOnFailureAndAbandonment(t *testing.T
 	if err := prepared.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if abandonedLifetime.releases != 1 {
-		t.Fatalf("abandoned preparation releases = %d, want 1", abandonedLifetime.releases)
+	if abandonedLifetime.releases.Load() != 1 {
+		t.Fatalf("abandoned preparation releases = %d, want 1", abandonedLifetime.releases.Load())
 	}
 }
 
@@ -306,11 +431,11 @@ func TestManagerPreparationFailsClosedWhenGenerationLeaseCannotPersist(t *testin
 	if _, err := manager.PrepareServingState(t.Context(), "dep_1"); err == nil {
 		t.Fatal("prepare error = nil, want durable generation lease failure")
 	}
-	if factory.runtime == nil || !factory.runtime.closed {
+	if factory.runtime == nil || !factory.runtime.closed.Load() {
 		t.Fatalf("prepared runtime = %#v, want closed after lease failure", factory.runtime)
 	}
-	if lifetime.releases != 1 {
-		t.Fatalf("managed-data lifetime releases = %d, want 1", lifetime.releases)
+	if lifetime.releases.Load() != 1 {
+		t.Fatalf("managed-data lifetime releases = %d, want 1", lifetime.releases.Load())
 	}
 }
 
@@ -416,6 +541,7 @@ func TestManagerRetiredGenerationKeepsSnapshotLeaseUntilReadersDrain(t *testing.
 	}
 
 	reader.Release()
+	waitForManagerCleanup(t, manager)
 	if got := repo.releasedLeases; len(got) != 1 || got[0] != "lease_1" {
 		t.Fatalf("released leases after old reader drained = %#v, want [lease_1]", got)
 	}
@@ -471,14 +597,15 @@ func TestManagerCloseDefersRuntimeCloseUntilLeaseRelease(t *testing.T) {
 	if err := manager.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if runtime.closed {
+	if runtime.closed.Load() {
 		t.Fatal("runtime closed while close waited on active lease")
 	}
 	if _, err := manager.Acquire(); err == nil {
 		t.Fatal("acquire after close error = nil")
 	}
 	lease.Release()
-	if !runtime.closed {
+	waitForManagerCleanup(t, manager)
+	if !runtime.closed.Load() {
 		t.Fatal("runtime was not closed after leased close release")
 	}
 }
@@ -778,7 +905,7 @@ func TestRegistryPreparedSetActivatesAndCommitsEveryWorkspaceTogether(t *testing
 		t.Fatalf("prepare set: %v", err)
 	}
 	defer prepared.Close()
-	if len(factory.runtimes) != 4 || factory.runtimes[0].closed || factory.runtimes[1].closed {
+	if len(factory.runtimes) != 4 || factory.runtimes[0].closed.Load() || factory.runtimes[1].closed.Load() {
 		t.Fatalf("active generation was not retained during prepare: %#v", factory.runtimes)
 	}
 	activeLease, err := registry.managerForWorkspace("operations").Acquire()
@@ -879,6 +1006,9 @@ func TestRegistryActivatePreparedSetReportsCleanupFailureAfterPublishingEveryWor
 		}
 		lease.Release()
 	}
+	for _, workspaceID := range []servingstate.WorkspaceID{"operations", "sales"} {
+		waitForManagerCleanup(t, registry.managerForWorkspace(workspaceID))
+	}
 	if len(failures) != 1 || !errors.Is(failures[0].Err, wantCleanupErr) {
 		t.Fatalf("cleanup failures = %#v, want runtime close failure", failures)
 	}
@@ -932,7 +1062,7 @@ func TestRegistryDelayedDrainReportsCleanupFailureAfterLeaseRelease(t *testing.T
 	if err := registry.ActivatePrepared(prepared, func() error { return nil }); err != nil {
 		t.Fatal(err)
 	}
-	if factory.runtimes[0].closed {
+	if factory.runtimes[0].closed.Load() {
 		t.Fatal("leased runtime closed during activation")
 	}
 	lease.Release()
@@ -1065,8 +1195,8 @@ func TestRegistryPreparationFailureReleasesUnprocessedManagedDataLifetimes(t *te
 	if err == nil {
 		t.Fatal("preparation unexpectedly succeeded")
 	}
-	if first.releases != 1 || second.releases != 1 {
-		t.Fatalf("managed-data releases = (%d, %d), want (1, 1)", first.releases, second.releases)
+	if first.releases.Load() != 1 || second.releases.Load() != 1 {
+		t.Fatalf("managed-data releases = (%d, %d), want (1, 1)", first.releases.Load(), second.releases.Load())
 	}
 }
 
@@ -1253,7 +1383,7 @@ func TestRegistryPrepareServingStateClosesLoadedRuntimesBeforePrepare(t *testing
 	if err := registry.Reload(context.Background()); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	if len(factory.runtimes) != 2 || factory.runtimes[0].closed || factory.runtimes[1].closed {
+	if len(factory.runtimes) != 2 || factory.runtimes[0].closed.Load() || factory.runtimes[1].closed.Load() {
 		t.Fatalf("loaded runtimes = %#v, want two open runtimes", factory.runtimes)
 	}
 
@@ -1262,10 +1392,10 @@ func TestRegistryPrepareServingStateClosesLoadedRuntimesBeforePrepare(t *testing
 		t.Fatalf("prepare visuals: %v", err)
 	}
 	defer prepared.Close()
-	if !factory.runtimes[0].closed || !factory.runtimes[1].closed {
+	if !factory.runtimes[0].closed.Load() || !factory.runtimes[1].closed.Load() {
 		t.Fatalf("previous active runtimes were not closed before prepare: %#v", factory.runtimes)
 	}
-	if len(factory.runtimes) != 3 || factory.runtimes[2].closed {
+	if len(factory.runtimes) != 3 || factory.runtimes[2].closed.Load() {
 		t.Fatalf("prepared runtime = %#v, want new open runtime", factory.runtimes)
 	}
 }
@@ -1290,7 +1420,7 @@ func TestRegistryAcquireForWorkspaceDoesNotDiscoverRepositoryChanges(t *testing.
 	if err := registry.Reload(context.Background()); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	if len(factory.runtimes) != 2 || factory.runtimes[0].closed || factory.runtimes[1].closed {
+	if len(factory.runtimes) != 2 || factory.runtimes[0].closed.Load() || factory.runtimes[1].closed.Load() {
 		t.Fatalf("loaded runtimes = %#v, want two open runtimes", factory.runtimes)
 	}
 	repo.active["visuals/prod"] = registryDeploymentArtifact{
@@ -1305,7 +1435,7 @@ func TestRegistryAcquireForWorkspaceDoesNotDiscoverRepositoryChanges(t *testing.
 	if len(repo.activeCalls) != activeCalls {
 		t.Fatalf("repository active calls = %d, want unchanged %d", len(repo.activeCalls), activeCalls)
 	}
-	if len(factory.runtimes) != 2 || factory.runtimes[0].closed || factory.runtimes[1].closed {
+	if len(factory.runtimes) != 2 || factory.runtimes[0].closed.Load() || factory.runtimes[1].closed.Load() {
 		t.Fatalf("acquisition mutated loaded runtimes: %#v", factory.runtimes)
 	}
 }
@@ -1343,7 +1473,7 @@ func TestRegistryAcquireForWorkspaceIsMemoryOnly(t *testing.T) {
 	if len(factory.runtimes) != 2 {
 		t.Fatalf("runtime count = %d, want no new prepare", len(factory.runtimes))
 	}
-	if factory.runtimes[0].closed || factory.runtimes[1].closed {
+	if factory.runtimes[0].closed.Load() || factory.runtimes[1].closed.Load() {
 		t.Fatalf("no-change reload closed runtimes: %#v", factory.runtimes)
 	}
 }
@@ -1373,7 +1503,7 @@ func TestRegistryCloseClosesEveryActiveWorkspaceRuntime(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 	for _, runtime := range factory.runtimes {
-		if !runtime.closed {
+		if !runtime.closed.Load() {
 			t.Fatalf("runtime %#v was not closed", runtime)
 		}
 	}
@@ -1475,7 +1605,7 @@ func (f *fakeFactory) Prepare(_ context.Context, input RuntimeInput) (Runtime, e
 	if input.State.DuckLakeSnapshotID > 0 {
 		snapshotID = input.State.DuckLakeSnapshotID
 	}
-	f.runtime = &fakeRuntime{snapshotID: snapshotID}
+	f.runtime = &fakeRuntime{snapshotID: snapshotID, closedCh: make(chan struct{})}
 	return f.runtime, nil
 }
 
@@ -1496,11 +1626,11 @@ func (r *countingManagedDataResolver) ResolveManagedData(context.Context, servin
 }
 
 type fakeManagedDataLifetime struct {
-	releases int
+	releases atomic.Int32
 }
 
 func (l *fakeManagedDataLifetime) Release() error {
-	l.releases++
+	l.releases.Add(1)
 	return nil
 }
 
@@ -1509,13 +1639,30 @@ func (r fakeManagedDataResolver) ResolveManagedData(context.Context, servingstat
 }
 
 type fakeRuntime struct {
-	closed      bool
-	snapshotID  int64
-	verifyCalls int
+	closed       atomic.Bool
+	snapshotID   int64
+	verifyCalls  int
+	closeStarted chan struct{}
+	closeBlock   chan struct{}
+	closedCh     chan struct{}
+	closeOnce    sync.Once
+	closeCalls   atomic.Int32
 }
 
 func (r *fakeRuntime) Close() error {
-	r.closed = true
+	r.closeOnce.Do(func() {
+		r.closeCalls.Add(1)
+		if r.closeStarted != nil {
+			close(r.closeStarted)
+		}
+		if r.closeBlock != nil {
+			<-r.closeBlock
+		}
+		r.closed.Store(true)
+		if r.closedCh != nil {
+			close(r.closedCh)
+		}
+	})
 	return nil
 }
 
@@ -1600,18 +1747,25 @@ type recordingRegistryFactory struct {
 func (f *recordingRegistryFactory) Prepare(_ context.Context, input RuntimeInput) (Runtime, error) {
 	f.inputs = append(f.inputs, fmt.Sprintf("%s/%s/%s", input.State.WorkspaceID, input.State.Environment, input.State.ID))
 	f.managedData = append(f.managedData, input.ManagedData)
-	runtime := &recordingRuntime{}
+	runtime := &recordingRuntime{closedCh: make(chan struct{})}
 	f.runtimes = append(f.runtimes, runtime)
 	return runtime, nil
 }
 
 type recordingRuntime struct {
-	closed   bool
-	closeErr error
+	closed    atomic.Bool
+	closeErr  error
+	closedCh  chan struct{}
+	closeOnce sync.Once
 }
 
 func (r *recordingRuntime) Close() error {
-	r.closed = true
+	r.closeOnce.Do(func() {
+		r.closed.Store(true)
+		if r.closedCh != nil {
+			close(r.closedCh)
+		}
+	})
 	return r.closeErr
 }
 
@@ -1630,7 +1784,7 @@ func (f *blockingRegistryFactory) Prepare(_ context.Context, input RuntimeInput)
 		close(f.started)
 		<-f.release
 	}
-	return &recordingRuntime{}, nil
+	return &recordingRuntime{closedCh: make(chan struct{})}, nil
 }
 
 func (f *overlapDetectingRegistryFactory) Prepare(context.Context, RuntimeInput) (Runtime, error) {
@@ -1640,7 +1794,7 @@ func (f *overlapDetectingRegistryFactory) Prepare(context.Context, RuntimeInput)
 	}
 	time.Sleep(25 * time.Millisecond)
 	f.active.Add(-1)
-	return &recordingRuntime{}, nil
+	return &recordingRuntime{closedCh: make(chan struct{})}, nil
 }
 
 func equalStrings(got, want []string) bool {
@@ -1665,4 +1819,15 @@ func equalInt64s(got, want []int64) bool {
 		}
 	}
 	return true
+}
+
+func waitForManagerCleanup(t testing.TB, manager *Manager) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for len(manager.RetiredGenerations()) != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("retired generations did not clean up: %#v", manager.RetiredGenerations())
+		}
+		time.Sleep(time.Millisecond)
+	}
 }

--- a/internal/runtimehost/manager_test.go
+++ b/internal/runtimehost/manager_test.go
@@ -283,6 +283,37 @@ func TestManagerFinalReleaseDoesNotBlockOnRetiredCleanup(t *testing.T) {
 	waitForManagerCleanup(t, manager)
 }
 
+func TestManagerOnDrainedObservesSnapshotAfterTombstoneRemoval(t *testing.T) {
+	ctx := context.Background()
+	repo := &fakeRepo{
+		deployment: servingstate.State{ID: "dep_1", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive, DuckLakeSnapshotID: 11},
+		artifact:   servingstate.Artifact{ServingStateID: "dep_1", WorkspaceID: "test", Environment: "dev", Digest: "digest-1"},
+	}
+	observed := make(chan []int64, 1)
+	var manager *Manager
+	manager = NewManagerWithFactory(ManagerOptions{
+		Repo: repo, WorkspaceID: "test", Environment: "dev", Factory: &fakeFactory{},
+		OnDrained: func(_ servingstate.ID, _ int64) {
+			observed <- manager.LeasedSnapshots()
+		},
+	})
+	require.NoError(t, manager.Reload(ctx))
+	oldLease, err := manager.Acquire()
+	require.NoError(t, err)
+
+	repo.deployment = servingstate.State{ID: "dep_2", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive, DuckLakeSnapshotID: 22}
+	repo.artifact = servingstate.Artifact{ServingStateID: "dep_2", WorkspaceID: "test", Environment: "dev", Digest: "digest-2"}
+	require.NoError(t, manager.Reload(ctx))
+	oldLease.Release()
+
+	select {
+	case snapshots := <-observed:
+		require.Equal(t, []int64{22}, snapshots)
+	case <-time.After(time.Second):
+		t.Fatal("drained callback did not run")
+	}
+}
+
 func TestManagerCloseBoundsBlockingCleanup(t *testing.T) {
 	repo := &fakeRepo{
 		deployment: servingstate.State{ID: "dep_1", WorkspaceID: "test", Environment: "dev", Status: servingstate.StatusActive},
@@ -1505,6 +1536,46 @@ func TestRegistryCloseClosesEveryActiveWorkspaceRuntime(t *testing.T) {
 	for _, runtime := range factory.runtimes {
 		if !runtime.closed.Load() {
 			t.Fatalf("runtime %#v was not closed", runtime)
+		}
+	}
+}
+
+func TestRegistryCloseSerializesWithActivation(t *testing.T) {
+	repo := newFakeRegistryRepo()
+	repo.deployments["dep_sales_next"] = servingstate.State{ID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Status: servingstate.StatusValidated}
+	repo.artifacts["dep_sales_next"] = servingstate.Artifact{ServingStateID: "dep_sales_next", WorkspaceID: "sales", Environment: "prod", Digest: "next"}
+	factory := &recordingRegistryFactory{}
+	registry := NewRegistryWithFactory(RegistryOptions{Repo: repo, Environment: "prod", Factory: factory})
+	prepared, err := registry.PrepareServingState(context.Background(), "dep_sales_next")
+	require.NoError(t, err)
+
+	activationStarted := make(chan struct{})
+	allowActivation := make(chan struct{})
+	activationDone := make(chan error, 1)
+	go func() {
+		activationDone <- registry.ActivatePrepared(prepared, func() error {
+			close(activationStarted)
+			<-allowActivation
+			return nil
+		})
+	}()
+	<-activationStarted
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- registry.Close() }()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close completed during activation: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(allowActivation)
+	require.NoError(t, <-activationDone)
+	require.NoError(t, <-closeDone)
+	if _, err := registry.AcquireForWorkspace(context.Background(), "sales"); err == nil {
+		t.Fatal("runtime was acquirable after registry close")
+	}
+	for _, runtime := range factory.runtimes {
+		if !runtime.closed.Load() {
+			t.Fatal("runtime published during close was not closed")
 		}
 	}
 }

--- a/internal/runtimehost/registry.go
+++ b/internal/runtimehost/registry.go
@@ -15,30 +15,32 @@ import (
 )
 
 type RegistryOptions struct {
-	Repo             ServingStateRepository
-	WorkspaceIDs     []servingstate.WorkspaceID
-	Environment      servingstate.Environment
-	Factory          RuntimeFactory
-	ManagedData      ManagedDataResolver
-	Now              func() time.Time
-	OnDrained        func(servingstate.ID, int64)
-	Logger           *slog.Logger
-	OnCleanupFailure func(CleanupFailure)
+	Repo                ServingStateRepository
+	WorkspaceIDs        []servingstate.WorkspaceID
+	Environment         servingstate.Environment
+	Factory             RuntimeFactory
+	ManagedData         ManagedDataResolver
+	Now                 func() time.Time
+	OnDrained           func(servingstate.ID, int64)
+	Logger              *slog.Logger
+	OnCleanupFailure    func(CleanupFailure)
+	CleanupDrainTimeout time.Duration
 }
 
 type Registry struct {
-	mu               sync.RWMutex
-	prepareMu        sync.Mutex
-	cutoverMu        sync.RWMutex
-	repo             ServingStateRepository
-	environment      servingstate.Environment
-	factory          RuntimeFactory
-	managedData      ManagedDataResolver
-	onDrained        func(servingstate.ID, int64)
-	logger           *slog.Logger
-	onCleanupFailure func(CleanupFailure)
-	managers         map[servingstate.WorkspaceID]*Manager
-	candidates       *candidateRuntimeRegistry
+	mu                  sync.RWMutex
+	prepareMu           sync.Mutex
+	cutoverMu           sync.RWMutex
+	repo                ServingStateRepository
+	environment         servingstate.Environment
+	factory             RuntimeFactory
+	managedData         ManagedDataResolver
+	onDrained           func(servingstate.ID, int64)
+	logger              *slog.Logger
+	onCleanupFailure    func(CleanupFailure)
+	cleanupDrainTimeout time.Duration
+	managers            map[servingstate.WorkspaceID]*Manager
+	candidates          *candidateRuntimeRegistry
 }
 
 type RegistryPrepared struct {
@@ -201,15 +203,16 @@ type WorkspaceProvider struct {
 
 func NewRegistryWithFactory(options RegistryOptions) *Registry {
 	registry := &Registry{
-		repo:             options.Repo,
-		environment:      servingstate.NormalizeEnvironment(options.Environment),
-		factory:          options.Factory,
-		managedData:      options.ManagedData,
-		onDrained:        options.OnDrained,
-		logger:           options.Logger,
-		onCleanupFailure: options.OnCleanupFailure,
-		managers:         map[servingstate.WorkspaceID]*Manager{},
-		candidates:       newCandidateRuntimeRegistry(options.Now),
+		repo:                options.Repo,
+		environment:         servingstate.NormalizeEnvironment(options.Environment),
+		factory:             options.Factory,
+		managedData:         options.ManagedData,
+		onDrained:           options.OnDrained,
+		logger:              options.Logger,
+		onCleanupFailure:    options.OnCleanupFailure,
+		cleanupDrainTimeout: options.CleanupDrainTimeout,
+		managers:            map[servingstate.WorkspaceID]*Manager{},
+		candidates:          newCandidateRuntimeRegistry(options.Now),
 	}
 	for _, workspaceID := range options.WorkspaceIDs {
 		registry.managerForWorkspace(workspaceID)
@@ -523,14 +526,15 @@ func (r *Registry) managerForWorkspace(workspaceID servingstate.WorkspaceID) *Ma
 		return manager
 	}
 	manager := NewManagerWithFactory(ManagerOptions{
-		Repo:             r.repo,
-		WorkspaceID:      workspaceID,
-		Environment:      r.environment,
-		Factory:          r.factory,
-		ManagedData:      r.managedData,
-		OnDrained:        r.onDrained,
-		Logger:           r.logger,
-		OnCleanupFailure: r.onCleanupFailure,
+		Repo:                r.repo,
+		WorkspaceID:         workspaceID,
+		Environment:         r.environment,
+		Factory:             r.factory,
+		ManagedData:         r.managedData,
+		OnDrained:           r.onDrained,
+		Logger:              r.logger,
+		OnCleanupFailure:    r.onCleanupFailure,
+		CleanupDrainTimeout: r.cleanupDrainTimeout,
 	})
 	r.managers[workspaceID] = manager
 	return manager

--- a/internal/runtimehost/registry.go
+++ b/internal/runtimehost/registry.go
@@ -41,7 +41,12 @@ type Registry struct {
 	cleanupDrainTimeout time.Duration
 	managers            map[servingstate.WorkspaceID]*Manager
 	candidates          *candidateRuntimeRegistry
+	closed              bool
+	closeDone           chan struct{}
+	closeErr            error
 }
+
+var ErrRegistryClosed = errors.New("runtime registry closed")
 
 type RegistryPrepared struct {
 	registry    *Registry
@@ -210,7 +215,7 @@ func NewRegistryWithFactory(options RegistryOptions) *Registry {
 		onDrained:           options.OnDrained,
 		logger:              options.Logger,
 		onCleanupFailure:    options.OnCleanupFailure,
-		cleanupDrainTimeout: options.CleanupDrainTimeout,
+		cleanupDrainTimeout: normalizedCleanupDrainTimeout(options.CleanupDrainTimeout),
 		managers:            map[servingstate.WorkspaceID]*Manager{},
 		candidates:          newCandidateRuntimeRegistry(options.Now),
 	}
@@ -221,11 +226,16 @@ func NewRegistryWithFactory(options RegistryOptions) *Registry {
 }
 
 func (r *Registry) Reload(ctx context.Context) error {
+	r.prepareMu.Lock()
+	defer r.prepareMu.Unlock()
+	r.cutoverMu.RLock()
+	defer r.cutoverMu.RUnlock()
+	if r.closed {
+		return ErrRegistryClosed
+	}
 	for _, workspaceID := range r.workspaceIDs() {
 		manager := r.managerForWorkspace(workspaceID)
-		r.prepareMu.Lock()
 		err := manager.ReloadBeforePrepare(ctx, r.closePreparedRuntimes)
-		r.prepareMu.Unlock()
 		if err != nil {
 			return err
 		}
@@ -241,13 +251,21 @@ func (r *Registry) PrepareServingState(ctx context.Context, servingStateID strin
 	if servingstate.NormalizeEnvironment(current.Environment) != r.environment {
 		return nil, fmt.Errorf("serving state %s environment = %q, want %q", servingStateID, current.Environment, r.environment)
 	}
-	manager := r.managerForWorkspace(current.WorkspaceID)
 	r.prepareMu.Lock()
+	r.cutoverMu.RLock()
+	if r.closed {
+		r.cutoverMu.RUnlock()
+		r.prepareMu.Unlock()
+		return nil, ErrRegistryClosed
+	}
+	manager := r.managerForWorkspace(current.WorkspaceID)
 	if err := r.closePreparedRuntimes(); err != nil {
+		r.cutoverMu.RUnlock()
 		r.prepareMu.Unlock()
 		return nil, err
 	}
 	prepared, err := manager.PrepareServingState(ctx, servingStateID)
+	r.cutoverMu.RUnlock()
 	r.prepareMu.Unlock()
 	if err != nil {
 		return nil, err
@@ -321,6 +339,11 @@ func (r *Registry) prepareServingStateCandidates(ctx context.Context, inputs []s
 
 	r.prepareMu.Lock()
 	defer r.prepareMu.Unlock()
+	r.cutoverMu.RLock()
+	defer r.cutoverMu.RUnlock()
+	if r.closed {
+		return nil, ErrRegistryClosed
+	}
 	set := &PreparedSet{registry: r, items: make([]*RegistryPrepared, 0, len(candidates))}
 	for _, candidate := range candidates {
 		manager := r.managerForWorkspace(candidate.state.WorkspaceID)
@@ -358,6 +381,10 @@ func (r *Registry) ActivatePrepared(candidate servingstate.PreparedRuntime, acti
 		)
 	}
 	r.cutoverMu.Lock()
+	if r.closed {
+		r.cutoverMu.Unlock()
+		return errors.Join(ErrRegistryClosed, prepared.abort())
+	}
 	if err := activate(); err != nil {
 		r.cutoverMu.Unlock()
 		return errors.Join(err, prepared.abort())
@@ -413,6 +440,10 @@ func (r *Registry) ActivatePreparedSet(set *PreparedSet, activate func() error) 
 	set.consumed = true
 
 	r.cutoverMu.Lock()
+	if r.closed {
+		r.cutoverMu.Unlock()
+		return errors.Join(ErrRegistryClosed, abortSealed(batch))
+	}
 	if err := activate(); err != nil {
 		r.cutoverMu.Unlock()
 		return errors.Join(err, abortSealed(batch))
@@ -461,16 +492,39 @@ func abortSealed(items []*sealedPrepared) error {
 }
 
 func (r *Registry) Close() error {
-	for _, generation := range r.candidates.close() {
+	r.prepareMu.Lock()
+	r.cutoverMu.Lock()
+	if r.closed {
+		done := r.closeDone
+		r.cutoverMu.Unlock()
+		r.prepareMu.Unlock()
+		if done != nil {
+			<-done
+		}
+		return r.closeErr
+	}
+	r.closed = true
+	r.closeDone = make(chan struct{})
+	done := r.closeDone
+	r.cutoverMu.Unlock()
+	r.prepareMu.Unlock()
+
+	drainedCandidates, candidateTargets := r.candidates.close()
+	for _, generation := range drainedCandidates {
 		r.cleanupCandidateGeneration(generation)
 	}
-	var first error
+	var errs []error
 	for _, workspaceID := range r.workspaceIDs() {
-		if err := r.managerForWorkspace(workspaceID).Close(); err != nil && first == nil {
-			first = err
+		if err := r.managerForWorkspace(workspaceID).Close(); err != nil {
+			errs = append(errs, err)
 		}
 	}
-	return first
+	if err := r.waitForCandidateCleanup(candidateTargets); err != nil {
+		errs = append(errs, err)
+	}
+	r.closeErr = errors.Join(errs...)
+	close(done)
+	return r.closeErr
 }
 
 func (r *Registry) AcquireForWorkspace(ctx context.Context, workspaceID servingstate.WorkspaceID) (Lease, error) {
@@ -479,6 +533,9 @@ func (r *Registry) AcquireForWorkspace(ctx context.Context, workspaceID servings
 	}
 	r.cutoverMu.RLock()
 	defer r.cutoverMu.RUnlock()
+	if r.closed {
+		return nil, ErrRegistryClosed
+	}
 	r.mu.RLock()
 	manager := r.managers[workspaceID]
 	r.mu.RUnlock()
@@ -489,8 +546,28 @@ func (r *Registry) AcquireForWorkspace(ctx context.Context, workspaceID servings
 }
 
 func (r *Registry) ProviderForWorkspace(workspaceID servingstate.WorkspaceID) *WorkspaceProvider {
-	r.managerForWorkspace(workspaceID)
+	r.cutoverMu.RLock()
+	if !r.closed {
+		r.managerForWorkspace(workspaceID)
+	}
+	r.cutoverMu.RUnlock()
 	return &WorkspaceProvider{registry: r, workspaceID: workspaceID}
+}
+
+func (r *Registry) waitForCandidateCleanup(targets []*candidateGeneration) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	timer := time.NewTimer(r.cleanupDrainTimeout)
+	defer timer.Stop()
+	for _, generation := range targets {
+		select {
+		case <-generation.cleanupDone:
+		case <-timer.C:
+			return fmt.Errorf("candidate runtime cleanup did not drain within %s", r.cleanupDrainTimeout)
+		}
+	}
+	return nil
 }
 
 func (p *WorkspaceProvider) Acquire(ctx context.Context) (Lease, error) {


### PR DESCRIPTION
## Summary

- move final-reader teardown off the lease release path onto one serialized cleanup worker per workspace manager
- retain observable retired-generation tombstones and snapshot leases through draining, pending, and running cleanup states
- close runtime, managed-data, snapshot, and dependency resources exactly once while preserving structured failure reporting
- bound Manager and Registry shutdown cleanup with a configurable drain timeout
- cover blocked teardown, concurrent release/close, candidate cleanup, lifecycle observability, and deployment cutover integration under the race detector

## Inspiration

- Dagger Sourcebook revision 6fdd9b9d09c6: engine/server/session.go and engine/server/session_test.go for non-blocking final disconnect and once-only teardown behavior
- go-control-plane Sourcebook revision 0bd970b40121: pkg/cache/v3/snapshot.go and pkg/cache/v3/simple.go for explicit generation/snapshot lifetime separation
- LeapView implementation: internal/runtimehost/manager.go, internal/runtimehost/registry.go, internal/runtimehost/manager_test.go, internal/runtimehost/candidates_test.go, and internal/deployment/sqlite/repository_test.go

## Validation

- go test -tags=duckdb_arrow ./internal/runtimehost ./internal/deployment/... ./internal/dashboard/module ./internal/app/... (runtime/deployment/dashboard/app passed; unrelated public-site asset tests lack generated static/vendor files in this worktree)
- go test -race -tags=duckdb_arrow ./internal/runtimehost ./internal/deployment/sqlite
- go vet -tags=duckdb_arrow ./internal/runtimehost ./internal/deployment/...
- task generated:check
- git diff --check

## Stack

Stack 4/7. Depends on #236.

Linear: LEA-294