### PR TITLE
FAI-528: Define query-result dependency digest contract

### DIFF
--- a/internal/analytics/resultidentity/contract.go
+++ b/internal/analytics/resultidentity/contract.go
@@ -242,7 +242,11 @@ func NewDependency(input DependencyInput) (Dependency, error) {
 		return Dependency{}, fmt.Errorf("%w: serialize: %v", ErrInvalidDependency, err)
 	}
 
-	preimage := make([]byte, 0, len(DependencyDigestDomain)+1+len(canonical))
+	preimageCapacity, err := dependencyPreimageCapacity(len(canonical))
+	if err != nil {
+		return Dependency{}, err
+	}
+	preimage := make([]byte, 0, preimageCapacity)
 	preimage = append(preimage, DependencyDigestDomain...)
 	preimage = append(preimage, 0)
 	preimage = append(preimage, canonical...)
@@ -315,6 +319,19 @@ func validateExecution(identity ExecutionIdentity) error {
 		}
 	}
 	return nil
+}
+
+func dependencyPreimageCapacity(canonicalLength int) (int, error) {
+	maximumInt := int(^uint(0) >> 1)
+	domainLength := len(DependencyDigestDomain)
+	if canonicalLength < 0 || domainLength > maximumInt-1 {
+		return 0, fmt.Errorf("%w: dependency preimage size cannot be represented", ErrInvalidDependency)
+	}
+	overhead := domainLength + 1
+	if canonicalLength > maximumInt-overhead {
+		return 0, fmt.Errorf("%w: dependency preimage size cannot be represented", ErrInvalidDependency)
+	}
+	return overhead + canonicalLength, nil
 }
 
 func validateDigest(name, value string) error {

--- a/internal/analytics/resultidentity/contract.go
+++ b/internal/analytics/resultidentity/contract.go
@@ -1,0 +1,343 @@
+// Package resultidentity defines stable, storage- and engine-independent
+// identity contracts for analytical query results.
+package resultidentity
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	platformdigest "github.com/flidai/leapview/internal/platform/digest"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+)
+
+const (
+	// DependencyVersion is the canonical dependency serialization version.
+	DependencyVersion = 1
+	// PartitionVersion is the canonical result partition serialization version.
+	PartitionVersion = 1
+	// CacheKeyFormatVersion reserves the version of a future composite cache key
+	// without coupling this package to a cache implementation.
+	CacheKeyFormatVersion = 1
+
+	// DependencyDigestDomain separates dependency digests from other SHA-256
+	// content identities. The digest preimage is this value, one NUL byte, and
+	// the canonical dependency serialization.
+	DependencyDigestDomain = "flid.resultidentity.dependency.v1"
+)
+
+var (
+	// ErrInvalidDependency indicates a dependency input that cannot be given a
+	// canonical, collision-resistant identity.
+	ErrInvalidDependency = errors.New("invalid result dependency")
+	// ErrInvalidPartition indicates a malformed production or candidate result
+	// partition.
+	ErrInvalidPartition = errors.New("invalid result partition")
+)
+
+// PartitionKind identifies the serving namespace in which a result belongs.
+type PartitionKind string
+
+const (
+	PartitionProduction PartitionKind = "production"
+	PartitionCandidate  PartitionKind = "candidate"
+)
+
+// PartitionInput supplies the stable project scope for one result partition.
+// CandidateID must be empty for production and non-empty for candidates.
+type PartitionInput struct {
+	Kind        PartitionKind
+	ProjectID   projectgraph.ResourceID
+	Environment string
+	CandidateID string
+}
+
+// Partition is an immutable, opaque result namespace. Its canonical bytes are
+// owned by the value and accessors never expose mutable storage.
+type Partition struct {
+	kind        PartitionKind
+	projectID   projectgraph.ResourceID
+	environment string
+	candidateID string
+	canonical   []byte
+}
+
+// NewPartition validates and canonically serializes a result partition.
+func NewPartition(input PartitionInput) (Partition, error) {
+	if err := projectgraph.ValidateServingScope(input.ProjectID, input.Environment); err != nil {
+		return Partition{}, fmt.Errorf("%w: %v", ErrInvalidPartition, err)
+	}
+
+	switch input.Kind {
+	case PartitionProduction:
+		if input.CandidateID != "" {
+			return Partition{}, fmt.Errorf("%w: production candidate ID must be empty", ErrInvalidPartition)
+		}
+	case PartitionCandidate:
+		if err := validateOpaqueText(input.CandidateID); err != nil {
+			return Partition{}, fmt.Errorf("%w: candidate ID: %v", ErrInvalidPartition, err)
+		}
+	default:
+		return Partition{}, fmt.Errorf("%w: unknown kind %q", ErrInvalidPartition, input.Kind)
+	}
+
+	wire := partitionWire{
+		Version:     PartitionVersion,
+		Kind:        input.Kind,
+		ProjectID:   input.ProjectID.String(),
+		Environment: input.Environment,
+		CandidateID: input.CandidateID,
+	}
+	canonical, err := json.Marshal(wire)
+	if err != nil {
+		return Partition{}, fmt.Errorf("%w: serialize: %v", ErrInvalidPartition, err)
+	}
+	return Partition{
+		kind:        input.Kind,
+		projectID:   input.ProjectID,
+		environment: input.Environment,
+		candidateID: input.CandidateID,
+		canonical:   append([]byte(nil), canonical...),
+	}, nil
+}
+
+// Version returns the canonical serialization version.
+func (p Partition) Version() int {
+	if len(p.canonical) == 0 {
+		return 0
+	}
+	return PartitionVersion
+}
+
+// Kind returns the partition namespace kind.
+func (p Partition) Kind() PartitionKind { return p.kind }
+
+// ProjectID returns the stable project identity.
+func (p Partition) ProjectID() projectgraph.ResourceID { return p.projectID }
+
+// Environment returns the stable serving environment.
+func (p Partition) Environment() string { return p.environment }
+
+// CandidateID returns the candidate identity, or an empty string for a
+// production partition.
+func (p Partition) CandidateID() string { return p.candidateID }
+
+// Canonical returns a defensive copy of the versioned canonical serialization.
+func (p Partition) Canonical() []byte { return append([]byte(nil), p.canonical...) }
+
+type partitionWire struct {
+	Version     int           `json:"version"`
+	Kind        PartitionKind `json:"kind"`
+	ProjectID   string        `json:"projectId"`
+	Environment string        `json:"environment"`
+	CandidateID string        `json:"candidateId,omitempty"`
+}
+
+// RelationRevision identifies the exact content revision of one physical
+// relation referenced by a query result.
+type RelationRevision struct {
+	RelationID     projectgraph.ResourceID
+	RevisionDigest string
+}
+
+// ExecutionIdentity contains independently versionable identities for every
+// result-affecting execution concern.
+type ExecutionIdentity struct {
+	PlannerDigest    string
+	RuntimeDigest    string
+	CapabilityDigest string
+	SettingsDigest   string
+}
+
+// ResultFormat identifies the result representation contract.
+type ResultFormat struct {
+	Name    string
+	Version uint32
+}
+
+// DependencyInput supplies the complete result-affecting dependency set.
+// Dashboard presentation, serving generations, cache storage, and execution
+// engine objects are deliberately absent.
+type DependencyInput struct {
+	SemanticModelID     projectgraph.ResourceID
+	SemanticModelDigest string
+	Relations           []RelationRevision
+	BindingFingerprint  string
+	Execution           ExecutionIdentity
+	ResultFormat        ResultFormat
+}
+
+// Dependency is an immutable, opaque result dependency identity. Construction
+// owns the canonical bytes and digest; accessors do not expose mutable storage.
+type Dependency struct {
+	canonical []byte
+	digest    string
+}
+
+// NewDependency validates, orders, serializes, and hashes a complete result
+// dependency set.
+func NewDependency(input DependencyInput) (Dependency, error) {
+	if err := input.SemanticModelID.Validate(); err != nil {
+		return Dependency{}, fmt.Errorf("%w: semantic model ID: %v", ErrInvalidDependency, err)
+	}
+	if err := validateDigest("semantic model digest", input.SemanticModelDigest); err != nil {
+		return Dependency{}, err
+	}
+	if len(input.Relations) == 0 {
+		return Dependency{}, fmt.Errorf("%w: at least one relation revision is required", ErrInvalidDependency)
+	}
+	if err := validateDigest("binding fingerprint", input.BindingFingerprint); err != nil {
+		return Dependency{}, err
+	}
+	if err := validateExecution(input.Execution); err != nil {
+		return Dependency{}, err
+	}
+	if err := validateOpaqueText(input.ResultFormat.Name); err != nil {
+		return Dependency{}, fmt.Errorf("%w: result format name: %v", ErrInvalidDependency, err)
+	}
+	if input.ResultFormat.Version == 0 {
+		return Dependency{}, fmt.Errorf("%w: result format version must be positive", ErrInvalidDependency)
+	}
+
+	relations := make([]relationWire, len(input.Relations))
+	for index, relation := range input.Relations {
+		if err := relation.RelationID.Validate(); err != nil {
+			return Dependency{}, fmt.Errorf("%w: relation %d ID: %v", ErrInvalidDependency, index, err)
+		}
+		if err := validateDigest(fmt.Sprintf("relation %q revision digest", relation.RelationID), relation.RevisionDigest); err != nil {
+			return Dependency{}, err
+		}
+		relations[index] = relationWire{ID: relation.RelationID.String(), RevisionDigest: relation.RevisionDigest}
+	}
+	sort.Slice(relations, func(left, right int) bool { return relations[left].ID < relations[right].ID })
+	for index := 1; index < len(relations); index++ {
+		if relations[index-1].ID == relations[index].ID {
+			return Dependency{}, fmt.Errorf("%w: duplicate relation ID %q", ErrInvalidDependency, relations[index].ID)
+		}
+	}
+
+	wire := dependencyWire{
+		Version: DependencyVersion,
+		SemanticModel: semanticModelWire{
+			ID:     input.SemanticModelID.String(),
+			Digest: input.SemanticModelDigest,
+		},
+		Relations:          relations,
+		BindingFingerprint: input.BindingFingerprint,
+		Execution: executionWire{
+			PlannerDigest:    input.Execution.PlannerDigest,
+			RuntimeDigest:    input.Execution.RuntimeDigest,
+			CapabilityDigest: input.Execution.CapabilityDigest,
+			SettingsDigest:   input.Execution.SettingsDigest,
+		},
+		ResultFormat: resultFormatWire{Name: input.ResultFormat.Name, Version: input.ResultFormat.Version},
+	}
+	canonical, err := json.Marshal(wire)
+	if err != nil {
+		return Dependency{}, fmt.Errorf("%w: serialize: %v", ErrInvalidDependency, err)
+	}
+
+	preimage := make([]byte, 0, len(DependencyDigestDomain)+1+len(canonical))
+	preimage = append(preimage, DependencyDigestDomain...)
+	preimage = append(preimage, 0)
+	preimage = append(preimage, canonical...)
+	sum := sha256.Sum256(preimage)
+
+	return Dependency{
+		canonical: append([]byte(nil), canonical...),
+		digest:    fmt.Sprintf("sha256:%x", sum),
+	}, nil
+}
+
+// Version returns the canonical serialization version.
+func (d Dependency) Version() int {
+	if len(d.canonical) == 0 {
+		return 0
+	}
+	return DependencyVersion
+}
+
+// Canonical returns a defensive copy of the versioned canonical serialization.
+func (d Dependency) Canonical() []byte { return append([]byte(nil), d.canonical...) }
+
+// Digest returns the canonical SHA-256 identity of the domain-separated
+// dependency preimage.
+func (d Dependency) Digest() string { return d.digest }
+
+type dependencyWire struct {
+	Version            int               `json:"version"`
+	SemanticModel      semanticModelWire `json:"semanticModel"`
+	Relations          []relationWire    `json:"relations"`
+	BindingFingerprint string            `json:"bindingFingerprint"`
+	Execution          executionWire     `json:"execution"`
+	ResultFormat       resultFormatWire  `json:"resultFormat"`
+}
+
+type semanticModelWire struct {
+	ID     string `json:"id"`
+	Digest string `json:"digest"`
+}
+
+type relationWire struct {
+	ID             string `json:"id"`
+	RevisionDigest string `json:"revisionDigest"`
+}
+
+type executionWire struct {
+	PlannerDigest    string `json:"plannerDigest"`
+	RuntimeDigest    string `json:"runtimeDigest"`
+	CapabilityDigest string `json:"capabilityDigest"`
+	SettingsDigest   string `json:"settingsDigest"`
+}
+
+type resultFormatWire struct {
+	Name    string `json:"name"`
+	Version uint32 `json:"version"`
+}
+
+func validateExecution(identity ExecutionIdentity) error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "planner digest", value: identity.PlannerDigest},
+		{name: "runtime digest", value: identity.RuntimeDigest},
+		{name: "capability digest", value: identity.CapabilityDigest},
+		{name: "settings digest", value: identity.SettingsDigest},
+	} {
+		if err := validateDigest(field.name, field.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDigest(name, value string) error {
+	if err := platformdigest.ValidateSHA256Identity(value); err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrInvalidDependency, name, err)
+	}
+	return nil
+}
+
+func validateOpaqueText(value string) error {
+	if value == "" {
+		return errors.New("must not be empty")
+	}
+	if value != strings.TrimSpace(value) {
+		return errors.New("must not contain surrounding whitespace")
+	}
+	if !utf8.ValidString(value) {
+		return errors.New("must be valid UTF-8")
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return errors.New("must not contain control characters")
+		}
+	}
+	return nil
+}

--- a/internal/analytics/resultidentity/contract_test.go
+++ b/internal/analytics/resultidentity/contract_test.go
@@ -1,0 +1,255 @@
+package resultidentity
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+)
+
+func TestDependencyCanonicalSerializationAndDigest(t *testing.T) {
+	if DependencyVersion != 1 || PartitionVersion != 1 || CacheKeyFormatVersion != 1 {
+		t.Fatalf("contract versions = dependency %d, partition %d, cache key %d; want all 1", DependencyVersion, PartitionVersion, CacheKeyFormatVersion)
+	}
+	if DependencyDigestDomain != "flid.resultidentity.dependency.v1" {
+		t.Fatalf("DependencyDigestDomain = %q", DependencyDigestDomain)
+	}
+	dependency, err := NewDependency(validDependencyInput())
+	if err != nil {
+		t.Fatalf("NewDependency() error = %v", err)
+	}
+
+	wantCanonical := `{"version":1,"semanticModel":{"id":"semantic_sales","digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"relations":[{"id":"orders","revisionDigest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},{"id":"returns","revisionDigest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}],"bindingFingerprint":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","execution":{"plannerDigest":"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","runtimeDigest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","capabilityDigest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","settingsDigest":"sha256:2222222222222222222222222222222222222222222222222222222222222222"},"resultFormat":{"name":"arrow-ipc","version":1}}`
+	if got := string(dependency.Canonical()); got != wantCanonical {
+		t.Fatalf("Canonical() = %s, want %s", got, wantCanonical)
+	}
+
+	preimage := append([]byte("flid.resultidentity.dependency.v1"), 0)
+	preimage = append(preimage, wantCanonical...)
+	wantDigest := fmt.Sprintf("sha256:%x", sha256.Sum256(preimage))
+	if got := dependency.Digest(); got != wantDigest {
+		t.Fatalf("Digest() = %q, want %q", got, wantDigest)
+	}
+	if dependency.Version() != DependencyVersion {
+		t.Fatalf("Version() = %d, want %d", dependency.Version(), DependencyVersion)
+	}
+}
+
+func TestDependencyCanonicalizesRelationsAndDefensivelyCopies(t *testing.T) {
+	input := validDependencyInput()
+	input.Relations[0], input.Relations[1] = input.Relations[1], input.Relations[0]
+	dependency, err := NewDependency(input)
+	if err != nil {
+		t.Fatalf("NewDependency() error = %v", err)
+	}
+	originalCanonical := dependency.Canonical()
+	originalDigest := dependency.Digest()
+	ordered, err := NewDependency(validDependencyInput())
+	if err != nil {
+		t.Fatalf("NewDependency(ordered) error = %v", err)
+	}
+	if string(ordered.Canonical()) != string(originalCanonical) || ordered.Digest() != originalDigest {
+		t.Fatal("relation input order changed canonical dependency identity")
+	}
+
+	input.Relations[0].RelationID = "mutated"
+	input.Relations[0].RevisionDigest = testDigest("9")
+	returned := dependency.Canonical()
+	returned[0] = 'x'
+
+	if got := dependency.Canonical(); string(got) != string(originalCanonical) {
+		t.Fatalf("Canonical() changed through an input or output alias: %s", got)
+	}
+	if got := dependency.Digest(); got != originalDigest {
+		t.Fatalf("Digest() changed through an input alias: %q", got)
+	}
+	if strings.Index(string(originalCanonical), `"id":"orders"`) > strings.Index(string(originalCanonical), `"id":"returns"`) {
+		t.Fatalf("relations are not ordered by canonical resource ID: %s", originalCanonical)
+	}
+}
+
+func TestDependencyDigestRotatesForEveryResultAffectingInput(t *testing.T) {
+	base := validDependencyInput()
+	baseline, err := NewDependency(base)
+	if err != nil {
+		t.Fatalf("NewDependency() error = %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*DependencyInput)
+	}{
+		{name: "semantic model ID", mutate: func(input *DependencyInput) { input.SemanticModelID = "semantic_other" }},
+		{name: "semantic model digest", mutate: func(input *DependencyInput) { input.SemanticModelDigest = testDigest("3") }},
+		{name: "relation set", mutate: func(input *DependencyInput) {
+			input.Relations = append(input.Relations, RelationRevision{RelationID: "customers", RevisionDigest: testDigest("0")})
+		}},
+		{name: "relation revision", mutate: func(input *DependencyInput) { input.Relations[0].RevisionDigest = testDigest("4") }},
+		{name: "binding fingerprint", mutate: func(input *DependencyInput) { input.BindingFingerprint = testDigest("5") }},
+		{name: "planner", mutate: func(input *DependencyInput) { input.Execution.PlannerDigest = testDigest("6") }},
+		{name: "runtime", mutate: func(input *DependencyInput) { input.Execution.RuntimeDigest = testDigest("7") }},
+		{name: "capability", mutate: func(input *DependencyInput) { input.Execution.CapabilityDigest = testDigest("8") }},
+		{name: "settings", mutate: func(input *DependencyInput) { input.Execution.SettingsDigest = testDigest("9") }},
+		{name: "result format name", mutate: func(input *DependencyInput) { input.ResultFormat.Name = "arrow-stream" }},
+		{name: "result format version", mutate: func(input *DependencyInput) { input.ResultFormat.Version++ }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := cloneDependencyInput(base)
+			test.mutate(&input)
+			changed, err := NewDependency(input)
+			if err != nil {
+				t.Fatalf("NewDependency() error = %v", err)
+			}
+			if changed.Digest() == baseline.Digest() {
+				t.Fatalf("Digest() did not rotate from %q", baseline.Digest())
+			}
+		})
+	}
+}
+
+func TestPartitionCanonicalSerializationAndIsolation(t *testing.T) {
+	production, err := NewPartition(PartitionInput{
+		Kind: PartitionProduction, ProjectID: "project_sales", Environment: "prod",
+	})
+	if err != nil {
+		t.Fatalf("NewPartition(production) error = %v", err)
+	}
+	candidate, err := NewPartition(PartitionInput{
+		Kind: PartitionCandidate, ProjectID: "project_sales", Environment: "prod", CandidateID: "candidate_1",
+	})
+	if err != nil {
+		t.Fatalf("NewPartition(candidate) error = %v", err)
+	}
+	otherCandidate, err := NewPartition(PartitionInput{
+		Kind: PartitionCandidate, ProjectID: "project_sales", Environment: "prod", CandidateID: "candidate_2",
+	})
+	if err != nil {
+		t.Fatalf("NewPartition(other candidate) error = %v", err)
+	}
+
+	if got, want := string(production.Canonical()), `{"version":1,"kind":"production","projectId":"project_sales","environment":"prod"}`; got != want {
+		t.Fatalf("production Canonical() = %s, want %s", got, want)
+	}
+	if got, want := string(candidate.Canonical()), `{"version":1,"kind":"candidate","projectId":"project_sales","environment":"prod","candidateId":"candidate_1"}`; got != want {
+		t.Fatalf("candidate Canonical() = %s, want %s", got, want)
+	}
+	if string(production.Canonical()) == string(candidate.Canonical()) || string(candidate.Canonical()) == string(otherCandidate.Canonical()) {
+		t.Fatal("production and candidate partitions are not isolated")
+	}
+	if candidate.Kind() != PartitionCandidate || candidate.ProjectID() != "project_sales" || candidate.Environment() != "prod" || candidate.CandidateID() != "candidate_1" {
+		t.Fatalf("candidate accessors returned unexpected values")
+	}
+	if production.Version() != PartitionVersion || candidate.Version() != PartitionVersion {
+		t.Fatalf("partition versions = production %d, candidate %d; want %d", production.Version(), candidate.Version(), PartitionVersion)
+	}
+
+	returned := candidate.Canonical()
+	returned[0] = 'x'
+	if got := string(candidate.Canonical()); got[0] != '{' {
+		t.Fatalf("Canonical() exposes mutable storage: %s", got)
+	}
+}
+
+func TestContractsRejectInvalidInputs(t *testing.T) {
+	t.Run("dependency", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			mutate func(*DependencyInput)
+		}{
+			{name: "invalid semantic model ID", mutate: func(input *DependencyInput) { input.SemanticModelID = " semantic_sales" }},
+			{name: "invalid semantic digest", mutate: func(input *DependencyInput) { input.SemanticModelDigest = "sha256:ABC" }},
+			{name: "invalid relation ID", mutate: func(input *DependencyInput) { input.Relations[0].RelationID = "orders table" }},
+			{name: "invalid revision digest", mutate: func(input *DependencyInput) { input.Relations[0].RevisionDigest = "md5:abcd" }},
+			{name: "duplicate relation", mutate: func(input *DependencyInput) { input.Relations[1].RelationID = input.Relations[0].RelationID }},
+			{name: "invalid binding fingerprint", mutate: func(input *DependencyInput) { input.BindingFingerprint = "" }},
+			{name: "invalid planner digest", mutate: func(input *DependencyInput) { input.Execution.PlannerDigest = testDigest("A") }},
+			{name: "invalid runtime digest", mutate: func(input *DependencyInput) { input.Execution.RuntimeDigest = "" }},
+			{name: "invalid capability digest", mutate: func(input *DependencyInput) { input.Execution.CapabilityDigest = "sha512:" + strings.Repeat("1", 128) }},
+			{name: "invalid settings digest", mutate: func(input *DependencyInput) { input.Execution.SettingsDigest = "sha256:" + strings.Repeat("1", 63) }},
+			{name: "empty result format", mutate: func(input *DependencyInput) { input.ResultFormat.Name = "" }},
+			{name: "noncanonical result format", mutate: func(input *DependencyInput) { input.ResultFormat.Name = " arrow-ipc" }},
+			{name: "zero result format version", mutate: func(input *DependencyInput) { input.ResultFormat.Version = 0 }},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				input := cloneDependencyInput(validDependencyInput())
+				test.mutate(&input)
+				if _, err := NewDependency(input); err == nil {
+					t.Fatal("NewDependency() error = nil")
+				}
+			})
+		}
+	})
+
+	t.Run("partition", func(t *testing.T) {
+		tests := []PartitionInput{
+			{},
+			{Kind: "preview", ProjectID: "project_sales", Environment: "prod"},
+			{Kind: PartitionProduction, ProjectID: "project sales", Environment: "prod"},
+			{Kind: PartitionProduction, ProjectID: "project_sales", Environment: " prod"},
+			{Kind: PartitionProduction, ProjectID: "project_sales", Environment: "prod", CandidateID: "candidate_1"},
+			{Kind: PartitionCandidate, ProjectID: "project_sales", Environment: "prod"},
+			{Kind: PartitionCandidate, ProjectID: "project_sales", Environment: "prod", CandidateID: " candidate_1"},
+		}
+		for _, input := range tests {
+			if _, err := NewPartition(input); err == nil {
+				t.Fatalf("NewPartition(%#v) error = nil", input)
+			}
+		}
+	})
+}
+
+func TestDependencyRejectsEmptyRelationEvidence(t *testing.T) {
+	tests := []struct {
+		name      string
+		relations []RelationRevision
+	}{
+		{name: "nil", relations: nil},
+		{name: "empty", relations: []RelationRevision{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validDependencyInput()
+			input.Relations = test.relations
+			_, err := NewDependency(input)
+			if !errors.Is(err, ErrInvalidDependency) {
+				t.Fatalf("NewDependency() error = %v, want ErrInvalidDependency", err)
+			}
+			if !strings.Contains(err.Error(), "at least one relation revision is required") {
+				t.Fatalf("NewDependency() error = %q, want missing relation evidence detail", err)
+			}
+		})
+	}
+}
+
+func validDependencyInput() DependencyInput {
+	return DependencyInput{
+		SemanticModelID:     projectgraph.ResourceID("semantic_sales"),
+		SemanticModelDigest: testDigest("a"),
+		Relations: []RelationRevision{
+			{RelationID: "orders", RevisionDigest: testDigest("b")},
+			{RelationID: "returns", RevisionDigest: testDigest("c")},
+		},
+		BindingFingerprint: testDigest("d"),
+		Execution: ExecutionIdentity{
+			PlannerDigest:    testDigest("e"),
+			RuntimeDigest:    testDigest("f"),
+			CapabilityDigest: testDigest("1"),
+			SettingsDigest:   testDigest("2"),
+		},
+		ResultFormat: ResultFormat{Name: "arrow-ipc", Version: 1},
+	}
+}
+
+func cloneDependencyInput(input DependencyInput) DependencyInput {
+	input.Relations = append([]RelationRevision(nil), input.Relations...)
+	return input
+}
+
+func testDigest(character string) string {
+	return "sha256:" + strings.Repeat(character, 64)
+}

--- a/internal/analytics/resultidentity/contract_test.go
+++ b/internal/analytics/resultidentity/contract_test.go
@@ -38,6 +38,21 @@ func TestDependencyCanonicalSerializationAndDigest(t *testing.T) {
 	}
 }
 
+func TestDependencyPreimageCapacityRejectsOverflow(t *testing.T) {
+	maximumInt := int(^uint(0) >> 1)
+	if _, err := dependencyPreimageCapacity(maximumInt); !errors.Is(err, ErrInvalidDependency) {
+		t.Fatalf("dependencyPreimageCapacity(maximumInt) error = %v, want ErrInvalidDependency", err)
+	}
+
+	capacity, err := dependencyPreimageCapacity(0)
+	if err != nil {
+		t.Fatalf("dependencyPreimageCapacity(0) error = %v", err)
+	}
+	if want := len(DependencyDigestDomain) + 1; capacity != want {
+		t.Fatalf("dependencyPreimageCapacity(0) = %d, want %d", capacity, want)
+	}
+}
+
 func TestDependencyCanonicalizesRelationsAndDefensivelyCopies(t *testing.T) {
 	input := validDependencyInput()
 	input.Relations[0], input.Relations[1] = input.Relations[1], input.Relations[0]

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -219,6 +219,20 @@ func TestPublicArrowResultPackageIsAnalyticsOwned(t *testing.T) {
 	}
 }
 
+func TestResultIdentityPackageIsAnAnalyticsContract(t *testing.T) {
+	const path = "internal/analytics/resultidentity"
+	rule, ok := ClassifyPackage(path)
+	if !ok {
+		t.Fatalf("%s is not classified", path)
+	}
+	if rule.Capability != "analytics" || rule.Layer != LayerContract {
+		t.Fatalf("%s classification = %#v, want analytics contract-layer", path, rule)
+	}
+	if !IsPublicContractImport("analytics", path) {
+		t.Fatalf("%s is not published as an analytics contract", path)
+	}
+}
+
 func TestEnterpriseAuthoringForbiddenImportsAreRejected(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -34,7 +34,7 @@ type PackageRule struct {
 var PublicContractPrefixes = map[string][]string{
 	"access":       {"internal/access", "internal/access/api", "internal/access/policy", "internal/access/snapshot", "internal/access/ui/signals"},
 	"agent":        {"internal/agent/api", "internal/agent/ui/signals"},
-	"analytics":    {"pkg/arrowresult", "internal/analytics/model", "internal/analytics/modelsql", "internal/analytics/query", "internal/analytics/materialize", "internal/analytics/materialization", "internal/analytics/connectors", "internal/analytics/connectionadmin", "internal/analytics/arrowquery", "internal/analytics/resource", "internal/analytics/runtime", "internal/analytics/queryaudit", "internal/analytics/dataquery", "internal/analytics/physicalpool", "internal/analytics/catalogseal", "internal/analytics/catalogartifact", "internal/analytics/catalogstats"},
+	"analytics":    {"pkg/arrowresult", "internal/analytics/model", "internal/analytics/modelsql", "internal/analytics/query", "internal/analytics/materialize", "internal/analytics/materialization", "internal/analytics/connectors", "internal/analytics/connectionadmin", "internal/analytics/arrowquery", "internal/analytics/resource", "internal/analytics/runtime", "internal/analytics/queryaudit", "internal/analytics/dataquery", "internal/analytics/physicalpool", "internal/analytics/catalogseal", "internal/analytics/catalogartifact", "internal/analytics/catalogstats", "internal/analytics/resultidentity"},
 	"dashboard":    {"internal/dashboard", "internal/dashboard/api", "internal/dashboard/appearance", "internal/dashboard/authoring", "internal/dashboard/catalog", "internal/dashboard/compiler", "internal/dashboard/definition", "internal/dashboard/document", "internal/dashboard/filter", "internal/dashboard/layoutcontract", "internal/dashboard/publication", "internal/dashboard/report", "internal/dashboard/reportmodel", "internal/dashboard/queryruntime", "internal/dashboard/resolver", "internal/dashboard/ui/signals", "internal/dashboard/visualization/definition", "internal/dashboard/visualization/format", "internal/dashboard/visualization/geometry", "internal/dashboard/visualization/ir", "internal/dashboard/visualization/mapasset", "internal/dashboard/visualization/runtime"},
 	"manageddata":  {"internal/manageddata", "internal/manageddata/binding", "internal/manageddata/runtimebinding"},
 	"project":      {"internal/project", "internal/project/api", "internal/project/schema", "internal/project/contracts", "internal/project/artifact", "internal/project/bundle", "internal/project/catalog", "internal/project/compiler", "internal/project/manifest", "internal/project/runtime"},
@@ -248,6 +248,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "internal/project/runtime", Capability: "project", Layer: LayerContract},
 	{Prefix: "internal/project/compiler", Capability: "project", Layer: LayerUseCase},
 	{Prefix: "internal/project/artifact", Capability: "project", Layer: LayerContract},
+	{Prefix: "internal/analytics/resultidentity", Capability: "analytics", Layer: LayerContract},
 	{Prefix: "internal/analytics/runtime", Capability: "analytics", Layer: LayerContract},
 	{Prefix: "internal/analytics/modelsql", Capability: "analytics", Layer: LayerContract},
 	{Prefix: "internal/analytics/gates", Capability: "release", Layer: LayerUseCase},


### PR DESCRIPTION
## Problem

Query-result reuse needs an analytics-owned identity contract that describes stable result dependencies without coupling query semantics to cache storage or execution engines.

## Root cause

The repository did not have a versioned, canonical contract for identifying semantic model inputs, physical relation revisions, binding state, execution identity, result format, or production versus candidate partitions.

## Solution

- Add the internal/analytics/resultidentity contract package.
- Define opaque immutable Dependency and Partition identities with defensive copies.
- Canonically serialize versioned JSON using fixed wire structs and deterministic relation ordering.
- Generate dependency identities with SHA-256 over flid.resultidentity.dependency.v1, a NUL separator, and the canonical payload.
- Strictly validate canonical lowercase SHA-256 input identities.
- Fail closed for missing relation evidence, malformed digests, duplicate relations, invalid resource IDs, and invalid partition combinations.
- Isolate production and candidate partitions.
- Classify resultidentity as a public analytics contract in the architecture rules.

## Tests added

- Golden canonical serialization and domain-separated digest verification.
- Relation ordering and digest determinism.
- Digest rotation for every result-affecting input.
- Nil and empty relation evidence rejection.
- Duplicate relation and malformed identity rejection.
- Production and candidate partition isolation.
- Defensive-copy guarantees.
- Analytics contract architecture classification.

## Verification performed

- go test ./internal/analytics/resultidentity
- go vet ./internal/analytics/resultidentity
- go test ./internal/platform/architecture -run ^TestResultIdentityPackageIsAnAnalyticsContract$ -count=1
- git diff --check

## Scope and remaining limitations

No cache lookup or cache storage behavior changed. No materialization behavior, runtime wiring, DuckDB execution, or Arrow transport changed. This PR defines the contract only; dependency derivation and cache integration remain follow-up work for FAI-529 and FAI-530.