### PR TITLE
security: isolate production CSP exceptions

### DIFF
--- a/docs/articles/operate/production-configuration.md
+++ b/docs/articles/operate/production-configuration.md
@@ -22,6 +22,8 @@ Set `LEAPVIEW_PUBLIC_URL` to the application deployment's canonical HTTPS origin
 
 Browser authentication in production requires secure cookies. Configure exact public OIDC or Azure callback URLs and register those same URLs with the identity provider.
 
+Production content security policy keeps executable strings and inline styles disabled on API, health, stream, and static-asset responses. Interactive HTML documents retain one explicit `unsafe-eval` exception because the pinned Datastar runtime compiles declarative `data-*` expressions; inline script attributes remain disabled. Lit and server-rendered dynamic styles are isolated with `style-src-elem` and `style-src-attr` instead of weakening the script policy. Do not add third-party script origins or widen these exceptions at the reverse proxy.
+
 ## Authentication and security secrets
 
 Production requires at least one supported authentication mode: local browser auth, generic OIDC, Azure/Entra, or API-token-only mode. Development auth bypass is forbidden.

--- a/internal/app/site/http/server.go
+++ b/internal/app/site/http/server.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	mapassethttp "github.com/flidai/leapview/internal/dashboard/visualization/mapasset/http"
+	apihttpmiddleware "github.com/flidai/leapview/internal/platform/http/middleware"
 	"github.com/flidai/leapview/pkg/pagestream"
 	siteassets "github.com/flidai/leapview/site"
 )
@@ -140,11 +141,14 @@ func cloneURL(value *url.URL) *url.URL {
 
 func (s *siteServer) productionHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		policy := "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: blob:; object-src 'none'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:"
+		policyConfig := apihttpmiddleware.ContentSecurityPolicyConfig{FrameAncestors: "'none'"}
 		if r.URL.Path == "/showcase" && s.showcaseOrigin != "" {
-			policy += "; frame-src " + s.showcaseOrigin
+			policyConfig.FrameSrc = s.showcaseOrigin
 		}
-		w.Header().Set("Content-Security-Policy", policy)
+		strictPolicy := apihttpmiddleware.ContentSecurityPolicy(policyConfig)
+		policyConfig.DatastarExpressions = true
+		policyConfig.DynamicStyles = true
+		documentPolicy := apihttpmiddleware.ContentSecurityPolicy(policyConfig)
 		w.Header().Set("Permissions-Policy", "camera=(), geolocation=(), microphone=()")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -165,7 +169,7 @@ func (s *siteServer) productionHeaders(next http.Handler) http.Handler {
 		default:
 			w.Header().Set("Cache-Control", "no-cache")
 		}
-		next.ServeHTTP(w, r)
+		apihttpmiddleware.ContentSecurityPolicyByMediaType(strictPolicy, documentPolicy)(next).ServeHTTP(w, r)
 	})
 }
 

--- a/internal/app/site/http/server_internal_test.go
+++ b/internal/app/site/http/server_internal_test.go
@@ -452,13 +452,22 @@ func TestSiteProductionHeadersAndHealthEndpoints(t *testing.T) {
 		t.Errorf("Content-Security-Policy = %q, want same-origin and blob renderer workers", got)
 	}
 
-	response, err = server.Client().Get(server.URL + "/static/site-page.js")
+	response, err = server.Client().Get(server.URL + "/static/favicon.svg")
 	if err != nil {
 		t.Fatalf("get site asset: %v", err)
 	}
+	assetPolicy := response.Header.Get("Content-Security-Policy")
 	response.Body.Close()
 	if got := response.Header.Get("Cache-Control"); got != "public, max-age=0, must-revalidate" {
 		t.Fatalf("site asset cache control = %q", got)
+	}
+	if strings.Contains(assetPolicy, "'unsafe-eval'") || strings.Contains(assetPolicy, "'unsafe-inline'") {
+		t.Fatalf("static asset CSP contains an unsafe directive: %q", assetPolicy)
+	}
+	for _, want := range []string{"script-src 'self'", "script-src-attr 'none'", "style-src-attr 'none'"} {
+		if !strings.Contains(assetPolicy, want) {
+			t.Fatalf("static asset CSP missing %q: %q", want, assetPolicy)
+		}
 	}
 
 }

--- a/internal/dashboard/module/public_http.go
+++ b/internal/dashboard/module/public_http.go
@@ -321,11 +321,13 @@ func SetPublicDashboardSecurityHeaders(header http.Header, presentation string, 
 	} else {
 		header.Set("X-Frame-Options", "DENY")
 	}
-	header.Set("Content-Security-Policy", strings.Join([]string{
-		"default-src 'self'", "base-uri 'none'", "object-src 'none'", "frame-ancestors " + frameAncestors,
-		"form-action 'none'", "script-src 'self' 'unsafe-eval'", "style-src 'self' 'unsafe-inline'",
-		"img-src 'self' data: blob:", "font-src 'self' data:", "connect-src 'self'", "worker-src 'self' blob:",
-	}, "; "))
+	header.Set("Content-Security-Policy", apihttpmiddleware.ContentSecurityPolicy(apihttpmiddleware.ContentSecurityPolicyConfig{
+		BaseURI:             "'none'",
+		FrameAncestors:      frameAncestors,
+		FormAction:          "'none'",
+		DatastarExpressions: true,
+		DynamicStyles:       true,
+	}))
 	header.Set("Referrer-Policy", "no-referrer")
 	header.Set("X-Robots-Tag", "noindex")
 	header.Set("X-Content-Type-Options", "nosniff")

--- a/internal/dashboard/module/publication_test.go
+++ b/internal/dashboard/module/publication_test.go
@@ -36,4 +36,16 @@ func TestEmbedWithNoAllowedOriginsDeniesFraming(t *testing.T) {
 	if got := header.Get("Content-Security-Policy"); !strings.Contains(got, "frame-ancestors 'none'") {
 		t.Fatalf("Content-Security-Policy = %q", got)
 	}
+	policy := header.Get("Content-Security-Policy")
+	for _, want := range []string{
+		"script-src 'self' 'unsafe-eval'",
+		"script-src-attr 'none'",
+		"style-src 'self'",
+		"style-src-elem 'self' 'unsafe-inline'",
+		"style-src-attr 'unsafe-inline'",
+	} {
+		if !strings.Contains(policy, want) {
+			t.Fatalf("Content-Security-Policy missing %q: %q", want, policy)
+		}
+	}
 }

--- a/internal/platform/http/middleware/csp.go
+++ b/internal/platform/http/middleware/csp.go
@@ -1,0 +1,135 @@
+package httpmiddleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// ContentSecurityPolicyConfig describes the small set of browser capabilities
+// used by LeapView document surfaces. Non-document responses should use the
+// zero-value capability flags so executable strings and inline styles remain
+// disabled.
+type ContentSecurityPolicyConfig struct {
+	BaseURI             string
+	FrameAncestors      string
+	FormAction          string
+	FrameSrc            string
+	DatastarExpressions bool
+	DynamicStyles       bool
+}
+
+// ContentSecurityPolicy returns a deterministic CSP for a LeapView surface.
+// Datastar currently compiles declarative data-* expressions in the browser,
+// so unsafe-eval is deliberately restricted to interactive HTML documents.
+// Lit and the server-rendered shell require generated style elements and
+// attributes; CSP level-three directives keep that exception out of script
+// policy and away from non-document responses.
+func ContentSecurityPolicy(config ContentSecurityPolicyConfig) string {
+	baseURI := cspValue(config.BaseURI, "'self'")
+	frameAncestors := cspValue(config.FrameAncestors, "'self'")
+	formAction := cspValue(config.FormAction, "'self'")
+	scriptSrc := "script-src 'self'"
+	if config.DatastarExpressions {
+		scriptSrc += " 'unsafe-eval'"
+	}
+	styleElem := "style-src-elem 'self'"
+	styleAttr := "style-src-attr 'none'"
+	if config.DynamicStyles {
+		styleElem += " 'unsafe-inline'"
+		styleAttr = "style-src-attr 'unsafe-inline'"
+	}
+	directives := []string{
+		"default-src 'self'",
+		"base-uri " + baseURI,
+		"object-src 'none'",
+		"frame-ancestors " + frameAncestors,
+		"form-action " + formAction,
+		scriptSrc,
+		"script-src-attr 'none'",
+		"style-src 'self'",
+		styleElem,
+		styleAttr,
+		"img-src 'self' data: blob:",
+		"font-src 'self' data:",
+		"connect-src 'self'",
+		"worker-src 'self' blob:",
+		"manifest-src 'self'",
+	}
+	if frameSrc := strings.TrimSpace(config.FrameSrc); frameSrc != "" {
+		directives = append(directives, "frame-src "+frameSrc)
+	}
+	return strings.Join(directives, "; ")
+}
+
+func cspValue(value, fallback string) string {
+	if value = strings.TrimSpace(value); value != "" {
+		return value
+	}
+	return fallback
+}
+
+// ContentSecurityPolicyByMediaType applies documentPolicy only to HTML
+// responses. Everything else receives strictPolicy. A handler-owned CSP is
+// preserved so specialized surfaces such as public dashboard embeds can set a
+// narrower frame-ancestors policy.
+func ContentSecurityPolicyByMediaType(strictPolicy, documentPolicy string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Security-Policy", strictPolicy)
+			next.ServeHTTP(&contentSecurityPolicyWriter{
+				ResponseWriter: w,
+				strictPolicy:   strictPolicy,
+				documentPolicy: documentPolicy,
+			}, r)
+		})
+	}
+}
+
+type contentSecurityPolicyWriter struct {
+	http.ResponseWriter
+	strictPolicy   string
+	documentPolicy string
+	applied        bool
+}
+
+func (w *contentSecurityPolicyWriter) WriteHeader(statusCode int) {
+	w.apply(w.Header().Get("Content-Type"))
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *contentSecurityPolicyWriter) Write(contents []byte) (int, error) {
+	contentType := w.Header().Get("Content-Type")
+	if contentType == "" && len(contents) > 0 {
+		contentType = http.DetectContentType(contents)
+		w.Header().Set("Content-Type", contentType)
+	}
+	w.apply(contentType)
+	return w.ResponseWriter.Write(contents)
+}
+
+func (w *contentSecurityPolicyWriter) Flush() {
+	w.apply(w.Header().Get("Content-Type"))
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *contentSecurityPolicyWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *contentSecurityPolicyWriter) apply(contentType string) {
+	if w.applied {
+		return
+	}
+	w.applied = true
+	if current := w.Header().Get("Content-Security-Policy"); current != "" && current != w.strictPolicy {
+		return
+	}
+	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0]))
+	if mediaType == "text/html" || mediaType == "application/xhtml+xml" {
+		w.Header().Set("Content-Security-Policy", w.documentPolicy)
+		return
+	}
+	w.Header().Set("Content-Security-Policy", w.strictPolicy)
+}

--- a/internal/platform/http/middleware/middleware.go
+++ b/internal/platform/http/middleware/middleware.go
@@ -276,30 +276,22 @@ func SecurityHeadersMiddleware(config SecurityHeadersConfig) func(http.Handler) 
 		if !config.Enabled {
 			return next
 		}
+		strictPolicy := ContentSecurityPolicy(ContentSecurityPolicyConfig{})
+		documentPolicy := ContentSecurityPolicy(ContentSecurityPolicyConfig{
+			DatastarExpressions: true,
+			DynamicStyles:       true,
+		})
+		withContentSecurityPolicy := ContentSecurityPolicyByMediaType(strictPolicy, documentPolicy)(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := w.Header()
 			header.Set("X-Content-Type-Options", "nosniff")
 			header.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 			header.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 			header.Set("X-Frame-Options", "SAMEORIGIN")
-			header.Set("Content-Security-Policy", strings.Join([]string{
-				"default-src 'self'",
-				"base-uri 'self'",
-				"object-src 'none'",
-				"frame-ancestors 'self'",
-				"form-action 'self'",
-				"script-src 'self' 'unsafe-eval'",
-				"style-src 'self' 'unsafe-inline'",
-				"img-src 'self' data: blob:",
-				"font-src 'self' data:",
-				"connect-src 'self'",
-				"worker-src 'self' blob:",
-				"manifest-src 'self'",
-			}, "; "))
 			if config.HSTS {
 				header.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 			}
-			next.ServeHTTP(w, r)
+			withContentSecurityPolicy.ServeHTTP(w, r)
 		})
 	}
 }

--- a/internal/platform/http/middleware/middleware_active_test.go
+++ b/internal/platform/http/middleware/middleware_active_test.go
@@ -123,10 +123,13 @@ func TestSecurityHeadersAndOptionalHSTS(t *testing.T) {
 				}
 			}
 			csp := response.Header().Get("Content-Security-Policy")
-			for _, want := range []string{"default-src 'self'", "object-src 'none'", "frame-ancestors 'self'", "script-src 'self' 'unsafe-eval'", "connect-src 'self'", "worker-src 'self' blob:"} {
+			for _, want := range []string{"default-src 'self'", "object-src 'none'", "frame-ancestors 'self'", "script-src 'self'", "script-src-attr 'none'", "style-src-attr 'none'", "connect-src 'self'", "worker-src 'self' blob:"} {
 				if !strings.Contains(csp, want) {
 					t.Fatalf("CSP missing %q: %q", want, csp)
 				}
+			}
+			if strings.Contains(csp, "'unsafe-eval'") || strings.Contains(csp, "'unsafe-inline'") {
+				t.Fatalf("non-document CSP contains an unsafe directive: %q", csp)
 			}
 			if strings.Contains(csp, "cdn.jsdelivr.net") {
 				t.Fatalf("CSP allows CDN scripts: %q", csp)
@@ -135,6 +138,67 @@ func TestSecurityHeadersAndOptionalHSTS(t *testing.T) {
 				t.Fatalf("HSTS presence=%v, want %v (%q)", got != "", test.hsts, got)
 			}
 		})
+	}
+}
+
+func TestSecurityHeadersRestrictCSPExceptionsToHTMLDocuments(t *testing.T) {
+	tests := []struct {
+		name              string
+		contentType       string
+		body              string
+		wantUnsafeEval    bool
+		wantDynamicStyles bool
+	}{
+		{name: "html", contentType: "text/html; charset=utf-8", body: "<!doctype html><html></html>", wantUnsafeEval: true, wantDynamicStyles: true},
+		{name: "detected html", body: "<!doctype html><html></html>", wantUnsafeEval: true, wantDynamicStyles: true},
+		{name: "json", contentType: "application/json", body: `{\"status\":\"ok\"}`},
+		{name: "event stream", contentType: "text/event-stream", body: "event: ready\\n\\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := SecurityHeadersMiddleware(SecurityHeaders(false))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if test.contentType != "" {
+					w.Header().Set("Content-Type", test.contentType)
+				}
+				_, _ = w.Write([]byte(test.body))
+			}))
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			policy := response.Header().Get("Content-Security-Policy")
+			if got := strings.Contains(policy, "'unsafe-eval'"); got != test.wantUnsafeEval {
+				t.Fatalf("unsafe-eval presence = %v, want %v: %q", got, test.wantUnsafeEval, policy)
+			}
+			if got := strings.Contains(policy, "'unsafe-inline'"); got != test.wantDynamicStyles {
+				t.Fatalf("unsafe-inline presence = %v, want %v: %q", got, test.wantDynamicStyles, policy)
+			}
+			for _, want := range []string{"script-src-attr 'none'", "style-src 'self'"} {
+				if !strings.Contains(policy, want) {
+					t.Fatalf("CSP missing %q: %q", want, policy)
+				}
+			}
+			if test.wantDynamicStyles {
+				for _, want := range []string{"style-src-elem 'self' 'unsafe-inline'", "style-src-attr 'unsafe-inline'"} {
+					if !strings.Contains(policy, want) {
+						t.Fatalf("document CSP missing %q: %q", want, policy)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSecurityHeadersPreserveHandlerOwnedCSP(t *testing.T) {
+	const policy = "default-src 'none'; frame-ancestors https://embed.example"
+	handler := SecurityHeadersMiddleware(SecurityHeaders(false))(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Security-Policy", policy)
+		_, _ = w.Write([]byte("<!doctype html><html></html>"))
+	}))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/public", nil))
+	if got := response.Header().Get("Content-Security-Policy"); got != policy {
+		t.Fatalf("Content-Security-Policy = %q, want handler policy %q", got, policy)
 	}
 }
 


### PR DESCRIPTION
## Problem

LeapView applied the same production Content Security Policy to HTML documents, JSON/API responses, health endpoints, streams, and static assets. Datastar's browser expression compiler requires script evaluation, while Lit and server-rendered shells use dynamic styles, so the shared policy granted `unsafe-eval` and a broad `style-src 'unsafe-inline'` exception everywhere.

## Root cause

Security headers were written before the response media type was known, and the application, public-dashboard, and documentation-site surfaces each maintained their own broad CSP string.

## Security risk closed

An injection primitive on a non-document response no longer inherits browser execution/style exceptions. Inline script attributes are explicitly denied. Public embed framing rules remain handler-owned and cannot be replaced by the shared middleware.

## Solution

- Add one deterministic CSP builder for application, public-dashboard, and site surfaces.
- Select a strict policy for non-HTML responses and an interactive policy only for HTML documents.
- Keep Datastar's required `unsafe-eval` capability isolated to interactive HTML.
- Replace broad inline-style allowance with CSP Level 3 `style-src-elem` and `style-src-attr` exceptions.
- Preserve specialized public-dashboard `frame-ancestors` policies.
- Document the remaining compatibility boundary for production operators.

## Files/components changed

- `internal/platform/http/middleware/csp.go`
- `internal/platform/http/middleware/middleware.go`
- `internal/dashboard/module/public_http.go`
- `internal/app/site/http/server.go`
- Focused middleware, publication, and site response tests
- Production configuration documentation

## Tests added/updated

- Strict CSP for JSON, event streams, static assets, and no-content responses
- Interactive CSP for explicit and detected HTML responses
- Handler-owned CSP preservation
- Public embed directives and scoped style exceptions
- Site HTML/static response behavior

## Verification performed

- `go test ./internal/platform/http/middleware -count=1`
- `go test ./internal/dashboard/module -run 'TestEmbedWithNoAllowedOriginsDeniesFraming' -count=1`
- `go test ./internal/app/site/http -run 'TestSiteProductionHeadersAndHealthEndpoints' -count=1`

## Remaining limitations

The pinned Datastar runtime currently compiles declarative `data-*` expressions with `Function`, so interactive HTML still requires `unsafe-eval`. Removing that final exception requires a CSP-compatible Datastar evaluator/runtime change. Lit shadow styles and existing server-rendered style attributes retain narrowly scoped style exceptions.

Project: [Identity and Production Surface Hardening](https://linear.app/flid/project/identity-and-production-surface-hardening-458805365a8d)
