### PR TITLE
Split app navigation into Insights and Develop

### DIFF
--- a/api/signals/main.tsp
+++ b/api/signals/main.tsp
@@ -1695,6 +1695,15 @@ model SidebarActionSignal {
 
 @apigen.contract(#{ kind: "ui-signal", tags: #["shared", "signal"] })
 @apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "shared" })
+model SidebarAreaSignal {
+  `href`: string;
+  `icon`: string;
+  `id`: string;
+  `label`: string;
+}
+
+@apigen.contract(#{ kind: "ui-signal", tags: #["shared", "signal"] })
+@apigen.`metadata`(#{ `x-leapview-contract-role`: "signal", `x-leapview-surface`: "shared" })
 model SidebarGroupSignal {
   `items`: SidebarItemSignal[];
   `label`: string;
@@ -1734,6 +1743,8 @@ model SidebarItemSignal {
 model SidebarSignal {
   `active`: string;
   `admin`?: boolean;
+  `area`?: string;
+  `areas`?: SidebarAreaSignal[];
   `compact`: boolean;
   `dashboardId`?: string;
   `dashboardTitle`: string;
@@ -1748,6 +1759,7 @@ model SidebarSignal {
   `userAvatarUrl`?: string;
   `userName`?: string;
   `userRole`?: string;
+  `userSettingsHref`: string;
   `workspaceTitle`: string;
 }
 

--- a/internal/app/agent_ui_adapters.go
+++ b/internal/app/agent_ui_adapters.go
@@ -43,7 +43,7 @@ func applicationLayout(access *accessmodule.Module, agent *agentmodule.Module, p
 			config.AdminAccess = &appshell.AdminNavigationAccess{
 				ManagePlatform: privileges.ManagePlatform, ManageGrants: privileges.ManageGrants,
 				ManageWorkspace: privileges.ManageWorkspace, ManagePublications: privileges.ManagePublications,
-				ViewAudit: privileges.ViewAudit, ViewConnections: privileges.ViewConnections,
+				ViewAudit: privileges.ViewAudit,
 			}
 		}
 	}
@@ -75,7 +75,7 @@ func adminLayoutRequest(r *http.Request) bool {
 		return false
 	}
 	path := strings.TrimSpace(r.URL.Path)
-	return strings.HasPrefix(path, "/admin") || path == "/connections" || strings.HasPrefix(path, "/connections/") ||
+	return strings.HasPrefix(path, "/admin") ||
 		(path == "/updates" && strings.TrimSpace(r.URL.Query().Get("route")) == routeAdmin)
 }
 

--- a/internal/app/agent_ui_adapters_test.go
+++ b/internal/app/agent_ui_adapters_test.go
@@ -32,8 +32,8 @@ func TestApplicationLayoutUsesCurrentPrincipalIdentity(t *testing.T) {
 func TestAdminLayoutRequestRecognizesDocumentsAndAdminStreams(t *testing.T) {
 	tests := map[string]bool{
 		"/admin/profile":                     true,
-		"/connections":                       true,
-		"/connections/warehouse":             true,
+		"/connections":                       false,
+		"/connections/warehouse":             false,
 		"/updates?route=admin&section=audit": true,
 		"/workspaces":                        false,
 		"/updates?route=workspace":           false,

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -860,8 +860,8 @@ func TestAPIGenOwnsUISignalContracts(t *testing.T) {
 	if irDoc.SchemaVersion != "v4" {
 		t.Fatalf("UI signal IR schema_version = %q, want v4", irDoc.SchemaVersion)
 	}
-	if len(irDoc.Contracts) != 120 {
-		t.Fatalf("UI signal IR contracts = %d, want 120", len(irDoc.Contracts))
+	if len(irDoc.Contracts) != 121 {
+		t.Fatalf("UI signal IR contracts = %d, want 121", len(irDoc.Contracts))
 	}
 	foundEnvelopeMetadata := false
 	foundImportedVisualizationRoot := false

--- a/internal/app/deployment_candidates_test.go
+++ b/internal/app/deployment_candidates_test.go
@@ -644,7 +644,7 @@ func TestWorkspaceListUsesActiveDeploymentCatalogMetadata(t *testing.T) {
 	}
 }
 
-func TestWorkspaceListPageDoesNotRenderWorkspaceScopedChat(t *testing.T) {
+func TestWorkspaceListPageUsesDevelopNavigationWithoutChat(t *testing.T) {
 	t.Setenv("LEAPVIEW_DEV_AUTH_BYPASS", "1")
 	store := testStore(t)
 	seedActiveDeployment(t, store, "test")
@@ -665,8 +665,18 @@ func TestWorkspaceListPageDoesNotRenderWorkspaceScopedChat(t *testing.T) {
 			t.Fatalf("workspace list rendered workspace-scoped chat %q:\n%s", notWant, rec.Body.String())
 		}
 	}
-	if !strings.Contains(rendered, `"id":"chat"`) || !strings.Contains(rendered, `"href":"/chats"`) {
-		t.Fatalf("workspace list did not render global chat navigation:\n%s", rec.Body.String())
+	for _, notWant := range []string{`"id":"chat"`, `"href":"/chats"`, `"history":`, `"primaryAction":`} {
+		if strings.Contains(rendered, notWant) {
+			t.Fatalf("workspace list rendered Insights navigation %q:\n%s", notWant, rec.Body.String())
+		}
+	}
+	for _, want := range []string{`"area":"develop"`, `"label":"Develop"`, `"id":"workspaces"`, `"id":"pipelines"`, `"id":"connections"`} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("workspace list did not render Develop navigation %q:\n%s", want, rec.Body.String())
+		}
+	}
+	if strings.Contains(rendered, `"id":"data"`) {
+		t.Fatalf("workspace list rendered Insights Explore navigation:\n%s", rec.Body.String())
 	}
 	if !strings.Contains(rendered, `"workspaceTitle":"LeapView"`) {
 		t.Fatalf("workspace list did not render global app chrome:\n%s", rec.Body.String())

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -817,12 +817,12 @@ func TestHomeRouteRendersDashboardCatalog(t *testing.T) {
 	if !strings.Contains(rendered, `"href":"/workspaces/test-workspace/dashboards/executive-sales"`) {
 		t.Fatalf("home missing dashboard link:\n%s", body)
 	}
-	for _, want := range []string{`Dashboards`, `/`, `Workspaces`, `/workspaces`, `Data`, `/data`, `Admin`, `/admin`} {
+	for _, want := range []string{`Dashboards`, `"id":"data"`, `"label":"Explore"`, `"href":"/data"`, `"label":"Insights"`, `"label":"Develop"`, `"href":"/workspaces"`, `"userSettingsHref":"/admin/profile"`} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("home sidebar missing %q:\n%s", want, body)
 		}
 	}
-	for _, notWant := range []string{`Connections`, `/connections`, `Metric Views`, `/metrics`, `Semantic Models`, `/models`, `Settings`, `/workspaces/test-workspace/permissions`, `/workspaces/test-workspace/chat`} {
+	for _, notWant := range []string{`"id":"workspaces"`, `"id":"pipelines"`, `"id":"connections"`, `"id":"admin"`, `Metric Views`, `/metrics`, `Semantic Models`, `/models`, `/workspaces/test-workspace/permissions`, `/workspaces/test-workspace/chat`} {
 		if strings.Contains(rendered, notWant) {
 			t.Fatalf("home sidebar rendered removed navigation %q:\n%s", notWant, body)
 		}

--- a/internal/app/shell/shell.go
+++ b/internal/app/shell/shell.go
@@ -37,7 +37,6 @@ type AdminNavigationAccess struct {
 	ManageWorkspace    bool
 	ManagePublications bool
 	ViewAudit          bool
-	ViewConnections    bool
 }
 
 type Chrome struct {
@@ -45,23 +44,33 @@ type Chrome struct {
 }
 
 type Sidebar struct {
-	Active         string   `json:"active"`
-	Admin          bool     `json:"admin,omitempty"`
-	Compact        bool     `json:"compact"`
-	DashboardID    *string  `json:"dashboardId,omitempty"`
-	DashboardTitle string   `json:"dashboardTitle"`
-	Groups         []Group  `json:"groups"`
-	History        *History `json:"history,omitempty"`
-	ModelID        *string  `json:"modelId,omitempty"`
-	ModelTitle     *string  `json:"modelTitle,omitempty"`
-	PageTitle      string   `json:"pageTitle"`
-	PrimaryAction  *Action  `json:"primaryAction,omitempty"`
-	ProductLogoURL *string  `json:"productLogoUrl,omitempty"`
-	ProductName    string   `json:"productName"`
-	UserAvatarURL  *string  `json:"userAvatarUrl,omitempty"`
-	UserName       *string  `json:"userName,omitempty"`
-	UserRole       *string  `json:"userRole,omitempty"`
-	WorkspaceTitle string   `json:"workspaceTitle"`
+	Active           string   `json:"active"`
+	Admin            bool     `json:"admin,omitempty"`
+	Area             string   `json:"area,omitempty"`
+	Areas            []Area   `json:"areas,omitempty"`
+	Compact          bool     `json:"compact"`
+	DashboardID      *string  `json:"dashboardId,omitempty"`
+	DashboardTitle   string   `json:"dashboardTitle"`
+	Groups           []Group  `json:"groups"`
+	History          *History `json:"history,omitempty"`
+	ModelID          *string  `json:"modelId,omitempty"`
+	ModelTitle       *string  `json:"modelTitle,omitempty"`
+	PageTitle        string   `json:"pageTitle"`
+	PrimaryAction    *Action  `json:"primaryAction,omitempty"`
+	ProductLogoURL   *string  `json:"productLogoUrl,omitempty"`
+	ProductName      string   `json:"productName"`
+	UserAvatarURL    *string  `json:"userAvatarUrl,omitempty"`
+	UserName         *string  `json:"userName,omitempty"`
+	UserRole         *string  `json:"userRole,omitempty"`
+	UserSettingsHref string   `json:"userSettingsHref"`
+	WorkspaceTitle   string   `json:"workspaceTitle"`
+}
+
+type Area struct {
+	Href  string `json:"href"`
+	Icon  string `json:"icon"`
+	ID    string `json:"id"`
+	Label string `json:"label"`
 }
 
 type Action struct {
@@ -100,27 +109,32 @@ type HistoryItem struct {
 
 func Provider(config Config) webpage.Provider {
 	return func(context webpage.Context) webpage.Layout {
-		isAdmin := context.Active == "admin" || context.Active == "connections"
-		navigation := []Group{{Label: "Navigation", Items: globalNavigation()}}
+		isAdmin := context.Active == "admin"
+		area := areaForActive(context.Active)
+		navigation := areaNavigation(area)
 		if isAdmin {
 			navigation = adminNavigation(config.AdminAccess)
+			area = ""
 		}
 		sidebarActive := context.Active
 		if isAdmin {
 			sidebarActive = firstNonEmpty(context.PageID, context.Active)
 		}
 		sidebar := Sidebar{
-			Active: sidebarActive, Admin: isAdmin, Compact: context.Compact,
+			Active: sidebarActive, Admin: isAdmin, Area: area, Compact: context.Compact,
 			DashboardID: optional(context.SectionID), DashboardTitle: context.SectionTitle,
 			ModelID: optional(context.RelatedID), ModelTitle: optional(context.RelatedTitle),
 			PageTitle: context.PageTitle, ProductLogoURL: optional(config.ProductLogoURL), ProductName: firstNonEmpty(config.Presentation.ProductName, "LeapView"),
 			UserAvatarURL: optional(config.UserAvatarURL), UserName: optional(config.UserName), UserRole: optional(config.RoleLabel),
-			WorkspaceTitle: firstNonEmpty(context.ScopeTitle, context.ScopeID, config.Presentation.ProductName),
-			Groups:         navigation,
+			UserSettingsHref: "/admin/profile", WorkspaceTitle: firstNonEmpty(context.ScopeTitle, context.ScopeID, config.Presentation.ProductName),
+			Groups: navigation,
 		}
 		if isAdmin {
 			sidebar.PrimaryAction = &Action{Label: "Back to app", Href: "/", Icon: "back"}
 		} else {
+			sidebar.Areas = productAreas()
+		}
+		if area == "insights" {
 			sidebar.PrimaryAction = &Action{Label: "New chat", Href: "/chats/new", Icon: "plus"}
 			sidebar.History = &History{
 				Label: "Chats", EmptyText: optional("No chats yet."),
@@ -140,21 +154,52 @@ func Provider(config Config) webpage.Provider {
 	}
 }
 
-func globalNavigation() []Item {
+func productAreas() []Area {
+	return []Area{
+		{ID: "insights", Label: "Insights", Href: "/", Icon: "insights"},
+		{ID: "develop", Label: "Develop", Href: "/workspaces", Icon: "code"},
+	}
+}
+
+func areaForActive(active string) string {
+	switch strings.TrimSpace(active) {
+	case "workspaces", "connections", "pipelines", "develop":
+		return "develop"
+	default:
+		return "insights"
+	}
+}
+
+func areaNavigation(area string) []Group {
+	items := insightsNavigation()
+	label := "Insights"
+	if area == "develop" {
+		items = developNavigation()
+		label = "Develop"
+	}
+	return []Group{{Label: label, Items: items}}
+}
+
+func insightsNavigation() []Item {
 	return []Item{
 		{ID: "dashboards", Label: "Dashboards", Href: "/", Icon: "dashboard", Meta: optional("Reports")},
-		{ID: "pipelines", Label: "Pipelines", Href: "/pipelines", Icon: "workflow", Meta: optional("Refresh monitoring")},
+		{ID: "data", Label: "Explore", Href: "/data", Icon: "cache", Meta: optional("Ad hoc analysis")},
 		{ID: "chat", Label: "Chats", Href: "/chats", Icon: "chat", Meta: optional("Agent interface")},
+	}
+}
+
+func developNavigation() []Item {
+	return []Item{
 		{ID: "workspaces", Label: "Workspaces", Href: "/workspaces", Icon: "catalog", Meta: optional("Published assets")},
-		{ID: "data", Label: "Data", Href: "/data", Icon: "cache", Meta: optional("Inspect rows")},
-		{ID: "admin", Label: "Admin", Href: "/admin/profile", Icon: "settings", Meta: optional("Product administration")},
+		{ID: "pipelines", Label: "Pipelines", Href: "/pipelines", Icon: "workflow", Meta: optional("Refresh monitoring")},
+		{ID: "connections", Label: "Connections", Href: "/connections", Icon: "data", Meta: optional("Data sources")},
 	}
 }
 
 func adminNavigation(access *AdminNavigationAccess) []Group {
 	allowed := AdminNavigationAccess{
 		ManagePlatform: true, ManageGrants: true, ManageWorkspace: true,
-		ManagePublications: true, ViewAudit: true, ViewConnections: true,
+		ManagePublications: true, ViewAudit: true,
 	}
 	if access != nil {
 		allowed = *access
@@ -187,7 +232,6 @@ func adminNavigation(access *AdminNavigationAccess) []Group {
 		{
 			Label: "Data & sharing",
 			Items: filterItems([]conditionalItem{
-				{allowed: allowed.ViewConnections, item: Item{ID: "connections", Label: "Connections", Href: "/connections", Icon: "data"}},
 				{allowed: allowed.ManagePlatform, item: Item{ID: "storage", Label: "Storage", Href: "/admin/storage", Icon: "database"}},
 				{allowed: allowed.ManagePublications, item: Item{ID: "publications", Label: "Publications", Href: "/admin/publications", Icon: "globe"}},
 			}),

--- a/internal/app/shell/shell_test.go
+++ b/internal/app/shell/shell_test.go
@@ -6,7 +6,7 @@ import (
 	webpage "github.com/flidai/leapview/internal/platform/web/page"
 )
 
-func TestProviderOwnsGlobalNavigationAndAgentHistory(t *testing.T) {
+func TestProviderOwnsInsightsNavigationAndAgentHistory(t *testing.T) {
 	provider := Provider(Config{
 		Presentation: webpage.Presentation{ProductName: "LeapView"},
 		RoleLabel:    "Owner", UserName: "Ada Lovelace", UserAvatarURL: "/profile/avatars/ada/avatar-digest",
@@ -18,8 +18,20 @@ func TestProviderOwnsGlobalNavigationAndAgentHistory(t *testing.T) {
 	if !ok {
 		t.Fatalf("signal = %T, want shell.Chrome", layout.Signal)
 	}
-	if len(chrome.Sidebar.Groups) != 1 || len(chrome.Sidebar.Groups[0].Items) != 6 {
+	if chrome.Sidebar.Area != "insights" || len(chrome.Sidebar.Areas) != 2 {
+		t.Fatalf("areas = %q %#v, want insights with two available areas", chrome.Sidebar.Area, chrome.Sidebar.Areas)
+	}
+	if chrome.Sidebar.Areas[0].ID != "insights" || chrome.Sidebar.Areas[0].Icon != "insights" {
+		t.Fatalf("insights area = %#v, want a distinct insights icon", chrome.Sidebar.Areas[0])
+	}
+	if chrome.Sidebar.UserSettingsHref != "/admin/profile" {
+		t.Fatalf("user settings href = %q, want /admin/profile", chrome.Sidebar.UserSettingsHref)
+	}
+	if len(chrome.Sidebar.Groups) != 1 || len(chrome.Sidebar.Groups[0].Items) != 3 {
 		t.Fatalf("navigation = %#v", chrome.Sidebar.Groups)
+	}
+	if chrome.Sidebar.Groups[0].Items[0].ID != "dashboards" || chrome.Sidebar.Groups[0].Items[1].ID != "data" || chrome.Sidebar.Groups[0].Items[1].Label != "Explore" || chrome.Sidebar.Groups[0].Items[2].ID != "chat" {
+		t.Fatalf("insights navigation = %#v", chrome.Sidebar.Groups)
 	}
 	if chrome.Sidebar.UserName == nil || *chrome.Sidebar.UserName != "Ada Lovelace" {
 		t.Fatalf("sidebar user name = %v, want Ada Lovelace", chrome.Sidebar.UserName)
@@ -35,17 +47,56 @@ func TestProviderOwnsGlobalNavigationAndAgentHistory(t *testing.T) {
 	}
 }
 
-func TestGlobalNavigationIncludesInstancePipelines(t *testing.T) {
-	items := globalNavigation()
-	for _, item := range items {
-		if item.ID == "pipelines" {
-			if item.Href != "/pipelines" || item.Label != "Pipelines" || item.Icon != "workflow" {
-				t.Fatalf("pipelines navigation = %#v", item)
+func TestProviderUsesDevelopNavigationForTechnicalRoutes(t *testing.T) {
+	provider := Provider(Config{Presentation: webpage.Presentation{ProductName: "LeapView"}})
+	for _, active := range []string{"workspaces", "connections", "pipelines"} {
+		t.Run(active, func(t *testing.T) {
+			layout := provider(webpage.Context{Active: active})
+			chrome := layout.Signal.(Chrome)
+			if chrome.Sidebar.Area != "develop" || chrome.Sidebar.Admin {
+				t.Fatalf("sidebar = %#v, want develop area", chrome.Sidebar)
 			}
-			return
+			if len(chrome.Sidebar.Groups) != 1 {
+				t.Fatalf("develop navigation = %#v", chrome.Sidebar.Groups)
+			}
+			got := []string{}
+			for _, item := range chrome.Sidebar.Groups[0].Items {
+				got = append(got, item.ID)
+			}
+			want := []string{"workspaces", "pipelines", "connections"}
+			if len(got) != len(want) {
+				t.Fatalf("develop navigation = %v, want %v", got, want)
+			}
+			for index := range want {
+				if got[index] != want[index] {
+					t.Fatalf("develop navigation = %v, want %v", got, want)
+				}
+			}
+			if chrome.Sidebar.History != nil || chrome.Sidebar.PrimaryAction != nil {
+				t.Fatalf("develop sidebar should not project insights actions: %#v", chrome.Sidebar)
+			}
+		})
+	}
+}
+
+func TestProviderPlacesExploreInInsightsNavigation(t *testing.T) {
+	provider := Provider(Config{Presentation: webpage.Presentation{ProductName: "LeapView"}})
+	layout := provider(webpage.Context{Active: "data"})
+	chrome := layout.Signal.(Chrome)
+	if chrome.Sidebar.Admin || chrome.Sidebar.Area != "insights" || chrome.Sidebar.Active != "data" {
+		t.Fatalf("sidebar = %#v, want insights Explore navigation", chrome.Sidebar)
+	}
+	for _, group := range chrome.Sidebar.Groups {
+		for _, item := range group.Items {
+			if item.ID == "data" {
+				if item.Label != "Explore" || item.Href != "/data" || item.Icon != "cache" {
+					t.Fatalf("Explore item = %#v", item)
+				}
+				return
+			}
 		}
 	}
-	t.Fatal("global navigation does not include pipelines")
+	t.Fatal("Insights navigation did not contain Explore")
 }
 
 func TestProviderProjectsCustomProductIdentity(t *testing.T) {
@@ -69,6 +120,9 @@ func TestProviderUsesAdminNavigationAndBackAction(t *testing.T) {
 	chrome := layout.Signal.(Chrome)
 	if chrome.Sidebar.Active != "principals" || !chrome.Sidebar.Admin || !chrome.Sidebar.Compact {
 		t.Fatalf("sidebar = %#v", chrome.Sidebar)
+	}
+	if chrome.Sidebar.Area != "" || len(chrome.Sidebar.Areas) != 0 {
+		t.Fatalf("admin sidebar areas = %q %#v, want none", chrome.Sidebar.Area, chrome.Sidebar.Areas)
 	}
 	if len(chrome.Sidebar.Groups) != 5 {
 		t.Fatalf("navigation = %#v", chrome.Sidebar.Groups)
@@ -95,7 +149,7 @@ func TestProviderUsesAdminNavigationAndBackAction(t *testing.T) {
 		{label: "Data & sharing", items: []struct {
 			label string
 			icon  string
-		}{{label: "Connections", icon: "data"}, {label: "Storage", icon: "database"}, {label: "Publications", icon: "globe"}}},
+		}{{label: "Storage", icon: "database"}, {label: "Publications", icon: "globe"}}},
 		{label: "Operations", items: []struct {
 			label string
 			icon  string
@@ -124,7 +178,7 @@ func TestProviderUsesAdminNavigationAndBackAction(t *testing.T) {
 func TestProviderFiltersAdminNavigationByPrivileges(t *testing.T) {
 	provider := Provider(Config{
 		Presentation: webpage.Presentation{ProductName: "LeapView"},
-		AdminAccess:  &AdminNavigationAccess{ManageGrants: true, ViewConnections: true},
+		AdminAccess:  &AdminNavigationAccess{ManageGrants: true},
 	})
 	layout := provider(webpage.Context{Active: "admin", PageID: "principals"})
 	chrome := layout.Signal.(Chrome)
@@ -134,7 +188,7 @@ func TestProviderFiltersAdminNavigationByPrivileges(t *testing.T) {
 			got[item.ID] = true
 		}
 	}
-	for _, id := range []string{"profile", "security", "api-tokens", "principals", "groups", "connections"} {
+	for _, id := range []string{"profile", "security", "api-tokens", "principals", "groups"} {
 		if !got[id] {
 			t.Fatalf("navigation is missing %q: %#v", id, chrome.Sidebar.Groups)
 		}
@@ -146,12 +200,12 @@ func TestProviderFiltersAdminNavigationByPrivileges(t *testing.T) {
 	}
 }
 
-func TestProviderPlacesConnectionsInAdminSettingsNavigation(t *testing.T) {
+func TestProviderPlacesConnectionsInDevelopNavigation(t *testing.T) {
 	provider := Provider(Config{Presentation: webpage.Presentation{ProductName: "LeapView"}})
 	layout := provider(webpage.Context{Active: "connections"})
 	chrome := layout.Signal.(Chrome)
-	if !chrome.Sidebar.Admin || chrome.Sidebar.Active != "connections" {
-		t.Fatalf("sidebar = %#v, want admin connections navigation", chrome.Sidebar)
+	if chrome.Sidebar.Admin || chrome.Sidebar.Area != "develop" || chrome.Sidebar.Active != "connections" {
+		t.Fatalf("sidebar = %#v, want develop connections navigation", chrome.Sidebar)
 	}
 	for _, group := range chrome.Sidebar.Groups {
 		for _, item := range group.Items {
@@ -163,7 +217,7 @@ func TestProviderPlacesConnectionsInAdminSettingsNavigation(t *testing.T) {
 			}
 		}
 	}
-	t.Fatal("admin navigation did not contain Connections")
+	t.Fatal("develop navigation did not contain Connections")
 }
 
 func TestRouteContextSelectsActiveHistoryWithoutOwningHistory(t *testing.T) {

--- a/web/components/app/app-shell.dom.test.ts
+++ b/web/components/app/app-shell.dom.test.ts
@@ -757,9 +757,11 @@ test('sidebar switches between Insights and Develop and remembers the last area 
     expect(developState.settings).toEqual({ href: '/admin/profile', label: 'Open settings for Current User' })
     expect(developState.visibleAreaSwitcherCount).toBe(1)
     expect(developState.currentAreaClickPrevented).toBe(true)
-    expect(developState.switcherStyle).toEqual({ borderTopWidth: '0px', backgroundColor: 'rgba(0, 0, 0, 0)' })
+    expect(developState.switcherStyle).toEqual({ display: 'flex', borderTopWidth: '0px', backgroundColor: 'rgba(0, 0, 0, 0)' })
     expect(developState.currentAreaStyle.boxShadow).toBe('none')
-    expect(developState.currentAreaStyle.backgroundColor).not.toBe(developState.switcherStyle.backgroundColor)
+    expect(developState.currentAreaStyle.backgroundColor).toBe(developState.switcherStyle.backgroundColor)
+    expect(developState.currentAreaStyle.borderBottomColor).not.toBe(developState.otherAreaStyle.borderBottomColor)
+    expect(developState.areaIconDisplay).toBe('none')
 
     await page.locator('lv-app-shell').evaluate((element: any) => {
       const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
@@ -1176,12 +1178,17 @@ async function sidebarAreaState(page: import('@playwright/test').Page) {
       })(),
       switcherStyle: (() => {
         const style = getComputedStyle(root.querySelector('.brand .area-switcher') as HTMLElement)
-        return { borderTopWidth: style.borderTopWidth, backgroundColor: style.backgroundColor }
+        return { display: style.display, borderTopWidth: style.borderTopWidth, backgroundColor: style.backgroundColor }
       })(),
       currentAreaStyle: (() => {
         const style = getComputedStyle(root.querySelector('.brand .area-item[aria-current="page"]') as HTMLElement)
-        return { backgroundColor: style.backgroundColor, boxShadow: style.boxShadow }
+        return { backgroundColor: style.backgroundColor, borderBottomColor: style.borderBottomColor, boxShadow: style.boxShadow }
       })(),
+      otherAreaStyle: (() => {
+        const style = getComputedStyle(root.querySelector('.brand .area-item[aria-current="false"]') as HTMLElement)
+        return { borderBottomColor: style.borderBottomColor }
+      })(),
+      areaIconDisplay: getComputedStyle(root.querySelector('.brand .area-icon') as HTMLElement).display,
     }
   })
 }

--- a/web/components/app/app-shell.dom.test.ts
+++ b/web/components/app/app-shell.dom.test.ts
@@ -281,6 +281,11 @@ test('compact app shell keeps the primary sidebar collapsible', async () => {
           return button ? { label: button.getAttribute('aria-label'), disabled: button.disabled } : null
         })(),
         collapsedAttribute: sidebar.hasAttribute('data-collapsed'),
+        visibleAreaSwitcherCount: Array.from(root.querySelectorAll('.area-switcher')).filter((item) => {
+          const rect = item.getBoundingClientRect()
+          const style = getComputedStyle(item)
+          return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden'
+        }).length,
       }
     })
 
@@ -295,6 +300,7 @@ test('compact app shell keeps the primary sidebar collapsible', async () => {
       markCount: 0,
       collapseControl: { label: 'Expand navigation', disabled: false },
       collapsedAttribute: true,
+      visibleAreaSwitcherCount: 0,
     })
 
     await page.locator('lv-app-shell').evaluate(async (element: any) => {
@@ -757,11 +763,10 @@ test('sidebar switches between Insights and Develop and remembers the last area 
     expect(developState.settings).toEqual({ href: '/admin/profile', label: 'Open settings for Current User' })
     expect(developState.visibleAreaSwitcherCount).toBe(1)
     expect(developState.currentAreaClickPrevented).toBe(true)
-    expect(developState.switcherStyle).toEqual({ display: 'flex', borderTopWidth: '0px', backgroundColor: 'rgba(0, 0, 0, 0)' })
+    expect(developState.switcherStyle).toEqual({ display: 'grid', borderTopWidth: '0px', backgroundColor: 'rgba(0, 0, 0, 0)' })
     expect(developState.currentAreaStyle.boxShadow).toBe('none')
-    expect(developState.currentAreaStyle.backgroundColor).toBe(developState.switcherStyle.backgroundColor)
-    expect(developState.currentAreaStyle.borderBottomColor).not.toBe(developState.otherAreaStyle.borderBottomColor)
-    expect(developState.areaIconDisplay).toBe('none')
+    expect(developState.currentAreaStyle.backgroundColor).not.toBe(developState.switcherStyle.backgroundColor)
+    expect(developState.areaIconDisplay).toBe('grid')
 
     await page.locator('lv-app-shell').evaluate((element: any) => {
       const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
@@ -1182,11 +1187,7 @@ async function sidebarAreaState(page: import('@playwright/test').Page) {
       })(),
       currentAreaStyle: (() => {
         const style = getComputedStyle(root.querySelector('.brand .area-item[aria-current="page"]') as HTMLElement)
-        return { backgroundColor: style.backgroundColor, borderBottomColor: style.borderBottomColor, boxShadow: style.boxShadow }
-      })(),
-      otherAreaStyle: (() => {
-        const style = getComputedStyle(root.querySelector('.brand .area-item[aria-current="false"]') as HTMLElement)
-        return { borderBottomColor: style.borderBottomColor }
+        return { backgroundColor: style.backgroundColor, boxShadow: style.boxShadow }
       })(),
       areaIconDisplay: getComputedStyle(root.querySelector('.brand .area-icon') as HTMLElement).display,
     }

--- a/web/components/app/app-shell.dom.test.ts
+++ b/web/components/app/app-shell.dom.test.ts
@@ -39,6 +39,16 @@ beforeAll(async () => {
       response.end(testDocument(true, false, false, true))
       return
     }
+    if (url.pathname === '/') {
+      response.setHeader('content-type', 'text/html')
+      response.end(testDocument(true, false, true))
+      return
+    }
+    if (url.pathname === '/workspaces') {
+      response.setHeader('content-type', 'text/html')
+      response.end(testDocument(true, false, false, true))
+      return
+    }
     if (url.pathname === '/admin-sidebar') {
       response.setHeader('content-type', 'text/html')
       response.end(testDocument(true, true, false, false, true))
@@ -379,6 +389,12 @@ test('mobile navigation opens in an accessible drawer', async () => {
       const backdrop = root.querySelector('.mobile-backdrop') as HTMLButtonElement
       const drawerHeader = root.querySelector('.mobile-drawer-header') as HTMLElement
       const drawer = root.querySelector('aside') as HTMLElement
+      const visible = (target: Element) => {
+        const box = target.getBoundingClientRect()
+        const style = getComputedStyle(target)
+        return box.width > 0 && box.height > 0 && style.display !== 'none' && style.visibility !== 'hidden'
+      }
+      const mobileSettings = root.querySelector('.mobile-footer .user-card') as HTMLAnchorElement | null
       return {
         drawerOpen: root.querySelector('aside')?.hasAttribute('data-mobile-open'),
         expanded: menuButton.getAttribute('aria-expanded'),
@@ -390,6 +406,11 @@ test('mobile navigation opens in an accessible drawer', async () => {
         headerBorderBottomWidth: getComputedStyle(drawerHeader).borderBottomWidth,
         navBoxShadow: getComputedStyle(nav).boxShadow,
         closeControlCount: root.querySelectorAll('button[aria-label="Close navigation"]:not([inert])').length,
+        visibleAreaSwitcherCount: Array.from(root.querySelectorAll('.area-switcher')).filter(visible).length,
+        mobileSettings: mobileSettings && visible(mobileSettings) ? {
+          href: mobileSettings.getAttribute('href'),
+          label: mobileSettings.getAttribute('aria-label'),
+        } : null,
       }
     })
 
@@ -402,6 +423,8 @@ test('mobile navigation opens in an accessible drawer', async () => {
     expect(openState.headerBorderBottomWidth).not.toBe('0px')
     expect(openState.navBoxShadow).not.toBe('none')
     expect(openState.closeControlCount).toBe(1)
+    expect(openState.visibleAreaSwitcherCount).toBe(1)
+    expect(openState.mobileSettings).toEqual({ href: '/admin/profile', label: 'Open settings for Current User' })
 
     await page.locator('lv-app-shell').evaluate(async (element: any) => {
       const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
@@ -703,10 +726,58 @@ test('admin sidebar replaces global navigation and provides a back to app action
       const root = sidebar.shadowRoot!
       return {
         groupLabels: Array.from(root.querySelectorAll('.nav-group:not(.primary-action)')).map((group) => group.getAttribute('aria-label')),
-        links: Array.from(root.querySelectorAll('a[href^="/admin/"]')).map((link) => link.getAttribute('href')),
+        links: Array.from(root.querySelectorAll('#mobile-navigation a[href^="/admin/"]')).map((link) => link.getAttribute('href')),
       }
     })
     expect(filtered).toEqual({ groupLabels: ['Data & sharing'], links: ['/admin/storage'] })
+  } finally {
+    await page.close()
+  }
+})
+
+test('sidebar switches between Insights and Develop and remembers the last area location', async () => {
+  const page = await browser.newPage({ viewport: { width: 1320, height: 900 } })
+  try {
+    await page.goto(`${baseURL}/sidebar-active-nav`)
+    await page.evaluate(() => {
+      localStorage.removeItem('leapview-area-last-insights')
+      localStorage.removeItem('leapview-area-last-develop')
+    })
+    await page.reload()
+    await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
+
+    const developState = await sidebarAreaState(page)
+    expect(developState.area).toBe('develop')
+    expect(developState.areas).toEqual([
+      { label: 'Insights', current: 'false', href: '/' },
+      { label: 'Develop', current: 'page', href: '/sidebar-active-nav' },
+    ])
+    expect(developState.items).toEqual(['Workspaces', 'Pipelines', 'Connections'])
+    expect(developState.visibleGroupLabels).toEqual([])
+    expect(developState.settings).toEqual({ href: '/admin/profile', label: 'Open settings for Current User' })
+    expect(developState.visibleAreaSwitcherCount).toBe(1)
+    expect(developState.currentAreaClickPrevented).toBe(true)
+    expect(developState.switcherStyle).toEqual({ borderTopWidth: '0px', backgroundColor: 'rgba(0, 0, 0, 0)' })
+    expect(developState.currentAreaStyle.boxShadow).toBe('none')
+    expect(developState.currentAreaStyle.backgroundColor).not.toBe(developState.switcherStyle.backgroundColor)
+
+    await page.locator('lv-app-shell').evaluate((element: any) => {
+      const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
+      ;(sidebar.shadowRoot!.querySelector('.area-item[aria-label="Insights"]') as HTMLAnchorElement).click()
+    })
+    await page.waitForURL(`${baseURL}/`)
+    await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
+
+    const insightsState = await sidebarAreaState(page)
+    expect(insightsState.area).toBe('insights')
+    expect(insightsState.items).toEqual(['Dashboards', 'Explore', 'Chats'])
+    expect(insightsState.visibleGroupLabels).toEqual([])
+
+    await page.locator('lv-app-shell').evaluate((element: any) => {
+      const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
+      ;(sidebar.shadowRoot!.querySelector('.area-item[aria-label="Develop"]') as HTMLAnchorElement).click()
+    })
+    await page.waitForURL(`${baseURL}/sidebar-active-nav`)
   } finally {
     await page.close()
   }
@@ -911,18 +982,23 @@ function signalShellDocument(): string {
       sidebar: {
         workspaceTitle: 'LeapView Workspace',
         active: 'chat',
+        area: 'insights',
+        areas: [
+          { id: 'insights', label: 'Insights', href: '/', icon: 'insights' },
+          { id: 'develop', label: 'Develop', href: '/workspaces', icon: 'code' },
+        ],
         dashboardId: '',
         dashboardTitle: '',
         pageTitle: '',
         modelId: '',
         modelTitle: '',
         compact: false,
+        userSettingsHref: '/admin/profile',
         groups: [{
           label: 'Navigation',
           items: [
             { id: 'dashboards', label: 'Dashboards', href: '/', icon: 'dashboard' },
             { id: 'chat', label: 'Chats', href: '/chats', icon: 'chat' },
-            { id: 'workspaces', label: 'Workspaces', href: '/workspaces', icon: 'catalog' },
           ],
         }],
       },
@@ -953,6 +1029,11 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
       workspaceTitle: 'LeapView Workspace',
       active: admin ? 'principals' : history ? 'chat' : 'workspaces',
       admin,
+      area: admin ? undefined : history ? 'insights' : 'develop',
+      areas: admin ? undefined : [
+        { id: 'insights', label: 'Insights', href: '/', icon: 'insights' },
+        { id: 'develop', label: 'Develop', href: '/workspaces', icon: 'code' },
+      ],
       dashboardId: '',
       dashboardTitle: '',
       pageTitle: '',
@@ -962,6 +1043,7 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
       userName: admin ? 'Ada Lovelace' : 'Current User',
       userAvatarUrl: admin ? '/profile/avatars/ada/avatar-digest' : undefined,
       userRole: admin ? 'Platform admin' : 'Workspace member',
+      userSettingsHref: '/admin/profile',
       primaryAction: admin ? { label: 'Back to app', href: '/', icon: 'back' } : history ? { label: 'New chat', href: '/chats/new', icon: 'plus' } : undefined,
       history: history ? {
         label: 'Chats',
@@ -999,7 +1081,6 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
         {
           label: 'Data & sharing',
           items: [
-            { id: 'connections', label: 'Connections', href: '/connections', icon: 'data' },
             { id: 'storage', label: 'Storage', href: '/admin/storage', icon: 'database' },
             { id: 'publications', label: 'Publications', href: '/admin/publications', icon: 'globe' },
           ],
@@ -1013,12 +1094,19 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
             { id: 'system', label: 'System', href: '/admin/system', icon: 'system' },
           ],
         },
-      ] : history || nav ? [{
-        label: 'Navigation',
+      ] : history ? [{
+        label: 'Insights',
         items: [
           { id: 'dashboards', label: 'Dashboards', href: '/', icon: 'dashboard' },
+          { id: 'data', label: 'Explore', href: '/data', icon: 'cache' },
           { id: 'chat', label: 'Chats', href: '/chats', icon: 'chat' },
+        ],
+      }] : nav ? [{
+        label: 'Develop',
+        items: [
           { id: 'workspaces', label: 'Workspaces', href: '/workspaces', icon: 'catalog' },
+          { id: 'pipelines', label: 'Pipelines', href: '/pipelines', icon: 'workflow' },
+          { id: 'connections', label: 'Connections', href: '/connections', icon: 'data' },
         ],
       }] : [],
     },
@@ -1053,6 +1141,49 @@ function testDocument(includeShellScript: boolean, compact = false, history = fa
       </body>
     </html>
   `
+}
+
+async function sidebarAreaState(page: import('@playwright/test').Page) {
+  return page.locator('lv-app-shell').evaluate((element: any) => {
+    const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
+    const root = sidebar.shadowRoot!
+    return {
+      area: sidebar.getAttribute('data-area'),
+      areas: Array.from(root.querySelectorAll('.brand .area-item')).map((item) => ({
+        label: item.getAttribute('aria-label'),
+        current: item.getAttribute('aria-current'),
+        href: item.getAttribute('href'),
+      })),
+      items: Array.from(root.querySelectorAll('#mobile-navigation > .nav-group:not(.primary-action) .nav-text strong')).map((item) => item.textContent?.trim()),
+      visibleGroupLabels: Array.from(root.querySelectorAll('#mobile-navigation > .nav-group .nav-group-label')).filter((item) => {
+        const style = getComputedStyle(item)
+        return style.display !== 'none' && style.visibility !== 'hidden'
+      }).map((item) => item.textContent?.trim()),
+      settings: (() => {
+        const link = root.querySelector('.user-card') as HTMLAnchorElement
+        return { href: link.getAttribute('href'), label: link.getAttribute('aria-label') }
+      })(),
+      visibleAreaSwitcherCount: Array.from(root.querySelectorAll('.area-switcher')).filter((item) => {
+        const box = item.getBoundingClientRect()
+        const style = getComputedStyle(item)
+        return box.width > 0 && box.height > 0 && style.display !== 'none' && style.visibility !== 'hidden'
+      }).length,
+      currentAreaClickPrevented: (() => {
+        const current = root.querySelector('.brand .area-item[aria-current="page"]') as HTMLAnchorElement
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true, composed: true, button: 0 })
+        current.dispatchEvent(event)
+        return event.defaultPrevented
+      })(),
+      switcherStyle: (() => {
+        const style = getComputedStyle(root.querySelector('.brand .area-switcher') as HTMLElement)
+        return { borderTopWidth: style.borderTopWidth, backgroundColor: style.backgroundColor }
+      })(),
+      currentAreaStyle: (() => {
+        const style = getComputedStyle(root.querySelector('.brand .area-item[aria-current="page"]') as HTMLElement)
+        return { backgroundColor: style.backgroundColor, boxShadow: style.boxShadow }
+      })(),
+    }
+  })
 }
 
 function escapeHTML(value: string): string {

--- a/web/components/app/app-shell.ts
+++ b/web/components/app/app-shell.ts
@@ -12,6 +12,7 @@ const emptyChrome: ChromeSignal = {
     dashboardId: '',
     dashboardTitle: '',
     pageTitle: '',
+    userSettingsHref: '/admin/profile',
     modelId: '',
     modelTitle: '',
     compact: false,

--- a/web/components/navigation/sidebar.ts
+++ b/web/components/navigation/sidebar.ts
@@ -303,50 +303,47 @@ class LeapViewSidebar extends LitElement {
     }
 
 		.area-switcher {
-			display: flex;
-			align-items: center;
-			gap: var(--base-size-12);
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: var(--base-size-2);
 			border: 0;
+			border-radius: var(--lv-radius-default);
 			background: transparent;
-			padding: 0 var(--base-size-2);
+			padding: 0;
     }
 
     .area-item {
-      display: inline-flex;
+      display: grid;
       min-width: 0;
-      min-height: var(--control-xsmall-size);
+      min-height: var(--control-small-size);
+      grid-template-columns: var(--control-xsmall-size) minmax(0, 1fr);
       align-items: center;
       justify-content: center;
-      border-bottom: var(--borderWidth-thick) solid transparent;
-      border-radius: 0;
+      gap: var(--base-size-4);
+      border-radius: calc(var(--lv-radius-default) - var(--base-size-2));
       color: var(--lv-fg-muted);
-      padding: 0 var(--base-size-2);
+      padding: 0 var(--base-size-6);
       text-decoration: none;
       font: var(--lv-type-body-compact);
     }
 
-    .area-item:hover {
-      background: transparent;
-      color: var(--lv-fg-default);
-    }
-
+    .area-item:hover,
     .area-item:focus-visible {
-      background: transparent;
+      background: var(--control-bgColor-hover);
       color: var(--lv-fg-default);
       outline: var(--focus-outline);
       outline-offset: var(--focus-outline-offset);
     }
 
 		.area-item[aria-current='page'] {
-			border-bottom-color: var(--lv-line-accent);
-			background: transparent;
+			background: var(--control-bgColor-hover);
 			box-shadow: none;
 			color: var(--lv-fg-default);
 			font-weight: var(--base-text-weight-medium);
     }
 
     .area-icon {
-      display: none;
+      display: grid;
       width: var(--control-xsmall-size);
       height: var(--control-xsmall-size);
       place-items: center;
@@ -822,31 +819,15 @@ class LeapViewSidebar extends LitElement {
     }
 
     :host([data-collapsed]) .area-switcher:not(.mobile-area-switcher) {
-      display: grid;
-      grid-template-columns: 1fr;
-      justify-items: center;
-      gap: var(--base-size-2);
-      border: 0;
-      background: transparent;
-      padding: 0;
+      display: none;
     }
 
     :host([data-collapsed]) .area-item {
       width: var(--base-size-36);
       min-height: var(--base-size-36);
-      border-bottom: 0;
-      border-radius: var(--lv-radius-default);
       grid-template-columns: 1fr;
       justify-items: center;
       padding: 0;
-    }
-
-    :host([data-collapsed]) .area-item[aria-current='page'] {
-      background: var(--control-bgColor-hover);
-    }
-
-    :host([data-collapsed]) .area-icon {
-      display: grid;
     }
 
     :host([data-collapsed]) .area-label {
@@ -1043,35 +1024,22 @@ class LeapViewSidebar extends LitElement {
 
 			.area-switcher,
 			:host([data-collapsed]) .area-switcher {
-				display: flex;
-				align-items: center;
-				justify-content: flex-start;
-				gap: var(--base-size-12);
+				display: grid;
+				grid-template-columns: repeat(2, minmax(0, 1fr));
+				justify-items: stretch;
 				margin-bottom: var(--base-size-8);
 				border: 0;
 				background: transparent;
-				padding: 0 var(--base-size-2);
+				padding: 0;
 			}
 
       .area-item,
       :host([data-collapsed]) .area-item {
         width: auto;
-        min-height: var(--control-xsmall-size);
-        border-bottom: var(--borderWidth-thick) solid transparent;
-        border-radius: 0;
-        background: transparent;
-        padding: 0 var(--base-size-2);
-      }
-
-      .area-item[aria-current='page'],
-      :host([data-collapsed]) .area-item[aria-current='page'] {
-        border-bottom-color: var(--lv-line-accent);
-        background: transparent;
-      }
-
-      .area-icon,
-      :host([data-collapsed]) .area-icon {
-        display: none;
+        min-height: var(--control-small-size);
+        grid-template-columns: var(--control-xsmall-size) minmax(0, auto);
+        justify-items: stretch;
+        padding: 0 var(--base-size-6);
       }
 
       .area-label,

--- a/web/components/navigation/sidebar.ts
+++ b/web/components/navigation/sidebar.ts
@@ -303,47 +303,50 @@ class LeapViewSidebar extends LitElement {
     }
 
 		.area-switcher {
-			display: grid;
-			grid-template-columns: repeat(2, minmax(0, 1fr));
-			gap: var(--base-size-2);
+			display: flex;
+			align-items: center;
+			gap: var(--base-size-12);
 			border: 0;
-			border-radius: var(--lv-radius-default);
 			background: transparent;
-			padding: 0;
+			padding: 0 var(--base-size-2);
     }
 
     .area-item {
-      display: grid;
+      display: inline-flex;
       min-width: 0;
-      min-height: var(--control-small-size);
-      grid-template-columns: var(--control-xsmall-size) minmax(0, 1fr);
+      min-height: var(--control-xsmall-size);
       align-items: center;
       justify-content: center;
-      gap: var(--base-size-4);
-      border-radius: calc(var(--lv-radius-default) - var(--base-size-2));
+      border-bottom: var(--borderWidth-thick) solid transparent;
+      border-radius: 0;
       color: var(--lv-fg-muted);
-      padding: 0 var(--base-size-6);
+      padding: 0 var(--base-size-2);
       text-decoration: none;
       font: var(--lv-type-body-compact);
     }
 
-    .area-item:hover,
+    .area-item:hover {
+      background: transparent;
+      color: var(--lv-fg-default);
+    }
+
     .area-item:focus-visible {
-      background: var(--control-bgColor-hover);
+      background: transparent;
       color: var(--lv-fg-default);
       outline: var(--focus-outline);
       outline-offset: var(--focus-outline-offset);
     }
 
 		.area-item[aria-current='page'] {
-			background: var(--control-bgColor-hover);
+			border-bottom-color: var(--lv-line-accent);
+			background: transparent;
 			box-shadow: none;
 			color: var(--lv-fg-default);
 			font-weight: var(--base-text-weight-medium);
     }
 
     .area-icon {
-      display: grid;
+      display: none;
       width: var(--control-xsmall-size);
       height: var(--control-xsmall-size);
       place-items: center;
@@ -818,9 +821,11 @@ class LeapViewSidebar extends LitElement {
       display: none;
     }
 
-    :host([data-collapsed]) .area-switcher {
+    :host([data-collapsed]) .area-switcher:not(.mobile-area-switcher) {
+      display: grid;
       grid-template-columns: 1fr;
       justify-items: center;
+      gap: var(--base-size-2);
       border: 0;
       background: transparent;
       padding: 0;
@@ -829,9 +834,19 @@ class LeapViewSidebar extends LitElement {
     :host([data-collapsed]) .area-item {
       width: var(--base-size-36);
       min-height: var(--base-size-36);
+      border-bottom: 0;
+      border-radius: var(--lv-radius-default);
       grid-template-columns: 1fr;
       justify-items: center;
       padding: 0;
+    }
+
+    :host([data-collapsed]) .area-item[aria-current='page'] {
+      background: var(--control-bgColor-hover);
+    }
+
+    :host([data-collapsed]) .area-icon {
+      display: grid;
     }
 
     :host([data-collapsed]) .area-label {
@@ -1028,22 +1043,35 @@ class LeapViewSidebar extends LitElement {
 
 			.area-switcher,
 			:host([data-collapsed]) .area-switcher {
-				display: grid;
-				grid-template-columns: repeat(2, minmax(0, 1fr));
-				justify-items: stretch;
+				display: flex;
+				align-items: center;
+				justify-content: flex-start;
+				gap: var(--base-size-12);
 				margin-bottom: var(--base-size-8);
 				border: 0;
 				background: transparent;
-				padding: 0;
+				padding: 0 var(--base-size-2);
 			}
 
       .area-item,
       :host([data-collapsed]) .area-item {
         width: auto;
-        min-height: var(--control-small-size);
-        grid-template-columns: var(--control-xsmall-size) minmax(0, auto);
-        justify-items: stretch;
-        padding: 0 var(--base-size-6);
+        min-height: var(--control-xsmall-size);
+        border-bottom: var(--borderWidth-thick) solid transparent;
+        border-radius: 0;
+        background: transparent;
+        padding: 0 var(--base-size-2);
+      }
+
+      .area-item[aria-current='page'],
+      :host([data-collapsed]) .area-item[aria-current='page'] {
+        border-bottom-color: var(--lv-line-accent);
+        background: transparent;
+      }
+
+      .area-icon,
+      :host([data-collapsed]) .area-icon {
+        display: none;
       }
 
       .area-label,

--- a/web/components/navigation/sidebar.ts
+++ b/web/components/navigation/sidebar.ts
@@ -4,6 +4,8 @@ import {
 	Activity,
 	ArrowLeft,
 	Bot,
+	ChartNoAxesCombined,
+	Code2,
 	Database,
 	Globe,
 	History,
@@ -45,9 +47,18 @@ type NavGroup = {
   items: NavItem[]
 }
 
+type SidebarArea = {
+  id: string
+  label: string
+  href: string
+  icon: string
+}
+
 type SidebarConfig = {
   active: string
   admin?: boolean
+  area?: string
+  areas?: SidebarArea[]
   productLogoUrl?: string
   productName?: string
   workspaceTitle?: string
@@ -62,6 +73,7 @@ type SidebarConfig = {
   history?: SidebarHistory
   userAvatarUrl?: string
   userName?: string
+  userSettingsHref?: string
   groups: NavGroup[]
 }
 
@@ -100,6 +112,7 @@ type IconName =
   | 'chat'
   | 'globe'
   | 'history'
+  | 'insights'
   | 'model'
   | 'data'
   | 'cache'
@@ -114,11 +127,18 @@ type IconName =
   | 'expand'
   | 'menu'
   | 'close'
+  | 'code'
   | 'plus'
   | 'workflow'
 
 const defaultConfig: SidebarConfig = {
   active: 'dashboards',
+  area: 'insights',
+  areas: [
+    { id: 'insights', label: 'Insights', href: '/', icon: 'insights' },
+    { id: 'develop', label: 'Develop', href: '/workspaces', icon: 'code' },
+  ],
+  userSettingsHref: '/admin/profile',
   workspaceTitle: 'LeapView Workspace',
   groups: [
     { label: 'Workspace', items: [{ id: 'dashboards', label: 'Dashboards', href: '/', icon: 'dashboard' }] },
@@ -282,6 +302,59 @@ class LeapViewSidebar extends LitElement {
       gap: var(--base-size-12);
     }
 
+		.area-switcher {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: var(--base-size-2);
+			border: 0;
+			border-radius: var(--lv-radius-default);
+			background: transparent;
+			padding: 0;
+    }
+
+    .area-item {
+      display: grid;
+      min-width: 0;
+      min-height: var(--control-small-size);
+      grid-template-columns: var(--control-xsmall-size) minmax(0, 1fr);
+      align-items: center;
+      justify-content: center;
+      gap: var(--base-size-4);
+      border-radius: calc(var(--lv-radius-default) - var(--base-size-2));
+      color: var(--lv-fg-muted);
+      padding: 0 var(--base-size-6);
+      text-decoration: none;
+      font: var(--lv-type-body-compact);
+    }
+
+    .area-item:hover,
+    .area-item:focus-visible {
+      background: var(--control-bgColor-hover);
+      color: var(--lv-fg-default);
+      outline: var(--focus-outline);
+      outline-offset: var(--focus-outline-offset);
+    }
+
+		.area-item[aria-current='page'] {
+			background: var(--control-bgColor-hover);
+			box-shadow: none;
+			color: var(--lv-fg-default);
+			font-weight: var(--base-text-weight-medium);
+    }
+
+    .area-icon {
+      display: grid;
+      width: var(--control-xsmall-size);
+      height: var(--control-xsmall-size);
+      place-items: center;
+    }
+
+    .area-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     .brand-back {
       position: relative;
       box-sizing: border-box;
@@ -391,7 +464,9 @@ class LeapViewSidebar extends LitElement {
     .mobile-menu-button,
     .mobile-close-button,
     .mobile-backdrop,
-    .mobile-drawer-header {
+    .mobile-drawer-header,
+    .mobile-area-switcher,
+    .mobile-footer {
       display: none;
     }
 
@@ -670,17 +745,29 @@ class LeapViewSidebar extends LitElement {
 
     .user-card {
       display: grid;
-      grid-template-columns: var(--control-small-size) minmax(0, 1fr);
+      grid-template-columns: var(--control-small-size) minmax(0, 1fr) var(--control-xsmall-size);
       min-height: calc(var(--control-medium-size) + var(--base-size-2));
       align-items: center;
       gap: var(--base-size-8);
       border-radius: var(--lv-radius-default);
       color: var(--lv-fg-default);
       padding: 0 var(--control-xsmall-paddingInline-normal);
+      text-decoration: none;
     }
 
-    .user-card:hover {
+    .user-card:hover,
+    .user-card:focus-visible {
       background: var(--control-bgColor-hover);
+      outline: var(--focus-outline);
+      outline-offset: var(--focus-outline-offset);
+    }
+
+    .user-settings-icon {
+      display: grid;
+      width: var(--control-xsmall-size);
+      height: var(--control-xsmall-size);
+      place-items: center;
+      color: var(--lv-fg-muted);
     }
 
     .user-text {
@@ -724,6 +811,30 @@ class LeapViewSidebar extends LitElement {
     :host([data-collapsed]) .nav-text,
     :host([data-collapsed]) .history,
     :host([data-collapsed]) .user-text {
+      display: none;
+    }
+
+    :host([data-collapsed]) .user-settings-icon {
+      display: none;
+    }
+
+    :host([data-collapsed]) .area-switcher {
+      grid-template-columns: 1fr;
+      justify-items: center;
+      border: 0;
+      background: transparent;
+      padding: 0;
+    }
+
+    :host([data-collapsed]) .area-item {
+      width: var(--base-size-36);
+      min-height: var(--base-size-36);
+      grid-template-columns: 1fr;
+      justify-items: center;
+      padding: 0;
+    }
+
+    :host([data-collapsed]) .area-label {
       display: none;
     }
 
@@ -876,10 +987,10 @@ class LeapViewSidebar extends LitElement {
         bottom: 0;
         left: 0;
         box-sizing: border-box;
-        display: grid;
+        display: flex;
+        flex-direction: column;
         width: min(20rem, calc(100vw - var(--base-size-32)));
         min-height: 100svh;
-        align-content: start;
         overflow-y: auto;
         overscroll-behavior: contain;
         border: 0;
@@ -913,6 +1024,31 @@ class LeapViewSidebar extends LitElement {
         margin-bottom: var(--base-size-8);
         border-bottom: var(--lv-border-muted);
         padding-bottom: var(--base-size-8);
+      }
+
+			.area-switcher,
+			:host([data-collapsed]) .area-switcher {
+				display: grid;
+				grid-template-columns: repeat(2, minmax(0, 1fr));
+				justify-items: stretch;
+				margin-bottom: var(--base-size-8);
+				border: 0;
+				background: transparent;
+				padding: 0;
+			}
+
+      .area-item,
+      :host([data-collapsed]) .area-item {
+        width: auto;
+        min-height: var(--control-small-size);
+        grid-template-columns: var(--control-xsmall-size) minmax(0, auto);
+        justify-items: stretch;
+        padding: 0 var(--base-size-6);
+      }
+
+      .area-label,
+      :host([data-collapsed]) .area-label {
+        display: block;
       }
 
       .mobile-drawer-title {
@@ -959,6 +1095,13 @@ class LeapViewSidebar extends LitElement {
       .footer {
         display: none;
       }
+
+      .mobile-footer {
+        display: grid;
+        margin-top: auto;
+        border-top: var(--lv-border-muted);
+        padding-top: var(--base-size-8);
+      }
     }
 
   `
@@ -993,6 +1136,8 @@ class LeapViewSidebar extends LitElement {
 
   protected updated(): void {
     this.toggleAttribute('data-admin', Boolean(this.config.admin))
+    if (this.config.area) this.setAttribute('data-area', this.config.area)
+    else this.removeAttribute('data-area')
     this.syncCollapsedState()
   }
 
@@ -1052,8 +1197,6 @@ class LeapViewSidebar extends LitElement {
     const collapsed = this.effectiveCollapsed
     const mobileNavigationClosed = this.isMobileViewport && !this.mobileOpen
     const groups = this.filteredGroups()
-    const userName = this.config.userName?.trim() || 'Local user'
-    const userAvatarUrl = this.liveUserAvatarUrl ?? this.config.userAvatarUrl?.trim()
     const productName = this.config.productName?.trim() || leapViewBrandName
     const productLogoUrl = this.config.productLogoUrl?.trim()
     const hasCustomIdentity = productName !== leapViewBrandName || Boolean(productLogoUrl)
@@ -1109,6 +1252,7 @@ class LeapViewSidebar extends LitElement {
               </button>
             `}
           </div>
+          ${this.config.admin ? null : this.renderAreaSwitcher()}
           ${this.config.admin ? this.renderSearch() : null}
         </header>
 
@@ -1159,6 +1303,7 @@ class LeapViewSidebar extends LitElement {
               ${icon('close')}
             </button>
           </div>
+          ${this.config.admin ? null : this.renderAreaSwitcher(true)}
           ${this.config.admin ? this.renderSearch(true) : null}
           ${this.config.primaryAction && !this.config.admin ? html`
             <section class="nav-group primary-action" aria-label=${this.config.primaryAction.label}>
@@ -1172,21 +1317,16 @@ class LeapViewSidebar extends LitElement {
           ` : null}
           ${groups.length > 0 ? groups.map((group) => html`
             <section class="nav-group" aria-label=${group.label}>
-              <strong class="nav-group-label">${group.label}</strong>
+              ${this.config.admin ? html`<strong class="nav-group-label">${group.label}</strong>` : null}
               ${group.items.map((item) => item.disabled ? this.renderDisabledItem(item) : this.renderLink(item))}
             </section>
           `) : this.config.admin ? html`<p class="search-empty">No matching pages</p>` : null}
           ${this.renderHistory()}
+          ${this.config.admin ? null : html`<div class="mobile-footer">${this.renderUserCard()}</div>`}
         </nav>
 
         <footer class="footer">
-          <div class="user-card" title=${userName}>
-            <lv-user-avatar .name=${userName} .imageUrl=${userAvatarUrl ?? ''} aria-hidden="true"></lv-user-avatar>
-            <span class="user-text">
-              <strong class="user-name">${userName}</strong>
-              <span class="user-role">${this.config.userRole ?? 'Local workspace'}</span>
-            </span>
-          </div>
+          ${this.renderUserCard()}
         </footer>
       </aside>
     `
@@ -1301,6 +1441,75 @@ class LeapViewSidebar extends LitElement {
     this.searchQuery = (event.target as HTMLInputElement).value
   }
 
+  private renderAreaSwitcher(mobile = false) {
+    const areas = Array.isArray(this.config.areas) ? this.config.areas : []
+    if (areas.length < 2) return null
+    return html`
+      <div class=${mobile ? 'area-switcher mobile-area-switcher' : 'area-switcher'} role="group" aria-label="Product area">
+        ${areas.map((area) => {
+          const current = area.id === this.config.area
+          const href = this.areaHref(area, current)
+          return html`
+            <a
+              class="area-item"
+              href=${href}
+              aria-current=${current ? 'page' : 'false'}
+              aria-label=${area.label}
+              title=${area.label}
+              @click=${(event: MouseEvent) => this.followInternalLink(event, href)}
+            >
+              <span class="area-icon" aria-hidden="true">${icon(area.icon)}</span>
+              <span class="area-label">${area.label}</span>
+            </a>
+          `
+        })}
+      </div>
+    `
+  }
+
+  private renderUserCard() {
+    const userName = this.config.userName?.trim() || 'Local user'
+    const userAvatarUrl = this.liveUserAvatarUrl ?? this.config.userAvatarUrl?.trim()
+    const href = this.config.userSettingsHref || '/admin/profile'
+    return html`
+      <a
+        class="user-card"
+        href=${href}
+        aria-label=${`Open settings for ${userName}`}
+        title=${userName}
+        @click=${(event: MouseEvent) => this.followInternalLink(event, href)}
+      >
+        <lv-user-avatar .name=${userName} .imageUrl=${userAvatarUrl ?? ''} aria-hidden="true"></lv-user-avatar>
+        <span class="user-text">
+          <strong class="user-name">${userName}</strong>
+          <span class="user-role">${this.config.userRole ?? 'Local workspace'}</span>
+        </span>
+        <span class="user-settings-icon" aria-hidden="true">${icon('settings')}</span>
+      </a>
+    `
+  }
+
+  private areaHref(area: SidebarArea, current: boolean): string {
+    if (current && typeof window !== 'undefined') return `${window.location.pathname}${window.location.search}${window.location.hash}`
+    try {
+      const stored = localStorage.getItem(areaStorageKey(area.id))
+      if (stored && stored.startsWith('/') && !stored.startsWith('//')) return stored
+    } catch {
+      // Storage is an enhancement; canonical area roots remain usable without it.
+    }
+    return area.href
+  }
+
+  private rememberCurrentArea(): void {
+    const area = this.config.area?.trim()
+    if (!area || this.config.admin || typeof window === 'undefined') return
+    try {
+      localStorage.setItem(areaStorageKey(area), `${window.location.pathname}${window.location.search}${window.location.hash}`)
+    } catch {
+      // Ignore storage failures; the link still follows the canonical area root.
+    }
+  }
+
   private filteredGroups(): NavGroup[] {
     if (!this.config.admin || !this.searchQuery.trim()) return this.config.groups
     const query = this.searchQuery.trim().toLocaleLowerCase()
@@ -1362,8 +1571,13 @@ class LeapViewSidebar extends LitElement {
   private followInternalLink(event: MouseEvent, href: string): void {
     if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
     const target = new URL(href, window.location.href)
-    if (target.origin !== window.location.origin || target.href === window.location.href) return
+    if (target.origin !== window.location.origin) return
+    if (target.href === window.location.href) {
+      event.preventDefault()
+      return
+    }
     event.preventDefault()
+    this.rememberCurrentArea()
     this.closeMobileNavigation()
     window.location.assign(target.href)
   }
@@ -1378,9 +1592,11 @@ function icon(name: string) {
     database: Database,
     globe: Globe,
     history: History,
+    insights: ChartNoAxesCombined,
     model: Database,
     data: Plug,
     cache: TableProperties,
+    code: Code2,
     settings: Settings,
     system: Monitor,
     activity: Activity,
@@ -1398,6 +1614,10 @@ function icon(name: string) {
   }
 
   return lucideIcon(icons[name as IconName] ?? Layers)
+}
+
+function areaStorageKey(area: string): string {
+  return `leapview-area-last-${area}`
 }
 
 function storedCollapsed(fallback = false): boolean {


### PR DESCRIPTION
## Summary

- add a quiet top-level Insights and Develop area switcher that remembers the last location in each area
- organize Dashboards, Explore, and Chats under Insights
- organize Workspaces, Pipelines, and Connections under Develop
- keep the existing /data surface titled Data Explorer while presenting it as Explore in navigation
- move profile and settings access to the user control and preserve the dedicated admin navigation
- add server and browser regression coverage for desktop, collapsed, and mobile navigation

## Testing

- task ci