### PR TITLE
fix: generate config before demo bootstrap

### DIFF
--- a/deploy/demo/deployment_test.go
+++ b/deploy/demo/deployment_test.go
@@ -94,6 +94,11 @@ func TestDemoDeploymentIsAutomaticAndDigestPinned(t *testing.T) {
 	} {
 		require.NotContains(t, strings.ToLower(script), forbidden)
 	}
+	configGeneration := strings.Index(script, "go run ./internal/app/tools/configgen")
+	olistBootstrap := strings.Index(script, "go run ./internal/app/tools/bootstrapolist")
+	require.NotEqual(t, -1, configGeneration, "demo deployment must generate ignored config sources")
+	require.NotEqual(t, -1, olistBootstrap, "demo deployment must bootstrap Olist")
+	require.Less(t, configGeneration, olistBootstrap, "config generation must precede Olist compilation")
 }
 
 func TestDemoDeploymentRejectsMutableImagesBeforeChangingInfrastructure(t *testing.T) {

--- a/scripts/deploy_demo.sh
+++ b/scripts/deploy_demo.sh
@@ -195,6 +195,7 @@ chmod 0755 "$temporary_directory/leapview"
 leapview="$temporary_directory/leapview"
 
 cd "$repo_root"
+go run ./internal/app/tools/configgen
 go run ./internal/app/tools/bootstrapolist --shared-cache --out "$data_link"
 data_path="$(cd -P "$data_link" && pwd)"
 "$leapview" data sync \


### PR DESCRIPTION
## Summary
- generate ignored runtime config sources before compiling the Olist bootstrap tool in hosted deployment
- assert generation happens before Olist bootstrap

## Verification
- red: clean deployment contract lacked config generation
- `go test ./deploy/demo -count=1`
- `bash -n scripts/deploy_demo.sh scripts/lib/hcloud_actions.sh`
- `task ci:pr`