### PR TITLE
security: sanitize production readiness responses

### DIFF
--- a/docs/articles/operate/observability.md
+++ b/docs/articles/operate/observability.md
@@ -14,6 +14,8 @@ leapview healthcheck \
 
 Use liveness for process restart decisions and readiness for traffic admission. Keep both inexpensive; they should not execute a full dashboard query. Use separate synthetic probes for end-to-end analytical behavior.
 
+The unauthenticated readiness response contains only stable check names and fixed states. Reviewed delivery-startup diagnostics may expose documented non-secret codes; platform, analytics, runtime, lease, and arbitrary custom-check errors collapse to `failed`, and active project identifiers are not returned. Use restricted application logs, metrics, and offline operator commands for internal error details rather than widening the readiness payload.
+
 ## Metrics
 
 LeapView exposes Prometheus metrics behind `LEAPVIEW_METRICS_BEARER_TOKEN`. Production validation requires a strong token. Restrict the endpoint by network policy as well, inject the token into the scraper securely, and avoid logging it.

--- a/internal/app/health.go
+++ b/internal/app/health.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 
+	"github.com/flidai/leapview/internal/deployment"
 	apitransport "github.com/flidai/leapview/internal/platform/http/transport"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 )
@@ -51,14 +54,14 @@ func (h *health) Readyz(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 	defer cancel()
 	if err := h.config.Platform(ctx); err != nil {
-		checks["platformStore"] = err.Error()
+		checks["platformStore"] = "failed"
 		apitransport.WriteJSON(w, http.StatusServiceUnavailable, healthResponse{Status: "not_ready", Checks: checks})
 		return
 	}
 	checks["platformStore"] = "ok"
 	if h.config.Analytics != nil {
 		if err := h.config.Analytics(); err != nil {
-			checks["analytics"] = err.Error()
+			checks["analytics"] = "failed"
 			apitransport.WriteJSON(w, http.StatusServiceUnavailable, healthResponse{Status: "not_ready", Checks: checks})
 			return
 		}
@@ -74,12 +77,18 @@ func (h *health) Readyz(w http.ResponseWriter, r *http.Request) {
 		}
 		checks["runtimeLease"] = "ok"
 	}
-	for name, check := range h.config.Checks {
+	checkNames := make([]string, 0, len(h.config.Checks))
+	for name := range h.config.Checks {
+		checkNames = append(checkNames, name)
+	}
+	sort.Strings(checkNames)
+	for _, name := range checkNames {
+		check := h.config.Checks[name]
 		if check == nil {
 			continue
 		}
 		if err := check(ctx); err != nil {
-			checks[name] = err.Error()
+			checks[name] = stableReadinessFailure(err)
 			apitransport.WriteJSON(w, http.StatusServiceUnavailable, healthResponse{Status: "not_ready", Checks: checks})
 			return
 		}
@@ -99,7 +108,7 @@ func (h *health) runtimeReady(ctx context.Context, checks map[string]string) boo
 	}
 	projectID, err := h.config.ActiveProjectID(ctx)
 	if err != nil {
-		checks["runtime"] = err.Error()
+		checks["runtime"] = "failed"
 		return false
 	}
 	if err := projectID.Validate(); err != nil {
@@ -111,9 +120,52 @@ func (h *health) runtimeReady(ctx context.Context, checks map[string]string) boo
 			checks["runtime"] = "no_active_deployments"
 			return !h.config.RequireActiveDeployment
 		}
-		checks["projectRuntime:"+projectID.String()] = err.Error()
+		checks["runtime"] = "failed"
 		return false
 	}
-	checks["projectRuntime:"+projectID.String()] = "ok"
+	checks["runtime"] = "ok"
 	return true
+}
+
+// stableReadinessFailure preserves only the reviewed delivery-startup codes
+// that are part of the operator contract. Arbitrary dependency errors,
+// including wrapped platform paths or provider messages, collapse to a fixed
+// value before crossing the unauthenticated readiness boundary.
+func stableReadinessFailure(err error) string {
+	diagnostics := deployment.DeliveryStartupDiagnosticsOf(err)
+	if len(diagnostics) == 0 {
+		return "failed"
+	}
+	codes := make([]string, 0, len(diagnostics))
+	seen := map[deployment.DeliveryStartupDiagnosticCode]struct{}{}
+	for _, diagnostic := range diagnostics {
+		if !stableDeliveryStartupDiagnostic(diagnostic.Code) {
+			continue
+		}
+		if _, ok := seen[diagnostic.Code]; ok {
+			continue
+		}
+		seen[diagnostic.Code] = struct{}{}
+		codes = append(codes, string(diagnostic.Code))
+	}
+	if len(codes) == 0 {
+		return "failed"
+	}
+	sort.Strings(codes)
+	return strings.Join(codes, ",")
+}
+
+func stableDeliveryStartupDiagnostic(code deployment.DeliveryStartupDiagnosticCode) bool {
+	switch code {
+	case deployment.DeliveryStartupMissingPoolAdmission,
+		deployment.DeliveryStartupUnadmittedPool,
+		deployment.DeliveryStartupLegacyServingIdentity,
+		deployment.DeliveryStartupMixedServingPaths,
+		deployment.DeliveryStartupMissingTargetRevision,
+		deployment.DeliveryStartupMissingServingGeneration,
+		deployment.DeliveryStartupIndeterminatePublication:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/app/health_test.go
+++ b/internal/app/health_test.go
@@ -1,0 +1,139 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/deployment"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+)
+
+func TestReadyzDoesNotExposeDependencyErrors(t *testing.T) {
+	const secret = "postgres://operator:super-secret@db.internal/platform?token=private"
+	projectID := projectgraph.ResourceID("project:customer-secret")
+	tests := []struct {
+		name      string
+		config    healthConfig
+		wantBody  string
+		forbidden []string
+	}{
+		{
+			name:     "platform",
+			config:   healthConfig{Platform: func(context.Context) error { return errors.New(secret) }},
+			wantBody: `{"checks":{"platformStore":"failed"},"status":"not_ready"}` + "\n",
+		},
+		{
+			name: "analytics",
+			config: healthConfig{
+				Platform:  func(context.Context) error { return nil },
+				Analytics: func() error { return errors.New("analytics catalog at /var/lib/private: " + secret) },
+			},
+			wantBody: `{"checks":{"analytics":"failed","platformStore":"ok"},"status":"not_ready"}` + "\n",
+		},
+		{
+			name: "runtime lease",
+			config: healthConfig{
+				Platform:          func(context.Context) error { return nil },
+				RuntimeLeaseReady: func(context.Context) error { return errors.New("lease backend: " + secret) },
+			},
+			wantBody: `{"checks":{"platformStore":"ok","runtimeLease":"failed"},"status":"not_ready"}` + "\n",
+		},
+		{
+			name: "custom check",
+			config: healthConfig{
+				Platform: func(context.Context) error { return nil },
+				Checks: map[string]func(context.Context) error{
+					"mapAssets": func(context.Context) error { return errors.New("s3://private-bucket?" + secret) },
+				},
+			},
+			wantBody: `{"checks":{"mapAssets":"failed","platformStore":"ok"},"status":"not_ready"}` + "\n",
+		},
+		{
+			name: "active project lookup",
+			config: healthConfig{
+				Platform:        func(context.Context) error { return nil },
+				ActiveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return "", errors.New(secret) },
+				RuntimeReady:    func(context.Context) error { return nil },
+			},
+			wantBody: `{"checks":{"platformStore":"ok","runtime":"failed"},"status":"not_ready"}` + "\n",
+		},
+		{
+			name: "project runtime",
+			config: healthConfig{
+				Platform:        func(context.Context) error { return nil },
+				ActiveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return projectID, nil },
+				RuntimeReady: func(context.Context) error {
+					return errors.New("runtime path /private/" + projectID.String() + ": " + secret)
+				},
+			},
+			wantBody:  `{"checks":{"platformStore":"ok","runtime":"failed"},"status":"not_ready"}` + "\n",
+			forbidden: []string{projectID.String()},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			newHealth(test.config).Readyz(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+			if response.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+			}
+			if got := response.Body.String(); got != test.wantBody {
+				t.Fatalf("body = %q, want %q", got, test.wantBody)
+			}
+			for _, forbidden := range append([]string{secret, "super-secret", "db.internal", "/var/lib/private", "private-bucket"}, test.forbidden...) {
+				if strings.Contains(response.Body.String(), forbidden) {
+					t.Fatalf("response exposed %q: %s", forbidden, response.Body.String())
+				}
+			}
+		})
+	}
+}
+
+func TestReadyzExposesOnlyReviewedDeliveryStartupCodes(t *testing.T) {
+	deliveryErr := deployment.ValidateDeliveryStartup(deployment.DeliveryStartupState{
+		TargetID:   "customer-secret-target",
+		Production: true,
+	})
+	response := httptest.NewRecorder()
+	newHealth(healthConfig{
+		Platform: func(context.Context) error { return nil },
+		Checks: map[string]func(context.Context) error{
+			"deliveryStartup": func(context.Context) error { return deliveryErr },
+		},
+	}).Readyz(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+	}
+	want := `{"checks":{"deliveryStartup":"missing_physical_pool_admission,target_revision_missing","platformStore":"ok"},"status":"not_ready"}` + "\n"
+	if got := response.Body.String(); got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+	if strings.Contains(response.Body.String(), "customer-secret-target") || strings.Contains(response.Body.String(), "delivery startup is not ready") {
+		t.Fatalf("response exposed delivery error context: %s", response.Body.String())
+	}
+}
+
+func TestReadyzUsesStableRuntimeKeyWhenReady(t *testing.T) {
+	response := httptest.NewRecorder()
+	newHealth(healthConfig{
+		Platform:        func(context.Context) error { return nil },
+		ActiveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return "project:internal-name", nil },
+		RuntimeReady:    func(context.Context) error { return nil },
+	}).Readyz(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	want := `{"checks":{"platformStore":"ok","runtime":"ok"},"status":"ready"}` + "\n"
+	if got := response.Body.String(); got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+	if strings.Contains(response.Body.String(), "internal-name") {
+		t.Fatalf("response exposed project identity: %s", response.Body.String())
+	}
+}


### PR DESCRIPTION
## Problem

The unauthenticated `/readyz` endpoint serialized raw platform, analytics, runtime, and arbitrary custom-check errors. Runtime keys also embedded the active project identifier.

## Root cause

The readiness handler copied `err.Error()` directly into its public JSON map and used `projectRuntime:<project-id>` as a response key. The only sanitized dependency path was the runtime lease check.

## Security risk closed

Database URLs, filesystem paths, provider messages, project identifiers, and other internal diagnostics can no longer cross the unauthenticated readiness boundary.

## Solution

- Collapse platform, analytics, lease, runtime, and arbitrary custom-check failures to fixed states.
- Use one stable `runtime` key instead of a project-qualified key.
- Preserve only explicitly allowlisted, typed delivery-startup codes that are already part of the non-secret operator contract.
- Sort custom-check execution for deterministic first-failure behavior.
- Document where operators should obtain restricted diagnostic detail.

## Files/components changed

- `internal/app/health.go`
- `internal/app/health_test.go`
- `docs/articles/operate/observability.md`

## Tests added/updated

Direct response tests cover raw platform, analytics, lease, custom-check, active-project, and runtime errors; project-identity suppression; reviewed delivery codes; and the successful stable runtime response.

## Verification performed

- `go test ./internal/app -run '^(TestReadyz|TestAuditOutboxReadiness)' -count=1`

## Remaining limitations

The response intentionally retains stable check names and reviewed delivery codes for traffic admission and controlled bootstrap. Internal error detail remains a restricted logs/metrics/offline-operations concern.

Project: [Identity and Production Surface Hardening](https://linear.app/flid/project/identity-and-production-surface-hardening-458805365a8d)
