### PR TITLE
fix(desktop): use portable nupkg extraction overload

### DIFF
--- a/desktop/scripts/verify-installer.mjs
+++ b/desktop/scripts/verify-installer.mjs
@@ -72,7 +72,7 @@ export function squirrelArchiveArguments(archive, destination) {
     "-NoProfile",
     "-NonInteractive",
     "-Command",
-    `Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory(${quote(archive)}, ${quote(destination)}, $true)`,
+    `Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory(${quote(archive)}, ${quote(destination)})`,
   ];
 }
 

--- a/desktop/scripts/verify-installer.test.mjs
+++ b/desktop/scripts/verify-installer.test.mjs
@@ -16,7 +16,7 @@ test("uses .NET ZIP extraction for Windows Squirrel archives", () => {
       "-NoProfile",
       "-NonInteractive",
       "-Command",
-      "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg', 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\payload', $true)",
+      "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\\a\\leapview\\leapview\\desktop\\out\\make\\package.nupkg', 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\payload')",
     ],
   );
 });


### PR DESCRIPTION
The Windows post-merge security proof showed that the 3-argument .NET ZipFile overload binds `$true` as `System.Text.Encoding` on the hosted PowerShell runtime. Use the two-argument overload; the destination is always a fresh temp directory.

Tests: `bun test desktop/scripts/verify-installer.test.mjs`.