### PR TITLE
Establish canonical HTTP request correlation identities

### DIFF
--- a/docs/articles/operate/observability.md
+++ b/docs/articles/operate/observability.md
@@ -28,7 +28,7 @@ Collect structured application logs from the service output. Preserve timestamp,
 
 Secrets, bearer tokens, passwords, raw OAuth payloads, and sensitive query data must not appear in logs. Restrict log access according to the most sensitive metadata retained.
 
-Carry a request identifier through the trusted reverse proxy and application. Proxy access logs and application logs should agree on public request time, status, and correlation identity.
+LeapView establishes `X-Request-ID` and `X-Correlation-ID` before process-wide middleware and route handling. A non-empty client request ID is preserved for idempotency compatibility; otherwise LeapView generates one. A missing correlation ID defaults to the request ID. Both canonical values are returned in response headers, including responses rejected by early security middleware, so proxy and application logs can agree on public request time, status, and correlation identity.
 
 ## Delivery signals
 

--- a/internal/agent/http/command_audit.go
+++ b/internal/agent/http/command_audit.go
@@ -11,6 +11,7 @@ import (
 	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
 	"github.com/flidai/leapview/internal/agent"
 	agentgen "github.com/flidai/leapview/internal/agent/api/gen"
+	httpmiddleware "github.com/flidai/leapview/internal/platform/http/middleware"
 	"github.com/flidai/leapview/internal/platform/web/uicommand"
 )
 
@@ -139,7 +140,7 @@ func (h *Handler) recordLegacyCommandAudit(r *stdhttp.Request, operationID agent
 // one. The operation-specific idempotency key is derived from this identity
 // by beginUICommandInvocation.
 func uiRequestIdentity(r *stdhttp.Request, input string) string {
-	if value := firstNonEmptyHeader(r, "X-Request-Id", "X-Request-ID"); value != "" {
+	if value := firstNonEmptyHeader(r, "X-Request-Id", "X-Request-ID"); value != "" && !httpmiddleware.RequestIDWasGenerated(r) {
 		return value
 	}
 	clientID := "default"

--- a/internal/agent/http/command_audit_test.go
+++ b/internal/agent/http/command_audit_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/flidai/leapview/internal/agent"
 	agentsqlite "github.com/flidai/leapview/internal/agent/sqlite"
 	"github.com/flidai/leapview/internal/platform"
+	httpmiddleware "github.com/flidai/leapview/internal/platform/http/middleware"
 	"github.com/flidai/leapview/internal/platform/web/uicommand"
 	agentcore "github.com/flidai/leapview/pkg/agent"
 	"github.com/go-chi/chi/v5"
@@ -187,6 +188,29 @@ func TestAgentUICommandInvocationUsesStableGeneratedIdentity(t *testing.T) {
 		// The second invocation should replace the context state with the run
 		// operation while preserving the same request identity.
 		t.Fatalf("run operation ID = %q/%v", operationID, ok)
+	}
+}
+
+func TestAgentUICommandIdentityIgnoresGeneratedCorrelationRequestID(t *testing.T) {
+	var identities []string
+	var requestIDs []string
+	handler := httpmiddleware.RequestCorrelation(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identities = append(identities, uiRequestIdentity(r, "hello"))
+		requestIDs = append(requestIDs, r.Header.Get("X-Request-ID"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	for range 2 {
+		request := httptest.NewRequest(http.MethodPost, "/chats/turns", nil)
+		request.AddCookie(&http.Cookie{Name: "pagestream_client_id", Value: "client-fixed"})
+		handler.ServeHTTP(httptest.NewRecorder(), request)
+	}
+
+	if identities[0] != identities[1] || !strings.HasPrefix(identities[0], "ui_") {
+		t.Fatalf("retry identities = %#v, want one stable UI identity", identities)
+	}
+	if requestIDs[0] == requestIDs[1] || !strings.HasPrefix(requestIDs[0], "req_") || !strings.HasPrefix(requestIDs[1], "req_") {
+		t.Fatalf("canonical request IDs = %#v, want distinct generated identities", requestIDs)
 	}
 }
 

--- a/internal/app/middleware_active_test.go
+++ b/internal/app/middleware_active_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	accessmodule "github.com/flidai/leapview/internal/access/module"
+	"github.com/flidai/leapview/internal/platform/observability"
+	"github.com/go-chi/chi/v5"
 )
 
 func TestHealthRoutesRemainUnauthenticated(t *testing.T) {
@@ -23,6 +25,33 @@ func TestHealthRoutesRemainUnauthenticated(t *testing.T) {
 		if got := response.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
 			t.Fatalf("%s Content-Type = %q, want application/json", path, got)
 		}
+	}
+}
+
+func TestCorrelationIdentitySurvivesEarlyMiddlewareFailure(t *testing.T) {
+	mux := chi.NewRouter()
+	mountRouterMiddleware(mux, routerMiddlewareDependencies{
+		telemetry:    observability.New(),
+		allowedHosts: []string{"app.example.com"},
+	})
+	mux.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	request.Host = "unexpected.example.com"
+	response := httptest.NewRecorder()
+
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusMisdirectedRequest)
+	}
+	requestID := response.Header().Get("X-Request-ID")
+	if !strings.HasPrefix(requestID, "req_") {
+		t.Fatalf("response request ID = %q, want generated req_ identity", requestID)
+	}
+	if got := response.Header().Get("X-Correlation-ID"); got != requestID {
+		t.Fatalf("response correlation ID = %q, want request ID %q", got, requestID)
 	}
 }
 

--- a/internal/app/runtime_router_routes.go
+++ b/internal/app/runtime_router_routes.go
@@ -82,6 +82,7 @@ type staticRouteDependencies struct {
 // separate from capability route mounting makes the order of security
 // middleware explicit and prevents feature modules from silently changing it.
 func mountRouterMiddleware(mux *chi.Mux, dependencies routerMiddlewareDependencies) {
+	mux.Use(apihttpmiddleware.RequestCorrelation)
 	if dependencies.requestLogging {
 		mux.Use(apihttpmiddleware.RequestLogger(dependencies.logger))
 	}

--- a/internal/dashboard/http/builder.go
+++ b/internal/dashboard/http/builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/flidai/leapview/internal/dashboard/authoring/sourceadapter"
 	"github.com/flidai/leapview/internal/dashboard/ui"
 	uisignals "github.com/flidai/leapview/internal/dashboard/ui/signals"
+	httpmiddleware "github.com/flidai/leapview/internal/platform/http/middleware"
 	httptransport "github.com/flidai/leapview/internal/platform/http/transport"
 	webpage "github.com/flidai/leapview/internal/platform/web/page"
 	webtransport "github.com/flidai/leapview/internal/platform/web/transport"
@@ -401,7 +402,7 @@ func (s dashboardBuilderCommandSignal) authoringCommand(r *nethttp.Request, acto
 		return authoring.Command{}, err
 	}
 	requestID := strings.TrimSpace(r.Header.Get("X-Request-ID"))
-	if requestID == "" {
+	if requestID == "" || httpmiddleware.RequestIDWasGenerated(r) {
 		requestID = strings.TrimSpace(r.Header.Get("Idempotency-Key"))
 	}
 	if requestID == "" {

--- a/internal/dashboard/http/builder_test.go
+++ b/internal/dashboard/http/builder_test.go
@@ -22,6 +22,7 @@ import (
 	visualizationdefinition "github.com/flidai/leapview/internal/dashboard/visualization/definition"
 	visualizationir "github.com/flidai/leapview/internal/dashboard/visualization/ir"
 	visualizationruntime "github.com/flidai/leapview/internal/dashboard/visualization/runtime"
+	httpmiddleware "github.com/flidai/leapview/internal/platform/http/middleware"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	"github.com/go-chi/chi/v5"
 )
@@ -189,6 +190,35 @@ func TestDashboardBuilderCommandRoutesBuilderIntentsWithServerGeneratedIDs(t *te
 	}
 	if fake.executed.AddVisual.VisualID != "" || fake.executed.AddVisual.ComponentID != "" || fake.executed.AddVisual.Type != "bar" {
 		t.Fatalf("server-generated visual IDs were not preserved: %#v", fake.executed.AddVisual)
+	}
+}
+
+func TestDashboardBuilderCommandPreservesIdempotencyFallbackWithGeneratedRequestID(t *testing.T) {
+	fake := &builderAuthoringFake{}
+	handler := Handler{Authoring: fake, CurrentPrincipalID: func(*nethttp.Request) string { return "principal-1" }}
+	correlated := httpmiddleware.RequestCorrelation(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		handler.DashboardBuilderCommand(w, withBuilderURLParams(r, "sales", "revenue"))
+	}))
+
+	for range 2 {
+		req := builderRequest(nethttp.MethodPost, "/dashboards/revenue/draft/command", map[string]any{"builderCommand": map[string]any{
+			"dashboardId": "revenue", "draftId": "draft-1", "revisionId": "revision-1", "revisionNumber": "1", "revisionContentHash": "sha256:" + strings.Repeat("a", 64), "action": "publish",
+		}})
+		req.Header.Set("X-LeapView-Operation-ID", dashboardBuilderOperationID)
+		req.Header.Set("Idempotency-Key", "builder-retry-1")
+		rec := httptest.NewRecorder()
+
+		correlated.ServeHTTP(rec, req)
+
+		if rec.Code != nethttp.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		if fake.executed.ID != "builder-retry-1" {
+			t.Fatalf("command ID = %q, want stable Idempotency-Key fallback", fake.executed.ID)
+		}
+		if got := rec.Header().Get("X-Request-ID"); !strings.HasPrefix(got, "req_") {
+			t.Fatalf("response request ID = %q, want generated correlation identity", got)
+		}
 	}
 }
 

--- a/internal/platform/http/middleware/middleware.go
+++ b/internal/platform/http/middleware/middleware.go
@@ -2,6 +2,7 @@ package httpmiddleware
 
 import (
 	"bufio"
+	"context"
 	"log/slog"
 	"net"
 	"net/http"
@@ -14,6 +15,8 @@ import (
 )
 
 const DefaultMaxRequestBodyBytes int64 = 128 << 20
+
+type generatedRequestIDContextKey struct{}
 
 type RateLimitConfig struct {
 	Enabled             bool
@@ -312,6 +315,7 @@ func SecurityHeadersMiddleware(config SecurityHeadersConfig) func(http.Handler) 
 func RequestCorrelation(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestID := strings.TrimSpace(r.Header.Get("X-Request-ID"))
+		generatedRequestID := requestID == ""
 		if requestID == "" {
 			requestID = apitransport.NewRequestID()
 		}
@@ -324,8 +328,21 @@ func RequestCorrelation(next http.Handler) http.Handler {
 		r.Header.Set("X-Correlation-ID", correlationID)
 		w.Header().Set("X-Request-ID", requestID)
 		w.Header().Set("X-Correlation-ID", correlationID)
+		if generatedRequestID {
+			r = r.WithContext(context.WithValue(r.Context(), generatedRequestIDContextKey{}, true))
+		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// RequestIDWasGenerated reports whether RequestCorrelation supplied the
+// request ID instead of preserving a client-provided identity.
+func RequestIDWasGenerated(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	generated, _ := r.Context().Value(generatedRequestIDContextKey{}).(bool)
+	return generated
 }
 
 func RequestLogger(logger *slog.Logger) func(http.Handler) http.Handler {

--- a/internal/platform/http/middleware/middleware.go
+++ b/internal/platform/http/middleware/middleware.go
@@ -306,6 +306,28 @@ func SecurityHeadersMiddleware(config SecurityHeadersConfig) func(http.Handler) 
 	}
 }
 
+// RequestCorrelation establishes one request and correlation identity before
+// any other process-wide middleware runs. Existing request identities are
+// preserved because browser commands also use them for idempotency.
+func RequestCorrelation(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := strings.TrimSpace(r.Header.Get("X-Request-ID"))
+		if requestID == "" {
+			requestID = apitransport.NewRequestID()
+		}
+		correlationID := strings.TrimSpace(r.Header.Get("X-Correlation-ID"))
+		if correlationID == "" {
+			correlationID = requestID
+		}
+
+		r.Header.Set("X-Request-ID", requestID)
+		r.Header.Set("X-Correlation-ID", correlationID)
+		w.Header().Set("X-Request-ID", requestID)
+		w.Header().Set("X-Correlation-ID", correlationID)
+		next.ServeHTTP(w, r)
+	})
+}
+
 func RequestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 	if logger == nil {
 		logger = slog.Default()

--- a/internal/platform/http/middleware/middleware_active_test.go
+++ b/internal/platform/http/middleware/middleware_active_test.go
@@ -223,6 +223,9 @@ func TestRequestCorrelationGeneratesAndPropagatesIdentity(t *testing.T) {
 	handler := RequestCorrelation(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestID = r.Header.Get("X-Request-ID")
 		correlationID = r.Header.Get("X-Correlation-ID")
+		if !RequestIDWasGenerated(r) {
+			t.Fatal("request ID was not marked as generated")
+		}
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	response := httptest.NewRecorder()
@@ -245,6 +248,9 @@ func TestRequestCorrelationGeneratesAndPropagatesIdentity(t *testing.T) {
 
 func TestRequestCorrelationPreservesClientIdentity(t *testing.T) {
 	handler := RequestCorrelation(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if RequestIDWasGenerated(r) {
+			t.Fatal("client request ID was marked as generated")
+		}
 		if got := r.Header.Get("X-Request-ID"); got != "client-request" {
 			t.Fatalf("request ID = %q, want client-request", got)
 		}

--- a/internal/platform/http/middleware/middleware_active_test.go
+++ b/internal/platform/http/middleware/middleware_active_test.go
@@ -218,27 +218,76 @@ func TestSecurityHeadersPreserveHandlerOwnedCSP(t *testing.T) {
 	}
 }
 
+func TestRequestCorrelationGeneratesAndPropagatesIdentity(t *testing.T) {
+	var requestID, correlationID string
+	handler := RequestCorrelation(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID = r.Header.Get("X-Request-ID")
+		correlationID = r.Header.Get("X-Correlation-ID")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !strings.HasPrefix(requestID, "req_") {
+		t.Fatalf("request ID = %q, want generated req_ identity", requestID)
+	}
+	if correlationID != requestID {
+		t.Fatalf("correlation ID = %q, want request ID %q", correlationID, requestID)
+	}
+	if got := response.Header().Get("X-Request-ID"); got != requestID {
+		t.Fatalf("response request ID = %q, want %q", got, requestID)
+	}
+	if got := response.Header().Get("X-Correlation-ID"); got != correlationID {
+		t.Fatalf("response correlation ID = %q, want %q", got, correlationID)
+	}
+}
+
+func TestRequestCorrelationPreservesClientIdentity(t *testing.T) {
+	handler := RequestCorrelation(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Request-ID"); got != "client-request" {
+			t.Fatalf("request ID = %q, want client-request", got)
+		}
+		if got := r.Header.Get("X-Correlation-ID"); got != "client-correlation" {
+			t.Fatalf("correlation ID = %q, want client-correlation", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("X-Request-ID", "client-request")
+	request.Header.Set("X-Correlation-ID", "client-correlation")
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	if got := response.Header().Get("X-Request-ID"); got != "client-request" {
+		t.Fatalf("response request ID = %q, want client-request", got)
+	}
+	if got := response.Header().Get("X-Correlation-ID"); got != "client-correlation" {
+		t.Fatalf("response correlation ID = %q, want client-correlation", got)
+	}
+}
+
 func TestRequestLoggerOmitsSensitiveHeadersAndValues(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	handler := RequestLogger(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := RequestCorrelation(RequestLogger(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte("ok"))
-	}))
-	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	})))
+	request := httptest.NewRequest(http.MethodGet, "/?token=secret-query", nil)
 	request.Header.Set("Authorization", "Bearer secret-token")
 	request.Header.Set("X-Request-ID", "req_123")
-	request.Header.Set("X-Correlation-ID", "corr_456")
 	request.AddCookie(&http.Cookie{Name: "lv_session", Value: "secret-session"})
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 
 	logged := logs.String()
-	for _, want := range []string{"method=GET", "path=/", "status=200", "duration=", "bytes=2", "request_id=req_123", "correlation_id=corr_456"} {
+	for _, want := range []string{"method=GET", "path=/", "status=200", "duration=", "bytes=2", "request_id=req_123", "correlation_id=req_123"} {
 		if !strings.Contains(logged, want) {
 			t.Fatalf("log %q missing %q", logged, want)
 		}
 	}
-	for _, secret := range []string{"secret-token", "secret-session", "Authorization", "Cookie"} {
+	for _, secret := range []string{"secret-token", "secret-session", "secret-query", "Authorization", "Cookie"} {
 		if strings.Contains(logged, secret) {
 			t.Fatalf("log %q contains sensitive value %q", logged, secret)
 		}


### PR DESCRIPTION
## Problem

HTTP request and correlation identities were established only in route-specific paths, so process-wide logging, telemetry, panic recovery, security rejections, and other early responses could not rely on one canonical identity contract.

Linear: https://linear.app/flid/issue/FAI-552/establish-canonical-http-request-correlation-identities

## Root cause

Request identity preparation happened after the outer router middleware stack. Ordinary requests without client IDs and requests rejected before route handling therefore had no consistently propagated identifiers.

## Solution

- Add one centralized request-correlation middleware as the first router middleware.
- Preserve non-empty client-provided request and correlation IDs.
- Generate a request ID when absent and use it as the fallback correlation ID.
- Set canonical IDs on the downstream request and response before logging, telemetry, panic recovery, security middleware, and route handling.
- Retain whether the request ID was generated in private request context so existing builder and agent retry identities continue using their stable idempotency fallbacks.
- Document only the new correlation contract.

## Tests added/updated

- Generated request and fallback correlation IDs.
- Preserved client request and correlation IDs.
- Response-header propagation.
- Propagation through an early allowed-host rejection.
- Request logger fallback identity and sensitive header, cookie, and query-value exclusion.
- Dashboard builder Idempotency-Key fallback across generated correlation IDs.
- Agent UI deterministic retry identity across generated correlation IDs.

## Verification performed

- `go test ./internal/platform/http/middleware ./internal/dashboard/http ./internal/agent/http`
- `go test ./internal/app -run ^(TestCorrelationIdentitySurvivesEarlyMiddlewareFailure|TestUpdatesLoginBootstrapStreamsOnceWithoutAuthAndReturns|TestJourneyQualificationAssembledRouter)$ -count=1`
- `go test ./internal/app/api/protocol -run ^(TestBrowserMutationMiddleware|TestPrepareRequest) -count=1`
- `go vet ./internal/platform/http/middleware ./internal/dashboard/http ./internal/agent/http ./internal/app/api/protocol`
- `go test -race ./internal/platform/http/middleware -count=1`
- Focused race tests for the dashboard-builder and agent retry-identity regressions.
- `task generate`
- `git diff --check`

The full local `task ci` contract was attempted but could not complete in this environment because temporary build storage reached its quota, the APIGen temporary consumer could not obtain VCS stamping, and Chromium timed out/crashed. The prior PR head passed every GitHub Actions CI and security check; checks for the review-fix head are running.

## Remaining limitations

This PR intentionally does not add OpenTelemetry changes, alerts or SLOs, synthetic monitoring, or background-job correlation. Those remain separate project work.