### PR TITLE
fix: harden post-merge build and desktop proofs

### DIFF
--- a/.github/actions/desktop-preview-candidate/action.yml
+++ b/.github/actions/desktop-preview-candidate/action.yml
@@ -66,7 +66,8 @@ runs:
       shell: bash
       run: |
         executable="$(find desktop/out -path '*/LeapView.app/Contents/MacOS/LeapView' -print -quit)"
-        LEAPVIEW_PACKAGED_APP="$executable" go test -count=1 \
+        test -n "$executable"
+        LEAPVIEW_PACKAGED_APP="$GITHUB_WORKSPACE/$executable" go test -count=1 \
           -run TestPackagedLeapViewPreservesRemoteContentBoundary \
           -v ./internal/app/testing/maliciousinstance
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS web
 WORKDIR /src
 
+COPY --from=go-deps /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 COPY package.json bun.lock tsconfig.json ./
 COPY scripts ./scripts
 COPY static ./static

--- a/desktop/scripts/workflow-contract.test.mjs
+++ b/desktop/scripts/workflow-contract.test.mjs
@@ -43,6 +43,7 @@ test("desktop workflow builds and qualifies both native macOS architectures", as
   for (const required of [
     "TestPackagedLeapViewPreservesRemoteContentBoundary",
     "runner.os == 'macOS'",
+    'LEAPVIEW_PACKAGED_APP="$GITHUB_WORKSPACE/$executable"',
     "runner.os == 'Windows'",
     "runner.os == 'Linux'",
   ]) {

--- a/desktop/src/remote-window.test.ts
+++ b/desktop/src/remote-window.test.ts
@@ -71,6 +71,8 @@ describe("createRemoteWindow", () => {
       new URL("./main.ts", import.meta.url),
       "utf8",
     );
-    expect(entrypoint).toBe('import "./application.js";\n');
+    expect(entrypoint.replace(/\r\n?/gu, "\n")).toBe(
+      'import "./application.js";\n',
+    );
   });
 });

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2383,6 +2383,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"go run ./internal/app/tools/openapidocgen",
 		"go run ./internal/app/tools/docsitegen",
 		"FROM oven/bun:1.3.14@sha256:",
+		"COPY --from=go-deps /usr/local/go/bin/gofmt /usr/local/bin/gofmt",
 		"COPY --from=sourcegen /src/api/gen ./api/gen",
 		"COPY --from=sourcegen /src/api/visualization ./api/visualization",
 		"COPY --from=sourcegen /src/web/generated ./web/generated",


### PR DESCRIPTION
Fixes the post-merge CI failures observed after #324 landed:

- make `gofmt` available in the production image web build stage
- pass an absolute macOS packaged-app path to the Go hostile-instance proof
- normalize Windows line endings in the desktop entrypoint contract

Focused desktop, workflow-contract, and architecture tests pass locally.