### PR TITLE
refactor: migrate APIGen command authoring

### DIFF
--- a/api/typespec/access.tsp
+++ b/api/typespec/access.tsp
@@ -148,6 +148,142 @@ model RoleBindingInvalidFailure {}
 })
 model RoleBindingNotFoundFailure {}
 
+@apigen.failureDefinition(#{
+  kind: "denied",
+  statusCode: 400,
+  code: "DEVICE_AUTHORIZATION_DENIED",
+  publicDetail: "Device authorization was denied.",
+})
+model DeviceAuthorizationDeniedFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "expired",
+  statusCode: 400,
+  code: "DEVICE_AUTHORIZATION_EXPIRED",
+  publicDetail: "Device authorization has expired.",
+})
+model DeviceAuthorizationExpiredFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "invalid_principal",
+  statusCode: 400,
+  code: "INVALID_PRINCIPAL",
+  publicDetail: "The authorizing principal is invalid.",
+})
+model InvalidPrincipalFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "DEVICE_AUTHORIZATION_NOT_FOUND",
+  publicDetail: "Device authorization was not found.",
+})
+model DeviceAuthorizationNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "invalid_credential",
+  statusCode: 400,
+  code: "INVALID_AUTHORING_CREDENTIAL",
+  publicDetail: "The authoring session is invalid.",
+})
+model InvalidAuthoringCredentialFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "AUTHORING_SESSION_NOT_FOUND",
+  publicDetail: "Authoring session not found.",
+})
+model AuthoringSessionNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "conflict",
+  statusCode: 409,
+  code: "PRINCIPAL_ALREADY_EXISTS",
+  publicDetail: "A principal with this email already exists.",
+})
+model PrincipalAlreadyExistsFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "PRINCIPAL_NOT_FOUND",
+  publicDetail: "Principal not found.",
+})
+model PrincipalNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "invalid",
+  statusCode: 400,
+  code: "SERVICE_PRINCIPAL_INVALID",
+  publicDetail: "The service principal request is invalid.",
+})
+model ServicePrincipalInvalidFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "SERVICE_PRINCIPAL_NOT_FOUND",
+  publicDetail: "Service principal not found.",
+})
+model ServicePrincipalNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "invalid",
+  statusCode: 400,
+  code: "SERVICE_PRINCIPAL_SECRET_INVALID",
+  publicDetail: "The service principal secret request is invalid.",
+})
+model ServicePrincipalSecretInvalidFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "SERVICE_PRINCIPAL_SECRET_NOT_FOUND",
+  publicDetail: "Service principal secret not found.",
+})
+model ServicePrincipalSecretNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "invalid",
+  statusCode: 400,
+  code: "GROUP_INVALID",
+  publicDetail: "The group request is invalid.",
+})
+model GroupInvalidFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "GROUP_NOT_FOUND",
+  publicDetail: "Group not found.",
+})
+model GroupNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "GRANT_NOT_FOUND",
+  publicDetail: "Grant not found.",
+})
+model GrantNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "invalid",
+  statusCode: 400,
+  code: "OWNERSHIP_TRANSFER_INVALID",
+  publicDetail: "The ownership transfer request is invalid.",
+})
+model OwnershipTransferInvalidFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "DATA_POLICY_NOT_FOUND",
+  publicDetail: "Data policy not found.",
+})
+model DataPolicyNotFoundFailure {}
+
 // Durable, typed payloads for Access command audit records.  Every field is
 // required so the generated encoder can reject incomplete audit events before
 // they reach the repository.
@@ -466,41 +602,31 @@ model AuthoringSessionListResponse {
 @route("/access/device-authorizations/approval")
 @post
 @apigen.authz(#{ mode: "authenticated" })
-@apigen.command(#{
-  audit: #{ required: true, successAction: "authoring.device.decided", guarantee: "transactional" },
-  failures: #[
-    #{ kind: "denied", statusCode: 400, code: "DEVICE_AUTHORIZATION_DENIED", publicDetail: "Device authorization was denied." },
-    #{ kind: "expired", statusCode: 400, code: "DEVICE_AUTHORIZATION_EXPIRED", publicDetail: "Device authorization has expired." },
-    #{ kind: "invalid_principal", statusCode: 400, code: "INVALID_PRINCIPAL", publicDetail: "The authorizing principal is invalid." },
-    #{ kind: "not_found", statusCode: 404, code: "DEVICE_AUTHORIZATION_NOT_FOUND", publicDetail: "Device authorization was not found." },
-  ],
-})
+@apigen.command(#{ auditAction: "authoring.device.decided", guarantee: "transactional" })
+@apigen.failsWith(DeviceAuthorizationDeniedFailure)
+@apigen.failsWith(DeviceAuthorizationExpiredFailure)
+@apigen.failsWith(InvalidPrincipalFailure)
+@apigen.failsWith(DeviceAuthorizationNotFoundFailure)
 @apigen.auditPayload(DeviceAuthorizationDecidedAuditPayload)
-@operationId("decideDeviceAuthorization")
 op decideDeviceAuthorization(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeviceAuthorizationApprovalRequest): OkJson<StatusResponse> | CommonErrors;
 
 @tag("Current User")
 @route("/me/authoring-sessions")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
 interface CurrentAuthoringSessions {
   @summary("List current CLI and workload sessions")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-  @operationId("listCurrentAuthoringSessions")
   listCurrentAuthoringSessions(@query limit?: ListLimit, @query pageToken?: PageToken): OkJson<AuthoringSessionListResponse> | CommonErrors;
 
   @summary("Revoke a current CLI or workload session")
   @route("/{session}")
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "authoring.session.revoked", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "invalid_credential", statusCode: 400, code: "INVALID_AUTHORING_CREDENTIAL", publicDetail: "The authoring session is invalid." },
-      #{ kind: "not_found", statusCode: 404, code: "AUTHORING_SESSION_NOT_FOUND", publicDetail: "Authoring session not found." },
-    ],
-  })
+  @apigen.command(#{ auditAction: "authoring.session.revoked" })
+  @apigen.failsWith(InvalidAuthoringCredentialFailure)
+  @apigen.failsWith(AuthoringSessionNotFoundFailure)
   @apigen.auditPayload(AuthoringSessionRevokedAuditPayload)
-  @operationId("revokeCurrentAuthoringSession")
   revokeCurrentAuthoringSession(@path session: string): OkJson<StatusResponse> | CommonErrors;
 }
 
@@ -513,26 +639,21 @@ alias ListPrincipalSessionsOK = OkJson<SessionListResponse>;
 
 @tag("Access")
 @route("/principals")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
 interface Principals {
   @summary("List principals")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "grant-management")
-  @operationId("listPrincipals")
   listPrincipals(@query email?: string, @query q?: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListPrincipalsOK | CommonErrors;
 
   @summary("Create a local principal")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "grant-management")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "principal.local_user.created", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "conflict", statusCode: 409, code: "PRINCIPAL_ALREADY_EXISTS", publicDetail: "A principal with this email already exists." },
-    ],
-  })
+  @apigen.command(#{ auditAction: "principal.local_user.created" })
+  @apigen.failsWith(PrincipalAlreadyExistsFailure)
   @apigen.auditPayload(PrincipalCreatedAuditPayload)
-  @operationId("createPrincipal")
   createPrincipal(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: PrincipalCreateRequest): CreatePrincipalCreated | CommonErrors;
 
   @summary("Get a principal")
@@ -540,7 +661,6 @@ interface Principals {
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "grant-management")
-  @operationId("getPrincipal")
   getPrincipal(@path principal: string): GetPrincipalOK | CommonErrors;
 
   @summary("Update a principal")
@@ -549,14 +669,13 @@ interface Principals {
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "grant-management")
   @apigen.command(#{
-    audit: #{ required: true, successAction: "principal.updated", guarantee: "transactional" },
+    auditAction: "principal.updated",
     failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "PRINCIPAL_NOT_FOUND", publicDetail: "Principal not found." },
       #{ kind: "invalid", statusCode: 422, code: "PRINCIPAL_NOT_MUTABLE", publicDetail: "This principal cannot be modified by this operation." },
     ],
   })
+  @apigen.failsWith(PrincipalNotFoundFailure)
   @apigen.auditPayload(PrincipalUpdatedAuditPayload)
-  @operationId("updatePrincipal")
   updatePrincipal(@path principal: string, @header("If-Match") ifMatch: string, @body body: PrincipalPatchRequest): UpdatePrincipalOK | CommonErrors;
 
   @summary("Delete a principal")
@@ -565,14 +684,13 @@ interface Principals {
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "grant-management")
   @apigen.command(#{
-    audit: #{ required: true, successAction: "principal.deleted", guarantee: "transactional" },
+    auditAction: "principal.deleted",
     failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "PRINCIPAL_NOT_FOUND", publicDetail: "Principal not found." },
       #{ kind: "invalid", statusCode: 422, code: "PRINCIPAL_NOT_MUTABLE", publicDetail: "This principal cannot be deleted by this operation." },
     ],
   })
+  @apigen.failsWith(PrincipalNotFoundFailure)
   @apigen.auditPayload(PrincipalDeletedAuditPayload)
-  @operationId("deletePrincipal")
   deletePrincipal(@path principal: string): EmptyResponse | CommonErrors;
 
   @summary("Reset a local principal password")
@@ -580,14 +698,9 @@ interface Principals {
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "grant-management")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "principal.local_password.reset", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "PRINCIPAL_NOT_FOUND", publicDetail: "Principal not found." },
-    ],
-  })
+  @apigen.command(#{ auditAction: "principal.local_password.reset" })
+  @apigen.failsWith(PrincipalNotFoundFailure)
   @apigen.auditPayload(PrincipalPasswordResetAuditPayload)
-  @operationId("resetPrincipalPassword")
   resetPrincipalPassword(@path principal: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): ResetPrincipalPasswordOK | CommonErrors;
 
   @summary("List a principal's sessions")
@@ -595,7 +708,6 @@ interface Principals {
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "grant-management")
-  @operationId("listPrincipalSessions")
   listPrincipalSessions(@path principal: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListPrincipalSessionsOK | CommonErrors;
 
   @summary("Revoke a principal's session")
@@ -603,16 +715,10 @@ interface Principals {
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "grant-management")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "session.revoked", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "SESSION_NOT_FOUND", publicDetail: "Session not found." },
-    ],
-    targetParameter: "principal",
-  })
+  @apigen.command(#{ auditAction: "session.revoked" })
+  @apigen.failsWith(SessionNotFoundFailure)
   @apigen.auditPayload(PrincipalSessionRevokedAuditPayload)
-  @operationId("revokePrincipalSession")
-  revokePrincipalSession(@path principal: string, @path session: string): EmptyResponse | CommonErrors;
+  revokePrincipalSession(@path @apigen.target principal: string, @path session: string): EmptyResponse | CommonErrors;
 }
 
 alias ListServicePrincipalsOK = OkJson<ServicePrincipalListResponse>;
@@ -622,103 +728,74 @@ alias CreateServicePrincipalSecretCreated = CreatedJson<ServicePrincipalSecretCr
 
 @tag("Access")
 @route("/service-principals")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
 interface ServicePrincipals {
   @summary("List service principals")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @operationId("listServicePrincipals")
   listServicePrincipals(@query limit?: ListLimit, @query pageToken?: PageToken): ListServicePrincipalsOK | CommonErrors;
 
   @summary("Create a service principal")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "service_principal.created", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "SERVICE_PRINCIPAL_INVALID", publicDetail: "The service principal request is invalid." },
-    ],
-  })
+  @apigen.command(#{ auditAction: "service_principal.created" })
+  @apigen.failsWith(ServicePrincipalInvalidFailure)
   @apigen.auditPayload(ServicePrincipalAuditPayload)
-  @operationId("createServicePrincipal")
   createServicePrincipal(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: ServicePrincipalCreateRequest): CreateServicePrincipalCreated | CommonErrors;
 
   @summary("Get a service principal")
   @route("/{servicePrincipal}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @operationId("getServicePrincipal")
   getServicePrincipal(@path servicePrincipal: string): OkJson<PrincipalResponse> | CommonErrors;
 
   @summary("Update a service principal")
   @route("/{servicePrincipal}")
   @patch
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "service_principal.updated", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "SERVICE_PRINCIPAL_NOT_FOUND", publicDetail: "Service principal not found." },
-    ],
-  })
+  @apigen.command(#{ auditAction: "service_principal.updated" })
+  @apigen.failsWith(ServicePrincipalNotFoundFailure)
   @apigen.auditPayload(ServicePrincipalAuditPayload)
-  @operationId("updateServicePrincipal")
   updateServicePrincipal(@path servicePrincipal: string, @header("If-Match") ifMatch: string, @body body: ServicePrincipalPatchRequest): UpdateServicePrincipalOK | CommonErrors;
 
   @summary("Delete a service principal")
   @route("/{servicePrincipal}")
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "service_principal.deleted", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "SERVICE_PRINCIPAL_NOT_FOUND", publicDetail: "Service principal not found." },
-    ],
-  })
+  @apigen.command(#{ auditAction: "service_principal.deleted" })
+  @apigen.failsWith(ServicePrincipalNotFoundFailure)
   @apigen.auditPayload(ServicePrincipalAuditPayload)
-  @operationId("deleteServicePrincipal")
   deleteServicePrincipal(@path servicePrincipal: string): EmptyResponse | CommonErrors;
 
   @summary("Create a service principal secret")
   @route("/{servicePrincipal}/secrets")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "service_principal_secret.created", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "SERVICE_PRINCIPAL_SECRET_INVALID", publicDetail: "The service principal secret request is invalid." },
-    ],
-  })
+  @apigen.command(#{ auditAction: "service_principal_secret.created" })
+  @apigen.failsWith(ServicePrincipalSecretInvalidFailure)
   @apigen.auditPayload(ServicePrincipalSecretAuditPayload)
-  @operationId("createServicePrincipalSecret")
   createServicePrincipalSecret(@path servicePrincipal: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: ServicePrincipalSecretCreateRequest): CreateServicePrincipalSecretCreated | CommonErrors;
 
   @summary("List service-principal secrets")
   @route("/{servicePrincipal}/secrets")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @operationId("listServicePrincipalSecrets")
   listServicePrincipalSecrets(@path servicePrincipal: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ServicePrincipalSecretListResponse> | CommonErrors;
 
   @summary("Get service-principal secret metadata")
   @route("/{servicePrincipal}/secrets/{secret}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @operationId("getServicePrincipalSecret")
   getServicePrincipalSecret(@path servicePrincipal: string, @path secret: string): OkJson<ServicePrincipalSecretResponse> | CommonErrors;
 
   @summary("Revoke a service principal secret")
   @route("/{servicePrincipal}/secrets/{secret}")
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PLATFORM" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "service_principal_secret.revoked", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "SERVICE_PRINCIPAL_SECRET_NOT_FOUND", publicDetail: "Service principal secret not found." },
-    ],
-    targetParameter: "servicePrincipal",
-  })
+  @apigen.command(#{ auditAction: "service_principal_secret.revoked" })
+  @apigen.failsWith(ServicePrincipalSecretNotFoundFailure)
   @apigen.auditPayload(ServicePrincipalSecretAuditPayload)
-  @operationId("revokeServicePrincipalSecret")
-  revokeServicePrincipalSecret(@path servicePrincipal: string, @path secret: string): EmptyResponse | CommonErrors;
+  revokeServicePrincipalSecret(@path @apigen.target servicePrincipal: string, @path secret: string): EmptyResponse | CommonErrors;
 }
 
 alias ListGroupsOK = OkJson<GroupListResponse>;
@@ -730,68 +807,49 @@ alias AddGroupMemberOK = OkJson<StatusResponse>;
 
 @tag("Access")
 @route("/workspaces/{workspace}/groups")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
 interface Groups {
   @summary("List groups")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("listGroups")
   listGroups(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListGroupsOK | CommonErrors;
 
   @summary("Create a group")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "group.created", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "GROUP_INVALID", publicDetail: "The group request is invalid." },
-    ],
-  })
+  @apigen.command(#{ auditAction: "group.created" })
+  @apigen.failsWith(GroupInvalidFailure)
   @apigen.auditPayload(GroupAuditPayload)
-  @operationId("createGroup")
   createGroup(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: GroupCreateRequest): CreateGroupCreated | CommonErrors;
 
   @summary("Delete a group")
   @route("/{group}")
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "group.deleted", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "GROUP_NOT_FOUND", publicDetail: "Group not found." },
-    ],
-    targetParameter: "workspace",
-  })
+  @apigen.command(#{ auditAction: "group.deleted" })
+  @apigen.failsWith(GroupNotFoundFailure)
   @apigen.auditPayload(GroupAuditPayload)
-  @operationId("deleteGroup")
-  deleteGroup(@path workspace: string, @path group: string): EmptyResponse | CommonErrors;
+  deleteGroup(@path @apigen.target workspace: string, @path group: string): EmptyResponse | CommonErrors;
 
   @summary("Get a group")
   @route("/{group}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("getGroup")
   getGroup(@path workspace: string, @path group: string): GetGroupOK | CommonErrors;
 
   @summary("Update a group")
   @route("/{group}")
   @patch
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "group.updated", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "GROUP_NOT_FOUND", publicDetail: "Group not found." },
-    ],
-    targetParameter: "workspace",
-  })
+  @apigen.command(#{ auditAction: "group.updated" })
+  @apigen.failsWith(GroupNotFoundFailure)
   @apigen.auditPayload(GroupAuditPayload)
-  @operationId("updateGroup")
-  updateGroup(@path workspace: string, @path group: string, @header("If-Match") ifMatch: string, @body body: GroupPatchRequest): UpdateGroupOK | CommonErrors;
+  updateGroup(@path @apigen.target workspace: string, @path group: string, @header("If-Match") ifMatch: string, @body body: GroupPatchRequest): UpdateGroupOK | CommonErrors;
 
   @summary("List group members")
   @route("/{group}/members")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("listGroupMembers")
   listGroupMembers(@path workspace: string, @path group: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListGroupMembersOK | CommonErrors;
 
   @summary("Remove a group member")
@@ -799,30 +857,26 @@ interface Groups {
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.command(#{
-    audit: #{ required: true, successAction: "group.member_removed", guarantee: "transactional" },
+    auditAction: "group.member_removed",
     failures: #[
       #{ kind: "not_found", statusCode: 404, code: "GROUP_MEMBER_NOT_FOUND", publicDetail: "Group member not found." },
     ],
-    targetParameter: "workspace",
   })
   @apigen.auditPayload(GroupMemberAuditPayload)
-  @operationId("removeGroupMember")
-  removeGroupMember(@path workspace: string, @path group: string, @path principal: string): EmptyResponse | CommonErrors;
+  removeGroupMember(@path @apigen.target workspace: string, @path group: string, @path principal: string): EmptyResponse | CommonErrors;
 
   @summary("Add a group member")
   @route("/{group}/members/{principal}")
   @put
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.command(#{
-    audit: #{ required: true, successAction: "group.member_added", guarantee: "transactional" },
+    auditAction: "group.member_added",
     failures: #[
       #{ kind: "not_found", statusCode: 404, code: "GROUP_MEMBER_NOT_FOUND", publicDetail: "Group or principal not found." },
     ],
-    targetParameter: "workspace",
   })
   @apigen.auditPayload(GroupMemberAuditPayload)
-  @operationId("addGroupMember")
-  addGroupMember(@path workspace: string, @path group: string, @path principal: string): AddGroupMemberOK | CommonErrors;
+  addGroupMember(@path @apigen.target workspace: string, @path group: string, @path principal: string): AddGroupMemberOK | CommonErrors;
 }
 
 alias ListRoleBindingsOK = OkJson<RoleBindingListResponse>;
@@ -877,7 +931,6 @@ alias ListWorkspaceRolesOK = OkJson<RoleListResponse>;
 @route("/workspaces/{workspace}/roles")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-@operationId("listWorkspaceRoles")
 op listWorkspaceRoles(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListWorkspaceRolesOK | CommonErrors;
 
 alias ListEffectivePrivilegesOK = OkJson<EffectivePrivilegeListResponse>;
@@ -887,7 +940,6 @@ alias ListEffectivePrivilegesOK = OkJson<EffectivePrivilegeListResponse>;
 @route("/workspaces/{workspace}/effective-privileges")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-@operationId("listEffectivePrivileges")
 op listEffectivePrivileges(@path workspace: string, @query objectType?: string, @query objectId?: string): ListEffectivePrivilegesOK | CommonErrors;
 
 alias ListGrantsOK = OkJson<GrantListResponse>;
@@ -895,11 +947,11 @@ alias CreateGrantCreated = CreatedJson<GrantResponse>;
 
 @tag("Access")
 @route("/workspaces/{workspace}/grants")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
 interface Grants {
   @summary("List grants")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("listGrants")
   listGrants(@path workspace: string, @query objectType?: string, @query objectId?: string, @query includeInherited?: boolean, @query limit?: ListLimit, @query pageToken?: PageToken): ListGrantsOK | CommonErrors;
 
   @summary("Create a grant")
@@ -907,20 +959,18 @@ interface Grants {
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.ui("workspace.access.grant.create")
   @apigen.command(#{
-    audit: #{ required: true, successAction: "grant.created", guarantee: "transactional" },
+    auditAction: "grant.created",
     failures: #[
       #{ kind: "invalid", statusCode: 400, code: "GRANT_INVALID", publicDetail: "The grant request is invalid." },
     ],
   })
   @apigen.auditPayload(GrantAuditPayload)
-  @operationId("createGrant")
   createGrant(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: GrantRequest): CreateGrantCreated | CommonErrors;
 
   @summary("Get an object privilege grant")
   @route("/{grant}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("getGrant")
   getGrant(@path workspace: string, @path grant: string): OkJson<GrantResponse> | CommonErrors;
 
   @summary("Update an object privilege grant")
@@ -928,32 +978,24 @@ interface Grants {
   @patch
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.command(#{
-    audit: #{ required: true, successAction: "grant.updated", guarantee: "transactional" },
+    auditAction: "grant.updated",
     failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "GRANT_NOT_FOUND", publicDetail: "Grant not found." },
       #{ kind: "invalid", statusCode: 422, code: "GRANT_INVALID", publicDetail: "The grant is invalid." },
     ],
-    targetParameter: "workspace",
   })
+  @apigen.failsWith(GrantNotFoundFailure)
   @apigen.auditPayload(GrantAuditPayload)
-  @operationId("updateGrant")
-  updateGrant(@path workspace: string, @path grant: string, @header("If-Match") ifMatch: string, @body body: GrantRequest): OkJson<GrantResponse> | CommonErrors;
+  updateGrant(@path @apigen.target workspace: string, @path grant: string, @header("If-Match") ifMatch: string, @body body: GrantRequest): OkJson<GrantResponse> | CommonErrors;
 
   @summary("Delete a grant")
   @route("/{grant}")
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.ui("workspace.access.grant.delete")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "grant.deleted", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "GRANT_NOT_FOUND", publicDetail: "Grant not found." },
-    ],
-    targetParameter: "workspace",
-  })
+  @apigen.command(#{ auditAction: "grant.deleted" })
+  @apigen.failsWith(GrantNotFoundFailure)
   @apigen.auditPayload(GrantAuditPayload)
-  @operationId("deleteGrant")
-  deleteGrant(@path workspace: string, @path grant: string): EmptyResponse | CommonErrors;
+  deleteGrant(@path @apigen.target workspace: string, @path grant: string): EmptyResponse | CommonErrors;
 }
 
 alias TransferOwnershipOK = OkJson<SecurableObjectResponse>;
@@ -963,14 +1005,9 @@ alias TransferOwnershipOK = OkJson<SecurableObjectResponse>;
 @route("/workspaces/{workspace}/ownership")
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_ITEM" })
-@apigen.command(#{
-  audit: #{ required: true, successAction: "ownership.transferred", guarantee: "transactional" },
-  failures: #[
-    #{ kind: "invalid", statusCode: 400, code: "OWNERSHIP_TRANSFER_INVALID", publicDetail: "The ownership transfer request is invalid." },
-  ],
-})
+@apigen.command(#{ auditAction: "ownership.transferred", guarantee: "transactional" })
+@apigen.failsWith(OwnershipTransferInvalidFailure)
 @apigen.auditPayload(OwnershipTransferAuditPayload)
-@operationId("transferOwnership")
 op transferOwnership(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: OwnershipTransferRequest): TransferOwnershipOK | CommonErrors;
 
 alias ListDataPoliciesOK = OkJson<DataPolicyListResponse>;
@@ -978,31 +1015,29 @@ alias CreateDataPolicyCreated = CreatedJson<DataPolicyResponse>;
 
 @tag("Access")
 @route("/workspaces/{workspace}/data-policies")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
 interface DataPolicies {
   @summary("List data policies")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("listDataPolicies")
   listDataPolicies(@path workspace: string, @query objectType?: string, @query objectId?: string, @query includeInherited?: boolean, @query limit?: ListLimit, @query pageToken?: PageToken): ListDataPoliciesOK | CommonErrors;
 
   @summary("Create a data policy")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.command(#{
-    audit: #{ required: true, successAction: "data_policy.created", guarantee: "transactional" },
+    auditAction: "data_policy.created",
     failures: #[
       #{ kind: "invalid", statusCode: 400, code: "DATA_POLICY_INVALID", publicDetail: "The data policy request is invalid." },
     ],
   })
   @apigen.auditPayload(DataPolicyAuditPayload)
-  @operationId("createDataPolicy")
   createDataPolicy(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DataPolicyRequest): CreateDataPolicyCreated | CommonErrors;
 
   @summary("Get a data policy")
   @route("/{policy}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("getDataPolicy")
   getDataPolicy(@path workspace: string, @path policy: string): OkJson<DataPolicyResponse> | CommonErrors;
 
   @summary("Update a data policy")
@@ -1010,31 +1045,23 @@ interface DataPolicies {
   @patch
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.command(#{
-    audit: #{ required: true, successAction: "data_policy.updated", guarantee: "transactional" },
+    auditAction: "data_policy.updated",
     failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "DATA_POLICY_NOT_FOUND", publicDetail: "Data policy not found." },
       #{ kind: "invalid", statusCode: 422, code: "DATA_POLICY_INVALID", publicDetail: "The data policy is invalid." },
     ],
-    targetParameter: "workspace",
   })
+  @apigen.failsWith(DataPolicyNotFoundFailure)
   @apigen.auditPayload(DataPolicyAuditPayload)
-  @operationId("updateDataPolicy")
-  updateDataPolicy(@path workspace: string, @path policy: string, @header("If-Match") ifMatch: string, @body body: DataPolicyRequest): OkJson<DataPolicyResponse> | CommonErrors;
+  updateDataPolicy(@path @apigen.target workspace: string, @path policy: string, @header("If-Match") ifMatch: string, @body body: DataPolicyRequest): OkJson<DataPolicyResponse> | CommonErrors;
 
   @summary("Delete a data policy")
   @route("/{policy}")
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "data_policy.deleted", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "DATA_POLICY_NOT_FOUND", publicDetail: "Data policy not found." },
-    ],
-    targetParameter: "workspace",
-  })
+  @apigen.command(#{ auditAction: "data_policy.deleted" })
+  @apigen.failsWith(DataPolicyNotFoundFailure)
   @apigen.auditPayload(DataPolicyAuditPayload)
-  @operationId("deleteDataPolicy")
-  deleteDataPolicy(@path workspace: string, @path policy: string): EmptyResponse | CommonErrors;
+  deleteDataPolicy(@path @apigen.target workspace: string, @path policy: string): EmptyResponse | CommonErrors;
 }
 
 @tag("Access")
@@ -1043,5 +1070,4 @@ interface DataPolicies {
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @apigen.query
-@operationId("checkAuthorizationBatch")
 op checkAuthorizationBatch(@path workspace: string, @body body: AuthorizationBatchCheckRequest): OkJson<AuthorizationBatchCheckResponse> | CommonErrors;

--- a/api/typespec/agent.tsp
+++ b/api/typespec/agent.tsp
@@ -22,6 +22,33 @@ model AgentCommandAuditPayload {
   surface: string;
 }
 
+@apigen.failureDefinition(#{ kind: "invalid", statusCode: 422, code: "INVALID_AGENT_CONFIG", publicDetail: "The agent configuration is invalid." })
+model InvalidAgentConfigFailure {}
+
+@apigen.failureDefinition(#{ kind: "unavailable", statusCode: 503, code: "AGENT_CONFIG_UNAVAILABLE", publicDetail: "Agent configuration is unavailable." })
+model AgentConfigUnavailableFailure {}
+
+@apigen.failureDefinition(#{ kind: "unavailable", statusCode: 503, code: "AGENT_SERVICE_UNAVAILABLE", publicDetail: "Agent service is unavailable." })
+model AgentServiceUnavailableFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "AGENT_CONVERSATION_NOT_FOUND", publicDetail: "Agent conversation not found." })
+model AgentConversationNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "invalid", statusCode: 422, code: "INVALID_AGENT_CONVERSATION", publicDetail: "The agent conversation request is invalid." })
+model InvalidAgentConversationFailure {}
+
+@apigen.failureDefinition(#{ kind: "conflict", statusCode: 409, code: "AGENT_RUN_CONFLICT", publicDetail: "The agent conversation already has an active run." })
+model AgentRunConflictFailure {}
+
+@apigen.failureDefinition(#{ kind: "invalid", statusCode: 422, code: "INVALID_AGENT_RUN", publicDetail: "The agent run request is invalid." })
+model InvalidAgentRunFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "AGENT_RUN_NOT_FOUND", publicDetail: "Agent run not found." })
+model AgentRunNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_cancellable", statusCode: 409, code: "AGENT_RUN_NOT_CANCELLABLE", publicDetail: "The agent run cannot be cancelled in its current state." })
+model AgentRunNotCancellableFailure {}
+
 model AgentConversationCreateRequest {
   title?: string;
 }
@@ -111,116 +138,88 @@ alias GetAgentConfigOK = OkJson<AgentConfigResponse>;
 @tag("Agent")
 @doc("Platform-wide agent configuration. The update command is shared by API and administration UI invocations.")
 @route("/agent/config")
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
+@apigen.auditPayload(AgentCommandAuditPayload)
 interface AgentConfiguration {
   @summary("Get the agent configuration")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
-  @operationId("getAgentConfig")
   getAgentConfig(): GetAgentConfigOK | CommonErrors;
 
   @summary("Update the agent configuration")
   @patch
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @apigen.ui("agent.config.update")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "agent.config.updated", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_AGENT_CONFIG", publicDetail: "The agent configuration is invalid." },
-      #{ kind: "unavailable", statusCode: 503, code: "AGENT_CONFIG_UNAVAILABLE", publicDetail: "Agent configuration is unavailable." },
-    ],
-  })
-  @apigen.auditPayload(AgentCommandAuditPayload)
-  @operationId("updateAgentConfig")
+  @apigen.failsWith(InvalidAgentConfigFailure)
+  @apigen.failsWith(AgentConfigUnavailableFailure)
+  @apigen.command(#{ auditAction: "agent.config.updated" })
   updateAgentConfig(@header("If-Match") ifMatch: string, @body body: AgentConfigUpdateRequest): UpdateAgentConfigOK | CommonErrors;
 }
 
 @tag("Agent")
 @doc("Agent conversation and run lifecycle. GET operations and event streams are queries; create, update, archive, start, and cancel operations mutate durable agent state.")
 @route("/agent/conversations")
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
+@apigen.auditPayload(AgentCommandAuditPayload)
 interface AgentConversations {
   @summary("List agent conversations")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
   @apigen.cli(#{ command: #["agent", "conversations"], output: #{ mode: "raw" } })
-  @operationId("listAgentConversations")
   listAgentConversations(@query limit?: ListLimit, @query pageToken?: PageToken): ListAgentConversationsOK | CommonErrors;
 
   @summary("Create an agent conversation")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
   @apigen.ui("agent.conversation.create")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "agent.conversation.created", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "unavailable", statusCode: 503, code: "AGENT_SERVICE_UNAVAILABLE", publicDetail: "Agent service is unavailable." },
-    ],
-  })
-  @apigen.auditPayload(AgentCommandAuditPayload)
-  @operationId("createAgentConversation")
+  @apigen.failsWith(AgentServiceUnavailableFailure)
+  @apigen.command(#{ auditAction: "agent.conversation.created" })
   createAgentConversation(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: AgentConversationCreateRequest): CreateAgentConversationCreated | CommonErrors;
 
   @summary("Archive an agent conversation")
   @route("/{conversation}")
   @delete
   @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "agent.conversation.archived", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "AGENT_CONVERSATION_NOT_FOUND", publicDetail: "Agent conversation not found." },
-    ],
-  })
-  @apigen.auditPayload(AgentCommandAuditPayload)
-  @operationId("archiveAgentConversation")
-  archiveAgentConversation(@path conversation: string): EmptyResponse | CommonErrors;
+  @apigen.failsWith(AgentConversationNotFoundFailure)
+  @apigen.command(#{ auditAction: "agent.conversation.archived" })
+  archiveAgentConversation(@path @apigen.target conversation: string): EmptyResponse | CommonErrors;
 
   @summary("Get an agent conversation")
   @route("/{conversation}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
-  @operationId("getAgentConversation")
   getAgentConversation(@path conversation: string): GetAgentConversationOK | CommonErrors;
 
   @summary("Update an agent conversation")
   @route("/{conversation}")
   @patch
   @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "agent.conversation.updated", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "AGENT_CONVERSATION_NOT_FOUND", publicDetail: "Agent conversation not found." },
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_AGENT_CONVERSATION", publicDetail: "The agent conversation request is invalid." },
-    ],
-  })
-  @apigen.auditPayload(AgentCommandAuditPayload)
-  @operationId("updateAgentConversation")
-  updateAgentConversation(@path conversation: string, @header("If-Match") ifMatch: string, @body body: AgentConversationPatchRequest): UpdateAgentConversationOK | CommonErrors;
+  @apigen.failsWith(AgentConversationNotFoundFailure)
+  @apigen.failsWith(InvalidAgentConversationFailure)
+  @apigen.command(#{ auditAction: "agent.conversation.updated" })
+  updateAgentConversation(@path @apigen.target conversation: string, @header("If-Match") ifMatch: string, @body body: AgentConversationPatchRequest): UpdateAgentConversationOK | CommonErrors;
 
   @summary("List agent messages")
   @route("/{conversation}/messages")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
-  @operationId("listAgentMessages")
   listAgentMessages(@path conversation: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListAgentMessagesOK | CommonErrors;
 
   @summary("List agent runs")
   @route("/{conversation}/runs")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
-  @operationId("listAgentRuns")
   listAgentRuns(@path conversation: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListAgentRunsOK | CommonErrors;
 
   @summary("Get an agent run")
   @route("/{conversation}/runs/{run}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
-  @operationId("getAgentRun")
   getAgentRun(@path conversation: string, @path run: string): GetAgentRunOK | CommonErrors;
 
   @summary("List agent run events")
   @route("/{conversation}/runs/{run}/events")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AGENT" })
-  @operationId("listAgentEvents")
   listAgentEvents(@path conversation: string, @path run: string, @header accept?: string, @header("Last-Event-ID") lastEventId?: string, @query limit?: ListLimit, @query pageToken?: PageToken): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;
 
   @summary("Create an asynchronous agent run")
@@ -228,45 +227,29 @@ interface AgentConversations {
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
   @apigen.ui("agent.run.create")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "agent.run.created", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "AGENT_CONVERSATION_NOT_FOUND", publicDetail: "Agent conversation not found." },
-      #{ kind: "conflict", statusCode: 409, code: "AGENT_RUN_CONFLICT", publicDetail: "The agent conversation already has an active run." },
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_AGENT_RUN", publicDetail: "The agent run request is invalid." },
-      #{ kind: "unavailable", statusCode: 503, code: "AGENT_SERVICE_UNAVAILABLE", publicDetail: "Agent service is unavailable." },
-    ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "agent.run",
-      resourceKind: "agent_run",
-      initialEvent: "agent_run.queued",
-      initialState: "running",
-      statusOperation: "getAgentRun",
-      eventsOperation: "listAgentEvents",
-      cancellation: "supported",
-    },
+  @apigen.failsWith(AgentConversationNotFoundFailure)
+  @apigen.failsWith(AgentRunConflictFailure)
+  @apigen.failsWith(InvalidAgentRunFailure)
+  @apigen.failsWith(AgentServiceUnavailableFailure)
+  @apigen.asyncExecution(AgentConversations.getAgentRun, AgentConversations.listAgentEvents, #{
+    guarantee: "transactional",
+    jobKind: "agent.run",
+    resourceKind: "agent_run",
+    initialEvent: "agent_run.queued",
+    initialState: "running",
+    cancellation: "supported",
   })
-  @apigen.auditPayload(AgentCommandAuditPayload)
-  @operationId("createAgentRun")
-  createAgentRun(@path conversation: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: AgentRunCreateRequest): AcceptedJson<AgentRunResponse> | CommonErrors;
+  @apigen.command(#{ auditAction: "agent.run.created" })
+  createAgentRun(@path @apigen.target conversation: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: AgentRunCreateRequest): AcceptedJson<AgentRunResponse> | CommonErrors;
 
   @summary("Cancel an agent run")
   @doc("Cancels an existing run and its queued work synchronously. The 202 response reports the resulting run state; this operation does not create a new asynchronous execution.")
   @route("/{conversation}/runs/{run}/cancel")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "USE_AGENT" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "agent.run.cancelled", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "AGENT_RUN_NOT_FOUND", publicDetail: "Agent run not found." },
-      #{ kind: "not_cancellable", statusCode: 409, code: "AGENT_RUN_NOT_CANCELLABLE", publicDetail: "The agent run cannot be cancelled in its current state." },
-      #{ kind: "unavailable", statusCode: 503, code: "AGENT_SERVICE_UNAVAILABLE", publicDetail: "Agent service is unavailable." },
-    ],
-    targetParameter: "conversation",
-  })
-  @apigen.auditPayload(AgentCommandAuditPayload)
-  @operationId("cancelAgentRun")
-  cancelAgentRun(@path conversation: string, @path run: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<AgentRunResponse> | CommonErrors;
+  @apigen.failsWith(AgentRunNotFoundFailure)
+  @apigen.failsWith(AgentRunNotCancellableFailure)
+  @apigen.failsWith(AgentServiceUnavailableFailure)
+  @apigen.command(#{ auditAction: "agent.run.cancelled" })
+  cancelAgentRun(@path @apigen.target conversation: string, @path run: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<AgentRunResponse> | CommonErrors;
 }

--- a/api/typespec/audit.tsp
+++ b/api/typespec/audit.tsp
@@ -31,5 +31,4 @@ alias ListAuditEventsOK = OkJson<AuditEventListResponse>;
 @route("/workspaces/{workspace}/audit-events")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
-@operationId("listAuditEvents")
 op listAuditEvents(@path workspace: string, @query actor?: string, @query action?: string, @query targetType?: string, @query targetId?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListAuditEventsOK | CommonErrors;

--- a/api/typespec/bi.tsp
+++ b/api/typespec/bi.tsp
@@ -654,7 +654,6 @@ model DashboardFilterOptionListResponse {
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @apigen.cli(#{ command: #["dashboards", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@operationId("listDashboards")
 op listDashboards(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<DashboardListResponse> | CommonErrors;
 
 @tag("BI")
@@ -664,7 +663,6 @@ op listDashboards(@path workspace: string, @query limit?: ListLimit, @query page
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }], output: #{ mode: "raw" } })
-@operationId("getDashboard")
 op getDashboard(@path workspace: string, @path dashboard: string): OkJson<DashboardManifestResponse> | CommonErrors;
 
 @tag("BI")
@@ -674,7 +672,6 @@ op getDashboard(@path workspace: string, @path dashboard: string): OkJson<Dashbo
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "page"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }], output: #{ mode: "raw" } })
-@operationId("getDashboardPage")
 op getDashboardPage(@path workspace: string, @path dashboard: string, @path page: string): OkJson<DashboardPageResponse> | CommonErrors;
 
 @tag("BI")
@@ -684,7 +681,6 @@ op getDashboardPage(@path workspace: string, @path dashboard: string, @path page
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "visual"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "visual", displayName: "visual" }], output: #{ mode: "raw" } })
-@operationId("getDashboardVisual")
 op getDashboardVisual(@path workspace: string, @path dashboard: string, @path page: string, @path visual: string): OkJson<DashboardVisualDescribeResponse> | CommonErrors;
 
 @tag("BI")
@@ -693,7 +689,6 @@ op getDashboardVisual(@path workspace: string, @path dashboard: string, @path pa
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "dashboard")
-@operationId("getDashboardFilter")
 op getDashboardFilter(@path workspace: string, @path dashboard: string, @path page: string, @path filter: string): OkJson<DashboardFilterDescribeResponse> | CommonErrors;
 
 @tag("BI")
@@ -702,7 +697,6 @@ op getDashboardFilter(@path workspace: string, @path dashboard: string, @path pa
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @apigen.cli(#{ command: #["semantic-models", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@operationId("listSemanticModels")
 op listSemanticModels(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticModelListResponse> | CommonErrors;
 
 @tag("BI")
@@ -712,7 +706,6 @@ op listSemanticModels(@path workspace: string, @query limit?: ListLimit, @query 
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
-@operationId("getSemanticModel")
 op getSemanticModel(@path workspace: string, @path("model") modelName: string): OkJson<SemanticModelDescriptionResponse> | CommonErrors;
 
 @tag("BI")
@@ -721,7 +714,6 @@ op getSemanticModel(@path workspace: string, @path("model") modelName: string): 
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
-@operationId("listSemanticRelationships")
 op listSemanticRelationships(@path workspace: string, @path("model") modelName: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticRelationshipListResponse> | CommonErrors;
 
 @tag("BI")
@@ -730,7 +722,6 @@ op listSemanticRelationships(@path workspace: string, @path("model") modelName: 
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
-@operationId("listSemanticSources")
 op listSemanticSources(@path workspace: string, @path("model") modelName: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticSourceListResponse> | CommonErrors;
 
 @tag("BI")
@@ -740,7 +731,6 @@ op listSemanticSources(@path workspace: string, @path("model") modelName: string
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "model-fields"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
-@operationId("listSemanticModelFields")
 op listSemanticModelFields(@path workspace: string, @path("model") modelName: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticFieldListResponse> | CommonErrors;
 
 @tag("BI")
@@ -790,7 +780,6 @@ op listSemanticModelFields(@path workspace: string, @path("model") modelName: st
     cursor: #{ source: "/page/nextCursor" }
   },
 })
-@operationId("querySemanticModel")
 op querySemanticModel(@path workspace: WorkspaceId, @path("model") modelName: string, @header accept?: string, @body body?: SemanticQueryRequest): RowsetResponse<SemanticQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -801,7 +790,6 @@ op querySemanticModel(@path workspace: WorkspaceId, @path("model") modelName: st
 @apigen.authz(#{ mode: "privilege", privilege: "QUERY_DATA" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "model-explain"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
-@operationId("explainSemanticModelQuery")
 op explainSemanticModelQuery(@path workspace: string, @path("model") modelName: string, @body body?: SemanticQueryRequest): OkJson<SemanticExplainResponse> | CommonErrors;
 
 @tag("BI")
@@ -811,7 +799,6 @@ op explainSemanticModelQuery(@path workspace: string, @path("model") modelName: 
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "datasets"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }], output: #{ mode: "raw" } })
-@operationId("listSemanticDatasets")
 op listSemanticDatasets(@path workspace: string, @path("model") modelName: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticDatasetListResponse> | CommonErrors;
 
 @tag("BI")
@@ -821,7 +808,6 @@ op listSemanticDatasets(@path workspace: string, @path("model") modelName: strin
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "dataset"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@operationId("getSemanticDataset")
 op getSemanticDataset(@path workspace: string, @path("model") modelName: string, @path dataset: string): OkJson<SemanticDatasetResponse> | CommonErrors;
 
 @tag("BI")
@@ -831,7 +817,6 @@ op getSemanticDataset(@path workspace: string, @path("model") modelName: string,
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "fields"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@operationId("listSemanticFields")
 op listSemanticFields(@path workspace: string, @path("model") modelName: string, @path dataset: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticFieldListResponse> | CommonErrors;
 
 @tag("BI")
@@ -843,7 +828,6 @@ op listSemanticFields(@path workspace: string, @path("model") modelName: string,
 @extension("x-leapview-object-scope", "semantic-model")
 @extension("x-leapview-response-trailers", #["X-Next-Cursor"])
 @apigen.cli(#{ command: #["semantic-models", "preview"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@operationId("previewSemanticDataset")
 op previewSemanticDataset(@path workspace: string, @path("model") modelName: string, @path dataset: string, @header accept?: string, @body body?: SemanticPreviewRequest): RowsetResponse<SemanticQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -854,7 +838,6 @@ op previewSemanticDataset(@path workspace: string, @path("model") modelName: str
 @apigen.authz(#{ mode: "privilege", privilege: "PREVIEW_DATA" })
 @extension("x-leapview-object-scope", "semantic-model")
 @apigen.cli(#{ command: #["semantic-models", "explain-preview"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "model", displayName: "model" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-@operationId("explainSemanticPreview")
 op explainSemanticPreview(@path workspace: string, @path("model") modelName: string, @path dataset: string, @body body?: SemanticPreviewRequest): OkJson<SemanticExplainResponse> | CommonErrors;
 
 @tag("BI")
@@ -865,7 +848,6 @@ op explainSemanticPreview(@path workspace: string, @path("model") modelName: str
 @apigen.authz(#{ mode: "privilege", privilege: "QUERY_DATA" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "query-page"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }], output: #{ mode: "raw" } })
-@operationId("queryDashboardPage")
 op queryDashboardPage(@path workspace: string, @path dashboard: string, @path page: string, @body body?: DashboardPageQueryRequest): OkJson<DashboardPageQueryResponse> | CommonErrors;
 
 @tag("BI")
@@ -888,7 +870,6 @@ op queryDashboardPage(@path workspace: string, @path dashboard: string, @path pa
   ] },
   output: #{ mode: "raw" },
 })
-@operationId("queryDashboardVisualData")
 op queryDashboardVisualData(@path workspace: WorkspaceId, @path dashboard: string, @path page: string, @path visual: string, @header accept?: string, @body body?: DashboardVisualQueryRequest): RowsetResponse<LeapViewVisualization.VisualizationEnvelope> | CommonErrors;
 
 @tag("BI")
@@ -899,5 +880,4 @@ op queryDashboardVisualData(@path workspace: WorkspaceId, @path dashboard: strin
 @apigen.authz(#{ mode: "privilege", privilege: "QUERY_DATA" })
 @extension("x-leapview-object-scope", "dashboard")
 @apigen.cli(#{ command: #["dashboards", "filter-options"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "dashboard", displayName: "dashboard" }, #{ source: "path", name: "page", displayName: "page" }, #{ source: "path", name: "filter", displayName: "filter" }], output: #{ mode: "raw" } })
-@operationId("listDashboardFilterValues")
 op listDashboardFilterValues(@path workspace: string, @path dashboard: string, @path page: string, @path filter: string, @query limit?: ListLimit, @query pageToken?: PageToken, @body body?: DashboardPageQueryRequest): OkJson<DashboardFilterOptionListResponse> | CommonErrors;

--- a/api/typespec/capabilities.tsp
+++ b/api/typespec/capabilities.tsp
@@ -70,5 +70,4 @@ model CapabilitiesResponse {
 @route("/capabilities")
 @get
 @apigen.authz(#{ mode: "authenticated" })
-@operationId("getCapabilities")
 op getCapabilities(): OkJson<CapabilitiesResponse> | CommonErrors;

--- a/api/typespec/connection_bindings.tsp
+++ b/api/typespec/connection_bindings.tsp
@@ -34,6 +34,30 @@ model TargetConnectionRotationAuditPayload {
   targetId: string;
 }
 
+@apigen.failureDefinition(#{ kind: "invalid", statusCode: 400, code: "INVALID_CONNECTION_BINDING", publicDetail: "Connection binding is invalid." })
+model InvalidConnectionBindingFailure {}
+
+@apigen.failureDefinition(#{ kind: "unauthorized", statusCode: 403, code: "FORBIDDEN", publicDetail: "Connection operation is forbidden." })
+model ForbiddenConnectionOperationFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "CONNECTION_BINDING_NOT_FOUND", publicDetail: "Connection binding was not found." })
+model ConnectionBindingNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "conflict", statusCode: 409, code: "CONNECTION_BINDING_CONFLICT", publicDetail: "Connection binding changed concurrently or is incompatible." })
+model ConnectionBindingConflictFailure {}
+
+@apigen.failureDefinition(#{ kind: "credential_invalid", statusCode: 422, code: "CONNECTION_TEST_FAILED", publicDetail: "Connection validation failed." })
+model ConnectionTestFailedFailure {}
+
+@apigen.failureDefinition(#{ kind: "provider_unavailable", statusCode: 503, code: "CONNECTION_PROVIDER_UNAVAILABLE", publicDetail: "Connection provider is unavailable." })
+model ConnectionProviderUnavailableFailure {}
+
+@apigen.failureDefinition(#{ kind: "disabled", statusCode: 409, code: "CONNECTION_BINDING_DISABLED", publicDetail: "Connection binding is disabled." })
+model ConnectionBindingDisabledFailure {}
+
+@apigen.failureDefinition(#{ kind: "confirmation_required", statusCode: 412, code: "CONFIRMATION_REQUIRED", publicDetail: "Dependency confirmation is required." })
+model ConfirmationRequiredFailure {}
+
 @minLength(1)
 @maxLength(128)
 @pattern("^[A-Za-z_][A-Za-z0-9_]{0,127}$")
@@ -160,11 +184,11 @@ model TargetConnectionBindingHealthResponse {
 
 @route("/workspaces/{workspace}/targets/{target}/environments/{environment}/connection-bindings")
 @tag("Connections")
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
 interface TargetConnectionBindings {
   @summary("List target connection bindings")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_CONNECTION_METADATA" })
-  @operationId("listTargetConnectionBindings")
   listTargetConnectionBindings(
     @path workspace: string,
     @path target: TargetConnectionIdentifier,
@@ -174,23 +198,19 @@ interface TargetConnectionBindings {
   @summary("Create a target connection binding")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_CONNECTION_METADATA" })
+  @apigen.failsWith(InvalidConnectionBindingFailure)
+  @apigen.failsWith(ForbiddenConnectionOperationFailure)
+  @apigen.failsWith(ConnectionBindingNotFoundFailure)
+  @apigen.failsWith(ConnectionBindingConflictFailure)
+  @apigen.failsWith(ConnectionTestFailedFailure)
+  @apigen.failsWith(ConnectionProviderUnavailableFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "connection.binding.created", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "INVALID_CONNECTION_BINDING", publicDetail: "Connection binding is invalid." },
-      #{ kind: "unauthorized", statusCode: 403, code: "FORBIDDEN", publicDetail: "Connection operation is forbidden." },
-      #{ kind: "not_found", statusCode: 404, code: "CONNECTION_BINDING_NOT_FOUND", publicDetail: "Connection binding was not found." },
-      #{ kind: "conflict", statusCode: 409, code: "CONNECTION_BINDING_CONFLICT", publicDetail: "Connection binding changed concurrently or is incompatible." },
-      #{ kind: "credential_invalid", statusCode: 422, code: "CONNECTION_TEST_FAILED", publicDetail: "Connection validation failed." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." },
-      #{ kind: "provider_unavailable", statusCode: 503, code: "CONNECTION_PROVIDER_UNAVAILABLE", publicDetail: "Connection provider is unavailable." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "connection.binding.created",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
   })
   @apigen.auditPayload(TargetConnectionAdministrationAuditPayload)
-  @operationId("createTargetConnectionBinding")
   createTargetConnectionBinding(
-    @path workspace: string,
+    @path @apigen.target workspace: string,
     @path target: TargetConnectionIdentifier,
     @path environment: TargetConnectionIdentifier,
     @header("Idempotency-Key") idempotencyKey: IdempotencyKey,
@@ -201,7 +221,6 @@ interface TargetConnectionBindings {
   @route("/{connection}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_CONNECTION_METADATA" })
-  @operationId("getTargetConnectionBinding")
   getTargetConnectionBinding(
     @path workspace: string,
     @path target: TargetConnectionIdentifier,
@@ -215,7 +234,6 @@ interface TargetConnectionBindings {
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_CONNECTION_METADATA" })
   @apigen.query
-  @operationId("planTargetConnectionBindingChange")
   planTargetConnectionBindingChange(
     @path workspace: string,
     @path target: TargetConnectionIdentifier,
@@ -228,24 +246,20 @@ interface TargetConnectionBindings {
   @route("/{connection}")
   @put
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_CONNECTION_METADATA" })
+  @apigen.failsWith(InvalidConnectionBindingFailure)
+  @apigen.failsWith(ForbiddenConnectionOperationFailure)
+  @apigen.failsWith(ConnectionBindingNotFoundFailure)
+  @apigen.failsWith(ConnectionBindingConflictFailure)
+  @apigen.failsWith(ConnectionBindingDisabledFailure)
+  @apigen.failsWith(ConfirmationRequiredFailure)
+  @apigen.failsWith(ConnectionProviderUnavailableFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "connection.binding.updated", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "INVALID_CONNECTION_BINDING", publicDetail: "Connection binding is invalid." },
-      #{ kind: "unauthorized", statusCode: 403, code: "FORBIDDEN", publicDetail: "Connection operation is forbidden." },
-      #{ kind: "not_found", statusCode: 404, code: "CONNECTION_BINDING_NOT_FOUND", publicDetail: "Connection binding was not found." },
-      #{ kind: "conflict", statusCode: 409, code: "CONNECTION_BINDING_CONFLICT", publicDetail: "Connection binding changed concurrently or is incompatible." },
-      #{ kind: "disabled", statusCode: 409, code: "CONNECTION_BINDING_DISABLED", publicDetail: "Connection binding is disabled." },
-      #{ kind: "confirmation_required", statusCode: 412, code: "CONFIRMATION_REQUIRED", publicDetail: "Dependency confirmation is required." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." },
-      #{ kind: "provider_unavailable", statusCode: 503, code: "CONNECTION_PROVIDER_UNAVAILABLE", publicDetail: "Connection provider is unavailable." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "connection.binding.updated",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
   })
   @apigen.auditPayload(TargetConnectionAdministrationAuditPayload)
-  @operationId("updateTargetConnectionBinding")
   updateTargetConnectionBinding(
-    @path workspace: string,
+    @path @apigen.target workspace: string,
     @path target: TargetConnectionIdentifier,
     @path environment: TargetConnectionIdentifier,
     @path connection: LogicalConnectionId,
@@ -257,24 +271,20 @@ interface TargetConnectionBindings {
   @route("/{connection}/test")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "TEST_CONNECTION" })
+  @apigen.failsWith(InvalidConnectionBindingFailure)
+  @apigen.failsWith(ForbiddenConnectionOperationFailure)
+  @apigen.failsWith(ConnectionBindingNotFoundFailure)
+  @apigen.failsWith(ConnectionBindingConflictFailure)
+  @apigen.failsWith(ConnectionBindingDisabledFailure)
+  @apigen.failsWith(ConnectionTestFailedFailure)
+  @apigen.failsWith(ConnectionProviderUnavailableFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "credential.test.requested", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "INVALID_CONNECTION_BINDING", publicDetail: "Connection binding is invalid." },
-      #{ kind: "unauthorized", statusCode: 403, code: "FORBIDDEN", publicDetail: "Connection operation is forbidden." },
-      #{ kind: "not_found", statusCode: 404, code: "CONNECTION_BINDING_NOT_FOUND", publicDetail: "Connection binding was not found." },
-      #{ kind: "conflict", statusCode: 409, code: "CONNECTION_BINDING_CONFLICT", publicDetail: "Connection binding changed concurrently or is incompatible." },
-      #{ kind: "disabled", statusCode: 409, code: "CONNECTION_BINDING_DISABLED", publicDetail: "Connection binding is disabled." },
-      #{ kind: "credential_invalid", statusCode: 422, code: "CONNECTION_TEST_FAILED", publicDetail: "Connection validation failed." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." },
-      #{ kind: "provider_unavailable", statusCode: 503, code: "CONNECTION_PROVIDER_UNAVAILABLE", publicDetail: "Connection provider is unavailable." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "credential.test.requested",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
   })
   @apigen.auditPayload(TargetConnectionRotationAuditPayload)
-  @operationId("testTargetConnectionBinding")
   testTargetConnectionBinding(
-    @path workspace: string,
+    @path @apigen.target workspace: string,
     @path target: TargetConnectionIdentifier,
     @path environment: TargetConnectionIdentifier,
     @path connection: LogicalConnectionId,
@@ -285,24 +295,20 @@ interface TargetConnectionBindings {
   @route("/{connection}/refresh")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "TEST_CONNECTION" })
+  @apigen.failsWith(InvalidConnectionBindingFailure)
+  @apigen.failsWith(ForbiddenConnectionOperationFailure)
+  @apigen.failsWith(ConnectionBindingNotFoundFailure)
+  @apigen.failsWith(ConnectionBindingConflictFailure)
+  @apigen.failsWith(ConnectionBindingDisabledFailure)
+  @apigen.failsWith(ConnectionTestFailedFailure)
+  @apigen.failsWith(ConnectionProviderUnavailableFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "credential.refresh.requested", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "INVALID_CONNECTION_BINDING", publicDetail: "Connection binding is invalid." },
-      #{ kind: "unauthorized", statusCode: 403, code: "FORBIDDEN", publicDetail: "Connection operation is forbidden." },
-      #{ kind: "not_found", statusCode: 404, code: "CONNECTION_BINDING_NOT_FOUND", publicDetail: "Connection binding was not found." },
-      #{ kind: "conflict", statusCode: 409, code: "CONNECTION_BINDING_CONFLICT", publicDetail: "Connection binding changed concurrently or is incompatible." },
-      #{ kind: "disabled", statusCode: 409, code: "CONNECTION_BINDING_DISABLED", publicDetail: "Connection binding is disabled." },
-      #{ kind: "credential_invalid", statusCode: 422, code: "CONNECTION_TEST_FAILED", publicDetail: "Connection validation failed." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." },
-      #{ kind: "provider_unavailable", statusCode: 503, code: "CONNECTION_PROVIDER_UNAVAILABLE", publicDetail: "Connection provider is unavailable." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "credential.refresh.requested",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
   })
   @apigen.auditPayload(TargetConnectionRotationAuditPayload)
-  @operationId("refreshTargetConnectionBinding")
   refreshTargetConnectionBinding(
-    @path workspace: string,
+    @path @apigen.target workspace: string,
     @path target: TargetConnectionIdentifier,
     @path environment: TargetConnectionIdentifier,
     @path connection: LogicalConnectionId,
@@ -313,22 +319,18 @@ interface TargetConnectionBindings {
   @route("/{connection}/enable")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_CONNECTION_METADATA" })
+  @apigen.failsWith(InvalidConnectionBindingFailure)
+  @apigen.failsWith(ForbiddenConnectionOperationFailure)
+  @apigen.failsWith(ConnectionBindingNotFoundFailure)
+  @apigen.failsWith(ConnectionBindingConflictFailure)
+  @apigen.failsWith(ConnectionProviderUnavailableFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "connection.binding.enabled", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "INVALID_CONNECTION_BINDING", publicDetail: "Connection binding is invalid." },
-      #{ kind: "unauthorized", statusCode: 403, code: "FORBIDDEN", publicDetail: "Connection operation is forbidden." },
-      #{ kind: "not_found", statusCode: 404, code: "CONNECTION_BINDING_NOT_FOUND", publicDetail: "Connection binding was not found." },
-      #{ kind: "conflict", statusCode: 409, code: "CONNECTION_BINDING_CONFLICT", publicDetail: "Connection binding changed concurrently or is incompatible." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." },
-      #{ kind: "provider_unavailable", statusCode: 503, code: "CONNECTION_PROVIDER_UNAVAILABLE", publicDetail: "Connection provider is unavailable." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "connection.binding.enabled",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
   })
   @apigen.auditPayload(TargetConnectionAdministrationAuditPayload)
-  @operationId("enableTargetConnectionBinding")
   enableTargetConnectionBinding(
-    @path workspace: string,
+    @path @apigen.target workspace: string,
     @path target: TargetConnectionIdentifier,
     @path environment: TargetConnectionIdentifier,
     @path connection: LogicalConnectionId,
@@ -339,23 +341,19 @@ interface TargetConnectionBindings {
   @route("/{connection}/disable")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_CONNECTION_METADATA" })
+  @apigen.failsWith(InvalidConnectionBindingFailure)
+  @apigen.failsWith(ForbiddenConnectionOperationFailure)
+  @apigen.failsWith(ConnectionBindingNotFoundFailure)
+  @apigen.failsWith(ConnectionBindingConflictFailure)
+  @apigen.failsWith(ConnectionBindingDisabledFailure)
+  @apigen.failsWith(ConnectionProviderUnavailableFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "connection.binding.disabled", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "INVALID_CONNECTION_BINDING", publicDetail: "Connection binding is invalid." },
-      #{ kind: "unauthorized", statusCode: 403, code: "FORBIDDEN", publicDetail: "Connection operation is forbidden." },
-      #{ kind: "not_found", statusCode: 404, code: "CONNECTION_BINDING_NOT_FOUND", publicDetail: "Connection binding was not found." },
-      #{ kind: "conflict", statusCode: 409, code: "CONNECTION_BINDING_CONFLICT", publicDetail: "Connection binding changed concurrently or is incompatible." },
-      #{ kind: "disabled", statusCode: 409, code: "CONNECTION_BINDING_DISABLED", publicDetail: "Connection binding is disabled." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." },
-      #{ kind: "provider_unavailable", statusCode: 503, code: "CONNECTION_PROVIDER_UNAVAILABLE", publicDetail: "Connection provider is unavailable." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "connection.binding.disabled",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
   })
   @apigen.auditPayload(TargetConnectionAdministrationAuditPayload)
-  @operationId("disableTargetConnectionBinding")
   disableTargetConnectionBinding(
-    @path workspace: string,
+    @path @apigen.target workspace: string,
     @path target: TargetConnectionIdentifier,
     @path environment: TargetConnectionIdentifier,
     @path connection: LogicalConnectionId,
@@ -366,7 +364,6 @@ interface TargetConnectionBindings {
   @route("/{connection}/health")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_CONNECTION_HEALTH" })
-  @operationId("getTargetConnectionBindingHealth")
   getTargetConnectionBindingHealth(
     @path workspace: string,
     @path target: TargetConnectionIdentifier,

--- a/api/typespec/current_user.tsp
+++ b/api/typespec/current_user.tsp
@@ -60,6 +60,15 @@ model SessionListResponse {
   page: PageInfo;
 }
 
+@apigen.failureDefinition(#{ kind: "invalid", statusCode: 400, code: "API_TOKEN_INVALID", publicDetail: "The API token request is invalid." })
+model APITokenInvalidFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "API_TOKEN_NOT_FOUND", publicDetail: "API token not found." })
+model APITokenNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "SESSION_NOT_FOUND", publicDetail: "Session not found." })
+model SessionNotFoundFailure {}
+
 alias GetCurrentPrincipalOK = OkJson<PrincipalResponse>;
 
 @tag("Current User")
@@ -68,7 +77,6 @@ alias GetCurrentPrincipalOK = OkJson<PrincipalResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @extension("x-leapview-object-scope", "principal")
-@operationId("getCurrentPrincipal")
 op getCurrentPrincipal(): GetCurrentPrincipalOK | CommonErrors;
 
 alias ListCurrentAPITokensOK = OkJson<APITokenListResponse>;
@@ -76,42 +84,29 @@ alias CreateCurrentAPITokenCreated = CreatedJson<APITokenCreateResponse>;
 
 @tag("Current User")
 @route("/me/api-tokens")
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
+@apigen.commandDefaults(#{ guarantee: "transactional" })
+@apigen.auditPayload(APITokenAuditPayload)
 interface CurrentAPITokens {
   @summary("List current API tokens")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "principal")
-  @operationId("listCurrentAPITokens")
   listCurrentAPITokens(@query limit?: ListLimit, @query pageToken?: PageToken): ListCurrentAPITokensOK | CommonErrors;
 
   @summary("Create current API token")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "principal")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "api_token.created", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "API_TOKEN_INVALID", publicDetail: "The API token request is invalid." },
-    ],
-  })
-  @apigen.auditPayload(APITokenAuditPayload)
-  @operationId("createCurrentAPIToken")
+  @apigen.failsWith(APITokenInvalidFailure)
+  @apigen.command(#{ auditAction: "api_token.created" })
   createCurrentAPIToken(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: APITokenCreateRequest): CreateCurrentAPITokenCreated | CommonErrors;
 
   @summary("Revoke current API token")
   @route("/{token}")
   @delete
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_GRANTS" })
   @extension("x-leapview-object-scope", "principal")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "api_token.revoked", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "API_TOKEN_NOT_FOUND", publicDetail: "API token not found." },
-    ],
-  })
-  @apigen.auditPayload(APITokenAuditPayload)
-  @operationId("revokeCurrentAPIToken")
-  revokeCurrentAPIToken(@path token: string): EmptyResponse | CommonErrors;
+  @apigen.failsWith(APITokenNotFoundFailure)
+  @apigen.command(#{ auditAction: "api_token.revoked" })
+  revokeCurrentAPIToken(@path @apigen.target token: string): EmptyResponse | CommonErrors;
 }
 
 alias ListCurrentEffectivePrivilegesOK = OkJson<EffectivePrivilegesResponse>;
@@ -122,33 +117,25 @@ alias ListCurrentEffectivePrivilegesOK = OkJson<EffectivePrivilegesResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @extension("x-leapview-object-scope", "principal")
-@operationId("listCurrentEffectivePrivileges")
 op listCurrentEffectivePrivileges(@query workspace?: string): ListCurrentEffectivePrivilegesOK | CommonErrors;
 
 alias ListCurrentSessionsOK = OkJson<SessionListResponse>;
 
 @tag("Current User")
 @route("/me/sessions")
+@apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 interface CurrentSessions {
   @summary("List current sessions")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
   @extension("x-leapview-object-scope", "principal")
-  @operationId("listCurrentSessions")
   listCurrentSessions(@query limit?: ListLimit, @query pageToken?: PageToken): ListCurrentSessionsOK | CommonErrors;
 
   @summary("Revoke current session")
   @route("/{session}")
   @delete
-  @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
   @extension("x-leapview-object-scope", "principal")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "session.revoked", guarantee: "transactional" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "SESSION_NOT_FOUND", publicDetail: "Session not found." },
-    ],
-  })
+  @apigen.failsWith(SessionNotFoundFailure)
+  @apigen.command(#{ auditAction: "session.revoked", guarantee: "transactional" })
   @apigen.auditPayload(CurrentSessionRevokedAuditPayload)
-  @operationId("revokeCurrentSession")
-  revokeCurrentSession(@path session: string): EmptyResponse | CommonErrors;
+  revokeCurrentSession(@path @apigen.target session: string): EmptyResponse | CommonErrors;
 }

--- a/api/typespec/dashboard_publications.tsp
+++ b/api/typespec/dashboard_publications.tsp
@@ -46,74 +46,61 @@ model DashboardPublicationCommandAuditPayload {
   surface: string;
 }
 
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "PUBLICATION_NOT_FOUND", publicDetail: "Dashboard publication not found." })
+model DashboardPublicationNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "conflict", statusCode: 409, code: "PUBLICATION_NOT_CONFIGURED", publicDetail: "Dashboard publication is not present in the active configuration." })
+model DashboardPublicationNotConfiguredFailure {}
+
 @tag("Publications")
 @doc("Dashboard publication discovery and lifecycle commands within a workspace. Publication mutations complete synchronously and return the updated publication; they do not create durable asynchronous executions.")
 @route("/workspaces/{workspace}/dashboard-publications")
+@apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
+@apigen.auditPayload(DashboardPublicationCommandAuditPayload)
 interface DashboardPublications {
   @summary("List dashboard publications in a workspace")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
-  @operationId("listDashboardPublications")
   listDashboardPublications(@path workspace: string): OkJson<DashboardPublicationListResponse> | CommonErrors;
 
   @summary("Get a dashboard publication")
   @route("/{publication}")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
-  @operationId("getDashboardPublication")
   getDashboardPublication(@path workspace: string, @path publication: string): OkJson<DashboardPublicationResponse> | CommonErrors;
 
   @summary("Suspend a dashboard publication immediately")
   @route("/{publication}/suspend")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
   @apigen.ui("dashboard.publication.suspend")
+  @apigen.failsWith(DashboardPublicationNotFoundFailure)
+  @apigen.failsWith(DashboardPublicationNotConfiguredFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "dashboard_publication.suspended", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "PUBLICATION_NOT_FOUND", publicDetail: "Dashboard publication not found." },
-      #{ kind: "conflict", statusCode: 409, code: "PUBLICATION_NOT_CONFIGURED", publicDetail: "Dashboard publication is not present in the active configuration." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Dashboard publication audit could not be persisted." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "dashboard_publication.suspended",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Dashboard publication audit could not be persisted." }],
   })
-  @apigen.auditPayload(DashboardPublicationCommandAuditPayload)
-  @operationId("suspendDashboardPublication")
-  suspendDashboardPublication(@path workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;
+  suspendDashboardPublication(@path @apigen.target workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;
 
   @summary("Resume a configured dashboard publication")
   @route("/{publication}/resume")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
   @apigen.ui("dashboard.publication.resume")
+  @apigen.failsWith(DashboardPublicationNotFoundFailure)
+  @apigen.failsWith(DashboardPublicationNotConfiguredFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "dashboard_publication.resumed", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "PUBLICATION_NOT_FOUND", publicDetail: "Dashboard publication not found." },
-      #{ kind: "conflict", statusCode: 409, code: "PUBLICATION_NOT_CONFIGURED", publicDetail: "Dashboard publication is not present in the active configuration." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Dashboard publication audit could not be persisted." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "dashboard_publication.resumed",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Dashboard publication audit could not be persisted." }],
   })
-  @apigen.auditPayload(DashboardPublicationCommandAuditPayload)
-  @operationId("resumeDashboardPublication")
-  resumeDashboardPublication(@path workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;
+  resumeDashboardPublication(@path @apigen.target workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;
 
   @summary("Rotate a dashboard publication public ID")
   @route("/{publication}/rotate")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "MANAGE_PUBLICATIONS" })
   @apigen.ui("dashboard.publication.rotate")
+  @apigen.failsWith(DashboardPublicationNotFoundFailure)
+  @apigen.failsWith(DashboardPublicationNotConfiguredFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "dashboard_publication.public_id_rotated", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "PUBLICATION_NOT_FOUND", publicDetail: "Dashboard publication not found." },
-      #{ kind: "conflict", statusCode: 409, code: "PUBLICATION_NOT_CONFIGURED", publicDetail: "Dashboard publication is not present in the active configuration." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Dashboard publication audit could not be persisted." },
-    ],
-    targetParameter: "workspace",
+    auditAction: "dashboard_publication.public_id_rotated",
+    failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Dashboard publication audit could not be persisted." }],
   })
-  @apigen.auditPayload(DashboardPublicationCommandAuditPayload)
-  @operationId("rotateDashboardPublication")
-  rotateDashboardPublication(@path workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;
+  rotateDashboardPublication(@path @apigen.target workspace: string, @path publication: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<DashboardPublicationResponse> | CommonErrors;
 }

--- a/api/typespec/deployments.tsp
+++ b/api/typespec/deployments.tsp
@@ -286,51 +286,223 @@ model CandidateSourceBlobAuditPayload {
   sizeBytes: int64;
 }
 
+@apigen.failureDefinition(#{
+  kind: "approval_credential_required",
+  statusCode: 401,
+  code: "ACTIVATION_CREDENTIAL_REQUIRED",
+  publicDetail: "A bounded activation credential is required.",
+})
+model ActivationCredentialRequiredFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "activation_forbidden",
+  statusCode: 403,
+  code: "ACTIVATION_FORBIDDEN",
+  publicDetail: "Deployment activation is forbidden.",
+})
+model ActivationForbiddenFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "approval_credential_expired",
+  statusCode: 401,
+  code: "APPROVAL_CREDENTIAL_EXPIRED",
+  publicDetail: "The deployment approval credential has expired.",
+})
+model ApprovalCredentialExpiredFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "approval_forbidden",
+  statusCode: 403,
+  code: "APPROVAL_FORBIDDEN",
+  publicDetail: "Deployment approval is forbidden.",
+})
+model ApprovalForbiddenFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "audit_unavailable",
+  statusCode: 503,
+  code: "AUDIT_UNAVAILABLE",
+  publicDetail: "Candidate source blob audit is temporarily unavailable.",
+})
+model AuditUnavailableFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "candidate_conflict",
+  statusCode: 409,
+  code: "CANDIDATE_CONFLICT",
+  publicDetail: "The candidate conflicts with its current state.",
+})
+model CandidateConflictFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "candidate_not_found",
+  statusCode: 404,
+  code: "CANDIDATE_NOT_FOUND",
+  publicDetail: "Candidate not found.",
+})
+model CandidateNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "candidate_quota",
+  statusCode: 429,
+  code: "CANDIDATE_QUOTA_EXCEEDED",
+  publicDetail: "Candidate quota exceeded.",
+})
+model CandidateQuotaExceededFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "candidate_unavailable",
+  statusCode: 503,
+  code: "CANDIDATE_SERVICE_UNAVAILABLE",
+  publicDetail: "Candidate service is unavailable.",
+})
+model CandidateServiceUnavailableFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "approval_conflict",
+  statusCode: 409,
+  code: "DEPLOYMENT_APPROVAL_CONFLICT",
+  publicDetail: "The deployment approval conflicts with its current state.",
+})
+model DeploymentApprovalConflictFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "approval_not_found",
+  statusCode: 404,
+  code: "DEPLOYMENT_APPROVAL_NOT_FOUND",
+  publicDetail: "Deployment approval not found.",
+})
+model DeploymentApprovalNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "approval_unavailable",
+  statusCode: 503,
+  code: "DEPLOYMENT_APPROVAL_UNAVAILABLE",
+  publicDetail: "Deployment approvals are unavailable.",
+})
+model DeploymentApprovalUnavailableFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "conflict",
+  statusCode: 409,
+  code: "DEPLOYMENT_CONFLICT",
+  publicDetail: "The deployment conflicts with its current state.",
+})
+model DeploymentConflictFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "not_found",
+  statusCode: 404,
+  code: "DEPLOYMENT_NOT_FOUND",
+  publicDetail: "Deployment not found.",
+})
+model DeploymentNotFoundFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "service_unavailable",
+  statusCode: 503,
+  code: "DEPLOYMENT_SERVICE_UNAVAILABLE",
+  publicDetail: "Deployment service is unavailable.",
+})
+model DeploymentServiceUnavailableFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "candidate_invalid",
+  statusCode: 422,
+  code: "INVALID_CANDIDATE",
+  publicDetail: "The candidate request is invalid.",
+})
+model InvalidCandidateFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "source_blob_invalid",
+  statusCode: 422,
+  code: "INVALID_CANDIDATE_SOURCE_BLOB",
+  publicDetail: "Candidate source blob headers do not match the canonical content identity.",
+})
+model InvalidCandidateSourceBlobFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "invalid",
+  statusCode: 422,
+  code: "INVALID_DEPLOYMENT",
+  publicDetail: "The deployment request is invalid.",
+})
+model InvalidDeploymentFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "publication_forbidden",
+  statusCode: 403,
+  code: "PUBLICATION_MANAGEMENT_REQUIRED",
+  publicDetail: "MANAGE_PUBLICATIONS is required to activate this publication.",
+})
+model PublicationManagementRequiredFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "release_incomplete",
+  statusCode: 409,
+  code: "RELEASE_INCOMPLETE",
+  publicDetail: "The release is missing a workspace artifact.",
+})
+model ReleaseIncompleteFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "release_not_ready",
+  statusCode: 409,
+  code: "RELEASE_NOT_READY",
+  publicDetail: "Only ready releases can be deployed.",
+})
+model ReleaseNotReadyFailure {}
+
+@apigen.failureDefinition(#{
+  kind: "separation_of_duty",
+  statusCode: 409,
+  code: "SEPARATION_OF_DUTY_REQUIRED",
+  publicDetail: "A separate principal must approve this deployment.",
+})
+model SeparationOfDutyRequiredFailure {}
+
 @route("/projects/{project}/deployments")
 @tag("Deployments")
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
 interface Deployments {
   @summary("List project deployments")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("listDeployments")
   listDeployments(@path project: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<DeploymentListResponse> | CommonErrors;
 
   @summary("Deploy a ready project release")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "REQUEST_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.asyncExecution(Deployments.getDeployment, Deployments.listDeploymentEvents, #{
+    guarantee: "transactional",
+    jobKind: "deployment.activate",
+    resourceKind: "deployment",
+    initialEvent: "deployment.queued",
+    initialState: "queued",
+    cancellation: "supported",
+  })
+  @apigen.failsWith(DeploymentNotFoundFailure)
+  @apigen.failsWith(DeploymentConflictFailure)
+  @apigen.failsWith(ReleaseNotReadyFailure)
+  @apigen.failsWith(ReleaseIncompleteFailure)
+  @apigen.failsWith(PublicationManagementRequiredFailure)
+  @apigen.failsWith(DeploymentServiceUnavailableFailure)
+  @apigen.failsWith(DeploymentApprovalUnavailableFailure)
+  @apigen.failsWith(ApprovalCredentialExpiredFailure)
+  @apigen.failsWith(DeploymentApprovalConflictFailure)
+  @apigen.failsWith(InvalidDeploymentFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.queued", guarantee: "best-effort" },
+    auditAction: "deployment.queued",
     failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
-      #{ kind: "conflict", statusCode: 409, code: "DEPLOYMENT_CONFLICT", publicDetail: "The deployment conflicts with its current state." },
-      #{ kind: "release_not_ready", statusCode: 409, code: "RELEASE_NOT_READY", publicDetail: "Only ready releases can be deployed." },
-      #{ kind: "release_incomplete", statusCode: 409, code: "RELEASE_INCOMPLETE", publicDetail: "The release is missing a workspace artifact." },
-      #{ kind: "publication_forbidden", statusCode: 403, code: "PUBLICATION_MANAGEMENT_REQUIRED", publicDetail: "MANAGE_PUBLICATIONS is required to activate this publication." },
       #{ kind: "authorization_unavailable", statusCode: 503, code: "AUTHORIZATION_UNAVAILABLE", publicDetail: "Publication activation authorization could not be evaluated." },
-      #{ kind: "service_unavailable", statusCode: 503, code: "DEPLOYMENT_SERVICE_UNAVAILABLE", publicDetail: "Deployment service is unavailable." },
       #{ kind: "approval_credential_required", statusCode: 401, code: "APPROVAL_CREDENTIAL_REQUIRED", publicDetail: "A bounded publication credential is required." },
-      #{ kind: "approval_unavailable", statusCode: 503, code: "DEPLOYMENT_APPROVAL_UNAVAILABLE", publicDetail: "Deployment approvals are unavailable." },
-      #{ kind: "approval_credential_expired", statusCode: 401, code: "APPROVAL_CREDENTIAL_EXPIRED", publicDetail: "The deployment approval credential has expired." },
-      #{ kind: "approval_conflict", statusCode: 409, code: "DEPLOYMENT_APPROVAL_CONFLICT", publicDetail: "The deployment approval conflicts with its current state." },
       #{ kind: "approval_invalid", statusCode: 422, code: "INVALID_DEPLOYMENT_APPROVAL", publicDetail: "The deployment approval request is invalid." },
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_DEPLOYMENT", publicDetail: "The deployment request is invalid." },
     ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "deployment.activate",
-      resourceKind: "deployment",
-      initialEvent: "deployment.queued",
-      initialState: "queued",
-      statusOperation: "getDeployment",
-      eventsOperation: "listDeploymentEvents",
-      cancellation: "supported",
-    },
   })
   @apigen.auditPayload(DeploymentQueuedAuditPayload)
-  @operationId("createDeployment")
   createDeployment(@path project: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeploymentCreateRequest): AcceptedJson<DeploymentResponse> | CommonErrors;
 
   @summary("Get a project deployment")
@@ -338,7 +510,6 @@ interface Deployments {
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("getDeployment")
   getDeployment(@path project: string, @path deployment: string): OkJson<DeploymentResponse> | CommonErrors;
 
   @summary("List or stream deployment events")
@@ -346,7 +517,6 @@ interface Deployments {
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("listDeploymentEvents")
   listDeploymentEvents(@path project: string, @path deployment: string, @header accept?: string, @header("Last-Event-ID") lastEventId?: string, @query limit?: ListLimit, @query pageToken?: PageToken): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;
 
   @summary("Cancel a deployment before cutover")
@@ -354,241 +524,214 @@ interface Deployments {
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "REQUEST_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(DeploymentNotFoundFailure)
+  @apigen.failsWith(DeploymentConflictFailure)
+  @apigen.failsWith(DeploymentServiceUnavailableFailure)
+  @apigen.failsWith(InvalidDeploymentFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.cancelled", guarantee: "best-effort" },
+    auditAction: "deployment.cancelled",
     failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
-      #{ kind: "conflict", statusCode: 409, code: "DEPLOYMENT_CONFLICT", publicDetail: "The deployment conflicts with its current state." },
-      #{ kind: "service_unavailable", statusCode: 503, code: "DEPLOYMENT_SERVICE_UNAVAILABLE", publicDetail: "Deployment service is unavailable." },
       #{ kind: "queue_unavailable", statusCode: 503, code: "ASYNC_QUEUE_UNAVAILABLE", publicDetail: "Deployment cancellation could not be persisted." },
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_DEPLOYMENT", publicDetail: "The deployment request is invalid." },
     ],
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentCancelledAuditPayload)
-  @operationId("cancelDeployment")
-  cancelDeployment(@path project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
+  cancelDeployment(@path @apigen.target project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
 
   @summary("Retry a terminal publication request without changing its immutable release")
   @route("/{deployment}/retry")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "REQUEST_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.asyncExecution(Deployments.getDeployment, Deployments.listDeploymentEvents, #{
+    guarantee: "transactional",
+    jobKind: "deployment.activate",
+    resourceKind: "deployment",
+    initialEvent: "deployment.queued",
+    initialState: "queued",
+    cancellation: "supported",
+  })
+  @apigen.failsWith(DeploymentNotFoundFailure)
+  @apigen.failsWith(DeploymentConflictFailure)
+  @apigen.failsWith(ReleaseNotReadyFailure)
+  @apigen.failsWith(ReleaseIncompleteFailure)
+  @apigen.failsWith(PublicationManagementRequiredFailure)
+  @apigen.failsWith(DeploymentServiceUnavailableFailure)
+  @apigen.failsWith(InvalidDeploymentFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.queued", guarantee: "best-effort" },
+    auditAction: "deployment.queued",
     failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
-      #{ kind: "conflict", statusCode: 409, code: "DEPLOYMENT_CONFLICT", publicDetail: "The deployment conflicts with its current state." },
-      #{ kind: "release_not_ready", statusCode: 409, code: "RELEASE_NOT_READY", publicDetail: "Only ready releases can be deployed." },
-      #{ kind: "release_incomplete", statusCode: 409, code: "RELEASE_INCOMPLETE", publicDetail: "The release is missing a workspace artifact." },
-      #{ kind: "publication_forbidden", statusCode: 403, code: "PUBLICATION_MANAGEMENT_REQUIRED", publicDetail: "MANAGE_PUBLICATIONS is required to activate this publication." },
       #{ kind: "authorization_unavailable", statusCode: 503, code: "AUTHORIZATION_UNAVAILABLE", publicDetail: "Publication activation authorization could not be evaluated." },
-      #{ kind: "service_unavailable", statusCode: 503, code: "DEPLOYMENT_SERVICE_UNAVAILABLE", publicDetail: "Deployment service is unavailable." },
       #{ kind: "approval_credential_required", statusCode: 401, code: "APPROVAL_CREDENTIAL_REQUIRED", publicDetail: "A bounded publication credential is required." },
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_DEPLOYMENT", publicDetail: "The deployment request is invalid." },
     ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "deployment.activate",
-      resourceKind: "deployment",
-      initialEvent: "deployment.queued",
-      initialState: "queued",
-      statusOperation: "getDeployment",
-      eventsOperation: "listDeploymentEvents",
-      cancellation: "supported",
-    },
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentQueuedAuditPayload)
-  @operationId("retryDeployment")
-  retryDeployment(@path project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
+  retryDeployment(@path @apigen.target project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
 
   @summary("Roll back by creating a deployment of the prior release")
   @route("/{deployment}/rollback")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "ROLLBACK_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.asyncExecution(Deployments.getDeployment, Deployments.listDeploymentEvents, #{
+    guarantee: "transactional",
+    jobKind: "deployment.activate",
+    resourceKind: "deployment",
+    initialEvent: "deployment.queued",
+    initialState: "queued",
+    cancellation: "supported",
+  })
+  @apigen.failsWith(DeploymentNotFoundFailure)
+  @apigen.failsWith(DeploymentConflictFailure)
+  @apigen.failsWith(ReleaseNotReadyFailure)
+  @apigen.failsWith(ReleaseIncompleteFailure)
+  @apigen.failsWith(PublicationManagementRequiredFailure)
+  @apigen.failsWith(DeploymentServiceUnavailableFailure)
+  @apigen.failsWith(InvalidDeploymentFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.queued", guarantee: "best-effort" },
+    auditAction: "deployment.queued",
     failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
-      #{ kind: "conflict", statusCode: 409, code: "DEPLOYMENT_CONFLICT", publicDetail: "The deployment conflicts with its current state." },
-      #{ kind: "release_not_ready", statusCode: 409, code: "RELEASE_NOT_READY", publicDetail: "Only ready releases can be deployed." },
-      #{ kind: "release_incomplete", statusCode: 409, code: "RELEASE_INCOMPLETE", publicDetail: "The release is missing a workspace artifact." },
-      #{ kind: "publication_forbidden", statusCode: 403, code: "PUBLICATION_MANAGEMENT_REQUIRED", publicDetail: "MANAGE_PUBLICATIONS is required to activate this publication." },
       #{ kind: "authorization_unavailable", statusCode: 503, code: "AUTHORIZATION_UNAVAILABLE", publicDetail: "Publication activation authorization could not be evaluated." },
-      #{ kind: "service_unavailable", statusCode: 503, code: "DEPLOYMENT_SERVICE_UNAVAILABLE", publicDetail: "Deployment service is unavailable." },
       #{ kind: "approval_credential_required", statusCode: 401, code: "APPROVAL_CREDENTIAL_REQUIRED", publicDetail: "A bounded publication credential is required." },
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_DEPLOYMENT", publicDetail: "The deployment request is invalid." },
     ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "deployment.activate",
-      resourceKind: "deployment",
-      initialEvent: "deployment.queued",
-      initialState: "queued",
-      statusOperation: "getDeployment",
-      eventsOperation: "listDeploymentEvents",
-      cancellation: "supported",
-    },
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentQueuedAuditPayload)
-  @operationId("rollbackDeployment")
-  rollbackDeployment(@path project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
+  rollbackDeployment(@path @apigen.target project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
 
   @summary("Request approval for an immutable deployment plan")
   @route("/{deployment}/approval-requests")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "REQUEST_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(DeploymentApprovalUnavailableFailure)
+  @apigen.failsWith(DeploymentApprovalNotFoundFailure)
+  @apigen.failsWith(ApprovalCredentialExpiredFailure)
+  @apigen.failsWith(DeploymentConflictFailure)
+  @apigen.failsWith(DeploymentNotFoundFailure)
+  @apigen.failsWith(InvalidDeploymentFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.approval_requested", guarantee: "best-effort" },
+    auditAction: "deployment.approval_requested",
     failures: #[
       #{ kind: "approval_credential_required", statusCode: 401, code: "APPROVAL_CREDENTIAL_REQUIRED", publicDetail: "A bounded publication credential is required." },
-      #{ kind: "approval_unavailable", statusCode: 503, code: "DEPLOYMENT_APPROVAL_UNAVAILABLE", publicDetail: "Deployment approvals are unavailable." },
-      #{ kind: "approval_not_found", statusCode: 404, code: "DEPLOYMENT_APPROVAL_NOT_FOUND", publicDetail: "Deployment approval not found." },
-      #{ kind: "approval_credential_expired", statusCode: 401, code: "APPROVAL_CREDENTIAL_EXPIRED", publicDetail: "The deployment approval credential has expired." },
       #{ kind: "approval_conflict", statusCode: 409, code: "DEPLOYMENT_APPROVAL_REQUIRED", publicDetail: "The deployment approval is not valid for this action." },
-      #{ kind: "conflict", statusCode: 409, code: "DEPLOYMENT_CONFLICT", publicDetail: "The deployment conflicts with its current state." },
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_DEPLOYMENT", publicDetail: "The deployment request is invalid." },
     ],
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentApprovalRequestedAuditPayload)
-  @operationId("requestDeploymentApproval")
-  requestDeploymentApproval(@path project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): CreatedJson<DeploymentApprovalResponse> | CommonErrors;
+  requestDeploymentApproval(@path @apigen.target project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): CreatedJson<DeploymentApprovalResponse> | CommonErrors;
 
   @summary("Approve an immutable deployment plan")
   @route("/{deployment}/approval-requests/{approval}/approve")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "APPROVE_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(DeploymentApprovalUnavailableFailure)
+  @apigen.failsWith(DeploymentApprovalNotFoundFailure)
+  @apigen.failsWith(ApprovalCredentialExpiredFailure)
+  @apigen.failsWith(SeparationOfDutyRequiredFailure)
+  @apigen.failsWith(DeploymentNotFoundFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.approved", guarantee: "best-effort" },
+    auditAction: "deployment.approved",
     failures: #[
       #{ kind: "approval_credential_required", statusCode: 401, code: "APPROVAL_CREDENTIAL_REQUIRED", publicDetail: "A bounded approval credential is required." },
-      #{ kind: "approval_unavailable", statusCode: 503, code: "DEPLOYMENT_APPROVAL_UNAVAILABLE", publicDetail: "Deployment approvals are unavailable." },
-      #{ kind: "approval_not_found", statusCode: 404, code: "DEPLOYMENT_APPROVAL_NOT_FOUND", publicDetail: "Deployment approval not found." },
-      #{ kind: "approval_credential_expired", statusCode: 401, code: "APPROVAL_CREDENTIAL_EXPIRED", publicDetail: "The deployment approval credential has expired." },
       #{ kind: "approval_conflict", statusCode: 409, code: "DEPLOYMENT_APPROVAL_REQUIRED", publicDetail: "The deployment approval is not valid for this action." },
       #{ kind: "approval_invalid", statusCode: 422, code: "INVALID_DEPLOYMENT_APPROVAL", publicDetail: "The deployment approval request is invalid." },
-      #{ kind: "separation_of_duty", statusCode: 409, code: "SEPARATION_OF_DUTY_REQUIRED", publicDetail: "A separate principal must approve this deployment." },
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
     ],
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentApprovalDecisionAuditPayload)
-  @operationId("approveDeployment")
-  approveDeployment(@path project: string, @path deployment: string, @path approval: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeploymentApprovalDecisionRequest): OkJson<DeploymentApprovalResponse> | CommonErrors;
+  approveDeployment(@path @apigen.target project: string, @path deployment: string, @path approval: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeploymentApprovalDecisionRequest): OkJson<DeploymentApprovalResponse> | CommonErrors;
 
   @summary("Deny an immutable deployment plan")
   @route("/{deployment}/approval-requests/{approval}/deny")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "APPROVE_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(DeploymentApprovalUnavailableFailure)
+  @apigen.failsWith(DeploymentApprovalNotFoundFailure)
+  @apigen.failsWith(ApprovalCredentialExpiredFailure)
+  @apigen.failsWith(SeparationOfDutyRequiredFailure)
+  @apigen.failsWith(DeploymentNotFoundFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.denied", guarantee: "best-effort" },
+    auditAction: "deployment.denied",
     failures: #[
       #{ kind: "approval_credential_required", statusCode: 401, code: "APPROVAL_CREDENTIAL_REQUIRED", publicDetail: "A bounded approval credential is required." },
-      #{ kind: "approval_unavailable", statusCode: 503, code: "DEPLOYMENT_APPROVAL_UNAVAILABLE", publicDetail: "Deployment approvals are unavailable." },
-      #{ kind: "approval_not_found", statusCode: 404, code: "DEPLOYMENT_APPROVAL_NOT_FOUND", publicDetail: "Deployment approval not found." },
-      #{ kind: "approval_credential_expired", statusCode: 401, code: "APPROVAL_CREDENTIAL_EXPIRED", publicDetail: "The deployment approval credential has expired." },
       #{ kind: "approval_conflict", statusCode: 409, code: "DEPLOYMENT_APPROVAL_REQUIRED", publicDetail: "The deployment approval is not valid for this action." },
       #{ kind: "approval_invalid", statusCode: 422, code: "INVALID_DEPLOYMENT_APPROVAL", publicDetail: "The deployment approval request is invalid." },
-      #{ kind: "separation_of_duty", statusCode: 409, code: "SEPARATION_OF_DUTY_REQUIRED", publicDetail: "A separate principal must approve this deployment." },
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
     ],
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentApprovalDecisionAuditPayload)
-  @operationId("denyDeploymentApproval")
-  denyDeploymentApproval(@path project: string, @path deployment: string, @path approval: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeploymentApprovalDecisionRequest): OkJson<DeploymentApprovalResponse> | CommonErrors;
+  denyDeploymentApproval(@path @apigen.target project: string, @path deployment: string, @path approval: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeploymentApprovalDecisionRequest): OkJson<DeploymentApprovalResponse> | CommonErrors;
 
   @summary("Revoke a pending or approved deployment decision")
   @route("/{deployment}/approval-requests/{approval}/revoke")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "APPROVE_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(DeploymentApprovalUnavailableFailure)
+  @apigen.failsWith(DeploymentApprovalNotFoundFailure)
+  @apigen.failsWith(ApprovalCredentialExpiredFailure)
+  @apigen.failsWith(SeparationOfDutyRequiredFailure)
+  @apigen.failsWith(DeploymentNotFoundFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.approval_revoked", guarantee: "best-effort" },
+    auditAction: "deployment.approval_revoked",
     failures: #[
       #{ kind: "approval_credential_required", statusCode: 401, code: "APPROVAL_CREDENTIAL_REQUIRED", publicDetail: "A bounded approval credential is required." },
-      #{ kind: "approval_unavailable", statusCode: 503, code: "DEPLOYMENT_APPROVAL_UNAVAILABLE", publicDetail: "Deployment approvals are unavailable." },
-      #{ kind: "approval_not_found", statusCode: 404, code: "DEPLOYMENT_APPROVAL_NOT_FOUND", publicDetail: "Deployment approval not found." },
-      #{ kind: "approval_credential_expired", statusCode: 401, code: "APPROVAL_CREDENTIAL_EXPIRED", publicDetail: "The deployment approval credential has expired." },
       #{ kind: "approval_conflict", statusCode: 409, code: "DEPLOYMENT_APPROVAL_REQUIRED", publicDetail: "The deployment approval is not valid for this action." },
       #{ kind: "approval_invalid", statusCode: 422, code: "INVALID_DEPLOYMENT_APPROVAL", publicDetail: "The deployment approval request is invalid." },
-      #{ kind: "separation_of_duty", statusCode: 409, code: "SEPARATION_OF_DUTY_REQUIRED", publicDetail: "A separate principal must approve this deployment." },
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
     ],
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentApprovalDecisionAuditPayload)
-  @operationId("revokeDeploymentApproval")
-  revokeDeploymentApproval(@path project: string, @path deployment: string, @path approval: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeploymentApprovalDecisionRequest): OkJson<DeploymentApprovalResponse> | CommonErrors;
+  revokeDeploymentApproval(@path @apigen.target project: string, @path deployment: string, @path approval: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: DeploymentApprovalDecisionRequest): OkJson<DeploymentApprovalResponse> | CommonErrors;
 
   @summary("Activate an approved immutable deployment plan")
   @route("/{deployment}/activate")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "ACTIVATE_DEPLOYMENT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.asyncExecution(Deployments.getDeployment, Deployments.listDeploymentEvents, #{
+    guarantee: "transactional",
+    jobKind: "deployment.activate",
+    resourceKind: "deployment",
+    initialEvent: "deployment.activation_requested",
+    initialState: "queued",
+    cancellation: "supported",
+  })
+  @apigen.failsWith(ActivationCredentialRequiredFailure)
+  @apigen.failsWith(DeploymentApprovalUnavailableFailure)
+  @apigen.failsWith(DeploymentApprovalNotFoundFailure)
+  @apigen.failsWith(ApprovalCredentialExpiredFailure)
+  @apigen.failsWith(ActivationForbiddenFailure)
+  @apigen.failsWith(ApprovalForbiddenFailure)
+  @apigen.failsWith(DeploymentNotFoundFailure)
+  @apigen.failsWith(DeploymentConflictFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.activation_requested", guarantee: "best-effort" },
+    auditAction: "deployment.activation_requested",
     failures: #[
-      #{ kind: "approval_credential_required", statusCode: 401, code: "ACTIVATION_CREDENTIAL_REQUIRED", publicDetail: "A bounded activation credential is required." },
-      #{ kind: "approval_unavailable", statusCode: 503, code: "DEPLOYMENT_APPROVAL_UNAVAILABLE", publicDetail: "Deployment approvals are unavailable." },
-      #{ kind: "approval_not_found", statusCode: 404, code: "DEPLOYMENT_APPROVAL_NOT_FOUND", publicDetail: "Deployment approval not found." },
-      #{ kind: "approval_credential_expired", statusCode: 401, code: "APPROVAL_CREDENTIAL_EXPIRED", publicDetail: "The deployment approval credential has expired." },
       #{ kind: "approval_conflict", statusCode: 409, code: "DEPLOYMENT_APPROVAL_REQUIRED", publicDetail: "An approved deployment is required for activation." },
       #{ kind: "approval_invalid", statusCode: 422, code: "INVALID_DEPLOYMENT_APPROVAL", publicDetail: "The deployment approval is invalid." },
-      #{ kind: "activation_forbidden", statusCode: 403, code: "ACTIVATION_FORBIDDEN", publicDetail: "Deployment activation is forbidden." },
-      #{ kind: "approval_forbidden", statusCode: 403, code: "APPROVAL_FORBIDDEN", publicDetail: "Deployment approval is forbidden." },
       #{ kind: "authorization_unavailable", statusCode: 503, code: "AUTHORIZATION_UNAVAILABLE", publicDetail: "Deployment activation authorization could not be evaluated." },
       #{ kind: "queue_unavailable", statusCode: 503, code: "ASYNC_QUEUE_UNAVAILABLE", publicDetail: "Deployment activation could not be persisted." },
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
-      #{ kind: "conflict", statusCode: 409, code: "DEPLOYMENT_CONFLICT", publicDetail: "The deployment conflicts with its current state." },
     ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "deployment.activate",
-      resourceKind: "deployment",
-      initialEvent: "deployment.activation_requested",
-      initialState: "queued",
-      statusOperation: "getDeployment",
-      eventsOperation: "listDeploymentEvents",
-      cancellation: "supported",
-    },
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentQueuedAuditPayload)
-  @operationId("activateDeployment")
-  activateDeployment(@path project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
+  activateDeployment(@path @apigen.target project: string, @path deployment: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<DeploymentResponse> | CommonErrors;
 }
 
 @route("/projects/{project}/candidates")
 @tag("Deployments")
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
 interface ProjectCandidates {
   @summary("Create or resume the current author's private project candidate")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(CandidateServiceUnavailableFailure)
+  @apigen.failsWith(CandidateNotFoundFailure)
+  @apigen.failsWith(CandidateConflictFailure)
+  @apigen.failsWith(CandidateQuotaExceededFailure)
+  @apigen.failsWith(InvalidCandidateFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "candidate.started", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "candidate_unavailable", statusCode: 503, code: "CANDIDATE_SERVICE_UNAVAILABLE", publicDetail: "Candidate service is unavailable." },
-      #{ kind: "candidate_not_found", statusCode: 404, code: "CANDIDATE_NOT_FOUND", publicDetail: "Candidate not found." },
-      #{ kind: "candidate_conflict", statusCode: 409, code: "CANDIDATE_CONFLICT", publicDetail: "The candidate conflicts with its current state." },
-      #{ kind: "candidate_quota", statusCode: 429, code: "CANDIDATE_QUOTA_EXCEEDED", publicDetail: "Candidate quota exceeded." },
-      #{ kind: "candidate_invalid", statusCode: 422, code: "INVALID_CANDIDATE", publicDetail: "The candidate request is invalid." },
-    ],
+    auditAction: "candidate.started",
   })
   @apigen.auditPayload(CandidateAuditPayload)
-  @operationId("startProjectCandidate")
   startProjectCandidate(@path project: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: CandidateStartRequest): CreatedJson<CandidateResponse> | CommonErrors;
 
   @summary("Get an owned private project candidate")
@@ -596,7 +739,6 @@ interface ProjectCandidates {
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("getProjectCandidate")
   getProjectCandidate(@path project: string, @path candidate: string): OkJson<CandidateResponse> | CommonErrors;
 
   @summary("Replace a private candidate artifact with optimistic concurrency")
@@ -604,96 +746,79 @@ interface ProjectCandidates {
   @put
   @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(CandidateServiceUnavailableFailure)
+  @apigen.failsWith(CandidateNotFoundFailure)
+  @apigen.failsWith(CandidateConflictFailure)
+  @apigen.failsWith(InvalidCandidateFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "candidate.artifact_replaced", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "candidate_unavailable", statusCode: 503, code: "CANDIDATE_SERVICE_UNAVAILABLE", publicDetail: "Candidate service is unavailable." },
-      #{ kind: "candidate_not_found", statusCode: 404, code: "CANDIDATE_NOT_FOUND", publicDetail: "Candidate not found." },
-      #{ kind: "candidate_conflict", statusCode: 409, code: "CANDIDATE_CONFLICT", publicDetail: "The candidate conflicts with its current state." },
-      #{ kind: "candidate_invalid", statusCode: 422, code: "INVALID_CANDIDATE", publicDetail: "The candidate request is invalid." },
-    ],
-    targetParameter: "project",
+    auditAction: "candidate.artifact_replaced",
   })
   @apigen.auditPayload(CandidateAuditPayload)
-  @operationId("replaceProjectCandidateArtifact")
-  replaceProjectCandidateArtifact(@path project: string, @path candidate: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: CandidateArtifactRequest): OkJson<CandidateResponse> | CommonErrors;
+  replaceProjectCandidateArtifact(@path @apigen.target project: string, @path candidate: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: CandidateArtifactRequest): OkJson<CandidateResponse> | CommonErrors;
 
   @summary("Retry preparation of a failed private candidate")
   @route("/{candidate}/retry")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(CandidateServiceUnavailableFailure)
+  @apigen.failsWith(CandidateNotFoundFailure)
+  @apigen.failsWith(CandidateConflictFailure)
+  @apigen.failsWith(InvalidCandidateFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "candidate.retried", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "candidate_unavailable", statusCode: 503, code: "CANDIDATE_SERVICE_UNAVAILABLE", publicDetail: "Candidate service is unavailable." },
-      #{ kind: "candidate_not_found", statusCode: 404, code: "CANDIDATE_NOT_FOUND", publicDetail: "Candidate not found." },
-      #{ kind: "candidate_conflict", statusCode: 409, code: "CANDIDATE_CONFLICT", publicDetail: "The candidate conflicts with its current state." },
-      #{ kind: "candidate_invalid", statusCode: 422, code: "INVALID_CANDIDATE", publicDetail: "The candidate request is invalid." },
-    ],
-    targetParameter: "project",
+    auditAction: "candidate.retried",
   })
   @apigen.auditPayload(CandidateAuditPayload)
-  @operationId("retryProjectCandidate")
-  retryProjectCandidate(@path project: string, @path candidate: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<CandidateResponse> | CommonErrors;
+  retryProjectCandidate(@path @apigen.target project: string, @path candidate: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<CandidateResponse> | CommonErrors;
 
   @summary("Cancel an owned private project candidate")
   @route("/{candidate}/cancel")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(CandidateServiceUnavailableFailure)
+  @apigen.failsWith(CandidateNotFoundFailure)
+  @apigen.failsWith(CandidateConflictFailure)
+  @apigen.failsWith(InvalidCandidateFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "candidate.cancelled", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "candidate_unavailable", statusCode: 503, code: "CANDIDATE_SERVICE_UNAVAILABLE", publicDetail: "Candidate service is unavailable." },
-      #{ kind: "candidate_not_found", statusCode: 404, code: "CANDIDATE_NOT_FOUND", publicDetail: "Candidate not found." },
-      #{ kind: "candidate_conflict", statusCode: 409, code: "CANDIDATE_CONFLICT", publicDetail: "The candidate conflicts with its current state." },
-      #{ kind: "candidate_invalid", statusCode: 422, code: "INVALID_CANDIDATE", publicDetail: "The candidate request is invalid." },
-    ],
-    targetParameter: "project",
+    auditAction: "candidate.cancelled",
   })
   @apigen.auditPayload(CandidateAuditPayload)
-  @operationId("cancelProjectCandidate")
-  cancelProjectCandidate(@path project: string, @path candidate: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<CandidateResponse> | CommonErrors;
+  cancelProjectCandidate(@path @apigen.target project: string, @path candidate: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<CandidateResponse> | CommonErrors;
 
   @summary("Publish the exact ready candidate through target policy")
   @route("/{candidate}/publish")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.asyncExecution(Deployments.getDeployment, Deployments.listDeploymentEvents, #{
+    guarantee: "transactional",
+    jobKind: "deployment.activate",
+    resourceKind: "deployment",
+    initialEvent: "deployment.queued",
+    initialState: "queued",
+    cancellation: "supported",
+  })
+  @apigen.failsWith(CandidateServiceUnavailableFailure)
+  @apigen.failsWith(CandidateNotFoundFailure)
+  @apigen.failsWith(CandidateConflictFailure)
+  @apigen.failsWith(InvalidCandidateFailure)
+  @apigen.failsWith(DeploymentNotFoundFailure)
+  @apigen.failsWith(DeploymentConflictFailure)
+  @apigen.failsWith(ReleaseNotReadyFailure)
+  @apigen.failsWith(ReleaseIncompleteFailure)
+  @apigen.failsWith(PublicationManagementRequiredFailure)
+  @apigen.failsWith(DeploymentServiceUnavailableFailure)
+  @apigen.failsWith(InvalidDeploymentFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "deployment.queued", guarantee: "best-effort" },
+    auditAction: "deployment.queued",
     failures: #[
-      #{ kind: "candidate_unavailable", statusCode: 503, code: "CANDIDATE_SERVICE_UNAVAILABLE", publicDetail: "Candidate service is unavailable." },
-      #{ kind: "candidate_not_found", statusCode: 404, code: "CANDIDATE_NOT_FOUND", publicDetail: "Candidate not found." },
-      #{ kind: "candidate_conflict", statusCode: 409, code: "CANDIDATE_CONFLICT", publicDetail: "The candidate conflicts with its current state." },
-      #{ kind: "candidate_invalid", statusCode: 422, code: "INVALID_CANDIDATE", publicDetail: "The candidate request is invalid." },
-      #{ kind: "not_found", statusCode: 404, code: "DEPLOYMENT_NOT_FOUND", publicDetail: "Deployment not found." },
-      #{ kind: "conflict", statusCode: 409, code: "DEPLOYMENT_CONFLICT", publicDetail: "The deployment conflicts with its current state." },
-      #{ kind: "release_not_ready", statusCode: 409, code: "RELEASE_NOT_READY", publicDetail: "Only ready releases can be deployed." },
-      #{ kind: "release_incomplete", statusCode: 409, code: "RELEASE_INCOMPLETE", publicDetail: "The release is missing a workspace artifact." },
-      #{ kind: "publication_forbidden", statusCode: 403, code: "PUBLICATION_MANAGEMENT_REQUIRED", publicDetail: "MANAGE_PUBLICATIONS is required to activate this publication." },
       #{ kind: "authorization_unavailable", statusCode: 503, code: "AUTHORIZATION_UNAVAILABLE", publicDetail: "Publication activation authorization could not be evaluated." },
-      #{ kind: "service_unavailable", statusCode: 503, code: "DEPLOYMENT_SERVICE_UNAVAILABLE", publicDetail: "Deployment service is unavailable." },
       #{ kind: "approval_credential_required", statusCode: 401, code: "APPROVAL_CREDENTIAL_REQUIRED", publicDetail: "A bounded publication credential is required." },
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_DEPLOYMENT", publicDetail: "The deployment request is invalid." },
     ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "deployment.activate",
-      resourceKind: "deployment",
-      initialEvent: "deployment.queued",
-      initialState: "queued",
-      statusOperation: "getDeployment",
-      eventsOperation: "listDeploymentEvents",
-      cancellation: "supported",
-    },
-    targetParameter: "project",
   })
   @apigen.auditPayload(DeploymentQueuedAuditPayload)
-  @operationId("publishProjectCandidate")
-  publishProjectCandidate(@path project: string, @path candidate: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: CandidatePublishRequest): AcceptedJson<DeploymentResponse> | CommonErrors;
+  publishProjectCandidate(@path @apigen.target project: string, @path candidate: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: CandidatePublishRequest): AcceptedJson<DeploymentResponse> | CommonErrors;
 }
 
 @tag("Deployments")
@@ -702,7 +827,6 @@ interface ProjectCandidates {
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "REVIEW_CANDIDATE" })
 @extension("x-leapview-object-scope", "project-environment")
-@operationId("reviewProjectCandidate")
 op reviewProjectCandidate(@path project: string, @path candidate: string): OkJson<CandidateResponse> | CommonErrors;
 
 @tag("Deployments")
@@ -711,31 +835,28 @@ op reviewProjectCandidate(@path project: string, @path candidate: string): OkJso
 @post
 @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
 @extension("x-leapview-object-scope", "project-environment")
+@apigen.failsWith(CandidateServiceUnavailableFailure)
+@apigen.failsWith(CandidateNotFoundFailure)
+@apigen.failsWith(CandidateConflictFailure)
+@apigen.failsWith(InvalidCandidateFailure)
 @apigen.command(#{
-  audit: #{ required: true, successAction: "candidate.cancelled", guarantee: "best-effort" },
-  failures: #[
-    #{ kind: "candidate_unavailable", statusCode: 503, code: "CANDIDATE_SERVICE_UNAVAILABLE", publicDetail: "Candidate service is unavailable." },
-    #{ kind: "candidate_not_found", statusCode: 404, code: "CANDIDATE_NOT_FOUND", publicDetail: "Candidate not found." },
-    #{ kind: "candidate_conflict", statusCode: 409, code: "CANDIDATE_CONFLICT", publicDetail: "The candidate conflicts with its current state." },
-    #{ kind: "candidate_invalid", statusCode: 422, code: "INVALID_CANDIDATE", publicDetail: "The candidate request is invalid." },
-  ],
-  targetParameter: "project",
+  auditAction: "candidate.cancelled",
+  guarantee: "best-effort",
 })
 @apigen.auditPayload(CandidateAuditPayload)
-@operationId("cancelProjectCandidateByKey")
-op cancelProjectCandidateByKey(@path project: string, @path candidateKey: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<CandidateResponse> | CommonErrors;
+op cancelProjectCandidateByKey(@path @apigen.target project: string, @path candidateKey: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): OkJson<CandidateResponse> | CommonErrors;
 
 @route("/projects/{project}/candidate-sync")
 @tag("Deployments")
+@apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
 interface CandidateSynchronization {
   @summary("Plan content-addressed synchronization for the current author's private candidate")
   @doc("Query classification: reports missing immutable blobs without uploading or committing source state.")
   @route("/plan")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
   @extension("x-leapview-object-scope", "project-environment")
   @apigen.query
-  @operationId("planProjectCandidateSynchronization")
   planProjectCandidateSynchronization(
     @path project: string,
     @header("Idempotency-Key") idempotencyKey: IdempotencyKey,
@@ -745,43 +866,30 @@ interface CandidateSynchronization {
   @summary("Upload a missing immutable private-candidate source blob")
   @route("/blobs/{digest}")
   @put
-  @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(CandidateServiceUnavailableFailure)
+  @apigen.failsWith(CandidateConflictFailure)
+  @apigen.failsWith(InvalidCandidateFailure)
+  @apigen.failsWith(InvalidCandidateSourceBlobFailure)
+  @apigen.failsWith(AuditUnavailableFailure)
   @apigen.command(#{
-    audit: #{
-      required: true,
-      successAction: "candidate.source_blob_uploaded",
-      guarantee: "best-effort",
-    },
-    failures: #[
-      #{ kind: "candidate_unavailable", statusCode: 503, code: "CANDIDATE_SERVICE_UNAVAILABLE", publicDetail: "Candidate service is unavailable." },
-      #{ kind: "candidate_conflict", statusCode: 409, code: "CANDIDATE_CONFLICT", publicDetail: "The candidate conflicts with its current state." },
-      #{ kind: "candidate_invalid", statusCode: 422, code: "INVALID_CANDIDATE", publicDetail: "The candidate request is invalid." },
-      #{ kind: "source_blob_invalid", statusCode: 422, code: "INVALID_CANDIDATE_SOURCE_BLOB", publicDetail: "Candidate source blob headers do not match the canonical content identity." },
-      #{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Candidate source blob audit is temporarily unavailable." },
-    ],
-    targetParameter: "project",
+    auditAction: "candidate.source_blob_uploaded",
   })
   @apigen.auditPayload(CandidateSourceBlobAuditPayload)
   @apigen.manual
-  @operationId("uploadProjectCandidateSourceBlob")
-  uploadProjectCandidateSourceBlob(@path project: string, @path digest: string, @header contentType: "application/octet-stream", @header("Content-Digest") contentDigest: string, @body body: bytes): CreatedJson<CandidateSourceBlobResponse> | CommonErrors;
+  uploadProjectCandidateSourceBlob(@path @apigen.target project: string, @path digest: string, @header contentType: "application/octet-stream", @header("Content-Digest") contentDigest: string, @body body: bytes): CreatedJson<CandidateSourceBlobResponse> | CommonErrors;
 
   @summary("Atomically commit a complete source snapshot to the current author's private candidate")
   @route("/commit")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "AUTHOR_PROJECT" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(CandidateServiceUnavailableFailure)
+  @apigen.failsWith(CandidateNotFoundFailure)
+  @apigen.failsWith(CandidateConflictFailure)
+  @apigen.failsWith(InvalidCandidateFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "candidate.ready", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "candidate_unavailable", statusCode: 503, code: "CANDIDATE_SERVICE_UNAVAILABLE", publicDetail: "Candidate service is unavailable." },
-      #{ kind: "candidate_not_found", statusCode: 404, code: "CANDIDATE_NOT_FOUND", publicDetail: "Candidate not found." },
-      #{ kind: "candidate_conflict", statusCode: 409, code: "CANDIDATE_CONFLICT", publicDetail: "The candidate conflicts with its current state." },
-      #{ kind: "candidate_invalid", statusCode: 422, code: "INVALID_CANDIDATE", publicDetail: "The candidate request is invalid." },
-    ],
+    auditAction: "candidate.ready",
   })
   @apigen.auditPayload(CandidateAuditPayload)
-  @operationId("commitProjectCandidateSynchronization")
   commitProjectCandidateSynchronization(@path project: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: CandidateSynchronizationRequest): OkJson<CandidateResponse> | CommonErrors;
 }

--- a/api/typespec/instance.tsp
+++ b/api/typespec/instance.tsp
@@ -18,5 +18,4 @@ alias PublicInstanceErrors = BadRequest | RateLimited | InternalServerError | Se
 @route("/instance")
 @get
 @apigen.authz(#{ mode: "none" })
-@operationId("getInstance")
 op getInstance(): OkJson<InstanceResponse> | PublicInstanceErrors;

--- a/api/typespec/managed_data.tsp
+++ b/api/typespec/managed_data.tsp
@@ -22,6 +22,36 @@ model ManagedDataCommandAuditPayload {
   surface: string;
 }
 
+@apigen.failureDefinition(#{ kind: "invalid", statusCode: 400, code: "MANAGED_DATA_UPLOAD_INVALID", publicDetail: "The managed-data upload request is invalid." })
+model ManagedDataUploadInvalidFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "MANAGED_DATA_UPLOAD_NOT_FOUND", publicDetail: "Managed-data upload resource not found." })
+model ManagedDataUploadNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "conflict", statusCode: 409, code: "MANAGED_DATA_UPLOAD_CONFLICT", publicDetail: "Managed-data upload conflicts with its current state." })
+model ManagedDataUploadConflictFailure {}
+
+@apigen.failureDefinition(#{ kind: "incomplete", statusCode: 409, code: "UPLOAD_INCOMPLETE", publicDetail: "Managed-data upload is incomplete." })
+model ManagedDataUploadIncompleteFailure {}
+
+@apigen.failureDefinition(#{ kind: "expired", statusCode: 409, code: "UPLOAD_EXPIRED", publicDetail: "Managed-data upload has expired." })
+model ManagedDataUploadExpiredFailure {}
+
+@apigen.failureDefinition(#{ kind: "integrity", statusCode: 409, code: "UPLOAD_INTEGRITY_FAILED", publicDetail: "Managed-data upload failed integrity verification." })
+model ManagedDataUploadIntegrityFailure {}
+
+@apigen.failureDefinition(#{ kind: "too_large", statusCode: 413, code: "MANAGED_DATA_UPLOAD_TOO_LARGE", publicDetail: "Managed-data upload request is too large." })
+model ManagedDataUploadTooLargeFailure {}
+
+@apigen.failureDefinition(#{ kind: "backend", statusCode: 502, code: "BACKEND_UNAVAILABLE", publicDetail: "Managed-data storage is unavailable." })
+model ManagedDataBackendUnavailableFailure {}
+
+@apigen.failureDefinition(#{ kind: "unavailable", statusCode: 503, code: "MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE", publicDetail: "Managed-data upload service is unavailable." })
+model ManagedDataUploadUnavailableFailure {}
+
+@apigen.failureDefinition(#{ kind: "internal", statusCode: 500, code: "MANAGED_DATA_UPLOAD_INTERNAL_ERROR", publicDetail: "Managed-data upload could not be completed." })
+model ManagedDataUploadInternalFailure {}
+
 model ManagedConnectionResponse {
   id: string;
   projectId: string;
@@ -43,7 +73,6 @@ interface ManagedConnections {
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("listManagedConnections")
   listManagedConnections(@path project: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ManagedConnectionListResponse> | CommonErrors;
 
   @summary("Describe a project managed connection")
@@ -51,7 +80,6 @@ interface ManagedConnections {
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("getManagedConnection")
   getManagedConnection(@path project: string, @path connection: string): OkJson<ManagedConnectionResponse> | CommonErrors;
 }
 
@@ -274,11 +302,12 @@ model ManagedDataUploadSessionListResponse {
 @tag("Managed Data")
 @doc("Managed-data revision queries and upload-session lifecycle commands. Revision reads, session reads, and event streaming do not mutate durable domain state.")
 @route("/projects/{project}/connections/{connection}")
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
+@apigen.auditPayload(ManagedDataCommandAuditPayload)
 interface ManagedDataLifecycle {
   @summary("Get the active managed-data revision")
   @route("/active-revision")
   @get
-  @operationId("getActiveManagedDataRevision")
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
   getActiveManagedDataRevision(
@@ -289,7 +318,6 @@ interface ManagedDataLifecycle {
   @summary("List immutable managed-data revisions")
   @route("/revisions")
   @get
-  @operationId("listManagedDataRevisions")
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
   listManagedDataRevisions(
@@ -302,7 +330,6 @@ interface ManagedDataLifecycle {
   @summary("Get an immutable managed-data revision")
   @route("/revisions/{revision}")
   @get
-  @operationId("getManagedDataRevision")
   @apigen.authz(#{ mode: "privilege", privilege: "VIEW_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
   getManagedDataRevision(
@@ -314,28 +341,21 @@ interface ManagedDataLifecycle {
   @summary("Create a managed-data upload session from a canonical manifest")
   @route("/upload-sessions")
   @post
-  @operationId("createManagedDataUploadSession")
   @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "managed_data.upload_session.created", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "MANAGED_DATA_UPLOAD_INVALID", publicDetail: "The managed-data upload request is invalid." },
-      #{ kind: "not_found", statusCode: 404, code: "MANAGED_DATA_UPLOAD_NOT_FOUND", publicDetail: "Managed-data upload resource not found." },
-      #{ kind: "conflict", statusCode: 409, code: "MANAGED_DATA_UPLOAD_CONFLICT", publicDetail: "Managed-data upload conflicts with its current state." },
-      #{ kind: "incomplete", statusCode: 409, code: "UPLOAD_INCOMPLETE", publicDetail: "Managed-data upload is incomplete." },
-      #{ kind: "expired", statusCode: 409, code: "UPLOAD_EXPIRED", publicDetail: "Managed-data upload has expired." },
-      #{ kind: "integrity", statusCode: 409, code: "UPLOAD_INTEGRITY_FAILED", publicDetail: "Managed-data upload failed integrity verification." },
-      #{ kind: "too_large", statusCode: 413, code: "MANAGED_DATA_UPLOAD_TOO_LARGE", publicDetail: "Managed-data upload request is too large." },
-      #{ kind: "backend", statusCode: 502, code: "BACKEND_UNAVAILABLE", publicDetail: "Managed-data storage is unavailable." },
-      #{ kind: "unavailable", statusCode: 503, code: "MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE", publicDetail: "Managed-data upload service is unavailable." },
-      #{ kind: "internal", statusCode: 500, code: "MANAGED_DATA_UPLOAD_INTERNAL_ERROR", publicDetail: "Managed-data upload could not be completed." },
-    ],
-    targetParameter: "project",
-  })
-  @apigen.auditPayload(ManagedDataCommandAuditPayload)
+  @apigen.failsWith(ManagedDataUploadInvalidFailure)
+  @apigen.failsWith(ManagedDataUploadNotFoundFailure)
+  @apigen.failsWith(ManagedDataUploadConflictFailure)
+  @apigen.failsWith(ManagedDataUploadIncompleteFailure)
+  @apigen.failsWith(ManagedDataUploadExpiredFailure)
+  @apigen.failsWith(ManagedDataUploadIntegrityFailure)
+  @apigen.failsWith(ManagedDataUploadTooLargeFailure)
+  @apigen.failsWith(ManagedDataBackendUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadInternalFailure)
+  @apigen.command(#{ auditAction: "managed_data.upload_session.created" })
   createManagedDataUploadSession(
-    @path project: ManagedDataProjectId,
+    @path @apigen.target project: ManagedDataProjectId,
     @path connection: ManagedDataConnectionId,
     @header("Idempotency-Key") idempotencyKey: ManagedDataIdempotencyKey,
     @body body: ManagedDataUploadSessionCreateRequest,
@@ -344,7 +364,6 @@ interface ManagedDataLifecycle {
   @summary("List managed-data upload sessions")
   @route("/upload-sessions")
   @get
-  @operationId("listManagedDataUploadSessions")
   @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
   listManagedDataUploadSessions(
@@ -357,7 +376,6 @@ interface ManagedDataLifecycle {
   @summary("Get a managed-data upload session")
   @route("/upload-sessions/{uploadSession}")
   @get
-  @operationId("getManagedDataUploadSession")
   @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
   getManagedDataUploadSession(
@@ -369,28 +387,21 @@ interface ManagedDataLifecycle {
   @summary("Cancel a managed-data upload session")
   @route("/upload-sessions/{uploadSession}/cancel")
   @post
-  @operationId("cancelManagedDataUploadSession")
   @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "managed_data.upload_session.cancelled", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "MANAGED_DATA_UPLOAD_INVALID", publicDetail: "The managed-data upload request is invalid." },
-      #{ kind: "not_found", statusCode: 404, code: "MANAGED_DATA_UPLOAD_NOT_FOUND", publicDetail: "Managed-data upload resource not found." },
-      #{ kind: "conflict", statusCode: 409, code: "MANAGED_DATA_UPLOAD_CONFLICT", publicDetail: "Managed-data upload conflicts with its current state." },
-      #{ kind: "incomplete", statusCode: 409, code: "UPLOAD_INCOMPLETE", publicDetail: "Managed-data upload is incomplete." },
-      #{ kind: "expired", statusCode: 409, code: "UPLOAD_EXPIRED", publicDetail: "Managed-data upload has expired." },
-      #{ kind: "integrity", statusCode: 409, code: "UPLOAD_INTEGRITY_FAILED", publicDetail: "Managed-data upload failed integrity verification." },
-      #{ kind: "too_large", statusCode: 413, code: "MANAGED_DATA_UPLOAD_TOO_LARGE", publicDetail: "Managed-data upload request is too large." },
-      #{ kind: "backend", statusCode: 502, code: "BACKEND_UNAVAILABLE", publicDetail: "Managed-data storage is unavailable." },
-      #{ kind: "unavailable", statusCode: 503, code: "MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE", publicDetail: "Managed-data upload service is unavailable." },
-      #{ kind: "internal", statusCode: 500, code: "MANAGED_DATA_UPLOAD_INTERNAL_ERROR", publicDetail: "Managed-data upload could not be completed." },
-    ],
-    targetParameter: "project",
-  })
-  @apigen.auditPayload(ManagedDataCommandAuditPayload)
+  @apigen.failsWith(ManagedDataUploadInvalidFailure)
+  @apigen.failsWith(ManagedDataUploadNotFoundFailure)
+  @apigen.failsWith(ManagedDataUploadConflictFailure)
+  @apigen.failsWith(ManagedDataUploadIncompleteFailure)
+  @apigen.failsWith(ManagedDataUploadExpiredFailure)
+  @apigen.failsWith(ManagedDataUploadIntegrityFailure)
+  @apigen.failsWith(ManagedDataUploadTooLargeFailure)
+  @apigen.failsWith(ManagedDataBackendUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadInternalFailure)
+  @apigen.command(#{ auditAction: "managed_data.upload_session.cancelled" })
   cancelManagedDataUploadSession(
-    @path project: ManagedDataProjectId,
+    @path @apigen.target project: ManagedDataProjectId,
     @path connection: ManagedDataConnectionId,
     @path uploadSession: ManagedDataUploadSessionId,
     @header("Idempotency-Key") idempotencyKey: ManagedDataIdempotencyKey,
@@ -399,39 +410,29 @@ interface ManagedDataLifecycle {
   @summary("Finalize a managed-data upload session")
   @route("/upload-sessions/{uploadSession}/finalize")
   @post
-  @operationId("finalizeManagedDataUploadSession")
   @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "managed_data.upload_session.finalization_requested", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "MANAGED_DATA_UPLOAD_INVALID", publicDetail: "The managed-data upload request is invalid." },
-      #{ kind: "not_found", statusCode: 404, code: "MANAGED_DATA_UPLOAD_NOT_FOUND", publicDetail: "Managed-data upload resource not found." },
-      #{ kind: "conflict", statusCode: 409, code: "MANAGED_DATA_UPLOAD_CONFLICT", publicDetail: "Managed-data upload conflicts with its current state." },
-      #{ kind: "incomplete", statusCode: 409, code: "UPLOAD_INCOMPLETE", publicDetail: "Managed-data upload is incomplete." },
-      #{ kind: "expired", statusCode: 409, code: "UPLOAD_EXPIRED", publicDetail: "Managed-data upload has expired." },
-      #{ kind: "integrity", statusCode: 409, code: "UPLOAD_INTEGRITY_FAILED", publicDetail: "Managed-data upload failed integrity verification." },
-      #{ kind: "too_large", statusCode: 413, code: "MANAGED_DATA_UPLOAD_TOO_LARGE", publicDetail: "Managed-data upload request is too large." },
-      #{ kind: "backend", statusCode: 502, code: "BACKEND_UNAVAILABLE", publicDetail: "Managed-data storage is unavailable." },
-      #{ kind: "unavailable", statusCode: 503, code: "MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE", publicDetail: "Managed-data upload service is unavailable." },
-      #{ kind: "internal", statusCode: 500, code: "MANAGED_DATA_UPLOAD_INTERNAL_ERROR", publicDetail: "Managed-data upload could not be completed." },
-    ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "upload.finalize",
-      resourceKind: "upload",
-      initialEvent: "upload_session.finalizing",
-      initialState: "finalizing",
-      statusOperation: "getManagedDataUploadSession",
-      eventsOperation: "listManagedDataUploadSessionEvents",
-      cancellation: "unsupported",
-    },
-    targetParameter: "project",
+  @apigen.failsWith(ManagedDataUploadInvalidFailure)
+  @apigen.failsWith(ManagedDataUploadNotFoundFailure)
+  @apigen.failsWith(ManagedDataUploadConflictFailure)
+  @apigen.failsWith(ManagedDataUploadIncompleteFailure)
+  @apigen.failsWith(ManagedDataUploadExpiredFailure)
+  @apigen.failsWith(ManagedDataUploadIntegrityFailure)
+  @apigen.failsWith(ManagedDataUploadTooLargeFailure)
+  @apigen.failsWith(ManagedDataBackendUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadInternalFailure)
+  @apigen.asyncExecution(ManagedDataLifecycle.getManagedDataUploadSession, ManagedDataLifecycle.listManagedDataUploadSessionEvents, #{
+    guarantee: "transactional",
+    jobKind: "upload.finalize",
+    resourceKind: "upload",
+    initialEvent: "upload_session.finalizing",
+    initialState: "finalizing",
+    cancellation: "unsupported",
   })
-  @apigen.auditPayload(ManagedDataCommandAuditPayload)
+  @apigen.command(#{ auditAction: "managed_data.upload_session.finalization_requested" })
   finalizeManagedDataUploadSession(
-    @path project: ManagedDataProjectId,
+    @path @apigen.target project: ManagedDataProjectId,
     @path connection: ManagedDataConnectionId,
     @path uploadSession: ManagedDataUploadSessionId,
     @header("Idempotency-Key") idempotencyKey: ManagedDataIdempotencyKey,
@@ -440,7 +441,6 @@ interface ManagedDataLifecycle {
   @summary("List or stream upload-session events")
   @route("/upload-sessions/{uploadSession}/events")
   @get
-  @operationId("listManagedDataUploadSessionEvents")
   @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
   listManagedDataUploadSessionEvents(

--- a/api/typespec/projects.tsp
+++ b/api/typespec/projects.tsp
@@ -36,7 +36,6 @@ model ProjectWorkspaceListResponse {
 @route("/projects")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-@operationId("listProjects")
 op listProjects(@query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ProjectListResponse> | CommonErrors;
 
 @tag("Projects")
@@ -45,7 +44,6 @@ op listProjects(@query limit?: ListLimit, @query pageToken?: PageToken): OkJson<
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @extension("x-leapview-object-scope", "project-environment")
-@operationId("getProject")
 op getProject(@path project: string): OkJson<ProjectResponse> | CommonErrors;
 
 @tag("Projects")
@@ -54,5 +52,4 @@ op getProject(@path project: string): OkJson<ProjectResponse> | CommonErrors;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "project-environment")
-@operationId("listProjectWorkspaces")
 op listProjectWorkspaces(@path project: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ProjectWorkspaceListResponse> | CommonErrors;

--- a/api/typespec/query_audit.tsp
+++ b/api/typespec/query_audit.tsp
@@ -40,5 +40,4 @@ alias ListQueryEventsOK = OkJson<QueryEventListResponse>;
 @route("/workspaces/{workspace}/query-events")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_AUDIT" })
-@operationId("listQueryEvents")
 op listQueryEvents(@path workspace: string, @query principal?: string, @query surface?: string, @query operation?: string, @query kind?: string, @query modelId?: string, @query target?: string, @query status?: string, @query search?: string, @query from?: utcDateTime, @query to?: utcDateTime, @query limit?: ListLimit, @query pageToken?: PageToken): ListQueryEventsOK | CommonErrors;

--- a/api/typespec/refresh_runs.tsp
+++ b/api/typespec/refresh_runs.tsp
@@ -62,76 +62,78 @@ model RefreshCancelledAuditPayload {
   trigger: string;
 }
 
+@apigen.failureDefinition(#{ kind: "invalid", statusCode: 422, code: "INVALID_REFRESH_RUN", publicDetail: "The refresh run request is invalid." })
+model InvalidRefreshRunFailure {}
+
+@apigen.failureDefinition(#{ kind: "conflict", statusCode: 409, code: "REFRESH_RUN_CONFLICT", publicDetail: "The refresh run conflicts with its current state." })
+model RefreshRunConflictFailure {}
+
+@apigen.failureDefinition(#{ kind: "forbidden", statusCode: 403, code: "REFRESH_RUN_FORBIDDEN", publicDetail: "The refresh run is not permitted." })
+model RefreshRunForbiddenFailure {}
+
+@apigen.failureDefinition(#{ kind: "unavailable", statusCode: 503, code: "REFRESH_SERVICE_UNAVAILABLE", publicDetail: "Refresh service is unavailable." })
+model RefreshServiceUnavailableFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "REFRESH_RUN_NOT_FOUND", publicDetail: "Refresh run not found." })
+model RefreshRunNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_cancellable", statusCode: 409, code: "REFRESH_RUN_NOT_CANCELLABLE", publicDetail: "Only queued refresh runs can be cancelled." })
+model RefreshRunNotCancellableFailure {}
+
 alias ListRefreshRunsOK = OkJson<RefreshRunListResponse>;
 alias CreateRefreshRunAccepted = AcceptedJson<RefreshRunResponse>;
 alias GetRefreshRunOK = OkJson<RefreshRunResponse>;
 
 @route("/workspaces/{workspace}/refresh-runs")
 @tag("Refresh Runs")
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
 interface RefreshRuns {
   @summary("List refresh runs")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-  @operationId("listRefreshRuns")
   listRefreshRuns(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListRefreshRunsOK | CommonErrors;
 
   @summary("Create a refresh run")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "REFRESH_DATA" })
   @apigen.ui("workspace.refresh.run")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "refresh.queued", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_REFRESH_RUN", publicDetail: "The refresh run request is invalid." },
-      #{ kind: "conflict", statusCode: 409, code: "REFRESH_RUN_CONFLICT", publicDetail: "The refresh run conflicts with its current state." },
-      #{ kind: "forbidden", statusCode: 403, code: "REFRESH_RUN_FORBIDDEN", publicDetail: "The refresh run is not permitted." },
-      #{ kind: "unavailable", statusCode: 503, code: "REFRESH_SERVICE_UNAVAILABLE", publicDetail: "Refresh service is unavailable." },
-    ],
-    execution: #{
-      mode: "async",
-      guarantee: "transactional",
-      jobKind: "refresh_pipeline",
-      resourceKind: "refresh",
-      initialEvent: "refresh.queued",
-      initialState: "queued",
-      statusOperation: "getRefreshRun",
-      eventsOperation: "listRefreshRunEvents",
-      cancellation: "supported",
-    },
+  @apigen.failsWith(InvalidRefreshRunFailure)
+  @apigen.failsWith(RefreshRunConflictFailure)
+  @apigen.failsWith(RefreshRunForbiddenFailure)
+  @apigen.failsWith(RefreshServiceUnavailableFailure)
+  @apigen.asyncExecution(RefreshRuns.getRefreshRun, RefreshRuns.listRefreshRunEvents, #{
+    guarantee: "transactional",
+    jobKind: "refresh_pipeline",
+    resourceKind: "refresh",
+    initialEvent: "refresh.queued",
+    initialState: "queued",
+    cancellation: "supported",
   })
+  @apigen.command(#{ auditAction: "refresh.queued" })
   @apigen.auditPayload(RefreshQueuedAuditPayload)
-  @operationId("createRefreshRun")
-  createRefreshRun(@path workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: RefreshRunCreateRequest): CreateRefreshRunAccepted | CommonErrors;
+  createRefreshRun(@path @apigen.target workspace: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: RefreshRunCreateRequest): CreateRefreshRunAccepted | CommonErrors;
 
   @summary("Get a refresh run")
   @route("/{run}")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-  @operationId("getRefreshRun")
   getRefreshRun(@path workspace: string, @path run: string): GetRefreshRunOK | CommonErrors;
 
   @summary("List or stream refresh run events")
   @route("/{run}/events")
   @get
   @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-  @operationId("listRefreshRunEvents")
   listRefreshRunEvents(@path workspace: string, @path run: string, @header accept?: string, @header("Last-Event-ID") lastEventId?: string, @query limit?: ListLimit, @query pageToken?: PageToken): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;
 
   @summary("Cancel a refresh run")
   @route("/{run}/cancel")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "refresh.cancelled", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "not_found", statusCode: 404, code: "REFRESH_RUN_NOT_FOUND", publicDetail: "Refresh run not found." },
-      #{ kind: "forbidden", statusCode: 403, code: "REFRESH_RUN_FORBIDDEN", publicDetail: "The refresh run is not permitted." },
-      #{ kind: "not_cancellable", statusCode: 409, code: "REFRESH_RUN_NOT_CANCELLABLE", publicDetail: "Only queued refresh runs can be cancelled." },
-      #{ kind: "unavailable", statusCode: 503, code: "REFRESH_SERVICE_UNAVAILABLE", publicDetail: "Refresh service is unavailable." },
-    ],
-    targetParameter: "workspace",
-  })
+  @apigen.failsWith(RefreshRunNotFoundFailure)
+  @apigen.failsWith(RefreshRunForbiddenFailure)
+  @apigen.failsWith(RefreshRunNotCancellableFailure)
+  @apigen.failsWith(RefreshServiceUnavailableFailure)
   @apigen.auditPayload(RefreshCancelledAuditPayload)
-  @operationId("cancelRefreshRun")
-  cancelRefreshRun(@path workspace: string, @path run: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<RefreshRunResponse> | CommonErrors;
+  @apigen.command(#{ auditAction: "refresh.cancelled" })
+  cancelRefreshRun(@path @apigen.target workspace: string, @path run: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey): AcceptedJson<RefreshRunResponse> | CommonErrors;
 }

--- a/api/typespec/releases.tsp
+++ b/api/typespec/releases.tsp
@@ -172,64 +172,64 @@ model ReleaseValidatingAuditPayload {
   status: string;
 }
 
+@apigen.failureDefinition(#{ kind: "conflict", statusCode: 409, code: "RELEASE_CONFLICT", publicDetail: "The release conflicts with its current state." })
+model ReleaseConflictFailure {}
+
+@apigen.failureDefinition(#{ kind: "immutable", statusCode: 409, code: "RELEASE_IMMUTABLE", publicDetail: "The release is immutable." })
+model ReleaseImmutableFailure {}
+
+@apigen.failureDefinition(#{ kind: "digest_mismatch", statusCode: 422, code: "CONTENT_DIGEST_MISMATCH", publicDetail: "The release artifact digest does not match the expected content." })
+model ReleaseArtifactDigestMismatchFailure {}
+
 @route("/projects/{project}/releases")
 @tag("Releases")
+@apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
 interface Releases {
   @summary("List project releases")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("listReleases")
   listReleases(@path project: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<ReleaseListResponse> | CommonErrors;
 
   @summary("Create a draft project release")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(ReleaseConflictFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "release.created", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 422, code: "INVALID_RELEASE", publicDetail: "The release request is invalid." },
-      #{ kind: "conflict", statusCode: 409, code: "RELEASE_CONFLICT", publicDetail: "The release conflicts with its current state." },
-    ],
+    auditAction: "release.created",
+    guarantee: "best-effort",
+    failures: #[#{ kind: "invalid", statusCode: 422, code: "INVALID_RELEASE", publicDetail: "The release request is invalid." }],
   })
   @apigen.auditPayload(ReleaseCreatedAuditPayload)
-  @operationId("createRelease")
-  createRelease(@path project: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: ReleaseCreateRequest): CreatedJson<ReleaseResponse> | CommonErrors;
+  createRelease(@path @apigen.target project: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: ReleaseCreateRequest): CreatedJson<ReleaseResponse> | CommonErrors;
 
   @summary("Get a project release")
   @route("/{release}")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("getRelease")
   getRelease(@path project: string, @path release: string): OkJson<ReleaseResponse> | CommonErrors;
 
   @summary("Upload an immutable workspace artifact")
   @route("/{release}/workspaces/{workspace}/artifact")
   @put
-  @apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
   @extension("x-leapview-object-scope", "project-environment")
+  @apigen.failsWith(ReleaseConflictFailure)
+  @apigen.failsWith(ReleaseImmutableFailure)
+  @apigen.failsWith(ReleaseArtifactDigestMismatchFailure)
   @apigen.command(#{
-    audit: #{ required: true, successAction: "release.artifact_uploaded", guarantee: "best-effort" },
+    auditAction: "release.artifact_uploaded",
+    guarantee: "best-effort",
     failures: #[
       #{ kind: "invalid", statusCode: 422, code: "INVALID_RELEASE", publicDetail: "The release artifact request is invalid." },
       #{ kind: "not_found", statusCode: 404, code: "RELEASE_NOT_FOUND", publicDetail: "Release or workspace artifact not found." },
-      #{ kind: "conflict", statusCode: 409, code: "RELEASE_CONFLICT", publicDetail: "The release conflicts with its current state." },
-      #{ kind: "immutable", statusCode: 409, code: "RELEASE_IMMUTABLE", publicDetail: "The release is immutable." },
-      #{ kind: "digest_mismatch", statusCode: 422, code: "CONTENT_DIGEST_MISMATCH", publicDetail: "The release artifact digest does not match the expected content." },
     ],
-    targetParameter: "project",
   })
   @apigen.auditPayload(ReleaseArtifactUploadedAuditPayload)
   @apigen.manual
-  @operationId("uploadReleaseArtifact")
-  uploadReleaseArtifact(@path project: string, @path release: string, @path workspace: string, @header contentType: "application/octet-stream", @header("Content-Digest") contentDigest: string, @body body: bytes): CreatedJson<ReleaseArtifactResponse> | CommonErrors;
+  uploadReleaseArtifact(@path @apigen.target project: string, @path release: string, @path workspace: string, @header contentType: "application/octet-stream", @header("Content-Digest") contentDigest: string, @body body: bytes): CreatedJson<ReleaseArtifactResponse> | CommonErrors;
 
   @summary("Finalize and validate a release")
   @route("/{release}/finalize")
   @post
-  @apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
   @extension("x-leapview-object-scope", "project-environment")
   @apigen.asyncExecution(Releases.getRelease, Releases.listReleaseEvents, #{
     guarantee: "transactional",
@@ -239,12 +239,12 @@ interface Releases {
     initialState: "validating",
     cancellation: "unsupported",
   })
+  @apigen.failsWith(ReleaseConflictFailure)
+  @apigen.failsWith(ReleaseImmutableFailure)
   @apigen.command(#{
     auditAction: "release.validating",
     guarantee: "transactional",
     failures: #[
-      #{ kind: "conflict", statusCode: 409, code: "RELEASE_CONFLICT", publicDetail: "The release conflicts with its current state." },
-      #{ kind: "immutable", statusCode: 409, code: "RELEASE_IMMUTABLE", publicDetail: "The release is immutable." },
       #{ kind: "incomplete", statusCode: 409, code: "RELEASE_INCOMPLETE", publicDetail: "The release artifacts are incomplete." },
       #{ kind: "not_found", statusCode: 404, code: "RELEASE_NOT_FOUND", publicDetail: "Release not found." },
       #{ kind: "queue_unavailable", statusCode: 503, code: "ASYNC_QUEUE_UNAVAILABLE", publicDetail: "Release finalization could not be queued." },
@@ -256,8 +256,6 @@ interface Releases {
   @summary("List or stream release events")
   @route("/{release}/events")
   @get
-  @apigen.authz(#{ mode: "privilege", privilege: "PUBLISH_RELEASE" })
   @extension("x-leapview-object-scope", "project-environment")
-  @operationId("listReleaseEvents")
   listReleaseEvents(@path project: string, @path release: string, @header accept?: string, @header("Last-Event-ID") lastEventId?: string, @query limit?: ListLimit, @query pageToken?: PageToken): EventHistoryResponse<AsyncEventListResponse> | CommonErrors;
 }

--- a/api/typespec/search.tsp
+++ b/api/typespec/search.tsp
@@ -69,7 +69,6 @@ alias SearchOK = OkJson<SearchResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @apigen.cli(#{ command: #["search"], args: #[#{ source: "query", name: "q", displayName: "query" }], output: #{ mode: "raw" } })
-@operationId("search")
 op search(
   @query q?: string,
   @query workspace?: string[],

--- a/api/typespec/upload_s3_multipart.tsp
+++ b/api/typespec/upload_s3_multipart.tsp
@@ -90,30 +90,25 @@ model ManagedDataS3MultipartCompleteRequest {
 @tag("Managed Data")
 @doc("S3 multipart transport lifecycle. Part signing is a query because it issues transient upload authorization without mutating durable multipart state.")
 @route("/projects/{project}/connections/{connection}/upload-sessions/{uploadSession}/s3-multipart-uploads")
+@apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
+@apigen.commandDefaults(#{ guarantee: "best-effort" })
+@apigen.auditPayload(ManagedDataS3MultipartAuditPayload)
 interface ManagedDataS3MultipartUploads {
   @summary("Create an S3 multipart upload for a session file")
   @post
-  @operationId("createManagedDataS3MultipartUpload")
-  @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "managed_data.s3_multipart_upload.created", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "MANAGED_DATA_UPLOAD_INVALID", publicDetail: "The managed-data upload request is invalid." },
-      #{ kind: "not_found", statusCode: 404, code: "MANAGED_DATA_UPLOAD_NOT_FOUND", publicDetail: "Managed-data upload resource not found." },
-      #{ kind: "conflict", statusCode: 409, code: "MANAGED_DATA_UPLOAD_CONFLICT", publicDetail: "Managed-data upload conflicts with its current state." },
-      #{ kind: "incomplete", statusCode: 409, code: "UPLOAD_INCOMPLETE", publicDetail: "Managed-data upload is incomplete." },
-      #{ kind: "expired", statusCode: 409, code: "UPLOAD_EXPIRED", publicDetail: "Managed-data upload has expired." },
-      #{ kind: "integrity", statusCode: 409, code: "UPLOAD_INTEGRITY_FAILED", publicDetail: "Managed-data upload failed integrity verification." },
-      #{ kind: "backend", statusCode: 502, code: "BACKEND_UNAVAILABLE", publicDetail: "Managed-data storage is unavailable." },
-      #{ kind: "unavailable", statusCode: 503, code: "MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE", publicDetail: "Managed-data upload service is unavailable." },
-      #{ kind: "internal", statusCode: 500, code: "MANAGED_DATA_UPLOAD_INTERNAL_ERROR", publicDetail: "Managed-data upload could not be completed." },
-    ],
-    targetParameter: "project",
-  })
-  @apigen.auditPayload(ManagedDataS3MultipartAuditPayload)
+  @apigen.failsWith(ManagedDataUploadInvalidFailure)
+  @apigen.failsWith(ManagedDataUploadNotFoundFailure)
+  @apigen.failsWith(ManagedDataUploadConflictFailure)
+  @apigen.failsWith(ManagedDataUploadIncompleteFailure)
+  @apigen.failsWith(ManagedDataUploadExpiredFailure)
+  @apigen.failsWith(ManagedDataUploadIntegrityFailure)
+  @apigen.failsWith(ManagedDataBackendUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadInternalFailure)
+  @apigen.command(#{ auditAction: "managed_data.s3_multipart_upload.created" })
   createManagedDataS3MultipartUpload(
-    @path project: ManagedDataProjectId,
+    @path @apigen.target project: ManagedDataProjectId,
     @path connection: ManagedDataConnectionId,
     @path uploadSession: ManagedDataUploadSessionId,
     @header("Idempotency-Key") idempotencyKey: ManagedDataIdempotencyKey,
@@ -124,7 +119,6 @@ interface ManagedDataS3MultipartUploads {
   @doc("Query: issues a short-lived signed part-upload request and does not change durable multipart state.")
   @route("/{multipartUpload}/parts/{partNumber}/sign")
   @post
-  @operationId("signManagedDataS3MultipartPart")
   @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @apigen.query
   @extension("x-leapview-object-scope", "project-environment")
@@ -141,28 +135,20 @@ interface ManagedDataS3MultipartUploads {
   @summary("Complete an S3 multipart upload")
   @route("/{multipartUpload}/complete")
   @post
-  @operationId("completeManagedDataS3MultipartUpload")
-  @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "managed_data.s3_multipart_upload.completed", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "MANAGED_DATA_UPLOAD_INVALID", publicDetail: "The managed-data upload request is invalid." },
-      #{ kind: "not_found", statusCode: 404, code: "MANAGED_DATA_UPLOAD_NOT_FOUND", publicDetail: "Managed-data upload resource not found." },
-      #{ kind: "conflict", statusCode: 409, code: "MANAGED_DATA_UPLOAD_CONFLICT", publicDetail: "Managed-data upload conflicts with its current state." },
-      #{ kind: "incomplete", statusCode: 409, code: "UPLOAD_INCOMPLETE", publicDetail: "Managed-data upload is incomplete." },
-      #{ kind: "expired", statusCode: 409, code: "UPLOAD_EXPIRED", publicDetail: "Managed-data upload has expired." },
-      #{ kind: "integrity", statusCode: 409, code: "UPLOAD_INTEGRITY_FAILED", publicDetail: "Managed-data upload failed integrity verification." },
-      #{ kind: "too_large", statusCode: 413, code: "MANAGED_DATA_UPLOAD_TOO_LARGE", publicDetail: "Managed-data upload request is too large." },
-      #{ kind: "backend", statusCode: 502, code: "BACKEND_UNAVAILABLE", publicDetail: "Managed-data storage is unavailable." },
-      #{ kind: "unavailable", statusCode: 503, code: "MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE", publicDetail: "Managed-data upload service is unavailable." },
-      #{ kind: "internal", statusCode: 500, code: "MANAGED_DATA_UPLOAD_INTERNAL_ERROR", publicDetail: "Managed-data upload could not be completed." },
-    ],
-    targetParameter: "project",
-  })
-  @apigen.auditPayload(ManagedDataS3MultipartAuditPayload)
+  @apigen.failsWith(ManagedDataUploadInvalidFailure)
+  @apigen.failsWith(ManagedDataUploadNotFoundFailure)
+  @apigen.failsWith(ManagedDataUploadConflictFailure)
+  @apigen.failsWith(ManagedDataUploadIncompleteFailure)
+  @apigen.failsWith(ManagedDataUploadExpiredFailure)
+  @apigen.failsWith(ManagedDataUploadIntegrityFailure)
+  @apigen.failsWith(ManagedDataUploadTooLargeFailure)
+  @apigen.failsWith(ManagedDataBackendUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadInternalFailure)
+  @apigen.command(#{ auditAction: "managed_data.s3_multipart_upload.completed" })
   completeManagedDataS3MultipartUpload(
-    @path project: ManagedDataProjectId,
+    @path @apigen.target project: ManagedDataProjectId,
     @path connection: ManagedDataConnectionId,
     @path uploadSession: ManagedDataUploadSessionId,
     @path multipartUpload: ManagedDataMultipartUploadId,
@@ -173,27 +159,19 @@ interface ManagedDataS3MultipartUploads {
   @summary("Abort an S3 multipart upload")
   @route("/{multipartUpload}/abort")
   @post
-  @operationId("abortManagedDataS3MultipartUpload")
-  @apigen.authz(#{ mode: "privilege", privilege: "INGEST_DATA" })
   @extension("x-leapview-object-scope", "project-environment")
-  @apigen.command(#{
-    audit: #{ required: true, successAction: "managed_data.s3_multipart_upload.aborted", guarantee: "best-effort" },
-    failures: #[
-      #{ kind: "invalid", statusCode: 400, code: "MANAGED_DATA_UPLOAD_INVALID", publicDetail: "The managed-data upload request is invalid." },
-      #{ kind: "not_found", statusCode: 404, code: "MANAGED_DATA_UPLOAD_NOT_FOUND", publicDetail: "Managed-data upload resource not found." },
-      #{ kind: "conflict", statusCode: 409, code: "MANAGED_DATA_UPLOAD_CONFLICT", publicDetail: "Managed-data upload conflicts with its current state." },
-      #{ kind: "incomplete", statusCode: 409, code: "UPLOAD_INCOMPLETE", publicDetail: "Managed-data upload is incomplete." },
-      #{ kind: "expired", statusCode: 409, code: "UPLOAD_EXPIRED", publicDetail: "Managed-data upload has expired." },
-      #{ kind: "integrity", statusCode: 409, code: "UPLOAD_INTEGRITY_FAILED", publicDetail: "Managed-data upload failed integrity verification." },
-      #{ kind: "backend", statusCode: 502, code: "BACKEND_UNAVAILABLE", publicDetail: "Managed-data storage is unavailable." },
-      #{ kind: "unavailable", statusCode: 503, code: "MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE", publicDetail: "Managed-data upload service is unavailable." },
-      #{ kind: "internal", statusCode: 500, code: "MANAGED_DATA_UPLOAD_INTERNAL_ERROR", publicDetail: "Managed-data upload could not be completed." },
-    ],
-    targetParameter: "project",
-  })
-  @apigen.auditPayload(ManagedDataS3MultipartAuditPayload)
+  @apigen.failsWith(ManagedDataUploadInvalidFailure)
+  @apigen.failsWith(ManagedDataUploadNotFoundFailure)
+  @apigen.failsWith(ManagedDataUploadConflictFailure)
+  @apigen.failsWith(ManagedDataUploadIncompleteFailure)
+  @apigen.failsWith(ManagedDataUploadExpiredFailure)
+  @apigen.failsWith(ManagedDataUploadIntegrityFailure)
+  @apigen.failsWith(ManagedDataBackendUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadUnavailableFailure)
+  @apigen.failsWith(ManagedDataUploadInternalFailure)
+  @apigen.command(#{ auditAction: "managed_data.s3_multipart_upload.aborted" })
   abortManagedDataS3MultipartUpload(
-    @path project: ManagedDataProjectId,
+    @path @apigen.target project: ManagedDataProjectId,
     @path connection: ManagedDataConnectionId,
     @path uploadSession: ManagedDataUploadSessionId,
     @path multipartUpload: ManagedDataMultipartUploadId,

--- a/api/typespec/workspaces.tsp
+++ b/api/typespec/workspaces.tsp
@@ -104,7 +104,6 @@ alias ListWorkspacesOK = OkJson<WorkspaceListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @apigen.cli(#{ command: #["workspaces", "list"], output: #{ mode: "raw" } })
-@operationId("listWorkspaces")
 op listWorkspaces(@query limit?: ListLimit, @query pageToken?: PageToken): ListWorkspacesOK | CommonErrors;
 
 @tag("Workspaces")
@@ -112,7 +111,6 @@ op listWorkspaces(@query limit?: ListLimit, @query pageToken?: PageToken): ListW
 @route("/workspaces/{workspace}")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
-@operationId("getWorkspace")
 op getWorkspace(@path workspace: string): OkJson<WorkspaceResponse> | CommonErrors;
 
 alias ListWorkspaceAssetEdgesOK = OkJson<AssetEdgeListResponse>;
@@ -123,7 +121,6 @@ alias ListWorkspaceAssetEdgesOK = OkJson<AssetEdgeListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @apigen.cli(#{ command: #["assets", "edges"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@operationId("listWorkspaceAssetEdges")
 op listWorkspaceAssetEdges(@path workspace: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListWorkspaceAssetEdgesOK | CommonErrors;
 
 alias ListWorkspaceAssetsOK = OkJson<AssetListResponse>;
@@ -134,7 +131,6 @@ alias ListWorkspaceAssetsOK = OkJson<AssetListResponse>;
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
 @apigen.cli(#{ command: #["assets", "list"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }], output: #{ mode: "raw" } })
-@operationId("listWorkspaceAssets")
 op listWorkspaceAssets(@path workspace: string, @query type?: string, @query q?: string, @query limit?: ListLimit, @query pageToken?: PageToken): ListWorkspaceAssetsOK | CommonErrors;
 
 @tag("Workspaces")
@@ -142,7 +138,6 @@ op listWorkspaceAssets(@path workspace: string, @query type?: string, @query q?:
 @route("/workspaces/{workspace}/active-asset-graph")
 @get
 @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
-@operationId("getWorkspaceActiveAssetGraph")
 op getWorkspaceActiveAssetGraph(@path workspace: string): OkJson<WorkspaceAssetGraphResponse> | CommonErrors;
 
 @tag("Workspaces")
@@ -152,7 +147,6 @@ op getWorkspaceActiveAssetGraph(@path workspace: string): OkJson<WorkspaceAssetG
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "workspace-asset")
 @apigen.cli(#{ command: #["assets", "describe"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "assetId", displayName: "asset-id" }], output: #{ mode: "raw" } })
-@operationId("getWorkspaceAsset")
 op getWorkspaceAsset(@path workspace: string, @path assetId: string): OkJson<AssetResponse> | CommonErrors;
 
 @tag("Workspaces")
@@ -162,5 +156,4 @@ op getWorkspaceAsset(@path workspace: string, @path assetId: string): OkJson<Ass
 @apigen.authz(#{ mode: "privilege", privilege: "VIEW_ITEM" })
 @extension("x-leapview-object-scope", "workspace-asset")
 @apigen.cli(#{ command: #["assets", "lineage"], args: #[#{ source: "path", name: "workspace", displayName: "workspace" }, #{ source: "path", name: "assetId", displayName: "asset-id" }], output: #{ mode: "raw" } })
-@operationId("getWorkspaceAssetLineage")
 op getWorkspaceAssetLineage(@path workspace: string, @path assetId: string): OkJson<AssetLineageResponse> | CommonErrors;

--- a/internal/app/apigen_authoring_contract_test.go
+++ b/internal/app/apigen_authoring_contract_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var (
+	legacyAuditPattern          = regexp.MustCompile(`(?m)^\s*audit:\s*#\{`)
+	legacyTargetPattern         = regexp.MustCompile(`(?m)^\s*targetParameter\s*:`)
+	legacyAsyncReferencePattern = regexp.MustCompile(`(?m)^\s*(statusOperation|eventsOperation)\s*:`)
+	redundantOperationIDPattern = regexp.MustCompile(`(?m)@operationId\("([A-Za-z_][A-Za-z0-9_]*)"\)\s*(?:\r?\n\s*@[^(\r\n]+(?:\([^\r\n]*\))?\s*)*\r?\n\s*(?:op\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\(`)
+)
+
+func TestAPIGenTypeSpecUsesErgonomicCommandAuthoring(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join("..", "..", "api", "typespec")
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".tsp" {
+			return nil
+		}
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		source := string(contents)
+		relative := filepath.ToSlash(path)
+		for _, check := range []struct {
+			pattern *regexp.Regexp
+			message string
+		}{
+			{legacyAuditPattern, "legacy nested command audit; use auditAction/guarantee and interface defaults"},
+			{legacyTargetPattern, "string targetParameter; annotate the path parameter with @apigen.target"},
+			{legacyAsyncReferencePattern, "string async operation reference; use @apigen.asyncExecution"},
+		} {
+			if location := check.pattern.FindStringIndex(source); location != nil {
+				t.Errorf("%s:%d contains %s", relative, sourceLine(source, location[0]), check.message)
+			}
+		}
+		for _, match := range redundantOperationIDPattern.FindAllStringSubmatchIndex(source, -1) {
+			operationID := source[match[2]:match[3]]
+			operationName := source[match[4]:match[5]]
+			if operationID == operationName {
+				t.Errorf(
+					"%s:%d repeats operation ID %q; APIGen infers it from the operation declaration",
+					relative,
+					sourceLine(source, match[0]),
+					operationID,
+				)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sourceLine(source string, offset int) int {
+	return strings.Count(source[:offset], "\n") + 1
+}


### PR DESCRIPTION
## Summary

- migrate all 73 TypeSpec command contracts to concise audited command authoring
- replace every string target and async operation link with compiler-resolved references
- remove all 160 redundant explicit operation IDs across commands and queries
- consolidate identical command failures into 82 named definitions and 258 typed references
- add a CI guard rejecting regression to legacy audit, target, async-reference, and redundant operation-ID syntax

## Contract safety

The migration preserves existing public behavior. After regeneration, both `api/gen/json-ir.json` and `api/gen/openapi.yaml` are byte-for-byte identical to the pre-migration baseline. Existing same-code failure variants with different status/detail remain inline rather than being silently normalized.

## Validation

- `task api:generate`
- byte comparison of generated JSON IR and OpenAPI against the pre-migration baseline
- `task apigen:test`
- `go test ./internal/app -run TestAPIGenTypeSpecUsesErgonomicCommandAuthoring -count=1`
- `task ci`

## Stack

Depends on #283. This PR contains only the repository-wide contract migration and its anti-regression guard.