### PR TITLE
fix: authorize visible workspace catalog streams

### DIFF
--- a/internal/app/integration_auth_spec_test.go
+++ b/internal/app/integration_auth_spec_test.go
@@ -54,7 +54,7 @@ func TestAuthSpecWorkspaceViewerCanOpenDashboardCatalog(t *testing.T) {
 	ctx := context.Background()
 
 	viewer := authSpecPrincipal(t, ctx, repo, "workspace-viewer@example.com")
-	authSpecGrant(t, ctx, repo, access.WorkspaceObject("sales"), access.SubjectPrincipal, viewer.ID, access.PrivilegeViewItem)
+	authSpecGrant(t, ctx, repo, access.WorkspaceObject(h.workspaceID), access.SubjectPrincipal, viewer.ID, access.PrivilegeViewItem)
 	session, err := repo.CreateSession(ctx, viewer.ID, time.Hour)
 	if err != nil {
 		t.Fatalf("create viewer session: %v", err)
@@ -72,6 +72,36 @@ func TestAuthSpecWorkspaceViewerCanOpenDashboardCatalog(t *testing.T) {
 	body, _ := io.ReadAll(res.Body)
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("dashboard catalog status=%d want=200 body=%s", res.StatusCode, body)
+	}
+
+	updatesCtx, cancelUpdates := context.WithCancel(context.Background())
+	updatesReq, err := http.NewRequestWithContext(updatesCtx, http.MethodGet, h.serverURL(t)+"/updates?route=catalog", nil)
+	if err != nil {
+		t.Fatalf("create dashboard catalog updates request: %v", err)
+	}
+	updatesReq.AddCookie(&http.Cookie{Name: "lv_session", Value: session})
+	updatesRes, err := http.DefaultClient.Do(updatesReq)
+	if err != nil {
+		cancelUpdates()
+		t.Fatalf("get dashboard catalog updates: %v", err)
+	}
+	if updatesRes.StatusCode != http.StatusOK {
+		defer updatesRes.Body.Close()
+		updatesBody, _ := io.ReadAll(updatesRes.Body)
+		cancelUpdates()
+		t.Fatalf("dashboard catalog updates status=%d want=200 body=%s", updatesRes.StatusCode, updatesBody)
+	}
+	client := &streamClient{
+		cancel:  cancelUpdates,
+		body:    updatesRes.Body,
+		patches: make(chan map[string]any, 1),
+		errs:    make(chan error, 1),
+	}
+	go client.read()
+	t.Cleanup(client.close)
+	patch := patchString(client.nextPatch(t))
+	if !strings.Contains(patch, `"href":"/workspaces/sales/dashboards/executive-sales"`) {
+		t.Fatalf("dashboard catalog updates missing visible dashboard: %s", patch)
 	}
 }
 

--- a/internal/app/page_stream.go
+++ b/internal/app/page_stream.go
@@ -29,7 +29,9 @@ func configurePageStream(routes *capabilityRoutes, runtime *runtimeServices, pla
 			switch route {
 			case routeLogin:
 				return next, true
-			case routeCatalog, routeDashboard, routeWorkspace, routeWorkspaceAsset, routeConnections, routeConnectionAsset, routeData:
+			case routeCatalog:
+				return routes.accessModule.ProtectAnyWorkspaceNamed("VIEW_ITEM", next), true
+			case routeDashboard, routeWorkspace, routeWorkspaceAsset, routeConnections, routeConnectionAsset, routeData:
 				return routes.accessModule.ProtectNamed("VIEW_ITEM", next), true
 			case routeChat:
 				return routes.accessModule.ProtectNamed("VIEW_AGENT", next), true


### PR DESCRIPTION
## Summary
- authorize catalog bootstrap streams against any workspace visible to the signed-in principal
- keep workspace-scoped dashboard, data, and asset streams bound to their selected workspace
- extend the auth specification to exercise the hydrated catalog and assert a visible dashboard link

## Verification
- `GOFLAGS=-tags=duckdb_arrow go test ./internal/app -run ^'TestAuthSpecWorkspaceViewerCanOpenDashboardCatalog$' -count=1`\n- `GOFLAGS=-tags=duckdb_arrow go test ./internal/app -run ^'TestAuthSpec' -count=1`\n- `task ci:pr`\n\n## Live finding\nFresh shared-viewer acceptance on `demo.leapview.dev` showed `/` returned 200 but the catalog bootstrap `/updates?route=catalog` returned 403. The regression test fails with that exact response before this fix.