### PR TITLE
feat: add shared read-only demo login

### DIFF
--- a/dashboards/workspaces/operations/access/demo-query-data.yaml
+++ b/dashboards/workspaces/operations/access/demo-query-data.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: operations
+  name: demo-query-data
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: QUERY_DATA

--- a/dashboards/workspaces/operations/access/demo-use-workspace.yaml
+++ b/dashboards/workspaces/operations/access/demo-use-workspace.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: operations
+  name: demo-use-workspace
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: USE_WORKSPACE

--- a/dashboards/workspaces/operations/access/demo-view-items.yaml
+++ b/dashboards/workspaces/operations/access/demo-view-items.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: operations
+  name: demo-view-items
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: VIEW_ITEM

--- a/dashboards/workspaces/sales/access/demo-query-data.yaml
+++ b/dashboards/workspaces/sales/access/demo-query-data.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: sales
+  name: demo-query-data
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: QUERY_DATA

--- a/dashboards/workspaces/sales/access/demo-use-workspace.yaml
+++ b/dashboards/workspaces/sales/access/demo-use-workspace.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: sales
+  name: demo-use-workspace
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: USE_WORKSPACE

--- a/dashboards/workspaces/sales/access/demo-view-items.yaml
+++ b/dashboards/workspaces/sales/access/demo-view-items.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: sales
+  name: demo-view-items
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: VIEW_ITEM

--- a/dashboards/workspaces/visuals/access/demo-query-data.yaml
+++ b/dashboards/workspaces/visuals/access/demo-query-data.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: visuals
+  name: demo-query-data
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: QUERY_DATA

--- a/dashboards/workspaces/visuals/access/demo-use-workspace.yaml
+++ b/dashboards/workspaces/visuals/access/demo-use-workspace.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: visuals
+  name: demo-use-workspace
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: USE_WORKSPACE

--- a/dashboards/workspaces/visuals/access/demo-view-items.yaml
+++ b/dashboards/workspaces/visuals/access/demo-view-items.yaml
@@ -1,0 +1,13 @@
+apiVersion: leapview.dev/v1
+kind: Grant
+metadata:
+  workspace: visuals
+  name: demo-view-items
+spec:
+  object:
+    type: workspace
+  subject:
+    kind: principal
+    email: demo@leapview.dev
+    displayName: LeapView Demo
+  privilege: VIEW_ITEM

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -53,6 +53,32 @@ because the project's workspaces do not exist until its exact candidate is
 activated. The subsequent authoring, ingestion, publication, approval, and
 activation calls remain protected by their project-environment grants.
 
+## Human access
+
+Human credentials are isolated from the deployment identity in the Infisical
+`prod:/demo/access` path. GitHub Actions must never import this path. It contains
+the private administrator recovery login and the deliberately shared product
+demo login:
+
+- `DEMO_ADMIN_EMAIL`
+- `DEMO_ADMIN_PASSWORD`
+- `DEMO_VIEWER_EMAIL`
+- `DEMO_VIEWER_PASSWORD`
+
+The shared principal is `demo@leapview.dev`. The project grants it only
+`USE_WORKSPACE`, `VIEW_ITEM`, and `QUERY_DATA` on the `sales`, `operations`, and
+`visuals` workspaces. Do not bind it to the built-in `viewer` role: that role
+also enables the agent and shared conversation history. The shared login must
+never receive administration, authoring, preview, refresh, deployment, token,
+or connection privileges.
+
+Treat the shared credential as public. To rotate it, reset the local password,
+revoke every existing session for the principal, complete the forced password
+change, and update `DEMO_VIEWER_PASSWORD` in Infisical. A password reset alone
+does not revoke an already-issued browser session. On a replacement instance,
+create the local shared principal before the first project deployment; the
+project deployment then reconciles its least-privilege grants.
+
 The checked-in `ssh-host-key.sha256` pins the server identity. The workflow
 adds only its current runner `/32` to SSH, then restores the complete prior
 firewall rule set on exit.

--- a/deploy/demo/deployment_test.go
+++ b/deploy/demo/deployment_test.go
@@ -45,6 +45,37 @@ func TestDemoUsesCanonicalOlistShowcase(t *testing.T) {
 	require.NotContains(t, project, "kind: quack")
 }
 
+func TestDemoSharedLoginIsDashboardOnly(t *testing.T) {
+	root := filepath.Join("..", "..")
+	compiled, err := projectcompiler.CompileProject(
+		filepath.Join(root, "dashboards", "leapview.yaml"),
+		projectcompiler.Options{ServingStateID: workspace.ServingStateID("hosted-demo-access-test")},
+	)
+	require.NoError(t, err)
+
+	for _, workspaceID := range []string{"operations", "sales", "visuals"} {
+		compiledWorkspace, ok := compiled.Workspace(workspaceID)
+		require.True(t, ok, "compiled demo workspace %q", workspaceID)
+
+		var privileges []string
+		for _, grant := range compiledWorkspace.Manifest().Access.Grants {
+			if grant.Subject.Email != "demo@leapview.dev" {
+				continue
+			}
+			require.Equal(t, "principal", grant.Subject.Kind)
+			require.Equal(t, "workspace", grant.Object.Type)
+			require.Empty(t, grant.Object.ID)
+			privileges = append(privileges, grant.Privilege)
+		}
+		require.ElementsMatch(t, []string{"USE_WORKSPACE", "VIEW_ITEM", "QUERY_DATA"}, privileges)
+
+		for _, binding := range compiledWorkspace.Manifest().Access.RoleBindings {
+			require.NotEqual(t, "demo@leapview.dev", binding.Subject.Email,
+				"shared demo login must not inherit a role that enables chat or mutations")
+		}
+	}
+}
+
 func TestDemoDeploymentIsAutomaticAndDigestPinned(t *testing.T) {
 	root := filepath.Join("..", "..")
 	workflow := read(t, filepath.Join(root, ".github", "workflows", "demo-deploy.yml"))
@@ -101,6 +132,26 @@ func TestDemoDeploymentIsAutomaticAndDigestPinned(t *testing.T) {
 	require.NotEqual(t, -1, configGeneration, "demo deployment must generate ignored config sources")
 	require.NotEqual(t, -1, olistBootstrap, "demo deployment must bootstrap Olist")
 	require.Less(t, configGeneration, olistBootstrap, "config generation must precede Olist compilation")
+}
+
+func TestDemoHumanCredentialsStayOutOfDeploymentAutomation(t *testing.T) {
+	root := filepath.Join("..", "..")
+	workflow := read(t, filepath.Join(root, ".github", "workflows", "demo-deploy.yml"))
+	require.NotContains(t, workflow, "/demo/access")
+	require.NotContains(t, workflow, "DEMO_ADMIN_PASSWORD")
+	require.NotContains(t, workflow, "DEMO_VIEWER_PASSWORD")
+
+	runbook := read(t, filepath.Join(root, "deploy", "demo", "README.md"))
+	for _, required := range []string{
+		"prod:/demo/access",
+		"DEMO_ADMIN_EMAIL",
+		"DEMO_ADMIN_PASSWORD",
+		"DEMO_VIEWER_EMAIL",
+		"DEMO_VIEWER_PASSWORD",
+		"revoke every existing session",
+	} {
+		require.Contains(t, runbook, required)
+	}
 }
 
 func TestDemoDeploymentRejectsMutableImagesBeforeChangingInfrastructure(t *testing.T) {


### PR DESCRIPTION
## Summary
- grant `demo@leapview.dev` only workspace use, dashboard visibility, and governed query access across the three Olist demo workspaces
- keep the shared principal outside the broader viewer role so it cannot use AI/chat or mutate content
- isolate human admin/viewer credentials in Infisical `prod:/demo/access`, which deployment automation does not import
- document rotation, session revocation, and replacement-instance recovery

## Validation
- `go test ./deploy/demo -count=1`
- `task ci:pr`

The local shared principal has been provisioned on the hosted demo; the normal post-merge project deployment will reconcile these grants.