### PR TITLE
fix: authorize demo publications

### DIFF
--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -44,7 +44,8 @@ principals. Their credentials are exchanged for one-hour, project-scoped OAuth
 workload tokens on every deployment. The publisher is restricted to
 managed-data ingestion, project authoring, and release publication. The
 release principal is restricted to viewing, approving, and activating the demo
-project environment.
+project environment, plus managing the public dashboard publications declared
+by the canonical showcase.
 
 Target capability discovery requires an authenticated credential but no
 pre-existing workspace grant. This is essential on the first deployment,

--- a/deploy/demo/deployment_test.go
+++ b/deploy/demo/deployment_test.go
@@ -84,6 +84,7 @@ func TestDemoDeploymentIsAutomaticAndDigestPinned(t *testing.T) {
 		"DEMO_PUBLISHER_CLIENT_ID",
 		"DEMO_RELEASE_CLIENT_ID",
 		"'AUTHOR_PROJECT PUBLISH_RELEASE INGEST_DATA'",
+		"'VIEW_ITEM APPROVE_DEPLOYMENT ACTIVATE_DEPLOYMENT MANAGE_PUBLICATIONS'",
 	} {
 		require.Contains(t, script, required)
 	}

--- a/scripts/deploy_demo.sh
+++ b/scripts/deploy_demo.sh
@@ -184,7 +184,7 @@ publisher_token="$(exchange_workload_token \
 release_token="$(exchange_workload_token \
   "$release_client_id" \
   "$release_client_secret" \
-  'VIEW_ITEM APPROVE_DEPLOYMENT ACTIVATE_DEPLOYMENT')"
+  'VIEW_ITEM APPROVE_DEPLOYMENT ACTIVATE_DEPLOYMENT MANAGE_PUBLICATIONS')"
 unset publisher_client_secret release_client_secret
 
 docker pull "$demo_image"


### PR DESCRIPTION
The canonical Olist showcase declares public dashboard publications. Its release service principal therefore needs the project-scoped `MANAGE_PUBLICATIONS` privilege in addition to view, approval, and activation.

This updates the workload token scope, adds a deployment contract regression, and documents the least-privilege boundary. The matching project-environment grant is already applied to `leapview-demo`.

Validation: `task ci:pr`.