### PR TITLE
Establish dashboard refresh reliability SLI

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -875,6 +875,12 @@ tasks:
       - ./scripts/promtool.sh check rules deploy/observability/prometheus/leapview-alerts.yaml
       - ./scripts/promtool.sh test rules deploy/observability/prometheus/testdata/leapview-alerts.test.yaml
 
+  observability:sli:check:
+    desc: Validate repository-owned Prometheus SLI recording rules and fixtures
+    cmds:
+      - ./scripts/promtool.sh check rules deploy/observability/prometheus/leapview-recording-rules.yaml
+      - ./scripts/promtool.sh test rules deploy/observability/prometheus/testdata/leapview-recording-rules.test.yaml
+
   image:qualify:production:
     desc: Qualify an immutable LeapView production image
     requires:

--- a/deploy/observability/prometheus/leapview-recording-rules.yaml
+++ b/deploy/observability/prometheus/leapview-recording-rules.yaml
@@ -1,0 +1,42 @@
+groups:
+  - name: leapview-dashboard-refresh-reliability
+    rules:
+      - record: 'leapview:dashboard_refresh_reliability:ratio_5m'
+        expr: |
+          (
+            sum by (job, instance) (
+              rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome="complete"}[5m])
+              or
+              (rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome!="canceled"}[5m]) * 0)
+            )
+            /
+            sum by (job, instance) (
+              rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome!="canceled"}[5m])
+            )
+          )
+          and on (job, instance)
+          (
+            sum by (job, instance) (
+              rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome!="canceled"}[5m])
+            ) > 0
+          )
+
+      - record: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        expr: |
+          (
+            sum by (job, instance) (
+              rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome="complete"}[30d])
+              or
+              (rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome!="canceled"}[30d]) * 0)
+            )
+            /
+            sum by (job, instance) (
+              rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome!="canceled"}[30d])
+            )
+          )
+          and on (job, instance)
+          (
+            sum by (job, instance) (
+              rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome!="canceled"}[30d])
+            ) > 0
+          )

--- a/deploy/observability/prometheus/testdata/leapview-recording-rules.test.yaml
+++ b/deploy/observability/prometheus/testdata/leapview-recording-rules.test.yaml
@@ -1,0 +1,128 @@
+rule_files:
+  - ../leapview-recording-rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - name: successful refreshes produce perfect reliability
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="complete"}'
+        values: '0+10x10'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_5m'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_5m",instance="app:8080",job="leapview"}'
+            value: 1
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
+            value: 1
+
+  - name: partial failures aggregate commands and prohibited labels
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="complete",route="/dashboards/{dashboard}",request_id="req-forbidden",trace_id="trace-forbidden",user_id="user-forbidden",project_id="project-forbidden",resource_id="resource-forbidden"}'
+        values: '0+4x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="navigate",outcome="complete",route="/updates",request_id="req-other",trace_id="trace-other",user_id="user-other",project_id="project-other",resource_id="resource-other"}'
+        values: '0+4x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="filter_change",outcome="partial",route="/updates",request_id="req-partial",trace_id="trace-partial",user_id="user-partial",project_id="project-partial",resource_id="resource-partial"}'
+        values: '0+2x10'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_5m'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_5m",instance="app:8080",job="leapview"}'
+            value: 0.8
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.8
+
+  - name: error and unknown outcomes are bad refreshes
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="select",outcome="complete"}'
+        values: '0+8x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="select",outcome="error"}'
+        values: '0+1x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="other",outcome="other"}'
+        values: '0+1x10'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_5m'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_5m",instance="app:8080",job="leapview"}'
+            value: 0.8
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.8
+
+  - name: canceled refreshes are excluded from eligibility
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="complete"}'
+        values: '0+5x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="filter_change",outcome="canceled"}'
+        values: '0+100x10'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_5m'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_5m",instance="app:8080",job="leapview"}'
+            value: 1
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
+            value: 1
+
+  - name: counter resets preserve reliability
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="complete"}'
+        values: '0 4 8 12 16 20 0 4 8 12 16'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="error"}'
+        values: '0 4 8 12 16 20 0 4 8 12 16'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_5m'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_5m",instance="app:8080",job="leapview"}'
+            value: 0.5
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.5
+
+  - name: zero eligible traffic produces no ratio
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="complete"}'
+        values: '0x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="filter_change",outcome="canceled"}'
+        values: '0+10x10'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_5m'
+        eval_time: 10m
+        exp_samples: []
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples: []
+
+  - name: missing traffic is not perfect reliability
+    interval: 1m
+    input_series: []
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_5m'
+        eval_time: 10m
+        exp_samples: []
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples: []

--- a/docs/articles/operate/observability.md
+++ b/docs/articles/operate/observability.md
@@ -34,11 +34,12 @@ task observability:alerts:check
 
 The task downloads the official Prometheus archive for the supported Linux or macOS architecture, verifies its pinned SHA-256 digest, caches `promtool` under `.tmp/tools`, then runs `promtool check rules` and the healthy and firing rule fixtures.
 
-Copy or mount the rule file into the Prometheus deployment and reference it from the Prometheus configuration:
+Copy or mount the rule files into the Prometheus deployment and reference them from the Prometheus configuration:
 
 ```yaml
 rule_files:
   - /etc/prometheus/rules/leapview-alerts.yaml
+  - /etc/prometheus/rules/leapview-recording-rules.yaml
 ```
 
 Reload Prometheus only after validation succeeds. The target-unavailable rule relies on Prometheus's standard `up` metric and therefore requires the target to remain present in Prometheus service discovery; a target omitted from the scrape configuration cannot alert. The 5xx rule uses `leapview_http_requests_total`, aggregates method, route, and status dimensions down to `job` and `instance`, and requires a positive five-minute error rate continuously for ten minutes. `leapview_duckdb_fatal_health` is present only when LeapView owns a process-local DuckDB environment.
@@ -46,6 +47,20 @@ Reload Prometheus only after validation succeeds. The target-unavailable rule re
 Recovery alerts use current-state ledger projections. `leapview_recovery_qualification_scrape_error` clears after a successful ledger collection. `leapview_recovery_qualification_overdue` is recalculated from each active schedule's staleness policy and current occurrences, so ordinary missing or due work does not alert before its policy deadline. `leapview_recovery_qualification_evidence{state="failed"}` represents unresolved publication failures, remains retryable with persisted backoff, and clears after publication succeeds. The retained terminal-history gauge `leapview_recovery_qualification_failed` is deliberately not used for alerting because a later successful qualification does not remove old failures. Hold windows of five, ten, and fifteen minutes respectively absorb transient collection, reconciliation, and publication retry conditions.
 
 Every alert links to [Operational troubleshooting](/docs/guides/operate/troubleshooting); recovery alerts link directly to the [recovery qualification response](/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire). Configure routing and receivers in the operator-owned Alertmanager deployment.
+
+### Dashboard refresh reliability SLI
+
+The repository-owned recording rules at `deploy/observability/prometheus/leapview-recording-rules.yaml` derive dashboard refresh reliability only from `leapview_dashboard_refresh_duration_seconds_count`. A finished refresh is eligible unless its outcome is `canceled`. `complete` is good; `partial`, `error`, and the bounded fallback `other` are bad. Cancellations are excluded because refresh supersession and stream closure are expected lifecycle behavior rather than evidence of failed dashboard work.
+
+`leapview:dashboard_refresh_reliability:ratio_5m` records the five-minute good-to-eligible ratio. `leapview:dashboard_refresh_reliability:ratio_30d` records the rolling 30-day ratio. Both aggregate command and outcome dimensions to the stable `job` and `instance` scrape labels. Validate the rules, counter-reset behavior, empty-traffic handling, aggregation, and label contract with the existing pinned toolchain:
+
+```sh
+task observability:sli:check
+```
+
+Prometheus must retain at least 30 days of source samples for a complete rolling window. Until that history has accumulated after initial deployment or retention loss, the 30-day rule reflects only the available portion of the window. Counter resets are handled by `rate`. When an instance has no eligible refresh traffic, including when it has only canceled refreshes, the recording rules emit no ratio; missing or idle traffic is never reported as perfect reliability. Sparse traffic can make the five-minute ratio volatile and the 30-day ratio statistically weak, so operators should inspect eligible event volume before interpreting either series.
+
+This SLI measures only completed dashboard refresh work. It does not measure refreshes still in flight, HTTP or SSE transport continuity, authentication, static assets, direct API queries, or an end-to-end synthetic journey. It defines no SLO target, error budget, burn rate, or alert threshold.
 
 ## Structured logs
 


### PR DESCRIPTION
## Problem

LeapView records bounded dashboard refresh outcomes and end-to-end durations, but operators had no repository-owned Prometheus recording rules that converted those observations into a canonical reliability indicator. Ad hoc queries could disagree about good and bad outcomes, count expected cancellations as failures, or report missing traffic as perfect reliability.

## Root cause

The dashboard refresh histogram was designed as a stable source metric, while prior observability work owned alert rules only. No repository contract defined the eligible event population, the good-event numerator, empty-traffic behavior, or rolling measurement windows.

## Solution

- Add separate five-minute and rolling 30-day dashboard refresh reliability recording rules.
- Treat every non-canceled refresh as eligible and only `complete` as good, making `partial`, `error`, and future/`other` outcomes bad by default.
- Exclude expected canceled/superseded refreshes from both numerator and denominator.
- Filter zero denominators so idle or missing traffic emits no ratio.
- Aggregate command, outcome, and all other source dimensions to stable `job` and `instance` labels.
- Add a reproducible validation task using the existing checksum-pinned promtool wrapper.
- Document the SLI definition, retention and warm-up assumptions, low-traffic behavior, and measurement boundaries.

## Tests added/updated

- All-success traffic.
- Partial failures.
- Error and unknown/`other` outcomes.
- Cancellation exclusion.
- Counter resets.
- Zero and missing eligible traffic.
- Command aggregation and prohibited/high-cardinality label removal.
- Existing alert rule regression validation.

## Verification performed

- `task observability:sli:check`
- `task observability:alerts:check`
- `go test ./internal/dashboard/observability ./internal/dashboard/stream`
- `go run ./internal/app/tools/agenttooldocgen --check`
- `go run -tags=duckdb_arrow ./internal/app/tools/visualdocgen --check`
- `go run ./internal/app/tools/docsitegen --check`
- `go test ./internal/app/site/http -run '^TestEveryRenderedDocumentationLinkResolves$' -count=1`
- `git diff --check`

All listed checks passed. Go and documentation checks were run sequentially with a worktree-local temporary directory after concurrent compilation exhausted the shared `/tmp` quota. The combined `task docs:check` was not run because Bun is unavailable locally; all relevant Go documentation generators and the rendered-link check passed independently.

## Limitations

- The SLI measures only completed dashboard refresh work; in-flight refreshes, HTTP/SSE continuity, authentication, static assets, direct API queries, and synthetic journeys are not covered.
- A complete 30-day value requires at least 30 days of retained source samples; during warm-up it reflects only available history.
- Sparse traffic can make ratios volatile or statistically weak.
- No SLO target, error budget, burn rate, alert threshold, dashboard, or runtime instrumentation is introduced.

Closes FAI-579
