### PR TITLE
ci: add pragmatic continuous delivery gates

### DIFF
--- a/.github/actions/desktop-preview-candidate/action.yml
+++ b/.github/actions/desktop-preview-candidate/action.yml
@@ -8,6 +8,10 @@ inputs:
   source-sha:
     description: Exact source revision recorded in release evidence.
     required: true
+  upload-artifact:
+    description: Upload the qualified candidate and evidence bundle.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -16,6 +20,20 @@ runs:
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         bun-version: 1.3.7
+
+    - name: Configure the Bun download cache
+      shell: bash
+      run: |
+        mkdir -p "${RUNNER_TEMP}/desktop-bun-cache"
+        echo "BUN_INSTALL_CACHE_DIR=${RUNNER_TEMP}/desktop-bun-cache" >> "${GITHUB_ENV}"
+
+    - name: Restore the Bun download cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/desktop-bun-cache
+        key: desktop-bun-${{ runner.os }}-${{ runner.arch }}-1.3.7-${{ hashFiles('desktop/bun.lock') }}
+        restore-keys: |
+          desktop-bun-${{ runner.os }}-${{ runner.arch }}-1.3.7-
 
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -66,6 +84,9 @@ runs:
       shell: bash
       run: |
         executable="$(find desktop/out -path '*/LeapView.app/Contents/MacOS/LeapView' -print -quit)"
+        test -n "$executable"
+        executable="$(realpath "$executable")"
+        test -x "$executable"
         LEAPVIEW_PACKAGED_APP="$executable" go test -count=1 \
           -run TestPackagedLeapViewPreservesRemoteContentBoundary \
           -v ./internal/app/testing/maliciousinstance
@@ -118,6 +139,7 @@ runs:
         ./scripts/qualify-consumer-windows.ps1 $installer
 
     - name: Upload verifiable unsigned candidate
+      if: inputs.upload-artifact == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
+      - name: Resolve deterministic build identity
+        id: identity
+        run: |
+          set -euo pipefail
+          build_time="$(git show -s --format=%cI HEAD)"
+          test -n "${build_time}"
+          printf 'build_time=%s\n' "${build_time}" >> "${GITHUB_OUTPUT}"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
@@ -49,6 +57,18 @@ jobs:
           push: true
           pull: true
           tags: ${{ env.IMAGE_REPOSITORY }}:main-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.version=main-${{ github.sha }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.identity.outputs.build_time }}
+            dev.leapview.build.dirty=false
+            dev.leapview.build.release=false
+          build-args: |
+            BUILD_VERSION=main-${{ github.sha }}
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_TIME=${{ steps.identity.outputs.build_time }}
+            BUILD_DIRTY=false
+            BUILD_RELEASE=false
           cache-from: type=gha,scope=production-amd64
           cache-to: type=gha,mode=max,scope=production-amd64,ignore-error=true
           provenance: mode=max
@@ -83,3 +103,113 @@ jobs:
           immutable_image="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
           task image:qualify:production IMAGE="${immutable_image}"
           printf 'Production image: `%s`\n' "${immutable_image}" >> "${GITHUB_STEP_SUMMARY}"
+
+  deploy-production:
+    name: Deploy qualified production image
+    needs: [build-production-image, qualify-production-image]
+    if: >-
+      github.repository == 'flidai/leapview' &&
+      github.ref == 'refs/heads/main' &&
+      vars.PRODUCT_AUTODEPLOY == 'true'
+    environment: leapview-production
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out deployed source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Reject a superseded candidate
+        id: freshness
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if [[ "$(git rev-parse origin/main)" == "${GITHUB_SHA}" ]]; then
+            echo "current=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "current=false" >> "${GITHUB_OUTPUT}"
+            printf 'Skipping superseded revision `%s`; main is now `%s`.\n' \
+              "${GITHUB_SHA}" "$(git rev-parse origin/main)" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Deploy, verify, and roll back on external failure
+        if: steps.freshness.outputs.current == 'true'
+        env:
+          IMAGE_DIGEST: ${{ needs.build-production-image.outputs.digest }}
+          PRODUCTION_HOST: ${{ vars.PRODUCT_HOST }}
+          PRODUCTION_URL: ${{ vars.PRODUCT_URL }}
+          PROBE_TOKEN: ${{ secrets.PRODUCT_PROBE_TOKEN }}
+          SSH_PRIVATE_KEY: ${{ secrets.PRODUCT_SSH_PRIVATE_KEY }}
+          SSH_HOST_KEY: ${{ secrets.PRODUCT_SSH_HOST_KEY }}
+        run: |
+          set -Eeuo pipefail
+          [[ "${IMAGE_DIGEST}" == sha256:* ]]
+          [[ "${PRODUCTION_HOST}" =~ ^[A-Za-z0-9.-]+$ ]]
+          [[ "${PRODUCTION_URL}" == https://* ]]
+          test -n "${PROBE_TOKEN}"
+          test -n "${SSH_PRIVATE_KEY}"
+          test -n "${SSH_HOST_KEY}"
+
+          ssh_dir="${RUNNER_TEMP}/leapview-production-ssh"
+          install -d -m 0700 "${ssh_dir}"
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > "${ssh_dir}/id"
+          printf '%s\n' "${SSH_HOST_KEY}" > "${ssh_dir}/known_hosts"
+          chmod 0600 "${ssh_dir}/id" "${ssh_dir}/known_hosts"
+          ssh-keygen -y -f "${ssh_dir}/id" >/dev/null
+          ssh-keygen -F "${PRODUCTION_HOST}" -f "${ssh_dir}/known_hosts" >/dev/null
+
+          ssh_options=(
+            -i "${ssh_dir}/id"
+            -o BatchMode=yes
+            -o ConnectTimeout=10
+            -o StrictHostKeyChecking=yes
+            -o "UserKnownHostsFile=${ssh_dir}/known_hosts"
+          )
+          immutable_image="ghcr.io/flidai/leapview@${IMAGE_DIGEST}"
+          production_url="${PRODUCTION_URL%/}"
+          upgrade_completed=false
+
+          rollback_on_error() {
+            status=$?
+            trap - ERR
+            if [[ "${upgrade_completed}" == true ]]; then
+              printf 'External verification failed; rolling back the paired image and state checkpoint.\n' >&2
+              ssh "${ssh_options[@]}" "root@${PRODUCTION_HOST}" \
+                "leapviewctl rollback --confirm" || \
+                printf 'Automatic rollback also failed; operator intervention is required.\n' >&2
+            fi
+            exit "${status}"
+          }
+          trap rollback_on_error ERR
+
+          ssh "${ssh_options[@]}" "root@${PRODUCTION_HOST}" \
+            "leapviewctl upgrade '${immutable_image}'"
+          upgrade_completed=true
+
+          ready=false
+          for _ in $(seq 1 24); do
+            if curl --fail --silent --show-error --connect-timeout 5 \
+              "${production_url}/healthz" >/dev/null && \
+              curl --fail --silent --show-error --connect-timeout 5 \
+              "${production_url}/readyz" >/dev/null; then
+              ready=true
+              break
+            fi
+            sleep 5
+          done
+          [[ "${ready}" == true ]]
+
+          capabilities="$(curl --fail --silent --show-error --connect-timeout 5 \
+            --header "Authorization: Bearer ${PROBE_TOKEN}" \
+            "${production_url}/api/v1/capabilities")"
+          jq -e '(.buildRevision == env.GITHUB_SHA)' <<< "${capabilities}" >/dev/null
+          trap - ERR
+
+          {
+            printf 'Deployed image: `%s`\n' "${immutable_image}"
+            printf 'Verified revision: `%s`\n' "${GITHUB_SHA}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -71,7 +71,6 @@ jobs:
   full-validation:
     name: Full merge validation
     if: github.repository == 'flidai/leapview'
-    needs: [go-validation, frontend-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
@@ -95,10 +94,85 @@ jobs:
       - name: Run merge-only validation
         run: task ci:full:extras
 
+  desktop-validation:
+    name: Desktop package (merge queue, ${{ matrix.name }})
+    if: github.repository == 'flidai/leapview'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            os: ubuntu-24.04
+            artifact: linux-x64
+          - name: macOS Intel
+            os: macos-15-intel
+            artifact: macos-x64
+          - name: macOS Apple silicon
+            os: macos-15
+            artifact: macos-arm64
+          - name: Windows x64
+            os: windows-2025
+            artifact: windows-x64
+
+    steps:
+      - name: Check out merge group
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Build, prove, and qualify the native candidate
+        uses: ./.github/actions/desktop-preview-candidate
+        with:
+          artifact-name: leapview-merge-${{ matrix.artifact }}
+          source-sha: ${{ github.sha }}
+          upload-artifact: "false"
+
+  image-validation:
+    name: Production image (merge queue)
+    if: github.repository == 'flidai/leapview'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out merge group
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up the cached CI toolchain
+        uses: ./.github/actions/setup-ci
+        with:
+          browser: "false"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build the production image candidate
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          load: true
+          pull: true
+          tags: leapview:merge-candidate
+          build-args: |
+            BUILD_VERSION=merge-${{ github.sha }}
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_DIRTY=false
+            BUILD_RELEASE=false
+          cache-from: type=gha,scope=production-amd64
+          cache-to: type=gha,mode=max,scope=production-amd64,ignore-error=true
+
+      - name: Qualify the production image candidate
+        run: task image:qualify:candidate IMAGE=leapview:merge-candidate
+
   ci-gate:
     name: CI gate
     if: ${{ always() }}
-    needs: [go-validation, frontend-validation, full-validation]
+    needs: [go-validation, frontend-validation, full-validation, desktop-validation, image-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -107,6 +181,8 @@ jobs:
           GO_RESULT: ${{ needs.go-validation.result }}
           FRONTEND_RESULT: ${{ needs.frontend-validation.result }}
           FULL_VALIDATION_RESULT: ${{ needs.full-validation.result }}
+          DESKTOP_RESULT: ${{ needs.desktop-validation.result }}
+          IMAGE_RESULT: ${{ needs.image-validation.result }}
         run: |
           test "${GO_RESULT}" = success || {
             printf 'Go validation: %s\n' "${GO_RESULT}" >&2
@@ -118,5 +194,13 @@ jobs:
           }
           test "${FULL_VALIDATION_RESULT}" = success || {
             printf 'Full merge validation: %s\n' "${FULL_VALIDATION_RESULT}" >&2
+            exit 1
+          }
+          test "${DESKTOP_RESULT}" = success || {
+            printf 'Desktop package validation: %s\n' "${DESKTOP_RESULT}" >&2
+            exit 1
+          }
+          test "${IMAGE_RESULT}" = success || {
+            printf 'Production image validation: %s\n' "${IMAGE_RESULT}" >&2
             exit 1
           }

--- a/.github/workflows/site-image.yml
+++ b/.github/workflows/site-image.yml
@@ -106,7 +106,7 @@ jobs:
             BUILD_VERSION=${{ needs.identity.outputs.version }}
             BUILD_REVISION=${{ needs.identity.outputs.revision }}
           cache-from: type=gha,scope=public-site-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=public-site-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=public-site-${{ matrix.arch }},ignore-error=true
           sbom: true
           provenance: mode=max
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -683,6 +683,20 @@ tasks:
         --require-immutable
         --evidence-dir {{.ROOT_DIR}}/.tmp/qualification/production-image
 
+  image:qualify:candidate:
+    desc: Qualify a locally built LeapView production-image candidate
+    requires:
+      vars: [IMAGE]
+    cmds:
+      - task: api:generate
+      - mkdir -p {{.ROOT_DIR}}/.tmp/qualification/tmp
+      - >-
+        env TMPDIR={{.ROOT_DIR}}/.tmp/qualification/tmp
+        LEAPVIEWCTL_ROOT={{.ROOT_DIR}}/deploy/compose
+        go run ./cmd/leapviewctl qualify image
+        --image {{.IMAGE | quote}}
+        --evidence-dir {{.ROOT_DIR}}/.tmp/qualification/merge-candidate-image
+
   image:qualify:site:
     desc: Qualify an immutable LeapView public-site image
     requires:

--- a/deploy/hetzner-site/deployment_test.go
+++ b/deploy/hetzner-site/deployment_test.go
@@ -304,6 +304,11 @@ func TestGitHubActionsPromotesVerifiedSiteImageWithoutProductionCredentials(t *t
 	}
 }
 
+func TestSiteImageCacheExportCannotFailAValidBuild(t *testing.T) {
+	workflow := readFile(t, filepath.Join("..", "..", ".github", "workflows", "site-image.yml"))
+	requireContains(t, workflow, "cache-to: type=gha,mode=max,scope=public-site-${{ matrix.arch }},ignore-error=true")
+}
+
 func TestPullReconcilerResolvesDesiredTagToImmutableDigest(t *testing.T) {
 	reconciler := readFile(t, filepath.Join("files", "reconcile.sh"))
 	for _, fragment := range []string{

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -156,6 +156,40 @@ after a successful upgrade, discarding post-upgrade state, with:
 $(terraform output -raw operations_command) rollback --confirm
 ```
 
+### Automatic promotion from main
+
+The `Main artifacts` GitHub Actions workflow builds the main revision once,
+qualifies its immutable digest, and can promote that same digest to this
+deployment. It verifies public health, readiness, and the authenticated build
+revision after the upgrade. A failed external verification invokes
+`leapviewctl rollback --confirm`; a failed controller healthcheck is rolled back
+inside `leapviewctl upgrade` itself. A newer main revision supersedes an older
+run before it can deploy.
+
+Create a protected GitHub environment named `leapview-production`. Configure
+these environment variables:
+
+- `PRODUCT_AUTODEPLOY=true` enables promotion. Leave it unset while
+  preparing or pausing the target.
+- `PRODUCT_HOST` is the SSH hostname without a username or port.
+- `PRODUCT_URL` is the target's public HTTPS origin.
+
+Configure these environment secrets:
+
+- `PRODUCT_SSH_PRIVATE_KEY` is the private key accepted by the
+  provisioned root operations account.
+- `PRODUCT_SSH_HOST_KEY` is the pinned OpenSSH `known_hosts` record
+  for `PRODUCT_HOST`, for example the output of a separately
+  verified `ssh-keyscan` operation. The workflow does not trust new keys.
+- `PRODUCT_PROBE_TOKEN` is a narrowly scoped bearer token that can
+  call `GET /api/v1/capabilities` and therefore has `USE_WORKSPACE` only. It is
+  used to confirm that the live process reports the exact deployed Git commit.
+
+Keep required reviewers off this environment for fully continuous deployment,
+or add reviewers when a manual production approval is desired. Environment
+protection does not change the artifact: both modes promote the already
+qualified digest and preserve the same rollback behavior.
+
 ## Destroy
 
 Export an independent backup first. Hetzner server backups are deleted with the

--- a/deploy/hetzner/deployment_test.go
+++ b/deploy/hetzner/deployment_test.go
@@ -225,6 +225,41 @@ func TestEphemeralDeploymentExercisesPublicAndBackupContracts(t *testing.T) {
 	}
 }
 
+func TestQualifiedMainImageDeploysThroughProtectedRollbackSafeEnvironment(t *testing.T) {
+	workflow := readFile(t, filepath.Join("..", "..", ".github", "workflows", "artifacts.yml"))
+	for _, fragment := range []string{
+		"deploy-production:",
+		"needs: [build-production-image, qualify-production-image]",
+		"environment: leapview-production",
+		"vars.PRODUCT_AUTODEPLOY == 'true'",
+		"PRODUCT_HOST",
+		"PRODUCT_URL",
+		"PRODUCT_SSH_PRIVATE_KEY",
+		"PRODUCT_SSH_HOST_KEY",
+		"StrictHostKeyChecking=yes",
+		"UserKnownHostsFile=",
+		"ghcr.io/flidai/leapview@${IMAGE_DIGEST}",
+		"leapviewctl upgrade",
+		"/healthz",
+		"/readyz",
+		"/api/v1/capabilities",
+		`buildRevision == env.GITHUB_SHA`,
+		"leapviewctl rollback --confirm",
+		"origin/main",
+	} {
+		requireContains(t, workflow, fragment)
+	}
+	for _, forbidden := range []string{
+		"StrictHostKeyChecking=no",
+		"StrictHostKeyChecking=accept-new",
+		"ghcr.io/flidai/leapview:main",
+	} {
+		if strings.Contains(workflow, forbidden) {
+			t.Errorf("automatic production deployment contains forbidden fragment %q", forbidden)
+		}
+	}
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	contents, err := os.ReadFile(path)

--- a/desktop/src/remote-window.test.ts
+++ b/desktop/src/remote-window.test.ts
@@ -71,6 +71,8 @@ describe("createRemoteWindow", () => {
       new URL("./main.ts", import.meta.url),
       "utf8",
     );
-    expect(entrypoint).toBe('import "./application.js";\n');
+    expect(entrypoint.replaceAll("\r\n", "\n")).toBe(
+      'import "./application.js";\n',
+    );
   });
 });

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2627,10 +2627,20 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"name: Full merge validation",
 		"runs-on: ubuntu-24.04",
 		"uses: ./.github/actions/setup-ci",
-		"needs: [go-validation, frontend-validation]",
 		"run: task ci:full:extras",
+		"desktop-validation:",
+		"name: Desktop package (merge queue, ${{ matrix.name }})",
+		"macos-15-intel",
+		"macos-15",
+		"windows-2025",
+		"uses: ./.github/actions/desktop-preview-candidate",
+		"image-validation:",
+		"name: Production image (merge queue)",
+		"load: true",
+		"tags: leapview:merge-candidate",
+		"task image:qualify:candidate IMAGE=leapview:merge-candidate",
 		"name: CI gate",
-		"needs: [go-validation, frontend-validation, full-validation]",
+		"needs: [go-validation, frontend-validation, full-validation, desktop-validation, image-validation]",
 	} {
 		if !strings.Contains(mergeText, want) {
 			t.Fatalf("merge validation workflow missing %q", want)
@@ -2638,6 +2648,9 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	}
 	if strings.Contains(mergeText, "group: merge-validation-${{ github.repository }}") {
 		t.Fatal("merge validation concurrency must not cancel distinct merge-queue candidates")
+	}
+	if strings.Contains(workflowJobBlock(t, mergeText, "full-validation"), "needs:") {
+		t.Fatal("full merge validation must start in parallel with the focused validation lanes")
 	}
 	artifactText := string(artifactWorkflow)
 	for _, want := range []string{
@@ -2648,16 +2661,48 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"name: Build production image",
 		"uses: docker/build-push-action@",
 		"cache-from: type=gha,scope=production-amd64",
-		"cache-to: type=gha,mode=max,scope=production-amd64",
+		"cache-to: type=gha,mode=max,scope=production-amd64,ignore-error=true",
+		"BUILD_VERSION=main-${{ github.sha }}",
+		"BUILD_REVISION=${{ github.sha }}",
 		"qualify-production-image:",
 		"name: Qualify production image",
 		"needs: build-production-image",
 		"uses: ./.github/actions/setup-ci",
 		"task image:qualify:production IMAGE=\"${immutable_image}\"",
+		"deploy-production:",
+		"environment: leapview-production",
+		"vars.PRODUCT_AUTODEPLOY == 'true'",
+		"StrictHostKeyChecking=yes",
+		"leapviewctl upgrade",
+		"/api/v1/capabilities",
+		"leapviewctl rollback --confirm",
 	} {
 		if !strings.Contains(artifactText, want) {
 			t.Fatalf("main artifact workflow missing %q", want)
 		}
+	}
+	desktopAction, err := os.ReadFile(filepath.Join(root, ".github", "actions", "desktop-preview-candidate", "action.yml"))
+	if err != nil {
+		t.Fatalf("read desktop preview candidate action: %v", err)
+	}
+	if !strings.Contains(string(desktopAction), `executable="$(realpath "$executable")"`) {
+		t.Fatal("desktop preview proof must pass an absolute macOS executable path to Go tests")
+	}
+	for _, want := range []string{
+		"actions/cache@",
+		"BUN_INSTALL_CACHE_DIR",
+		"desktop-bun-${{ runner.os }}-${{ runner.arch }}-1.3.7-${{ hashFiles('desktop/bun.lock') }}",
+	} {
+		if !strings.Contains(string(desktopAction), want) {
+			t.Fatalf("desktop preview candidate must restore its native dependency cache: missing %q", want)
+		}
+	}
+	remoteWindowTest, err := os.ReadFile(filepath.Join(root, "desktop", "src", "remote-window.test.ts"))
+	if err != nil {
+		t.Fatalf("read remote window test: %v", err)
+	}
+	if !strings.Contains(string(remoteWindowTest), `.replaceAll("\r\n", "\n")`) {
+		t.Fatal("desktop composition-root assertion must normalize Windows checkout line endings")
 	}
 	for _, forbidden := range []string{
 		"Build and smoke-test the public site image remotely",


### PR DESCRIPTION
## Summary

- run focused, full, native desktop, and production-image merge gates in parallel
- make BuildKit cache export non-fatal and cache native Bun downloads
- fix macOS packaged-proof paths and Windows line-ending portability
- build deterministic main images, qualify immutable digests, then optionally deploy through the protected leapview-production environment
- verify live health and build revision, with paired image-and-state rollback on external verification failure

## Deployment setup

Automatic product deployment remains disabled until the leapview-production environment defines PRODUCT_AUTODEPLOY=true, PRODUCT_HOST, PRODUCT_URL, PRODUCT_SSH_PRIVATE_KEY, PRODUCT_SSH_HOST_KEY, and PRODUCT_PROBE_TOKEN. The repository documentation describes each value and the required token scope.

## Verification

- full PR validation lanes passed
- generated contract check passed
- desktop tests, go vet, and race checks passed
- managed UI framework QA passed across 8 routes
- Docker CLI and Testcontainers qualification passed with OrbStack
- deployment contract suites passed
- actionlint passed for changed workflows, with the existing macos-15-intel label allowlisted

Latest main currently has an unrelated pre-existing architecture failure in the access OAuth module; the focused architecture contract for this change passes.