### PR TITLE
build: freeze production runtime OS packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,12 @@ LABEL org.opencontainers.image.title="LeapView" \
       dev.leapview.build.dirty="$BUILD_DIRTY" \
       dev.leapview.build.release="$BUILD_RELEASE"
 
+# The pinned Go builder supplies the bootstrap CA bundle. APT then resolves
+# every direct and transitive runtime package from one immutable Debian
+# snapshot and verifies the signed repository metadata and package hashes.
+COPY --from=go-deps /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY deploy/container/debian-bookworm.sources /etc/apt/sources.list.d/debian.sources
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates libstdc++6 tzdata && \
     rm -rf /var/lib/apt/lists/*

--- a/deploy/container/debian-bookworm.sources
+++ b/deploy/container/debian-bookworm.sources
@@ -1,0 +1,15 @@
+# Frozen release-image package universe. Update the timestamp only in a
+# reviewed dependency refresh that rebuilds and scans both release platforms.
+Types: deb
+URIs: https://snapshot.debian.org/archive/debian/20260820T000000Z/
+Suites: bookworm bookworm-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: no
+
+Types: deb
+URIs: https://snapshot.debian.org/archive/debian-security/20260820T000000Z/
+Suites: bookworm-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: no

--- a/docs/articles/security/dependency-clearance.md
+++ b/docs/articles/security/dependency-clearance.md
@@ -37,6 +37,14 @@ notices, deduplicated by advisory and module. They do not satisfy the scanner's
 definition of affected code and therefore do not require a waiver. A finding
 with a symbol-level call trace is recorded as reachable and blocks clearance.
 
+## Runtime OS packages
+
+The production server image combines a digest-pinned Debian base with the dated sources in `deploy/container/debian-bookworm.sources`. Both the Debian and Debian security suites use one immutable snapshot timestamp. APT binds each source to the Debian archive keyring, verifies signed repository metadata and package hashes, and therefore resolves direct and transitive packages from a frozen package universe on both release architectures. The bootstrap CA bundle comes from the separately digest-pinned Go builder before APT connects to the HTTPS snapshot.
+
+The distroless public-site runtime installs no OS packages. The authoring qualification image derives from the server runtime and inherits its frozen sources. The malicious-browser proof image is test-only, and the Ubuntu host bootstrap is an installation-time patching boundary: it intentionally consumes the current signed Ubuntu 24.04 repositories and enables unattended upgrades rather than becoming part of the immutable application image.
+
+To refresh runtime packages, choose a reviewed snapshot containing the intended security updates, update the snapshot timestamp and the pinned runtime base digest together, build both `linux/amd64` and `linux/arm64`, inspect the installed package inventory, and rerun container vulnerability and provenance checks. Do not point a release build back at a moving mirror.
+
 ## Waivers
 
 Waivers are optional JSON in `security/dependency-waivers.json`. Reports bind

--- a/internal/platform/architecture/runtime_os_packages_test.go
+++ b/internal/platform/architecture/runtime_os_packages_test.go
@@ -1,0 +1,83 @@
+package architecture
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestProductionRuntimeOSPackagesUseFrozenSignedSnapshot(t *testing.T) {
+	root := repoRoot(t)
+	dockerfileBytes, err := os.ReadFile(filepath.Join(root, "Dockerfile"))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	sourcesPath := filepath.Join("deploy", "container", "debian-bookworm.sources")
+	sourcesBytes, err := os.ReadFile(filepath.Join(root, sourcesPath))
+	if err != nil {
+		t.Fatalf("read runtime package sources: %v", err)
+	}
+	dockerfile := string(dockerfileBytes)
+	sources := string(sourcesBytes)
+
+	copySources := "COPY " + filepath.ToSlash(sourcesPath) + " /etc/apt/sources.list.d/debian.sources"
+	for _, required := range []string{
+		"FROM debian:bookworm-slim@sha256:",
+		"COPY --from=go-deps /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt",
+		copySources,
+		"apt-get install -y --no-install-recommends ca-certificates libstdc++6 tzdata",
+	} {
+		if !strings.Contains(dockerfile, required) {
+			t.Fatalf("Dockerfile missing reproducible runtime package fragment %q", required)
+		}
+	}
+	if copyAt, updateAt := strings.Index(dockerfile, copySources), strings.Index(dockerfile, "RUN apt-get update"); copyAt < 0 || updateAt < 0 || copyAt > updateAt {
+		t.Fatal("frozen Debian sources must replace the image defaults before apt-get update")
+	}
+
+	snapshotPattern := regexp.MustCompile(`/([0-9]{8}T[0-9]{6}Z)/`)
+	matches := snapshotPattern.FindAllStringSubmatch(sources, -1)
+	if len(matches) != 2 || matches[0][1] != matches[1][1] {
+		t.Fatalf("runtime sources must pin Debian and Debian security to one timestamp: %q", sources)
+	}
+	for _, required := range []string{
+		"URIs: https://snapshot.debian.org/archive/debian/" + matches[0][1] + "/",
+		"URIs: https://snapshot.debian.org/archive/debian-security/" + matches[0][1] + "/",
+		"Suites: bookworm bookworm-updates",
+		"Suites: bookworm-security",
+		"Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg",
+		"Check-Valid-Until: no",
+	} {
+		if !strings.Contains(sources, required) {
+			t.Fatalf("runtime package sources missing %q", required)
+		}
+	}
+	for _, movingSource := range []string{"deb.debian.org", "security.debian.org", "archive.ubuntu.com"} {
+		if strings.Contains(sources, movingSource) {
+			t.Fatalf("runtime package sources contain moving repository %q", movingSource)
+		}
+	}
+	if count := strings.Count(sources, "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg"); count != 2 {
+		t.Fatalf("signed repository binding count = %d, want 2", count)
+	}
+	if count := strings.Count(sources, "Check-Valid-Until: no"); count != 2 {
+		t.Fatalf("snapshot validity override count = %d, want 2", count)
+	}
+
+	siteDockerfile, err := os.ReadFile(filepath.Join(root, "Dockerfile.site"))
+	if err != nil {
+		t.Fatalf("read Dockerfile.site: %v", err)
+	}
+	if strings.Contains(string(siteDockerfile), "apt-get install") {
+		t.Fatal("distroless site runtime unexpectedly installs OS packages")
+	}
+	qualificationDockerfile, err := os.ReadFile(filepath.Join(root, "deploy", "compose", "qualification", "Dockerfile.authoring-client"))
+	if err != nil {
+		t.Fatalf("read authoring qualification Dockerfile: %v", err)
+	}
+	if strings.Contains(string(qualificationDockerfile), "deb.debian.org") || strings.Contains(string(qualificationDockerfile), "snapshot.debian.org") {
+		t.Fatal("derived qualification image must inherit the release image's frozen sources without overriding them")
+	}
+}


### PR DESCRIPTION
## Problem

The production server image pinned its Debian base by digest but resolved `ca-certificates`, `libstdc++6`, `tzdata`, and all transitive dependencies from moving live repositories. Rebuilding the same commit could therefore produce a different runtime package inventory.

## Root cause

The runtime stage inherited Debian's default sources and ran an unversioned `apt-get update`/install. Direct version pins alone would still leave transitive resolution and repository retention unstable across amd64 and arm64.

## Security risk closed

Release rebuilds now resolve the same signed package universe instead of silently accepting newly published or replaced OS packages.

## Solution

- Add dated Debian and Debian-security deb822 sources pinned to `20260820T000000Z`.
- Bind both sources to the Debian archive keyring and retain APT signed-metadata/package-hash verification.
- Bootstrap HTTPS trust from the separately digest-pinned Go builder.
- Replace the runtime's default source file before `apt-get update`; the derived authoring qualification image inherits the frozen sources.
- Add an architecture contract test and a documented two-architecture refresh procedure.

## Files/components changed

- `Dockerfile`
- `deploy/container/debian-bookworm.sources`
- `internal/platform/architecture/runtime_os_packages_test.go`
- `docs/articles/security/dependency-clearance.md`

## Tests added/updated

The contract test validates source ordering, one timestamp across Debian/security, signed keyring bindings, absence of moving mirrors, required runtime packages, the package-free distroless site runtime, and qualification-image inheritance.

## Verification performed

- `go test ./internal/platform/architecture -run '^(TestProductionRuntimeOSPackagesUseFrozenSignedSnapshot|TestProductionContainerContractExists)$' -count=1`
- Confirmed all three pinned `InRelease` endpoints (bookworm, bookworm-updates, and bookworm-security) resolve on the official Debian snapshot service.

## Remaining limitations

Docker is not installed in the local execution environment, so the actual multi-architecture image build and container scan must run in PR CI. The Ubuntu host bootstrap intentionally consumes current signed Ubuntu 24.04 packages and enables unattended upgrades; it is an installation-time patching boundary, not part of the immutable application image. The malicious-browser proof image is test-only.

Project: [Identity and Production Surface Hardening](https://linear.app/flid/project/identity-and-production-surface-hardening-458805365a8d)
