### PR TITLE
fix(ci): pass exact desktop SBOM to attest

### DIFF
--- a/.github/workflows/electron-security-proof.yml
+++ b/.github/workflows/electron-security-proof.yml
@@ -129,6 +129,14 @@ jobs:
             --sbom "$sbom" \
             "${update_arguments[@]}"
 
+      - name: Resolve candidate SBOM
+        id: evidence
+        shell: bash
+        run: |
+          sbom="$(find candidate/out/evidence -type f -name '*.spdx.json' -print -quit)"
+          test -n "$sbom"
+          printf 'sbom_path=%s\n' "$sbom" >> "$GITHUB_OUTPUT"
+
       - name: Attest candidate provenance
         uses: actions/attest@f6bf1532d7d6793fce74eac584813a8eee607999 # v4
         with:
@@ -147,7 +155,7 @@ jobs:
             candidate/out/make/**/*.zip
             candidate/out/make/**/*.nupkg
             candidate/out/make/**/RELEASES
-          sbom-path: candidate/out/evidence/*.spdx.json
+          sbom-path: ${{ steps.evidence.outputs.sbom_path }}
 
   macos:
     name: Policy integration (macOS ${{ matrix.architecture }})

--- a/desktop/scripts/workflow-contract.test.mjs
+++ b/desktop/scripts/workflow-contract.test.mjs
@@ -21,6 +21,8 @@ test("desktop workflow builds and qualifies both native macOS architectures", as
     "name: Policy integration (macOS ${{ matrix.architecture }})",
     "architecture: Apple silicon",
     "architecture: Intel",
+    "sbom=\"$(find candidate/out/evidence -type f -name '*.spdx.json' -print -quit)\"",
+    "sbom-path: ${{ steps.evidence.outputs.sbom_path }}",
   ]) {
     assert.ok(workflow.includes(required), `workflow is missing ${required}`);
   }


### PR DESCRIPTION
Post-merge Electron attestation failed because actions/attest does not resolve the wildcard `sbom-path` input. Resolve the downloaded SPDX file explicitly and pass its exact path to the attestation action.

Tests: `bun test desktop/scripts/workflow-contract.test.mjs`.