### PR TITLE
fix: scope publication activation to project

### DIFF
--- a/internal/app/dashboard_publications_test.go
+++ b/internal/app/dashboard_publications_test.go
@@ -98,6 +98,14 @@ func TestPublicationDeploymentRequiresManagementPrivilege(t *testing.T) {
 		t.Fatalf("viewer authorization error = %v", err)
 	}
 	owner := testPrincipal(t, ctx, store, "owner-publication@example.com", "Owner", "owner")
+	if _, err := testAccessRepository(store).CreateGrant(ctx, access.GrantInput{
+		Object:      access.ProjectEnvironmentObject("project", "prod"),
+		SubjectType: access.SubjectPrincipal,
+		SubjectID:   owner.ID,
+		Privilege:   access.PrivilegeManagePublications,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if err := server.routes.deploymentModule.AuthorizePublicationDeployment(ctx, owner.ID, "prod", targets); err != nil {
 		t.Fatalf("owner authorization: %v", err)
 	}

--- a/internal/deployment/module/authorization.go
+++ b/internal/deployment/module/authorization.go
@@ -3,6 +3,8 @@ package module
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/flidai/leapview/internal/access"
 	"github.com/flidai/leapview/internal/deployment/apiadapter"
@@ -34,13 +36,28 @@ func (m *Module) AuthorizePublicationDeployment(ctx context.Context, actor, envi
 }
 
 func authorizePublicationDeployment(ctx context.Context, actor, environment string, targets []apiadapter.TargetRequest, config PublicationAuthorizationConfig) error {
-	if servingstate.NormalizeEnvironment(servingstate.Environment(environment)) != servingstate.Environment("prod") {
+	normalizedEnvironment := servingstate.NormalizeEnvironment(servingstate.Environment(environment))
+	if normalizedEnvironment != servingstate.Environment("prod") {
 		return nil
 	}
+	projectID := ""
+	requiresAuthorization := false
 	for _, target := range targets {
 		state, err := config.States.ByID(ctx, servingstate.ID(target.CandidateID))
 		if err != nil {
 			return err
+		}
+		stateProjectID := strings.TrimSpace(state.ProjectID)
+		if stateProjectID == "" {
+			return fmt.Errorf("publication serving state %q has no project identity", target.CandidateID)
+		}
+		if projectID == "" {
+			projectID = stateProjectID
+		} else if projectID != stateProjectID {
+			return fmt.Errorf("publication deployment spans multiple projects: %q and %q", projectID, stateProjectID)
+		}
+		if stateWorkspaceID := strings.TrimSpace(string(state.WorkspaceID)); stateWorkspaceID != strings.TrimSpace(target.Workspace) {
+			return fmt.Errorf("publication serving state %q belongs to workspace %q, want %q", target.CandidateID, stateWorkspaceID, target.Workspace)
 		}
 		var configured map[string]json.RawMessage
 		if state.DashboardPublicationsJSON != "" {
@@ -48,19 +65,27 @@ func authorizePublicationDeployment(ctx context.Context, actor, environment stri
 				return err
 			}
 		}
-		if len(configured) == 0 || config.Bypass != nil && config.Bypass(actor) {
-			continue
+		if len(configured) > 0 {
+			requiresAuthorization = true
 		}
-		if config.AuthorizeObject == nil {
-			return ErrPublicationForbidden
-		}
-		allowed, err := config.AuthorizeObject(ctx, actor, access.PrivilegeManagePublications, access.WorkspaceObject(target.Workspace))
-		if err != nil {
-			return err
-		}
-		if !allowed {
-			return ErrPublicationForbidden
-		}
+	}
+	if !requiresAuthorization || config.Bypass != nil && config.Bypass(actor) {
+		return nil
+	}
+	if config.AuthorizeObject == nil {
+		return ErrPublicationForbidden
+	}
+	allowed, err := config.AuthorizeObject(
+		ctx,
+		actor,
+		access.PrivilegeManagePublications,
+		access.ProjectEnvironmentObject(projectID, string(normalizedEnvironment)),
+	)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrPublicationForbidden
 	}
 	return nil
 }

--- a/internal/deployment/module/authorization_test.go
+++ b/internal/deployment/module/authorization_test.go
@@ -1,0 +1,69 @@
+package module
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/deployment/apiadapter"
+	"github.com/flidai/leapview/internal/servingstate"
+	"github.com/stretchr/testify/require"
+)
+
+type publicationStateStore map[servingstate.ID]servingstate.State
+
+func (s publicationStateStore) ByID(_ context.Context, id servingstate.ID) (servingstate.State, error) {
+	return s[id], nil
+}
+
+func TestPublicationAuthorizationUsesProjectEnvironmentBoundary(t *testing.T) {
+	states := publicationStateStore{
+		"state_sales": {
+			ID: "state_sales", WorkspaceID: "sales", ProjectID: "leapview-showcase",
+			DashboardPublicationsJSON: `{"executive-sales":{}}`,
+		},
+		"state_visuals": {
+			ID: "state_visuals", WorkspaceID: "visuals", ProjectID: "leapview-showcase",
+			DashboardPublicationsJSON: `{"visual-showcase":{}}`,
+		},
+	}
+	var authorized []access.ObjectRef
+	err := authorizePublicationDeployment(t.Context(), "release-principal", "prod", []apiadapter.TargetRequest{
+		{Workspace: "sales", CandidateID: "state_sales"},
+		{Workspace: "visuals", CandidateID: "state_visuals"},
+	}, PublicationAuthorizationConfig{
+		States: states,
+		AuthorizeObject: func(_ context.Context, actor string, privilege access.Privilege, object access.ObjectRef) (bool, error) {
+			require.Equal(t, "release-principal", actor)
+			require.Equal(t, access.PrivilegeManagePublications, privilege)
+			authorized = append(authorized, object)
+			return true, nil
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []access.ObjectRef{access.ProjectEnvironmentObject("leapview-showcase", "prod")}, authorized)
+}
+
+func TestPublicationAuthorizationRejectsMixedProjects(t *testing.T) {
+	states := publicationStateStore{
+		"state_sales": {
+			ID: "state_sales", WorkspaceID: "sales", ProjectID: "leapview-showcase",
+			DashboardPublicationsJSON: `{"executive-sales":{}}`,
+		},
+		"state_other": {
+			ID: "state_other", WorkspaceID: "other", ProjectID: "other-project",
+			DashboardPublicationsJSON: `{"other":{}}`,
+		},
+	}
+	err := authorizePublicationDeployment(t.Context(), "release-principal", "prod", []apiadapter.TargetRequest{
+		{Workspace: "sales", CandidateID: "state_sales"},
+		{Workspace: "other", CandidateID: "state_other"},
+	}, PublicationAuthorizationConfig{
+		States: states,
+		AuthorizeObject: func(context.Context, string, access.Privilege, access.ObjectRef) (bool, error) {
+			t.Fatal("mixed-project deployment reached authorization")
+			return false, nil
+		},
+	})
+	require.ErrorContains(t, err, "multiple projects")
+}


### PR DESCRIPTION
## Summary
- authorize production publication activation at the project-environment boundary used by release grants
- reject mixed-project and mismatched-workspace activation targets before authorization
- cover the canonical multi-workspace deployment path and update the integration fixture

## Verification
- `task test:go:external`
- `task ci:pr`