### PR TITLE
Improve responsive dashboard viewing controls

### DIFF
--- a/internal/dashboard/ui/page.go
+++ b/internal/dashboard/ui/page.go
@@ -315,7 +315,7 @@ func PublicBootstrapSignals(clientID, streamInstanceID, publicID, presentation s
 
 func dashboardLayoutContext(catalog dashboard.Catalog, report dashboarddefinition.Definition, model *semanticmodel.Model, activePage dashboard.Page) webpage.Context {
 	context := webpage.Context{
-		Active: "workspaces", ScopeID: catalog.Workspace.ID, ScopeTitle: catalog.Workspace.Title,
+		Active: "dashboards", ScopeID: catalog.Workspace.ID, ScopeTitle: catalog.Workspace.Title,
 		SectionID: report.ID, SectionTitle: report.Title,
 		PageID: activePage.ID, PageTitle: activePage.Title, Compact: true,
 	}

--- a/internal/dashboard/ui/page_test.go
+++ b/internal/dashboard/ui/page_test.go
@@ -34,6 +34,19 @@ func fieldRefs(fields ...string) []reportdef.FieldRef {
 	return refs
 }
 
+func TestDashboardLayoutContextSelectsDashboardsNavigation(t *testing.T) {
+	context := dashboardLayoutContext(
+		dashboard.Catalog{Workspace: dashboard.CatalogWorkspace{ID: "sales", Title: "Sales"}},
+		dashboarddefinition.Definition{ID: "executive-sales", Title: "Executive Sales"},
+		nil,
+		dashboard.Page{ID: "overview", Title: "Overview"},
+	)
+
+	if context.Active != "dashboards" {
+		t.Fatalf("active navigation = %q, want dashboards", context.Active)
+	}
+}
+
 func TestPageInitialSignalsArePageScoped(t *testing.T) {
 	report := reportdef.Dashboard{
 		ID:            "report",

--- a/web/components/app/app-shell.dom.test.ts
+++ b/web/components/app/app-shell.dom.test.ts
@@ -232,6 +232,7 @@ test('mobile navigation opens in an accessible drawer', async () => {
       const sidebarBox = sidebar.getBoundingClientRect()
       const mainBox = main.getBoundingClientRect()
       return {
+        documentOverflow: document.documentElement.scrollHeight - window.innerHeight,
         sidebarWidth: Math.round(sidebarBox.width),
         mainX: Math.round(mainBox.x),
         mainY: Math.round(mainBox.y),
@@ -250,6 +251,7 @@ test('mobile navigation opens in an accessible drawer', async () => {
       }
     })
 
+    expect(state.documentOverflow).toBe(0)
     expect(state.sidebarWidth).toBe(553)
     expect(state.mainX).toBe(0)
     expect(state.mainY).toBe(state.sidebarBottom)

--- a/web/components/app/app-shell.ts
+++ b/web/components/app/app-shell.ts
@@ -47,13 +47,31 @@ class LeapViewAppShell extends DatastarLit(LitElement) {
 
     @media (max-width: 640px) {
       :host {
+        height: 100svh;
+        min-height: 0;
         grid-template-columns: 1fr;
+        grid-template-rows: auto minmax(0, 1fr);
+        overflow: hidden;
       }
 
       lv-sidebar {
         border-right: 0;
         border-bottom: var(--lv-border-default);
         min-width: 0;
+      }
+
+      main {
+        min-height: 0;
+        overflow-y: auto;
+      }
+
+      ::slotted([slot='page']) {
+        min-height: 100%;
+      }
+
+      ::slotted(lv-dashboard-page[slot='page']) {
+        height: 100%;
+        min-height: 0;
       }
     }
   `

--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -75,6 +75,7 @@ for (const viewport of [{ name: 'desktop', width: 1280, height: 820 }, { name: '
         const kpiValue = kpi?.querySelector('.lv-visualization-kpi') as HTMLElement | null
         const canvas = root.querySelector('lv-report-canvas') as any
         await canvas.updateComplete
+        const canvasViewport = canvas.shadowRoot.querySelector('.viewport') as HTMLElement
         const assigned = (canvas.shadowRoot.querySelector('slot') as HTMLSlotElement).assignedElements() as HTMLElement[]
         const visualFrame = (id: string) => assigned.find((item) => (item.querySelector('lv-visualization-host') as any)?.envelope?.visualID === id)?.getBoundingClientRect()
         const chart = visualFrame('orders_chart')
@@ -101,6 +102,9 @@ for (const viewport of [{ name: 'desktop', width: 1280, height: 820 }, { name: '
             labelSize: kpiLabel ? Number.parseFloat(getComputedStyle(kpiLabel).fontSize) : 0,
           },
           presentationMode: canvas.shadowRoot.querySelector('.surface')?.dataset.presentationMode,
+          canvasScrollbarWidth: getComputedStyle(canvasViewport, '::-webkit-scrollbar').width,
+          canvasScrollbarTrack: getComputedStyle(canvasViewport, '::-webkit-scrollbar-track').backgroundColor,
+          canvasScrollbarThumb: getComputedStyle(canvasViewport, '::-webkit-scrollbar-thumb').backgroundColor,
           chartHeight: chart?.height ?? 0, tableHeight: tableFrame?.height ?? 0,
           tableAfterChart: (tableFrame?.top ?? 0) > (chart?.bottom ?? 0),
         }
@@ -120,19 +124,23 @@ for (const viewport of [{ name: 'desktop', width: 1280, height: 820 }, { name: '
       expect(state.kpi).toMatchObject({ tone: 'ink', label: 'Orders', value: '42', note: 'Filtered', display: 'grid' })
       expect(state.kpi.valueSize).toBeGreaterThan(state.kpi.labelSize)
       if (viewport.name === 'mobile') {
-        expect(state.presentationMode).toBe('responsive')
+        expect(state.presentationMode).toBe('mobile')
+        expect(state.canvasScrollbarWidth).toBe('auto')
         expect(state.chartHeight).toBeGreaterThanOrEqual(280)
         expect(state.tableHeight).toBeLessThanOrEqual(700)
         expect(state.tableAfterChart).toBe(true)
       } else {
         expect(state.presentationMode).toBe('fit-width')
+        expect(state.canvasScrollbarWidth).toBe('8px')
+        expect(state.canvasScrollbarTrack).toBe('rgb(234, 238, 242)')
+        expect(state.canvasScrollbarThumb).toBe('rgb(140, 149, 159)')
       }
     } finally { await page.close() }
   })
 }
 
 test('embed presentation keeps page navigation and removes non-navigation chrome', async () => {
-  const page = await browser.newPage({ viewport: { width: 760, height: 620 } })
+  const page = await browser.newPage({ viewport: { width: 863, height: 700 } })
   try {
     await page.goto(baseURL)
     await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page?.title === 'Executive Sales Dashboard')
@@ -166,6 +174,370 @@ test('embed presentation keeps page navigation and removes non-navigation chrome
     expect(state.agentActionCount).toBe(0)
     expect(state.canvasWidth).toBeGreaterThan(500)
     expect(state.documentOverflow).toBe(0)
+  } finally {
+    await page.close()
+  }
+})
+
+test('narrow dashboards let viewers preserve the desktop canvas with internal scrollbars', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (
+      customElements.get('lv-dashboard-page')
+        && customElements.get('lv-report-zoom')
+        && (document.querySelector('lv-dashboard-page') as any)?.page
+    ))
+
+    const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const footer = element.shadowRoot.querySelector('lv-report-footer') as any
+      await footer.updateComplete
+      const view = footer.shadowRoot.querySelector('lv-report-zoom') as any
+      const canvas = element.shadowRoot.querySelector('lv-report-canvas') as any
+      await Promise.all([view.updateComplete, canvas.updateComplete])
+      const details = view.shadowRoot.querySelector('[data-control="layout"]') as HTMLDetailsElement
+      details.open = true
+      await view.updateComplete
+      const control = view.shadowRoot.querySelector('[data-layout="desktop"]') as HTMLButtonElement
+      control.click()
+      await Promise.all([view.updateComplete, canvas.updateComplete])
+      details.open = true
+      await view.updateComplete
+      ;(view.shadowRoot.querySelector('[data-mode="actual-size"]') as HTMLButtonElement).click()
+      await Promise.all([view.updateComplete, canvas.updateComplete])
+      await new Promise(requestAnimationFrame)
+      const surface = canvas.shadowRoot.querySelector('.surface') as HTMLElement
+      const viewport = canvas.shadowRoot.querySelector('.viewport') as HTMLElement
+      const assigned = (canvas.shadowRoot.querySelector('slot') as HTMLSlotElement).assignedElements() as HTMLElement[]
+      const chart = assigned.find((item) => item.dataset.visualType === 'bar')?.getBoundingClientRect()
+      const table = assigned.find((item) => item.dataset.visualType === 'table')?.getBoundingClientRect()
+      return {
+        controlDisplay: getComputedStyle(view).display,
+        controlHeight: Math.round(control.getBoundingClientRect().height),
+        headerControl: Boolean(element.shadowRoot.querySelector('lv-report-view')),
+        bottomControl: Boolean(footer.shadowRoot.querySelector('lv-report-zoom')),
+        layout: surface.dataset.layout,
+        mode: surface.dataset.presentationMode,
+        horizontalScroll: viewport.scrollWidth > viewport.clientWidth,
+        verticalScroll: viewport.scrollHeight > viewport.clientHeight,
+        chartAndTableKeepCanvasPositions: (table?.top ?? 0) > (chart?.top ?? 0) + 300,
+        stored: localStorage.getItem('leapview-report-layout:/'),
+      }
+    })
+
+    expect(result).toEqual({
+      controlDisplay: 'block',
+      controlHeight: 32,
+      headerControl: false,
+      bottomControl: true,
+      layout: 'desktop',
+      mode: 'actual-size',
+      horizontalScroll: true,
+      verticalScroll: true,
+      chartAndTableKeepCanvasPositions: true,
+      stored: 'desktop',
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('fit width never exposes a horizontal canvas scrollbar when vertical scrolling is needed', async () => {
+  const page = await browser.newPage({ viewport: { width: 640, height: 620 } })
+  try {
+    await page.addInitScript(() => {
+      localStorage.setItem('leapview-report-layout:/', 'desktop')
+      localStorage.setItem('leapview-report-zoom:/', 'actual-size')
+    })
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
+
+    const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const footer = element.shadowRoot.querySelector('lv-report-footer') as any
+      await footer.updateComplete
+      const toolbar = footer.shadowRoot.querySelector('lv-report-zoom') as any
+      const canvas = element.shadowRoot.querySelector('lv-report-canvas') as any
+      await Promise.all([toolbar.updateComplete, canvas.updateComplete])
+      ;(toolbar.shadowRoot.querySelector('[data-mode="fit-width"]') as HTMLButtonElement).click()
+      await Promise.all([toolbar.updateComplete, canvas.updateComplete])
+      await new Promise(requestAnimationFrame)
+      await new Promise(requestAnimationFrame)
+      const surface = canvas.shadowRoot.querySelector('.surface') as HTMLElement
+      const viewport = canvas.shadowRoot.querySelector('.viewport') as HTMLElement
+      const frame = canvas.shadowRoot.querySelector('.frame-wrap') as HTMLElement
+      const viewportRect = viewport.getBoundingClientRect()
+      const frameRect = frame.getBoundingClientRect()
+      return {
+        mode: surface.dataset.presentationMode,
+        overflowX: getComputedStyle(viewport).overflowX,
+        scrollbarGutter: getComputedStyle(viewport).scrollbarGutter,
+        horizontalOverflow: viewport.scrollWidth - viewport.clientWidth,
+        verticalScroll: viewport.scrollHeight > viewport.clientHeight,
+        frameWithinViewport: frameRect.right <= viewportRect.right,
+      }
+    })
+
+    expect(result).toEqual({
+      mode: 'fit-width',
+      overflowX: 'hidden',
+      scrollbarGutter: 'stable',
+      horizontalOverflow: 0,
+      verticalScroll: true,
+      frameWithinViewport: true,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('bottom report toolbar separates layout, fit actions, and zoom presets on compact screens', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
+  try {
+    await page.addInitScript(() => {
+      localStorage.removeItem('leapview-report-layout:/')
+      localStorage.removeItem('leapview-report-zoom:/')
+      localStorage.removeItem('leapview-report-zoom-scale:/')
+    })
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
+
+    const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const footer = element.shadowRoot.querySelector('lv-report-footer') as any
+      await footer.updateComplete
+      const toolbar = footer.shadowRoot.querySelector('lv-report-zoom') as any
+      const canvas = element.shadowRoot.querySelector('lv-report-canvas') as any
+      await Promise.all([toolbar.updateComplete, canvas.updateComplete])
+      const root = toolbar.shadowRoot
+      const layoutMenu = root.querySelector('[data-control="layout"]') as HTMLDetailsElement
+      const zoomMenu = root.querySelector('[data-control="zoom-presets"]') as HTMLDetailsElement
+      const slider = root.querySelector('.slider') as HTMLElement
+      const controls = root.querySelector('.zoom') as HTMLElement
+      const initialLayoutTriggerLabel = root.querySelector('[data-control="layout"] summary')?.getAttribute('aria-label')
+      const layoutHasIcon = Boolean(root.querySelector('[data-control="layout"] summary svg'))
+
+      layoutMenu.open = true
+      await toolbar.updateComplete
+      ;(root.querySelector('[data-layout="desktop"]') as HTMLButtonElement).click()
+      await Promise.all([toolbar.updateComplete, canvas.updateComplete])
+
+      ;(root.querySelector('[data-mode="fit-page"]') as HTMLButtonElement).click()
+      await Promise.all([toolbar.updateComplete, canvas.updateComplete])
+      await new Promise(requestAnimationFrame)
+      const fitPageSurface = canvas.shadowRoot.querySelector('.surface') as HTMLElement
+      const fitPageMode = fitPageSurface.dataset.presentationMode
+      const fitPageScale = Number(fitPageSurface.dataset.scale)
+      const fitPageSelected = root.querySelector('[data-mode="fit-page"]')?.getAttribute('aria-pressed')
+
+      zoomMenu.open = true
+      await toolbar.updateComplete
+      ;(root.querySelector('[data-scale="1.25"]') as HTMLButtonElement).click()
+      await Promise.all([toolbar.updateComplete, canvas.updateComplete])
+      await new Promise(requestAnimationFrame)
+
+      const surface = canvas.shadowRoot.querySelector('.surface') as HTMLElement
+      return {
+        layoutTriggerLabel: initialLayoutTriggerLabel,
+        layoutHasIcon,
+        layoutOptions: Array.from(root.querySelectorAll('[data-layout]')).map((node: any) => node.dataset.layout),
+        fitActions: Array.from(root.querySelectorAll('.fit-action')).map((node: any) => node.dataset.mode),
+        presetValues: Array.from(root.querySelectorAll('[data-scale]')).map((node: any) => node.dataset.scale),
+        percent: root.querySelector('[data-control="zoom-presets"] summary')?.textContent?.trim(),
+        sliderDisplay: getComputedStyle(slider).display,
+        toolbarOverflow: controls.scrollWidth - controls.clientWidth,
+        fitPageMode,
+        fitPageScale,
+        fitPageSelected,
+        layout: surface.dataset.layout,
+        mode: surface.dataset.presentationMode,
+        scale: Number(surface.dataset.scale),
+        zoomMenuOpen: zoomMenu.open,
+      }
+    })
+
+    expect(result).toEqual({
+      layoutTriggerLabel: 'Layout, Auto, currently Mobile',
+      layoutHasIcon: true,
+      layoutOptions: ['auto', 'desktop', 'mobile'],
+      fitActions: ['fit-width', 'fit-page', 'actual-size'],
+      presetValues: ['0.5', '0.75', '1', '1.25', '1.5', '2'],
+      percent: '125%',
+      sliderDisplay: 'none',
+      toolbarOverflow: 0,
+      fitPageMode: 'fit-page',
+      fitPageScale: expect.any(Number),
+      fitPageSelected: 'true',
+      layout: 'desktop',
+      mode: 'custom',
+      scale: 1.25,
+      zoomMenuOpen: false,
+    })
+    expect(result.fitPageScale).toBeLessThan(0.5)
+  } finally {
+    await page.close()
+  }
+})
+
+test('compact report footers hide refresh status before it can overlap view controls', async () => {
+  const page = await browser.newPage({ viewport: { width: 760, height: 620 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
+
+    const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const footerHost = element.shadowRoot.querySelector('lv-report-footer') as any
+      await footerHost.updateComplete
+      const root = footerHost.shadowRoot
+      const footer = root.querySelector('footer') as HTMLElement
+      const status = root.querySelector('.status') as HTMLElement
+      const controls = root.querySelector('lv-report-zoom') as HTMLElement
+      const statusRect = status.getBoundingClientRect()
+      const controlsRect = controls.getBoundingClientRect()
+      return {
+        footerWidth: Math.round(footer.getBoundingClientRect().width),
+        statusDisplay: getComputedStyle(status).display,
+        controlsWithinFooter: controlsRect.right <= footer.getBoundingClientRect().right,
+        overlap: statusRect.width > 0 && statusRect.right > controlsRect.left,
+      }
+    })
+
+    expect(result.footerWidth).toBeLessThanOrEqual(800)
+    expect(result.statusDisplay).toBe('none')
+    expect(result.controlsWithinFooter).toBe(true)
+    expect(result.overlap).toBe(false)
+  } finally {
+    await page.close()
+  }
+})
+
+test('mobile layout pins the bottom toolbar while the stacked report content scrolls', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 600 } })
+  try {
+    await page.addInitScript(() => localStorage.setItem('leapview-report-layout:/', 'mobile'))
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
+
+    const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const canvas = element.shadowRoot.querySelector('lv-report-canvas') as any
+      await canvas.updateComplete
+      await new Promise(requestAnimationFrame)
+      const surface = canvas.shadowRoot.querySelector('.surface') as HTMLElement
+      const body = element.shadowRoot.querySelector('.body') as HTMLElement
+      const footer = element.shadowRoot.querySelector('lv-report-footer') as HTMLElement
+      const footerBottomBefore = footer.getBoundingClientRect().bottom
+      body.scrollTo({ top: body.scrollHeight, behavior: 'instant' })
+      await new Promise(requestAnimationFrame)
+      return {
+        layout: surface.dataset.layout,
+        bodyOverflowY: getComputedStyle(body).overflowY,
+        bodyClientHeight: body.clientHeight,
+        bodyScrollHeight: body.scrollHeight,
+        bodyScrollTop: body.scrollTop,
+        bodyTabIndex: body.tabIndex,
+        bodyLabel: body.getAttribute('aria-label'),
+        footerBottomBefore,
+        footerBottomAfter: footer.getBoundingClientRect().bottom,
+        viewportHeight: window.innerHeight,
+        horizontalOverflow: document.documentElement.scrollWidth - window.innerWidth,
+      }
+    })
+
+    expect(result.layout).toBe('mobile')
+    expect(result.bodyOverflowY).toBe('auto')
+    expect(result.bodyScrollHeight).toBeGreaterThan(result.bodyClientHeight)
+    expect(result.bodyScrollTop).toBeGreaterThan(0)
+    expect(result.bodyTabIndex).toBe(0)
+    expect(result.bodyLabel).toBe('Scrollable report content')
+    expect(Math.round(result.footerBottomBefore)).toBe(result.viewportHeight)
+    expect(Math.round(result.footerBottomAfter)).toBe(result.viewportHeight)
+    expect(result.horizontalOverflow).toBe(0)
+  } finally {
+    await page.close()
+  }
+})
+
+test('the closed filter control follows scrolling in Mobile layout', async () => {
+  const page = await browser.newPage({ viewport: { width: 863, height: 700 } })
+  try {
+    await page.addInitScript(() => {
+      localStorage.setItem('leapview-report-layout:/', 'mobile')
+      localStorage.setItem('leapview:filters-open', 'closed')
+    })
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
+
+    const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const root = element.shadowRoot
+      const body = root.querySelector('.body') as HTMLElement
+      const dock = root.querySelector('lv-filter-dock') as any
+      await dock.updateComplete
+      const rail = dock.shadowRoot.querySelector('button.rail') as HTMLElement
+      const bodyRect = body.getBoundingClientRect()
+      const before = rail.getBoundingClientRect()
+      const dockPosition = getComputedStyle(dock).position
+      body.scrollTop = body.scrollHeight
+      await new Promise(requestAnimationFrame)
+      const after = rail.getBoundingClientRect()
+      const scrolled = body.scrollTop > 0
+      rail.click()
+      await dock.updateComplete
+      const panel = dock.shadowRoot.querySelector('.panel') as HTMLElement
+      return {
+        dockPosition,
+        bodyTop: Math.round(bodyRect.top),
+        bodyBottom: Math.round(bodyRect.bottom),
+        beforeTop: Math.round(before.top),
+        afterTop: Math.round(after.top),
+        afterBottom: Math.round(after.bottom),
+        scrolled,
+        expanded: rail.getAttribute('aria-expanded'),
+        panelDisplay: getComputedStyle(panel).display,
+      }
+    })
+
+    expect(result.dockPosition).toBe('sticky')
+    expect(result.scrolled).toBe(true)
+    expect(result.afterTop).toBe(result.beforeTop)
+    expect(result.afterTop).toBeGreaterThanOrEqual(result.bodyTop)
+    expect(result.afterBottom).toBeLessThanOrEqual(result.bodyBottom)
+    expect(result.expanded).toBe('true')
+    expect(result.panelDisplay).toBe('grid')
+  } finally {
+    await page.close()
+  }
+})
+
+test('auto layout follows the viewport and does not stack when desktop side panels narrow the canvas', async () => {
+  const page = await browser.newPage({ viewport: { width: 760, height: 620 } })
+  try {
+    await page.addInitScript(() => localStorage.setItem('leapview:filters-open', 'open'))
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
+
+    const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const canvas = element.shadowRoot.querySelector('lv-report-canvas') as any
+      await canvas.updateComplete
+      await new Promise(requestAnimationFrame)
+      const surface = canvas.shadowRoot.querySelector('.surface') as HTMLElement
+      const viewport = canvas.shadowRoot.querySelector('.viewport') as HTMLElement
+      return {
+        canvasWidth: Math.round(canvas.getBoundingClientRect().width),
+        layout: surface.dataset.layout,
+        mode: surface.dataset.presentationMode,
+        horizontalScroll: viewport.scrollWidth > viewport.clientWidth,
+      }
+    })
+
+    expect(result.canvasWidth).toBeLessThan(640)
+    expect(result.layout).toBe('desktop')
+    expect(result.mode).toBe('fit-width')
+    expect(result.horizontalScroll).toBe(false)
   } finally {
     await page.close()
   }
@@ -730,14 +1102,17 @@ test('collapsed filters and page navigation use the same rail width', async () =
       const pageSidebar = root.querySelector('lv-sub-sidebar') as any
       const filterDock = root.querySelector('lv-filter-dock') as any
       await Promise.all([pageSidebar.updateComplete, filterDock.updateComplete])
+      const filterRail = filterDock.shadowRoot.querySelector('aside') as HTMLElement
       return {
         pageSidebar: Math.round(pageSidebar.getBoundingClientRect().width),
-        filters: Math.round(filterDock.shadowRoot.querySelector('aside').getBoundingClientRect().width),
+        filters: Math.round(filterRail.getBoundingClientRect().width),
+        filterBackground: getComputedStyle(filterRail).backgroundColor,
       }
     })
 
     expect(widths.pageSidebar).toBeGreaterThan(0)
     expect(widths.filters).toBe(widths.pageSidebar)
+    expect(widths.filterBackground).toBe('rgb(246, 248, 250)')
   } finally {
     await page.close()
   }
@@ -754,6 +1129,8 @@ test('opening the desktop filter pane reduces the usable canvas instead of cover
       const root = element.shadowRoot
       const dock = root.querySelector('lv-filter-dock') as any
       const canvas = root.querySelector('.canvas-wrap') as HTMLElement
+      const reportCanvas = root.querySelector('lv-report-canvas') as HTMLElement
+      const footer = root.querySelector('lv-report-footer') as HTMLElement
       await dock.updateComplete
       const before = canvas.getBoundingClientRect()
       ;(dock.shadowRoot.querySelector('.rail') as HTMLButtonElement).click()
@@ -762,6 +1139,9 @@ test('opening the desktop filter pane reduces the usable canvas instead of cover
       await Promise.all(dock.getAnimations().map((animation: Animation) => animation.finished))
       const after = canvas.getBoundingClientRect()
       const pane = dock.getBoundingClientRect()
+      const report = reportCanvas.getBoundingClientRect()
+      const footerRect = footer.getBoundingClientRect()
+      const canvasStyle = getComputedStyle(canvas)
       return {
         beforeWidth: Math.round(before.width),
         afterWidth: Math.round(after.width),
@@ -769,6 +1149,10 @@ test('opening the desktop filter pane reduces the usable canvas instead of cover
         paneLeft: Math.round(pane.left),
         paneWidth: Math.round(pane.width),
         expanded: dock.hasAttribute('data-open'),
+        paddingRight: canvasStyle.paddingRight,
+        paddingBottom: canvasStyle.paddingBottom,
+        scrollbarToFiltersGap: Math.round(pane.left - report.right),
+        scrollbarToFooterGap: Math.round(footerRect.top - report.bottom),
       }
     })
 
@@ -776,35 +1160,104 @@ test('opening the desktop filter pane reduces the usable canvas instead of cover
     expect(result.paneWidth).toBeGreaterThan(240)
     expect(result.afterWidth).toBeLessThan(result.beforeWidth)
     expect(result.canvasRight).toBeLessThanOrEqual(result.paneLeft)
+    expect(result.paddingRight).toBe('0px')
+    expect(result.paddingBottom).toBe('0px')
+    expect(result.scrollbarToFiltersGap).toBe(0)
+    expect(result.scrollbarToFooterGap).toBe(0)
   } finally {
     await page.close()
   }
 })
 
-test('mobile filter dock is reachable before the canvas and opens with pointer activation', async () => {
-  const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
+test('mobile report header combines page and filter controls without stacked rails', async () => {
+  const page = await browser.newPage({ viewport: { width: 640, height: 820 } })
   try {
     await page.addInitScript(() => localStorage.setItem('leapview:filters-open', 'closed'))
     await page.goto(baseURL)
     const dashboard = page.locator('lv-dashboard-page')
     await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
-    const positions = await dashboard.evaluate(async (element: any) => {
+    const compact = await dashboard.evaluate(async (element: any) => {
       await element.updateComplete
+      const root = element.shadowRoot
       const dock = element.shadowRoot.querySelector('lv-filter-dock') as any
       await dock.updateComplete
+      const header = root.querySelector('.header') as HTMLElement
+      const pageMenu = root.querySelector('.mobile-page-menu') as HTMLDetailsElement
+      const filterTrigger = root.querySelector('.mobile-filter-toggle') as HTMLButtonElement
+      const agentTrigger = root.querySelector('.agent-toggle') as HTMLButtonElement
+      const dockRail = dock.shadowRoot.querySelector('.rail') as HTMLButtonElement
+      const actions = root.querySelector('.actions') as HTMLElement
+      const actionRects = Array.from(actions.children).map((child: any) => child.getBoundingClientRect())
+      filterTrigger.focus()
+      const filterFocus = getComputedStyle(filterTrigger)
+      const filterFocusStyle = { style: filterFocus.outlineStyle, width: filterFocus.outlineWidth }
+      agentTrigger.focus()
+      const agentFocus = getComputedStyle(agentTrigger)
+      const agentFocusStyle = { style: agentFocus.outlineStyle, width: agentFocus.outlineWidth }
       return {
-        dockTop: dock.getBoundingClientRect().top,
-        canvasTop: element.shadowRoot.querySelector('.canvas-wrap').getBoundingClientRect().top,
-        dockBeforeCanvas: Boolean(
-          dock.compareDocumentPosition(element.shadowRoot.querySelector('.canvas-wrap'))
-          & Node.DOCUMENT_POSITION_FOLLOWING
-        ),
+        sidebarDisplay: getComputedStyle(root.querySelector('lv-sub-sidebar')).display,
+        headerHeight: Math.round(header.getBoundingClientRect().height),
+        pageMenuDisplay: getComputedStyle(pageMenu).display,
+        pageLabel: pageMenu.querySelector('summary')?.textContent?.replace(/\s+/g, ' ').trim(),
+        pageOptions: Array.from(pageMenu.querySelectorAll('a')).map((item: any) => item.textContent.trim()),
+        filterLabel: filterTrigger.getAttribute('aria-label'),
+        dockWidth: Math.round(dock.getBoundingClientRect().width),
+        dockHeight: Math.round(dock.getBoundingClientRect().height),
+        canvasTop: Math.round(root.querySelector('.canvas-wrap').getBoundingClientRect().top),
+        headerBottom: Math.round(header.getBoundingClientRect().bottom),
+        headerOverflow: header.scrollWidth - header.clientWidth,
+        actionsOverlap: actionRects.some((rect, index) => index > 0 && rect.left < actionRects[index - 1].right),
+        filterTextDisplay: getComputedStyle(filterTrigger.querySelector('.mobile-filter-label')).display,
+        askTextDisplay: getComputedStyle(root.querySelector('.agent-toggle span')).display,
+        filterFocusStyle,
+        agentFocusStyle,
+        dockRailDisplay: getComputedStyle(dockRail).display,
+        dockRailTabIndex: dockRail.tabIndex,
+        dockRailAriaHidden: dockRail.getAttribute('aria-hidden'),
+        dockRailInert: dockRail.inert,
       }
     })
-    expect(positions.dockTop).toBeLessThan(positions.canvasTop)
-    expect(positions.dockBeforeCanvas).toBe(true)
+    expect(compact).toMatchObject({
+      sidebarDisplay: 'none',
+      pageMenuDisplay: 'block',
+      pageLabel: 'Overview',
+      pageOptions: ['Overview', 'Details'],
+      filterLabel: 'Filters, 1 active',
+      dockWidth: 0,
+      dockHeight: 0,
+      headerOverflow: 0,
+      actionsOverlap: false,
+      filterTextDisplay: 'none',
+      askTextDisplay: 'none',
+      filterFocusStyle: { style: 'solid', width: '2px' },
+      agentFocusStyle: { style: 'solid', width: '2px' },
+      dockRailDisplay: 'none',
+      dockRailTabIndex: -1,
+      dockRailAriaHidden: 'true',
+      dockRailInert: true,
+    })
+    expect(compact.headerHeight).toBeLessThanOrEqual(64)
+    expect(compact.canvasTop - compact.headerBottom).toBeLessThanOrEqual(16)
 
-    const toggle = page.locator('lv-filter-dock button.rail')
+    const pageMenu = page.locator('lv-dashboard-page .mobile-page-menu')
+    const pageMenuSummary = page.locator('lv-dashboard-page .mobile-page-menu summary')
+    await pageMenuSummary.click()
+    expect(await pageMenu.getAttribute('open')).not.toBeNull()
+    await page.locator('lv-dashboard-page h1').click()
+    expect(await pageMenu.getAttribute('open')).toBeNull()
+
+    await pageMenuSummary.click()
+    await page.keyboard.press('Escape')
+    const dismissedMenu = await dashboard.evaluate((element: any) => {
+      const menu = element.shadowRoot.querySelector('.mobile-page-menu') as HTMLDetailsElement
+      return {
+        open: menu.open,
+        summaryFocused: element.shadowRoot.activeElement === menu.querySelector('summary'),
+      }
+    })
+    expect(dismissedMenu).toEqual({ open: false, summaryFocused: true })
+
+    const toggle = page.locator('lv-dashboard-page button.mobile-filter-toggle')
     await toggle.click()
     const opened = await dashboard.evaluate(async (element: any) => {
       const dock = element.shadowRoot.querySelector('lv-filter-dock') as any
@@ -813,7 +1266,7 @@ test('mobile filter dock is reachable before the canvas and opens with pointer a
       const background = element.shadowRoot.querySelector('.agent-toggle')
       background.focus()
       return {
-        expanded: dock.shadowRoot.querySelector('button.rail').getAttribute('aria-expanded'),
+        expanded: element.shadowRoot.querySelector('.mobile-filter-toggle').getAttribute('aria-expanded'),
         panelDisplay: getComputedStyle(panel).display,
         panelRole: panel.getAttribute('role'),
         panelModal: panel.getAttribute('aria-modal'),
@@ -852,19 +1305,61 @@ test('mobile filter dock is reachable before the canvas and opens with pointer a
     const closed = await dashboard.evaluate(async (element: any) => {
       const dock = element.shadowRoot.querySelector('lv-filter-dock') as any
       await dock.updateComplete
-      const focused = dock.shadowRoot.activeElement?.className
+      await element.updateComplete
+      const trigger = element.shadowRoot.querySelector('.mobile-filter-toggle')
       const background = element.shadowRoot.querySelector('.agent-toggle')
-      background.focus()
       return {
-        expanded: dock.shadowRoot.querySelector('button.rail').getAttribute('aria-expanded'),
-        focused,
-        backgroundFocusRestored: element.shadowRoot.activeElement === background,
+        expanded: trigger.getAttribute('aria-expanded'),
+        triggerFocusRestored: element.shadowRoot.activeElement === trigger,
+        backgroundFocusBlocked: element.shadowRoot.activeElement !== background,
       }
     })
     expect(closed).toEqual({
       expanded: 'false',
-      focused: 'rail',
-      backgroundFocusRestored: true,
+      triggerFocusRestored: true,
+      backgroundFocusBlocked: true,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('single-page mobile dashboards show page context without an empty menu', async () => {
+  const page = await browser.newPage({ viewport: { width: 320, height: 820 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
+    const state = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev')
+      mergePatch({
+        page: {
+          pages: [{ id: 'overview', title: 'Overview', href: '/dashboards/executive-sales/pages/overview', active: true }],
+        },
+      })
+      await element.updateComplete
+      const root = element.shadowRoot
+      const label = root.querySelector('.mobile-page-label') as HTMLElement
+      const header = root.querySelector('.header') as HTMLElement
+      const actionRects = Array.from(root.querySelector('.actions').children)
+        .filter((child: any) => getComputedStyle(child).display !== 'none')
+        .map((child: any) => child.getBoundingClientRect())
+      return {
+        menuCount: root.querySelectorAll('.mobile-page-menu').length,
+        label: label.textContent?.trim(),
+        labelAria: label.getAttribute('aria-label'),
+        labelDisplay: getComputedStyle(label).display,
+        headerOverflow: header.scrollWidth - header.clientWidth,
+        actionsOverlap: actionRects.some((rect, index) => index > 0 && rect.left < actionRects[index - 1].right),
+      }
+    })
+
+    expect(state).toEqual({
+      menuCount: 0,
+      label: 'Overview',
+      labelAria: 'Current page: Overview',
+      labelDisplay: 'block',
+      headerOverflow: 0,
+      actionsOverlap: false,
     })
   } finally {
     await page.close()
@@ -1986,7 +2481,7 @@ function testDocument(): string {
       <head>
         <style>
           html, body { margin: 0; min-height: 100%; }
-          body { ${typographyTestTokens} --lv-bg-app: #f6f8fa; --lv-bg-panel: #fff; --lv-bg-panel-muted: #f6f8fa; --lv-bg-control-hover: #f3f4f6; --lv-chart-surface: #fff; --lv-report-page-bg: #fff; --lv-report-canvas-bg: #eaeef2; --lv-report-rail-bg: #fff; --lv-bg-overlay: #fff; --lv-fg-default: #24292f; --lv-fg-muted: #57606a; --lv-fg-link: #0969da; --lv-line-muted: #d8dee4; --lv-border-default: 1px solid #d0d7de; --lv-border-muted: 1px solid #d8dee4; --lv-border-transparent: 1px solid transparent; --lv-radius-default: 6px; --lv-radius-full: 999px; --lv-page-rail-width-collapsed: 38px; --lv-dashboard-filter-open-width: 320px; --lv-dashboard-agent-width: 420px; --base-size-2: 2px; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-10: 10px; --base-size-12: 12px; --base-size-16: 16px; --base-size-20: 20px; --base-size-24: 24px; --control-medium-size: 32px; --control-xlarge-size: 40px; --zIndex-dropdown: 100; --zIndex-modal: 200; --zIndex-sticky: 50; --shadow-resting-small: 0 1px 2px rgb(0 0 0 / .08); --shadow-floating-small: 0 8px 24px rgb(0 0 0 / .12); --lv-duration-fast: 160ms; --lv-spinner-size-md: 16px; --lv-spinner-duration: 1800ms; --motion-easing-move: ease; --motion-transition-stateChange: 160ms ease; }
+          body { ${typographyTestTokens} --lv-bg-app: #f6f8fa; --lv-bg-panel: #fff; --lv-bg-panel-muted: #eaeef2; --lv-bg-control-hover: #f3f4f6; --lv-chart-surface: #fff; --lv-report-page-bg: #fff; --lv-report-canvas-bg: #eaeef2; --lv-report-rail-bg: #fff; --lv-bg-overlay: #fff; --lv-fg-default: #24292f; --lv-fg-muted: #57606a; --lv-fg-link: #0969da; --lv-line-muted: #d8dee4; --lv-scrollbar-thumb: #8c959f; --lv-scrollbar-thumb-hover: #6e7781; --lv-border-default: 1px solid #d0d7de; --lv-border-muted: 1px solid #d8dee4; --lv-border-transparent: 1px solid transparent; --lv-radius-default: 6px; --lv-radius-full: 999px; --lv-page-rail-width-collapsed: 38px; --lv-dashboard-filter-open-width: 320px; --lv-dashboard-agent-width: 420px; --base-size-2: 2px; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-10: 10px; --base-size-12: 12px; --base-size-16: 16px; --base-size-20: 20px; --base-size-24: 24px; --borderWidth-default: 1px; --control-medium-size: 32px; --control-xlarge-size: 40px; --focus-outline: 2px solid #0969da; --focus-outline-offset: -2px; --zIndex-dropdown: 100; --zIndex-modal: 200; --zIndex-sticky: 50; --shadow-resting-small: 0 1px 2px rgb(0 0 0 / .08); --shadow-floating-small: 0 8px 24px rgb(0 0 0 / .12); --lv-duration-fast: 160ms; --lv-spinner-size-md: 16px; --lv-spinner-duration: 1800ms; --motion-easing-move: ease; --motion-transition-stateChange: 160ms ease; }
           body { --lv-loading-delay-short: 250ms; --lv-loading-delay-long: 500ms; }
           lv-dashboard-page { min-height: 720px; }
         </style>

--- a/web/components/dashboard/dashboard-page.ts
+++ b/web/components/dashboard/dashboard-page.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html, nothing } from 'lit'
 import { property, state } from 'lit/decorators.js'
+import { ChevronDown, SlidersHorizontal } from 'lucide'
 import type {
   AgentContextSignal,
   AgentReferenceSignal,
@@ -20,6 +21,7 @@ import { DatastarLit } from '../shared/datastar-lit'
 import { domainEvents, emitDomainEvent } from '../shared/events'
 import { checkSignalContract } from '../shared/signal-contract'
 import { agentIcon } from '../chat/agent-icon'
+import { lucideIcon } from '../shared/lucide-icons'
 import '../navigation/sub-sidebar'
 import '../chat/chat-drawer'
 import './filters/filter-dock'
@@ -105,6 +107,8 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
   @state() private optimisticSpatialSelections: VisualizationSpatialSelectionState[] | null = null
   @state() private agentDrawerOpen = false
   @state() private agentReferences: AgentReferenceSignal[] = []
+  @state() private reportLayout: 'desktop' | 'mobile' = 'desktop'
+  @state() private filterDockOpen = false
   private agentStateInitialized = false
   private agentRestoreDispatched = false
   private restoredAgentConversationID = ''
@@ -168,6 +172,30 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
       background: var(--lv-bg-app);
     }
 
+    .main[data-report-layout='mobile'] {
+      height: 100svh;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .main[data-report-layout='mobile'] .body {
+      overflow-x: hidden;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+    }
+
+    .main[data-report-layout='mobile'] .canvas-wrap {
+      overflow: visible;
+    }
+
+    .main[data-report-layout='mobile'] lv-filter-dock:not([data-open]) {
+      position: sticky;
+      top: 0;
+      align-self: start;
+      height: 100%;
+      max-height: 100%;
+    }
+
     .header {
       display: grid;
       min-width: 0;
@@ -213,6 +241,143 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
       gap: var(--base-size-8);
     }
 
+    .mobile-page-menu,
+    .mobile-page-label,
+    .icon-button.mobile-filter-toggle {
+      display: none;
+    }
+
+    .mobile-page-label {
+      max-width: 9rem;
+      overflow: hidden;
+      color: var(--lv-fg-muted);
+      padding-inline: var(--base-size-4);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font: var(--lv-type-body-compact);
+      font-weight: var(--base-text-weight-medium);
+    }
+
+    .mobile-page-menu {
+      position: relative;
+      flex: 0 1 auto;
+      min-width: 0;
+    }
+
+    .mobile-page-menu summary {
+      display: flex;
+      width: auto;
+      max-width: 9rem;
+      height: var(--control-medium-size);
+      box-sizing: border-box;
+      align-items: center;
+      gap: var(--base-size-4);
+      border: var(--lv-border-default);
+      border-radius: var(--lv-radius-default);
+      background: var(--lv-bg-control, var(--lv-bg-panel-muted));
+      color: var(--lv-fg-default);
+      cursor: pointer;
+      padding: 0 var(--base-size-8);
+      list-style: none;
+      font: var(--lv-type-body-compact);
+      font-weight: var(--base-text-weight-medium);
+    }
+
+    .mobile-page-menu summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .mobile-page-menu summary:hover,
+    .mobile-page-menu summary:focus-visible,
+    .mobile-page-menu[open] summary {
+      background: var(--lv-bg-control-hover);
+      outline: 0;
+    }
+
+    .mobile-page-menu summary:focus-visible {
+      outline: var(--focus-outline);
+      outline-offset: var(--focus-outline-offset);
+    }
+
+    .mobile-page-current {
+      overflow: hidden;
+      min-width: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .mobile-page-menu summary svg {
+      width: var(--base-size-16);
+      height: var(--base-size-16);
+      flex: 0 0 auto;
+    }
+
+    .mobile-page-popover {
+      position: absolute;
+      z-index: var(--zIndex-popover, 300);
+      top: calc(100% + var(--base-size-6));
+      right: 0;
+      display: grid;
+      width: min(18rem, calc(100vw - var(--base-size-24)));
+      max-height: min(60svh, 24rem);
+      gap: var(--base-size-2);
+      overflow-y: auto;
+      border: var(--lv-border-default);
+      border-radius: var(--lv-radius-default);
+      background: var(--lv-bg-panel);
+      padding: var(--base-size-6);
+      box-shadow: var(--shadow-floating-small);
+    }
+
+    .mobile-page-option {
+      display: flex;
+      min-height: var(--control-large-size);
+      align-items: center;
+      border-radius: var(--lv-radius-default);
+      color: var(--lv-fg-default);
+      padding: 0 var(--lv-space-control);
+      text-decoration: none;
+      font: var(--lv-type-body);
+    }
+
+    .mobile-page-option:hover,
+    .mobile-page-option:focus-visible,
+    .mobile-page-option[aria-current='page'] {
+      background: var(--lv-bg-control-hover);
+      outline: 0;
+    }
+
+    .mobile-page-option[aria-current='page'] {
+      color: var(--lv-fg-link);
+      font-weight: var(--base-text-weight-semibold);
+    }
+
+    .mobile-filter-toggle {
+      position: relative;
+      width: auto;
+      min-width: var(--control-medium-size);
+      grid-auto-flow: column;
+      gap: var(--base-size-4);
+      padding-inline: var(--base-size-8);
+    }
+
+    .mobile-filter-toggle svg {
+      width: var(--base-size-16);
+      height: var(--base-size-16);
+    }
+
+    .mobile-filter-count {
+      display: grid;
+      min-width: 18px;
+      min-height: 18px;
+      place-items: center;
+      border-radius: var(--lv-radius-full);
+      background: var(--lv-line-accent);
+      color: var(--lv-fg-on-emphasis);
+      font: var(--lv-type-caption);
+      line-height: 1;
+    }
+
     button {
       font: inherit;
     }
@@ -231,10 +396,14 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
       padding: 0;
     }
 
-    .icon-button:hover,
+    .icon-button:hover {
+      background: var(--lv-bg-control-hover);
+    }
+
     .icon-button:focus-visible {
       background: var(--lv-bg-control-hover);
-      outline: 0;
+      outline: var(--focus-outline);
+      outline-offset: var(--focus-outline-offset);
     }
 
 		.agent-toggle {
@@ -383,7 +552,7 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
       min-height: 0;
       overflow: hidden;
       background: transparent;
-      padding: var(--base-size-20) var(--base-size-24);
+      padding: 0;
     }
 
     .heading-visual {
@@ -446,6 +615,70 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
         grid-template-columns: 1fr;
       }
 
+      .route,
+      .route.agent-open {
+        height: 100svh;
+        min-height: 0;
+        grid-template-rows: auto minmax(0, 1fr);
+        overflow: hidden;
+      }
+
+      :host(:not([presentation='embed'])) .route > lv-sub-sidebar {
+        display: none;
+      }
+
+      :host(:not([presentation='embed'])) .header {
+        position: relative;
+        z-index: var(--zIndex-sticky, 50);
+        min-height: var(--control-large-size);
+        padding: var(--base-size-8) var(--base-size-12);
+      }
+
+      :host(:not([presentation='embed'])) .detail {
+        display: none;
+      }
+
+      :host(:not([presentation='embed'])) .actions {
+        gap: var(--base-size-4);
+      }
+
+      :host(:not([presentation='embed'])) .mobile-page-menu {
+        display: block;
+      }
+
+      :host(:not([presentation='embed'])) .mobile-page-label {
+        display: block;
+      }
+
+      :host(:not([presentation='embed'])) .mobile-filter-toggle {
+        display: inline-grid;
+      }
+
+      :host(:not([presentation='embed'])) .mobile-filter-toggle,
+      :host(:not([presentation='embed'])) .agent-toggle {
+        width: var(--control-medium-size);
+        padding-inline: 0;
+      }
+
+      :host(:not([presentation='embed'])) .mobile-filter-label,
+      :host(:not([presentation='embed'])) .agent-toggle span {
+        display: none;
+      }
+
+      :host(:not([presentation='embed'])) .mobile-filter-count {
+        position: absolute;
+        top: calc(-1 * var(--base-size-4));
+        right: calc(-1 * var(--base-size-4));
+      }
+
+      :host(:not([presentation='embed'])) lv-filter-dock:not([data-open]) {
+        position: absolute;
+        width: 0;
+        height: 0;
+        min-height: 0;
+        overflow: hidden;
+      }
+
       lv-filter-dock {
         grid-column: 1;
         grid-row: 1;
@@ -460,15 +693,38 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
       }
 
       .main {
-        height: auto;
+        height: 100%;
         min-height: 0;
-        overflow: visible;
+        grid-row: 2;
+        overflow: hidden;
+      }
+
+      .main[data-report-layout='mobile'] {
+        height: 100%;
+      }
+
+      :host([slot='page'][presentation='app']) {
+        height: 100%;
+        min-height: 0;
+      }
+
+      :host([slot='page'][presentation='app']) .route,
+      :host([slot='page'][presentation='app']) .route.agent-open {
+        height: 100%;
       }
 
       .canvas-wrap {
         grid-row: 3;
         padding: var(--base-size-12);
-        overflow: auto;
+        overflow: hidden;
+      }
+
+      :host(:not([presentation='embed'])) .canvas-wrap {
+        grid-row: 1;
+      }
+
+      lv-chat-drawer:not([open]) {
+        display: none;
       }
 
     }
@@ -503,6 +759,8 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
       this.agentStateInitialized = true
     }
     super.connectedCallback()
+    document.addEventListener('pointerdown', this.handleMobilePageMenuPointerDown, true)
+    document.addEventListener('keydown', this.handleMobilePageMenuKeyDown, true)
     this.addEventListener('lv-interaction-select', this.handleOptimisticInteraction as EventListener, { capture: true })
     this.addEventListener('lv-interaction-spatial-select', this.handleOptimisticSpatialInteraction as EventListener, { capture: true })
     this.addEventListener('lv-filter-mutate', this.handleFilterMutation as EventListener, { capture: true })
@@ -511,6 +769,8 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
   }
 
   disconnectedCallback(): void {
+    document.removeEventListener('pointerdown', this.handleMobilePageMenuPointerDown, true)
+    document.removeEventListener('keydown', this.handleMobilePageMenuKeyDown, true)
     this.removeEventListener('lv-interaction-select', this.handleOptimisticInteraction as EventListener, { capture: true })
     this.removeEventListener('lv-interaction-spatial-select', this.handleOptimisticSpatialInteraction as EventListener, { capture: true })
     this.removeEventListener('lv-filter-mutate', this.handleFilterMutation as EventListener, { capture: true })
@@ -632,6 +892,13 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
     return this.signal<DashboardStatus>('status', emptyStatus)
   }
 
+  private handleReportZoomState = (event: CustomEvent<{ layout?: unknown }>): void => {
+    const layout = event.detail?.layout
+    if ((layout === 'desktop' || layout === 'mobile') && layout !== this.reportLayout) {
+      this.reportLayout = layout
+    }
+  }
+
   render() {
     const page = this.page
     if (!page) return html`<slot></slot>`
@@ -651,26 +918,54 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
     this.renderSnapshot = snapshot
     const refreshProgress = this.refreshProgress(snapshot)
     const agentEnabled = this.presentation === 'app'
+    const activeFilterCount = this.activeFilterCount(snapshot)
     return html`
 			<div class=${`route${agentEnabled && this.agentDrawerOpen ? ' agent-open' : ''}`}>
         <lv-sub-sidebar .config=${this.pageSidebar(page)} @click=${this.handlePageNavigation}></lv-sub-sidebar>
-        <section class="main" aria-label="LeapView report canvas">
+        <section
+          class="main"
+          data-report-layout=${this.reportLayout}
+          aria-label="LeapView report canvas"
+          @lv-report-zoom-state=${this.handleReportZoomState}
+        >
           <header class="header">
             <div class="title-block">
               <h1>${page.title}</h1>
               <p class="detail">${page.headerDetail}</p>
             </div>
-						${agentEnabled ? html`<div class="actions">
+						<div class="actions">
+							${this.renderMobilePageMenu(page)}
+							<button
+								type="button"
+								class="icon-button mobile-filter-toggle"
+								aria-label=${activeFilterCount > 0 ? `Filters, ${activeFilterCount} active` : 'Filters'}
+								aria-expanded=${String(this.filterDockOpen)}
+								aria-haspopup="dialog"
+								title="Filters"
+								@click=${this.openFiltersFromHeader}
+							>
+								${lucideIcon(SlidersHorizontal)}
+								<span class="mobile-filter-label">Filters</span>
+								${activeFilterCount > 0 ? html`<span class="mobile-filter-count" aria-hidden="true">${activeFilterCount}</span>` : nothing}
+							</button>
+							${agentEnabled ? html`
 							<button
 								type="button"
 								class="icon-button agent-toggle"
 								aria-label="Toggle dashboard agent"
 								aria-expanded=${String(this.agentDrawerOpen)}
+								title="Ask"
 								@click=${() => { this.setAgentDrawerOpen(!this.agentDrawerOpen) }}
 							>${agentIcon()}<span>Ask</span></button>
-						</div>` : nothing}
+							` : nothing}
+						</div>
           </header>
-          <div class="body">
+          <div
+            class="body"
+            role=${this.reportLayout === 'mobile' ? 'region' : nothing}
+            aria-label=${this.reportLayout === 'mobile' ? 'Scrollable report content' : nothing}
+            tabindex=${this.reportLayout === 'mobile' ? '0' : nothing}
+          >
             ${this.renderRefreshProgress(refreshProgress)}
             ${this.renderFilterValidation()}
             ${this.renderFilterDock()}
@@ -751,12 +1046,85 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
     }
   }
 
+  private renderMobilePageMenu(page: DashboardPageSignal) {
+    const activePage = page.pages.find(item => item.active || item.id === page.pageId) ?? page.pages[0]
+    if (!activePage) return nothing
+    if (page.pages.length === 1) {
+      return html`<span class="mobile-page-label" aria-label=${`Current page: ${activePage.title}`}>${activePage.title}</span>`
+    }
+    return html`
+      <details class="mobile-page-menu" @click=${this.handleMobilePageNavigation}>
+        <summary aria-label=${`Pages, current ${activePage.title}`}>
+          <span class="mobile-page-current">${activePage.title}</span>
+          ${lucideIcon(ChevronDown)}
+        </summary>
+        <nav class="mobile-page-popover" aria-label="Report pages">
+          ${page.pages.map(item => html`
+            <a
+              class="mobile-page-option"
+              href=${item.href}
+              aria-current=${item.active || item.id === page.pageId ? 'page' : nothing}
+            >${item.title}</a>
+          `)}
+        </nav>
+      </details>
+    `
+  }
+
+  private activeFilterCount(snapshot: DashboardRenderSnapshot): number {
+    return Object.values(snapshot.filterContract.bindings)
+      .filter(binding => binding.paneVisible && (binding.scope === 'report' || binding.pageID === snapshot.page.pageId))
+      .filter(binding => {
+        const expression = snapshot.filterState.draftControls[binding.key]
+          ?? snapshot.filterState.appliedControls[binding.key]?.expression
+          ?? binding.default
+        return expression.kind !== 'unfiltered'
+      }).length
+  }
+
+  private handleMobilePageNavigation = (event: MouseEvent): void => {
+    const menu = event.currentTarget as HTMLDetailsElement
+    const anchor = event.composedPath().find((node): node is HTMLAnchorElement => node instanceof HTMLAnchorElement)
+    if (!anchor) return
+    this.handlePageNavigation(event)
+    menu.open = false
+  }
+
+  private handleMobilePageMenuPointerDown = (event: PointerEvent): void => {
+    const menu = this.renderRoot.querySelector<HTMLDetailsElement>('.mobile-page-menu')
+    if (!menu?.open || event.composedPath().includes(menu)) return
+    menu.open = false
+  }
+
+  private handleMobilePageMenuKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== 'Escape') return
+    const menu = this.renderRoot.querySelector<HTMLDetailsElement>('.mobile-page-menu')
+    if (!menu?.open) return
+    event.preventDefault()
+    menu.open = false
+    menu.querySelector<HTMLElement>('summary')?.focus()
+  }
+
+  private openFiltersFromHeader = (event: MouseEvent): void => {
+    const trigger = event.currentTarget as HTMLButtonElement
+    const dock = this.renderRoot.querySelector('lv-filter-dock') as (HTMLElement & { openPanel(returnFocus?: HTMLElement): Promise<void> }) | null
+    void dock?.openPanel(trigger)
+  }
+
+  private handleFilterDockState = (event: CustomEvent<{ open?: boolean }>): void => {
+    this.filterDockOpen = event.detail?.open === true
+  }
+
   private handlePageNavigation = (event: MouseEvent): void => {
     if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
     const anchor = event.composedPath().find((node): node is HTMLAnchorElement => node instanceof HTMLAnchorElement)
     if (!anchor?.href) return
     const target = this.page?.pages.find((item) => new URL(item.href, window.location.href).href === anchor.href)
-    if (!target || target.active) return
+    if (!target) return
+    if (target.active) {
+      event.preventDefault()
+      return
+    }
     event.preventDefault()
     event.stopPropagation()
     this.pendingPageNavigation = anchor.href
@@ -913,6 +1281,7 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
   private renderFilterDock() {
     return html`
       <lv-filter-dock
+        .externalTrigger=${this.presentation !== 'embed'}
         .loading=${(this.renderSnapshot?.status ?? this.status).loading}
         .pending=${this.filterController.pending}
         .contract=${this.renderSnapshot?.filterContract ?? this.filterContract}
@@ -924,6 +1293,7 @@ class LeapViewDashboardPage extends DatastarLit(LitElement) {
         @lv-filter-reset-scope=${this.handleFilterResetScope}
         @lv-filter-apply=${this.handleFilterApply}
         @lv-filter-cancel=${this.handleFilterCancel}
+        @lv-filter-dock-state=${this.handleFilterDockState}
       ></lv-filter-dock>
     `
   }

--- a/web/components/dashboard/filters/filter-dock.ts
+++ b/web/components/dashboard/filters/filter-dock.ts
@@ -19,12 +19,14 @@ class LeapViewFilterDock extends LitElement {
   @property({ type: String }) pageId = ''
   @property({ type: Boolean, reflect: true }) loading: DashboardStatus['loading'] = false
   @property({ type: Boolean, reflect: true }) pending = false
+  @property({ type: Boolean, attribute: false }) externalTrigger = false
 
   @property({ type: Boolean, reflect: true, attribute: 'data-open' })
   private open = storedFilterDockOpen()
   @state() private mobile = isMobileFilterDock()
 
   private mobileQuery: MediaQueryList | null = null
+  private returnFocus?: HTMLElement
 
   connectedCallback(): void {
     super.connectedCallback()
@@ -44,6 +46,7 @@ class LeapViewFilterDock extends LitElement {
   protected firstUpdated(): void {
     this.syncDialogMode()
     if (this.open) this.focusCloseButton()
+    this.emitState()
   }
 
   static styles = css`
@@ -72,7 +75,7 @@ class LeapViewFilterDock extends LitElement {
       height: 100%;
       overflow: hidden;
       border-left: var(--lv-border-default);
-      background: var(--lv-bg-panel-muted);
+      background: var(--lv-bg-app);
       transition:
         width var(--lv-duration-fast) var(--motion-easing-move),
         background-color var(--lv-duration-fast) var(--motion-easing-move);
@@ -353,6 +356,10 @@ class LeapViewFilterDock extends LitElement {
         padding: var(--base-size-12);
       }
 
+      .rail[data-suppressed] {
+        display: none;
+      }
+
       .rail span,
       aside[data-open] .rail span {
         writing-mode: horizontal-tb;
@@ -387,6 +394,7 @@ class LeapViewFilterDock extends LitElement {
   render() {
     const visibleBindings = this.visibleBindings()
     const activeCount = visibleBindings.filter(binding => this.isActive(this.expression(binding))).length
+    const railSuppressed = this.mobile && this.externalTrigger
     return html`
       <aside ?data-open=${this.open} aria-label="Report filters" @keydown=${this.onKeyDown}>
         <button
@@ -395,6 +403,10 @@ class LeapViewFilterDock extends LitElement {
           title="Open filters"
           aria-label=${activeCount > 0 ? `Filters, ${activeCount} active` : 'Filters'}
           aria-expanded=${String(this.open)}
+          aria-hidden=${railSuppressed ? 'true' : nothing}
+          data-suppressed=${railSuppressed ? '' : nothing}
+          tabindex=${railSuppressed ? '-1' : nothing}
+          ?inert=${railSuppressed}
           @click=${this.toggle}
         >
           ${lucideIcon(SlidersHorizontal)}
@@ -531,16 +543,23 @@ class LeapViewFilterDock extends LitElement {
     return this.filterState?.dirtyBindings.length ?? 0
   }
 
-  private toggle = async (): Promise<void> => {
-    if (this.open) {
-      await this.close()
-      return
-    }
+  public async openPanel(returnFocus?: HTMLElement): Promise<void> {
+    if (this.open) return
+    this.returnFocus = returnFocus
     this.open = true
     storeFilterDockOpen(true)
     await this.updateComplete
     this.syncDialogMode()
     this.focusCloseButton()
+    this.emitState()
+  }
+
+  private toggle = async (): Promise<void> => {
+    if (this.open) {
+      await this.close()
+      return
+    }
+    await this.openPanel(this.renderRoot.querySelector<HTMLButtonElement>('.rail') ?? undefined)
   }
 
   private close = async (): Promise<void> => {
@@ -548,7 +567,18 @@ class LeapViewFilterDock extends LitElement {
     this.open = false
     storeFilterDockOpen(false)
     await this.updateComplete
-    this.renderRoot.querySelector<HTMLButtonElement>('.rail')?.focus({ preventScroll: true })
+    const focusTarget = this.returnFocus ?? this.renderRoot.querySelector<HTMLButtonElement>('.rail') ?? undefined
+    this.returnFocus = undefined
+    focusTarget?.focus({ preventScroll: true })
+    this.emitState()
+  }
+
+  private emitState(): void {
+    this.dispatchEvent(new CustomEvent('lv-filter-dock-state', {
+      bubbles: true,
+      composed: true,
+      detail: { open: this.open },
+    }))
   }
 
   private onKeyDown = (event: KeyboardEvent): void => {

--- a/web/components/dashboard/report-canvas.ts
+++ b/web/components/dashboard/report-canvas.ts
@@ -1,18 +1,25 @@
-import { LitElement, css, html } from 'lit'
+import { LitElement, css, html, nothing } from 'lit'
 import { property, state } from 'lit/decorators.js'
-import { Maximize2, Minus, Plus, type IconNode } from 'lucide'
-import { lucideIcon } from '../shared/lucide-icons'
+import {
+  autoMobileLayoutQuery,
+  clampFittedScale,
+  clampScale,
+  layoutStorageKey,
+  resolvedLayoutMode,
+  storedCustomScale,
+  storedLayoutMode,
+  storedZoomMode,
+  zoomScaleStorageKey,
+  zoomStorageKey,
+  type LayoutMode,
+  type PresentationMode,
+  type ResolvedLayout,
+  type ZoomCommand,
+  type ZoomMode,
+} from './report-view-state'
 
 type VisualElement = HTMLElement & {
   dataset: DOMStringMap
-}
-
-type ZoomMode = 'fit-width' | 'fit-page' | 'actual-size' | 'custom'
-type PresentationMode = ZoomMode | 'responsive'
-
-type ZoomCommand = {
-  mode?: ZoomMode
-  scale?: number
 }
 
 type ZoomAnchor = {
@@ -24,6 +31,8 @@ class ReportCanvas extends LitElement {
   @property({ type: Number }) width = 1366
   @property({ type: Number }) height = 768
   @state() private scale = 1
+  @state() private layoutMode: LayoutMode = storedLayoutMode()
+  @state() private resolvedLayout: ResolvedLayout = resolvedLayoutMode(this.layoutMode)
   @state() private zoomMode: ZoomMode = storedZoomMode()
   @state() private presentationMode: PresentationMode = 'fit-width'
   @state() private contentHeight = this.height
@@ -31,6 +40,7 @@ class ReportCanvas extends LitElement {
   private zoomAnchor?: ZoomAnchor
 
   private resizeObserver?: ResizeObserver
+  private autoLayoutMediaQuery?: MediaQueryList
 
   static styles = css`
     :host {
@@ -59,6 +69,48 @@ class ReportCanvas extends LitElement {
       min-height: 0;
       overflow: auto;
       padding: 0;
+    }
+
+    :host([data-layout='desktop']) .viewport {
+      scrollbar-gutter: stable;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      :host([data-layout='desktop']) .viewport {
+        scrollbar-color: var(--lv-scrollbar-thumb) var(--lv-report-canvas-bg);
+        scrollbar-width: thin;
+      }
+
+      :host([data-layout='desktop']) .viewport::-webkit-scrollbar {
+        width: var(--base-size-8);
+        height: var(--base-size-8);
+      }
+
+      :host([data-layout='desktop']) .viewport::-webkit-scrollbar-track,
+      :host([data-layout='desktop']) .viewport::-webkit-scrollbar-corner {
+        background: var(--lv-report-canvas-bg);
+      }
+
+      :host([data-layout='desktop']) .viewport::-webkit-scrollbar-thumb {
+        min-width: var(--base-size-32);
+        min-height: var(--base-size-32);
+        border: var(--borderWidth-default) solid transparent;
+        border-radius: var(--lv-radius-full);
+        background: var(--lv-scrollbar-thumb);
+        background-clip: padding-box;
+      }
+
+      :host([data-layout='desktop']) .viewport::-webkit-scrollbar-thumb:hover,
+      :host([data-layout='desktop']) .viewport::-webkit-scrollbar-thumb:active {
+        background: var(--lv-scrollbar-thumb-hover);
+        background-clip: padding-box;
+      }
+    }
+
+    .surface[data-presentation-mode='fit-width'] .viewport,
+    .surface[data-presentation-mode='fit-page'] .viewport {
+      overflow-x: hidden;
+      overflow-y: auto;
     }
 
     .sizer {
@@ -103,83 +155,89 @@ class ReportCanvas extends LitElement {
       z-index: 5;
     }
 
-    @media (max-width: 767px) {
-      :host,
-      .surface,
-      .viewport,
-      .sizer,
-      .frame-wrap,
-      .frame {
+    :host([data-layout='mobile']),
+    :host([data-layout='mobile']) .surface,
+    :host([data-layout='mobile']) .viewport,
+    :host([data-layout='mobile']) .sizer,
+    :host([data-layout='mobile']) .frame-wrap,
+    :host([data-layout='mobile']) .frame {
+      width: 100%;
+      height: auto;
+      min-height: 0;
+    }
+
+    :host([data-layout='mobile']) .viewport {
+      overflow: visible;
+    }
+
+    :host([data-layout='mobile']) .sizer {
+      display: block;
+    }
+
+    :host([data-layout='mobile']) .frame-wrap {
+      position: relative;
+    }
+
+    :host([data-layout='mobile']) .frame {
+      position: relative;
+      inset: auto;
+      display: grid;
+      gap: var(--base-size-12);
+      transform: none;
+      background: transparent;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-canvas-visual]) {
+      position: relative !important;
+      inset: auto !important;
+      width: 100% !important;
+      height: auto !important;
+      min-height: 132px;
+      overflow: visible;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-component-kind='header']) {
+      min-height: 96px;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-component-kind='slicer']) {
+      min-height: 88px;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-slicer-style='dropdown']) {
+      min-height: 90px;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-slicer-style='input']) {
+      min-height: 112px;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-slicer-style='numeric_range']),
+    :host([data-layout='mobile']) ::slotted([data-slicer-style='date_range']) {
+      min-height: 172px;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-slicer-style='relative_period']) {
+      min-height: 184px;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-component-kind='visual'][data-visual-type='kpi']) {
+      height: auto !important;
+      min-height: 144px;
+      overflow: hidden;
+    }
+
+    :host([data-layout='mobile']) ::slotted([data-component-kind='visual']:not([data-visual-type='kpi'])) {
+      height: 520px !important;
+      min-height: 320px;
+      overflow: hidden;
+    }
+
+    @media (max-width: 640px) {
+      :host([data-layout='desktop']) {
         width: 100%;
-        height: auto;
-        min-height: 0;
-      }
-
-      .viewport {
-        overflow: visible;
-      }
-
-      .sizer {
-        display: block;
-      }
-
-      .frame-wrap {
-        position: relative;
-      }
-
-      .frame {
-        position: relative;
-        inset: auto;
-        display: grid;
-        gap: var(--base-size-12);
-        transform: none;
-        background: transparent;
-      }
-
-      ::slotted([data-canvas-visual]) {
-        position: relative !important;
-        inset: auto !important;
-        width: 100% !important;
-        height: auto !important;
-        min-height: 132px;
-        overflow: visible;
-      }
-
-      ::slotted([data-component-kind='header']) {
-        min-height: 96px;
-      }
-
-      ::slotted([data-component-kind='slicer']) {
-        min-height: 88px;
-      }
-
-      ::slotted([data-slicer-style='dropdown']) {
-        min-height: 90px;
-      }
-
-      ::slotted([data-slicer-style='input']) {
-        min-height: 112px;
-      }
-
-      ::slotted([data-slicer-style='numeric_range']),
-      ::slotted([data-slicer-style='date_range']) {
-        min-height: 172px;
-      }
-
-      ::slotted([data-slicer-style='relative_period']) {
-        min-height: 184px;
-      }
-
-      ::slotted([data-component-kind='visual'][data-visual-type='kpi']) {
-        height: auto !important;
-        min-height: 144px;
-        overflow: hidden;
-      }
-
-      ::slotted([data-component-kind='visual']:not([data-visual-type='kpi'])) {
-        height: 520px !important;
-        min-height: 320px;
-        overflow: hidden;
+        height: max(360px, calc(100svh - 12rem));
+        min-height: 360px;
       }
     }
   `
@@ -187,6 +245,9 @@ class ReportCanvas extends LitElement {
   connectedCallback(): void {
     super.connectedCallback()
     document.addEventListener('lv-report-zoom-command', this.onZoomCommand as EventListener)
+    this.autoLayoutMediaQuery = window.matchMedia(autoMobileLayoutQuery)
+    this.autoLayoutMediaQuery.addEventListener('change', this.onAutoLayoutChange)
+    this.syncResolvedLayout()
     this.resizeObserver = new ResizeObserver(() => this.updateScale())
     this.updateComplete.then(() => {
       this.resizeObserver?.observe(this)
@@ -198,6 +259,8 @@ class ReportCanvas extends LitElement {
 
   disconnectedCallback(): void {
     document.removeEventListener('lv-report-zoom-command', this.onZoomCommand as EventListener)
+    this.autoLayoutMediaQuery?.removeEventListener('change', this.onAutoLayoutChange)
+    this.autoLayoutMediaQuery = undefined
     this.resizeObserver?.disconnect()
     super.disconnectedCallback()
   }
@@ -209,33 +272,34 @@ class ReportCanvas extends LitElement {
 
   private updateScale(): void {
     const hostRect = this.getBoundingClientRect()
-    const availableWidth = Math.max(0, hostRect.width)
-    const availableHeight = Math.max(0, hostRect.height)
+    const viewport = this.viewportElement()
+    const availableWidth = Math.max(0, viewport?.clientWidth ?? hostRect.width)
+    const availableHeight = Math.max(0, viewport?.clientHeight ?? hostRect.height)
     if (!availableWidth || !availableHeight || !this.width || !this.contentHeight) return
-    const responsive = availableWidth < 768
+    const nextLayout = resolvedLayoutMode(this.layoutMode, this.autoLayoutMediaQuery?.matches)
     const widthScale = availableWidth / this.width
     const heightScale = availableHeight / this.contentHeight
     let nextMode: PresentationMode = this.zoomMode
     let nextScale = 1
 
-    if (responsive) {
-      nextMode = 'responsive'
+    if (nextLayout === 'mobile') {
+      nextMode = 'mobile'
     } else if (this.zoomMode === 'fit-width') {
       nextScale = widthScale
     } else if (this.zoomMode === 'fit-page') {
-      const fitPageScale = Math.min(widthScale, heightScale)
-      if (fitPageScale < 0.75) {
-        nextMode = 'fit-width'
-        nextScale = widthScale
-      } else {
-        nextScale = fitPageScale
-      }
+      nextScale = Math.min(widthScale, heightScale)
     } else if (this.zoomMode === 'custom') {
       nextScale = this.customScale
     }
-    nextScale = clampScale(nextScale)
+    const fittedMode = nextLayout === 'desktop' && (this.zoomMode === 'fit-width' || this.zoomMode === 'fit-page')
+    nextScale = fittedMode ? clampFittedScale(nextScale) : clampScale(nextScale)
+    const layoutChanged = nextLayout !== this.resolvedLayout
     const modeChanged = nextMode !== this.presentationMode
     const scaleChanged = Math.abs(nextScale - this.scale) > 0.001
+    if (layoutChanged) {
+      this.resolvedLayout = nextLayout
+      this.setAttribute('data-layout', nextLayout)
+    }
     if (modeChanged) this.presentationMode = nextMode
     if (scaleChanged) {
       const anchor = this.zoomAnchor
@@ -244,10 +308,10 @@ class ReportCanvas extends LitElement {
       if (anchor) {
         this.updateComplete.then(() => this.restoreZoomAnchor(anchor))
       }
-    } else if (!modeChanged) {
+    } else if (!modeChanged && !layoutChanged) {
       this.zoomAnchor = undefined
     }
-    if (modeChanged && !scaleChanged) this.emitZoomState()
+    if ((layoutChanged || modeChanged) && !scaleChanged) this.emitZoomState()
   }
 
   private positionVisuals(): void {
@@ -291,6 +355,14 @@ class ReportCanvas extends LitElement {
   private onZoomCommand = (event: CustomEvent<ZoomCommand>): void => {
     const detail = event.detail ?? {}
     this.zoomAnchor = this.captureZoomAnchor()
+    if (detail.layout !== undefined) {
+      this.layoutMode = detail.layout
+      try {
+        localStorage.setItem(layoutStorageKey(), detail.layout)
+      } catch {
+        // Ignore storage failures; the active component state still updates.
+      }
+    }
     if (detail.scale !== undefined) {
       this.customScale = clampScale(detail.scale)
       try {
@@ -300,6 +372,16 @@ class ReportCanvas extends LitElement {
       }
     }
     this.setZoomMode(detail.mode ?? (detail.scale !== undefined ? 'custom' : this.zoomMode))
+  }
+
+  private onAutoLayoutChange = (): void => {
+    this.updateScale()
+  }
+
+  private syncResolvedLayout(): void {
+    const layout = resolvedLayoutMode(this.layoutMode, this.autoLayoutMediaQuery?.matches)
+    this.resolvedLayout = layout
+    this.setAttribute('data-layout', layout)
   }
 
   private captureZoomAnchor(): ZoomAnchor {
@@ -340,7 +422,12 @@ class ReportCanvas extends LitElement {
 
   private emitZoomState(): void {
     this.dispatchEvent(new CustomEvent('lv-report-zoom-state', {
-      detail: { mode: this.presentationMode, scale: this.scale },
+      detail: {
+        layoutMode: this.layoutMode,
+        layout: this.resolvedLayout,
+        mode: this.presentationMode,
+        scale: this.scale,
+      },
       bubbles: true,
       composed: true,
     }))
@@ -357,10 +444,16 @@ class ReportCanvas extends LitElement {
       <div
         class="surface"
         style=${style}
+        data-layout=${this.resolvedLayout}
         data-presentation-mode=${this.presentationMode}
         data-scale=${String(this.scale)}
       >
-        <div class="viewport">
+        <div
+          class="viewport"
+          role=${this.resolvedLayout === 'desktop' ? 'region' : nothing}
+          aria-label=${this.resolvedLayout === 'desktop' ? 'Scrollable report canvas' : nothing}
+          tabindex=${this.resolvedLayout === 'desktop' ? '0' : nothing}
+        >
           <div class="sizer">
             <div class="frame-wrap">
               <div class="frame">
@@ -374,204 +467,6 @@ class ReportCanvas extends LitElement {
   }
 }
 
-class ReportZoom extends LitElement {
-  @state() private mode: PresentationMode = storedZoomMode()
-  @state() private scale = storedCustomScale()
-
-  static styles = css`
-    :host {
-      display: inline-block;
-      color: var(--lv-fg-default);
-      font-family: var(--fontStack-system);
-    }
-
-    .zoom {
-      display: inline-grid;
-      grid-template-columns: auto auto auto auto minmax(86px, 176px) auto auto;
-      align-items: center;
-      min-height: 32px;
-    }
-
-    button {
-      display: grid;
-      width: 28px;
-      height: 28px;
-      place-items: center;
-      border: 0;
-      border-radius: var(--lv-radius-default);
-      background: transparent;
-      color: var(--lv-fg-muted);
-      cursor: pointer;
-      padding: 0;
-      font: inherit;
-    }
-
-    button:hover,
-    button:focus-visible {
-      background: var(--lv-bg-panel-muted);
-      color: var(--lv-fg-default);
-      outline: 0;
-    }
-
-    button[aria-pressed='true'] {
-      background: var(--bgColor-accent-muted);
-      color: var(--lv-fg-link);
-    }
-
-    svg {
-      width: 15px;
-      height: 15px;
-      fill: none;
-      stroke: currentColor;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-      stroke-width: 2;
-    }
-
-    input {
-      appearance: none;
-      width: 100%;
-      min-width: 0;
-      height: 16px;
-      background: transparent;
-      cursor: pointer;
-    }
-
-    input::-webkit-slider-runnable-track {
-      height: 4px;
-      border-radius: var(--lv-radius-full);
-      background: var(--lv-line-muted);
-    }
-
-    input::-webkit-slider-thumb {
-      appearance: none;
-      width: 12px;
-      height: 12px;
-      margin-top: -4px;
-      border: var(--lv-border-default);
-      border-radius: var(--lv-radius-full);
-      background: var(--lv-fg-muted);
-    }
-
-    input::-moz-range-track {
-      height: 4px;
-      border-radius: var(--lv-radius-full);
-      background: var(--lv-line-muted);
-    }
-
-    input::-moz-range-thumb {
-      width: 12px;
-      height: 12px;
-      border: var(--lv-border-default);
-      border-radius: var(--lv-radius-full);
-      background: var(--lv-fg-muted);
-    }
-
-    input:focus-visible {
-      outline: 0;
-    }
-
-    input:focus-visible::-webkit-slider-thumb {
-      outline: var(--lv-border-width-focus) solid var(--lv-line-accent-muted);
-      outline-offset: 2px;
-    }
-
-    input:focus-visible::-moz-range-thumb {
-      outline: var(--lv-border-width-focus) solid var(--lv-line-accent-muted);
-      outline-offset: 2px;
-    }
-
-    .slider {
-      display: grid;
-      min-width: 0;
-      margin-inline: 6px;
-      padding-inline: 10px;
-      border-inline: var(--lv-border-muted);
-    }
-
-    .percent {
-      min-width: 38px;
-      color: var(--lv-fg-muted);
-      text-align: center;
-      font: var(--lv-type-caption);
-      font-weight: var(--base-text-weight-medium);
-      white-space: nowrap;
-    }
-
-    .mode-label {
-      width: auto;
-      min-width: 32px;
-      padding-inline: 7px;
-      font: var(--lv-type-caption);
-    }
-
-    @media (max-width: 700px) {
-      :host {
-        display: none;
-      }
-    }
-  `
-
-  connectedCallback(): void {
-    super.connectedCallback()
-    document.addEventListener('lv-report-zoom-state', this.onZoomState as EventListener)
-  }
-
-  disconnectedCallback(): void {
-    document.removeEventListener('lv-report-zoom-state', this.onZoomState as EventListener)
-    super.disconnectedCallback()
-  }
-
-  private onZoomState = (event: CustomEvent<{ mode: PresentationMode; scale: number }>): void => {
-    this.mode = event.detail.mode
-    this.scale = event.detail.scale
-  }
-
-  private command(detail: ZoomCommand): void {
-    this.dispatchEvent(new CustomEvent('lv-report-zoom-command', {
-      detail,
-      bubbles: true,
-      composed: true,
-    }))
-  }
-
-  private nudge(delta: number): void {
-    this.command({ mode: 'custom', scale: clampScale(this.scale + delta) })
-  }
-
-  private slide(event: Event): void {
-    const input = event.currentTarget as HTMLInputElement
-    this.command({ mode: 'custom', scale: clampScale(Number(input.value) / 100) })
-  }
-
-  render() {
-    const percent = Math.round(this.scale * 100)
-    return html`
-      <div class="zoom" role="group" aria-label="Report zoom">
-        <button class="mode-label" type="button" title="Fit width" aria-label="Fit width" aria-pressed=${String(this.mode === 'fit-width')} @click=${() => this.command({ mode: 'fit-width' })}>
-          Width
-        </button>
-        <button type="button" title="Fit page" aria-label="Fit page" aria-pressed=${String(this.mode === 'fit-page')} @click=${() => this.command({ mode: 'fit-page' })}>
-          ${zoomIcon('fit-page')}
-        </button>
-        <button class="mode-label" type="button" title="Actual size" aria-label="Actual size" aria-pressed=${String(this.mode === 'actual-size')} @click=${() => this.command({ mode: 'actual-size' })}>
-          1:1
-        </button>
-        <button type="button" title="Zoom out" aria-label="Zoom out" @click=${() => this.nudge(-0.1)}>
-          ${zoomIcon('minus')}
-        </button>
-        <div class="slider">
-          <input type="range" min="50" max="200" .value=${String(percent)} aria-label="Zoom percent" @input=${this.slide} />
-        </div>
-        <button type="button" title="Zoom in" aria-label="Zoom in" @click=${() => this.nudge(0.1)}>
-          ${zoomIcon('plus')}
-        </button>
-        <span class="percent">${percent}%</span>
-      </div>
-    `
-  }
-}
-
 function parseCanvasNumber(value: string | undefined, fallback: number): number {
   if (!value) return fallback
   const parsed = Number(value)
@@ -579,40 +474,6 @@ function parseCanvasNumber(value: string | undefined, fallback: number): number 
 }
 
 customElements.define('lv-report-canvas', ReportCanvas)
-customElements.define('lv-report-zoom', ReportZoom)
-
-function zoomStorageKey(): string {
-  return `leapview-report-zoom:${location.pathname}`
-}
-
-function zoomScaleStorageKey(): string {
-  return `leapview-report-zoom-scale:${location.pathname}`
-}
-
-function storedZoomMode(): ZoomMode {
-  try {
-    const value = localStorage.getItem(zoomStorageKey())
-    if (value === 'fit-width' || value === 'fit-page' || value === 'actual-size' || value === 'custom') {
-      return value
-    }
-  } catch {
-    // Ignore storage failures.
-  }
-  return 'fit-width'
-}
-
-function storedCustomScale(): number {
-  try {
-    return clampScale(Number(localStorage.getItem(zoomScaleStorageKey()) || 0.6))
-  } catch {
-    return 0.6
-  }
-}
-
-function clampScale(value: number): number {
-  if (!Number.isFinite(value)) return 1
-  return Math.min(2, Math.max(0.5, value))
-}
 
 function clampRatio(value: number): number {
   if (!Number.isFinite(value)) return 0.5
@@ -622,14 +483,4 @@ function clampRatio(value: number): number {
 function clampScroll(value: number, max: number): number {
   if (!Number.isFinite(value)) return 0
   return Math.min(Math.max(0, max), Math.max(0, value))
-}
-
-function zoomIcon(name: 'fit-page' | 'minus' | 'plus') {
-  const icons: Record<'fit-page' | 'minus' | 'plus', IconNode> = {
-    'fit-page': Maximize2,
-    minus: Minus,
-    plus: Plus,
-  }
-
-  return lucideIcon(icons[name])
 }

--- a/web/components/dashboard/report-footer.ts
+++ b/web/components/dashboard/report-footer.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from 'lit'
 import { property } from 'lit/decorators.js'
+import './report-view-controls'
 
 type FooterStatus = {
   loading?: boolean
@@ -28,6 +29,7 @@ class ReportFooter extends LitElement {
     :host {
       display: block;
       min-width: 0;
+      container-type: inline-size;
       color: var(--lv-fg-default);
       font-family: var(--fontStack-system);
     }
@@ -46,13 +48,21 @@ class ReportFooter extends LitElement {
 
     .status {
       display: inline-flex;
+      flex: 1 1 auto;
       min-width: 0;
       align-items: center;
       gap: var(--base-size-8);
+      overflow: hidden;
       color: var(--lv-fg-muted);
       font: var(--lv-type-caption);
       font-weight: var(--base-text-weight-medium);
       white-space: nowrap;
+    }
+
+    .status > span:last-child {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .dot {
@@ -73,17 +83,40 @@ class ReportFooter extends LitElement {
 
     lv-report-zoom {
       flex: 0 1 auto;
+      min-width: 0;
+    }
+
+    @container (max-width: 800px) {
+      footer {
+        justify-content: flex-end;
+        gap: 0;
+        padding-inline: var(--base-size-8);
+      }
+
+      .status {
+        display: none;
+      }
+
+      lv-report-zoom {
+        max-width: 100%;
+      }
     }
 
     @media (max-width: 560px) {
       footer {
-        height: auto;
+        height: var(--control-medium-size);
         min-height: var(--control-medium-size);
-        align-items: flex-start;
-        flex-direction: column;
-        gap: var(--base-size-8);
-        padding-block: var(--base-size-8);
-        padding-inline: var(--base-size-12);
+        justify-content: flex-end;
+        gap: 0;
+        padding-inline: var(--base-size-8);
+      }
+
+      .status {
+        display: none;
+      }
+
+      lv-report-zoom {
+        max-width: 100%;
       }
     }
   `

--- a/web/components/dashboard/report-view-controls.ts
+++ b/web/components/dashboard/report-view-controls.ts
@@ -1,0 +1,443 @@
+import { LitElement, css, html, nothing } from 'lit'
+import { state } from 'lit/decorators.js'
+import { ChevronDown, Maximize2, Minus, Monitor, MonitorSmartphone, MoveHorizontal, Plus, Smartphone, type IconNode } from 'lucide'
+import { lucideIcon } from '../shared/lucide-icons'
+import {
+  clampScale,
+  resolvedLayoutMode,
+  storedCustomScale,
+  storedLayoutMode,
+  storedZoomMode,
+  type LayoutMode,
+  type PresentationMode,
+  type ZoomCommand,
+  type ZoomState,
+} from './report-view-state'
+
+class ReportZoom extends LitElement {
+  @state() private layoutMode: LayoutMode = storedLayoutMode()
+  @state() private layout = resolvedLayoutMode(this.layoutMode)
+  @state() private mode: PresentationMode = storedZoomMode()
+  @state() private scale = storedCustomScale()
+
+  static styles = css`
+    :host {
+      position: relative;
+      display: inline-block;
+      max-width: 100%;
+      color: var(--lv-fg-default);
+      font-family: var(--fontStack-system);
+    }
+
+    .zoom {
+      display: inline-flex;
+      max-width: 100%;
+      align-items: center;
+      min-height: 32px;
+      gap: var(--base-size-2);
+      white-space: nowrap;
+    }
+
+    details {
+      position: relative;
+      flex: 0 0 auto;
+    }
+
+    summary {
+      display: inline-flex;
+      width: 32px;
+      min-width: 32px;
+      height: 32px;
+      box-sizing: border-box;
+      align-items: center;
+      justify-content: center;
+      border: 0;
+      border-radius: var(--lv-radius-default);
+      background: transparent;
+      color: var(--lv-fg-muted);
+      cursor: pointer;
+      padding: 0;
+      font: var(--lv-type-caption);
+      font-weight: var(--base-text-weight-medium);
+      list-style: none;
+      white-space: nowrap;
+    }
+
+    summary::-webkit-details-marker {
+      display: none;
+    }
+
+    summary:hover,
+    summary:focus-visible,
+    details[open] summary {
+      background: var(--lv-bg-panel-muted);
+      color: var(--lv-fg-default);
+    }
+
+    summary:focus-visible {
+      outline: 0;
+      outline: var(--lv-border-width-focus) solid var(--lv-line-accent-muted);
+      outline-offset: var(--base-size-2);
+    }
+
+    .layout-trigger {
+      width: 38px;
+      gap: var(--base-size-2);
+    }
+
+    .layout-trigger > svg {
+      width: 17px;
+      height: 17px;
+    }
+
+    .layout-trigger .chevron {
+      width: 10px;
+      height: 10px;
+      color: var(--lv-fg-muted);
+    }
+
+    .menu {
+      position: absolute;
+      z-index: var(--zIndex-popover, 300);
+      bottom: calc(100% + var(--base-size-6));
+      display: grid;
+      box-sizing: border-box;
+      gap: var(--base-size-4);
+      border: var(--lv-border-default);
+      border-radius: var(--lv-radius-default);
+      background: var(--lv-bg-panel);
+      padding: var(--base-size-8);
+      box-shadow: var(--shadow-floating-small);
+    }
+
+    .layout-menu {
+      left: 0;
+      width: 208px;
+    }
+
+    .zoom-menu {
+      right: 0;
+      width: 148px;
+    }
+
+    .group-label {
+      color: var(--lv-fg-muted);
+      padding: var(--base-size-4) var(--base-size-8) 0;
+      font: var(--lv-type-caption);
+      font-weight: var(--base-text-weight-semibold, 600);
+      text-transform: uppercase;
+    }
+
+    .divider {
+      height: 1px;
+      margin: var(--base-size-4) 0;
+      background: var(--lv-line-muted);
+    }
+
+    .menu-button {
+      display: flex;
+      width: 100%;
+      min-height: 32px;
+      box-sizing: border-box;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--base-size-6) var(--base-size-8);
+      text-align: left;
+      font: var(--lv-type-body-compact);
+    }
+
+    .option-label {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--base-size-8);
+    }
+
+    .option-label svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .menu-button[aria-pressed='true'] {
+      background: var(--bgColor-accent-muted);
+      color: var(--lv-fg-link);
+      font-weight: var(--base-text-weight-semibold, 600);
+    }
+
+    .current {
+      color: var(--lv-fg-muted);
+      font: var(--lv-type-caption);
+    }
+
+    button {
+      display: grid;
+      width: 32px;
+      min-width: 32px;
+      height: 32px;
+      place-items: center;
+      border: 0;
+      border-radius: var(--lv-radius-default);
+      background: transparent;
+      color: var(--lv-fg-muted);
+      cursor: pointer;
+      padding: 0;
+      font: inherit;
+    }
+
+    button:hover,
+    button:focus-visible {
+      background: var(--lv-bg-panel-muted);
+      color: var(--lv-fg-default);
+      outline: 0;
+    }
+
+    button[aria-pressed='true'] {
+      background: var(--bgColor-accent-muted);
+      color: var(--lv-fg-link);
+    }
+
+    svg {
+      width: 16px;
+      height: 16px;
+      fill: none;
+      stroke: currentColor;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-width: 2;
+    }
+
+    input {
+      appearance: none;
+      width: 100%;
+      min-width: 0;
+      height: 16px;
+      background: transparent;
+      cursor: pointer;
+    }
+
+    input::-webkit-slider-runnable-track {
+      height: 4px;
+      border-radius: var(--lv-radius-full);
+      background: var(--lv-line-muted);
+    }
+
+    input::-webkit-slider-thumb {
+      appearance: none;
+      width: 12px;
+      height: 12px;
+      margin-top: -4px;
+      border: var(--lv-border-default);
+      border-radius: var(--lv-radius-full);
+      background: var(--lv-fg-muted);
+    }
+
+    input::-moz-range-track {
+      height: 4px;
+      border-radius: var(--lv-radius-full);
+      background: var(--lv-line-muted);
+    }
+
+    input::-moz-range-thumb {
+      width: 12px;
+      height: 12px;
+      border: var(--lv-border-default);
+      border-radius: var(--lv-radius-full);
+      background: var(--lv-fg-muted);
+    }
+
+    input:focus-visible {
+      outline: 0;
+    }
+
+    input:focus-visible::-webkit-slider-thumb {
+      outline: var(--lv-border-width-focus) solid var(--lv-line-accent-muted);
+      outline-offset: 2px;
+    }
+
+    input:focus-visible::-moz-range-thumb {
+      outline: var(--lv-border-width-focus) solid var(--lv-line-accent-muted);
+      outline-offset: 2px;
+    }
+
+    .slider {
+      display: grid;
+      width: clamp(86px, 15vw, 176px);
+      min-width: 0;
+      margin-inline: var(--base-size-4);
+      padding-inline: var(--base-size-8);
+    }
+
+    .group-separator {
+      width: 1px;
+      height: 20px;
+      flex: 0 0 auto;
+      margin-inline: var(--base-size-4);
+      background: var(--lv-line-muted);
+    }
+
+    .mode-label {
+      width: auto;
+      min-width: 38px;
+      padding-inline: var(--base-size-6);
+      font: var(--lv-type-caption);
+    }
+
+    .percent-trigger {
+      width: auto;
+      min-width: 46px;
+      padding-inline: var(--base-size-6);
+    }
+
+    @media (max-width: 520px) {
+      .slider {
+        display: none;
+      }
+
+      .zoom-out {
+        order: 1;
+      }
+
+      .percent-menu {
+        order: 2;
+      }
+
+      .zoom-in {
+        order: 3;
+      }
+
+      .group-separator {
+        margin-inline: var(--base-size-2);
+      }
+    }
+  `
+
+  connectedCallback(): void {
+    super.connectedCallback()
+    document.addEventListener('lv-report-zoom-state', this.onZoomState as EventListener)
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener('lv-report-zoom-state', this.onZoomState as EventListener)
+    super.disconnectedCallback()
+  }
+
+  private onZoomState = (event: CustomEvent<ZoomState>): void => {
+    this.layoutMode = event.detail.layoutMode
+    this.layout = event.detail.layout
+    this.mode = event.detail.mode
+    this.scale = event.detail.scale
+  }
+
+  private command(detail: ZoomCommand): void {
+    const command = this.layout === 'mobile' && detail.layout === undefined
+      ? { ...detail, layout: 'desktop' as const }
+      : detail
+    this.dispatchEvent(new CustomEvent('lv-report-zoom-command', {
+      detail: command,
+      bubbles: true,
+      composed: true,
+    }))
+    this.shadowRoot?.querySelectorAll('details').forEach(details => details.removeAttribute('open'))
+  }
+
+  private nudge(delta: number): void {
+    this.command({ mode: 'custom', scale: clampScale(this.scale + delta) })
+  }
+
+  private slide(event: Event): void {
+    const input = event.currentTarget as HTMLInputElement
+    this.command({ mode: 'custom', scale: clampScale(Number(input.value) / 100) })
+  }
+
+  private layoutLabel(): string {
+    return `Layout, ${capitalize(this.layoutMode)}, currently ${capitalize(this.layout)}`
+  }
+
+  render() {
+    const percent = Math.round(this.scale * 100)
+    return html`
+      <div class="zoom" role="group" aria-label="Report view controls">
+        <details data-control="layout">
+          <summary class="layout-trigger" title="Layout" aria-label=${this.layoutLabel()}>
+            ${lucideIcon(layoutIcon(this.layoutMode))}
+            <span class="chevron" aria-hidden="true">${lucideIcon(ChevronDown)}</span>
+          </summary>
+          <div class="menu layout-menu" role="group" aria-label="Report layout">
+            <span class="group-label">Layout</span>
+            ${(['auto', 'desktop', 'mobile'] as const).map(layout => html`
+              <button
+                class="menu-button"
+                type="button"
+                data-layout=${layout}
+                aria-pressed=${String(this.layoutMode === layout)}
+                @click=${() => this.command({ layout })}
+              >
+                <span class="option-label">${lucideIcon(layoutIcon(layout))}<span>${capitalize(layout)}</span></span>
+                ${layout === 'auto' ? html`<span class="current">${capitalize(this.layout)}</span>` : nothing}
+              </button>
+            `)}
+          </div>
+        </details>
+        <span class="group-separator" aria-hidden="true"></span>
+        <button class="fit-action" data-mode="fit-width" type="button" title="Fit width" aria-label="Fit width" aria-pressed=${String(this.layout === 'desktop' && this.mode === 'fit-width')} @click=${() => this.command({ mode: 'fit-width' })}>
+          ${zoomIcon('fit-width')}
+        </button>
+        <button class="fit-action" data-mode="fit-page" type="button" title="Fit page" aria-label="Fit page" aria-pressed=${String(this.layout === 'desktop' && this.mode === 'fit-page')} @click=${() => this.command({ mode: 'fit-page' })}>
+          ${zoomIcon('fit-page')}
+        </button>
+        <button class="fit-action mode-label" data-mode="actual-size" type="button" title="Actual size" aria-label="Actual size" aria-pressed=${String(this.layout === 'desktop' && this.mode === 'actual-size')} @click=${() => this.command({ mode: 'actual-size' })}>
+          1:1
+        </button>
+        <span class="group-separator" aria-hidden="true"></span>
+        <button class="zoom-out" type="button" title="Zoom out" aria-label="Zoom out" @click=${() => this.nudge(-0.1)}>
+          ${zoomIcon('minus')}
+        </button>
+        <div class="slider">
+          <input type="range" min="10" max="200" .value=${String(percent)} aria-label="Zoom percent" aria-valuetext=${`${percent}%`} @input=${this.slide} />
+        </div>
+        <button class="zoom-in" type="button" title="Zoom in" aria-label="Zoom in" @click=${() => this.nudge(0.1)}>
+          ${zoomIcon('plus')}
+        </button>
+        <details class="percent-menu" data-control="zoom-presets">
+          <summary class="percent-trigger" title="Zoom presets" aria-label=${`Zoom presets, ${percent}%`}>${percent}%</summary>
+          <div class="menu zoom-menu" role="group" aria-label="Zoom presets">
+            <span class="group-label">Zoom</span>
+            ${zoomPresets.map(scale => html`
+              <button
+                class="menu-button"
+                type="button"
+                data-scale=${String(scale)}
+                aria-pressed=${String(this.mode === 'custom' && Math.abs(this.scale - scale) < 0.001)}
+                @click=${() => this.command({ mode: 'custom', scale })}
+              >${Math.round(scale * 100)}%</button>
+            `)}
+          </div>
+        </details>
+      </div>
+    `
+  }
+}
+
+function capitalize(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`
+}
+
+const zoomPresets = [0.5, 0.75, 1, 1.25, 1.5, 2] as const
+
+function layoutIcon(layout: LayoutMode): IconNode {
+  if (layout === 'desktop') return Monitor
+  if (layout === 'mobile') return Smartphone
+  return MonitorSmartphone
+}
+
+function zoomIcon(name: 'fit-width' | 'fit-page' | 'minus' | 'plus') {
+  const icons: Record<'fit-width' | 'fit-page' | 'minus' | 'plus', IconNode> = {
+    'fit-width': MoveHorizontal,
+    'fit-page': Maximize2,
+    minus: Minus,
+    plus: Plus,
+  }
+
+  return lucideIcon(icons[name])
+}
+
+customElements.define('lv-report-zoom', ReportZoom)

--- a/web/components/dashboard/report-view-state.ts
+++ b/web/components/dashboard/report-view-state.ts
@@ -1,0 +1,77 @@
+export type ZoomMode = 'fit-width' | 'fit-page' | 'actual-size' | 'custom'
+export type LayoutMode = 'auto' | 'desktop' | 'mobile'
+export type ResolvedLayout = Exclude<LayoutMode, 'auto'>
+export type PresentationMode = ZoomMode | 'mobile'
+
+export type ZoomCommand = {
+  layout?: LayoutMode
+  mode?: ZoomMode
+  scale?: number
+}
+
+export type ZoomState = {
+  layoutMode: LayoutMode
+  layout: ResolvedLayout
+  mode: PresentationMode
+  scale: number
+}
+
+export const autoMobileLayoutQuery = '(max-width: 640px)'
+
+export function layoutStorageKey(): string {
+  return `leapview-report-layout:${location.pathname}`
+}
+
+export function zoomScaleStorageKey(): string {
+  return `leapview-report-zoom-scale:${location.pathname}`
+}
+
+export function storedZoomMode(): ZoomMode {
+  try {
+    const value = localStorage.getItem(zoomStorageKey())
+    if (value === 'fit-width' || value === 'fit-page' || value === 'actual-size' || value === 'custom') {
+      return value
+    }
+  } catch {
+    // Ignore storage failures.
+  }
+  return 'fit-width'
+}
+
+export function storedLayoutMode(): LayoutMode {
+  try {
+    const value = localStorage.getItem(layoutStorageKey())
+    if (value === 'auto' || value === 'desktop' || value === 'mobile') return value
+  } catch {
+    // Ignore storage failures.
+  }
+  return 'auto'
+}
+
+export function resolvedLayoutMode(mode: LayoutMode, mobileViewport?: boolean): ResolvedLayout {
+  if (mode !== 'auto') return mode
+  const mobile = mobileViewport ?? (typeof window !== 'undefined' && window.matchMedia(autoMobileLayoutQuery).matches)
+  return mobile ? 'mobile' : 'desktop'
+}
+
+export function storedCustomScale(): number {
+  try {
+    return clampScale(Number(localStorage.getItem(zoomScaleStorageKey()) || 0.6))
+  } catch {
+    return 0.6
+  }
+}
+
+export function clampScale(value: number): number {
+  if (!Number.isFinite(value)) return 1
+  return Math.min(2, Math.max(0.1, value))
+}
+
+export function clampFittedScale(value: number): number {
+  if (!Number.isFinite(value)) return 1
+  return Math.min(2, Math.max(0.05, value))
+}
+
+export function zoomStorageKey(): string {
+  return `leapview-report-zoom:${location.pathname}`
+}


### PR DESCRIPTION
## Summary

- add viewer-controlled Auto, Desktop, and Mobile dashboard layouts so narrow screens can preserve the desktop canvas with internal scrolling
- add persistent fit-width, fit-page, actual-size, and custom zoom controls in a pinned bottom toolbar
- reorganize mobile page and filter controls, prevent panel overlap, and keep filters and view controls accessible while scrolling
- refine canvas overflow, spacing, scrollbar styling, filter backgrounds, and compact footer behavior
- extract report view controls and shared view state from the canvas component
- correct dashboard routes so the global navigation highlights Dashboards instead of Workspaces

## Verification

- task ci
- 38 dashboard DOM regression tests, including desktop preservation, fit-width overflow, mobile scrolling, pinned controls, filters, and responsive navigation
- live dashboard SSE verified with active navigation set to dashboards