### PR TITLE
Reject dashboard layouts with empty rows

### DIFF
--- a/dashboards/dashboards/executive-sales.yaml
+++ b/dashboards/dashboards/executive-sales.yaml
@@ -155,7 +155,7 @@ spec:
     - id: total-orders
       placement:
         column: 1
-        row: 4
+        row: 3
         columnSpan: 4
         rowSpan: 3
       type: visual
@@ -163,7 +163,7 @@ spec:
     - id: revenue
       placement:
         column: 5
-        row: 4
+        row: 3
         columnSpan: 4
         rowSpan: 3
       type: visual
@@ -171,7 +171,7 @@ spec:
     - id: aov
       placement:
         column: 9
-        row: 4
+        row: 3
         columnSpan: 4
         rowSpan: 3
       type: visual
@@ -179,7 +179,7 @@ spec:
     - id: revenue-trend
       placement:
         column: 1
-        row: 8
+        row: 6
         columnSpan: 12
         rowSpan: 6
       type: visual
@@ -187,7 +187,7 @@ spec:
     - id: categories
       placement:
         column: 1
-        row: 14
+        row: 12
         columnSpan: 12
         rowSpan: 6
       type: visual
@@ -195,7 +195,7 @@ spec:
     - id: orders_table
       placement:
         column: 1
-        row: 21
+        row: 18
         columnSpan: 12
         rowSpan: 8
       type: visual

--- a/dashboards/dashboards/fulfillment-operations.yaml
+++ b/dashboards/dashboards/fulfillment-operations.yaml
@@ -150,7 +150,7 @@ spec:
     - id: total-orders
       placement:
         column: 1
-        row: 4
+        row: 3
         columnSpan: 4
         rowSpan: 3
       type: visual
@@ -158,7 +158,7 @@ spec:
     - id: delivery-days
       placement:
         column: 5
-        row: 4
+        row: 3
         columnSpan: 4
         rowSpan: 3
       type: visual
@@ -166,7 +166,7 @@ spec:
     - id: review-score
       placement:
         column: 9
-        row: 4
+        row: 3
         columnSpan: 4
         rowSpan: 3
       type: visual
@@ -174,7 +174,7 @@ spec:
     - id: status
       placement:
         column: 1
-        row: 8
+        row: 6
         columnSpan: 4
         rowSpan: 6
       type: visual
@@ -182,7 +182,7 @@ spec:
     - id: delivery-speed
       placement:
         column: 5
-        row: 8
+        row: 6
         columnSpan: 4
         rowSpan: 6
       type: visual
@@ -190,7 +190,7 @@ spec:
     - id: reviews
       placement:
         column: 9
-        row: 8
+        row: 6
         columnSpan: 4
         rowSpan: 6
       type: visual

--- a/dashboards/experiments/movielens/dashboards/genre-analysis.yaml
+++ b/dashboards/experiments/movielens/dashboards/genre-analysis.yaml
@@ -178,7 +178,7 @@ spec:
     - id: genre-ratings
       placement:
         column: 1
-        row: 4
+        row: 3
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -186,7 +186,7 @@ spec:
     - id: average-rating
       placement:
         column: 4
-        row: 4
+        row: 3
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -194,7 +194,7 @@ spec:
     - id: active-users
       placement:
         column: 7
-        row: 4
+        row: 3
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -202,7 +202,7 @@ spec:
     - id: rated-movies
       placement:
         column: 10
-        row: 4
+        row: 3
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -210,7 +210,7 @@ spec:
     - id: ratings-by-genre
       placement:
         column: 1
-        row: 8
+        row: 6
         columnSpan: 6
         rowSpan: 7
       type: visual
@@ -218,7 +218,7 @@ spec:
     - id: average-by-genre
       placement:
         column: 7
-        row: 8
+        row: 6
         columnSpan: 6
         rowSpan: 7
       type: visual
@@ -226,7 +226,7 @@ spec:
     - id: genre-trend
       placement:
         column: 1
-        row: 16
+        row: 13
         columnSpan: 6
         rowSpan: 7
       type: visual
@@ -234,7 +234,7 @@ spec:
     - id: decade-genres
       placement:
         column: 7
-        row: 16
+        row: 13
         columnSpan: 6
         rowSpan: 7
       type: visual

--- a/dashboards/experiments/movielens/dashboards/ratings-overview.yaml
+++ b/dashboards/experiments/movielens/dashboards/ratings-overview.yaml
@@ -255,7 +255,7 @@ spec:
     - id: rating-count
       placement:
         column: 1
-        row: 4
+        row: 3
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -263,7 +263,7 @@ spec:
     - id: average-rating
       placement:
         column: 4
-        row: 4
+        row: 3
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -271,7 +271,7 @@ spec:
     - id: active-users
       placement:
         column: 7
-        row: 4
+        row: 3
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -279,7 +279,7 @@ spec:
     - id: rated-movies
       placement:
         column: 10
-        row: 4
+        row: 3
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -287,7 +287,7 @@ spec:
     - id: ratings-trend
       placement:
         column: 1
-        row: 8
+        row: 6
         columnSpan: 8
         rowSpan: 6
       type: visual
@@ -295,7 +295,7 @@ spec:
     - id: rating-distribution
       placement:
         column: 9
-        row: 8
+        row: 6
         columnSpan: 4
         rowSpan: 6
       type: visual
@@ -303,7 +303,7 @@ spec:
     - id: top-movies
       placement:
         column: 1
-        row: 15
+        row: 12
         columnSpan: 6
         rowSpan: 7
       type: visual
@@ -311,7 +311,7 @@ spec:
     - id: decade-average
       placement:
         column: 7
-        row: 15
+        row: 12
         columnSpan: 6
         rowSpan: 7
       type: visual
@@ -319,7 +319,7 @@ spec:
     - id: movie-table
       placement:
         column: 1
-        row: 23
+        row: 19
         columnSpan: 12
         rowSpan: 8
       type: visual
@@ -327,7 +327,7 @@ spec:
     - id: tags-per-rating
       placement:
         column: 1
-        row: 32
+        row: 27
         columnSpan: 3
         rowSpan: 3
       type: visual
@@ -335,7 +335,7 @@ spec:
     - id: activity-by-month
       placement:
         column: 4
-        row: 32
+        row: 27
         columnSpan: 9
         rowSpan: 7
       type: visual
@@ -343,7 +343,7 @@ spec:
     - id: tags-per-rating-by-decade
       placement:
         column: 1
-        row: 40
+        row: 34
         columnSpan: 12
         rowSpan: 7
       type: visual

--- a/docs/articles/build/pages-layout.md
+++ b/docs/articles/build/pages-layout.md
@@ -50,12 +50,12 @@ components:
   - id: order-details
     type: visual
     visual: orders-table
-    placement: {column: 1, row: 10, columnSpan: 12, rowSpan: 8}
+    placement: {column: 1, row: 9, columnSpan: 12, rowSpan: 8}
 ```
 
 Use `type: visual` for charts, KPIs, tables, matrices, and pivots. Use `type: filter` for an on-page filter presentation and `type: header` for headings. A filter component references the dashboard filter ID; it does not define a second predicate system.
 
-Coordinates are one-based. Keep `column + columnSpan - 1` within the configured column count and avoid accidental overlaps.
+Coordinates are one-based. Keep `column + columnSpan - 1` within the configured column count and avoid accidental overlaps. Every grid row through the last component must contain part of a component; a fully empty row creates an oversized horizontal band and is rejected during compilation and publishing.
 
 ### Design reading order
 

--- a/evaluation/project/dashboards/sales-overview.yaml
+++ b/evaluation/project/dashboards/sales-overview.yaml
@@ -121,7 +121,7 @@ spec:
     - id: total-orders
       placement:
         column: 1
-        row: 4
+        row: 3
         columnSpan: 6
         rowSpan: 3
       type: visual
@@ -129,7 +129,7 @@ spec:
     - id: revenue
       placement:
         column: 7
-        row: 4
+        row: 3
         columnSpan: 6
         rowSpan: 3
       type: visual
@@ -137,7 +137,7 @@ spec:
     - id: categories
       placement:
         column: 1
-        row: 8
+        row: 6
         columnSpan: 12
         rowSpan: 6
       type: visual
@@ -145,7 +145,7 @@ spec:
     - id: orders
       placement:
         column: 1
-        row: 15
+        row: 12
         columnSpan: 12
         rowSpan: 8
       type: visual

--- a/internal/app/tools/visualdocgen/main.go
+++ b/internal/app/tools/visualdocgen/main.go
@@ -1144,7 +1144,7 @@ func buildExampleDashboard(catalog visualCatalog, examplesByPage map[string][]vi
 		for index, example := range examplesByPage[document.Source] {
 			report.Spec.Visuals[example.ID] = example.Visual
 			page.Components = append(page.Components, dashboarddocument.DashboardPageComponent{Value: &dashboarddocument.VisualDashboardPageComponent{
-				DashboardPageComponentBase: dashboarddocument.DashboardPageComponentBase{ID: example.ID, Type: "visual", Placement: dashboarddocument.DashboardPlacement{Column: 1, Row: int32(1 + index*8), ColumnSpan: 6, RowSpan: 7}},
+				DashboardPageComponentBase: dashboarddocument.DashboardPageComponentBase{ID: example.ID, Type: "visual", Placement: dashboarddocument.DashboardPlacement{Column: 1, Row: int32(1 + index*7), ColumnSpan: 6, RowSpan: 7}},
 				Type:                       "visual", Visual: example.ID,
 			}})
 		}

--- a/internal/dashboard/compiler/dashboard_layout_canonical.go
+++ b/internal/dashboard/compiler/dashboard_layout_canonical.go
@@ -7,6 +7,7 @@ package compiler
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/flidai/leapview/internal/dashboard"
 	"github.com/flidai/leapview/internal/dashboard/definition"
@@ -158,6 +159,9 @@ func CompileDashboardPageLayout(page document.DashboardPage, defaults definition
 			occupiedRows = occupied
 		}
 	}
+	if err := validateCanonicalRowContinuity(compiled.Visuals); err != nil {
+		return dashboard.Page{}, err
+	}
 	compiled.ResponsiveLayout.OccupiedRows = occupiedRows
 	if occupiedRows == 0 {
 		compiled.Height = resolved.Padding * 2
@@ -165,6 +169,43 @@ func CompileDashboardPageLayout(page document.DashboardPage, defaults definition
 		compiled.Height = resolved.Padding*2 + occupiedRows*resolved.RowHeight + (occupiedRows-1)*resolved.Gap
 	}
 	return compiled, nil
+}
+
+func validateCanonicalRowContinuity(visuals []dashboard.PageVisual) error {
+	if len(visuals) == 0 {
+		return nil
+	}
+	type rowInterval struct {
+		start int
+		end   int
+	}
+	intervals := make([]rowInterval, 0, len(visuals))
+	for _, visual := range visuals {
+		intervals = append(intervals, rowInterval{
+			start: visual.Placement.Row,
+			end:   visual.Placement.Row + visual.Placement.RowSpan - 1,
+		})
+	}
+	sort.Slice(intervals, func(i, j int) bool {
+		if intervals[i].start == intervals[j].start {
+			return intervals[i].end < intervals[j].end
+		}
+		return intervals[i].start < intervals[j].start
+	})
+	coveredThrough := 0
+	for _, interval := range intervals {
+		if interval.start > coveredThrough+1 {
+			emptyStart, emptyEnd := coveredThrough+1, interval.start-1
+			if emptyStart == emptyEnd {
+				return fmt.Errorf("grid row %d is empty before component row %d; placements must not leave empty rows", emptyStart, interval.start)
+			}
+			return fmt.Errorf("grid rows %d..%d are empty before component row %d; placements must not leave empty rows", emptyStart, emptyEnd, interval.start)
+		}
+		if interval.end > coveredThrough {
+			coveredThrough = interval.end
+		}
+	}
+	return nil
 }
 
 // CompileCanonicalDashboardPageLayout accepts generated defaults for callers

--- a/internal/dashboard/compiler/dashboard_layout_canonical_test.go
+++ b/internal/dashboard/compiler/dashboard_layout_canonical_test.go
@@ -26,7 +26,7 @@ func TestCompileDashboardLayoutUsesDefaultsAndDerivesHeight(t *testing.T) {
 		ID: "overview", Title: "Overview",
 		Components: []document.DashboardPageComponent{
 			canonicalVisualComponent("first", "revenue", canonicalPlacement(1, 1, 6, 2)),
-			canonicalVisualComponent("second", "orders", canonicalPlacement(7, 4, 6, 3)),
+			canonicalVisualComponent("second", "orders", canonicalPlacement(7, 3, 6, 3)),
 		},
 	}}}
 	layout, err := CompileDashboardLayout(spec)
@@ -37,10 +37,10 @@ func TestCompileDashboardLayoutUsesDefaultsAndDerivesHeight(t *testing.T) {
 		t.Fatalf("defaults = %#v, want %#v", got, want)
 	}
 	page := layout.Pages[0]
-	if page.ResponsiveLayout.OccupiedRows != 6 {
-		t.Fatalf("occupied rows = %d, want 6", page.ResponsiveLayout.OccupiedRows)
+	if page.ResponsiveLayout.OccupiedRows != 5 {
+		t.Fatalf("occupied rows = %d, want 5", page.ResponsiveLayout.OccupiedRows)
 	}
-	if got, want := page.Height, 16*2+6*48+5*16; got != want {
+	if got, want := page.Height, 16*2+5*48+4*16; got != want {
 		t.Fatalf("height = %d, want %d", got, want)
 	}
 	if page.Canvas.Width != 0 || page.Canvas.Height != 0 || page.Visuals[1].X != 0 || page.Visuals[1].Y != 0 || page.Visuals[1].Width != 0 || page.Visuals[1].Height != 0 {
@@ -64,7 +64,7 @@ func TestCompileDashboardLayoutAppliesPageOverrides(t *testing.T) {
 		Pages: []document.DashboardPage{{
 			ID: "detail", Title: "Detail",
 			Layout:     &document.DashboardLayoutOverride{Columns: &columns, RowHeight: &rowHeight, Gap: &gap, Padding: &padding},
-			Components: []document.DashboardPageComponent{canonicalVisualComponent("card", "orders", canonicalPlacement(8, 2, 1, 1))},
+			Components: []document.DashboardPageComponent{canonicalVisualComponent("card", "orders", canonicalPlacement(8, 1, 1, 1))},
 		}},
 	}
 	layout, err := CompileDashboardLayout(spec)
@@ -75,8 +75,8 @@ func TestCompileDashboardLayoutAppliesPageOverrides(t *testing.T) {
 	if page.Grid != (dashboard.PageGrid{Columns: 8, RowHeight: 24, Gap: 4, Padding: 10}) {
 		t.Fatalf("page override = %#v", page.Grid)
 	}
-	if page.Height != 10*2+2*24+4 {
-		t.Fatalf("height = %d, want %d", page.Height, 10*2+2*24+4)
+	if page.Height != 10*2+24 {
+		t.Fatalf("height = %d, want %d", page.Height, 10*2+24)
 	}
 }
 
@@ -117,6 +117,14 @@ func TestCompileDashboardLayoutRejectsInvalidPlacements(t *testing.T) {
 				canonicalVisualComponent("two", "orders", canonicalPlacement(4, 2, 4, 2)),
 			}}},
 			want: "overlap",
+		},
+		{
+			name: "empty grid row",
+			pages: []document.DashboardPage{{ID: "overview", Components: []document.DashboardPageComponent{
+				canonicalVisualComponent("one", "revenue", canonicalPlacement(1, 1, 12, 2)),
+				canonicalVisualComponent("two", "orders", canonicalPlacement(1, 4, 12, 2)),
+			}}},
+			want: "grid row 3 is empty",
 		},
 	}
 	for _, test := range cases {


### PR DESCRIPTION
## Summary

- reject dashboard pages that leave fully empty grid rows before their final component
- compact Executive Sales and every other checked-in dashboard fixture using the old spacer-row pattern
- keep generated visual documentation layouts contiguous and document the publishing rule

## Validation

- `go test ./internal/dashboard/compiler`
- `go test -tags=duckdb_arrow ./internal/project/compiler ./internal/app/tools/visualdocgen`
- `task generated:check`
- `task ci`