### PR TITLE
fix: unblock first project deployment

### DIFF
--- a/api/typespec/capabilities.tsp
+++ b/api/typespec/capabilities.tsp
@@ -69,6 +69,6 @@ model CapabilitiesResponse {
 @summary("Describe server capabilities")
 @route("/capabilities")
 @get
-@apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@apigen.authz(#{ mode: "authenticated" })
 @operationId("getCapabilities")
 op getCapabilities(): OkJson<CapabilitiesResponse> | CommonErrors;

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -46,6 +46,12 @@ managed-data ingestion, project authoring, and release publication. The
 release principal is restricted to viewing, approving, and activating the demo
 project environment.
 
+Target capability discovery requires an authenticated credential but no
+pre-existing workspace grant. This is essential on the first deployment,
+because the project's workspaces do not exist until its exact candidate is
+activated. The subsequent authoring, ingestion, publication, approval, and
+activation calls remain protected by their project-environment grants.
+
 The checked-in `ssh-host-key.sha256` pins the server identity. The workflow
 adds only its current runner `/32` to SSH, then restores the complete prior
 firewall rule set on exit.

--- a/deploy/demo/deployment_test.go
+++ b/deploy/demo/deployment_test.go
@@ -83,6 +83,7 @@ func TestDemoDeploymentIsAutomaticAndDigestPinned(t *testing.T) {
 		"grant_type=client_credentials",
 		"DEMO_PUBLISHER_CLIENT_ID",
 		"DEMO_RELEASE_CLIENT_ID",
+		"'AUTHOR_PROJECT PUBLISH_RELEASE INGEST_DATA'",
 	} {
 		require.Contains(t, script, required)
 	}

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3681,9 +3681,6 @@ paths:
                 type: example
       tags:
         - System
-      x-authz:
-        mode: privilege
-        privilege: USE_WORKSPACE
   /api/v1/instance:
     get:
       operationId: getInstance

--- a/internal/access/module/apigen_test.go
+++ b/internal/access/module/apigen_test.go
@@ -64,6 +64,10 @@ func TestAPIGenAuthorizationContractCoverage(t *testing.T) {
 	publicAuthoringAuth := map[string]bool{
 		"getInstance": true,
 	}
+	authenticatedOnly := map[string]bool{
+		"decideDeviceAuthorization": true,
+		"getCapabilities":           true,
+	}
 	for operationID, contract := range contracts {
 		if publicAuthoringAuth[operationID] {
 			if contract.Protected || contract.AuthzMode != "none" {
@@ -78,7 +82,7 @@ func TestAPIGenAuthorizationContractCoverage(t *testing.T) {
 		if !ok {
 			t.Fatalf("%s has invalid authorization metadata", operationID)
 		}
-		if operationID == "decideDeviceAuthorization" {
+		if authenticatedOnly[operationID] {
 			if contract.AuthzMode != "authenticated" {
 				t.Fatalf("%s auth mode = %q, want authenticated", operationID, contract.AuthzMode)
 			}

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -975,6 +975,7 @@ func TestAPIGenOperationExtensions(t *testing.T) {
 	}
 	authenticatedOperations := map[string]bool{
 		"decideDeviceAuthorization": true,
+		"getCapabilities":           true,
 	}
 	for operationID, contract := range contracts {
 		authz, ok := contract.Extensions["x-authz"].(map[string]any)

--- a/internal/app/capabilities_test.go
+++ b/internal/app/capabilities_test.go
@@ -54,3 +54,13 @@ func TestCapabilitiesReportOnlyEnabledUploadProtocols(t *testing.T) {
 		}
 	}
 }
+
+func TestCapabilitiesRequireAuthenticationWithoutWorkspaceAuthorization(t *testing.T) {
+	contract, ok := apigenapi.GetAPIGenOperationContracts()["getCapabilities"]
+	if !ok {
+		t.Fatal("getCapabilities contract is missing")
+	}
+	if !contract.Protected || contract.AuthzMode != "authenticated" {
+		t.Fatalf("getCapabilities authorization = protected:%t mode:%q, want authenticated", contract.Protected, contract.AuthzMode)
+	}
+}

--- a/internal/app/route_inventory_test.go
+++ b/internal/app/route_inventory_test.go
@@ -84,7 +84,7 @@ func TestRouteInventory(t *testing.T) {
 		rows = append(rows, fmt.Sprintf("%s|%s|%s|%s", key, contract.owner, contract.access, contract.privilege))
 	}
 	sort.Strings(rows)
-	const expectedRouteContractDigest = "04c93c4f105b62890ec729ba6680b0da80cd71c711aa5c0a6a718fb1384b1bee"
+	const expectedRouteContractDigest = "45fae806e6917db9885adcf0a5a8431e327754e1b139da926bd756d1c2e21e07"
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(rows, "\n"))))
 	if digest != expectedRouteContractDigest {
 		t.Fatalf("route ownership/auth contract changed: got digest %s\n%s", digest, strings.Join(rows, "\n"))


### PR DESCRIPTION
## Summary

- allow authenticated capability discovery before a project has created any workspaces
- keep authoring, ingestion, publication, approval, and activation behind their existing project-scoped grants
- document and regression-test the clean hosted-demo bootstrap path

## Verification

- `task ci:pr`
- hosted demo service-principal grants normalized to their canonical subject type
- temporary diagnostic grant removed