### PR TITLE
security: harden browser authentication transport

### DIFF
--- a/docs/articles/operate/production-configuration.md
+++ b/docs/articles/operate/production-configuration.md
@@ -20,7 +20,7 @@ Set `LEAPVIEW_PUBLIC_URL` to the application deployment's canonical HTTPS origin
 
 `LEAPVIEW_TRUST_PROXY_HEADERS` must be enabled only when requests arrive through a trusted proxy that overwrites client-address headers. Never trust forwarding headers from an arbitrary public client.
 
-Browser authentication in production requires secure cookies. Configure exact public OIDC or Azure callback URLs and register those same URLs with the identity provider.
+Browser authentication in production requires secure cookies. Secure deployments use `__Host-` cookie names for browser sessions, CSRF state, OIDC state, and authentication return targets so browsers enforce a secure, host-only, root-path boundary. Enabling secure cookies therefore invalidates legacy unprefixed browser cookies and requires users to sign in again. Configure exact public OIDC or Azure callback URLs and register those same URLs with the identity provider.
 
 ## Authentication and security secrets
 

--- a/docs/articles/security/local-auth.md
+++ b/docs/articles/security/local-auth.md
@@ -21,7 +21,7 @@ Validate the complete environment:
 leapview config validate --production
 ```
 
-The CSRF key protects CSRF state and OAuth state cookies. Store it in the deployment secret manager. Rotating it can invalidate security state and should follow a controlled maintenance procedure.
+The CSRF key protects CSRF state and OAuth state cookies. Store it in the deployment secret manager. Rotating it can invalidate security state and should follow a controlled maintenance procedure. Local sign-in and password forms are capped at 8 KiB, and authentication responses are marked `no-store`.
 
 ## Initialize the first administrator
 

--- a/docs/articles/security/oidc.md
+++ b/docs/articles/security/oidc.md
@@ -41,7 +41,7 @@ Production validation requires the issuer and callback to use HTTPS and treats i
 
 Terminate TLS at a maintained trusted proxy and ensure the application sees the correct public scheme and host used by the callback. Set exact allowed hosts. Enable proxy-header trust only when that proxy overwrites client-supplied forwarding headers.
 
-Secure cookies must remain enabled for browser auth. Clock synchronization matters for token and state validation on both LeapView and the identity provider.
+Secure cookies must remain enabled for browser auth. With secure cookies enabled, LeapView uses browser-enforced `__Host-` names for session and authentication-state cookies; switching from an insecure development boundary to this production boundary requires a fresh sign-in. Authentication and authenticated responses are marked `no-store`, and provider failures return generic client messages rather than upstream details. Clock synchronization matters for token and state validation on both LeapView and the identity provider.
 
 ## Understand identity mapping
 

--- a/internal/access/module/auth.go
+++ b/internal/access/module/auth.go
@@ -27,12 +27,15 @@ import (
 type principalContextKey struct{}
 type apiCredentialContextKey struct{}
 
+const sessionCookieName = "lv_session"
 const csrfCookieName = "lv_csrf"
 const oidcStateCookieName = "lv_oidc_state"
 const authReturnCookieName = "lv_auth_return"
+const hostCookiePrefix = "__Host-"
 const oidcStateMaxAge = 10 * time.Minute
 const oidcStateClockSkew = time.Minute
 const maxAuthReturnTargetBytes = 2500
+const LocalAuthMaxFormBytes int64 = 8 * 1024
 
 var (
 	errUnauthorized = errors.New("unauthorized")
@@ -87,21 +90,25 @@ type disabledCredentialResolver interface {
 }
 
 type Auth struct {
-	repo          access.Repository
-	sessions      sessionManager
-	devBypass     bool
-	devAPIToken   string
-	apiTokenOnly  bool
-	localAuth     bool
-	enabled       bool
-	configured    bool
-	azureTenant   string
-	cookieSecure  bool
-	csrf          func(http.Handler) http.Handler
-	oidcRegistry  *oidcauth.Registry
-	oidcOverride  map[string]oidcClient
-	stateKey      []byte
-	authoringAuth *access.AuthoringAuthService
+	repo             access.Repository
+	sessions         sessionManager
+	devBypass        bool
+	devAPIToken      string
+	apiTokenOnly     bool
+	localAuth        bool
+	enabled          bool
+	configured       bool
+	azureTenant      string
+	cookieSecure     bool
+	sessionCookieKey string
+	csrfCookie       string
+	oidcCookie       string
+	returnCookie     string
+	csrf             func(http.Handler) http.Handler
+	oidcRegistry     *oidcauth.Registry
+	oidcOverride     map[string]oidcClient
+	stateKey         []byte
+	authoringAuth    *access.AuthoringAuthService
 }
 
 type AuthConfig struct {
@@ -131,14 +138,18 @@ type OIDCProviderConfig struct {
 
 func NewAuth(repo access.Repository, cfg AuthConfig) *Auth {
 	auth := &Auth{
-		repo:         repo,
-		sessions:     repo,
-		devBypass:    cfg.DevBypass,
-		devAPIToken:  strings.TrimSpace(cfg.DevAPIToken),
-		apiTokenOnly: cfg.APITokenOnly,
-		localAuth:    cfg.LocalAuth,
-		azureTenant:  cfg.AzureTenant,
-		cookieSecure: cfg.CookieSecure,
+		repo:             repo,
+		sessions:         repo,
+		devBypass:        cfg.DevBypass,
+		devAPIToken:      strings.TrimSpace(cfg.DevAPIToken),
+		apiTokenOnly:     cfg.APITokenOnly,
+		localAuth:        cfg.LocalAuth,
+		azureTenant:      cfg.AzureTenant,
+		cookieSecure:     cfg.CookieSecure,
+		sessionCookieKey: hardenedCookieName(sessionCookieName, cfg.CookieSecure),
+		csrfCookie:       hardenedCookieName(csrfCookieName, cfg.CookieSecure),
+		oidcCookie:       hardenedCookieName(oidcStateCookieName, cfg.CookieSecure),
+		returnCookie:     hardenedCookieName(authReturnCookieName, cfg.CookieSecure),
 	}
 	providers := make([]oidcauth.Config, 0, len(cfg.OIDCProviders))
 	for _, provider := range cfg.OIDCProviders {
@@ -157,7 +168,7 @@ func NewAuth(repo access.Repository, cfg AuthConfig) *Auth {
 	}
 	auth.csrf = csrf.Protect(
 		csrfKey(cfg.CSRFKey),
-		csrf.CookieName(csrfCookieName),
+		csrf.CookieName(auth.csrfCookie),
 		csrf.Path("/"),
 		csrf.Secure(cfg.CookieSecure),
 		csrf.SameSite(csrf.SameSiteLaxMode),
@@ -200,6 +211,22 @@ func hasOIDCProvider(providers []oidcauth.Config, id string) bool {
 	return false
 }
 
+func hardenedCookieName(name string, secure bool) string {
+	if secure {
+		return hostCookiePrefix + name
+	}
+	return name
+}
+
+// SessionCookieName returns the environment-appropriate browser session
+// cookie name. Secure deployments use the browser-enforced __Host- prefix.
+func (a *Auth) SessionCookieName() string {
+	if a == nil || a.sessionCookieKey == "" {
+		return sessionCookieName
+	}
+	return a.sessionCookieKey
+}
+
 func (a *Auth) Enabled() bool {
 	return a != nil && a.enabled
 }
@@ -234,7 +261,7 @@ func (a *Auth) Begin(w http.ResponseWriter, r *http.Request) {
 	}
 	client, _, err := a.oidcClient(r.Context(), provider)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		http.Error(w, "identity provider unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	state, err := randomAuthValue()
@@ -262,21 +289,21 @@ func (a *Auth) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 	state, nonce, err := a.consumeOIDCState(w, r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		http.Error(w, "invalid authentication response", http.StatusUnauthorized)
 		return
 	}
 	if r.URL.Query().Get("state") != state {
-		http.Error(w, "invalid oidc state", http.StatusUnauthorized)
+		http.Error(w, "invalid authentication response", http.StatusUnauthorized)
 		return
 	}
 	client, providerConfig, err := a.oidcClient(r.Context(), provider)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		http.Error(w, "identity provider unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	claims, err := client.Authenticate(r.Context(), r.URL.Query().Get("code"), nonce)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		http.Error(w, "authentication failed", http.StatusUnauthorized)
 		return
 	}
 	email := oidcEmail(claims)
@@ -294,7 +321,7 @@ func (a *Auth) Callback(w http.ResponseWriter, r *http.Request) {
 		return authAuditInput(r, "session.created", principal.ID, "session", "", "", "success", map[string]any{"provider": provider}), mutationErr
 	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 	recordAccessAudit(r, a.repo, "sign_in", principal.ID, "principal", principal.ID, "", "success", map[string]any{"provider": provider})
@@ -303,7 +330,7 @@ func (a *Auth) Callback(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *Auth) Logout(w http.ResponseWriter, r *http.Request) {
-	if cookie, err := r.Cookie("lv_session"); err == nil {
+	if cookie, err := r.Cookie(a.SessionCookieName()); err == nil {
 		principal, _ := a.sessions.PrincipalForToken(r.Context(), cookie.Value)
 		if err := runAuthAuditedMutation(r, a.repo, func(txRepo access.Repository) (access.AuditEventInput, error) {
 			mutationErr := txRepo.DeleteSession(r.Context(), cookie.Value)
@@ -314,7 +341,7 @@ func (a *Auth) Logout(w http.ResponseWriter, r *http.Request) {
 		}
 		recordAccessAudit(r, a.repo, "sign_out", principal.ID, "principal", principal.ID, "", "success", nil)
 	}
-	http.SetCookie(w, &http.Cookie{Name: "lv_session", Value: "", Path: "/", MaxAge: -1, HttpOnly: true, SameSite: http.SameSiteLaxMode, Secure: a.cookieSecure})
+	http.SetCookie(w, a.expiredSessionCookie())
 	http.Redirect(w, r, "/", http.StatusFound)
 }
 
@@ -323,8 +350,8 @@ func (a *Auth) LocalLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "local auth is not enabled", http.StatusServiceUnavailable)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	if err := parseLocalAuthForm(w, r); err != nil {
+		writeLocalAuthFormError(w, err)
 		return
 	}
 	email := access.NormalizeEmail(firstNonEmpty(r.Form.Get("email"), r.Form.Get("username")))
@@ -351,7 +378,7 @@ func (a *Auth) LocalLogin(w http.ResponseWriter, r *http.Request) {
 		return authAuditInput(r, "session.created", principal.ID, "session", "", "", "success", map[string]any{"provider": "local"}), mutationErr
 	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 	recordAccessAudit(r, a.repo, "sign_in", principal.ID, "principal", principal.ID, "", "success", map[string]any{"provider": "local"})
@@ -377,8 +404,8 @@ func (a *Auth) LocalPassword(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errUnauthorized.Error(), http.StatusUnauthorized)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	if err := parseLocalAuthForm(w, r); err != nil {
+		writeLocalAuthFormError(w, err)
 		return
 	}
 	_, ok = a.repo.(localCredentialManager)
@@ -549,7 +576,7 @@ func (a *Auth) CSRFMiddleware(next http.Handler) http.Handler {
 	}
 	protected := a.csrf(next)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if bearerToken(r) != "" && !hasSessionCookie(r) {
+		if bearerToken(r) != "" && !a.hasSessionCookie(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -570,7 +597,7 @@ func (a *Auth) authenticate(r *http.Request) (Principal, *access.APICredential, 
 	if a.apiTokenOnly {
 		return Principal{}, nil, false
 	}
-	cookie, err := r.Cookie("lv_session")
+	cookie, err := r.Cookie(a.SessionCookieName())
 	if err != nil || cookie.Value == "" {
 		return Principal{}, nil, false
 	}
@@ -620,8 +647,8 @@ func (a *Auth) authenticateBearer(r *http.Request) (Principal, *access.APICreden
 	return Principal{}, nil, false
 }
 
-func hasSessionCookie(r *http.Request) bool {
-	cookie, err := r.Cookie("lv_session")
+func (a *Auth) hasSessionCookie(r *http.Request) bool {
+	cookie, err := r.Cookie(a.SessionCookieName())
 	return err == nil && strings.TrimSpace(cookie.Value) != ""
 }
 
@@ -648,7 +675,7 @@ func (a *Auth) auditDisabledCredentialFailure(r *http.Request, credentialType, s
 
 func (a *Auth) sessionCookie(token string, expires time.Time) *http.Cookie {
 	return &http.Cookie{
-		Name:     "lv_session",
+		Name:     a.SessionCookieName(),
 		Value:    token,
 		Path:     "/",
 		Expires:  expires,
@@ -656,6 +683,34 @@ func (a *Auth) sessionCookie(token string, expires time.Time) *http.Cookie {
 		SameSite: http.SameSiteLaxMode,
 		Secure:   a.cookieSecure,
 	}
+}
+
+func (a *Auth) expiredSessionCookie() *http.Cookie {
+	return &http.Cookie{
+		Name:     a.SessionCookieName(),
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   a.cookieSecure,
+	}
+}
+
+func parseLocalAuthForm(w http.ResponseWriter, r *http.Request) error {
+	if r.Body != nil && r.Body != http.NoBody {
+		r.Body = http.MaxBytesReader(w, r.Body, LocalAuthMaxFormBytes)
+	}
+	return r.ParseForm()
+}
+
+func writeLocalAuthFormError(w http.ResponseWriter, err error) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+		return
+	}
+	http.Error(w, "invalid authentication request", http.StatusBadRequest)
 }
 
 func wantsJSON(r *http.Request) bool {
@@ -706,7 +761,7 @@ func csrfKey(value string) []byte {
 
 func (a *Auth) oidcStateCookie(state, nonce string) *http.Cookie {
 	return &http.Cookie{
-		Name:     oidcStateCookieName,
+		Name:     a.oidcCookie,
 		Value:    a.encodeOIDCState(state, nonce),
 		Path:     "/",
 		MaxAge:   int(oidcStateMaxAge / time.Second),
@@ -729,7 +784,7 @@ func authenticationReturnTarget(r *http.Request) string {
 
 func (a *Auth) authReturnCookie(target string) *http.Cookie {
 	return &http.Cookie{
-		Name:     authReturnCookieName,
+		Name:     a.returnCookie,
 		Value:    a.encodeAuthReturn(target, authNow()),
 		Path:     "/",
 		MaxAge:   int(oidcStateMaxAge / time.Second),
@@ -740,12 +795,12 @@ func (a *Auth) authReturnCookie(target string) *http.Cookie {
 }
 
 func (a *Auth) authenticationRedirectTarget(w http.ResponseWriter, r *http.Request, fallback string) string {
-	cookie, err := r.Cookie(authReturnCookieName)
+	cookie, err := r.Cookie(a.returnCookie)
 	if err != nil {
 		return fallback
 	}
 	http.SetCookie(w, &http.Cookie{
-		Name: authReturnCookieName, Value: "", Path: "/", MaxAge: -1,
+		Name: a.returnCookie, Value: "", Path: "/", MaxAge: -1,
 		HttpOnly: true, Secure: a.cookieSecure, SameSite: http.SameSiteLaxMode,
 	})
 	target, err := a.decodeAuthReturn(cookie.Value, authNow())
@@ -802,11 +857,11 @@ func isAuthenticationReturnPath(path string) bool {
 }
 
 func (a *Auth) consumeOIDCState(w http.ResponseWriter, r *http.Request) (string, string, error) {
-	cookie, err := r.Cookie(oidcStateCookieName)
+	cookie, err := r.Cookie(a.oidcCookie)
 	if err != nil {
 		return "", "", err
 	}
-	http.SetCookie(w, &http.Cookie{Name: oidcStateCookieName, Value: "", Path: "/", MaxAge: -1, HttpOnly: true, SameSite: http.SameSiteLaxMode, Secure: a.cookieSecure})
+	http.SetCookie(w, &http.Cookie{Name: a.oidcCookie, Value: "", Path: "/", MaxAge: -1, HttpOnly: true, SameSite: http.SameSiteLaxMode, Secure: a.cookieSecure})
 	return a.decodeOIDCState(cookie.Value)
 }
 

--- a/internal/access/module/auth_transport_test.go
+++ b/internal/access/module/auth_transport_test.go
@@ -1,0 +1,82 @@
+package module
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	oidcauth "github.com/flidai/leapview/internal/access/oidc"
+)
+
+func TestSecureAuthCookiesUseHostPrefix(t *testing.T) {
+	auth := NewAuth(nil, AuthConfig{CookieSecure: true, CSRFKey: strings.Repeat("k", 32)})
+
+	for label, cookie := range map[string]*http.Cookie{
+		"session":     auth.sessionCookie("token", authNow()),
+		"expired":     auth.expiredSessionCookie(),
+		"oidc state":  auth.oidcStateCookie("state", "nonce"),
+		"return path": auth.authReturnCookie("/oauth/authorize"),
+	} {
+		if !strings.HasPrefix(cookie.Name, hostCookiePrefix) {
+			t.Fatalf("%s cookie name = %q, want __Host- prefix", label, cookie.Name)
+		}
+		if !cookie.Secure || cookie.Path != "/" || cookie.Domain != "" {
+			t.Fatalf("%s cookie does not satisfy __Host- contract: %#v", label, cookie)
+		}
+	}
+	if auth.csrfCookie != "__Host-lv_csrf" {
+		t.Fatalf("CSRF cookie name = %q", auth.csrfCookie)
+	}
+}
+
+func TestDevelopmentAuthCookiesKeepUnprefixedNames(t *testing.T) {
+	auth := NewAuth(nil, AuthConfig{CSRFKey: strings.Repeat("k", 32)})
+
+	if auth.SessionCookieName() != sessionCookieName || auth.csrfCookie != csrfCookieName ||
+		auth.oidcCookie != oidcStateCookieName || auth.returnCookie != authReturnCookieName {
+		t.Fatalf("development cookie names = %q %q %q %q", auth.SessionCookieName(), auth.csrfCookie, auth.oidcCookie, auth.returnCookie)
+	}
+}
+
+func TestLocalLoginRejectsStreamedOversizeBody(t *testing.T) {
+	auth := NewAuth(nil, AuthConfig{LocalAuth: true, CSRFKey: strings.Repeat("k", 32)})
+	request := httptest.NewRequest(http.MethodPost, "/auth/local/login", strings.NewReader("password="+strings.Repeat("a", int(LocalAuthMaxFormBytes))))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.ContentLength = -1
+	response := httptest.NewRecorder()
+
+	auth.LocalLogin(response, request)
+
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d body=%s", response.Code, http.StatusRequestEntityTooLarge, response.Body.String())
+	}
+}
+
+func TestOIDCErrorsDoNotExposeProviderDetails(t *testing.T) {
+	auth := NewAuth(nil, AuthConfig{DevBypass: true, CSRFKey: strings.Repeat("k", 32)})
+	auth.ConfigureOIDCTestClients(map[string]OIDCClient{"azureadv2": rejectingOIDCClient{}})
+	stateCookie := auth.OIDCStateCookie("state", "nonce")
+	request := httptest.NewRequest(http.MethodGet, "/auth/azureadv2/callback?state=state&code=code", nil)
+	request.AddCookie(stateCookie)
+	response := httptest.NewRecorder()
+
+	auth.Callback(response, request)
+
+	if response.Code != http.StatusUnauthorized || !strings.Contains(response.Body.String(), "authentication failed") {
+		t.Fatalf("response = %d body=%q", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "provider-secret-detail") {
+		t.Fatalf("provider detail leaked in response: %q", response.Body.String())
+	}
+}
+
+type rejectingOIDCClient struct{}
+
+func (rejectingOIDCClient) AuthCodeURL(_, _ string) string { return "https://issuer.example/authorize" }
+
+func (rejectingOIDCClient) Authenticate(context.Context, string, string) (oidcauth.Claims, error) {
+	return oidcauth.Claims{}, errors.New("provider-secret-detail")
+}

--- a/internal/access/module/desktop_auth.go
+++ b/internal/access/module/desktop_auth.go
@@ -54,7 +54,7 @@ func (m *Module) DesktopSessionStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
 		return
 	}
-	cookie, err := r.Cookie("lv_session")
+	cookie, err := r.Cookie(m.auth.SessionCookieName())
 	if err != nil || cookie.Value == "" {
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
@@ -210,9 +210,9 @@ func (m *Module) DesktopDisconnect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
-	cookie, err := r.Cookie("lv_session")
+	cookie, err := r.Cookie(m.auth.SessionCookieName())
 	if err != nil || cookie.Value == "" {
-		clearDesktopSessionCookie(w, m.auth.cookieSecure)
+		clearDesktopSessionCookie(w, m.auth)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
@@ -224,7 +224,7 @@ func (m *Module) DesktopDisconnect(w http.ResponseWriter, r *http.Request) {
 	}
 	binding, err := desktopRepository.DesktopSessionForToken(r.Context(), cookie.Value)
 	if err != nil {
-		clearDesktopSessionCookie(w, m.auth.cookieSecure)
+		clearDesktopSessionCookie(w, m.auth)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
@@ -247,7 +247,7 @@ func (m *Module) DesktopDisconnect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
-	clearDesktopSessionCookie(w, m.auth.cookieSecure)
+	clearDesktopSessionCookie(w, m.auth)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -273,9 +273,6 @@ func hasExactForm(form map[string][]string, fields map[string]struct{}) bool {
 	return true
 }
 
-func clearDesktopSessionCookie(w http.ResponseWriter, secure bool) {
-	http.SetCookie(w, &http.Cookie{
-		Name: "lv_session", Value: "", Path: "/", MaxAge: -1,
-		HttpOnly: true, Secure: secure, SameSite: http.SameSiteLaxMode,
-	})
+func clearDesktopSessionCookie(w http.ResponseWriter, auth *Auth) {
+	http.SetCookie(w, auth.expiredSessionCookie())
 }

--- a/internal/access/module/desktop_auth_test.go
+++ b/internal/access/module/desktop_auth_test.go
@@ -90,7 +90,7 @@ func TestDesktopAuthorizationEstablishesHttpOnlySessionWithoutReturningSecret(t 
 		t.Fatalf("redeem cookies = %#v, want one session cookie", cookies)
 	}
 	session := cookies[0]
-	if session.Name != "lv_session" || session.Value == "" || !session.HttpOnly ||
+	if session.Name != fixture.module.auth.SessionCookieName() || session.Value == "" || !session.HttpOnly ||
 		!session.Secure || session.SameSite != http.SameSiteLaxMode {
 		t.Fatalf("session cookie = %#v, want secure HttpOnly SameSite=Lax cookie", session)
 	}
@@ -137,7 +137,7 @@ func TestDesktopAuthorizationEstablishesHttpOnlySessionWithoutReturningSecret(t 
 		t.Fatalf("disconnect status = %d, want %d: %s", disconnect.Code, http.StatusNoContent, disconnect.Body.String())
 	}
 	cleared := disconnect.Result().Cookies()
-	if len(cleared) != 1 || cleared[0].Name != "lv_session" || cleared[0].MaxAge != -1 {
+	if len(cleared) != 1 || cleared[0].Name != fixture.module.auth.SessionCookieName() || cleared[0].MaxAge != -1 {
 		t.Fatalf("disconnect cookies = %#v, want expired session cookie", cleared)
 	}
 	revokedStatus := httptest.NewRecorder()
@@ -332,7 +332,7 @@ func newDesktopAuthTestModule(t *testing.T) desktopAuthTestFixture {
 	module.auth.devBypass = false
 	return desktopAuthTestFixture{
 		module:         module,
-		browserSession: &http.Cookie{Name: "lv_session", Value: token},
+		browserSession: &http.Cookie{Name: module.auth.SessionCookieName(), Value: token},
 		database:       store.SQLDB(),
 	}
 }

--- a/internal/access/module/module.go
+++ b/internal/access/module/module.go
@@ -72,7 +72,11 @@ func newSurface(config surfaceConfig) (*Module, error) {
 		if config.Repository == nil {
 			return "", false
 		}
-		cookie, err := r.Cookie("lv_session")
+		cookieName := sessionCookieName
+		if config.Auth != nil {
+			cookieName = config.Auth.SessionCookieName()
+		}
+		cookie, err := r.Cookie(cookieName)
 		if err != nil || strings.TrimSpace(cookie.Value) == "" {
 			return "", false
 		}
@@ -406,7 +410,11 @@ func (m *Module) CurrentCredentialEvidence(
 			}
 		}
 	}
-	cookie, err := r.Cookie("lv_session")
+	cookieName := sessionCookieName
+	if m.auth != nil {
+		cookieName = m.auth.SessionCookieName()
+	}
+	cookie, err := r.Cookie(cookieName)
 	if err != nil || strings.TrimSpace(cookie.Value) == "" {
 		return access.CredentialEvidence{}, false
 	}

--- a/internal/app/auth_transport_test.go
+++ b/internal/app/auth_transport_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthenticationAndAuthenticatedBrowserResponsesArePrivate(t *testing.T) {
+	server := assembleRuntime(fakeMetrics{}, assemblyConfig{})
+	handler := server.Routes()
+
+	for _, path := range []string{"/login", "/", "/auth/azureadv2"} {
+		t.Run(path, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+			if got := response.Header().Get("Cache-Control"); got != "no-store" {
+				t.Fatalf("Cache-Control = %q, want no-store", got)
+			}
+			if got := response.Header().Get("Pragma"); got != "no-cache" {
+				t.Fatalf("Pragma = %q, want no-cache", got)
+			}
+		})
+	}
+}

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -7,6 +7,7 @@ import (
 
 	accessmodule "github.com/flidai/leapview/internal/access/module"
 	apiaggregate "github.com/flidai/leapview/internal/app/api/aggregate"
+	apihttpmiddleware "github.com/flidai/leapview/internal/platform/http/middleware"
 	"github.com/flidai/leapview/internal/platform/web/staticasset"
 	"github.com/go-chi/chi/v5"
 )
@@ -40,7 +41,7 @@ func Routes(routes *capabilityRoutes, runtime *runtimeServices, platform *platfo
 	})
 	mountDevelopmentRoutes(mux, runtime.pageStreamTrace)
 	mux.With(policy.rateLimits.Auth()).Handle("/metrics", platform.telemetry.MetricsHandler(policy.metricsBearerToken, accessmodule.BearerToken))
-	mux.With(csrf).Group(routes.accessModule.MountLoginPage)
+	mux.With(apihttpmiddleware.PrivateResponse, csrf).Group(routes.accessModule.MountLoginPage)
 	mountAuthenticatedRoutes(mux, authenticatedRouteDependencies{
 		access: routes.accessModule, projectBrowser: routes.projectBrowser, agent: routes.agentModule,
 		admin: routes.adminModule, dashboard: routes.dashboardModule, runtimeHost: runtime.runtimeHostModule,

--- a/internal/app/runtime_router_routes.go
+++ b/internal/app/runtime_router_routes.go
@@ -129,6 +129,7 @@ func mountDevelopmentRoutes(mux *chi.Mux, trace *pagestream.TraceStore) {
 
 func mountAuthenticatedRoutes(mux *chi.Mux, dependencies authenticatedRouteDependencies, csrf func(http.Handler) http.Handler) {
 	mux.Group(func(r chi.Router) {
+		r.Use(apihttpmiddleware.PrivateResponse)
 		r.Use(csrf)
 		r.With(dependencies.rateLimits.Updates()).Get("/updates", dependencies.pageStreams.ServeHTTP)
 		if dependencies.projectBrowser != nil {
@@ -168,11 +169,13 @@ func mountAuthenticatedRoutes(mux *chi.Mux, dependencies authenticatedRouteDepen
 func mountAuthenticationRoutes(mux *chi.Mux, accessModule *accessmodule.Module, rateLimits apihttpmiddleware.RateLimitConfig, csrf func(http.Handler) http.Handler) {
 	mux.Group(func(r chi.Router) {
 		r.Use(rateLimits.Auth())
+		r.Use(apihttpmiddleware.PrivateResponse)
 		r.Use(csrf)
 		accessModule.MountLocalLogin(r)
 	})
 	mux.Group(func(r chi.Router) {
 		r.Use(rateLimits.Auth())
+		r.Use(apihttpmiddleware.PrivateResponse)
 		accessModule.MountOAuthEndpoints(r)
 	})
 	accessModule.MountOAuthMetadata(mux)

--- a/internal/platform/http/middleware/middleware.go
+++ b/internal/platform/http/middleware/middleware.go
@@ -228,6 +228,16 @@ func RequestBodyLimit(config RequestBodyLimitConfig) func(http.Handler) http.Han
 	}
 }
 
+// PrivateResponse prevents browsers and shared intermediaries from retaining
+// authenticated or authentication-flow responses.
+func PrivateResponse(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		next.ServeHTTP(w, r)
+	})
+}
+
 func PanicRecovery(logger *slog.Logger) func(http.Handler) http.Handler {
 	if logger == nil {
 		logger = slog.Default()

--- a/internal/platform/http/middleware/middleware_active_test.go
+++ b/internal/platform/http/middleware/middleware_active_test.go
@@ -98,6 +98,22 @@ func TestRequestBodyLimitRejectsDeclaredAndStreamedOversize(t *testing.T) {
 	})
 }
 
+func TestPrivateResponseDisablesBrowserAndSharedCaching(t *testing.T) {
+	handler := PrivateResponse(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/login", nil))
+
+	if got := response.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	if got := response.Header().Get("Pragma"); got != "no-cache" {
+		t.Fatalf("Pragma = %q, want no-cache", got)
+	}
+}
+
 func TestSecurityHeadersAndOptionalHSTS(t *testing.T) {
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
## Problem

Production browser authentication cookies used ordinary names, authentication and authenticated responses did not have a uniform non-cacheable boundary, local auth forms inherited the large global body limit, and OIDC failures could expose provider/internal details to clients.

## Security risk closed

The previous surface lacked browser-enforced host scoping for secure cookies, allowed sensitive responses to be cached by clients or intermediaries, accepted unnecessarily large authentication bodies, and leaked identity-provider error detail.

## Approach

- Use `__Host-` names for secure session, CSRF, OIDC-state, and return-target cookies; preserve unprefixed names for insecure local development.
- Apply `Cache-Control: no-store` and `Pragma: no-cache` to authentication and authenticated browser routes.
- Cap local authentication forms at 8 KiB and return 413 for streamed oversized bodies.
- Replace OIDC/provider and internal failure detail with stable generic client responses.
- Carry the dynamic session-cookie name through browser, Desktop, current-session, and credential-evidence paths.

## Components changed

- `internal/access/module`: cookie contract, auth body parsing, OIDC errors, Desktop integration, and regression tests.
- `internal/app`: private-response route wiring and integration coverage.
- `internal/platform/http/middleware`: reusable private-response middleware and tests.
- Production, local-auth, and OIDC operator documentation.

## Testing performed

- `go test ./internal/access/module ./internal/platform/http/middleware -count=1`
- `go test ./internal/app -run '^Test(AuthenticationAndAuthenticatedBrowserResponsesArePrivate|RouteInventory)$' -count=1`
- Re-verified after rebasing onto current `origin/main` with Go 1.25.14.

## Remaining considerations

- Enabling secure cookies changes cookie names and intentionally requires existing users to sign in again.
- Public OAuth metadata remains outside the private-response middleware.
- Full CI remains required before merge.

## Tracking

- Linear project: [Identity and Production Surface Hardening](https://linear.app/flid/project/identity-and-production-surface-hardening-458805365a8d)
- Milestone: Browser authentication transport boundaries
