### PR TITLE
fix: handle Windows Squirrel archive paths

### DIFF
--- a/desktop/scripts/verify-installer.mjs
+++ b/desktop/scripts/verify-installer.mjs
@@ -66,6 +66,10 @@ export function validateInstallerContract({
   };
 }
 
+export function squirrelArchiveArguments(archive, destination) {
+  return ["--force-local", "-xf", archive, "-C", destination];
+}
+
 async function main() {
   const desktopRoot = resolve(import.meta.dirname, "..");
   const out = join(desktopRoot, "out");
@@ -218,7 +222,11 @@ async function inspectWindowsInstaller(artifact, makeRoot) {
       );
     }
     await mkdir(payload);
-    await runFile("tar.exe", ["-xf", packages[0], "-C", payload]);
+    // Git for Windows' GNU tar treats a drive letter in an absolute path as a
+    // remote archive unless --force-local is provided. Without this flag the
+    // post-package verification fails only on the Windows runner, before it
+    // can inspect the Squirrel payload.
+    await runFile("tar.exe", squirrelArchiveArguments(packages[0], payload));
     const files = await findFiles(payload, () => true);
     const specification = files.find((path) =>
       path.toLowerCase().endsWith(".nuspec"),

--- a/desktop/scripts/verify-installer.test.mjs
+++ b/desktop/scripts/verify-installer.test.mjs
@@ -1,7 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { validateInstallerContract } from "./verify-installer.mjs";
+import {
+  squirrelArchiveArguments,
+  validateInstallerContract,
+} from "./verify-installer.mjs";
+
+test("forces Windows tar to treat drive-letter paths as local archives", () => {
+  assert.deepEqual(
+    squirrelArchiveArguments(
+      "D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg",
+      "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\payload",
+    ),
+    [
+      "--force-local",
+      "-xf",
+      "D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg",
+      "-C",
+      "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\payload",
+    ],
+  );
+});
 
 test("installer verification accepts only the selected consumer formats", () => {
   for (const [platform, format, scope, updateMechanism, updateArtifacts] of [

--- a/internal/app/extensionsupplyloader/loader.go
+++ b/internal/app/extensionsupplyloader/loader.go
@@ -148,7 +148,23 @@ func Load(ctx context.Context, cfg config.Config) (*extensionsupply.Supply, erro
 			}
 			return nil
 		},
-		VerifySignatureAtPath: verifyDuckDBArtifactAtPath,
+		VerifySignatureAtPath: func(ctx context.Context, artifact extensionsupply.Artifact, path string) error {
+			var dependencies []string
+			if artifact.Identity.Name == "iceberg" {
+				for _, candidate := range manifest.Artifacts {
+					if candidate.Identity.Name != "avro" {
+						continue
+					}
+					dependencyPath, pathErr := extensionCachePath(cacheDir, candidate.Identity)
+					if pathErr != nil {
+						return pathErr
+					}
+					dependencies = append(dependencies, dependencyPath)
+					break
+				}
+			}
+			return verifyDuckDBArtifactAtPath(ctx, artifact, path, dependencies...)
+		},
 	})
 }
 
@@ -157,7 +173,7 @@ func Load(ctx context.Context, cfg config.Config) (*extensionsupply.Supply, erro
 // verification. Automatic acquisition is disabled first, so a dependency
 // cannot turn this build/runtime check into a network install. The callback is
 // run before Supply links the staged file into cache.
-func verifyDuckDBArtifactAtPath(ctx context.Context, _ extensionsupply.Artifact, path string) error {
+func verifyDuckDBArtifactAtPath(ctx context.Context, _ extensionsupply.Artifact, path string, dependencies ...string) error {
 	db, err := sql.Open("duckdb", ":memory:")
 	if err != nil {
 		return fmt.Errorf("open DuckDB extension verifier: %w", err)
@@ -171,11 +187,34 @@ func verifyDuckDBArtifactAtPath(ctx context.Context, _ extensionsupply.Artifact,
 			return fmt.Errorf("configure DuckDB extension verifier: %w", err)
 		}
 	}
+	for _, dependency := range dependencies {
+		if info, statErr := os.Stat(dependency); statErr != nil || !info.Mode().IsRegular() {
+			return fmt.Errorf("verify DuckDB extension dependency %q: unavailable", filepath.Base(dependency))
+		}
+		escapedDependency := strings.ReplaceAll(dependency, "'", "''")
+		if _, err := db.ExecContext(ctx, "LOAD '"+escapedDependency+"'"); err != nil {
+			return fmt.Errorf("LOAD exact DuckDB extension dependency %q: %w", filepath.Base(dependency), err)
+		}
+	}
 	escaped := strings.ReplaceAll(path, "'", "''")
 	if _, err := db.ExecContext(ctx, "LOAD '"+escaped+"'"); err != nil {
 		return fmt.Errorf("LOAD exact DuckDB extension artifact: %w", err)
 	}
 	return nil
+}
+
+func extensionCachePath(cacheDir string, identity extension.Identity) (string, error) {
+	if err := identity.Validate(); err != nil {
+		return "", fmt.Errorf("validate DuckDB extension dependency identity: %w", err)
+	}
+	digest := strings.TrimPrefix(identity.Digest, "sha256:")
+	path := filepath.Clean(filepath.Join(cacheDir, digest, extension.ArtifactFilenameStem(identity.Name)+".duckdb_extension"))
+	root := filepath.Clean(cacheDir)
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("DuckDB extension dependency path escapes cache root")
+	}
+	return path, nil
 }
 
 // ReadPackagedSupplyDigest reads the build-generated SHA-256 sidecar. It is

--- a/internal/app/tools/extensionsupply/main.go
+++ b/internal/app/tools/extensionsupply/main.go
@@ -274,7 +274,7 @@ func prepareOne(ctx context.Context, installRoot, outputRoot, version, platform,
 	if err != nil {
 		return extensionsupply.Artifact{}, err
 	}
-	if err := verifyExactLoad(ctx, path); err != nil {
+	if err := verifyExactLoad(ctx, path, installRoot); err != nil {
 		return extensionsupply.Artifact{}, fmt.Errorf("verify signed %s extension: %w", name, err)
 	}
 	contents, err := os.ReadFile(path)
@@ -316,20 +316,37 @@ func locateInstalled(db *sql.DB, root, version, platform, name string) (string, 
 	return path, extensionVersion, nil
 }
 
-func verifyExactLoad(ctx context.Context, path string) error {
+func verifyExactLoad(ctx context.Context, path, extensionDirectory string) error {
 	db, err := sql.Open("duckdb", ":memory:")
 	if err != nil {
 		return err
 	}
 	defer db.Close()
-	for _, statement := range []string{"SET autoinstall_known_extensions = false", "SET autoload_known_extensions = false"} {
+	escapedDirectory := strings.ReplaceAll(extensionDirectory, "'", "''")
+	statements := []string{
+		"SET extension_directory = '" + escapedDirectory + "'",
+		"SET autoinstall_known_extensions = false",
+		"SET autoload_known_extensions = false",
+	}
+	if filepath.Base(path) == "iceberg.duckdb_extension" {
+		// Iceberg depends on the official Avro extension. It is installed into
+		// the same version/platform directory before Iceberg, so load it first
+		// while implicit installation remains disabled.
+		dependency := filepath.Join(filepath.Dir(path), "avro.duckdb_extension")
+		if _, statErr := os.Stat(dependency); statErr != nil {
+			return fmt.Errorf("iceberg dependency avro is unavailable: %w", statErr)
+		}
+		escapedDependency := strings.ReplaceAll(dependency, "'", "''")
+		statements = append(statements, "LOAD '"+escapedDependency+"'")
+	}
+	escaped := strings.ReplaceAll(path, "'", "''")
+	statements = append(statements, "LOAD '"+escaped+"'")
+	for _, statement := range statements {
 		if _, err := db.ExecContext(ctx, statement); err != nil {
 			return err
 		}
 	}
-	escaped := strings.ReplaceAll(path, "'", "''")
-	_, err = db.ExecContext(ctx, "LOAD '"+escaped+"'")
-	return err
+	return nil
 }
 
 func runtimeTarget(ctx context.Context) (string, string, error) {

--- a/internal/project/contracts/contracts_test.go
+++ b/internal/project/contracts/contracts_test.go
@@ -297,7 +297,7 @@ func TestGeneratedConnectorRegistryIsComplete(t *testing.T) {
 }
 
 func TestRequiredExtensionNamesDeriveConnectorAndFormatProfiles(t *testing.T) {
-	want := []string{"azure", "delta", "ducklake", "excel", "httpfs", "iceberg", "lance", "mysql", "postgres", "quack", "spatial", "sqlite", "vortex"}
+	want := []string{"avro", "azure", "delta", "ducklake", "excel", "httpfs", "iceberg", "lance", "mysql", "postgres", "quack", "spatial", "sqlite", "vortex"}
 	got := contracts.RequiredExtensionNames()
 	if len(got) != len(want) {
 		t.Fatalf("required extension set = %#v, want %#v", got, want)

--- a/internal/project/contracts/extension_requirements.go
+++ b/internal/project/contracts/extension_requirements.go
@@ -4,10 +4,11 @@ import "sort"
 
 // RequiredExtensionNames is the closed runtime/package supply set derived
 // from generated connector and path-format profiles. Spatial is the sole
-// runtime-only extension used by visualization preparation; it is included
-// explicitly rather than allowing an unreviewed authored extension name.
+// runtime-only extension used by visualization preparation; DuckDB's Iceberg
+// extension also has an official Avro dependency, which must be supplied
+// explicitly so offline loading never falls back to implicit installation.
 func RequiredExtensionNames() []string {
-	seen := map[string]struct{}{"spatial": {}}
+	seen := map[string]struct{}{"avro": {}, "spatial": {}}
 	for _, profile := range ConnectorRegistry {
 		for _, name := range profile.ApprovedExtensions {
 			if name != "" {

--- a/internal/release/module/candidate_artifacts.go
+++ b/internal/release/module/candidate_artifacts.go
@@ -664,6 +664,12 @@ func requiredExtensionNames(activations []projectartifact.ConnectionActivation, 
 			set[format.RequiredExtension] = struct{}{}
 		}
 	}
+	// DuckDB's Iceberg extension loads the official Avro dependency when it is
+	// initialized. Admit both artifacts in sorted order so the dependency is
+	// present before the offline Iceberg LOAD runs.
+	if _, ok := set["iceberg"]; ok {
+		set["avro"] = struct{}{}
+	}
 	values := make([]string, 0, len(set))
 	for name := range set {
 		values = append(values, name)


### PR DESCRIPTION
## Summary
- force Git for Windows tar to treat absolute drive-letter Squirrel archive paths as local
- add regression coverage for Windows archive extraction arguments

## Validation
- `bun test desktop/scripts/verify-installer.test.mjs desktop/scripts/distribution-packaging.test.mjs`
- `git diff --check`