### PR TITLE
Establish canonical inbound W3C trace context

### DIFF
--- a/docs/articles/operate/observability.md
+++ b/docs/articles/operate/observability.md
@@ -30,6 +30,8 @@ Secrets, bearer tokens, passwords, raw OAuth payloads, and sensitive query data 
 
 LeapView establishes `X-Request-ID` and `X-Correlation-ID` before process-wide middleware and route handling. A non-empty client request ID is preserved for idempotency compatibility; otherwise LeapView generates one. A missing correlation ID defaults to the request ID. Both canonical values are returned in response headers, including responses rejected by early security middleware, so proxy and application logs can agree on public request time, status, and correlation identity.
 
+When an upstream service supplies valid W3C `traceparent` and `tracestate` headers, LeapView validates and carries that remote trace context through the request. Request and panic logs add the parsed `trace_id` and `upstream_span_id`; they never log the raw trace headers, baggage, authorization, cookies, query values, or request bodies. Missing or malformed trace context is ignored without rejecting the request or generating a trace ID, and the request ID remains LeapView's local correlation identity. This contract does not create spans, sample traces, or export telemetry.
+
 ## Delivery signals
 
 Track project deployment IDs, environment, acting principal, candidate validation results, managed revision pins, activation outcome, and active deployment. Uploading an artifact or staging a data revision is not the same as successful activation.

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,8 @@ require (
 	github.com/tus/tusd/v2 v2.10.0
 	github.com/yuin/goldmark v1.7.17
 	github.com/zalando/go-keyring v0.2.8
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/image v0.45.0
 	golang.org/x/mod v0.40.0
 	golang.org/x/net v0.58.0
@@ -193,14 +195,12 @@ require (
 	go.opentelemetry.io/contrib/propagators/b3 v1.21.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.21.1 // indirect
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.15.1 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0 // indirect
 	go.opentelemetry.io/otel/exporters/zipkin v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/internal/app/middleware_active_test.go
+++ b/internal/app/middleware_active_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -29,16 +31,27 @@ func TestHealthRoutesRemainUnauthenticated(t *testing.T) {
 }
 
 func TestCorrelationIdentitySurvivesEarlyMiddlewareFailure(t *testing.T) {
+	const (
+		traceID        = "0af7651916cd43dd8448eb211c80319c"
+		upstreamSpanID = "b7ad6b7169203331"
+		traceparent    = "00-" + traceID + "-" + upstreamSpanID + "-01"
+	)
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
 	mux := chi.NewRouter()
 	mountRouterMiddleware(mux, routerMiddlewareDependencies{
-		telemetry:    observability.New(),
-		allowedHosts: []string{"app.example.com"},
+		logger:         logger,
+		telemetry:      observability.New(),
+		allowedHosts:   []string{"app.example.com"},
+		requestLogging: true,
 	})
 	mux.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	request.Host = "unexpected.example.com"
+	request.Header.Set("traceparent", traceparent)
+	request.Header.Set("tracestate", "vendor=secret-state")
 	response := httptest.NewRecorder()
 
 	mux.ServeHTTP(response, request)
@@ -52,6 +65,17 @@ func TestCorrelationIdentitySurvivesEarlyMiddlewareFailure(t *testing.T) {
 	}
 	if got := response.Header().Get("X-Correlation-ID"); got != requestID {
 		t.Fatalf("response correlation ID = %q, want request ID %q", got, requestID)
+	}
+	logged := logs.String()
+	for _, want := range []string{"status=421", "request_id=" + requestID, "correlation_id=" + requestID, "trace_id=" + traceID, "upstream_span_id=" + upstreamSpanID} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("log %q missing %q", logged, want)
+		}
+	}
+	for _, sensitive := range []string{traceparent, "secret-state", "traceparent", "tracestate"} {
+		if strings.Contains(logged, sensitive) {
+			t.Fatalf("log %q contains sensitive trace context %q", logged, sensitive)
+		}
 	}
 }
 

--- a/internal/app/runtime_router_routes.go
+++ b/internal/app/runtime_router_routes.go
@@ -83,6 +83,7 @@ type staticRouteDependencies struct {
 // middleware explicit and prevents feature modules from silently changing it.
 func mountRouterMiddleware(mux *chi.Mux, dependencies routerMiddlewareDependencies) {
 	mux.Use(apihttpmiddleware.RequestCorrelation)
+	mux.Use(apihttpmiddleware.TraceContext)
 	if dependencies.requestLogging {
 		mux.Use(apihttpmiddleware.RequestLogger(dependencies.logger))
 	}

--- a/internal/platform/http/middleware/middleware.go
+++ b/internal/platform/http/middleware/middleware.go
@@ -12,6 +12,8 @@ import (
 
 	apitransport "github.com/flidai/leapview/internal/platform/http/transport"
 	"github.com/go-chi/httprate"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const DefaultMaxRequestBodyBytes int64 = 128 << 20
@@ -249,12 +251,14 @@ func PanicRecovery(logger *slog.Logger) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if recovered := recover(); recovered != nil {
-					logger.ErrorContext(r.Context(), "http handler panic",
+					attributes := []any{
 						"method", r.Method,
 						"path", r.URL.Path,
 						"panic", recovered,
 						"stack", string(debug.Stack()),
-					)
+					}
+					attributes = append(attributes, inboundTraceLogAttributes(r.Context())...)
+					logger.ErrorContext(r.Context(), "http handler panic", attributes...)
 					writeMiddlewareError(w, r, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR", "The server could not complete the request")
 				}
 			}()
@@ -345,6 +349,27 @@ func RequestIDWasGenerated(r *http.Request) bool {
 	return generated
 }
 
+// TraceContext validates and carries inbound W3C traceparent and tracestate
+// without generating a trace or changing the request's local correlation ID.
+func TraceContext(next http.Handler) http.Handler {
+	propagator := propagation.TraceContext{}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func inboundTraceLogAttributes(ctx context.Context) []any {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() || !spanContext.IsRemote() {
+		return nil
+	}
+	return []any{
+		"trace_id", spanContext.TraceID().String(),
+		"upstream_span_id", spanContext.SpanID().String(),
+	}
+}
+
 func RequestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 	if logger == nil {
 		logger = slog.Default()
@@ -354,7 +379,7 @@ func RequestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 			start := time.Now()
 			rec := &Recorder{ResponseWriter: w, StatusCode: http.StatusOK}
 			next.ServeHTTP(rec, r)
-			logger.InfoContext(r.Context(), "http request",
+			attributes := []any{
 				"method", r.Method,
 				"path", r.URL.Path,
 				"status", rec.StatusCode,
@@ -363,7 +388,9 @@ func RequestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 				"remote", r.RemoteAddr,
 				"request_id", firstNonEmpty(r.Header.Get("X-Request-Id"), r.Header.Get("X-Request-ID")),
 				"correlation_id", firstNonEmpty(r.Header.Get("X-Correlation-Id"), r.Header.Get("X-Correlation-ID"), r.Header.Get("X-Request-Id"), r.Header.Get("X-Request-ID")),
-			)
+			}
+			attributes = append(attributes, inboundTraceLogAttributes(r.Context())...)
+			logger.InfoContext(r.Context(), "http request", attributes...)
 		})
 	}
 }

--- a/internal/platform/http/middleware/middleware_active_test.go
+++ b/internal/platform/http/middleware/middleware_active_test.go
@@ -9,6 +9,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	testTraceID        = "0af7651916cd43dd8448eb211c80319c"
+	testUpstreamSpanID = "b7ad6b7169203331"
+	testTraceparent    = "00-" + testTraceID + "-" + testUpstreamSpanID + "-01"
 )
 
 func TestPanicRecoveryWritesGenericInternalServerError(t *testing.T) {
@@ -274,26 +282,146 @@ func TestRequestCorrelationPreservesClientIdentity(t *testing.T) {
 	}
 }
 
+func TestTraceContextExtractsAndPropagatesValidW3CContext(t *testing.T) {
+	var propagated trace.SpanContext
+	handler := TraceContext(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		propagated = trace.SpanContextFromContext(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("traceparent", testTraceparent)
+	request.Header.Set("tracestate", "vendor=opaque")
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusNoContent)
+	}
+	if !propagated.IsValid() || !propagated.IsRemote() {
+		t.Fatalf("propagated span context = %+v, want valid remote context", propagated)
+	}
+	if got := propagated.TraceID().String(); got != testTraceID {
+		t.Fatalf("trace ID = %q, want %q", got, testTraceID)
+	}
+	if got := propagated.SpanID().String(); got != testUpstreamSpanID {
+		t.Fatalf("upstream span ID = %q, want %q", got, testUpstreamSpanID)
+	}
+	if got := propagated.TraceState().Get("vendor"); got != "opaque" {
+		t.Fatalf("trace state vendor = %q, want opaque", got)
+	}
+}
+
+func TestTraceContextIgnoresMalformedOrMissingParent(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		traceparent string
+	}{
+		{name: "missing"},
+		{name: "malformed", traceparent: "not-a-traceparent"},
+		{name: "zero trace ID", traceparent: "00-00000000000000000000000000000000-b7ad6b7169203331-01"},
+		{name: "zero span ID", traceparent: "00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := TraceContext(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				if propagated := trace.SpanContextFromContext(r.Context()); propagated.IsValid() {
+					t.Errorf("propagated span context = %+v, want invalid context", propagated)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			request := httptest.NewRequest(http.MethodGet, "/", nil)
+			if test.traceparent != "" {
+				request.Header.Set("traceparent", test.traceparent)
+			}
+			request.Header.Set("tracestate", "vendor=opaque")
+			response := httptest.NewRecorder()
+
+			handler.ServeHTTP(response, request)
+
+			if response.Code != http.StatusNoContent || !called {
+				t.Fatalf("status = %d called = %v, want 204 and downstream call", response.Code, called)
+			}
+		})
+	}
+}
+
 func TestRequestLoggerOmitsSensitiveHeadersAndValues(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	handler := RequestCorrelation(RequestLogger(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := RequestCorrelation(TraceContext(RequestLogger(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte("ok"))
-	})))
+	}))))
 	request := httptest.NewRequest(http.MethodGet, "/?token=secret-query", nil)
 	request.Header.Set("Authorization", "Bearer secret-token")
 	request.Header.Set("X-Request-ID", "req_123")
+	request.Header.Set("traceparent", testTraceparent)
+	request.Header.Set("tracestate", "vendor=secret-state")
+	request.Header.Set("baggage", "account=secret-baggage")
 	request.AddCookie(&http.Cookie{Name: "lv_session", Value: "secret-session"})
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 
 	logged := logs.String()
-	for _, want := range []string{"method=GET", "path=/", "status=200", "duration=", "bytes=2", "request_id=req_123", "correlation_id=req_123"} {
+	for _, want := range []string{"method=GET", "path=/", "status=200", "duration=", "bytes=2", "request_id=req_123", "correlation_id=req_123", "trace_id=" + testTraceID, "upstream_span_id=" + testUpstreamSpanID} {
 		if !strings.Contains(logged, want) {
 			t.Fatalf("log %q missing %q", logged, want)
 		}
 	}
-	for _, secret := range []string{"secret-token", "secret-session", "secret-query", "Authorization", "Cookie"} {
+	for _, secret := range []string{"secret-token", "secret-session", "secret-query", "secret-state", "secret-baggage", "Authorization", "Cookie", "traceparent", "tracestate", "baggage", testTraceparent} {
+		if strings.Contains(logged, secret) {
+			t.Fatalf("log %q contains sensitive value %q", logged, secret)
+		}
+	}
+}
+
+func TestRequestLoggerOmitsTraceFieldsWithoutValidContext(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	handler := TraceContext(RequestLogger(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})))
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("traceparent", "not-a-traceparent")
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	logged := logs.String()
+	for _, field := range []string{"trace_id=", "upstream_span_id="} {
+		if strings.Contains(logged, field) {
+			t.Fatalf("log %q contains invalid trace field %q", logged, field)
+		}
+	}
+}
+
+func TestPanicLoggerAddsValidatedTraceContextWithoutSensitiveRequestData(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	handler := RequestCorrelation(TraceContext(PanicRecovery(logger)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}))))
+	request := httptest.NewRequest(http.MethodPost, "/panic?token=secret-query", strings.NewReader("secret-body"))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	request.Header.Set("traceparent", testTraceparent)
+	request.Header.Set("tracestate", "vendor=secret-state")
+	request.Header.Set("baggage", "account=secret-baggage")
+	request.AddCookie(&http.Cookie{Name: "lv_session", Value: "secret-session"})
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+	}
+	logged := logs.String()
+	for _, want := range []string{"msg=\"http handler panic\"", "method=POST", "path=/panic", "trace_id=" + testTraceID, "upstream_span_id=" + testUpstreamSpanID} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("log %q missing %q", logged, want)
+		}
+	}
+	for _, secret := range []string{"secret-token", "secret-session", "secret-query", "secret-body", "secret-state", "secret-baggage", "Authorization", "Cookie", "traceparent", "tracestate", "baggage", testTraceparent} {
 		if strings.Contains(logged, secret) {
 			t.Fatalf("log %q contains sensitive value %q", logged, secret)
 		}


### PR DESCRIPTION
## Problem

LeapView has canonical local request and correlation IDs, but valid upstream W3C trace context is not available to downstream handlers or production request and panic logs. This prevents safe correlation with upstream services.

Root cause: the process-wide middleware stack has no inbound `traceparent` and `tracestate` extractor before logging, telemetry, recovery, and route handling.

## Solution

- Add a centralized W3C trace-context middleware immediately after request correlation.
- Use the OpenTelemetry propagation API only to validate and carry remote context; no SDK, provider, exporter, spans, sampling, or global propagator configuration is added.
- Add parsed `trace_id` and `upstream_span_id` fields to request and panic logs only for valid remote context.
- Preserve FAI-552 request and correlation identity behavior.
- Document the inbound-only correlation contract and sensitive-data exclusions.

## Tests added or updated

- Valid `traceparent` and `tracestate` extraction and downstream propagation.
- Missing, malformed, zero-trace, and zero-span parent handling.
- Request-log and panic-log correlation.
- Early host-rejection correlation through the real middleware order.
- Exclusion of raw trace headers, baggage, authorization, cookies, query values, and request bodies.

## Verification

- `go test ./internal/platform/http/middleware ./internal/app -run "TestTraceContext|TestRequestLogger|TestPanicLogger|TestCorrelationIdentitySurvivesEarlyMiddlewareFailure" -count=1`
- `GOFLAGS=-tags=duckdb_arrow go test ./internal/platform/http/middleware ./internal/platform/observability ./internal/app -count=1`
- `go test -race ./internal/platform/http/middleware` for the focused trace/log tests.
- `go test -race ./internal/app -run "^TestCorrelationIdentitySurvivesEarlyMiddlewareFailure$" -count=1`
- `GOFLAGS=-tags=duckdb_arrow go vet ./internal/platform/http/middleware ./internal/platform/observability ./internal/app`
- `git diff --check`

All commands above passed. `go mod tidy -diff` confirmed the OpenTelemetry declarations are direct as required; it also reports an unrelated pre-existing `prometheus/client_model` directness difference, which this PR intentionally leaves untouched.

Local `task ci` was not run because this environment does not provide the Bun runtime. GitHub PR CI remains authoritative for frontend and generated-contract lanes.

## Limitations

This is inbound propagation only. It does not generate trace IDs, create spans, sample, export OTLP, instrument outbound calls, correlate background work, add alerts or SLOs, or add synthetic monitoring.

Linear: [FAI-553](https://linear.app/flid/issue/FAI-553/establish-canonical-inbound-w3c-trace-context)