### PR TITLE
fix: accept Windows desktop distribution markers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
       -X github.com/flidai/leapview/internal/platform/buildinfo.dirty=${BUILD_DIRTY} \
       -X github.com/flidai/leapview/internal/platform/buildinfo.release=${BUILD_RELEASE}" && \
     CGO_ENABLED=1 go build -tags=duckdb_arrow -trimpath -ldflags="$BUILD_LDFLAGS" -o /out/leapview ./cmd/leapview && \
-    CGO_ENABLED=0 go build -trimpath -ldflags="$BUILD_LDFLAGS" -o /out/leapviewctl ./cmd/leapviewctl
+    CGO_ENABLED=1 go build -tags=duckdb_arrow -trimpath -ldflags="$BUILD_LDFLAGS" -o /out/leapviewctl ./cmd/leapviewctl
 
 # The production image carries a complete, target-native, offline extension
 # supply. This stage performs the only upstream acquisition during packaging;

--- a/desktop/scripts/verify-package.mjs
+++ b/desktop/scripts/verify-package.mjs
@@ -101,10 +101,10 @@ const distributionMarkers = {
   },
 };
 const expectedDistribution = distributionMarkers[packagedDistribution];
-const marker = await readFile(
+const marker = (await readFile(
   join(resources, expectedDistribution.filename),
   "utf8",
-);
+)).replace(/\r\n?/gu, "\n");
 if (marker !== expectedDistribution.contents) {
   throw new Error(
     `packaged ${packagedDistribution} distribution marker is invalid`,

--- a/desktop/src/distribution.test.ts
+++ b/desktop/src/distribution.test.ts
@@ -42,6 +42,23 @@ describe("resolveDesktopDistribution", () => {
     ).toBe("preview");
   });
 
+  test("recognizes packaged markers checked out with Windows line endings", () => {
+    expect(
+      resolveDesktopDistribution({
+        packaged: true,
+        resourcesPath: "/application/resources",
+        readFile: (path) => {
+          if (path.endsWith(PREVIEW_DISTRIBUTION_MARKER)) {
+            return '{"schemaVersion":1,"channel":"preview","updates":false}\r\n';
+          }
+          const error = new Error("missing") as NodeJS.ErrnoException;
+          error.code = "ENOENT";
+          throw error;
+        },
+      }),
+    ).toBe("preview");
+  });
+
   test("recognizes only the exact packaged stable marker", () => {
     expect(
       resolveDesktopDistribution({

--- a/desktop/src/distribution.ts
+++ b/desktop/src/distribution.ts
@@ -48,7 +48,7 @@ function readMarker(
   path: string,
 ): string | undefined | null {
   try {
-    return readFile(path);
+    return readFile(path).replace(/\r\n?/gu, "\n");
   } catch (error) {
     return error instanceof Error &&
         "code" in error &&

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2412,6 +2412,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 		"COPY --from=web /src/internal/dashboard/appearance/icons_gen.go ./internal/dashboard/appearance/icons_gen.go",
 		"COPY --from=sourcegen /src/docs ./docs",
 		"CGO_ENABLED=1 go build",
+		"CGO_ENABLED=1 go build -tags=duckdb_arrow -trimpath -ldflags=\"$BUILD_LDFLAGS\" -o /out/leapviewctl ./cmd/leapviewctl",
 		"FROM debian:bookworm-slim@sha256:",
 		"USER leapview",
 		"WORKDIR /app",


### PR DESCRIPTION
Fixes the remaining Windows post-merge packaging failure in #326.

Git for Windows can check out the packaged distribution marker with CRLF line endings, while verification and runtime distribution detection required LF exactly. Normalize line endings at both boundaries and add a regression test.