### PR TITLE
fix: restore governed asset data workflows

### DIFF
--- a/internal/app/route_inventory_test.go
+++ b/internal/app/route_inventory_test.go
@@ -84,7 +84,7 @@ func TestRouteInventory(t *testing.T) {
 		rows = append(rows, fmt.Sprintf("%s|%s|%s|%s", key, contract.owner, contract.access, contract.privilege))
 	}
 	sort.Strings(rows)
-	const expectedRouteContractDigest = "2b812581c9eec9759ca366e1e9e2133367d72a4902c3cdd5d74493bf855ee06a"
+	const expectedRouteContractDigest = "9dbe6e076596047557129784b056a13791a9a10beeb2cb5d48d4d9de570e1db8"
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(rows, "\n"))))
 	if digest != expectedRouteContractDigest {
 		t.Fatalf("route ownership/auth contract changed: got digest %s\n%s", digest, strings.Join(rows, "\n"))
@@ -161,7 +161,7 @@ func nonAPIRouteMetadata(method, path string) (routeMetadata, bool) {
 	case strings.Contains(path, "/dashboards/") || strings.Contains(path, "/commands/"):
 		authenticated.owner = "dashboard"
 		authenticated.privilege = "RESOURCE_READ"
-	case path == "/explore":
+	case path == "/explore" || path == "/explore/command" || path == "/models/{asset}/data/command" || path == "/semantic-models/{asset}/data/command":
 		authenticated.owner = "project"
 		authenticated.privilege = "RESOURCE_USE"
 	case path == "/" || path == "/catalog/search" || path == "/sources" || strings.HasPrefix(path, "/sources/") ||
@@ -320,6 +320,7 @@ POST /chats/turns
 POST /candidates/{candidate}/commands/{command}
 POST /catalog/search
 POST /connections/search
+POST /explore/command
 POST /dashboards/{dashboard}/commands/clear-selection
 POST /dashboards/{dashboard}/commands/filter
 POST /dashboards/{dashboard}/commands/filter-options
@@ -330,7 +331,9 @@ POST /dashboards/{dashboard}/commands/visual-window
 POST /dashboards/{dashboard}/draft/command
 POST /sources/search
 POST /models/search
+POST /models/{asset}/data/command
 POST /semantic-models/search
+POST /semantic-models/{asset}/data/command
 POST /device
 POST /metrics
 POST /oauth/register

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -524,7 +524,7 @@ func buildApplicationSurfaces(
 		projectDefinitionReader = projectmodule.NewActiveProjectDefinitionReader(runtimeConfig.RuntimeHost.Provider())
 	}
 	routes.projectBrowser = &projecthttp.BrowserHandler{
-		Graph: capabilities.ProjectGraph, SemanticModelReader: metrics, ProjectDefinitionReader: projectDefinitionReader, Catalog: capabilities.ProjectCatalog,
+		Graph: capabilities.ProjectGraph, SemanticModelReader: metrics, ProjectDefinitionReader: projectDefinitionReader, QueryExecutor: metrics, Catalog: capabilities.ProjectCatalog,
 		ResolveProjectID: runtime.resolveProjectID, Environment: runtimeConfig.DefaultEnvironment, Trace: runtime.pageStreamTrace,
 		Layout: func(r *http.Request) webpage.Provider {
 			return applicationLayout(routes.accessModule, routes.agentModule, routes.product, platform.assets, r)

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -43,6 +43,7 @@ import (
 	projectcatalog "github.com/flidai/leapview/internal/project/catalog"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	projecthttp "github.com/flidai/leapview/internal/project/http"
+	projectmodule "github.com/flidai/leapview/internal/project/module"
 	refreshmodule "github.com/flidai/leapview/internal/refresh/module"
 	refreshrun "github.com/flidai/leapview/internal/refresh/run"
 	releasemodule "github.com/flidai/leapview/internal/release/module"
@@ -518,8 +519,12 @@ func buildApplicationSurfaces(
 	policy.requestLogging = httpConfig.RequestLogging
 	routes.managedDataModule = capabilities.ManagedDataModule
 	routes.projectCatalog = capabilities.ProjectCatalog
+	var projectDefinitionReader projecthttp.ProjectDefinitionReader
+	if runtimeConfig.RuntimeHost != nil {
+		projectDefinitionReader = projectmodule.NewActiveProjectDefinitionReader(runtimeConfig.RuntimeHost.Provider())
+	}
 	routes.projectBrowser = &projecthttp.BrowserHandler{
-		Graph: capabilities.ProjectGraph, SemanticModelReader: metrics, Catalog: capabilities.ProjectCatalog,
+		Graph: capabilities.ProjectGraph, SemanticModelReader: metrics, ProjectDefinitionReader: projectDefinitionReader, Catalog: capabilities.ProjectCatalog,
 		ResolveProjectID: runtime.resolveProjectID, Environment: runtimeConfig.DefaultEnvironment, Trace: runtime.pageStreamTrace,
 		Layout: func(r *http.Request) webpage.Provider {
 			return applicationLayout(routes.accessModule, routes.agentModule, routes.product, platform.assets, r)

--- a/internal/app/runtimefactory/dashboard_projection.go
+++ b/internal/app/runtimefactory/dashboard_projection.go
@@ -2,6 +2,7 @@ package runtimefactory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
@@ -21,6 +22,7 @@ type dashboardRuntimeWithGraph struct {
 	servingStateID  string
 	authorization   accesssnapshot.AuthorizationSnapshot
 	authoredSources map[string]dashboardauthoring.AuthoredDashboardSource
+	projectManifest projectmanifest.Project
 }
 
 // AuthorizationSnapshot returns the immutable authorization policy compiled
@@ -28,6 +30,23 @@ type dashboardRuntimeWithGraph struct {
 // project-resource guards can authorize against the exact active generation.
 func (r dashboardRuntimeWithGraph) AuthorizationSnapshot() accesssnapshot.AuthorizationSnapshot {
 	return r.authorization
+}
+
+// ProjectManifest returns a detached copy of the complete compiled project
+// definition for this serving generation. The portable graph deliberately
+// contains only identity, metadata, and topology; browser detail projections
+// must read their typed definitions from the exact active generation instead
+// of interpreting graph metadata as a resource document.
+func (r dashboardRuntimeWithGraph) ProjectManifest() projectmanifest.Project {
+	encoded, err := json.Marshal(r.projectManifest)
+	if err != nil {
+		return projectmanifest.Project{}
+	}
+	var cloned projectmanifest.Project
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		return projectmanifest.Project{}
+	}
+	return cloned
 }
 
 // AuthoredDashboardSource returns a fresh deep copy of retained authored

--- a/internal/app/runtimefactory/dashboard_projection_test.go
+++ b/internal/app/runtimefactory/dashboard_projection_test.go
@@ -3,10 +3,31 @@ package runtimefactory
 import (
 	"testing"
 
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	dashboardauthoring "github.com/flidai/leapview/internal/dashboard/authoring"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
 )
+
+func TestProjectManifestReturnsDetachedCompiledDefinition(t *testing.T) {
+	runtime := dashboardRuntimeWithGraph{projectManifest: projectmanifest.Project{
+		ID: "project:demo",
+		Models: map[string]semanticmodel.Table{
+			"model:orders": {PrimaryKey: "order_id", Sources: []string{"orders"}},
+		},
+	}}
+
+	first := runtime.ProjectManifest()
+	model := first.Models["model:orders"]
+	model.PrimaryKey = "changed"
+	model.Sources[0] = "changed"
+	first.Models["model:orders"] = model
+
+	second := runtime.ProjectManifest()
+	if second.Models["model:orders"].PrimaryKey != "order_id" || second.Models["model:orders"].Sources[0] != "orders" {
+		t.Fatalf("project manifest aliases caller mutation: %#v", second.Models["model:orders"])
+	}
+}
 
 func TestAuthoredDashboardSourcesRetainsDescriptiveDomain(t *testing.T) {
 	projectID, err := projectgraph.NewResourceID("project:demo")

--- a/internal/app/runtimefactory/factory.go
+++ b/internal/app/runtimefactory/factory.go
@@ -140,6 +140,7 @@ func (f servingStateRuntimeFactory) Prepare(ctx context.Context, input runtimeho
 		servingStateID:  string(input.State.ID),
 		authorization:   authorization,
 		authoredSources: authoredSources,
+		projectManifest: compiled.Manifest,
 	}, nil
 }
 

--- a/internal/app/ui_command_contract_test.go
+++ b/internal/app/ui_command_contract_test.go
@@ -68,7 +68,7 @@ func TestUIRequestsCannotBypassTypedCommandHelpers(t *testing.T) {
 		filepath.Clean("internal/admin/personalsettings/ui.go"): {"QueryPost": true},
 		filepath.Clean("internal/dashboard/ui/page.go"):         {"EventPost": true},
 		filepath.Clean("internal/project/ui/data_explorer.go"):  {"EventPost": true},
-		filepath.Clean("internal/project/ui/develop.go"):        {"QueryPost": true},
+		filepath.Clean("internal/project/ui/develop.go"):        {"QueryPost": true, "EventPost": true},
 		filepath.Clean("internal/project/ui/page.go"):           {"QueryPost": true},
 	}
 	fset := token.NewFileSet()

--- a/internal/app/workload_metrics_test.go
+++ b/internal/app/workload_metrics_test.go
@@ -112,6 +112,20 @@ func TestWorkloadMetricsClassifiesAgentAndReleasesFailedQueries(t *testing.T) {
 	}
 }
 
+func TestWorkloadMetricsReusesInteractivePhysicalQueryAdmission(t *testing.T) {
+	controller, err := workload.New(workload.Config{MaxRunning: 1, Classes: map[workload.Class]workload.Policy{
+		workload.Interactive: {MaximumRunning: 1},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(controller.Close)
+	metrics := dashboardmodule.WithAdmission(nestedAdmissionMetrics{controller: controller}, controller)
+	if _, err := metrics.ExecuteDataQuery(t.Context(), workloadTestQuery()); err != nil {
+		t.Fatalf("physical query admission should reuse the outer interactive lease: %v", err)
+	}
+}
+
 func workloadTestQuery() dataquery.Query {
 	request := dataquery.SemanticRows("sales", "orders", []dataquery.Field{{Field: "orders.id"}}, nil, nil, nil, 0, 1, false)
 	request.ProjectID = "project:sales"
@@ -128,6 +142,22 @@ type errorQueryMetrics struct {
 	fakeMetrics
 	err     error
 	inspect func()
+}
+
+type nestedAdmissionMetrics struct {
+	fakeMetrics
+	controller *workload.Controller
+}
+
+func (m nestedAdmissionMetrics) ExecuteDataQuery(ctx context.Context, _ dataquery.Query) (dataquery.Result, error) {
+	lease, err := m.controller.Acquire(ctx, workload.Request{
+		Class: workload.Interactive, PrincipalID: "system:query", Operation: "physical_query", EstimatedMemoryBytes: 64 << 20,
+	})
+	if err != nil {
+		return dataquery.Result{}, err
+	}
+	defer lease.Release()
+	return dataquery.Result{}, nil
 }
 
 func (m errorQueryMetrics) ExecuteDataQuery(context.Context, dataquery.Query) (dataquery.Result, error) {

--- a/internal/dashboard/module/admitted_metrics.go
+++ b/internal/dashboard/module/admitted_metrics.go
@@ -120,7 +120,11 @@ func (m admittedMetrics) ExecuteDataQuery(ctx context.Context, request dataquery
 	if operation == "" {
 		operation = string(request.Kind)
 	}
-	lease, err := m.admitter.Acquire(ctx, workload.Request{Class: class, PrincipalID: "system:dashboard-query", Operation: operation, EstimatedMemoryBytes: 64 << 20})
+	principalID := "system:query"
+	if class == workload.Background {
+		principalID = "system:dashboard-query"
+	}
+	lease, err := m.admitter.Acquire(ctx, workload.Request{Class: class, PrincipalID: principalID, Operation: operation, EstimatedMemoryBytes: 64 << 20})
 	if err != nil {
 		result := dataquery.Result{ExecutionState: executionStateForWorkloadError(ctx, err)}
 		var rejection *workload.Rejection
@@ -169,7 +173,11 @@ func (m admittedMetrics) ExecuteDataQueryArrow(ctx context.Context, request data
 	if operation == "" {
 		operation = string(request.Kind)
 	}
-	lease, err := m.admitter.Acquire(ctx, workload.Request{Class: class, PrincipalID: "system:dashboard-query", Operation: operation, EstimatedMemoryBytes: 64 << 20})
+	principalID := "system:query"
+	if class == workload.Background {
+		principalID = "system:dashboard-query"
+	}
+	lease, err := m.admitter.Acquire(ctx, workload.Request{Class: class, PrincipalID: principalID, Operation: operation, EstimatedMemoryBytes: 64 << 20})
 	if err != nil {
 		result := dataquery.Result{ExecutionState: executionStateForWorkloadError(ctx, err)}
 		var rejection *workload.Rejection

--- a/internal/dashboard/ui/signals/projection.go
+++ b/internal/dashboard/ui/signals/projection.go
@@ -21,9 +21,11 @@ func DashboardInitialEnvelope(clientID, streamInstanceID string, catalog dashboa
 	activePage = activePage.WithDefaults()
 	tableRequest := DefaultTableRequest(report, activePage)
 	initialFilters = report.NormalizeFiltersForPage(activePage.ID, initialFilters).WithDefaults()
-	modelID, modelTitle := "", ""
+	modelID, modelTitle := strings.TrimSpace(report.SemanticModel), ""
 	if model != nil {
-		modelID = model.Name
+		if modelID == "" {
+			modelID = model.Name
+		}
 		modelTitle = model.Title
 	}
 	filterState := report.DefaultFilterState()

--- a/internal/dashboard/ui/signals/projection_test.go
+++ b/internal/dashboard/ui/signals/projection_test.go
@@ -1,0 +1,40 @@
+package signals
+
+import (
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/dashboard"
+	dashboarddefinition "github.com/flidai/leapview/internal/dashboard/definition"
+	visualizationdefinition "github.com/flidai/leapview/internal/dashboard/visualization/definition"
+)
+
+func TestDashboardInitialEnvelopeUsesCanonicalSemanticModelResourceID(t *testing.T) {
+	page := dashboard.Page{ID: "overview", Title: "Overview"}
+	report, err := dashboarddefinition.New("dashboard:showcase", "Showcase", "", "semantic-model:visuals", []dashboard.Page{page}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := &semanticmodel.Model{Name: "visuals", Title: "Visuals"}
+	envelope := DashboardInitialEnvelope("client", "stream", dashboard.Catalog{}, report, model, map[string]visualizationdefinition.Definition{}, []dashboard.Page{page}, page, dashboard.Filters{})
+
+	for label, got := range map[string]string{
+		"runtime":       optionalString(envelope.Runtime.ModelID),
+		"page":          envelope.Page.ModelID,
+		"agent context": envelope.AgentContext.ModelID,
+	} {
+		if got != report.SemanticModel {
+			t.Fatalf("%s model ID = %q, want canonical %q", label, got, report.SemanticModel)
+		}
+	}
+	if envelope.Page.ModelTitle != model.Title {
+		t.Fatalf("model title = %q, want %q", envelope.Page.ModelTitle, model.Title)
+	}
+}
+
+func optionalString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/project/http/browser.go
+++ b/internal/project/http/browser.go
@@ -18,6 +18,7 @@ import (
 	projectview "github.com/flidai/leapview/internal/project"
 	projectcatalog "github.com/flidai/leapview/internal/project/catalog"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
 	projectnavigation "github.com/flidai/leapview/internal/project/navigation"
 	projectui "github.com/flidai/leapview/internal/project/ui"
 	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
@@ -43,11 +44,25 @@ type SemanticModelReader interface {
 	SemanticModel(string) (*semanticmodel.Model, bool)
 }
 
+// ProjectDefinitionReader resolves the complete compiled definition from the
+// exact active serving generation. Graph payloads are intentionally limited
+// to portable identity, metadata, and topology and cannot populate resource
+// detail pages or Data Explorer on their own.
+type ProjectDefinitionReader interface {
+	ProjectDefinition(context.Context) (projectmanifest.Project, error)
+}
+
 // ErrSemanticModelUnavailable indicates that the active generation could not
 // provide the compiled definition required to render semantic-model detail.
 // A graph metadata payload is not a valid substitute because it would render
 // misleading zero-valued tables, measures, and relationships.
 var ErrSemanticModelUnavailable = errors.New("active semantic model definition is unavailable")
+
+// ErrProjectDefinitionUnavailable indicates that the selected graph resource
+// cannot be paired with its typed definition from the active generation.
+// Rendering graph metadata as a complete resource would produce misleading
+// empty fields, sources, schedules, and configuration values.
+var ErrProjectDefinitionUnavailable = errors.New("active project definition is unavailable")
 
 type Principal struct {
 	ID        string
@@ -55,16 +70,17 @@ type Principal struct {
 }
 
 type BrowserHandler struct {
-	Graph               GraphReader
-	SemanticModelReader SemanticModelReader
-	Catalog             CatalogAuthorizer
-	ResolveProjectID    func(context.Context) (projectgraph.ResourceID, error)
-	Environment         string
-	Trace               *pagestream.TraceStore
-	Layout              func(*stdhttp.Request) webpage.Provider
-	CSRFToken           func(*stdhttp.Request) string
-	CurrentUser         func(*stdhttp.Request) (Principal, bool)
-	Authenticate        func(stdhttp.Handler) stdhttp.Handler
+	Graph                   GraphReader
+	SemanticModelReader     SemanticModelReader
+	ProjectDefinitionReader ProjectDefinitionReader
+	Catalog                 CatalogAuthorizer
+	ResolveProjectID        func(context.Context) (projectgraph.ResourceID, error)
+	Environment             string
+	Trace                   *pagestream.TraceStore
+	Layout                  func(*stdhttp.Request) webpage.Provider
+	CSRFToken               func(*stdhttp.Request) string
+	CurrentUser             func(*stdhttp.Request) (Principal, bool)
+	Authenticate            func(stdhttp.Handler) stdhttp.Handler
 }
 
 // MountAuthenticated mounts only canonical browser paths. Legacy tenant
@@ -123,7 +139,10 @@ func (h *BrowserHandler) Explore(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		return
 	}
 	catalog := h.navigationCatalog(r)
-	page, explorer := h.dataExplorerSignals(r)
+	page, explorer, ok := h.dataExplorerSignals(w, r)
+	if !ok {
+		return
+	}
 	writeDocument(w, projectui.DataExplorerPage(catalog, page, explorer, h.csrf(r), h.layout(r)))
 }
 
@@ -173,7 +192,7 @@ func (h *BrowserHandler) assetDocument(w stdhttp.ResponseWriter, r *stdhttp.Requ
 		return
 	}
 	var err error
-	asset, err = h.semanticModelAssetReadModel(asset)
+	asset, err = h.projectAssetReadModel(r.Context(), asset)
 	if err != nil {
 		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
 		return
@@ -212,7 +231,20 @@ func (h *BrowserHandler) Pipelines(w stdhttp.ResponseWriter, r *stdhttp.Request)
 	if !h.authorizeAny(w, r, []projectgraph.Kind{projectgraph.KindPipeline}) {
 		return
 	}
-	state := projectui.PipelineMonitorState{Environment: h.Environment, CSRFToken: h.csrf(r)}
+	_, assets, _, ok := h.assets(w, r)
+	if !ok {
+		return
+	}
+	pipelines := projectview.FilterProjectLandingAssets(assets, string(projectview.AssetTypeRefreshPipeline), "")
+	pipelines, err := h.projectAssetReadModels(r.Context(), pipelines)
+	if err != nil {
+		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+		return
+	}
+	state := projectui.PipelineMonitorState{Environment: h.Environment, CSRFToken: h.csrf(r), Pipelines: make([]projectui.PipelineMonitorPipeline, 0, len(pipelines))}
+	for _, asset := range pipelines {
+		state.Pipelines = append(state.Pipelines, projectui.PipelineMonitorPipeline{Asset: asset})
+	}
 	writeDocument(w, projectui.PipelinesPage(h.navigationCatalog(r), state, r.URL.Query().Get("view"), "", h.layout(r)))
 }
 
@@ -225,6 +257,11 @@ func (h *BrowserHandler) Connections(w stdhttp.ResponseWriter, r *stdhttp.Reques
 		return
 	}
 	assets = projectview.FilterConnections(assets, strings.TrimSpace(r.URL.Query().Get("q")))
+	assets, err := h.projectAssetReadModels(r.Context(), assets)
+	if err != nil {
+		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+		return
+	}
 	writeDocument(w, projectui.ConnectionsPage(h.navigationCatalog(r), projectID.String(), assets, edges, r.URL.Query().Get("q"), "", h.layout(r)))
 }
 
@@ -273,7 +310,13 @@ func (h *BrowserHandler) ConnectionsSearch(w stdhttp.ResponseWriter, r *stdhttp.
 	if query == "" {
 		query = strings.TrimSpace(r.FormValue("entityListQuery"))
 	}
-	patch := projectui.ConnectionsListResultsPatch(projectview.FilterConnections(assets, query), edges)
+	assets = projectview.FilterConnections(assets, query)
+	assets, err := h.projectAssetReadModels(r.Context(), assets)
+	if err != nil {
+		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+		return
+	}
+	patch := projectui.ConnectionsListResultsPatch(assets, edges)
 	_ = pagestream.PatchResponse(w, r, pagestream.SignalPatch(patch))
 }
 
@@ -288,7 +331,10 @@ func (h *BrowserHandler) Updates(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 	case "data":
 		surface := r.URL.Query().Get("surface")
 		if surface == "explore" {
-			page, explorer := h.dataExplorerSignals(r)
+			page, explorer, ok := h.dataExplorerSignals(w, r)
+			if !ok {
+				return
+			}
 			patch = projectui.DataExplorerBootstrapSignals(h.navigationCatalog(r), page, explorer, h.layout(r))
 		} else if surface == "asset" {
 			if assetPatch, ok := h.assetBootstrap(w, r); ok {
@@ -335,6 +381,11 @@ func (h *BrowserHandler) connectionsBootstrap(w stdhttp.ResponseWriter, r *stdht
 		return nil, false
 	}
 	assets = projectview.FilterConnections(assets, r.URL.Query().Get("q"))
+	assets, err := h.projectAssetReadModels(r.Context(), assets)
+	if err != nil {
+		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+		return nil, false
+	}
 	return projectui.ConnectionsBootstrapSignalsForEnvironment(h.navigationCatalog(r), projectID.String(), assets, edges, r.URL.Query().Get("q"), h.Environment, "", h.layout(r)), true
 }
 
@@ -344,6 +395,11 @@ func (h *BrowserHandler) pipelinesBootstrap(w stdhttp.ResponseWriter, r *stdhttp
 		return nil, false
 	}
 	pipelines := projectview.FilterProjectLandingAssets(assets, string(projectview.AssetTypeRefreshPipeline), "")
+	pipelines, err := h.projectAssetReadModels(r.Context(), pipelines)
+	if err != nil {
+		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+		return nil, false
+	}
 	state := projectui.PipelineMonitorState{Environment: h.Environment, CSRFToken: h.csrf(r), Pipelines: make([]projectui.PipelineMonitorPipeline, 0, len(pipelines))}
 	for _, asset := range pipelines {
 		state.Pipelines = append(state.Pipelines, projectui.PipelineMonitorPipeline{Asset: asset})
@@ -362,7 +418,7 @@ func (h *BrowserHandler) assetBootstrap(w stdhttp.ResponseWriter, r *stdhttp.Req
 		return nil, false
 	}
 	var err error
-	asset, err = h.semanticModelAssetReadModel(asset)
+	asset, err = h.projectAssetReadModel(r.Context(), asset)
 	if err != nil {
 		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
 		return nil, false
@@ -374,24 +430,99 @@ func (h *BrowserHandler) assetBootstrap(w stdhttp.ResponseWriter, r *stdhttp.Req
 	return projectui.ConnectionAssetBootstrapSignalsForEnvironment(h.navigationCatalog(r), project, asset, assets, edges, r.URL.Query().Get("section"), h.Environment, "", projectui.AssetVersionsState{}), true
 }
 
-// semanticModelAssetReadModel enriches only the selected asset. Lists and
-// lineage continue to use the immutable graph projection, while details and
-// their SSE bootstrap read the complete compiled semantic model for the
-// active generation.
-func (h *BrowserHandler) semanticModelAssetReadModel(asset projectview.DevelopAssetView) (projectview.DevelopAssetView, error) {
-	if asset.Type != string(projectview.AssetTypeSemanticModel) {
+// projectAssetReadModel enriches only the selected asset. Lists and lineage
+// continue to use the immutable graph projection, while details and their SSE
+// bootstrap read the complete typed definition from the active generation.
+func (h *BrowserHandler) projectAssetReadModel(ctx context.Context, asset projectview.DevelopAssetView) (projectview.DevelopAssetView, error) {
+	if h == nil {
+		return projectview.DevelopAssetView{}, ErrProjectDefinitionUnavailable
+	}
+	var payload map[string]any
+	if h.ProjectDefinitionReader != nil {
+		definition, err := h.ProjectDefinitionReader.ProjectDefinition(ctx)
+		if err != nil {
+			return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s: %v", ErrProjectDefinitionUnavailable, asset.ID, err)
+		}
+		return projectAssetReadModelFromDefinition(asset, definition)
+	} else if asset.Type == string(projectview.AssetTypeSemanticModel) && h.SemanticModelReader != nil {
+		// Retain the narrow compatibility seam for embedders that expose only
+		// semantic query runtime definitions. Production composition supplies
+		// ProjectDefinitionReader for every resource kind.
+		model, ok := h.SemanticModelReader.SemanticModel(asset.ID)
+		if !ok || model == nil {
+			return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrSemanticModelUnavailable, asset.ID)
+		}
+		payload = projectview.SemanticModelAssetPayload(model)
+	} else {
+		return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrProjectDefinitionUnavailable, asset.ID)
+	}
+	return mergeProjectAssetPayload(asset, payload)
+}
+
+func (h *BrowserHandler) projectAssetReadModels(ctx context.Context, assets []projectview.DevelopAssetView) ([]projectview.DevelopAssetView, error) {
+	if len(assets) == 0 {
+		return assets, nil
+	}
+	if h == nil || h.ProjectDefinitionReader == nil {
+		return nil, ErrProjectDefinitionUnavailable
+	}
+	definition, err := h.ProjectDefinitionReader.ProjectDefinition(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrProjectDefinitionUnavailable, err)
+	}
+	out := make([]projectview.DevelopAssetView, 0, len(assets))
+	for _, asset := range assets {
+		enriched, err := projectAssetReadModelFromDefinition(asset, definition)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, enriched)
+	}
+	return out, nil
+}
+
+func projectAssetReadModelFromDefinition(asset projectview.DevelopAssetView, definition projectmanifest.Project) (projectview.DevelopAssetView, error) {
+	var payload map[string]any
+	switch asset.Type {
+	case string(projectview.AssetTypeConnection):
+		resource, ok := definition.Connections[asset.ID]
+		if !ok {
+			return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrProjectDefinitionUnavailable, asset.ID)
+		}
+		payload = projectview.ConnectionAssetPayload(resource)
+	case string(projectview.AssetTypeSource):
+		resource, ok := definition.Sources[asset.ID]
+		if !ok {
+			return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrProjectDefinitionUnavailable, asset.ID)
+		}
+		payload = projectview.SourceAssetPayload(resource)
+	case string(projectview.AssetTypeModelTable):
+		resource, ok := definition.Models[asset.ID]
+		if !ok {
+			return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrProjectDefinitionUnavailable, asset.ID)
+		}
+		payload = projectview.ModelTableAssetPayload(resource)
+	case string(projectview.AssetTypeSemanticModel):
+		resource, ok := definition.SemanticModels[asset.ID]
+		if !ok || resource == nil {
+			return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrSemanticModelUnavailable, asset.ID)
+		}
+		payload = projectview.SemanticModelAssetPayload(resource)
+	case string(projectview.AssetTypeRefreshPipeline):
+		resource, ok := definition.RefreshPipelines[asset.ID]
+		if !ok {
+			return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrProjectDefinitionUnavailable, asset.ID)
+		}
+		payload = projectview.RefreshPipelineAssetPayload(resource)
+	default:
 		return asset, nil
 	}
-	if h == nil || h.SemanticModelReader == nil {
-		return projectview.DevelopAssetView{}, ErrSemanticModelUnavailable
-	}
-	model, ok := h.SemanticModelReader.SemanticModel(asset.ID)
-	if !ok || model == nil {
-		return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrSemanticModelUnavailable, asset.ID)
-	}
-	payload := projectview.SemanticModelAssetPayload(model)
+	return mergeProjectAssetPayload(asset, payload)
+}
+
+func mergeProjectAssetPayload(asset projectview.DevelopAssetView, payload map[string]any) (projectview.DevelopAssetView, error) {
 	if len(payload) == 0 {
-		return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrSemanticModelUnavailable, asset.ID)
+		return projectview.DevelopAssetView{}, fmt.Errorf("%w: %s", ErrProjectDefinitionUnavailable, asset.ID)
 	}
 	// Preserve graph identity/metadata keys while replacing the resource's
 	// generic payload fields with the typed detail projection.
@@ -678,21 +809,65 @@ func projectAreaType(area string) string {
 	}
 }
 
-func (h *BrowserHandler) dataExplorerSignals(r *stdhttp.Request) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal) {
+func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhttp.Request) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
 	project := h.navigationCatalog(r).Project
 	page := projectsignals.DataExplorerPageSignal{Kind: projectsignals.RouteKindData, Title: "Data Explorer", Description: projectsignals.Optional("Explore governed semantic data."), Tabs: []projectsignals.ResourceTabSignal{}, Context: projectsignals.DataExplorerContextSignal{Active: true, Environment: h.Environment, ProjectID: project.ID, ProjectTitle: projectsignals.Optional(project.Title)}}
 	exploreCommand := projectsignals.DataExploreCommand{Dimensions: []string{}, Measures: []string{}, Filters: []projectsignals.DataExploreFilterSignal{}, Sort: []projectsignals.DataExploreSortSignal{}, Limit: 100}
 	explorer := projectsignals.DataExplorerSignal{Command: projectsignals.DataExplorerCommand{Explore: &exploreCommand, Limit: 100}, Explore: projectsignals.DataExploreSignal{Command: exploreCommand, Models: []projectsignals.DataExploreModelSignal{}, Datasets: []projectsignals.DataExploreDatasetSignal{}, Fields: []projectsignals.DataExploreFieldSignal{}, Result: projectsignals.DataExploreResultSignal{Columns: []projectsignals.DataPreviewColumnSignal{}, Rows: []map[string]any{}, Warnings: []string{}}}, Objects: []projectsignals.DataExplorerObjectSignal{}, Preview: projectsignals.DataPreviewSignal{Blocks: map[string]projectsignals.DataPreviewBlockSignal{}, Columns: []projectsignals.DataPreviewColumnSignal{}, ChunkSize: 100, RowHeight: 32}}
-	for _, model := range h.navigationCatalog(r).SemanticModels {
-		explorer.Explore.Models = append(explorer.Explore.Models, projectsignals.DataExploreModelSignal{ID: model.ID, Title: model.Title, Description: projectsignals.Optional(model.Description)})
+	if value := strings.TrimSpace(r.URL.Query().Get("model")); value != "" {
+		exploreCommand.ModelID = projectsignals.Optional(value)
 	}
-	if len(explorer.Explore.Models) > 0 {
-		selected := explorer.Explore.Models[0]
-		explorer.Explore.SelectedModel = &selected
-		exploreCommand.ModelID = projectsignals.Optional(selected.ID)
-		explorer.Command.Explore.ModelID = exploreCommand.ModelID
+	if value := strings.TrimSpace(r.URL.Query().Get("dataset")); value != "" {
+		exploreCommand.DatasetID = projectsignals.Optional(value)
 	}
-	return page, explorer
+	_, assets, _, ok := h.assets(w, r)
+	if !ok {
+		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+	}
+	if h == nil || h.ProjectDefinitionReader == nil {
+		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+	}
+	definition, err := h.ProjectDefinitionReader.ProjectDefinition(r.Context())
+	if err != nil {
+		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+	}
+	projection := BuildDataExplorerProjection(assets, definition, exploreCommand)
+	explorer.Objects = projection.Objects
+	explorer.Explore.Models = projection.Models
+	explorer.Explore.SelectedModel = projection.SelectedModel
+	explorer.Explore.Datasets = projection.Datasets
+	explorer.Explore.SelectedDataset = projection.SelectedDataset
+	explorer.Explore.Fields = projection.Fields
+	if projection.SelectedModel != nil {
+		exploreCommand.ModelID = projectsignals.Optional(projection.SelectedModel.ID)
+	}
+	if projection.SelectedDataset != nil {
+		exploreCommand.DatasetID = projectsignals.Optional(projection.SelectedDataset.ID)
+	}
+	explorer.Explore.Command = exploreCommand
+	explorer.Command.Explore = &exploreCommand
+	page.Context.ObjectCount = int64(len(explorer.Objects))
+
+	requestedObject := strings.TrimSpace(r.URL.Query().Get("object"))
+	if requestedObject != "" {
+		for index := range explorer.Objects {
+			object := explorer.Objects[index]
+			if object.Key != requestedObject && object.ResourceID != requestedObject && projectsignals.ValueOrZero(object.AssetID) != requestedObject {
+				continue
+			}
+			explorer.Command.ObjectKey = projectsignals.Optional(object.Key)
+			explorer.SelectedKey = projectsignals.Optional(object.Key)
+			explorer.SelectedObject = &object
+			page.SelectedObject = projectsignals.Optional(object.Key)
+			if object.Columns != nil {
+				explorer.Preview.Columns = append([]projectsignals.DataPreviewColumnSignal(nil), (*object.Columns)...)
+			}
+			break
+		}
+	}
+	return page, explorer, true
 }
 
 func (h *BrowserHandler) layout(r *stdhttp.Request) webpage.Provider {

--- a/internal/project/http/browser.go
+++ b/internal/project/http/browser.go
@@ -73,6 +73,7 @@ type BrowserHandler struct {
 	Graph                   GraphReader
 	SemanticModelReader     SemanticModelReader
 	ProjectDefinitionReader ProjectDefinitionReader
+	QueryExecutor           DataQueryExecutor
 	Catalog                 CatalogAuthorizer
 	ResolveProjectID        func(context.Context) (projectgraph.ResourceID, error)
 	Environment             string
@@ -97,12 +98,15 @@ func (h *BrowserHandler) MountAuthenticated(r chi.Router) {
 	}
 	r.Get("/", wrap(h.Insights))
 	r.Get("/explore", wrap(h.Explore))
+	r.Post("/explore/command", wrap(h.DataExplorerCommand))
 	r.Get("/sources", wrap(h.Sources))
 	r.Get("/sources/{asset}/{section}", wrap(h.SourceAsset))
 	r.Get("/models", wrap(h.Models))
 	r.Get("/models/{asset}/{section}", wrap(h.ModelAsset))
+	r.Post("/models/{asset}/data/command", wrap(h.ModelDataExplorerCommand))
 	r.Get("/semantic-models", wrap(h.SemanticModels))
 	r.Get("/semantic-models/{asset}/{section}", wrap(h.SemanticModelAsset))
+	r.Post("/semantic-models/{asset}/data/command", wrap(h.SemanticModelDataExplorerCommand))
 	r.Get("/pipelines", wrap(h.Pipelines))
 	r.Get("/pipelines/{asset}/{section}", wrap(h.PipelineAsset))
 	r.Get("/connections", wrap(h.Connections))
@@ -144,6 +148,59 @@ func (h *BrowserHandler) Explore(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		return
 	}
 	writeDocument(w, projectui.DataExplorerPage(catalog, page, explorer, h.csrf(r), h.layout(r)))
+}
+
+func (h *BrowserHandler) DataExplorerCommand(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.authorizeAny(w, r, []projectgraph.Kind{projectgraph.KindSemanticModel}) {
+		return
+	}
+	var signals struct {
+		Command projectsignals.DataExplorerCommand `json:"dataExplorerCommand"`
+	}
+	if err := pagestream.ReadSignals(r, &signals); err != nil {
+		stdhttp.Error(w, "data explorer command payload is required", stdhttp.StatusBadRequest)
+		return
+	}
+	page, explorer, ok := h.dataExplorerSignalsForCommand(w, r, signals.Command)
+	if !ok {
+		return
+	}
+	_ = pagestream.PatchResponse(w, r, pagestream.SignalPatch{
+		"page": page, "dataExplorer": explorer, "dataExplorerCommand": explorer.Command,
+	})
+}
+
+func (h *BrowserHandler) ModelDataExplorerCommand(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.assetDataExplorerCommand(w, r, string(projectview.AssetTypeModelTable))
+}
+
+func (h *BrowserHandler) SemanticModelDataExplorerCommand(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.assetDataExplorerCommand(w, r, string(projectview.AssetTypeSemanticModel))
+}
+
+func (h *BrowserHandler) assetDataExplorerCommand(w stdhttp.ResponseWriter, r *stdhttp.Request, expectedType string) {
+	kind, ok := catalogKindForAssetType(expectedType)
+	if !ok || !h.authorizeAny(w, r, []projectgraph.Kind{kind}) {
+		return
+	}
+	var signals struct {
+		Command projectsignals.DataExplorerCommand `json:"dataExplorerCommand"`
+	}
+	if err := pagestream.ReadSignals(r, &signals); err != nil {
+		stdhttp.Error(w, "data explorer command payload is required", stdhttp.StatusBadRequest)
+		return
+	}
+	_, explorer, asset, ok := h.dataExplorerSignalsForAssetCommand(w, r, chi.URLParam(r, "asset"), signals.Command)
+	if !ok {
+		return
+	}
+	if asset.Type != expectedType {
+		stdhttp.NotFound(w, r)
+		return
+	}
+	_ = pagestream.PatchResponse(w, r, pagestream.SignalPatch{
+		"dataExplorer": explorer, "dataExplorerCommand": explorer.Command,
+	})
 }
 
 func (h *BrowserHandler) Sources(w stdhttp.ResponseWriter, r *stdhttp.Request) {
@@ -203,7 +260,7 @@ func (h *BrowserHandler) assetDocument(w stdhttp.ResponseWriter, r *stdhttp.Requ
 		writeDocument(w, projectui.ConnectionAssetPageWithVersionsForEnvironment(h.navigationCatalog(r), project, asset, assets, edges, section, h.Environment, "", projectui.AssetVersionsState{}))
 		return
 	}
-	writeDocument(w, projectui.ProjectAssetPageWithRefreshAndVersionsForEnvironment(h.navigationCatalog(r), project, asset, assets, edges, section, h.Environment, "", projectui.AssetRefreshState{}, projectui.AssetVersionsState{}, h.layout(r)))
+	writeDocument(w, projectui.ProjectAssetPageWithRefreshAndVersionsForEnvironment(h.navigationCatalog(r), project, asset, assets, edges, section, h.Environment, "", projectui.AssetRefreshState{CSRFToken: h.csrf(r)}, projectui.AssetVersionsState{}, h.layout(r)))
 }
 
 func (h *BrowserHandler) projectAssets(w stdhttp.ResponseWriter, r *stdhttp.Request, area, activeType string) {
@@ -425,7 +482,16 @@ func (h *BrowserHandler) assetBootstrap(w stdhttp.ResponseWriter, r *stdhttp.Req
 	}
 	project := projectview.DevelopView{ID: projectID.String(), Title: h.navigationCatalog(r).Project.Title, Description: h.navigationCatalog(r).Project.Description}
 	if r.URL.Query().Get("surface") == "asset" {
-		return projectui.ProjectAssetBootstrapSignalsForEnvironment(h.navigationCatalog(r), project, asset, assets, edges, r.URL.Query().Get("section"), h.Environment, "", projectui.AssetRefreshState{}, projectui.AssetVersionsState{}, h.layout(r)), true
+		patch := projectui.ProjectAssetBootstrapSignalsForEnvironment(h.navigationCatalog(r), project, asset, assets, edges, r.URL.Query().Get("section"), h.Environment, "", projectui.AssetRefreshState{}, projectui.AssetVersionsState{}, h.layout(r))
+		if r.URL.Query().Get("section") == "data" && (asset.Type == string(projectview.AssetTypeModelTable) || asset.Type == string(projectview.AssetTypeSemanticModel)) {
+			_, explorer, _, explorerOK := h.dataExplorerSignalsForAssetCommand(w, r, asset.ID, projectsignals.DataExplorerCommand{})
+			if !explorerOK {
+				return nil, false
+			}
+			patch["dataExplorer"] = explorer
+			patch["dataExplorerCommand"] = explorer.Command
+		}
+		return patch, true
 	}
 	return projectui.ConnectionAssetBootstrapSignalsForEnvironment(h.navigationCatalog(r), project, asset, assets, edges, r.URL.Query().Get("section"), h.Environment, "", projectui.AssetVersionsState{}), true
 }
@@ -810,16 +876,30 @@ func projectAreaType(area string) string {
 }
 
 func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhttp.Request) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
+	command := projectsignals.DataExplorerCommand{
+		ObjectKey: projectsignals.Optional(strings.TrimSpace(r.URL.Query().Get("object"))),
+		Mode:      projectsignals.Optional(strings.TrimSpace(r.URL.Query().Get("mode"))),
+		Limit:     dataExplorerDefaultLimit, Count: dataExplorerDefaultLimit, Block: projectsignals.Pointer("all"),
+	}
+	return h.dataExplorerSignalsForCommand(w, r, command)
+}
+
+func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter, r *stdhttp.Request, command projectsignals.DataExplorerCommand) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
+	command = normalizeDataExplorerCommand(command)
 	project := h.navigationCatalog(r).Project
 	page := projectsignals.DataExplorerPageSignal{Kind: projectsignals.RouteKindData, Title: "Data Explorer", Description: projectsignals.Optional("Explore governed semantic data."), Tabs: []projectsignals.ResourceTabSignal{}, Context: projectsignals.DataExplorerContextSignal{Active: true, Environment: h.Environment, ProjectID: project.ID, ProjectTitle: projectsignals.Optional(project.Title)}}
-	exploreCommand := projectsignals.DataExploreCommand{Dimensions: []string{}, Measures: []string{}, Filters: []projectsignals.DataExploreFilterSignal{}, Sort: []projectsignals.DataExploreSortSignal{}, Limit: 100}
-	explorer := projectsignals.DataExplorerSignal{Command: projectsignals.DataExplorerCommand{Explore: &exploreCommand, Limit: 100}, Explore: projectsignals.DataExploreSignal{Command: exploreCommand, Models: []projectsignals.DataExploreModelSignal{}, Datasets: []projectsignals.DataExploreDatasetSignal{}, Fields: []projectsignals.DataExploreFieldSignal{}, Result: projectsignals.DataExploreResultSignal{Columns: []projectsignals.DataPreviewColumnSignal{}, Rows: []map[string]any{}, Warnings: []string{}}}, Objects: []projectsignals.DataExplorerObjectSignal{}, Preview: projectsignals.DataPreviewSignal{Blocks: map[string]projectsignals.DataPreviewBlockSignal{}, Columns: []projectsignals.DataPreviewColumnSignal{}, ChunkSize: 100, RowHeight: 32}}
-	if value := strings.TrimSpace(r.URL.Query().Get("model")); value != "" {
+	exploreCommand := projectsignals.DataExploreCommand{Dimensions: []string{}, Measures: []string{}, Filters: []projectsignals.DataExploreFilterSignal{}, Sort: []projectsignals.DataExploreSortSignal{}, Limit: dataExplorerDefaultLimit}
+	if command.Explore != nil {
+		exploreCommand = *command.Explore
+	}
+	if value := strings.TrimSpace(r.URL.Query().Get("model")); value != "" && exploreCommand.ModelID == nil {
 		exploreCommand.ModelID = projectsignals.Optional(value)
 	}
-	if value := strings.TrimSpace(r.URL.Query().Get("dataset")); value != "" {
+	if value := strings.TrimSpace(r.URL.Query().Get("dataset")); value != "" && exploreCommand.DatasetID == nil {
 		exploreCommand.DatasetID = projectsignals.Optional(value)
 	}
+	command.Explore = &exploreCommand
+	explorer := projectsignals.DataExplorerSignal{Command: command, Explore: projectsignals.DataExploreSignal{Command: exploreCommand, Models: []projectsignals.DataExploreModelSignal{}, Datasets: []projectsignals.DataExploreDatasetSignal{}, Fields: []projectsignals.DataExploreFieldSignal{}, Result: projectsignals.DataExploreResultSignal{Columns: []projectsignals.DataPreviewColumnSignal{}, Rows: []map[string]any{}, Warnings: []string{}}}, Objects: []projectsignals.DataExplorerObjectSignal{}, Preview: projectsignals.DataPreviewSignal{Blocks: emptyDataExplorerBlocks(command), Columns: []projectsignals.DataPreviewColumnSignal{}, ChunkSize: command.Count, RowHeight: dataExplorerRowHeight}}
 	_, assets, _, ok := h.assets(w, r)
 	if !ok {
 		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
@@ -848,9 +928,29 @@ func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhtt
 	}
 	explorer.Explore.Command = exploreCommand
 	explorer.Command.Explore = &exploreCommand
+	if projectsignals.ValueOrZero(explorer.Command.Mode) == "explore" {
+		projectID, err := h.boundProject(r.Context())
+		if err != nil {
+			stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+			return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+		}
+		exploreCommand, explorer.Explore.Result = dataExplorerSemanticResult(r.Context(), h.QueryExecutor, projectID, exploreCommand, explorer.Explore.Fields)
+		explorer.Explore.Command = exploreCommand
+		explorer.Command.Explore = &exploreCommand
+	}
 	page.Context.ObjectCount = int64(len(explorer.Objects))
 
-	requestedObject := strings.TrimSpace(r.URL.Query().Get("object"))
+	requestedObject := strings.TrimSpace(projectsignals.ValueOrZero(command.ObjectKey))
+	if projectsignals.ValueOrZero(explorer.Command.Mode) == "explore" && requestedObject == "" {
+		modelID := strings.TrimSpace(projectsignals.ValueOrZero(exploreCommand.ModelID))
+		datasetID := strings.TrimSpace(projectsignals.ValueOrZero(exploreCommand.DatasetID))
+		for _, object := range explorer.Objects {
+			if object.Layer == "model_table" && projectsignals.ValueOrZero(object.ModelID) == modelID && projectsignals.ValueOrZero(object.Table) == datasetID {
+				requestedObject = object.Key
+				break
+			}
+		}
+	}
 	if requestedObject != "" {
 		for index := range explorer.Objects {
 			object := explorer.Objects[index]
@@ -861,13 +961,82 @@ func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhtt
 			explorer.SelectedKey = projectsignals.Optional(object.Key)
 			explorer.SelectedObject = &object
 			page.SelectedObject = projectsignals.Optional(object.Key)
-			if object.Columns != nil {
-				explorer.Preview.Columns = append([]projectsignals.DataPreviewColumnSignal(nil), (*object.Columns)...)
+			projectID, err := h.boundProject(r.Context())
+			if err != nil {
+				stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
+				return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+			}
+			if projectsignals.ValueOrZero(explorer.Command.Mode) != "explore" {
+				explorer.Preview = dataExplorerPreview(r.Context(), h.QueryExecutor, projectID, object, explorer.Command)
 			}
 			break
 		}
 	}
 	return page, explorer, true
+}
+
+func (h *BrowserHandler) dataExplorerSignalsForAssetCommand(w stdhttp.ResponseWriter, r *stdhttp.Request, assetID string, command projectsignals.DataExplorerCommand) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, projectview.DevelopAssetView, bool) {
+	_, assets, _, ok := h.assets(w, r)
+	if !ok {
+		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, projectview.DevelopAssetView{}, false
+	}
+	asset, found := projectview.AssetByID(assets, assetID)
+	if !found || (asset.Type != string(projectview.AssetTypeModelTable) && asset.Type != string(projectview.AssetTypeSemanticModel)) {
+		stdhttp.NotFound(w, r)
+		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, projectview.DevelopAssetView{}, false
+	}
+
+	if asset.Type == string(projectview.AssetTypeModelTable) {
+		command.Mode = projectsignals.Pointer("browse")
+		command.ObjectKey = projectsignals.Pointer(asset.ID)
+	} else {
+		command.Mode = projectsignals.Pointer("explore")
+		explore := projectsignals.DataExploreCommand{}
+		if command.Explore != nil {
+			explore = *command.Explore
+		}
+		explore.ModelID = projectsignals.Pointer(asset.ID)
+		command.Explore = &explore
+	}
+
+	page, explorer, ok := h.dataExplorerSignalsForCommand(w, r, command)
+	if !ok {
+		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, projectview.DevelopAssetView{}, false
+	}
+	objects := make([]projectsignals.DataExplorerObjectSignal, 0, len(explorer.Objects))
+	for _, object := range explorer.Objects {
+		include := asset.Type == string(projectview.AssetTypeModelTable) && explorer.SelectedObject != nil && object.Key == explorer.SelectedObject.Key
+		include = include || asset.Type == string(projectview.AssetTypeSemanticModel) && projectsignals.ValueOrZero(object.ModelID) == asset.ID
+		if include {
+			objects = append(objects, object)
+		}
+	}
+	explorer.Objects = objects
+	page.Context.ObjectCount = int64(len(objects))
+	if explorer.SelectedObject != nil {
+		selected := false
+		for _, object := range objects {
+			if object.Key == explorer.SelectedObject.Key {
+				selected = true
+				break
+			}
+		}
+		if !selected {
+			explorer.SelectedKey = nil
+			explorer.SelectedObject = nil
+			page.SelectedObject = nil
+		}
+	}
+	if asset.Type == string(projectview.AssetTypeSemanticModel) {
+		models := make([]projectsignals.DataExploreModelSignal, 0, 1)
+		for _, model := range explorer.Explore.Models {
+			if model.ID == asset.ID {
+				models = append(models, model)
+			}
+		}
+		explorer.Explore.Models = models
+	}
+	return page, explorer, asset, true
 }
 
 func (h *BrowserHandler) layout(r *stdhttp.Request) webpage.Provider {

--- a/internal/project/http/browser.go
+++ b/internal/project/http/browser.go
@@ -920,12 +920,7 @@ func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter,
 	explorer.Explore.Datasets = projection.Datasets
 	explorer.Explore.SelectedDataset = projection.SelectedDataset
 	explorer.Explore.Fields = projection.Fields
-	if projection.SelectedModel != nil {
-		exploreCommand.ModelID = projectsignals.Optional(projection.SelectedModel.ID)
-	}
-	if projection.SelectedDataset != nil {
-		exploreCommand.DatasetID = projectsignals.Optional(projection.SelectedDataset.ID)
-	}
+	exploreCommand = projection.Command
 	explorer.Explore.Command = exploreCommand
 	explorer.Command.Explore = &exploreCommand
 	if projectsignals.ValueOrZero(explorer.Command.Mode) == "explore" {
@@ -935,13 +930,15 @@ func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter,
 			return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
 		}
 		exploreCommand, explorer.Explore.Result = dataExplorerSemanticResult(r.Context(), h.QueryExecutor, projectID, exploreCommand, explorer.Explore.Fields)
+		explorer.Explore.Result.Warnings = append(explorer.Explore.Result.Warnings, projection.Warnings...)
 		explorer.Explore.Command = exploreCommand
 		explorer.Command.Explore = &exploreCommand
 	}
 	page.Context.ObjectCount = int64(len(explorer.Objects))
 
 	requestedObject := strings.TrimSpace(projectsignals.ValueOrZero(command.ObjectKey))
-	if projectsignals.ValueOrZero(explorer.Command.Mode) == "explore" && requestedObject == "" {
+	if projectsignals.ValueOrZero(explorer.Command.Mode) == "explore" {
+		requestedObject = ""
 		modelID := strings.TrimSpace(projectsignals.ValueOrZero(exploreCommand.ModelID))
 		datasetID := strings.TrimSpace(projectsignals.ValueOrZero(exploreCommand.DatasetID))
 		for _, object := range explorer.Objects {

--- a/internal/project/http/browser_test.go
+++ b/internal/project/http/browser_test.go
@@ -11,10 +11,12 @@ import (
 	"testing"
 
 	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	projectcatalog "github.com/flidai/leapview/internal/project/catalog"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
 	servingstate "github.com/flidai/leapview/internal/servingstate"
 	"github.com/go-chi/chi/v5"
 )
@@ -32,7 +34,7 @@ func TestMountAuthenticatedRegistersCanonicalSurfacesOnly(t *testing.T) {
 		t.Fatalf("walk routes: %v", err)
 	}
 	sort.Strings(got)
-	want := []string{"GET /", "GET /connections", "GET /connections/{asset}/{section}", "GET /explore", "GET /models", "GET /models/{asset}/{section}", "POST /models/search", "GET /pipelines", "GET /pipelines/{asset}/{section}", "GET /semantic-models", "GET /semantic-models/{asset}/{section}", "POST /semantic-models/search", "GET /sources", "GET /sources/{asset}/{section}", "POST /sources/search", "POST /catalog/search", "POST /connections/search"}
+	want := []string{"GET /", "GET /connections", "GET /connections/{asset}/{section}", "GET /explore", "POST /explore/command", "GET /models", "GET /models/{asset}/{section}", "POST /models/{asset}/data/command", "POST /models/search", "GET /pipelines", "GET /pipelines/{asset}/{section}", "GET /semantic-models", "GET /semantic-models/{asset}/{section}", "POST /semantic-models/{asset}/data/command", "POST /semantic-models/search", "GET /sources", "GET /sources/{asset}/{section}", "POST /sources/search", "POST /catalog/search", "POST /connections/search"}
 	sort.Strings(want)
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("routes = %v, want %v", got, want)
@@ -73,6 +75,17 @@ func (s browserSemanticModelStub) SemanticModel(string) (*semanticmodel.Model, b
 type browserProjectDefinitionStub struct {
 	definition projectmanifest.Project
 	err        error
+}
+
+type browserDataQueryStub struct {
+	query  dataquery.Query
+	result dataquery.Result
+	err    error
+}
+
+func (s *browserDataQueryStub) ExecuteDataQuery(_ context.Context, query dataquery.Query) (dataquery.Result, error) {
+	s.query = query
+	return s.result, s.err
 }
 
 func (s browserProjectDefinitionStub) ProjectDefinition(context.Context) (projectmanifest.Project, error) {
@@ -148,6 +161,110 @@ func TestDataExplorerSignalsUseAuthorizedActiveDefinition(t *testing.T) {
 	}
 	if len(explorer.Explore.Models) != 1 || len(explorer.Explore.Datasets) != 1 || len(explorer.Explore.Fields) != 1 {
 		t.Fatalf("explore signal = %#v", explorer.Explore)
+	}
+	_, semanticExplorer, ok := h.dataExplorerSignals(recorder, httptest.NewRequest(stdhttp.MethodGet, "/explore?mode=explore&model=semantic:sales&dataset=orders", nil))
+	if !ok || projectsignals.ValueOrZero(semanticExplorer.Command.Mode) != "explore" || semanticExplorer.SelectedObject == nil || semanticExplorer.SelectedObject.ResourceID != "model:orders" {
+		t.Fatalf("semantic deep link = %#v", semanticExplorer)
+	}
+}
+
+func TestDataExplorerPreviewExecutesGovernedModelTableQuery(t *testing.T) {
+	executor := &browserDataQueryStub{result: dataquery.Result{
+		Rows:           []dataquery.Row{{"order_id": int64(42), "status": "paid"}},
+		TotalRows:      1,
+		TotalRowsKnown: true,
+		SQL:            `select "order_id", "status" from "orders"`,
+	}}
+	columns := []projectsignals.DataPreviewColumnSignal{{Key: "order_id", Label: "Order ID"}, {Key: "status", Label: "Status"}}
+	object := projectsignals.DataExplorerObjectSignal{
+		Key: "model_table:model:orders:semantic-model:sales", ResourceID: "model:orders", Layer: "model_table",
+		ModelID: projectsignals.Pointer("semantic-model:sales"), Table: projectsignals.Pointer("orders"), Columns: &columns,
+	}
+	preview := dataExplorerPreview(t.Context(), executor, "project:test", object, projectsignals.DataExplorerCommand{
+		ObjectKey: projectsignals.Pointer(object.Key), Count: 100, Limit: 100, Block: projectsignals.Pointer("all"),
+	})
+
+	if preview.Error != nil {
+		t.Fatalf("preview error = %q", *preview.Error)
+	}
+	if preview.AvailableRows != 1 || len(preview.Blocks["a"].Rows) != 1 {
+		t.Fatalf("preview = %#v", preview)
+	}
+	if executor.query.ProjectID != "project:test" || executor.query.ModelID != "semantic-model:sales" || executor.query.Target != "orders" {
+		t.Fatalf("query = %#v", executor.query)
+	}
+	if executor.query.Surface != dataquery.SurfaceDataExplorer || executor.query.Operation != dataquery.OperationPreviewWindow {
+		t.Fatalf("query metadata = %#v", executor.query)
+	}
+}
+
+func TestDataExplorerSemanticExploreExecutesGovernedAggregate(t *testing.T) {
+	executor := &browserDataQueryStub{result: dataquery.Result{
+		Columns: []dataquery.Column{{Name: "status"}, {Name: "orders"}},
+		Rows:    []dataquery.Row{{"status": "paid", "orders": int64(7)}}, SQL: "select status, count(*)", DurationMS: 12,
+	}}
+	command, result := dataExplorerSemanticResult(t.Context(), executor, "project:test", projectsignals.DataExploreCommand{
+		ModelID: projectsignals.Pointer("semantic-model:sales"), DatasetID: projectsignals.Pointer("orders"),
+		Dimensions: []string{"orders.status"}, Measures: []string{"orders"}, Filters: []projectsignals.DataExploreFilterSignal{},
+		Sort: []projectsignals.DataExploreSortSignal{{Field: "orders", Direction: "desc"}}, Limit: 100,
+	}, []projectsignals.DataExploreFieldSignal{
+		{ID: "orders.status", Label: "Status", Kind: "dimension", Compatible: true},
+		{ID: "orders", Label: "Orders", Kind: "measure", Compatible: true},
+	})
+
+	if result.Error != nil || result.RowsReturned != 1 || len(result.Rows) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(command.Dimensions) != 1 || len(command.Measures) != 1 {
+		t.Fatalf("normalized command = %#v", command)
+	}
+	if executor.query.Kind != dataquery.KindSemanticAggregate || executor.query.ProjectID != "project:test" || executor.query.Operation != dataquery.OperationSemanticExplore {
+		t.Fatalf("query = %#v", executor.query)
+	}
+	if executor.query.Fields[0].Alias != "status" || executor.query.Measures[0].Alias != "orders" {
+		t.Fatalf("query aliases = %#v / %#v", executor.query.Fields, executor.query.Measures)
+	}
+}
+
+func TestAssetDataExplorerScopesModelsAndSemanticModels(t *testing.T) {
+	const projectID = "project:test"
+	model := &semanticmodel.Model{Name: "sales", Tables: map[string]semanticmodel.Table{
+		"orders": {Dimensions: map[string]semanticmodel.MetricDimension{"status": {Label: "Status"}}},
+	}}
+	executor := &browserDataQueryStub{result: dataquery.Result{Rows: []dataquery.Row{{"status": "paid"}}, TotalRows: 1, TotalRowsKnown: true}}
+	h := &BrowserHandler{
+		Graph: browserGraphStub{graph: servingstate.AssetGraph{Assets: []servingstate.Asset{
+			{ID: "model:orders", ProjectID: projectID, Type: "model_table", Key: "orders", Title: "Orders", PayloadJSON: `{}`},
+			{ID: "semantic-model:sales", ProjectID: projectID, Type: "semantic_model", Key: "sales", Title: "Sales", PayloadJSON: `{}`},
+		}}},
+		ProjectDefinitionReader: browserProjectDefinitionStub{definition: projectmanifest.Project{
+			ID: projectID, Models: map[string]semanticmodel.Table{"model:orders": model.Tables["orders"]},
+			SemanticModels: map[string]*semanticmodel.Model{"semantic-model:sales": model}, NameIndex: projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders"}},
+		}},
+		QueryExecutor: executor, ResolveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return projectID, nil },
+		Environment: "dev", CurrentUser: func(*stdhttp.Request) (Principal, bool) { return Principal{DevBypass: true}, true },
+	}
+	for _, test := range []struct {
+		asset string
+		mode  string
+	}{
+		{asset: "model:orders", mode: "browse"},
+		{asset: "semantic-model:sales", mode: "explore"},
+	} {
+		recorder := httptest.NewRecorder()
+		_, explorer, _, ok := h.dataExplorerSignalsForAssetCommand(recorder, httptest.NewRequest(stdhttp.MethodGet, "/", nil), test.asset, projectsignals.DataExplorerCommand{})
+		if !ok {
+			t.Fatalf("asset %s state failed: status=%d body=%s", test.asset, recorder.Code, recorder.Body.String())
+		}
+		if projectsignals.ValueOrZero(explorer.Command.Mode) != test.mode || len(explorer.Objects) != 1 || explorer.SelectedObject == nil {
+			t.Fatalf("asset %s explorer = %#v", test.asset, explorer)
+		}
+		if test.mode == "browse" && len(explorer.Preview.Blocks["a"].Rows) != 1 {
+			t.Fatalf("model preview = %#v", explorer.Preview)
+		}
+		if test.mode == "explore" && projectsignals.ValueOrZero(explorer.Explore.Command.ModelID) != test.asset {
+			t.Fatalf("semantic command = %#v", explorer.Explore.Command)
+		}
 	}
 }
 

--- a/internal/project/http/browser_test.go
+++ b/internal/project/http/browser_test.go
@@ -14,6 +14,7 @@ import (
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	projectcatalog "github.com/flidai/leapview/internal/project/catalog"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
 	servingstate "github.com/flidai/leapview/internal/servingstate"
 	"github.com/go-chi/chi/v5"
 )
@@ -67,6 +68,87 @@ type browserSemanticModelStub struct{ model *semanticmodel.Model }
 
 func (s browserSemanticModelStub) SemanticModel(string) (*semanticmodel.Model, bool) {
 	return s.model, s.model != nil
+}
+
+type browserProjectDefinitionStub struct {
+	definition projectmanifest.Project
+	err        error
+}
+
+func (s browserProjectDefinitionStub) ProjectDefinition(context.Context) (projectmanifest.Project, error) {
+	return s.definition, s.err
+}
+
+func TestModelAssetBootstrapUsesActiveCompiledDefinition(t *testing.T) {
+	const projectID = "project:test"
+	const assetID = "model:zip_geolocations"
+	h := &BrowserHandler{
+		Graph: browserGraphStub{graph: servingstate.AssetGraph{Assets: []servingstate.Asset{{
+			ID: assetID, ProjectID: projectID, ServingStateID: "state", Type: "model_table", Key: "zip_geolocations", Title: "ZIP locations", PayloadJSON: `{"kind":"model"}`,
+		}}}},
+		ProjectDefinitionReader: browserProjectDefinitionStub{definition: projectmanifest.Project{
+			ID: projectID,
+			Models: map[string]semanticmodel.Table{assetID: {
+				Sources: []string{"geolocations"}, Transform: semanticmodel.Transform{SQL: "select zip_code from source.geolocations"},
+				PrimaryKey: "zip_code", Grain: "zip_code", Dimensions: map[string]semanticmodel.MetricDimension{"zip_code": {Label: "ZIP code"}},
+			}},
+		}},
+		ResolveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return projectID, nil },
+		Environment:      "dev",
+		CurrentUser:      func(*stdhttp.Request) (Principal, bool) { return Principal{DevBypass: true}, true },
+	}
+
+	patch, ok := h.assetBootstrap(httptest.NewRecorder(), httptest.NewRequest(stdhttp.MethodGet, "/updates?surface=asset&asset="+assetID+"&section=details", nil))
+	if !ok {
+		t.Fatal("asset bootstrap returned not ok")
+	}
+	encoded, err := json.Marshal(patch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Fields (1)", `"label":"Input sources","value":"1"`, "select zip_code from source.geolocations"} {
+		if !strings.Contains(string(encoded), want) {
+			t.Fatalf("bootstrap = %s, missing %q", encoded, want)
+		}
+	}
+}
+
+func TestDataExplorerSignalsUseAuthorizedActiveDefinition(t *testing.T) {
+	const projectID = "project:test"
+	model := &semanticmodel.Model{Name: "sales", Tables: map[string]semanticmodel.Table{
+		"orders": {Grain: "order_id", Dimensions: map[string]semanticmodel.MetricDimension{"status": {Label: "Status"}}},
+	}}
+	h := &BrowserHandler{
+		Graph: browserGraphStub{graph: servingstate.AssetGraph{Assets: []servingstate.Asset{
+			{ID: "source:orders", ProjectID: projectID, ServingStateID: "state", Type: "source", Key: "orders", Title: "Orders source", PayloadJSON: `{}`},
+			{ID: "model:orders", ProjectID: projectID, ServingStateID: "state", Type: "model_table", Key: "orders", Title: "Orders", PayloadJSON: `{}`},
+			{ID: "semantic:sales", ProjectID: projectID, ServingStateID: "state", Type: "semantic_model", Key: "sales", Title: "Sales", PayloadJSON: `{}`},
+		}}},
+		ProjectDefinitionReader: browserProjectDefinitionStub{definition: projectmanifest.Project{
+			ID:             projectID,
+			Sources:        map[string]semanticmodel.Source{"source:orders": {Fields: map[string]semanticmodel.SourceField{"id": {Type: "integer"}}}},
+			Models:         map[string]semanticmodel.Table{"model:orders": model.Tables["orders"]},
+			SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": model},
+			NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders"}},
+		}},
+		ResolveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return projectID, nil },
+		Environment:      "dev",
+		CurrentUser:      func(*stdhttp.Request) (Principal, bool) { return Principal{DevBypass: true}, true },
+	}
+	recorder := httptest.NewRecorder()
+	page, explorer, ok := h.dataExplorerSignals(recorder, httptest.NewRequest(stdhttp.MethodGet, "/explore?object=model:orders", nil))
+	if !ok {
+		t.Fatalf("data explorer returned not ok: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if page.Context.ObjectCount != 2 || len(explorer.Objects) != 2 {
+		t.Fatalf("objects = %#v, context = %#v", explorer.Objects, page.Context)
+	}
+	if explorer.SelectedObject == nil || explorer.SelectedObject.ResourceID != "model:orders" {
+		t.Fatalf("selected object = %#v, want model:orders", explorer.SelectedObject)
+	}
+	if len(explorer.Explore.Models) != 1 || len(explorer.Explore.Datasets) != 1 || len(explorer.Explore.Fields) != 1 {
+		t.Fatalf("explore signal = %#v", explorer.Explore)
+	}
 }
 
 func TestSemanticModelAssetBootstrapUsesCompiledModelProjection(t *testing.T) {

--- a/internal/project/http/data_explorer_preview.go
+++ b/internal/project/http/data_explorer_preview.go
@@ -1,0 +1,408 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
+)
+
+const (
+	dataExplorerDefaultLimit = int64(100)
+	dataExplorerMaximumLimit = int64(1000)
+	dataExplorerRowHeight    = int64(32)
+)
+
+var dataExplorerBlockIDs = []string{"a", "b", "c"}
+
+// DataQueryExecutor is the narrow analytics port required by Data Explorer.
+// The composed implementation applies the same authorization, admission, and
+// audit policies as dashboard and semantic API queries.
+type DataQueryExecutor interface {
+	ExecuteDataQuery(context.Context, dataquery.Query) (dataquery.Result, error)
+}
+
+func normalizeDataExplorerCommand(command projectsignals.DataExplorerCommand) projectsignals.DataExplorerCommand {
+	if command.Limit <= 0 {
+		command.Limit = dataExplorerDefaultLimit
+	}
+	if command.Limit > dataExplorerMaximumLimit {
+		command.Limit = dataExplorerMaximumLimit
+	}
+	if command.Count <= 0 {
+		command.Count = command.Limit
+	}
+	if command.Count > dataExplorerMaximumLimit {
+		command.Count = dataExplorerMaximumLimit
+	}
+	if command.Offset < 0 {
+		command.Offset = 0
+	}
+	if command.Start < 0 {
+		command.Start = 0
+	}
+	if command.Start == 0 && command.Offset > 0 {
+		command.Start = command.Offset
+	}
+	block := strings.TrimSpace(projectsignals.ValueOrZero(command.Block))
+	if block != "a" && block != "b" && block != "c" && block != "all" {
+		block = "all"
+	}
+	command.Block = projectsignals.Pointer(block)
+	command.Sort = dataExplorerSortForColumns(command.Sort, command.VisibleColumns)
+	if command.Mode == nil || strings.TrimSpace(*command.Mode) == "" {
+		command.Mode = projectsignals.Pointer("browse")
+	}
+	return command
+}
+
+func dataExplorerPreview(ctx context.Context, executor DataQueryExecutor, projectID projectgraph.ResourceID, object projectsignals.DataExplorerObjectSignal, command projectsignals.DataExplorerCommand) projectsignals.DataPreviewSignal {
+	command = normalizeDataExplorerCommand(command)
+	columns := explorerPreviewColumns(object)
+	command.Sort = dataExplorerSortForObjectColumns(command.Sort, columns)
+	preview := projectsignals.DataPreviewSignal{
+		Columns: columns, Blocks: emptyDataExplorerBlocks(command), ChunkSize: command.Count,
+		RowHeight: dataExplorerRowHeight, ResetVersion: command.ResetVersion, Sort: command.Sort,
+		TotalRowLabel: object.RowCountLabel,
+	}
+	if executor == nil {
+		preview.Error = projectsignals.Pointer("data preview execution is unavailable")
+		return preview
+	}
+
+	starts, blockIDs := dataExplorerRequestedBlocks(command)
+	totalKnown := false
+	for index := 0; index < len(starts); index++ {
+		start := starts[index]
+		query, err := dataExplorerPreviewQuery(projectID, object, command, columns, start, command.Count, index == 0)
+		if err != nil {
+			preview.Error = projectsignals.Pointer(err.Error())
+			return preview
+		}
+		result, err := executor.ExecuteDataQuery(ctx, query)
+		if err != nil {
+			preview.Error = projectsignals.Pointer(err.Error())
+			return preview
+		}
+		if strings.TrimSpace(result.Error) != "" {
+			preview.Error = projectsignals.Pointer(result.Error)
+			return preview
+		}
+		if result.SQL != "" {
+			preview.SQL = projectsignals.Pointer(result.SQL)
+		}
+		if result.TotalRowsKnown {
+			totalKnown = true
+			preview.TotalRows = int64(result.TotalRows)
+			preview.AvailableRows = preview.TotalRows
+			preview.TotalRowLabel = projectsignals.Pointer(fmt.Sprintf("%d", result.TotalRows))
+		}
+		rows := dataExplorerRows(result.Rows)
+		preview.Blocks[blockIDs[index]] = projectsignals.DataPreviewBlockSignal{
+			Start: start, RequestSeq: command.RequestSeq, ResetVersion: command.ResetVersion, Sort: command.Sort, Rows: rows,
+		}
+		if !totalKnown {
+			loaded := start + int64(len(rows))
+			if loaded > preview.AvailableRows {
+				preview.AvailableRows = loaded
+				preview.TotalRows = loaded
+			}
+			if int64(len(rows)) == command.Count {
+				// Keep one more window reachable when the executor cannot provide a
+				// total. A short following block closes the provisional range.
+				preview.AvailableRows = loaded + command.Count
+				preview.TotalRows = preview.AvailableRows
+			}
+		}
+		if index == 0 && projectsignals.ValueOrZero(command.Block) == "all" {
+			starts, blockIDs = dataExplorerRemainingBlocks(command, preview, int64(len(rows)), totalKnown)
+		}
+	}
+	if !totalKnown && preview.TotalRowLabel == nil {
+		preview.TotalRowLabel = projectsignals.Pointer("Unknown")
+	}
+	return preview
+}
+
+func dataExplorerPreviewQuery(projectID projectgraph.ResourceID, object projectsignals.DataExplorerObjectSignal, command projectsignals.DataExplorerCommand, columns []projectsignals.DataPreviewColumnSignal, start, count int64, includeTotal bool) (dataquery.Query, error) {
+	modelID := strings.TrimSpace(projectsignals.ValueOrZero(object.ModelID))
+	table := strings.TrimSpace(projectsignals.ValueOrZero(object.Table))
+	if object.Layer != "model_table" {
+		return dataquery.Query{}, fmt.Errorf("data preview is not supported for %s resources", object.Layer)
+	}
+	if modelID == "" || table == "" {
+		return dataquery.Query{}, fmt.Errorf("model table preview target is incomplete")
+	}
+	columnNames := make([]string, 0, len(columns))
+	for _, column := range columns {
+		if key := strings.TrimSpace(column.Key); key != "" {
+			columnNames = append(columnNames, key)
+		}
+	}
+	sortSpec := []dataquery.Sort{}
+	if column := strings.TrimSpace(projectsignals.ValueOrZero(command.Sort.Column)); column != "" {
+		sortSpec = append(sortSpec, dataquery.Sort{Field: column, Direction: projectsignals.ValueOrZero(command.Sort.Direction)})
+	}
+	query := dataquery.ModelTableRows(modelID, table, columnNames, sortSpec, int(start), int(count), includeTotal)
+	return query.WithMetadata(dataquery.Metadata{
+		ProjectID: projectID, Surface: dataquery.SurfaceDataExplorer, Operation: dataquery.OperationPreviewWindow,
+		ObjectType: object.Layer, ObjectID: object.ResourceID,
+	}), nil
+}
+
+func explorerPreviewColumns(object projectsignals.DataExplorerObjectSignal) []projectsignals.DataPreviewColumnSignal {
+	if object.Columns == nil {
+		return []projectsignals.DataPreviewColumnSignal{}
+	}
+	return append([]projectsignals.DataPreviewColumnSignal(nil), (*object.Columns)...)
+}
+
+func dataExplorerSortForColumns(sortSignal projectsignals.DataPreviewSortSignal, visibleColumns *[]string) projectsignals.DataPreviewSortSignal {
+	column := strings.TrimSpace(projectsignals.ValueOrZero(sortSignal.Column))
+	direction := strings.ToLower(strings.TrimSpace(projectsignals.ValueOrZero(sortSignal.Direction)))
+	if column == "" || (direction != "asc" && direction != "desc") {
+		return projectsignals.DataPreviewSortSignal{}
+	}
+	if visibleColumns != nil && len(*visibleColumns) > 0 {
+		for _, visible := range *visibleColumns {
+			if visible == column {
+				return projectsignals.DataPreviewSortSignal{Column: projectsignals.Pointer(column), Direction: projectsignals.Pointer(direction)}
+			}
+		}
+		return projectsignals.DataPreviewSortSignal{}
+	}
+	return projectsignals.DataPreviewSortSignal{Column: projectsignals.Pointer(column), Direction: projectsignals.Pointer(direction)}
+}
+
+func dataExplorerSortForObjectColumns(sortSignal projectsignals.DataPreviewSortSignal, columns []projectsignals.DataPreviewColumnSignal) projectsignals.DataPreviewSortSignal {
+	column := strings.TrimSpace(projectsignals.ValueOrZero(sortSignal.Column))
+	if column == "" {
+		return projectsignals.DataPreviewSortSignal{}
+	}
+	for _, candidate := range columns {
+		if candidate.Key == column {
+			return sortSignal
+		}
+	}
+	return projectsignals.DataPreviewSortSignal{}
+}
+
+func emptyDataExplorerBlocks(command projectsignals.DataExplorerCommand) map[string]projectsignals.DataPreviewBlockSignal {
+	blocks := make(map[string]projectsignals.DataPreviewBlockSignal, len(dataExplorerBlockIDs))
+	for index, id := range dataExplorerBlockIDs {
+		blocks[id] = projectsignals.DataPreviewBlockSignal{
+			Start: int64(index) * command.Count, ResetVersion: command.ResetVersion, Sort: command.Sort, Rows: []map[string]any{},
+		}
+	}
+	return blocks
+}
+
+func dataExplorerRequestedBlocks(command projectsignals.DataExplorerCommand) ([]int64, []string) {
+	block := projectsignals.ValueOrZero(command.Block)
+	if block == "all" {
+		return []int64{command.Start}, []string{"a"}
+	}
+	return []int64{command.Start}, []string{block}
+}
+
+func dataExplorerRemainingBlocks(command projectsignals.DataExplorerCommand, preview projectsignals.DataPreviewSignal, firstRows int64, totalKnown bool) ([]int64, []string) {
+	starts := []int64{command.Start}
+	blocks := []string{"a"}
+	if firstRows < command.Count {
+		return starts, blocks
+	}
+	for index := int64(1); index < int64(len(dataExplorerBlockIDs)); index++ {
+		start := command.Start + index*command.Count
+		if totalKnown && start >= preview.AvailableRows {
+			break
+		}
+		starts = append(starts, start)
+		blocks = append(blocks, dataExplorerBlockIDs[index])
+	}
+	return starts, blocks
+}
+
+func dataExplorerRows(rows []dataquery.Row) []map[string]any {
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		copy := make(map[string]any, len(row))
+		for key, value := range row {
+			copy[key] = value
+		}
+		out = append(out, copy)
+	}
+	return out
+}
+
+func dataExplorerSemanticResult(ctx context.Context, executor DataQueryExecutor, projectID projectgraph.ResourceID, command projectsignals.DataExploreCommand, fields []projectsignals.DataExploreFieldSignal) (projectsignals.DataExploreCommand, projectsignals.DataExploreResultSignal) {
+	resultSignal := projectsignals.DataExploreResultSignal{
+		Columns: []projectsignals.DataPreviewColumnSignal{}, Rows: []map[string]any{}, Warnings: []string{}, RequestSeq: command.RequestSeq,
+	}
+	if command.Limit <= 0 {
+		command.Limit = dataExplorerDefaultLimit
+	}
+	if command.Limit > dataExplorerMaximumLimit {
+		command.Limit = dataExplorerMaximumLimit
+	}
+	fieldByID := make(map[string]projectsignals.DataExploreFieldSignal, len(fields))
+	for _, field := range fields {
+		fieldByID[field.ID] = field
+	}
+	command.Dimensions = validExplorerFields(command.Dimensions, "dimension", fieldByID)
+	command.Measures = validExplorerFields(command.Measures, "measure", fieldByID)
+	command.Filters = validExplorerFilters(command.Filters, fieldByID)
+	command.Sort = validExplorerSort(command.Sort, command)
+	if len(command.Dimensions) == 0 && len(command.Measures) == 0 && command.Time == nil {
+		return command, resultSignal
+	}
+	if executor == nil {
+		resultSignal.Error = projectsignals.Pointer("governed exploration execution is unavailable")
+		return command, resultSignal
+	}
+	modelID := strings.TrimSpace(projectsignals.ValueOrZero(command.ModelID))
+	datasetID := strings.TrimSpace(projectsignals.ValueOrZero(command.DatasetID))
+	if modelID == "" || datasetID == "" {
+		resultSignal.Error = projectsignals.Pointer("semantic exploration target is incomplete")
+		return command, resultSignal
+	}
+	aliases := explorerQueryAliases(command.Dimensions, command.Measures)
+	dimensions := make([]dataquery.Field, 0, len(command.Dimensions))
+	for _, field := range command.Dimensions {
+		dimensions = append(dimensions, dataquery.Field{Field: field, Alias: aliases[field]})
+	}
+	measures := make([]dataquery.Field, 0, len(command.Measures))
+	for _, field := range command.Measures {
+		measures = append(measures, dataquery.Field{Field: field, Alias: aliases[field]})
+	}
+	filters := make([]dataquery.Filter, 0, len(command.Filters))
+	for _, filter := range command.Filters {
+		values := make([]any, 0, len(filter.Values))
+		for _, value := range filter.Values {
+			values = append(values, value)
+		}
+		filters = append(filters, dataquery.Filter{Field: filter.Field, Fact: projectsignals.ValueOrZero(filter.Fact), Operator: filter.Operator, Values: values})
+	}
+	sortSpec := make([]dataquery.Sort, 0, len(command.Sort))
+	for _, sortSignal := range command.Sort {
+		sortSpec = append(sortSpec, dataquery.Sort{Field: sortSignal.Field, Direction: sortSignal.Direction})
+	}
+	query := dataquery.SemanticAggregate(modelID, datasetID, dimensions, measures, filters, sortSpec, 0, int(command.Limit)+1)
+	if command.Time != nil {
+		query.Time = dataquery.Time{Field: command.Time.Field, Grain: command.Time.Grain, Alias: projectsignals.ValueOrZero(command.Time.Alias)}
+	}
+	query = query.WithMetadata(dataquery.Metadata{
+		ProjectID: projectID, Surface: dataquery.SurfaceDataExplorer, Operation: dataquery.OperationSemanticExplore,
+		ObjectType: "semantic_dataset", ObjectID: modelID + ":" + datasetID,
+	})
+	executed, err := executor.ExecuteDataQuery(ctx, query)
+	if err != nil {
+		resultSignal.Error = projectsignals.Pointer(err.Error())
+		return command, resultSignal
+	}
+	if strings.TrimSpace(executed.Error) != "" {
+		resultSignal.Error = projectsignals.Pointer(executed.Error)
+		return command, resultSignal
+	}
+	rows := executed.Rows
+	truncated := int64(len(rows)) > command.Limit
+	if truncated {
+		rows = rows[:command.Limit]
+	}
+	labels := explorerResultLabels(fields, aliases)
+	columns := make([]projectsignals.DataPreviewColumnSignal, 0, len(executed.Columns))
+	for _, column := range executed.Columns {
+		columns = append(columns, projectsignals.DataPreviewColumnSignal{Key: column.Name, Label: firstExplorerNonEmpty(labels[column.Name], column.Name)})
+	}
+	return command, projectsignals.DataExploreResultSignal{
+		Columns: columns, Rows: dataExplorerRows(rows), SQL: projectsignals.Optional(executed.SQL), Plan: projectsignals.Optional(executed.PlanText),
+		DurationMS: executed.DurationMS, RowsReturned: int64(len(rows)), Truncated: truncated,
+		Warnings: append([]string(nil), executed.Warnings...), RequestSeq: command.RequestSeq,
+	}
+}
+
+func validExplorerFields(values []string, kind string, fields map[string]projectsignals.DataExploreFieldSignal) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		field, ok := fields[value]
+		if !ok || field.Kind != kind || !field.Compatible {
+			continue
+		}
+		if _, duplicate := seen[value]; duplicate {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func validExplorerFilters(filters []projectsignals.DataExploreFilterSignal, fields map[string]projectsignals.DataExploreFieldSignal) []projectsignals.DataExploreFilterSignal {
+	out := make([]projectsignals.DataExploreFilterSignal, 0, len(filters))
+	for _, filter := range filters {
+		field, ok := fields[filter.Field]
+		if !ok || field.Kind != "dimension" || !field.Compatible || strings.TrimSpace(filter.Operator) == "" {
+			continue
+		}
+		filter.Values = append([]string(nil), filter.Values...)
+		out = append(out, filter)
+	}
+	return out
+}
+
+func validExplorerSort(sortSignals []projectsignals.DataExploreSortSignal, command projectsignals.DataExploreCommand) []projectsignals.DataExploreSortSignal {
+	selected := map[string]struct{}{}
+	for _, field := range append(append([]string(nil), command.Dimensions...), command.Measures...) {
+		selected[field] = struct{}{}
+	}
+	out := make([]projectsignals.DataExploreSortSignal, 0, len(sortSignals))
+	for _, sortSignal := range sortSignals {
+		direction := strings.ToLower(strings.TrimSpace(sortSignal.Direction))
+		if _, ok := selected[sortSignal.Field]; !ok || (direction != "asc" && direction != "desc") {
+			continue
+		}
+		sortSignal.Direction = direction
+		out = append(out, sortSignal)
+	}
+	return out
+}
+
+func explorerQueryAliases(dimensions, measures []string) map[string]string {
+	all := append(append([]string(nil), dimensions...), measures...)
+	counts := map[string]int{}
+	for _, field := range all {
+		counts[explorerFieldName(field)]++
+	}
+	out := make(map[string]string, len(all))
+	for _, field := range all {
+		table, name, found := strings.Cut(field, ".")
+		if !found {
+			name = field
+		}
+		if counts[name] > 1 && table != "" {
+			name = table + "__" + name
+		}
+		out[field] = name
+	}
+	return out
+}
+
+func explorerFieldName(field string) string {
+	if index := strings.LastIndex(field, "."); index >= 0 && index+1 < len(field) {
+		return field[index+1:]
+	}
+	return field
+}
+
+func explorerResultLabels(fields []projectsignals.DataExploreFieldSignal, aliases map[string]string) map[string]string {
+	out := make(map[string]string, len(aliases))
+	for _, field := range fields {
+		if alias := aliases[field.ID]; alias != "" {
+			out[alias] = firstExplorerNonEmpty(field.Label, alias)
+		}
+	}
+	return out
+}

--- a/internal/project/http/data_explorer_projection.go
+++ b/internal/project/http/data_explorer_projection.go
@@ -1,0 +1,463 @@
+package http
+
+// This file contains the browser-facing Data Explorer projection.  The
+// serving graph decides which resources are visible; the compiled project
+// manifest supplies the semantic model and table metadata that is deliberately
+// not duplicated in the graph's project.graph.v1 payload.
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	projectview "github.com/flidai/leapview/internal/project"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
+)
+
+// DataExplorerProjection is the complete catalog/semantic payload needed to
+// bootstrap the Data Explorer browser.  It is intentionally detached from the
+// serving graph and manifest inputs, so a caller can safely retain the result
+// for one response.
+type DataExplorerProjection struct {
+	Objects         []projectsignals.DataExplorerObjectSignal
+	Models          []projectsignals.DataExploreModelSignal
+	SelectedModel   *projectsignals.DataExploreModelSignal
+	Datasets        []projectsignals.DataExploreDatasetSignal
+	SelectedDataset *projectsignals.DataExploreDatasetSignal
+	Fields          []projectsignals.DataExploreFieldSignal
+}
+
+// BuildDataExplorerProjection projects authorized serving assets together
+// with the active compiled project manifest.  Asset visibility is authoritative
+// for every output: manifest entries that do not have a visible serving asset
+// are never exposed to the browser.
+func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project projectmanifest.Project, command projectsignals.DataExploreCommand) DataExplorerProjection {
+	visible := make(map[string]projectview.DevelopAssetView, len(assets))
+	for _, asset := range assets {
+		if strings.TrimSpace(asset.ID) == "" {
+			continue
+		}
+		visible[asset.ID] = asset
+	}
+
+	semanticIDs := make([]string, 0, len(project.SemanticModels))
+	for id := range project.SemanticModels {
+		if asset, ok := visible[id]; ok && asset.Type == string(projectview.AssetTypeSemanticModel) {
+			semanticIDs = append(semanticIDs, id)
+		}
+	}
+	sort.Strings(semanticIDs)
+
+	models := make([]projectsignals.DataExploreModelSignal, 0, len(semanticIDs))
+	modelByID := make(map[string]*semanticmodel.Model, len(semanticIDs))
+	for _, id := range semanticIDs {
+		model := project.SemanticModels[id]
+		if model == nil {
+			continue
+		}
+		modelByID[id] = model
+		asset := visible[id]
+		models = append(models, projectsignals.DataExploreModelSignal{
+			ID:          id,
+			Title:       firstExplorerNonEmpty(model.Title, model.Name, asset.Title, id),
+			Description: projectsignals.Optional(firstExplorerNonEmpty(model.Description, asset.Description)),
+			Datasets:    explorerDatasets(model),
+		})
+	}
+
+	// A model table is keyed by its canonical model resource ID in the
+	// manifest. Semantic model table names remain authored names, so resolve
+	// them through NameIndex before associating browser objects with a model.
+	semanticForTable := make(map[string][]string)
+	for _, semanticID := range semanticIDs {
+		model := modelByID[semanticID]
+		for tableName := range model.Tables {
+			modelID := project.NameIndex.Models[tableName]
+			if modelID == "" {
+				modelID = explorerModelIDByName(visible, tableName)
+			}
+			if modelID == "" {
+				continue
+			}
+			semanticForTable[modelID] = append(semanticForTable[modelID], semanticID)
+		}
+	}
+	for id := range semanticForTable {
+		sort.Strings(semanticForTable[id])
+	}
+
+	objects := make([]projectsignals.DataExplorerObjectSignal, 0)
+	for _, asset := range sortedExplorerAssets(visible) {
+		switch asset.Type {
+		case string(projectview.AssetTypeSource):
+			// Sources are retained in the unified catalog. The Lit browser hides
+			// source groups while still allowing search and agent references to
+			// inspect the canonical source resource.
+			source := project.Sources[asset.ID]
+			columns := explorerSourceColumns(source)
+			objects = append(objects, projectsignals.DataExplorerObjectSignal{
+				Key:           "source:" + asset.ID,
+				AssetID:       projectsignals.Optional(asset.ID),
+				ResourceID:    asset.ID,
+				Layer:         "source",
+				Title:         firstExplorerNonEmpty(asset.Title, asset.Key, asset.ID),
+				Description:   projectsignals.Optional(firstExplorerNonEmpty(asset.Description, source.Description)),
+				DetailHref:    projectsignals.Optional(explorerAssetDetailsHref(asset, "details")),
+				ColumnCount:   int64(len(columns)),
+				RowCountLabel: projectsignals.Pointer("Preview unavailable"),
+				Columns:       projectsignals.OptionalSlice(columns),
+			})
+		case string(projectview.AssetTypeModelTable):
+			table, ok := project.Models[asset.ID]
+			if !ok {
+				// A malformed or stale manifest must not make the entire catalog
+				// unavailable. Keep the authorized object with graph metadata.
+				table = explorerTableByName(project.Models, asset.Key)
+			}
+			columns := explorerTableColumns(table)
+			modelIDs := semanticForTable[asset.ID]
+			if len(modelIDs) == 0 {
+				objects = append(objects, explorerModelTableObject(asset, table, columns, ""))
+				continue
+			}
+			// One object per semantic model keeps field compatibility scoped to
+			// the selected model while preserving a stable canonical asset ID.
+			for _, semanticID := range modelIDs {
+				objects = append(objects, explorerModelTableObject(asset, table, columns, semanticID))
+			}
+		}
+	}
+	sortExplorerObjects(objects)
+
+	selectedModelID := strings.TrimSpace(projectsignals.ValueOrZero(command.ModelID))
+	selectedModelIndex := -1
+	for index := range models {
+		if models[index].ID == selectedModelID {
+			selectedModelIndex = index
+			break
+		}
+	}
+	if selectedModelIndex < 0 && len(models) > 0 {
+		selectedModelIndex = 0
+	}
+	result := DataExplorerProjection{Objects: objects, Models: models}
+	if selectedModelIndex < 0 {
+		return result
+	}
+	selectedModel := models[selectedModelIndex]
+	result.SelectedModel = &selectedModel
+	result.Datasets = append([]projectsignals.DataExploreDatasetSignal(nil), selectedModel.Datasets...)
+	selectedDatasetID := strings.TrimSpace(projectsignals.ValueOrZero(command.DatasetID))
+	for index := range result.Datasets {
+		if result.Datasets[index].ID == selectedDatasetID {
+			selected := result.Datasets[index]
+			result.SelectedDataset = &selected
+			break
+		}
+	}
+	if result.SelectedDataset == nil && len(result.Datasets) > 0 {
+		selected := result.Datasets[0]
+		result.SelectedDataset = &selected
+	}
+	baseTable := ""
+	if result.SelectedDataset != nil {
+		baseTable = result.SelectedDataset.ID
+	}
+	result.Fields = explorerFields(modelByID[selectedModel.ID], baseTable, command)
+	return result
+}
+
+func explorerDatasets(model *semanticmodel.Model) []projectsignals.DataExploreDatasetSignal {
+	if model == nil {
+		return []projectsignals.DataExploreDatasetSignal{}
+	}
+	names := make([]string, 0, len(model.Tables))
+	for name := range model.Tables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]projectsignals.DataExploreDatasetSignal, 0, len(names))
+	for _, name := range names {
+		table := model.Tables[name]
+		fieldCount := len(table.Dimensions)
+		for _, measure := range model.Measures {
+			if !measure.Hidden && measure.Fact == name {
+				fieldCount++
+			}
+		}
+		out = append(out, projectsignals.DataExploreDatasetSignal{
+			ID: name, Title: explorerLabel(name), Description: projectsignals.Optional(table.Description),
+			Grain: projectsignals.Optional(table.Grain), FieldCount: int64(fieldCount),
+		})
+	}
+	return out
+}
+
+func explorerFields(model *semanticmodel.Model, baseTable string, command projectsignals.DataExploreCommand) []projectsignals.DataExploreFieldSignal {
+	if model == nil {
+		return []projectsignals.DataExploreFieldSignal{}
+	}
+	selectedDimensions := explorerStringSet(command.Dimensions)
+	selectedMeasures := explorerStringSet(command.Measures)
+	tableNames := make([]string, 0, len(model.Tables))
+	for name := range model.Tables {
+		tableNames = append(tableNames, name)
+	}
+	sort.Strings(tableNames)
+	out := make([]projectsignals.DataExploreFieldSignal, 0)
+	for _, tableName := range tableNames {
+		table := model.Tables[tableName]
+		fieldNames := make([]string, 0, len(table.Dimensions))
+		for name := range table.Dimensions {
+			fieldNames = append(fieldNames, name)
+		}
+		sort.Strings(fieldNames)
+		for _, fieldName := range fieldNames {
+			dimension := table.Dimensions[fieldName]
+			id := tableName + "." + fieldName
+			fieldType := firstExplorerNonEmpty(dimension.Type, table.Columns[fieldName].Type)
+			compatible, reason, path := explorerFieldCompatibility(model, baseTable, tableName)
+			out = append(out, projectsignals.DataExploreFieldSignal{
+				ID: id, Label: firstExplorerNonEmpty(dimension.Label, explorerLabel(fieldName)), Kind: "dimension", ModelTable: tableName,
+				Description: projectsignals.Optional(dimension.Description), Type: projectsignals.Optional(fieldType), Selected: selectedDimensions[id],
+				Compatible: compatible, CompatibilityReason: projectsignals.Optional(reason), RelationshipPath: projectsignals.OptionalSlice(path),
+			})
+		}
+	}
+	measureNames := make([]string, 0, len(model.Measures))
+	for name, measure := range model.Measures {
+		if !measure.Hidden {
+			measureNames = append(measureNames, name)
+		}
+	}
+	sort.Strings(measureNames)
+	for _, name := range measureNames {
+		measure := model.Measures[name]
+		compatible := strings.TrimSpace(baseTable) == "" || measure.Fact == baseTable
+		reason := ""
+		if !compatible {
+			reason = "Measure belongs to " + explorerLabel(measure.Fact) + " and cannot be combined safely with the selected fields."
+		}
+		out = append(out, projectsignals.DataExploreFieldSignal{
+			ID: name, Label: firstExplorerNonEmpty(measure.Label, explorerLabel(name)), Kind: "measure", ModelTable: measure.Fact,
+			Description: projectsignals.Optional(measure.Description), Fact: projectsignals.Optional(measure.Fact), Selected: selectedMeasures[name],
+			Compatible: compatible, CompatibilityReason: projectsignals.Optional(reason),
+		})
+	}
+	return out
+}
+
+func explorerFieldCompatibility(model *semanticmodel.Model, baseTable, table string) (bool, string, []string) {
+	baseTable = strings.TrimSpace(baseTable)
+	if baseTable == "" || baseTable == table {
+		return true, "", nil
+	}
+	// Relationships are intentionally treated as a small undirected graph for
+	// field presentation. Query planning remains the authority for whether a
+	// governed join is executable.
+	type step struct {
+		table string
+		path  []string
+	}
+	queue := []step{{table: baseTable}}
+	seen := map[string]struct{}{baseTable: {}}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, relationship := range model.Relationships {
+			from, fromField, fromOK := strings.Cut(relationship.From, ".")
+			to, toField, toOK := strings.Cut(relationship.To, ".")
+			if !fromOK || !toOK {
+				continue
+			}
+			next, edgeLabel := "", relationship.ID
+			switch current.table {
+			case from:
+				next = to
+			case to:
+				next = from
+			}
+			_ = fromField
+			_ = toField
+			if next == "" {
+				continue
+			}
+			path := append(append([]string(nil), current.path...), edgeLabel)
+			if next == table {
+				return true, "", path
+			}
+			if _, ok := seen[next]; ok {
+				continue
+			}
+			seen[next] = struct{}{}
+			queue = append(queue, step{table: next, path: path})
+		}
+	}
+	return false, "Field belongs to an unrelated table and cannot be combined safely with the selected fields.", nil
+}
+
+func explorerModelTableObject(asset projectview.DevelopAssetView, table semanticmodel.Table, columns []projectsignals.DataPreviewColumnSignal, modelID string) projectsignals.DataExplorerObjectSignal {
+	object := projectsignals.DataExplorerObjectSignal{
+		Key:           "model_table:" + asset.ID,
+		AssetID:       projectsignals.Optional(asset.ID),
+		ResourceID:    asset.ID,
+		Layer:         "model_table",
+		ModelID:       projectsignals.Optional(modelID),
+		Table:         projectsignals.Optional(firstExplorerNonEmpty(asset.Key, asset.ID)),
+		Title:         firstExplorerNonEmpty(asset.Title, asset.Key, asset.ID),
+		Description:   projectsignals.Optional(firstExplorerNonEmpty(asset.Description, table.Description)),
+		DetailHref:    projectsignals.Optional(explorerAssetDetailsHref(asset, "details")),
+		Grain:         projectsignals.Optional(table.Grain),
+		ColumnCount:   int64(len(columns)),
+		RowCountLabel: projectsignals.Pointer("Unknown"),
+		Columns:       projectsignals.OptionalSlice(columns),
+	}
+	return object
+}
+
+func explorerSourceColumns(source semanticmodel.Source) []projectsignals.DataPreviewColumnSignal {
+	names := make([]string, 0, len(source.Fields))
+	for name := range source.Fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	columns := make([]projectsignals.DataPreviewColumnSignal, 0, len(names))
+	for _, name := range names {
+		field := source.Fields[name]
+		columns = append(columns, projectsignals.DataPreviewColumnSignal{Key: name, Label: firstExplorerNonEmpty(field.Name, name), Type: projectsignals.Optional(field.Type), Description: projectsignals.Optional(field.Description)})
+	}
+	if len(columns) == 0 {
+		for _, column := range source.Schema.Columns {
+			columns = append(columns, projectsignals.DataPreviewColumnSignal{Key: column.Name, Label: column.Name, Type: projectsignals.Optional(column.PhysicalType), Description: projectsignals.Optional(column.Comment), Nullable: column.Nullable, DefaultValue: projectsignals.Optional(column.Default), PrimaryKey: projectsignals.Optional(column.PrimaryKey)})
+		}
+	}
+	return columns
+}
+
+func explorerTableColumns(table semanticmodel.Table) []projectsignals.DataPreviewColumnSignal {
+	if len(table.Schema.Columns) > 0 {
+		columns := make([]projectsignals.DataPreviewColumnSignal, 0, len(table.Schema.Columns))
+		for _, column := range table.Schema.Columns {
+			columns = append(columns, projectsignals.DataPreviewColumnSignal{Key: column.Name, Label: column.Name, Type: projectsignals.Optional(column.PhysicalType), Description: projectsignals.Optional(column.Comment), Nullable: column.Nullable, DefaultValue: projectsignals.Optional(column.Default), PrimaryKey: projectsignals.Optional(column.PrimaryKey)})
+		}
+		return columns
+	}
+	names := make([]string, 0, len(table.Columns))
+	for name := range table.Columns {
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		for name := range table.Dimensions {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	columns := make([]projectsignals.DataPreviewColumnSignal, 0, len(names))
+	for _, name := range names {
+		column := table.Columns[name]
+		if column.Name == "" {
+			column.Name = name
+		}
+		columns = append(columns, projectsignals.DataPreviewColumnSignal{Key: name, Label: firstExplorerNonEmpty(column.Name, name), Type: projectsignals.Optional(column.Type), Description: projectsignals.Optional(column.Description)})
+	}
+	return columns
+}
+
+func explorerTableByName(tables map[string]semanticmodel.Table, name string) semanticmodel.Table {
+	for key, table := range tables {
+		if key == name || strings.EqualFold(key, name) {
+			return table
+		}
+	}
+	return semanticmodel.Table{}
+}
+
+func explorerModelIDByName(assets map[string]projectview.DevelopAssetView, name string) string {
+	for id, asset := range assets {
+		if asset.Type == string(projectview.AssetTypeModelTable) && (asset.Key == name || strings.EqualFold(asset.Title, name)) {
+			return id
+		}
+	}
+	return ""
+}
+
+func sortedExplorerAssets(assets map[string]projectview.DevelopAssetView) []projectview.DevelopAssetView {
+	out := make([]projectview.DevelopAssetView, 0, len(assets))
+	for _, asset := range assets {
+		if asset.Type == string(projectview.AssetTypeSource) || asset.Type == string(projectview.AssetTypeModelTable) {
+			out = append(out, asset)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Type != out[j].Type {
+			return out[i].Type < out[j].Type
+		}
+		left := strings.ToLower(firstExplorerNonEmpty(out[i].Title, out[i].Key, out[i].ID))
+		right := strings.ToLower(firstExplorerNonEmpty(out[j].Title, out[j].Key, out[j].ID))
+		if left != right {
+			return left < right
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func sortExplorerObjects(objects []projectsignals.DataExplorerObjectSignal) {
+	sort.SliceStable(objects, func(i, j int) bool {
+		if objects[i].Layer != objects[j].Layer {
+			if objects[i].Layer == "source" {
+				return true
+			}
+			if objects[j].Layer == "source" {
+				return false
+			}
+			return objects[i].Layer < objects[j].Layer
+		}
+		left := strings.ToLower(firstExplorerNonEmpty(objects[i].Title, objects[i].Key))
+		right := strings.ToLower(firstExplorerNonEmpty(objects[j].Title, objects[j].Key))
+		if left != right {
+			return left < right
+		}
+		return objects[i].Key < objects[j].Key
+	})
+}
+
+func explorerAssetDetailsHref(asset projectview.DevelopAssetView, section string) string {
+	base := ""
+	switch asset.Type {
+	case string(projectview.AssetTypeSource):
+		base = "/sources/"
+	case string(projectview.AssetTypeModelTable):
+		base = "/models/"
+	default:
+		return ""
+	}
+	return base + url.PathEscape(asset.ID) + "/" + url.PathEscape(section)
+}
+
+func explorerStringSet(values []string) map[string]bool {
+	result := make(map[string]bool, len(values))
+	for _, value := range values {
+		result[value] = true
+	}
+	return result
+}
+
+func explorerLabel(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "_", " "))
+	if value == "" {
+		return "-"
+	}
+	return strings.ToUpper(value[:1]) + value[1:]
+}
+
+func firstExplorerNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/project/http/data_explorer_projection.go
+++ b/internal/project/http/data_explorer_projection.go
@@ -27,6 +27,8 @@ type DataExplorerProjection struct {
 	Datasets        []projectsignals.DataExploreDatasetSignal
 	SelectedDataset *projectsignals.DataExploreDatasetSignal
 	Fields          []projectsignals.DataExploreFieldSignal
+	Command         projectsignals.DataExploreCommand
+	Warnings        []string
 }
 
 // BuildDataExplorerProjection projects authorized serving assets together
@@ -142,12 +144,13 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 	if selectedModelIndex < 0 && len(models) > 0 {
 		selectedModelIndex = 0
 	}
-	result := DataExplorerProjection{Objects: objects, Models: models}
+	result := DataExplorerProjection{Objects: objects, Models: models, Command: command, Warnings: []string{}}
 	if selectedModelIndex < 0 {
 		return result
 	}
 	selectedModel := models[selectedModelIndex]
 	result.SelectedModel = &selectedModel
+	command.ModelID = projectsignals.Optional(selectedModel.ID)
 	result.Datasets = append([]projectsignals.DataExploreDatasetSignal(nil), selectedModel.Datasets...)
 	selectedDatasetID := strings.TrimSpace(projectsignals.ValueOrZero(command.DatasetID))
 	for index := range result.Datasets {
@@ -164,8 +167,24 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 	baseTable := ""
 	if result.SelectedDataset != nil {
 		baseTable = result.SelectedDataset.ID
+		command.DatasetID = projectsignals.Optional(baseTable)
 	}
-	result.Fields = explorerFields(modelByID[selectedModel.ID], baseTable, command)
+	model := modelByID[selectedModel.ID]
+	if resolvedBase, changed := resolveExplorerBase(model, baseTable, command); changed {
+		previousBase := baseTable
+		baseTable = resolvedBase
+		command.DatasetID = projectsignals.Optional(baseTable)
+		for index := range result.Datasets {
+			if result.Datasets[index].ID == baseTable {
+				selected := result.Datasets[index]
+				result.SelectedDataset = &selected
+				break
+			}
+		}
+		result.Warnings = append(result.Warnings, "Grain changed from "+explorerLabel(previousBase)+" to "+explorerLabel(baseTable)+" to support the selected fields.")
+	}
+	result.Command = command
+	result.Fields = explorerFields(model, baseTable, command)
 	return result
 }
 
@@ -219,10 +238,18 @@ func explorerFields(model *semanticmodel.Model, baseTable string, command projec
 			id := tableName + "." + fieldName
 			fieldType := firstExplorerNonEmpty(dimension.Type, table.Columns[fieldName].Type)
 			compatible, reason, path := explorerFieldCompatibility(model, baseTable, tableName)
+			rebaseDatasetID := ""
+			if !compatible {
+				rebaseDatasetID = explorerFieldRebase(model, command, baseTable, id, "dimension")
+				if rebaseDatasetID != "" {
+					reason = "Select " + firstExplorerNonEmpty(dimension.Label, explorerLabel(fieldName)) + " and change grain from " + explorerLabel(baseTable) + " to " + explorerLabel(rebaseDatasetID) + "."
+				}
+			}
 			out = append(out, projectsignals.DataExploreFieldSignal{
 				ID: id, Label: firstExplorerNonEmpty(dimension.Label, explorerLabel(fieldName)), Kind: "dimension", ModelTable: tableName,
 				Description: projectsignals.Optional(dimension.Description), Type: projectsignals.Optional(fieldType), Selected: selectedDimensions[id],
 				Compatible: compatible, CompatibilityReason: projectsignals.Optional(reason), RelationshipPath: projectsignals.OptionalSlice(path),
+				RebaseDatasetID: projectsignals.Optional(rebaseDatasetID),
 			})
 		}
 	}
@@ -237,13 +264,19 @@ func explorerFields(model *semanticmodel.Model, baseTable string, command projec
 		measure := model.Measures[name]
 		compatible := strings.TrimSpace(baseTable) == "" || measure.Fact == baseTable
 		reason := ""
+		rebaseDatasetID := ""
 		if !compatible {
-			reason = "Measure belongs to " + explorerLabel(measure.Fact) + " and cannot be combined safely with the selected fields."
+			rebaseDatasetID = explorerFieldRebase(model, command, baseTable, name, "measure")
+			if rebaseDatasetID != "" {
+				reason = "Select " + firstExplorerNonEmpty(measure.Label, explorerLabel(name)) + " and change grain from " + explorerLabel(baseTable) + " to " + explorerLabel(rebaseDatasetID) + "."
+			} else {
+				reason = "Measure belongs to " + explorerLabel(measure.Fact) + " and cannot be combined safely with the selected fields."
+			}
 		}
 		out = append(out, projectsignals.DataExploreFieldSignal{
 			ID: name, Label: firstExplorerNonEmpty(measure.Label, explorerLabel(name)), Kind: "measure", ModelTable: measure.Fact,
 			Description: projectsignals.Optional(measure.Description), Fact: projectsignals.Optional(measure.Fact), Selected: selectedMeasures[name],
-			Compatible: compatible, CompatibilityReason: projectsignals.Optional(reason),
+			Compatible: compatible, CompatibilityReason: projectsignals.Optional(reason), RebaseDatasetID: projectsignals.Optional(rebaseDatasetID),
 		})
 	}
 	return out
@@ -251,51 +284,134 @@ func explorerFields(model *semanticmodel.Model, baseTable string, command projec
 
 func explorerFieldCompatibility(model *semanticmodel.Model, baseTable, table string) (bool, string, []string) {
 	baseTable = strings.TrimSpace(baseTable)
-	if baseTable == "" || baseTable == table {
+	if model == nil || baseTable == "" || baseTable == table {
 		return true, "", nil
 	}
-	// Relationships are intentionally treated as a small undirected graph for
-	// field presentation. Query planning remains the authority for whether a
-	// governed join is executable.
-	type step struct {
-		table string
-		path  []string
+	path, err := model.SafeRelationshipPath(baseTable, table)
+	if err != nil {
+		return false, "Not available from " + explorerLabel(baseTable) + " because no grain-preserving relationship path reaches " + explorerLabel(table) + ".", nil
 	}
-	queue := []step{{table: baseTable}}
-	seen := map[string]struct{}{baseTable: {}}
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-		for _, relationship := range model.Relationships {
-			from, fromField, fromOK := strings.Cut(relationship.From, ".")
-			to, toField, toOK := strings.Cut(relationship.To, ".")
-			if !fromOK || !toOK {
-				continue
-			}
-			next, edgeLabel := "", relationship.ID
-			switch current.table {
-			case from:
-				next = to
-			case to:
-				next = from
-			}
-			_ = fromField
-			_ = toField
-			if next == "" {
-				continue
-			}
-			path := append(append([]string(nil), current.path...), edgeLabel)
-			if next == table {
-				return true, "", path
-			}
-			if _, ok := seen[next]; ok {
-				continue
-			}
-			seen[next] = struct{}{}
-			queue = append(queue, step{table: next, path: path})
+	ids := make([]string, 0, len(path))
+	for _, relationship := range path {
+		ids = append(ids, relationship.ID)
+	}
+	return true, "", ids
+}
+
+func resolveExplorerBase(model *semanticmodel.Model, currentBase string, command projectsignals.DataExploreCommand) (string, bool) {
+	currentBase = strings.TrimSpace(currentBase)
+	if model == nil {
+		return currentBase, false
+	}
+	targets, measureFacts := explorerCommandTargets(model, command)
+	if explorerBaseScore(model, currentBase, targets, measureFacts) >= 0 {
+		return currentBase, false
+	}
+	bestBase, bestScore, tied := "", -1, false
+	for candidate := range model.Tables {
+		score := explorerBaseScore(model, candidate, targets, measureFacts)
+		if score < 0 {
+			continue
+		}
+		switch {
+		case bestScore < 0 || score < bestScore:
+			bestBase, bestScore, tied = candidate, score, false
+		case score == bestScore:
+			tied = true
 		}
 	}
-	return false, "Field belongs to an unrelated table and cannot be combined safely with the selected fields.", nil
+	if bestBase == "" || tied || bestBase == currentBase {
+		return currentBase, false
+	}
+	return bestBase, true
+}
+
+func explorerCommandTargets(model *semanticmodel.Model, command projectsignals.DataExploreCommand) ([]string, []string) {
+	if model == nil {
+		return nil, nil
+	}
+	targetSet := map[string]bool{}
+	measureSet := map[string]bool{}
+	addDimension := func(id string) {
+		if dimension, err := model.ResolveDimension(strings.TrimSpace(id)); err == nil {
+			targetSet[dimension.Table] = true
+		}
+	}
+	for _, id := range command.Dimensions {
+		addDimension(id)
+	}
+	for _, filter := range command.Filters {
+		addDimension(filter.Field)
+	}
+	if command.Time != nil {
+		addDimension(command.Time.Field)
+	}
+	for _, id := range command.Measures {
+		if measure, err := model.ResolveMeasure(strings.TrimSpace(id)); err == nil && !measure.Hidden {
+			measureSet[measure.Fact] = true
+		}
+	}
+	targets := make([]string, 0, len(targetSet))
+	for table := range targetSet {
+		targets = append(targets, table)
+	}
+	measureFacts := make([]string, 0, len(measureSet))
+	for fact := range measureSet {
+		measureFacts = append(measureFacts, fact)
+	}
+	sort.Strings(targets)
+	sort.Strings(measureFacts)
+	return targets, measureFacts
+}
+
+func explorerBaseScore(model *semanticmodel.Model, candidate string, targets, measureFacts []string) int {
+	if model == nil {
+		return -1
+	}
+	if _, ok := model.Tables[candidate]; !ok {
+		return -1
+	}
+	for _, fact := range measureFacts {
+		if fact != candidate {
+			return -1
+		}
+	}
+	score := 0
+	for _, target := range targets {
+		if target == candidate {
+			continue
+		}
+		path, err := model.SafeRelationshipPath(candidate, target)
+		if err != nil {
+			return -1
+		}
+		score += len(path)
+	}
+	return score
+}
+
+func explorerFieldRebase(model *semanticmodel.Model, command projectsignals.DataExploreCommand, currentBase, fieldID, kind string) string {
+	hypothetical := command
+	if kind == "measure" {
+		hypothetical.Measures = appendUniqueExplorerValue(hypothetical.Measures, fieldID)
+	} else {
+		hypothetical.Dimensions = appendUniqueExplorerValue(hypothetical.Dimensions, fieldID)
+	}
+	base, changed := resolveExplorerBase(model, currentBase, hypothetical)
+	if !changed {
+		return ""
+	}
+	return base
+}
+
+func appendUniqueExplorerValue(values []string, value string) []string {
+	out := append([]string(nil), values...)
+	for _, current := range out {
+		if current == value {
+			return out
+		}
+	}
+	return append(out, value)
 }
 
 func explorerModelTableObject(asset projectview.DevelopAssetView, table semanticmodel.Table, columns []projectsignals.DataPreviewColumnSignal, modelID string) projectsignals.DataExplorerObjectSignal {

--- a/internal/project/http/data_explorer_projection_test.go
+++ b/internal/project/http/data_explorer_projection_test.go
@@ -114,6 +114,73 @@ func TestBuildDataExplorerProjectionCommandSelectsModelDatasetAndFields(t *testi
 	}
 }
 
+func TestBuildDataExplorerProjectionInfersSafeBaseForCrossTableFields(t *testing.T) {
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"customer_id": {Field: "orders.customer_id", Table: "orders"},
+					"status":      {Field: "orders.status", Table: "orders"},
+				},
+			},
+			"customers": {
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"customer_id": {Field: "customers.customer_id", Table: "customers"},
+					"region":      {Field: "customers.region", Table: "customers"},
+				},
+			},
+		},
+		Relationships: []semanticmodel.Relationship{{
+			ID: "orders_customers", From: "orders.customer_id", To: "customers.customer_id", Cardinality: "many_to_one",
+		}},
+	}
+	project := projectmanifest.Project{
+		Models: map[string]semanticmodel.Table{
+			"model:orders": model.Tables["orders"], "model:customers": model.Tables["customers"],
+		},
+		SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": model},
+		NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders", "customers": "model:customers"}},
+	}
+	command := projectsignals.DataExploreCommand{
+		ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("customers"),
+		Dimensions: []string{"customers.region", "orders.status"},
+	}
+	assets := []projectview.DevelopAssetView{
+		{ID: "model:orders", Type: string(projectview.AssetTypeModelTable), Key: "orders", Title: "Orders"},
+		{ID: "model:customers", Type: string(projectview.AssetTypeModelTable), Key: "customers", Title: "Customers"},
+		{ID: "semantic:sales", Type: string(projectview.AssetTypeSemanticModel), Key: "sales", Title: "Sales"},
+	}
+	customersProjection := BuildDataExplorerProjection(assets, project, projectsignals.DataExploreCommand{
+		ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("customers"),
+		Dimensions: []string{"customers.region"},
+	})
+	foundOrdersStatus := false
+	for _, field := range customersProjection.Fields {
+		if field.ID == "orders.status" {
+			foundOrdersStatus = true
+			if field.Compatible || projectsignals.ValueOrZero(field.RebaseDatasetID) != "orders" {
+				t.Fatalf("orders status = %#v, want unsafe reverse field that can rebase to orders", field)
+			}
+		}
+	}
+	if !foundOrdersStatus {
+		t.Fatal("orders status field was not projected")
+	}
+
+	projection := BuildDataExplorerProjection(assets, project, command)
+
+	if projection.SelectedDataset == nil || projection.SelectedDataset.ID != "orders" {
+		t.Fatalf("selected dataset = %#v, want safely inferred orders base", projection.SelectedDataset)
+	}
+	if projectsignals.ValueOrZero(projection.Command.DatasetID) != "orders" {
+		t.Fatalf("resolved command = %#v, want orders base", projection.Command)
+	}
+	if len(projection.Warnings) != 1 || projection.Warnings[0] != "Grain changed from Customers to Orders to support the selected fields." {
+		t.Fatalf("warnings = %#v", projection.Warnings)
+	}
+}
+
 func TestBuildDataExplorerProjectionDoesNotUseGraphPayloadAsSchema(t *testing.T) {
 	project := projectmanifest.Project{
 		Models:         map[string]semanticmodel.Table{"model:orders": {Columns: map[string]semanticmodel.ModelColumn{"id": {Type: "integer"}}}},

--- a/internal/project/http/data_explorer_projection_test.go
+++ b/internal/project/http/data_explorer_projection_test.go
@@ -1,0 +1,130 @@
+package http
+
+import (
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	projectview "github.com/flidai/leapview/internal/project"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
+)
+
+func TestBuildDataExplorerProjectionUsesAuthorizedAssetsAndRichManifest(t *testing.T) {
+	model := &semanticmodel.Model{
+		Name:  "sales",
+		Title: "Sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				PrimaryKey: "order_id", Grain: "order_id", Description: "Orders table",
+				Columns: map[string]semanticmodel.ModelColumn{
+					"order_id": {Name: "order_id", Type: "integer"},
+					"status":   {Name: "status", Type: "string", Description: "Order status"},
+				},
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"status": {Label: "Status", Type: "string", Description: "Order status"},
+				},
+			},
+		},
+		Measures: map[string]semanticmodel.MetricMeasure{
+			"order_count": {Fact: "orders", Label: "Orders", Aggregation: "count"},
+		},
+	}
+	project := projectmanifest.Project{
+		Sources: map[string]semanticmodel.Source{
+			"source:orders": {Description: "Orders source", Fields: map[string]semanticmodel.SourceField{"id": {Name: "id", Type: "integer"}}},
+		},
+		Models: map[string]semanticmodel.Table{
+			"model:orders": model.Tables["orders"],
+		},
+		SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": model},
+		NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders"}},
+	}
+	assets := []projectview.DevelopAssetView{
+		{ID: "source:orders", Type: string(projectview.AssetTypeSource), Key: "orders", Title: "Orders source"},
+		{ID: "model:orders", Type: string(projectview.AssetTypeModelTable), Key: "orders", Title: "Orders"},
+		{ID: "semantic:sales", Type: string(projectview.AssetTypeSemanticModel), Key: "sales", Title: "Sales"},
+	}
+	projection := BuildDataExplorerProjection(assets, project, projectsignals.DataExploreCommand{})
+	if len(projection.Models) != 1 || projection.Models[0].ID != "semantic:sales" {
+		t.Fatalf("models = %#v, want only authorized semantic model", projection.Models)
+	}
+	if projection.SelectedModel == nil || projection.SelectedModel.ID != "semantic:sales" {
+		t.Fatalf("selected model = %#v, want semantic:sales", projection.SelectedModel)
+	}
+	if len(projection.Datasets) != 1 || projection.Datasets[0].ID != "orders" {
+		t.Fatalf("datasets = %#v, want orders", projection.Datasets)
+	}
+	if len(projection.Objects) != 2 {
+		t.Fatalf("objects = %#v, want source and authorized model", projection.Objects)
+	}
+	var modelObject projectsignals.DataExplorerObjectSignal
+	for _, object := range projection.Objects {
+		if object.Layer == "model_table" {
+			modelObject = object
+		}
+	}
+	if modelObject.Key != "model_table:model:orders" || modelObject.ModelID == nil || *modelObject.ModelID != "semantic:sales" {
+		t.Fatalf("model object = %#v, want canonical object and semantic model context", modelObject)
+	}
+	if modelObject.ColumnCount != 2 || modelObject.Columns == nil || len(*modelObject.Columns) != 2 {
+		t.Fatalf("model object columns = %#v, want rich table columns", modelObject)
+	}
+	if len(projection.Fields) != 2 || projection.Fields[0].ID != "orders.status" || projection.Fields[1].ID != "order_count" {
+		t.Fatalf("fields = %#v, want dimension and measure", projection.Fields)
+	}
+}
+
+func TestBuildDataExplorerProjectionCommandSelectsModelDatasetAndFields(t *testing.T) {
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders":    {Dimensions: map[string]semanticmodel.MetricDimension{"status": {Label: "Status"}}},
+			"customers": {Dimensions: map[string]semanticmodel.MetricDimension{"region": {Label: "Region"}}},
+		},
+		Measures: map[string]semanticmodel.MetricMeasure{"revenue": {Fact: "orders", Label: "Revenue"}},
+	}
+	project := projectmanifest.Project{
+		Models:         map[string]semanticmodel.Table{"model:orders": model.Tables["orders"], "model:customers": model.Tables["customers"]},
+		SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": model},
+		NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders", "customers": "model:customers"}},
+	}
+	command := projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("customers"), Dimensions: []string{"customers.region"}, Measures: []string{"revenue"}}
+	projection := BuildDataExplorerProjection([]projectview.DevelopAssetView{
+		{ID: "model:orders", Type: string(projectview.AssetTypeModelTable), Key: "orders", Title: "Orders"},
+		{ID: "model:customers", Type: string(projectview.AssetTypeModelTable), Key: "customers", Title: "Customers"},
+		{ID: "semantic:sales", Type: string(projectview.AssetTypeSemanticModel), Key: "sales", Title: "Sales"},
+	}, project, command)
+	if projection.SelectedDataset == nil || projection.SelectedDataset.ID != "customers" {
+		t.Fatalf("selected dataset = %#v, want customers", projection.SelectedDataset)
+	}
+	if len(projection.Fields) != 3 {
+		t.Fatalf("fields = %#v, want two dimensions and one measure", projection.Fields)
+	}
+	for _, field := range projection.Fields {
+		switch field.ID {
+		case "customers.region":
+			if !field.Selected || !field.Compatible {
+				t.Fatalf("selected field = %#v, want selected and compatible", field)
+			}
+		case "revenue":
+			if !field.Selected || field.Compatible {
+				t.Fatalf("cross-table measure = %#v, want selected and incompatible", field)
+			}
+		}
+	}
+}
+
+func TestBuildDataExplorerProjectionDoesNotUseGraphPayloadAsSchema(t *testing.T) {
+	project := projectmanifest.Project{
+		Models:         map[string]semanticmodel.Table{"model:orders": {Columns: map[string]semanticmodel.ModelColumn{"id": {Type: "integer"}}}},
+		SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": {Name: "sales", Tables: map[string]semanticmodel.Table{"orders": {Columns: map[string]semanticmodel.ModelColumn{"id": {Type: "integer"}}}}}},
+		NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders"}},
+	}
+	projection := BuildDataExplorerProjection([]projectview.DevelopAssetView{
+		{ID: "model:orders", Type: string(projectview.AssetTypeModelTable), Key: "orders", Title: "Orders", Payload: map[string]any{"kind": "model"}},
+		{ID: "semantic:sales", Type: string(projectview.AssetTypeSemanticModel), Key: "sales", Title: "Sales", Payload: map[string]any{"kind": "semantic_model"}},
+	}, project, projectsignals.DataExploreCommand{})
+	if len(projection.Objects) != 1 || projection.Objects[0].ColumnCount != 1 {
+		t.Fatalf("objects = %#v, want one manifest-backed object", projection.Objects)
+	}
+}

--- a/internal/project/model_table_read_model.go
+++ b/internal/project/model_table_read_model.go
@@ -1,0 +1,92 @@
+package project
+
+import (
+	"encoding/json"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+)
+
+// ModelTableAssetReadModel is the typed detail projection for a compiled
+// model table. The serving graph deliberately carries only portable resource
+// metadata; model-table definitions remain in the active compiled manifest.
+// Keeping this projection at the read-model boundary prevents the UI from
+// treating a graph resource as if it were the compiled table definition.
+type ModelTableAssetReadModel struct {
+	Source             string                                   `json:"Source,omitempty"`
+	Sources            []string                                 `json:"Sources,omitempty"`
+	SourceReads        map[string][]string                      `json:"SourceReads,omitempty"`
+	SQL                string                                   `json:"SQL,omitempty"`
+	Transform          semanticmodel.Transform                  `json:"Transform,omitempty"`
+	Columns            map[string]semanticmodel.ModelColumn     `json:"Columns,omitempty"`
+	PrimaryKey         string                                   `json:"PrimaryKey,omitempty"`
+	Grain              string                                   `json:"Grain,omitempty"`
+	Dimensions         map[string]semanticmodel.MetricDimension `json:"Dimensions,omitempty"`
+	Description        string                                   `json:"Description,omitempty"`
+	Schema             semanticmodel.TableSchema                `json:"Schema,omitempty"`
+	SourceDependencies []string                                 `json:"SourceDependencies,omitempty"`
+	ModelDependencies  []string                                 `json:"ModelDependencies,omitempty"`
+}
+
+// ModelTableAssetPayload converts the validated compiled table into the
+// dynamic transport map consumed by the existing project UI signals. The
+// conversion is deliberately at this boundary: the table remains strongly
+// typed until it is encoded for the browser-facing read model.
+func ModelTableAssetPayload(table semanticmodel.Table) map[string]any {
+	projection := ModelTableAssetReadModel{
+		Source:             table.Source,
+		Sources:            append([]string(nil), table.Sources...),
+		SourceReads:        cloneStringSliceMap(table.SourceReads),
+		SQL:                table.SQL,
+		Transform:          table.Transform,
+		Columns:            cloneModelColumns(table.Columns),
+		PrimaryKey:         table.PrimaryKey,
+		Grain:              table.Grain,
+		Dimensions:         cloneMetricDimensions(table.Dimensions),
+		Description:        table.Description,
+		Schema:             table.Schema,
+		SourceDependencies: append([]string(nil), table.SourceDependencies...),
+		ModelDependencies:  append([]string(nil), table.ModelDependencies...),
+	}
+	encoded, err := json.Marshal(projection)
+	if err != nil {
+		return nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		return nil
+	}
+	return payload
+}
+
+func cloneStringSliceMap(input map[string][]string) map[string][]string {
+	if input == nil {
+		return nil
+	}
+	output := make(map[string][]string, len(input))
+	for key, values := range input {
+		output[key] = append([]string(nil), values...)
+	}
+	return output
+}
+
+func cloneModelColumns(input map[string]semanticmodel.ModelColumn) map[string]semanticmodel.ModelColumn {
+	if input == nil {
+		return nil
+	}
+	output := make(map[string]semanticmodel.ModelColumn, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}
+
+func cloneMetricDimensions(input map[string]semanticmodel.MetricDimension) map[string]semanticmodel.MetricDimension {
+	if input == nil {
+		return nil
+	}
+	output := make(map[string]semanticmodel.MetricDimension, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}

--- a/internal/project/model_table_read_model_test.go
+++ b/internal/project/model_table_read_model_test.go
@@ -1,0 +1,78 @@
+package project
+
+import (
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+)
+
+func TestModelTableAssetPayloadProjectsCompiledDefinition(t *testing.T) {
+	table := semanticmodel.Table{
+		Source:             "olist.geolocation",
+		Sources:            []string{"olist.geolocation"},
+		SQL:                "SELECT * FROM source.\"olist.geolocation\"",
+		Transform:          semanticmodel.Transform{SQL: "SELECT * FROM source.\"olist.geolocation\""},
+		Columns:            map[string]semanticmodel.ModelColumn{"zip_prefix": {Type: "string", SourceField: "geolocation_zip_code_prefix"}},
+		PrimaryKey:         "zip_prefix",
+		Grain:              "zip_prefix",
+		Dimensions:         map[string]semanticmodel.MetricDimension{"zip_prefix": {Label: "ZIP prefix", Type: "string"}},
+		Schema:             semanticmodel.TableSchema{Columns: []semanticmodel.ColumnSchema{{Name: "zip_prefix", Ordinal: 0, PhysicalType: "VARCHAR"}}},
+		SourceDependencies: []string{"olist.geolocation"},
+		ModelDependencies:  []string{"model:upstream"},
+	}
+
+	payload := ModelTableAssetPayload(table)
+	if payload["Source"] != "olist.geolocation" || payload["PrimaryKey"] != "zip_prefix" || payload["Grain"] != "zip_prefix" {
+		t.Fatalf("payload metadata = %#v", payload)
+	}
+	if payload["SQL"] != table.SQL {
+		t.Fatalf("payload SQL = %#v, want %q", payload["SQL"], table.SQL)
+	}
+	transform, ok := payload["Transform"].(map[string]any)
+	if !ok || transform["SQL"] != table.Transform.SQL {
+		t.Fatalf("payload transform = %#v, want SQL %q", payload["Transform"], table.Transform.SQL)
+	}
+	if got, ok := payload["SourceDependencies"].([]any); !ok || len(got) != 1 || got[0] != "olist.geolocation" {
+		t.Fatalf("payload source dependencies = %#v", payload["SourceDependencies"])
+	}
+	if got, ok := payload["ModelDependencies"].([]any); !ok || len(got) != 1 || got[0] != "model:upstream" {
+		t.Fatalf("payload model dependencies = %#v", payload["ModelDependencies"])
+	}
+	if fields, ok := payload["Dimensions"].(map[string]any); !ok || fields["zip_prefix"] == nil {
+		t.Fatalf("payload dimensions = %#v", payload["Dimensions"])
+	}
+	if columns, ok := payload["Columns"].(map[string]any); !ok || columns["zip_prefix"] == nil {
+		t.Fatalf("payload columns = %#v", payload["Columns"])
+	}
+	schema, ok := payload["Schema"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload schema = %#v", payload["Schema"])
+	}
+	if columns, ok := schema["columns"].([]any); !ok || len(columns) != 1 {
+		t.Fatalf("payload schema columns = %#v", schema["columns"])
+	}
+}
+
+func TestModelTableAssetPayloadDoesNotAliasCompiledMaps(t *testing.T) {
+	table := semanticmodel.Table{
+		SourceReads: map[string][]string{"olist.geolocation": {"zip_prefix"}},
+		Columns:     map[string]semanticmodel.ModelColumn{"zip_prefix": {Type: "string"}},
+		Dimensions:  map[string]semanticmodel.MetricDimension{"zip_prefix": {Label: "ZIP prefix"}},
+	}
+	payload := ModelTableAssetPayload(table)
+	if payload == nil {
+		t.Fatal("payload is nil")
+	}
+	table.SourceReads["olist.geolocation"][0] = "changed"
+	table.Columns["zip_prefix"] = semanticmodel.ModelColumn{Type: "integer"}
+	table.Dimensions["zip_prefix"] = semanticmodel.MetricDimension{Label: "changed"}
+	if got := payload["SourceReads"].(map[string]any)["olist.geolocation"].([]any)[0]; got != "zip_prefix" {
+		t.Fatalf("payload source reads changed with source table: %#v", got)
+	}
+	if got := payload["Columns"].(map[string]any)["zip_prefix"].(map[string]any)["Type"]; got != "string" {
+		t.Fatalf("payload columns changed with source table: %#v", got)
+	}
+	if got := payload["Dimensions"].(map[string]any)["zip_prefix"].(map[string]any)["Label"]; got != "ZIP prefix" {
+		t.Fatalf("payload dimensions changed with source table: %#v", got)
+	}
+}

--- a/internal/project/module/active_definition.go
+++ b/internal/project/module/active_definition.go
@@ -1,0 +1,50 @@
+package module
+
+import (
+	"context"
+	"errors"
+
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectruntime "github.com/flidai/leapview/internal/project/runtime"
+)
+
+var errActiveProjectDefinitionUnavailable = errors.New("active project definition is unavailable")
+
+// ProjectDefinitionReader exposes the complete compiled definition retained
+// by the exact active serving generation. Consumers use this module-owned port
+// instead of depending on project runtime or manifest implementation packages.
+type ProjectDefinitionReader interface {
+	ProjectDefinition(context.Context) (projectmanifest.Project, error)
+}
+
+type activeProjectDefinitionReader struct {
+	provider projectruntime.Provider
+}
+
+// NewActiveProjectDefinitionReader creates a lease-pinned reader for browser
+// projections that require more than the portable serving graph metadata.
+func NewActiveProjectDefinitionReader(provider projectruntime.Provider) ProjectDefinitionReader {
+	return activeProjectDefinitionReader{provider: provider}
+}
+
+func (r activeProjectDefinitionReader) ProjectDefinition(ctx context.Context) (projectmanifest.Project, error) {
+	if r.provider == nil {
+		return projectmanifest.Project{}, errActiveProjectDefinitionUnavailable
+	}
+	lease, err := r.provider.Acquire(ctx)
+	if err != nil {
+		return projectmanifest.Project{}, err
+	}
+	defer lease.Release()
+	port, ok := lease.Runtime().(interface {
+		ProjectManifest() projectmanifest.Project
+	})
+	if !ok {
+		return projectmanifest.Project{}, errActiveProjectDefinitionUnavailable
+	}
+	definition := port.ProjectManifest()
+	if definition.ID == "" {
+		return projectmanifest.Project{}, errActiveProjectDefinitionUnavailable
+	}
+	return definition, nil
+}

--- a/internal/project/module/active_definition_test.go
+++ b/internal/project/module/active_definition_test.go
@@ -1,0 +1,54 @@
+package module
+
+import (
+	"context"
+	"testing"
+
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectruntime "github.com/flidai/leapview/internal/project/runtime"
+)
+
+type projectDefinitionRuntimeStub struct {
+	definition projectmanifest.Project
+}
+
+func (r projectDefinitionRuntimeStub) Close() error { return nil }
+func (r projectDefinitionRuntimeStub) ProjectManifest() projectmanifest.Project {
+	return r.definition
+}
+
+type projectDefinitionProviderStub struct {
+	lease *projectDefinitionLeaseStub
+}
+
+func (p *projectDefinitionProviderStub) Acquire(context.Context) (projectruntime.Lease, error) {
+	p.lease = &projectDefinitionLeaseStub{runtime: projectDefinitionRuntimeStub{definition: projectmanifest.Project{ID: "project:demo", Title: "Demo"}}}
+	return p.lease, nil
+}
+
+type projectDefinitionLeaseStub struct {
+	runtime  projectruntime.Runtime
+	released bool
+}
+
+func (l *projectDefinitionLeaseStub) Runtime() projectruntime.Runtime { return l.runtime }
+func (l *projectDefinitionLeaseStub) Identity() projectgraph.ServingIdentity {
+	return projectgraph.ServingIdentity{}
+}
+func (l *projectDefinitionLeaseStub) Release() { l.released = true }
+
+func TestActiveProjectDefinitionReaderPinsAndReleasesRuntime(t *testing.T) {
+	provider := &projectDefinitionProviderStub{}
+	reader := NewActiveProjectDefinitionReader(provider)
+	definition, err := reader.ProjectDefinition(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if definition.ID != "project:demo" || definition.Title != "Demo" {
+		t.Fatalf("definition = %#v", definition)
+	}
+	if provider.lease == nil || !provider.lease.released {
+		t.Fatal("active runtime lease was not released")
+	}
+}

--- a/internal/project/resource_read_models.go
+++ b/internal/project/resource_read_models.go
@@ -1,0 +1,103 @@
+package project
+
+import (
+	"encoding/json"
+	"strings"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	refreshschedule "github.com/flidai/leapview/internal/refresh/schedule"
+)
+
+// SourceAssetReadModel is the credential-free source definition used by the
+// project browser. Source payloads persisted in the serving graph contain
+// only graph metadata; this projection keeps the authored source shape at the
+// runtime read boundary without exposing secrets.
+type SourceAssetReadModel struct {
+	Format      string                               `json:"Format,omitempty"`
+	Description string                               `json:"Description,omitempty"`
+	Path        string                               `json:"Path,omitempty"`
+	Connection  string                               `json:"Connection,omitempty"`
+	Object      string                               `json:"Object,omitempty"`
+	Options     map[string]any                       `json:"Options,omitempty"`
+	Fields      map[string]semanticmodel.SourceField `json:"Fields,omitempty"`
+	Schema      semanticmodel.TableSchema            `json:"Schema,omitempty"`
+}
+
+// ConnectionAssetReadModel is the non-secret connection definition used by
+// the project browser. Credentials are reduced to a boolean configured state;
+// provider names, secret paths, and resolved auth values never cross this
+// boundary.
+type ConnectionAssetReadModel struct {
+	Kind                  string                           `json:"Kind,omitempty"`
+	Description           string                           `json:"Description,omitempty"`
+	Path                  string                           `json:"Path,omitempty"`
+	Root                  string                           `json:"Root,omitempty"`
+	Scope                 string                           `json:"Scope,omitempty"`
+	Options               map[string]any                   `json:"Options,omitempty"`
+	Defaults              semanticmodel.ConnectionDefaults `json:"Defaults,omitempty"`
+	CredentialsConfigured bool                             `json:"credentials_configured"`
+	CredentialsRequired   bool                             `json:"credentials_required"`
+}
+
+// RefreshPipelineScheduleReadModel carries the public schedule fields needed
+// by the pipeline list/detail surfaces. The schedule's parsed cron internals
+// are intentionally not serialized.
+type RefreshPipelineScheduleReadModel struct {
+	Cron     string `json:"Cron,omitempty"`
+	Timezone string `json:"Timezone,omitempty"`
+}
+
+// RefreshPipelineAssetReadModel is the public refresh-pipeline projection.
+type RefreshPipelineAssetReadModel struct {
+	ID              string                             `json:"ID,omitempty"`
+	Name            string                             `json:"Name,omitempty"`
+	SemanticModel   string                             `json:"SemanticModel,omitempty"`
+	SemanticModelID string                             `json:"SemanticModelID,omitempty"`
+	Schedules       []RefreshPipelineScheduleReadModel `json:"Schedules,omitempty"`
+}
+
+func SourceAssetPayload(source semanticmodel.Source) map[string]any {
+	return encodeAssetReadModel(SourceAssetReadModel{
+		Format: source.Format, Description: source.Description, Path: source.Path,
+		Connection: source.Connection, Object: source.Object, Options: source.Options,
+		Fields: source.Fields, Schema: source.Schema,
+	})
+}
+
+func ConnectionAssetPayload(connection semanticmodel.Connection) map[string]any {
+	return encodeAssetReadModel(ConnectionAssetReadModel{
+		Kind: connection.Kind, Description: connection.Description, Path: connection.Path,
+		Root: connection.Root, Scope: connection.Scope, Options: connection.Options,
+		Defaults:              connection.Defaults,
+		CredentialsConfigured: semanticmodel.ConnectionCredentialsConfigured(connection),
+		// An omitted provider is intentionally treated as requiring runtime
+		// configuration. Only an explicit `none` provider proves that the
+		// connection is anonymous; this avoids presenting an unresolved target
+		// binding as healthy on the browser list.
+		CredentialsRequired: strings.TrimSpace(connection.Credentials.Provider) != "none",
+	})
+}
+
+func RefreshPipelineAssetPayload(pipeline refreshschedule.Definition) map[string]any {
+	schedules := make([]RefreshPipelineScheduleReadModel, 0, len(pipeline.Schedules))
+	for _, schedule := range pipeline.Schedules {
+		schedules = append(schedules, RefreshPipelineScheduleReadModel{Cron: schedule.Expression, Timezone: schedule.Timezone})
+	}
+	return encodeAssetReadModel(RefreshPipelineAssetReadModel{
+		ID: pipeline.ID.String(), Name: pipeline.Name,
+		SemanticModel: pipeline.SemanticModelID.String(), SemanticModelID: pipeline.SemanticModelID.String(),
+		Schedules: schedules,
+	})
+}
+
+func encodeAssetReadModel(value any) map[string]any {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		return nil
+	}
+	return payload
+}

--- a/internal/project/resource_read_models_test.go
+++ b/internal/project/resource_read_models_test.go
@@ -1,0 +1,80 @@
+package project
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	refreshschedule "github.com/flidai/leapview/internal/refresh/schedule"
+)
+
+func TestSourceAssetPayloadProjectsSchemaAndFields(t *testing.T) {
+	source := semanticmodel.Source{
+		Format: "csv", Connection: "warehouse", Path: "s3://bucket/orders.csv",
+		Fields:  map[string]semanticmodel.SourceField{"order_id": {Type: "int", Description: "Order ID"}},
+		Schema:  semanticmodel.TableSchema{Columns: []semanticmodel.ColumnSchema{{Name: "order_id", Ordinal: 0, PhysicalType: "BIGINT"}}},
+		Options: map[string]any{"header": true},
+	}
+	payload := SourceAssetPayload(source)
+	if payload["Format"] != "csv" || payload["Connection"] != "warehouse" || payload["Path"] != "s3://bucket/orders.csv" {
+		t.Fatalf("source payload = %#v", payload)
+	}
+	fields, ok := payload["Fields"].(map[string]any)
+	if !ok || fields["order_id"] == nil {
+		t.Fatalf("source fields = %#v, want order_id", payload["Fields"])
+	}
+	schema, ok := payload["Schema"].(map[string]any)
+	if !ok || len(schema["columns"].([]any)) != 1 {
+		t.Fatalf("source schema = %#v, want one column", payload["Schema"])
+	}
+}
+
+func TestConnectionAssetPayloadOmitsCredentialMaterial(t *testing.T) {
+	connection := semanticmodel.Connection{
+		Kind: "postgres", Scope: "warehouse", Path: "db.example", Root: "orders",
+		Credentials: semanticmodel.ConnectionCredentials{Provider: "env", Secret: "PROD_PASSWORD", Region: "eu-west-1"},
+		Options:     map[string]any{"sslmode": "verify-full"},
+	}
+	payload := ConnectionAssetPayload(connection)
+	if payload["Kind"] != "postgres" || payload["Scope"] != "warehouse" || payload["credentials_configured"] != true {
+		t.Fatalf("connection payload = %#v", payload)
+	}
+	serialized := strings.ToLower(string(mustJSON(t, payload)))
+	for _, forbidden := range []string{"prod_password", "eu-west-1", "provider", "secret"} {
+		if strings.Contains(serialized, forbidden) {
+			t.Fatalf("connection payload contains credential material %q: %s", forbidden, serialized)
+		}
+	}
+}
+
+func TestRefreshPipelineAssetPayloadProjectsPublicSchedule(t *testing.T) {
+	pipeline := refreshschedule.Definition{
+		ID: "pipeline:sales", Name: "sales-refresh", SemanticModelID: projectgraph.ResourceID("semantic:sales"),
+		Schedules: []refreshschedule.Schedule{{Expression: "0 * * * *", Timezone: "Europe/Copenhagen"}},
+	}
+	payload := RefreshPipelineAssetPayload(pipeline)
+	if payload["SemanticModel"] != "semantic:sales" || payload["SemanticModelID"] != "semantic:sales" {
+		t.Fatalf("pipeline payload = %#v", payload)
+	}
+	schedules, ok := payload["Schedules"].([]any)
+	if !ok || len(schedules) != 1 {
+		t.Fatalf("pipeline schedules = %#v, want one schedule", payload["Schedules"])
+	}
+	entry := schedules[0].(map[string]any)
+	if entry["Cron"] != "0 * * * *" || entry["Timezone"] != "Europe/Copenhagen" {
+		t.Fatalf("pipeline schedule = %#v", entry)
+	}
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	// The helpers already perform a JSON round trip. Formatting through the
+	// same standard encoder keeps this test independent of map iteration order.
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encoded
+}

--- a/internal/project/ui/connection_admin.go
+++ b/internal/project/ui/connection_admin.go
@@ -77,6 +77,13 @@ func connectionLifecycleSignal(asset projectview.DevelopAssetView, assets []proj
 		Tone:              "neutral",
 	}
 	if !classified {
+		// A graph-only browser request has no binding administration snapshot.
+		// Anonymous connections are still valid when the compiled definition
+		// explicitly says credentials are not required; do not mislabel them as
+		// missing configuration merely because no binding row exists.
+		if _, hasRequired := asset.Payload["credentials_required"]; hasRequired && !metaBool(asset.Payload, "credentials_required") {
+			return lifecycle
+		}
 		lifecycle.State = "missing"
 		lifecycle.StatusLabel = "Not configured"
 		lifecycle.Tone = "warning"

--- a/internal/project/ui/connection_admin_test.go
+++ b/internal/project/ui/connection_admin_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	projectview "github.com/flidai/leapview/internal/project"
+)
+
+func TestConnectionLifecycleTreatsAnonymousConnectionAsNotRequired(t *testing.T) {
+	asset := projectview.DevelopAssetView{
+		ID: "connection:public", Type: string(projectview.AssetTypeConnection), Key: "public", Title: "Public files",
+		Payload: projectview.ConnectionAssetPayload(semanticmodel.Connection{Kind: "s3", Scope: "s3://public/", Credentials: semanticmodel.ConnectionCredentials{Provider: "none"}}),
+	}
+	lifecycle := ConnectionLifecycleForAsset(asset, []projectview.DevelopAssetView{asset}, nil, ConnectionAdministrationView{})
+	if lifecycle.State != "not_required" || lifecycle.StatusLabel != "Not required" {
+		t.Fatalf("anonymous lifecycle = %#v, want not required", lifecycle)
+	}
+}
+
+func TestConnectionLifecycleShowsMissingRequiredCredentials(t *testing.T) {
+	asset := projectview.DevelopAssetView{
+		ID: "connection:warehouse", Type: string(projectview.AssetTypeConnection), Key: "warehouse", Title: "Warehouse",
+		Payload: map[string]any{"Kind": "postgres", "Scope": "warehouse", "credentials_configured": false, "credentials_required": true},
+	}
+	lifecycle := ConnectionLifecycleForAsset(asset, []projectview.DevelopAssetView{asset}, nil, ConnectionAdministrationView{})
+	if lifecycle.State != "missing" || lifecycle.StatusLabel != "Not configured" {
+		t.Fatalf("required lifecycle = %#v, want missing/not configured", lifecycle)
+	}
+}

--- a/internal/project/ui/develop.go
+++ b/internal/project/ui/develop.go
@@ -2635,13 +2635,17 @@ func sourcesUsingConnection(connectionID string, assets []projectview.DevelopAss
 }
 
 func connectionFacts(asset projectview.DevelopAssetView) []definitionFact {
+	options := compactJSON(metaValue(asset.Payload, "Options", "options"))
+	if options == "" {
+		options = compactJSON(metaValue(asset.Payload, "Defaults", "defaults"))
+	}
 	return []definitionFact{
 		{Label: "Kind", Value: metaString(asset.Payload, "Kind", "kind")},
 		{Label: "Scope", Value: metaString(asset.Payload, "Scope", "scope")},
 		{Label: "Root", Value: metaString(asset.Payload, "Root", "root")},
 		{Label: "Path", Value: metaString(asset.Payload, "Path", "path")},
 		{Label: "Credentials", Value: boolLabel(metaBool(asset.Payload, "credentials_configured"))},
-		{Label: "Options", Value: compactJSON(metaValue(asset.Payload, "Options", "options"))},
+		{Label: "Options", Value: options},
 	}
 }
 

--- a/internal/project/ui/develop.go
+++ b/internal/project/ui/develop.go
@@ -361,7 +361,7 @@ func projectAssetPageSignalWithRefreshAndVersions(project projectview.DevelopVie
 		{ID: "details", Label: "Details", Href: assetnav.CanonicalAssetSectionHref(asset, "details"), Active: activeSection == "details"},
 	}
 	if assetDataInspectable(asset.Type) {
-		page.Tabs = append(page.Tabs, uisignals.ResourceTabSignal{ID: "data", Label: "Data", Href: projectAssetDataHref(project.ID, asset.ID), Active: activeSection == "data"})
+		page.Tabs = append(page.Tabs, uisignals.ResourceTabSignal{ID: "data", Label: "Data", Href: projectAssetDataHref(asset), Active: activeSection == "data"})
 	}
 	if assetRefreshable(asset.Type) {
 		page.Tabs = append(page.Tabs, uisignals.ResourceTabSignal{ID: "refreshes", Label: "Refreshes", Href: assetnav.CanonicalAssetSectionHref(asset, "refreshes"), Active: activeSection == "refreshes"})
@@ -499,6 +499,11 @@ func ProjectAssetPageWithRefreshAndVersionsForEnvironment(catalog catalog.Catalo
 	attrs := []g.Node{
 		g.Attr("slot", "page"),
 	}
+	if activeSection == "data" && assetDataInspectable(asset.Type) {
+		extras.CSRFToken = refresh.CSRFToken
+		commandPath := projectAssetDataHref(asset) + "/command"
+		attrs = append(attrs, g.Attr("data-on:lv-data-explorer-command", "$dataExplorerCommand = evt.detail; "+uiactions.EventPost(commandPath)))
+	}
 	if assetRefreshable(asset.Type) {
 		refreshPath := "/pipelines/" + url.PathEscape(asset.ID) + "/refresh"
 		extras.CSRFToken = refresh.CSRFToken
@@ -510,7 +515,7 @@ func ProjectAssetPageWithRefreshAndVersionsForEnvironment(catalog catalog.Catalo
 		}
 		return projectAssetRouteDocument(asset, catalog, area, roleLabel, page, uisignals.RouteKindData, g.El("lv-project-asset-page", attrs...), extras, activeSection, chromeOptions)
 	}
-	return projectAssetRouteDocument(asset, catalog, area, roleLabel, page, uisignals.RouteKindData, g.El("lv-project-asset-page", attrs...), projectDocumentExtras{}, activeSection, chromeOptions)
+	return projectAssetRouteDocument(asset, catalog, area, roleLabel, page, uisignals.RouteKindData, g.El("lv-project-asset-page", attrs...), extras, activeSection, chromeOptions)
 }
 
 func ProjectAssetBootstrapSignals(catalog catalog.Catalog, project projectview.DevelopView, asset projectview.DevelopAssetView, assets []projectview.DevelopAssetView, edges []projectview.DevelopEdgeView, activeSection, roleLabel string, refresh AssetRefreshState, versions AssetVersionsState, chromeOptions ...webpage.Provider) map[string]any {
@@ -575,6 +580,11 @@ func projectAssetRouteDocument(asset projectview.DevelopAssetView, catalog catal
 		extraHead = append(extraHead,
 			h.Link(h.Rel("stylesheet"), h.Href(projectStaticAssetURL(chromeOptions, "/static/semantic-model-graph.css"))),
 			h.Script(h.Type("module"), h.Src(projectStaticAssetURL(chromeOptions, "/static/semantic-model-graph.js"))),
+		)
+	}
+	if activeSection == "data" && assetDataInspectable(asset.Type) {
+		extraHead = append(extraHead,
+			h.Script(h.Type("module"), h.Src(projectStaticAssetURL(chromeOptions, "/static/data-explorer.js"))),
 		)
 	}
 	return projectRouteDocumentWithBodyExtras(asset.Title, catalog, active, roleLabel, page, routeKind, routeRoot, extras, bodyExtras, chromeOptions, extraHead...)
@@ -978,13 +988,11 @@ func assetRefreshable(assetType string) bool {
 }
 
 func assetDataInspectable(assetType string) bool {
-	return assetType == "semantic_model" || assetType == "model_table" || assetType == "source"
+	return assetType == "semantic_model" || assetType == "model_table"
 }
 
-func projectAssetDataHref(projectID, assetID string) string {
-	values := url.Values{}
-	values.Set("object", assetID)
-	return "/explore?" + values.Encode()
+func projectAssetDataHref(asset projectview.DevelopAssetView) string {
+	return assetnav.CanonicalAssetSectionHref(asset, "data")
 }
 
 func normalizeProjectAssetSection(section string) string {

--- a/internal/project/ui/develop_test.go
+++ b/internal/project/ui/develop_test.go
@@ -8,7 +8,10 @@ import (
 
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	projectview "github.com/flidai/leapview/internal/project"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	catalog "github.com/flidai/leapview/internal/project/navigation"
+	uisignals "github.com/flidai/leapview/internal/project/ui/signals"
+	refreshschedule "github.com/flidai/leapview/internal/refresh/schedule"
 )
 
 func TestSemanticModelDetailProjectionRendersTablesMeasuresRelationshipsAndGraph(t *testing.T) {
@@ -84,6 +87,51 @@ func TestSemanticModelDetailProjectionRendersTablesMeasuresRelationshipsAndGraph
 	}
 }
 
+func TestModelTableDetailProjectionRendersCompiledDefinition(t *testing.T) {
+	table := semanticmodel.Table{
+		Sources:            []string{"olist.geolocation"},
+		Transform:          semanticmodel.Transform{SQL: "SELECT zip_prefix FROM source.\"olist.geolocation\""},
+		Dimensions:         map[string]semanticmodel.MetricDimension{"zip_prefix": {Label: "ZIP prefix", Description: "ZIP code prefix"}},
+		PrimaryKey:         "zip_prefix",
+		Grain:              "zip_prefix",
+		SourceDependencies: []string{"olist.geolocation"},
+		Schema:             semanticmodel.TableSchema{Columns: []semanticmodel.ColumnSchema{{Name: "zip_prefix", Ordinal: 0, PhysicalType: "VARCHAR"}}},
+	}
+	asset := projectview.DevelopAssetView{
+		ID: "model:zip_geolocations", Type: string(projectview.AssetTypeModelTable), Key: "zip_geolocations", Title: "ZIP locations",
+		Payload: projectview.ModelTableAssetPayload(table),
+	}
+	project := projectview.DevelopView{ID: "project:test", Title: "Test"}
+	details := projectAssetDetailsSignal(project, asset, []projectview.DevelopAssetView{asset}, nil)
+	if got := factValue(details.Overview, "Fields"); got != "1" {
+		t.Fatalf("fields fact = %q, want 1", got)
+	}
+	if got := factValue(details.Overview, "Input sources"); got != "1" {
+		t.Fatalf("input sources fact = %q, want 1", got)
+	}
+	if got := factValue(details.Overview, "Mode"); got != "Transform" {
+		t.Fatalf("mode fact = %q, want Transform", got)
+	}
+	if len(details.Sections) != 2 || details.Sections[0].Title != "Fields (1)" || details.Sections[1].Title != "SQL" {
+		t.Fatalf("sections = %#v, want fields and SQL", details.Sections)
+	}
+	if uisignals.ValueOrZero(details.Sections[1].Code) != table.Transform.SQL || uisignals.ValueOrZero(details.Sections[1].Lang) != "sql" {
+		t.Fatalf("SQL section = %#v, want compiled transform SQL", details.Sections[1])
+	}
+	if len(details.Sections[0].Table.Rows) != 1 {
+		t.Fatalf("field rows = %#v, want one row", details.Sections[0].Table.Rows)
+	}
+}
+
+func factValue(facts []uisignals.DefinitionFactSignal, label string) string {
+	for _, fact := range facts {
+		if fact.Label == label {
+			return fact.Value
+		}
+	}
+	return ""
+}
+
 func TestDevelopCatalogUsesStableDashboardLinksWithoutProjectPicker(t *testing.T) {
 	page := catalogPageSignal(catalog.Catalog{
 		Project:    catalog.Project{ID: "sales", Title: "Sales"},
@@ -92,6 +140,47 @@ func TestDevelopCatalogUsesStableDashboardLinksWithoutProjectPicker(t *testing.T
 	if len(page.Dashboards) != 1 || page.Dashboards[0].Href != "/dashboards/executive" {
 		t.Fatalf("dashboard link = %#v, want stable dashboard route", page.Dashboards)
 	}
+}
+
+func TestSourceAndPipelineDetailsConsumeTypedAssetProjections(t *testing.T) {
+	source := projectview.DevelopAssetView{
+		ID: "source:orders", Type: string(projectview.AssetTypeSource), Key: "orders", Title: "Orders",
+		Payload: projectview.SourceAssetPayload(semanticmodel.Source{
+			Format: "csv", Connection: "warehouse", Path: "s3://bucket/orders.csv",
+			Fields: map[string]semanticmodel.SourceField{"order_id": {Type: "int"}},
+		}),
+	}
+	sourceDetails := assetDetailModelForAsset(projectview.DevelopView{ID: "project:test"}, source, []projectview.DevelopAssetView{source}, nil)
+	if got := detailFactValue(sourceDetails.Overview, "Connection"); got != "warehouse" {
+		t.Fatalf("source connection fact = %q, want warehouse", got)
+	}
+	if len(sourceDetails.Sections) != 1 || len(sourceDetails.Sections[0].Table.Rows) != 1 {
+		t.Fatalf("source field section = %#v, want one projected field", sourceDetails.Sections)
+	}
+
+	pipeline := projectview.DevelopAssetView{
+		ID: "pipeline:sales", Type: string(projectview.AssetTypeRefreshPipeline), Key: "sales", Title: "Sales refresh",
+		Payload: projectview.RefreshPipelineAssetPayload(refreshschedule.Definition{
+			ID: "pipeline:sales", Name: "sales", SemanticModelID: projectgraph.ResourceID("semantic:sales"),
+			Schedules: []refreshschedule.Schedule{{Expression: "0 * * * *", Timezone: "UTC"}},
+		}),
+	}
+	pipelineDetails := assetDetailModelForAsset(projectview.DevelopView{ID: "project:test"}, pipeline, []projectview.DevelopAssetView{pipeline}, nil)
+	if got := detailFactValue(pipelineDetails.Overview, "Semantic model"); got != "semantic:sales" {
+		t.Fatalf("pipeline semantic model fact = %q, want semantic:sales", got)
+	}
+	if got := detailFactValue(pipelineDetails.Overview, "Schedule"); !strings.Contains(got, "0 * * * *") || !strings.Contains(got, "UTC") {
+		t.Fatalf("pipeline schedule fact = %q, want cron and timezone", got)
+	}
+}
+
+func detailFactValue(facts []definitionFact, label string) string {
+	for _, fact := range facts {
+		if fact.Label == label {
+			return fact.Value
+		}
+	}
+	return ""
 }
 
 func TestDevelopAssetLinksStayInResourceArea(t *testing.T) {

--- a/internal/project/ui/develop_test.go
+++ b/internal/project/ui/develop_test.go
@@ -87,6 +87,36 @@ func TestSemanticModelDetailProjectionRendersTablesMeasuresRelationshipsAndGraph
 	}
 }
 
+func TestModelAndSemanticDataTabsStayOnAssetRoutes(t *testing.T) {
+	project := projectview.DevelopView{ID: "project:test", Title: "Test"}
+	for _, test := range []struct {
+		asset projectview.DevelopAssetView
+		href  string
+	}{
+		{asset: projectview.DevelopAssetView{ID: "model:orders", Type: string(projectview.AssetTypeModelTable), Key: "orders"}, href: "/models/model:orders/data"},
+		{asset: projectview.DevelopAssetView{ID: "semantic-model:sales", Type: string(projectview.AssetTypeSemanticModel), Key: "sales"}, href: "/semantic-models/semantic-model:sales/data"},
+	} {
+		page := projectAssetPageSignal(project, test.asset, []projectview.DevelopAssetView{test.asset}, nil, "data", assetLineageModel{})
+		var dataTab *uisignals.ResourceTabSignal
+		for index := range page.Tabs {
+			if page.Tabs[index].ID == "data" {
+				dataTab = &page.Tabs[index]
+				break
+			}
+		}
+		if dataTab == nil || dataTab.Href != test.href || !dataTab.Active {
+			t.Fatalf("asset %s data tab = %#v, want active %s", test.asset.ID, dataTab, test.href)
+		}
+	}
+	source := projectview.DevelopAssetView{ID: "source:orders", Type: string(projectview.AssetTypeSource), Key: "orders"}
+	page := projectAssetPageSignal(project, source, []projectview.DevelopAssetView{source}, nil, "details", assetLineageModel{})
+	for _, tab := range page.Tabs {
+		if tab.ID == "data" {
+			t.Fatalf("source unexpectedly exposes unsupported data tab: %#v", tab)
+		}
+	}
+}
+
 func TestModelTableDetailProjectionRendersCompiledDefinition(t *testing.T) {
 	table := semanticmodel.Table{
 		Sources:            []string{"olist.geolocation"},

--- a/scripts/build_test_assets.ts
+++ b/scripts/build_test_assets.ts
@@ -25,7 +25,26 @@ const fixtures = new Map<string, FixtureBuild>([
     ),
   ],
   ['dashboard-builder', single('dashboard-builder', 'web/components/dashboard/dashboard-builder.ts', '.tmp/dashboard-builder-test/dashboard-builder-under-test.js')],
-  ['project-page', single('project-page', 'web/components/project/project-page.ts', '.tmp/project-page-test/project-page-under-test.js')],
+  [
+    'project-page',
+    {
+      label: 'project-page',
+      clean: ['.tmp/project-page-test'],
+      options: {
+        entrypoints: ['web/components/project/project-page.ts', 'web/components/data/data-explorer.ts'],
+        target: 'browser',
+        format: 'esm',
+        splitting: true,
+        external: externalModules,
+        outdir: '.tmp/project-page-test',
+        naming: { entry: '[name].[ext]', chunk: 'chunks/project-page-[name]-[hash].[ext]' },
+      },
+      copy: [
+        { from: '.tmp/project-page-test/project-page.js', to: '.tmp/project-page-test/project-page-under-test.js' },
+        { from: '.tmp/project-page-test/data-explorer.js', to: '.tmp/project-page-test/data-explorer-under-test.js' },
+      ],
+    },
+  ],
   [
     'chat-page',
     split('chat-page', 'web/components/chat/chat-page.ts', '.tmp/chat-page-test', 'chat-page-under-test.js', 'chunks/[name]-[hash].[ext]'),

--- a/web/components/data/data-explorer.dom.test.ts
+++ b/web/components/data/data-explorer.dom.test.ts
@@ -321,6 +321,43 @@ test('data explorer renders object browser and emits preview commands', async ()
   }
 })
 
+test('data explorer prompts for a selection when objects are available', async () => {
+  const page = await browser.newPage({ viewport: { width: 900, height: 700 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => customElements.get('lv-data-explorer'))
+
+    const message = await page.evaluate(async () => {
+      const element = document.createElement('lv-data-explorer') as any
+      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev') as any
+      mergePatch({
+        page: { kind: 'data', title: 'Data Explorer', tabs: [] },
+        dataExplorer: {
+          objects: [{
+            key: 'model_table:model:orders', resourceId: 'model:orders', layer: 'model_table',
+            modelId: 'semantic:sales', table: 'orders', title: 'Orders', columnCount: 1,
+            columns: [{ key: 'order_id', label: 'Order ID', type: 'string' }],
+          }],
+          preview: { columns: [], totalRows: 0, availableRows: 0, chunkSize: 100, rowHeight: 32, resetVersion: 0, blocks: {}, sort: {} },
+          command: { offset: 0, limit: 100, start: 0, count: 100, requestSeq: 0, resetVersion: 0, sort: {}, visibleColumns: [], columnWidths: {} },
+          explore: { command: { dimensions: [], measures: [], filters: [], sort: [], limit: 100, requestSeq: 0, resetVersion: 0, columnWidths: {} }, models: [], datasets: [], fields: [], result: { columns: [], rows: [], warnings: [] } },
+          warnings: [],
+        },
+      })
+      document.body.append(element)
+      for (let index = 0; index < 10; index += 1) {
+        await element.updateComplete
+        await new Promise((resolve) => requestAnimationFrame(resolve))
+      }
+      return element.shadowRoot?.querySelector('.main .empty')?.textContent?.trim()
+    })
+
+    expect(message).toBe('Select a data object to begin.')
+  } finally {
+    await page.close()
+  }
+})
+
 test('data explorer builds a governed semantic exploration and filter command', async () => {
   const page = await browser.newPage({ viewport: { width: 1440, height: 900 } })
   try {

--- a/web/components/data/data-explorer.dom.test.ts
+++ b/web/components/data/data-explorer.dom.test.ts
@@ -383,7 +383,10 @@ test('data explorer builds a governed semantic exploration and filter command', 
       }
       const customersObject = {
         key: 'model_table:model_table:sales.customers', resourceId: 'model_table:sales.customers', layer: 'model_table', modelId: 'sales', table: 'customers', title: 'customers',
-        columnCount: 1, rowCountLabel: '10', columns: [{ key: 'state', label: 'State', type: 'string' }],
+        columnCount: 2, rowCountLabel: '10', columns: [
+          { key: 'customer_id', label: 'Customer ID', type: 'string' },
+          { key: 'state', label: 'State', type: 'string' },
+        ],
       }
       const itemsObject = {
         key: 'model_table:model_table:sales.items', resourceId: 'model_table:sales.items', layer: 'model_table', modelId: 'sales', table: 'items', title: 'items',
@@ -403,6 +406,7 @@ test('data explorer builds a governed semantic exploration and filter command', 
           fields: [
             { id: 'orders.order_id', label: 'Order ID', kind: 'dimension', modelTable: 'orders', type: 'string', compatible: true, selected: false },
             { id: 'orders.status', label: 'Status', kind: 'dimension', modelTable: 'orders', type: 'string', compatible: true, selected: true },
+            { id: 'customers.customer_id', label: 'Customer ID', kind: 'dimension', modelTable: 'customers', type: 'string', compatible: true, relationshipPath: ['orders_customers'], selected: false },
             { id: 'customers.state', label: 'State', kind: 'dimension', modelTable: 'customers', type: 'string', compatible: true, relationshipPath: ['orders_customers'], selected: false },
             { id: 'items.sku', label: 'SKU', kind: 'dimension', modelTable: 'items', type: 'string', compatible: false, compatibilityReason: 'Not available from Orders because no grain-preserving relationship path reaches Items.', selected: false },
             { id: 'revenue', label: 'Revenue', kind: 'measure', modelTable: 'orders', type: 'sum', compatible: true, selected: true },
@@ -425,6 +429,10 @@ test('data explorer builds a governed semantic exploration and filter command', 
       }
 
       const root = element.shadowRoot
+      const customersTable = Array.from(root.querySelectorAll<HTMLElement>('.object-button')).find((button) => button.textContent?.includes('customers'))!
+      customersTable.click()
+      await element.updateComplete
+      const tableSelectionCommand = commands.at(-1)?.explore
       const orderID = Array.from(root.querySelectorAll<HTMLButtonElement>('.field-button')).find((button) => button.textContent?.includes('Order ID'))
       if (!orderID) throw new Error(`Order ID field was not rendered: ${root.textContent}`)
       orderID.click()
@@ -497,6 +505,7 @@ test('data explorer builds a governed semantic exploration and filter command', 
         unavailableField,
         rebaseField: { disabled: rebaseField.disabled, text: rebaseField.textContent?.replace(/\s+/g, ' ').trim(), title: rebaseField.title },
         rebaseCommand,
+        tableSelectionCommand,
         commands,
       }
     })
@@ -519,6 +528,9 @@ test('data explorer builds a governed semantic exploration and filter command', 
     expect(state.rebaseField.title).toContain('change grain from Customers to Orders')
     expect(state.rebaseCommand.datasetId).toBe('customers')
     expect(state.rebaseCommand.dimensions).toEqual(['customers.state', 'orders.status'])
+    expect(state.tableSelectionCommand.datasetId).toBe('customers')
+    expect(state.tableSelectionCommand.dimensions).toEqual(['customers.customer_id', 'customers.state'])
+    expect(state.tableSelectionCommand.measures).toEqual([])
     expect(state.commands.some((command) => command.explore?.dimensions?.includes('items.sku'))).toBe(false)
     expect(state.commands.some((command) => command.mode === 'explore' && command.explore?.dimensions?.includes('orders.order_id'))).toBe(true)
     expect(state.commands.some((command) => command.explore?.filters?.[0]?.field === 'orders.status' && command.explore.filters[0].values[0] === 'delivered')).toBe(true)

--- a/web/components/data/data-explorer.ts
+++ b/web/components/data/data-explorer.ts
@@ -1102,7 +1102,9 @@ class DataExplorerPage extends DatastarLit(LitElement) {
               ? semanticActive
                 ? this.renderExploreSelected(selected, explorer.explore ?? emptyExplorer.explore)
                 : this.renderSelected(selected, explorer.preview ?? emptyPreview, explorer.command ?? emptyExplorer.command)
-              : html`<p class="empty">No data objects are available.</p>`}
+              : html`<p class="empty">${(explorer.objects ?? []).length
+                ? 'Select a data object to begin.'
+                : 'No data objects are available.'}</p>`}
           </main>
         </div>
         ${agentEnabled && this.agentDrawerOpen ? html`<lv-chat-drawer

--- a/web/components/data/data-explorer.ts
+++ b/web/components/data/data-explorer.ts
@@ -1,5 +1,5 @@
 import { LitElement, css, html, nothing } from 'lit'
-import { state } from 'lit/decorators.js'
+import { property, state } from 'lit/decorators.js'
 import { ChevronRight, Code2, Columns3, Database, Eye, Filter, Play, Plus, RotateCcw, Search, Server, Sigma, Square, SquareCheckBig, Table2, X } from 'lucide'
 import type {
   AgentReferenceSignal,
@@ -70,6 +70,7 @@ function readDataExplorerAgentState(): { open: boolean, conversationId: string }
 }
 
 class DataExplorerPage extends DatastarLit(LitElement) {
+  @property({ type: Boolean, reflect: true }) embedded = false
   @state() private search = ''
   @state() private fieldSearch = ''
   @state() private showSQL = false
@@ -98,6 +99,30 @@ class DataExplorerPage extends DatastarLit(LitElement) {
       color: var(--lv-fg-default);
       background: var(--lv-bg-app);
       font-family: var(--fontStack-system);
+    }
+
+    :host([embedded]) {
+      height: 100%;
+      min-height: 0;
+    }
+
+    :host([embedded]) .route {
+      height: 100%;
+      min-height: 32rem;
+      grid-template-rows: minmax(0, 1fr);
+    }
+
+    :host([embedded]) .header {
+      display: none;
+    }
+
+    :host([embedded]) .route:not(.semantic) .explorer {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    :host([embedded]) .route:not(.semantic) .browser,
+    :host([embedded]) .route:not(.semantic) .browser-resizer {
+      display: none;
     }
 
     .route {
@@ -986,7 +1011,7 @@ class DataExplorerPage extends DatastarLit(LitElement) {
     }
     if (this.optimisticExplore && (this.dataExplorer.explore?.command?.requestSeq ?? 0) >= this.optimisticExplore.requestSeq) {
       this.optimisticExplore = null
-      replaceDataExplorerURL(this.dataExplorer.command)
+      if (!this.embedded) replaceDataExplorerURL(this.dataExplorer.command)
     }
     const agent = this.signal<{ activeConversationId?: string } | null>('agent', null)
     const activeConversationId = agent?.activeConversationId?.trim() ?? ''
@@ -1014,12 +1039,12 @@ class DataExplorerPage extends DatastarLit(LitElement) {
     const selected = explorer.selectedObject
     const semanticActive = explorer.command?.mode === 'explore' || this.optimisticExplore !== null
     const filtered = filterObjects(explorer.objects ?? [], this.search)
-    const grouped = groupObjectsByModel(filtered)
+    const grouped = groupObjectsByModel(filtered, explorer.explore?.models ?? [])
     const agentEnabled = this.signal<unknown | null>('agent', null) !== null
     const columns = this.headerColumns(explorer, semanticActive)
     const visibleColumnKeys = this.headerVisibleColumnKeys(explorer, columns, semanticActive)
     return html`
-      <section class=${`route${agentEnabled && this.agentDrawerOpen ? ' agent-open' : ''}`} aria-label="Data Explorer">
+      <section class=${`route${semanticActive ? ' semantic' : ''}${agentEnabled && this.agentDrawerOpen ? ' agent-open' : ''}`} aria-label="Data Explorer">
         <header class="header">
           <h1>${page?.title ?? 'Data Explorer'}</h1>
           <div class="header-actions">
@@ -1388,7 +1413,7 @@ class DataExplorerPage extends DatastarLit(LitElement) {
       columnWidths: next.columnWidths ?? current.columnWidths ?? {},
     }
     this.optimisticExplore = command
-    replaceDataExplorerURL({ ...this.dataExplorer.command, mode: 'explore', explore: command })
+    if (!this.embedded) replaceDataExplorerURL({ ...this.dataExplorer.command, mode: 'explore', explore: command })
     const dispatch = () => this.emitCommand({ mode: 'explore', explore: command })
     if (immediate) dispatch()
     else this.exploreTimer = window.setTimeout(dispatch, 320)
@@ -1803,7 +1828,7 @@ class DataExplorerPage extends DatastarLit(LitElement) {
       visibleColumns: partial.visibleColumns ?? current.visibleColumns ?? [],
       columnWidths: partial.columnWidths ?? current.columnWidths ?? {},
     }
-    if (partial.objectKey !== undefined || partial.mode !== undefined || partial.explore !== undefined) {
+    if (!this.embedded && (partial.objectKey !== undefined || partial.mode !== undefined || partial.explore !== undefined)) {
       replaceDataExplorerURL(next)
     }
     this.dispatchEvent(new CustomEvent('lv-data-explorer-command', { bubbles: true, composed: true, detail: next }))
@@ -1849,13 +1874,14 @@ function objectColumnMatchesSearch(object: DataExplorerObjectSignal, query: stri
     .some((value) => String(value ?? '').toLowerCase().includes(normalized)))
 }
 
-function groupObjectsByModel(objects: DataExplorerObjectSignal[]): ResourceGroup[] {
+function groupObjectsByModel(objects: DataExplorerObjectSignal[], models: DataExploreSignal['models'] = []): ResourceGroup[] {
   const groups = new Map<string, ResourceGroup>()
+  const modelTitles = new Map(models.map((model) => [model.id, model.title]))
   for (const object of objects) {
     if (object.layer === 'source') continue
     const id = object.modelId || object.layer
     if (!groups.has(id)) {
-      groups.set(id, { id, title: object.modelId || 'Data objects', objects: [] })
+      groups.set(id, { id, title: modelTitles.get(id) || object.modelId || 'Data objects', objects: [] })
     }
     groups.get(id)!.objects.push(object)
   }

--- a/web/components/data/data-explorer.ts
+++ b/web/components/data/data-explorer.ts
@@ -1731,11 +1731,14 @@ class DataExplorerPage extends DatastarLit(LitElement) {
     this.optimisticExplore = null
     this.closeFilter()
     const currentExplore = this.dataExplorer?.explore?.command ?? emptyExplorer.explore.command
+    const tableID = objectTableID(object)
+    const localDimensions = localPreviewDimensions(object, this.dataExplorer?.explore?.fields ?? [])
+    const semanticActive = this.dataExplorer?.command?.mode === 'explore'
     const explore: DataExploreCommand = {
       ...currentExplore,
       modelId: object.modelId ?? '',
-      datasetId: objectTableID(object),
-      dimensions: [],
+      datasetId: tableID,
+      dimensions: localDimensions,
       measures: [],
       filters: [],
       sort: [],
@@ -1744,7 +1747,7 @@ class DataExplorerPage extends DatastarLit(LitElement) {
       columnWidths: {},
     }
     this.emitCommand({
-      mode: 'browse',
+      mode: semanticActive ? 'explore' : 'browse',
       explore,
       objectKey: object.key,
       offset: 0,
@@ -1833,6 +1836,18 @@ class DataExplorerPage extends DatastarLit(LitElement) {
     }
     this.dispatchEvent(new CustomEvent('lv-data-explorer-command', { bubbles: true, composed: true, detail: next }))
   }
+}
+
+function localPreviewDimensions(object: DataExplorerObjectSignal, fields: DataExploreFieldSignal[]): string[] {
+  const tableID = objectTableID(object)
+  const localFields = fields.filter((field) => field.kind !== 'measure' && field.modelTable === tableID)
+  const localByColumn = new Map(localFields.map((field) => [fieldColumnID(field), field.id]))
+  const ordered = (object.columns ?? []).map((column) => localByColumn.get(column.key) ?? `${tableID}.${column.key}`)
+  const seen = new Set(ordered)
+  for (const field of localFields) {
+    if (!seen.has(field.id)) ordered.push(field.id)
+  }
+  return ordered
 }
 
 function objectTableID(object: DataExplorerObjectSignal): string {

--- a/web/components/project/project-page.dom.test.ts
+++ b/web/components/project/project-page.dom.test.ts
@@ -108,6 +108,34 @@ test('semantic model asset details use the Waypoints SVG identity', async () => 
   }
 })
 
+test('asset data section embeds the shared explorer without a duplicate route header', async () => {
+  const page = await browser.newPage()
+  try {
+    await page.goto(`${baseURL}/?root=model-data`)
+    await page.waitForFunction(() => customElements.get('lv-project-asset-page') && customElements.get('lv-data-explorer'))
+    const data = await page.locator('lv-project-asset-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const explorer = element.shadowRoot?.querySelector('lv-data-explorer') as any
+      await explorer?.updateComplete
+      explorer?.emitCommand({ objectKey: 'orders' })
+      return {
+        embedded: explorer?.hasAttribute('embedded') ?? false,
+        routeHeaders: explorer?.shadowRoot?.querySelectorAll('.header').length ?? 0,
+        visibleRouteHeaders: Array.from(explorer?.shadowRoot?.querySelectorAll('.header') ?? []).filter((node: any) => getComputedStyle(node).display !== 'none').length,
+        browserVisible: getComputedStyle(explorer?.shadowRoot?.querySelector('.browser') as Element).display !== 'none',
+        pathname: window.location.pathname,
+      }
+    })
+    expect(data.embedded).toBe(true)
+    expect(data.routeHeaders).toBe(1)
+    expect(data.visibleRouteHeaders).toBe(0)
+    expect(data.browserVisible).toBe(false)
+    expect(data.pathname).toBe('/')
+  } finally {
+    await page.close()
+  }
+})
+
 test('connections list and asset detail render without workspace terminology', async () => {
   const page = await browser.newPage()
   try {
@@ -144,6 +172,8 @@ function testDocument(rootName: string): string {
     kind: 'data', title: 'orders', assetId: 'orders', activeSection: 'details', asset: { id: 'orders', key: 'model_table:orders', title: 'orders', type: 'model_table', typeLabel: 'Model table', detailHref: '/models/model:orders/details', openHref: '/models/model:orders/details' }, breadcrumbs: [{ label: 'Develop', href: '/models' }, { label: 'orders', current: true }], tabs: [{ id: 'details', label: 'Details', href: '/models/model:orders/details', active: true }], details: { overview: [{ label: 'Rows', value: '100' }], sections: [] },
   } : rootName === 'semantic-detail' ? {
     kind: 'data', title: 'orders', assetId: 'semantic:orders', activeSection: 'details', asset: { id: 'semantic:orders', key: 'semantic_model:orders', title: 'orders', type: 'semantic_model', typeLabel: 'Semantic model', detailHref: '/semantic-models/semantic:orders/details', openHref: '/semantic-models/semantic:orders/details' }, breadcrumbs: [{ label: 'Semantic models', href: '/semantic-models' }, { label: 'orders', current: true }], tabs: [{ id: 'details', label: 'Details', href: '/semantic-models/semantic:orders/details', active: true }], details: { overview: [{ label: 'Rows', value: '100' }], sections: [] },
+  } : rootName === 'model-data' ? {
+    kind: 'data', title: 'orders', assetId: 'model:orders', activeSection: 'data', asset: { id: 'model:orders', key: 'orders', title: 'orders', type: 'model_table', typeLabel: 'Model table', detailHref: '/models/model:orders/details', openHref: '/models/model:orders/details' }, breadcrumbs: [{ label: 'Models', href: '/models' }, { label: 'orders', current: true }], tabs: [{ id: 'details', label: 'Details', href: '/models/model:orders/details' }, { id: 'data', label: 'Data', href: '/models/model:orders/data', active: true }], details: { overview: [], sections: [] },
   } : rootName === 'models' ? {
     kind: 'data', title: 'Models', assetList: { activeType: 'model_table', assets: [{ id: 'model:orders', key: 'model_table:orders', title: 'orders', type: 'model_table', typeLabel: 'Model table', detailHref: '/models/model:orders/details', openHref: '/models/model:orders/details' }], empty: 'No models.', searchHref: '/models', tabs: [] },
   } : rootName === 'semantic-models' ? {
@@ -151,8 +181,9 @@ function testDocument(rootName: string): string {
   } : {
     kind: 'data', title: 'Develop', assetList: { activeType: 'source', assets: [{ id: 'source:orders', key: 'source:orders', title: 'orders', type: 'source', typeLabel: 'Source', detailHref: '/sources/source:orders/details', openHref: '/sources/source:orders/details' }], empty: 'No assets.', searchHref: '/sources', tabs: [] },
   }
-  const rootTag = rootName === 'connections' ? 'lv-connections-page' : rootName === 'detail' || rootName === 'semantic-detail' ? 'lv-project-asset-page' : 'lv-project-page'
-  return `<!doctype html><html><body><main data-signals="${escapeHTML(JSON.stringify({ page, connectionAdmin: { command: {}, status: { loading: false, error: '', message: '' } } }))}"><${rootTag}></${rootTag}></main><script type="module" src="/project-page-under-test.js"></script><script type="module" src="/static/vendor/datastar-1.0.2.js?v=dev"></script></body></html>`
+  const rootTag = rootName === 'connections' ? 'lv-connections-page' : rootName === 'detail' || rootName === 'semantic-detail' || rootName === 'model-data' ? 'lv-project-asset-page' : 'lv-project-page'
+  const dataExplorer = { objects: [{ key: 'orders', resourceId: 'model:orders', title: 'orders', layer: 'model_table' }], selectedKey: 'orders', selectedObject: { key: 'orders', resourceId: 'model:orders', title: 'orders', layer: 'model_table' }, preview: { columns: [], totalRows: 0, availableRows: 0, chunkSize: 100, rowHeight: 32, resetVersion: 0, blocks: {}, totalRowLabel: '0', sort: {}, sql: '', error: '' }, explore: { command: { modelId: '', datasetId: '', dimensions: [], measures: [], filters: [], sort: [], limit: 100, requestSeq: 0, resetVersion: 0, columnWidths: {} }, models: [], datasets: [], fields: [], result: { columns: [], rows: [], rowsReturned: 0, durationMs: 0, requestSeq: 0, truncated: false, warnings: [] } }, command: { mode: 'browse', objectKey: 'orders', offset: 0, limit: 100, block: 'all', start: 0, count: 100, requestSeq: 0, resetVersion: 0, sort: {}, visibleColumns: [], columnWidths: {} }, warnings: [] }
+  return `<!doctype html><html><body><main data-signals="${escapeHTML(JSON.stringify({ page, dataExplorer, connectionAdmin: { command: {}, status: { loading: false, error: '', message: '' } } }))}"><${rootTag}></${rootTag}></main><script type="module" src="/project-page-under-test.js"></script>${rootName === 'model-data' ? '<script type="module" src="/data-explorer-under-test.js"></script>' : ''}<script type="module" src="/static/vendor/datastar-1.0.2.js?v=dev"></script></body></html>`
 }
 
 function lifecycle() {

--- a/web/components/project/project-page.dom.test.ts
+++ b/web/components/project/project-page.dom.test.ts
@@ -109,7 +109,7 @@ test('semantic model asset details use the Waypoints SVG identity', async () => 
 })
 
 test('asset data section embeds the shared explorer without a duplicate route header', async () => {
-  const page = await browser.newPage()
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } })
   try {
     await page.goto(`${baseURL}/?root=model-data`)
     await page.waitForFunction(() => customElements.get('lv-project-asset-page') && customElements.get('lv-data-explorer'))
@@ -117,6 +117,13 @@ test('asset data section embeds the shared explorer without a duplicate route he
       await element.updateComplete
       const explorer = element.shadowRoot?.querySelector('lv-data-explorer') as any
       await explorer?.updateComplete
+      const preview = explorer?.shadowRoot?.querySelector('lv-data-preview-table') as any
+      await preview?.updateComplete
+      const table = preview?.shadowRoot?.querySelector('lv-windowed-table') as any
+      await table?.updateComplete
+      await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+      await table?.updateComplete
+      const scrollport = table?.shadowRoot?.querySelector('.scrollport') as HTMLElement | null
       explorer?.emitCommand({ objectKey: 'orders' })
       return {
         embedded: explorer?.hasAttribute('embedded') ?? false,
@@ -124,6 +131,10 @@ test('asset data section embeds the shared explorer without a duplicate route he
         visibleRouteHeaders: Array.from(explorer?.shadowRoot?.querySelectorAll('.header') ?? []).filter((node: any) => getComputedStyle(node).display !== 'none').length,
         browserVisible: getComputedStyle(explorer?.shadowRoot?.querySelector('.browser') as Element).display !== 'none',
         pathname: window.location.pathname,
+        assetHeight: Math.round(element.getBoundingClientRect().height),
+        viewportHeight: scrollport?.clientHeight ?? 0,
+        renderedRows: table?.shadowRoot?.querySelectorAll('.canvas > .row').length ?? 0,
+        windowHeight: window.innerHeight,
       }
     })
     expect(data.embedded).toBe(true)
@@ -131,6 +142,10 @@ test('asset data section embeds the shared explorer without a duplicate route he
     expect(data.visibleRouteHeaders).toBe(0)
     expect(data.browserVisible).toBe(false)
     expect(data.pathname).toBe('/')
+    expect(data.assetHeight).toBeLessThanOrEqual(data.windowHeight)
+    expect(data.viewportHeight).toBeGreaterThan(0)
+    expect(data.viewportHeight).toBeLessThan(data.windowHeight)
+    expect(data.renderedRows).toBeLessThan(100)
   } finally {
     await page.close()
   }
@@ -182,7 +197,8 @@ function testDocument(rootName: string): string {
     kind: 'data', title: 'Develop', assetList: { activeType: 'source', assets: [{ id: 'source:orders', key: 'source:orders', title: 'orders', type: 'source', typeLabel: 'Source', detailHref: '/sources/source:orders/details', openHref: '/sources/source:orders/details' }], empty: 'No assets.', searchHref: '/sources', tabs: [] },
   }
   const rootTag = rootName === 'connections' ? 'lv-connections-page' : rootName === 'detail' || rootName === 'semantic-detail' || rootName === 'model-data' ? 'lv-project-asset-page' : 'lv-project-page'
-  const dataExplorer = { objects: [{ key: 'orders', resourceId: 'model:orders', title: 'orders', layer: 'model_table' }], selectedKey: 'orders', selectedObject: { key: 'orders', resourceId: 'model:orders', title: 'orders', layer: 'model_table' }, preview: { columns: [], totalRows: 0, availableRows: 0, chunkSize: 100, rowHeight: 32, resetVersion: 0, blocks: {}, totalRowLabel: '0', sort: {}, sql: '', error: '' }, explore: { command: { modelId: '', datasetId: '', dimensions: [], measures: [], filters: [], sort: [], limit: 100, requestSeq: 0, resetVersion: 0, columnWidths: {} }, models: [], datasets: [], fields: [], result: { columns: [], rows: [], rowsReturned: 0, durationMs: 0, requestSeq: 0, truncated: false, warnings: [] } }, command: { mode: 'browse', objectKey: 'orders', offset: 0, limit: 100, block: 'all', start: 0, count: 100, requestSeq: 0, resetVersion: 0, sort: {}, visibleColumns: [], columnWidths: {} }, warnings: [] }
+  const previewRows = Array.from({ length: 100 }, (_, index) => ({ customer_id: `customer-${index + 1}`, city: 'Example' }))
+  const dataExplorer = { objects: [{ key: 'orders', resourceId: 'model:orders', title: 'orders', layer: 'model_table' }], selectedKey: 'orders', selectedObject: { key: 'orders', resourceId: 'model:orders', title: 'orders', layer: 'model_table' }, preview: { columns: [{ key: 'customer_id', label: 'Customer ID', type: 'string' }, { key: 'city', label: 'City', type: 'string' }], totalRows: 99441, availableRows: 99441, chunkSize: 100, rowHeight: 32, resetVersion: 0, blocks: { a: { start: 0, requestSeq: 0, resetVersion: 0, sort: {}, rows: previewRows } }, totalRowLabel: '99441', sort: {}, sql: '', error: '' }, explore: { command: { modelId: '', datasetId: '', dimensions: [], measures: [], filters: [], sort: [], limit: 100, requestSeq: 0, resetVersion: 0, columnWidths: {} }, models: [], datasets: [], fields: [], result: { columns: [], rows: [], rowsReturned: 0, durationMs: 0, requestSeq: 0, truncated: false, warnings: [] } }, command: { mode: 'browse', objectKey: 'orders', offset: 0, limit: 100, block: 'all', start: 0, count: 100, requestSeq: 0, resetVersion: 0, sort: {}, visibleColumns: [], columnWidths: {} }, warnings: [] }
   return `<!doctype html><html><body><main data-signals="${escapeHTML(JSON.stringify({ page, dataExplorer, connectionAdmin: { command: {}, status: { loading: false, error: '', message: '' } } }))}"><${rootTag}></${rootTag}></main><script type="module" src="/project-page-under-test.js"></script>${rootName === 'model-data' ? '<script type="module" src="/data-explorer-under-test.js"></script>' : ''}<script type="module" src="/static/vendor/datastar-1.0.2.js?v=dev"></script></body></html>`
 }
 

--- a/web/components/project/project-page.ts
+++ b/web/components/project/project-page.ts
@@ -277,7 +277,7 @@ class LeapViewProjectAssetPage extends DatastarLit(LitElement) {
 
   private renderAssetPage(page: ResourceAssetPageSignal) {
     return html`
-      <section class="asset-page" aria-label="Project asset detail">
+      <section class=${`asset-page${page.activeSection === 'data' ? ' data-asset-page' : ''}`} aria-label="Project asset detail">
         <header class="breadcrumb-header">
           <nav aria-label="Breadcrumb">
             <ol>
@@ -641,6 +641,13 @@ const projectStyles = css`
     margin-inline: 0;
     padding: 0;
     overflow: visible;
+  }
+
+  .asset-page.data-asset-page {
+    height: 100svh;
+    min-height: 0;
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
   }
 
   .connection-detail-route {
@@ -1105,6 +1112,11 @@ const projectStyles = css`
     grid-template-rows: auto auto;
   }
 
+  .data-asset-page .asset-body {
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
+  }
+
   .asset-body > .tabs {
     padding-inline: var(--base-size-16);
   }
@@ -1120,7 +1132,7 @@ const projectStyles = css`
   }
 
   .data-body {
-    min-height: 32rem;
+    min-height: 0;
     overflow: hidden;
     padding: 0;
   }
@@ -1309,6 +1321,12 @@ const projectStyles = css`
       overflow: visible;
     }
 
+    .asset-page.data-asset-page {
+      height: 100svh;
+      min-height: 0;
+      overflow: hidden;
+    }
+
     .connection-detail-route {
       width: 100%;
       padding: var(--base-size-16);
@@ -1321,6 +1339,10 @@ const projectStyles = css`
 
     .section-body {
       overflow: visible;
+    }
+
+    .data-asset-page .section-body {
+      overflow: hidden;
     }
 
     .graph-details-body {

--- a/web/components/project/project-page.ts
+++ b/web/components/project/project-page.ts
@@ -304,7 +304,7 @@ class LeapViewProjectAssetPage extends DatastarLit(LitElement) {
         </header>
         <div class="asset-body">
           ${renderTabs(page.tabs)}
-          <div class=${page.activeSection === 'lineage' ? 'section-body lineage-body' : page.activeSection === 'details' && page.details?.semanticModelGraph ? 'section-body graph-details-body' : 'section-body'}>
+          <div class=${page.activeSection === 'lineage' ? 'section-body lineage-body' : page.activeSection === 'data' ? 'section-body data-body' : page.activeSection === 'details' && page.details?.semanticModelGraph ? 'section-body graph-details-body' : 'section-body'}>
             ${this.renderSection(page)}
           </div>
         </div>
@@ -315,6 +315,8 @@ class LeapViewProjectAssetPage extends DatastarLit(LitElement) {
   private renderSection(page: ResourceAssetPageSignal) {
     return page.activeSection === 'lineage'
       ? this.renderLineage(page)
+      : page.activeSection === 'data'
+        ? html`<lv-data-explorer embedded></lv-data-explorer>`
       : page.activeSection === 'refreshes'
         ? this.renderRefreshes(page)
         : page.activeSection === 'versions'
@@ -1115,6 +1117,16 @@ const projectStyles = css`
 
   .lineage-body {
     padding: 0;
+  }
+
+  .data-body {
+    min-height: 32rem;
+    overflow: hidden;
+    padding: 0;
+  }
+
+  .data-body lv-data-explorer {
+    height: 100%;
   }
 
   .graph-details-body {


### PR DESCRIPTION
## Summary

- restore complete project-wide model and semantic-model read models, including code, fields, inputs, relationships, and lineage
- add governed Data views directly to model and semantic-model asset pages while keeping model previews windowed and lazily loaded
- make semantic table selection preview all local fields and automatically infer a safe query base when cross-table fields change grain
- preserve canonical dashboard model identity so interactive dashboard commands, including cross-filtering, continue to route correctly

## Validation

- `task ci`
- manually verified model-table chunk loading
- manually verified semantic Customers to Fulfillment Orders grain rebasing with retained fields and 100 preview rows
- manually verified the dashboard command routing fix against the visual showcase
