### PR TITLE
fix: allow workspace viewers to open dashboard catalog

### DIFF
--- a/internal/app/integration_auth_spec_test.go
+++ b/internal/app/integration_auth_spec_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/flidai/leapview/internal/access"
 	accesssqlite "github.com/flidai/leapview/internal/access/sqlite"
@@ -45,6 +46,32 @@ func TestAuthSpecItemSharingAndDataPrivileges(t *testing.T) {
 	status, body = h.authSpecDo(t, http.MethodPost, "/api/v1/workspaces/sales/semantic-models/sales/datasets/orders/preview", token, `{"dimensions":[{"field":"orders.status"}],"limit":1}`)
 	if status != http.StatusNotFound {
 		t.Fatalf("raw preview status=%d want=404 body=%s", status, body)
+	}
+}
+
+func TestAuthSpecWorkspaceViewerCanOpenDashboardCatalog(t *testing.T) {
+	h, repo := newAuthSpecHarnessWithAuthWorkspace(t, AuthConfig{}, "default")
+	ctx := context.Background()
+
+	viewer := authSpecPrincipal(t, ctx, repo, "workspace-viewer@example.com")
+	authSpecGrant(t, ctx, repo, access.WorkspaceObject("sales"), access.SubjectPrincipal, viewer.ID, access.PrivilegeViewItem)
+	session, err := repo.CreateSession(ctx, viewer.ID, time.Hour)
+	if err != nil {
+		t.Fatalf("create viewer session: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, h.serverURL(t)+"/", nil)
+	if err != nil {
+		t.Fatalf("create dashboard catalog request: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "lv_session", Value: session})
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get dashboard catalog: %v", err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("dashboard catalog status=%d want=200 body=%s", res.StatusCode, body)
 	}
 }
 
@@ -635,6 +662,10 @@ func TestAuthSpecAuditCoversLocalAccessMutations(t *testing.T) {
 }
 
 func newAuthSpecHarness(t *testing.T) (*harness, *accesssqlite.Repository) {
+	return newAuthSpecHarnessWithAuthWorkspace(t, AuthConfig{APITokenOnly: true}, "")
+}
+
+func newAuthSpecHarnessWithAuthWorkspace(t *testing.T, authConfig AuthConfig, authWorkspaceID string) (*harness, *accesssqlite.Repository) {
 	t.Helper()
 	h, metrics, catalogPath := newHarnessWithMetrics(t)
 	ctx := context.Background()
@@ -647,12 +678,21 @@ func newAuthSpecHarness(t *testing.T) (*harness, *accesssqlite.Repository) {
 	if workspaceID == "" {
 		workspaceID = config.DefaultWorkspaceID
 	}
-	if err := workspacesqlite.NewRepository(store.SQLDB()).Ensure(ctx, workspace.EnsureInput{ID: workspace.WorkspaceID(workspaceID), Title: metrics.Catalog().Workspace.Title, Description: metrics.Catalog().Workspace.Description}); err != nil {
+	workspaceRepo := workspacesqlite.NewRepository(store.SQLDB())
+	if err := workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: workspace.WorkspaceID(workspaceID), Title: metrics.Catalog().Workspace.Title, Description: metrics.Catalog().Workspace.Description}); err != nil {
 		t.Fatalf("ensure workspace: %v", err)
+	}
+	if authWorkspaceID != "" && authWorkspaceID != workspaceID {
+		if err := workspaceRepo.Ensure(ctx, workspace.EnsureInput{ID: workspace.WorkspaceID(authWorkspaceID), Title: "Default Workspace"}); err != nil {
+			t.Fatalf("ensure auth workspace: %v", err)
+		}
 	}
 	seedIntegrationActiveDeployment(t, store, workspaceID, catalogPath)
 	repo := accesssqlite.NewRepository(store.SQLDB())
-	auth := NewAuth(repo, workspaceID, AuthConfig{APITokenOnly: true})
+	if authWorkspaceID == "" {
+		authWorkspaceID = workspaceID
+	}
+	auth := NewAuth(repo, authWorkspaceID, authConfig)
 	server := assembleRuntime(metrics, testStoreOptions(store, assemblyConfig{Auth: auth, DefaultWorkspaceID: workspaceID}))
 	h.store = store
 	h.handler = server.Routes()

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -70,7 +70,7 @@ func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platfo
 	mux.Group(func(r chi.Router) {
 		r.Use(csrf)
 		r.With(policy.rateLimits.Updates()).Get("/updates", runtime.pageStreams.ServeHTTP)
-		r.Get("/", routes.accessModule.ProtectViewItem(routes.workspaceModule.Home))
+		r.Get("/", routes.accessModule.ProtectAnyWorkspace(accessmodule.PrivilegeViewItem, routes.workspaceModule.Home))
 		r.Get("/candidates/{candidate}", routes.accessModule.Protect(accessmodule.PrivilegeAuthorProject, func(w http.ResponseWriter, request *http.Request) {
 			candidatePreview(candidates, w, request)
 		}))


### PR DESCRIPTION
## Summary
- authorize the dashboard catalog against any workspace with `VIEW_ITEM`
- preserve per-workspace catalog filtering and least-privilege access
- cover human-session access when the configured default workspace is not granted

## Verification
- `GOFLAGS=-tags=duckdb_arrow go test ./internal/app -run ^TestAuthSpecWorkspaceViewerCanOpenDashboardCatalog$ -count=1`
- `GOFLAGS=-tags=duckdb_arrow go test ./internal/app -run ^TestAuthSpec -count=1`
- `task ci:pr`

Follow-up to #263: the shared demo viewer could open its granted dashboards directly, but `/` checked only the configured default workspace and returned 403 after login.