### PR TITLE
Define project-wide resource access contracts

### DIFF
--- a/internal/access/canonical_contract.go
+++ b/internal/access/canonical_contract.go
@@ -1,0 +1,525 @@
+package access
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/flidai/leapview/internal/project/graph"
+)
+
+var (
+	// ErrInvalidResourceRef indicates that a canonical resource reference has
+	// an invalid graph ID or kind.
+	ErrInvalidResourceRef = errors.New("invalid canonical resource reference")
+	// ErrResourceNotFound indicates that a reference ID is absent from the
+	// authoritative project graph.
+	ErrResourceNotFound = errors.New("canonical resource is not in project graph")
+	// ErrResourceKindMismatch indicates that a reference kind does not match the
+	// authoritative graph node for its ID.
+	ErrResourceKindMismatch = errors.New("canonical resource kind does not match project graph")
+	// ErrInvalidCapability indicates a capability outside the canonical access
+	// contract.
+	ErrInvalidCapability = errors.New("invalid canonical capability")
+	// ErrCapabilityNotAllowed indicates that a capability is valid in general,
+	// but not for the referenced graph kind.
+	ErrCapabilityNotAllowed = errors.New("canonical capability is not allowed for resource kind")
+	// ErrInvalidCanonicalGrant indicates a grant with a missing subject or an
+	// invalid resource reference.
+	ErrInvalidCanonicalGrant = errors.New("invalid canonical grant")
+	// ErrUnboundCanonicalGrant indicates a grant that was not validated against
+	// the immutable project graph that authorizes its resource identity.
+	ErrUnboundCanonicalGrant = errors.New("canonical grant is not bound to a project graph")
+	// ErrInvalidSubjectRef indicates a missing or unsupported subject identity.
+	ErrInvalidSubjectRef = errors.New("invalid canonical subject reference")
+)
+
+// ResourceRef is the canonical authorization and audit reference for one
+// project graph resource. The ID is the sole identity component; kind is
+// retained for validation and capability selection, but is not part of the
+// canonical key. Descriptive metadata, paths, domains, and parent references
+// intentionally do not appear in this type.
+//
+// ResourceRef values are constructor-only. The constructor is the trust
+// boundary for authored references; ValidateAgainst must additionally be
+// called before installing a reference into an authorization store.
+type ResourceRef struct {
+	id   graph.ResourceID
+	kind graph.Kind
+}
+
+// NewResourceRef validates an explicit graph resource ID and kind.
+func NewResourceRef(id graph.ResourceID, kind graph.Kind) (ResourceRef, error) {
+	validatedID, err := graph.NewResourceID(id.String())
+	if err != nil {
+		return ResourceRef{}, fmt.Errorf("%w: %w", ErrInvalidResourceRef, err)
+	}
+	validatedKind, err := graph.ParseKind(string(kind))
+	if err != nil {
+		return ResourceRef{}, fmt.Errorf("%w: %w", ErrInvalidResourceRef, err)
+	}
+	return ResourceRef{id: validatedID, kind: validatedKind}, nil
+}
+
+// ID returns the validated graph resource ID.
+func (r ResourceRef) ID() graph.ResourceID { return r.id }
+
+// Kind returns the validated graph resource kind.
+func (r ResourceRef) Kind() graph.Kind { return r.kind }
+
+// Validate checks a reference. Zero values and values assembled inside this
+// package are rejected unless they came through NewResourceRef.
+func (r ResourceRef) Validate() error {
+	validated, err := NewResourceRef(r.id, r.kind)
+	if err != nil {
+		return err
+	}
+	if validated.id != r.id || validated.kind != r.kind {
+		return ErrInvalidResourceRef
+	}
+	return nil
+}
+
+// ValidateAgainst checks that the ID and kind agree with the authoritative
+// project graph. This check is mandatory before installing authored grants;
+// otherwise a caller could relabel a resource ID with another kind.
+func (r ResourceRef) ValidateAgainst(project graph.ProjectGraph) error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	resource, ok := project.Resource(r.id)
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrResourceNotFound, r.id)
+	}
+	if resource.Kind != r.kind {
+		return fmt.Errorf("%w: id %q is %q, reference is %q", ErrResourceKindMismatch, r.id, resource.Kind, r.kind)
+	}
+	return nil
+}
+
+// CanonicalID returns the globally unique graph resource ID. It is the sole
+// resource component of authorization and audit keys.
+func (r ResourceRef) CanonicalID() string {
+	if err := r.Validate(); err != nil {
+		return ""
+	}
+	return r.id.String()
+}
+
+type resourceRefWire struct {
+	ID   graph.ResourceID `json:"id"`
+	Kind graph.Kind       `json:"kind"`
+}
+
+// MarshalJSON emits only the canonical ID and descriptive kind, rejecting
+// invalid values before they cross a serialization boundary.
+func (r ResourceRef) MarshalJSON() ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(resourceRefWire{ID: r.id, Kind: r.kind})
+}
+
+// UnmarshalJSON validates IDs and kinds, rejecting duplicate/unknown/trailing
+// JSON values.
+func (r *ResourceRef) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("cannot unmarshal canonical resource reference into nil receiver")
+	}
+	var decoded resourceRefWire
+	if err := decodeCanonicalJSON(data, &decoded, "canonical resource reference"); err != nil {
+		return err
+	}
+	validated, err := NewResourceRef(decoded.ID, decoded.Kind)
+	if err != nil {
+		return err
+	}
+	*r = validated
+	return nil
+}
+
+// Capability is an authorization action in the project/resource contract. It
+// is distinct from the legacy privilege vocabulary.
+type Capability string
+
+const (
+	CapabilityProjectAdmin    Capability = "PROJECT_ADMIN"
+	CapabilityResourceUse     Capability = "RESOURCE_USE"
+	CapabilityResourceRead    Capability = "RESOURCE_READ"
+	CapabilityResourceEdit    Capability = "RESOURCE_EDIT"
+	CapabilityResourceManage  Capability = "RESOURCE_MANAGE"
+	CapabilityResourceShare   Capability = "RESOURCE_SHARE"
+	CapabilityResourcePublish Capability = "RESOURCE_PUBLISH"
+)
+
+var canonicalCapabilityOrder = []Capability{
+	CapabilityProjectAdmin,
+	CapabilityResourceUse,
+	CapabilityResourceRead,
+	CapabilityResourceEdit,
+	CapabilityResourceManage,
+	CapabilityResourceShare,
+	CapabilityResourcePublish,
+}
+
+var canonicalCapabilitySet = map[Capability]struct{}{
+	CapabilityProjectAdmin:    {},
+	CapabilityResourceUse:     {},
+	CapabilityResourceRead:    {},
+	CapabilityResourceEdit:    {},
+	CapabilityResourceManage:  {},
+	CapabilityResourceShare:   {},
+	CapabilityResourcePublish: {},
+}
+
+// ParseCapability validates a canonical capability wire value.
+func ParseCapability(value string) (Capability, error) {
+	capability := Capability(value)
+	if _, ok := canonicalCapabilitySet[capability]; !ok {
+		return "", fmt.Errorf("%w %q", ErrInvalidCapability, value)
+	}
+	return capability, nil
+}
+
+// Valid reports whether capability belongs to the canonical capability set.
+func (capability Capability) Valid() bool {
+	_, ok := canonicalCapabilitySet[capability]
+	return ok
+}
+
+// Validate checks a canonical capability value.
+func (capability Capability) Validate() error {
+	if !capability.Valid() {
+		return fmt.Errorf("%w %q", ErrInvalidCapability, capability)
+	}
+	return nil
+}
+
+// String returns the wire representation of a capability.
+func (capability Capability) String() string { return string(capability) }
+
+// MarshalText rejects invalid capability values and supports the canonical
+// text representation in encoders using encoding.TextMarshaler.
+func (capability Capability) MarshalText() ([]byte, error) {
+	if err := capability.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(capability), nil
+}
+
+// UnmarshalText validates a canonical capability wire value.
+func (capability *Capability) UnmarshalText(data []byte) error {
+	if capability == nil {
+		return errors.New("cannot unmarshal canonical capability into nil receiver")
+	}
+	parsed, err := ParseCapability(string(data))
+	if err != nil {
+		return err
+	}
+	*capability = parsed
+	return nil
+}
+
+// CanonicalCapabilities returns every capability in deterministic contract
+// order. The returned slice is defensive.
+func CanonicalCapabilities() []Capability {
+	return append([]Capability(nil), canonicalCapabilityOrder...)
+}
+
+// canonicalCapabilityMatrix is immutable package state. CapabilitiesForKind
+// always returns defensive copies.
+var canonicalCapabilityMatrix = map[graph.Kind][]Capability{
+	graph.KindProject:       {CapabilityProjectAdmin},
+	graph.KindConnection:    {CapabilityResourceUse, CapabilityResourceRead, CapabilityResourceEdit, CapabilityResourceManage},
+	graph.KindSource:        {CapabilityResourceUse, CapabilityResourceRead, CapabilityResourceEdit, CapabilityResourceManage},
+	graph.KindModel:         {CapabilityResourceUse, CapabilityResourceRead, CapabilityResourceEdit, CapabilityResourceManage},
+	graph.KindSemanticModel: {CapabilityResourceUse, CapabilityResourceRead, CapabilityResourceEdit, CapabilityResourceManage},
+	graph.KindPipeline:      {CapabilityResourceUse, CapabilityResourceRead, CapabilityResourceEdit, CapabilityResourceManage},
+	graph.KindDashboard:     {CapabilityResourceRead, CapabilityResourceEdit, CapabilityResourceManage, CapabilityResourceShare, CapabilityResourcePublish},
+}
+
+// CapabilitiesForKind returns the capabilities allowed for kind in stable
+// contract order. Invalid kinds return nil.
+func CapabilitiesForKind(kind graph.Kind) []Capability {
+	if !kind.Valid() {
+		return nil
+	}
+	return append([]Capability(nil), canonicalCapabilityMatrix[kind]...)
+}
+
+// SupportsCapability reports whether capability is valid for kind. Invalid
+// kinds and capabilities are denied.
+func SupportsCapability(kind graph.Kind, capability Capability) bool {
+	if !kind.Valid() || !capability.Valid() {
+		return false
+	}
+	for _, allowed := range canonicalCapabilityMatrix[kind] {
+		if allowed == capability {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateCapabilityForKind validates a capability against the deliberate
+// kind matrix.
+func ValidateCapabilityForKind(kind graph.Kind, capability Capability) error {
+	if !kind.Valid() {
+		return fmt.Errorf("%w: %w", ErrInvalidResourceRef, graph.ErrInvalidKind)
+	}
+	if err := capability.Validate(); err != nil {
+		return err
+	}
+	if !SupportsCapability(kind, capability) {
+		return fmt.Errorf("%w: kind %q, capability %q", ErrCapabilityNotAllowed, kind, capability)
+	}
+	return nil
+}
+
+// SubjectKind identifies the explicit subject class used by canonical grants.
+// Service principals use SubjectKindPrincipal.
+type SubjectKind string
+
+const (
+	SubjectKindPrincipal SubjectKind = "principal"
+	SubjectKindGroup     SubjectKind = "group"
+)
+
+// SubjectRef identifies one principal or group. Domain membership is not a
+// subject kind and therefore cannot be represented as authorization.
+type SubjectRef struct {
+	Kind SubjectKind `json:"kind"`
+	ID   string      `json:"id"`
+}
+
+// NewSubjectRef validates an explicit subject kind and opaque ID.
+func NewSubjectRef(kind SubjectKind, id string) (SubjectRef, error) {
+	if kind != SubjectKindPrincipal && kind != SubjectKindGroup {
+		return SubjectRef{}, fmt.Errorf("%w: kind %q", ErrInvalidSubjectRef, kind)
+	}
+	id = strings.TrimSpace(id)
+	if id == "" || strings.ContainsAny(id, "\x00\r\n\t") {
+		return SubjectRef{}, fmt.Errorf("%w: subject ID is blank or contains control characters", ErrInvalidSubjectRef)
+	}
+	return SubjectRef{Kind: kind, ID: id}, nil
+}
+
+// Validate checks a subject that may have been assembled as a struct literal.
+func (subject SubjectRef) Validate() error {
+	validated, err := NewSubjectRef(subject.Kind, subject.ID)
+	if err != nil {
+		return err
+	}
+	if validated != subject {
+		return ErrInvalidSubjectRef
+	}
+	return nil
+}
+
+// CanonicalGrant records one explicit subject capability on one resource.
+// There is no domain, path, display, or parent field: authorization is always
+// evaluated against this resource and this capability directly.
+type CanonicalGrant struct {
+	subject    SubjectRef
+	resource   ResourceRef
+	capability Capability
+	projectID  graph.ResourceID
+}
+
+// Subject returns the explicit principal or group by value.
+func (grant CanonicalGrant) Subject() SubjectRef { return grant.subject }
+
+// Resource returns the immutable canonical resource reference by value.
+func (grant CanonicalGrant) Resource() ResourceRef { return grant.resource }
+
+// Capability returns the authorized canonical capability.
+func (grant CanonicalGrant) Capability() Capability { return grant.capability }
+
+// NewCanonicalGrant validates a subject, resource, and kind-specific
+// capability against the authoritative immutable project graph. There is no
+// constructor for an installable grant that omits this graph check.
+func NewCanonicalGrant(project graph.ProjectGraph, subject SubjectRef, resource ResourceRef, capability Capability) (CanonicalGrant, error) {
+	if err := project.Validate(); err != nil {
+		return CanonicalGrant{}, fmt.Errorf("%w: project graph: %w", ErrInvalidCanonicalGrant, err)
+	}
+	if err := subject.Validate(); err != nil {
+		return CanonicalGrant{}, fmt.Errorf("%w: subject: %w", ErrInvalidCanonicalGrant, err)
+	}
+	if err := resource.Validate(); err != nil {
+		return CanonicalGrant{}, fmt.Errorf("%w: resource: %w", ErrInvalidCanonicalGrant, err)
+	}
+	if err := ValidateCapabilityForKind(resource.kind, capability); err != nil {
+		return CanonicalGrant{}, fmt.Errorf("%w: %w", ErrInvalidCanonicalGrant, err)
+	}
+	if err := resource.ValidateAgainst(project); err != nil {
+		return CanonicalGrant{}, fmt.Errorf("%w: resource: %w", ErrInvalidCanonicalGrant, err)
+	}
+	return CanonicalGrant{subject: subject, resource: resource, capability: capability, projectID: project.ProjectID()}, nil
+}
+
+// Validate checks that the grant was constructed against an authoritative
+// project graph and that its canonical fields remain valid.
+func (grant CanonicalGrant) Validate() error {
+	if grant.projectID == "" {
+		return fmt.Errorf("%w: %w", ErrInvalidCanonicalGrant, ErrUnboundCanonicalGrant)
+	}
+	if err := grant.subject.Validate(); err != nil {
+		return fmt.Errorf("%w: subject: %w", ErrInvalidCanonicalGrant, err)
+	}
+	if err := grant.resource.Validate(); err != nil {
+		return fmt.Errorf("%w: resource: %w", ErrInvalidCanonicalGrant, err)
+	}
+	if err := ValidateCapabilityForKind(grant.resource.kind, grant.capability); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidCanonicalGrant, err)
+	}
+	return nil
+}
+
+// ValidateAgainst checks the resource ID and kind against the authoritative
+// project graph, then checks the capability matrix. This prevents a caller
+// from relabeling a model ID as a dashboard to obtain publication access.
+func (grant CanonicalGrant) ValidateAgainst(project graph.ProjectGraph) error {
+	if err := grant.Validate(); err != nil {
+		return err
+	}
+	if project.ProjectID() != grant.projectID {
+		return fmt.Errorf("%w: project identity %q does not match bound project %q", ErrInvalidCanonicalGrant, project.ProjectID(), grant.projectID)
+	}
+	if err := grant.resource.ValidateAgainst(project); err != nil {
+		return fmt.Errorf("%w: resource: %w", ErrInvalidCanonicalGrant, err)
+	}
+	return nil
+}
+
+// MarshalJSON validates the whole grant before serialization.
+func (grant CanonicalGrant) MarshalJSON() ([]byte, error) {
+	if err := grant.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(canonicalGrantWire{Subject: grant.subject, Resource: grant.resource, Capability: grant.capability})
+}
+
+type canonicalGrantWire struct {
+	Subject    SubjectRef  `json:"subject"`
+	Resource   ResourceRef `json:"resource"`
+	Capability Capability  `json:"capability"`
+}
+
+// DecodeCanonicalGrant validates canonical JSON against the authoritative
+// graph. Standard json.Unmarshal cannot supply that graph and is deliberately
+// rejected by UnmarshalJSON so decoded grants can never appear installable.
+func DecodeCanonicalGrant(data []byte, project graph.ProjectGraph) (CanonicalGrant, error) {
+	var decoded canonicalGrantWire
+	if err := decodeCanonicalJSON(data, &decoded, "canonical grant"); err != nil {
+		return CanonicalGrant{}, err
+	}
+	return NewCanonicalGrant(project, decoded.Subject, decoded.Resource, decoded.Capability)
+}
+
+// UnmarshalJSON rejects graph-free decoding. Use DecodeCanonicalGrant.
+func (grant *CanonicalGrant) UnmarshalJSON(data []byte) error {
+	if grant == nil {
+		return errors.New("cannot unmarshal canonical grant into nil receiver")
+	}
+	return ErrUnboundCanonicalGrant
+}
+
+// GrantKey returns a deterministic subject/resource/capability key. Subject
+// kind and ID are both included to avoid principal/group collisions; the
+// resource portion is the globally unique graph ResourceID.
+func (grant CanonicalGrant) GrantKey() string {
+	if err := grant.Validate(); err != nil {
+		return ""
+	}
+	return string(grant.subject.Kind) + "\x00" + grant.subject.ID + "\x00" + grant.resource.CanonicalID() + "\x00" + grant.capability.String()
+}
+
+func decodeCanonicalJSON(data []byte, target any, label string) error {
+	if err := rejectDuplicateCanonicalJSONKeys(data); err != nil {
+		return fmt.Errorf("decode %s: %w", label, err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("decode %s: %w", label, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return fmt.Errorf("decode %s: trailing JSON value", label)
+	} else if !errors.Is(err, io.EOF) {
+		return fmt.Errorf("decode %s: trailing data: %w", label, err)
+	}
+	return nil
+}
+
+func rejectDuplicateCanonicalJSONKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := walkCanonicalJSONValue(decoder); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return errors.New("trailing JSON value")
+	} else if !errors.Is(err, io.EOF) {
+		return fmt.Errorf("trailing data: %w", err)
+	}
+	return nil
+}
+
+func walkCanonicalJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	switch delimiter := token.(type) {
+	case json.Delim:
+		switch delimiter {
+		case '{':
+			keys := make(map[string]struct{})
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return errors.New("JSON object key is not a string")
+				}
+				canonicalKey := strings.ToLower(key)
+				if _, exists := keys[canonicalKey]; exists {
+					return fmt.Errorf("duplicate JSON object key %q", key)
+				}
+				keys[canonicalKey] = struct{}{}
+				if err := walkCanonicalJSONValue(decoder); err != nil {
+					return err
+				}
+			}
+			end, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if end != json.Delim('}') {
+				return fmt.Errorf("JSON object ended with %v", end)
+			}
+		case '[':
+			for decoder.More() {
+				if err := walkCanonicalJSONValue(decoder); err != nil {
+					return err
+				}
+			}
+			end, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if end != json.Delim(']') {
+				return fmt.Errorf("JSON array ended with %v", end)
+			}
+		default:
+			return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+		}
+	}
+	return nil
+}

--- a/internal/access/canonical_contract_test.go
+++ b/internal/access/canonical_contract_test.go
@@ -1,0 +1,303 @@
+package access
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/project/graph"
+)
+
+func TestResourceRefIdentityIsIndependentOfDescriptiveMetadata(t *testing.T) {
+	id, err := graph.NewResourceID("model_orders")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := NewResourceRef(id, graph.KindModel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource := graph.Resource{
+		ID: id, Kind: graph.KindModel, Name: "orders",
+		Metadata:   graph.Metadata{DisplayName: "Orders", Domain: "commerce"},
+		Provenance: graph.Provenance{Path: "models/orders.yaml", Origin: "project"},
+	}
+	second, err := NewResourceRef(resource.ID, resource.Kind)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Metadata.DisplayName = "Order facts"
+	resource.Metadata.Domain = "finance"
+	resource.Provenance.Path = "archive/orders.yaml"
+	if first.CanonicalID() != second.CanonicalID() {
+		t.Fatalf("descriptive metadata changed canonical identity: %#v %#v", first, second)
+	}
+	if first.CanonicalID() != "model_orders" {
+		t.Fatalf("CanonicalID() = %q, want globally unique resource ID", first.CanonicalID())
+	}
+
+	otherKind, err := NewResourceRef(id, graph.KindSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherKind.CanonicalID() != first.CanonicalID() {
+		t.Fatal("kind became part of canonical resource identity")
+	}
+}
+
+func TestCanonicalGrantHasNoDomainOrHierarchyIdentity(t *testing.T) {
+	project := canonicalTestProject(t)
+	resource, err := NewResourceRef("dashboard_main", graph.KindDashboard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject, err := NewSubjectRef(SubjectKindPrincipal, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant, err := NewCanonicalGrant(project, subject, resource, CapabilityResourceRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.GrantKey() == "" || grant.Resource().CanonicalID() != resource.CanonicalID() {
+		t.Fatalf("grant key = %q, resource key = %q", grant.GrantKey(), resource.CanonicalID())
+	}
+	encoded, err := json.Marshal(grant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"domain", "parent", "path", "displayName", "workspace"} {
+		if containsJSONField(string(encoded), forbidden) {
+			t.Fatalf("canonical grant JSON contains forbidden identity field %q: %s", forbidden, encoded)
+		}
+	}
+
+	decoded, err := DecodeCanonicalGrant(encoded, project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.GrantKey() != grant.GrantKey() {
+		t.Fatalf("grant key changed after JSON round trip: %q != %q", decoded.GrantKey(), grant.GrantKey())
+	}
+}
+
+func TestCanonicalGrantKeysIncludeSubjectKind(t *testing.T) {
+	project := canonicalTestProject(t)
+	resource, err := NewResourceRef("dashboard_main", graph.KindDashboard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	principal, err := NewSubjectRef(SubjectKindPrincipal, "shared-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	group, err := NewSubjectRef(SubjectKindGroup, "shared-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	principalGrant, err := NewCanonicalGrant(project, principal, resource, CapabilityResourceRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	groupGrant, err := NewCanonicalGrant(project, group, resource, CapabilityResourceRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if principalGrant.GrantKey() == groupGrant.GrantKey() {
+		t.Fatal("principal and group grants collided in canonical key")
+	}
+}
+
+func TestCanonicalCapabilitiesRoundTripAndMatrixIsDefensive(t *testing.T) {
+	want := []Capability{
+		CapabilityProjectAdmin,
+		CapabilityResourceUse,
+		CapabilityResourceRead,
+		CapabilityResourceEdit,
+		CapabilityResourceManage,
+		CapabilityResourceShare,
+		CapabilityResourcePublish,
+	}
+	for _, capability := range want {
+		parsed, err := ParseCapability(string(capability))
+		if err != nil || parsed != capability {
+			t.Fatalf("ParseCapability(%q) = %q, %v", capability, parsed, err)
+		}
+		wire, err := json.Marshal(capability)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var roundTripped Capability
+		if err := json.Unmarshal(wire, &roundTripped); err != nil || roundTripped != capability {
+			t.Fatalf("Capability JSON round trip = %q, %v", roundTripped, err)
+		}
+	}
+	for _, invalid := range []string{"", "RESOURCE_DELETE", "resource.read", " USE_RESOURCE"} {
+		if _, err := ParseCapability(invalid); !errors.Is(err, ErrInvalidCapability) {
+			t.Fatalf("ParseCapability(%q) error = %v, want invalid capability", invalid, err)
+		}
+	}
+
+	first := CanonicalCapabilities()
+	second := CanonicalCapabilities()
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("canonical capabilities are not deterministic: %#v != %#v", first, second)
+	}
+	first[0] = CapabilityResourcePublish
+	third := CanonicalCapabilities()
+	if third[0] == CapabilityResourcePublish {
+		t.Fatal("canonical capabilities leaked mutable caller state")
+	}
+	for _, kind := range []graph.Kind{graph.KindProject, graph.KindConnection, graph.KindSource, graph.KindModel, graph.KindSemanticModel, graph.KindPipeline, graph.KindDashboard} {
+		got := CapabilitiesForKind(kind)
+		if len(got) == 0 {
+			t.Fatalf("CapabilitiesForKind(%q) is empty", kind)
+		}
+		got[0] = CapabilityResourcePublish
+		if CapabilitiesForKind(kind)[0] == CapabilityResourcePublish && kind != graph.KindDashboard {
+			t.Fatalf("CapabilitiesForKind(%q) leaked mutable caller state", kind)
+		}
+	}
+}
+
+func TestCanonicalCapabilityMatrixEnforcesKinds(t *testing.T) {
+	for _, kind := range []graph.Kind{
+		graph.KindConnection, graph.KindSource, graph.KindModel,
+		graph.KindSemanticModel, graph.KindPipeline,
+	} {
+		if !SupportsCapability(kind, CapabilityResourceRead) {
+			t.Errorf("kind %q does not support resource read", kind)
+		}
+		for _, capability := range []Capability{CapabilityResourceShare, CapabilityResourcePublish, CapabilityProjectAdmin} {
+			if SupportsCapability(kind, capability) {
+				t.Errorf("kind %q unexpectedly supports %q", kind, capability)
+			}
+		}
+	}
+	if !SupportsCapability(graph.KindDashboard, CapabilityResourceShare) || !SupportsCapability(graph.KindDashboard, CapabilityResourcePublish) {
+		t.Fatal("dashboard does not support sharing and publishing")
+	}
+	if !SupportsCapability(graph.KindProject, CapabilityProjectAdmin) {
+		t.Fatal("project does not support project admin")
+	}
+	for _, capability := range []Capability{
+		CapabilityResourceUse, CapabilityResourceRead, CapabilityResourceEdit,
+		CapabilityResourceManage, CapabilityResourceShare, CapabilityResourcePublish,
+	} {
+		if SupportsCapability(graph.KindProject, capability) {
+			t.Errorf("project unexpectedly supports resource capability %q", capability)
+		}
+	}
+}
+
+func TestCanonicalValidationRejectsInvalidInputs(t *testing.T) {
+	project := canonicalTestProject(t)
+	if _, err := NewResourceRef("models/orders", graph.KindModel); !errors.Is(err, graph.ErrInvalidResourceID) {
+		t.Fatalf("invalid resource ID error = %v", err)
+	}
+	if _, err := NewResourceRef("model_orders", graph.Kind("table")); !errors.Is(err, graph.ErrInvalidKind) {
+		t.Fatalf("invalid resource kind error = %v", err)
+	}
+	resource, err := NewResourceRef("model_orders", graph.KindModel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewCanonicalGrant(project, SubjectRef{}, resource, CapabilityResourceRead); !errors.Is(err, ErrInvalidCanonicalGrant) {
+		t.Fatalf("empty subject error = %v", err)
+	}
+	subject, err := NewSubjectRef(SubjectKindPrincipal, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewCanonicalGrant(project, subject, resource, CapabilityResourceShare); !errors.Is(err, ErrCapabilityNotAllowed) {
+		t.Fatalf("unsupported capability error = %v", err)
+	}
+	if _, err := NewCanonicalGrant(project, subject, resource, Capability("RESOURCE_DELETE")); !errors.Is(err, ErrInvalidCapability) {
+		t.Fatalf("invalid capability error = %v", err)
+	}
+}
+
+func TestCanonicalReferencesMustMatchAuthoritativeGraph(t *testing.T) {
+	project, err := graph.NewProjectGraph([]graph.Resource{
+		{ID: "project_demo", Kind: graph.KindProject, Name: "demo"},
+		{ID: "model_orders", Kind: graph.KindModel, Name: "orders"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongKind, err := NewResourceRef("model_orders", graph.KindDashboard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(wrongKind.ValidateAgainst(project), ErrResourceKindMismatch) {
+		t.Fatalf("wrong-kind reference validation = %v", wrongKind.ValidateAgainst(project))
+	}
+	subject, err := NewSubjectRef(SubjectKindPrincipal, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewCanonicalGrant(project, subject, wrongKind, CapabilityResourcePublish); !errors.Is(err, ErrResourceKindMismatch) {
+		t.Fatalf("wrong-kind grant construction = %v", err)
+	}
+}
+
+func TestCanonicalJSONRejectsDuplicateAndTrailingValues(t *testing.T) {
+	var resource ResourceRef
+	if err := json.Unmarshal([]byte(`{"id":"model_orders","id":"model_orders","kind":"model"}`), &resource); err == nil {
+		t.Fatal("ResourceRef JSON accepted duplicate ID")
+	}
+	if err := json.Unmarshal([]byte(`{"id":"model_orders","kind":"model"}{}`), &resource); err == nil {
+		t.Fatal("ResourceRef JSON accepted trailing value")
+	}
+	if err := json.Unmarshal([]byte(`{"id":"model_orders","kind":"model","domain":"finance"}`), &resource); err == nil {
+		t.Fatal("ResourceRef JSON accepted unknown descriptive field")
+	}
+	var grant CanonicalGrant
+	duplicateGrant := `{"subject":{"kind":"principal","id":"alice"},"resource":{"id":"dashboard_main","kind":"dashboard"},"resource":{"id":"dashboard_main","kind":"dashboard"},"capability":"RESOURCE_READ"}`
+	if _, err := DecodeCanonicalGrant([]byte(duplicateGrant), canonicalTestProject(t)); err == nil {
+		t.Fatal("CanonicalGrant JSON accepted duplicate resource")
+	}
+	unknownGrant := `{"subject":{"kind":"principal","id":"alice"},"resource":{"id":"dashboard_main","kind":"dashboard"},"capability":"RESOURCE_READ","domain":"finance"}`
+	if _, err := DecodeCanonicalGrant([]byte(unknownGrant), canonicalTestProject(t)); err == nil {
+		t.Fatal("CanonicalGrant JSON accepted unknown domain field")
+	}
+	invalidGrant := `{"subject":{"kind":"principal","id":"alice"},"resource":{"id":"model_orders","kind":"model"},"capability":"RESOURCE_SHARE"}`
+	if _, err := DecodeCanonicalGrant([]byte(invalidGrant), canonicalTestProject(t)); !errors.Is(err, ErrCapabilityNotAllowed) {
+		t.Fatalf("CanonicalGrant JSON error = %v, want unsupported capability", err)
+	}
+	if err := json.Unmarshal([]byte(`{"subject":{"kind":"principal","id":"alice"},"resource":{"id":"dashboard_main","kind":"dashboard"},"capability":"RESOURCE_READ"}`), &grant); !errors.Is(err, ErrUnboundCanonicalGrant) {
+		t.Fatalf("graph-free CanonicalGrant JSON error = %v, want unbound grant", err)
+	}
+	if _, err := DecodeCanonicalGrant([]byte(`{"subject":{"kind":"principal","id":"alice"},"resource":{"id":"dashboard_main","ID":"model_orders","kind":"dashboard"},"capability":"RESOURCE_READ"}`), canonicalTestProject(t)); err == nil {
+		t.Fatal("CanonicalGrant JSON accepted case-folded duplicate resource ID")
+	}
+}
+
+func TestCanonicalGrantCannotProduceAuthorizationKeyWithoutGraphBinding(t *testing.T) {
+	unbound := CanonicalGrant{}
+	if key := unbound.GrantKey(); key != "" {
+		t.Fatalf("unbound grant produced authorization key %q", key)
+	}
+	if _, err := json.Marshal(unbound); !errors.Is(err, ErrUnboundCanonicalGrant) {
+		t.Fatalf("unbound grant marshal error = %v, want unbound grant", err)
+	}
+}
+
+func canonicalTestProject(t *testing.T) graph.ProjectGraph {
+	t.Helper()
+	project, err := graph.NewProjectGraph([]graph.Resource{
+		{ID: "project_demo", Kind: graph.KindProject, Name: "demo"},
+		{ID: "dashboard_main", Kind: graph.KindDashboard, Name: "main"},
+		{ID: "model_orders", Kind: graph.KindModel, Name: "orders"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return project
+}
+
+func containsJSONField(encoded, field string) bool {
+	return len(encoded) > 0 && (encoded == field || strings.Contains(encoded, `"`+field+`"`))
+}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -229,6 +229,35 @@ func TestEnterpriseAuthoringForbiddenImportsAreRejected(t *testing.T) {
 	}
 }
 
+func TestAccessMayImportOnlyThePublishedProjectGraphContract(t *testing.T) {
+	if !IsSharedContractImport("access", "internal/project/graph") {
+		t.Fatal("access graph contract is not published")
+	}
+	if IsSharedContractImport("access", "internal/project/graph/compiler") || IsSharedContractImport("project", "internal/project/graph") {
+		t.Fatal("shared graph contract rule widened beyond the exact access contract")
+	}
+	source, ok := ClassifyPackage("internal/access")
+	if !ok {
+		t.Fatal("access package is not classified")
+	}
+	graphContract, ok := ClassifyPackage("internal/project/graph")
+	if !ok || graphContract.Capability != "project" || graphContract.Layer != LayerContract {
+		t.Fatal("project graph package is not classified")
+	}
+	if violation := CapabilityImportViolation("internal/access", source, "internal/project/graph", graphContract); violation != "" {
+		t.Fatalf("access -> project/graph violation = %q, want allowed shared contract", violation)
+	}
+	for _, targetPath := range []string{"internal/project/schema", "internal/project/compiler", "internal/project/artifact"} {
+		target, targetOK := ClassifyPackage(targetPath)
+		if !targetOK {
+			t.Fatalf("%s is not classified", targetPath)
+		}
+		if violation := CapabilityImportViolation("internal/access", source, targetPath, target); !strings.Contains(violation, "undeclared capability edge") {
+			t.Fatalf("access -> %s violation = %q, want undeclared capability edge", targetPath, violation)
+		}
+	}
+}
+
 func TestEnterpriseAuthoringStateRemainsCapabilityOwned(t *testing.T) {
 	tests := []struct {
 		path       string

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -71,6 +71,26 @@ var WorkloadImportPrefixes = []string{
 	"internal/analytics/materialize", "internal/analytics/ducklake", "internal/dashboard/semanticapi",
 }
 
+// SharedContractPrefixes are narrow cross-capability contracts whose package
+// ownership remains with another capability. They are checked explicitly
+// before capability dependency edges so a consumer cannot import the owning
+// capability's broader implementation packages by accident.
+var SharedContractPrefixes = map[string][]string{
+	"access": {"internal/project/graph"},
+}
+
+// IsSharedContractImport reports whether packagePath is one of the explicitly
+// published shared contracts for sourceCapability. Matching is exact, never a
+// broad capability root.
+func IsSharedContractImport(sourceCapability, packagePath string) bool {
+	for _, prefix := range SharedContractPrefixes[sourceCapability] {
+		if packagePath == prefix {
+			return true
+		}
+	}
+	return false
+}
+
 func AllowsWorkloadImport(packagePath string) bool {
 	for _, prefix := range WorkloadImportPrefixes {
 		if packagePath == prefix || strings.HasPrefix(packagePath, prefix+"/") {
@@ -134,6 +154,9 @@ func CapabilityImportViolation(sourcePath string, source PackageRule, packagePat
 	if target.Capability == "workload" && AllowsWorkloadImport(sourcePath) {
 		return ""
 	}
+	if IsSharedContractImport(source.Capability, packagePath) {
+		return ""
+	}
 	if IsDeferredPackageEdge(sourcePath, target.Capability) {
 		return ""
 	}
@@ -155,6 +178,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "site", Capability: "composition", Layer: LayerAdapter},
 	{Prefix: "desktop/native/windowspolicy", Capability: "platform", Layer: LayerAdapter},
 	{Prefix: "pkg/agent", Capability: "agent", Layer: LayerContract},
+	{Prefix: "internal/project/graph", Capability: "project", Layer: LayerContract},
 	{Prefix: "internal/project/compiler", Capability: "project", Layer: LayerUseCase},
 	{Prefix: "internal/project/artifact", Capability: "project", Layer: LayerContract},
 	{Prefix: "internal/analytics/runtime", Capability: "analytics", Layer: LayerContract},


### PR DESCRIPTION
## Outcome

Defines the canonical object access contract over ProjectGraph resources.

- Stable project/resource references and subject identities
- Explicit project and resource capabilities with a strict kind matrix
- Graph-bound grant construction and validation
- Domain metadata is non-authoritative for authorization
- No workspace aliases or compatibility contract

## Verification

- go test ./internal/access/...
- go test ./internal/platform/architecture/...
- full task ci previously passed for the identical contract stack before re-anchoring onto merged main

Linear: LEA-370