### PR TITLE
Add global pipeline monitoring

### DIFF
--- a/api/signals/main.tsp
+++ b/api/signals/main.tsp
@@ -15,6 +15,7 @@ namespace LeapViewUISignals;
 enum RouteKind {
   dashboard: "dashboard",
   catalog: "catalog",
+  pipelines: "pipelines",
   chat: "chat",
   workspace: "workspace",
   workspaceAsset: "workspace_asset",
@@ -361,6 +362,90 @@ model CatalogPageSignal {
 	`listQuery`?: string;
 	`title`: string;
 	`workspaceFilters`: CatalogWorkspaceFilterSignal[];
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["workspace", "pipelines", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "pipelines" })
+model PipelineMetricSignal {
+  `detail`?: string;
+  `label`: string;
+  `tone`?: string;
+  `value`: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["workspace", "pipelines", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "pipelines" })
+model PipelineListItemSignal {
+  `assetId`: string;
+  `canRun`: boolean;
+  `description`?: string;
+  `duration`?: string;
+  `href`: string;
+  `id`: string;
+  `lastSuccessful`?: string;
+  `nextRun`?: string;
+  `pipelineId`: string;
+  `running`: boolean;
+  `schedule`: string;
+  `semanticModel`: string;
+  `status`: string;
+  `title`: string;
+  `workspace`: string;
+  `workspaceId`: string;
+}
+
+model PipelineWorkspaceFilterSignal {
+  `id`: string;
+  `title`: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["workspace", "pipelines", "command"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "command", `x-leapview-surface`: "pipelines" })
+model PipelineCommandSignal {
+  `action`: string;
+  `assetId`: string;
+  `pipelineId`: string;
+  `runId`: string;
+  `workspaceId`: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["workspace", "pipelines", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "pipelines" })
+model PipelineCommandStatusSignal {
+  `error`: string;
+  `loading`: boolean;
+  `message`: string;
+}
+
+@apigen.contract(#{ kind: "ui-envelope", tags: #["workspace", "pipelines", "envelope"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "envelope", `x-leapview-surface`: "pipelines" })
+model PipelinePageEnvelope {
+  @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "chrome" })
+  `chrome`: ChromeSignal;
+  @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "page" })
+  `page`: PipelinePageSignal;
+  @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "pipelineCommand" })
+  `pipelineCommand`: PipelineCommandSignal;
+  @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "pipelineCommandStatus" })
+  `pipelineCommandStatus`: PipelineCommandStatusSignal;
+  @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "runtime" })
+  `runtime`: RouteRuntimeSignal;
+  @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "status" })
+  `status`: DashboardStatus;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["workspace", "pipelines", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "pipelines" })
+model PipelinePageSignal {
+  `activeTab`: string;
+  `description`: string;
+  `environment`: string;
+  `kind`: RouteKind;
+  `metrics`: PipelineMetricSignal[];
+  `pipelines`: PipelineListItemSignal[];
+  `runsTable`: RecordTableSignal;
+  `title`: string;
+  `workspaceFilters`: PipelineWorkspaceFilterSignal[];
 }
 
 model ChatArtifactSignal {

--- a/api/typespec/refresh_runs.tsp
+++ b/api/typespec/refresh_runs.tsp
@@ -129,6 +129,7 @@ interface RefreshRuns {
   @route("/{run}/cancel")
   @post
   @apigen.authz(#{ mode: "privilege", privilege: "USE_WORKSPACE" })
+  @apigen.ui("workspace.refresh.cancel")
   @apigen.failsWith(RefreshRunNotFoundFailure)
   @apigen.failsWith(RefreshRunForbiddenFailure)
   @apigen.failsWith(RefreshRunNotCancellableFailure)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -49294,6 +49294,8 @@ paths:
         - Refresh Runs
       x-apigen-operation-kind: command
       x-apigen-command:
+        additional_exposures:
+          - ui
         audit:
           guarantee: best-effort
           payload:
@@ -49337,6 +49339,8 @@ paths:
         target:
           parameter: workspace
           type: workspace
+        ui:
+          action_id: workspace.refresh.cancel
         privilege: USE_WORKSPACE
       x-authz:
         mode: privilege

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -860,8 +860,8 @@ func TestAPIGenOwnsUISignalContracts(t *testing.T) {
 	if irDoc.SchemaVersion != "v4" {
 		t.Fatalf("UI signal IR schema_version = %q, want v4", irDoc.SchemaVersion)
 	}
-	if len(irDoc.Contracts) != 114 {
-		t.Fatalf("UI signal IR contracts = %d, want 114", len(irDoc.Contracts))
+	if len(irDoc.Contracts) != 120 {
+		t.Fatalf("UI signal IR contracts = %d, want 120", len(irDoc.Contracts))
 	}
 	foundEnvelopeMetadata := false
 	foundImportedVisualizationRoot := false

--- a/internal/app/page_stream.go
+++ b/internal/app/page_stream.go
@@ -12,6 +12,7 @@ import (
 const (
 	routeLogin           = "login"
 	routeCatalog         = "catalog"
+	routePipelines       = "pipelines"
 	routeDashboard       = "dashboard"
 	routeWorkspace       = "workspace"
 	routeWorkspaceAsset  = "workspace_asset"
@@ -29,7 +30,7 @@ func configurePageStream(routes *capabilityRoutes, runtime *runtimeServices, pla
 			switch route {
 			case routeLogin:
 				return next, true
-			case routeCatalog:
+			case routeCatalog, routePipelines:
 				return routes.accessModule.ProtectAnyWorkspaceNamed("VIEW_ITEM", next), true
 			case routeWorkspace, routeConnections:
 				return routes.accessModule.ProtectAnyWorkspaceNamed("VIEW_ITEM", next), true
@@ -57,6 +58,7 @@ func configurePageStream(routes *capabilityRoutes, runtime *runtimeServices, pla
 			}
 		},
 		Handlers: map[string]http.Handler{
+			routePipelines: http.HandlerFunc(routes.workspaceModule.HTTP().PipelinesBootstrapUpdates),
 			routeDashboard: http.HandlerFunc(routes.dashboardModule.HTTP().Updates),
 			routeChat:      http.HandlerFunc(routes.agentModule.HTTP().ChatUpdates),
 			routeData:      http.HandlerFunc(routes.workspaceModule.HTTP().DataExplorerUpdates),

--- a/internal/app/route_inventory_test.go
+++ b/internal/app/route_inventory_test.go
@@ -84,7 +84,7 @@ func TestRouteInventory(t *testing.T) {
 		rows = append(rows, fmt.Sprintf("%s|%s|%s|%s", key, contract.owner, contract.access, contract.privilege))
 	}
 	sort.Strings(rows)
-	const expectedRouteContractDigest = "bbd7254d0cf0ff84e2caca0991a0ee63af5560d78852469be79ff14bffae7e41"
+	const expectedRouteContractDigest = "997cc9868be63955edafe98376584ecefc63b71a0722d3495d5330548f2a4521"
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(rows, "\n"))))
 	if digest != expectedRouteContractDigest {
 		t.Fatalf("route ownership/auth contract changed: got digest %s\n%s", digest, strings.Join(rows, "\n"))
@@ -183,7 +183,7 @@ func nonAPIRouteMetadata(method, path string) (routeMetadata, bool) {
 	case path == "/workspaces/{workspace}/catalog/appearance":
 		authenticated.owner = "workspace"
 		authenticated.privilege = "MANAGE_WORKSPACE"
-	case path == "/" || path == "/catalog/search" || path == "/data" || path == "/data/command" ||
+	case path == "/" || path == "/catalog/search" || path == "/pipelines" || path == "/pipelines/command" || path == "/data" || path == "/data/command" ||
 		strings.HasPrefix(path, "/workspaces") || strings.HasPrefix(path, "/connections"):
 		authenticated.owner = "workspace"
 		authenticated.privilege = "VIEW_ITEM"
@@ -299,6 +299,7 @@ GET /login
 GET /profile/avatars/{principal}/{digest}
 GET /product/logo/{digest}
 GET /metrics
+GET /pipelines
 GET /public/dashboards/{publicId}
 GET /public/dashboards/{publicId}/pages/{page}
 GET /public/dashboards/{publicId}/updates
@@ -349,6 +350,7 @@ POST /oauth/register
 POST /oauth/device/code
 POST /oauth/revoke
 POST /oauth/token
+POST /pipelines/command
 PUT /profile/avatar
 PUT /admin/product-logo
 POST /public/dashboards/{publicId}/commands/clear-selection

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -677,9 +677,24 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 			AuthConfigured:     platform.auth != nil,
 			RuntimeEnvironment: policy.defaultEnvironment,
 			RefreshState:       workspaceRefreshStateBridge{support: refreshSupport},
-			RefreshRunner: workspacemodule.AssetRefreshFunc(func(ctx context.Context, input workspacemodule.AssetRefreshInput) error {
-				return refreshSupport.RefreshAsset(ctx, input.Request, input.WorkspaceID, input.Asset, input.Assets, input.Edges)
-			}),
+			RefreshCapacity: func(context.Context) (workspacemodule.PipelineMonitorCapacity, error) {
+				stats := workloadController(&runtime.workloads).Stats()
+				refreshStats := stats.Classes[workloadmodule.RefreshClass]
+				return workspacemodule.PipelineMonitorCapacity{
+					Running: refreshStats.Running, Queued: refreshStats.Queued, MaximumRunning: refreshStats.Policy.MaximumRunning,
+				}, nil
+			},
+			RefreshRunner: workspacemodule.AssetRefreshFuncs{
+				Run: func(ctx context.Context, input workspacemodule.AssetRefreshInput) error {
+					return refreshSupport.RefreshAsset(ctx, input.Request, input.WorkspaceID, input.Asset, input.Assets, input.Edges)
+				},
+				Retry: func(ctx context.Context, input workspacemodule.AssetRefreshInput, retryOf string) error {
+					return refreshSupport.RetryAsset(ctx, input.Request, input.WorkspaceID, input.Asset, input.Assets, input.Edges, retryOf)
+				},
+				Cancel: func(ctx context.Context, input workspacemodule.PipelineRunCancelInput) error {
+					return refreshSupport.CancelRefreshRun(ctx, input.Request, input.WorkspaceID, input.PipelineID, input.RunID)
+				},
+			},
 			Broker:           runtime.broker,
 			CSRFToken:        routes.accessModule.CSRFToken,
 			CurrentRoleLabel: routes.accessModule.CurrentRoleLabel,

--- a/internal/app/shell/shell.go
+++ b/internal/app/shell/shell.go
@@ -143,6 +143,7 @@ func Provider(config Config) webpage.Provider {
 func globalNavigation() []Item {
 	return []Item{
 		{ID: "dashboards", Label: "Dashboards", Href: "/", Icon: "dashboard", Meta: optional("Reports")},
+		{ID: "pipelines", Label: "Pipelines", Href: "/pipelines", Icon: "workflow", Meta: optional("Refresh monitoring")},
 		{ID: "chat", Label: "Chats", Href: "/chats", Icon: "chat", Meta: optional("Agent interface")},
 		{ID: "workspaces", Label: "Workspaces", Href: "/workspaces", Icon: "catalog", Meta: optional("Published assets")},
 		{ID: "data", Label: "Data", Href: "/data", Icon: "cache", Meta: optional("Inspect rows")},

--- a/internal/app/shell/shell_test.go
+++ b/internal/app/shell/shell_test.go
@@ -18,7 +18,7 @@ func TestProviderOwnsGlobalNavigationAndAgentHistory(t *testing.T) {
 	if !ok {
 		t.Fatalf("signal = %T, want shell.Chrome", layout.Signal)
 	}
-	if len(chrome.Sidebar.Groups) != 1 || len(chrome.Sidebar.Groups[0].Items) != 5 {
+	if len(chrome.Sidebar.Groups) != 1 || len(chrome.Sidebar.Groups[0].Items) != 6 {
 		t.Fatalf("navigation = %#v", chrome.Sidebar.Groups)
 	}
 	if chrome.Sidebar.UserName == nil || *chrome.Sidebar.UserName != "Ada Lovelace" {
@@ -33,6 +33,19 @@ func TestProviderOwnsGlobalNavigationAndAgentHistory(t *testing.T) {
 	if chrome.Sidebar.History == nil || len(chrome.Sidebar.History.Items) != 1 || !chrome.Sidebar.History.Items[0].Active {
 		t.Fatalf("history = %#v", chrome.Sidebar.History)
 	}
+}
+
+func TestGlobalNavigationIncludesInstancePipelines(t *testing.T) {
+	items := globalNavigation()
+	for _, item := range items {
+		if item.ID == "pipelines" {
+			if item.Href != "/pipelines" || item.Label != "Pipelines" || item.Icon != "workflow" {
+				t.Fatalf("pipelines navigation = %#v", item)
+			}
+			return
+		}
+	}
+	t.Fatal("global navigation does not include pipelines")
 }
 
 func TestProviderProjectsCustomProductIdentity(t *testing.T) {

--- a/internal/app/workspace_refresh_adapters.go
+++ b/internal/app/workspace_refresh_adapters.go
@@ -46,6 +46,7 @@ func workspaceAssetRefreshState(state refreshmodule.AssetRefreshState) workspace
 	return workspacemodule.AssetRefreshState{
 		CSRFToken:        state.CSRFToken,
 		RunCommand:       state.RunCommand,
+		CancelCommand:    state.CancelCommand,
 		Runs:             workspaceAssetRefreshRuns(state.Runs),
 		Latest:           workspaceAssetRefreshRun(state.Latest),
 		LatestSuccessful: workspaceAssetRefreshRun(state.LatestSuccessful),
@@ -67,8 +68,11 @@ func workspaceAssetRefreshRuns(runs []refreshmodule.AssetRefreshRun) []workspace
 
 func workspaceAssetRefreshRun(run refreshmodule.AssetRefreshRun) workspacemodule.AssetRefreshRun {
 	return workspacemodule.AssetRefreshRun{
-		ID: run.ID, PrincipalDisplayName: run.PrincipalDisplayName, TriggerType: run.TriggerType,
-		Status: run.Status, StartedAt: run.StartedAt, FinishedAt: run.FinishedAt, Error: run.Error,
+		ID: run.ID, Environment: run.Environment, ModelID: run.ModelID, ServingStateID: run.ServingStateID,
+		PrincipalID: run.PrincipalID, PrincipalDisplayName: run.PrincipalDisplayName, TriggerType: run.TriggerType,
+		ParentRunID: run.ParentRunID, RetryOf: run.RetryOf, TargetGeneration: run.TargetGeneration,
+		Status: run.Status, CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+		StartedAt: run.StartedAt, FinishedAt: run.FinishedAt, Error: run.Error,
 	}
 }
 
@@ -121,6 +125,20 @@ func workspaceRefreshSupport(deps *workspaceRefreshDependencies) refreshmodule.W
 				return fmt.Errorf("refresh module is required")
 			}
 			return refresh.VerifyRunCreated(ctx, run)
+		},
+		CancelRun: func(ctx context.Context, workspaceID, runID string) (refreshmodule.RunRecord, error) {
+			refresh := deps.refresh()
+			if refresh == nil {
+				return refreshmodule.RunRecord{}, fmt.Errorf("refresh module is required")
+			}
+			return refresh.CancelRun(ctx, workspaceID, runID)
+		},
+		RunCancelled: func(ctx context.Context, run refreshmodule.RunRecord) error {
+			refresh := deps.refresh()
+			if refresh == nil {
+				return fmt.Errorf("refresh module is required")
+			}
+			return refresh.VerifyRunCancelled(ctx, run)
 		},
 		Environment: func(r *http.Request) servingstatemodule.Environment {
 			return requestServingEnvironment(deps.defaultEnvironment, r)

--- a/internal/refresh/module/api.go
+++ b/internal/refresh/module/api.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
 	apigenfailure "github.com/Yacobolo/toolbelt/apigen/runtime/failure"
@@ -55,10 +56,44 @@ func (m *Module) verifyRunCreated(ctx context.Context, run refreshrun.RunRecord)
 	})
 }
 
+func (m *Module) verifyRunCancelled(ctx context.Context, run refreshrun.RunRecord) error {
+	logger := m.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	executor, err := apigencommand.NewExecutor(refreshgen.GetAPIGenCommandRuntimeContract, logger)
+	if err != nil {
+		return err
+	}
+	return executor.Execute(ctx, string(refreshgen.GenOperationCancelRefreshRun), apigencommand.Execution{
+		BestEffortAudit: func(ctx context.Context, contract apigencommand.Contract) error {
+			if m.events == nil {
+				return errors.New("refresh event store is unavailable")
+			}
+			encoded, err := refreshgen.EncodeGenCancelRefreshRunAuditPayload(refreshgen.GenSchemaRefreshCancelledAuditPayload{
+				Id: run.ID, WorkspaceId: run.WorkspaceID,
+				PipelineId: strings.TrimPrefix(run.TargetID, run.WorkspaceID+"."),
+				Status:     run.Status, Trigger: run.TriggerType,
+			})
+			if err != nil {
+				return err
+			}
+			_, err = m.events.AppendEvent(ctx, m.refreshExecution.ResourceKind, run.ID, contract.AuditAction, []byte(encoded))
+			return err
+		},
+		LogMessage:    "refresh audit failed",
+		LogAttributes: []slog.Attr{slog.String("refresh_run_id", run.ID)},
+	})
+}
+
 // VerifyRunCreated completes the generated createRefreshRun policy after a
 // non-API surface has atomically queued the same refresh lifecycle.
 func (m *Module) VerifyRunCreated(ctx context.Context, run refreshrun.RunRecord) error {
 	return m.verifyRunCreated(ctx, run)
+}
+
+func (m *Module) VerifyRunCancelled(ctx context.Context, run refreshrun.RunRecord) error {
+	return m.verifyRunCancelled(ctx, run)
 }
 
 func (m *Module) runFinished(after func(context.Context, refreshrun.RunRecord)) func(context.Context, refreshrun.JobRecord) {
@@ -134,30 +169,7 @@ func (m *Module) CancelRefreshRun(w http.ResponseWriter, r *http.Request, worksp
 		writeRefreshCommandFailure(m, w, r, operationID, errors.New("refresh response is invalid"))
 		return
 	}
-	logger := m.logger
-	if logger == nil {
-		logger = slog.Default()
-	}
-	executor, err := apigencommand.NewExecutor(refreshgen.GetAPIGenCommandRuntimeContract, logger)
-	if err != nil {
-		writeRefreshCommandFailure(m, w, r, operationID, err)
-		return
-	}
-	if err := executor.Execute(r.Context(), string(refreshgen.GenOperationCancelRefreshRun), apigencommand.Execution{
-		BestEffortAudit: func(ctx context.Context, contract apigencommand.Contract) error {
-			encoded, err := refreshgen.EncodeGenCancelRefreshRunAuditPayload(refreshgen.GenSchemaRefreshCancelledAuditPayload{
-				Id: response.ID, WorkspaceId: response.WorkspaceID, PipelineId: response.PipelineID,
-				Status: response.Status, Trigger: response.Trigger,
-			})
-			if err != nil {
-				return err
-			}
-			_, err = m.events.AppendEvent(ctx, m.refreshExecution.ResourceKind, runID, contract.AuditAction, []byte(encoded))
-			return err
-		},
-		LogMessage:    "refresh audit failed",
-		LogAttributes: []slog.Attr{slog.String("refresh_run_id", runID)},
-	}); err != nil {
+	if err := m.verifyRunCancelled(r.Context(), row); err != nil {
 		writeRefreshCommandFailure(m, w, r, operationID, err)
 		return
 	}

--- a/internal/refresh/module/operation_contracts_test.go
+++ b/internal/refresh/module/operation_contracts_test.go
@@ -36,6 +36,10 @@ func TestRefreshRunLifecycleOperationContracts(t *testing.T) {
 	if create.UI == nil || create.UI.ActionID != "workspace.refresh.run" || len(create.AdditionalExposures) != 1 || string(create.AdditionalExposures[0]) != "ui" {
 		t.Errorf("create refresh UI contract = %#v", create)
 	}
+	cancel := contracts["cancelRefreshRun"].Command
+	if cancel.UI == nil || cancel.UI.ActionID != "workspace.refresh.cancel" || len(cancel.AdditionalExposures) != 1 || string(cancel.AdditionalExposures[0]) != "ui" {
+		t.Errorf("cancel refresh UI contract = %#v", cancel)
+	}
 	if create.Execution == nil || create.Execution.Guarantee != "transactional" ||
 		create.Execution.JobKind != "refresh_pipeline" || create.Execution.ResourceKind != "refresh" ||
 		create.Execution.InitialEvent != refreshQueuedAuditAction || create.Execution.InitialState != "queued" ||

--- a/internal/refresh/module/workspace_support.go
+++ b/internal/refresh/module/workspace_support.go
@@ -19,6 +19,7 @@ import (
 )
 
 type RunReader interface {
+	GetRun(context.Context, string, string) (refresh.RunRecord, error)
 	ListTargetRuns(context.Context, string, string, string, refresh.RunPage) ([]refresh.RunRecord, error)
 	LatestSuccessfulTargetRun(context.Context, string, string, string, string) (refresh.RunRecord, bool, error)
 }
@@ -38,6 +39,8 @@ type WorkspaceSupport struct {
 	Runs           func() (RunReader, error)
 	QueuePipeline  func(context.Context, refresh.QueuePipelineInput) (refresh.QueueAssetResult, error)
 	RunCreated     func(context.Context, refresh.RunRecord) error
+	CancelRun      func(context.Context, string, string) (refresh.RunRecord, error)
+	RunCancelled   func(context.Context, refresh.RunRecord) error
 	Environment    func(*nethttp.Request) servingstate.Environment
 	PrincipalID    func(*nethttp.Request) string
 	DispatchQueued func()
@@ -52,7 +55,11 @@ type WorkspaceSupport struct {
 }
 
 func (s WorkspaceSupport) RefreshAsset(_ context.Context, r *nethttp.Request, workspaceID string, asset workspace.AssetView, assets []workspace.AssetView, edges []workspace.AssetEdgeView) error {
-	return s.queueAssetRefreshWithPatches(r, workspaceID, asset, assets, edges)
+	return s.queueAssetRefreshWithPatches(r, workspaceID, asset, assets, edges, "")
+}
+
+func (s WorkspaceSupport) RetryAsset(_ context.Context, r *nethttp.Request, workspaceID string, asset workspace.AssetView, assets []workspace.AssetView, edges []workspace.AssetEdgeView, retryOf string) error {
+	return s.queueAssetRefreshWithPatches(r, workspaceID, asset, assets, edges, retryOf)
 }
 
 func (s WorkspaceSupport) AssetRefreshState(ctx context.Context, workspaceID, environment string, asset workspace.AssetView) (refreshpresentation.AssetRefreshState, error) {
@@ -71,8 +78,9 @@ func (s WorkspaceSupport) AssetRefreshState(ctx context.Context, workspaceID, en
 		return refreshpresentation.AssetRefreshState{}, err
 	}
 	state := refreshpresentation.AssetRefreshState{
-		RunCommand: refreshgen.GenUIActionCreateRefreshRun(),
-		Runs:       uiRefreshRuns(runs),
+		RunCommand:    refreshgen.GenUIActionCreateRefreshRun(),
+		CancelCommand: refreshgen.GenUIActionCancelRefreshRun(),
+		Runs:          uiRefreshRuns(runs),
 	}
 	pipelineID := strings.TrimPrefix(asset.Key, workspaceID+".")
 	if s.DataVersions != nil {
@@ -115,7 +123,7 @@ func refreshPipelineModelID(asset workspace.AssetView) string {
 	return ""
 }
 
-func (s WorkspaceSupport) queueAssetRefreshWithPatches(r *nethttp.Request, workspaceID string, asset workspace.AssetView, assets []workspace.AssetView, edges []workspace.AssetEdgeView) error {
+func (s WorkspaceSupport) queueAssetRefreshWithPatches(r *nethttp.Request, workspaceID string, asset workspace.AssetView, assets []workspace.AssetView, edges []workspace.AssetEdgeView, retryOf string) error {
 	operationID := refreshgen.GenCommandOperationCreateRefreshRun()
 	if err := uicommand.VerifyClaim(uicommand.OperationClaims(r), operationID.APIGenOperationID()); err != nil {
 		return err
@@ -143,12 +151,32 @@ func (s WorkspaceSupport) queueAssetRefreshWithPatches(r *nethttp.Request, works
 		environment = s.Environment(r)
 	}
 	pipelineID := strings.TrimPrefix(asset.Key, workspaceID+".")
+	trigger := refresh.TriggerManual
+	retryOf = strings.TrimSpace(retryOf)
+	if retryOf != "" {
+		repo, repoErr := s.runRepository()
+		if repoErr != nil {
+			return repoErr
+		}
+		prior, priorErr := repo.GetRun(ctx, workspaceID, retryOf)
+		if priorErr != nil {
+			return errors.New("retry run was not found")
+		}
+		if prior.Status == refresh.RunStatusQueued || prior.Status == refresh.RunStatusRunning {
+			return errors.New("retry run is not terminal")
+		}
+		if prior.Environment != string(environment) || prior.TargetType != refresh.TargetRefreshPipeline || prior.TargetID != workspaceID+"."+pipelineID {
+			return errors.New("retry run does not belong to the pipeline")
+		}
+		trigger = refresh.TriggerRetry
+	}
 	result, err := s.QueuePipeline(ctx, refresh.QueuePipelineInput{
 		WorkspaceID: workspaceID,
 		Environment: environment,
 		PrincipalID: s.principalID(r),
 		PipelineID:  pipelineID,
-		TriggerType: refresh.TriggerManual,
+		TriggerType: trigger,
+		RetryOf:     retryOf,
 	})
 	if err != nil {
 		return err
@@ -160,6 +188,40 @@ func (s WorkspaceSupport) queueAssetRefreshWithPatches(r *nethttp.Request, works
 		s.DispatchQueued()
 	}
 	return nil
+}
+
+func (s WorkspaceSupport) CancelRefreshRun(_ context.Context, r *nethttp.Request, workspaceID, pipelineID, runID string) error {
+	operationID := refreshgen.GenCommandOperationCancelRefreshRun()
+	if err := uicommand.VerifyClaim(uicommand.OperationClaims(r), operationID.APIGenOperationID()); err != nil {
+		return err
+	}
+	requestID := strings.TrimSpace(r.Header.Get("X-Request-ID"))
+	ctx, _, err := refreshgen.BeginGenCancelRefreshRunCommand(r.Context(), refreshgen.GenCancelRefreshRunCommandInvocation{
+		Surface:        apigencommand.SurfaceUI,
+		Workspace:      strings.TrimSpace(workspaceID),
+		IdempotencyKey: "ui:" + operationID.APIGenOperationID() + ":" + requestID,
+		RequestID:      requestID,
+		CorrelationID:  strings.TrimSpace(r.Header.Get("X-Correlation-ID")),
+	})
+	if err != nil {
+		return err
+	}
+	repo, err := s.runRepository()
+	if err != nil {
+		return err
+	}
+	prior, err := repo.GetRun(ctx, workspaceID, runID)
+	if err != nil || prior.TargetType != refresh.TargetRefreshPipeline || prior.TargetID != workspaceID+"."+pipelineID {
+		return errors.New("refresh run does not belong to the pipeline")
+	}
+	if s.CancelRun == nil || s.RunCancelled == nil {
+		return errors.New("refresh cancellation service is required")
+	}
+	cancelled, err := s.CancelRun(ctx, workspaceID, runID)
+	if err != nil {
+		return err
+	}
+	return s.RunCancelled(ctx, cancelled)
 }
 
 func (s WorkspaceSupport) PublishWorkspaceAssetRefreshPatch(r *nethttp.Request, workspaceID string, asset workspace.AssetView, assets []workspace.AssetView, edges []workspace.AssetEdgeView) {
@@ -274,9 +336,18 @@ func uiRefreshRuns(runs []refresh.RunRecord) []refreshpresentation.AssetRefreshR
 func uiRefreshRun(run refresh.RunRecord) refreshpresentation.AssetRefreshRun {
 	return refreshpresentation.AssetRefreshRun{
 		ID:                   run.ID,
+		Environment:          run.Environment,
+		ModelID:              run.ModelID,
+		ServingStateID:       run.ServingStateID,
+		PrincipalID:          run.PrincipalID,
 		PrincipalDisplayName: run.PrincipalDisplayName,
 		TriggerType:          run.TriggerType,
+		ParentRunID:          run.ParentRunID,
+		RetryOf:              run.RetryOf,
+		TargetGeneration:     run.TargetGeneration,
 		Status:               run.Status,
+		CreatedAt:            run.CreatedAt,
+		UpdatedAt:            run.UpdatedAt,
 		StartedAt:            run.StartedAt,
 		FinishedAt:           run.FinishedAt,
 		Error:                run.Error,

--- a/internal/refresh/module/workspace_support_test.go
+++ b/internal/refresh/module/workspace_support_test.go
@@ -50,3 +50,80 @@ func TestWorkspaceRefreshExecutesGeneratedUICommandContract(t *testing.T) {
 		t.Fatalf("queued=%v completed=%v", queued, completed)
 	}
 }
+
+func TestWorkspaceRefreshRetryAndCancelExecuteGeneratedUICommandContracts(t *testing.T) {
+	asset := workspace.AssetView{ID: "refresh_pipeline:daily", Key: "sales.daily", Type: string(workspace.AssetTypeRefreshPipeline)}
+	prior := refreshrun.RunRecord{
+		ID: "run_failed", WorkspaceID: "sales", Environment: "dev", TargetType: refreshrun.TargetRefreshPipeline,
+		TargetID: "sales.daily", Status: refreshrun.RunStatusFailed,
+	}
+	reader := workspaceSupportRunReader{run: prior}
+	var retryQueued, cancelled bool
+	support := WorkspaceSupport{
+		Runs: func() (RunReader, error) { return reader, nil },
+		QueuePipeline: func(ctx context.Context, input refreshrun.QueuePipelineInput) (refreshrun.QueueAssetResult, error) {
+			operationID, ok := apigencommand.OperationID(ctx)
+			if !ok || operationID != string(refreshgen.GenOperationCreateRefreshRun) || input.TriggerType != refreshrun.TriggerRetry || input.RetryOf != prior.ID {
+				t.Fatalf("retry invocation = operation %q, input %#v", operationID, input)
+			}
+			retryQueued = true
+			return refreshrun.QueueAssetResult{Run: refreshrun.RunRecord{ID: "run_retry"}}, nil
+		},
+		RunCreated: func(ctx context.Context, _ refreshrun.RunRecord) error {
+			return executeWorkspaceSupportCommand(ctx, string(refreshgen.GenOperationCreateRefreshRun))
+		},
+		CancelRun: func(_ context.Context, workspaceID, runID string) (refreshrun.RunRecord, error) {
+			if workspaceID != "sales" || runID != prior.ID {
+				t.Fatalf("cancel target = %s/%s", workspaceID, runID)
+			}
+			cancelled = true
+			row := prior
+			row.Status = refreshrun.RunStatusCancelled
+			return row, nil
+		},
+		RunCancelled: func(ctx context.Context, _ refreshrun.RunRecord) error {
+			return executeWorkspaceSupportCommand(ctx, string(refreshgen.GenOperationCancelRefreshRun))
+		},
+	}
+
+	retryRequest := httptest.NewRequest(http.MethodPost, "/pipelines/command", nil)
+	retryRequest.Header.Set(uicommand.HeaderOperationID, string(refreshgen.GenOperationCreateRefreshRun))
+	retryRequest.Header.Set("X-Request-ID", "retry-request")
+	if err := support.RetryAsset(t.Context(), retryRequest, "sales", asset, nil, nil, prior.ID); err != nil {
+		t.Fatalf("retry asset: %v", err)
+	}
+
+	cancelRequest := httptest.NewRequest(http.MethodPost, "/pipelines/command", nil)
+	cancelRequest.Header.Set(uicommand.HeaderOperationID, string(refreshgen.GenOperationCancelRefreshRun))
+	cancelRequest.Header.Set("X-Request-ID", "cancel-request")
+	if err := support.CancelRefreshRun(t.Context(), cancelRequest, "sales", "daily", prior.ID); err != nil {
+		t.Fatalf("cancel refresh run: %v", err)
+	}
+	if !retryQueued || !cancelled {
+		t.Fatalf("retryQueued=%v cancelled=%v", retryQueued, cancelled)
+	}
+}
+
+type workspaceSupportRunReader struct{ run refreshrun.RunRecord }
+
+func (r workspaceSupportRunReader) GetRun(context.Context, string, string) (refreshrun.RunRecord, error) {
+	return r.run, nil
+}
+
+func (workspaceSupportRunReader) ListTargetRuns(context.Context, string, string, string, refreshrun.RunPage) ([]refreshrun.RunRecord, error) {
+	return nil, nil
+}
+
+func (workspaceSupportRunReader) LatestSuccessfulTargetRun(context.Context, string, string, string, string) (refreshrun.RunRecord, bool, error) {
+	return refreshrun.RunRecord{}, false, nil
+}
+
+func executeWorkspaceSupportCommand(ctx context.Context, operationID string) error {
+	executor, err := apigencommand.NewExecutor(refreshgen.GetAPIGenCommandRuntimeContract, nil)
+	if err != nil {
+		return err
+	}
+	return executor.Execute(ctx, operationID, apigencommand.Execution{
+		BestEffortAudit: func(context.Context, apigencommand.Contract) error { return nil },
+	})
+}

--- a/internal/refresh/presentation/state.go
+++ b/internal/refresh/presentation/state.go
@@ -11,6 +11,7 @@ import (
 type AssetRefreshState struct {
 	CSRFToken        string
 	RunCommand       uicommand.Binding
+	CancelCommand    uicommand.Binding
 	Runs             []AssetRefreshRun
 	Latest           AssetRefreshRun
 	LatestSuccessful AssetRefreshRun
@@ -27,9 +28,18 @@ type AssetDataVersion struct {
 
 type AssetRefreshRun struct {
 	ID                   string
+	Environment          string
+	ModelID              string
+	ServingStateID       string
+	PrincipalID          string
 	PrincipalDisplayName string
 	TriggerType          string
+	ParentRunID          string
+	RetryOf              string
+	TargetGeneration     int64
 	Status               string
+	CreatedAt            string
+	UpdatedAt            string
 	StartedAt            string
 	FinishedAt           string
 	Error                string

--- a/internal/workload/module/module.go
+++ b/internal/workload/module/module.go
@@ -33,6 +33,7 @@ func JobAdmitter(admitter Admitter) jobs.Admitter {
 
 const (
 	BackgroundClass  = workload.Background
+	RefreshClass     = workload.Refresh
 	ControlClass     = workload.Control
 	MaintenanceClass = workload.Maintenance
 	GlobalWorkspace  = workload.GlobalWorkspace

--- a/internal/workspace/http/handler.go
+++ b/internal/workspace/http/handler.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Yacobolo/toolbelt/pagestream"
 	"github.com/flidai/leapview/internal/access"
@@ -35,6 +36,7 @@ type Handler struct {
 	Environment              func(*nethttp.Request) string
 	ReadModel                ReadModel
 	RefreshState             RefreshStateProvider
+	RefreshCapacity          func(context.Context) (ui.PipelineMonitorCapacity, error)
 	RefreshRunner            AssetRefreshRunner
 	Broker                   *pagestream.Broker
 	CSRFToken                func(*nethttp.Request) string
@@ -50,6 +52,7 @@ type Handler struct {
 	AgentBootstrap           func(*nethttp.Request, string) ui.DataExplorerAgentBootstrap
 	AgentCommands            ui.DataExplorerAgentCommandBindings
 	Layout                   func(*nethttp.Request) webpage.Provider
+	AuthorizeObject          func(context.Context, string, access.Privilege, access.ObjectRef) (bool, error)
 }
 
 type workspaceAccessSignalPayload struct {
@@ -68,6 +71,10 @@ type workspaceAssetFilterSignalPayload struct {
 type entityListSignalPayload struct {
 	Query  *string `json:"entityListQuery"`
 	Filter *string `json:"entityListFilter"`
+}
+
+type pipelineCommandSignalPayload struct {
+	PipelineCommand uisignals.PipelineCommandSignal `json:"pipelineCommand"`
 }
 
 func (h Handler) AccessSearch(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -110,6 +117,202 @@ func (h Handler) WorkspaceCatalog(w nethttp.ResponseWriter, r *nethttp.Request) 
 	if err := ui.WorkspacesPageForEnvironmentQuery(h.catalogForWorkspacesPage(r, workspaces), workspaces, h.environment(r), query, h.currentRoleLabel(r), h.csrfToken(r), h.chromeOptions(r)...).Render(w); err != nil {
 		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
 	}
+}
+
+func (h Handler) Pipelines(w nethttp.ResponseWriter, r *nethttp.Request) {
+	state, workspaces, err := h.pipelineMonitorState(r)
+	if err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(nethttp.StatusOK)
+	if err := ui.PipelinesPage(h.catalogForWorkspacesPage(r, workspaces), state, r.URL.Query().Get("view"), h.currentRoleLabel(r), h.chromeOptions(r)...).Render(w); err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+	}
+}
+
+func (h Handler) PipelinesBootstrapUpdates(w nethttp.ResponseWriter, r *nethttp.Request) {
+	clientID := pagestream.EnsureClientID(w, r)
+	var trace *pagestream.TraceStore
+	if broker := h.broker(); broker != nil {
+		trace = broker.TraceStore()
+	}
+	updates := pagestream.NewSignalStream(w, r, pagestream.WithStreamTrace(trace, "pipelines:"+clientID, "pipelines.bootstrap"))
+	view := r.URL.Query().Get("view")
+	state, workspaces, err := h.pipelineMonitorState(r)
+	if err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+		return
+	}
+	if err := updates.Patch(ui.PipelinesBootstrapSignals(h.catalogForWorkspacesPage(r, workspaces), state, view, h.currentRoleLabel(r), h.chromeOptions(r)...)); err != nil {
+		return
+	}
+
+	poll := time.NewTicker(2 * time.Second)
+	defer poll.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-poll.C:
+			state, _, err = h.pipelineMonitorState(r)
+			if err != nil {
+				if patchErr := updates.Patch(pagestream.SignalPatch{"status": map[string]any{"loading": false, "error": err.Error()}}); patchErr != nil {
+					return
+				}
+				continue
+			}
+			if err := updates.Patch(ui.PipelinesPagePatch(state, view)); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (h Handler) PipelineCommand(w nethttp.ResponseWriter, r *nethttp.Request) {
+	var signals pipelineCommandSignalPayload
+	if err := pagestream.ReadSignals(r, &signals); err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	command := signals.PipelineCommand
+	command.Action = strings.ToLower(strings.TrimSpace(command.Action))
+	command.WorkspaceID = h.workspaceID(command.WorkspaceID)
+	command.AssetID = strings.TrimSpace(command.AssetID)
+	command.PipelineID = strings.TrimSpace(command.PipelineID)
+	command.RunID = strings.TrimSpace(command.RunID)
+	if command.WorkspaceID == "" || command.AssetID == "" || command.PipelineID == "" {
+		nethttp.Error(w, "pipeline command target is required", nethttp.StatusBadRequest)
+		return
+	}
+	if command.Action != "run" && command.Action != "retry" && command.Action != "cancel" {
+		nethttp.Error(w, "unsupported pipeline command", nethttp.StatusBadRequest)
+		return
+	}
+	if command.Action != "run" && command.RunID == "" {
+		nethttp.Error(w, "pipeline run id is required", nethttp.StatusBadRequest)
+		return
+	}
+	visible := false
+	workspaces, err := h.workspaceList(r)
+	if err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+		return
+	}
+	for _, candidate := range workspaces {
+		if candidate.ID == command.WorkspaceID {
+			visible = true
+			break
+		}
+	}
+	if !visible {
+		nethttp.Error(w, "pipeline was not found", nethttp.StatusNotFound)
+		return
+	}
+	assets, edges, err := h.assetsAndEdges(r, command.WorkspaceID)
+	if err != nil {
+		nethttp.Error(w, err.Error(), statusForNotFound(err))
+		return
+	}
+	asset, ok := workspace.AssetByID(assets, command.AssetID)
+	if !ok || asset.Type != string(workspace.AssetTypeRefreshPipeline) || strings.TrimPrefix(asset.Key, command.WorkspaceID+".") != command.PipelineID {
+		nethttp.Error(w, "pipeline was not found", nethttp.StatusNotFound)
+		return
+	}
+	privilege := access.PrivilegeRefreshData
+	if command.Action == "cancel" {
+		privilege = access.PrivilegeUseWorkspace
+	}
+	allowed, err := h.canPipelineCommand(r, command.WorkspaceID, privilege)
+	if err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+		return
+	}
+	if !allowed {
+		nethttp.Error(w, "pipeline command is not permitted", nethttp.StatusForbidden)
+		return
+	}
+	if h.RefreshRunner == nil {
+		nethttp.Error(w, "pipeline command service is unavailable", nethttp.StatusServiceUnavailable)
+		return
+	}
+	input := AssetRefreshInput{Request: r, WorkspaceID: command.WorkspaceID, Asset: asset, Assets: assets, Edges: edges}
+	var message string
+	switch command.Action {
+	case "run":
+		err = h.RefreshRunner.RefreshAsset(r.Context(), input)
+		message = "Pipeline run queued."
+	case "retry":
+		err = h.RefreshRunner.RetryAsset(r.Context(), input, command.RunID)
+		message = "Pipeline retry queued."
+	case "cancel":
+		err = h.RefreshRunner.CancelRefreshRun(r.Context(), PipelineRunCancelInput{Request: r, WorkspaceID: command.WorkspaceID, PipelineID: command.PipelineID, RunID: command.RunID})
+		message = "Pipeline run cancelled."
+	}
+	status := uisignals.PipelineCommandStatusSignal{Message: message}
+	if err != nil {
+		status.Message = ""
+		status.Error = err.Error()
+	}
+	_ = pagestream.PatchResponse(w, r, pagestream.SignalPatch{"pipelineCommandStatus": status})
+}
+
+func (h Handler) canPipelineCommand(r *nethttp.Request, workspaceID string, privilege access.Privilege) (bool, error) {
+	principal, ok := h.ReadModel.currentPrincipal(r)
+	if !ok {
+		return !h.ReadModel.AuthConfigured, nil
+	}
+	if principal.DevBypass {
+		return true, nil
+	}
+	if h.AuthorizeObject == nil {
+		return false, nil
+	}
+	return h.AuthorizeObject(r.Context(), principal.ID, privilege, access.WorkspaceObject(workspaceID))
+}
+
+func (h Handler) pipelineMonitorState(r *nethttp.Request) (ui.PipelineMonitorState, []workspace.WorkspaceView, error) {
+	workspaces, err := h.workspaceList(r)
+	if err != nil {
+		return ui.PipelineMonitorState{}, nil, err
+	}
+	state := ui.PipelineMonitorState{Environment: h.environment(r), CSRFToken: h.csrfToken(r)}
+	if h.RefreshCapacity != nil {
+		state.Capacity, err = h.RefreshCapacity(r.Context())
+		if err != nil {
+			return ui.PipelineMonitorState{}, nil, err
+		}
+	}
+	for _, workspaceView := range workspaces {
+		assets, _, assetsErr := h.assetsAndEdges(r, workspaceView.ID)
+		if assetsErr != nil {
+			return ui.PipelineMonitorState{}, nil, assetsErr
+		}
+		for _, asset := range assets {
+			if asset.Type != "refresh_pipeline" {
+				continue
+			}
+			refresh, refreshErr := h.assetRefreshState(r.Context(), workspaceView.ID, state.Environment, asset)
+			if refreshErr != nil {
+				return ui.PipelineMonitorState{}, nil, refreshErr
+			}
+			canRun, authErr := h.canPipelineCommand(r, workspaceView.ID, access.PrivilegeRefreshData)
+			if authErr != nil {
+				return ui.PipelineMonitorState{}, nil, authErr
+			}
+			canCancel, authErr := h.canPipelineCommand(r, workspaceView.ID, access.PrivilegeUseWorkspace)
+			if authErr != nil {
+				return ui.PipelineMonitorState{}, nil, authErr
+			}
+			if state.RunCommand.OperationID() == "" {
+				state.RunCommand = refresh.RunCommand
+				state.CancelCommand = refresh.CancelCommand
+			}
+			state.Pipelines = append(state.Pipelines, ui.PipelineMonitorPipeline{Workspace: workspaceView, Asset: asset, Refresh: refresh, CanRun: canRun, CanCancel: canCancel})
+		}
+	}
+	return state, workspaces, nil
 }
 
 func (h Handler) WorkspaceListSearch(w nethttp.ResponseWriter, r *nethttp.Request) {

--- a/internal/workspace/http/ports.go
+++ b/internal/workspace/http/ports.go
@@ -146,6 +146,8 @@ type RefreshStateProvider interface {
 
 type AssetRefreshRunner interface {
 	RefreshAsset(ctx context.Context, input AssetRefreshInput) error
+	RetryAsset(ctx context.Context, input AssetRefreshInput, retryOf string) error
+	CancelRefreshRun(ctx context.Context, input PipelineRunCancelInput) error
 }
 
 type AssetRefreshInput struct {
@@ -154,4 +156,11 @@ type AssetRefreshInput struct {
 	Asset       workspace.AssetView
 	Assets      []workspace.AssetView
 	Edges       []workspace.AssetEdgeView
+}
+
+type PipelineRunCancelInput struct {
+	Request     *nethttp.Request
+	WorkspaceID string
+	PipelineID  string
+	RunID       string
 }

--- a/internal/workspace/module/assets.go
+++ b/internal/workspace/module/assets.go
@@ -65,3 +65,22 @@ func (r moduleRefreshRunner) RefreshAsset(ctx context.Context, input workspaceht
 		Asset: input.Asset, Assets: input.Assets, Edges: input.Edges,
 	})
 }
+
+func (r moduleRefreshRunner) RetryAsset(ctx context.Context, input workspacehttp.AssetRefreshInput, retryOf string) error {
+	if r.upstream == nil {
+		return nil
+	}
+	return r.upstream.RetryAsset(ctx, AssetRefreshInput{
+		Request: input.Request, WorkspaceID: input.WorkspaceID,
+		Asset: input.Asset, Assets: input.Assets, Edges: input.Edges,
+	}, retryOf)
+}
+
+func (r moduleRefreshRunner) CancelRefreshRun(ctx context.Context, input workspacehttp.PipelineRunCancelInput) error {
+	if r.upstream == nil {
+		return nil
+	}
+	return r.upstream.CancelRefreshRun(ctx, PipelineRunCancelInput{
+		Request: input.Request, WorkspaceID: input.WorkspaceID, PipelineID: input.PipelineID, RunID: input.RunID,
+	})
+}

--- a/internal/workspace/module/module.go
+++ b/internal/workspace/module/module.go
@@ -66,16 +66,38 @@ type AssetRefreshInput struct {
 
 type AssetRefreshRunner interface {
 	RefreshAsset(context.Context, AssetRefreshInput) error
+	RetryAsset(context.Context, AssetRefreshInput, string) error
+	CancelRefreshRun(context.Context, PipelineRunCancelInput) error
 }
 
-type AssetRefreshFunc func(context.Context, AssetRefreshInput) error
+type PipelineRunCancelInput struct {
+	Request     *http.Request
+	WorkspaceID string
+	PipelineID  string
+	RunID       string
+}
 
-func (f AssetRefreshFunc) RefreshAsset(ctx context.Context, input AssetRefreshInput) error {
-	return f(ctx, input)
+type AssetRefreshFuncs struct {
+	Run    func(context.Context, AssetRefreshInput) error
+	Retry  func(context.Context, AssetRefreshInput, string) error
+	Cancel func(context.Context, PipelineRunCancelInput) error
+}
+
+func (f AssetRefreshFuncs) RefreshAsset(ctx context.Context, input AssetRefreshInput) error {
+	return f.Run(ctx, input)
+}
+
+func (f AssetRefreshFuncs) RetryAsset(ctx context.Context, input AssetRefreshInput, retryOf string) error {
+	return f.Retry(ctx, input, retryOf)
+}
+
+func (f AssetRefreshFuncs) CancelRefreshRun(ctx context.Context, input PipelineRunCancelInput) error {
+	return f.Cancel(ctx, input)
 }
 
 type AccessCommandBindings = ui.AccessCommandBindings
 type ConnectionCommandBindings = ui.ConnectionCommandBindings
+type PipelineMonitorCapacity = ui.PipelineMonitorCapacity
 type DataExplorerAgentBootstrap = ui.DataExplorerAgentBootstrap
 type DataExplorerAgentCommandBindings = ui.DataExplorerAgentCommandBindings
 type PopularityLevel = uisignals.PopularityLevel
@@ -109,6 +131,7 @@ type Config struct {
 	AuthConfigured           bool
 	RuntimeEnvironment       string
 	RefreshState             RefreshStateProvider
+	RefreshCapacity          func(context.Context) (ui.PipelineMonitorCapacity, error)
 	RefreshRunner            AssetRefreshRunner
 	Broker                   *pagestream.Broker
 	CSRFToken                func(*http.Request) string
@@ -220,7 +243,7 @@ func Build(_ context.Context, config Config) (*Module, error) {
 	}
 	m.handler = workspacehttp.Handler{
 		WorkspaceID: config.WorkspaceID, Environment: config.Environment, ReadModel: httpReadModel,
-		RefreshState:  moduleRefreshState{module: m, upstream: config.RefreshState},
+		RefreshState: moduleRefreshState{module: m, upstream: config.RefreshState}, RefreshCapacity: config.RefreshCapacity,
 		RefreshRunner: refreshRunner, Broker: config.Broker,
 		CSRFToken: config.CSRFToken, CurrentRoleLabel: config.CurrentRoleLabel, Layout: config.Layout,
 		RoleBindingCommands:      config.RoleBindingCommands,
@@ -233,6 +256,7 @@ func Build(_ context.Context, config Config) (*Module, error) {
 		ConnectionWorkspaceID:    config.ConnectionWorkspaceID,
 		AgentBootstrap:           config.AgentBootstrap,
 		AgentCommands:            config.AgentCommands,
+		AuthorizeObject:          config.AuthorizeObject,
 	}
 	m.search = buildSearch(config.Database, config.AuthorizeObject)
 	return m, nil

--- a/internal/workspace/module/routes.go
+++ b/internal/workspace/module/routes.go
@@ -28,6 +28,8 @@ func (m *Module) MountAuthenticated(r chi.Router, guard RouteGuard) {
 	if protectAnyWorkspace == nil {
 		protectAnyWorkspace = guard.Protect
 	}
+	r.Get("/pipelines", protectAnyWorkspace(access.PrivilegeViewItem, h.Pipelines))
+	r.Post("/pipelines/command", protectAnyWorkspace(access.PrivilegeViewItem, h.PipelineCommand))
 	r.Get("/data", protectAnyWorkspace(access.PrivilegeViewItem, h.DataExplorer))
 	r.Post("/data/command", protectAnyWorkspace(access.PrivilegeViewItem, h.DataExplorerCommand))
 	r.Post("/catalog/search", protectAnyWorkspace(access.PrivilegeViewItem, m.CatalogSearch))

--- a/internal/workspace/ui/pipelines.go
+++ b/internal/workspace/ui/pipelines.go
@@ -1,0 +1,259 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	uiactions "github.com/flidai/leapview/internal/platform/web/actions"
+	webpage "github.com/flidai/leapview/internal/platform/web/page"
+	"github.com/flidai/leapview/internal/platform/web/uicommand"
+	workspaceview "github.com/flidai/leapview/internal/workspace"
+	catalog "github.com/flidai/leapview/internal/workspace/navigation"
+	uisignals "github.com/flidai/leapview/internal/workspace/ui/signals"
+	g "maragu.dev/gomponents"
+)
+
+// PipelineMonitorCapacity describes the node-wide refresh workload pool. The
+// page is global because refresh pipelines contend for this shared capacity.
+type PipelineMonitorCapacity struct {
+	Running        int
+	Queued         int
+	MaximumRunning int
+}
+
+type PipelineMonitorPipeline struct {
+	Workspace workspaceview.WorkspaceView
+	Asset     workspaceview.AssetView
+	Refresh   AssetRefreshState
+	CanRun    bool
+	CanCancel bool
+}
+
+type PipelineMonitorState struct {
+	Environment   string
+	CSRFToken     string
+	Capacity      PipelineMonitorCapacity
+	Pipelines     []PipelineMonitorPipeline
+	RunCommand    uicommand.Binding
+	CancelCommand uicommand.Binding
+}
+
+func PipelinesPage(nav catalog.Catalog, state PipelineMonitorState, activeTab, roleLabel string, chromeOptions ...webpage.Provider) g.Node {
+	page := pipelineMonitorPageSignal(state, activeTab)
+	attrs := []g.Node{g.Attr("slot", "page")}
+	if state.RunCommand.OperationID() != "" && state.CancelCommand.OperationID() != "" {
+		command := "$pipelineCommand = evt.detail; $pipelineCommandStatus = {loading: true, error: '', message: ''}; " + uiactions.CommandPostSwitch("evt.detail.action", map[string]uicommand.Binding{
+			"run": state.RunCommand, "retry": state.RunCommand, "cancel": state.CancelCommand,
+		}, "/pipelines/command", "pipelineCommand")
+		attrs = append(attrs, g.Attr("data-on:lv-pipeline-command", command))
+	}
+	return workspaceRouteDocument("Pipelines", catalogWithoutWorkspaceContext(nav), "pipelines", roleLabel, page, uisignals.RoutePipelines,
+		g.El("lv-pipelines-page", attrs...),
+		workspaceDocumentExtras{CSRFToken: state.CSRFToken}, chromeOptions,
+	)
+}
+
+func PipelinesBootstrapSignals(nav catalog.Catalog, state PipelineMonitorState, activeTab, roleLabel string, chromeOptions ...webpage.Provider) map[string]any {
+	signals := workspaceRouteBootstrapSignals(catalogWithoutWorkspaceContext(nav), "pipelines", roleLabel, pipelineMonitorPageSignal(state, activeTab), uisignals.RoutePipelines, nil, chromeOptions)
+	signals["pipelineCommand"] = uisignals.PipelineCommandSignal{}
+	signals["pipelineCommandStatus"] = uisignals.PipelineCommandStatusSignal{}
+	return signals
+}
+
+func PipelinesPagePatch(state PipelineMonitorState, activeTab string) map[string]any {
+	return map[string]any{"page": pipelineMonitorPageSignal(state, activeTab)}
+}
+
+func pipelineMonitorPageSignal(state PipelineMonitorState, activeTab string) uisignals.PipelinePageSignal {
+	activeTab = strings.ToLower(strings.TrimSpace(activeTab))
+	if activeTab != "runs" {
+		activeTab = "pipelines"
+	}
+	pipelines := append([]PipelineMonitorPipeline(nil), state.Pipelines...)
+	sort.SliceStable(pipelines, func(i, j int) bool {
+		left := strings.ToLower(pipelines[i].Workspace.Title + "\x00" + pipelines[i].Asset.Title)
+		right := strings.ToLower(pipelines[j].Workspace.Title + "\x00" + pipelines[j].Asset.Title)
+		return left < right
+	})
+
+	items := make([]uisignals.PipelineListItemSignal, 0, len(pipelines))
+	workspaceTitles := map[string]string{}
+	failed := 0
+	for _, pipeline := range pipelines {
+		workspaceTitles[pipeline.Workspace.ID] = pipeline.Workspace.Title
+		status := strings.ToLower(strings.TrimSpace(pipeline.Refresh.Latest.Status))
+		if status == "" {
+			status = "not refreshed"
+		}
+		if status == "failed" {
+			failed++
+		}
+		assetHref := strings.TrimSpace(pipeline.Asset.Href)
+		if assetHref == "" {
+			assetHref = "/workspaces/" + pipeline.Workspace.ID + "/assets/" + pipeline.Asset.ID + "/details"
+		}
+		item := uisignals.PipelineListItemSignal{
+			AssetID:       pipeline.Asset.ID,
+			CanRun:        pipeline.CanRun,
+			ID:            firstNonEmpty(pipeline.Asset.Key, pipeline.Workspace.ID+"."+pipeline.Asset.ID),
+			Title:         firstNonEmpty(pipeline.Asset.Title, pipeline.Asset.Key, pipeline.Asset.ID),
+			Description:   uisignals.Optional(pipeline.Asset.Description),
+			Href:          assetHref,
+			Workspace:     firstNonEmpty(pipeline.Workspace.Title, pipeline.Workspace.ID),
+			WorkspaceID:   pipeline.Workspace.ID,
+			SemanticModel: emptyDash(metaString(pipeline.Asset.Payload, "SemanticModel", "semanticModel")),
+			Schedule:      pipelineScheduleLabel(pipeline.Asset.Payload),
+			PipelineID:    strings.TrimPrefix(pipeline.Asset.Key, pipeline.Workspace.ID+"."),
+			Running:       status == "queued" || status == "running",
+			Status:        status,
+			Duration:      uisignals.Optional(refreshRunDuration(pipeline.Refresh.Latest)),
+			LastSuccessful: uisignals.Optional(
+				pipeline.Refresh.LatestSuccessful.FinishedAt,
+			),
+		}
+		if !pipeline.Refresh.NextRun.IsZero() {
+			item.NextRun = uisignals.Optional(pipeline.Refresh.NextRun.UTC().Format(time.RFC3339))
+		}
+		items = append(items, item)
+	}
+
+	filters := make([]uisignals.PipelineWorkspaceFilterSignal, 0, len(workspaceTitles))
+	for id, title := range workspaceTitles {
+		filters = append(filters, uisignals.PipelineWorkspaceFilterSignal{ID: id, Title: firstNonEmpty(title, id)})
+	}
+	sort.Slice(filters, func(i, j int) bool { return strings.ToLower(filters[i].Title) < strings.ToLower(filters[j].Title) })
+
+	capacity := state.Capacity
+	if capacity.MaximumRunning < 0 {
+		capacity.MaximumRunning = 0
+	}
+	return uisignals.PipelinePageSignal{
+		Kind:             uisignals.RoutePipelines,
+		Title:            "Pipelines",
+		Description:      "Monitor refresh pipelines and their shared node-wide execution capacity.",
+		Environment:      state.Environment,
+		ActiveTab:        activeTab,
+		Pipelines:        items,
+		WorkspaceFilters: filters,
+		RunsTable:        pipelineRunsTable(pipelines),
+		Metrics: []uisignals.PipelineMetricSignal{
+			{Label: "Running", Value: fmt.Sprint(capacity.Running), Detail: uisignals.Pointer("Refresh jobs executing now"), Tone: uisignals.Pointer("accent")},
+			{Label: "Queued", Value: fmt.Sprint(capacity.Queued), Detail: uisignals.Pointer("Waiting for shared capacity"), Tone: uisignals.Pointer("attention")},
+			{Label: "Failed", Value: fmt.Sprint(failed), Detail: uisignals.Pointer("Latest pipeline state"), Tone: uisignals.Pointer(metricFailureTone(failed))},
+			{Label: "Refresh capacity", Value: fmt.Sprintf("%d / %d", capacity.Running, capacity.MaximumRunning), Detail: uisignals.Pointer("Running / node maximum"), Tone: uisignals.Pointer("muted")},
+		},
+	}
+}
+
+func pipelineScheduleLabel(payload map[string]any) string {
+	schedules := metaSlice(payload, "Schedules", "schedules")
+	if len(schedules) == 0 {
+		return "Manual only"
+	}
+	entry, _ := schedules[0].(map[string]any)
+	cron := metaString(entry, "Cron", "cron")
+	timezone := metaString(entry, "Timezone", "timezone")
+	label := strings.TrimSpace(strings.Join([]string{cron, timezone}, " · "))
+	label = strings.Trim(label, " ·")
+	if len(schedules) > 1 {
+		label += fmt.Sprintf(" +%d", len(schedules)-1)
+	}
+	return firstNonEmpty(label, "Scheduled")
+}
+
+func pipelineRunsTable(pipelines []PipelineMonitorPipeline) recordTable {
+	type runRow struct {
+		started time.Time
+		row     map[string]any
+	}
+	all := make([]runRow, 0)
+	seen := map[string]struct{}{}
+	for _, pipeline := range pipelines {
+		href := strings.TrimSpace(pipeline.Asset.Href)
+		if href == "" {
+			href = "/workspaces/" + pipeline.Workspace.ID + "/assets/" + pipeline.Asset.ID + "/refreshes"
+		}
+		for _, run := range pipeline.Refresh.Runs {
+			key := pipeline.Workspace.ID + "\x00" + run.ID
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			started, _ := parseRefreshTime(run.StartedAt)
+			status := strings.ToLower(strings.TrimSpace(run.Status))
+			actions := []map[string]any{{"label": "View run details", "action": "detail", "icon": "details"}}
+			if status == "queued" && pipeline.CanCancel {
+				actions = append(actions, map[string]any{"label": "Cancel run", "action": "cancel", "icon": "cancel"})
+			} else if status != "" && status != "queued" && status != "running" && pipeline.CanRun {
+				label := "Rerun"
+				if status == "failed" || status == "cancelled" {
+					label = "Retry run"
+				}
+				actions = append(actions, map[string]any{"label": label, "action": "retry", "icon": "refresh"})
+			}
+			semanticModel := firstNonEmpty(run.ModelID, metaString(pipeline.Asset.Payload, "SemanticModel", "semanticModel"))
+			all = append(all, runRow{started: started, row: map[string]any{
+				"id":                     run.ID,
+				"status":                 refreshStatusGridValue(run.Status),
+				"pipeline":               firstNonEmpty(pipeline.Asset.Title, pipeline.Asset.Key, pipeline.Asset.ID),
+				"pipeline_href":          href,
+				"workspace":              firstNonEmpty(pipeline.Workspace.Title, pipeline.Workspace.ID),
+				"started":                emptyDash(run.StartedAt),
+				"duration":               emptyDash(refreshRunDuration(run)),
+				"trigger":                refreshTriggerLabel(run.TriggerType),
+				"triggered_by":           emptyDash(run.PrincipalDisplayName),
+				"run":                    emptyDash(shortRefreshRunID(run.ID)),
+				"error":                  emptyDash(run.Error),
+				"actions":                actions,
+				"environment":            emptyDash(run.Environment),
+				"semantic_model":         emptyDash(semanticModel),
+				"principal_id":           emptyDash(run.PrincipalID),
+				"principal_display_name": emptyDash(run.PrincipalDisplayName),
+				"created_at":             emptyDash(run.CreatedAt),
+				"updated_at":             emptyDash(run.UpdatedAt),
+				"started_at":             emptyDash(run.StartedAt),
+				"finished_at":            emptyDash(run.FinishedAt),
+				"retry_of":               emptyDash(run.RetryOf),
+				"parent_run_id":          emptyDash(run.ParentRunID),
+				"serving_state_id":       emptyDash(run.ServingStateID),
+				"target_generation":      run.TargetGeneration,
+				"asset_id":               pipeline.Asset.ID,
+				"pipeline_id":            strings.TrimPrefix(pipeline.Asset.Key, pipeline.Workspace.ID+"."),
+				"run_id":                 run.ID,
+				"workspace_id":           pipeline.Workspace.ID,
+				"status_value":           strings.ToLower(strings.TrimSpace(run.Status)),
+				"trigger_value":          strings.ToLower(strings.TrimSpace(run.TriggerType)),
+				"pipeline_search": strings.ToLower(strings.Join([]string{
+					pipeline.Asset.Title, pipeline.Asset.Key, pipeline.Asset.ID, pipeline.Workspace.Title, pipeline.Workspace.ID, run.ID,
+				}, " ")),
+			}})
+		}
+	}
+	sort.SliceStable(all, func(i, j int) bool { return all[i].started.After(all[j].started) })
+	rows := make([]map[string]any, 0, len(all))
+	for _, item := range all {
+		rows = append(rows, item.row)
+	}
+	return recordTable{
+		Columns: []recordTableColumn{
+			{ID: "status", Header: "Status", Kind: uisignals.Pointer("status"), Width: uisignals.Pointer("120px")},
+			{ID: "pipeline", Header: "Pipeline", Kind: uisignals.Pointer("link"), HrefKey: uisignals.Pointer("pipeline_href"), Width: uisignals.Pointer("200px")},
+			{ID: "workspace", Header: "Workspace", Width: uisignals.Pointer("150px")},
+			{ID: "started", Header: "Started", Width: uisignals.Pointer("170px")},
+			{ID: "duration", Header: "Duration", Width: uisignals.Pointer("90px")},
+			{ID: "trigger", Header: "Trigger", Width: uisignals.Pointer("100px")},
+			{ID: "triggered_by", Header: "Triggered by", Width: uisignals.Pointer("140px")},
+			{ID: "actions", Header: "", Kind: uisignals.Pointer("actions"), Toggleable: uisignals.Pointer(false), Width: uisignals.Pointer("80px")},
+		},
+		Rows: rows, Empty: "No pipeline runs have been recorded yet.", MinWidth: uisignals.Pointer("1050px"), RowAction: uisignals.Pointer("detail"),
+	}
+}
+
+func metricFailureTone(failed int) string {
+	if failed > 0 {
+		return "danger"
+	}
+	return "success"
+}

--- a/internal/workspace/ui/pipelines_test.go
+++ b/internal/workspace/ui/pipelines_test.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	apigenui "github.com/Yacobolo/toolbelt/apigen/runtime/ui"
+	workspaceview "github.com/flidai/leapview/internal/workspace"
+	catalog "github.com/flidai/leapview/internal/workspace/navigation"
+	uisignals "github.com/flidai/leapview/internal/workspace/ui/signals"
+)
+
+func TestPipelineMonitorPageUsesGlobalListAndRunHistory(t *testing.T) {
+	state := PipelineMonitorState{
+		Environment: "dev",
+		Capacity:    PipelineMonitorCapacity{Running: 1, Queued: 2, MaximumRunning: 1},
+		Pipelines: []PipelineMonitorPipeline{{
+			Workspace: workspaceview.WorkspaceView{ID: "sales", Title: "Sales Workspace"},
+			Asset: workspaceview.AssetView{ID: "refresh_pipeline:sales-refresh", Key: "sales.sales-refresh", Title: "Sales refresh", Payload: map[string]any{
+				"semanticModel": "sales",
+				"schedules":     []any{map[string]any{"cron": "0 6 * * *", "timezone": "Europe/Copenhagen"}},
+			}},
+			Refresh: AssetRefreshState{
+				NextRun:          time.Date(2026, 8, 15, 4, 0, 0, 0, time.UTC),
+				Latest:           AssetRefreshRun{ID: "matrun_queued", Status: "queued", TriggerType: "manual", StartedAt: "2026-08-14T10:00:00Z", PrincipalDisplayName: "Ada"},
+				LatestSuccessful: AssetRefreshRun{ID: "matrun_success", Status: "succeeded", TriggerType: "schedule", StartedAt: "2026-08-14T08:00:00Z", FinishedAt: "2026-08-14T08:03:00Z"},
+				Runs: []AssetRefreshRun{
+					{ID: "matrun_queued", Status: "queued", TriggerType: "manual", StartedAt: "2026-08-14T10:00:00Z", PrincipalDisplayName: "Ada"},
+					{ID: "matrun_failed", Status: "failed", TriggerType: "retry", CreatedAt: "2026-08-14T08:59:59Z", StartedAt: "2026-08-14T09:00:00Z", FinishedAt: "2026-08-14T09:01:00Z", Error: "source unavailable", PrincipalID: "principal_ada", PrincipalDisplayName: "Ada", RetryOf: "matrun_prior", ServingStateID: "serving_42", TargetGeneration: 42, Environment: "dev"},
+				},
+			},
+			CanRun: true, CanCancel: true,
+		}},
+	}
+	page := pipelineMonitorPageSignal(state, "runs")
+	if page.Kind != uisignals.RoutePipelines || page.ActiveTab != "runs" {
+		t.Fatalf("pipeline page route = %#v", page)
+	}
+	if len(page.Pipelines) != 1 || page.Pipelines[0].Workspace != "Sales Workspace" || page.Pipelines[0].Status != "queued" {
+		t.Fatalf("pipeline rows = %#v", page.Pipelines)
+	}
+	if got := len(page.RunsTable.Rows); got != 2 {
+		t.Fatalf("run rows = %d, want 2", got)
+	}
+	if page.RunsTable.RowAction == nil || *page.RunsTable.RowAction != "detail" {
+		t.Fatalf("run table row action = %v, want detail", page.RunsTable.RowAction)
+	}
+	for _, column := range page.RunsTable.Columns {
+		if column.ID == "error" {
+			t.Fatal("long run errors must be shown in the detail drawer, not a cramped table column")
+		}
+	}
+	if len(page.Metrics) != 4 || page.Metrics[3].Value != "1 / 1" {
+		t.Fatalf("metrics = %#v", page.Metrics)
+	}
+	payload, err := json.Marshal(page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"sales-refresh", "matrun_queued", "matrun_failed", "Europe/Copenhagen", "Sales Workspace"} {
+		if !strings.Contains(string(payload), want) {
+			t.Fatalf("pipeline payload missing %q: %s", want, payload)
+		}
+	}
+	rows := page.RunsTable.Rows
+	if got := fmt.Sprint(rows[0]["actions"]); !strings.Contains(got, "cancel") {
+		t.Fatalf("queued run actions = %v, want cancel", rows[0]["actions"])
+	}
+	if got := fmt.Sprint(rows[1]["actions"]); !strings.Contains(got, "retry") {
+		t.Fatalf("failed run actions = %v, want retry", rows[1]["actions"])
+	}
+	for key, want := range map[string]any{
+		"error": "source unavailable", "principal_id": "principal_ada", "retry_of": "matrun_prior",
+		"serving_state_id": "serving_42", "target_generation": int64(42), "environment": "dev",
+	} {
+		if got := rows[1][key]; got != want {
+			t.Fatalf("failed run detail %s = %v, want %v", key, got, want)
+		}
+	}
+}
+
+func TestPipelinesPageUsesSharedWorkspaceBundleAndGlobalUpdates(t *testing.T) {
+	page := PipelinesPage(catalog.Catalog{}, PipelineMonitorState{
+		CSRFToken:     "csrf-pipelines",
+		RunCommand:    apigenui.MustAction("workspace.refresh.run", "createRefreshRun"),
+		CancelCommand: apigenui.MustAction("workspace.refresh.cancel", "cancelRefreshRun"),
+	}, "pipelines", "Owner")
+	var rendered strings.Builder
+	if err := page.Render(&rendered); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`<lv-pipelines-page`, `/static/workspace-page.js`, `route=pipelines`, `data-on:lv-pipeline-command`, `createRefreshRun`, `cancelRefreshRun`, `csrf-pipelines`} {
+		if !strings.Contains(rendered.String(), want) {
+			t.Fatalf("pipelines page missing %q:\n%s", want, rendered.String())
+		}
+	}
+}

--- a/internal/workspace/ui/signals/types.go
+++ b/internal/workspace/ui/signals/types.go
@@ -4,6 +4,7 @@ import workspaceview "github.com/flidai/leapview/internal/workspace"
 
 const (
 	RouteCatalog         RouteKind = "catalog"
+	RoutePipelines       RouteKind = "pipelines"
 	RouteWorkspace       RouteKind = "workspace"
 	RouteWorkspaceAsset  RouteKind = "workspace_asset"
 	RouteConnections     RouteKind = "connections"

--- a/internal/workspace/ui/workspace.go
+++ b/internal/workspace/ui/workspace.go
@@ -897,6 +897,8 @@ func workspaceRouteUpdatesURL(routeKind uisignals.RouteKind, catalog catalog.Cat
 		}
 		pairs := []string{"workspace", firstNonEmpty(typed.WorkspaceID, catalog.Workspace.ID), "environment", uisignals.ValueOrZero(typed.Environment), "asset", typed.AssetID, "section", typed.ActiveSection}
 		return updatesURL(routeKind, pairs...)
+	case uisignals.PipelinePageSignal:
+		return updatesURL(routeKind, "view", typed.ActiveTab, "environment", typed.Environment)
 	default:
 		return updatesURL(routeKind)
 	}
@@ -929,6 +931,7 @@ func ValidWorkspaceAssetSection(section string) bool {
 type AssetRefreshState struct {
 	CSRFToken        string
 	RunCommand       uicommand.Binding
+	CancelCommand    uicommand.Binding
 	Runs             []AssetRefreshRun
 	Latest           AssetRefreshRun
 	LatestSuccessful AssetRefreshRun
@@ -945,9 +948,18 @@ type AssetDataVersion struct {
 
 type AssetRefreshRun struct {
 	ID                   string
+	Environment          string
+	ModelID              string
+	ServingStateID       string
+	PrincipalID          string
 	PrincipalDisplayName string
 	TriggerType          string
+	ParentRunID          string
+	RetryOf              string
+	TargetGeneration     int64
 	Status               string
+	CreatedAt            string
+	UpdatedAt            string
 	StartedAt            string
 	FinishedAt           string
 	Error                string

--- a/web/components/navigation/sidebar.ts
+++ b/web/components/navigation/sidebar.ts
@@ -22,6 +22,7 @@ import {
 	Users,
 	UsersRound,
 	User,
+  Workflow,
   X,
   type IconNode,
 } from 'lucide'
@@ -114,6 +115,7 @@ type IconName =
   | 'menu'
   | 'close'
   | 'plus'
+  | 'workflow'
 
 const defaultConfig: SidebarConfig = {
   active: 'dashboards',
@@ -1392,6 +1394,7 @@ function icon(name: string) {
     menu: Menu,
     close: X,
     plus: Plus,
+    workflow: Workflow,
   }
 
   return lucideIcon(icons[name as IconName] ?? Layers)

--- a/web/components/shared/entity-list.ts
+++ b/web/components/shared/entity-list.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit'
+import { LitElement, html, nothing } from 'lit'
 import { property, state } from 'lit/decorators.js'
 import {
   ArrowUpDown,
@@ -6,16 +6,22 @@ import {
   BookOpen,
   Boxes,
   Cable,
+  CheckCircle2,
   ChartColumn,
   ChartNoAxesColumnIncreasing,
   ChevronDown,
   ChevronRight,
+  Circle,
+  Clock3,
   Component,
   Database,
   Download,
+  FileText,
   LayoutDashboard,
   Plus,
   Plug,
+  Play,
+  RefreshCw,
   Search,
   Table2,
   TableProperties,
@@ -23,6 +29,7 @@ import {
   UserRound,
   Waypoints,
   Workflow,
+  XCircle,
   type IconNode,
 } from 'lucide'
 import { lucideIcon } from './lucide-icons'
@@ -48,6 +55,14 @@ export type EntityListItem = {
   columnTitles?: Record<string, string>
   sortValues?: Record<string, string | number>
   badges?: EntityListBadge[]
+  actions?: EntityListRowAction[]
+}
+
+export type EntityListRowAction = {
+  label: string
+  action: string
+  icon?: 'play' | 'refresh' | 'details' | 'cancel'
+  disabled?: boolean
 }
 
 export type EntityListBadge = {
@@ -62,7 +77,7 @@ export type EntityListColumn = {
   width?: string
   align?: 'left' | 'right'
   sortable?: boolean
-  render?: 'badges'
+  render?: 'badges' | 'actions' | 'status'
 }
 
 export type EntityListFilter = {
@@ -183,6 +198,41 @@ const entityListStyles = `
   .entity-action-primary:hover {
     border-color: var(--lv-button-accent-border-hover);
     background: var(--lv-button-accent-bg-hover);
+  }
+
+  .entity-list-row-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--base-size-4);
+  }
+
+  .entity-list-row-action {
+    display: inline-flex;
+    width: var(--control-medium-size);
+    height: var(--control-medium-size);
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: var(--lv-radius-default);
+    background: transparent;
+    color: var(--lv-fg-muted);
+    cursor: pointer;
+  }
+
+  .entity-list-row-action:hover:not(:disabled),
+  .entity-list-row-action:focus-visible {
+    background: var(--lv-bg-control-hover, var(--lv-bg-panel-muted));
+    color: var(--lv-fg-default);
+  }
+
+  .entity-list-row-action:focus-visible {
+    outline: var(--focus-outline);
+    outline-offset: var(--focus-outline-offset);
+  }
+
+  .entity-list-row-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
   }
 
   .entity-list-items {
@@ -345,6 +395,10 @@ const entityListStyles = `
     font: var(--lv-type-caption);
   }
 
+  .entity-list-table-row.is-actionable {
+    cursor: pointer;
+  }
+
   .entity-list-table-row:hover,
   .entity-list-table-row:focus-within {
     background: var(--lv-bg-control-hover);
@@ -466,6 +520,10 @@ const entityListStyles = `
     font-weight: var(--base-text-weight-semibold);
   }
 
+  .entity-list.is-title-normal .entity-list-title {
+    font-weight: var(--base-text-weight-normal);
+  }
+
   .entity-list-title-row {
     display: flex;
     min-width: 0;
@@ -514,6 +572,67 @@ const entityListStyles = `
     font: var(--lv-type-body);
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .entity-list-status {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--base-size-6);
+    color: var(--lv-fg-default);
+    font-weight: var(--base-text-weight-medium);
+    white-space: nowrap;
+  }
+
+  .entity-list-status-icon {
+    display: inline-flex;
+    width: var(--base-size-16);
+    height: var(--base-size-16);
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    color: var(--lv-fg-muted);
+  }
+
+  .entity-list-status-icon svg {
+    display: block;
+    width: var(--base-size-16);
+    height: var(--base-size-16);
+  }
+
+  .entity-list-status.is-success .entity-list-status-icon { color: var(--lv-fg-success); }
+  .entity-list-status.is-danger .entity-list-status-icon { color: var(--lv-fg-danger); }
+  .entity-list-status.is-attention .entity-list-status-icon { color: var(--lv-fg-warning); }
+
+  .entity-list.is-compact {
+    gap: var(--base-size-8);
+  }
+
+  .entity-list.is-compact .entity-list-table-row {
+    height: 2.5rem;
+  }
+
+  .entity-list.is-compact .entity-list-table thead th {
+    height: 2rem;
+  }
+
+  .entity-list.is-compact .entity-list-icon {
+    width: var(--base-size-24);
+    height: var(--base-size-24);
+    border: 0;
+    background: transparent;
+  }
+
+  .entity-list.is-compact .entity-list-copy {
+    gap: 0;
+  }
+
+  .entity-list.is-compact .entity-list-description {
+    display: none;
+  }
+
+  .entity-list.is-compact .entity-list-row-action {
+    width: var(--base-size-28);
+    height: var(--base-size-28);
   }
 
   .entity-list-empty {
@@ -568,7 +687,12 @@ class EntityList extends LitElement {
   @property({ attribute: 'active-filter' }) activeFilter = ''
   @property({ attribute: 'group-by' }) groupBy = ''
   @property({ attribute: 'group-icon' }) groupIcon = ''
+  @property({ type: Boolean }) compact = false
+  @property({ attribute: 'title-emphasis' }) titleEmphasis: 'strong' | 'normal' = 'strong'
+  @property({ attribute: 'row-action' }) rowAction = ''
+  @property({ attribute: 'min-width' }) minWidth = ''
   @property({ type: Boolean, attribute: 'client-filter' }) clientFilter = false
+  @property({ type: Boolean, attribute: 'show-toolbar' }) showToolbar = true
   @state() private query = ''
   @state() private filter = ''
   @state() private sortColumnId = ''
@@ -597,8 +721,8 @@ class EntityList extends LitElement {
     const columns = this.resolvedColumns()
     return html`
       <style>${entityListStyles}</style>
-      <section class="entity-list" aria-label=${this.listLabel}>
-        <div class="entity-toolbar">
+      <section class=${`entity-list ${this.compact ? 'is-compact' : ''} ${this.titleEmphasis === 'normal' ? 'is-title-normal' : ''}`} aria-label=${this.listLabel}>
+        ${this.showToolbar ? html`<div class="entity-toolbar">
           <form class="entity-search" @submit=${this.preventSubmit}>
             ${lucideIcon(Search, { size: 16, strokeWidth: 1.8 })}
             <input
@@ -636,10 +760,10 @@ class EntityList extends LitElement {
               `)}
             </div>
           ` : ''}
-        </div>
+        </div>` : ''}
         ${items.length ? html`
           <div class="entity-list-items entity-list-table-wrap">
-            <table class="entity-list-table" aria-label=${this.listLabel}>
+            <table class="entity-list-table" aria-label=${this.listLabel} style=${this.minWidth ? `min-width: ${this.minWidth}` : ''}>
               <colgroup>
                 ${columns.map((column) => html`<col style=${column.width ? `width: ${column.width}` : ''}>`)}
               </colgroup>
@@ -647,7 +771,7 @@ class EntityList extends LitElement {
                 <tr>
                   ${columns.map((column) => {
                     const direction = this.sortColumnId === column.id ? this.sortDirection : false
-                    const sortable = column.sortable !== false
+                    const sortable = column.sortable !== false && column.render !== 'actions'
                     return html`
                       <th
                         class=${column.align === 'right' ? 'is-right' : ''}
@@ -780,11 +904,23 @@ class EntityList extends LitElement {
 
   private renderItem(item: EntityListItem, columns: EntityListColumn[]) {
     const badgesColumn = columns.some((column) => column.render === 'badges')
+    return html`
+      <tr class=${`entity-list-table-row ${this.rowAction ? 'is-actionable' : ''}`} @click=${() => this.emitItemAction(item)}>
+        ${columns.map((column) => column.id === 'name'
+          ? this.renderIdentityCell(item, badgesColumn)
+          : this.renderDataCell(item, column))}
+      </tr>
+    `
+  }
+
+  private renderIdentityCell(item: EntityListItem, badgesColumn: boolean) {
     const iconTreatment = item.iconTreatment ?? (item.icon ? 'plain' : 'none')
     const iconColorClass = iconTreatment === 'framed'
       ? ` color-${item.iconColor || 'purple'}`
       : item.iconColor ? ` color-${item.iconColor}` : ''
-    const icon = item.icon === 'user'
+    const icon = item.icon === 'none'
+      ? nothing
+      : item.icon === 'user'
         ? html`<lv-user-avatar .name=${item.title} .imageUrl=${item.avatarUrl ?? ''} aria-hidden="true"></lv-user-avatar>`
         : iconTreatment === 'none'
           ? html`<span class="entity-list-icon-spacer" aria-hidden="true"></span>`
@@ -800,35 +936,46 @@ class EntityList extends LitElement {
         ${item.description ? html`<span class="entity-list-description">${item.description}</span>` : ''}
       </span>
     `
-    const identity = item.iconButtonLabel
-      ? html`<span class="entity-list-identity-row">${icon}${item.href ? html`<a class="entity-list-identity" href=${item.href}>${copy}</a>` : html`<span class="entity-list-identity">${copy}</span>`}</span>`
-      : html`${icon}${copy}`
     return html`
-      <tr class="entity-list-table-row">
-        <th scope="row">
-          ${item.iconButtonLabel
-            ? identity
-            : item.href
-            ? html`<a class="entity-list-identity" href=${item.href}>${identity}</a>`
-            : html`<span class="entity-list-identity">${identity}</span>`}
-        </th>
-        ${columns.slice(1).map((column) => {
-          const value = item.columns?.[column.id]
-          const badges = item.badges ?? []
-          const title = column.render === 'badges'
-            ? badges.map((badge) => badge.label).join(', ')
-            : item.columnTitles?.[column.id] ?? String(value ?? '')
-          return html`
-            <td class=${`entity-list-cell ${column.align === 'right' ? 'is-right' : ''}`} title=${title}>
-              ${column.render === 'badges'
-                ? (badges.length ? badges.map((badge) => this.renderBadge(badge)) : html`
-                    <span class="entity-list-badge-empty" role="img" aria-label="No popularity data">—</span>
-                  `)
-                : (value == null || value === '' ? '—' : value)}
-            </td>
-          `
-        })}
-      </tr>
+      <th scope="row">
+        ${item.iconButtonLabel
+          ? html`<span class="entity-list-identity-row">${icon}${item.href
+            ? html`<a class="entity-list-identity" href=${item.href} @click=${this.stopRowAction}>${copy}</a>`
+            : html`<span class="entity-list-identity">${copy}</span>`}</span>`
+          : item.href
+            ? html`<a class="entity-list-identity" href=${item.href} @click=${this.stopRowAction}>${icon}${copy}</a>`
+            : html`<span class="entity-list-identity">${icon}${copy}</span>`}
+      </th>
+    `
+  }
+
+  private renderDataCell(item: EntityListItem, column: EntityListColumn) {
+    const value = item.columns?.[column.id]
+    const badges = item.badges ?? []
+    const title = column.render === 'badges'
+      ? badges.map((badge) => badge.label).join(', ')
+      : item.columnTitles?.[column.id] ?? String(value ?? '')
+    return html`
+      <td class=${`entity-list-cell ${column.align === 'right' ? 'is-right' : ''}`} title=${title}>
+        ${column.render === 'badges'
+          ? (badges.length ? badges.map((badge) => this.renderBadge(badge)) : html`
+              <span class="entity-list-badge-empty" role="img" aria-label="No popularity data">—</span>
+            `)
+          : column.render === 'actions'
+            ? html`<span class="entity-list-row-actions">${(item.actions ?? []).map((action) => html`
+                <button
+                  type="button"
+                  class="entity-list-row-action"
+                  title=${action.label}
+                  aria-label=${action.label}
+                  ?disabled=${action.disabled}
+                  @click=${(event: Event) => this.emitRowAction(event, action, item)}
+                >${lucideIcon(entityActionIcon(action.icon), { size: 15, strokeWidth: 2 })}</button>
+	              `)}</span>`
+            : column.render === 'status'
+              ? this.renderStatus(value)
+              : (value == null || value === '' ? '—' : value)}
+      </td>
     `
   }
 
@@ -848,6 +995,17 @@ class EntityList extends LitElement {
       composed: true,
       detail: { item, anchor: event.currentTarget },
     }))
+  }
+
+  private renderStatus(value: string | number | undefined) {
+    const label = value == null || value === '' ? '—' : String(value)
+    const status = entityStatusPresentation(label)
+    return html`
+      <span class=${`entity-list-status is-${status.tone}`}>
+        <span class="entity-list-status-icon" aria-hidden="true">${lucideIcon(status.icon, { size: 16, strokeWidth: 2 })}</span>
+        <span>${label}</span>
+      </span>
+    `
   }
 
   private exportCSV = () => {
@@ -871,6 +1029,26 @@ class EntityList extends LitElement {
       detail: { id: action.id },
     }))
   }
+
+  private emitRowAction(event: Event, action: EntityListRowAction, item: EntityListItem): void {
+    event.stopPropagation()
+    this.dispatchEvent(new CustomEvent('lv-entity-list-row-action', {
+      bubbles: true,
+      composed: true,
+      detail: { action: action.action, item },
+    }))
+  }
+
+  private emitItemAction(item: EntityListItem): void {
+    if (!this.rowAction) return
+    this.dispatchEvent(new CustomEvent('lv-entity-list-row-action', {
+      bubbles: true,
+      composed: true,
+      detail: { action: this.rowAction, item },
+    }))
+  }
+
+  private stopRowAction = (event: Event): void => event.stopPropagation()
 
   private toggleSort(columnId: string): void {
     if (this.sortColumnId === columnId) {
@@ -934,6 +1112,35 @@ function entityIcon(type = ''): IconNode {
     case 'workflow': return Workflow
     case 'component': return Component
     default: return Boxes
+  }
+}
+
+function entityActionIcon(type: EntityListRowAction['icon']): IconNode {
+  switch (type) {
+    case 'refresh': return RefreshCw
+    case 'details': return FileText
+    case 'cancel': return XCircle
+    default: return Play
+  }
+}
+
+function entityStatusPresentation(label: string): { icon: IconNode, tone: 'success' | 'danger' | 'attention' | 'muted' } {
+  switch (label.trim().toLowerCase()) {
+    case 'succeeded':
+    case 'success':
+    case 'healthy':
+      return { icon: CheckCircle2, tone: 'success' }
+    case 'failed':
+    case 'cancelled':
+    case 'error':
+      return { icon: XCircle, tone: 'danger' }
+    case 'queued':
+    case 'running':
+    case 'prepared':
+    case 'pending':
+      return { icon: Clock3, tone: 'attention' }
+    default:
+      return { icon: Circle, tone: 'muted' }
   }
 }
 

--- a/web/components/shared/record-table.ts
+++ b/web/components/shared/record-table.ts
@@ -18,6 +18,7 @@ import {
   KeyRound,
   Layers3,
   ListTree,
+  RefreshCw,
   Server,
   Sigma,
   Table2,
@@ -507,7 +508,7 @@ class RecordTable extends LitElement {
     const href = cellHref(column, value, row)
     const label = cellLabel(value)
     if (label === '-') return html`<span class="record-muted">-</span>`
-    return href && href !== '-' ? html`<a class="record-link" href=${href}>${label}</a>` : html`<span>${label}</span>`
+    return href && href !== '-' ? html`<a class="record-link" href=${href} @click=${(event: Event) => event.stopPropagation()}>${label}</a>` : html`<span>${label}</span>`
   }
 
   private renderEntity(column: RecordColumn, value: unknown, row: RecordRow) {
@@ -787,6 +788,11 @@ function iconForName(name: string): any {
       return ExternalLink
     case 'details':
       return FileText
+    case 'refresh':
+    case 'retry':
+      return RefreshCw
+    case 'cancel':
+      return XCircle
     default:
       return Layers3
   }

--- a/web/components/workspace/pipelines-page.ts
+++ b/web/components/workspace/pipelines-page.ts
@@ -1,0 +1,653 @@
+import { LitElement, css, html, nothing } from 'lit'
+import { state } from 'lit/decorators.js'
+import { CheckCircle2, Circle, Clock3, XCircle } from 'lucide'
+import type { PipelineCommandSignal, PipelineCommandStatusSignal, PipelineListItemSignal, PipelinePageSignal, RecordTableSignal } from '../../generated/signals'
+import { DatastarLit } from '../shared/datastar-lit'
+import { lucideIcon } from '../shared/lucide-icons'
+import { checkSignalContract } from '../shared/signal-contract'
+import { pageHeaderStyles, renderPageHeader } from '../shared/page-header'
+import type { EntityListItem, EntityListRowAction } from '../shared/entity-list'
+import '../shared/drawer'
+import '../shared/entity-list'
+
+const pipelineRunStatuses = ['queued', 'running', 'prepared', 'succeeded', 'failed', 'cancelled', 'superseded'] as const
+
+class LeapViewPipelinesPage extends DatastarLit(LitElement) {
+  @state() private runQuery = ''
+  @state() private runWorkspace = 'all'
+  @state() private runStatus = 'all'
+  @state() private runTrigger = 'all'
+  @state() private selectedRunID = ''
+
+  static styles = [pageHeaderStyles, css`
+    :host {
+      display: block;
+      min-width: 0;
+      min-height: 100svh;
+      background: var(--lv-bg-app);
+      color: var(--lv-fg-default);
+      font-family: var(--fontStack-system);
+    }
+
+    .page {
+      box-sizing: border-box;
+      display: grid;
+      width: min(100%, var(--lv-page-content-max-width));
+      min-width: 0;
+      min-height: 100svh;
+      align-content: start;
+      gap: var(--base-size-16);
+      margin-inline: auto;
+      padding: var(--base-size-24);
+    }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      overflow: hidden;
+      border: var(--lv-border-muted);
+      border-radius: var(--lv-radius-default);
+      background: var(--lv-bg-panel);
+    }
+
+    .metric {
+      display: grid;
+      min-width: 0;
+      gap: var(--base-size-4);
+      padding: var(--base-size-16);
+    }
+
+    .metric + .metric {
+      border-left: var(--lv-border-muted);
+    }
+
+    .metric-label,
+    .metric-detail {
+      overflow: hidden;
+      color: var(--lv-fg-muted);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font: var(--lv-type-caption);
+    }
+
+    .metric-value {
+      color: var(--lv-fg-default);
+      font: var(--lv-type-section-title);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .metric.tone-danger .metric-value { color: var(--lv-fg-danger); }
+    .metric.tone-accent .metric-value { color: var(--lv-fg-accent, var(--lv-fg-default)); }
+
+    .tabs {
+      display: flex;
+      gap: var(--base-size-16);
+      border-bottom: var(--lv-border-muted);
+    }
+
+    .tabs a {
+      position: relative;
+      display: inline-flex;
+      min-height: var(--control-medium-size);
+      align-items: center;
+      color: var(--lv-fg-muted);
+      text-decoration: none;
+      font: var(--lv-type-body);
+    }
+
+    .tabs a:hover,
+    .tabs a:focus-visible,
+    .tabs a.active {
+      color: var(--lv-fg-default);
+    }
+
+    .tabs a:focus-visible {
+      outline: var(--focus-outline);
+      outline-offset: var(--focus-outline-offset);
+    }
+
+    .tabs a.active::after {
+      position: absolute;
+      right: 0;
+      bottom: -1px;
+      left: 0;
+      height: 2px;
+      border-radius: 2px 2px 0 0;
+      background: var(--lv-fg-accent, var(--lv-fg-default));
+      content: '';
+    }
+
+    .runs {
+      display: grid;
+      min-width: 0;
+      gap: var(--base-size-16);
+    }
+
+    .command-feedback {
+      border: var(--lv-border-muted);
+      border-radius: var(--lv-radius-default);
+      background: var(--lv-bg-panel-muted);
+      color: var(--lv-fg-muted);
+      padding: var(--base-size-8) var(--base-size-12);
+      font: var(--lv-type-body);
+    }
+
+    .command-feedback.is-error {
+      border-color: var(--lv-border-danger, var(--lv-border-muted));
+      color: var(--lv-fg-danger);
+    }
+
+    .run-toolbar {
+      display: flex;
+      min-width: 0;
+      flex-wrap: wrap;
+      gap: var(--base-size-8);
+    }
+
+    .run-toolbar input,
+    .run-toolbar select {
+      box-sizing: border-box;
+      height: var(--control-medium-size);
+      border: var(--lv-border-muted);
+      border-radius: var(--lv-radius-default);
+      background: var(--lv-bg-panel);
+      color: var(--lv-fg-default);
+      padding: 0 var(--base-size-8);
+      font: var(--lv-type-body);
+    }
+
+    .run-toolbar input {
+      width: min(100%, 19rem);
+      min-width: 12rem;
+      padding-inline: var(--base-size-12);
+    }
+
+    .run-toolbar input:focus-visible,
+    .run-toolbar select:focus-visible {
+      outline: var(--focus-outline);
+      outline-offset: var(--focus-outline-offset);
+    }
+
+    .run-table {
+      min-width: 0;
+    }
+
+    .run-detail-title {
+      display: inline-flex;
+      min-width: 0;
+      align-items: center;
+      gap: var(--base-size-6);
+      color: var(--lv-fg-default);
+      font-weight: var(--base-text-weight-semibold);
+    }
+
+    .run-detail-title svg {
+      display: block;
+      width: var(--base-size-16);
+      height: var(--base-size-16);
+    }
+
+    .run-detail-title.is-success svg { color: var(--lv-fg-success); }
+    .run-detail-title.is-danger svg { color: var(--lv-fg-danger); }
+    .run-detail-title.is-attention svg { color: var(--lv-fg-warning); }
+    .run-detail-title.is-muted svg { color: var(--lv-fg-muted); }
+
+    .run-detail-subtitle {
+      margin: var(--base-size-4) 0 0;
+      color: var(--lv-fg-muted);
+      font: var(--lv-type-body-compact);
+    }
+
+    .run-detail-body {
+      display: grid;
+      min-width: 0;
+      align-content: start;
+      gap: var(--base-size-20);
+    }
+
+    .run-detail-section {
+      display: grid;
+      min-width: 0;
+      gap: var(--base-size-8);
+    }
+
+    .run-detail-section h2 {
+      margin: 0;
+      color: var(--lv-fg-default);
+      font: var(--lv-type-body);
+      font-weight: var(--base-text-weight-semibold);
+    }
+
+    .run-detail-facts {
+      display: grid;
+      gap: var(--base-size-6);
+    }
+
+    .run-detail-fact {
+      display: grid;
+      min-width: 0;
+      grid-template-columns: minmax(7rem, .44fr) minmax(0, 1fr);
+      align-items: start;
+      gap: var(--base-size-12);
+      font: var(--lv-type-body-compact);
+    }
+
+    .run-detail-fact > span:first-child {
+      color: var(--lv-fg-muted);
+    }
+
+    .run-detail-fact code,
+    .run-detail-fact strong,
+    .run-detail-fact a {
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+
+    .run-detail-fact a {
+      color: var(--lv-fg-link);
+      text-decoration: none;
+    }
+
+    .run-detail-fact a:hover,
+    .run-detail-fact a:focus-visible {
+      text-decoration: underline;
+    }
+
+    .run-detail-error {
+      max-height: 16rem;
+      min-width: 0;
+      overflow: auto;
+      margin: 0;
+      border: var(--lv-border-muted);
+      border-radius: var(--lv-radius-default);
+      background: var(--lv-bg-panel-muted);
+      color: var(--lv-fg-danger);
+      padding: var(--base-size-12);
+      font-family: var(--fontStack-monospace);
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
+    @media (max-width: 880px) {
+      .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .metric:nth-child(3) { border-left: 0; border-top: var(--lv-border-muted); }
+      .metric:nth-child(4) { border-top: var(--lv-border-muted); }
+    }
+
+    @media (max-width: 720px) {
+      .page { padding: var(--base-size-12); }
+      .run-toolbar input { width: 100%; }
+    }
+  `]
+
+  get page(): PipelinePageSignal | null {
+    return this.signal<PipelinePageSignal | null>('page', null)
+  }
+
+  get command(): PipelineCommandSignal {
+    return this.signal<PipelineCommandSignal>('pipelineCommand', { action: '', assetId: '', pipelineId: '', runId: '', workspaceId: '' })
+  }
+
+  get commandStatus(): PipelineCommandStatusSignal {
+    return this.signal<PipelineCommandStatusSignal>('pipelineCommandStatus', { loading: false, error: '', message: '' })
+  }
+
+  updated(): void {
+    checkSignalContract('pipelines page', this.page, { kind: 'required', pipelines: 'required', runsTable: 'required' })
+  }
+
+  render() {
+    const page = this.page
+    if (!page) return html`<slot></slot>`
+    const selectedRun = this.selectedRunID
+      ? page.runsTable.rows.find((row) => String(row.run_id || row.id || '') === this.selectedRunID)
+      : null
+    return html`
+      <section class="page" aria-label="LeapView pipelines">
+        ${renderPageHeader(page.title, page.description, page.environment ? `Environment · ${page.environment}` : '')}
+        ${this.renderCommandFeedback()}
+        <div class="metrics" aria-label="Pipeline health summary">
+          ${page.metrics.map((metric) => html`
+            <div class=${`metric tone-${metric.tone || 'muted'}`}>
+              <span class="metric-label">${metric.label}</span>
+              <strong class="metric-value">${metric.value}</strong>
+              ${metric.detail ? html`<span class="metric-detail">${metric.detail}</span>` : nothing}
+            </div>
+          `)}
+        </div>
+        <nav class="tabs" aria-label="Pipeline monitor views">
+          <a class=${page.activeTab === 'pipelines' ? 'active' : ''} href="/pipelines?view=pipelines" aria-current=${page.activeTab === 'pipelines' ? 'page' : nothing}>Pipelines</a>
+          <a class=${page.activeTab === 'runs' ? 'active' : ''} href="/pipelines?view=runs" aria-current=${page.activeTab === 'runs' ? 'page' : nothing}>Run history</a>
+        </nav>
+        ${page.activeTab === 'runs' ? this.renderRuns(page) : this.renderPipelines(page)}
+      </section>
+      ${selectedRun ? this.renderRunDetail(selectedRun) : nothing}
+    `
+  }
+
+  private renderPipelines(page: PipelinePageSignal) {
+    return html`
+      <lv-entity-list
+        .items=${page.pipelines.map((pipeline) => ({
+          id: pipeline.id,
+          title: pipeline.title,
+          description: pipeline.description || `${pipeline.semanticModel} · ${pipeline.schedule}`,
+          href: pipeline.href,
+          icon: 'workflow',
+          category: pipeline.workspaceId,
+          columns: {
+            workspace: pipeline.workspace,
+            semanticModel: pipeline.semanticModel,
+            schedule: pipeline.schedule,
+            nextRun: formatDateTime(pipeline.nextRun),
+            status: capitalize(pipeline.status),
+          },
+          sortValues: {
+            nextRun: pipeline.nextRun || '',
+            status: pipeline.status,
+          },
+          columnTitles: {
+            nextRun: formatExactDateTime(pipeline.nextRun),
+          },
+          actions: pipeline.canRun ? [{
+            label: pipeline.running ? 'Pipeline is running' : 'Run now',
+            action: 'run',
+            icon: 'play',
+            disabled: pipeline.running || this.commandPendingFor(pipeline.workspaceId, pipeline.pipelineId),
+          }] : [],
+        }))}
+        .columns=${[
+          { id: 'name', label: 'Pipeline', width: '26%' },
+          { id: 'workspace', label: 'Workspace', width: '16%' },
+          { id: 'semanticModel', label: 'Semantic model', width: '15%' },
+          { id: 'schedule', label: 'Schedule', width: '19%' },
+          { id: 'nextRun', label: 'Next run', width: '13%' },
+          { id: 'status', label: 'Status', width: '11%' },
+          { id: 'actions', label: '', width: '5%', sortable: false, render: 'actions' },
+        ]}
+        .filters=${[
+          { id: 'all', label: 'All workspaces' },
+          ...page.workspaceFilters.map((workspace) => ({ id: workspace.id, label: workspace.title })),
+        ]}
+        search-placeholder="Search pipelines"
+        empty-text="No refresh pipelines are available."
+        client-filter
+        @lv-entity-list-row-action=${this.handlePipelineAction}
+      ></lv-entity-list>
+    `
+  }
+
+  private renderRuns(page: PipelinePageSignal) {
+    return html`
+      <div class="runs">
+        <div class="run-toolbar" aria-label="Run history filters">
+          <input type="search" placeholder="Search pipeline or run ID" aria-label="Search pipeline runs" .value=${this.runQuery} @input=${(event: Event) => { this.runQuery = (event.currentTarget as HTMLInputElement).value }}>
+          <select aria-label="Filter runs by workspace" .value=${this.runWorkspace} @change=${(event: Event) => { this.runWorkspace = (event.currentTarget as HTMLSelectElement).value }}>
+            <option value="all">All workspaces</option>
+            ${page.workspaceFilters.map((workspace) => html`<option value=${workspace.id}>${workspace.title}</option>`)}
+          </select>
+          <select aria-label="Filter runs by status" .value=${this.runStatus} @change=${(event: Event) => { this.runStatus = (event.currentTarget as HTMLSelectElement).value }}>
+            <option value="all">All statuses</option>
+            ${pipelineRunStatuses.map((status) => html`<option value=${status}>${capitalize(status)}</option>`)}
+          </select>
+          <select aria-label="Filter runs by trigger" .value=${this.runTrigger} @change=${(event: Event) => { this.runTrigger = (event.currentTarget as HTMLSelectElement).value }}>
+            <option value="all">All triggers</option>
+            ${['manual', 'schedule', 'retry'].map((trigger) => html`<option value=${trigger}>${capitalize(trigger)}</option>`)}
+          </select>
+        </div>
+        <div class="run-table">
+          <lv-entity-list
+            compact
+            title-emphasis="normal"
+            row-action="detail"
+            min-width="1050px"
+            list-label="Pipeline run history"
+            empty-text="No pipeline runs have been recorded yet."
+            .showToolbar=${false}
+            .items=${this.filteredRunItems(page.runsTable)}
+            .columns=${[
+              { id: 'status', label: 'Status', width: '120px', render: 'status' },
+              { id: 'name', label: 'Pipeline', width: '200px' },
+              { id: 'workspace', label: 'Workspace', width: '150px' },
+              { id: 'started', label: 'Started', width: '170px' },
+              { id: 'duration', label: 'Duration', width: '90px' },
+              { id: 'trigger', label: 'Trigger', width: '100px' },
+              { id: 'triggeredBy', label: 'Triggered by', width: '130px' },
+              { id: 'actions', label: '', width: '90px', sortable: false, render: 'actions' },
+            ]}
+            @lv-entity-list-row-action=${this.handleRunAction}
+          ></lv-entity-list>
+        </div>
+      </div>
+    `
+  }
+
+  private filteredRunItems(table: RecordTableSignal): EntityListItem[] {
+    const query = this.runQuery.trim().toLowerCase()
+    return table.rows
+      .filter((row) => {
+        if (query && !String(row.pipeline_search || '').includes(query)) return false
+        if (this.runWorkspace !== 'all' && row.workspace_id !== this.runWorkspace) return false
+        if (this.runStatus !== 'all' && row.status_value !== this.runStatus) return false
+        if (this.runTrigger !== 'all' && row.trigger_value !== this.runTrigger) return false
+        return true
+      })
+      .map((row) => ({
+        id: String(row.run_id || row.id || ''),
+        title: runDetailValue(row, 'pipeline'),
+        description: firstRunListValue(row.run_id, row.run, row.id),
+        href: runDetailValue(row, 'pipeline_href') === '—' ? '#' : runDetailValue(row, 'pipeline_href'),
+        icon: 'none',
+        columns: {
+          status: capitalize(runDetailValue(row, 'status_value')),
+          workspace: runDetailValue(row, 'workspace'),
+          started: runDetailValue(row, 'started'),
+          duration: runDetailValue(row, 'duration'),
+          trigger: runDetailValue(row, 'trigger'),
+          triggeredBy: runDetailValue(row, 'triggered_by'),
+        },
+        columnTitles: {
+          started: formatRunDetailDate(row.started_at),
+        },
+        sortValues: {
+          status: runDetailValue(row, 'status_value'),
+          started: String(row.started_at || ''),
+        },
+        actions: Array.isArray(row.actions)
+          ? row.actions.map((action) => {
+              const value = action as Record<string, unknown>
+              return {
+                label: String(value.label || ''),
+                action: String(value.action || ''),
+                icon: pipelineRunActionIcon(String(value.icon || '')),
+                disabled: value.action !== 'detail' && this.commandPendingFor(String(row.workspace_id || ''), String(row.pipeline_id || ''), String(row.run_id || '')),
+              }
+            })
+          : [],
+      }))
+  }
+
+  private renderCommandFeedback() {
+    const status = this.commandStatus
+    if (!status.loading && !status.error && !status.message) return nothing
+    const message = status.loading ? commandLoadingLabel(this.command.action) : status.error || status.message
+    return html`<div class=${`command-feedback ${status.error ? 'is-error' : ''}`} role=${status.error ? 'alert' : 'status'}>${message}</div>`
+  }
+
+  private commandPendingFor(workspaceId: string, pipelineId: string, runId = ''): boolean {
+    const command = this.command
+    return this.commandStatus.loading && command.workspaceId === workspaceId && command.pipelineId === pipelineId && (!runId || command.runId === runId)
+  }
+
+  private handlePipelineAction = (event: CustomEvent<{ action: string, item: { id: string } }>): void => {
+    if (event.detail.action !== 'run') return
+    const pipeline = this.page?.pipelines.find((candidate) => candidate.id === event.detail.item.id)
+    if (!pipeline || !pipeline.canRun || pipeline.running) return
+    this.emitCommand('run', pipeline, '')
+  }
+
+  private handleRunAction = (event: CustomEvent<{ action: string, item: EntityListItem }>): void => {
+    const action = event.detail.action
+    const row = this.page?.runsTable.rows.find((candidate) => String(candidate.run_id || candidate.id || '') === event.detail.item.id)
+    if (!row) return
+    if (action === 'detail') {
+      this.selectedRunID = String(row.run_id || row.id || '')
+      return
+    }
+    if (action !== 'retry' && action !== 'cancel') return
+    const pipeline = this.page?.pipelines.find((candidate) => candidate.workspaceId === String(row.workspace_id) && candidate.pipelineId === String(row.pipeline_id))
+    if (!pipeline) return
+    this.emitCommand(action, pipeline, String(row.run_id || ''))
+  }
+
+  private closeRunDetail = (): void => {
+    this.selectedRunID = ''
+  }
+
+  private renderRunDetail(row: Record<string, unknown>) {
+    const status = runDetailValue(row, 'status_value')
+    const pipeline = runDetailValue(row, 'pipeline')
+    const workspace = runDetailValue(row, 'workspace')
+    const error = runDetailValue(row, 'error')
+    const pipelineHref = runDetailValue(row, 'pipeline_href')
+    return html`
+      <lv-drawer
+        open
+        size="wide"
+        label="Pipeline run detail"
+        .modal=${false}
+        @lv-drawer-close=${this.closeRunDetail}
+      >
+        <div slot="title" class=${`run-detail-title is-${runStatusTone(status)}`}>
+          ${runStatusIcon(status)}
+          <span>${capitalize(status)}</span>
+        </div>
+        <p slot="subtitle" class="run-detail-subtitle">${pipeline} · ${workspace}</p>
+        <div class="run-detail-body">
+          <section class="run-detail-section" aria-label="Run identity">
+            <h2>Run identity</h2>
+            <div class="run-detail-facts">
+              ${runDetailFact('Run ID', runDetailValue(row, 'run_id'), true)}
+              ${pipelineHref !== '—'
+                ? html`<div class="run-detail-fact"><span>Pipeline</span><a href=${pipelineHref}>${pipeline}</a></div>`
+                : runDetailFact('Pipeline', pipeline)}
+              ${runDetailFact('Workspace', workspace)}
+              ${runDetailFact('Environment', runDetailValue(row, 'environment'))}
+              ${runDetailFact('Semantic model', runDetailValue(row, 'semantic_model'), true)}
+            </div>
+          </section>
+          <section class="run-detail-section" aria-label="Lifecycle">
+            <h2>Lifecycle</h2>
+            <div class="run-detail-facts">
+              ${runDetailFact('Status', capitalize(status))}
+              ${runDetailFact('Trigger', runDetailValue(row, 'trigger'))}
+              ${runDetailFact('Triggered by', runDetailValue(row, 'principal_display_name'))}
+              ${runDetailFact('Principal ID', runDetailValue(row, 'principal_id'), true)}
+              ${runDetailFact('Created', formatRunDetailDate(row.created_at))}
+              ${runDetailFact('Started', formatRunDetailDate(row.started_at))}
+              ${runDetailFact('Finished', formatRunDetailDate(row.finished_at))}
+              ${runDetailFact('Duration', runDetailValue(row, 'duration'))}
+            </div>
+          </section>
+          <section class="run-detail-section" aria-label="Execution">
+            <h2>Execution</h2>
+            <div class="run-detail-facts">
+              ${runDetailFact('Retry of', runDetailValue(row, 'retry_of'), true)}
+              ${runDetailFact('Parent run', runDetailValue(row, 'parent_run_id'), true)}
+              ${runDetailFact('Serving state', runDetailValue(row, 'serving_state_id'), true)}
+              ${runDetailFact('Target generation', runDetailValue(row, 'target_generation'), true)}
+            </div>
+          </section>
+          ${error !== '—' ? html`
+            <section class="run-detail-section" aria-label="Run error">
+              <h2>Error</h2>
+              <pre class="run-detail-error"><code>${error}</code></pre>
+            </section>
+          ` : nothing}
+        </div>
+      </lv-drawer>
+    `
+  }
+
+  private emitCommand(action: 'run' | 'retry' | 'cancel', pipeline: PipelineListItemSignal, runId: string): void {
+    this.dispatchEvent(new CustomEvent('lv-pipeline-command', {
+      bubbles: true,
+      composed: true,
+      detail: { action, workspaceId: pipeline.workspaceId, pipelineId: pipeline.pipelineId, assetId: pipeline.assetId, runId },
+    }))
+  }
+}
+
+function commandLoadingLabel(action: string): string {
+  if (action === 'cancel') return 'Cancelling pipeline run…'
+  if (action === 'retry') return 'Queuing pipeline retry…'
+  return 'Queuing pipeline run…'
+}
+
+customElements.define('lv-pipelines-page', LeapViewPipelinesPage)
+
+function capitalize(value: string): string {
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : '—'
+}
+
+function formatDateTime(value: string | undefined): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  const elapsed = date.getTime() - Date.now()
+  const minutes = Math.round(Math.abs(elapsed) / 60_000)
+  if (minutes < 1) return elapsed >= 0 ? 'Now' : 'Just now'
+  if (minutes < 60) return elapsed >= 0 ? `In ${minutes} min` : `${minutes} min ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return elapsed >= 0 ? `In ${hours} hr` : `${hours} hr ago`
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date)
+}
+
+function formatExactDateTime(value: string | undefined): string {
+  if (!value) return ''
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+}
+
+function runDetailValue(row: Record<string, unknown>, key: string): string {
+  const value = row[key]
+  if (value == null || value === '' || value === '-') return '—'
+  return String(value)
+}
+
+function runDetailFact(label: string, value: string, code = false) {
+  return html`<div class="run-detail-fact"><span>${label}</span>${code ? html`<code>${value}</code>` : html`<strong>${value}</strong>`}</div>`
+}
+
+function formatRunDetailDate(value: unknown): string {
+  const normalized = value == null || value === '' || value === '-' ? '' : String(value)
+  if (!normalized) return '—'
+  const date = new Date(normalized)
+  return Number.isNaN(date.getTime()) ? normalized : new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'medium' }).format(date)
+}
+
+function runStatusTone(status: string): 'success' | 'danger' | 'attention' | 'muted' {
+  if (status === 'succeeded') return 'success'
+  if (status === 'failed' || status === 'cancelled') return 'danger'
+  if (status === 'queued' || status === 'running' || status === 'prepared') return 'attention'
+  return 'muted'
+}
+
+function runStatusIcon(status: string) {
+  if (status === 'succeeded') return lucideIcon(CheckCircle2, { size: 16, strokeWidth: 2 })
+  if (status === 'failed' || status === 'cancelled') return lucideIcon(XCircle, { size: 16, strokeWidth: 2 })
+  if (status === 'queued' || status === 'running' || status === 'prepared') return lucideIcon(Clock3, { size: 16, strokeWidth: 2 })
+  return lucideIcon(Circle, { size: 16, strokeWidth: 2 })
+}
+
+function firstRunListValue(...values: unknown[]): string {
+  const value = values.find((candidate) => candidate != null && candidate !== '' && candidate !== '-')
+  return value == null ? '—' : String(value)
+}
+
+function pipelineRunActionIcon(icon: string): EntityListRowAction['icon'] {
+  if (icon === 'details') return 'details'
+  if (icon === 'cancel') return 'cancel'
+  if (icon === 'refresh') return 'refresh'
+  return 'play'
+}

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -40,6 +40,11 @@ beforeAll(async () => {
       response.end(testDocument('source'))
       return
     }
+    if (url.pathname === '/pipelines') {
+      response.setHeader('content-type', 'text/html')
+      response.end(testDocument('pipelines'))
+      return
+    }
     const fileRoot = url.pathname.startsWith('/static/vendor/') ? projectRoot : root
     const file = normalize(join(fileRoot, url.pathname))
     if (!file.startsWith(fileRoot)) {
@@ -835,7 +840,105 @@ test('connection source detail opens as a non-modal drawer over its connection',
   }
 })
 
-function testDocument(root: 'workspace' | 'connections' | 'connection' | 'asset' | 'source'): string {
+test('global pipelines page reuses the list pattern and exposes run history details', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
+  try {
+    await page.goto(`${baseURL}/pipelines`)
+    await page.waitForFunction(() => customElements.get('lv-pipelines-page') && customElements.get('lv-entity-list') && customElements.get('lv-drawer'))
+    await page.waitForFunction(() => document.querySelector('lv-pipelines-page')?.shadowRoot?.querySelector('lv-entity-list tbody'))
+    const state = await page.evaluate(async () => {
+      const pipelines = document.querySelector('lv-pipelines-page') as any
+      const commands: unknown[] = []
+      pipelines.addEventListener('lv-pipeline-command', (event: CustomEvent) => commands.push(event.detail))
+      await pipelines.updateComplete
+      const list = pipelines.shadowRoot.querySelector('lv-entity-list') as any
+      await list.updateComplete
+      const pipelineTitle = list.querySelector('tbody tr:first-child .entity-list-title')?.textContent?.trim()
+      ;(list.querySelector('button[aria-label="Run now"]') as HTMLButtonElement).click()
+      const metrics = Array.from(pipelines.shadowRoot.querySelectorAll('.metric-value')).map((item: any) => item.textContent?.trim())
+      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev') as any
+      mergePatch({ page: { activeTab: 'runs' } })
+      await pipelines.updateComplete
+      const runList = pipelines.shadowRoot.querySelector('lv-entity-list') as any
+      await runList.updateComplete
+      ;(runList.querySelectorAll('tbody tr')[1] as HTMLTableRowElement).click()
+      await pipelines.updateComplete
+      const drawer = pipelines.shadowRoot.querySelector('lv-drawer') as any
+      const drawerText = drawer?.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+      const drawerIsNonModal = drawer?.modal === false
+      const hasErrorColumn = Array.from(runList.querySelectorAll('thead th')).some((cell: any) => cell.textContent?.trim() === 'Error')
+      const firstRunRow = runList.querySelector('tbody tr') as HTMLTableRowElement
+      const successStatus = firstRunRow.querySelector('.entity-list-status') as HTMLElement | null
+      const firstStatusCell = firstRunRow.querySelector(':scope > td:first-child') as HTMLElement | null
+      const pipelineTitleElement = firstRunRow.querySelector('.entity-list-title') as HTMLElement
+      const runTable = pipelines.shadowRoot.querySelector('.run-table') as HTMLElement
+      ;(runList.querySelector('button[aria-label="Retry run"]') as HTMLButtonElement).click()
+      ;(runList.querySelector('button[aria-label="Cancel run"]') as HTMLButtonElement).click()
+      drawer?.shadowRoot?.querySelector<HTMLButtonElement>('.close')?.click()
+      await pipelines.updateComplete
+      return {
+        title: pipelines.shadowRoot.querySelector('h1')?.textContent?.trim(),
+        pipelineTitle,
+        metrics,
+        activeTab: pipelines.shadowRoot.querySelector('.tabs a.active')?.textContent?.trim(),
+        runText: runList.textContent,
+        runListTag: runList.tagName,
+        runListCompact: runList.compact,
+        compactRowHeight: getComputedStyle(runList.querySelector('tbody tr') as HTMLElement).height,
+        runTableBorderWidth: getComputedStyle(runTable).borderTopWidth,
+        successStatusClass: successStatus?.className ?? '',
+        successStatusHasIcon: Boolean(successStatus?.querySelector('svg')),
+        firstStatusCellHasIcon: Boolean(firstStatusCell?.querySelector('svg')),
+        pipelineIconCount: runList.querySelectorAll('.entity-list-icon').length,
+        headers: Array.from(runList.querySelectorAll('thead th')).map((cell: any) => cell.textContent?.trim()),
+        secondColumnIsRowHeader: firstRunRow.children[1]?.tagName,
+        pipelineTitleWeight: getComputedStyle(pipelineTitleElement).fontWeight,
+        filterCount: pipelines.shadowRoot.querySelectorAll('.run-toolbar select').length,
+        statusFilterOptions: Array.from(pipelines.shadowRoot.querySelectorAll('.run-toolbar select')[1].options).map((option: any) => option.value),
+        drawerText,
+        drawerIsNonModal,
+        hasErrorColumn,
+        drawerClosed: !pipelines.shadowRoot.querySelector('lv-drawer'),
+        commands,
+      }
+    })
+    expect(state.title).toBe('Pipelines')
+    expect(state.pipelineTitle).toBe('Sales refresh')
+    expect(state.metrics).toEqual(['1', '2', '0', '1 / 1'])
+    expect(state.activeTab).toBe('Run history')
+    expect(state.runText).toMatch(/matrun_123/)
+    expect(state.runListTag).toBe('LV-ENTITY-LIST')
+    expect(state.runListCompact).toBe(true)
+    expect(parseFloat(state.compactRowHeight)).toBeLessThan(52)
+    expect(state.runTableBorderWidth).toBe('0px')
+    expect(state.successStatusClass).toContain('is-success')
+    expect(state.successStatusHasIcon).toBe(true)
+    expect(state.firstStatusCellHasIcon).toBe(true)
+    expect(state.pipelineIconCount).toBe(0)
+    expect(state.headers).toEqual(['Status', 'Pipeline', 'Workspace', 'Started', 'Duration', 'Trigger', 'Triggered by', ''])
+    expect(state.secondColumnIsRowHeader).toBe('TH')
+    expect(state.pipelineTitleWeight).toBe('400')
+    expect(state.filterCount).toBe(3)
+    expect(state.statusFilterOptions).toEqual(['all', 'queued', 'running', 'prepared', 'succeeded', 'failed', 'cancelled', 'superseded'])
+    expect(state.drawerText).toMatch(/Failed/)
+    expect(state.drawerText).toMatch(/matrun_failed/)
+    expect(state.drawerText).toMatch(/Sales Workspace/)
+    expect(state.drawerText).toMatch(/source unavailable/)
+    expect(state.drawerText).toMatch(/serving_42/)
+    expect(state.drawerIsNonModal).toBe(true)
+    expect(state.hasErrorColumn).toBe(false)
+    expect(state.drawerClosed).toBe(true)
+    expect(state.commands).toEqual([
+      { action: 'run', workspaceId: 'sales', pipelineId: 'sales-refresh', assetId: 'refresh_pipeline:sales-refresh', runId: '' },
+      { action: 'retry', workspaceId: 'sales', pipelineId: 'sales-refresh', assetId: 'refresh_pipeline:sales-refresh', runId: 'matrun_failed' },
+      { action: 'cancel', workspaceId: 'sales', pipelineId: 'sales-refresh', assetId: 'refresh_pipeline:sales-refresh', runId: 'matrun_queued' },
+    ])
+  } finally {
+    await page.close()
+  }
+})
+
+function testDocument(root: 'workspace' | 'connections' | 'connection' | 'asset' | 'source' | 'pipelines'): string {
   const assetList = {
     workspaceId: 'leapview',
     searchHref: '/workspaces/leapview',
@@ -1042,6 +1145,49 @@ function testDocument(root: 'workspace' | 'connections' | 'connection' | 'asset'
       }],
     },
   }
+  const pipelinesPage = {
+    kind: 'pipelines',
+    title: 'Pipelines',
+    description: 'Monitor refresh pipelines.',
+    environment: 'dev',
+    activeTab: 'pipelines',
+    metrics: [
+      { label: 'Running', value: '1', tone: 'accent' },
+      { label: 'Queued', value: '2', tone: 'attention' },
+      { label: 'Failed', value: '0', tone: 'success' },
+      { label: 'Refresh capacity', value: '1 / 1', tone: 'muted' },
+    ],
+    pipelines: [{
+      id: 'sales.sales-refresh', title: 'Sales refresh', href: '/workspaces/sales/assets/refresh_pipeline:sales-refresh/details',
+      workspace: 'Sales Workspace', workspaceId: 'sales', semanticModel: 'sales', schedule: '0 6 * * * · Europe/Copenhagen',
+      nextRun: '2026-08-15T04:00:00Z', status: 'succeeded', assetId: 'refresh_pipeline:sales-refresh', pipelineId: 'sales-refresh', canRun: true, running: false,
+    }],
+    workspaceFilters: [{ id: 'sales', title: 'Sales Workspace' }],
+    runsTable: {
+      rowAction: 'detail',
+      columns: [
+        { id: 'status', header: 'Status', kind: 'status' },
+        { id: 'pipeline', header: 'Pipeline', kind: 'link', hrefKey: 'pipeline_href' },
+        { id: 'run', header: 'Run ID', kind: 'code' },
+        { id: 'actions', header: '', kind: 'actions', toggleable: false },
+      ],
+      rows: [{
+        status: { label: 'succeeded', tone: 'success' }, pipeline: 'Sales refresh', pipeline_href: '/workspaces/sales/assets/refresh_pipeline:sales-refresh/refreshes',
+        run: 'matrun_123', workspace_id: 'sales', status_value: 'succeeded', trigger_value: 'manual', pipeline_search: 'sales refresh matrun_123',
+      }, {
+        status: { label: 'failed', tone: 'danger' }, pipeline: 'Sales refresh', run: 'matrun_failed', run_id: 'matrun_failed', workspace_id: 'sales',
+        workspace: 'Sales Workspace', semantic_model: 'sales', environment: 'dev', created_at: '2026-08-14T08:59:59Z', started_at: '2026-08-14T09:00:00Z', finished_at: '2026-08-14T09:01:00Z',
+        principal_id: 'principal_ada', principal_display_name: 'Ada', retry_of: 'matrun_prior', serving_state_id: 'serving_42', target_generation: 42, error: 'source unavailable',
+        asset_id: 'refresh_pipeline:sales-refresh', pipeline_id: 'sales-refresh', status_value: 'failed', trigger_value: 'retry', pipeline_search: 'sales refresh matrun_failed',
+        actions: [{ label: 'Retry run', action: 'retry', icon: 'refresh' }],
+      }, {
+        status: { label: 'queued', tone: 'attention' }, pipeline: 'Sales refresh', run: 'matrun_queued', run_id: 'matrun_queued', workspace_id: 'sales',
+        asset_id: 'refresh_pipeline:sales-refresh', pipeline_id: 'sales-refresh', status_value: 'queued', trigger_value: 'manual', pipeline_search: 'sales refresh matrun_queued',
+        actions: [{ label: 'Cancel run', action: 'cancel', icon: 'cancel' }],
+      }],
+      empty: 'No pipeline runs.',
+    },
+  }
   const access = {
     workspace: { ID: 'leapview', Title: 'LeapView Workspace' },
     roles: [{ Name: 'viewer' }, { Name: 'workspace_admin' }, { Name: 'data_deployer' }],
@@ -1085,7 +1231,9 @@ function testDocument(root: 'workspace' | 'connections' | 'connection' | 'asset'
       ? { signals: { page: sourcePage }, element: '<lv-workspace-asset-page></lv-workspace-asset-page>' }
     : root === 'asset'
       ? { signals: { page: assetPage }, element: '<lv-workspace-asset-page></lv-workspace-asset-page>' }
-      : { signals: { page: workspacePage, workspaceAccess: access }, element: '<lv-workspace-page></lv-workspace-page>' }
+      : root === 'pipelines'
+        ? { signals: { page: pipelinesPage }, element: '<lv-pipelines-page></lv-pipelines-page>' }
+        : { signals: { page: workspacePage, workspaceAccess: access }, element: '<lv-workspace-page></lv-workspace-page>' }
   return `
     <!doctype html>
     <html>
@@ -1094,7 +1242,7 @@ function testDocument(root: 'workspace' | 'connections' | 'connection' | 'asset'
           html, body { margin: 0; min-height: 100%; }
           body { ${typographyTestTokens} --lv-bg-app: #f6f8fa; --lv-bg-page: #eef2f6; --lv-bg-panel: #fff; --lv-bg-panel-muted: #f6f8fa; --lv-bg-control: #f6f8fa; --lv-bg-control-hover: #f3f4f6; --lv-fg-default: #24292f; --lv-fg-muted: #57606a; --lv-fg-link: #0969da; --lv-accent: #0969da; --lv-accent-fg: #fff; --lv-line-muted: #d8dee4; --lv-line-accent: #0969da; --lv-border-default: 1px solid #d0d7de; --lv-border-muted: 1px solid #d8dee4; --lv-border-transparent: 1px solid transparent; --lv-radius-default: 6px; --lv-radius-tight: 4px; --lv-radius-full: 999px; --lv-page-content-max-width: 72rem; --lv-workspace-detail-max-width: 72rem; --base-size-4: 4px; --base-size-6: 6px; --base-size-8: 8px; --base-size-10: 10px; --base-size-12: 12px; --base-size-16: 16px; --base-size-20: 20px; --base-size-24: 24px; --lv-space-control: 10px; --control-medium-size: 32px; --control-xlarge-size: 40px; --lv-spinner-size-md: 16px; --lv-spinner-duration: 1800ms; --lv-asset-dashboard-bg: #fbefff; --lv-asset-dashboard-accent: #8250df; --lv-asset-dashboard-border: #d2bfff; --lv-asset-semantic-model-bg: #ddf4ff; --lv-asset-semantic-model-accent: #0969da; --lv-asset-semantic-model-border: #b6e3ff; --z-index-inspector: 1000; --lv-modal-backdrop: rgb(0 0 0 / .28); }
           body { --focus-outline: 2px solid var(--lv-line-accent); --focus-outline-offset: 2px; }
-          lv-workspace-page, lv-connections-page, lv-workspace-asset-page { display: block; min-height: 720px; }
+          lv-workspace-page, lv-connections-page, lv-workspace-asset-page, lv-pipelines-page { display: block; min-height: 720px; }
         </style>
       </head>
       <body>

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -49,6 +49,7 @@ import '../shared/code-block'
 import '../shared/drawer'
 import '../shared/workspace-access-control'
 import './connection-administration'
+import './pipelines-page'
 
 const emptyWorkspaceAccess: WorkspaceAccessSignal = {
   workspace: {},


### PR DESCRIPTION
## Summary

- add a global Pipelines surface for refresh pipeline health and shared execution capacity
- expose run, retry, rerun, and cancel commands through the generated authorized and audited command flow
- add compact run history with complete status filtering, semantic status icons, and a non-modal detail drawer
- extend the shared entity list for compact operational records without changing existing entity pages

## Validation

- Pipeline browser coverage: 11 passed
- shared catalog/entity-list coverage: 9 passed
- generated contract snapshot check passed
- full Go package, app-shard, and external MinIO contracts passed
- full CI frontend lanes passed except one public-site global hook timeout under parallel load; the affected site suite passed 51/51 when rerun in isolation
- live Tailscale page validated with real pipeline runs and no browser errors