### PR TITLE
fix(desktop): use portable nupkg extraction overload

### DIFF
--- a/desktop/scripts/verify-installer.mjs
+++ b/desktop/scripts/verify-installer.mjs
@@ -72,7 +72,7 @@ export function squirrelArchiveArguments(archive, destination) {
     "-NoProfile",
     "-NonInteractive",
     "-Command",
-    `Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory(${quote(archive)}, ${quote(destination)}, $true)`,
+    `Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory(${quote(archive)}, ${quote(destination)})`,
   ];
 }
 

--- a/desktop/scripts/verify-installer.mjs
+++ b/desktop/scripts/verify-installer.mjs
@@ -72,7 +72,7 @@ export function squirrelArchiveArguments(archive, destination) {
     "-NoProfile",
     "-NonInteractive",
     "-Command",
-    `Expand-Archive -LiteralPath ${quote(archive)} -DestinationPath ${quote(destination)} -Force`,
+    `Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory(${quote(archive)}, ${quote(destination)}, $true)`,
   ];
 }
 
@@ -228,9 +228,9 @@ async function inspectWindowsInstaller(artifact, makeRoot) {
       );
     }
     await mkdir(payload);
-    // Squirrel's .nupkg is a ZIP archive, not a tar stream. Use the inbox
-    // PowerShell extractor on Windows so absolute drive-letter paths and the
-    // ZIP format are both handled by a platform-native tool.
+    // Squirrel's .nupkg is a ZIP archive, not a tar stream. Use .NET's ZIP
+    // reader because Expand-Archive rejects the .nupkg extension even though
+    // the payload is a valid ZIP file.
     await runFile(
       "powershell.exe",
       squirrelArchiveArguments(packages[0], payload),

--- a/desktop/scripts/verify-installer.test.mjs
+++ b/desktop/scripts/verify-installer.test.mjs
@@ -6,7 +6,7 @@ import {
   validateInstallerContract,
 } from "./verify-installer.mjs";
 
-test("uses PowerShell ZIP extraction for Windows Squirrel archives", () => {
+test("uses .NET ZIP extraction for Windows Squirrel archives", () => {
   assert.deepEqual(
     squirrelArchiveArguments(
       "D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg",
@@ -16,7 +16,7 @@ test("uses PowerShell ZIP extraction for Windows Squirrel archives", () => {
       "-NoProfile",
       "-NonInteractive",
       "-Command",
-      "Expand-Archive -LiteralPath 'D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg' -DestinationPath 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\payload' -Force",
+      "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg', 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\payload', $true)",
     ],
   );
 });

--- a/desktop/scripts/verify-installer.test.mjs
+++ b/desktop/scripts/verify-installer.test.mjs
@@ -16,7 +16,7 @@ test("uses .NET ZIP extraction for Windows Squirrel archives", () => {
       "-NoProfile",
       "-NonInteractive",
       "-Command",
-      "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg', 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\payload', $true)",
+      "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg', 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\payload')",
     ],
   );
 });

--- a/internal/app/integration_updates_test.go
+++ b/internal/app/integration_updates_test.go
@@ -75,7 +75,18 @@ func TestUpdatesStreamsSetupRequiredPatchForMissingData(t *testing.T) {
 		return setupRequiredMetrics{integrationMetrics: metrics}
 	}))
 
-	patches := h.getUpdatesSignals(t, "executive-sales", "overview", map[string]any{})
+	// The setup-required path performs the first dashboard refresh through the
+	// full runtime harness; give it the same bounded budget as the other
+	// integration stream assertions so cold CI runners do not cancel before
+	// the patch is published.
+	patches := h.getUpdatesSignalsWithQueryTimeout(
+		t,
+		"executive-sales",
+		"overview",
+		map[string]any{},
+		nil,
+		time.Second,
+	)
 
 	requireFirstStatusLoading(t, patches)
 	requirePatch(t, patches, func(patch map[string]any) bool {


### PR DESCRIPTION
The Windows post-merge security proof revealed that the 3-argument .NET ZipFile overload binds to the Encoding overload on the hosted runner, so PowerShell rejects `$true`. Use the two-argument overload; the destination is always a fresh temp directory.

Tests: `bun test desktop/scripts/verify-installer.test.mjs`.