### PR TITLE
feat: streamline APIGen command authoring

### DIFF
--- a/api/typespec/access.tsp
+++ b/api/typespec/access.tsp
@@ -132,6 +132,22 @@ model RoleBindingCreatedAuditPayload {
   surface: string;
 }
 
+@apigen.failureDefinition(#{
+  kind: "invalid",
+  statusCode: 400,
+  code: "ROLE_BINDING_INVALID",
+  publicDetail: "The role binding request is invalid.",
+})
+model RoleBindingInvalidFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "ROLE_BINDING_NOT_FOUND",
+  publicDetail: "Role binding not found.",
+})
+model RoleBindingNotFoundFailure {}
+
 // Durable, typed payloads for Access command audit records.  Every field is
 // required so the generated encoder can reject incomplete audit events before
 // they reach the repository.
@@ -815,66 +831,43 @@ alias UpdateRoleBindingOK = OkJson<RoleBindingResponse>;
 
 @tag("Access")
 @route("/workspaces/{workspace}/role-bindings")
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@apigen.commandDefaults(#{ guarantee: "transactional" })
+@apigen.auditPayload(RoleBindingAuditPayload)
 interface RoleBindings {
   @summary("List role bindings")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("listRoleBindings")
   listRoleBindings(@path workspace: string, @query subjectType?: string, @query subjectId?: string, @query role?: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListRoleBindingsOK | CommonErrors;
 
   @summary("Create a role binding")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.ui("workspace.access.role-binding.create")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "role_binding.created", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "ROLE_BINDING_INVALID", publicDetail: "The role binding request is invalid." },
-    ],
-  })
+  @apigen.failsWith(RoleBindingInvalidFailure)
+  @apigen.command(#{ auditAction: "role_binding.created" })
   @apigen.auditPayload(RoleBindingCreatedAuditPayload)
-  @operationId("createRoleBinding")
   createRoleBinding(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: RoleBindingRequest): CreateRoleBindingCreated | CommonErrors;
 
   @summary("Get a workspace role binding")
   @route("/{binding}")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("getRoleBinding")
   getRoleBinding(@path workspace: string, @path binding: string): OkJson<RoleBindingResponse> | CommonErrors;
 
   @summary("Delete a role binding")
   @route("/{binding}")
   @delete
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.ui("workspace.access.role-binding.delete")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "role_binding.deleted", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "ROLE_BINDING_NOT_FOUND", publicDetail: "Role binding not found." },
-      #{ kind: "invalid", statusCode: 400, code: "ROLE_BINDING_INVALID", publicDetail: "The role binding request is invalid." },
-    ],
-    targetParameter: "workspace",
-  })
-  @apigen.auditPayload(RoleBindingAuditPayload)
-  @operationId("deleteRoleBinding")
-  deleteRoleBinding(@path workspace: string, @path binding: string): EmptyResponse | CommonErrors;
+  @apigen.failsWith(RoleBindingNotFoundFailure)
+  @apigen.failsWith(RoleBindingInvalidFailure)
+  @apigen.command(#{ auditAction: "role_binding.deleted" })
+  deleteRoleBinding(@path @apigen.target workspace: string, @path binding: string): EmptyResponse | CommonErrors;
 
   @summary("Update a role binding")
   @route("/{binding}")
   @patch
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.ui("workspace.access.role-binding.update")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "role_binding.updated", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "ROLE_BINDING_NOT_FOUND", publicDetail: "Role binding not found." },
-    ],
-    targetParameter: "workspace",
-  })
-  @apigen.auditPayload(RoleBindingAuditPayload)
-  @operationId("updateRoleBinding")
-  updateRoleBinding(@path workspace: string, @path binding: string, @header("If-Match") ifMatch: string, @body body: RoleBindingRequest): UpdateRoleBindingOK | CommonErrors;
+  @apigen.failsWith(RoleBindingNotFoundFailure)
+  @apigen.command(#{ auditAction: "role_binding.updated" })
+  updateRoleBinding(@path @apigen.target workspace: string, @path binding: string, @header("If-Match") ifMatch: string, @body body: RoleBindingRequest): UpdateRoleBindingOK | CommonErrors;
 }
 
 alias ListWorkspaceRolesOK = OkJson<RoleListResponse>;

--- a/api/typespec/releases.tsp
+++ b/api/typespec/releases.tsp
@@ -231,8 +231,17 @@ interface Releases {
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.asyncExecution(Releases.getRelease, Releases.listReleaseEvents, #{
+    guarantee: "transactional",
+    jobKind: "release.finalize",
+    resourceKind: "release",
+    initialEvent: "release.validating",
+    initialState: "validating",
+    cancellation: "unsupported",
+  })
   @apigen.command(#{
-    audit: #{ required: true, successAction: "release.validating", guarantee: "transactional" },
+    auditAction: "release.validating",
+    guarantee: "transactional",
     failures: #[
       #{ kind: "conflict", statusCode: 409, code: "RELEASE_CONFLICT", publicDetail: "The release conflicts with its current state." },
       #{ kind: "immutable", statusCode: 409, code: "RELEASE_IMMUTABLE", publicDetail: "The release is immutable." },
@@ -240,22 +249,9 @@ interface Releases {
       #{ kind: "not_found", statusCode: 404, code: "RELEASE_NOT_FOUND", publicDetail: "Release not found." },
       #{ kind: "queue_unavailable", statusCode: 503, code: "ASYNC_QUEUE_UNAVAILABLE", publicDetail: "Release finalization could not be queued." },
     ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "release.finalize",
-      resourceKind: "release",
-      initialEvent: "release.validating",
-      initialState: "validating",
-      statusOperation: "getRelease",
-      eventsOperation: "listReleaseEvents",
-      cancellation: "unsupported",
-    },
-    targetParameter: "project",
   })
   @apigen.auditPayload(ReleaseValidatingAuditPayload)
-  @operationId("finalizeRelease")
-  finalizeRelease(@path project: string, @path release: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<ReleaseResponse> | CommonErrors;
+  finalizeRelease(@path @apigen.target project: string, @path release: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<ReleaseResponse> | CommonErrors;
 
   @summary("List or stream release events")
   @route("/{release}/events")

--- a/pkg/apigen/README.md
+++ b/pkg/apigen/README.md
@@ -112,32 +112,30 @@ also the transport-neutral application command identity:
 
 ```typespec
 @route("/workspaces/{workspace}/role-bindings")
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@apigen.commandDefaults(#{ guarantee: "transactional" })
+@apigen.auditPayload(RoleBindingAuditPayload)
 interface RoleBindings {
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+  @apigen.ui("workspace.access.role-binding.create")
+  @apigen.failsWith(RoleBindingConflict)
   @apigen.command(#{
-    audit: #{
-      required: true,
-      successAction: "role_binding.created",
-      guarantee: "transactional",
-    },
-    failures: #[
-      #{
-        kind: "conflict",
-        statusCode: 409,
-        code: "ROLE_BINDING_CONFLICT",
-        publicDetail: "The role binding conflicts with current state.",
-      },
-    ],
-    additionalExposures: #["ui"],
+    auditAction: "role_binding.created",
   })
-  @operationId("createRoleBinding")
   createRoleBinding(
-    @path workspace: string,
+    @path @apigen.target workspace: string,
     @header("Idempotency-Key") idempotencyKey: string,
     @body body: RoleBindingRequest,
   ): RoleBindingResponse;
 }
+
+@apigen.failureDefinition(#{
+  kind: "conflict",
+  statusCode: 409,
+  code: "ROLE_BINDING_CONFLICT",
+  publicDetail: "The role binding conflicts with current state.",
+})
+model RoleBindingConflict {}
 ```
 
 HTTP is implied by the endpoint, and generated clients provide the CLI/API
@@ -146,8 +144,10 @@ such as `ui`, `agent`, or `automation`. Owner and authorization are derived
 from the declaring namespace and `@apigen.authz`; the target is inferred from a
 single path parameter or selected explicitly with `targetParameter`.
 
-APIGen requires an explicit `@operationId`, stable dotted lower-snake-case
-audit actions, a required `Idempotency-Key` on POST commands, and a required
+APIGen uses the TypeSpec operation name as the operation ID by default;
+`@operationId` remains available for intentional overrides. Inferred IDs must
+be unique. APIGen also requires stable dotted lower-snake-case audit actions, a
+required `Idempotency-Key` on POST commands, and a required
 `If-Match` on PATCH commands. It emits the normalized value in IR, generated Go
 operation registries, aggregate registries, and OpenAPI `x-apigen-command`.
 The generated runtime registry is the transport-neutral execution policy:
@@ -168,8 +168,11 @@ request bodies, target values, idempotency keys, and concurrency tokens are not
 logged. Applications should not maintain parallel method/path allowlists or
 surface-specific command-policy tables.
 
-Every command must explicitly declare `failures`, using `#[]` when it has no
-operation-owned domain failures. Each failure binds a transport-neutral stable
+Every command must explicitly declare `failures`, inherit them through
+`@apigen.commandDefaults`, use one or more `@apigen.failsWith` references, or
+use `#[]` when it has no operation-owned domain failures. Named failures are
+declared once with `@apigen.failureDefinition`; APIGen rejects conflicting
+definitions for the same public code. Each failure binds a transport-neutral stable
 lower-snake-case `kind` to one documented HTTP status, stable upper-snake-case
 public `code`, and safe `publicDetail`. Generated registries expose
 `GetAPIGenCommandFailureContracts`; `runtime/failure` classifies domain errors
@@ -213,6 +216,14 @@ redacts `internal`, `pii`, and `secret`. Both encoders reject missing or
 undeclared fields, so schema drift fails the command lifecycle instead of
 silently changing persisted audit data.
 
+Auditing is required by default for concise `@apigen.command` declarations.
+Interfaces can own shared `@apigen.authz`, `@apigen.commandDefaults`, and
+`@apigen.auditPayload` metadata; operation metadata overrides inherited
+defaults, and generated IR always contains the fully expanded policy. A truly
+ephemeral mutation must opt out conspicuously with
+`@apigen.unaudited("reason")`. The legacy nested `audit` form remains accepted
+while contracts migrate.
+
 Generated Go servers also expose `GetAPIGenCommandRuntimeContract`, which
 normalizes every required audit into `runtime/command.Contract`. Construct a
 `runtime/command.Executor` with that lookup and supply both application
@@ -222,20 +233,18 @@ and reject successful responses whose command never completed through the
 executor. This makes a newly declared command fail closed until its runtime
 capability is wired.
 
-Commands that start durable work can add a typed execution lifecycle:
+Commands that start durable work can reference their status and event
+operations by symbol:
 
 ```typespec
-execution: #{
-  mode: "async",
+@apigen.asyncExecution(Releases.getRelease, Releases.listReleaseEvents, #{
   guarantee: "transactional",
   jobKind: "release.finalize",
   resourceKind: "release",
   initialEvent: "release.validating",
   initialState: "validating",
-  statusOperation: "getRelease",
-  eventsOperation: "listReleaseEvents",
   cancellation: "unsupported",
-}
+})
 ```
 
 APIGen requires a transactional execution guarantee, a `202` response, and

--- a/pkg/apigen/cmd/apigen/main_test.go
+++ b/pkg/apigen/cmd/apigen/main_test.go
@@ -315,8 +315,8 @@ namespace Analytics {
 		namespaces[endpoint.OperationID] = endpoint.Namespace
 	}
 	require.Equal(t, map[string]string{
-		"Access_getCurrentPrincipal": "PartitionedAPI.Access",
-		"Reports_listReports":        "PartitionedAPI.Analytics.Reports",
+		"getCurrentPrincipal": "PartitionedAPI.Access",
+		"listReports":         "PartitionedAPI.Analytics.Reports",
 	}, namespaces)
 	require.FileExists(t, openAPIPath)
 }

--- a/pkg/apigen/typespec/dist/src/decorators.d.ts
+++ b/pkg/apigen/typespec/dist/src/decorators.d.ts
@@ -1,4 +1,4 @@
-import type { DecoratorContext, Enum, Model, ModelProperty, Namespace, Operation } from "@typespec/compiler";
+import type { DecoratorContext, Enum, Interface, Model, ModelProperty, Namespace, Operation } from "@typespec/compiler";
 export interface CLIArg {
     source: "path" | "query" | "body";
     name: string;
@@ -46,6 +46,15 @@ export interface AsyncExecutionOptions {
     eventsOperation: string;
     cancellation: "supported" | "unsupported";
 }
+export interface TypedAsyncExecutionOptions {
+    mode?: "async";
+    guarantee: "transactional";
+    jobKind: string;
+    resourceKind: string;
+    initialEvent: string;
+    initialState: string;
+    cancellation: "supported" | "unsupported";
+}
 export interface CommandFailureOptions {
     kind: string;
     statusCode: number;
@@ -53,11 +62,23 @@ export interface CommandFailureOptions {
     publicDetail: string;
 }
 export interface CommandOptions {
-    audit: AuditOptions;
+    audit?: AuditOptions;
+    auditAction?: string;
+    guarantee?: "transactional" | "best-effort";
     execution?: AsyncExecutionOptions;
-    failures: CommandFailureOptions[];
+    failures?: CommandFailureOptions[];
     additionalExposures?: Array<"ui" | "agent" | "automation">;
     targetParameter?: string;
+}
+export interface CommandDefaultsOptions {
+    guarantee?: "transactional" | "best-effort";
+    failures?: CommandFailureOptions[];
+    additionalExposures?: Array<"ui" | "agent" | "automation">;
+}
+export interface TypedAsyncExecutionDefinition {
+    status: Operation;
+    events: Operation;
+    options: TypedAsyncExecutionOptions;
 }
 export interface ResponseShapeOptions {
     kind: "wrapped_json";
@@ -123,8 +144,10 @@ export interface ToolOptions {
 }
 export declare function $cli(context: DecoratorContext, target: Operation, options: CLIOptions): void;
 export declare function $command(context: DecoratorContext, target: Operation, options: CommandOptions): void;
+export declare function $commandDefaults(context: DecoratorContext, target: Interface, options: CommandDefaultsOptions): void;
+export declare function $unaudited(context: DecoratorContext, target: Operation, reason: string): void;
 export declare function $ui(context: DecoratorContext, target: Operation, actionId: string): void;
-export declare function $auditPayload(context: DecoratorContext, target: Operation, schema: Model, options?: AuditPayloadOptions): void;
+export declare function $auditPayload(context: DecoratorContext, target: Operation | Interface, schema: Model, options?: AuditPayloadOptions): void;
 export declare function $auditSchema(context: DecoratorContext, target: Model, options: AuditPayloadOptions): void;
 export declare function $sensitivity(context: DecoratorContext, target: ModelProperty, classification: AuditSensitivity): void;
 export declare function $auditPublic(context: DecoratorContext, target: ModelProperty): void;
@@ -132,7 +155,11 @@ export declare function $auditInternal(context: DecoratorContext, target: ModelP
 export declare function $auditPii(context: DecoratorContext, target: ModelProperty): void;
 export declare function $auditSecret(context: DecoratorContext, target: ModelProperty): void;
 export declare function $query(context: DecoratorContext, target: Operation): void;
-export declare function $authz(context: DecoratorContext, target: Operation, value: unknown): void;
+export declare function $authz(context: DecoratorContext, target: Operation | Interface, value: unknown): void;
+export declare function $target(context: DecoratorContext, target: ModelProperty): void;
+export declare function $asyncExecution(context: DecoratorContext, target: Operation, status: Operation, events: Operation, options: TypedAsyncExecutionOptions): void;
+export declare function $failureDefinition(context: DecoratorContext, target: Model, options: CommandFailureOptions): void;
+export declare function $failsWith(context: DecoratorContext, target: Operation, definition: Model): void;
 export declare function $manual(context: DecoratorContext, target: Operation): void;
 export declare function $responseShape(context: DecoratorContext, target: Model, options: ResponseShapeOptions): void;
 export declare function $package(context: DecoratorContext, target: Namespace, options: PackageOptions): void;
@@ -144,6 +171,8 @@ export declare const $decorators: {
     apigen: {
         cli: typeof $cli;
         command: typeof $command;
+        commandDefaults: typeof $commandDefaults;
+        unaudited: typeof $unaudited;
         ui: typeof $ui;
         auditPayload: typeof $auditPayload;
         auditSchema: typeof $auditSchema;
@@ -154,6 +183,10 @@ export declare const $decorators: {
         auditSecret: typeof $auditSecret;
         query: typeof $query;
         authz: typeof $authz;
+        target: typeof $target;
+        asyncExecution: typeof $asyncExecution;
+        failureDefinition: typeof $failureDefinition;
+        failsWith: typeof $failsWith;
         manual: typeof $manual;
         responseShape: typeof $responseShape;
         package: typeof $package;
@@ -168,7 +201,19 @@ export declare function getCLI(context: {
 }, target: Operation): CLIOptions | undefined;
 export declare function getCommand(context: {
     program: DecoratorContext["program"];
+}, target: Operation): (CommandOptions & {
+    audit: AuditOptions;
+    failures: CommandFailureOptions[];
+}) | undefined;
+export declare function getAuthoredCommand(context: {
+    program: DecoratorContext["program"];
 }, target: Operation): CommandOptions | undefined;
+export declare function getCommandDefaults(context: {
+    program: DecoratorContext["program"];
+}, target: Interface): CommandDefaultsOptions | undefined;
+export declare function getUnauditedReason(context: {
+    program: DecoratorContext["program"];
+}, target: Operation): string | undefined;
 export declare function getUI(context: {
     program: DecoratorContext["program"];
 }, target: Operation): string | undefined;
@@ -187,6 +232,18 @@ export declare function isQuery(context: {
 export declare function getAuthz(context: {
     program: DecoratorContext["program"];
 }, target: Operation): any;
+export declare function isTarget(context: {
+    program: DecoratorContext["program"];
+}, target: ModelProperty): boolean;
+export declare function getAsyncExecution(context: {
+    program: DecoratorContext["program"];
+}, target: Operation): TypedAsyncExecutionDefinition | undefined;
+export declare function getNamedFailures(context: {
+    program: DecoratorContext["program"];
+}, target: Operation): {
+    model: Model;
+    options: CommandFailureOptions | undefined;
+}[];
 export declare function isManual(context: {
     program: DecoratorContext["program"];
 }, target: Operation): boolean;

--- a/pkg/apigen/typespec/dist/src/decorators.js
+++ b/pkg/apigen/typespec/dist/src/decorators.js
@@ -1,12 +1,18 @@
 import { reportDiagnostic } from "./lib.js";
 const cliKey = Symbol.for("@yacobolo/apigen.cli");
 const commandKey = Symbol.for("@yacobolo/apigen.command");
+const commandDefaultsKey = Symbol.for("@yacobolo/apigen.commandDefaults");
+const unauditedKey = Symbol.for("@yacobolo/apigen.unaudited");
 const uiKey = Symbol.for("@yacobolo/apigen.ui");
 const auditPayloadKey = Symbol.for("@yacobolo/apigen.auditPayload");
 const auditSchemaKey = Symbol.for("@yacobolo/apigen.auditSchema");
 const sensitivityKey = Symbol.for("@yacobolo/apigen.sensitivity");
 const queryKey = Symbol.for("@yacobolo/apigen.query");
 const authzKey = Symbol.for("@yacobolo/apigen.authz");
+const targetKey = Symbol.for("@yacobolo/apigen.target");
+const asyncExecutionKey = Symbol.for("@yacobolo/apigen.asyncExecution");
+const failureDefinitionKey = Symbol.for("@yacobolo/apigen.failureDefinition");
+const failsWithKey = Symbol.for("@yacobolo/apigen.failsWith");
 const manualKey = Symbol.for("@yacobolo/apigen.manual");
 const responseShapeKey = Symbol.for("@yacobolo/apigen.responseShape");
 const packageKey = Symbol.for("@yacobolo/apigen.package");
@@ -18,7 +24,21 @@ export function $cli(context, target, options) {
     context.program.stateMap(cliKey).set(target, options);
 }
 export function $command(context, target, options) {
+    if (options.audit && (options.auditAction !== undefined || options.guarantee !== undefined)) {
+        reportDiagnostic(context.program, {
+            code: "invalid-command",
+            format: { reason: "use legacy audit or concise auditAction/guarantee syntax, not both" },
+            target,
+        });
+        return;
+    }
     context.program.stateMap(commandKey).set(target, options);
+}
+export function $commandDefaults(context, target, options) {
+    context.program.stateMap(commandDefaultsKey).set(target, options);
+}
+export function $unaudited(context, target, reason) {
+    context.program.stateMap(unauditedKey).set(target, reason);
 }
 export function $ui(context, target, actionId) {
     const actions = context.program.stateMap(uiKey);
@@ -89,6 +109,43 @@ export function $query(context, target) {
 export function $authz(context, target, value) {
     context.program.stateMap(authzKey).set(target, value);
 }
+export function $target(context, target) {
+    context.program.stateSet(targetKey).add(target);
+}
+export function $asyncExecution(context, target, status, events, options) {
+    context.program.stateMap(asyncExecutionKey).set(target, { status, events, options });
+}
+export function $failureDefinition(context, target, options) {
+    const definitions = context.program.stateMap(failureDefinitionKey);
+    if (definitions.has(target)) {
+        reportDiagnostic(context.program, {
+            code: "invalid-command",
+            format: { reason: "@apigen.failureDefinition must not be applied more than once" },
+            target,
+        });
+        return;
+    }
+    for (const [model, authored] of definitions.entries()) {
+        if (authored.code === options.code && (authored.kind !== options.kind ||
+            authored.statusCode !== options.statusCode ||
+            authored.publicDetail !== options.publicDetail)) {
+            reportDiagnostic(context.program, {
+                code: "invalid-command",
+                format: {
+                    reason: `failure code ${JSON.stringify(options.code)} conflicts with definition ${JSON.stringify(model.name)}`,
+                },
+                target,
+            });
+            return;
+        }
+    }
+    definitions.set(target, options);
+}
+export function $failsWith(context, target, definition) {
+    const definitions = context.program.stateMap(failsWithKey);
+    const current = definitions.get(target) ?? [];
+    definitions.set(target, [...current, definition]);
+}
 export function $manual(context, target) {
     context.program.stateSet(manualKey).add(target);
 }
@@ -114,6 +171,8 @@ export const $decorators = {
     apigen: {
         cli: $cli,
         command: $command,
+        commandDefaults: $commandDefaults,
+        unaudited: $unaudited,
         ui: $ui,
         auditPayload: $auditPayload,
         auditSchema: $auditSchema,
@@ -124,6 +183,10 @@ export const $decorators = {
         auditSecret: $auditSecret,
         query: $query,
         authz: $authz,
+        target: $target,
+        asyncExecution: $asyncExecution,
+        failureDefinition: $failureDefinition,
+        failsWith: $failsWith,
         manual: $manual,
         responseShape: $responseShape,
         package: $package,
@@ -137,13 +200,43 @@ export function getCLI(context, target) {
     return context.program.stateMap(cliKey).get(target);
 }
 export function getCommand(context, target) {
+    const authored = context.program.stateMap(commandKey).get(target);
+    if (!authored) {
+        return undefined;
+    }
+    const defaults = target.interface
+        ? context.program.stateMap(commandDefaultsKey).get(target.interface)
+        : undefined;
+    const audit = authored.audit ?? {
+        required: context.program.stateMap(unauditedKey).has(target) ? false : true,
+        successAction: authored.auditAction,
+        guarantee: authored.guarantee ?? defaults?.guarantee,
+    };
+    return {
+        ...authored,
+        audit: {
+            ...audit,
+            guarantee: audit.guarantee ?? defaults?.guarantee,
+        },
+        failures: authored.failures ?? defaults?.failures ?? [],
+        additionalExposures: authored.additionalExposures ?? defaults?.additionalExposures,
+    };
+}
+export function getAuthoredCommand(context, target) {
     return context.program.stateMap(commandKey).get(target);
+}
+export function getCommandDefaults(context, target) {
+    return context.program.stateMap(commandDefaultsKey).get(target);
+}
+export function getUnauditedReason(context, target) {
+    return context.program.stateMap(unauditedKey).get(target);
 }
 export function getUI(context, target) {
     return context.program.stateMap(uiKey).get(target);
 }
 export function getAuditPayload(context, target) {
-    return context.program.stateMap(auditPayloadKey).get(target);
+    return (context.program.stateMap(auditPayloadKey).get(target) ??
+        (target.interface ? context.program.stateMap(auditPayloadKey).get(target.interface) : undefined));
 }
 export function getAuditSchema(context, target) {
     return context.program.stateMap(auditSchemaKey).get(target);
@@ -155,7 +248,21 @@ export function isQuery(context, target) {
     return context.program.stateSet(queryKey).has(target);
 }
 export function getAuthz(context, target) {
-    return context.program.stateMap(authzKey).get(target);
+    return context.program.stateMap(authzKey).get(target) ??
+        (target.interface ? context.program.stateMap(authzKey).get(target.interface) : undefined);
+}
+export function isTarget(context, target) {
+    return context.program.stateSet(targetKey).has(target);
+}
+export function getAsyncExecution(context, target) {
+    return context.program.stateMap(asyncExecutionKey).get(target);
+}
+export function getNamedFailures(context, target) {
+    const models = context.program.stateMap(failsWithKey).get(target);
+    return (models ?? []).map((model) => ({
+        model,
+        options: context.program.stateMap(failureDefinitionKey).get(model),
+    }));
 }
 export function isManual(context, target) {
     return context.program.stateSet(manualKey).has(target);

--- a/pkg/apigen/typespec/dist/src/on-emit.js
+++ b/pkg/apigen/typespec/dist/src/on-emit.js
@@ -1,7 +1,7 @@
 import { emitFile, getAllTags, getDoc, getDiscriminatedUnion, getDiscriminatedUnionFromInheritance, getDiscriminator, getMaxLength, getMaxValue, getMinLength, getMinValue, getOverloadedOperation, getOverloads, getService, getSummary, isArrayModelType, isRecordModelType, } from "@typespec/compiler";
 import { getAllHttpServices, getServers, isOverloadSameEndpoint, isSharedRoute, resolveAuthentication, } from "@typespec/http";
-import { getExtensions, getOperationId, getTagsMetadata, resolveInfo, resolveOperationId } from "@typespec/openapi";
-import { getAuthz, getAuditPayload, getAuditSchema, getCLI, getCommand, getContracts, getMetadata, getPackages, getResponseShape, getSensitivity, getTool, getTransportErrors, getUI, isManual, isQuery, } from "./decorators.js";
+import { getExtensions, getOperationId, getTagsMetadata, resolveInfo } from "@typespec/openapi";
+import { getAuthz, getAsyncExecution, getAuthoredCommand, getAuditPayload, getAuditSchema, getCLI, getCommand, getCommandDefaults, getContracts, getMetadata, getNamedFailures, getPackages, getResponseShape, getSensitivity, getTool, getTransportErrors, getUI, getUnauditedReason, isTarget, isManual, isQuery, } from "./decorators.js";
 import { reportDiagnostic } from "./lib.js";
 class IRBuilder {
     program;
@@ -514,7 +514,20 @@ function buildDocument(program, builder, service, options) {
 }
 function mergedEndpoints(program, builder, operations, operationsAuth, defaultSecurity) {
     const groups = operationGroups(program, operations);
-    return groups.map((group) => endpoint(program, builder, group, operationsAuth, defaultSecurity));
+    const endpoints = groups.map((group) => endpoint(program, builder, group, operationsAuth, defaultSecurity));
+    const operationIDs = new Map();
+    for (let index = 0; index < endpoints.length; index++) {
+        const operationID = endpoints[index].operation_id;
+        const target = groups[index].canonical.operation;
+        const existing = operationIDs.get(operationID);
+        if (existing) {
+            builder.invalidOperationKind(`operation ID ${JSON.stringify(operationID)} is duplicated; use @operationId for an intentional override`, target);
+        }
+        else {
+            operationIDs.set(operationID, target);
+        }
+    }
+    return endpoints;
 }
 function operationGroups(program, operations) {
     const byRoute = new Map();
@@ -578,7 +591,7 @@ function endpoint(program, builder, group, operationsAuth, defaultSecurity) {
     const output = prune({
         method: operation.verb,
         path: operation.path,
-        operation_id: getOperationId(program, operation.operation) ?? resolveOperationId(program, operation.operation),
+        operation_id: operationID(program, operation.operation),
         kind: operationKind(program, builder, operation),
         namespace: namespaceName(operation.operation.namespace),
         summary: getSummary(program, operation.operation),
@@ -600,7 +613,7 @@ function endpoint(program, builder, group, operationsAuth, defaultSecurity) {
 function validateSharedRouteMetadata(program, builder, operations, canonical) {
     const canonicalNamespace = namespaceName(canonical.operation.namespace);
     const canonicalCLI = stableJSONString(cliMetadata(program, canonical));
-    const canonicalCommand = stableJSONString(getCommand({ program }, canonical.operation));
+    const canonicalCommand = stableJSONString(commandIdentity(program, canonical.operation));
     const canonicalUI = stableJSONString(getUI({ program }, canonical.operation));
     const canonicalAuditPayload = stableJSONString(auditPayloadIdentity(program, canonical.operation));
     const canonicalQuery = isQuery({ program }, canonical.operation);
@@ -615,7 +628,7 @@ function validateSharedRouteMetadata(program, builder, operations, canonical) {
         if (stableJSONString(cliMetadata(program, operation)) !== canonicalCLI) {
             builder.unsupportedSharedRoute(operation.operation, "incompatible cli metadata");
         }
-        if (stableJSONString(getCommand({ program }, operation.operation)) !== canonicalCommand) {
+        if (stableJSONString(commandIdentity(program, operation.operation)) !== canonicalCommand) {
             builder.unsupportedSharedRoute(operation.operation, "incompatible command metadata");
         }
         if (stableJSONString(getUI({ program }, operation.operation)) !== canonicalUI) {
@@ -646,9 +659,6 @@ function operationKind(program, builder, operation) {
     const ui = getUI({ program }, operation.operation);
     const query = isQuery({ program }, operation.operation);
     const method = operation.verb.toLowerCase();
-    if (builder.requireExplicitOperationKind && getOperationId(program, operation.operation) === undefined) {
-        builder.invalidOperationKind("an explicit @operationId is required", operation.operation);
-    }
     if (command && query) {
         builder.invalidOperationKind("@apigen.command and @apigen.query are mutually exclusive", operation.operation);
         return "command";
@@ -686,11 +696,15 @@ function commandMetadata(program, builder, operation, parameters) {
     if (!options) {
         return undefined;
     }
-    if (getOperationId(program, operation.operation) === undefined) {
-        builder.invalidCommand("an explicit @operationId is required", operation.operation);
-    }
     const successAction = options.audit.successAction?.trim();
     const guarantee = options.audit.guarantee;
+    const unauditedReason = getUnauditedReason({ program }, operation.operation)?.trim();
+    if (getUnauditedReason({ program }, operation.operation) !== undefined && !unauditedReason) {
+        builder.invalidCommand("@apigen.unaudited requires a non-empty reason", operation.operation);
+    }
+    if (unauditedReason && (options.audit.required || successAction)) {
+        builder.invalidCommand("@apigen.unaudited cannot be combined with an audited command", operation.operation);
+    }
     if (options.audit.required && !successAction) {
         builder.invalidCommand("audit.successAction is required when audit.required is true", operation.operation);
     }
@@ -741,13 +755,25 @@ function commandMetadata(program, builder, operation, parameters) {
         }
     }
     let execution;
-    if (options.execution) {
-        const jobKind = options.execution.jobKind.trim();
-        const resourceKind = options.execution.resourceKind.trim();
-        const initialEvent = options.execution.initialEvent.trim();
-        const initialState = options.execution.initialState.trim();
-        const statusOperation = options.execution.statusOperation.trim();
-        const eventsOperation = options.execution.eventsOperation.trim();
+    const typedExecution = getAsyncExecution({ program }, operation.operation);
+    if (options.execution && typedExecution) {
+        builder.invalidCommand("declare async execution either inline or with @apigen.asyncExecution, not both", operation.operation);
+    }
+    const executionOptions = typedExecution
+        ? {
+            mode: typedExecution.options.mode ?? "async",
+            ...typedExecution.options,
+            statusOperation: operationID(program, typedExecution.status),
+            eventsOperation: operationID(program, typedExecution.events),
+        }
+        : options.execution;
+    if (executionOptions) {
+        const jobKind = executionOptions.jobKind.trim();
+        const resourceKind = executionOptions.resourceKind.trim();
+        const initialEvent = executionOptions.initialEvent.trim();
+        const initialState = executionOptions.initialState.trim();
+        const statusOperation = executionOptions.statusOperation.trim();
+        const eventsOperation = executionOptions.eventsOperation.trim();
         if (!jobKindPattern.test(jobKind)) {
             builder.invalidCommand("execution.jobKind must be a stable lower_snake_case identifier", operation.operation);
         }
@@ -761,21 +787,37 @@ function commandMetadata(program, builder, operation, parameters) {
             builder.invalidCommand("execution statusOperation and eventsOperation must be distinct operation IDs", operation.operation);
         }
         execution = {
-            mode: options.execution.mode,
-            guarantee: options.execution.guarantee,
+            mode: executionOptions.mode,
+            guarantee: executionOptions.guarantee,
             job_kind: jobKind,
             resource_kind: resourceKind,
             initial_event: initialEvent,
             initial_state: initialState,
             status_operation: statusOperation,
             events_operation: eventsOperation,
-            cancellation: options.execution.cancellation,
+            cancellation: executionOptions.cancellation,
         };
     }
     const failures = [];
     const failureKinds = new Set();
     const failureCodes = new Set();
-    for (const authored of options.failures ?? []) {
+    const namedFailures = getNamedFailures({ program }, operation.operation);
+    const authoredCommand = getAuthoredCommand({ program }, operation.operation);
+    const commandDefaults = operation.operation.interface
+        ? getCommandDefaults({ program }, operation.operation.interface)
+        : undefined;
+    if (authoredCommand?.failures === undefined && commandDefaults?.failures === undefined && namedFailures.length === 0) {
+        builder.invalidCommand("every command must declare failures, inherit default failures, or use @apigen.failsWith", operation.operation);
+    }
+    for (const named of namedFailures) {
+        if (!named.options) {
+            builder.invalidCommand(`failure model ${JSON.stringify(named.model.name)} requires @apigen.failureDefinition`, operation.operation);
+        }
+    }
+    for (const authored of [
+        ...(options.failures ?? []),
+        ...namedFailures.flatMap((named) => named.options ? [named.options] : []),
+    ]) {
         const kind = authored.kind.trim();
         const code = authored.code.trim();
         const publicDetail = authored.publicDetail.trim();
@@ -826,7 +868,15 @@ function commandMetadata(program, builder, operation, parameters) {
     additionalExposures.sort();
     const emittedParameters = parameters ?? [];
     const pathParameters = emittedParameters.filter((parameter) => parameter.in === "path");
-    let targetParameter = options.targetParameter?.trim();
+    const decoratedTargets = [...operation.operation.parameters.properties.values()]
+        .filter((property) => propertyIsTarget(program, property));
+    if (decoratedTargets.length > 1) {
+        builder.invalidCommand("@apigen.target must identify exactly one operation parameter", operation.operation);
+    }
+    if (options.targetParameter && decoratedTargets.length > 0) {
+        builder.invalidCommand("declare a command target with targetParameter or @apigen.target, not both", operation.operation);
+    }
+    let targetParameter = decoratedTargets[0]?.name ?? options.targetParameter?.trim();
     if (!targetParameter && pathParameters.length === 1) {
         targetParameter = pathParameters[0].name;
     }
@@ -869,6 +919,37 @@ function commandMetadata(program, builder, operation, parameters) {
         authz_mode: authzMode,
         privilege,
     });
+}
+function operationID(program, operation) {
+    return getOperationId(program, operation) ?? operation.name;
+}
+function propertyIsTarget(program, property) {
+    let candidate = property;
+    while (candidate) {
+        if (isTarget({ program }, candidate)) {
+            return true;
+        }
+        candidate = candidate.sourceProperty;
+    }
+    return false;
+}
+function commandIdentity(program, operation) {
+    const asyncExecution = getAsyncExecution({ program }, operation);
+    return {
+        options: getCommand({ program }, operation),
+        target: [...operation.parameters.properties.values()]
+            .filter((property) => propertyIsTarget(program, property))
+            .map((property) => property.name),
+        asyncExecution: asyncExecution && {
+            status: operationID(program, asyncExecution.status),
+            events: operationID(program, asyncExecution.events),
+            options: asyncExecution.options,
+        },
+        namedFailures: getNamedFailures({ program }, operation).map((failure) => ({
+            name: failure.model.name,
+            options: failure.options,
+        })),
+    };
 }
 function auditPayloadIdentity(program, operation) {
     const payload = getAuditPayload({ program }, operation);

--- a/pkg/apigen/typespec/lib/main.tsp
+++ b/pkg/apigen/typespec/lib/main.tsp
@@ -55,6 +55,16 @@ model AsyncExecutionOptions {
   cancellation: "supported" | "unsupported";
 }
 
+model TypedAsyncExecutionOptions {
+  mode?: "async";
+  guarantee: "transactional";
+  jobKind: string;
+  resourceKind: string;
+  initialEvent: string;
+  initialState: string;
+  cancellation: "supported" | "unsupported";
+}
+
 model CommandFailureOptions {
   kind: string;
   statusCode: int32;
@@ -63,11 +73,19 @@ model CommandFailureOptions {
 }
 
 model CommandOptions {
-  audit: AuditOptions;
+  audit?: AuditOptions;
+  auditAction?: string;
+  guarantee?: "transactional" | "best-effort";
   execution?: AsyncExecutionOptions;
-  failures: CommandFailureOptions[];
+  failures?: CommandFailureOptions[];
   additionalExposures?: ("ui" | "agent" | "automation")[];
   targetParameter?: string;
+}
+
+model CommandDefaultsOptions {
+  guarantee?: "transactional" | "best-effort";
+  failures?: CommandFailureOptions[];
+  additionalExposures?: ("ui" | "agent" | "automation")[];
 }
 
 model ResponseShapeOptions {
@@ -151,8 +169,10 @@ model ToolOptions {
 
 extern dec cli(target: Operation, options: valueof CLIOptions);
 extern dec command(target: Operation, options: valueof CommandOptions);
+extern dec commandDefaults(target: Interface, options: valueof CommandDefaultsOptions);
+extern dec unaudited(target: Operation, reason: valueof string);
 extern dec ui(target: Operation, actionId: valueof string);
-extern dec auditPayload(target: Operation, schema: Model, options?: valueof AuditPayloadOptions);
+extern dec auditPayload(target: Operation | Interface, schema: Model, options?: valueof AuditPayloadOptions);
 extern dec auditSchema(target: Model, options: valueof AuditPayloadOptions);
 extern dec sensitivity(target: ModelProperty, classification: valueof ("public" | "internal" | "pii" | "secret"));
 extern dec auditPublic(target: ModelProperty);
@@ -160,7 +180,11 @@ extern dec auditInternal(target: ModelProperty);
 extern dec auditPii(target: ModelProperty);
 extern dec auditSecret(target: ModelProperty);
 extern dec query(target: Operation);
-extern dec authz(target: Operation, value: valueof unknown);
+extern dec authz(target: Operation | Interface, value: valueof unknown);
+extern dec target(target: ModelProperty);
+extern dec asyncExecution(target: Operation, status: Operation, events: Operation, options: valueof TypedAsyncExecutionOptions);
+extern dec failureDefinition(target: Model, options: valueof CommandFailureOptions);
+extern dec failsWith(target: Operation, definition: Model);
 extern dec manual(target: Operation);
 extern dec responseShape(target: Model, options: valueof ResponseShapeOptions);
 extern dec `package`(target: Namespace, options: valueof PackageOptions);

--- a/pkg/apigen/typespec/src/decorators.ts
+++ b/pkg/apigen/typespec/src/decorators.ts
@@ -1,4 +1,4 @@
-import type { DecoratorContext, Enum, Model, ModelProperty, Namespace, Operation } from "@typespec/compiler";
+import type { DecoratorContext, Enum, Interface, Model, ModelProperty, Namespace, Operation } from "@typespec/compiler";
 
 import { reportDiagnostic } from "./lib.js";
 
@@ -58,6 +58,16 @@ export interface AsyncExecutionOptions {
   cancellation: "supported" | "unsupported";
 }
 
+export interface TypedAsyncExecutionOptions {
+  mode?: "async";
+  guarantee: "transactional";
+  jobKind: string;
+  resourceKind: string;
+  initialEvent: string;
+  initialState: string;
+  cancellation: "supported" | "unsupported";
+}
+
 export interface CommandFailureOptions {
   kind: string;
   statusCode: number;
@@ -66,11 +76,25 @@ export interface CommandFailureOptions {
 }
 
 export interface CommandOptions {
-  audit: AuditOptions;
+  audit?: AuditOptions;
+  auditAction?: string;
+  guarantee?: "transactional" | "best-effort";
   execution?: AsyncExecutionOptions;
-  failures: CommandFailureOptions[];
+  failures?: CommandFailureOptions[];
   additionalExposures?: Array<"ui" | "agent" | "automation">;
   targetParameter?: string;
+}
+
+export interface CommandDefaultsOptions {
+  guarantee?: "transactional" | "best-effort";
+  failures?: CommandFailureOptions[];
+  additionalExposures?: Array<"ui" | "agent" | "automation">;
+}
+
+export interface TypedAsyncExecutionDefinition {
+  status: Operation;
+  events: Operation;
+  options: TypedAsyncExecutionOptions;
 }
 
 export interface ResponseShapeOptions {
@@ -135,12 +159,18 @@ export interface ToolOptions {
 
 const cliKey = Symbol.for("@yacobolo/apigen.cli");
 const commandKey = Symbol.for("@yacobolo/apigen.command");
+const commandDefaultsKey = Symbol.for("@yacobolo/apigen.commandDefaults");
+const unauditedKey = Symbol.for("@yacobolo/apigen.unaudited");
 const uiKey = Symbol.for("@yacobolo/apigen.ui");
 const auditPayloadKey = Symbol.for("@yacobolo/apigen.auditPayload");
 const auditSchemaKey = Symbol.for("@yacobolo/apigen.auditSchema");
 const sensitivityKey = Symbol.for("@yacobolo/apigen.sensitivity");
 const queryKey = Symbol.for("@yacobolo/apigen.query");
 const authzKey = Symbol.for("@yacobolo/apigen.authz");
+const targetKey = Symbol.for("@yacobolo/apigen.target");
+const asyncExecutionKey = Symbol.for("@yacobolo/apigen.asyncExecution");
+const failureDefinitionKey = Symbol.for("@yacobolo/apigen.failureDefinition");
+const failsWithKey = Symbol.for("@yacobolo/apigen.failsWith");
 const manualKey = Symbol.for("@yacobolo/apigen.manual");
 const responseShapeKey = Symbol.for("@yacobolo/apigen.responseShape");
 const packageKey = Symbol.for("@yacobolo/apigen.package");
@@ -154,7 +184,27 @@ export function $cli(context: DecoratorContext, target: Operation, options: CLIO
 }
 
 export function $command(context: DecoratorContext, target: Operation, options: CommandOptions) {
+  if (options.audit && (options.auditAction !== undefined || options.guarantee !== undefined)) {
+    reportDiagnostic(context.program, {
+      code: "invalid-command",
+      format: { reason: "use legacy audit or concise auditAction/guarantee syntax, not both" },
+      target,
+    });
+    return;
+  }
   context.program.stateMap(commandKey).set(target, options);
+}
+
+export function $commandDefaults(
+  context: DecoratorContext,
+  target: Interface,
+  options: CommandDefaultsOptions,
+) {
+  context.program.stateMap(commandDefaultsKey).set(target, options);
+}
+
+export function $unaudited(context: DecoratorContext, target: Operation, reason: string) {
+  context.program.stateMap(unauditedKey).set(target, reason);
 }
 
 export function $ui(context: DecoratorContext, target: Operation, actionId: string) {
@@ -172,7 +222,7 @@ export function $ui(context: DecoratorContext, target: Operation, actionId: stri
 
 export function $auditPayload(
   context: DecoratorContext,
-  target: Operation,
+  target: Operation | Interface,
   schema: Model,
   options?: AuditPayloadOptions,
 ) {
@@ -250,8 +300,61 @@ export function $query(context: DecoratorContext, target: Operation) {
   context.program.stateSet(queryKey).add(target);
 }
 
-export function $authz(context: DecoratorContext, target: Operation, value: unknown) {
+export function $authz(context: DecoratorContext, target: Operation | Interface, value: unknown) {
   context.program.stateMap(authzKey).set(target, value);
+}
+
+export function $target(context: DecoratorContext, target: ModelProperty) {
+  context.program.stateSet(targetKey).add(target);
+}
+
+export function $asyncExecution(
+  context: DecoratorContext,
+  target: Operation,
+  status: Operation,
+  events: Operation,
+  options: TypedAsyncExecutionOptions,
+) {
+  context.program.stateMap(asyncExecutionKey).set(target, { status, events, options });
+}
+
+export function $failureDefinition(
+  context: DecoratorContext,
+  target: Model,
+  options: CommandFailureOptions,
+) {
+  const definitions = context.program.stateMap(failureDefinitionKey);
+  if (definitions.has(target)) {
+    reportDiagnostic(context.program, {
+      code: "invalid-command",
+      format: { reason: "@apigen.failureDefinition must not be applied more than once" },
+      target,
+    });
+    return;
+  }
+  for (const [model, authored] of definitions.entries() as Iterable<[Model, CommandFailureOptions]>) {
+    if (authored.code === options.code && (
+      authored.kind !== options.kind ||
+      authored.statusCode !== options.statusCode ||
+      authored.publicDetail !== options.publicDetail
+    )) {
+      reportDiagnostic(context.program, {
+        code: "invalid-command",
+        format: {
+          reason: `failure code ${JSON.stringify(options.code)} conflicts with definition ${JSON.stringify(model.name)}`,
+        },
+        target,
+      });
+      return;
+    }
+  }
+  definitions.set(target, options);
+}
+
+export function $failsWith(context: DecoratorContext, target: Operation, definition: Model) {
+  const definitions = context.program.stateMap(failsWithKey);
+  const current = (definitions.get(target) as Model[] | undefined) ?? [];
+  definitions.set(target, [...current, definition]);
 }
 
 export function $manual(context: DecoratorContext, target: Operation) {
@@ -303,6 +406,8 @@ export const $decorators = {
   apigen: {
     cli: $cli,
     command: $command,
+    commandDefaults: $commandDefaults,
+    unaudited: $unaudited,
     ui: $ui,
     auditPayload: $auditPayload,
     auditSchema: $auditSchema,
@@ -313,6 +418,10 @@ export const $decorators = {
     auditSecret: $auditSecret,
     query: $query,
     authz: $authz,
+    target: $target,
+    asyncExecution: $asyncExecution,
+    failureDefinition: $failureDefinition,
+    failsWith: $failsWith,
     manual: $manual,
     responseShape: $responseShape,
     package: $package,
@@ -328,7 +437,45 @@ export function getCLI(context: { program: DecoratorContext["program"] }, target
 }
 
 export function getCommand(context: { program: DecoratorContext["program"] }, target: Operation) {
+  const authored = context.program.stateMap(commandKey).get(target) as CommandOptions | undefined;
+  if (!authored) {
+    return undefined;
+  }
+  const defaults = target.interface
+    ? context.program.stateMap(commandDefaultsKey).get(target.interface) as CommandDefaultsOptions | undefined
+    : undefined;
+  const audit = authored.audit ?? {
+    required: context.program.stateMap(unauditedKey).has(target) ? false : true,
+    successAction: authored.auditAction,
+    guarantee: authored.guarantee ?? defaults?.guarantee,
+  };
+  return {
+    ...authored,
+    audit: {
+      ...audit,
+      guarantee: audit.guarantee ?? defaults?.guarantee,
+    },
+    failures: authored.failures ?? defaults?.failures ?? [],
+    additionalExposures: authored.additionalExposures ?? defaults?.additionalExposures,
+  } as CommandOptions & { audit: AuditOptions; failures: CommandFailureOptions[] };
+}
+
+export function getAuthoredCommand(context: { program: DecoratorContext["program"] }, target: Operation) {
   return context.program.stateMap(commandKey).get(target) as CommandOptions | undefined;
+}
+
+export function getCommandDefaults(
+  context: { program: DecoratorContext["program"] },
+  target: Interface,
+) {
+  return context.program.stateMap(commandDefaultsKey).get(target) as CommandDefaultsOptions | undefined;
+}
+
+export function getUnauditedReason(
+  context: { program: DecoratorContext["program"] },
+  target: Operation,
+) {
+  return context.program.stateMap(unauditedKey).get(target) as string | undefined;
 }
 
 export function getUI(context: { program: DecoratorContext["program"] }, target: Operation) {
@@ -336,7 +483,9 @@ export function getUI(context: { program: DecoratorContext["program"] }, target:
 }
 
 export function getAuditPayload(context: { program: DecoratorContext["program"] }, target: Operation) {
-  return context.program.stateMap(auditPayloadKey).get(target) as AuditPayloadDefinition | undefined;
+  return (context.program.stateMap(auditPayloadKey).get(target) ??
+    (target.interface ? context.program.stateMap(auditPayloadKey).get(target.interface) : undefined)) as
+    AuditPayloadDefinition | undefined;
 }
 
 export function getAuditSchema(context: { program: DecoratorContext["program"] }, target: Model) {
@@ -355,7 +504,30 @@ export function isQuery(context: { program: DecoratorContext["program"] }, targe
 }
 
 export function getAuthz(context: { program: DecoratorContext["program"] }, target: Operation) {
-  return context.program.stateMap(authzKey).get(target);
+  return context.program.stateMap(authzKey).get(target) ??
+    (target.interface ? context.program.stateMap(authzKey).get(target.interface) : undefined);
+}
+
+export function isTarget(context: { program: DecoratorContext["program"] }, target: ModelProperty) {
+  return context.program.stateSet(targetKey).has(target);
+}
+
+export function getAsyncExecution(
+  context: { program: DecoratorContext["program"] },
+  target: Operation,
+) {
+  return context.program.stateMap(asyncExecutionKey).get(target) as TypedAsyncExecutionDefinition | undefined;
+}
+
+export function getNamedFailures(
+  context: { program: DecoratorContext["program"] },
+  target: Operation,
+) {
+  const models = context.program.stateMap(failsWithKey).get(target) as Model[] | undefined;
+  return (models ?? []).map((model) => ({
+    model,
+    options: context.program.stateMap(failureDefinitionKey).get(model) as CommandFailureOptions | undefined,
+  }));
 }
 
 export function isManual(context: { program: DecoratorContext["program"] }, target: Operation) {

--- a/pkg/apigen/typespec/src/on-emit.ts
+++ b/pkg/apigen/typespec/src/on-emit.ts
@@ -43,21 +43,27 @@ import {
   type HttpPayloadBody,
   type HttpService,
 } from "@typespec/http";
-import { getExtensions, getOperationId, getTagsMetadata, resolveInfo, resolveOperationId } from "@typespec/openapi";
+import { getExtensions, getOperationId, getTagsMetadata, resolveInfo } from "@typespec/openapi";
 import {
   getAuthz,
+  getAsyncExecution,
+  getAuthoredCommand,
   getAuditPayload,
   getAuditSchema,
   getCLI,
   getCommand,
+  getCommandDefaults,
   getContracts,
   getMetadata,
+  getNamedFailures,
   getPackages,
   getResponseShape,
   getSensitivity,
   getTool,
   getTransportErrors,
   getUI,
+  getUnauditedReason,
+  isTarget,
   isManual,
   isQuery,
 } from "./decorators.js";
@@ -853,7 +859,22 @@ function mergedEndpoints(
   defaultSecurity: Record<string, string[]>[] | undefined,
 ): Endpoint[] {
   const groups = operationGroups(program, operations);
-  return groups.map((group) => endpoint(program, builder, group, operationsAuth, defaultSecurity));
+  const endpoints = groups.map((group) => endpoint(program, builder, group, operationsAuth, defaultSecurity));
+  const operationIDs = new Map<string, Operation>();
+  for (let index = 0; index < endpoints.length; index++) {
+    const operationID = endpoints[index].operation_id;
+    const target = groups[index].canonical.operation;
+    const existing = operationIDs.get(operationID);
+    if (existing) {
+      builder.invalidOperationKind(
+        `operation ID ${JSON.stringify(operationID)} is duplicated; use @operationId for an intentional override`,
+        target,
+      );
+    } else {
+      operationIDs.set(operationID, target);
+    }
+  }
+  return endpoints;
 }
 
 interface OperationGroup {
@@ -935,7 +956,7 @@ function endpoint(
   const output = prune({
     method: operation.verb,
     path: operation.path,
-    operation_id: getOperationId(program, operation.operation) ?? resolveOperationId(program, operation.operation),
+    operation_id: operationID(program, operation.operation),
     kind: operationKind(program, builder, operation),
     namespace: namespaceName(operation.operation.namespace),
     summary: getSummary(program, operation.operation),
@@ -963,7 +984,7 @@ function validateSharedRouteMetadata(
 ) {
   const canonicalNamespace = namespaceName(canonical.operation.namespace);
   const canonicalCLI = stableJSONString(cliMetadata(program, canonical));
-  const canonicalCommand = stableJSONString(getCommand({ program }, canonical.operation));
+  const canonicalCommand = stableJSONString(commandIdentity(program, canonical.operation));
   const canonicalUI = stableJSONString(getUI({ program }, canonical.operation));
   const canonicalAuditPayload = stableJSONString(auditPayloadIdentity(program, canonical.operation));
   const canonicalQuery = isQuery({ program }, canonical.operation);
@@ -978,7 +999,7 @@ function validateSharedRouteMetadata(
     if (stableJSONString(cliMetadata(program, operation)) !== canonicalCLI) {
       builder.unsupportedSharedRoute(operation.operation, "incompatible cli metadata");
     }
-    if (stableJSONString(getCommand({ program }, operation.operation)) !== canonicalCommand) {
+    if (stableJSONString(commandIdentity(program, operation.operation)) !== canonicalCommand) {
       builder.unsupportedSharedRoute(operation.operation, "incompatible command metadata");
     }
     if (stableJSONString(getUI({ program }, operation.operation)) !== canonicalUI) {
@@ -1014,9 +1035,6 @@ function operationKind(
   const ui = getUI({ program }, operation.operation);
   const query = isQuery({ program }, operation.operation);
   const method = operation.verb.toLowerCase();
-  if (builder.requireExplicitOperationKind && getOperationId(program, operation.operation) === undefined) {
-    builder.invalidOperationKind("an explicit @operationId is required", operation.operation);
-  }
   if (command && query) {
     builder.invalidOperationKind("@apigen.command and @apigen.query are mutually exclusive", operation.operation);
     return "command";
@@ -1064,12 +1082,15 @@ function commandMetadata(
   if (!options) {
     return undefined;
   }
-  if (getOperationId(program, operation.operation) === undefined) {
-    builder.invalidCommand("an explicit @operationId is required", operation.operation);
-  }
-
   const successAction = options.audit.successAction?.trim();
   const guarantee = options.audit.guarantee;
+  const unauditedReason = getUnauditedReason({ program }, operation.operation)?.trim();
+  if (getUnauditedReason({ program }, operation.operation) !== undefined && !unauditedReason) {
+    builder.invalidCommand("@apigen.unaudited requires a non-empty reason", operation.operation);
+  }
+  if (unauditedReason && (options.audit.required || successAction)) {
+    builder.invalidCommand("@apigen.unaudited cannot be combined with an audited command", operation.operation);
+  }
   if (options.audit.required && !successAction) {
     builder.invalidCommand("audit.successAction is required when audit.required is true", operation.operation);
   }
@@ -1130,13 +1151,25 @@ function commandMetadata(
   }
 
   let execution: Command["execution"];
-  if (options.execution) {
-    const jobKind = options.execution.jobKind.trim();
-    const resourceKind = options.execution.resourceKind.trim();
-    const initialEvent = options.execution.initialEvent.trim();
-    const initialState = options.execution.initialState.trim();
-    const statusOperation = options.execution.statusOperation.trim();
-    const eventsOperation = options.execution.eventsOperation.trim();
+  const typedExecution = getAsyncExecution({ program }, operation.operation);
+  if (options.execution && typedExecution) {
+    builder.invalidCommand("declare async execution either inline or with @apigen.asyncExecution, not both", operation.operation);
+  }
+  const executionOptions = typedExecution
+    ? {
+        mode: typedExecution.options.mode ?? "async" as const,
+        ...typedExecution.options,
+        statusOperation: operationID(program, typedExecution.status),
+        eventsOperation: operationID(program, typedExecution.events),
+      }
+    : options.execution;
+  if (executionOptions) {
+    const jobKind = executionOptions.jobKind.trim();
+    const resourceKind = executionOptions.resourceKind.trim();
+    const initialEvent = executionOptions.initialEvent.trim();
+    const initialState = executionOptions.initialState.trim();
+    const statusOperation = executionOptions.statusOperation.trim();
+    const eventsOperation = executionOptions.eventsOperation.trim();
     if (!jobKindPattern.test(jobKind)) {
       builder.invalidCommand("execution.jobKind must be a stable lower_snake_case identifier", operation.operation);
     }
@@ -1150,22 +1183,44 @@ function commandMetadata(
       builder.invalidCommand("execution statusOperation and eventsOperation must be distinct operation IDs", operation.operation);
     }
     execution = {
-      mode: options.execution.mode,
-      guarantee: options.execution.guarantee,
+      mode: executionOptions.mode,
+      guarantee: executionOptions.guarantee,
       job_kind: jobKind,
       resource_kind: resourceKind,
       initial_event: initialEvent,
       initial_state: initialState,
       status_operation: statusOperation,
       events_operation: eventsOperation,
-      cancellation: options.execution.cancellation,
+      cancellation: executionOptions.cancellation,
     };
   }
 
   const failures: NonNullable<Command["failures"]> = [];
   const failureKinds = new Set<string>();
   const failureCodes = new Set<string>();
-  for (const authored of options.failures ?? []) {
+  const namedFailures = getNamedFailures({ program }, operation.operation);
+  const authoredCommand = getAuthoredCommand({ program }, operation.operation);
+  const commandDefaults = operation.operation.interface
+    ? getCommandDefaults({ program }, operation.operation.interface)
+    : undefined;
+  if (authoredCommand?.failures === undefined && commandDefaults?.failures === undefined && namedFailures.length === 0) {
+    builder.invalidCommand(
+      "every command must declare failures, inherit default failures, or use @apigen.failsWith",
+      operation.operation,
+    );
+  }
+  for (const named of namedFailures) {
+    if (!named.options) {
+      builder.invalidCommand(
+        `failure model ${JSON.stringify(named.model.name)} requires @apigen.failureDefinition`,
+        operation.operation,
+      );
+    }
+  }
+  for (const authored of [
+    ...(options.failures ?? []),
+    ...namedFailures.flatMap((named) => named.options ? [named.options] : []),
+  ]) {
     const kind = authored.kind.trim();
     const code = authored.code.trim();
     const publicDetail = authored.publicDetail.trim();
@@ -1221,7 +1276,15 @@ function commandMetadata(
 
   const emittedParameters = parameters ?? [];
   const pathParameters = emittedParameters.filter((parameter) => parameter.in === "path");
-  let targetParameter = options.targetParameter?.trim();
+  const decoratedTargets = [...operation.operation.parameters.properties.values()]
+    .filter((property) => propertyIsTarget(program, property));
+  if (decoratedTargets.length > 1) {
+    builder.invalidCommand("@apigen.target must identify exactly one operation parameter", operation.operation);
+  }
+  if (options.targetParameter && decoratedTargets.length > 0) {
+    builder.invalidCommand("declare a command target with targetParameter or @apigen.target, not both", operation.operation);
+  }
+  let targetParameter = decoratedTargets[0]?.name ?? options.targetParameter?.trim();
   if (!targetParameter && pathParameters.length === 1) {
     targetParameter = pathParameters[0].name;
   } else if (!targetParameter && pathParameters.length > 1) {
@@ -1270,6 +1333,40 @@ function commandMetadata(
     authz_mode: authzMode,
     privilege,
   }) as Command;
+}
+
+function operationID(program: Program, operation: Operation): string {
+  return getOperationId(program, operation) ?? operation.name;
+}
+
+function propertyIsTarget(program: Program, property: ModelProperty): boolean {
+  let candidate: ModelProperty | undefined = property;
+  while (candidate) {
+    if (isTarget({ program }, candidate)) {
+      return true;
+    }
+    candidate = candidate.sourceProperty;
+  }
+  return false;
+}
+
+function commandIdentity(program: Program, operation: Operation): unknown {
+  const asyncExecution = getAsyncExecution({ program }, operation);
+  return {
+    options: getCommand({ program }, operation),
+    target: [...operation.parameters.properties.values()]
+      .filter((property) => propertyIsTarget(program, property))
+      .map((property) => property.name),
+    asyncExecution: asyncExecution && {
+      status: operationID(program, asyncExecution.status),
+      events: operationID(program, asyncExecution.events),
+      options: asyncExecution.options,
+    },
+    namedFailures: getNamedFailures({ program }, operation).map((failure) => ({
+      name: failure.model.name,
+      options: failure.options,
+    })),
+  };
 }
 
 function auditPayloadIdentity(program: Program, operation: Operation): unknown {

--- a/pkg/apigen/typespec/test/emitter.test.ts
+++ b/pkg/apigen/typespec/test/emitter.test.ts
@@ -63,9 +63,25 @@ describe("APIGen TypeSpec emitter", () => {
       operation_id: endpoint.operation_id,
       namespace: endpoint.namespace,
     }))).toEqual([
-      { operation_id: "Access_getCurrentPrincipal", namespace: "PartitionedAPI.Access" },
-      { operation_id: "Reports_listReports", namespace: "PartitionedAPI.Analytics.Reports" },
+      { operation_id: "getCurrentPrincipal", namespace: "PartitionedAPI.Access" },
+      { operation_id: "listReports", namespace: "PartitionedAPI.Analytics.Reports" },
     ]);
+  });
+
+  it("rejects colliding inferred operation IDs", async () => {
+    await expectCompileFails(`
+      using Http;
+
+      @service(#{ title: "Partitioned API" })
+      namespace PartitionedAPI {
+        namespace Access {
+          @route("/access/me") @get op getCurrentPrincipal(): string;
+        }
+        namespace Admin {
+          @route("/admin/me") @get op getCurrentPrincipal(): string;
+        }
+      }
+    `, "operation ID \"getCurrentPrincipal\" is duplicated");
   });
 
   it("fails when a request body cannot map to a named IR schema", async () => {
@@ -172,6 +188,87 @@ describe("APIGen TypeSpec emitter", () => {
         authz_mode: "privilege",
         privilege: "MANAGE_GRANTS",
       },
+    });
+  });
+
+  it("expands ergonomic command authoring into the explicit command contract", async () => {
+    const doc = await compileSource(`
+      using Http;
+
+      @service(#{ title: "Command API" })
+      namespace CommandAPI;
+
+      @apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+      model RoleBindingAuditPayload {
+        @apigen.auditInternal bindingId: string;
+      }
+
+      @apigen.failureDefinition(#{
+        kind: "not_found",
+        statusCode: 404,
+        code: "ROLE_BINDING_NOT_FOUND",
+        publicDetail: "Role binding not found.",
+      })
+      model RoleBindingNotFound {}
+
+      @tag("Access")
+      @route("/workspaces/{workspace}/role-bindings")
+      @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+      @apigen.commandDefaults(#{ guarantee: "transactional" })
+      @apigen.auditPayload(RoleBindingAuditPayload)
+      interface RoleBindings {
+        @route("/{binding}")
+        @patch
+        @apigen.ui("workspace.access.role-binding.update")
+        @apigen.failsWith(RoleBindingNotFound)
+        @apigen.command(#{ auditAction: "role_binding.updated" })
+        updateRoleBinding(
+          @path @apigen.target workspace: string,
+          @path binding: string,
+          @header("If-Match") ifMatch: string,
+        ): string;
+      }
+    `);
+
+    expect(doc.endpoints[0]).toMatchObject({
+      operation_id: "updateRoleBinding",
+      kind: "command",
+      command: {
+        audit: {
+          required: true,
+          success_action: "role_binding.updated",
+          guarantee: "transactional",
+        },
+        failures: [{
+          kind: "not_found",
+          status_code: 404,
+          code: "ROLE_BINDING_NOT_FOUND",
+          public_detail: "Role binding not found.",
+        }],
+        target: { parameter: "workspace", type: "workspace" },
+        concurrency: "if-match",
+        authz_mode: "privilege",
+        privilege: "MANAGE_GRANTS",
+      },
+    });
+  });
+
+  it("requires a conspicuous reason for concise unaudited commands", async () => {
+    const doc = await compileSource(`
+      using Http;
+      @service(#{ title: "Ephemeral API" })
+      namespace EphemeralAPI;
+
+      @route("/preview")
+      @post
+      @apigen.unaudited("Only updates request-local preview state.")
+      @apigen.command(#{ failures: #[] })
+      op updatePreview(@header("Idempotency-Key") key: string): string;
+    `);
+
+    expect(doc.endpoints[0]).toMatchObject({
+      operation_id: "updatePreview",
+      command: { audit: { required: false } },
     });
   });
 
@@ -330,6 +427,53 @@ describe("APIGen TypeSpec emitter", () => {
     });
   });
 
+  it("resolves typed async operation references", async () => {
+    const doc = await compileSource(`
+      using Http;
+
+      @service(#{ title: "Release API" })
+      namespace ReleaseAPI;
+
+      @route("/releases/{release}")
+      @get
+      op getRelease(@path release: string): string;
+
+      @route("/releases/{release}/events")
+      @get
+      op listReleaseEvents(@path release: string): string;
+
+      @apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+      model ReleaseAuditPayload { @apigen.auditInternal releaseId: string; }
+
+      @route("/releases/{release}/finalize")
+      @post
+      @apigen.auditPayload(ReleaseAuditPayload)
+      @apigen.asyncExecution(getRelease, listReleaseEvents, #{
+        guarantee: "transactional",
+        jobKind: "release.finalize",
+        resourceKind: "release",
+        initialEvent: "release.validating",
+        initialState: "validating",
+        cancellation: "unsupported",
+      })
+      @apigen.command(#{
+        auditAction: "release.validating",
+        guarantee: "transactional",
+        failures: #[],
+      })
+      op finalizeRelease(
+        @path release: string,
+        @header("Idempotency-Key") idempotencyKey: string,
+      ): string;
+    `);
+
+    expect(doc.endpoints.find((endpoint: any) => endpoint.operation_id === "finalizeRelease").command.execution)
+      .toMatchObject({
+        status_operation: "getRelease",
+        events_operation: "listReleaseEvents",
+      });
+  });
+
   it("requires explicit command/query classification for non-read operations in strict mode", async () => {
     const doc = await compileSource(`
       using Http;
@@ -406,14 +550,6 @@ describe("APIGen TypeSpec emitter", () => {
         operation: `
           @post
           @operationId("createWidget")
-          @apigen.command(#{ audit: #{ required: true, successAction: "widget.created" }, failures: #[] })
-          op create(@header("Idempotency-Key") key: string): string;
-        `,
-      },
-      {
-        message: "explicit @operationId is required",
-        operation: `
-          @post
           @apigen.command(#{ audit: #{ required: true, successAction: "widget.created" }, failures: #[] })
           op create(@header("Idempotency-Key") key: string): string;
         `,
@@ -706,7 +842,7 @@ describe("APIGen TypeSpec emitter", () => {
       @operationId("createWidget")
       @apigen.command(#{ audit: #{ required: false } })
       op createWidget(@header("Idempotency-Key") key: string): string;
-    `, "apigen.CommandOptions");
+    `, "every command must declare failures");
   });
 
   it("emits v4 IR for optimized TypeSpec HTTP authoring", async () => {


### PR DESCRIPTION
## Summary

- add interface-level authorization, command defaults, and audit payload inheritance while materializing the same explicit IR
- make concise commands audited by default, with a conspicuous `@apigen.unaudited("reason")` escape hatch
- infer operation IDs from TypeSpec operation names and reject collisions
- replace stringly typed targets and async operation links with compiler-resolved decorators
- add reusable named command failures with conflict validation
- migrate Role Bindings and `finalizeRelease` as end-to-end proofs

## Contract safety

`task api:generate` produces no generated API artifact changes: the new syntax expands to the existing runtime contract. Legacy verbose syntax remains supported for incremental migration.

## Validation

- `task api:generate`
- `task apigen:test`
- `task ci`

## Stack

Depends on #281, which depends on #280. The PR base keeps this review limited to the APIGen authoring layer.