### PR TITLE
docs: define the MFA security decision boundary

### DIFF
--- a/docs/articles/security/local-auth.md
+++ b/docs/articles/security/local-auth.md
@@ -2,6 +2,8 @@
 
 Local authentication supports self-hosted browser login and a controlled break-glass path. Local users are administrator-created; LeapView does not provide public self-registration.
 
+Local authentication is password-only. It is not an MFA-capable production profile. Deployments that require MFA for people must use an external provider that enforces it; see the [MFA security decision boundary](/docs/security/mfa-boundary). Do not retain a local account outside the documented break-glass controls and represent it as satisfying MFA.
+
 ## Enable the mode
 
 Configure local auth with production security requirements:

--- a/docs/articles/security/mfa-boundary.md
+++ b/docs/articles/security/mfa-boundary.md
@@ -1,0 +1,70 @@
+# MFA security decision boundary
+
+Status: accepted on 2026-08-25.
+
+LeapView does not implement application-managed multi-factor authentication in the current authentication model. Deployments that require MFA for people must enforce it at the configured OIDC or Entra identity provider with provider-side conditional access. Local password authentication is not an MFA-capable production profile; retain it only where single-factor access is explicitly accepted or as a controlled, monitored break-glass path.
+
+This is a deliberate fail-closed scope decision. It is not a claim that an upstream login satisfied MFA, and LeapView does not currently authorize sensitive operations from `acr`, `amr`, or other provider-assurance claims.
+
+## Current boundary
+
+Interactive browser authentication has two entry paths:
+
+- OIDC verifies the authorization response, issuer, signature, state, and nonce, resolves the stable issuer-subject identity, and creates a browser session.
+- Local authentication verifies the stored password credential and creates the same kind of browser session.
+
+The durable browser-session record binds a token to a principal and expiration. It does not record authentication method, authenticator identity, assurance level, authentication time, or a step-up deadline. Desktop sessions add instance, profile, client, idle, and absolute-lifetime boundaries, but do not add authentication assurance. CLI authorization sessions and API tokens are separate credential classes.
+
+Authorization therefore receives an authenticated principal, not evidence that a particular factor combination was completed. Adding a TOTP prompt only to local login would leave OIDC callbacks, desktop completion, session restoration, recovery, and sensitive-operation step-up outside a coherent assurance model.
+
+## Why minimal local TOTP is rejected
+
+A secure MFA implementation is a lifecycle and authorization feature, not an extra form field. A minimal TOTP secret and challenge would leave material gaps:
+
+- no recent-authentication proof and confirmation ceremony for enrollment or removal;
+- no encrypted authenticator storage, key rotation, device naming, or multiple-device lifecycle;
+- no single-use recovery-code storage, recovery ceremony, or recovery notification;
+- no challenge replay protection, clock-skew policy, attempt budget, or distributed rate-limit contract;
+- no assurance attributes on browser, Desktop, or CLI sessions;
+- no step-up policy for credential, principal, grant, token, or security-setting changes;
+- no session revocation rule after authenticator reset or administrative recovery;
+- no complete audit vocabulary for enrollment, challenge, recovery, reset, and factor removal.
+
+Shipping only the challenge would create a bypassable control and could encourage operators to claim an assurance level the application cannot prove. The current architecture is safer when it names the limitation and delegates MFA to a mature external provider.
+
+## Production operating decision
+
+For a production deployment that requires MFA:
+
+1. Use OIDC or Entra for human browser authentication.
+2. Enforce phishing-resistant MFA or the organization's approved factor policy at that provider.
+3. Apply provider conditional access to the exact LeapView client and intended users.
+4. Verify the policy with a non-administrator account and preserve provider sign-in evidence alongside LeapView audit events.
+5. Keep any local break-glass account individually attributable, vaulted, monitored, tested, and rotated after use.
+
+Do not describe local password login as MFA. Do not treat API tokens, service-principal credentials, or a second network hop as a second human factor. If the application itself must cryptographically require and inspect a provider assurance value, the current release does not meet that requirement.
+
+## Requirements before application-managed MFA
+
+Future implementation starts only after the session and recovery boundaries are designed together. The minimum architecture must include:
+
+- WebAuthn/passkeys as the preferred phishing-resistant authenticator, with an explicit decision on any TOTP fallback;
+- durable authenticator identity and lifecycle records with protected secret material where applicable;
+- recent-authentication enrollment, confirmation before activation, named devices, and safe factor removal;
+- single-use hashed recovery codes and an attributable administrative recovery process;
+- replay-safe challenges, bounded attempts, clock handling where applicable, and production rate limits;
+- session evidence containing authentication method, assurance level, authentication time, and step-up expiry;
+- one issuance policy shared by local browser, external browser, Desktop, and CLI completion paths;
+- exact issuer-specific rules for accepted `acr` or `amr` values if upstream assurance is consumed, with missing or unknown values failing closed;
+- step-up requirements for security-sensitive operations rather than only at initial login;
+- revocation of affected interactive sessions after factor reset, recovery, or removal while keeping machine credentials an explicit independent class;
+- audit events and operator notifications that contain stable identifiers but no authenticator secrets or recovery material;
+- accessible enrollment, challenge, recovery, and device-management flows with tested browser and multi-device behavior.
+
+Acceptance requires bypass tests across every session-creation path, recovery and factor-reset tests, replay and rate-limit tests, provider-claim tests, direct authorization tests for step-up operations, and an operational runbook. A future implementation must update this decision instead of silently weakening it.
+
+## Revisit triggers
+
+Revisit this boundary when a supported deployment requires local users with MFA, LeapView introduces step-up authorization for sensitive actions, or a provider-assurance contract must be enforced inside the application. Until then, external provider enforcement is the supported MFA boundary.
+
+See [OIDC](/docs/security/oidc), [Local authentication](/docs/security/local-auth), and [Roles, grants, and policies](/docs/security/authorization) for the surrounding identity and authorization controls.

--- a/docs/articles/security/oidc.md
+++ b/docs/articles/security/oidc.md
@@ -59,6 +59,8 @@ Test with a non-administrator user. An owner account can hide missing group prov
 
 Use provider MFA and conditional access. Restrict who may use the client, protect client-secret rotation, and monitor provider-side sign-in events. Keep redirect URI lists narrow and remove retired callbacks.
 
+LeapView currently delegates the MFA decision to the provider and does not authorize from `acr` or `amr` assurance claims. Read the [MFA security decision boundary](/docs/security/mfa-boundary) before describing the deployment's assurance level or requiring application-side step-up.
+
 When rotating the client secret, install the new value through the secret manager and coordinate restart without exposing either value. Verify login before revoking the old provider credential where the provider supports overlap.
 
 ## Validate the configuration

--- a/docs/enterprise-auth.md
+++ b/docs/enterprise-auth.md
@@ -6,6 +6,7 @@ LeapView separates authentication, provisioning, authorization, workload identit
 
 - Use [Local authentication](/docs/security/local-auth) for self-hosted users and a controlled break-glass path.
 - Use [OIDC](/docs/security/oidc) for interactive enterprise browser login.
+- Use the [MFA security decision boundary](/docs/security/mfa-boundary) to distinguish provider-enforced MFA from application-managed assurance, which is not currently supported.
 - Use browser/device authorization for `leapview login <target>`; CLI credentials remain separate from browser and Desktop sessions.
 
 Both sign-in modes resolve an ordinary LeapView principal. Authentication proves identity; it does not grant project-resource access.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -86,6 +86,7 @@ Focused slices are available at `/docs/agent-tools/tools/{name}.json|md`, `/docs
 - [Authentication and authorization](/docs/enterprise-auth): Understand LeapView identity and authorization boundaries.
 - [Local authentication](/docs/security/local-auth): Configure self-hosted and break-glass local users.
 - [OIDC](/docs/security/oidc): Connect an enterprise identity provider for browser login.
+- [MFA security decision boundary](/docs/security/mfa-boundary): Understand where MFA is enforced and what application-managed MFA requires.
 - [SCIM provisioning](/docs/security/scim): Provision users, groups, and memberships from a directory.
 - [Roles, grants, and policies](/docs/security/authorization): Assign least-privilege access to securable resources.
 - [Service principals and API tokens](/docs/security/tokens): Authenticate non-human workloads with scoped credentials.

--- a/docs/navigation.yaml
+++ b/docs/navigation.yaml
@@ -300,6 +300,11 @@ sections:
         type: how-to
         summary: Connect an enterprise identity provider for browser login.
         source: articles/security/oidc.md
+      - slug: security/mfa-boundary
+        title: MFA security decision boundary
+        type: explanation
+        summary: Understand where MFA is enforced and what application-managed MFA requires.
+        source: articles/security/mfa-boundary.md
       - slug: security/scim
         title: SCIM provisioning
         type: how-to


### PR DESCRIPTION
## Problem

The product documented provider MFA as a recommendation but did not state whether LeapView itself enforced MFA, whether local authentication was MFA-capable, or what assurance could be relied on after session creation. An ad hoc TOTP addition would create a control that could be bypassed through other authentication/session paths.

## Root cause

Browser sessions bind a token, principal, and lifetime but do not carry authentication method, authenticator identity, assurance level, authentication time, or step-up expiry. OIDC, local browser, Desktop, CLI, recovery, and API-token paths do not share an MFA issuance/policy model.

## Security risk closed

Operators now have a fail-closed decision boundary and cannot reasonably interpret local password auth or an uninspected provider claim as application-enforced MFA. The repository explicitly rejects minimal local TOTP without enrollment, recovery, replay, revocation, audit, and cross-client assurance controls.

## Solution

- Declare external OIDC/Entra conditional access as the supported MFA boundary.
- State that local authentication is password-only and suitable only where single factor is accepted or as controlled break glass.
- Document why minimal TOTP is not safe within the current architecture.
- Define prerequisites and acceptance criteria for future WebAuthn/passkey, recovery, provider-claim, session-assurance, and step-up work.
- Link the decision from the authentication landing page and both local-auth and OIDC guidance.

## Files/components changed

- `docs/articles/security/mfa-boundary.md`
- `docs/articles/security/local-auth.md`
- `docs/articles/security/oidc.md`
- `docs/enterprise-auth.md`
- Documentation navigation and generated `llms.txt`

## Tests added/updated

No runtime code was changed. Documentation generation and embedded-document contracts cover the new page and links.

## Verification performed

- `go run ./internal/app/tools/docsitegen --check`
- `go test ./internal/app/tools/docsitegen -count=1`
- `go test ./docs -count=1`

## Remaining limitations

LeapView does not currently provide application-managed MFA or authorize from `acr`/`amr` claims. Deployments requiring MFA must enforce it at the external provider. The decision record lists the implementation and bypass-test gates required before this can change.

Project: [Identity and Production Surface Hardening](https://linear.app/flid/project/identity-and-production-surface-hardening-458805365a8d)
