### PR TITLE
ci: require native desktop proof in merge queue

### DIFF
--- a/.github/workflows/electron-security-proof.yml
+++ b/.github/workflows/electron-security-proof.yml
@@ -1,6 +1,8 @@
 name: Electron security proof
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     paths:
       - ".github/actions/desktop-preview-candidate/**"
@@ -252,3 +254,38 @@ jobs:
         run: |
           docker run --rm --cap-add=SYS_ADMIN \
             leapview-electron-security-proof:43.2.0
+
+  gate:
+    name: Electron gate
+    if: ${{ always() }}
+    needs: [contract, packages, macos, windows, linux]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Require the event-appropriate desktop proof
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CONTRACT_RESULT: ${{ needs.contract.result }}
+          PACKAGES_RESULT: ${{ needs.packages.result }}
+          MACOS_RESULT: ${{ needs.macos.result }}
+          WINDOWS_RESULT: ${{ needs.windows.result }}
+          LINUX_RESULT: ${{ needs.linux.result }}
+        run: |
+          for result in "$CONTRACT_RESULT" "$PACKAGES_RESULT" "$LINUX_RESULT"; do
+            test "$result" = success || {
+              printf 'Required desktop proof result: %s\n' "$result" >&2
+              exit 1
+            }
+          done
+          if [[ "$EVENT_NAME" == pull_request ]]; then
+            test "$MACOS_RESULT" = skipped
+            test "$WINDOWS_RESULT" = skipped
+          else
+            for result in "$MACOS_RESULT" "$WINDOWS_RESULT"; do
+              test "$result" = success || {
+                printf 'Required native desktop proof result: %s\n' "$result" >&2
+                exit 1
+              }
+            done
+          fi

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -147,7 +147,10 @@ jobs:
     if: ${{ always() }}
     needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, full-validation]
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
     steps:
       - name: Require full merge validation
         env:
@@ -177,3 +180,26 @@ jobs:
             printf 'Full merge validation: %s\n' "${FULL_VALIDATION_RESULT}" >&2
             exit 1
           }
+
+      - name: Require native desktop merge proof
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          REVISION: ${{ github.sha }}
+        run: |
+          endpoint="/repos/$REPOSITORY/actions/workflows/electron-security-proof.yml/runs?head_sha=$REVISION&event=merge_group&per_page=1"
+          for _ in $(seq 1 240); do
+            proof="$(gh api "$endpoint")"
+            status="$(jq -r '.workflow_runs[0].status // "missing"' <<<"$proof")"
+            conclusion="$(jq -r '.workflow_runs[0].conclusion // ""' <<<"$proof")"
+            if [[ "$status" == completed ]]; then
+              test "$conclusion" = success || {
+                printf 'Native desktop merge proof: %s\n' "$conclusion" >&2
+                exit 1
+              }
+              exit 0
+            fi
+            sleep 10
+          done
+          printf 'Native desktop merge proof did not complete within the gate budget\n' >&2
+          exit 1

--- a/desktop/scripts/workflow-contract.test.mjs
+++ b/desktop/scripts/workflow-contract.test.mjs
@@ -5,8 +5,9 @@ import test from "node:test";
 
 test("desktop workflow builds and qualifies both native macOS architectures", async () => {
   const root = resolve(import.meta.dirname, "..", "..");
-  const [workflow, candidateAction, readme] = await Promise.all([
+  const [workflow, mergeWorkflow, candidateAction, readme] = await Promise.all([
     readFile(resolve(root, ".github/workflows/electron-security-proof.yml"), "utf8"),
+    readFile(resolve(root, ".github/workflows/merge-validation.yml"), "utf8"),
     readFile(resolve(root, ".github/actions/desktop-preview-candidate/action.yml"), "utf8"),
     readFile(resolve(root, "desktop/README.md"), "utf8"),
   ]);
@@ -44,6 +45,18 @@ test("desktop workflow builds and qualifies both native macOS architectures", as
     workflow.includes("uses: ./.github/actions/desktop-preview-candidate"),
     "security workflow does not reuse the candidate action",
   );
+  for (const required of [
+    "name: Require native desktop merge proof",
+    "actions: read",
+    "electron-security-proof.yml/runs?head_sha=$REVISION&event=merge_group",
+    "for _ in $(seq 1 240)",
+    "test \"$conclusion\" = success",
+  ]) {
+    assert.ok(
+      mergeWorkflow.includes(required),
+      `merge validation is missing ${required}`,
+    );
+  }
   assert.doesNotMatch(
     workflow,
     /^ {4}if:.*matrix\./mu,

--- a/desktop/scripts/workflow-contract.test.mjs
+++ b/desktop/scripts/workflow-contract.test.mjs
@@ -12,6 +12,8 @@ test("desktop workflow builds and qualifies both native macOS architectures", as
   ]);
 
   for (const required of [
+    "merge_group:",
+    "types: [checks_requested]",
     "name: macOS Apple silicon",
     "os: macos-15",
     "artifact: macos-arm64",
@@ -23,6 +25,11 @@ test("desktop workflow builds and qualifies both native macOS architectures", as
     "architecture: Intel",
     "sbom=\"$(find candidate/out/evidence -type f -name '*.spdx.json' -print -quit)\"",
     "sbom-path: ${{ steps.evidence.outputs.sbom_path }}",
+    "name: Electron gate",
+    "needs: [contract, packages, macos, windows, linux]",
+    "EVENT_NAME: ${{ github.event_name }}",
+    "MACOS_RESULT: ${{ needs.macos.result }}",
+    "WINDOWS_RESULT: ${{ needs.windows.result }}",
   ]) {
     assert.ok(workflow.includes(required), `workflow is missing ${required}`);
   }

--- a/internal/app/cli/composectl/qualification_test.go
+++ b/internal/app/cli/composectl/qualification_test.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -936,6 +937,31 @@ type qualificationTestWriteCloser struct{ bytes.Buffer }
 
 func (*qualificationTestWriteCloser) Close() error { return nil }
 
+type qualificationTestRoundTrip struct {
+	response io.Reader
+	request  chan struct{}
+	once     sync.Once
+}
+
+func newQualificationTestRoundTrip(response string) *qualificationTestRoundTrip {
+	return &qualificationTestRoundTrip{
+		response: strings.NewReader(response),
+		request:  make(chan struct{}),
+	}
+}
+
+func (t *qualificationTestRoundTrip) Read(contents []byte) (int, error) {
+	<-t.request
+	return t.response.Read(contents)
+}
+
+func (t *qualificationTestRoundTrip) Write(contents []byte) (int, error) {
+	t.once.Do(func() { close(t.request) })
+	return len(contents), nil
+}
+
+func (*qualificationTestRoundTrip) Close() error { return nil }
+
 func TestQualificationJSONWorkerRejectsMalformedAndMismatchedResponses(t *testing.T) {
 	for name, response := range map[string]struct {
 		response string
@@ -951,14 +977,12 @@ func TestQualificationJSONWorkerRejectsMalformedAndMismatchedResponses(t *testin
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			transport := newQualificationTestRoundTrip(response.response)
 			worker := &qualificationJSONWorker{
 				stderr: &boundedQualificationBuffer{maxBytes: 1024},
 			}
 			worker.client = jrpc2.NewClient(
-				newQualificationRPCChannel(
-					strings.NewReader(response.response),
-					&qualificationTestWriteCloser{},
-				),
+				newQualificationRPCChannel(transport, transport),
 				&jrpc2.ClientOptions{
 					OnNotify:   worker.handleNotification,
 					OnCallback: worker.handleCallback,


### PR DESCRIPTION
## Summary
- run the existing Electron security proof for exact merge-group candidates
- keep pull requests Linux-only while requiring Linux, macOS, and Windows proof before merge
- make the already-required `CI gate` wait for the successful Electron workflow run for the same merge-group SHA
- preserve post-merge-only attestations without adding another repository ruleset check
- remove a pre-existing jrpc2 test startup race discovered by the first merge-group validation

## Merge-queue impact
- native jobs run in parallel with existing merge validation
- measured native proof: 3m37s; existing merge validation remained active past 27m, so the added wall-clock delay was 0s for the candidate
- the gate exits immediately when proof completes; its wider timeout only protects against slow hosted-runner allocation

## Validation
- `bun test desktop/scripts/workflow-contract.test.mjs`
- qualification worker test: 500 focused repetitions and 50 race-enabled repetitions
- `go test ./internal/app/cli/composectl`
- `git diff --check`
- PR CI and Electron proof passed before the merge-group run
- exact merge-group Electron proof passed on Linux, Windows, macOS Intel, and macOS Apple silicon
- first merge-group full validation exposed the synchronized-worker test race; refreshed checks will validate the fix