### PR TITLE
feat(project): define canonical resource graph

### DIFF
--- a/internal/project/graph/graph.go
+++ b/internal/project/graph/graph.go
@@ -1,0 +1,715 @@
+// Package graph defines the portable, project-wide resource graph contract.
+//
+// A graph is an immutable value after construction. Resource IDs and symbolic
+// names are deliberately separate: IDs are explicit, opaque, and stable while
+// names are a convenient project-local reference. Authoring metadata (including
+// paths and provenance) is retained in the graph artifact, but is never used
+// to derive an ID or to resolve an edge.
+package graph
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	// GraphVersion is the portable project graph format version.
+	GraphVersion = 1
+	// ArtifactVersion is the serving-scoped envelope format version.
+	ArtifactVersion = 1
+
+	digestPrefix = "sha256:"
+)
+
+// Resource IDs are opaque references. The grammar intentionally accepts
+// generated UUID/ULID values and namespaced IDs such as semantic_model:orders,
+// while excluding path separators and whitespace.
+var resourceIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.:-]*$`)
+
+// Symbolic names are project-local readable references, deliberately stricter
+// than opaque IDs so IDs and names cannot be confused at the API boundary.
+var resourceNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.-]*$`)
+
+var (
+	// ErrInvalidResourceID indicates an empty or malformed canonical ID.
+	ErrInvalidResourceID = errors.New("invalid resource id")
+	// ErrInvalidKind indicates a kind outside the project graph contract.
+	ErrInvalidKind = errors.New("invalid resource kind")
+	// ErrInvalidName indicates an empty or malformed symbolic project name.
+	ErrInvalidName = errors.New("invalid resource name")
+	// ErrDuplicateResourceID indicates that two resources have the same ID.
+	ErrDuplicateResourceID = errors.New("duplicate resource id")
+	// ErrDuplicateName indicates that two resources have the same symbolic name.
+	ErrDuplicateName = errors.New("duplicate resource name")
+	// ErrMissingEndpoint indicates an edge endpoint that is not in the graph.
+	ErrMissingEndpoint = errors.New("missing edge endpoint")
+	// ErrDuplicateEdge indicates that an edge is repeated.
+	ErrDuplicateEdge = errors.New("duplicate edge")
+	// ErrCycle indicates that the dependency graph is cyclic.
+	ErrCycle = errors.New("resource graph contains a cycle")
+	// ErrProjectRoot indicates that the graph does not have exactly one project
+	// root resource.
+	ErrProjectRoot = errors.New("project graph must contain exactly one project root")
+	// ErrProjectIdentityMismatch indicates that an artifact identity does not
+	// match the project root in its graph.
+	ErrProjectIdentityMismatch = errors.New("project identity does not match graph root")
+	// ErrInvalidServingIdentity indicates a malformed serving scope.
+	ErrInvalidServingIdentity = errors.New("invalid serving identity")
+)
+
+// UnsupportedVersionError reports a graph or serving artifact envelope whose
+// canonical format version is not understood by this package.
+type UnsupportedVersionError struct {
+	Contract string
+	Version  int
+}
+
+func (e UnsupportedVersionError) Error() string {
+	return fmt.Sprintf("unsupported %s version %d", e.Contract, e.Version)
+}
+
+// ResourceID is an explicit, stable project resource identity. It is not
+// generated from a path, display name, domain, owner, or authoring origin.
+// IDs are opaque and may be digit-first, UUID/ULID-shaped, or namespaced with
+// a colon; callers must not infer symbolic meaning from their spelling.
+type ResourceID string
+
+// NewResourceID validates an explicit resource ID.
+func NewResourceID(value string) (ResourceID, error) {
+	if !resourceIDPattern.MatchString(value) {
+		return "", fmt.Errorf("%w %q", ErrInvalidResourceID, value)
+	}
+	return ResourceID(value), nil
+}
+
+// String returns the textual form of the ID.
+func (id ResourceID) String() string { return string(id) }
+
+// Valid reports whether id is a valid canonical resource ID.
+func (id ResourceID) Valid() bool { return resourceIDPattern.MatchString(string(id)) }
+
+// Kind is a first-class project graph resource kind.
+type Kind string
+
+const (
+	KindProject       Kind = "project"
+	KindConnection    Kind = "connection"
+	KindSource        Kind = "source"
+	KindModel         Kind = "model"
+	KindSemanticModel Kind = "semantic_model"
+	KindPipeline      Kind = "pipeline"
+	KindDashboard     Kind = "dashboard"
+)
+
+var validKinds = map[Kind]struct{}{
+	KindProject: {}, KindConnection: {}, KindSource: {}, KindModel: {},
+	KindSemanticModel: {}, KindPipeline: {}, KindDashboard: {},
+}
+
+// Valid reports whether kind belongs to the project graph contract.
+func (kind Kind) Valid() bool {
+	_, ok := validKinds[kind]
+	return ok
+}
+
+// ParseKind validates a wire kind.
+func ParseKind(value string) (Kind, error) {
+	kind := Kind(value)
+	if !kind.Valid() {
+		return "", fmt.Errorf("%w %q", ErrInvalidKind, value)
+	}
+	return kind, nil
+}
+
+// Metadata is descriptive resource metadata. Domain is intentionally only
+// metadata: it is not a namespace, access boundary, or identity component.
+type Metadata struct {
+	DisplayName   string   `json:"displayName,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	Owner         string   `json:"owner,omitempty"`
+	Domain        string   `json:"domain,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	Documentation string   `json:"documentation,omitempty"`
+}
+
+// Provenance describes where a resource was authored or imported. It has no
+// bearing on resource identity or graph topology.
+type Provenance struct {
+	Origin string `json:"origin,omitempty"`
+	Path   string `json:"path,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+// Resource is a project-wide graph node. ID is explicit and immutable by
+// convention; callers receive defensive copies from ProjectGraph methods.
+type Resource struct {
+	ID         ResourceID `json:"id"`
+	Kind       Kind       `json:"kind"`
+	Name       string     `json:"name"`
+	Metadata   Metadata   `json:"metadata,omitempty"`
+	Provenance Provenance `json:"provenance,omitempty"`
+}
+
+// Edge is a directed dependency from From to To. Relation is optional
+// descriptive data; endpoint identity alone defines graph topology.
+type Edge struct {
+	From     ResourceID `json:"from"`
+	To       ResourceID `json:"to"`
+	Relation string     `json:"relation,omitempty"`
+}
+
+// ProjectGraph is an immutable, validated project resource graph. It contains
+// exactly one project root resource; that root supplies ProjectID. The graph
+// bytes are portable and do not carry serving environment or generation data.
+type ProjectGraph struct {
+	projectID ResourceID
+	resources []Resource
+	edges     []Edge
+	canonical []byte
+	digest    string
+}
+
+// NewProjectGraph validates resources and edges, then returns an immutable
+// project graph.
+func NewProjectGraph(resources []Resource, edges []Edge) (ProjectGraph, error) {
+	resourcesCopy := cloneResources(resources)
+	edgesCopy := cloneEdges(edges)
+	if edgesCopy == nil {
+		edgesCopy = []Edge{}
+	}
+	if err := validate(resourcesCopy, edgesCopy); err != nil {
+		return ProjectGraph{}, err
+	}
+	projectID, err := projectRootID(resourcesCopy)
+	if err != nil {
+		return ProjectGraph{}, err
+	}
+	sortResources(resourcesCopy)
+	sortEdges(edgesCopy)
+
+	wire := graphWire{Version: GraphVersion, Resources: resourcesCopy, Edges: edgesCopy}
+	canonical, err := json.Marshal(wire)
+	if err != nil {
+		return ProjectGraph{}, fmt.Errorf("encode canonical project graph: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return ProjectGraph{
+		projectID: projectID,
+		resources: resourcesCopy,
+		edges:     edgesCopy,
+		canonical: canonical,
+		digest:    digestPrefix + hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+// Validate validates a resource and edge collection without constructing a
+// graph. It is useful to validate decoded or incrementally assembled inputs.
+func Validate(resources []Resource, edges []Edge) error {
+	resourcesCopy := cloneResources(resources)
+	if err := validate(resourcesCopy, cloneEdges(edges)); err != nil {
+		return err
+	}
+	_, err := projectRootID(resourcesCopy)
+	return err
+}
+
+// Decode decodes a canonical graph artifact and revalidates its invariants.
+func Decode(data []byte) (ProjectGraph, error) {
+	if err := rejectDuplicateJSONKeys(data); err != nil {
+		return ProjectGraph{}, fmt.Errorf("decode project graph: %w", err)
+	}
+	var wire graphWire
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&wire); err != nil {
+		return ProjectGraph{}, fmt.Errorf("decode project graph: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err == nil {
+		return ProjectGraph{}, errors.New("decode project graph: trailing JSON value")
+	} else if !errors.Is(err, io.EOF) {
+		return ProjectGraph{}, fmt.Errorf("decode project graph: trailing data: %w", err)
+	}
+	if wire.Version != GraphVersion {
+		return ProjectGraph{}, UnsupportedVersionError{Contract: "project graph", Version: wire.Version}
+	}
+	return NewProjectGraph(wire.Resources, wire.Edges)
+}
+
+// Resources returns a defensive copy sorted by canonical ID.
+func (g ProjectGraph) Resources() []Resource { return cloneResources(g.resources) }
+
+// Edges returns a defensive copy sorted by canonical endpoint order.
+func (g ProjectGraph) Edges() []Edge { return cloneEdges(g.edges) }
+
+// ProjectID returns the stable ID of the graph's project root resource.
+func (g ProjectGraph) ProjectID() ResourceID { return g.projectID }
+
+// Resource returns a defensive copy of the resource with id.
+func (g ProjectGraph) Resource(id ResourceID) (Resource, bool) {
+	for _, resource := range g.resources {
+		if resource.ID == id {
+			return cloneResource(resource), true
+		}
+	}
+	return Resource{}, false
+}
+
+// CanonicalBytes returns the deterministic portable graph artifact.
+func (g ProjectGraph) CanonicalBytes() []byte { return append([]byte(nil), g.canonical...) }
+
+// Digest returns the SHA-256 digest of CanonicalBytes in the project's
+// canonical digest form ("sha256:" followed by lowercase hexadecimal).
+func (g ProjectGraph) Digest() string { return g.digest }
+
+// MarshalJSON emits the canonical artifact bytes.
+func (g ProjectGraph) MarshalJSON() ([]byte, error) {
+	if len(g.canonical) == 0 {
+		return nil, errors.New("project graph is not initialized")
+	}
+	return g.CanonicalBytes(), nil
+}
+
+// UnmarshalJSON decodes and validates a graph artifact.
+func (g *ProjectGraph) UnmarshalJSON(data []byte) error {
+	if g == nil {
+		return errors.New("cannot unmarshal project graph into nil receiver")
+	}
+	decoded, err := Decode(data)
+	if err != nil {
+		return err
+	}
+	*g = decoded
+	return nil
+}
+
+// Validate checks an already-constructed graph. NewProjectGraph always returns a
+// validated graph; this method is useful for zero-value checks in callers.
+func (g ProjectGraph) Validate() error {
+	if len(g.canonical) == 0 {
+		return errors.New("project graph is not initialized")
+	}
+	if err := validate(g.resources, g.edges); err != nil {
+		return err
+	}
+	_, err := projectRootID(g.resources)
+	return err
+}
+
+// ServingIdentity binds one portable project graph to the immutable serving
+// scope that owns it. Environment and GenerationID are explicit values; they
+// are never inferred from a legacy container, path, or graph metadata.
+type ServingIdentity struct {
+	ProjectID    ResourceID `json:"projectId"`
+	Environment  string     `json:"environment"`
+	GenerationID string     `json:"generationId"`
+}
+
+// NewServingIdentity validates the complete immutable serving scope without
+// requiring a graph payload. Artifact binding separately verifies that the
+// identity's project ID matches the graph root.
+func NewServingIdentity(projectID ResourceID, environment, generationID string) (ServingIdentity, error) {
+	return normalizeServingIdentity(ServingIdentity{
+		ProjectID:    projectID,
+		Environment:  environment,
+		GenerationID: generationID,
+	})
+}
+
+// Validate rejects zero, malformed, or non-canonical serving identities.
+func (identity ServingIdentity) Validate() error {
+	validated, err := normalizeServingIdentity(identity)
+	if err != nil {
+		return err
+	}
+	if validated != identity {
+		return ErrInvalidServingIdentity
+	}
+	return nil
+}
+
+// ArtifactEnvelope is one serving-scoped artifact containing exactly one
+// portable project graph. The graph's canonical bytes are independent of this
+// envelope; the envelope adds serving identity for activation and leasing.
+type ArtifactEnvelope struct {
+	version   int
+	identity  ServingIdentity
+	graph     ProjectGraph
+	canonical []byte
+	digest    string
+}
+
+// Version returns the serving artifact format version.
+func (a ArtifactEnvelope) Version() int { return a.version }
+
+// Identity returns the serving identity by value.
+func (a ArtifactEnvelope) Identity() ServingIdentity { return a.identity }
+
+// Graph returns the portable project graph by value.
+func (a ArtifactEnvelope) Graph() ProjectGraph { return a.graph }
+
+// NewArtifactEnvelope validates and binds graph to a serving identity.
+func NewArtifactEnvelope(identity ServingIdentity, graph ProjectGraph) (ArtifactEnvelope, error) {
+	identity, err := normalizeServingIdentity(identity)
+	if err != nil {
+		return ArtifactEnvelope{}, err
+	}
+	if err := graph.Validate(); err != nil {
+		return ArtifactEnvelope{}, err
+	}
+	if identity.ProjectID != graph.ProjectID() {
+		return ArtifactEnvelope{}, fmt.Errorf("%w: identity %q, graph root %q", ErrProjectIdentityMismatch, identity.ProjectID, graph.ProjectID())
+	}
+	wire := artifactWire{Version: ArtifactVersion, Identity: identity, Graph: graph}
+	canonical, err := json.Marshal(wire)
+	if err != nil {
+		return ArtifactEnvelope{}, fmt.Errorf("encode canonical project artifact: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return ArtifactEnvelope{
+		version: ArtifactVersion, identity: identity, graph: graph,
+		canonical: canonical,
+		digest:    digestPrefix + hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+// DecodeArtifactEnvelope decodes and validates a serving-scoped artifact.
+func DecodeArtifactEnvelope(data []byte) (ArtifactEnvelope, error) {
+	if err := rejectDuplicateJSONKeys(data); err != nil {
+		return ArtifactEnvelope{}, fmt.Errorf("decode project artifact: %w", err)
+	}
+	var wire artifactWire
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&wire); err != nil {
+		return ArtifactEnvelope{}, fmt.Errorf("decode project artifact: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err == nil {
+		return ArtifactEnvelope{}, errors.New("decode project artifact: trailing JSON value")
+	} else if !errors.Is(err, io.EOF) {
+		return ArtifactEnvelope{}, fmt.Errorf("decode project artifact: trailing data: %w", err)
+	}
+	if wire.Version != ArtifactVersion {
+		return ArtifactEnvelope{}, UnsupportedVersionError{Contract: "project artifact", Version: wire.Version}
+	}
+	return NewArtifactEnvelope(wire.Identity, wire.Graph)
+}
+
+// CanonicalBytes returns deterministic serving-scoped artifact bytes.
+func (a ArtifactEnvelope) CanonicalBytes() []byte { return append([]byte(nil), a.canonical...) }
+
+// Digest returns the SHA-256 digest of CanonicalBytes.
+func (a ArtifactEnvelope) Digest() string { return a.digest }
+
+// MarshalJSON emits canonical serving-scoped artifact bytes.
+func (a ArtifactEnvelope) MarshalJSON() ([]byte, error) {
+	if len(a.canonical) == 0 {
+		return nil, errors.New("project artifact is not initialized")
+	}
+	return a.CanonicalBytes(), nil
+}
+
+// UnmarshalJSON decodes and validates a serving-scoped artifact.
+func (a *ArtifactEnvelope) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		return errors.New("cannot unmarshal project artifact into nil receiver")
+	}
+	decoded, err := DecodeArtifactEnvelope(data)
+	if err != nil {
+		return err
+	}
+	*a = decoded
+	return nil
+}
+
+type artifactWire struct {
+	Version  int             `json:"version"`
+	Identity ServingIdentity `json:"identity"`
+	Graph    ProjectGraph    `json:"graph"`
+}
+
+func normalizeServingIdentity(identity ServingIdentity) (ServingIdentity, error) {
+	projectID, err := NewResourceID(identity.ProjectID.String())
+	if err != nil {
+		return ServingIdentity{}, fmt.Errorf("%w: project id %q (%v)", ErrInvalidServingIdentity, identity.ProjectID, err)
+	}
+	environment, err := canonicalScopeValue(identity.Environment, "environment")
+	if err != nil {
+		return ServingIdentity{}, err
+	}
+	generation, err := canonicalScopeValue(identity.GenerationID, "generation id")
+	if err != nil {
+		return ServingIdentity{}, err
+	}
+	return ServingIdentity{ProjectID: projectID, Environment: environment, GenerationID: generation}, nil
+}
+
+func canonicalScopeValue(value, label string) (string, error) {
+	if !resourceIDPattern.MatchString(value) {
+		return "", fmt.Errorf("%w: %s %q", ErrInvalidServingIdentity, label, value)
+	}
+	return value, nil
+}
+
+type graphWire struct {
+	Version   int        `json:"version"`
+	Resources []Resource `json:"resources"`
+	Edges     []Edge     `json:"edges"`
+}
+
+func validate(resources []Resource, edges []Edge) error {
+	ids := make(map[ResourceID]struct{}, len(resources))
+	names := make(map[string]ResourceID, len(resources))
+	for index := range resources {
+		resource := &resources[index]
+		id, err := NewResourceID(resource.ID.String())
+		if err != nil {
+			return fmt.Errorf("resource %d: %w", index, err)
+		}
+		resource.ID = id
+		kind, err := ParseKind(string(resource.Kind))
+		if err != nil {
+			return fmt.Errorf("resource %q: %w", id, err)
+		}
+		resource.Kind = kind
+		if resource.Name == "" {
+			return fmt.Errorf("resource %q: %w (name is required)", id, ErrInvalidName)
+		}
+		if !resourceNamePattern.MatchString(resource.Name) {
+			return fmt.Errorf("resource %q name: %w", id, ErrInvalidName)
+		}
+		if _, exists := ids[id]; exists {
+			return fmt.Errorf("resource %q: %w", id, ErrDuplicateResourceID)
+		}
+		ids[id] = struct{}{}
+		if previous, exists := names[resource.Name]; exists {
+			return fmt.Errorf("resources %q and %q: %w %q", previous, id, ErrDuplicateName, resource.Name)
+		}
+		names[resource.Name] = id
+		resource.Metadata.Tags = sortedStrings(resource.Metadata.Tags)
+	}
+
+	edgesSeen := make(map[string]struct{}, len(edges))
+	adjacency := make(map[ResourceID][]ResourceID, len(ids))
+	for index := range edges {
+		edge := &edges[index]
+		from, err := NewResourceID(edge.From.String())
+		if err != nil {
+			return fmt.Errorf("edge %d from: %w", index, err)
+		}
+		to, err := NewResourceID(edge.To.String())
+		if err != nil {
+			return fmt.Errorf("edge %d to: %w", index, err)
+		}
+		edge.From, edge.To = from, to
+		if _, ok := ids[from]; !ok {
+			return fmt.Errorf("edge %d from %q: %w", index, from, ErrMissingEndpoint)
+		}
+		if _, ok := ids[to]; !ok {
+			return fmt.Errorf("edge %d to %q: %w", index, to, ErrMissingEndpoint)
+		}
+		// Relation is descriptive; duplicate endpoint pairs are still one
+		// dependency edge even when an input gives them different labels.
+		key := string(from) + "\x00" + string(to)
+		if _, exists := edgesSeen[key]; exists {
+			return fmt.Errorf("edge %q -> %q: %w", from, to, ErrDuplicateEdge)
+		}
+		edgesSeen[key] = struct{}{}
+		adjacency[from] = append(adjacency[from], to)
+	}
+	if cycle := findCycle(ids, adjacency); len(cycle) > 0 {
+		return fmt.Errorf("%w: %s", ErrCycle, strings.Join(cycle, " -> "))
+	}
+	return nil
+}
+
+func projectRootID(resources []Resource) (ResourceID, error) {
+	var root ResourceID
+	for _, resource := range resources {
+		if resource.Kind != KindProject {
+			continue
+		}
+		if root != "" {
+			return "", fmt.Errorf("%w: multiple project resources", ErrProjectRoot)
+		}
+		root = resource.ID
+	}
+	if root == "" {
+		return "", fmt.Errorf("%w: project resource is missing", ErrProjectRoot)
+	}
+	return root, nil
+}
+
+func findCycle(ids map[ResourceID]struct{}, adjacency map[ResourceID][]ResourceID) []string {
+	state := make(map[ResourceID]uint8, len(ids))
+	stack := make([]ResourceID, 0, len(ids))
+	positions := make(map[ResourceID]int, len(ids))
+	var visit func(ResourceID) []string
+	visit = func(node ResourceID) []string {
+		switch state[node] {
+		case 1:
+			start := positions[node]
+			cycle := make([]string, 0, len(stack)-start+1)
+			for _, id := range stack[start:] {
+				cycle = append(cycle, id.String())
+			}
+			cycle = append(cycle, node.String())
+			return cycle
+		case 2:
+			return nil
+		}
+		state[node] = 1
+		positions[node] = len(stack)
+		stack = append(stack, node)
+		neighbors := append([]ResourceID(nil), adjacency[node]...)
+		sort.Slice(neighbors, func(i, j int) bool { return neighbors[i] < neighbors[j] })
+		for _, neighbor := range neighbors {
+			if cycle := visit(neighbor); len(cycle) > 0 {
+				return cycle
+			}
+		}
+		stack = stack[:len(stack)-1]
+		delete(positions, node)
+		state[node] = 2
+		return nil
+	}
+	idsSorted := make([]ResourceID, 0, len(ids))
+	for id := range ids {
+		idsSorted = append(idsSorted, id)
+	}
+	sort.Slice(idsSorted, func(i, j int) bool { return idsSorted[i] < idsSorted[j] })
+	for _, id := range idsSorted {
+		if state[id] == 0 {
+			if cycle := visit(id); len(cycle) > 0 {
+				return cycle
+			}
+		}
+	}
+	return nil
+}
+
+func cloneResources(resources []Resource) []Resource {
+	if resources == nil {
+		return nil
+	}
+	out := make([]Resource, len(resources))
+	for index, resource := range resources {
+		out[index] = cloneResource(resource)
+	}
+	return out
+}
+
+func cloneResource(resource Resource) Resource {
+	resource.Metadata.Tags = append([]string(nil), resource.Metadata.Tags...)
+	return resource
+}
+
+func cloneEdges(edges []Edge) []Edge { return append([]Edge(nil), edges...) }
+
+func sortResources(resources []Resource) {
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].ID != resources[j].ID {
+			return resources[i].ID < resources[j].ID
+		}
+		if resources[i].Kind != resources[j].Kind {
+			return resources[i].Kind < resources[j].Kind
+		}
+		return resources[i].Name < resources[j].Name
+	})
+}
+
+func sortEdges(edges []Edge) {
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].From != edges[j].From {
+			return edges[i].From < edges[j].From
+		}
+		if edges[i].To != edges[j].To {
+			return edges[i].To < edges[j].To
+		}
+		return edges[i].Relation < edges[j].Relation
+	})
+}
+
+func sortedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	values = append([]string(nil), values...)
+	sort.Strings(values)
+	return values
+}
+
+// rejectDuplicateJSONKeys walks one JSON value before typed decoding. The
+// standard decoder intentionally applies last-key-wins semantics; canonical
+// project artifacts instead reject ambiguity at every nested object level.
+func rejectDuplicateJSONKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := walkJSONValue(decoder); err != nil {
+		return err
+	}
+	return nil
+}
+
+func walkJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	switch delimiter := token.(type) {
+	case json.Delim:
+		switch delimiter {
+		case '{':
+			keys := make(map[string]struct{})
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return errors.New("JSON object key is not a string")
+				}
+				canonicalKey := strings.ToLower(key)
+				if _, exists := keys[canonicalKey]; exists {
+					return fmt.Errorf("duplicate JSON object key %q", key)
+				}
+				keys[canonicalKey] = struct{}{}
+				if err := walkJSONValue(decoder); err != nil {
+					return err
+				}
+			}
+			end, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if end != json.Delim('}') {
+				return fmt.Errorf("JSON object ended with %v", end)
+			}
+		case '[':
+			for decoder.More() {
+				if err := walkJSONValue(decoder); err != nil {
+					return err
+				}
+			}
+			end, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if end != json.Delim(']') {
+				return fmt.Errorf("JSON array ended with %v", end)
+			}
+		default:
+			return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+		}
+	}
+	return nil
+}

--- a/internal/project/graph/graph_test.go
+++ b/internal/project/graph/graph_test.go
@@ -1,0 +1,416 @@
+package graph
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestResourceIDDoesNotDependOnMetadataPathOrProvenance(t *testing.T) {
+	base := Resource{
+		ID:   "model_orders",
+		Kind: KindModel,
+		Name: "orders",
+		Metadata: Metadata{
+			DisplayName: "Orders",
+			Owner:       "team-data",
+			Domain:      "commerce",
+		},
+		Provenance: Provenance{Origin: "project", Path: "models/orders.yaml", Source: "git:abc"},
+	}
+	changed := base
+	changed.Metadata.DisplayName = "Order facts"
+	changed.Metadata.Owner = "team-analytics"
+	changed.Metadata.Domain = "finance"
+	changed.Provenance = Provenance{Origin: "agent", Path: "archive/orders.yml", Source: "builder"}
+
+	if base.ID != changed.ID {
+		t.Fatalf("metadata/path/provenance changed resource ID: %q != %q", base.ID, changed.ID)
+	}
+	first, err := NewProjectGraph([]Resource{{ID: "project_demo", Kind: KindProject, Name: "demo"}, base}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewProjectGraph([]Resource{{ID: "project_demo", Kind: KindProject, Name: "demo"}, changed}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := first.Resource(base.ID)
+	if !ok || got.ID != changed.ID {
+		t.Fatalf("graph lookup changed resource ID: %#v", got)
+	}
+	if _, ok := second.Resource(changed.ID); !ok {
+		t.Fatalf("changed resource is missing from graph")
+	}
+}
+
+func TestResourceIDsAreOpaqueAndNamesRemainSymbolic(t *testing.T) {
+	for _, value := range []string{"01J8N3YQ6F7T8V9W0X1Y2Z3A4B", "semantic_model:orders", "7f3a.orders-v2"} {
+		if id, err := NewResourceID(value); err != nil || id.String() != value {
+			t.Fatalf("NewResourceID(%q) = %q, %v", value, id, err)
+		}
+	}
+	for _, value := range []string{"orders/view", " semantic_model:orders", "semantic model:orders"} {
+		if _, err := NewResourceID(value); !errors.Is(err, ErrInvalidResourceID) {
+			t.Fatalf("NewResourceID(%q) error = %v, want malformed ID", value, err)
+		}
+	}
+	if _, err := NewProjectGraph([]Resource{
+		{ID: "semantic_model:demo", Kind: KindProject, Name: "demo"},
+		{ID: "semantic_model:orders", Kind: KindModel, Name: "orders"},
+	}, nil); err != nil {
+		t.Fatalf("NewProjectGraph() rejected opaque IDs: %v", err)
+	}
+	if _, err := NewProjectGraph([]Resource{
+		{ID: "project_demo", Kind: KindProject, Name: "demo"},
+		{ID: "semantic_model:orders", Kind: KindModel, Name: "semantic_model:orders"},
+	}, nil); !errors.Is(err, ErrInvalidName) {
+		t.Fatalf("NewProjectGraph() error = %v, want symbolic name rejection", err)
+	}
+}
+
+func TestCanonicalBytesAndDigestAreDeterministic(t *testing.T) {
+	resources := []Resource{
+		{ID: "project_demo", Kind: KindProject, Name: "demo"},
+		{ID: "dashboard_main", Kind: KindDashboard, Name: "main", Metadata: Metadata{Tags: []string{"insights", "core"}}},
+		{ID: "model_orders", Kind: KindModel, Name: "orders"},
+		{ID: "source_warehouse", Kind: KindSource, Name: "warehouse"},
+	}
+	edges := []Edge{
+		{From: "model_orders", To: "source_warehouse"},
+		{From: "dashboard_main", To: "model_orders"},
+	}
+	first, err := NewProjectGraph(resources, edges)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewProjectGraph([]Resource{resources[2], resources[0], resources[1], resources[3]}, []Edge{edges[1], edges[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first.CanonicalBytes(), second.CanonicalBytes()) {
+		t.Fatalf("canonical bytes differ:\n%s\n%s", first.CanonicalBytes(), second.CanonicalBytes())
+	}
+	if first.Digest() != second.Digest() || !strings.HasPrefix(first.Digest(), "sha256:") {
+		t.Fatalf("digest = %q and %q", first.Digest(), second.Digest())
+	}
+	if got := string(first.CanonicalBytes()); got != `{"version":1,"resources":[{"id":"dashboard_main","kind":"dashboard","name":"main","metadata":{"tags":["core","insights"]},"provenance":{}},{"id":"model_orders","kind":"model","name":"orders","metadata":{},"provenance":{}},{"id":"project_demo","kind":"project","name":"demo","metadata":{},"provenance":{}},{"id":"source_warehouse","kind":"source","name":"warehouse","metadata":{},"provenance":{}}],"edges":[{"from":"dashboard_main","to":"model_orders"},{"from":"model_orders","to":"source_warehouse"}]}` {
+		t.Fatalf("canonical bytes = %s", got)
+	}
+}
+
+func TestSharedResourceAppearsOnceAcrossSemanticDomains(t *testing.T) {
+	resources := []Resource{
+		{ID: "project_demo", Kind: KindProject, Name: "demo"},
+		{ID: "model_date", Kind: KindModel, Name: "date", Metadata: Metadata{Domain: "shared"}},
+		{ID: "semantic_sales", Kind: KindSemanticModel, Name: "sales", Metadata: Metadata{Domain: "sales"}},
+		{ID: "semantic_finance", Kind: KindSemanticModel, Name: "finance", Metadata: Metadata{Domain: "finance"}},
+	}
+	edges := []Edge{
+		{From: "semantic_sales", To: "model_date"},
+		{From: "semantic_finance", To: "model_date"},
+	}
+	project, err := NewProjectGraph(resources, edges)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(project.Resources()); got != len(resources) {
+		t.Fatalf("resource count = %d, want shared model represented once in %d resources", got, len(resources))
+	}
+	shared, ok := project.Resource("model_date")
+	if !ok || shared.Metadata.Domain != "shared" {
+		t.Fatalf("shared resource = %#v, want one shared model", shared)
+	}
+	if got := len(project.Edges()); got != 2 {
+		t.Fatalf("edge count = %d, want two cross-domain references", got)
+	}
+	for _, edge := range project.Edges() {
+		if edge.To != "model_date" {
+			t.Fatalf("edge = %#v, want shared model endpoint", edge)
+		}
+		if _, ok := project.Resource(edge.From); !ok {
+			t.Fatalf("edge source %q is not in graph", edge.From)
+		}
+	}
+}
+
+func TestGraphDefensivelyCopiesInputsAndOutputs(t *testing.T) {
+	resources := []Resource{{ID: "project_demo", Kind: KindProject, Name: "demo"}, {ID: "model_orders", Kind: KindModel, Name: "orders", Metadata: Metadata{Tags: []string{"orders"}}}}
+	edges := []Edge{{From: "model_orders", To: "model_orders"}}
+	// A self-edge is a cycle, so construct with an acyclic edge below.
+	edges[0].To = "model_orders_view"
+	resources = append(resources, Resource{ID: "model_orders_view", Kind: KindModel, Name: "orders_view"})
+	g, err := NewProjectGraph(resources, edges)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resources[1].Metadata.Tags[0] = "changed"
+	edges[0].From = "model_orders_view"
+	got, ok := g.Resource("model_orders")
+	if !ok || got.Metadata.Tags[0] != "orders" {
+		t.Fatalf("graph retained mutable input: %#v", got)
+	}
+	got.Metadata.Tags[0] = "changed again"
+	again, _ := g.Resource("model_orders")
+	if again.Metadata.Tags[0] != "orders" {
+		t.Fatalf("resource lookup escaped immutable graph: %#v", again)
+	}
+	returned := g.Resources()
+	for index := range returned {
+		if returned[index].ID == "model_orders" {
+			returned[index].Metadata.Tags[0] = "changed yet again"
+		}
+	}
+	if got, _ := g.Resource("model_orders"); got.Metadata.Tags[0] != "orders" {
+		t.Fatalf("resources escaped immutable graph: %#v", got)
+	}
+}
+
+func TestValidationRejectsMalformedIDsAndKinds(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []Resource
+		want      error
+	}{
+		{name: "empty id", resources: []Resource{{Kind: KindModel}}, want: ErrInvalidResourceID},
+		{name: "path id", resources: []Resource{{ID: "models/orders", Kind: KindModel}}, want: ErrInvalidResourceID},
+		{name: "whitespace id", resources: []Resource{{ID: " orders", Kind: KindModel}}, want: ErrInvalidResourceID},
+		{name: "invalid kind", resources: []Resource{{ID: "orders", Kind: "table"}}, want: ErrInvalidKind},
+		{name: "missing name", resources: []Resource{{ID: "orders", Kind: KindModel}}, want: ErrInvalidName},
+		{name: "invalid name", resources: []Resource{{ID: "orders", Kind: KindModel, Name: "orders/view"}}, want: ErrInvalidName},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Validate(test.resources, nil); !errors.Is(err, test.want) {
+				t.Fatalf("Validate() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidationRejectsDuplicateIDsNamesAndEdges(t *testing.T) {
+	base := []Resource{
+		{ID: "model_one", Kind: KindModel, Name: "one"},
+		{ID: "model_two", Kind: KindModel, Name: "two"},
+	}
+	tests := []struct {
+		name      string
+		resources []Resource
+		edges     []Edge
+		want      error
+	}{
+		{name: "duplicate id", resources: append(append([]Resource(nil), base...), Resource{ID: "model_one", Kind: KindSource, Name: "three"}), want: ErrDuplicateResourceID},
+		{name: "duplicate name", resources: []Resource{{ID: "model_one", Kind: KindModel, Name: "same"}, {ID: "model_two", Kind: KindSource, Name: "same"}}, want: ErrDuplicateName},
+		{name: "missing from", resources: base, edges: []Edge{{From: "missing", To: "model_one"}}, want: ErrMissingEndpoint},
+		{name: "missing to", resources: base, edges: []Edge{{From: "model_one", To: "missing"}}, want: ErrMissingEndpoint},
+		{name: "duplicate edge", resources: base, edges: []Edge{{From: "model_one", To: "model_two"}, {From: "model_one", To: "model_two", Relation: "refresh"}}, want: ErrDuplicateEdge},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Validate(test.resources, test.edges); !errors.Is(err, test.want) {
+				t.Fatalf("Validate() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidationRejectsCycles(t *testing.T) {
+	resources := []Resource{
+		{ID: "a", Kind: KindModel, Name: "a"},
+		{ID: "b", Kind: KindModel, Name: "b"},
+		{ID: "c", Kind: KindModel, Name: "c"},
+	}
+	edges := []Edge{{From: "a", To: "b"}, {From: "b", To: "c"}, {From: "c", To: "a"}}
+	if err := Validate(resources, edges); !errors.Is(err, ErrCycle) {
+		t.Fatalf("Validate() error = %v, want cycle", err)
+	}
+
+	if _, err := NewProjectGraph([]Resource{{ID: "project_demo", Kind: KindProject, Name: "demo"}, {ID: "a", Kind: KindModel, Name: "a"}}, []Edge{{From: "a", To: "a"}}); !errors.Is(err, ErrCycle) {
+		t.Fatalf("NewProjectGraph() error = %v, want self-cycle", err)
+	}
+}
+
+func TestDecodeCanonicalGraph(t *testing.T) {
+	original, err := NewProjectGraph([]Resource{{ID: "project_demo", Kind: KindProject, Name: "demo"}, {ID: "source_orders", Kind: KindSource, Name: "orders"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := Decode(original.CanonicalBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(original.CanonicalBytes(), decoded.CanonicalBytes()) || original.Digest() != decoded.Digest() {
+		t.Fatalf("decoded graph changed canonical artifact")
+	}
+	_, err = Decode([]byte(`{"version":99,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}`))
+	var unsupported UnsupportedVersionError
+	if !errors.As(err, &unsupported) || unsupported.Contract != "project graph" || unsupported.Version != 99 {
+		t.Fatalf("Decode() error = %v, want graph UnsupportedVersionError", err)
+	}
+	if err == nil {
+		t.Fatal("Decode() accepted unsupported version")
+	}
+	artifactBytes := `{"version":99,"identity":{"projectId":"project_demo","environment":"production","generationId":"generation_1"},"graph":{"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}}`
+	_, err = DecodeArtifactEnvelope([]byte(artifactBytes))
+	unsupported = UnsupportedVersionError{}
+	if !errors.As(err, &unsupported) || unsupported.Contract != "project artifact" || unsupported.Version != 99 {
+		t.Fatalf("DecodeArtifactEnvelope() error = %v, want artifact UnsupportedVersionError", err)
+	}
+}
+
+func TestProjectGraphRequiresExactlyOneProjectRoot(t *testing.T) {
+	resources := []Resource{{ID: "model_orders", Kind: KindModel, Name: "orders"}}
+	if _, err := NewProjectGraph(resources, nil); !errors.Is(err, ErrProjectRoot) {
+		t.Fatalf("NewProjectGraph() error = %v, want missing project root", err)
+	}
+	resources = append(resources, Resource{ID: "project_one", Kind: KindProject, Name: "one"}, Resource{ID: "project_two", Kind: KindProject, Name: "two"})
+	if _, err := NewProjectGraph(resources, nil); !errors.Is(err, ErrProjectRoot) {
+		t.Fatalf("NewProjectGraph() error = %v, want multiple project roots", err)
+	}
+}
+
+func TestArtifactEnvelopeBindsPortableGraphToServingIdentity(t *testing.T) {
+	project, err := NewProjectGraph([]Resource{
+		{ID: "project_demo", Kind: KindProject, Name: "demo"},
+		{ID: "model_orders", Kind: KindModel, Name: "orders"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := ServingIdentity{ProjectID: "project_demo", Environment: "production", GenerationID: "generation_7"}
+	envelope, err := NewArtifactEnvelope(identity, project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Identity().ProjectID != project.ProjectID() || envelope.Identity().Environment != "production" || envelope.Identity().GenerationID != "generation_7" {
+		t.Fatalf("serving identity = %#v", envelope.Identity())
+	}
+	wantCanonical := `{"version":1,"identity":{"projectId":"project_demo","environment":"production","generationId":"generation_7"},"graph":{"version":1,"resources":[{"id":"model_orders","kind":"model","name":"orders","metadata":{},"provenance":{}},{"id":"project_demo","kind":"project","name":"demo","metadata":{},"provenance":{}}],"edges":[]}}`
+	if got := string(envelope.CanonicalBytes()); got != wantCanonical {
+		t.Fatalf("canonical artifact = %s, want %s", got, wantCanonical)
+	}
+	if bytes.Equal(envelope.CanonicalBytes(), project.CanonicalBytes()) {
+		t.Fatal("serving envelope unexpectedly equals portable graph bytes")
+	}
+	if strings.Contains(string(project.CanonicalBytes()), "workspace") || strings.Contains(string(envelope.CanonicalBytes()), "workspace") {
+		t.Fatalf("canonical contract contains workspace identity: %s", envelope.CanonicalBytes())
+	}
+	decoded, err := DecodeArtifactEnvelope(envelope.CanonicalBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Digest() != envelope.Digest() || decoded.Graph().Digest() != project.Digest() {
+		t.Fatalf("decoded artifact changed canonical identity")
+	}
+	if _, err := NewArtifactEnvelope(ServingIdentity{ProjectID: "other_project", Environment: "production", GenerationID: "generation_7"}, project); !errors.Is(err, ErrProjectIdentityMismatch) {
+		t.Fatalf("NewArtifactEnvelope() error = %v, want project mismatch", err)
+	}
+	if _, err := NewArtifactEnvelope(ServingIdentity{ProjectID: "project_demo", Environment: "production", GenerationID: "01J8N3YQ6F7T8V9W0X1Y2Z3A4B:serve"}, project); err != nil {
+		t.Fatalf("NewArtifactEnvelope() rejected opaque generation ID: %v", err)
+	}
+}
+
+func TestArtifactEnvelopeRejectsMalformedServingIdentity(t *testing.T) {
+	project, err := NewProjectGraph([]Resource{{ID: "project_demo", Kind: KindProject, Name: "demo"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []ServingIdentity{
+		{ProjectID: "project_demo", Environment: "", GenerationID: "generation_1"},
+		{ProjectID: "project_demo", Environment: "production", GenerationID: ""},
+		{ProjectID: "project_demo", Environment: "production/env", GenerationID: "generation_1"},
+		{ProjectID: "project_demo", Environment: "production", GenerationID: "generation 1"},
+		{ProjectID: "bad/project", Environment: "production", GenerationID: "generation_1"},
+	}
+	for _, identity := range tests {
+		if _, err := NewArtifactEnvelope(identity, project); !errors.Is(err, ErrInvalidServingIdentity) {
+			t.Fatalf("NewArtifactEnvelope(%#v) error = %v, want malformed identity", identity, err)
+		}
+	}
+}
+
+func TestServingIdentityCanBeValidatedBeforeArtifactBinding(t *testing.T) {
+	identity, err := NewServingIdentity("project_demo", "production", "generation_7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := identity.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if identity.ProjectID != "project_demo" || identity.Environment != "production" || identity.GenerationID != "generation_7" {
+		t.Fatalf("identity = %#v", identity)
+	}
+	if _, err := NewServingIdentity("project_demo", "production/env", "generation_7"); !errors.Is(err, ErrInvalidServingIdentity) {
+		t.Fatalf("invalid environment error = %v", err)
+	}
+	if err := (ServingIdentity{}).Validate(); !errors.Is(err, ErrInvalidServingIdentity) {
+		t.Fatalf("zero identity error = %v", err)
+	}
+}
+
+func TestDecodeRejectsWorkspaceFieldsAndKinds(t *testing.T) {
+	workspaceField := `{"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo","workspace":"legacy"}],"edges":[]}`
+	if _, err := Decode([]byte(workspaceField)); err == nil {
+		t.Fatal("Decode() accepted workspace field")
+	}
+	workspaceKind := `{"version":1,"resources":[{"id":"project_demo","kind":"workspace","name":"demo"}],"edges":[]}`
+	if _, err := Decode([]byte(workspaceKind)); !errors.Is(err, ErrInvalidKind) {
+		t.Fatalf("Decode() error = %v, want invalid workspace kind", err)
+	}
+
+	artifactWorkspaceField := `{"version":1,"identity":{"projectId":"project_demo","environment":"production","generationId":"generation_1","workspaceId":"legacy"},"graph":{"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}}`
+	if _, err := DecodeArtifactEnvelope([]byte(artifactWorkspaceField)); err == nil {
+		t.Fatal("DecodeArtifactEnvelope() accepted workspaceId field")
+	}
+	artifactWorkspaceKind := `{"version":1,"identity":{"projectId":"project_demo","environment":"production","generationId":"generation_1"},"graph":{"version":1,"resources":[{"id":"project_demo","kind":"workspace","name":"demo"}],"edges":[]}}`
+	if _, err := DecodeArtifactEnvelope([]byte(artifactWorkspaceKind)); !errors.Is(err, ErrInvalidKind) {
+		t.Fatalf("DecodeArtifactEnvelope() error = %v, want invalid workspace kind", err)
+	}
+}
+
+func TestDecodersRejectDuplicateJSONKeysRecursively(t *testing.T) {
+	graphCases := []string{
+		`{"version":1,"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}`,
+		`{"version":1,"resources":[{"id":"project_demo","id":"project_demo","kind":"project","name":"demo"}],"edges":[]}`,
+		`{"version":1,"resources":[{"id":"project_demo","kind":"project","kind":"project","name":"demo"}],"edges":[]}`,
+		`{"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo","metadata":{"domain":"a","domain":"b"}}],"edges":[]}`,
+	}
+	for _, input := range graphCases {
+		if _, err := Decode([]byte(input)); err == nil {
+			t.Fatalf("Decode() accepted duplicate key: %s", input)
+		}
+	}
+	artifactCases := []string{
+		`{"version":1,"version":1,"identity":{"projectId":"project_demo","environment":"production","generationId":"generation_1"},"graph":{"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}}`,
+		`{"version":1,"identity":{"projectId":"project_demo","projectId":"other","environment":"production","generationId":"generation_1"},"graph":{"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}}`,
+	}
+	for _, input := range artifactCases {
+		if _, err := DecodeArtifactEnvelope([]byte(input)); err == nil {
+			t.Fatalf("DecodeArtifactEnvelope() accepted duplicate key: %s", input)
+		}
+	}
+}
+
+func TestDecodersRejectCaseFoldedDuplicateJSONKeys(t *testing.T) {
+	graph := `{"version":1,"Version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}`
+	if _, err := Decode([]byte(graph)); err == nil {
+		t.Fatal("Decode() accepted case-folded duplicate version key")
+	}
+
+	artifact := `{"version":1,"identity":{"projectId":"project_demo","ProjectID":"project_demo","environment":"production","generationId":"generation_one"},"graph":{"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}}`
+	if _, err := DecodeArtifactEnvelope([]byte(artifact)); err == nil {
+		t.Fatal("DecodeArtifactEnvelope() accepted case-folded duplicate project ID key")
+	}
+}
+
+func TestDecodeRejectsTrailingJSONValues(t *testing.T) {
+	graph := `{"version":1,"resources":[{"id":"project_demo","kind":"project","name":"demo"}],"edges":[]}`
+	if _, err := Decode([]byte(graph + graph)); err == nil {
+		t.Fatal("Decode() accepted trailing JSON")
+	}
+	artifact := `{"version":1,"identity":{"projectId":"project_demo","environment":"production","generationId":"generation_1"},"graph":` + graph + `}`
+	if _, err := DecodeArtifactEnvelope([]byte(artifact + artifact)); err == nil {
+		t.Fatal("DecodeArtifactEnvelope() accepted trailing JSON")
+	}
+}


### PR DESCRIPTION
Implements LEA-369.

Defines the immutable project-wide resource graph, stable opaque resource IDs, deterministic canonical serialization and digesting, typed dependency edges, global duplicate/missing/cycle validation, and the explicit project/environment/generation serving identity envelope required by ADR-0005.

The contract has no workspace kind, namespace, selector, or compatibility identity. Metadata and provenance remain descriptive and do not participate in identity.

Verification:
- go test ./internal/project/graph/... ./internal/platform/architecture/...
- task ci (same resulting tree validated before re-anchoring onto merged guardrail)

Depends on merged guardrail PR #301.