### PR TITLE
Add settings administration UI and APIs

### DIFF
--- a/api/apigen.yaml
+++ b/api/apigen.yaml
@@ -16,6 +16,7 @@ targets:
           dir: ../internal/app/api/gen
           package: gen
           import_path: github.com/flidai/leapview/internal/app/api/gen
+          client_file: client.apigen.gen.go
         LeapViewAPI.Access:
           dir: ../internal/access/api/gen
           package: gen

--- a/api/signals/main.tsp
+++ b/api/signals/main.tsp
@@ -1,5 +1,8 @@
 import "@yacobolo/apigen";
 import "../visualization/main.tsp";
+import "./personal-settings.tsp";
+import "./product_settings.tsp";
+import "./settings.tsp";
 
 @apigen.`package`(#{
   title: "LeapView UI Signal Contracts",
@@ -62,17 +65,6 @@ model AdminMetricSignal {
 
 @apigen.contract(#{ kind: "ui-signal", tags: #["admin", "signal"] })
 @apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
-model AdminProfileSignal {
-  `displayName`: string;
-  `email`: string;
-  `id`: string;
-  `profilePictureUrl`?: string;
-  `title`: string;
-  `username`: string;
-}
-
-@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "signal"] })
-@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
 model AdminPublicationSignal {
   `workspaceId`: string;
   `name`: string;
@@ -102,31 +94,23 @@ model AdminPublicationCommand {
 @apigen.contract(#{ kind: "ui-signal", tags: #["admin", "signal"] })
 @apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
 model AdminDirectoryListItemSignal {
+  `avatarUrl`?: string;
   `email`: string;
   `groupCount`: int64;
   `href`: string;
   `id`: string;
   `joinedAt`: string;
-  `kind`: string;
+  `lastSeenAt`: string;
   `name`: string;
-  `role`: string;
   `status`: string;
   `username`: string;
 }
 
 @apigen.contract(#{ kind: "ui-signal", tags: #["admin", "signal"] })
 @apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
-model AdminDirectoryListGroupSignal {
-  `id`: string;
-  `items`: AdminDirectoryListItemSignal[];
-  `label`: string;
-}
-
-@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "signal"] })
-@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
 model AdminDirectoryListSignal {
   `filterLabel`: string;
-  `groups`: AdminDirectoryListGroupSignal[];
+  `items`: AdminDirectoryListItemSignal[];
   `searchPlaceholder`: string;
 }
 
@@ -157,7 +141,6 @@ model AdminPageSignal {
 	`listFilterOptions`?: string[];
 	`listQuery`?: string;
 	`metrics`?: AdminMetricSignal[];
-	`profile`?: AdminProfileSignal;
 	`publications`?: AdminPublicationSignal[];
   `sections`?: AdminContentSectionSignal[];
   `storage`?: AdminStorageSignal;
@@ -1542,6 +1525,10 @@ model SidebarSignal {
   `modelTitle`?: string;
   `pageTitle`: string;
   `primaryAction`?: SidebarActionSignal;
+  `productLogoUrl`?: string;
+  `productName`: string;
+  `userAvatarUrl`?: string;
+  `userName`?: string;
   `userRole`?: string;
   `workspaceTitle`: string;
 }

--- a/api/signals/personal-settings.tsp
+++ b/api/signals/personal-settings.tsp
@@ -1,0 +1,149 @@
+import "@yacobolo/apigen";
+
+namespace LeapViewUISignals;
+
+/** The authenticated user's personal settings surface. */
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalSettingsSignal {
+  `active`: string;
+  `profile`: PersonalProfileSignal;
+  `security`: PersonalSecuritySignal;
+  `tokens`: PersonalTokensSignal;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalProfileSignal {
+  `id`: string;
+  `email`: string;
+  `displayName`: string;
+  `theme`: string;
+  `avatarUrl`?: string;
+  `identitySource`: string;
+  `canEditDisplayName`: boolean;
+  `hasLocalPassword`: boolean;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalSecuritySignal {
+  `localPasswordEnabled`: boolean;
+  `sessions`: PersonalSessionSignal[];
+  `authoringSessions`: PersonalAuthoringSessionSignal[];
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalSessionSignal {
+  `id`: string;
+  `kind`: string;
+  `clientLabel`: string;
+  `current`: boolean;
+  `createdAt`: string;
+  `lastSeenAt`: string;
+  `expiresAt`: string;
+  `absoluteExpiresAt`: string;
+  `revokedAt`: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalAuthoringSessionSignal {
+  `id`: string;
+  `kind`: string;
+  `clientId`: string;
+  `targetId`: string;
+  `projectId`: string;
+  `privileges`: string[];
+  `createdAt`: string;
+  `lastUsedAt`: string;
+  `expiresAt`: string;
+  `revokedAt`: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalTokensSignal {
+  `items`: PersonalTokenSignal[];
+  `scopes`: PersonalTokenScopeSignal[];
+  `newToken`?: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalTokenScopeSignal {
+  `kind`: string;
+  `workspaceId`: string;
+  `label`: string;
+  `description`: string;
+  `privileges`: PersonalTokenPrivilegeSignal[];
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalTokenPrivilegeSignal {
+  `value`: string;
+  `label`: string;
+  `description`: string;
+  `category`: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "personal-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model PersonalTokenSignal {
+  `id`: string;
+  `name`: string;
+  `workspaceId`: string;
+  `privileges`: string[];
+  `createdAt`: string;
+  `lastUsedAt`: string;
+  `expiresAt`: string;
+  `revokedAt`: string;
+}
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "personal-settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model PersonalProfileCommand {
+  `action`: string;
+  `displayName`: string;
+}
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "personal-settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model PersonalThemeCommand {
+  `action`: string;
+  `theme`: string;
+}
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "personal-settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model PersonalPasswordCommand {
+  `currentPassword`: string;
+  `newPassword`: string;
+}
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "personal-settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model PersonalSessionCommand {
+  `action`: string;
+  `sessionId`: string;
+}
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "personal-settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model PersonalAuthoringSessionCommand {
+  `action`: string;
+  `sessionId`: string;
+}
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "personal-settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model PersonalTokenCommand {
+  `action`: string;
+  `tokenId`: string;
+  `name`: string;
+  `workspaceId`: string;
+  `privileges`: string[];
+  `expiresAt`: string;
+}

--- a/api/signals/product_settings.tsp
+++ b/api/signals/product_settings.tsp
@@ -1,0 +1,117 @@
+import "@yacobolo/apigen";
+
+/**
+ * Product/platform administration signals.  This contract intentionally lives
+ * beside (rather than inside) the shared admin envelope: platform settings are
+ * mounted by the admin shell as a typed signal subtree and can evolve without
+ * changing the workspace administration contract.
+ */
+namespace LeapViewUISignals;
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "product-settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model ProductSettingsSignal {
+  `active`: string;
+  `canManage`: boolean;
+  `general`: ProductGeneralSignal;
+  `authentication`: ProductAuthenticationSignal;
+  `api`: ProductAPIStatusSignal;
+  `system`: ProductSystemSignal;
+  `error`?: string;
+}
+
+model ProductGeneralSignal {
+  `displayName`: string;
+  `revision`: int64;
+  `updatedAt`: string;
+  `logo`?: ProductLogoSignal;
+  `instanceId`: string;
+  `canonicalOrigin`: string;
+  `environment`: string;
+}
+
+model ProductLogoSignal {
+  `url`: string;
+  `sha256`: string;
+  `mediaType`: string;
+  `sizeBytes`: int64;
+  `width`: int32;
+  `height`: int32;
+}
+
+model ProductAvailabilitySignal {
+  `available`: boolean;
+  `enabled`: boolean;
+}
+
+model ProductNamedAvailabilitySignal {
+  `available`: boolean;
+  `enabled`: boolean;
+  `provider`?: string;
+}
+
+model ProductAuthenticationSignal {
+  `browserEnabled`: boolean;
+  `apiTokenOnly`: boolean;
+  `local`: ProductAvailabilitySignal;
+  `oidc`: ProductNamedAvailabilitySignal;
+  `azure`: ProductAvailabilitySignal;
+  `scim`: ProductAvailabilitySignal;
+  `managedBy`: "deployment";
+}
+
+model ProductAPIStatusSignal {
+  `bearerCredentials`: ProductAvailabilitySignal;
+  `servicePrincipals`: ProductAvailabilitySignal;
+  `oauth`: ProductAvailabilitySignal;
+  `mcp`: ProductAvailabilitySignal;
+  `externalMcpIssuer`: boolean;
+}
+
+model ProductBuildSignal {
+  `version`: string;
+  `revision`: string;
+  `buildTime`: string;
+  `dirty`: boolean;
+  `development`: boolean;
+}
+
+model ProductAgentSignal {
+  `available`: boolean;
+  `configured`: boolean;
+  `provider`?: string;
+  `modelConfigured`: boolean;
+}
+
+model ProductLimitsSignal {
+  `queryResultMaxRows`: int32;
+  `queryResultMaxBytes`: int64;
+  `managedDataMaxFiles`: int32;
+  `managedDataMaxFileBytes`: int64;
+  `managedDataMaxRevisionBytes`: int64;
+}
+
+model ProductRuntimeSignal {
+  `health`: string;
+  `controlPlane`: string;
+  `environment`: string;
+}
+
+model ProductSystemSignal {
+  `instanceId`: string;
+  `canonicalOrigin`: string;
+  `environment`: string;
+  `build`: ProductBuildSignal;
+  `storageBackend`: string;
+  `agent`: ProductAgentSignal;
+  `limits`: ProductLimitsSignal;
+  `runtime`: ProductRuntimeSignal;
+}
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "product-settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model ProductSettingsCommand {
+  `action`: string;
+  `displayName`?: string;
+  `revision`: int64;
+}

--- a/api/signals/settings.tsp
+++ b/api/signals/settings.tsp
@@ -1,0 +1,110 @@
+// Settings surfaces are kept in a separate contract so they can evolve
+// independently from the shared admin page envelope. The admin stream may
+// embed these signals under `adminWorkspaces`, `adminServiceAccounts`, and
+// `adminAuditLog` without introducing ad-hoc browser fetches.
+import "@yacobolo/apigen";
+
+namespace LeapViewUISignals;
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model WorkspaceRegistrySignal {
+  `items`: WorkspaceRegistryItemSignal[];
+  `empty`?: string;
+  `loading`: boolean;
+  `error`?: string;
+  `nextCursor`?: string;
+  `hasMore`: boolean;
+}
+
+model WorkspaceRegistryItemSignal {
+  `id`: string;
+  `title`: string;
+  `description`?: string;
+  `href`: string;
+  `createdAt`?: string;
+  `updatedAt`?: string;
+  `owner`?: WorkspaceSubjectSignal;
+  `administrators`: WorkspaceSubjectSignal[];
+  `environment`?: string;
+  `activeServingStateId`?: string;
+  `servingStateStatus`?: string;
+  `servingStateSince`?: string;
+  `projectId`?: string;
+  `currentDeploymentId`?: string;
+  `deploymentStatus`?: string;
+  `deploymentSince`?: string;
+  `currentReleaseId`?: string;
+  `links`: WorkspaceLinksSignal;
+}
+
+model WorkspaceSubjectSignal {
+  `subjectType`: string;
+  `subjectId`: string;
+  `email`?: string;
+  `displayName`: string;
+  `role`?: string;
+}
+
+model WorkspaceLinksSignal {
+  `self`: string;
+  `workspace`: string;
+  `project`?: string;
+  `release`?: string;
+  `deployment`?: string;
+  `deployments`?: string;
+  `connections`?: string;
+  `publications`?: string;
+  `agent`?: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model ServiceAccountsSignal {
+  `items`: ServiceAccountSignal[];
+  `selectedId`?: string;
+  `secrets`?: ServiceAccountSecretSignal[];
+  `createdSecret`?: string;
+  `error`?: string;
+  `loading`: boolean;
+  `nextCursor`?: string;
+  `hasMore`: boolean;
+}
+
+model ServiceAccountSignal { `id`: string; `displayName`: string; `email`?: string; `kind`: string; `createdAt`?: string; `updatedAt`?: string; `disabledAt`?: string; }
+model ServiceAccountSecretSignal { `id`: string; `servicePrincipalId`: string; `name`: string; `expiresAt`?: string; `createdAt`?: string; `revokedAt`?: string; }
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["admin", "settings", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "admin" })
+model AuditLogSignal {
+  `items`: AuditEventSignal[];
+  `filters`: AuditLogFilters;
+  `nextCursor`?: string;
+  `hasMore`: boolean;
+  `loadedCount`: int32;
+  `loading`: boolean;
+  `error`?: string;
+}
+
+model AuditEventSignal { `id`: string; `workspaceId`?: string; `principalId`?: string; `action`: string; `targetType`: string; `targetId`: string; `privilege`?: string; `status`?: string; `requestId`?: string; `correlationId`?: string; `metadata`?: Record<unknown>; `createdAt`: string; }
+model AuditLogFilters { `workspaceId`?: string; `principalId`?: string; `action`?: string; `targetType`?: string; `targetId`?: string; `from`?: string; `to`?: string; }
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model ServiceAccountCommand {
+  `action`: string;
+  `accountId`?: string;
+  `secretId`?: string;
+  `displayName`?: string;
+  `secretName`?: string;
+  `expiresAt`?: string;
+}
+
+@apigen.contract(#{ kind: "ui-command", tags: #["admin", "settings", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "admin" })
+model AuditLogCommand {
+  `action`: string;
+  `filters`: AuditLogFilters;
+  `pageToken`?: string;
+  `limit`?: int32;
+}

--- a/api/typespec/access.tsp
+++ b/api/typespec/access.tsp
@@ -9,6 +9,7 @@ model PrincipalResponse {
   kind: string;
   email: string;
   displayName: string;
+  disabledAt?: utcDateTime;
   createdAt: utcDateTime;
   updatedAt: utcDateTime;
 }
@@ -430,6 +431,7 @@ model DeviceAuthorizationApprovalRequest {
 model AuthoringSessionResponse {
   id: string;
   kind: string;
+  current: boolean;
   clientId: string;
   targetId: string;
   projectId: string;
@@ -468,14 +470,14 @@ op decideDeviceAuthorization(@header("Idempotency-Key") idempotencyKey: Idempote
 interface CurrentAuthoringSessions {
   @summary("List current CLI and workload sessions")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+  @apigen.authz(#{ mode: "authenticated" })
   @operationId("listCurrentAuthoringSessions")
   listCurrentAuthoringSessions(@query limit?: ListLimit, @query pageToken?: PageToken): OkJson<AuthoringSessionListResponse> | CommonErrors;
 
   @summary("Revoke a current CLI or workload session")
   @route("/{session}")
   @delete
-  @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+  @apigen.authz(#{ mode: "authenticated" })
   @apigen.command(#{
     audit: #{ required: true, successAction: "authoring.session.revoked", guarantee: "transactional" },
     failures: #[
@@ -553,6 +555,7 @@ interface Principals {
     failures: #[
       #{ kind: "not_found", statusCode: 404, code: "PRINCIPAL_NOT_FOUND", publicDetail: "Principal not found." },
       #{ kind: "invalid", statusCode: 422, code: "PRINCIPAL_NOT_MUTABLE", publicDetail: "This principal cannot be deleted by this operation." },
+      #{ kind: "conflict", statusCode: 409, code: "PRINCIPAL_OWNS_OBJECTS", publicDetail: "Transfer owned objects before deleting this principal." },
     ],
   })
   @apigen.auditPayload(PrincipalDeletedAuditPayload)
@@ -573,6 +576,40 @@ interface Principals {
   @apigen.auditPayload(PrincipalPasswordResetAuditPayload)
   @operationId("resetPrincipalPassword")
   resetPrincipalPassword(@path principal: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): ResetPrincipalPasswordOK | CommonErrors;
+
+  @summary("Disable a principal and reject its credentials")
+  @route("/{principal}/disable")
+  @post
+  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+  @extension("x-leapview-object-scope", "grant-management")
+  @apigen.command(#{
+    audit: #{ required: true, successAction: "principal.disabled", guarantee: "transactional" },
+    failures: #[
+      #{ kind: "not_found", statusCode: 404, code: "PRINCIPAL_NOT_FOUND", publicDetail: "Principal not found." },
+      #{ kind: "invalid", statusCode: 422, code: "PRINCIPAL_NOT_MUTABLE", publicDetail: "This principal cannot be disabled by this operation." },
+    ],
+    targetParameter: "principal",
+  })
+  @apigen.auditPayload(PrincipalUpdatedAuditPayload)
+  @operationId("disablePrincipal")
+  disablePrincipal(@path principal: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<PrincipalResponse> | CommonErrors;
+
+  @summary("Re-enable a disabled principal")
+  @route("/{principal}/enable")
+  @post
+  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+  @extension("x-leapview-object-scope", "grant-management")
+  @apigen.command(#{
+    audit: #{ required: true, successAction: "principal.enabled", guarantee: "transactional" },
+    failures: #[
+      #{ kind: "not_found", statusCode: 404, code: "PRINCIPAL_NOT_FOUND", publicDetail: "Principal not found." },
+      #{ kind: "invalid", statusCode: 422, code: "PRINCIPAL_NOT_MUTABLE", publicDetail: "This principal cannot be enabled by this operation." },
+    ],
+    targetParameter: "principal",
+  })
+  @apigen.auditPayload(PrincipalUpdatedAuditPayload)
+  @operationId("enablePrincipal")
+  enablePrincipal(@path principal: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<PrincipalResponse> | CommonErrors;
 
   @summary("List a principal's sessions")
   @route("/{principal}/sessions")
@@ -641,6 +678,7 @@ interface ServicePrincipals {
     audit: #{ required: true, successAction: "service_principal.updated", guarantee: "transactional" },
     failures: #[
       #{ kind: "not_found", statusCode: 404, code: "SERVICE_PRINCIPAL_NOT_FOUND", publicDetail: "Service principal not found." },
+      #{ kind: "conflict", statusCode: 409, code: "SERVICE_PRINCIPAL_OWNS_OBJECTS", publicDetail: "Transfer owned objects before deleting this service principal." },
     ],
   })
   @apigen.auditPayload(ServicePrincipalAuditPayload)

--- a/api/typespec/audit.tsp
+++ b/api/typespec/audit.tsp
@@ -6,7 +6,7 @@ namespace LeapViewAPI.Access;
 
 model AuditEventResponse {
   id: string;
-  workspaceId: string;
+  workspaceId?: string;
   principalId?: string;
   action: string;
   targetType: string;
@@ -33,3 +33,12 @@ alias ListAuditEventsOK = OkJson<AuditEventListResponse>;
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
 @operationId("listAuditEvents")
 op listAuditEvents(@path workspace: string, @query actor?: string, @query action?: string, @query targetType?: string, @query targetId?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListAuditEventsOK | CommonErrors;
+
+@tag("Audit")
+@summary("List product audit events")
+@route("/audit-events")
+@get
+@apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
+@extension("x-leapview-object-scope", "platform")
+@operationId("listPlatformAuditEvents")
+op listPlatformAuditEvents(@query workspace?: string, @query actor?: string, @query action?: string, @query targetType?: string, @query targetId?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListAuditEventsOK | CommonErrors;

--- a/api/typespec/current_user.tsp
+++ b/api/typespec/current_user.tsp
@@ -12,6 +12,7 @@ model EffectivePrivilegesResponse {
 model APITokenCreateRequest {
   name: string;
   workspaceId?: string;
+  @doc("Omit to keep the token dynamically constrained by the principal's effective privileges at request time. An explicit list must be a subset of the principal's current effective privileges.")
   privileges?: string[];
   expiresAt?: utcDateTime;
 }
@@ -20,7 +21,8 @@ model APITokenResponse {
   id: string;
   name: string;
   workspaceId?: string;
-  privileges: string[];
+  @doc("Present when the token has an explicit privilege allowlist. When omitted, the principal's effective privileges are evaluated dynamically at request time.")
+  privileges?: string[];
   expiresAt?: utcDateTime;
   revokedAt?: utcDateTime;
   createdAt: utcDateTime;
@@ -45,6 +47,7 @@ enum SessionKind {
 model SessionResponse {
   id: string;
   kind: SessionKind;
+  current: boolean;
   instanceId?: string;
   profileId?: string;
   clientId?: string;
@@ -60,16 +63,136 @@ model SessionListResponse {
   page: PageInfo;
 }
 
-alias GetCurrentPrincipalOK = OkJson<PrincipalResponse>;
+model AvatarResponse {
+  principalId: string;
+  sha256: string;
+  mediaType: "image/png";
+  sizeBytes: int64;
+  width: int32;
+  height: int32;
+  updatedAt: utcDateTime;
+  url: string;
+}
+
+model AvatarImageResponse {
+  ...OkResponse;
+  @header contentType: "image/png";
+  @header etag: string;
+  @header cacheControl: string;
+  @header contentLength: int64;
+  @body body: bytes;
+}
+
+enum IdentityManagementSource {
+  local: "local",
+  external: "external",
+  system: "system",
+}
+
+model IdentityManagementResponse {
+  source: IdentityManagementSource;
+  provider?: string;
+}
+
+model CurrentPrincipalCapabilities {
+  canUpdateDisplayName: boolean;
+  canChangePassword: boolean;
+  canManageAvatar: boolean;
+  canManageSessions: boolean;
+  canManageAuthoringSessions: boolean;
+  canManageApiTokens: boolean;
+}
+
+model CurrentPrincipalResponse {
+  ...PrincipalResponse;
+  identityManagement: IdentityManagementResponse;
+  capabilities: CurrentPrincipalCapabilities;
+  avatar?: AvatarResponse;
+}
+
+model CurrentPrincipalPatchRequest {
+  displayName?: string;
+}
+
+model CurrentPasswordChangeRequest {
+  currentPassword: string;
+  newPassword: string;
+}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model CurrentPrincipalUpdatedAuditPayload {
+  @apigen.auditPii
+  email: string;
+  @apigen.auditPii
+  displayName: string;
+}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model CurrentPasswordChangedAuditPayload {
+  @apigen.auditPii
+  email: string;
+  @apigen.auditPublic
+  provider: string;
+}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model CurrentAvatarUploadedAuditPayload {
+  @apigen.auditInternal
+  principalId: string;
+  @apigen.auditInternal
+  sha256: string;
+}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model CurrentAvatarDeletedAuditPayload {
+  @apigen.auditInternal
+  principalId: string;
+}
+
+alias GetCurrentPrincipalOK = OkJson<CurrentPrincipalResponse>;
 
 @tag("Current User")
 @summary("Get current principal")
 @route("/me")
 @get
-@apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+@apigen.authz(#{ mode: "authenticated" })
 @extension("x-leapview-object-scope", "principal")
 @operationId("getCurrentPrincipal")
 op getCurrentPrincipal(): GetCurrentPrincipalOK | CommonErrors;
+
+alias UpdateCurrentPrincipalOK = OkJson<CurrentPrincipalResponse>;
+
+@tag("Current User")
+@summary("Update the current principal's self-managed profile fields")
+@route("/me")
+@patch
+@apigen.authz(#{ mode: "authenticated" })
+@extension("x-leapview-object-scope", "principal")
+@apigen.command(#{
+    audit: #{ required: true, successAction: "principal.profile.updated", guarantee: "transactional" },
+    failures: #[
+      #{ kind: "invalid", statusCode: 422, code: "PRINCIPAL_PROFILE_NOT_MUTABLE", publicDetail: "The current principal profile cannot be modified." },
+    ],
+})
+@apigen.auditPayload(CurrentPrincipalUpdatedAuditPayload)
+@operationId("updateCurrentPrincipal")
+op updateCurrentPrincipal(@header("If-Match") ifMatch: string, @body body: CurrentPrincipalPatchRequest): UpdateCurrentPrincipalOK | CommonErrors;
+
+@tag("Current User")
+@summary("Change the current principal's local password")
+@route("/me/password")
+@post
+@apigen.authz(#{ mode: "authenticated" })
+@extension("x-leapview-object-scope", "principal")
+@apigen.command(#{
+    audit: #{ required: true, successAction: "password.changed", guarantee: "transactional" },
+    failures: #[
+      #{ kind: "invalid", statusCode: 400, code: "PASSWORD_CHANGE_INVALID", publicDetail: "The password change request is invalid." },
+    ],
+})
+@apigen.auditPayload(CurrentPasswordChangedAuditPayload)
+@operationId("changeCurrentPassword")
+op changeCurrentPassword(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: CurrentPasswordChangeRequest): EmptyResponse | CommonErrors;
 
 alias ListCurrentAPITokensOK = OkJson<APITokenListResponse>;
 alias CreateCurrentAPITokenCreated = CreatedJson<APITokenCreateResponse>;
@@ -79,14 +202,14 @@ alias CreateCurrentAPITokenCreated = CreatedJson<APITokenCreateResponse>;
 interface CurrentAPITokens {
   @summary("List current API tokens")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+  @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "principal")
   @operationId("listCurrentAPITokens")
   listCurrentAPITokens(@query limit?: ListLimit, @query pageToken?: PageToken): ListCurrentAPITokensOK | CommonErrors;
 
   @summary("Create current API token")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+  @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "principal")
   @apigen.command(#{
     audit: #{ required: true, successAction: "api_token.created", guarantee: "transactional" },
@@ -101,7 +224,7 @@ interface CurrentAPITokens {
   @summary("Revoke current API token")
   @route("/{token}")
   @delete
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+  @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "principal")
   @apigen.command(#{
     audit: #{ required: true, successAction: "api_token.revoked", guarantee: "transactional" },
@@ -132,7 +255,7 @@ alias ListCurrentSessionsOK = OkJson<SessionListResponse>;
 interface CurrentSessions {
   @summary("List current sessions")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+  @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "principal")
   @operationId("listCurrentSessions")
   listCurrentSessions(@query limit?: ListLimit, @query pageToken?: PageToken): ListCurrentSessionsOK | CommonErrors;
@@ -140,7 +263,7 @@ interface CurrentSessions {
   @summary("Revoke current session")
   @route("/{session}")
   @delete
-  @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+  @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "principal")
   @apigen.command(#{
     audit: #{ required: true, successAction: "session.revoked", guarantee: "transactional" },
@@ -152,3 +275,45 @@ interface CurrentSessions {
   @operationId("revokeCurrentSession")
   revokeCurrentSession(@path session: string): EmptyResponse | CommonErrors;
 }
+
+@tag("Current User")
+@summary("Upload and normalize the current user's avatar")
+@route("/me/avatar")
+@put
+@apigen.authz(#{ mode: "authenticated" })
+@extension("x-leapview-object-scope", "principal")
+@apigen.command(#{
+    audit: #{ required: true, successAction: "principal.avatar.updated", guarantee: "best-effort" },
+    failures: #[
+      #{ kind: "invalid", statusCode: 422, code: "INVALID_AVATAR_IMAGE", publicDetail: "The avatar image is invalid." },
+      #{ kind: "unsupported_media_type", statusCode: 415, code: "UNSUPPORTED_AVATAR_MEDIA_TYPE", publicDetail: "The avatar media type is unsupported." },
+    ],
+})
+@apigen.auditPayload(CurrentAvatarUploadedAuditPayload)
+@operationId("uploadCurrentAvatar")
+op uploadCurrentAvatar(@header contentType: string, @body body: bytes): OkJson<AvatarResponse> | CommonErrors;
+
+@tag("Current User")
+@summary("Delete the current user's avatar")
+@route("/me/avatar")
+@delete
+@apigen.authz(#{ mode: "authenticated" })
+@extension("x-leapview-object-scope", "principal")
+@apigen.command(#{
+    audit: #{ required: true, successAction: "principal.avatar.deleted", guarantee: "best-effort" },
+    failures: #[
+      #{ kind: "not_found", statusCode: 404, code: "AVATAR_NOT_FOUND", publicDetail: "The current principal has no avatar." },
+    ],
+})
+@apigen.auditPayload(CurrentAvatarDeletedAuditPayload)
+@operationId("deleteCurrentAvatar")
+op deleteCurrentAvatar(): EmptyResponse | CommonErrors;
+
+@tag("Current User")
+@summary("Read a content-addressed principal avatar")
+@route("/principals/{principal}/avatar/{digest}")
+@get
+@apigen.authz(#{ mode: "authenticated" })
+@extension("x-leapview-object-scope", "principal")
+@operationId("getPrincipalAvatar")
+op getPrincipalAvatar(@path principal: string, @path digest: string): AvatarImageResponse | CommonErrors;

--- a/api/typespec/instance.tsp
+++ b/api/typespec/instance.tsp
@@ -11,6 +11,98 @@ model InstanceResponse {
   environment: string;
 }
 
+model ProductLogoResponse {
+  url: string;
+  sha256: string;
+  mediaType: string;
+  sizeBytes: int64;
+  width: int32;
+  height: int32;
+}
+
+model ProductSettingsResponse {
+  displayName: string;
+  logo?: ProductLogoResponse;
+  updatedAt: utcDateTime;
+}
+
+model ProductSettingsPatchRequest { displayName: string; }
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model ProductIdentityUpdatedAuditPayload {
+  @apigen.auditPublic
+  fields: string[];
+}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model ProductLogoUpdatedAuditPayload {
+  @apigen.auditInternal
+  sha256: string;
+}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model ProductLogoDeletedAuditPayload {
+  @apigen.auditPublic
+  removed: boolean;
+}
+
+model ProductSettingsOK {
+  ...OkResponse;
+  @header etag: string;
+  ...Body<ProductSettingsResponse>;
+}
+
+model ProductLogoImageResponse {
+  ...OkResponse;
+  @header contentType: string;
+  @header etag: string;
+  @header cacheControl: string;
+  @header contentLength: int64;
+  @body body: bytes;
+}
+
+model ProductAvailabilityResponse { available: boolean; enabled: boolean; }
+model ProductNamedAvailabilityResponse { available: boolean; enabled: boolean; provider?: string; }
+
+model ProductAuthenticationStatusResponse {
+  browserEnabled: boolean;
+  apiTokenOnly: boolean;
+  local: ProductAvailabilityResponse;
+  oidc: ProductNamedAvailabilityResponse;
+  azure: ProductAvailabilityResponse;
+  scim: ProductAvailabilityResponse;
+  managedBy: "deployment";
+}
+
+model ProductAPIStatusResponse {
+  bearerCredentials: ProductAvailabilityResponse;
+  servicePrincipals: ProductAvailabilityResponse;
+  oauth: ProductAvailabilityResponse;
+  mcp: ProductAvailabilityResponse;
+  externalMcpIssuer: boolean;
+}
+
+model ProductAgentStatusResponse { available: boolean; configured: boolean; provider?: string; modelConfigured: boolean; }
+model ProductLimitsResponse {
+  queryResultMaxRows: int32;
+  queryResultMaxBytes: int64;
+  managedDataMaxFiles: int32;
+  managedDataMaxFileBytes: int64;
+  managedDataMaxRevisionBytes: int64;
+}
+model ProductBuildResponse { version: string; revision: string; buildTime: string; dirty: boolean; development: boolean; }
+
+model ProductSystemStatusResponse {
+  instanceId: string;
+  canonicalOrigin: string;
+  environment: string;
+  build: ProductBuildResponse;
+  controlPlane: string;
+  storageBackend: string;
+  agent: ProductAgentStatusResponse;
+  limits: ProductLimitsResponse;
+}
+
 alias PublicInstanceErrors = BadRequest | RateLimited | InternalServerError | ServiceUnavailable;
 
 @tag("Instance")
@@ -20,3 +112,106 @@ alias PublicInstanceErrors = BadRequest | RateLimited | InternalServerError | Se
 @apigen.authz(#{ mode: "none" })
 @operationId("getInstance")
 op getInstance(): OkJson<InstanceResponse> | PublicInstanceErrors;
+
+@tag("Instance")
+@summary("Get mutable product identity")
+@route("/instance/settings")
+@get
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@apigen.manual
+@extension("x-leapview-object-scope", "platform")
+@operationId("getProductSettings")
+op getProductSettings(): ProductSettingsOK | CommonErrors;
+
+@tag("Instance")
+@summary("Update mutable product identity")
+@route("/instance/settings")
+@patch
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@apigen.manual
+@apigen.command(#{
+  audit: #{ required: true, successAction: "product.identity.updated", guarantee: "transactional" },
+  failures: #[
+    #{ kind: "invalid", statusCode: 422, code: "INVALID_PRODUCT_IDENTITY", publicDetail: "The product identity is invalid." },
+    #{ kind: "precondition", statusCode: 412, code: "PRODUCT_IDENTITY_PRECONDITION_FAILED", publicDetail: "The product identity changed before this request was applied." },
+  ],
+})
+@apigen.auditPayload(ProductIdentityUpdatedAuditPayload)
+@extension("x-leapview-object-scope", "platform")
+@operationId("updateProductSettings")
+op updateProductSettings(@header("If-Match") ifMatch: string, @body body: ProductSettingsPatchRequest): ProductSettingsOK | CommonErrors;
+
+@tag("Instance")
+@summary("Upload the product logo")
+@route("/instance/logo")
+@put
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@apigen.manual
+@apigen.command(#{
+  audit: #{ required: true, successAction: "product.logo.updated", guarantee: "transactional" },
+  failures: #[
+    #{ kind: "invalid", statusCode: 422, code: "INVALID_PRODUCT_LOGO", publicDetail: "The product logo is invalid." },
+    #{ kind: "precondition", statusCode: 412, code: "PRODUCT_IDENTITY_PRECONDITION_FAILED", publicDetail: "The product identity changed before this request was applied." },
+  ],
+})
+@apigen.auditPayload(ProductLogoUpdatedAuditPayload)
+@extension("x-leapview-object-scope", "platform")
+@operationId("uploadProductLogo")
+op uploadProductLogo(@header("If-Match") ifMatch: string, @header contentType: string, @body body: bytes): ProductSettingsOK | CommonErrors;
+
+@tag("Instance")
+@summary("Remove the product logo")
+@route("/instance/logo")
+@delete
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@apigen.manual
+@apigen.command(#{
+  audit: #{ required: true, successAction: "product.logo.deleted", guarantee: "transactional" },
+  failures: #[
+    #{ kind: "precondition", statusCode: 412, code: "PRODUCT_IDENTITY_PRECONDITION_FAILED", publicDetail: "The product identity changed before this request was applied." },
+  ],
+})
+@apigen.auditPayload(ProductLogoDeletedAuditPayload)
+@extension("x-leapview-object-scope", "platform")
+@operationId("deleteProductLogo")
+op deleteProductLogo(@header("If-Match") ifMatch: string): ProductSettingsOK | CommonErrors;
+
+@tag("Instance")
+@summary("Read an immutable product logo")
+@route("/instance/logo/{digest}")
+@get
+@apigen.authz(#{ mode: "authenticated" })
+@apigen.manual
+@extension("x-leapview-object-scope", "platform")
+@operationId("getProductLogo")
+op getProductLogo(@path digest: string): ProductLogoImageResponse | CommonErrors;
+
+@tag("Instance")
+@summary("Get redacted authentication configuration status")
+@route("/instance/authentication")
+@get
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@apigen.manual
+@extension("x-leapview-object-scope", "platform")
+@operationId("getProductAuthenticationStatus")
+op getProductAuthenticationStatus(): OkJson<ProductAuthenticationStatusResponse> | CommonErrors;
+
+@tag("Instance")
+@summary("Get redacted system status")
+@route("/instance/system")
+@get
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@apigen.manual
+@extension("x-leapview-object-scope", "platform")
+@operationId("getProductSystemStatus")
+op getProductSystemStatus(): OkJson<ProductSystemStatusResponse> | CommonErrors;
+
+@tag("Instance")
+@summary("Get safe API and protocol availability")
+@route("/instance/api-status")
+@get
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
+@apigen.manual
+@extension("x-leapview-object-scope", "platform")
+@operationId("getProductAPIStatus")
+op getProductAPIStatus(): OkJson<ProductAPIStatusResponse> | CommonErrors;

--- a/api/typespec/workspaces.tsp
+++ b/api/typespec/workspaces.tsp
@@ -18,6 +18,63 @@ model WorkspaceListResponse {
   page: PageInfo;
 }
 
+model WorkspaceAdministrationSubjectResponse {
+  subjectType: string;
+  subjectId: string;
+  email?: string;
+  displayName: string;
+  role?: string;
+}
+
+model WorkspaceAdministrationRuntimeResponse {
+  environment: string;
+  activeServingStateId?: string;
+  activeServingStateStatus?: string;
+  activeServingStateSince?: utcDateTime;
+  projectId?: string;
+  currentDeploymentId?: string;
+  currentDeploymentStatus?: string;
+  currentDeploymentSince?: utcDateTime;
+  currentReleaseId?: string;
+}
+
+model WorkspaceAdministrationCapabilitiesResponse {
+  manageWorkspace: boolean;
+  manageAccess: boolean;
+  managePublications: boolean;
+  manageConnections: boolean;
+  viewManagedData: boolean;
+  ingestManagedData: boolean;
+  publishReleases: boolean;
+  requestDeployments: boolean;
+  viewDeployments: boolean;
+  useAgent: boolean;
+  viewAgent: boolean;
+}
+
+model WorkspaceAdministrationLinksResponse {
+  self: string;
+  workspace: string;
+  groups?: string;
+  roles?: string;
+  roleBindings?: string;
+  grants?: string;
+  publications?: string;
+  managedConnections?: string;
+  releases?: string;
+  deployments?: string;
+  agentConversations?: string;
+}
+
+model WorkspaceAdministrationResponse {
+  workspace: WorkspaceResponse;
+  owner?: WorkspaceAdministrationSubjectResponse;
+  administrators: WorkspaceAdministrationSubjectResponse[];
+  runtime: WorkspaceAdministrationRuntimeResponse;
+  capabilities: WorkspaceAdministrationCapabilitiesResponse;
+  links: WorkspaceAdministrationLinksResponse;
+}
+
 model AssetResponse {
   id: string;
   snapshotId: string;
@@ -114,6 +171,14 @@ op listWorkspaces(@query limit?: ListLimit, @query pageToken?: PageToken): ListW
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @operationId("getWorkspace")
 op getWorkspace(@path workspace: string): OkJson<WorkspaceResponse> | CommonErrors;
+
+@tag("Workspaces")
+@summary("Get the workspace administration overview")
+@route("/workspaces/{workspace}/administration")
+@get
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_WORKSPACE" })
+@operationId("getWorkspaceAdministration")
+op getWorkspaceAdministration(@path workspace: string): OkJson<WorkspaceAdministrationResponse> | CommonErrors;
 
 alias ListWorkspaceAssetEdgesOK = OkJson<AssetEdgeListResponse>;
 

--- a/design-qa.md
+++ b/design-qa.md
@@ -89,3 +89,54 @@ The requested follow-up removes the parent card around the entire section. The h
 - [x] No actionable P0/P1/P2 differences remain.
 
 final result: passed
+---
+
+# Personal API token design QA
+
+## Comparison target
+
+- Source visual truth: `/home/codex/.codex/attachments/a3cf84e3-0799-47fa-a22b-0db340ec39e4/codex-clipboard-df1232fa-df9c-463c-bada-d4935712edb5.png`
+- Browser-rendered implementation: `/home/codex/.codex/worktrees/e397/leapview/.tmp/design-qa/api-tokens-page-final.png`
+- Focused implementation region: `/home/codex/.codex/worktrees/e397/leapview/.tmp/design-qa/api-token-focused-final.png`
+- Mobile implementation: `/home/codex/.codex/worktrees/e397/leapview/.tmp/design-qa/api-tokens-mobile-final.png`
+- Side-by-side evidence: `/home/codex/.codex/worktrees/e397/leapview/.tmp/design-qa/api-token-comparison-normalized-final.png`
+- State: dark theme, workspace scope selected, permission picker open.
+
+## Capture normalization
+
+- Source pixels: 1594 × 810.
+- Desktop browser viewport and screenshot: 1440 × 1000 CSS pixels at device scale factor 1.
+- Focused implementation crop: 640 × 800 pixels at device scale factor 1.
+- Mobile browser viewport and screenshot: 390 × 844 CSS pixels at device scale factor 1.
+- The source is a wide GitHub permission panel, while LeapView intentionally preserves its established 640-pixel settings column. The comparison therefore normalizes the interaction region rather than forcing GitHub's full-page width onto LeapView.
+
+## Evidence review
+
+- Full view: the LeapView settings hierarchy remains centered and compact, with token basics, resource access, permissions, and existing credentials in a clear sequence. The open picker stays within the desktop viewport and does not expand the document.
+- Focused region: the implementation matches the source pattern of an explicit permission count, an Add permissions trigger, a searchable floating picker, grouped native checkboxes, and concise permission descriptions.
+- Typography: all settings and permission labels resolve to the required 14px Primer-backed type recipe. Weight, line height, and muted supporting text preserve the existing LeapView hierarchy.
+- Spacing and layout: Primer base-size tokens provide consistent 6/8/12/16/20px rhythm, compact control sizing, panel borders, and restrained radii. The narrower LeapView column is an intentional product constraint.
+- Colors and tokens: surfaces, borders, focus, foregrounds, backdrop, and accent states use LeapView aliases backed by Primer primitives; no new raw colors were introduced.
+- Images and icons: the reference contains no product imagery. Add, search, remove, and close actions use the application's existing icon system rather than simulated assets.
+- Copy and content: repository-specific wording was translated to LeapView's workspace and product scopes. Permission names and descriptions are server-owned and reflect the capabilities the signed-in user may delegate.
+- Primary interactions tested: choose scope, search permissions, select and remove permissions, create typed command payload, Escape dismissal with focus return, outside-pointer dismissal, mobile close action, and mobile viewport containment.
+- Browser console errors: none during the final desktop capture.
+
+## Comparison history
+
+1. Initial mobile capture found a P2 dismissal issue: the nearly full-height picker relied on tapping a narrow outside margin or using a keyboard Escape key.
+2. The picker gained a visible close action and a Primer-backed modal backdrop on compact viewports. The revised 390 × 844 capture shows the close control, bounded panel, background separation, and no horizontal overflow.
+3. Final desktop and mobile comparison found no remaining P0, P1, or P2 issues.
+4. An in-app browser annotation on 2026-08-12 exposed a P2 desktop overflow issue: implicit grid rows let a long permission list retain its content height, while the panel maximum did not account for its actual vertical position. The panel now uses `auto minmax(0, 1fr)` rows, calculates the available height below its trigger, keeps a 16px viewport gap, and confines scrolling to the permission list. A browser DOM regression at 1440 × 700 with 13 permissions verifies the panel remains inside the viewport, the list has `scrollHeight > clientHeight`, and computed vertical overflow is `auto`.
+
+## Findings
+
+No actionable P0, P1, or P2 visual differences remain. The implementation follows the GitHub interaction model while retaining LeapView's narrower settings layout and Primer visual language.
+
+## Follow-up polish
+
+- P3: a future iteration could replace the native datetime-local field with predefined expiration choices, but this is outside the workspace-and-permissions problem addressed here.
+
+Typography, tokens, icons, and copy are unchanged by the viewport-containment fix. Mobile retains its fixed, viewport-bounded sheet behavior.
+
+final result: passed

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3672,6 +3672,346 @@ paths:
       x-authz:
         mode: privilege
         privilege: VIEW_AGENT
+  /api/v1/audit-events:
+    get:
+      operationId: listPlatformAuditEvents
+      summary: List product audit events
+      parameters:
+        - name: workspace
+          in: query
+          required: false
+          schema:
+            type: string
+          example: example
+          explode: false
+        - name: actor
+          in: query
+          required: false
+          schema:
+            type: string
+          example: example
+          explode: false
+        - name: action
+          in: query
+          required: false
+          schema:
+            type: string
+          example: example
+          explode: false
+        - name: targetType
+          in: query
+          required: false
+          schema:
+            type: string
+          example: example
+          explode: false
+        - name: targetId
+          in: query
+          required: false
+          schema:
+            type: string
+          example: example
+          explode: false
+        - name: from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          example: "2026-01-02T15:04:05Z"
+          explode: false
+        - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          example: "2026-01-02T15:04:05Z"
+          explode: false
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: !!float 1
+            maximum: !!float 200
+          example: 1
+          explode: false
+        - name: pageToken
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 2048
+          example: example
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditEventListResponse'
+              example:
+                items:
+                  - action: example
+                    correlationId: example
+                    createdAt: "2026-01-02T15:04:05Z"
+                    id: example
+                    metadata:
+                      key: example
+                    principalId: example
+                    requestId: example
+                    status: example
+                    targetId: example
+                    targetType: example
+                    workspaceId: example
+                    privilege: example
+                page:
+                  nextCursor: example
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Audit
+      x-apigen-operation-kind: query
+      x-authz:
+        mode: privilege
+        privilege: VIEW_AUDIT
+      x-leapview-object-scope: platform
   /api/v1/capabilities:
     get:
       operationId: getCapabilities
@@ -4054,6 +4394,2283 @@ paths:
       x-apigen-operation-kind: query
       x-authz:
         mode: none
+  /api/v1/instance/api-status:
+    get:
+      operationId: getProductAPIStatus
+      summary: Get safe API and protocol availability
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductAPIStatusResponse'
+              example:
+                bearerCredentials:
+                  available: true
+                  enabled: true
+                externalMcpIssuer: true
+                mcp:
+                  available: true
+                  enabled: true
+                oauth:
+                  available: true
+                  enabled: true
+                servicePrincipals:
+                  available: true
+                  enabled: true
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Instance
+      x-apigen-operation-kind: query
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_PLATFORM
+      x-leapview-object-scope: platform
+      x-apigen-manual: true
+  /api/v1/instance/authentication:
+    get:
+      operationId: getProductAuthenticationStatus
+      summary: Get redacted authentication configuration status
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductAuthenticationStatusResponse'
+              example:
+                apiTokenOnly: true
+                azure:
+                  available: true
+                  enabled: true
+                browserEnabled: true
+                local:
+                  available: true
+                  enabled: true
+                managedBy: example
+                oidc:
+                  available: true
+                  enabled: true
+                  provider: example
+                scim:
+                  available: true
+                  enabled: true
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Instance
+      x-apigen-operation-kind: query
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_PLATFORM
+      x-leapview-object-scope: platform
+      x-apigen-manual: true
+  /api/v1/instance/logo:
+    delete:
+      operationId: deleteProductLogo
+      summary: Remove the product logo
+      parameters:
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          headers:
+            etag:
+              required: true
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductSettingsResponse'
+              example:
+                displayName: example
+                logo:
+                  height: 1
+                  mediaType: example
+                  sha256: example
+                  sizeBytes: 1
+                  url: example
+                  width: 1
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Instance
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: removed
+                sensitivity: public
+            retention: security
+            schema:
+              ref: ProductLogoDeletedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: product.logo.deleted
+        authz_mode: privilege
+        concurrency: if-match
+        failures:
+          - code: PRODUCT_IDENTITY_PRECONDITION_FAILED
+            kind: precondition
+            public_detail: The product identity changed before this request was applied.
+            status_code: !!float 412
+        owner: LeapViewAPI
+        privilege: MANAGE_PLATFORM
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_PLATFORM
+      x-leapview-object-scope: platform
+      x-apigen-manual: true
+    put:
+      operationId: uploadProductLogo
+      summary: Upload the product logo
+      parameters:
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: Content-Type
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          headers:
+            etag:
+              required: true
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductSettingsResponse'
+              example:
+                displayName: example
+                logo:
+                  height: 1
+                  mediaType: example
+                  sha256: example
+                  sizeBytes: 1
+                  url: example
+                  width: 1
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Instance
+      requestBody:
+        required: true
+        content:
+          '*/*':
+            schema:
+              type: string
+              format: binary
+            example: example
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: sha256
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: ProductLogoUpdatedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: product.logo.updated
+        authz_mode: privilege
+        concurrency: if-match
+        failures:
+          - code: INVALID_PRODUCT_LOGO
+            kind: invalid
+            public_detail: The product logo is invalid.
+            status_code: !!float 422
+          - code: PRODUCT_IDENTITY_PRECONDITION_FAILED
+            kind: precondition
+            public_detail: The product identity changed before this request was applied.
+            status_code: !!float 412
+        owner: LeapViewAPI
+        privilege: MANAGE_PLATFORM
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_PLATFORM
+      x-leapview-object-scope: platform
+      x-apigen-manual: true
+  /api/v1/instance/logo/{digest}:
+    get:
+      operationId: getProductLogo
+      summary: Read an immutable product logo
+      parameters:
+        - name: digest
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          headers:
+            cache-control:
+              required: true
+              schema:
+                type: string
+            content-length:
+              required: true
+              schema:
+                type: integer
+                format: int64
+            etag:
+              required: true
+              schema:
+                type: string
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: binary
+              example: example
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Instance
+      x-apigen-operation-kind: query
+      x-leapview-object-scope: platform
+      x-apigen-manual: true
+  /api/v1/instance/settings:
+    get:
+      operationId: getProductSettings
+      summary: Get mutable product identity
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          headers:
+            etag:
+              required: true
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductSettingsResponse'
+              example:
+                displayName: example
+                logo:
+                  height: 1
+                  mediaType: example
+                  sha256: example
+                  sizeBytes: 1
+                  url: example
+                  width: 1
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Instance
+      x-apigen-operation-kind: query
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_PLATFORM
+      x-leapview-object-scope: platform
+      x-apigen-manual: true
+    patch:
+      operationId: updateProductSettings
+      summary: Update mutable product identity
+      parameters:
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          headers:
+            etag:
+              required: true
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductSettingsResponse'
+              example:
+                displayName: example
+                logo:
+                  height: 1
+                  mediaType: example
+                  sha256: example
+                  sizeBytes: 1
+                  url: example
+                  width: 1
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductSettingsPatchRequest'
+            example:
+              displayName: example
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: fields
+                sensitivity: public
+            retention: security
+            schema:
+              ref: ProductIdentityUpdatedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: product.identity.updated
+        authz_mode: privilege
+        concurrency: if-match
+        failures:
+          - code: INVALID_PRODUCT_IDENTITY
+            kind: invalid
+            public_detail: The product identity is invalid.
+            status_code: !!float 422
+          - code: PRODUCT_IDENTITY_PRECONDITION_FAILED
+            kind: precondition
+            public_detail: The product identity changed before this request was applied.
+            status_code: !!float 412
+        owner: LeapViewAPI
+        privilege: MANAGE_PLATFORM
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_PLATFORM
+      x-leapview-object-scope: platform
+      x-apigen-manual: true
+  /api/v1/instance/system:
+    get:
+      operationId: getProductSystemStatus
+      summary: Get redacted system status
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductSystemStatusResponse'
+              example:
+                agent:
+                  available: true
+                  configured: true
+                  modelConfigured: true
+                  provider: example
+                build:
+                  buildTime: example
+                  development: true
+                  dirty: true
+                  revision: example
+                  version: example
+                canonicalOrigin: example
+                controlPlane: example
+                environment: example
+                instanceId: example
+                limits:
+                  managedDataMaxFileBytes: 1
+                  managedDataMaxFiles: 1
+                  managedDataMaxRevisionBytes: 1
+                  queryResultMaxBytes: 1
+                  queryResultMaxRows: 1
+                storageBackend: example
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Instance
+      x-apigen-operation-kind: query
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_PLATFORM
+      x-leapview-object-scope: platform
+      x-apigen-manual: true
   /api/v1/me:
     get:
       operationId: getCurrentPrincipal
@@ -4065,12 +6682,32 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PrincipalResponse'
+                $ref: '#/components/schemas/CurrentPrincipalResponse'
               example:
+                avatar:
+                  height: 1
+                  mediaType: example
+                  principalId: example
+                  sha256: example
+                  sizeBytes: 1
+                  updatedAt: "2026-01-02T15:04:05Z"
+                  url: example
+                  width: 1
+                capabilities:
+                  canChangePassword: true
+                  canManageApiTokens: true
+                  canManageAuthoringSessions: true
+                  canManageAvatar: true
+                  canManageSessions: true
+                  canUpdateDisplayName: true
                 createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
                 displayName: example
                 email: example
                 id: example
+                identityManagement:
+                  provider: example
+                  source: local
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
@@ -4310,9 +6947,319 @@ paths:
       tags:
         - Current User
       x-apigen-operation-kind: query
-      x-authz:
-        mode: privilege
-        privilege: USE_WORKSPACE
+      x-leapview-object-scope: principal
+    patch:
+      operationId: updateCurrentPrincipal
+      summary: Update the current principal's self-managed profile fields
+      parameters:
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CurrentPrincipalResponse'
+              example:
+                avatar:
+                  height: 1
+                  mediaType: example
+                  principalId: example
+                  sha256: example
+                  sizeBytes: 1
+                  updatedAt: "2026-01-02T15:04:05Z"
+                  url: example
+                  width: 1
+                capabilities:
+                  canChangePassword: true
+                  canManageApiTokens: true
+                  canManageAuthoringSessions: true
+                  canManageAvatar: true
+                  canManageSessions: true
+                  canUpdateDisplayName: true
+                createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
+                displayName: example
+                email: example
+                id: example
+                identityManagement:
+                  provider: example
+                  source: local
+                kind: example
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Current User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CurrentPrincipalPatchRequest'
+            example:
+              displayName: example
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: displayName
+                sensitivity: pii
+              - name: email
+                sensitivity: pii
+            retention: security
+            schema:
+              ref: CurrentPrincipalUpdatedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: principal.profile.updated
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: PRINCIPAL_PROFILE_NOT_MUTABLE
+            kind: invalid
+            public_detail: The current principal profile cannot be modified.
+            status_code: !!float 422
+        owner: LeapViewAPI.Access
       x-leapview-object-scope: principal
   /api/v1/me/api-tokens:
     get:
@@ -4595,9 +7542,6 @@ paths:
       tags:
         - Current User
       x-apigen-operation-kind: query
-      x-authz:
-        mode: privilege
-        privilege: MANAGE_GRANTS
       x-leapview-object-scope: principal
     post:
       operationId: createCurrentAPIToken
@@ -4899,7 +7843,7 @@ paths:
             schema_version: !!float 1
           required: true
           success_action: api_token.created
-        authz_mode: privilege
+        authz_mode: authenticated
         failures:
           - code: API_TOKEN_INVALID
             kind: invalid
@@ -4907,10 +7851,6 @@ paths:
             status_code: !!float 400
         idempotency: required
         owner: LeapViewAPI.Access
-        privilege: MANAGE_GRANTS
-      x-authz:
-        mode: privilege
-        privilege: MANAGE_GRANTS
       x-leapview-object-scope: principal
   /api/v1/me/api-tokens/{token}:
     delete:
@@ -5178,7 +8118,7 @@ paths:
             schema_version: !!float 1
           required: true
           success_action: api_token.revoked
-        authz_mode: privilege
+        authz_mode: authenticated
         failures:
           - code: API_TOKEN_NOT_FOUND
             kind: not_found
@@ -5188,10 +8128,6 @@ paths:
         target:
           parameter: token
           type: token
-        privilege: MANAGE_GRANTS
-      x-authz:
-        mode: privilege
-        privilege: MANAGE_GRANTS
       x-leapview-object-scope: principal
   /api/v1/me/authoring-sessions:
     get:
@@ -5228,6 +8164,7 @@ paths:
                 items:
                   - clientId: example
                     createdAt: "2026-01-02T15:04:05Z"
+                    current: true
                     expiresAt: "2026-01-02T15:04:05Z"
                     id: example
                     kind: example
@@ -5476,9 +8413,6 @@ paths:
       tags:
         - Current User
       x-apigen-operation-kind: query
-      x-authz:
-        mode: privilege
-        privilege: USE_WORKSPACE
   /api/v1/me/authoring-sessions/{session}:
     delete:
       operationId: revokeCurrentAuthoringSession
@@ -5757,7 +8691,7 @@ paths:
             schema_version: !!float 1
           required: true
           success_action: authoring.session.revoked
-        authz_mode: privilege
+        authz_mode: authenticated
         failures:
           - code: INVALID_AUTHORING_CREDENTIAL
             kind: invalid_credential
@@ -5771,10 +8705,570 @@ paths:
         target:
           parameter: session
           type: session
-        privilege: USE_WORKSPACE
-      x-authz:
-        mode: privilege
-        privilege: USE_WORKSPACE
+  /api/v1/me/avatar:
+    delete:
+      operationId: deleteCurrentAvatar
+      summary: Delete the current user's avatar
+      parameters: []
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Current User
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: best-effort
+          payload:
+            fields:
+              - name: principalId
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: CurrentAvatarDeletedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: principal.avatar.deleted
+        authz_mode: authenticated
+        failures:
+          - code: AVATAR_NOT_FOUND
+            kind: not_found
+            public_detail: The current principal has no avatar.
+            status_code: !!float 404
+        owner: LeapViewAPI.Access
+      x-leapview-object-scope: principal
+    put:
+      operationId: uploadCurrentAvatar
+      summary: Upload and normalize the current user's avatar
+      parameters:
+        - name: Content-Type
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvatarResponse'
+              example:
+                height: 1
+                mediaType: example
+                principalId: example
+                sha256: example
+                sizeBytes: 1
+                updatedAt: "2026-01-02T15:04:05Z"
+                url: example
+                width: 1
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Current User
+      requestBody:
+        required: true
+        content:
+          '*/*':
+            schema:
+              type: string
+              format: binary
+            example: example
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: best-effort
+          payload:
+            fields:
+              - name: principalId
+                sensitivity: internal
+              - name: sha256
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: CurrentAvatarUploadedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: principal.avatar.updated
+        authz_mode: authenticated
+        failures:
+          - code: INVALID_AVATAR_IMAGE
+            kind: invalid
+            public_detail: The avatar image is invalid.
+            status_code: !!float 422
+          - code: UNSUPPORTED_AVATAR_MEDIA_TYPE
+            kind: unsupported_media_type
+            public_detail: The avatar media type is unsupported.
+            status_code: !!float 415
+        owner: LeapViewAPI.Access
+      x-leapview-object-scope: principal
   /api/v1/me/effective-privileges:
     get:
       operationId: listCurrentEffectivePrivileges
@@ -6039,6 +9533,292 @@ paths:
         mode: privilege
         privilege: USE_WORKSPACE
       x-leapview-object-scope: principal
+  /api/v1/me/password:
+    post:
+      operationId: changeCurrentPassword
+      summary: Change the current principal's local password
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+          example: example
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Current User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CurrentPasswordChangeRequest'
+            example:
+              currentPassword: example
+              newPassword: example
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: email
+                sensitivity: pii
+              - name: provider
+                sensitivity: public
+            retention: security
+            schema:
+              ref: CurrentPasswordChangedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: password.changed
+        authz_mode: authenticated
+        failures:
+          - code: PASSWORD_CHANGE_INVALID
+            kind: invalid
+            public_detail: The password change request is invalid.
+            status_code: !!float 400
+        idempotency: required
+        owner: LeapViewAPI.Access
+      x-leapview-object-scope: principal
   /api/v1/me/sessions:
     get:
       operationId: listCurrentSessions
@@ -6075,6 +9855,7 @@ paths:
                   - absoluteExpiresAt: "2026-01-02T15:04:05Z"
                     clientId: example
                     createdAt: "2026-01-02T15:04:05Z"
+                    current: true
                     expiresAt: "2026-01-02T15:04:05Z"
                     id: example
                     instanceId: example
@@ -6321,9 +10102,6 @@ paths:
       tags:
         - Current User
       x-apigen-operation-kind: query
-      x-authz:
-        mode: privilege
-        privilege: USE_WORKSPACE
       x-leapview-object-scope: principal
   /api/v1/me/sessions/{session}:
     delete:
@@ -6589,7 +10367,7 @@ paths:
             schema_version: !!float 1
           required: true
           success_action: session.revoked
-        authz_mode: privilege
+        authz_mode: authenticated
         failures:
           - code: SESSION_NOT_FOUND
             kind: not_found
@@ -6599,10 +10377,6 @@ paths:
         target:
           parameter: session
           type: session
-        privilege: USE_WORKSPACE
-      x-authz:
-        mode: privilege
-        privilege: USE_WORKSPACE
       x-leapview-object-scope: principal
   /api/v1/principals:
     get:
@@ -6652,6 +10426,7 @@ paths:
               example:
                 items:
                   - createdAt: "2026-01-02T15:04:05Z"
+                    disabledAt: "2026-01-02T15:04:05Z"
                     displayName: example
                     email: example
                     id: example
@@ -6927,6 +10702,7 @@ paths:
               example:
                 principal:
                   createdAt: "2026-01-02T15:04:05Z"
+                  disabledAt: "2026-01-02T15:04:05Z"
                   displayName: example
                   email: example
                   id: example
@@ -7475,6 +11251,10 @@ paths:
           success_action: principal.deleted
         authz_mode: privilege
         failures:
+          - code: PRINCIPAL_OWNS_OBJECTS
+            kind: conflict
+            public_detail: Transfer owned objects before deleting this principal.
+            status_code: !!float 409
           - code: PRINCIPAL_NOT_MUTABLE
             kind: invalid
             public_detail: This principal cannot be deleted by this operation.
@@ -7511,6 +11291,7 @@ paths:
                 $ref: '#/components/schemas/PrincipalResponse'
               example:
                 createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
                 displayName: example
                 email: example
                 id: example
@@ -7782,6 +11563,7 @@ paths:
                 $ref: '#/components/schemas/PrincipalResponse'
               example:
                 createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
                 displayName: example
                 email: example
                 id: example
@@ -8069,6 +11851,900 @@ paths:
         mode: privilege
         privilege: MANAGE_GRANTS
       x-leapview-object-scope: grant-management
+  /api/v1/principals/{principal}/avatar/{digest}:
+    get:
+      operationId: getPrincipalAvatar
+      summary: Read a content-addressed principal avatar
+      parameters:
+        - name: principal
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: digest
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          headers:
+            cache-control:
+              required: true
+              schema:
+                type: string
+            content-length:
+              required: true
+              schema:
+                type: integer
+                format: int64
+            etag:
+              required: true
+              schema:
+                type: string
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+              example: example
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Current User
+      x-apigen-operation-kind: query
+      x-leapview-object-scope: principal
+  /api/v1/principals/{principal}/disable:
+    post:
+      operationId: disablePrincipal
+      summary: Disable a principal and reject its credentials
+      parameters:
+        - name: principal
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrincipalResponse'
+              example:
+                createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
+                displayName: example
+                email: example
+                id: example
+                kind: example
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: displayName
+                sensitivity: pii
+              - name: email
+                sensitivity: pii
+              - name: kind
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: PrincipalUpdatedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: principal.disabled
+        authz_mode: privilege
+        failures:
+          - code: PRINCIPAL_NOT_MUTABLE
+            kind: invalid
+            public_detail: This principal cannot be disabled by this operation.
+            status_code: !!float 422
+          - code: PRINCIPAL_NOT_FOUND
+            kind: not_found
+            public_detail: Principal not found.
+            status_code: !!float 404
+        idempotency: required
+        owner: LeapViewAPI.Access
+        target:
+          parameter: principal
+          type: principal
+        privilege: MANAGE_GRANTS
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_GRANTS
+      x-leapview-object-scope: grant-management
+  /api/v1/principals/{principal}/enable:
+    post:
+      operationId: enablePrincipal
+      summary: Re-enable a disabled principal
+      parameters:
+        - name: principal
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrincipalResponse'
+              example:
+                createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
+                displayName: example
+                email: example
+                id: example
+                kind: example
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: displayName
+                sensitivity: pii
+              - name: email
+                sensitivity: pii
+              - name: kind
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: PrincipalUpdatedAuditPayload
+            schema_version: !!float 1
+          required: true
+          success_action: principal.enabled
+        authz_mode: privilege
+        failures:
+          - code: PRINCIPAL_NOT_MUTABLE
+            kind: invalid
+            public_detail: This principal cannot be enabled by this operation.
+            status_code: !!float 422
+          - code: PRINCIPAL_NOT_FOUND
+            kind: not_found
+            public_detail: Principal not found.
+            status_code: !!float 404
+        idempotency: required
+        owner: LeapViewAPI.Access
+        target:
+          parameter: principal
+          type: principal
+        privilege: MANAGE_GRANTS
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_GRANTS
+      x-leapview-object-scope: grant-management
   /api/v1/principals/{principal}/password-reset:
     post:
       operationId: resetPrincipalPassword
@@ -8098,6 +12774,7 @@ paths:
               example:
                 principal:
                   createdAt: "2026-01-02T15:04:05Z"
+                  disabledAt: "2026-01-02T15:04:05Z"
                   displayName: example
                   email: example
                   id: example
@@ -8412,6 +13089,7 @@ paths:
                   - absoluteExpiresAt: "2026-01-02T15:04:05Z"
                     clientId: example
                     createdAt: "2026-01-02T15:04:05Z"
+                    current: true
                     expiresAt: "2026-01-02T15:04:05Z"
                     id: example
                     instanceId: example
@@ -25707,6 +30385,7 @@ paths:
               example:
                 items:
                   - createdAt: "2026-01-02T15:04:05Z"
+                    disabledAt: "2026-01-02T15:04:05Z"
                     displayName: example
                     email: example
                     id: example
@@ -25980,6 +30659,7 @@ paths:
                 $ref: '#/components/schemas/PrincipalResponse'
               example:
                 createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
                 displayName: example
                 email: example
                 id: example
@@ -26553,6 +31233,7 @@ paths:
                 $ref: '#/components/schemas/PrincipalResponse'
               example:
                 createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
                 displayName: example
                 email: example
                 id: example
@@ -26823,6 +31504,7 @@ paths:
                 $ref: '#/components/schemas/PrincipalResponse'
               example:
                 createdAt: "2026-01-02T15:04:05Z"
+                disabledAt: "2026-01-02T15:04:05Z"
                 displayName: example
                 email: example
                 id: example
@@ -27089,6 +31771,10 @@ paths:
         authz_mode: privilege
         concurrency: if-match
         failures:
+          - code: SERVICE_PRINCIPAL_OWNS_OBJECTS
+            kind: conflict
+            public_detail: Transfer owned objects before deleting this service principal.
+            status_code: !!float 409
           - code: SERVICE_PRINCIPAL_NOT_FOUND
             kind: not_found
             public_detail: Service principal not found.
@@ -29085,6 +33771,318 @@ paths:
       x-authz:
         mode: privilege
         privilege: USE_WORKSPACE
+  /api/v1/workspaces/{workspace}/administration:
+    get:
+      operationId: getWorkspaceAdministration
+      summary: Get the workspace administration overview
+      parameters:
+        - name: workspace
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceAdministrationResponse'
+              example:
+                administrators:
+                  - displayName: example
+                    email: example
+                    role: example
+                    subjectId: example
+                    subjectType: example
+                capabilities:
+                  ingestManagedData: true
+                  manageAccess: true
+                  manageConnections: true
+                  managePublications: true
+                  manageWorkspace: true
+                  publishReleases: true
+                  requestDeployments: true
+                  useAgent: true
+                  viewAgent: true
+                  viewDeployments: true
+                  viewManagedData: true
+                links:
+                  agentConversations: example
+                  deployments: example
+                  grants: example
+                  groups: example
+                  managedConnections: example
+                  publications: example
+                  releases: example
+                  roleBindings: example
+                  roles: example
+                  self: example
+                  workspace: example
+                owner:
+                  displayName: example
+                  email: example
+                  role: example
+                  subjectId: example
+                  subjectType: example
+                runtime:
+                  activeServingStateId: example
+                  activeServingStateSince: "2026-01-02T15:04:05Z"
+                  activeServingStateStatus: example
+                  currentDeploymentId: example
+                  currentDeploymentSince: "2026-01-02T15:04:05Z"
+                  currentDeploymentStatus: example
+                  currentReleaseId: example
+                  environment: example
+                  projectId: example
+                workspace:
+                  activeServingStateId: example
+                  createdAt: "2026-01-02T15:04:05Z"
+                  description: example
+                  id: example
+                  title: example
+                  updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Workspaces
+      x-apigen-operation-kind: query
+      x-authz:
+        mode: privilege
+        privilege: MANAGE_WORKSPACE
   /api/v1/workspaces/{workspace}/asset-edges:
     get:
       operationId: listWorkspaceAssetEdges
@@ -39862,6 +44860,7 @@ paths:
               example:
                 items:
                   - createdAt: "2026-01-02T15:04:05Z"
+                    disabledAt: "2026-01-02T15:04:05Z"
                     displayName: example
                     email: example
                     id: example
@@ -52004,6 +57003,7 @@ components:
           type: array
           items:
             type: string
+          description: Omit to keep the token dynamically constrained by the principal's effective privileges at request time. An explicit list must be a subset of the principal's current effective privileges.
           example:
             - example
         expiresAt:
@@ -52079,7 +57079,6 @@ components:
       required:
         - id
         - name
-        - privileges
         - createdAt
       properties:
         id:
@@ -52095,6 +57094,7 @@ components:
           type: array
           items:
             type: string
+          description: Present when the token has an explicit privilege allowlist. When omitted, the principal's effective privileges are evaluated dynamically at request time.
           example:
             - example
         expiresAt:
@@ -52984,7 +57984,6 @@ components:
       type: object
       required:
         - id
-        - workspaceId
         - action
         - targetType
         - targetId
@@ -53062,6 +58061,7 @@ components:
           example:
             - clientId: example
               createdAt: "2026-01-02T15:04:05Z"
+              current: true
               expiresAt: "2026-01-02T15:04:05Z"
               id: example
               kind: example
@@ -53077,6 +58077,7 @@ components:
         items:
           - clientId: example
             createdAt: "2026-01-02T15:04:05Z"
+            current: true
             expiresAt: "2026-01-02T15:04:05Z"
             id: example
             kind: example
@@ -53093,6 +58094,7 @@ components:
       required:
         - id
         - kind
+        - current
         - clientId
         - targetId
         - projectId
@@ -53106,6 +58108,9 @@ components:
         kind:
           type: string
           example: example
+        current:
+          type: boolean
+          example: true
         clientId:
           type: string
           example: example
@@ -53140,6 +58145,7 @@ components:
       example:
         clientId: example
         createdAt: "2026-01-02T15:04:05Z"
+        current: true
         expiresAt: "2026-01-02T15:04:05Z"
         id: example
         kind: example
@@ -53314,6 +58320,57 @@ components:
         subjectId: example
         subjectType: example
         privilege: example
+    AvatarResponse:
+      type: object
+      required:
+        - principalId
+        - sha256
+        - mediaType
+        - sizeBytes
+        - width
+        - height
+        - updatedAt
+        - url
+      properties:
+        principalId:
+          type: string
+          example: example
+        sha256:
+          type: string
+          example: example
+        mediaType:
+          type: string
+          enum:
+            - image/png
+          example: example
+        sizeBytes:
+          type: integer
+          format: int64
+          example: 1
+        width:
+          type: integer
+          format: int32
+          example: 1
+        height:
+          type: integer
+          format: int32
+          example: 1
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        url:
+          type: string
+          example: example
+      example:
+        height: 1
+        mediaType: example
+        principalId: example
+        sha256: example
+        sizeBytes: 1
+        updatedAt: "2026-01-02T15:04:05Z"
+        url: example
+        width: 1
     CandidateArtifactRequest:
       type: object
       required:
@@ -54003,6 +59060,188 @@ components:
         kind: example
         maximumFractionDigits: 1
         minimumFractionDigits: 1
+    CurrentAvatarDeletedAuditPayload:
+      type: object
+      required:
+        - principalId
+      properties:
+        principalId:
+          type: string
+          example: example
+      example:
+        principalId: example
+    CurrentAvatarUploadedAuditPayload:
+      type: object
+      required:
+        - principalId
+        - sha256
+      properties:
+        principalId:
+          type: string
+          example: example
+        sha256:
+          type: string
+          example: example
+      example:
+        principalId: example
+        sha256: example
+    CurrentPasswordChangeRequest:
+      type: object
+      required:
+        - currentPassword
+        - newPassword
+      properties:
+        currentPassword:
+          type: string
+          example: example
+        newPassword:
+          type: string
+          example: example
+      example:
+        currentPassword: example
+        newPassword: example
+    CurrentPasswordChangedAuditPayload:
+      type: object
+      required:
+        - email
+        - provider
+      properties:
+        email:
+          type: string
+          example: example
+        provider:
+          type: string
+          example: example
+      example:
+        email: example
+        provider: example
+    CurrentPrincipalCapabilities:
+      type: object
+      required:
+        - canUpdateDisplayName
+        - canChangePassword
+        - canManageAvatar
+        - canManageSessions
+        - canManageAuthoringSessions
+        - canManageApiTokens
+      properties:
+        canUpdateDisplayName:
+          type: boolean
+          example: true
+        canChangePassword:
+          type: boolean
+          example: true
+        canManageAvatar:
+          type: boolean
+          example: true
+        canManageSessions:
+          type: boolean
+          example: true
+        canManageAuthoringSessions:
+          type: boolean
+          example: true
+        canManageApiTokens:
+          type: boolean
+          example: true
+      example:
+        canChangePassword: true
+        canManageApiTokens: true
+        canManageAuthoringSessions: true
+        canManageAvatar: true
+        canManageSessions: true
+        canUpdateDisplayName: true
+    CurrentPrincipalPatchRequest:
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: example
+      example:
+        displayName: example
+    CurrentPrincipalResponse:
+      type: object
+      required:
+        - id
+        - kind
+        - email
+        - displayName
+        - createdAt
+        - updatedAt
+        - identityManagement
+        - capabilities
+      properties:
+        id:
+          type: string
+          example: example
+        kind:
+          type: string
+          example: example
+        email:
+          type: string
+          example: example
+        displayName:
+          type: string
+          example: example
+        disabledAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        createdAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        identityManagement:
+          $ref: '#/components/schemas/IdentityManagementResponse'
+        capabilities:
+          $ref: '#/components/schemas/CurrentPrincipalCapabilities'
+        avatar:
+          $ref: '#/components/schemas/AvatarResponse'
+      example:
+        avatar:
+          height: 1
+          mediaType: example
+          principalId: example
+          sha256: example
+          sizeBytes: 1
+          updatedAt: "2026-01-02T15:04:05Z"
+          url: example
+          width: 1
+        capabilities:
+          canChangePassword: true
+          canManageApiTokens: true
+          canManageAuthoringSessions: true
+          canManageAvatar: true
+          canManageSessions: true
+          canUpdateDisplayName: true
+        createdAt: "2026-01-02T15:04:05Z"
+        disabledAt: "2026-01-02T15:04:05Z"
+        displayName: example
+        email: example
+        id: example
+        identityManagement:
+          provider: example
+          source: local
+        kind: example
+        updatedAt: "2026-01-02T15:04:05Z"
+    CurrentPrincipalUpdatedAuditPayload:
+      type: object
+      required:
+        - email
+        - displayName
+      properties:
+        email:
+          type: string
+          example: example
+        displayName:
+          type: string
+          example: example
+      example:
+        displayName: example
+        email: example
     CurrentSessionRevokedAuditPayload:
       type: object
       required:
@@ -57450,6 +62689,7 @@ components:
             $ref: '#/components/schemas/PrincipalResponse'
           example:
             - createdAt: "2026-01-02T15:04:05Z"
+              disabledAt: "2026-01-02T15:04:05Z"
               displayName: example
               email: example
               id: example
@@ -57460,6 +62700,7 @@ components:
       example:
         items:
           - createdAt: "2026-01-02T15:04:05Z"
+            disabledAt: "2026-01-02T15:04:05Z"
             displayName: example
             email: example
             id: example
@@ -57604,6 +62845,26 @@ components:
         value:
           dataset: example
           field: example
+    IdentityManagementResponse:
+      type: object
+      required:
+        - source
+      properties:
+        source:
+          $ref: '#/components/schemas/IdentityManagementSource'
+        provider:
+          type: string
+          example: example
+      example:
+        provider: example
+        source: local
+    IdentityManagementSource:
+      type: string
+      enum:
+        - local
+        - external
+        - system
+      example: local
     InlineVisualizationDataState:
       type: object
       allOf:
@@ -57797,6 +63058,7 @@ components:
       example:
         principal:
           createdAt: "2026-01-02T15:04:05Z"
+          disabledAt: "2026-01-02T15:04:05Z"
           displayName: example
           email: example
           id: example
@@ -59337,6 +64599,7 @@ components:
             $ref: '#/components/schemas/PrincipalResponse'
           example:
             - createdAt: "2026-01-02T15:04:05Z"
+              disabledAt: "2026-01-02T15:04:05Z"
               displayName: example
               email: example
               id: example
@@ -59347,6 +64610,7 @@ components:
       example:
         items:
           - createdAt: "2026-01-02T15:04:05Z"
+            disabledAt: "2026-01-02T15:04:05Z"
             displayName: example
             email: example
             id: example
@@ -59394,6 +64658,10 @@ components:
         displayName:
           type: string
           example: example
+        disabledAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
         createdAt:
           type: string
           format: date-time
@@ -59404,6 +64672,7 @@ components:
           example: "2026-01-02T15:04:05Z"
       example:
         createdAt: "2026-01-02T15:04:05Z"
+        disabledAt: "2026-01-02T15:04:05Z"
         displayName: example
         email: example
         id: example
@@ -59513,6 +64782,373 @@ components:
         code: example
         detail: example
         field: example
+    ProductAPIStatusResponse:
+      type: object
+      required:
+        - bearerCredentials
+        - servicePrincipals
+        - oauth
+        - mcp
+        - externalMcpIssuer
+      properties:
+        bearerCredentials:
+          $ref: '#/components/schemas/ProductAvailabilityResponse'
+        servicePrincipals:
+          $ref: '#/components/schemas/ProductAvailabilityResponse'
+        oauth:
+          $ref: '#/components/schemas/ProductAvailabilityResponse'
+        mcp:
+          $ref: '#/components/schemas/ProductAvailabilityResponse'
+        externalMcpIssuer:
+          type: boolean
+          example: true
+      example:
+        bearerCredentials:
+          available: true
+          enabled: true
+        externalMcpIssuer: true
+        mcp:
+          available: true
+          enabled: true
+        oauth:
+          available: true
+          enabled: true
+        servicePrincipals:
+          available: true
+          enabled: true
+    ProductAgentStatusResponse:
+      type: object
+      required:
+        - available
+        - configured
+        - modelConfigured
+      properties:
+        available:
+          type: boolean
+          example: true
+        configured:
+          type: boolean
+          example: true
+        provider:
+          type: string
+          example: example
+        modelConfigured:
+          type: boolean
+          example: true
+      example:
+        available: true
+        configured: true
+        modelConfigured: true
+        provider: example
+    ProductAuthenticationStatusResponse:
+      type: object
+      required:
+        - browserEnabled
+        - apiTokenOnly
+        - local
+        - oidc
+        - azure
+        - scim
+        - managedBy
+      properties:
+        browserEnabled:
+          type: boolean
+          example: true
+        apiTokenOnly:
+          type: boolean
+          example: true
+        local:
+          $ref: '#/components/schemas/ProductAvailabilityResponse'
+        oidc:
+          $ref: '#/components/schemas/ProductNamedAvailabilityResponse'
+        azure:
+          $ref: '#/components/schemas/ProductAvailabilityResponse'
+        scim:
+          $ref: '#/components/schemas/ProductAvailabilityResponse'
+        managedBy:
+          type: string
+          enum:
+            - deployment
+          example: example
+      example:
+        apiTokenOnly: true
+        azure:
+          available: true
+          enabled: true
+        browserEnabled: true
+        local:
+          available: true
+          enabled: true
+        managedBy: example
+        oidc:
+          available: true
+          enabled: true
+          provider: example
+        scim:
+          available: true
+          enabled: true
+    ProductAvailabilityResponse:
+      type: object
+      required:
+        - available
+        - enabled
+      properties:
+        available:
+          type: boolean
+          example: true
+        enabled:
+          type: boolean
+          example: true
+      example:
+        available: true
+        enabled: true
+    ProductBuildResponse:
+      type: object
+      required:
+        - version
+        - revision
+        - buildTime
+        - dirty
+        - development
+      properties:
+        version:
+          type: string
+          example: example
+        revision:
+          type: string
+          example: example
+        buildTime:
+          type: string
+          example: example
+        dirty:
+          type: boolean
+          example: true
+        development:
+          type: boolean
+          example: true
+      example:
+        buildTime: example
+        development: true
+        dirty: true
+        revision: example
+        version: example
+    ProductIdentityUpdatedAuditPayload:
+      type: object
+      required:
+        - fields
+      properties:
+        fields:
+          type: array
+          items:
+            type: string
+          example:
+            - example
+      example:
+        fields:
+          - example
+    ProductLimitsResponse:
+      type: object
+      required:
+        - queryResultMaxRows
+        - queryResultMaxBytes
+        - managedDataMaxFiles
+        - managedDataMaxFileBytes
+        - managedDataMaxRevisionBytes
+      properties:
+        queryResultMaxRows:
+          type: integer
+          format: int32
+          example: 1
+        queryResultMaxBytes:
+          type: integer
+          format: int64
+          example: 1
+        managedDataMaxFiles:
+          type: integer
+          format: int32
+          example: 1
+        managedDataMaxFileBytes:
+          type: integer
+          format: int64
+          example: 1
+        managedDataMaxRevisionBytes:
+          type: integer
+          format: int64
+          example: 1
+      example:
+        managedDataMaxFileBytes: 1
+        managedDataMaxFiles: 1
+        managedDataMaxRevisionBytes: 1
+        queryResultMaxBytes: 1
+        queryResultMaxRows: 1
+    ProductLogoDeletedAuditPayload:
+      type: object
+      required:
+        - removed
+      properties:
+        removed:
+          type: boolean
+          example: true
+      example:
+        removed: true
+    ProductLogoResponse:
+      type: object
+      required:
+        - url
+        - sha256
+        - mediaType
+        - sizeBytes
+        - width
+        - height
+      properties:
+        url:
+          type: string
+          example: example
+        sha256:
+          type: string
+          example: example
+        mediaType:
+          type: string
+          example: example
+        sizeBytes:
+          type: integer
+          format: int64
+          example: 1
+        width:
+          type: integer
+          format: int32
+          example: 1
+        height:
+          type: integer
+          format: int32
+          example: 1
+      example:
+        height: 1
+        mediaType: example
+        sha256: example
+        sizeBytes: 1
+        url: example
+        width: 1
+    ProductLogoUpdatedAuditPayload:
+      type: object
+      required:
+        - sha256
+      properties:
+        sha256:
+          type: string
+          example: example
+      example:
+        sha256: example
+    ProductNamedAvailabilityResponse:
+      type: object
+      required:
+        - available
+        - enabled
+      properties:
+        available:
+          type: boolean
+          example: true
+        enabled:
+          type: boolean
+          example: true
+        provider:
+          type: string
+          example: example
+      example:
+        available: true
+        enabled: true
+        provider: example
+    ProductSettingsPatchRequest:
+      type: object
+      required:
+        - displayName
+      properties:
+        displayName:
+          type: string
+          example: example
+      example:
+        displayName: example
+    ProductSettingsResponse:
+      type: object
+      required:
+        - displayName
+        - updatedAt
+      properties:
+        displayName:
+          type: string
+          example: example
+        logo:
+          $ref: '#/components/schemas/ProductLogoResponse'
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+      example:
+        displayName: example
+        logo:
+          height: 1
+          mediaType: example
+          sha256: example
+          sizeBytes: 1
+          url: example
+          width: 1
+        updatedAt: "2026-01-02T15:04:05Z"
+    ProductSystemStatusResponse:
+      type: object
+      required:
+        - instanceId
+        - canonicalOrigin
+        - environment
+        - build
+        - controlPlane
+        - storageBackend
+        - agent
+        - limits
+      properties:
+        instanceId:
+          type: string
+          example: example
+        canonicalOrigin:
+          type: string
+          example: example
+        environment:
+          type: string
+          example: example
+        build:
+          $ref: '#/components/schemas/ProductBuildResponse'
+        controlPlane:
+          type: string
+          example: example
+        storageBackend:
+          type: string
+          example: example
+        agent:
+          $ref: '#/components/schemas/ProductAgentStatusResponse'
+        limits:
+          $ref: '#/components/schemas/ProductLimitsResponse'
+      example:
+        agent:
+          available: true
+          configured: true
+          modelConfigured: true
+          provider: example
+        build:
+          buildTime: example
+          development: true
+          dirty: true
+          revision: example
+          version: example
+        canonicalOrigin: example
+        controlPlane: example
+        environment: example
+        instanceId: example
+        limits:
+          managedDataMaxFileBytes: 1
+          managedDataMaxFiles: 1
+          managedDataMaxRevisionBytes: 1
+          queryResultMaxBytes: 1
+          queryResultMaxRows: 1
+        storageBackend: example
     ProjectListResponse:
       type: object
       required:
@@ -62610,6 +68246,7 @@ components:
             $ref: '#/components/schemas/PrincipalResponse'
           example:
             - createdAt: "2026-01-02T15:04:05Z"
+              disabledAt: "2026-01-02T15:04:05Z"
               displayName: example
               email: example
               id: example
@@ -62620,6 +68257,7 @@ components:
       example:
         items:
           - createdAt: "2026-01-02T15:04:05Z"
+            disabledAt: "2026-01-02T15:04:05Z"
             displayName: example
             email: example
             id: example
@@ -62771,6 +68409,7 @@ components:
             - absoluteExpiresAt: "2026-01-02T15:04:05Z"
               clientId: example
               createdAt: "2026-01-02T15:04:05Z"
+              current: true
               expiresAt: "2026-01-02T15:04:05Z"
               id: example
               instanceId: example
@@ -62785,6 +68424,7 @@ components:
           - absoluteExpiresAt: "2026-01-02T15:04:05Z"
             clientId: example
             createdAt: "2026-01-02T15:04:05Z"
+            current: true
             expiresAt: "2026-01-02T15:04:05Z"
             id: example
             instanceId: example
@@ -62799,6 +68439,7 @@ components:
       required:
         - id
         - kind
+        - current
         - createdAt
         - expiresAt
       properties:
@@ -62807,6 +68448,9 @@ components:
           example: example
         kind:
           $ref: '#/components/schemas/SessionKind'
+        current:
+          type: boolean
+          example: true
         instanceId:
           type: string
           example: example
@@ -62840,6 +68484,7 @@ components:
         absoluteExpiresAt: "2026-01-02T15:04:05Z"
         clientId: example
         createdAt: "2026-01-02T15:04:05Z"
+        current: true
         expiresAt: "2026-01-02T15:04:05Z"
         id: example
         instanceId: example
@@ -67305,6 +72950,272 @@ components:
             field:
               dataset: example
               field: example
+    WorkspaceAdministrationCapabilitiesResponse:
+      type: object
+      required:
+        - manageWorkspace
+        - manageAccess
+        - managePublications
+        - manageConnections
+        - viewManagedData
+        - ingestManagedData
+        - publishReleases
+        - requestDeployments
+        - viewDeployments
+        - useAgent
+        - viewAgent
+      properties:
+        manageWorkspace:
+          type: boolean
+          example: true
+        manageAccess:
+          type: boolean
+          example: true
+        managePublications:
+          type: boolean
+          example: true
+        manageConnections:
+          type: boolean
+          example: true
+        viewManagedData:
+          type: boolean
+          example: true
+        ingestManagedData:
+          type: boolean
+          example: true
+        publishReleases:
+          type: boolean
+          example: true
+        requestDeployments:
+          type: boolean
+          example: true
+        viewDeployments:
+          type: boolean
+          example: true
+        useAgent:
+          type: boolean
+          example: true
+        viewAgent:
+          type: boolean
+          example: true
+      example:
+        ingestManagedData: true
+        manageAccess: true
+        manageConnections: true
+        managePublications: true
+        manageWorkspace: true
+        publishReleases: true
+        requestDeployments: true
+        useAgent: true
+        viewAgent: true
+        viewDeployments: true
+        viewManagedData: true
+    WorkspaceAdministrationLinksResponse:
+      type: object
+      required:
+        - self
+        - workspace
+      properties:
+        self:
+          type: string
+          example: example
+        workspace:
+          type: string
+          example: example
+        groups:
+          type: string
+          example: example
+        roles:
+          type: string
+          example: example
+        roleBindings:
+          type: string
+          example: example
+        grants:
+          type: string
+          example: example
+        publications:
+          type: string
+          example: example
+        managedConnections:
+          type: string
+          example: example
+        releases:
+          type: string
+          example: example
+        deployments:
+          type: string
+          example: example
+        agentConversations:
+          type: string
+          example: example
+      example:
+        agentConversations: example
+        deployments: example
+        grants: example
+        groups: example
+        managedConnections: example
+        publications: example
+        releases: example
+        roleBindings: example
+        roles: example
+        self: example
+        workspace: example
+    WorkspaceAdministrationResponse:
+      type: object
+      required:
+        - workspace
+        - administrators
+        - runtime
+        - capabilities
+        - links
+      properties:
+        workspace:
+          $ref: '#/components/schemas/WorkspaceResponse'
+        owner:
+          $ref: '#/components/schemas/WorkspaceAdministrationSubjectResponse'
+        administrators:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkspaceAdministrationSubjectResponse'
+          example:
+            - displayName: example
+              email: example
+              role: example
+              subjectId: example
+              subjectType: example
+        runtime:
+          $ref: '#/components/schemas/WorkspaceAdministrationRuntimeResponse'
+        capabilities:
+          $ref: '#/components/schemas/WorkspaceAdministrationCapabilitiesResponse'
+        links:
+          $ref: '#/components/schemas/WorkspaceAdministrationLinksResponse'
+      example:
+        administrators:
+          - displayName: example
+            email: example
+            role: example
+            subjectId: example
+            subjectType: example
+        capabilities:
+          ingestManagedData: true
+          manageAccess: true
+          manageConnections: true
+          managePublications: true
+          manageWorkspace: true
+          publishReleases: true
+          requestDeployments: true
+          useAgent: true
+          viewAgent: true
+          viewDeployments: true
+          viewManagedData: true
+        links:
+          agentConversations: example
+          deployments: example
+          grants: example
+          groups: example
+          managedConnections: example
+          publications: example
+          releases: example
+          roleBindings: example
+          roles: example
+          self: example
+          workspace: example
+        owner:
+          displayName: example
+          email: example
+          role: example
+          subjectId: example
+          subjectType: example
+        runtime:
+          activeServingStateId: example
+          activeServingStateSince: "2026-01-02T15:04:05Z"
+          activeServingStateStatus: example
+          currentDeploymentId: example
+          currentDeploymentSince: "2026-01-02T15:04:05Z"
+          currentDeploymentStatus: example
+          currentReleaseId: example
+          environment: example
+          projectId: example
+        workspace:
+          activeServingStateId: example
+          createdAt: "2026-01-02T15:04:05Z"
+          description: example
+          id: example
+          title: example
+          updatedAt: "2026-01-02T15:04:05Z"
+    WorkspaceAdministrationRuntimeResponse:
+      type: object
+      required:
+        - environment
+      properties:
+        environment:
+          type: string
+          example: example
+        activeServingStateId:
+          type: string
+          example: example
+        activeServingStateStatus:
+          type: string
+          example: example
+        activeServingStateSince:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        projectId:
+          type: string
+          example: example
+        currentDeploymentId:
+          type: string
+          example: example
+        currentDeploymentStatus:
+          type: string
+          example: example
+        currentDeploymentSince:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        currentReleaseId:
+          type: string
+          example: example
+      example:
+        activeServingStateId: example
+        activeServingStateSince: "2026-01-02T15:04:05Z"
+        activeServingStateStatus: example
+        currentDeploymentId: example
+        currentDeploymentSince: "2026-01-02T15:04:05Z"
+        currentDeploymentStatus: example
+        currentReleaseId: example
+        environment: example
+        projectId: example
+    WorkspaceAdministrationSubjectResponse:
+      type: object
+      required:
+        - subjectType
+        - subjectId
+        - displayName
+      properties:
+        subjectType:
+          type: string
+          example: example
+        subjectId:
+          type: string
+          example: example
+        email:
+          type: string
+          example: example
+        displayName:
+          type: string
+          example: example
+        role:
+          type: string
+          example: example
+      example:
+        displayName: example
+        email: example
+        role: example
+        subjectId: example
+        subjectType: example
     WorkspaceAssetGraphResponse:
       type: object
       required:

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/tus/tusd/v2 v2.10.0
 	github.com/yuin/goldmark v1.7.17
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/image v0.18.0
 	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -798,6 +798,8 @@ golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJk
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
+golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -13,6 +13,7 @@ import (
 
 var ErrAuditTransaction = apigenfailure.New("audit_transaction", "audit transaction failed")
 var ErrPrincipalAlreadyExists = apigenfailure.New("conflict", "principal already exists")
+var ErrPrincipalOwnsSecurableObject = apigenfailure.New("conflict", "principal owns a securable object; transfer ownership before deletion")
 
 type Privilege string
 
@@ -300,6 +301,51 @@ type Principal struct {
 	DisabledAt  string
 	CreatedAt   string
 	UpdatedAt   string
+	LastSeenAt  string
+}
+
+type ThemeMode string
+
+const (
+	ThemeSystem          ThemeMode = "system"
+	ThemeLight           ThemeMode = "light"
+	ThemeDark            ThemeMode = "dark"
+	ThemeDarkDimmed      ThemeMode = "dark_dimmed"
+	ThemeLightColorblind ThemeMode = "light_colorblind"
+	ThemeDarkColorblind  ThemeMode = "dark_colorblind"
+	ThemeLightTritanopia ThemeMode = "light_tritanopia"
+	ThemeDarkTritanopia  ThemeMode = "dark_tritanopia"
+)
+
+func ParseThemeMode(value string) (ThemeMode, bool) {
+	theme := ThemeMode(strings.TrimSpace(value))
+	switch theme {
+	case ThemeSystem, ThemeLight, ThemeDark, ThemeDarkDimmed,
+		ThemeLightColorblind, ThemeDarkColorblind,
+		ThemeLightTritanopia, ThemeDarkTritanopia:
+		return theme, true
+	default:
+		return "", false
+	}
+}
+
+type PrincipalPreferences struct {
+	PrincipalID string
+	Theme       ThemeMode
+	UpdatedAt   string
+}
+
+type PrincipalPreferencesReader interface {
+	PrincipalPreferences(context.Context, string) (PrincipalPreferences, error)
+}
+
+type PrincipalPreferencesWriter interface {
+	SetPrincipalTheme(context.Context, string, ThemeMode) (PrincipalPreferences, error)
+}
+
+type AuditedPrincipalPreferences interface {
+	PrincipalPreferencesReader
+	SetPrincipalThemeAudited(context.Context, string, ThemeMode) error
 }
 
 type Role struct {
@@ -535,6 +581,29 @@ type LocalCredential struct {
 	CreatedAt          string
 	UpdatedAt          string
 	PasswordChangedAt  string
+}
+
+type IdentityManagementSource string
+
+const (
+	IdentityManagementLocal    IdentityManagementSource = "local"
+	IdentityManagementExternal IdentityManagementSource = "external"
+	IdentityManagementSystem   IdentityManagementSource = "system"
+)
+
+// PrincipalIdentityManagement describes which subsystem owns profile fields
+// and whether a separate local credential exists. A principal can have both an
+// external identity and a local credential; in that case the external provider
+// still owns synchronized profile fields while the local password remains
+// changeable when local authentication is enabled.
+type PrincipalIdentityManagement struct {
+	Source           IdentityManagementSource
+	Provider         string
+	HasLocalPassword bool
+}
+
+type PrincipalIdentityManagementRepository interface {
+	PrincipalIdentityManagement(context.Context, string) (PrincipalIdentityManagement, error)
 }
 
 type PrincipalFilter struct {
@@ -799,6 +868,7 @@ type Repository interface {
 	EffectivePrivileges(ctx context.Context, principalID string, object ObjectRef) ([]Privilege, error)
 	EffectiveAccess(ctx context.Context, principalID string, object ObjectRef) ([]AuthorizationDecision, error)
 	UpsertSecurableObject(ctx context.Context, object ObjectRef, ownerPrincipalID string) (SecurableObject, error)
+	GetSecurableObject(ctx context.Context, object ObjectRef) (SecurableObject, error)
 	CreateGrant(ctx context.Context, input GrantInput) (Grant, error)
 	GetGrant(ctx context.Context, workspaceID, id string) (Grant, error)
 	DeleteGrant(ctx context.Context, workspaceID, id string) error

--- a/internal/access/avatar/service.go
+++ b/internal/access/avatar/service.go
@@ -1,0 +1,298 @@
+// Package avatar validates, normalizes, stores, and resolves user profile images.
+package avatar
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"strings"
+
+	"golang.org/x/image/draw"
+	_ "golang.org/x/image/webp"
+)
+
+const (
+	MaxUploadBytes int64 = 5 << 20
+	MaxPixels            = 16_000_000
+	OutputSize           = 256
+)
+
+var (
+	ErrInvalid      = errors.New("invalid avatar")
+	ErrBlobNotFound = errors.New("avatar blob not found")
+	ErrNotFound     = errors.New("avatar not found")
+	ErrTooLarge     = errors.New("avatar is too large")
+)
+
+type Metadata struct {
+	PrincipalID string
+	SHA256      string
+	MediaType   string
+	SizeBytes   int64
+	Width       int
+	Height      int
+	UpdatedAt   string
+}
+
+type Repository interface {
+	Avatar(context.Context, string) (Metadata, error)
+	UpsertAvatar(context.Context, Metadata) (Metadata, error)
+	DeleteAvatar(context.Context, string) error
+}
+
+type BlobStore interface {
+	Put(context.Context, Blob, io.Reader) (Blob, error)
+	Open(context.Context, string) (io.ReadCloser, error)
+}
+
+type Blob struct {
+	SHA256 string
+	Size   int64
+}
+
+type Service struct {
+	repository Repository
+	blobs      BlobStore
+}
+
+func New(repository Repository, blobs BlobStore) (*Service, error) {
+	if repository == nil {
+		return nil, fmt.Errorf("avatar repository is required")
+	}
+	if blobs == nil {
+		return nil, fmt.Errorf("avatar blob store is required")
+	}
+	return &Service{repository: repository, blobs: blobs}, nil
+}
+
+func (s *Service) Upload(ctx context.Context, principalID string, body io.Reader) (Metadata, error) {
+	principalID = strings.TrimSpace(principalID)
+	if principalID == "" {
+		return Metadata{}, fmt.Errorf("%w: principal id is required", ErrInvalid)
+	}
+	if body == nil {
+		return Metadata{}, fmt.Errorf("%w: image body is required", ErrInvalid)
+	}
+	raw, err := io.ReadAll(io.LimitReader(body, MaxUploadBytes+1))
+	if err != nil {
+		return Metadata{}, fmt.Errorf("read avatar: %w", err)
+	}
+	if int64(len(raw)) > MaxUploadBytes {
+		return Metadata{}, fmt.Errorf("%w: image exceeds %d bytes", ErrTooLarge, MaxUploadBytes)
+	}
+	normalized, err := normalize(raw)
+	if err != nil {
+		return Metadata{}, err
+	}
+	digest := sha256.Sum256(normalized)
+	sha := hex.EncodeToString(digest[:])
+	blob := Blob{SHA256: sha, Size: int64(len(normalized))}
+	if _, err := s.blobs.Put(ctx, blob, bytes.NewReader(normalized)); err != nil {
+		return Metadata{}, fmt.Errorf("store avatar: %w", err)
+	}
+	metadata := Metadata{
+		PrincipalID: principalID,
+		SHA256:      sha,
+		MediaType:   "image/png",
+		SizeBytes:   int64(len(normalized)),
+		Width:       OutputSize,
+		Height:      OutputSize,
+	}
+	stored, err := s.repository.UpsertAvatar(ctx, metadata)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("persist avatar metadata: %w", err)
+	}
+	return stored, nil
+}
+
+// Current returns the principal's current avatar metadata without opening the
+// immutable image blob. It is used to embed a content-addressed avatar URL in
+// profile responses.
+func (s *Service) Current(ctx context.Context, principalID string) (Metadata, error) {
+	return s.repository.Avatar(ctx, strings.TrimSpace(principalID))
+}
+
+func (s *Service) Open(ctx context.Context, principalID, digest string) (io.ReadCloser, Metadata, error) {
+	metadata, err := s.repository.Avatar(ctx, strings.TrimSpace(principalID))
+	if err != nil {
+		return nil, Metadata{}, err
+	}
+	if metadata.SHA256 == "" || metadata.SHA256 != strings.ToLower(strings.TrimSpace(digest)) {
+		return nil, Metadata{}, ErrNotFound
+	}
+	reader, err := s.blobs.Open(ctx, metadata.SHA256)
+	if errors.Is(err, ErrBlobNotFound) {
+		return nil, Metadata{}, ErrNotFound
+	}
+	if err != nil {
+		return nil, Metadata{}, fmt.Errorf("open avatar blob: %w", err)
+	}
+	return reader, metadata, nil
+}
+
+func (s *Service) Delete(ctx context.Context, principalID string) error {
+	principalID = strings.TrimSpace(principalID)
+	if principalID == "" {
+		return fmt.Errorf("%w: principal id is required", ErrInvalid)
+	}
+	return s.repository.DeleteAvatar(ctx, principalID)
+}
+
+func normalize(raw []byte) ([]byte, error) {
+	config, format, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%w: image could not be decoded", ErrInvalid)
+	}
+	if format != "jpeg" && format != "png" && format != "webp" {
+		return nil, fmt.Errorf("%w: supported formats are JPEG, PNG, and WebP", ErrInvalid)
+	}
+	if config.Width <= 0 || config.Height <= 0 || config.Width > MaxPixels/config.Height {
+		return nil, fmt.Errorf("%w: image exceeds %d pixels", ErrInvalid, MaxPixels)
+	}
+	source, decodedFormat, err := image.Decode(bytes.NewReader(raw))
+	if err != nil || decodedFormat != format {
+		return nil, fmt.Errorf("%w: image could not be decoded", ErrInvalid)
+	}
+	if format == "jpeg" {
+		source = orient(source, jpegEXIFOrientation(raw))
+	}
+	bounds := source.Bounds()
+	side := bounds.Dx()
+	if bounds.Dy() < side {
+		side = bounds.Dy()
+	}
+	left := bounds.Min.X + (bounds.Dx()-side)/2
+	top := bounds.Min.Y + (bounds.Dy()-side)/2
+	crop := image.Rect(left, top, left+side, top+side)
+	destination := image.NewNRGBA(image.Rect(0, 0, OutputSize, OutputSize))
+	draw.CatmullRom.Scale(destination, destination.Bounds(), source, crop, draw.Over, nil)
+	var output bytes.Buffer
+	encoder := png.Encoder{CompressionLevel: png.DefaultCompression}
+	if err := encoder.Encode(&output, destination); err != nil {
+		return nil, fmt.Errorf("normalize avatar: %w", err)
+	}
+	return output.Bytes(), nil
+}
+
+func jpegEXIFOrientation(raw []byte) int {
+	if len(raw) < 4 || raw[0] != 0xff || raw[1] != 0xd8 {
+		return 1
+	}
+	for offset := 2; offset+4 <= len(raw); {
+		if raw[offset] != 0xff {
+			return 1
+		}
+		for offset < len(raw) && raw[offset] == 0xff {
+			offset++
+		}
+		if offset >= len(raw) {
+			return 1
+		}
+		marker := raw[offset]
+		offset++
+		if marker == 0xda || marker == 0xd9 {
+			return 1
+		}
+		if marker == 0x01 || marker >= 0xd0 && marker <= 0xd7 {
+			continue
+		}
+		if offset+2 > len(raw) {
+			return 1
+		}
+		length := int(binary.BigEndian.Uint16(raw[offset : offset+2]))
+		if length < 2 || offset+length > len(raw) {
+			return 1
+		}
+		segment := raw[offset+2 : offset+length]
+		if marker == 0xe1 && len(segment) >= 6 && bytes.Equal(segment[:6], []byte("Exif\x00\x00")) {
+			if orientation := tiffOrientation(segment[6:]); orientation >= 1 && orientation <= 8 {
+				return orientation
+			}
+		}
+		offset += length
+	}
+	return 1
+}
+
+func tiffOrientation(tiff []byte) int {
+	if len(tiff) < 8 {
+		return 1
+	}
+	var order binary.ByteOrder
+	switch string(tiff[:2]) {
+	case "II":
+		order = binary.LittleEndian
+	case "MM":
+		order = binary.BigEndian
+	default:
+		return 1
+	}
+	if order.Uint16(tiff[2:4]) != 42 {
+		return 1
+	}
+	ifdOffset := uint64(order.Uint32(tiff[4:8]))
+	if ifdOffset+2 > uint64(len(tiff)) {
+		return 1
+	}
+	count := uint64(order.Uint16(tiff[ifdOffset : ifdOffset+2]))
+	entries := ifdOffset + 2
+	if count > (uint64(len(tiff))-entries)/12 {
+		return 1
+	}
+	for index := uint64(0); index < count; index++ {
+		entry := tiff[entries+index*12 : entries+(index+1)*12]
+		if order.Uint16(entry[:2]) != 0x0112 || order.Uint16(entry[2:4]) != 3 || order.Uint32(entry[4:8]) != 1 {
+			continue
+		}
+		return int(order.Uint16(entry[8:10]))
+	}
+	return 1
+}
+
+func orient(source image.Image, orientation int) image.Image {
+	if orientation <= 1 || orientation > 8 {
+		return source
+	}
+	bounds := source.Bounds()
+	width, height := bounds.Dx(), bounds.Dy()
+	outputWidth, outputHeight := width, height
+	if orientation >= 5 {
+		outputWidth, outputHeight = height, width
+	}
+	destination := image.NewNRGBA(image.Rect(0, 0, outputWidth, outputHeight))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			destinationX, destinationY := orientedPoint(x, y, width, height, orientation)
+			destination.Set(destinationX, destinationY, source.At(bounds.Min.X+x, bounds.Min.Y+y))
+		}
+	}
+	return destination
+}
+
+func orientedPoint(x, y, width, height, orientation int) (int, int) {
+	switch orientation {
+	case 2:
+		return width - 1 - x, y
+	case 3:
+		return width - 1 - x, height - 1 - y
+	case 4:
+		return x, height - 1 - y
+	case 5:
+		return y, x
+	case 6:
+		return height - 1 - y, x
+	case 7:
+		return height - 1 - y, width - 1 - x
+	case 8:
+		return y, width - 1 - x
+	default:
+		return x, y
+	}
+}

--- a/internal/access/avatar/service_test.go
+++ b/internal/access/avatar/service_test.go
@@ -1,0 +1,167 @@
+package avatar
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"testing"
+)
+
+func TestServiceUploadNormalizesAndPersistsAvatar(t *testing.T) {
+	repository := &memoryRepository{}
+	blobs := newMemoryBlobStore()
+	service, err := New(repository, blobs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := image.NewNRGBA(image.Rect(0, 0, 640, 320))
+	for y := 0; y < input.Bounds().Dy(); y++ {
+		for x := 0; x < input.Bounds().Dx(); x++ {
+			input.Set(x, y, color.NRGBA{R: uint8(x % 255), G: uint8(y % 255), B: 80, A: 255})
+		}
+	}
+	var encoded bytes.Buffer
+	if err := jpeg.Encode(&encoded, input, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatal(err)
+	}
+
+	metadata, err := service.Upload(t.Context(), "principal_1", bytes.NewReader(encoded.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metadata.PrincipalID != "principal_1" || metadata.MediaType != "image/png" || metadata.Width != 256 || metadata.Height != 256 {
+		t.Fatalf("metadata = %#v", metadata)
+	}
+	if metadata.SizeBytes <= 0 || len(metadata.SHA256) != 64 || repository.value.SHA256 != metadata.SHA256 {
+		t.Fatalf("metadata persistence = %#v repository=%#v", metadata, repository.value)
+	}
+
+	reader, stored, err := service.Open(t.Context(), "principal_1", metadata.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	decoded, format, err := image.Decode(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if format != "png" || decoded.Bounds() != image.Rect(0, 0, 256, 256) || stored != metadata {
+		t.Fatalf("stored avatar format=%q bounds=%v metadata=%#v", format, decoded.Bounds(), stored)
+	}
+}
+
+func TestServiceRejectsUnsupportedAndOversizedImages(t *testing.T) {
+	service, err := New(&memoryRepository{}, newMemoryBlobStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := service.Upload(t.Context(), "principal_1", bytes.NewBufferString(`<svg xmlns="http://www.w3.org/2000/svg"/>`)); err == nil {
+		t.Fatal("SVG upload succeeded")
+	}
+	if _, err := service.Upload(t.Context(), "principal_1", bytes.NewReader(make([]byte, MaxUploadBytes+1))); err == nil {
+		t.Fatal("oversized upload succeeded")
+	}
+
+	large := image.NewNRGBA(image.Rect(0, 0, 5000, 4000))
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, large); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Upload(t.Context(), "principal_1", bytes.NewReader(encoded.Bytes())); err == nil {
+		t.Fatal("oversized dimensions succeeded")
+	}
+}
+
+func TestServiceDeleteRemovesMetadataAndMakesOldDigestUnavailable(t *testing.T) {
+	repository := &memoryRepository{value: Metadata{PrincipalID: "principal_1", SHA256: string(make([]byte, 64)), MediaType: "image/png", SizeBytes: 1, Width: 256, Height: 256}}
+	service, err := New(repository, newMemoryBlobStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Delete(t.Context(), "principal_1"); err != nil {
+		t.Fatal(err)
+	}
+	if repository.value.PrincipalID != "" {
+		t.Fatalf("metadata remains: %#v", repository.value)
+	}
+	if _, _, err := service.Open(t.Context(), "principal_1", string(make([]byte, 64))); err == nil {
+		t.Fatal("deleted avatar remained readable")
+	}
+}
+
+func TestJPEGEXIFOrientationIsAppliedBeforeCropping(t *testing.T) {
+	exif := []byte{
+		0xff, 0xd8, 0xff, 0xe1, 0x00, 0x22,
+		'E', 'x', 'i', 'f', 0, 0,
+		'I', 'I', 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00,
+		0x01, 0x00,
+		0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0xff, 0xd9,
+	}
+	if got := jpegEXIFOrientation(exif); got != 6 {
+		t.Fatalf("jpegEXIFOrientation() = %d, want 6", got)
+	}
+	source := image.NewNRGBA(image.Rect(0, 0, 2, 3))
+	source.Set(0, 0, color.NRGBA{R: 255, A: 255})
+	rotated := orient(source, 6)
+	if rotated.Bounds() != image.Rect(0, 0, 3, 2) || color.NRGBAModel.Convert(rotated.At(2, 0)).(color.NRGBA).R != 255 {
+		t.Fatalf("rotated bounds=%v top-right=%v", rotated.Bounds(), rotated.At(2, 0))
+	}
+}
+
+type memoryRepository struct{ value Metadata }
+
+func (r *memoryRepository) Avatar(context.Context, string) (Metadata, error) {
+	if r.value.PrincipalID == "" {
+		return Metadata{}, ErrNotFound
+	}
+	return r.value, nil
+}
+
+func (r *memoryRepository) UpsertAvatar(_ context.Context, value Metadata) (Metadata, error) {
+	r.value = value
+	return value, nil
+}
+
+func (r *memoryRepository) DeleteAvatar(context.Context, string) error {
+	if r.value.PrincipalID == "" {
+		return ErrNotFound
+	}
+	r.value = Metadata{}
+	return nil
+}
+
+type memoryBlobStore struct{ values map[string][]byte }
+
+func newMemoryBlobStore() *memoryBlobStore { return &memoryBlobStore{values: map[string][]byte{}} }
+
+func (s *memoryBlobStore) Put(_ context.Context, expected Blob, body io.Reader) (Blob, error) {
+	value, err := io.ReadAll(body)
+	if err != nil {
+		return Blob{}, err
+	}
+	digest := sha256.Sum256(value)
+	if hex.EncodeToString(digest[:]) != expected.SHA256 || int64(len(value)) != expected.Size {
+		return Blob{}, errors.New("integrity mismatch")
+	}
+	s.values[expected.SHA256] = value
+	return expected, nil
+}
+
+func (s *memoryBlobStore) Open(_ context.Context, digest string) (io.ReadCloser, error) {
+	value, ok := s.values[digest]
+	if !ok {
+		return nil, ErrBlobNotFound
+	}
+	return io.NopCloser(bytes.NewReader(value)), nil
+}

--- a/internal/access/avatar/url.go
+++ b/internal/access/avatar/url.go
@@ -1,0 +1,25 @@
+package avatar
+
+import (
+	"net/url"
+	"strings"
+)
+
+// URL returns the canonical content-addressed path for avatar metadata.
+func URL(value Metadata) string {
+	principalID := strings.TrimSpace(value.PrincipalID)
+	digest := strings.ToLower(strings.TrimSpace(value.SHA256))
+	if principalID == "" || digest == "" {
+		return ""
+	}
+	return "/profile/avatars/" + url.PathEscape(principalID) + "/" + digest
+}
+
+// URLForPrincipal builds the canonical path when the caller already knows the
+// principal and the metadata reader only returns content fields.
+func URLForPrincipal(principalID string, value Metadata) string {
+	if strings.TrimSpace(value.PrincipalID) == "" {
+		value.PrincipalID = principalID
+	}
+	return URL(value)
+}

--- a/internal/access/avatar/url_test.go
+++ b/internal/access/avatar/url_test.go
@@ -1,0 +1,17 @@
+package avatar
+
+import "testing"
+
+func TestURLBuildsCanonicalContentAddressedPath(t *testing.T) {
+	got := URL(Metadata{PrincipalID: " user/one ", SHA256: " ABC123 "})
+	want := "/profile/avatars/user%2Fone/abc123"
+	if got != want {
+		t.Fatalf("URL() = %q, want %q", got, want)
+	}
+	if got := URL(Metadata{PrincipalID: "user"}); got != "" {
+		t.Fatalf("URL() without digest = %q, want empty", got)
+	}
+	if got := URLForPrincipal("user", Metadata{SHA256: "abc123"}); got != "/profile/avatars/user/abc123" {
+		t.Fatalf("URLForPrincipal() = %q", got)
+	}
+}

--- a/internal/access/http/apigen.go
+++ b/internal/access/http/apigen.go
@@ -35,6 +35,20 @@ func (d *APIGenDispatcher) GetCurrentPrincipal(w stdhttp.ResponseWriter, r *stdh
 	d.handler.GetCurrentPrincipal(w, r)
 }
 
+func (d *APIGenDispatcher) UpdateCurrentPrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, headers accessgen.GenUpdateCurrentPrincipalHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	d.handler.UpdateCurrentPrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) ChangeCurrentPassword(w stdhttp.ResponseWriter, r *stdhttp.Request, headers accessgen.GenChangeCurrentPasswordHeaders) {
+	r.Header.Set("Idempotency-Key", headers.IdempotencyKey)
+	d.handler.ChangeCurrentPassword(w, r)
+}
+
+func (d *APIGenDispatcher) ListPlatformAuditEvents(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenListPlatformAuditEventsParams) {
+	d.handler.ListPlatformAuditEvents(w, r)
+}
+
 func (d *APIGenDispatcher) DecideDeviceAuthorization(w stdhttp.ResponseWriter, r *stdhttp.Request, headers accessgen.GenDecideDeviceAuthorizationHeaders) {
 	r.Header.Set("Idempotency-Key", headers.IdempotencyKey)
 	d.handler.DecideDeviceAuthorization(w, r)
@@ -70,6 +84,26 @@ func (d *APIGenDispatcher) ListCurrentSessions(w stdhttp.ResponseWriter, r *stdh
 
 func (d *APIGenDispatcher) RevokeCurrentSession(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
 	d.handler.RevokeCurrentSession(w, r)
+}
+
+func (d *APIGenDispatcher) UploadCurrentAvatar(w stdhttp.ResponseWriter, r *stdhttp.Request, headers accessgen.GenUploadCurrentAvatarHeaders) {
+	d.handler.UploadCurrentAvatar(w, r, headers.ContentType)
+}
+
+func (d *APIGenDispatcher) DeleteCurrentAvatar(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	d.handler.DeleteCurrentAvatar(w, r)
+}
+
+func (d *APIGenDispatcher) GetPrincipalAvatar(w stdhttp.ResponseWriter, r *stdhttp.Request, principal, digest string) {
+	d.handler.GetPrincipalAvatar(w, r, principal, digest)
+}
+
+func (d *APIGenDispatcher) DisablePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenDisablePrincipalHeaders) {
+	d.handler.DisablePrincipal(w, r)
+}
+
+func (d *APIGenDispatcher) EnablePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenEnablePrincipalHeaders) {
+	d.handler.EnablePrincipal(w, r)
 }
 
 func (d *APIGenDispatcher) ListPrincipals(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenListPrincipalsParams) {

--- a/internal/access/http/apigen_test.go
+++ b/internal/access/http/apigen_test.go
@@ -33,3 +33,18 @@ func TestAPIGenDispatcherPreservesGeneratedIfMatchHeader(t *testing.T) {
 		t.Fatalf("If-Match = %q, want %q", got, want)
 	}
 }
+
+func TestAPIGenDispatcherPreservesCurrentPrincipalIfMatchHeader(t *testing.T) {
+	request := httptest.NewRequest(stdhttp.MethodPatch, "/api/v1/me", strings.NewReader(`{"displayName":"Updated"}`))
+	dispatcher := NewAPIGenDispatcher(Handler{})
+
+	dispatcher.UpdateCurrentPrincipal(
+		httptest.NewRecorder(),
+		request,
+		accessgen.GenUpdateCurrentPrincipalHeaders{IfMatch: `"profile-1"`},
+	)
+
+	if got, want := request.Header.Get("If-Match"), `"profile-1"`; got != want {
+		t.Fatalf("If-Match = %q, want %q", got, want)
+	}
+}

--- a/internal/access/http/audit_test.go
+++ b/internal/access/http/audit_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	stdhttp "net/http"
@@ -13,6 +14,8 @@ import (
 	"github.com/flidai/leapview/internal/access"
 	accesssqlite "github.com/flidai/leapview/internal/access/sqlite"
 	"github.com/flidai/leapview/internal/platform"
+	"github.com/flidai/leapview/internal/workspace"
+	workspacesqlite "github.com/flidai/leapview/internal/workspace/sqlite"
 )
 
 type auditedMutationRepository struct {
@@ -171,5 +174,79 @@ func TestDashboardPublicationPrincipalsRejectGenericIdentityMutations(t *testing
 	}
 	if !principalKindAllowsGenericMutation(access.PrincipalKindUser) {
 		t.Fatal("user principal rejected a generic identity mutation")
+	}
+}
+func TestListPlatformAuditEventsIncludesProductEventsAndFiltersWorkspace(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "access.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	repo := accesssqlite.NewRepository(store.SQLDB())
+	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
+	for _, workspaceID := range []string{"sales", "finance"} {
+		if err := workspaceRepo.Ensure(t.Context(), workspace.EnsureInput{ID: workspace.WorkspaceID(workspaceID), Title: workspaceID}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, input := range []access.AuditEventInput{
+		{Action: "product.updated", TargetType: "product", TargetID: "instance", Status: "success"},
+		{WorkspaceID: "sales", Action: "workspace.updated", TargetType: "workspace", TargetID: "sales", Status: "success"},
+		{WorkspaceID: "finance", Action: "workspace.updated", TargetType: "workspace", TargetID: "finance", Status: "success"},
+	} {
+		if err := repo.RecordAuditEvent(t.Context(), input); err != nil {
+			t.Fatal(err)
+		}
+	}
+	handler := Handler{Repository: func() (access.Repository, error) { return repo, nil }}
+
+	type event struct {
+		Action      string  `json:"action"`
+		WorkspaceID *string `json:"workspaceId"`
+		PrincipalID *string `json:"principalId"`
+		Privilege   *string `json:"privilege"`
+		RequestID   *string `json:"requestId"`
+		Correlation *string `json:"correlationId"`
+	}
+	type response struct {
+		Items []event `json:"items"`
+	}
+	list := func(path string) response {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		handler.ListPlatformAuditEvents(recorder, httptest.NewRequest(stdhttp.MethodGet, path, nil))
+		if recorder.Code != stdhttp.StatusOK {
+			t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+		}
+		var result response
+		if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil {
+			t.Fatalf("decode response: %v body=%s", err, recorder.Body.String())
+		}
+		return result
+	}
+
+	all := list("/api/v1/audit-events")
+	if len(all.Items) != 3 {
+		t.Fatalf("all audit events = %#v, want 3", all.Items)
+	}
+	productFound := false
+	for _, item := range all.Items {
+		if item.Action == "product.updated" {
+			productFound = true
+			if item.WorkspaceID != nil {
+				t.Fatalf("product event workspaceId = %q, want omitted", *item.WorkspaceID)
+			}
+			if item.PrincipalID != nil || item.Privilege != nil || item.RequestID != nil || item.Correlation != nil {
+				t.Fatalf("product event emitted empty optional fields: %#v", item)
+			}
+		}
+	}
+	if !productFound {
+		t.Fatalf("product event missing from %#v", all.Items)
+	}
+
+	sales := list("/api/v1/audit-events?workspace=sales")
+	if len(sales.Items) != 1 || sales.Items[0].WorkspaceID == nil || *sales.Items[0].WorkspaceID != "sales" {
+		t.Fatalf("sales audit events = %#v", sales.Items)
 	}
 }

--- a/internal/access/http/authoring_auth.go
+++ b/internal/access/http/authoring_auth.go
@@ -69,8 +69,12 @@ func (h Handler) ListCurrentAuthoringSessions(w stdhttp.ResponseWriter, r *stdht
 		return
 	}
 	out := make([]map[string]any, 0, len(sessions))
+	currentSessionID := ""
+	if credential, found := h.currentCredential(r); found && credential.Authoring != nil {
+		currentSessionID = credential.Authoring.ID
+	}
 	for _, session := range sessions {
-		out = append(out, authoringSessionDTO(session))
+		out = append(out, authoringSessionDTO(session, session.ID != "" && session.ID == currentSessionID))
 	}
 	_ = writePagedJSON(w, r, out)
 }
@@ -87,6 +91,9 @@ func (h Handler) RevokeCurrentAuthoringSession(w stdhttp.ResponseWriter, r *stdh
 	}
 	sessionID := chi.URLParam(r, "session")
 	if err := service.RevokeSession(r.Context(), principal.ID, sessionID); err != nil {
+		if errors.Is(err, access.ErrInvalidAuthoringCredential) {
+			err = apigenfailure.Wrap("not_found", err)
+		}
 		writeAuthoringCommandError(w, r, accessgen.GenCommandOperationRevokeCurrentAuthoringSession(), err)
 		return
 	}
@@ -104,7 +111,7 @@ func (h Handler) authoringAuthentication(w stdhttp.ResponseWriter) (AuthoringAut
 func authoringTokenDTO(tokens access.AuthoringTokenSet) map[string]any {
 	response := map[string]any{
 		"accessToken": tokens.AccessToken, "tokenType": tokens.TokenType,
-		"expiresIn": tokens.ExpiresIn, "session": authoringSessionDTO(tokens.Session),
+		"expiresIn": tokens.ExpiresIn, "session": authoringSessionDTO(tokens.Session, true),
 	}
 	if tokens.RefreshToken != "" {
 		response["refreshToken"] = tokens.RefreshToken
@@ -112,13 +119,13 @@ func authoringTokenDTO(tokens access.AuthoringTokenSet) map[string]any {
 	return response
 }
 
-func authoringSessionDTO(session access.AuthoringSession) map[string]any {
+func authoringSessionDTO(session access.AuthoringSession, current bool) map[string]any {
 	privileges := make([]string, len(session.Scope.Privileges))
 	for index, privilege := range session.Scope.Privileges {
 		privileges[index] = string(privilege)
 	}
 	response := map[string]any{
-		"id": session.ID, "kind": session.Kind, "clientId": session.ClientID,
+		"id": session.ID, "kind": session.Kind, "current": current, "clientId": session.ClientID,
 		"targetId": session.Scope.TargetID, "projectId": session.Scope.ProjectID,
 		"privileges": privileges, "createdAt": session.CreatedAt.UTC().Format(time.RFC3339),
 		"expiresAt": session.ExpiresAt.UTC().Format(time.RFC3339),

--- a/internal/access/http/authoring_auth_test.go
+++ b/internal/access/http/authoring_auth_test.go
@@ -2,17 +2,22 @@ package http
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	stdhttp "net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/flidai/leapview/internal/access"
 )
 
 type fakeAuthoringAuthentication struct {
 	AuthoringAuthentication
-	approve string
+	approve   string
+	sessions  []access.AuthoringSession
+	revokeErr error
 }
 
 func (service *fakeAuthoringAuthentication) InstanceID() string { return "lvinst_prod" }
@@ -20,6 +25,14 @@ func (service *fakeAuthoringAuthentication) InstanceID() string { return "lvinst
 func (service *fakeAuthoringAuthentication) ApproveDeviceAuthorization(_ context.Context, _ access.Principal, userCode string) error {
 	service.approve = userCode
 	return nil
+}
+
+func (service *fakeAuthoringAuthentication) ListSessions(context.Context, string) ([]access.AuthoringSession, error) {
+	return service.sessions, nil
+}
+
+func (service *fakeAuthoringAuthentication) RevokeSession(context.Context, string, string) error {
+	return service.revokeErr
 }
 
 func TestDeviceAuthorizationApprovalRejectsBearerCredentials(t *testing.T) {
@@ -40,5 +53,55 @@ func TestDeviceAuthorizationApprovalRejectsBearerCredentials(t *testing.T) {
 	handler.DecideDeviceAuthorization(recorder, request)
 	if recorder.Code != stdhttp.StatusForbidden || service.approve != "" {
 		t.Fatalf("status=%d approved=%q body=%s", recorder.Code, service.approve, recorder.Body.String())
+	}
+}
+
+func TestCurrentAuthoringSessionListMarksTheBearerSession(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	service := &fakeAuthoringAuthentication{sessions: []access.AuthoringSession{
+		{ID: "authoring_current", Kind: access.AuthoringSessionHumanCLI, ClientID: "cli", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		{ID: "authoring_other", Kind: access.AuthoringSessionHumanCLI, ClientID: "cli", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+	}}
+	handler := Handler{
+		AuthoringAuth: service,
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+			return Principal{ID: "principal-1"}, true
+		},
+		CurrentCredential: func(*stdhttp.Request) (access.APICredential, bool) {
+			return access.APICredential{Authoring: &service.sessions[0]}, true
+		},
+	}
+	response := httptest.NewRecorder()
+	handler.ListCurrentAuthoringSessions(response, httptest.NewRequest(stdhttp.MethodGet, "/api/v1/me/authoring-sessions", nil))
+	if response.Code != stdhttp.StatusOK {
+		t.Fatalf("response = %d body=%s", response.Code, response.Body.String())
+	}
+	var body struct {
+		Items []struct {
+			ID      string `json:"id"`
+			Current bool   `json:"current"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Items) != 2 || !body.Items[0].Current || body.Items[1].Current {
+		t.Fatalf("sessions = %#v", body.Items)
+	}
+}
+
+func TestRevokeCurrentAuthoringSessionHidesForeignSession(t *testing.T) {
+	service := &fakeAuthoringAuthentication{revokeErr: access.ErrInvalidAuthoringCredential}
+	handler := Handler{
+		AuthoringAuth: service,
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+			return Principal{ID: "principal-1"}, true
+		},
+	}
+	request := requestWithRouteParam(stdhttp.MethodDelete, "/api/v1/me/authoring-sessions/foreign", "session", "foreign")
+	response := httptest.NewRecorder()
+	handler.RevokeCurrentAuthoringSession(response, request)
+	if response.Code != stdhttp.StatusNotFound || !errors.Is(service.revokeErr, access.ErrInvalidAuthoringCredential) {
+		t.Fatalf("response = %d body=%s", response.Code, response.Body.String())
 	}
 }

--- a/internal/access/http/avatar.go
+++ b/internal/access/http/avatar.go
@@ -1,0 +1,200 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	stdhttp "net/http"
+	"strconv"
+	"strings"
+
+	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
+	"github.com/flidai/leapview/internal/access"
+	accessgen "github.com/flidai/leapview/internal/access/api/gen"
+	"github.com/flidai/leapview/internal/access/avatar"
+	apitransport "github.com/flidai/leapview/internal/platform/http/transport"
+)
+
+const avatarCacheControl = "private, max-age=31536000, immutable"
+
+type AvatarService interface {
+	Upload(context.Context, string, io.Reader) (avatar.Metadata, error)
+	Current(context.Context, string) (avatar.Metadata, error)
+	Open(context.Context, string, string) (io.ReadCloser, avatar.Metadata, error)
+	Delete(context.Context, string) error
+}
+
+func (h Handler) UploadCurrentAvatar(w stdhttp.ResponseWriter, r *stdhttp.Request, contentType string) {
+	principal, ok := h.currentPrincipal(r)
+	if !ok {
+		writeAvatarProblem(w, r, stdhttp.StatusUnauthorized, "AUTHENTICATION_REQUIRED", "An authenticated user is required")
+		return
+	}
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	if principal.Kind != "" && principal.Kind != "user" {
+		writeAvatarProblem(w, r, stdhttp.StatusForbidden, "AVATAR_USER_REQUIRED", "Only user principals can have avatars")
+		return
+	}
+	if h.Avatar == nil {
+		writeAvatarProblem(w, r, stdhttp.StatusServiceUnavailable, "AVATAR_STORAGE_UNAVAILABLE", "Avatar storage is unavailable")
+		return
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || !supportedAvatarMediaType(mediaType) {
+		writeAvatarProblem(w, r, stdhttp.StatusUnsupportedMediaType, "UNSUPPORTED_AVATAR_MEDIA_TYPE", "Avatar uploads require image/jpeg, image/png, or image/webp")
+		return
+	}
+	metadata, err := h.Avatar.Upload(r.Context(), principal.ID, stdhttp.MaxBytesReader(w, r.Body, avatar.MaxUploadBytes+1))
+	if err != nil {
+		switch {
+		case errors.Is(err, avatar.ErrTooLarge):
+			writeAvatarProblem(w, r, stdhttp.StatusRequestEntityTooLarge, "AVATAR_TOO_LARGE", fmt.Sprintf("Avatar uploads must not exceed %d bytes", avatar.MaxUploadBytes))
+		case errors.Is(err, avatar.ErrInvalid):
+			writeAvatarProblem(w, r, stdhttp.StatusUnprocessableEntity, "INVALID_AVATAR_IMAGE", err.Error())
+		default:
+			writeAvatarProblem(w, r, stdhttp.StatusInternalServerError, "AVATAR_UPLOAD_FAILED", "The avatar could not be stored")
+		}
+		return
+	}
+	auditPayload, err := accessgen.EncodeGenUploadCurrentAvatarAuditPayload(accessgen.GenSchemaCurrentAvatarUploadedAuditPayload{
+		PrincipalId: principal.ID,
+		Sha256:      metadata.SHA256,
+	})
+	if err != nil {
+		writeCommandFailure(w, r, accessgen.GenCommandOperationUploadCurrentAvatar(), err)
+		return
+	}
+	if err := h.completeAvatarCommand(r, accessgen.GenCommandOperationUploadCurrentAvatar(), principal.ID, "principal.avatar.updated", auditPayload); err != nil {
+		writeCommandFailure(w, r, accessgen.GenCommandOperationUploadCurrentAvatar(), err)
+		return
+	}
+	apitransport.WriteJSON(w, stdhttp.StatusOK, avatarResponse(metadata))
+}
+
+func (h Handler) GetPrincipalAvatar(w stdhttp.ResponseWriter, r *stdhttp.Request, principalID, digest string) {
+	if h.Avatar == nil {
+		writeAvatarProblem(w, r, stdhttp.StatusServiceUnavailable, "AVATAR_STORAGE_UNAVAILABLE", "Avatar storage is unavailable")
+		return
+	}
+	reader, metadata, err := h.Avatar.Open(r.Context(), principalID, digest)
+	if err != nil {
+		if errors.Is(err, avatar.ErrNotFound) {
+			writeAvatarProblem(w, r, stdhttp.StatusNotFound, "AVATAR_NOT_FOUND", "The avatar does not exist")
+			return
+		}
+		writeAvatarProblem(w, r, stdhttp.StatusInternalServerError, "AVATAR_READ_FAILED", "The avatar could not be read")
+		return
+	}
+	defer reader.Close()
+	etag := `"` + metadata.SHA256 + `"`
+	w.Header().Set("Content-Type", metadata.MediaType)
+	w.Header().Set("Content-Length", strconv.FormatInt(metadata.SizeBytes, 10))
+	w.Header().Set("Cache-Control", avatarCacheControl)
+	w.Header().Set("ETag", etag)
+	if etagMatches(r.Header.Get("If-None-Match"), etag) {
+		w.WriteHeader(stdhttp.StatusNotModified)
+		return
+	}
+	w.WriteHeader(stdhttp.StatusOK)
+	_, _ = io.Copy(w, reader)
+}
+
+func (h Handler) DeleteCurrentAvatar(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	principal, ok := h.currentPrincipal(r)
+	if !ok {
+		writeAvatarProblem(w, r, stdhttp.StatusUnauthorized, "AUTHENTICATION_REQUIRED", "An authenticated user is required")
+		return
+	}
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	if h.Avatar == nil {
+		writeAvatarProblem(w, r, stdhttp.StatusServiceUnavailable, "AVATAR_STORAGE_UNAVAILABLE", "Avatar storage is unavailable")
+		return
+	}
+	if err := h.Avatar.Delete(r.Context(), principal.ID); err != nil && !errors.Is(err, avatar.ErrNotFound) {
+		writeAvatarProblem(w, r, stdhttp.StatusInternalServerError, "AVATAR_DELETE_FAILED", "The avatar could not be deleted")
+		return
+	}
+	auditPayload, err := accessgen.EncodeGenDeleteCurrentAvatarAuditPayload(accessgen.GenSchemaCurrentAvatarDeletedAuditPayload{PrincipalId: principal.ID})
+	if err != nil {
+		writeCommandFailure(w, r, accessgen.GenCommandOperationDeleteCurrentAvatar(), err)
+		return
+	}
+	if err := h.completeAvatarCommand(r, accessgen.GenCommandOperationDeleteCurrentAvatar(), principal.ID, "principal.avatar.deleted", auditPayload); err != nil {
+		writeCommandFailure(w, r, accessgen.GenCommandOperationDeleteCurrentAvatar(), err)
+		return
+	}
+	w.WriteHeader(stdhttp.StatusNoContent)
+}
+
+func (h Handler) completeAvatarCommand(r *stdhttp.Request, operationID accessgen.GenCommandOperationID, principalID, action, auditPayload string) error {
+	if _, generatedCommand := apigencommand.OperationID(r.Context()); !generatedCommand {
+		return nil
+	}
+	executor, err := apigencommand.NewExecutor(accessgen.GetAPIGenCommandRuntimeContract, nil)
+	if err != nil {
+		return err
+	}
+	return executor.Execute(r.Context(), operationID.APIGenOperationID(), apigencommand.Execution{
+		BestEffortAudit: func(ctx context.Context, contract apigencommand.Contract) error {
+			if contract.AuditAction != action {
+				return fmt.Errorf("generated audit action %q does not match avatar mutation action %q", contract.AuditAction, action)
+			}
+			repository, err := h.repository()
+			if err != nil {
+				return err
+			}
+			return repository.RecordAuditEvent(ctx, access.AuditEventInput{
+				PrincipalID:   principalID,
+				Action:        action,
+				TargetType:    "principal",
+				TargetID:      principalID,
+				Status:        "success",
+				RequestID:     requestIDFromRequest(r),
+				CorrelationID: correlationIDFromRequest(r),
+				MetadataJSON:  auditPayload,
+			})
+		},
+	})
+}
+
+func avatarResponse(value avatar.Metadata) accessgen.AvatarResponse {
+	return accessgen.AvatarResponse{
+		PrincipalId: value.PrincipalID,
+		Sha256:      value.SHA256,
+		MediaType:   value.MediaType,
+		SizeBytes:   value.SizeBytes,
+		Width:       int32(value.Width),
+		Height:      int32(value.Height),
+		UpdatedAt:   normalizeTimestamp(value.UpdatedAt),
+		Url:         avatar.URL(value),
+	}
+}
+
+func supportedAvatarMediaType(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "image/jpeg", "image/png", "image/webp":
+		return true
+	default:
+		return false
+	}
+}
+
+func etagMatches(header, etag string) bool {
+	for _, candidate := range strings.Split(header, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" || candidate == etag || candidate == "W/"+etag {
+			return true
+		}
+	}
+	return false
+}
+
+func writeAvatarProblem(w stdhttp.ResponseWriter, r *stdhttp.Request, status int, code, detail string) {
+	apitransport.WriteProblem(w, r, status, code, detail, nil)
+}

--- a/internal/access/http/avatar_test.go
+++ b/internal/access/http/avatar_test.go
@@ -1,0 +1,119 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	accessgen "github.com/flidai/leapview/internal/access/api/gen"
+	"github.com/flidai/leapview/internal/access/avatar"
+)
+
+func TestUploadCurrentAvatarReturnsContentAddressedMetadata(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	service := &fakeAvatarService{metadata: avatar.Metadata{
+		PrincipalID: "principal_1", SHA256: digest, MediaType: "image/png",
+		SizeBytes: 3, Width: 256, Height: 256, UpdatedAt: "2026-08-08 12:00:00",
+	}}
+	handler := Handler{Avatar: service, CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+		return Principal{ID: "principal_1", Kind: access.PrincipalKindUser}, true
+	}}
+	request := httptest.NewRequest(stdhttp.MethodPut, "/api/v1/me/avatar", bytes.NewBufferString("raw"))
+	recorder := httptest.NewRecorder()
+	handler.UploadCurrentAvatar(recorder, request, "image/jpeg")
+	if recorder.Code != stdhttp.StatusOK || service.uploadedPrincipal != "principal_1" {
+		t.Fatalf("response = %d %s, uploaded principal=%q", recorder.Code, recorder.Body.String(), service.uploadedPrincipal)
+	}
+	var response accessgen.AvatarResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Sha256 != digest || response.Url != "/profile/avatars/principal_1/"+digest || response.MediaType != "image/png" {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestUploadCurrentAvatarRejectsUnsupportedMediaTypeBeforeStorage(t *testing.T) {
+	service := &fakeAvatarService{}
+	handler := Handler{Avatar: service, CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+		return Principal{ID: "principal_1", Kind: access.PrincipalKindUser}, true
+	}}
+	recorder := httptest.NewRecorder()
+	handler.UploadCurrentAvatar(recorder, httptest.NewRequest(stdhttp.MethodPut, "/api/v1/me/avatar", bytes.NewBufferString("svg")), "image/svg+xml")
+	if recorder.Code != stdhttp.StatusUnsupportedMediaType || service.uploadedPrincipal != "" {
+		t.Fatalf("response = %d %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestGetPrincipalAvatarServesImmutablePrivateResponseAndRevalidates(t *testing.T) {
+	digest := strings.Repeat("b", 64)
+	service := &fakeAvatarService{metadata: avatar.Metadata{PrincipalID: "principal_1", SHA256: digest, MediaType: "image/png", SizeBytes: 3, Width: 256, Height: 256}, body: []byte("png")}
+	handler := Handler{Avatar: service}
+
+	request := httptest.NewRequest(stdhttp.MethodGet, "/profile/avatars/principal_1/"+digest, nil)
+	recorder := httptest.NewRecorder()
+	handler.GetPrincipalAvatar(recorder, request, "principal_1", digest)
+	if recorder.Code != stdhttp.StatusOK || recorder.Body.String() != "png" || recorder.Header().Get("ETag") != `"`+digest+`"` || recorder.Header().Get("Cache-Control") != avatarCacheControl {
+		t.Fatalf("response = %d headers=%v body=%q", recorder.Code, recorder.Header(), recorder.Body.String())
+	}
+
+	revalidated := httptest.NewRequest(stdhttp.MethodGet, "/profile/avatars/principal_1/"+digest, nil)
+	revalidated.Header.Set("If-None-Match", `"`+digest+`"`)
+	revalidatedRecorder := httptest.NewRecorder()
+	handler.GetPrincipalAvatar(revalidatedRecorder, revalidated, "principal_1", digest)
+	if revalidatedRecorder.Code != stdhttp.StatusNotModified || revalidatedRecorder.Body.Len() != 0 {
+		t.Fatalf("revalidated response = %d body=%q", revalidatedRecorder.Code, revalidatedRecorder.Body.String())
+	}
+}
+
+func TestDeleteCurrentAvatarIsIdempotent(t *testing.T) {
+	service := &fakeAvatarService{deleteErr: avatar.ErrNotFound}
+	handler := Handler{Avatar: service, CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+		return Principal{ID: "principal_1", Kind: access.PrincipalKindUser}, true
+	}}
+	recorder := httptest.NewRecorder()
+	handler.DeleteCurrentAvatar(recorder, httptest.NewRequest(stdhttp.MethodDelete, "/api/v1/me/avatar", nil))
+	if recorder.Code != stdhttp.StatusNoContent || service.deletedPrincipal != "principal_1" {
+		t.Fatalf("response = %d body=%q deleted=%q", recorder.Code, recorder.Body.String(), service.deletedPrincipal)
+	}
+}
+
+type fakeAvatarService struct {
+	metadata          avatar.Metadata
+	body              []byte
+	uploadErr         error
+	openErr           error
+	deleteErr         error
+	uploadedPrincipal string
+	deletedPrincipal  string
+}
+
+func (s *fakeAvatarService) Upload(_ context.Context, principalID string, _ io.Reader) (avatar.Metadata, error) {
+	s.uploadedPrincipal = principalID
+	return s.metadata, s.uploadErr
+}
+
+func (s *fakeAvatarService) Current(context.Context, string) (avatar.Metadata, error) {
+	if s.openErr != nil {
+		return avatar.Metadata{}, s.openErr
+	}
+	return s.metadata, nil
+}
+
+func (s *fakeAvatarService) Open(context.Context, string, string) (io.ReadCloser, avatar.Metadata, error) {
+	if s.openErr != nil {
+		return nil, avatar.Metadata{}, s.openErr
+	}
+	return io.NopCloser(bytes.NewReader(s.body)), s.metadata, nil
+}
+
+func (s *fakeAvatarService) Delete(_ context.Context, principalID string) error {
+	s.deletedPrincipal = principalID
+	return s.deleteErr
+}

--- a/internal/access/http/current_user_test.go
+++ b/internal/access/http/current_user_test.go
@@ -1,0 +1,249 @@
+package http
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
+)
+
+type currentUserRepository struct {
+	access.Repository
+	principal       access.Principal
+	management      access.PrincipalIdentityManagement
+	audit           access.AuditEventInput
+	password        struct{ current, next string }
+	tokenInput      access.APITokenInput
+	effective       []access.Privilege
+	effectiveObject access.ObjectRef
+}
+
+func (r *currentUserRepository) EffectivePrivileges(_ context.Context, _ string, object access.ObjectRef) ([]access.Privilege, error) {
+	r.effectiveObject = object
+	return r.effective, nil
+}
+
+func (r *currentUserRepository) CreateAPITokenWithMetadata(_ context.Context, input access.APITokenInput) (string, access.APIToken, error) {
+	r.tokenInput = input
+	return "secret", access.APIToken{
+		ID: "token_created", PrincipalID: input.PrincipalID, WorkspaceID: input.WorkspaceID,
+		Name: input.Name, Privileges: input.Privileges, CreatedAt: "2026-08-10T12:00:00Z",
+	}, nil
+}
+
+func (r *currentUserRepository) PrincipalByID(_ context.Context, principalID string) (access.Principal, error) {
+	if principalID != r.principal.ID {
+		return access.Principal{}, sql.ErrNoRows
+	}
+	return r.principal, nil
+}
+
+func (r *currentUserRepository) PrincipalIdentityManagement(_ context.Context, principalID string) (access.PrincipalIdentityManagement, error) {
+	if principalID != r.principal.ID {
+		return access.PrincipalIdentityManagement{}, sql.ErrNoRows
+	}
+	return r.management, nil
+}
+
+func (r *currentUserRepository) UpsertPrincipal(_ context.Context, input access.PrincipalInput) (access.Principal, error) {
+	r.principal.DisplayName = input.DisplayName
+	r.principal.UpdatedAt = "2026-08-10T12:05:00Z"
+	return r.principal, nil
+}
+
+func (r *currentUserRepository) ChangeLocalPassword(_ context.Context, principalID, currentPassword, newPassword string) (access.LocalCredential, error) {
+	if principalID != r.principal.ID || currentPassword != "old-secret" {
+		return access.LocalCredential{}, sql.ErrNoRows
+	}
+	r.password.current, r.password.next = currentPassword, newPassword
+	return access.LocalCredential{PrincipalID: principalID}, nil
+}
+
+func (r *currentUserRepository) RunAuditedMutation(ctx context.Context, mutation func(access.Repository) (access.AuditEventInput, error)) error {
+	event, err := mutation(r)
+	r.audit = event
+	return err
+}
+
+func TestGetCurrentPrincipalReturnsIdentityCapabilitiesAndAvatar(t *testing.T) {
+	repository := &currentUserRepository{
+		principal: access.Principal{
+			ID: "principal_me", Kind: access.PrincipalKindUser, Email: "me@example.com", DisplayName: "Me",
+			CreatedAt: "2026-08-10T12:00:00Z", UpdatedAt: "2026-08-10T12:00:00Z",
+		},
+		management: access.PrincipalIdentityManagement{Source: access.IdentityManagementLocal, HasLocalPassword: true},
+	}
+	digest := strings.Repeat("a", 64)
+	handler := Handler{
+		Repository: func() (access.Repository, error) { return repository, nil },
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+			return Principal{ID: repository.principal.ID, Kind: access.PrincipalKindUser}, true
+		},
+		LocalPasswordEnabled: true,
+		Avatar: &fakeAvatarService{metadata: avatar.Metadata{
+			PrincipalID: repository.principal.ID, SHA256: digest, MediaType: "image/png",
+			SizeBytes: 123, Width: 256, Height: 256, UpdatedAt: "2026-08-10T12:01:00Z",
+		}},
+	}
+	response := httptest.NewRecorder()
+	handler.GetCurrentPrincipal(response, httptest.NewRequest(stdhttp.MethodGet, "/api/v1/me", nil))
+	if response.Code != stdhttp.StatusOK || response.Header().Get("ETag") == "" {
+		t.Fatalf("response = %d headers=%v body=%s", response.Code, response.Header(), response.Body.String())
+	}
+	var body struct {
+		IdentityManagement struct {
+			Source   string `json:"source"`
+			Provider string `json:"provider"`
+		} `json:"identityManagement"`
+		Capabilities map[string]bool `json:"capabilities"`
+		Avatar       struct {
+			SHA256 string `json:"sha256"`
+			URL    string `json:"url"`
+		} `json:"avatar"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.IdentityManagement.Source != "local" || body.IdentityManagement.Provider != "" {
+		t.Fatalf("identity management = %#v", body.IdentityManagement)
+	}
+	for _, capability := range []string{"canUpdateDisplayName", "canChangePassword", "canManageAvatar", "canManageSessions", "canManageApiTokens"} {
+		if !body.Capabilities[capability] {
+			t.Fatalf("capability %q = false; body=%s", capability, response.Body.String())
+		}
+	}
+	if body.Capabilities["canManageAuthoringSessions"] {
+		t.Fatalf("authoring sessions unexpectedly available; body=%s", response.Body.String())
+	}
+	if body.Avatar.SHA256 != digest || body.Avatar.URL == "" {
+		t.Fatalf("avatar = %#v", body.Avatar)
+	}
+}
+
+func TestUpdateCurrentPrincipalRequiresSelfManagedIdentityAndCurrentETag(t *testing.T) {
+	repository := &currentUserRepository{
+		principal: access.Principal{
+			ID: "principal_me", Kind: access.PrincipalKindUser, Email: "me@example.com", DisplayName: "Before",
+			CreatedAt: "2026-08-10T12:00:00Z", UpdatedAt: "2026-08-10T12:00:00Z",
+		},
+		management: access.PrincipalIdentityManagement{Source: access.IdentityManagementLocal, HasLocalPassword: true},
+	}
+	handler := Handler{
+		Repository: func() (access.Repository, error) { return repository, nil },
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+			return Principal{ID: repository.principal.ID, Kind: access.PrincipalKindUser}, true
+		},
+		LocalPasswordEnabled: true,
+	}
+	getResponse := httptest.NewRecorder()
+	handler.GetCurrentPrincipal(getResponse, httptest.NewRequest(stdhttp.MethodGet, "/api/v1/me", nil))
+
+	request := httptest.NewRequest(stdhttp.MethodPatch, "/api/v1/me", strings.NewReader(`{"displayName":"After"}`))
+	request.Header.Set("If-Match", getResponse.Header().Get("ETag"))
+	response := httptest.NewRecorder()
+	handler.UpdateCurrentPrincipal(response, request)
+	if response.Code != stdhttp.StatusOK || repository.principal.DisplayName != "After" {
+		t.Fatalf("response = %d body=%s principal=%#v", response.Code, response.Body.String(), repository.principal)
+	}
+	if repository.audit.Action != "principal.profile.updated" || repository.audit.PrincipalID != repository.principal.ID {
+		t.Fatalf("audit = %#v", repository.audit)
+	}
+
+	repository.management = access.PrincipalIdentityManagement{Source: access.IdentityManagementExternal, Provider: "scim"}
+	denied := httptest.NewRecorder()
+	deniedRequest := httptest.NewRequest(stdhttp.MethodPatch, "/api/v1/me", strings.NewReader(`{"displayName":"Provider owned"}`))
+	deniedRequest.Header.Set("If-Match", "*")
+	handler.UpdateCurrentPrincipal(denied, deniedRequest)
+	if denied.Code != stdhttp.StatusUnprocessableEntity || repository.principal.DisplayName != "After" {
+		t.Fatalf("external update = %d body=%s principal=%#v", denied.Code, denied.Body.String(), repository.principal)
+	}
+}
+
+func TestChangeCurrentPasswordIsAvailableOnlyForLocalCredential(t *testing.T) {
+	repository := &currentUserRepository{
+		principal:  access.Principal{ID: "principal_me", Kind: access.PrincipalKindUser},
+		management: access.PrincipalIdentityManagement{Source: access.IdentityManagementLocal, HasLocalPassword: true},
+	}
+	handler := Handler{
+		Repository: func() (access.Repository, error) { return repository, nil },
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+			return Principal{ID: repository.principal.ID, Kind: access.PrincipalKindUser}, true
+		},
+		LocalPasswordEnabled: true,
+	}
+	request := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/me/password", strings.NewReader(`{"currentPassword":"old-secret","newPassword":"new-secret"}`))
+	response := httptest.NewRecorder()
+	handler.ChangeCurrentPassword(response, request)
+	if response.Code != stdhttp.StatusNoContent || repository.password.next != "new-secret" {
+		t.Fatalf("response = %d body=%s password=%#v", response.Code, response.Body.String(), repository.password)
+	}
+	if repository.audit.Action != "password.changed" {
+		t.Fatalf("audit = %#v", repository.audit)
+	}
+
+	wrong := httptest.NewRecorder()
+	handler.ChangeCurrentPassword(wrong, httptest.NewRequest(stdhttp.MethodPost, "/api/v1/me/password", strings.NewReader(`{"currentPassword":"wrong","newPassword":"other"}`)))
+	if wrong.Code != stdhttp.StatusUnauthorized || !strings.Contains(wrong.Body.String(), "unauthorized") || strings.Contains(wrong.Body.String(), "no rows") {
+		t.Fatalf("wrong-current-password response = %d body=%s", wrong.Code, wrong.Body.String())
+	}
+
+	repository.management = access.PrincipalIdentityManagement{Source: access.IdentityManagementExternal, Provider: "azure"}
+	denied := httptest.NewRecorder()
+	handler.ChangeCurrentPassword(denied, httptest.NewRequest(stdhttp.MethodPost, "/api/v1/me/password", strings.NewReader(`{"currentPassword":"old-secret","newPassword":"other"}`)))
+	if denied.Code != stdhttp.StatusUnprocessableEntity {
+		t.Fatalf("external password change = %d body=%s", denied.Code, denied.Body.String())
+	}
+}
+
+func TestCreateCurrentAPITokenValidatesAndAttenuatesCredentialScope(t *testing.T) {
+	repository := &currentUserRepository{
+		principal: access.Principal{ID: "principal_me", Kind: access.PrincipalKindUser},
+		effective: []access.Privilege{access.PrivilegeViewData},
+	}
+	handler := Handler{
+		Repository: func() (access.Repository, error) { return repository, nil },
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+			return Principal{ID: repository.principal.ID, Kind: access.PrincipalKindUser}, true
+		},
+	}
+	invalid := httptest.NewRecorder()
+	handler.CreateCurrentAPIToken(invalid, httptest.NewRequest(stdhttp.MethodPost, "/api/v1/me/api-tokens", strings.NewReader(`{"name":"invalid","privileges":["NOT_A_PRIVILEGE"]}`)))
+	if invalid.Code != stdhttp.StatusBadRequest || repository.tokenInput.Name != "" {
+		t.Fatalf("invalid token create = %d body=%s input=%#v", invalid.Code, invalid.Body.String(), repository.tokenInput)
+	}
+
+	absent := httptest.NewRecorder()
+	handler.CreateCurrentAPIToken(absent, httptest.NewRequest(stdhttp.MethodPost, "/api/v1/me/api-tokens", strings.NewReader(`{"name":"absent","workspaceId":"alpha","privileges":["USE_AGENT"]}`)))
+	if absent.Code != stdhttp.StatusForbidden || repository.tokenInput.Name != "" || repository.effectiveObject != access.WorkspaceObject("alpha") {
+		t.Fatalf("absent-effective-privilege token create = %d body=%s input=%#v", absent.Code, absent.Body.String(), repository.tokenInput)
+	}
+
+	handler.CurrentCredential = func(*stdhttp.Request) (access.APICredential, bool) {
+		return access.APICredential{Token: access.APIToken{
+			ID: "token_parent", WorkspaceID: "alpha", Privileges: []access.Privilege{access.PrivilegeViewData},
+		}}, true
+	}
+	broader := httptest.NewRecorder()
+	handler.CreateCurrentAPIToken(broader, httptest.NewRequest(stdhttp.MethodPost, "/api/v1/me/api-tokens", strings.NewReader(`{"name":"broader","workspaceId":"alpha","privileges":["USE_AGENT"]}`)))
+	if broader.Code != stdhttp.StatusForbidden || repository.tokenInput.Name != "" {
+		t.Fatalf("broader token create = %d body=%s input=%#v", broader.Code, broader.Body.String(), repository.tokenInput)
+	}
+
+	empty := httptest.NewRecorder()
+	handler.CreateCurrentAPIToken(empty, httptest.NewRequest(stdhttp.MethodPost, "/api/v1/me/api-tokens", strings.NewReader(`{"name":"empty-child","workspaceId":"alpha","privileges":[]}`)))
+	if empty.Code != stdhttp.StatusCreated || repository.tokenInput.Name != "empty-child" || repository.tokenInput.Privileges == nil || len(repository.tokenInput.Privileges) != 0 {
+		t.Fatalf("empty child token create = %d body=%s input=%#v", empty.Code, empty.Body.String(), repository.tokenInput)
+	}
+
+	allowed := httptest.NewRecorder()
+	handler.CreateCurrentAPIToken(allowed, httptest.NewRequest(stdhttp.MethodPost, "/api/v1/me/api-tokens", strings.NewReader(`{"name":"child","workspaceId":"alpha","privileges":["VIEW_DATA"]}`)))
+	if allowed.Code != stdhttp.StatusCreated || repository.tokenInput.Name != "child" || len(repository.tokenInput.Privileges) != 1 || repository.tokenInput.Privileges[0] != access.PrivilegeViewData {
+		t.Fatalf("allowed token create = %d body=%s input=%#v", allowed.Code, allowed.Body.String(), repository.tokenInput)
+	}
+}

--- a/internal/access/http/handler.go
+++ b/internal/access/http/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/flidai/leapview/internal/access"
 	accessapi "github.com/flidai/leapview/internal/access/api"
 	accessgen "github.com/flidai/leapview/internal/access/api/gen"
+	"github.com/flidai/leapview/internal/access/avatar"
 	httpmodel "github.com/flidai/leapview/internal/platform/http/model"
 	apitransport "github.com/flidai/leapview/internal/platform/http/transport"
 	"github.com/go-chi/chi/v5"
@@ -42,6 +43,7 @@ type Principal struct {
 type RepositoryProvider func() (access.Repository, error)
 type PrincipalProvider func(*stdhttp.Request) (Principal, bool)
 type CredentialProvider func(*stdhttp.Request) (access.APICredential, bool)
+type SessionProvider func(*stdhttp.Request) (string, bool)
 type WorkspaceIDNormalizer func(string) string
 
 type AuthoringAuthentication interface {
@@ -58,13 +60,16 @@ type AuthoringAuthentication interface {
 }
 
 type Handler struct {
-	Repository          RepositoryProvider
-	RoleBindingCommands access.RoleBindingCommander
-	GrantCommands       access.GrantCommander
-	CurrentPrincipal    PrincipalProvider
-	CurrentCredential   CredentialProvider
-	WorkspaceID         WorkspaceIDNormalizer
-	AuthoringAuth       AuthoringAuthentication
+	Repository           RepositoryProvider
+	RoleBindingCommands  access.RoleBindingCommander
+	GrantCommands        access.GrantCommander
+	CurrentPrincipal     PrincipalProvider
+	CurrentCredential    CredentialProvider
+	CurrentSession       SessionProvider
+	WorkspaceID          WorkspaceIDNormalizer
+	AuthoringAuth        AuthoringAuthentication
+	Avatar               AvatarService
+	LocalPasswordEnabled bool
 }
 
 func (h Handler) GetCurrentPrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request) {
@@ -73,15 +78,144 @@ func (h Handler) GetCurrentPrincipal(w stdhttp.ResponseWriter, r *stdhttp.Reques
 		writeJSONError(w, fmt.Errorf("authenticated principal is required"), stdhttp.StatusUnauthorized)
 		return
 	}
-	if h.Repository != nil {
-		if repo, err := h.repository(); err == nil {
-			if stored, err := repo.PrincipalByID(r.Context(), principal.ID); err == nil {
-				writeJSON(w, stdhttp.StatusOK, principalDTO(stored))
-				return
-			}
-		}
+	response, err := h.currentPrincipalResponse(r, principal)
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusInternalServerError)
+		return
 	}
-	writeJSON(w, stdhttp.StatusOK, currentPrincipalDTO(principal))
+	w.Header().Set("ETag", resourceETag(response))
+	writeJSON(w, stdhttp.StatusOK, response)
+}
+
+func (h Handler) UpdateCurrentPrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	current, ok := h.currentPrincipal(r)
+	if !ok {
+		writeJSONError(w, fmt.Errorf("authenticated principal is required"), stdhttp.StatusUnauthorized)
+		return
+	}
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	var input struct {
+		DisplayName *string `json:"displayName"`
+	}
+	if err := decodeStrictJSON(r, &input); err != nil {
+		writeJSONError(w, err, stdhttp.StatusBadRequest)
+		return
+	}
+	if input.DisplayName == nil {
+		writeJSONError(w, fmt.Errorf("displayName is required"), stdhttp.StatusBadRequest)
+		return
+	}
+	displayName := strings.TrimSpace(*input.DisplayName)
+	if displayName == "" || len(displayName) > 200 {
+		writeJSONError(w, fmt.Errorf("displayName must contain between 1 and 200 bytes"), stdhttp.StatusBadRequest)
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusInternalServerError)
+		return
+	}
+	existing, err := repo.PrincipalByID(r.Context(), current.ID)
+	if err != nil {
+		writeJSONError(w, err, statusForNotFound(err))
+		return
+	}
+	management, err := principalIdentityManagement(r.Context(), repo, existing.ID)
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusInternalServerError)
+		return
+	}
+	if management.Source != access.IdentityManagementLocal {
+		writeJSONError(w, fmt.Errorf("display name is managed by the identity provider"), stdhttp.StatusUnprocessableEntity)
+		return
+	}
+	currentResponse, err := h.currentPrincipalResponseFor(r.Context(), existing, management, repo, true)
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusInternalServerError)
+		return
+	}
+	if !requireIfMatch(w, r, resourceETag(currentResponse)) {
+		return
+	}
+	var updated access.Principal
+	err = runAuditedMutation(r, repo, func(txRepo access.Repository) (access.AuditEventInput, error) {
+		var mutationErr error
+		updated, mutationErr = txRepo.UpsertPrincipal(r.Context(), access.PrincipalInput{
+			ID: existing.ID, Kind: existing.Kind, Email: existing.Email, DisplayName: displayName,
+		})
+		return commandAccessAuditInput(r, "principal.profile.updated", existing.ID, "", "principal", existing.ID, "", "success", map[string]any{
+			"email": existing.Email, "displayName": displayName,
+		}, mutationErr)
+	})
+	if err != nil {
+		writeAuditedMutationError(w, r, accessgen.GenCommandOperationUpdateCurrentPrincipal(), err, stdhttp.StatusBadRequest)
+		return
+	}
+	response, err := h.currentPrincipalResponseFor(r.Context(), updated, management, repo, true)
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("ETag", resourceETag(response))
+	writeJSON(w, stdhttp.StatusOK, response)
+}
+
+func (h Handler) ChangeCurrentPassword(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	principal, ok := h.currentPrincipal(r)
+	if !ok {
+		writeJSONError(w, fmt.Errorf("authenticated principal is required"), stdhttp.StatusUnauthorized)
+		return
+	}
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	var input struct {
+		CurrentPassword string `json:"currentPassword"`
+		NewPassword     string `json:"newPassword"`
+	}
+	if err := decodeStrictJSON(r, &input); err != nil {
+		writeJSONError(w, err, stdhttp.StatusBadRequest)
+		return
+	}
+	if input.CurrentPassword == "" || input.NewPassword == "" {
+		writeJSONError(w, fmt.Errorf("currentPassword and newPassword are required"), stdhttp.StatusBadRequest)
+		return
+	}
+	if input.CurrentPassword == input.NewPassword {
+		writeJSONError(w, fmt.Errorf("newPassword must differ from currentPassword"), stdhttp.StatusBadRequest)
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusInternalServerError)
+		return
+	}
+	management, err := principalIdentityManagement(r.Context(), repo, principal.ID)
+	if err != nil {
+		writeJSONError(w, err, statusForNotFound(err))
+		return
+	}
+	if !h.LocalPasswordEnabled || !management.HasLocalPassword {
+		writeJSONError(w, fmt.Errorf("local password changes are unavailable for this principal"), stdhttp.StatusUnprocessableEntity)
+		return
+	}
+	err = runAuditedMutation(r, repo, func(txRepo access.Repository) (access.AuditEventInput, error) {
+		_, mutationErr := txRepo.ChangeLocalPassword(r.Context(), principal.ID, input.CurrentPassword, input.NewPassword)
+		return commandAccessAuditInput(r, "password.changed", principal.ID, "", "principal", principal.ID, "", "success", map[string]any{
+			"email": principal.Email, "provider": "local",
+		}, mutationErr)
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeJSONError(w, errUnauthorized, stdhttp.StatusUnauthorized)
+			return
+		}
+		writeAuditedMutationError(w, r, accessgen.GenCommandOperationChangeCurrentPassword(), err, stdhttp.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(stdhttp.StatusNoContent)
 }
 
 func (h Handler) ListCurrentEffectivePrivileges(w stdhttp.ResponseWriter, r *stdhttp.Request) {
@@ -117,6 +251,13 @@ func (h Handler) ListCurrentAPITokens(w stdhttp.ResponseWriter, r *stdhttp.Reque
 		writeJSONError(w, fmt.Errorf("authenticated principal is required"), stdhttp.StatusUnauthorized)
 		return
 	}
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	if principal.Kind != "" && principal.Kind != access.PrincipalKindUser {
+		writeJSONError(w, fmt.Errorf("personal API tokens are only available to user principals"), stdhttp.StatusForbidden)
+		return
+	}
 	repo, err := h.repository()
 	if err != nil {
 		writeJSONError(w, err, stdhttp.StatusInternalServerError)
@@ -140,6 +281,13 @@ func (h Handler) CreateCurrentAPIToken(w stdhttp.ResponseWriter, r *stdhttp.Requ
 		writeCommandFailure(w, r, accessgen.GenCommandOperationCreateCurrentAPIToken(), fmt.Errorf("authenticated principal is required"))
 		return
 	}
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	if principal.Kind != "" && principal.Kind != access.PrincipalKindUser {
+		writeJSONError(w, fmt.Errorf("personal API tokens are only available to user principals"), stdhttp.StatusForbidden)
+		return
+	}
 	var input struct {
 		Name        string   `json:"name"`
 		WorkspaceID string   `json:"workspaceId"`
@@ -159,10 +307,58 @@ func (h Handler) CreateCurrentAPIToken(w stdhttp.ResponseWriter, r *stdhttp.Requ
 		}
 		expiresAt = parsed
 	}
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	requestedPrivileges := privilegesFromStrings(input.Privileges)
+	if input.Privileges == nil {
+		requestedPrivileges = nil
+	}
+	for _, privilege := range requestedPrivileges {
+		if !knownPrivilege(privilege) {
+			writeJSONError(w, fmt.Errorf("unsupported API token privilege %q", privilege), stdhttp.StatusBadRequest)
+			return
+		}
+	}
+	if credential, ok := h.currentCredential(r); ok && credential.Token.ID != "" {
+		if credential.Token.WorkspaceID != "" && credential.Token.WorkspaceID != input.WorkspaceID {
+			writeJSONError(w, fmt.Errorf("API tokens cannot create credentials outside their workspace scope"), stdhttp.StatusForbidden)
+			return
+		}
+		if credential.Token.Privileges != nil && input.Privileges == nil {
+			writeJSONError(w, fmt.Errorf("API tokens cannot create credentials broader than their privilege scope"), stdhttp.StatusForbidden)
+			return
+		}
+		for _, privilege := range requestedPrivileges {
+			if !apiTokenAllows(credential.Token, input.WorkspaceID, privilege) {
+				writeJSONError(w, fmt.Errorf("API tokens cannot create credentials broader than their privilege scope"), stdhttp.StatusForbidden)
+				return
+			}
+		}
+	}
 	repo, err := h.repository()
 	if err != nil {
 		writeCommandFailure(w, r, accessgen.GenCommandOperationCreateCurrentAPIToken(), err)
 		return
+	}
+	if len(requestedPrivileges) > 0 {
+		target := access.PlatformObject()
+		if input.WorkspaceID != "" {
+			target = access.WorkspaceObject(input.WorkspaceID)
+		}
+		effective, effectiveErr := repo.EffectivePrivileges(r.Context(), principal.ID, target)
+		if effectiveErr != nil {
+			writeJSONError(w, effectiveErr, stdhttp.StatusInternalServerError)
+			return
+		}
+		allowed := make(map[access.Privilege]struct{}, len(effective))
+		for _, privilege := range effective {
+			allowed[privilege] = struct{}{}
+		}
+		for _, privilege := range requestedPrivileges {
+			if _, ok := allowed[privilege]; !ok {
+				writeJSONError(w, fmt.Errorf("requested API token privileges exceed the principal's effective privileges"), stdhttp.StatusForbidden)
+				return
+			}
+		}
 	}
 	var token string
 	var row access.APIToken
@@ -170,7 +366,7 @@ func (h Handler) CreateCurrentAPIToken(w stdhttp.ResponseWriter, r *stdhttp.Requ
 		var mutationErr error
 		token, row, mutationErr = txRepo.CreateAPITokenWithMetadata(r.Context(), access.APITokenInput{
 			PrincipalID: principal.ID, WorkspaceID: input.WorkspaceID, Name: input.Name,
-			Privileges: privilegesFromStrings(input.Privileges), ExpiresAt: expiresAt,
+			Privileges: requestedPrivileges, ExpiresAt: expiresAt,
 		})
 		return commandAccessAuditInput(r, "api_token.created", principal.ID, row.WorkspaceID, "api_token", row.ID, access.PrivilegeManageGrants, "success", map[string]any{"name": row.Name, "privileges": row.Privileges}, mutationErr)
 	})
@@ -185,6 +381,13 @@ func (h Handler) RevokeCurrentAPIToken(w stdhttp.ResponseWriter, r *stdhttp.Requ
 	principal, ok := h.currentPrincipal(r)
 	if !ok {
 		writeCommandFailure(w, r, accessgen.GenCommandOperationRevokeCurrentAPIToken(), fmt.Errorf("authenticated principal is required"))
+		return
+	}
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	if principal.Kind != "" && principal.Kind != access.PrincipalKindUser {
+		writeJSONError(w, fmt.Errorf("personal API tokens are only available to user principals"), stdhttp.StatusForbidden)
 		return
 	}
 	repo, err := h.repository()
@@ -219,6 +422,9 @@ func (h Handler) ListCurrentSessions(w stdhttp.ResponseWriter, r *stdhttp.Reques
 		writeJSONError(w, fmt.Errorf("authenticated principal is required"), stdhttp.StatusUnauthorized)
 		return
 	}
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
 	h.listPrincipalSessions(w, r, principal.ID)
 }
 
@@ -238,8 +444,12 @@ func (h Handler) listPrincipalSessions(w stdhttp.ResponseWriter, r *stdhttp.Requ
 		return
 	}
 	out := make([]map[string]any, 0, len(rows))
+	currentSessionID := ""
+	if current, ok := h.currentPrincipal(r); ok && current.ID == principalID && h.CurrentSession != nil {
+		currentSessionID, _ = h.CurrentSession(r)
+	}
 	for _, row := range rows {
-		out = append(out, sessionDTO(row))
+		out = append(out, sessionDTOFor(row, currentSessionID))
 	}
 	_ = writePagedJSON(w, r, out)
 }
@@ -248,6 +458,9 @@ func (h Handler) RevokeCurrentSession(w stdhttp.ResponseWriter, r *stdhttp.Reque
 	principal, ok := h.currentPrincipal(r)
 	if !ok {
 		writeCommandFailure(w, r, accessgen.GenCommandOperationRevokeCurrentSession(), fmt.Errorf("authenticated principal is required"))
+		return
+	}
+	if h.rejectAuthoringCredential(w, r) {
 		return
 	}
 	h.revokePrincipalSession(w, r, accessgen.GenCommandOperationRevokeCurrentSession(), principal.ID, principal.ID, access.PrivilegeUseWorkspace, nil)
@@ -416,6 +629,10 @@ func (h Handler) DeletePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		writeCommandFailure(w, r, accessgen.GenCommandOperationDeletePrincipal(), apigenfailure.New("invalid", fmt.Sprintf("principal kind %q is managed by its owning subsystem", existing.Kind)))
 		return
 	}
+	if existing.ID == h.currentPrincipalID(r) {
+		writeCommandFailure(w, r, accessgen.GenCommandOperationDeletePrincipal(), apigenfailure.New("invalid", "the current principal cannot delete itself"))
+		return
+	}
 	if _, ok := repo.(interface {
 		DeletePrincipal(context.Context, string) error
 	}); !ok {
@@ -435,10 +652,79 @@ func (h Handler) DeletePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		}, mutationErr)
 	})
 	if err != nil {
-		writeAuditedMutationError(w, r, accessgen.GenCommandOperationDeletePrincipal(), err, statusForNotFound(err))
+		writeAuditedMutationError(w, r, accessgen.GenCommandOperationDeletePrincipal(), err, principalDeletionStatus(err))
 		return
 	}
 	w.WriteHeader(stdhttp.StatusNoContent)
+}
+
+func (h Handler) DisablePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.setPrincipalDisabled(w, r, true)
+}
+
+func (h Handler) EnablePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.setPrincipalDisabled(w, r, false)
+}
+
+func (h Handler) setPrincipalDisabled(w stdhttp.ResponseWriter, r *stdhttp.Request, disabled bool) {
+	operationID := accessgen.GenCommandOperationDisablePrincipal()
+	if !disabled {
+		operationID = accessgen.GenCommandOperationEnablePrincipal()
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusInternalServerError)
+		return
+	}
+	id := chi.URLParam(r, "principal")
+	existing, err := repo.PrincipalByID(r.Context(), id)
+	if err != nil {
+		writeJSONError(w, err, statusForNotFound(err))
+		return
+	}
+	if !principalKindAllowsGenericMutation(existing.Kind) {
+		writeJSONError(w, fmt.Errorf("principal kind %q is managed by its owning subsystem", existing.Kind), stdhttp.StatusUnprocessableEntity)
+		return
+	}
+	if disabled && existing.ID == h.currentPrincipalID(r) {
+		writeJSONError(w, fmt.Errorf("the current principal cannot disable itself"), stdhttp.StatusUnprocessableEntity)
+		return
+	}
+	type principalStatusWriter interface {
+		DisablePrincipal(context.Context, string) (access.Principal, error)
+		EnablePrincipal(context.Context, string) (access.Principal, error)
+	}
+	if _, ok := repo.(principalStatusWriter); !ok {
+		writeJSONError(w, fmt.Errorf("principal status changes are unavailable"), stdhttp.StatusServiceUnavailable)
+		return
+	}
+	action := "principal.disabled"
+	if !disabled {
+		action = "principal.enabled"
+	}
+	var updated access.Principal
+	err = runAuditedMutation(r, repo, func(txRepo access.Repository) (access.AuditEventInput, error) {
+		writer, ok := txRepo.(principalStatusWriter)
+		if !ok {
+			return access.AuditEventInput{}, fmt.Errorf("principal status changes are unavailable")
+		}
+		var mutationErr error
+		if disabled {
+			updated, mutationErr = writer.DisablePrincipal(r.Context(), id)
+		} else {
+			updated, mutationErr = writer.EnablePrincipal(r.Context(), id)
+		}
+		return commandAccessAuditInput(r, action, h.currentPrincipalID(r), "", "principal", id, access.PrivilegeManageGrants, "success", map[string]any{
+			"email": existing.Email, "kind": string(existing.Kind), "displayName": existing.DisplayName,
+		}, mutationErr)
+	})
+	if err != nil {
+		writeAuditedMutationError(w, r, operationID, err, statusForNotFound(err))
+		return
+	}
+	dto := principalDTO(updated)
+	w.Header().Set("ETag", resourceETag(dto))
+	writeJSON(w, stdhttp.StatusOK, dto)
 }
 
 func (h Handler) ResetPrincipalPassword(w stdhttp.ResponseWriter, r *stdhttp.Request) {
@@ -706,7 +992,7 @@ func (h Handler) DeleteServicePrincipal(w stdhttp.ResponseWriter, r *stdhttp.Req
 		return commandAccessAuditInput(r, "service_principal.deleted", principal.ID, "", "service_principal", id, access.PrivilegeManagePlatform, "success", nil, mutationErr)
 	})
 	if err != nil {
-		writeAuditedMutationError(w, r, accessgen.GenCommandOperationDeleteServicePrincipal(), err, statusForNotFound(err))
+		writeAuditedMutationError(w, r, accessgen.GenCommandOperationDeleteServicePrincipal(), err, principalDeletionStatus(err))
 		return
 	}
 	w.WriteHeader(stdhttp.StatusNoContent)
@@ -1649,6 +1935,18 @@ func (h Handler) grantInvocation(r *stdhttp.Request) access.GrantInvocation {
 }
 
 func (h Handler) ListAuditEvents(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.listAuditEvents(w, r, h.workspaceID(chi.URLParam(r, "workspace")))
+}
+
+func (h Handler) ListPlatformAuditEvents(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	workspaceID := strings.TrimSpace(r.URL.Query().Get("workspace"))
+	if workspaceID != "" {
+		workspaceID = h.workspaceID(workspaceID)
+	}
+	h.listAuditEvents(w, r, workspaceID)
+}
+
+func (h Handler) listAuditEvents(w stdhttp.ResponseWriter, r *stdhttp.Request, workspaceID string) {
 	repo, err := h.repository()
 	if err != nil {
 		writeJSONError(w, err, stdhttp.StatusInternalServerError)
@@ -1660,7 +1958,7 @@ func (h Handler) ListAuditEvents(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 	}
 	cursorTime, cursorID := decodeCursor(r.URL.Query().Get("pageToken"))
 	rows, err := repo.ListAuditEvents(r.Context(), access.AuditEventFilter{
-		WorkspaceID: h.workspaceID(chi.URLParam(r, "workspace")),
+		WorkspaceID: workspaceID,
 		PrincipalID: r.URL.Query().Get("actor"),
 		Action:      r.URL.Query().Get("action"),
 		TargetType:  r.URL.Query().Get("targetType"),
@@ -1717,6 +2015,15 @@ func (h Handler) currentCredential(r *stdhttp.Request) (access.APICredential, bo
 	return h.CurrentCredential(r)
 }
 
+func (h Handler) rejectAuthoringCredential(w stdhttp.ResponseWriter, r *stdhttp.Request) bool {
+	credential, ok := h.currentCredential(r)
+	if !ok || credential.Authoring == nil {
+		return false
+	}
+	writeJSONError(w, fmt.Errorf("authoring credentials cannot manage personal account security"), stdhttp.StatusForbidden)
+	return true
+}
+
 func (h Handler) workspaceID(value string) string {
 	if h.WorkspaceID == nil {
 		return strings.TrimSpace(value)
@@ -1725,7 +2032,11 @@ func (h Handler) workspaceID(value string) string {
 }
 
 func principalDTO(row access.Principal) map[string]any {
-	return map[string]any{"id": row.ID, "kind": string(row.Kind), "email": row.Email, "displayName": row.DisplayName, "createdAt": normalizeTimestamp(row.CreatedAt), "updatedAt": normalizeTimestamp(row.UpdatedAt)}
+	dto := map[string]any{"id": row.ID, "kind": string(row.Kind), "email": row.Email, "displayName": row.DisplayName, "createdAt": normalizeTimestamp(row.CreatedAt), "updatedAt": normalizeTimestamp(row.UpdatedAt)}
+	if row.DisabledAt != "" {
+		dto["disabledAt"] = normalizeTimestamp(row.DisabledAt)
+	}
+	return dto
 }
 
 func localPasswordResetDTO(row access.LocalPasswordReset) map[string]any {
@@ -1738,6 +2049,76 @@ func currentPrincipalDTO(row Principal) map[string]any {
 		kind = access.PrincipalKindUser
 	}
 	return map[string]any{"id": row.ID, "kind": string(kind), "email": row.Email, "displayName": row.DisplayName, "createdAt": normalizeTimestamp(row.CreatedAt), "updatedAt": normalizeTimestamp(row.UpdatedAt)}
+}
+
+func (h Handler) currentPrincipalResponse(r *stdhttp.Request, current Principal) (map[string]any, error) {
+	ctx := r.Context()
+	accountManagement := true
+	if credential, ok := h.currentCredential(r); ok && credential.Authoring != nil {
+		accountManagement = false
+	}
+	if h.Repository == nil {
+		return h.currentPrincipalResponseFor(ctx, access.Principal{
+			ID: current.ID, Kind: current.Kind, Email: current.Email, DisplayName: current.DisplayName,
+			CreatedAt: current.CreatedAt, UpdatedAt: current.UpdatedAt,
+		}, access.PrincipalIdentityManagement{Source: access.IdentityManagementSystem}, nil, accountManagement)
+	}
+	repo, err := h.repository()
+	if err != nil {
+		return nil, err
+	}
+	stored, err := repo.PrincipalByID(ctx, current.ID)
+	if err != nil {
+		return nil, err
+	}
+	management, err := principalIdentityManagement(ctx, repo, stored.ID)
+	if err != nil {
+		return nil, err
+	}
+	return h.currentPrincipalResponseFor(ctx, stored, management, repo, accountManagement)
+}
+
+func (h Handler) currentPrincipalResponseFor(
+	ctx context.Context,
+	principal access.Principal,
+	management access.PrincipalIdentityManagement,
+	repo access.Repository,
+	accountManagement bool,
+) (map[string]any, error) {
+	response := principalDTO(principal)
+	identity := map[string]any{"source": management.Source}
+	if management.Provider != "" {
+		identity["provider"] = management.Provider
+	}
+	response["identityManagement"] = identity
+	isUser := principal.Kind == "" || principal.Kind == access.PrincipalKindUser
+	response["capabilities"] = map[string]bool{
+		"canUpdateDisplayName":       accountManagement && isUser && management.Source == access.IdentityManagementLocal,
+		"canChangePassword":          accountManagement && isUser && h.LocalPasswordEnabled && management.HasLocalPassword,
+		"canManageAvatar":            accountManagement && isUser && h.Avatar != nil,
+		"canManageSessions":          accountManagement && isUser && repo != nil,
+		"canManageAuthoringSessions": isUser && h.AuthoringAuth != nil,
+		"canManageApiTokens":         accountManagement && isUser && repo != nil,
+	}
+	if h.Avatar != nil && isUser {
+		metadata, err := h.Avatar.Current(ctx, principal.ID)
+		switch {
+		case err == nil:
+			response["avatar"] = avatarResponse(metadata)
+		case errors.Is(err, avatar.ErrNotFound):
+		default:
+			return nil, err
+		}
+	}
+	return response, nil
+}
+
+func principalIdentityManagement(ctx context.Context, repo access.Repository, principalID string) (access.PrincipalIdentityManagement, error) {
+	resolver, ok := repo.(access.PrincipalIdentityManagementRepository)
+	if !ok {
+		return access.PrincipalIdentityManagement{Source: access.IdentityManagementSystem}, nil
+	}
+	return resolver.PrincipalIdentityManagement(ctx, principalID)
 }
 
 func normalizeTimestamp(value string) string {
@@ -1833,7 +2214,11 @@ func authorizationDecisionDTO(row access.AuthorizationDecision) map[string]any {
 }
 
 func apiTokenDTO(row access.APIToken) map[string]any {
-	return map[string]any{"id": row.ID, "name": row.Name, "workspaceId": row.WorkspaceID, "privileges": row.Privileges, "expiresAt": emptyToNil(row.ExpiresAt), "revokedAt": emptyToNil(row.RevokedAt), "createdAt": row.CreatedAt, "lastUsedAt": emptyToNil(row.LastUsedAt)}
+	dto := map[string]any{"id": row.ID, "name": row.Name, "workspaceId": row.WorkspaceID, "expiresAt": emptyToNil(row.ExpiresAt), "revokedAt": emptyToNil(row.RevokedAt), "createdAt": row.CreatedAt, "lastUsedAt": emptyToNil(row.LastUsedAt)}
+	if row.Privileges != nil {
+		dto["privileges"] = row.Privileges
+	}
+	return dto
 }
 
 func servicePrincipalSecretDTO(row access.ServicePrincipalSecret, rawSecret string) map[string]any {
@@ -1852,9 +2237,14 @@ func servicePrincipalSecretDTO(row access.ServicePrincipalSecret, rawSecret stri
 }
 
 func sessionDTO(row access.Session) map[string]any {
+	return sessionDTOFor(row, "")
+}
+
+func sessionDTOFor(row access.Session, currentSessionID string) map[string]any {
 	return map[string]any{
 		"id":                row.ID,
 		"kind":              row.Kind,
+		"current":           row.ID != "" && row.ID == currentSessionID,
 		"instanceId":        emptyToNil(row.InstanceID),
 		"profileId":         emptyToNil(row.ProfileID),
 		"clientId":          emptyToNil(row.ClientID),
@@ -1908,6 +2298,10 @@ func encodeAccessAuditPayload(r *stdhttp.Request, action, targetID string, metad
 	operationID, ok := apigencommand.OperationID(r.Context())
 	if !ok {
 		switch action {
+		case "principal.profile.updated":
+			operationID = "updateCurrentPrincipal"
+		case "password.changed":
+			operationID = "changeCurrentPassword"
 		case "api_token.created":
 			operationID = "createCurrentAPIToken"
 		case "api_token.revoked":
@@ -1924,6 +2318,10 @@ func encodeAccessAuditPayload(r *stdhttp.Request, action, targetID string, metad
 			operationID = "deletePrincipal"
 		case "principal.updated":
 			operationID = "updatePrincipal"
+		case "principal.disabled":
+			operationID = "disablePrincipal"
+		case "principal.enabled":
+			operationID = "enablePrincipal"
 		case "principal.local_password.reset":
 			operationID = "resetPrincipalPassword"
 		case "service_principal.created":
@@ -1973,6 +2371,10 @@ func encodeAccessAuditPayload(r *stdhttp.Request, action, targetID string, metad
 	var encoded string
 	var err error
 	switch operationID {
+	case "updateCurrentPrincipal":
+		encoded, err = accessgen.EncodeGenUpdateCurrentPrincipalAuditPayload(accessgen.GenSchemaCurrentPrincipalUpdatedAuditPayload{Email: str("email"), DisplayName: str("displayName")})
+	case "changeCurrentPassword":
+		encoded, err = accessgen.EncodeGenChangeCurrentPasswordAuditPayload(accessgen.GenSchemaCurrentPasswordChangedAuditPayload{Email: str("email"), Provider: str("provider")})
 	case "createCurrentAPIToken":
 		encoded, err = accessgen.EncodeGenCreateCurrentAPITokenAuditPayload(accessgen.GenSchemaAPITokenAuditPayload{Name: str("name"), Privileges: stringsValue("privileges")})
 	case "revokeCurrentAPIToken":
@@ -1987,6 +2389,10 @@ func encodeAccessAuditPayload(r *stdhttp.Request, action, targetID string, metad
 		encoded, err = accessgen.EncodeGenDeletePrincipalAuditPayload(accessgen.GenSchemaPrincipalDeletedAuditPayload{Email: str("email"), Kind: str("kind"), DisplayName: str("displayName")})
 	case "updatePrincipal":
 		encoded, err = accessgen.EncodeGenUpdatePrincipalAuditPayload(accessgen.GenSchemaPrincipalUpdatedAuditPayload{Email: str("email"), Kind: str("kind"), DisplayName: str("displayName")})
+	case "disablePrincipal":
+		encoded, err = accessgen.EncodeGenDisablePrincipalAuditPayload(accessgen.GenSchemaPrincipalUpdatedAuditPayload{Email: str("email"), Kind: str("kind"), DisplayName: str("displayName")})
+	case "enablePrincipal":
+		encoded, err = accessgen.EncodeGenEnablePrincipalAuditPayload(accessgen.GenSchemaPrincipalUpdatedAuditPayload{Email: str("email"), Kind: str("kind"), DisplayName: str("displayName")})
 	case "resetPrincipalPassword":
 		encoded, err = accessgen.EncodeGenResetPrincipalPasswordAuditPayload(accessgen.GenSchemaPrincipalPasswordResetAuditPayload{Email: str("email")})
 	case "createServicePrincipal":
@@ -2136,20 +2542,33 @@ func auditEventDTO(row access.AuditEvent) map[string]any {
 	if metadata == nil {
 		metadata = map[string]any{}
 	}
-	return map[string]any{
-		"id":            row.ID,
-		"workspaceId":   row.WorkspaceID,
-		"principalId":   row.PrincipalID,
-		"action":        row.Action,
-		"targetType":    row.TargetType,
-		"targetId":      row.TargetID,
-		"privilege":     row.Privilege,
-		"status":        row.Status,
-		"requestId":     row.RequestID,
-		"correlationId": row.CorrelationID,
-		"metadata":      metadata,
-		"createdAt":     row.CreatedAt,
+	dto := map[string]any{
+		"id":         row.ID,
+		"action":     row.Action,
+		"targetType": row.TargetType,
+		"targetId":   row.TargetID,
+		"metadata":   metadata,
+		"createdAt":  row.CreatedAt,
 	}
+	if row.WorkspaceID != "" {
+		dto["workspaceId"] = row.WorkspaceID
+	}
+	if row.PrincipalID != "" {
+		dto["principalId"] = row.PrincipalID
+	}
+	if row.Privilege != "" {
+		dto["privilege"] = row.Privilege
+	}
+	if row.Status != "" {
+		dto["status"] = row.Status
+	}
+	if row.RequestID != "" {
+		dto["requestId"] = row.RequestID
+	}
+	if row.CorrelationID != "" {
+		dto["correlationId"] = row.CorrelationID
+	}
+	return dto
 }
 
 func emptyToNil(value string) any {
@@ -2697,11 +3116,28 @@ func resourceETag(value any) string {
 	return apitransport.StrongETag(string(encoded))
 }
 
+func requireIfMatch(w stdhttp.ResponseWriter, r *stdhttp.Request, current string) bool {
+	value := strings.TrimSpace(r.Header.Get("If-Match"))
+	if value == "*" || value == current {
+		return true
+	}
+	w.Header().Set("Content-Type", "application/problem+json")
+	writeJSONError(w, fmt.Errorf("If-Match does not match the current resource"), stdhttp.StatusPreconditionFailed)
+	return false
+}
+
 func statusForNotFound(err error) int {
 	if err == sql.ErrNoRows {
 		return stdhttp.StatusNotFound
 	}
 	return stdhttp.StatusInternalServerError
+}
+
+func principalDeletionStatus(err error) int {
+	if errors.Is(err, access.ErrPrincipalOwnsSecurableObject) {
+		return stdhttp.StatusConflict
+	}
+	return statusForNotFound(err)
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/access/http/mcpoauth/service_test.go
+++ b/internal/access/http/mcpoauth/service_test.go
@@ -128,6 +128,82 @@ func TestAuthorizationCodePKCERefreshAndRevocation(t *testing.T) {
 	}
 }
 
+func TestPrincipalDisableThenEnableDoesNotReviveMCPOAuthTokens(t *testing.T) {
+	ctx := context.Background()
+	store, err := platform.Open(ctx, filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	repo := accesssqlite.NewRepository(store.SQLDB())
+	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{
+		Email: "disabled-mcp@example.com", DisplayName: "Disabled MCP User",
+	})
+	if err != nil {
+		t.Fatalf("create principal: %v", err)
+	}
+	service, err := mcpoauth.New(store.SQLDB(), repo, mcpoauth.Config{
+		IssuerURL: testIssuer, ResourceURL: testResource,
+		Secret: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("new OAuth service: %v", err)
+	}
+
+	registered := registerClient(t, service)
+	verifier := "abcdefghijklmnopqrstuvwxyz-._~ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	challengeBytes := sha256.Sum256([]byte(verifier))
+	authorizeURL := testIssuer + "/oauth/authorize?" + url.Values{
+		"response_type": {"code"}, "client_id": {registered.ClientID},
+		"redirect_uri": {testRedirect}, "scope": {"mcp:use offline_access"},
+		"state": {"disable-state"}, "code_challenge": {base64.RawURLEncoding.EncodeToString(challengeBytes[:])},
+		"code_challenge_method": {"S256"}, "resource": {testResource},
+	}.Encode()
+	authorizeResponse := httptest.NewRecorder()
+	service.Authorize(authorizeResponse, httptest.NewRequest(http.MethodPost, authorizeURL, nil), principal.ID, true)
+	if authorizeResponse.Code != http.StatusSeeOther {
+		t.Fatalf("authorize status = %d body=%s", authorizeResponse.Code, authorizeResponse.Body.String())
+	}
+	callback, err := url.Parse(authorizeResponse.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := exchangeCode(t, service, registered.ClientID, callback.Query().Get("code"), verifier)
+	if token.AccessToken == "" || token.RefreshToken == "" {
+		t.Fatalf("token response = %#v", token)
+	}
+	if _, err := service.Authenticate(ctx, token.AccessToken); err != nil {
+		t.Fatalf("authenticate before disable: %v", err)
+	}
+
+	if _, err := repo.DisablePrincipal(ctx, principal.ID); err != nil {
+		t.Fatalf("disable principal: %v", err)
+	}
+	if _, err := repo.EnablePrincipal(ctx, principal.ID); err != nil {
+		t.Fatalf("enable principal: %v", err)
+	}
+	if _, err := service.Authenticate(ctx, token.AccessToken); err == nil {
+		t.Fatal("pre-disable MCP access token revived after enable")
+	}
+	assertOAuthError(t, http.StatusBadRequest, func(rec *httptest.ResponseRecorder) {
+		service.Token(rec, formRequest("/oauth/token", url.Values{
+			"grant_type": {"refresh_token"}, "client_id": {registered.ClientID},
+			"refresh_token": {token.RefreshToken}, "resource": {testResource},
+		}))
+	})
+	var active int
+	if err := store.SQLDB().QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM oauth_sessions
+WHERE active = 1
+  AND json_extract(request_json, '$.session.subject') = ?`, principal.ID).Scan(&active); err != nil {
+		t.Fatal(err)
+	}
+	if active != 0 {
+		t.Fatalf("active MCP OAuth sessions after enable = %d, want 0", active)
+	}
+}
+
 func TestRejectsMissingPKCEAndWrongResource(t *testing.T) {
 	service := testService(t)
 	registered := registerClient(t, service)

--- a/internal/access/http/principal_lifecycle_test.go
+++ b/internal/access/http/principal_lifecycle_test.go
@@ -1,0 +1,228 @@
+package http
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	accesssqlite "github.com/flidai/leapview/internal/access/sqlite"
+	"github.com/flidai/leapview/internal/platform"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestPrincipalLifecycleIsAuditedAndDisableRejectsCredentials(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	repository := accesssqlite.NewRepository(store.SQLDB())
+	actor, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "admin", Kind: access.PrincipalKindUser, Email: "admin@example.test", DisplayName: "Admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "member", Kind: access.PrincipalKindUser, Email: "member@example.test", DisplayName: "Member",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionToken, err := repository.CreateSession(t.Context(), target.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiToken, _, err := repository.CreateAPITokenWithMetadata(t.Context(), access.APITokenInput{
+		PrincipalID: target.ID, Name: "before-disable",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	if _, err := store.SQLDB().ExecContext(t.Context(), `
+INSERT INTO oauth_authoring_sessions (
+  id, kind, client_id, principal_id, target_id, project_id, privileges_json,
+  created_at, expires_at
+) VALUES (?, 'human_cli', 'leapview-cli', ?, 'lvinst_test', 'test', '[]', ?, ?)`,
+		"authoring_before_disable", target.ID, now.Format(time.RFC3339), now.Add(time.Hour).Format(time.RFC3339)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SQLDB().ExecContext(t.Context(), `
+INSERT INTO oauth_authoring_credentials (
+  id, session_id, access_token_hash, refresh_token_hash, access_expires_at,
+  refresh_expires_at, active, created_at
+) VALUES (?, ?, ?, ?, ?, ?, 1, ?)`,
+		"credential_before_disable", "authoring_before_disable", "access_hash_before_disable", "refresh_hash_before_disable",
+		now.Add(15*time.Minute).Format(time.RFC3339), now.Add(time.Hour).Format(time.RFC3339), now.Format(time.RFC3339)); err != nil {
+		t.Fatal(err)
+	}
+	handler := Handler{
+		Repository: func() (access.Repository, error) { return repository, nil },
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+			return Principal{ID: actor.ID, Kind: actor.Kind, Email: actor.Email, DisplayName: actor.DisplayName}, true
+		},
+	}
+
+	disableRecorder := httptest.NewRecorder()
+	handler.DisablePrincipal(disableRecorder, principalRequest(stdhttp.MethodPost, "/api/v1/principals/member/disable", target.ID))
+	if disableRecorder.Code != stdhttp.StatusOK {
+		t.Fatalf("disable status=%d body=%s", disableRecorder.Code, disableRecorder.Body.String())
+	}
+	var disabled map[string]any
+	if err := json.Unmarshal(disableRecorder.Body.Bytes(), &disabled); err != nil {
+		t.Fatal(err)
+	}
+	if disabled["disabledAt"] == nil || disableRecorder.Header().Get("ETag") == "" {
+		t.Fatalf("disabled principal response=%v headers=%v", disabled, disableRecorder.Header())
+	}
+	if _, err := repository.PrincipalForToken(t.Context(), sessionToken); err == nil {
+		t.Fatal("disabled principal session remained usable")
+	}
+
+	enableRecorder := httptest.NewRecorder()
+	handler.EnablePrincipal(enableRecorder, principalRequest(stdhttp.MethodPost, "/api/v1/principals/member/enable", target.ID))
+	if enableRecorder.Code != stdhttp.StatusOK {
+		t.Fatalf("enable status=%d body=%s", enableRecorder.Code, enableRecorder.Body.String())
+	}
+	var enabled map[string]any
+	if err := json.Unmarshal(enableRecorder.Body.Bytes(), &enabled); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := enabled["disabledAt"]; exists {
+		t.Fatalf("enabled principal retained disabledAt: %v", enabled)
+	}
+	if _, err := repository.PrincipalForToken(t.Context(), sessionToken); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("browser session revived after enable: %v", err)
+	}
+	if _, err := repository.PrincipalForAPIToken(t.Context(), apiToken); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("API token revived after enable: %v", err)
+	}
+	if _, err := repository.AuthoringCredentialByAccessTokenHash(t.Context(), "access_hash_before_disable", now.Add(time.Minute)); !errors.Is(err, access.ErrInvalidAuthoringCredential) {
+		t.Fatalf("authoring access credential revived after enable: %v", err)
+	}
+	var active int
+	var revokedAt sql.NullString
+	if err := store.SQLDB().QueryRowContext(t.Context(), `
+SELECT c.active, s.revoked_at
+FROM oauth_authoring_credentials c
+JOIN oauth_authoring_sessions s ON s.id = c.session_id
+WHERE c.id = ?`, "credential_before_disable").Scan(&active, &revokedAt); err != nil {
+		t.Fatal(err)
+	}
+	if active != 0 || !revokedAt.Valid {
+		t.Fatalf("authoring credential/session after enable = active %d, revokedAt %#v", active, revokedAt)
+	}
+
+	deleteRecorder := httptest.NewRecorder()
+	handler.DeletePrincipal(deleteRecorder, principalRequest(stdhttp.MethodDelete, "/api/v1/principals/member", target.ID))
+	if deleteRecorder.Code != stdhttp.StatusNoContent {
+		t.Fatalf("delete status=%d body=%s", deleteRecorder.Code, deleteRecorder.Body.String())
+	}
+	if _, err := repository.PrincipalByID(t.Context(), target.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("deleted principal lookup error=%v, want sql.ErrNoRows", err)
+	}
+
+	for _, action := range []string{"principal.disabled", "principal.enabled", "principal.deleted"} {
+		events, err := repository.ListAuditEvents(t.Context(), access.AuditEventFilter{Action: action, TargetID: target.ID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(events) != 1 || events[0].PrincipalID != actor.ID || events[0].Status != "success" {
+			t.Fatalf("%s audit events=%#v", action, events)
+		}
+	}
+}
+
+func TestPrincipalLifecycleRejectsSelfDisableAndDelete(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	repository := accesssqlite.NewRepository(store.SQLDB())
+	actor, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "admin", Kind: access.PrincipalKindUser, Email: "admin@example.test", DisplayName: "Admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Handler{
+		Repository:       func() (access.Repository, error) { return repository, nil },
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) { return Principal{ID: actor.ID}, true },
+	}
+	for _, test := range []struct {
+		name string
+		call func(stdhttp.ResponseWriter, *stdhttp.Request)
+		path string
+	}{
+		{name: "disable", call: handler.DisablePrincipal, path: "/api/v1/principals/admin/disable"},
+		{name: "delete", call: handler.DeletePrincipal, path: "/api/v1/principals/admin"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			test.call(recorder, principalRequest(stdhttp.MethodPost, test.path, actor.ID))
+			if recorder.Code != stdhttp.StatusUnprocessableEntity {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestPrincipalDeletionMapsOwnedSecurableToConflictAndRollsBack(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	repository := accesssqlite.NewRepository(store.SQLDB())
+	actor, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "admin", Kind: access.PrincipalKindUser, Email: "admin@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "owner", Kind: access.PrincipalKindUser, Email: "owner@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	object := access.ItemObject(access.SecurableDashboard, "test", "owned")
+	if _, err := repository.UpsertSecurableObject(t.Context(), object, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	handler := Handler{
+		Repository:       func() (access.Repository, error) { return repository, nil },
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) { return Principal{ID: actor.ID}, true },
+	}
+	recorder := httptest.NewRecorder()
+	handler.DeletePrincipal(recorder, principalRequest(stdhttp.MethodDelete, "/api/v1/principals/owner", owner.ID))
+	if recorder.Code != stdhttp.StatusConflict {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if _, err := repository.PrincipalByID(t.Context(), owner.ID); err != nil {
+		t.Fatalf("owner was deleted despite conflict: %v", err)
+	}
+	events, err := repository.ListAuditEvents(t.Context(), access.AuditEventFilter{Action: "principal.deleted", TargetID: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("failed deletion wrote success audit: %#v", events)
+	}
+}
+
+func principalRequest(method, path, principalID string) *stdhttp.Request {
+	request := httptest.NewRequest(method, path, nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("principal", principalID)
+	return request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+}

--- a/internal/access/http/session_test.go
+++ b/internal/access/http/session_test.go
@@ -113,6 +113,37 @@ func TestAdministratorListsPrincipalSessionsWithoutCredentialMaterial(t *testing
 	}
 }
 
+func TestCurrentSessionListMarksOnlyTheCredentialUsedForTheRequest(t *testing.T) {
+	repository := &sessionLifecycleRepository{sessions: []access.Session{
+		{ID: "session_current", PrincipalID: "principal_me", Kind: access.SessionKindBrowser, CreatedAt: "2026-07-29T10:00:00Z", ExpiresAt: "2026-07-29T18:00:00Z"},
+		{ID: "session_other", PrincipalID: "principal_me", Kind: access.SessionKindDesktop, CreatedAt: "2026-07-28T10:00:00Z", ExpiresAt: "2026-07-28T18:00:00Z"},
+	}}
+	handler := Handler{
+		Repository: func() (access.Repository, error) { return repository, nil },
+		CurrentPrincipal: func(*stdhttp.Request) (Principal, bool) {
+			return Principal{ID: "principal_me"}, true
+		},
+		CurrentSession: func(*stdhttp.Request) (string, bool) { return "session_current", true },
+	}
+	response := httptest.NewRecorder()
+	handler.ListCurrentSessions(response, httptest.NewRequest(stdhttp.MethodGet, "/api/v1/me/sessions", nil))
+	if response.Code != stdhttp.StatusOK {
+		t.Fatalf("response = %d body=%s", response.Code, response.Body.String())
+	}
+	var body struct {
+		Items []struct {
+			ID      string `json:"id"`
+			Current bool   `json:"current"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Items) != 2 || !body.Items[0].Current || body.Items[1].Current {
+		t.Fatalf("sessions = %#v", body.Items)
+	}
+}
+
 func TestAdministratorRevokesOnlyTheTargetPrincipalsSession(t *testing.T) {
 	repository := &sessionLifecycleRepository{}
 	handler := Handler{

--- a/internal/access/module/admin_read.go
+++ b/internal/access/module/admin_read.go
@@ -12,6 +12,10 @@ type AdminReader struct {
 	repository access.Repository
 }
 
+type principalActivityReader interface {
+	ListPrincipalsWithActivity(context.Context, access.PrincipalFilter) ([]access.Principal, error)
+}
+
 func (m *Module) AdminReader() *AdminReader {
 	if m == nil {
 		return nil
@@ -24,6 +28,9 @@ func (m *Module) AdminReader() *AdminReader {
 }
 
 func (r *AdminReader) ListPrincipals(ctx context.Context, filter access.PrincipalFilter) ([]access.Principal, error) {
+	if reader, ok := r.repository.(principalActivityReader); ok {
+		return reader.ListPrincipalsWithActivity(ctx, filter)
+	}
 	return r.repository.ListPrincipals(ctx, filter)
 }
 
@@ -41,6 +48,10 @@ func (r *AdminReader) ListRoles(ctx context.Context) ([]access.Role, error) {
 
 func (r *AdminReader) ListAllRoleBindings(ctx context.Context) ([]access.RoleBinding, error) {
 	return r.repository.ListAllRoleBindings(ctx)
+}
+
+func (r *AdminReader) GetSecurableObject(ctx context.Context, object access.ObjectRef) (access.SecurableObject, error) {
+	return r.repository.GetSecurableObject(ctx, object)
 }
 
 func (r *AdminReader) Authorize(ctx context.Context, principalID string, privilege access.Privilege, object access.ObjectRef) (access.AuthorizationDecision, error) {

--- a/internal/access/module/apigen_test.go
+++ b/internal/access/module/apigen_test.go
@@ -129,8 +129,22 @@ func TestAPIGenAuthorizationContractCoverage(t *testing.T) {
 		"getInstance": true,
 	}
 	authenticatedOnly := map[string]bool{
-		"decideDeviceAuthorization": true,
-		"getCapabilities":           true,
+		"changeCurrentPassword":         true,
+		"createCurrentAPIToken":         true,
+		"decideDeviceAuthorization":     true,
+		"deleteCurrentAvatar":           true,
+		"getCapabilities":               true,
+		"getCurrentPrincipal":           true,
+		"getProductLogo":                true,
+		"getPrincipalAvatar":            true,
+		"listCurrentAPITokens":          true,
+		"listCurrentAuthoringSessions":  true,
+		"listCurrentSessions":           true,
+		"revokeCurrentAPIToken":         true,
+		"revokeCurrentAuthoringSession": true,
+		"revokeCurrentSession":          true,
+		"updateCurrentPrincipal":        true,
+		"uploadCurrentAvatar":           true,
 	}
 	for operationID, contract := range contracts {
 		if publicAuthoringAuth[operationID] {

--- a/internal/access/module/avatar.go
+++ b/internal/access/module/avatar.go
@@ -1,0 +1,14 @@
+package module
+
+import "github.com/flidai/leapview/internal/access/avatar"
+
+// Avatar blob aliases keep application composition on the access module
+// surface while the image implementation remains owned by access.
+type AvatarBlob = avatar.Blob
+type AvatarBlobStore = avatar.BlobStore
+
+var ErrAvatarBlobNotFound = avatar.ErrBlobNotFound
+
+func AvatarURL(principalID string, value avatar.Metadata) string {
+	return avatar.URLForPrincipal(principalID, value)
+}

--- a/internal/access/module/avatar_routes_test.go
+++ b/internal/access/module/avatar_routes_test.go
@@ -1,0 +1,66 @@
+package module
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access/avatar"
+	accesshttp "github.com/flidai/leapview/internal/access/http"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestAuthenticatedBrowserAvatarRoutesUseProtectedPrincipal(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	service := &routeAvatarService{metadata: avatar.Metadata{
+		PrincipalID: "dev", SHA256: digest, MediaType: "image/png", SizeBytes: 3,
+		Width: 256, Height: 256, UpdatedAt: "2026-08-08 12:00:00",
+	}}
+	module, err := newSurface(surfaceConfig{Avatar: nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	module.handler.Avatar = service
+	router := chi.NewRouter()
+	module.MountAuthenticatedBrowser(router)
+
+	upload := httptest.NewRequest(http.MethodPut, "/profile/avatar", bytes.NewBufferString("raw"))
+	upload.Header.Set("Content-Type", "image/png")
+	uploadRecorder := httptest.NewRecorder()
+	router.ServeHTTP(uploadRecorder, upload)
+	if uploadRecorder.Code != http.StatusOK || service.uploadedPrincipal != "dev" {
+		t.Fatalf("upload response=%d %s principal=%q", uploadRecorder.Code, uploadRecorder.Body.String(), service.uploadedPrincipal)
+	}
+
+	readRecorder := httptest.NewRecorder()
+	router.ServeHTTP(readRecorder, httptest.NewRequest(http.MethodGet, "/profile/avatars/dev/"+digest, nil))
+	if readRecorder.Code != http.StatusOK || readRecorder.Body.String() != "png" {
+		t.Fatalf("read response=%d %q", readRecorder.Code, readRecorder.Body.String())
+	}
+}
+
+type routeAvatarService struct {
+	metadata          avatar.Metadata
+	uploadedPrincipal string
+}
+
+func (s *routeAvatarService) Upload(_ context.Context, principalID string, _ io.Reader) (avatar.Metadata, error) {
+	s.uploadedPrincipal = principalID
+	return s.metadata, nil
+}
+
+func (s *routeAvatarService) Current(context.Context, string) (avatar.Metadata, error) {
+	return s.metadata, nil
+}
+
+func (s *routeAvatarService) Open(context.Context, string, string) (io.ReadCloser, avatar.Metadata, error) {
+	return io.NopCloser(bytes.NewBufferString("png")), s.metadata, nil
+}
+
+func (*routeAvatarService) Delete(context.Context, string) error { return nil }
+
+var _ accesshttp.AvatarService = (*routeAvatarService)(nil)

--- a/internal/access/module/build.go
+++ b/internal/access/module/build.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
 	"github.com/flidai/leapview/internal/access/desktopauth"
 	"github.com/flidai/leapview/internal/access/http/mcpoauth"
 	accesssqlite "github.com/flidai/leapview/internal/access/sqlite"
@@ -28,6 +29,7 @@ type Config struct {
 	MCPIssuerURL string
 	Presentation webpage.Presentation
 	Assets       staticasset.Resolver
+	AvatarBlobs  avatar.BlobStore
 }
 
 func newRepository(database *sql.DB) access.Repository { return accesssqlite.NewRepository(database) }
@@ -54,6 +56,18 @@ func Build(ctx context.Context, config Config) (*Module, error) {
 		return nil, err
 	}
 	repository := newRepository(config.Database)
+	var avatarService *avatar.Service
+	if config.AvatarBlobs != nil {
+		avatarRepository, ok := repository.(avatar.Repository)
+		if !ok {
+			return nil, fmt.Errorf("access repository does not support avatar metadata")
+		}
+		var err error
+		avatarService, err = avatar.New(avatarRepository, config.AvatarBlobs)
+		if err != nil {
+			return nil, err
+		}
+	}
 	publicURL := strings.TrimSuffix(strings.TrimSpace(config.PublicURL), "/")
 	if publicURL == "" {
 		publicURL = "http://localhost:8080"
@@ -86,6 +100,7 @@ func Build(ctx context.Context, config Config) (*Module, error) {
 		Repository: func() (access.Repository, error) { return repository, nil },
 		Auth:       auth, WorkspaceIDs: config.WorkspaceIDs,
 		AuthoringAuth:      authoringAuth,
+		Avatar:             avatarService,
 		Presentation:       config.Presentation,
 		Assets:             config.Assets,
 		DefaultWorkspaceID: config.WorkspaceID,

--- a/internal/access/module/guards.go
+++ b/internal/access/module/guards.go
@@ -26,6 +26,12 @@ func (m *Module) ProtectGlobal(privilege access.Privilege, handler http.HandlerF
 	return m.protectAnyWorkspace(privilege, handler).ServeHTTP
 }
 
+func (m *Module) ProtectPlatform(privilege access.Privilege, handler http.HandlerFunc) http.HandlerFunc {
+	return m.ProtectWithObjects(privilege, func(*http.Request, string) []access.ObjectRef {
+		return []access.ObjectRef{access.PlatformObject()}
+	}, handler)
+}
+
 func (m *Module) ProtectHandler(privilege access.Privilege, next http.Handler) http.Handler {
 	return m.ProtectHandlerWithObjects(privilege, nil, next)
 }
@@ -36,6 +42,12 @@ func (m *Module) ProtectNamed(privilege string, next http.Handler) http.Handler 
 
 func (m *Module) ProtectGlobalNamed(privilege string, next http.Handler) http.Handler {
 	return m.protectAnyWorkspace(access.Privilege(privilege), next)
+}
+
+func (m *Module) ProtectPlatformNamed(privilege string, next http.Handler) http.Handler {
+	return m.ProtectHandlerWithObjects(access.Privilege(privilege), func(*http.Request, string) []access.ObjectRef {
+		return []access.ObjectRef{access.PlatformObject()}
+	}, next)
 }
 
 func (m *Module) ProtectAnyWorkspaceNamed(privilege string, next http.Handler) http.Handler {

--- a/internal/access/module/module.go
+++ b/internal/access/module/module.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
 	"github.com/flidai/leapview/internal/access/desktopauth"
 	accesshttp "github.com/flidai/leapview/internal/access/http"
 	"github.com/flidai/leapview/internal/access/http/mcpoauth"
@@ -45,6 +46,7 @@ type surfaceConfig struct {
 	OAuth              *mcpoauth.Service
 	OAuthResource      mcpoauth.ResourceServer
 	AuthoringAuth      *access.AuthoringAuthService
+	Avatar             *avatar.Service
 	Presentation       webpage.Presentation
 	Assets             staticasset.Resolver
 }
@@ -56,10 +58,40 @@ func newSurface(config surfaceConfig) (*Module, error) {
 	}
 	currentPrincipal := func(r *http.Request) (accesshttp.Principal, bool) {
 		if config.CurrentPrincipal == nil {
-			return accesshttp.Principal{}, false
+			principal, ok := PrincipalFromContext(r.Context())
+			return accesshttp.Principal{ID: principal.ID, Kind: principal.Kind, Email: principal.Email, DisplayName: principal.DisplayName, CreatedAt: principal.CreatedAt, UpdatedAt: principal.UpdatedAt}, ok
 		}
 		principal, ok := config.CurrentPrincipal(r)
 		return accesshttp.Principal{ID: principal.ID, Kind: principal.Kind, Email: principal.Email, DisplayName: principal.DisplayName, CreatedAt: principal.CreatedAt, UpdatedAt: principal.UpdatedAt}, ok
+	}
+	localPasswordEnabled := config.Auth != nil && config.Auth.LocalAuthEnabled()
+	var avatarService accesshttp.AvatarService
+	if config.Avatar != nil {
+		avatarService = config.Avatar
+	}
+	currentSession := func(r *http.Request) (string, bool) {
+		if config.Repository == nil {
+			return "", false
+		}
+		cookie, err := r.Cookie("lv_session")
+		if err != nil || strings.TrimSpace(cookie.Value) == "" {
+			return "", false
+		}
+		repository, err := config.Repository()
+		if err != nil || repository == nil {
+			return "", false
+		}
+		resolver, ok := repository.(interface {
+			CredentialForSessionToken(context.Context, string) (access.Session, error)
+		})
+		if !ok {
+			return "", false
+		}
+		session, err := resolver.CredentialForSessionToken(r.Context(), cookie.Value)
+		if err != nil || session.ID == "" {
+			return "", false
+		}
+		return session.ID, true
 	}
 	catalog, err := generatedRoleBindingCatalog()
 	if err != nil {
@@ -83,9 +115,10 @@ func newSurface(config surfaceConfig) (*Module, error) {
 		grantCommands:       grantCommands,
 		presentation:        config.Presentation, assets: config.Assets, handler: accesshttp.Handler{
 			Repository: config.Repository, CurrentPrincipal: currentPrincipal,
-			RoleBindingCommands: roleBindingCommands,
-			GrantCommands:       grantCommands,
-			CurrentCredential:   config.CurrentCredential, WorkspaceID: config.WorkspaceID, AuthoringAuth: config.AuthoringAuth,
+			RoleBindingCommands: roleBindingCommands, GrantCommands: grantCommands,
+			CurrentCredential: config.CurrentCredential, CurrentSession: currentSession,
+			WorkspaceID: config.WorkspaceID, AuthoringAuth: config.AuthoringAuth,
+			Avatar: avatarService, LocalPasswordEnabled: localPasswordEnabled,
 		}}, nil
 }
 

--- a/internal/access/module/operation_contracts_test.go
+++ b/internal/access/module/operation_contracts_test.go
@@ -9,10 +9,17 @@ import (
 
 func TestGeneratedAccessMutationContractsAreComplete(t *testing.T) {
 	expected := map[string]struct {
-		audit  string
-		target string
-		ui     bool
+		audit     string
+		target    string
+		guarantee string
+		ui        bool
 	}{
+		"updateCurrentPrincipal":        {audit: "principal.profile.updated"},
+		"changeCurrentPassword":         {audit: "password.changed"},
+		"uploadCurrentAvatar":           {audit: "principal.avatar.updated", guarantee: "best-effort"},
+		"deleteCurrentAvatar":           {audit: "principal.avatar.deleted", guarantee: "best-effort"},
+		"disablePrincipal":              {audit: "principal.disabled", target: "principal"},
+		"enablePrincipal":               {audit: "principal.enabled", target: "principal"},
 		"decideDeviceAuthorization":     {audit: "authoring.device.decided"},
 		"revokeCurrentAuthoringSession": {audit: "authoring.session.revoked", target: "session"},
 		"createPrincipal":               {audit: "principal.local_user.created"},
@@ -58,8 +65,12 @@ func TestGeneratedAccessMutationContractsAreComplete(t *testing.T) {
 			continue
 		}
 		command := contract.Command
-		if !command.Audit.Required || command.Audit.SuccessAction != want.audit || command.Audit.Guarantee != "transactional" {
-			t.Errorf("%s audit = %#v, want required transactional action %q", operationID, command.Audit, want.audit)
+		wantGuarantee := want.guarantee
+		if wantGuarantee == "" {
+			wantGuarantee = "transactional"
+		}
+		if !command.Audit.Required || command.Audit.SuccessAction != want.audit || command.Audit.Guarantee != wantGuarantee {
+			t.Errorf("%s audit = %#v, want required %s action %q", operationID, command.Audit, wantGuarantee, want.audit)
 		}
 		if command.Audit.Payload == nil || command.Audit.Payload.Schema == "" || command.Audit.Payload.SchemaVersion != 1 || command.Audit.Payload.Retention != "security" {
 			t.Errorf("%s audit payload = %#v, want versioned security payload", operationID, command.Audit.Payload)

--- a/internal/access/module/personal_settings_ports.go
+++ b/internal/access/module/personal_settings_ports.go
@@ -1,0 +1,61 @@
+package module
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
+)
+
+type PersonalAvatar interface {
+	Current(context.Context, string) (avatar.Metadata, error)
+}
+
+type AuthoringSessions interface {
+	ListSessions(context.Context, string) ([]access.AuthoringSession, error)
+	RevokeSession(context.Context, string, string) error
+}
+
+// SettingsAdministration is the access-owned administration surface consumed
+// by product settings. The concrete persistence adapter remains private to the
+// access module.
+type SettingsAdministration interface {
+	access.Repository
+	access.AuditedPrincipalPreferences
+	ListServicePrincipalSecrets(context.Context, string) ([]access.ServicePrincipalSecret, error)
+	PrincipalIdentityManagement(context.Context, string) (access.PrincipalIdentityManagement, error)
+}
+
+func (m *Module) PersonalAvatar() PersonalAvatar {
+	if m == nil {
+		return nil
+	}
+	return m.handler.Avatar
+}
+
+func (m *Module) AuthoringSessions() AuthoringSessions {
+	if m == nil || m.authoringAuth == nil {
+		return nil
+	}
+	return m.authoringAuth
+}
+
+func (m *Module) SettingsAdministration() SettingsAdministration {
+	if m == nil {
+		return nil
+	}
+	repository := m.repositoryValue()
+	if repository == nil {
+		return nil
+	}
+	settings, _ := repository.(SettingsAdministration)
+	return settings
+}
+
+func (m *Module) CurrentSessionID(r *http.Request) (string, bool) {
+	if m == nil || m.handler.CurrentSession == nil {
+		return "", false
+	}
+	return m.handler.CurrentSession(r)
+}

--- a/internal/access/module/routes.go
+++ b/internal/access/module/routes.go
@@ -38,6 +38,13 @@ func (m *Module) MountAuthenticatedBrowser(r chi.Router) {
 	r.Method(http.MethodPost, "/device", deviceAuthorization)
 	r.Post("/auth/logout", m.Logout)
 	r.Post("/auth/local/password", m.LocalPassword)
+	r.Method(http.MethodPut, "/profile/avatar", m.ProtectHandler("", http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		m.handler.UploadCurrentAvatar(w, request, request.Header.Get("Content-Type"))
+	})))
+	r.Method(http.MethodDelete, "/profile/avatar", m.ProtectHandler("", http.HandlerFunc(m.handler.DeleteCurrentAvatar)))
+	r.Method(http.MethodGet, "/profile/avatars/{principal}/{digest}", m.ProtectHandler("", http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		m.handler.GetPrincipalAvatar(w, request, chi.URLParam(request, "principal"), chi.URLParam(request, "digest"))
+	})))
 }
 
 func (m *Module) MountLocalLogin(r chi.Router) {

--- a/internal/access/module/ui.go
+++ b/internal/access/module/ui.go
@@ -2,9 +2,20 @@ package module
 
 import (
 	"net/http"
+	"strings"
 
+	"github.com/flidai/leapview/internal/access"
 	"github.com/gorilla/csrf"
 )
+
+type AdminNavigationPrivileges struct {
+	ManagePlatform     bool
+	ManageGrants       bool
+	ManageWorkspace    bool
+	ManagePublications bool
+	ViewAudit          bool
+	ViewConnections    bool
+}
 
 func (m *Module) CSRFToken(r *http.Request) string {
 	if m == nil || m.auth == nil {
@@ -25,4 +36,60 @@ func (m *Module) CurrentRoleLabel(r *http.Request) string {
 		return "Platform admin"
 	}
 	return "Platform access"
+}
+
+func (m *Module) CurrentTheme(r *http.Request) access.ThemeMode {
+	if m == nil || r == nil {
+		return access.ThemeSystem
+	}
+	principal, ok := m.CurrentPrincipal(r)
+	if !ok || strings.TrimSpace(principal.ID) == "" {
+		return access.ThemeSystem
+	}
+	reader, ok := any(m.repositoryValue()).(access.PrincipalPreferencesReader)
+	if !ok || reader == nil {
+		return access.ThemeSystem
+	}
+	preferences, err := reader.PrincipalPreferences(r.Context(), principal.ID)
+	if err != nil {
+		return access.ThemeSystem
+	}
+	if _, valid := access.ParseThemeMode(string(preferences.Theme)); !valid {
+		return access.ThemeSystem
+	}
+	return preferences.Theme
+}
+
+func (m *Module) AdminNavigationPrivileges(r *http.Request) AdminNavigationPrivileges {
+	all := AdminNavigationPrivileges{
+		ManagePlatform: true, ManageGrants: true, ManageWorkspace: true,
+		ManagePublications: true, ViewAudit: true, ViewConnections: true,
+	}
+	if m == nil || m.auth == nil {
+		return all
+	}
+	principal, ok := m.auth.Principal(r)
+	if !ok {
+		return AdminNavigationPrivileges{}
+	}
+	if principal.DevBypass {
+		return all
+	}
+	repository := m.repositoryValue()
+	if repository == nil {
+		return AdminNavigationPrivileges{}
+	}
+	platform, err := repository.Authorize(r.Context(), principal.ID, access.PrivilegeManagePlatform, access.PlatformObject())
+	if err != nil {
+		return AdminNavigationPrivileges{}
+	}
+	allowed := func(privilege access.Privilege) bool {
+		ok, err := m.authorizeAnyWorkspace(r.Context(), principal.ID, nil, privilege)
+		return err == nil && ok
+	}
+	return AdminNavigationPrivileges{
+		ManagePlatform: platform.Allowed, ManageGrants: allowed(access.PrivilegeManageGrants),
+		ManageWorkspace: allowed(access.PrivilegeManageWorkspace), ManagePublications: allowed(access.PrivilegeManagePublications),
+		ViewAudit: allowed(access.PrivilegeViewAudit), ViewConnections: allowed(access.PrivilegeViewItem),
+	}
 }

--- a/internal/access/sqlite/api_symmetry.go
+++ b/internal/access/sqlite/api_symmetry.go
@@ -3,6 +3,8 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"time"
 
 	"github.com/flidai/leapview/internal/access"
 	platformdb "github.com/flidai/leapview/internal/access/internal/db"
@@ -34,6 +36,13 @@ func (r *Repository) UpdateGrant(ctx context.Context, workspaceID, id string, in
 }
 
 func (r *Repository) DeletePrincipal(ctx context.Context, id string) error {
+	access.ClearAuthorizationCache(ctx)
+	if _, err := r.PrincipalByID(ctx, id); err != nil {
+		return err
+	}
+	if err := r.preparePrincipalDeletion(ctx, id); err != nil {
+		return err
+	}
 	result, err := r.q.DeletePrincipalByID(ctx, id)
 	if err != nil {
 		return err
@@ -46,6 +55,85 @@ func (r *Repository) DeletePrincipal(ctx context.Context, id string) error {
 		return sql.ErrNoRows
 	}
 	return nil
+}
+
+func (r *Repository) preparePrincipalDeletion(ctx context.Context, id string) error {
+	owned, err := r.q.PrincipalOwnsSecurableObject(ctx, id)
+	if err != nil {
+		return err
+	}
+	if owned != 0 {
+		return access.ErrPrincipalOwnsSecurableObject
+	}
+	return r.q.DeleteDirectPrincipalGrants(ctx, id)
+}
+
+func (r *Repository) DisablePrincipal(ctx context.Context, id string) (access.Principal, error) {
+	access.ClearAuthorizationCache(ctx)
+	if r == nil {
+		return access.Principal{}, fmt.Errorf("access repository database is required")
+	}
+	if _, inTransaction := r.db.(*sql.Tx); inTransaction {
+		return r.disablePrincipal(ctx, id)
+	}
+	if r.root == nil {
+		return access.Principal{}, fmt.Errorf("access repository database is required")
+	}
+	tx, err := r.root.BeginTx(ctx, nil)
+	if err != nil {
+		return access.Principal{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	txRepo := &Repository{root: r.root, db: tx, q: r.q.WithTx(tx), policyCache: r.policyCache}
+	principal, err := txRepo.disablePrincipal(ctx, id)
+	if err != nil {
+		return access.Principal{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return access.Principal{}, err
+	}
+	return principal, nil
+}
+
+func (r *Repository) disablePrincipal(ctx context.Context, id string) (access.Principal, error) {
+	if _, err := r.PrincipalByID(ctx, id); err != nil {
+		return access.Principal{}, err
+	}
+	if err := r.q.DisablePrincipal(ctx, id); err != nil {
+		return access.Principal{}, err
+	}
+	if err := r.q.RevokeSessionsByPrincipal(ctx, id); err != nil {
+		return access.Principal{}, err
+	}
+	if err := r.q.RevokeAPITokensByPrincipal(ctx, id); err != nil {
+		return access.Principal{}, err
+	}
+	if err := r.q.DeactivateOAuthSessionsByPrincipal(ctx, id); err != nil {
+		return access.Principal{}, err
+	}
+	now := nullableTime(time.Now().UTC())
+	if err := r.q.DeactivateAuthoringCredentialsByPrincipal(ctx, platformdb.DeactivateAuthoringCredentialsByPrincipalParams{
+		ReplacedAt: now, PrincipalID: id,
+	}); err != nil {
+		return access.Principal{}, err
+	}
+	if err := r.q.RevokeAuthoringSessionsByPrincipal(ctx, platformdb.RevokeAuthoringSessionsByPrincipalParams{
+		RevokedAt: now, PrincipalID: id,
+	}); err != nil {
+		return access.Principal{}, err
+	}
+	return r.PrincipalByID(ctx, id)
+}
+
+func (r *Repository) EnablePrincipal(ctx context.Context, id string) (access.Principal, error) {
+	access.ClearAuthorizationCache(ctx)
+	if _, err := r.PrincipalByID(ctx, id); err != nil {
+		return access.Principal{}, err
+	}
+	if err := r.q.EnablePrincipal(ctx, id); err != nil {
+		return access.Principal{}, err
+	}
+	return r.PrincipalByID(ctx, id)
 }
 
 func (r *Repository) ListServicePrincipalSecrets(ctx context.Context, principalID string) ([]access.ServicePrincipalSecret, error) {

--- a/internal/access/sqlite/authorization.go
+++ b/internal/access/sqlite/authorization.go
@@ -212,6 +212,17 @@ func (r *Repository) UpsertSecurableObject(ctx context.Context, object access.Ob
 	return r.securableObjectByID(ctx, objectID)
 }
 
+func (r *Repository) GetSecurableObject(ctx context.Context, object access.ObjectRef) (access.SecurableObject, error) {
+	objectID, exists, err := r.lookupSecurableObjectID(ctx, object)
+	if err != nil {
+		return access.SecurableObject{}, err
+	}
+	if !exists {
+		return access.SecurableObject{}, sql.ErrNoRows
+	}
+	return r.securableObjectByID(ctx, objectID)
+}
+
 func (r *Repository) CreateGrant(ctx context.Context, input access.GrantInput) (access.Grant, error) {
 	access.ClearAuthorizationCache(ctx)
 	id, err := newID("grant")

--- a/internal/access/sqlite/avatar.go
+++ b/internal/access/sqlite/avatar.go
@@ -1,0 +1,60 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/flidai/leapview/internal/access/avatar"
+)
+
+func (r *Repository) Avatar(ctx context.Context, principalID string) (avatar.Metadata, error) {
+	return scanAvatar(r.db.QueryRowContext(ctx, `
+SELECT principal_id, sha256, media_type, size_bytes, width, height, updated_at
+FROM principal_avatars
+WHERE principal_id = ?`, principalID))
+}
+
+func (r *Repository) UpsertAvatar(ctx context.Context, value avatar.Metadata) (avatar.Metadata, error) {
+	_, err := r.db.ExecContext(ctx, `
+INSERT INTO principal_avatars (principal_id, sha256, media_type, size_bytes, width, height, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+ON CONFLICT(principal_id) DO UPDATE SET
+  sha256 = excluded.sha256,
+  media_type = excluded.media_type,
+  size_bytes = excluded.size_bytes,
+  width = excluded.width,
+  height = excluded.height,
+  updated_at = CURRENT_TIMESTAMP`,
+		value.PrincipalID, value.SHA256, value.MediaType, value.SizeBytes, value.Width, value.Height)
+	if err != nil {
+		return avatar.Metadata{}, err
+	}
+	return r.Avatar(ctx, value.PrincipalID)
+}
+
+func (r *Repository) DeleteAvatar(ctx context.Context, principalID string) error {
+	result, err := r.db.ExecContext(ctx, `DELETE FROM principal_avatars WHERE principal_id = ?`, principalID)
+	if err != nil {
+		return err
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return avatar.ErrNotFound
+	}
+	return nil
+}
+
+type avatarScanner interface{ Scan(...any) error }
+
+func scanAvatar(row avatarScanner) (avatar.Metadata, error) {
+	var result avatar.Metadata
+	err := row.Scan(&result.PrincipalID, &result.SHA256, &result.MediaType, &result.SizeBytes, &result.Width, &result.Height, &result.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return avatar.Metadata{}, avatar.ErrNotFound
+	}
+	return result, err
+}

--- a/internal/access/sqlite/avatar_test.go
+++ b/internal/access/sqlite/avatar_test.go
@@ -1,0 +1,43 @@
+package sqlite
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
+	"github.com/flidai/leapview/internal/platform"
+)
+
+func TestAvatarMetadataRoundTrip(t *testing.T) {
+	store, err := platform.Open(t.Context(), t.TempDir()+"/platform.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	repository := NewRepository(store.SQLDB())
+	principal, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{Email: "avatar@example.com", DisplayName: "Avatar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := avatar.Metadata{PrincipalID: principal.ID, SHA256: strings.Repeat("a", 64), MediaType: "image/png", SizeBytes: 1234, Width: 256, Height: 256}
+	got, err := repository.UpsertAvatar(t.Context(), want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PrincipalID != want.PrincipalID || got.SHA256 != want.SHA256 || got.MediaType != want.MediaType || got.SizeBytes != want.SizeBytes || got.Width != want.Width || got.Height != want.Height || got.UpdatedAt == "" {
+		t.Fatalf("UpsertAvatar() = %#v, want %#v", got, want)
+	}
+	loaded, err := repository.Avatar(t.Context(), principal.ID)
+	if err != nil || loaded != got {
+		t.Fatalf("Avatar() = %#v, %v; want %#v", loaded, err, got)
+	}
+	if err := repository.DeleteAvatar(t.Context(), principal.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.Avatar(t.Context(), principal.ID); !errors.Is(err, avatar.ErrNotFound) {
+		t.Fatalf("Avatar() after delete error = %v", err)
+	}
+}

--- a/internal/access/sqlite/credentials.go
+++ b/internal/access/sqlite/credentials.go
@@ -358,8 +358,19 @@ func (r *Repository) UpdateServicePrincipal(ctx context.Context, id string, inpu
 
 func (r *Repository) DeleteServicePrincipal(ctx context.Context, id string) error {
 	access.ClearAuthorizationCache(ctx)
-	if strings.TrimSpace(id) == "" {
+	id = strings.TrimSpace(id)
+	if id == "" {
 		return fmt.Errorf("service principal id is required")
+	}
+	principal, err := r.PrincipalByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if principal.Kind != access.PrincipalKindServicePrincipal {
+		return sql.ErrNoRows
+	}
+	if err := r.preparePrincipalDeletion(ctx, id); err != nil {
+		return err
 	}
 	return r.q.DeleteServicePrincipal(ctx, id)
 }

--- a/internal/access/sqlite/identity.go
+++ b/internal/access/sqlite/identity.go
@@ -35,6 +35,34 @@ func (r *Repository) ListPrincipals(ctx context.Context, filter access.Principal
 	return out, nil
 }
 
+// ListPrincipalsWithActivity is the administration read model for people
+// directory activity. Generic principal reads avoid paying for this aggregate.
+func (r *Repository) ListPrincipalsWithActivity(ctx context.Context, filter access.PrincipalFilter) ([]access.Principal, error) {
+	if r == nil || r.db == nil {
+		return []access.Principal{}, nil
+	}
+	rows, err := r.q.ListPrincipalsWithActivity(ctx, platformdb.ListPrincipalsWithActivityParams{
+		Email: strings.TrimSpace(filter.Email), Search: strings.TrimSpace(filter.Query),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]access.Principal, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, access.Principal{
+			ID:          row.ID,
+			Kind:        access.PrincipalKind(row.Kind),
+			Email:       row.Email,
+			DisplayName: row.DisplayName,
+			DisabledAt:  nullString(row.DisabledAt),
+			CreatedAt:   row.CreatedAt,
+			UpdatedAt:   row.UpdatedAt,
+			LastSeenAt:  row.LastSeenAt,
+		})
+	}
+	return out, nil
+}
+
 func (r *Repository) SearchPrincipals(ctx context.Context, query string, limit int) ([]access.Principal, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {

--- a/internal/access/sqlite/identity_management.go
+++ b/internal/access/sqlite/identity_management.go
@@ -1,0 +1,47 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+func (r *Repository) PrincipalIdentityManagement(ctx context.Context, principalID string) (access.PrincipalIdentityManagement, error) {
+	principalID = strings.TrimSpace(principalID)
+	if _, err := r.PrincipalByID(ctx, principalID); err != nil {
+		return access.PrincipalIdentityManagement{}, err
+	}
+
+	var provider string
+	err := r.db.QueryRowContext(ctx, `
+SELECT provider
+FROM external_identities
+WHERE principal_id = ?
+ORDER BY CASE WHEN provider = 'scim' THEN 0 ELSE 1 END, provider
+LIMIT 1`, principalID).Scan(&provider)
+	switch {
+	case err == nil:
+	case err == sql.ErrNoRows:
+		provider = ""
+	default:
+		return access.PrincipalIdentityManagement{}, err
+	}
+
+	var hasLocalPassword bool
+	if err := r.db.QueryRowContext(ctx, `
+SELECT EXISTS(SELECT 1 FROM local_user_credentials WHERE principal_id = ?)`, principalID).Scan(&hasLocalPassword); err != nil {
+		return access.PrincipalIdentityManagement{}, err
+	}
+
+	source := access.IdentityManagementSystem
+	if provider != "" {
+		source = access.IdentityManagementExternal
+	} else if hasLocalPassword {
+		source = access.IdentityManagementLocal
+	}
+	return access.PrincipalIdentityManagement{
+		Source: source, Provider: provider, HasLocalPassword: hasLocalPassword,
+	}, nil
+}

--- a/internal/access/sqlite/identity_management_test.go
+++ b/internal/access/sqlite/identity_management_test.go
@@ -1,0 +1,61 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+func TestPrincipalIdentityManagementDistinguishesLocalAndExternalOwnership(t *testing.T) {
+	_, repository := openAccessRepo(t, t.Context())
+	local, err := repository.CreateLocalUser(t.Context(), access.LocalUserInput{
+		Email: "local-settings@example.com", DisplayName: "Local Settings",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	localManagement, err := repository.PrincipalIdentityManagement(t.Context(), local.Principal.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localManagement.Source != access.IdentityManagementLocal || !localManagement.HasLocalPassword || localManagement.Provider != "" {
+		t.Fatalf("local identity management = %#v", localManagement)
+	}
+
+	external, err := repository.ResolveExternalPrincipal(t.Context(), access.ExternalIdentityInput{
+		Provider: "azure", TenantID: "tenant", Subject: "subject", Email: "external-settings@example.com", DisplayName: "External Settings",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	externalManagement, err := repository.PrincipalIdentityManagement(t.Context(), external.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if externalManagement.Source != access.IdentityManagementExternal || externalManagement.HasLocalPassword || externalManagement.Provider != "azure" {
+		t.Fatalf("external identity management = %#v", externalManagement)
+	}
+}
+
+func TestPrincipalIdentityManagementKeepsExternalProfileOwnershipWhenLocalCredentialIsLinked(t *testing.T) {
+	_, repository := openAccessRepo(t, t.Context())
+	local, err := repository.CreateLocalUser(t.Context(), access.LocalUserInput{
+		Email: "linked-settings@example.com", DisplayName: "Linked Settings",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	linked, err := repository.ResolveExternalPrincipal(t.Context(), access.ExternalIdentityInput{
+		Provider: "scim", TenantID: "tenant", Subject: "linked", Email: local.Principal.Email, DisplayName: "Provider Name",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	management, err := repository.PrincipalIdentityManagement(t.Context(), linked.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if management.Source != access.IdentityManagementExternal || management.Provider != "scim" || !management.HasLocalPassword {
+		t.Fatalf("linked identity management = %#v", management)
+	}
+}

--- a/internal/access/sqlite/principal_disable_test.go
+++ b/internal/access/sqlite/principal_disable_test.go
@@ -1,0 +1,156 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+func TestDisableThenEnableDoesNotRevivePrincipalCredentials(t *testing.T) {
+	_, repository := openAccessRepo(t, t.Context())
+	principal, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "disable_credentials", Kind: access.PrincipalKindUser,
+		Email: "disable-credentials@example.test", DisplayName: "Disable Credentials",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	browserSecret, err := repository.CreateSession(t.Context(), principal.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiSecret, _, err := repository.CreateAPITokenWithMetadata(t.Context(), access.APITokenInput{
+		PrincipalID: principal.ID, Name: "before-disable",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	authoringSession := access.AuthoringSession{
+		ID: "authoring_before_disable", Kind: access.AuthoringSessionHumanCLI,
+		ClientID: access.AuthoringCLIClientID, PrincipalID: principal.ID,
+		Scope: access.AuthoringScope{
+			TargetID: "lvinst_test", ProjectID: "test",
+			Privileges: []access.Privilege{access.PrivilegeAuthorProject},
+		},
+		CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}
+	if err := createAuthoringSession(t.Context(), repository.q, authoringSession); err != nil {
+		t.Fatal(err)
+	}
+	if err := createAuthoringCredential(
+		t.Context(), repository.q, "credential_before_disable", authoringSession.ID,
+		"access_hash_before_disable", "refresh_hash_before_disable",
+		now.Add(15*time.Minute), now.Add(time.Hour), now,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := repository.PrincipalForToken(t.Context(), browserSecret); err != nil {
+		t.Fatalf("browser credential was not initially usable: %v", err)
+	}
+	if _, err := repository.PrincipalForAPIToken(t.Context(), apiSecret); err != nil {
+		t.Fatalf("API credential was not initially usable: %v", err)
+	}
+	if _, err := repository.AuthoringCredentialByAccessTokenHash(t.Context(), "access_hash_before_disable", now); err != nil {
+		t.Fatalf("authoring credential was not initially usable: %v", err)
+	}
+
+	if _, err := repository.DisablePrincipal(t.Context(), principal.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.EnablePrincipal(t.Context(), principal.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := repository.PrincipalForToken(t.Context(), browserSecret); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("browser credential after re-enable error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := repository.PrincipalForAPIToken(t.Context(), apiSecret); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("API credential after re-enable error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := repository.AuthoringCredentialByAccessTokenHash(t.Context(), "access_hash_before_disable", now.Add(time.Minute)); !errors.Is(err, access.ErrInvalidAuthoringCredential) {
+		t.Fatalf("authoring access credential after re-enable error = %v, want ErrInvalidAuthoringCredential", err)
+	}
+	if _, err := repository.RotateAuthoringCredential(t.Context(), access.AuthoringCredentialRotation{
+		RefreshTokenHash: "refresh_hash_before_disable", Now: now.Add(time.Minute),
+		CredentialID: "credential_after_disable", AccessTokenHash: "access_hash_after_disable",
+		RefreshTokenHashNew: "refresh_hash_after_disable", AccessExpiresAt: now.Add(20 * time.Minute),
+		RefreshExpiresAt: now.Add(2 * time.Hour),
+	}); err == nil {
+		t.Fatal("authoring refresh credential became usable after re-enable")
+	}
+}
+
+func TestDisablePrincipalRollsBackStatusAndRevocationsTogether(t *testing.T) {
+	store, repository := openAccessRepo(t, t.Context())
+	principal, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "disable_rollback", Kind: access.PrincipalKindUser,
+		Email: "disable-rollback@example.test", DisplayName: "Disable Rollback",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	browserSecret, err := repository.CreateSession(t.Context(), principal.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiSecret, _, err := repository.CreateAPITokenWithMetadata(t.Context(), access.APITokenInput{
+		PrincipalID: principal.ID, Name: "rollback",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	authoringSession := access.AuthoringSession{
+		ID: "authoring_disable_rollback", Kind: access.AuthoringSessionHumanCLI,
+		ClientID: access.AuthoringCLIClientID, PrincipalID: principal.ID,
+		Scope: access.AuthoringScope{
+			TargetID: "lvinst_test", ProjectID: "test",
+			Privileges: []access.Privilege{access.PrivilegeAuthorProject},
+		},
+		CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}
+	if err := createAuthoringSession(t.Context(), repository.q, authoringSession); err != nil {
+		t.Fatal(err)
+	}
+	if err := createAuthoringCredential(
+		t.Context(), repository.q, "credential_disable_rollback", authoringSession.ID,
+		"access_hash_disable_rollback", "refresh_hash_disable_rollback",
+		now.Add(15*time.Minute), now.Add(time.Hour), now,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SQLDB().ExecContext(t.Context(), `
+CREATE TRIGGER fail_authoring_credential_deactivation
+BEFORE UPDATE OF active ON oauth_authoring_credentials
+WHEN NEW.active = 0
+BEGIN
+  SELECT RAISE(ABORT, 'forced authoring deactivation failure');
+END`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := repository.DisablePrincipal(t.Context(), principal.ID); err == nil {
+		t.Fatal("DisablePrincipal succeeded despite forced credential revocation failure")
+	}
+	stored, err := repository.PrincipalByID(t.Context(), principal.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.DisabledAt != "" {
+		t.Fatalf("principal status was not rolled back: %#v", stored)
+	}
+	if _, err := repository.PrincipalForToken(t.Context(), browserSecret); err != nil {
+		t.Fatalf("browser credential revocation was not rolled back: %v", err)
+	}
+	if _, err := repository.PrincipalForAPIToken(t.Context(), apiSecret); err != nil {
+		t.Fatalf("API credential revocation was not rolled back: %v", err)
+	}
+	if _, err := repository.AuthoringCredentialByAccessTokenHash(t.Context(), "access_hash_disable_rollback", now.Add(time.Minute)); err != nil {
+		t.Fatalf("authoring credential changed despite rollback: %v", err)
+	}
+}

--- a/internal/access/sqlite/principal_preferences.go
+++ b/internal/access/sqlite/principal_preferences.go
@@ -1,0 +1,52 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/flidai/leapview/internal/access"
+	platformdb "github.com/flidai/leapview/internal/access/internal/db"
+)
+
+func (r *Repository) PrincipalPreferences(ctx context.Context, principalID string) (access.PrincipalPreferences, error) {
+	row, err := r.q.GetPrincipalPreferences(ctx, principalID)
+	if err != nil {
+		return access.PrincipalPreferences{}, err
+	}
+	return principalPreferences(row.PrincipalID, row.Theme, row.UpdatedAt), nil
+}
+
+func (r *Repository) SetPrincipalTheme(ctx context.Context, principalID string, theme access.ThemeMode) (access.PrincipalPreferences, error) {
+	if parsed, ok := access.ParseThemeMode(string(theme)); !ok || parsed != theme {
+		return access.PrincipalPreferences{}, fmt.Errorf("unsupported theme %q", theme)
+	}
+	row, err := r.q.UpsertPrincipalTheme(ctx, platformdb.UpsertPrincipalThemeParams{PrincipalID: principalID, Theme: string(theme)})
+	if err != nil {
+		return access.PrincipalPreferences{}, err
+	}
+	return principalPreferences(row.PrincipalID, row.Theme, row.UpdatedAt), nil
+}
+
+func (r *Repository) SetPrincipalThemeAudited(ctx context.Context, principalID string, theme access.ThemeMode) error {
+	return r.RunAuditedMutation(ctx, func(repository access.Repository) (access.AuditEventInput, error) {
+		writer, ok := any(repository).(access.PrincipalPreferencesWriter)
+		if !ok {
+			return access.AuditEventInput{}, fmt.Errorf("principal preference writer is unavailable")
+		}
+		preferences, err := writer.SetPrincipalTheme(ctx, principalID, theme)
+		metadata, _ := json.Marshal(map[string]string{"theme": string(theme)})
+		return access.AuditEventInput{
+			PrincipalID: principalID, Action: "principal.theme.updated", TargetType: "principal",
+			TargetID: preferences.PrincipalID, Status: "success", MetadataJSON: string(metadata),
+		}, err
+	})
+}
+
+func principalPreferences(principalID, theme, updatedAt string) access.PrincipalPreferences {
+	parsed, ok := access.ParseThemeMode(theme)
+	if !ok {
+		parsed = access.ThemeSystem
+	}
+	return access.PrincipalPreferences{PrincipalID: principalID, Theme: parsed, UpdatedAt: updatedAt}
+}

--- a/internal/access/sqlite/principal_preferences_test.go
+++ b/internal/access/sqlite/principal_preferences_test.go
@@ -1,0 +1,34 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+func TestPrincipalThemePreferencePersistsAndAudits(t *testing.T) {
+	_, repository := openAccessRepo(t, t.Context())
+	principal, err := repository.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "principal-theme", Kind: access.PrincipalKindUser, Email: "theme@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.SetPrincipalThemeAudited(t.Context(), principal.ID, access.ThemeDarkDimmed); err != nil {
+		t.Fatal(err)
+	}
+	preferences, err := repository.PrincipalPreferences(t.Context(), principal.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preferences.Theme != access.ThemeDarkDimmed {
+		t.Fatalf("theme = %q, want dark_dimmed", preferences.Theme)
+	}
+	events, err := repository.ListAuditEvents(t.Context(), access.AuditEventFilter{PrincipalID: principal.ID, Action: "principal.theme.updated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].TargetID != principal.ID {
+		t.Fatalf("audit events = %#v", events)
+	}
+}

--- a/internal/access/sqlite/provisioning.go
+++ b/internal/access/sqlite/provisioning.go
@@ -237,16 +237,10 @@ func (r *Repository) DisableSCIMUser(ctx context.Context, principalID string) (a
 	if err != nil {
 		return access.SCIMUser{}, err
 	}
-	if err := r.q.DisablePrincipal(ctx, principalID); err != nil {
+	if _, err := r.DisablePrincipal(ctx, principalID); err != nil {
 		return access.SCIMUser{}, err
 	}
 	if err := r.q.DeleteSCIMGroupMembersByPrincipal(ctx, principalID); err != nil {
-		return access.SCIMUser{}, err
-	}
-	if err := r.q.RevokeSessionsByPrincipal(ctx, principalID); err != nil {
-		return access.SCIMUser{}, err
-	}
-	if err := r.q.RevokeAPITokensByPrincipal(ctx, principalID); err != nil {
 		return access.SCIMUser{}, err
 	}
 	row, err := r.q.GetPrincipal(ctx, principalID)

--- a/internal/access/sqlite/queries/access.sql
+++ b/internal/access/sqlite/queries/access.sql
@@ -15,8 +15,31 @@ ON CONFLICT(id) DO NOTHING;
 -- name: GetPrincipal :one
 SELECT * FROM principals WHERE id = ?;
 
+-- name: GetPrincipalPreferences :one
+SELECT principal_id, theme, updated_at
+FROM principal_preferences
+WHERE principal_id = ?;
+
+-- name: UpsertPrincipalTheme :one
+INSERT INTO principal_preferences (principal_id, theme, updated_at)
+VALUES (sqlc.arg(principal_id), sqlc.arg(theme), CURRENT_TIMESTAMP)
+ON CONFLICT(principal_id) DO UPDATE SET
+  theme = excluded.theme,
+  updated_at = CURRENT_TIMESTAMP
+RETURNING principal_id, theme, updated_at;
+
 -- name: DeletePrincipalByID :execresult
 DELETE FROM principals WHERE id = sqlc.arg(id);
+
+-- name: PrincipalOwnsSecurableObject :one
+SELECT EXISTS(
+  SELECT 1 FROM securable_objects WHERE owner_principal_id = sqlc.arg(principal_id)
+);
+
+-- name: DeleteDirectPrincipalGrants :exec
+DELETE FROM grants
+WHERE subject_type IN ('principal', 'service_principal')
+  AND subject_id = sqlc.arg(principal_id);
 
 -- name: GetPrincipalByEmail :one
 SELECT * FROM principals WHERE lower(email) = lower(?) AND email <> '' LIMIT 1;
@@ -396,6 +419,12 @@ UPDATE api_tokens
 SET revoked_at = COALESCE(revoked_at, CURRENT_TIMESTAMP)
 WHERE principal_id = ? AND revoked_at IS NULL;
 
+-- name: DeactivateOAuthSessionsByPrincipal :exec
+UPDATE oauth_sessions
+SET active = 0
+WHERE active = 1
+  AND json_extract(request_json, '$.session.subject') = sqlc.arg(principal_id);
+
 -- name: CreateServicePrincipalSecret :exec
 INSERT INTO service_principal_secrets (id, service_principal_id, name, secret_fingerprint, secret_verifier, expires_at)
 VALUES (?, ?, ?, ?, ?, ?);
@@ -450,6 +479,32 @@ SELECT principals.id, principals.email, principals.display_name,
        principals.created_at, principals.updated_at, principals.kind, principals.disabled_at
 FROM principals CROSS JOIN params
 WHERE (params.email = '' OR lower(principals.email) = lower(params.email))
+  AND (params.search = '' OR lower(principals.email) LIKE '%' || lower(params.search) || '%'
+       OR lower(display_name) LIKE '%' || lower(params.search) || '%')
+ORDER BY principals.email, principals.id;
+
+-- name: ListPrincipalsWithActivity :many
+WITH params AS (
+  SELECT CAST(sqlc.arg(email) AS TEXT) AS email, CAST(sqlc.arg(search) AS TEXT) AS search
+), human_activity AS (
+  SELECT principal_id, datetime(last_seen_at) AS seen_at
+  FROM sessions
+  UNION ALL
+  SELECT principal_id, datetime(last_used_at) AS seen_at
+  FROM oauth_authoring_sessions
+  WHERE kind = 'human_cli' AND last_used_at IS NOT NULL
+), latest_human_activity AS (
+  SELECT principal_id, strftime('%Y-%m-%dT%H:%M:%SZ', MAX(seen_at)) AS last_seen_at
+  FROM human_activity
+  GROUP BY principal_id
+)
+SELECT principals.id, principals.email, principals.display_name,
+       principals.created_at, principals.updated_at, principals.kind, principals.disabled_at,
+       CASE WHEN principals.kind = 'user' THEN COALESCE(latest_human_activity.last_seen_at, '') ELSE '' END AS last_seen_at
+FROM principals CROSS JOIN params
+LEFT JOIN latest_human_activity ON latest_human_activity.principal_id = principals.id
+WHERE (params.email = '' OR lower(principals.email) = lower(params.email))
+  AND principals.kind = 'user'
   AND (params.search = '' OR lower(principals.email) LIKE '%' || lower(params.search) || '%'
        OR lower(display_name) LIKE '%' || lower(params.search) || '%')
 ORDER BY principals.email, principals.id;
@@ -831,6 +886,22 @@ WHERE id = sqlc.arg(id) AND principal_id = sqlc.arg(principal_id);
 UPDATE oauth_authoring_sessions
 SET revoked_at = COALESCE(revoked_at, sqlc.arg(revoked_at))
 WHERE id = sqlc.arg(id);
+
+-- name: RevokeAuthoringSessionsByPrincipal :exec
+UPDATE oauth_authoring_sessions
+SET revoked_at = COALESCE(revoked_at, sqlc.arg(revoked_at))
+WHERE principal_id = sqlc.arg(principal_id) AND revoked_at IS NULL;
+
+-- name: DeactivateAuthoringCredentialsByPrincipal :exec
+UPDATE oauth_authoring_credentials
+SET active = 0,
+    replaced_at = COALESCE(replaced_at, sqlc.arg(replaced_at))
+WHERE active = 1
+  AND session_id IN (
+    SELECT id
+    FROM oauth_authoring_sessions
+    WHERE principal_id = sqlc.arg(principal_id)
+  );
 
 -- name: ListAuthoringSessions :many
 SELECT id, kind, client_id, principal_id, target_id, project_id, privileges_json,

--- a/internal/access/sqlite/repository_test.go
+++ b/internal/access/sqlite/repository_test.go
@@ -39,6 +39,88 @@ func TestRepositoryChecksGrantPrivileges(t *testing.T) {
 	}
 }
 
+func TestDeletePrincipalRejectsOwnedSecurablesWithoutPartialCleanup(t *testing.T) {
+	ctx := context.Background()
+	_, repo := openAccessRepo(t, ctx)
+	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{
+		ID: "owner-to-delete", Kind: access.PrincipalKindUser, Email: "owner-to-delete@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	object := access.ItemObject(access.SecurableDashboard, "test", "owned-dashboard")
+	if _, err := repo.UpsertSecurableObject(ctx, object, principal.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateGrant(ctx, access.GrantInput{
+		Object: object, SubjectType: access.SubjectPrincipal, SubjectID: principal.ID, Privilege: access.PrivilegeViewItem,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.DeletePrincipal(ctx, principal.ID); !errors.Is(err, access.ErrPrincipalOwnsSecurableObject) {
+		t.Fatalf("delete owner error = %v, want ownership conflict", err)
+	}
+	if _, err := repo.PrincipalByID(ctx, principal.ID); err != nil {
+		t.Fatalf("owner principal was partially deleted: %v", err)
+	}
+	stored, err := repo.GetSecurableObject(ctx, object)
+	if err != nil || stored.OwnerPrincipalID != principal.ID {
+		t.Fatalf("owned object after rejected delete = %#v, %v", stored, err)
+	}
+	grants, err := repo.ListGrants(ctx, object)
+	if err != nil || len(grants) != 1 || grants[0].SubjectID != principal.ID {
+		t.Fatalf("grants were partially cleaned on ownership conflict: %#v, %v", grants, err)
+	}
+}
+
+func TestDeletePrincipalRemovesDirectGrantsBeforeStableIDCanBeRecreated(t *testing.T) {
+	ctx := access.WithAuthorizationCache(context.Background())
+	_, repo := openAccessRepo(t, ctx)
+	const principalID = "stable-principal-id"
+	principal, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{
+		ID: principalID, Kind: access.PrincipalKindUser, Email: "before@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	object := access.ItemObject(access.SecurableDashboard, "test", "shared-dashboard")
+	if _, err := repo.UpsertSecurableObject(ctx, object, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateGrant(ctx, access.GrantInput{
+		Object: object, SubjectType: access.SubjectPrincipal, SubjectID: principal.ID, Privilege: access.PrivilegeViewItem,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	decision, err := repo.Authorize(ctx, principal.ID, access.PrivilegeViewItem, object)
+	if err != nil || !decision.Allowed {
+		t.Fatalf("initial authorization = %#v, %v", decision, err)
+	}
+	if err := repo.DeletePrincipal(ctx, principal.ID); err != nil {
+		t.Fatalf("delete principal: %v", err)
+	}
+	recreated, err := repo.UpsertPrincipal(ctx, access.PrincipalInput{
+		ID: principalID, Kind: access.PrincipalKindUser, Email: "after@example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err = repo.Authorize(ctx, recreated.ID, access.PrivilegeViewItem, object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Allowed {
+		t.Fatalf("recreated principal inherited stale grant: %#v", decision)
+	}
+	grants, err := repo.ListGrants(ctx, object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("direct grants remain after deletion: %#v", grants)
+	}
+}
+
 func TestAdversarialGroupParentAndWorkspaceValidation(t *testing.T) {
 	ctx := context.Background()
 	store, repo := openAccessRepo(t, ctx)
@@ -291,6 +373,53 @@ func TestRepositoryInitializeInstanceRollsBackWhenCredentialPreparationFails(t *
 	}
 	if len(events) != 0 {
 		t.Fatalf("audit events = %#v, want none", events)
+	}
+}
+
+func TestListPrincipalsDerivesLatestHumanActivity(t *testing.T) {
+	ctx := context.Background()
+	store, repo := openAccessRepo(t, ctx)
+	for _, input := range []access.PrincipalInput{
+		{ID: "active-user", Kind: access.PrincipalKindUser, Email: "active@example.test", DisplayName: "Active User"},
+		{ID: "never-user", Kind: access.PrincipalKindUser, Email: "never@example.test", DisplayName: "Never User"},
+		{ID: "automation", Kind: access.PrincipalKindServicePrincipal, Email: "automation@example.test", DisplayName: "Automation"},
+	} {
+		if _, err := repo.UpsertPrincipal(ctx, input); err != nil {
+			t.Fatalf("upsert principal %s: %v", input.ID, err)
+		}
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `
+INSERT INTO sessions (id, principal_id, token_fingerprint, token_verifier, expires_at, created_at, last_seen_at)
+VALUES ('browser-session', 'active-user', 'browser-fingerprint', 'browser-verifier', '2026-09-01T00:00:00Z', '2026-08-01T00:00:00Z', '2026-08-08T12:00:00Z')`); err != nil {
+		t.Fatalf("insert browser session: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `
+INSERT INTO oauth_authoring_sessions (id, kind, client_id, principal_id, target_id, project_id, privileges_json, created_at, last_used_at, expires_at)
+VALUES ('cli-session', 'human_cli', 'leapview-cli', 'active-user', 'target', 'project', '[]', '2026-08-02T00:00:00Z', '2026-08-09T15:30:00Z', '2026-09-01T00:00:00Z')`); err != nil {
+		t.Fatalf("insert CLI session: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `
+INSERT INTO oauth_authoring_sessions (id, kind, client_id, principal_id, target_id, project_id, privileges_json, created_at, last_used_at, expires_at)
+VALUES ('workload-session', 'workload', 'automation-client', 'automation', 'target', 'project', '[]', '2026-08-03T00:00:00Z', '2026-08-10T18:00:00Z', '2026-09-01T00:00:00Z')`); err != nil {
+		t.Fatalf("insert workload session: %v", err)
+	}
+
+	principals, err := repo.ListPrincipalsWithActivity(ctx, access.PrincipalFilter{})
+	if err != nil {
+		t.Fatalf("list principals: %v", err)
+	}
+	byID := make(map[string]access.Principal, len(principals))
+	for _, principal := range principals {
+		byID[principal.ID] = principal
+	}
+	if got := byID["active-user"].LastSeenAt; got != "2026-08-09T15:30:00Z" {
+		t.Fatalf("active user last seen = %q, want latest CLI activity", got)
+	}
+	if got := byID["never-user"].LastSeenAt; got != "" {
+		t.Fatalf("never user last seen = %q, want empty", got)
+	}
+	if _, exists := byID["automation"]; exists {
+		t.Fatal("administration people directory included a service principal")
 	}
 }
 

--- a/internal/access/theme_test.go
+++ b/internal/access/theme_test.go
@@ -1,0 +1,26 @@
+package access
+
+import "testing"
+
+func TestParseThemeModeAcceptsSupportedPrimerThemes(t *testing.T) {
+	for _, value := range []string{
+		"system",
+		"light",
+		"dark",
+		"dark_dimmed",
+		"light_colorblind",
+		"dark_colorblind",
+		"light_tritanopia",
+		"dark_tritanopia",
+	} {
+		t.Run(value, func(t *testing.T) {
+			if theme, ok := ParseThemeMode(value); !ok || string(theme) != value {
+				t.Fatalf("ParseThemeMode(%q) = %q, %v", value, theme, ok)
+			}
+		})
+	}
+
+	if _, ok := ParseThemeMode("dark_high_contrast"); ok {
+		t.Fatal("unsupported Primer theme was accepted")
+	}
+}

--- a/internal/access/workspace_service.go
+++ b/internal/access/workspace_service.go
@@ -17,6 +17,7 @@ type WorkspaceAccessService interface {
 	ListRoleBindings(context.Context, string) ([]RoleBinding, error)
 	ListRoles(context.Context) ([]Role, error)
 	Authorize(context.Context, string, Privilege, ObjectRef) (AuthorizationDecision, error)
+	GetSecurableObject(context.Context, ObjectRef) (SecurableObject, error)
 	CreateGrant(context.Context, GrantInput) (Grant, error)
 	DeleteGrant(context.Context, string, string) error
 	ListGrants(context.Context, ObjectRef) ([]Grant, error)

--- a/internal/admin/http/handler.go
+++ b/internal/admin/http/handler.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 
 	"github.com/Yacobolo/toolbelt/pagestream"
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/admin/personalsettings"
+	"github.com/flidai/leapview/internal/admin/productsettings"
+	adminsettings "github.com/flidai/leapview/internal/admin/settings"
 	"github.com/flidai/leapview/internal/admin/ui"
 	uisignals "github.com/flidai/leapview/internal/admin/ui/signals"
 	"github.com/flidai/leapview/internal/analytics/queryaudit"
@@ -21,6 +25,13 @@ type Handler struct {
 	EnsureClientID      func(nethttp.ResponseWriter, *nethttp.Request)
 	Broker              *pagestream.Broker
 	PublicationMutation func(*nethttp.Request, uisignals.AdminPublicationCommand) error
+	PersonalSettings    *personalsettings.Handler
+	ProductSettings     *productsettings.Handler
+	SettingsRepository  adminsettings.Repository
+	WorkspaceSettings   adminsettings.WorkspaceAdministrationReader
+	WorkspaceAccess     access.WorkspaceAccessService
+	SettingsEnvironment string
+	CurrentCredential   func(*nethttp.Request) (access.APICredential, bool)
 }
 
 type storageCommandSignals struct {
@@ -29,6 +40,15 @@ type storageCommandSignals struct {
 
 type publicationCommandSignals struct {
 	AdminPublicationCommand uisignals.AdminPublicationCommand `json:"adminPublicationCommand"`
+}
+
+type serviceAccountCommandSignals struct {
+	Command adminsettings.ServiceAccountCommand `json:"adminServiceAccountCommand"`
+}
+
+type auditLogCommandSignals struct {
+	Command adminsettings.AuditLogCommand `json:"adminAuditLogCommand"`
+	Current adminsettings.AuditLogSignal  `json:"adminAuditLog"`
 }
 
 type entityListSignals struct {
@@ -41,8 +61,36 @@ func (h Handler) AdminRoot(w nethttp.ResponseWriter, r *nethttp.Request) {
 }
 
 func (h Handler) Profile(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
 	h.renderPage(w, r, "profile")
 }
+
+func (h Handler) Security(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	h.renderPage(w, r, "security")
+}
+func (h Handler) APITokens(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	h.renderPage(w, r, "api-tokens")
+}
+func (h Handler) General(w nethttp.ResponseWriter, r *nethttp.Request) { h.renderPage(w, r, "general") }
+func (h Handler) Workspaces(w nethttp.ResponseWriter, r *nethttp.Request) {
+	h.renderPage(w, r, "workspaces-admin")
+}
+func (h Handler) ServiceAccounts(w nethttp.ResponseWriter, r *nethttp.Request) {
+	h.renderPage(w, r, "service-accounts")
+}
+func (h Handler) Authentication(w nethttp.ResponseWriter, r *nethttp.Request) {
+	h.renderPage(w, r, "authentication")
+}
+func (h Handler) Audit(w nethttp.ResponseWriter, r *nethttp.Request)  { h.renderPage(w, r, "audit") }
+func (h Handler) System(w nethttp.ResponseWriter, r *nethttp.Request) { h.renderPage(w, r, "system") }
 
 func (h Handler) Principals(w nethttp.ResponseWriter, r *nethttp.Request) {
 	h.renderPage(w, r, "principals")
@@ -165,10 +213,94 @@ func (h Handler) PublicationCommand(w nethttp.ResponseWriter, r *nethttp.Request
 	_ = pagestream.Redirect(w, r, "/admin/publications")
 }
 
+func (h Handler) PersonalSettingsCommand(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if h.rejectAuthoringCredential(w, r) {
+		return
+	}
+	if h.PersonalSettings == nil {
+		nethttp.Error(w, "personal settings are unavailable", nethttp.StatusServiceUnavailable)
+		return
+	}
+	h.PersonalSettings.Command(w, r)
+}
+
+func (h Handler) ProductSettingsCommand(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if h.ProductSettings == nil {
+		nethttp.Error(w, "product settings are unavailable", nethttp.StatusServiceUnavailable)
+		return
+	}
+	h.ProductSettings.Command(w, r)
+}
+
+func (h Handler) ServiceAccountCommand(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if h.SettingsRepository == nil {
+		nethttp.Error(w, "service accounts are unavailable", nethttp.StatusServiceUnavailable)
+		return
+	}
+	var request serviceAccountCommandSignals
+	if err := pagestream.ReadSignals(r, &request); err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(request.Command.Action) == "select" {
+		state, err := adminsettings.LoadServiceAccounts(r.Context(), h.SettingsRepository, request.Command.AccountID)
+		if err != nil {
+			nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+			return
+		}
+		_ = pagestream.PatchResponse(w, r, map[string]any{"adminServiceAccounts": state})
+		return
+	}
+	actorID := ""
+	if h.ReadModel.CurrentPrincipal != nil {
+		if principal, ok := h.ReadModel.CurrentPrincipal(r); ok {
+			actorID = principal.ID
+		}
+	}
+	secret, err := adminsettings.ApplyServiceAccountCommandAudited(r.Context(), h.SettingsRepository, actorID, request.Command)
+	if err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	state, err := adminsettings.LoadServiceAccounts(r.Context(), h.SettingsRepository, request.Command.AccountID)
+	if err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+		return
+	}
+	state.CreatedSecret = secret
+	_ = pagestream.PatchResponse(w, r, map[string]any{"adminServiceAccounts": state})
+}
+
+func (h Handler) AuditLogCommand(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if h.SettingsRepository == nil {
+		nethttp.Error(w, "audit log is unavailable", nethttp.StatusServiceUnavailable)
+		return
+	}
+	var request auditLogCommandSignals
+	if err := pagestream.ReadSignals(r, &request); err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	command := adminsettings.NormalizeAuditLogCommand(request.Command)
+	state, err := adminsettings.LoadAuditLog(r.Context(), h.SettingsRepository, command.Filters, command.PageToken, command.Limit)
+	if err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	if command.Action == "load_more" {
+		state.Items = append(append([]adminsettings.AuditEventSignal{}, request.Current.Items...), state.Items...)
+		state.LoadedCount = len(state.Items)
+	}
+	_ = pagestream.PatchResponse(w, r, map[string]any{"adminAuditLog": state})
+}
+
 func (h Handler) BootstrapUpdates(w nethttp.ResponseWriter, r *nethttp.Request) {
 	active := strings.TrimSpace(r.URL.Query().Get("section"))
-	if active == "" || active == "general" {
+	if active == "" {
 		active = "profile"
+	}
+	if (active == "profile" || active == "security" || active == "api-tokens") && h.rejectAuthoringCredential(w, r) {
+		return
 	}
 	var listState entityListSignals
 	query := strings.TrimSpace(r.URL.Query().Get("q"))
@@ -214,7 +346,80 @@ func (h Handler) BootstrapUpdates(w nethttp.ResponseWriter, r *nethttp.Request) 
 	}
 	data.ListQuery = query
 	data.ListFilter = filter
-	h.patchAndWait(w, r, ui.AdminBootstrapSignals(active, data, h.layout(r)))
+	signals := ui.AdminBootstrapSignals(active, data, h.layout(r))
+	if err := h.addSettingsSignals(r, active, signals); err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+		return
+	}
+	h.patchAndWait(w, r, signals)
+}
+
+func (h Handler) rejectAuthoringCredential(w nethttp.ResponseWriter, r *nethttp.Request) bool {
+	if h.CurrentCredential == nil {
+		return false
+	}
+	credential, ok := h.CurrentCredential(r)
+	if !ok || credential.Authoring == nil {
+		return false
+	}
+	nethttp.Error(w, "personal settings require a browser session or personal API token", nethttp.StatusForbidden)
+	return true
+}
+
+func (h Handler) addSettingsSignals(r *nethttp.Request, active string, signals map[string]any) error {
+	switch active {
+	case "profile", "security", "api-tokens":
+		if h.PersonalSettings == nil {
+			return nil
+		}
+		state, err := h.PersonalSettings.State(r)
+		if err != nil {
+			return err
+		}
+		for key, value := range personalsettings.BootstrapSignals(state) {
+			signals[key] = value
+		}
+	case "general", "authentication", "system":
+		if h.ProductSettings == nil {
+			return nil
+		}
+		state, err := h.ProductSettings.Bootstrap(r, active)
+		if err != nil {
+			return err
+		}
+		signals["productSettings"] = productsettings.Payload(state)
+		signals["productSettingsCommand"] = map[string]any{}
+	case "workspaces-admin":
+		if h.WorkspaceSettings == nil {
+			return nil
+		}
+		state, err := adminsettings.LoadWorkspaceRegistry(r.Context(), h.WorkspaceSettings, h.WorkspaceAccess, h.SettingsEnvironment)
+		if err != nil {
+			return err
+		}
+		signals["adminWorkspaces"] = state
+	case "service-accounts":
+		if h.SettingsRepository == nil {
+			return nil
+		}
+		state, err := adminsettings.LoadServiceAccounts(r.Context(), h.SettingsRepository, "")
+		if err != nil {
+			return err
+		}
+		signals["adminServiceAccounts"] = state
+		signals["adminServiceAccountCommand"] = adminsettings.ServiceAccountCommand{}
+	case "audit":
+		if h.SettingsRepository == nil {
+			return nil
+		}
+		state, err := adminsettings.LoadAuditLog(r.Context(), h.SettingsRepository, adminsettings.AuditLogFilters{}, "", 50)
+		if err != nil {
+			return err
+		}
+		signals["adminAuditLog"] = state
+		signals["adminAuditLogCommand"] = adminsettings.AuditLogCommand{Action: "reset", Limit: 50}
+	}
+	return nil
 }
 
 func (h Handler) QueryUpdates(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -298,6 +503,8 @@ func (h Handler) adminDataForUpdates(r *nethttp.Request, active string) (ui.Admi
 		return h.readModel().PrincipalsListData(r)
 	case "groups":
 		return h.readModel().GroupsListData(r)
+	case "profile", "security", "api-tokens", "general", "workspaces-admin", "service-accounts", "authentication", "audit", "system":
+		return h.readModel().SettingsData(r)
 	}
 	data, err := h.adminData(r)
 	if err != nil {

--- a/internal/admin/http/handler_test.go
+++ b/internal/admin/http/handler_test.go
@@ -70,6 +70,19 @@ func TestProfileRendersAdminOwnedPageAdapter(t *testing.T) {
 	}
 }
 
+func TestPersonalSettingsRejectAuthoringCredentials(t *testing.T) {
+	handler := Handler{ReadModel: ReadModel{}, CurrentCredential: func(*http.Request) (access.APICredential, bool) {
+		return access.APICredential{Authoring: &access.AuthoringSession{ID: "authoring-1"}}, true
+	}}
+	for _, path := range []string{"/admin/profile", "/admin/security", "/admin/api-tokens"} {
+		recorder := httptest.NewRecorder()
+		handler.Profile(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("%s status = %d, want %d", path, recorder.Code, http.StatusForbidden)
+		}
+	}
+}
+
 func TestBuildAdminPrincipalsKeepsEmailDuplicatesIDDistinct(t *testing.T) {
 	principals := []ui.AdminPrincipal{
 		{ID: "principal-old", Email: "analyst@example.com", DisplayName: "Sales Analyst", CreatedAt: "2026-08-06T00:00:00Z"},

--- a/internal/admin/http/read_model.go
+++ b/internal/admin/http/read_model.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
 	"github.com/flidai/leapview/internal/admin/storage"
 	"github.com/flidai/leapview/internal/admin/ui"
 	uisignals "github.com/flidai/leapview/internal/admin/ui/signals"
@@ -37,8 +38,13 @@ type AccessReader interface {
 	Authorize(context.Context, string, access.Privilege, access.ObjectRef) (access.AuthorizationDecision, error)
 }
 
+type AvatarReader interface {
+	Current(context.Context, string) (avatar.Metadata, error)
+}
+
 type ReadModel struct {
 	Access              AccessReader
+	Avatars             AvatarReader
 	AgentDetails        AgentDetailsProvider
 	StorageService      storage.Service
 	QueryAuditReader    QueryAuditReaderProvider
@@ -49,6 +55,10 @@ type ReadModel struct {
 	DefaultWorkspaceID  string
 	AuthConfigured      bool
 	AccessConfigured    bool
+}
+
+func (m ReadModel) SettingsData(r *http.Request) (ui.AdminData, error) {
+	return m.baseData(r), nil
 }
 
 func (m ReadModel) Data(r *http.Request) (ui.AdminData, error) {
@@ -94,12 +104,6 @@ func (m ReadModel) baseData(r *http.Request) ui.AdminData {
 		AccessConfigured:    m.AccessConfigured,
 		AccessStatusLabel:   "Configured",
 		PublicationCommands: m.PublicationCommands,
-	}
-	if principal, ok := m.currentPrincipal(r); ok {
-		data.Profile = ui.AdminProfile{
-			ID: principal.ID, Email: principal.Email, DisplayName: principal.DisplayName,
-			Username: profileUsername(principal),
-		}
 	}
 	return data
 }
@@ -218,19 +222,32 @@ func (m ReadModel) principalsData(r *http.Request, repo AccessReader) ([]ui.Admi
 	principals := make([]ui.AdminPrincipal, 0, len(rows))
 	for _, row := range rows {
 		principals = append(principals, ui.AdminPrincipal{
-			ID:          row.ID,
-			Kind:        string(row.Kind),
-			Email:       row.Email,
-			DisplayName: row.DisplayName,
-			DisabledAt:  row.DisabledAt,
-			CreatedAt:   row.CreatedAt,
-			UpdatedAt:   row.UpdatedAt,
+			ID:                row.ID,
+			Kind:              string(row.Kind),
+			Email:             row.Email,
+			DisplayName:       row.DisplayName,
+			ProfilePictureURL: m.avatarURL(r.Context(), row.ID),
+			DisabledAt:        row.DisabledAt,
+			CreatedAt:         row.CreatedAt,
+			UpdatedAt:         row.UpdatedAt,
+			LastSeenAt:        row.LastSeenAt,
 		})
 	}
 	sort.SliceStable(principals, func(i, j int) bool {
 		return adminPrincipalSortKey(principals[i]) < adminPrincipalSortKey(principals[j])
 	})
 	return principals, nil
+}
+
+func (m ReadModel) avatarURL(ctx context.Context, principalID string) string {
+	if m.Avatars == nil {
+		return ""
+	}
+	metadata, err := m.Avatars.Current(ctx, principalID)
+	if err != nil {
+		return ""
+	}
+	return avatar.URLForPrincipal(principalID, metadata)
 }
 
 func groupMembersData(r *http.Request, repo AccessReader, groupID string) []ui.AdminPrincipalRef {
@@ -331,15 +348,6 @@ func (m ReadModel) csrfToken(r *http.Request) string {
 		return ""
 	}
 	return m.CSRFToken(r)
-}
-
-func profileUsername(principal Principal) string {
-	if email := strings.TrimSpace(principal.Email); email != "" {
-		if username, _, ok := strings.Cut(email, "@"); ok && username != "" {
-			return username
-		}
-	}
-	return strings.TrimSpace(principal.ID)
 }
 
 func buildAdminPrincipals(principals []ui.AdminPrincipal, bindings []workspace.RoleBindingView, groupsByID map[string]access.Group, membersByGroup map[string][]ui.AdminPrincipalRef) []ui.AdminPrincipal {

--- a/internal/admin/module/module.go
+++ b/internal/admin/module/module.go
@@ -8,7 +8,12 @@ import (
 	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
 	"github.com/Yacobolo/toolbelt/pagestream"
 	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
 	adminhttp "github.com/flidai/leapview/internal/admin/http"
+	"github.com/flidai/leapview/internal/admin/personalsettings"
+	"github.com/flidai/leapview/internal/admin/product"
+	"github.com/flidai/leapview/internal/admin/productsettings"
+	adminsettings "github.com/flidai/leapview/internal/admin/settings"
 	adminstorage "github.com/flidai/leapview/internal/admin/storage"
 	"github.com/flidai/leapview/internal/agent/api"
 	"github.com/flidai/leapview/internal/analytics/queryaudit"
@@ -18,6 +23,7 @@ import (
 	webpage "github.com/flidai/leapview/internal/platform/web/page"
 	"github.com/flidai/leapview/internal/platform/web/uicommand"
 	"github.com/flidai/leapview/internal/workload"
+	"github.com/flidai/leapview/internal/workspace"
 )
 
 type PublicationService interface {
@@ -49,6 +55,27 @@ type AccessReader interface {
 	Authorize(context.Context, string, access.Privilege, access.ObjectRef) (access.AuthorizationDecision, error)
 }
 
+type SettingsAccess interface {
+	access.Repository
+	access.AuditedPrincipalPreferences
+	adminsettings.ServicePrincipalSecretReader
+	personalsettings.IdentityManagementReader
+}
+
+type WorkspaceSettings interface {
+	workspace.ReadModel
+	workspace.AdministrationReadModel
+}
+
+type PersonalAvatar interface {
+	Current(context.Context, string) (avatar.Metadata, error)
+}
+
+type AuthoringSessions interface {
+	ListSessions(context.Context, string) ([]access.AuthoringSession, error)
+	RevokeSession(context.Context, string, string) error
+}
+
 type QueryAuditReaderProvider func() (queryaudit.Reader, error)
 
 type StorageConfig struct {
@@ -75,11 +102,23 @@ type Config struct {
 	PublicationCommands   map[string]uicommand.Binding
 	DefaultWorkspaceID    string
 	AuthConfigured        bool
+	LocalPasswordEnabled  bool
 	AccessConfigured      bool
 	Storage               StorageConfig
 	Layout                func(*http.Request) webpage.Provider
 	EnsureClientID        func(http.ResponseWriter, *http.Request)
 	Broker                *pagestream.Broker
+	Product               *product.Service
+	ProductCommands       product.CommandExecutor
+	ProductCommandFailure product.CommandFailureWriter
+	ProductStatus         product.Status
+	SettingsAccess        SettingsAccess
+	PersonalAvatar        PersonalAvatar
+	AuthoringSessions     AuthoringSessions
+	CurrentSession        func(*http.Request) (string, bool)
+	WorkspaceSettings     WorkspaceSettings
+	WorkspaceAccess       access.WorkspaceAccessService
+	SettingsEnvironment   string
 }
 
 type Module struct {
@@ -89,6 +128,7 @@ type Module struct {
 	currentCredential     func(*http.Request) (access.APICredential, bool)
 	authorizeAnyWorkspace func(context.Context, string, *access.APICredential, access.Privilege) (bool, error)
 	publications          PublicationService
+	product               *product.Handler
 	publicationCommands   map[string]uicommand.Binding
 }
 
@@ -99,7 +139,7 @@ func Build(_ context.Context, config Config) (*Module, error) {
 		publications: config.Publications, publicationCommands: config.PublicationCommands,
 	}
 	readModel := adminhttp.ReadModel{
-		Access: config.Access, AgentDetails: config.AgentDetails,
+		Access: config.Access, Avatars: config.PersonalAvatar, AgentDetails: config.AgentDetails,
 		StorageService: adminstorage.Service{
 			CatalogPath: config.Storage.CatalogPath, DataPath: config.Storage.DataPath,
 			Environment: config.Storage.Environment, ControlPlane: config.Storage.ControlPlane,
@@ -124,6 +164,62 @@ func Build(_ context.Context, config Config) (*Module, error) {
 		ReadModel: readModel, Layout: config.Layout,
 		EnsureClientID: config.EnsureClientID, Broker: config.Broker,
 		PublicationMutation: m.mutatePublication,
+		SettingsRepository:  config.SettingsAccess, WorkspaceSettings: config.WorkspaceSettings,
+		WorkspaceAccess: config.WorkspaceAccess, SettingsEnvironment: config.SettingsEnvironment,
+		CurrentCredential: config.CurrentCredential,
+	}
+	if config.SettingsAccess != nil {
+		personalService := &personalsettings.Service{
+			Repository: config.SettingsAccess, IdentityManagement: config.SettingsAccess,
+			Preferences: config.SettingsAccess,
+			Avatar:      config.PersonalAvatar, Authoring: config.AuthoringSessions,
+			Workspaces:           config.WorkspaceSettings,
+			LocalPasswordEnabled: config.LocalPasswordEnabled,
+		}
+		m.handler.PersonalSettings = &personalsettings.Handler{
+			Service: personalService, CurrentSession: config.CurrentSession,
+			CurrentPrincipal: func(r *http.Request) (string, bool) {
+				if config.CurrentPrincipal == nil {
+					return "", false
+				}
+				principal, ok := config.CurrentPrincipal(r)
+				return principal.ID, ok
+			},
+		}
+	}
+	if config.Product != nil {
+		config.Product.ConfigureCommandExecutor(config.ProductCommands)
+		settingsHandler, err := productsettings.NewHandler(productsettings.HTTPConfig{
+			ReadModel: productsettings.ReadModel{Service: config.Product, Status: config.ProductStatus, ControlPlane: config.Storage.ControlPlane},
+			CurrentPrincipal: func(r *http.Request) (product.Principal, bool) {
+				if config.CurrentPrincipal == nil {
+					return product.Principal{}, false
+				}
+				principal, ok := config.CurrentPrincipal(r)
+				return product.Principal{ID: principal.ID}, ok
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		m.handler.ProductSettings = settingsHandler
+	}
+	if config.Product != nil {
+		var err error
+		m.product, err = product.NewHandler(product.HTTPConfig{
+			Service: config.Product, Status: config.ProductStatus,
+			CommandFailure: config.ProductCommandFailure,
+			CurrentPrincipal: func(r *http.Request) (product.Principal, bool) {
+				if config.CurrentPrincipal == nil {
+					return product.Principal{}, false
+				}
+				principal, ok := config.CurrentPrincipal(r)
+				return product.Principal{ID: principal.ID}, ok
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 	return m, nil
 }

--- a/internal/admin/module/product.go
+++ b/internal/admin/module/product.go
@@ -1,0 +1,94 @@
+package module
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/flidai/leapview/internal/admin/product"
+)
+
+// Product aliases keep process composition on the admin module surface while
+// the product implementation remains private to the administration capability.
+type ProductService = product.Service
+type ProductStatus = product.Status
+type ProductBlob = product.Blob
+type ProductBlobStore = product.BlobStore
+type ProductCommandExecutor = product.CommandExecutor
+type ProductCommandFailureWriter = product.CommandFailureWriter
+type ProductAuthenticationStatus = product.AuthenticationStatus
+type ProductAvailability = product.Availability
+type ProductNamedAvailability = product.NamedAvailability
+type ProductAPIStatus = product.APIStatus
+type ProductSystemStatus = product.SystemStatus
+type ProductAgentStatus = product.AgentStatus
+type ProductLimits = product.Limits
+
+var ErrProductLogoNotFound = product.ErrNotFound
+
+func NewProductService(database *sql.DB, blobs ProductBlobStore) (*ProductService, error) {
+	return product.New(database, blobs)
+}
+
+func (m *Module) GetProductSettings(w http.ResponseWriter, r *http.Request) {
+	if m == nil || m.product == nil {
+		http.NotFound(w, r)
+		return
+	}
+	m.product.GetSettings(w, r)
+}
+
+func (m *Module) UpdateProductSettings(w http.ResponseWriter, r *http.Request) {
+	if m == nil || m.product == nil {
+		http.NotFound(w, r)
+		return
+	}
+	m.product.PatchSettings(w, r)
+}
+
+func (m *Module) UploadProductLogo(w http.ResponseWriter, r *http.Request) {
+	if m == nil || m.product == nil {
+		http.NotFound(w, r)
+		return
+	}
+	m.product.UploadLogo(w, r)
+}
+
+func (m *Module) DeleteProductLogo(w http.ResponseWriter, r *http.Request) {
+	if m == nil || m.product == nil {
+		http.NotFound(w, r)
+		return
+	}
+	m.product.DeleteLogo(w, r)
+}
+
+func (m *Module) GetProductLogo(w http.ResponseWriter, r *http.Request) {
+	if m == nil || m.product == nil {
+		http.NotFound(w, r)
+		return
+	}
+	m.product.GetLogo(w, r)
+}
+
+func (m *Module) GetProductAuthenticationStatus(w http.ResponseWriter, r *http.Request) {
+	if m == nil || m.product == nil {
+		http.NotFound(w, r)
+		return
+	}
+	m.product.GetAuthentication(w, r)
+}
+
+func (m *Module) GetProductSystemStatus(w http.ResponseWriter, r *http.Request) {
+	if m == nil || m.product == nil {
+		http.NotFound(w, r)
+		return
+	}
+	m.product.GetSystem(w, r)
+}
+
+func (m *Module) GetProductAPIStatus(w http.ResponseWriter, r *http.Request) {
+	if m == nil || m.product == nil {
+		http.NotFound(w, r)
+		return
+	}
+	m.product.GetAPIStatus(w, r)
+}

--- a/internal/admin/module/routes.go
+++ b/internal/admin/module/routes.go
@@ -10,6 +10,7 @@ import (
 type RouteGuard struct {
 	Protect             func(access.Privilege, http.HandlerFunc) http.HandlerFunc
 	ProtectGlobal       func(access.Privilege, http.HandlerFunc) http.HandlerFunc
+	ProtectPlatform     func(access.Privilege, http.HandlerFunc) http.HandlerFunc
 	ProtectAnyWorkspace func(access.Privilege, http.HandlerFunc) http.HandlerFunc
 }
 
@@ -18,19 +19,33 @@ func (m *Module) MountAuthenticated(r chi.Router, guard RouteGuard) {
 		return
 	}
 	h := m.handler
-	r.Get("/admin", guard.ProtectGlobal(access.PrivilegeManageGrants, h.AdminRoot))
-	r.Get("/admin/profile", guard.ProtectGlobal(access.PrivilegeManageGrants, h.Profile))
+	r.Get("/admin", guard.Protect("", h.AdminRoot))
+	r.Get("/admin/profile", guard.Protect("", h.Profile))
+	r.Get("/admin/security", guard.Protect("", h.Security))
+	r.Get("/admin/api-tokens", guard.Protect("", h.APITokens))
+	r.Post("/admin/personal-settings/command", guard.Protect("", h.PersonalSettingsCommand))
+	r.Get("/admin/general", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.General))
+	r.Get("/admin/workspaces", guard.ProtectGlobal(access.PrivilegeManageWorkspace, h.Workspaces))
 	r.Get("/admin/principals", guard.ProtectGlobal(access.PrivilegeManageGrants, h.Principals))
 	r.Post("/admin/principals/search", guard.ProtectGlobal(access.PrivilegeManageGrants, h.PrincipalsSearch))
 	r.Get("/admin/principals/{principal}", guard.ProtectGlobal(access.PrivilegeManageGrants, h.PrincipalDetail))
 	r.Get("/admin/groups", guard.ProtectGlobal(access.PrivilegeManageGrants, h.Groups))
 	r.Post("/admin/groups/search", guard.ProtectGlobal(access.PrivilegeManageGrants, h.GroupsSearch))
 	r.Get("/admin/groups/{group}", guard.ProtectGlobal(access.PrivilegeManageGrants, h.GroupDetail))
-	r.Get("/admin/agent", guard.ProtectGlobal(access.PrivilegeManageGrants, h.Agent))
-	r.Get("/admin/storage", guard.ProtectGlobal(access.PrivilegeManageGrants, h.Storage))
-	r.Post("/admin/storage/select-table", guard.ProtectGlobal(access.PrivilegeManageGrants, h.StorageTableSelect))
+	r.Get("/admin/service-accounts", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.ServiceAccounts))
+	r.Post("/admin/service-accounts/command", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.ServiceAccountCommand))
+	r.Get("/admin/authentication", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.Authentication))
+	r.Post("/admin/product-settings/command", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.ProductSettingsCommand))
+	r.Put("/admin/product-logo", guard.ProtectPlatform(access.PrivilegeManagePlatform, m.UploadProductLogo))
+	r.Get("/product/logo/{digest}", guard.Protect("", m.GetProductLogo))
+	r.Get("/admin/agent", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.Agent))
+	r.Get("/admin/storage", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.Storage))
+	r.Post("/admin/storage/select-table", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.StorageTableSelect))
 	r.Get("/admin/queries", guard.ProtectGlobal(access.PrivilegeViewAudit, h.Queries))
 	r.Post("/admin/queries/command", guard.ProtectGlobal(access.PrivilegeViewAudit, h.QueryCommand))
+	r.Get("/admin/audit", guard.ProtectGlobal(access.PrivilegeViewAudit, h.Audit))
+	r.Post("/admin/audit/command", guard.ProtectGlobal(access.PrivilegeViewAudit, h.AuditLogCommand))
+	r.Get("/admin/system", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.System))
 	r.Get("/admin/publications", guard.ProtectAnyWorkspace(access.PrivilegeManagePublications, h.Publications))
 	r.Post("/admin/publications/command", guard.ProtectAnyWorkspace(access.PrivilegeManagePublications, h.PublicationCommand))
 }

--- a/internal/admin/personalsettings/handler.go
+++ b/internal/admin/personalsettings/handler.go
@@ -1,0 +1,132 @@
+package personalsettings
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Yacobolo/toolbelt/pagestream"
+)
+
+type PrincipalProvider func(*http.Request) (string, bool)
+type SessionProvider func(*http.Request) (string, bool)
+
+type commandSignals struct {
+	Profile          ProfileCommand          `json:"personalProfileCommand"`
+	Theme            ThemeCommand            `json:"personalThemeCommand"`
+	Password         PasswordCommand         `json:"personalPasswordCommand"`
+	Session          SessionCommand          `json:"personalSessionCommand"`
+	AuthoringSession AuthoringSessionCommand `json:"personalAuthoringSessionCommand"`
+	Token            TokenCommand            `json:"personalTokenCommand"`
+}
+
+type Handler struct {
+	Service          *Service
+	CurrentPrincipal PrincipalProvider
+	CurrentSession   SessionProvider
+}
+
+// Bootstrap emits the settings state as a normal Datastar signal patch. The
+// admin page may call it from its canonical updates stream; it does not make a
+// browser fetch to load personal settings.
+func (h Handler) Bootstrap(w http.ResponseWriter, r *http.Request) {
+	principalID, ok := h.currentPrincipal(r)
+	if !ok {
+		h.writeError(w, r, ErrPrincipalRequired, http.StatusUnauthorized)
+		return
+	}
+	state, err := h.load(r, principalID)
+	if err != nil {
+		h.writeError(w, r, err, http.StatusInternalServerError)
+		return
+	}
+	_ = pagestream.PatchResponse(w, r, map[string]any{"personalSettings": state})
+}
+
+// Command applies one typed settings command and returns a complete state
+// patch. Sending the resulting state keeps the browser component declarative
+// and avoids ad hoc GET requests after mutations.
+func (h Handler) Command(w http.ResponseWriter, r *http.Request) {
+	principalID, ok := h.currentPrincipal(r)
+	if !ok {
+		h.writeError(w, r, ErrPrincipalRequired, http.StatusUnauthorized)
+		return
+	}
+	if h.Service == nil {
+		h.writeError(w, r, errors.New("personal settings are unavailable"), http.StatusServiceUnavailable)
+		return
+	}
+	var signals commandSignals
+	if err := pagestream.ReadSignals(r, &signals); err != nil {
+		h.writeError(w, r, err, http.StatusBadRequest)
+		return
+	}
+	var commandErr error
+	var newToken *string
+	switch {
+	case signals.Profile.Action == "refresh":
+		// The avatar upload is the binary API exception; refresh only reloads signals.
+	case signals.Profile.Action != "":
+		commandErr = h.Service.ApplyProfile(r.Context(), principalID, signals.Profile)
+	case signals.Theme.Action != "":
+		commandErr = h.Service.ApplyTheme(r.Context(), principalID, signals.Theme)
+	case signals.Password.CurrentPassword != "" || signals.Password.NewPassword != "":
+		commandErr = h.Service.ApplyPassword(r.Context(), principalID, signals.Password)
+	case signals.Session.Action != "":
+		commandErr = h.Service.RevokeSession(r.Context(), principalID, signals.Session)
+	case signals.AuthoringSession.Action != "":
+		commandErr = h.Service.RevokeAuthoringSession(r.Context(), principalID, signals.AuthoringSession)
+	case signals.Token.Action != "":
+		newToken, commandErr = h.Service.ApplyToken(r.Context(), principalID, signals.Token)
+	default:
+		commandErr = ErrCommandInvalid
+	}
+	if commandErr != nil {
+		status := http.StatusBadRequest
+		if errors.Is(commandErr, ErrPrincipalRequired) {
+			status = http.StatusUnauthorized
+		}
+		h.writeError(w, r, commandErr, status)
+		return
+	}
+	state, err := h.load(r, principalID)
+	if err != nil {
+		h.writeError(w, r, err, http.StatusInternalServerError)
+		return
+	}
+	if newToken != nil {
+		state.Tokens.NewToken = newToken
+	}
+	_ = pagestream.PatchResponse(w, r, BootstrapSignals(state))
+}
+
+func (h Handler) currentPrincipal(r *http.Request) (string, bool) {
+	if h.CurrentPrincipal == nil {
+		return "", false
+	}
+	id, ok := h.CurrentPrincipal(r)
+	return strings.TrimSpace(id), ok && strings.TrimSpace(id) != ""
+}
+
+func (h Handler) load(r *http.Request, principalID string) (Signal, error) {
+	currentSessionID := ""
+	if h.CurrentSession != nil {
+		currentSessionID, _ = h.CurrentSession(r)
+	}
+	active := strings.TrimSpace(r.URL.Query().Get("section"))
+	state, err := h.Service.Load(r.Context(), principalID, currentSessionID, active == "api-tokens")
+	state.Active = active
+	return state, err
+}
+
+func (h Handler) State(r *http.Request) (Signal, error) {
+	principalID, ok := h.currentPrincipal(r)
+	if !ok {
+		return Signal{}, ErrPrincipalRequired
+	}
+	return h.load(r, principalID)
+}
+
+func (h Handler) writeError(w http.ResponseWriter, r *http.Request, err error, status int) {
+	http.Error(w, err.Error(), status)
+}

--- a/internal/admin/personalsettings/service.go
+++ b/internal/admin/personalsettings/service.go
@@ -1,0 +1,369 @@
+package personalsettings
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
+	"github.com/flidai/leapview/internal/workspace"
+)
+
+var (
+	ErrPrincipalRequired        = errors.New("authenticated principal is required")
+	ErrCommandInvalid           = errors.New("personal settings command is invalid")
+	ErrDisplayNameManaged       = errors.New("display name is managed by the identity provider")
+	ErrLocalPasswordUnavailable = errors.New("local password changes are unavailable for this principal")
+	ErrTokenPrincipal           = errors.New("personal API tokens are only available to user principals")
+	ErrSessionNotOwned          = errors.New("session does not belong to the current principal")
+)
+
+// Repository is intentionally narrower than access.Repository.  It keeps the
+// settings vertical slice easy to exercise with in-memory fakes while the
+// production access repository satisfies it directly.
+type Repository interface {
+	PrincipalByID(context.Context, string) (access.Principal, error)
+	UpsertPrincipal(context.Context, access.PrincipalInput) (access.Principal, error)
+	ChangeLocalPassword(context.Context, string, string, string) (access.LocalCredential, error)
+	ListSessions(context.Context, string) ([]access.Session, error)
+	RevokeSessionForPrincipal(context.Context, string, string) error
+	ListAPITokens(context.Context, string) ([]access.APIToken, error)
+	CreateAPITokenWithMetadata(context.Context, access.APITokenInput) (string, access.APIToken, error)
+	RevokeAPITokenForPrincipal(context.Context, string, string) error
+	EffectivePrivileges(context.Context, string, access.ObjectRef) ([]access.Privilege, error)
+	RecordAuditEvent(context.Context, access.AuditEventInput) error
+}
+
+type IdentityManagementReader interface {
+	PrincipalIdentityManagement(context.Context, string) (access.PrincipalIdentityManagement, error)
+}
+
+type PreferencesRepository interface {
+	access.AuditedPrincipalPreferences
+}
+
+type AvatarReader interface {
+	Current(context.Context, string) (avatar.Metadata, error)
+}
+
+type AuthoringReader interface {
+	ListSessions(context.Context, string) ([]access.AuthoringSession, error)
+	RevokeSession(context.Context, string, string) error
+}
+
+type WorkspaceReader interface {
+	List(context.Context) ([]workspace.Summary, error)
+}
+
+type Service struct {
+	Repository           Repository
+	Preferences          PreferencesRepository
+	IdentityManagement   IdentityManagementReader
+	Avatar               AvatarReader
+	Authoring            AuthoringReader
+	Workspaces           WorkspaceReader
+	LocalPasswordEnabled bool
+	Now                  func() time.Time
+}
+
+func (s *Service) Load(ctx context.Context, principalID, currentSessionID string, includeTokenScopes bool) (Signal, error) {
+	principalID = strings.TrimSpace(principalID)
+	if principalID == "" {
+		return Signal{}, ErrPrincipalRequired
+	}
+	if s == nil || s.Repository == nil {
+		return Signal{}, fmt.Errorf("personal settings repository is unavailable")
+	}
+	principal, err := s.Repository.PrincipalByID(ctx, principalID)
+	if err != nil {
+		return Signal{}, err
+	}
+	theme := access.ThemeSystem
+	if s.Preferences != nil {
+		preferences, preferencesErr := s.Preferences.PrincipalPreferences(ctx, principalID)
+		if preferencesErr == nil {
+			theme = preferences.Theme
+		} else if !errors.Is(preferencesErr, sql.ErrNoRows) {
+			return Signal{}, preferencesErr
+		}
+	}
+	identity := access.PrincipalIdentityManagement{Source: access.IdentityManagementLocal}
+	if s.IdentityManagement != nil {
+		identity, err = s.IdentityManagement.PrincipalIdentityManagement(ctx, principalID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return Signal{}, err
+		}
+	}
+	var avatarURL *string
+	if s.Avatar != nil && principal.Kind == access.PrincipalKindUser {
+		if metadata, avatarErr := s.Avatar.Current(ctx, principalID); avatarErr == nil {
+			if currentURL := avatar.URLForPrincipal(principalID, metadata); currentURL != "" {
+				avatarURL = &currentURL
+			}
+		}
+	}
+	sessions, err := s.Repository.ListSessions(ctx, principalID)
+	if err != nil {
+		return Signal{}, err
+	}
+	tokens, err := s.Repository.ListAPITokens(ctx, principalID)
+	if err != nil {
+		return Signal{}, err
+	}
+	tokenScopes := []TokenScopeSignal{}
+	if includeTokenScopes {
+		tokenScopes, err = s.tokenScopes(ctx, principalID)
+		if err != nil {
+			return Signal{}, err
+		}
+	}
+	result := Signal{
+		Profile:  signalFromPrincipal(principal, identity, avatarURL, theme),
+		Security: SecuritySignal{LocalPasswordEnabled: s.LocalPasswordEnabled, Sessions: make([]SessionSignal, 0, len(sessions))},
+		Tokens:   TokensSignal{Items: make([]TokenSignal, 0, len(tokens)), Scopes: tokenScopes},
+	}
+	for _, session := range sessions {
+		result.Security.Sessions = append(result.Security.Sessions, sessionSignal(session, currentSessionID))
+	}
+	for _, token := range tokens {
+		if strings.TrimSpace(token.RevokedAt) != "" {
+			continue
+		}
+		result.Tokens.Items = append(result.Tokens.Items, tokenSignal(token))
+	}
+	if s.Authoring != nil {
+		authoringSessions, authoringErr := s.Authoring.ListSessions(ctx, principalID)
+		if authoringErr != nil {
+			return Signal{}, authoringErr
+		}
+		result.Security.AuthoringSessions = make([]AuthoringSessionSignal, 0, len(authoringSessions))
+		for _, session := range authoringSessions {
+			result.Security.AuthoringSessions = append(result.Security.AuthoringSessions, authoringSessionSignal(session))
+		}
+	} else {
+		result.Security.AuthoringSessions = []AuthoringSessionSignal{}
+	}
+	return result, nil
+}
+
+func (s *Service) ApplyTheme(ctx context.Context, principalID string, command ThemeCommand) error {
+	if strings.TrimSpace(command.Action) != "save" {
+		return fmt.Errorf("%w: theme action %q", ErrCommandInvalid, command.Action)
+	}
+	theme, ok := access.ParseThemeMode(command.Theme)
+	if !ok {
+		return fmt.Errorf("unsupported theme %q", command.Theme)
+	}
+	if s == nil || s.Preferences == nil {
+		return fmt.Errorf("personal preferences are unavailable")
+	}
+	return s.Preferences.SetPrincipalThemeAudited(ctx, strings.TrimSpace(principalID), theme)
+}
+
+func (s *Service) ApplyProfile(ctx context.Context, principalID string, command ProfileCommand) error {
+	if strings.TrimSpace(command.Action) != "save" && strings.TrimSpace(command.Action) != "update" {
+		return fmt.Errorf("%w: profile action %q", ErrCommandInvalid, command.Action)
+	}
+	principal, identity, err := s.principalAndIdentity(ctx, principalID)
+	if err != nil {
+		return err
+	}
+	if identity.Source != "" && identity.Source != access.IdentityManagementLocal {
+		return ErrDisplayNameManaged
+	}
+	displayName := strings.TrimSpace(command.DisplayName)
+	if displayName == "" || len(displayName) > 200 {
+		return fmt.Errorf("display name must contain between 1 and 200 bytes")
+	}
+	return s.runAudited(ctx, func(repository Repository) (access.AuditEventInput, error) {
+		updated, err := repository.UpsertPrincipal(ctx, access.PrincipalInput{
+			ID: principal.ID, Kind: principal.Kind, Email: principal.Email, DisplayName: displayName,
+		})
+		return access.AuditEventInput{
+			PrincipalID: principal.ID, Action: "principal.profile.updated", TargetType: "principal", TargetID: updated.ID,
+			Status: "success", MetadataJSON: `{"field":"displayName"}`,
+		}, err
+	})
+}
+
+func (s *Service) ApplyPassword(ctx context.Context, principalID string, command PasswordCommand) error {
+	if command.CurrentPassword == "" || command.NewPassword == "" || command.CurrentPassword == command.NewPassword {
+		return fmt.Errorf("current and new passwords must be present and differ")
+	}
+	_, identity, err := s.principalAndIdentity(ctx, principalID)
+	if err != nil {
+		return err
+	}
+	if !s.LocalPasswordEnabled || !identity.HasLocalPassword {
+		return ErrLocalPasswordUnavailable
+	}
+	return s.runAudited(ctx, func(repository Repository) (access.AuditEventInput, error) {
+		_, err := repository.ChangeLocalPassword(ctx, principalID, command.CurrentPassword, command.NewPassword)
+		return access.AuditEventInput{
+			PrincipalID: principalID, Action: "password.changed", TargetType: "principal", TargetID: principalID,
+			Status: "success", MetadataJSON: `{"provider":"local"}`,
+		}, err
+	})
+}
+
+func (s *Service) RevokeSession(ctx context.Context, principalID string, command SessionCommand) error {
+	if strings.TrimSpace(command.Action) != "revoke" || strings.TrimSpace(command.SessionID) == "" {
+		return fmt.Errorf("%w: session revoke", ErrCommandInvalid)
+	}
+	return s.runAudited(ctx, func(repository Repository) (access.AuditEventInput, error) {
+		err := repository.RevokeSessionForPrincipal(ctx, principalID, strings.TrimSpace(command.SessionID))
+		return access.AuditEventInput{
+			PrincipalID: principalID, Action: "session.revoked", TargetType: "session", TargetID: command.SessionID,
+			Status: "success", MetadataJSON: `{}`,
+		}, err
+	})
+}
+
+func (s *Service) RevokeAuthoringSession(ctx context.Context, principalID string, command AuthoringSessionCommand) error {
+	if s.Authoring == nil {
+		return fmt.Errorf("authoring sessions are unavailable")
+	}
+	if strings.TrimSpace(command.Action) != "revoke" || strings.TrimSpace(command.SessionID) == "" {
+		return fmt.Errorf("%w: authoring session revoke", ErrCommandInvalid)
+	}
+	// The authoring service owns its transactional audit event.
+	return s.Authoring.RevokeSession(ctx, principalID, strings.TrimSpace(command.SessionID))
+}
+
+func (s *Service) ApplyToken(ctx context.Context, principalID string, command TokenCommand) (*string, error) {
+	principal, err := s.Repository.PrincipalByID(ctx, principalID)
+	if err != nil {
+		return nil, err
+	}
+	if principal.Kind != "" && principal.Kind != access.PrincipalKindUser {
+		return nil, ErrTokenPrincipal
+	}
+	switch strings.TrimSpace(command.Action) {
+	case "revoke":
+		if strings.TrimSpace(command.TokenID) == "" {
+			return nil, fmt.Errorf("%w: token id is required", ErrCommandInvalid)
+		}
+		return nil, s.runAudited(ctx, func(repository Repository) (access.AuditEventInput, error) {
+			err := repository.RevokeAPITokenForPrincipal(ctx, principalID, command.TokenID)
+			return access.AuditEventInput{PrincipalID: principalID, Action: "api_token.revoked", TargetType: "api_token", TargetID: command.TokenID, Status: "success", MetadataJSON: `{}`}, err
+		})
+	case "create":
+		name := strings.TrimSpace(command.Name)
+		if name == "" || len(name) > 200 {
+			return nil, fmt.Errorf("token name must contain between 1 and 200 bytes")
+		}
+		if len(command.Privileges) == 0 {
+			return nil, fmt.Errorf("select at least one privilege for the API token")
+		}
+		var privileges []access.Privilege
+		if len(command.Privileges) > 0 {
+			privileges = make([]access.Privilege, 0, len(command.Privileges))
+		}
+		for _, raw := range command.Privileges {
+			privilege, ok := access.ParsePrivilege(raw)
+			if !ok {
+				return nil, fmt.Errorf("unsupported API token privilege %q", raw)
+			}
+			privileges = append(privileges, privilege)
+		}
+		workspaceID := strings.TrimSpace(command.WorkspaceID)
+		if len(privileges) > 0 {
+			target := access.PlatformObject()
+			if workspaceID != "" {
+				target = access.WorkspaceObject(workspaceID)
+			}
+			effective, effectiveErr := s.Repository.EffectivePrivileges(ctx, principalID, target)
+			if effectiveErr != nil {
+				return nil, effectiveErr
+			}
+			allowed := make(map[access.Privilege]struct{}, len(effective))
+			for _, privilege := range effective {
+				allowed[privilege] = struct{}{}
+			}
+			for _, privilege := range privileges {
+				if _, ok := allowed[privilege]; !ok {
+					return nil, fmt.Errorf("requested API token privileges exceed effective access")
+				}
+			}
+		}
+		var expiresAt time.Time
+		if strings.TrimSpace(command.ExpiresAt) != "" {
+			expiresAt, err = time.Parse(time.RFC3339, strings.TrimSpace(command.ExpiresAt))
+			if err != nil {
+				return nil, fmt.Errorf("invalid token expiry: %w", err)
+			}
+			if !expiresAt.After(s.now()) {
+				return nil, fmt.Errorf("token expiry must be in the future")
+			}
+		}
+		var secret string
+		err = s.runAudited(ctx, func(repository Repository) (access.AuditEventInput, error) {
+			createdSecret, token, createErr := repository.CreateAPITokenWithMetadata(ctx, access.APITokenInput{
+				PrincipalID: principalID, WorkspaceID: workspaceID, Name: name, Privileges: privileges, ExpiresAt: expiresAt,
+			})
+			secret = createdSecret
+			return access.AuditEventInput{PrincipalID: principalID, WorkspaceID: workspaceID, Action: "api_token.created", TargetType: "api_token", TargetID: token.ID, Status: "success", MetadataJSON: metadataJSON(map[string]string{"name": name})}, createErr
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &secret, nil
+	default:
+		return nil, fmt.Errorf("%w: token action %q", ErrCommandInvalid, command.Action)
+	}
+}
+
+func (s *Service) principalAndIdentity(ctx context.Context, principalID string) (access.Principal, access.PrincipalIdentityManagement, error) {
+	principal, err := s.Repository.PrincipalByID(ctx, strings.TrimSpace(principalID))
+	if err != nil {
+		return access.Principal{}, access.PrincipalIdentityManagement{}, err
+	}
+	identity := access.PrincipalIdentityManagement{Source: access.IdentityManagementLocal}
+	if s.IdentityManagement != nil {
+		identity, err = s.IdentityManagement.PrincipalIdentityManagement(ctx, principal.ID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return access.Principal{}, access.PrincipalIdentityManagement{}, err
+		}
+	}
+	return principal, identity, nil
+}
+
+func (s *Service) audit(ctx context.Context, event access.AuditEventInput) error {
+	if event.MetadataJSON == "" {
+		event.MetadataJSON = "{}"
+	}
+	return s.Repository.RecordAuditEvent(ctx, event)
+}
+
+func (s *Service) runAudited(ctx context.Context, mutation func(Repository) (access.AuditEventInput, error)) error {
+	if transactional, ok := s.Repository.(access.AuditedMutationRepository); ok {
+		return transactional.RunAuditedMutation(ctx, func(repository access.Repository) (access.AuditEventInput, error) {
+			return mutation(repository)
+		})
+	}
+	event, err := mutation(s.Repository)
+	if err != nil {
+		return err
+	}
+	return s.audit(ctx, event)
+}
+
+func (s *Service) now() time.Time {
+	if s != nil && s.Now != nil {
+		return s.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func metadataJSON(value map[string]string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}

--- a/internal/admin/personalsettings/service_test.go
+++ b/internal/admin/personalsettings/service_test.go
@@ -1,0 +1,202 @@
+package personalsettings
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/avatar"
+	"github.com/flidai/leapview/internal/workspace"
+)
+
+func TestBootstrapSignalsExplicitlyClearNullableState(t *testing.T) {
+	payload, err := json.Marshal(BootstrapSignals(Signal{})["personalSettings"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"avatarUrl":null`, `"newToken":null`} {
+		if !strings.Contains(string(payload), want) {
+			t.Fatalf("payload = %s, want %s", payload, want)
+		}
+	}
+}
+
+type fakeRepository struct {
+	principal       access.Principal
+	identity        access.PrincipalIdentityManagement
+	identityErr     error
+	sessions        []access.Session
+	tokens          []access.APIToken
+	privileges      []access.Privilege
+	audits          []access.AuditEventInput
+	passwordChanged bool
+	createdToken    bool
+	theme           access.ThemeMode
+	themeChanged    bool
+}
+
+func (f *fakeRepository) PrincipalPreferences(context.Context, string) (access.PrincipalPreferences, error) {
+	return access.PrincipalPreferences{PrincipalID: f.principal.ID, Theme: f.theme}, nil
+}
+
+func (f *fakeRepository) SetPrincipalThemeAudited(_ context.Context, principalID string, theme access.ThemeMode) error {
+	f.theme = theme
+	f.themeChanged = true
+	f.audits = append(f.audits, access.AuditEventInput{PrincipalID: principalID, Action: "principal.theme.updated"})
+	return nil
+}
+
+func (f *fakeRepository) PrincipalByID(context.Context, string) (access.Principal, error) {
+	return f.principal, nil
+}
+func (f *fakeRepository) UpsertPrincipal(_ context.Context, input access.PrincipalInput) (access.Principal, error) {
+	f.principal.DisplayName = input.DisplayName
+	return f.principal, nil
+}
+func (f *fakeRepository) ChangeLocalPassword(context.Context, string, string, string) (access.LocalCredential, error) {
+	f.passwordChanged = true
+	return access.LocalCredential{}, nil
+}
+func (f *fakeRepository) ListSessions(context.Context, string) ([]access.Session, error) {
+	return f.sessions, nil
+}
+func (f *fakeRepository) RevokeSessionForPrincipal(_ context.Context, _, id string) error {
+	for i := range f.sessions {
+		if f.sessions[i].ID == id {
+			f.sessions[i].RevokedAt = "revoked"
+			return nil
+		}
+	}
+	return errors.New("missing session")
+}
+func (f *fakeRepository) ListAPITokens(context.Context, string) ([]access.APIToken, error) {
+	return f.tokens, nil
+}
+func (f *fakeRepository) CreateAPITokenWithMetadata(_ context.Context, input access.APITokenInput) (string, access.APIToken, error) {
+	f.createdToken = true
+	row := access.APIToken{ID: "token-2", PrincipalID: input.PrincipalID, Name: input.Name, WorkspaceID: input.WorkspaceID, Privileges: input.Privileges, CreatedAt: "now"}
+	f.tokens = append(f.tokens, row)
+	return "lv_test_secret", row, nil
+}
+func (f *fakeRepository) RevokeAPITokenForPrincipal(_ context.Context, _, id string) error {
+	for i := range f.tokens {
+		if f.tokens[i].ID == id {
+			f.tokens[i].RevokedAt = "revoked"
+			return nil
+		}
+	}
+	return errors.New("missing token")
+}
+func (f *fakeRepository) EffectivePrivileges(context.Context, string, access.ObjectRef) ([]access.Privilege, error) {
+	return f.privileges, nil
+}
+func (f *fakeRepository) RecordAuditEvent(_ context.Context, event access.AuditEventInput) error {
+	f.audits = append(f.audits, event)
+	return nil
+}
+func (f *fakeRepository) PrincipalIdentityManagement(context.Context, string) (access.PrincipalIdentityManagement, error) {
+	return f.identity, f.identityErr
+}
+
+type fakeAvatar struct{}
+
+func (fakeAvatar) Current(context.Context, string) (avatar.Metadata, error) {
+	return avatar.Metadata{SHA256: "abc123"}, nil
+}
+
+type fakeAuthoring struct{ sessions []access.AuthoringSession }
+
+func (f *fakeAuthoring) ListSessions(context.Context, string) ([]access.AuthoringSession, error) {
+	return f.sessions, nil
+}
+func (f *fakeAuthoring) RevokeSession(context.Context, string, string) error { return nil }
+
+type fakeWorkspaces struct{ rows []workspace.Summary }
+
+func (f fakeWorkspaces) List(context.Context) ([]workspace.Summary, error) { return f.rows, nil }
+
+func testService(repo *fakeRepository) *Service {
+	return &Service{Repository: repo, Preferences: repo, IdentityManagement: repo, Avatar: fakeAvatar{}, Authoring: &fakeAuthoring{sessions: []access.AuthoringSession{{ID: "authoring-1", Kind: access.AuthoringSessionHumanCLI, ClientID: access.AuthoringCLIClientID, CreatedAt: time.Unix(1, 0), Scope: access.AuthoringScope{TargetID: "instance", ProjectID: "project", Privileges: []access.Privilege{access.PrivilegeAuthorProject}}}}}, LocalPasswordEnabled: true}
+}
+
+func TestServiceLoadBuildsPersonalSettingsSignal(t *testing.T) {
+	repo := &fakeRepository{
+		principal: access.Principal{ID: "principal-1", Kind: access.PrincipalKindUser, Email: "user@example.com", DisplayName: "User"},
+		identity:  access.PrincipalIdentityManagement{Source: access.IdentityManagementLocal, HasLocalPassword: true},
+		sessions:  []access.Session{{ID: "browser-1", Kind: access.SessionKindBrowser, CreatedAt: "today"}, {ID: "desktop-1", Kind: access.SessionKindDesktop, ClientID: "LeapView Desktop"}},
+		tokens: []access.APIToken{
+			{ID: "token-1", Name: "CI", Privileges: []access.Privilege{access.PrivilegeQueryData}},
+			{ID: "token-revoked", Name: "Old CI", RevokedAt: "yesterday"},
+		},
+		theme: access.ThemeDark,
+	}
+	service := testService(repo)
+	service.Workspaces = fakeWorkspaces{rows: []workspace.Summary{
+		{ID: "sales", Title: "Sales analytics", Description: "Revenue and pipeline reporting."},
+		{ID: "operations", Title: "Operations"},
+	}}
+	repo.privileges = []access.Privilege{access.PrivilegeUseWorkspace, access.PrivilegeQueryData}
+	state, err := service.Load(context.Background(), "principal-1", "desktop-1", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Profile.AvatarURL == nil || *state.Profile.AvatarURL != "/profile/avatars/principal-1/abc123" {
+		t.Fatalf("avatar URL = %v", state.Profile.AvatarURL)
+	}
+	if !state.Profile.CanEditDisplayName || !state.Profile.HasLocalPassword {
+		t.Fatalf("profile edit state = %#v", state.Profile)
+	}
+	if state.Profile.Theme != string(access.ThemeDark) {
+		t.Fatalf("profile theme = %q, want dark", state.Profile.Theme)
+	}
+	if !state.Security.Sessions[1].Current || state.Security.Sessions[1].ClientLabel != "LeapView Desktop" {
+		t.Fatalf("sessions = %#v", state.Security.Sessions)
+	}
+	if len(state.Security.AuthoringSessions) != 1 || state.Security.AuthoringSessions[0].Privileges[0] != string(access.PrivilegeAuthorProject) {
+		t.Fatalf("authoring sessions = %#v", state.Security.AuthoringSessions)
+	}
+	if len(state.Tokens.Items) != 1 || state.Tokens.Items[0].ID != "token-1" {
+		t.Fatalf("tokens = %#v", state.Tokens)
+	}
+	if len(state.Tokens.Scopes) != 3 {
+		t.Fatalf("token scopes = %#v", state.Tokens.Scopes)
+	}
+	if scope := state.Tokens.Scopes[1]; scope.Kind != "workspace" || scope.WorkspaceID != "operations" || scope.Label != "Operations" || len(scope.Privileges) != 2 {
+		t.Fatalf("operations token scope = %#v", scope)
+	}
+	if privilege := state.Tokens.Scopes[2].Privileges[1]; privilege.Value != string(access.PrivilegeQueryData) || privilege.Label != "Query data" || privilege.Category != "Data" || privilege.Description == "" {
+		t.Fatalf("query privilege = %#v", privilege)
+	}
+}
+
+func TestServiceMutationsAuditAndValidateIdentity(t *testing.T) {
+	repo := &fakeRepository{principal: access.Principal{ID: "principal-1", Kind: access.PrincipalKindUser, Email: "user@example.com"}, identity: access.PrincipalIdentityManagement{Source: access.IdentityManagementLocal, HasLocalPassword: true}, privileges: []access.Privilege{access.PrivilegeQueryData}}
+	service := testService(repo)
+	if err := service.ApplyProfile(context.Background(), "principal-1", ProfileCommand{Action: "save", DisplayName: "Updated"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.ApplyPassword(context.Background(), "principal-1", PasswordCommand{CurrentPassword: "old", NewPassword: "new"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.ApplyTheme(context.Background(), "principal-1", ThemeCommand{Action: "save", Theme: "dark_colorblind"}); err != nil {
+		t.Fatal(err)
+	}
+	secret, err := service.ApplyToken(context.Background(), "principal-1", TokenCommand{Action: "create", Name: "CI", Privileges: []string{string(access.PrivilegeQueryData)}})
+	if err != nil || secret == nil || *secret != "lv_test_secret" {
+		t.Fatalf("create token = %v, %v", secret, err)
+	}
+	if !repo.passwordChanged || !repo.createdToken || !repo.themeChanged || repo.theme != access.ThemeDarkColorblind || len(repo.audits) != 4 {
+		t.Fatalf("mutations changed=%v token=%v audits=%d", repo.passwordChanged, repo.createdToken, len(repo.audits))
+	}
+	if _, err := service.ApplyToken(context.Background(), "principal-1", TokenCommand{Action: "create", Name: "Unscoped"}); err == nil || !strings.Contains(err.Error(), "at least one privilege") {
+		t.Fatalf("empty token privileges error = %v", err)
+	}
+	repo.identity.Source = access.IdentityManagementExternal
+	if err := service.ApplyProfile(context.Background(), "principal-1", ProfileCommand{Action: "save", DisplayName: "Nope"}); !errors.Is(err, ErrDisplayNameManaged) {
+		t.Fatalf("external profile error = %v", err)
+	}
+}

--- a/internal/admin/personalsettings/signals.go
+++ b/internal/admin/personalsettings/signals.go
@@ -1,0 +1,93 @@
+// Package personalsettings contains the personal settings vertical slice used
+// by the platform administration surface.  It deliberately owns its signal
+// models so the admin page can adopt the surface without coupling the access
+// API transport to the Datastar command loop.
+package personalsettings
+
+import (
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	uisignals "github.com/flidai/leapview/internal/admin/ui/signals"
+)
+
+// These aliases keep the vertical slice readable while making the generated
+// TypeSpec models the only definition of the browser contract.
+type Signal = uisignals.PersonalSettingsSignal
+type ProfileSignal = uisignals.PersonalProfileSignal
+type SecuritySignal = uisignals.PersonalSecuritySignal
+type SessionSignal = uisignals.PersonalSessionSignal
+type AuthoringSessionSignal = uisignals.PersonalAuthoringSessionSignal
+type TokensSignal = uisignals.PersonalTokensSignal
+type TokenSignal = uisignals.PersonalTokenSignal
+type TokenScopeSignal = uisignals.PersonalTokenScopeSignal
+type TokenPrivilegeSignal = uisignals.PersonalTokenPrivilegeSignal
+type ProfileCommand = uisignals.PersonalProfileCommand
+type ThemeCommand = uisignals.PersonalThemeCommand
+type PasswordCommand = uisignals.PersonalPasswordCommand
+type SessionCommand = uisignals.PersonalSessionCommand
+type AuthoringSessionCommand = uisignals.PersonalAuthoringSessionCommand
+type TokenCommand = uisignals.PersonalTokenCommand
+
+func signalFromPrincipal(principal access.Principal, identity access.PrincipalIdentityManagement, avatarURL *string, theme access.ThemeMode) ProfileSignal {
+	identitySource := string(identity.Source)
+	if identitySource == "" {
+		identitySource = string(access.IdentityManagementLocal)
+	}
+	return ProfileSignal{
+		ID: principal.ID, Email: principal.Email, DisplayName: principal.DisplayName,
+		AvatarURL: avatarURL, Theme: string(theme), IdentitySource: identitySource,
+		CanEditDisplayName: identitySource == string(access.IdentityManagementLocal),
+		HasLocalPassword:   identity.HasLocalPassword,
+	}
+}
+
+func sessionSignal(value access.Session, currentSessionID string) SessionSignal {
+	label := "Browser"
+	if value.Kind == access.SessionKindDesktop {
+		label = value.ClientID
+		if label == "" {
+			label = "Desktop app"
+		}
+	}
+	return SessionSignal{
+		ID: value.ID, Kind: string(value.Kind), ClientLabel: label,
+		Current:   value.ID != "" && value.ID == currentSessionID,
+		CreatedAt: value.CreatedAt, LastSeenAt: value.LastSeenAt,
+		ExpiresAt: value.ExpiresAt, AbsoluteExpiresAt: value.AbsoluteExpiresAt,
+		RevokedAt: value.RevokedAt,
+	}
+}
+
+func authoringSessionSignal(value access.AuthoringSession) AuthoringSessionSignal {
+	privileges := make([]string, 0, len(value.Scope.Privileges))
+	for _, privilege := range value.Scope.Privileges {
+		privileges = append(privileges, string(privilege))
+	}
+	return AuthoringSessionSignal{
+		ID: value.ID, Kind: string(value.Kind), ClientID: value.ClientID,
+		TargetID: value.Scope.TargetID, ProjectID: value.Scope.ProjectID,
+		Privileges: privileges, CreatedAt: formatTime(value.CreatedAt),
+		LastUsedAt: formatTime(value.LastUsedAt), ExpiresAt: formatTime(value.ExpiresAt),
+		RevokedAt: formatTime(value.RevokedAt),
+	}
+}
+
+func tokenSignal(value access.APIToken) TokenSignal {
+	privileges := make([]string, 0, len(value.Privileges))
+	for _, privilege := range value.Privileges {
+		privileges = append(privileges, string(privilege))
+	}
+	return TokenSignal{
+		ID: value.ID, Name: value.Name, WorkspaceID: value.WorkspaceID,
+		Privileges: privileges, CreatedAt: value.CreatedAt, LastUsedAt: value.LastUsedAt,
+		ExpiresAt: value.ExpiresAt, RevokedAt: value.RevokedAt,
+	}
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format("2006-01-02T15:04:05Z07:00")
+}

--- a/internal/admin/personalsettings/token_scopes.go
+++ b/internal/admin/personalsettings/token_scopes.go
@@ -1,0 +1,124 @@
+package personalsettings
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+type tokenPrivilegeDescriptor struct {
+	label       string
+	description string
+	category    string
+}
+
+func (s *Service) tokenScopes(ctx context.Context, principalID string) ([]TokenScopeSignal, error) {
+	scopes := []TokenScopeSignal{}
+	platformPrivileges, err := s.Repository.EffectivePrivileges(ctx, principalID, access.PlatformObject())
+	if err != nil {
+		return nil, err
+	}
+	if options := tokenPrivilegeOptions(platformPrivileges); len(options) > 0 {
+		scopes = append(scopes, TokenScopeSignal{
+			Kind: "platform", Label: "All workspaces and product",
+			Description: "Access can apply across every current and future workspace. Prefer a single workspace.", Privileges: options,
+		})
+	}
+	if s.Workspaces == nil {
+		return scopes, nil
+	}
+	rows, err := s.Workspaces.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		return tokenWorkspaceLabel(rows[i].Title, string(rows[i].ID)) < tokenWorkspaceLabel(rows[j].Title, string(rows[j].ID))
+	})
+	for _, row := range rows {
+		workspaceID := string(row.ID)
+		privileges, privilegesErr := s.Repository.EffectivePrivileges(ctx, principalID, access.WorkspaceObject(workspaceID))
+		if privilegesErr != nil {
+			return nil, privilegesErr
+		}
+		options := tokenPrivilegeOptions(privileges)
+		if len(options) == 0 {
+			continue
+		}
+		description := strings.TrimSpace(row.Description)
+		if description == "" {
+			description = "Access limited to this workspace."
+		}
+		scopes = append(scopes, TokenScopeSignal{
+			Kind: "workspace", WorkspaceID: workspaceID,
+			Label: tokenWorkspaceLabel(row.Title, workspaceID), Description: description, Privileges: options,
+		})
+	}
+	return scopes, nil
+}
+
+func tokenWorkspaceLabel(title, id string) string {
+	if label := strings.TrimSpace(title); label != "" {
+		return label
+	}
+	return strings.TrimSpace(id)
+}
+
+func tokenPrivilegeOptions(effective []access.Privilege) []TokenPrivilegeSignal {
+	allowed := make(map[access.Privilege]struct{}, len(effective))
+	for _, privilege := range effective {
+		allowed[privilege] = struct{}{}
+	}
+	options := make([]TokenPrivilegeSignal, 0, len(effective))
+	for _, privilege := range access.KnownPrivileges() {
+		if _, ok := allowed[privilege]; !ok {
+			continue
+		}
+		descriptor := describeTokenPrivilege(privilege)
+		options = append(options, TokenPrivilegeSignal{
+			Value: string(privilege), Label: descriptor.label,
+			Description: descriptor.description, Category: descriptor.category,
+		})
+	}
+	return options
+}
+
+var tokenPrivilegeDescriptors = map[access.Privilege]tokenPrivilegeDescriptor{
+	access.PrivilegeUseWorkspace:             {"Use workspace", "Open and use the workspace.", "Workspace"},
+	access.PrivilegeViewItem:                 {"View content", "View dashboards and other workspace content.", "Workspace"},
+	access.PrivilegeEditItem:                 {"Edit content", "Create and update workspace content.", "Workspace"},
+	access.PrivilegeManageItem:               {"Manage content", "Delete and administer workspace content.", "Workspace"},
+	access.PrivilegeQueryData:                {"Query data", "Run governed queries against workspace data.", "Data"},
+	access.PrivilegePreviewData:              {"Preview data", "Preview source and model data.", "Data"},
+	access.PrivilegeTestDataPolicy:           {"Test data policies", "Evaluate data-policy behavior.", "Data"},
+	access.PrivilegeRefreshData:              {"Refresh data", "Start and manage data refreshes.", "Data"},
+	access.PrivilegeViewData:                 {"View managed data", "View managed-data metadata and revisions.", "Data"},
+	access.PrivilegeIngestData:               {"Ingest data", "Upload and ingest managed data.", "Data"},
+	access.PrivilegeAuthorProject:            {"Author project", "Create and synchronize project candidates.", "Projects and releases"},
+	access.PrivilegePublishRelease:           {"Publish releases", "Publish project releases.", "Projects and releases"},
+	access.PrivilegeReviewCandidate:          {"Review candidates", "Review project candidates before deployment.", "Projects and releases"},
+	access.PrivilegeRequestDeployment:        {"Request deployments", "Create deployments and request approval.", "Projects and releases"},
+	access.PrivilegeApproveDeployment:        {"Approve deployments", "Approve or revoke deployment approvals.", "Projects and releases"},
+	access.PrivilegeDeploy:                   {"Deploy", "Run deployment operations.", "Projects and releases"},
+	access.PrivilegeActivateDeployment:       {"Activate deployments", "Promote a deployment to active serving state.", "Projects and releases"},
+	access.PrivilegeVerifyDeployment:         {"Verify deployments", "Run deployment verification checks.", "Projects and releases"},
+	access.PrivilegeRollbackDeployment:       {"Rollback deployments", "Restore a previous serving state.", "Projects and releases"},
+	access.PrivilegeUseAgent:                 {"Use agent", "Start and continue agent conversations.", "Agent"},
+	access.PrivilegeViewAgent:                {"View agent", "View agent status and conversations.", "Agent"},
+	access.PrivilegeManageConnectionMetadata: {"Manage connections", "Create and update connection metadata.", "Connections"},
+	access.PrivilegeTestConnection:           {"Test connections", "Run connection tests.", "Connections"},
+	access.PrivilegeViewConnectionHealth:     {"View connection health", "Inspect connection availability and health.", "Connections"},
+	access.PrivilegeManagePublications:       {"Manage publications", "Configure and control public dashboards.", "Administration"},
+	access.PrivilegeManageGrants:             {"Manage access", "Manage members, groups, roles, and grants.", "Administration"},
+	access.PrivilegeViewAudit:                {"View audit log", "Read security and administration events.", "Administration"},
+	access.PrivilegeManageWorkspace:          {"Manage workspace", "Manage workspace ownership and administration.", "Administration"},
+	access.PrivilegeManagePlatform:           {"Manage product", "Manage product-wide configuration and resources.", "Administration"},
+}
+
+func describeTokenPrivilege(privilege access.Privilege) tokenPrivilegeDescriptor {
+	if descriptor, ok := tokenPrivilegeDescriptors[privilege]; ok {
+		return descriptor
+	}
+	return tokenPrivilegeDescriptor{label: string(privilege), description: "Use this API capability.", category: "Other"}
+}

--- a/internal/admin/personalsettings/ui.go
+++ b/internal/admin/personalsettings/ui.go
@@ -1,0 +1,66 @@
+package personalsettings
+
+import (
+	uiactions "github.com/flidai/leapview/internal/platform/web/actions"
+	g "maragu.dev/gomponents"
+)
+
+// Component is the page-local Lit host. The parent admin shell can place it
+// in the profile/settings branch without importing any access transport code.
+func Component() g.Node {
+	return g.El("lv-personal-settings", g.Attr("slot", "personal-settings"))
+}
+
+// CommandAttributes wires browser events to Datastar commands. All mutations
+// are represented as typed signals; the component itself never performs a
+// settings GET request.
+func CommandAttributes(path string) []g.Node {
+	return []g.Node{
+		g.Attr("data-on:lv-personal-profile-command", "$personalProfileCommand = evt.detail; "+uiactions.UncontractedMutationPost(path, "personalProfileCommand")),
+		g.Attr("data-on:lv-personal-theme-command", "$personalThemeCommand = evt.detail; "+uiactions.UncontractedMutationPost(path, "personalThemeCommand")),
+		g.Attr("data-on:lv-personal-password-command", "$personalPasswordCommand = evt.detail; "+uiactions.UncontractedMutationPost(path, "personalPasswordCommand")),
+		g.Attr("data-on:lv-personal-session-command", "$personalSessionCommand = evt.detail; "+uiactions.UncontractedMutationPost(path, "personalSessionCommand")),
+		g.Attr("data-on:lv-personal-authoring-session-command", "$personalAuthoringSessionCommand = evt.detail; "+uiactions.UncontractedMutationPost(path, "personalAuthoringSessionCommand")),
+		g.Attr("data-on:lv-personal-token-command", "$personalTokenCommand = evt.detail; "+uiactions.UncontractedMutationPost(path, "personalTokenCommand")),
+	}
+}
+
+func BootstrapSignals(state Signal) map[string]any {
+	return map[string]any{
+		"personalSettings":                personalSettingsPayload(state),
+		"personalProfileCommand":          ProfileCommand{},
+		"personalThemeCommand":            ThemeCommand{},
+		"personalPasswordCommand":         PasswordCommand{},
+		"personalSessionCommand":          SessionCommand{},
+		"personalAuthoringSessionCommand": AuthoringSessionCommand{},
+		"personalTokenCommand":            TokenCommand{},
+	}
+}
+
+// Generated optional fields use omitempty, while Datastar merge patches need
+// an explicit null to clear an avatar or one-time token from browser state.
+// These narrow wire wrappers preserve that transport behavior without
+// duplicating the generated signal models.
+type personalSettingsWire struct {
+	Signal
+	Profile personalProfileWire `json:"profile"`
+	Tokens  personalTokensWire  `json:"tokens"`
+}
+
+type personalProfileWire struct {
+	ProfileSignal
+	AvatarURL *string `json:"avatarUrl"`
+}
+
+type personalTokensWire struct {
+	TokensSignal
+	NewToken *string `json:"newToken"`
+}
+
+func personalSettingsPayload(state Signal) personalSettingsWire {
+	return personalSettingsWire{
+		Signal:  state,
+		Profile: personalProfileWire{ProfileSignal: state.Profile, AvatarURL: state.Profile.AvatarURL},
+		Tokens:  personalTokensWire{TokensSignal: state.Tokens, NewToken: state.Tokens.NewToken},
+	}
+}

--- a/internal/admin/product/http.go
+++ b/internal/admin/product/http.go
@@ -1,0 +1,293 @@
+package product
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"strconv"
+	"strings"
+
+	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
+	"github.com/flidai/leapview/internal/platform/buildinfo"
+	apitransport "github.com/flidai/leapview/internal/platform/http/transport"
+	"github.com/go-chi/chi/v5"
+)
+
+type Principal struct{ ID string }
+
+type AuthenticationStatus struct {
+	BrowserEnabled bool              `json:"browserEnabled"`
+	APITokenOnly   bool              `json:"apiTokenOnly"`
+	Local          Availability      `json:"local"`
+	OIDC           NamedAvailability `json:"oidc"`
+	Azure          Availability      `json:"azure"`
+	SCIM           Availability      `json:"scim"`
+	ManagedBy      string            `json:"managedBy"`
+}
+
+type Availability struct {
+	Available bool `json:"available"`
+	Enabled   bool `json:"enabled"`
+}
+
+type NamedAvailability struct {
+	Available bool   `json:"available"`
+	Enabled   bool   `json:"enabled"`
+	Provider  string `json:"provider,omitempty"`
+}
+
+type APIStatus struct {
+	BearerCredentials Availability `json:"bearerCredentials"`
+	ServicePrincipals Availability `json:"servicePrincipals"`
+	OAuth             Availability `json:"oauth"`
+	MCP               Availability `json:"mcp"`
+	ExternalMCPIssuer bool         `json:"externalMcpIssuer"`
+}
+
+type AgentStatus struct {
+	Available       bool   `json:"available"`
+	Configured      bool   `json:"configured"`
+	Provider        string `json:"provider,omitempty"`
+	ModelConfigured bool   `json:"modelConfigured"`
+}
+
+type Limits struct {
+	QueryResultMaxRows          int   `json:"queryResultMaxRows"`
+	QueryResultMaxBytes         int64 `json:"queryResultMaxBytes"`
+	ManagedDataMaxFiles         int   `json:"managedDataMaxFiles"`
+	ManagedDataMaxFileBytes     int64 `json:"managedDataMaxFileBytes"`
+	ManagedDataMaxRevisionBytes int64 `json:"managedDataMaxRevisionBytes"`
+}
+
+type SystemStatus struct {
+	InstanceID      string             `json:"instanceId"`
+	CanonicalOrigin string             `json:"canonicalOrigin"`
+	Environment     string             `json:"environment"`
+	Build           buildinfo.Identity `json:"build"`
+	ControlPlane    string             `json:"controlPlane"`
+	StorageBackend  string             `json:"storageBackend"`
+	Agent           AgentStatus        `json:"agent"`
+	Limits          Limits             `json:"limits"`
+}
+
+// Status is a redacted snapshot assembled from deployment configuration.
+// It intentionally contains no credential values, client identifiers, issuer
+// URLs, callback URLs, filesystem paths, buckets, or tenant identifiers.
+type Status struct {
+	Authentication AuthenticationStatus
+	API            APIStatus
+	System         SystemStatus
+}
+
+type HTTPConfig struct {
+	Service          *Service
+	Status           Status
+	CurrentPrincipal func(*http.Request) (Principal, bool)
+	CommandFailure   CommandFailureWriter
+	Logger           *slog.Logger
+}
+
+type CommandFailureWriter func(context.Context, http.ResponseWriter, *http.Request, string, error)
+
+type Handler struct{ config HTTPConfig }
+
+func NewHandler(config HTTPConfig) (*Handler, error) {
+	if config.Service == nil {
+		return nil, fmt.Errorf("product identity service is required")
+	}
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+	return &Handler{config: config}, nil
+}
+
+type SettingsResponse struct {
+	DisplayName string        `json:"displayName"`
+	Logo        *LogoResponse `json:"logo,omitempty"`
+	UpdatedAt   string        `json:"updatedAt"`
+}
+
+type LogoResponse struct {
+	URL       string `json:"url"`
+	SHA256    string `json:"sha256"`
+	MediaType string `json:"mediaType"`
+	SizeBytes int64  `json:"sizeBytes"`
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+}
+
+func (h *Handler) GetSettings(w http.ResponseWriter, r *http.Request) {
+	identity, err := h.config.Service.Get(r.Context())
+	if err != nil {
+		h.problem(w, r, err)
+		return
+	}
+	h.writeIdentity(w, http.StatusOK, identity)
+}
+
+func (h *Handler) PatchSettings(w http.ResponseWriter, r *http.Request) {
+	expected, ok := h.requireRevision(w, r)
+	if !ok {
+		return
+	}
+	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(r.Header.Get("Content-Type")))
+	if err != nil || mediaType != "application/json" {
+		apitransport.WriteProblem(w, r, http.StatusUnsupportedMediaType, "UNSUPPORTED_MEDIA_TYPE", "Content-Type must be application/json", nil)
+		return
+	}
+	var body struct {
+		DisplayName *string `json:"displayName"`
+	}
+	if err := apitransport.DecodeBody(w, r, &body); err != nil {
+		apitransport.WriteProblem(w, r, http.StatusBadRequest, "INVALID_REQUEST_BODY", "The request body must be a JSON object containing displayName", nil)
+		return
+	}
+	if body.DisplayName == nil {
+		apitransport.WriteProblem(w, r, http.StatusBadRequest, "INVALID_REQUEST", "displayName is required", []apitransport.ProblemFieldError{{Field: "displayName", Code: "REQUIRED", Detail: "displayName is required"}})
+		return
+	}
+	identity, err := h.config.Service.SetDisplayName(r.Context(), expected, *body.DisplayName, h.mutation(r))
+	if err != nil {
+		h.problem(w, r, err)
+		return
+	}
+	h.writeIdentity(w, http.StatusOK, identity)
+}
+
+func (h *Handler) UploadLogo(w http.ResponseWriter, r *http.Request) {
+	expected, ok := h.requireRevision(w, r)
+	if !ok {
+		return
+	}
+	identity, err := h.config.Service.UploadLogo(r.Context(), expected, r.Header.Get("Content-Type"), r.Body, h.mutation(r))
+	if err != nil {
+		h.problem(w, r, err)
+		return
+	}
+	h.writeIdentity(w, http.StatusOK, identity)
+}
+
+func (h *Handler) DeleteLogo(w http.ResponseWriter, r *http.Request) {
+	expected, ok := h.requireRevision(w, r)
+	if !ok {
+		return
+	}
+	identity, err := h.config.Service.DeleteLogo(r.Context(), expected, h.mutation(r))
+	if err != nil {
+		h.problem(w, r, err)
+		return
+	}
+	h.writeIdentity(w, http.StatusOK, identity)
+}
+
+func (h *Handler) GetLogo(w http.ResponseWriter, r *http.Request) {
+	reader, logo, err := h.config.Service.OpenLogo(r.Context(), chi.URLParam(r, "digest"))
+	if err != nil {
+		h.problem(w, r, err)
+		return
+	}
+	defer reader.Close()
+	w.Header().Set("Content-Type", logo.MediaType)
+	w.Header().Set("Content-Length", strconv.FormatInt(logo.SizeBytes, 10))
+	w.Header().Set("ETag", `"`+logo.SHA256+`"`)
+	w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.Copy(w, reader)
+}
+
+func (h *Handler) GetAuthentication(w http.ResponseWriter, _ *http.Request) {
+	apitransport.WriteJSON(w, http.StatusOK, h.config.Status.Authentication)
+}
+
+func (h *Handler) GetSystem(w http.ResponseWriter, r *http.Request) {
+	status := h.config.Status.System
+	status.ControlPlane = "available"
+	if err := h.config.Service.db.PingContext(r.Context()); err != nil {
+		status.ControlPlane = "unavailable"
+	}
+	apitransport.WriteJSON(w, http.StatusOK, status)
+}
+
+func (h *Handler) GetAPIStatus(w http.ResponseWriter, _ *http.Request) {
+	apitransport.WriteJSON(w, http.StatusOK, h.config.Status.API)
+}
+
+func (h *Handler) writeIdentity(w http.ResponseWriter, status int, identity Identity) {
+	w.Header().Set("ETag", revisionETag(identity.Revision))
+	apitransport.WriteJSON(w, status, settingsResponse(identity))
+}
+
+func settingsResponse(identity Identity) SettingsResponse {
+	result := SettingsResponse{DisplayName: identity.DisplayName, UpdatedAt: identity.UpdatedAt}
+	if identity.Logo != nil {
+		logo := identity.Logo
+		result.Logo = &LogoResponse{URL: "/api/v1/instance/logo/" + logo.SHA256, SHA256: logo.SHA256, MediaType: logo.MediaType, SizeBytes: logo.SizeBytes, Width: logo.Width, Height: logo.Height}
+	}
+	return result
+}
+
+func revisionETag(revision int64) string { return `"product-` + strconv.FormatInt(revision, 10) + `"` }
+
+func (h *Handler) requireRevision(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	value := strings.TrimSpace(r.Header.Get("If-Match"))
+	if value == "" {
+		apitransport.WriteProblem(w, r, http.StatusPreconditionFailed, "IF_MATCH_REQUIRED", "If-Match is required", nil)
+		return 0, false
+	}
+	value = strings.Trim(value, `"`)
+	text, ok := strings.CutPrefix(value, "product-")
+	if !ok {
+		if _, generatedCommand := apigencommand.OperationID(r.Context()); generatedCommand && h.config.CommandFailure != nil {
+			h.problem(w, r, ErrPrecondition)
+			return 0, false
+		}
+		apitransport.WriteProblem(w, r, http.StatusPreconditionFailed, "ETAG_MISMATCH", "If-Match does not match the current product identity", nil)
+		return 0, false
+	}
+	revision, err := strconv.ParseInt(text, 10, 64)
+	if err != nil || revision <= 0 {
+		if _, generatedCommand := apigencommand.OperationID(r.Context()); generatedCommand && h.config.CommandFailure != nil {
+			h.problem(w, r, ErrPrecondition)
+			return 0, false
+		}
+		apitransport.WriteProblem(w, r, http.StatusPreconditionFailed, "ETAG_MISMATCH", "If-Match does not match the current product identity", nil)
+		return 0, false
+	}
+	return revision, true
+}
+
+func (h *Handler) mutation(r *http.Request) Mutation {
+	mutation := Mutation{
+		RequestID:        r.Header.Get("X-Request-ID"),
+		CorrelationID:    r.Header.Get("X-Correlation-ID"),
+		ConcurrencyToken: r.Header.Get("If-Match"),
+	}
+	if h.config.CurrentPrincipal != nil {
+		if principal, ok := h.config.CurrentPrincipal(r); ok {
+			mutation.PrincipalID = principal.ID
+		}
+	}
+	return mutation
+}
+
+func (h *Handler) problem(w http.ResponseWriter, r *http.Request, err error) {
+	if operationID, generatedCommand := apigencommand.OperationID(r.Context()); generatedCommand && h.config.CommandFailure != nil {
+		h.config.CommandFailure(r.Context(), w, r, operationID, err)
+		return
+	}
+	switch {
+	case errors.Is(err, ErrInvalid):
+		apitransport.WriteProblem(w, r, http.StatusUnprocessableEntity, "INVALID_PRODUCT_IDENTITY", err.Error(), nil)
+	case errors.Is(err, ErrPrecondition):
+		apitransport.WriteProblem(w, r, http.StatusPreconditionFailed, "ETAG_MISMATCH", "If-Match does not match the current product identity", nil)
+	case errors.Is(err, ErrNotFound):
+		apitransport.WriteProblem(w, r, http.StatusNotFound, "PRODUCT_LOGO_NOT_FOUND", "The product logo does not exist", nil)
+	default:
+		h.config.Logger.ErrorContext(r.Context(), "product administration request failed", "error", err)
+		apitransport.WriteProblem(w, r, http.StatusInternalServerError, "PRODUCT_ADMINISTRATION_FAILED", "The product administration request could not be completed", nil)
+	}
+}

--- a/internal/admin/product/http_test.go
+++ b/internal/admin/product/http_test.go
@@ -1,0 +1,131 @@
+package product
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/platform"
+	"github.com/flidai/leapview/internal/platform/buildinfo"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandlerRequiresETagAndReturnsRedactedStatus(t *testing.T) {
+	handler := testHandler(t, Status{
+		Authentication: AuthenticationStatus{
+			BrowserEnabled: true, Local: Availability{Available: true, Enabled: true},
+			OIDC:  NamedAvailability{Available: true, Enabled: true, Provider: "corporate"},
+			Azure: Availability{Available: true}, SCIM: Availability{Available: true}, ManagedBy: "deployment",
+		},
+		API:    APIStatus{BearerCredentials: Availability{Available: true, Enabled: true}, ServicePrincipals: Availability{Available: true, Enabled: true}, OAuth: Availability{Available: true, Enabled: true}, MCP: Availability{Available: true, Enabled: true}},
+		System: SystemStatus{InstanceID: "lvinst_1", Environment: "prod", CanonicalOrigin: "https://example.test", Build: buildinfo.Identity{Version: "1.2.3"}, StorageBackend: "s3"},
+	})
+
+	get := httptest.NewRecorder()
+	handler.GetSettings(get, httptest.NewRequest(http.MethodGet, "/api/v1/instance/settings", nil))
+	if get.Code != http.StatusOK || get.Header().Get("ETag") != `"product-1"` {
+		t.Fatalf("get settings status=%d etag=%q body=%s", get.Code, get.Header().Get("ETag"), get.Body.String())
+	}
+	var initial SettingsResponse
+	if err := json.Unmarshal(get.Body.Bytes(), &initial); err != nil {
+		t.Fatalf("decode initial settings: %v body=%s", err, get.Body.String())
+	}
+	if _, err := time.Parse(time.RFC3339Nano, initial.UpdatedAt); err != nil {
+		t.Fatalf("initial updatedAt = %q, want RFC3339: %v", initial.UpdatedAt, err)
+	}
+
+	missing := httptest.NewRecorder()
+	missingRequest := httptest.NewRequest(http.MethodPatch, "/api/v1/instance/settings", strings.NewReader(`{"displayName":"Acme"}`))
+	missingRequest.Header.Set("Content-Type", "application/json")
+	handler.PatchSettings(missing, missingRequest)
+	if missing.Code != http.StatusPreconditionFailed {
+		t.Fatalf("missing If-Match status=%d body=%s", missing.Code, missing.Body.String())
+	}
+
+	patch := httptest.NewRequest(http.MethodPatch, "/api/v1/instance/settings", strings.NewReader(`{"displayName":"Acme"}`))
+	patch.Header.Set("Content-Type", "application/json")
+	patch.Header.Set("If-Match", get.Header().Get("ETag"))
+	patch.Header.Set("X-Request-ID", "req_patch")
+	patched := httptest.NewRecorder()
+	handler.PatchSettings(patched, patch)
+	if patched.Code != http.StatusOK || patched.Header().Get("ETag") != `"product-2"` || !strings.Contains(patched.Body.String(), `"displayName":"Acme"`) {
+		t.Fatalf("patch status=%d etag=%q body=%s", patched.Code, patched.Header().Get("ETag"), patched.Body.String())
+	}
+	var updated SettingsResponse
+	if err := json.Unmarshal(patched.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode updated settings: %v body=%s", err, patched.Body.String())
+	}
+	if _, err := time.Parse(time.RFC3339Nano, updated.UpdatedAt); err != nil {
+		t.Fatalf("updated updatedAt = %q, want RFC3339: %v", updated.UpdatedAt, err)
+	}
+
+	auth := httptest.NewRecorder()
+	handler.GetAuthentication(auth, httptest.NewRequest(http.MethodGet, "/api/v1/instance/authentication", nil))
+	for _, forbidden := range []string{"client-secret", "issuer.example", "tenant-id", "callback"} {
+		if strings.Contains(auth.Body.String(), forbidden) {
+			t.Fatalf("authentication status leaked %q: %s", forbidden, auth.Body.String())
+		}
+	}
+	var status map[string]any
+	if err := json.Unmarshal(auth.Body.Bytes(), &status); err != nil || status["managedBy"] != "deployment" {
+		t.Fatalf("authentication status = %#v err=%v", status, err)
+	}
+}
+
+func TestHandlerUploadsAndServesImmutableLogo(t *testing.T) {
+	handler := testHandler(t, Status{})
+	logo := testPNG(t, 16, 8)
+	upload := httptest.NewRequest(http.MethodPut, "/api/v1/instance/logo", bytes.NewReader(logo))
+	upload.Header.Set("If-Match", `"product-1"`)
+	upload.Header.Set("Content-Type", "image/png")
+	uploaded := httptest.NewRecorder()
+	handler.UploadLogo(uploaded, upload)
+	if uploaded.Code != http.StatusOK {
+		t.Fatalf("upload status=%d body=%s", uploaded.Code, uploaded.Body.String())
+	}
+	var body SettingsResponse
+	if err := json.Unmarshal(uploaded.Body.Bytes(), &body); err != nil || body.Logo == nil {
+		t.Fatalf("upload response=%#v err=%v", body, err)
+	}
+	request := httptest.NewRequest(http.MethodGet, body.Logo.URL, nil)
+	request = request.WithContext(request.Context())
+	route := httptest.NewRecorder()
+	request = withDigest(request, body.Logo.SHA256)
+	handler.GetLogo(route, request)
+	if route.Code != http.StatusOK || route.Header().Get("Cache-Control") != "private, max-age=31536000, immutable" || !bytes.Equal(route.Body.Bytes(), logo) {
+		t.Fatalf("logo status=%d headers=%v bytes=%d", route.Code, route.Header(), route.Body.Len())
+	}
+}
+
+func testHandler(t *testing.T, status Status) *Handler {
+	t.Helper()
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	service, err := New(store.SQLDB(), &memoryBlobs{values: map[string][]byte{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SQLDB().ExecContext(t.Context(), `INSERT INTO principals (id, email, display_name) VALUES ('principal_admin', 'admin@example.test', 'Admin')`); err != nil {
+		t.Fatal(err)
+	}
+	handler, err := NewHandler(HTTPConfig{Service: service, Status: status, CurrentPrincipal: func(*http.Request) (Principal, bool) { return Principal{ID: "principal_admin"}, true }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handler
+}
+
+func withDigest(request *http.Request, digest string) *http.Request {
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("digest", digest)
+	return request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+}

--- a/internal/admin/product/product.go
+++ b/internal/admin/product/product.go
@@ -1,0 +1,337 @@
+// Package product owns mutable instance identity and safe, read-only product
+// administration status. Deployment configuration and secrets are never
+// persisted through this package.
+package product
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	apigenaudit "github.com/Yacobolo/toolbelt/apigen/runtime/audit"
+	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
+	apigenfailure "github.com/Yacobolo/toolbelt/apigen/runtime/failure"
+	_ "golang.org/x/image/webp"
+)
+
+const (
+	DefaultDisplayName       = "LeapView"
+	MaxLogoBytes       int64 = 5 << 20
+	MaxLogoPixels            = 16_000_000
+)
+
+var (
+	ErrInvalid      = apigenfailure.New("invalid", "invalid product identity")
+	ErrNotFound     = apigenfailure.New("not_found", "product logo not found")
+	ErrPrecondition = apigenfailure.New("precondition", "product identity precondition failed")
+)
+
+type Logo struct {
+	SHA256    string `json:"sha256"`
+	MediaType string `json:"mediaType"`
+	SizeBytes int64  `json:"sizeBytes"`
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+}
+
+type Identity struct {
+	DisplayName string `json:"displayName"`
+	Logo        *Logo  `json:"logo,omitempty"`
+	Revision    int64  `json:"revision"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+type Mutation struct {
+	PrincipalID      string
+	RequestID        string
+	CorrelationID    string
+	ConcurrencyToken string
+}
+
+type Blob struct {
+	SHA256 string
+	Size   int64
+}
+
+type BlobStore interface {
+	Put(context.Context, Blob, io.Reader) (Blob, error)
+	Open(context.Context, string) (io.ReadCloser, error)
+}
+
+type CommandExecutor interface {
+	Execute(context.Context, string, apigencommand.Execution) error
+	CheckConcurrency(context.Context, string, string, string) error
+}
+
+type Service struct {
+	db       *sql.DB
+	blobs    BlobStore
+	commands CommandExecutor
+}
+
+func New(db *sql.DB, blobs BlobStore) (*Service, error) {
+	if db == nil {
+		return nil, fmt.Errorf("product identity database is required")
+	}
+	if blobs == nil {
+		return nil, fmt.Errorf("product logo blob store is required")
+	}
+	return &Service{db: db, blobs: blobs}, nil
+}
+
+func (s *Service) ConfigureCommandExecutor(executor CommandExecutor) {
+	if s != nil {
+		s.commands = executor
+	}
+}
+
+func (s *Service) Get(ctx context.Context) (Identity, error) {
+	return scanIdentity(s.db.QueryRowContext(ctx, `
+SELECT display_name, logo_sha256, logo_media_type, logo_size_bytes, logo_width, logo_height, revision, updated_at
+FROM product_identity WHERE singleton = 1`))
+}
+
+func (s *Service) SetDisplayName(ctx context.Context, expectedRevision int64, displayName string, mutation Mutation) (Identity, error) {
+	displayName = strings.TrimSpace(displayName)
+	if displayName == "" || !utf8.ValidString(displayName) || utf8.RuneCountInString(displayName) > 120 {
+		return Identity{}, fmt.Errorf("%w: displayName must contain 1 to 120 characters", ErrInvalid)
+	}
+	return s.mutate(ctx, expectedRevision, mutation, "product.identity.updated", map[string]any{"fields": []string{"displayName"}}, func(tx *sql.Tx) (sql.Result, error) {
+		return tx.ExecContext(ctx, `
+UPDATE product_identity
+SET display_name = ?, revision = revision + 1, updated_at = CURRENT_TIMESTAMP
+WHERE singleton = 1 AND revision = ?`, displayName, expectedRevision)
+	})
+}
+
+func (s *Service) UploadLogo(ctx context.Context, expectedRevision int64, contentType string, body io.Reader, mutation Mutation) (Identity, error) {
+	current, err := s.Get(ctx)
+	if err != nil {
+		return Identity{}, err
+	}
+	if expectedRevision <= 0 || current.Revision != expectedRevision {
+		return Identity{}, ErrPrecondition
+	}
+	if body == nil {
+		return Identity{}, fmt.Errorf("%w: logo body is required", ErrInvalid)
+	}
+	raw, err := io.ReadAll(io.LimitReader(body, MaxLogoBytes+1))
+	if err != nil {
+		return Identity{}, fmt.Errorf("read product logo: %w", err)
+	}
+	if int64(len(raw)) > MaxLogoBytes {
+		return Identity{}, fmt.Errorf("%w: logo exceeds %d bytes", ErrInvalid, MaxLogoBytes)
+	}
+	logo, err := inspectLogo(contentType, raw)
+	if err != nil {
+		return Identity{}, err
+	}
+	if _, err := s.blobs.Put(ctx, Blob{SHA256: logo.SHA256, Size: logo.SizeBytes}, bytes.NewReader(raw)); err != nil {
+		return Identity{}, fmt.Errorf("store product logo: %w", err)
+	}
+	return s.mutate(ctx, expectedRevision, mutation, "product.logo.updated", map[string]any{"sha256": logo.SHA256}, func(tx *sql.Tx) (sql.Result, error) {
+		return tx.ExecContext(ctx, `
+UPDATE product_identity
+SET logo_sha256 = ?, logo_media_type = ?, logo_size_bytes = ?, logo_width = ?, logo_height = ?,
+    revision = revision + 1, updated_at = CURRENT_TIMESTAMP
+WHERE singleton = 1 AND revision = ?`, logo.SHA256, logo.MediaType, logo.SizeBytes, logo.Width, logo.Height, expectedRevision)
+	})
+}
+
+func (s *Service) DeleteLogo(ctx context.Context, expectedRevision int64, mutation Mutation) (Identity, error) {
+	return s.mutate(ctx, expectedRevision, mutation, "product.logo.deleted", map[string]any{"removed": true}, func(tx *sql.Tx) (sql.Result, error) {
+		return tx.ExecContext(ctx, `
+UPDATE product_identity
+SET logo_sha256 = NULL, logo_media_type = NULL, logo_size_bytes = NULL, logo_width = NULL, logo_height = NULL,
+    revision = revision + 1, updated_at = CURRENT_TIMESTAMP
+WHERE singleton = 1 AND revision = ? AND logo_sha256 IS NOT NULL`, expectedRevision)
+	})
+}
+
+// ResetIdentity restores the community-edition identity in a single audited
+// revision so callers never observe a default name paired with a stale logo.
+func (s *Service) ResetIdentity(ctx context.Context, expectedRevision int64, mutation Mutation) (Identity, error) {
+	return s.mutate(ctx, expectedRevision, mutation, "product.identity.reset", map[string]any{"fields": []string{"displayName", "logo"}}, func(tx *sql.Tx) (sql.Result, error) {
+		return tx.ExecContext(ctx, `
+UPDATE product_identity
+SET display_name = ?, logo_sha256 = NULL, logo_media_type = NULL, logo_size_bytes = NULL,
+    logo_width = NULL, logo_height = NULL, revision = revision + 1, updated_at = CURRENT_TIMESTAMP
+WHERE singleton = 1 AND revision = ?`, DefaultDisplayName, expectedRevision)
+	})
+}
+
+func (s *Service) OpenLogo(ctx context.Context, digest string) (io.ReadCloser, Logo, error) {
+	identity, err := s.Get(ctx)
+	if err != nil {
+		return nil, Logo{}, err
+	}
+	digest = strings.ToLower(strings.TrimSpace(digest))
+	if identity.Logo == nil || identity.Logo.SHA256 != digest {
+		return nil, Logo{}, ErrNotFound
+	}
+	reader, err := s.blobs.Open(ctx, digest)
+	if errors.Is(err, ErrNotFound) {
+		return nil, Logo{}, ErrNotFound
+	}
+	if err != nil {
+		return nil, Logo{}, fmt.Errorf("open product logo: %w", err)
+	}
+	return reader, *identity.Logo, nil
+}
+
+func (s *Service) mutate(ctx context.Context, expectedRevision int64, mutation Mutation, action string, metadata any, update func(*sql.Tx) (sql.Result, error)) (Identity, error) {
+	operationID, generatedCommand := apigencommand.OperationID(ctx)
+	if !generatedCommand {
+		metadataJSON, err := encodeProductAuditMetadata(metadata)
+		if err != nil {
+			return Identity{}, err
+		}
+		return s.mutateAtomic(ctx, expectedRevision, mutation, action, metadataJSON, nil, update)
+	}
+	if s.commands == nil {
+		return Identity{}, fmt.Errorf("product command executor is unavailable")
+	}
+	var identity Identity
+	err := s.commands.Execute(ctx, operationID, apigencommand.Execution{
+		Transactional: func(ctx context.Context, contract apigencommand.Contract) error {
+			if action != contract.AuditAction {
+				return fmt.Errorf("generated audit action %q does not match product mutation action %q", contract.AuditAction, action)
+			}
+			metadataJSON, encodeErr := apigenaudit.EncodeForAudit(*contract.AuditPayload, metadata)
+			if encodeErr != nil {
+				return encodeErr
+			}
+			checkConcurrency := func(ctx context.Context, tx *sql.Tx) error {
+				var currentRevision int64
+				if err := tx.QueryRowContext(ctx, `SELECT revision FROM product_identity WHERE singleton = 1`).Scan(&currentRevision); err != nil {
+					return err
+				}
+				return s.commands.CheckConcurrency(ctx, operationID, mutation.ConcurrencyToken, revisionETag(currentRevision))
+			}
+			var mutationErr error
+			identity, mutationErr = s.mutateAtomic(ctx, expectedRevision, mutation, action, metadataJSON, checkConcurrency, update)
+			return mutationErr
+		},
+	})
+	return identity, err
+}
+
+func (s *Service) mutateAtomic(
+	ctx context.Context,
+	expectedRevision int64,
+	mutation Mutation,
+	action, metadataJSON string,
+	checkConcurrency func(context.Context, *sql.Tx) error,
+	update func(*sql.Tx) (sql.Result, error),
+) (Identity, error) {
+	if expectedRevision <= 0 {
+		return Identity{}, ErrPrecondition
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Identity{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if checkConcurrency != nil {
+		if err := checkConcurrency(ctx, tx); err != nil {
+			return Identity{}, err
+		}
+	}
+	result, err := update(tx)
+	if err != nil {
+		return Identity{}, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return Identity{}, err
+	}
+	if rows != 1 {
+		return Identity{}, ErrPrecondition
+	}
+	if err := insertAudit(ctx, tx, mutation, action, metadataJSON); err != nil {
+		return Identity{}, fmt.Errorf("audit product mutation: %w", err)
+	}
+	identity, err := scanIdentity(tx.QueryRowContext(ctx, `
+SELECT display_name, logo_sha256, logo_media_type, logo_size_bytes, logo_width, logo_height, revision, updated_at
+FROM product_identity WHERE singleton = 1`))
+	if err != nil {
+		return Identity{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Identity{}, err
+	}
+	return identity, nil
+}
+
+func encodeProductAuditMetadata(metadata any) (string, error) {
+	if metadata == nil {
+		return "{}", nil
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func inspectLogo(contentType string, raw []byte) (Logo, error) {
+	contentType = strings.ToLower(strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0]))
+	config, format, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil {
+		return Logo{}, fmt.Errorf("%w: logo could not be decoded", ErrInvalid)
+	}
+	mediaTypes := map[string]string{"jpeg": "image/jpeg", "png": "image/png", "webp": "image/webp"}
+	mediaType, ok := mediaTypes[format]
+	if !ok || mediaType != contentType {
+		return Logo{}, fmt.Errorf("%w: Content-Type must match a JPEG, PNG, or WebP image", ErrInvalid)
+	}
+	if config.Width <= 0 || config.Height <= 0 || config.Height > MaxLogoPixels || config.Width > MaxLogoPixels/config.Height {
+		return Logo{}, fmt.Errorf("%w: logo exceeds %d pixels", ErrInvalid, MaxLogoPixels)
+	}
+	if _, decodedFormat, err := image.Decode(bytes.NewReader(raw)); err != nil || decodedFormat != format {
+		return Logo{}, fmt.Errorf("%w: logo could not be decoded", ErrInvalid)
+	}
+	digest := sha256.Sum256(raw)
+	return Logo{SHA256: hex.EncodeToString(digest[:]), MediaType: mediaType, SizeBytes: int64(len(raw)), Width: config.Width, Height: config.Height}, nil
+}
+
+type scanner interface{ Scan(...any) error }
+
+func scanIdentity(row scanner) (Identity, error) {
+	var identity Identity
+	var digest, mediaType sql.NullString
+	var size, width, height sql.NullInt64
+	if err := row.Scan(&identity.DisplayName, &digest, &mediaType, &size, &width, &height, &identity.Revision, &identity.UpdatedAt); err != nil {
+		return Identity{}, err
+	}
+	if digest.Valid {
+		identity.Logo = &Logo{SHA256: digest.String, MediaType: mediaType.String, SizeBytes: size.Int64, Width: int(width.Int64), Height: int(height.Int64)}
+	}
+	return identity, nil
+}
+
+func insertAudit(ctx context.Context, tx *sql.Tx, mutation Mutation, action, metadataJSON string) error {
+	var idBytes [16]byte
+	if _, err := rand.Read(idBytes[:]); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `
+INSERT INTO audit_events
+  (id, workspace_id, principal_id, action, target_type, target_id, privilege, status, request_id, correlation_id, metadata_json)
+VALUES (?, NULL, NULLIF(?, ''), ?, 'product', 'instance', 'MANAGE_PLATFORM', 'success', ?, ?, ?)`,
+		"audit_"+hex.EncodeToString(idBytes[:]), strings.TrimSpace(mutation.PrincipalID), action,
+		strings.TrimSpace(mutation.RequestID), strings.TrimSpace(mutation.CorrelationID), metadataJSON)
+	return err
+}

--- a/internal/admin/product/product_test.go
+++ b/internal/admin/product/product_test.go
@@ -1,0 +1,164 @@
+package product
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/flidai/leapview/internal/platform"
+)
+
+func TestServicePersistsIdentityLogoAndAtomicAudit(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, err := store.SQLDB().ExecContext(t.Context(), `INSERT INTO principals (id, email, display_name) VALUES ('principal_admin', 'admin@example.test', 'Admin')`); err != nil {
+		t.Fatal(err)
+	}
+	blobs := &memoryBlobs{values: map[string][]byte{}}
+	service, err := New(store.SQLDB(), blobs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initial, err := service.Get(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initial.DisplayName != "LeapView" || initial.Revision != 1 || initial.Logo != nil {
+		t.Fatalf("initial identity = %#v", initial)
+	}
+
+	updated, err := service.SetDisplayName(t.Context(), initial.Revision, "  Acme Analytics  ", Mutation{PrincipalID: "principal_admin", RequestID: "req_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.DisplayName != "Acme Analytics" || updated.Revision != 2 {
+		t.Fatalf("updated identity = %#v", updated)
+	}
+
+	logoBytes := testPNG(t, 80, 40)
+	withLogo, err := service.UploadLogo(t.Context(), updated.Revision, "image/png", bytes.NewReader(logoBytes), Mutation{PrincipalID: "principal_admin", RequestID: "req_2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withLogo.Logo == nil || withLogo.Logo.Width != 80 || withLogo.Logo.Height != 40 || withLogo.Revision != 3 {
+		t.Fatalf("identity with logo = %#v", withLogo)
+	}
+	wantDigest := sha256.Sum256(logoBytes)
+	if withLogo.Logo.SHA256 != hex.EncodeToString(wantDigest[:]) {
+		t.Fatalf("logo digest = %q", withLogo.Logo.SHA256)
+	}
+
+	reader, logo, err := service.OpenLogo(t.Context(), withLogo.Logo.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(reader)
+	_ = reader.Close()
+	if !bytes.Equal(got, logoBytes) || logo != *withLogo.Logo {
+		t.Fatalf("opened logo metadata=%#v bytes=%d", logo, len(got))
+	}
+
+	var auditCount int
+	if err := store.SQLDB().QueryRowContext(t.Context(), `SELECT count(*) FROM audit_events WHERE target_type = 'product' AND target_id = 'instance' AND principal_id = 'principal_admin'`).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 2 {
+		t.Fatalf("product audit events = %d, want 2", auditCount)
+	}
+
+	reset, err := service.ResetIdentity(t.Context(), withLogo.Revision, Mutation{PrincipalID: "principal_admin", RequestID: "req_3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reset.DisplayName != DefaultDisplayName || reset.Logo != nil || reset.Revision != 4 {
+		t.Fatalf("reset identity = %#v", reset)
+	}
+	var resetAction string
+	if err := store.SQLDB().QueryRowContext(t.Context(), `SELECT action FROM audit_events WHERE request_id = 'req_3'`).Scan(&resetAction); err != nil {
+		t.Fatal(err)
+	}
+	if resetAction != "product.identity.reset" {
+		t.Fatalf("reset audit action = %q", resetAction)
+	}
+}
+
+func TestServiceRejectsStaleRevisionAndInvalidLogoWithoutAudit(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	blobs := &memoryBlobs{values: map[string][]byte{}}
+	service, err := New(store.SQLDB(), blobs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := service.SetDisplayName(t.Context(), 99, "Stale", Mutation{}); err != ErrPrecondition {
+		t.Fatalf("stale update error = %v", err)
+	}
+	if _, err := service.UploadLogo(t.Context(), 99, "image/png", bytes.NewReader(testPNG(t, 2, 2)), Mutation{}); err != ErrPrecondition {
+		t.Fatalf("stale logo error = %v", err)
+	}
+	if len(blobs.values) != 0 {
+		t.Fatalf("stale logo persisted %d blobs", len(blobs.values))
+	}
+	if _, err := service.UploadLogo(t.Context(), 1, "image/svg+xml", bytes.NewBufferString("<svg/>"), Mutation{}); err == nil {
+		t.Fatal("SVG logo upload succeeded")
+	}
+	if _, err := service.UploadLogo(t.Context(), 1, "image/jpeg", bytes.NewReader(testPNG(t, 2, 2)), Mutation{}); err == nil {
+		t.Fatal("mismatched logo Content-Type succeeded")
+	}
+	var auditCount int
+	if err := store.SQLDB().QueryRowContext(t.Context(), `SELECT count(*) FROM audit_events WHERE target_type = 'product'`).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 0 {
+		t.Fatalf("failed mutations wrote %d audit events", auditCount)
+	}
+}
+
+func testPNG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	value := image.NewNRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			value.Set(x, y, color.NRGBA{R: 20, G: 80, B: 140, A: 255})
+		}
+	}
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, value); err != nil {
+		t.Fatal(err)
+	}
+	return encoded.Bytes()
+}
+
+type memoryBlobs struct{ values map[string][]byte }
+
+func (s *memoryBlobs) Put(_ context.Context, expected Blob, body io.Reader) (Blob, error) {
+	value, err := io.ReadAll(body)
+	if err != nil {
+		return Blob{}, err
+	}
+	s.values[expected.SHA256] = value
+	return expected, nil
+}
+
+func (s *memoryBlobs) Open(_ context.Context, digest string) (io.ReadCloser, error) {
+	value, ok := s.values[digest]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(value)), nil
+}

--- a/internal/admin/productsettings/handler.go
+++ b/internal/admin/productsettings/handler.go
@@ -1,0 +1,133 @@
+package productsettings
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Yacobolo/toolbelt/pagestream"
+	"github.com/flidai/leapview/internal/admin/product"
+	signals "github.com/flidai/leapview/internal/admin/ui/signals"
+	"github.com/flidai/leapview/internal/platform/http/transport"
+)
+
+// CommandSignals is the Datastar request envelope. Keeping the root key
+// explicit prevents command payloads from becoming an ad hoc JSON API.
+type CommandSignals struct {
+	ProductSettingsCommand signals.ProductSettingsCommand `json:"productSettingsCommand"`
+}
+
+type HTTPConfig struct {
+	ReadModel        ReadModel
+	CanManage        func(*http.Request) bool
+	CurrentPrincipal func(*http.Request) (product.Principal, bool)
+}
+
+type Handler struct{ config HTTPConfig }
+
+func NewHandler(config HTTPConfig) (*Handler, error) {
+	if config.ReadModel.Service == nil {
+		return nil, errors.New("product settings service is required")
+	}
+	return &Handler{config: config}, nil
+}
+
+// Bootstrap returns the complete signal subtree for the page stream. The
+// parent admin handler can place it under the `productSettings` signal key.
+func (h *Handler) Bootstrap(r *http.Request, active string) (signals.ProductSettingsSignal, error) {
+	canManage := true
+	if h.config.CanManage != nil {
+		canManage = h.config.CanManage(r)
+	}
+	data, err := h.config.ReadModel.Data(r.Context(), active, canManage)
+	if err != nil {
+		return signals.ProductSettingsSignal{}, err
+	}
+	return Signal(data), nil
+}
+
+// Command handles the non-binary settings mutations through the page stream.
+// Logo bytes use the browser-authenticated upload route because Datastar
+// signal payloads are JSON; the Lit component preserves the returned ETag and
+// CSRF token for that one unavoidable binary operation.
+func (h *Handler) Command(w http.ResponseWriter, r *http.Request) {
+	if h.config.CanManage != nil && !h.config.CanManage(r) {
+		transport.WriteProblem(w, r, http.StatusForbidden, "FORBIDDEN", "MANAGE_PLATFORM is required", nil)
+		return
+	}
+	var request CommandSignals
+	if err := pagestream.ReadSignals(r, &request); err != nil {
+		h.writeProblem(w, r, http.StatusBadRequest, "INVALID_COMMAND", "The product settings command is invalid")
+		return
+	}
+	command := request.ProductSettingsCommand
+	if command.Revision <= 0 && command.Action != "refresh" {
+		h.writeProblem(w, r, http.StatusPreconditionFailed, "ETAG_MISMATCH", "The product settings revision is required")
+		return
+	}
+	var err error
+	switch strings.TrimSpace(command.Action) {
+	case "save_display_name":
+		if command.DisplayName == nil {
+			h.writeProblem(w, r, http.StatusBadRequest, "INVALID_COMMAND", "displayName is required")
+			return
+		}
+		_, err = h.config.ReadModel.Service.SetDisplayName(r.Context(), command.Revision, *command.DisplayName, h.mutation(r))
+	case "remove_logo":
+		_, err = h.config.ReadModel.Service.DeleteLogo(r.Context(), command.Revision, h.mutation(r))
+	case "reset_identity":
+		_, err = h.config.ReadModel.Service.ResetIdentity(r.Context(), command.Revision, h.mutation(r))
+	case "refresh":
+		// Read-only refresh is useful after the binary logo PUT response.
+	default:
+		h.writeProblem(w, r, http.StatusBadRequest, "UNKNOWN_COMMAND", "The product settings command is not supported")
+		return
+	}
+	if err != nil {
+		h.problem(w, r, err)
+		return
+	}
+	active := strings.TrimSpace(r.URL.Query().Get("section"))
+	if active == "" {
+		active = "general"
+	}
+	canManage := true
+	if h.config.CanManage != nil {
+		canManage = h.config.CanManage(r)
+	}
+	data, err := h.config.ReadModel.Data(r.Context(), active, canManage)
+	if err != nil {
+		h.problem(w, r, err)
+		return
+	}
+	_ = pagestream.PatchResponse(w, r, pagestream.SignalPatch{"productSettings": Payload(Signal(data))})
+}
+
+func (h *Handler) mutation(r *http.Request) product.Mutation {
+	mutation := product.Mutation{
+		RequestID:        r.Header.Get("X-Request-ID"),
+		CorrelationID:    r.Header.Get("X-Correlation-ID"),
+		ConcurrencyToken: r.Header.Get("If-Match"),
+	}
+	if h.config.CurrentPrincipal != nil {
+		if principal, ok := h.config.CurrentPrincipal(r); ok {
+			mutation.PrincipalID = principal.ID
+		}
+	}
+	return mutation
+}
+
+func (h *Handler) problem(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, product.ErrInvalid):
+		h.writeProblem(w, r, http.StatusUnprocessableEntity, "INVALID_PRODUCT_IDENTITY", err.Error())
+	case errors.Is(err, product.ErrPrecondition):
+		h.writeProblem(w, r, http.StatusPreconditionFailed, "ETAG_MISMATCH", "The product settings revision is stale")
+	default:
+		h.writeProblem(w, r, http.StatusInternalServerError, "PRODUCT_SETTINGS_FAILED", "The product settings command could not be completed")
+	}
+}
+
+func (h *Handler) writeProblem(w http.ResponseWriter, r *http.Request, status int, code, detail string) {
+	transport.WriteProblem(w, r, status, code, detail, nil)
+}

--- a/internal/admin/productsettings/handler_test.go
+++ b/internal/admin/productsettings/handler_test.go
@@ -1,0 +1,51 @@
+package productsettings
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/flidai/leapview/internal/admin/product"
+	"github.com/flidai/leapview/internal/platform"
+)
+
+func TestHandlerBootstrapAndManagePlatformGuard(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	service, err := product.New(store.SQLDB(), emptyBlobs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := NewHandler(HTTPConfig{ReadModel: ReadModel{Service: service}, CanManage: func(*http.Request) bool { return false }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+	signal, err := handler.Bootstrap(request, "authentication")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if signal.Active != "authentication" || signal.CanManage {
+		t.Fatalf("bootstrap = %#v", signal)
+	}
+	response := httptest.NewRecorder()
+	handler.Command(response, httptest.NewRequest(http.MethodPost, "/admin/settings/command", nil))
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("guard status = %d body=%s", response.Code, response.Body.String())
+	}
+}
+
+type emptyBlobs struct{}
+
+func (emptyBlobs) Put(context.Context, product.Blob, io.Reader) (product.Blob, error) {
+	return product.Blob{}, nil
+}
+func (emptyBlobs) Open(context.Context, string) (io.ReadCloser, error) {
+	return nil, product.ErrNotFound
+}

--- a/internal/admin/productsettings/read_model.go
+++ b/internal/admin/productsettings/read_model.go
@@ -1,0 +1,155 @@
+// Package productsettings owns the page-stream projection for product and
+// platform settings. It deliberately consumes the redacted product status
+// assembled by the deployment layer; it does not inspect auth credentials.
+package productsettings
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flidai/leapview/internal/admin/product"
+	signals "github.com/flidai/leapview/internal/admin/ui/signals"
+)
+
+// Pinger is the small health dependency needed to render the runtime status.
+// Keeping it narrow makes the projection usable with *sql.DB and test fakes.
+type Pinger interface {
+	PingContext(context.Context) error
+}
+
+type ReadModel struct {
+	Service      *product.Service
+	Status       product.Status
+	ControlPlane Pinger
+}
+
+type Data struct {
+	Identity  product.Identity
+	Status    product.Status
+	CanManage bool
+	Active    string
+}
+
+func (m ReadModel) Data(ctx context.Context, active string, canManage bool) (Data, error) {
+	if m.Service == nil {
+		return Data{}, fmt.Errorf("product settings service is required")
+	}
+	identity, err := m.Service.Get(ctx)
+	if err != nil {
+		return Data{}, err
+	}
+	status := m.Status
+	if status.System.ControlPlane == "" {
+		status.System.ControlPlane = "unknown"
+	}
+	if m.ControlPlane != nil {
+		status.System.ControlPlane = "available"
+		if err := m.ControlPlane.PingContext(ctx); err != nil {
+			status.System.ControlPlane = "unavailable"
+		}
+	}
+	if active == "" {
+		active = "general"
+	}
+	return Data{Identity: identity, Status: status, CanManage: canManage, Active: active}, nil
+}
+
+// Signal projects one complete, self-contained settings subtree. Keeping all
+// three views in the signal lets the Lit component switch tabs without issuing
+// ad hoc GET requests.
+func Signal(data Data) signals.ProductSettingsSignal {
+	status := data.Status
+	identity := data.Identity
+	general := signals.ProductGeneralSignal{
+		DisplayName: identity.DisplayName, Revision: identity.Revision, UpdatedAt: identity.UpdatedAt,
+		InstanceID: status.System.InstanceID, CanonicalOrigin: status.System.CanonicalOrigin,
+		Environment: status.System.Environment,
+	}
+	if identity.Logo != nil {
+		logo := identity.Logo
+		general.Logo = &signals.ProductLogoSignal{
+			URL: "/product/logo/" + logo.SHA256, Sha256: logo.SHA256,
+			MediaType: logo.MediaType, SizeBytes: logo.SizeBytes, Width: int32(logo.Width), Height: int32(logo.Height),
+		}
+	}
+	auth := status.Authentication
+	managedBy := auth.ManagedBy
+	if managedBy == "" {
+		managedBy = "deployment"
+	}
+	availability := func(value product.Availability) signals.ProductAvailabilitySignal {
+		return signals.ProductAvailabilitySignal{Available: value.Available, Enabled: value.Enabled}
+	}
+	named := func(value product.NamedAvailability) signals.ProductNamedAvailabilitySignal {
+		return signals.ProductNamedAvailabilitySignal{Available: value.Available, Enabled: value.Enabled, Provider: optionalString(value.Provider)}
+	}
+	api := status.API
+	system := status.System
+	build := system.Build
+	limits := system.Limits
+	agent := system.Agent
+	return signals.ProductSettingsSignal{
+		Active: data.Active, CanManage: data.CanManage, General: general,
+		Authentication: signals.ProductAuthenticationSignal{
+			BrowserEnabled: auth.BrowserEnabled, APITokenOnly: auth.APITokenOnly,
+			Local: availability(auth.Local), Oidc: named(auth.OIDC), Azure: availability(auth.Azure),
+			Scim: availability(auth.SCIM), ManagedBy: managedBy,
+		},
+		API: signals.ProductAPIStatusSignal{
+			BearerCredentials: availability(api.BearerCredentials), ServicePrincipals: availability(api.ServicePrincipals),
+			Oauth: availability(api.OAuth), Mcp: availability(api.MCP), ExternalMcpIssuer: api.ExternalMCPIssuer,
+		},
+		System: signals.ProductSystemSignal{
+			InstanceID: system.InstanceID, CanonicalOrigin: system.CanonicalOrigin, Environment: system.Environment,
+			Build:          signals.ProductBuildSignal{Version: build.Version, Revision: build.Revision, BuildTime: build.BuildTime, Dirty: build.Dirty, Development: build.Development},
+			StorageBackend: system.StorageBackend,
+			Agent:          signals.ProductAgentSignal{Available: agent.Available, Configured: agent.Configured, Provider: optionalString(agent.Provider), ModelConfigured: agent.ModelConfigured},
+			Limits: signals.ProductLimitsSignal{
+				QueryResultMaxRows: int32(limits.QueryResultMaxRows), QueryResultMaxBytes: limits.QueryResultMaxBytes,
+				ManagedDataMaxFiles: int32(limits.ManagedDataMaxFiles), ManagedDataMaxFileBytes: limits.ManagedDataMaxFileBytes,
+				ManagedDataMaxRevisionBytes: limits.ManagedDataMaxRevisionBytes,
+			},
+			Runtime: signals.ProductRuntimeSignal{Health: runtimeHealth(system.ControlPlane), ControlPlane: system.ControlPlane, Environment: system.Environment},
+		},
+	}
+}
+
+// Payload keeps the generated model authoritative while preserving the
+// explicit null required to remove a logo from Datastar's merge-patched state.
+type productSettingsWire struct {
+	signals.ProductSettingsSignal
+	General productGeneralWire `json:"general"`
+}
+
+type productGeneralWire struct {
+	signals.ProductGeneralSignal
+	Logo *signals.ProductLogoSignal `json:"logo"`
+}
+
+func Payload(signal signals.ProductSettingsSignal) productSettingsWire {
+	return productSettingsWire{
+		ProductSettingsSignal: signal,
+		General: productGeneralWire{
+			ProductGeneralSignal: signal.General,
+			Logo:                 signal.General.Logo,
+		},
+	}
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func runtimeHealth(controlPlane string) string {
+	switch controlPlane {
+	case "available":
+		return "healthy"
+	case "unavailable":
+		return "degraded"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/admin/productsettings/read_model_test.go
+++ b/internal/admin/productsettings/read_model_test.go
@@ -1,0 +1,88 @@
+package productsettings
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/admin/product"
+	"github.com/flidai/leapview/internal/platform"
+	"github.com/flidai/leapview/internal/platform/buildinfo"
+)
+
+func TestSignalProjectsIdentityAndRedactedStatus(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	service, err := product.New(store.SQLDB(), &testBlobs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := ReadModel{Service: service, Status: product.Status{
+		Authentication: product.AuthenticationStatus{BrowserEnabled: true, ManagedBy: "deployment", OIDC: product.NamedAvailability{Available: true, Enabled: true, Provider: "corporate"}},
+		API:            product.APIStatus{MCP: product.Availability{Available: true, Enabled: true}},
+		System:         product.SystemStatus{InstanceID: "lvinst_test", CanonicalOrigin: "https://example.test", Environment: "production", Build: buildinfo.Identity{Version: "1.2.3"}, StorageBackend: "s3", Agent: product.AgentStatus{Available: true, Configured: true}, Limits: product.Limits{QueryResultMaxRows: 100}},
+	}, ControlPlane: ping{}}
+	data, err := model.Data(t.Context(), "system", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signal := Signal(data)
+	if signal.General.DisplayName != "LeapView" || signal.General.Revision != 1 || signal.General.InstanceID != "lvinst_test" {
+		t.Fatalf("general = %#v", signal.General)
+	}
+	if !signal.CanManage || signal.Authentication.ManagedBy != "deployment" || signal.System.Runtime.Health != "healthy" {
+		t.Fatalf("signal = %#v", signal)
+	}
+	if signal.API.Mcp.Enabled != true || signal.System.Limits.QueryResultMaxRows != 100 {
+		t.Fatalf("api/system = %#v %#v", signal.API, signal.System)
+	}
+}
+
+func TestPayloadExplicitlyClearsRemovedLogo(t *testing.T) {
+	payload, err := json.Marshal(Payload(Signal(Data{})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(payload), `"logo":null`) {
+		t.Fatalf("payload = %s, want explicit null logo", payload)
+	}
+}
+
+func TestReadModelMarksControlPlaneUnavailable(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	service, err := product.New(store.SQLDB(), &testBlobs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := (ReadModel{Service: service, ControlPlane: ping{err: context.Canceled}}).Data(t.Context(), "general", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data.Status.System.ControlPlane != "unavailable" || Signal(data).System.Runtime.Health != "degraded" {
+		t.Fatalf("status = %#v signal=%#v", data.Status.System, Signal(data).System.Runtime)
+	}
+}
+
+type ping struct{ err error }
+
+func (p ping) PingContext(context.Context) error { return p.err }
+
+type testBlobs struct{}
+
+func (testBlobs) Put(context.Context, product.Blob, io.Reader) (product.Blob, error) {
+	return product.Blob{}, nil
+}
+
+func (testBlobs) Open(context.Context, string) (io.ReadCloser, error) {
+	return nil, product.ErrNotFound
+}

--- a/internal/admin/settings/commands.go
+++ b/internal/admin/settings/commands.go
@@ -1,0 +1,102 @@
+package settings
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+// ApplyServiceAccountCommand executes a validated settings command. It
+// returns the one-time raw secret only for create_secret; callers should put
+// that value in a short-lived signal patch and never persist it.
+func ApplyServiceAccountCommand(ctx context.Context, mutator ServiceAccountMutator, command ServiceAccountCommand) (string, error) {
+	secret, _, err := applyServiceAccountCommand(ctx, mutator, command)
+	return secret, err
+}
+
+func applyServiceAccountCommand(ctx context.Context, mutator ServiceAccountMutator, command ServiceAccountCommand) (string, string, error) {
+	if mutator == nil {
+		return "", "", errors.New("service account mutator is nil")
+	}
+	command = NormalizeServiceAccountCommand(command)
+	switch command.Action {
+	case "create":
+		if command.DisplayName == "" {
+			return "", "", errors.New("display name is required")
+		}
+		principal, err := mutator.CreateServicePrincipal(ctx, access.ServicePrincipalInput{ID: command.AccountID, DisplayName: command.DisplayName})
+		return "", principal.ID, err
+	case "update":
+		if command.AccountID == "" || command.DisplayName == "" {
+			return "", "", errors.New("account id and display name are required")
+		}
+		_, err := mutator.UpdateServicePrincipal(ctx, command.AccountID, access.ServicePrincipalInput{ID: command.AccountID, DisplayName: command.DisplayName})
+		return "", command.AccountID, err
+	case "delete":
+		if command.AccountID == "" {
+			return "", "", errors.New("account id is required")
+		}
+		return "", command.AccountID, mutator.DeleteServicePrincipal(ctx, command.AccountID)
+	case "create_secret":
+		if command.AccountID == "" || command.SecretName == "" {
+			return "", "", errors.New("account id and secret name are required")
+		}
+		var expiresAt time.Time
+		if command.ExpiresAt != "" {
+			parsed, err := time.Parse(time.RFC3339, command.ExpiresAt)
+			if err != nil {
+				return "", "", errors.New("expiresAt must be RFC3339")
+			}
+			expiresAt = parsed
+		}
+		raw, _, err := mutator.CreateServicePrincipalSecret(ctx, command.AccountID, access.ServicePrincipalSecretInput{Name: command.SecretName, ExpiresAt: expiresAt})
+		return raw, command.AccountID, err
+	case "revoke_secret":
+		if command.AccountID == "" || command.SecretID == "" {
+			return "", "", errors.New("account id and secret id are required")
+		}
+		return "", command.AccountID, mutator.RevokeServicePrincipalSecret(ctx, command.AccountID, command.SecretID)
+	default:
+		return "", "", errors.New("unknown service account action")
+	}
+}
+
+func ApplyServiceAccountCommandAudited(ctx context.Context, repository access.Repository, actorID string, command ServiceAccountCommand) (string, error) {
+	command = NormalizeServiceAccountCommand(command)
+	var secret string
+	mutation := func(tx access.Repository) (access.AuditEventInput, error) {
+		createdSecret, targetID, err := applyServiceAccountCommand(ctx, tx, command)
+		secret = createdSecret
+		return access.AuditEventInput{
+			PrincipalID: actorID, Action: "service_account." + command.Action,
+			TargetType: "service_principal", TargetID: targetID, Status: "success", MetadataJSON: `{}`,
+		}, err
+	}
+	if transactional, ok := repository.(access.AuditedMutationRepository); ok {
+		if err := transactional.RunAuditedMutation(ctx, mutation); err != nil {
+			return "", err
+		}
+		return secret, nil
+	}
+	event, err := mutation(repository)
+	if err != nil {
+		return "", err
+	}
+	if err := repository.RecordAuditEvent(ctx, event); err != nil {
+		return "", err
+	}
+	return secret, nil
+}
+
+func NormalizeServiceAccountCommand(command ServiceAccountCommand) ServiceAccountCommand {
+	command.Action = strings.TrimSpace(command.Action)
+	command.AccountID = strings.TrimSpace(command.AccountID)
+	command.SecretID = strings.TrimSpace(command.SecretID)
+	command.DisplayName = strings.TrimSpace(command.DisplayName)
+	command.SecretName = strings.TrimSpace(command.SecretName)
+	command.ExpiresAt = strings.TrimSpace(command.ExpiresAt)
+	return command
+}

--- a/internal/admin/settings/loaders.go
+++ b/internal/admin/settings/loaders.go
@@ -1,0 +1,234 @@
+package settings
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/workspace"
+)
+
+// WorkspaceAdministrationReader is implemented by workspace repositories and
+// keeps this adapter independent from the HTTP API module.
+type WorkspaceAdministrationReader interface {
+	workspace.ReadModel
+	workspace.AdministrationReadModel
+}
+
+// LoadWorkspaceRegistry joins workspace-owned runtime projections with the
+// access-owned owner/administrator projection. A missing access service is
+// treated as an intentionally redacted owner/admin view.
+func LoadWorkspaceRegistry(ctx context.Context, reader WorkspaceAdministrationReader, accessService access.WorkspaceAccessService, environment string) (WorkspaceRegistrySignal, error) {
+	if reader == nil {
+		return WorkspaceRegistrySignal{Error: "Workspace registry is unavailable."}, errors.New("workspace registry reader is nil")
+	}
+	summaries, err := reader.List(ctx)
+	if err != nil {
+		return WorkspaceRegistrySignal{Error: err.Error()}, err
+	}
+	result := WorkspaceRegistrySignal{Items: make([]WorkspaceRegistryItemSignal, 0, len(summaries))}
+	for _, summary := range summaries {
+		state, stateErr := reader.AdministrationByID(ctx, summary.ID, environment)
+		if stateErr != nil {
+			if errors.Is(stateErr, workspace.ErrNotFound) {
+				continue
+			}
+			return WorkspaceRegistrySignal{Error: stateErr.Error()}, stateErr
+		}
+		item := WorkspaceSignalFromSummary(summary, environment)
+		item.Environment = state.Environment
+		item.ActiveServingStateID = string(state.Workspace.ActiveServingStateID)
+		item.ServingStateStatus = state.ActiveServingStateStatus
+		item.ServingStateSince = state.ActiveServingStateSince
+		item.ProjectID = state.ProjectID
+		item.CurrentDeploymentID = state.CurrentDeploymentID
+		item.DeploymentStatus = state.CurrentDeploymentStatus
+		item.DeploymentSince = state.CurrentDeploymentSince
+		item.CurrentReleaseID = state.CurrentReleaseID
+		item.Links = workspaceLinks(item, state)
+		if accessService != nil {
+			owner, admins, accessErr := workspaceSubjects(ctx, accessService, string(summary.ID))
+			if accessErr != nil {
+				return WorkspaceRegistrySignal{Error: accessErr.Error()}, accessErr
+			}
+			item.Owner, item.Administrators = owner, admins
+		}
+		result.Items = append(result.Items, item)
+	}
+	SortWorkspaceItems(result.Items)
+	if len(result.Items) == 0 {
+		result.Empty = "No workspaces are available."
+	}
+	return result, nil
+}
+
+func workspaceSubjects(ctx context.Context, service access.WorkspaceAccessService, id string) (*WorkspaceSubjectSignal, []WorkspaceSubjectSignal, error) {
+	object, err := service.GetSecurableObject(ctx, access.WorkspaceObject(id))
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		// A workspace can legitimately have no owner yet. Other errors should be
+		// surfaced so a partial access projection is not mistaken for truth.
+		return nil, nil, err
+	}
+	var owner *WorkspaceSubjectSignal
+	if object.OwnerPrincipalID != "" {
+		principal, principalErr := service.PrincipalByID(ctx, object.OwnerPrincipalID)
+		if principalErr != nil && !errors.Is(principalErr, sql.ErrNoRows) && !strings.Contains(strings.ToLower(principalErr.Error()), "no rows") {
+			return nil, nil, principalErr
+		}
+		if principal.ID != "" {
+			owner = &WorkspaceSubjectSignal{SubjectType: string(access.SubjectPrincipal), SubjectID: principal.ID,
+				Email: principal.Email, DisplayName: firstNonEmpty(principal.DisplayName, principal.Email, principal.ID), Role: access.RoleOwner}
+		}
+	}
+	bindings, err := service.ListRoleBindings(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	admins := make([]WorkspaceSubjectSignal, 0, len(bindings))
+	for _, binding := range bindings {
+		if binding.Role != access.RoleOwner && binding.Role != access.RoleAdmin {
+			continue
+		}
+		admins = append(admins, WorkspaceSubjectSignal{SubjectType: string(binding.SubjectType), SubjectID: binding.SubjectID,
+			Email: binding.Email, DisplayName: firstNonEmpty(binding.DisplayName, binding.Email, binding.GroupName, binding.SubjectID), Role: binding.Role})
+	}
+	sort.SliceStable(admins, func(i, j int) bool {
+		if admins[i].Role != admins[j].Role {
+			return admins[i].Role < admins[j].Role
+		}
+		return admins[i].SubjectID < admins[j].SubjectID
+	})
+	return owner, admins, nil
+}
+
+func workspaceLinks(item WorkspaceRegistryItemSignal, state workspace.AdministrationState) WorkspaceLinksSignal {
+	id := url.PathEscape(item.ID)
+	links := WorkspaceLinksSignal{Self: "/api/v1/workspaces/" + id, Workspace: "/workspaces/" + id}
+	project := url.PathEscape(state.ProjectID)
+	if strings.TrimSpace(state.ProjectID) == "" {
+		return links
+	}
+	links.Project = "/api/v1/projects/" + project
+	if state.CurrentReleaseID != "" {
+		links.Release = links.Project + "/releases/" + url.PathEscape(state.CurrentReleaseID)
+	}
+	if state.CurrentDeploymentID != "" {
+		links.Deployment = links.Project + "/deployments/" + url.PathEscape(state.CurrentDeploymentID)
+	}
+	links.Deployments = links.Project + "/deployments"
+	links.Connections = "/connections"
+	links.Publications = "/admin/publications"
+	links.Agent = "/admin/agent"
+	return links
+}
+
+// ServicePrincipalSecretReader is the optional metadata extension implemented
+// by the production repository. It intentionally does not expose raw secrets.
+type ServicePrincipalSecretReader interface {
+	ListServicePrincipalSecrets(context.Context, string) ([]access.ServicePrincipalSecret, error)
+}
+
+type ServiceAccountReader interface {
+	ListServicePrincipals(context.Context) ([]access.Principal, error)
+	ServicePrincipalSecretReader
+}
+
+type Repository interface {
+	access.Repository
+	ServicePrincipalSecretReader
+}
+
+type ServiceAccountMutator interface {
+	CreateServicePrincipal(context.Context, access.ServicePrincipalInput) (access.Principal, error)
+	UpdateServicePrincipal(context.Context, string, access.ServicePrincipalInput) (access.Principal, error)
+	DeleteServicePrincipal(context.Context, string) error
+	CreateServicePrincipalSecret(context.Context, string, access.ServicePrincipalSecretInput) (string, access.ServicePrincipalSecret, error)
+	RevokeServicePrincipalSecret(context.Context, string, string) error
+}
+
+func LoadServiceAccounts(ctx context.Context, store ServiceAccountReader, selectedID string) (ServiceAccountsSignal, error) {
+	if store == nil {
+		return ServiceAccountsSignal{Error: "Service account store is unavailable."}, errors.New("service account store is nil")
+	}
+	principals, err := store.ListServicePrincipals(ctx)
+	if err != nil {
+		return ServiceAccountsSignal{Error: err.Error()}, err
+	}
+	result := ServiceAccountsSignal{Items: make([]ServiceAccountSignal, 0, len(principals)), SelectedID: strings.TrimSpace(selectedID)}
+	for _, principal := range principals {
+		result.Items = append(result.Items, ServiceAccountSignalFromPrincipal(principal))
+	}
+	sort.SliceStable(result.Items, func(i, j int) bool {
+		if strings.EqualFold(result.Items[i].DisplayName, result.Items[j].DisplayName) {
+			return result.Items[i].ID < result.Items[j].ID
+		}
+		return strings.ToLower(result.Items[i].DisplayName) < strings.ToLower(result.Items[j].DisplayName)
+	})
+	if result.SelectedID == "" && len(result.Items) > 0 {
+		result.SelectedID = result.Items[0].ID
+	}
+	if result.SelectedID != "" {
+		secrets, secretErr := store.ListServicePrincipalSecrets(ctx, result.SelectedID)
+		if secretErr != nil {
+			return ServiceAccountsSignal{Items: result.Items, SelectedID: result.SelectedID, Error: secretErr.Error()}, secretErr
+		}
+		result.Secrets = make([]ServiceAccountSecretSignal, 0, len(secrets))
+		for _, secret := range secrets {
+			result.Secrets = append(result.Secrets, ServiceAccountSecretSignalFromDomain(secret))
+		}
+	}
+	return result, nil
+}
+
+func ServiceAccountsSignalFromPrincipals(principals []access.Principal) ServiceAccountsSignal {
+	result := ServiceAccountsSignal{Items: make([]ServiceAccountSignal, 0, len(principals))}
+	for _, principal := range principals {
+		result.Items = append(result.Items, ServiceAccountSignalFromPrincipal(principal))
+	}
+	sort.SliceStable(result.Items, func(i, j int) bool { return result.Items[i].ID < result.Items[j].ID })
+	return result
+}
+
+// LoadAuditLog requests one extra row so callers can safely expose HasMore
+// without a count query. Repository implementations apply all filter fields
+// and cursor validation.
+func LoadAuditLog(ctx context.Context, repository access.Repository, filters AuditLogFilters, pageToken string, limit int) (AuditLogSignal, error) {
+	if repository == nil {
+		return AuditLogSignal{Error: "Audit log is unavailable."}, errors.New("audit repository is nil")
+	}
+	filters = NormalizeAuditLogFilters(filters)
+	limit = normalizeLimit(limit)
+	rows, err := repository.ListAuditEvents(ctx, access.AuditEventFilter{WorkspaceID: filters.WorkspaceID, PrincipalID: filters.PrincipalID,
+		Action: filters.Action, TargetType: filters.TargetType, TargetID: filters.TargetID, From: filters.From, To: filters.To,
+		PageToken: strings.TrimSpace(pageToken), Limit: limit + 1})
+	if err != nil {
+		return AuditLogSignal{Filters: filters, Error: err.Error()}, err
+	}
+	hasMore := len(rows) > limit
+	if hasMore {
+		rows = rows[:limit]
+	}
+	items := make([]AuditEventSignal, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, AuditEventSignalFromDomain(row))
+	}
+	result := AuditLogSignal{Items: items, Filters: filters, HasMore: hasMore, LoadedCount: len(items)}
+	if hasMore && len(rows) > 0 {
+		last := rows[len(rows)-1]
+		result.NextCursor = AuditPageToken(last.CreatedAt, last.ID)
+	}
+	return result, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/admin/settings/signals.go
+++ b/internal/admin/settings/signals.go
@@ -1,0 +1,246 @@
+// Package settings contains the presentation contracts used by the settings
+// surfaces.  The package deliberately has no HTTP or Datastar dependencies:
+// callers can put these values in an existing page envelope/stream and keep
+// mutations on the normal CSRF-protected command path.
+package settings
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/workspace"
+)
+
+// WorkspaceRegistrySignal is the read-only workspace registry used by the
+// settings overview.  An item includes ownership, administrators, runtime
+// deployment state, and links to the owning API resources.
+type WorkspaceRegistrySignal struct {
+	Items      []WorkspaceRegistryItemSignal `json:"items"`
+	Empty      string                        `json:"empty,omitempty"`
+	Loading    bool                          `json:"loading"`
+	Error      string                        `json:"error,omitempty"`
+	NextCursor string                        `json:"nextCursor,omitempty"`
+	HasMore    bool                          `json:"hasMore"`
+}
+
+type WorkspaceRegistryItemSignal struct {
+	ID                   string                   `json:"id"`
+	Title                string                   `json:"title"`
+	Description          string                   `json:"description,omitempty"`
+	Href                 string                   `json:"href"`
+	CreatedAt            string                   `json:"createdAt,omitempty"`
+	UpdatedAt            string                   `json:"updatedAt,omitempty"`
+	Owner                *WorkspaceSubjectSignal  `json:"owner,omitempty"`
+	Administrators       []WorkspaceSubjectSignal `json:"administrators"`
+	Environment          string                   `json:"environment,omitempty"`
+	ActiveServingStateID string                   `json:"activeServingStateId,omitempty"`
+	ServingStateStatus   string                   `json:"servingStateStatus,omitempty"`
+	ServingStateSince    string                   `json:"servingStateSince,omitempty"`
+	ProjectID            string                   `json:"projectId,omitempty"`
+	CurrentDeploymentID  string                   `json:"currentDeploymentId,omitempty"`
+	DeploymentStatus     string                   `json:"deploymentStatus,omitempty"`
+	DeploymentSince      string                   `json:"deploymentSince,omitempty"`
+	CurrentReleaseID     string                   `json:"currentReleaseId,omitempty"`
+	Links                WorkspaceLinksSignal     `json:"links"`
+}
+
+type WorkspaceSubjectSignal struct {
+	SubjectType string `json:"subjectType"`
+	SubjectID   string `json:"subjectId"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"displayName"`
+	Role        string `json:"role,omitempty"`
+}
+
+type WorkspaceLinksSignal struct {
+	Self         string `json:"self"`
+	Workspace    string `json:"workspace"`
+	Project      string `json:"project,omitempty"`
+	Release      string `json:"release,omitempty"`
+	Deployment   string `json:"deployment,omitempty"`
+	Deployments  string `json:"deployments,omitempty"`
+	Connections  string `json:"connections,omitempty"`
+	Publications string `json:"publications,omitempty"`
+	Agent        string `json:"agent,omitempty"`
+}
+
+// ServiceAccountsSignal contains account rows and the selected account's
+// secret metadata. Raw secrets are only present in ServiceAccountSecretSignal
+// at creation time and are never copied into this list signal.
+type ServiceAccountsSignal struct {
+	Items         []ServiceAccountSignal       `json:"items"`
+	SelectedID    string                       `json:"selectedId"`
+	Secrets       []ServiceAccountSecretSignal `json:"secrets"`
+	CreatedSecret string                       `json:"createdSecret"`
+	Error         string                       `json:"error"`
+	Loading       bool                         `json:"loading"`
+	NextCursor    string                       `json:"nextCursor,omitempty"`
+	HasMore       bool                         `json:"hasMore"`
+}
+
+type ServiceAccountSignal struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	Email       string `json:"email,omitempty"`
+	Kind        string `json:"kind"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+	DisabledAt  string `json:"disabledAt,omitempty"`
+}
+
+type ServiceAccountSecretSignal struct {
+	ID                 string `json:"id"`
+	ServicePrincipalID string `json:"servicePrincipalId"`
+	Name               string `json:"name"`
+	ExpiresAt          string `json:"expiresAt,omitempty"`
+	CreatedAt          string `json:"createdAt,omitempty"`
+	RevokedAt          string `json:"revokedAt,omitempty"`
+}
+
+type ServiceAccountCommand struct {
+	Action      string `json:"action"`
+	AccountID   string `json:"accountId,omitempty"`
+	SecretID    string `json:"secretId,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	SecretName  string `json:"secretName,omitempty"`
+	ExpiresAt   string `json:"expiresAt,omitempty"`
+}
+
+// AuditLogSignal is a product-level, read-only audit table. Filters and page
+// tokens are carried in AuditLogCommand so the stream remains the sole data
+// transport.
+type AuditLogSignal struct {
+	Items       []AuditEventSignal `json:"items"`
+	Filters     AuditLogFilters    `json:"filters"`
+	NextCursor  string             `json:"nextCursor"`
+	HasMore     bool               `json:"hasMore"`
+	LoadedCount int                `json:"loadedCount"`
+	Loading     bool               `json:"loading"`
+	Error       string             `json:"error"`
+}
+
+type AuditEventSignal struct {
+	ID            string         `json:"id"`
+	WorkspaceID   string         `json:"workspaceId,omitempty"`
+	PrincipalID   string         `json:"principalId,omitempty"`
+	Action        string         `json:"action"`
+	TargetType    string         `json:"targetType"`
+	TargetID      string         `json:"targetId"`
+	Privilege     string         `json:"privilege,omitempty"`
+	Status        string         `json:"status,omitempty"`
+	RequestID     string         `json:"requestId,omitempty"`
+	CorrelationID string         `json:"correlationId,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+	CreatedAt     string         `json:"createdAt"`
+}
+
+type AuditLogFilters struct {
+	WorkspaceID string `json:"workspaceId"`
+	PrincipalID string `json:"principalId"`
+	Action      string `json:"action"`
+	TargetType  string `json:"targetType"`
+	TargetID    string `json:"targetId"`
+	From        string `json:"from"`
+	To          string `json:"to"`
+}
+
+type AuditLogCommand struct {
+	Action    string          `json:"action"`
+	Filters   AuditLogFilters `json:"filters"`
+	PageToken string          `json:"pageToken,omitempty"`
+	Limit     int             `json:"limit,omitempty"`
+}
+
+func normalizeLimit(limit int) int {
+	if limit <= 0 {
+		return 50
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}
+
+// NormalizeAuditLogCommand drops unknown actions and bounds the page size.
+// Filtering actions reset pagination so a stale cursor cannot skip results.
+func NormalizeAuditLogCommand(command AuditLogCommand) AuditLogCommand {
+	command.Action = strings.TrimSpace(command.Action)
+	switch command.Action {
+	case "load_more", "reset", "filter", "clear":
+	default:
+		command.Action = "reset"
+	}
+	command.Filters = NormalizeAuditLogFilters(command.Filters)
+	command.Limit = normalizeLimit(command.Limit)
+	command.PageToken = strings.TrimSpace(command.PageToken)
+	if command.Action == "reset" || command.Action == "filter" || command.Action == "clear" {
+		command.PageToken = ""
+	}
+	return command
+}
+
+func NormalizeAuditLogFilters(filters AuditLogFilters) AuditLogFilters {
+	filters.WorkspaceID = strings.TrimSpace(filters.WorkspaceID)
+	filters.PrincipalID = strings.TrimSpace(filters.PrincipalID)
+	filters.Action = strings.TrimSpace(filters.Action)
+	filters.TargetType = strings.TrimSpace(filters.TargetType)
+	filters.TargetID = strings.TrimSpace(filters.TargetID)
+	filters.From = strings.TrimSpace(filters.From)
+	filters.To = strings.TrimSpace(filters.To)
+	return filters
+}
+
+// AuditPageToken encodes the stable createdAt/id cursor used by the access
+// repository and API. It is exported so command handlers can produce the same
+// cursor as the REST endpoint without reaching into sqlite implementation.
+func AuditPageToken(createdAt, id string) string {
+	if strings.TrimSpace(createdAt) == "" || strings.TrimSpace(id) == "" {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString([]byte(createdAt + "\x00" + id))
+}
+
+// WorkspaceSignalFromSummary provides a useful empty-state row when an
+// administration projection is unavailable.
+func WorkspaceSignalFromSummary(summary workspace.Summary, environment string) WorkspaceRegistryItemSignal {
+	id := string(summary.ID)
+	return WorkspaceRegistryItemSignal{ID: id, Title: summary.Title, Description: summary.Description,
+		Href: "/workspaces/" + url.PathEscape(id), CreatedAt: summary.CreatedAt, UpdatedAt: summary.UpdatedAt,
+		Environment: environment, ActiveServingStateID: string(summary.ActiveServingStateID),
+		Administrators: []WorkspaceSubjectSignal{},
+		Links:          WorkspaceLinksSignal{Self: "/api/v1/workspaces/" + url.PathEscape(id), Workspace: "/workspaces/" + url.PathEscape(id)}}
+}
+
+func ServiceAccountSignalFromPrincipal(principal access.Principal) ServiceAccountSignal {
+	return ServiceAccountSignal{ID: principal.ID, DisplayName: principal.DisplayName, Email: principal.Email,
+		Kind: string(principal.Kind), CreatedAt: principal.CreatedAt, UpdatedAt: principal.UpdatedAt, DisabledAt: principal.DisabledAt}
+}
+
+func ServiceAccountSecretSignalFromDomain(secret access.ServicePrincipalSecret) ServiceAccountSecretSignal {
+	return ServiceAccountSecretSignal{ID: secret.ID, ServicePrincipalID: secret.ServicePrincipalID, Name: secret.Name,
+		ExpiresAt: secret.ExpiresAt, CreatedAt: secret.CreatedAt, RevokedAt: secret.RevokedAt}
+}
+
+func AuditEventSignalFromDomain(event access.AuditEvent) AuditEventSignal {
+	metadata := map[string]any{}
+	if strings.TrimSpace(event.MetadataJSON) != "" {
+		_ = json.Unmarshal([]byte(event.MetadataJSON), &metadata)
+	}
+	return AuditEventSignal{ID: event.ID, WorkspaceID: event.WorkspaceID, PrincipalID: event.PrincipalID,
+		Action: event.Action, TargetType: event.TargetType, TargetID: event.TargetID, Privilege: string(event.Privilege),
+		Status: event.Status, RequestID: event.RequestID, CorrelationID: event.CorrelationID, Metadata: metadata, CreatedAt: event.CreatedAt}
+}
+
+func SortWorkspaceItems(items []WorkspaceRegistryItemSignal) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := strings.ToLower(items[i].Title), strings.ToLower(items[j].Title)
+		if left == right {
+			return items[i].ID < items[j].ID
+		}
+		return left < right
+	})
+}

--- a/internal/admin/settings/signals_test.go
+++ b/internal/admin/settings/signals_test.go
@@ -1,0 +1,49 @@
+package settings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/workspace"
+)
+
+func TestWorkspaceSignalFromSummaryEscapesLinks(t *testing.T) {
+	item := WorkspaceSignalFromSummary(workspace.Summary{ID: "sales team", Title: "Sales", Description: "Revenue"}, "prod")
+	if item.Href != "/workspaces/sales%20team" || item.Links.Self != "/api/v1/workspaces/sales%20team" {
+		t.Fatalf("links = %#v", item)
+	}
+}
+
+func TestNormalizeAuditLogCommandResetsCursorAndBoundsLimit(t *testing.T) {
+	command := NormalizeAuditLogCommand(AuditLogCommand{Action: "filter", PageToken: "stale", Limit: 500, Filters: AuditLogFilters{Action: " create "}})
+	if command.PageToken != "" || command.Limit != 100 || command.Filters.Action != "create" {
+		t.Fatalf("normalized command = %#v", command)
+	}
+}
+
+func TestAuditEventSignalParsesMetadataWithoutRawSecret(t *testing.T) {
+	event := AuditEventSignalFromDomain(access.AuditEvent{ID: "a1", Action: "service_principal_secret.created", MetadataJSON: `{"secretId":"s1"}`})
+	if event.Metadata["secretId"] != "s1" || event.Metadata == nil {
+		t.Fatalf("metadata = %#v", event.Metadata)
+	}
+}
+
+type testServiceAccountReader struct{}
+
+func (testServiceAccountReader) ListServicePrincipals(context.Context) ([]access.Principal, error) {
+	return []access.Principal{{ID: "svc-2", DisplayName: "Zulu", Kind: access.PrincipalKindServicePrincipal}, {ID: "svc-1", DisplayName: "Alpha", Kind: access.PrincipalKindServicePrincipal}}, nil
+}
+func (testServiceAccountReader) ListServicePrincipalSecrets(context.Context, string) ([]access.ServicePrincipalSecret, error) {
+	return []access.ServicePrincipalSecret{{ID: "secret-1", ServicePrincipalID: "svc-1", Name: "ci"}}, nil
+}
+
+func TestLoadServiceAccountsSortsAndSelectsMetadata(t *testing.T) {
+	signal, err := LoadServiceAccounts(context.Background(), testServiceAccountReader{}, "svc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if signal.Items[0].ID != "svc-1" || signal.SelectedID != "svc-1" || len(signal.Secrets) != 1 {
+		t.Fatalf("signal = %#v", signal)
+	}
+}

--- a/internal/admin/ui/page.go
+++ b/internal/admin/ui/page.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/flidai/leapview/internal/admin/personalsettings"
 	uisignals "github.com/flidai/leapview/internal/admin/ui/signals"
 	adminview "github.com/flidai/leapview/internal/admin/view"
 	"github.com/flidai/leapview/internal/dashboard"
@@ -78,15 +79,17 @@ type AdminAgentTool struct {
 }
 
 type AdminPrincipal struct {
-	ID          string
-	Kind        string
-	Email       string
-	DisplayName string
-	DisabledAt  string
-	CreatedAt   string
-	UpdatedAt   string
-	DirectRoles []string
-	Groups      []AdminGroupRef
+	ID                string
+	Kind              string
+	Email             string
+	DisplayName       string
+	ProfilePictureURL string
+	DisabledAt        string
+	CreatedAt         string
+	UpdatedAt         string
+	LastSeenAt        string
+	DirectRoles       []string
+	Groups            []AdminGroupRef
 }
 
 type AdminGroupRef struct {
@@ -190,6 +193,24 @@ func AdminPage(active string, data AdminData, providers ...webpage.Provider) g.N
 			g.Attr("data-on:lv-storage-table-select", "$adminStorageCommand = evt.detail; "+uiactions.EventPost("/admin/storage/select-table")),
 		)
 	}
+	if active == "profile" || active == "security" || active == "api-tokens" {
+		adminAttrs = append(adminAttrs, personalsettings.CommandAttributes("/admin/personal-settings/command?section="+url.QueryEscape(active))...)
+	}
+	if active == "general" || active == "authentication" || active == "system" {
+		adminAttrs = append(adminAttrs,
+			g.Attr("data-on:lv-product-settings-command", "$productSettingsCommand = evt.detail; "+uiactions.UncontractedMutationPost("/admin/product-settings/command?section="+url.QueryEscape(active), "productSettingsCommand")),
+		)
+	}
+	if active == "service-accounts" {
+		adminAttrs = append(adminAttrs,
+			g.Attr("data-on:lv-service-account-command", "$adminServiceAccountCommand = evt.detail; "+uiactions.UncontractedMutationPost("/admin/service-accounts/command", "adminServiceAccountCommand")),
+		)
+	}
+	if active == "audit" {
+		adminAttrs = append(adminAttrs,
+			g.Attr("data-on:lv-audit-log-command", "$adminAuditLogCommand = evt.detail; "+uiactions.UncontractedMutationPost("/admin/audit/command", "adminAuditLogCommand", "adminAuditLog")),
+		)
+	}
 	if active == "agent" {
 		adminAttrs = append(adminAttrs,
 			g.Attr("data-on:lv-agent-system-prompt-save", "$adminAgentCommand = evt.detail; "+uiactions.UncontractedMutationPatch("/admin/agent/config")),
@@ -250,12 +271,12 @@ func AdminListResultsPatch(active string, data AdminData) map[string]any {
 	page := adminPageSignal(active, data)
 	switch normalizeAdminSection(active) {
 	case "principals":
-		groups := []uisignals.AdminDirectoryListGroupSignal{}
+		items := []uisignals.AdminDirectoryListItemSignal{}
 		if page.DirectoryList != nil {
-			groups = page.DirectoryList.Groups
+			items = page.DirectoryList.Items
 		}
 		return map[string]any{"page": map[string]any{
-			"directoryList": map[string]any{"groups": groups},
+			"directoryList": map[string]any{"items": items},
 		}}
 	case "groups":
 		return map[string]any{"page": map[string]any{"sections": uisignals.ValueOrZero(page.Sections)}}
@@ -300,11 +321,24 @@ func adminPageSignal(active string, data AdminData) uisignals.AdminPageSignal {
 	}
 	switch active {
 	case "principals":
-		page.HeaderTitle = "Members"
+		page.HeaderTitle = "Principals"
+		page.HeaderDetail = "Manage users and their account status."
 		page.DirectoryList = uisignals.Pointer(adminDirectoryList(data.Principals, data.ListFilter))
 	case "profile":
 		page.HeaderTitle = "Profile"
-		page.Profile = uisignals.Pointer(adminProfileSignal(data.Profile))
+		page.HeaderDetail = "Manage your photo and display name."
+	case "security":
+		page.HeaderTitle = "Security & sessions"
+		page.HeaderDetail = "Change your password and review signed-in devices."
+	case "api-tokens":
+		page.HeaderTitle = "API tokens"
+		page.HeaderDetail = "Manage personal API and CLI credentials."
+	case "general":
+		page.HeaderTitle = "General"
+		page.HeaderDetail = "Configure product identity and view instance details."
+	case "workspaces-admin":
+		page.HeaderTitle = "Workspaces"
+		page.HeaderDetail = "Review workspaces, ownership, and deployment state."
 	case "principal-detail":
 		page.HeaderTitle = "Principals"
 		page.HeaderDetail = "Read-only principal access."
@@ -327,9 +361,15 @@ func adminPageSignal(active string, data AdminData) uisignals.AdminPageSignal {
 		page.Sections = uisignals.OptionalSlice([]uisignals.AdminContentSectionSignal{{Title: "Groups", Table: uisignals.Pointer(adminPrincipalGroupsGrid(principal, data.Groups))}})
 	case "groups":
 		page.HeaderTitle = "Groups"
-		page.HeaderDetail = "Workspace groups and their read-only membership summaries."
+		page.HeaderDetail = "Organize users and assign access collectively."
 		page.ListFilterOptions = uisignals.OptionalSlice(adminGroupProviders(data.Groups))
 		page.Sections = uisignals.OptionalSlice([]uisignals.AdminContentSectionSignal{{Title: "Groups", Table: uisignals.Pointer(adminGroupsGrid(filterAdminGroups(data.Groups, data.ListQuery, data.ListFilter)))}})
+	case "service-accounts":
+		page.HeaderTitle = "Service accounts"
+		page.HeaderDetail = "Manage machine identities and credentials."
+	case "authentication":
+		page.HeaderTitle = "Authentication"
+		page.HeaderDetail = "Review login and provisioning configuration."
 	case "group-detail":
 		page.HeaderTitle = "Groups"
 		page.HeaderDetail = "Read-only group membership."
@@ -351,7 +391,7 @@ func adminPageSignal(active string, data AdminData) uisignals.AdminPageSignal {
 		page.Sections = uisignals.OptionalSlice([]uisignals.AdminContentSectionSignal{{Title: "Members", Table: uisignals.Pointer(adminGroupMembersGrid(group, data.Principals))}})
 	case "agent":
 		page.HeaderTitle = "Agent"
-		page.HeaderDetail = "Platform agent prompt and read-only tool inventory."
+		page.HeaderDetail = "Review agent availability and configuration."
 		page.Agent = uisignals.Pointer(adminAgentSignal(data.Agent))
 		page.Metrics = uisignals.OptionalSlice([]uisignals.AdminMetricSignal{
 			{Label: "Status", Value: configuredLabel(data.Agent.Enabled)},
@@ -360,7 +400,7 @@ func adminPageSignal(active string, data AdminData) uisignals.AdminPageSignal {
 		})
 	case "storage":
 		page.HeaderTitle = "Storage"
-		page.HeaderDetail = "Read-only DuckLake catalog and table metadata."
+		page.HeaderDetail = "Review managed data capacity and health."
 		page.Storage = uisignals.Pointer(AdminStorageSignalFromData(data.Storage, AdminStorageCommand{}))
 		if data.Storage.Status != "" {
 			page.Empty = uisignals.Pointer(data.Storage.Status)
@@ -372,18 +412,23 @@ func adminPageSignal(active string, data AdminData) uisignals.AdminPageSignal {
 			{Label: "Tables", Value: fmt.Sprint(data.Storage.TableCount)},
 		})
 	case "queries":
-		page.HeaderTitle = "Query History"
-		page.HeaderDetail = "Product query audit across dashboards, API, agents, and Data Explorer."
+		page.HeaderTitle = "Query history"
+		page.HeaderDetail = "Inspect query activity, performance, and failures."
+	case "audit":
+		page.HeaderTitle = "Audit log"
+		page.HeaderDetail = "Review security and administrative changes."
+	case "system":
+		page.HeaderTitle = "System"
+		page.HeaderDetail = "View health, version, limits, and runtime configuration."
 	case "publications":
 		page.HeaderTitle = "Publications"
-		page.HeaderDetail = "Public dashboard URLs, embedding policy, and immediate lifecycle controls. Configuration remains YAML-only."
+		page.HeaderDetail = "Control publicly shared dashboards."
 		page.Publications = uisignals.OptionalSlice(adminPublicationSignals(data.Publications))
 		if len(data.Publications) == 0 {
 			page.Empty = uisignals.Pointer("No dashboard publications have been configured.")
 		}
 	default:
 		page.HeaderTitle = "Profile"
-		page.Profile = uisignals.Pointer(adminProfileSignal(data.Profile))
 	}
 	return page
 }
@@ -529,17 +574,6 @@ func adminAgentSignal(data AdminAgentData) uisignals.AdminAgentSignal {
 	}
 }
 
-func adminProfileSignal(data AdminProfile) uisignals.AdminProfileSignal {
-	return uisignals.AdminProfileSignal{
-		ID:                data.ID,
-		Email:             data.Email,
-		DisplayName:       data.DisplayName,
-		Title:             data.Title,
-		Username:          data.Username,
-		ProfilePictureURL: uisignals.Optional(data.ProfilePictureURL),
-	}
-}
-
 func adminPrincipalsGrid(principals []AdminPrincipal) adminRecordTable {
 	rows := make([]map[string]any, 0, len(principals))
 	for _, principal := range principals {
@@ -569,72 +603,39 @@ func adminPrincipalsGrid(principals []AdminPrincipal) adminRecordTable {
 }
 
 func adminDirectoryList(principals []AdminPrincipal, filter string) uisignals.AdminDirectoryListSignal {
-	groupOrder := []struct {
-		id    string
-		label string
-	}{
-		{id: "active", label: "Active"},
-		{id: "application", label: "Application"},
-		{id: "inactive", label: "Inactive"},
-	}
-	itemsByGroup := make(map[string][]uisignals.AdminDirectoryListItemSignal, len(groupOrder))
+	items := make([]uisignals.AdminDirectoryListItemSignal, 0, len(principals))
 	for _, principal := range principals {
-		groupID := "active"
-		kind := "person"
+		if kind := strings.TrimSpace(principal.Kind); kind != "" && kind != "user" {
+			continue
+		}
 		status := "active"
-		role := firstRoleLabel(principal.DirectRoles)
 		if strings.TrimSpace(principal.DisabledAt) != "" {
-			groupID = "inactive"
 			status = "inactive"
-			role = "Suspended"
-		} else if principal.Kind == "service_principal" || principal.Kind == "dashboard_publication" {
-			groupID = "application"
-			kind = "application"
-			role = "Application"
 		}
-		if role == "" {
-			role = "Member"
-		}
-		if !adminDirectoryFilterMatches(filter, groupID, kind) {
+		if !adminDirectoryFilterMatches(filter, status) {
 			continue
 		}
-		itemsByGroup[groupID] = append(itemsByGroup[groupID], uisignals.AdminDirectoryListItemSignal{
-			ID:         principal.ID,
-			Name:       adminDisplayLabel(principal.DisplayName, principal.Email, principal.ID),
-			Username:   adminPrincipalUsername(principal),
-			Email:      principal.Email,
-			Href:       adminPrincipalHref(principal.ID),
-			Kind:       kind,
-			Status:     status,
-			Role:       role,
-			GroupCount: int64(len(principal.Groups)),
-			JoinedAt:   principal.CreatedAt,
+		items = append(items, uisignals.AdminDirectoryListItemSignal{
+			ID: principal.ID, AvatarURL: uisignals.Optional(principal.ProfilePictureURL),
+			Name:     adminDisplayLabel(principal.DisplayName, principal.Email, principal.ID),
+			Username: adminPrincipalUsername(principal), Email: principal.Email,
+			Href: adminPrincipalHref(principal.ID), Status: status,
+			GroupCount: int64(len(principal.Groups)), JoinedAt: principal.CreatedAt, LastSeenAt: principal.LastSeenAt,
 		})
-	}
-
-	groups := make([]uisignals.AdminDirectoryListGroupSignal, 0, len(groupOrder))
-	for _, group := range groupOrder {
-		items := itemsByGroup[group.id]
-		if len(items) == 0 {
-			continue
-		}
-		groups = append(groups, uisignals.AdminDirectoryListGroupSignal{ID: group.id, Label: group.label, Items: items})
 	}
 	return uisignals.AdminDirectoryListSignal{
 		SearchPlaceholder: "Search by name or email",
 		FilterLabel:       "Filter members",
-		Groups:            groups,
+		Items:             items,
 	}
 }
 
-func adminDirectoryFilterMatches(filter, groupID, kind string) bool {
+func adminDirectoryFilterMatches(filter, status string) bool {
 	switch strings.ToLower(strings.TrimSpace(filter)) {
-	case "people":
-		return groupID == "active" && kind == "person"
-	case "applications":
-		return groupID == "application"
+	case "active":
+		return status == "active"
 	case "inactive":
-		return groupID == "inactive"
+		return status == "inactive"
 	default:
 		return true
 	}
@@ -673,17 +674,6 @@ func adminGroupProviders(groups []AdminGroup) []string {
 	}
 	sort.Strings(providers)
 	return providers
-}
-
-func firstRoleLabel(roles []string) string {
-	if len(roles) == 0 {
-		return ""
-	}
-	role := strings.TrimSpace(roles[0])
-	if role == "" {
-		return ""
-	}
-	return strings.ToUpper(role[:1]) + role[1:]
 }
 
 func adminPrincipalUsername(principal AdminPrincipal) string {
@@ -956,6 +946,14 @@ func adminPrincipalHref(principalID string) string {
 
 func adminPageTitle(active string) string {
 	switch active {
+	case "api-tokens":
+		return "API tokens"
+	case "security":
+		return "Security & sessions"
+	case "general":
+		return "General"
+	case "workspaces-admin":
+		return "Workspaces"
 	case "principals":
 		return "Principals"
 	case "profile":
@@ -966,12 +964,20 @@ func adminPageTitle(active string) string {
 		return "Groups"
 	case "group-detail":
 		return "Group"
+	case "service-accounts":
+		return "Service accounts"
+	case "authentication":
+		return "Authentication"
 	case "agent":
 		return "Agent"
 	case "storage":
 		return "Storage"
 	case "queries":
-		return "Query History"
+		return "Query history"
+	case "audit":
+		return "Audit log"
+	case "system":
+		return "System"
 	case "publications":
 		return "Publications"
 	default:
@@ -981,7 +987,7 @@ func adminPageTitle(active string) string {
 
 func normalizeAdminSection(active string) string {
 	switch strings.TrimSpace(active) {
-	case "profile", "principals", "principal-detail", "groups", "group-detail", "agent", "storage", "queries", "publications":
+	case "profile", "security", "api-tokens", "general", "workspaces-admin", "principals", "principal-detail", "groups", "group-detail", "service-accounts", "authentication", "agent", "storage", "queries", "audit", "system", "publications":
 		return strings.TrimSpace(active)
 	default:
 		return "profile"

--- a/internal/admin/ui/page_test.go
+++ b/internal/admin/ui/page_test.go
@@ -25,7 +25,6 @@ func TestAdminBootstrapSignalsUseAdminOwnedContracts(t *testing.T) {
 			AuthConfigured:    true,
 			AccessConfigured:  true,
 			AccessStatusLabel: "Configured",
-			Profile:           AdminProfile{Email: "owner@example.com", DisplayName: "Owner", Username: "owner"},
 		}, provider,
 	)
 
@@ -33,11 +32,11 @@ func TestAdminBootstrapSignalsUseAdminOwnedContracts(t *testing.T) {
 	if !ok {
 		t.Fatalf("chrome = %T, want admin signal contract", signals["chrome"])
 	}
-	if chrome.Sidebar.Active != "profile" || !chrome.Sidebar.Compact || chrome.Sidebar.History != nil || len(chrome.Sidebar.Groups) != 4 {
+	if chrome.Sidebar.Active != "profile" || !chrome.Sidebar.Compact || chrome.Sidebar.History != nil || len(chrome.Sidebar.Groups) != 5 {
 		t.Fatalf("chrome = %#v", chrome)
 	}
 	page, ok := signals["page"].(uisignals.AdminPageSignal)
-	if !ok || page.Kind != uisignals.RouteAdmin || page.Active != "profile" || page.Profile == nil || page.Profile.Email != "owner@example.com" {
+	if !ok || page.Kind != uisignals.RouteAdmin || page.Active != "profile" || page.HeaderDetail != "Manage your photo and display name." {
 		t.Fatalf("page = %#v", signals["page"])
 	}
 	runtime, ok := signals["runtime"].(uisignals.RouteRuntimeSignal)
@@ -82,6 +81,35 @@ func TestAdminListResultPatchesDoNotEchoSearchState(t *testing.T) {
 	}
 }
 
+func TestAdminDirectoryUsesPrincipalAvatarURL(t *testing.T) {
+	signal := adminDirectoryList([]AdminPrincipal{{
+		ID: "principal-1", DisplayName: "Ada Lovelace",
+		ProfilePictureURL: "/profile/avatars/principal-1/avatar-digest",
+		LastSeenAt:        "2026-08-09T15:30:00Z",
+	}}, "")
+	if len(signal.Items) != 1 {
+		t.Fatalf("directory signal = %#v", signal)
+	}
+	avatarURL := signal.Items[0].AvatarURL
+	if avatarURL == nil || *avatarURL != "/profile/avatars/principal-1/avatar-digest" {
+		t.Fatalf("avatar URL = %v", avatarURL)
+	}
+	if got := signal.Items[0].LastSeenAt; got != "2026-08-09T15:30:00Z" {
+		t.Fatalf("last seen = %q", got)
+	}
+}
+
+func TestAdminDirectoryExcludesMachinePrincipals(t *testing.T) {
+	signal := adminDirectoryList([]AdminPrincipal{
+		{ID: "person", Kind: "user", DisplayName: "Person"},
+		{ID: "service", Kind: "service_principal", DisplayName: "Service"},
+		{ID: "publication", Kind: "dashboard_publication", DisplayName: "Publication"},
+	}, "")
+	if len(signal.Items) != 1 || signal.Items[0].ID != "person" {
+		t.Fatalf("directory items = %#v, want only human principal", signal.Items)
+	}
+}
+
 func TestAdminPageRendersAdminRouteShell(t *testing.T) {
 	var output strings.Builder
 	provider := appshell.Provider(appshell.Config{Presentation: webpage.Presentation{ProductName: "LeapView"}})
@@ -90,7 +118,7 @@ func TestAdminPageRendersAdminRouteShell(t *testing.T) {
 		t.Fatal(err)
 	}
 	html := output.String()
-	for _, expected := range []string{"<lv-app-shell", "<lv-admin-page", `section="profile"`, "/updates?route=admin&amp;section=profile", "/static/admin-page.js"} {
+	for _, expected := range []string{"<lv-app-shell", "<lv-admin-page", `section="general"`, "/updates?route=admin&amp;section=general", "/static/admin-page.js"} {
 		if !strings.Contains(html, expected) {
 			t.Fatalf("admin page is missing %q:\n%s", expected, html)
 		}

--- a/internal/agent/module/routes.go
+++ b/internal/agent/module/routes.go
@@ -8,8 +8,9 @@ import (
 )
 
 type RouteGuard struct {
-	Protect       func(access.Privilege, http.HandlerFunc) http.HandlerFunc
-	ProtectGlobal func(access.Privilege, http.HandlerFunc) http.HandlerFunc
+	Protect         func(access.Privilege, http.HandlerFunc) http.HandlerFunc
+	ProtectGlobal   func(access.Privilege, http.HandlerFunc) http.HandlerFunc
+	ProtectPlatform func(access.Privilege, http.HandlerFunc) http.HandlerFunc
 }
 
 func (m *Module) MountAuthenticated(r chi.Router, guard RouteGuard) {
@@ -23,7 +24,7 @@ func (m *Module) MountAuthenticated(r chi.Router, guard RouteGuard) {
 	r.Get("/chats/restore", guard.ProtectGlobal(access.PrivilegeViewAgent, h.ChatRestore))
 	r.Get("/chats/{conversation}", guard.ProtectGlobal(access.PrivilegeViewAgent, h.ChatConversation))
 	r.Post("/chats/turns", guard.ProtectGlobal(access.PrivilegeUseAgent, h.ChatTurn))
-	r.Patch("/admin/agent/config", guard.Protect(access.PrivilegeManageGrants, h.UpdateAdminConfig))
+	r.Patch("/admin/agent/config", guard.ProtectPlatform(access.PrivilegeManagePlatform, h.UpdateAdminConfig))
 }
 
 func (m *Module) MountMCP(r chi.Router) {

--- a/internal/app/access_api_test.go
+++ b/internal/app/access_api_test.go
@@ -208,7 +208,7 @@ func TestCurrentAPITokenCreateAndRevokeRecordsAudit(t *testing.T) {
 		PrincipalID: owner.ID,
 		WorkspaceID: "test",
 		Name:        "auth",
-		Privileges:  []access.Privilege{access.PrivilegeManageGrants},
+		Privileges:  []access.Privilege{access.PrivilegeManageGrants, access.PrivilegeUseWorkspace},
 	})
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -273,7 +273,7 @@ func TestCurrentAPITokenCreateRejectsExpiredExpiry(t *testing.T) {
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
 
 	expiresAt := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/me/api-tokens", strings.NewReader(`{"name":"expired-api-token","workspaceId":"test","expiresAt":"`+expiresAt+`"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/me/api-tokens", strings.NewReader(`{"name":"expired-api-token","workspaceId":"test","privileges":[],"expiresAt":"`+expiresAt+`"}`))
 	req.Header.Set("Authorization", "Bearer "+authSecret)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
@@ -344,7 +344,7 @@ func TestSecretMintingResponsesDisableHTTPStorage(t *testing.T) {
 	authSecret, _ := testScopedAPIToken(t, ctx, store, access.APITokenInput{
 		PrincipalID: owner.ID,
 		Name:        "platform-admin",
-		Privileges:  []access.Privilege{access.PrivilegeManagePlatform, access.PrivilegeManageGrants},
+		Privileges:  []access.Privilege{access.PrivilegeManagePlatform, access.PrivilegeManageGrants, access.PrivilegeUseWorkspace},
 	})
 	servicePrincipal, err := repo.CreateServicePrincipal(ctx, access.ServicePrincipalInput{ID: "sp_secret_cache", DisplayName: "Secret Cache"})
 	if err != nil {

--- a/internal/app/admin_test.go
+++ b/internal/app/admin_test.go
@@ -59,7 +59,7 @@ func (r *synchronizedResponseRecorder) BodyString() string {
 	return r.Body.String()
 }
 
-func TestAdminRouteRejectsViewer(t *testing.T) {
+func TestAdminRoutesExposeOnlyPersonalSettingsToViewer(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
 	viewer := testPrincipal(t, ctx, store, "viewer@example.com", "Viewer", access.RoleViewer)
@@ -71,20 +71,24 @@ func TestAdminRouteRejectsViewer(t *testing.T) {
 		method string
 		path   string
 		body   string
+		status int
 	}{
-		{method: http.MethodGet, path: "/admin"},
-		{method: http.MethodGet, path: "/admin/agent"},
-		{method: http.MethodGet, path: "/admin/storage"},
-		{method: http.MethodGet, path: "/updates?route=admin&section=storage"},
-		{method: http.MethodPost, path: "/admin/storage/select-table", body: `{}`},
+		{method: http.MethodGet, path: "/admin", status: http.StatusSeeOther},
+		{method: http.MethodGet, path: "/admin/profile", status: http.StatusOK},
+		{method: http.MethodGet, path: "/admin/security", status: http.StatusOK},
+		{method: http.MethodGet, path: "/admin/api-tokens", status: http.StatusOK},
+		{method: http.MethodGet, path: "/admin/agent", status: http.StatusForbidden},
+		{method: http.MethodGet, path: "/admin/storage", status: http.StatusForbidden},
+		{method: http.MethodGet, path: "/updates?route=admin&section=storage", status: http.StatusForbidden},
+		{method: http.MethodPost, path: "/admin/storage/select-table", body: `{}`, status: http.StatusForbidden},
 	} {
 		req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 		server.Routes().ServeHTTP(rec, req)
 
-		if rec.Code != http.StatusForbidden {
-			t.Fatalf("%s status = %d, want %d body=%s", tc.path, rec.Code, http.StatusForbidden, rec.Body.String())
+		if rec.Code != tc.status {
+			t.Fatalf("%s status = %d, want %d body=%s", tc.path, rec.Code, tc.status, rec.Body.String())
 		}
 	}
 }
@@ -92,7 +96,7 @@ func TestAdminRouteRejectsViewer(t *testing.T) {
 func TestAdminPagesRenderReadOnlyAccessData(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	analyst := testPrincipal(t, ctx, store, "analyst@example.com", "Analyst", access.RoleViewer)
 	repo := testAccessRepository(store)
 	group, err := repo.UpsertGroup(ctx, access.GroupInput{ID: "group_finance", WorkspaceID: "test", Provider: "local", ExternalID: "finance", Name: "Finance"})
@@ -157,7 +161,7 @@ func TestAdminPagesRenderReadOnlyAccessData(t *testing.T) {
 func TestAdminQueryHistoryCommandPublishesLoadMorePatch(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -222,7 +226,7 @@ func encodeAdminQueryCursor(createdAt, id string) string {
 func TestAdminQueryHistoryCommandPublishesFilteredResetPatch(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -281,7 +285,7 @@ func TestAdminQueryHistoryCommandPublishesFilteredResetPatch(t *testing.T) {
 func TestAdminQueryHistoryCommandSearchesFilterMenuOptions(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -331,7 +335,7 @@ func TestAdminQueryHistoryCommandSearchesFilterMenuOptions(t *testing.T) {
 func TestAdminQueryHistoryCommandTogglesFilterAndResetsTable(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -385,7 +389,7 @@ func TestAdminQueryHistoryCommandTogglesFilterAndResetsTable(t *testing.T) {
 func TestAdminQueryHistoryCommandPublishesDetailPatch(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -500,15 +504,15 @@ func TestAdminPrincipalSearchCommandPatchesOnlyDirectoryRows(t *testing.T) {
 	if !ok || len(directory) != 1 {
 		t.Fatalf("directory patch = %#v", page["directoryList"])
 	}
-	if _, ok := directory["groups"].([]any); !ok {
-		t.Fatalf("directory groups = %#v", directory["groups"])
+	if _, ok := directory["items"].([]any); !ok {
+		t.Fatalf("directory items = %#v", directory["items"])
 	}
 }
 
 func TestAdminQueryHistoryUpdatesForwardsPatches(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -554,7 +558,7 @@ func TestAdminQueryHistoryUpdatesForwardsPatches(t *testing.T) {
 func TestAdminStorageDetailRouteIsDropped(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -572,7 +576,7 @@ func TestAdminStorageDetailRouteIsDropped(t *testing.T) {
 func TestAdminStorageUpdatesSubscribesWithoutInitialRescan(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -618,7 +622,7 @@ func TestAdminStorageUpdatesSubscribesWithoutInitialRescan(t *testing.T) {
 func TestAdminStorageSelectTablePublishesSelectedTablePatch(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	dir := t.TempDir()
@@ -770,7 +774,7 @@ VALUES ('test', 'prod', 'dep_prod')`, snapshotID, snapshotID); err != nil {
 func TestAdminStorageSelectTableRejectsInvalidCommand(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	dir := t.TempDir()
@@ -802,7 +806,7 @@ func TestAdminStorageSelectTableRejectsInvalidCommand(t *testing.T) {
 func TestAdminAccessRouteIsDropped(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -820,7 +824,7 @@ func TestAdminAccessRouteIsDropped(t *testing.T) {
 func TestAdminPrincipalDetailReturnsNotFoundForMissingPrincipal(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))
@@ -838,7 +842,7 @@ func TestAdminPrincipalDetailReturnsNotFoundForMissingPrincipal(t *testing.T) {
 func TestAdminGroupDetailReturnsNotFoundForMissingGroup(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
-	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RoleAdmin)
+	owner := testPlatformPrincipal(t, ctx, store, "owner@example.com", "Owner", access.RolePlatformAdmin)
 	token := testAPIToken(t, ctx, store, owner.ID, "test")
 	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test"}))

--- a/internal/app/agent_ui_adapters.go
+++ b/internal/app/agent_ui_adapters.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"net/http"
+	"strings"
 
 	accessmodule "github.com/flidai/leapview/internal/access/module"
+	adminmodule "github.com/flidai/leapview/internal/admin/module"
 	agentmodule "github.com/flidai/leapview/internal/agent/module"
 	"github.com/flidai/leapview/internal/app/brand"
 	appshell "github.com/flidai/leapview/internal/app/shell"
@@ -12,13 +14,38 @@ import (
 	"github.com/flidai/leapview/internal/platform/web/staticasset"
 )
 
-func applicationLayout(access *accessmodule.Module, agent *agentmodule.Module, assets staticasset.Resolver, r *http.Request) webpage.Provider {
+func applicationLayout(access *accessmodule.Module, agent *agentmodule.Module, product *adminmodule.ProductService, assets staticasset.Resolver, r *http.Request) webpage.Provider {
 	config := appshell.Config{
 		Presentation: webpage.Presentation{ProductName: brand.Name, FaviconPath: brand.FaviconPath},
 		Assets:       assets,
 	}
+	if product != nil {
+		if identity, err := product.Get(r.Context()); err == nil {
+			config.Presentation.ProductName = sidebarUserName(identity.DisplayName, brand.Name)
+			if identity.Logo != nil {
+				config.ProductLogoURL = "/product/logo/" + identity.Logo.SHA256
+			}
+		}
+	}
 	if access != nil {
 		config.RoleLabel = access.CurrentRoleLabel(r)
+		config.ColorMode = string(access.CurrentTheme(r))
+		if principal, ok := access.CurrentPrincipal(r); ok {
+			config.UserName = sidebarUserName(principal.DisplayName, principal.Email, principal.ID)
+			if avatars := access.PersonalAvatar(); avatars != nil {
+				if metadata, err := avatars.Current(r.Context(), principal.ID); err == nil {
+					config.UserAvatarURL = accessmodule.AvatarURL(principal.ID, metadata)
+				}
+			}
+		}
+		if adminLayoutRequest(r) {
+			privileges := access.AdminNavigationPrivileges(r)
+			config.AdminAccess = &appshell.AdminNavigationAccess{
+				ManagePlatform: privileges.ManagePlatform, ManageGrants: privileges.ManageGrants,
+				ManageWorkspace: privileges.ManageWorkspace, ManagePublications: privileges.ManagePublications,
+				ViewAudit: privileges.ViewAudit, ViewConnections: privileges.ViewConnections,
+			}
+		}
 	}
 	if agent == nil {
 		return appshell.Provider(config)
@@ -32,6 +59,24 @@ func applicationLayout(access *accessmodule.Module, agent *agentmodule.Module, a
 		})
 	}
 	return appshell.Provider(config)
+}
+
+func sidebarUserName(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func adminLayoutRequest(r *http.Request) bool {
+	if r == nil || r.URL == nil {
+		return false
+	}
+	path := strings.TrimSpace(r.URL.Path)
+	return strings.HasPrefix(path, "/admin") || path == "/connections" || strings.HasPrefix(path, "/connections/") ||
+		(path == "/updates" && strings.TrimSpace(r.URL.Query().Get("route")) == routeAdmin)
 }
 
 func dashboardAgentBootstrap(state agentmodule.ChatViewState) dashboardmodule.AgentBootstrap {

--- a/internal/app/agent_ui_adapters_test.go
+++ b/internal/app/agent_ui_adapters_test.go
@@ -2,11 +2,49 @@ package app
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
+	accessmodule "github.com/flidai/leapview/internal/access/module"
 	agentui "github.com/flidai/leapview/internal/agent/ui"
+	appshell "github.com/flidai/leapview/internal/app/shell"
+	webpage "github.com/flidai/leapview/internal/platform/web/page"
+	"github.com/flidai/leapview/internal/platform/web/staticasset"
 )
+
+func TestApplicationLayoutUsesCurrentPrincipalIdentity(t *testing.T) {
+	auth := accessmodule.NewAuth(nil, "", accessmodule.AuthConfig{DevBypass: true})
+	access, err := accessmodule.Build(t.Context(), accessmodule.Config{ExistingAuth: auth})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/admin/profile", nil)
+	request = request.WithContext(accessmodule.WithPrincipal(request.Context(), accessmodule.LocalDeveloperPrincipal()))
+	layout := applicationLayout(access, nil, nil, staticasset.Resolver{}, request)(webpage.Context{Active: "admin", PageID: "profile"})
+	chrome := layout.Signal.(appshell.Chrome)
+	if chrome.Sidebar.UserName == nil || *chrome.Sidebar.UserName != "Local Developer" {
+		t.Fatalf("sidebar user name = %v, want Local Developer", chrome.Sidebar.UserName)
+	}
+}
+
+func TestAdminLayoutRequestRecognizesDocumentsAndAdminStreams(t *testing.T) {
+	tests := map[string]bool{
+		"/admin/profile":                     true,
+		"/connections":                       true,
+		"/connections/warehouse":             true,
+		"/updates?route=admin&section=audit": true,
+		"/workspaces":                        false,
+		"/updates?route=workspace":           false,
+	}
+	for target, want := range tests {
+		request := httptest.NewRequest("GET", target, nil)
+		if got := adminLayoutRequest(request); got != want {
+			t.Errorf("adminLayoutRequest(%q) = %t, want %t", target, got, want)
+		}
+	}
+}
 
 func TestDashboardChatAdapterPreservesBrowserContract(t *testing.T) {
 	source := agentui.ChatSignal{

--- a/internal/app/api/apigenruntime/handler.go
+++ b/internal/app/api/apigenruntime/handler.go
@@ -180,6 +180,11 @@ func requestHasBody(r *http.Request) (bool, error) {
 }
 
 func expectedRequestContentType(operationID, method string) (string, bool) {
+	if operationID == "uploadCurrentAvatar" || operationID == "uploadProductLogo" {
+		// Avatar uploads accept a small allowlist of image media types. The
+		// access handler validates that allowlist and the decoded bytes.
+		return "", false
+	}
 	switch operationID {
 	case "uploadProjectCandidateSourceBlob", "uploadReleaseArtifact":
 		return "application/octet-stream", true

--- a/internal/app/api/apigenruntime/handler_test.go
+++ b/internal/app/api/apigenruntime/handler_test.go
@@ -246,6 +246,42 @@ func TestGeneratedTransportAcceptsJSONContentTypeParameters(t *testing.T) {
 	}
 }
 
+func TestGeneratedTransportPassesAvatarImageMediaTypesToAccessHandler(t *testing.T) {
+	called := false
+	handler, err := buildTestHandler(func(operationID string, _ http.ResponseWriter, request *http.Request) bool {
+		called = operationID == "uploadCurrentAvatar" && request.Header.Get("Content-Type") == "image/webp"
+		return true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/me/avatar", bytes.NewBufferString("image"))
+	request.Header.Set("Content-Type", "image/webp")
+	recorder := httptest.NewRecorder()
+	handler.HandleAPIGen("uploadCurrentAvatar", recorder, request)
+	if !called {
+		t.Fatalf("avatar request was rejected: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestGeneratedTransportPassesProductLogoImageMediaTypesToAdminHandler(t *testing.T) {
+	called := false
+	handler, err := buildTestHandler(func(operationID string, _ http.ResponseWriter, request *http.Request) bool {
+		called = operationID == "uploadProductLogo" && request.Header.Get("Content-Type") == "image/png"
+		return true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/instance/logo", bytes.NewBufferString("image"))
+	request.Header.Set("Content-Type", "image/png")
+	recorder := httptest.NewRecorder()
+	handler.HandleAPIGen("uploadProductLogo", recorder, request)
+	if !called {
+		t.Fatalf("product logo request was rejected: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestGeneratedSemanticTransportBoundsBodyBeforeService(t *testing.T) {
 	called := false
 	handler, err := buildTestHandler(func(string, http.ResponseWriter, *http.Request) bool { called = true; return true })

--- a/internal/app/api_apigen.go
+++ b/internal/app/api_apigen.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	accessmodule "github.com/flidai/leapview/internal/access/module"
+	adminmodule "github.com/flidai/leapview/internal/admin/module"
 	agentmodule "github.com/flidai/leapview/internal/agent/module"
 	apiaggregate "github.com/flidai/leapview/internal/app/api/aggregate"
 	apigenapi "github.com/flidai/leapview/internal/app/api/gen"
@@ -52,6 +53,7 @@ func accessAPIGenOperationContracts() map[string]accessmodule.APIGenOperationCon
 
 type apiGenDispatcher struct {
 	managedDataModule  *manageddatamodule.Module
+	productAPI         *adminmodule.Module
 	defaultEnvironment string
 	instanceID         string
 	canonicalOrigin    string
@@ -64,4 +66,40 @@ func (a apiGenDispatcher) GetInstance(w http.ResponseWriter, _ *http.Request) {
 	apitransport.WriteJSON(w, http.StatusOK, apigenapi.InstanceResponse{
 		Id: a.instanceID, CanonicalOrigin: a.canonicalOrigin, Environment: a.defaultEnvironment,
 	})
+}
+
+func (a apiGenDispatcher) GetProductSettings(w http.ResponseWriter, r *http.Request) {
+	a.productAPI.GetProductSettings(w, r)
+}
+
+func (a apiGenDispatcher) UpdateProductSettings(w http.ResponseWriter, r *http.Request, headers apigenapi.GenUpdateProductSettingsHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	a.productAPI.UpdateProductSettings(w, r)
+}
+
+func (a apiGenDispatcher) UploadProductLogo(w http.ResponseWriter, r *http.Request, headers apigenapi.GenUploadProductLogoHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	r.Header.Set("Content-Type", headers.ContentType)
+	a.productAPI.UploadProductLogo(w, r)
+}
+
+func (a apiGenDispatcher) DeleteProductLogo(w http.ResponseWriter, r *http.Request, headers apigenapi.GenDeleteProductLogoHeaders) {
+	r.Header.Set("If-Match", headers.IfMatch)
+	a.productAPI.DeleteProductLogo(w, r)
+}
+
+func (a apiGenDispatcher) GetProductLogo(w http.ResponseWriter, r *http.Request, _ string) {
+	a.productAPI.GetProductLogo(w, r)
+}
+
+func (a apiGenDispatcher) GetProductAuthenticationStatus(w http.ResponseWriter, r *http.Request) {
+	a.productAPI.GetProductAuthenticationStatus(w, r)
+}
+
+func (a apiGenDispatcher) GetProductSystemStatus(w http.ResponseWriter, r *http.Request) {
+	a.productAPI.GetProductSystemStatus(w, r)
+}
+
+func (a apiGenDispatcher) GetProductAPIStatus(w http.ResponseWriter, r *http.Request) {
+	a.productAPI.GetProductAPIStatus(w, r)
 }

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -231,7 +231,7 @@ func TestAPIGenAgentCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Errorf("Agent operation %q is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -273,7 +273,7 @@ func TestAPIGenAccessCapabilityOwnsItsGeneratedPackage(t *testing.T) {
 
 func TestAPIGenAccessCapabilityOwnsItsOperationSurface(t *testing.T) {
 	accessContracts := accessgen.GetAPIGenOperationContracts()
-	if got, want := len(accessContracts), 55; got != want {
+	if got, want := len(accessContracts), 63; got != want {
 		t.Fatalf("Access generated operations = %d, want %d", got, want)
 	}
 	allowedTags := map[string]bool{"Access": true, "Audit": true, "Current User": true}
@@ -292,7 +292,7 @@ func TestAPIGenAccessCapabilityOwnsItsOperationSurface(t *testing.T) {
 	if _, exists := appContracts["listQueryEvents"]; exists {
 		t.Fatal("Analytics-owned listQueryEvents is still emitted by the application package")
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -314,7 +314,7 @@ func TestAPIGenAnalyticsCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Fatalf("Analytics-owned %s is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -362,7 +362,7 @@ func TestAPIGenProjectCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Errorf("Project operation %q is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -409,7 +409,7 @@ func TestAPIGenRefreshCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Errorf("Refresh operation %q is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -456,7 +456,7 @@ func TestAPIGenDeploymentCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Errorf("Deployment operation %q is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -503,7 +503,7 @@ func TestAPIGenReleaseCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Errorf("Release operation %q is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -538,7 +538,7 @@ func TestAPIGenWorkspaceCapabilityOwnsItsGeneratedPackage(t *testing.T) {
 
 func TestAPIGenWorkspaceCapabilityOwnsItsOperationSurface(t *testing.T) {
 	contracts := workspacegen.GetAPIGenOperationContracts()
-	if got, want := len(contracts), 8; got != want {
+	if got, want := len(contracts), 9; got != want {
 		t.Fatalf("Workspace generated operations = %d, want %d", got, want)
 	}
 	allowedTags := map[string]bool{"Search": true, "Workspaces": true}
@@ -551,7 +551,7 @@ func TestAPIGenWorkspaceCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Errorf("Workspace operation %q is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -598,7 +598,7 @@ func TestAPIGenManagedDataCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Errorf("ManagedData operation %q is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -646,7 +646,7 @@ func TestAPIGenDashboardCapabilityOwnsItsOperationSurface(t *testing.T) {
 			t.Errorf("Dashboard operation %q is still emitted by the application package", operationID)
 		}
 	}
-	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 164; got != want {
+	if got, want := len(apiaggregate.GetAPIGenOperationContracts()), 181; got != want {
 		t.Fatalf("aggregate generated operations = %d, want %d", got, want)
 	}
 }
@@ -671,7 +671,7 @@ func TestAPIGenIRAssignsCapabilityNamespaces(t *testing.T) {
 	if err := json.Unmarshal(content, &document); err != nil {
 		t.Fatalf("decode APIGen IR: %v", err)
 	}
-	if got, want := len(document.Endpoints), 164; got != want {
+	if got, want := len(document.Endpoints), 181; got != want {
 		t.Fatalf("APIGen IR endpoints = %d, want %d", got, want)
 	}
 
@@ -860,8 +860,8 @@ func TestAPIGenOwnsUISignalContracts(t *testing.T) {
 	if irDoc.SchemaVersion != "v4" {
 		t.Fatalf("UI signal IR schema_version = %q, want v4", irDoc.SchemaVersion)
 	}
-	if len(irDoc.Contracts) != 87 {
-		t.Fatalf("UI signal IR contracts = %d, want 87", len(irDoc.Contracts))
+	if len(irDoc.Contracts) != 107 {
+		t.Fatalf("UI signal IR contracts = %d, want 107", len(irDoc.Contracts))
 	}
 	foundEnvelopeMetadata := false
 	foundImportedVisualizationRoot := false
@@ -987,8 +987,22 @@ func TestAPIGenOperationExtensions(t *testing.T) {
 		"getInstance": true,
 	}
 	authenticatedOperations := map[string]bool{
-		"decideDeviceAuthorization": true,
-		"getCapabilities":           true,
+		"changeCurrentPassword":         true,
+		"createCurrentAPIToken":         true,
+		"decideDeviceAuthorization":     true,
+		"deleteCurrentAvatar":           true,
+		"getCapabilities":               true,
+		"getCurrentPrincipal":           true,
+		"getProductLogo":                true,
+		"getPrincipalAvatar":            true,
+		"listCurrentAPITokens":          true,
+		"listCurrentAuthoringSessions":  true,
+		"listCurrentSessions":           true,
+		"revokeCurrentAPIToken":         true,
+		"revokeCurrentAuthoringSession": true,
+		"revokeCurrentSession":          true,
+		"updateCurrentPrincipal":        true,
+		"uploadCurrentAvatar":           true,
 	}
 	for operationID, contract := range contracts {
 		authz, ok := contract.Extensions["x-authz"].(map[string]any)

--- a/internal/app/api_client_failure_contract_test.go
+++ b/internal/app/api_client_failure_contract_test.go
@@ -29,6 +29,7 @@ func TestEveryCommandFailureVocabularyGeneratesTypedClientContracts(t *testing.T
 	}
 
 	clientPaths := map[string]string{
+		"LeapViewAPI":             "internal/app/api/gen/client.apigen.gen.go",
 		"LeapViewAPI.Access":      "internal/access/api/gen/client.apigen.gen.go",
 		"LeapViewAPI.Agent":       "internal/agent/api/gen/client.apigen.gen.go",
 		"LeapViewAPI.Analytics":   "internal/analytics/api/gen/client.apigen.gen.go",

--- a/internal/app/avatar_storage.go
+++ b/internal/app/avatar_storage.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	accessmodule "github.com/flidai/leapview/internal/access/module"
+	appconfig "github.com/flidai/leapview/internal/app/config"
+	manageddatamodule "github.com/flidai/leapview/internal/manageddata/module"
+)
+
+func profileImageBlobStore(ctx context.Context, config appconfig.Config) (accessmodule.AvatarBlobStore, error) {
+	prefix := strings.Trim(strings.TrimSpace(config.ManagedDataS3Prefix), "/")
+	if prefix == "" {
+		prefix = "managed-data"
+	}
+	blobs, err := manageddatamodule.NewContentBlobStore(ctx, managedDataProductConfig(config), filepath.Join(config.HomeDir, "profile-images"), prefix+"-profile-images")
+	if err != nil {
+		return nil, fmt.Errorf("initialize profile-image storage: %w", err)
+	}
+	return profileImageStore{blobs: blobs}, nil
+}
+
+type profileImageStore struct {
+	blobs manageddatamodule.ContentBlobStore
+}
+
+func (s profileImageStore) Put(ctx context.Context, expected accessmodule.AvatarBlob, body io.Reader) (accessmodule.AvatarBlob, error) {
+	stored, err := s.blobs.PutContent(ctx, manageddatamodule.ContentBlob{SHA256: expected.SHA256, Size: expected.Size}, body)
+	return accessmodule.AvatarBlob{SHA256: stored.SHA256, Size: stored.Size}, err
+}
+
+func (s profileImageStore) Open(ctx context.Context, digest string) (io.ReadCloser, error) {
+	reader, err := s.blobs.OpenContent(ctx, digest)
+	if errors.Is(err, manageddatamodule.ErrContentBlobNotFound) {
+		return nil, accessmodule.ErrAvatarBlobNotFound
+	}
+	return reader, err
+}

--- a/internal/app/avatar_storage_test.go
+++ b/internal/app/avatar_storage_test.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	accessmodule "github.com/flidai/leapview/internal/access/module"
+	"github.com/flidai/leapview/internal/app/config"
+)
+
+func TestProfileImageBlobStoreUsesDedicatedLocalNamespace(t *testing.T) {
+	home := t.TempDir()
+	store, err := profileImageBlobStore(t.Context(), config.Config{HomeDir: home, ManagedDataBackend: "local"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("avatar")
+	digest := sha256.Sum256(body)
+	blob := accessmodule.AvatarBlob{SHA256: hex.EncodeToString(digest[:]), Size: int64(len(body))}
+	if _, err := store.Put(t.Context(), blob, bytes.NewReader(body)); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := store.Open(t.Context(), blob.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	stored, err := io.ReadAll(reader)
+	if err != nil || !bytes.Equal(stored, body) {
+		t.Fatalf("stored avatar = %q, %v", stored, err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "profile-images", "blobs", "sha256", blob.SHA256[:2], blob.SHA256)); err != nil {
+		t.Fatalf("dedicated profile-image object: %v", err)
+	}
+}

--- a/internal/app/candidate_routes.go
+++ b/internal/app/candidate_routes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	accessmodule "github.com/flidai/leapview/internal/access/module"
+	adminmodule "github.com/flidai/leapview/internal/admin/module"
 	agentmodule "github.com/flidai/leapview/internal/agent/module"
 	dashboardmodule "github.com/flidai/leapview/internal/dashboard/module"
 	deploymentmodule "github.com/flidai/leapview/internal/deployment/module"
@@ -22,6 +23,7 @@ type candidatePreviewHandler interface {
 
 type candidateRouteDependencies struct {
 	access           *accessmodule.Module
+	product          *adminmodule.ProductService
 	agent            *agentmodule.Module
 	assets           staticasset.Resolver
 	dashboards       *dashboardmodule.Module
@@ -38,7 +40,7 @@ func candidatePreview(deps candidateRouteDependencies, w http.ResponseWriter, r 
 	if candidate.Status != deploymentmodule.CandidateReady {
 		serveCandidatePreview(
 			deps.deployments, candidate.ID, principalID,
-			applicationLayout(deps.access, deps.agent, deps.assets, r), w, r,
+			applicationLayout(deps.access, deps.agent, deps.product, deps.assets, r), w, r,
 		)
 		return
 	}

--- a/internal/app/composition.go
+++ b/internal/app/composition.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	accessmodule "github.com/flidai/leapview/internal/access/module"
+	adminmodule "github.com/flidai/leapview/internal/admin/module"
 	agentmodule "github.com/flidai/leapview/internal/agent/module"
 	analyticsmodule "github.com/flidai/leapview/internal/analytics/module"
 	"github.com/flidai/leapview/internal/app/config"
@@ -126,10 +127,23 @@ func buildRuntime(ctx context.Context, cfg config.Config, production bool, envir
 	cleanup.Push("analytics", func(context.Context) error { return analyticsModule.Close() })
 	analyticsWorkspaceFactory := analyticsModule.WorkspaceRuntimeFactory()
 	var workspaceDirectory workspacemodule.Directory
+	avatarBlobs, err := profileImageBlobStore(ctx, cfg)
+	if err != nil {
+		return fail(err)
+	}
+	productLogoBlobs, err := productLogoBlobStore(ctx, cfg)
+	if err != nil {
+		return fail(err)
+	}
+	productService, err := adminmodule.NewProductService(store.SQLDB(), productLogoBlobs)
+	if err != nil {
+		return fail(err)
+	}
 	accessModule, err := accessmodule.Build(ctx, accessmodule.Config{
 		Database: store.SQLDB(), Auth: accessAuthConfig(cfg, production, cookieSecure),
 		WorkspaceID: config.DefaultWorkspaceID,
 		Assets:      assets,
+		AvatarBlobs: avatarBlobs,
 		PublicURL:   publicURL, InstanceID: instanceID, MCPIssuerURL: cfg.MCPOAuthIssuerURL,
 		WorkspaceIDs: func(ctx context.Context) ([]string, error) {
 			if workspaceDirectory == nil {
@@ -420,6 +434,7 @@ func buildRuntime(ctx context.Context, cfg config.Config, production bool, envir
 			AnalyticsModule: analyticsModule, DashboardAssets: dashboardAssets,
 			ReleaseModule: releaseModule, JobModule: jobModule,
 			AccessModule: accessModule, ManagedDataModule: managedDataModule,
+			Product: productService, ProductStatus: productAdministrationStatus(cfg, instanceID, publicURL, string(environment), identity),
 		},
 		workflowAssemblyInputs{
 			AgentSettings: store,

--- a/internal/app/page_stream.go
+++ b/internal/app/page_stream.go
@@ -37,7 +37,13 @@ func configurePageStream(routes *capabilityRoutes, runtime *runtimeServices, pla
 				return routes.accessModule.ProtectNamed("VIEW_AGENT", next), true
 			case routeAdmin:
 				switch strings.TrimSpace(section) {
-				case "queries":
+				case "profile", "security", "api-tokens":
+					return routes.accessModule.ProtectNamed("", next), true
+				case "general", "service-accounts", "authentication", "storage", "agent", "system":
+					return routes.accessModule.ProtectPlatformNamed("MANAGE_PLATFORM", next), true
+				case "workspaces-admin":
+					return routes.accessModule.ProtectGlobalNamed("MANAGE_WORKSPACE", next), true
+				case "queries", "audit":
 					return routes.accessModule.ProtectGlobalNamed("VIEW_AUDIT", next), true
 				case "publications":
 					return routes.accessModule.ProtectAnyWorkspaceNamed("MANAGE_PUBLICATIONS", next), true
@@ -73,7 +79,7 @@ func configurePageStream(routes *capabilityRoutes, runtime *runtimeServices, pla
 				_ = uitransport.PatchOnce(runtime.pageStreamTrace, w, r, routes.accessModule.LoginBootstrapSignals(r))
 			}),
 			routeCatalog: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				signals, err := routes.workspaceModule.CatalogBootstrapSignals(r, applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r))
+				signals, err := routes.workspaceModule.CatalogBootstrapSignals(r, applicationLayout(routes.accessModule, routes.agentModule, routes.product, platform.assets, r))
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return

--- a/internal/app/product_authorization_test.go
+++ b/internal/app/product_authorization_test.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	adminmodule "github.com/flidai/leapview/internal/admin/module"
+)
+
+func TestProductAdministrationRejectsWorkspaceScopedManagePlatform(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	repository := testAccessRepository(store)
+	principal := testPrincipal(t, ctx, store, "workspace-platform@example.test", "Workspace Platform", "")
+	if _, err := repository.UpsertSecurableObject(ctx, access.WorkspaceObject("test"), ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.CreateGrant(ctx, access.GrantInput{
+		Object: access.WorkspaceObject("test"), SubjectType: access.SubjectPrincipal,
+		SubjectID: principal.ID, Privilege: access.PrivilegeManagePlatform,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	token, _ := testScopedAPIToken(t, ctx, store, access.APITokenInput{
+		PrincipalID: principal.ID, WorkspaceID: "test", Name: "workspace-manage-platform",
+		Privileges: []access.Privilege{access.PrivilegeManagePlatform},
+	})
+	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
+	service, err := adminmodule.NewProductService(store.SQLDB(), productAuthorizationBlobs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test", Product: service}))
+
+	// This credential demonstrates the old ProtectGlobal behavior: a matching
+	// workspace grant was enough even though no PlatformObject grant exists.
+	broadRequest := httptest.NewRequest(http.MethodGet, "/broad-guard", nil)
+	broadRequest.Header.Set("Authorization", "Bearer "+token)
+	broadResponse := httptest.NewRecorder()
+	server.routes.accessModule.ProtectGlobal(access.PrivilegeManagePlatform, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})(broadResponse, broadRequest)
+	if broadResponse.Code != http.StatusNoContent {
+		t.Fatalf("workspace-scoped credential did not exercise broad guard: status=%d body=%s", broadResponse.Code, broadResponse.Body.String())
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/instance/settings", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	server.Routes().ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("workspace-scoped MANAGE_PLATFORM reached product settings: status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestProductAdministrationUsesGeneratedRouteDispatch(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	repository := testAccessRepository(store)
+	principal := testPrincipal(t, ctx, store, "platform-admin@example.test", "Platform Admin", "")
+	if _, err := repository.CreateGrant(ctx, access.GrantInput{
+		Object: access.PlatformObject(), SubjectType: access.SubjectPrincipal,
+		SubjectID: principal.ID, Privilege: access.PrivilegeManagePlatform,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	token, _ := testScopedAPIToken(t, ctx, store, access.APITokenInput{
+		PrincipalID: principal.ID, Name: "platform-manage", Privileges: []access.Privilege{access.PrivilegeManagePlatform},
+	})
+	service, err := adminmodule.NewProductService(store.SQLDB(), productAuthorizationBlobs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth := testAuth(store, "test", AuthConfig{APITokenOnly: true})
+	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: "test", Product: service}))
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/instance/settings", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	server.Routes().ServeHTTP(response, request)
+	if response.Code != http.StatusOK || response.Header().Get("ETag") != `"product-1"` {
+		t.Fatalf("generated product route status=%d etag=%q body=%s", response.Code, response.Header().Get("ETag"), response.Body.String())
+	}
+
+	patch := httptest.NewRequest(http.MethodPatch, "/api/v1/instance/settings", strings.NewReader(`{"displayName":"Acme Analytics"}`))
+	patch.Header.Set("Authorization", "Bearer "+token)
+	patch.Header.Set("Content-Type", "application/json")
+	patch.Header.Set("If-Match", response.Header().Get("ETag"))
+	patch.Header.Set("X-Request-ID", "req_product_patch")
+	patched := httptest.NewRecorder()
+	server.Routes().ServeHTTP(patched, patch)
+	if patched.Code != http.StatusOK || patched.Header().Get("ETag") != `"product-2"` || !strings.Contains(patched.Body.String(), `"displayName":"Acme Analytics"`) {
+		t.Fatalf("generated product patch status=%d etag=%q body=%s", patched.Code, patched.Header().Get("ETag"), patched.Body.String())
+	}
+	var action, metadata string
+	if err := store.SQLDB().QueryRowContext(ctx, `SELECT action, metadata_json FROM audit_events WHERE request_id = 'req_product_patch'`).Scan(&action, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if action != "product.identity.updated" || !strings.Contains(metadata, `"payloadSchema":"ProductIdentityUpdatedAuditPayload"`) || !strings.Contains(metadata, `"fields":["displayName"]`) {
+		t.Fatalf("product command audit action=%q metadata=%s", action, metadata)
+	}
+
+	stale := httptest.NewRequest(http.MethodPatch, "/api/v1/instance/settings", strings.NewReader(`{"displayName":"Stale"}`))
+	stale.Header.Set("Authorization", "Bearer "+token)
+	stale.Header.Set("Content-Type", "application/json")
+	stale.Header.Set("If-Match", `"invalid"`)
+	staleResponse := httptest.NewRecorder()
+	server.Routes().ServeHTTP(staleResponse, stale)
+	if staleResponse.Code != http.StatusPreconditionFailed || !strings.Contains(staleResponse.Body.String(), `"code":"PRODUCT_IDENTITY_PRECONDITION_FAILED"`) {
+		t.Fatalf("generated stale product patch status=%d body=%s", staleResponse.Code, staleResponse.Body.String())
+	}
+}
+
+type productAuthorizationBlobs struct{}
+
+func (productAuthorizationBlobs) Put(_ context.Context, expected adminmodule.ProductBlob, body io.Reader) (adminmodule.ProductBlob, error) {
+	_, err := io.Copy(io.Discard, body)
+	return expected, err
+}
+
+func (productAuthorizationBlobs) Open(context.Context, string) (io.ReadCloser, error) {
+	return nil, adminmodule.ErrProductLogoNotFound
+}

--- a/internal/app/product_logo_storage.go
+++ b/internal/app/product_logo_storage.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+
+	adminmodule "github.com/flidai/leapview/internal/admin/module"
+	appconfig "github.com/flidai/leapview/internal/app/config"
+	manageddatamodule "github.com/flidai/leapview/internal/manageddata/module"
+)
+
+func productLogoBlobStore(ctx context.Context, config appconfig.Config) (adminmodule.ProductBlobStore, error) {
+	prefix := strings.Trim(strings.TrimSpace(config.ManagedDataS3Prefix), "/")
+	if prefix == "" {
+		prefix = "managed-data"
+	}
+	blobs, err := manageddatamodule.NewContentBlobStore(ctx, managedDataProductConfig(config), filepath.Join(config.HomeDir, "product-logos"), prefix+"-product-logos")
+	if err != nil {
+		return nil, err
+	}
+	return productLogoStore{blobs: blobs}, nil
+}
+
+type productLogoStore struct {
+	blobs manageddatamodule.ContentBlobStore
+}
+
+func (s productLogoStore) Put(ctx context.Context, expected adminmodule.ProductBlob, body io.Reader) (adminmodule.ProductBlob, error) {
+	stored, err := s.blobs.PutContent(ctx, manageddatamodule.ContentBlob{SHA256: expected.SHA256, Size: expected.Size}, body)
+	return adminmodule.ProductBlob{SHA256: stored.SHA256, Size: stored.Size}, err
+}
+
+func (s productLogoStore) Open(ctx context.Context, digest string) (io.ReadCloser, error) {
+	reader, err := s.blobs.OpenContent(ctx, digest)
+	if errors.Is(err, manageddatamodule.ErrContentBlobNotFound) {
+		return nil, adminmodule.ErrProductLogoNotFound
+	}
+	return reader, err
+}

--- a/internal/app/product_status.go
+++ b/internal/app/product_status.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"strings"
+
+	adminmodule "github.com/flidai/leapview/internal/admin/module"
+	appconfig "github.com/flidai/leapview/internal/app/config"
+	"github.com/flidai/leapview/internal/platform/buildinfo"
+)
+
+func productAdministrationStatus(config appconfig.Config, instanceID, publicURL, environment string, build buildinfo.Identity) adminmodule.ProductStatus {
+	authentication := adminmodule.ProductAuthenticationStatus{
+		BrowserEnabled: !config.APITokenOnlyAuth,
+		APITokenOnly:   config.APITokenOnlyAuth,
+		Local:          adminmodule.ProductAvailability{Available: true, Enabled: config.LocalAuth},
+		OIDC: adminmodule.ProductNamedAvailability{
+			Available: true, Enabled: config.OIDCConfigured(), Provider: enabledLabel(config.OIDCConfigured(), config.OIDCProviderID),
+		},
+		Azure:     adminmodule.ProductAvailability{Available: true, Enabled: config.AzureConfigured()},
+		SCIM:      adminmodule.ProductAvailability{Available: true, Enabled: strings.TrimSpace(config.SCIMBearerToken) != ""},
+		ManagedBy: "deployment",
+	}
+	agentConfigured := strings.TrimSpace(config.AgentAPIKey) != ""
+	storageBackend := strings.TrimSpace(config.ManagedDataBackend)
+	if storageBackend == "" {
+		storageBackend = "local"
+	}
+	return adminmodule.ProductStatus{
+		Authentication: authentication,
+		API: adminmodule.ProductAPIStatus{
+			BearerCredentials: adminmodule.ProductAvailability{Available: true, Enabled: true},
+			ServicePrincipals: adminmodule.ProductAvailability{Available: true, Enabled: true},
+			OAuth:             adminmodule.ProductAvailability{Available: true, Enabled: true},
+			MCP:               adminmodule.ProductAvailability{Available: true, Enabled: true},
+			ExternalMCPIssuer: strings.TrimSpace(config.MCPOAuthIssuerURL) != "",
+		},
+		System: adminmodule.ProductSystemStatus{
+			InstanceID: instanceID, CanonicalOrigin: publicURL, Environment: environment, Build: build,
+			StorageBackend: storageBackend,
+			Agent: adminmodule.ProductAgentStatus{
+				Available: true, Configured: agentConfigured, Provider: enabledLabel(agentConfigured, "openai-compatible"),
+				ModelConfigured: strings.TrimSpace(config.AgentModel) != "",
+			},
+			Limits: adminmodule.ProductLimits{
+				QueryResultMaxRows: config.QueryResultMaxRows, QueryResultMaxBytes: config.QueryResultMaxBytes,
+				ManagedDataMaxFiles: config.ManagedDataMaxFiles, ManagedDataMaxFileBytes: config.ManagedDataMaxFileBytes,
+				ManagedDataMaxRevisionBytes: config.ManagedDataMaxRevisionBytes,
+			},
+		},
+	}
+}
+
+func enabledLabel(enabled bool, value string) string {
+	if !enabled {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}

--- a/internal/app/product_status_test.go
+++ b/internal/app/product_status_test.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/app/config"
+	"github.com/flidai/leapview/internal/platform/buildinfo"
+)
+
+func TestProductAdministrationStatusIsRedacted(t *testing.T) {
+	configuration := config.Config{
+		LocalAuth: true, OIDCProviderID: "corporate", OIDCIssuerURL: "https://issuer.secret.test",
+		OIDCClientID: "secret-client-id", OIDCSecret: "secret-client-secret", OIDCCallbackURL: "https://app.test/callback",
+		AzureClientID: "azure-secret-id", AzureSecret: "azure-secret-value", AzureCallbackURL: "https://app.test/azure-callback", AzureTenant: "secret-tenant",
+		SCIMBearerToken: "secret-scim-bearer", AgentAPIKey: "secret-agent-key", AgentModel: "model-name",
+		ManagedDataBackend: "s3", ManagedDataS3Bucket: "secret-bucket", QueryResultMaxRows: 1000, QueryResultMaxBytes: 1024,
+		ManagedDataMaxFiles: 25, ManagedDataMaxFileBytes: 2048, ManagedDataMaxRevisionBytes: 4096,
+	}
+	status := productAdministrationStatus(configuration, "lvinst_1", "https://app.test", "prod", buildinfo.Identity{Version: "1.2.3"})
+	encoded, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	for _, forbidden := range []string{
+		"issuer.secret.test", "secret-client-id", "secret-client-secret", "azure-secret-id", "azure-secret-value",
+		"secret-tenant", "secret-scim-bearer", "secret-agent-key", "secret-bucket", "model-name",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("product status leaked %q: %s", forbidden, text)
+		}
+	}
+	if !status.Authentication.OIDC.Enabled || status.Authentication.OIDC.Provider != "corporate" || !status.API.ServicePrincipals.Enabled || status.System.StorageBackend != "s3" {
+		t.Fatalf("safe status fields = %#v", status)
+	}
+	if status.System.Limits.QueryResultMaxRows != 1000 || status.System.Limits.QueryResultMaxBytes != 1024 ||
+		status.System.Limits.ManagedDataMaxFiles != 25 || status.System.Limits.ManagedDataMaxFileBytes != 2048 ||
+		status.System.Limits.ManagedDataMaxRevisionBytes != 4096 {
+		t.Fatalf("system limits = %#v", status.System.Limits)
+	}
+}

--- a/internal/app/route_inventory_test.go
+++ b/internal/app/route_inventory_test.go
@@ -84,7 +84,7 @@ func TestRouteInventory(t *testing.T) {
 		rows = append(rows, fmt.Sprintf("%s|%s|%s|%s", key, contract.owner, contract.access, contract.privilege))
 	}
 	sort.Strings(rows)
-	const expectedRouteContractDigest = "f70a574126a6b1718372b3e1e16e8fddb87017e964c6b22de0d722f8a042aa8f"
+	const expectedRouteContractDigest = "0b1c790d3fb4b9683a5b562fe9e2b4d4925f5f34305540a16a426296e31f6044"
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(rows, "\n"))))
 	if digest != expectedRouteContractDigest {
 		t.Fatalf("route ownership/auth contract changed: got digest %s\n%s", digest, strings.Join(rows, "\n"))
@@ -120,6 +120,10 @@ func nonAPIRouteMetadata(method, path string) (routeMetadata, bool) {
 			public.access = "authenticated"
 		}
 		return public, true
+	case strings.HasPrefix(path, "/profile/avatar") || strings.HasPrefix(path, "/profile/avatars/"):
+		public.owner = "access"
+		public.access = "authenticated"
+		return public, true
 	case strings.HasPrefix(path, "/public/dashboards/") || strings.HasPrefix(path, "/embed/dashboards/"):
 		public.owner = "dashboard"
 		return public, true
@@ -127,18 +131,28 @@ func nonAPIRouteMetadata(method, path string) (routeMetadata, bool) {
 
 	authenticated := routeMetadata{access: "authenticated"}
 	switch {
+	case strings.HasPrefix(path, "/product/logo/"):
+		authenticated.owner = "admin"
+	case path == "/admin" || path == "/admin/profile" || path == "/admin/security" || path == "/admin/api-tokens" || path == "/admin/personal-settings/command":
+		authenticated.owner = "admin"
 	case path == "/admin/agent" || path == "/admin/agent/config":
 		authenticated.owner = "agent"
-		authenticated.privilege = "MANAGE_GRANTS"
+		authenticated.privilege = "MANAGE_PLATFORM"
 	case strings.HasPrefix(path, "/admin/publications"):
 		authenticated.owner = "admin"
 		authenticated.privilege = "MANAGE_PUBLICATIONS"
-	case strings.HasPrefix(path, "/admin/queries"):
+	case strings.HasPrefix(path, "/admin/queries") || strings.HasPrefix(path, "/admin/audit"):
 		authenticated.owner = "admin"
 		authenticated.privilege = "VIEW_AUDIT"
-	case strings.HasPrefix(path, "/admin"):
+	case path == "/admin/workspaces":
+		authenticated.owner = "admin"
+		authenticated.privilege = "MANAGE_WORKSPACE"
+	case strings.HasPrefix(path, "/admin/principals") || strings.HasPrefix(path, "/admin/groups"):
 		authenticated.owner = "admin"
 		authenticated.privilege = "MANAGE_GRANTS"
+	case strings.HasPrefix(path, "/admin"):
+		authenticated.owner = "admin"
+		authenticated.privilege = "MANAGE_PLATFORM"
 	case strings.HasPrefix(path, "/chats"):
 		authenticated.owner = "agent"
 		switch {
@@ -220,6 +234,7 @@ func apiOwner(tags []string) (string, bool) {
 const nonAPIRouteInventory = `
 CONNECT /metrics
 CONNECT /static/*
+DELETE /profile/avatar
 DELETE /metrics
 DELETE /static/*
 GET /
@@ -230,7 +245,11 @@ GET /.well-known/oauth-protected-resource/mcp
 GET /__dev/pagestream/signals
 GET /__dev/pagestream/traces
 GET /admin
+GET /admin/api-tokens
 GET /admin/agent
+GET /admin/audit
+GET /admin/authentication
+GET /admin/general
 GET /admin/groups
 GET /admin/groups/{group}
 GET /admin/principals
@@ -238,7 +257,11 @@ GET /admin/principals/{principal}
 GET /admin/profile
 GET /admin/publications
 GET /admin/queries
+GET /admin/security
+GET /admin/service-accounts
 GET /admin/storage
+GET /admin/system
+GET /admin/workspaces
 GET /api/docs
 GET /api/openapi.json
 GET /auth/{provider}
@@ -269,6 +292,8 @@ GET /embed/dashboards/{publicId}/pages/{page}
 GET /favicon.ico
 GET /healthz
 GET /login
+GET /profile/avatars/{principal}/{digest}
+GET /product/logo/{digest}
 GET /metrics
 GET /public/dashboards/{publicId}
 GET /public/dashboards/{publicId}/pages/{page}
@@ -291,10 +316,14 @@ OPTIONS /static/*
 PATCH /admin/agent/config
 PATCH /metrics
 PATCH /static/*
+POST /admin/audit/command
+POST /admin/personal-settings/command
+POST /admin/product-settings/command
 POST /admin/publications/command
 POST /admin/groups/search
 POST /admin/principals/search
 POST /admin/queries/command
+POST /admin/service-accounts/command
 POST /admin/storage/select-table
 POST /auth/desktop/disconnect
 POST /auth/desktop/redeem
@@ -313,6 +342,8 @@ POST /oauth/register
 POST /oauth/device/code
 POST /oauth/revoke
 POST /oauth/token
+PUT /profile/avatar
+PUT /admin/product-logo
 POST /public/dashboards/{publicId}/commands/clear-selection
 POST /public/dashboards/{publicId}/commands/filter
 POST /public/dashboards/{publicId}/commands/filter-options

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -23,7 +23,7 @@ import (
 func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platformServices, policy *httpPolicy) http.Handler {
 	mux := chi.NewRouter()
 	candidates := candidateRouteDependencies{
-		access: routes.accessModule, agent: routes.agentModule, assets: platform.assets,
+		access: routes.accessModule, agent: routes.agentModule, product: routes.product, assets: platform.assets,
 		dashboards: routes.dashboardModule, deployments: routes.deploymentModule,
 		runtimeHost: runtime.runtimeHostModule, candidateMetrics: runtime.candidateMetrics,
 	}
@@ -91,6 +91,7 @@ func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platfo
 		})
 		routes.agentModule.MountAuthenticated(r, agentmodule.RouteGuard{
 			Protect: routes.accessModule.Protect, ProtectGlobal: routes.accessModule.ProtectGlobal,
+			ProtectPlatform: routes.accessModule.ProtectPlatform,
 		})
 		r.Get("/chat", redirectLegacyChat)
 		r.Get("/chat/updates", http.NotFound)
@@ -98,6 +99,7 @@ func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platfo
 		r.Post("/chat/turns", redirectLegacyChat)
 		routes.adminModule.MountAuthenticated(r, adminmodule.RouteGuard{
 			Protect: routes.accessModule.Protect, ProtectGlobal: routes.accessModule.ProtectGlobal,
+			ProtectPlatform:     routes.accessModule.ProtectPlatform,
 			ProtectAnyWorkspace: routes.accessModule.ProtectAnyWorkspace,
 		})
 		routes.dashboardModule.MountAuthenticated(r, dashboardmodule.RouteGuard{

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
+	apigenfailure "github.com/Yacobolo/toolbelt/apigen/runtime/failure"
 	"github.com/Yacobolo/toolbelt/pagestream"
 	accessmodule "github.com/flidai/leapview/internal/access/module"
 	adminmodule "github.com/flidai/leapview/internal/admin/module"
@@ -29,6 +30,7 @@ import (
 	"github.com/flidai/leapview/internal/platform/buildinfo"
 	"github.com/flidai/leapview/internal/platform/http/cursorsigning"
 	apihttpmiddleware "github.com/flidai/leapview/internal/platform/http/middleware"
+	apitransport "github.com/flidai/leapview/internal/platform/http/transport"
 	"github.com/flidai/leapview/internal/platform/jobs"
 	jobsmodule "github.com/flidai/leapview/internal/platform/jobs/module"
 	platformlifecycle "github.com/flidai/leapview/internal/platform/lifecycle"
@@ -60,6 +62,7 @@ type capabilityRoutes struct {
 	releaseModule      *releasemodule.Module
 	refreshModule      *refreshmodule.Module
 	adminModule        *adminmodule.Module
+	product            *adminmodule.ProductService
 	dashboardTelemetry dashboardmodule.Telemetry
 }
 
@@ -115,6 +118,8 @@ type persistenceInputs struct {
 	workspaceDirectory    workspacemodule.Directory
 	workspaceAssetCatalog workspacemodule.AssetCatalogReader
 	accessRepo            accessmodule.Repository
+	product               *adminmodule.ProductService
+	productStatus         adminmodule.ProductStatus
 }
 
 type workflowInputs struct {
@@ -189,6 +194,8 @@ type capabilityAssemblyInputs struct {
 	ManagedDataModule *manageddatamodule.Module
 	AnalyticsModule   *analyticsmodule.Module
 	DashboardAssets   dashboardmodule.Assets
+	Product           *adminmodule.ProductService
+	ProductStatus     adminmodule.ProductStatus
 }
 
 type workflowAssemblyInputs struct {
@@ -367,6 +374,9 @@ func buildApplicationSurfaces(
 	runtime.platformHealth = data.PlatformHealth
 	persistence.agentSettings = workflow.AgentSettings
 	persistence.adminDatabase = data.AdminDatabase
+	persistence.product = capabilities.Product
+	routes.product = capabilities.Product
+	persistence.productStatus = capabilities.ProductStatus
 	if data.Database != nil {
 		platform.jobModule = capabilities.JobModule
 		if platform.jobModule == nil {
@@ -648,7 +658,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			CSRFToken:        routes.accessModule.CSRFToken,
 			CurrentRoleLabel: routes.accessModule.CurrentRoleLabel,
 			Layout: func(r *http.Request) webpage.Provider {
-				return applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)
+				return applicationLayout(routes.accessModule, routes.agentModule, routes.product, platform.assets, r)
 			},
 			CurrentCredential: func(r *http.Request) (accessmodule.APICredential, bool) {
 				return accessmodule.APICredentialFromContext(r.Context())
@@ -729,7 +739,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				},
 				CSRFToken: routes.accessModule.CSRFToken,
 				Layout: func(r *http.Request) webpage.Provider {
-					return applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)
+					return applicationLayout(routes.accessModule, routes.agentModule, routes.product, platform.assets, r)
 				},
 				Environment: func(r *http.Request) string {
 					return string(requestServingEnvironment(policy.defaultEnvironment, r))
@@ -984,7 +994,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				CSRFToken:        routes.accessModule.CSRFToken,
 				CurrentRoleLabel: routes.accessModule.CurrentRoleLabel,
 				Layout: func(r *http.Request) webpage.Provider {
-					return applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)
+					return applicationLayout(routes.accessModule, routes.agentModule, routes.product, platform.assets, r)
 				},
 				CurrentPrincipal: func(r *http.Request) (agentmodule.Principal, bool) {
 					if platform.auth == nil {
@@ -1021,6 +1031,13 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				ID: principal.ID, Email: principal.Email, DisplayName: principal.DisplayName, DevBypass: principal.DevBypass,
 			}, ok
 		}
+		settingsAccess := routes.accessModule.SettingsAdministration()
+		workspaceSettings := routes.workspaceModule.SettingsAdministration()
+		localPasswordEnabled := routes.accessModule.Auth() != nil && routes.accessModule.Auth().LocalAuthEnabled()
+		productCommands, commandErr := apigencommand.NewExecutor(apiaggregate.GetAPIGenCommandRuntimeContract, nil)
+		if commandErr != nil {
+			return fmt.Errorf("build product command executor: %w", commandErr)
+		}
 		var err error
 		routes.adminModule, err = adminmodule.Build(ctx, adminmodule.Config{
 			Access: accessReader,
@@ -1041,6 +1058,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			PublicationCommands:   routes.dashboardModule.PublicationCommandBindings(),
 			DefaultWorkspaceID:    policy.defaultWorkspaceID,
 			AuthConfigured:        platform.auth != nil,
+			LocalPasswordEnabled:  localPasswordEnabled,
 			AccessConfigured:      accessReader != nil,
 			Storage: adminmodule.StorageConfig{
 				CatalogPath: storage.duckLakeCatalogPath, DataPath: storage.duckLakeDataPath,
@@ -1048,12 +1066,20 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				Analytics: runtime.analyticsModule.AdminResources(), Admitter: workloadController(&runtime.workloads),
 			},
 			Layout: func(r *http.Request) webpage.Provider {
-				return applicationLayout(routes.accessModule, routes.agentModule, platform.assets, r)
+				return applicationLayout(routes.accessModule, routes.agentModule, routes.product, platform.assets, r)
 			},
 			EnsureClientID: func(w http.ResponseWriter, r *http.Request) {
 				_ = pagestream.EnsureClientID(w, r)
 			},
-			Broker: runtime.broker,
+			Broker:  runtime.broker,
+			Product: persistence.product, ProductCommands: productCommands, ProductCommandFailure: writeProductCommandFailure, ProductStatus: persistence.productStatus,
+			SettingsAccess:      settingsAccess,
+			PersonalAvatar:      routes.accessModule.PersonalAvatar(),
+			AuthoringSessions:   routes.accessModule.AuthoringSessions(),
+			CurrentSession:      routes.accessModule.CurrentSessionID,
+			WorkspaceSettings:   workspaceSettings,
+			WorkspaceAccess:     settingsAccess,
+			SettingsEnvironment: policy.defaultEnvironment,
 		})
 		if err != nil {
 			return fmt.Errorf("build admin module: %w", err)
@@ -1085,6 +1111,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 	}
 	apiDispatcher = &apiGenDispatcher{
 		managedDataModule:  routes.managedDataModule,
+		productAPI:         routes.adminModule,
 		arrowQueries:       supportsNativeArrow(runtime.metrics),
 		defaultEnvironment: policy.defaultEnvironment, managedDataTus: policy.managedDataTus,
 		instanceID: storage.instanceID, canonicalOrigin: storage.publicURL, buildIdentity: platform.buildIdentity,
@@ -1237,6 +1264,22 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 		platformlifecycle.Component{Start: platform.jobModule.Start, Stop: platform.jobModule.Stop},
 	)
 	return nil
+}
+
+func writeProductCommandFailure(ctx context.Context, w http.ResponseWriter, r *http.Request, operationID string, cause error) {
+	if contracts, ok := apiaggregate.GetAPIGenCommandFailureContracts(operationID); ok && apigenfailure.ValidateContracts(contracts) == nil {
+		if contract, matched := apigenfailure.Match(contracts, cause); matched {
+			apitransport.WriteAPIGenFailure(ctx, w, r, nil, apitransport.APIGenFailure{
+				OperationID: operationID, Kind: contract.Kind, StatusCode: contract.StatusCode,
+				Code: contract.Code, PublicDetail: contract.PublicDetail, Cause: cause,
+			})
+			return
+		}
+	}
+	apitransport.WriteAPIGenFailure(ctx, w, r, nil, apitransport.APIGenFailure{
+		OperationID: operationID, Kind: "handler", StatusCode: http.StatusInternalServerError,
+		Code: "INTERNAL_ERROR", PublicDetail: "The request could not be completed.", Cause: cause,
+	})
 }
 
 func workspaceReadModel(persistence persistenceInputs) (workspacemodule.ReadModel, error) {

--- a/internal/app/shell/shell.go
+++ b/internal/app/shell/shell.go
@@ -19,8 +19,25 @@ type Config struct {
 	Presentation         webpage.Presentation
 	Assets               staticasset.Resolver
 	RoleLabel            string
+	ProductLogoURL       string
+	UserAvatarURL        string
+	UserName             string
+	ColorMode            string
+	AdminAccess          *AdminNavigationAccess
 	ActiveConversationID string
 	Conversations        []Conversation
+}
+
+// AdminNavigationAccess describes the settings surfaces the signed-in
+// principal may open. A nil value preserves the complete navigation for
+// callers that do not provide authorization context, such as static previews.
+type AdminNavigationAccess struct {
+	ManagePlatform     bool
+	ManageGrants       bool
+	ManageWorkspace    bool
+	ManagePublications bool
+	ViewAudit          bool
+	ViewConnections    bool
 }
 
 type Chrome struct {
@@ -39,6 +56,10 @@ type Sidebar struct {
 	ModelTitle     *string  `json:"modelTitle,omitempty"`
 	PageTitle      string   `json:"pageTitle"`
 	PrimaryAction  *Action  `json:"primaryAction,omitempty"`
+	ProductLogoURL *string  `json:"productLogoUrl,omitempty"`
+	ProductName    string   `json:"productName"`
+	UserAvatarURL  *string  `json:"userAvatarUrl,omitempty"`
+	UserName       *string  `json:"userName,omitempty"`
 	UserRole       *string  `json:"userRole,omitempty"`
 	WorkspaceTitle string   `json:"workspaceTitle"`
 }
@@ -82,7 +103,7 @@ func Provider(config Config) webpage.Provider {
 		isAdmin := context.Active == "admin" || context.Active == "connections"
 		navigation := []Group{{Label: "Navigation", Items: globalNavigation()}}
 		if isAdmin {
-			navigation = adminNavigation()
+			navigation = adminNavigation(config.AdminAccess)
 		}
 		sidebarActive := context.Active
 		if isAdmin {
@@ -92,7 +113,8 @@ func Provider(config Config) webpage.Provider {
 			Active: sidebarActive, Admin: isAdmin, Compact: context.Compact,
 			DashboardID: optional(context.SectionID), DashboardTitle: context.SectionTitle,
 			ModelID: optional(context.RelatedID), ModelTitle: optional(context.RelatedTitle),
-			PageTitle: context.PageTitle, UserRole: optional(config.RoleLabel),
+			PageTitle: context.PageTitle, ProductLogoURL: optional(config.ProductLogoURL), ProductName: firstNonEmpty(config.Presentation.ProductName, "LeapView"),
+			UserAvatarURL: optional(config.UserAvatarURL), UserName: optional(config.UserName), UserRole: optional(config.RoleLabel),
 			WorkspaceTitle: firstNonEmpty(context.ScopeTitle, context.ScopeID, config.Presentation.ProductName),
 			Groups:         navigation,
 		}
@@ -108,6 +130,7 @@ func Provider(config Config) webpage.Provider {
 		return webpage.Layout{
 			Presentation: config.Presentation,
 			Assets:       config.Assets,
+			ColorMode:    config.ColorMode,
 			Signal:       Chrome{Sidebar: sidebar},
 			Scripts:      []string{"/static/app-shell.js"},
 			Mount: func(content g.Node, attrs ...g.Node) g.Node {
@@ -123,41 +146,83 @@ func globalNavigation() []Item {
 		{ID: "chat", Label: "Chats", Href: "/chats", Icon: "chat", Meta: optional("Agent interface")},
 		{ID: "workspaces", Label: "Workspaces", Href: "/workspaces", Icon: "catalog", Meta: optional("Published assets")},
 		{ID: "data", Label: "Data", Href: "/data", Icon: "cache", Meta: optional("Inspect rows")},
-		{ID: "admin", Label: "Admin", Href: "/admin/profile", Icon: "settings", Meta: optional("Read-only administration")},
+		{ID: "admin", Label: "Admin", Href: "/admin/profile", Icon: "settings", Meta: optional("Product administration")},
 	}
 }
 
-func adminNavigation() []Group {
-	return []Group{
+func adminNavigation(access *AdminNavigationAccess) []Group {
+	allowed := AdminNavigationAccess{
+		ManagePlatform: true, ManageGrants: true, ManageWorkspace: true,
+		ManagePublications: true, ViewAudit: true, ViewConnections: true,
+	}
+	if access != nil {
+		allowed = *access
+	}
+	groups := []Group{
 		{
 			Label: "Personal",
 			Items: []Item{
 				{ID: "profile", Label: "Profile", Href: "/admin/profile", Icon: "user"},
+				{ID: "security", Label: "Security & sessions", Href: "/admin/security", Icon: "activity"},
+				{ID: "api-tokens", Label: "API tokens", Href: "/admin/api-tokens", Icon: "data"},
 			},
+		},
+		{
+			Label: "Product",
+			Items: filterItems([]conditionalItem{
+				{allowed: allowed.ManagePlatform, item: Item{ID: "general", Label: "General", Href: "/admin/general", Icon: "settings"}},
+				{allowed: allowed.ManageWorkspace, item: Item{ID: "workspaces-admin", Label: "Workspaces", Href: "/admin/workspaces", Icon: "catalog"}},
+			}),
 		},
 		{
 			Label: "Access",
-			Items: []Item{
-				{ID: "principals", Label: "Principals", Href: "/admin/principals", Icon: "users"},
-				{ID: "groups", Label: "Groups", Href: "/admin/groups", Icon: "users-round"},
-			},
+			Items: filterItems([]conditionalItem{
+				{allowed: allowed.ManageGrants, item: Item{ID: "principals", Label: "Principals", Href: "/admin/principals", Icon: "users"}},
+				{allowed: allowed.ManageGrants, item: Item{ID: "groups", Label: "Groups", Href: "/admin/groups", Icon: "users-round"}},
+				{allowed: allowed.ManagePlatform, item: Item{ID: "service-accounts", Label: "Service accounts", Href: "/admin/service-accounts", Icon: "bot"}},
+				{allowed: allowed.ManagePlatform, item: Item{ID: "authentication", Label: "Authentication", Href: "/admin/authentication", Icon: "system"}},
+			}),
 		},
 		{
-			Label: "Data",
-			Items: []Item{
-				{ID: "connections", Label: "Connections", Href: "/connections", Icon: "data"},
-				{ID: "storage", Label: "Storage", Href: "/admin/storage", Icon: "database"},
-				{ID: "publications", Label: "Publications", Href: "/admin/publications", Icon: "globe"},
-			},
+			Label: "Data & sharing",
+			Items: filterItems([]conditionalItem{
+				{allowed: allowed.ViewConnections, item: Item{ID: "connections", Label: "Connections", Href: "/connections", Icon: "data"}},
+				{allowed: allowed.ManagePlatform, item: Item{ID: "storage", Label: "Storage", Href: "/admin/storage", Icon: "database"}},
+				{allowed: allowed.ManagePublications, item: Item{ID: "publications", Label: "Publications", Href: "/admin/publications", Icon: "globe"}},
+			}),
 		},
 		{
 			Label: "Operations",
-			Items: []Item{
-				{ID: "agent", Label: "Agent", Href: "/admin/agent", Icon: "bot"},
-				{ID: "queries", Label: "Query History", Href: "/admin/queries", Icon: "history"},
-			},
+			Items: filterItems([]conditionalItem{
+				{allowed: allowed.ManagePlatform, item: Item{ID: "agent", Label: "Agent", Href: "/admin/agent", Icon: "bot"}},
+				{allowed: allowed.ViewAudit, item: Item{ID: "queries", Label: "Query history", Href: "/admin/queries", Icon: "history"}},
+				{allowed: allowed.ViewAudit, item: Item{ID: "audit", Label: "Audit log", Href: "/admin/audit", Icon: "activity"}},
+				{allowed: allowed.ManagePlatform, item: Item{ID: "system", Label: "System", Href: "/admin/system", Icon: "system"}},
+			}),
 		},
 	}
+	visible := groups[:0]
+	for _, group := range groups {
+		if len(group.Items) > 0 {
+			visible = append(visible, group)
+		}
+	}
+	return visible
+}
+
+type conditionalItem struct {
+	allowed bool
+	item    Item
+}
+
+func filterItems(values []conditionalItem) []Item {
+	items := make([]Item, 0, len(values))
+	for _, value := range values {
+		if value.allowed {
+			items = append(items, value.item)
+		}
+	}
+	return items
 }
 
 func historyItems(config Config, activeConversationID string) []HistoryItem {

--- a/internal/app/shell/shell_test.go
+++ b/internal/app/shell/shell_test.go
@@ -9,8 +9,9 @@ import (
 func TestProviderOwnsGlobalNavigationAndAgentHistory(t *testing.T) {
 	provider := Provider(Config{
 		Presentation: webpage.Presentation{ProductName: "LeapView"},
-		RoleLabel:    "Owner", ActiveConversationID: "chat-1",
-		Conversations: []Conversation{{ID: "chat-1", Title: "Revenue"}},
+		RoleLabel:    "Owner", UserName: "Ada Lovelace", UserAvatarURL: "/profile/avatars/ada/avatar-digest",
+		ActiveConversationID: "chat-1",
+		Conversations:        []Conversation{{ID: "chat-1", Title: "Revenue"}},
 	})
 	layout := provider(webpage.Context{Active: "chat", ScopeTitle: "Sales", SectionTitle: "Workspace", PageTitle: "Published assets"})
 	chrome, ok := layout.Signal.(Chrome)
@@ -20,8 +21,32 @@ func TestProviderOwnsGlobalNavigationAndAgentHistory(t *testing.T) {
 	if len(chrome.Sidebar.Groups) != 1 || len(chrome.Sidebar.Groups[0].Items) != 5 {
 		t.Fatalf("navigation = %#v", chrome.Sidebar.Groups)
 	}
+	if chrome.Sidebar.UserName == nil || *chrome.Sidebar.UserName != "Ada Lovelace" {
+		t.Fatalf("sidebar user name = %v, want Ada Lovelace", chrome.Sidebar.UserName)
+	}
+	if chrome.Sidebar.UserAvatarURL == nil || *chrome.Sidebar.UserAvatarURL != "/profile/avatars/ada/avatar-digest" {
+		t.Fatalf("sidebar user avatar URL = %v", chrome.Sidebar.UserAvatarURL)
+	}
+	if chrome.Sidebar.ProductName != "LeapView" {
+		t.Fatalf("sidebar product name = %q", chrome.Sidebar.ProductName)
+	}
 	if chrome.Sidebar.History == nil || len(chrome.Sidebar.History.Items) != 1 || !chrome.Sidebar.History.Items[0].Active {
 		t.Fatalf("history = %#v", chrome.Sidebar.History)
+	}
+}
+
+func TestProviderProjectsCustomProductIdentity(t *testing.T) {
+	provider := Provider(Config{
+		Presentation:   webpage.Presentation{ProductName: "Northstar Analytics"},
+		ProductLogoURL: "/product/logo/digest",
+	})
+	layout := provider(webpage.Context{})
+	chrome := layout.Signal.(Chrome)
+	if chrome.Sidebar.ProductName != "Northstar Analytics" || chrome.Sidebar.ProductLogoURL == nil || *chrome.Sidebar.ProductLogoURL != "/product/logo/digest" {
+		t.Fatalf("sidebar product identity = %#v", chrome.Sidebar)
+	}
+	if layout.Presentation.ProductName != "Northstar Analytics" {
+		t.Fatalf("presentation = %#v", layout.Presentation)
 	}
 }
 
@@ -32,7 +57,7 @@ func TestProviderUsesAdminNavigationAndBackAction(t *testing.T) {
 	if chrome.Sidebar.Active != "principals" || !chrome.Sidebar.Admin || !chrome.Sidebar.Compact {
 		t.Fatalf("sidebar = %#v", chrome.Sidebar)
 	}
-	if len(chrome.Sidebar.Groups) != 4 {
+	if len(chrome.Sidebar.Groups) != 5 {
 		t.Fatalf("navigation = %#v", chrome.Sidebar.Groups)
 	}
 	wantGroups := []struct {
@@ -45,19 +70,23 @@ func TestProviderUsesAdminNavigationAndBackAction(t *testing.T) {
 		{label: "Personal", items: []struct {
 			label string
 			icon  string
-		}{{label: "Profile", icon: "user"}}},
+		}{{label: "Profile", icon: "user"}, {label: "Security & sessions", icon: "activity"}, {label: "API tokens", icon: "data"}}},
+		{label: "Product", items: []struct {
+			label string
+			icon  string
+		}{{label: "General", icon: "settings"}, {label: "Workspaces", icon: "catalog"}}},
 		{label: "Access", items: []struct {
 			label string
 			icon  string
-		}{{label: "Principals", icon: "users"}, {label: "Groups", icon: "users-round"}}},
-		{label: "Data", items: []struct {
+		}{{label: "Principals", icon: "users"}, {label: "Groups", icon: "users-round"}, {label: "Service accounts", icon: "bot"}, {label: "Authentication", icon: "system"}}},
+		{label: "Data & sharing", items: []struct {
 			label string
 			icon  string
 		}{{label: "Connections", icon: "data"}, {label: "Storage", icon: "database"}, {label: "Publications", icon: "globe"}}},
 		{label: "Operations", items: []struct {
 			label string
 			icon  string
-		}{{label: "Agent", icon: "bot"}, {label: "Query History", icon: "history"}}},
+		}{{label: "Agent", icon: "bot"}, {label: "Query history", icon: "history"}, {label: "Audit log", icon: "activity"}, {label: "System", icon: "system"}}},
 	}
 	for groupIndex, wantGroup := range wantGroups {
 		group := chrome.Sidebar.Groups[groupIndex]
@@ -76,6 +105,31 @@ func TestProviderUsesAdminNavigationAndBackAction(t *testing.T) {
 	}
 	if chrome.Sidebar.History != nil {
 		t.Fatalf("admin sidebar history = %#v, want nil", chrome.Sidebar.History)
+	}
+}
+
+func TestProviderFiltersAdminNavigationByPrivileges(t *testing.T) {
+	provider := Provider(Config{
+		Presentation: webpage.Presentation{ProductName: "LeapView"},
+		AdminAccess:  &AdminNavigationAccess{ManageGrants: true, ViewConnections: true},
+	})
+	layout := provider(webpage.Context{Active: "admin", PageID: "principals"})
+	chrome := layout.Signal.(Chrome)
+	got := map[string]bool{}
+	for _, group := range chrome.Sidebar.Groups {
+		for _, item := range group.Items {
+			got[item.ID] = true
+		}
+	}
+	for _, id := range []string{"profile", "security", "api-tokens", "principals", "groups", "connections"} {
+		if !got[id] {
+			t.Fatalf("navigation is missing %q: %#v", id, chrome.Sidebar.Groups)
+		}
+	}
+	for _, id := range []string{"general", "workspaces-admin", "service-accounts", "authentication", "storage", "publications", "agent", "queries", "audit", "system"} {
+		if got[id] {
+			t.Fatalf("navigation unexpectedly includes %q: %#v", id, chrome.Sidebar.Groups)
+		}
 	}
 }
 

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	accessmodule "github.com/flidai/leapview/internal/access/module"
+	adminmodule "github.com/flidai/leapview/internal/admin/module"
 	agentmodule "github.com/flidai/leapview/internal/agent/module"
 	analyticsmodule "github.com/flidai/leapview/internal/analytics/module"
 	"github.com/flidai/leapview/internal/app/desktopdiscovery"
@@ -74,6 +75,8 @@ type assemblyConfig struct {
 	AnalyticsModule       *analyticsmodule.Module
 	DashboardAssets       dashboardmodule.Assets
 	QueryAudit            *analyticsmodule.QueryAuditSurface
+	Product               *adminmodule.ProductService
+	ProductStatus         adminmodule.ProductStatus
 }
 
 // appTestHarness is a test fixture facade for legacy app-package tests.
@@ -174,7 +177,7 @@ func assembleRuntimeChecked(ctx context.Context, metrics QueryMetrics, options a
 			ReleaseModule: options.ReleaseModule, JobModule: options.JobModule,
 			AccessModule: options.AccessModule, Agent: options.Agent,
 			ManagedDataModule: options.ManagedDataModule, AnalyticsModule: options.AnalyticsModule,
-			DashboardAssets: options.DashboardAssets,
+			DashboardAssets: options.DashboardAssets, Product: options.Product, ProductStatus: options.ProductStatus,
 		},
 		workflowAssemblyInputs{
 			AgentSettings: options.AgentSettings, ManagedDataValidation: options.ManagedDataValidation,

--- a/internal/app/ui_command_contract_test.go
+++ b/internal/app/ui_command_contract_test.go
@@ -66,8 +66,9 @@ func TestUIRequestsCannotBypassTypedCommandHelpers(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
 	nonCommandAllowlist := map[string]map[string]int{
 		filepath.Clean("internal/admin/ui/page.go"): {
-			"uiactions.QueryPost(": 2, "uiactions.EventPost(": 1, "uiactions.UncontractedMutationPatch(": 1,
+			"uiactions.QueryPost(": 2, "uiactions.EventPost(": 1, "uiactions.UncontractedMutationPost(": 3, "uiactions.UncontractedMutationPatch(": 1,
 		},
+		filepath.Clean("internal/admin/personalsettings/ui.go"):  {"uiactions.UncontractedMutationPost(": 6},
 		filepath.Clean("internal/workspace/ui/page.go"):          {"uiactions.QueryPost(": 1},
 		filepath.Clean("internal/workspace/ui/workspace.go"):     {"uiactions.QueryPost(": 3, "uiactions.UncontractedMutationPost(": 1},
 		filepath.Clean("internal/workspace/ui/data_explorer.go"): {"uiactions.EventPost(": 1},

--- a/internal/manageddata/module/content_blobs.go
+++ b/internal/manageddata/module/content_blobs.go
@@ -1,0 +1,61 @@
+package module
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	managedfilesystem "github.com/flidai/leapview/internal/manageddata/storage/filesystem"
+)
+
+// ContentBlobStore is the module-level port for small content-addressed assets
+// that share deployment-managed local/S3 connectivity without sharing keys or
+// retention with managed data.
+type ContentBlobStore interface {
+	PutContent(context.Context, ContentBlob, io.Reader) (ContentBlob, error)
+	OpenContent(context.Context, string) (io.ReadCloser, error)
+}
+
+type ContentBlob struct {
+	SHA256 string
+	Size   int64
+}
+
+func NewContentBlobStore(ctx context.Context, config ProductConfig, localDirectory, s3Prefix string) (ContentBlobStore, error) {
+	var blobs storage.BlobStore
+	var err error
+	switch strings.TrimSpace(config.Backend) {
+	case "", "local":
+		blobs, err = managedfilesystem.New(filepath.Clean(localDirectory))
+	case "s3":
+		config.S3Prefix = strings.Trim(strings.TrimSpace(s3Prefix), "/")
+		blobs, err = newManagedDataS3Store(ctx, config)
+	default:
+		return nil, fmt.Errorf("content-blob backend must be local or s3")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return contentBlobStore{blobs: blobs}, nil
+}
+
+type contentBlobStore struct{ blobs storage.BlobStore }
+
+func (s contentBlobStore) PutContent(ctx context.Context, expected ContentBlob, body io.Reader) (ContentBlob, error) {
+	stored, err := s.blobs.Put(ctx, storage.Blob{SHA256: expected.SHA256, Size: expected.Size}, body)
+	return ContentBlob{SHA256: stored.SHA256, Size: stored.Size}, err
+}
+
+func (s contentBlobStore) OpenContent(ctx context.Context, digest string) (io.ReadCloser, error) {
+	reader, err := s.blobs.Open(ctx, digest)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, ErrContentBlobNotFound
+	}
+	return reader, err
+}
+
+var ErrContentBlobNotFound = errors.New("content blob not found")

--- a/internal/manageddata/module/content_blobs_test.go
+++ b/internal/manageddata/module/content_blobs_test.go
@@ -1,0 +1,37 @@
+package module
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestContentBlobStoreUsesIsolatedLocalDirectory(t *testing.T) {
+	store, err := NewContentBlobStore(t.Context(), ProductConfig{Backend: "local"}, t.TempDir(), "unused")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value := []byte("product-logo")
+	digest := sha256.Sum256(value)
+	expected := ContentBlob{SHA256: hex.EncodeToString(digest[:]), Size: int64(len(value))}
+	stored, err := store.PutContent(t.Context(), expected, bytes.NewReader(value))
+	if err != nil || stored != expected {
+		t.Fatalf("PutContent() = %#v, %v", stored, err)
+	}
+	reader, err := store.OpenContent(t.Context(), expected.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(reader)
+	_ = reader.Close()
+	if !bytes.Equal(got, value) {
+		t.Fatalf("stored bytes = %q", got)
+	}
+	if _, err := store.OpenContent(t.Context(), strings.Repeat("a", 64)); !errors.Is(err, ErrContentBlobNotFound) {
+		t.Fatalf("missing blob error = %v", err)
+	}
+}

--- a/internal/manageddata/module/storage.go
+++ b/internal/manageddata/module/storage.go
@@ -449,6 +449,17 @@ func capacityProtectedTus(next http.Handler, capacity *maintenance.CapacityCheck
 }
 
 func newManagedDataS3Store(ctx context.Context, cfg ProductConfig) (*manageds3.Store, error) {
+	return newS3BlobStore(ctx, cfg, cfg.S3Prefix)
+}
+
+// NewS3BlobStore constructs a content-addressed store that shares the managed
+// data S3 connection settings but uses an independent key prefix. Independent
+// prefixes keep each capability's reachability and garbage collection isolated.
+func NewS3BlobStore(ctx context.Context, cfg ProductConfig, prefix string) (storage.BlobStore, error) {
+	return newS3BlobStore(ctx, cfg, prefix)
+}
+
+func newS3BlobStore(ctx context.Context, cfg ProductConfig, prefix string) (*manageds3.Store, error) {
 	loadOptions := []func(*awsconfig.LoadOptions) error{awsconfig.WithRegion(strings.TrimSpace(cfg.S3Region))}
 	if cfg.S3AccessKeyID != "" {
 		provider := credentials.NewStaticCredentialsProvider(
@@ -470,7 +481,7 @@ func newManagedDataS3Store(ctx context.Context, cfg ProductConfig) (*manageds3.S
 	})
 	return manageds3.New(client, awss3.NewPresignClient(client), manageds3.Config{
 		Bucket: cfg.S3Bucket,
-		Prefix: cfg.S3Prefix,
+		Prefix: prefix,
 	})
 }
 

--- a/internal/platform/filesystem/private_file_test.go
+++ b/internal/platform/filesystem/private_file_test.go
@@ -33,6 +33,11 @@ func TestReadPrivateFileRejectsBroadPermissions(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// os.WriteFile applies the process umask to newly created files. Force the
+	// broad mode so this assertion is stable under security-conscious CI shells.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := ReadPrivateFile(path); err == nil {
 		t.Fatal("broadly readable private file was accepted")
 	}

--- a/internal/platform/http/transport/transport.go
+++ b/internal/platform/http/transport/transport.go
@@ -105,7 +105,7 @@ func requiredCollectionField(key string) bool {
 }
 
 func isTimestampField(key string) bool {
-	return strings.HasSuffix(key, "At") || key == "timestamp" || key == "created" || key == "updated"
+	return strings.HasSuffix(key, "At") || strings.HasSuffix(key, "Since") || key == "timestamp" || key == "created" || key == "updated"
 }
 
 func parsePublicTimestamp(value string) (string, error) {

--- a/internal/platform/http/transport/transport_test.go
+++ b/internal/platform/http/transport/transport_test.go
@@ -18,11 +18,12 @@ func (operation testCommandOperationID) APIGenOperationID() string { return oper
 func TestWriteJSONNormalizesTimestampsAndRequiredCollections(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	WriteJSON(recorder, 200, map[string]any{
-		"createdAt":  "2026-01-02 03:04:05",
-		"items":      nil,
-		"bindings":   nil,
-		"workspaces": nil,
-		"optional":   nil,
+		"createdAt":               "2026-01-02 03:04:05",
+		"activeServingStateSince": "2026-01-02T05:04:05+02:00",
+		"items":                   nil,
+		"bindings":                nil,
+		"workspaces":              nil,
+		"optional":                nil,
 	})
 	var body map[string]any
 	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
@@ -30,6 +31,9 @@ func TestWriteJSONNormalizesTimestampsAndRequiredCollections(t *testing.T) {
 	}
 	if body["createdAt"] != "2026-01-02T03:04:05Z" {
 		t.Fatalf("createdAt = %#v", body["createdAt"])
+	}
+	if body["activeServingStateSince"] != "2026-01-02T03:04:05Z" {
+		t.Fatalf("activeServingStateSince = %#v", body["activeServingStateSince"])
 	}
 	if items, ok := body["items"].([]any); !ok || items == nil {
 		t.Fatalf("items = %#v, want empty array", body["items"])

--- a/internal/platform/migrations/060_principal_avatars.sql
+++ b/internal/platform/migrations/060_principal_avatars.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS principal_avatars (
+  principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
+  sha256 TEXT NOT NULL,
+  media_type TEXT NOT NULL CHECK(media_type = 'image/png'),
+  size_bytes INTEGER NOT NULL CHECK(size_bytes > 0),
+  width INTEGER NOT NULL CHECK(width = 256),
+  height INTEGER NOT NULL CHECK(height = 256),
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK(length(sha256) = 64 AND sha256 = lower(sha256))
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS principal_avatars;

--- a/internal/platform/migrations/061_product_identity.sql
+++ b/internal/platform/migrations/061_product_identity.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS product_identity (
+  singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+  display_name TEXT NOT NULL CHECK(length(trim(display_name)) BETWEEN 1 AND 120),
+  logo_sha256 TEXT,
+  logo_media_type TEXT,
+  logo_size_bytes INTEGER,
+  logo_width INTEGER,
+  logo_height INTEGER,
+  revision INTEGER NOT NULL DEFAULT 1 CHECK(revision > 0),
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK(
+    (logo_sha256 IS NULL AND logo_media_type IS NULL AND logo_size_bytes IS NULL AND logo_width IS NULL AND logo_height IS NULL)
+    OR
+    (length(logo_sha256) = 64 AND logo_sha256 = lower(logo_sha256)
+      AND logo_media_type IN ('image/jpeg', 'image/png', 'image/webp')
+      AND logo_size_bytes > 0 AND logo_width > 0 AND logo_height > 0)
+  )
+);
+
+INSERT INTO product_identity (singleton, display_name)
+VALUES (1, 'LeapView')
+ON CONFLICT(singleton) DO NOTHING;
+
+-- +goose Down
+DROP TABLE IF EXISTS product_identity;

--- a/internal/platform/migrations/062_principal_preferences.sql
+++ b/internal/platform/migrations/062_principal_preferences.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS principal_preferences (
+  principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
+  theme TEXT NOT NULL DEFAULT 'system' CHECK(theme IN ('system', 'light', 'dark')),
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS principal_preferences;

--- a/internal/platform/migrations/063_principal_activity_indexes.sql
+++ b/internal/platform/migrations/063_principal_activity_indexes.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+CREATE INDEX sessions_principal_last_seen_idx
+  ON sessions(principal_id, last_seen_at DESC);
+
+CREATE INDEX oauth_authoring_sessions_human_activity_idx
+  ON oauth_authoring_sessions(principal_id, last_used_at DESC)
+  WHERE kind = 'human_cli' AND last_used_at IS NOT NULL;
+
+-- +goose Down
+DROP INDEX oauth_authoring_sessions_human_activity_idx;
+DROP INDEX sessions_principal_last_seen_idx;

--- a/internal/platform/migrations/064_principal_theme_variants.sql
+++ b/internal/platform/migrations/064_principal_theme_variants.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE principal_preferences_new (
+  principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
+  theme TEXT NOT NULL DEFAULT 'system' CHECK(theme IN (
+    'system',
+    'light',
+    'dark',
+    'dark_dimmed',
+    'light_colorblind',
+    'dark_colorblind',
+    'light_tritanopia',
+    'dark_tritanopia'
+  )),
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO principal_preferences_new (principal_id, theme, updated_at)
+SELECT principal_id, theme, updated_at
+FROM principal_preferences;
+
+DROP TABLE principal_preferences;
+ALTER TABLE principal_preferences_new RENAME TO principal_preferences;
+
+PRAGMA foreign_keys = ON;
+
+-- +goose Down
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE principal_preferences_old (
+  principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
+  theme TEXT NOT NULL DEFAULT 'system' CHECK(theme IN ('system', 'light', 'dark')),
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO principal_preferences_old (principal_id, theme, updated_at)
+SELECT principal_id,
+  CASE
+    WHEN theme IN ('light_colorblind', 'light_tritanopia') THEN 'light'
+    WHEN theme IN ('dark_dimmed', 'dark_colorblind', 'dark_tritanopia') THEN 'dark'
+    ELSE theme
+  END,
+  updated_at
+FROM principal_preferences;
+
+DROP TABLE principal_preferences;
+ALTER TABLE principal_preferences_old RENAME TO principal_preferences;
+
+PRAGMA foreign_keys = ON;

--- a/internal/platform/web/page/page.go
+++ b/internal/platform/web/page/page.go
@@ -38,6 +38,7 @@ type Presentation struct {
 type Layout struct {
 	Presentation Presentation
 	Assets       staticasset.Resolver
+	ColorMode    string
 	Signal       any
 	Scripts      []string
 	Mount        func(g.Node, ...g.Node) g.Node
@@ -75,10 +76,7 @@ func WithSignal(layout Layout, signals map[string]any) map[string]any {
 }
 
 func Render(layout Layout, spec Spec) g.Node {
-	title := strings.TrimSpace(spec.Title)
-	if title == "" {
-		title = strings.TrimSpace(layout.Presentation.ProductName)
-	}
+	title := documentTitle(spec.Title, layout.Presentation.ProductName)
 	head := make([]g.Node, 0, 8+len(layout.Scripts)+len(spec.Stylesheets)+len(spec.Scripts)+len(spec.Head))
 	if favicon := strings.TrimSpace(layout.Presentation.FaviconPath); favicon != "" {
 		head = append(head, h.Link(h.Rel("icon"), h.Href(layout.Assets.URL(favicon)), h.Type("image/svg+xml")))
@@ -110,10 +108,14 @@ func Render(layout Layout, spec Spec) g.Node {
 	body = append(body, inspectorElement(layout.Assets))
 	htmlAttrs := spec.HTMLAttrs
 	if len(htmlAttrs) == 0 {
+		theme := themeAttributes(layout.ColorMode)
 		htmlAttrs = []g.Node{
-			g.Attr("data-color-mode", "auto"),
-			g.Attr("data-light-theme", "light"),
-			g.Attr("data-dark-theme", "dark"),
+			g.Attr("data-color-mode", theme.colorMode),
+			g.Attr("data-light-theme", theme.lightTheme),
+			g.Attr("data-dark-theme", theme.darkTheme),
+		}
+		if theme.preference != "" {
+			htmlAttrs = append(htmlAttrs, g.Attr("data-theme-preference", theme.preference))
 		}
 	}
 	mainAttrs := spec.MainAttrs
@@ -125,6 +127,51 @@ func Render(layout Layout, spec Spec) g.Node {
 		HTMLAttrs: htmlAttrs, Head: head, MainAttrs: mainAttrs,
 		UpdatesURL: spec.UpdatesURL, Body: body,
 	})
+}
+
+func documentTitle(pageTitle, productName string) string {
+	pageTitle = strings.TrimSpace(pageTitle)
+	productName = strings.TrimSpace(productName)
+	if pageTitle == "" {
+		return productName
+	}
+	if productName == "" || strings.Contains(pageTitle, productName) {
+		return pageTitle
+	}
+	if productName != "LeapView" && strings.Contains(pageTitle, "LeapView") {
+		return strings.Replace(pageTitle, "LeapView", productName, 1)
+	}
+	return pageTitle + " · " + productName
+}
+
+type documentTheme struct {
+	colorMode  string
+	preference string
+	lightTheme string
+	darkTheme  string
+}
+
+func themeAttributes(value string) documentTheme {
+	switch strings.TrimSpace(value) {
+	case "light":
+		return documentTheme{colorMode: "light", preference: "light", lightTheme: "light", darkTheme: "dark"}
+	case "dark":
+		return documentTheme{colorMode: "dark", preference: "dark", lightTheme: "light", darkTheme: "dark"}
+	case "dark_dimmed":
+		return documentTheme{colorMode: "dark", preference: "dark_dimmed", lightTheme: "light", darkTheme: "dark_dimmed"}
+	case "light_colorblind":
+		return documentTheme{colorMode: "light", preference: "light_colorblind", lightTheme: "light_colorblind", darkTheme: "dark"}
+	case "dark_colorblind":
+		return documentTheme{colorMode: "dark", preference: "dark_colorblind", lightTheme: "light", darkTheme: "dark_colorblind"}
+	case "light_tritanopia":
+		return documentTheme{colorMode: "light", preference: "light_tritanopia", lightTheme: "light_tritanopia", darkTheme: "dark"}
+	case "dark_tritanopia":
+		return documentTheme{colorMode: "dark", preference: "dark_tritanopia", lightTheme: "light", darkTheme: "dark_tritanopia"}
+	case "system":
+		return documentTheme{colorMode: "auto", preference: "system", lightTheme: "light", darkTheme: "dark"}
+	default:
+		return documentTheme{colorMode: "auto", lightTheme: "light", darkTheme: "dark"}
+	}
 }
 
 func csrfMeta(token string) g.Node {

--- a/internal/platform/web/page/page_test.go
+++ b/internal/platform/web/page/page_test.go
@@ -20,6 +20,7 @@ func TestRenderAppliesInjectedLayoutWithoutOwningItsSignal(t *testing.T) {
 		Mount: func(content g.Node, attrs ...g.Node) g.Node {
 			return g.El("product-shell", append(attrs, content)...)
 		},
+		ColorMode: "light_colorblind",
 	}
 	var output bytes.Buffer
 	if err := Render(layout, Spec{
@@ -29,7 +30,7 @@ func TestRenderAppliesInjectedLayoutWithoutOwningItsSignal(t *testing.T) {
 		t.Fatal(err)
 	}
 	body := output.String()
-	for _, want := range []string{"<title>Product</title>", `href="/brand.svg?v=release-123"`, `src="/shell.js?v=release-123"`, `src="/route.js?v=release-123"`, `<product-shell slot="page"><route-page>`} {
+	for _, want := range []string{"<title>Product</title>", `data-color-mode="light"`, `data-light-theme="light_colorblind"`, `data-theme-preference="light_colorblind"`, `href="/brand.svg?v=release-123"`, `src="/shell.js?v=release-123"`, `src="/route.js?v=release-123"`, `<product-shell slot="page"><route-page>`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("rendered document missing %q", want)
 		}
@@ -37,5 +38,14 @@ func TestRenderAppliesInjectedLayoutWithoutOwningItsSignal(t *testing.T) {
 	signals := WithSignal(layout, map[string]any{"page": "route"})
 	if signals["chrome"] != layout.Signal {
 		t.Fatal("layout signal was not merged")
+	}
+}
+
+func TestDocumentTitleIncludesCustomProductIdentity(t *testing.T) {
+	if got := documentTitle("Admin - General", "Northstar Analytics"); got != "Admin - General · Northstar Analytics" {
+		t.Fatalf("document title = %q", got)
+	}
+	if got := documentTitle("LeapView Dashboards", "Northstar Analytics"); got != "Northstar Analytics Dashboards" {
+		t.Fatalf("branded document title = %q", got)
 	}
 }

--- a/internal/workspace/api/contracts.go
+++ b/internal/workspace/api/contracts.go
@@ -13,6 +13,63 @@ type WorkspaceResponse struct {
 	UpdatedAt            string `json:"updatedAt"`
 }
 
+type WorkspaceAdministrationSubjectResponse struct {
+	SubjectType string `json:"subjectType"`
+	SubjectID   string `json:"subjectId"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"displayName"`
+	Role        string `json:"role,omitempty"`
+}
+
+type WorkspaceAdministrationRuntimeResponse struct {
+	Environment              string `json:"environment"`
+	ActiveServingStateID     string `json:"activeServingStateId,omitempty"`
+	ActiveServingStateStatus string `json:"activeServingStateStatus,omitempty"`
+	ActiveServingStateSince  string `json:"activeServingStateSince,omitempty"`
+	ProjectID                string `json:"projectId,omitempty"`
+	CurrentDeploymentID      string `json:"currentDeploymentId,omitempty"`
+	CurrentDeploymentStatus  string `json:"currentDeploymentStatus,omitempty"`
+	CurrentDeploymentSince   string `json:"currentDeploymentSince,omitempty"`
+	CurrentReleaseID         string `json:"currentReleaseId,omitempty"`
+}
+
+type WorkspaceAdministrationCapabilitiesResponse struct {
+	ManageWorkspace    bool `json:"manageWorkspace"`
+	ManageAccess       bool `json:"manageAccess"`
+	ManagePublications bool `json:"managePublications"`
+	ManageConnections  bool `json:"manageConnections"`
+	ViewManagedData    bool `json:"viewManagedData"`
+	IngestManagedData  bool `json:"ingestManagedData"`
+	PublishReleases    bool `json:"publishReleases"`
+	RequestDeployments bool `json:"requestDeployments"`
+	ViewDeployments    bool `json:"viewDeployments"`
+	UseAgent           bool `json:"useAgent"`
+	ViewAgent          bool `json:"viewAgent"`
+}
+
+type WorkspaceAdministrationLinksResponse struct {
+	Self               string `json:"self"`
+	Workspace          string `json:"workspace"`
+	Groups             string `json:"groups,omitempty"`
+	Roles              string `json:"roles,omitempty"`
+	RoleBindings       string `json:"roleBindings,omitempty"`
+	Grants             string `json:"grants,omitempty"`
+	Publications       string `json:"publications,omitempty"`
+	ManagedConnections string `json:"managedConnections,omitempty"`
+	Releases           string `json:"releases,omitempty"`
+	Deployments        string `json:"deployments,omitempty"`
+	AgentConversations string `json:"agentConversations,omitempty"`
+}
+
+type WorkspaceAdministrationResponse struct {
+	Workspace      WorkspaceResponse                           `json:"workspace"`
+	Owner          *WorkspaceAdministrationSubjectResponse     `json:"owner,omitempty"`
+	Administrators []WorkspaceAdministrationSubjectResponse    `json:"administrators"`
+	Runtime        WorkspaceAdministrationRuntimeResponse      `json:"runtime"`
+	Capabilities   WorkspaceAdministrationCapabilitiesResponse `json:"capabilities"`
+	Links          WorkspaceAdministrationLinksResponse        `json:"links"`
+}
+
 type SearchParams struct {
 	Query            *string
 	Workspaces       *[]string

--- a/internal/workspace/http/apigen.go
+++ b/internal/workspace/http/apigen.go
@@ -16,6 +16,7 @@ type APIGenHandler interface {
 	Search(stdhttp.ResponseWriter, *stdhttp.Request, APIGenSearchParams)
 	ListWorkspaces(stdhttp.ResponseWriter, *stdhttp.Request)
 	GetWorkspace(stdhttp.ResponseWriter, *stdhttp.Request, string)
+	GetWorkspaceAdministration(stdhttp.ResponseWriter, *stdhttp.Request, string)
 	GetWorkspaceActiveAssetGraph(stdhttp.ResponseWriter, *stdhttp.Request)
 	ListWorkspaceAssetEdges(stdhttp.ResponseWriter, *stdhttp.Request)
 	ListWorkspaceAssets(stdhttp.ResponseWriter, *stdhttp.Request)
@@ -51,6 +52,10 @@ func (d *APIGenDispatcher) ListWorkspaces(w stdhttp.ResponseWriter, r *stdhttp.R
 
 func (d *APIGenDispatcher) GetWorkspace(w stdhttp.ResponseWriter, r *stdhttp.Request, workspace string) {
 	d.handler.GetWorkspace(w, r, workspace)
+}
+
+func (d *APIGenDispatcher) GetWorkspaceAdministration(w stdhttp.ResponseWriter, r *stdhttp.Request, workspace string) {
+	d.handler.GetWorkspaceAdministration(w, r, workspace)
 }
 
 func (d *APIGenDispatcher) GetWorkspaceActiveAssetGraph(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {

--- a/internal/workspace/http/apigen_test.go
+++ b/internal/workspace/http/apigen_test.go
@@ -53,6 +53,8 @@ func (h *recordingAPIGenHandler) Search(_ stdhttp.ResponseWriter, _ *stdhttp.Req
 
 func (*recordingAPIGenHandler) ListWorkspaces(stdhttp.ResponseWriter, *stdhttp.Request)       {}
 func (*recordingAPIGenHandler) GetWorkspace(stdhttp.ResponseWriter, *stdhttp.Request, string) {}
+func (*recordingAPIGenHandler) GetWorkspaceAdministration(stdhttp.ResponseWriter, *stdhttp.Request, string) {
+}
 func (*recordingAPIGenHandler) GetWorkspaceActiveAssetGraph(stdhttp.ResponseWriter, *stdhttp.Request) {
 }
 func (*recordingAPIGenHandler) ListWorkspaceAssetEdges(stdhttp.ResponseWriter, *stdhttp.Request) {}

--- a/internal/workspace/module/administration_settings.go
+++ b/internal/workspace/module/administration_settings.go
@@ -1,0 +1,18 @@
+package module
+
+import "github.com/flidai/leapview/internal/workspace"
+
+// SettingsAdministration is the workspace-owned read surface used by product
+// settings. Persistence remains assembled inside the workspace capability.
+type SettingsAdministration interface {
+	workspace.ReadModel
+	workspace.AdministrationReadModel
+}
+
+func (m *Module) SettingsAdministration() SettingsAdministration {
+	if m == nil {
+		return nil
+	}
+	settings, _ := m.readModel.(SettingsAdministration)
+	return settings
+}

--- a/internal/workspace/module/api.go
+++ b/internal/workspace/module/api.go
@@ -1,12 +1,215 @@
 package module
 
 import (
+	"database/sql"
+	"errors"
 	"net/http"
+	"net/url"
+	"sort"
+	"strings"
 
+	"github.com/flidai/leapview/internal/access"
 	apitransport "github.com/flidai/leapview/internal/platform/http/transport"
 	"github.com/flidai/leapview/internal/workspace"
 	workspaceapi "github.com/flidai/leapview/internal/workspace/api"
+	workspacehttp "github.com/flidai/leapview/internal/workspace/http"
 )
+
+func (m *Module) GetWorkspaceAdministration(w http.ResponseWriter, r *http.Request, workspaceID string) {
+	if m == nil || m.readModel == nil {
+		apitransport.WriteProblem(w, r, http.StatusServiceUnavailable, "WORKSPACE_SERVICE_UNAVAILABLE", "Workspace service is unavailable", nil)
+		return
+	}
+	reader, ok := m.readModel.(workspace.AdministrationReadModel)
+	if !ok {
+		apitransport.WriteProblem(w, r, http.StatusServiceUnavailable, "WORKSPACE_ADMINISTRATION_UNAVAILABLE", "Workspace administration is unavailable", nil)
+		return
+	}
+	environment := m.runtimeEnvironment
+	if m.handler.Environment != nil {
+		environment = m.handler.Environment(r)
+	}
+	state, err := reader.AdministrationByID(r.Context(), workspace.WorkspaceID(workspaceID), environment)
+	if err != nil {
+		if errors.Is(err, workspace.ErrNotFound) {
+			apitransport.WriteProblem(w, r, http.StatusNotFound, "WORKSPACE_NOT_FOUND", "Workspace not found", nil)
+			return
+		}
+		apitransport.WriteProblem(w, r, http.StatusInternalServerError, "WORKSPACE_ADMINISTRATION_FAILED", "Workspace administration could not be loaded", nil)
+		return
+	}
+
+	response := workspaceAdministrationResponse(state)
+	var accessService access.WorkspaceAccessService
+	var accessErr error
+	if m.handler.ReadModel.AccessService != nil {
+		accessService, accessErr = m.handler.ReadModel.AccessService()
+	}
+	if accessErr != nil {
+		apitransport.WriteProblem(w, r, http.StatusInternalServerError, "WORKSPACE_ACCESS_FAILED", "Workspace access details could not be loaded", nil)
+		return
+	}
+	if accessService != nil {
+		response.Owner, response.Administrators, err = workspaceAdministrationAccess(r, accessService, workspaceID)
+		if err != nil {
+			apitransport.WriteProblem(w, r, http.StatusInternalServerError, "WORKSPACE_ACCESS_FAILED", "Workspace access details could not be loaded", nil)
+			return
+		}
+	}
+	response.Capabilities = m.workspaceAdministrationCapabilities(r, accessService, workspaceID)
+	response.Links = workspaceAdministrationLinks(workspaceID, state.ProjectID, response.Capabilities)
+	apitransport.WriteJSON(w, http.StatusOK, response)
+}
+
+func workspaceAdministrationResponse(state workspace.AdministrationState) workspaceapi.WorkspaceAdministrationResponse {
+	return workspaceapi.WorkspaceAdministrationResponse{
+		Workspace: workspaceapi.WorkspaceResponse{
+			ID: string(state.Workspace.ID), Title: state.Workspace.Title, Description: state.Workspace.Description,
+			ActiveServingStateID: string(state.Workspace.ActiveServingStateID),
+			CreatedAt:            state.Workspace.CreatedAt, UpdatedAt: state.Workspace.UpdatedAt,
+		},
+		Administrators: []workspaceapi.WorkspaceAdministrationSubjectResponse{},
+		Runtime: workspaceapi.WorkspaceAdministrationRuntimeResponse{
+			Environment: state.Environment, ActiveServingStateID: string(state.Workspace.ActiveServingStateID),
+			ActiveServingStateStatus: state.ActiveServingStateStatus, ActiveServingStateSince: state.ActiveServingStateSince,
+			ProjectID: state.ProjectID, CurrentDeploymentID: state.CurrentDeploymentID,
+			CurrentDeploymentStatus: state.CurrentDeploymentStatus, CurrentDeploymentSince: state.CurrentDeploymentSince,
+			CurrentReleaseID: state.CurrentReleaseID,
+		},
+	}
+}
+
+func workspaceAdministrationAccess(r *http.Request, service access.WorkspaceAccessService, workspaceID string) (*workspaceapi.WorkspaceAdministrationSubjectResponse, []workspaceapi.WorkspaceAdministrationSubjectResponse, error) {
+	var owner *workspaceapi.WorkspaceAdministrationSubjectResponse
+	object, err := service.GetSecurableObject(r.Context(), access.WorkspaceObject(workspaceID))
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, nil, err
+	}
+	if object.OwnerPrincipalID != "" {
+		principal, principalErr := service.PrincipalByID(r.Context(), object.OwnerPrincipalID)
+		if principalErr != nil && !errors.Is(principalErr, sql.ErrNoRows) {
+			return nil, nil, principalErr
+		}
+		value := administrationPrincipalSubject(principal, object.OwnerPrincipalID, access.RoleOwner)
+		owner = &value
+	}
+
+	bindings, err := service.ListRoleBindings(r.Context(), workspaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	administrators := make([]workspaceapi.WorkspaceAdministrationSubjectResponse, 0)
+	for _, binding := range bindings {
+		if binding.Role != access.RoleOwner && binding.Role != access.RoleAdmin {
+			continue
+		}
+		displayName := firstAdministrationValue(binding.DisplayName, binding.Email, binding.GroupName, binding.SubjectID)
+		administrators = append(administrators, workspaceapi.WorkspaceAdministrationSubjectResponse{
+			SubjectType: string(binding.SubjectType), SubjectID: binding.SubjectID,
+			Email: binding.Email, DisplayName: displayName, Role: binding.Role,
+		})
+	}
+	sort.Slice(administrators, func(i, j int) bool {
+		if administrators[i].Role != administrators[j].Role {
+			return administrators[i].Role < administrators[j].Role
+		}
+		if administrators[i].SubjectType != administrators[j].SubjectType {
+			return administrators[i].SubjectType < administrators[j].SubjectType
+		}
+		return administrators[i].SubjectID < administrators[j].SubjectID
+	})
+	return owner, administrators, nil
+}
+
+func administrationPrincipalSubject(principal access.Principal, fallbackID, role string) workspaceapi.WorkspaceAdministrationSubjectResponse {
+	id := firstAdministrationValue(principal.ID, fallbackID)
+	return workspaceapi.WorkspaceAdministrationSubjectResponse{
+		SubjectType: string(access.SubjectPrincipal), SubjectID: id, Email: principal.Email,
+		DisplayName: firstAdministrationValue(principal.DisplayName, principal.Email, id), Role: role,
+	}
+}
+
+func (m *Module) workspaceAdministrationCapabilities(r *http.Request, service access.WorkspaceAccessService, workspaceID string) workspaceapi.WorkspaceAdministrationCapabilitiesResponse {
+	capabilities := workspaceapi.WorkspaceAdministrationCapabilitiesResponse{}
+	var principal workspacehttp.Principal
+	var hasPrincipal bool
+	if m.handler.ReadModel.CurrentPrincipal != nil {
+		principal, hasPrincipal = m.handler.ReadModel.CurrentPrincipal(r)
+	}
+	if !m.handler.ReadModel.AuthConfigured || (hasPrincipal && principal.DevBypass) {
+		return workspaceapi.WorkspaceAdministrationCapabilitiesResponse{
+			ManageWorkspace: true, ManageAccess: true, ManagePublications: true, ManageConnections: true,
+			ViewManagedData: true, IngestManagedData: true, PublishReleases: true, RequestDeployments: true,
+			ViewDeployments: true, UseAgent: true, ViewAgent: true,
+		}
+	}
+	if service == nil || !hasPrincipal {
+		return capabilities
+	}
+	has := func(privilege access.Privilege) bool {
+		if m.currentCredential != nil {
+			if credential, ok := m.currentCredential(r); ok && !access.TokenAllows(credential.Token, workspaceID, privilege) {
+				return false
+			}
+		}
+		decision, err := service.Authorize(r.Context(), principal.ID, privilege, access.WorkspaceObject(workspaceID))
+		return err == nil && decision.Allowed
+	}
+	capabilities.ManageWorkspace = has(access.PrivilegeManageWorkspace)
+	capabilities.ManageAccess = has(access.PrivilegeManageGrants)
+	capabilities.ManagePublications = has(access.PrivilegeManagePublications)
+	capabilities.ManageConnections = has(access.PrivilegeManageConnectionMetadata)
+	capabilities.ViewManagedData = has(access.PrivilegeViewData)
+	capabilities.IngestManagedData = has(access.PrivilegeIngestData)
+	capabilities.PublishReleases = has(access.PrivilegePublishRelease)
+	capabilities.RequestDeployments = has(access.PrivilegeRequestDeployment)
+	capabilities.ViewDeployments = has(access.PrivilegeViewItem)
+	capabilities.UseAgent = has(access.PrivilegeUseAgent)
+	capabilities.ViewAgent = has(access.PrivilegeViewAgent)
+	return capabilities
+}
+
+func workspaceAdministrationLinks(workspaceID, projectID string, capabilities workspaceapi.WorkspaceAdministrationCapabilitiesResponse) workspaceapi.WorkspaceAdministrationLinksResponse {
+	workspacePath := "/api/v1/workspaces/" + url.PathEscape(workspaceID)
+	links := workspaceapi.WorkspaceAdministrationLinksResponse{
+		Self: workspacePath + "/administration", Workspace: workspacePath,
+	}
+	if capabilities.ManageAccess {
+		links.Groups = workspacePath + "/groups"
+		links.Roles = workspacePath + "/roles"
+		links.RoleBindings = workspacePath + "/role-bindings"
+		links.Grants = workspacePath + "/grants"
+	}
+	if capabilities.ManagePublications {
+		links.Publications = workspacePath + "/dashboard-publications"
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID != "" {
+		projectPath := "/api/v1/projects/" + url.PathEscape(projectID)
+		if capabilities.ViewManagedData {
+			links.ManagedConnections = projectPath + "/connections"
+		}
+		if capabilities.PublishReleases {
+			links.Releases = projectPath + "/releases"
+		}
+		if capabilities.ViewDeployments {
+			links.Deployments = projectPath + "/deployments"
+		}
+	}
+	if capabilities.ViewAgent {
+		links.AgentConversations = "/api/v1/agent/conversations"
+	}
+	return links
+}
+
+func firstAdministrationValue(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
 
 func (m *Module) GetWorkspace(w http.ResponseWriter, r *http.Request, workspaceID string) {
 	if m == nil || m.handler.ReadModel.WorkspaceRepository == nil {

--- a/internal/workspace/module/apigen.go
+++ b/internal/workspace/module/apigen.go
@@ -21,6 +21,10 @@ func (h workspaceAPIGenHandler) GetWorkspace(w http.ResponseWriter, r *http.Requ
 	h.module.GetWorkspace(w, r, workspaceID)
 }
 
+func (h workspaceAPIGenHandler) GetWorkspaceAdministration(w http.ResponseWriter, r *http.Request, workspaceID string) {
+	h.module.GetWorkspaceAdministration(w, r, workspaceID)
+}
+
 func (h workspaceAPIGenHandler) GetWorkspaceActiveAssetGraph(w http.ResponseWriter, r *http.Request) {
 	h.module.HTTP().ActiveDeploymentGraph(w, r)
 }

--- a/internal/workspace/module/workspace_administration_test.go
+++ b/internal/workspace/module/workspace_administration_test.go
@@ -1,0 +1,204 @@
+package module
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	accesssqlite "github.com/flidai/leapview/internal/access/sqlite"
+	"github.com/flidai/leapview/internal/platform"
+	"github.com/flidai/leapview/internal/workspace"
+	workspaceapi "github.com/flidai/leapview/internal/workspace/api"
+	workspacesqlite "github.com/flidai/leapview/internal/workspace/sqlite"
+)
+
+func TestWorkspaceAdministrationReturnsScopedAccessAndCapabilityLinks(t *testing.T) {
+	store, err := platform.Open(t.Context(), filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	accessRepo := accesssqlite.NewRepository(store.SQLDB())
+	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
+	for _, input := range []workspace.EnsureInput{{ID: "sales", Title: "Sales"}, {ID: "other", Title: "Other"}} {
+		if err := workspaceRepo.Ensure(t.Context(), input); err != nil {
+			t.Fatal(err)
+		}
+	}
+	owner, err := accessRepo.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "sales-owner", Kind: access.PrincipalKindUser, Email: "owner@example.test", DisplayName: "Sales Owner",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	admin, err := accessRepo.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "sales-admin", Kind: access.PrincipalKindUser, Email: "admin@example.test", DisplayName: "Sales Admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherAdmin, err := accessRepo.UpsertPrincipal(t.Context(), access.PrincipalInput{
+		ID: "other-admin", Kind: access.PrincipalKindUser, Email: "other@example.test", DisplayName: "Other Admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := accessRepo.UpsertSecurableObject(t.Context(), access.WorkspaceObject("sales"), owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := accessRepo.CreateRoleBinding(t.Context(), access.RoleBindingInput{
+		ID: "sales-admin-binding", WorkspaceID: "sales", SubjectType: access.SubjectPrincipal, SubjectID: admin.ID, Role: access.RoleAdmin,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := accessRepo.CreateRoleBinding(t.Context(), access.RoleBindingInput{
+		ID: "other-admin-binding", WorkspaceID: "other", SubjectType: access.SubjectPrincipal, SubjectID: otherAdmin.ID, Role: access.RoleAdmin,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	module, err := Build(t.Context(), Config{
+		ReadModel: workspaceRepo, AccessService: accessRepo, RuntimeEnvironment: "prod",
+		Environment: func(*http.Request) string { return "prod" },
+		CurrentPrincipal: func(*http.Request) (Principal, bool) {
+			return Principal{ID: admin.ID, Email: admin.Email, DisplayName: admin.DisplayName}, true
+		},
+		AuthConfigured: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/sales/administration", nil)
+	module.GetWorkspaceAdministration(recorder, request, "sales")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response workspaceapi.WorkspaceAdministrationResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, recorder.Body.String())
+	}
+	if response.Workspace.ID != "sales" || response.Owner == nil || response.Owner.SubjectID != owner.ID {
+		t.Fatalf("workspace/owner = %#v / %#v", response.Workspace, response.Owner)
+	}
+	if len(response.Administrators) != 1 || response.Administrators[0].SubjectID != admin.ID || response.Administrators[0].Role != access.RoleAdmin {
+		t.Fatalf("administrators = %#v", response.Administrators)
+	}
+	if response.Administrators[0].SubjectID == otherAdmin.ID {
+		t.Fatalf("other workspace administrator leaked: %#v", response.Administrators)
+	}
+	if !response.Capabilities.ManageWorkspace || !response.Capabilities.ManageAccess || !response.Capabilities.ManagePublications {
+		t.Fatalf("admin capabilities = %#v", response.Capabilities)
+	}
+	if response.Links.RoleBindings != "/api/v1/workspaces/sales/role-bindings" || response.Links.Publications != "/api/v1/workspaces/sales/dashboard-publications" {
+		t.Fatalf("domain links = %#v", response.Links)
+	}
+	if response.Links.ManagedConnections != "" || response.Links.Releases != "" || response.Links.Deployments != "" {
+		t.Fatalf("project links emitted without an active project: %#v", response.Links)
+	}
+}
+
+func TestWorkspaceAdministrationLinksRequireCollectionViewPrivileges(t *testing.T) {
+	links := workspaceAdministrationLinks("sales team", "project", workspaceapi.WorkspaceAdministrationCapabilitiesResponse{
+		ViewManagedData: true,
+		ViewDeployments: true,
+		ViewAgent:       true,
+	})
+	if links.ManagedConnections != "/api/v1/projects/project/connections" {
+		t.Fatalf("managed connections link = %q", links.ManagedConnections)
+	}
+	if links.Deployments != "/api/v1/projects/project/deployments" {
+		t.Fatalf("deployments link = %q", links.Deployments)
+	}
+	if links.AgentConversations != "/api/v1/agent/conversations" {
+		t.Fatalf("agent conversations link = %q", links.AgentConversations)
+	}
+
+	actionOnly := workspaceAdministrationLinks("sales", "project", workspaceapi.WorkspaceAdministrationCapabilitiesResponse{
+		IngestManagedData:  true,
+		RequestDeployments: true,
+		UseAgent:           true,
+	})
+	if actionOnly.ManagedConnections != "" || actionOnly.Deployments != "" || actionOnly.AgentConversations != "" {
+		t.Fatalf("collection links emitted from action-only privileges: %#v", actionOnly)
+	}
+}
+
+type administrationReadModel struct {
+	workspace.ReadModel
+	state workspace.AdministrationState
+}
+
+func (m administrationReadModel) AdministrationByID(context.Context, workspace.WorkspaceID, string) (workspace.AdministrationState, error) {
+	return m.state, nil
+}
+
+func TestGetWorkspaceAdministrationNormalizesPublicTimestamps(t *testing.T) {
+	state := workspace.AdministrationState{
+		Workspace: workspace.Summary{
+			ID: "sales", CreatedAt: "2026-08-10 11:12:13", UpdatedAt: "2026-08-10 11:13:14.123456789",
+		},
+		Environment:             "prod",
+		ActiveServingStateSince: "2026-08-10T13:14:15+02:00",
+		CurrentDeploymentSince:  "2026-08-10 11:15:16",
+	}
+	module, err := Build(t.Context(), Config{ReadModel: administrationReadModel{state: state}, RuntimeEnvironment: "prod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	module.GetWorkspaceAdministration(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/sales/administration", nil), "sales")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response workspaceapi.WorkspaceAdministrationResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, recorder.Body.String())
+	}
+	for field, value := range map[string]string{
+		"workspace.createdAt":             response.Workspace.CreatedAt,
+		"workspace.updatedAt":             response.Workspace.UpdatedAt,
+		"runtime.activeServingStateSince": response.Runtime.ActiveServingStateSince,
+		"runtime.currentDeploymentSince":  response.Runtime.CurrentDeploymentSince,
+	} {
+		parsed, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil {
+			t.Fatalf("%s = %q is not RFC3339: %v", field, value, err)
+		}
+		if parsed.Location() != time.UTC {
+			t.Fatalf("%s = %q is not UTC", field, value)
+		}
+	}
+}
+
+func TestGetWorkspaceAdministrationOmitsEmptyOptionalTimestamps(t *testing.T) {
+	state := workspace.AdministrationState{
+		Workspace: workspace.Summary{ID: "sales", CreatedAt: "2026-08-10 11:12:13", UpdatedAt: "2026-08-10 11:13:14"},
+	}
+	module, err := Build(t.Context(), Config{ReadModel: administrationReadModel{state: state}, RuntimeEnvironment: "prod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	module.GetWorkspaceAdministration(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/sales/administration", nil), "sales")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Runtime map[string]any `json:"runtime"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, recorder.Body.String())
+	}
+	for _, field := range []string{"activeServingStateSince", "currentDeploymentSince"} {
+		if _, present := response.Runtime[field]; present {
+			t.Fatalf("empty optional field %q was emitted: %s", field, recorder.Body.String())
+		}
+	}
+}

--- a/internal/workspace/repository.go
+++ b/internal/workspace/repository.go
@@ -16,6 +16,26 @@ type Summary struct {
 	UpdatedAt            string
 }
 
+// AdministrationState is the workspace-owned operational projection used by
+// administration clients. Deployments and releases remain owned by their
+// respective domains; this projection only identifies the currently active
+// resources so clients can follow their canonical API links.
+type AdministrationState struct {
+	Workspace                Summary
+	Environment              string
+	ActiveServingStateStatus string
+	ActiveServingStateSince  string
+	ProjectID                string
+	CurrentDeploymentID      string
+	CurrentDeploymentStatus  string
+	CurrentDeploymentSince   string
+	CurrentReleaseID         string
+}
+
+type AdministrationReadModel interface {
+	AdministrationByID(ctx context.Context, id WorkspaceID, environment string) (AdministrationState, error)
+}
+
 type AssetVersion struct {
 	ServingStateID ServingStateID
 	WorkspaceID    WorkspaceID

--- a/internal/workspace/sqlite/queries/workspace.sql
+++ b/internal/workspace/sqlite/queries/workspace.sql
@@ -45,6 +45,42 @@ LEFT JOIN assets a
  AND a.logical_asset_id = 'catalog:' || w.id
 WHERE w.id = ?;
 
+-- name: GetWorkspaceAdministration :one
+SELECT
+  w.id,
+  CAST(CASE WHEN catalog.title IS NOT NULL AND catalog.title <> '' THEN catalog.title ELSE w.title END AS TEXT) AS title,
+  CAST(CASE WHEN catalog.description IS NOT NULL THEN catalog.description ELSE w.description END AS TEXT) AS description,
+  COALESCE(active.serving_state_id, '') AS active_serving_state_id,
+  w.created_at,
+  w.updated_at,
+  COALESCE(serving.status, '') AS active_serving_state_status,
+  COALESCE(serving.activated_at, '') AS active_serving_state_since,
+  COALESCE(serving.project_id, '') AS project_id,
+  COALESCE(deployment.id, '') AS current_deployment_id,
+  COALESCE(deployment.status, '') AS current_deployment_status,
+  COALESCE(deployment.activated_at, '') AS current_deployment_since,
+  COALESCE(link.release_id, '') AS current_release_id
+FROM workspaces w
+LEFT JOIN workspace_active_serving_states active
+  ON active.workspace_id = w.id AND active.environment = sqlc.arg(environment)
+LEFT JOIN serving_states serving ON serving.id = active.serving_state_id
+LEFT JOIN assets catalog
+  ON catalog.serving_state_id = active.serving_state_id
+ AND catalog.asset_type = 'catalog'
+ AND catalog.logical_asset_id = 'catalog:' || w.id
+LEFT JOIN project_deployment_targets target
+  ON target.serving_state_id = active.serving_state_id
+ AND target.workspace_id = w.id
+ AND target.status = 'active'
+LEFT JOIN project_deployments deployment
+  ON deployment.id = target.deployment_id
+ AND deployment.environment = sqlc.arg(environment)
+ AND deployment.status = 'active'
+LEFT JOIN api_deployment_releases link ON link.deployment_id = deployment.id
+WHERE w.id = sqlc.arg(id)
+ORDER BY deployment.activated_at DESC, deployment.id DESC
+LIMIT 1;
+
 -- Workspace-owned catalog projection over the active serving generation.
 
 -- name: GetActiveServingState :one

--- a/internal/workspace/sqlite/repository.go
+++ b/internal/workspace/sqlite/repository.go
@@ -104,6 +104,31 @@ func (r *Repository) ByIDWithActiveMetadata(ctx context.Context, id workspace.Wo
 	return mapWorkspaceWithActiveMetadata(row.ID, queryText(row.Title), queryText(row.Description), row.ActiveServingStateID, row.CreatedAt, row.UpdatedAt), nil
 }
 
+func (r *Repository) AdministrationByID(ctx context.Context, id workspace.WorkspaceID, environment string) (workspace.AdministrationState, error) {
+	environment = normalizedEnvironment(environment)
+	row, err := r.q.GetWorkspaceAdministration(ctx, platformdb.GetWorkspaceAdministrationParams{
+		Environment: environment,
+		ID:          string(id),
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return workspace.AdministrationState{}, workspace.ErrNotFound
+		}
+		return workspace.AdministrationState{}, err
+	}
+	return workspace.AdministrationState{
+		Workspace: workspace.Summary{
+			ID: workspace.WorkspaceID(row.ID), Title: row.Title, Description: row.Description,
+			ActiveServingStateID: workspace.ServingStateID(row.ActiveServingStateID),
+			CreatedAt:            row.CreatedAt, UpdatedAt: row.UpdatedAt,
+		},
+		Environment: environment, ActiveServingStateStatus: row.ActiveServingStateStatus,
+		ActiveServingStateSince: row.ActiveServingStateSince, ProjectID: row.ProjectID,
+		CurrentDeploymentID: row.CurrentDeploymentID, CurrentDeploymentStatus: row.CurrentDeploymentStatus,
+		CurrentDeploymentSince: row.CurrentDeploymentSince, CurrentReleaseID: row.CurrentReleaseID,
+	}, nil
+}
+
 func (r *Repository) ActiveServingStateGraph(ctx context.Context, id workspace.WorkspaceID, environment string) (workspace.AssetGraph, bool, error) {
 	activeServingState, err := r.q.GetActiveServingState(ctx, platformdb.GetActiveServingStateParams{
 		WorkspaceID: string(id),

--- a/internal/workspace/sqlite/repository_test.go
+++ b/internal/workspace/sqlite/repository_test.go
@@ -55,6 +55,100 @@ func TestRepositoryEnsureRejectsBlankWorkspaceID(t *testing.T) {
 	}
 }
 
+func TestRepositoryAdministrationStateIsWorkspaceAndEnvironmentScoped(t *testing.T) {
+	ctx := context.Background()
+	store, err := platform.Open(ctx, filepath.Join(t.TempDir(), "leapview.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
+	servingRepo := servingstatesqlite.NewRepository(store.SQLDB())
+	for _, input := range []workspace.EnsureInput{
+		{ID: "sales", Title: "Sales", Description: "Sales workspace"},
+		{ID: "other", Title: "Other", Description: "Other workspace"},
+	} {
+		if err := workspaceRepo.Ensure(ctx, input); err != nil {
+			t.Fatalf("ensure workspace %s: %v", input.ID, err)
+		}
+	}
+	salesState := seedVersionDeployment(t, ctx, servingRepo, versionSeed{
+		WorkspaceID: "sales", Environment: "prod", Status: servingstate.StatusActive,
+		Source: servingstate.SourcePublish, VersionKey: "sales",
+	})
+	otherState := seedVersionDeployment(t, ctx, servingRepo, versionSeed{
+		WorkspaceID: "other", Environment: "prod", Status: servingstate.StatusActive,
+		Source: servingstate.SourcePublish, VersionKey: "other",
+	})
+	if _, err := store.SQLDB().ExecContext(ctx, `UPDATE serving_states SET project_id = 'shared-project' WHERE id = ?`, salesState.ID); err != nil {
+		t.Fatalf("scope sales serving state: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `UPDATE serving_states SET project_id = 'shared-project' WHERE id = ?`, otherState.ID); err != nil {
+		t.Fatalf("scope other serving state: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `
+		INSERT INTO api_releases (
+			id, project_id, project_digest, request_digest, idempotency_key, status,
+			manifest_json, created_by, finalized_at
+		) VALUES
+			('release-sales', 'shared-project', 'sha256:sales', 'sha256:sales-request', 'release-sales', 'ready', '{"workspaces":[],"connections":[]}', 'publisher', CURRENT_TIMESTAMP),
+			('release-other', 'shared-project', 'sha256:other', 'sha256:other-request', 'release-other', 'ready', '{"workspaces":[],"connections":[]}', 'publisher', CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatalf("insert releases: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `
+		INSERT INTO project_deployments (
+			id, project_id, environment, request_digest, status, created_by, activated_at
+		) VALUES
+			('deployment-sales', 'shared-project', 'prod', 'sha256:sales-deploy', 'active', 'deployer', CURRENT_TIMESTAMP),
+			('deployment-other', 'shared-project', 'prod', 'sha256:other-deploy', 'active', 'deployer', CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatalf("insert deployments: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `
+		INSERT INTO project_deployment_targets (
+			deployment_id, workspace_id, serving_state_id, status, activated_at
+		) VALUES
+			('deployment-sales', 'sales', ?, 'active', CURRENT_TIMESTAMP),
+			('deployment-other', 'other', ?, 'active', CURRENT_TIMESTAMP)`, salesState.ID, otherState.ID); err != nil {
+		t.Fatalf("insert deployment targets: %v", err)
+	}
+	if _, err := store.SQLDB().ExecContext(ctx, `
+		INSERT INTO api_deployment_releases (deployment_id, project_id, release_id)
+		VALUES
+			('deployment-sales', 'shared-project', 'release-sales'),
+			('deployment-other', 'shared-project', 'release-other')`); err != nil {
+		t.Fatalf("link deployment releases: %v", err)
+	}
+
+	state, err := workspaceRepo.AdministrationByID(ctx, "sales", "prod")
+	if err != nil {
+		t.Fatalf("administration state: %v", err)
+	}
+	if state.Workspace.ID != "sales" || state.Workspace.Title != "Sales" || state.Environment != "prod" {
+		t.Fatalf("workspace identity = %#v", state)
+	}
+	if state.Workspace.ActiveServingStateID != workspace.ServingStateID(salesState.ID) || state.ActiveServingStateStatus != "active" {
+		t.Fatalf("active serving state = %#v", state)
+	}
+	if state.ProjectID != "shared-project" || state.CurrentDeploymentID != "deployment-sales" || state.CurrentReleaseID != "release-sales" {
+		t.Fatalf("current release state = %#v", state)
+	}
+	if state.CurrentDeploymentID == "deployment-other" || state.CurrentReleaseID == "release-other" {
+		t.Fatalf("administration state leaked other workspace: %#v", state)
+	}
+
+	devState, err := workspaceRepo.AdministrationByID(ctx, "sales", "dev")
+	if err != nil {
+		t.Fatalf("dev administration state: %v", err)
+	}
+	if devState.Workspace.ActiveServingStateID != "" || devState.ProjectID != "" || devState.CurrentDeploymentID != "" || devState.CurrentReleaseID != "" {
+		t.Fatalf("prod state leaked into dev: %#v", devState)
+	}
+	if _, err := workspaceRepo.AdministrationByID(ctx, "missing", "prod"); !errors.Is(err, workspace.ErrNotFound) {
+		t.Fatalf("missing administration error = %v, want workspace.ErrNotFound", err)
+	}
+}
+
 func TestRepositoryActiveServingStateGraphUsesLogicalAssetIDs(t *testing.T) {
 	ctx := context.Background()
 	store, err := platform.Open(ctx, filepath.Join(t.TempDir(), "leapview.db"))

--- a/static/app.input.css
+++ b/static/app.input.css
@@ -24,6 +24,11 @@
 /* color */
 @import '@primer/primitives/dist/css/functional/themes/light.css';
 @import '@primer/primitives/dist/css/functional/themes/dark.css';
+@import '@primer/primitives/dist/css/functional/themes/dark-dimmed.css';
+@import '@primer/primitives/dist/css/functional/themes/light-colorblind.css';
+@import '@primer/primitives/dist/css/functional/themes/dark-colorblind.css';
+@import '@primer/primitives/dist/css/functional/themes/light-tritanopia.css';
+@import '@primer/primitives/dist/css/functional/themes/dark-tritanopia.css';
 
 @import 'tailwindcss' source(none);
 
@@ -135,6 +140,7 @@
   --container-card: 21rem;
   --container-inspector: calc(100vw - var(--base-size-32));
   --container-login-panel: 24.125rem;
+  --container-settings: var(--overlay-width-large);
   --container-workspace-detail: 72rem;
   --container-workspace-search: 32rem;
 
@@ -382,13 +388,16 @@
     --lv-icon-sm: var(--base-size-16);
     --lv-icon-md: var(--base-size-24);
     --lv-page-content-max-width: var(--container-workspace-detail);
+    --lv-settings-content-max-width: var(--container-settings);
     --lv-workspace-detail-max-width: var(--container-workspace-detail);
     --lv-login-panel-width: var(--container-login-panel);
     --lv-lineage-graph-height: var(--spacing-inspector-panel);
     --lv-dashboard-filter-open-width: var(--overlay-width-small);
     --lv-dashboard-agent-width: calc(var(--base-size-128) * 3 + var(--base-size-36));
     --lv-sidebar-width-expanded: calc(var(--base-size-128) + var(--base-size-80) + var(--base-size-40));
+    --lv-admin-sidebar-width-expanded: calc(var(--base-size-128) + var(--base-size-64));
     --lv-sidebar-width-collapsed: var(--base-size-48);
+    --lv-sidebar-resized-width: initial;
     --lv-page-rail-width-collapsed: calc(var(--base-size-40) - var(--base-size-2));
     --lv-sub-sidebar-width-expanded: calc(var(--base-size-128) + var(--base-size-16));
     --lv-spinner-size-sm: calc(var(--base-size-8) + var(--base-size-2));

--- a/static/theme.dom.test.ts
+++ b/static/theme.dom.test.ts
@@ -16,6 +16,11 @@ beforeAll(async () => {
       response.end(testDocument())
       return
     }
+    if (url.pathname === '/saved-theme') {
+      response.setHeader('content-type', 'text/html')
+      response.end(testDocument('dark'))
+      return
+    }
     if (url.pathname === '/theme.js') {
       response.setHeader('content-type', 'text/javascript')
       response.end(await readFile(join(process.cwd(), 'static/theme.js'), 'utf8'))
@@ -68,23 +73,83 @@ test('explicit theme changes still emit applied event', async () => {
     await page.waitForFunction(() => (window as any).themeBooted === true)
     await page.evaluate(() => {
       ;(window as any).themeAppliedEvents = []
-      document.dispatchEvent(new CustomEvent('leapview-theme-change', { detail: { mode: 'dark' } }))
+      document.dispatchEvent(new CustomEvent('leapview-theme-change', { detail: { mode: 'dark_dimmed' } }))
     })
     await page.waitForFunction(() => (window as any).themeAppliedEvents.length === 1)
 
     const state = await page.evaluate(() => ({
       events: (window as any).themeAppliedEvents,
       colorMode: document.documentElement.dataset.colorMode,
+      darkTheme: document.documentElement.dataset.darkTheme,
       colorScheme: document.documentElement.style.colorScheme,
       storedMode: localStorage.getItem('leapview-color-mode'),
     }))
 
     expect(state).toEqual({
-      events: [{ mode: 'dark', resolvedMode: 'dark' }],
+      events: [{ mode: 'dark_dimmed', resolvedMode: 'dark' }],
       colorMode: 'dark',
+      darkTheme: 'dark_dimmed',
       colorScheme: 'dark',
-      storedMode: 'dark',
+      storedMode: 'dark_dimmed',
     })
+  } finally {
+    await page.close()
+  }
+})
+
+test('supported Primer themes apply their native color mode and theme identifiers', async () => {
+  const page = await browser.newPage()
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (window as any).themeBooted === true)
+    const states = await page.evaluate(async () => {
+      const preferences = [
+        'light',
+        'dark',
+        'dark_dimmed',
+        'light_colorblind',
+        'dark_colorblind',
+        'light_tritanopia',
+        'dark_tritanopia',
+      ]
+      const results = []
+      for (const mode of preferences) {
+        document.dispatchEvent(new CustomEvent('leapview-theme-change', { detail: { mode } }))
+        await new Promise((resolve) => requestAnimationFrame(resolve))
+        results.push({
+          mode,
+          colorMode: document.documentElement.dataset.colorMode,
+          lightTheme: document.documentElement.dataset.lightTheme,
+          darkTheme: document.documentElement.dataset.darkTheme,
+        })
+      }
+      return results
+    })
+
+    expect(states).toEqual([
+      { mode: 'light', colorMode: 'light', lightTheme: 'light', darkTheme: 'dark' },
+      { mode: 'dark', colorMode: 'dark', lightTheme: 'light', darkTheme: 'dark' },
+      { mode: 'dark_dimmed', colorMode: 'dark', lightTheme: 'light', darkTheme: 'dark_dimmed' },
+      { mode: 'light_colorblind', colorMode: 'light', lightTheme: 'light_colorblind', darkTheme: 'dark' },
+      { mode: 'dark_colorblind', colorMode: 'dark', lightTheme: 'light', darkTheme: 'dark_colorblind' },
+      { mode: 'light_tritanopia', colorMode: 'light', lightTheme: 'light_tritanopia', darkTheme: 'dark' },
+      { mode: 'dark_tritanopia', colorMode: 'dark', lightTheme: 'light', darkTheme: 'dark_tritanopia' },
+    ])
+  } finally {
+    await page.close()
+  }
+})
+
+test('authenticated saved theme overrides stale browser storage', async () => {
+  const page = await browser.newPage()
+  try {
+    await page.goto(`${baseURL}/saved-theme`)
+    await page.waitForFunction(() => (window as any).themeBooted === true)
+    const state = await page.evaluate(() => ({
+      colorMode: document.documentElement.dataset.colorMode,
+      storedMode: localStorage.getItem('leapview-color-mode'),
+    }))
+    expect(state).toEqual({ colorMode: 'dark', storedMode: 'dark' })
   } finally {
     await page.close()
   }
@@ -115,10 +180,10 @@ test('view transition abort rejections are treated as progressive enhancement mi
   }
 })
 
-function testDocument(): string {
+function testDocument(savedTheme = ''): string {
   return `
     <!doctype html>
-    <html data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
+    <html data-color-mode="auto" data-light-theme="light" data-dark-theme="dark"${savedTheme ? ` data-theme-preference="${savedTheme}"` : ''}>
       <head>
         <script>
           localStorage.setItem('leapview-color-mode', 'light');

--- a/static/theme.js
+++ b/static/theme.js
@@ -2,7 +2,26 @@ const storageKey = 'leapview-color-mode';
 const root = document.documentElement;
 const media = window.matchMedia?.('(prefers-color-scheme: dark)');
 const nextModes = { system: 'light', light: 'dark', dark: 'system' };
-const modeLabels = { system: 'System theme', light: 'Light theme', dark: 'Dark theme' };
+const themes = {
+  system: { colorMode: 'auto', lightTheme: 'light', darkTheme: 'dark' },
+  light: { colorMode: 'light', lightTheme: 'light', darkTheme: 'dark' },
+  dark: { colorMode: 'dark', lightTheme: 'light', darkTheme: 'dark' },
+  dark_dimmed: { colorMode: 'dark', lightTheme: 'light', darkTheme: 'dark_dimmed' },
+  light_colorblind: { colorMode: 'light', lightTheme: 'light_colorblind', darkTheme: 'dark' },
+  dark_colorblind: { colorMode: 'dark', lightTheme: 'light', darkTheme: 'dark_colorblind' },
+  light_tritanopia: { colorMode: 'light', lightTheme: 'light_tritanopia', darkTheme: 'dark' },
+  dark_tritanopia: { colorMode: 'dark', lightTheme: 'light', darkTheme: 'dark_tritanopia' },
+};
+const modeLabels = {
+  system: 'System theme',
+  light: 'Light default',
+  dark: 'Dark default',
+  dark_dimmed: 'Soft dark',
+  light_colorblind: 'Light protanopia and deuteranopia',
+  dark_colorblind: 'Dark protanopia and deuteranopia',
+  light_tritanopia: 'Light tritanopia',
+  dark_tritanopia: 'Dark tritanopia',
+};
 let lastAppliedEvent = 0;
 
 window.addEventListener('unhandledrejection', (event) => {
@@ -18,17 +37,21 @@ window.addEventListener('unhandledrejection', (event) => {
 });
 
 function storedMode() {
+  const preference = root.dataset.themePreference;
+  if (Object.hasOwn(themes, preference)) return preference;
   const saved = localStorage.getItem(storageKey);
-  if (saved === 'system' || saved === 'light' || saved === 'dark') return saved;
+  if (Object.hasOwn(themes, saved)) return saved;
   return 'system';
 }
 
 function setMode(mode, options = {}) {
-  const next = mode === 'light' || mode === 'dark' ? mode : 'system';
-  const resolved = next === 'system' ? (media?.matches ? 'dark' : 'light') : next;
-  root.dataset.colorMode = next === 'system' ? 'auto' : next;
-  root.dataset.lightTheme = 'light';
-  root.dataset.darkTheme = 'dark';
+  const next = Object.hasOwn(themes, mode) ? mode : 'system';
+  const theme = themes[next];
+  const resolved = theme.colorMode === 'auto' ? (media?.matches ? 'dark' : 'light') : theme.colorMode;
+  root.dataset.colorMode = theme.colorMode;
+  root.dataset.themePreference = next;
+  root.dataset.lightTheme = theme.lightTheme;
+  root.dataset.darkTheme = theme.darkTheme;
   root.style.colorScheme = resolved;
   localStorage.setItem(storageKey, next);
   for (const button of document.querySelectorAll('[data-theme-value]')) {

--- a/web/components/admin/admin-page.dom.test.ts
+++ b/web/components/admin/admin-page.dom.test.ts
@@ -81,39 +81,293 @@ test('publications admin renders lifecycle controls and emits typed commands', a
   }
 })
 
-test('profile admin renders the signed-in identity with read-only fields', async () => {
-  const page = await browser.newPage({ viewport: { width: 1100, height: 760 } })
+test('profile settings renders the signed-in identity and editable local fields', async () => {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 760 } })
   try {
     await page.goto(baseURL)
     await page.waitForFunction(() => customElements.get('lv-admin-page'))
     const state = await page.evaluate(async () => {
       const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev') as any
       mergePatch({ page: {
-        kind: 'admin', title: 'Profile', active: 'profile', headerTitle: 'Profile', headerDetail: '',
-        profile: { id: 'principal-1', email: 'jacob@example.com', displayName: 'Jacob Nielsen', title: '', username: 'jacob', profilePictureUrl: undefined },
+        kind: 'admin', title: 'Profile', active: 'profile', headerTitle: 'Profile', headerDetail: 'Manage your photo and display name.',
+      }, personalSettings: {
+        active: 'profile',
+        profile: { id: 'principal-1', email: 'jacob@example.com', displayName: 'Jacob Nielsen', theme: 'system', avatarUrl: '/profile/avatar.png', identitySource: 'local', canEditDisplayName: true, hasLocalPassword: true },
+        security: { localPasswordEnabled: true, sessions: [], authoringSessions: [] },
+        tokens: { items: [], scopes: [] },
       } })
       const element = document.querySelector('lv-admin-page') as any
+      await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
       await element.updateComplete
       const root = element.shadowRoot!
+      const profile = root.querySelector('lv-personal-settings') as any
+      await profile.updateComplete
+      const profileRoot = profile.shadowRoot as ShadowRoot
+      const main = root.querySelector('.main') as HTMLElement
+      const route = root.querySelector('.route') as HTMLElement
+      const header = root.querySelector('.page-header') as HTMLElement
+      const avatarTrigger = profileRoot.querySelector('.avatar-trigger') as HTMLButtonElement
+      const fieldLabel = profileRoot.querySelector('.settings-label') as HTMLElement
+      avatarTrigger.click()
+      await profile.updateComplete
+      const avatarMenuItems = Array.from(profileRoot.querySelectorAll('[role="menuitem"]')).map((item) => item.textContent?.trim())
+      const avatarMenuOpen = avatarTrigger.getAttribute('aria-expanded')
+      avatarTrigger.focus()
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      await profile.updateComplete
+      const avatarMenuClosed = !profileRoot.querySelector('[role="menu"]')
+      const avatarTriggerFocused = profileRoot.activeElement === avatarTrigger
+      let themeCommand: unknown = null
+      let appliedTheme: unknown = null
+      profile.addEventListener('lv-personal-theme-command', (event: CustomEvent) => { themeCommand = event.detail }, { once: true })
+      document.addEventListener('leapview-theme-change', (event: CustomEvent) => { appliedTheme = event.detail?.mode }, { once: true })
+      const theme = profileRoot.querySelector('select[name="theme"]') as HTMLSelectElement
+      avatarTrigger.click()
+      await profile.updateComplete
+      theme.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }))
+      await profile.updateComplete
+      const avatarMenuClosedOnOutsidePointer = !profileRoot.querySelector('[role="menu"]')
+      theme.value = 'dark_colorblind'
+      theme.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
       return {
         title: root.querySelector('h1')?.textContent?.trim(),
-        cardBorderWidth: getComputedStyle(root.querySelector('.profile-card') as HTMLElement).borderTopWidth,
-        rows: Array.from(root.querySelectorAll('.profile-row')).map((row) => row.textContent?.replace(/\s+/g, ' ').trim()),
-        initials: root.querySelector('.profile-avatar')?.textContent?.trim(),
-        editableFields: root.querySelectorAll('input, textarea, select, button').length,
+        text: profileRoot.textContent?.replace(/\s+/g, ' ').trim(),
+        nestedHeadings: profileRoot.querySelectorAll('h2').length,
+        mainCentered: Math.abs((main.getBoundingClientRect().left + main.getBoundingClientRect().width / 2) - (route.getBoundingClientRect().left + route.getBoundingClientRect().width / 2)) <= 1,
+        mainWidth: Math.round(main.getBoundingClientRect().width),
+        headerGap: Math.round(profile.getBoundingClientRect().top - header.getBoundingClientRect().bottom),
+        fieldLabelFontSize: getComputedStyle(fieldLabel).fontSize,
+        avatarMenuItems,
+        avatarMenuOpen,
+        avatarMenuClosed,
+        avatarTriggerFocused,
+        avatarMenuClosedOnOutsidePointer,
+        hasHiddenFileInput: Boolean(profileRoot.querySelector('input[type="file"].avatar-input')),
+        themeOptions: Array.from(profileRoot.querySelectorAll('select[name="theme"] option')).map((option) => option.textContent?.trim()),
+        themeCommand,
+        appliedTheme,
       }
     })
     expect(state.title).toBe('Profile')
-    expect(state.cardBorderWidth).toBe('0px')
-    expect(state.rows).toEqual(expect.arrayContaining([
-      'Profile picture JN',
-      'Email jacob@example.com',
-      'Full name Jacob Nielsen',
-      'Title Your job title or role Not set',
-      'Username One word, like a nickname or first name jacob',
-    ]))
-    expect(state.initials).toBe('JN')
-    expect(state.editableFields).toBe(0)
+    expect(state.text).toContain('Profile picture')
+    expect(state.text).toContain('jacob@example.com')
+    expect(state.text).toContain('Display name')
+    expect(state.text).toContain('Theme')
+    expect(state.themeOptions).toEqual([
+      'System',
+      'Light default',
+      'Dark default',
+      'Soft dark',
+      'Light protanopia and deuteranopia',
+      'Dark protanopia and deuteranopia',
+      'Light tritanopia',
+      'Dark tritanopia',
+    ])
+    expect(state.themeCommand).toEqual({ action: 'save', theme: 'dark_colorblind' })
+    expect(state.appliedTheme).toBe('dark_colorblind')
+    expect(state.nestedHeadings).toBe(0)
+    expect(state.mainCentered).toBe(true)
+    expect(state.mainWidth).toBe(640)
+    expect(state.headerGap).toBeGreaterThanOrEqual(16)
+    expect(state.fieldLabelFontSize).toBe('14px')
+    expect(state.avatarMenuItems).toEqual(['Change avatar', 'Remove avatar'])
+    expect(state.avatarMenuOpen).toBe('true')
+    expect(state.avatarMenuClosed).toBe(true)
+    expect(state.avatarTriggerFocused).toBe(true)
+    expect(state.avatarMenuClosedOnOutsidePointer).toBe(true)
+    expect(state.hasHiddenFileInput).toBe(true)
+  } finally {
+    await page.close()
+  }
+})
+
+test('personal API tokens use authorized scope and permission selectors', async () => {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 700 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('lv-personal-settings'))
+    const state = await page.evaluate(async () => {
+      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev') as any
+      mergePatch({ page: {
+        kind: 'admin', title: 'API tokens', active: 'api-tokens', headerTitle: 'API tokens', headerDetail: 'Manage personal API and CLI credentials.',
+      }, personalSettings: {
+        active: 'api-tokens',
+        profile: { id: 'principal-1', email: 'jacob@example.com', displayName: 'Jacob Nielsen', theme: 'system', identitySource: 'local', canEditDisplayName: true, hasLocalPassword: true },
+        security: { localPasswordEnabled: true, sessions: [], authoringSessions: [] },
+        tokens: { items: [], scopes: [
+          { kind: 'workspace', workspaceId: 'sales', label: 'Sales analytics', description: 'Revenue and pipeline reporting.', privileges: [
+            { value: 'USE_WORKSPACE', label: 'Use workspace', description: 'Open and use the workspace.', category: 'Workspace' },
+            { value: 'VIEW_ITEM', label: 'View content', description: 'View dashboards and other workspace content.', category: 'Workspace' },
+            { value: 'EDIT_ITEM', label: 'Edit content', description: 'Create and update workspace content.', category: 'Workspace' },
+            { value: 'MANAGE_ITEM', label: 'Manage content', description: 'Delete and administer workspace content.', category: 'Workspace' },
+            { value: 'QUERY_DATA', label: 'Query data', description: 'Run governed queries against workspace data.', category: 'Data' },
+            { value: 'PREVIEW_DATA', label: 'Preview data', description: 'Preview source and model data.', category: 'Data' },
+            { value: 'REFRESH_DATA', label: 'Refresh data', description: 'Start and manage data refreshes.', category: 'Data' },
+            { value: 'VIEW_DATA', label: 'View managed data', description: 'View managed-data metadata and revisions.', category: 'Data' },
+            { value: 'INGEST_DATA', label: 'Ingest data', description: 'Upload and ingest managed data.', category: 'Data' },
+            { value: 'AUTHOR_PROJECT', label: 'Author project', description: 'Create and synchronize project candidates.', category: 'Projects and releases' },
+            { value: 'PUBLISH_RELEASE', label: 'Publish releases', description: 'Publish project releases.', category: 'Projects and releases' },
+            { value: 'USE_AGENT', label: 'Use agent', description: 'Start and continue agent conversations.', category: 'Agent' },
+            { value: 'MANAGE_PUBLICATIONS', label: 'Manage publications', description: 'Configure and control public dashboards.', category: 'Administration' },
+          ] },
+          { kind: 'workspace', workspaceId: 'operations', label: 'Operations', description: 'Access limited to this workspace.', privileges: [
+            { value: 'USE_WORKSPACE', label: 'Use workspace', description: 'Open and use the workspace.', category: 'Workspace' },
+          ] },
+        ] },
+      } })
+      await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+      const admin = document.querySelector('lv-admin-page') as any
+      await admin.updateComplete
+      const personal = admin.shadowRoot.querySelector('lv-personal-settings') as any
+      await personal.updateComplete
+      const root = personal.shadowRoot as ShadowRoot
+      const scope = root.querySelector('#token-scope') as HTMLSelectElement
+      const name = root.querySelector('#token-name') as HTMLInputElement
+      const create = root.querySelector('button[type="submit"]') as HTMLButtonElement
+      const initial = {
+        scopeOptions: Array.from(scope.options).map((option) => option.textContent?.trim()),
+        createDisabled: create.disabled,
+        rawWorkspaceField: Boolean(root.querySelector('input[placeholder*="Workspace ID"]')),
+        rawPrivilegeField: Boolean(root.querySelector('input[placeholder*="Privileges"]')),
+      }
+
+      scope.value = 'workspace:sales'
+      scope.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
+      name.value = 'Sales automation'
+      name.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      await personal.updateComplete
+      const add = root.querySelector('.permission-trigger') as HTMLButtonElement
+      add.click()
+      await personal.updateComplete
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      const menu = root.querySelector('.permission-menu') as HTMLElement
+      const permissionList = root.querySelector('.permission-list') as HTMLElement
+      const menuRect = menu.getBoundingClientRect()
+      const menuLayout = {
+        bottom: Math.round(menuRect.bottom),
+        viewportHeight: innerHeight,
+        listScrollable: permissionList.scrollHeight > permissionList.clientHeight,
+        listOverflowY: getComputedStyle(permissionList).overflowY,
+      }
+      const search = root.querySelector('.permission-search input') as HTMLInputElement
+      const searchFocused = root.activeElement === search
+      search.value = 'query'
+      search.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      await personal.updateComplete
+      const filteredPermissions = Array.from(root.querySelectorAll('.permission-option .settings-label')).map((label) => label.textContent?.trim())
+      const queryPermission = root.querySelector('input[type="checkbox"][value="QUERY_DATA"]') as HTMLInputElement
+      queryPermission.click()
+      await personal.updateComplete
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      await personal.updateComplete
+      await Promise.resolve()
+      const scopeDescription = root.querySelector('.scope-description')?.textContent?.trim()
+      const selectedPermissions = Array.from(root.querySelectorAll('.selected-permission .settings-label')).map((label) => label.textContent?.trim())
+      const triggerFocused = root.activeElement === add
+
+      let command: unknown = null
+      personal.addEventListener('lv-personal-token-command', (event: CustomEvent) => { command = event.detail }, { once: true })
+      const form = root.querySelector('.token-form') as HTMLFormElement
+      form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, composed: true, cancelable: true }))
+      await personal.updateComplete
+      const pending = {
+        name: (root.querySelector('#token-name') as HTMLInputElement).value,
+        selectedPermissions: root.querySelectorAll('.selected-permission').length,
+        buttonText: (root.querySelector('button[type="submit"]') as HTMLButtonElement).textContent?.trim(),
+      }
+      document.dispatchEvent(new CustomEvent('datastar-fetch', { detail: { type: 'error', argsRaw: { status: '403' } } }))
+      await personal.updateComplete
+      const failed = {
+        name: (root.querySelector('#token-name') as HTMLInputElement).value,
+        selectedPermissions: root.querySelectorAll('.selected-permission').length,
+        error: root.querySelector('[role="alert"]')?.textContent?.trim(),
+        createDisabled: (root.querySelector('button[type="submit"]') as HTMLButtonElement).disabled,
+      }
+      form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, composed: true, cancelable: true }))
+      mergePatch({ personalSettings: { tokens: { items: [
+        { id: 'token-1', name: 'Sales automation', workspaceId: 'sales', privileges: ['QUERY_DATA'], createdAt: '2026-08-12T06:40:00Z' },
+      ], newToken: 'lv_created_secret' } } })
+      await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+      await personal.updateComplete
+      const succeeded = {
+        name: (root.querySelector('#token-name') as HTMLInputElement).value,
+        selectedPermissions: root.querySelectorAll('.selected-permission').length,
+        tokenNames: Array.from(root.querySelectorAll('.card:last-child .settings-label')).map((element) => element.textContent?.trim()),
+        notice: root.querySelector('[role="status"]')?.textContent?.trim(),
+      }
+      return {
+        initial,
+        menuLayout,
+        scopeDescription,
+        filteredPermissions,
+        selectedPermissions,
+        menuClosed: !root.querySelector('.permission-menu'),
+        searchFocused,
+        triggerFocused,
+        command,
+        pending,
+        failed,
+        succeeded,
+      }
+    })
+
+    await page.setViewportSize({ width: 390, height: 700 })
+    const mobile = await page.evaluate(async () => {
+      const admin = document.querySelector('lv-admin-page') as any
+      const personal = admin.shadowRoot.querySelector('lv-personal-settings') as any
+      const root = personal.shadowRoot as ShadowRoot
+      const scope = root.querySelector('#token-scope') as HTMLSelectElement
+      scope.value = 'workspace:sales'
+      scope.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
+      await personal.updateComplete
+      ;(root.querySelector('.permission-trigger') as HTMLButtonElement).click()
+      await personal.updateComplete
+      const menu = root.querySelector('.permission-menu') as HTMLElement
+      const close = root.querySelector('.permission-menu-close') as HTMLButtonElement
+      const rect = menu.getBoundingClientRect()
+      const state = {
+        position: getComputedStyle(menu).position,
+        left: Math.round(rect.left), right: Math.round(rect.right), bottom: Math.round(rect.bottom),
+        viewportWidth: innerWidth, viewportHeight: innerHeight,
+      }
+      close.click()
+      await personal.updateComplete
+      return { ...state, closed: !root.querySelector('.permission-menu') }
+    })
+
+    expect(state.initial).toEqual({
+      scopeOptions: ['Choose a scope', 'Sales analytics', 'Operations'],
+      createDisabled: true,
+      rawWorkspaceField: false,
+      rawPrivilegeField: false,
+    })
+    expect(state.scopeDescription).toBe('Revenue and pipeline reporting.')
+    expect(state.menuLayout.bottom).toBeLessThanOrEqual(state.menuLayout.viewportHeight - 16)
+    expect(state.menuLayout.listScrollable).toBe(true)
+    expect(state.menuLayout.listOverflowY).toBe('auto')
+    expect(state.filteredPermissions).toEqual(['Query data'])
+    expect(state.selectedPermissions).toEqual(['Query data'])
+    expect(state.menuClosed).toBe(true)
+    expect(state.searchFocused).toBe(true)
+    expect(state.triggerFocused).toBe(true)
+    expect(state.command).toMatchObject({
+      action: 'create', name: 'Sales automation', workspaceId: 'sales', privileges: ['QUERY_DATA'],
+    })
+    expect(state.pending).toEqual({ name: 'Sales automation', selectedPermissions: 1, buttonText: 'Creating…' })
+    expect(state.failed).toEqual({
+      name: 'Sales automation', selectedPermissions: 1,
+      error: 'Token creation failed because this page expired. Reload the page and try again.',
+      createDisabled: false,
+    })
+    expect(state.succeeded.name).toBe('')
+    expect(state.succeeded.selectedPermissions).toBe(0)
+    expect(state.succeeded.tokenNames).toContain('Sales automation')
+    expect(state.succeeded.notice).toContain('Copy this token now')
+    expect(mobile.position).toBe('fixed')
+    expect(mobile.left).toBeGreaterThanOrEqual(16)
+    expect(mobile.right).toBeLessThanOrEqual(mobile.viewportWidth - 16)
+    expect(mobile.bottom).toBeLessThanOrEqual(mobile.viewportHeight - 16)
+    expect(mobile.closed).toBe(true)
   } finally {
     await page.close()
   }
@@ -133,9 +387,19 @@ test('members directory list delegates search and filtering to the page stream',
       const rows = () => Array.from(root.querySelectorAll('.entity-list-table-row')).map((row: Element) => row.textContent?.replace(/\s+/g, ' ').trim())
       const initial = {
         title: root.querySelector('table')?.getAttribute('aria-label'),
-        groupLabels: Array.from(root.querySelectorAll('.entity-list-group-row')).map((row) => row.textContent?.replace(/\s+/g, ' ').trim()),
+        avatarSrc: (root.querySelector('lv-user-avatar') as any)?.shadowRoot?.querySelector('img')?.getAttribute('src'),
+        fallbackInitials: (() => {
+          const avatars = Array.from(root.querySelectorAll('lv-user-avatar')) as any[]
+          return avatars.find((avatar) => avatar.name === 'Local Developer')?.shadowRoot?.textContent?.trim()
+        })(),
+        groupRows: root.querySelectorAll('.entity-list-group-row').length,
         rows: rows(),
         headers: Array.from(root.querySelectorAll('thead th .entity-list-sort-button > span:first-child')).map((header) => header.textContent?.trim()),
+        filterOptions: Array.from(root.querySelectorAll('select option')).map((option) => option.textContent?.trim()),
+        lastSeenCells: Array.from(root.querySelectorAll('.entity-list-table-row td:last-child')).map((cell) => ({
+          text: cell.textContent?.trim(),
+          title: cell.getAttribute('title'),
+        })),
       }
       const input = root.querySelector('input[type="search"]') as HTMLInputElement
       input.value = 'analyst'
@@ -143,20 +407,32 @@ test('members directory list delegates search and filtering to the page stream',
       await list.updateComplete
       const filtered = rows()
       const select = root.querySelector('select') as HTMLSelectElement
-      select.value = 'applications'
+      select.value = 'inactive'
       select.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
       await list.updateComplete
-      return { initial, filtered, applicationRows: rows() }
+      const inactiveRows = rows()
+      const lastSeenSort = Array.from(root.querySelectorAll<HTMLButtonElement>('.entity-list-sort-button'))
+        .find((button) => button.textContent?.includes('Last seen'))
+      lastSeenSort?.click()
+      await list.updateComplete
+      return { initial, filtered, inactiveRows, sortedRows: rows() }
     })
 
     expect(state.initial.title).toBe('Members')
-    expect(state.initial.groupLabels).toEqual(['Active1'])
-    expect(state.initial.headers).toEqual(['Name', 'Email', 'Status', 'Teams', 'Joined'])
-    expect(state.initial.rows).toHaveLength(1)
+    expect(state.initial.avatarSrc).toBe('/profile/avatars/p1/avatar-digest')
+    expect(state.initial.fallbackInitials).toBe('LD')
+    expect(state.initial.groupRows).toBe(0)
+    expect(state.initial.headers).toEqual(['Name', 'Email', 'Status', 'Teams', 'Joined', 'Last seen'])
+    expect(state.initial.filterOptions).toEqual(['All', 'Active', 'Inactive'])
+    expect(state.initial.lastSeenCells[0]?.text).toMatch(/^5m ago$/)
+    expect(state.initial.lastSeenCells[0]?.title).toContain('UTC')
+    expect(state.initial.lastSeenCells[1]).toEqual({ text: 'Never', title: '' })
+    expect(state.initial.rows).toHaveLength(2)
     // The list emits both changes but keeps the last server payload visible
     // until the page stream sends the filtered groups back.
     expect(state.filtered).toEqual(state.initial.rows)
-    expect(state.applicationRows).toEqual(state.initial.rows)
+    expect(state.inactiveRows).toEqual(state.initial.rows)
+    expect(state.sortedRows[0]).toContain('Local Developer')
   } finally {
     await page.close()
   }
@@ -1768,6 +2044,7 @@ test('admin storage explorer keeps table, schema, and breadcrumb selection coher
 })
 
 function testDocument(): string {
+  const fiveMinutesAgo = new Date(Date.now() - 5 * 60_000).toISOString()
   const page = {
     kind: 'admin',
     title: 'Principals',
@@ -1793,11 +2070,10 @@ function testDocument(): string {
     directoryList: {
       searchPlaceholder: 'Search by name or email',
       filterLabel: 'Filter members',
-      groups: [{
-        id: 'active',
-        label: 'Active',
-        items: [{ id: 'p1', name: 'Analyst', username: 'analyst', email: 'analyst@example.com', href: '/admin/principals/p1', kind: 'person', status: 'active', role: 'Viewer', groupCount: 1, joinedAt: '2026-07-20' }],
-      }],
+      items: [
+        { id: 'p1', name: 'Analyst', username: 'analyst', avatarUrl: '/profile/avatars/p1/avatar-digest', email: 'analyst@example.com', href: '/admin/principals/p1', status: 'active', groupCount: 1, joinedAt: '2026-07-20', lastSeenAt: fiveMinutesAgo },
+        { id: 'p2', name: 'Local Developer', username: 'dev', email: 'dev@localhost', href: '/admin/principals/p2', status: 'active', groupCount: 0, joinedAt: '2026-07-20', lastSeenAt: '' },
+      ],
     },
   }
   const signals = escapeHTML(JSON.stringify({ page }))
@@ -1807,7 +2083,7 @@ function testDocument(): string {
       <head>
         <style>
           html, body { margin: 0; min-height: 100%; }
-          body { ${typographyTestTokens} --lv-bg-app: #f6f8fa; --lv-bg-page: #fff; --lv-bg-panel: #fff; --lv-bg-panel-muted: #f6f8fa; --lv-bg-control: #f6f8fa; --lv-bg-control-hover: #f3f4f6; --lv-bg-accent: #0969da; --lv-bg-accent-muted: #ddf4ff; --lv-sidebar-bg: #f1f3f5; --lv-report-rail-bg: #ffffff; --lv-fg-default: #24292f; --lv-fg-muted: #57606a; --lv-fg-accent: #0969da; --lv-fg-link: #0969da; --lv-fg-success: #1a7f37; --lv-fg-warning: #9a6700; --lv-fg-danger: #d1242f; --lv-fg-on-accent: #fff; --lv-icon-muted: #57606a; --lv-line-muted: #d8dee4; --lv-border-width: 1px; --lv-border-default: 1px solid #d0d7de; --lv-border-muted: 1px solid #d8dee4; --lv-radius-default: 6px; --lv-radius-full: 999px; --lv-page-content-max-width: 72rem; --lv-workspace-detail-max-width: 72rem; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-12: 12px; --base-size-16: 16px; --lv-transition-fast: 160ms ease; }
+          body { ${typographyTestTokens} --lv-bg-app: #f6f8fa; --lv-bg-page: #fff; --lv-bg-panel: #fff; --lv-bg-panel-muted: #f6f8fa; --lv-bg-control: #f6f8fa; --lv-bg-control-hover: #f3f4f6; --lv-bg-accent: #0969da; --lv-bg-accent-muted: #ddf4ff; --lv-sidebar-bg: #f1f3f5; --lv-report-rail-bg: #ffffff; --lv-fg-default: #24292f; --lv-fg-muted: #57606a; --lv-fg-accent: #0969da; --lv-fg-link: #0969da; --lv-fg-success: #1a7f37; --lv-fg-warning: #9a6700; --lv-fg-danger: #d1242f; --lv-fg-on-accent: #fff; --lv-icon-muted: #57606a; --lv-line-muted: #d8dee4; --lv-border-width: 1px; --lv-border-default: 1px solid #d0d7de; --lv-border-muted: 1px solid #d8dee4; --lv-radius-default: 6px; --lv-radius-full: 999px; --lv-page-content-max-width: 72rem; --lv-settings-content-max-width: 40rem; --lv-workspace-detail-max-width: 72rem; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-12: 12px; --base-size-16: 16px; --base-size-20: 20px; --base-size-24: 24px; --base-size-32: 32px; --base-size-40: 40px; --base-size-48: 48px; --base-size-64: 64px; --control-large-size: 40px; --lv-transition-fast: 160ms ease; }
           lv-admin-page { min-height: 720px; }
         </style>
       </head>

--- a/web/components/admin/admin-page.ts
+++ b/web/components/admin/admin-page.ts
@@ -646,7 +646,7 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
     const mainClass = [
       'main',
       page.active === 'storage' ? 'main-storage' : '',
-      page.active === 'principals' || page.active === 'groups' ? 'main-directory' : '',
+      page.active === 'principals' || page.active === 'groups' || page.active === 'workspaces-admin' ? 'main-directory' : '',
       isPersonalSettings(page.active) || isProductSettings(page.active) ? 'main-settings' : '',
     ].filter(Boolean).join(' ')
     return html`

--- a/web/components/admin/admin-page.ts
+++ b/web/components/admin/admin-page.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html, nothing } from 'lit'
 import { state } from 'lit/decorators.js'
 import { CheckCircle2, Clock3, Copy, XCircle } from 'lucide'
-import type { AdminPageSignal, AdminContentSectionSignal, AdminProfileSignal, AdminPublicationSignal, AdminQueryDetailSignal, AdminQueryHistoryFilters, AdminQueryHistorySignal, AdminStorageSignal, FilterMenuCommand, FilterMenuSignal, RecordTableSignal } from '../../generated/signals'
+import type { AdminPageSignal, AdminContentSectionSignal, AdminPublicationSignal, AdminQueryDetailSignal, AdminQueryHistoryFilters, AdminQueryHistorySignal, AdminStorageSignal, FilterMenuCommand, FilterMenuSignal, RecordTableSignal } from '../../generated/signals'
 import { DatastarLit } from '../shared/datastar-lit'
 import { lucideIcon } from '../shared/lucide-icons'
 import { pageHeaderStyles, renderPageHeader } from '../shared/page-header'
@@ -11,9 +11,13 @@ import '../shared/drawer'
 import '../shared/entity-list'
 import '../shared/filter-menu'
 import '../shared/record-table'
+import '../shared/user-avatar'
 import './agent-tools'
 import './agent-prompt-editor'
 import './storage-explorer'
+import './personal-settings'
+import './product-settings'
+import './settings-surfaces'
 
 const emptyStorage: AdminStorageSignal = {
   summary: {
@@ -82,6 +86,25 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
       gap: 0;
       justify-self: stretch;
       padding: 0;
+    }
+
+    .main-settings {
+      width: min(calc(100% - var(--base-size-48)), var(--lv-settings-content-max-width));
+      gap: var(--base-size-24);
+      padding: var(--base-size-64) 0;
+    }
+
+    .main-settings .page-title-block {
+      display: grid;
+      gap: var(--base-size-8);
+    }
+
+    .main-settings .page-header .page-detail {
+      margin-top: 0;
+    }
+
+    .main-settings .page-header h1 {
+      font: var(--lv-type-page-title);
     }
 
     header {
@@ -164,89 +187,6 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
 
     .empty {
       padding: var(--base-size-12);
-    }
-
-    .profile-card {
-      display: grid;
-      max-width: 42rem;
-      overflow: hidden;
-      border: 0;
-      border-radius: var(--lv-radius-default);
-      background: var(--lv-bg-panel);
-    }
-
-    .profile-row {
-      display: grid;
-      min-width: 0;
-      min-height: 4rem;
-      grid-template-columns: minmax(0, 1fr) minmax(0, auto);
-      align-items: center;
-      gap: var(--base-size-16);
-      margin: 0 var(--base-size-16);
-      border-bottom: var(--lv-border-muted);
-    }
-
-    .profile-row:last-child {
-      border-bottom: 0;
-    }
-
-    .profile-label-group {
-      display: grid;
-      min-width: 0;
-      gap: var(--base-size-2);
-    }
-
-    .profile-label {
-      color: var(--lv-fg-default);
-      font: var(--lv-type-body-compact);
-    }
-
-    .profile-help {
-      color: var(--lv-fg-muted);
-      font: var(--lv-type-caption);
-    }
-
-    .profile-value {
-      box-sizing: border-box;
-      min-width: 0;
-      max-width: min(24rem, 58vw);
-      overflow: hidden;
-      border: var(--lv-border-muted);
-      border-radius: var(--lv-radius-default);
-      background: var(--lv-bg-control);
-      color: var(--lv-fg-default);
-      padding: var(--base-size-6) var(--base-size-12);
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      font: var(--lv-type-body-compact);
-    }
-
-    .profile-value-muted {
-      color: var(--lv-fg-muted);
-    }
-
-    .profile-picture {
-      min-height: 4.25rem;
-    }
-
-    .profile-avatar {
-      display: grid;
-      width: var(--control-large-size);
-      height: var(--control-large-size);
-      place-items: center;
-      overflow: hidden;
-      border: var(--lv-border-muted);
-      border-radius: 50%;
-      background: var(--lv-bg-selected);
-      color: var(--lv-fg-default);
-      font: var(--lv-type-body);
-      font-weight: var(--base-text-weight-semibold);
-    }
-
-    .profile-avatar img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
     }
 
     .warnings {
@@ -647,6 +587,15 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
         padding: var(--base-size-12);
       }
 
+      .main-settings {
+        gap: var(--base-size-24);
+        padding: var(--base-size-32) var(--base-size-16) var(--base-size-64);
+      }
+
+      .main-settings .page-header h1 {
+        font: var(--lv-type-page-title);
+      }
+
       .local-user-action {
         width: 100%;
       }
@@ -698,11 +647,12 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
       'main',
       page.active === 'storage' ? 'main-storage' : '',
       page.active === 'principals' || page.active === 'groups' ? 'main-directory' : '',
+      isPersonalSettings(page.active) || isProductSettings(page.active) ? 'main-settings' : '',
     ].filter(Boolean).join(' ')
     return html`
       <div class="route">
         <section class=${mainClass} aria-label="Admin">
-          ${page.active === 'storage' ? nothing : renderPageHeader(page.headerTitle || page.title)}
+          ${page.active === 'storage' ? nothing : renderPageHeader(page.headerTitle || page.title, page.headerDetail)}
           ${page.empty && page.active !== 'storage' ? html`<div class="panel"><div class="empty">${page.empty}</div></div>` : nothing}
           ${page.metrics?.length && page.active !== 'storage' && page.active !== 'queries' ? html`
             <div class="metrics">
@@ -721,7 +671,6 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
                 .items=${adminPrincipalListItems(page)}
                 .columns=${adminPrincipalListColumns()}
                 .filters=${adminPrincipalListFilters()}
-                .groups=${adminPrincipalListGroups(page)}
                 initial-query=${page.listQuery ?? ''}
                 active-filter=${page.listFilter ?? 'all'}
                 search-placeholder=${page.directoryList.searchPlaceholder}
@@ -731,7 +680,12 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
               ></lv-entity-list>`
             : page.active === 'groups'
               ? html`<lv-entity-list .items=${adminGroupListItems(page)} .columns=${adminGroupListColumns()} .filters=${adminGroupListFilters(page)} initial-query=${page.listQuery ?? ''} active-filter=${page.listFilter ?? 'all'} search-placeholder="Search groups by name or ID" empty-text="No groups found."></lv-entity-list>`
-            : page.active === 'profile' ? this.renderProfile(page.profile) : page.active === 'storage' ? this.renderStorage(page) : page.active === 'agent' ? this.renderAgent(page) : page.active === 'queries' ? this.renderQueries(page) : page.active === 'publications' ? this.renderPublications(page.publications ?? []) : page.sections?.map(renderSection)}
+            : isPersonalSettings(page.active) ? html`<lv-personal-settings></lv-personal-settings>`
+              : isProductSettings(page.active) ? html`<lv-product-settings></lv-product-settings>`
+                : page.active === 'workspaces-admin' ? html`<lv-workspace-registry></lv-workspace-registry>`
+                  : page.active === 'service-accounts' ? html`<lv-service-accounts></lv-service-accounts>`
+                    : page.active === 'audit' ? html`<lv-audit-log></lv-audit-log>`
+                      : page.active === 'storage' ? this.renderStorage(page) : page.active === 'agent' ? this.renderAgent(page) : page.active === 'queries' ? this.renderQueries(page) : page.active === 'publications' ? this.renderPublications(page.publications ?? []) : page.sections?.map(renderSection)}
         </section>
       </div>
     `
@@ -751,50 +705,6 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
       `
     }
     return nothing
-  }
-
-  private renderProfile(profile?: AdminProfileSignal) {
-    const current = profile ?? { id: '', email: '', displayName: '', title: '', username: '', profilePictureUrl: undefined }
-    const displayName = current.displayName || current.email || current.username || 'Not set'
-    const initials = profileInitials(displayName)
-    return html`
-      <section class="profile-card" aria-label="Profile details">
-        <div class="profile-row profile-picture">
-          <div class="profile-label-group">
-            <span class="profile-label">Profile picture</span>
-          </div>
-          <div class="profile-avatar" aria-label=${current.profilePictureUrl ? 'Profile picture' : `Profile initials: ${initials}`}>
-            ${current.profilePictureUrl ? html`<img src=${current.profilePictureUrl} alt="">` : initials}
-          </div>
-        </div>
-        <div class="profile-row">
-          <div class="profile-label-group">
-            <span class="profile-label">Email</span>
-          </div>
-          <span class="profile-value">${current.email || 'Not set'}</span>
-        </div>
-        <div class="profile-row">
-          <div class="profile-label-group">
-            <span class="profile-label">Full name</span>
-          </div>
-          <span class="profile-value">${displayName}</span>
-        </div>
-        <div class="profile-row">
-          <div class="profile-label-group">
-            <span class="profile-label">Title</span>
-            <span class="profile-help">Your job title or role</span>
-          </div>
-          <span class=${current.title ? 'profile-value' : 'profile-value profile-value-muted'}>${current.title || 'Not set'}</span>
-        </div>
-        <div class="profile-row">
-          <div class="profile-label-group">
-            <span class="profile-label">Username</span>
-            <span class="profile-help">One word, like a nickname or first name</span>
-          </div>
-          <span class=${current.username ? 'profile-value' : 'profile-value profile-value-muted'}>${current.username || 'Not set'}</span>
-        </div>
-      </section>
-    `
   }
 
   private renderAgent(page: AdminPageSignal) {
@@ -1112,6 +1022,14 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
 
 }
 
+function isPersonalSettings(active: string): boolean {
+  return active === 'profile' || active === 'security' || active === 'api-tokens'
+}
+
+function isProductSettings(active: string): boolean {
+  return active === 'general' || active === 'authentication' || active === 'system'
+}
+
 const emptyQueryHistoryTable: RecordTableSignal = {
   columns: [],
   rows: [],
@@ -1138,43 +1056,46 @@ function adminGroupTable(page: AdminPageSignal): RecordTableSignal | undefined {
 }
 
 function adminPrincipalListItems(page: AdminPageSignal) {
-  return (page.directoryList?.groups ?? []).flatMap((group) => group.items.map((item) => ({
+  return (page.directoryList?.items ?? []).map((item) => ({
     id: item.id,
     title: item.name,
     description: item.username,
     href: item.href,
-    icon: item.kind === 'application' ? 'application' : 'user',
-    group: group.id,
+    avatarUrl: item.avatarUrl,
+    icon: 'user',
     columns: {
       email: item.email || '—',
-      status: item.role,
+      status: item.status === 'inactive' ? 'Inactive' : 'Active',
       teams: `${item.groupCount} ${item.groupCount === 1 ? 'team' : 'teams'}`,
       joined: formatAdminListDate(item.joinedAt),
+      lastSeen: formatAdminLastSeen(item.lastSeenAt),
     },
-  })))
+    columnTitles: {
+      lastSeen: item.lastSeenAt ? formatAdminExactDate(item.lastSeenAt) : '',
+    },
+    sortValues: {
+      lastSeen: adminTimestamp(item.lastSeenAt),
+    },
+  }))
 }
 
 function adminPrincipalListColumns() {
   return [
-    { id: 'name', label: 'Name', width: '31%' },
-    { id: 'email', label: 'Email', width: '24%' },
-    { id: 'status', label: 'Status', width: '17%' },
-    { id: 'teams', label: 'Teams', width: '14%' },
-    { id: 'joined', label: 'Joined', width: '14%' },
+    { id: 'name', label: 'Name', width: '27%' },
+    { id: 'email', label: 'Email', width: '22%' },
+    { id: 'status', label: 'Status', width: '14%' },
+    { id: 'teams', label: 'Teams', width: '12%' },
+    { id: 'joined', label: 'Joined', width: '12%' },
+    { id: 'lastSeen', label: 'Last seen', width: '13%' },
   ]
 }
 
 function adminPrincipalListFilters() {
   return [
     { id: 'all', label: 'All' },
-    { id: 'people', label: 'People' },
-    { id: 'applications', label: 'Applications' },
+    { id: 'active', label: 'Active' },
     { id: 'inactive', label: 'Inactive' },
   ]
-}
-
-function adminPrincipalListGroups(page: AdminPageSignal) {
-  return (page.directoryList?.groups ?? []).map((group) => ({ id: group.id, label: group.label }))
 }
 
 function formatAdminListDate(value: string): string {
@@ -1182,6 +1103,32 @@ function formatAdminListDate(value: string): string {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }).format(date)
+}
+
+function formatAdminLastSeen(value: string): string {
+  const timestamp = adminTimestamp(value)
+  if (!timestamp) return 'Never'
+  const elapsed = Math.max(0, Date.now() - timestamp)
+  if (elapsed < 60_000) return 'Now'
+  if (elapsed < 60 * 60_000) return `${Math.floor(elapsed / 60_000)}m ago`
+  if (elapsed < 24 * 60 * 60_000) return `${Math.floor(elapsed / (60 * 60_000))}h ago`
+  if (elapsed < 7 * 24 * 60 * 60_000) return `${Math.floor(elapsed / (24 * 60 * 60_000))}d ago`
+  return formatAdminListDate(value)
+}
+
+function formatAdminExactDate(value: string): string {
+  const timestamp = adminTimestamp(value)
+  if (!timestamp) return ''
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', second: '2-digit',
+    timeZone: 'UTC', timeZoneName: 'short',
+  }).format(timestamp)
+}
+
+function adminTimestamp(value: string): number {
+  if (!value) return 0
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? 0 : timestamp
 }
 
 function adminGroupListItems(page: AdminPageSignal) {
@@ -1322,12 +1269,6 @@ function csrfToken(): string {
 function principalIDFromPage(page: AdminPageSignal): string {
   const metric = page.metrics?.find((item) => item.label === 'Principal ID')
   return metric?.value ?? ''
-}
-
-function profileInitials(value: string): string {
-  const parts = value.trim().split(/\s+/).filter(Boolean)
-  if (parts.length > 1) return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
-  return (parts[0]?.slice(0, 2) || '?').toUpperCase()
 }
 
 function renderSection(section: AdminContentSectionSignal) {

--- a/web/components/admin/personal-settings.ts
+++ b/web/components/admin/personal-settings.ts
@@ -1,0 +1,548 @@
+import { LitElement, css, html, nothing } from 'lit'
+import { query, state } from 'lit/decorators.js'
+import { Camera, Plus, Search, Trash2, X } from 'lucide'
+import type {
+  PersonalAuthoringSessionSignal,
+  PersonalSessionSignal,
+  PersonalSettingsSignal,
+  PersonalTokenPrivilegeSignal,
+  PersonalTokenScopeSignal,
+  PersonalTokenSignal,
+} from '../../generated/signals'
+import { DatastarLit } from '../shared/datastar-lit'
+import { lucideIcon } from '../shared/lucide-icons'
+import { settingsFieldStyles } from '../shared/settings-field-styles'
+import '../shared/user-avatar'
+
+const emptySettings: PersonalSettingsSignal = {
+  active: 'profile',
+  profile: { id: '', email: '', displayName: '', theme: 'system', identitySource: '', canEditDisplayName: false, hasLocalPassword: false },
+  security: { localPasswordEnabled: false, sessions: [], authoringSessions: [] },
+  tokens: { items: [], scopes: [] },
+}
+
+class LeapViewPersonalSettings extends DatastarLit(LitElement) {
+  @state() private profileName = ''
+  @state() private currentPassword = ''
+  @state() private newPassword = ''
+  @state() private tokenName = ''
+  @state() private tokenScopeKey = ''
+  @state() private tokenPrivileges: string[] = []
+  @state() private tokenExpires = ''
+  @state() private tokenCreatePending = false
+  @state() private tokenPermissionMenuOpen = false
+  @state() private tokenPermissionSearch = ''
+  @state() private message = ''
+  @state() private error = ''
+  @state() private avatarMenuOpen = false
+  @state() private avatarBusy = false
+  @query('.avatar-trigger') private avatarTrigger?: HTMLButtonElement
+  @query('.avatar-input') private avatarInput?: HTMLInputElement
+  @query('.permission-trigger') private permissionTrigger?: HTMLButtonElement
+  private handledNewToken = ''
+
+  static styles = [settingsFieldStyles, css`
+    :host { display: block; color: var(--lv-fg-default); font: var(--lv-type-body); }
+    .settings { display: grid; gap: var(--base-size-20); width: 100%; min-width: 0; }
+    section { display: grid; gap: var(--base-size-20); }
+    h2, h3, p { margin: 0; }
+    h2 { font: var(--lv-type-section-title); }
+    h3 { font: var(--lv-type-body); font-weight: var(--base-text-weight-semibold); }
+    .card { display: grid; gap: 0; overflow: visible; border: var(--lv-border-muted); border-radius: var(--lv-radius-large); background: var(--lv-bg-panel); }
+    .row { display: grid; min-height: var(--base-size-48); box-sizing: border-box; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: var(--base-size-16); padding: var(--base-size-8) var(--base-size-16); border-bottom: var(--lv-border-muted); }
+    .row:first-child { border-radius: var(--lv-radius-large) var(--lv-radius-large) 0 0; }
+    .row:last-child { border-bottom: 0; }
+    .muted { color: var(--lv-fg-muted); font: var(--lv-type-caption); }
+    input, select { min-width: 0; min-height: var(--control-small-size); box-sizing: border-box; border: var(--lv-border-default); border-radius: var(--lv-radius-small); padding: 0 var(--control-small-paddingInline-normal); color: var(--lv-fg-default); background: var(--lv-bg-input); font: var(--lv-type-body-compact); }
+    button { min-height: var(--control-small-size); border: var(--lv-border-default); border-radius: var(--lv-radius-small); padding: 0 var(--control-small-paddingInline-normal); color: var(--lv-fg-default); background: var(--lv-button-bg-rest); cursor: pointer; font: var(--lv-type-body-compact); }
+    button.primary { color: var(--lv-fg-on-accent); border-color: var(--lv-bg-accent); background: var(--lv-bg-accent); }
+    button.danger { color: var(--lv-fg-danger); }
+    button:disabled { cursor: not-allowed; opacity: .55; }
+    form { display: grid; gap: var(--base-size-8); }
+    .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); gap: var(--base-size-8); }
+    .actions { display: flex; flex-wrap: wrap; gap: var(--base-size-8); align-items: center; }
+    .token-form { width: 100%; gap: var(--base-size-20); }
+    .token-form-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(12rem, .7fr); gap: var(--base-size-16); }
+    .token-field { display: grid; min-width: 0; align-content: start; gap: var(--base-size-6); }
+    .token-field input, .token-field select { width: 100%; }
+    .scope-description { min-height: var(--base-size-16); }
+    .permissions { display: grid; gap: var(--base-size-12); }
+    .permissions-header { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: var(--base-size-12); }
+    .permissions-title { display: flex; min-width: 0; align-items: center; gap: var(--base-size-8); }
+    .count { display: inline-grid; min-width: var(--base-size-24); height: var(--base-size-24); box-sizing: border-box; place-items: center; border-radius: var(--lv-radius-full); padding: 0 var(--base-size-8); color: var(--lv-fg-muted); background: var(--lv-bg-control); font: var(--lv-type-caption); }
+    .permission-picker { position: relative; flex: none; }
+    .permission-trigger { display: inline-flex; align-items: center; gap: var(--base-size-8); }
+    .permission-trigger svg, .permission-remove svg, .permission-search svg { width: var(--base-size-16); height: var(--base-size-16); }
+    .permission-backdrop { display: none; }
+    .permission-menu { position: absolute; z-index: var(--z-index-dropdown); top: calc(100% + var(--base-size-6)); right: 0; display: grid; width: min(var(--overlay-width-medium), calc(100vw - var(--base-size-32))); max-height: min(30rem, var(--permission-menu-max-height, calc(100svh - var(--base-size-64)))); box-sizing: border-box; grid-template-rows: auto minmax(0, 1fr); overflow: hidden; border: var(--lv-border-default); border-radius: var(--lv-radius-large); background: var(--lv-bg-overlay); box-shadow: var(--lv-shadow-floating-lg); }
+    .permission-menu-header { display: grid; gap: var(--base-size-8); padding: var(--base-size-12); border-bottom: var(--lv-border-muted); }
+    .permission-menu-title { display: flex; align-items: center; justify-content: space-between; gap: var(--base-size-8); }
+    .permission-menu-close { display: none; width: var(--control-small-size); min-height: var(--control-small-size); place-items: center; padding: 0; color: var(--lv-fg-muted); background: transparent; }
+    .permission-search { position: relative; display: grid; align-items: center; }
+    .permission-search svg { position: absolute; left: var(--base-size-12); z-index: 1; color: var(--lv-fg-muted); pointer-events: none; }
+    .permission-search input { width: 100%; padding-left: var(--base-size-40); }
+    .permission-list { display: grid; min-height: 0; align-content: start; overflow-y: auto; overscroll-behavior: contain; padding: var(--base-size-4); scrollbar-color: var(--lv-scrollbar-thumb) transparent; scrollbar-width: thin; }
+    .permission-category { padding: var(--base-size-8) var(--base-size-8) var(--base-size-4); color: var(--lv-fg-muted); font: var(--lv-type-caption); font-weight: var(--base-text-weight-semibold); }
+    .permission-option { display: grid; min-width: 0; grid-template-columns: var(--base-size-20) minmax(0, 1fr); align-items: start; gap: var(--base-size-8); border-radius: var(--lv-radius-small); padding: var(--base-size-8); cursor: pointer; }
+    .permission-option:hover { background: var(--lv-bg-control-hover); }
+    .permission-option input[type="checkbox"] { width: var(--base-size-16); height: var(--base-size-16); min-height: 0; margin: var(--base-size-2) 0 0; padding: 0; accent-color: var(--lv-bg-accent); }
+    .selected-permissions { display: grid; overflow: hidden; border: var(--lv-border-muted); border-radius: var(--lv-radius-large); }
+    .selected-permission { display: grid; min-height: var(--base-size-48); grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: var(--base-size-12); padding: var(--base-size-8) var(--base-size-12); border-bottom: var(--lv-border-muted); }
+    .selected-permission:last-child { border-bottom: 0; }
+    .permission-remove { display: grid; width: var(--control-small-size); min-height: var(--control-small-size); place-items: center; padding: 0; color: var(--lv-fg-muted); background: transparent; }
+    .permission-empty { display: grid; min-height: var(--base-size-48); place-items: center start; padding: var(--base-size-8) var(--base-size-12); color: var(--lv-fg-muted); font: var(--lv-type-caption); }
+    .avatar-control { position: relative; display: inline-grid; justify-items: end; }
+    .avatar-trigger { display: grid; width: var(--control-large-size); height: var(--control-large-size); min-height: var(--control-large-size); place-items: center; border: 0; border-radius: var(--lv-radius-full); padding: 0; background: transparent; }
+    .avatar-trigger:hover { box-shadow: var(--lv-shadow-resting-sm); }
+    .avatar-trigger:focus-visible { outline: var(--focus-outline); outline-offset: var(--focus-outline-offset); }
+    .avatar-trigger lv-user-avatar { pointer-events: none; }
+    .avatar-input { display: none; }
+    .avatar-menu { position: absolute; z-index: var(--z-index-dropdown); top: calc(100% + var(--base-size-6)); right: 0; display: grid; width: var(--overlay-width-xsmall); border: var(--lv-border-muted); border-radius: var(--lv-radius-default); background: var(--lv-bg-overlay); box-shadow: var(--lv-shadow-floating-lg); padding: var(--base-size-4); }
+    .avatar-menu-item { display: grid; min-height: var(--control-medium-size); grid-template-columns: var(--base-size-16) minmax(0, 1fr); align-items: center; gap: var(--base-size-8); border: var(--lv-border-transparent); border-radius: var(--lv-radius-small); background: transparent; padding: 0 var(--base-size-8); text-align: left; }
+    .avatar-menu-item:hover, .avatar-menu-item:focus-visible { background: var(--lv-bg-control-hover); outline: 0; }
+    .avatar-menu-item svg { width: var(--base-size-16); height: var(--base-size-16); color: var(--lv-fg-muted); }
+    .avatar-menu-item.danger, .avatar-menu-item.danger svg { color: var(--lv-fg-danger); }
+    .notice { padding: var(--base-size-8) var(--base-size-12); border-radius: var(--lv-radius-small); background: var(--lv-bg-success-muted); color: var(--lv-fg-success); }
+    .error { color: var(--lv-fg-danger); }
+    @media (max-width: 40rem) {
+      .row { grid-template-columns: 1fr; gap: var(--base-size-12); padding: var(--base-size-16); }
+      .avatar-control { justify-self: start; }
+      .token-form-grid { grid-template-columns: 1fr; }
+      .permissions-header { align-items: start; }
+      .permission-backdrop { position: fixed; z-index: var(--z-index-dropdown); inset: 0; display: block; background: var(--lv-modal-backdrop); }
+      .permission-menu { position: fixed; z-index: var(--z-index-modal); top: auto; right: var(--base-size-16); bottom: var(--base-size-16); left: var(--base-size-16); width: auto; max-height: calc(100svh - var(--base-size-32)); }
+      .permission-menu-close { display: grid; }
+    }
+  `]
+
+  override connectedCallback(): void {
+    super.connectedCallback()
+    document.addEventListener('pointerdown', this.handleDocumentPointerDown)
+    document.addEventListener('datastar-fetch', this.handleDatastarFetch)
+    window.addEventListener('keydown', this.handleWindowKeydown)
+    window.addEventListener('resize', this.fitPermissionMenu)
+    window.addEventListener('scroll', this.fitPermissionMenu, true)
+  }
+
+  override disconnectedCallback(): void {
+    document.removeEventListener('pointerdown', this.handleDocumentPointerDown)
+    document.removeEventListener('datastar-fetch', this.handleDatastarFetch)
+    window.removeEventListener('keydown', this.handleWindowKeydown)
+    window.removeEventListener('resize', this.fitPermissionMenu)
+    window.removeEventListener('scroll', this.fitPermissionMenu, true)
+    super.disconnectedCallback()
+  }
+
+  get settings(): PersonalSettingsSignal {
+    return this.signal<PersonalSettingsSignal>('personalSettings', emptySettings)
+  }
+
+  override updated(): void {
+    const settings = this.settings
+    const displayName = settings.profile.displayName
+    if (!this.profileName && displayName) this.profileName = displayName
+    const newToken = settings.tokens.newToken ?? ''
+    if (newToken && newToken !== this.handledNewToken) {
+      this.handledNewToken = newToken
+      this.tokenCreatePending = false
+      this.tokenName = ''
+      this.tokenScopeKey = ''
+      this.tokenPrivileges = []
+      this.tokenExpires = ''
+      this.closePermissionMenu()
+    }
+  }
+
+  render() {
+    const settings = this.settings
+    if (!settings.profile.id) return html`<slot></slot>`
+    return html`
+      <div class="settings" aria-label="Personal settings">
+        ${this.renderNotice(settings)}
+        ${settings.active === 'profile' ? html`<section aria-label="Profile">
+          <div class="card">
+            <div class="row">
+              <div class="settings-field"><span class="settings-label">Profile picture</span><span class="settings-description">Shown across LeapView.</span></div>
+              <div class="avatar-control">
+                <button
+                  class="avatar-trigger"
+                  type="button"
+                  aria-label="Manage profile picture"
+                  aria-haspopup="menu"
+                  aria-expanded=${String(this.avatarMenuOpen)}
+                  ?disabled=${this.avatarBusy}
+                  @click=${this.toggleAvatarMenu}
+                  @keydown=${this.handleAvatarTriggerKeydown}
+                >
+                  <lv-user-avatar
+                    size="medium"
+                    .name=${settings.profile.displayName || settings.profile.email}
+                    .imageUrl=${settings.profile.avatarUrl ?? ''}
+                    aria-hidden="true"
+                  ></lv-user-avatar>
+                </button>
+                <input class="avatar-input" type="file" accept="image/png,image/jpeg,image/webp" tabindex="-1" @change=${this.uploadAvatar}>
+                ${this.avatarMenuOpen ? html`
+                  <div class="avatar-menu" role="menu" aria-label="Profile picture actions" @keydown=${this.handleAvatarMenuKeydown}>
+                    <button class="avatar-menu-item" type="button" role="menuitem" @click=${this.chooseAvatar}>
+                      ${lucideIcon(Camera, { size: 16, strokeWidth: 2 })}
+                      <span>${settings.profile.avatarUrl ? 'Change avatar' : 'Upload avatar'}</span>
+                    </button>
+                    ${settings.profile.avatarUrl ? html`
+                      <button class="avatar-menu-item danger" type="button" role="menuitem" @click=${this.deleteAvatar}>
+                        ${lucideIcon(Trash2, { size: 16, strokeWidth: 2 })}
+                        <span>Remove avatar</span>
+                      </button>
+                    ` : nothing}
+                  </div>
+                ` : nothing}
+              </div>
+            </div>
+            <div class="row"><div class="settings-field"><span class="settings-label">Email</span><span class="settings-description">Managed by your identity provider.</span></div><span class="settings-value">${settings.profile.email || 'Not set'}</span></div>
+            <div class="row">
+              <div class="settings-field"><label class="settings-label" for="personal-display-name">Display name</label><span class="settings-description">How your name appears to collaborators.</span></div>
+              <form @submit=${this.saveProfile}><div class="actions"><input id="personal-display-name" .value=${this.profileName || settings.profile.displayName} ?disabled=${!settings.profile.canEditDisplayName} @input=${this.onProfileNameInput}><button class="primary" type="submit" ?disabled=${!settings.profile.canEditDisplayName}>Save</button></div></form>
+            </div>
+            <div class="row">
+              <div class="settings-field"><label class="settings-label" for="personal-theme">Theme</label><span class="settings-description">Choose how LeapView appears on your devices.</span></div>
+              <select id="personal-theme" name="theme" .value=${settings.profile.theme || 'system'} @change=${this.changeTheme}>
+                <optgroup label="Automatic">
+                  <option value="system">System</option>
+                </optgroup>
+                <optgroup label="Standard">
+                  <option value="light">Light default</option>
+                  <option value="dark">Dark default</option>
+                  <option value="dark_dimmed">Soft dark</option>
+                </optgroup>
+                <optgroup label="Accessibility">
+                  <option value="light_colorblind">Light protanopia and deuteranopia</option>
+                  <option value="dark_colorblind">Dark protanopia and deuteranopia</option>
+                  <option value="light_tritanopia">Light tritanopia</option>
+                  <option value="dark_tritanopia">Dark tritanopia</option>
+                </optgroup>
+              </select>
+            </div>
+          </div>
+        </section>` : nothing}
+        ${settings.active === 'security' ? this.renderSecurity(settings) : nothing}
+        ${settings.active === 'api-tokens' ? this.renderTokens(settings.tokens) : nothing}
+      </div>
+    `
+  }
+
+  private renderNotice(settings: PersonalSettingsSignal) {
+    if (settings.tokens.newToken) return html`<p class="notice" role="status">Copy this token now; it will not be shown again: <code>${settings.tokens.newToken}</code></p>`
+    if (this.error) return html`<p class="error" role="alert">${this.error}</p>`
+    if (this.message) return html`<p class="notice" role="status">${this.message}</p>`
+    return nothing
+  }
+
+  private renderSecurity(settings: PersonalSettingsSignal) {
+    return html`
+      <section aria-label="Security and sessions">
+        ${settings.security.localPasswordEnabled && settings.profile.hasLocalPassword ? html`
+          <div class="card"><div class="row"><div class="settings-field"><h3>Change password</h3><span class="settings-description">Use a strong password you do not reuse elsewhere.</span></div></div><div class="row"><form @submit=${this.changePassword}><div class="form-grid"><input type="password" autocomplete="current-password" placeholder="Current password" .value=${this.currentPassword} @input=${this.onCurrentPasswordInput}><input type="password" autocomplete="new-password" placeholder="New password" .value=${this.newPassword} @input=${this.onNewPasswordInput}></div><div class="actions"><button class="primary" type="submit">Change password</button></div></form></div></div>
+        ` : html`<div class="card"><div class="row"><div class="settings-field"><h3>Local password</h3><span class="settings-description">Password changes are managed by your identity provider.</span></div></div></div>`}
+        <div class="card"><div class="row"><div class="settings-field"><h3>Browser &amp; desktop sessions</h3><span class="settings-description">Revoke sessions you no longer recognize.</span></div></div>${settings.security.sessions.length ? settings.security.sessions.map((session) => this.renderSession(session)) : html`<div class="row"><span class="muted">No active sessions.</span></div>`}</div>
+        ${settings.security.authoringSessions.length ? html`<div class="card"><div class="row"><div class="settings-field"><h3>CLI &amp; authoring sessions</h3><span class="settings-description">These sessions grant scoped access to authoring tools.</span></div></div>${settings.security.authoringSessions.map((session) => this.renderAuthoringSession(session))}</div>` : nothing}
+      </section>
+    `
+  }
+
+  private renderSession(session: PersonalSessionSignal) {
+    return html`<div class="row"><div class="settings-field"><span class="settings-label">${session.clientLabel || session.kind}${session.current ? ' · This device' : ''}</span><span class="settings-description">Created ${formatDate(session.createdAt)} · Last seen ${formatDate(session.lastSeenAt)}${session.expiresAt ? ` · Expires ${formatDate(session.expiresAt)}` : ''}</span></div>${session.revokedAt ? html`<span class="muted">Revoked</span>` : html`<button class="danger" type="button" @click=${() => this.revokeSession(session.id)}>Revoke</button>`}</div>`
+  }
+
+  private renderAuthoringSession(session: PersonalAuthoringSessionSignal) {
+    return html`<div class="row"><div class="settings-field"><span class="settings-label">${session.clientId || session.kind}</span><span class="settings-description">${session.projectId || 'No project'} · ${session.privileges.join(', ') || 'Scoped access'} · Created ${formatDate(session.createdAt)}</span></div>${session.revokedAt ? html`<span class="muted">Revoked</span>` : html`<button class="danger" type="button" @click=${() => this.revokeAuthoringSession(session.id)}>Revoke</button>`}</div>`
+  }
+
+  private renderTokens(tokens: PersonalSettingsSignal['tokens']) {
+    const scope = this.selectedTokenScope(tokens)
+    const selected = scope?.privileges.filter((privilege) => this.tokenPrivileges.includes(privilege.value)) ?? []
+    const filtered = this.filteredTokenPrivileges(scope)
+    const categories = groupTokenPrivileges(filtered)
+    const platformScopes = tokens.scopes.filter((option) => option.kind === 'platform')
+    const workspaceScopes = tokens.scopes.filter((option) => option.kind !== 'platform')
+    const canCreate = Boolean(this.tokenName.trim() && scope && selected.length && !this.tokenCreatePending)
+    return html`
+      <section aria-label="API tokens">
+        <div class="card token-card">
+          <div class="row"><div class="settings-field"><h3>Create a personal API token</h3><span class="settings-description">Choose only the workspace and permissions your script needs.</span></div></div>
+          <div class="row">
+            <form class="token-form" @submit=${this.createToken}>
+              <div class="token-form-grid">
+                <label class="token-field" for="token-name">
+                  <span class="settings-label">Token name</span>
+                  <input id="token-name" required autocomplete="off" placeholder="For example, Sales reporting" .value=${this.tokenName} @input=${this.onTokenNameInput}>
+                  <span class="settings-description">A recognizable name for this credential.</span>
+                </label>
+                <label class="token-field" for="token-expiry">
+                  <span class="settings-label">Expiration</span>
+                  <input id="token-expiry" type="datetime-local" .value=${this.tokenExpires} @input=${this.onTokenExpiresInput}>
+                  <span class="settings-description">Defaults to the product token lifetime.</span>
+                </label>
+              </div>
+              <label class="token-field" for="token-scope">
+                <span class="settings-label">Resource access</span>
+                <select id="token-scope" required .value=${this.tokenScopeKey} @change=${this.onTokenScopeChange}>
+                  <option value="">Choose a scope</option>
+                  ${platformScopes.length ? html`<optgroup label="Broad access">${platformScopes.map((option) => html`<option value=${tokenScopeKey(option)}>${option.label}</option>`)}</optgroup>` : nothing}
+                  ${workspaceScopes.length ? html`<optgroup label="Workspace access">${workspaceScopes.map((option) => html`<option value=${tokenScopeKey(option)}>${option.label}</option>`)}</optgroup>` : nothing}
+                </select>
+                <span class="settings-description scope-description">${scope?.description ?? 'The token will be limited to one workspace or product-administration scope.'}</span>
+              </label>
+              <div class="permissions">
+                <div class="permissions-header">
+                  <div class="settings-field">
+                    <div class="permissions-title"><span class="settings-label">Permissions</span><span class="count" aria-label="${selected.length} selected permissions">${selected.length}</span></div>
+                    <span class="settings-description">Choose the minimal permissions necessary for your needs.</span>
+                  </div>
+                  <div class="permission-picker">
+                    <button class="permission-trigger" type="button" aria-haspopup="dialog" aria-controls="token-permission-menu" aria-expanded=${String(this.tokenPermissionMenuOpen)} ?disabled=${!scope} @click=${this.togglePermissionMenu}>
+                      ${lucideIcon(Plus, { size: 16, strokeWidth: 2 })}<span>Add permissions</span>
+                    </button>
+                    ${this.tokenPermissionMenuOpen && scope ? html`
+                      <div class="permission-backdrop" aria-hidden="true" @click=${() => this.closePermissionMenu(true)}></div>
+                      <div id="token-permission-menu" class="permission-menu" role="dialog" aria-label="Add token permissions">
+                        <div class="permission-menu-header">
+                          <div class="permission-menu-title"><span class="settings-label">Select permissions</span><button class="permission-menu-close" type="button" aria-label="Close permission picker" @click=${() => this.closePermissionMenu(true)}>${lucideIcon(X, { size: 16, strokeWidth: 2 })}</button></div>
+                          <label class="permission-search">
+                            ${lucideIcon(Search, { size: 16, strokeWidth: 2 })}
+                            <input type="search" aria-label="Search permissions" placeholder="Search permissions" .value=${this.tokenPermissionSearch} @input=${this.onTokenPermissionSearch}>
+                          </label>
+                        </div>
+                        <div class="permission-list">
+                          ${categories.length ? categories.map(([category, privileges]) => html`
+                            <div class="permission-category">${category}</div>
+                            ${privileges.map((privilege) => html`
+                              <label class="permission-option">
+                                <input type="checkbox" value=${privilege.value} .checked=${this.tokenPrivileges.includes(privilege.value)} @change=${() => this.toggleTokenPrivilege(privilege.value)}>
+                                <span class="settings-field"><span class="settings-label">${privilege.label}</span><span class="settings-description">${privilege.description}</span></span>
+                              </label>
+                            `)}
+                          `) : html`<div class="permission-empty">No permissions match your search.</div>`}
+                        </div>
+                      </div>
+                    ` : nothing}
+                  </div>
+                </div>
+                <div class="selected-permissions" aria-live="polite">
+                  ${selected.length ? selected.map((privilege) => html`
+                    <div class="selected-permission">
+                      <div class="settings-field"><span class="settings-label">${privilege.label}</span><span class="settings-description">${privilege.description}</span></div>
+                      <button class="permission-remove" type="button" aria-label="Remove ${privilege.label}" @click=${() => this.removeTokenPrivilege(privilege.value)}>${lucideIcon(X, { size: 16, strokeWidth: 2 })}</button>
+                    </div>
+                  `) : html`<div class="permission-empty">${scope ? 'No permissions selected.' : 'Choose resource access before adding permissions.'}</div>`}
+                </div>
+              </div>
+              <div class="actions"><button class="primary" type="submit" ?disabled=${!canCreate}>${this.tokenCreatePending ? 'Creating…' : 'Create token'}</button></div>
+            </form>
+          </div>
+        </div>
+        <div class="card"><div class="row"><div class="settings-field"><h3>Personal API tokens</h3><span class="settings-description">Revoke credentials you no longer use.</span></div></div>${tokens.items.length ? tokens.items.map((token) => this.renderToken(token, tokens.scopes)) : html`<div class="row"><span class="muted">No personal API tokens.</span></div>`}</div>
+      </section>
+    `
+  }
+
+  private renderToken(token: PersonalTokenSignal, scopes: PersonalTokenScopeSignal[]) {
+    const scope = scopes.find((option) => option.workspaceId === token.workspaceId)
+    const options = new Map(scope?.privileges.map((privilege) => [privilege.value, privilege.label]) ?? [])
+    const privileges = token.privileges.map((privilege) => options.get(privilege) ?? humanizePrivilege(privilege))
+    return html`<div class="row"><div class="settings-field"><span class="settings-label">${token.name}</span><span class="settings-description">${scope?.label || token.workspaceId || 'Legacy unrestricted scope'} · ${privileges.join(', ') || 'Inherited effective privileges'} · Created ${formatDate(token.createdAt)}${token.expiresAt ? ` · Expires ${formatDate(token.expiresAt)}` : ''}</span></div>${token.revokedAt ? html`<span class="muted">Revoked</span>` : html`<button class="danger" type="button" @click=${() => this.revokeToken(token.id)}>Revoke</button>`}</div>`
+  }
+
+  private saveProfile = (event: Event): void => { event.preventDefault(); this.send('lv-personal-profile-command', { action: 'save', displayName: this.profileName.trim() }) }
+  private changeTheme = (event: Event): void => {
+    const theme = (event.currentTarget as HTMLSelectElement).value
+    document.dispatchEvent(new CustomEvent('leapview-theme-change', { detail: { mode: theme } }))
+    this.send('lv-personal-theme-command', { action: 'save', theme })
+  }
+  private changePassword = (event: Event): void => { event.preventDefault(); this.send('lv-personal-password-command', { currentPassword: this.currentPassword, newPassword: this.newPassword }); this.currentPassword = ''; this.newPassword = '' }
+  private createToken = (event: Event): void => {
+    event.preventDefault()
+    const scope = this.selectedTokenScope(this.settings.tokens)
+    if (!this.tokenName.trim() || !scope || !this.tokenPrivileges.length) return
+    this.send('lv-personal-token-command', {
+      action: 'create', name: this.tokenName.trim(), workspaceId: scope.workspaceId,
+      privileges: [...this.tokenPrivileges], expiresAt: localDateTimeToRFC3339(this.tokenExpires),
+    })
+    this.tokenCreatePending = true
+  }
+  private revokeToken = (tokenId: string): void => { this.send('lv-personal-token-command', { action: 'revoke', tokenId }) }
+  private revokeSession = (sessionId: string): void => { this.send('lv-personal-session-command', { action: 'revoke', sessionId }) }
+  private revokeAuthoringSession = (sessionId: string): void => { this.send('lv-personal-authoring-session-command', { action: 'revoke', sessionId }) }
+  private toggleAvatarMenu = (): void => {
+    this.avatarMenuOpen = !this.avatarMenuOpen
+    if (this.avatarMenuOpen) void this.focusFirstAvatarMenuItem()
+  }
+  private handleAvatarTriggerKeydown = (event: KeyboardEvent): void => {
+    if (event.key !== 'ArrowDown') return
+    event.preventDefault()
+    this.avatarMenuOpen = true
+    void this.focusFirstAvatarMenuItem()
+  }
+  private focusFirstAvatarMenuItem = async (): Promise<void> => {
+    await this.updateComplete
+    this.renderRoot.querySelector<HTMLButtonElement>('[role="menuitem"]')?.focus()
+  }
+  private handleAvatarMenuKeydown = (event: KeyboardEvent): void => {
+    const items = Array.from(this.renderRoot.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)'))
+    const index = items.indexOf(this.shadowRoot?.activeElement as HTMLButtonElement)
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const offset = event.key === 'ArrowDown' ? 1 : -1
+      items[(index + offset + items.length) % items.length]?.focus()
+    } else if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault()
+      items[event.key === 'Home' ? 0 : items.length - 1]?.focus()
+    }
+  }
+  private chooseAvatar = (): void => {
+    this.avatarMenuOpen = false
+    this.avatarInput?.click()
+  }
+  private closeAvatarMenu(returnFocus = false): void {
+    if (!this.avatarMenuOpen) return
+    this.avatarMenuOpen = false
+    if (returnFocus) void this.updateComplete.then(() => this.avatarTrigger?.focus())
+  }
+  private handleDocumentPointerDown = (event: PointerEvent): void => {
+    const path = event.composedPath()
+    const avatarControl = this.renderRoot.querySelector('.avatar-control')
+    if (avatarControl && !path.includes(avatarControl)) this.closeAvatarMenu()
+    const permissionPicker = this.renderRoot.querySelector('.permission-picker')
+    if (permissionPicker && !path.includes(permissionPicker)) this.closePermissionMenu()
+  }
+  private handleWindowKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape' && this.avatarMenuOpen) {
+      event.preventDefault()
+      this.closeAvatarMenu(true)
+    }
+    if (event.key === 'Escape' && this.tokenPermissionMenuOpen) {
+      event.preventDefault()
+      this.closePermissionMenu(true)
+    }
+  }
+  private handleDatastarFetch = (event: Event): void => {
+    if (!this.tokenCreatePending) return
+    const detail = (event as CustomEvent<{ type?: string, argsRaw?: { status?: string } }>).detail
+    if (detail?.type !== 'error' && detail?.type !== 'retries-failed') return
+    this.tokenCreatePending = false
+    this.error = detail.argsRaw?.status === '403'
+      ? 'Token creation failed because this page expired. Reload the page and try again.'
+      : 'Token creation failed. Your selections were kept; please try again.'
+  }
+  private uploadAvatar = async (event: Event): Promise<void> => {
+    const input = event.currentTarget as HTMLInputElement
+    const file = input.files?.[0]
+    if (!file) return
+    this.avatarBusy = true
+    this.error = ''
+    try {
+      const response = await fetch('/profile/avatar', { method: 'PUT', headers: { ...window.LeapViewCommand.headers(), 'Content-Type': file.type }, body: file })
+      if (!response.ok) throw new Error('Avatar upload failed')
+      const uploaded = await response.json() as { url?: string }
+      document.dispatchEvent(new CustomEvent('leapview-avatar-change', { detail: { url: uploaded.url ?? '' } }))
+      this.send('lv-personal-profile-command', { action: 'refresh', displayName: this.profileName })
+      this.message = 'Profile picture updated.'
+    } catch (error) { this.error = error instanceof Error ? error.message : 'Avatar upload failed' } finally { this.avatarBusy = false; input.value = '' }
+  }
+  private deleteAvatar = async (): Promise<void> => {
+    this.avatarMenuOpen = false
+    if (!window.confirm('Remove your profile picture?')) return
+    this.avatarBusy = true
+    this.error = ''
+    try {
+      const response = await fetch('/profile/avatar', { method: 'DELETE', headers: window.LeapViewCommand.headers() })
+      if (!response.ok) throw new Error('Avatar removal failed')
+      document.dispatchEvent(new CustomEvent('leapview-avatar-change', { detail: { url: '' } }))
+      this.send('lv-personal-profile-command', { action: 'refresh', displayName: this.profileName })
+      this.message = 'Profile picture removed.'
+    } catch (error) { this.error = error instanceof Error ? error.message : 'Avatar removal failed' } finally { this.avatarBusy = false }
+  }
+  private send(name: string, detail: Record<string, unknown>): void { this.error = ''; this.message = ''; this.dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true, detail })) }
+  private onProfileNameInput = (event: Event): void => { this.profileName = (event.currentTarget as HTMLInputElement).value }
+  private onCurrentPasswordInput = (event: Event): void => { this.currentPassword = (event.currentTarget as HTMLInputElement).value }
+  private onNewPasswordInput = (event: Event): void => { this.newPassword = (event.currentTarget as HTMLInputElement).value }
+  private onTokenNameInput = (event: Event): void => { this.tokenName = (event.currentTarget as HTMLInputElement).value }
+  private onTokenExpiresInput = (event: Event): void => { this.tokenExpires = (event.currentTarget as HTMLInputElement).value }
+  private onTokenScopeChange = (event: Event): void => {
+    this.tokenScopeKey = (event.currentTarget as HTMLSelectElement).value
+    this.tokenPrivileges = []
+    this.closePermissionMenu()
+  }
+  private selectedTokenScope(tokens: PersonalSettingsSignal['tokens']): PersonalTokenScopeSignal | undefined {
+    return tokens.scopes.find((scope) => tokenScopeKey(scope) === this.tokenScopeKey)
+  }
+  private filteredTokenPrivileges(scope?: PersonalTokenScopeSignal): PersonalTokenPrivilegeSignal[] {
+    if (!scope) return []
+    const query = this.tokenPermissionSearch.trim().toLocaleLowerCase()
+    if (!query) return scope.privileges
+    return scope.privileges.filter((privilege) => `${privilege.label} ${privilege.description} ${privilege.category} ${privilege.value}`.toLocaleLowerCase().includes(query))
+  }
+  private togglePermissionMenu = (): void => {
+    this.tokenPermissionMenuOpen = !this.tokenPermissionMenuOpen
+    if (this.tokenPermissionMenuOpen) {
+      void this.updateComplete.then(() => {
+        this.fitPermissionMenu()
+        this.renderRoot.querySelector<HTMLInputElement>('.permission-search input')?.focus()
+      })
+    }
+  }
+  private fitPermissionMenu = (): void => {
+    if (!this.tokenPermissionMenuOpen || window.matchMedia('(max-width: 40rem)').matches) return
+    const menu = this.renderRoot.querySelector<HTMLElement>('.permission-menu')
+    if (!menu) return
+    menu.style.removeProperty('--permission-menu-max-height')
+    const availableHeight = Math.max(0, window.innerHeight - menu.getBoundingClientRect().top - 16)
+    menu.style.setProperty('--permission-menu-max-height', `${availableHeight}px`)
+  }
+  private closePermissionMenu(returnFocus = false): void {
+    if (!this.tokenPermissionMenuOpen) return
+    this.tokenPermissionMenuOpen = false
+    this.tokenPermissionSearch = ''
+    if (returnFocus) void this.updateComplete.then(() => this.permissionTrigger?.focus())
+  }
+  private onTokenPermissionSearch = (event: Event): void => { this.tokenPermissionSearch = (event.currentTarget as HTMLInputElement).value }
+  private toggleTokenPrivilege(value: string): void {
+    this.tokenPrivileges = this.tokenPrivileges.includes(value)
+      ? this.tokenPrivileges.filter((privilege) => privilege !== value)
+      : [...this.tokenPrivileges, value]
+  }
+  private removeTokenPrivilege(value: string): void { this.tokenPrivileges = this.tokenPrivileges.filter((privilege) => privilege !== value) }
+}
+
+function tokenScopeKey(scope: PersonalTokenScopeSignal): string {
+  return scope.kind === 'platform' ? 'platform' : `workspace:${scope.workspaceId}`
+}
+
+function groupTokenPrivileges(privileges: PersonalTokenPrivilegeSignal[]): Array<[string, PersonalTokenPrivilegeSignal[]]> {
+  const groups = new Map<string, PersonalTokenPrivilegeSignal[]>()
+  for (const privilege of privileges) {
+    const values = groups.get(privilege.category) ?? []
+    values.push(privilege)
+    groups.set(privilege.category, values)
+  }
+  return [...groups.entries()]
+}
+
+function humanizePrivilege(value: string): string {
+  return value.toLocaleLowerCase().split('_').filter(Boolean).map((part, index) => index === 0 ? `${part.charAt(0).toLocaleUpperCase()}${part.slice(1)}` : part).join(' ')
+}
+
+function formatDate(value: string): string {
+  if (!value) return 'unknown'
+  const date = new Date(value)
+  return Number.isNaN(date.valueOf()) ? value : date.toLocaleString()
+}
+
+function localDateTimeToRFC3339(value: string): string {
+  if (!value) return ''
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.valueOf()) ? '' : parsed.toISOString()
+}
+
+customElements.define('lv-personal-settings', LeapViewPersonalSettings)
+
+export { LeapViewPersonalSettings }

--- a/web/components/admin/product-settings.dom.test.ts
+++ b/web/components/admin/product-settings.dom.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import { createServer, type Server } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { join, normalize } from 'node:path'
+import { chromium, type Browser } from '@playwright/test'
+import { datastarRuntimeURL } from '../shared/datastar-runtime'
+import { typographyTestTokens } from '../test-typography-tokens'
+
+let server: Server
+let baseURL = ''
+let browser: Browser
+
+const projectRoot = process.cwd()
+const root = join(projectRoot, '.tmp/product-settings-test')
+const bundle = join(root, 'product-settings-under-test.js')
+
+beforeAll(async () => {
+  await Bun.$`rm -rf ${root}`.quiet()
+  const built = await Bun.build({
+    entrypoints: ['web/components/admin/product-settings.ts'],
+    target: 'browser',
+    format: 'esm',
+    external: [datastarRuntimeURL],
+    outdir: root,
+    naming: { entry: 'product-settings-under-test.js' },
+  })
+  if (!built.success) throw new Error('failed to build product settings test bundle')
+  server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+    if (url.pathname === '/') {
+      response.setHeader('content-type', 'text/html')
+      response.end(testDocument())
+      return
+    }
+    const fileRoot = url.pathname.startsWith('/static/vendor/') ? projectRoot : root
+    const file = normalize(join(fileRoot, url.pathname))
+    if (!file.startsWith(fileRoot)) {
+      response.writeHead(404)
+      response.end('not found')
+      return
+    }
+    try {
+      response.setHeader('content-type', file.endsWith('.css') ? 'text/css' : 'text/javascript')
+      response.end(await readFile(file))
+    } catch {
+      response.writeHead(404)
+      response.end('not found')
+    }
+  })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('test server did not bind to a port')
+  baseURL = `http://127.0.0.1:${address.port}`
+  browser = await chromium.launch()
+})
+
+afterAll(async () => {
+  await browser?.close()
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+}, 15_000)
+
+test('product settings renders redacted sections and emits typed identity commands', async () => {
+  const page = await browser.newPage({ viewport: { width: 1100, height: 760 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('lv-product-settings'))
+    const state = await page.evaluate(async () => {
+      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev') as any
+      mergePatch({ productSettings: {
+        active: 'general', canManage: true,
+        general: { displayName: 'Acme Analytics', revision: 7, updatedAt: '2026-08-11T00:00:00Z', instanceId: 'lvinst_test', canonicalOrigin: 'https://example.test', environment: 'production', logo: { url: '/logo.png', sha256: 'abc', mediaType: 'image/png', sizeBytes: 3, width: 16, height: 8 } },
+        authentication: { browserEnabled: true, apiTokenOnly: false, local: { available: true, enabled: true }, oidc: { available: true, enabled: true, provider: 'corporate' }, azure: { available: true, enabled: false }, scim: { available: true, enabled: true }, managedBy: 'deployment' },
+        api: { bearerCredentials: { available: true, enabled: true }, servicePrincipals: { available: true, enabled: true }, oauth: { available: true, enabled: true }, mcp: { available: true, enabled: true }, externalMcpIssuer: false },
+        system: { instanceId: 'lvinst_test', canonicalOrigin: 'https://example.test', environment: 'production', build: { version: '1.2.3', revision: 'abcdef', buildTime: 'now', dirty: false, development: false }, storageBackend: 'local', agent: { available: true, configured: true, provider: 'openai-compatible', modelConfigured: true }, limits: { queryResultMaxRows: 10, queryResultMaxBytes: 1024, managedDataMaxFiles: 2, managedDataMaxFileBytes: 3, managedDataMaxRevisionBytes: 4 }, runtime: { health: 'healthy', controlPlane: 'available', environment: 'production' } },
+      } })
+      const element = document.querySelector('lv-product-settings') as any
+      await element.updateComplete
+      let command: unknown = null
+      element.addEventListener('lv-product-settings-command', (event: CustomEvent) => { command = event.detail })
+      const input = element.shadowRoot.querySelector('input[type="text"]') as HTMLInputElement
+      input.value = 'Acme BI'
+      input.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      ;(Array.from(element.shadowRoot.querySelectorAll('button')) as HTMLButtonElement[]).find((button) => button.textContent?.trim() === 'Save')?.click()
+      await element.updateComplete
+      const saveCommand = command
+      ;(Array.from(element.shadowRoot.querySelectorAll('button')) as HTMLButtonElement[]).find((button) => button.textContent?.trim() === 'Reset to LeapView')?.click()
+      const resetCommand = command
+      const generalText = element.shadowRoot.textContent.replace(/\s+/g, ' ').trim()
+      const fieldLabelFontSize = getComputedStyle(element.shadowRoot.querySelector('.settings-label')!).fontSize
+      mergePatch({ productSettings: { active: 'authentication' } })
+      await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+      await element.updateComplete
+      return {
+        generalText,
+        inputValue: input.value,
+        authText: element.shadowRoot.textContent.replace(/\s+/g, ' ').trim(),
+        saveCommand,
+        resetCommand,
+        fieldLabelFontSize,
+      }
+    })
+    expect(state.generalText).toContain('Instance identity')
+    expect(state.generalText).toContain('Powered by LeapView')
+    expect(state.inputValue).toBe('Acme BI')
+    expect(state.generalText).toContain('Instance ID')
+    expect(state.authText).toContain('Managed by deployment')
+    expect(state.authText).toContain('API and protocol availability')
+    expect(state.saveCommand).toEqual({ action: 'save_display_name', displayName: 'Acme BI', revision: 7 })
+    expect(state.resetCommand).toEqual({ action: 'reset_identity', revision: 7 })
+    expect(state.fieldLabelFontSize).toBe('14px')
+  } finally {
+    await page.close()
+  }
+})
+
+test('logo upload preserves product ETag and CSRF token', async () => {
+  const page = await browser.newPage()
+  try {
+    await page.route('**/admin/product-logo', async (route) => {
+      await route.fulfill({ status: 200, headers: { ETag: '"product-8"', 'content-type': 'application/json' }, body: '{}' })
+    })
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('lv-product-settings'))
+    await page.evaluate(async () => {
+      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev') as any
+      mergePatch({ productSettings: {
+        active: 'general', canManage: true,
+        general: { displayName: 'Acme', revision: 7, updatedAt: '', instanceId: '', canonicalOrigin: '', environment: '' },
+        authentication: { browserEnabled: false, apiTokenOnly: false, local: { available: false, enabled: false }, oidc: { available: false, enabled: false }, azure: { available: false, enabled: false }, scim: { available: false, enabled: false }, managedBy: 'deployment' },
+        api: { bearerCredentials: { available: false, enabled: false }, servicePrincipals: { available: false, enabled: false }, oauth: { available: false, enabled: false }, mcp: { available: false, enabled: false }, externalMcpIssuer: false },
+        system: { instanceId: '', canonicalOrigin: '', environment: '', build: { version: '', revision: '', buildTime: '', dirty: false, development: false }, storageBackend: '', agent: { available: false, configured: false, modelConfigured: false }, limits: { queryResultMaxRows: 0, queryResultMaxBytes: 0, managedDataMaxFiles: 0, managedDataMaxFileBytes: 0, managedDataMaxRevisionBytes: 0 }, runtime: { health: '', controlPlane: '', environment: '' } },
+      } })
+      await (document.querySelector('lv-product-settings') as any).updateComplete
+    })
+    const input = page.locator('lv-product-settings').locator('input[type="file"]')
+    const requestPromise = page.waitForRequest('**/admin/product-logo')
+    await input.setInputFiles({ name: 'logo.png', mimeType: 'image/png', buffer: Buffer.from('png') })
+    const request = await requestPromise
+    expect(request.method()).toBe('PUT')
+    expect(request.headers()['if-match']).toBe('"product-7"')
+    expect(request.headers()['x-csrf-token']).toBe('test-csrf')
+  } finally {
+    await page.close()
+  }
+})
+
+function testDocument(): string {
+  return `<!doctype html><html><head><meta name="csrf-token" content="test-csrf"><style>body { ${typographyTestTokens} }</style></head><body><lv-product-settings></lv-product-settings><script type="module" src="/product-settings-under-test.js"></script></body></html>`
+}

--- a/web/components/admin/product-settings.ts
+++ b/web/components/admin/product-settings.ts
@@ -1,0 +1,323 @@
+import { LitElement, css, html, nothing } from 'lit'
+import { state } from 'lit/decorators.js'
+import { DatastarLit } from '../shared/datastar-lit'
+import { settingsFieldStyles } from '../shared/settings-field-styles'
+import type {
+  ProductAPIStatusSignal,
+  ProductAuthenticationSignal,
+  ProductAvailabilitySignal,
+  ProductGeneralSignal,
+  ProductSettingsCommand,
+  ProductSettingsSignal,
+  ProductSystemSignal,
+} from '../../generated/signals'
+
+type ProductSection = 'general' | 'authentication' | 'system'
+
+const emptyProductSettings: ProductSettingsSignal = {
+  active: 'general', canManage: false,
+  general: { displayName: '', revision: 0, updatedAt: '', instanceId: '', canonicalOrigin: '', environment: '' },
+  authentication: {
+    browserEnabled: false, apiTokenOnly: false,
+    local: { available: false, enabled: false }, oidc: { available: false, enabled: false },
+    azure: { available: false, enabled: false }, scim: { available: false, enabled: false }, managedBy: 'deployment',
+  },
+  api: {
+    bearerCredentials: { available: false, enabled: false }, servicePrincipals: { available: false, enabled: false },
+    oauth: { available: false, enabled: false }, mcp: { available: false, enabled: false }, externalMcpIssuer: false,
+  },
+  system: {
+    instanceId: '', canonicalOrigin: '', environment: '',
+    build: { version: '', revision: '', buildTime: '', dirty: false, development: false },
+    storageBackend: '', agent: { available: false, configured: false, modelConfigured: false },
+    limits: { queryResultMaxRows: 0, queryResultMaxBytes: 0, managedDataMaxFiles: 0, managedDataMaxFileBytes: 0, managedDataMaxRevisionBytes: 0 },
+    runtime: { health: '', controlPlane: '', environment: '' },
+  },
+}
+
+/**
+ * Platform settings rendered from the page-stream `productSettings` signal.
+ * Text edits and destructive actions emit typed commands; only a binary logo
+ * body uses the same-origin browser upload route.
+ */
+export class LeapViewProductSettings extends DatastarLit(LitElement) {
+  @state() private selectedSection: ProductSection = 'general'
+  @state() private displayNameDraft = ''
+  @state() private busy = false
+  @state() private message = ''
+  private lastRevision = -1
+
+  static styles = [settingsFieldStyles, css`
+    :host { display: block; min-width: 0; color: var(--lv-fg-default); font: var(--lv-type-body); }
+    .settings { display: grid; gap: var(--base-size-24); max-width: 72rem; }
+    .panel { display: grid; gap: 1rem; border: var(--lv-border-muted); border-radius: var(--lv-radius-default); background: var(--lv-bg-panel); padding: 1rem; }
+    .panel h2, .panel h3, .panel p { margin: 0; }
+    .panel h2 { font: var(--lv-type-section-title); }
+    .panel h3 { font: var(--lv-type-body); font-weight: var(--base-text-weight-semibold); }
+    .hint { color: var(--lv-fg-muted); font: var(--lv-type-caption); line-height: var(--base-text-lineHeight-snug); }
+    .row { display: grid; grid-template-columns: minmax(10rem, 15rem) minmax(0, 1fr); gap: .75rem; align-items: center; border-top: var(--lv-border-muted); padding-top: .75rem; }
+    .row:first-of-type { border-top: 0; padding-top: 0; }
+    input[type="text"] { box-sizing: border-box; width: min(100%, 32rem); border: var(--lv-border-default); border-radius: var(--lv-radius-small); background: var(--lv-bg-control); color: inherit; padding: .45rem .6rem; font: var(--lv-type-body-compact); }
+    button.action { border: var(--lv-border-default); border-radius: var(--lv-radius-small); background: var(--lv-button-bg-rest); color: var(--lv-button-fg-rest); cursor: pointer; padding: .42rem .7rem; font: var(--lv-type-body-compact); }
+    button.action.primary { border-color: var(--lv-bg-accent); background: var(--lv-bg-accent); color: var(--lv-fg-on-accent); }
+    button.action.danger { border-color: var(--lv-border-danger); color: var(--lv-fg-danger); }
+    button.action:disabled { cursor: not-allowed; opacity: .55; }
+    .inline { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; }
+    .logo { display: flex; align-items: center; gap: .75rem; }
+    .logo img { width: 3.25rem; height: 3.25rem; border: var(--lv-border-muted); border-radius: var(--lv-radius-small); object-fit: contain; background: var(--lv-bg-panel); }
+    .identity-preview { display: flex; min-width: 0; align-items: center; gap: var(--base-size-12); border: var(--lv-border-muted); border-radius: var(--lv-radius-default); background: var(--lv-bg-panel-muted); padding: var(--base-size-12); }
+    .identity-preview img, .identity-fallback { box-sizing: border-box; display: grid; width: var(--control-large-size); height: var(--control-large-size); flex: 0 0 auto; place-items: center; border: var(--lv-border-muted); border-radius: var(--lv-radius-small); background: var(--lv-bg-panel); object-fit: contain; color: var(--lv-fg-muted); font: var(--lv-type-body); font-weight: var(--base-text-weight-semibold); }
+    .identity-copy { display: grid; min-width: 0; gap: var(--base-size-2); }
+    .identity-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: var(--lv-type-body); font-weight: var(--base-text-weight-semibold); }
+    .attribution { color: var(--lv-fg-muted); text-decoration: none; font: var(--lv-type-caption); }
+    .attribution:hover, .attribution:focus-visible { color: var(--lv-fg-default); text-decoration: underline; }
+    .file-action { position: relative; display: inline-flex; align-items: center; border: var(--lv-border-default); border-radius: var(--lv-radius-small); background: var(--lv-button-bg-rest); color: var(--lv-button-fg-rest); cursor: pointer; padding: .42rem .7rem; font: var(--lv-type-body-compact); }
+    .file-action:focus-within { outline: var(--borderWidth-thick) solid var(--focus-outlineColor); outline-offset: -1px; }
+    .file-action.disabled { cursor: not-allowed; opacity: .55; }
+    .file-action input { position: absolute; width: 1px; height: 1px; opacity: 0; overflow: hidden; }
+    .about-links { display: flex; flex-wrap: wrap; gap: var(--base-size-16); }
+    .about-links a { color: var(--lv-fg-accent); }
+    .status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); gap: .65rem; }
+    .status-card { display: grid; gap: .3rem; border: var(--lv-border-muted); border-radius: var(--lv-radius-small); padding: .7rem; }
+    .status-card strong { font: var(--lv-type-body); font-weight: var(--base-text-weight-semibold); }
+    .status { font: var(--lv-type-caption); }
+    .status.enabled { color: var(--lv-fg-success); }
+    .status.disabled { color: var(--lv-fg-muted); }
+    .notice { border-radius: var(--lv-radius-small); background: var(--lv-bg-panel-muted); color: var(--lv-fg-muted); padding: .6rem .7rem; font: var(--lv-type-caption); }
+    .message { color: var(--lv-fg-muted); font: var(--lv-type-caption); }
+    @media (max-width: 620px) { .row { grid-template-columns: 1fr; gap: .35rem; } }
+  `]
+
+  private get settings(): ProductSettingsSignal {
+    return this.signal<ProductSettingsSignal>('productSettings', emptyProductSettings)
+  }
+
+  override updated(): void {
+    const revision = this.settings.general.revision
+    if (revision !== this.lastRevision) {
+      this.lastRevision = revision
+      this.displayNameDraft = this.settings.general.displayName
+    }
+    const active = this.settings.active as ProductSection
+    if ((active === 'general' || active === 'authentication' || active === 'system') && active !== this.selectedSection) this.selectedSection = active
+  }
+
+  render() {
+    const settings = this.settings
+    return html`
+      <div class="settings" aria-label="Product settings">
+        ${settings.error ? html`<div class="notice" role="alert">${settings.error}</div>` : nothing}
+        ${this.selectedSection === 'general' ? this.renderGeneral(settings.general, settings.canManage) : nothing}
+        ${this.selectedSection === 'authentication' ? this.renderAuthentication(settings.authentication, settings.api) : nothing}
+        ${this.selectedSection === 'system' ? this.renderSystem(settings.system, settings.api) : nothing}
+        ${this.message ? html`<div class="message" role="status">${this.message}</div>` : nothing}
+      </div>
+    `
+  }
+
+  private renderGeneral(general: ProductGeneralSignal, canManage: boolean) {
+    const previewName = this.displayNameDraft.trim() || 'LeapView'
+    const resetDisabled = !canManage || this.busy || (general.displayName === 'LeapView' && !general.logo)
+    return html`
+      <section class="panel" aria-label="Instance identity settings">
+        <h2>Instance identity</h2>
+        <p class="hint">Choose the name and logo shown in the application. Customized instances retain a subtle link back to LeapView.</p>
+        <div class="identity-preview" aria-label="Instance identity preview">
+          ${general.logo
+            ? html`<img src=${general.logo.url} alt="">`
+            : html`<span class="identity-fallback" aria-hidden="true">${previewName.slice(0, 1).toLocaleUpperCase()}</span>`}
+          <span class="identity-copy">
+            <span class="identity-name">${previewName}</span>
+            <a class="attribution" href="https://leapview.dev" target="_blank" rel="noreferrer">Powered by LeapView</a>
+          </span>
+        </div>
+        <div class="row">
+          <div class="settings-field"><span class="settings-label">Instance name</span><span class="settings-description">Used in navigation and browser titles · 120 characters maximum</span></div>
+          <div class="inline">
+            <input type="text" maxlength="120" .value=${this.displayNameDraft} ?disabled=${!canManage || this.busy} @input=${this.handleDisplayNameInput}>
+            <button class="action primary" type="button" ?disabled=${!canManage || this.busy || this.displayNameDraft.trim() === general.displayName} @click=${this.saveDisplayName}>Save</button>
+          </div>
+        </div>
+        <div class="row">
+          <div class="settings-field"><span class="settings-label">Instance logo</span><span class="settings-description">JPEG, PNG, or WebP · 5 MB maximum</span></div>
+          <div class="inline">
+            ${general.logo ? html`<div class="logo"><img src=${general.logo.url} alt="Product logo"><span class="hint">${general.logo.width} × ${general.logo.height}</span></div>` : html`<span class="settings-value">No logo configured</span>`}
+            <label class=${`file-action ${!canManage || this.busy ? 'disabled' : ''}`}>
+              <span>${general.logo ? 'Change logo' : 'Upload logo'}</span>
+              <input type="file" accept="image/jpeg,image/png,image/webp" ?disabled=${!canManage || this.busy} @change=${this.handleLogoFile}>
+            </label>
+            ${general.logo ? html`<button class="action danger" type="button" ?disabled=${!canManage || this.busy} @click=${this.removeLogo}>Remove</button>` : nothing}
+          </div>
+        </div>
+        <div class="row">
+          <div class="settings-field"><span class="settings-label">LeapView defaults</span><span class="settings-description">Restore the default name and remove the custom logo</span></div>
+          <button class="action" type="button" ?disabled=${resetDisabled} @click=${this.resetIdentity}>Reset to LeapView</button>
+        </div>
+        ${!canManage ? html`<div class="notice">You have read-only access. MANAGE_PLATFORM is required to change product identity.</div>` : nothing}
+      </section>
+      <section class="panel" aria-label="Instance details">
+        <h2>Instance details</h2>
+        <p class="hint">Read-only deployment metadata for this installation.</p>
+        <div class="row"><div class="settings-label">Instance ID</div><span class="settings-value">${general.instanceId || 'Unknown'}</span></div>
+        <div class="row"><div class="settings-label">Canonical origin</div><span class="settings-value">${general.canonicalOrigin || 'Unknown'}</span></div>
+        <div class="row"><div class="settings-label">Environment</div><span class="settings-value">${general.environment || 'Unknown'}</span></div>
+        <div class="row"><div class="settings-label">Last updated</div><span class="settings-value">${general.updatedAt || 'Unknown'} · revision ${general.revision || 'unknown'}</span></div>
+      </section>
+    `
+  }
+
+  private renderAuthentication(auth: ProductAuthenticationSignal, api: ProductAPIStatusSignal) {
+    return html`
+      <section class="panel" aria-label="Authentication settings">
+        <h2>Authentication</h2>
+        <p class="hint">Deployment-managed authentication configuration. Secrets, issuer URLs, tenant IDs, and callback URLs are never exposed here.</p>
+        <div class="notice">Managed by <strong>${auth.managedBy || 'deployment'}</strong>; configuration changes are made through deployment settings.</div>
+        <div class="status-grid">
+          ${this.statusCard('Browser sign-in', auth.browserEnabled, auth.browserEnabled ? 'Enabled' : 'Disabled')}
+          ${this.statusCard('API-token-only mode', auth.apiTokenOnly, auth.apiTokenOnly ? 'Enabled' : 'Disabled')}
+          ${this.statusCard('Local credentials', auth.local.enabled, availabilityLabel(auth.local))}
+          ${this.statusCard('OIDC', auth.oidc.enabled, `${availabilityLabel(auth.oidc)}${auth.oidc.provider ? ` · ${auth.oidc.provider}` : ''}`)}
+          ${this.statusCard('Azure', auth.azure.enabled, availabilityLabel(auth.azure))}
+          ${this.statusCard('SCIM provisioning', auth.scim.enabled, availabilityLabel(auth.scim))}
+        </div>
+        <h3>API and protocol availability</h3>
+        <div class="status-grid">
+          ${this.statusCard('Bearer credentials', api.bearerCredentials.enabled, availabilityLabel(api.bearerCredentials))}
+          ${this.statusCard('Service principals', api.servicePrincipals.enabled, availabilityLabel(api.servicePrincipals))}
+          ${this.statusCard('OAuth', api.oauth.enabled, availabilityLabel(api.oauth))}
+          ${this.statusCard('MCP', api.mcp.enabled, availabilityLabel(api.mcp))}
+          ${this.statusCard('External MCP issuer', api.externalMcpIssuer, api.externalMcpIssuer ? 'Configured' : 'Not configured')}
+        </div>
+      </section>
+    `
+  }
+
+  private renderSystem(system: ProductSystemSignal, api: ProductAPIStatusSignal) {
+    const build = system.build
+    const limits = system.limits
+    const agent = system.agent
+    return html`
+      <section class="panel" aria-label="System settings">
+        <h2>System</h2>
+        <p class="hint">Runtime health and safe operational metadata for this instance.</p>
+        <div class="status-grid">
+          ${this.statusCard('Runtime health', system.runtime.health === 'healthy', system.runtime.health || 'Unknown')}
+          ${this.statusCard('Control plane', system.runtime.controlPlane === 'available', system.runtime.controlPlane || 'Unknown')}
+          ${this.statusCard('Agent', agent.configured, agent.configured ? `${agent.provider || 'Configured'}${agent.modelConfigured ? ' · model ready' : ' · model missing'}` : 'Not configured')}
+          ${this.statusCard('Storage backend', Boolean(system.storageBackend), system.storageBackend || 'Unknown')}
+        </div>
+        <div class="row"><div class="settings-label">Instance ID</div><span class="settings-value">${system.instanceId || 'Unknown'}</span></div>
+        <div class="row"><div class="settings-label">Canonical origin</div><span class="settings-value">${system.canonicalOrigin || 'Unknown'}</span></div>
+        <div class="row"><div class="settings-label">Environment</div><span class="settings-value">${system.environment || 'Unknown'}</span></div>
+        <h3>Build</h3>
+        <div class="status-grid">
+          ${this.statusCard('Version', Boolean(build.version), build.version || 'Unknown')}
+          ${this.statusCard('Revision', Boolean(build.revision), build.revision || 'Unknown')}
+          ${this.statusCard('Build time', Boolean(build.buildTime), build.buildTime || 'Unknown')}
+          ${this.statusCard('Build state', !build.dirty, build.dirty ? 'Dirty' : build.development ? 'Development' : 'Release')}
+        </div>
+        <h3>Limits</h3>
+        <div class="status-grid">
+          ${this.limitCard('Query result rows', limits.queryResultMaxRows)}
+          ${this.limitCard('Query result bytes', limits.queryResultMaxBytes)}
+          ${this.limitCard('Managed-data files', limits.managedDataMaxFiles)}
+          ${this.limitCard('Managed-data file bytes', limits.managedDataMaxFileBytes)}
+          ${this.limitCard('Managed-data revision bytes', limits.managedDataMaxRevisionBytes)}
+        </div>
+        <h3>API and protocol</h3>
+        <p class="hint">${api.externalMcpIssuer ? 'External MCP issuer is available.' : 'External MCP issuer is not configured.'} API capabilities remain deployment-managed.</p>
+      </section>
+      <section class="panel" aria-label="About LeapView">
+        <h2>About LeapView</h2>
+        <p>Powered by LeapView, open-source dashboards-as-code business intelligence.</p>
+        <div class="about-links">
+          <a href="https://leapview.dev" target="_blank" rel="noreferrer">LeapView website</a>
+          <a href="https://github.com/flidai/leapview" target="_blank" rel="noreferrer">View source</a>
+        </div>
+        <p class="hint">Build ${build.version || 'development'}${build.revision ? ` · ${build.revision}` : ''}</p>
+      </section>
+    `
+  }
+
+  private statusCard(label: string, enabled: boolean, value: string) {
+    return html`<div class="status-card"><strong>${label}</strong><span class=${`status ${enabled ? 'enabled' : 'disabled'}`}>${value}</span></div>`
+  }
+
+  private limitCard(label: string, value: number) {
+    return html`<div class="status-card"><strong>${label}</strong><span class="settings-value">${formatLimit(value)}</span></div>`
+  }
+
+  private handleDisplayNameInput = (event: Event): void => {
+    this.displayNameDraft = (event.currentTarget as HTMLInputElement).value
+  }
+
+  private saveDisplayName = (): void => {
+    this.emitCommand({ action: 'save_display_name', displayName: this.displayNameDraft, revision: this.settings.general.revision })
+  }
+
+  private removeLogo = (): void => {
+    this.emitCommand({ action: 'remove_logo', revision: this.settings.general.revision })
+  }
+
+  private resetIdentity = (): void => {
+    this.emitCommand({ action: 'reset_identity', revision: this.settings.general.revision })
+  }
+
+  private emitCommand(command: ProductSettingsCommand): void {
+    this.dispatchEvent(new CustomEvent<ProductSettingsCommand>('lv-product-settings-command', { bubbles: true, composed: true, detail: command }))
+  }
+
+  private handleLogoFile = async (event: Event): Promise<void> => {
+    const input = event.currentTarget as HTMLInputElement
+    const file = input.files?.[0]
+    if (!file) return
+    const settings = this.settings
+    if (!settings.canManage) return
+    this.busy = true
+    this.message = ''
+    try {
+      const response = await fetch('/admin/product-logo', {
+        method: 'PUT',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': file.type,
+          'If-Match': productETag(settings.general.revision),
+          'X-CSRF-Token': csrfToken(),
+        },
+        body: file,
+      })
+      if (!response.ok) throw new Error(`Logo upload failed (${response.status})`)
+      this.message = 'Logo uploaded.'
+      this.dispatchEvent(new CustomEvent('lv-product-settings-logo-updated', { bubbles: true, composed: true, detail: { etag: response.headers.get('ETag') ?? '' } }))
+      this.emitCommand({ action: 'refresh', revision: 0 })
+    } catch (error) {
+      this.message = error instanceof Error ? error.message : 'Logo upload failed.'
+    } finally {
+      this.busy = false
+      input.value = ''
+    }
+  }
+}
+
+function availabilityLabel(status: ProductAvailabilitySignal): string {
+  if (!status.available) return 'Unavailable'
+  return status.enabled ? 'Enabled' : 'Disabled'
+}
+
+function formatLimit(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return 'Not configured'
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)} GB`
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)} MB`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)} KB`
+  return value.toLocaleString()
+}
+
+function productETag(revision: number): string {
+  return `"product-${revision}"`
+}
+
+function csrfToken(): string {
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? ''
+}
+
+if (!customElements.get('lv-product-settings')) customElements.define('lv-product-settings', LeapViewProductSettings)

--- a/web/components/admin/settings-surfaces.dom.test.ts
+++ b/web/components/admin/settings-surfaces.dom.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import { createServer, type Server } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { join, normalize } from 'node:path'
+import { chromium, type Browser } from '@playwright/test'
+
+let server: Server
+let browser: Browser
+let baseURL = ''
+const projectRoot = process.cwd()
+const root = join(projectRoot, '.tmp/settings-surfaces-test')
+
+beforeAll(async () => {
+  await Bun.$`mkdir -p ${root}`
+  const result = await Bun.build({ entrypoints: [join(projectRoot, 'web/components/admin/settings-surfaces.ts')], outdir: root, naming: 'settings-surfaces.js', target: 'browser', minify: false })
+  if (!result.success) throw new Error('settings surface bundle failed')
+  server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+    if (url.pathname === '/') {
+      response.setHeader('content-type', 'text/html')
+      response.end('<!doctype html><main><lv-workspace-registry></lv-workspace-registry><lv-service-accounts></lv-service-accounts><lv-audit-log></lv-audit-log><script type="module" src="/settings-surfaces.js"></script></main>')
+      return
+    }
+    const file = normalize(join(root, url.pathname))
+    if (!file.startsWith(root)) { response.writeHead(404); response.end(); return }
+    try { response.setHeader('content-type', 'text/javascript'); response.end(await readFile(file)) } catch { response.writeHead(404); response.end() }
+  })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('test server did not bind')
+  baseURL = `http://127.0.0.1:${address.port}`
+  browser = await chromium.launch()
+})
+
+afterAll(async () => {
+  await browser?.close()
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+})
+
+test('settings surfaces render typed signals and emit commands', async () => {
+  const page = await browser.newPage()
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('lv-service-accounts'))
+    const result = await page.evaluate(async () => {
+      const runtime = await import('/settings-surfaces.js') as any
+      runtime.setDatastarLitRuntimeForTests?.({ root: { adminServiceAccounts: { items: [{ id: 'svc-1', displayName: 'CI', kind: 'service_principal' }], secrets: [] } }, getPath: (path: string) => (path === 'adminServiceAccounts' ? { items: [{ id: 'svc-1', displayName: 'CI', kind: 'service_principal' }], secrets: [] } : undefined), effect: (fn: () => void) => { fn(); return () => {} } })
+      const element = document.querySelector('lv-service-accounts') as any
+      element.requestUpdate()
+      await element.updateComplete
+      let detail: unknown = null
+      element.addEventListener('lv-service-account-command', (event: CustomEvent) => { detail = event.detail })
+      ;(element.shadowRoot.querySelector('tbody button') as HTMLButtonElement).click()
+      return { text: element.shadowRoot.textContent?.replace(/\s+/g, ' ').trim(), detail }
+    })
+    expect(result.text).toContain('CI')
+    expect(result.detail).toEqual({ action: 'select', accountId: 'svc-1' })
+  } finally { await page.close() }
+})

--- a/web/components/admin/settings-surfaces.dom.test.ts
+++ b/web/components/admin/settings-surfaces.dom.test.ts
@@ -57,3 +57,70 @@ test('settings surfaces render typed signals and emit commands', async () => {
     expect(result.detail).toEqual({ action: 'select', accountId: 'svc-1' })
   } finally { await page.close() }
 })
+
+test('workspace registry uses the shared searchable entity list', async () => {
+  const page = await browser.newPage()
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('lv-workspace-registry') && customElements.get('lv-entity-list'))
+    const result = await page.evaluate(async () => {
+      const runtime = await import('/settings-surfaces.js') as any
+      const registry = {
+        items: [
+          {
+            id: 'sales', title: 'Sales', description: 'Revenue reporting', href: '/workspaces/sales',
+            owner: { subjectType: 'principal', subjectId: 'owner-1', displayName: 'Ada Lovelace', email: 'ada@example.com' },
+            administrators: [{ subjectType: 'principal', subjectId: 'admin-1', displayName: 'Grace Hopper', role: 'admin' }],
+            environment: 'production', deploymentStatus: 'Active', updatedAt: '2026-08-11T08:00:00Z', links: { self: '/api/v1/workspaces/sales', workspace: '/workspaces/sales' },
+          },
+          {
+            id: 'retail', title: 'Retail', description: 'Store operations', href: '/workspaces/retail',
+            administrators: [], environment: 'development', servingStateStatus: 'Not deployed', updatedAt: '2026-08-10T08:00:00Z',
+            links: { self: '/api/v1/workspaces/retail', workspace: '/workspaces/retail' },
+          },
+        ],
+        loading: false,
+        hasMore: false,
+      }
+      runtime.setDatastarLitRuntimeForTests?.({
+        root: { adminWorkspaces: registry },
+        getPath: (path: string) => path === 'adminWorkspaces' ? registry : undefined,
+        effect: (fn: () => void) => { fn(); return () => {} },
+      })
+      const element = document.querySelector('lv-workspace-registry') as any
+      element.requestUpdate()
+      await element.updateComplete
+      const list = element.shadowRoot.querySelector('lv-entity-list') as any
+      await list.updateComplete
+      const rows = () => Array.from(element.shadowRoot.querySelectorAll('.entity-list-table-row')).map((row: Element) => row.textContent?.replace(/\s+/g, ' ').trim())
+      const initialRows = rows()
+      const input = element.shadowRoot.querySelector('.entity-search input') as HTMLInputElement
+      input.value = 'retail'
+      input.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      await list.updateComplete
+      return {
+        hasSharedList: Boolean(list),
+        ownTableCount: element.shadowRoot.querySelectorAll(':scope > section > .table-wrap').length,
+        headings: Array.from(element.shadowRoot.querySelectorAll('h2')).map((heading) => heading.textContent?.trim()),
+        headers: Array.from(element.shadowRoot.querySelectorAll('.entity-list-sort-button > span:first-child')).map((header) => header.textContent?.trim()),
+        initialRows,
+        filteredRows: rows(),
+        firstHref: element.shadowRoot.querySelector('.entity-list-identity')?.getAttribute('href'),
+      }
+    })
+
+    expect(result.hasSharedList).toBe(true)
+    expect(result.ownTableCount).toBe(0)
+    expect(result.headings).toEqual([])
+    expect(result.headers).toEqual(['Name', 'Owner', 'Administrators', 'Environment', 'Deployment', 'Updated'])
+    expect(result.initialRows).toHaveLength(2)
+    expect(result.initialRows[0]).toContain('Sales Revenue reporting')
+    expect(result.initialRows[0]).toContain('Ada Lovelace')
+    expect(result.initialRows[0]).toContain('Grace Hopper')
+    expect(result.initialRows[0]).toContain('production')
+    expect(result.initialRows[0]).toContain('Active')
+    expect(result.filteredRows).toHaveLength(1)
+    expect(result.filteredRows[0]).toContain('Retail Store operations')
+    expect(result.firstHref).toBe('/workspaces/retail')
+  } finally { await page.close() }
+})

--- a/web/components/admin/settings-surfaces.ts
+++ b/web/components/admin/settings-surfaces.ts
@@ -1,6 +1,8 @@
 import { LitElement, css, html, nothing } from 'lit'
 import { DatastarLit } from '../shared/datastar-lit'
 import type { AuditLogSignal, ServiceAccountSignal, ServiceAccountsSignal, WorkspaceRegistrySignal } from '../../generated/signals'
+import '../shared/entity-list'
+import type { EntityListColumn, EntityListItem } from '../shared/entity-list'
 
 const tableStyles = css`
   :host { display: block; color: var(--lv-fg-default); font: var(--lv-type-body); font-family: var(--fontStack-system); }
@@ -32,21 +34,70 @@ class LeapViewWorkspaceRegistry extends DatastarLit(LitElement) {
   render() {
     const signal = this.registry
     return html`<section class="surface" aria-label="Workspaces">
-      <h2>Workspaces</h2>
       ${signal.error ? html`<p class="error" role="alert">${signal.error}</p>` : nothing}
       ${signal.loading ? html`<p class="muted" aria-live="polite">Loading workspaces…</p>` : nothing}
-      ${signal.items?.length ? html`<div class="table-wrap"><table>
-        <thead><tr><th>Name</th><th>Owner</th><th>Administrators</th><th>Deployment</th><th>Links</th></tr></thead>
-        <tbody>${signal.items.map((item) => html`<tr>
-          <td><a href=${item.href}>${item.title || item.id}</a>${item.description ? html`<div class="muted">${item.description}</div>` : nothing}<div class="muted">${item.environment || '—'}</div></td>
-          <td>${item.owner ? html`${item.owner.displayName}${item.owner.email ? html`<div class="muted">${item.owner.email}</div>` : nothing}` : html`<span class="muted">Unassigned</span>`}</td>
-          <td>${item.administrators?.length ? item.administrators.map((admin) => html`<div>${admin.displayName}<span class="muted"> · ${admin.role || 'admin'}</span></div>`) : html`<span class="muted">None</span>`}</td>
-          <td><span class="badge">${item.deploymentStatus || item.servingStateStatus || 'Not deployed'}</span>${item.currentDeploymentId ? html`<div class="muted">${item.currentDeploymentId}</div>` : nothing}</td>
-          <td class="actions"><a href=${item.links.workspace}>Open</a>${item.links.connections ? html`<a href=${item.links.connections}>Connections</a>` : nothing}${item.links.publications ? html`<a href=${item.links.publications}>Publications</a>` : nothing}</td>
-        </tr>`)}</tbody>
-      </table></div>` : html`<p class="empty">${signal.empty || 'No workspaces are available.'}</p>`}
+      <lv-entity-list
+        .items=${workspaceListItems(signal)}
+        .columns=${workspaceListColumns()}
+        client-filter
+        search-placeholder="Search workspaces by name, owner, or environment"
+        list-label="Workspaces"
+        empty-text=${signal.empty || 'No workspaces are available.'}
+      ></lv-entity-list>
     </section>`
   }
+}
+
+function workspaceListItems(signal: WorkspaceRegistrySignal): EntityListItem[] {
+  return (signal.items ?? []).map((item) => {
+    const administrators = (item.administrators ?? []).map((administrator) => administrator.displayName).filter(Boolean)
+    const deployment = item.deploymentStatus || item.servingStateStatus || 'Not deployed'
+    return {
+      id: item.id,
+      title: item.title || item.id,
+      description: item.description,
+      href: item.href || item.links.workspace,
+      icon: 'workspace',
+      columns: {
+        owner: item.owner?.displayName || 'Unassigned',
+        administrators: administrators.length ? administrators.join(', ') : 'None',
+        environment: item.environment || '—',
+        deployment,
+        updated: formatWorkspaceDate(item.updatedAt),
+      },
+      columnTitles: {
+        owner: item.owner?.email || item.owner?.displayName || '',
+        administrators: administrators.join(', '),
+        deployment: item.currentDeploymentId || deployment,
+        updated: item.updatedAt || '',
+      },
+      sortValues: {
+        updated: workspaceTimestamp(item.updatedAt),
+      },
+    }
+  })
+}
+
+function workspaceListColumns(): EntityListColumn[] {
+  return [
+    { id: 'name', label: 'Name', width: '27%' },
+    { id: 'owner', label: 'Owner', width: '18%' },
+    { id: 'administrators', label: 'Administrators', width: '18%' },
+    { id: 'environment', label: 'Environment', width: '13%' },
+    { id: 'deployment', label: 'Deployment', width: '13%' },
+    { id: 'updated', label: 'Updated', width: '11%' },
+  ]
+}
+
+function formatWorkspaceDate(value = ''): string {
+  const timestamp = workspaceTimestamp(value)
+  if (!timestamp) return '—'
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }).format(timestamp)
+}
+
+function workspaceTimestamp(value = ''): number {
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? 0 : timestamp
 }
 
 class LeapViewServiceAccounts extends DatastarLit(LitElement) {

--- a/web/components/admin/settings-surfaces.ts
+++ b/web/components/admin/settings-surfaces.ts
@@ -1,0 +1,103 @@
+import { LitElement, css, html, nothing } from 'lit'
+import { DatastarLit } from '../shared/datastar-lit'
+import type { AuditLogSignal, ServiceAccountSignal, ServiceAccountsSignal, WorkspaceRegistrySignal } from '../../generated/signals'
+
+const tableStyles = css`
+  :host { display: block; color: var(--lv-fg-default); font: var(--lv-type-body); font-family: var(--fontStack-system); }
+  .surface { display: grid; gap: 12px; min-width: 0; }
+  h2, p { margin: 0; }
+  h2 { font: var(--lv-type-section-title); }
+  .muted { color: var(--lv-fg-muted); }
+  .error { color: var(--lv-fg-danger); }
+  .table-wrap { overflow-x: auto; border: var(--lv-border-muted); border-radius: var(--lv-radius-default); }
+  table { width: 100%; min-width: 620px; border-collapse: collapse; }
+  th, td { padding: var(--base-size-8) var(--base-size-12); text-align: left; border-bottom: var(--lv-border-muted); vertical-align: top; }
+  th { color: var(--lv-fg-muted); font: var(--lv-type-caption); text-transform: uppercase; letter-spacing: .03em; }
+  tbody tr:last-child td { border-bottom: 0; }
+  a { color: var(--lv-fg-link); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  button, input, select { box-sizing: border-box; min-height: var(--lv-control-small); border: var(--lv-border-default); border-radius: var(--lv-radius-small); background: var(--lv-bg-control); color: inherit; padding: var(--base-size-4) var(--base-size-8); font: inherit; }
+  button { cursor: pointer; }
+  button[disabled] { cursor: default; opacity: .55; }
+  .toolbar, .form { display: flex; flex-wrap: wrap; align-items: end; gap: 8px; }
+  label { display: grid; gap: var(--base-size-4); color: var(--lv-fg-muted); font: var(--lv-type-caption); }
+  .empty { padding: var(--base-size-20) var(--base-size-12); color: var(--lv-fg-muted); }
+  .badge { display: inline-flex; padding: var(--base-size-2) var(--base-size-6); border-radius: var(--lv-radius-full); background: var(--lv-bg-selected); font: var(--lv-type-caption); }
+  .actions { display: flex; flex-wrap: wrap; gap: 6px; }
+`
+
+class LeapViewWorkspaceRegistry extends DatastarLit(LitElement) {
+  static styles = tableStyles
+  get registry(): WorkspaceRegistrySignal { return this.signal('adminWorkspaces', { items: [], loading: false, hasMore: false }) }
+  render() {
+    const signal = this.registry
+    return html`<section class="surface" aria-label="Workspaces">
+      <h2>Workspaces</h2>
+      ${signal.error ? html`<p class="error" role="alert">${signal.error}</p>` : nothing}
+      ${signal.loading ? html`<p class="muted" aria-live="polite">Loading workspaces…</p>` : nothing}
+      ${signal.items?.length ? html`<div class="table-wrap"><table>
+        <thead><tr><th>Name</th><th>Owner</th><th>Administrators</th><th>Deployment</th><th>Links</th></tr></thead>
+        <tbody>${signal.items.map((item) => html`<tr>
+          <td><a href=${item.href}>${item.title || item.id}</a>${item.description ? html`<div class="muted">${item.description}</div>` : nothing}<div class="muted">${item.environment || '—'}</div></td>
+          <td>${item.owner ? html`${item.owner.displayName}${item.owner.email ? html`<div class="muted">${item.owner.email}</div>` : nothing}` : html`<span class="muted">Unassigned</span>`}</td>
+          <td>${item.administrators?.length ? item.administrators.map((admin) => html`<div>${admin.displayName}<span class="muted"> · ${admin.role || 'admin'}</span></div>`) : html`<span class="muted">None</span>`}</td>
+          <td><span class="badge">${item.deploymentStatus || item.servingStateStatus || 'Not deployed'}</span>${item.currentDeploymentId ? html`<div class="muted">${item.currentDeploymentId}</div>` : nothing}</td>
+          <td class="actions"><a href=${item.links.workspace}>Open</a>${item.links.connections ? html`<a href=${item.links.connections}>Connections</a>` : nothing}${item.links.publications ? html`<a href=${item.links.publications}>Publications</a>` : nothing}</td>
+        </tr>`)}</tbody>
+      </table></div>` : html`<p class="empty">${signal.empty || 'No workspaces are available.'}</p>`}
+    </section>`
+  }
+}
+
+class LeapViewServiceAccounts extends DatastarLit(LitElement) {
+  static styles = tableStyles
+  get accounts(): ServiceAccountsSignal { return this.signal('adminServiceAccounts', { items: [], secrets: [], loading: false, hasMore: false }) }
+  private emit(detail: Record<string, unknown>) { this.dispatchEvent(new CustomEvent('lv-service-account-command', { bubbles: true, composed: true, detail })) }
+  render() {
+    const signal = this.accounts
+    return html`<section class="surface" aria-label="Service accounts">
+      <h2>Service accounts</h2>
+      ${signal.error ? html`<p class="error" role="alert">${signal.error}</p>` : nothing}
+      <form class="form" @submit=${(event: SubmitEvent) => { event.preventDefault(); const form = event.currentTarget as HTMLFormElement; const input = form.elements.namedItem('displayName') as HTMLInputElement; this.emit({ action: 'create', displayName: input.value }); input.value = '' }}>
+        <label>New account<input name="displayName" required placeholder="Display name"></label><button type="submit">Create</button>
+      </form>
+      ${signal.createdSecret ? html`<p role="status"><strong>Copy this secret now:</strong> <code>${signal.createdSecret}</code></p>` : nothing}
+      ${signal.items?.length ? html`<div class="table-wrap"><table><thead><tr><th>Account</th><th>Status</th><th>Secrets</th><th>Actions</th></tr></thead><tbody>
+        ${signal.items.map((account) => html`<tr>
+          <td><strong>${account.displayName || account.id}</strong><div class="muted">${account.id}</div></td><td>${account.disabledAt ? 'Disabled' : 'Active'}</td>
+          <td>${account.id === signal.selectedId ? (signal.secrets?.length || 0) : '—'}</td>
+          <td class="actions"><button @click=${() => this.emit({ action: 'select', accountId: account.id })}>Secrets</button><button @click=${() => this.deleteAccount(account)}>Delete</button></td>
+        </tr>`)}</tbody></table></div>` : html`<p class="empty">No service accounts have been created.</p>`}
+      ${signal.selectedId ? html`<div><h3>Secrets</h3><form class="form" @submit=${(event: SubmitEvent) => { event.preventDefault(); const form = event.currentTarget as HTMLFormElement; const name = (form.elements.namedItem('secretName') as HTMLInputElement).value; this.emit({ action: 'create_secret', accountId: signal.selectedId, secretName: name }); }}><label>Secret name<input name="secretName" required placeholder="CI pipeline"></label><button type="submit">Create secret</button></form>${signal.secrets?.length ? html`<div class="table-wrap"><table><thead><tr><th>Name</th><th>Created</th><th>Expires</th><th></th></tr></thead><tbody>${signal.secrets.map((secret) => html`<tr><td>${secret.name}</td><td>${secret.createdAt || '—'}</td><td>${secret.expiresAt || 'Never'}</td><td><button ?disabled=${Boolean(secret.revokedAt)} @click=${() => this.emit({ action: 'revoke_secret', accountId: signal.selectedId, secretId: secret.id })}>${secret.revokedAt ? 'Revoked' : 'Revoke'}</button></td></tr>`)}</tbody></table></div>` : html`<p class="empty">No secrets have been created.</p>`}</div>` : nothing}
+    </section>`
+  }
+
+  private deleteAccount(account: ServiceAccountSignal): void {
+    if (window.confirm(`Delete ${account.displayName || account.id}? Its credentials will stop working immediately.`)) {
+      this.emit({ action: 'delete', accountId: account.id })
+    }
+  }
+}
+
+class LeapViewAuditLog extends DatastarLit(LitElement) {
+  static styles = tableStyles
+  get audit(): AuditLogSignal { return this.signal('adminAuditLog', { items: [], filters: {}, loadedCount: 0, loading: false, hasMore: false }) }
+  private emit(detail: Record<string, unknown>) { this.dispatchEvent(new CustomEvent('lv-audit-log-command', { bubbles: true, composed: true, detail })) }
+  render() {
+    const signal = this.audit
+    const filters = signal.filters || {}
+    const submit = (event: SubmitEvent) => { event.preventDefault(); const form = event.currentTarget as HTMLFormElement; const value = (name: string) => (form.elements.namedItem(name) as HTMLInputElement)?.value || ''; this.emit({ action: 'filter', filters: { workspaceId: value('workspaceId'), principalId: value('principalId'), action: value('action'), targetType: value('targetType'), targetId: value('targetId'), from: value('from'), to: value('to') } }) }
+    return html`<section class="surface" aria-label="Audit log"><h2>Audit log</h2><p class="muted">Read-only product activity.</p>${signal.error ? html`<p class="error" role="alert">${signal.error}</p>` : nothing}
+      <form class="toolbar" @submit=${submit}><label>Workspace<input name="workspaceId" value=${filters.workspaceId || ''}></label><label>Actor<input name="principalId" value=${filters.principalId || ''}></label><label>Action<input name="action" value=${filters.action || ''}></label><label>Target type<input name="targetType" value=${filters.targetType || ''}></label><button type="submit">Filter</button><button type="button" @click=${() => this.emit({ action: 'clear', filters: {} })}>Clear</button></form>
+      ${signal.items?.length ? html`<div class="table-wrap"><table><thead><tr><th>Time</th><th>Action</th><th>Actor</th><th>Target</th><th>Status</th></tr></thead><tbody>${signal.items.map((event) => html`<tr><td>${event.createdAt}</td><td>${event.action}</td><td>${event.principalId || 'System'}</td><td>${event.targetType} / ${event.targetId}</td><td>${event.status || '—'}</td></tr>`)}</tbody></table></div>` : html`<p class="empty">No audit events match these filters.</p>`}
+      ${signal.hasMore ? html`<button @click=${() => this.emit({ action: 'load_more', filters, pageToken: signal.nextCursor })}>Load more</button>` : nothing}
+    </section>`
+  }
+}
+
+if (!customElements.get('lv-workspace-registry')) customElements.define('lv-workspace-registry', LeapViewWorkspaceRegistry)
+if (!customElements.get('lv-service-accounts')) customElements.define('lv-service-accounts', LeapViewServiceAccounts)
+if (!customElements.get('lv-audit-log')) customElements.define('lv-audit-log', LeapViewAuditLog)
+
+export { LeapViewWorkspaceRegistry, LeapViewServiceAccounts, LeapViewAuditLog }
+export { setDatastarLitRuntimeForTests } from '../shared/datastar-lit'

--- a/web/components/app/app-shell.dom.test.ts
+++ b/web/components/app/app-shell.dom.test.ts
@@ -150,6 +150,103 @@ test('app shell renders a restrained text-only LeapView identity', async () => {
   }
 })
 
+test('app shell renders custom identity with permanent LeapView attribution', async () => {
+  const page = await browser.newPage({ viewport: { width: 1320, height: 900 } })
+  try {
+    await page.goto(`${baseURL}/upgraded-shell`)
+    await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
+    const identity = await page.locator('lv-app-shell').evaluate(async (element: any) => {
+      const sidebar = element.shadowRoot.querySelector('lv-sidebar') as any
+      sidebar.config = { ...sidebar.config, productName: 'Northstar Analytics', productLogoUrl: '/instance-logo.png' }
+      await sidebar.updateComplete
+      const root = sidebar.shadowRoot!
+      return {
+        navigationLabel: root.querySelector('aside')?.getAttribute('aria-label'),
+        name: root.querySelector('.brand .name')?.textContent?.trim(),
+        logo: root.querySelector('.product-logo')?.getAttribute('src'),
+        attribution: root.querySelector('.powered-by')?.textContent?.trim(),
+        attributionHref: root.querySelector('.powered-by')?.getAttribute('href'),
+      }
+    })
+    expect(identity).toEqual({
+      navigationLabel: 'Northstar Analytics workspace',
+      name: 'Northstar Analytics',
+      logo: '/instance-logo.png',
+      attribution: 'Powered by LeapView',
+      attributionHref: 'https://leapview.dev',
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('desktop sidebar exposes an accessible persisted resize handle', async () => {
+  const page = await browser.newPage({ viewport: { width: 1320, height: 900 } })
+  try {
+    await page.goto(`${baseURL}/admin-sidebar`)
+    await page.evaluate(() => localStorage.removeItem('leapview-admin-sidebar-width'))
+    await page.reload()
+    await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
+
+    const initial = await page.locator('lv-app-shell').evaluate(async (element: any) => {
+      const sidebar = element.shadowRoot.querySelector('lv-sidebar') as any
+      await sidebar.updateComplete
+      const handle = sidebar.shadowRoot.querySelector('.resize-handle') as HTMLElement
+      handle.focus()
+      handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }))
+      await sidebar.updateComplete
+      return {
+        label: handle.getAttribute('aria-label'),
+        orientation: handle.getAttribute('aria-orientation'),
+        role: handle.getAttribute('role'),
+        tabIndex: handle.tabIndex,
+        value: handle.getAttribute('aria-valuenow'),
+      }
+    })
+
+    expect(initial).toEqual({
+      label: 'Resize navigation sidebar',
+      orientation: 'vertical',
+      role: 'separator',
+      tabIndex: 0,
+      value: '200',
+    })
+    await page.waitForFunction(() => {
+      const shell = document.querySelector('lv-app-shell') as HTMLElement
+      const sidebar = shell?.shadowRoot?.querySelector('lv-sidebar') as HTMLElement
+      return Math.round(sidebar?.getBoundingClientRect().width ?? 0) === 200
+    })
+
+    const handleBox = await page.locator('lv-app-shell').evaluate((element: any) => {
+      const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
+      const handle = sidebar.shadowRoot!.querySelector('.resize-handle') as HTMLElement
+      const box = handle.getBoundingClientRect()
+      return { x: box.x, y: box.y, width: box.width, height: box.height }
+    })
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + Math.min(80, handleBox.height / 2))
+    await page.mouse.down()
+    await page.mouse.move(handleBox.x + handleBox.width / 2 + 32, handleBox.y + Math.min(80, handleBox.height / 2))
+    await page.mouse.up()
+
+    const resized = await shellGeometry(page)
+    expect(resized.sidebar.width).toBe(232)
+    expect(resized.shellMain.x).toBe(resized.sidebar.right)
+
+    await page.reload()
+    await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
+    await page.waitForFunction(() => {
+      const shell = document.querySelector('lv-app-shell') as HTMLElement
+      const sidebar = shell?.shadowRoot?.querySelector('lv-sidebar') as HTMLElement
+      return Math.round(sidebar?.getBoundingClientRect().width ?? 0) === 232
+    })
+    const persistedWidth = (await shellGeometry(page)).sidebar.width
+    expect(persistedWidth).toBe(232)
+  } finally {
+    await page.evaluate(() => localStorage.removeItem('leapview-admin-sidebar-width')).catch(() => undefined)
+    await page.close()
+  }
+})
+
 test('compact app shell keeps the primary sidebar collapsible', async () => {
   const page = await browser.newPage({ viewport: { width: 1320, height: 900 } })
   try {
@@ -487,11 +584,18 @@ test('admin sidebar replaces global navigation and provides a back to app action
     await page.goto(`${baseURL}/admin-sidebar`)
     await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
     await page.locator('lv-app-shell').evaluate((element: any) => element.updateComplete)
+    await page.waitForFunction(() => {
+      const shell = document.querySelector('lv-app-shell') as HTMLElement
+      const sidebar = shell?.shadowRoot?.querySelector('lv-sidebar') as HTMLElement | null
+      return sidebar?.hasAttribute('data-admin') && Math.round(sidebar.getBoundingClientRect().width) === 192
+    })
 
     const state = await page.locator('lv-app-shell').evaluate((element: any) => {
       const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
       const root = sidebar.shadowRoot!
       return {
+        adminMode: sidebar.hasAttribute('data-admin'),
+        width: Math.round(sidebar.getBoundingClientRect().width),
         links: Array.from(root.querySelectorAll('a')).map((link: any) => ({
           href: link.getAttribute('href'),
           text: link.textContent.trim(),
@@ -536,18 +640,32 @@ test('admin sidebar replaces global navigation and provides a back to app action
         collapseControlCount: root.querySelectorAll('.collapse-button').length,
         hasNavPrimaryAction: Boolean(root.querySelector('.primary-action')),
         hasHistory: Boolean(root.querySelector('.history')),
+        hasThemeToggle: Boolean(root.querySelector('.theme-button, [data-theme-toggle]')),
+        currentUser: (() => {
+          const card = root.querySelector('.user-card') as HTMLElement
+          const avatar = card.querySelector('lv-user-avatar') as any
+          return {
+            title: card.getAttribute('title'),
+            name: card.querySelector('.user-name')?.textContent?.trim(),
+            initials: avatar?.shadowRoot?.textContent?.trim(),
+            avatarSrc: avatar?.shadowRoot?.querySelector('img')?.getAttribute('src'),
+            role: card.querySelector('.user-role')?.textContent?.trim(),
+          }
+        })(),
       }
     })
 
-    expect(state.groupLabels).toEqual(['Personal', 'Access', 'Data', 'Operations'])
-    expect(state.visibleGroupLabels).toEqual(['Personal', 'Access', 'Data', 'Operations'])
+    expect(state.groupLabels).toEqual(['Personal', 'Product', 'Access', 'Data & sharing', 'Operations'])
+    expect(state.adminMode).toBe(true)
+    expect(state.width).toBe(192)
+    expect(state.visibleGroupLabels).toEqual(['Personal', 'Product', 'Access', 'Data & sharing', 'Operations'])
     expect(state.links).toEqual(expect.arrayContaining([
       { href: '/admin/profile', text: 'Profile', current: 'false' },
       { href: '/admin/principals', text: 'Principals', current: 'page' },
       { href: '/admin/groups', text: 'Groups', current: 'false' },
       { href: '/admin/agent', text: 'Agent', current: 'false' },
       { href: '/admin/storage', text: 'Storage', current: 'false' },
-      { href: '/admin/queries', text: 'Query History', current: 'false' },
+      { href: '/admin/queries', text: 'Query history', current: 'false' },
       { href: '/admin/publications', text: 'Publications', current: 'false' },
     ]))
     expect(state.brandAction).toEqual({ href: '/', text: 'Back to app' })
@@ -557,6 +675,19 @@ test('admin sidebar replaces global navigation and provides a back to app action
     expect(state.collapseControlCount).toBe(0)
     expect(state.hasNavPrimaryAction).toBe(false)
     expect(state.hasHistory).toBe(false)
+    expect(state.hasThemeToggle).toBe(false)
+    expect(state.currentUser).toEqual({
+      title: 'Ada Lovelace', name: 'Ada Lovelace', initials: '',
+      avatarSrc: '/profile/avatars/ada/avatar-digest', role: 'Platform admin',
+    })
+
+    const updatedAvatarSrc = await page.locator('lv-app-shell').evaluate(async (element: any) => {
+      const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement & { updateComplete: Promise<unknown> }
+      document.dispatchEvent(new CustomEvent('leapview-avatar-change', { detail: { url: '/profile/avatars/ada/new-digest' } }))
+      await sidebar.updateComplete
+      return (sidebar.shadowRoot!.querySelector('lv-user-avatar') as any)?.shadowRoot?.querySelector('img')?.getAttribute('src')
+    })
+    expect(updatedAvatarSrc).toBe('/profile/avatars/ada/new-digest')
 
     await page.locator('lv-app-shell').evaluate(async (element: any) => {
       const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement & { updateComplete: Promise<unknown> }
@@ -573,7 +704,68 @@ test('admin sidebar replaces global navigation and provides a back to app action
         links: Array.from(root.querySelectorAll('a[href^="/admin/"]')).map((link) => link.getAttribute('href')),
       }
     })
-    expect(filtered).toEqual({ groupLabels: ['Data'], links: ['/admin/storage'] })
+    expect(filtered).toEqual({ groupLabels: ['Data & sharing'], links: ['/admin/storage'] })
+  } finally {
+    await page.close()
+  }
+})
+
+test('admin sidebar keeps chrome fixed while only navigation items scroll', async () => {
+  const page = await browser.newPage({ viewport: { width: 1320, height: 520 } })
+  try {
+    await page.goto(`${baseURL}/admin-sidebar`)
+    await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
+    await page.locator('lv-app-shell').evaluate((element: any) => element.updateComplete)
+
+    const state = await page.locator('lv-app-shell').evaluate((element: any) => {
+      const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
+      const root = sidebar.shadowRoot!
+      const aside = root.querySelector('aside') as HTMLElement
+      const nav = root.querySelector('nav') as HTMLElement
+      const header = root.querySelector('.brand') as HTMLElement
+      const footer = root.querySelector('.footer') as HTMLElement
+      return {
+        viewportHeight: window.innerHeight,
+        documentHeight: document.documentElement.scrollHeight,
+        sidebarHeight: Math.round(sidebar.getBoundingClientRect().height),
+        asideHeight: Math.round(aside.getBoundingClientRect().height),
+        navOverflowY: getComputedStyle(nav).overflowY,
+        navScrolls: nav.scrollHeight > nav.clientHeight,
+        headerTop: Math.round(header.getBoundingClientRect().top),
+        footerBottom: Math.round(footer.getBoundingClientRect().bottom),
+      }
+    })
+
+    expect(state).toEqual({
+      viewportHeight: 520,
+      documentHeight: 520,
+      sidebarHeight: 520,
+      asideHeight: 520,
+      navOverflowY: 'auto',
+      navScrolls: true,
+      headerTop: 0,
+      footerBottom: 520,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('app shell ignores synthetic file input clicks from page content', async () => {
+  const page = await browser.newPage({ viewport: { width: 1320, height: 900 } })
+  try {
+    await page.goto(`${baseURL}/admin-sidebar`)
+    await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
+    await page.locator('lv-app-shell').evaluate((element: HTMLElement) => {
+      const input = document.createElement('input')
+      input.type = 'file'
+      input.slot = 'page'
+      element.append(input)
+      input.click()
+    })
+    await page.waitForTimeout(100)
+
+    expect(new URL(page.url()).pathname).toBe('/admin-sidebar')
   } finally {
     await page.close()
   }
@@ -765,6 +957,9 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
       modelId: '',
       modelTitle: '',
       compact,
+      userName: admin ? 'Ada Lovelace' : 'Current User',
+      userAvatarUrl: admin ? '/profile/avatars/ada/avatar-digest' : undefined,
+      userRole: admin ? 'Platform admin' : 'Workspace member',
       primaryAction: admin ? { label: 'Back to app', href: '/', icon: 'back' } : history ? { label: 'New chat', href: '/chats/new', icon: 'plus' } : undefined,
       history: history ? {
         label: 'Chats',
@@ -779,6 +974,15 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
           label: 'Personal',
           items: [
             { id: 'profile', label: 'Profile', href: '/admin/profile', icon: 'user' },
+            { id: 'security', label: 'Security & sessions', href: '/admin/security', icon: 'activity' },
+            { id: 'api-tokens', label: 'API tokens', href: '/admin/api-tokens', icon: 'data' },
+          ],
+        },
+        {
+          label: 'Product',
+          items: [
+            { id: 'general', label: 'General', href: '/admin/general', icon: 'settings' },
+            { id: 'workspaces-admin', label: 'Workspaces', href: '/admin/workspaces', icon: 'catalog' },
           ],
         },
         {
@@ -786,11 +990,14 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
           items: [
             { id: 'principals', label: 'Principals', href: '/admin/principals', icon: 'users' },
             { id: 'groups', label: 'Groups', href: '/admin/groups', icon: 'users-round' },
+            { id: 'service-accounts', label: 'Service accounts', href: '/admin/service-accounts', icon: 'bot' },
+            { id: 'authentication', label: 'Authentication', href: '/admin/authentication', icon: 'system' },
           ],
         },
         {
-          label: 'Data',
+          label: 'Data & sharing',
           items: [
+            { id: 'connections', label: 'Connections', href: '/connections', icon: 'data' },
             { id: 'storage', label: 'Storage', href: '/admin/storage', icon: 'database' },
             { id: 'publications', label: 'Publications', href: '/admin/publications', icon: 'globe' },
           ],
@@ -799,7 +1006,9 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
           label: 'Operations',
           items: [
             { id: 'agent', label: 'Agent', href: '/admin/agent', icon: 'bot' },
-            { id: 'queries', label: 'Query History', href: '/admin/queries', icon: 'history' },
+            { id: 'queries', label: 'Query history', href: '/admin/queries', icon: 'history' },
+            { id: 'audit', label: 'Audit log', href: '/admin/audit', icon: 'activity' },
+            { id: 'system', label: 'System', href: '/admin/system', icon: 'system' },
           ],
         },
       ] : history || nav ? [{

--- a/web/components/app/app-shell.ts
+++ b/web/components/app/app-shell.ts
@@ -7,6 +7,7 @@ import '../navigation/sidebar'
 const emptyChrome: ChromeSignal = {
   sidebar: {
     workspaceTitle: '',
+    productName: 'LeapView',
     active: '',
     dashboardId: '',
     dashboardTitle: '',
@@ -87,11 +88,14 @@ class LeapViewAppShell extends DatastarLit(LitElement) {
 
   private followSidebarLinkFromHost = (event: MouseEvent): void => {
     if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
-    if (event.composedPath().some((node) => node instanceof HTMLAnchorElement)) return
 
     const sidebar = this.shadowRoot?.querySelector('lv-sidebar') as HTMLElement | null
     const root = sidebar?.shadowRoot
     if (!sidebar || !root) return
+
+    const path = event.composedPath()
+    if (event.target !== this && !path.includes(sidebar)) return
+    if (path.some((node) => node instanceof HTMLAnchorElement)) return
 
     const sidebarRect = sidebar.getBoundingClientRect()
     if (event.clientX < sidebarRect.left || event.clientX > sidebarRect.right || event.clientY < sidebarRect.top || event.clientY > sidebarRect.bottom) return

--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -152,6 +152,8 @@ test('embed presentation keeps page navigation and removes non-navigation chrome
         footerVisible: visible('lv-report-footer'),
         hasAgentToggle: Boolean(root.querySelector('.agent-toggle')),
         hasAgentDrawer: Boolean(root.querySelector('lv-chat-drawer')),
+        attribution: root.querySelector('.publication-attribution')?.textContent?.trim(),
+        attributionHref: root.querySelector('.publication-attribution')?.getAttribute('href'),
         agentActionCount: root.querySelectorAll('.ask-visual').length,
         canvasWidth: canvas.getBoundingClientRect().width,
         documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
@@ -163,6 +165,8 @@ test('embed presentation keeps page navigation and removes non-navigation chrome
     expect(state.footerVisible).toBe(false)
     expect(state.hasAgentToggle).toBe(false)
     expect(state.hasAgentDrawer).toBe(false)
+    expect(state.attribution).toBe('Powered by LeapView')
+    expect(state.attributionHref).toBe('https://leapview.dev')
     expect(state.agentActionCount).toBe(0)
     expect(state.canvasWidth).toBeGreaterThan(500)
     expect(state.documentOverflow).toBe(0)

--- a/web/components/dashboard/dashboard-page.ts
+++ b/web/components/dashboard/dashboard-page.ts
@@ -138,11 +138,33 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
     }
 
     .route {
+      position: relative;
       display: grid;
       min-height: 100svh;
       grid-template-columns: auto minmax(0, 1fr) 0px;
       background: var(--lv-bg-app);
       transition: grid-template-columns var(--lv-duration-fast) var(--motion-easing-move);
+    }
+
+    .publication-attribution {
+      position: fixed;
+      right: var(--base-size-12);
+      bottom: var(--base-size-12);
+      z-index: 4;
+      border: var(--lv-border-muted);
+      border-radius: var(--lv-radius-full);
+      background: var(--lv-bg-panel);
+      color: var(--lv-fg-muted);
+      padding: var(--base-size-4) var(--base-size-8);
+      text-decoration: none;
+      box-shadow: var(--shadow-resting-small);
+      font: var(--lv-type-caption);
+    }
+
+    .publication-attribution:hover,
+    .publication-attribution:focus-visible {
+      color: var(--lv-fg-default);
+      text-decoration: underline;
     }
 
     :host([presentation='embed']) .header,
@@ -689,6 +711,9 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
 					@lv-chat-new=${this.handleAgentNew}
 					@lv-agent-references-change=${this.handleAgentReferencesChanged}
 				></lv-chat-drawer>` : nothing}
+        ${this.presentation !== 'app' ? html`
+          <a class="publication-attribution" href="https://leapview.dev" target="_blank" rel="noreferrer">Powered by LeapView</a>
+        ` : nothing}
       </div>
       <lv-visual-modal></lv-visual-modal>
     `

--- a/web/components/login/login-page.dom.test.ts
+++ b/web/components/login/login-page.dom.test.ts
@@ -170,6 +170,34 @@ test('login theme toggle cycles shadow DOM icon and dispatches theme change', as
   }
 })
 
+test('login theme toggle preserves an accessibility theme until the user changes it', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
+  try {
+    await page.addInitScript(() => localStorage.setItem('leapview-color-mode', 'dark_colorblind'))
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('lv-login-page'))
+    await page.locator('lv-login-page').evaluate((element: any) => element.updateComplete)
+
+    const state = await page.locator('lv-login-page').evaluate((element: any) => {
+      const toggle = element.shadowRoot.querySelector('[data-theme-toggle]') as HTMLButtonElement
+      const visibleThemeIcon = element.shadowRoot.querySelector('[data-theme-icon]:not([hidden])') as HTMLElement | null
+      return {
+        mode: toggle.dataset.themeMode,
+        label: toggle.getAttribute('aria-label'),
+        visibleThemeIcon: visibleThemeIcon?.dataset.themeIcon,
+      }
+    })
+
+    expect(state).toEqual({
+      mode: 'dark_colorblind',
+      label: 'Dark protanopia and deuteranopia. Switch to System theme.',
+      visibleThemeIcon: 'dark',
+    })
+  } finally {
+    await page.close()
+  }
+})
+
 function testDocument(): string {
   const page = {
     kind: 'login',

--- a/web/components/login/login-page.ts
+++ b/web/components/login/login-page.ts
@@ -7,21 +7,32 @@ import { checkSignalContract } from '../shared/signal-contract'
 import { lucideIcon } from '../shared/lucide-icons'
 
 type ThemeMode = 'system' | 'light' | 'dark'
+type ThemePreference = ThemeMode | 'dark_dimmed' | 'light_colorblind' | 'dark_colorblind' | 'light_tritanopia' | 'dark_tritanopia'
 
-const nextThemeMode: Record<ThemeMode, ThemeMode> = {
+const nextThemeMode: Record<ThemePreference, ThemeMode> = {
   system: 'light',
   light: 'dark',
   dark: 'system',
+  dark_dimmed: 'system',
+  light_colorblind: 'system',
+  dark_colorblind: 'system',
+  light_tritanopia: 'system',
+  dark_tritanopia: 'system',
 }
 
-const themeLabels: Record<ThemeMode, string> = {
+const themeLabels: Record<ThemePreference, string> = {
   system: 'System theme',
-  light: 'Light theme',
-  dark: 'Dark theme',
+  light: 'Light default',
+  dark: 'Dark default',
+  dark_dimmed: 'Soft dark',
+  light_colorblind: 'Light protanopia and deuteranopia',
+  dark_colorblind: 'Dark protanopia and deuteranopia',
+  light_tritanopia: 'Light tritanopia',
+  dark_tritanopia: 'Dark tritanopia',
 }
 
 class LeapViewLoginPage extends DatastarLit(LitElement) {
-  private themeMode: ThemeMode = currentThemeMode()
+  private themeMode: ThemePreference = currentThemeMode()
   private readonly handleThemeApplied = (event: Event) => {
     const detail = (event as CustomEvent<{ mode?: string }>).detail
     this.themeMode = normalizeThemeMode(detail?.mode)
@@ -272,8 +283,8 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
         @click=${this.toggleTheme}
       >
         <span data-theme-icon="system" ?hidden=${this.themeMode !== 'system'}>${lucideIcon(Monitor)}</span>
-        <span data-theme-icon="light" ?hidden=${this.themeMode !== 'light'}>${lucideIcon(Sun)}</span>
-        <span data-theme-icon="dark" ?hidden=${this.themeMode !== 'dark'}>${lucideIcon(Moon)}</span>
+        <span data-theme-icon="light" ?hidden=${!isLightTheme(this.themeMode)}>${lucideIcon(Sun)}</span>
+        <span data-theme-icon="dark" ?hidden=${!isDarkTheme(this.themeMode)}>${lucideIcon(Moon)}</span>
       </button>
       <section class="panel" aria-label="${leapViewBrandName} login">
         <div class="brand-lockup">
@@ -332,7 +343,7 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
 
 if (!customElements.get('lv-login-page')) customElements.define('lv-login-page', LeapViewLoginPage)
 
-function currentThemeMode(): ThemeMode {
+function currentThemeMode(): ThemePreference {
   try {
     return normalizeThemeMode(localStorage.getItem('leapview-color-mode'))
   } catch {
@@ -345,6 +356,26 @@ function csrfToken(): string {
   return document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content.trim() ?? ''
 }
 
-function normalizeThemeMode(mode: string | null | undefined): ThemeMode {
-  return mode === 'light' || mode === 'dark' || mode === 'system' ? mode : 'system'
+function normalizeThemeMode(mode: string | null | undefined): ThemePreference {
+  switch (mode) {
+    case 'system':
+    case 'light':
+    case 'dark':
+    case 'dark_dimmed':
+    case 'light_colorblind':
+    case 'dark_colorblind':
+    case 'light_tritanopia':
+    case 'dark_tritanopia':
+      return mode
+    default:
+      return 'system'
+  }
+}
+
+function isLightTheme(mode: ThemePreference): boolean {
+  return mode === 'light' || mode === 'light_colorblind' || mode === 'light_tritanopia'
+}
+
+function isDarkTheme(mode: ThemePreference): boolean {
+  return mode === 'dark' || mode === 'dark_dimmed' || mode === 'dark_colorblind' || mode === 'dark_tritanopia'
 }

--- a/web/components/navigation/sidebar.ts
+++ b/web/components/navigation/sidebar.ts
@@ -12,14 +12,12 @@ import {
   Menu,
   MessagesSquare,
 	Monitor,
-	Moon,
 	PanelLeftClose,
 	PanelLeftOpen,
 	Plus,
 	Plug,
 	Search,
 	Settings,
-  Sun,
   TableProperties,
 	Users,
 	UsersRound,
@@ -30,6 +28,7 @@ import {
 import { lucideIcon } from '../shared/lucide-icons'
 import { leapViewBrandName } from '../shared/brand-mark'
 import '../shared/loading-spinner'
+import '../shared/user-avatar'
 
 type NavItem = {
   id: string
@@ -48,6 +47,8 @@ type NavGroup = {
 type SidebarConfig = {
   active: string
   admin?: boolean
+  productLogoUrl?: string
+  productName?: string
   workspaceTitle?: string
   dashboardTitle?: string
   pageTitle?: string
@@ -58,6 +59,8 @@ type SidebarConfig = {
   compact?: boolean
   primaryAction?: SidebarAction
   history?: SidebarHistory
+  userAvatarUrl?: string
+  userName?: string
   groups: NavGroup[]
 }
 
@@ -87,8 +90,6 @@ type SidebarStatus = {
   error?: string
 }
 
-type ThemeMode = 'system' | 'light' | 'dark'
-
 type IconName =
   | 'catalog'
   | 'back'
@@ -103,8 +104,6 @@ type IconName =
   | 'cache'
   | 'settings'
   | 'system'
-  | 'sun'
-  | 'moon'
   | 'activity'
   | 'users'
   | 'users-round'
@@ -123,6 +122,12 @@ const defaultConfig: SidebarConfig = {
     { label: 'Workspace', items: [{ id: 'dashboards', label: 'Dashboards', href: '/', icon: 'dashboard' }] },
   ],
 }
+
+const SIDEBAR_MIN_WIDTH = 160
+const SIDEBAR_MAX_WIDTH = 384
+const SIDEBAR_RESIZE_STEP = 8
+const SIDEBAR_DEFAULT_WIDTH = 248
+const ADMIN_SIDEBAR_DEFAULT_WIDTH = 192
 
 const configConverter = {
   fromAttribute(value: string | null): SidebarConfig {
@@ -155,19 +160,28 @@ const statusConverter = {
 class LeapViewSidebar extends LitElement {
   @property({ attribute: 'config', converter: configConverter }) config: SidebarConfig = defaultConfig
   @property({ attribute: 'status', converter: statusConverter }) status: SidebarStatus = {}
-  @state() private mode: ThemeMode = storedThemeMode()
   @state() private collapsed = storedCollapsed()
   @state() private mobileOpen = false
   @state() private searchQuery = ''
+  @state() private liveUserAvatarUrl: string | undefined
+  @state() private sidebarWidth = SIDEBAR_DEFAULT_WIDTH
   private collapseStateInitialized = false
+  private loadedWidthStorageKey = ''
   private mobileMediaQuery?: MediaQueryList
+  private resizeDrag?: { pointerId: number; startX: number; startWidth: number }
 
   static styles = css`
     :host {
-      --lv-sidebar-width: var(--lv-sidebar-width-expanded);
+      --lv-sidebar-width-default: var(--lv-sidebar-width-expanded);
+      --lv-sidebar-width: var(--lv-sidebar-resized-width, var(--lv-sidebar-width-default));
+      box-sizing: border-box;
       display: block;
       width: var(--lv-sidebar-width);
-      min-height: 100svh;
+      height: 100svh;
+      min-height: 0;
+      max-height: 100svh;
+      position: sticky;
+      top: 0;
       color: var(--lv-fg-default);
       font-family: var(--fontStack-system);
       transition: width var(--motion-transition-stateChange);
@@ -177,15 +191,80 @@ class LeapViewSidebar extends LitElement {
       --lv-sidebar-width: var(--lv-sidebar-width-collapsed);
     }
 
+    :host([data-admin]) {
+      --lv-sidebar-width-default: var(--lv-admin-sidebar-width-expanded);
+    }
+
+    :host([data-resizing]),
+    :host([data-resizing]) aside {
+      transition: none;
+      user-select: none;
+    }
+
+    :host([data-admin]) .brand {
+      gap: var(--base-size-8);
+      padding: var(--base-size-8);
+    }
+
+    :host([data-admin]) .brand-back,
+    :host([data-admin]) .nav-item {
+      min-height: var(--control-small-size);
+      font: var(--lv-type-body-compact);
+    }
+
+    :host([data-admin]) .nav-text strong,
+    :host([data-admin]) .sidebar-search input {
+      font: var(--lv-type-body-compact);
+    }
+
+    :host([data-admin]) .sidebar-search input {
+      min-height: var(--control-small-size);
+    }
+
     aside {
-      position: sticky;
-      top: 0;
+      position: relative;
       display: grid;
-      width: var(--lv-sidebar-width);
-      min-height: 100svh;
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+      max-height: 100%;
       grid-template-rows: auto minmax(0, 1fr) auto;
       background: var(--lv-sidebar-bg);
       transition: width var(--motion-transition-stateChange);
+    }
+
+    .resize-handle {
+      position: absolute;
+      z-index: calc(var(--zIndex-default) + 1);
+      top: 0;
+      right: calc(var(--base-size-4) * -1);
+      bottom: 0;
+      width: var(--base-size-8);
+      border: 0;
+      cursor: col-resize;
+      outline: none;
+      touch-action: none;
+    }
+
+    .resize-handle::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: calc(50% - var(--borderWidth-thin));
+      width: var(--borderWidth-thin);
+      background: transparent;
+      transition: background var(--motion-transition-stateChange);
+    }
+
+    .resize-handle:hover::after,
+    .resize-handle:focus-visible::after,
+    :host([data-resizing]) .resize-handle::after {
+      background: var(--borderColor-accent-emphasis);
+    }
+
+    :host([data-collapsed]) .resize-handle {
+      display: none;
     }
 
     .brand {
@@ -249,6 +328,38 @@ class LeapViewSidebar extends LitElement {
       font: var(--lv-type-body-large);
       font-weight: var(--base-text-weight-semibold);
       letter-spacing: 0;
+    }
+
+    .brand-identity {
+      display: grid;
+      min-width: 0;
+      flex: 1 1 auto;
+      grid-template-columns: auto minmax(0, 1fr);
+      align-items: center;
+      column-gap: var(--base-size-8);
+    }
+
+    .product-logo {
+      width: var(--control-small-size);
+      height: var(--control-small-size);
+      grid-row: 1 / span 2;
+      border-radius: var(--lv-radius-small);
+      object-fit: contain;
+    }
+
+    .powered-by {
+      overflow: hidden;
+      color: var(--lv-fg-muted);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      text-decoration: none;
+      font: var(--lv-type-caption);
+    }
+
+    .powered-by:hover,
+    .powered-by:focus-visible {
+      color: var(--lv-fg-default);
+      text-decoration: underline;
     }
 
     .collapse-button {
@@ -337,9 +448,31 @@ class LeapViewSidebar extends LitElement {
       align-content: start;
       gap: var(--base-size-8);
       min-height: 0;
-      overflow: auto;
+      overflow-x: hidden;
+      overflow-y: auto;
+      overscroll-behavior: contain;
       padding: var(--base-size-8);
       border-bottom: var(--lv-border-muted);
+      scrollbar-color: var(--lv-scrollbar-thumb) transparent;
+      scrollbar-gutter: stable;
+      scrollbar-width: thin;
+    }
+
+    nav::-webkit-scrollbar {
+      width: var(--base-size-6);
+    }
+
+    nav::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    nav::-webkit-scrollbar-thumb {
+      border-radius: var(--lv-radius-full);
+      background: var(--lv-scrollbar-thumb);
+    }
+
+    nav::-webkit-scrollbar-thumb:hover {
+      background: var(--lv-scrollbar-thumb-hover);
     }
 
     .nav-group {
@@ -525,7 +658,7 @@ class LeapViewSidebar extends LitElement {
 
     .footer {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-columns: minmax(0, 1fr);
       gap: var(--base-size-6);
       align-items: center;
       padding: var(--base-size-8);
@@ -546,19 +679,6 @@ class LeapViewSidebar extends LitElement {
 
     .user-card:hover {
       background: var(--control-bgColor-hover);
-    }
-
-    .avatar {
-      display: grid;
-      width: var(--control-xsmall-size);
-      height: var(--control-xsmall-size);
-      place-items: center;
-      border-radius: 50%;
-      background: var(--bgColor-neutral-muted);
-      color: var(--lv-fg-default);
-      font: var(--lv-type-caption);
-      font-weight: var(--base-text-weight-medium);
-      letter-spacing: 0;
     }
 
     .user-text {
@@ -584,46 +704,6 @@ class LeapViewSidebar extends LitElement {
       font: var(--lv-type-caption);
     }
 
-    .actions {
-      display: flex;
-      gap: var(--base-size-4);
-      align-items: center;
-      justify-content: end;
-    }
-
-    .theme-button {
-      display: inline-flex;
-      width: var(--lv-button-height);
-      height: var(--lv-button-height);
-      min-height: var(--lv-button-height);
-      align-items: center;
-      justify-content: center;
-      gap: var(--base-size-8);
-      border: var(--borderWidth-default) solid var(--lv-button-border-rest);
-      border-radius: var(--lv-button-radius);
-      background: var(--lv-button-bg-rest);
-      color: var(--lv-button-fg-rest);
-      cursor: pointer;
-      padding: 0;
-      font: var(--lv-type-caption);
-      font-weight: var(--base-text-weight-medium);
-    }
-
-    .theme-button:hover,
-    .theme-button:focus-visible {
-      border-color: var(--lv-button-border-hover);
-      background: var(--lv-button-bg-hover);
-      color: var(--lv-fg-default);
-      outline: var(--focus-outline);
-      outline-offset: var(--focus-outline-offset);
-    }
-
-    .theme-button {
-      border-color: var(--lv-button-border-rest);
-      background: var(--lv-button-bg-rest);
-      color: var(--lv-button-fg-rest);
-    }
-
     :host([data-collapsed]) .brand {
       justify-items: center;
       gap: 0;
@@ -637,11 +717,18 @@ class LeapViewSidebar extends LitElement {
     }
 
     :host([data-collapsed]) .name,
+    :host([data-collapsed]) .powered-by,
     :host([data-collapsed]) .nav-group-label,
     :host([data-collapsed]) .nav-text,
     :host([data-collapsed]) .history,
     :host([data-collapsed]) .user-text {
       display: none;
+    }
+
+    :host([data-collapsed]) .brand-identity {
+      display: grid;
+      flex: none;
+      grid-template-columns: auto;
     }
 
     :host([data-collapsed]) .collapse-button {
@@ -681,19 +768,6 @@ class LeapViewSidebar extends LitElement {
       padding: var(--base-size-8) var(--base-size-4);
     }
 
-    :host([data-collapsed]) .actions {
-      display: grid;
-      justify-content: center;
-      justify-items: center;
-    }
-
-    :host([data-collapsed]) .theme-button {
-      width: calc(var(--lv-button-height) + var(--base-size-2));
-      min-height: calc(var(--lv-button-height) + var(--base-size-2));
-      height: calc(var(--lv-button-height) + var(--base-size-2));
-      padding: 0;
-    }
-
     :host([data-collapsed]) .user-card {
       grid-template-columns: 1fr;
       justify-items: center;
@@ -704,15 +778,23 @@ class LeapViewSidebar extends LitElement {
       :host,
       :host([data-collapsed]) {
         --lv-sidebar-width: 100%;
+        position: relative;
+        top: auto;
         width: 100%;
+        height: auto;
         min-height: var(--control-large-size);
+        max-height: none;
+        overflow: visible;
       }
 
       aside {
         position: relative;
         display: block;
         width: 100%;
+        height: auto;
         min-height: var(--control-large-size);
+        max-height: none;
+        overflow: visible;
       }
 
       .brand {
@@ -766,7 +848,8 @@ class LeapViewSidebar extends LitElement {
       }
 
       .collapse-button,
-      :host([data-collapsed]) .collapse-button {
+      :host([data-collapsed]) .collapse-button,
+      .resize-handle {
         display: none;
       }
 
@@ -796,6 +879,7 @@ class LeapViewSidebar extends LitElement {
         min-height: 100svh;
         align-content: start;
         overflow-y: auto;
+        overscroll-behavior: contain;
         border: 0;
         border-right: var(--lv-border-default);
         background: var(--lv-sidebar-bg);
@@ -805,6 +889,7 @@ class LeapViewSidebar extends LitElement {
         transform: translateX(-100%);
         transition: transform var(--motion-transition-stateChange), visibility var(--motion-transition-stateChange);
         visibility: hidden;
+        scrollbar-gutter: auto;
       }
 
       aside[data-mobile-open] nav {
@@ -878,32 +963,19 @@ class LeapViewSidebar extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback()
-    document.addEventListener('leapview-theme-applied', this.onThemeApplied as EventListener)
     document.addEventListener('keydown', this.onKeyDown)
+    document.addEventListener('leapview-avatar-change', this.onAvatarChange as EventListener)
     this.mobileMediaQuery = window.matchMedia('(max-width: 640px)')
     this.mobileMediaQuery.addEventListener('change', this.onMobileViewportChange)
-    this.mode = storedThemeMode()
     this.syncCollapsedState()
   }
 
   disconnectedCallback(): void {
-    document.removeEventListener('leapview-theme-applied', this.onThemeApplied as EventListener)
     document.removeEventListener('keydown', this.onKeyDown)
+    document.removeEventListener('leapview-avatar-change', this.onAvatarChange as EventListener)
     this.mobileMediaQuery?.removeEventListener('change', this.onMobileViewportChange)
     this.mobileMediaQuery = undefined
     super.disconnectedCallback()
-  }
-
-  private onThemeApplied = (event: CustomEvent<{ mode: ThemeMode }>): void => {
-    this.mode = normalizeThemeMode(event.detail?.mode)
-  }
-
-  private changeTheme(mode: ThemeMode): void {
-    this.dispatchEvent(new CustomEvent('leapview-theme-change', {
-      detail: { mode },
-      bubbles: true,
-      composed: true,
-    }))
   }
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
@@ -914,9 +986,11 @@ class LeapViewSidebar extends LitElement {
       this.collapsed = this.config.admin ? false : storedCollapsed(this.config.compact)
       this.collapseStateInitialized = true
     }
+    if (changedProperties.has('config')) this.syncSidebarWidth()
   }
 
   protected updated(): void {
+    this.toggleAttribute('data-admin', Boolean(this.config.admin))
     this.syncCollapsedState()
   }
 
@@ -976,8 +1050,30 @@ class LeapViewSidebar extends LitElement {
     const collapsed = this.effectiveCollapsed
     const mobileNavigationClosed = this.isMobileViewport && !this.mobileOpen
     const groups = this.filteredGroups()
+    const userName = this.config.userName?.trim() || 'Local user'
+    const userAvatarUrl = this.liveUserAvatarUrl ?? this.config.userAvatarUrl?.trim()
+    const productName = this.config.productName?.trim() || leapViewBrandName
+    const productLogoUrl = this.config.productLogoUrl?.trim()
+    const hasCustomIdentity = productName !== leapViewBrandName || Boolean(productLogoUrl)
     return html`
-      <aside aria-label="${leapViewBrandName} workspace" ?data-mobile-open=${this.mobileOpen}>
+      <aside aria-label="${productName} workspace" ?data-mobile-open=${this.mobileOpen}>
+        <span
+          class="resize-handle"
+          role="separator"
+          tabindex="0"
+          aria-label="Resize navigation sidebar"
+          aria-orientation="vertical"
+          aria-valuemin=${SIDEBAR_MIN_WIDTH}
+          aria-valuemax=${SIDEBAR_MAX_WIDTH}
+          aria-valuenow=${this.sidebarWidth}
+          title="Drag to resize. Double-click to reset."
+          @keydown=${this.resizeSidebarByKeyboard}
+          @pointerdown=${this.beginSidebarResize}
+          @pointermove=${this.continueSidebarResize}
+          @pointerup=${this.endSidebarResize}
+          @pointercancel=${this.endSidebarResize}
+          @dblclick=${this.resetSidebarWidth}
+        ></span>
         <header class="brand">
           <div class="brand-row">
             ${this.config.admin && this.config.primaryAction ? html`
@@ -991,7 +1087,13 @@ class LeapViewSidebar extends LitElement {
                 <span class="brand-back-icon">${icon(this.config.primaryAction.icon)}</span>
                 <span class="brand-back-text">${this.config.primaryAction.label}</span>
               </a>
-            ` : html`<span class="name">${leapViewBrandName}</span>`}
+            ` : html`
+              <span class="brand-identity">
+                ${productLogoUrl ? html`<img class="product-logo" src=${productLogoUrl} alt="">` : null}
+                <span class="name">${productName}</span>
+                ${hasCustomIdentity ? html`<a class="powered-by" href="https://leapview.dev" target="_blank" rel="noreferrer">Powered by LeapView</a>` : null}
+              </span>
+            `}
             ${this.config.admin ? null : html`
               <button
                 class="collapse-button"
@@ -1020,7 +1122,7 @@ class LeapViewSidebar extends LitElement {
               <span class="brand-back-icon">${icon(this.config.primaryAction.icon)}</span>
               <span class="brand-back-text">${this.config.primaryAction.label}</span>
             </a>
-          ` : html`<strong class="mobile-header-title">${leapViewBrandName}</strong>`}
+          ` : html`<strong class="mobile-header-title">${productName}</strong>`}
           <button
             class="mobile-menu-button"
             type="button"
@@ -1050,7 +1152,7 @@ class LeapViewSidebar extends LitElement {
                 <span class="brand-back-icon">${icon(this.config.primaryAction.icon)}</span>
                 <span class="brand-back-text">${this.config.primaryAction.label}</span>
               </a>
-            ` : html`<strong class="mobile-drawer-title">${leapViewBrandName}</strong>`}
+            ` : html`<strong class="mobile-drawer-title">${productName}</strong>`}
             <button class="mobile-close-button" type="button" aria-label="Close navigation" title="Close navigation" @click=${() => this.closeMobileNavigation(true)}>
               ${icon('close')}
             </button>
@@ -1076,21 +1178,101 @@ class LeapViewSidebar extends LitElement {
         </nav>
 
         <footer class="footer">
-          <div class="user-card" title="Jacob Nielsen">
-            <span class="avatar" aria-hidden="true">JN</span>
+          <div class="user-card" title=${userName}>
+            <lv-user-avatar .name=${userName} .imageUrl=${userAvatarUrl ?? ''} aria-hidden="true"></lv-user-avatar>
             <span class="user-text">
-              <strong class="user-name">Jacob Nielsen</strong>
+              <strong class="user-name">${userName}</strong>
               <span class="user-role">${this.config.userRole ?? 'Local workspace'}</span>
             </span>
-          </div>
-          <div class="actions">
-            <button class="theme-button" type="button" aria-label=${this.themeLabel()} title=${this.themeTitle()} @click=${() => this.changeTheme(this.nextTheme())}>
-              ${icon(this.themeIcon())}
-            </button>
           </div>
         </footer>
       </aside>
     `
+  }
+
+  private onAvatarChange = (event: CustomEvent<{ url?: string }>): void => {
+    this.liveUserAvatarUrl = event.detail?.url?.trim() || ''
+  }
+
+  private get widthStorageKey(): string {
+    return this.config.admin ? 'leapview-admin-sidebar-width' : 'leapview-sidebar-width'
+  }
+
+  private get defaultSidebarWidth(): number {
+    return this.config.admin ? ADMIN_SIDEBAR_DEFAULT_WIDTH : SIDEBAR_DEFAULT_WIDTH
+  }
+
+  private syncSidebarWidth(): void {
+    const storageKey = this.widthStorageKey
+    if (storageKey === this.loadedWidthStorageKey) return
+    this.loadedWidthStorageKey = storageKey
+    const storedWidth = storedSidebarWidth(storageKey)
+    this.sidebarWidth = storedWidth ?? this.defaultSidebarWidth
+    if (storedWidth === undefined) {
+      this.style.removeProperty('--lv-sidebar-resized-width')
+    } else {
+      this.style.setProperty('--lv-sidebar-resized-width', `${storedWidth}px`)
+    }
+  }
+
+  private applySidebarWidth(width: number, persist: boolean): void {
+    const nextWidth = Math.round(Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width)))
+    this.sidebarWidth = nextWidth
+    this.style.setProperty('--lv-sidebar-resized-width', `${nextWidth}px`)
+    if (!persist) return
+    try {
+      localStorage.setItem(this.widthStorageKey, String(nextWidth))
+    } catch {
+      // Ignore storage failures; the current session state still updates.
+    }
+  }
+
+  private beginSidebarResize = (event: PointerEvent): void => {
+    if (event.button !== 0 || this.isMobileViewport || this.effectiveCollapsed) return
+    event.preventDefault()
+    const handle = event.currentTarget as HTMLElement
+    this.resizeDrag = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: this.getBoundingClientRect().width,
+    }
+    handle.setPointerCapture?.(event.pointerId)
+    this.toggleAttribute('data-resizing', true)
+  }
+
+  private continueSidebarResize = (event: PointerEvent): void => {
+    if (!this.resizeDrag || event.pointerId !== this.resizeDrag.pointerId) return
+    this.applySidebarWidth(this.resizeDrag.startWidth + event.clientX - this.resizeDrag.startX, false)
+  }
+
+  private endSidebarResize = (event: PointerEvent): void => {
+    if (!this.resizeDrag || event.pointerId !== this.resizeDrag.pointerId) return
+    const handle = event.currentTarget as HTMLElement
+    if (handle.hasPointerCapture?.(event.pointerId)) handle.releasePointerCapture(event.pointerId)
+    this.resizeDrag = undefined
+    this.toggleAttribute('data-resizing', false)
+    this.applySidebarWidth(this.sidebarWidth, true)
+  }
+
+  private resizeSidebarByKeyboard = (event: KeyboardEvent): void => {
+    let nextWidth: number | undefined
+    if (event.key === 'ArrowLeft') nextWidth = this.sidebarWidth - SIDEBAR_RESIZE_STEP
+    if (event.key === 'ArrowRight') nextWidth = this.sidebarWidth + SIDEBAR_RESIZE_STEP
+    if (event.key === 'Home') nextWidth = SIDEBAR_MIN_WIDTH
+    if (event.key === 'End') nextWidth = SIDEBAR_MAX_WIDTH
+    if (nextWidth === undefined) return
+    event.preventDefault()
+    this.applySidebarWidth(nextWidth, true)
+  }
+
+  private resetSidebarWidth = (): void => {
+    try {
+      localStorage.removeItem(this.widthStorageKey)
+    } catch {
+      // Ignore storage failures; the current session state still updates.
+    }
+    this.sidebarWidth = this.defaultSidebarWidth
+    this.style.removeProperty('--lv-sidebar-resized-width')
   }
 
   private get effectiveCollapsed(): boolean {
@@ -1125,30 +1307,6 @@ class LeapViewSidebar extends LitElement {
       const items = groupMatches ? group.items : group.items.filter((item) => item.label.toLocaleLowerCase().includes(query))
       return items.length > 0 ? [{ ...group, items }] : []
     })
-  }
-
-  private nextTheme(): ThemeMode {
-    if (this.mode === 'system') return 'light'
-    if (this.mode === 'light') return 'dark'
-    return 'system'
-  }
-
-  private themeLabel(): string {
-    if (this.mode === 'system') return 'System'
-    if (this.mode === 'light') return 'Light'
-    return 'Dark'
-  }
-
-  private themeTitle(): string {
-    const next = this.nextTheme()
-    const nextLabel = next === 'system' ? 'System preference' : next === 'light' ? 'Light mode' : 'Dark mode'
-    return `${this.themeLabel()} theme. Switch to ${nextLabel}.`
-  }
-
-  private themeIcon(): IconName {
-    if (this.mode === 'system') return 'system'
-    if (this.mode === 'light') return 'sun'
-    return 'moon'
   }
 
   private renderLink(item: NavItem) {
@@ -1223,8 +1381,6 @@ function icon(name: string) {
     cache: TableProperties,
     settings: Settings,
     system: Monitor,
-    sun: Sun,
-    moon: Moon,
     activity: Activity,
     back: ArrowLeft,
     users: Users,
@@ -1252,17 +1408,14 @@ function storedCollapsed(fallback = false): boolean {
   return fallback
 }
 
-function storedThemeMode(): ThemeMode {
+function storedSidebarWidth(storageKey: string): number | undefined {
   try {
-    return normalizeThemeMode(localStorage.getItem('leapview-color-mode') || document.documentElement.dataset.colorMode)
+    const width = Number(localStorage.getItem(storageKey))
+    if (Number.isFinite(width) && width >= SIDEBAR_MIN_WIDTH && width <= SIDEBAR_MAX_WIDTH) return Math.round(width)
   } catch {
-    return normalizeThemeMode(document.documentElement.dataset.colorMode)
+    // Ignore storage failures and use the route's default width.
   }
-}
-
-function normalizeThemeMode(mode: string | null | undefined): ThemeMode {
-  if (mode === 'light' || mode === 'dark') return mode
-  return 'system'
+  return undefined
 }
 
 customElements.define('lv-sidebar', LeapViewSidebar)

--- a/web/components/shared/entity-list.ts
+++ b/web/components/shared/entity-list.ts
@@ -21,22 +21,20 @@ import {
   type IconNode,
 } from 'lucide'
 import { lucideIcon } from './lucide-icons'
+import './user-avatar'
 
 export type EntityListItem = {
   id: string
   title: string
   description?: string
   href: string
+  avatarUrl?: string
   icon?: string
   meta?: string
   category?: string
-  group?: string
   columns?: Record<string, string | number>
-}
-
-export type EntityListGroup = {
-  id: string
-  label: string
+  columnTitles?: Record<string, string>
+  sortValues?: Record<string, string | number>
 }
 
 export type EntityListColumn = {
@@ -180,19 +178,6 @@ const entityListStyles = `
     font: var(--lv-type-caption);
   }
 
-  .entity-list-group-row th {
-    height: var(--control-medium-size);
-    border-radius: var(--lv-radius-default);
-    background: var(--lv-bg-panel-muted);
-    color: var(--lv-fg-muted);
-    padding-inline: var(--base-size-8);
-    font: var(--lv-type-caption);
-  }
-
-  .entity-list-group-count {
-    margin-left: var(--base-size-4);
-  }
-
   .entity-list-sort-button {
     display: inline-flex;
     max-width: 100%;
@@ -280,16 +265,10 @@ const entityListStyles = `
     color: var(--lv-asset-source-accent, var(--lv-fg-muted));
   }
 
-  .entity-list-icon-user,
   .entity-list-icon-application {
     width: var(--base-size-24);
     height: var(--base-size-24);
     border-radius: var(--lv-radius-full);
-  }
-
-  .entity-list-icon-user {
-    background: var(--lv-bg-accent-muted);
-    color: var(--lv-fg-accent);
   }
 
   .entity-list-identity {
@@ -378,7 +357,6 @@ class EntityList extends LitElement {
   @property({ attribute: false }) items: EntityListItem[] = []
   @property({ attribute: false }) columns: EntityListColumn[] = []
   @property({ attribute: false }) filters: EntityListFilter[] = []
-  @property({ attribute: false }) groups: EntityListGroup[] = []
   @property({ attribute: 'list-label' }) listLabel = 'List'
   @property({ attribute: 'export-filename' }) exportFilename = ''
   @property({ attribute: 'search-placeholder' }) searchPlaceholder = 'Search'
@@ -476,7 +454,7 @@ class EntityList extends LitElement {
                   })}
                 </tr>
               </thead>
-              ${this.renderBodies(items, columns)}
+              <tbody>${items.map((item) => this.renderItem(item, columns))}</tbody>
             </table>
           </div>
         ` : html`<div class="entity-list-empty" role="status">${this.query.trim() ? 'No results match your search.' : this.emptyText}</div>`}
@@ -494,7 +472,7 @@ class EntityList extends LitElement {
     return visible
       .map((item, index) => ({ item, index }))
       .sort((left, right) => {
-        const result = compareEntityValues(this.itemValue(left.item, column), this.itemValue(right.item, column), this.sortDirection)
+        const result = compareEntityValues(this.sortValue(left.item, column), this.sortValue(right.item, column), this.sortDirection)
         return result || left.index - right.index
       })
       .map(({ item }) => item)
@@ -508,20 +486,8 @@ class EntityList extends LitElement {
     return column.id === 'name' ? item.title : item.columns?.[column.id] ?? ''
   }
 
-  private renderBodies(items: EntityListItem[], columns: EntityListColumn[]) {
-    if (!this.groups.length) return html`<tbody>${items.map((item) => this.renderItem(item, columns))}</tbody>`
-    return this.groups.map((group) => {
-      const groupedItems = items.filter((item) => item.group === group.id)
-      if (!groupedItems.length) return ''
-      return html`
-        <tbody aria-label=${`${group.label} ${groupedItems.length}`}>
-          <tr class="entity-list-group-row">
-            <th colspan=${columns.length} scope="colgroup">${group.label}<span class="entity-list-group-count">${groupedItems.length}</span></th>
-          </tr>
-          ${groupedItems.map((item) => this.renderItem(item, columns))}
-        </tbody>
-      `
-    })
+  private sortValue(item: EntityListItem, column: EntityListColumn): string | number {
+    return item.sortValues?.[column.id] ?? this.itemValue(item, column)
   }
 
   private renderItem(item: EntityListItem, columns: EntityListColumn[]) {
@@ -529,9 +495,9 @@ class EntityList extends LitElement {
       <tr class="entity-list-table-row">
         <th scope="row">
           <a class="entity-list-identity" href=${item.href}>
-            <span class=${`entity-list-icon entity-list-icon-${item.icon || 'default'}`} aria-hidden="true">
-              ${lucideIcon(entityIcon(item.icon))}
-            </span>
+            ${item.icon === 'user'
+              ? html`<lv-user-avatar .name=${item.title} .imageUrl=${item.avatarUrl ?? ''} aria-hidden="true"></lv-user-avatar>`
+              : html`<span class=${`entity-list-icon entity-list-icon-${item.icon || 'default'}`} aria-hidden="true">${lucideIcon(entityIcon(item.icon))}</span>`}
             <span class="entity-list-copy">
               <span class="entity-list-title">${item.title}</span>
               ${item.description ? html`<span class="entity-list-description">${item.description}</span>` : ''}
@@ -540,7 +506,8 @@ class EntityList extends LitElement {
         </th>
         ${columns.slice(1).map((column) => {
           const value = item.columns?.[column.id]
-          return html`<td class=${`entity-list-cell ${column.align === 'right' ? 'is-right' : ''}`} title=${String(value ?? '')}>${value == null || value === '' ? '—' : value}</td>`
+          const title = item.columnTitles?.[column.id] ?? String(value ?? '')
+          return html`<td class=${`entity-list-cell ${column.align === 'right' ? 'is-right' : ''}`} title=${title}>${value == null || value === '' ? '—' : value}</td>`
         })}
       </tr>
     `

--- a/web/components/shared/entity-list.ts
+++ b/web/components/shared/entity-list.ts
@@ -363,6 +363,7 @@ class EntityList extends LitElement {
   @property({ attribute: 'empty-text' }) emptyText = 'No results found.'
   @property({ attribute: 'initial-query' }) initialQuery = ''
   @property({ attribute: 'active-filter' }) activeFilter = ''
+  @property({ type: Boolean, attribute: 'client-filter' }) clientFilter = false
   @state() private query = ''
   @state() private filter = ''
   @state() private sortColumnId = ''
@@ -465,8 +466,22 @@ class EntityList extends LitElement {
   private visibleItems(): EntityListItem[] {
     // Query and filter state are server-driven. Keep rendering the last
     // authoritative payload while the debounced page-stream request is in
-    // flight instead of applying a second, client-side filter here.
-    const visible = this.items
+    // flight instead of applying a second, client-side filter here. Small,
+    // already-complete registries can opt into local filtering explicitly.
+    let visible = this.items
+    if (this.clientFilter) {
+      const query = this.query.trim().toLocaleLowerCase()
+      const filter = this.filter.trim().toLocaleLowerCase()
+      visible = visible.filter((item) => {
+        if (filter && filter !== 'all' && item.category?.toLocaleLowerCase() !== filter) return false
+        if (!query) return true
+        const searchable = [item.title, item.description, item.meta, ...Object.values(item.columns ?? {})]
+          .filter((value) => value != null)
+          .join(' ')
+          .toLocaleLowerCase()
+        return searchable.includes(query)
+      })
+    }
     const column = this.resolvedColumns().find((candidate) => candidate.id === this.sortColumnId)
     if (!column || column.sortable === false) return visible
     return visible

--- a/web/components/shared/settings-field-styles.ts
+++ b/web/components/shared/settings-field-styles.ts
@@ -1,0 +1,28 @@
+import { css } from 'lit'
+
+/** Shared Primer-backed typography for label/value rows in settings surfaces. */
+export const settingsFieldStyles = css`
+  .settings-field {
+    display: grid;
+    min-width: 0;
+    gap: var(--base-size-2);
+  }
+
+  .settings-label {
+    color: var(--lv-fg-default);
+    font: var(--lv-type-body);
+    font-weight: var(--base-text-weight-semibold);
+  }
+
+  .settings-description {
+    color: var(--lv-fg-muted);
+    font: var(--lv-type-caption);
+  }
+
+  .settings-value {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--lv-fg-default);
+    font: var(--lv-type-body);
+  }
+`

--- a/web/components/shared/user-avatar.ts
+++ b/web/components/shared/user-avatar.ts
@@ -1,0 +1,67 @@
+import { LitElement, css, html } from 'lit'
+import { property } from 'lit/decorators.js'
+
+type UserAvatarSize = 'small' | 'medium'
+
+class LeapViewUserAvatar extends LitElement {
+  @property() name = ''
+  @property({ attribute: 'image-url' }) imageUrl = ''
+  @property({ reflect: true }) size: UserAvatarSize = 'small'
+
+  static styles = css`
+    :host {
+      --lv-user-avatar-size: var(--control-xsmall-size);
+      display: inline-grid;
+      width: var(--lv-user-avatar-size);
+      height: var(--lv-user-avatar-size);
+      flex: 0 0 auto;
+      vertical-align: middle;
+    }
+
+    :host([size='medium']) {
+      --lv-user-avatar-size: var(--control-large-size);
+    }
+
+    .avatar {
+      display: grid;
+      width: 100%;
+      height: 100%;
+      box-sizing: border-box;
+      place-items: center;
+      overflow: hidden;
+      border: var(--lv-border-muted);
+      border-radius: var(--lv-radius-full);
+      background: var(--bgColor-neutral-muted, var(--lv-bg-panel-muted));
+      color: var(--fgColor-default, var(--lv-fg-default));
+      font: var(--lv-type-caption);
+      font-weight: var(--base-text-weight-semibold);
+      letter-spacing: 0;
+    }
+
+    :host([size='medium']) .avatar {
+      font: var(--lv-type-body);
+      font-weight: var(--base-text-weight-semibold);
+    }
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  `
+
+  render() {
+    return html`<span class="avatar">${this.imageUrl
+      ? html`<img src=${this.imageUrl} alt="">`
+      : userInitials(this.name)}</span>`
+  }
+}
+
+function userInitials(value: string): string {
+  const parts = value.trim().split(/\s+/).filter(Boolean)
+  return (parts.length > 1 ? parts[0][0] + parts[parts.length - 1][0] : parts[0]?.slice(0, 2) ?? '?').toUpperCase()
+}
+
+if (!customElements.get('lv-user-avatar')) customElements.define('lv-user-avatar', LeapViewUserAvatar)
+
+export { LeapViewUserAvatar, userInitials }


### PR DESCRIPTION
## Summary

- add the complete V1 settings navigation and privilege-filtered routes across Personal, Product, Access, Data & sharing, and Operations
- implement Profile, Security & sessions, API tokens, General, Workspaces, Service accounts, Authentication, Audit log, and System settings surfaces using typed Datastar signals
- retain Principals, Groups, Connections, Storage, Publications, Agent, and Query history in the shared settings shell
- add consistent user avatars, persisted Primer theme selection, product identity and attribution, sidebar resizing/scrolling, principal activity, and scoped personal-token controls
- add backend projections and commands for profile/password/session/token management, product identity, workspace administration, service-account credentials, audit history, authentication status, and system status
- hide revoked personal tokens from active token lists and preserve token drafts when creation fails

## Security and architecture

- keep principals, workspaces, credentials, and audit events as managed resources rather than generic key/value settings
- enforce authenticated personal routes and exact `MANAGE_PLATFORM`, `MANAGE_GRANTS`, `MANAGE_WORKSPACE`, `MANAGE_PUBLICATIONS`, and `VIEW_AUDIT` scopes
- reject scoped CLI authoring credentials from personal settings and preserve credential privilege boundaries
- commit privileged mutations and audit records atomically in production repositories
- expose settings data through access- and workspace-owned module ports without importing capability SQLite adapters from the app composition layer
- clear one-time secrets and command signals explicitly in merge patches

## Verification

- `task ci`
- rebased directly onto `origin/main`; aggregate tree verified identical before and after the squash rebase
- local preview: http://100.123.164.118:8170/admin/profile

Linear project: https://linear.app/leapstack/project/leapview-settings-backend-and-api-1362f6bad8f8

Tracks LEA-331 through LEA-346.