### PR TITLE
ci: retry transient macOS DMG detach failures

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,9 +9,9 @@
     "build": "node scripts/build.mjs",
     "evidence": "node scripts/release-evidence.mjs",
     "start": "bun run build && bun scripts/run-electron.mjs start",
-    "test": "bun test ./src && node --test vendor/brace-expansion-compat.test.cjs vendor/image-size-next-compat.test.cjs scripts/accessibility-contract.test.mjs scripts/distribution-packaging.test.mjs scripts/native-maker-modules.test.mjs scripts/package-startup-policy.test.mjs scripts/packaged-diagnostics.test.mjs scripts/preview-release.test.mjs scripts/release-evidence.test.mjs scripts/release-operations.test.mjs scripts/verify-installer.test.mjs scripts/workflow-contract.test.mjs ../internal/app/testing/maliciousinstance/electron/policy.test.mjs",
+    "test": "bun test ./src && node --test vendor/brace-expansion-compat.test.cjs vendor/image-size-next-compat.test.cjs scripts/accessibility-contract.test.mjs scripts/distribution-packaging.test.mjs scripts/make-with-dmg-retry.test.mjs scripts/native-maker-modules.test.mjs scripts/package-startup-policy.test.mjs scripts/packaged-diagnostics.test.mjs scripts/preview-release.test.mjs scripts/release-evidence.test.mjs scripts/release-operations.test.mjs scripts/verify-installer.test.mjs scripts/workflow-contract.test.mjs ../internal/app/testing/maliciousinstance/electron/policy.test.mjs",
     "package": "bun run build && bun scripts/run-electron.mjs package && node scripts/verify-package.mjs",
-    "make": "bun run build && bun scripts/run-electron.mjs make && node scripts/verify-package.mjs && node scripts/verify-installer.mjs"
+    "make": "bun run build && node scripts/make-with-dmg-retry.mjs && node scripts/verify-package.mjs && node scripts/verify-installer.mjs"
   },
   "devDependencies": {
     "@electron-forge/cli": "8.0.0-alpha.9",

--- a/desktop/scripts/make-with-dmg-retry.mjs
+++ b/desktop/scripts/make-with-dmg-retry.mjs
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const desktopRoot = resolve(import.meta.dirname, "..");
+const capturedOutputLimit = 128 * 1024;
+const detachCommand = "hdiutil detach /Volumes/LeapView";
+const alreadyDetachedError = "hdiutil: detach failed - No such file or directory";
+const maximumSignatureSeparation = 512;
+
+export function isAlreadyDetachedDMGFailure(output) {
+  const commandIndex = output.indexOf(detachCommand);
+  if (commandIndex < 0) return false;
+
+  const errorIndex = output.indexOf(
+    alreadyDetachedError,
+    commandIndex + detachCommand.length,
+  );
+  return errorIndex >= 0 && errorIndex - commandIndex <= maximumSignatureSeparation;
+}
+
+export async function runWithDMGDetachRetry(
+  runMake,
+  {
+    platform = process.platform,
+    diagnostic = (message) => console.error(message),
+  } = {},
+) {
+  const first = await runMake();
+  if (
+    first.code === 0 ||
+    platform !== "darwin" ||
+    !isAlreadyDetachedDMGFailure(first.output)
+  ) {
+    return first.code;
+  }
+
+  diagnostic(
+    "macOS DMG cleanup found an already-detached LeapView volume; retrying Electron Forge make once",
+  );
+  const retry = await runMake();
+  return retry.code;
+}
+
+async function runElectronMake() {
+  const child = spawn("bun", ["scripts/run-electron.mjs", "make"], {
+    cwd: desktopRoot,
+    env: process.env,
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+  let output = "";
+
+  const forward = (stream, destination) => {
+    stream.on("data", (chunk) => {
+      destination.write(chunk);
+      output = `${output}${chunk}`.slice(-capturedOutputLimit);
+    });
+  };
+  forward(child.stdout, process.stdout);
+  forward(child.stderr, process.stderr);
+
+  return await new Promise((resolveResult, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => {
+      resolveResult({ code: code ?? 1, output });
+    });
+  });
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : "";
+if (invokedPath === import.meta.url) {
+  process.exitCode = await runWithDMGDetachRetry(runElectronMake);
+}

--- a/desktop/scripts/make-with-dmg-retry.test.mjs
+++ b/desktop/scripts/make-with-dmg-retry.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runWithDMGDetachRetry } from "./make-with-dmg-retry.mjs";
+
+const transientDetachFailure = `Making a dmg distributable for darwin/x64
+Command failed: hdiutil detach /Volumes/LeapView
+hdiutil: detach failed - No such file or directory`;
+
+test("retries one macOS make after the exact already-detached DMG failure", async () => {
+  const attempts = [
+    { code: 1, output: transientDetachFailure },
+    { code: 0, output: "DMG created" },
+  ];
+  const diagnostics = [];
+  let calls = 0;
+
+  const code = await runWithDMGDetachRetry(
+    async () => attempts[calls++],
+    { platform: "darwin", diagnostic: (message) => diagnostics.push(message) },
+  );
+
+  assert.equal(code, 0);
+  assert.equal(calls, 2);
+  assert.deepEqual(diagnostics, [
+    "macOS DMG cleanup found an already-detached LeapView volume; retrying Electron Forge make once",
+  ]);
+});
+
+test("does not retry unrelated, partial, or non-macOS failures", async (t) => {
+  for (const scenario of [
+    {
+      name: "unrelated make failure",
+      platform: "darwin",
+      output: "Electron Forge make failed",
+    },
+    {
+      name: "detach command without the exact error",
+      platform: "darwin",
+      output: "hdiutil detach /Volumes/LeapView\nhdiutil: detach failed - Resource busy",
+    },
+    {
+      name: "detach error without the exact command",
+      platform: "darwin",
+      output: "hdiutil: detach failed - No such file or directory",
+    },
+    {
+      name: "matching output on another platform",
+      platform: "linux",
+      output: transientDetachFailure,
+    },
+  ]) {
+    await t.test(scenario.name, async () => {
+      let calls = 0;
+      const code = await runWithDMGDetachRetry(
+        async () => {
+          calls += 1;
+          return { code: 23, output: scenario.output };
+        },
+        {
+          platform: scenario.platform,
+          diagnostic: () => assert.fail("unexpected retry"),
+        },
+      );
+
+      assert.equal(code, 23);
+      assert.equal(calls, 1);
+    });
+  }
+});
+
+test("keeps a failed retry fatal and never attempts a third make", async () => {
+  const attempts = [
+    { code: 1, output: transientDetachFailure },
+    { code: 42, output: "retry failed for another reason" },
+  ];
+  let calls = 0;
+
+  const code = await runWithDMGDetachRetry(
+    async () => attempts[calls++],
+    { platform: "darwin", diagnostic: () => undefined },
+  );
+
+  assert.equal(code, 42);
+  assert.equal(calls, 2);
+});
+
+test("does not retry a successful make", async () => {
+  let calls = 0;
+  const code = await runWithDMGDetachRetry(
+    async () => {
+      calls += 1;
+      return { code: 0, output: transientDetachFailure };
+    },
+    { platform: "darwin", diagnostic: () => assert.fail("unexpected retry") },
+  );
+
+  assert.equal(code, 0);
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
## Problem

The merge queue repeatedly failed during macOS Intel Electron packaging. Application packaging succeeds; the failure occurs during DMG cleanup when Electron Forge attempts to detach a volume that is already absent:

    hdiutil detach /Volumes/LeapView
    hdiutil: detach failed - No such file or directory

## Root cause

A transient DMG cleanup race can leave the LeapView volume already detached before Forge runs its cleanup detach command. Forge then treats the missing volume as a fatal make failure.

## Solution

Add a narrow retry wrapper around the existing Electron Forge make phase. A retry happens only when all of these conditions hold:

- the runner is macOS
- output contains the exact hdiutil detach /Volumes/LeapView command
- output contains the exact missing-volume error
- the initial make failed

The wrapper retries once only. Unrelated errors, partial matches, non-macOS failures, and a failed retry remain fatal.

Package verification and installer verification remain unchanged and continue to run only after a successful make.

## Tests added

Regression coverage verifies the exact retry path, unrelated and partial failures, non-macOS behavior, successful makes, and fatal retry failures.

## Verification performed

- Focused retry tests passed
- Full desktop tests passed: 141 Bun tests and 45 Node tests, with one expected platform skip
- Desktop build passed
- Node syntax checks passed
- git diff --check passed

## Remaining limitation

The native DMG path is exercised by macOS CI. No Electron Forge or DMG dependency versions were changed.