### PR TITLE
Harden agent tool integrations and dev smoke checks

### DIFF
--- a/internal/agent/module/mcp.go
+++ b/internal/agent/module/mcp.go
@@ -3,6 +3,7 @@ package module
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -89,6 +90,9 @@ func (m *Module) mcpServer(r *http.Request) (*mcp.Server, error) {
 				Arguments: arguments,
 			})
 			if err != nil {
+				if errors.Is(err, agentcore.ErrInvalidToolArguments) {
+					return mcpErrorResult("invalid_arguments", err.Error()), nil
+				}
 				return mcpErrorResult("tool_execution_failed", err.Error()), nil
 			}
 			return mcpResult(result)

--- a/internal/agent/tools/apigen_provider.go
+++ b/internal/agent/tools/apigen_provider.go
@@ -149,7 +149,48 @@ func (p APIGenProvider) Run(ctx context.Context, scope Scope, operation APIGenOp
 	if err != nil {
 		return agentToolRuntimeError(err)
 	}
+	if result.IsError {
+		return apigenAgentToolError(agentToolHTTPErrorCode(result.StatusCode), agentToolHTTPErrorMessage(result.Content, result.StatusCode))
+	}
 	return agentcore.ToolResult{Content: result.Content, IsError: result.IsError}
+}
+
+func agentToolHTTPErrorCode(status int) string {
+	switch status {
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return "invalid_arguments"
+	case http.StatusUnauthorized:
+		return "authentication_required"
+	case http.StatusForbidden:
+		return "access_denied"
+	case http.StatusNotFound:
+		return "resource_not_found"
+	case http.StatusConflict:
+		return "conflict"
+	case http.StatusTooManyRequests:
+		return "rate_limited"
+	case http.StatusServiceUnavailable:
+		return "service_unavailable"
+	default:
+		return "agent_tool_failed"
+	}
+}
+
+func agentToolHTTPErrorMessage(content any, status int) string {
+	if envelope, ok := content.(map[string]any); ok {
+		if body, ok := envelope["body"].(map[string]any); ok {
+			for _, key := range []string{"message", "detail", "title"} {
+				if message, ok := body[key].(string); ok && strings.TrimSpace(message) != "" {
+					return strings.TrimSpace(message)
+				}
+			}
+		}
+	}
+	message := strings.TrimSpace(http.StatusText(status))
+	if message == "" {
+		message = "agent tool request failed"
+	}
+	return message
 }
 
 func normalizeCuratedQueryArguments(toolName string, arguments json.RawMessage) json.RawMessage {

--- a/internal/app/agent_tools_integration_test.go
+++ b/internal/app/agent_tools_integration_test.go
@@ -1,0 +1,420 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/app/config"
+	"github.com/flidai/leapview/internal/platform"
+	"github.com/flidai/leapview/internal/workspace"
+	workspacesqlite "github.com/flidai/leapview/internal/workspace/sqlite"
+)
+
+func TestMCPIntegrationCallsEveryAdvertisedAgentTool(t *testing.T) {
+	harness := newStoreBackedHarness(t)
+	called := map[string]bool{}
+
+	listed := mcpRequest(t, harness.handler, "dev", "2025-11-25", `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	if listed.Code != http.StatusOK {
+		t.Fatalf("list MCP tools: status=%d body=%s", listed.Code, listed.Body.String())
+	}
+	var listResponse struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(listed.Body.Bytes(), &listResponse); err != nil {
+		t.Fatalf("decode MCP tools: %v", err)
+	}
+
+	root := callAgentToolThroughMCP(t, harness.handler, called, "catalog_list", map[string]any{})
+	rootItems := integrationArray(t, root, "items")
+	if integrationInt(t, root, "count") != 1 || len(rootItems) != 1 {
+		t.Fatalf("catalog_list root = %#v, want one workspace", root)
+	}
+	workspaceItem := integrationObjectValue(t, rootItems[0], "catalog_list workspace")
+	workspaceRef := integrationObject(t, workspaceItem, "ref")
+	if integrationString(t, workspaceRef, "type") != "workspace" || integrationString(t, workspaceRef, "id") != "sales" {
+		t.Fatalf("catalog_list workspace ref = %#v, want sales workspace", workspaceRef)
+	}
+
+	search := callAgentToolThroughMCP(t, harness.handler, called, "catalog_search", map[string]any{
+		"query": "dashboard",
+		"types": []string{"dashboard"},
+	})
+	searchItems := integrationArray(t, search, "items")
+	if integrationInt(t, search, "count") != 1 || len(searchItems) != 1 {
+		t.Fatalf("typed catalog_search = %#v, want one dashboard", search)
+	}
+	searchItem := integrationObjectValue(t, searchItems[0], "catalog_search item")
+	if integrationString(t, searchItem, "name") != "Executive Sales" {
+		t.Fatalf("catalog_search item = %#v, want Executive Sales", searchItem)
+	}
+
+	dashboardRef := map[string]any{"workspaceId": "sales", "type": "dashboard", "id": "executive-sales"}
+	get := callAgentToolThroughMCP(t, harness.handler, called, "catalog_get", map[string]any{"ref": dashboardRef})
+	getItem := integrationObject(t, get, "item")
+	getDetails := integrationObject(t, get, "details")
+	if integrationString(t, getItem, "name") != "Executive Sales" || integrationString(t, getDetails, "type") != "dashboard" {
+		t.Fatalf("catalog_get dashboard = %#v", get)
+	}
+
+	semantic := callAgentToolThroughMCP(t, harness.handler, called, "query_semantic_model", map[string]any{
+		"workspace":  "sales",
+		"model":      "sales",
+		"dimensions": []map[string]any{{"field": "orders.status"}},
+		"measures":   []map[string]any{{"field": "order_count"}},
+		"limit":      10,
+	})
+	if integrationString(t, semantic, "queryId") == "" || len(integrationArray(t, semantic, "columns")) != 2 || len(integrationArray(t, semantic, "rows")) == 0 {
+		t.Fatalf("query_semantic_model result = %#v", semantic)
+	}
+
+	dashboardVisual := callAgentToolThroughMCP(t, harness.handler, called, "query_dashboard_visual", map[string]any{
+		"workspace": "sales",
+		"dashboard": "executive-sales",
+		"page":      "overview",
+		"visual":    "total_orders",
+		"limit":     10,
+	})
+	if integrationString(t, dashboardVisual, "visualId") != "total_orders" || len(integrationArray(t, dashboardVisual, "rows")) == 0 {
+		t.Fatalf("query_dashboard_visual result = %#v", dashboardVisual)
+	}
+	if status := integrationObject(t, dashboardVisual, "status"); integrationString(t, status, "kind") != "ready" {
+		t.Fatalf("query_dashboard_visual status = %#v", status)
+	}
+
+	visual := callAgentToolThroughMCP(t, harness.handler, called, "query_visual", map[string]any{
+		"workspace":  "sales",
+		"type":       "bar",
+		"model":      "sales",
+		"dataset":    "orders",
+		"dimensions": []map[string]any{{"field": "orders.status"}},
+		"measures":   []map[string]any{{"field": "order_count"}},
+		"limit":      10,
+	})
+	if ok, _ := visual["ok"].(bool); !ok || integrationString(t, visual, "queryId") == "" || len(integrationArray(t, visual, "fields")) != 2 {
+		t.Fatalf("query_visual result = %#v", visual)
+	}
+	if modelRef := integrationObject(t, visual, "modelRef"); integrationString(t, modelRef, "id") != "sales" {
+		t.Fatalf("query_visual model ref = %#v", modelRef)
+	}
+
+	docs := callAgentToolThroughMCP(t, harness.handler, called, "docs_search", map[string]any{
+		"query": "semantic models",
+		"limit": 1,
+	})
+	matches := integrationArray(t, docs, "matches")
+	if len(matches) != 1 {
+		t.Fatalf("docs_search result = %#v, want one match", docs)
+	}
+	docID := integrationString(t, integrationObjectValue(t, matches[0], "docs_search match"), "id")
+	read := callAgentToolThroughMCP(t, harness.handler, called, "docs_read", map[string]any{
+		"id": docID, "limit": 5,
+	})
+	if integrationString(t, read, "id") != docID || !strings.Contains(integrationString(t, read, "content"), "Semantic model") {
+		t.Fatalf("docs_read result = %#v", read)
+	}
+
+	advertised := make([]string, 0, len(listResponse.Result.Tools))
+	for _, tool := range listResponse.Result.Tools {
+		advertised = append(advertised, tool.Name)
+		if !called[tool.Name] {
+			t.Errorf("advertised agent tool %q has no integration call", tool.Name)
+		}
+	}
+	slices.Sort(advertised)
+	if len(called) != len(advertised) {
+		t.Fatalf("called tools = %#v, advertised tools = %#v", called, advertised)
+	}
+}
+
+func TestMCPIntegrationAgentToolContractMatrix(t *testing.T) {
+	harness := newStoreBackedHarness(t)
+
+	t.Run("invalid arguments use one MCP tool error shape", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			arguments map[string]any
+		}{
+			{name: "catalog_search", arguments: map[string]any{}},
+			{name: "catalog_list", arguments: map[string]any{"childTypes": []string{"dashboard"}}},
+			{name: "catalog_get", arguments: map[string]any{}},
+			{name: "query_semantic_model", arguments: map[string]any{}},
+			{name: "query_dashboard_visual", arguments: map[string]any{}},
+			{name: "query_visual", arguments: map[string]any{}},
+			{name: "docs_search", arguments: map[string]any{}},
+			{name: "docs_read", arguments: map[string]any{}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				code := callAgentToolErrorThroughMCP(t, harness.handler, tc.name, tc.arguments)
+				if code != "invalid_arguments" && code != "tool_validation_failed" {
+					t.Fatalf("%s invalid argument code = %q", tc.name, code)
+				}
+			})
+		}
+	})
+
+	t.Run("empty search is a successful empty page", func(t *testing.T) {
+		result := callAgentToolThroughMCP(t, harness.handler, map[string]bool{}, "catalog_search", map[string]any{
+			"query": "definitely-no-such-leapview-resource-7db4c2",
+		})
+		if integrationInt(t, result, "count") != 0 || len(integrationArray(t, result, "items")) != 0 || integrationBool(t, result, "hasMore") {
+			t.Fatalf("empty catalog search = %#v", result)
+		}
+	})
+
+	t.Run("unknown resources and query failures are tool errors", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			arguments map[string]any
+		}{
+			{name: "catalog_get", arguments: map[string]any{"ref": map[string]any{"workspaceId": "sales", "type": "dashboard", "id": "missing-dashboard"}}},
+			{name: "query_semantic_model", arguments: map[string]any{"workspace": "sales", "model": "missing-model", "measures": []map[string]any{{"field": "order_count"}}}},
+			{name: "query_dashboard_visual", arguments: map[string]any{"workspace": "sales", "dashboard": "executive-sales", "page": "overview", "visual": "missing-visual"}},
+			{name: "query_visual", arguments: map[string]any{"workspace": "sales", "type": "bar", "model": "sales", "dataset": "orders", "measures": []map[string]any{{"field": "missing_measure"}}}},
+			{name: "docs_read", arguments: map[string]any{"id": "doc:missing/integration-document.md"}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if code := callAgentToolErrorThroughMCP(t, harness.handler, tc.name, tc.arguments); code == "" || code == "invalid_arguments" {
+					t.Fatalf("%s runtime failure code = %q", tc.name, code)
+				}
+			})
+		}
+	})
+
+	t.Run("catalog and query cursors continue without repeating rows", func(t *testing.T) {
+		parent := map[string]any{"workspaceId": "sales", "type": "workspace", "id": "sales"}
+		firstCatalog := callAgentToolThroughMCP(t, harness.handler, map[string]bool{}, "catalog_list", map[string]any{
+			"parent": parent, "limit": 1,
+		})
+		if !integrationBool(t, firstCatalog, "hasMore") || integrationString(t, firstCatalog, "nextCursor") == "" {
+			t.Fatalf("first catalog page = %#v", firstCatalog)
+		}
+		secondCatalog := callAgentToolThroughMCP(t, harness.handler, map[string]bool{}, "catalog_list", map[string]any{
+			"parent": parent, "limit": 1, "cursor": integrationString(t, firstCatalog, "nextCursor"),
+		})
+		firstRef := integrationObject(t, integrationObjectValue(t, integrationArray(t, firstCatalog, "items")[0], "first catalog item"), "ref")
+		secondRef := integrationObject(t, integrationObjectValue(t, integrationArray(t, secondCatalog, "items")[0], "second catalog item"), "ref")
+		if integrationString(t, firstRef, "id") == integrationString(t, secondRef, "id") {
+			t.Fatalf("catalog cursor repeated item: first=%#v second=%#v", firstRef, secondRef)
+		}
+
+		query := map[string]any{
+			"workspace": "sales", "model": "sales",
+			"dimensions": []map[string]any{{"field": "orders.status", "alias": "status"}},
+			"measures":   []map[string]any{{"field": "order_count"}},
+			"sort":       []map[string]any{{"field": "status", "direction": "asc"}},
+			"limit":      1,
+		}
+		firstQuery := callAgentToolThroughMCP(t, harness.handler, map[string]bool{}, "query_semantic_model", query)
+		if !integrationBool(t, firstQuery, "hasMore") || integrationString(t, firstQuery, "nextCursor") == "" {
+			t.Fatalf("first semantic page = %#v", firstQuery)
+		}
+		query["pageToken"] = integrationString(t, firstQuery, "nextCursor")
+		secondQuery := callAgentToolThroughMCP(t, harness.handler, map[string]bool{}, "query_semantic_model", query)
+		firstRows := integrationArray(t, firstQuery, "rows")
+		secondRows := integrationArray(t, secondQuery, "rows")
+		if len(firstRows) != 1 || len(secondRows) != 1 || jsonObjectsEqualValue(firstRows[0], secondRows[0]) {
+			t.Fatalf("semantic cursor pages = first %#v second %#v", firstRows, secondRows)
+		}
+	})
+}
+
+func TestApplicationCompositionCatalogListsPersistedWorkspaces(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	application, err := Build(ctx, agentToolIntegrationConfig(home))
+	if err != nil {
+		t.Fatalf("build application: %v", err)
+	}
+	t.Cleanup(func() { _ = application.Shutdown(context.Background()) })
+
+	store, err := platform.Open(ctx, filepath.Join(home, "leapview.db"))
+	if err != nil {
+		t.Fatalf("open application store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	repository := workspacesqlite.NewRepository(store.SQLDB())
+	if err := repository.Ensure(ctx, workspace.EnsureInput{ID: "sales", Title: "Sales Workspace"}); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+
+	root := callAgentToolThroughMCP(t, application.Handler(), map[string]bool{}, "catalog_list", map[string]any{})
+	items := integrationArray(t, root, "items")
+	if integrationInt(t, root, "count") != 1 || len(items) != 1 {
+		t.Fatalf("production-composition catalog_list = %#v, want persisted workspace", root)
+	}
+	item := integrationObjectValue(t, items[0], "catalog_list workspace")
+	if integrationString(t, integrationObject(t, item, "ref"), "id") != "sales" {
+		t.Fatalf("production-composition catalog_list item = %#v", item)
+	}
+}
+
+func callAgentToolThroughMCP(t *testing.T, handler http.Handler, called map[string]bool, name string, arguments map[string]any) map[string]any {
+	t.Helper()
+	called[name] = true
+	envelope := callAgentToolMCPEnvelope(t, handler, name, arguments)
+	if envelope.Error != nil || envelope.Result.IsError || envelope.Result.StructuredContent == nil {
+		t.Fatalf("call %s failed: %#v", name, envelope)
+	}
+	if len(envelope.Result.Content) != 1 {
+		t.Fatalf("call %s content blocks = %d, want 1", name, len(envelope.Result.Content))
+	}
+	var textContent map[string]any
+	if err := json.Unmarshal([]byte(envelope.Result.Content[0].Text), &textContent); err != nil {
+		t.Fatalf("decode %s text content: %v", name, err)
+	}
+	if !jsonObjectsEqual(envelope.Result.StructuredContent, textContent) {
+		t.Fatalf("%s structured and text content differ", name)
+	}
+	return envelope.Result.StructuredContent
+}
+
+type agentToolMCPEnvelope struct {
+	Result struct {
+		IsError           bool           `json:"isError"`
+		StructuredContent map[string]any `json:"structuredContent"`
+		Content           []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"result"`
+	Error any `json:"error"`
+}
+
+func callAgentToolMCPEnvelope(t *testing.T, handler http.Handler, name string, arguments map[string]any) agentToolMCPEnvelope {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      name,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": name, "arguments": arguments,
+		},
+	})
+	if err != nil {
+		t.Fatalf("encode %s call: %v", name, err)
+	}
+	response := mcpRequest(t, handler, "dev", "2025-11-25", string(body))
+	if response.Code != http.StatusOK {
+		t.Fatalf("call %s: status=%d body=%s", name, response.Code, response.Body.String())
+	}
+	var envelope agentToolMCPEnvelope
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode %s response: %v body=%s", name, err, response.Body.String())
+	}
+	return envelope
+}
+
+func callAgentToolErrorThroughMCP(t *testing.T, handler http.Handler, name string, arguments map[string]any) string {
+	t.Helper()
+	envelope := callAgentToolMCPEnvelope(t, handler, name, arguments)
+	if envelope.Error != nil || !envelope.Result.IsError || envelope.Result.StructuredContent != nil || len(envelope.Result.Content) != 1 {
+		t.Fatalf("%s error envelope = %#v", name, envelope)
+	}
+	var content struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(envelope.Result.Content[0].Text), &content); err != nil {
+		t.Fatalf("decode %s tool error: %v", name, err)
+	}
+	if content.Error.Code == "" || content.Error.Message == "" {
+		t.Fatalf("%s tool error content = %#v", name, content)
+	}
+	return content.Error.Code
+}
+
+func integrationObject(t *testing.T, value map[string]any, key string) map[string]any {
+	t.Helper()
+	return integrationObjectValue(t, value[key], key)
+}
+
+func integrationObjectValue(t *testing.T, value any, label string) map[string]any {
+	t.Helper()
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want object", label, value)
+	}
+	return object
+}
+
+func integrationArray(t *testing.T, value map[string]any, key string) []any {
+	t.Helper()
+	items, ok := value[key].([]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want array in %#v", key, value[key], value)
+	}
+	return items
+}
+
+func integrationString(t *testing.T, value map[string]any, key string) string {
+	t.Helper()
+	text, ok := value[key].(string)
+	if !ok {
+		t.Fatalf("%s = %#v, want string in %#v", key, value[key], value)
+	}
+	return text
+}
+
+func integrationInt(t *testing.T, value map[string]any, key string) int {
+	t.Helper()
+	number, ok := value[key].(float64)
+	if !ok {
+		t.Fatalf("%s = %#v, want number in %#v", key, value[key], value)
+	}
+	return int(number)
+}
+
+func integrationBool(t *testing.T, value map[string]any, key string) bool {
+	t.Helper()
+	boolean, ok := value[key].(bool)
+	if !ok {
+		t.Fatalf("%s = %#v, want boolean in %#v", key, value[key], value)
+	}
+	return boolean
+}
+
+func jsonObjectsEqualValue(left, right any) bool {
+	leftJSON, _ := json.Marshal(left)
+	rightJSON, _ := json.Marshal(right)
+	return string(leftJSON) == string(rightJSON)
+}
+
+func agentToolIntegrationConfig(home string) config.Config {
+	return config.Config{
+		HomeDir:                       home,
+		ManagedDataBackend:            "local",
+		ManagedDataDir:                filepath.Join(home, "managed-data"),
+		ManagedDataMaxFiles:           100,
+		ManagedDataMaxFileBytes:       1 << 20,
+		ManagedDataMaxRevisionBytes:   10 << 20,
+		ManagedDataUploadSessionTTL:   time.Hour,
+		ManagedDataGCInterval:         time.Hour,
+		ManagedDataGCGracePeriod:      time.Hour,
+		ManagedDataMinFreeBytes:       1,
+		DuckDBNodeMemoryMaxBytes:      256 << 20,
+		DuckDBNodeTempMaxBytes:        1 << 30,
+		DuckDBNodeMaxThreads:          2,
+		QueryResultMaxRows:            10_000,
+		QueryResultMaxBytes:           32 << 20,
+		QueryCacheRuntimeMaxEntries:   16,
+		QueryCacheRuntimeMaxBytes:     4 << 20,
+		QueryCacheWorkspaceMaxEntries: 32,
+		QueryCacheWorkspaceMaxBytes:   8 << 20,
+		QueryCacheNodeMaxEntries:      64,
+		QueryCacheNodeMaxBytes:        16 << 20,
+	}
+}

--- a/internal/app/composition.go
+++ b/internal/app/composition.go
@@ -160,6 +160,10 @@ func buildRuntime(ctx context.Context, cfg config.Config, production bool, envir
 	if err != nil {
 		return fail(err)
 	}
+	workspaceReadModel, err := workspacemodule.BuildReadModel(store.SQLDB())
+	if err != nil {
+		return fail(err)
+	}
 	if !production {
 		if err := accessModule.SeedLocalDeveloperPlatformAdmin(ctx); err != nil {
 			return fail(err)
@@ -428,7 +432,7 @@ func buildRuntime(ctx context.Context, cfg config.Config, production bool, envir
 		dataAssemblyInputs{
 			Database: store.SQLDB(), PlatformHealth: store, AdminDatabase: store.SQLDB(),
 			ServingStateRepo: servingStateRepo, StorageRetention: retention,
-			WorkspaceDirectory: workspaceDirectory,
+			WorkspaceReadModel: workspaceReadModel, WorkspaceDirectory: workspaceDirectory,
 		},
 		capabilityAssemblyInputs{
 			AnalyticsModule: analyticsModule, DashboardAssets: dashboardAssets,

--- a/internal/app/mcp_test.go
+++ b/internal/app/mcp_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -331,15 +332,46 @@ func TestMCPAcceptsOAuthTokensAndRejectsGeneralAPITokens(t *testing.T) {
 		t.Fatalf("restricted OAuth token status = %d body=%s", response.Code, response.Body.String())
 	}
 
-	foreignWorkspace := mcpRequest(t, handler, oauthToken, "2025-11-25", `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"catalog_get","arguments":{"ref":{"workspaceId":"other","type":"workspace","id":"other"}}}}`)
-	if foreignWorkspace.Code != http.StatusOK || !strings.Contains(foreignWorkspace.Body.String(), `"isError":true`) {
-		t.Fatalf("foreign workspace response = %d body=%s", foreignWorkspace.Code, foreignWorkspace.Body.String())
+	foreignCalls := map[string]string{
+		"catalog_get":            `{"ref":{"workspaceId":"other","type":"workspace","id":"other"}}`,
+		"catalog_list":           `{"parent":{"workspaceId":"other","type":"workspace","id":"other"}}`,
+		"query_semantic_model":   `{"workspace":"other","model":"test","measures":[{"field":"order_count"}]}`,
+		"query_dashboard_visual": `{"workspace":"other","dashboard":"executive-sales","page":"overview","visual":"orders"}`,
+		"query_visual":           `{"workspace":"other","type":"bar","model":"test","dataset":"orders","measures":[{"field":"order_count"}]}`,
+	}
+	for name, arguments := range foreignCalls {
+		body := fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"method":"tools/call","params":{"name":%q,"arguments":%s}}`, name, name, arguments)
+		response := mcpRequest(t, handler, oauthToken, "2025-11-25", body)
+		if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"isError":true`) {
+			t.Fatalf("foreign workspace %s response = %d body=%s", name, response.Code, response.Body.String())
+		}
+	}
+	authorizedCatalog := mcpRequest(t, handler, oauthToken, "2025-11-25", `{"jsonrpc":"2.0","id":"authorized-catalog","method":"tools/call","params":{"name":"catalog_list","arguments":{}}}`)
+	if authorizedCatalog.Code != http.StatusOK || strings.Contains(authorizedCatalog.Body.String(), `"id":"other"`) {
+		t.Fatalf("authorized catalog leaked foreign workspace: %d body=%s", authorizedCatalog.Code, authorizedCatalog.Body.String())
 	}
 	audits, err := repo.ListAuditEvents(ctx, access.AuditEventFilter{WorkspaceID: "other", Action: "agent_tool.called"})
 	if err != nil {
 		t.Fatalf("list MCP tool audits: %v", err)
 	}
-	if len(audits) != 1 || audits[0].Status != "denied" || audits[0].TargetID != "catalog_get" {
+	deniedTargets := map[string]bool{}
+	for _, audit := range audits {
+		if audit.Status == "denied" {
+			deniedTargets[audit.TargetID] = true
+		}
+	}
+	wantDeniedTargets := map[string]string{
+		"catalog_get":            "catalog_get",
+		"query_semantic_model":   "querySemanticModel",
+		"query_dashboard_visual": "queryDashboardVisualData",
+		"query_visual":           "query_visual",
+	}
+	for name, target := range wantDeniedTargets {
+		if !deniedTargets[target] {
+			t.Errorf("foreign workspace call %s was not audited with target %s: %#v", name, target, audits)
+		}
+	}
+	if len(deniedTargets) != len(wantDeniedTargets) {
 		t.Fatalf("MCP credential denial was not audited: %#v", audits)
 	}
 

--- a/internal/deployment/candidate_service.go
+++ b/internal/deployment/candidate_service.go
@@ -363,7 +363,7 @@ func (service *CandidateService) expireOnRead(ctx context.Context, candidate Can
 	return Candidate{}, ErrCandidateConflict
 }
 
-func (service *CandidateService) record(ctx context.Context, action string, candidate Candidate, metadata map[string]any) error {
+func (service *CandidateService) record(ctx context.Context, operationID, action string, candidate Candidate, metadata map[string]any) error {
 	if service.audit == nil {
 		return ErrCandidateAuditUnavailable
 	}
@@ -374,10 +374,6 @@ func (service *CandidateService) record(ctx context.Context, action string, cand
 	metadata["baseGeneration"] = candidate.BaseGeneration
 	metadata["projectId"] = candidate.ProjectID
 	metadata["candidateKey"] = candidate.Key
-	operationID, command := apigencommand.OperationID(ctx)
-	if !command {
-		operationID, _ = candidateOperationID(action)
-	}
 	resumed, _ := metadata["resumed"].(bool)
 	payload := deploymentgen.GenSchemaCandidateAuditPayload{
 		OperationId: operationID, CandidateId: candidate.ID, ProjectId: candidate.ProjectID,
@@ -427,11 +423,16 @@ func (service *CandidateService) recordBestEffort(
 		logger = slog.Default()
 	}
 	operationID, command := apigencommand.OperationID(ctx)
-	if !command {
+	if command {
+		contract, ok := deploymentgen.GetAPIGenCommandRuntimeContract(operationID)
+		if !ok || contract.AuditAction != action {
+			operationID, command = candidateOperationID(action)
+		}
+	} else {
 		operationID, command = candidateOperationID(action)
 	}
 	if !command {
-		if err := service.record(ctx, action, candidate, metadata); err != nil {
+		if err := service.record(ctx, "", action, candidate, metadata); err != nil {
 			logger.ErrorContext(ctx, "candidate audit failed", "audit_action", action, "candidate_id", candidate.ID, "project_id", candidate.ProjectID, "principal_id", candidate.OwnerID, "error", err)
 		}
 		return
@@ -446,7 +447,7 @@ func (service *CandidateService) recordBestEffort(
 			if action != contract.AuditAction {
 				return fmt.Errorf("candidate audit action %q does not match generated action %q", action, contract.AuditAction)
 			}
-			return service.record(ctx, contract.AuditAction, candidate, metadata)
+			return service.record(ctx, contract.OperationID, contract.AuditAction, candidate, metadata)
 		},
 		LogMessage: "candidate audit failed",
 		LogAttributes: []slog.Attr{

--- a/internal/deployment/candidate_service_test.go
+++ b/internal/deployment/candidate_service_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
+	deploymentgen "github.com/flidai/leapview/internal/deployment/api/gen"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,6 +125,54 @@ func TestCandidateServicePreservesCommittedMutationWhenBestEffortAuditFails(t *t
 		!strings.Contains(output, "candidate_id=cand_audit_failure") ||
 		!strings.Contains(output, "audit store unavailable") {
 		t.Fatalf("audit failure log = %q", output)
+	}
+}
+
+func TestCandidateServiceUsesNestedAuditContractDuringSynchronization(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	repository := newCandidateMemoryRepository()
+	var events []CandidateEvent
+	var logs bytes.Buffer
+	service, err := NewCandidateService(repository, CandidateServiceConfig{
+		TargetID: "lvinst_prod", CanonicalOrigin: "https://prod.leapview.example", Environment: "prod",
+		Lifetime: time.Hour, MaxActivePerOwner: 4, Now: func() time.Time { return now },
+		NewID: func() (string, error) { return "cand_nested_audit", nil },
+		Audit: func(_ context.Context, event CandidateEvent) error {
+			events = append(events, event)
+			return nil
+		},
+		Logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	require.NoError(t, err)
+
+	contract, ok := deploymentgen.GetAPIGenCommandRuntimeContract(string(deploymentgen.GenOperationCommitProjectCandidateSynchronization))
+	if !ok {
+		t.Fatal("commit synchronization command contract is missing")
+	}
+	ctx, guard, err := apigencommand.Begin(t.Context(), contract)
+	require.NoError(t, err)
+	digest := "sha256:" + strings.Repeat("a", 64)
+	started, err := service.Start(ctx, StartCandidateRequest{
+		ProjectID: "finance", OwnerID: "principal_1", ArtifactDigest: digest,
+	})
+	require.NoError(t, err)
+	if guard.Completed() {
+		t.Fatal("nested candidate start completed the outer synchronization command")
+	}
+	_, err = service.MarkReady(ctx, candidateScopeForService(started.Candidate), digest, "sha256:"+strings.Repeat("b", 64))
+	require.NoError(t, err)
+	if !guard.Completed() {
+		t.Fatal("candidate ready audit did not complete the outer synchronization command")
+	}
+	if len(events) != 2 || events[0].Action != CandidateAuditStarted || events[1].Action != CandidateAuditReady {
+		t.Fatalf("nested synchronization audit events = %#v", events)
+	}
+	if !strings.Contains(events[0].MetadataJSON, `"operationId":"startProjectCandidate"`) ||
+		!strings.Contains(events[1].MetadataJSON, `"operationId":"commitProjectCandidateSynchronization"`) {
+		t.Fatalf("nested synchronization audit metadata = %#v", events)
+	}
+	if strings.Contains(logs.String(), "does not match generated action") {
+		t.Fatalf("nested synchronization logged an audit mismatch: %s", logs.String())
 	}
 }
 

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2514,6 +2514,48 @@ func TestDevelopmentServerTracksCompiledFallbackProcess(t *testing.T) {
 	}
 }
 
+func TestDevelopmentServerDefaultsAgentToAmbientDeepSeekCredential(t *testing.T) {
+	root := repoRoot(t)
+	server, err := os.ReadFile(filepath.Join(root, "scripts", "dev-server.sh"))
+	if err != nil {
+		t.Fatalf("read development server script: %v", err)
+	}
+	serverText := string(server)
+	for _, want := range []string{
+		`if [[ -z "${LEAPVIEW_AGENT_API_KEY:-}" && -n "${DEEPSEEK_API_KEY:-}" ]]; then`,
+		`LEAPVIEW_AGENT_API_KEY="$DEEPSEEK_API_KEY"`,
+		`LEAPVIEW_AGENT_BASE_URL="${LEAPVIEW_AGENT_BASE_URL:-https://api.deepseek.com}"`,
+		`LEAPVIEW_AGENT_MODEL="${LEAPVIEW_AGENT_MODEL:-deepseek-v4-flash}"`,
+	} {
+		if !strings.Contains(serverText, want) {
+			t.Fatalf("development server must configure the default DeepSeek agent without overriding explicit agent credentials: missing %q", want)
+		}
+	}
+}
+
+func TestDevelopmentServerRunsAgentMCPSmokeCheckAfterPublishing(t *testing.T) {
+	root := repoRoot(t)
+	server, err := os.ReadFile(filepath.Join(root, "scripts", "dev-server.sh"))
+	if err != nil {
+		t.Fatalf("read development server script: %v", err)
+	}
+	serverText := string(server)
+	for _, want := range []string{
+		"mcp_smoke()",
+		`"method":"tools/list"`,
+		`"name":"catalog_list"`,
+		`name:"query_semantic_model"`,
+		`mcp_smoke "$port"`,
+	} {
+		if !strings.Contains(serverText, want) {
+			t.Fatalf("development server must smoke-test the live MCP tool surface after publishing: missing %q", want)
+		}
+	}
+	if strings.Index(serverText, `go run ./cmd/leapview publish`) > strings.Index(serverText, `mcp_smoke "$port"`) {
+		t.Fatal("development MCP smoke check must run after candidate publication")
+	}
+}
+
 func TestDevelopmentPublishingCanonicalizesSharedDatasetRoots(t *testing.T) {
 	root := repoRoot(t)
 	server, err := os.ReadFile(filepath.Join(root, "scripts", "dev-server.sh"))
@@ -2599,7 +2641,7 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	goApplicationCI := workflowJobBlock(t, text, "go-application-validation")
 	frontendCI := workflowJobBlock(t, text, "frontend-validation")
 	for name, block := range map[string]string{
-		"apigen-validation":        apigenCI,
+		"apigen-validation":         apigenCI,
 		"go-packages-validation":    goPackagesCI,
 		"go-application-validation": goApplicationCI,
 		"frontend-validation":       frontendCI,

--- a/internal/workspace/module/persistence.go
+++ b/internal/workspace/module/persistence.go
@@ -31,6 +31,13 @@ func BuildDirectory(database *sql.DB, securables SecurableRegistrar) (Directory,
 	return &directory{repository: workspacesqlite.NewRepositoryWithSecurables(database, securables)}, nil
 }
 
+func BuildReadModel(database *sql.DB) (ReadModel, error) {
+	if database == nil {
+		return nil, errors.New("workspace database is required")
+	}
+	return workspacesqlite.NewRepository(database), nil
+}
+
 func (p *directory) Ensure(ctx context.Context, input workspace.EnsureInput) error {
 	return p.repository.Ensure(ctx, input)
 }

--- a/internal/workspace/search/service.go
+++ b/internal/workspace/search/service.go
@@ -412,6 +412,8 @@ func normalizeQuery(subject Subject, query Query) (RepositoryQuery, error) {
 	if len(normalizedTypes) == 0 {
 		text, normalizedTypes = implicitTypeFilters(text)
 		typeOperator = len(normalizedTypes) > 0
+	} else if filteredText, inferredTypes := implicitTypeFilters(text); len(inferredTypes) > 0 && catalogTypesInclude(normalizedTypes, inferredTypes) {
+		text = filteredText
 	}
 	noTypes := false
 	if len(allowedTypes) > 0 {
@@ -464,6 +466,19 @@ func intersectTypes(left, right []Type) []Type {
 		}
 	}
 	return out
+}
+
+func catalogTypesInclude(types, wanted []Type) bool {
+	available := make(map[Type]struct{}, len(types))
+	for _, typ := range types {
+		available[typ] = struct{}{}
+	}
+	for _, typ := range wanted {
+		if _, ok := available[typ]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func implicitTypeFilters(text string) (string, []Type) {

--- a/internal/workspace/search/service_test.go
+++ b/internal/workspace/search/service_test.go
@@ -125,6 +125,16 @@ func TestNormalizeQueryKeepsTextualTypeTermsWhenExplicitFiltersArePresent(t *tes
 	}
 }
 
+func TestNormalizeQueryRemovesRedundantTypeTermsMatchingExplicitFilters(t *testing.T) {
+	got, err := normalizeQuery(Subject{}, Query{Text: "executive dashboard", Types: []Type{TypeDashboard}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Text != "executive" || !slices.Equal(got.Types, []Type{TypeDashboard}) {
+		t.Fatalf("normalized query = %#v, want executive dashboard search", got)
+	}
+}
+
 func TestNormalizeQueryConstrainsResultsToAllowedTypes(t *testing.T) {
 	tests := map[string]struct {
 		query     Query

--- a/pkg/agent/tools.go
+++ b/pkg/agent/tools.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -11,6 +12,8 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"golang.org/x/sync/errgroup"
 )
+
+var ErrInvalidToolArguments = errors.New("invalid tool arguments")
 
 type ToolDefinition struct {
 	Name         string
@@ -98,14 +101,14 @@ func (c *ToolCatalog) Execute(ctx context.Context, call ToolCall) (ToolResult, e
 
 func validateCompiledToolCall(tool *compiledTool, call ToolCall) error {
 	if !json.Valid(call.Arguments) {
-		return fmt.Errorf("tool arguments must be valid JSON")
+		return fmt.Errorf("%w: arguments must be valid JSON", ErrInvalidToolArguments)
 	}
 	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(call.Arguments))
 	if err != nil {
-		return fmt.Errorf("tool arguments must be valid JSON: %w", err)
+		return fmt.Errorf("%w: arguments must be valid JSON: %v", ErrInvalidToolArguments, err)
 	}
 	if err := tool.schema.Validate(instance); err != nil {
-		return fmt.Errorf("tool arguments did not match the schema: %w", err)
+		return fmt.Errorf("%w: arguments did not match the schema: %v", ErrInvalidToolArguments, err)
 	}
 	return nil
 }

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -223,6 +223,69 @@ wait_ready() {
   return 1
 }
 
+mcp_call() {
+  local port="$1"
+  local body="$2"
+  local token="${LEAPVIEW_DEV_API_TOKEN:-dev}"
+  curl --fail --silent --show-error --max-time 15 \
+    --config <(printf 'header = "Authorization: Bearer %s"\n' "$token") \
+    --header 'Content-Type: application/json' \
+    --header 'Accept: application/json, text/event-stream' \
+    --header 'Mcp-Protocol-Version: 2025-11-25' \
+    --data "$body" \
+    "http://localhost:${port}/mcp"
+}
+
+mcp_smoke() {
+  local port="$1"
+  command -v jq >/dev/null 2>&1 || {
+    echo "jq is required for the development MCP smoke check" >&2
+    return 1
+  }
+
+  local listed
+  listed="$(mcp_call "$port" '{"jsonrpc":"2.0","id":"dev-tools","method":"tools/list","params":{}}')" || return 1
+  jq -e '
+    (.error == null) and
+    ([.result.tools[].name] | contains(["catalog_list", "catalog_search", "query_semantic_model"]))
+  ' <<<"$listed" >/dev/null || {
+    echo "Development MCP smoke check could not list the required tools" >&2
+    return 1
+  }
+
+  local catalog
+  catalog="$(mcp_call "$port" '{"jsonrpc":"2.0","id":"dev-catalog","method":"tools/call","params":{"name":"catalog_list","arguments":{}}}')" || return 1
+  jq -e '(.error == null) and (.result.isError != true) and (.result.structuredContent.count > 0)' <<<"$catalog" >/dev/null || {
+    echo "Development MCP smoke check found no accessible workspaces" >&2
+    return 1
+  }
+
+  local measure
+  measure="$(mcp_call "$port" '{"jsonrpc":"2.0","id":"dev-measure","method":"tools/call","params":{"name":"catalog_search","arguments":{"query":"measure","types":["measure"],"limit":1}}}')" || return 1
+  local query_arguments
+  query_arguments="$(jq -ce '
+    .result.structuredContent.items[0] as $item |
+    ($item.hierarchy[] | select(.ref.type == "semantic_model") | .ref.id) as $model |
+    {workspace: $item.ref.workspaceId, model: $model, measures: [{field: $item.ref.id}], limit: 1}
+  ' <<<"$measure")" || {
+    echo "Development MCP smoke check could not resolve a semantic measure" >&2
+    return 1
+  }
+
+  local query_body query
+  query_body="$(jq -cn --argjson arguments "$query_arguments" '{jsonrpc:"2.0", id:"dev-query", method:"tools/call", params:{name:"query_semantic_model", arguments:$arguments}}')"
+  query="$(mcp_call "$port" "$query_body")" || return 1
+  jq -e '
+    (.error == null) and (.result.isError != true) and
+    (.result.structuredContent.queryId | type == "string" and length > 0) and
+    (.result.structuredContent.rows | type == "array")
+  ' <<<"$query" >/dev/null || {
+    echo "Development MCP smoke check semantic query failed" >&2
+    return 1
+  }
+  echo "Agent MCP smoke check passed"
+}
+
 canonical_source_root() {
 	local source_root="$1"
 	if [[ "$source_root" != /* ]]; then
@@ -268,6 +331,7 @@ publish_project() {
 	fi
   go run ./cmd/leapview dev --once --no-browser --project "$project" --target "http://localhost:${port}" --token dev
 	go run ./cmd/leapview publish --project "$project" --target "http://localhost:${port}" --token dev
+	mcp_smoke "$port"
 }
 
 publish_running() {
@@ -364,6 +428,11 @@ start() {
   export LEAPVIEW_ADDR=":$port"
   export LEAPVIEW_DEV_WORKTREE="$ROOT"
   export LEAPVIEW_MANAGED_DATA_MIN_FREE_BYTES="${LEAPVIEW_MANAGED_DATA_MIN_FREE_BYTES:-67108864}"
+  if [[ -z "${LEAPVIEW_AGENT_API_KEY:-}" && -n "${DEEPSEEK_API_KEY:-}" ]]; then
+    export LEAPVIEW_AGENT_API_KEY="$DEEPSEEK_API_KEY"
+    export LEAPVIEW_AGENT_BASE_URL="${LEAPVIEW_AGENT_BASE_URL:-https://api.deepseek.com}"
+    export LEAPVIEW_AGENT_MODEL="${LEAPVIEW_AGENT_MODEL:-deepseek-v4-flash}"
+  fi
 
   : > "$LOG_FILE"
   if [[ "$runner" == "air" ]]; then


### PR DESCRIPTION
## Summary

- add real MCP integration coverage for all eight advertised agent tools, including invalid inputs, empty results, missing resources, pagination, query failures, and cross-workspace authorization
- wire the persisted workspace read model into production composition and normalize explicit catalog type searches
- return stable MCP validation and generated-query error envelopes
- correct nested candidate synchronization audit contracts
- default local development to the ambient DeepSeek credential and run a live MCP smoke check after publication

## Bugs fixed

- root catalog browsing returned no persisted workspaces
- typed dashboard searches treated `dashboard` as literal full-text input
- candidate start audits were evaluated against the outer candidate-ready contract
- MCP schema failures were collapsed to `tool_execution_failed`
- generated query errors exposed inconsistent raw HTTP payloads

## Verification

- `task ci`
- live post-publish MCP smoke check
- Tailscale-shared development endpoint verified healthy