### PR TITLE
Fix nested Docker bind mounts on self-hosted CI

### DIFF
--- a/docs/articles/architecture/self-hosted-ci.md
+++ b/docs/articles/architecture/self-hosted-ci.md
@@ -52,9 +52,10 @@ is not already present. A failed toolchain change cannot overwrite the image use
 commit.
 
 The harness mounts stable Docker volumes for the Go build cache, the complete Go workspace,
-the Bun download cache, and the Terraform provider cache. It also mounts the checked-out
-workspace and Docker socket, configures the checkout as a safe Git directory, forwards the
-command without shell evaluation, and repairs checkout ownership on every exit path.
+the Bun download cache, and the Terraform provider cache. It mounts the checked-out workspace
+at its unchanged host path so nested Docker commands can safely bind files from that checkout.
+It also mounts the Docker socket, configures the checkout as a safe Git directory, forwards
+the command without shell evaluation, and repairs checkout ownership on every exit path.
 
 ## Workflow tiers
 

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2651,13 +2651,19 @@ func TestSelfHostedWorkflowsUseTheRepositoryOwnedRunnerHarness(t *testing.T) {
 		"leapview-actions-go-pkg:/go/pkg",
 		"leapview-actions-bun:/root/.bun/install/cache",
 		"leapview-actions-terraform:/root/.cache/terraform",
+		"--volume \"${workspace}:${workspace}\"",
+		"--workdir \"${workspace}\"",
 		"GIT_CONFIG_KEY_0=safe.directory",
+		"GIT_CONFIG_VALUE_0=${workspace}",
 		"chown -R",
 		"\"$@\"",
 	} {
 		if !strings.Contains(harnessText, want) {
 			t.Fatalf("self-hosted runner harness missing %q", want)
 		}
+	}
+	if strings.Contains(harnessText, "${workspace}:/workspace") {
+		t.Fatal("self-hosted runner harness must preserve the host checkout path for nested Docker bind mounts")
 	}
 }
 

--- a/scripts/run_ci_container.sh
+++ b/scripts/run_ci_container.sh
@@ -28,11 +28,14 @@ docker_args=(
   --rm
   --network host
   --volume /var/run/docker.sock:/var/run/docker.sock
-  --volume "${workspace}:/workspace"
-  --workdir /workspace
+  # Nested Docker commands share the host daemon. Preserve the checkout's host
+  # path inside this container so bind mounts created by those commands resolve
+  # to the same files in both path namespaces.
+  --volume "${workspace}:${workspace}"
+  --workdir "${workspace}"
   --env GIT_CONFIG_COUNT=1
   --env GIT_CONFIG_KEY_0=safe.directory
-  --env GIT_CONFIG_VALUE_0=/workspace
+  --env "GIT_CONFIG_VALUE_0=${workspace}"
 )
 for cache_spec in "${cache_specs[@]}"; do
   cache_name="${cache_spec%%:*}"
@@ -55,9 +58,9 @@ cleanup() {
   trap - EXIT INT TERM
   docker rm --force "${container_name}" >/dev/null 2>&1 || true
   if ! docker run --rm \
-    --volume "${workspace}:/workspace" \
+    --volume "${workspace}:${workspace}" \
     "${runner_image}" \
-    chown -R "$(id -u):$(id -g)" /workspace; then
+    chown -R "$(id -u):$(id -g)" "${workspace}"; then
     echo "failed to restore workspace ownership" >&2
     if (( exit_status == 0 )); then
       exit_status=1


### PR DESCRIPTION
## Summary
- preserve the host checkout path inside the repository-owned CI container
- keep nested Docker/Compose bind mounts in the host daemon namespace
- add a regression contract and document the path invariant

## Validation
- go test ./internal/platform/architecture -count=1
- bash -n scripts/run_ci_container.sh
- git diff --check
- self-hosted PR validation and CI gate passed: https://github.com/flidai/leapview/actions/runs/31014001072
- immutable production image qualification passed on leapview-ci-cx53, including enterprise authoring, using ghcr.io/flidai/leapview@sha256:8c256a386eae0448d1c664b660bbb7bbb3904836e469ba98ca7933b0216dc1f5

Follow-up to #244.