### PR TITLE
fix: make plan-driven delivery executable

### DIFF
--- a/internal/app/cli/delivery_cli.go
+++ b/internal/app/cli/delivery_cli.go
@@ -124,9 +124,13 @@ func (operations projectDeliveryPlanOperations) Create(ctx context.Context, opti
 	if err != nil {
 		return projectcli.DeliveryPlanResult{}, err
 	}
+	operationKey, err := newDeploymentIdempotencyKey("delivery-plan", projectID, targetID, operation, sourceDigest, candidateID)
+	if err != nil {
+		return projectcli.DeliveryPlanResult{}, err
+	}
 	response, err := deploymentgen.NewGenClient(transport).CreateDeliveryPlan(ctx, deploymentgen.GenCreateDeliveryPlanClientRequest{
 		Project: projectID,
-		Headers: deploymentgen.GenCreateDeliveryPlanClientHeaders{IdempotencyKey: deploymentIdempotencyKey("delivery-plan", projectID, targetID, operation, sourceDigest, candidateID)},
+		Headers: deploymentgen.GenCreateDeliveryPlanClientHeaders{IdempotencyKey: operationKey},
 		Body:    deploymentgen.DeliveryPlanRequest{TargetId: targetID, Operation: deploymentgen.DeliveryOperationKind(operation), SourceDigest: sourceDigest, SourceAttestationDigest: sourceAttestationDigest},
 	})
 	if err != nil {
@@ -267,10 +271,40 @@ func (operations projectDeliveryBuildOperations) Build(ctx context.Context, opti
 	if err != nil {
 		return projectcli.DeliveryBuildResult{}, err
 	}
-	response, err := deploymentgen.NewGenClient(transport).BuildDeliveryPlan(ctx, deploymentgen.GenBuildDeliveryPlanClientRequest{
-		Project: options.ProjectID, Plan: options.PlanID,
-		Headers: deploymentgen.GenBuildDeliveryPlanClientHeaders{IdempotencyKey: deploymentIdempotencyKey("delivery-build", options.ProjectID, options.PlanID)},
-	})
+	operationKey := deploymentIdempotencyKey("delivery-build", options.ProjectID, options.PlanID)
+	if operations.checkpoints != nil && planCheckpoint.PlanID != "" {
+		freshKey, keyErr := newDeploymentIdempotencyKey("delivery-build", options.ProjectID, options.PlanID)
+		if keyErr != nil {
+			return projectcli.DeliveryBuildResult{}, keyErr
+		}
+		operationKey, keyErr = operations.checkpoints.BindPlanBuildIdempotencyKey(options.PlanID, "", freshKey)
+		if keyErr != nil {
+			return projectcli.DeliveryBuildResult{}, fmt.Errorf("persist delivery build operation: %w", keyErr)
+		}
+	}
+	client := deploymentgen.NewGenClient(transport)
+	build := func(key string) (deploymentgen.GenBuildDeliveryPlanClientResponse, error) {
+		return client.BuildDeliveryPlan(ctx, deploymentgen.GenBuildDeliveryPlanClientRequest{
+			Project: options.ProjectID, Plan: options.PlanID,
+			Headers: deploymentgen.GenBuildDeliveryPlanClientHeaders{IdempotencyKey: key},
+		})
+	}
+	response, err := build(operationKey)
+	if err != nil && deliveryCLIProblemCode(err, "DELIVERY_IDEMPOTENCY_DRIFT") {
+		freshKey, keyErr := newDeploymentIdempotencyKey("delivery-build", options.ProjectID, options.PlanID)
+		if keyErr != nil {
+			return projectcli.DeliveryBuildResult{}, keyErr
+		}
+		if operations.checkpoints != nil && planCheckpoint.PlanID != "" {
+			freshKey, keyErr = operations.checkpoints.BindPlanBuildIdempotencyKey(options.PlanID, operationKey, freshKey)
+			if keyErr != nil {
+				return projectcli.DeliveryBuildResult{}, fmt.Errorf("rotate delivery build operation: %w", keyErr)
+			}
+		}
+		if freshKey != operationKey {
+			response, err = build(freshKey)
+		}
+	}
 	if err != nil {
 		return projectcli.DeliveryBuildResult{}, mapDeliveryCLIError("build delivery plan", err)
 	}
@@ -364,4 +398,9 @@ func mapDeliveryCLIError(operation string, err error) error {
 		kind = "authentication"
 	}
 	return &projectcli.DeliveryError{Operation: operation, Kind: kind, Code: code, Status: problem.Response.StatusCode, Detail: problem.Problem.Detail, Cause: err}
+}
+
+func deliveryCLIProblemCode(err error, code string) bool {
+	var problem *apigenclient.ProblemError
+	return errors.As(err, &problem) && strings.TrimSpace(problem.Problem.Code) == code
 }

--- a/internal/app/cli/delivery_cli.go
+++ b/internal/app/cli/delivery_cli.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	apigenclient "github.com/Yacobolo/toolbelt/apigen/runtime/client"
+	"github.com/flidai/leapview/internal/app/config"
 	deploymentgen "github.com/flidai/leapview/internal/deployment/api/gen"
 	"github.com/flidai/leapview/internal/platform/cliapi"
 	projectcli "github.com/flidai/leapview/internal/project/cli"
@@ -39,6 +40,10 @@ func (operations projectDeliveryPlanOperations) Create(ctx context.Context, opti
 	if operations.client == nil {
 		return projectcli.DeliveryPlanResult{}, fmt.Errorf("delivery plan API client is required")
 	}
+	targetSelector := strings.TrimSpace(options.Credentials.Target)
+	if targetSelector == "" {
+		targetSelector = strings.TrimSpace(config.MustLoad().Target)
+	}
 	credentials, err := operations.client.Resolve(ctx, options.Credentials)
 	if err != nil {
 		return projectcli.DeliveryPlanResult{}, err
@@ -51,6 +56,7 @@ func (operations projectDeliveryPlanOperations) Create(ctx context.Context, opti
 		return operations.resolveCandidatePlan(
 			ctx,
 			credentials,
+			targetSelector,
 			projectID,
 			candidateID,
 			targetID,
@@ -128,7 +134,7 @@ func (operations projectDeliveryPlanOperations) Create(ctx context.Context, opti
 	}
 	result := deliveryPlanResult(response.Body)
 	if operations.checkpoints != nil {
-		if err := operations.checkpoints.SavePlan(projectcli.DeliveryPlanCheckpoint{PlanID: result.PlanID, ProjectID: result.ProjectID, TargetID: result.TargetID, Environment: result.Environment, TargetOrigin: credentials.Target, SourceDigest: result.SourceDigest, SourceAttestationDigest: result.SourceAttestationDigest, PlanDigest: result.PlanDigest, ExecutionDigest: result.ExecutionDigest, EvidenceDigest: result.EvidenceDigest}); err != nil {
+		if err := operations.checkpoints.SavePlan(projectcli.DeliveryPlanCheckpoint{PlanID: result.PlanID, ProjectID: result.ProjectID, TargetID: result.TargetID, Environment: result.Environment, TargetOrigin: credentials.Target, TargetSelector: targetSelector, SourceDigest: result.SourceDigest, SourceAttestationDigest: result.SourceAttestationDigest, PlanDigest: result.PlanDigest, ExecutionDigest: result.ExecutionDigest, EvidenceDigest: result.EvidenceDigest}); err != nil {
 			return projectcli.DeliveryPlanResult{}, fmt.Errorf("persist delivery plan checkpoint: %w", err)
 		}
 	}
@@ -138,6 +144,7 @@ func (operations projectDeliveryPlanOperations) Create(ctx context.Context, opti
 func (operations projectDeliveryPlanOperations) resolveCandidatePlan(
 	ctx context.Context,
 	credentials cliapi.Credentials,
+	targetSelector string,
 	projectID string,
 	candidateID string,
 	targetID string,
@@ -190,7 +197,7 @@ func (operations projectDeliveryPlanOperations) resolveCandidatePlan(
 		if err := operations.checkpoints.SavePlan(projectcli.DeliveryPlanCheckpoint{
 			PlanID: result.PlanID, ProjectID: result.ProjectID,
 			TargetID: result.TargetID, Environment: result.Environment,
-			TargetOrigin: credentials.Target, SourceDigest: result.SourceDigest,
+			TargetOrigin: credentials.Target, TargetSelector: targetSelector, SourceDigest: result.SourceDigest,
 			SourceAttestationDigest: result.SourceAttestationDigest,
 			PlanDigest:              result.PlanDigest, ExecutionDigest: result.ExecutionDigest,
 			EvidenceDigest: result.EvidenceDigest,
@@ -238,14 +245,19 @@ func (operations projectDeliveryBuildOperations) Build(ctx context.Context, opti
 	if operations.client == nil {
 		return projectcli.DeliveryBuildResult{}, fmt.Errorf("delivery build API client is required")
 	}
+	var planCheckpoint projectcli.DeliveryPlanCheckpoint
 	if strings.TrimSpace(options.ProjectID) == "" && operations.checkpoints != nil {
 		plan, lookupErr := operations.checkpoints.LoadPlan(options.PlanID)
 		if lookupErr != nil {
 			return projectcli.DeliveryBuildResult{}, fmt.Errorf("resolve plan checkpoint: %w", lookupErr)
 		}
+		planCheckpoint = plan
 		options.ProjectID = plan.ProjectID
 		if options.Credentials.Target == "" {
-			options.Credentials.Target = plan.TargetOrigin
+			options.Credentials.Target = plan.TargetSelector
+			if strings.TrimSpace(options.Credentials.Target) == "" {
+				options.Credentials.Target = plan.TargetOrigin
+			}
 		}
 	}
 	if strings.TrimSpace(options.ProjectID) == "" {
@@ -265,17 +277,14 @@ func (operations projectDeliveryBuildOperations) Build(ctx context.Context, opti
 	value := response.Body
 	result := projectcli.DeliveryBuildResult{SchemaVersion: 1, BuildID: value.Id, PlanID: value.PlanId, PlanDigest: value.PlanDigest, SourceDigest: value.SourceDigest, ExecutionDigest: value.ExecutionDigest, CandidateID: optionalString(value.CandidateId), SealID: optionalString(value.SealId), Status: string(value.Status), Revision: value.Revision}
 	if result.CandidateID != "" && operations.checkpoints != nil {
-		origin := options.Credentials.Target
-		var targetID, environment string
-		if origin == "" {
-			if plan, lookupErr := operations.checkpoints.LoadPlan(options.PlanID); lookupErr == nil {
-				origin = plan.TargetOrigin
-				targetID, environment = plan.TargetID, plan.Environment
-			}
-		} else if plan, lookupErr := operations.checkpoints.LoadPlan(options.PlanID); lookupErr == nil {
-			targetID, environment = plan.TargetID, plan.Environment
+		if planCheckpoint.PlanID == "" {
+			planCheckpoint, _ = operations.checkpoints.LoadPlan(options.PlanID)
 		}
-		_ = operations.checkpoints.SaveObjectIdentity("candidate", result.CandidateID, projectcli.DeliveryObjectCheckpoint{ProjectID: options.ProjectID, TargetOrigin: origin, TargetID: targetID, Environment: environment})
+		origin := planCheckpoint.TargetOrigin
+		if origin == "" {
+			origin = options.Credentials.Target
+		}
+		_ = operations.checkpoints.SaveObjectIdentity("candidate", result.CandidateID, projectcli.DeliveryObjectCheckpoint{ProjectID: options.ProjectID, TargetOrigin: origin, TargetSelector: planCheckpoint.TargetSelector, TargetID: planCheckpoint.TargetID, Environment: planCheckpoint.Environment})
 	}
 	return result, nil
 }
@@ -296,7 +305,10 @@ func (operations projectDeliveryRollbackOperations) Rollback(ctx context.Context
 		}
 		options.ProjectID = identity.ProjectID
 		if options.Credentials.Target == "" {
-			options.Credentials.Target = identity.TargetOrigin
+			options.Credentials.Target = identity.TargetSelector
+			if strings.TrimSpace(options.Credentials.Target) == "" {
+				options.Credentials.Target = identity.TargetOrigin
+			}
 		}
 	}
 	if strings.TrimSpace(options.ProjectID) == "" {

--- a/internal/app/cli/delivery_cli_test.go
+++ b/internal/app/cli/delivery_cli_test.go
@@ -89,6 +89,25 @@ func TestDeliveryPlanResultPreservesReviewEvidence(t *testing.T) {
 	}
 }
 
+func TestDeliveryPlanInvocationsUseFreshOperationKeys(t *testing.T) {
+	transport := &deliveryPlanSourceHandoffTransport{}
+	operations := projectDeliveryPlanOperations{client: fixedTransportClient{transport: transport}}
+	digest := "sha256:" + strings.Repeat("a", 64)
+	options := projectcli.DeliveryPlanOptions{
+		ProjectID: "project-1", TargetID: "target-1", Environment: "development",
+		SourceDigest: digest, SourceAttestationDigest: digest,
+	}
+	if _, err := operations.Create(t.Context(), options); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := operations.Create(t.Context(), options); err != nil {
+		t.Fatal(err)
+	}
+	if len(transport.planKeys) != 2 || transport.planKeys[0] == transport.planKeys[1] {
+		t.Fatalf("plan operation keys = %#v, want a new plan identity per invocation", transport.planKeys)
+	}
+}
+
 func stringPointer(value string) *string { return &value }
 
 func TestDeliveryPlanRetainsSourceWhenCandidateIdentityIsIncomplete(t *testing.T) {
@@ -143,6 +162,72 @@ func TestDeliveryPlanResolvesThePlanAlreadyBuiltByDev(t *testing.T) {
 		transport.createCalls != 0 || transport.retainCalls != 0 {
 		t.Fatalf("result=%#v transport=%#v", result, transport)
 	}
+}
+
+func TestDeliveryBuildRotatesPoisonedOperationKeyAndRetries(t *testing.T) {
+	checkpoints := projectcli.NewCandidateCheckpointStore(filepath.Join(t.TempDir(), "authoring.json"))
+	if err := checkpoints.SavePlan(projectcli.DeliveryPlanCheckpoint{
+		PlanID: "plan-1", ProjectID: "project-1", TargetOrigin: "https://target.example",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	transport := &deliveryBuildRetryTransport{}
+	result, err := (projectDeliveryBuildOperations{
+		client: fixedTransportClient{transport: transport}, checkpoints: checkpoints,
+	}).Build(t.Context(), projectcli.DeliveryBuildOptions{PlanID: "plan-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "sealed" || result.CandidateID != "candidate-2" {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(transport.keys) != 2 || transport.keys[0] == transport.keys[1] {
+		t.Fatalf("build idempotency keys = %#v, want one rotated retry", transport.keys)
+	}
+	replay, err := (projectDeliveryBuildOperations{
+		client: fixedTransportClient{transport: transport}, checkpoints: checkpoints,
+	}).Build(t.Context(), projectcli.DeliveryBuildOptions{PlanID: "plan-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replay.BuildID != result.BuildID || len(transport.keys) != 3 || transport.keys[2] != transport.keys[1] {
+		t.Fatalf("replay = %#v keys = %#v, want persisted sealed operation", replay, transport.keys)
+	}
+	checkpoint, err := checkpoints.LoadPlan("plan-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkpoint.BuildIdempotencyKey != transport.keys[1] {
+		t.Fatalf("checkpoint build key = %q, want %q", checkpoint.BuildIdempotencyKey, transport.keys[1])
+	}
+}
+
+type deliveryBuildRetryTransport struct {
+	keys []string
+}
+
+func (transport *deliveryBuildRetryTransport) DoAPIGen(_ context.Context, request apigenclient.Request, out any) (apigenclient.Response, error) {
+	if request.OperationID != deploymentgen.GenOperationBuildDeliveryPlan {
+		return apigenclient.Response{}, fmt.Errorf("unexpected operation %q", request.OperationID)
+	}
+	transport.keys = append(transport.keys, request.Headers.Get("Idempotency-Key"))
+	if len(transport.keys) == 1 {
+		return apigenclient.Response{}, generatedProblemErrorForTest(http.StatusConflict, "DELIVERY_IDEMPOTENCY_DRIFT")
+	}
+	candidateID, sealID := "candidate-2", "seal-2"
+	response := deploymentgen.DeliveryBuildStatusResponse{
+		Id: "attempt-2", PlanId: "plan-1", PlanDigest: "sha256:plan", SourceDigest: "sha256:source",
+		ExecutionDigest: "sha256:execution", PhysicalPoolId: "pool-1", WriterLeaseId: "writer-2",
+		CandidateId: &candidateID, SealId: &sealID, Status: deploymentgen.DeliveryBuildStatusSealed, Revision: 2,
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return apigenclient.Response{}, err
+	}
+	if err := json.Unmarshal(encoded, out); err != nil {
+		return apigenclient.Response{}, err
+	}
+	return apigenclient.Response{StatusCode: http.StatusOK, Headers: http.Header{}, ContentType: "application/json"}, nil
 }
 
 func TestDeliveryPlanRejectsRetainedSourceIdentityMismatch(t *testing.T) {
@@ -208,6 +293,7 @@ type deliveryPlanSourceHandoffTransport struct {
 	createCalls    int
 	candidateCalls int
 	previewCalls   int
+	planKeys       []string
 }
 
 func (transport *deliveryPlanSourceHandoffTransport) DoAPIGen(_ context.Context, request apigenclient.Request, out any) (apigenclient.Response, error) {
@@ -224,6 +310,7 @@ func (transport *deliveryPlanSourceHandoffTransport) DoAPIGen(_ context.Context,
 		response = transport.retained
 	case deploymentgen.GenOperationCreateDeliveryPlan:
 		transport.createCalls++
+		transport.planKeys = append(transport.planKeys, request.Headers.Get("Idempotency-Key"))
 		body := request.Body.(deploymentgen.DeliveryPlanRequest)
 		response = deploymentgen.DeliveryPlanPreviewResponse{Id: "plan-1", ProjectId: request.PathParams["project"], TargetId: body.TargetId, Environment: "development", SourceDigest: body.SourceDigest, SourceAttestationDigest: body.SourceAttestationDigest, Status: deploymentgen.DeliveryPlanStatusPlanned}
 	case deploymentgen.GenOperationGetDeliveryCandidateStatus:

--- a/internal/app/cli/deployment_identity.go
+++ b/internal/app/cli/deployment_identity.go
@@ -1,12 +1,23 @@
 package cli
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"strings"
 )
+
+func newDeploymentIdempotencyKey(kind string, values ...string) (string, error) {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", fmt.Errorf("generate %s operation identity: %w", kind, err)
+	}
+	keyValues := append([]string(nil), values...)
+	keyValues = append(keyValues, hex.EncodeToString(nonce[:]))
+	return deploymentIdempotencyKey(kind, keyValues...), nil
+}
 
 func deploymentIdempotencyKey(kind string, values ...string) string {
 	digest := sha256.New()

--- a/internal/app/cli/plan_build_publish_integration_test.go
+++ b/internal/app/cli/plan_build_publish_integration_test.go
@@ -99,6 +99,21 @@ func TestPlanBuildPublishCommandsCompleteAgainstRealApplication(t *testing.T) {
 	if plan.Evidence.AddedCount == 0 {
 		t.Errorf("bootstrap plan reported no added resources: %#v", plan.Evidence)
 	}
+	// Replanning is an explicit new review operation. It must not resurrect an
+	// older durable plan merely because source and target inputs are unchanged;
+	// planner/compiler evidence may have changed between invocations.
+	replanCommand := projectcli.DeliveryPlanCommand(ctx, projectDeliveryPlanOperations{
+		client: client, remotes: projectDevRemoteFactory{client: client}, checkpoints: checkpoints,
+	})
+	replanOutput := executeDeliveryCommand(t, replanCommand, projectPath, "--target", targetProfile, "--format", "json")
+	var replanned projectcli.DeliveryPlanResult
+	if err := json.Unmarshal(replanOutput, &replanned); err != nil {
+		t.Fatalf("decode replanned result: %v\n%s", err, replanOutput)
+	}
+	if replanned.PlanID == plan.PlanID || replanned.SourceDigest != plan.SourceDigest || replanned.BaseTargetRevision != plan.BaseTargetRevision {
+		t.Fatalf("replanned identity = %#v, first = %#v", replanned, plan)
+	}
+	plan = replanned
 
 	buildOperations := projectDeliveryBuildOperations{client: client, checkpoints: checkpoints}
 	buildCommand := projectcli.DeliveryBuildCommand(ctx, buildOperations)

--- a/internal/app/cli/plan_build_publish_integration_test.go
+++ b/internal/app/cli/plan_build_publish_integration_test.go
@@ -1,0 +1,182 @@
+//go:build duckdb_arrow
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	accesscli "github.com/flidai/leapview/internal/access/cli"
+	"github.com/flidai/leapview/internal/app"
+	manageddatacli "github.com/flidai/leapview/internal/manageddata/cli"
+	"github.com/flidai/leapview/internal/manageddata/localplan"
+	"github.com/flidai/leapview/internal/platform/cliapi"
+	projectcli "github.com/flidai/leapview/internal/project/cli"
+	"github.com/spf13/cobra"
+)
+
+func TestPlanBuildPublishCommandsCompleteAgainstRealApplication(t *testing.T) {
+	ctx := t.Context()
+	home := t.TempDir()
+	t.Cleanup(func() {
+		if err := restoreWritableTree(home); err != nil {
+			t.Errorf("restore writable test tree: %v", err)
+		}
+	})
+	application, err := app.Build(ctx, serveTestConfig(t, home))
+	if err != nil {
+		t.Fatalf("build application: %v", err)
+	}
+	if err := application.Start(ctx); err != nil {
+		t.Fatalf("start application: %v", err)
+	}
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := application.Shutdown(shutdownCtx); err != nil {
+			t.Errorf("shutdown application: %v", err)
+		}
+	})
+	target := httptest.NewServer(application.Handler())
+	t.Cleanup(target.Close)
+
+	assets, err := evaluationAssetsRoot()
+	if err != nil {
+		t.Fatalf("locate evaluation assets: %v", err)
+	}
+	projectPath := filepath.Join(assets, evaluationProjectRelativePath)
+	dataPath := filepath.Join(assets, evaluationDataRelativePath)
+	dataPlan, err := localplan.NewService(loadManagedDataPlanProject).Plan(ctx, localplan.Request{
+		ProjectPath: projectPath,
+		Connection:  evaluationConnection,
+		From:        dataPath,
+	})
+	if err != nil {
+		t.Fatalf("plan managed data: %v", err)
+	}
+	if err := manageddatacli.RunSync(ctx, manageddatacli.SyncRequest{
+		ProjectPath: projectPath,
+		ProjectID:   evaluationProjectID,
+		Connection:  evaluationConnection,
+		Root:        dataPlan.Root,
+		Target:      target.URL,
+		Token:       "dev",
+		Plan:        dataPlan,
+		Out:         &bytes.Buffer{},
+		HTTPClient:  target.Client(),
+	}); err != nil {
+		t.Fatalf("stage managed data: %v", err)
+	}
+
+	const targetProfile = "integration"
+	client := capabilityAPIClient{httpClient: target.Client(), authoring: deliveryIntegrationAuthoringResolver{
+		selector: targetProfile,
+		credential: accesscli.ResolvedCredential{
+			Profile:     cliapi.TargetProfile{Origin: target.URL, InstanceID: "integration", Environment: "default", ProjectID: evaluationProjectID, CredentialAccount: "integration"},
+			AccessToken: "dev",
+		},
+	}}
+	checkpoints := projectcli.NewCandidateCheckpointStore(filepath.Join(home, "authoring.json"))
+	planCommand := projectcli.DeliveryPlanCommand(ctx, projectDeliveryPlanOperations{
+		client: client, remotes: projectDevRemoteFactory{client: client}, checkpoints: checkpoints,
+	})
+	planOutput := executeDeliveryCommand(t, planCommand, projectPath, "--target", targetProfile, "--format", "json")
+	var plan projectcli.DeliveryPlanResult
+	if err := json.Unmarshal(planOutput, &plan); err != nil {
+		t.Fatalf("decode plan result: %v\n%s", err, planOutput)
+	}
+	if plan.PlanID == "" || plan.Status != "planned" {
+		t.Fatalf("plan result = %#v", plan)
+	}
+	if plan.Evidence.AddedCount == 0 {
+		t.Errorf("bootstrap plan reported no added resources: %#v", plan.Evidence)
+	}
+
+	buildOperations := projectDeliveryBuildOperations{client: client, checkpoints: checkpoints}
+	buildCommand := projectcli.DeliveryBuildCommand(ctx, buildOperations)
+	buildOutput := executeDeliveryCommand(t, buildCommand, plan.PlanID, "--format", "json")
+	var build projectcli.DeliveryBuildResult
+	if err := json.Unmarshal(buildOutput, &build); err != nil {
+		t.Fatalf("decode build result: %v\n%s", err, buildOutput)
+	}
+	if build.Status != "sealed" || build.CandidateID == "" || build.SealID == "" {
+		t.Fatalf("build result = %#v", build)
+	}
+	candidateIdentity, err := checkpoints.LoadObjectIdentity("candidate", build.CandidateID)
+	if err != nil {
+		t.Fatalf("load candidate handoff: %v", err)
+	}
+	if candidateIdentity.TargetOrigin != target.URL || candidateIdentity.TargetSelector != targetProfile {
+		t.Fatalf("candidate handoff lost target profile: %#v", candidateIdentity)
+	}
+
+	replayCommand := projectcli.DeliveryBuildCommand(ctx, buildOperations)
+	replayOutput := executeDeliveryCommand(t, replayCommand, plan.PlanID, "--format", "json")
+	var replay projectcli.DeliveryBuildResult
+	if err := json.Unmarshal(replayOutput, &replay); err != nil {
+		t.Fatalf("decode replayed build result: %v\n%s", err, replayOutput)
+	}
+	if replay.BuildID != build.BuildID || replay.CandidateID != build.CandidateID || replay.SealID != build.SealID {
+		t.Fatalf("build replay changed sealed identity: first=%#v replay=%#v", build, replay)
+	}
+
+	publishCommand := projectcli.PublishCommand(ctx, client, checkpoints, projectPublishOperations{
+		client: client, checkpoints: checkpoints,
+	})
+	publishOutput := executeDeliveryCommand(t, publishCommand, build.CandidateID, "--format", "json")
+	var publication projectcli.PublishResult
+	if err := json.Unmarshal(publishOutput, &publication); err != nil {
+		t.Fatalf("decode publication result: %v\n%s", err, publishOutput)
+	}
+	if publication.Status != "committed" || publication.GenerationID == "" || publication.CandidateID != build.CandidateID || publication.PlanID != plan.PlanID || publication.TargetRevision != 1 {
+		t.Fatalf("publication result = %#v", publication)
+	}
+}
+
+type deliveryIntegrationAuthoringResolver struct {
+	selector   string
+	credential accesscli.ResolvedCredential
+}
+
+func (resolver deliveryIntegrationAuthoringResolver) Resolve(_ context.Context, selector string) (accesscli.ResolvedCredential, error) {
+	if selector != resolver.selector {
+		return accesscli.ResolvedCredential{}, fmt.Errorf("resolve unexpected target selector %q", selector)
+	}
+	return resolver.credential, nil
+}
+
+func executeDeliveryCommand(t *testing.T, command *cobra.Command, args ...string) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs(args)
+	if err := command.Execute(); err != nil {
+		t.Fatalf("execute %s: %v\n%s", command.Name(), err, output.String())
+	}
+	return output.Bytes()
+}
+
+func restoreWritableTree(root string) error {
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		mode := os.FileMode(0o600)
+		if entry.IsDir() {
+			mode = 0o700
+		}
+		return os.Chmod(path, mode)
+	})
+}

--- a/internal/app/cli/publish.go
+++ b/internal/app/cli/publish.go
@@ -68,7 +68,7 @@ func (operations projectPublishOperations) Publish(
 		return fmt.Errorf("publish delivery candidate returned no durable publication identity")
 	}
 	if operations.checkpoints != nil {
-		identity := projectcli.DeliveryObjectCheckpoint{ProjectID: checkpoint.ProjectID, TargetOrigin: options.Credentials.Target}
+		identity := projectcli.DeliveryObjectCheckpoint{ProjectID: checkpoint.ProjectID, TargetOrigin: options.Credentials.Target, TargetSelector: checkpoint.TargetSelector}
 		if response.Body.CandidateId != "" {
 			_ = operations.checkpoints.SaveObjectIdentity("candidate", response.Body.CandidateId, identity)
 		}

--- a/internal/app/composition.go
+++ b/internal/app/composition.go
@@ -861,6 +861,14 @@ func buildRuntime(ctx context.Context, cfg config.Config, production bool, envir
 	// physical-pool admission is absent.
 	var canonicalDelivery *deploymentmodule.CanonicalDeliveryAdapter
 	var canonicalDeliveryMutations *deploymentmodule.CanonicalDeliveryMutations
+	candidatePreparationAdmission := deploymentmodule.CandidatePreparationAdmitterFunc(
+		func(ctx context.Context) (deploymentmodule.CandidatePreparationLease, error) {
+			return workloadController.Acquire(
+				ctx,
+				workloadmodule.ControlRequest("candidate.prepare"),
+			)
+		},
+	)
 	canonicalDeliveryRequired := true
 	// Sealed production serving uses delivery-owned catalog lease/GC state;
 	// the legacy serving-state snapshot retention worker must not inspect or
@@ -1393,6 +1401,7 @@ func buildRuntime(ctx context.Context, cfg config.Config, production bool, envir
 			Lifecycle:    canonicalDelivery.Lifecycle,
 			Sources:      candidateSources,
 			Artifacts:    releaseModule,
+			Admission:    candidatePreparationAdmission,
 			Plan:         canonicalDelivery.Plan,
 			PlanPreview:  canonicalDelivery.PlanPreview,
 			BuildRequest: canonicalDelivery.BuildRequest,
@@ -1516,22 +1525,15 @@ func buildRuntime(ctx context.Context, cfg config.Config, production bool, envir
 		},
 		CandidateRuntime:          runtimeHostModule,
 		CandidateRuntimeLifecycle: runtimeHostModule,
-		CandidateAdmission: deploymentmodule.CandidatePreparationAdmitterFunc(
-			func(ctx context.Context) (deploymentmodule.CandidatePreparationLease, error) {
-				return workloadController.Acquire(
-					ctx,
-					workloadmodule.ControlRequest("candidate.prepare"),
-				)
-			},
-		),
-		CandidateSources:         candidateSources,
-		CandidateArtifacts:       releaseModule,
-		CanonicalDeliveryAdapter: canonicalDelivery,
-		DeliveryMutations:        canonicalDeliveryMutations,
-		RequireCanonicalDelivery: canonicalDeliveryRequired,
-		CandidateSourceAudit:     candidateSourceAuditRecorder(accessModule),
-		CandidateSourceBlobAudit: candidateSourceAuditRecorder(accessModule),
-		RuntimeVersion:           identity.Version + ":" + identity.Revision,
+		CandidateAdmission:        candidatePreparationAdmission,
+		CandidateSources:          candidateSources,
+		CandidateArtifacts:        releaseModule,
+		CanonicalDeliveryAdapter:  canonicalDelivery,
+		DeliveryMutations:         canonicalDeliveryMutations,
+		RequireCanonicalDelivery:  canonicalDeliveryRequired,
+		CandidateSourceAudit:      candidateSourceAuditRecorder(accessModule),
+		CandidateSourceBlobAudit:  candidateSourceAuditRecorder(accessModule),
+		RuntimeVersion:            identity.Version + ":" + identity.Revision,
 		AfterActivated: func(ctx context.Context, activated deployment.Deployment) {
 			generation, generationErr := activatedRevalidationGeneration(
 				ctx, servingStateRepo, runtimeHostModule, activated.ServingIdentity, activated.PriorGenerationID,

--- a/internal/deployment/module/canonical_delivery.go
+++ b/internal/deployment/module/canonical_delivery.go
@@ -33,6 +33,7 @@ type CanonicalDeliveryMutations struct {
 	Sources   deployment.CandidateSourceSynchronizer
 	Adapter   *CanonicalDeliveryAdapter
 	Artifacts release.CandidateArtifactPreparer
+	Admission CandidatePreparationAdmitter
 	Plan      func(context.Context, deployment.DeliveryCandidateBuildInput, release.CandidateArtifactSet) (deployment.DeliveryPlan, error)
 	// PlanPreview is the non-persisting form used when Build rechecks durable
 	// compiler evidence. Keeping it separate prevents a retry from attempting
@@ -132,7 +133,7 @@ func (m *CanonicalDeliveryMutations) CreatePlan(ctx context.Context, intent Deli
 }
 
 func (m *CanonicalDeliveryMutations) BuildPlan(ctx context.Context, projectID, planID, principalID, idempotencyKey string) (deployment.DeliveryBuildAttempt, error) {
-	if m == nil || m.Lifecycle == nil || m.Artifacts == nil || m.BuildRequest == nil || m.Adapter == nil || m.Adapter.ReadyCandidate == nil {
+	if m == nil || m.Lifecycle == nil || m.Artifacts == nil || m.Admission == nil || m.BuildRequest == nil || m.Adapter == nil || m.Adapter.ReadyCandidate == nil {
 		return deployment.DeliveryBuildAttempt{}, fmt.Errorf("canonical delivery build coordinator is unavailable")
 	}
 	plan, err := m.Lifecycle.Store.PlanByID(ctx, planID)
@@ -188,6 +189,12 @@ func (m *CanonicalDeliveryMutations) BuildPlan(ctx context.Context, projectID, p
 	if err := m.verifyPlanEvidence(ctx, plan, planningInput, inspected); err != nil {
 		return deployment.DeliveryBuildAttempt{}, err
 	}
+	preparationLease, err := m.Admission.AcquireCandidatePreparation(ctx)
+	if err != nil {
+		return deployment.DeliveryBuildAttempt{}, candidatePreparationError(err)
+	}
+	defer preparationLease.Release()
+	ctx = preparationLease.Context()
 	buildRequest, err := m.BuildRequest(ctx, buildInput, inspected)
 	if err != nil {
 		return deployment.DeliveryBuildAttempt{}, err

--- a/internal/deployment/module/module.go
+++ b/internal/deployment/module/module.go
@@ -336,7 +336,8 @@ func Build(_ context.Context, config Config) (*Module, error) {
 			config.DeliveryMutations = &CanonicalDeliveryMutations{
 				Lifecycle: config.CanonicalDeliveryAdapter.Lifecycle,
 				Sources:   config.CandidateSources, Artifacts: config.CandidateArtifacts,
-				Plan: config.CanonicalDeliveryAdapter.Plan, PlanPreview: config.CanonicalDeliveryAdapter.PlanPreview, BuildRequest: config.CanonicalDeliveryAdapter.BuildRequest,
+				Admission: config.CandidateAdmission,
+				Plan:      config.CanonicalDeliveryAdapter.Plan, PlanPreview: config.CanonicalDeliveryAdapter.PlanPreview, BuildRequest: config.CanonicalDeliveryAdapter.BuildRequest,
 				Adapter: config.CanonicalDeliveryAdapter, Publish: config.CanonicalDeliveryAdapter.Publish, Rollback: config.CanonicalDeliveryAdapter.Rollback,
 			}
 		}

--- a/internal/platform/architecture/delivery_conformance_test.go
+++ b/internal/platform/architecture/delivery_conformance_test.go
@@ -3,6 +3,7 @@ package architecture
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -109,13 +110,15 @@ func TestLEA414ProductionUsesSealedCanonicalPath(t *testing.T) {
 	composition := string(compositionBytes)
 	for _, required := range []string{
 		"canonicalDeliveryRequired := true",
-		"RequireCanonicalDelivery: canonicalDeliveryRequired",
 		"NewSQLiteSealedFactory",
 		"LegacyServingPathEnabled: false",
 	} {
 		if !strings.Contains(composition, required) {
 			t.Errorf("production composition missing LEA-414 gate %q", required)
 		}
+	}
+	if !regexp.MustCompile(`RequireCanonicalDelivery:\s+canonicalDeliveryRequired`).MatchString(composition) {
+		t.Error("production composition does not require canonical delivery")
 	}
 
 	// No non-test production source may construct the snapshot-pinned factory.

--- a/internal/project/cli/candidate_checkpoint.go
+++ b/internal/project/cli/candidate_checkpoint.go
@@ -63,6 +63,7 @@ type DeliveryPlanCheckpoint struct {
 	PlanDigest              string `json:"planDigest"`
 	ExecutionDigest         string `json:"executionDigest,omitempty"`
 	EvidenceDigest          string `json:"evidenceDigest,omitempty"`
+	BuildIdempotencyKey     string `json:"buildIdempotencyKey,omitempty"`
 }
 
 type DeliveryObjectCheckpoint struct {
@@ -216,6 +217,9 @@ func (store *CandidateCheckpointStore) SavePlan(plan DeliveryPlanCheckpoint) err
 	if err != nil {
 		return err
 	}
+	if existing, ok := document.Plans[plan.PlanID]; ok && plan.BuildIdempotencyKey == "" {
+		plan.BuildIdempotencyKey = existing.BuildIdempotencyKey
+	}
 	document.Plans[plan.PlanID] = plan
 	return store.save(document)
 }
@@ -235,6 +239,46 @@ func (store *CandidateCheckpointStore) LoadPlan(planID string) (DeliveryPlanChec
 		return DeliveryPlanCheckpoint{}, ErrCandidateCheckpointNotFound
 	}
 	return plan, nil
+}
+
+// BindPlanBuildIdempotencyKey atomically creates or compare-and-swaps the
+// operation key used to build a plan. Keeping the key in the non-secret plan
+// checkpoint makes lost-response retries converge on the same sealed attempt,
+// while replace permits an explicit retry after the target proves the prior
+// non-sealed attempt is no longer replayable.
+func (store *CandidateCheckpointStore) BindPlanBuildIdempotencyKey(planID, replace, next string) (string, error) {
+	if store == nil {
+		return "", fmt.Errorf("candidate checkpoint store is required")
+	}
+	planID, replace, next = strings.TrimSpace(planID), strings.TrimSpace(replace), strings.TrimSpace(next)
+	if planID == "" || next == "" {
+		return "", fmt.Errorf("delivery plan build operation requires plan and idempotency identities")
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	lock, err := store.acquireMutationLock()
+	if err != nil {
+		return "", err
+	}
+	defer lock.Release()
+	document, err := store.load()
+	if err != nil {
+		return "", err
+	}
+	plan, ok := document.Plans[planID]
+	if !ok {
+		return "", ErrCandidateCheckpointNotFound
+	}
+	current := strings.TrimSpace(plan.BuildIdempotencyKey)
+	if current == "" || replace != "" && current == replace {
+		plan.BuildIdempotencyKey = next
+		document.Plans[planID] = plan
+		if err := store.save(document); err != nil {
+			return "", err
+		}
+		return next, nil
+	}
+	return current, nil
 }
 
 func (store *CandidateCheckpointStore) SaveObjectIdentity(kind, objectID string, identity DeliveryObjectCheckpoint) error {

--- a/internal/project/cli/candidate_checkpoint.go
+++ b/internal/project/cli/candidate_checkpoint.go
@@ -28,6 +28,7 @@ var ErrCandidateCheckpointNotFound = errors.New("candidate checkpoint not found"
 type CandidateCheckpoint struct {
 	ProjectPath       string `json:"projectPath"`
 	TargetOrigin      string `json:"targetOrigin"`
+	TargetSelector    string `json:"targetSelector,omitempty"`
 	TargetID          string `json:"targetId"`
 	Environment       string `json:"environment"`
 	ProjectID         string `json:"projectId"`
@@ -56,6 +57,7 @@ type DeliveryPlanCheckpoint struct {
 	TargetID                string `json:"targetId"`
 	Environment             string `json:"environment"`
 	TargetOrigin            string `json:"targetOrigin"`
+	TargetSelector          string `json:"targetSelector,omitempty"`
 	SourceDigest            string `json:"sourceDigest"`
 	SourceAttestationDigest string `json:"sourceAttestationDigest,omitempty"`
 	PlanDigest              string `json:"planDigest"`
@@ -64,10 +66,11 @@ type DeliveryPlanCheckpoint struct {
 }
 
 type DeliveryObjectCheckpoint struct {
-	ProjectID    string `json:"projectId"`
-	TargetOrigin string `json:"targetOrigin"`
-	TargetID     string `json:"targetId,omitempty"`
-	Environment  string `json:"environment,omitempty"`
+	ProjectID      string `json:"projectId"`
+	TargetOrigin   string `json:"targetOrigin"`
+	TargetSelector string `json:"targetSelector,omitempty"`
+	TargetID       string `json:"targetId,omitempty"`
+	Environment    string `json:"environment,omitempty"`
 }
 
 // CandidateCheckpointStore atomically persists non-secret authoring state.
@@ -312,6 +315,7 @@ func normalizeCandidateCheckpoint(checkpoint CandidateCheckpoint) (CandidateChec
 		return CandidateCheckpoint{}, err
 	}
 	checkpoint.TargetID = strings.TrimSpace(checkpoint.TargetID)
+	checkpoint.TargetSelector = strings.TrimSpace(checkpoint.TargetSelector)
 	checkpoint.Environment = strings.TrimSpace(checkpoint.Environment)
 	checkpoint.ProjectID = strings.TrimSpace(checkpoint.ProjectID)
 	checkpoint.CandidateID = strings.TrimSpace(checkpoint.CandidateID)

--- a/internal/project/cli/dev_command.go
+++ b/internal/project/cli/dev_command.go
@@ -207,6 +207,7 @@ func RunDev(
 	if options.Format != "text" && options.Format != "json" {
 		return fmt.Errorf("dev format must be text or json")
 	}
+	targetSelector := strings.TrimSpace(options.Credentials.Target)
 	credentials, err := client.Resolve(ctx, options.Credentials)
 	if err != nil {
 		return err
@@ -258,7 +259,8 @@ func RunDev(
 		}
 		checkpoint := CandidateCheckpoint{
 			ProjectPath: options.ProjectPath, TargetOrigin: credentials.Target,
-			TargetID: candidate.TargetID, Environment: candidate.Environment,
+			TargetSelector: targetSelector,
+			TargetID:       candidate.TargetID, Environment: candidate.Environment,
 			ProjectID: candidate.ProjectID.String(), CandidateID: candidate.ID,
 			CandidateKey:      options.CandidateKey,
 			CandidateRevision: candidate.Revision,
@@ -286,7 +288,8 @@ func RunDev(
 		}
 		if err := checkpoints.SaveObjectIdentity("candidate", candidate.ID, DeliveryObjectCheckpoint{
 			ProjectID: candidate.ProjectID.String(), TargetOrigin: credentials.Target,
-			TargetID: candidate.TargetID, Environment: candidate.Environment,
+			TargetSelector: targetSelector,
+			TargetID:       candidate.TargetID, Environment: candidate.Environment,
 		}); err != nil {
 			return fmt.Errorf("persist candidate identity: %w", err)
 		}

--- a/internal/project/cli/publish_command.go
+++ b/internal/project/cli/publish_command.go
@@ -107,13 +107,16 @@ func RunPublish(
 		options.ProjectID = identity.ProjectID
 	}
 	if strings.TrimSpace(options.Credentials.Target) == "" {
-		options.Credentials.Target = identity.TargetOrigin
+		options.Credentials.Target = identity.TargetSelector
+		if strings.TrimSpace(options.Credentials.Target) == "" {
+			options.Credentials.Target = identity.TargetOrigin
+		}
 	}
 	credentials, err := client.Resolve(ctx, options.Credentials)
 	if err != nil {
 		return err
 	}
-	checkpoint := CandidateCheckpoint{ProjectPath: options.ProjectPath, TargetOrigin: credentials.Target, TargetID: identity.TargetID, Environment: identity.Environment, ProjectID: options.ProjectID, CandidateID: options.CandidateID}
+	checkpoint := CandidateCheckpoint{ProjectPath: options.ProjectPath, TargetOrigin: credentials.Target, TargetSelector: identity.TargetSelector, TargetID: identity.TargetID, Environment: identity.Environment, ProjectID: options.ProjectID, CandidateID: options.CandidateID}
 	if options.CandidateID != "" {
 		checkpoint.CandidateID = options.CandidateID
 	}

--- a/internal/project/cli/publish_command_test.go
+++ b/internal/project/cli/publish_command_test.go
@@ -82,6 +82,37 @@ func TestCandidateCheckpointStoreRefusesReadModifyWriteWhileAnotherProcessOwnsLo
 	}
 }
 
+func TestPlanCheckpointBuildOperationBindingIsStableAndRotatable(t *testing.T) {
+	store := NewCandidateCheckpointStore(filepath.Join(t.TempDir(), "authoring.json"))
+	plan := DeliveryPlanCheckpoint{PlanID: "plan-1", ProjectID: "project-1", PlanDigest: "sha256:plan"}
+	if err := store.SavePlan(plan); err != nil {
+		t.Fatal(err)
+	}
+	first, err := store.BindPlanBuildIdempotencyKey(plan.PlanID, "", "build-1")
+	if err != nil || first != "build-1" {
+		t.Fatalf("first binding = %q, err = %v", first, err)
+	}
+	stable, err := store.BindPlanBuildIdempotencyKey(plan.PlanID, "", "build-other")
+	if err != nil || stable != first {
+		t.Fatalf("stable binding = %q, err = %v", stable, err)
+	}
+	if err := store.SavePlan(plan); err != nil {
+		t.Fatal(err)
+	}
+	preserved, err := store.LoadPlan(plan.PlanID)
+	if err != nil || preserved.BuildIdempotencyKey != first {
+		t.Fatalf("preserved plan = %#v, err = %v", preserved, err)
+	}
+	rotated, err := store.BindPlanBuildIdempotencyKey(plan.PlanID, first, "build-2")
+	if err != nil || rotated != "build-2" {
+		t.Fatalf("rotated binding = %q, err = %v", rotated, err)
+	}
+	concurrent, err := store.BindPlanBuildIdempotencyKey(plan.PlanID, first, "build-stale")
+	if err != nil || concurrent != rotated {
+		t.Fatalf("stale rotation = %q, err = %v", concurrent, err)
+	}
+}
+
 func TestCandidateCheckpointStoreIsolatesStableAuthoringKeys(t *testing.T) {
 	store := NewCandidateCheckpointStore(
 		filepath.Join(t.TempDir(), "authoring.json"),

--- a/internal/release/module/candidate_artifacts.go
+++ b/internal/release/module/candidate_artifacts.go
@@ -50,6 +50,13 @@ type candidateGenerationBase struct {
 	active          bool
 }
 
+func planCandidateProject(projectPath string, base candidateGenerationBase) (projectcompiler.ProjectPlan, error) {
+	if base.active {
+		return projectcompiler.PlanProjectAgainstArtifact(projectPath, base.artifact)
+	}
+	return projectcompiler.PlanProjectAgainstGraph(projectPath, projectgraph.ProjectGraph{})
+}
+
 // InspectCandidateArtifacts is the plan-phase, read-only half of candidate
 // preparation. It compiles the retained source, computes graph impact against
 // the exact active base, resolves managed-data pins, and derives authorization
@@ -76,10 +83,6 @@ func (service *candidateArtifactService) InspectCandidateArtifacts(ctx context.C
 		}
 		return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
 	}
-	plan, err := projectcompiler.PlanProject(request.Source.ProjectPath)
-	if err != nil {
-		return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
-	}
 	baseIdentity, err := request.Scope.BaseIdentity()
 	if err != nil {
 		return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
@@ -88,11 +91,9 @@ func (service *candidateArtifactService) InspectCandidateArtifacts(ctx context.C
 	if err != nil {
 		return release.CandidateArtifactSet{}, err
 	}
-	if base.active {
-		plan, err = projectcompiler.PlanProjectAgainstArtifact(request.Source.ProjectPath, base.artifact)
-		if err != nil {
-			return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
-		}
+	plan, err := planCandidateProject(request.Source.ProjectPath, base)
+	if err != nil {
+		return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
 	}
 	activations, err := compiledProject.ConnectionActivations()
 	if err != nil {
@@ -426,10 +427,6 @@ func (service *candidateArtifactService) prepare(ctx context.Context, request re
 		}
 		return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
 	}
-	plan, err := projectcompiler.PlanProject(request.Source.ProjectPath)
-	if err != nil {
-		return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
-	}
 	projectID := request.Scope.ProjectID
 	environment := servingstate.Environment(request.Scope.Environment)
 	baseIdentity, identityErr := request.Scope.BaseIdentity()
@@ -440,11 +437,9 @@ func (service *candidateArtifactService) prepare(ctx context.Context, request re
 	if err != nil {
 		return release.CandidateArtifactSet{}, err
 	}
-	if base.active {
-		plan, err = projectcompiler.PlanProjectAgainstArtifact(request.Source.ProjectPath, base.artifact)
-		if err != nil {
-			return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
-		}
+	plan, err := planCandidateProject(request.Source.ProjectPath, base)
+	if err != nil {
+		return release.CandidateArtifactSet{}, candidateArtifactInvalid(err)
 	}
 	activations, err := compiledProject.ConnectionActivations()
 	if err != nil {


### PR DESCRIPTION
## Summary

- acquire workload admission for canonical `plan -> build` candidate preparation
- calculate fresh-target plan impact against an empty graph so bootstrap additions are visible and materialization evidence stays stable
- retain the original non-secret target profile selector across plan, build, publish, and rollback checkpoints
- give each explicit `plan` invocation a fresh operation identity so replanning creates new review evidence instead of resurrecting an incompatible durable plan
- persist each plan build operation key for lost-response/sealed replay, and atomically rotate it when the target proves a failed pre-seal attempt is no longer replayable
- add a DuckDB-backed real-application integration test for plan, explicit replan, build, sealed replay, and publish
- keep the workflow CLI-only; no UI surface is required

## Verification

- real process: managed-data sync -> fresh plan (27 additions, 46 downstream effects) -> build -> exact sealed replay -> publish revision 1
- `go test -tags=duckdb_arrow ./internal/app/cli ./internal/project/cli -count=1 -timeout=15m`
- `go test -tags=duckdb_arrow ./internal/app/cli -run "^TestPlanBuildPublishCommandsCompleteAgainstRealApplication$" -count=3 -timeout=15m`
- `go test -race -tags=duckdb_arrow ./internal/app/cli ./internal/project/cli -run "^(TestDeliveryPlanInvocationsUseFreshOperationKeys|TestDeliveryBuildRotatesPoisonedOperationKeyAndRetries|TestPlanBuildPublishCommandsCompleteAgainstRealApplication|TestPlanCheckpointBuildOperationBindingIsStableAndRotatable)$" -count=1 -timeout=15m`
- `task ci`
- `task ci:full:extras` (desktop, vet, race, fuzz/bench, 13-route browser QA, Docker/Terraform deployment, MinIO/DuckLake, and plan-to-GC conformance)