### PR TITLE
fix: handle Hetzner firewall action batches

### DIFF
--- a/deploy/demo/deployment_test.go
+++ b/deploy/demo/deployment_test.go
@@ -116,6 +116,21 @@ func TestDemoDeploymentRejectsMutableImagesBeforeChangingInfrastructure(t *testi
 	require.Contains(t, string(output), "immutable sha256 digest")
 }
 
+func TestHetznerFirewallWaitsForEveryReturnedAction(t *testing.T) {
+	root := filepath.Join("..", "..")
+	helper := filepath.Join(root, "scripts", "lib", "hcloud_actions.sh")
+	command := exec.Command("bash", "-c", `
+set -euo pipefail
+source "$1"
+wait_hcloud_action() { printf '%s\n' "$1"; }
+wait_hcloud_actions '{"actions":[{"id":101,"status":"success"},{"id":102,"status":"running"}]}'
+`, "test-hcloud-actions", helper)
+
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Equal(t, "101\n102\n", string(output))
+}
+
 func read(t *testing.T, path string) string {
 	t.Helper()
 	body, err := os.ReadFile(path)

--- a/scripts/deploy_demo.sh
+++ b/scripts/deploy_demo.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/hcloud_actions.sh
+source "$repo_root/scripts/lib/hcloud_actions.sh"
 demo_image="${DEMO_IMAGE:?Set DEMO_IMAGE to an immutable ghcr.io/flidai/leapview digest}"
 demo_host="${DEMO_HOST:?Set DEMO_HOST to the demo server IP address}"
 demo_target="${DEMO_TARGET:-https://demo.leapview.dev}"
@@ -82,14 +84,9 @@ wait_hcloud_action() {
 
 set_firewall_rules() {
   local payload="$1"
-  local response action_id
+  local response
   response="$(hcloud_request POST "/firewalls/$firewall_id/actions/set_rules" "$payload")"
-  action_id="$(jq -r '.action.id' <<<"$response")"
-  [[ "$action_id" =~ ^[0-9]+$ ]] || {
-    echo "Hetzner did not return a firewall action identity" >&2
-    return 1
-  }
-  wait_hcloud_action "$action_id"
+  wait_hcloud_actions "$response"
 }
 
 cleanup() {
@@ -121,8 +118,8 @@ if ! jq -e --arg cidr "$runner_cidr" '
     source_ips: [$cidr],
     description: "Temporary GitHub-hosted demo deployment access"
   }])}' "$original_firewall_rules" >"$next_payload"
-  set_firewall_rules "$next_payload"
   firewall_changed=true
+  set_firewall_rules "$next_payload"
 fi
 
 identity_file="$temporary_directory/operator-identity"

--- a/scripts/lib/hcloud_actions.sh
+++ b/scripts/lib/hcloud_actions.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+wait_hcloud_actions() {
+  local response="$1"
+  local action_ids action_id
+
+  if ! action_ids="$(jq -er '
+    [(.action.id?), (.actions[]?.id?)]
+    | map(select(type == "number"))
+    | unique
+    | if length == 0 then error("Hetzner returned no action identities") else .[] end
+  ' <<<"$response")"; then
+    echo "Hetzner did not return any firewall action identities" >&2
+    return 1
+  fi
+
+  while IFS= read -r action_id; do
+    wait_hcloud_action "$action_id"
+  done <<<"$action_ids"
+}


### PR DESCRIPTION
## Summary
- handle both legacy single-action and current multi-action Hetzner firewall responses
- wait for every returned firewall action before continuing
- claim cleanup responsibility before mutating the firewall so parse/wait failures cannot leak runner SSH access
- add a regression test for current Hetzner action batches

## Verification
- `go test ./deploy/demo -count=1`
- `bash -n scripts/deploy_demo.sh scripts/lib/hcloud_actions.sh`
- `task ci:pr`
- removed the temporary SSH rule leaked by the failed deployment