### PR TITLE
Add connection administration lifecycle

### DIFF
--- a/api/signals/main.tsp
+++ b/api/signals/main.tsp
@@ -524,6 +524,8 @@ model ComposerSignal {
 model ConnectionsPageEnvelope {
   @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "chrome" })
   `chrome`: ChromeSignal;
+  @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "connectionAdmin" })
+  `connectionAdmin`: ConnectionAdministrationSignal;
   @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "page" })
   `page`: ConnectionsPageSignal;
   @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "runtime" })
@@ -535,12 +537,99 @@ model ConnectionsPageEnvelope {
 @apigen.contract(#{ kind: "ui-signal", tags: #["connections", "signal"] })
 @apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "connections" })
 model ConnectionsPageSignal {
-  `assetList`?: WorkspaceAssetListSignal;
+  `connections`: ConnectionSummarySignal[];
   `description`?: string;
   `environment`?: string;
   `kind`: RouteKind;
+  `query`?: string;
   `title`: string;
   `workspaceId`?: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["connections", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "connections" })
+model ConnectionSummarySignal {
+  `credentialStatus`: string;
+  `description`?: string;
+  `detailHref`: string;
+  `id`: string;
+  `kind`: string;
+  `lifecycle`: ConnectionLifecycleSignal;
+  `scope`: string;
+  `sourceCount`: int64;
+  `title`: string;
+}
+
+model ConnectionAdministrationCommandSignal {
+  `action`: string;
+  `assetId`: string;
+  `authenticationMode`: string;
+  `confirmationToken`: string;
+  `connectorKind`: string;
+  `credentialEnvironment`: string;
+  `credentialProjectId`: string;
+  `database`: string;
+  `expectedRevision`: int64;
+  `host`: string;
+  `logicalConnection`: string;
+  `objectScope`: string;
+  `options`: string;
+  `port`: string;
+  `secretKey`: string;
+  `secretPath`: string;
+  `sourceIdentity`: string;
+  `surface`: string;
+  `tlsMode`: string;
+}
+
+model ConnectionAdministrationSignal {
+  `command`: ConnectionAdministrationCommandSignal;
+  `status`: ConnectionAdministrationStatusSignal;
+}
+
+model ConnectionAdministrationStatusSignal {
+  `error`: string;
+  `loading`: boolean;
+  `message`: string;
+}
+
+model ConnectionLifecycleActionSignal {
+  `destructive`: boolean;
+  `id`: string;
+  `label`: string;
+  `primary`: boolean;
+}
+
+model ConnectionLifecycleSignal {
+  `actions`: ConnectionLifecycleActionSignal[];
+  `assetId`: string;
+  `authenticationMode`: string;
+  `bindingId`: string;
+  `canManage`: boolean;
+  `canTest`: boolean;
+  `connectorKind`: string;
+  `credentialEnvironment`: string;
+  `credentialProjectId`: string;
+  `database`: string;
+  `diagnosticCode`: string;
+  `enabled`: boolean;
+  `exists`: boolean;
+  `health`: string;
+  `host`: string;
+  `lastValidatedAt`: string;
+  `logicalConnection`: string;
+  `objectScope`: string;
+  `options`: string;
+  `port`: string;
+  `revision`: int64;
+  `secretKey`: string;
+  `secretPath`: string;
+  `sourceIdentity`: string;
+  `state`: string;
+  `statusLabel`: string;
+  `tlsMode`: string;
+  `tone`: string;
+  `validatedVersion`: string;
 }
 
 @apigen.contract(#{ kind: "ui-signal", tags: #["dashboard", "signal"] })
@@ -1711,6 +1800,8 @@ model WorkspaceAssetListSignal {
 model WorkspaceAssetPageEnvelope {
   @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "chrome" })
   `chrome`: ChromeSignal;
+  @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "connectionAdmin" })
+  `connectionAdmin`?: ConnectionAdministrationSignal;
   @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "page" })
   `page`: WorkspaceAssetPageSignal;
   @apigen.`metadata`(#{ `x-leapview-patch-mode`: "replace", `x-leapview-signal-key`: "runtime" })
@@ -1727,7 +1818,9 @@ model WorkspaceAssetPageSignal {
   `asset`: WorkspaceAssetSummarySignal;
   `assetId`: string;
   `breadcrumbs`: WorkspaceBreadcrumbSignal[];
+  `connectionLifecycle`?: ConnectionLifecycleSignal;
   `details`?: WorkspaceAssetDetailsSignal;
+  `drawerParent`?: WorkspaceAssetPageSignal;
   `environment`?: string;
   `kind`: RouteKind;
   `lineage`?: WorkspaceAssetLineageSignal;

--- a/api/typespec/connection_bindings.tsp
+++ b/api/typespec/connection_bindings.tsp
@@ -204,6 +204,7 @@ interface TargetConnectionBindings {
   @apigen.failsWith(ConnectionBindingConflictFailure)
   @apigen.failsWith(ConnectionTestFailedFailure)
   @apigen.failsWith(ConnectionProviderUnavailableFailure)
+  @apigen.ui("connection.binding.configure")
   @apigen.command(#{
     auditAction: "connection.binding.created",
     failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
@@ -253,6 +254,7 @@ interface TargetConnectionBindings {
   @apigen.failsWith(ConnectionBindingDisabledFailure)
   @apigen.failsWith(ConfirmationRequiredFailure)
   @apigen.failsWith(ConnectionProviderUnavailableFailure)
+  @apigen.ui("connection.binding.update")
   @apigen.command(#{
     auditAction: "connection.binding.updated",
     failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
@@ -278,6 +280,7 @@ interface TargetConnectionBindings {
   @apigen.failsWith(ConnectionBindingDisabledFailure)
   @apigen.failsWith(ConnectionTestFailedFailure)
   @apigen.failsWith(ConnectionProviderUnavailableFailure)
+  @apigen.ui("connection.binding.test")
   @apigen.command(#{
     auditAction: "credential.test.requested",
     failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
@@ -302,6 +305,7 @@ interface TargetConnectionBindings {
   @apigen.failsWith(ConnectionBindingDisabledFailure)
   @apigen.failsWith(ConnectionTestFailedFailure)
   @apigen.failsWith(ConnectionProviderUnavailableFailure)
+  @apigen.ui("connection.binding.refresh")
   @apigen.command(#{
     auditAction: "credential.refresh.requested",
     failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
@@ -324,6 +328,7 @@ interface TargetConnectionBindings {
   @apigen.failsWith(ConnectionBindingNotFoundFailure)
   @apigen.failsWith(ConnectionBindingConflictFailure)
   @apigen.failsWith(ConnectionProviderUnavailableFailure)
+  @apigen.ui("connection.binding.enable")
   @apigen.command(#{
     auditAction: "connection.binding.enabled",
     failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],
@@ -347,6 +352,7 @@ interface TargetConnectionBindings {
   @apigen.failsWith(ConnectionBindingConflictFailure)
   @apigen.failsWith(ConnectionBindingDisabledFailure)
   @apigen.failsWith(ConnectionProviderUnavailableFailure)
+  @apigen.ui("connection.binding.disable")
   @apigen.command(#{
     auditAction: "connection.binding.disabled",
     failures: #[#{ kind: "audit_unavailable", statusCode: 503, code: "AUDIT_UNAVAILABLE", publicDetail: "Connection binding audit could not be persisted." }],

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -55824,6 +55824,8 @@ paths:
               logicalConnection: example
       x-apigen-operation-kind: command
       x-apigen-command:
+        additional_exposures:
+          - ui
         audit:
           guarantee: best-effort
           payload:
@@ -55875,6 +55877,8 @@ paths:
         target:
           parameter: workspace
           type: workspace
+        ui:
+          action_id: connection.binding.configure
         privilege: MANAGE_CONNECTION_METADATA
       x-authz:
         mode: privilege
@@ -56524,6 +56528,8 @@ paths:
               expectedRevision: 1
       x-apigen-operation-kind: command
       x-apigen-command:
+        additional_exposures:
+          - ui
         audit:
           guarantee: best-effort
           payload:
@@ -56578,6 +56584,8 @@ paths:
         target:
           parameter: workspace
           type: workspace
+        ui:
+          action_id: connection.binding.update
         privilege: MANAGE_CONNECTION_METADATA
       x-authz:
         mode: privilege
@@ -56899,6 +56907,8 @@ paths:
         - Connections
       x-apigen-operation-kind: command
       x-apigen-command:
+        additional_exposures:
+          - ui
         audit:
           guarantee: best-effort
           payload:
@@ -56950,6 +56960,8 @@ paths:
         target:
           parameter: workspace
           type: workspace
+        ui:
+          action_id: connection.binding.disable
         privilege: MANAGE_CONNECTION_METADATA
       x-authz:
         mode: privilege
@@ -57271,6 +57283,8 @@ paths:
         - Connections
       x-apigen-operation-kind: command
       x-apigen-command:
+        additional_exposures:
+          - ui
         audit:
           guarantee: best-effort
           payload:
@@ -57318,6 +57332,8 @@ paths:
         target:
           parameter: workspace
           type: workspace
+        ui:
+          action_id: connection.binding.enable
         privilege: MANAGE_CONNECTION_METADATA
       x-authz:
         mode: privilege
@@ -58238,6 +58254,8 @@ paths:
         - Connections
       x-apigen-operation-kind: command
       x-apigen-command:
+        additional_exposures:
+          - ui
         audit:
           guarantee: best-effort
           payload:
@@ -58297,6 +58315,8 @@ paths:
         target:
           parameter: workspace
           type: workspace
+        ui:
+          action_id: connection.binding.refresh
         privilege: TEST_CONNECTION
       x-authz:
         mode: privilege
@@ -58605,6 +58625,8 @@ paths:
         - Connections
       x-apigen-operation-kind: command
       x-apigen-command:
+        additional_exposures:
+          - ui
         audit:
           guarantee: best-effort
           payload:
@@ -58664,6 +58686,8 @@ paths:
         target:
           parameter: workspace
           type: workspace
+        ui:
+          action_id: connection.binding.test
         privilege: TEST_CONNECTION
       x-authz:
         mode: privilege

--- a/internal/analytics/connectionadmin/contracts.go
+++ b/internal/analytics/connectionadmin/contracts.go
@@ -1,0 +1,50 @@
+// Package connectionadmin exposes the analytics-owned connection binding
+// administration contract to product surfaces. The implementation remains in
+// the connectionbinding use-case package and is assembled by the application.
+package connectionadmin
+
+import (
+	"context"
+
+	"github.com/flidai/leapview/internal/analytics/connectionbinding"
+)
+
+type BindingScope = connectionbinding.BindingScope
+type BindingKey = connectionbinding.BindingKey
+type BindingHealthStatus = connectionbinding.BindingHealthStatus
+type BindingChangePlan = connectionbinding.BindingChangePlan
+type TargetBinding = connectionbinding.TargetBinding
+type TargetBindingInput = connectionbinding.TargetBindingInput
+type TargetBindingConfiguration = connectionbinding.TargetBindingConfiguration
+type UpdateConfigurationRequest = connectionbinding.UpdateConfigurationRequest
+type AuthenticationMode = connectionbinding.AuthenticationMode
+type EndpointConfig = connectionbinding.EndpointConfig
+type CredentialReference = connectionbinding.CredentialReference
+
+var (
+	ErrInvalidBinding          = connectionbinding.ErrInvalidBinding
+	ErrBindingNotFound         = connectionbinding.ErrBindingNotFound
+	ErrIncompatibleBinding     = connectionbinding.ErrIncompatibleBinding
+	ErrDisabledBinding         = connectionbinding.ErrDisabledBinding
+	ErrUnauthorizedBinding     = connectionbinding.ErrUnauthorizedBinding
+	ErrCredentialDenied        = connectionbinding.ErrCredentialDenied
+	ErrCredentialNotFound      = connectionbinding.ErrCredentialNotFound
+	ErrCredentialRateLimited   = connectionbinding.ErrCredentialRateLimited
+	ErrProviderUnavailable     = connectionbinding.ErrProviderUnavailable
+	ErrInvalidCredentialBundle = connectionbinding.ErrInvalidCredentialBundle
+)
+
+var ParseLogicalConnectionID = connectionbinding.ParseLogicalConnectionID
+
+// Administration is the synchronous lifecycle surface consumed by workspace
+// UI. It deliberately carries references, never credential secret values.
+type Administration interface {
+	List(context.Context, string, BindingScope, string) ([]TargetBinding, error)
+	Create(context.Context, string, TargetBindingInput) (TargetBinding, error)
+	PlanConfigurationChange(context.Context, string, BindingKey, TargetBindingConfiguration) (BindingChangePlan, error)
+	UpdateConfiguration(context.Context, UpdateConfigurationRequest) (TargetBinding, error)
+	Test(context.Context, string, BindingKey) (BindingHealthStatus, error)
+	RefreshNow(context.Context, string, BindingKey) (BindingHealthStatus, error)
+	Enable(context.Context, string, BindingKey) (TargetBinding, error)
+	Disable(context.Context, string, BindingKey) (TargetBinding, error)
+}

--- a/internal/analytics/module/connection_binding_operation_contracts_test.go
+++ b/internal/analytics/module/connection_binding_operation_contracts_test.go
@@ -15,13 +15,14 @@ func TestConnectionBindingOperationClassifications(t *testing.T) {
 		auditAction string
 		privilege   string
 		idempotency string
+		uiAction    string
 	}{
-		"createTargetConnectionBinding":  {auditAction: string(connectionbinding.AuditBindingCreated), privilege: "MANAGE_CONNECTION_METADATA", idempotency: "required"},
-		"updateTargetConnectionBinding":  {auditAction: string(connectionbinding.AuditBindingUpdated), privilege: "MANAGE_CONNECTION_METADATA"},
-		"testTargetConnectionBinding":    {auditAction: string(connectionbinding.RefreshTest), privilege: "TEST_CONNECTION", idempotency: "required"},
-		"refreshTargetConnectionBinding": {auditAction: string(connectionbinding.RefreshRequested), privilege: "TEST_CONNECTION", idempotency: "required"},
-		"enableTargetConnectionBinding":  {auditAction: string(connectionbinding.AuditBindingEnabled), privilege: "MANAGE_CONNECTION_METADATA", idempotency: "required"},
-		"disableTargetConnectionBinding": {auditAction: string(connectionbinding.AuditBindingDisabled), privilege: "MANAGE_CONNECTION_METADATA", idempotency: "required"},
+		"createTargetConnectionBinding":  {auditAction: string(connectionbinding.AuditBindingCreated), privilege: "MANAGE_CONNECTION_METADATA", idempotency: "required", uiAction: "connection.binding.configure"},
+		"updateTargetConnectionBinding":  {auditAction: string(connectionbinding.AuditBindingUpdated), privilege: "MANAGE_CONNECTION_METADATA", uiAction: "connection.binding.update"},
+		"testTargetConnectionBinding":    {auditAction: string(connectionbinding.RefreshTest), privilege: "TEST_CONNECTION", idempotency: "required", uiAction: "connection.binding.test"},
+		"refreshTargetConnectionBinding": {auditAction: string(connectionbinding.RefreshRequested), privilege: "TEST_CONNECTION", idempotency: "required", uiAction: "connection.binding.refresh"},
+		"enableTargetConnectionBinding":  {auditAction: string(connectionbinding.AuditBindingEnabled), privilege: "MANAGE_CONNECTION_METADATA", idempotency: "required", uiAction: "connection.binding.enable"},
+		"disableTargetConnectionBinding": {auditAction: string(connectionbinding.AuditBindingDisabled), privilege: "MANAGE_CONNECTION_METADATA", idempotency: "required", uiAction: "connection.binding.disable"},
 	}
 	for operationID, expected := range commands {
 		contract, ok := contracts[operationID]
@@ -37,7 +38,8 @@ func TestConnectionBindingOperationClassifications(t *testing.T) {
 			contract.Command.Target.Type != "workspace" ||
 			contract.Command.Privilege != expected.privilege ||
 			contract.Command.Idempotency != expected.idempotency ||
-			len(contract.Command.AdditionalExposures) != 0 {
+			contract.Command.UI == nil ||
+			contract.Command.UI.ActionID != expected.uiAction {
 			t.Errorf("command contract %q = %#v", operationID, contract)
 		}
 	}

--- a/internal/analytics/module/connection_ui_commands.go
+++ b/internal/analytics/module/connection_ui_commands.go
@@ -1,0 +1,29 @@
+package module
+
+import (
+	analyticsgen "github.com/flidai/leapview/internal/analytics/api/gen"
+	"github.com/flidai/leapview/internal/platform/web/uicommand"
+)
+
+// ConnectionUICommandBindings is the analytics-owned identity surface used by
+// the workspace UI adapter. The generated bindings keep browser mutations
+// tied to their audited API operation contracts.
+type ConnectionUICommandBindings struct {
+	Create  uicommand.Binding
+	Update  uicommand.Binding
+	Test    uicommand.Binding
+	Refresh uicommand.Binding
+	Enable  uicommand.Binding
+	Disable uicommand.Binding
+}
+
+func (*Module) ConnectionUICommandBindings() ConnectionUICommandBindings {
+	return ConnectionUICommandBindings{
+		Create:  analyticsgen.GenUIActionCreateTargetConnectionBinding(),
+		Update:  analyticsgen.GenUIActionUpdateTargetConnectionBinding(),
+		Test:    analyticsgen.GenUIActionTestTargetConnectionBinding(),
+		Refresh: analyticsgen.GenUIActionRefreshTargetConnectionBinding(),
+		Enable:  analyticsgen.GenUIActionEnableTargetConnectionBinding(),
+		Disable: analyticsgen.GenUIActionDisableTargetConnectionBinding(),
+	}
+}

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -860,8 +860,8 @@ func TestAPIGenOwnsUISignalContracts(t *testing.T) {
 	if irDoc.SchemaVersion != "v4" {
 		t.Fatalf("UI signal IR schema_version = %q, want v4", irDoc.SchemaVersion)
 	}
-	if len(irDoc.Contracts) != 113 {
-		t.Fatalf("UI signal IR contracts = %d, want 113", len(irDoc.Contracts))
+	if len(irDoc.Contracts) != 114 {
+		t.Fatalf("UI signal IR contracts = %d, want 114", len(irDoc.Contracts))
 	}
 	foundEnvelopeMetadata := false
 	foundImportedVisualizationRoot := false

--- a/internal/app/data_explorer_test.go
+++ b/internal/app/data_explorer_test.go
@@ -368,8 +368,40 @@ func TestGlobalDataExplorerSelectsDuplicateKeysByWorkspace(t *testing.T) {
 	if uisignals.ValueOrZero(explorer.SelectedKey) != "model_table:model_table:olist.orders" || explorer.SelectedObject == nil || explorer.SelectedObject.WorkspaceID != "ops" {
 		t.Fatalf("selected object = %#v key=%q", explorer.SelectedObject, uisignals.ValueOrZero(explorer.SelectedKey))
 	}
-	if len(explorer.Objects) != 2 {
-		t.Fatalf("object count = %d, want both workspaces' model table", len(explorer.Objects))
+	if len(explorer.Objects) != 4 {
+		t.Fatalf("object count = %d, want both workspaces' source and model table", len(explorer.Objects))
+	}
+}
+
+func TestGlobalDataExplorerKeepsRequestedSourceSelected(t *testing.T) {
+	store := testStore(t)
+	metrics := dataExplorerFixtureMetrics{dataDir: seedDataExplorerCSV(t)}
+	seedActiveDeploymentFromWorkspaceAssets(t, store, "test", metrics)
+	server := assembleRuntime(metrics, testStoreOptions(store, assemblyConfig{WorkspaceID: "test"}))
+
+	const object = "source:olist.orders"
+	req := dataExplorerTestRequest(http.MethodGet, "/data?workspace=test&object="+object, nil)
+	_, explorer, err := server.globalDataExplorerState(req, dataExplorerCommandFromQuery("test", object))
+	if err != nil {
+		t.Fatalf("globalDataExplorerState() error = %v", err)
+	}
+	if explorer.SelectedObject == nil {
+		t.Fatal("selected source is nil")
+	}
+	if got := uisignals.ValueOrZero(explorer.SelectedObject.AssetID); got != object {
+		t.Fatalf("selected asset = %q, want %q", got, object)
+	}
+	if explorer.SelectedObject.Layer != "source" || uisignals.ValueOrZero(explorer.SelectedObject.Table) != "orders" {
+		t.Fatalf("selected object = %#v, want orders source", explorer.SelectedObject)
+	}
+	if got := uisignals.ValueOrZero(explorer.SelectedObject.RowCountLabel); got != "Preview unavailable" {
+		t.Fatalf("source row label = %q", got)
+	}
+	if len(uisignals.ValueOrZero(explorer.SelectedObject.Columns)) != 2 {
+		t.Fatalf("source columns = %#v", explorer.SelectedObject.Columns)
+	}
+	if len(explorer.Preview.Blocks["a"].Rows) != 0 {
+		t.Fatalf("raw source rows must not be queried: %#v", explorer.Preview.Blocks["a"].Rows)
 	}
 }
 

--- a/internal/app/deployment_candidates_test.go
+++ b/internal/app/deployment_candidates_test.go
@@ -791,7 +791,7 @@ func TestWorkspaceConnectionFilterRedirectsToGlobalConnections(t *testing.T) {
 	}
 }
 
-func TestWorkspaceSourceFilterRedirectsToConnectionSources(t *testing.T) {
+func TestWorkspaceSourceFilterRedirectsToConnections(t *testing.T) {
 	t.Setenv("LEAPVIEW_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
 	seedActiveDeployment(t, store, "test")
@@ -806,8 +806,8 @@ func TestWorkspaceSourceFilterRedirectsToConnectionSources(t *testing.T) {
 	if rec.Code != http.StatusFound {
 		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusFound, rec.Body.String())
 	}
-	if got := rec.Header().Get("Location"); got != "/connections?type=source&q=orders" {
-		t.Fatalf("Location = %q, want /connections?type=source&q=orders", got)
+	if got := rec.Header().Get("Location"); got != "/connections" {
+		t.Fatalf("Location = %q, want /connections", got)
 	}
 }
 
@@ -827,7 +827,7 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
 	body := renderedWithBootstrap(t, server, rec.Body.String(), "Bearer dev")
-	for _, want := range []string{"<lv-connections-page", "Connections", "Connection", "Source", "assetList", "Project-global managed Olist ecommerce demo data.", "orders"} {
+	for _, want := range []string{"<lv-connections-page", "Connections", "connections", "Project-global managed Olist ecommerce demo data.", "sourceCount", "credentialStatus"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("connections page missing %q:\n%s", want, body)
 		}
@@ -835,8 +835,8 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 	if !strings.Contains(body, `/connections/connection:olist/details`) {
 		t.Fatalf("connections page did not link to canonical connection details:\n%s", body)
 	}
-	if !strings.Contains(body, `/sources/source:olist.orders/details`) {
-		t.Fatalf("connections page did not link to canonical source details:\n%s", body)
+	if strings.Contains(body, `/sources/`) || strings.Contains(body, `"typeLabel":"Source"`) {
+		t.Fatalf("connections page mixed source rows into the connection list:\n%s", body)
 	}
 	if strings.Contains(body, `/workspaces/test/assets/`) {
 		t.Fatalf("connections page linked to workspace asset details:\n%s", body)
@@ -846,14 +846,14 @@ func TestConnectionsPageRendersGlobalConnectionSurface(t *testing.T) {
 	}
 }
 
-func TestConnectionsPageFiltersSources(t *testing.T) {
+func TestConnectionsPageIgnoresLegacySourceFilter(t *testing.T) {
 	t.Setenv("LEAPVIEW_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
 	seedActiveDeployment(t, store, "test")
 	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, WorkspaceID: "test"}))
 
-	req := httptest.NewRequest(http.MethodGet, "/connections?type=source&q=orders", nil)
+	req := httptest.NewRequest(http.MethodGet, "/connections?type=source", nil)
 	req.Header.Set("Authorization", "Bearer dev")
 	rec := httptest.NewRecorder()
 	server.Routes().ServeHTTP(rec, req)
@@ -862,13 +862,13 @@ func TestConnectionsPageFiltersSources(t *testing.T) {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
 	body := renderedWithBootstrap(t, server, rec.Body.String(), "Bearer dev")
-	for _, want := range []string{"Source", "orders", `/connections/`, `/sources/`} {
+	for _, want := range []string{"olist", `/connections/connection:olist/details`, `"kind":"managed"`} {
 		if !strings.Contains(body, want) {
-			t.Fatalf("source-filtered connections page missing %q:\n%s", want, body)
+			t.Fatalf("connections page missing %q with legacy source filter:\n%s", want, body)
 		}
 	}
-	if strings.Contains(body, "Local CSV files for the Olist ecommerce demo dataset.") {
-		t.Fatalf("source-filtered connections page included connection row:\n%s", body)
+	if strings.Contains(body, `/sources/`) || strings.Contains(body, `"typeLabel":"Source"`) {
+		t.Fatalf("legacy source filter restored source rows:\n%s", body)
 	}
 }
 
@@ -879,7 +879,7 @@ func TestConnectionsSearchCommandPatchesOnlyResultRows(t *testing.T) {
 	auth := testAuth(store, "test", AuthConfig{DevBypass: true})
 	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: auth, WorkspaceID: "test"}))
 
-	req := httptest.NewRequest(http.MethodPost, "/connections/search", strings.NewReader(`{"entityListQuery":"orders","entityListFilter":"source"}`))
+	req := httptest.NewRequest(http.MethodPost, "/connections/search", strings.NewReader(`{"entityListQuery":"olist"}`))
 	req.Header.Set("Authorization", "Bearer dev")
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -896,17 +896,13 @@ func TestConnectionsSearchCommandPatchesOnlyResultRows(t *testing.T) {
 	if !ok || len(patches[0]) != 1 || len(page) != 1 {
 		t.Fatalf("search command patched more than result data: %#v", patches[0])
 	}
-	assetList, ok := page["assetList"].(map[string]any)
-	if !ok || len(assetList) != 1 {
-		t.Fatalf("search command asset list patch = %#v", page["assetList"])
+	connections, ok := page["connections"].([]any)
+	if !ok || len(connections) == 0 {
+		t.Fatalf("search command connections = %#v", page["connections"])
 	}
-	assets, ok := assetList["assets"].([]any)
-	if !ok || len(assets) == 0 {
-		t.Fatalf("search command assets = %#v", assetList["assets"])
-	}
-	for _, value := range assets {
+	for _, value := range connections {
 		asset, ok := value.(map[string]any)
-		if !ok || asset["type"] != "source" || !strings.Contains(strings.ToLower(fmt.Sprint(asset["title"])), "orders") {
+		if !ok || !strings.Contains(strings.ToLower(fmt.Sprint(asset["title"])), "olist") || asset["sourceCount"] == nil {
 			t.Fatalf("unexpected connection search result: %#v", value)
 		}
 	}
@@ -993,7 +989,7 @@ func TestConnectionSourceAssetRoutesUseConnectionScopedSurface(t *testing.T) {
 		t.Fatalf("source detail status = %d body=%s", detailRec.Code, detailRec.Body.String())
 	}
 	detailBody := renderedWithBootstrap(t, server, detailRec.Body.String(), "Bearer dev")
-	for _, want := range []string{"Connections", "Sources", "orders", "Fields", "Physical type", "Lineage"} {
+	for _, want := range []string{"Connections", "Sources", "orders", "Fields", "Physical type", "Lineage", `"drawerParent":`} {
 		if !strings.Contains(detailBody, want) {
 			t.Fatalf("source detail missing %q:\n%s", want, detailBody)
 		}

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -616,6 +616,11 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 		}
 		var err error
 		agentUICommands := routes.agentModule.UICommandBindings()
+		connectionUICommands := runtime.analyticsModule.ConnectionUICommandBindings()
+		connectionWorkspaceID := ""
+		if runtime.metrics != nil {
+			connectionWorkspaceID = runtime.metrics.Catalog().Workspace.ID
+		}
 		routes.workspaceModule, err = workspacemodule.Build(ctx, workspacemodule.Config{
 			Database:            database,
 			Logger:              platform.logger,
@@ -632,7 +637,18 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 				CreateGrant:       accessUICommands.CreateGrant,
 				DeleteGrant:       accessUICommands.DeleteGrant,
 			},
-			AssetCatalog: persistence.workspaceAssetCatalog,
+			ConnectionAdministration: connectionAdministration,
+			ConnectionAuthorize: func(ctx context.Context, principalID string, privilege accessmodule.Privilege, workspaceID string) (bool, error) {
+				return routes.accessModule.AuthorizeObject(ctx, principalID, privilege, accessmodule.WorkspaceObject(workspaceID))
+			},
+			ConnectionCommands: workspacemodule.ConnectionCommandBindings{
+				Create: connectionUICommands.Create, Update: connectionUICommands.Update,
+				Test: connectionUICommands.Test, Refresh: connectionUICommands.Refresh,
+				Enable: connectionUICommands.Enable, Disable: connectionUICommands.Disable,
+			},
+			ConnectionTargetID:    storage.instanceID,
+			ConnectionWorkspaceID: connectionWorkspaceID,
+			AssetCatalog:          persistence.workspaceAssetCatalog,
 			WorkspaceID: func(value string) string {
 				return value
 			},

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -34,7 +34,7 @@ type PackageRule struct {
 var PublicContractPrefixes = map[string][]string{
 	"access":       {"internal/access", "internal/access/api", "internal/access/policy", "internal/access/snapshot", "internal/access/ui/signals"},
 	"agent":        {"internal/agent/api", "internal/agent/ui/signals"},
-	"analytics":    {"internal/analytics/model", "internal/analytics/query", "internal/analytics/materialize", "internal/analytics/materialization", "internal/analytics/connectors", "internal/analytics/arrowquery", "internal/analytics/resource", "internal/analytics/runtime", "internal/analytics/queryaudit", "internal/analytics/dataquery"},
+	"analytics":    {"internal/analytics/model", "internal/analytics/query", "internal/analytics/materialize", "internal/analytics/materialization", "internal/analytics/connectors", "internal/analytics/connectionadmin", "internal/analytics/arrowquery", "internal/analytics/resource", "internal/analytics/runtime", "internal/analytics/queryaudit", "internal/analytics/dataquery"},
 	"dashboard":    {"internal/dashboard", "internal/dashboard/api", "internal/dashboard/appearance", "internal/dashboard/catalog", "internal/dashboard/definition", "internal/dashboard/filter", "internal/dashboard/publication", "internal/dashboard/report", "internal/dashboard/reportmodel", "internal/dashboard/queryruntime", "internal/dashboard/ui/signals", "internal/dashboard/visualization/definition", "internal/dashboard/visualization/format", "internal/dashboard/visualization/geometry", "internal/dashboard/visualization/ir", "internal/dashboard/visualization/mapasset", "internal/dashboard/visualization/runtime"},
 	"manageddata":  {"internal/manageddata", "internal/manageddata/binding", "internal/manageddata/runtimebinding"},
 	"workspace":    {"internal/workspace", "internal/workspace/api", "internal/workspace/navigation", "internal/workspace/search"},
@@ -158,6 +158,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/project/compiler", Capability: "project", Layer: LayerUseCase},
 	{Prefix: "internal/project/artifact", Capability: "project", Layer: LayerContract},
 	{Prefix: "internal/analytics/runtime", Capability: "analytics", Layer: LayerContract},
+	{Prefix: "internal/analytics/connectionadmin", Capability: "analytics", Layer: LayerContract},
 	{Prefix: "internal/analytics/infisical", Capability: "analytics", Layer: LayerAdapter},
 	{Prefix: "internal/analytics/environment", Capability: "analytics", Layer: LayerAdapter},
 	{Prefix: "internal/dashboard/analyticsruntime", Capability: "dashboard", Layer: LayerAdapter},

--- a/internal/workspace/assetnav/hrefs.go
+++ b/internal/workspace/assetnav/hrefs.go
@@ -8,21 +8,10 @@ import (
 )
 
 func ConnectionsHref(query string) string {
-	return ConnectionsHrefWithType("", query)
-}
-
-func ConnectionsHrefWithType(typ, query string) string {
-	params := []string{}
-	if typ = strings.TrimSpace(typ); typ != "" {
-		params = append(params, "type="+url.QueryEscape(typ))
-	}
-	if query = strings.TrimSpace(query); query != "" {
-		params = append(params, "q="+url.QueryEscape(query))
-	}
-	if len(params) == 0 {
+	if query = strings.TrimSpace(query); query == "" {
 		return "/connections"
 	}
-	return "/connections?" + strings.Join(params, "&")
+	return "/connections?q=" + url.QueryEscape(query)
 }
 
 func WorkspaceAssetSectionHref(workspaceID, assetID, section string) string {

--- a/internal/workspace/http/connection_admin.go
+++ b/internal/workspace/http/connection_admin.go
@@ -1,0 +1,349 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	nethttp "net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Yacobolo/toolbelt/pagestream"
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/connectionadmin"
+	"github.com/flidai/leapview/internal/analytics/connectors"
+	"github.com/flidai/leapview/internal/platform/web/uicommand"
+	"github.com/flidai/leapview/internal/workspace"
+	"github.com/flidai/leapview/internal/workspace/ui"
+	uisignals "github.com/flidai/leapview/internal/workspace/ui/signals"
+)
+
+type ConnectionPrivilegeAuthorizer func(context.Context, string, access.Privilege, string) (bool, error)
+
+type connectionAdministrationPayload struct {
+	ConnectionAdmin uisignals.ConnectionAdministrationSignal `json:"connectionAdmin"`
+}
+
+func (h Handler) connectionAdministrationView(r *nethttp.Request, assets []workspace.AssetView, edges []workspace.AssetEdgeView, status uisignals.ConnectionAdministrationStatusSignal) ui.ConnectionAdministrationView {
+	view := ui.ConnectionAdministrationView{
+		Bindings:        map[string]ui.ConnectionBindingView{},
+		RequiresBinding: map[string]bool{},
+		Status:          status,
+	}
+	for _, asset := range assets {
+		if asset.Type != string(workspace.AssetTypeConnection) {
+			continue
+		}
+		logical := ui.ConnectionLogicalName(asset, assets, edges)
+		kind := strings.TrimSpace(connectionAssetKind(asset))
+		spec, ok := connectors.LookupConnection(kind)
+		view.RequiresBinding[logical] = ok && spec.ActivationMode == connectors.TargetBindingActivation
+	}
+	if h.ConnectionAdministration == nil {
+		return view
+	}
+	principal, ok := h.ReadModel.currentPrincipal(r)
+	if !ok || strings.TrimSpace(principal.ID) == "" {
+		return view
+	}
+	if principal.DevBypass {
+		view.CanManage, view.CanTest = true, true
+	} else if h.ConnectionAuthorize != nil {
+		view.CanManage, _ = h.ConnectionAuthorize(r.Context(), principal.ID, access.PrivilegeManageConnectionMetadata, h.connectionWorkspaceID())
+		view.CanTest, _ = h.ConnectionAuthorize(r.Context(), principal.ID, access.PrivilegeTestConnection, h.connectionWorkspaceID())
+	}
+	// Listing binding metadata is itself a management operation. Keep test-only
+	// principals on the read-only surface until the API exposes a health list
+	// that does not disclose endpoint metadata.
+	if !view.CanManage {
+		view.CanTest = false
+		return view
+	}
+	bindings, err := h.ConnectionAdministration.List(r.Context(), principal.ID, h.connectionBindingScope(r), h.ConnectionTargetID)
+	if err != nil {
+		view.Status.Error = connectionAdministrationErrorMessage(err)
+		return view
+	}
+	for _, binding := range bindings {
+		view.Bindings[binding.LogicalConnectionID.String()] = connectionBindingView(binding)
+	}
+	return view
+}
+
+func connectionBindingView(binding connectionadmin.TargetBinding) ui.ConnectionBindingView {
+	lastValidatedAt := ""
+	if !binding.LastValidatedAt.IsZero() {
+		lastValidatedAt = binding.LastValidatedAt.UTC().Format("2006-01-02 15:04 UTC")
+	}
+	return ui.ConnectionBindingView{
+		ID: binding.ID, LogicalConnection: binding.LogicalConnectionID.String(), ConnectorKind: binding.ConnectorKind,
+		AuthenticationMode: string(binding.AuthenticationMode), Host: binding.Endpoint.Host, Port: binding.Endpoint.Port,
+		Database: binding.Endpoint.Database, ObjectScope: binding.Endpoint.ObjectScope, SourceIdentity: binding.Endpoint.SourceIdentity,
+		TLSMode: binding.Endpoint.TLSMode, Options: binding.Endpoint.Options,
+		CredentialProjectID: binding.CredentialReference.ProjectID, CredentialEnvironment: binding.CredentialReference.Environment,
+		SecretPath: binding.CredentialReference.SecretPath, SecretKey: binding.CredentialReference.SecretKey,
+		Enabled: binding.Enabled, Health: string(binding.Health), DiagnosticCode: binding.HealthReason,
+		ValidatedVersion: binding.ValidatedVersion, LastValidatedAt: lastValidatedAt, Revision: binding.Revision,
+	}
+}
+
+func connectionAssetKind(asset workspace.AssetView) string {
+	for _, key := range []string{"Kind", "kind", "Provider", "provider"} {
+		if value, ok := asset.Payload[key].(string); ok && strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (h Handler) ConnectionConfiguration(w nethttp.ResponseWriter, r *nethttp.Request) {
+	payload, ok := readConnectionAdministrationPayload(w, r)
+	if !ok {
+		return
+	}
+	command := payload.ConnectionAdmin.Command
+	assets, edges, asset, principalID, ok := h.connectionCommandContext(w, r, command)
+	if !ok {
+		return
+	}
+	configuration, err := connectionBindingConfiguration(command)
+	if err == nil {
+		kind := strings.TrimSpace(connectionAssetKind(asset))
+		spec, supported := connectors.LookupConnection(kind)
+		if !supported || spec.ActivationMode != connectors.TargetBindingActivation || configuration.ConnectorKind != kind {
+			err = connectionadmin.ErrInvalidBinding
+		}
+	}
+	if err != nil {
+		h.patchConnectionAdministration(w, r, command, assets, edges, asset, uisignals.ConnectionAdministrationStatusSignal{Error: connectionAdministrationErrorMessage(err)}, false)
+		return
+	}
+	status := uisignals.ConnectionAdministrationStatusSignal{}
+	switch command.Action {
+	case "create":
+		if err := uicommand.VerifyClaim(uicommand.OperationClaims(r), h.ConnectionCommands.Create.OperationID()); err != nil {
+			status.Error = "The configure command could not be verified."
+			break
+		}
+		_, err = h.ConnectionAdministration.Create(r.Context(), principalID, connectionadmin.TargetBindingInput{
+			ID: command.LogicalConnection, TargetID: h.ConnectionTargetID, LogicalConnectionID: command.LogicalConnection,
+			ConnectorKind: configuration.ConnectorKind, AuthenticationMode: configuration.AuthenticationMode,
+			Scope: h.connectionBindingScope(r), Endpoint: configuration.Endpoint,
+			CredentialReference: configuration.CredentialReference, Enabled: true,
+		})
+		if err == nil {
+			status.Message = "Connection configured. Test it before use."
+		}
+	case "update":
+		if err := uicommand.VerifyClaim(uicommand.OperationClaims(r), h.ConnectionCommands.Update.OperationID()); err != nil {
+			status.Error = "The update command could not be verified."
+			break
+		}
+		key := h.connectionBindingKey(r, command.LogicalConnection)
+		plan, planErr := h.ConnectionAdministration.PlanConfigurationChange(r.Context(), principalID, key, configuration)
+		if planErr != nil {
+			err = planErr
+			break
+		}
+		if plan.RequiresConfirmation && command.ConfirmationToken != plan.ConfirmationToken {
+			command.ConfirmationToken = plan.ConfirmationToken
+			command.ExpectedRevision = plan.ExpectedRevision
+			status.Error = fmt.Sprintf("This change affects %d dependent source(s). Review the configuration and confirm the update.", len(plan.Dependencies))
+			h.patchConnectionAdministration(w, r, command, assets, edges, asset, status, true)
+			return
+		}
+		_, err = h.ConnectionAdministration.UpdateConfiguration(r.Context(), connectionadmin.UpdateConfigurationRequest{
+			ActorID: principalID, Key: key, Configuration: configuration,
+			ExpectedRevision: command.ExpectedRevision, ConfirmationToken: command.ConfirmationToken,
+		})
+		if err == nil {
+			status.Message = "Connection updated. Test it before use."
+		}
+	default:
+		err = connectionadmin.ErrInvalidBinding
+	}
+	if err != nil {
+		status.Error = connectionAdministrationErrorMessage(err)
+	}
+	h.patchConnectionAdministration(w, r, command, assets, edges, asset, status, false)
+}
+
+func (h Handler) ConnectionLifecycle(w nethttp.ResponseWriter, r *nethttp.Request) {
+	payload, ok := readConnectionAdministrationPayload(w, r)
+	if !ok {
+		return
+	}
+	command := payload.ConnectionAdmin.Command
+	assets, edges, asset, principalID, ok := h.connectionCommandContext(w, r, command)
+	if !ok {
+		return
+	}
+	key := h.connectionBindingKey(r, command.LogicalConnection)
+	status := uisignals.ConnectionAdministrationStatusSignal{}
+	var err error
+	switch command.Action {
+	case "test":
+		err = verifyConnectionClaim(r, h.ConnectionCommands.Test)
+		if err == nil {
+			_, err = h.ConnectionAdministration.Test(r.Context(), principalID, key)
+		}
+		if err == nil {
+			status.Message = "Connection test succeeded."
+		}
+	case "refresh":
+		err = verifyConnectionClaim(r, h.ConnectionCommands.Refresh)
+		if err == nil {
+			_, err = h.ConnectionAdministration.RefreshNow(r.Context(), principalID, key)
+		}
+		if err == nil {
+			status.Message = "Credentials refreshed."
+		}
+	case "enable":
+		err = verifyConnectionClaim(r, h.ConnectionCommands.Enable)
+		if err == nil {
+			_, err = h.ConnectionAdministration.Enable(r.Context(), principalID, key)
+		}
+		if err == nil {
+			status.Message = "Connection enabled. Test it before use."
+		}
+	case "disable":
+		err = verifyConnectionClaim(r, h.ConnectionCommands.Disable)
+		if err == nil {
+			_, err = h.ConnectionAdministration.Disable(r.Context(), principalID, key)
+		}
+		if err == nil {
+			status.Message = "Connection disabled."
+		}
+	default:
+		err = connectionadmin.ErrInvalidBinding
+	}
+	if err != nil {
+		status.Error = connectionAdministrationErrorMessage(err)
+	}
+	h.patchConnectionAdministration(w, r, command, assets, edges, asset, status, false)
+}
+
+func verifyConnectionClaim(r *nethttp.Request, binding uicommand.Binding) error {
+	if err := uicommand.VerifyClaim(uicommand.OperationClaims(r), binding.OperationID()); err != nil {
+		return connectionadmin.ErrUnauthorizedBinding
+	}
+	return nil
+}
+
+func readConnectionAdministrationPayload(w nethttp.ResponseWriter, r *nethttp.Request) (connectionAdministrationPayload, bool) {
+	payload := connectionAdministrationPayload{}
+	if err := pagestream.ReadSignals(r, &payload); err != nil {
+		nethttp.Error(w, "Connection command is invalid.", nethttp.StatusBadRequest)
+		return payload, false
+	}
+	return payload, true
+}
+
+func (h Handler) connectionCommandContext(w nethttp.ResponseWriter, r *nethttp.Request, command uisignals.ConnectionAdministrationCommandSignal) ([]workspace.AssetView, []workspace.AssetEdgeView, workspace.AssetView, string, bool) {
+	if h.ConnectionAdministration == nil {
+		nethttp.Error(w, "Connection administration is unavailable.", nethttp.StatusServiceUnavailable)
+		return nil, nil, workspace.AssetView{}, "", false
+	}
+	assets, edges, err := h.platformAssetsAndEdges(r)
+	if err != nil {
+		nethttp.Error(w, "Connection catalog is unavailable.", nethttp.StatusInternalServerError)
+		return nil, nil, workspace.AssetView{}, "", false
+	}
+	asset, ok := workspace.AssetByID(assets, command.AssetID)
+	if !ok || asset.Type != string(workspace.AssetTypeConnection) || ui.ConnectionLogicalName(asset, assets, edges) != strings.TrimSpace(command.LogicalConnection) {
+		nethttp.Error(w, "Connection was not found.", nethttp.StatusNotFound)
+		return nil, nil, workspace.AssetView{}, "", false
+	}
+	principal, ok := h.ReadModel.currentPrincipal(r)
+	if !ok || strings.TrimSpace(principal.ID) == "" {
+		nethttp.Error(w, "Connection operation is forbidden.", nethttp.StatusForbidden)
+		return nil, nil, workspace.AssetView{}, "", false
+	}
+	return assets, edges, asset, principal.ID, true
+}
+
+func connectionBindingConfiguration(command uisignals.ConnectionAdministrationCommandSignal) (connectionadmin.TargetBindingConfiguration, error) {
+	port := 0
+	if strings.TrimSpace(command.Port) != "" {
+		parsed, err := strconv.Atoi(strings.TrimSpace(command.Port))
+		if err != nil || parsed <= 0 || parsed > 65535 {
+			return connectionadmin.TargetBindingConfiguration{}, fmt.Errorf("%w: port must be between 1 and 65535", connectionadmin.ErrInvalidBinding)
+		}
+		port = parsed
+	}
+	options := map[string]string{}
+	if strings.TrimSpace(command.Options) != "" {
+		if err := json.Unmarshal([]byte(command.Options), &options); err != nil {
+			return connectionadmin.TargetBindingConfiguration{}, fmt.Errorf("%w: options must be a JSON object of string values", connectionadmin.ErrInvalidBinding)
+		}
+	}
+	return connectionadmin.TargetBindingConfiguration{
+		ConnectorKind:      strings.TrimSpace(command.ConnectorKind),
+		AuthenticationMode: connectionadmin.AuthenticationMode(strings.TrimSpace(command.AuthenticationMode)),
+		Endpoint: connectionadmin.EndpointConfig{
+			Host: strings.TrimSpace(command.Host), Port: port, Database: strings.TrimSpace(command.Database),
+			ObjectScope: strings.TrimSpace(command.ObjectScope), SourceIdentity: strings.TrimSpace(command.SourceIdentity),
+			TLSMode: strings.TrimSpace(command.TLSMode), Options: options,
+		},
+		CredentialReference: connectionadmin.CredentialReference{
+			ProjectID: strings.TrimSpace(command.CredentialProjectID), Environment: strings.TrimSpace(command.CredentialEnvironment),
+			SecretPath: strings.TrimSpace(command.SecretPath), SecretKey: strings.TrimSpace(command.SecretKey),
+		},
+	}, nil
+}
+
+func (h Handler) patchConnectionAdministration(w nethttp.ResponseWriter, r *nethttp.Request, command uisignals.ConnectionAdministrationCommandSignal, assets []workspace.AssetView, edges []workspace.AssetEdgeView, asset workspace.AssetView, status uisignals.ConnectionAdministrationStatusSignal, preserveCommand bool) {
+	view := h.connectionAdministrationView(r, assets, edges, status)
+	adminSignal := uisignals.ConnectionAdministrationSignal{Status: status}
+	if preserveCommand {
+		adminSignal.Command = command
+	}
+	patch := pagestream.SignalPatch{"connectionAdmin": adminSignal}
+	if command.Surface == "list" {
+		patch["page"] = map[string]any{"connections": ui.ConnectionsListResultsPatchWithAdministration(assets, edges, view)["page"].(map[string]any)["connections"]}
+	} else {
+		lifecycle := ui.ConnectionLifecycleForAsset(asset, assets, edges, view)
+		patch["page"] = map[string]any{"connectionLifecycle": lifecycle}
+	}
+	_ = pagestream.PatchResponse(w, r, patch)
+}
+
+func (h Handler) connectionWorkspaceID() string {
+	if value := strings.TrimSpace(h.ConnectionWorkspaceID); value != "" {
+		return value
+	}
+	return "platform"
+}
+
+func (h Handler) connectionBindingScope(r *nethttp.Request) connectionadmin.BindingScope {
+	return connectionadmin.BindingScope{WorkspaceID: h.connectionWorkspaceID(), Environment: h.environment(r)}
+}
+
+func (h Handler) connectionBindingKey(r *nethttp.Request, logical string) connectionadmin.BindingKey {
+	parsed, _ := connectionadmin.ParseLogicalConnectionID(strings.TrimSpace(logical))
+	return connectionadmin.BindingKey{Scope: h.connectionBindingScope(r), TargetID: h.ConnectionTargetID, LogicalConnectionID: parsed}
+}
+
+func connectionAdministrationErrorMessage(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, connectionadmin.ErrUnauthorizedBinding):
+		return "You do not have permission to administer this connection."
+	case errors.Is(err, connectionadmin.ErrBindingNotFound):
+		return "The connection is not configured for this environment."
+	case errors.Is(err, connectionadmin.ErrDisabledBinding):
+		return "Enable the connection before running this operation."
+	case errors.Is(err, connectionadmin.ErrIncompatibleBinding):
+		return "The connection changed while you were editing it. Reopen the configuration and try again."
+	case errors.Is(err, connectionadmin.ErrCredentialDenied), errors.Is(err, connectionadmin.ErrCredentialNotFound), errors.Is(err, connectionadmin.ErrInvalidCredentialBundle):
+		return "Connection validation failed. Check the credential reference and try again."
+	case errors.Is(err, connectionadmin.ErrCredentialRateLimited), errors.Is(err, connectionadmin.ErrProviderUnavailable):
+		return "The credential provider is temporarily unavailable. Try again shortly."
+	case errors.Is(err, connectionadmin.ErrInvalidBinding):
+		return "The connection configuration is invalid. Check the required fields and try again."
+	default:
+		return "The connection operation could not be completed."
+	}
+}

--- a/internal/workspace/http/data_explorer_service.go
+++ b/internal/workspace/http/data_explorer_service.go
@@ -682,6 +682,28 @@ func dataExplorerObjects(workspaceID, workspaceTitle string, metrics Metrics, as
 	for _, asset := range assets {
 		modelID, name := keyParts(asset.Key)
 		switch asset.Type {
+		case string(workspace.AssetTypeSource):
+			sourceModelID, sourceName, source, ok := dataExplorerSourceForAsset(metrics, asset.Key)
+			if !ok {
+				warnings = append(warnings, fmt.Sprintf("Source %q is not available in the workspace runtime catalog.", asset.Title))
+				continue
+			}
+			columns := dataColumnsFromSource(source)
+			out = append(out, uisignals.DataExplorerObjectSignal{
+				Key:            dataObjectKey("source", asset.ID),
+				WorkspaceID:    workspaceID,
+				WorkspaceTitle: uisignals.Optional(workspaceTitle),
+				AssetID:        uisignals.Optional(asset.ID),
+				Layer:          "source",
+				ModelID:        uisignals.Optional(sourceModelID),
+				Table:          uisignals.Optional(sourceName),
+				Title:          asset.Title,
+				Description:    uisignals.Optional(asset.Description),
+				DetailHref:     uisignals.Optional(assetnav.CanonicalAssetSectionHref(workspaceID, asset, "details", edges)),
+				ColumnCount:    int64(len(columns)),
+				RowCountLabel:  uisignals.Pointer("Preview unavailable"),
+				Columns:        uisignals.OptionalSlice(columns),
+			})
 		case string(workspace.AssetTypeModelTable):
 			model, _ := metrics.DataExplorerModel(modelID)
 			table := DataExplorerTable{}

--- a/internal/workspace/http/handler.go
+++ b/internal/workspace/http/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Yacobolo/toolbelt/pagestream"
 	"github.com/flidai/leapview/internal/access"
 	accessapi "github.com/flidai/leapview/internal/access/api"
+	"github.com/flidai/leapview/internal/analytics/connectionadmin"
 	httptransport "github.com/flidai/leapview/internal/platform/http/transport"
 	webpage "github.com/flidai/leapview/internal/platform/web/page"
 	"github.com/flidai/leapview/internal/platform/web/uicommand"
@@ -30,20 +31,25 @@ import (
 )
 
 type Handler struct {
-	WorkspaceID         func(string) string
-	Environment         func(*nethttp.Request) string
-	ReadModel           ReadModel
-	RefreshState        RefreshStateProvider
-	RefreshRunner       AssetRefreshRunner
-	Broker              *pagestream.Broker
-	CSRFToken           func(*nethttp.Request) string
-	CurrentRoleLabel    func(*nethttp.Request) string
-	RoleBindingCommands access.RoleBindingCommander
-	GrantCommands       access.GrantOperations
-	AccessCommands      ui.AccessCommandBindings
-	AgentBootstrap      func(*nethttp.Request, string) ui.DataExplorerAgentBootstrap
-	AgentCommands       ui.DataExplorerAgentCommandBindings
-	Layout              func(*nethttp.Request) webpage.Provider
+	WorkspaceID              func(string) string
+	Environment              func(*nethttp.Request) string
+	ReadModel                ReadModel
+	RefreshState             RefreshStateProvider
+	RefreshRunner            AssetRefreshRunner
+	Broker                   *pagestream.Broker
+	CSRFToken                func(*nethttp.Request) string
+	CurrentRoleLabel         func(*nethttp.Request) string
+	RoleBindingCommands      access.RoleBindingCommander
+	GrantCommands            access.GrantOperations
+	AccessCommands           ui.AccessCommandBindings
+	ConnectionAdministration connectionadmin.Administration
+	ConnectionAuthorize      ConnectionPrivilegeAuthorizer
+	ConnectionCommands       ui.ConnectionCommandBindings
+	ConnectionTargetID       string
+	ConnectionWorkspaceID    string
+	AgentBootstrap           func(*nethttp.Request, string) ui.DataExplorerAgentBootstrap
+	AgentCommands            ui.DataExplorerAgentCommandBindings
+	Layout                   func(*nethttp.Request) webpage.Provider
 }
 
 type workspaceAccessSignalPayload struct {
@@ -159,15 +165,13 @@ func (h Handler) ConnectionsSearch(w nethttp.ResponseWriter, r *nethttp.Request)
 		nethttp.Error(w, err.Error(), statusForNotFound(err))
 		return
 	}
-	activeType, query := "", ""
-	if signals.Filter != nil {
-		activeType = workspace.NormalizeConnectionAssetType(*signals.Filter)
-	}
+	query := ""
 	if signals.Query != nil {
 		query = strings.TrimSpace(*signals.Query)
 	}
-	filtered := workspace.FilterConnectionAssets(assets, activeType, query)
-	_ = pagestream.PatchResponse(w, r, ui.ConnectionsListResultsPatch("platform", filtered, edges))
+	filtered := workspace.FilterConnections(assets, query)
+	administration := h.connectionAdministrationView(r, assets, edges, uisignals.ConnectionAdministrationStatusSignal{})
+	_ = pagestream.PatchResponse(w, r, ui.ConnectionsListResultsPatchWithAdministration(filtered, edges, administration))
 }
 
 func (h Handler) WorkspaceAssets(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -177,7 +181,7 @@ func (h Handler) WorkspaceAssets(w nethttp.ResponseWriter, r *nethttp.Request) {
 		nethttp.Redirect(w, r, assetnav.ConnectionsHref(r.URL.Query().Get("q")), nethttp.StatusFound)
 		return
 	case "source":
-		nethttp.Redirect(w, r, assetnav.ConnectionsHrefWithType("source", r.URL.Query().Get("q")), nethttp.StatusFound)
+		nethttp.Redirect(w, r, assetnav.ConnectionsHref(""), nethttp.StatusFound)
 		return
 	}
 	assets, _, err := h.assetsAndEdges(r, workspaceID)
@@ -293,11 +297,11 @@ func (h Handler) Connections(w nethttp.ResponseWriter, r *nethttp.Request) {
 		nethttp.Error(w, err.Error(), statusForNotFound(err))
 		return
 	}
-	activeType := workspace.NormalizeConnectionAssetType(r.URL.Query().Get("type"))
-	filtered := workspace.FilterConnectionAssets(assets, activeType, r.URL.Query().Get("q"))
+	filtered := workspace.FilterConnections(assets, r.URL.Query().Get("q"))
+	administration := h.connectionAdministrationView(r, assets, edges, uisignals.ConnectionAdministrationStatusSignal{})
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(nethttp.StatusOK)
-	if err := ui.ConnectionsPageForEnvironment(h.catalogForWorkspacesPage(r, nil), "platform", filtered, edges, activeType, r.URL.Query().Get("q"), h.environment(r), h.currentRoleLabel(r), h.csrfToken(r), h.chromeOptions(r)...).Render(w); err != nil {
+	if err := ui.ConnectionsPageWithAdministrationForEnvironment(h.catalogForWorkspacesPage(r, nil), "platform", filtered, edges, r.URL.Query().Get("q"), h.environment(r), h.currentRoleLabel(r), h.csrfToken(r), administration, h.ConnectionCommands, h.chromeOptions(r)...).Render(w); err != nil {
 		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
 	}
 }
@@ -356,7 +360,6 @@ func (h Handler) ConnectionsBootstrapUpdates(w nethttp.ResponseWriter, r *nethtt
 		nethttp.Error(w, err.Error(), statusForNotFound(err))
 		return
 	}
-	activeType := workspace.NormalizeConnectionAssetType(r.URL.Query().Get("type"))
 	query := r.URL.Query().Get("q")
 	var listSignals struct {
 		Query  *string `json:"entityListQuery"`
@@ -369,11 +372,9 @@ func (h Handler) ConnectionsBootstrapUpdates(w nethttp.ResponseWriter, r *nethtt
 	if listSignals.Query != nil {
 		query = strings.TrimSpace(*listSignals.Query)
 	}
-	if listSignals.Filter != nil {
-		activeType = workspace.NormalizeConnectionAssetType(*listSignals.Filter)
-	}
-	filtered := workspace.FilterConnectionAssets(assets, activeType, query)
-	h.patchAndWait(w, r, ui.ConnectionsBootstrapSignalsForEnvironment(h.catalogForWorkspacesPage(r, nil), "platform", filtered, edges, activeType, query, h.environment(r), h.currentRoleLabel(r), h.chromeOptions(r)...))
+	filtered := workspace.FilterConnections(assets, query)
+	administration := h.connectionAdministrationView(r, assets, edges, uisignals.ConnectionAdministrationStatusSignal{})
+	h.patchAndWait(w, r, ui.ConnectionsBootstrapSignalsWithAdministrationForEnvironment(h.catalogForWorkspacesPage(r, nil), "platform", filtered, edges, query, h.environment(r), h.currentRoleLabel(r), administration, h.chromeOptions(r)...))
 }
 
 func (h Handler) ConnectionSource(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -429,7 +430,8 @@ func (h Handler) ConnectionSourceSection(w nethttp.ResponseWriter, r *nethttp.Re
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(nethttp.StatusOK)
-	if err := ui.ConnectionSourceAssetPageWithVersionsForEnvironment(h.catalogForWorkspacesPage(r, nil), platformAssetWorkspaceView(), connection, source, assets, edges, section, h.environment(r), h.currentRoleLabel(r), versions).Render(w); err != nil {
+	administration := h.connectionAdministrationView(r, assets, edges, uisignals.ConnectionAdministrationStatusSignal{})
+	if err := ui.ConnectionSourceAssetPageWithAdministrationForEnvironment(h.catalogForWorkspacesPage(r, nil), platformAssetWorkspaceView(), connection, source, assets, edges, section, h.environment(r), h.currentRoleLabel(r), versions, administration, h.ConnectionCommands, h.csrfToken(r), h.chromeOptions(r)).Render(w); err != nil {
 		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
 	}
 }
@@ -469,7 +471,8 @@ func (h Handler) ConnectionAssetSection(w nethttp.ResponseWriter, r *nethttp.Req
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(nethttp.StatusOK)
-	if err := ui.ConnectionAssetPageWithVersionsForEnvironment(h.catalogForWorkspacesPage(r, nil), platformAssetWorkspaceView(), selected, assets, edges, section, h.environment(r), h.currentRoleLabel(r), versions).Render(w); err != nil {
+	administration := h.connectionAdministrationView(r, assets, edges, uisignals.ConnectionAdministrationStatusSignal{})
+	if err := ui.ConnectionAssetPageWithAdministrationForEnvironment(h.catalogForWorkspacesPage(r, nil), platformAssetWorkspaceView(), selected, assets, edges, section, h.environment(r), h.currentRoleLabel(r), versions, administration, h.ConnectionCommands, h.csrfToken(r), h.chromeOptions(r)).Render(w); err != nil {
 		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
 	}
 }
@@ -1131,11 +1134,13 @@ func (h Handler) AssetUpdatesStream(w nethttp.ResponseWriter, r *nethttp.Request
 		if selected.Type == string(workspace.AssetTypeSource) {
 			connectionID := assetnav.SourceConnectionID(selected.ID, edges)
 			if connection, ok := workspace.AssetByID(assets, connectionID); ok {
-				patch = ui.ConnectionSourceAssetBootstrapSignalsForEnvironment(h.catalogForWorkspacesPage(r, nil), platformAssetWorkspaceView(), connection, selected, assets, edges, section, h.environment(r), h.currentRoleLabel(r), versions)
+				administration := h.connectionAdministrationView(r, assets, edges, uisignals.ConnectionAdministrationStatusSignal{})
+				patch = ui.ConnectionSourceAssetBootstrapSignalsWithAdministrationForEnvironment(h.catalogForWorkspacesPage(r, nil), platformAssetWorkspaceView(), connection, selected, assets, edges, section, h.environment(r), h.currentRoleLabel(r), versions, administration, h.chromeOptions(r)...)
 			}
 		}
 		if patch == nil {
-			patch = ui.ConnectionAssetBootstrapSignalsForEnvironment(h.catalogForWorkspacesPage(r, nil), platformAssetWorkspaceView(), selected, assets, edges, section, h.environment(r), h.currentRoleLabel(r), versions)
+			administration := h.connectionAdministrationView(r, assets, edges, uisignals.ConnectionAdministrationStatusSignal{})
+			patch = ui.ConnectionAssetBootstrapSignalsWithAdministrationForEnvironment(h.catalogForWorkspacesPage(r, nil), platformAssetWorkspaceView(), selected, assets, edges, section, h.environment(r), h.currentRoleLabel(r), versions, administration, h.chromeOptions(r)...)
 		}
 	} else {
 		patch = ui.WorkspaceAssetBootstrapSignalsForEnvironment(h.catalogForWorkspace(workspaceID), h.workspaceResponse(r, workspaceID), selected, assets, edges, section, h.environment(r), h.currentRoleLabel(r), refresh, versions, h.chromeOptions(r)...)

--- a/internal/workspace/module/module.go
+++ b/internal/workspace/module/module.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Yacobolo/toolbelt/pagestream"
 	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/connectionadmin"
 	dashboardappearance "github.com/flidai/leapview/internal/dashboard/appearance"
 	dashboardcatalog "github.com/flidai/leapview/internal/dashboard/catalog"
 	"github.com/flidai/leapview/internal/dashboard/queryruntime"
@@ -74,6 +75,7 @@ func (f AssetRefreshFunc) RefreshAsset(ctx context.Context, input AssetRefreshIn
 }
 
 type AccessCommandBindings = ui.AccessCommandBindings
+type ConnectionCommandBindings = ui.ConnectionCommandBindings
 type DataExplorerAgentBootstrap = ui.DataExplorerAgentBootstrap
 type DataExplorerAgentCommandBindings = ui.DataExplorerAgentCommandBindings
 type PopularityLevel = uisignals.PopularityLevel
@@ -81,37 +83,42 @@ type DashboardPopularityProvider func(context.Context, int) (map[string]Populari
 type DashboardLastRefreshedProvider func(context.Context, string, string, string) (string, bool, error)
 
 type Config struct {
-	Database             *sql.DB
-	Directory            Directory
-	ReadModel            ReadModel
-	Securables           SecurableRegistrar
-	WorkspaceID          func(string) string
-	Environment          func(*http.Request) string
-	AccessService        access.WorkspaceAccessService
-	RoleBindingCommands  access.RoleBindingOperations
-	GrantCommands        access.GrantOperations
-	CommandPrivileges    access.WorkspaceCommandPrivileges
-	AccessCommands       ui.AccessCommandBindings
-	AgentBootstrap       func(*http.Request, string) ui.DataExplorerAgentBootstrap
-	AgentCommands        ui.DataExplorerAgentCommandBindings
-	AssetCatalog         workspace.AssetCatalogReader
-	MetricsForWorkspace  func(string) (queryruntime.Metrics, bool)
-	RootMetrics          queryruntime.Metrics
-	CurrentPrincipal     func(*http.Request) (Principal, bool)
-	RecordAudit          func(context.Context, access.AuditEventInput) error
-	Logger               *slog.Logger
-	AuthConfigured       bool
-	RuntimeEnvironment   string
-	RefreshState         RefreshStateProvider
-	RefreshRunner        AssetRefreshRunner
-	Broker               *pagestream.Broker
-	CSRFToken            func(*http.Request) string
-	CurrentRoleLabel     func(*http.Request) string
-	Layout               func(*http.Request) webpage.Provider
-	CurrentCredential    func(*http.Request) (access.APICredential, bool)
-	AuthorizeObject      func(context.Context, string, access.Privilege, access.ObjectRef) (bool, error)
-	DashboardPopularity  DashboardPopularityProvider
-	DashboardRefreshedAt DashboardLastRefreshedProvider
+	Database                 *sql.DB
+	Directory                Directory
+	ReadModel                ReadModel
+	Securables               SecurableRegistrar
+	WorkspaceID              func(string) string
+	Environment              func(*http.Request) string
+	AccessService            access.WorkspaceAccessService
+	RoleBindingCommands      access.RoleBindingOperations
+	GrantCommands            access.GrantOperations
+	CommandPrivileges        access.WorkspaceCommandPrivileges
+	AccessCommands           ui.AccessCommandBindings
+	ConnectionAdministration connectionadmin.Administration
+	ConnectionAuthorize      func(context.Context, string, access.Privilege, string) (bool, error)
+	ConnectionCommands       ui.ConnectionCommandBindings
+	ConnectionTargetID       string
+	ConnectionWorkspaceID    string
+	AgentBootstrap           func(*http.Request, string) ui.DataExplorerAgentBootstrap
+	AgentCommands            ui.DataExplorerAgentCommandBindings
+	AssetCatalog             workspace.AssetCatalogReader
+	MetricsForWorkspace      func(string) (queryruntime.Metrics, bool)
+	RootMetrics              queryruntime.Metrics
+	CurrentPrincipal         func(*http.Request) (Principal, bool)
+	RecordAudit              func(context.Context, access.AuditEventInput) error
+	AuthConfigured           bool
+	RuntimeEnvironment       string
+	RefreshState             RefreshStateProvider
+	RefreshRunner            AssetRefreshRunner
+	Broker                   *pagestream.Broker
+	CSRFToken                func(*http.Request) string
+	CurrentRoleLabel         func(*http.Request) string
+	Layout                   func(*http.Request) webpage.Provider
+	CurrentCredential        func(*http.Request) (access.APICredential, bool)
+	AuthorizeObject          func(context.Context, string, access.Privilege, access.ObjectRef) (bool, error)
+	DashboardPopularity      DashboardPopularityProvider
+	DashboardRefreshedAt     DashboardLastRefreshedProvider
+	Logger                   *slog.Logger
 }
 
 func Build(_ context.Context, config Config) (*Module, error) {
@@ -216,11 +223,16 @@ func Build(_ context.Context, config Config) (*Module, error) {
 		RefreshState:  moduleRefreshState{module: m, upstream: config.RefreshState},
 		RefreshRunner: refreshRunner, Broker: config.Broker,
 		CSRFToken: config.CSRFToken, CurrentRoleLabel: config.CurrentRoleLabel, Layout: config.Layout,
-		RoleBindingCommands: config.RoleBindingCommands,
-		GrantCommands:       config.GrantCommands,
-		AccessCommands:      config.AccessCommands,
-		AgentBootstrap:      config.AgentBootstrap,
-		AgentCommands:       config.AgentCommands,
+		RoleBindingCommands:      config.RoleBindingCommands,
+		GrantCommands:            config.GrantCommands,
+		AccessCommands:           config.AccessCommands,
+		ConnectionAdministration: config.ConnectionAdministration,
+		ConnectionAuthorize:      config.ConnectionAuthorize,
+		ConnectionCommands:       config.ConnectionCommands,
+		ConnectionTargetID:       config.ConnectionTargetID,
+		ConnectionWorkspaceID:    config.ConnectionWorkspaceID,
+		AgentBootstrap:           config.AgentBootstrap,
+		AgentCommands:            config.AgentCommands,
 	}
 	m.search = buildSearch(config.Database, config.AuthorizeObject)
 	return m, nil

--- a/internal/workspace/module/routes.go
+++ b/internal/workspace/module/routes.go
@@ -53,6 +53,10 @@ func (m *Module) MountAuthenticated(r chi.Router, guard RouteGuard) {
 	}
 	r.Get("/connections", protectAnyWorkspace(access.PrivilegeViewItem, h.Connections))
 	r.Post("/connections/search", protectAnyWorkspace(access.PrivilegeViewItem, h.ConnectionsSearch))
+	if h.ConnectionAdministration != nil {
+		r.Post("/connections/administration/configuration", protectAnyWorkspace(access.PrivilegeViewItem, h.ConnectionConfiguration))
+		r.Post("/connections/administration/lifecycle", protectAnyWorkspace(access.PrivilegeViewItem, h.ConnectionLifecycle))
+	}
 	r.Get("/connections/{connection}/sources/{source}", protectAnyWorkspace(access.PrivilegeViewItem, h.ConnectionSource))
 	r.Get("/connections/{connection}/sources/{source}/{section}", protectAnyWorkspace(access.PrivilegeViewItem, h.ConnectionSourceSection))
 	r.Get("/connections/{asset}", protectAnyWorkspace(access.PrivilegeViewItem, h.ConnectionAsset))

--- a/internal/workspace/ui/connection_admin.go
+++ b/internal/workspace/ui/connection_admin.go
@@ -1,0 +1,213 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/flidai/leapview/internal/platform/web/uicommand"
+	workspaceview "github.com/flidai/leapview/internal/workspace"
+	uisignals "github.com/flidai/leapview/internal/workspace/ui/signals"
+)
+
+type ConnectionCommandBindings struct {
+	Create  uicommand.Binding
+	Update  uicommand.Binding
+	Test    uicommand.Binding
+	Refresh uicommand.Binding
+	Enable  uicommand.Binding
+	Disable uicommand.Binding
+}
+
+type ConnectionBindingView struct {
+	ID                    string
+	LogicalConnection     string
+	ConnectorKind         string
+	AuthenticationMode    string
+	Host                  string
+	Port                  int
+	Database              string
+	ObjectScope           string
+	SourceIdentity        string
+	TLSMode               string
+	Options               map[string]string
+	CredentialProjectID   string
+	CredentialEnvironment string
+	SecretPath            string
+	SecretKey             string
+	Enabled               bool
+	Health                string
+	DiagnosticCode        string
+	ValidatedVersion      string
+	LastValidatedAt       string
+	Revision              int64
+}
+
+type ConnectionAdministrationView struct {
+	Bindings        map[string]ConnectionBindingView
+	CanManage       bool
+	CanTest         bool
+	RequiresBinding map[string]bool
+	Status          uisignals.ConnectionAdministrationStatusSignal
+}
+
+func emptyConnectionAdministrationSignal(status uisignals.ConnectionAdministrationStatusSignal) uisignals.ConnectionAdministrationSignal {
+	return uisignals.ConnectionAdministrationSignal{
+		Command: uisignals.ConnectionAdministrationCommandSignal{},
+		Status:  status,
+	}
+}
+
+func connectionLifecycleSignal(asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, administration ConnectionAdministrationView) uisignals.ConnectionLifecycleSignal {
+	logical := ConnectionLogicalName(asset, assets, edges)
+	kind := firstNonEmpty(metaString(asset.Payload, "Kind", "kind"), metaString(asset.Payload, "Provider", "provider"))
+	requiresBinding, classified := administration.RequiresBinding[logical]
+	binding, exists := administration.Bindings[logical]
+	lifecycle := uisignals.ConnectionLifecycleSignal{
+		Actions:           []uisignals.ConnectionLifecycleActionSignal{},
+		AssetID:           asset.ID,
+		CanManage:         administration.CanManage,
+		CanTest:           administration.CanTest,
+		ConnectorKind:     kind,
+		LogicalConnection: logical,
+		State:             "not_required",
+		StatusLabel:       "Not required",
+		Tone:              "neutral",
+	}
+	if !classified {
+		lifecycle.State = "missing"
+		lifecycle.StatusLabel = "Not configured"
+		lifecycle.Tone = "warning"
+		if metaBool(asset.Payload, "credentials_configured") {
+			lifecycle.State = "healthy"
+			lifecycle.StatusLabel = "Configured"
+			lifecycle.Tone = "success"
+		}
+		return lifecycle
+	}
+	if !requiresBinding {
+		return lifecycle
+	}
+	if !exists {
+		lifecycle.State = "missing"
+		lifecycle.StatusLabel = "Not configured"
+		lifecycle.Tone = "warning"
+		if administration.CanManage {
+			lifecycle.Actions = append(lifecycle.Actions, lifecycleAction("configure", "Configure", true, false))
+		}
+		return lifecycle
+	}
+	lifecycle.Exists = true
+	lifecycle.BindingID = binding.ID
+	lifecycle.ConnectorKind = firstNonEmpty(binding.ConnectorKind, kind)
+	lifecycle.AuthenticationMode = binding.AuthenticationMode
+	lifecycle.Host = binding.Host
+	if binding.Port > 0 {
+		lifecycle.Port = strconv.Itoa(binding.Port)
+	}
+	lifecycle.Database = binding.Database
+	lifecycle.ObjectScope = binding.ObjectScope
+	lifecycle.SourceIdentity = binding.SourceIdentity
+	lifecycle.TLSMode = binding.TLSMode
+	lifecycle.Options = encodeConnectionOptions(binding.Options)
+	lifecycle.CredentialProjectID = binding.CredentialProjectID
+	lifecycle.CredentialEnvironment = binding.CredentialEnvironment
+	lifecycle.SecretPath = binding.SecretPath
+	lifecycle.SecretKey = binding.SecretKey
+	lifecycle.Enabled = binding.Enabled
+	lifecycle.Health = binding.Health
+	lifecycle.DiagnosticCode = binding.DiagnosticCode
+	lifecycle.ValidatedVersion = binding.ValidatedVersion
+	lifecycle.LastValidatedAt = binding.LastValidatedAt
+	lifecycle.Revision = binding.Revision
+	if !binding.Enabled || binding.Health == "disabled" {
+		lifecycle.State = "disabled"
+		lifecycle.StatusLabel = "Disabled"
+		lifecycle.Tone = "neutral"
+		if administration.CanManage {
+			lifecycle.Actions = append(lifecycle.Actions, lifecycleAction("enable", "Enable", true, false))
+		}
+		return lifecycle
+	}
+	switch binding.Health {
+	case "healthy":
+		lifecycle.State = "healthy"
+		lifecycle.StatusLabel = "Healthy"
+		lifecycle.Tone = "success"
+		if administration.CanTest {
+			lifecycle.Actions = append(lifecycle.Actions, lifecycleAction("refresh", "Refresh credentials", true, false))
+		}
+		appendEnabledSecondaryActions(&lifecycle, administration, true)
+	case "degraded":
+		lifecycle.State = "degraded"
+		lifecycle.StatusLabel = "Degraded"
+		lifecycle.Tone = "danger"
+		if administration.CanTest {
+			lifecycle.Actions = append(lifecycle.Actions, lifecycleAction("refresh", "Refresh credentials", true, false))
+		}
+		appendEnabledSecondaryActions(&lifecycle, administration, true)
+	default:
+		lifecycle.State = "pending"
+		lifecycle.StatusLabel = "Pending test"
+		lifecycle.Tone = "warning"
+		if administration.CanTest {
+			lifecycle.Actions = append(lifecycle.Actions, lifecycleAction("test", "Test connection", true, false))
+		}
+		appendEnabledSecondaryActions(&lifecycle, administration, false)
+	}
+	return lifecycle
+}
+
+func ConnectionLifecycleForAsset(asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, administration ConnectionAdministrationView) uisignals.ConnectionLifecycleSignal {
+	return connectionLifecycleSignal(asset, assets, edges, administration)
+}
+
+func appendEnabledSecondaryActions(lifecycle *uisignals.ConnectionLifecycleSignal, administration ConnectionAdministrationView, includeTest bool) {
+	if includeTest && administration.CanTest {
+		lifecycle.Actions = append(lifecycle.Actions, lifecycleAction("test", "Test connection", false, false))
+	}
+	if administration.CanManage {
+		lifecycle.Actions = append(lifecycle.Actions,
+			lifecycleAction("edit", "Edit", false, false),
+			lifecycleAction("disable", "Disable", false, true),
+		)
+	}
+}
+
+func lifecycleAction(id, label string, primary, destructive bool) uisignals.ConnectionLifecycleActionSignal {
+	return uisignals.ConnectionLifecycleActionSignal{ID: id, Label: label, Primary: primary, Destructive: destructive}
+}
+
+func ConnectionLogicalName(connection workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView) string {
+	for _, source := range sourcesUsingConnection(connection.ID, assets, edges) {
+		if value := strings.TrimSpace(metaString(source.Payload, "Connection", "connection")); value != "" {
+			return value
+		}
+	}
+	if value := strings.TrimPrefix(strings.TrimSpace(connection.ID), "connection:"); value != "" {
+		return value
+	}
+	return strings.TrimSpace(connection.Key)
+}
+
+func encodeConnectionOptions(options map[string]string) string {
+	if len(options) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(options))
+	for key := range options {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	ordered := make(map[string]string, len(options))
+	for _, key := range keys {
+		ordered[key] = options[key]
+	}
+	encoded, err := json.Marshal(ordered)
+	if err != nil {
+		return fmt.Sprint(options)
+	}
+	return string(encoded)
+}

--- a/internal/workspace/ui/workspace.go
+++ b/internal/workspace/ui/workspace.go
@@ -104,41 +104,56 @@ func WorkspaceAssetListResultsPatch(workspaceID string, assets []workspaceview.A
 	}}
 }
 
-func ConnectionsPage(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeType, query, roleLabel string, chromeOptions ...webpage.Provider) g.Node {
-	return ConnectionsPageForEnvironment(catalog, workspaceID, assets, edges, activeType, query, "", roleLabel, "", chromeOptions...)
+func ConnectionsPage(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, query, roleLabel string, chromeOptions ...webpage.Provider) g.Node {
+	return ConnectionsPageForEnvironment(catalog, workspaceID, assets, edges, query, "", roleLabel, "", chromeOptions...)
 }
 
-func ConnectionsPageForEnvironment(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeType, query, environment, roleLabel, csrfToken string, chromeOptions ...webpage.Provider) g.Node {
-	page := connectionsPageSignal(workspaceID, assets, edges, activeType, query, environment)
+func ConnectionsPageForEnvironment(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, query, environment, roleLabel, csrfToken string, chromeOptions ...webpage.Provider) g.Node {
+	return ConnectionsPageWithAdministrationForEnvironment(catalog, workspaceID, assets, edges, query, environment, roleLabel, csrfToken, ConnectionAdministrationView{}, ConnectionCommandBindings{}, chromeOptions...)
+}
+
+func ConnectionsPageWithAdministrationForEnvironment(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, query, environment, roleLabel, csrfToken string, administration ConnectionAdministrationView, commands ConnectionCommandBindings, chromeOptions ...webpage.Provider) g.Node {
+	page := connectionsPageSignal(workspaceID, assets, edges, query, environment, administration)
 	if strings.TrimSpace(workspaceID) == "" {
 		catalog = catalogWithoutWorkspaceContext(catalog)
 	}
+	rootAttributes := []g.Node{
+		g.Attr("slot", "page"),
+		g.Attr("data-on:lv-entity-list-query__debounce.200ms", "$entityListQuery = evt.detail.query; "+uiactions.QueryPost("/connections/search", "entityListQuery")),
+	}
+	rootAttributes = append(rootAttributes, connectionAdministrationRouteBridge(commands)...)
 	return workspaceRouteDocument("Connections", catalog, "connections", roleLabel, page, uisignals.RouteConnections,
-		g.El("lv-connections-page",
-			g.Attr("slot", "page"),
-			g.Attr("data-on:lv-entity-list-query__debounce.200ms", "$entityListQuery = evt.detail.query; $entityListFilter = evt.detail.filter; "+uiactions.QueryPost("/connections/search", "entityListQuery", "entityListFilter")),
-		),
-		workspaceDocumentExtras{CSRFToken: csrfToken},
+		g.El("lv-connections-page", rootAttributes...),
+		workspaceDocumentExtras{CSRFToken: csrfToken, BootstrapSignals: map[string]any{"connectionAdmin": emptyConnectionAdministrationSignal(administration.Status)}},
 		chromeOptions,
 	)
 }
 
-func ConnectionsBootstrapSignals(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeType, query, roleLabel string, chromeOptions ...webpage.Provider) map[string]any {
-	return ConnectionsBootstrapSignalsForEnvironment(catalog, workspaceID, assets, edges, activeType, query, "", roleLabel, chromeOptions...)
+func ConnectionsBootstrapSignals(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, query, roleLabel string, chromeOptions ...webpage.Provider) map[string]any {
+	return ConnectionsBootstrapSignalsForEnvironment(catalog, workspaceID, assets, edges, query, "", roleLabel, chromeOptions...)
 }
 
-func ConnectionsBootstrapSignalsForEnvironment(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeType, query, environment, roleLabel string, chromeOptions ...webpage.Provider) map[string]any {
-	page := connectionsPageSignal(workspaceID, assets, edges, activeType, query, environment)
+func ConnectionsBootstrapSignalsForEnvironment(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, query, environment, roleLabel string, chromeOptions ...webpage.Provider) map[string]any {
+	return ConnectionsBootstrapSignalsWithAdministrationForEnvironment(catalog, workspaceID, assets, edges, query, environment, roleLabel, ConnectionAdministrationView{}, chromeOptions...)
+}
+
+func ConnectionsBootstrapSignalsWithAdministrationForEnvironment(catalog catalog.Catalog, workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, query, environment, roleLabel string, administration ConnectionAdministrationView, chromeOptions ...webpage.Provider) map[string]any {
+	page := connectionsPageSignal(workspaceID, assets, edges, query, environment, administration)
 	if strings.TrimSpace(workspaceID) == "" {
 		catalog = catalogWithoutWorkspaceContext(catalog)
 	}
-	return workspaceRouteBootstrapSignals(catalog, "connections", roleLabel, page, uisignals.RouteConnections, nil, chromeOptions)
+	patch := workspaceRouteBootstrapSignals(catalog, "connections", roleLabel, page, uisignals.RouteConnections, nil, chromeOptions)
+	patch["connectionAdmin"] = emptyConnectionAdministrationSignal(administration.Status)
+	return patch
 }
 
-func ConnectionsListResultsPatch(workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView) map[string]any {
-	list := workspaceAssetListSignal(workspaceID, assets, edges, "", "", nil, "", "")
+func ConnectionsListResultsPatch(assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView) map[string]any {
+	return ConnectionsListResultsPatchWithAdministration(assets, edges, ConnectionAdministrationView{})
+}
+
+func ConnectionsListResultsPatchWithAdministration(assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, administration ConnectionAdministrationView) map[string]any {
 	return map[string]any{"page": map[string]any{
-		"assetList": map[string]any{"assets": list.Assets},
+		"connections": connectionSummarySignals(assets, edges, administration),
 	}}
 }
 
@@ -204,6 +219,30 @@ func workspaceAccessRouteBridge(workspaceID string, access WorkspaceAccessRespon
 		}
 }
 
+func connectionAdministrationRouteBridge(commands ConnectionCommandBindings) []g.Node {
+	if commands.Create.OperationID() == "" || commands.Update.OperationID() == "" ||
+		commands.Test.OperationID() == "" || commands.Refresh.OperationID() == "" ||
+		commands.Enable.OperationID() == "" || commands.Disable.OperationID() == "" {
+		return nil
+	}
+	configuration := "$connectionAdmin.command = evt.detail; $connectionAdmin.status = {loading: true, error: '', message: ''}; " +
+		uiactions.CommandPostSwitch("$connectionAdmin.command.action", map[string]uicommand.Binding{
+			"create": commands.Create,
+			"update": commands.Update,
+		}, "/connections/administration/configuration", "connectionAdmin")
+	lifecycle := "$connectionAdmin.command = evt.detail; $connectionAdmin.status = {loading: true, error: '', message: ''}; " +
+		uiactions.CommandPostSwitch("$connectionAdmin.command.action", map[string]uicommand.Binding{
+			"test":    commands.Test,
+			"refresh": commands.Refresh,
+			"enable":  commands.Enable,
+			"disable": commands.Disable,
+		}, "/connections/administration/lifecycle", "connectionAdmin")
+	return []g.Node{
+		g.Attr("data-on:lv-connection-administration-save", configuration),
+		g.Attr("data-on:lv-connection-administration-action", lifecycle),
+	}
+}
+
 func workspaceAssetFilterRouteBridge(workspaceID, environment string) []g.Node {
 	filter := "$workspaceAssetType = evt.detail.type; $workspaceAssetQuery = evt.detail.query; " + uiactions.QueryPost("/workspaces/"+workspaceID+"/search", "workspaceAssetType", "workspaceAssetQuery")
 	return []g.Node{g.Attr("data-on:lv-workspace-asset-filter__debounce.200ms", filter)}
@@ -247,24 +286,58 @@ func workspacePageSignal(workspace workspaceview.WorkspaceView, assets []workspa
 	}
 }
 
-func connectionsPageSignal(workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeType, query, environment string) uisignals.ConnectionsPageSignal {
+func connectionsPageSignal(workspaceID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, query, environment string, administration ConnectionAdministrationView) uisignals.ConnectionsPageSignal {
 	return uisignals.ConnectionsPageSignal{
 		Kind:        uisignals.RouteConnections,
 		Title:       "Connections",
-		Description: uisignals.Pointer("Connection-scoped data assets used by published semantic models."),
+		Description: uisignals.Pointer("Data connections used by published semantic models."),
 		WorkspaceID: uisignals.Optional(workspaceID),
 		Environment: uisignals.Optional(environment),
-		AssetList: uisignals.Pointer(workspaceAssetListSignal(
-			workspaceID,
-			assets,
-			edges,
-			activeType,
-			query,
-			connectionAssetListTabs(activeType, query),
-			"No connection assets match this view.",
-			"/connections",
-		)),
+		Query:       uisignals.Optional(query),
+		Connections: connectionSummarySignals(assets, edges, administration),
 	}
+}
+
+func connectionSummarySignals(assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, administration ConnectionAdministrationView) []uisignals.ConnectionSummarySignal {
+	connections := make([]workspaceview.AssetView, 0, len(assets))
+	for _, asset := range assets {
+		if asset.Type == "connection" {
+			connections = append(connections, asset)
+		}
+	}
+	sort.SliceStable(connections, func(i, j int) bool {
+		left, right := strings.ToLower(assetTitle(connections[i])), strings.ToLower(assetTitle(connections[j]))
+		if left != right {
+			return left < right
+		}
+		return connections[i].ID < connections[j].ID
+	})
+	out := make([]uisignals.ConnectionSummarySignal, 0, len(connections))
+	for _, connection := range connections {
+		lifecycle := connectionLifecycleSignal(connection, assets, edges, administration)
+		out = append(out, uisignals.ConnectionSummarySignal{
+			ID:               connection.ID,
+			Title:            assetTitle(connection),
+			Description:      uisignals.Optional(connection.Description),
+			DetailHref:       assetnav.ConnectionAssetSectionHref(connection.ID, "details"),
+			Kind:             emptyDash(firstNonEmpty(metaString(connection.Payload, "Kind", "kind"), metaString(connection.Payload, "Provider", "provider"))),
+			Lifecycle:        lifecycle,
+			Scope:            emptyDash(metaString(connection.Payload, "Scope", "scope")),
+			SourceCount:      connectionSourceCount(connection.ID, edges),
+			CredentialStatus: lifecycle.StatusLabel,
+		})
+	}
+	return out
+}
+
+func connectionSourceCount(connectionID string, edges []workspaceview.AssetEdgeView) int64 {
+	seen := map[string]struct{}{}
+	for _, edge := range edges {
+		if edge.Type == "uses_connection" && edge.ToAssetID == connectionID {
+			seen[edge.FromAssetID] = struct{}{}
+		}
+	}
+	return int64(len(seen))
 }
 
 func workspaceCatalogItemSignals(workspaces []workspaceview.WorkspaceView) []uisignals.WorkspaceCatalogItemSignal {
@@ -346,19 +419,6 @@ func workspaceAssetListTabs(workspaceID, activeType, query string) []uisignals.W
 			label = assetTypeLabel(typ)
 		}
 		tabs = append(tabs, uisignals.WorkspaceTabSignal{ID: typ, Label: label, Href: workspaceAssetHref(workspaceID, typ, query), Active: typ == activeType})
-	}
-	return tabs
-}
-
-func connectionAssetListTabs(activeType, query string) []uisignals.WorkspaceTabSignal {
-	types := []string{"", "connection", "source"}
-	tabs := make([]uisignals.WorkspaceTabSignal, 0, len(types))
-	for _, typ := range types {
-		label := "All"
-		if typ != "" {
-			label = assetTypeLabel(typ)
-		}
-		tabs = append(tabs, uisignals.WorkspaceTabSignal{ID: typ, Label: label, Href: connectionAssetListHref(typ, query), Active: typ == activeType})
 	}
 	return tabs
 }
@@ -447,9 +507,15 @@ func connectionAssetPageSignal(workspace workspaceview.WorkspaceView, asset work
 	return connectionAssetPageSignalWithVersions(workspace, asset, assets, edges, activeSection, lineage, AssetVersionsState{})
 }
 
-func connectionAssetPageSignalWithVersions(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, versions AssetVersionsState) uisignals.WorkspaceAssetPageSignal {
+func connectionAssetPageSignalWithVersions(workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, versions AssetVersionsState, administration ...ConnectionAdministrationView) uisignals.WorkspaceAssetPageSignal {
 	page := baseWorkspaceAssetPageSignalWithRefreshAndVersions(workspace, asset, assets, edges, activeSection, lineage, AssetRefreshState{}, versions)
+	admin := ConnectionAdministrationView{}
+	if len(administration) > 0 {
+		admin = administration[0]
+	}
 	page.Kind = uisignals.RouteConnectionAsset
+	lifecycle := connectionLifecycleSignal(asset, assets, edges, admin)
+	page.ConnectionLifecycle = &lifecycle
 	page.Breadcrumbs = []uisignals.WorkspaceBreadcrumbSignal{
 		{Label: "Connections", Href: uisignals.Pointer("/connections")},
 		{Label: assetTitle(asset), Current: uisignals.Pointer(true)},
@@ -466,16 +532,18 @@ func connectionSourceAssetPageSignal(workspace workspaceview.WorkspaceView, conn
 	return connectionSourceAssetPageSignalWithVersions(workspace, connection, source, assets, edges, activeSection, lineage, AssetVersionsState{})
 }
 
-func connectionSourceAssetPageSignalWithVersions(workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, versions AssetVersionsState) uisignals.WorkspaceAssetPageSignal {
+func connectionSourceAssetPageSignalWithVersions(workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection string, lineage assetLineageModel, versions AssetVersionsState, administration ...ConnectionAdministrationView) uisignals.WorkspaceAssetPageSignal {
 	page := baseWorkspaceAssetPageSignalWithRefreshAndVersions(workspace, source, assets, edges, activeSection, lineage, AssetRefreshState{}, versions)
 	page.Kind = uisignals.RouteConnectionAsset
+	parentLineage := assetLineage(workspace.ID, connection, assets, edges)
+	parent := connectionAssetPageSignalWithVersions(workspace, connection, assets, edges, "details", parentLineage, AssetVersionsState{}, administration...)
+	page.DrawerParent = &parent
 	page.Breadcrumbs = []uisignals.WorkspaceBreadcrumbSignal{
 		{Label: "Connections", Href: uisignals.Pointer("/connections")},
 		{Label: assetTitle(connection), Href: uisignals.Pointer(assetnav.ConnectionAssetSectionHref(connection.ID, "details"))},
-		{Label: "Sources", Href: uisignals.Pointer("/connections?type=source")},
 		{Label: assetTitle(source), Current: uisignals.Pointer(true)},
 	}
-	page.Actions = uisignals.Pointer([]uisignals.WorkspaceActionSignal{{Label: "Back to sources", Href: uisignals.Pointer("/connections?type=source"), Icon: uisignals.Pointer("back")}})
+	page.Actions = uisignals.Pointer([]uisignals.WorkspaceActionSignal{{Label: "Back to connection", Href: uisignals.Pointer(assetnav.ConnectionAssetSectionHref(connection.ID, "details")), Icon: uisignals.Pointer("back")}})
 	page.Tabs = []uisignals.WorkspaceTabSignal{
 		{ID: "details", Label: "Details", Href: assetnav.ConnectionSourceAssetSectionHref(connection.ID, source.ID, "details"), Active: activeSection == "details"},
 		{ID: "data", Label: "Data", Href: workspaceAssetDataHref(source.WorkspaceID, source.ID), Active: activeSection == "data"},
@@ -612,11 +680,17 @@ func ConnectionAssetBootstrapSignals(catalog catalog.Catalog, workspace workspac
 }
 
 func ConnectionAssetBootstrapSignalsForEnvironment(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, environment, roleLabel string, versions AssetVersionsState) map[string]any {
+	return ConnectionAssetBootstrapSignalsWithAdministrationForEnvironment(catalog, workspace, asset, assets, edges, activeSection, environment, roleLabel, versions, ConnectionAdministrationView{})
+}
+
+func ConnectionAssetBootstrapSignalsWithAdministrationForEnvironment(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, environment, roleLabel string, versions AssetVersionsState, administration ConnectionAdministrationView, chromeOptions ...webpage.Provider) map[string]any {
 	activeSection = normalizeWorkspaceAssetSection(activeSection)
 	lineage := assetLineage(workspace.ID, asset, assets, edges)
-	page := connectionAssetPageSignalWithVersions(workspace, asset, assets, edges, activeSection, lineage, versions)
+	page := connectionAssetPageSignalWithVersions(workspace, asset, assets, edges, activeSection, lineage, versions, administration)
 	page.Environment = uisignals.Optional(environment)
-	return workspaceRouteBootstrapSignals(catalog, "connections", roleLabel, page, uisignals.RouteConnectionAsset, nil, nil)
+	patch := workspaceRouteBootstrapSignals(catalog, "connections", roleLabel, page, uisignals.RouteConnectionAsset, nil, chromeOptions)
+	patch["connectionAdmin"] = emptyConnectionAdministrationSignal(administration.Status)
+	return patch
 }
 
 func ConnectionSourceAssetBootstrapSignals(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, roleLabel string, versions AssetVersionsState) map[string]any {
@@ -624,11 +698,17 @@ func ConnectionSourceAssetBootstrapSignals(catalog catalog.Catalog, workspace wo
 }
 
 func ConnectionSourceAssetBootstrapSignalsForEnvironment(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, environment, roleLabel string, versions AssetVersionsState) map[string]any {
+	return ConnectionSourceAssetBootstrapSignalsWithAdministrationForEnvironment(catalog, workspace, connection, source, assets, edges, activeSection, environment, roleLabel, versions, ConnectionAdministrationView{})
+}
+
+func ConnectionSourceAssetBootstrapSignalsWithAdministrationForEnvironment(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, environment, roleLabel string, versions AssetVersionsState, administration ConnectionAdministrationView, chromeOptions ...webpage.Provider) map[string]any {
 	activeSection = normalizeWorkspaceAssetSection(activeSection)
 	lineage := assetLineage(workspace.ID, source, assets, edges)
-	page := connectionSourceAssetPageSignalWithVersions(workspace, connection, source, assets, edges, activeSection, lineage, versions)
+	page := connectionSourceAssetPageSignalWithVersions(workspace, connection, source, assets, edges, activeSection, lineage, versions, administration)
 	page.Environment = uisignals.Optional(environment)
-	return workspaceRouteBootstrapSignals(catalog, "connections", roleLabel, page, uisignals.RouteConnectionAsset, nil, nil)
+	patch := workspaceRouteBootstrapSignals(catalog, "connections", roleLabel, page, uisignals.RouteConnectionAsset, nil, chromeOptions)
+	patch["connectionAdmin"] = emptyConnectionAdministrationSignal(administration.Status)
+	return patch
 }
 
 func ConnectionAssetPageWithVersions(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, roleLabel string, versions AssetVersionsState) g.Node {
@@ -636,13 +716,19 @@ func ConnectionAssetPageWithVersions(catalog catalog.Catalog, workspace workspac
 }
 
 func ConnectionAssetPageWithVersionsForEnvironment(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, environment, roleLabel string, versions AssetVersionsState) g.Node {
+	return ConnectionAssetPageWithAdministrationForEnvironment(catalog, workspace, asset, assets, edges, activeSection, environment, roleLabel, versions, ConnectionAdministrationView{}, ConnectionCommandBindings{}, "", nil)
+}
+
+func ConnectionAssetPageWithAdministrationForEnvironment(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, asset workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, environment, roleLabel string, versions AssetVersionsState, administration ConnectionAdministrationView, commands ConnectionCommandBindings, csrfToken string, chromeOptions []webpage.Provider) g.Node {
 	activeSection = normalizeWorkspaceAssetSection(activeSection)
 	lineage := assetLineage(workspace.ID, asset, assets, edges)
-	page := connectionAssetPageSignalWithVersions(workspace, asset, assets, edges, activeSection, lineage, versions)
+	page := connectionAssetPageSignalWithVersions(workspace, asset, assets, edges, activeSection, lineage, versions, administration)
 	page.Environment = uisignals.Optional(environment)
+	rootAttributes := []g.Node{g.Attr("slot", "page")}
+	rootAttributes = append(rootAttributes, connectionAdministrationRouteBridge(commands)...)
 	return workspaceAssetRouteDocument(asset, catalog, "connections", roleLabel, page, uisignals.RouteConnectionAsset, g.El("lv-workspace-asset-page",
-		g.Attr("slot", "page"),
-	), workspaceDocumentExtras{}, activeSection, nil)
+		rootAttributes...,
+	), workspaceDocumentExtras{CSRFToken: csrfToken, BootstrapSignals: map[string]any{"connectionAdmin": emptyConnectionAdministrationSignal(administration.Status)}}, activeSection, chromeOptions)
 }
 
 func ConnectionSourceAssetPageWithVersions(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, roleLabel string, versions AssetVersionsState) g.Node {
@@ -650,13 +736,19 @@ func ConnectionSourceAssetPageWithVersions(catalog catalog.Catalog, workspace wo
 }
 
 func ConnectionSourceAssetPageWithVersionsForEnvironment(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, environment, roleLabel string, versions AssetVersionsState) g.Node {
+	return ConnectionSourceAssetPageWithAdministrationForEnvironment(catalog, workspace, connection, source, assets, edges, activeSection, environment, roleLabel, versions, ConnectionAdministrationView{}, ConnectionCommandBindings{}, "", nil)
+}
+
+func ConnectionSourceAssetPageWithAdministrationForEnvironment(catalog catalog.Catalog, workspace workspaceview.WorkspaceView, connection workspaceview.AssetView, source workspaceview.AssetView, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView, activeSection, environment, roleLabel string, versions AssetVersionsState, administration ConnectionAdministrationView, commands ConnectionCommandBindings, csrfToken string, chromeOptions []webpage.Provider) g.Node {
 	activeSection = normalizeWorkspaceAssetSection(activeSection)
 	lineage := assetLineage(workspace.ID, source, assets, edges)
-	page := connectionSourceAssetPageSignalWithVersions(workspace, connection, source, assets, edges, activeSection, lineage, versions)
+	page := connectionSourceAssetPageSignalWithVersions(workspace, connection, source, assets, edges, activeSection, lineage, versions, administration)
 	page.Environment = uisignals.Optional(environment)
+	rootAttributes := []g.Node{g.Attr("slot", "page")}
+	rootAttributes = append(rootAttributes, connectionAdministrationRouteBridge(commands)...)
 	return workspaceAssetRouteDocument(source, catalog, "connections", roleLabel, page, uisignals.RouteConnectionAsset, g.El("lv-workspace-asset-page",
-		g.Attr("slot", "page"),
-	), workspaceDocumentExtras{}, activeSection, nil)
+		rootAttributes...,
+	), workspaceDocumentExtras{CSRFToken: csrfToken, BootstrapSignals: map[string]any{"connectionAdmin": emptyConnectionAdministrationSignal(administration.Status)}}, activeSection, chromeOptions)
 }
 
 func workspaceAssetRouteDocument(asset workspaceview.AssetView, catalog catalog.Catalog, active, roleLabel string, page any, routeKind uisignals.RouteKind, routeRoot g.Node, extras workspaceDocumentExtras, activeSection string, chromeOptions []webpage.Provider, bodyExtras ...g.Node) g.Node {
@@ -798,8 +890,7 @@ func workspaceRouteUpdatesURL(routeKind uisignals.RouteKind, catalog catalog.Cat
 		assetList := uisignals.ValueOrZero(typed.AssetList)
 		return updatesURL(routeKind, "workspace", firstNonEmpty(uisignals.ValueOrZero(typed.WorkspaceID), catalog.Workspace.ID), "environment", uisignals.ValueOrZero(typed.Environment), "type", firstNonEmpty(uisignals.ValueOrZero(assetList.ActiveType), uisignals.ValueOrZero(typed.ListFilter)), "q", firstNonEmpty(uisignals.ValueOrZero(assetList.Query), uisignals.ValueOrZero(typed.ListQuery)))
 	case uisignals.ConnectionsPageSignal:
-		assetList := uisignals.ValueOrZero(typed.AssetList)
-		return updatesURL(routeKind, "environment", uisignals.ValueOrZero(typed.Environment), "type", uisignals.ValueOrZero(assetList.ActiveType), "q", uisignals.ValueOrZero(assetList.Query))
+		return updatesURL(routeKind, "environment", uisignals.ValueOrZero(typed.Environment), "q", uisignals.ValueOrZero(typed.Query))
 	case uisignals.WorkspaceAssetPageSignal:
 		if routeKind == uisignals.RouteConnectionAsset {
 			return updatesURL(routeKind, "environment", uisignals.ValueOrZero(typed.Environment), "asset", typed.AssetID, "section", typed.ActiveSection, "assetWorkspace", extras.AssetWorkspaceID)
@@ -809,21 +900,6 @@ func workspaceRouteUpdatesURL(routeKind uisignals.RouteKind, catalog catalog.Cat
 	default:
 		return updatesURL(routeKind)
 	}
-}
-
-func connectionAssetListHref(typ, query string) string {
-	href := "/connections"
-	values := url.Values{}
-	if typ != "" {
-		values.Set("type", typ)
-	}
-	if strings.TrimSpace(query) != "" {
-		values.Set("q", query)
-	}
-	if encoded := values.Encode(); encoded != "" {
-		href += "?" + encoded
-	}
-	return href
 }
 
 func workspaceAssetHref(workspaceID, typ, query string) string {
@@ -2685,9 +2761,38 @@ func connectionDetailModel(model *assetDetailModel, workspace workspaceview.Work
 		assetDetailSection{
 			Title:  fmt.Sprintf("Sources (%d)", len(sources)),
 			Signal: "assetDetailsConnectionSourcesTable",
-			Table:  childAssetGrid(workspace.ID, sources, edges, "No sources use this connection."),
+			Table:  connectionSourcesGrid(workspace.ID, sources, edges),
 		},
 	)
+}
+
+func connectionSourcesGrid(workspaceID string, sources []workspaceview.AssetView, edges []workspaceview.AssetEdgeView) recordTable {
+	sort.SliceStable(sources, func(i, j int) bool {
+		return strings.ToLower(assetTitle(sources[i])) < strings.ToLower(assetTitle(sources[j]))
+	})
+	rows := make([]map[string]any, 0, len(sources))
+	for _, source := range sources {
+		fields := metaMap(source.Payload, "Fields", "fields")
+		schema := metaMap(source.Payload, "Schema", "schema")
+		rows = append(rows, map[string]any{
+			"source":     assetTitle(source),
+			"sourceHref": assetnav.CanonicalAssetSectionHref(workspaceID, source, "details", edges),
+			"format":     emptyDash(metaString(source.Payload, "Format", "format")),
+			"path":       emptyDash(metaString(source.Payload, "Path", "path")),
+			"fields":     len(modelTableSchemaColumns(fields, schema)),
+		})
+	}
+	return recordTable{
+		Columns: []recordTableColumn{
+			{ID: "source", Header: "Source", Kind: uisignals.Pointer("link"), HrefKey: uisignals.Pointer("sourceHref"), Width: uisignals.Pointer("240px")},
+			{ID: "format", Header: "Format", Width: uisignals.Pointer("140px")},
+			{ID: "path", Header: "Path", Kind: uisignals.Pointer("code")},
+			{ID: "fields", Header: "Fields", Align: uisignals.Pointer("right"), Width: uisignals.Pointer("100px")},
+		},
+		Rows:     rows,
+		Empty:    "No sources use this connection.",
+		MinWidth: uisignals.Pointer("760px"),
+	}
 }
 
 func sourcesUsingConnection(connectionID string, assets []workspaceview.AssetView, edges []workspaceview.AssetEdgeView) []workspaceview.AssetView {

--- a/internal/workspace/ui/workspace_test.go
+++ b/internal/workspace/ui/workspace_test.go
@@ -47,7 +47,7 @@ func TestListPagesUseDebouncedPostSearchCommands(t *testing.T) {
 		{name: "catalog", page: CatalogPage(catalog), path: "/catalog/search"},
 		{name: "workspaces", page: WorkspacesPage(catalog, []workspaceview.WorkspaceView{workspace}, "Owner"), path: "/workspaces/search"},
 		{name: "workspace assets", page: WorkspacePage(catalog, workspace, assets, "", "", "Owner", WorkspaceAccessResponse{}, "", testAccessCommandBindings()), path: "/workspaces/leapview/search"},
-		{name: "connections", page: ConnectionsPage(catalog, workspace.ID, assets, edges, "", "", "Owner"), path: "/connections/search"},
+		{name: "connections", page: ConnectionsPage(catalog, workspace.ID, assets, edges, "", "Owner"), path: "/connections/search"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestListResultPatchesOnlyReplaceServerOwnedRows(t *testing.T) {
 		{name: "catalog", patch: CatalogListPatchForCatalogsQuery([]catalog.Catalog{workspaceCatalog}, "sales"), field: "dashboards"},
 		{name: "workspaces", patch: WorkspacesListResultsPatch([]workspaceview.WorkspaceView{workspace}), field: "workspaces"},
 		{name: "workspace assets", patch: WorkspaceAssetListResultsPatch(workspace.ID, assets, edges), field: "assetList", nested: "assets"},
-		{name: "connections", patch: ConnectionsListResultsPatch("platform", assets, edges), field: "assetList", nested: "assets"},
+		{name: "connections", patch: ConnectionsListResultsPatch(assets, edges), field: "connections"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -889,36 +889,33 @@ func TestConnectionAssetDetailsRenderConnectionSurface(t *testing.T) {
 	}
 }
 
-func TestConnectionsPageUsesConnectionAssetTabs(t *testing.T) {
+func TestConnectionsPageListsOnlyConnectionsWithConnectionFields(t *testing.T) {
 	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
-	visibleAssets := []workspaceview.AssetView{}
-	for _, asset := range assets {
-		if asset.Type == "connection" || asset.Type == "source" {
-			visibleAssets = append(visibleAssets, asset)
-		}
-	}
 
 	var out strings.Builder
-	err := ConnectionsPage(catalog, workspace.ID, visibleAssets, edges, "source", "", "Owner").Render(&out)
+	err := ConnectionsPage(catalog, workspace.ID, assets, edges, "", "Owner").Render(&out)
 	if err != nil {
 		t.Fatal(err)
 	}
 	rendered := html.UnescapeString(out.String())
-	rendered += bootstrapJSON(ConnectionsBootstrapSignals(catalog, workspace.ID, visibleAssets, edges, "source", "", "Owner"))
+	rendered += bootstrapJSON(ConnectionsBootstrapSignals(catalog, workspace.ID, assets, edges, "", "Owner"))
 
 	for _, want := range []string{
 		`<lv-connections-page`,
 		`data-on:lv-entity-list-query__debounce.200ms=`,
 		`@post('/connections/search'`,
-		`"searchHref":"/connections"`,
-		`"href":"/connections?type=connection"`,
-		`"active":true,"href":"/connections?type=source"`,
-		`"/connections/connection:olist.olist/sources/source:olist.orders/details"`,
-		`"parentHref":"/connections/connection:olist.olist/details"`,
-		`"typeLabel":"Source"`,
+		`"connections":[`,
+		`"kind":"local"`,
+		`"sourceCount":1`,
+		`"credentialStatus":"Not configured"`,
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("connections page did not render %q:\n%s", want, rendered)
+		}
+	}
+	for _, notWant := range []string{`"typeLabel":"Source"`, `?type=source`, `"title":"orders"`} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("connections page mixed source content %q:\n%s", notWant, rendered)
 		}
 	}
 	if strings.Contains(rendered, `data-workspace-asset-toolbar`) {
@@ -926,29 +923,81 @@ func TestConnectionsPageUsesConnectionAssetTabs(t *testing.T) {
 	}
 }
 
+func TestConnectionLifecycleUsesOneStateDrivenPrimaryAction(t *testing.T) {
+	_, _, assets, edges := testWorkspaceAssetFixtures()
+	connection := testAssetByID(t, assets, "connection")
+	logical := ConnectionLogicalName(connection, assets, edges)
+	tests := []struct {
+		name        string
+		binding     *ConnectionBindingView
+		wantState   string
+		wantPrimary string
+	}{
+		{name: "missing", wantState: "missing", wantPrimary: "configure"},
+		{name: "pending", binding: &ConnectionBindingView{ID: logical, LogicalConnection: logical, Enabled: true, Health: "pending", Revision: 1}, wantState: "pending", wantPrimary: "test"},
+		{name: "healthy", binding: &ConnectionBindingView{ID: logical, LogicalConnection: logical, Enabled: true, Health: "healthy", Revision: 2}, wantState: "healthy", wantPrimary: "refresh"},
+		{name: "degraded", binding: &ConnectionBindingView{ID: logical, LogicalConnection: logical, Enabled: true, Health: "degraded", Revision: 3}, wantState: "degraded", wantPrimary: "refresh"},
+		{name: "disabled", binding: &ConnectionBindingView{ID: logical, LogicalConnection: logical, Health: "disabled", Revision: 4}, wantState: "disabled", wantPrimary: "enable"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			administration := ConnectionAdministrationView{
+				Bindings: map[string]ConnectionBindingView{}, CanManage: true, CanTest: true,
+				RequiresBinding: map[string]bool{logical: true},
+			}
+			if test.binding != nil {
+				administration.Bindings[logical] = *test.binding
+			}
+			lifecycle := ConnectionLifecycleForAsset(connection, assets, edges, administration)
+			if lifecycle.State != test.wantState {
+				t.Fatalf("state = %q, want %q", lifecycle.State, test.wantState)
+			}
+			primary := ""
+			primaryCount := 0
+			for _, action := range lifecycle.Actions {
+				if action.Primary {
+					primary, primaryCount = action.ID, primaryCount+1
+				}
+			}
+			if primary != test.wantPrimary || primaryCount != 1 {
+				t.Fatalf("primary action = %q count=%d, want %q count=1: %#v", primary, primaryCount, test.wantPrimary, lifecycle.Actions)
+			}
+		})
+	}
+}
+
 func TestConnectionSourceAssetDetailsRenderConnectionChrome(t *testing.T) {
 	workspace, catalog, assets, edges := testWorkspaceAssetFixtures()
 	source := testAssetByID(t, assets, "source")
 	connection := testAssetByID(t, assets, "connection")
+	logical := ConnectionLogicalName(connection, assets, edges)
+	administration := ConnectionAdministrationView{
+		Bindings: map[string]ConnectionBindingView{}, CanManage: true, CanTest: true,
+		RequiresBinding: map[string]bool{logical: false},
+	}
 
 	var out strings.Builder
-	err := ConnectionSourceAssetPage(catalog, workspace, connection, source, assets, edges, "details", "Owner").Render(&out)
+	err := ConnectionSourceAssetPageWithAdministrationForEnvironment(catalog, workspace, connection, source, assets, edges, "details", "dev", "Owner", AssetVersionsState{}, administration, ConnectionCommandBindings{}, "csrf", nil).Render(&out)
 	if err != nil {
 		t.Fatal(err)
 	}
 	rendered := html.UnescapeString(out.String())
-	rendered += bootstrapJSON(ConnectionSourceAssetBootstrapSignals(catalog, workspace, connection, source, assets, edges, "details", "Owner", AssetVersionsState{}))
+	rendered += bootstrapJSON(ConnectionSourceAssetBootstrapSignalsWithAdministrationForEnvironment(catalog, workspace, connection, source, assets, edges, "details", "dev", "Owner", AssetVersionsState{}, administration, testLayoutProvider()))
 
 	for _, want := range []string{
 		`<lv-workspace-asset-page`,
+		`"drawerParent":`,
 		`assetWorkspace=leapview`,
 		"Connections",
 		"Olist connection",
 		"Sources",
 		"orders",
 		"Fields",
-		`"href":"/connections?type=source"`,
 		`"href":"/connections/connection:olist.olist/sources/source:olist.orders/lineage"`,
+		`"state":"not_required"`,
+		`"statusLabel":"Not required"`,
+		`"chrome":`,
+		`"active":"connections"`,
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("connection-scoped source details did not render %q:\n%s", want, rendered)

--- a/internal/workspace/view.go
+++ b/internal/workspace/view.go
@@ -203,15 +203,11 @@ func FilterWorkspaceLandingAssets(assets []AssetView, typ, query string) []Asset
 	return out
 }
 
-func FilterConnectionAssets(assets []AssetView, typ, query string) []AssetView {
-	typ = NormalizeConnectionAssetType(typ)
+func FilterConnections(assets []AssetView, query string) []AssetView {
 	query = strings.ToLower(strings.TrimSpace(query))
 	out := make([]AssetView, 0, len(assets))
 	for _, asset := range assets {
-		if asset.Type != string(AssetTypeConnection) && asset.Type != string(AssetTypeSource) {
-			continue
-		}
-		if typ != "" && asset.Type != typ {
+		if asset.Type != string(AssetTypeConnection) {
 			continue
 		}
 		haystack := strings.ToLower(asset.Type + " " + asset.Key + " " + asset.Title + " " + asset.Description)
@@ -221,15 +217,6 @@ func FilterConnectionAssets(assets []AssetView, typ, query string) []AssetView {
 		out = append(out, asset)
 	}
 	return out
-}
-
-func NormalizeConnectionAssetType(typ string) string {
-	switch strings.TrimSpace(typ) {
-	case string(AssetTypeConnection), string(AssetTypeSource):
-		return strings.TrimSpace(typ)
-	default:
-		return ""
-	}
 }
 
 func AssetByID(assets []AssetView, id string) (AssetView, bool) {

--- a/internal/workspace/view_test.go
+++ b/internal/workspace/view_test.go
@@ -19,8 +19,11 @@ func TestWorkspaceViewHelpersFilterAndNavigateAssets(t *testing.T) {
 	if filtered := FilterWorkspaceAssets(assets, "connection", "duck"); len(filtered) != 1 || filtered[0].ID != "connection:duckdb" {
 		t.Fatalf("workspace dependency filter = %#v", filtered)
 	}
-	if filtered := FilterConnectionAssets(assets, "source", "ord"); len(filtered) != 1 || filtered[0].ID != "source:orders" {
-		t.Fatalf("filtered connection assets = %#v", filtered)
+	if filtered := FilterConnections(assets, "duck"); len(filtered) != 1 || filtered[0].ID != "connection:duckdb" {
+		t.Fatalf("filtered connections = %#v", filtered)
+	}
+	if filtered := FilterConnections(assets, "ord"); len(filtered) != 0 {
+		t.Fatalf("connection search leaked sources = %#v", filtered)
 	}
 	edges := []AssetEdgeView{{FromAssetID: "source:orders", ToAssetID: "connection:duckdb", Type: string(AssetEdgeUsesConnection)}}
 	if got := SourceConnectionID("source:orders", edges); got != "connection:duckdb" {

--- a/web/components/shared/asset-lineage-graph.dom.test.ts
+++ b/web/components/shared/asset-lineage-graph.dom.test.ts
@@ -69,6 +69,8 @@ test('asset lineage graph carries React Flow layout styles inside shadow hosts',
       const controlIconRect = controlIcon.getBoundingClientRect()
       return {
         flowHeight: Math.round(flowRect.height),
+        flowWidth: Math.round(flowRect.width),
+        inspectorPanels: graph.querySelectorAll('.asset-lineage-panel').length,
         viewportPosition: getComputedStyle(viewport).position,
         viewportMatchesFlowWidth: Math.round(Number.parseFloat(getComputedStyle(viewport).width)) === Math.round(flowRect.width),
         edgePosition: getComputedStyle(edge).position,
@@ -84,6 +86,8 @@ test('asset lineage graph carries React Flow layout styles inside shadow hosts',
 
     expect(state).toEqual({
       flowHeight: 420,
+      flowWidth: 900,
+      inspectorPanels: 0,
       viewportPosition: 'absolute',
       viewportMatchesFlowWidth: true,
       edgePosition: 'absolute',

--- a/web/components/shared/asset-lineage-graph.ts
+++ b/web/components/shared/asset-lineage-graph.ts
@@ -139,7 +139,6 @@ class AssetLineageGraph extends LitElement {
             ],
           }),
         ),
-        React.createElement(LineageInspectorPanel, { key: selectedNode?.id ?? 'empty', node: selectedNode }),
       ),
     )
   }
@@ -165,7 +164,7 @@ const assetLineageGraphStyles = `
 
   lv-asset-lineage-graph .asset-lineage-layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(17rem, 20rem);
+    grid-template-columns: minmax(0, 1fr);
   }
 
   lv-asset-lineage-graph .asset-lineage-flow {
@@ -176,94 +175,6 @@ const assetLineageGraphStyles = `
       linear-gradient(var(--lv-bg-page), var(--lv-bg-page)),
       radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--lv-fg-muted), transparent 87%) 1px, transparent 0);
     background-size: auto, 18px 18px;
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel {
-    display: grid;
-    align-content: start;
-    gap: var(--base-size-16);
-    min-width: 0;
-    border-left: var(--borderWidth-thin) solid var(--lv-line-muted);
-    background: var(--lv-bg-panel);
-    padding: var(--base-size-16);
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-eyebrow {
-    color: var(--lv-fg-muted);
-    font: var(--lv-type-caption);
-    text-transform: uppercase;
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-title {
-    overflow: hidden;
-    margin: var(--base-size-4) 0 0;
-    color: var(--lv-fg-default);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font: var(--lv-type-body-compact);
-    font-weight: var(--base-text-weight-semibold);
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-key {
-    overflow: hidden;
-    margin-top: var(--base-size-6);
-    color: var(--lv-fg-muted);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font: var(--lv-type-code-inline);
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-stats {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--base-size-8);
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-stat {
-    display: grid;
-    gap: var(--base-size-4);
-    min-width: 0;
-    border: var(--borderWidth-thin) solid var(--lv-line-muted);
-    border-radius: var(--borderRadius-default);
-    background: var(--lv-bg-panel-muted);
-    padding: var(--base-size-8);
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-stat span {
-    color: var(--lv-fg-muted);
-    font: var(--lv-type-caption);
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-stat strong {
-    color: var(--lv-fg-default);
-    font: var(--lv-type-body-compact);
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-summary {
-    min-width: 0;
-    color: var(--lv-fg-muted);
-    font: var(--lv-type-body);
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-action {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 2rem;
-    border: var(--borderWidth-thin) solid var(--lv-line-accent);
-    border-radius: var(--borderRadius-default);
-    background: var(--lv-line-accent);
-    color: var(--lv-fg-on-emphasis);
-    padding: 0 var(--base-size-12);
-    font: var(--lv-type-body);
-    font-weight: var(--base-text-weight-medium);
-    text-decoration: none;
-  }
-
-  lv-asset-lineage-graph .asset-lineage-panel-action:hover,
-  lv-asset-lineage-graph .asset-lineage-panel-action:focus-visible {
-    outline: 0;
-    filter: brightness(1.06);
   }
 
   lv-asset-lineage-graph .react-flow {
@@ -492,17 +403,6 @@ const assetLineageGraphStyles = `
     font: var(--lv-type-caption);
   }
 
-  @media (max-width: 860px) {
-    lv-asset-lineage-graph .asset-lineage-layout {
-      grid-template-columns: minmax(0, 1fr);
-      grid-template-rows: minmax(26rem, 1fr) auto;
-    }
-
-    lv-asset-lineage-graph .asset-lineage-panel {
-      border-top: var(--borderWidth-thin) solid var(--lv-line-muted);
-      border-left: 0;
-    }
-  }
 `
 
 function toFlowNode(node: LineageNode, layout: LineageLayout, pathState: LineagePathState, onSelect: (id: string) => void): Node<LineageNodeData> {
@@ -668,49 +568,6 @@ function LineageNodeComponent({ data }: { data: LineageNodeData }) {
     React.createElement('div', { className: 'asset-lineage-node-title', title: data.label }, data.label),
     data.meta ? React.createElement('div', { className: 'asset-lineage-node-meta' }, data.meta) : null,
     React.createElement(Handle, { type: 'source', position: Position.Right }),
-  )
-}
-
-function LineageInspectorPanel({ node }: { node?: LineageNode }) {
-  if (!node) {
-    return React.createElement(
-      'aside',
-      { className: 'asset-lineage-panel', 'aria-label': 'Selected lineage asset' },
-      React.createElement('div', null,
-        React.createElement('div', { className: 'asset-lineage-panel-eyebrow' }, 'Lineage'),
-        React.createElement('p', { className: 'asset-lineage-panel-summary' }, 'Select a node to inspect its lineage context.'),
-      ),
-    )
-  }
-  return React.createElement(
-    'aside',
-    { className: 'asset-lineage-panel', 'aria-label': 'Selected lineage asset' },
-    React.createElement('div', null,
-      React.createElement('div', { className: 'asset-lineage-panel-eyebrow' }, kindLabel(node.kind)),
-      React.createElement('h2', { className: 'asset-lineage-panel-title', title: node.label }, node.label),
-      node.meta ? React.createElement('div', { className: 'asset-lineage-panel-key', title: node.meta }, node.meta) : null,
-    ),
-    React.createElement('div', { className: 'asset-lineage-panel-stats' },
-      panelStat('Visible upstream', node.visibleUpstreamCount ?? 0),
-      panelStat('Visible downstream', node.visibleDownstreamCount ?? 0),
-      panelStat('Uses', node.usesCount ?? 0),
-      panelStat('Used by', node.usedByCount ?? 0),
-    ),
-    React.createElement(
-      'div',
-      { className: 'asset-lineage-panel-summary' },
-      node.containedCount
-        ? `${node.containedCount} contained assets: ${node.containedSummary ?? 'mixed assets'}`
-        : 'No directly contained assets.',
-    ),
-    node.href ? React.createElement('a', { className: 'asset-lineage-panel-action', href: node.href }, 'Open details') : null,
-  )
-}
-
-function panelStat(label: string, value: number) {
-  return React.createElement('div', { className: 'asset-lineage-panel-stat' },
-    React.createElement('span', null, label),
-    React.createElement('strong', null, String(value)),
   )
 }
 

--- a/web/components/workspace/connection-administration.ts
+++ b/web/components/workspace/connection-administration.ts
@@ -1,0 +1,239 @@
+import { LitElement, css, html, nothing } from 'lit'
+import { property, state } from 'lit/decorators.js'
+import { MoreHorizontal } from 'lucide'
+import type {
+  ConnectionAdministrationSignal,
+  ConnectionLifecycleActionSignal,
+  ConnectionLifecycleSignal,
+} from '../../generated/signals'
+import { lucideIcon } from '../shared/lucide-icons'
+import '../shared/drawer'
+import '../shared/loading-spinner'
+
+class LeapViewConnectionAdministration extends LitElement {
+  @property({ attribute: false }) lifecycles: ConnectionLifecycleSignal[] = []
+  @property({ attribute: false }) administration: ConnectionAdministrationSignal = emptyAdministration()
+  @property() surface: 'list' | 'detail' = 'detail'
+  @property() environment = ''
+  @state() private drawerOpen = false
+  @state() private selectedLogical = ''
+  @state() private authenticationMode = 'external_bundle'
+
+  static get styles() {
+    return css`
+      :host { display: inline-flex; min-width: 0; align-items: center; gap: var(--base-size-8); }
+      button, input, select, textarea { font: inherit; }
+      .lifecycle-actions { display: inline-flex; min-width: 0; align-items: center; gap: var(--base-size-8); }
+      .status-badge { display: inline-flex; min-height: var(--base-size-24); align-items: center; border: var(--lv-border-muted); border-radius: var(--lv-radius-full); background: var(--lv-bg-panel-muted); color: var(--lv-fg-muted); padding: 0 var(--base-size-8); font: var(--lv-type-caption); white-space: nowrap; }
+      .status-badge[data-tone='success'] { border-color: var(--lv-line-success-muted); color: var(--lv-fg-success); }
+      .status-badge[data-tone='warning'] { border-color: var(--lv-line-warning-muted); color: var(--lv-fg-warning); }
+      .status-badge[data-tone='danger'] { border-color: var(--lv-line-danger-muted); color: var(--lv-fg-danger); }
+      .button { display: inline-flex; min-height: var(--lv-button-height-sm); align-items: center; justify-content: center; gap: var(--base-size-6); border: var(--borderWidth-default) solid var(--lv-button-border-rest); border-radius: var(--lv-button-radius); background: var(--lv-button-bg-rest); color: var(--lv-button-fg-rest); padding: 0 var(--lv-button-padding-inline-sm); cursor: pointer; font: var(--lv-type-caption); font-weight: var(--base-text-weight-medium); white-space: nowrap; }
+      .button.primary { border-color: var(--lv-button-accent-border-rest); background: var(--lv-button-accent-bg-rest); color: var(--lv-button-accent-fg-rest); }
+      .button.danger { color: var(--lv-fg-danger); }
+      .button:disabled { opacity: .6; cursor: wait; }
+      .menu { position: relative; }
+      .menu summary { display: inline-grid; width: var(--control-medium-size); height: var(--control-medium-size); border: var(--lv-border-muted); border-radius: var(--lv-radius-default); background: var(--lv-bg-panel); color: var(--lv-fg-muted); cursor: pointer; list-style: none; place-items: center; }
+      .menu summary::-webkit-details-marker { display: none; }
+      .menu-items { position: absolute; z-index: var(--z-index-dropdown); top: calc(100% + var(--base-size-4)); right: 0; display: grid; width: max-content; min-width: 10.5rem; gap: var(--base-size-2); border: var(--lv-border-default); border-radius: var(--lv-radius-default); background: var(--lv-bg-overlay); box-shadow: var(--lv-shadow-floating-lg); padding: var(--base-size-4); }
+      .menu-items button { border: 0; border-radius: var(--lv-radius-default); background: transparent; color: var(--lv-fg-default); padding: var(--base-size-8); text-align: left; cursor: pointer; }
+      .menu-items button:hover { background: var(--lv-bg-control-hover); }
+      .menu-items button.danger { color: var(--lv-fg-danger); }
+      .drawer-body { display: grid; gap: var(--base-size-16); padding: var(--base-size-16) var(--base-size-20) var(--base-size-24); }
+      .form-section { display: grid; gap: var(--base-size-12); }
+      .form-section + .form-section { border-top: var(--lv-border-muted); padding-top: var(--base-size-16); }
+      .form-section h2 { margin: 0; color: var(--lv-fg-default); font: var(--lv-type-body); font-weight: var(--base-text-weight-semibold); }
+      .form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--base-size-12); }
+      label { display: grid; min-width: 0; gap: var(--base-size-6); color: var(--lv-fg-muted); font: var(--lv-type-caption); }
+      label.wide { grid-column: 1 / -1; }
+      input, select, textarea { width: 100%; min-width: 0; box-sizing: border-box; border: var(--lv-border-muted); border-radius: var(--lv-radius-default); background: var(--lv-bg-panel); color: var(--lv-fg-default); padding: var(--base-size-8) var(--base-size-12); }
+      input, select { min-height: var(--control-medium-size); }
+      input:read-only { background: var(--lv-bg-panel-muted); color: var(--lv-fg-muted); }
+      textarea { min-height: 5.5rem; resize: vertical; font-family: var(--fontStack-monospace); }
+      .form-status { border-radius: var(--lv-radius-default); padding: var(--base-size-8) var(--base-size-12); font: var(--lv-type-body-compact); }
+      .form-status.error { border: var(--lv-border-danger); background: var(--lv-bg-danger-muted); color: var(--lv-fg-danger); }
+      .drawer-footer { display: flex; align-items: center; justify-content: flex-end; gap: var(--base-size-8); border-top: var(--lv-border-muted); padding: var(--base-size-12) var(--base-size-20); }
+      @media (max-width: 640px) { .form-grid { grid-template-columns: 1fr; } }
+    `
+  }
+
+  updated(changed: Map<string, unknown>): void {
+    if (changed.has('administration') && this.administration.status.message) this.drawerOpen = false
+  }
+
+  render() {
+    const lifecycle = this.selectedLifecycle()
+    return html`
+      ${this.renderTrigger(lifecycle)}
+      ${this.drawerOpen && lifecycle ? this.renderDrawer(lifecycle) : nothing}
+    `
+  }
+
+  private renderTrigger(lifecycle?: ConnectionLifecycleSignal) {
+    if (this.surface === 'list') {
+      const missing = this.lifecycles.filter((item) => item.state === 'missing' && item.actions.some((action) => action.id === 'configure'))
+      if (!missing.length) return nothing
+      return html`<button class="button primary" type="button" @click=${() => this.openDrawer(missing[0])}>Configure connection</button>`
+    }
+    if (!lifecycle) return nothing
+    const primary = lifecycle.actions.find((action) => action.primary)
+    const secondary = lifecycle.actions.filter((action) => !action.primary)
+    return html`
+      <div class="lifecycle-actions">
+        <span class="status-badge" data-tone=${lifecycle.tone}>${lifecycle.statusLabel}</span>
+        ${primary ? this.renderAction(primary, lifecycle, true) : nothing}
+        ${secondary.length ? html`
+          <details class="menu">
+            <summary aria-label="More connection actions">${lucideIcon(MoreHorizontal)}</summary>
+            <div class="menu-items">${secondary.map((action) => this.renderAction(action, lifecycle, false))}</div>
+          </details>
+        ` : nothing}
+      </div>
+    `
+  }
+
+  private renderAction(action: ConnectionLifecycleActionSignal, lifecycle: ConnectionLifecycleSignal, primary: boolean) {
+    return html`
+      <button
+        class=${primary ? 'button primary' : action.destructive ? 'danger' : ''}
+        type="button"
+        ?disabled=${this.administration.status.loading}
+        @click=${() => this.handleAction(action, lifecycle)}
+      >
+        ${primary && this.administration.status.loading ? html`<lv-loading-spinner aria-hidden="true"></lv-loading-spinner>` : nothing}
+        ${action.label}
+      </button>
+    `
+  }
+
+  private handleAction(action: ConnectionLifecycleActionSignal, lifecycle: ConnectionLifecycleSignal) {
+    if (action.id === 'configure' || action.id === 'edit') {
+      this.openDrawer(lifecycle)
+      return
+    }
+    if (action.id === 'disable' && !window.confirm(`Disable ${lifecycle.logicalConnection}? Dependent sources will stop using this connection until it is enabled and tested again.`)) return
+    this.dispatchEvent(new CustomEvent('lv-connection-administration-action', {
+      bubbles: true,
+      composed: true,
+      detail: this.commandFor(lifecycle, action.id),
+    }))
+  }
+
+  private openDrawer(lifecycle: ConnectionLifecycleSignal) {
+    this.selectedLogical = lifecycle.logicalConnection
+    this.authenticationMode = lifecycle.authenticationMode || 'external_bundle'
+    this.drawerOpen = true
+  }
+
+  private renderDrawer(lifecycle: ConnectionLifecycleSignal) {
+    const confirm = this.administration.command.confirmationToken && this.administration.command.logicalConnection === lifecycle.logicalConnection
+    return html`
+      <lv-drawer open size="wide" label=${`${lifecycle.exists ? 'Edit' : 'Configure'} ${lifecycle.logicalConnection}`} @lv-drawer-close=${() => { this.drawerOpen = false }}>
+        <div slot="title">${lifecycle.exists ? 'Edit connection' : 'Configure connection'}</div>
+        <p slot="subtitle">${lifecycle.logicalConnection} · ${this.environment || 'current environment'}</p>
+        <form class="drawer-body" id="connection-configuration-form" @submit=${(event: SubmitEvent) => this.save(event, lifecycle)}>
+          ${this.administration.status.error ? html`<div class="form-status error" role="alert">${this.administration.status.error}</div>` : nothing}
+          <section class="form-section">
+            <h2>Connection</h2>
+            <div class="form-grid">
+              <label>Logical connection<input name="logicalConnection" .value=${lifecycle.logicalConnection} readonly></label>
+              <label>Connector<input name="connectorKind" .value=${lifecycle.connectorKind} readonly></label>
+            </div>
+          </section>
+          <section class="form-section">
+            <h2>Endpoint</h2>
+            <div class="form-grid">
+              <label>Host<input name="host" .value=${lifecycle.host}></label>
+              <label>Port<input name="port" inputmode="numeric" .value=${lifecycle.port}></label>
+              <label>Database<input name="database" .value=${lifecycle.database}></label>
+              <label>Object scope<input name="objectScope" .value=${lifecycle.objectScope}></label>
+              <label>Source identity<input name="sourceIdentity" .value=${lifecycle.sourceIdentity}></label>
+              <label>TLS mode<input name="tlsMode" .value=${lifecycle.tlsMode}></label>
+              <label class="wide">Options (JSON)<textarea name="options" .value=${lifecycle.options}></textarea></label>
+            </div>
+          </section>
+          <section class="form-section">
+            <h2>Authentication</h2>
+            <div class="form-grid">
+              <label class="wide">Mode
+                <select name="authenticationMode" .value=${this.authenticationMode} @change=${(event: Event) => { this.authenticationMode = (event.currentTarget as HTMLSelectElement).value }}>
+                  <option value="external_bundle">External credential bundle</option>
+                  <option value="workload_identity">Workload identity</option>
+                  <option value="none">No credentials</option>
+                </select>
+              </label>
+              ${this.authenticationMode === 'external_bundle' ? html`
+                <label>Credential project<input name="credentialProjectId" .value=${lifecycle.credentialProjectId} required></label>
+                <label>Credential environment<input name="credentialEnvironment" .value=${lifecycle.credentialEnvironment} required></label>
+                <label>Secret path<input name="secretPath" .value=${lifecycle.secretPath} placeholder="/connections/warehouse" required></label>
+                <label>Secret key<input name="secretKey" .value=${lifecycle.secretKey} required></label>
+              ` : nothing}
+            </div>
+          </section>
+          <div class="drawer-footer">
+          <button class="button" type="button" @click=${() => { this.drawerOpen = false }}>Cancel</button>
+          <button class="button primary" type="submit" form="connection-configuration-form" ?disabled=${this.administration.status.loading}>
+            ${this.administration.status.loading ? html`<lv-loading-spinner aria-hidden="true"></lv-loading-spinner>` : nothing}
+            ${confirm ? 'Confirm update' : lifecycle.exists ? 'Save changes' : 'Configure'}
+          </button>
+          </div>
+        </form>
+      </lv-drawer>
+    `
+  }
+
+  private save(event: SubmitEvent, lifecycle: ConnectionLifecycleSignal) {
+    event.preventDefault()
+    const form = event.currentTarget as HTMLFormElement
+    if (!form.reportValidity()) return
+    const data = new FormData(form)
+    const command = this.commandFor(lifecycle, lifecycle.exists ? 'update' : 'create')
+    for (const key of ['authenticationMode', 'connectorKind', 'credentialEnvironment', 'credentialProjectId', 'database', 'host', 'logicalConnection', 'objectScope', 'options', 'port', 'secretKey', 'secretPath', 'sourceIdentity', 'tlsMode'] as const) {
+      ;(command as Record<string, unknown>)[key] = String(data.get(key) ?? '')
+    }
+    if (this.administration.command.logicalConnection === lifecycle.logicalConnection) {
+      command.confirmationToken = this.administration.command.confirmationToken
+    }
+    this.dispatchEvent(new CustomEvent('lv-connection-administration-save', { bubbles: true, composed: true, detail: command }))
+  }
+
+  private commandFor(lifecycle: ConnectionLifecycleSignal, action: string) {
+    return {
+      action,
+      assetId: lifecycle.assetId,
+      authenticationMode: lifecycle.authenticationMode,
+      confirmationToken: '',
+      connectorKind: lifecycle.connectorKind,
+      credentialEnvironment: lifecycle.credentialEnvironment,
+      credentialProjectId: lifecycle.credentialProjectId,
+      database: lifecycle.database,
+      expectedRevision: lifecycle.revision,
+      host: lifecycle.host,
+      logicalConnection: lifecycle.logicalConnection,
+      objectScope: lifecycle.objectScope,
+      options: lifecycle.options,
+      port: lifecycle.port,
+      secretKey: lifecycle.secretKey,
+      secretPath: lifecycle.secretPath,
+      sourceIdentity: lifecycle.sourceIdentity,
+      surface: this.surface,
+      tlsMode: lifecycle.tlsMode,
+    }
+  }
+
+  private selectedLifecycle(): ConnectionLifecycleSignal | undefined {
+    return this.lifecycles.find((item) => item.logicalConnection === this.selectedLogical) || this.lifecycles[0]
+  }
+}
+
+function emptyAdministration(): ConnectionAdministrationSignal {
+  return {
+    command: {
+      action: '', assetId: '', authenticationMode: '', confirmationToken: '', connectorKind: '', credentialEnvironment: '', credentialProjectId: '', database: '', expectedRevision: 0,
+      host: '', logicalConnection: '', objectScope: '', options: '', port: '', secretKey: '', secretPath: '', sourceIdentity: '', surface: '', tlsMode: '',
+    },
+    status: { error: '', loading: false, message: '' },
+  }
+}
+
+if (!customElements.get('lv-connection-administration')) customElements.define('lv-connection-administration', LeapViewConnectionAdministration)

--- a/web/components/workspace/workspace-page.dom.test.ts
+++ b/web/components/workspace/workspace-page.dom.test.ts
@@ -30,6 +30,16 @@ beforeAll(async () => {
       response.end(testDocument('asset'))
       return
     }
+    if (url.pathname === '/connection') {
+      response.setHeader('content-type', 'text/html')
+      response.end(testDocument('connection'))
+      return
+    }
+    if (url.pathname === '/source') {
+      response.setHeader('content-type', 'text/html')
+      response.end(testDocument('source'))
+      return
+    }
     const fileRoot = url.pathname.startsWith('/static/vendor/') ? projectRoot : root
     const file = normalize(join(fileRoot, url.pathname))
     if (!file.startsWith(fileRoot)) {
@@ -190,6 +200,7 @@ for (const viewport of [
         return {
           connectionsTitle: connections.shadowRoot.querySelector('h1')?.textContent?.trim(),
           connectionsHasSource: connections.shadowRoot.textContent?.includes('Orders source') ?? false,
+          connectionsHeaders: Array.from(connections.shadowRoot.querySelectorAll('thead th .entity-list-sort-button > span:first-child')).map((header) => header.textContent?.trim()),
           connectionsHasEntityList: Boolean(connections.shadowRoot.querySelector('.entity-list-items')),
           connectionsHasRecordTable: Boolean(connections.shadowRoot.querySelector('lv-record-table')),
           connectionsFilterOptions: Array.from(connections.shadowRoot.querySelectorAll('.entity-filter option')).map((option) => option.textContent?.trim()),
@@ -201,10 +212,11 @@ for (const viewport of [
       })
       expect(connectionsState).toEqual({
         connectionsTitle: 'Connections',
-        connectionsHasSource: true,
+        connectionsHasSource: false,
+        connectionsHeaders: ['Name', 'Kind / provider', 'Scope', 'Sources', 'Credentials'],
         connectionsHasEntityList: true,
         connectionsHasRecordTable: false,
-        connectionsFilterOptions: ['All', 'Connection', 'Source'],
+        connectionsFilterOptions: [],
         connectionsIconsArePlain: true,
         connectionsIsStyled: true,
         connectionsPageCentered: true,
@@ -727,7 +739,103 @@ test('workspace asset page does not render versions as a product surface', async
   }
 })
 
-function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
+test('connection administration configures missing bindings from a drawer', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
+  try {
+    await page.goto(`${baseURL}/connections`)
+    await page.waitForFunction(() => customElements.get('lv-connection-administration'))
+    await page.evaluate(() => {
+      const root = document.querySelector('lv-connections-page') as any
+      root.addEventListener('lv-connection-administration-save', (event: CustomEvent) => { (window as any).__connectionSave = event.detail })
+    })
+    await page.getByRole('button', { name: 'Configure connection' }).click()
+    const drawer = page.locator('lv-drawer')
+    expect(await drawer.getByText('Edit connection').isVisible()).toBe(false)
+    await drawer.getByLabel('Credential project').fill('leapview')
+    await drawer.getByLabel('Credential environment').fill('production')
+    await drawer.getByLabel('Secret path').fill('/connections/olist')
+    await drawer.getByLabel('Secret key').fill('credentials')
+    await drawer.getByRole('button', { name: 'Configure', exact: true }).click()
+    await page.waitForFunction(() => Boolean((window as any).__connectionSave))
+    const command = await page.evaluate(() => (window as any).__connectionSave)
+    expect(command).toMatchObject({
+      action: 'create',
+      assetId: 'connection:olist',
+      connectorKind: 's3',
+      logicalConnection: 'olist',
+      surface: 'list',
+      credentialProjectId: 'leapview',
+      credentialEnvironment: 'production',
+      secretPath: '/connections/olist',
+      secretKey: 'credentials',
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('connection detail exposes the state-driven primary lifecycle action', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
+  try {
+    await page.goto(`${baseURL}/connection`)
+    await page.waitForFunction(() => customElements.get('lv-connection-administration'))
+    await page.evaluate(() => {
+      const root = document.querySelector('lv-workspace-asset-page') as any
+      root.addEventListener('lv-connection-administration-action', (event: CustomEvent) => { (window as any).__connectionAction = event.detail })
+    })
+    const detail = page.locator('lv-workspace-asset-page').locator('.connection-detail-route .detail-surface')
+    expect(await detail.getByRole('link', { name: 'All connections' }).getAttribute('href')).toBe('/connections')
+    expect(await detail.getByRole('heading', { level: 1 }).textContent()).toBe('Olist connection')
+    expect(await page.locator('lv-workspace-asset-page').locator('.asset-page').count()).toBe(0)
+    expect(await page.getByText('Pending test', { exact: true }).isVisible()).toBe(true)
+    await page.getByRole('button', { name: 'Test connection', exact: true }).click()
+    await page.waitForFunction(() => Boolean((window as any).__connectionAction))
+    expect(await page.evaluate(() => (window as any).__connectionAction)).toMatchObject({
+      action: 'test',
+      assetId: 'connection:olist',
+      logicalConnection: 'olist',
+      surface: 'detail',
+      expectedRevision: 1,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('connection source detail opens as a non-modal drawer over its connection', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
+  try {
+    await page.goto(`${baseURL}/source`)
+    await page.waitForFunction(() => customElements.get('lv-workspace-asset-page') && customElements.get('lv-drawer'))
+    await page.locator('lv-workspace-asset-page').evaluate((element: any) => element.updateComplete)
+    const state = await page.evaluate(async () => {
+      const asset = document.querySelector('lv-workspace-asset-page') as any
+      const drawer = asset.shadowRoot.querySelector('lv-drawer') as any
+      await drawer.updateComplete
+      return {
+        backgroundTitle: asset.shadowRoot.querySelector('.connection-detail-route .detail-header h1')?.textContent?.trim(),
+        drawerTitle: drawer.querySelector('[slot="title"] h1')?.textContent?.trim(),
+        drawerSubtitle: drawer.querySelector('[slot="subtitle"]')?.textContent?.trim(),
+        drawerOpen: drawer.open,
+        drawerModal: drawer.shadowRoot.querySelector('[role="dialog"]')?.getAttribute('aria-modal'),
+        tabs: Array.from(drawer.querySelectorAll('.tabs a')).map((tab) => tab.textContent?.replace(/\s+/g, ' ').trim()),
+        text: drawer.textContent?.replace(/\s+/g, ' ').trim(),
+      }
+    })
+    expect(state.backgroundTitle).toBe('Olist connection')
+    expect(state.drawerTitle).toBe('Orders')
+    expect(state.drawerSubtitle).toBe('Source in Olist connection')
+    expect(state.drawerOpen).toBe(true)
+    expect(state.drawerModal).toBeNull()
+    expect(state.tabs).toEqual(['Details', 'Data', 'Lineage 1'])
+    expect(state.text).toMatch(/Format csv Path orders\.csv Fields 2/)
+    expect(state.text).toMatch(/Fields \(2\).*order_id.*VARCHAR/)
+  } finally {
+    await page.close()
+  }
+})
+
+function testDocument(root: 'workspace' | 'connections' | 'connection' | 'asset' | 'source'): string {
   const assetList = {
     workspaceId: 'leapview',
     searchHref: '/workspaces/leapview',
@@ -771,18 +879,19 @@ function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
   const connectionsPage = {
     kind: 'connections',
     title: 'Connections',
-    description: 'Connection-scoped data assets.',
+    description: 'Data connections.',
     workspaceId: 'leapview',
-    assetList: {
-      ...assetList,
-      searchHref: '/connections',
-      tabs: [
-        { id: '', label: 'All', href: '/connections', active: true },
-        { id: 'connection', label: 'Connection', href: '/connections?type=connection', active: false },
-        { id: 'source', label: 'Source', href: '/connections?type=source', active: false },
-      ],
-      assets: [{ ...assetList.assets[0], title: 'Orders source', type: 'source', typeLabel: 'Source', detailHref: '/connections/connection:olist/sources/source:orders/details' }],
-    },
+    connections: [{
+      id: 'connection:olist',
+      title: 'Olist connection',
+      description: 'Local ecommerce files.',
+      detailHref: '/connections/connection:olist/details',
+      kind: 'local',
+      scope: 'project',
+      sourceCount: 2,
+      credentialStatus: 'Not configured',
+      lifecycle: missingConnectionLifecycle(),
+    }],
   }
   const assetPage = {
     kind: 'workspace_asset',
@@ -843,6 +952,96 @@ function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
       }],
     },
   }
+  const connectionAsset = {
+    id: 'connection:olist',
+    title: 'Olist connection',
+    description: 'Local ecommerce files.',
+    type: 'connection',
+    typeLabel: 'Connection',
+    key: 'olist',
+    detailHref: '/connections/connection:olist/details',
+    openHref: '/connections/connection:olist/details',
+  }
+  const sourceAsset = {
+    id: 'source:orders',
+    title: 'Orders',
+    type: 'source',
+    typeLabel: 'Source',
+    key: 'orders',
+    detailHref: '/connections/connection:olist/sources/source:orders/details',
+    openHref: '/connections/connection:olist/sources/source:orders/details',
+  }
+  const connectionPage = {
+    kind: 'connection_asset',
+    title: 'Olist connection',
+    workspaceId: 'leapview',
+    assetId: connectionAsset.id,
+    activeSection: 'details',
+    asset: connectionAsset,
+    connectionLifecycle: {
+      ...missingConnectionLifecycle(),
+      exists: true,
+      bindingId: 'olist',
+      enabled: true,
+      health: 'pending',
+      revision: 1,
+      state: 'pending',
+      statusLabel: 'Pending test',
+      actions: [
+        { id: 'test', label: 'Test connection', primary: true, destructive: false },
+        { id: 'edit', label: 'Edit', primary: false, destructive: false },
+        { id: 'disable', label: 'Disable', primary: false, destructive: true },
+      ],
+    },
+    breadcrumbs: [{ label: 'Connections', href: '/connections' }, { label: 'Olist connection', current: true }],
+    actions: [],
+    tabs: [
+      { id: 'details', label: 'Details', href: connectionAsset.detailHref, active: true },
+      { id: 'lineage', label: 'Lineage', href: '/connections/connection:olist/lineage', active: false, count: 2 },
+    ],
+    details: {
+      overview: [{ label: 'Kind', value: 'local' }, { label: 'Sources', value: '2' }],
+      sections: [{
+        title: 'Sources (2)',
+        table: {
+          columns: [{ id: 'source', header: 'Source' }, { id: 'format', header: 'Format' }, { id: 'path', header: 'Path' }],
+          rows: [{ source: 'Orders', format: 'csv', path: 'orders.csv' }],
+          empty: 'No sources.',
+        },
+      }],
+    },
+  }
+  const sourcePage = {
+    kind: 'connection_asset',
+    title: 'Orders',
+    workspaceId: 'leapview',
+    assetId: sourceAsset.id,
+    activeSection: 'details',
+    asset: sourceAsset,
+    drawerParent: connectionPage,
+    breadcrumbs: [],
+    actions: [],
+    tabs: [
+      { id: 'details', label: 'Details', href: sourceAsset.detailHref, active: true },
+      { id: 'data', label: 'Data', href: '/data?workspace=leapview&object=source%3Aorders', active: false },
+      { id: 'lineage', label: 'Lineage', href: '/connections/connection:olist/sources/source:orders/lineage', active: false, count: 1 },
+    ],
+    details: {
+      overview: [
+        { label: 'Format', value: 'csv' },
+        { label: 'Path', value: 'orders.csv', code: true },
+        { label: 'Fields', value: '2' },
+      ],
+      sections: [{
+        title: 'Fields (2)',
+        table: {
+          columns: [{ id: 'name', header: 'Name' }, { id: 'physical_type', header: 'Physical type' }],
+          rows: [{ name: 'order_id', physical_type: 'VARCHAR' }],
+          empty: 'No fields.',
+        },
+      }],
+    },
+  }
   const access = {
     workspace: { ID: 'leapview', Title: 'LeapView Workspace' },
     roles: [{ Name: 'viewer' }, { Name: 'workspace_admin' }, { Name: 'data_deployer' }],
@@ -874,8 +1073,16 @@ function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
     search: 'ana',
     searchStatus: { loading: false, error: '' },
   }
+  const connectionAdmin = {
+    command: { action: '', assetId: '', authenticationMode: '', confirmationToken: '', connectorKind: '', credentialEnvironment: '', credentialProjectId: '', database: '', expectedRevision: 0, host: '', logicalConnection: '', objectScope: '', options: '', port: '', secretKey: '', secretPath: '', sourceIdentity: '', surface: '', tlsMode: '' },
+    status: { loading: false, error: '', message: '' },
+  }
   const route = root === 'connections'
-    ? { signals: { page: connectionsPage }, element: '<lv-connections-page></lv-connections-page>' }
+    ? { signals: { page: connectionsPage, connectionAdmin }, element: '<lv-connections-page></lv-connections-page>' }
+    : root === 'connection'
+      ? { signals: { page: connectionPage, connectionAdmin }, element: '<lv-workspace-asset-page></lv-workspace-asset-page>' }
+    : root === 'source'
+      ? { signals: { page: sourcePage }, element: '<lv-workspace-asset-page></lv-workspace-asset-page>' }
     : root === 'asset'
       ? { signals: { page: assetPage }, element: '<lv-workspace-asset-page></lv-workspace-asset-page>' }
       : { signals: { page: workspacePage, workspaceAccess: access }, element: '<lv-workspace-page></lv-workspace-page>' }
@@ -899,6 +1106,40 @@ function testDocument(root: 'workspace' | 'connections' | 'asset'): string {
       </body>
     </html>
   `
+}
+
+function missingConnectionLifecycle() {
+  return {
+    actions: [{ id: 'configure', label: 'Configure', primary: true, destructive: false }],
+    assetId: 'connection:olist',
+    authenticationMode: '',
+    bindingId: '',
+    canManage: true,
+    canTest: true,
+    connectorKind: 's3',
+    credentialEnvironment: '',
+    credentialProjectId: '',
+    database: '',
+    diagnosticCode: '',
+    enabled: false,
+    exists: false,
+    health: '',
+    host: '',
+    lastValidatedAt: '',
+    logicalConnection: 'olist',
+    objectScope: '',
+    options: '',
+    port: '',
+    revision: 0,
+    secretKey: '',
+    secretPath: '',
+    sourceIdentity: '',
+    state: 'missing',
+    statusLabel: 'Not configured',
+    tlsMode: '',
+    tone: 'warning',
+    validatedVersion: '',
+  }
 }
 
 function escapeHTML(value: string): string {

--- a/web/components/workspace/workspace-page.ts
+++ b/web/components/workspace/workspace-page.ts
@@ -26,6 +26,7 @@ import {
   type IconNode,
 } from 'lucide'
 import type {
+  ConnectionAdministrationSignal,
   ConnectionsPageSignal,
   DefinitionFactSignal,
   RecordTableSignal,
@@ -37,6 +38,7 @@ import type {
   WorkspaceTabSignal,
 } from '../../generated/signals'
 import { DatastarLit } from '../shared/datastar-lit'
+import { entityDetailStyles, renderEntityDetail } from '../shared/entity-detail'
 import { checkSignalContract } from '../shared/signal-contract'
 import { lucideIcon } from '../shared/lucide-icons'
 import { pageHeaderStyles, renderPageHeader } from '../shared/page-header'
@@ -44,7 +46,9 @@ import '../shared/entity-list'
 import '../shared/loading-spinner'
 import '../shared/record-table'
 import '../shared/code-block'
+import '../shared/drawer'
 import '../shared/workspace-access-control'
+import './connection-administration'
 
 const emptyWorkspaceAccess: WorkspaceAccessSignal = {
   workspace: {},
@@ -56,6 +60,14 @@ const emptyWorkspaceAccess: WorkspaceAccessSignal = {
   command: { bindingId: '', email: '', principalId: '', privilege: '', role: '', subjectId: '', subjectType: '', subjects: [] },
   search: '',
   searchStatus: { loading: false, error: '' },
+}
+
+const emptyConnectionAdministration: ConnectionAdministrationSignal = {
+  command: {
+    action: '', assetId: '', authenticationMode: '', confirmationToken: '', connectorKind: '', credentialEnvironment: '', credentialProjectId: '', database: '', expectedRevision: 0,
+    host: '', logicalConnection: '', objectScope: '', options: '', port: '', secretKey: '', secretPath: '', sourceIdentity: '', surface: '', tlsMode: '',
+  },
+  status: { error: '', loading: false, message: '' },
 }
 
 class LeapViewWorkspacePage extends DatastarLit(LitElement) {
@@ -179,43 +191,56 @@ class LeapViewConnectionsPage extends DatastarLit(LitElement) {
   }
 
   updated(): void {
-    checkSignalContract('connections page', this.page, { kind: 'required', title: 'required', assetList: 'required' })
+    checkSignalContract('connections page', this.page, { kind: 'required', title: 'required', connections: 'required' })
   }
 
   get page(): ConnectionsPageSignal | null {
     return this.signal<ConnectionsPageSignal | null>('page', null)
   }
 
+  get connectionAdmin(): ConnectionAdministrationSignal {
+    return this.signal<ConnectionAdministrationSignal>('connectionAdmin', emptyConnectionAdministration)
+  }
+
   render() {
     const page = this.page
     if (!page) return html`<slot></slot>`
-    const assetList = page.assetList
     return html`
-      <section class="page" aria-label="Connections and sources">
-        ${renderPageHeader(page.title)}
+      <section class="page" aria-label="Connections">
+        ${renderPageHeader(page.title, page.description ?? '', '', html`
+          <lv-connection-administration
+            surface="list"
+            environment=${page.environment ?? ''}
+            .lifecycles=${page.connections.map((connection) => connection.lifecycle)}
+            .administration=${this.connectionAdmin}
+          ></lv-connection-administration>
+        `)}
         <lv-entity-list
-          .items=${(assetList?.assets ?? []).map((asset) => ({
-            id: asset.id,
-            title: asset.title,
-            href: asset.detailHref,
-            icon: asset.type,
+          .items=${page.connections.map((connection) => ({
+            id: connection.id,
+            title: connection.title,
+            description: connection.description,
+            href: connection.detailHref,
+            icon: 'connection',
             iconTreatment: 'plain' as const,
-            category: asset.type,
             columns: {
-              type: asset.typeLabel,
-              key: asset.key,
+              kind: connection.kind,
+              scope: connection.scope,
+              sources: connection.sourceCount,
+              credentials: connection.credentialStatus,
             },
           }))}
           .columns=${[
-            { id: 'name', label: 'Name', width: '54%' },
-            { id: 'type', label: 'Type', width: '20%' },
-            { id: 'key', label: 'Key', width: '26%' },
+            { id: 'name', label: 'Name', width: '32%' },
+            { id: 'kind', label: 'Kind / provider', width: '18%' },
+            { id: 'scope', label: 'Scope', width: '16%' },
+            { id: 'sources', label: 'Sources', width: '12%', align: 'right' },
+            { id: 'credentials', label: 'Credentials', width: '22%' },
           ]}
-          .filters=${(assetList?.tabs ?? []).map((tab) => ({ id: tab.id || 'all', label: tab.label, href: tab.href }))}
-          active-filter=${assetList?.activeType || 'all'}
-          initial-query=${assetList?.query ?? ''}
-          search-placeholder="Search connections and sources"
-          empty-text=${assetList?.empty ?? 'No connection assets match this view.'}
+          .filters=${[]}
+          initial-query=${page.query ?? ''}
+          search-placeholder="Search connections"
+          empty-text="No connections match this search."
         ></lv-entity-list>
       </section>
     `
@@ -224,7 +249,7 @@ class LeapViewConnectionsPage extends DatastarLit(LitElement) {
 
 class LeapViewWorkspaceAssetPage extends DatastarLit(LitElement) {
   static get styles() {
-    return workspaceStyles
+    return [entityDetailStyles, workspaceStyles]
   }
 
   updated(): void {
@@ -235,9 +260,93 @@ class LeapViewWorkspaceAssetPage extends DatastarLit(LitElement) {
     return this.signal<WorkspaceAssetPageSignal | null>('page', null)
   }
 
+  get connectionAdmin(): ConnectionAdministrationSignal {
+    return this.signal<ConnectionAdministrationSignal>('connectionAdmin', emptyConnectionAdministration)
+  }
+
   render() {
     const page = this.page
     if (!page) return html`<slot></slot>`
+    if (page.drawerParent) return this.renderDrawerPage(page)
+    if (page.asset.type === 'connection') return this.renderConnectionPage(page)
+    return this.renderAssetPage(page)
+  }
+
+  private renderDrawerPage(page: WorkspaceAssetPageSignal) {
+    const parent = page.drawerParent!
+    return html`
+      <div class="drawer-page">
+        ${parent.asset.type === 'connection' ? this.renderConnectionPage(parent) : this.renderAssetPage(parent)}
+        <lv-drawer
+          open
+          size="wide"
+          label=${`${page.title} source details`}
+          .modal=${false}
+          @lv-drawer-close=${() => window.location.assign(parent.asset.detailHref)}
+        >
+          <div slot="title" class="source-drawer-title">
+            ${assetTypeGlyph(page.asset.type, 'inline')}
+            <h1>${page.title}</h1>
+          </div>
+          <p slot="subtitle" class="source-drawer-subtitle">Source in ${parent.title}</p>
+          <div class="source-drawer-body">
+            ${renderTabs(page.tabs)}
+            <div class=${page.activeSection === 'lineage' ? 'source-drawer-section lineage-body' : 'source-drawer-section'}>
+              ${this.renderSection(page)}
+            </div>
+          </div>
+        </lv-drawer>
+      </div>
+    `
+  }
+
+  private renderConnectionPage(page: WorkspaceAssetPageSignal) {
+    const lifecycle = page.connectionLifecycle
+    const administration = this.connectionAdmin
+    const feedback = administration.status.error
+      ? html`<div class="connection-feedback error" role="alert">${administration.status.error}</div>`
+      : administration.status.message
+        ? html`<div class="connection-feedback success" role="status">${administration.status.message}</div>`
+        : nothing
+    const actions = lifecycle ? html`
+      <lv-connection-administration
+        surface="detail"
+        environment=${page.environment ?? ''}
+        .lifecycles=${[lifecycle]}
+        .administration=${administration}
+      ></lv-connection-administration>
+    ` : nothing
+    const details = page.activeSection === 'lineage'
+      ? this.renderLineage(page)
+      : html`
+          ${renderFacts('Overview', page.details?.overview ?? [], true)}
+          ${(page.details?.sections ?? []).map(renderDetailSection)}
+        `
+    return html`
+      <div class="connection-detail-route">
+        ${renderEntityDetail({
+          label: 'Connection administration',
+          feedback,
+          backHref: '/connections',
+          backLabel: 'All connections',
+          avatar: lucideIcon(Plug, { size: 28, strokeWidth: 1.75 }),
+          title: page.title,
+          subtitle: page.asset.description || 'Connection used by published sources.',
+          badges: html`
+            <span class="badge">${lifecycle?.connectorKind || page.asset.typeLabel}</span>
+            ${lifecycle?.objectScope ? html`<span class="badge">${lifecycle.objectScope}</span>` : nothing}
+          `,
+          actions,
+          sections: html`
+            <div class="connection-detail-tabs">${renderTabs(page.tabs, 'Connection sections')}</div>
+            ${details}
+          `,
+        })}
+      </div>
+    `
+  }
+
+  private renderAssetPage(page: WorkspaceAssetPageSignal) {
     return html`
       <section class="asset-page" aria-label="Workspace asset detail">
         <header class="breadcrumb-header">
@@ -253,21 +362,33 @@ class LeapViewWorkspaceAssetPage extends DatastarLit(LitElement) {
             </ol>
           </nav>
           <div class="actions">
+            ${page.connectionLifecycle ? html`
+              <lv-connection-administration
+                surface="detail"
+                environment=${page.environment ?? ''}
+                .lifecycles=${[page.connectionLifecycle]}
+                .administration=${this.connectionAdmin}
+              ></lv-connection-administration>
+            ` : nothing}
             ${page.actions?.map((action) => this.renderAction(action, page))}
           </div>
         </header>
         <div class="asset-body">
           ${renderTabs(page.tabs)}
           <div class=${page.activeSection === 'lineage' ? 'section-body lineage-body' : page.activeSection === 'details' && page.details?.semanticModelGraph ? 'section-body graph-details-body' : 'section-body'}>
-            ${page.activeSection === 'lineage'
-              ? this.renderLineage(page)
-              : page.activeSection === 'refreshes'
-                ? this.renderRefreshes(page)
-                : this.renderDetails(page)}
+            ${this.renderSection(page)}
           </div>
         </div>
       </section>
     `
+  }
+
+  private renderSection(page: WorkspaceAssetPageSignal) {
+    return page.activeSection === 'lineage'
+      ? this.renderLineage(page)
+      : page.activeSection === 'refreshes'
+        ? this.renderRefreshes(page)
+        : this.renderDetails(page)
   }
 
   private renderAction(action: NonNullable<WorkspaceAssetPageSignal['actions']>[number], page: WorkspaceAssetPageSignal) {
@@ -402,10 +523,10 @@ function renderAssetTable(assets: WorkspaceAssetSummarySignal[], empty: string) 
   `
 }
 
-function renderTabs(tabs: WorkspaceTabSignal[]) {
+function renderTabs(tabs: WorkspaceTabSignal[], label = 'Asset sections') {
   if (!tabs.length) return nothing
   return html`
-    <nav class="tabs" aria-label="Asset sections">
+    <nav class="tabs" aria-label=${label}>
       ${tabs.map((tab) => html`
         <a class=${tab.active ? 'active' : ''} href=${tab.href} aria-current=${tab.active ? 'page' : nothing}>
           <span>${tab.label}</span>
@@ -586,6 +707,58 @@ const workspaceStyles = css`
     margin-inline: 0;
     padding: 0;
     overflow: visible;
+  }
+
+  .connection-detail-route {
+    width: min(calc(100% - var(--base-size-48)), var(--lv-workspace-detail-max-width));
+    min-width: 0;
+    min-height: 100svh;
+    box-sizing: border-box;
+    margin-inline: auto;
+    padding-block: var(--base-size-24);
+  }
+
+  .connection-detail-route .muted {
+    margin: 0;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  .connection-detail-route .detail-section {
+    gap: var(--base-size-16);
+    border-top: var(--lv-border-muted);
+    border-bottom: 0;
+    padding: var(--base-size-24) 0;
+  }
+
+  .connection-detail-route .facts,
+  .connection-detail-route .facts.overview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--base-size-16) var(--base-size-48);
+  }
+
+  .connection-detail-tabs {
+    padding-top: var(--base-size-8);
+  }
+
+  .connection-feedback {
+    margin-bottom: var(--base-size-16);
+    border: var(--lv-border-muted);
+    border-radius: var(--lv-radius-default);
+    background: var(--lv-bg-panel-muted);
+    padding: var(--base-size-12) var(--base-size-16);
+    font: var(--lv-type-body-compact);
+  }
+
+  .connection-feedback.error {
+    border-color: var(--lv-line-danger-muted);
+    color: var(--lv-fg-danger);
+  }
+
+  .connection-feedback.success {
+    border-color: var(--lv-line-success-muted);
+    color: var(--lv-fg-success);
   }
 
   .catalog {
@@ -1028,6 +1201,51 @@ const workspaceStyles = css`
     padding: var(--base-size-16);
   }
 
+  .drawer-page {
+    min-height: 100svh;
+  }
+
+  .source-drawer-title {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: var(--base-size-8);
+  }
+
+  .source-drawer-title h1 {
+    font: var(--lv-type-section-title);
+  }
+
+  .source-drawer-subtitle {
+    margin-top: var(--base-size-4);
+    color: var(--lv-fg-muted);
+    font: var(--lv-type-body-compact);
+  }
+
+  .source-drawer-body {
+    display: grid;
+    min-width: 0;
+    align-content: start;
+  }
+
+  .source-drawer-section {
+    min-width: 0;
+    padding-top: var(--base-size-16);
+  }
+
+  .source-drawer-section.lineage-body {
+    margin-inline: calc(-1 * var(--base-size-20));
+    padding-top: 0;
+  }
+
+  .source-drawer-section .details-content {
+    padding-inline: 0;
+  }
+
+  .source-drawer-section .lineage-graph {
+    height: 20rem;
+  }
+
   .lineage {
     display: grid;
     min-height: 0;
@@ -1145,6 +1363,16 @@ const workspaceStyles = css`
       height: auto;
       min-height: 100svh;
       overflow: visible;
+    }
+
+    .connection-detail-route {
+      width: 100%;
+      padding: var(--base-size-16);
+    }
+
+    .connection-detail-route .facts,
+    .connection-detail-route .facts.overview {
+      grid-template-columns: minmax(0, 1fr);
     }
 
     .section-body {


### PR DESCRIPTION
## Summary

- replace the mixed connections/sources list with a dedicated connection inventory showing provider, scope, source count, and credential state
- add state-driven connection configuration, testing, credential refresh, enable, disable, and update commands backed by the analytics administration contract
- render connection details with the shared entity detail layout and open source details in a non-modal drawer
- restore administration chrome during connection SSE bootstrap and remove the redundant lineage inspector panel across lineage graphs
- update generated UI and OpenAPI contracts plus route, lifecycle, authorization, and DOM coverage

## Validation

- task ci