### PR TITLE
fix: preserve qualified main image identity

### DIFF
--- a/internal/platform/buildinfo/buildinfo.go
+++ b/internal/platform/buildinfo/buildinfo.go
@@ -76,14 +76,14 @@ func resolve(injected injectedMetadata, vcs vcsMetadata) Identity {
 		}
 	}
 
-	if requested, err := strconv.ParseBool(strings.TrimSpace(injected.release)); err == nil && requested &&
-		dirtyValid && !resolvedDirty &&
-		validVersion(injected.version) &&
-		validRevision(resolvedRevision) &&
-		validBuildTime(resolvedBuildTime) {
+	requestedRelease, releaseErr := strconv.ParseBool(strings.TrimSpace(injected.release))
+	qualifiedDevelopment := releaseErr == nil && !requestedRelease && validDevelopmentVersion(injected.version)
+	if releaseErr == nil && (requestedRelease || qualifiedDevelopment) &&
+		dirtyValid && !resolvedDirty && validVersion(injected.version) &&
+		validRevision(resolvedRevision) && validBuildTime(resolvedBuildTime) {
 		return Identity{
 			Version: strings.TrimSpace(injected.version), Revision: resolvedRevision,
-			BuildTime: resolvedBuildTime,
+			BuildTime: resolvedBuildTime, Development: !requestedRelease,
 		}
 	}
 
@@ -115,6 +115,11 @@ func readVCSMetadata() vcsMetadata {
 func validVersion(value string) bool {
 	value = strings.TrimSpace(value)
 	return value != "" && !strings.HasPrefix(value, "v") && semver.IsValid("v"+value)
+}
+
+func validDevelopmentVersion(value string) bool {
+	value = strings.TrimSpace(value)
+	return validVersion(value) && semver.Build("v"+value) != ""
 }
 
 func validRevision(value string) bool {

--- a/internal/platform/buildinfo/buildinfo_test.go
+++ b/internal/platform/buildinfo/buildinfo_test.go
@@ -24,6 +24,24 @@ func TestDevelopmentIdentityNeverClaimsReleaseVersion(t *testing.T) {
 	}
 }
 
+func TestDevelopmentIdentityPreservesQualifiedBuildVersion(t *testing.T) {
+	metadata := injectedMetadata{
+		version:   "0.2.0-rc.1+main.248521fd0cd8",
+		revision:  strings.Repeat("a", 40),
+		buildTime: "2026-08-07T07:33:28Z",
+		dirty:     "false",
+		release:   "false",
+	}
+	identity := resolve(metadata, vcsMetadata{})
+
+	if identity.Version != metadata.version || identity.Revision != metadata.revision || identity.BuildTime != metadata.buildTime {
+		t.Fatalf("qualified development identity = %#v", identity)
+	}
+	if !identity.Development || identity.Dirty {
+		t.Fatalf("qualified development state = %#v", identity)
+	}
+}
+
 func TestReleaseIdentityRequiresCompleteValidatedMetadata(t *testing.T) {
 	valid := injectedMetadata{
 		version:   "0.2.0-rc.1",


### PR DESCRIPTION
## Summary
- preserve SemVer build metadata for qualified non-release main images
- keep those images explicitly marked as development builds
- cover the exact main artifact identity contract with a regression test

## Root cause
Main artifacts injected `0.2.0-rc.1+main.<sha>` with `BUILD_RELEASE=false`, but build identity normalization discarded every non-release version as `development`. The image qualifier then passed its authoring proof and failed the subsequent exact identity assertion, causing the hosted Olist deployment to be skipped.

## Verification
- `go test ./internal/platform/buildinfo -count=1`
- exact `go run -ldflags=... ./cmd/leapview version --json` contract
- `task ci:pr`