### PR TITLE
ci: split APIGen validation lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  apigen-validation:
+    name: APIGen tests (PR)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.position == github.event.pull_request.stack.size
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up the cached CI toolchain
+        uses: ./.github/actions/setup-ci
+        with:
+          browser: "false"
+
+      - name: Run APIGen validation
+        run: task ci:lane:go:apigen
+
   go-packages-validation:
     name: Go package tests (PR)
     if: >-
@@ -106,20 +131,25 @@ jobs:
   ci-gate:
     name: CI gate
     if: ${{ always() }}
-    needs: [go-packages-validation, go-application-validation, frontend-validation]
+    needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Require GitHub-hosted validation
         env:
+          APIGEN_RESULT: ${{ needs.apigen-validation.result }}
           GO_PACKAGES_RESULT: ${{ needs.go-packages-validation.result }}
           GO_APPLICATION_RESULT: ${{ needs.go-application-validation.result }}
           FRONTEND_RESULT: ${{ needs.frontend-validation.result }}
         run: |
-          if [[ "${GO_PACKAGES_RESULT}" = skipped && "${GO_APPLICATION_RESULT}" = skipped && "${FRONTEND_RESULT}" = skipped ]]; then
+          if [[ "${APIGEN_RESULT}" = skipped && "${GO_PACKAGES_RESULT}" = skipped && "${GO_APPLICATION_RESULT}" = skipped && "${FRONTEND_RESULT}" = skipped ]]; then
             printf '%s\n' 'Validation is deferred to the top of this stack.' >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
+          test "${APIGEN_RESULT}" = success || {
+            printf 'APIGen validation: %s\n' "${APIGEN_RESULT}" >&2
+            exit 1
+          }
           test "${GO_PACKAGES_RESULT}" = success || {
             printf 'Go package validation: %s\n' "${GO_PACKAGES_RESULT}" >&2
             exit 1

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -12,6 +12,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  apigen-validation:
+    name: APIGen tests (merge queue)
+    if: github.repository == 'flidai/leapview'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out merge group
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up the cached CI toolchain
+        uses: ./.github/actions/setup-ci
+        with:
+          browser: "false"
+
+      - name: Run APIGen validation
+        run: task ci:lane:go:apigen
+
   go-packages-validation:
     name: Go package tests (merge queue)
     if: github.repository == 'flidai/leapview'
@@ -96,7 +118,7 @@ jobs:
   full-validation:
     name: Full merge validation
     if: github.repository == 'flidai/leapview'
-    needs: [go-packages-validation, go-application-validation, frontend-validation]
+    needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
@@ -123,17 +145,22 @@ jobs:
   ci-gate:
     name: CI gate
     if: ${{ always() }}
-    needs: [go-packages-validation, go-application-validation, frontend-validation, full-validation]
+    needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, full-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Require full merge validation
         env:
+          APIGEN_RESULT: ${{ needs.apigen-validation.result }}
           GO_PACKAGES_RESULT: ${{ needs.go-packages-validation.result }}
           GO_APPLICATION_RESULT: ${{ needs.go-application-validation.result }}
           FRONTEND_RESULT: ${{ needs.frontend-validation.result }}
           FULL_VALIDATION_RESULT: ${{ needs.full-validation.result }}
         run: |
+          test "${APIGEN_RESULT}" = success || {
+            printf 'APIGen validation: %s\n' "${APIGEN_RESULT}" >&2
+            exit 1
+          }
           test "${GO_PACKAGES_RESULT}" = success || {
             printf 'Go package validation: %s\n' "${GO_PACKAGES_RESULT}" >&2
             exit 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  apigen-validation:
+    name: APIGen tests (nightly)
+    if: github.repository == 'flidai/leapview'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the cached CI toolchain
+        uses: ./.github/actions/setup-ci
+        with:
+          browser: "false"
+
+      - name: Run APIGen validation
+        run: task ci:lane:go:apigen
+
   go-packages-validation:
     name: Go package tests (nightly)
     if: github.repository == 'flidai/leapview'
@@ -91,7 +111,7 @@ jobs:
   full-validation:
     name: Full nightly validation
     if: github.repository == 'flidai/leapview'
-    needs: [go-packages-validation, go-application-validation, frontend-validation]
+    needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
@@ -136,19 +156,20 @@ jobs:
   ci-gate:
     name: CI gate
     if: ${{ always() }}
-    needs: [go-packages-validation, go-application-validation, frontend-validation, full-validation, security-validation]
+    needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, full-validation, security-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Require exhaustive nightly validation
         env:
+          APIGEN_RESULT: ${{ needs.apigen-validation.result }}
           GO_PACKAGES_RESULT: ${{ needs.go-packages-validation.result }}
           GO_APPLICATION_RESULT: ${{ needs.go-application-validation.result }}
           FRONTEND_RESULT: ${{ needs.frontend-validation.result }}
           FULL_RESULT: ${{ needs.full-validation.result }}
           SECURITY_RESULT: ${{ needs.security-validation.result }}
         run: |
-          for result in "${GO_PACKAGES_RESULT}" "${GO_APPLICATION_RESULT}" "${FRONTEND_RESULT}" "${FULL_RESULT}" "${SECURITY_RESULT}"; do
+          for result in "${APIGEN_RESULT}" "${GO_PACKAGES_RESULT}" "${GO_APPLICATION_RESULT}" "${FRONTEND_RESULT}" "${FULL_RESULT}" "${SECURITY_RESULT}"; do
             test "${result}" = success || {
               printf 'Nightly validation result: %s\n' "${result}" >&2
               exit 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -795,10 +795,14 @@ tasks:
       - task: test:go:prepared
 
   ci:lane:go:packages:
-    desc: Run generated API and non-application Go package tests
+    desc: Run non-application Go package tests
+    cmds:
+      - task: test:go:packages
+
+  ci:lane:go:apigen:
+    desc: Run the vendored APIGen Go module and TypeSpec tests
     cmds:
       - task: apigen:test
-      - task: test:go:packages
 
   ci:lane:go:application:
     desc: Run sharded application and external-service Go tests

--- a/docs/articles/architecture/github-hosted-ci.md
+++ b/docs/articles/architecture/github-hosted-ci.md
@@ -38,11 +38,12 @@ adds desktop tests, static and selected race analysis, route QA, and deployment 
 compatibility alias for the full current-machine contract.
 
 GitHub Actions distributes those same Taskfile units across clean runners. Pull requests run
-the non-application Go packages, sharded application tests, and frontend validation concurrently
-after each runner executes `task ci:prepare`. The merge queue adds `task ci:full:extras`, and the
-daily schedule also runs `task ci:nightly:extras`. Local composition remains available through
-the tier targets; the workflow does not duplicate individual test commands or introduce a
-runner-specific container wrapper.
+APIGen, the non-application Go packages, sharded application tests, and frontend validation
+concurrently. The three repository lanes execute `task ci:prepare`; the independent APIGen module
+does not need generated or embedded application assets and skips that preparation. The merge queue
+adds `task ci:full:extras`, and the daily schedule also runs `task ci:nightly:extras`. Local
+composition remains available through the tier targets; the workflow does not duplicate individual
+test commands or introduce a runner-specific container wrapper.
 
 ## Toolchain and caches
 
@@ -72,9 +73,9 @@ change validation behavior.
 
 ## Workflow tiers
 
-The pull-request workflow runs Go package, Go application, and frontend validation on independent
-four-vCPU runners and reports the stable required `CI gate` check. This prevents browser and Go
-test contention and shortens wall-clock feedback without increasing per-job machine size.
+The pull-request workflow runs APIGen, Go package, Go application, and frontend validation on
+independent four-vCPU runners and reports the stable required `CI gate` check. This prevents browser
+and Go test contention and shortens wall-clock feedback without increasing per-job machine size.
 
 For a native GitHub pull-request stack, only the top pull request runs those validation lanes.
 Lower layers report a successful `CI gate` with a summary that validation is deferred to the

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2565,6 +2565,8 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"types: [opened, synchronize, reopened, ready_for_review, stacked]",
 		"workflow_dispatch:",
 		"group: ci-${{ github.workflow }}-${{ github.event.pull_request.stack.id || github.ref }}",
+		"apigen-validation:",
+		"name: APIGen tests (PR)",
 		"go-packages-validation:",
 		"name: Go package tests (PR)",
 		"go-application-validation:",
@@ -2574,13 +2576,15 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"runs-on: ubuntu-24.04",
 		"uses: ./.github/actions/setup-ci",
 		"run: task ci:prepare",
+		"run: task ci:lane:go:apigen",
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
 		"run: task ci:lane:frontend",
 		"run: task generated:check",
 		"ci-gate:",
 		"name: CI gate",
-		"needs: [go-packages-validation, go-application-validation, frontend-validation]",
+		"needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation]",
+		"APIGEN_RESULT: ${{ needs.apigen-validation.result }}",
 		"GO_PACKAGES_RESULT: ${{ needs.go-packages-validation.result }}",
 		"GO_APPLICATION_RESULT: ${{ needs.go-application-validation.result }}",
 		"FRONTEND_RESULT: ${{ needs.frontend-validation.result }}",
@@ -2590,10 +2594,12 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 			t.Fatalf("CI workflow missing GitHub-hosted fragment %q", want)
 		}
 	}
+	apigenCI := workflowJobBlock(t, text, "apigen-validation")
 	goPackagesCI := workflowJobBlock(t, text, "go-packages-validation")
 	goApplicationCI := workflowJobBlock(t, text, "go-application-validation")
 	frontendCI := workflowJobBlock(t, text, "frontend-validation")
 	for name, block := range map[string]string{
+		"apigen-validation":        apigenCI,
 		"go-packages-validation":    goPackagesCI,
 		"go-application-validation": goApplicationCI,
 		"frontend-validation":       frontendCI,
@@ -2626,6 +2632,8 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"merge_group:",
 		"types: [checks_requested]",
 		"group: merge-validation-${{ github.ref }}",
+		"apigen-validation:",
+		"name: APIGen tests (merge queue)",
 		"go-packages-validation:",
 		"name: Go package tests (merge queue)",
 		"go-application-validation:",
@@ -2636,10 +2644,10 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"name: Full merge validation",
 		"runs-on: ubuntu-24.04",
 		"uses: ./.github/actions/setup-ci",
-		"needs: [go-packages-validation, go-application-validation, frontend-validation]",
+		"needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation]",
 		"run: task ci:full:extras",
 		"name: CI gate",
-		"needs: [go-packages-validation, go-application-validation, frontend-validation, full-validation]",
+		"needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, full-validation]",
 	} {
 		if !strings.Contains(mergeText, want) {
 			t.Fatalf("merge validation workflow missing %q", want)
@@ -2711,6 +2719,14 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 				t.Fatalf("GitHub-hosted validation lane missing %q", want)
 			}
 		}
+	}
+	for _, want := range []string{"uses: ./.github/actions/setup-ci", "task ci:lane:go:apigen"} {
+		if !strings.Contains(apigenCI, want) {
+			t.Fatalf("GitHub-hosted APIGen lane missing %q", want)
+		}
+	}
+	if strings.Contains(apigenCI, "task ci:prepare") {
+		t.Fatal("GitHub-hosted APIGen lane must not pay for repository-wide preparation")
 	}
 	for name, block := range map[string]string{"go package": goPackagesCI, "frontend": frontendCI} {
 		if !strings.Contains(block, "task generated:check") {
@@ -2898,6 +2914,7 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		"run: task ci:lane:go:apigen",
 		"run: task ci:prepare",
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
@@ -2913,6 +2930,7 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 	}
 	for _, want := range []string{
 		"merge_group:",
+		"run: task ci:lane:go:apigen",
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
 		"run: task ci:lane:frontend",
@@ -2927,6 +2945,7 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 		"schedule:",
 		"cron: '17 2 * * *'",
 		"workflow_dispatch:",
+		"run: task ci:lane:go:apigen",
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
 		"run: task ci:lane:frontend",
@@ -2953,6 +2972,8 @@ func TestGitHubHostedCISplitsGoWorkAndWarmsReusableBunCache(t *testing.T) {
 	for _, workflow := range []string{"ci.yml", "merge-validation.yml", "nightly.yml"} {
 		text := read(".github", "workflows", workflow)
 		for _, want := range []string{
+			"apigen-validation:",
+			"run: task ci:lane:go:apigen",
 			"go-packages-validation:",
 			"run: task ci:lane:go:packages",
 			"go-application-validation:",
@@ -2966,8 +2987,9 @@ func TestGitHubHostedCISplitsGoWorkAndWarmsReusableBunCache(t *testing.T) {
 
 	taskfile := read("Taskfile.yml")
 	for _, want := range []string{
-		"ci:lane:go:packages:",
+		"ci:lane:go:apigen:",
 		"- task: apigen:test",
+		"ci:lane:go:packages:",
 		"- task: test:go:packages",
 		"ci:lane:go:application:",
 		"- task: test:go:app:shards",
@@ -2987,6 +3009,46 @@ func TestGitHubHostedCISplitsGoWorkAndWarmsReusableBunCache(t *testing.T) {
 	populateAt := strings.Index(artifacts, "name: Populate main-branch Bun cache")
 	if setupAt < 0 || populateAt < setupAt {
 		t.Fatal("main artifact qualification must populate Bun downloads before the cache save hook")
+	}
+}
+
+func TestGitHubHostedCIRunsAPIGenAsAnIndependentLeanLane(t *testing.T) {
+	root := repoRoot(t)
+	read := func(path ...string) string {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(append([]string{root}, path...)...))
+		if err != nil {
+			t.Fatalf("read %s: %v", filepath.Join(path...), err)
+		}
+		return string(data)
+	}
+
+	for _, workflow := range []string{"ci.yml", "merge-validation.yml", "nightly.yml"} {
+		text := read(".github", "workflows", workflow)
+		apigen := workflowJobBlock(t, text, "apigen-validation")
+		for _, want := range []string{
+			"uses: ./.github/actions/setup-ci",
+			"run: task ci:lane:go:apigen",
+		} {
+			if !strings.Contains(apigen, want) {
+				t.Fatalf("%s APIGen lane missing %q", workflow, want)
+			}
+		}
+		for _, forbidden := range []string{"task ci:prepare", "task generated:check"} {
+			if strings.Contains(apigen, forbidden) {
+				t.Fatalf("%s APIGen lane must stay lean: found %q", workflow, forbidden)
+			}
+		}
+	}
+
+	taskfile := read("Taskfile.yml")
+	apigenLane := taskfileTaskBlock(t, taskfile, "ci:lane:go:apigen")
+	if !strings.Contains(apigenLane, "- task: apigen:test") {
+		t.Fatal("APIGen CI lane must run the vendored APIGen test contract")
+	}
+	packagesLane := taskfileTaskBlock(t, taskfile, "ci:lane:go:packages")
+	if strings.Contains(packagesLane, "apigen:test") {
+		t.Fatal("Go package CI lane must not repeat the independent APIGen contract")
 	}
 }
 


### PR DESCRIPTION
## Summary
- run APIGen as an independent GitHub-hosted validation lane
- remove APIGen from the non-application Go package lane
- skip repository-wide preparation in the self-contained APIGen lane

## Hosted benchmark
Compared with the final green PR #272 baseline:

| Sample | APIGen | Go packages | Go application | Frontend | PR critical path |
| --- | ---: | ---: | ---: | ---: | ---: |
| #272 baseline | included in packages | 13m12s | 9m55s | 7m23s | 13m12s |
| #278 initial | 4m58s | 10m14s | 10m59s | 6m53s | 10m59s |
| #278 confirmation | 4m59s | 10m51s | 9m31s | 6m55s | 11m03s |

Both #278 samples passed. The critical path improved by 2m09s-2m13s, or about 16.5%. All four lanes started concurrently; the confirmation package job began 12 seconds after the other jobs, and its critical-path figure includes that delay.

Runs: [initial](https://github.com/flidai/leapview/actions/runs/31492171724), [confirmation](https://github.com/flidai/leapview/actions/runs/31493130220).

## Local validation
- `task ci:lane:go:apigen`
- `task ci:lane:go:packages`
- `go test ./internal/platform/architecture -count=1`
- workflow YAML parse
- `git diff --check`