### PR TITLE
security: protect backup archive directories

### DIFF
--- a/docs/articles/operate/backup-restore.md
+++ b/docs/articles/operate/backup-restore.md
@@ -13,8 +13,11 @@ Dashboard source history belongs in Git, but Git cannot restore user principals,
 Write the archive outside the active instance directory:
 
 ```sh
-leapview admin backup --out /srv/backups/leapview-2026-07-16.tar
+install -d -m 0700 /srv/backups
+leapview admin backup --out /srv/backups/leapview-2026-07-16.tar.gz
 ```
+
+Use a dedicated backup directory rather than a shared output directory. The direct backup path enforces mode `0700` on its parent and `0600` on the completed archive even when the process umask is permissive. Compose and supported host installations apply the same private directory, archive, checksum, and systemd `UMask=0077` contract.
 
 The output path must not already exist. Record a checksum, creation time, LeapView version, storage-backend configuration, and the identity of any corresponding external catalog or object-store recovery point.
 

--- a/internal/platform/instance_backup.go
+++ b/internal/platform/instance_backup.go
@@ -223,7 +223,7 @@ func BackupInstance(ctx context.Context, options InstanceBackupOptions) error {
 		return err
 	}
 	outParent := filepath.Dir(outAbs)
-	if err := os.MkdirAll(outParent, 0o755); err != nil {
+	if err := securefs.EnsurePrivateDir(outParent); err != nil {
 		return err
 	}
 	homeParent := filepath.Dir(homeAbs)
@@ -237,6 +237,11 @@ func BackupInstance(ctx context.Context, options InstanceBackupOptions) error {
 	}
 	tmpArchive, err := os.CreateTemp(outParent, fmt.Sprintf(".leapview-instance-backup-%s-*.tar.gz", targetID))
 	if err != nil {
+		return err
+	}
+	if err := tmpArchive.Chmod(securefs.PrivateFileMode); err != nil {
+		_ = tmpArchive.Close()
+		_ = os.Remove(tmpArchive.Name())
 		return err
 	}
 	tmpArchivePath := tmpArchive.Name()

--- a/internal/platform/store_test.go
+++ b/internal/platform/store_test.go
@@ -628,12 +628,18 @@ func TestBackupInstanceCreatesPrivateArchive(t *testing.T) {
 	}
 
 	restoreUmask := setUmask(t, 0)
-	backupPath := filepath.Join(dir, "backups", "leapview-instance.tar.gz")
+	backupDir := filepath.Join(dir, "backups")
+	if err := os.Mkdir(backupDir, 0o755); err != nil {
+		restoreUmask()
+		t.Fatalf("seed permissive backup directory: %v", err)
+	}
+	backupPath := filepath.Join(backupDir, "leapview-instance.tar.gz")
 	if err := BackupInstance(ctx, InstanceBackupOptions{HomeDir: home, DBPath: dbPath, OutPath: backupPath}); err != nil {
 		restoreUmask()
 		t.Fatalf("backup instance: %v", err)
 	}
 	restoreUmask()
+	assertFileMode(t, backupDir, 0o700)
 	assertFileMode(t, backupPath, 0o600)
 }
 


### PR DESCRIPTION
## Problem

Direct full-instance backups created a missing archive parent directory with mode `0755`. The archive itself was private, but directory listing/traversal remained broader than the database-only, Compose, and supported host-install backup contracts.

## Root cause

`BackupInstance` used a literal permissive `os.MkdirAll` mode and relied on `os.CreateTemp` for archive-file permissions instead of using the repository's private-filesystem boundary.

## Security risk closed

Sensitive backup locations no longer remain group/world accessible when a permissive process umask or pre-existing `0755` directory is present.

## Solution

- Enforce the shared `0700` private-directory contract for the direct archive parent.
- Explicitly set the temporary/final archive inode to `0600` before writing sensitive state.
- Extend operator guidance to require a dedicated backup directory and describe the Compose/host `UMask=0077` contract.

## Files/components changed

- `internal/platform/instance_backup.go`
- `internal/platform/store_test.go`
- `docs/articles/operate/backup-restore.md`

## Tests added/updated

The regression test sets umask to zero, seeds the output directory as `0755`, performs a full-instance backup, and verifies the directory is `0700` and archive is `0600`.

## Verification performed

- `go test ./internal/platform -run '^(TestBackupInstanceCreatesPrivateArchive|TestStoreBackupCreatesPrivateDatabaseCopy)$' -count=1`
- `go test ./internal/platform -run '^TestBackupInstance' -count=1`

## Remaining limitations

Operators should choose a dedicated output directory because its mode is intentionally hardened. S3-managed data and remote DuckLake/catalog stores still require their native backup/versioning controls.

Project: [Identity and Production Surface Hardening](https://linear.app/flid/project/identity-and-production-surface-hardening-458805365a8d)
