### PR TITLE
feat: add executable v0.1 preservation qualification (FAI-517)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,6 +508,14 @@ jobs:
           args=(qualify installed-candidate --require-release-transition --previous-image "$previous_image" --evidence-dir "$RUNNER_TEMP/installed-candidate-evidence")
           ./leapviewctl "${args[@]}"
 
+      - name: Restore least-privilege GHCR access for historical qualification
+        if: matrix.arch == 'amd64'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run exact v0.1 preservation qualification
         if: matrix.arch == 'amd64'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,6 +434,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up exact OCI resolver
+        if: matrix.arch == 'amd64'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
       - name: Admit the exact release image
         id: admission
         uses: ./.github/actions/oci-admission
@@ -504,6 +508,33 @@ jobs:
           args=(qualify installed-candidate --require-release-transition --previous-image "$previous_image" --evidence-dir "$RUNNER_TEMP/installed-candidate-evidence")
           ./leapviewctl "${args[@]}"
 
+      - name: Run exact v0.1 preservation qualification
+        if: matrix.arch == 'amd64'
+        run: |
+          set -euo pipefail
+          cd "$PACKAGE_ROOT"
+          evidence_dir="$RUNNER_TEMP/installed-candidate-evidence"
+          predecessor_evidence="$evidence_dir/v0.1-reviewed-identity.json"
+          qualification_evidence="$evidence_dir/v0.1-preservation-qualification.json"
+          candidate_admission="$GITHUB_WORKSPACE/candidate/assembled-image-admission.json"
+          policy="$PACKAGE_ROOT/release-transition-policy.json"
+          policy_sha256="$(sha256sum "$policy" | awk '{print $1}')"
+          test -s "$candidate_admission"
+          test -s "$policy"
+          mkdir -p "$evidence_dir"
+          ./leapviewctl qualify v0.1-artifact-review \
+            --transition-policy "$policy" \
+            --policy-sha256 "$policy_sha256" \
+            --evidence "$predecessor_evidence"
+          test -s "$predecessor_evidence"
+          ./leapviewctl qualify v0.1-preservation \
+            --candidate-admission "$candidate_admission" \
+            --transition-policy "$policy" \
+            --policy-sha256 "$policy_sha256" \
+            --predecessor-evidence "$predecessor_evidence" \
+            --evidence-dir "$evidence_dir"
+          test -s "$qualification_evidence"
+
       - name: Upload bounded qualification evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -521,6 +552,8 @@ jobs:
             ${{ runner.temp }}/installed-candidate-evidence/policy-validation.json
             ${{ runner.temp }}/installed-candidate-evidence/decision.json
             ${{ runner.temp }}/installed-candidate-evidence/transition-qualification.json
+            ${{ runner.temp }}/installed-candidate-evidence/v0.1-reviewed-identity.json
+            ${{ runner.temp }}/installed-candidate-evidence/v0.1-preservation-qualification.json
             ${{ runner.temp }}/installed-candidate-evidence/*.log
             ${{ runner.temp }}/installed-candidate-evidence/browser-failure.png
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -992,6 +992,19 @@ tasks:
       # attestations are enforced, rather than trusting client provenance text.
       - go test ./internal/project/module -run '^(TestCandidateSourceSynchronizerAuthorizesOnlyPlannedOwnerUploads|TestCandidateSourceSynchronizerRetainsActivePlanAcrossRestart)$' -count=1 -v
 
+  test:ubdr:v0.1-artifact:
+    desc: Validate exact v0.1 registry provenance and authentic isolated application journey
+    deps:
+      - db:generate
+      - api:generate
+    cmds:
+      - >-
+        go test
+        ./internal/platform/compatibility
+        ./internal/app/cli/composectl
+        -run 'V010'
+        -count=1
+
   test:ubdr:transition-policy:
     desc: Validate the versioned release-transition policy and pre-mutation denial contract
     deps:
@@ -1006,7 +1019,7 @@ tasks:
         ./internal/app/cli/hostinstall
         ./internal/app/cli/composectl
         ./internal/platform
-        -run 'Bind|Predecessor|Transition|Upgrade|Rollback|Legacy|ReleasePolicy'
+        -run 'Bind|Predecessor|Transition|Upgrade|Rollback|Legacy|ReleasePolicy|V010'
         -count=1
       - >-
         go run ./internal/app/tools/transitionpolicy

--- a/deploy/compose/QUALIFICATION.md
+++ b/deploy/compose/QUALIFICATION.md
@@ -99,6 +99,126 @@ its own `admin backup`, then provision a fresh LeapView instance and redeploy
 authored projects. Pass `--evidence-dir` to redirect the bounded report and
 failure screenshot.
 
+## v0.1 preservation release gate
+
+The release workflow runs the v0.1 preservation gate in the pre-publication
+qualification job after the candidate image has been assembled and admitted,
+the candidate-bound transition policy has been generated, and the release
+archive has passed its checksum verification. The historical v0.1 artifact has
+only a `linux/amd64` runtime, so this gate runs on the `amd64` qualification
+runner. The regular installed-candidate journey still runs independently on
+every release architecture.
+
+### Release-runner requirements
+
+The runner must provide all of the following:
+
+- a `linux/amd64` host capable of executing `linux/amd64` containers;
+- Docker Engine with Buildx and permission to pull images, inspect OCI index
+  and manifest bytes, and create and remove isolated containers, networks,
+  volumes, and run directories;
+- the extracted candidate's `leapviewctl`, `release-transition-policy.json`,
+  and the exact `assembled-image-admission.json` produced by candidate image
+  admission; and
+- authenticated pull access to the policy-declared historical artifact in
+  `ghcr.io/yacobolo/libredash`.
+
+Configure GHCR credentials with `docker login ghcr.io` before qualification.
+The resolver reads `config.json` from `DOCKER_CONFIG` when that variable is set,
+or from `$HOME/.docker/config.json` otherwise. An auth entry, configured GHCR
+credential helper, identity token, or credential store must be present. The
+credential needs read access to the historical package only; do not grant
+write, delete, or package-administration permission. In GitHub Actions the
+qualification job has `packages: read`, and the token used by the login step
+must also have been granted pull access to the cross-namespace historical
+package. A syntactically configured credential that lacks that package access
+still fails when the exact OCI object is resolved.
+
+Do not copy registry credentials into the release archive, command arguments,
+qualification directory, or uploaded evidence. The qualification evidence
+contains normalized identities and checksums, not tokens, Docker configuration,
+raw authenticated responses, or application credentials.
+
+### Invocation and publication boundary
+
+The release runner derives the policy checksum from the verified archive and
+uses one evidence directory for the existing pre-publication artifact. The
+equivalent controlled invocation is:
+
+```sh
+docker login ghcr.io
+evidence_dir="$RUNNER_TEMP/installed-candidate-evidence"
+policy="$PACKAGE_ROOT/release-transition-policy.json"
+policy_sha256="$(sha256sum "$policy" | awk '{print $1}')"
+predecessor_evidence="$evidence_dir/v0.1-reviewed-identity.json"
+
+./leapviewctl qualify v0.1-artifact-review \
+  --transition-policy "$policy" \
+  --policy-sha256 "$policy_sha256" \
+  --evidence "$predecessor_evidence"
+
+./leapviewctl qualify v0.1-preservation \
+  --candidate-admission "$GITHUB_WORKSPACE/candidate/assembled-image-admission.json" \
+  --transition-policy "$policy" \
+  --policy-sha256 "$policy_sha256" \
+  --predecessor-evidence "$predecessor_evidence" \
+  --evidence-dir "$evidence_dir"
+```
+
+Do not replace either input with a locally built image, mutable tag, policy
+from another archive, or reconstructed admission record. The artifact-review
+command removes stale output before it starts and publishes evidence atomically
+only after owner validation. The preservation command independently resolves
+the exact historical artifact again and rejects a different artifact,
+provenance record, or policy identity.
+
+Any nonzero command result or missing final evidence file fails the `amd64`
+qualification job. Release publication depends on the complete qualification
+matrix, so the image and release assets cannot be published after this gate
+fails. The evidence is produced and checked before the workflow can report
+qualification success.
+
+### Evidence chain
+
+The existing GitHub Actions artifact
+`prepublication-<release-tag>-amd64` retains the v0.1 evidence for 14 days:
+
+| File | Meaning |
+| --- | --- |
+| `v0.1-reviewed-identity.json` | The Phase 1 owner-validated review of the authenticated, exact policy-declared v0.1 OCI index, `linux/amd64` manifest, config digest, source revision, and provenance. It is bound to the candidate policy SHA-256 and intentionally has no execution section. |
+| `v0.1-preservation-qualification.json` | The same evidence contract extended with the observed container identity, authentic bootstrap/workload journey, before/after stopped-state inventory and checksums, clean restart and shutdown, isolated fresh-candidate inventory, policy denials, mutation-free checksums, and cleanup proof. This file exists only after the complete journey passes owner validation. |
+
+The second document does not merely refer to the first by filename. Before
+success, the controller requires their historical identity, OCI artifact,
+provenance, policy version, and policy SHA-256 to match exactly. It also binds
+the candidate identity to the assembled-image admission output. Preserve both
+documents together when reviewing a release decision.
+
+Success proves that the exact historical application executed, deterministic
+application state survived a clean stop and restart, the admitted candidate
+started with isolated clean state, and unsupported legacy-state adoption was
+denied before mutation. It does not declare an in-place v0.1 migration path or
+authorize restoring a v0.1 archive into LeapView.
+
+### Diagnose failures
+
+Open the GitHub Actions **Pre-publication qualification (amd64)** job, locate
+the first failing v0.1 step, and download its
+`prepublication-<release-tag>-amd64` artifact when present. The upload step runs
+after failures so reviewed identity evidence and bounded logs may be available;
+absence of `v0.1-preservation-qualification.json` means the complete journey
+did not pass. Never infer success from the review document alone.
+
+| Failure | Required response |
+| --- | --- |
+| Credentials unavailable or not configured | Configure an owner-readable Docker credential file through `docker login ghcr.io` or the approved credential helper. Verify the token can read the historical package. Do not make the package public, copy a token into evidence, or enable a local-image fallback. |
+| Historical artifact unavailable | Confirm access to the exact immutable reference declared by policy. Escalate removal or registry unavailability to the release owner; do not substitute a tag, registry namespace, rebuilt image, or different digest. |
+| OCI or image digest mismatch | Stop the release and retain the registry diagnostic. The index bytes, platform manifest, config, or pulled image no longer matches the reviewed immutable graph. Do not regenerate policy or evidence to accept the observation. |
+| Candidate policy digest mismatch | Re-extract the checksummed candidate archive, recompute `sha256sum release-transition-policy.json`, and pass that exact value and file to both commands. Do not edit or reserialize the policy. |
+| Reviewed predecessor evidence rejected | Regenerate `v0.1-reviewed-identity.json` with the same shipped controller, exact policy file, and policy checksum used by the preservation command. Do not hand-edit, reuse evidence from another candidate, or copy only its identity fields. |
+| Candidate admission rejected | Use the original `assembled-image-admission.json` from the candidate artifact. A different image digest, source revision, workflow attestation, SBOM result, or vulnerability-policy result requires rebuilding and readmitting the candidate. |
+| Preservation or fresh-candidate journey failed | Inspect the bounded step diagnostic to identify readiness, bootstrap, authentication, workload, inventory, restart, denial, or cleanup failure. Fix and readmit the candidate or restore the historical artifact service before rerunning; do not publish partial evidence. |
+
 ## Evidence and timing
 
 Retain only `qualification-report.json`, `authoring-report.json`, `performance-report.json`,

--- a/deploy/compose/deployment_test.go
+++ b/deploy/compose/deployment_test.go
@@ -832,6 +832,10 @@ func TestV010ReleaseWorkflowRejectsIncompleteOrUnboundWiring(t *testing.T) {
 		replacement string
 	}{
 		{
+			name: "missing restored historical authentication",
+			old:  `- name: Restore least-privilege GHCR access for historical qualification`,
+		},
+		{
 			name: "missing admission artifact",
 			old:  `candidate_admission="$GITHUB_WORKSPACE/candidate/assembled-image-admission.json"`,
 		},
@@ -859,6 +863,7 @@ func TestV010ReleaseWorkflowRejectsIncompleteOrUnboundWiring(t *testing.T) {
 
 func validateV010ReleaseWorkflow(workflow string) error {
 	required := []string{
+		"- name: Restore least-privilege GHCR access for historical qualification",
 		"- name: Run exact v0.1 preservation qualification",
 		"if: matrix.arch == 'amd64'",
 		"- name: Set up exact OCI resolver",
@@ -883,10 +888,26 @@ func validateV010ReleaseWorkflow(workflow string) error {
 		}
 	}
 	review := strings.Index(workflow, "./leapviewctl qualify v0.1-artifact-review")
+	authenticated := strings.Index(workflow, "- name: Log in to GHCR for admission")
+	installed := strings.Index(workflow, "- name: Run installed-candidate journey")
+	reauthenticated := strings.Index(workflow, "- name: Restore least-privilege GHCR access for historical qualification")
 	qualification := strings.Index(workflow, "./leapviewctl qualify v0.1-preservation")
 	upload := strings.Index(workflow, "- name: Upload bounded qualification evidence")
-	if review < 0 || qualification < 0 || upload < 0 || review >= qualification || qualification >= upload {
-		return fmt.Errorf("release workflow must review v0.1 identity, qualify preservation, then upload evidence")
+	if authenticated < 0 || installed < 0 || reauthenticated < 0 || review < 0 || qualification < 0 || upload < 0 ||
+		authenticated >= installed || installed >= reauthenticated || reauthenticated >= review || review >= qualification || qualification >= upload {
+		return fmt.Errorf("release workflow must authenticate, qualify the installed candidate, restore authentication, review v0.1 identity, qualify preservation, then upload evidence")
+	}
+	reauthenticationBlock := workflow[reauthenticated:review]
+	for _, contract := range []string{
+		"if: matrix.arch == 'amd64'",
+		"uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4",
+		"registry: ghcr.io",
+		"username: ${{ github.actor }}",
+		"password: ${{ secrets.GITHUB_TOKEN }}",
+	} {
+		if !strings.Contains(reauthenticationBlock, contract) {
+			return fmt.Errorf("historical qualification authentication is incomplete: missing %q", contract)
+		}
 	}
 	return nil
 }

--- a/deploy/compose/deployment_test.go
+++ b/deploy/compose/deployment_test.go
@@ -819,6 +819,78 @@ func TestControllerReleasePackagingContract(t *testing.T) {
 	}
 }
 
+func TestV010ReleaseWorkflowInvokesPolicyBoundPreservationQualification(t *testing.T) {
+	workflow := read(t, filepath.Join("..", "..", ".github", "workflows", "release.yml"))
+	require.NoError(t, validateV010ReleaseWorkflow(workflow))
+}
+
+func TestV010ReleaseWorkflowRejectsIncompleteOrUnboundWiring(t *testing.T) {
+	workflow := read(t, filepath.Join("..", "..", ".github", "workflows", "release.yml"))
+	for _, test := range []struct {
+		name        string
+		old         string
+		replacement string
+	}{
+		{
+			name: "missing admission artifact",
+			old:  `candidate_admission="$GITHUB_WORKSPACE/candidate/assembled-image-admission.json"`,
+		},
+		{
+			name: "missing predecessor evidence",
+			old:  `--predecessor-evidence "$predecessor_evidence"`,
+		},
+		{
+			name:        "wrong policy digest",
+			old:         `policy_sha256="$(sha256sum "$policy" | awk '{print $1}')"`,
+			replacement: `policy_sha256="0000000000000000000000000000000000000000000000000000000000000000"`,
+		},
+		{
+			name: "missing evidence artifact",
+			old:  `${{ runner.temp }}/installed-candidate-evidence/v0.1-preservation-qualification.json`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mutated := strings.Replace(workflow, test.old, test.replacement, 1)
+			require.NotEqual(t, workflow, mutated, "contract mutation did not match workflow")
+			require.Error(t, validateV010ReleaseWorkflow(mutated))
+		})
+	}
+}
+
+func validateV010ReleaseWorkflow(workflow string) error {
+	required := []string{
+		"- name: Run exact v0.1 preservation qualification",
+		"if: matrix.arch == 'amd64'",
+		"- name: Set up exact OCI resolver",
+		`candidate_admission="$GITHUB_WORKSPACE/candidate/assembled-image-admission.json"`,
+		`policy="$PACKAGE_ROOT/release-transition-policy.json"`,
+		`policy_sha256="$(sha256sum "$policy" | awk '{print $1}')"`,
+		`./leapviewctl qualify v0.1-artifact-review`,
+		`--policy-sha256 "$policy_sha256"`,
+		`--evidence "$predecessor_evidence"`,
+		`test -s "$predecessor_evidence"`,
+		`./leapviewctl qualify v0.1-preservation`,
+		`--candidate-admission "$candidate_admission"`,
+		`--predecessor-evidence "$predecessor_evidence"`,
+		`test -s "$qualification_evidence"`,
+		`${{ runner.temp }}/installed-candidate-evidence/v0.1-reviewed-identity.json`,
+		`${{ runner.temp }}/installed-candidate-evidence/v0.1-preservation-qualification.json`,
+		"needs: [image, qualify, minio-conformance, plan-gc-conformance]",
+	}
+	for _, contract := range required {
+		if !strings.Contains(workflow, contract) {
+			return fmt.Errorf("release workflow missing v0.1 qualification contract %q", contract)
+		}
+	}
+	review := strings.Index(workflow, "./leapviewctl qualify v0.1-artifact-review")
+	qualification := strings.Index(workflow, "./leapviewctl qualify v0.1-preservation")
+	upload := strings.Index(workflow, "- name: Upload bounded qualification evidence")
+	if review < 0 || qualification < 0 || upload < 0 || review >= qualification || qualification >= upload {
+		return fmt.Errorf("release workflow must review v0.1 identity, qualify preservation, then upload evidence")
+	}
+	return nil
+}
+
 func TestControllerLifecycleWithStateAwareUpgradeRollback(t *testing.T) {
 	root := t.TempDir()
 	buildController(t, root)

--- a/docs/articles/operate/upgrades.md
+++ b/docs/articles/operate/upgrades.md
@@ -51,6 +51,58 @@ refreshes, denials, backup, and restore before cutover. Retain the stopped
 v0.1.0 container, its volume, configuration, immutable image, archive, and
 checksum as the rollback boundary until the migration is accepted.
 
+## Inspect the automated v0.1 preservation gate
+
+Every release runs the v0.1 preservation qualification before publication.
+The gate consumes the real assembled-image admission record, the
+candidate-bound transition policy, its exact SHA-256, and the reviewed
+historical v0.1 identity. Because the historical image is available only for
+`linux/amd64`, its execution journey runs in the release workflow's `amd64`
+pre-publication job. A failure in that job prevents the dependent publication
+job from releasing the image or archives.
+
+The release runner must have Docker Engine with Buildx, permission to create
+and remove isolated containers, networks, volumes, and run directories, and an
+owner-readable Docker credential configuration with pull access to
+`ghcr.io/yacobolo/libredash`. The credential requires package read access only.
+Qualification fails closed when credentials are missing, the exact artifact is
+unavailable, or the registry returns different immutable OCI bytes. There is no
+tag, alternate namespace, local image, or source-build fallback.
+
+Inspect the GitHub Actions **Pre-publication qualification (amd64)** job and its
+`prepublication-<release-tag>-amd64` artifact. It contains two related JSON
+documents:
+
+- `v0.1-reviewed-identity.json` proves that the exact authenticated historical
+  artifact, platform manifest, config, and source provenance matched the
+  reviewed policy identity. It is bound to the candidate policy SHA-256 but is
+  not execution evidence.
+- `v0.1-preservation-qualification.json` extends the same evidence contract
+  with the authentic v0.1 application journey, stopped-state inventory and
+  before/after checksums, clean restart proof, isolated candidate identity,
+  fresh-install and legacy-state denial decisions, mutation-free checksums, and
+  cleanup result.
+
+The final document is published atomically only after owner validation. Its
+historical identity, artifact graph, provenance, policy version, and policy
+digest must match the reviewed document, while its candidate identity must
+match the admission record. If the final document is absent, qualification did
+not succeed even when the reviewed identity file was uploaded.
+
+A successful gate means deterministic state created through supported v0.1
+interfaces survived clean shutdown and restart, while the admitted candidate
+started in separate clean state and rejected unsupported legacy-state reuse
+without mutation. It does not make v0.1 state compatible with LeapView and does
+not replace the export-and-fresh-install procedure above.
+
+For a failure, preserve the bounded workflow diagnostic and both evidence files
+that exist. Reauthenticate for a credential error; escalate an unavailable or
+digest-mismatched historical artifact without substituting it; re-extract the
+candidate archive for a policy checksum error; regenerate predecessor evidence
+with the same shipped controller and policy if it is rejected; and rebuild and
+readmit the candidate when its admission identity or qualification journey
+fails. Never edit evidence, policy, or admission JSON to make a release pass.
+
 ## Assess the release
 
 Before scheduling an upgrade, review release notes for:

--- a/internal/app/cli/composectl/command.go
+++ b/internal/app/cli/composectl/command.go
@@ -172,6 +172,39 @@ func Command(ctx context.Context, controller *Controller) *cobra.Command {
 			return controller.RunScheduledRecoveryQualification(ctx)
 		},
 	}
+	v010Qualification := QualificationV010Options{}
+	qualifyV010 := &cobra.Command{
+		Use:   "v0.1-preservation",
+		Short: "Qualify exact v0.1 preservation and candidate fresh-install denial",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return controller.QualifyV010Preservation(ctx, v010Qualification)
+		},
+	}
+	qualifyV010.Flags().StringVar(&v010Qualification.CandidateAdmission, "candidate-admission", "", "exact candidate OCI admission evidence")
+	qualifyV010.Flags().StringVar(&v010Qualification.TransitionPolicy, "transition-policy", "", "candidate-bound release-transition policy")
+	qualifyV010.Flags().StringVar(&v010Qualification.PolicySHA256, "policy-sha256", "", "expected SHA-256 of the candidate-bound policy")
+	qualifyV010.Flags().StringVar(&v010Qualification.PredecessorEvidence, "predecessor-evidence", "", "reviewed exact v0.1 artifact identity evidence")
+	qualifyV010.Flags().StringVar(&v010Qualification.EvidenceDir, "evidence-dir", "", "existing qualification evidence directory")
+	_ = qualifyV010.MarkFlagRequired("candidate-admission")
+	_ = qualifyV010.MarkFlagRequired("transition-policy")
+	_ = qualifyV010.MarkFlagRequired("policy-sha256")
+	_ = qualifyV010.MarkFlagRequired("predecessor-evidence")
+	v010ArtifactReview := QualificationV010ArtifactReviewOptions{}
+	qualifyV010ArtifactReview := &cobra.Command{
+		Use:   "v0.1-artifact-review",
+		Short: "Publish reviewed exact v0.1 artifact identity evidence",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return controller.ReviewV010Artifact(ctx, v010ArtifactReview)
+		},
+	}
+	qualifyV010ArtifactReview.Flags().StringVar(&v010ArtifactReview.TransitionPolicy, "transition-policy", "", "candidate-bound release-transition policy")
+	qualifyV010ArtifactReview.Flags().StringVar(&v010ArtifactReview.PolicySHA256, "policy-sha256", "", "expected SHA-256 of the candidate-bound policy")
+	qualifyV010ArtifactReview.Flags().StringVar(&v010ArtifactReview.Evidence, "evidence", "", "destination for reviewed exact v0.1 artifact identity evidence")
+	_ = qualifyV010ArtifactReview.MarkFlagRequired("transition-policy")
+	_ = qualifyV010ArtifactReview.MarkFlagRequired("policy-sha256")
+	_ = qualifyV010ArtifactReview.MarkFlagRequired("evidence")
 
 	qualify := &cobra.Command{
 		Use:   "qualify",
@@ -195,7 +228,7 @@ func Command(ctx context.Context, controller *Controller) *cobra.Command {
 	qualifyClientWorker.Flags().StringVar(&clientWorkerOptions.Project, "project", "", "qualification project")
 	qualifyClientWorker.Flags().StringVar(&clientWorkerOptions.SourceRevision, "source-revision", "", "staged source revision")
 
-	qualify.AddCommand(qualifyImage, qualifySiteImage, qualifyInstalled, qualifyScheduledRecovery, qualifyClientWorker)
+	qualify.AddCommand(qualifyImage, qualifySiteImage, qualifyInstalled, qualifyScheduledRecovery, qualifyV010ArtifactReview, qualifyV010, qualifyClientWorker)
 
 	root.AddCommand(version, initialize, start, status, logs, firstLogin, backup, restore, upgrade, rollback, qualify)
 	return root

--- a/internal/app/cli/composectl/qualification_v010_candidate.go
+++ b/internal/app/cli/composectl/qualification_v010_candidate.go
@@ -135,7 +135,7 @@ func (c *Controller) qualifyV010FreshCandidate(
 	if freshBeforeEntries != 0 {
 		return result, fmt.Errorf("candidate state volume was not empty before fresh installation")
 	}
-	credentials, err := c.initializeV010FreshCandidate(ctx, candidate.Image, volume)
+	credentials, err := c.initializeV010FreshCandidate(ctx, candidate.Image, network, volume)
 	if err != nil {
 		return result, err
 	}
@@ -291,13 +291,16 @@ func (c *Controller) resolveV010CandidateImage(ctx context.Context, candidate co
 	return image.ID, nil
 }
 
-func (c *Controller) initializeV010FreshCandidate(ctx context.Context, image, volume string) (v010CandidateCredentials, error) {
+func (c *Controller) initializeV010FreshCandidate(ctx context.Context, image, network, volume string) (v010CandidateCredentials, error) {
 	output, err := c.qualificationDocker(ctx, nil,
-		"run", "--rm", "--platform", compatibility.ReleasedV010Platform,
+		"run", "--rm", "--network", network, "--platform", compatibility.ReleasedV010Platform,
+		"--pull", "never", "--read-only", "--security-opt", "no-new-privileges",
+		"--cap-drop", "ALL", "--pids-limit", "512",
 		"--env", "LEAPVIEW_PRODUCTION=1", "--env", "LEAPVIEW_ENVIRONMENT=fai-517-candidate",
 		"--env", "LEAPVIEW_HOME=/var/lib/leapview/home",
 		"--env", "LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL="+v010CandidateAdminEmail,
 		"--mount", "type=volume,source="+volume+",target="+v010CandidateStateMount,
+		"--tmpfs", "/tmp:rw,nosuid,nodev,mode=1777,size=64m",
 		image, "admin", "initialize", "--format", "json",
 	)
 	if err != nil {
@@ -390,10 +393,13 @@ func (c *Controller) collectV010FreshCandidateInventory(
 
 func (c *Controller) attemptV010LegacyStateAdoption(ctx context.Context, image, volume, target, home string) error {
 	_, err := c.qualificationDocker(ctx, nil,
-		"run", "--rm", "--platform", compatibility.ReleasedV010Platform,
+		"run", "--rm", "--network", "none", "--platform", compatibility.ReleasedV010Platform,
+		"--pull", "never", "--read-only", "--security-opt", "no-new-privileges",
+		"--cap-drop", "ALL", "--pids-limit", "512",
 		"--env", "LEAPVIEW_PRODUCTION=1", "--env", "LEAPVIEW_ENVIRONMENT=fai-517-candidate",
 		"--env", "LEAPVIEW_HOME="+home, "--env", "LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL="+v010CandidateAdminEmail,
 		"--mount", "type=volume,source="+volume+",target="+target,
+		"--tmpfs", "/tmp:rw,nosuid,nodev,mode=1777,size=64m",
 		image, "admin", "initialize", "--format", "json",
 	)
 	if err == nil || !strings.Contains(err.Error(), compatibility.ErrV010FreshInstallOnly.Error()) {
@@ -404,7 +410,10 @@ func (c *Controller) attemptV010LegacyStateAdoption(ctx context.Context, image, 
 
 func (c *Controller) v010QualificationVolumeChecksum(ctx context.Context, image, volume string) (string, int, error) {
 	document, err := c.qualificationDocker(ctx, nil,
-		"run", "--rm", "--read-only", "--user", "0:0", "--entrypoint", "tar",
+		"run", "--rm", "--network", "none", "--platform", compatibility.ReleasedV010Platform,
+		"--pull", "never", "--read-only", "--user", "0:0",
+		"--security-opt", "no-new-privileges", "--cap-drop", "ALL", "--cap-add", "DAC_READ_SEARCH",
+		"--pids-limit", "128", "--entrypoint", "tar",
 		"--mount", "type=volume,source="+volume+",target=/state,readonly",
 		image, "--sort=name", "--mtime=UTC 1970-01-01", "--owner=0", "--group=0", "--numeric-owner", "-C", "/state", "-cf", "-", ".",
 	)

--- a/internal/app/cli/composectl/qualification_v010_candidate.go
+++ b/internal/app/cli/composectl/qualification_v010_candidate.go
@@ -381,14 +381,87 @@ func (c *Controller) collectV010FreshCandidateInventory(
 	if err != nil {
 		return compatibility.V010FreshCandidateInventory{}, err
 	}
-	if legacyPrincipals != 0 || dashboards != 0 || semanticModels != 0 {
+	instanceOutput, err := call("api", "call", "getInstance", "--target", "http://127.0.0.1:8080")
+	if err != nil {
+		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("observe fresh candidate environment: %w", err)
+	}
+	var instance struct {
+		ID          string `json:"id"`
+		Environment string `json:"environment"`
+	}
+	if err := decodeV010JourneyJSON(instanceOutput, &instance); err != nil || strings.TrimSpace(instance.ID) == "" ||
+		(instance.Environment != "fai-517-candidate" && instance.Environment != v010Environment) {
+		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("fresh candidate environment observation is invalid")
+	}
+	// listDeployments is the supported RESOURCE_READ observation for the exact
+	// project claim during bootstrap. A clean installation has no claim and is
+	// denied by that route; an admitted legacy claim makes the read succeed even
+	// when its deployment list is empty. Earlier authenticated observations prove
+	// the credential itself before this claim-specific denial is interpreted.
+	projectOutput, projectErr := call(
+		"api", "call", "listDeployments", "--target", "http://127.0.0.1:8080",
+		"--path", "project="+v010ProjectID,
+	)
+	projectVisible := projectErr == nil
+	if projectErr != nil && !v010CandidateAPIStatus(projectErr, 403) {
+		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("observe fresh candidate legacy project: %w", projectErr)
+	}
+	if projectVisible {
+		var deployments struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := decodeV010JourneyJSON(projectOutput, &deployments); err != nil {
+			return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("decode fresh candidate legacy project observation: %w", err)
+		}
+	}
+	projectVisible = projectVisible || instance.Environment == v010Environment
+	managedDataOutput, err := call(
+		"api", "call", "listManagedConnections", "--target", "http://127.0.0.1:8080",
+		"--path", "project="+v010ProjectID,
+	)
+	if err != nil {
+		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("observe fresh candidate legacy managed-data metadata: %w", err)
+	}
+	var managedData struct {
+		Items []struct {
+			ID        string `json:"id"`
+			ProjectID string `json:"projectId"`
+		} `json:"items"`
+	}
+	if err := decodeV010JourneyJSON(managedDataOutput, &managedData); err != nil {
+		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("decode fresh candidate legacy managed-data observation: %w", err)
+	}
+	managedDataVisible := len(managedData.Items) > 0
+	for _, item := range managedData.Items {
+		if strings.TrimSpace(item.ID) == "" || item.ProjectID != v010ProjectID {
+			return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("fresh candidate legacy managed-data observation is invalid")
+		}
+	}
+	if legacyPrincipals != 0 || dashboards != 0 || semanticModels != 0 || projectVisible || managedDataVisible {
 		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("fresh candidate exposed preserved v0.1 principals, project, or managed data")
 	}
 	return compatibility.V010FreshCandidateInventory{
 		AdminEmail: credentials.Email, AdminPrincipalID: adminResponse.Items[0].ID,
 		LegacyPrincipalCount: legacyPrincipals, DashboardCount: dashboards, SemanticModelCount: semanticModels,
-		LegacyProjectVisible: false, LegacyManagedDataVisible: false,
+		LegacyProjectVisible: projectVisible, LegacyManagedDataVisible: managedDataVisible,
 	}, nil
+}
+
+func v010CandidateAPIStatus(err error, status int) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	want := fmt.Sprintf("%d", status)
+	for _, marker := range []string{
+		`"status":` + want + `,`, `"status": ` + want + `,`,
+		`"status":` + want + `}`, `"status": ` + want + `}`,
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Controller) attemptV010LegacyStateAdoption(ctx context.Context, image, volume, target, home string) error {

--- a/internal/app/cli/composectl/qualification_v010_candidate.go
+++ b/internal/app/cli/composectl/qualification_v010_candidate.go
@@ -1,0 +1,471 @@
+package composectl
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/flidai/leapview/internal/platform/compatibility"
+)
+
+const (
+	v010CandidateAdminEmail = "fai-517-candidate@qualification.invalid"
+	v010CandidateStateMount = "/var/lib/leapview"
+	v010CandidateRunMount   = "/qualification"
+)
+
+type v010CandidateCredentials struct {
+	Email          string `json:"email"`
+	PublisherToken string `json:"publisherToken"`
+}
+
+func (c *Controller) qualifyV010FreshCandidate(
+	ctx context.Context,
+	policyDocument []byte,
+	predecessor compatibility.V010ReleaseIdentityEvidence,
+	predecessorVolume string,
+) (result compatibility.V010FreshCandidateEvidence, runErr error) {
+	policy, err := compatibility.ParsePolicy(policyDocument)
+	if err != nil {
+		return result, err
+	}
+	candidateRelease, ok := policy.ReleaseByID(policy.CandidateRelease)
+	if !ok {
+		return result, fmt.Errorf("transition policy candidate release %q is unavailable", policy.CandidateRelease)
+	}
+	candidate := candidateRelease.IdentityForPlatform(compatibility.ReleasedV010Platform)
+	freshDecision := policy.Evaluate(compatibility.Request{
+		Operation: compatibility.OperationFreshInstall,
+		Next:      candidate,
+	})
+	if err := freshDecision.Err(); err != nil || freshDecision.ReasonCode != compatibility.ReasonAllowedFreshInstall {
+		return result, fmt.Errorf("candidate fresh installation is not allowed by the exact transition policy: %w", err)
+	}
+	upgradeDenial := policy.Evaluate(compatibility.Request{
+		Operation: compatibility.OperationUpgrade,
+		Current:   predecessor.Identity,
+		Next:      candidate,
+	})
+	if !errors.Is(upgradeDenial.Err(), compatibility.ErrV010FreshInstallOnly) ||
+		upgradeDenial.ReasonCode != compatibility.ReasonDeniedFreshInstallOnly {
+		return result, fmt.Errorf("transition policy did not deny preserved v0.1 state adoption")
+	}
+	directAdoptionDenial := policy.Evaluate(compatibility.Request{
+		Operation: compatibility.OperationFreshInstall,
+		Next:      predecessor.Identity,
+	})
+	if directAdoptionDenial.Allowed || directAdoptionDenial.ReasonCode != compatibility.ReasonDeniedUnknownRelease {
+		return result, fmt.Errorf("transition policy did not deny direct v0.1 artifact adoption")
+	}
+
+	imageID, err := c.resolveV010CandidateImage(ctx, candidate)
+	if err != nil {
+		return result, err
+	}
+	runID, err := qualificationRandomHex(16)
+	if err != nil {
+		return result, err
+	}
+	name := "leapview-v010-candidate-" + runID
+	network := name + "-network"
+	volume := name + "-state"
+	runDirectory, err := os.MkdirTemp(c.root, ".v010-candidate-run-"+runID+"-")
+	if err != nil {
+		return result, err
+	}
+	if err := os.Chmod(runDirectory, 0o755); err != nil {
+		_ = os.RemoveAll(runDirectory)
+		return result, err
+	}
+	var networkCreated, volumeCreated, containerCreated, cleanupComplete bool
+	cleanup := func(cleanupCtx context.Context) error {
+		var cleanupErr error
+		if containerCreated {
+			_, removeErr := c.qualificationDocker(cleanupCtx, nil, "rm", "--force", name)
+			cleanupErr = errors.Join(cleanupErr, ignoreQualificationNotFound(removeErr))
+		}
+		if volumeCreated {
+			_, removeErr := c.qualificationDocker(cleanupCtx, nil, "volume", "rm", volume)
+			cleanupErr = errors.Join(cleanupErr, ignoreQualificationNotFound(removeErr))
+		}
+		if networkCreated {
+			_, removeErr := c.qualificationDocker(cleanupCtx, nil, "network", "rm", network)
+			cleanupErr = errors.Join(cleanupErr, ignoreQualificationNotFound(removeErr))
+		}
+		cleanupErr = errors.Join(cleanupErr, os.RemoveAll(runDirectory))
+		return cleanupErr
+	}
+	defer func() {
+		if cleanupComplete {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), qualificationCleanupTimeout)
+		defer cancel()
+		runErr = errors.Join(runErr, cleanup(cleanupCtx))
+	}()
+
+	labels := []string{"--label", "com.leapview.qualification=fai-517", "--label", "com.leapview.qualification.run-id=" + runID}
+	networkArgs := append([]string{"network", "create", "--driver", "bridge", "--internal"}, labels...)
+	networkArgs = append(networkArgs, network)
+	if _, err := c.qualificationDocker(ctx, nil, networkArgs...); err != nil {
+		return result, fmt.Errorf("create isolated fresh candidate network: %w", err)
+	}
+	networkCreated = true
+	volumeArgs := append([]string{"volume", "create"}, labels...)
+	volumeArgs = append(volumeArgs, volume)
+	if _, err := c.qualificationDocker(ctx, nil, volumeArgs...); err != nil {
+		return result, fmt.Errorf("create isolated fresh candidate state: %w", err)
+	}
+	volumeCreated = true
+	startedAt := c.now().UTC()
+	freshBefore, freshBeforeEntries, err := c.v010QualificationVolumeChecksum(ctx, candidate.Image, volume)
+	if err != nil {
+		return result, fmt.Errorf("inventory clean candidate state: %w", err)
+	}
+	if freshBeforeEntries != 0 {
+		return result, fmt.Errorf("candidate state volume was not empty before fresh installation")
+	}
+	credentials, err := c.initializeV010FreshCandidate(ctx, candidate.Image, volume)
+	if err != nil {
+		return result, err
+	}
+	csrfKey, err := qualificationRandomHex(32)
+	if err != nil {
+		return result, err
+	}
+	metricsToken, err := qualificationRandomHex(32)
+	if err != nil {
+		return result, err
+	}
+	runOutput, err := c.qualificationDockerWithEnvironment(ctx, map[string]string{
+		"LEAPVIEW_CSRF_KEY": csrfKey, "LEAPVIEW_METRICS_BEARER_TOKEN": metricsToken,
+	},
+		"run", "--detach", "--name", name, "--hostname", "leapview-fai-517",
+		"--network", network, "--platform", compatibility.ReleasedV010Platform,
+		"--pull", "never", "--restart", "no", "--read-only",
+		"--security-opt", "no-new-privileges", "--cap-drop", "ALL", "--pids-limit", "512",
+		"--env", "LEAPVIEW_PRODUCTION=1", "--env", "LEAPVIEW_ENVIRONMENT=fai-517-candidate",
+		"--env", "LEAPVIEW_HOME=/var/lib/leapview/home", "--env", "LEAPVIEW_API_TOKEN_ONLY_AUTH=1",
+		"--env", "LEAPVIEW_ALLOWED_HOSTS=127.0.0.1,localhost", "--env", "LEAPVIEW_PUBLIC_URL=https://localhost",
+		"--env", "LEAPVIEW_CSRF_KEY", "--env", "LEAPVIEW_METRICS_BEARER_TOKEN",
+		"--mount", "type=volume,source="+volume+",target="+v010CandidateStateMount,
+		"--mount", "type=bind,source="+runDirectory+",target="+v010CandidateRunMount+",readonly",
+		"--tmpfs", "/tmp:rw,nosuid,nodev,mode=1777,size=64m",
+		labels[0], labels[1], labels[2], labels[3], candidate.Image,
+	)
+	if err != nil {
+		return result, fmt.Errorf("start isolated fresh candidate: %w", err)
+	}
+	containerCreated = true
+	containerID := strings.TrimSpace(string(runOutput))
+	inspected, err := c.inspectV010Container(ctx, name)
+	if err != nil {
+		return result, err
+	}
+	if err := validateV010FreshCandidateInspect(inspected, containerID, name, network, volume, runDirectory, candidate, imageID, true); err != nil {
+		return result, err
+	}
+	inventory, err := c.collectV010FreshCandidateInventory(ctx, name, credentials)
+	if err != nil {
+		return result, err
+	}
+	if _, err := c.qualificationDocker(ctx, nil, "stop", "--time", "30", name); err != nil {
+		return result, fmt.Errorf("cleanly stop isolated fresh candidate: %w", err)
+	}
+	inspected, err = c.inspectV010Container(ctx, name)
+	if err != nil {
+		return result, err
+	}
+	if err := validateV010FreshCandidateInspect(inspected, containerID, name, network, volume, runDirectory, candidate, imageID, false); err != nil {
+		return result, err
+	}
+	freshAfter, freshAfterEntries, err := c.v010QualificationVolumeChecksum(ctx, candidate.Image, volume)
+	if err != nil {
+		return result, fmt.Errorf("inventory initialized candidate state: %w", err)
+	}
+	if freshBefore == freshAfter || freshAfterEntries == 0 {
+		return result, fmt.Errorf("candidate installation did not create deterministic fresh state")
+	}
+	predecessorBefore, predecessorEntries, err := c.v010QualificationVolumeChecksum(ctx, candidate.Image, predecessorVolume)
+	if err != nil {
+		return result, fmt.Errorf("inventory preserved predecessor before denial: %w", err)
+	}
+	if predecessorEntries == 0 {
+		return result, fmt.Errorf("preserved predecessor state is empty before denial qualification")
+	}
+
+	denials := make([]compatibility.V010LegacyDenialEvidence, 0, 3)
+	for _, probe := range []struct {
+		scenario string
+		target   string
+		home     string
+	}{
+		{scenario: "preserved-state-mount", target: v010CandidateStateMount, home: v010CandidateStateMount},
+		{scenario: "legacy-state-reference", target: "/legacy-v010", home: "/legacy-v010"},
+	} {
+		if err := c.attemptV010LegacyStateAdoption(ctx, candidate.Image, predecessorVolume, probe.target, probe.home); err != nil {
+			return result, fmt.Errorf("%s denial: %w", probe.scenario, err)
+		}
+		predecessorAfterProbe, _, checksumErr := c.v010QualificationVolumeChecksum(ctx, candidate.Image, predecessorVolume)
+		if checksumErr != nil {
+			return result, checksumErr
+		}
+		if predecessorAfterProbe != predecessorBefore {
+			return result, fmt.Errorf("%s changed preserved predecessor state", probe.scenario)
+		}
+		denials = append(denials, compatibility.V010LegacyDenialEvidence{
+			Scenario: probe.scenario, Operation: upgradeDenial.Operation, ReasonCode: upgradeDenial.ReasonCode,
+			BeforeSHA256: predecessorBefore, AfterSHA256: predecessorAfterProbe, DeniedBeforeMutation: true,
+		})
+	}
+	denials = append(denials, compatibility.V010LegacyDenialEvidence{
+		Scenario: "direct-legacy-artifact-adoption", Operation: directAdoptionDenial.Operation,
+		ReasonCode: directAdoptionDenial.ReasonCode, BeforeSHA256: freshAfter, AfterSHA256: freshAfter,
+		DeniedBeforeMutation: true,
+	})
+	candidateAfterDenials, _, err := c.v010QualificationVolumeChecksum(ctx, candidate.Image, volume)
+	if err != nil {
+		return result, err
+	}
+	predecessorAfterDenials, _, err := c.v010QualificationVolumeChecksum(ctx, candidate.Image, predecessorVolume)
+	if err != nil {
+		return result, err
+	}
+	if candidateAfterDenials != freshAfter || predecessorAfterDenials != predecessorBefore {
+		return result, fmt.Errorf("legacy adoption denial changed candidate or predecessor state")
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), qualificationCleanupTimeout)
+	cleanupErr := cleanup(cleanupCtx)
+	cancel()
+	if cleanupErr != nil {
+		return result, fmt.Errorf("clean up isolated fresh candidate: %w", cleanupErr)
+	}
+	if err := c.verifyV010Cleanup(ctx, name, network, volume, runDirectory); err != nil {
+		return result, err
+	}
+	cleanupComplete = true
+	return compatibility.V010FreshCandidateEvidence{
+		RunID: runID, ContainerID: containerID, ContainerName: name, StateVolumeName: volume, NetworkName: network,
+		Predecessor: predecessor.Identity, Candidate: candidate, CandidateImageID: imageID,
+		PolicyVersion: policy.PolicyVersion, PolicySHA256: predecessor.PolicySHA256, FreshInstallDecision: freshDecision,
+		FreshStateBeforeSHA256: freshBefore, FreshStateAfterSHA256: freshAfter,
+		CandidateBeforeDenialsSHA256: freshAfter, CandidateAfterDenialsSHA256: candidateAfterDenials,
+		PredecessorBeforeDenialsSHA256: predecessorBefore, PredecessorAfterDenialsSHA256: predecessorAfterDenials,
+		CandidateInventory: inventory, Denials: denials, StartedAt: startedAt, CompletedAt: c.now().UTC(),
+		CleanStateVerified: true, LegacyStateUnavailable: true, MutationFree: true, CleanupVerified: true,
+	}, nil
+}
+
+func (c *Controller) resolveV010CandidateImage(ctx context.Context, candidate compatibility.ReleaseIdentity) (string, error) {
+	if candidate.Platform != compatibility.ReleasedV010Platform || !strings.Contains(candidate.Image, "@sha256:") {
+		return "", fmt.Errorf("candidate must use the policy-admitted immutable linux/amd64 artifact")
+	}
+	if _, err := c.qualificationDocker(ctx, nil, "pull", "--platform", candidate.Platform, candidate.Image); err != nil {
+		return "", fmt.Errorf("pull exact admitted candidate artifact: %w", err)
+	}
+	document, err := c.qualificationDocker(ctx, nil, "image", "inspect", "--format", "{{json .}}", candidate.Image)
+	if err != nil {
+		return "", fmt.Errorf("inspect admitted candidate artifact: %w", err)
+	}
+	var image v010DockerImageInspect
+	if err := decodeV010RegistryDocument(document, &image); err != nil {
+		return "", err
+	}
+	if image.OS+"/"+image.Architecture != candidate.Platform || !containsQualificationString(image.RepoDigests, candidate.Image) ||
+		image.Config.Labels["org.opencontainers.image.version"] != candidate.Version ||
+		image.Config.Labels["org.opencontainers.image.revision"] != candidate.SourceRevision ||
+		!strings.HasPrefix(image.ID, "sha256:") {
+		return "", fmt.Errorf("candidate runtime identity does not match the admitted policy artifact")
+	}
+	return image.ID, nil
+}
+
+func (c *Controller) initializeV010FreshCandidate(ctx context.Context, image, volume string) (v010CandidateCredentials, error) {
+	output, err := c.qualificationDocker(ctx, nil,
+		"run", "--rm", "--platform", compatibility.ReleasedV010Platform,
+		"--env", "LEAPVIEW_PRODUCTION=1", "--env", "LEAPVIEW_ENVIRONMENT=fai-517-candidate",
+		"--env", "LEAPVIEW_HOME=/var/lib/leapview/home",
+		"--env", "LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL="+v010CandidateAdminEmail,
+		"--mount", "type=volume,source="+volume+",target="+v010CandidateStateMount,
+		image, "admin", "initialize", "--format", "json",
+	)
+	if err != nil {
+		return v010CandidateCredentials{}, fmt.Errorf("initialize isolated fresh candidate through supported CLI: %w", err)
+	}
+	var credentials v010CandidateCredentials
+	if err := decodeV010JourneyJSON(output, &credentials); err != nil || credentials.Email != v010CandidateAdminEmail ||
+		strings.TrimSpace(credentials.PublisherToken) == "" {
+		return v010CandidateCredentials{}, fmt.Errorf("fresh candidate initialization credentials are incomplete")
+	}
+	return credentials, nil
+}
+
+func (c *Controller) collectV010FreshCandidateInventory(
+	ctx context.Context,
+	container string,
+	credentials v010CandidateCredentials,
+) (compatibility.V010FreshCandidateInventory, error) {
+	call := func(arguments ...string) ([]byte, error) {
+		dockerArguments := []string{"exec", "--env", "LEAPVIEW_API_TOKEN", container, "leapview"}
+		dockerArguments = append(dockerArguments, arguments...)
+		return c.qualificationDockerWithEnvironment(ctx, map[string]string{"LEAPVIEW_API_TOKEN": credentials.PublisherToken}, dockerArguments...)
+	}
+	listCount := func(operation string, arguments ...string) (int, error) {
+		command := []string{"api", "call", operation, "--target", "http://127.0.0.1:8080"}
+		command = append(command, arguments...)
+		output, err := call(command...)
+		if err != nil {
+			return 0, err
+		}
+		var response struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := decodeV010JourneyJSON(output, &response); err != nil {
+			return 0, err
+		}
+		return len(response.Items), nil
+	}
+	readyCtx, cancel := qualificationContext(ctx, v010ReadinessTimeout)
+	defer cancel()
+	var adminOutput []byte
+	var lastErr error
+	if err := qualificationWait(readyCtx, time.Second, func(requestCtx context.Context) (bool, error) {
+		var callErr error
+		adminOutput, callErr = func() ([]byte, error) {
+			dockerArguments := []string{"exec", "--env", "LEAPVIEW_API_TOKEN", container, "leapview", "api", "call", "listPrincipals",
+				"--target", "http://127.0.0.1:8080", "--query", "email=" + v010CandidateAdminEmail}
+			return c.qualificationDockerWithEnvironment(requestCtx, map[string]string{"LEAPVIEW_API_TOKEN": credentials.PublisherToken}, dockerArguments...)
+		}()
+		lastErr = callErr
+		return callErr == nil, nil
+	}); err != nil {
+		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("fresh candidate API readiness: %w", errors.Join(err, lastErr))
+	}
+	var adminResponse struct {
+		Items []struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"items"`
+	}
+	if err := decodeV010JourneyJSON(adminOutput, &adminResponse); err != nil || len(adminResponse.Items) != 1 ||
+		adminResponse.Items[0].ID == "" || adminResponse.Items[0].Email != v010CandidateAdminEmail {
+		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("fresh candidate administrator identity is invalid")
+	}
+	legacyPrincipals := 0
+	for _, email := range []string{v010AdminEmail, v010UserEmail} {
+		count, err := listCount("listPrincipals", "--query", "email="+email)
+		if err != nil {
+			return compatibility.V010FreshCandidateInventory{}, err
+		}
+		legacyPrincipals += count
+	}
+	dashboards, err := listCount("listDashboards")
+	if err != nil {
+		return compatibility.V010FreshCandidateInventory{}, err
+	}
+	semanticModels, err := listCount("listSemanticModels")
+	if err != nil {
+		return compatibility.V010FreshCandidateInventory{}, err
+	}
+	if legacyPrincipals != 0 || dashboards != 0 || semanticModels != 0 {
+		return compatibility.V010FreshCandidateInventory{}, fmt.Errorf("fresh candidate exposed preserved v0.1 principals, project, or managed data")
+	}
+	return compatibility.V010FreshCandidateInventory{
+		AdminEmail: credentials.Email, AdminPrincipalID: adminResponse.Items[0].ID,
+		LegacyPrincipalCount: legacyPrincipals, DashboardCount: dashboards, SemanticModelCount: semanticModels,
+		LegacyProjectVisible: false, LegacyManagedDataVisible: false,
+	}, nil
+}
+
+func (c *Controller) attemptV010LegacyStateAdoption(ctx context.Context, image, volume, target, home string) error {
+	_, err := c.qualificationDocker(ctx, nil,
+		"run", "--rm", "--platform", compatibility.ReleasedV010Platform,
+		"--env", "LEAPVIEW_PRODUCTION=1", "--env", "LEAPVIEW_ENVIRONMENT=fai-517-candidate",
+		"--env", "LEAPVIEW_HOME="+home, "--env", "LEAPVIEW_BOOTSTRAP_ADMIN_EMAIL="+v010CandidateAdminEmail,
+		"--mount", "type=volume,source="+volume+",target="+target,
+		image, "admin", "initialize", "--format", "json",
+	)
+	if err == nil || !strings.Contains(err.Error(), compatibility.ErrV010FreshInstallOnly.Error()) {
+		return fmt.Errorf("candidate did not reject preserved v0.1 state before initialization: %v", err)
+	}
+	return nil
+}
+
+func (c *Controller) v010QualificationVolumeChecksum(ctx context.Context, image, volume string) (string, int, error) {
+	document, err := c.qualificationDocker(ctx, nil,
+		"run", "--rm", "--read-only", "--user", "0:0", "--entrypoint", "tar",
+		"--mount", "type=volume,source="+volume+",target=/state,readonly",
+		image, "--sort=name", "--mtime=UTC 1970-01-01", "--owner=0", "--group=0", "--numeric-owner", "-C", "/state", "-cf", "-", ".",
+	)
+	if err != nil {
+		return "", 0, fmt.Errorf("read deterministic state archive: %w", err)
+	}
+	entries := 0
+	reader := tar.NewReader(bytes.NewReader(document))
+	for {
+		header, readErr := reader.Next()
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return "", 0, fmt.Errorf("decode deterministic state archive: %w", readErr)
+		}
+		name := filepath.Clean(header.Name)
+		if name == "." || header.Typeflag == tar.TypeDir {
+			continue
+		}
+		if filepath.IsAbs(name) || name == ".." || strings.HasPrefix(name, ".."+string(filepath.Separator)) {
+			return "", 0, fmt.Errorf("state archive contains an unsafe path")
+		}
+		entries++
+	}
+	digest := sha256.Sum256(document)
+	return hex.EncodeToString(digest[:]), entries, nil
+}
+
+func validateV010FreshCandidateInspect(
+	inspected v010ContainerInspect,
+	containerID, name, network, volume, runDirectory string,
+	candidate compatibility.ReleaseIdentity,
+	imageID string,
+	running bool,
+) error {
+	wantedState := "exited"
+	if running {
+		wantedState = "running"
+	}
+	if inspected.ID != containerID || inspected.Name != "/"+name || inspected.Image != imageID ||
+		inspected.Config.Image != candidate.Image || inspected.State.Running != running || inspected.State.Status != wantedState ||
+		inspected.HostConfig.NetworkMode != network || len(inspected.NetworkSettings.Networks) != 1 {
+		return fmt.Errorf("fresh candidate container identity or lifecycle does not match admitted artifact")
+	}
+	if _, ok := inspected.NetworkSettings.Networks[network]; !ok {
+		return fmt.Errorf("fresh candidate is not attached only to its isolated network")
+	}
+	var stateMount, runMount bool
+	for _, mount := range inspected.Mounts {
+		switch mount.Destination {
+		case v010CandidateStateMount:
+			stateMount = mount.Type == "volume" && mount.Name == volume && mount.RW
+		case v010CandidateRunMount:
+			runMount = mount.Type == "bind" && filepath.Clean(mount.Source) == filepath.Clean(runDirectory) && !mount.RW
+		case v010StateMount:
+			return fmt.Errorf("fresh candidate can access preserved v0.1 state")
+		}
+	}
+	if !stateMount || !runMount {
+		return fmt.Errorf("fresh candidate does not use its isolated state and run directory")
+	}
+	return nil
+}

--- a/internal/app/cli/composectl/qualification_v010_command.go
+++ b/internal/app/cli/composectl/qualification_v010_command.go
@@ -1,0 +1,204 @@
+package composectl
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/flidai/leapview/internal/platform/compatibility"
+	securefs "github.com/flidai/leapview/internal/platform/filesystem"
+)
+
+const v010QualificationEvidenceName = "v0.1-preservation-qualification.json"
+
+type QualificationV010Options struct {
+	CandidateAdmission  string
+	TransitionPolicy    string
+	PolicySHA256        string
+	PredecessorEvidence string
+	EvidenceDir         string
+}
+
+type QualificationV010ArtifactReviewOptions struct {
+	TransitionPolicy string
+	PolicySHA256     string
+	Evidence         string
+}
+
+// ReviewV010Artifact publishes the compatibility owner's existing Phase 1
+// evidence contract for the exact authenticated v0.1 artifact. Release
+// qualification supplies this document to the complete preservation journey.
+func (c *Controller) ReviewV010Artifact(ctx context.Context, options QualificationV010ArtifactReviewOptions) error {
+	if ctx == nil {
+		return fmt.Errorf("v0.1 artifact review context is required")
+	}
+	if strings.TrimSpace(options.Evidence) == "" {
+		return fmt.Errorf("v0.1 artifact review evidence destination is required")
+	}
+	destination, err := filepath.Abs(options.Evidence)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return fmt.Errorf("create v0.1 artifact review evidence directory: %w", err)
+	}
+	if err := os.Remove(destination); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale v0.1 artifact review evidence: %w", err)
+	}
+	policyDocument, err := readV010QualificationPolicy(options.TransitionPolicy, options.PolicySHA256)
+	if err != nil {
+		return err
+	}
+	resolver := newDockerV010ArtifactResolver(c.root, c.dockerBin, c.qualificationExecutor)
+	evidence, err := compatibility.VerifyReleasedV010Artifact(ctx, compatibility.V010ArtifactVerificationOptions{
+		PolicyDocument: policyDocument,
+		Resolver:       resolver,
+		Now:            c.now,
+	})
+	if err != nil {
+		return err
+	}
+	document, err := compatibility.MarshalV010ReleaseIdentityEvidence(evidence, policyDocument)
+	if err != nil {
+		return fmt.Errorf("owner-validate reviewed v0.1 artifact evidence: %w", err)
+	}
+	if err := securefs.WritePrivateFileAtomic(destination, document); err != nil {
+		return fmt.Errorf("atomically publish reviewed v0.1 artifact evidence: %w", err)
+	}
+	published, err := os.ReadFile(destination)
+	if err != nil {
+		_ = os.Remove(destination)
+		return fmt.Errorf("read published v0.1 artifact review evidence: %w", err)
+	}
+	validated, err := compatibility.ValidateV010ReleaseIdentityEvidence(published, policyDocument)
+	if err != nil || !reflect.DeepEqual(validated, evidence) {
+		_ = os.Remove(destination)
+		if err != nil {
+			return fmt.Errorf("validate published v0.1 artifact review evidence: %w", err)
+		}
+		return fmt.Errorf("published v0.1 artifact review evidence changed after owner validation")
+	}
+	_, err = fmt.Fprintf(c.stdout, "reviewed exact v0.1 artifact evidence: %s\n", destination)
+	return err
+}
+
+// QualifyV010Preservation is the supported production entry point for the
+// complete exact-v0.1 preservation and candidate fresh-install qualification.
+func (c *Controller) QualifyV010Preservation(ctx context.Context, options QualificationV010Options) error {
+	if ctx == nil {
+		return fmt.Errorf("v0.1 qualification context is required")
+	}
+	for label, value := range map[string]string{
+		"candidate admission":                options.CandidateAdmission,
+		"candidate-bound transition policy":  options.TransitionPolicy,
+		"expected transition policy SHA-256": options.PolicySHA256,
+		"reviewed v0.1 predecessor evidence": options.PredecessorEvidence,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", label)
+		}
+	}
+	evidenceDir := strings.TrimSpace(options.EvidenceDir)
+	if evidenceDir == "" {
+		evidenceDir = c.path("qualification-evidence")
+	}
+	evidenceDir, err := filepath.Abs(evidenceDir)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(evidenceDir, 0o700); err != nil {
+		return fmt.Errorf("create v0.1 qualification evidence directory: %w", err)
+	}
+	destination := filepath.Join(evidenceDir, v010QualificationEvidenceName)
+	if err := os.Remove(destination); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale v0.1 qualification evidence: %w", err)
+	}
+	policyDocument, err := readV010QualificationPolicy(options.TransitionPolicy, options.PolicySHA256)
+	if err != nil {
+		return err
+	}
+	policy, err := compatibility.ParsePolicy(policyDocument)
+	if err != nil {
+		return fmt.Errorf("validate candidate-bound transition policy: %w", err)
+	}
+	candidateRelease, ok := policy.ReleaseByID(policy.CandidateRelease)
+	if !ok {
+		return fmt.Errorf("candidate-bound transition policy omits candidate release %q", policy.CandidateRelease)
+	}
+	candidate := candidateRelease.IdentityForPlatform(compatibility.ReleasedV010Platform)
+	admissionDocument, err := os.ReadFile(options.CandidateAdmission)
+	if err != nil {
+		return fmt.Errorf("read candidate admission evidence: %w", err)
+	}
+	if _, err := compatibility.ValidateCandidateAdmissionEvidence(admissionDocument, candidate); err != nil {
+		return err
+	}
+	predecessorDocument, err := os.ReadFile(options.PredecessorEvidence)
+	if err != nil {
+		return fmt.Errorf("read reviewed v0.1 predecessor evidence: %w", err)
+	}
+	reviewed, err := compatibility.ValidateV010ReleaseIdentityEvidence(predecessorDocument, policyDocument)
+	if err != nil {
+		return fmt.Errorf("validate reviewed v0.1 predecessor evidence: %w", err)
+	}
+
+	completed, err := c.qualifyV010ArtifactExecution(ctx, policyDocument)
+	if err != nil {
+		return err
+	}
+	if completed.Identity != reviewed.Identity || completed.Artifact != reviewed.Artifact ||
+		completed.Provenance != reviewed.Provenance || completed.PolicyVersion != reviewed.PolicyVersion ||
+		completed.PolicySHA256 != reviewed.PolicySHA256 {
+		return fmt.Errorf("observed v0.1 artifact does not match reviewed predecessor evidence")
+	}
+	if completed.Execution == nil || completed.Execution.Preservation == nil || completed.Execution.FreshCandidate == nil {
+		return fmt.Errorf("completed v0.1 qualification evidence is incomplete")
+	}
+	document, err := compatibility.MarshalV010ReleaseIdentityEvidence(completed, policyDocument)
+	if err != nil {
+		return fmt.Errorf("owner-validate completed v0.1 qualification evidence: %w", err)
+	}
+	if err := securefs.WritePrivateFileAtomic(destination, document); err != nil {
+		return fmt.Errorf("atomically publish v0.1 qualification evidence: %w", err)
+	}
+	published, err := os.ReadFile(destination)
+	if err != nil {
+		_ = os.Remove(destination)
+		return fmt.Errorf("read published v0.1 qualification evidence: %w", err)
+	}
+	validated, err := compatibility.ValidateV010ReleaseIdentityEvidence(published, policyDocument)
+	if err != nil {
+		_ = os.Remove(destination)
+		return fmt.Errorf("validate published v0.1 qualification evidence: %w", err)
+	}
+	if !reflect.DeepEqual(validated, completed) {
+		_ = os.Remove(destination)
+		return fmt.Errorf("published v0.1 qualification evidence changed after owner validation")
+	}
+	_, err = fmt.Fprintf(c.stdout, "v0.1 preservation and fresh-install qualification passed; evidence: %s\n", destination)
+	return err
+}
+
+func readV010QualificationPolicy(path, expectedSHA256 string) ([]byte, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("candidate-bound transition policy is required")
+	}
+	if strings.TrimSpace(expectedSHA256) == "" {
+		return nil, fmt.Errorf("expected transition policy SHA-256 is required")
+	}
+	document, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read candidate-bound transition policy: %w", err)
+	}
+	digest := sha256.Sum256(document)
+	actual := hex.EncodeToString(digest[:])
+	if strings.TrimSpace(expectedSHA256) != actual {
+		return nil, fmt.Errorf("candidate-bound transition policy digest mismatch: got %s", actual)
+	}
+	return document, nil
+}

--- a/internal/app/cli/composectl/qualification_v010_command_test.go
+++ b/internal/app/cli/composectl/qualification_v010_command_test.go
@@ -1,0 +1,264 @@
+package composectl
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/platform/compatibility"
+	"github.com/stretchr/testify/require"
+)
+
+type v010CommandArtifactResolver struct{}
+
+func (v010CommandArtifactResolver) ResolveExact(
+	context.Context,
+	compatibility.V010ArtifactResolutionRequest,
+) (compatibility.V010ResolvedArtifact, error) {
+	return compatibility.V010ResolvedArtifact{
+		Image: compatibility.ReleasedV010Image, ResolvedDigest: strings.TrimPrefix(compatibility.ReleasedV010Image[strings.LastIndex(compatibility.ReleasedV010Image, "@"):], "@"),
+		Platform: compatibility.ReleasedV010Platform, PlatformManifestDigest: compatibility.ReleasedV010PlatformManifest,
+		ConfigDigest: compatibility.ReleasedV010ConfigDigest, Authenticated: true,
+		SourceRepository: compatibility.ReleasedV010SourceRepository, SourceTag: compatibility.ReleasedV010ID,
+		Version: "0.1.0", SourceRevision: "5bf4aded574df459e80d81b77d1989ecd4fa7de0",
+	}, nil
+}
+
+type v010CommandInputs struct {
+	policyPath      string
+	policySHA256    string
+	admissionPath   string
+	predecessorPath string
+	evidenceDir     string
+	policyDocument  []byte
+}
+
+func TestV010PreservationQualificationCommandPublishesCompleteOwnerValidatedEvidence(t *testing.T) {
+	root := t.TempDir()
+	inputs := writeV010CommandInputs(t, root)
+	fixture := newV010DockerFixture(t)
+	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+	var stdout bytes.Buffer
+	controller, err := New(Options{
+		Root: root, DockerBin: "docker-probe", Stdout: &stdout,
+		qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+	})
+	require.NoError(t, err)
+
+	command := Command(t.Context(), controller)
+	command.SetArgs(v010CommandArguments(inputs))
+	require.NoError(t, command.Execute())
+
+	destination := filepath.Join(inputs.evidenceDir, v010QualificationEvidenceName)
+	document, err := os.ReadFile(destination)
+	require.NoError(t, err)
+	evidence, err := compatibility.ValidateV010ReleaseIdentityEvidence(document, inputs.policyDocument)
+	require.NoError(t, err)
+	require.NotNil(t, evidence.Execution)
+	require.NotNil(t, evidence.Execution.Preservation)
+	require.NotNil(t, evidence.Execution.FreshCandidate)
+	require.True(t, evidence.Execution.FreshCandidate.MutationFree)
+	require.Equal(t, compatibility.ReasonDeniedFreshInstallOnly, evidence.Execution.FreshCandidate.Denials[0].ReasonCode)
+	info, err := os.Stat(destination)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	require.Contains(t, stdout.String(), destination)
+	temporary, err := filepath.Glob(filepath.Join(inputs.evidenceDir, ".*"+v010QualificationEvidenceName+"*"))
+	require.NoError(t, err)
+	require.Empty(t, temporary)
+}
+
+func TestV010ArtifactReviewCommandPublishesPolicyBoundOwnerEvidence(t *testing.T) {
+	root := t.TempDir()
+	inputs := writeV010CommandInputs(t, root)
+	fixture := newV010DockerFixture(t)
+	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+	destination := filepath.Join(root, "review", "v0.1-reviewed-identity.json")
+	var stdout bytes.Buffer
+	controller, err := New(Options{
+		Root: root, DockerBin: "docker-probe", Stdout: &stdout,
+		qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+	})
+	require.NoError(t, err)
+	command := Command(t.Context(), controller)
+	command.SetArgs([]string{
+		"qualify", "v0.1-artifact-review",
+		"--transition-policy", inputs.policyPath,
+		"--policy-sha256", inputs.policySHA256,
+		"--evidence", destination,
+	})
+	require.NoError(t, command.Execute())
+
+	document, err := os.ReadFile(destination)
+	require.NoError(t, err)
+	evidence, err := compatibility.ValidateV010ReleaseIdentityEvidence(document, inputs.policyDocument)
+	require.NoError(t, err)
+	require.Nil(t, evidence.Execution)
+	require.Equal(t, inputs.policySHA256, evidence.PolicySHA256)
+	require.Equal(t, compatibility.ReleasedV010Image, evidence.Identity.Image)
+	require.Contains(t, stdout.String(), destination)
+	info, err := os.Stat(destination)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestV010ArtifactReviewCommandRejectsWrongPolicyDigestBeforeRegistryAccess(t *testing.T) {
+	root := t.TempDir()
+	inputs := writeV010CommandInputs(t, root)
+	fixture := newV010DockerFixture(t)
+	destination := filepath.Join(root, "wrong-digest-review.json")
+	require.NoError(t, os.WriteFile(destination, []byte("stale evidence"), 0o600))
+	controller, err := New(Options{
+		Root: root, DockerBin: "docker-probe",
+		qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+	})
+	require.NoError(t, err)
+	command := Command(t.Context(), controller)
+	command.SetArgs([]string{
+		"qualify", "v0.1-artifact-review",
+		"--transition-policy", inputs.policyPath,
+		"--policy-sha256", strings.Repeat("0", 64),
+		"--evidence", destination,
+	})
+	err = command.Execute()
+	require.ErrorContains(t, err, "policy digest mismatch")
+	require.Empty(t, fixture.requests)
+	require.NoFileExists(t, destination)
+}
+
+func TestV010PreservationQualificationCommandRejectsUnboundInputsBeforeExecution(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, *v010CommandInputs) []string
+		want   string
+	}{
+		{name: "missing admission evidence", mutate: func(_ *testing.T, inputs *v010CommandInputs) []string {
+			arguments := v010CommandArguments(*inputs)
+			return removeV010CommandFlag(arguments, "--candidate-admission")
+		}, want: "required flag"},
+		{name: "missing predecessor evidence", mutate: func(t *testing.T, inputs *v010CommandInputs) []string {
+			inputs.predecessorPath = filepath.Join(t.TempDir(), "missing-predecessor.json")
+			return v010CommandArguments(*inputs)
+		}, want: "read reviewed v0.1 predecessor evidence"},
+		{name: "wrong candidate digest", mutate: func(t *testing.T, inputs *v010CommandInputs) []string {
+			var admission map[string]any
+			document, err := os.ReadFile(inputs.admissionPath)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(document, &admission))
+			admission["digest"] = "sha256:" + strings.Repeat("9", 64)
+			require.NoError(t, writeQualificationJSON(inputs.admissionPath, admission))
+			return v010CommandArguments(*inputs)
+		}, want: "candidate admission does not authorize"},
+		{name: "substituted candidate identity", mutate: func(t *testing.T, inputs *v010CommandInputs) []string {
+			var admission map[string]any
+			document, err := os.ReadFile(inputs.admissionPath)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(document, &admission))
+			digest := "sha256:" + strings.Repeat("8", 64)
+			admission["image"] = "ghcr.io/flidai/leapview@" + digest
+			admission["digest"] = digest
+			admission["registryDigest"] = digest
+			require.NoError(t, writeQualificationJSON(inputs.admissionPath, admission))
+			return v010CommandArguments(*inputs)
+		}, want: "candidate admission does not authorize"},
+		{name: "wrong policy digest", mutate: func(_ *testing.T, inputs *v010CommandInputs) []string {
+			inputs.policySHA256 = strings.Repeat("0", 64)
+			return v010CommandArguments(*inputs)
+		}, want: "policy digest mismatch"},
+		{name: "invalid predecessor evidence", mutate: func(t *testing.T, inputs *v010CommandInputs) []string {
+			var evidence map[string]any
+			document, err := os.ReadFile(inputs.predecessorPath)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(document, &evidence))
+			evidence["artifact"].(map[string]any)["configDigest"] = "sha256:" + strings.Repeat("0", 64)
+			require.NoError(t, writeQualificationJSON(inputs.predecessorPath, evidence))
+			return v010CommandArguments(*inputs)
+		}, want: "validate reviewed v0.1 predecessor evidence"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			inputs := writeV010CommandInputs(t, root)
+			arguments := test.mutate(t, &inputs)
+			fixture := newV010DockerFixture(t)
+			controller, err := New(Options{
+				Root: root, DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+			})
+			require.NoError(t, err)
+			command := Command(t.Context(), controller)
+			command.SetArgs(arguments)
+			err = command.Execute()
+			require.ErrorContains(t, err, test.want)
+			require.Empty(t, fixture.requests)
+			require.NoFileExists(t, filepath.Join(inputs.evidenceDir, v010QualificationEvidenceName))
+		})
+	}
+}
+
+func writeV010CommandInputs(t *testing.T, root string) v010CommandInputs {
+	t.Helper()
+	policyDocument := v010CandidateBoundTestPolicy(t)
+	policyPath := filepath.Join(root, "release-transition-policy.json")
+	require.NoError(t, os.WriteFile(policyPath, policyDocument, 0o600))
+	policyDigest := sha256.Sum256(policyDocument)
+	policy, err := compatibility.ParsePolicy(policyDocument)
+	require.NoError(t, err)
+	candidate, ok := policy.ReleaseByID(policy.CandidateRelease)
+	require.True(t, ok)
+	identity := candidate.IdentityForPlatform(compatibility.ReleasedV010Platform)
+	digest := identity.Image[strings.LastIndex(identity.Image, "@")+1:]
+	admission := map[string]any{
+		"schemaVersion": 1, "image": identity.Image, "digest": digest, "registryDigest": digest,
+		"attestation": map[string]any{
+			"verified": true, "repository": "flidai/leapview",
+			"workflow": "flidai/leapview/.github/workflows/release.yml", "sourceRevision": identity.SourceRevision,
+		},
+		"sbom":                map[string]any{"discoverable": true},
+		"vulnerabilityPolicy": map[string]any{"passed": true},
+	}
+	admissionPath := filepath.Join(root, "assembled-image-admission.json")
+	require.NoError(t, writeQualificationJSON(admissionPath, admission))
+	predecessor, err := compatibility.VerifyReleasedV010Artifact(t.Context(), compatibility.V010ArtifactVerificationOptions{
+		PolicyDocument: policyDocument, Resolver: v010CommandArtifactResolver{},
+		Now: func() time.Time { return time.Date(2026, time.July, 13, 15, 45, 27, 0, time.UTC) },
+	})
+	require.NoError(t, err)
+	predecessorDocument, err := compatibility.MarshalV010ReleaseIdentityEvidence(predecessor, policyDocument)
+	require.NoError(t, err)
+	predecessorPath := filepath.Join(root, "v0.1-reviewed-identity.json")
+	require.NoError(t, os.WriteFile(predecessorPath, predecessorDocument, 0o600))
+	return v010CommandInputs{
+		policyPath: policyPath, policySHA256: hex.EncodeToString(policyDigest[:]),
+		admissionPath: admissionPath, predecessorPath: predecessorPath,
+		evidenceDir: filepath.Join(root, "qualification-evidence"), policyDocument: policyDocument,
+	}
+}
+
+func v010CommandArguments(inputs v010CommandInputs) []string {
+	return []string{
+		"qualify", "v0.1-preservation",
+		"--candidate-admission", inputs.admissionPath,
+		"--transition-policy", inputs.policyPath,
+		"--policy-sha256", inputs.policySHA256,
+		"--predecessor-evidence", inputs.predecessorPath,
+		"--evidence-dir", inputs.evidenceDir,
+	}
+}
+
+func removeV010CommandFlag(arguments []string, flag string) []string {
+	result := make([]string, 0, len(arguments)-2)
+	for index := 0; index < len(arguments); index++ {
+		if arguments[index] == flag && index+1 < len(arguments) {
+			index++
+			continue
+		}
+		result = append(result, arguments[index])
+	}
+	return result
+}

--- a/internal/app/cli/composectl/qualification_v010_inventory.go
+++ b/internal/app/cli/composectl/qualification_v010_inventory.go
@@ -1,0 +1,211 @@
+package composectl
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/flidai/leapview/internal/platform/compatibility"
+)
+
+func (c *Controller) collectV010StateInventory(
+	ctx context.Context,
+	container string,
+	containerID string,
+	token string,
+	release compatibility.V010ReleaseIdentityEvidence,
+	journey compatibility.V010ApplicationJourney,
+) (compatibility.V010StateInventory, string, error) {
+	principals, err := c.collectV010Principals(ctx, container, token, journey)
+	if err != nil {
+		return compatibility.V010StateInventory{}, "", err
+	}
+	project, err := c.collectV010Project(ctx, container, token, journey)
+	if err != nil {
+		return compatibility.V010StateInventory{}, "", err
+	}
+	publish, err := c.collectV010Publish(ctx, container, token, journey)
+	if err != nil {
+		return compatibility.V010StateInventory{}, "", err
+	}
+	assets, err := c.collectV010Assets(ctx, container, token, project.ActiveServingStateID)
+	if err != nil {
+		return compatibility.V010StateInventory{}, "", err
+	}
+	semanticChecksum, dashboardChecksum, err := c.collectV010QueryState(ctx, container, token)
+	if err != nil {
+		return compatibility.V010StateInventory{}, "", err
+	}
+	inventory := compatibility.V010StateInventory{
+		Application: compatibility.V010InventoryApplication{
+			Image: release.Identity.Image, ImageID: release.Artifact.ConfigDigest,
+			ContainerID: containerID, Platform: compatibility.ReleasedV010Platform,
+			SourceRevision: release.Provenance.SourceRevision,
+		},
+		Principals: principals, Project: project, Publish: publish, Assets: assets,
+		ManagedDataRows: 3, SemanticResultSHA256: semanticChecksum, DashboardResultSHA256: dashboardChecksum,
+	}
+	digest, err := compatibility.V010StateInventorySHA256(inventory)
+	if err != nil {
+		return compatibility.V010StateInventory{}, "", err
+	}
+	return inventory, digest, nil
+}
+
+func (c *Controller) collectV010Principals(
+	ctx context.Context,
+	container string,
+	token string,
+	journey compatibility.V010ApplicationJourney,
+) ([]compatibility.V010InventoryPrincipal, error) {
+	expected := []struct {
+		email string
+		id    string
+	}{
+		{email: journey.AdminEmail, id: journey.AdminPrincipalID},
+		{email: journey.UserEmail, id: journey.UserPrincipalID},
+	}
+	principals := make([]compatibility.V010InventoryPrincipal, 0, len(expected))
+	for _, wanted := range expected {
+		output, err := c.v010ContainerCLI(ctx, container, token,
+			"api", "call", "listPrincipals", "--target", "http://127.0.0.1:8080",
+			"--query", "email="+wanted.email)
+		if err != nil {
+			return nil, fmt.Errorf("inventory v0.1 principal %s through supported API: %w", wanted.email, err)
+		}
+		var response struct {
+			Items []compatibility.V010InventoryPrincipal `json:"items"`
+		}
+		if err := decodeV010JourneyJSON(output, &response); err != nil || len(response.Items) != 1 ||
+			response.Items[0].ID != wanted.id || response.Items[0].Email != wanted.email {
+			return nil, fmt.Errorf("v0.1 inventory omitted or changed principal %s", wanted.email)
+		}
+		principals = append(principals, response.Items[0])
+	}
+	return principals, nil
+}
+
+func (c *Controller) collectV010Project(
+	ctx context.Context,
+	container string,
+	token string,
+	journey compatibility.V010ApplicationJourney,
+) (compatibility.V010InventoryProject, error) {
+	output, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "listWork"+"spaces", "--target", "http://127.0.0.1:8080",
+		"--query", "environment="+journey.Environment)
+	if err != nil {
+		return compatibility.V010InventoryProject{}, fmt.Errorf("inventory v0.1 project and environment through supported API: %w", err)
+	}
+	var response struct {
+		Items []struct {
+			ID                   string `json:"id"`
+			Title                string `json:"title"`
+			ActiveServingStateID string `json:"activeServingStateId"`
+		} `json:"items"`
+	}
+	if err := decodeV010JourneyJSON(output, &response); err != nil {
+		return compatibility.V010InventoryProject{}, fmt.Errorf("decode v0.1 project inventory: %w", err)
+	}
+	for _, item := range response.Items {
+		if item.ID == journey.ProjectID && item.Title == "FAI-517 Compatibility" && item.ActiveServingStateID != "" {
+			return compatibility.V010InventoryProject{
+				ID: item.ID, Title: item.Title, Environment: journey.Environment,
+				ActiveServingStateID: item.ActiveServingStateID,
+			}, nil
+		}
+	}
+	return compatibility.V010InventoryProject{}, fmt.Errorf("v0.1 inventory omitted or changed the activated project state")
+}
+
+func (c *Controller) collectV010Publish(
+	ctx context.Context,
+	container string,
+	token string,
+	journey compatibility.V010ApplicationJourney,
+) (compatibility.V010InventoryPublish, error) {
+	output, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "listPublishes", "--target", "http://127.0.0.1:8080",
+		"--path", "work"+"space="+journey.ProjectID, "--query", "environment="+journey.Environment)
+	if err != nil {
+		return compatibility.V010InventoryPublish{}, fmt.Errorf("inventory v0.1 published workload through supported API: %w", err)
+	}
+	var response struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := decodeV010JourneyJSON(output, &response); err != nil {
+		return compatibility.V010InventoryPublish{}, fmt.Errorf("decode v0.1 publish inventory: %w", err)
+	}
+	for _, item := range response.Items {
+		id, _ := item["id"].(string)
+		projectID, _ := item["work"+"spaceId"].(string)
+		environment, _ := item["environment"].(string)
+		status, _ := item["status"].(string)
+		digest, _ := item["digest"].(string)
+		if id == journey.PublishID && projectID == journey.ProjectID && environment == journey.Environment &&
+			status == "active" && digest == journey.ActivatedDigest {
+			return compatibility.V010InventoryPublish{
+				ID: id, ProjectID: projectID, Environment: environment, Status: status, Digest: digest,
+			}, nil
+		}
+	}
+	return compatibility.V010InventoryPublish{}, fmt.Errorf("v0.1 inventory omitted or changed the active published workload")
+}
+
+func (c *Controller) collectV010Assets(
+	ctx context.Context,
+	container string,
+	token string,
+	servingStateID string,
+) ([]compatibility.V010InventoryAsset, error) {
+	output, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "getWork"+"spaceActiveAssetGraph", "--target", "http://127.0.0.1:8080",
+		"--path", "work"+"space="+v010ProjectID, "--query", "environment="+v010Environment)
+	if err != nil {
+		return nil, fmt.Errorf("inventory v0.1 managed-data and project graph through supported API: %w", err)
+	}
+	var response struct {
+		Assets []compatibility.V010InventoryAsset `json:"assets"`
+	}
+	if err := decodeV010JourneyJSON(output, &response); err != nil || len(response.Assets) == 0 {
+		return nil, fmt.Errorf("v0.1 inventory could not decode the active project graph")
+	}
+	sort.Slice(response.Assets, func(i, j int) bool {
+		left := response.Assets[i].Type + ":" + response.Assets[i].Key
+		right := response.Assets[j].Type + ":" + response.Assets[j].Key
+		return left < right
+	})
+	for _, asset := range response.Assets {
+		if asset.ID == "" || asset.Type == "" || asset.Key == "" || asset.ContentHash == "" || asset.ServingStateID != servingStateID {
+			return nil, fmt.Errorf("v0.1 inventory contains incomplete managed-data or project asset metadata")
+		}
+	}
+	return response.Assets, nil
+}
+
+func (c *Controller) collectV010QueryState(ctx context.Context, container, token string) (string, string, error) {
+	semanticOutput, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "querySemanticDataset", "--target", "http://127.0.0.1:8080",
+		"--path", "work"+"space="+v010ProjectID, "--path", "model="+v010SemanticModelID,
+		"--path", "dataset="+v010DatasetID,
+		"--body-json", `{"dimensions":[{"field":"orders.status","alias":"status"}],"measures":[{"field":"order_count"}],"sort":[{"field":"status","direction":"asc"}]}`)
+	if err != nil {
+		return "", "", fmt.Errorf("inventory v0.1 semantic query-visible state: %w", err)
+	}
+	semanticChecksum, err := validateV010SemanticResult(semanticOutput)
+	if err != nil {
+		return "", "", err
+	}
+	dashboardOutput, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "queryDashboardVisualData", "--target", "http://127.0.0.1:8080",
+		"--path", "work"+"space="+v010ProjectID, "--path", "dashboard="+v010DashboardID,
+		"--path", "page=overview", "--path", "visual=total", "--body-json", `{}`)
+	if err != nil {
+		return "", "", fmt.Errorf("inventory v0.1 dashboard query-visible state: %w", err)
+	}
+	dashboardChecksum, err := validateV010DashboardResult(dashboardOutput)
+	if err != nil {
+		return "", "", err
+	}
+	return semanticChecksum, dashboardChecksum, nil
+}

--- a/internal/app/cli/composectl/qualification_v010_journey.go
+++ b/internal/app/cli/composectl/qualification_v010_journey.go
@@ -1,0 +1,333 @@
+package composectl
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/flidai/leapview/internal/platform/compatibility"
+)
+
+const (
+	v010AdminEmail        = "fai-517-admin@qualification.invalid"
+	v010UserEmail         = "fai-517-user@qualification.invalid"
+	v010ProjectID         = "compatibility"
+	v010Environment       = "fai-517"
+	v010DashboardID       = "preservation"
+	v010SemanticModelID   = "compatibility"
+	v010DatasetID         = "orders"
+	v010ReadinessTimeout  = 90 * time.Second
+	v010DiagnosticTimeout = 10 * time.Second
+)
+
+var v010PublishedPattern = regexp.MustCompile(`(?m)^published compatibility publish=([^ ]+) environment=fai-517 digest=([^ ]+) localDigest=([^ ]+) status=([^ ]+)$`)
+
+//go:embed qualification_v010_project
+var v010QualificationProject embed.FS
+
+func prepareV010QualificationProject(runDirectory string) error {
+	return fs.WalkDir(v010QualificationProject, "qualification_v010_project", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel("qualification_v010_project", path)
+		if err != nil || relative == "." {
+			return err
+		}
+		target := filepath.Join(runDirectory, relative)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		document, err := v010QualificationProject.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, document, 0o444); err != nil {
+			return fmt.Errorf("write v0.1 qualification fixture %s: %w", relative, err)
+		}
+		return nil
+	})
+}
+
+type v010JourneyResult struct {
+	evidence compatibility.V010ApplicationJourney
+	token    string
+}
+
+func (c *Controller) runV010ApplicationJourney(
+	ctx context.Context,
+	container string,
+) (v010JourneyResult, error) {
+	journey := compatibility.V010ApplicationJourney{
+		StartedAt: c.now().UTC(), ProjectID: v010ProjectID, Environment: v010Environment,
+		AdminEmail: v010AdminEmail, UserEmail: v010UserEmail,
+	}
+	if err := c.waitV010Readiness(ctx, container); err != nil {
+		return v010JourneyResult{}, err
+	}
+	journey.ReadyAt = c.now().UTC()
+
+	bootstrapOutput, err := c.v010ContainerCLI(ctx, container, "", "admin", "bootstrap")
+	if err != nil {
+		return v010JourneyResult{}, fmt.Errorf("bootstrap v0.1 application through supported admin CLI: %w", err)
+	}
+	token, err := parseV010BootstrapToken(bootstrapOutput)
+	if err != nil {
+		return v010JourneyResult{}, err
+	}
+	principalOutput, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "getCurrentPrincipal", "--target", "http://127.0.0.1:8080")
+	if err != nil {
+		return v010JourneyResult{}, fmt.Errorf("authenticate to v0.1 API with bootstrap credential: %w", err)
+	}
+	var admin struct {
+		ID    string `json:"id"`
+		Email string `json:"email"`
+	}
+	if err := decodeV010JourneyJSON(principalOutput, &admin); err != nil || admin.ID == "" || admin.Email != v010AdminEmail {
+		return v010JourneyResult{}, fmt.Errorf("v0.1 authentication response did not identify the bootstrapped administrator")
+	}
+
+	createdOutput, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "createPrincipal", "--target", "http://127.0.0.1:8080",
+		"--body-json", `{"email":"`+v010UserEmail+`","displayName":"FAI-517 User"}`)
+	if err != nil {
+		return v010JourneyResult{}, fmt.Errorf("create deterministic v0.1 user through supported API: %w", err)
+	}
+	var created struct {
+		Principal struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"principal"`
+		TemporaryPassword string `json:"temporaryPassword"`
+	}
+	if err := decodeV010JourneyJSON(createdOutput, &created); err != nil || created.Principal.ID == "" ||
+		created.Principal.Email != v010UserEmail || strings.TrimSpace(created.TemporaryPassword) == "" {
+		return v010JourneyResult{}, fmt.Errorf("v0.1 user bootstrap response was incomplete")
+	}
+	journey.AdminPrincipalID = admin.ID
+	journey.UserPrincipalID = created.Principal.ID
+	journey.AuthenticationVerified = true
+
+	publishOutput, err := c.v010ContainerCLI(ctx, container, token,
+		"publish", "--target", "http://127.0.0.1:8080",
+		"--project", v010QualificationMount+"/libredash.yaml",
+		"--environment", v010Environment, "--auto-approve")
+	if err != nil {
+		return v010JourneyResult{}, fmt.Errorf("publish deterministic v0.1 project through supported CLI: %w", err)
+	}
+	match := v010PublishedPattern.FindSubmatch(bytes.TrimSpace(publishOutput))
+	if len(match) != 5 || string(match[4]) != "active" {
+		return v010JourneyResult{}, fmt.Errorf("v0.1 project publish did not report an active deterministic project")
+	}
+	journey.PublishID = string(match[1])
+	journey.ActivatedDigest = string(match[2])
+	journey.ProjectDigest = string(match[3])
+	journey.ProjectActivated = true
+
+	dashboardsOutput, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "listDashboards", "--target", "http://127.0.0.1:8080",
+		"--path", "work"+"space="+v010ProjectID)
+	if err != nil {
+		return v010JourneyResult{}, fmt.Errorf("list activated v0.1 dashboards: %w", err)
+	}
+	if err := validateV010DashboardList(dashboardsOutput); err != nil {
+		return v010JourneyResult{}, err
+	}
+
+	semanticOutput, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "querySemanticDataset", "--target", "http://127.0.0.1:8080",
+		"--path", "work"+"space="+v010ProjectID, "--path", "model="+v010SemanticModelID,
+		"--path", "dataset="+v010DatasetID,
+		"--body-json", `{"dimensions":[{"field":"orders.status","alias":"status"}],"measures":[{"field":"order_count"}],"sort":[{"field":"status","direction":"asc"}]}`)
+	if err != nil {
+		return v010JourneyResult{}, fmt.Errorf("query deterministic v0.1 semantic workload: %w", err)
+	}
+	semanticChecksum, err := validateV010SemanticResult(semanticOutput)
+	if err != nil {
+		return v010JourneyResult{}, err
+	}
+
+	dashboardOutput, err := c.v010ContainerCLI(ctx, container, token,
+		"api", "call", "queryDashboardVisualData", "--target", "http://127.0.0.1:8080",
+		"--path", "work"+"space="+v010ProjectID, "--path", "dashboard="+v010DashboardID,
+		"--path", "page=overview", "--path", "visual=total", "--body-json", `{}`)
+	if err != nil {
+		return v010JourneyResult{}, fmt.Errorf("query deterministic v0.1 dashboard workload: %w", err)
+	}
+	dashboardChecksum, err := validateV010DashboardResult(dashboardOutput)
+	if err != nil {
+		return v010JourneyResult{}, err
+	}
+	journey.ManagedDataRows = 3
+	journey.SemanticResultSHA256 = semanticChecksum
+	journey.DashboardResultSHA256 = dashboardChecksum
+	journey.ManagedDataVerified = true
+	journey.WorkloadVerified = true
+	journey.CompletedAt = c.now().UTC()
+	return v010JourneyResult{evidence: journey, token: token}, nil
+}
+
+func (c *Controller) waitV010Readiness(ctx context.Context, container string) error {
+	readyCtx, cancel := qualificationContext(ctx, v010ReadinessTimeout)
+	defer cancel()
+	var lastErr error
+	err := qualificationWait(readyCtx, time.Second, func(requestCtx context.Context) (bool, error) {
+		output, checkErr := c.v010ContainerCLI(requestCtx, container, "", "healthcheck", "--timeout", "5s")
+		if checkErr != nil {
+			lastErr = checkErr
+			return false, nil
+		}
+		if strings.TrimSpace(string(output)) != "ready" {
+			lastErr = fmt.Errorf("healthcheck returned an unexpected response")
+			return false, nil
+		}
+		return true, nil
+	})
+	if err == nil {
+		return nil
+	}
+	diagnosticCtx, diagnosticCancel := context.WithTimeout(context.WithoutCancel(ctx), v010DiagnosticTimeout)
+	defer diagnosticCancel()
+	logs, logErr := c.qualificationDocker(diagnosticCtx, nil, "logs", "--tail", "80", container)
+	if logErr != nil {
+		logs = []byte("container logs unavailable")
+	}
+	return fmt.Errorf("v0.1 readiness was not reached within %s: %v; diagnostics: %s",
+		v010ReadinessTimeout, errors.Join(err, lastErr), strings.TrimSpace(string(redactQualificationLog(logs, 80))))
+}
+
+func (c *Controller) v010ContainerCLI(ctx context.Context, container, token string, arguments ...string) ([]byte, error) {
+	dockerArguments := []string{"exec"}
+	environment := map[string]string{}
+	if token != "" {
+		dockerArguments = append(dockerArguments, "--env", "LIBREDASH_API_TOKEN")
+		environment["LIBREDASH_API_TOKEN"] = token
+	}
+	dockerArguments = append(dockerArguments, container, "libredash")
+	dockerArguments = append(dockerArguments, arguments...)
+	return c.qualificationDockerWithEnvironment(ctx, environment, dockerArguments...)
+}
+
+func (c *Controller) qualificationDockerWithEnvironment(ctx context.Context, values map[string]string, arguments ...string) ([]byte, error) {
+	environment := append([]string(nil), os.Environ()...)
+	for name, value := range values {
+		prefix := name + "="
+		for index := len(environment) - 1; index >= 0; index-- {
+			if strings.HasPrefix(environment[index], prefix) {
+				environment = append(environment[:index], environment[index+1:]...)
+			}
+		}
+		environment = append(environment, prefix+value)
+	}
+	return qualificationProcess{dir: c.root, executable: c.dockerBin, environment: environment}.
+		Run(ctx, nil, c.qualificationExecutor, arguments...)
+}
+
+func parseV010BootstrapToken(document []byte) (string, error) {
+	token := strings.TrimSpace(string(document))
+	if token == "" || len(token) > 512 || strings.ContainsAny(token, " \t\r\n") {
+		return "", fmt.Errorf("v0.1 admin bootstrap did not return one bounded API credential")
+	}
+	return token, nil
+}
+
+func decodeV010JourneyJSON(document []byte, target any) error {
+	if len(document) == 0 || len(document) > 1<<20 {
+		return fmt.Errorf("v0.1 journey response is empty or exceeds 1 MiB")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("v0.1 journey response contains trailing JSON")
+	}
+	return nil
+}
+
+func validateV010DashboardList(document []byte) error {
+	var response struct {
+		Items []struct {
+			ID string `json:"id"`
+		} `json:"items"`
+	}
+	if err := decodeV010JourneyJSON(document, &response); err != nil {
+		return fmt.Errorf("decode v0.1 dashboard list: %w", err)
+	}
+	for _, item := range response.Items {
+		if item.ID == v010DashboardID {
+			return nil
+		}
+	}
+	return fmt.Errorf("activated v0.1 project omitted the deterministic dashboard")
+}
+
+func validateV010SemanticResult(document []byte) (string, error) {
+	var response struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := decodeV010JourneyJSON(document, &response); err != nil {
+		return "", fmt.Errorf("decode v0.1 semantic result: %w", err)
+	}
+	rows := make([]string, 0, len(response.Items))
+	for _, item := range response.Items {
+		status, _ := item["status"].(string)
+		count, ok := v010JSONInteger(item["order_count"])
+		if !ok || status == "" {
+			return "", fmt.Errorf("v0.1 semantic workload returned an invalid row")
+		}
+		rows = append(rows, fmt.Sprintf("%s=%d", status, count))
+	}
+	sort.Strings(rows)
+	if strings.Join(rows, ",") != "delivered=2,shipped=1" {
+		return "", fmt.Errorf("v0.1 semantic workload result did not match deterministic managed data")
+	}
+	return v010ResultDigest(strings.Join(rows, "\n")), nil
+}
+
+func validateV010DashboardResult(document []byte) (string, error) {
+	var response struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := decodeV010JourneyJSON(document, &response); err != nil {
+		return "", fmt.Errorf("decode v0.1 dashboard result: %w", err)
+	}
+	if len(response.Data) != 1 {
+		return "", fmt.Errorf("v0.1 dashboard workload returned an unexpected result shape")
+	}
+	value, ok := v010JSONInteger(response.Data[0]["value"])
+	if !ok || value != 3 {
+		return "", fmt.Errorf("v0.1 dashboard workload result did not match deterministic managed data")
+	}
+	return v010ResultDigest("total=3"), nil
+}
+
+func v010JSONInteger(value any) (int64, bool) {
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, false
+	}
+	parsed, err := number.Int64()
+	return parsed, err == nil
+}
+
+func v010ResultDigest(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/app/cli/composectl/qualification_v010_project/connections/qualification.yaml
+++ b/internal/app/cli/composectl/qualification_v010_project/connections/qualification.yaml
@@ -1,0 +1,6 @@
+apiVersion: libredash.dev/v1
+kind: Connection
+metadata:
+  name: qualification
+spec:
+  kind: local

--- a/internal/app/cli/composectl/qualification_v010_project/data/orders.csv
+++ b/internal/app/cli/composectl/qualification_v010_project/data/orders.csv
@@ -1,0 +1,4 @@
+order_id,order_status
+o-001,delivered
+o-002,shipped
+o-003,delivered

--- a/internal/app/cli/composectl/qualification_v010_project/libredash.yaml
+++ b/internal/app/cli/composectl/qualification_v010_project/libredash.yaml
@@ -1,0 +1,14 @@
+apiVersion: libredash.dev/v1
+kind: Project
+metadata:
+  name: fai-517-v010-preservation
+spec:
+  connections:
+    include:
+      - connections/*.yaml
+  sources:
+    include:
+      - sources/*.yaml
+  workspaces:
+    include:
+      - workspaces/*/workspace.yaml

--- a/internal/app/cli/composectl/qualification_v010_project/sources/qualification.orders.yaml
+++ b/internal/app/cli/composectl/qualification_v010_project/sources/qualification.orders.yaml
@@ -1,0 +1,12 @@
+apiVersion: libredash.dev/v1
+kind: Source
+metadata:
+  name: qualification.orders
+spec:
+  connection: qualification
+  path: orders.csv
+  fields:
+    order_id:
+      type: string
+    order_status:
+      type: string

--- a/internal/app/cli/composectl/qualification_v010_project/workspaces/compatibility/dashboards/preservation.yaml
+++ b/internal/app/cli/composectl/qualification_v010_project/workspaces/compatibility/dashboards/preservation.yaml
@@ -1,0 +1,27 @@
+apiVersion: libredash.dev/v1
+kind: Dashboard
+metadata:
+  workspace: compatibility
+  name: preservation
+  title: v0.1 Preservation
+spec:
+  semanticModel: compatibility
+  visuals:
+    total:
+      kind: kpi
+      shape: single_value
+      query:
+        measures:
+          order_count:
+  pages:
+    - name: overview
+      title: Overview
+      visuals:
+        - id: total
+          kind: kpi_card
+          visual: total
+          placement:
+            col: 1
+            row: 1
+            col_span: 3
+            row_span: 2

--- a/internal/app/cli/composectl/qualification_v010_project/workspaces/compatibility/models/orders.yaml
+++ b/internal/app/cli/composectl/qualification_v010_project/workspaces/compatibility/models/orders.yaml
@@ -1,0 +1,20 @@
+apiVersion: libredash.dev/v1
+kind: ModelTable
+metadata:
+  workspace: compatibility
+  name: orders
+spec:
+  primaryKey: order_id
+  sources:
+    - qualification.orders
+  fields:
+    order_id:
+      label: Order
+      type: string
+    status:
+      label: Status
+      type: string
+  transform:
+    sql: |
+      SELECT order_id, order_status AS status
+      FROM source."qualification.orders"

--- a/internal/app/cli/composectl/qualification_v010_project/workspaces/compatibility/semantic-models/compatibility.yaml
+++ b/internal/app/cli/composectl/qualification_v010_project/workspaces/compatibility/semantic-models/compatibility.yaml
@@ -1,0 +1,15 @@
+apiVersion: libredash.dev/v1
+kind: SemanticModel
+metadata:
+  workspace: compatibility
+  name: compatibility
+spec:
+  baseTable: orders
+  tables:
+    - orders
+  measures:
+    defaults:
+      table: orders
+    order_count:
+      label: Orders
+      expression: count(orders.order_id)

--- a/internal/app/cli/composectl/qualification_v010_project/workspaces/compatibility/workspace.yaml
+++ b/internal/app/cli/composectl/qualification_v010_project/workspaces/compatibility/workspace.yaml
@@ -1,0 +1,22 @@
+apiVersion: libredash.dev/v1
+kind: Workspace
+metadata:
+  name: compatibility
+  title: FAI-517 Compatibility
+spec:
+  uses:
+    sources:
+      - qualification.orders
+  models:
+    include:
+      - models/*.yaml
+  semanticModels:
+    include:
+      - semantic-models/*.yaml
+  dashboards:
+    include:
+      - dashboards/*.yaml
+  access:
+    include: []
+  agentPolicy:
+    include: []

--- a/internal/app/cli/composectl/qualification_v010_runtime.go
+++ b/internal/app/cli/composectl/qualification_v010_runtime.go
@@ -1,0 +1,561 @@
+package composectl
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/flidai/leapview/internal/platform/compatibility"
+)
+
+const (
+	v010OCIIndexMediaType    = "application/vnd.oci.image.index.v1+json"
+	v010OCIManifestMediaType = "application/vnd.oci.image.manifest.v1+json"
+	v010OCIConfigMediaType   = "application/vnd.oci.image.config.v1+json"
+	v010StateMount           = "/var/lib/libredash"
+	v010QualificationMount   = "/qualification"
+)
+
+type dockerV010ArtifactResolver struct {
+	process    qualificationProcess
+	executor   qualificationCommandExecutor
+	configPath string
+}
+
+type v010OCIDescriptor struct {
+	MediaType string `json:"mediaType"`
+	Digest    string `json:"digest"`
+	Size      int64  `json:"size"`
+	Platform  *struct {
+		Architecture string `json:"architecture"`
+		OS           string `json:"os"`
+	} `json:"platform,omitempty"`
+}
+
+type v010OCIIndex struct {
+	SchemaVersion int                 `json:"schemaVersion"`
+	MediaType     string              `json:"mediaType"`
+	Manifests     []v010OCIDescriptor `json:"manifests"`
+}
+
+type v010OCIManifest struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType"`
+	Config        v010OCIDescriptor `json:"config"`
+}
+
+type v010DockerImageInspect struct {
+	ID           string   `json:"Id"`
+	RepoDigests  []string `json:"RepoDigests"`
+	Architecture string   `json:"Architecture"`
+	OS           string   `json:"Os"`
+	Config       struct {
+		Labels map[string]string `json:"Labels"`
+	} `json:"Config"`
+}
+
+func newDockerV010ArtifactResolver(root, dockerBin string, executor qualificationCommandExecutor) *dockerV010ArtifactResolver {
+	return &dockerV010ArtifactResolver{
+		process:  qualificationProcess{dir: root, executable: dockerBin, environment: os.Environ()},
+		executor: executor,
+	}
+}
+
+func (resolver *dockerV010ArtifactResolver) ResolveExact(
+	ctx context.Context,
+	request compatibility.V010ArtifactResolutionRequest,
+) (compatibility.V010ResolvedArtifact, error) {
+	if request.Image != compatibility.ReleasedV010Image || request.Platform != compatibility.ReleasedV010Platform ||
+		!request.RequireAuthentication {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("v0.1 resolver accepts only the authenticated exact policy-selected linux/amd64 artifact")
+	}
+	if err := resolver.requireRegistryCredentials(); err != nil {
+		return compatibility.V010ResolvedArtifact{}, err
+	}
+
+	indexDocument, err := resolver.run(ctx, "buildx", "imagetools", "inspect", "--raw", request.Image)
+	if err != nil {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("resolve authenticated v0.1 OCI index: %w", err)
+	}
+	indexDigest := qualificationSHA256Digest(indexDocument)
+	if indexDigest != request.Image[strings.LastIndex(request.Image, "@")+1:] {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("v0.1 registry bytes do not match the policy-selected immutable digest")
+	}
+	var index v010OCIIndex
+	if err := decodeV010RegistryDocument(indexDocument, &index); err != nil {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("decode v0.1 OCI index: %w", err)
+	}
+	if index.SchemaVersion != 2 || index.MediaType != v010OCIIndexMediaType {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("v0.1 registry object is not the reviewed OCI image index")
+	}
+	platformDescriptor, err := selectV010PlatformManifest(index.Manifests)
+	if err != nil {
+		return compatibility.V010ResolvedArtifact{}, err
+	}
+	platformReference := compatibility.ReleasedV010Repository + "@" + platformDescriptor.Digest
+	manifestDocument, err := resolver.run(ctx, "buildx", "imagetools", "inspect", "--raw", platformReference)
+	if err != nil {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("resolve authenticated v0.1 linux/amd64 manifest: %w", err)
+	}
+	if qualificationSHA256Digest(manifestDocument) != platformDescriptor.Digest || int64(len(manifestDocument)) != platformDescriptor.Size {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("v0.1 linux/amd64 manifest bytes do not match the OCI index descriptor")
+	}
+	var manifest v010OCIManifest
+	if err := decodeV010RegistryDocument(manifestDocument, &manifest); err != nil {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("decode v0.1 linux/amd64 manifest: %w", err)
+	}
+	if manifest.SchemaVersion != 2 || manifest.MediaType != v010OCIManifestMediaType ||
+		manifest.Config.MediaType != v010OCIConfigMediaType || manifest.Config.Digest == "" || manifest.Config.Size <= 0 {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("v0.1 linux/amd64 manifest has an invalid OCI config descriptor")
+	}
+
+	if _, err := resolver.run(ctx, "pull", "--platform", compatibility.ReleasedV010Platform, request.Image); err != nil {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("pull authenticated exact v0.1 artifact: %w", err)
+	}
+	inspectDocument, err := resolver.run(ctx, "image", "inspect", "--format", "{{json .}}", request.Image)
+	if err != nil {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("inspect exact v0.1 artifact: %w", err)
+	}
+	var image v010DockerImageInspect
+	if err := decodeV010RegistryDocument(inspectDocument, &image); err != nil {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("decode v0.1 image inspection: %w", err)
+	}
+	if image.ID != manifest.Config.Digest || image.OS+"/"+image.Architecture != compatibility.ReleasedV010Platform ||
+		(!containsQualificationString(image.RepoDigests, request.Image) &&
+			!containsQualificationString(image.RepoDigests, platformReference)) {
+		return compatibility.V010ResolvedArtifact{}, fmt.Errorf("local v0.1 image identity does not match the exact pulled registry artifact")
+	}
+	labels := image.Config.Labels
+	return compatibility.V010ResolvedArtifact{
+		Image: request.Image, ResolvedDigest: indexDigest, Platform: compatibility.ReleasedV010Platform,
+		PlatformManifestDigest: platformDescriptor.Digest, ConfigDigest: manifest.Config.Digest,
+		Authenticated: true, SourceRepository: labels["org.opencontainers.image.source"],
+		SourceTag: compatibility.ReleasedV010ID, Version: labels["org.opencontainers.image.version"],
+		SourceRevision: labels["org.opencontainers.image.revision"],
+	}, nil
+}
+
+func (resolver *dockerV010ArtifactResolver) run(ctx context.Context, arguments ...string) ([]byte, error) {
+	return resolver.process.Run(ctx, nil, resolver.executor, arguments...)
+}
+
+func (resolver *dockerV010ArtifactResolver) requireRegistryCredentials() error {
+	path := strings.TrimSpace(resolver.configPath)
+	if path == "" {
+		var err error
+		path, err = v010DockerConfigPath()
+		if err != nil {
+			return err
+		}
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("v0.1 authenticated registry credentials are required in %s: %w", path, err)
+	}
+	defer file.Close()
+	document, err := io.ReadAll(io.LimitReader(file, 1<<20+1))
+	if err != nil {
+		return fmt.Errorf("read Docker credential configuration: %w", err)
+	}
+	if len(document) == 0 || len(document) > 1<<20 {
+		return fmt.Errorf("Docker credential configuration is empty or exceeds 1 MiB")
+	}
+	var config struct {
+		Auths map[string]struct {
+			Auth          string `json:"auth"`
+			IdentityToken string `json:"identitytoken"`
+		} `json:"auths"`
+		CredHelpers map[string]string `json:"credHelpers"`
+		CredsStore  string            `json:"credsStore"`
+	}
+	if err := json.Unmarshal(document, &config); err != nil {
+		return fmt.Errorf("decode Docker credential configuration: %w", err)
+	}
+	for _, registry := range []string{"ghcr.io", "https://ghcr.io", "https://ghcr.io/v1/"} {
+		entry, configured := config.Auths[registry]
+		helper := strings.TrimSpace(config.CredHelpers[registry])
+		if helper != "" || validV010DockerAuth(entry.Auth) || strings.TrimSpace(entry.IdentityToken) != "" ||
+			(configured && strings.TrimSpace(config.CredsStore) != "") {
+			return nil
+		}
+	}
+	return fmt.Errorf("v0.1 authenticated registry credentials for ghcr.io are not configured")
+}
+
+func validV010DockerAuth(value string) bool {
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		return false
+	}
+	username, secret, found := strings.Cut(string(decoded), ":")
+	return found && strings.TrimSpace(username) != "" && strings.TrimSpace(secret) != ""
+}
+
+func v010DockerConfigPath() (string, error) {
+	if root := strings.TrimSpace(os.Getenv("DOCKER_CONFIG")); root != "" {
+		return filepath.Join(root, "config.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve Docker credential configuration: %w", err)
+	}
+	return filepath.Join(home, ".docker", "config.json"), nil
+}
+
+func selectV010PlatformManifest(manifests []v010OCIDescriptor) (v010OCIDescriptor, error) {
+	var selected v010OCIDescriptor
+	count := 0
+	for _, descriptor := range manifests {
+		if descriptor.Platform == nil || descriptor.Platform.OS != "linux" || descriptor.Platform.Architecture != "amd64" {
+			continue
+		}
+		if descriptor.MediaType != v010OCIManifestMediaType || descriptor.Digest == "" || descriptor.Size <= 0 {
+			return v010OCIDescriptor{}, fmt.Errorf("v0.1 linux/amd64 OCI descriptor is invalid")
+		}
+		selected = descriptor
+		count++
+	}
+	if count != 1 {
+		return v010OCIDescriptor{}, fmt.Errorf("v0.1 OCI index must contain exactly one linux/amd64 runtime manifest, found %d", count)
+	}
+	return selected, nil
+}
+
+func decodeV010RegistryDocument(document []byte, target any) error {
+	if len(document) == 0 || len(document) > 1<<20 {
+		return fmt.Errorf("registry document is empty or exceeds 1 MiB")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("registry document contains trailing data")
+	}
+	return nil
+}
+
+func qualificationSHA256Digest(document []byte) string {
+	digest := sha256.Sum256(document)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+type v010ContainerInspect struct {
+	ID    string `json:"Id"`
+	Name  string `json:"Name"`
+	Image string `json:"Image"`
+	State struct {
+		Status  string `json:"Status"`
+		Running bool   `json:"Running"`
+	} `json:"State"`
+	Config struct {
+		Image string `json:"Image"`
+	} `json:"Config"`
+	HostConfig struct {
+		NetworkMode string `json:"NetworkMode"`
+	} `json:"HostConfig"`
+	Mounts []struct {
+		Type        string `json:"Type"`
+		Name        string `json:"Name"`
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+		RW          bool   `json:"RW"`
+	} `json:"Mounts"`
+	NetworkSettings struct {
+		Networks map[string]json.RawMessage `json:"Networks"`
+	} `json:"NetworkSettings"`
+}
+
+// qualifyV010ArtifactExecution verifies the exact registry artifact, executes
+// the supported v0.1 application journey, and then cleanly stops it in an
+// isolated run directory, network, volume, and container.
+func (c *Controller) qualifyV010ArtifactExecution(
+	ctx context.Context,
+	policyDocument []byte,
+) (evidence compatibility.V010ReleaseIdentityEvidence, runErr error) {
+	resolver := newDockerV010ArtifactResolver(c.root, c.dockerBin, c.qualificationExecutor)
+	evidence, err := compatibility.VerifyReleasedV010Artifact(ctx, compatibility.V010ArtifactVerificationOptions{
+		PolicyDocument: policyDocument, Resolver: resolver, Now: c.now,
+	})
+	if err != nil {
+		return compatibility.V010ReleaseIdentityEvidence{}, err
+	}
+	runID, err := qualificationRandomHex(16)
+	if err != nil {
+		return compatibility.V010ReleaseIdentityEvidence{}, err
+	}
+	name := "leapview-v010-" + runID
+	network := name + "-network"
+	volume := name + "-state"
+	runDirectory, err := os.MkdirTemp(c.root, ".v010-run-"+runID+"-")
+	if err != nil {
+		return compatibility.V010ReleaseIdentityEvidence{}, err
+	}
+	// The directory contains only checked-in deterministic fixtures. It must be
+	// traversable by the released image's unprivileged libredash user.
+	if err := os.Chmod(runDirectory, 0o755); err != nil {
+		_ = os.RemoveAll(runDirectory)
+		return compatibility.V010ReleaseIdentityEvidence{}, err
+	}
+	if err := prepareV010QualificationProject(runDirectory); err != nil {
+		_ = os.RemoveAll(runDirectory)
+		return compatibility.V010ReleaseIdentityEvidence{}, fmt.Errorf("prepare deterministic v0.1 project: %w", err)
+	}
+	csrfKey, err := qualificationRandomHex(32)
+	if err != nil {
+		_ = os.RemoveAll(runDirectory)
+		return compatibility.V010ReleaseIdentityEvidence{}, err
+	}
+	metricsToken, err := qualificationRandomHex(32)
+	if err != nil {
+		_ = os.RemoveAll(runDirectory)
+		return compatibility.V010ReleaseIdentityEvidence{}, err
+	}
+	var networkCreated, volumeCreated, containerCreated, cleanupComplete bool
+	cleanup := func(cleanupCtx context.Context) error {
+		var cleanupErr error
+		if containerCreated {
+			_, err := c.qualificationDocker(cleanupCtx, nil, "rm", "--force", name)
+			cleanupErr = errors.Join(cleanupErr, ignoreQualificationNotFound(err))
+		}
+		if volumeCreated {
+			_, err := c.qualificationDocker(cleanupCtx, nil, "volume", "rm", volume)
+			cleanupErr = errors.Join(cleanupErr, ignoreQualificationNotFound(err))
+		}
+		if networkCreated {
+			_, err := c.qualificationDocker(cleanupCtx, nil, "network", "rm", network)
+			cleanupErr = errors.Join(cleanupErr, ignoreQualificationNotFound(err))
+		}
+		cleanupErr = errors.Join(cleanupErr, os.RemoveAll(runDirectory))
+		return cleanupErr
+	}
+	defer func() {
+		if cleanupComplete {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), qualificationCleanupTimeout)
+		defer cancel()
+		runErr = errors.Join(runErr, cleanup(cleanupCtx))
+	}()
+
+	labels := []string{"--label", "com.leapview.qualification=fai-517", "--label", "com.leapview.qualification.run-id=" + runID}
+	networkArguments := append([]string{"network", "create", "--driver", "bridge", "--internal"}, labels...)
+	networkArguments = append(networkArguments, network)
+	if _, err := c.qualificationDocker(ctx, nil, networkArguments...); err != nil {
+		return evidence, fmt.Errorf("create isolated v0.1 network: %w", err)
+	}
+	networkCreated = true
+	volumeArguments := append([]string{"volume", "create"}, labels...)
+	volumeArguments = append(volumeArguments, volume)
+	if _, err := c.qualificationDocker(ctx, nil, volumeArguments...); err != nil {
+		return evidence, fmt.Errorf("create isolated v0.1 state volume: %w", err)
+	}
+	volumeCreated = true
+	startedAt := c.now().UTC()
+	runOutput, err := c.qualificationDockerWithEnvironment(ctx, map[string]string{
+		"LIBREDASH_CSRF_KEY": csrfKey, "LIBREDASH_METRICS_BEARER_TOKEN": metricsToken,
+	},
+		"run", "--detach", "--name", name, "--hostname", "libredash-v010",
+		"--network", network, "--platform", compatibility.ReleasedV010Platform,
+		"--pull", "never", "--restart", "no", "--read-only",
+		"--security-opt", "no-new-privileges", "--cap-drop", "ALL", "--pids-limit", "512",
+		"--env", "LIBREDASH_LOCAL_AUTH=1",
+		"--env", "LIBREDASH_COOKIE_SECURE=1",
+		"--env", "LIBREDASH_ALLOWED_HOSTS=127.0.0.1,localhost",
+		"--env", "LIBREDASH_BOOTSTRAP_ADMIN_EMAIL="+v010AdminEmail,
+		"--env", "LIBREDASH_DATA_DIR="+v010QualificationMount+"/data",
+		"--env", "LIBREDASH_CSRF_KEY", "--env", "LIBREDASH_METRICS_BEARER_TOKEN",
+		"--mount", "type=volume,source="+volume+",target="+v010StateMount,
+		"--mount", "type=bind,source="+runDirectory+",target="+v010QualificationMount+",readonly",
+		"--tmpfs", "/tmp:rw,nosuid,nodev,mode=1777,size=64m",
+		labels[0], labels[1], labels[2], labels[3], evidence.Identity.Image,
+	)
+	if err != nil {
+		return evidence, fmt.Errorf("start isolated exact v0.1 artifact: %w", err)
+	}
+	containerCreated = true
+	containerID := strings.TrimSpace(string(runOutput))
+	running, err := c.inspectV010Container(ctx, name)
+	if err != nil {
+		return evidence, err
+	}
+	if err := validateV010ContainerInspect(running, containerID, name, network, volume, runDirectory, evidence, true); err != nil {
+		return evidence, err
+	}
+	journeyResult, err := c.runV010ApplicationJourney(ctx, name)
+	if err != nil {
+		return evidence, err
+	}
+	beforeInventory, beforeDigest, err := c.collectV010StateInventory(
+		ctx, name, containerID, journeyResult.token, evidence, journeyResult.evidence,
+	)
+	if err != nil {
+		return evidence, fmt.Errorf("collect v0.1 inventory before clean shutdown: %w", err)
+	}
+	observedBeforeShutdownAt := c.now().UTC()
+	if _, err := c.qualificationDocker(ctx, nil, "stop", "--time", "30", name); err != nil {
+		return evidence, fmt.Errorf("cleanly stop isolated v0.1 container: %w", err)
+	}
+	shutdownAt := c.now().UTC()
+	stopped, err := c.inspectV010Container(ctx, name)
+	if err != nil {
+		return evidence, err
+	}
+	if err := validateV010ContainerInspect(stopped, containerID, name, network, volume, runDirectory, evidence, false); err != nil {
+		return evidence, err
+	}
+	if _, err := c.qualificationDocker(ctx, nil, "start", name); err != nil {
+		return evidence, fmt.Errorf("restart preserved v0.1 container for stopped-state inspection: %w", err)
+	}
+	restartedAt := c.now().UTC()
+	restarted, err := c.inspectV010Container(ctx, name)
+	if err != nil {
+		return evidence, err
+	}
+	if err := validateV010ContainerInspect(restarted, containerID, name, network, volume, runDirectory, evidence, true); err != nil {
+		return evidence, fmt.Errorf("verify restarted v0.1 application identity: %w", err)
+	}
+	if err := c.waitV010Readiness(ctx, name); err != nil {
+		return evidence, fmt.Errorf("wait for preserved v0.1 state inspection: %w", err)
+	}
+	afterInventory, afterDigest, err := c.collectV010StateInventory(
+		ctx, name, containerID, journeyResult.token, evidence, journeyResult.evidence,
+	)
+	if err != nil {
+		return evidence, fmt.Errorf("collect v0.1 inventory after clean shutdown and restart: %w", err)
+	}
+	observedAfterRestartAt := c.now().UTC()
+	if beforeDigest != afterDigest || !reflect.DeepEqual(beforeInventory, afterInventory) {
+		return evidence, fmt.Errorf("v0.1 state inventory changed across clean shutdown and restart")
+	}
+	if _, err := c.qualificationDocker(ctx, nil, "stop", "--time", "30", name); err != nil {
+		return evidence, fmt.Errorf("cleanly stop inspected v0.1 container: %w", err)
+	}
+	stoppedAt := c.now().UTC()
+	stopped, err = c.inspectV010Container(ctx, name)
+	if err != nil {
+		return evidence, err
+	}
+	if err := validateV010ContainerInspect(stopped, containerID, name, network, volume, runDirectory, evidence, false); err != nil {
+		return evidence, err
+	}
+	freshCandidate, err := c.qualifyV010FreshCandidate(ctx, policyDocument, evidence, volume)
+	if err != nil {
+		return evidence, fmt.Errorf("qualify isolated fresh candidate and legacy-state denial: %w", err)
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), qualificationCleanupTimeout)
+	cleanupErr := cleanup(cleanupCtx)
+	cancel()
+	if cleanupErr != nil {
+		return evidence, fmt.Errorf("clean up isolated v0.1 execution resources: %w", cleanupErr)
+	}
+	if err := c.verifyV010Cleanup(ctx, name, network, volume, runDirectory); err != nil {
+		return evidence, err
+	}
+	cleanupComplete = true
+	evidence.Execution = &compatibility.V010ContainerExecution{
+		RunID: runID, ContainerID: containerID, ContainerName: name,
+		Image: evidence.Identity.Image, ImageID: evidence.Artifact.ConfigDigest,
+		Platform: compatibility.ReleasedV010Platform, NetworkName: network, StateVolumeName: volume,
+		StartedAt: startedAt, StoppedAt: stoppedAt, StartedState: "running", StoppedState: "exited",
+		CleanShutdown: true, CleanupVerified: true, Journey: &journeyResult.evidence,
+		Preservation: &compatibility.V010PreservationEvidence{
+			ObservedBeforeShutdownAt: observedBeforeShutdownAt, ShutdownAt: shutdownAt,
+			RestartedAt: restartedAt, ObservedAfterRestartAt: observedAfterRestartAt,
+			Inventory: beforeInventory, BeforeSHA256: beforeDigest, AfterSHA256: afterDigest,
+			RestartIdentityVerified: true, StatePreserved: true,
+		},
+		FreshCandidate: &freshCandidate,
+	}
+	if _, err := compatibility.MarshalV010ReleaseIdentityEvidence(evidence, policyDocument); err != nil {
+		return compatibility.V010ReleaseIdentityEvidence{}, err
+	}
+	return evidence, nil
+}
+
+func (c *Controller) verifyV010Cleanup(ctx context.Context, name, network, volume, runDirectory string) error {
+	checks := []struct {
+		resource  string
+		arguments []string
+	}{
+		{resource: "container", arguments: []string{"ps", "--all", "--quiet", "--filter", "name=^/" + name + "$"}},
+		{resource: "volume", arguments: []string{"volume", "ls", "--quiet", "--filter", "name=^" + volume + "$"}},
+		{resource: "network", arguments: []string{"network", "ls", "--quiet", "--filter", "name=^" + network + "$"}},
+	}
+	for _, check := range checks {
+		output, err := c.qualificationDocker(ctx, nil, check.arguments...)
+		if err != nil {
+			return fmt.Errorf("verify isolated v0.1 %s cleanup: %w", check.resource, err)
+		}
+		if strings.TrimSpace(string(output)) != "" {
+			return fmt.Errorf("isolated v0.1 %s still exists after cleanup", check.resource)
+		}
+	}
+	if _, err := os.Lstat(runDirectory); !os.IsNotExist(err) {
+		if err == nil {
+			return fmt.Errorf("isolated v0.1 run directory still exists after cleanup")
+		}
+		return fmt.Errorf("verify isolated v0.1 run directory cleanup: %w", err)
+	}
+	return nil
+}
+
+func (c *Controller) inspectV010Container(ctx context.Context, name string) (v010ContainerInspect, error) {
+	document, err := c.qualificationDocker(ctx, nil, "inspect", "--format", "{{json .}}", name)
+	if err != nil {
+		return v010ContainerInspect{}, fmt.Errorf("inspect isolated v0.1 container: %w", err)
+	}
+	var inspected v010ContainerInspect
+	if err := decodeV010RegistryDocument(document, &inspected); err != nil {
+		return v010ContainerInspect{}, fmt.Errorf("decode isolated v0.1 container inspection: %w", err)
+	}
+	return inspected, nil
+}
+
+func validateV010ContainerInspect(
+	inspected v010ContainerInspect,
+	containerID, name, network, volume, runDirectory string,
+	evidence compatibility.V010ReleaseIdentityEvidence,
+	running bool,
+) error {
+	wantedState := "exited"
+	if running {
+		wantedState = "running"
+	}
+	if inspected.ID != containerID || inspected.Name != "/"+name || inspected.Image != evidence.Artifact.ConfigDigest ||
+		inspected.Config.Image != evidence.Identity.Image || inspected.State.Running != running || inspected.State.Status != wantedState ||
+		inspected.HostConfig.NetworkMode != network {
+		return fmt.Errorf("isolated v0.1 container identity or lifecycle state does not match the verified artifact")
+	}
+	if len(inspected.NetworkSettings.Networks) != 1 {
+		return fmt.Errorf("isolated v0.1 container must have exactly one network")
+	}
+	if _, ok := inspected.NetworkSettings.Networks[network]; !ok {
+		return fmt.Errorf("isolated v0.1 container is not attached to its private network")
+	}
+	var stateMount, qualificationMount bool
+	for _, mount := range inspected.Mounts {
+		switch mount.Destination {
+		case v010StateMount:
+			stateMount = mount.Type == "volume" && mount.Name == volume && mount.RW
+		case v010QualificationMount:
+			qualificationMount = mount.Type == "bind" && mount.Source == runDirectory && !mount.RW
+		}
+	}
+	if !stateMount || !qualificationMount {
+		return fmt.Errorf("isolated v0.1 container does not use the dedicated state volume and read-only run directory")
+	}
+	return nil
+}

--- a/internal/app/cli/composectl/qualification_v010_runtime_test.go
+++ b/internal/app/cli/composectl/qualification_v010_runtime_test.go
@@ -668,6 +668,77 @@ func TestV010FreshCandidateDeniesLegacyStateWithoutMutation(t *testing.T) {
 	require.NotContains(t, candidateServerRunCommand(fixture.requests, fixture.candidateImage), evidence.Execution.StateVolumeName)
 }
 
+func TestV010FreshCandidateEveryRunUsesExplicitIsolationAndHardening(t *testing.T) {
+	fixture := newV010DockerFixture(t)
+	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+	controller, err := New(Options{
+		Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+	})
+	require.NoError(t, err)
+	evidence, err := controller.qualifyV010ArtifactExecution(t.Context(), v010CandidateBoundTestPolicy(t))
+	require.NoError(t, err)
+	require.NotNil(t, evidence.Execution)
+	require.NotNil(t, evidence.Execution.FreshCandidate)
+
+	fresh := evidence.Execution.FreshCandidate
+	var persistentRuns, initializationRuns, denialRuns, checksumRuns int
+	for _, arguments := range fixture.requests {
+		if len(arguments) == 0 || arguments[0] != "run" || !slices.Contains(arguments, fixture.candidateImage) {
+			continue
+		}
+		requireV010CandidateRunHardening(t, arguments, fixture.candidateImage)
+		network := v010CommandFlagValue(arguments, "--network")
+		switch {
+		case slices.Contains(arguments, "--detach"):
+			persistentRuns++
+			require.Equal(t, fresh.NetworkName, network)
+		case slices.Contains(arguments, "tar"):
+			checksumRuns++
+			require.Equal(t, "none", network)
+		case strings.Contains(strings.Join(arguments, " "), " admin initialize --format json"):
+			mount := v010CommandFlagValue(arguments, "--mount")
+			if strings.Contains(mount, "source="+fresh.StateVolumeName+",") {
+				initializationRuns++
+				require.Equal(t, fresh.NetworkName, network)
+			} else {
+				denialRuns++
+				require.Equal(t, "none", network)
+				require.Contains(t, mount, "source="+evidence.Execution.StateVolumeName+",")
+			}
+		default:
+			t.Fatalf("unclassified candidate-image helper run: %v", arguments)
+		}
+	}
+	require.Equal(t, 1, persistentRuns)
+	require.Equal(t, 1, initializationRuns)
+	require.Equal(t, 2, denialRuns)
+	require.NotZero(t, checksumRuns)
+}
+
+func requireV010CandidateRunHardening(t *testing.T, arguments []string, image string) {
+	t.Helper()
+	require.NotEmpty(t, v010CommandFlagValue(arguments, "--network"), "candidate run used Docker's default network: %v", arguments)
+	require.Equal(t, compatibility.ReleasedV010Platform, v010CommandFlagValue(arguments, "--platform"))
+	require.Equal(t, "never", v010CommandFlagValue(arguments, "--pull"))
+	require.Contains(t, arguments, "--read-only")
+	require.Equal(t, "no-new-privileges", v010CommandFlagValue(arguments, "--security-opt"))
+	require.Equal(t, "ALL", v010CommandFlagValue(arguments, "--cap-drop"))
+	require.NotEmpty(t, v010CommandFlagValue(arguments, "--pids-limit"))
+	require.NotContains(t, arguments, "--publish")
+	require.NotContains(t, arguments, "-p")
+	require.NotContains(t, arguments, "-P")
+	require.Contains(t, image, "@sha256:")
+}
+
+func v010CommandFlagValue(arguments []string, flag string) string {
+	for index, argument := range arguments {
+		if argument == flag && index+1 < len(arguments) {
+			return arguments[index+1]
+		}
+	}
+	return ""
+}
+
 func TestV010FreshCandidateFailsClosedOnLegacyVisibilityOrMutation(t *testing.T) {
 	for _, test := range []struct {
 		name   string

--- a/internal/app/cli/composectl/qualification_v010_runtime_test.go
+++ b/internal/app/cli/composectl/qualification_v010_runtime_test.go
@@ -51,6 +51,12 @@ type v010DockerFixture struct {
 	candidateStopped         bool
 	candidateInitialized     bool
 	candidateLegacyVisible   bool
+	candidateLegacyProject   bool
+	candidateLegacyManaged   bool
+	candidateLegacyEnv       bool
+	candidateProjectObserved bool
+	candidateManagedObserved bool
+	candidateEnvObserved     bool
 	candidateDenialMutates   bool
 	candidateDenialAttempted bool
 }
@@ -258,6 +264,25 @@ func (fixture *v010DockerFixture) executeCandidateCLI(arguments []string) ([]byt
 		}
 		return []byte(`{"items":[],"page":{}}`), nil
 	case strings.Contains(joined, "listSemanticModels"):
+		return []byte(`{"items":[],"page":{}}`), nil
+	case strings.Contains(joined, "getInstance"):
+		fixture.candidateEnvObserved = true
+		environment := "fai-517-candidate"
+		if fixture.candidateLegacyEnv {
+			environment = v010Environment
+		}
+		return json.Marshal(map[string]string{"id": "candidate-instance", "environment": environment})
+	case strings.Contains(joined, "listDeployments"):
+		fixture.candidateProjectObserved = true
+		if fixture.candidateLegacyProject {
+			return []byte(`{"items":[],"page":{}}`), nil
+		}
+		return nil, errors.New(`GET /api/v1/projects/compatibility/deployments: {"status":403,"code":"FORBIDDEN"}`)
+	case strings.Contains(joined, "listManagedConnections"):
+		fixture.candidateManagedObserved = true
+		if fixture.candidateLegacyManaged {
+			return []byte(`{"items":[{"id":"qualification","projectId":"compatibility","title":"Qualification"}],"page":{}}`), nil
+		}
 		return []byte(`{"items":[],"page":{}}`), nil
 	default:
 		return nil, fmt.Errorf("unexpected candidate CLI command %v", arguments)
@@ -566,6 +591,22 @@ func TestDockerV010ArtifactResolverFailsClosed(t *testing.T) {
 	}
 }
 
+func TestDockerV010ArtifactResolverRequiresAuthenticationRestoredAfterLogout(t *testing.T) {
+	credentials := writeV010DockerCredentials(t)
+	resolver := newDockerV010ArtifactResolver(t.TempDir(), "docker-probe", nil)
+	resolver.configPath = credentials
+	require.NoError(t, resolver.requireRegistryCredentials())
+
+	require.NoError(t, os.WriteFile(credentials, []byte(`{"auths":{}}`), 0o600))
+	require.ErrorContains(t, resolver.requireRegistryCredentials(), "not configured")
+
+	restored := writeV010DockerCredentials(t)
+	document, err := os.ReadFile(restored)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(credentials, document, 0o600))
+	require.NoError(t, resolver.requireRegistryCredentials())
+}
+
 func TestV010ArtifactExecutionUsesIsolatedIdentityAndCleansUp(t *testing.T) {
 	fixture := newV010DockerFixture(t)
 	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
@@ -746,6 +787,9 @@ func TestV010FreshCandidateFailsClosedOnLegacyVisibilityOrMutation(t *testing.T)
 		want   string
 	}{
 		{name: "legacy state visible", mutate: func(f *v010DockerFixture) { f.candidateLegacyVisible = true }, want: "exposed preserved v0.1"},
+		{name: "legacy project visible", mutate: func(f *v010DockerFixture) { f.candidateLegacyProject = true }, want: "exposed preserved v0.1"},
+		{name: "legacy environment visible", mutate: func(f *v010DockerFixture) { f.candidateLegacyEnv = true }, want: "exposed preserved v0.1"},
+		{name: "legacy managed data visible", mutate: func(f *v010DockerFixture) { f.candidateLegacyManaged = true }, want: "exposed preserved v0.1"},
 		{name: "denial mutates state", mutate: func(f *v010DockerFixture) { f.candidateDenialMutates = true }, want: "changed preserved predecessor state"},
 		{name: "candidate identity mismatch", mutate: func(f *v010DockerFixture) { f.candidateRevision = strings.Repeat("0", 40) }, want: "does not match the admitted policy artifact"},
 	} {
@@ -761,6 +805,22 @@ func TestV010FreshCandidateFailsClosedOnLegacyVisibilityOrMutation(t *testing.T)
 			require.ErrorContains(t, err, test.want)
 		})
 	}
+}
+
+func TestV010FreshCandidateRecordsObservedLegacyProjectAndManagedDataAbsence(t *testing.T) {
+	fixture := newV010DockerFixture(t)
+	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+	controller, err := New(Options{
+		Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+	})
+	require.NoError(t, err)
+	evidence, err := controller.qualifyV010ArtifactExecution(t.Context(), v010CandidateBoundTestPolicy(t))
+	require.NoError(t, err)
+	require.True(t, fixture.candidateEnvObserved)
+	require.True(t, fixture.candidateProjectObserved)
+	require.True(t, fixture.candidateManagedObserved)
+	require.False(t, evidence.Execution.FreshCandidate.CandidateInventory.LegacyProjectVisible)
+	require.False(t, evidence.Execution.FreshCandidate.CandidateInventory.LegacyManagedDataVisible)
 }
 
 func candidateServerRunCommand(requests [][]string, image string) string {

--- a/internal/app/cli/composectl/qualification_v010_runtime_test.go
+++ b/internal/app/cli/composectl/qualification_v010_runtime_test.go
@@ -1,0 +1,856 @@
+package composectl
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/platform/compatibility"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	v010TestContainerID          = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	v010CandidateTestContainerID = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	v010CandidateTestImageID     = "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+)
+
+type v010DockerFixture struct {
+	t                        *testing.T
+	index                    []byte
+	manifest                 []byte
+	requests                 [][]string
+	stopped                  bool
+	imageOS                  string
+	imageArch                string
+	inspectMutate            func(*v010ContainerInspect)
+	rootError                error
+	readinessError           bool
+	bootstrapError           bool
+	authenticationError      bool
+	workloadMismatch         bool
+	projectVerified          bool
+	restarted                bool
+	missingPrincipal         bool
+	alteredProject           bool
+	alteredManagedData       bool
+	missingPublish           bool
+	candidateImage           string
+	candidateVersion         string
+	candidateRevision        string
+	candidateStopped         bool
+	candidateInitialized     bool
+	candidateLegacyVisible   bool
+	candidateDenialMutates   bool
+	candidateDenialAttempted bool
+}
+
+func newV010DockerFixture(t *testing.T) *v010DockerFixture {
+	t.Helper()
+	policy, err := compatibility.ParsePolicy(v010CandidateBoundTestPolicy(t))
+	require.NoError(t, err)
+	candidate, ok := policy.ReleaseByID(policy.CandidateRelease)
+	require.True(t, ok)
+	identity := candidate.IdentityForPlatform(compatibility.ReleasedV010Platform)
+	return &v010DockerFixture{
+		t:                 t,
+		index:             readExactV010RegistryFixture(t, "testdata/v010-oci-index.json"),
+		manifest:          readExactV010RegistryFixture(t, "testdata/v010-oci-manifest.json"),
+		imageOS:           "linux",
+		imageArch:         "amd64",
+		candidateImage:    identity.Image,
+		candidateVersion:  identity.Version,
+		candidateRevision: identity.SourceRevision,
+	}
+}
+
+func v010CandidateBoundTestPolicy(t *testing.T) []byte {
+	t.Helper()
+	base, err := compatibility.EmbeddedPolicy()
+	require.NoError(t, err)
+	bound, err := base.BindCandidate(compatibility.ReleaseIdentity{
+		Version: "0.2.0-rc.2", SourceRevision: strings.Repeat("4", 40),
+		Image: "ghcr.io/flidai/leapview@sha256:" + strings.Repeat("4", 64), Distribution: "public",
+	}, []string{"linux/amd64", "linux/arm64"})
+	require.NoError(t, err)
+	document, err := compatibility.MarshalPolicy(bound)
+	require.NoError(t, err)
+	return document
+}
+
+func (fixture *v010DockerFixture) execute(_ context.Context, request qualificationCommandRequest) ([]byte, error) {
+	arguments := append([]string(nil), request.Arguments...)
+	fixture.requests = append(fixture.requests, arguments)
+	switch {
+	case slices.Equal(arguments, []string{"buildx", "imagetools", "inspect", "--raw", compatibility.ReleasedV010Image}):
+		if fixture.rootError != nil {
+			return nil, fixture.rootError
+		}
+		return append([]byte(nil), fixture.index...), nil
+	case slices.Equal(arguments, []string{"buildx", "imagetools", "inspect", "--raw", compatibility.ReleasedV010Repository + "@" + compatibility.ReleasedV010PlatformManifest}):
+		return append([]byte(nil), fixture.manifest...), nil
+	case slices.Equal(arguments, []string{"pull", "--platform", compatibility.ReleasedV010Platform, compatibility.ReleasedV010Image}):
+		return []byte("pulled exact digest\n"), nil
+	case slices.Equal(arguments, []string{"image", "inspect", "--format", "{{json .}}", compatibility.ReleasedV010Image}):
+		return json.Marshal(map[string]any{
+			"Id": compatibility.ReleasedV010ConfigDigest, "RepoDigests": []string{compatibility.ReleasedV010Image},
+			"Architecture": fixture.imageArch, "Os": fixture.imageOS,
+			"Config": map[string]any{"Labels": map[string]string{
+				"org.opencontainers.image.source":   compatibility.ReleasedV010SourceRepository,
+				"org.opencontainers.image.version":  "0.1.0",
+				"org.opencontainers.image.revision": "5bf4aded574df459e80d81b77d1989ecd4fa7de0",
+			}},
+		})
+	case slices.Equal(arguments, []string{"pull", "--platform", compatibility.ReleasedV010Platform, fixture.candidateImage}):
+		return []byte("pulled admitted candidate\n"), nil
+	case slices.Equal(arguments, []string{"image", "inspect", "--format", "{{json .}}", fixture.candidateImage}):
+		return json.Marshal(map[string]any{
+			"Id": v010CandidateTestImageID, "RepoDigests": []string{fixture.candidateImage},
+			"Architecture": "amd64", "Os": "linux",
+			"Config": map[string]any{"Labels": map[string]string{
+				"org.opencontainers.image.version":  fixture.candidateVersion,
+				"org.opencontainers.image.revision": fixture.candidateRevision,
+			}},
+		})
+	case len(arguments) > 0 && arguments[0] == "run" && slices.Contains(arguments, fixture.candidateImage):
+		return fixture.executeCandidateRun(arguments)
+	case len(arguments) > 0 && arguments[0] == "exec" && slices.Contains(arguments, "leapview"):
+		return fixture.executeCandidateCLI(arguments)
+	case len(arguments) > 0 && arguments[0] == "run":
+		if err := fixture.verifyV010Project(); err != nil {
+			return nil, err
+		}
+		return []byte(v010TestContainerID + "\n"), nil
+	case len(arguments) > 0 && arguments[0] == "exec":
+		return fixture.executeV010CLI(arguments)
+	case len(arguments) > 0 && arguments[0] == "logs":
+		return []byte("bounded v0.1 server diagnostics\n"), nil
+	case len(arguments) > 0 && arguments[0] == "inspect":
+		name := arguments[len(arguments)-1]
+		if strings.HasPrefix(name, "leapview-v010-candidate-") {
+			return fixture.candidateContainerInspect(name)
+		}
+		return fixture.containerInspect(name)
+	case len(arguments) > 0 && arguments[0] == "stop":
+		if strings.HasPrefix(arguments[len(arguments)-1], "leapview-v010-candidate-") {
+			fixture.candidateStopped = true
+			return []byte(arguments[len(arguments)-1] + "\n"), nil
+		}
+		fixture.stopped = true
+		return []byte(arguments[len(arguments)-1] + "\n"), nil
+	case len(arguments) > 0 && arguments[0] == "start":
+		fixture.stopped = false
+		fixture.restarted = true
+		return []byte(arguments[len(arguments)-1] + "\n"), nil
+	case len(arguments) > 0 && (arguments[0] == "ps" ||
+		(len(arguments) > 1 && arguments[1] == "ls")):
+		return nil, nil
+	default:
+		return []byte("ok\n"), nil
+	}
+}
+
+func (fixture *v010DockerFixture) verifyV010Project() error {
+	root := fixture.runDirectory()
+	files := []struct {
+		path string
+		want string
+	}{
+		{path: "libredash.yaml", want: "kind: Project"},
+		{path: "data/orders.csv", want: "o-003,delivered"},
+		{path: "workspaces/compatibility/dashboards/preservation.yaml", want: "name: preservation"},
+	}
+	for _, file := range files {
+		path := filepath.Join(root, filepath.FromSlash(file.path))
+		document, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(document), file.want) {
+			return fmt.Errorf("v0.1 project fixture %s omitted %q", file.path, file.want)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if info.Mode().Perm()&0o044 == 0 {
+			return fmt.Errorf("v0.1 project fixture %s is unreadable by the released image", file.path)
+		}
+	}
+	fixture.projectVerified = true
+	return nil
+}
+
+func (fixture *v010DockerFixture) executeCandidateRun(arguments []string) ([]byte, error) {
+	joined := strings.Join(arguments, " ")
+	isCandidateVolume := strings.Contains(joined, "source=leapview-v010-candidate-")
+	isPredecessorVolume := strings.Contains(joined, "source=leapview-v010-") && !isCandidateVolume
+	if slices.Contains(arguments, "tar") {
+		switch {
+		case isCandidateVolume && fixture.candidateInitialized:
+			if fixture.candidateDenialMutates && fixture.candidateDenialAttempted {
+				return v010TestStateArchive(fixture.t, "candidate-state-mutated-by-denial"), nil
+			}
+			return v010TestStateArchive(fixture.t, "candidate-initialized-state"), nil
+		case isCandidateVolume:
+			return v010TestStateArchive(fixture.t, ""), nil
+		case isPredecessorVolume:
+			if fixture.candidateDenialMutates && fixture.candidateDenialAttempted {
+				return v010TestStateArchive(fixture.t, "predecessor-state-mutated-by-denial"), nil
+			}
+			return v010TestStateArchive(fixture.t, "preserved-v010-state"), nil
+		default:
+			return nil, errors.New("unknown qualification volume")
+		}
+	}
+	if strings.Contains(joined, " admin initialize --format json") {
+		if isPredecessorVolume {
+			fixture.candidateDenialAttempted = true
+			return []byte(compatibility.ErrV010FreshInstallOnly.Error()), compatibility.ErrV010FreshInstallOnly
+		}
+		fixture.candidateInitialized = true
+		return []byte(`{"email":"fai-517-candidate@qualification.invalid","temporaryPassword":"transient","publisherToken":"candidate-publisher-token","publisherTokenExpiresAt":"2026-07-14T15:45:00Z"}`), nil
+	}
+	if slices.Contains(arguments, "--detach") {
+		return []byte(v010CandidateTestContainerID + "\n"), nil
+	}
+	return nil, fmt.Errorf("unexpected candidate run %v", arguments)
+}
+
+func v010TestStateArchive(t *testing.T, contents string) []byte {
+	t.Helper()
+	var document bytes.Buffer
+	writer := tar.NewWriter(&document)
+	if contents != "" {
+		require.NoError(t, writer.WriteHeader(&tar.Header{
+			Name: "state", Mode: 0o600, Size: int64(len(contents)), Typeflag: tar.TypeReg,
+		}))
+		_, err := writer.Write([]byte(contents))
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+	return document.Bytes()
+}
+
+func (fixture *v010DockerFixture) executeCandidateCLI(arguments []string) ([]byte, error) {
+	joined := strings.Join(arguments, " ")
+	switch {
+	case strings.Contains(joined, "listPrincipals") && strings.Contains(joined, v010CandidateAdminEmail):
+		return []byte(`{"items":[{"id":"candidate_admin","email":"fai-517-candidate@qualification.invalid"}],"page":{}}`), nil
+	case strings.Contains(joined, "listPrincipals"):
+		if fixture.candidateLegacyVisible {
+			return []byte(`{"items":[{"id":"legacy_principal","email":"fai-517-user@qualification.invalid"}],"page":{}}`), nil
+		}
+		return []byte(`{"items":[],"page":{}}`), nil
+	case strings.Contains(joined, "listDashboards"):
+		if fixture.candidateLegacyVisible {
+			return []byte(`{"items":[{"id":"preservation"}],"page":{}}`), nil
+		}
+		return []byte(`{"items":[],"page":{}}`), nil
+	case strings.Contains(joined, "listSemanticModels"):
+		return []byte(`{"items":[],"page":{}}`), nil
+	default:
+		return nil, fmt.Errorf("unexpected candidate CLI command %v", arguments)
+	}
+}
+
+func (fixture *v010DockerFixture) candidateContainerInspect(name string) ([]byte, error) {
+	network := name + "-network"
+	volume := name + "-state"
+	status := "running"
+	running := true
+	if fixture.candidateStopped {
+		status = "exited"
+		running = false
+	}
+	return json.Marshal(map[string]any{
+		"Id": v010CandidateTestContainerID, "Name": "/" + name, "Image": v010CandidateTestImageID,
+		"State":      map[string]any{"Status": status, "Running": running},
+		"Config":     map[string]any{"Image": fixture.candidateImage},
+		"HostConfig": map[string]any{"NetworkMode": network},
+		"Mounts": []map[string]any{
+			{"Type": "volume", "Name": volume, "Source": "/var/lib/docker/volumes/" + volume, "Destination": v010CandidateStateMount, "RW": true},
+			{"Type": "bind", "Source": fixture.candidateRunDirectory(), "Destination": v010CandidateRunMount, "RW": false},
+		},
+		"NetworkSettings": map[string]any{"Networks": map[string]any{network: map[string]any{}}},
+	})
+}
+
+func (fixture *v010DockerFixture) candidateRunDirectory() string {
+	for _, arguments := range fixture.requests {
+		for _, argument := range arguments {
+			if !strings.Contains(argument, ".v010-candidate-run-") || !strings.Contains(argument, "source=") {
+				continue
+			}
+			for _, part := range strings.Split(argument, ",") {
+				if strings.HasPrefix(part, "source=") {
+					return strings.TrimPrefix(part, "source=")
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func (fixture *v010DockerFixture) executeV010CLI(arguments []string) ([]byte, error) {
+	binary := slices.Index(arguments, "libredash")
+	if binary < 0 || binary+1 >= len(arguments) {
+		return nil, errors.New("missing v0.1 CLI")
+	}
+	command := arguments[binary+1:]
+	switch {
+	case slices.Equal(command, []string{"healthcheck", "--timeout", "5s"}):
+		if fixture.readinessError {
+			return nil, errors.New("connection refused")
+		}
+		return []byte("ready\n"), nil
+	case slices.Equal(command, []string{"admin", "bootstrap"}):
+		if fixture.bootstrapError {
+			return nil, errors.New("bootstrap failed")
+		}
+		return []byte("ld_test_bootstrap_token\n"), nil
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "getCurrentPrincipal"}):
+		if fixture.authenticationError {
+			return nil, errors.New("unauthorized")
+		}
+		return []byte(`{"id":"principal_admin","email":"fai-517-admin@qualification.invalid"}`), nil
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "createPrincipal"}):
+		return []byte(`{"principal":{"id":"principal_user","email":"fai-517-user@qualification.invalid"},"temporaryPassword":"temporary-secret"}`), nil
+	case len(command) > 0 && command[0] == "publish":
+		return []byte("published compatibility publish=publish_001 environment=fai-517 digest=" + strings.Repeat("a", 64) + " localDigest=" + strings.Repeat("b", 64) + " status=active\n"), nil
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "listDashboards"}):
+		return []byte(`{"items":[{"id":"preservation"}],"page":{}}`), nil
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "querySemanticDataset"}):
+		if fixture.workloadMismatch {
+			return []byte(`{"items":[{"status":"delivered","order_count":1},{"status":"shipped","order_count":1}]}`), nil
+		}
+		return []byte(`{"items":[{"status":"delivered","order_count":2},{"status":"shipped","order_count":1}]}`), nil
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "queryDashboardVisualData"}):
+		return []byte(`{"data":[{"label":"Orders","series":"","value":3}]}`), nil
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "listPrincipals"}):
+		joined := strings.Join(command, " ")
+		if strings.Contains(joined, v010AdminEmail) {
+			return []byte(`{"items":[{"id":"principal_admin","kind":"user","email":"fai-517-admin@qualification.invalid","displayName":"fai-517-admin@qualification.invalid"}],"page":{}}`), nil
+		}
+		if fixture.restarted && fixture.missingPrincipal {
+			return []byte(`{"items":[],"page":{}}`), nil
+		}
+		return []byte(`{"items":[{"id":"principal_user","kind":"user","email":"fai-517-user@qualification.invalid","displayName":"FAI-517 User"}],"page":{}}`), nil
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "listWorkspaces"}):
+		title := "FAI-517 Compatibility"
+		if fixture.restarted && fixture.alteredProject {
+			title = "Changed Project"
+		}
+		return json.Marshal(map[string]any{"items": []map[string]any{{
+			"id": "compatibility", "title": title, "activeServingStateId": "serving_001",
+		}}, "page": map[string]any{}})
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "listPublishes"}):
+		if fixture.restarted && fixture.missingPublish {
+			return []byte(`{"items":[],"page":{}}`), nil
+		}
+		return json.Marshal(map[string]any{"items": []map[string]any{{
+			"id": "publish_001", "workspaceId": "compatibility", "environment": "fai-517",
+			"status": "active", "digest": strings.Repeat("a", 64),
+		}}, "page": map[string]any{}})
+	case len(command) >= 3 && slices.Equal(command[:3], []string{"api", "call", "getWorkspaceActiveAssetGraph"}):
+		sourceHash := strings.Repeat("c", 64)
+		if fixture.restarted && fixture.alteredManagedData {
+			sourceHash = strings.Repeat("0", 64)
+		}
+		return json.Marshal(map[string]any{"assets": []map[string]any{
+			{"id": "source:qualification.orders", "type": "source", "key": "qualification.orders", "servingStateId": "serving_001", "contentHash": sourceHash},
+			{"id": "model_table:compatibility.orders", "type": "model_table", "key": "compatibility.orders", "servingStateId": "serving_001", "contentHash": strings.Repeat("d", 64)},
+			{"id": "semantic_model:compatibility.compatibility", "type": "semantic_model", "key": "compatibility.compatibility", "servingStateId": "serving_001", "contentHash": strings.Repeat("e", 64)},
+			{"id": "dashboard:compatibility.preservation", "type": "dashboard", "key": "compatibility.preservation", "servingStateId": "serving_001", "contentHash": strings.Repeat("f", 64)},
+		}})
+	default:
+		return nil, fmt.Errorf("unexpected v0.1 CLI command %v", command)
+	}
+}
+
+func (fixture *v010DockerFixture) containerInspect(name string) ([]byte, error) {
+	network := name + "-network"
+	volume := name + "-state"
+	runDirectory := fixture.runDirectory()
+	status := "running"
+	running := true
+	if fixture.stopped {
+		status = "exited"
+		running = false
+	}
+	var inspected v010ContainerInspect
+	inspected.ID = v010TestContainerID
+	inspected.Name = "/" + name
+	inspected.Image = compatibility.ReleasedV010ConfigDigest
+	inspected.State.Status = status
+	inspected.State.Running = running
+	inspected.Config.Image = compatibility.ReleasedV010Image
+	inspected.HostConfig.NetworkMode = network
+	inspected.NetworkSettings.Networks = map[string]json.RawMessage{network: json.RawMessage(`{}`)}
+	inspected.Mounts = append(inspected.Mounts,
+		struct {
+			Type        string `json:"Type"`
+			Name        string `json:"Name"`
+			Source      string `json:"Source"`
+			Destination string `json:"Destination"`
+			RW          bool   `json:"RW"`
+		}{Type: "volume", Name: volume, Destination: v010StateMount, RW: true},
+		struct {
+			Type        string `json:"Type"`
+			Name        string `json:"Name"`
+			Source      string `json:"Source"`
+			Destination string `json:"Destination"`
+			RW          bool   `json:"RW"`
+		}{Type: "bind", Source: runDirectory, Destination: v010QualificationMount, RW: false},
+	)
+	if fixture.inspectMutate != nil {
+		fixture.inspectMutate(&inspected)
+	}
+	return json.Marshal(inspected)
+}
+
+func (fixture *v010DockerFixture) runDirectory() string {
+	fixture.t.Helper()
+	for _, arguments := range fixture.requests {
+		if len(arguments) == 0 || arguments[0] != "run" {
+			continue
+		}
+		for index, argument := range arguments {
+			if argument != "--mount" || index+1 >= len(arguments) {
+				continue
+			}
+			value := arguments[index+1]
+			if strings.Contains(value, "target="+v010QualificationMount) {
+				for _, field := range strings.Split(value, ",") {
+					if source, ok := strings.CutPrefix(field, "source="); ok {
+						return source
+					}
+				}
+			}
+		}
+	}
+	fixture.t.Fatal("v0.1 run directory was not mounted")
+	return ""
+}
+
+func readExactV010RegistryFixture(t *testing.T, path string) []byte {
+	t.Helper()
+	document, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return bytes.TrimSuffix(document, []byte("\n"))
+}
+
+func writeV010DockerCredentials(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	path := filepath.Join(root, "config.json")
+	auth := base64.StdEncoding.EncodeToString([]byte("test:token"))
+	document, err := json.Marshal(map[string]any{"auths": map[string]any{"ghcr.io": map[string]string{"auth": auth}}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, document, 0o600))
+	return path
+}
+
+func TestDockerV010ArtifactResolverUsesAuthenticatedExactRegistryGraph(t *testing.T) {
+	fixture := newV010DockerFixture(t)
+	resolver := newDockerV010ArtifactResolver(t.TempDir(), "docker-probe", qualificationExecutorFunc(fixture.execute))
+	resolver.configPath = writeV010DockerCredentials(t)
+	resolved, err := resolver.ResolveExact(t.Context(), compatibility.V010ArtifactResolutionRequest{
+		Image: compatibility.ReleasedV010Image, Platform: compatibility.ReleasedV010Platform, RequireAuthentication: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, compatibility.ReleasedV010Image, resolved.Image)
+	require.Equal(t, compatibility.ReleasedV010PlatformManifest, resolved.PlatformManifestDigest)
+	require.Equal(t, compatibility.ReleasedV010ConfigDigest, resolved.ConfigDigest)
+	require.True(t, resolved.Authenticated)
+
+	for _, arguments := range fixture.requests {
+		joined := strings.Join(arguments, " ")
+		require.NotContains(t, joined, ":latest")
+		require.NotContains(t, joined, "ghcr.io/flidai/libredash")
+		if strings.Contains(joined, "ghcr.io/") {
+			require.Contains(t, joined, "ghcr.io/yacobolo/libredash@sha256:")
+		}
+	}
+}
+
+func TestDockerV010ArtifactResolverFailsClosed(t *testing.T) {
+	t.Run("authentication missing", func(t *testing.T) {
+		called := false
+		resolver := newDockerV010ArtifactResolver(t.TempDir(), "docker-probe", qualificationExecutorFunc(func(context.Context, qualificationCommandRequest) ([]byte, error) {
+			called = true
+			return nil, nil
+		}))
+		resolver.configPath = filepath.Join(t.TempDir(), "missing-config.json")
+		_, err := resolver.ResolveExact(t.Context(), compatibility.V010ArtifactResolutionRequest{
+			Image: compatibility.ReleasedV010Image, Platform: compatibility.ReleasedV010Platform, RequireAuthentication: true,
+		})
+		require.ErrorContains(t, err, "authenticated registry credentials are required")
+		require.False(t, called)
+	})
+
+	t.Run("artifact unavailable", func(t *testing.T) {
+		fixture := newV010DockerFixture(t)
+		fixture.rootError = errors.New("manifest unknown")
+		resolver := newDockerV010ArtifactResolver(t.TempDir(), "docker-probe", qualificationExecutorFunc(fixture.execute))
+		resolver.configPath = writeV010DockerCredentials(t)
+		_, err := resolver.ResolveExact(t.Context(), compatibility.V010ArtifactResolutionRequest{
+			Image: compatibility.ReleasedV010Image, Platform: compatibility.ReleasedV010Platform, RequireAuthentication: true,
+		})
+		require.ErrorContains(t, err, "manifest unknown")
+	})
+
+	t.Run("registry authentication rejected", func(t *testing.T) {
+		fixture := newV010DockerFixture(t)
+		fixture.rootError = errors.New("unauthorized: authentication required")
+		resolver := newDockerV010ArtifactResolver(t.TempDir(), "docker-probe", qualificationExecutorFunc(fixture.execute))
+		resolver.configPath = writeV010DockerCredentials(t)
+		_, err := resolver.ResolveExact(t.Context(), compatibility.V010ArtifactResolutionRequest{
+			Image: compatibility.ReleasedV010Image, Platform: compatibility.ReleasedV010Platform, RequireAuthentication: true,
+		})
+		require.ErrorContains(t, err, "unauthorized: authentication required")
+	})
+
+	t.Run("digest mismatch", func(t *testing.T) {
+		fixture := newV010DockerFixture(t)
+		fixture.index = append(fixture.index, ' ')
+		resolver := newDockerV010ArtifactResolver(t.TempDir(), "docker-probe", qualificationExecutorFunc(fixture.execute))
+		resolver.configPath = writeV010DockerCredentials(t)
+		_, err := resolver.ResolveExact(t.Context(), compatibility.V010ArtifactResolutionRequest{
+			Image: compatibility.ReleasedV010Image, Platform: compatibility.ReleasedV010Platform, RequireAuthentication: true,
+		})
+		require.ErrorContains(t, err, "policy-selected immutable digest")
+	})
+
+	t.Run("pulled image has wrong platform", func(t *testing.T) {
+		fixture := newV010DockerFixture(t)
+		fixture.imageArch = "arm64"
+		resolver := newDockerV010ArtifactResolver(t.TempDir(), "docker-probe", qualificationExecutorFunc(fixture.execute))
+		resolver.configPath = writeV010DockerCredentials(t)
+		_, err := resolver.ResolveExact(t.Context(), compatibility.V010ArtifactResolutionRequest{
+			Image: compatibility.ReleasedV010Image, Platform: compatibility.ReleasedV010Platform, RequireAuthentication: true,
+		})
+		require.ErrorContains(t, err, "local v0.1 image identity")
+	})
+
+	for _, test := range []struct {
+		name    string
+		request compatibility.V010ArtifactResolutionRequest
+	}{
+		{name: "wrong platform", request: compatibility.V010ArtifactResolutionRequest{Image: compatibility.ReleasedV010Image, Platform: "linux/arm64", RequireAuthentication: true}},
+		{name: "tag fallback", request: compatibility.V010ArtifactResolutionRequest{Image: "ghcr.io/yacobolo/libredash:v0.1.0", Platform: compatibility.ReleasedV010Platform, RequireAuthentication: true}},
+		{name: "namespace override", request: compatibility.V010ArtifactResolutionRequest{Image: "ghcr.io/flidai/libredash@sha256:" + strings.Repeat("6", 64), Platform: compatibility.ReleasedV010Platform, RequireAuthentication: true}},
+		{name: "unauthenticated request", request: compatibility.V010ArtifactResolutionRequest{Image: compatibility.ReleasedV010Image, Platform: compatibility.ReleasedV010Platform}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			resolver := newDockerV010ArtifactResolver(t.TempDir(), "docker-probe", qualificationExecutorFunc(func(context.Context, qualificationCommandRequest) ([]byte, error) {
+				called = true
+				return nil, nil
+			}))
+			resolver.configPath = writeV010DockerCredentials(t)
+			_, err := resolver.ResolveExact(t.Context(), test.request)
+			require.ErrorContains(t, err, "only the authenticated exact policy-selected")
+			require.False(t, called)
+		})
+	}
+}
+
+func TestV010ArtifactExecutionUsesIsolatedIdentityAndCleansUp(t *testing.T) {
+	fixture := newV010DockerFixture(t)
+	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+	now := time.Date(2026, time.July, 13, 15, 45, 27, 0, time.UTC)
+	controller, err := New(Options{
+		Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+		Now: func() time.Time { now = now.Add(time.Second); return now },
+	})
+	require.NoError(t, err)
+	policyDocument := v010CandidateBoundTestPolicy(t)
+	evidence, err := controller.qualifyV010ArtifactExecution(t.Context(), policyDocument)
+	require.NoError(t, err)
+	require.NotNil(t, evidence.Execution)
+	require.Equal(t, v010TestContainerID, evidence.Execution.ContainerID)
+	require.True(t, evidence.Execution.CleanShutdown)
+	require.True(t, evidence.Execution.CleanupVerified)
+	require.NotNil(t, evidence.Execution.Journey)
+	require.True(t, evidence.Execution.Journey.AuthenticationVerified)
+	require.True(t, evidence.Execution.Journey.ProjectActivated)
+	require.True(t, evidence.Execution.Journey.ManagedDataVerified)
+	require.True(t, evidence.Execution.Journey.WorkloadVerified)
+	require.Equal(t, 3, evidence.Execution.Journey.ManagedDataRows)
+	require.NotNil(t, evidence.Execution.Preservation)
+	require.True(t, evidence.Execution.Preservation.StatePreserved)
+	require.True(t, evidence.Execution.Preservation.RestartIdentityVerified)
+	require.Equal(t, evidence.Execution.Preservation.BeforeSHA256, evidence.Execution.Preservation.AfterSHA256)
+	require.Len(t, evidence.Execution.Preservation.Inventory.Principals, 2)
+	require.Len(t, evidence.Execution.Preservation.Inventory.Assets, 4)
+	require.NotNil(t, evidence.Execution.FreshCandidate)
+	require.True(t, evidence.Execution.FreshCandidate.CleanStateVerified)
+	require.True(t, evidence.Execution.FreshCandidate.LegacyStateUnavailable)
+	require.True(t, evidence.Execution.FreshCandidate.MutationFree)
+	require.True(t, evidence.Execution.FreshCandidate.CleanupVerified)
+	require.Equal(t, fixture.candidateImage, evidence.Execution.FreshCandidate.Candidate.Image)
+	require.Equal(t, compatibility.ReasonAllowedFreshInstall, evidence.Execution.FreshCandidate.FreshInstallDecision.ReasonCode)
+	require.NotEqual(t, evidence.Execution.FreshCandidate.FreshStateBeforeSHA256, evidence.Execution.FreshCandidate.FreshStateAfterSHA256)
+	require.Equal(t, evidence.Execution.FreshCandidate.CandidateBeforeDenialsSHA256, evidence.Execution.FreshCandidate.CandidateAfterDenialsSHA256)
+	require.Equal(t, evidence.Execution.FreshCandidate.PredecessorBeforeDenialsSHA256, evidence.Execution.FreshCandidate.PredecessorAfterDenialsSHA256)
+	require.Len(t, evidence.Execution.FreshCandidate.Denials, 3)
+	require.Zero(t, evidence.Execution.FreshCandidate.CandidateInventory.LegacyPrincipalCount)
+	require.Zero(t, evidence.Execution.FreshCandidate.CandidateInventory.DashboardCount)
+	require.Zero(t, evidence.Execution.FreshCandidate.CandidateInventory.SemanticModelCount)
+	require.True(t, fixture.projectVerified)
+	_, err = compatibility.MarshalV010ReleaseIdentityEvidence(evidence, policyDocument)
+	require.NoError(t, err)
+
+	var runArguments []string
+	for _, arguments := range fixture.requests {
+		if len(arguments) > 0 && arguments[0] == "run" {
+			runArguments = arguments
+			break
+		}
+	}
+	require.NotEmpty(t, runArguments)
+	joined := strings.Join(runArguments, "\x00")
+	for _, required := range []string{
+		"--platform\x00linux/amd64", "--pull\x00never", "--read-only", "--network\x00" + evidence.Execution.NetworkName,
+		"--env\x00LIBREDASH_LOCAL_AUTH=1", "--env\x00LIBREDASH_COOKIE_SECURE=1",
+		"type=volume,source=" + evidence.Execution.StateVolumeName + ",target=" + v010StateMount,
+		"target=" + v010QualificationMount + ",readonly", compatibility.ReleasedV010Image,
+	} {
+		require.Contains(t, joined, required)
+	}
+	requireV010CleanupCommand(t, fixture.requests, []string{"stop", "--time", "30", evidence.Execution.ContainerName})
+	requireV010CleanupCommand(t, fixture.requests, []string{"start", evidence.Execution.ContainerName})
+	require.Equal(t, 2, countV010Command(fixture.requests, []string{"stop", "--time", "30", evidence.Execution.ContainerName}))
+	requireV010CleanupCommand(t, fixture.requests, []string{"rm", "--force", evidence.Execution.ContainerName})
+	requireV010CleanupCommand(t, fixture.requests, []string{"volume", "rm", evidence.Execution.StateVolumeName})
+	requireV010CleanupCommand(t, fixture.requests, []string{"network", "rm", evidence.Execution.NetworkName})
+	require.NoDirExists(t, fixture.runDirectory())
+	require.NoDirExists(t, fixture.candidateRunDirectory())
+}
+
+func TestV010FreshCandidateDeniesLegacyStateWithoutMutation(t *testing.T) {
+	fixture := newV010DockerFixture(t)
+	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+	controller, err := New(Options{
+		Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+	})
+	require.NoError(t, err)
+	evidence, err := controller.qualifyV010ArtifactExecution(t.Context(), v010CandidateBoundTestPolicy(t))
+	require.NoError(t, err)
+	fresh := evidence.Execution.FreshCandidate
+	require.NotNil(t, fresh)
+	require.Equal(t, []string{
+		"preserved-state-mount", "legacy-state-reference", "direct-legacy-artifact-adoption",
+	}, []string{fresh.Denials[0].Scenario, fresh.Denials[1].Scenario, fresh.Denials[2].Scenario})
+	for _, denial := range fresh.Denials {
+		require.True(t, denial.DeniedBeforeMutation)
+		require.Equal(t, denial.BeforeSHA256, denial.AfterSHA256)
+	}
+	joined := make([]string, 0, len(fixture.requests))
+	for _, request := range fixture.requests {
+		joined = append(joined, strings.Join(request, " "))
+	}
+	commands := strings.Join(joined, "\n")
+	require.Contains(t, commands, "LEAPVIEW_HOME=/var/lib/leapview")
+	require.Contains(t, commands, "LEAPVIEW_HOME=/legacy-v010")
+	require.Contains(t, commands, "source="+evidence.Execution.StateVolumeName+",target=/var/lib/leapview")
+	require.NotContains(t, candidateServerRunCommand(fixture.requests, fixture.candidateImage), evidence.Execution.StateVolumeName)
+}
+
+func TestV010FreshCandidateFailsClosedOnLegacyVisibilityOrMutation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*v010DockerFixture)
+		want   string
+	}{
+		{name: "legacy state visible", mutate: func(f *v010DockerFixture) { f.candidateLegacyVisible = true }, want: "exposed preserved v0.1"},
+		{name: "denial mutates state", mutate: func(f *v010DockerFixture) { f.candidateDenialMutates = true }, want: "changed preserved predecessor state"},
+		{name: "candidate identity mismatch", mutate: func(f *v010DockerFixture) { f.candidateRevision = strings.Repeat("0", 40) }, want: "does not match the admitted policy artifact"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newV010DockerFixture(t)
+			test.mutate(fixture)
+			t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+			controller, err := New(Options{
+				Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+			})
+			require.NoError(t, err)
+			_, err = controller.qualifyV010ArtifactExecution(t.Context(), v010CandidateBoundTestPolicy(t))
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func candidateServerRunCommand(requests [][]string, image string) string {
+	for _, request := range requests {
+		if len(request) > 0 && request[0] == "run" && slices.Contains(request, "--detach") && slices.Contains(request, image) {
+			return strings.Join(request, " ")
+		}
+	}
+	return ""
+}
+
+func TestV010StoppedStateInventoryFailsClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*v010DockerFixture)
+		want   string
+	}{
+		{name: "missing principal", mutate: func(f *v010DockerFixture) { f.missingPrincipal = true }, want: "omitted or changed principal"},
+		{name: "altered project state", mutate: func(f *v010DockerFixture) { f.alteredProject = true }, want: "omitted or changed the activated project"},
+		{name: "altered managed-data metadata", mutate: func(f *v010DockerFixture) { f.alteredManagedData = true }, want: "inventory changed across clean shutdown"},
+		{name: "missing published workload", mutate: func(f *v010DockerFixture) { f.missingPublish = true }, want: "omitted or changed the active published workload"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newV010DockerFixture(t)
+			test.mutate(fixture)
+			t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+			controller, err := New(Options{
+				Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+			})
+			require.NoError(t, err)
+			_, err = controller.qualifyV010ArtifactExecution(t.Context(), v010CandidateBoundTestPolicy(t))
+			require.ErrorContains(t, err, test.want)
+			name := v010ContainerNameFromRequests(fixture.requests)
+			require.NotEmpty(t, name)
+			requireV010CleanupCommand(t, fixture.requests, []string{"start", name})
+			requireV010CleanupCommand(t, fixture.requests, []string{"rm", "--force", name})
+		})
+	}
+}
+
+func TestV010ApplicationJourneyFailsClosedAtSupportedBoundaries(t *testing.T) {
+	tests := []struct {
+		name         string
+		mutate       func(*v010DockerFixture)
+		want         string
+		shortContext bool
+	}{
+		{name: "readiness failure", mutate: func(f *v010DockerFixture) { f.readinessError = true }, want: "readiness was not reached", shortContext: true},
+		{name: "bootstrap failure", mutate: func(f *v010DockerFixture) { f.bootstrapError = true }, want: "bootstrap v0.1 application"},
+		{name: "authentication failure", mutate: func(f *v010DockerFixture) { f.authenticationError = true }, want: "authenticate to v0.1 API"},
+		{name: "workload mismatch", mutate: func(f *v010DockerFixture) { f.workloadMismatch = true }, want: "semantic workload result"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newV010DockerFixture(t)
+			test.mutate(fixture)
+			t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+			controller, err := New(Options{
+				Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+			})
+			require.NoError(t, err)
+			ctx := t.Context()
+			if test.shortContext {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, 20*time.Millisecond)
+				defer cancel()
+			}
+			_, err = controller.qualifyV010ArtifactExecution(ctx, v010CandidateBoundTestPolicy(t))
+			require.ErrorContains(t, err, test.want)
+			name := v010ContainerNameFromRequests(fixture.requests)
+			require.NotEmpty(t, name)
+			requireV010CleanupCommand(t, fixture.requests, []string{"rm", "--force", name})
+		})
+	}
+}
+
+func TestV010ApplicationJourneyUsesOnlyReleasedCLIAndDoesNotExposeCredentialArguments(t *testing.T) {
+	fixture := newV010DockerFixture(t)
+	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+	controller, err := New(Options{
+		Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+	})
+	require.NoError(t, err)
+	evidence, err := controller.qualifyV010ArtifactExecution(t.Context(), v010CandidateBoundTestPolicy(t))
+	require.NoError(t, err)
+	require.NotNil(t, evidence.Execution.Journey)
+	require.Equal(t, v010ProjectID, evidence.Execution.Journey.ProjectID)
+	require.Equal(t, v010Environment, evidence.Execution.Journey.Environment)
+	for _, arguments := range fixture.requests {
+		joined := strings.Join(arguments, " ")
+		require.NotContains(t, joined, "ld_test_bootstrap_token")
+		require.NotContains(t, joined, "temporary-secret")
+		if len(arguments) > 0 && arguments[0] == "exec" {
+			if slices.Contains(arguments, "leapview") {
+				require.NotContains(t, joined, "candidate-publisher-token")
+			} else {
+				require.Contains(t, arguments, "libredash")
+			}
+		}
+	}
+}
+
+func v010ContainerNameFromRequests(requests [][]string) string {
+	for _, arguments := range requests {
+		if len(arguments) == 0 || arguments[0] != "run" {
+			continue
+		}
+		for index, argument := range arguments {
+			if argument == "--name" && index+1 < len(arguments) {
+				return arguments[index+1]
+			}
+		}
+	}
+	return ""
+}
+
+func TestV010ArtifactExecutionRejectsContainerIdentityMismatchAndStillCleansUp(t *testing.T) {
+	fixture := newV010DockerFixture(t)
+	fixture.inspectMutate = func(inspected *v010ContainerInspect) {
+		inspected.Config.Image = "ghcr.io/yacobolo/libredash:v0.1.0"
+	}
+	t.Setenv("DOCKER_CONFIG", filepath.Dir(writeV010DockerCredentials(t)))
+	controller, err := New(Options{
+		Root: t.TempDir(), DockerBin: "docker-probe", qualificationExecutor: qualificationExecutorFunc(fixture.execute),
+	})
+	require.NoError(t, err)
+	_, err = controller.qualifyV010ArtifactExecution(t.Context(), v010CandidateBoundTestPolicy(t))
+	require.ErrorContains(t, err, "container identity")
+	name := ""
+	for _, arguments := range fixture.requests {
+		if len(arguments) > 0 && arguments[0] == "run" {
+			for index, argument := range arguments {
+				if argument == "--name" && index+1 < len(arguments) {
+					name = arguments[index+1]
+				}
+			}
+		}
+	}
+	require.NotEmpty(t, name)
+	requireV010CleanupCommand(t, fixture.requests, []string{"rm", "--force", name})
+	requireV010CleanupCommand(t, fixture.requests, []string{"volume", "rm", name + "-state"})
+	requireV010CleanupCommand(t, fixture.requests, []string{"network", "rm", name + "-network"})
+}
+
+func requireV010CleanupCommand(t *testing.T, requests [][]string, want []string) {
+	t.Helper()
+	for _, request := range requests {
+		if slices.Equal(request, want) {
+			return
+		}
+	}
+	t.Fatalf("Docker command %v not found in %v", want, requests)
+}
+
+func countV010Command(requests [][]string, want []string) int {
+	count := 0
+	for _, request := range requests {
+		if slices.Equal(request, want) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/app/cli/composectl/testdata/v010-oci-index.json
+++ b/internal/app/cli/composectl/testdata/v010-oci-index.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:a8a60264b099c21eb46bf2ed8de1cca7f5867687d570ca2c6c3f9de4ad11018a",
+      "size": 2007,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:189623101fe1865f693e1c0f51f17b101518307af39c3b8871cc164166dbb066",
+      "size": 839,
+      "annotations": {
+        "vnd.docker.reference.digest": "sha256:a8a60264b099c21eb46bf2ed8de1cca7f5867687d570ca2c6c3f9de4ad11018a",
+        "vnd.docker.reference.type": "attestation-manifest"
+      },
+      "platform": {
+        "architecture": "unknown",
+        "os": "unknown"
+      }
+    }
+  ]
+}

--- a/internal/app/cli/composectl/testdata/v010-oci-manifest.json
+++ b/internal/app/cli/composectl/testdata/v010-oci-manifest.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9",
+    "size": 5401
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:68629629b516c3cd6f5e71ffbe18e32afb1ae5b4926c92d058c0f11ef1fd58a3",
+      "size": 28237639
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:24a717159cc1ba66e868d5e0c6179a91714013843672b7fb855026231a7204ff",
+      "size": 3511615
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:613fc76a173fbc335cf214257af96d908b1ec0339f9ea10833a881dfbb8043d2",
+      "size": 1110
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:a1eb1aa47a17b45babfe885cec65a12352ffa01651432a4c5cc53147c870ddc1",
+      "size": 93
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:35ae3bc2d3f398bdf16c551c26469f6f04a11b1b0a9f712d0ab33f0d0fbc0f0f",
+      "size": 33179355
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:dc8f6b6cafced68598d16d752540f06c1a4c88d6e7c4a2580ba53f45310f4c11",
+      "size": 2713012
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:da2e53663a1029f995bfce3c8b0dd6cd2e9c9546d46c4b3eba2f298cfd29e5f7",
+      "size": 16271
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:f5e8d93ba899beb6fa3f869125fa7414e3509cc0bc27cd647b93f44c67ae3224",
+      "size": 18672
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:27edcc45033286c13e955ad8e8eaa5f2006ca00ac7ef45137a608a270134d318",
+      "size": 2747189
+    }
+  ]
+}

--- a/internal/app/tools/transitionpolicy/main.go
+++ b/internal/app/tools/transitionpolicy/main.go
@@ -56,25 +56,6 @@ func main() {
 	}
 }
 
-type candidateAdmissionRecord struct {
-	SchemaVersion  int    `json:"schemaVersion"`
-	Image          string `json:"image"`
-	Digest         string `json:"digest"`
-	RegistryDigest string `json:"registryDigest"`
-	Attestation    struct {
-		Verified       bool   `json:"verified"`
-		Repository     string `json:"repository"`
-		Workflow       string `json:"workflow"`
-		SourceRevision string `json:"sourceRevision"`
-	} `json:"attestation"`
-	SBOM struct {
-		Discoverable bool `json:"discoverable"`
-	} `json:"sbom"`
-	VulnerabilityPolicy struct {
-		Passed bool `json:"passed"`
-	} `json:"vulnerabilityPolicy"`
-}
-
 type predecessorVerification struct {
 	SchemaVersion   int                           `json:"schemaVersion"`
 	PolicyVersion   string                        `json:"policyVersion"`
@@ -160,21 +141,10 @@ func validateCandidateAdmission(path, image, revision string) error {
 	if err != nil {
 		return fmt.Errorf("read candidate admission: %w", err)
 	}
-	var record candidateAdmissionRecord
-	if err := json.Unmarshal(contents, &record); err != nil {
-		return fmt.Errorf("decode candidate admission: %w", err)
-	}
-	digest := ""
-	if index := strings.LastIndex(image, "@"); index >= 0 {
-		digest = image[index+1:]
-	}
-	if record.SchemaVersion != 1 || !record.Attestation.Verified || record.Attestation.Repository != "flidai/leapview" ||
-		record.Attestation.Workflow != "flidai/leapview/.github/workflows/release.yml" ||
-		!record.SBOM.Discoverable || !record.VulnerabilityPolicy.Passed ||
-		record.Image != image || record.Digest != digest || record.RegistryDigest != digest || record.Attestation.SourceRevision != revision {
-		return fmt.Errorf("candidate admission does not authorize release identity %s at revision %s", image, revision)
-	}
-	return nil
+	_, err = compatibility.ValidateCandidateAdmissionEvidence(contents, compatibility.ReleaseIdentity{
+		Image: image, SourceRevision: revision,
+	})
+	return err
 }
 
 func verifyPredecessors(policy *compatibility.Policy, template compatibility.CandidateTransitionTemplate, resolve predecessorResolver) (predecessorVerification, error) {

--- a/internal/platform/compatibility/candidate_admission.go
+++ b/internal/platform/compatibility/candidate_admission.go
@@ -1,0 +1,76 @@
+package compatibility
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/flidai/leapview/internal/platform/ociref"
+)
+
+const candidateAdmissionMaxBytes = 64 * 1024
+
+// CandidateAdmissionEvidence is the release workflow's immutable OCI
+// admission output. Transition-policy binding and downstream qualification
+// share this owner validator so neither can accept a weaker projection.
+type CandidateAdmissionEvidence struct {
+	SchemaVersion  int    `json:"schemaVersion"`
+	Image          string `json:"image"`
+	Digest         string `json:"digest"`
+	RegistryDigest string `json:"registryDigest"`
+	Attestation    struct {
+		Verified       bool   `json:"verified"`
+		Repository     string `json:"repository"`
+		Workflow       string `json:"workflow"`
+		SourceRevision string `json:"sourceRevision"`
+	} `json:"attestation"`
+	SBOM struct {
+		Discoverable bool `json:"discoverable"`
+	} `json:"sbom"`
+	VulnerabilityPolicy struct {
+		Passed bool `json:"passed"`
+	} `json:"vulnerabilityPolicy"`
+}
+
+// ValidateCandidateAdmissionEvidence binds the exact admitted registry digest
+// and verified release provenance to the policy candidate identity.
+func ValidateCandidateAdmissionEvidence(document []byte, expected ReleaseIdentity) (CandidateAdmissionEvidence, error) {
+	if err := ociref.ValidateImmutable(expected.Image); err != nil {
+		return CandidateAdmissionEvidence{}, fmt.Errorf("candidate admission expected identity: %w", err)
+	}
+	if len(expected.SourceRevision) != 40 || !isLowerHex(expected.SourceRevision) {
+		return CandidateAdmissionEvidence{}, fmt.Errorf("candidate admission expected source revision is invalid")
+	}
+	if len(document) == 0 || len(document) > candidateAdmissionMaxBytes {
+		return CandidateAdmissionEvidence{}, fmt.Errorf("candidate admission evidence size must be between 1 and %d bytes", candidateAdmissionMaxBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.DisallowUnknownFields()
+	var record CandidateAdmissionEvidence
+	if err := decoder.Decode(&record); err != nil {
+		return CandidateAdmissionEvidence{}, fmt.Errorf("decode candidate admission evidence: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return CandidateAdmissionEvidence{}, fmt.Errorf("candidate admission evidence contains trailing data")
+	}
+	digest := ""
+	if index := strings.LastIndex(expected.Image, "@"); index >= 0 {
+		digest = expected.Image[index+1:]
+	}
+	if record.SchemaVersion != CurrentSchemaVersion || !record.Attestation.Verified ||
+		record.Attestation.Repository != "flidai/leapview" ||
+		record.Attestation.Workflow != "flidai/leapview/.github/workflows/release.yml" ||
+		!record.SBOM.Discoverable || !record.VulnerabilityPolicy.Passed ||
+		record.Image != expected.Image || record.Digest != digest || record.RegistryDigest != digest ||
+		record.Attestation.SourceRevision != expected.SourceRevision {
+		return CandidateAdmissionEvidence{}, fmt.Errorf(
+			"candidate admission does not authorize release identity %s at revision %s",
+			expected.Image, expected.SourceRevision,
+		)
+	}
+	return record, nil
+}

--- a/internal/platform/compatibility/testdata/v010-release-identity.executed.valid.json
+++ b/internal/platform/compatibility/testdata/v010-release-identity.executed.valid.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": 1,
+  "kind": "leapview-v0.1-release-identity",
+  "verifiedAt": "2026-07-13T15:45:27Z",
+  "policyVersion": "ubdr/v1",
+  "policySha256": "10a8e5a5fdaba641ba830866286b09ce8da04621925649ff86955094af526914",
+  "identity": {
+    "releaseId": "v0.1.0",
+    "version": "0.1.0",
+    "sourceRevision": "5bf4aded574df459e80d81b77d1989ecd4fa7de0",
+    "image": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+    "distribution": "authentication-required",
+    "platform": "linux/amd64"
+  },
+  "artifact": {
+    "repository": "ghcr.io/yacobolo/libredash",
+    "image": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+    "resolvedDigest": "sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+    "platform": "linux/amd64",
+    "platformManifestDigest": "sha256:a8a60264b099c21eb46bf2ed8de1cca7f5867687d570ca2c6c3f9de4ad11018a",
+    "configDigest": "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9",
+    "authenticated": true
+  },
+  "provenance": {
+    "sourceRepository": "https://github.com/Yacobolo/libredash",
+    "sourceTag": "v0.1.0",
+    "version": "0.1.0",
+    "sourceRevision": "5bf4aded574df459e80d81b77d1989ecd4fa7de0"
+  },
+  "execution": {
+    "runId": "0123456789abcdef0123456789abcdef",
+    "containerId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "containerName": "leapview-v010-0123456789abcdef0123456789abcdef",
+    "image": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+    "imageId": "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9",
+    "platform": "linux/amd64",
+    "networkName": "leapview-v010-0123456789abcdef0123456789abcdef-network",
+    "stateVolumeName": "leapview-v010-0123456789abcdef0123456789abcdef-state",
+    "startedAt": "2026-07-13T15:45:28Z",
+    "stoppedAt": "2026-07-13T15:45:34Z",
+    "startedState": "running",
+    "stoppedState": "exited",
+    "cleanShutdown": true,
+    "cleanupVerified": true,
+    "journey": {
+      "startedAt": "2026-07-13T15:45:28Z",
+      "readyAt": "2026-07-13T15:45:28Z",
+      "completedAt": "2026-07-13T15:45:29Z",
+      "adminEmail": "fai-517-admin@qualification.invalid",
+      "adminPrincipalId": "principal_admin",
+      "userEmail": "fai-517-user@qualification.invalid",
+      "userPrincipalId": "principal_user",
+      "projectId": "compatibility",
+      "environment": "fai-517",
+      "publishId": "publish_001",
+      "activatedDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "projectDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "managedDataRows": 3,
+      "semanticResultSha256": "21bc8a539aa05a0d97e07b294bfead69daaee6e6be3d15698efa2ed8d028c473",
+      "dashboardResultSha256": "4e235add0e3c1f6c9a399981e981fdfd04f33c472a451b4516bb6a569a9a4ef9",
+      "authenticationVerified": true,
+      "projectActivated": true,
+      "managedDataVerified": true,
+      "workloadVerified": true
+    },
+    "preservation": {
+      "observedBeforeShutdownAt": "2026-07-13T15:45:30Z",
+      "shutdownAt": "2026-07-13T15:45:31Z",
+      "restartedAt": "2026-07-13T15:45:32Z",
+      "observedAfterRestartAt": "2026-07-13T15:45:33Z",
+      "inventory": {
+        "application": {
+          "image": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+          "imageId": "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9",
+          "containerId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          "platform": "linux/amd64",
+          "sourceRevision": "5bf4aded574df459e80d81b77d1989ecd4fa7de0"
+        },
+        "principals": [
+          {
+            "id": "principal_admin",
+            "email": "fai-517-admin@qualification.invalid",
+            "displayName": "fai-517-admin@qualification.invalid"
+          },
+          {
+            "id": "principal_user",
+            "email": "fai-517-user@qualification.invalid",
+            "displayName": "FAI-517 User"
+          }
+        ],
+        "project": {
+          "id": "compatibility",
+          "title": "FAI-517 Compatibility",
+          "environment": "fai-517",
+          "activeServingStateId": "serving_001"
+        },
+        "publish": {
+          "id": "publish_001",
+          "projectId": "compatibility",
+          "environment": "fai-517",
+          "status": "active",
+          "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "assets": [
+          {
+            "id": "dashboard:compatibility.preservation",
+            "type": "dashboard",
+            "key": "compatibility.preservation",
+            "servingStateId": "serving_001",
+            "contentHash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+          },
+          {
+            "id": "model_table:compatibility.orders",
+            "type": "model_table",
+            "key": "compatibility.orders",
+            "servingStateId": "serving_001",
+            "contentHash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+          },
+          {
+            "id": "semantic_model:compatibility.compatibility",
+            "type": "semantic_model",
+            "key": "compatibility.compatibility",
+            "servingStateId": "serving_001",
+            "contentHash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+          },
+          {
+            "id": "source:qualification.orders",
+            "type": "source",
+            "key": "qualification.orders",
+            "servingStateId": "serving_001",
+            "contentHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+          }
+        ],
+        "managedDataRows": 3,
+        "semanticResultSha256": "21bc8a539aa05a0d97e07b294bfead69daaee6e6be3d15698efa2ed8d028c473",
+        "dashboardResultSha256": "4e235add0e3c1f6c9a399981e981fdfd04f33c472a451b4516bb6a569a9a4ef9"
+      },
+      "beforeSha256": "fb88cd5b7e02d39497d90c48f12f49f9a61c159df9d0f4548daf1ab44e72c3e6",
+      "afterSha256": "fb88cd5b7e02d39497d90c48f12f49f9a61c159df9d0f4548daf1ab44e72c3e6",
+      "restartIdentityVerified": true,
+      "statePreserved": true
+    },
+    "freshCandidate": {
+      "runId": "abcdef0123456789abcdef0123456789",
+      "containerId": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+      "containerName": "leapview-v010-candidate-abcdef0123456789abcdef0123456789",
+      "stateVolumeName": "leapview-v010-candidate-abcdef0123456789abcdef0123456789-state",
+      "networkName": "leapview-v010-candidate-abcdef0123456789abcdef0123456789-network",
+      "predecessor": {
+        "releaseId": "v0.1.0",
+        "version": "0.1.0",
+        "sourceRevision": "5bf4aded574df459e80d81b77d1989ecd4fa7de0",
+        "image": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+        "distribution": "authentication-required",
+        "platform": "linux/amd64"
+      },
+      "candidate": {
+        "releaseId": "v0.2.0-rc.2",
+        "version": "0.2.0-rc.2",
+        "sourceRevision": "4444444444444444444444444444444444444444",
+        "image": "ghcr.io/flidai/leapview@sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "distribution": "public",
+        "platform": "linux/amd64"
+      },
+      "candidateImageId": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+      "policyVersion": "ubdr/v1",
+      "policySha256": "10a8e5a5fdaba641ba830866286b09ce8da04621925649ff86955094af526914",
+      "freshInstallDecision": {
+        "schemaVersion": 1,
+        "policyVersion": "ubdr/v1",
+        "operation": "fresh-install",
+        "allowed": true,
+        "reasonCode": "transition.allowed.fresh_install",
+        "remediation": "",
+        "requirements": [],
+        "current": { "image": "", "platform": "" },
+        "next": {
+          "releaseId": "v0.2.0-rc.2",
+          "version": "0.2.0-rc.2",
+          "sourceRevision": "4444444444444444444444444444444444444444",
+          "image": "ghcr.io/flidai/leapview@sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "distribution": "public",
+          "platform": "linux/amd64"
+        }
+      },
+      "freshStateBeforeSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "freshStateAfterSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "candidateBeforeDenialsSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "candidateAfterDenialsSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "predecessorBeforeDenialsSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+      "predecessorAfterDenialsSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+      "candidateInventory": {
+        "adminEmail": "fai-517-candidate@qualification.invalid",
+        "adminPrincipalId": "candidate_admin",
+        "legacyPrincipalCount": 0,
+        "dashboardCount": 0,
+        "semanticModelCount": 0,
+        "legacyProjectVisible": false,
+        "legacyManagedDataVisible": false
+      },
+      "denials": [
+        {
+          "scenario": "preserved-state-mount",
+          "operation": "upgrade",
+          "reasonCode": "transition.denied.fresh_install_only",
+          "beforeSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "afterSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "deniedBeforeMutation": true
+        },
+        {
+          "scenario": "legacy-state-reference",
+          "operation": "upgrade",
+          "reasonCode": "transition.denied.fresh_install_only",
+          "beforeSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "afterSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "deniedBeforeMutation": true
+        },
+        {
+          "scenario": "direct-legacy-artifact-adoption",
+          "operation": "fresh-install",
+          "reasonCode": "transition.denied.release_unknown",
+          "beforeSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "afterSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "deniedBeforeMutation": true
+        }
+      ],
+      "startedAt": "2026-07-13T15:45:35Z",
+      "completedAt": "2026-07-13T15:45:36Z",
+      "cleanStateVerified": true,
+      "legacyStateUnavailable": true,
+      "mutationFree": true,
+      "cleanupVerified": true
+    }
+  },
+  "result": "verified"
+}

--- a/internal/platform/compatibility/testdata/v010-release-identity.valid.json
+++ b/internal/platform/compatibility/testdata/v010-release-identity.valid.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": 1,
+  "kind": "leapview-v0.1-release-identity",
+  "verifiedAt": "2026-07-13T15:45:27Z",
+  "policyVersion": "ubdr/v1",
+  "policySha256": "aa5563af84408c0efe3828bd8a8d18467dc263075a945e86106dab3f332c7c19",
+  "identity": {
+    "releaseId": "v0.1.0",
+    "version": "0.1.0",
+    "sourceRevision": "5bf4aded574df459e80d81b77d1989ecd4fa7de0",
+    "image": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+    "distribution": "authentication-required",
+    "platform": "linux/amd64"
+  },
+  "artifact": {
+    "repository": "ghcr.io/yacobolo/libredash",
+    "image": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+    "resolvedDigest": "sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+    "platform": "linux/amd64",
+    "platformManifestDigest": "sha256:a8a60264b099c21eb46bf2ed8de1cca7f5867687d570ca2c6c3f9de4ad11018a",
+    "configDigest": "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9",
+    "authenticated": true
+  },
+  "provenance": {
+    "sourceRepository": "https://github.com/Yacobolo/libredash",
+    "sourceTag": "v0.1.0",
+    "version": "0.1.0",
+    "sourceRevision": "5bf4aded574df459e80d81b77d1989ecd4fa7de0"
+  },
+  "result": "verified"
+}

--- a/internal/platform/compatibility/v010_artifact_evidence.go
+++ b/internal/platform/compatibility/v010_artifact_evidence.go
@@ -1,0 +1,760 @@
+package compatibility
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const (
+	ReleasedV010ID               = "v0.1.0"
+	ReleasedV010Platform         = "linux/amd64"
+	ReleasedV010Repository       = "ghcr.io/yacobolo/libredash"
+	ReleasedV010SourceRepository = "https://github.com/Yacobolo/libredash"
+	ReleasedV010PlatformManifest = "sha256:a8a60264b099c21eb46bf2ed8de1cca7f5867687d570ca2c6c3f9de4ad11018a"
+	ReleasedV010ConfigDigest     = "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9"
+
+	v010ReleaseIdentityEvidenceKind   = "leapview-v0.1-release-identity"
+	v010EvidenceResultVerified        = "verified"
+	v010ArtifactEvidenceMaxBytes      = 64 * 1024
+	v010ExpectedSemanticResultSHA256  = "21bc8a539aa05a0d97e07b294bfead69daaee6e6be3d15698efa2ed8d028c473"
+	v010ExpectedDashboardResultSHA256 = "4e235add0e3c1f6c9a399981e981fdfd04f33c472a451b4516bb6a569a9a4ef9"
+)
+
+//go:embed v010_artifact_evidence.schema.json
+var v010ArtifactEvidenceSchemaJSON []byte
+
+var (
+	v010ArtifactEvidenceSchemaOnce sync.Once
+	v010ArtifactEvidenceSchema     *jsonschema.Schema
+	v010ArtifactEvidenceSchemaErr  error
+)
+
+// V010ArtifactResolutionRequest is deliberately limited to the immutable
+// policy-owned identity. It contains no tag, local image, or source-build
+// fallback surface.
+type V010ArtifactResolutionRequest struct {
+	Image                 string
+	Platform              string
+	RequireAuthentication bool
+}
+
+// V010ResolvedArtifact is the registry resolver's observation of the exact
+// policy-owned v0.1 artifact. The compatibility owner validates every field
+// before it can become qualification evidence.
+type V010ResolvedArtifact struct {
+	Image                  string
+	ResolvedDigest         string
+	Platform               string
+	PlatformManifestDigest string
+	ConfigDigest           string
+	Authenticated          bool
+	SourceRepository       string
+	SourceTag              string
+	Version                string
+	SourceRevision         string
+}
+
+// V010ArtifactResolver must resolve the requested immutable registry object.
+// Implementations must not substitute a local image, mutable tag, rebuilt
+// artifact, or alternate registry namespace.
+type V010ArtifactResolver interface {
+	ResolveExact(context.Context, V010ArtifactResolutionRequest) (V010ResolvedArtifact, error)
+}
+
+type V010ArtifactVerificationOptions struct {
+	PolicyDocument []byte
+	Resolver       V010ArtifactResolver
+	Now            func() time.Time
+}
+
+// V010ReleaseIdentityEvidence is the persisted proof that the exact released
+// v0.1 artifact named by the supplied policy was available and its immutable
+// registry and OCI provenance matched the reviewed historical release.
+type V010ReleaseIdentityEvidence struct {
+	SchemaVersion int                     `json:"schemaVersion"`
+	Kind          string                  `json:"kind"`
+	VerifiedAt    time.Time               `json:"verifiedAt"`
+	PolicyVersion string                  `json:"policyVersion"`
+	PolicySHA256  string                  `json:"policySha256"`
+	Identity      ReleaseIdentity         `json:"identity"`
+	Artifact      V010ArtifactEvidence    `json:"artifact"`
+	Provenance    V010ProvenanceEvidence  `json:"provenance"`
+	Execution     *V010ContainerExecution `json:"execution,omitempty"`
+	Result        string                  `json:"result"`
+}
+
+type V010ArtifactEvidence struct {
+	Repository             string `json:"repository"`
+	Image                  string `json:"image"`
+	ResolvedDigest         string `json:"resolvedDigest"`
+	Platform               string `json:"platform"`
+	PlatformManifestDigest string `json:"platformManifestDigest"`
+	ConfigDigest           string `json:"configDigest"`
+	Authenticated          bool   `json:"authenticated"`
+}
+
+type V010ProvenanceEvidence struct {
+	SourceRepository string `json:"sourceRepository"`
+	SourceTag        string `json:"sourceTag"`
+	Version          string `json:"version"`
+	SourceRevision   string `json:"sourceRevision"`
+}
+
+// V010ContainerExecution records the isolated container identity and clean
+// lifecycle for the same exact artifact. Host paths and credentials are
+// deliberately excluded from persisted evidence.
+type V010ContainerExecution struct {
+	RunID           string                      `json:"runId"`
+	ContainerID     string                      `json:"containerId"`
+	ContainerName   string                      `json:"containerName"`
+	Image           string                      `json:"image"`
+	ImageID         string                      `json:"imageId"`
+	Platform        string                      `json:"platform"`
+	NetworkName     string                      `json:"networkName"`
+	StateVolumeName string                      `json:"stateVolumeName"`
+	StartedAt       time.Time                   `json:"startedAt"`
+	StoppedAt       time.Time                   `json:"stoppedAt"`
+	StartedState    string                      `json:"startedState"`
+	StoppedState    string                      `json:"stoppedState"`
+	CleanShutdown   bool                        `json:"cleanShutdown"`
+	CleanupVerified bool                        `json:"cleanupVerified"`
+	Journey         *V010ApplicationJourney     `json:"journey,omitempty"`
+	Preservation    *V010PreservationEvidence   `json:"preservation,omitempty"`
+	FreshCandidate  *V010FreshCandidateEvidence `json:"freshCandidate,omitempty"`
+}
+
+// V010ApplicationJourney records the assertions produced by the authentic
+// v0.1 CLI and API journey. It deliberately retains stable identities and
+// normalized result checksums, not bootstrap credentials or raw responses.
+type V010ApplicationJourney struct {
+	StartedAt              time.Time `json:"startedAt"`
+	ReadyAt                time.Time `json:"readyAt"`
+	CompletedAt            time.Time `json:"completedAt"`
+	AdminEmail             string    `json:"adminEmail"`
+	AdminPrincipalID       string    `json:"adminPrincipalId"`
+	UserEmail              string    `json:"userEmail"`
+	UserPrincipalID        string    `json:"userPrincipalId"`
+	ProjectID              string    `json:"projectId"`
+	Environment            string    `json:"environment"`
+	PublishID              string    `json:"publishId"`
+	ActivatedDigest        string    `json:"activatedDigest"`
+	ProjectDigest          string    `json:"projectDigest"`
+	ManagedDataRows        int       `json:"managedDataRows"`
+	SemanticResultSHA256   string    `json:"semanticResultSha256"`
+	DashboardResultSHA256  string    `json:"dashboardResultSha256"`
+	AuthenticationVerified bool      `json:"authenticationVerified"`
+	ProjectActivated       bool      `json:"projectActivated"`
+	ManagedDataVerified    bool      `json:"managedDataVerified"`
+	WorkloadVerified       bool      `json:"workloadVerified"`
+}
+
+// V010PreservationEvidence binds two owner-normalized observations around a
+// clean stop and restart of the same exact container and state volume.
+type V010PreservationEvidence struct {
+	ObservedBeforeShutdownAt time.Time          `json:"observedBeforeShutdownAt"`
+	ShutdownAt               time.Time          `json:"shutdownAt"`
+	RestartedAt              time.Time          `json:"restartedAt"`
+	ObservedAfterRestartAt   time.Time          `json:"observedAfterRestartAt"`
+	Inventory                V010StateInventory `json:"inventory"`
+	BeforeSHA256             string             `json:"beforeSha256"`
+	AfterSHA256              string             `json:"afterSha256"`
+	RestartIdentityVerified  bool               `json:"restartIdentityVerified"`
+	StatePreserved           bool               `json:"statePreserved"`
+}
+
+type V010StateInventory struct {
+	Application           V010InventoryApplication `json:"application"`
+	Principals            []V010InventoryPrincipal `json:"principals"`
+	Project               V010InventoryProject     `json:"project"`
+	Publish               V010InventoryPublish     `json:"publish"`
+	Assets                []V010InventoryAsset     `json:"assets"`
+	ManagedDataRows       int                      `json:"managedDataRows"`
+	SemanticResultSHA256  string                   `json:"semanticResultSha256"`
+	DashboardResultSHA256 string                   `json:"dashboardResultSha256"`
+}
+
+type V010InventoryApplication struct {
+	Image          string `json:"image"`
+	ImageID        string `json:"imageId"`
+	ContainerID    string `json:"containerId"`
+	Platform       string `json:"platform"`
+	SourceRevision string `json:"sourceRevision"`
+}
+
+type V010InventoryPrincipal struct {
+	ID          string `json:"id"`
+	Email       string `json:"email"`
+	DisplayName string `json:"displayName"`
+}
+
+type V010InventoryProject struct {
+	ID                   string `json:"id"`
+	Title                string `json:"title"`
+	Environment          string `json:"environment"`
+	ActiveServingStateID string `json:"activeServingStateId"`
+}
+
+type V010InventoryPublish struct {
+	ID          string `json:"id"`
+	ProjectID   string `json:"projectId"`
+	Environment string `json:"environment"`
+	Status      string `json:"status"`
+	Digest      string `json:"digest"`
+}
+
+type V010InventoryAsset struct {
+	ID             string `json:"id"`
+	Type           string `json:"type"`
+	Key            string `json:"key"`
+	ServingStateID string `json:"servingStateId"`
+	ContentHash    string `json:"contentHash"`
+}
+
+// V010FreshCandidateEvidence proves that the policy candidate was initialized
+// in state isolated from the preserved predecessor and that every attempted
+// legacy-state adoption was denied without changing either state set.
+type V010FreshCandidateEvidence struct {
+	RunID                          string                      `json:"runId"`
+	ContainerID                    string                      `json:"containerId"`
+	ContainerName                  string                      `json:"containerName"`
+	StateVolumeName                string                      `json:"stateVolumeName"`
+	NetworkName                    string                      `json:"networkName"`
+	Predecessor                    ReleaseIdentity             `json:"predecessor"`
+	Candidate                      ReleaseIdentity             `json:"candidate"`
+	CandidateImageID               string                      `json:"candidateImageId"`
+	PolicyVersion                  string                      `json:"policyVersion"`
+	PolicySHA256                   string                      `json:"policySha256"`
+	FreshInstallDecision           Decision                    `json:"freshInstallDecision"`
+	FreshStateBeforeSHA256         string                      `json:"freshStateBeforeSha256"`
+	FreshStateAfterSHA256          string                      `json:"freshStateAfterSha256"`
+	CandidateBeforeDenialsSHA256   string                      `json:"candidateBeforeDenialsSha256"`
+	CandidateAfterDenialsSHA256    string                      `json:"candidateAfterDenialsSha256"`
+	PredecessorBeforeDenialsSHA256 string                      `json:"predecessorBeforeDenialsSha256"`
+	PredecessorAfterDenialsSHA256  string                      `json:"predecessorAfterDenialsSha256"`
+	CandidateInventory             V010FreshCandidateInventory `json:"candidateInventory"`
+	Denials                        []V010LegacyDenialEvidence  `json:"denials"`
+	StartedAt                      time.Time                   `json:"startedAt"`
+	CompletedAt                    time.Time                   `json:"completedAt"`
+	CleanStateVerified             bool                        `json:"cleanStateVerified"`
+	LegacyStateUnavailable         bool                        `json:"legacyStateUnavailable"`
+	MutationFree                   bool                        `json:"mutationFree"`
+	CleanupVerified                bool                        `json:"cleanupVerified"`
+}
+
+type V010FreshCandidateInventory struct {
+	AdminEmail               string `json:"adminEmail"`
+	AdminPrincipalID         string `json:"adminPrincipalId"`
+	LegacyPrincipalCount     int    `json:"legacyPrincipalCount"`
+	DashboardCount           int    `json:"dashboardCount"`
+	SemanticModelCount       int    `json:"semanticModelCount"`
+	LegacyProjectVisible     bool   `json:"legacyProjectVisible"`
+	LegacyManagedDataVisible bool   `json:"legacyManagedDataVisible"`
+}
+
+type V010LegacyDenialEvidence struct {
+	Scenario             string    `json:"scenario"`
+	Operation            Operation `json:"operation"`
+	ReasonCode           string    `json:"reasonCode"`
+	BeforeSHA256         string    `json:"beforeSha256"`
+	AfterSHA256          string    `json:"afterSha256"`
+	DeniedBeforeMutation bool      `json:"deniedBeforeMutation"`
+}
+
+// V010StateInventorySHA256 hashes the ordered, normalized inventory contract.
+// The inventory contains no timestamps, credentials, or raw API payloads.
+func V010StateInventorySHA256(inventory V010StateInventory) (string, error) {
+	document, err := json.Marshal(inventory)
+	if err != nil {
+		return "", fmt.Errorf("encode v0.1 state inventory: %w", err)
+	}
+	digest := sha256.Sum256(document)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func EmbeddedV010ArtifactEvidenceSchema() []byte {
+	return append([]byte(nil), v010ArtifactEvidenceSchemaJSON...)
+}
+
+// VerifyReleasedV010Artifact resolves only the exact v0.1 artifact from the
+// supplied checked-in or candidate-bound policy and fails closed on every
+// resolver or identity error. It never attempts an alternate reference.
+func VerifyReleasedV010Artifact(ctx context.Context, options V010ArtifactVerificationOptions) (V010ReleaseIdentityEvidence, error) {
+	if ctx == nil {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("v0.1 artifact verification context is required")
+	}
+	if options.Resolver == nil {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("v0.1 exact artifact resolver is required")
+	}
+	release, policy, policyDigest, err := releasedV010FromPolicy(options.PolicyDocument)
+	if err != nil {
+		return V010ReleaseIdentityEvidence{}, err
+	}
+	identity := release.IdentityForPlatform(ReleasedV010Platform)
+	request := V010ArtifactResolutionRequest{
+		Image:                 identity.Image,
+		Platform:              ReleasedV010Platform,
+		RequireAuthentication: true,
+	}
+	resolved, err := options.Resolver.ResolveExact(ctx, request)
+	if err != nil {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("resolve exact policy-declared v0.1 artifact %s: %w", identity.Image, err)
+	}
+	if err := validateResolvedV010Artifact(resolved, identity); err != nil {
+		return V010ReleaseIdentityEvidence{}, err
+	}
+	now := time.Now
+	if options.Now != nil {
+		now = options.Now
+	}
+	verifiedAt := now().UTC()
+	if verifiedAt.IsZero() {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("v0.1 artifact verification time is required")
+	}
+	evidence := V010ReleaseIdentityEvidence{
+		SchemaVersion: CurrentSchemaVersion,
+		Kind:          v010ReleaseIdentityEvidenceKind,
+		VerifiedAt:    verifiedAt,
+		PolicyVersion: policy.PolicyVersion,
+		PolicySHA256:  policyDigest,
+		Identity:      identity,
+		Artifact: V010ArtifactEvidence{
+			Repository:             ReleasedV010Repository,
+			Image:                  resolved.Image,
+			ResolvedDigest:         resolved.ResolvedDigest,
+			Platform:               resolved.Platform,
+			PlatformManifestDigest: resolved.PlatformManifestDigest,
+			ConfigDigest:           resolved.ConfigDigest,
+			Authenticated:          resolved.Authenticated,
+		},
+		Provenance: V010ProvenanceEvidence{
+			SourceRepository: resolved.SourceRepository,
+			SourceTag:        resolved.SourceTag,
+			Version:          resolved.Version,
+			SourceRevision:   resolved.SourceRevision,
+		},
+		Result: v010EvidenceResultVerified,
+	}
+	if err := validateV010ReleaseIdentityEvidence(evidence, options.PolicyDocument); err != nil {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("validate produced v0.1 release identity evidence: %w", err)
+	}
+	return evidence, nil
+}
+
+// ValidateV010ReleaseIdentityEvidence is the compatibility owner's canonical
+// validator for a persisted release-identity.json document. Callers must
+// supply the exact policy document used by the qualification run.
+func ValidateV010ReleaseIdentityEvidence(document, policyDocument []byte) (V010ReleaseIdentityEvidence, error) {
+	if len(document) == 0 || len(document) > v010ArtifactEvidenceMaxBytes {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("v0.1 release identity evidence size must be between 1 and %d bytes", v010ArtifactEvidenceMaxBytes)
+	}
+	schema, err := compiledV010ArtifactEvidenceSchema()
+	if err != nil {
+		return V010ReleaseIdentityEvidence{}, err
+	}
+	value, err := jsonschema.UnmarshalJSON(bytes.NewReader(document))
+	if err != nil {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("decode v0.1 release identity evidence JSON: %w", err)
+	}
+	if err := schema.Validate(value); err != nil {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("validate v0.1 release identity evidence schema: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.DisallowUnknownFields()
+	var evidence V010ReleaseIdentityEvidence
+	if err := decoder.Decode(&evidence); err != nil {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("decode v0.1 release identity evidence: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return V010ReleaseIdentityEvidence{}, fmt.Errorf("v0.1 release identity evidence contains trailing data")
+	}
+	if err := validateV010ReleaseIdentityEvidence(evidence, policyDocument); err != nil {
+		return V010ReleaseIdentityEvidence{}, err
+	}
+	return evidence, nil
+}
+
+// MarshalV010ReleaseIdentityEvidence produces the canonical persisted
+// release-identity.json document only after applying the owner validator.
+func MarshalV010ReleaseIdentityEvidence(evidence V010ReleaseIdentityEvidence, policyDocument []byte) ([]byte, error) {
+	if err := validateV010ReleaseIdentityEvidence(evidence, policyDocument); err != nil {
+		return nil, err
+	}
+	document, err := json.MarshalIndent(evidence, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode v0.1 release identity evidence: %w", err)
+	}
+	document = append(document, '\n')
+	if _, err := ValidateV010ReleaseIdentityEvidence(document, policyDocument); err != nil {
+		return nil, err
+	}
+	return document, nil
+}
+
+func validateV010ReleaseIdentityEvidence(evidence V010ReleaseIdentityEvidence, policyDocument []byte) error {
+	release, policy, policyDigest, err := releasedV010FromPolicy(policyDocument)
+	if err != nil {
+		return err
+	}
+	identity := release.IdentityForPlatform(ReleasedV010Platform)
+	if evidence.SchemaVersion != CurrentSchemaVersion || evidence.Kind != v010ReleaseIdentityEvidenceKind ||
+		evidence.Result != v010EvidenceResultVerified || evidence.VerifiedAt.IsZero() {
+		return fmt.Errorf("v0.1 release identity evidence result is incomplete")
+	}
+	if evidence.PolicyVersion != policy.PolicyVersion || evidence.PolicySHA256 != policyDigest {
+		return fmt.Errorf("v0.1 release identity evidence does not bind the supplied policy")
+	}
+	if evidence.Identity != identity {
+		return fmt.Errorf("v0.1 release identity evidence does not match the exact policy-declared identity")
+	}
+	resolved := V010ResolvedArtifact{
+		Image: evidence.Artifact.Image, ResolvedDigest: evidence.Artifact.ResolvedDigest,
+		Platform: evidence.Artifact.Platform, PlatformManifestDigest: evidence.Artifact.PlatformManifestDigest,
+		ConfigDigest: evidence.Artifact.ConfigDigest, Authenticated: evidence.Artifact.Authenticated,
+		SourceRepository: evidence.Provenance.SourceRepository, SourceTag: evidence.Provenance.SourceTag,
+		Version: evidence.Provenance.Version, SourceRevision: evidence.Provenance.SourceRevision,
+	}
+	if evidence.Artifact.Repository != ReleasedV010Repository {
+		return fmt.Errorf("v0.1 release identity evidence registry repository is not the reviewed repository")
+	}
+	if err := validateResolvedV010Artifact(resolved, identity); err != nil {
+		return err
+	}
+	if evidence.Execution != nil {
+		if err := validateV010ContainerExecution(*evidence.Execution, evidence, policyDocument); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateV010ContainerExecution(execution V010ContainerExecution, evidence V010ReleaseIdentityEvidence, policyDocument []byte) error {
+	if len(execution.RunID) != 32 || !isLowerHex(execution.RunID) ||
+		len(execution.ContainerID) != 64 || !isLowerHex(execution.ContainerID) {
+		return fmt.Errorf("v0.1 execution run and container identities are invalid")
+	}
+	prefix := "leapview-v010-" + execution.RunID
+	if execution.ContainerName != prefix || execution.NetworkName != prefix+"-network" ||
+		execution.StateVolumeName != prefix+"-state" {
+		return fmt.Errorf("v0.1 execution resource identities do not match the isolated run")
+	}
+	if execution.Image != evidence.Identity.Image || execution.ImageID != evidence.Artifact.ConfigDigest ||
+		execution.Platform != ReleasedV010Platform {
+		return fmt.Errorf("v0.1 execution container does not match the verified artifact identity")
+	}
+	if execution.StartedAt.IsZero() || execution.StoppedAt.Before(execution.StartedAt) ||
+		execution.StartedState != "running" || execution.StoppedState != "exited" ||
+		!execution.CleanShutdown || !execution.CleanupVerified {
+		return fmt.Errorf("v0.1 execution did not complete a clean isolated lifecycle")
+	}
+	if execution.Journey == nil {
+		return fmt.Errorf("v0.1 execution omitted the authentic application journey")
+	}
+	if err := validateV010ApplicationJourney(*execution.Journey, execution); err != nil {
+		return err
+	}
+	if execution.Preservation == nil {
+		return fmt.Errorf("v0.1 execution omitted stopped-state preservation evidence")
+	}
+	if err := validateV010PreservationEvidence(*execution.Preservation, *execution.Journey, execution, evidence); err != nil {
+		return err
+	}
+	if execution.FreshCandidate == nil {
+		return fmt.Errorf("v0.1 execution omitted fresh candidate denial evidence")
+	}
+	if err := validateV010FreshCandidateEvidence(*execution.FreshCandidate, execution, evidence, policyDocument); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateV010ApplicationJourney(journey V010ApplicationJourney, execution V010ContainerExecution) error {
+	if journey.StartedAt.Before(execution.StartedAt) || journey.ReadyAt.Before(journey.StartedAt) ||
+		journey.CompletedAt.Before(journey.ReadyAt) || execution.StoppedAt.Before(journey.CompletedAt) {
+		return fmt.Errorf("v0.1 application journey chronology is invalid")
+	}
+	if journey.AdminEmail != "fai-517-admin@qualification.invalid" ||
+		journey.UserEmail != "fai-517-user@qualification.invalid" || journey.ProjectID != "compatibility" ||
+		journey.Environment != "fai-517" || journey.AdminPrincipalID == "" || journey.UserPrincipalID == "" ||
+		journey.PublishID == "" || journey.ActivatedDigest == "" || journey.ProjectDigest == "" {
+		return fmt.Errorf("v0.1 application journey identities are incomplete")
+	}
+	if journey.ManagedDataRows != 3 || journey.SemanticResultSHA256 != v010ExpectedSemanticResultSHA256 ||
+		journey.DashboardResultSHA256 != v010ExpectedDashboardResultSHA256 ||
+		!journey.AuthenticationVerified || !journey.ProjectActivated || !journey.ManagedDataVerified || !journey.WorkloadVerified {
+		return fmt.Errorf("v0.1 application journey did not prove the deterministic workload")
+	}
+	return nil
+}
+
+func validateV010PreservationEvidence(
+	preservation V010PreservationEvidence,
+	journey V010ApplicationJourney,
+	execution V010ContainerExecution,
+	evidence V010ReleaseIdentityEvidence,
+) error {
+	if preservation.ObservedBeforeShutdownAt.Before(journey.CompletedAt) ||
+		preservation.ShutdownAt.Before(preservation.ObservedBeforeShutdownAt) ||
+		preservation.RestartedAt.Before(preservation.ShutdownAt) ||
+		preservation.ObservedAfterRestartAt.Before(preservation.RestartedAt) ||
+		execution.StoppedAt.Before(preservation.ObservedAfterRestartAt) {
+		return fmt.Errorf("v0.1 stopped-state preservation chronology is invalid")
+	}
+	if !preservation.RestartIdentityVerified || !preservation.StatePreserved {
+		return fmt.Errorf("v0.1 stopped-state preservation was not verified")
+	}
+	hash, err := V010StateInventorySHA256(preservation.Inventory)
+	if err != nil {
+		return err
+	}
+	if preservation.BeforeSHA256 != hash || preservation.AfterSHA256 != hash {
+		return fmt.Errorf("v0.1 before and after inventory checksums do not match the normalized inventory")
+	}
+	inventory := preservation.Inventory
+	if inventory.Application != (V010InventoryApplication{
+		Image: evidence.Identity.Image, ImageID: evidence.Artifact.ConfigDigest,
+		ContainerID: execution.ContainerID, Platform: ReleasedV010Platform,
+		SourceRevision: evidence.Provenance.SourceRevision,
+	}) {
+		return fmt.Errorf("v0.1 inventory application identity does not match the exact released artifact")
+	}
+	if len(inventory.Principals) != 2 ||
+		inventory.Principals[0].ID != journey.AdminPrincipalID ||
+		inventory.Principals[0].Email != journey.AdminEmail ||
+		inventory.Principals[1].ID != journey.UserPrincipalID ||
+		inventory.Principals[1].Email != journey.UserEmail {
+		return fmt.Errorf("v0.1 inventory principals do not match the authenticated journey")
+	}
+	if inventory.Project.ID != journey.ProjectID || inventory.Project.Title != "FAI-517 Compatibility" ||
+		inventory.Project.Environment != journey.Environment || inventory.Project.ActiveServingStateID == "" {
+		return fmt.Errorf("v0.1 inventory project or environment identity is incomplete")
+	}
+	if inventory.Publish.ID != journey.PublishID || inventory.Publish.ProjectID != journey.ProjectID ||
+		inventory.Publish.Environment != journey.Environment || inventory.Publish.Status != "active" ||
+		inventory.Publish.Digest != journey.ActivatedDigest {
+		return fmt.Errorf("v0.1 inventory published workload identity does not match the activated journey")
+	}
+	if inventory.ManagedDataRows != journey.ManagedDataRows ||
+		inventory.SemanticResultSHA256 != journey.SemanticResultSHA256 ||
+		inventory.DashboardResultSHA256 != journey.DashboardResultSHA256 {
+		return fmt.Errorf("v0.1 inventory query-visible managed data does not match the journey")
+	}
+	if err := validateV010InventoryAssets(inventory.Assets, inventory.Project.ActiveServingStateID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateV010InventoryAssets(assets []V010InventoryAsset, servingStateID string) error {
+	required := map[string]bool{
+		"source:qualification.orders":                false,
+		"model_table:compatibility.orders":           false,
+		"semantic_model:compatibility.compatibility": false,
+		"dashboard:compatibility.preservation":       false,
+	}
+	previous := ""
+	for _, asset := range assets {
+		key := asset.Type + ":" + asset.Key
+		if asset.ID == "" || asset.ContentHash == "" || asset.ServingStateID != servingStateID || key <= previous {
+			return fmt.Errorf("v0.1 inventory asset metadata is incomplete or not canonically ordered")
+		}
+		previous = key
+		if _, ok := required[key]; ok {
+			required[key] = true
+		}
+	}
+	for key, found := range required {
+		if !found {
+			return fmt.Errorf("v0.1 inventory omits required published asset %s", key)
+		}
+	}
+	return nil
+}
+
+func validateV010FreshCandidateEvidence(
+	fresh V010FreshCandidateEvidence,
+	execution V010ContainerExecution,
+	evidence V010ReleaseIdentityEvidence,
+	policyDocument []byte,
+) error {
+	if len(fresh.RunID) != 32 || !isLowerHex(fresh.RunID) || len(fresh.ContainerID) != 64 || !isLowerHex(fresh.ContainerID) {
+		return fmt.Errorf("fresh candidate run and container identities are invalid")
+	}
+	prefix := "leapview-v010-candidate-" + fresh.RunID
+	if fresh.ContainerName != prefix || fresh.NetworkName != prefix+"-network" || fresh.StateVolumeName != prefix+"-state" {
+		return fmt.Errorf("fresh candidate resources are not bound to the isolated run")
+	}
+	_, policy, policyDigest, err := releasedV010FromPolicy(policyDocument)
+	if err != nil {
+		return err
+	}
+	if fresh.PolicyVersion != evidence.PolicyVersion || fresh.PolicySHA256 != evidence.PolicySHA256 ||
+		fresh.PolicyVersion != policy.PolicyVersion || fresh.PolicySHA256 != policyDigest {
+		return fmt.Errorf("fresh candidate evidence is not bound to the exact transition policy")
+	}
+	candidateRelease, ok := policy.ReleaseByID(policy.CandidateRelease)
+	if !ok {
+		return fmt.Errorf("transition policy candidate release is unavailable")
+	}
+	wantCandidate := candidateRelease.IdentityForPlatform(ReleasedV010Platform)
+	if fresh.Predecessor != evidence.Identity || fresh.Candidate != wantCandidate || !validV010OCIDigest(fresh.CandidateImageID) {
+		return fmt.Errorf("fresh candidate evidence does not bind the exact predecessor and candidate artifacts")
+	}
+	wantFresh := policy.Evaluate(Request{Operation: OperationFreshInstall, Next: wantCandidate})
+	if !reflect.DeepEqual(fresh.FreshInstallDecision, wantFresh) || !fresh.FreshInstallDecision.Allowed ||
+		fresh.FreshInstallDecision.ReasonCode != ReasonAllowedFreshInstall {
+		return fmt.Errorf("fresh candidate evidence contains an invalid fresh-install decision")
+	}
+	for label, value := range map[string]string{
+		"fresh state before":         fresh.FreshStateBeforeSHA256,
+		"fresh state after":          fresh.FreshStateAfterSHA256,
+		"candidate before denials":   fresh.CandidateBeforeDenialsSHA256,
+		"candidate after denials":    fresh.CandidateAfterDenialsSHA256,
+		"predecessor before denials": fresh.PredecessorBeforeDenialsSHA256,
+		"predecessor after denials":  fresh.PredecessorAfterDenialsSHA256,
+	} {
+		if len(value) != 64 || !isLowerHex(value) {
+			return fmt.Errorf("fresh candidate %s checksum is invalid", label)
+		}
+	}
+	if fresh.FreshStateBeforeSHA256 == fresh.FreshStateAfterSHA256 ||
+		fresh.CandidateBeforeDenialsSHA256 != fresh.FreshStateAfterSHA256 ||
+		fresh.CandidateAfterDenialsSHA256 != fresh.CandidateBeforeDenialsSHA256 ||
+		fresh.PredecessorAfterDenialsSHA256 != fresh.PredecessorBeforeDenialsSHA256 {
+		return fmt.Errorf("fresh candidate or predecessor state changed during denied legacy adoption")
+	}
+	if fresh.StartedAt.Before(execution.StoppedAt) || fresh.CompletedAt.Before(fresh.StartedAt) ||
+		!fresh.CleanStateVerified || !fresh.LegacyStateUnavailable || !fresh.MutationFree || !fresh.CleanupVerified {
+		return fmt.Errorf("fresh candidate lifecycle did not prove isolated mutation-free qualification")
+	}
+	inventory := fresh.CandidateInventory
+	if inventory.AdminEmail != "fai-517-candidate@qualification.invalid" || strings.TrimSpace(inventory.AdminPrincipalID) == "" ||
+		inventory.LegacyPrincipalCount != 0 || inventory.DashboardCount != 0 || inventory.SemanticModelCount != 0 ||
+		inventory.LegacyProjectVisible || inventory.LegacyManagedDataVisible {
+		return fmt.Errorf("fresh candidate inventory contains preserved v0.1 state")
+	}
+	if len(fresh.Denials) != 3 {
+		return fmt.Errorf("fresh candidate evidence must contain all legacy-state denial scenarios")
+	}
+	wantUpgrade := policy.Evaluate(Request{Operation: OperationUpgrade, Current: evidence.Identity, Next: wantCandidate})
+	wantAdoption := policy.Evaluate(Request{Operation: OperationFreshInstall, Next: evidence.Identity})
+	wants := []struct {
+		scenario string
+		decision Decision
+		before   string
+	}{
+		{scenario: "preserved-state-mount", decision: wantUpgrade, before: fresh.PredecessorBeforeDenialsSHA256},
+		{scenario: "legacy-state-reference", decision: wantUpgrade, before: fresh.PredecessorBeforeDenialsSHA256},
+		{scenario: "direct-legacy-artifact-adoption", decision: wantAdoption, before: fresh.CandidateBeforeDenialsSHA256},
+	}
+	for index, want := range wants {
+		denial := fresh.Denials[index]
+		if denial.Scenario != want.scenario || denial.Operation != want.decision.Operation ||
+			denial.ReasonCode != want.decision.ReasonCode || want.decision.Allowed ||
+			denial.BeforeSHA256 != want.before || denial.AfterSHA256 != denial.BeforeSHA256 || !denial.DeniedBeforeMutation {
+			return fmt.Errorf("fresh candidate denial evidence for %s is invalid", want.scenario)
+		}
+	}
+	return nil
+}
+
+func validateResolvedV010Artifact(resolved V010ResolvedArtifact, identity ReleaseIdentity) error {
+	wantDigest := identity.Image[strings.LastIndex(identity.Image, "@")+1:]
+	for label, value := range map[string]string{
+		"resolved manifest": resolved.ResolvedDigest,
+		"platform manifest": resolved.PlatformManifestDigest,
+		"config":            resolved.ConfigDigest,
+	} {
+		if !validV010OCIDigest(value) {
+			return fmt.Errorf("v0.1 %s digest is invalid", label)
+		}
+	}
+	if resolved.Image != identity.Image || resolved.ResolvedDigest != wantDigest {
+		return fmt.Errorf("v0.1 registry manifest does not match the exact policy-declared immutable image")
+	}
+	if resolved.PlatformManifestDigest != ReleasedV010PlatformManifest || resolved.ConfigDigest != ReleasedV010ConfigDigest {
+		return fmt.Errorf("v0.1 platform manifest and config do not match the reviewed immutable OCI graph")
+	}
+	if resolved.Platform != ReleasedV010Platform || identity.Platform != ReleasedV010Platform {
+		return fmt.Errorf("v0.1 artifact platform must be %s", ReleasedV010Platform)
+	}
+	if !resolved.Authenticated {
+		return fmt.Errorf("v0.1 authentication-required artifact was not resolved with registry credentials")
+	}
+	if resolved.SourceRepository != ReleasedV010SourceRepository || resolved.SourceTag != ReleasedV010ID ||
+		resolved.Version != identity.Version || resolved.SourceRevision != identity.SourceRevision {
+		return fmt.Errorf("v0.1 OCI provenance does not match the reviewed source tag, repository, version, and revision")
+	}
+	return nil
+}
+
+func releasedV010FromPolicy(document []byte) (Release, *Policy, string, error) {
+	if len(document) == 0 {
+		return Release{}, nil, "", fmt.Errorf("v0.1 qualification requires the exact release-transition policy document")
+	}
+	policy, err := ParsePolicy(document)
+	if err != nil {
+		return Release{}, nil, "", err
+	}
+	release, ok := policy.ReleaseByID(ReleasedV010ID)
+	if !ok {
+		return Release{}, nil, "", fmt.Errorf("release-transition policy omits %s", ReleasedV010ID)
+	}
+	embedded, err := EmbeddedPolicy()
+	if err != nil {
+		return Release{}, nil, "", err
+	}
+	reviewed, ok := embedded.ReleaseByID(ReleasedV010ID)
+	if !ok {
+		return Release{}, nil, "", fmt.Errorf("checked-in release-transition policy omits %s", ReleasedV010ID)
+	}
+	if !reflect.DeepEqual(release, reviewed) {
+		return Release{}, nil, "", fmt.Errorf("release-transition policy v0.1 identity does not match the checked-in reviewed release")
+	}
+	if release.Distribution != "authentication-required" || len(release.Artifacts) != 1 ||
+		release.Artifacts[0].Platform != ReleasedV010Platform || release.Artifacts[0].Image != ReleasedV010Image {
+		return Release{}, nil, "", fmt.Errorf("checked-in v0.1 release identity is not the supported authentication-required linux/amd64 artifact")
+	}
+	digest := sha256.Sum256(document)
+	return release, policy, hex.EncodeToString(digest[:]), nil
+}
+
+func validV010OCIDigest(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") {
+		return false
+	}
+	encoded := strings.TrimPrefix(value, "sha256:")
+	decoded, err := hex.DecodeString(encoded)
+	return err == nil && len(decoded) == sha256.Size && encoded == strings.ToLower(encoded)
+}
+
+func compiledV010ArtifactEvidenceSchema() (*jsonschema.Schema, error) {
+	v010ArtifactEvidenceSchemaOnce.Do(func() {
+		document, err := jsonschema.UnmarshalJSON(bytes.NewReader(v010ArtifactEvidenceSchemaJSON))
+		if err != nil {
+			v010ArtifactEvidenceSchemaErr = fmt.Errorf("decode v0.1 artifact evidence schema: %w", err)
+			return
+		}
+		compiler := jsonschema.NewCompiler()
+		const schemaURL = "https://leapview.dev/schemas/v0.1-artifact-evidence.schema.json"
+		if err := compiler.AddResource(schemaURL, document); err != nil {
+			v010ArtifactEvidenceSchemaErr = fmt.Errorf("register v0.1 artifact evidence schema: %w", err)
+			return
+		}
+		v010ArtifactEvidenceSchema, v010ArtifactEvidenceSchemaErr = compiler.Compile(schemaURL)
+	})
+	return v010ArtifactEvidenceSchema, v010ArtifactEvidenceSchemaErr
+}

--- a/internal/platform/compatibility/v010_artifact_evidence.schema.json
+++ b/internal/platform/compatibility/v010_artifact_evidence.schema.json
@@ -1,0 +1,385 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://leapview.dev/schemas/v0.1-artifact-evidence.schema.json",
+  "title": "LeapView v0.1 released artifact identity evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "verifiedAt",
+    "policyVersion",
+    "policySha256",
+    "identity",
+    "artifact",
+    "provenance",
+    "result"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "leapview-v0.1-release-identity" },
+    "verifiedAt": { "type": "string", "format": "date-time" },
+    "policyVersion": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "policySha256": { "$ref": "#/$defs/sha256" },
+    "identity": { "$ref": "#/$defs/releaseIdentity" },
+    "artifact": { "$ref": "#/$defs/artifact" },
+    "provenance": { "$ref": "#/$defs/provenance" },
+    "execution": { "$ref": "#/$defs/execution" },
+    "result": { "const": "verified" }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "releaseIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["releaseId", "version", "sourceRevision", "image", "distribution", "platform"],
+      "properties": {
+        "releaseId": { "const": "v0.1.0" },
+        "version": { "const": "0.1.0" },
+        "sourceRevision": { "const": "5bf4aded574df459e80d81b77d1989ecd4fa7de0" },
+        "image": { "const": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153" },
+        "distribution": { "const": "authentication-required" },
+        "platform": { "const": "linux/amd64" }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "image", "resolvedDigest", "platform", "platformManifestDigest", "configDigest", "authenticated"],
+      "properties": {
+        "repository": { "const": "ghcr.io/yacobolo/libredash" },
+        "image": { "const": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153" },
+        "resolvedDigest": { "const": "sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153" },
+        "platform": { "const": "linux/amd64" },
+        "platformManifestDigest": { "const": "sha256:a8a60264b099c21eb46bf2ed8de1cca7f5867687d570ca2c6c3f9de4ad11018a" },
+        "configDigest": { "const": "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9" },
+        "authenticated": { "const": true }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceRepository", "sourceTag", "version", "sourceRevision"],
+      "properties": {
+        "sourceRepository": { "const": "https://github.com/Yacobolo/libredash" },
+        "sourceTag": { "const": "v0.1.0" },
+        "version": { "const": "0.1.0" },
+        "sourceRevision": { "const": "5bf4aded574df459e80d81b77d1989ecd4fa7de0" }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runId",
+        "containerId",
+        "containerName",
+        "image",
+        "imageId",
+        "platform",
+        "networkName",
+        "stateVolumeName",
+        "startedAt",
+        "stoppedAt",
+        "startedState",
+        "stoppedState",
+        "cleanShutdown",
+        "cleanupVerified",
+        "journey",
+        "preservation",
+        "freshCandidate"
+      ],
+      "properties": {
+        "runId": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+        "containerId": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "containerName": { "type": "string", "pattern": "^leapview-v010-[0-9a-f]{32}$" },
+        "image": { "const": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153" },
+        "imageId": { "const": "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9" },
+        "platform": { "const": "linux/amd64" },
+        "networkName": { "type": "string", "pattern": "^leapview-v010-[0-9a-f]{32}-network$" },
+        "stateVolumeName": { "type": "string", "pattern": "^leapview-v010-[0-9a-f]{32}-state$" },
+        "startedAt": { "type": "string", "format": "date-time" },
+        "stoppedAt": { "type": "string", "format": "date-time" },
+        "startedState": { "const": "running" },
+        "stoppedState": { "const": "exited" },
+        "cleanShutdown": { "const": true },
+        "cleanupVerified": { "const": true },
+        "journey": { "$ref": "#/$defs/journey" },
+        "preservation": { "$ref": "#/$defs/preservation" },
+        "freshCandidate": { "$ref": "#/$defs/freshCandidate" }
+      }
+    },
+    "journey": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "startedAt",
+        "readyAt",
+        "completedAt",
+        "adminEmail",
+        "adminPrincipalId",
+        "userEmail",
+        "userPrincipalId",
+        "projectId",
+        "environment",
+        "publishId",
+        "activatedDigest",
+        "projectDigest",
+        "managedDataRows",
+        "semanticResultSha256",
+        "dashboardResultSha256",
+        "authenticationVerified",
+        "projectActivated",
+        "managedDataVerified",
+        "workloadVerified"
+      ],
+      "properties": {
+        "startedAt": { "type": "string", "format": "date-time" },
+        "readyAt": { "type": "string", "format": "date-time" },
+        "completedAt": { "type": "string", "format": "date-time" },
+        "adminEmail": { "const": "fai-517-admin@qualification.invalid" },
+        "adminPrincipalId": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,128}$" },
+        "userEmail": { "const": "fai-517-user@qualification.invalid" },
+        "userPrincipalId": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,128}$" },
+        "projectId": { "const": "compatibility" },
+        "environment": { "const": "fai-517" },
+        "publishId": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,128}$" },
+        "activatedDigest": { "type": "string", "pattern": "^(sha256:)?[0-9a-f]{64}$" },
+        "projectDigest": { "type": "string", "pattern": "^(sha256:)?[0-9a-f]{64}$" },
+        "managedDataRows": { "const": 3 },
+        "semanticResultSha256": { "const": "21bc8a539aa05a0d97e07b294bfead69daaee6e6be3d15698efa2ed8d028c473" },
+        "dashboardResultSha256": { "const": "4e235add0e3c1f6c9a399981e981fdfd04f33c472a451b4516bb6a569a9a4ef9" },
+        "authenticationVerified": { "const": true },
+        "projectActivated": { "const": true },
+        "managedDataVerified": { "const": true },
+        "workloadVerified": { "const": true }
+      }
+    },
+    "preservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observedBeforeShutdownAt",
+        "shutdownAt",
+        "restartedAt",
+        "observedAfterRestartAt",
+        "inventory",
+        "beforeSha256",
+        "afterSha256",
+        "restartIdentityVerified",
+        "statePreserved"
+      ],
+      "properties": {
+        "observedBeforeShutdownAt": { "type": "string", "format": "date-time" },
+        "shutdownAt": { "type": "string", "format": "date-time" },
+        "restartedAt": { "type": "string", "format": "date-time" },
+        "observedAfterRestartAt": { "type": "string", "format": "date-time" },
+        "inventory": { "$ref": "#/$defs/inventory" },
+        "beforeSha256": { "$ref": "#/$defs/sha256" },
+        "afterSha256": { "$ref": "#/$defs/sha256" },
+        "restartIdentityVerified": { "const": true },
+        "statePreserved": { "const": true }
+      }
+    },
+    "inventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "application",
+        "principals",
+        "project",
+        "publish",
+        "assets",
+        "managedDataRows",
+        "semanticResultSha256",
+        "dashboardResultSha256"
+      ],
+      "properties": {
+        "application": { "$ref": "#/$defs/inventoryApplication" },
+        "principals": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "$ref": "#/$defs/inventoryPrincipal" }
+        },
+        "project": { "$ref": "#/$defs/inventoryProject" },
+        "publish": { "$ref": "#/$defs/inventoryPublish" },
+        "assets": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 256,
+          "items": { "$ref": "#/$defs/inventoryAsset" }
+        },
+        "managedDataRows": { "const": 3 },
+        "semanticResultSha256": { "const": "21bc8a539aa05a0d97e07b294bfead69daaee6e6be3d15698efa2ed8d028c473" },
+        "dashboardResultSha256": { "const": "4e235add0e3c1f6c9a399981e981fdfd04f33c472a451b4516bb6a569a9a4ef9" }
+      }
+    },
+    "inventoryApplication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["image", "imageId", "containerId", "platform", "sourceRevision"],
+      "properties": {
+        "image": { "const": "ghcr.io/yacobolo/libredash@sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153" },
+        "imageId": { "const": "sha256:fbeefbd98aebc862dee9204478e6c8dd30a54c760929bfe1d7e4236cfe63c8f9" },
+        "containerId": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "platform": { "const": "linux/amd64" },
+        "sourceRevision": { "const": "5bf4aded574df459e80d81b77d1989ecd4fa7de0" }
+      }
+    },
+    "inventoryPrincipal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "email", "displayName"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,128}$" },
+        "email": { "enum": ["fai-517-admin@qualification.invalid", "fai-517-user@qualification.invalid"] },
+        "displayName": { "type": "string", "minLength": 1, "maxLength": 128 }
+      }
+    },
+    "inventoryProject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "environment", "activeServingStateId"],
+      "properties": {
+        "id": { "const": "compatibility" },
+        "title": { "const": "FAI-517 Compatibility" },
+        "environment": { "const": "fai-517" },
+        "activeServingStateId": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,128}$" }
+      }
+    },
+    "inventoryPublish": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "projectId", "environment", "status", "digest"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,128}$" },
+        "projectId": { "const": "compatibility" },
+        "environment": { "const": "fai-517" },
+        "status": { "const": "active" },
+        "digest": { "type": "string", "pattern": "^(sha256:)?[0-9a-f]{64}$" }
+      }
+    },
+    "inventoryAsset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "key", "servingStateId", "contentHash"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "type": { "type": "string", "pattern": "^[a-z_]{1,64}$" },
+        "key": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,256}$" },
+        "servingStateId": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,128}$" },
+        "contentHash": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "genericReleaseIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["releaseId", "version", "sourceRevision", "image", "distribution", "platform"],
+      "properties": {
+        "releaseId": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "sourceRevision": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "image": { "type": "string", "pattern": "^[^@[:space:]]+@sha256:[0-9a-f]{64}$" },
+        "distribution": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "platform": { "const": "linux/amd64" }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "policyVersion", "operation", "allowed", "reasonCode", "remediation", "requirements", "current", "next"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "policyVersion": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "operation": { "enum": ["fresh-install", "upgrade", "rollback"] },
+        "allowed": { "type": "boolean" },
+        "reasonCode": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "remediation": { "type": "string", "maxLength": 512 },
+        "requirements": { "type": "array", "maxItems": 16, "items": { "type": "string", "minLength": 1, "maxLength": 128 } },
+        "current": {
+          "oneOf": [
+            { "$ref": "#/$defs/genericReleaseIdentity" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["image", "platform"],
+              "properties": {
+                "image": { "const": "" },
+                "platform": { "const": "" }
+              }
+            }
+          ]
+        },
+        "next": { "$ref": "#/$defs/genericReleaseIdentity" }
+      }
+    },
+    "freshCandidateInventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adminEmail", "adminPrincipalId", "legacyPrincipalCount", "dashboardCount", "semanticModelCount", "legacyProjectVisible", "legacyManagedDataVisible"],
+      "properties": {
+        "adminEmail": { "const": "fai-517-candidate@qualification.invalid" },
+        "adminPrincipalId": { "type": "string", "pattern": "^[A-Za-z0-9._:-]{1,128}$" },
+        "legacyPrincipalCount": { "const": 0 },
+        "dashboardCount": { "const": 0 },
+        "semanticModelCount": { "const": 0 },
+        "legacyProjectVisible": { "const": false },
+        "legacyManagedDataVisible": { "const": false }
+      }
+    },
+    "legacyDenial": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenario", "operation", "reasonCode", "beforeSha256", "afterSha256", "deniedBeforeMutation"],
+      "properties": {
+        "scenario": { "enum": ["preserved-state-mount", "legacy-state-reference", "direct-legacy-artifact-adoption"] },
+        "operation": { "enum": ["fresh-install", "upgrade"] },
+        "reasonCode": { "enum": ["transition.denied.fresh_install_only", "transition.denied.release_unknown"] },
+        "beforeSha256": { "$ref": "#/$defs/sha256" },
+        "afterSha256": { "$ref": "#/$defs/sha256" },
+        "deniedBeforeMutation": { "const": true }
+      }
+    },
+    "freshCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runId", "containerId", "containerName", "stateVolumeName", "networkName",
+        "predecessor", "candidate", "candidateImageId", "policyVersion", "policySha256",
+        "freshInstallDecision", "freshStateBeforeSha256", "freshStateAfterSha256",
+        "candidateBeforeDenialsSha256", "candidateAfterDenialsSha256",
+        "predecessorBeforeDenialsSha256", "predecessorAfterDenialsSha256",
+        "candidateInventory", "denials", "startedAt", "completedAt",
+        "cleanStateVerified", "legacyStateUnavailable", "mutationFree", "cleanupVerified"
+      ],
+      "properties": {
+        "runId": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+        "containerId": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "containerName": { "type": "string", "pattern": "^leapview-v010-candidate-[0-9a-f]{32}$" },
+        "stateVolumeName": { "type": "string", "pattern": "^leapview-v010-candidate-[0-9a-f]{32}-state$" },
+        "networkName": { "type": "string", "pattern": "^leapview-v010-candidate-[0-9a-f]{32}-network$" },
+        "predecessor": { "$ref": "#/$defs/releaseIdentity" },
+        "candidate": { "$ref": "#/$defs/genericReleaseIdentity" },
+        "candidateImageId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "policyVersion": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "policySha256": { "$ref": "#/$defs/sha256" },
+        "freshInstallDecision": { "$ref": "#/$defs/decision" },
+        "freshStateBeforeSha256": { "$ref": "#/$defs/sha256" },
+        "freshStateAfterSha256": { "$ref": "#/$defs/sha256" },
+        "candidateBeforeDenialsSha256": { "$ref": "#/$defs/sha256" },
+        "candidateAfterDenialsSha256": { "$ref": "#/$defs/sha256" },
+        "predecessorBeforeDenialsSha256": { "$ref": "#/$defs/sha256" },
+        "predecessorAfterDenialsSha256": { "$ref": "#/$defs/sha256" },
+        "candidateInventory": { "$ref": "#/$defs/freshCandidateInventory" },
+        "denials": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/legacyDenial" } },
+        "startedAt": { "type": "string", "format": "date-time" },
+        "completedAt": { "type": "string", "format": "date-time" },
+        "cleanStateVerified": { "const": true },
+        "legacyStateUnavailable": { "const": true },
+        "mutationFree": { "const": true },
+        "cleanupVerified": { "const": true }
+      }
+    }
+  }
+}

--- a/internal/platform/compatibility/v010_artifact_evidence_test.go
+++ b/internal/platform/compatibility/v010_artifact_evidence_test.go
@@ -1,0 +1,450 @@
+package compatibility
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+var validV010ResolvedArtifact = V010ResolvedArtifact{
+	Image:                  ReleasedV010Image,
+	ResolvedDigest:         "sha256:677caaf256cb3a0d61efd47b289debbd91984976a5a5c4b372196a5d79ce7153",
+	Platform:               ReleasedV010Platform,
+	PlatformManifestDigest: ReleasedV010PlatformManifest,
+	ConfigDigest:           ReleasedV010ConfigDigest,
+	Authenticated:          true,
+	SourceRepository:       ReleasedV010SourceRepository,
+	SourceTag:              ReleasedV010ID,
+	Version:                "0.1.0",
+	SourceRevision:         "5bf4aded574df459e80d81b77d1989ecd4fa7de0",
+}
+
+type recordingV010Resolver struct {
+	resolved V010ResolvedArtifact
+	err      error
+	requests []V010ArtifactResolutionRequest
+}
+
+func (r *recordingV010Resolver) ResolveExact(_ context.Context, request V010ArtifactResolutionRequest) (V010ResolvedArtifact, error) {
+	r.requests = append(r.requests, request)
+	if r.err != nil {
+		return V010ResolvedArtifact{}, r.err
+	}
+	return r.resolved, nil
+}
+
+func TestVerifyReleasedV010ArtifactUsesOnlyExactPolicyIdentity(t *testing.T) {
+	resolver := &recordingV010Resolver{resolved: validV010ResolvedArtifact}
+	verifiedAt := time.Date(2026, time.July, 13, 15, 45, 27, 0, time.UTC)
+	evidence, err := VerifyReleasedV010Artifact(context.Background(), V010ArtifactVerificationOptions{
+		PolicyDocument: EmbeddedPolicyDocument(),
+		Resolver:       resolver,
+		Now:            func() time.Time { return verifiedAt },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resolver.requests) != 1 {
+		t.Fatalf("registry resolution count = %d, want 1", len(resolver.requests))
+	}
+	request := resolver.requests[0]
+	if request.Image != ReleasedV010Image || request.Platform != ReleasedV010Platform || !request.RequireAuthentication {
+		t.Fatalf("registry request = %#v", request)
+	}
+	if evidence.Identity.Image != ReleasedV010Image || evidence.Artifact.ResolvedDigest != validV010ResolvedArtifact.ResolvedDigest ||
+		evidence.Provenance.SourceRevision != validV010ResolvedArtifact.SourceRevision || evidence.VerifiedAt != verifiedAt {
+		t.Fatalf("release identity evidence = %#v", evidence)
+	}
+	document, err := MarshalV010ReleaseIdentityEvidence(evidence, EmbeddedPolicyDocument())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ValidateV010ReleaseIdentityEvidence(document, EmbeddedPolicyDocument()); err != nil {
+		t.Fatalf("produced evidence did not satisfy owner validator: %v", err)
+	}
+}
+
+func TestVerifyReleasedV010ArtifactAcceptsCandidateBoundPolicyWithoutChangingLegacyIdentity(t *testing.T) {
+	base, err := EmbeddedPolicy()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, err := base.BindCandidate(ReleaseIdentity{
+		Version: "0.3.0", SourceRevision: strings.Repeat("c", 40),
+		Image: "ghcr.io/flidai/leapview@sha256:" + strings.Repeat("d", 64), Distribution: "public",
+	}, []string{"linux/amd64", "linux/arm64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := MarshalPolicy(bound)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := &recordingV010Resolver{resolved: validV010ResolvedArtifact}
+	if _, err := VerifyReleasedV010Artifact(context.Background(), V010ArtifactVerificationOptions{
+		PolicyDocument: document, Resolver: resolver,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyReleasedV010ArtifactFailsClosedWithoutRegistryProof(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{name: "missing credentials", err: errors.New("registry credentials unavailable")},
+		{name: "missing artifact", err: errors.New("registry manifest not found")},
+		{name: "registry unavailable", err: errors.New("registry request timed out")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := &recordingV010Resolver{err: test.err}
+			_, err := VerifyReleasedV010Artifact(context.Background(), V010ArtifactVerificationOptions{
+				PolicyDocument: EmbeddedPolicyDocument(), Resolver: resolver,
+			})
+			if err == nil || !strings.Contains(err.Error(), test.err.Error()) {
+				t.Fatalf("verification error = %v, want %q", err, test.err)
+			}
+			if len(resolver.requests) != 1 || resolver.requests[0].Image != ReleasedV010Image {
+				t.Fatalf("resolver attempted unexpected fallback: %#v", resolver.requests)
+			}
+		})
+	}
+}
+
+func TestVerifyReleasedV010ArtifactRejectsRegistryAndProvenanceMismatch(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*V010ResolvedArtifact)
+		want   string
+	}{
+		{name: "alternate namespace", mutate: func(value *V010ResolvedArtifact) {
+			value.Image = "ghcr.io/flidai/libredash@sha256:" + strings.Repeat("6", 64)
+		}, want: "exact policy-declared"},
+		{name: "mutable digest mismatch", mutate: func(value *V010ResolvedArtifact) { value.ResolvedDigest = "sha256:" + strings.Repeat("6", 64) }, want: "exact policy-declared"},
+		{name: "wrong platform", mutate: func(value *V010ResolvedArtifact) { value.Platform = "linux/arm64" }, want: "linux/amd64"},
+		{name: "unauthenticated", mutate: func(value *V010ResolvedArtifact) { value.Authenticated = false }, want: "registry credentials"},
+		{name: "wrong source", mutate: func(value *V010ResolvedArtifact) { value.SourceRepository = "https://github.com/flidai/leapview" }, want: "OCI provenance"},
+		{name: "wrong tag", mutate: func(value *V010ResolvedArtifact) { value.SourceTag = "v0.1" }, want: "OCI provenance"},
+		{name: "wrong version", mutate: func(value *V010ResolvedArtifact) { value.Version = "0.1.1" }, want: "OCI provenance"},
+		{name: "wrong revision", mutate: func(value *V010ResolvedArtifact) { value.SourceRevision = strings.Repeat("a", 40) }, want: "OCI provenance"},
+		{name: "invalid platform manifest digest", mutate: func(value *V010ResolvedArtifact) { value.PlatformManifestDigest = "not-a-digest" }, want: "platform manifest digest"},
+		{name: "invalid config digest", mutate: func(value *V010ResolvedArtifact) { value.ConfigDigest = "sha256:" + strings.Repeat("A", 64) }, want: "config digest"},
+		{name: "different platform manifest", mutate: func(value *V010ResolvedArtifact) { value.PlatformManifestDigest = "sha256:" + strings.Repeat("1", 64) }, want: "reviewed immutable OCI graph"},
+		{name: "different config", mutate: func(value *V010ResolvedArtifact) { value.ConfigDigest = "sha256:" + strings.Repeat("2", 64) }, want: "reviewed immutable OCI graph"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resolved := validV010ResolvedArtifact
+			test.mutate(&resolved)
+			resolver := &recordingV010Resolver{resolved: resolved}
+			_, err := VerifyReleasedV010Artifact(context.Background(), V010ArtifactVerificationOptions{
+				PolicyDocument: EmbeddedPolicyDocument(), Resolver: resolver,
+			})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("verification error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestVerifyReleasedV010ArtifactRejectsPolicySubstitutionBeforeRegistryAccess(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*Release)
+	}{
+		{name: "distribution", mutate: func(release *Release) { release.Distribution = "public" }},
+		{name: "source revision", mutate: func(release *Release) { release.SourceRevision = strings.Repeat("a", 40) }},
+		{name: "registry identity", mutate: func(release *Release) {
+			release.Artifacts[0].Image = "ghcr.io/flidai/libredash@sha256:" + strings.Repeat("6", 64)
+		}},
+		{name: "platform", mutate: func(release *Release) { release.Artifacts[0].Platform = "linux/arm64" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			policy, err := EmbeddedPolicy()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for index := range policy.Releases {
+				if policy.Releases[index].ID == ReleasedV010ID {
+					test.mutate(&policy.Releases[index])
+				}
+			}
+			document, err := MarshalPolicy(policy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resolver := &recordingV010Resolver{resolved: validV010ResolvedArtifact}
+			_, err = VerifyReleasedV010Artifact(context.Background(), V010ArtifactVerificationOptions{
+				PolicyDocument: document, Resolver: resolver,
+			})
+			if err == nil || !strings.Contains(err.Error(), "checked-in reviewed release") {
+				t.Fatalf("verification error = %v", err)
+			}
+			if len(resolver.requests) != 0 {
+				t.Fatalf("registry was accessed for substituted policy: %#v", resolver.requests)
+			}
+		})
+	}
+}
+
+func TestValidateV010ReleaseIdentityEvidenceFixture(t *testing.T) {
+	for _, path := range []string{
+		"testdata/v010-release-identity.valid.json",
+		"testdata/v010-release-identity.executed.valid.json",
+	} {
+		t.Run(path, func(t *testing.T) {
+			document, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			policyDocument := EmbeddedPolicyDocument()
+			if strings.Contains(path, ".executed.") {
+				policyDocument = v010CandidateBoundEvidencePolicy(t)
+			}
+			evidence, err := ValidateV010ReleaseIdentityEvidence(document, policyDocument)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if evidence.Artifact.PlatformManifestDigest != validV010ResolvedArtifact.PlatformManifestDigest ||
+				evidence.Artifact.ConfigDigest != validV010ResolvedArtifact.ConfigDigest {
+				t.Fatalf("fixture does not contain the observed released artifact digests: %#v", evidence.Artifact)
+			}
+		})
+	}
+}
+
+func TestValidateV010ReleaseIdentityEvidenceRejectsInvalidDocuments(t *testing.T) {
+	valid, err := os.ReadFile("testdata/v010-release-identity.valid.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]any)
+		want   string
+	}{
+		{name: "unknown field", mutate: func(value map[string]any) { value["fallbackImage"] = "libredash:local" }, want: "schema"},
+		{name: "policy digest mismatch", mutate: func(value map[string]any) { value["policySha256"] = strings.Repeat("0", 64) }, want: "supplied policy"},
+		{name: "alternate identity", mutate: func(value map[string]any) { value["identity"].(map[string]any)["distribution"] = "public" }, want: "schema"},
+		{name: "unauthenticated artifact", mutate: func(value map[string]any) { value["artifact"].(map[string]any)["authenticated"] = false }, want: "schema"},
+		{name: "wrong source tag", mutate: func(value map[string]any) { value["provenance"].(map[string]any)["sourceTag"] = "candidate" }, want: "schema"},
+		{name: "invalid config digest", mutate: func(value map[string]any) { value["artifact"].(map[string]any)["configDigest"] = "sha256:bad" }, want: "schema"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var value map[string]any
+			if err := json.Unmarshal(valid, &value); err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(value)
+			document, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = ValidateV010ReleaseIdentityEvidence(document, EmbeddedPolicyDocument())
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validation error = %v, want %q", err, test.want)
+			}
+		})
+	}
+
+	trailing := append(append([]byte(nil), valid...), []byte("\n{}")...)
+	if _, err := ValidateV010ReleaseIdentityEvidence(trailing, EmbeddedPolicyDocument()); err == nil {
+		t.Fatal("trailing evidence document was accepted")
+	}
+}
+
+func TestValidateV010ReleaseIdentityEvidenceRejectsForgedExecution(t *testing.T) {
+	valid, err := os.ReadFile("testdata/v010-release-identity.executed.valid.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "wrong image identity", mutate: func(execution map[string]any) { execution["imageId"] = "sha256:" + strings.Repeat("1", 64) }},
+		{name: "unclean shutdown", mutate: func(execution map[string]any) { execution["cleanShutdown"] = false }},
+		{name: "cleanup not verified", mutate: func(execution map[string]any) { execution["cleanupVerified"] = false }},
+		{name: "impossible chronology", mutate: func(execution map[string]any) { execution["stoppedAt"] = "2026-07-13T15:45:26Z" }},
+		{name: "resource identity mismatch", mutate: func(execution map[string]any) {
+			execution["networkName"] = "leapview-v010-" + strings.Repeat("f", 32) + "-network"
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var value map[string]any
+			if err := json.Unmarshal(valid, &value); err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(value["execution"].(map[string]any))
+			document, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ValidateV010ReleaseIdentityEvidence(document, v010CandidateBoundEvidencePolicy(t)); err == nil {
+				t.Fatal("forged execution evidence was accepted")
+			}
+		})
+	}
+}
+
+func TestValidateV010ReleaseIdentityEvidenceRejectsForgedApplicationJourney(t *testing.T) {
+	valid, err := os.ReadFile("testdata/v010-release-identity.executed.valid.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "authentication not verified", mutate: func(journey map[string]any) { journey["authenticationVerified"] = false }},
+		{name: "wrong managed data", mutate: func(journey map[string]any) { journey["managedDataRows"] = 2.0 }},
+		{name: "semantic result mismatch", mutate: func(journey map[string]any) { journey["semanticResultSha256"] = strings.Repeat("0", 64) }},
+		{name: "dashboard result mismatch", mutate: func(journey map[string]any) { journey["dashboardResultSha256"] = strings.Repeat("0", 64) }},
+		{name: "completion before readiness", mutate: func(journey map[string]any) { journey["completedAt"] = "2026-07-13T15:45:27Z" }},
+		{name: "credential field", mutate: func(journey map[string]any) { journey["temporaryPassword"] = "secret" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var value map[string]any
+			if err := json.Unmarshal(valid, &value); err != nil {
+				t.Fatal(err)
+			}
+			journey := value["execution"].(map[string]any)["journey"].(map[string]any)
+			test.mutate(journey)
+			document, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ValidateV010ReleaseIdentityEvidence(document, v010CandidateBoundEvidencePolicy(t)); err == nil {
+				t.Fatal("forged application journey evidence was accepted")
+			}
+		})
+	}
+}
+
+func TestValidateV010ReleaseIdentityEvidenceRejectsForgedStoppedStateInventory(t *testing.T) {
+	valid, err := os.ReadFile("testdata/v010-release-identity.executed.valid.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]any)
+		rehash bool
+	}{
+		{name: "missing principal", mutate: func(inventory map[string]any) {
+			inventory["principals"] = inventory["principals"].([]any)[:1]
+		}, rehash: true},
+		{name: "altered project", mutate: func(inventory map[string]any) {
+			inventory["project"].(map[string]any)["title"] = "Forged Project"
+		}, rehash: true},
+		{name: "altered managed metadata without matching checksum", mutate: func(inventory map[string]any) {
+			inventory["assets"].([]any)[3].(map[string]any)["contentHash"] = strings.Repeat("0", 64)
+		}},
+		{name: "missing published workload", mutate: func(inventory map[string]any) {
+			inventory["publish"].(map[string]any)["id"] = "publish_missing"
+		}, rehash: true},
+		{name: "forged application identity with recomputed checksums", mutate: func(inventory map[string]any) {
+			inventory["application"].(map[string]any)["containerId"] = strings.Repeat("f", 64)
+		}, rehash: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var value map[string]any
+			if err := json.Unmarshal(valid, &value); err != nil {
+				t.Fatal(err)
+			}
+			preservation := value["execution"].(map[string]any)["preservation"].(map[string]any)
+			inventory := preservation["inventory"].(map[string]any)
+			test.mutate(inventory)
+			if test.rehash {
+				document, err := json.Marshal(inventory)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var typed V010StateInventory
+				if err := json.Unmarshal(document, &typed); err != nil {
+					t.Fatal(err)
+				}
+				hash, err := V010StateInventorySHA256(typed)
+				if err != nil {
+					t.Fatal(err)
+				}
+				preservation["beforeSha256"] = hash
+				preservation["afterSha256"] = hash
+			}
+			document, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ValidateV010ReleaseIdentityEvidence(document, v010CandidateBoundEvidencePolicy(t)); err == nil {
+				t.Fatal("forged stopped-state inventory evidence was accepted")
+			}
+		})
+	}
+}
+
+func TestValidateV010ReleaseIdentityEvidenceRejectsForgedFreshCandidateDenial(t *testing.T) {
+	valid, err := os.ReadFile("testdata/v010-release-identity.executed.valid.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "candidate identity", mutate: func(fresh map[string]any) {
+			fresh["candidate"].(map[string]any)["image"] = "ghcr.io/flidai/leapview@sha256:" + strings.Repeat("5", 64)
+		}},
+		{name: "fresh decision", mutate: func(fresh map[string]any) {
+			fresh["freshInstallDecision"].(map[string]any)["reasonCode"] = ReasonDeniedNoExplicitRule
+		}},
+		{name: "denial reason", mutate: func(fresh map[string]any) {
+			fresh["denials"].([]any)[0].(map[string]any)["reasonCode"] = ReasonDeniedUnknownRelease
+		}},
+		{name: "forged matching denial checksums", mutate: func(fresh map[string]any) {
+			denial := fresh["denials"].([]any)[0].(map[string]any)
+			denial["beforeSha256"] = strings.Repeat("4", 64)
+			denial["afterSha256"] = strings.Repeat("4", 64)
+		}},
+		{name: "mutation proof disabled", mutate: func(fresh map[string]any) { fresh["mutationFree"] = false }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var value map[string]any
+			if err := json.Unmarshal(valid, &value); err != nil {
+				t.Fatal(err)
+			}
+			fresh := value["execution"].(map[string]any)["freshCandidate"].(map[string]any)
+			test.mutate(fresh)
+			document, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ValidateV010ReleaseIdentityEvidence(document, v010CandidateBoundEvidencePolicy(t)); err == nil {
+				t.Fatal("forged fresh-candidate denial evidence was accepted")
+			}
+		})
+	}
+}
+
+func v010CandidateBoundEvidencePolicy(t *testing.T) []byte {
+	t.Helper()
+	base, err := EmbeddedPolicy()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, err := base.BindCandidate(ReleaseIdentity{
+		Version: "0.2.0-rc.2", SourceRevision: strings.Repeat("4", 40),
+		Image: "ghcr.io/flidai/leapview@sha256:" + strings.Repeat("4", 64), Distribution: "public",
+	}, []string{"linux/amd64", "linux/arm64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := MarshalPolicy(bound)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return document
+}


### PR DESCRIPTION
## Summary

Implements executable v0.1 preservation/fresh-install qualification.

## Delivered

- Exact v0.1 artifact provenance validation
- Authenticated OCI resolution
- Isolated v0.1 runtime execution
- Real v0.1 application journey
- Preservation inventory validation
- Fresh candidate qualification
- Legacy state denial proof
- Release qualification workflow integration
- Operator documentation

## Verification

Passed:

- task test:ubdr:v0.1-artifact
- task test:ubdr:transition-policy
- task docs:check
- task generated:check
- go test ./internal/platform/architecture -count=1

## Scope

No changes to:

- recovery ledger
- scheduling
- migration behavior
- installer behavior
- unrelated evidence formats