### PR TITLE
feat: add reusable strict JSON decoder

### DIFF
--- a/internal/access/canonical_contract.go
+++ b/internal/access/canonical_contract.go
@@ -1,14 +1,13 @@
 package access
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/pkg/strictjson"
 )
 
 var (
@@ -570,88 +569,13 @@ func (grant CanonicalGrant) GrantKey() string {
 }
 
 func decodeCanonicalJSON(data []byte, target any, label string) error {
-	if err := rejectDuplicateCanonicalJSONKeys(data); err != nil {
+	if err := strictjson.Decode(data, target); err != nil {
 		return fmt.Errorf("decode %s: %w", label, err)
-	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(target); err != nil {
-		return fmt.Errorf("decode %s: %w", label, err)
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err == nil {
-		return fmt.Errorf("decode %s: trailing JSON value", label)
-	} else if !errors.Is(err, io.EOF) {
-		return fmt.Errorf("decode %s: trailing data: %w", label, err)
 	}
 	return nil
 }
 
 func rejectDuplicateCanonicalJSONKeys(data []byte) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	if err := walkCanonicalJSONValue(decoder); err != nil {
-		return err
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err == nil {
-		return errors.New("trailing JSON value")
-	} else if !errors.Is(err, io.EOF) {
-		return fmt.Errorf("trailing data: %w", err)
-	}
-	return nil
-}
-
-func walkCanonicalJSONValue(decoder *json.Decoder) error {
-	token, err := decoder.Token()
-	if err != nil {
-		return err
-	}
-	switch delimiter := token.(type) {
-	case json.Delim:
-		switch delimiter {
-		case '{':
-			keys := make(map[string]struct{})
-			for decoder.More() {
-				keyToken, err := decoder.Token()
-				if err != nil {
-					return err
-				}
-				key, ok := keyToken.(string)
-				if !ok {
-					return errors.New("JSON object key is not a string")
-				}
-				canonicalKey := strings.ToLower(key)
-				if _, exists := keys[canonicalKey]; exists {
-					return fmt.Errorf("duplicate JSON object key %q", key)
-				}
-				keys[canonicalKey] = struct{}{}
-				if err := walkCanonicalJSONValue(decoder); err != nil {
-					return err
-				}
-			}
-			end, err := decoder.Token()
-			if err != nil {
-				return err
-			}
-			if end != json.Delim('}') {
-				return fmt.Errorf("JSON object ended with %v", end)
-			}
-		case '[':
-			for decoder.More() {
-				if err := walkCanonicalJSONValue(decoder); err != nil {
-					return err
-				}
-			}
-			end, err := decoder.Token()
-			if err != nil {
-				return err
-			}
-			if end != json.Delim(']') {
-				return fmt.Errorf("JSON array ended with %v", end)
-			}
-		default:
-			return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
-		}
-	}
-	return nil
+	var value any
+	return strictjson.DecodeWithOptions(data, &value, strictjson.Options{AllowUnknownFields: true})
 }

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -235,6 +235,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "desktop/native/windowspolicy", Capability: "platform", Layer: LayerAdapter},
 	{Prefix: "internal/extension", Capability: "platform", Layer: LayerContract},
 	{Prefix: "pkg/agent", Capability: "agent", Layer: LayerContract},
+	{Prefix: "pkg/strictjson", Capability: "platform", Layer: LayerPlatform},
 	{Prefix: "internal/project/graph", Capability: "project", Layer: LayerContract},
 	{Prefix: "internal/project/contracts", Capability: "project", Layer: LayerContract},
 	{Prefix: "internal/project/catalog", Capability: "project", Layer: LayerContract},

--- a/internal/project/graph/graph.go
+++ b/internal/project/graph/graph.go
@@ -8,16 +8,16 @@
 package graph
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/flidai/leapview/pkg/strictjson"
 )
 
 const (
@@ -231,20 +231,9 @@ func Validate(resources []Resource, edges []Edge) error {
 
 // Decode decodes a canonical graph artifact and revalidates its invariants.
 func Decode(data []byte) (ProjectGraph, error) {
-	if err := rejectDuplicateJSONKeys(data); err != nil {
-		return ProjectGraph{}, fmt.Errorf("decode project graph: %w", err)
-	}
 	var wire graphWire
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&wire); err != nil {
+	if err := strictjson.Decode(data, &wire); err != nil {
 		return ProjectGraph{}, fmt.Errorf("decode project graph: %w", err)
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err == nil {
-		return ProjectGraph{}, errors.New("decode project graph: trailing JSON value")
-	} else if !errors.Is(err, io.EOF) {
-		return ProjectGraph{}, fmt.Errorf("decode project graph: trailing data: %w", err)
 	}
 	if wire.Version != GraphVersion {
 		return ProjectGraph{}, UnsupportedVersionError{Contract: "project graph", Version: wire.Version}
@@ -509,20 +498,9 @@ func NewArtifactEnvelope(identity ServingIdentity, graph ProjectGraph) (Artifact
 
 // DecodeArtifactEnvelope decodes and validates a serving-scoped artifact.
 func DecodeArtifactEnvelope(data []byte) (ArtifactEnvelope, error) {
-	if err := rejectDuplicateJSONKeys(data); err != nil {
-		return ArtifactEnvelope{}, fmt.Errorf("decode project artifact: %w", err)
-	}
 	var wire artifactWire
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&wire); err != nil {
+	if err := strictjson.Decode(data, &wire); err != nil {
 		return ArtifactEnvelope{}, fmt.Errorf("decode project artifact: %w", err)
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err == nil {
-		return ArtifactEnvelope{}, errors.New("decode project artifact: trailing JSON value")
-	} else if !errors.Is(err, io.EOF) {
-		return ArtifactEnvelope{}, fmt.Errorf("decode project artifact: trailing data: %w", err)
 	}
 	if wire.Version != ArtifactVersion {
 		return ArtifactEnvelope{}, UnsupportedVersionError{Contract: "project artifact", Version: wire.Version}
@@ -767,70 +745,4 @@ func sortedStrings(values []string) []string {
 	values = append([]string(nil), values...)
 	sort.Strings(values)
 	return values
-}
-
-// rejectDuplicateJSONKeys walks one JSON value before typed decoding. The
-// standard decoder intentionally applies last-key-wins semantics; canonical
-// project artifacts instead reject ambiguity at every nested object level.
-func rejectDuplicateJSONKeys(data []byte) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	if err := walkJSONValue(decoder); err != nil {
-		return err
-	}
-	return nil
-}
-
-func walkJSONValue(decoder *json.Decoder) error {
-	token, err := decoder.Token()
-	if err != nil {
-		return err
-	}
-	switch delimiter := token.(type) {
-	case json.Delim:
-		switch delimiter {
-		case '{':
-			keys := make(map[string]struct{})
-			for decoder.More() {
-				keyToken, err := decoder.Token()
-				if err != nil {
-					return err
-				}
-				key, ok := keyToken.(string)
-				if !ok {
-					return errors.New("JSON object key is not a string")
-				}
-				canonicalKey := strings.ToLower(key)
-				if _, exists := keys[canonicalKey]; exists {
-					return fmt.Errorf("duplicate JSON object key %q", key)
-				}
-				keys[canonicalKey] = struct{}{}
-				if err := walkJSONValue(decoder); err != nil {
-					return err
-				}
-			}
-			end, err := decoder.Token()
-			if err != nil {
-				return err
-			}
-			if end != json.Delim('}') {
-				return fmt.Errorf("JSON object ended with %v", end)
-			}
-		case '[':
-			for decoder.More() {
-				if err := walkJSONValue(decoder); err != nil {
-					return err
-				}
-			}
-			end, err := decoder.Token()
-			if err != nil {
-				return err
-			}
-			if end != json.Delim(']') {
-				return fmt.Errorf("JSON array ended with %v", end)
-			}
-		default:
-			return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
-		}
-	}
-	return nil
 }

--- a/pkg/strictjson/boundary_test.go
+++ b/pkg/strictjson/boundary_test.go
@@ -1,0 +1,35 @@
+package strictjson
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPackageDoesNotImportApplicationPrivateCode(t *testing.T) {
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
+			return nil
+		}
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, imported := range parsed.Imports {
+			importPath := strings.Trim(imported.Path.Value, `"`)
+			if importPath == "github.com/flidai/leapview/internal" || strings.HasPrefix(importPath, "github.com/flidai/leapview/internal/") {
+				t.Errorf("%s imports application-private package %s", path, importPath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/strictjson/decode.go
+++ b/pkg/strictjson/decode.go
@@ -1,0 +1,218 @@
+package strictjson
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// DefaultMaxBytes is the largest document accepted by Decode.
+	DefaultMaxBytes int64 = 16 << 20
+	// DefaultMaxDepth is the largest object/array nesting depth accepted by Decode.
+	DefaultMaxDepth = 100
+)
+
+var (
+	// ErrDuplicateKey indicates that an object repeats a key under the selected comparison mode.
+	ErrDuplicateKey = errors.New("strictjson: duplicate object key")
+	// ErrTrailingData indicates that non-whitespace data follows the first JSON value.
+	ErrTrailingData = errors.New("strictjson: trailing data")
+	// ErrSizeLimit indicates that the encoded document exceeds MaxBytes.
+	ErrSizeLimit = errors.New("strictjson: size limit exceeded")
+	// ErrDepthLimit indicates that object or array nesting exceeds MaxDepth.
+	ErrDepthLimit = errors.New("strictjson: depth limit exceeded")
+)
+
+// DuplicateKeyMode controls how object keys are compared for duplicates.
+type DuplicateKeyMode uint8
+
+const (
+	// CaseFoldedKeys rejects keys that differ only by case. It is the default
+	// because encoding/json matches struct fields case-insensitively.
+	CaseFoldedKeys DuplicateKeyMode = iota
+	// CaseSensitiveKeys compares object keys exactly.
+	CaseSensitiveKeys
+)
+
+// Options configures decoding. Zero-valued limits use the safe defaults.
+type Options struct {
+	// MaxBytes bounds the encoded document. Zero uses DefaultMaxBytes.
+	MaxBytes int64
+	// MaxDepth bounds object and array nesting. Zero uses DefaultMaxDepth.
+	MaxDepth int
+	// DuplicateKeys selects exact or case-folded key comparison.
+	DuplicateKeys DuplicateKeyMode
+	// AllowUnknownFields disables the default typed-struct unknown-field check.
+	AllowUnknownFields bool
+}
+
+// DuplicateKeyError identifies an ambiguous object key.
+type DuplicateKeyError struct {
+	// Key is the later spelling that collided with a key in the same object.
+	Key string
+}
+
+func (e *DuplicateKeyError) Error() string {
+	return fmt.Sprintf("%s %q", ErrDuplicateKey, e.Key)
+}
+
+func (e *DuplicateKeyError) Unwrap() error { return ErrDuplicateKey }
+
+// Decode decodes one JSON value using bounded, strict defaults.
+func Decode(data []byte, target any) error {
+	return DecodeWithOptions(data, target, Options{})
+}
+
+// DecodeWithOptions decodes exactly one JSON value from data.
+func DecodeWithOptions(data []byte, target any, options Options) error {
+	options, err := normalize(options)
+	if err != nil {
+		return err
+	}
+	if int64(len(data)) > options.MaxBytes {
+		return fmt.Errorf("%w: maximum is %d bytes", ErrSizeLimit, options.MaxBytes)
+	}
+	return decode(data, target, options)
+}
+
+// DecodeReader reads and decodes exactly one bounded JSON value. It does not
+// close the reader.
+func DecodeReader(reader io.Reader, target any, options Options) error {
+	if reader == nil {
+		return errors.New("strictjson: reader is nil")
+	}
+	options, err := normalize(options)
+	if err != nil {
+		return err
+	}
+	data, err := io.ReadAll(io.LimitReader(reader, options.MaxBytes+1))
+	if err != nil {
+		return err
+	}
+	if int64(len(data)) > options.MaxBytes {
+		return fmt.Errorf("%w: maximum is %d bytes", ErrSizeLimit, options.MaxBytes)
+	}
+	return decode(data, target, options)
+}
+
+func normalize(options Options) (Options, error) {
+	if options.MaxBytes == 0 {
+		options.MaxBytes = DefaultMaxBytes
+	}
+	if options.MaxDepth == 0 {
+		options.MaxDepth = DefaultMaxDepth
+	}
+	if options.MaxBytes < 0 {
+		return Options{}, errors.New("strictjson: max bytes must be positive")
+	}
+	if options.MaxDepth < 0 {
+		return Options{}, errors.New("strictjson: max depth must be positive")
+	}
+	if options.DuplicateKeys != CaseFoldedKeys && options.DuplicateKeys != CaseSensitiveKeys {
+		return Options{}, errors.New("strictjson: invalid duplicate key mode")
+	}
+	return options, nil
+}
+
+func decode(data []byte, target any, options Options) error {
+	if err := validate(data, options); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if !options.AllowUnknownFields {
+		decoder.DisallowUnknownFields()
+	}
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return ErrTrailingData
+		}
+		return fmt.Errorf("%w: %v", ErrTrailingData, err)
+	}
+	return nil
+}
+
+func validate(data []byte, options Options) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := walkValue(decoder, 0, options); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return ErrTrailingData
+		}
+		return fmt.Errorf("%w: %v", ErrTrailingData, err)
+	}
+	return nil
+}
+
+func walkValue(decoder *json.Decoder, depth int, options Options) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	depth++
+	if depth > options.MaxDepth {
+		return fmt.Errorf("%w: maximum is %d", ErrDepthLimit, options.MaxDepth)
+	}
+	switch delimiter {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("strictjson: object key is not a string")
+			}
+			comparisonKey := key
+			if options.DuplicateKeys == CaseFoldedKeys {
+				comparisonKey = strings.ToLower(key)
+			}
+			if _, exists := seen[comparisonKey]; exists {
+				return &DuplicateKeyError{Key: key}
+			}
+			seen[comparisonKey] = struct{}{}
+			if err := walkValue(decoder, depth, options); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim('}') {
+			return fmt.Errorf("strictjson: object ended with %v", end)
+		}
+	case '[':
+		for decoder.More() {
+			if err := walkValue(decoder, depth, options); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim(']') {
+			return fmt.Errorf("strictjson: array ended with %v", end)
+		}
+	default:
+		return fmt.Errorf("strictjson: unexpected delimiter %q", delimiter)
+	}
+	return nil
+}

--- a/pkg/strictjson/decode_test.go
+++ b/pkg/strictjson/decode_test.go
@@ -1,0 +1,131 @@
+package strictjson
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type document struct {
+	Name   string `json:"name"`
+	Nested struct {
+		Value int `json:"value"`
+	} `json:"nested"`
+}
+
+func TestDecodeValidDocument(t *testing.T) {
+	var got document
+	if err := Decode([]byte(`{"name":"demo","nested":{"value":7}}`), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "demo" || got.Nested.Value != 7 {
+		t.Fatalf("decoded document = %#v", got)
+	}
+}
+
+func TestDecodeRejectsNestedDuplicateKeys(t *testing.T) {
+	for _, input := range []string{
+		`{"name":"first","name":"second"}`,
+		`{"nested":{"value":1,"value":2}}`,
+		`{"nested":{"value":1,"VALUE":2}}`,
+	} {
+		var got document
+		err := Decode([]byte(input), &got)
+		if !errors.Is(err, ErrDuplicateKey) {
+			t.Fatalf("Decode(%s) error = %v, want duplicate key", input, err)
+		}
+		var duplicate *DuplicateKeyError
+		if !errors.As(err, &duplicate) || duplicate.Key == "" {
+			t.Fatalf("Decode(%s) error = %v, want typed duplicate", input, err)
+		}
+	}
+}
+
+func TestCaseSensitiveDuplicateOption(t *testing.T) {
+	var got map[string]int
+	err := DecodeWithOptions([]byte(`{"value":1,"VALUE":2}`), &got, Options{
+		DuplicateKeys:      CaseSensitiveKeys,
+		AllowUnknownFields: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("decoded map = %#v", got)
+	}
+}
+
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	var got document
+	if err := Decode([]byte(`{"name":"demo","unknown":true}`), &got); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("Decode unknown field error = %v", err)
+	}
+	if err := DecodeWithOptions([]byte(`{"name":"demo","unknown":true}`), &got, Options{AllowUnknownFields: true}); err != nil {
+		t.Fatalf("DecodeWithOptions allowing unknown fields: %v", err)
+	}
+}
+
+func TestDecodeRejectsTrailingData(t *testing.T) {
+	for _, input := range []string{
+		`{"name":"demo"}{}`,
+		`{"name":"demo"} trailing`,
+	} {
+		var got document
+		if err := Decode([]byte(input), &got); !errors.Is(err, ErrTrailingData) {
+			t.Fatalf("Decode(%q) error = %v, want trailing data", input, err)
+		}
+	}
+}
+
+func TestDecodeEnforcesSizeLimit(t *testing.T) {
+	var got any
+	err := DecodeWithOptions([]byte(`{"name":"demo"}`), &got, Options{MaxBytes: 4})
+	if !errors.Is(err, ErrSizeLimit) {
+		t.Fatalf("DecodeWithOptions error = %v, want size limit", err)
+	}
+	err = DecodeReader(strings.NewReader(`{"name":"demo"}`), &got, Options{MaxBytes: 4})
+	if !errors.Is(err, ErrSizeLimit) {
+		t.Fatalf("DecodeReader error = %v, want size limit", err)
+	}
+}
+
+func TestDecodeEnforcesDepthLimit(t *testing.T) {
+	var got any
+	err := DecodeWithOptions([]byte(`{"one":{"two":true}}`), &got, Options{
+		MaxDepth:           1,
+		AllowUnknownFields: true,
+	})
+	if !errors.Is(err, ErrDepthLimit) {
+		t.Fatalf("DecodeWithOptions error = %v, want depth limit", err)
+	}
+}
+
+func TestDecodeRejectsInvalidSyntax(t *testing.T) {
+	var got any
+	if err := Decode([]byte(`{"name":`), &got); err == nil {
+		t.Fatal("Decode accepted invalid syntax")
+	}
+}
+
+func TestDecodeReader(t *testing.T) {
+	var got document
+	if err := DecodeReader(strings.NewReader(`{"name":"reader"}`), &got, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "reader" {
+		t.Fatalf("decoded name = %q", got.Name)
+	}
+}
+
+func TestDecodeDoesNotNarrowJSONNumbersDuringValidation(t *testing.T) {
+	var got struct {
+		Value json.Number `json:"value"`
+	}
+	if err := Decode([]byte(`{"value":1e1000}`), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Value.String() != "1e1000" {
+		t.Fatalf("decoded number = %q", got.Value)
+	}
+}

--- a/pkg/strictjson/doc.go
+++ b/pkg/strictjson/doc.go
@@ -1,0 +1,7 @@
+// Package strictjson provides bounded, ambiguity-free JSON decoding.
+//
+// The package owns generic decoding mechanics only. It does not define a
+// schema, authorize fields, canonicalize application values, or turn JSON
+// metadata into an allowlist. Callers remain responsible for validating the
+// decoded value against their domain contract.
+package strictjson


### PR DESCRIPTION
## Summary

- add a stdlib-only `pkg/strictjson` package with bounded size/depth defaults, case-folded duplicate-key rejection, unknown-field rejection, and exactly-one-value decoding
- expose typed/sentinel failures and configurable byte, depth, key-comparison, and reader decoding behavior
- migrate project graph and canonical access decoding, removing their duplicated recursive JSON walkers
- register the package as application-neutral platform mechanism and enforce its no-`internal` import boundary

## Verification

- `task ci`
- `go test -race ./pkg/strictjson`
