### PR TITLE
fix(ci): make electron proof result writes atomic

### DIFF
--- a/.github/workflows/electron-security-proof.yml
+++ b/.github/workflows/electron-security-proof.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run pure security contract tests
         working-directory: internal/app/testing/maliciousinstance/electron
-        run: node --test policy.test.mjs manifest-proof.test.mjs result-file.test.mjs
+        run: node --test policy.test.mjs manifest-proof.test.mjs proof-lifecycle.test.mjs result-file.test.mjs
 
   packages:
     name: Hardened package (${{ matrix.name }})

--- a/.github/workflows/electron-security-proof.yml
+++ b/.github/workflows/electron-security-proof.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run pure security contract tests
         working-directory: internal/app/testing/maliciousinstance/electron
-        run: node --test policy.test.mjs manifest-proof.test.mjs
+        run: node --test policy.test.mjs manifest-proof.test.mjs result-file.test.mjs
 
   packages:
     name: Hardened package (${{ matrix.name }})

--- a/internal/app/testing/maliciousinstance/electron/package.json
+++ b/internal/app/testing/maliciousinstance/electron/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test policy.test.mjs manifest-proof.test.mjs"
+    "test": "node --test policy.test.mjs manifest-proof.test.mjs result-file.test.mjs"
   },
   "devDependencies": {
     "electron": "43.2.0"

--- a/internal/app/testing/maliciousinstance/electron/package.json
+++ b/internal/app/testing/maliciousinstance/electron/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test policy.test.mjs manifest-proof.test.mjs result-file.test.mjs"
+    "test": "node --test policy.test.mjs manifest-proof.test.mjs proof-lifecycle.test.mjs result-file.test.mjs"
   },
   "devDependencies": {
     "electron": "43.2.0"

--- a/internal/app/testing/maliciousinstance/electron/proof-lifecycle.mjs
+++ b/internal/app/testing/maliciousinstance/electron/proof-lifecycle.mjs
@@ -1,21 +1,23 @@
-export async function runProofLifecycle({ app, result, runProof, writeResult }) {
+export async function startProofLifecycle({ app, result, runProof, writeResult }) {
   // The proof owns application termination. Electron's default Linux/Windows
   // behavior would otherwise quit as soon as runProof destroys its last window.
   app.on("window-all-closed", () => {});
 
   await writeResult();
-  try {
-    await app.whenReady();
-    result.phase = "running";
-    await runProof();
-    result.passed = true;
-    result.phase = "complete";
-    await writeResult();
-    app.quit();
-  } catch (error) {
-    result.error = error instanceof Error ? error.message : String(error);
-    result.phase = "failed";
-    await writeResult();
-    app.exit(1);
-  }
+  const completion = app.whenReady()
+    .then(async () => {
+      result.phase = "running";
+      await runProof();
+      result.passed = true;
+      result.phase = "complete";
+      await writeResult();
+      app.quit();
+    })
+    .catch(async (error) => {
+      result.error = error instanceof Error ? error.message : String(error);
+      result.phase = "failed";
+      await writeResult();
+      app.exit(1);
+    });
+  return { completion };
 }

--- a/internal/app/testing/maliciousinstance/electron/proof-lifecycle.mjs
+++ b/internal/app/testing/maliciousinstance/electron/proof-lifecycle.mjs
@@ -1,0 +1,21 @@
+export async function runProofLifecycle({ app, result, runProof, writeResult }) {
+  // The proof owns application termination. Electron's default Linux/Windows
+  // behavior would otherwise quit as soon as runProof destroys its last window.
+  app.on("window-all-closed", () => {});
+
+  await writeResult();
+  try {
+    await app.whenReady();
+    result.phase = "running";
+    await runProof();
+    result.passed = true;
+    result.phase = "complete";
+    await writeResult();
+    app.quit();
+  } catch (error) {
+    result.error = error instanceof Error ? error.message : String(error);
+    result.phase = "failed";
+    await writeResult();
+    app.exit(1);
+  }
+}

--- a/internal/app/testing/maliciousinstance/electron/proof-lifecycle.test.mjs
+++ b/internal/app/testing/maliciousinstance/electron/proof-lifecycle.test.mjs
@@ -2,17 +2,30 @@ import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import test from "node:test";
 
-import { runProofLifecycle } from "./proof-lifecycle.mjs";
+import { startProofLifecycle } from "./proof-lifecycle.mjs";
 
 class FakeApplication extends EventEmitter {
   constructor(events) {
     super();
     this.events = events;
     this.exited = false;
+    this.readyPromise = new Promise((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
   }
 
-  async whenReady() {
+  whenReady() {
+    return this.readyPromise;
+  }
+
+  becomeReady() {
     this.events.push("ready");
+    this.resolveReady();
+  }
+
+  failReady(error) {
+    this.rejectReady(error);
   }
 
   closeLastWindow() {
@@ -41,7 +54,7 @@ test("last-window closure cannot exit before the complete result is durable", as
   const app = new FakeApplication(events);
   const result = { passed: false, phase: "bootstrap" };
 
-  await runProofLifecycle({
+  const lifecycle = await startProofLifecycle({
     app,
     result,
     runProof: async () => {
@@ -54,6 +67,9 @@ test("last-window closure cannot exit before the complete result is durable", as
       events.push(`write:${result.phase}`);
     },
   });
+  assert.deepEqual(events, ["write:bootstrap"]);
+  app.becomeReady();
+  await lifecycle.completion;
 
   assert.deepEqual(events, [
     "write:bootstrap",
@@ -71,7 +87,7 @@ test("last-window closure cannot hide a failed proof result", async () => {
   const app = new FakeApplication(events);
   const result = { passed: false, phase: "bootstrap" };
 
-  await runProofLifecycle({
+  const lifecycle = await startProofLifecycle({
     app,
     result,
     runProof: async () => {
@@ -83,6 +99,9 @@ test("last-window closure cannot hide a failed proof result", async () => {
       events.push(`write:${result.phase}`);
     },
   });
+  assert.deepEqual(events, ["write:bootstrap"]);
+  app.becomeReady();
+  await lifecycle.completion;
 
   assert.deepEqual(events, [
     "write:bootstrap",
@@ -94,4 +113,26 @@ test("last-window closure cannot hide a failed proof result", async () => {
   assert.equal(result.passed, false);
   assert.equal(result.phase, "failed");
   assert.equal(result.error, "policy proof failed");
+});
+
+test("application readiness rejection is persisted as a proof failure", async () => {
+  const events = [];
+  const app = new FakeApplication(events);
+  const result = { passed: false, phase: "bootstrap" };
+
+  const lifecycle = await startProofLifecycle({
+    app,
+    result,
+    runProof: async () => {
+      assert.fail("proof ran after readiness failed");
+    },
+    writeResult: async () => {
+      events.push(`write:${result.phase}`);
+    },
+  });
+  app.failReady(new Error("Electron readiness failed"));
+  await lifecycle.completion;
+
+  assert.deepEqual(events, ["write:bootstrap", "write:failed", "exit:1"]);
+  assert.equal(result.error, "Electron readiness failed");
 });

--- a/internal/app/testing/maliciousinstance/electron/proof-lifecycle.test.mjs
+++ b/internal/app/testing/maliciousinstance/electron/proof-lifecycle.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { runProofLifecycle } from "./proof-lifecycle.mjs";
+
+class FakeApplication extends EventEmitter {
+  constructor(events) {
+    super();
+    this.events = events;
+    this.exited = false;
+  }
+
+  async whenReady() {
+    this.events.push("ready");
+  }
+
+  closeLastWindow() {
+    this.events.push("windows-closed");
+    if (this.listenerCount("window-all-closed") === 0) {
+      this.exited = true;
+      this.events.push("default-quit");
+      return;
+    }
+    this.emit("window-all-closed");
+  }
+
+  quit() {
+    this.exited = true;
+    this.events.push("quit");
+  }
+
+  exit(code) {
+    this.exited = true;
+    this.events.push(`exit:${code}`);
+  }
+}
+
+test("last-window closure cannot exit before the complete result is durable", async () => {
+  const events = [];
+  const app = new FakeApplication(events);
+  const result = { passed: false, phase: "bootstrap" };
+
+  await runProofLifecycle({
+    app,
+    result,
+    runProof: async () => {
+      events.push("proof");
+      app.closeLastWindow();
+      assert.equal(app.exited, false);
+    },
+    writeResult: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      events.push(`write:${result.phase}`);
+    },
+  });
+
+  assert.deepEqual(events, [
+    "write:bootstrap",
+    "ready",
+    "proof",
+    "windows-closed",
+    "write:complete",
+    "quit",
+  ]);
+  assert.deepEqual(result, { passed: true, phase: "complete" });
+});
+
+test("last-window closure cannot hide a failed proof result", async () => {
+  const events = [];
+  const app = new FakeApplication(events);
+  const result = { passed: false, phase: "bootstrap" };
+
+  await runProofLifecycle({
+    app,
+    result,
+    runProof: async () => {
+      app.closeLastWindow();
+      throw new Error("policy proof failed");
+    },
+    writeResult: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      events.push(`write:${result.phase}`);
+    },
+  });
+
+  assert.deepEqual(events, [
+    "write:bootstrap",
+    "ready",
+    "windows-closed",
+    "write:failed",
+    "exit:1",
+  ]);
+  assert.equal(result.passed, false);
+  assert.equal(result.phase, "failed");
+  assert.equal(result.error, "policy proof failed");
+});

--- a/internal/app/testing/maliciousinstance/electron/result-file.mjs
+++ b/internal/app/testing/maliciousinstance/electron/result-file.mjs
@@ -1,0 +1,30 @@
+import { randomBytes } from "node:crypto";
+import { open, rename, unlink } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export async function writeJSONAtomic(path, input) {
+  const body = `${JSON.stringify(input, null, 2)}\n`;
+  const temporaryPath = `${path}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  const handle = await open(temporaryPath, "wx", 0o600);
+  try {
+    try {
+      await handle.writeFile(body, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(temporaryPath, path);
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+
+  if (process.platform !== "win32") {
+    const directory = await open(dirname(path), "r");
+    try {
+      await directory.sync();
+    } finally {
+      await directory.close();
+    }
+  }
+}

--- a/internal/app/testing/maliciousinstance/electron/result-file.test.mjs
+++ b/internal/app/testing/maliciousinstance/electron/result-file.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { writeJSONAtomic } from "./result-file.mjs";
+
+test("atomic result writes publish complete private JSON", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "leapview-electron-result-"));
+  try {
+    const path = join(directory, "electron-proof.json");
+    const result = { passed: true, phase: "complete", observations: [] };
+
+    await writeJSONAtomic(path, result);
+
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), result);
+    if (process.platform !== "win32") {
+      assert.equal((await stat(path)).mode & 0o777, 0o600);
+    }
+    assert.deepEqual(await readdir(directory), ["electron-proof.json"]);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("failed and concurrent replacements never corrupt the published result", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "leapview-electron-result-"));
+  try {
+    const path = join(directory, "electron-proof.json");
+    const bootstrap = { passed: false, phase: "bootstrap" };
+    await writeJSONAtomic(path, bootstrap);
+
+    await assert.rejects(
+      writeJSONAtomic(path, { invalid: 1n }),
+      /BigInt/,
+    );
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), bootstrap);
+
+    const orphan = `${path}.interrupted.tmp`;
+    await writeFile(orphan, '{"passed":', { mode: 0o600 });
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), bootstrap);
+
+    const replacements = Array.from({ length: 12 }, (_, index) => ({
+      passed: true,
+      phase: "complete",
+      sequence: index,
+      padding: String(index).repeat(64 * 1024),
+    }));
+    let writing = true;
+    const reader = (async () => {
+      while (writing) {
+        const observed = JSON.parse(await readFile(path, "utf8"));
+        assert.ok(
+          observed.phase === "bootstrap" ||
+            replacements.some((candidate) => candidate.sequence === observed.sequence),
+        );
+      }
+    })();
+    try {
+      await Promise.all(replacements.map((value) => writeJSONAtomic(path, value)));
+    } finally {
+      writing = false;
+    }
+    await reader;
+
+    const final = JSON.parse(await readFile(path, "utf8"));
+    assert.ok(replacements.some((candidate) => candidate.sequence === final.sequence));
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});

--- a/internal/app/testing/maliciousinstance/electron/runner.mjs
+++ b/internal/app/testing/maliciousinstance/electron/runner.mjs
@@ -14,6 +14,7 @@ import {
 import {
   createRemoteWindow,
 } from "../../../../../desktop/src/security/remote-window.mjs";
+import { runProofLifecycle } from "./proof-lifecycle.mjs";
 import { writeJSONAtomic } from "./result-file.mjs";
 
 app.enableSandbox();
@@ -37,26 +38,12 @@ const result = {
   decisions: [],
 };
 
-await writeResult();
-app.whenReady().then(async () => {
-  try {
-    result.phase = "running";
-    await withTimeout(runProof(), 40_000, "policy integration");
-    result.passed = true;
-    result.phase = "complete";
-    await writeResult();
-    app.quit();
-  } catch (error) {
-    await fail(error);
-  }
-}).catch(fail);
-
-async function fail(error) {
-  result.error = error instanceof Error ? error.message : String(error);
-  result.phase = "failed";
-  await writeResult();
-  app.exit(1);
-}
+await runProofLifecycle({
+  app,
+  result,
+  runProof: () => withTimeout(runProof(), 40_000, "policy integration"),
+  writeResult,
+});
 
 async function runProof() {
   result.currentCheck = "manifest";

--- a/internal/app/testing/maliciousinstance/electron/runner.mjs
+++ b/internal/app/testing/maliciousinstance/electron/runner.mjs
@@ -14,7 +14,7 @@ import {
 import {
   createRemoteWindow,
 } from "../../../../../desktop/src/security/remote-window.mjs";
-import { runProofLifecycle } from "./proof-lifecycle.mjs";
+import { startProofLifecycle } from "./proof-lifecycle.mjs";
 import { writeJSONAtomic } from "./result-file.mjs";
 
 app.enableSandbox();
@@ -38,7 +38,7 @@ const result = {
   decisions: [],
 };
 
-await runProofLifecycle({
+await startProofLifecycle({
   app,
   result,
   runProof: () => withTimeout(runProof(), 40_000, "policy integration"),

--- a/internal/app/testing/maliciousinstance/electron/runner.mjs
+++ b/internal/app/testing/maliciousinstance/electron/runner.mjs
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { writeFile } from "node:fs/promises";
 
 import { app, BrowserWindow, session } from "electron";
 
@@ -15,6 +14,7 @@ import {
 import {
   createRemoteWindow,
 } from "../../../../../desktop/src/security/remote-window.mjs";
+import { writeJSONAtomic } from "./result-file.mjs";
 
 app.enableSandbox();
 
@@ -455,9 +455,7 @@ function recordDecision(decision) {
 }
 
 async function writeResult() {
-  await writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`, {
-    mode: 0o600,
-  });
+  await writeJSONAtomic(resultPath, result);
 }
 
 function delay(milliseconds) {

--- a/internal/app/testing/maliciousinstance/electron_proof_result_test.go
+++ b/internal/app/testing/maliciousinstance/electron_proof_result_test.go
@@ -1,0 +1,91 @@
+package maliciousinstance
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadElectronProofResultClassifiesMissingEmptyAndMalformedDocuments(t *testing.T) {
+	processErr := errors.New("Electron exited unexpectedly")
+	output := []byte("electron stderr")
+
+	tests := []struct {
+		name       string
+		contents   []byte
+		write      bool
+		want       []string
+		wantAbsent []string
+	}{
+		{
+			name:  "missing",
+			want:  []string{"Electron proof result is missing", "Electron exited unexpectedly", "electron stderr"},
+			write: false,
+		},
+		{
+			name:     "empty",
+			contents: []byte{},
+			write:    true,
+			want:     []string{"Electron proof result is empty", "size=0 bytes", `raw result: ""`, "Electron exited unexpectedly", "electron stderr"},
+		},
+		{
+			name:       "malformed",
+			contents:   []byte(`{"passed":`),
+			write:      true,
+			want:       []string{"Electron proof result is malformed", "size=10 bytes", `raw result: "{\"passed\":"`, "unexpected end of JSON input", "Electron exited unexpectedly", "electron stderr"},
+			wantAbsent: []string{"Electron proof result is empty"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "electron-proof.json")
+			if test.write {
+				if err := os.WriteFile(path, test.contents, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			_, _, err := readElectronProofResult(path, processErr, output)
+			if err == nil {
+				t.Fatal("readElectronProofResult returned no error")
+			}
+			for _, want := range test.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err, want)
+				}
+			}
+			for _, unwanted := range test.wantAbsent {
+				if strings.Contains(err.Error(), unwanted) {
+					t.Errorf("error %q unexpectedly contains %q", err, unwanted)
+				}
+			}
+		})
+	}
+}
+
+func TestElectronProofProcessFailurePreservesValidResultAndProcessDiagnostics(t *testing.T) {
+	payload := []byte(`{"passed":false,"phase":"failed","error":"permission proof failed"}`)
+	result := electronProofResult{
+		Passed: false,
+		Error:  "permission proof failed",
+	}
+	processErr := errors.New("exit status 1")
+
+	err := electronProofProcessFailure(result, payload, processErr, []byte("electron stderr"))
+	if err == nil {
+		t.Fatal("electronProofProcessFailure returned no error")
+	}
+	for _, want := range []string{
+		"valid failure result",
+		"permission proof failed",
+		"exit status 1",
+		"electron stderr",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}

--- a/internal/app/testing/maliciousinstance/electron_proof_test.go
+++ b/internal/app/testing/maliciousinstance/electron_proof_test.go
@@ -3,13 +3,27 @@ package maliciousinstance
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 )
+
+const maximumElectronProofDiagnosticBytes = 8 * 1024
+
+type electronProofResult struct {
+	Passed          bool          `json:"passed"`
+	Framework       string        `json:"framework"`
+	Chromium        string        `json:"chromium"`
+	Phase           string        `json:"phase"`
+	ManifestVersion string        `json:"manifestVersion"`
+	Observations    []Observation `json:"observations"`
+	Error           string        `json:"error"`
+}
 
 func TestElectronPolicyIntegrationPreservesBrowserEquivalentAuthority(t *testing.T) {
 	switch runtime.GOOS {
@@ -40,23 +54,12 @@ func TestElectronPolicyIntegrationPreservesBrowserEquivalentAuthority(t *testing
 	)
 	output, runErr := command.CombinedOutput()
 
-	payload, readErr := os.ReadFile(resultPath)
-	if readErr != nil {
-		t.Fatalf("read Electron proof result: %v\nprocess error: %v\noutput:\n%s", readErr, runErr, output)
+	result, payload, err := readElectronProofResult(resultPath, runErr, output)
+	if err != nil {
+		t.Fatal(err)
 	}
-	var result struct {
-		Passed          bool          `json:"passed"`
-		Framework       string        `json:"framework"`
-		Chromium        string        `json:"chromium"`
-		ManifestVersion string        `json:"manifestVersion"`
-		Observations    []Observation `json:"observations"`
-		Error           string        `json:"error"`
-	}
-	if err := json.Unmarshal(payload, &result); err != nil {
-		t.Fatalf("decode Electron proof result: %v\n%s", err, payload)
-	}
-	if runErr != nil || !result.Passed {
-		t.Fatalf("Electron proof failed: process error=%v result=%s output=%s", runErr, payload, output)
+	if err := electronProofProcessFailure(result, payload, runErr, output); err != nil {
+		t.Fatal(err)
 	}
 	manifest := harness.Manifest()
 	if result.ManifestVersion != manifest.Version {
@@ -78,4 +81,76 @@ func TestElectronPolicyIntegrationPreservesBrowserEquivalentAuthority(t *testing
 		}
 	}
 	t.Logf("%s / Chromium %s satisfied all %d security invariants", result.Framework, result.Chromium, len(result.Observations))
+}
+
+func readElectronProofResult(
+	resultPath string,
+	processErr error,
+	output []byte,
+) (electronProofResult, []byte, error) {
+	payload, err := os.ReadFile(resultPath)
+	if err != nil {
+		classification := "could not be read"
+		if os.IsNotExist(err) {
+			classification = "is missing"
+		}
+		return electronProofResult{}, nil, fmt.Errorf(
+			"Electron proof result %s: %v\n%s",
+			classification,
+			err,
+			electronProofProcessDiagnostics(processErr, output),
+		)
+	}
+	if len(payload) == 0 {
+		return electronProofResult{}, payload, fmt.Errorf(
+			"Electron proof result is empty (size=0 bytes)\nraw result: %s\n%s",
+			formatElectronProofPayload(payload),
+			electronProofProcessDiagnostics(processErr, output),
+		)
+	}
+
+	var result electronProofResult
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return electronProofResult{}, payload, fmt.Errorf(
+			"Electron proof result is malformed (size=%d bytes): %w\nraw result: %s\n%s",
+			len(payload),
+			err,
+			formatElectronProofPayload(payload),
+			electronProofProcessDiagnostics(processErr, output),
+		)
+	}
+	return result, payload, nil
+}
+
+func electronProofProcessFailure(
+	result electronProofResult,
+	payload []byte,
+	processErr error,
+	output []byte,
+) error {
+	if processErr == nil && result.Passed {
+		return nil
+	}
+	return fmt.Errorf(
+		"Electron proof returned a valid failure result (size=%d bytes, phase=%q, error=%q)\nraw result: %s\n%s",
+		len(payload),
+		result.Phase,
+		result.Error,
+		formatElectronProofPayload(payload),
+		electronProofProcessDiagnostics(processErr, output),
+	)
+}
+
+func electronProofProcessDiagnostics(processErr error, output []byte) string {
+	return fmt.Sprintf("process error: %v\noutput:\n%s", processErr, output)
+}
+
+func formatElectronProofPayload(payload []byte) string {
+	display := payload
+	suffix := ""
+	if len(display) > maximumElectronProofDiagnosticBytes {
+		display = display[:maximumElectronProofDiagnosticBytes]
+		suffix = fmt.Sprintf(" (truncated; total size=%d bytes)", len(payload))
+	}
+	return strconv.QuoteToASCII(string(display)) + suffix
 }


### PR DESCRIPTION
## Summary

Fixes intermittent Electron security proof failures caused by truncated result files and clean application exit before final proof persistence.

## Root Cause

The proof destroys both BrowserWindows in `runProof()` cleanup before publishing its final asynchronous result. On Linux and Windows, Electron quits by default when the last window closes unless the application subscribes to `window-all-closed`.

That platform-default clean exit raced final result persistence. Before atomic publishing it could leave empty or malformed JSON; after atomic publishing it correctly preserved the valid bootstrap result and exposed the lifecycle failure.

## Changes

- Added atomic JSON publishing using private temporary files, fsync, and atomic rename.
- Made the proof harness explicitly retain application ownership after the last window closes.
- Let the Electron ESM main module finish evaluation after scheduling readiness, then run the proof.
- Persisted the final success or failure result before explicit application termination.
- Improved diagnostics for missing, empty, malformed, and explicit failure results.
- Added regression tests for atomic result handling, concurrent readers, readiness scheduling/rejection, last-window closure, and failure reporting.

## Safety

- Security validation logic remains unchanged.
- Proof failures still fail closed.
- Final success is persisted before explicit application termination.
- Readiness and proof rejections persist failure before exiting nonzero.
- No security checks or invariants were weakened.

## Verification

Verified locally:

- Electron Node contract suite: 15/15 passed
- `go test ./internal/app/testing/maliciousinstance/...` passed
- Repeated Go package suite (`-count=10`) passed
- Workflow contract tests passed
- Node syntax checks and `git diff --check` passed

Verified in PR CI:

- Linux x64 policy integration passed all 20 security invariants
- Hardened Linux x64 package passed
- Electron gate passed

The exact Linux Docker proof runs in PR CI; Docker is not installed on the development VPS.