### PR TITLE
Stabilize categorical chart colors and proportional interactions

### DIFF
--- a/web/components/dashboard/visualization/adapters/echarts.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.test.ts
@@ -2,8 +2,10 @@ import { expect, test } from 'bun:test'
 
 import type { VisualizationEnvelope } from '../../../../generated/visualization'
 import { Change, defaultRendererContext } from '../host-controller'
-import { brushSelectionCommands, createEChartsRendererFrame, echartsOption, echartsUpdatePlan, interactionCommandForRow, normalizeRendererLocale, removeEChartsRendererFrame, waitForEChartsFrame } from './echarts'
+import { brushSelectionCommands, createEChartsRendererFrame, echartsOption, echartsUpdatePlan, interactionCommandForRow, legendSelectionCommand, normalizeRendererLocale, removeEChartsRendererFrame, waitForEChartsFrame } from './echarts'
 import { echartsLabelPolicy, truncateVisualizationLabel } from './echarts/label-policy'
+import { CategoryColorRegistry } from './echarts/category-colors'
+import { proportionalCenterText } from './echarts/proportional'
 
 test('ECharts label policy truncates by grapheme and preserves selected and threshold labels', () => {
   const envelope = cartesianFixture('heatmap', ['label', 'row', 'value']) as any
@@ -436,10 +438,11 @@ test('ECharts normalizes stacks and preserves series order and color identity ac
   expect(filteredOption.dataset[1].source.map((row: unknown[]) => row.at(-1))).toEqual(['__lv_percent_value', 100, 100])
 
   delete envelope.spec.presentation.seriesIntent
-  const automatic = echartsOption(envelope, defaultRendererContext) as any
+  const categoryColors = new CategoryColorRegistry()
+  const automatic = echartsOption(envelope, defaultRendererContext, categoryColors) as any
   const automaticProcessing = automatic.series.find((series: any) => series.name === 'processing').itemStyle.color
   delete filtered.spec.presentation.seriesIntent
-  const automaticFiltered = echartsOption(filtered, defaultRendererContext) as any
+  const automaticFiltered = echartsOption(filtered, defaultRendererContext, categoryColors) as any
   expect(automaticFiltered.series[0].itemStyle.color).toBe(automaticProcessing)
 })
 
@@ -557,7 +560,11 @@ test('ECharts uses stable IDs, contractual formatting, and resolved theme colors
     dataState: { kind: 'inline', specRevision: 'sha256:test', dataRevision: 1, generation: 1, datasets: [{ id: 'primary', specRevision: 'sha256:test', dataRevision: 1, generation: 1, columns: ['month', 'revenue'], rows: [['Jan', 1234.5]], completeness: 'complete' }] },
     selection: [], status: { kind: 'ready' }, diagnostics: [],
   } as VisualizationEnvelope
-  const context = { ...defaultRendererContext, locale: 'pt-BR' as const, colors: { ...defaultRendererContext.colors, foreground: '#eee', grid: '#333', data: ['#123456'] } }
+  const context = {
+    ...defaultRendererContext,
+    locale: 'pt-BR' as const,
+    colors: { ...defaultRendererContext.colors, foreground: '#eee', grid: '#333', data: ['#123456'] },
+  }
   const option = echartsOption(envelope, context) as any
   expect(option.series[0].id).toBe('series:primary:revenue')
   expect(option.color).toEqual(['#123456'])
@@ -657,8 +664,8 @@ test('ECharts incremental plans commit data synchronously, preserve interaction 
   } as any
 
   const data = echartsUpdatePlan(Change.Data, option)
-  expect(data.settings).toEqual({ notMerge: false, lazyUpdate: false, replaceMerge: ['dataset', 'series', 'visualMap'] })
-  expect(data.option).toEqual({ dataset: option.dataset, series: option.series, visualMap: [], xAxis: option.xAxis, yAxis: option.yAxis })
+  expect(data.settings).toEqual({ notMerge: false, lazyUpdate: false, replaceMerge: ['dataset', 'series', 'visualMap', 'graphic'] })
+  expect(data.option).toEqual({ dataset: option.dataset, series: option.series, visualMap: [], graphic: [], xAxis: option.xAxis, yAxis: option.yAxis })
 
   const selection = echartsUpdatePlan(Change.Selection, option)
   expect(selection.settings.replaceMerge).toEqual(['dataset', 'visualMap'])
@@ -767,7 +774,7 @@ test('ECharts translates every cartesian mark with stable renderer-owned identit
     max: 3,
     calculable: false,
     text: ['3', '1'],
-    inRange: { color: ['rgba(9, 105, 218, 0.18)', defaultRendererContext.colors.data[0]] },
+    inRange: { color: ['rgba(0, 110, 219, 0.18)', defaultRendererContext.colors.data[0]] },
   })
   expect(heatmap.visualMap.precision).toBeUndefined()
   expect(heatmap.visualMap.outOfRange).toBeUndefined()
@@ -803,6 +810,84 @@ test('ECharts honors proportional presentation and hierarchy/network layout', ()
       })
     }
   }
+})
+
+test('ECharts gives donuts legible renderer defaults without changing their categories', () => {
+  const envelope = proportionalFixture('donut') as any
+  envelope.spec.presentation.centerLabel = undefined
+  envelope.spec.presentation.legend = 'bottom'
+  envelope.dataState.datasets[0].rows = Array.from({ length: 18 }, (_, index) => [`Category ${index + 1}`, index + 1])
+
+  const option = echartsOption(envelope, defaultRendererContext) as any
+  expect(option.dataset.source).toHaveLength(19)
+  expect(option.legend).toMatchObject({ type: 'scroll', orient: 'horizontal', bottom: 0 })
+  expect(option.series[0].itemStyle.borderColor).toBeUndefined()
+  expect(option.series[0].itemStyle.borderWidth).toBeUndefined()
+  expect(option.series[0].label).toMatchObject({
+    position: 'outside',
+    alignTo: 'edge',
+    edgeDistance: 8,
+    distanceToLabelLine: 4,
+  })
+  expect(option.series[0].label.formatter({ value: ['Category 1', 1] })).toBe('Category 1: 1')
+  expect(option.series[0].labelLine.show).toBe(true)
+  expect(option.series[0].minShowLabelAngle).toBe(3)
+  expect(option.graphic[0].style.text).toBe('Total\n171')
+  expect(option.aria).toMatchObject({ enabled: true, decal: { show: true } })
+  expect(option.aria.description).toContain('donut')
+  expect(proportionalCenterText(envelope, defaultRendererContext, ['Category 1', 1])).toBe('Category 1\n1')
+
+  envelope.dataState.datasets[0].rows = envelope.dataState.datasets[0].rows.slice(0, 2)
+  const filtered = echartsOption(envelope, defaultRendererContext) as any
+  const update = echartsUpdatePlan(Change.Data, filtered)
+  expect(update.option.graphic[0].style.text).toBe('Total\n3')
+  expect(update.option.aria.decal.show).toBe(false)
+})
+
+test('ECharts preserves proportional category colors when filtering changes row order', () => {
+  const envelope = proportionalFixture('donut') as any
+  envelope.spec.datasets[0].fields[0].sourceRef = 'orders.status'
+  envelope.dataState.datasets[0].rows = [['delivered', 90], ['shipped', 8], ['canceled', 2]]
+
+  const categoryColors = new CategoryColorRegistry()
+  const initial = echartsOption(envelope, defaultRendererContext, categoryColors) as any
+  const initialColor = initial.series[0].itemStyle.color
+  const delivered = initialColor({ value: ['delivered', 90] })
+  const shipped = initialColor({ value: ['shipped', 8] })
+  expect(delivered).not.toBe(shipped)
+
+  const filtered = structuredClone(envelope)
+  filtered.dataState.datasets[0].rows = [['shipped', 8], ['canceled', 2]]
+  const filteredColor = (echartsOption(filtered, defaultRendererContext, categoryColors) as any).series[0].itemStyle.color
+  expect(filteredColor({ value: ['shipped', 8] })).toBe(shipped)
+
+  const sibling = structuredClone(filtered)
+  sibling.visualID = 'orders-by-status-sibling'
+  const siblingColor = (echartsOption(sibling, defaultRendererContext, categoryColors) as any).series[0].itemStyle.color
+  expect(siblingColor({ value: ['shipped', 8] })).toBe(shipped)
+
+  const reordered = structuredClone(envelope)
+  reordered.dataState.datasets[0].rows.reverse()
+  const reorderedColor = (echartsOption(reordered, defaultRendererContext, categoryColors) as any).series[0].itemStyle.color
+  expect(reorderedColor({ value: ['delivered', 90] })).toBe(delivered)
+  expect(reorderedColor({ value: ['shipped', 8] })).toBe(shipped)
+  expect(new Set(defaultRendererContext.colors.data).size).toBe(17)
+})
+
+test('ECharts translates proportional legend categories into governed selections', () => {
+  const envelope = proportionalFixture('donut') as any
+  envelope.spec.datasets[0].fields[0].role = 'identity'
+  envelope.spec.interactions = [{
+    id: 'point_selection', kind: 'select', mode: 'multiple', requiresStableIdentity: true, targets: ['details'], mappings: [{
+      source: { dataset: 'primary', field: 'label' }, targetFieldID: 'orders.status', targetFactID: 'orders',
+    }],
+  }]
+
+  expect(legendSelectionCommand(envelope, 'A')).toEqual({
+    sourceKind: 'visual', sourceId: 'donut', interactionKind: 'point_selection', action: 'set', toggle: true,
+    mappings: [{ field: 'orders.status', fact: 'orders', value: 'A', label: 'A' }],
+  })
+  expect(legendSelectionCommand(envelope, 'missing')).toBeUndefined()
 })
 
 test('ECharts wraps a hierarchy forest so every tree root is rendered', () => {

--- a/web/components/dashboard/visualization/adapters/echarts.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.ts
@@ -4,26 +4,28 @@ import { Change, defaultRendererContext, normalizeRendererLocale, type RendererA
 import { clearInteractionCommand, interactionCommandForRow } from '../interaction-command'
 import { projectVisualizationHighlights } from '../highlight'
 import { baseOption } from './echarts/common'
+import { CategoryColorRegistry, categoryColorRegistryFor } from './echarts/category-colors'
 import { cartesianOption } from './echarts/cartesian'
 import { hierarchyOption } from './echarts/hierarchy'
 import { polarOption } from './echarts/polar'
 import { pointOption } from './echarts/point'
-import { proportionalOption } from './echarts/proportional'
+import { proportionalCenterText, proportionalOption } from './echarts/proportional'
 
 export { interactionCommandForRow, normalizeRendererLocale }
 
-export function echartsOption(envelope: VisualizationEnvelope, context: RendererContext = defaultRendererContext): EChartsOption {
+export function echartsOption(envelope: VisualizationEnvelope, context: RendererContext = defaultRendererContext, categoryColors = new CategoryColorRegistry()): EChartsOption {
   const base = baseOption(envelope, context)
   let translated: Record<string, any>
   switch (envelope.spec.kind) {
-    case 'cartesian': translated = cartesianOption(envelope, context); break
-    case 'proportional': translated = proportionalOption(envelope, context); break
+    case 'cartesian': translated = cartesianOption(envelope, context, categoryColors); break
+    case 'proportional': translated = proportionalOption(envelope, context, categoryColors); break
     case 'hierarchy': translated = hierarchyOption(envelope, context); break
     case 'polar': translated = polarOption(envelope, context); break
-    case 'point': translated = pointOption(envelope, context); break
+    case 'point': translated = pointOption(envelope, context, categoryColors); break
     default: throw new Error(`ECharts cannot render visualization kind ${JSON.stringify(envelope.spec.kind)}`)
   }
   const option = { ...base, ...translated } as Record<string, any>
+  if (base.aria || translated.aria) option.aria = { ...(base.aria ?? {}), ...(translated.aria ?? {}) }
   if (base.graphic && translated.graphic) option.graphic = [...base.graphic, ...translated.graphic]
   applyCrossHighlight(option, envelope)
   return option as EChartsOption
@@ -68,7 +70,7 @@ export const adapter: RendererAdapter = {
     const echarts = await import('echarts')
     const frame = createEChartsRendererFrame(container)
     const chart = echarts.init(frame, undefined, { renderer: 'canvas', devicePixelRatio: context.devicePixelRatio })
-    const handle = new EChartsHandle(container, frame, chart)
+    const handle = new EChartsHandle(container, frame, chart, categoryColorRegistryFor(container))
     try {
       handle.mount(envelope, context)
       return handle
@@ -92,21 +94,26 @@ export function removeEChartsRendererFrame(container: ParentNode, frame: HTMLEle
 
 class EChartsHandle implements RendererHandle {
   private envelope?: VisualizationEnvelope
+  private context?: RendererContext
   private disposed = false
   private readiness: Promise<void> = Promise.resolve()
   private readinessAbort?: AbortController
 
-  constructor(private readonly container: HTMLElement, private readonly frame: HTMLElement, private readonly chart: ECharts) {
+  constructor(private readonly container: HTMLElement, private readonly frame: HTMLElement, private readonly chart: ECharts, private readonly categoryColors: CategoryColorRegistry) {
     this.chart.on('click', this.handleClick)
     this.chart.on('brushSelected', this.handleBrushSelected)
+    this.chart.on('legendselectchanged', this.handleLegendSelect)
+    this.chart.on('mouseover', this.handleMouseOver)
+    this.chart.on('mouseout', this.handleMouseOut)
   }
 
   mount(envelope: VisualizationEnvelope, context: RendererContext): void {
     this.envelope = envelope
+    this.context = context
     this.readinessAbort?.abort()
     this.readinessAbort = new AbortController()
     this.readiness = waitForEChartsFrame(this.chart, 5_000, this.readinessAbort.signal)
-    this.chart.setOption(echartsOption(envelope, context), { notMerge: true, lazyUpdate: false })
+    this.chart.setOption(echartsOption(envelope, context, this.categoryColors), { notMerge: true, lazyUpdate: false })
   }
 
   whenReady(): Promise<void> { return this.readiness }
@@ -114,7 +121,8 @@ class EChartsHandle implements RendererHandle {
   update(envelope: VisualizationEnvelope, change: Change, context: RendererContext): void {
     if (this.disposed) return
     this.envelope = envelope
-    const option = echartsOption(envelope, context)
+    this.context = context
+    const option = echartsOption(envelope, context, this.categoryColors)
     const plan = echartsUpdatePlan(change, option)
     this.chart.setOption(plan.option, plan.settings)
   }
@@ -133,6 +141,9 @@ class EChartsHandle implements RendererHandle {
     this.readinessAbort = undefined
     this.chart.off('click', this.handleClick)
     this.chart.off('brushSelected', this.handleBrushSelected)
+    this.chart.off('legendselectchanged', this.handleLegendSelect)
+    this.chart.off('mouseover', this.handleMouseOver)
+    this.chart.off('mouseout', this.handleMouseOut)
     this.chart.dispose()
     removeEChartsRendererFrame(this.container, this.frame)
   }
@@ -166,6 +177,47 @@ class EChartsHandle implements RendererHandle {
     }
   }
 
+  private readonly handleLegendSelect = (params: unknown) => {
+    const envelope = this.envelope
+    const event = params as { name?: unknown }
+    if (!envelope || envelope.spec.kind !== 'proportional' || typeof event.name !== 'string') return
+    this.chart.dispatchAction({ type: 'legendSelect', name: event.name })
+    const command = legendSelectionCommand(envelope, event.name)
+    if (!command) return
+    this.container.dispatchEvent(new CustomEvent('lv-interaction-select', { bubbles: true, composed: true, detail: command }))
+  }
+
+  private readonly handleMouseOver = (params: unknown) => {
+    const envelope = this.envelope
+    const context = this.context
+    const event = params as { componentType?: unknown; value?: unknown }
+    if (!envelope || !context || event.componentType !== 'series' || !Array.isArray(event.value)) return
+    this.setProportionalCenter(proportionalCenterText(envelope, context, event.value))
+  }
+
+  private readonly handleMouseOut = (params: unknown) => {
+    const envelope = this.envelope
+    const context = this.context
+    const event = params as { componentType?: unknown }
+    if (!envelope || !context || event.componentType !== 'series') return
+    this.setProportionalCenter(proportionalCenterText(envelope, context))
+  }
+
+  private setProportionalCenter(text: string | undefined): void {
+    if (text === undefined) return
+    this.chart.setOption({ graphic: [{ id: 'graphic:proportional:center', style: { text } }] })
+  }
+
+}
+
+export function legendSelectionCommand(envelope: VisualizationEnvelope, categoryName: string) {
+  if (envelope.spec.kind !== 'proportional' || envelope.dataState.kind !== 'inline') return undefined
+  const ref = envelope.spec.category
+  const dataset = envelope.dataState.datasets.find((candidate) => candidate.id === ref.dataset)
+  const categoryIndex = dataset?.columns.indexOf(ref.field) ?? -1
+  if (!dataset || categoryIndex < 0) return undefined
+  const row = dataset.rows.find((candidate) => String(candidate[categoryIndex]) === categoryName)
+  return row ? interactionCommandForRow(envelope, dataset.id, row) : undefined
 }
 
 export function brushSelectionCommands(envelope: VisualizationEnvelope, params: unknown) {
@@ -210,10 +262,12 @@ export function echartsUpdatePlan(change: Change, option: EChartsOption): EChart
     patch.dataset = source.dataset
     patch.series = source.series
     patch.visualMap = source.visualMap ?? []
+    patch.graphic = source.graphic ?? []
+    if (source.aria !== undefined) patch.aria = source.aria
     for (const key of ['xAxis', 'yAxis', 'radar']) {
       if (source[key] !== undefined) patch[key] = source[key]
     }
-    replaceMerge.push('dataset', 'series', 'visualMap')
+    replaceMerge.push('dataset', 'series', 'visualMap', 'graphic')
   } else if ((change & Change.Selection) !== 0) {
     patch.dataset = source.dataset
     patch.visualMap = source.visualMap ?? []

--- a/web/components/dashboard/visualization/adapters/echarts/cartesian.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/cartesian.ts
@@ -4,15 +4,16 @@ import { conditionalIconGlyph, conditionalStyleColor, resolveConditionalFormat }
 import { resolveVisualizationMetadata } from '../../metadata'
 import { axis, escapeHTML, field, fieldLabel, formatDisplayField, formatField, inlineDataset, labelFormatter, legend, selectedDatasetSource, toneColor, type EChartsTranslation } from './common'
 import { echartsLabelPolicy } from './label-policy'
+import type { CategoryColorRegistry } from './category-colors'
 
 type CartesianSpec = Extract<VisualizationEnvelope['spec'], { kind: 'cartesian' }>
 type ReferenceValue = NonNullable<CartesianSpec['referenceLines']>[number]['value']
 
-export function cartesianOption(envelope: VisualizationEnvelope, context: RendererContext): EChartsTranslation {
-  return applyDecisionContext(envelope, context, cartesianBaseOption(envelope, context))
+export function cartesianOption(envelope: VisualizationEnvelope, context: RendererContext, categoryColors: CategoryColorRegistry): EChartsTranslation {
+  return applyDecisionContext(envelope, context, cartesianBaseOption(envelope, context, categoryColors))
 }
 
-function cartesianBaseOption(envelope: VisualizationEnvelope, context: RendererContext): EChartsTranslation {
+function cartesianBaseOption(envelope: VisualizationEnvelope, context: RendererContext, categoryColors: CategoryColorRegistry): EChartsTranslation {
   const spec = envelope.spec as CartesianSpec
   const horizontal = spec.presentation.orientation === 'horizontal' || spec.mark === 'bar'
   const xType = axisType(envelope, spec.x, horizontal ? 'value' : 'category')
@@ -115,7 +116,7 @@ function cartesianBaseOption(envelope: VisualizationEnvelope, context: RendererC
       }],
     }
   }
-  const split = splitCartesianSeries(envelope, context)
+  const split = splitCartesianSeries(envelope, context, categoryColors)
   if (split) {
     const secondary = split.series.some((item) => item.yAxisIndex === 1)
     const primaryAxis = axis(envelope, spec.y[0]!, 'value', context, 'primary_y', spec.y)
@@ -368,13 +369,14 @@ function chartLabel(envelope: VisualizationEnvelope, value: CartesianSpec['y'][n
   return translated
 }
 
-function splitCartesianSeries(envelope: VisualizationEnvelope, context: RendererContext): { datasets: EChartsTranslation[]; series: EChartsTranslation[] } | undefined {
+function splitCartesianSeries(envelope: VisualizationEnvelope, context: RendererContext, categoryColors: CategoryColorRegistry): { datasets: EChartsTranslation[]; series: EChartsTranslation[] } | undefined {
   const spec = envelope.spec
   if (spec.kind !== 'cartesian' || !spec.series || spec.y.length !== 1 || envelope.dataState.kind !== 'inline') return undefined
   const dataset = envelope.dataState.datasets.find((candidate) => candidate.id === spec.series?.dataset)
   const seriesIndex = dataset?.columns.indexOf(spec.series.field) ?? -1
   if (!dataset || seriesIndex < 0) return undefined
   const available = [...new Set(dataset.rows.map((row) => row[seriesIndex]).filter((value): value is string | number | boolean => typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'))]
+  categoryColors.register(envelope, spec.series, available)
   const configured = new Map((spec.presentation.comboSeries ?? []).map((item) => [String(item.seriesValue), item]))
   const intents = new Map((spec.presentation.seriesIntent ?? []).map((item) => [String(item.value), item]))
   const authoredOrder = (spec.presentation.seriesIntent ?? [])
@@ -410,7 +412,7 @@ function splitCartesianSeries(envelope: VisualizationEnvelope, context: Renderer
       encode: { x: spec.x.field, y: normalized?.dimension ?? spec.y[0]?.field }, smooth: spec.presentation.smooth, symbol: spec.presentation.showSymbols ? undefined : 'none',
       stack: stack === 'none' ? undefined : stack, areaStyle: spec.presentation.area || mark === 'area' ? {} : undefined,
       itemStyle: {
-        color: fill ?? seriesColor(String(value), intent?.color, context),
+        color: fill ?? (intent?.color ? seriesColor(String(value), intent.color, context) : categoryColors.color(envelope, spec.series!, value, context)),
         borderColor: stroke,
         borderWidth: stroke ? 2 : undefined,
       },

--- a/web/components/dashboard/visualization/adapters/echarts/category-colors.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/category-colors.ts
@@ -1,0 +1,79 @@
+import type { VisualizationEnvelope, VisualizationFieldRef } from '../../../../../generated/visualization'
+import type { RendererContext } from '../../host-controller'
+
+type ScopeAssignments = {
+  readonly slots: Map<string, number>
+  nextSlot: number
+}
+
+/**
+ * Owns automatic category-to-palette assignments for a dashboard page.
+ * Assignments store palette positions rather than resolved colors so they
+ * survive both data filtering and theme changes.
+ */
+export class CategoryColorRegistry {
+  readonly #scopes = new Map<string, ScopeAssignments>()
+
+  register(envelope: VisualizationEnvelope, ref: VisualizationFieldRef, values: readonly unknown[]): void {
+    const scope = categoryColorScope(envelope, ref)
+    const assignments = this.#scopes.get(scope) ?? { slots: new Map<string, number>(), nextSlot: 0 }
+    this.#scopes.set(scope, assignments)
+    for (const value of values) {
+      const identity = categoryIdentity(value)
+      if (assignments.slots.has(identity)) continue
+      assignments.slots.set(identity, assignments.nextSlot++)
+    }
+  }
+
+  color(envelope: VisualizationEnvelope, ref: VisualizationFieldRef, value: unknown, context: RendererContext): string {
+    this.register(envelope, ref, [value])
+    const palette = context.colors.data
+    if (palette.length === 0) return context.colors.accent
+    const slot = this.#scopes.get(categoryColorScope(envelope, ref))?.slots.get(categoryIdentity(value)) ?? 0
+    return palette[slot % palette.length]!
+  }
+}
+
+const pageRegistries = new WeakMap<object, CategoryColorRegistry>()
+
+export function categoryColorRegistryFor(container: HTMLElement): CategoryColorRegistry {
+  const owner = dashboardPageFor(container) ?? container.ownerDocument ?? container
+  let registry = pageRegistries.get(owner)
+  if (!registry) {
+    registry = new CategoryColorRegistry()
+    pageRegistries.set(owner, registry)
+  }
+  return registry
+}
+
+function dashboardPageFor(container: HTMLElement): Element | undefined {
+  let current: Node | undefined = container
+  while (current) {
+    const page = (current as Element).closest?.('lv-dashboard-page')
+    if (page) return page
+    const root: Node | undefined = current.getRootNode?.()
+    const shadowHost: Element | undefined = root && 'host' in root ? (root as ShadowRoot).host : undefined
+    current = shadowHost && shadowHost !== current ? shadowHost : undefined
+  }
+  return undefined
+}
+
+function categoryColorScope(envelope: VisualizationEnvelope, ref: VisualizationFieldRef): string {
+  const sourceRef = envelope.spec.datasets
+    .find((dataset) => dataset.id === ref.dataset)?.fields
+    .find((definition) => definition.id === ref.field)?.sourceRef?.trim()
+  return sourceRef ? `source:${sourceRef}` : `visual:${envelope.visualID}:${ref.dataset}:${ref.field}`
+}
+
+function categoryIdentity(value: unknown): string {
+  if (value === null) return 'null:'
+  if (value === undefined) return 'undefined:'
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) return 'number:NaN'
+    if (Object.is(value, -0)) return 'number:-0'
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return `${typeof value}:${String(value)}`
+  }
+  return `json:${JSON.stringify(value)}`
+}

--- a/web/components/dashboard/visualization/adapters/echarts/common.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/common.ts
@@ -175,10 +175,16 @@ export function axis(
   }
 }
 
-export function legend(position: string, context: RendererContext): EChartsTranslation | undefined {
+export function legend(position: string, context: RendererContext, scroll = false): EChartsTranslation | undefined {
   if (position === 'hidden') return undefined
   return {
     show: true,
+    ...(scroll ? {
+      type: 'scroll',
+      pageIconColor: context.colors.foreground,
+      pageIconInactiveColor: context.colors.grid,
+      pageTextStyle: { color: context.colors.muted, fontFamily: context.fontFamily },
+    } : {}),
     orient: position === 'left' || position === 'right' ? 'vertical' : 'horizontal',
     [position]: 0,
     textStyle: { color: context.colors.muted, fontFamily: context.fontFamily },

--- a/web/components/dashboard/visualization/adapters/echarts/point.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/point.ts
@@ -3,10 +3,11 @@ import type { RendererContext } from '../../host-controller'
 import { axis, field, formatField, inlineDataset, labelFormatter, legend, type EChartsTranslation } from './common'
 import { applyDecisionContext } from './cartesian'
 import { echartsLabelPolicy } from './label-policy'
+import type { CategoryColorRegistry } from './category-colors'
 
 type PointSpec = Extract<VisualizationEnvelope['spec'], { kind: 'point' }>
 
-export function pointOption(envelope: VisualizationEnvelope, context: RendererContext): EChartsTranslation {
+export function pointOption(envelope: VisualizationEnvelope, context: RendererContext, categoryColors: CategoryColorRegistry): EChartsTranslation {
   const spec = envelope.spec as PointSpec
   const dataset = inlineDataset(envelope, spec.x.dataset)
   const rows = dataset?.rows ?? []
@@ -35,7 +36,7 @@ export function pointOption(envelope: VisualizationEnvelope, context: RendererCo
       symbolSize: pointSymbolSize(envelope, spec),
       itemStyle: {
         opacity: spec.presentation.overplot === 'opacity' ? spec.presentation.opacity : 1,
-        ...(spec.colorScale?.kind === 'categorical' && spec.color ? { color: categoricalPointColor(envelope, spec.color, context) } : {}),
+        ...(spec.colorScale?.kind === 'categorical' && spec.color ? { color: categoricalPointColor(envelope, spec.color, context, categoryColors) } : {}),
       },
       ...labels,
       label: { ...labels.label, position: 'top' },
@@ -132,14 +133,13 @@ function pointColorDomain(
   return { min, max }
 }
 
-function categoricalPointColor(envelope: VisualizationEnvelope, ref: VisualizationFieldRef, context: RendererContext) {
+function categoricalPointColor(envelope: VisualizationEnvelope, ref: VisualizationFieldRef, context: RendererContext, categoryColors: CategoryColorRegistry) {
   const dataset = inlineDataset(envelope, ref.dataset)
   const index = dataset?.columns.indexOf(ref.field) ?? -1
-  const domain = [...new Set((dataset?.rows ?? []).map((row) => String(row[index])))].sort((left, right) => left.localeCompare(right, 'en'))
+  categoryColors.register(envelope, ref, index < 0 ? [] : (dataset?.rows ?? []).map((row) => row[index]))
   return (params: { value?: unknown[] }) => {
-    const value = Array.isArray(params.value) ? String(params.value[index]) : ''
-    const colorIndex = Math.max(0, domain.indexOf(value)) % context.colors.data.length
-    return context.colors.data[colorIndex]
+    const value = Array.isArray(params.value) ? params.value[index] : undefined
+    return categoryColors.color(envelope, ref, value, context)
   }
 }
 

--- a/web/components/dashboard/visualization/adapters/echarts/proportional.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/proportional.ts
@@ -1,22 +1,55 @@
 import type { VisualizationEnvelope } from '../../../../../generated/visualization'
 import type { RendererContext } from '../../host-controller'
-import { labelFormatter, legend, type EChartsTranslation } from './common'
+import { formatDisplayField, formatField, inlineDataset, legend, type EChartsTranslation } from './common'
 import { echartsLabelPolicy } from './label-policy'
+import type { CategoryColorRegistry } from './category-colors'
 
-export function proportionalOption(envelope: VisualizationEnvelope, context: RendererContext): EChartsTranslation {
+const CENTER_GRAPHIC_ID = 'graphic:proportional:center'
+
+export function proportionalOption(envelope: VisualizationEnvelope, context: RendererContext, categoryColors: CategoryColorRegistry): EChartsTranslation {
   const spec = envelope.spec
   if (spec.kind !== 'proportional') return {}
   const presentation = spec.presentation
   const radius = spec.mark === 'donut'
     ? [percent(presentation.innerRadius, 0.45), percent(presentation.outerRadius, 0.72)]
     : presentation.outerRadius ? percent(presentation.outerRadius, 0.72) : undefined
-  const labels = echartsLabelPolicy(envelope, spec.value.dataset, presentation.labelPolicy, labelFormatter(envelope, spec.value, context), context)
+  const dataset = inlineDataset(envelope, spec.category.dataset)
+  const categoryIndex = dataset?.columns.indexOf(spec.category.field) ?? -1
+  const valueIndex = dataset?.columns.indexOf(spec.value.field) ?? -1
+  const outside = presentation.labelPosition !== 'inside'
+  const isPie = spec.mark === 'pie' || spec.mark === 'donut'
+  const labels = echartsLabelPolicy(envelope, spec.value.dataset, presentation.labelPolicy, ({ value }) => {
+    const row = Array.isArray(value) ? value : []
+    const amount = formatDisplayField(envelope, spec.value, valueIndex >= 0 ? row[valueIndex] : undefined, context)
+    if (!outside) return amount
+    const category = formatField(envelope, spec.category, categoryIndex >= 0 ? row[categoryIndex] : undefined, context)
+    return `${category}: ${amount}`
+  }, context)
+  const categoryValues = categoryIndex < 0 ? [] : (dataset?.rows ?? []).map((row) => row[categoryIndex])
+  categoryColors.register(envelope, spec.category, categoryValues)
   const series: EChartsTranslation = {
     id: `series:primary:${spec.mark}`, type: spec.mark === 'funnel' ? 'funnel' : 'pie',
     encode: { itemName: spec.category.field, value: spec.value.field },
     ...labels,
-    label: { ...labels.label, position: presentation.labelPosition === 'inside' ? 'inside' : 'outside' },
+    label: {
+      ...labels.label,
+      position: outside ? 'outside' : 'inside',
+      ...(outside && isPie ? { alignTo: 'edge', edgeDistance: 8, distanceToLabelLine: 4 } : {}),
+    },
+    ...(isPie ? {
+      avoidLabelOverlap: true,
+      minShowLabelAngle: minimumLabelAngle(presentation.labelPolicy.density),
+      labelLine: {
+        show: outside,
+        length: 10,
+        length2: 8,
+        lineStyle: { color: context.colors.muted },
+      },
+    } : {}),
     roseType: presentation.rose ? 'radius' : false,
+    itemStyle: {
+      color: (params: { value?: unknown[] }) => categoryColors.color(envelope, spec.category, Array.isArray(params.value) ? params.value[categoryIndex] : undefined, context),
+    },
   }
   if (radius !== undefined) series.radius = radius
   if (spec.mark === 'funnel') {
@@ -24,10 +57,62 @@ export function proportionalOption(envelope: VisualizationEnvelope, context: Ren
     if (presentation.align !== undefined) series.funnelAlign = presentation.align
     series.sort = presentation.sort === 'ascending' ? 'ascending' : presentation.sort === 'descending' ? 'descending' : 'none'
   }
-  const center = presentation.centerLabel && spec.mark === 'donut' ? {
-    graphic: [{ type: 'text', left: 'center', top: 'middle', silent: true, style: { text: presentation.centerLabel, fill: context.colors.foreground, fontFamily: context.fontFamily, textAlign: 'center' } }],
-  } : {}
-  return { legend: legend(presentation.legend, context), series: [series], ...center }
+  const centerText = proportionalCenterText(envelope, context)
+  const center = centerText === undefined ? {} : {
+    graphic: [{
+      id: CENTER_GRAPHIC_ID,
+      type: 'text',
+      left: 'center',
+      top: 'middle',
+      silent: true,
+      style: {
+        text: centerText,
+        fill: context.colors.foreground,
+        fontFamily: context.fontFamily,
+        fontSize: 12,
+        fontWeight: 600,
+        lineHeight: 16,
+        textAlign: 'center',
+        textVerticalAlign: 'middle',
+      },
+    }],
+  }
+  const repeatsColors = uniqueValueCount(categoryValues) > context.colors.data.length
+  return {
+    legend: legend(presentation.legend, context, true),
+    series: [series],
+    aria: { decal: { show: repeatsColors } },
+    ...center,
+  }
+}
+
+export function proportionalCenterText(envelope: VisualizationEnvelope, context: RendererContext, activeRow?: readonly unknown[]): string | undefined {
+  const spec = envelope.spec
+  if (spec.kind !== 'proportional' || spec.mark !== 'donut') return undefined
+  const dataset = inlineDataset(envelope, spec.value.dataset)
+  const categoryIndex = dataset?.columns.indexOf(spec.category.field) ?? -1
+  const valueIndex = dataset?.columns.indexOf(spec.value.field) ?? -1
+  if (activeRow) {
+    const category = formatField(envelope, spec.category, categoryIndex >= 0 ? activeRow[categoryIndex] : undefined, context)
+    const amount = formatDisplayField(envelope, spec.value, valueIndex >= 0 ? activeRow[valueIndex] : undefined, context)
+    return `${category}\n${amount}`
+  }
+  if (spec.presentation.centerLabel) return spec.presentation.centerLabel
+  const total = (dataset?.rows ?? []).reduce((sum, row) => {
+    const value = valueIndex >= 0 ? Number(row[valueIndex]) : Number.NaN
+    return Number.isFinite(value) ? sum + value : sum
+  }, 0)
+  return `Total\n${formatDisplayField(envelope, spec.value, total, context)}`
+}
+
+function uniqueValueCount(values: readonly unknown[]): number {
+  return new Set(values.map((value) => `${typeof value}:${String(value)}`)).size
+}
+
+function minimumLabelAngle(density: string): number {
+  if (density === 'always') return 0
+  if (density === 'dense') return 1
+  return 3
 }
 
 function percent(value: number | undefined, fallback: number): string {

--- a/web/components/dashboard/visualization/host-controller.ts
+++ b/web/components/dashboard/visualization/host-controller.ts
@@ -39,7 +39,7 @@ export const defaultRendererContext: RendererContext = Object.freeze({
   colors: Object.freeze({
     foreground: '#24292f', muted: '#57606a', grid: '#d8dee4', surface: '#ffffff', accent: '#0969da',
     success: '#1a7f37', attention: '#9a6700', danger: '#cf222e',
-    data: Object.freeze(['#0969da', '#1a7f37', '#8250df', '#bc4c00', '#116329', '#bf3989', '#1b7c83', '#9a6700']),
+    data: Object.freeze(['#006edb', '#eb670f', '#30a147', '#ce2c85', '#856d4c', '#a830e8', '#179b9b', '#b88700', '#df0c24', '#808fa3', '#64762d', '#167e53', '#9d615c', '#866e04', '#894ceb', '#d43511', '#527a29']),
   }),
 })
 

--- a/web/components/dashboard/visualization/host.ts
+++ b/web/components/dashboard/visualization/host.ts
@@ -445,7 +445,10 @@ export class VisualizationHost extends LitElement {
         success: color('--lv-fg-success', defaultRendererContext.colors.success),
         attention: color('--lv-fg-warning', defaultRendererContext.colors.attention),
         danger: color('--lv-fg-danger', defaultRendererContext.colors.danger),
-        data: Array.from({ length: 8 }, (_, index) => color(`--lv-data-${index + 1}`, defaultRendererContext.colors.data[index]!)),
+        data: [
+          'blue', 'orange', 'green', 'pink', 'brown', 'plum', 'teal', 'yellow', 'red',
+          'gray', 'olive', 'pine', 'auburn', 'lemon', 'purple', 'coral', 'lime',
+        ].map((name, index) => color(`--data-${name}-color-emphasis`, defaultRendererContext.colors.data[index]!)),
       },
     }
   }


### PR DESCRIPTION
## Summary

- replace the legacy eight-color renderer palette with the 17 Primer data emphasis colors
- preserve category-to-color assignments across filtering, row reordering, sibling visuals, and theme changes
- improve pie and donut defaults with direct labels, small-slice suppression, scrollable legends, center totals, hover context, and high-cardinality decals
- translate proportional legend clicks into governed selections without hiding chart categories

## Validation

- `task ci:lane:frontend`
- `task ci:lane:go`
- `bun test web/components/dashboard/visualization/adapters/echarts.test.ts`
- `bun run typecheck:app`
- live verification in light and dark themes through the Tailscale development deployment
