### PR TITLE
LEA-295: replace field counts with composition invariants

### DIFF
--- a/docs/articles/architecture/overview.md
+++ b/docs/articles/architecture/overview.md
@@ -28,6 +28,19 @@ Offline initialization, retention, analytical cleanup, backup, and restore are A
 
 `cmd/leapview` starts the application and CLI. Transport adapters parse HTTP or Datastar commands and invoke capability use cases. Capability code enforces authorization and lifecycle invariants through explicit ports. Capability-owned adapters implement SQLite, DuckLake, object-storage, filesystem, and external-connector behavior.
 
+The process-facing `Application` surface is deliberately closed: handler,
+start, shutdown, and fatal health only. A private lifecycle owner starts
+components in dependency order, stops them in reverse order, and runs cleanup
+closures once. Capability browser routes remain in each capability's `module`
+package; the application router mounts those route sets and owns only global
+process endpoints and cross-capability candidate composition.
+
+Architecture checks enforce the declared capability graph as a directed
+acyclic graph, validate every production import against that graph, prevent
+the application router from reclaiming capability routes, and pin the narrow
+process surface. These dependency and lifecycle invariants replace structural
+field-count limits, which measured representation rather than coupling.
+
 Avoid introducing a second path around capability use cases. Browser, CLI-backed API, and agent tools should converge on the same authorization and semantic boundaries.
 
 ## Configuration and deployment

--- a/internal/access/module/routes.go
+++ b/internal/access/module/routes.go
@@ -1,7 +1,9 @@
 package module
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -10,6 +12,18 @@ func (m *Module) MountLoginPage(r chi.Router) {
 	if m != nil {
 		r.Get("/login", m.Login)
 	}
+}
+
+func (m *Module) MountSCIM(r chi.Router, bearerToken string) error {
+	if m == nil || strings.TrimSpace(bearerToken) == "" {
+		return nil
+	}
+	handler, err := m.SCIMHandler(bearerToken)
+	if err != nil {
+		return fmt.Errorf("build SCIM handler: %w", err)
+	}
+	r.Handle("/scim/*", http.StripPrefix("/scim", handler))
+	return nil
 }
 
 func (m *Module) MountAuthenticatedBrowser(r chi.Router) {

--- a/internal/agent/module/routes.go
+++ b/internal/agent/module/routes.go
@@ -25,3 +25,9 @@ func (m *Module) MountAuthenticated(r chi.Router, guard RouteGuard) {
 	r.Post("/chats/turns", guard.ProtectGlobal(access.PrivilegeUseAgent, h.ChatTurn))
 	r.Patch("/admin/agent/config", guard.Protect(access.PrivilegeManageGrants, h.UpdateAdminConfig))
 }
+
+func (m *Module) MountMCP(r chi.Router) {
+	if m != nil {
+		r.Handle("/mcp", m.MCPHandler())
+	}
+}

--- a/internal/app/agent_ui_adapters.go
+++ b/internal/app/agent_ui_adapters.go
@@ -3,6 +3,7 @@ package app
 import (
 	"net/http"
 
+	accessmodule "github.com/flidai/leapview/internal/access/module"
 	agentmodule "github.com/flidai/leapview/internal/agent/module"
 	"github.com/flidai/leapview/internal/app/brand"
 	appshell "github.com/flidai/leapview/internal/app/shell"
@@ -11,18 +12,18 @@ import (
 	"github.com/flidai/leapview/internal/platform/web/staticasset"
 )
 
-func applicationLayout(routes *capabilityRoutes, assets staticasset.Resolver, r *http.Request) webpage.Provider {
+func applicationLayout(access *accessmodule.Module, agent *agentmodule.Module, assets staticasset.Resolver, r *http.Request) webpage.Provider {
 	config := appshell.Config{
 		Presentation: webpage.Presentation{ProductName: brand.Name, FaviconPath: brand.FaviconPath},
 		Assets:       assets,
 	}
-	if routes != nil && routes.accessModule != nil {
-		config.RoleLabel = routes.accessModule.CurrentRoleLabel(r)
+	if access != nil {
+		config.RoleLabel = access.CurrentRoleLabel(r)
 	}
-	if routes == nil || routes.agentModule == nil {
+	if agent == nil {
 		return appshell.Provider(config)
 	}
-	state := routes.agentModule.ChromeSignal(r)
+	state := agent.ChromeSignal(r)
 	config.ActiveConversationID = state.ActiveConversationID
 	config.Conversations = make([]appshell.Conversation, 0, len(state.Conversations))
 	for _, conversation := range state.Conversations {

--- a/internal/app/api_apigen.go
+++ b/internal/app/api_apigen.go
@@ -10,7 +10,6 @@ import (
 	manageddatamodule "github.com/flidai/leapview/internal/manageddata/module"
 	"github.com/flidai/leapview/internal/platform/buildinfo"
 	apitransport "github.com/flidai/leapview/internal/platform/http/transport"
-	"github.com/go-chi/chi/v5"
 )
 
 func agentAPIGenOperations() []agentmodule.APIGenOperation {
@@ -36,10 +35,6 @@ func accessAPIGenOperationContracts() map[string]accessmodule.APIGenOperationCon
 		}
 	}
 	return contracts
-}
-
-func registerAPIGenRoutes(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, r chi.Router) {
-	apiaggregate.RegisterAPIGenRoutes(r, platform.apiGenServers)
 }
 
 type apiGenDispatcher struct {

--- a/internal/app/api_protocol.go
+++ b/internal/app/api_protocol.go
@@ -10,6 +10,8 @@ import (
 	apiaggregate "github.com/flidai/leapview/internal/app/api/aggregate"
 	apiprotocol "github.com/flidai/leapview/internal/app/api/protocol"
 	"github.com/flidai/leapview/internal/app/brand"
+	releasemodule "github.com/flidai/leapview/internal/release/module"
+	workspacemodule "github.com/flidai/leapview/internal/workspace/module"
 )
 
 func configureAPIProtocol(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, ctx context.Context, database *sql.DB) error {
@@ -32,7 +34,7 @@ func configureAPIProtocol(routes *capabilityRoutes, runtime *runtimeServices, pl
 		},
 		PublicRequest: isPublicAPIGenRequest,
 		CursorSnapshot: func(r *http.Request) string {
-			return cursorSnapshot(routes, runtime, platform, policy, r)
+			return cursorSnapshot(routes.workspaceModule, routes.releaseModule, r)
 		},
 	})
 	if err != nil {
@@ -54,19 +56,19 @@ func isPublicAPIGenRequest(r *http.Request) bool {
 	return false
 }
 
-func publicProtocolMiddleware(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, next http.Handler) http.Handler {
-	return platform.apiProtocol.Middleware(next)
+func publicProtocolMiddleware(protocol *apiprotocol.Protocol, next http.Handler) http.Handler {
+	return protocol.Middleware(next)
 }
 
-func openAPIDescription(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, w http.ResponseWriter, r *http.Request) {
-	platform.apiProtocol.OpenAPIDescription(w, r)
+func openAPIDescription(protocol *apiprotocol.Protocol, w http.ResponseWriter, r *http.Request) {
+	protocol.OpenAPIDescription(w, r)
 }
 
-func publicDocs(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, w http.ResponseWriter, r *http.Request) {
-	platform.apiProtocol.PublicDocs(w, r)
+func publicDocs(protocol *apiprotocol.Protocol, w http.ResponseWriter, r *http.Request) {
+	protocol.PublicDocs(w, r)
 }
 
-func cursorSnapshot(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, r *http.Request) string {
+func cursorSnapshot(workspaces *workspacemodule.Module, releases *releasemodule.Module, r *http.Request) string {
 	segments := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
 	for index, segment := range segments {
 		if index+1 >= len(segments) {
@@ -74,15 +76,17 @@ func cursorSnapshot(routes *capabilityRoutes, runtime *runtimeServices, platform
 		}
 		switch segment {
 		case "workspaces":
-			if routes.workspaceModule != nil {
-				snapshot, err := routes.workspaceModule.ActiveServingStateID(r.Context(), workspaceID(routes, runtime, platform, policy, segments[index+1]))
+			if workspaces != nil {
+				snapshot, err := workspaces.ActiveServingStateID(r.Context(), workspaceID(segments[index+1]))
 				if err == nil && snapshot != "" {
 					return snapshot
 				}
 			}
 		case "projects":
-			if snapshot := routes.releaseModule.ProjectCursorSnapshot(r, segments[index+1]); snapshot != "" {
-				return snapshot
+			if releases != nil {
+				if snapshot := releases.ProjectCursorSnapshot(r, segments[index+1]); snapshot != "" {
+					return snapshot
+				}
 			}
 		}
 	}

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -22,14 +22,17 @@ type fatalSource interface {
 
 type cleanupFunc func(context.Context) error
 
-// Application is the complete process-facing surface. It retains only the
-// final handler, lifecycle components, fatal probes, and cleanup closures.
+// Application is the complete process-facing surface. Construction details
+// stay behind the private lifecycle owner instead of leaking a service graph.
 type Application struct {
-	handler    http.Handler
-	components []Lifecycle
-	cleanup    []cleanupFunc
+	handler   http.Handler
+	lifecycle *applicationLifecycleOwner
+}
 
-	lifecycle   applicationLifecycleState
+type applicationLifecycleOwner struct {
+	components  []Lifecycle
+	cleanup     []cleanupFunc
+	state       applicationLifecycleState
 	cleanupOnce sync.Once
 	cleanupErr  error
 	fatal       chan error
@@ -37,8 +40,11 @@ type Application struct {
 
 func newApplication(handler http.Handler, components []Lifecycle, cleanup ...cleanupFunc) *Application {
 	return &Application{
-		handler: handler, components: append([]Lifecycle(nil), components...),
-		cleanup: append([]cleanupFunc(nil), cleanup...), fatal: make(chan error, 1),
+		handler: handler,
+		lifecycle: &applicationLifecycleOwner{
+			components: append([]Lifecycle(nil), components...),
+			cleanup:    append([]cleanupFunc(nil), cleanup...), fatal: make(chan error, 1),
+		},
 	}
 }
 
@@ -50,24 +56,42 @@ func (a *Application) Handler() http.Handler {
 }
 
 func (a *Application) Start(ctx context.Context) error {
-	if a == nil {
+	if a == nil || a.lifecycle == nil {
 		return errors.New("application is not initialized")
 	}
+	return a.lifecycle.start(ctx)
+}
+
+func (a *Application) Shutdown(ctx context.Context) error {
+	if a == nil || a.lifecycle == nil {
+		return nil
+	}
+	return a.lifecycle.shutdown(ctx)
+}
+
+func (a *Application) Fatal() <-chan error {
+	if a == nil || a.lifecycle == nil {
+		return nil
+	}
+	return a.lifecycle.fatalChannel()
+}
+
+func (o *applicationLifecycleOwner) start(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	a.lifecycle.mu.Lock()
-	if a.lifecycle.shutdownRequested {
-		a.lifecycle.mu.Unlock()
+	o.state.mu.Lock()
+	if o.state.shutdownRequested {
+		o.state.mu.Unlock()
 		return context.Canceled
 	}
-	if done := a.lifecycle.startDone; done != nil {
-		a.lifecycle.mu.Unlock()
+	if done := o.state.startDone; done != nil {
+		o.state.mu.Unlock()
 		select {
 		case <-done:
-			a.lifecycle.mu.Lock()
-			err := a.lifecycle.startErr
-			a.lifecycle.mu.Unlock()
+			o.state.mu.Lock()
+			err := o.state.startErr
+			o.state.mu.Unlock()
 			return err
 		case <-ctx.Done():
 			return ctx.Err()
@@ -75,36 +99,33 @@ func (a *Application) Start(ctx context.Context) error {
 	}
 	done := make(chan struct{})
 	runCtx, cancel := context.WithCancel(ctx)
-	a.lifecycle.startDone = done
-	a.lifecycle.startCancel = cancel
-	a.lifecycle.mu.Unlock()
+	o.state.startDone = done
+	o.state.startCancel = cancel
+	o.state.mu.Unlock()
 
-	err := a.startComponents(runCtx)
+	err := o.startComponents(runCtx)
 	if err != nil {
 		cancel()
 	}
-	a.lifecycle.mu.Lock()
+	o.state.mu.Lock()
 	if err != nil {
-		a.lifecycle.startCancel = nil
+		o.state.startCancel = nil
 	}
-	a.lifecycle.startErr = err
+	o.state.startErr = err
 	close(done)
-	a.lifecycle.mu.Unlock()
+	o.state.mu.Unlock()
 	return err
 }
 
-func (a *Application) Shutdown(ctx context.Context) error {
-	if a == nil {
-		return nil
-	}
+func (o *applicationLifecycleOwner) shutdown(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	a.lifecycle.mu.Lock()
-	a.lifecycle.shutdownRequested = true
-	startCancel := a.lifecycle.startCancel
-	startDone := a.lifecycle.startDone
-	a.lifecycle.mu.Unlock()
+	o.state.mu.Lock()
+	o.state.shutdownRequested = true
+	startCancel := o.state.startCancel
+	startDone := o.state.startDone
+	o.state.mu.Unlock()
 	if startCancel != nil {
 		startCancel()
 	}
@@ -116,98 +137,95 @@ func (a *Application) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	a.lifecycle.mu.Lock()
-	if done := a.lifecycle.shutdownDone; done != nil {
-		a.lifecycle.mu.Unlock()
+	o.state.mu.Lock()
+	if done := o.state.shutdownDone; done != nil {
+		o.state.mu.Unlock()
 		select {
 		case <-done:
-			a.lifecycle.mu.Lock()
-			err := a.lifecycle.shutdownErr
-			a.lifecycle.mu.Unlock()
+			o.state.mu.Lock()
+			err := o.state.shutdownErr
+			o.state.mu.Unlock()
 			return err
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 	}
 	done := make(chan struct{})
-	a.lifecycle.shutdownDone = done
-	a.lifecycle.mu.Unlock()
+	o.state.shutdownDone = done
+	o.state.mu.Unlock()
 
-	stopErr := a.stopStarted(ctx)
-	a.runCleanup(ctx)
-	err := errors.Join(stopErr, a.cleanupErr)
-	a.lifecycle.mu.Lock()
-	a.lifecycle.shutdownErr = err
+	stopErr := o.stopStarted(ctx)
+	o.runCleanup(ctx)
+	err := errors.Join(stopErr, o.cleanupErr)
+	o.state.mu.Lock()
+	o.state.shutdownErr = err
 	close(done)
-	a.lifecycle.mu.Unlock()
+	o.state.mu.Unlock()
 	return err
 }
 
-func (a *Application) startComponents(ctx context.Context) error {
-	for index, component := range a.components {
+func (o *applicationLifecycleOwner) startComponents(ctx context.Context) error {
+	for index, component := range o.components {
 		if err := ctx.Err(); err != nil {
-			return a.rollbackStartup(ctx, err)
+			return o.rollbackStartup(ctx, err)
 		}
 		if component != nil {
 			if err := component.Start(ctx); err != nil {
-				return a.rollbackStartup(ctx, fmt.Errorf("start application component %d: %w", index, err))
+				return o.rollbackStartup(ctx, fmt.Errorf("start application component %d: %w", index, err))
 			}
 		}
-		a.lifecycle.mu.Lock()
-		a.lifecycle.started = index + 1
-		shutdownRequested := a.lifecycle.shutdownRequested
-		a.lifecycle.mu.Unlock()
+		o.state.mu.Lock()
+		o.state.started = index + 1
+		shutdownRequested := o.state.shutdownRequested
+		o.state.mu.Unlock()
 		if component != nil {
-			a.forwardFatal(ctx, component)
+			o.forwardFatal(ctx, component)
 		}
 		if shutdownRequested || ctx.Err() != nil {
-			return a.rollbackStartup(ctx, context.Canceled)
+			return o.rollbackStartup(ctx, context.Canceled)
 		}
 	}
 	return nil
 }
 
-func (a *Application) rollbackStartup(ctx context.Context, cause error) error {
+func (o *applicationLifecycleOwner) rollbackStartup(ctx context.Context, cause error) error {
 	rollbackCtx := context.WithoutCancel(ctx)
-	stopErr := a.stopStarted(rollbackCtx)
-	a.runCleanup(rollbackCtx)
-	return errors.Join(cause, stopErr, a.cleanupErr)
+	stopErr := o.stopStarted(rollbackCtx)
+	o.runCleanup(rollbackCtx)
+	return errors.Join(cause, stopErr, o.cleanupErr)
 }
 
-func (a *Application) runCleanup(ctx context.Context) {
-	a.cleanupOnce.Do(func() {
+func (o *applicationLifecycleOwner) runCleanup(ctx context.Context) {
+	o.cleanupOnce.Do(func() {
 		var errs []error
-		for index := len(a.cleanup) - 1; index >= 0; index-- {
-			if cleanup := a.cleanup[index]; cleanup != nil {
+		for index := len(o.cleanup) - 1; index >= 0; index-- {
+			if cleanup := o.cleanup[index]; cleanup != nil {
 				errs = append(errs, cleanup(ctx))
 			}
 		}
-		a.cleanupErr = errors.Join(errs...)
+		o.cleanupErr = errors.Join(errs...)
 	})
 }
 
-func (a *Application) Fatal() <-chan error {
-	if a == nil {
-		return nil
-	}
-	return a.fatal
+func (o *applicationLifecycleOwner) fatalChannel() <-chan error {
+	return o.fatal
 }
 
-func (a *Application) stopStarted(ctx context.Context) error {
-	a.lifecycle.mu.Lock()
-	started := a.lifecycle.started
-	a.lifecycle.started = 0
-	a.lifecycle.mu.Unlock()
+func (o *applicationLifecycleOwner) stopStarted(ctx context.Context) error {
+	o.state.mu.Lock()
+	started := o.state.started
+	o.state.started = 0
+	o.state.mu.Unlock()
 	var errs []error
 	for index := started - 1; index >= 0; index-- {
-		if component := a.components[index]; component != nil {
+		if component := o.components[index]; component != nil {
 			errs = append(errs, component.Stop(ctx))
 		}
 	}
 	return errors.Join(errs...)
 }
 
-func (a *Application) forwardFatal(ctx context.Context, component Lifecycle) {
+func (o *applicationLifecycleOwner) forwardFatal(ctx context.Context, component Lifecycle) {
 	source, ok := component.(fatalSource)
 	if !ok || source.Fatal() == nil {
 		return
@@ -220,7 +238,7 @@ func (a *Application) forwardFatal(ctx context.Context, component Lifecycle) {
 				return
 			}
 			select {
-			case a.fatal <- err:
+			case o.fatal <- err:
 			default:
 			}
 		}

--- a/internal/app/candidate_routes.go
+++ b/internal/app/candidate_routes.go
@@ -6,9 +6,12 @@ import (
 	"net/url"
 	"strings"
 
+	accessmodule "github.com/flidai/leapview/internal/access/module"
+	agentmodule "github.com/flidai/leapview/internal/agent/module"
 	dashboardmodule "github.com/flidai/leapview/internal/dashboard/module"
 	deploymentmodule "github.com/flidai/leapview/internal/deployment/module"
 	webpage "github.com/flidai/leapview/internal/platform/web/page"
+	"github.com/flidai/leapview/internal/platform/web/staticasset"
 	runtimehostmodule "github.com/flidai/leapview/internal/runtimehost/module"
 	"github.com/go-chi/chi/v5"
 )
@@ -17,30 +20,40 @@ type candidatePreviewHandler interface {
 	ServeCandidatePreview(http.ResponseWriter, *http.Request, string, string, webpage.Provider)
 }
 
-func candidatePreview(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, _ *httpPolicy, w http.ResponseWriter, r *http.Request) {
-	candidate, principalID, ok := resolveOwnedCandidate(routes, w, r)
+type candidateRouteDependencies struct {
+	access           *accessmodule.Module
+	agent            *agentmodule.Module
+	assets           staticasset.Resolver
+	dashboards       *dashboardmodule.Module
+	deployments      *deploymentmodule.Module
+	runtimeHost      *runtimehostmodule.Module
+	candidateMetrics func(runtimehostmodule.Provider, string) QueryMetrics
+}
+
+func candidatePreview(deps candidateRouteDependencies, w http.ResponseWriter, r *http.Request) {
+	candidate, principalID, ok := resolveOwnedCandidate(deps, w, r)
 	if !ok {
 		return
 	}
 	if candidate.Status != deploymentmodule.CandidateReady {
 		serveCandidatePreview(
-			routes.deploymentModule, candidate.ID, principalID,
-			applicationLayout(routes, platform.assets, r), w, r,
+			deps.deployments, candidate.ID, principalID,
+			applicationLayout(deps.access, deps.agent, deps.assets, r), w, r,
 		)
 		return
 	}
-	if runtime == nil || runtime.runtimeHostModule == nil {
+	if deps.runtimeHost == nil {
 		http.Error(w, "Candidate preview is unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	view, err := runtime.runtimeHostModule.ResolveOwnedCandidate(candidate.ID, principalID)
-	if err != nil || len(view.Workspaces) == 0 || runtime.candidateMetrics == nil {
+	view, err := deps.runtimeHost.ResolveOwnedCandidate(candidate.ID, principalID)
+	if err != nil || len(view.Workspaces) == 0 || deps.candidateMetrics == nil {
 		http.Error(w, "Candidate preview is unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	for _, workspace := range view.Workspaces {
 		workspaceID := string(workspace.WorkspaceID)
-		metrics := runtime.candidateMetrics(workspace.Provider, workspaceID)
+		metrics := deps.candidateMetrics(workspace.Provider, workspaceID)
 		if metrics == nil {
 			continue
 		}
@@ -61,8 +74,8 @@ func candidatePreview(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	http.NotFound(w, r)
 }
 
-func candidateDashboard(routes *capabilityRoutes, runtime *runtimeServices, w http.ResponseWriter, r *http.Request, action func(dashboardmodule.HTTP)) {
-	handler, ok := resolveCandidateDashboardHTTP(routes, runtime, w, r)
+func candidateDashboard(deps candidateRouteDependencies, w http.ResponseWriter, r *http.Request, action func(dashboardmodule.HTTP)) {
+	handler, ok := resolveCandidateDashboardHTTP(deps, w, r)
 	if !ok {
 		return
 	}
@@ -70,8 +83,8 @@ func candidateDashboard(routes *capabilityRoutes, runtime *runtimeServices, w ht
 	action(handler)
 }
 
-func candidateDashboardDocument(routes *capabilityRoutes, runtime *runtimeServices, w http.ResponseWriter, r *http.Request) {
-	candidateDashboard(routes, runtime, w, r, func(handler dashboardmodule.HTTP) {
+func candidateDashboardDocument(deps candidateRouteDependencies, w http.ResponseWriter, r *http.Request) {
+	candidateDashboard(deps, w, r, func(handler dashboardmodule.HTTP) {
 		if strings.TrimSpace(chi.URLParam(r, "page")) == "" {
 			handler.Dashboard(w, r)
 			return
@@ -80,14 +93,14 @@ func candidateDashboardDocument(routes *capabilityRoutes, runtime *runtimeServic
 	})
 }
 
-func candidateDashboardUpdates(routes *capabilityRoutes, runtime *runtimeServices, w http.ResponseWriter, r *http.Request) {
-	candidateDashboard(routes, runtime, w, r, func(handler dashboardmodule.HTTP) {
+func candidateDashboardUpdates(deps candidateRouteDependencies, w http.ResponseWriter, r *http.Request) {
+	candidateDashboard(deps, w, r, func(handler dashboardmodule.HTTP) {
 		handler.Updates(w, r)
 	})
 }
 
-func candidateDashboardCommand(routes *capabilityRoutes, runtime *runtimeServices, w http.ResponseWriter, r *http.Request) {
-	candidateDashboard(routes, runtime, w, r, func(handler dashboardmodule.HTTP) {
+func candidateDashboardCommand(deps candidateRouteDependencies, w http.ResponseWriter, r *http.Request) {
+	candidateDashboard(deps, w, r, func(handler dashboardmodule.HTTP) {
 		switch strings.TrimSpace(chi.URLParam(r, "command")) {
 		case "filter":
 			handler.FilterCommand(w, r)
@@ -112,12 +125,11 @@ func candidateDashboardCommand(routes *capabilityRoutes, runtime *runtimeService
 }
 
 func resolveCandidateDashboardHTTP(
-	routes *capabilityRoutes,
-	runtime *runtimeServices,
+	deps candidateRouteDependencies,
 	w http.ResponseWriter,
 	r *http.Request,
 ) (dashboardmodule.HTTP, bool) {
-	candidate, principalID, ok := resolveOwnedCandidate(routes, w, r)
+	candidate, principalID, ok := resolveOwnedCandidate(deps, w, r)
 	if !ok {
 		return dashboardmodule.HTTP{}, false
 	}
@@ -125,13 +137,12 @@ func resolveCandidateDashboardHTTP(
 		http.Redirect(w, r, "/candidates/"+url.PathEscape(candidate.ID), http.StatusSeeOther)
 		return dashboardmodule.HTTP{}, false
 	}
-	if runtime == nil || runtime.runtimeHostModule == nil || runtime.candidateMetrics == nil ||
-		routes.dashboardModule == nil {
+	if deps.runtimeHost == nil || deps.candidateMetrics == nil || deps.dashboards == nil {
 		http.Error(w, "Candidate preview is unavailable", http.StatusServiceUnavailable)
 		return dashboardmodule.HTTP{}, false
 	}
 	workspaceID := strings.TrimSpace(chi.URLParam(r, "workspace"))
-	view, err := runtime.runtimeHostModule.ResolveOwnedCandidate(candidate.ID, principalID)
+	view, err := deps.runtimeHost.ResolveOwnedCandidate(candidate.ID, principalID)
 	if err != nil {
 		status := http.StatusServiceUnavailable
 		if errors.Is(err, runtimehostmodule.ErrCandidateRuntimeNotFound) ||
@@ -145,7 +156,7 @@ func resolveCandidateDashboardHTTP(
 		if string(workspace.WorkspaceID) != workspaceID {
 			continue
 		}
-		metrics := runtime.candidateMetrics(workspace.Provider, workspaceID)
+		metrics := deps.candidateMetrics(workspace.Provider, workspaceID)
 		restrictions := make([]dashboardmodule.CandidateRestriction, len(workspace.Restrictions))
 		for index, restriction := range workspace.Restrictions {
 			restrictions[index] = dashboardmodule.CandidateRestriction{
@@ -154,7 +165,7 @@ func resolveCandidateDashboardHTTP(
 				ExpressionJSON: restriction.ExpressionJSON,
 			}
 		}
-		handler, err := routes.dashboardModule.CandidateHTTP(dashboardmodule.CandidateHTTPConfig{
+		handler, err := deps.dashboards.CandidateHTTP(dashboardmodule.CandidateHTTPConfig{
 			Metrics: metrics, CandidateID: candidate.ID, OwnerPrincipalID: principalID,
 			WorkspaceID: workspaceID, ArtifactDigest: candidate.ArtifactDigest,
 			AuthorizationFingerprint: workspace.AuthorizationFingerprint,
@@ -171,17 +182,17 @@ func resolveCandidateDashboardHTTP(
 	return dashboardmodule.HTTP{}, false
 }
 
-func resolveOwnedCandidate(routes *capabilityRoutes, w http.ResponseWriter, r *http.Request) (deploymentmodule.Candidate, string, bool) {
-	if routes == nil || routes.accessModule == nil || routes.deploymentModule == nil {
+func resolveOwnedCandidate(deps candidateRouteDependencies, w http.ResponseWriter, r *http.Request) (deploymentmodule.Candidate, string, bool) {
+	if deps.access == nil || deps.deployments == nil {
 		http.Error(w, "Candidate preview is unavailable", http.StatusServiceUnavailable)
 		return deploymentmodule.Candidate{}, "", false
 	}
-	principal, ok := routes.accessModule.CurrentPrincipal(r)
+	principal, ok := deps.access.CurrentPrincipal(r)
 	if !ok {
 		http.Error(w, "Authentication required", http.StatusUnauthorized)
 		return deploymentmodule.Candidate{}, "", false
 	}
-	candidate, err := routes.deploymentModule.ResolveOwnedCandidate(
+	candidate, err := deps.deployments.ResolveOwnedCandidate(
 		r.Context(),
 		strings.TrimSpace(chi.URLParam(r, "candidate")),
 		principal.ID,

--- a/internal/app/deployment_candidates.go
+++ b/internal/app/deployment_candidates.go
@@ -19,21 +19,21 @@ type servingStateRepository interface {
 	ListActiveScopes(context.Context) ([]servingstatemodule.ActiveScope, error)
 }
 
-func resolveServingStateRepository(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, persistence persistenceInputs) (servingStateRepository, error) {
+func resolveServingStateRepository(persistence persistenceInputs) (servingStateRepository, error) {
 	if persistence.servingStateRepo != nil {
 		return persistence.servingStateRepo, nil
 	}
 	return nil, fmt.Errorf("serving state repository is not configured")
 }
 
-func workspaceID(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, value string) string {
+func workspaceID(value string) string {
 	return value
 }
 
-func defaultServingEnvironment(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy) servingstatemodule.Environment {
-	return servingstatemodule.NormalizeEnvironment(servingstatemodule.Environment(policy.defaultEnvironment))
+func defaultServingEnvironment(environment string) servingstatemodule.Environment {
+	return servingstatemodule.NormalizeEnvironment(servingstatemodule.Environment(environment))
 }
 
-func requestServingEnvironment(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, r *http.Request) servingstatemodule.Environment {
-	return defaultServingEnvironment(routes, runtime, platform, policy)
+func requestServingEnvironment(environment string, _ *http.Request) servingstatemodule.Environment {
+	return defaultServingEnvironment(environment)
 }

--- a/internal/app/page_stream.go
+++ b/internal/app/page_stream.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Yacobolo/toolbelt/pagestream"
 	uitransport "github.com/flidai/leapview/internal/platform/web/transport"
+	workspacemodule "github.com/flidai/leapview/internal/workspace/module"
 )
 
 const (
@@ -61,17 +62,17 @@ func configurePageStream(routes *capabilityRoutes, runtime *runtimeServices, pla
 				}
 			}),
 			routeWorkspaceAsset: http.HandlerFunc(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				workspaceAssetUpdates(routes, runtime, platform, policy, w, r)
+				workspaceAssetUpdates(routes.workspaceModule, runtime.pageStreamTrace, w, r)
 			})),
 			routeConnectionAsset: http.HandlerFunc(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				workspaceAssetUpdates(routes, runtime, platform, policy, w, r)
+				workspaceAssetUpdates(routes.workspaceModule, runtime.pageStreamTrace, w, r)
 			})),
 			routeLogin: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_ = uitransport.PatchOnce(runtime.pageStreamTrace, w, r, routes.accessModule.LoginBootstrapSignals(r))
 			}),
 			routeCatalog: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				uitransport.PatchAndWait(runtime.pageStreamTrace, w, r,
-					routes.workspaceModule.CatalogBootstrapSignals(r, applicationLayout(routes, platform.assets, r)))
+					routes.workspaceModule.CatalogBootstrapSignals(r, applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)))
 			}),
 			routeWorkspace:   http.HandlerFunc(routes.workspaceModule.HTTP().WorkspaceBootstrapUpdates),
 			routeConnections: http.HandlerFunc(routes.workspaceModule.HTTP().ConnectionsBootstrapUpdates),
@@ -79,10 +80,10 @@ func configurePageStream(routes *capabilityRoutes, runtime *runtimeServices, pla
 	})
 }
 
-func workspaceAssetUpdates(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, w http.ResponseWriter, r *http.Request) {
+func workspaceAssetUpdates(workspaces *workspacemodule.Module, trace *pagestream.TraceStore, w http.ResponseWriter, r *http.Request) {
 	if strings.TrimSpace(r.URL.Query().Get("asset")) != "" {
-		routes.workspaceModule.HTTP().AssetUpdatesStream(w, r)
+		workspaces.HTTP().AssetUpdatesStream(w, r)
 		return
 	}
-	uitransport.PatchAndWait(runtime.pageStreamTrace, w, r, pagestream.SignalPatch{"status": map[string]any{"loading": false, "error": ""}})
+	uitransport.PatchAndWait(trace, w, r, pagestream.SignalPatch{"status": map[string]any{"loading": false, "error": ""}})
 }

--- a/internal/app/refresh_module.go
+++ b/internal/app/refresh_module.go
@@ -8,7 +8,9 @@ import (
 
 	accessmodule "github.com/flidai/leapview/internal/access/module"
 	appruntimefactory "github.com/flidai/leapview/internal/app/runtimefactory"
+	dashboardmodule "github.com/flidai/leapview/internal/dashboard/module"
 	refreshmodule "github.com/flidai/leapview/internal/refresh/module"
+	workspacemodule "github.com/flidai/leapview/internal/workspace/module"
 )
 
 func configureRefreshModule(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, ctx context.Context, database *sql.DB, persistence persistenceInputs, workflow workflowInputs, storage storageInputs) error {
@@ -18,7 +20,15 @@ func configureRefreshModule(routes *capabilityRoutes, runtime *runtimeServices, 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	service, err := workspaceRefreshService(routes, runtime, platform, policy, persistence, workflow)
+	refreshDeps := workspaceRefreshDependencies{
+		access:                routes.accessModule,
+		dashboards:            func() *dashboardmodule.Module { return routes.dashboardModule },
+		refresh:               func() *refreshmodule.Module { return routes.refreshModule },
+		workspaces:            func() *workspacemodule.Module { return routes.workspaceModule },
+		broker:                runtime.broker,
+		persistenceConfigured: runtime.persistenceConfigured, defaultEnvironment: policy.defaultEnvironment,
+	}
+	service, err := workspaceRefreshService(&refreshDeps, persistence, workflow)
 	if err != nil && database != nil {
 		return fmt.Errorf("configure refresh service: %w", err)
 	}
@@ -33,10 +43,10 @@ func configureRefreshModule(routes *capabilityRoutes, runtime *runtimeServices, 
 				return refreshmodule.HTTPPrincipal{ID: principal.ID}, ok
 			},
 			WorkspaceID: func(value string) string {
-				return workspaceID(routes, runtime, platform, policy, value)
+				return workspaceID(value)
 			},
 			Environment: func(*http.Request) string {
-				return string(defaultServingEnvironment(routes, runtime, platform, policy))
+				return string(defaultServingEnvironment(policy.defaultEnvironment))
 			},
 		},
 		Authorization: refreshmodule.AuthorizationConfig{
@@ -50,18 +60,18 @@ func configureRefreshModule(routes *capabilityRoutes, runtime *runtimeServices, 
 			ResolvePipelineModel: refreshmodule.PipelineModelResolver(
 				persistence.servingStateRepo,
 				appruntimefactory.NewRefreshArtifactLoader(),
-				defaultServingEnvironment(routes, runtime, platform, policy),
+				defaultServingEnvironment(policy.defaultEnvironment),
 			),
 			AuthorizeObject: routes.accessModule.AuthorizeObject,
 		},
 		ApplyAccessSnapshot: accessmodule.ApplySnapshot,
-		Admission:           workloadController(routes, runtime, platform, policy), LeaseTimeout: storage.jobLeaseTimeout,
-		Environment: string(defaultServingEnvironment(routes, runtime, platform, policy)), Clock: workflow.refreshPipelineClock,
+		Admission:           workloadController(&runtime.workloads), LeaseTimeout: storage.jobLeaseTimeout,
+		Environment: string(defaultServingEnvironment(policy.defaultEnvironment)), Clock: workflow.refreshPipelineClock,
 		EnableDispatcher: database != nil && runtime.metrics != nil,
 		EnableScheduler:  database != nil && persistence.servingStateRepo != nil,
 		Logger:           platform.logger, Events: platform.asyncJobs,
 		WorkloadStats: func() refreshmodule.WorkloadStats {
-			return workloadController(routes, runtime, platform, policy).Stats()
+			return workloadController(&runtime.workloads).Stats()
 		},
 		RunFinished: func(ctx context.Context, run refreshmodule.RunRecord) {
 			if run.Status == refreshmodule.RunStatusSucceeded && runtime.storageRetention != nil {

--- a/internal/app/refresh_runs.go
+++ b/internal/app/refresh_runs.go
@@ -6,9 +6,9 @@ import (
 	workloadmodule "github.com/flidai/leapview/internal/workload/module"
 )
 
-func workloadController(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy) workloadControl {
-	if runtime.workloads == nil {
-		runtime.workloads, _ = workloadmodule.Build(context.Background(), workloadmodule.Config{Policy: workloadmodule.DefaultConfig()})
+func workloadController(current *workloadControl) workloadControl {
+	if *current == nil {
+		*current, _ = workloadmodule.Build(context.Background(), workloadmodule.Config{Policy: workloadmodule.DefaultConfig()})
 	}
-	return runtime.workloads
+	return *current
 }

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -8,6 +8,7 @@ import (
 	accessmodule "github.com/flidai/leapview/internal/access/module"
 	adminmodule "github.com/flidai/leapview/internal/admin/module"
 	agentmodule "github.com/flidai/leapview/internal/agent/module"
+	apiaggregate "github.com/flidai/leapview/internal/app/api/aggregate"
 	apiprotocol "github.com/flidai/leapview/internal/app/api/protocol"
 	"github.com/flidai/leapview/internal/app/desktopdiscovery"
 	dashboardmodule "github.com/flidai/leapview/internal/dashboard/module"
@@ -21,11 +22,16 @@ import (
 
 func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy) http.Handler {
 	mux := chi.NewRouter()
+	candidates := candidateRouteDependencies{
+		access: routes.accessModule, agent: routes.agentModule, assets: platform.assets,
+		dashboards: routes.dashboardModule, deployments: routes.deploymentModule,
+		runtimeHost: runtime.runtimeHostModule, candidateMetrics: runtime.candidateMetrics,
+	}
 	csrf := func(next http.Handler) http.Handler {
-		return csrfMiddleware(routes, runtime, platform, policy, next)
+		return csrfMiddleware(routes.accessModule, next)
 	}
 	publicProtocol := func(next http.Handler) http.Handler {
-		return publicProtocolMiddleware(routes, runtime, platform, policy, next)
+		return publicProtocolMiddleware(platform.apiProtocol, next)
 	}
 	if policy.requestLogging {
 		mux.Use(apihttpmiddleware.RequestLogger(platform.logger))
@@ -42,9 +48,9 @@ func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platfo
 		routes.dashboardTelemetry.PublicRateLimitObserved("desktop-discovery")
 	})).Get(desktopdiscovery.WellKnownPath, policy.desktopDiscovery.ServeHTTP)
 	mux.Get("/api/openapi.json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		openAPIDescription(routes, runtime, platform, policy, w, r)
+		openAPIDescription(platform.apiProtocol, w, r)
 	}))
-	mux.Get("/api/docs", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { publicDocs(routes, runtime, platform, policy, w, r) }))
+	mux.Get("/api/docs", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { publicDocs(platform.apiProtocol, w, r) }))
 	mux.Group(func(r chi.Router) {
 		r.Use(policy.rateLimits.PublicPage(func() { routes.dashboardTelemetry.PublicRateLimitObserved("page") }))
 		routes.dashboardModule.MountPublicDocuments(r)
@@ -66,19 +72,19 @@ func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platfo
 		r.With(policy.rateLimits.Updates()).Get("/updates", runtime.pageStreams.ServeHTTP)
 		r.Get("/", routes.accessModule.ProtectViewItem(routes.workspaceModule.Home))
 		r.Get("/candidates/{candidate}", routes.accessModule.Protect(accessmodule.PrivilegeAuthorProject, func(w http.ResponseWriter, request *http.Request) {
-			candidatePreview(routes, runtime, platform, policy, w, request)
+			candidatePreview(candidates, w, request)
 		}))
 		r.Get("/candidates/{candidate}/workspaces/{workspace}/dashboards/{dashboard}", routes.accessModule.Protect(accessmodule.PrivilegeAuthorProject, func(w http.ResponseWriter, request *http.Request) {
-			candidateDashboardDocument(routes, runtime, w, request)
+			candidateDashboardDocument(candidates, w, request)
 		}))
 		r.Get("/candidates/{candidate}/workspaces/{workspace}/dashboards/{dashboard}/pages/{page}", routes.accessModule.Protect(accessmodule.PrivilegeAuthorProject, func(w http.ResponseWriter, request *http.Request) {
-			candidateDashboardDocument(routes, runtime, w, request)
+			candidateDashboardDocument(candidates, w, request)
 		}))
 		r.With(policy.rateLimits.Updates()).Get("/candidates/{candidate}/workspaces/{workspace}/updates", routes.accessModule.Protect(accessmodule.PrivilegeAuthorProject, func(w http.ResponseWriter, request *http.Request) {
-			candidateDashboardUpdates(routes, runtime, w, request)
+			candidateDashboardUpdates(candidates, w, request)
 		}))
 		r.Post("/candidates/{candidate}/workspaces/{workspace}/commands/{command}", routes.accessModule.Protect(accessmodule.PrivilegeAuthorProject, func(w http.ResponseWriter, request *http.Request) {
-			candidateDashboardCommand(routes, runtime, w, request)
+			candidateDashboardCommand(candidates, w, request)
 		}))
 		routes.workspaceModule.MountAuthenticated(r, workspacemodule.RouteGuard{
 			Protect: routes.accessModule.Protect, ProtectWithObjects: routes.accessModule.ProtectWithObjects, AssetObjectRefs: routes.workspaceModule.AssetObjectRefs,
@@ -111,23 +117,16 @@ func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platfo
 	routes.accessModule.MountOAuthMetadata(mux)
 	if runtime.persistenceConfigured {
 		if platform.auth != nil {
-			mux.With(policy.rateLimits.API()).Handle("/mcp", routes.agentModule.MCPHandler())
+			routes.agentModule.MountMCP(mux.With(policy.rateLimits.API()))
 		}
 		if strings.TrimSpace(policy.scimBearerToken) != "" {
-			if handler, err := routes.accessModule.SCIMHandler(policy.scimBearerToken); err == nil {
-				scimHandler := policy.rateLimits.API()(http.StripPrefix("/scim", handler))
-				mux.Handle("/scim/*", scimHandler)
-			}
+			_ = routes.accessModule.MountSCIM(mux.With(policy.rateLimits.API()), policy.scimBearerToken)
 		}
 		mux.Group(func(r chi.Router) {
 			r.Use(policy.rateLimits.API())
 			r.Use(publicProtocol)
-			if policy.managedDataTus != nil {
-				tus := routes.accessModule.ProtectIngestData(policy.managedDataTus)
-				r.Handle("/upload-protocols/tus", tus)
-				r.Handle("/upload-protocols/tus/*", tus)
-			}
-			registerAPIGenRoutes(routes, runtime, platform, policy, r)
+			routes.managedDataModule.MountTus(r, policy.managedDataTus, routes.accessModule.ProtectIngestData)
+			apiaggregate.RegisterAPIGenRoutes(r, platform.apiGenServers)
 		})
 	}
 	if routes.dashboardAssets != nil {
@@ -193,28 +192,28 @@ func redirectLegacyChat(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, target, http.StatusPermanentRedirect)
 }
 
-func protectGlobalAgent(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, privilege accessmodule.Privilege, next http.Handler) http.Handler {
-	return routes.accessModule.ProtectGlobal(privilege, next.ServeHTTP)
+func protectGlobalAgent(access *accessmodule.Module, privilege accessmodule.Privilege, next http.Handler) http.Handler {
+	return access.ProtectGlobal(privilege, next.ServeHTTP)
 }
 
-func protectAnyWorkspace(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, privilege accessmodule.Privilege, next http.Handler) http.Handler {
-	return routes.accessModule.ProtectAnyWorkspace(privilege, next.ServeHTTP)
+func protectAnyWorkspace(access *accessmodule.Module, privilege accessmodule.Privilege, next http.Handler) http.Handler {
+	return access.ProtectAnyWorkspace(privilege, next.ServeHTTP)
 }
 
-func protect(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, privilege accessmodule.Privilege, next http.Handler) http.Handler {
-	return routes.accessModule.ProtectHandler(privilege, next)
+func protect(access *accessmodule.Module, privilege accessmodule.Privilege, next http.Handler) http.Handler {
+	return access.ProtectHandler(privilege, next)
 }
 
-func protectGlobal(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, privilege accessmodule.Privilege, next http.Handler) http.Handler {
-	return routes.accessModule.ProtectGlobal(privilege, next.ServeHTTP)
+func protectGlobal(access *accessmodule.Module, privilege accessmodule.Privilege, next http.Handler) http.Handler {
+	return access.ProtectGlobal(privilege, next.ServeHTTP)
 }
 
-func protectWithObjects(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, privilege accessmodule.Privilege, objectResolver accessmodule.ObjectResolver, next http.Handler) http.Handler {
-	return routes.accessModule.ProtectHandlerWithObjects(privilege, objectResolver, next)
+func protectWithObjects(access *accessmodule.Module, privilege accessmodule.Privilege, objectResolver accessmodule.ObjectResolver, next http.Handler) http.Handler {
+	return access.ProtectHandlerWithObjects(privilege, objectResolver, next)
 }
 
-func csrfMiddleware(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, next http.Handler) http.Handler {
-	return routes.accessModule.CSRFMiddleware(next)
+func csrfMiddleware(access *accessmodule.Module, next http.Handler) http.Handler {
+	return access.CSRFMiddleware(next)
 }
 
 func staticAssetCache(assets staticasset.Resolver, next http.Handler) http.Handler {

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -246,26 +246,6 @@ type workloadControl interface {
 	Close()
 }
 
-func AnalyticalFatal(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy) <-chan struct{} {
-	if runtime == nil || runtime.analyticsModule == nil {
-		return nil
-	}
-	return runtime.analyticsModule.Fatal()
-}
-
-func AnalyticalHealth(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy) error {
-	if runtime == nil || runtime.analyticsModule == nil {
-		return nil
-	}
-	return runtime.analyticsModule.Healthy()
-}
-
-func StopWorkloadAdmission(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy) {
-	if runtime != nil && runtime.workloads != nil {
-		runtime.workloads.Close()
-	}
-}
-
 func buildApplicationSurfaces(
 	ctx context.Context,
 	metrics QueryMetrics,
@@ -1188,20 +1168,6 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 		platformlifecycle.Component{Start: platform.jobModule.Start, Stop: platform.jobModule.Stop},
 	)
 	return nil
-}
-
-func StartBackgroundJobs(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, ctx context.Context) error {
-	if platform == nil || platform.workers == nil {
-		return nil
-	}
-	return platform.workers.Start(ctx)
-}
-
-func StopBackgroundJobs(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, ctx context.Context) error {
-	if platform == nil || platform.workers == nil {
-		return nil
-	}
-	return platform.workers.Stop(ctx)
 }
 
 func workspaceReadModel(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, persistence persistenceInputs) (workspacemodule.ReadModel, error) {

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -542,7 +542,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 		QueryAudit: analyticsmodule.QueryAuditAPIGenConfig{
 			Reader: runtime.queryAuditProvider,
 			WorkspaceID: func(value string) string {
-				return workspaceID(routes, runtime, platform, policy, value)
+				return workspaceID(value)
 			},
 		},
 		Connections: analyticsmodule.ConnectionBindingAPIGenConfig{
@@ -565,7 +565,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if persistence.workspaceDirectory != nil {
 					return persistence.workspaceDirectory.WorkspaceIDs(ctx)
 				}
-				repository, err := workspaceReadModel(routes, runtime, platform, policy, persistence)
+				repository, err := workspaceReadModel(persistence)
 				if err != nil || repository == nil {
 					return nil, err
 				}
@@ -585,7 +585,15 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 		}
 	}
 	if routes.workspaceModule == nil {
-		refreshSupport := workspaceRefreshSupport(routes, runtime, platform, policy)
+		refreshDeps := &workspaceRefreshDependencies{
+			access:                routes.accessModule,
+			dashboards:            func() *dashboardmodule.Module { return routes.dashboardModule },
+			refresh:               func() *refreshmodule.Module { return routes.refreshModule },
+			workspaces:            func() *workspacemodule.Module { return routes.workspaceModule },
+			broker:                runtime.broker,
+			persistenceConfigured: runtime.persistenceConfigured, defaultEnvironment: policy.defaultEnvironment,
+		}
+		refreshSupport := workspaceRefreshSupport(refreshDeps)
 		var err error
 		routes.workspaceModule, err = workspacemodule.Build(ctx, workspacemodule.Config{
 			Database:      database,
@@ -594,13 +602,13 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			AccessService: routes.accessModule.WorkspaceAccessService(),
 			AssetCatalog:  persistence.workspaceAssetCatalog,
 			WorkspaceID: func(value string) string {
-				return workspaceID(routes, runtime, platform, policy, value)
+				return workspaceID(value)
 			},
 			Environment: func(r *http.Request) string {
-				return string(requestServingEnvironment(routes, runtime, platform, policy, r))
+				return string(requestServingEnvironment(policy.defaultEnvironment, r))
 			},
 			MetricsForWorkspace: func(workspaceID string) (QueryMetrics, bool) {
-				return metricsForWorkspace(routes, runtime, platform, policy, workspaceID)
+				return metricsForWorkspace(runtime.metrics, policy.defaultWorkspaceID, workspaceID)
 			},
 			RootMetrics: runtime.metrics,
 			CurrentPrincipal: func(r *http.Request) (workspacemodule.Principal, bool) {
@@ -620,7 +628,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			Broker:           runtime.broker,
 			CSRFToken:        routes.accessModule.CSRFToken,
 			CurrentRoleLabel: routes.accessModule.CurrentRoleLabel,
-			Layout:           func(r *http.Request) webpage.Provider { return applicationLayout(routes, platform.assets, r) },
+			Layout: func(r *http.Request) webpage.Provider {
+				return applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)
+			},
 			CurrentCredential: func(r *http.Request) (accessmodule.APICredential, bool) {
 				return accessmodule.APICredentialFromContext(r.Context())
 			},
@@ -678,9 +688,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			HTTP: dashboardmodule.HTTPConfig{
 				Metrics: runtime.metrics,
 				MetricsForWorkspace: func(workspaceID string) (QueryMetrics, bool) {
-					return metricsForWorkspace(routes, runtime, platform, policy, workspaceID)
+					return metricsForWorkspace(runtime.metrics, policy.defaultWorkspaceID, workspaceID)
 				},
-				Admission: workloadController(routes, runtime, platform, policy), Broker: runtime.broker, Logger: platform.logger,
+				Admission: workloadController(&runtime.workloads), Broker: runtime.broker, Logger: platform.logger,
 				Telemetry: routes.dashboardTelemetry,
 				CurrentPrincipalID: func(r *http.Request) string {
 					principal, ok := accessmodule.PrincipalFromContext(r.Context())
@@ -690,12 +700,14 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 					return principal.ID
 				},
 				AuthorizeListObject: func(ctx context.Context, principalID string, object accessmodule.ObjectRef) (bool, error) {
-					return authorizeListObject(routes, runtime, platform, policy, ctx, principalID, object)
+					return authorizeListObject(routes.accessModule, platform.auth != nil, ctx, principalID, object)
 				},
 				CSRFToken: routes.accessModule.CSRFToken,
-				Layout:    func(r *http.Request) webpage.Provider { return applicationLayout(routes, platform.assets, r) },
+				Layout: func(r *http.Request) webpage.Provider {
+					return applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)
+				},
 				Environment: func(r *http.Request) string {
-					return string(requestServingEnvironment(routes, runtime, platform, policy, r))
+					return string(requestServingEnvironment(policy.defaultEnvironment, r))
 				},
 				DataRefreshedAt: func(ctx context.Context, workspaceID, environment, modelID string) string {
 					if routes.refreshModule == nil {
@@ -736,7 +748,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			Semantic: dashboardmodule.SemanticConfig{
 				Metrics: runtime.metrics,
 				MetricsForWorkspace: func(workspaceID string) (QueryMetrics, bool) {
-					return metricsForWorkspace(routes, runtime, platform, policy, workspaceID)
+					return metricsForWorkspace(runtime.metrics, policy.defaultWorkspaceID, workspaceID)
 				},
 				CurrentPrincipalID: func(r *http.Request) string {
 					principal, ok := accessmodule.PrincipalFromContext(r.Context())
@@ -746,7 +758,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 					return principal.ID
 				},
 				AuthorizeListObject: func(ctx context.Context, principalID string, object accessmodule.ObjectRef) (bool, error) {
-					return authorizeListObject(routes, runtime, platform, policy, ctx, principalID, object)
+					return authorizeListObject(routes.accessModule, platform.auth != nil, ctx, principalID, object)
 				},
 				QueryFreshness: func(ctx context.Context, workspaceID, modelID, servingSnapshot string) (dashboardmodule.QueryFreshness, bool) {
 					if routes.refreshModule == nil {
@@ -789,7 +801,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				if routes.workspaceModule == nil {
 					return "", nil
 				}
-				return routes.workspaceModule.ActiveServingStateID(ctx, workspaceID(routes, runtime, platform, policy, requestedWorkspaceID))
+				return routes.workspaceModule.ActiveServingStateID(ctx, workspaceID(requestedWorkspaceID))
 			},
 		})
 		if err != nil {
@@ -810,10 +822,10 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			RunWorkloadClass: string(workloadmodule.BackgroundClass), GlobalWorkspaceID: workloadmodule.GlobalWorkspace,
 			Search: routes.workspaceModule,
 			Environment: func(r *http.Request) string {
-				return string(requestServingEnvironment(routes, runtime, platform, policy, r))
+				return string(requestServingEnvironment(policy.defaultEnvironment, r))
 			},
 			DashboardMetrics: func(workspaceID string) (QueryMetrics, bool) {
-				return metricsForWorkspace(routes, runtime, platform, policy, workspaceID)
+				return metricsForWorkspace(runtime.metrics, policy.defaultWorkspaceID, workspaceID)
 			},
 			AuthorizeAnyObject:       routes.accessModule.AuthorizeAnyObject,
 			SkipContextAuthorization: platform.auth == nil,
@@ -823,7 +835,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				Search: routes.workspaceModule, Environment: policy.defaultEnvironment,
 				Workspaces: persistence.workspaceReadModel, RootMetrics: runtime.metrics,
 				MetricsForWorkspace: func(workspaceID string) (QueryMetrics, bool) {
-					return metricsForWorkspace(routes, runtime, platform, policy, workspaceID)
+					return metricsForWorkspace(runtime.metrics, policy.defaultWorkspaceID, workspaceID)
 				},
 				AuthorizeAnyObject: routes.accessModule.AuthorizeAnyObject,
 				RecordAudit:        routes.accessModule.RecordAudit,
@@ -942,7 +954,9 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				Settings: persistence.agentSettings, Broker: runtime.broker,
 				CSRFToken:        routes.accessModule.CSRFToken,
 				CurrentRoleLabel: routes.accessModule.CurrentRoleLabel,
-				Layout:           func(r *http.Request) webpage.Provider { return applicationLayout(routes, platform.assets, r) },
+				Layout: func(r *http.Request) webpage.Provider {
+					return applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)
+				},
 				CurrentPrincipal: func(r *http.Request) (agentmodule.Principal, bool) {
 					if platform.auth == nil {
 						return agentmodule.Principal{}, false
@@ -1001,9 +1015,11 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			Storage: adminmodule.StorageConfig{
 				CatalogPath: storage.duckLakeCatalogPath, DataPath: storage.duckLakeDataPath,
 				Environment: policy.defaultEnvironment, ControlPlane: persistence.adminDatabase,
-				Analytics: runtime.analyticsModule.AdminResources(), Admitter: workloadController(routes, runtime, platform, policy),
+				Analytics: runtime.analyticsModule.AdminResources(), Admitter: workloadController(&runtime.workloads),
 			},
-			Layout: func(r *http.Request) webpage.Provider { return applicationLayout(routes, platform.assets, r) },
+			Layout: func(r *http.Request) webpage.Provider {
+				return applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)
+			},
 			EnsureClientID: func(w http.ResponseWriter, r *http.Request) {
 				_ = pagestream.EnsureClientID(w, r)
 			},
@@ -1170,36 +1186,36 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	return nil
 }
 
-func workspaceReadModel(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, persistence persistenceInputs) (workspacemodule.ReadModel, error) {
+func workspaceReadModel(persistence persistenceInputs) (workspacemodule.ReadModel, error) {
 	return persistence.workspaceReadModel, nil
 }
 
-func authorizeListObject(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, ctx context.Context, principalID string, object accessmodule.ObjectRef) (bool, error) {
-	if platform.auth == nil {
+func authorizeListObject(access *accessmodule.Module, authenticationRequired bool, ctx context.Context, principalID string, object accessmodule.ObjectRef) (bool, error) {
+	if !authenticationRequired {
 		return true, nil
 	}
 	if strings.TrimSpace(principalID) == "" {
 		return false, nil
 	}
-	return routes.accessModule.AuthorizeObject(ctx, principalID, accessmodule.PrivilegeViewItem, object)
+	return access.AuthorizeObject(ctx, principalID, accessmodule.PrivilegeViewItem, object)
 }
 
-func metricsForWorkspace(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, workspaceID string) (QueryMetrics, bool) {
+func metricsForWorkspace(metrics QueryMetrics, defaultWorkspaceID, workspaceID string) (QueryMetrics, bool) {
 	if workspaceID == "" {
 		return nil, false
 	}
-	if provider, ok := runtime.metrics.(workspaceMetrics); ok {
+	if provider, ok := metrics.(workspaceMetrics); ok {
 		return provider.MetricsForWorkspace(workspaceID)
 	}
-	if runtime.metrics == nil {
+	if metrics == nil {
 		return nil, false
 	}
-	if policy.defaultWorkspaceID != "" && workspaceID == policy.defaultWorkspaceID {
-		return runtime.metrics, true
+	if defaultWorkspaceID != "" && workspaceID == defaultWorkspaceID {
+		return metrics, true
 	}
-	catalog := runtime.metrics.Catalog()
+	catalog := metrics.Catalog()
 	if catalog.Workspace.ID == "" || catalog.Workspace.ID == workspaceID {
-		return runtime.metrics, true
+		return metrics, true
 	}
 	return nil, false
 }

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -104,23 +104,23 @@ func (s *appTestHarness) StopBackgroundJobs(ctx context.Context) error {
 }
 
 func (s *appTestHarness) workloadController() workloadControl {
-	return workloadController(&s.routes, &s.runtime, &s.platform, &s.policy)
+	return workloadController(&s.runtime.workloads)
 }
 
 func (s *appTestHarness) workspaceID(value string) string {
-	return workspaceID(&s.routes, &s.runtime, &s.platform, &s.policy, value)
+	return workspaceID(value)
 }
 
 func (s *appTestHarness) requestServingEnvironment(r *http.Request) servingstatemodule.Environment {
-	return requestServingEnvironment(&s.routes, &s.runtime, &s.platform, &s.policy, r)
+	return requestServingEnvironment(s.policy.defaultEnvironment, r)
 }
 
 func (s *appTestHarness) publicProtocolMiddleware(next http.Handler) http.Handler {
-	return publicProtocolMiddleware(&s.routes, &s.runtime, &s.platform, &s.policy, next)
+	return publicProtocolMiddleware(s.platform.apiProtocol, next)
 }
 
 func (s *appTestHarness) metricsForWorkspace(workspaceID string) (QueryMetrics, bool) {
-	return metricsForWorkspace(&s.routes, &s.runtime, &s.platform, &s.policy, workspaceID)
+	return metricsForWorkspace(s.runtime.metrics, s.policy.defaultWorkspaceID, workspaceID)
 }
 
 func assembleRuntime(metrics QueryMetrics, options assemblyConfig) *appTestHarness {

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -90,11 +90,17 @@ func (s *appTestHarness) Routes() http.Handler {
 }
 
 func (s *appTestHarness) StartBackgroundJobs(ctx context.Context) error {
-	return StartBackgroundJobs(&s.routes, &s.runtime, &s.platform, &s.policy, ctx)
+	if s == nil || s.platform.workers == nil {
+		return nil
+	}
+	return s.platform.workers.Start(ctx)
 }
 
 func (s *appTestHarness) StopBackgroundJobs(ctx context.Context) error {
-	return StopBackgroundJobs(&s.routes, &s.runtime, &s.platform, &s.policy, ctx)
+	if s == nil || s.platform.workers == nil {
+		return nil
+	}
+	return s.platform.workers.Stop(ctx)
 }
 
 func (s *appTestHarness) workloadController() workloadControl {

--- a/internal/app/workspace_refresh_adapters.go
+++ b/internal/app/workspace_refresh_adapters.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/Yacobolo/toolbelt/pagestream"
+	accessmodule "github.com/flidai/leapview/internal/access/module"
+	dashboardmodule "github.com/flidai/leapview/internal/dashboard/module"
 	refreshmodule "github.com/flidai/leapview/internal/refresh/module"
 	servingstatemodule "github.com/flidai/leapview/internal/servingstate/module"
 	workspacemodule "github.com/flidai/leapview/internal/workspace/module"
@@ -86,56 +88,68 @@ func (b workspaceRefreshStateBridge) AssetRefreshState(
 	return workspaceAssetRefreshState(state), nil
 }
 
-func workspaceRefreshSupport(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy) refreshmodule.WorkspaceSupport {
+type workspaceRefreshDependencies struct {
+	access                *accessmodule.Module
+	dashboards            func() *dashboardmodule.Module
+	refresh               func() *refreshmodule.Module
+	workspaces            func() *workspacemodule.Module
+	broker                *pagestream.Broker
+	persistenceConfigured bool
+	defaultEnvironment    string
+}
+
+func workspaceRefreshSupport(deps *workspaceRefreshDependencies) refreshmodule.WorkspaceSupport {
 	support := refreshmodule.WorkspaceSupport{
 		Runs: func() (refreshmodule.RunReader, error) {
-			if routes.refreshModule == nil {
+			refresh := deps.refresh()
+			if refresh == nil {
 				return nil, fmt.Errorf("refresh module is required")
 			}
-			return routes.refreshModule, nil
+			return refresh, nil
 		},
 		QueuePipeline: func(ctx context.Context, input refreshmodule.QueuePipelineInput) (refreshmodule.QueueAssetResult, error) {
-			if routes.refreshModule == nil {
+			refresh := deps.refresh()
+			if refresh == nil {
 				return refreshmodule.QueueAssetResult{}, fmt.Errorf("refresh module is required")
 			}
-			return routes.refreshModule.QueuePipelineRefresh(ctx, input)
+			return refresh.QueuePipelineRefresh(ctx, input)
 		},
 		Environment: func(r *http.Request) servingstatemodule.Environment {
-			return requestServingEnvironment(routes, runtime, platform, policy, r)
+			return requestServingEnvironment(deps.defaultEnvironment, r)
 		},
 		PrincipalID: func(r *http.Request) string {
-			principal, _ := routes.accessModule.CurrentPrincipal(r)
+			principal, _ := deps.access.CurrentPrincipal(r)
 			return principal.ID
 		},
 		DispatchQueued: func() {
-			if routes.refreshModule != nil {
-				routes.refreshModule.Dispatch(context.Background())
+			if refresh := deps.refresh(); refresh != nil {
+				refresh.Dispatch(context.Background())
 			}
 		},
-		Broker: runtime.broker,
+		Broker: deps.broker,
 		AssetCatalog: func(ctx context.Context, workspaceID string) ([]workspacemodule.AssetView, []workspacemodule.AssetEdgeView, bool) {
-			assets, edges, err := routes.workspaceModule.WorkspaceAssetsAndEdgesForData(ctx, workspaceID, string(defaultServingEnvironment(routes, runtime, platform, policy)))
+			assets, edges, err := deps.workspaces().WorkspaceAssetsAndEdgesForData(ctx, workspaceID, string(defaultServingEnvironment(deps.defaultEnvironment)))
 			if err != nil || (len(assets) == 0 && len(edges) == 0) {
 				return nil, nil, false
 			}
 			return assets, edges, true
 		},
 		WorkspaceView: func(r *http.Request, workspaceID string) workspacemodule.WorkspaceView {
-			return routes.workspaceModule.WorkspaceResponse(r, workspaceID)
+			return deps.workspaces().WorkspaceResponse(r, workspaceID)
 		},
 		WorkspaceViewContext: func(ctx context.Context, workspaceID string) workspacemodule.WorkspaceView {
-			return routes.workspaceModule.WorkspaceViewContext(ctx, workspaceID)
+			return deps.workspaces().WorkspaceViewContext(ctx, workspaceID)
 		},
 		Presentation: workspaceRefreshPresentationBridge{},
 	}
-	if runtime.persistenceConfigured {
-		support.DataVersions = routes.refreshModule
+	if deps.persistenceConfigured {
+		support.DataVersions = deps.refresh()
 	}
 	return support
 }
 
-func workspaceRefreshService(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy, persistence persistenceInputs, workflow workflowInputs) (refreshmodule.Service, error) {
-	repo, err := resolveServingStateRepository(routes, runtime, platform, policy, persistence)
+func workspaceRefreshService(deps *workspaceRefreshDependencies, persistence persistenceInputs, workflow workflowInputs) (refreshmodule.Service, error) {
+	repo, err := resolveServingStateRepository(persistence)
 	if err != nil {
 		return refreshmodule.Service{}, err
 	}
@@ -151,17 +165,17 @@ func workspaceRefreshService(routes *capabilityRoutes, runtime *runtimeServices,
 		Runtime:       workflow.reloader,
 		Publisher: refreshmodule.Publisher{
 			Workspace: func() refreshmodule.WorkspaceSupport {
-				return workspaceRefreshSupport(routes, runtime, platform, policy)
+				return workspaceRefreshSupport(deps)
 			},
 			SemanticModelVersion: func(ctx context.Context, workspaceID, environment, modelID string) {
 				refreshedAt := ""
-				if routes.refreshModule != nil {
-					if version, ok, err := routes.refreshModule.DataVersion(ctx, workspaceID, environment, modelID); err == nil && ok {
+				if refresh := deps.refresh(); refresh != nil {
+					if version, ok, err := refresh.DataVersion(ctx, workspaceID, environment, modelID); err == nil && ok {
 						refreshedAt = version.RefreshedAt.Format(time.RFC3339)
 					}
 				}
-				if routes.dashboardModule != nil {
-					routes.dashboardModule.PublishSemanticModelRefresh(workspaceID, environment, modelID, refreshedAt)
+				if dashboards := deps.dashboards(); dashboards != nil {
+					dashboards.PublishSemanticModelRefresh(workspaceID, environment, modelID, refreshedAt)
 				}
 			},
 		},

--- a/internal/manageddata/module/routes.go
+++ b/internal/manageddata/module/routes.go
@@ -1,0 +1,16 @@
+package module
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (m *Module) MountTus(r chi.Router, handler http.Handler, protect func(http.Handler) http.Handler) {
+	if m == nil || handler == nil || protect == nil {
+		return
+	}
+	protected := protect(handler)
+	r.Handle("/upload-protocols/tus", protected)
+	r.Handle("/upload-protocols/tus/*", protected)
+}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -923,16 +923,17 @@ func TestApplicationAPIGenRoutesUseGeneratedAggregate(t *testing.T) {
 	}
 }
 
-func TestApplicationHasNoServerShapedDependencyContainer(t *testing.T) {
+func TestApplicationRetainsOnlyProcessFacingSurfaces(t *testing.T) {
+	root := repoRoot(t)
+	found := false
 	for _, file := range productionGoFiles(t) {
 		if file.pkgDir != "internal/app" {
 			continue
 		}
-		parsed, err := parser.ParseFile(token.NewFileSet(), file.path, file.body, 0)
+		parsed, err := parser.ParseFile(token.NewFileSet(), filepath.Join(root, filepath.FromSlash(file.path)), nil, 0)
 		if err != nil {
 			t.Fatalf("parse %s: %v", file.path, err)
 		}
-		localStructs := map[string]*ast.StructType{}
 		for _, declaration := range parsed.Decls {
 			generic, ok := declaration.(*ast.GenDecl)
 			if !ok || generic.Tok != token.TYPE {
@@ -943,57 +944,149 @@ func TestApplicationHasNoServerShapedDependencyContainer(t *testing.T) {
 				if !ok {
 					continue
 				}
-				if structure, ok := typeSpec.Type.(*ast.StructType); ok {
-					localStructs[typeSpec.Name.Name] = structure
+				if typeSpec.Name.Name != "Application" {
+					continue
+				}
+				found = true
+				structure, ok := typeSpec.Type.(*ast.StructType)
+				if !ok {
+					t.Fatalf("%s Application must be a struct", file.path)
+				}
+				fields := map[string]string{}
+				for _, field := range structure.Fields.List {
+					for _, name := range field.Names {
+						fields[name.Name] = expressionName(field.Type)
+					}
+				}
+				want := map[string]string{"handler": "http.Handler", "lifecycle": "*applicationLifecycleOwner"}
+				if !mapsEqual(fields, want) {
+					t.Errorf("%s Application fields = %#v, want only handler and private lifecycle owner", file.path, fields)
 				}
 			}
 		}
-		for name, structure := range localStructs {
-			switch name {
-			case "runtimeRouter", "assemblyConfig", "capabilityConstruction", "applicationAssembly", "assemblyInputs", "moduleAssemblyInputs":
-				t.Errorf("%s retains transitional dependency container %s", file.path, name)
+	}
+	if !found {
+		t.Fatal("internal/app does not declare Application")
+	}
+}
+
+func TestApplicationPublicSurfaceIsClosed(t *testing.T) {
+	want := map[string]bool{"Handler": true, "Start": true, "Shutdown": true, "Fatal": true}
+	got := map[string]bool{}
+	for _, file := range productionGoFiles(t) {
+		if file.pkgDir != "internal/app" {
+			continue
+		}
+		parsed, err := parser.ParseFile(token.NewFileSet(), file.path, file.body, 0)
+		require.NoError(t, err)
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Recv == nil || !ast.IsExported(function.Name.Name) {
+				continue
 			}
-			fields := expandedStructFieldCount(structure, localStructs, map[string]bool{name: true})
-			if fields > 12 {
-				t.Errorf("%s struct %s has %d transitive fields; split composition state into narrow route, lifecycle, health, and cleanup surfaces", file.path, name, fields)
+			for _, receiver := range function.Recv.List {
+				if expressionName(receiver.Type) == "*Application" {
+					got[function.Name.Name] = true
+				}
+			}
+		}
+	}
+	if !boolMapsEqual(got, want) {
+		t.Fatalf("Application exported methods = %#v, want handler, start, shutdown, and fatal only", got)
+	}
+}
+
+func TestCapabilityBrowserRoutesAreModuleOwned(t *testing.T) {
+	root := repoRoot(t)
+	routerPath := filepath.Join(root, "internal", "app", "router.go")
+	body, err := os.ReadFile(routerPath)
+	require.NoError(t, err)
+	parsed, err := parser.ParseFile(token.NewFileSet(), routerPath, body, 0)
+	require.NoError(t, err)
+	routeMethods := map[string]bool{
+		"Get": true, "Post": true, "Put": true, "Patch": true, "Delete": true,
+		"Method": true, "Handle": true,
+	}
+	capabilityPrefixes := []string{
+		"/admin", "/auth/", "/chats", "/connections", "/data", "/embed/dashboards",
+		"/login", "/oauth/", "/public/dashboards", "/workspaces", "/.well-known/oauth",
+	}
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !routeMethods[selector.Sel.Name] {
+			return true
+		}
+		literal, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || literal.Kind != token.STRING {
+			return true
+		}
+		path := strings.Trim(literal.Value, "\"`")
+		for _, prefix := range capabilityPrefixes {
+			owned := path == prefix || strings.HasPrefix(path, prefix+"/")
+			if strings.HasSuffix(prefix, "/") {
+				owned = strings.HasPrefix(path, prefix)
+			}
+			if owned {
+				t.Errorf("internal/app/router.go directly registers capability route %q; its module must own the route", path)
+			}
+		}
+		return true
+	})
+	for module, mounts := range map[string][]string{
+		"access":    {"MountLoginPage", "MountAuthenticatedBrowser", "MountLocalLogin", "MountOAuthEndpoints", "MountOAuthMetadata"},
+		"admin":     {"MountAuthenticated"},
+		"agent":     {"MountAuthenticated"},
+		"dashboard": {"MountPublicDocuments", "MountPublicCommands", "MountPublicStream", "MountAuthenticated"},
+		"workspace": {"MountAuthenticated"},
+	} {
+		moduleBody, readErr := os.ReadFile(filepath.Join(root, "internal", module, "module", "routes.go"))
+		require.NoError(t, readErr)
+		for _, mount := range mounts {
+			if !strings.Contains(string(moduleBody), "func (m *Module) "+mount+"(") {
+				t.Errorf("internal/%s/module does not own expected route mount %s", module, mount)
 			}
 		}
 	}
 }
 
-func expandedStructFieldCount(structure *ast.StructType, localStructs map[string]*ast.StructType, visiting map[string]bool) int {
-	fields := 0
-	for _, field := range structure.Fields.List {
-		fieldCount := len(field.Names)
-		if fieldCount == 0 {
-			fieldCount = 1
-		}
-		identifier, ok := localStructIdentifier(field.Type)
-		if !ok {
-			fields += fieldCount
-			continue
-		}
-		embedded, ok := localStructs[identifier.Name]
-		if !ok || visiting[identifier.Name] {
-			fields += fieldCount
-			continue
-		}
-		visiting[identifier.Name] = true
-		fields += fieldCount * expandedStructFieldCount(embedded, localStructs, visiting)
-		delete(visiting, identifier.Name)
+func mapsEqual(got, want map[string]string) bool {
+	if len(got) != len(want) {
+		return false
 	}
-	return fields
+	for key, value := range want {
+		if got[key] != value {
+			return false
+		}
+	}
+	return true
 }
 
-func localStructIdentifier(expression ast.Expr) (*ast.Ident, bool) {
+func boolMapsEqual(got, want map[string]bool) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for key, value := range want {
+		if got[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func expressionName(expression ast.Expr) string {
 	switch value := expression.(type) {
 	case *ast.Ident:
-		return value, true
+		return value.Name
+	case *ast.SelectorExpr:
+		return expressionName(value.X) + "." + value.Sel.Name
 	case *ast.StarExpr:
-		identifier, ok := value.X.(*ast.Ident)
-		return identifier, ok
+		return "*" + expressionName(value.X)
 	default:
-		return nil, false
+		return ""
 	}
 }
 
@@ -1266,13 +1359,33 @@ func TestEveryProductionPackageHasAnArchitecturalOwner(t *testing.T) {
 	}
 }
 
-func TestDeclaredCapabilityGraphHasNoReciprocalEdges(t *testing.T) {
-	for source, dependencies := range CapabilityDependencies {
-		for target := range dependencies {
-			if CapabilityDependencies[target][source] {
-				t.Errorf("capability graph contains reciprocal edges %s -> %s and %s -> %s", source, target, target, source)
-			}
+func TestDeclaredCapabilityGraphIsAcyclic(t *testing.T) {
+	const (
+		unvisited = iota
+		visiting
+		visited
+	)
+	states := map[string]int{}
+	stack := []string{}
+	var visit func(string)
+	visit = func(source string) {
+		switch states[source] {
+		case visited:
+			return
+		case visiting:
+			cycle := append(append([]string(nil), stack...), source)
+			t.Fatalf("capability dependency cycle: %s", strings.Join(cycle, " -> "))
 		}
+		states[source] = visiting
+		stack = append(stack, source)
+		for target := range CapabilityDependencies[source] {
+			visit(target)
+		}
+		stack = stack[:len(stack)-1]
+		states[source] = visited
+	}
+	for capability := range CapabilityDependencies {
+		visit(capability)
 	}
 }
 

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -954,6 +955,9 @@ func TestApplicationRetainsOnlyProcessFacingSurfaces(t *testing.T) {
 				}
 				fields := map[string]string{}
 				for _, field := range structure.Fields.List {
+					if len(field.Names) == 0 {
+						fields["<embedded:"+expressionName(field.Type)+">"] = expressionName(field.Type)
+					}
 					for _, name := range field.Names {
 						fields[name.Name] = expressionName(field.Type)
 					}
@@ -985,7 +989,8 @@ func TestApplicationPublicSurfaceIsClosed(t *testing.T) {
 				continue
 			}
 			for _, receiver := range function.Recv.List {
-				if expressionName(receiver.Type) == "*Application" {
+				receiverName := strings.TrimPrefix(expressionName(receiver.Type), "*")
+				if receiverName == "Application" {
 					got[function.Name.Name] = true
 				}
 			}
@@ -1007,9 +1012,11 @@ func TestCapabilityBrowserRoutesAreModuleOwned(t *testing.T) {
 		"Get": true, "Post": true, "Put": true, "Patch": true, "Delete": true,
 		"Method": true, "Handle": true,
 	}
+	constants := stringConstants(parsed)
 	capabilityPrefixes := []string{
 		"/admin", "/auth/", "/chats", "/connections", "/data", "/embed/dashboards",
-		"/login", "/oauth/", "/public/dashboards", "/workspaces", "/.well-known/oauth",
+		"/login", "/mcp", "/oauth/", "/public/dashboards", "/scim", "/upload-protocols/tus",
+		"/workspaces", "/.well-known/oauth",
 	}
 	ast.Inspect(parsed, func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
@@ -1020,11 +1027,10 @@ func TestCapabilityBrowserRoutesAreModuleOwned(t *testing.T) {
 		if !ok || !routeMethods[selector.Sel.Name] {
 			return true
 		}
-		literal, ok := call.Args[0].(*ast.BasicLit)
-		if !ok || literal.Kind != token.STRING {
+		path, ok := constantString(call.Args[0], constants)
+		if !ok {
 			return true
 		}
-		path := strings.Trim(literal.Value, "\"`")
 		for _, prefix := range capabilityPrefixes {
 			owned := path == prefix || strings.HasPrefix(path, prefix+"/")
 			if strings.HasSuffix(prefix, "/") {
@@ -1037,11 +1043,12 @@ func TestCapabilityBrowserRoutesAreModuleOwned(t *testing.T) {
 		return true
 	})
 	for module, mounts := range map[string][]string{
-		"access":    {"MountLoginPage", "MountAuthenticatedBrowser", "MountLocalLogin", "MountOAuthEndpoints", "MountOAuthMetadata"},
-		"admin":     {"MountAuthenticated"},
-		"agent":     {"MountAuthenticated"},
-		"dashboard": {"MountPublicDocuments", "MountPublicCommands", "MountPublicStream", "MountAuthenticated"},
-		"workspace": {"MountAuthenticated"},
+		"access":      {"MountLoginPage", "MountAuthenticatedBrowser", "MountLocalLogin", "MountOAuthEndpoints", "MountOAuthMetadata", "MountSCIM"},
+		"admin":       {"MountAuthenticated"},
+		"agent":       {"MountAuthenticated", "MountMCP"},
+		"dashboard":   {"MountPublicDocuments", "MountPublicCommands", "MountPublicStream", "MountAuthenticated"},
+		"manageddata": {"MountTus"},
+		"workspace":   {"MountAuthenticated"},
 	} {
 		moduleBody, readErr := os.ReadFile(filepath.Join(root, "internal", module, "module", "routes.go"))
 		require.NoError(t, readErr)
@@ -1050,6 +1057,87 @@ func TestCapabilityBrowserRoutesAreModuleOwned(t *testing.T) {
 				t.Errorf("internal/%s/module does not own expected route mount %s", module, mount)
 			}
 		}
+	}
+}
+
+func TestCompositionDependencyBagsStayAtCompositionBoundaries(t *testing.T) {
+	bagTypes := map[string]bool{
+		"*capabilityRoutes": true, "*runtimeServices": true, "*platformServices": true, "*httpPolicy": true,
+	}
+	allowed := map[string]bool{
+		"newCompositionSurfaces":   true,
+		"buildApplicationSurfaces": true,
+		"configureModules":         true,
+		"configureAPIProtocol":     true,
+		"configurePageStream":      true,
+		"configureRefreshModule":   true,
+		"Routes":                   true,
+	}
+	for _, file := range productionGoFiles(t) {
+		if file.pkgDir != "internal/app" {
+			continue
+		}
+		parsed, err := parser.ParseFile(token.NewFileSet(), file.path, file.body, 0)
+		require.NoError(t, err)
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Type.Params == nil || allowed[function.Name.Name] {
+				continue
+			}
+			for _, parameter := range function.Type.Params.List {
+				if bagTypes[expressionName(parameter.Type)] {
+					t.Errorf("%s %s accepts composition bag %s; pass its narrow dependency instead", file.path, function.Name.Name, expressionName(parameter.Type))
+				}
+			}
+		}
+	}
+}
+
+func stringConstants(file *ast.File) map[string]string {
+	values := map[string]string{}
+	for _, declaration := range file.Decls {
+		generic, ok := declaration.(*ast.GenDecl)
+		if !ok || generic.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range generic.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for index, name := range value.Names {
+				if index >= len(value.Values) {
+					continue
+				}
+				if resolved, ok := constantString(value.Values[index], values); ok {
+					values[name.Name] = resolved
+				}
+			}
+		}
+	}
+	return values
+}
+
+func constantString(expression ast.Expr, constants map[string]string) (string, bool) {
+	switch value := expression.(type) {
+	case *ast.BasicLit:
+		if value.Kind != token.STRING {
+			return "", false
+		}
+		resolved, err := strconv.Unquote(value.Value)
+		return resolved, err == nil
+	case *ast.Ident:
+		resolved, ok := constants[value.Name]
+		return resolved, ok
+	case *ast.BinaryExpr:
+		if value.Op != token.ADD {
+			return "", false
+		}
+		left, leftOK := constantString(value.X, constants)
+		right, rightOK := constantString(value.Y, constants)
+		return left + right, leftOK && rightOK
+	default:
+		return "", false
 	}
 }
 


### PR DESCRIPTION
## Summary

- reduce Application to the process-facing handler plus one private lifecycle owner with handler, start, shutdown, and fatal surfaces
- preserve and test dependency-order startup, rollback, reverse-order shutdown, once-only cleanup, and fatal forwarding
- remove exported service-bag lifecycle helpers used only by legacy tests
- replace the arbitrary transitive struct-field limit with full capability graph cycle detection, closed Application API checks, capability route ownership, and the existing import-direction/forbidden-import rules
- document the application composition and lifecycle invariants

## Inspiration

- Rill Sourcebook revision 0a5d448726ef: runtime/runtime.go for cohesive construction and one explicit Close owner
- Dagger Sourcebook revision 6fdd9b9d09c6: engine/server/server.go as a counterexample to avoid
- ZITADEL Sourcebook revision 9070b537d2eb: internal/command/command.go as a counterexample to avoid
- LeapView implementation: internal/app/application.go, internal/app/runtime_router.go, internal/platform/architecture/architecture_test.go, internal/platform/architecture/rules.go, and docs/articles/architecture/overview.md

## Validation

- go test ./internal/platform/architecture ./internal/platform/lifecycle -count=1
- go test -tags=duckdb_arrow ./internal/app -count=1
- go test -race ./internal/app -run TestApplication|TestRuntimeLifecycle|TestCleanupStack -count=1
- go vet -tags=duckdb_arrow ./internal/access/... ./internal/dashboard/queryauthz ./internal/app ./internal/platform/architecture ./internal/platform/lifecycle
- task generated:check
- git diff --check

## Stack

Stack 5/7. Depends on #237.

Linear: LEA-295