### PR TITLE
Add recovery qualification freshness alerts

### DIFF
--- a/deploy/observability/prometheus/leapview-alerts.yaml
+++ b/deploy/observability/prometheus/leapview-alerts.yaml
@@ -36,3 +36,36 @@ groups:
           summary: "LeapView DuckDB runtime on {{ $labels.instance }} is fatally unhealthy"
           description: "The process-owned DuckDB runtime on {{ $labels.instance }} reports a fatal cleanup-safety failure."
           runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
+
+      - alert: LeapViewRecoveryQualificationLedgerScrapeFailure
+        expr: max by (job, instance) (leapview_recovery_qualification_scrape_error{job="leapview"}) > 0
+        for: 5m
+        labels:
+          service: leapview
+          severity: warning
+        annotations:
+          summary: "LeapView recovery qualification ledger on {{ $labels.instance }} is unavailable"
+          description: "LeapView has been unable to collect recovery qualification ledger status on {{ $labels.instance }} for more than 5 minutes."
+          runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire"
+
+      - alert: LeapViewRecoveryQualificationOverdue
+        expr: max by (job, instance) (leapview_recovery_qualification_overdue{job="leapview"}) > 0
+        for: 10m
+        labels:
+          service: leapview
+          severity: critical
+        annotations:
+          summary: "LeapView recovery qualification on {{ $labels.instance }} is overdue"
+          description: "At least one recovery qualification on {{ $labels.instance }} has remained past its policy-defined stale deadline for more than 10 minutes."
+          runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire"
+
+      - alert: LeapViewRecoveryQualificationEvidencePublicationFailure
+        expr: max by (job, instance) (leapview_recovery_qualification_evidence{job="leapview",state="failed"}) > 0
+        for: 15m
+        labels:
+          service: leapview
+          severity: warning
+        annotations:
+          summary: "LeapView recovery evidence publication on {{ $labels.instance }} is failing"
+          description: "At least one recovery qualification on {{ $labels.instance }} has remained in failed evidence publication state for more than 15 minutes."
+          runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire"

--- a/deploy/observability/prometheus/testdata/leapview-alerts.test.yaml
+++ b/deploy/observability/prometheus/testdata/leapview-alerts.test.yaml
@@ -13,6 +13,12 @@ tests:
         values: '0+5x20'
       - series: 'leapview_duckdb_fatal_health{job="leapview",instance="app:8080",pod="leapview-healthy"}'
         values: '0x20'
+      - series: 'leapview_recovery_qualification_scrape_error{job="leapview",instance="app:8080"}'
+        values: '0x20'
+      - series: 'leapview_recovery_qualification_overdue{job="leapview",instance="app:8080"}'
+        values: '0x20'
+      - series: 'leapview_recovery_qualification_evidence{job="leapview",instance="app:8080",state="failed"}'
+        values: '0x20'
     alert_rule_test:
       - eval_time: 15m
         alertname: LeapViewTargetUnavailable
@@ -22,6 +28,15 @@ tests:
         exp_alerts: []
       - eval_time: 15m
         alertname: LeapViewDuckDBFatalHealth
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: LeapViewRecoveryQualificationLedgerScrapeFailure
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: LeapViewRecoveryQualificationOverdue
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: LeapViewRecoveryQualificationEvidencePublicationFailure
         exp_alerts: []
 
   - name: unavailable target fires after two minutes
@@ -100,4 +115,94 @@ tests:
               runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting"
       - eval_time: 5m
         alertname: LeapViewDuckDBFatalHealth
+        exp_alerts: []
+
+  - name: recovery ledger scrape failure fires and recovers
+    interval: 1m
+    input_series:
+      - series: 'leapview_recovery_qualification_scrape_error{job="leapview",instance="app:8080",operation="restore",state="failed",occurrence="occurrence-forbidden",schedule="schedule-forbidden",artifact="artifact-forbidden",target="target-forbidden",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
+        values: '1x7 0x4'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: LeapViewRecoveryQualificationLedgerScrapeFailure
+        exp_alerts:
+          - exp_labels:
+              instance: app:8080
+              job: leapview
+              service: leapview
+              severity: warning
+            exp_annotations:
+              summary: "LeapView recovery qualification ledger on app:8080 is unavailable"
+              description: "LeapView has been unable to collect recovery qualification ledger status on app:8080 for more than 5 minutes."
+              runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire"
+      - eval_time: 9m
+        alertname: LeapViewRecoveryQualificationLedgerScrapeFailure
+        exp_alerts: []
+
+  - name: policy overdue qualification fires and recovers
+    interval: 1m
+    input_series:
+      - series: 'leapview_recovery_qualification_overdue{job="leapview",instance="app:8080",operation="backup",state="overdue",occurrence="occurrence-forbidden",schedule="schedule-forbidden",artifact="artifact-forbidden",target="target-forbidden",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
+        values: '1x12 0x4'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: LeapViewRecoveryQualificationOverdue
+        exp_alerts:
+          - exp_labels:
+              instance: app:8080
+              job: leapview
+              service: leapview
+              severity: critical
+            exp_annotations:
+              summary: "LeapView recovery qualification on app:8080 is overdue"
+              description: "At least one recovery qualification on app:8080 has remained past its policy-defined stale deadline for more than 10 minutes."
+              runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire"
+      - eval_time: 14m
+        alertname: LeapViewRecoveryQualificationOverdue
+        exp_alerts: []
+
+  - name: delayed reconciliation remains healthy before the policy deadline
+    interval: 1m
+    input_series:
+      - series: 'leapview_recovery_qualification_missing{job="leapview",instance="app:8080",schedule="schedule-forbidden"}'
+        values: '1x20'
+      - series: 'leapview_recovery_qualification_due{job="leapview",instance="app:8080",occurrence="occurrence-forbidden"}'
+        values: '1x20'
+      - series: 'leapview_recovery_qualification_overdue{job="leapview",instance="app:8080"}'
+        values: '0x20'
+      - series: 'leapview_recovery_qualification_scrape_error{job="leapview",instance="app:8080"}'
+        values: '0x20'
+      - series: 'leapview_recovery_qualification_evidence{job="leapview",instance="app:8080",state="failed"}'
+        values: '0x20'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: LeapViewRecoveryQualificationLedgerScrapeFailure
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: LeapViewRecoveryQualificationOverdue
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: LeapViewRecoveryQualificationEvidencePublicationFailure
+        exp_alerts: []
+
+  - name: evidence publication failure fires and recovers
+    interval: 1m
+    input_series:
+      - series: 'leapview_recovery_qualification_evidence{job="leapview",instance="app:8080",state="failed",operation="restore",occurrence="occurrence-forbidden",schedule="schedule-forbidden",artifact="artifact-forbidden",target="target-forbidden",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
+        values: '1x17 0x4'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: LeapViewRecoveryQualificationEvidencePublicationFailure
+        exp_alerts:
+          - exp_labels:
+              instance: app:8080
+              job: leapview
+              service: leapview
+              severity: warning
+            exp_annotations:
+              summary: "LeapView recovery evidence publication on app:8080 is failing"
+              description: "At least one recovery qualification on app:8080 has remained in failed evidence publication state for more than 15 minutes."
+              runbook_url: "https://leapview.dev/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire"
+      - eval_time: 19m
+        alertname: LeapViewRecoveryQualificationEvidencePublicationFailure
         exp_alerts: []

--- a/docs/articles/operate/observability.md
+++ b/docs/articles/operate/observability.md
@@ -24,7 +24,7 @@ Monitor at least process resource use, request rate and latency, error status, r
 
 ### Baseline health alerts
 
-The repository-owned rule file at `deploy/observability/prometheus/leapview-alerts.yaml` provides portable alerts for an unavailable scrape target, sustained application 5xx responses, and fatal process-owned DuckDB health. The rules assume that Prometheus assigns LeapView targets the stable scrape label `job="leapview"`; `instance` must identify the bounded scrape target. Alert identity is limited to those scrape labels plus the static `service` and `severity` labels. Request routes, request or trace identities, principals, projects, and resource identifiers are aggregated away and never become alert labels.
+The repository-owned rule file at `deploy/observability/prometheus/leapview-alerts.yaml` provides portable alerts for an unavailable scrape target, sustained application 5xx responses, fatal process-owned DuckDB health, and recovery qualification freshness. The rules assume that Prometheus assigns LeapView targets the stable scrape label `job="leapview"`; `instance` must identify the bounded scrape target. Alert identity is limited to those scrape labels plus the static `service` and `severity` labels. Operation, publication state, occurrence, schedule, artifact, target, request or trace identities, principals, projects, and resource identifiers are aggregated away and never become alert labels.
 
 Validate the syntax, PromQL behavior, firing delay, labels, and annotations with the pinned Prometheus toolchain:
 
@@ -41,7 +41,11 @@ rule_files:
   - /etc/prometheus/rules/leapview-alerts.yaml
 ```
 
-Reload Prometheus only after validation succeeds. The target-unavailable rule relies on Prometheus's standard `up` metric and therefore requires the target to remain present in Prometheus service discovery; a target omitted from the scrape configuration cannot alert. The 5xx rule uses `leapview_http_requests_total`, aggregates method, route, and status dimensions down to `job` and `instance`, and requires a positive five-minute error rate continuously for ten minutes. `leapview_duckdb_fatal_health` is present only when LeapView owns a process-local DuckDB environment. Every alert links to [Operational troubleshooting](/docs/guides/operate/troubleshooting); configure routing and receivers in the operator-owned Alertmanager deployment.
+Reload Prometheus only after validation succeeds. The target-unavailable rule relies on Prometheus's standard `up` metric and therefore requires the target to remain present in Prometheus service discovery; a target omitted from the scrape configuration cannot alert. The 5xx rule uses `leapview_http_requests_total`, aggregates method, route, and status dimensions down to `job` and `instance`, and requires a positive five-minute error rate continuously for ten minutes. `leapview_duckdb_fatal_health` is present only when LeapView owns a process-local DuckDB environment.
+
+Recovery alerts use current-state ledger projections. `leapview_recovery_qualification_scrape_error` clears after a successful ledger collection. `leapview_recovery_qualification_overdue` is recalculated from each active schedule's staleness policy and current occurrences, so ordinary missing or due work does not alert before its policy deadline. `leapview_recovery_qualification_evidence{state="failed"}` represents unresolved publication failures, remains retryable with persisted backoff, and clears after publication succeeds. The retained terminal-history gauge `leapview_recovery_qualification_failed` is deliberately not used for alerting because a later successful qualification does not remove old failures. Hold windows of five, ten, and fifteen minutes respectively absorb transient collection, reconciliation, and publication retry conditions.
+
+Every alert links to [Operational troubleshooting](/docs/guides/operate/troubleshooting); recovery alerts link directly to the [recovery qualification response](/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire). Configure routing and receivers in the operator-owned Alertmanager deployment.
 
 ## Structured logs
 

--- a/docs/articles/operate/troubleshooting.md
+++ b/docs/articles/operate/troubleshooting.md
@@ -67,6 +67,18 @@ leapview admin storage cleanup
 
 Review protected serving states and query leases, then use `--apply` only under the approved maintenance procedure. Do not delete catalog rows or Parquet objects manually.
 
+## Recovery qualification freshness alerts fire
+
+Inspect the bounded ledger projection with the service stopped or from the same controlled maintenance environment used for other offline Admin commands:
+
+```sh
+leapview admin recovery status
+```
+
+For a ledger scrape failure, check the application logs for ledger read errors or the two-second collection timeout and confirm the protected metrics endpoint still scrapes successfully. For an overdue qualification, distinguish a schedule occurrence that was not materialized from pending work or an expired execution lease; the configured staleness policy has already elapsed. For failed evidence publication, check the private evidence destination, service-account access, capacity, and retry worker without printing credentials, signed URLs, evidence content, or failure payloads.
+
+Correct the underlying scheduler, worker, ledger, or publication dependency and let normal reconciliation or persisted publication backoff recover the current state. Do not delete ledger rows or rerun a destructive recovery scenario merely to clear an alert. Preserve occurrence and evidence identities in the restricted incident record, then confirm `leapview_recovery_qualification_scrape_error`, `leapview_recovery_qualification_overdue`, or `leapview_recovery_qualification_evidence{state="failed"}` returns to zero and the alert resolves on the next rule evaluation.
+
 ## Gather a useful incident record
 
 Record impact, start time, last known good deployment/image/revision, failing identities, relevant metrics and logs, attempted actions, and whether active state changed. Redact secrets but keep stable digests and IDs.


### PR DESCRIPTION
## Problem

LeapView exposes current recovery qualification ledger health and freshness metrics, but the repository-owned Prometheus rules did not alert when ledger collection failed, qualifications exceeded their configured staleness policy, or publication of existing evidence remained unhealthy. Operators could miss a degraded recovery-readiness posture until an incident.

## Root cause

FAI-554 established portable baseline alert ownership for process and HTTP health only. Stable recovery qualification metrics already existed, but their current-state versus retained-history semantics had not yet been encoded in alert rules.

## Solution

- Add bounded `job`/`instance` alerts for sustained ledger collection failure, policy-defined overdue qualifications, and unresolved retryable evidence publication failure.
- Exclude the retained `leapview_recovery_qualification_failed` history gauge from alerting.
- Aggregate all operation, publication-state, occurrence, schedule, artifact, target, request, trace, principal, project, and resource dimensions away from alert identity.
- Add hold windows of 5, 10, and 15 minutes to absorb transient collection, reconciliation, and evidence retry conditions.
- Add focused troubleshooting guidance and document the selected metric semantics and operator response.

## Tests added/updated

- Healthy recovery state.
- Firing and recovery for all three alerts.
- Delayed reconciliation before the policy-defined stale deadline.
- Exact labels and annotations, including direct runbook links.
- Prohibited/high-cardinality source labels are absent from alert output.

## Verification performed

- `task observability:alerts:check`
- `go test ./internal/refresh/recovery ./internal/refresh/sqlite`
- `go run ./internal/app/tools/agenttooldocgen --check`
- `go run -tags=duckdb_arrow ./internal/app/tools/visualdocgen --check`
- `go run ./internal/app/tools/docsitegen --check`
- `go test ./internal/app/site/http -run '^TestEveryRenderedDocumentationLinkResolves$' -count=1`
- `git diff --check`

All listed focused checks passed. The combined `task docs:check` could not run end-to-end in the local environment because Bun is unavailable; its relevant Go documentation generators and link test were run independently and passed.

## Limitations

- These rules do not deploy Prometheus or configure Alertmanager routing/receivers.
- No alert is created from the retained terminal failure gauge because it cannot distinguish unresolved current risk from historical failures.
- No metrics, runtime behavior, dashboards, SLOs, tracing, or synthetic checks are added.

Closes FAI-578
