### PR TITLE
Polish profile settings and keep admin sidebar fixed

### DIFF
--- a/web/components/admin/admin-page.dom.test.ts
+++ b/web/components/admin/admin-page.dom.test.ts
@@ -108,6 +108,26 @@ test('profile settings renders the signed-in identity and editable local fields'
       const header = root.querySelector('.page-header') as HTMLElement
       const avatarTrigger = profileRoot.querySelector('.avatar-trigger') as HTMLButtonElement
       const fieldLabel = profileRoot.querySelector('.settings-label') as HTMLElement
+      const profileRows = Array.from(profileRoot.querySelectorAll('.profile-row')) as HTMLElement[]
+      const profileRowsLargeEnough = profileRows.every((row) => row.getBoundingClientRect().height >= 64)
+      const avatarSize = Math.round(avatarTrigger.getBoundingClientRect().width)
+      const displayNameInput = profileRoot.querySelector('#personal-display-name') as HTMLInputElement
+      const displayNameInputStyle = getComputedStyle(displayNameInput)
+      const displayNameInputWidth = Math.round(displayNameInput.getBoundingClientRect().width)
+      const displayNameInputHeight = Math.round(displayNameInput.getBoundingClientRect().height)
+      const displayNameSaveInitiallyHidden = !profileRoot.querySelector('[data-profile-save]')
+      let profileCommand: unknown = null
+      profile.addEventListener('lv-personal-profile-command', (event: CustomEvent) => { profileCommand = event.detail }, { once: true })
+      displayNameInput.value = 'Jacob N.'
+      displayNameInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      await profile.updateComplete
+      const displayNameSave = profileRoot.querySelector('[data-profile-save]') as HTMLButtonElement | null
+      const displayNameSaveVisibleWhenDirty = Boolean(displayNameSave)
+      displayNameSave?.click()
+      await profile.updateComplete
+      const profileControlSelectors = ['.avatar-control', '.profile-email', '.profile-name-form', '.theme-picker']
+      const profileControlRightEdges = profileControlSelectors.map((selector) => Math.round((profileRoot.querySelector(selector) as HTMLElement | null)?.getBoundingClientRect().right ?? 0))
+      const profileControlsRightAligned = profileControlRightEdges.every((edge) => edge > 0 && Math.abs(edge - profileControlRightEdges[0]) <= 1)
       avatarTrigger.click()
       await profile.updateComplete
       const avatarMenuItems = Array.from(profileRoot.querySelectorAll('[role="menuitem"]')).map((item) => item.textContent?.trim())
@@ -121,14 +141,30 @@ test('profile settings renders the signed-in identity and editable local fields'
       let appliedTheme: unknown = null
       profile.addEventListener('lv-personal-theme-command', (event: CustomEvent) => { themeCommand = event.detail }, { once: true })
       document.addEventListener('leapview-theme-change', (event: CustomEvent) => { appliedTheme = event.detail?.mode }, { once: true })
-      const theme = profileRoot.querySelector('select[name="theme"]') as HTMLSelectElement
+      const theme = profileRoot.querySelector('.theme-trigger') as HTMLButtonElement
       avatarTrigger.click()
       await profile.updateComplete
       theme.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }))
       await profile.updateComplete
       const avatarMenuClosedOnOutsidePointer = !profileRoot.querySelector('[role="menu"]')
-      theme.value = 'dark_colorblind'
-      theme.dispatchEvent(new Event('change', { bubbles: true, composed: true }))
+      theme.click()
+      await profile.updateComplete
+      const themeListbox = profileRoot.querySelector('[role="listbox"]') as HTMLElement
+      const selectedTheme = themeListbox.querySelector('[role="option"][aria-selected="true"]') as HTMLElement
+      const selectedThemePreview = selectedTheme.querySelector('.theme-preview') as HTMLElement
+      const themeOptions = Array.from(themeListbox.querySelectorAll('[role="option"]')) as HTMLButtonElement[]
+      selectedTheme.focus()
+      selectedTheme.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }))
+      const keyboardNextTheme = (profileRoot.activeElement as HTMLElement | null)?.dataset.theme
+      profileRoot.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }))
+      await profile.updateComplete
+      const themeClosedWithEscape = !profileRoot.querySelector('[role="listbox"]')
+      const themeTriggerFocusedAfterEscape = profileRoot.activeElement === theme
+      theme.click()
+      await profile.updateComplete
+      const reopenedOptions = Array.from(profileRoot.querySelectorAll<HTMLButtonElement>('[role="option"]'))
+      reopenedOptions.find((option) => option.dataset.theme === 'dark_colorblind')?.click()
+      await profile.updateComplete
       return {
         title: root.querySelector('h1')?.textContent?.trim(),
         text: profileRoot.textContent?.replace(/\s+/g, ' ').trim(),
@@ -137,13 +173,33 @@ test('profile settings renders the signed-in identity and editable local fields'
         mainWidth: Math.round(main.getBoundingClientRect().width),
         headerGap: Math.round(profile.getBoundingClientRect().top - header.getBoundingClientRect().bottom),
         fieldLabelFontSize: getComputedStyle(fieldLabel).fontSize,
+        profileRowCount: profileRows.length,
+        profileRowsLargeEnough,
+        avatarSize,
+        displayNameTextAlign: displayNameInputStyle.textAlign,
+        displayNameInputWidth,
+        displayNameInputHeight,
+        displayNameSaveInitiallyHidden,
+        displayNameSaveVisibleWhenDirty,
+        profileCommand,
+        profileControlsRightAligned,
+        emailIsReadOnlyText: profileRoot.querySelector('.profile-email')?.tagName === 'SPAN',
         avatarMenuItems,
         avatarMenuOpen,
         avatarMenuClosed,
         avatarTriggerFocused,
         avatarMenuClosedOnOutsidePointer,
         hiddenFileInputLabel: profileRoot.querySelector('input[type="file"].avatar-input')?.getAttribute('aria-label'),
-        themeOptions: Array.from(profileRoot.querySelectorAll('select[name="theme"] option')).map((option) => option.textContent?.trim()),
+        themeOptions: themeOptions.map((option) => option.querySelector('.theme-option-label')?.textContent?.trim()),
+        themeGroups: Array.from(themeListbox.querySelectorAll('[role="group"]')).map((group) => group.getAttribute('aria-label')),
+        selectedTheme: selectedTheme.dataset.theme,
+        selectedThemeHasPreview: Boolean(selectedTheme.querySelector('.theme-preview')),
+        selectedThemePreviewClipped: selectedThemePreview.scrollWidth > selectedThemePreview.clientWidth || selectedThemePreview.scrollHeight > selectedThemePreview.clientHeight,
+        themeListboxClosed: !profileRoot.querySelector('[role="listbox"]'),
+        themeTriggerValue: profileRoot.querySelector('.theme-trigger-label')?.textContent?.trim(),
+        keyboardNextTheme,
+        themeClosedWithEscape,
+        themeTriggerFocusedAfterEscape,
         themeCommand,
         appliedTheme,
       }
@@ -163,13 +219,33 @@ test('profile settings renders the signed-in identity and editable local fields'
       'Light tritanopia',
       'Dark tritanopia',
     ])
+    expect(state.themeGroups).toEqual(['Automatic', 'Standard', 'Accessibility'])
+    expect(state.selectedTheme).toBe('system')
+    expect(state.selectedThemeHasPreview).toBe(true)
+    expect(state.selectedThemePreviewClipped).toBe(false)
+    expect(state.themeListboxClosed).toBe(true)
+    expect(state.themeTriggerValue).toBe('Dark protanopia and deuteranopia')
+    expect(state.keyboardNextTheme).toBe('light')
+    expect(state.themeClosedWithEscape).toBe(true)
+    expect(state.themeTriggerFocusedAfterEscape).toBe(true)
     expect(state.themeCommand).toEqual({ action: 'save', theme: 'dark_colorblind' })
     expect(state.appliedTheme).toBe('dark_colorblind')
     expect(state.nestedHeadings).toBe(0)
     expect(state.mainCentered).toBe(true)
-    expect(state.mainWidth).toBe(640)
+    expect(state.mainWidth).toBe(736)
     expect(state.headerGap).toBeGreaterThanOrEqual(16)
     expect(state.fieldLabelFontSize).toBe('14px')
+    expect(state.profileRowCount).toBe(4)
+    expect(state.profileRowsLargeEnough).toBe(true)
+    expect(state.avatarSize).toBeGreaterThanOrEqual(32)
+    expect(state.displayNameTextAlign).toBe('center')
+    expect(state.displayNameInputWidth).toBeGreaterThanOrEqual(256)
+    expect(state.displayNameInputHeight).toBeGreaterThanOrEqual(32)
+    expect(state.displayNameSaveInitiallyHidden).toBe(true)
+    expect(state.displayNameSaveVisibleWhenDirty).toBe(true)
+    expect(state.profileCommand).toEqual({ action: 'save', displayName: 'Jacob N.' })
+    expect(state.profileControlsRightAligned).toBe(true)
+    expect(state.emailIsReadOnlyText).toBe(true)
     expect(state.avatarMenuItems).toEqual(['Change avatar', 'Remove avatar'])
     expect(state.avatarMenuOpen).toBe('true')
     expect(state.avatarMenuClosed).toBe(true)

--- a/web/components/admin/admin-page.dom.test.ts
+++ b/web/components/admin/admin-page.dom.test.ts
@@ -115,6 +115,10 @@ test('profile settings renders the signed-in identity and editable local fields'
       const displayNameInputStyle = getComputedStyle(displayNameInput)
       const displayNameInputWidth = Math.round(displayNameInput.getBoundingClientRect().width)
       const displayNameInputHeight = Math.round(displayNameInput.getBoundingClientRect().height)
+      const titleInput = profileRoot.querySelector('#personal-title') as HTMLInputElement
+      const usernameInput = profileRoot.querySelector('#personal-username') as HTMLInputElement
+      const titlePlaceholder = titleInput.placeholder
+      const initialUsername = usernameInput.value
       const displayNameSaveInitiallyHidden = !profileRoot.querySelector('[data-profile-save]')
       let profileCommand: unknown = null
       profile.addEventListener('lv-personal-profile-command', (event: CustomEvent) => { profileCommand = event.detail }, { once: true })
@@ -125,7 +129,12 @@ test('profile settings renders the signed-in identity and editable local fields'
       const displayNameSaveVisibleWhenDirty = Boolean(displayNameSave)
       displayNameSave?.click()
       await profile.updateComplete
-      const profileControlSelectors = ['.avatar-control', '.profile-email', '.profile-name-form', '.theme-picker']
+      titleInput.value = 'Software engineer'
+      titleInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      usernameInput.value = 'jacob.n'
+      usernameInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      await profile.updateComplete
+      const profileControlSelectors = ['.avatar-control', '.profile-email', '.profile-name-form', '.profile-title-input', '.profile-username-input', '.theme-picker']
       const profileControlRightEdges = profileControlSelectors.map((selector) => Math.round((profileRoot.querySelector(selector) as HTMLElement | null)?.getBoundingClientRect().right ?? 0))
       const profileControlsRightAligned = profileControlRightEdges.every((edge) => edge > 0 && Math.abs(edge - profileControlRightEdges[0]) <= 1)
       avatarTrigger.click()
@@ -181,6 +190,10 @@ test('profile settings renders the signed-in identity and editable local fields'
         displayNameInputHeight,
         displayNameSaveInitiallyHidden,
         displayNameSaveVisibleWhenDirty,
+        titlePlaceholder,
+        titleValue: (profileRoot.querySelector('#personal-title') as HTMLInputElement).value,
+        initialUsername,
+        usernameValue: (profileRoot.querySelector('#personal-username') as HTMLInputElement).value,
         profileCommand,
         profileControlsRightAligned,
         emailIsReadOnlyText: profileRoot.querySelector('.profile-email')?.tagName === 'SPAN',
@@ -208,6 +221,8 @@ test('profile settings renders the signed-in identity and editable local fields'
     expect(state.text).toContain('Profile picture')
     expect(state.text).toContain('jacob@example.com')
     expect(state.text).toContain('Display name')
+    expect(state.text).toContain('Title')
+    expect(state.text).toContain('Username')
     expect(state.text).toContain('Theme')
     expect(state.themeOptions).toEqual([
       'System',
@@ -232,17 +247,21 @@ test('profile settings renders the signed-in identity and editable local fields'
     expect(state.appliedTheme).toBe('dark_colorblind')
     expect(state.nestedHeadings).toBe(0)
     expect(state.mainCentered).toBe(true)
-    expect(state.mainWidth).toBe(736)
+    expect(state.mainWidth).toBe(640)
     expect(state.headerGap).toBeGreaterThanOrEqual(16)
     expect(state.fieldLabelFontSize).toBe('14px')
-    expect(state.profileRowCount).toBe(4)
+    expect(state.profileRowCount).toBe(6)
     expect(state.profileRowsLargeEnough).toBe(true)
     expect(state.avatarSize).toBeGreaterThanOrEqual(32)
     expect(state.displayNameTextAlign).toBe('center')
-    expect(state.displayNameInputWidth).toBeGreaterThanOrEqual(256)
+    expect(state.displayNameInputWidth).toBe(208)
     expect(state.displayNameInputHeight).toBeGreaterThanOrEqual(32)
     expect(state.displayNameSaveInitiallyHidden).toBe(true)
     expect(state.displayNameSaveVisibleWhenDirty).toBe(true)
+    expect(state.titlePlaceholder).toBe('Software engineer')
+    expect(state.titleValue).toBe('Software engineer')
+    expect(state.initialUsername).toBe('jacob')
+    expect(state.usernameValue).toBe('jacob.n')
     expect(state.profileCommand).toEqual({ action: 'save', displayName: 'Jacob N.' })
     expect(state.profileControlsRightAligned).toBe(true)
     expect(state.emailIsReadOnlyText).toBe(true)

--- a/web/components/admin/admin-page.ts
+++ b/web/components/admin/admin-page.ts
@@ -100,6 +100,10 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
       padding: var(--base-size-64) 0;
     }
 
+    .main-profile {
+      width: min(calc(100% - var(--base-size-48)), 46rem);
+    }
+
     .main-settings .page-title-block {
       display: grid;
       gap: var(--base-size-8);
@@ -603,6 +607,10 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
         padding: var(--base-size-32) var(--base-size-16) var(--base-size-64);
       }
 
+      .main-profile {
+        width: 100%;
+      }
+
       .main-settings .page-header h1 {
         font: var(--lv-type-page-title);
       }
@@ -657,6 +665,7 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
       'main',
       page.active === 'principals' || page.active === 'groups' || page.active === 'principal-detail' || page.active === 'group-detail' || page.active === 'projects-admin' || page.active === 'storage' || page.active === 'storage-detail' ? 'main-directory' : '',
       isPersonalSettings(page.active) || isProductSettings(page.active) ? 'main-settings' : '',
+      page.active === 'profile' ? 'main-profile' : '',
     ].filter(Boolean).join(' ')
     return html`
       <div class="route">

--- a/web/components/admin/admin-page.ts
+++ b/web/components/admin/admin-page.ts
@@ -101,7 +101,7 @@ class LeapViewAdminPage extends DatastarLit(LitElement) {
     }
 
     .main-profile {
-      width: min(calc(100% - var(--base-size-48)), 46rem);
+      width: min(calc(100% - var(--base-size-48)), 40rem);
     }
 
     .main-settings .page-title-block {

--- a/web/components/admin/personal-settings.ts
+++ b/web/components/admin/personal-settings.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html, nothing } from 'lit'
 import { query, state } from 'lit/decorators.js'
-import { Camera, Plus, Search, Trash2, X } from 'lucide'
+import { Camera, Check, ChevronDown, Plus, Search, Trash2, X } from 'lucide'
 import type {
   PersonalAuthoringSessionSignal,
   PersonalCapabilityOptionSignal,
@@ -21,6 +21,28 @@ const emptySettings: PersonalSettingsSignal = {
   tokens: { items: [], capabilities: [] },
 }
 
+type ThemeOption = {
+  value: string
+  label: string
+  group: 'Automatic' | 'Standard' | 'Accessibility'
+  tone: 'system' | 'light' | 'dark'
+}
+
+const systemThemeOption: ThemeOption = { value: 'system', label: 'System', group: 'Automatic', tone: 'system' }
+
+const themeOptions: readonly ThemeOption[] = [
+  systemThemeOption,
+  { value: 'light', label: 'Light default', group: 'Standard', tone: 'light' },
+  { value: 'dark', label: 'Dark default', group: 'Standard', tone: 'dark' },
+  { value: 'dark_dimmed', label: 'Soft dark', group: 'Standard', tone: 'dark' },
+  { value: 'light_colorblind', label: 'Light protanopia and deuteranopia', group: 'Accessibility', tone: 'light' },
+  { value: 'dark_colorblind', label: 'Dark protanopia and deuteranopia', group: 'Accessibility', tone: 'dark' },
+  { value: 'light_tritanopia', label: 'Light tritanopia', group: 'Accessibility', tone: 'light' },
+  { value: 'dark_tritanopia', label: 'Dark tritanopia', group: 'Accessibility', tone: 'dark' },
+]
+
+const themeGroups: readonly ThemeOption['group'][] = ['Automatic', 'Standard', 'Accessibility']
+
 class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   @state() private profileName = ''
   @state() private currentPassword = ''
@@ -34,11 +56,16 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   @state() private message = ''
   @state() private error = ''
   @state() private avatarMenuOpen = false
+  @state() private themeMenuOpen = false
+  @state() private selectedTheme = ''
   @state() private avatarBusy = false
   @query('.avatar-trigger') private avatarTrigger?: HTMLButtonElement
   @query('.avatar-input') private avatarInput?: HTMLInputElement
   @query('.permission-trigger') private permissionTrigger?: HTMLButtonElement
+  @query('.theme-trigger') private themeTrigger?: HTMLButtonElement
   private handledNewToken = ''
+  private observedDisplayName = ''
+  private observedTheme = ''
 
   static styles = [settingsFieldStyles, css`
     :host { display: block; color: var(--lv-fg-default); font: var(--lv-type-body); }
@@ -51,6 +78,11 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
     .row { display: grid; min-height: var(--base-size-48); box-sizing: border-box; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: var(--base-size-16); padding: var(--base-size-8) var(--base-size-16); border-bottom: var(--lv-border-muted); }
     .row:first-child { border-radius: var(--lv-radius-large) var(--lv-radius-large) 0 0; }
     .row:last-child { border-bottom: 0; }
+    .profile-row { min-height: var(--base-size-64); padding: var(--base-size-12) var(--base-size-20); }
+    .profile-email { max-width: 22rem; justify-self: end; text-align: right; }
+    .profile-name-form { min-width: 0; justify-self: end; }
+    .profile-name-control { display: flex; min-width: 0; align-items: center; justify-content: flex-end; gap: var(--base-size-8); }
+    .profile-name-control input { width: min(16rem, 40vw); min-height: var(--control-medium-size, var(--base-size-32)); text-align: center; font: var(--lv-type-body); }
     .muted { color: var(--lv-fg-muted); font: var(--lv-type-caption); }
     input, select { min-width: 0; min-height: var(--control-small-size); box-sizing: border-box; border: var(--lv-border-default); border-radius: var(--lv-radius-small); padding: 0 var(--control-small-paddingInline-normal); color: var(--lv-fg-default); background: var(--lv-bg-input); font: var(--lv-type-body-compact); }
     button { min-height: var(--control-small-size); border: var(--lv-border-default); border-radius: var(--lv-radius-small); padding: 0 var(--control-small-paddingInline-normal); color: var(--lv-fg-default); background: var(--lv-button-bg-rest); cursor: pointer; font: var(--lv-type-body-compact); }
@@ -90,11 +122,29 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
     .selected-permission:last-child { border-bottom: 0; }
     .permission-remove { display: grid; width: var(--control-small-size); min-height: var(--control-small-size); place-items: center; padding: 0; color: var(--lv-fg-muted); background: transparent; }
     .permission-empty { display: grid; min-height: var(--base-size-48); place-items: center start; padding: var(--base-size-8) var(--base-size-12); color: var(--lv-fg-muted); font: var(--lv-type-caption); }
+    .theme-picker { position: relative; display: inline-block; max-width: 100%; justify-self: end; }
+    .theme-trigger { display: inline-grid; width: auto; max-width: 100%; min-height: var(--control-medium-size); grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: var(--base-size-8); padding-inline: var(--base-size-8); text-align: left; }
+    .theme-trigger:hover, .theme-trigger:focus-visible, .theme-trigger[aria-expanded="true"] { border-color: var(--lv-border-accent); outline: 0; }
+    .theme-trigger-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .theme-trigger > svg { width: var(--base-size-16); height: var(--base-size-16); color: var(--lv-fg-muted); }
+    .theme-preview { display: inline-grid; width: var(--base-size-40); height: var(--base-size-24); box-sizing: border-box; grid-template-columns: auto auto; place-content: center; align-items: center; gap: var(--base-size-2); overflow: hidden; border: var(--lv-border-default); border-radius: var(--lv-radius-small); padding: 0 var(--base-size-4); font: var(--lv-type-body-compact); font-weight: var(--base-text-weight-semibold); line-height: 1; }
+    .theme-preview[data-tone="light"] { color: var(--fgColor-black); background: var(--bgColor-white); }
+    .theme-preview[data-tone="dark"] { color: var(--fgColor-white); background: var(--bgColor-black); }
+    .theme-preview[data-tone="system"] { color: var(--fgColor-white); background: linear-gradient(135deg, var(--bgColor-white) 0 48%, var(--bgColor-black) 52% 100%); }
+    .theme-preview-dot { width: var(--base-size-6); height: var(--base-size-6); border-radius: var(--lv-radius-full); background: var(--lv-bg-accent); }
+    .theme-menu { position: absolute; z-index: var(--z-index-dropdown); top: calc(100% + var(--base-size-6)); right: 0; display: grid; width: min(22rem, calc(100vw - var(--base-size-32))); max-height: min(32rem, calc(100svh - var(--base-size-64))); overflow-y: auto; overscroll-behavior: contain; border: var(--lv-border-default); border-radius: var(--lv-radius-large); background: var(--lv-bg-overlay); box-shadow: var(--lv-shadow-floating-lg); padding: var(--base-size-6); scrollbar-color: var(--lv-scrollbar-thumb) transparent; scrollbar-width: thin; }
+    .theme-group { display: grid; gap: var(--base-size-2); padding: var(--base-size-4) 0; border-bottom: var(--lv-border-muted); }
+    .theme-group:last-child { border-bottom: 0; }
+    .theme-group-label { padding: var(--base-size-4) var(--base-size-8); color: var(--lv-fg-muted); font: var(--lv-type-caption); font-weight: var(--base-text-weight-semibold); }
+    button.theme-option { display: grid; width: 100%; min-height: var(--control-medium-size); grid-template-columns: auto minmax(0, 1fr) var(--base-size-16); align-items: center; gap: var(--base-size-8); border-color: transparent; background: transparent; padding-inline: var(--base-size-8); text-align: left; }
+    button.theme-option:hover, button.theme-option:focus-visible, button.theme-option[aria-selected="true"] { background: var(--lv-bg-control-hover); outline: 0; }
+    .theme-option-label { overflow-wrap: anywhere; }
+    .theme-check { display: inline-grid; width: var(--base-size-16); height: var(--base-size-16); place-items: center; color: var(--lv-fg-accent); }
     .avatar-control { position: relative; display: inline-grid; justify-items: end; }
-    .avatar-trigger { display: grid; width: var(--control-large-size); height: var(--control-large-size); min-height: var(--control-large-size); place-items: center; border: 0; border-radius: var(--lv-radius-full); padding: 0; background: transparent; }
+    .avatar-trigger { display: grid; width: var(--base-size-32); height: var(--base-size-32); min-height: var(--base-size-32); place-items: center; border: 0; border-radius: var(--lv-radius-full); padding: 0; background: transparent; }
     .avatar-trigger:hover { box-shadow: var(--lv-shadow-resting-sm); }
     .avatar-trigger:focus-visible { outline: var(--focus-outline); outline-offset: var(--focus-outline-offset); }
-    .avatar-trigger lv-user-avatar { pointer-events: none; }
+    .avatar-trigger lv-user-avatar { --lv-user-avatar-size: var(--base-size-32); pointer-events: none; }
     .avatar-input { display: none; }
     .avatar-menu { position: absolute; z-index: var(--z-index-dropdown); top: calc(100% + var(--base-size-6)); right: 0; display: grid; width: var(--overlay-width-xsmall); border: var(--lv-border-muted); border-radius: var(--lv-radius-default); background: var(--lv-bg-overlay); box-shadow: var(--lv-shadow-floating-lg); padding: var(--base-size-4); }
     .avatar-menu-item { display: grid; min-height: var(--control-medium-size); grid-template-columns: var(--base-size-16) minmax(0, 1fr); align-items: center; gap: var(--base-size-8); border: var(--lv-border-transparent); border-radius: var(--lv-radius-small); background: transparent; padding: 0 var(--base-size-8); text-align: left; }
@@ -105,6 +155,13 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
     .error { color: var(--lv-fg-danger); }
     @media (max-width: 40rem) {
       .row { grid-template-columns: 1fr; gap: var(--base-size-12); padding: var(--base-size-16); }
+      .profile-email { max-width: none; justify-self: stretch; text-align: left; }
+      .profile-name-form { width: 100%; justify-self: stretch; }
+      .profile-name-control { justify-content: stretch; }
+      .profile-name-control input { width: auto; flex: 1 1 auto; }
+      .theme-picker { width: 100%; min-width: 0; justify-self: stretch; }
+      .theme-trigger { width: 100%; }
+      .theme-menu { right: auto; left: 0; }
       .avatar-control { justify-self: start; }
       .token-form-grid { grid-template-columns: 1fr; }
       .permissions-header { align-items: start; }
@@ -139,7 +196,15 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   override updated(): void {
     const settings = this.settings
     const displayName = settings.profile.displayName
-    if (!this.profileName && displayName) this.profileName = displayName
+    if (displayName !== this.observedDisplayName) {
+      this.observedDisplayName = displayName
+      this.profileName = displayName
+    }
+    const theme = settings.profile.theme || 'system'
+    if (theme !== this.observedTheme) {
+      this.observedTheme = theme
+      this.selectedTheme = theme
+    }
     const newToken = settings.tokens.newToken ?? ''
     if (newToken && newToken !== this.handledNewToken) {
       this.handledNewToken = newToken
@@ -154,12 +219,15 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   render() {
     const settings = this.settings
     if (!settings.profile.id) return html`<slot></slot>`
+    const profileNameDraft = this.observedDisplayName === settings.profile.displayName ? this.profileName : settings.profile.displayName
+    const profileNameDirty = profileNameDraft.trim() !== settings.profile.displayName
+    const profileNameValid = profileNameDraft.trim().length > 0
     return html`
       <div class="settings" aria-label="Personal settings">
         ${this.renderNotice(settings)}
         ${settings.active === 'profile' ? html`<section aria-label="Profile">
-          <div class="card">
-            <div class="row">
+          <div class="card profile-card">
+            <div class="row profile-row">
               <div class="settings-field"><span class="settings-label">Profile picture</span><span class="settings-description">Shown across LeapView.</span></div>
               <div class="avatar-control">
                 <button
@@ -173,7 +241,7 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
                   @keydown=${this.handleAvatarTriggerKeydown}
                 >
                   <lv-user-avatar
-                    size="medium"
+                    size="small"
                     .name=${settings.profile.displayName || settings.profile.email}
                     .imageUrl=${settings.profile.avatarUrl ?? ''}
                     aria-hidden="true"
@@ -196,35 +264,80 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
                 ` : nothing}
               </div>
             </div>
-            <div class="row"><div class="settings-field"><span class="settings-label">Email</span><span class="settings-description">Managed by your identity provider.</span></div><span class="settings-value">${settings.profile.email || 'Not set'}</span></div>
-            <div class="row">
+            <div class="row profile-row"><div class="settings-field"><span class="settings-label">Email</span><span class="settings-description">Managed by your identity provider.</span></div><span class="settings-value profile-email">${settings.profile.email || 'Not set'}</span></div>
+            <div class="row profile-row">
               <div class="settings-field"><label class="settings-label" for="personal-display-name">Display name</label><span class="settings-description">How your name appears to collaborators.</span></div>
-              <form @submit=${this.saveProfile}><div class="actions"><input id="personal-display-name" .value=${this.profileName || settings.profile.displayName} ?disabled=${!settings.profile.canEditDisplayName} @input=${this.onProfileNameInput}><button class="primary" type="submit" ?disabled=${!settings.profile.canEditDisplayName}>Save</button></div></form>
+              <form class="profile-name-form" @submit=${this.saveProfile}>
+                <div class="profile-name-control">
+                  <input id="personal-display-name" .value=${profileNameDraft} ?disabled=${!settings.profile.canEditDisplayName} @input=${this.onProfileNameInput}>
+                  ${profileNameDirty ? html`<button class="primary" data-profile-save type="submit" ?disabled=${!settings.profile.canEditDisplayName || !profileNameValid}>Save</button>` : nothing}
+                </div>
+              </form>
             </div>
-            <div class="row">
-              <div class="settings-field"><label class="settings-label" for="personal-theme">Theme</label><span class="settings-description">Choose how LeapView appears on your devices.</span></div>
-              <select id="personal-theme" name="theme" .value=${settings.profile.theme || 'system'} @change=${this.changeTheme}>
-                <optgroup label="Automatic">
-                  <option value="system">System</option>
-                </optgroup>
-                <optgroup label="Standard">
-                  <option value="light">Light default</option>
-                  <option value="dark">Dark default</option>
-                  <option value="dark_dimmed">Soft dark</option>
-                </optgroup>
-                <optgroup label="Accessibility">
-                  <option value="light_colorblind">Light protanopia and deuteranopia</option>
-                  <option value="dark_colorblind">Dark protanopia and deuteranopia</option>
-                  <option value="light_tritanopia">Light tritanopia</option>
-                  <option value="dark_tritanopia">Dark tritanopia</option>
-                </optgroup>
-              </select>
+            <div class="row profile-row">
+              <div class="settings-field"><span class="settings-label" id="personal-theme-label">Theme</span><span class="settings-description">Choose how LeapView appears on your devices.</span></div>
+              ${this.renderThemePicker(this.selectedTheme || settings.profile.theme || 'system')}
             </div>
           </div>
         </section>` : nothing}
         ${settings.active === 'security' ? this.renderSecurity(settings) : nothing}
         ${settings.active === 'api-tokens' ? this.renderTokens(settings.tokens) : nothing}
       </div>
+    `
+  }
+
+  private renderThemePicker(theme: string) {
+    const selected = themeOption(theme)
+    return html`
+      <div class="theme-picker">
+        <button
+          class="theme-trigger"
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded=${String(this.themeMenuOpen)}
+          aria-labelledby="personal-theme-label personal-theme-value"
+          aria-controls="personal-theme-listbox"
+          @click=${this.toggleThemeMenu}
+          @keydown=${this.handleThemeTriggerKeydown}
+        >
+          ${this.renderThemePreview(selected)}
+          <span class="theme-trigger-label" id="personal-theme-value">${selected.label}</span>
+          ${lucideIcon(ChevronDown, { size: 16, strokeWidth: 2 })}
+        </button>
+        ${this.themeMenuOpen ? html`
+          <div id="personal-theme-listbox" class="theme-menu" role="listbox" aria-labelledby="personal-theme-label" @keydown=${this.handleThemeOptionKeydown}>
+            ${themeGroups.map((group) => html`
+              <div class="theme-group" role="group" aria-label=${group}>
+                <div class="theme-group-label" aria-hidden="true">${group}</div>
+                ${themeOptions.filter((option) => option.group === group).map((option) => html`
+                  <button
+                    class="theme-option"
+                    type="button"
+                    role="option"
+                    aria-selected=${String(option.value === selected.value)}
+                    data-theme=${option.value}
+                    tabindex="-1"
+                    @click=${() => this.chooseTheme(option.value)}
+                  >
+                    ${this.renderThemePreview(option)}
+                    <span class="theme-option-label">${option.label}</span>
+                    <span class="theme-check" aria-hidden="true">${option.value === selected.value ? lucideIcon(Check, { size: 16, strokeWidth: 2 }) : nothing}</span>
+                  </button>
+                `)}
+              </div>
+            `)}
+          </div>
+        ` : nothing}
+      </div>
+    `
+  }
+
+  private renderThemePreview(option: ThemeOption) {
+    return html`
+      <span class="theme-preview" data-tone=${option.tone} aria-hidden="true">
+        <span class="theme-preview-dot"></span>
+        <span>Aa</span>
+      </span>
     `
   }
 
@@ -337,10 +450,51 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   }
 
   private saveProfile = (event: Event): void => { event.preventDefault(); this.send('lv-personal-profile-command', { action: 'save', displayName: this.profileName.trim() }) }
-  private changeTheme = (event: Event): void => {
-    const theme = (event.currentTarget as HTMLSelectElement).value
+  private chooseTheme(theme: string): void {
+    this.selectedTheme = theme
     document.dispatchEvent(new CustomEvent('leapview-theme-change', { detail: { mode: theme } }))
     this.send('lv-personal-theme-command', { action: 'save', theme })
+    this.closeThemeMenu(true)
+  }
+  private toggleThemeMenu = (): void => {
+    this.themeMenuOpen = !this.themeMenuOpen
+    if (!this.themeMenuOpen) return
+    this.closeAvatarMenu()
+    this.closePermissionMenu()
+    void this.focusSelectedThemeOption()
+  }
+  private handleThemeTriggerKeydown = (event: KeyboardEvent): void => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+    event.preventDefault()
+    this.themeMenuOpen = true
+    this.closeAvatarMenu()
+    this.closePermissionMenu()
+    void this.focusSelectedThemeOption()
+  }
+  private focusSelectedThemeOption = async (): Promise<void> => {
+    await this.updateComplete
+    const options = Array.from(this.renderRoot.querySelectorAll<HTMLButtonElement>('.theme-option'))
+    const selected = options.find((option) => option.getAttribute('aria-selected') === 'true')
+    const focusTarget = selected ?? options[0]
+    focusTarget?.focus()
+  }
+  private handleThemeOptionKeydown = (event: KeyboardEvent): void => {
+    const options = Array.from(this.renderRoot.querySelectorAll<HTMLButtonElement>('.theme-option'))
+    const index = options.indexOf(this.shadowRoot?.activeElement as HTMLButtonElement)
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const offset = event.key === 'ArrowDown' ? 1 : -1
+      options[(index + offset + options.length) % options.length]?.focus()
+    } else if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault()
+      options[event.key === 'Home' ? 0 : options.length - 1]?.focus()
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      this.closeThemeMenu(true)
+    } else if (event.key === 'Tab') {
+      this.closeThemeMenu()
+    }
   }
   private changePassword = (event: Event): void => { event.preventDefault(); this.send('lv-personal-password-command', { currentPassword: this.currentPassword, newPassword: this.newPassword }); this.currentPassword = ''; this.newPassword = '' }
   private createToken = (event: Event): void => {
@@ -356,7 +510,11 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   private revokeAuthoringSession = (sessionId: string): void => { this.send('lv-personal-authoring-session-command', { action: 'revoke', sessionId }) }
   private toggleAvatarMenu = (): void => {
     this.avatarMenuOpen = !this.avatarMenuOpen
-    if (this.avatarMenuOpen) void this.focusFirstAvatarMenuItem()
+    if (this.avatarMenuOpen) {
+      this.closeThemeMenu()
+      this.closePermissionMenu()
+      void this.focusFirstAvatarMenuItem()
+    }
   }
   private handleAvatarTriggerKeydown = (event: KeyboardEvent): void => {
     if (event.key !== 'ArrowDown') return
@@ -395,6 +553,8 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
     if (avatarControl && !path.includes(avatarControl)) this.closeAvatarMenu()
     const permissionPicker = this.renderRoot.querySelector('.permission-picker')
     if (permissionPicker && !path.includes(permissionPicker)) this.closePermissionMenu()
+    const themePicker = this.renderRoot.querySelector('.theme-picker')
+    if (themePicker && !path.includes(themePicker)) this.closeThemeMenu()
   }
   private handleWindowKeydown = (event: KeyboardEvent): void => {
     if (event.key === 'Escape' && this.avatarMenuOpen) {
@@ -404,6 +564,10 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
     if (event.key === 'Escape' && this.tokenPermissionMenuOpen) {
       event.preventDefault()
       this.closePermissionMenu(true)
+    }
+    if (event.key === 'Escape' && this.themeMenuOpen) {
+      event.preventDefault()
+      this.closeThemeMenu(true)
     }
   }
   private handleDatastarFetch = (event: Event): void => {
@@ -455,6 +619,8 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   private togglePermissionMenu = (): void => {
     this.tokenPermissionMenuOpen = !this.tokenPermissionMenuOpen
     if (this.tokenPermissionMenuOpen) {
+      this.closeAvatarMenu()
+      this.closeThemeMenu()
       void this.updateComplete.then(() => {
         this.fitPermissionMenu()
         this.renderRoot.querySelector<HTMLInputElement>('.permission-search input')?.focus()
@@ -475,6 +641,11 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
     this.tokenPermissionSearch = ''
     if (returnFocus) void this.updateComplete.then(() => this.permissionTrigger?.focus())
   }
+  private closeThemeMenu(returnFocus = false): void {
+    if (!this.themeMenuOpen) return
+    this.themeMenuOpen = false
+    if (returnFocus) void this.updateComplete.then(() => this.themeTrigger?.focus())
+  }
   private onTokenPermissionSearch = (event: Event): void => { this.tokenPermissionSearch = (event.currentTarget as HTMLInputElement).value }
   private toggleTokenCapability(value: string): void {
     this.tokenCapabilities = this.tokenCapabilities.includes(value)
@@ -492,6 +663,10 @@ function groupTokenCapabilities(capabilities: PersonalCapabilityOptionSignal[]):
     groups.set(capability.category, values)
   }
   return [...groups.entries()]
+}
+
+function themeOption(value: string): ThemeOption {
+  return themeOptions.find((option) => option.value === value) ?? systemThemeOption
 }
 
 function humanizeCapability(value: string): string {

--- a/web/components/admin/personal-settings.ts
+++ b/web/components/admin/personal-settings.ts
@@ -45,6 +45,8 @@ const themeGroups: readonly ThemeOption['group'][] = ['Automatic', 'Standard', '
 
 class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   @state() private profileName = ''
+  @state() private profileTitle = ''
+  @state() private profileUsername = ''
   @state() private currentPassword = ''
   @state() private newPassword = ''
   @state() private tokenName = ''
@@ -65,6 +67,7 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   @query('.theme-trigger') private themeTrigger?: HTMLButtonElement
   private handledNewToken = ''
   private observedDisplayName = ''
+  private observedProfileID = ''
   private observedTheme = ''
 
   static styles = [settingsFieldStyles, css`
@@ -82,7 +85,8 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
     .profile-email { max-width: 22rem; justify-self: end; text-align: right; }
     .profile-name-form { min-width: 0; justify-self: end; }
     .profile-name-control { display: flex; min-width: 0; align-items: center; justify-content: flex-end; gap: var(--base-size-8); }
-    .profile-name-control input { width: min(16rem, 40vw); min-height: var(--control-medium-size, var(--base-size-32)); text-align: center; font: var(--lv-type-body); }
+    .profile-name-control input { width: min(13rem, 40vw); min-height: var(--control-medium-size, var(--base-size-32)); text-align: center; font: var(--lv-type-body); }
+    .profile-local-input { width: min(13rem, 40vw); min-height: var(--control-medium-size, var(--base-size-32)); justify-self: end; text-align: center; font: var(--lv-type-body); }
     .muted { color: var(--lv-fg-muted); font: var(--lv-type-caption); }
     input, select { min-width: 0; min-height: var(--control-small-size); box-sizing: border-box; border: var(--lv-border-default); border-radius: var(--lv-radius-small); padding: 0 var(--control-small-paddingInline-normal); color: var(--lv-fg-default); background: var(--lv-bg-input); font: var(--lv-type-body-compact); }
     button { min-height: var(--control-small-size); border: var(--lv-border-default); border-radius: var(--lv-radius-small); padding: 0 var(--control-small-paddingInline-normal); color: var(--lv-fg-default); background: var(--lv-button-bg-rest); cursor: pointer; font: var(--lv-type-body-compact); }
@@ -159,6 +163,7 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
       .profile-name-form { width: 100%; justify-self: stretch; }
       .profile-name-control { justify-content: stretch; }
       .profile-name-control input { width: auto; flex: 1 1 auto; }
+      .profile-local-input { width: 100%; justify-self: stretch; }
       .theme-picker { width: 100%; min-width: 0; justify-self: stretch; }
       .theme-trigger { width: 100%; }
       .theme-menu { right: auto; left: 0; }
@@ -195,6 +200,11 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
 
   override updated(): void {
     const settings = this.settings
+    if (settings.profile.id && settings.profile.id !== this.observedProfileID) {
+      this.observedProfileID = settings.profile.id
+      this.profileTitle = ''
+      this.profileUsername = usernameFromEmail(settings.profile.email)
+    }
     const displayName = settings.profile.displayName
     if (displayName !== this.observedDisplayName) {
       this.observedDisplayName = displayName
@@ -273,6 +283,14 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
                   ${profileNameDirty ? html`<button class="primary" data-profile-save type="submit" ?disabled=${!settings.profile.canEditDisplayName || !profileNameValid}>Save</button>` : nothing}
                 </div>
               </form>
+            </div>
+            <div class="row profile-row">
+              <div class="settings-field"><label class="settings-label" for="personal-title">Title</label><span class="settings-description">Your job title or role.</span></div>
+              <input id="personal-title" class="profile-local-input profile-title-input" maxlength="120" placeholder="Software engineer" .value=${this.profileTitle} @input=${this.onProfileTitleInput}>
+            </div>
+            <div class="row profile-row">
+              <div class="settings-field"><label class="settings-label" for="personal-username">Username</label><span class="settings-description">One word, like a nickname or first name.</span></div>
+              <input id="personal-username" class="profile-local-input profile-username-input" maxlength="64" autocomplete="off" .value=${this.profileUsername} @input=${this.onProfileUsernameInput}>
             </div>
             <div class="row profile-row">
               <div class="settings-field"><span class="settings-label" id="personal-theme-label">Theme</span><span class="settings-description">Choose how LeapView appears on your devices.</span></div>
@@ -607,6 +625,8 @@ class LeapViewPersonalSettings extends DatastarLit(LitElement) {
   }
   private send(name: string, detail: Record<string, unknown>): void { this.error = ''; this.message = ''; this.dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true, detail })) }
   private onProfileNameInput = (event: Event): void => { this.profileName = (event.currentTarget as HTMLInputElement).value }
+  private onProfileTitleInput = (event: Event): void => { this.profileTitle = (event.currentTarget as HTMLInputElement).value }
+  private onProfileUsernameInput = (event: Event): void => { this.profileUsername = (event.currentTarget as HTMLInputElement).value }
   private onCurrentPasswordInput = (event: Event): void => { this.currentPassword = (event.currentTarget as HTMLInputElement).value }
   private onNewPasswordInput = (event: Event): void => { this.newPassword = (event.currentTarget as HTMLInputElement).value }
   private onTokenNameInput = (event: Event): void => { this.tokenName = (event.currentTarget as HTMLInputElement).value }
@@ -667,6 +687,11 @@ function groupTokenCapabilities(capabilities: PersonalCapabilityOptionSignal[]):
 
 function themeOption(value: string): ThemeOption {
   return themeOptions.find((option) => option.value === value) ?? systemThemeOption
+}
+
+function usernameFromEmail(email: string): string {
+  const localPart = email.split('@', 1)[0]?.trim().toLocaleLowerCase() ?? ''
+  return localPart.replace(/[^a-z0-9._-]+/g, '.').replace(/^[._-]+|[._-]+$/g, '') || 'user'
 }
 
 function humanizeCapability(value: string): string {

--- a/web/components/admin/settings-surfaces.dom.test.ts
+++ b/web/components/admin/settings-surfaces.dom.test.ts
@@ -204,7 +204,8 @@ test('principal administration exposes local controls and keeps external profile
         activity: [{ id: 'event-1', action: 'principal.updated', actorId: 'admin-1', actorName: 'Admin User', status: 'success', createdAt: '2026-08-02T11:00:00Z' }],
         selectedPrincipalId: 'local-1', loading: false,
       }
-      runtime.setDatastarLitRuntimeForTests?.({ root: { adminAccess: state }, getPath: (path: string) => path === 'adminAccess' ? state : undefined, effect: (fn: () => void) => { fn(); return () => {} } })
+      const chrome = { sidebar: { userAvatarUrl: '/profile/avatars/local-1/avatar-digest' } }
+      runtime.setDatastarLitRuntimeForTests?.({ root: { adminAccess: state, chrome }, getPath: (path: string) => path === 'adminAccess' ? state : path === 'chrome' ? chrome : undefined, effect: (fn: () => void) => { fn(); return () => {} } })
       const element = document.querySelector('lv-principal-administration') as any
       element.requestUpdate(); await element.updateComplete
       const commands: unknown[] = []
@@ -221,6 +222,7 @@ test('principal administration exposes local controls and keeps external profile
         status: element.shadowRoot.querySelector('[data-user-status]')?.textContent?.trim(),
         sharedLayout: Boolean(element.shadowRoot.querySelector('.detail-surface .detail-sections')),
         cardCount: element.shadowRoot.querySelectorAll('.detail-card').length,
+        avatarSrc: (element.shadowRoot.querySelector('lv-user-avatar') as any)?.shadowRoot?.querySelector('img')?.getAttribute('src'),
       }
       state.selectedPrincipalId = 'sso-1'
       element.requestUpdate(); await element.updateComplete
@@ -240,6 +242,7 @@ test('principal administration exposes local controls and keeps external profile
     expect(result.local.status).toBe('Active')
     expect(result.local.sharedLayout).toBe(true)
     expect(result.local.cardCount).toBe(0)
+    expect(result.local.avatarSrc).toBe('/profile/avatars/local-1/avatar-digest')
     expect(result.externalText).toContain('OKTA owns this identity')
     expect(result.externalForm).toBe(false)
   } finally { await page.close() }

--- a/web/components/admin/settings-surfaces.ts
+++ b/web/components/admin/settings-surfaces.ts
@@ -7,6 +7,7 @@ import { entityDetailStyles, renderEntityDetail } from '../shared/entity-detail'
 import { lucideIcon } from '../shared/lucide-icons'
 import type { AccessActivitySignal, AccessAdministrationSignal, AccessGroupSignal, AccessPrincipalSignal, AuditLogSignal, ServiceAccountSignal, ServiceAccountsSignal, ProjectRegistrySignal } from '../../generated/signals'
 import '../shared/entity-list'
+import '../shared/user-avatar'
 import type { EntityListColumn, EntityListItem } from '../shared/entity-list'
 import '../shared/entity-multi-select'
 import type { EntityMultiSelectItem } from '../shared/entity-multi-select'
@@ -86,6 +87,7 @@ const tableStyles = css`
   .activity-item:last-child { border-bottom: 0; }
   .activity-dot { width: 8px; height: 8px; margin-top: 6px; border-radius: 50%; background: var(--lv-fg-muted); }
   .activity-copy { display: grid; gap: var(--base-size-2); }
+  .detail-user-avatar { --lv-user-avatar-size: 100%; width: 100%; height: 100%; }
   @media (max-width: 760px) {
     .detail-section { padding-block: var(--base-size-20); }
     .detail-empty-row { grid-template-columns: minmax(6.5rem, 0.7fr) minmax(0, 1.3fr); }
@@ -235,9 +237,10 @@ class LeapViewPrincipalAdministration extends LeapViewAccessAdministrationBase {
         </details>` : nothing}`
     const notice = principal.identitySource === 'external' ? html`<div class="detail-notice" role="note"><span class="detail-notice-icon" aria-hidden="true">${lucideIcon(Info, { size: 18, strokeWidth: 2 })}</span><p><strong>${source} owns this identity.</strong> Profile fields and synchronized memberships are read-only in LeapView. Block access locally or revoke sessions here; update or permanently remove the user in ${source}.</p></div>`
       : principal.identitySource === 'system' ? html`<div class="detail-notice" role="note"><span class="detail-notice-icon" aria-hidden="true">${lucideIcon(Info, { size: 18, strokeWidth: 2 })}</span><p><strong>System-managed account.</strong> Profile fields are read-only because this account is provisioned by LeapView configuration. Block access locally or revoke sessions here; update it through its provisioning source.</p></div>` : nothing
+    const avatarUrl = currentPrincipalAvatarUrl(this.signal<{ sidebar?: { userAvatarUrl?: string } }>('chrome', {}), principal.id)
     return renderEntityDetail({
       label: 'User administration', feedback: this.feedback(), backHref: '/admin/principals', backLabel: 'All users',
-      avatar: principalInitials(principal), title: principal.displayName || principal.email || principal.id, subtitle: principal.email,
+      avatar: avatarUrl ? html`<lv-user-avatar class="detail-user-avatar" .name=${principal.displayName || principal.email} .imageUrl=${avatarUrl} aria-hidden="true"></lv-user-avatar>` : principalInitials(principal), title: principal.displayName || principal.email || principal.id, subtitle: principal.email,
       badges: html`<span class="badge">${source}</span><span class=${`badge status-${status.toLowerCase()}`} data-user-status>${status}</span>`,
       actions, notice,
       sections: html`
@@ -470,6 +473,17 @@ function identitySourceLabel(principal: AccessPrincipalSignal): string {
 
 function principalInitials(principal: AccessPrincipalSignal): string {
   return initialsForValue(principal.displayName || principal.email || principal.id)
+}
+
+function currentPrincipalAvatarUrl(chrome: { sidebar?: { userAvatarUrl?: string } }, principalId: string): string {
+  const avatarUrl = chrome.sidebar?.userAvatarUrl?.trim() ?? ''
+  if (!avatarUrl) return ''
+  try {
+    const parts = new URL(avatarUrl, window.location.origin).pathname.split('/')
+    return parts[1] === 'profile' && parts[2] === 'avatars' && decodeURIComponent(parts[3] ?? '') === principalId ? avatarUrl : ''
+  } catch {
+    return ''
+  }
 }
 
 function initialsForValue(value: string): string {

--- a/web/components/app/app-shell.dom.test.ts
+++ b/web/components/app/app-shell.dom.test.ts
@@ -1260,6 +1260,41 @@ test('admin sidebar keeps chrome fixed while only navigation items scroll', asyn
   }
 })
 
+test('desktop page content scrolls without moving the sidebar', async () => {
+  const page = await browser.newPage({ viewport: { width: 1320, height: 520 } })
+  try {
+    await page.goto(`${baseURL}/admin-sidebar`)
+    await page.waitForFunction(() => customElements.get('lv-app-shell') && customElements.get('lv-sidebar'))
+    const state = await page.locator('lv-app-shell').evaluate(async (element: any) => {
+      await element.updateComplete
+      const main = element.shadowRoot.querySelector('main') as HTMLElement
+      const sidebar = element.shadowRoot.querySelector('lv-sidebar') as HTMLElement
+      const pageContent = element.querySelector('[slot="page"]') as HTMLElement
+      pageContent.style.minHeight = '1200px'
+      const sidebarTopBefore = Math.round(sidebar.getBoundingClientRect().top)
+      main.scrollTop = 320
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      return {
+        documentHeight: document.documentElement.scrollHeight,
+        mainOverflowY: getComputedStyle(main).overflowY,
+        mainScrollTop: main.scrollTop,
+        sidebarTopBefore,
+        sidebarTopAfter: Math.round(sidebar.getBoundingClientRect().top),
+      }
+    })
+
+    expect(state).toEqual({
+      documentHeight: 520,
+      mainOverflowY: 'auto',
+      mainScrollTop: 320,
+      sidebarTopBefore: 0,
+      sidebarTopAfter: 0,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
 test('app shell ignores synthetic file input clicks from page content', async () => {
   const page = await browser.newPage({ viewport: { width: 1320, height: 900 } })
   try {

--- a/web/components/app/app-shell.ts
+++ b/web/components/app/app-shell.ts
@@ -27,8 +27,10 @@ class LeapViewAppShell extends DatastarLit(LitElement) {
   static styles = css`
     :host {
       display: grid;
-      min-height: 100svh;
+      height: 100svh;
+      min-height: 0;
       grid-template-columns: auto minmax(0, 1fr);
+      overflow: hidden;
       background: var(--lv-bg-app);
       color: var(--lv-fg-default);
       font-family: var(--fontStack-system);
@@ -49,13 +51,15 @@ class LeapViewAppShell extends DatastarLit(LitElement) {
 
     main {
       min-width: 0;
-      min-height: 100svh;
+      min-height: 0;
+      overflow-y: auto;
+      overscroll-behavior: contain;
     }
 
     ::slotted([slot='page']) {
       display: block;
       min-width: 0;
-      min-height: 100svh;
+      min-height: 100%;
     }
 
     @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- polish the personal profile layout, theme picker, avatar controls, title, and username fields
- reuse the signed-in profile image on the matching Principals detail page
- keep the admin sidebar fixed while page content scrolls independently

## Frontend-only verification
- bun run test:admin-page (20 passed)
- bun run test:app-shell (25 passed)
- bun test web/components/admin/settings-surfaces.dom.test.ts (8 passed)

The dashboard visual changes were intentionally left out and will remain in a follow-up PR.