### PR TITLE
Add baseline Prometheus health alerts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -867,6 +867,12 @@ tasks:
     cmds:
       - task: ci:pr
 
+  observability:alerts:check:
+    desc: Validate repository-owned Prometheus alert rules and fixtures
+    cmds:
+      - ./scripts/promtool.sh check rules deploy/observability/prometheus/leapview-alerts.yaml
+      - ./scripts/promtool.sh test rules deploy/observability/prometheus/testdata/leapview-alerts.test.yaml
+
   image:qualify:production:
     desc: Qualify an immutable LeapView production image
     requires:

--- a/deploy/observability/prometheus/leapview-alerts.yaml
+++ b/deploy/observability/prometheus/leapview-alerts.yaml
@@ -1,0 +1,38 @@
+groups:
+  - name: leapview-health
+    rules:
+      - alert: LeapViewTargetUnavailable
+        expr: max by (job, instance) (up{job="leapview"}) == 0
+        for: 2m
+        labels:
+          service: leapview
+          severity: critical
+        annotations:
+          summary: "LeapView target {{ $labels.instance }} is unavailable"
+          description: "Prometheus has been unable to scrape the LeapView target for more than 2 minutes."
+          runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
+
+      - alert: LeapViewSustainedHTTP5xx
+        expr: |
+          sum by (job, instance) (
+            rate(leapview_http_requests_total{job="leapview",status=~"5.."}[5m])
+          ) > 0
+        for: 10m
+        labels:
+          service: leapview
+          severity: warning
+        annotations:
+          summary: "LeapView target {{ $labels.instance }} is returning sustained 5xx responses"
+          description: "LeapView has continuously observed 5xx responses on {{ $labels.instance }} for more than 10 minutes."
+          runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
+
+      - alert: LeapViewDuckDBFatalHealth
+        expr: max by (job, instance) (leapview_duckdb_fatal_health{job="leapview"}) > 0
+        for: 1m
+        labels:
+          service: leapview
+          severity: critical
+        annotations:
+          summary: "LeapView DuckDB runtime on {{ $labels.instance }} is fatally unhealthy"
+          description: "The process-owned DuckDB runtime on {{ $labels.instance }} reports a fatal cleanup-safety failure."
+          runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"

--- a/deploy/observability/prometheus/testdata/leapview-alerts.test.yaml
+++ b/deploy/observability/prometheus/testdata/leapview-alerts.test.yaml
@@ -1,0 +1,94 @@
+rule_files:
+  - ../leapview-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - name: healthy target does not alert
+    interval: 1m
+    input_series:
+      - series: 'up{job="leapview",instance="app:8080",pod="leapview-healthy"}'
+        values: '1x20'
+      - series: 'leapview_http_requests_total{job="leapview",instance="app:8080",method="GET",route="/healthz",status="200"}'
+        values: '0+5x20'
+      - series: 'leapview_duckdb_fatal_health{job="leapview",instance="app:8080",pod="leapview-healthy"}'
+        values: '0x20'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: LeapViewTargetUnavailable
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: LeapViewSustainedHTTP5xx
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: LeapViewDuckDBFatalHealth
+        exp_alerts: []
+
+  - name: unavailable target fires after two minutes
+    interval: 1m
+    input_series:
+      - series: 'up{job="leapview",instance="app:8080",pod="leapview-unavailable",route="/forbidden",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
+        values: '0x5'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: LeapViewTargetUnavailable
+        exp_alerts:
+          - exp_labels:
+              instance: app:8080
+              job: leapview
+              service: leapview
+              severity: critical
+            exp_annotations:
+              summary: "LeapView target app:8080 is unavailable"
+              description: "Prometheus has been unable to scrape the LeapView target for more than 2 minutes."
+              runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
+
+  - name: transient 5xx activity does not fire
+    interval: 1m
+    input_series:
+      - series: 'leapview_http_requests_total{job="leapview",instance="app:8080",method="POST",route="/api/v1/projects/{project}",status="500",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
+        values: '0x4 1 1x15'
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: LeapViewSustainedHTTP5xx
+        exp_alerts: []
+
+  - name: sustained 5xx activity aggregates request dimensions
+    interval: 1m
+    input_series:
+      - series: 'leapview_http_requests_total{job="leapview",instance="app:8080",method="POST",route="/api/v1/projects/{project}",status="500",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
+        values: '0+1x20'
+      - series: 'leapview_http_requests_total{job="leapview",instance="app:8080",method="GET",route="/updates",status="503"}'
+        values: '0+1x20'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: LeapViewSustainedHTTP5xx
+        exp_alerts:
+          - exp_labels:
+              instance: app:8080
+              job: leapview
+              service: leapview
+              severity: warning
+            exp_annotations:
+              summary: "LeapView target app:8080 is returning sustained 5xx responses"
+              description: "LeapView has continuously observed 5xx responses on app:8080 for more than 10 minutes."
+              runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
+
+  - name: fatal DuckDB runtime health fires
+    interval: 1m
+    input_series:
+      - series: 'leapview_duckdb_fatal_health{job="leapview",instance="app:8080",pod="leapview-fatal",resource_id="resource-forbidden",trace_id="trace-forbidden"}'
+        values: '1x5'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: LeapViewDuckDBFatalHealth
+        exp_alerts:
+          - exp_labels:
+              instance: app:8080
+              job: leapview
+              service: leapview
+              severity: critical
+            exp_annotations:
+              summary: "LeapView DuckDB runtime on app:8080 is fatally unhealthy"
+              description: "The process-owned DuckDB runtime on app:8080 reports a fatal cleanup-safety failure."
+              runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"

--- a/deploy/observability/prometheus/testdata/leapview-alerts.test.yaml
+++ b/deploy/observability/prometheus/testdata/leapview-alerts.test.yaml
@@ -28,7 +28,7 @@ tests:
     interval: 1m
     input_series:
       - series: 'up{job="leapview",instance="app:8080",pod="leapview-unavailable",route="/forbidden",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
-        values: '0x5'
+        values: '0x4 1x3'
     alert_rule_test:
       - eval_time: 3m
         alertname: LeapViewTargetUnavailable
@@ -42,6 +42,9 @@ tests:
               summary: "LeapView target app:8080 is unavailable"
               description: "Prometheus has been unable to scrape the LeapView target for more than 2 minutes."
               runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
+      - eval_time: 5m
+        alertname: LeapViewTargetUnavailable
+        exp_alerts: []
 
   - name: transient 5xx activity does not fire
     interval: 1m
@@ -57,9 +60,9 @@ tests:
     interval: 1m
     input_series:
       - series: 'leapview_http_requests_total{job="leapview",instance="app:8080",method="POST",route="/api/v1/projects/{project}",status="500",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
-        values: '0+1x20'
+        values: '0+1x15 15x10'
       - series: 'leapview_http_requests_total{job="leapview",instance="app:8080",method="GET",route="/updates",status="503"}'
-        values: '0+1x20'
+        values: '0+1x15 15x10'
     alert_rule_test:
       - eval_time: 15m
         alertname: LeapViewSustainedHTTP5xx
@@ -73,12 +76,15 @@ tests:
               summary: "LeapView target app:8080 is returning sustained 5xx responses"
               description: "LeapView has continuously observed 5xx responses on app:8080 for more than 10 minutes."
               runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
+      - eval_time: 21m
+        alertname: LeapViewSustainedHTTP5xx
+        exp_alerts: []
 
   - name: fatal DuckDB runtime health fires
     interval: 1m
     input_series:
       - series: 'leapview_duckdb_fatal_health{job="leapview",instance="app:8080",pod="leapview-fatal",resource_id="resource-forbidden",trace_id="trace-forbidden"}'
-        values: '1x5'
+        values: '1x3 0x3'
     alert_rule_test:
       - eval_time: 2m
         alertname: LeapViewDuckDBFatalHealth
@@ -92,3 +98,6 @@ tests:
               summary: "LeapView DuckDB runtime on app:8080 is fatally unhealthy"
               description: "The process-owned DuckDB runtime on app:8080 reports a fatal cleanup-safety failure."
               runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
+      - eval_time: 5m
+        alertname: LeapViewDuckDBFatalHealth
+        exp_alerts: []

--- a/docs/articles/operate/observability.md
+++ b/docs/articles/operate/observability.md
@@ -22,6 +22,27 @@ LeapView exposes Prometheus metrics behind `LEAPVIEW_METRICS_BEARER_TOKEN`. Prod
 
 Monitor at least process resource use, request rate and latency, error status, read/write executor saturation, queue depth and timeouts, refresh activity, storage capacity, and managed upload failures. Alert on sustained conditions and user-visible symptoms rather than every transient supersession.
 
+### Baseline health alerts
+
+The repository-owned rule file at `deploy/observability/prometheus/leapview-alerts.yaml` provides portable alerts for an unavailable scrape target, sustained application 5xx responses, and fatal process-owned DuckDB health. The rules assume that Prometheus assigns LeapView targets the stable scrape label `job="leapview"`; `instance` must identify the bounded scrape target. Alert identity is limited to those scrape labels plus the static `service` and `severity` labels. Request routes, request or trace identities, principals, projects, and resource identifiers are aggregated away and never become alert labels.
+
+Validate the syntax, PromQL behavior, firing delay, labels, and annotations with the pinned Prometheus toolchain:
+
+```sh
+task observability:alerts:check
+```
+
+The task downloads the official Prometheus archive for the supported Linux or macOS architecture, verifies its pinned SHA-256 digest, caches `promtool` under `.tmp/tools`, then runs `promtool check rules` and the healthy and firing rule fixtures.
+
+Copy or mount the rule file into the Prometheus deployment and reference it from the Prometheus configuration:
+
+```yaml
+rule_files:
+  - /etc/prometheus/rules/leapview-alerts.yaml
+```
+
+Reload Prometheus only after validation succeeds. The target-unavailable rule relies on Prometheus's standard `up` metric and therefore requires the target to remain present in Prometheus service discovery; a target omitted from the scrape configuration cannot alert. The 5xx rule uses `leapview_http_requests_total`, aggregates method, route, and status dimensions down to `job` and `instance`, and requires a positive five-minute error rate continuously for ten minutes. `leapview_duckdb_fatal_health` is present only when LeapView owns a process-local DuckDB environment. Every alert links to [Operational troubleshooting](/docs/guides/operate/troubleshooting); configure routing and receivers in the operator-owned Alertmanager deployment.
+
 ## Structured logs
 
 Collect structured application logs from the service output. Preserve timestamp, severity, operation, route, status, duration, principal where safe, project, environment, request/correlation ID, deployment ID, revision digest, and refresh generation when available.

--- a/scripts/promtool.sh
+++ b/scripts/promtool.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+set -eu
+
+version=3.14.0
+os=$(uname -s)
+arch=$(uname -m)
+
+case "$os" in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+  *)
+    echo "unsupported promtool operating system: $os" >&2
+    exit 1
+    ;;
+esac
+
+case "$arch" in
+  x86_64 | amd64) arch=amd64 ;;
+  arm64 | aarch64) arch=arm64 ;;
+  *)
+    echo "unsupported promtool architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+platform="$os-$arch"
+case "$platform" in
+  linux-amd64) checksum=f665c6da19eb7ba399c915d30c7d9793c9b417bf8a749b504bc470678631478d ;;
+  linux-arm64) checksum=077f3781ab7245dc04c9a3c9b78ba120fc8e41aa0dc97489b0af67247e50ba83 ;;
+  darwin-amd64) checksum=a14307b9726e66cadb81be9a544732623af26dabeb7702c987aa9c3c062ada34 ;;
+  darwin-arm64) checksum=a9623f7f4fe65b1b171b423c1a72bbf23dfdf41a171dcb33e7dd302af80dc01c ;;
+esac
+
+archive_name="prometheus-$version.$platform.tar.gz"
+archive_root="prometheus-$version.$platform"
+cache_root=${LEAPVIEW_PROMTOOL_CACHE_ROOT:-.tmp/tools}
+tool_root="$cache_root/$archive_root"
+promtool="$tool_root/promtool"
+
+if [ ! -x "$promtool" ]; then
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required to install promtool $version" >&2
+    exit 1
+  fi
+
+  promtool_tmp=$(mktemp -d "${TMPDIR:-/tmp}/leapview-promtool.XXXXXX")
+  cleanup() {
+    rm -rf -- "$promtool_tmp"
+  }
+  trap cleanup EXIT HUP INT TERM
+
+  archive="$promtool_tmp/$archive_name"
+  curl --fail --location --silent --show-error \
+    "https://github.com/prometheus/prometheus/releases/download/v$version/$archive_name" \
+    --output "$archive"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$archive")
+  elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$archive")
+  else
+    echo "sha256sum or shasum is required to verify promtool" >&2
+    exit 1
+  fi
+  actual=${actual%% *}
+  if [ "$actual" != "$checksum" ]; then
+    echo "promtool archive checksum mismatch: got $actual" >&2
+    exit 1
+  fi
+
+  tar -xzf "$archive" -C "$promtool_tmp" "$archive_root/promtool"
+  mkdir -p "$tool_root"
+  mv "$promtool_tmp/$archive_root/promtool" "$promtool"
+  chmod 0755 "$promtool"
+fi
+
+exec "$promtool" "$@"

--- a/scripts/promtool.sh
+++ b/scripts/promtool.sh
@@ -33,7 +33,7 @@ esac
 
 archive_name="prometheus-$version.$platform.tar.gz"
 archive_root="prometheus-$version.$platform"
-cache_root=${LEAPVIEW_PROMTOOL_CACHE_ROOT:-.tmp/tools}
+cache_root=.tmp/tools
 tool_root="$cache_root/$archive_root"
 promtool="$tool_root/promtool"
 


### PR DESCRIPTION
Closes FAI-554

## Problem

LeapView exposes stable Prometheus health signals, but the repository does not own executable alert rules. Operators therefore have to recreate detection logic and may miss basic production failures.

## Root cause

The existing observability contract stops at metric exposition. It does not provide portable, validated Prometheus rules or document the scrape-label assumptions required to load them safely.

## Solution

- Add repository-owned alerts for an unavailable LeapView target, sustained HTTP 5xx responses, and fatal process-owned DuckDB health.
- Aggregate every expression to bounded `job` and `instance` labels, with static `service` and `severity` labels.
- Add healthy, transient, and firing promtool fixtures that verify delays, labels, annotations, and exclusion of prohibited high-cardinality labels.
- Add a reproducible Task target backed by a checksum-pinned Prometheus 3.14.0 promtool download.
- Document the `job="leapview"` contract, validation and loading steps, runbook links, and topology limitations.

No Go code, runtime metrics, Prometheus deployment, Alertmanager configuration, dashboards, SLOs, or tracing behavior changed.

## Tests added/updated

- Added promtool rule fixtures for healthy state and every firing alert.
- Added a transient 5xx case to verify the sustained window.
- Added prohibited source labels to firing inputs and exact expected alert labels/annotations.

## Verification

- `task observability:alerts:check`
- `sh -n scripts/promtool.sh`
- `go run ./internal/app/tools/docsitegen --check`
- `go test ./internal/app/site/http -run '^TestEveryRenderedDocumentationLinkResolves$' -count=1`
- `git diff --check`

All commands passed.

## Remaining limitations

- Prometheus must assign LeapView targets `job="leapview"` and keep a failed target in service discovery for the target-unavailable alert to evaluate.
- The DuckDB fatal-health alert has data only when the process owns a local DuckDB environment.
- Alert routing, receivers, deployment, dashboards, SLOs, synthetic checks, and tracing remain operator-owned or future work.
