### PR TITLE
ci: make stacked validation head-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,23 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, stacked]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.stack.id || github.ref }}
   cancel-in-progress: true
 
 jobs:
   go-validation:
     name: Go tests (PR)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.position == github.event.pull_request.stack.size
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
@@ -42,6 +46,10 @@ jobs:
 
   frontend-validation:
     name: Frontend tests (PR)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.position == github.event.pull_request.stack.size
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
@@ -79,6 +87,10 @@ jobs:
           GO_RESULT: ${{ needs.go-validation.result }}
           FRONTEND_RESULT: ${{ needs.frontend-validation.result }}
         run: |
+          if [[ "${GO_RESULT}" = skipped && "${FRONTEND_RESULT}" = skipped ]]; then
+            printf '%s\n' 'Validation is deferred to the top of this stack.' >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
           test "${GO_RESULT}" = success || {
             printf 'Go validation: %s\n' "${GO_RESULT}" >&2
             exit 1

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: merge-validation-${{ github.repository }}
+  group: merge-validation-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/articles/architecture/github-hosted-ci.md
+++ b/docs/articles/architecture/github-hosted-ci.md
@@ -71,10 +71,22 @@ change validation behavior.
 
 The pull-request workflow runs Go and frontend validation on independent four-vCPU runners and
 reports the stable required `CI gate` check. This prevents browser timeouts caused by Go build
-contention and shortens wall-clock feedback without increasing per-job machine size. The merge
-queue runs those lanes plus the full extras against the exact merge-group commit. Nightly CI
-also runs security scans in parallel. Post-merge artifact CI builds and pushes the production
-image using a BuildKit cache, then qualifies its immutable digest on a second clean runner.
+contention and shortens wall-clock feedback without increasing per-job machine size.
+
+For a native GitHub pull-request stack, only the top pull request runs those validation lanes.
+Lower layers report a successful `CI gate` with a summary that validation is deferred to the
+stack tip. The workflow listens for the `stacked` action, and its concurrency key uses the native
+stack ID, so rebasing a stack cancels obsolete feedback for the whole stack instead of filling the
+runner queue. Standalone pull requests and manual dispatches continue to run both lanes.
+
+The main-branch ruleset must require GitHub's merge queue. A deferred lower-layer gate is feedback,
+not authorization to merge directly. The queue validates the exact candidate selected for main,
+whether that candidate is the complete stack or a contiguous prefix, by running the Go and frontend
+lanes plus the full extras. Merge-validation concurrency is scoped to the candidate ref: a rebuilt
+candidate cancels its obsolete run without making distinct queue candidates cancel one another.
+
+Nightly CI also runs security scans in parallel. Post-merge artifact CI builds and pushes the
+production image using a BuildKit cache, then qualifies its immutable digest on a second clean runner.
 
 Splitting production build and qualification prevents build layers from consuming the local
 disk needed by the qualification journey. The digest passed between jobs is the only product

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2535,7 +2535,9 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	for _, want := range []string{
 		"name: CI",
 		"pull_request:",
+		"types: [opened, synchronize, reopened, ready_for_review, stacked]",
 		"workflow_dispatch:",
+		"group: ci-${{ github.workflow }}-${{ github.event.pull_request.stack.id || github.ref }}",
 		"go-validation:",
 		"name: Go tests (PR)",
 		"frontend-validation:",
@@ -2551,6 +2553,7 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"needs: [go-validation, frontend-validation]",
 		"GO_RESULT: ${{ needs.go-validation.result }}",
 		"FRONTEND_RESULT: ${{ needs.frontend-validation.result }}",
+		"Validation is deferred to the top of this stack.",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("CI workflow missing GitHub-hosted fragment %q", want)
@@ -2558,6 +2561,20 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	}
 	goCI := workflowJobBlock(t, text, "go-validation")
 	frontendCI := workflowJobBlock(t, text, "frontend-validation")
+	for name, block := range map[string]string{
+		"go-validation":       goCI,
+		"frontend-validation": frontendCI,
+	} {
+		for _, want := range []string{
+			"github.event_name == 'workflow_dispatch'",
+			"github.event.pull_request.stack == null",
+			"github.event.pull_request.stack.position == github.event.pull_request.stack.size",
+		} {
+			if !strings.Contains(block, want) {
+				t.Fatalf("%s job is not limited to standalone pull requests and stack tips: missing %q", name, want)
+			}
+		}
+	}
 	for _, forbidden := range []string{
 		"push:",
 		"Build and qualify the production image remotely",
@@ -2575,6 +2592,7 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"name: Merge validation",
 		"merge_group:",
 		"types: [checks_requested]",
+		"group: merge-validation-${{ github.ref }}",
 		"go-validation:",
 		"name: Go tests (merge queue)",
 		"frontend-validation:",
@@ -2591,6 +2609,9 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		if !strings.Contains(mergeText, want) {
 			t.Fatalf("merge validation workflow missing %q", want)
 		}
+	}
+	if strings.Contains(mergeText, "group: merge-validation-${{ github.repository }}") {
+		t.Fatal("merge validation concurrency must not cancel distinct merge-queue candidates")
 	}
 	artifactText := string(artifactWorkflow)
 	for _, want := range []string{


### PR DESCRIPTION
## Summary

- run the GitHub-hosted PR lanes only for standalone pull requests and the top of native GitHub stacks
- give lower stack layers a successful `CI gate` with a clear deferred-validation summary
- key PR concurrency by native stack ID so a rebase cancels obsolete work across the stack
- keep the complete CI gate on every exact merge-queue candidate, including a contiguous stack prefix
- scope merge-validation concurrency to the candidate ref so separate queue candidates can use the configured parallel build capacity
- document the merge queue as the authoritative main-branch safety boundary

## Validation

- `task generate`
- `go test ./internal/platform/ci ./internal/platform/architecture -count=1`
- `task generated:check`
- `task ci`

All validation passed locally, including the complete 51/51 public-site browser suite.

## Required GitHub setting

The active `main` ruleset must require the merge queue and the stable `CI gate` status check. The merge queue then runs the full contract against the exact candidate before it reaches `main`; lower-layer deferred PR gates never authorize a direct merge.