### PR TITLE
fix(ci): accept canonical attestation claims

### DIFF
--- a/internal/app/tools/ociadmission/admission.go
+++ b/internal/app/tools/ociadmission/admission.go
@@ -280,12 +280,26 @@ func verifyAttestation(data []byte, workflow, revision string) bool {
 	}
 	for _, entry := range entries {
 		cert := entry.VerificationResult.Signature.Certificate
-		if stringValue(cert["sourceRepository"]) != repositoryIdentity {
+		repositoryValue := firstJSONAlternative(cert, "sourceRepositoryURI", "sourceRepository")
+		if !matchesRepositoryIdentity(repositoryValue) {
 			continue
 		}
-		workflowValue := firstJSONAlternative(cert, "workflow", "workflowPath", "buildConfigURI", "subjectAlternativeName")
+		workflowValue := firstJSONAlternative(cert, "buildSignerURI", "subjectAlternativeName", "workflow", "workflowPath", "buildConfigURI")
 		revisionValue := firstJSONAlternative(cert, "sourceRepositoryDigest", "sourceDigest")
-		if strings.Contains(workflowValue, workflow) && revisionValue == revision {
+		if matchesWorkflowIdentity(workflowValue, workflow) && revisionValue == revision {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesRepositoryIdentity(value string) bool {
+	return value == repositoryIdentity || value == "https://github.com/"+repositoryIdentity
+}
+
+func matchesWorkflowIdentity(value, workflow string) bool {
+	for _, expected := range []string{workflow, "https://github.com/" + workflow} {
+		if value == expected || strings.HasPrefix(value, expected+"@") {
 			return true
 		}
 	}

--- a/internal/app/tools/ociadmission/main_test.go
+++ b/internal/app/tools/ociadmission/main_test.go
@@ -52,6 +52,7 @@ func TestLiveAdmissionContractWithFakeTools(t *testing.T) {
 		name, mode, want string
 	}{
 		{"valid attestation SBOM scanner and policy", "valid", ""},
+		{"wrong repository", "wrong-repository", "identity or source revision"},
 		{"wrong workflow", "wrong-workflow", "identity or source revision"},
 		{"wrong source revision", "wrong-revision", "identity or source revision"},
 		{"missing SBOM", "missing-sbom", "no SPDX SBOM"},
@@ -78,6 +79,25 @@ func TestLiveAdmissionContractWithFakeTools(t *testing.T) {
 	}
 }
 
+func TestVerifyAttestationAcceptsGitHubCLICertificateSchema(t *testing.T) {
+	payload := []map[string]any{{
+		"verificationResult": map[string]any{
+			"signature": map[string]any{"certificate": map[string]any{
+				"sourceRepositoryURI":    "https://github.com/" + repositoryIdentity,
+				"buildSignerURI":         "https://github.com/" + testWorkflow + "@refs/heads/main",
+				"sourceRepositoryDigest": testRevision,
+			}},
+		},
+	}}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifyAttestation(data, testWorkflow, testRevision) {
+		t.Fatal("verifyAttestation rejected the canonical GitHub CLI certificate schema")
+	}
+}
+
 func TestLiveAdmissionRejectsMissingVerifier(t *testing.T) {
 	policyPath, _ := testPolicy(t)
 	var output bytes.Buffer
@@ -93,16 +113,25 @@ func TestAttestationCanonicalClaimsCannotBeBypassedByFallbacks(t *testing.T) {
 		certificate map[string]any
 	}{
 		{
+			name: "empty canonical repository",
+			certificate: map[string]any{
+				"sourceRepositoryURI": "", "sourceRepository": repositoryIdentity,
+				"buildSignerURI": "https://github.com/" + testWorkflow + "@refs/heads/main", "sourceRepositoryDigest": testRevision,
+			},
+		},
+		{
 			name: "empty canonical workflow",
 			certificate: map[string]any{
-				"sourceRepository": repositoryIdentity, "workflow": "", "workflowPath": testWorkflow,
+				"sourceRepositoryURI": "https://github.com/" + repositoryIdentity,
+				"buildSignerURI":      "", "subjectAlternativeName": "https://github.com/" + testWorkflow + "@refs/heads/main",
 				"sourceRepositoryDigest": testRevision,
 			},
 		},
 		{
 			name: "empty canonical revision",
 			certificate: map[string]any{
-				"sourceRepository": repositoryIdentity, "workflow": testWorkflow,
+				"sourceRepositoryURI":    "https://github.com/" + repositoryIdentity,
+				"buildSignerURI":         "https://github.com/" + testWorkflow + "@refs/heads/main",
 				"sourceRepositoryDigest": "", "sourceDigest": testRevision,
 			},
 		},
@@ -245,7 +274,7 @@ func testEnv(values map[string]string) []string {
 func liveTools(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	writeTool(t, filepath.Join(dir, "gh"), "#!/bin/sh\nset -eu\nif [ \"$3\" = --help ]; then exit 0; fi\nworkflow='"+testWorkflow+"'\nrevision='"+testRevision+"'\n[ \"$OCI_TEST_MODE\" = wrong-workflow ] && workflow='flidai/leapview/.github/workflows/untrusted.yml'\n[ \"$OCI_TEST_MODE\" = wrong-revision ] && revision='ffffffffffffffffffffffffffffffffffffffff'\nprintf '[{\"verificationResult\":{\"signature\":{\"certificate\":{\"sourceRepository\":\"flidai/leapview\",\"workflow\":\"%s\",\"sourceRepositoryDigest\":\"%s\"}}}}]\\n' \"$workflow\" \"$revision\"\n")
+	writeTool(t, filepath.Join(dir, "gh"), "#!/bin/sh\nset -eu\nif [ \"$3\" = --help ]; then exit 0; fi\nrepository='https://github.com/"+repositoryIdentity+"'\nworkflow='https://github.com/"+testWorkflow+"@refs/heads/main'\nrevision='"+testRevision+"'\n[ \"$OCI_TEST_MODE\" = wrong-repository ] && repository='https://github.com/attacker/example'\n[ \"$OCI_TEST_MODE\" = wrong-workflow ] && workflow='https://github.com/flidai/leapview/.github/workflows/untrusted.yml@refs/heads/main'\n[ \"$OCI_TEST_MODE\" = wrong-revision ] && revision='ffffffffffffffffffffffffffffffffffffffff'\nprintf '[{\"verificationResult\":{\"signature\":{\"certificate\":{\"sourceRepositoryURI\":\"%s\",\"buildSignerURI\":\"%s\",\"sourceRepositoryDigest\":\"%s\"}}}}]\\n' \"$repository\" \"$workflow\" \"$revision\"\n")
 	writeTool(t, filepath.Join(dir, "docker"), "#!/bin/sh\nset -eu\ncase \"$*\" in\n  *'imagetools inspect'*)\n    [ \"$OCI_TEST_MODE\" = missing-sbom ] && printf '{}\\n' || printf '{\"SPDX\":{\"SPDXID\":\"SPDXRef-DOCUMENT\"}}\\n';;\n  *) exit 64;;\nesac\n")
 	writeTool(t, filepath.Join(dir, "trivy"), "#!/bin/sh\nset -eu\nif [ \"$1\" = version ]; then printf '{\"Version\":\"0.74.0\"}\\n'; exit 0; fi\n[ \"$OCI_TEST_MODE\" = unavailable ] && exit 70\n[ \"$OCI_TEST_MODE\" = vulnerable ] && printf '{\"Results\":[{\"Vulnerabilities\":[{\"VulnerabilityID\":\"CVE-2026-0001\"}]}]}\\n' || printf '{\"Results\":[]}\\n'\n")
 	return dir


### PR DESCRIPTION
## Problem

The main production-image workflow built and signed the immutable image successfully, but repository-owned OCI admission rejected it before qualification with `attestation identity or source revision is wrong`.

## Root cause

GitHub CLI v2.98.0 verified the image's attestation, signer workflow, GitHub-hosted runner, and exact source revision successfully. LeapView then reparsed the verified certificate JSON and expected the obsolete field `sourceRepository`. Current GitHub CLI emits the canonical certificate extension as `sourceRepositoryURI`, so the second-stage parser rejected valid provenance. The fake `gh` fixture used the obsolete shape and hid the production schema mismatch.

## Solution

- Read the canonical `sourceRepositoryURI`, `buildSignerURI`, and `sourceRepositoryDigest` certificate claims emitted by current GitHub CLI.
- Retain narrowly ordered legacy fallbacks without allowing an explicit empty canonical claim to be bypassed.
- Require exact repository identity and exact workflow identity, permitting only the signed `@ref` suffix.
- Preserve GitHub CLI enforcement of repository, signer workflow, source revision, and GitHub-hosted runners; no security check is weakened.
- Update the live fake-tool fixture to match the production certificate schema and cover wrong repository, workflow, and revision claims.

## Tests added/updated

- Added a regression test using the canonical GitHub CLI certificate JSON shape.
- Added wrong-repository coverage to the live admission contract.
- Extended fail-closed fallback tests for repository, workflow, and revision claims.

## Verification performed

- Reproduced the original failure from [Main artifacts run 32812565167](https://github.com/flidai/leapview/actions/runs/32812565167).
- Confirmed the signed certificate contains:
  - signer: `flidai/leapview/.github/workflows/artifacts.yml@refs/heads/main`
  - source revision: `54d007fcbd457ef2bcc933407070a5e395c77568`
  - runner environment: `github-hosted`
- Verified the exact published digest with official GitHub CLI v2.98.0 using `--repo`, `--signer-workflow`, `--source-digest`, and `--deny-self-hosted-runners`.
- Ran the fixed repository-owned admission command end-to-end against that exact live attestation; it emitted a verified admission record for the expected workflow and revision. SBOM and vulnerability-command outputs were hermetic test doubles in this reproduction, so this does not replace the post-merge production qualification run.
- `go test ./internal/app/tools/ociadmission -count=1`
- Focused security/architecture contract tests passed.
- `git diff --check`

## Remaining limitations

- The failed image remains unqualified; after this PR merges, the main artifacts workflow must rebuild/admit/qualify an immutable image successfully.
- Main artifacts currently qualifies `linux/amd64`. The existing release candidate workflow remains responsible for native `amd64` and `arm64` builds, per-platform admission, multi-platform assembly, and downstream qualification/scanning.

## Tracking

Project: [Identity and Production Surface Hardening](https://linear.app/flid/project/identity-and-production-surface-hardening-458805365a8d)
