### PR TITLE
FAI-533: Separate generation execution scope from stable cache lifecycle

### DIFF
--- a/internal/analytics/duckdb/materialize.go
+++ b/internal/analytics/duckdb/materialize.go
@@ -606,6 +606,7 @@ type ProjectRuntimeConfig struct {
 	ResultPartition     resultidentity.Partition
 	QueryResultCache    *resultcache.Scope
 	ImmutableByteCache  *resultcache.Scope
+	ExecutionScope      *resultcache.ExecutionScope
 	ResultLimits        dataquery.ResultLimits
 	DependencyEvidence  map[string]resultidentity.Evidence
 }
@@ -626,6 +627,7 @@ type ProjectRuntime struct {
 	commitMetadata          map[string]string
 	queryResultCacheScope   *resultcache.Scope
 	immutableByteCacheScope *resultcache.Scope
+	executionScope          *resultcache.ExecutionScope
 	viewConfig              ProjectRuntimeConfig
 }
 
@@ -693,6 +695,11 @@ func OpenProjectMaterializeRuntime(ctx context.Context, config ProjectRuntimeCon
 			}
 		}
 	}
+	executionScope := config.ExecutionScope
+	if executionScope == nil {
+		executionScope = resultcache.NewExecutionScope()
+	}
+	config.ExecutionScope = executionScope
 	runtime := &ProjectRuntime{
 		projectID:               config.ProjectID,
 		db:                      db,
@@ -705,6 +712,7 @@ func OpenProjectMaterializeRuntime(ctx context.Context, config ProjectRuntimeCon
 		commitMetadata:          projectCommitMetadata(config),
 		queryResultCacheScope:   config.QueryResultCache,
 		immutableByteCacheScope: config.ImmutableByteCache,
+		executionScope:          executionScope,
 		viewConfig:              config,
 	}
 	if config.SnapshotID > 0 {
@@ -714,7 +722,7 @@ func OpenProjectMaterializeRuntime(ctx context.Context, config ProjectRuntimeCon
 		runtime.lastSnapshotID = config.SnapshotID
 	} else if !config.SkipInitialRefresh {
 		if err := runtime.Refresh(ctx); err != nil {
-			return nil, err
+			return nil, errors.Join(err, runtime.Close())
 		}
 	}
 	if len(runtime.views) == 0 {
@@ -752,6 +760,7 @@ func (r *ProjectRuntime) rebuildViews(ctx context.Context) error {
 			Database: r.db, Sources: r.sources, Resolver: r.sources,
 			SnapshotOnly: config.SnapshotID > 0, TableRelation: tableRelation,
 			QueryResultCache: config.QueryResultCache, ImmutableByteCache: config.ImmutableByteCache,
+			ExecutionScope:     config.ExecutionScope,
 			ResultLimits:       config.ResultLimits,
 			DependencyEvidence: dependencyEvidence,
 			RequiredExtensions: config.RequiredExtensions,
@@ -1279,18 +1288,23 @@ func (r *ProjectRuntime) Close() error {
 		return nil
 	}
 	var errs []error
+	if r.executionScope != nil {
+		if err := r.executionScope.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	for _, view := range r.views {
 		if err := view.CloseView(); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if r.queryResultCacheScope != nil {
-		if err := r.queryResultCacheScope.Close(); err != nil {
+	if r.immutableByteCacheScope != nil && r.immutableByteCacheScope != r.queryResultCacheScope {
+		if err := r.immutableByteCacheScope.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if r.immutableByteCacheScope != nil && r.immutableByteCacheScope != r.queryResultCacheScope {
-		if err := r.immutableByteCacheScope.Close(); err != nil {
+	if r.queryResultCacheScope != nil {
+		if err := r.queryResultCacheScope.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/analytics/duckdb/project_identity_test.go
+++ b/internal/analytics/duckdb/project_identity_test.go
@@ -2,11 +2,14 @@ package duckdb
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/flidai/leapview/internal/analytics/dataquery"
+	materialize "github.com/flidai/leapview/internal/analytics/materialize"
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/analytics/resultcache"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 )
 
@@ -49,5 +52,62 @@ func TestProjectRuntimeRejectsEmptyOrMismatchedProjectQueries(t *testing.T) {
 		if _, err := runtime.ExecuteDataQueryBundle(context.Background(), []dataquery.BundleRequest{{ID: "invalid", Query: query}}); err == nil || !strings.Contains(err.Error(), "project id") {
 			t.Fatalf("bundle query %#v error = %v, want project identity rejection", query, err)
 		}
+	}
+}
+
+func TestProjectRuntimeCloseDrainsExecutionBeforeCacheScopes(t *testing.T) {
+	pool, err := resultcache.New(resultcache.Limits{RuntimeEntries: 4, RuntimeBytes: 1 << 20, NodeEntries: 8, NodeBytes: 2 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	stable, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "generation-one"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	execution := resultcache.NewExecutionScope()
+	runtime := &ProjectRuntime{
+		views: map[string]*materialize.Runtime{}, executionScope: execution,
+		queryResultCacheScope: stable, immutableByteCacheScope: bytes,
+	}
+	started := make(chan struct{})
+	scopeCheck := make(chan error, 1)
+	flightDone := make(chan error, 1)
+	go func() {
+		_, _, flightErr := execution.Coalesce(context.Background(), "query", func(ctx context.Context) (any, error) {
+			close(started)
+			<-ctx.Done()
+			if _, _, _, lookupErr := stable.LookupArrow("missing"); lookupErr != nil {
+				scopeCheck <- lookupErr
+				return nil, ctx.Err()
+			}
+			if _, _, _, lookupErr := bytes.LookupBytes("missing"); lookupErr != nil {
+				scopeCheck <- lookupErr
+				return nil, ctx.Err()
+			}
+			scopeCheck <- nil
+			return nil, ctx.Err()
+		})
+		flightDone <- flightErr
+	}()
+	<-started
+	if err := runtime.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-scopeCheck; err != nil {
+		t.Fatalf("cache scope closed before execution drained: %v", err)
+	}
+	if err := <-flightDone; !errors.Is(err, resultcache.ErrExecutionScopeClosed) {
+		t.Fatalf("flight error = %v, want execution scope close", err)
+	}
+	if _, _, _, err := stable.LookupArrow("missing"); err == nil {
+		t.Fatal("stable cache handle remained open after project runtime close")
+	}
+	if _, _, _, err := bytes.LookupBytes("missing"); err == nil {
+		t.Fatal("generation byte cache remained open after project runtime close")
 	}
 }

--- a/internal/analytics/materialize/query_cache.go
+++ b/internal/analytics/materialize/query_cache.go
@@ -18,18 +18,21 @@ import (
 var localCacheID atomic.Uint64
 
 // queryResultCache retains the materialization-specific key contract while the
-// resultcache scope owns retention, hierarchy, invalidation, and coalescing.
+// stable result scope owns retention and invalidation, the byte scope owns
+// generation-bound immutable values, and the execution scope owns flights.
 type queryResultCache struct {
-	mu           sync.Mutex
-	pool         *resultcache.Pool
-	scope        *resultcache.Scope
-	byteScope    *resultcache.Scope
-	owned        bool
-	scopeOwned   bool
-	capacity     int
-	maxBytes     int64
-	currentBytes int64
-	generation   uint64
+	mu             sync.Mutex
+	pool           *resultcache.Pool
+	scope          *resultcache.Scope
+	byteScope      *resultcache.Scope
+	execution      *resultcache.ExecutionScope
+	owned          bool
+	scopeOwned     bool
+	executionOwned bool
+	capacity       int
+	maxBytes       int64
+	currentBytes   int64
+	generation     uint64
 }
 
 type arrowQueryExecution struct {
@@ -38,7 +41,7 @@ type arrowQueryExecution struct {
 	summary  dataquery.Result
 }
 
-func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency, diagnosticsSQL string, execute func() (arrowQueryExecution, error)) (dataquery.Result, error) {
+func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency, diagnosticsSQL string, execute func(context.Context) (arrowQueryExecution, error)) (dataquery.Result, error) {
 	key, generation, err := c.cacheKey(request, partition, dependency)
 	if err != nil {
 		return dataquery.Result{}, err
@@ -47,7 +50,7 @@ func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Q
 		return cached, err
 	}
 	var ownerSummary dataquery.Result
-	flight, status, err := c.scope.CoalesceArrow(ctx, fmt.Sprintf("arrow-query:%d:%s", generation, key), func() (resultcache.ArrowFlightValue, error) {
+	flight, status, err := c.execution.CoalesceArrow(ctx, fmt.Sprintf("arrow-query:%d:%s", generation, key), func(flightCtx context.Context) (resultcache.ArrowFlightValue, error) {
 		if entry, _, ok, lookupErr := c.scope.LookupArrow(key); lookupErr != nil {
 			return resultcache.ArrowFlightValue{}, lookupErr
 		} else if ok {
@@ -59,13 +62,13 @@ func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Q
 			}
 			return resultcache.ArrowFlightValue{Data: base, Metadata: metadata, Cached: true}, nil
 		}
-		execution, executeErr := execute()
+		execution, executeErr := execute(flightCtx)
 		ownerSummary = execution.summary
 		if execution.data != nil {
 			defer execution.data.Release()
 		}
-		if ownerErr := ctx.Err(); ownerErr != nil {
-			return resultcache.ArrowFlightValue{}, canceledQueryCacheFlightError{err: ownerErr}
+		if ownerErr := flightCtx.Err(); ownerErr != nil {
+			return resultcache.ArrowFlightValue{}, ownerErr
 		}
 		if executeErr != nil {
 			return resultcache.ArrowFlightValue{}, executeErr
@@ -155,14 +158,18 @@ func newQueryResultCacheWithLimits(capacity int, maxBytes int64) *queryResultCac
 	if err != nil {
 		panic(err)
 	}
-	return &queryResultCache{pool: pool, scope: scope, byteScope: scope, owned: true, capacity: capacity, maxBytes: maxBytes}
+	return &queryResultCache{pool: pool, scope: scope, byteScope: scope, execution: resultcache.NewExecutionScope(), owned: true, executionOwned: true, capacity: capacity, maxBytes: maxBytes}
 }
 
 func newQueryResultCacheWithScopes(scope, byteScope *resultcache.Scope) *queryResultCache {
+	return newQueryResultCacheWithExecutionScope(scope, byteScope, resultcache.NewExecutionScope(), true)
+}
+
+func newQueryResultCacheWithExecutionScope(scope, byteScope *resultcache.Scope, execution *resultcache.ExecutionScope, executionOwned bool) *queryResultCache {
 	if byteScope == nil {
 		byteScope = scope
 	}
-	return &queryResultCache{scope: scope, byteScope: byteScope}
+	return &queryResultCache{scope: scope, byteScope: byteScope, execution: execution, executionOwned: executionOwned}
 }
 
 func (c *queryResultCache) ownScope() {
@@ -171,14 +178,8 @@ func (c *queryResultCache) ownScope() {
 	}
 }
 
-func (c *queryResultCache) coalesce(ctx context.Context, key string, execute func() (any, error)) (any, bool, error) {
-	return c.scope.Coalesce(ctx, "bundle:"+key, func() (any, error) {
-		result, err := execute()
-		if ownerErr := ctx.Err(); ownerErr != nil {
-			return nil, canceledQueryCacheFlightError{err: ownerErr}
-		}
-		return result, err
-	})
+func (c *queryResultCache) coalesce(ctx context.Context, key string, execute func(context.Context) (any, error)) (any, bool, error) {
+	return c.execution.Coalesce(ctx, "bundle:"+key, execute)
 }
 
 func (c *queryResultCache) lookupBytes(key string) ([]byte, bool, error) {
@@ -205,12 +206,12 @@ func (c *queryResultCache) storeBytes(key string, value []byte) resultcache.Stor
 	return outcome
 }
 
-func (c *queryResultCache) coalesceBytes(ctx context.Context, key string, execute func() error) (bool, error) {
+func (c *queryResultCache) coalesceBytes(ctx context.Context, key string, execute func(context.Context) error) (bool, error) {
 	if c == nil || c.byteScope == nil {
 		return false, fmt.Errorf("result cache scope is required")
 	}
-	_, shared, err := c.byteScope.Coalesce(ctx, "immutable-bytes:"+key, func() (any, error) {
-		return struct{}{}, execute()
+	_, shared, err := c.execution.Coalesce(ctx, "immutable-bytes:"+key, func(executionCtx context.Context) (any, error) {
+		return struct{}{}, execute(executionCtx)
 	})
 	return shared, err
 }
@@ -282,11 +283,6 @@ func queryCacheIdentityAvailable(request dataquery.Query, partition resultidenti
 	}
 }
 
-type canceledQueryCacheFlightError struct{ err error }
-
-func (e canceledQueryCacheFlightError) Error() string { return e.err.Error() }
-func (e canceledQueryCacheFlightError) Unwrap() error { return e.err }
-
 type queryResultCacheKey struct {
 	Version                    int                   `json:"version"`
 	Partition                  json.RawMessage       `json:"partition"`
@@ -335,17 +331,21 @@ func (c *queryResultCache) close() error {
 	if c == nil {
 		return nil
 	}
+	var executionErr error
+	if c.executionOwned && c.execution != nil {
+		executionErr = c.execution.Close()
+	}
 	if c.scopeOwned {
 		var byteErr error
 		if c.byteScope != nil && c.byteScope != c.scope {
 			byteErr = c.byteScope.Close()
 		}
-		return errors.Join(c.scope.Close(), byteErr)
+		return errors.Join(executionErr, byteErr, c.scope.Close())
 	}
 	if !c.owned {
-		return nil
+		return executionErr
 	}
-	return errors.Join(c.scope.Close(), c.pool.Close())
+	return errors.Join(executionErr, c.scope.Close(), c.pool.Close())
 }
 
 func (c *queryResultCache) syncStats() {

--- a/internal/analytics/materialize/query_cache_test.go
+++ b/internal/analytics/materialize/query_cache_test.go
@@ -224,7 +224,7 @@ func (c *queryResultCache) execute(ctx context.Context, request dataquery.Query,
 	if cached, ok := c.get(key); ok {
 		return cached, nil
 	}
-	value, shared, err := c.scope.Coalesce(ctx, fmt.Sprintf("test-query:%d:%s", generation, key), func() (any, error) {
+	value, shared, err := c.execution.Coalesce(ctx, fmt.Sprintf("test-query:%d:%s", generation, key), func(context.Context) (any, error) {
 		if cached, ok := c.get(key); ok {
 			return cached, nil
 		}
@@ -436,6 +436,233 @@ func TestRuntimeSharedPartitionCacheReusesDataWithoutStaleSQLOrByteLifetime(t *t
 	_, found, err := second.LookupImmutableBytes("tile")
 	require.NoError(t, err)
 	require.False(t, found)
+}
+
+func TestGenerationExecutionScopesDoNotCoalesceColdMissesButReuseCompletedEntries(t *testing.T) {
+	pool, err := resultcache.New(resultcache.Limits{RuntimeEntries: 16, RuntimeBytes: 1 << 20, NodeEntries: 32, NodeBytes: 2 << 20})
+	require.NoError(t, err)
+	defer pool.Close()
+	firstScope, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
+	require.NoError(t, err)
+	secondScope, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
+	require.NoError(t, err)
+	firstBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "generation-one"})
+	require.NoError(t, err)
+	secondBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "generation-two"})
+	require.NoError(t, err)
+	first := newQueryResultCacheWithScopes(firstScope, firstBytes)
+	second := newQueryResultCacheWithScopes(secondScope, secondBytes)
+	defer first.close()
+	defer second.close()
+	request := dataquery.Query{ModelID: "sales", Kind: dataquery.KindSemanticAggregate, Target: "orders", Operation: dataquery.OperationDashboardFilterOptions}
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var executions atomic.Int32
+	execute := func() (dataquery.Result, error) {
+		executions.Add(1)
+		started <- struct{}{}
+		<-release
+		return dataquery.Result{Rows: []dataquery.Row{{"value": int64(1)}}}, nil
+	}
+	type response struct {
+		result dataquery.Result
+		err    error
+	}
+	responses := make(chan response, 2)
+	go func() {
+		result, err := first.execute(context.Background(), request, execute)
+		responses <- response{result, err}
+	}()
+	go func() {
+		result, err := second.execute(context.Background(), request, execute)
+		responses <- response{result, err}
+	}()
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("different generation cold misses shared one execution")
+		}
+	}
+	close(release)
+	for range 2 {
+		response := <-responses
+		require.NoError(t, response.err)
+		require.Equal(t, dataquery.CacheMiss, response.result.CacheOutcome)
+	}
+	require.Equal(t, int32(2), executions.Load())
+
+	cached, err := second.execute(context.Background(), request, func() (dataquery.Result, error) {
+		executions.Add(1)
+		return dataquery.Result{}, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, dataquery.CacheHit, cached.CacheOutcome)
+	require.Equal(t, int32(2), executions.Load())
+}
+
+func TestGenerationExecutionScopeStillCoalescesSameGenerationMisses(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cache := newQueryResultCache(16)
+		defer cache.close()
+		request := dataquery.Query{ModelID: "sales", Kind: dataquery.KindSemanticAggregate, Target: "orders", Operation: dataquery.OperationDashboardFilterOptions}
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var calls atomic.Int32
+		execute := func() (dataquery.Result, error) {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+			<-release
+			return dataquery.Result{Rows: []dataquery.Row{{"value": int64(1)}}}, nil
+		}
+		results := make(chan dataquery.Result, 2)
+		errs := make(chan error, 2)
+		go func() {
+			result, err := cache.execute(context.Background(), request, execute)
+			results <- result
+			errs <- err
+		}()
+		<-started
+		go func() {
+			result, err := cache.execute(context.Background(), request, execute)
+			results <- result
+			errs <- err
+		}()
+		synctest.Wait()
+		require.Equal(t, int32(1), calls.Load())
+		close(release)
+		for range 2 {
+			require.NoError(t, <-errs)
+			<-results
+		}
+		require.Equal(t, int32(1), calls.Load())
+	})
+}
+
+func TestImmutableByteFlightUsesExecutionScopeCancellationAndDrainsBeforeCacheRelease(t *testing.T) {
+	pool, err := resultcache.New(resultcache.Limits{RuntimeEntries: 4, RuntimeBytes: 1 << 20, NodeEntries: 8, NodeBytes: 2 << 20})
+	require.NoError(t, err)
+	defer pool.Close()
+	stable, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
+	require.NoError(t, err)
+	bytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "generation-one"})
+	require.NoError(t, err)
+	execution := resultcache.NewExecutionScope()
+	cache := newQueryResultCacheWithExecutionScope(stable, bytes, execution, true)
+	cache.ownScope()
+
+	started := make(chan struct{})
+	scopesOpen := make(chan error, 1)
+	flightDone := make(chan error, 1)
+	go func() {
+		_, flightErr := cache.coalesceBytes(context.Background(), "spatial-metatile", func(executionCtx context.Context) error {
+			close(started)
+			<-executionCtx.Done()
+			if _, _, _, lookupErr := stable.LookupArrow("missing"); lookupErr != nil {
+				scopesOpen <- lookupErr
+				return executionCtx.Err()
+			}
+			if _, _, _, lookupErr := bytes.LookupBytes("missing"); lookupErr != nil {
+				scopesOpen <- lookupErr
+				return executionCtx.Err()
+			}
+			scopesOpen <- nil
+			return executionCtx.Err()
+		})
+		flightDone <- flightErr
+	}()
+	<-started
+
+	closed := make(chan error, 1)
+	go func() { closed <- cache.close() }()
+	select {
+	case closeErr := <-closed:
+		require.NoError(t, closeErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cache close did not cancel and drain immutable-byte owner")
+	}
+	require.NoError(t, <-scopesOpen, "cache scopes closed before immutable-byte owner drained")
+	require.ErrorIs(t, <-flightDone, resultcache.ErrExecutionScopeClosed)
+	_, _, _, err = stable.LookupArrow("missing")
+	require.Error(t, err, "stable cache handle remained open after generation close")
+	_, _, _, err = bytes.LookupBytes("missing")
+	require.Error(t, err, "immutable byte cache remained open after generation close")
+}
+
+func TestInvalidationDuringGenerationFlightStillRejectsStaleStore(t *testing.T) {
+	cache := newQueryResultCache(16)
+	defer cache.close()
+	request := dataquery.Query{ModelID: "sales", Kind: dataquery.KindSemanticAggregate, Target: "orders", Operation: dataquery.OperationDashboardFilterOptions}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var executions atomic.Int32
+	done := make(chan error, 1)
+	go func() {
+		_, err := cache.execute(context.Background(), request, func() (dataquery.Result, error) {
+			executions.Add(1)
+			close(started)
+			<-release
+			return dataquery.Result{Rows: []dataquery.Row{{"value": int64(1)}}}, nil
+		})
+		done <- err
+	}()
+	<-started
+	cache.clear()
+	close(release)
+	require.NoError(t, <-done)
+	_, _, _, hit, err := cache.lookup(request)
+	require.NoError(t, err)
+	require.False(t, hit)
+
+	_, err = cache.execute(context.Background(), request, func() (dataquery.Result, error) {
+		executions.Add(1)
+		return dataquery.Result{Rows: []dataquery.Row{{"value": int64(2)}}}, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), executions.Load())
+}
+
+func TestBundleFlightsAreIsolatedByGenerationExecutionScope(t *testing.T) {
+	pool, err := resultcache.New(resultcache.Limits{RuntimeEntries: 16, RuntimeBytes: 1 << 20, NodeEntries: 32, NodeBytes: 2 << 20})
+	require.NoError(t, err)
+	defer pool.Close()
+	firstScope, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
+	require.NoError(t, err)
+	secondScope, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
+	require.NoError(t, err)
+	firstBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "bundle-generation-one"})
+	require.NoError(t, err)
+	secondBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "bundle-generation-two"})
+	require.NoError(t, err)
+	first := newQueryResultCacheWithScopes(firstScope, firstBytes)
+	second := newQueryResultCacheWithScopes(secondScope, secondBytes)
+	defer first.close()
+	defer second.close()
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var executions atomic.Int32
+	execute := func(context.Context) (any, error) {
+		executions.Add(1)
+		started <- struct{}{}
+		<-release
+		return "bundle", nil
+	}
+	done := make(chan error, 2)
+	go func() { _, _, err := first.coalesce(context.Background(), "same-bundle", execute); done <- err }()
+	go func() { _, _, err := second.coalesce(context.Background(), "same-bundle", execute); done <- err }()
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("different generation bundle flights shared one execution")
+		}
+	}
+	close(release)
+	require.NoError(t, <-done)
+	require.NoError(t, <-done)
+	require.Equal(t, int32(2), executions.Load())
 }
 
 func TestRuntimeInvalidDependencyEvidenceBypassesResultReuseAndRetainsCurrentPlanSQL(t *testing.T) {
@@ -950,7 +1177,7 @@ func TestQueryResultCacheLiveWaiterRetriesCanceledFlightAndCachesResult(t *testi
 		releaseCanceledFlight := make(chan struct{})
 		ownerContext, cancelOwner := context.WithCancel(context.Background())
 		go func() {
-			_, _, _ = cache.scope.Coalesce(ownerContext, fmt.Sprintf("query:%d:%s", generation, key), func() (any, error) {
+			_, _, _ = cache.execution.Coalesce(ownerContext, fmt.Sprintf("test-query:%d:%s", generation, key), func(context.Context) (any, error) {
 				close(flightStarted)
 				<-releaseCanceledFlight
 				return dataquery.Result{}, resultcache.OwnerCanceled(ownerContext.Err())
@@ -1308,13 +1535,13 @@ func TestQueryResultCacheCoalescesExactBundleFlightsAndRetriesCanceledOwner(t *t
 	}
 	ownerDone := make(chan error, 1)
 	go func() {
-		_, _, err := cache.coalesce(ownerCtx, "exact-bundle", func() (any, error) { return execute(ownerCtx) })
+		_, _, err := cache.coalesce(ownerCtx, "exact-bundle", func(executionCtx context.Context) (any, error) { return execute(executionCtx) })
 		ownerDone <- err
 	}()
 	<-started
 	waiterDone := make(chan error, 1)
 	go func() {
-		result, _, err := cache.coalesce(context.Background(), "exact-bundle", func() (any, error) { return execute(context.Background()) })
+		result, _, err := cache.coalesce(context.Background(), "exact-bundle", func(executionCtx context.Context) (any, error) { return execute(executionCtx) })
 		if err == nil && result != "fresh" {
 			err = fmt.Errorf("coalesced result = %v", result)
 		}

--- a/internal/analytics/materialize/runtime.go
+++ b/internal/analytics/materialize/runtime.go
@@ -32,7 +32,11 @@ type RuntimeConfig struct {
 	// acquire cross-generation reuse semantics.
 	QueryResultCache   *resultcache.Scope
 	ImmutableByteCache *resultcache.Scope
-	ResultLimits       dataquery.ResultLimits
+	// ExecutionScope owns mutable query, bundle, Arrow, and immutable-byte
+	// flights for one runtime generation. It must never be shared through the
+	// stable result partition scope.
+	ExecutionScope *resultcache.ExecutionScope
+	ResultLimits   dataquery.ResultLimits
 	// DependencyEvidence is immutable activation evidence used to derive an
 	// exact dependency identity from each validated query plan. When it is
 	// absent or incomplete, result reuse fails closed while execution remains
@@ -94,7 +98,7 @@ func (r *Runtime) StoreImmutableBytes(key string, value []byte) bool {
 	return r.queryCache.storeBytes(key, value) == resultcache.StoreStored
 }
 
-func (r *Runtime) CoalesceImmutableBytes(ctx context.Context, key string, execute func() error) (bool, error) {
+func (r *Runtime) CoalesceImmutableBytes(ctx context.Context, key string, execute func(context.Context) error) (bool, error) {
 	return r.queryCache.coalesceBytes(ctx, key, execute)
 }
 
@@ -130,13 +134,13 @@ func NewRuntimeView(ctx context.Context, config RuntimeConfig) (runtime *Runtime
 	// compilation and validation failures that occur before a query cache is
 	// constructed, as well as failures after construction.
 	defer func() {
-		if retErr == nil || !cacheOwned {
+		if retErr == nil {
 			return
 		}
 		var cleanupErr error
 		if cache != nil {
 			cleanupErr = cache.close()
-		} else {
+		} else if cacheOwned {
 			var resultErr, byteErr error
 			if config.QueryResultCache != nil {
 				resultErr = config.QueryResultCache.Close()
@@ -186,7 +190,11 @@ func NewRuntimeView(ctx context.Context, config RuntimeConfig) (runtime *Runtime
 	} else if config.QueryResultCache == nil || config.ImmutableByteCache == nil {
 		return nil, fmt.Errorf("query result and immutable byte cache scopes are both required")
 	} else {
-		cache = newQueryResultCacheWithScopes(config.QueryResultCache, config.ImmutableByteCache)
+		execution, executionOwned := config.ExecutionScope, false
+		if execution == nil {
+			execution, executionOwned = resultcache.NewExecutionScope(), true
+		}
+		cache = newQueryResultCacheWithExecutionScope(config.QueryResultCache, config.ImmutableByteCache, execution, executionOwned)
 	}
 	if config.QueryResultCache != nil && config.OwnQueryCache {
 		cache.ownScope()

--- a/internal/analytics/materialize/runtime_arrow_result.go
+++ b/internal/analytics/materialize/runtime_arrow_result.go
@@ -50,10 +50,10 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 			planned.dependency, planned.reusable = r.dependencyForPlan(planned.plan)
 		}
 	}
-	execute := func() (arrowQueryExecution, error) {
+	execute := func(executionCtx context.Context) (arrowQueryExecution, error) {
 		var execution arrowQueryExecution
 		current := planned
-		execCtx, statements := withPhysicalStatementCounter(dataquery.WithResultBudget(ctx, r.queryResultLimits()))
+		execCtx, statements := withPhysicalStatementCounter(dataquery.WithResultBudget(executionCtx, r.queryResultLimits()))
 		summary, err := admitPhysicalQuery(execCtx, request, func(queryCtx context.Context) (dataquery.Result, error) {
 			if !cacheable {
 				var planningErr error
@@ -129,7 +129,7 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 		result, err = r.queryCache.executeArrow(ctx, request, r.resultPartition, planned.dependency, planned.plan.SQL, execute)
 		observeQueryCacheOutcome(ctx, result, err)
 	} else {
-		execution, executeErr := execute()
+		execution, executeErr := execute(ctx)
 		err = executeErr
 		if execution.data != nil {
 			lease, acquireErr := execution.data.Acquire()

--- a/internal/analytics/materialize/runtime_bundle_pipeline.go
+++ b/internal/analytics/materialize/runtime_bundle_pipeline.go
@@ -281,8 +281,8 @@ func (r *Runtime) executePlannedBundle(ctx context.Context, planned plannedBundl
 	if err := enterBundleStage(ctx, bundleStageExecute); err != nil {
 		return bundleExecution{}, false, err
 	}
-	execute := func() (bundleExecution, error) {
-		execCtx, statements := withPhysicalStatementCounter(dataquery.WithIndependentResultBudget(ctx, r.queryResultLimits()))
+	execute := func(executionCtx context.Context) (bundleExecution, error) {
+		execCtx, statements := withPhysicalStatementCounter(dataquery.WithIndependentResultBudget(executionCtx, r.queryResultLimits()))
 		var execution bundleExecution
 		summary, executeErr := admitPhysicalQuery(execCtx, planned.resolved.misses[0].Query, func(queryCtx context.Context) (dataquery.Result, error) {
 			var err error
@@ -296,10 +296,10 @@ func (r *Runtime) executePlannedBundle(ctx context.Context, planned plannedBundl
 		return execution, executeErr
 	}
 	if planned.flightKey == "" {
-		execution, err := execute()
+		execution, err := execute(ctx)
 		return execution, false, err
 	}
-	value, shared, err := r.queryCache.coalesce(ctx, planned.flightKey, func() (any, error) { return execute() })
+	value, shared, err := r.queryCache.coalesce(ctx, planned.flightKey, func(executionCtx context.Context) (any, error) { return execute(executionCtx) })
 	if err != nil {
 		return bundleExecution{}, shared, err
 	}

--- a/internal/analytics/resultcache/execution_scope.go
+++ b/internal/analytics/resultcache/execution_scope.go
@@ -1,0 +1,304 @@
+package resultcache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/flidai/leapview/pkg/arrowresult"
+)
+
+var ErrExecutionScopeClosed = errors.New("result cache execution scope is closed")
+
+// ExecutionScope owns mutable in-flight work for exactly one analytical
+// runtime generation. It deliberately owns no reusable cache entries or
+// invalidation state.
+type ExecutionScope struct {
+	mu           sync.Mutex
+	closed       bool
+	closeDone    chan struct{}
+	owners       sync.WaitGroup
+	callers      sync.WaitGroup
+	flights      map[string]*executionFlight
+	arrowFlights map[string]*arrowExecutionFlight
+}
+
+type executionFlight struct {
+	done    chan struct{}
+	cancel  context.CancelCauseFunc
+	waiters int
+	shared  bool
+	value   any
+	err     error
+}
+
+type arrowExecutionFlight struct {
+	done     chan struct{}
+	cancel   context.CancelCauseFunc
+	waiters  int
+	shared   bool
+	complete bool
+	value    ArrowFlightValue
+	err      error
+}
+
+type canceledFlight struct{ err error }
+
+func (e canceledFlight) Error() string { return e.err.Error() }
+func (e canceledFlight) Unwrap() error { return e.err }
+
+// OwnerCanceled marks a coalesced execution whose owning context was canceled,
+// allowing a still-live waiter in the same execution scope to replace it.
+func OwnerCanceled(err error) error { return canceledFlight{err: err} }
+
+func NewExecutionScope() *ExecutionScope {
+	return &ExecutionScope{
+		closeDone:    make(chan struct{}),
+		flights:      map[string]*executionFlight{},
+		arrowFlights: map[string]*arrowExecutionFlight{},
+	}
+}
+
+// Close rejects new joins, cancels every owner, and waits until all owner
+// goroutines and their Arrow flight holds have drained.
+func (s *ExecutionScope) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	if s.closed {
+		done := s.closeDone
+		s.mu.Unlock()
+		<-done
+		return nil
+	}
+	s.closed = true
+	cancels := make([]context.CancelCauseFunc, 0, len(s.flights)+len(s.arrowFlights))
+	for _, flight := range s.flights {
+		cancels = append(cancels, flight.cancel)
+	}
+	for _, flight := range s.arrowFlights {
+		cancels = append(cancels, flight.cancel)
+	}
+	s.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel(ErrExecutionScopeClosed)
+	}
+	s.owners.Wait()
+	s.callers.Wait()
+	close(s.closeDone)
+	return nil
+}
+
+func (s *ExecutionScope) Coalesce(ctx context.Context, key string, execute func(context.Context) (any, error)) (any, bool, error) {
+	if s == nil || execute == nil {
+		return nil, false, ErrExecutionScopeClosed
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	if err := s.admitCaller(); err != nil {
+		return nil, false, err
+	}
+	defer s.callers.Done()
+	for {
+		flight, err := s.joinFlight(ctx, key, execute)
+		if err != nil {
+			return nil, false, err
+		}
+		select {
+		case <-ctx.Done():
+			s.leaveFlight(flight)
+			return nil, false, ctx.Err()
+		case <-flight.done:
+		}
+		s.mu.Lock()
+		value, flightErr, shared := flight.value, flight.err, flight.shared
+		s.mu.Unlock()
+		s.leaveFlight(flight)
+		if flightErr != nil {
+			var canceled canceledFlight
+			if ctx.Err() == nil && errors.As(flightErr, &canceled) {
+				continue
+			}
+			return nil, shared, flightErr
+		}
+		return value, shared, nil
+	}
+}
+
+func (s *ExecutionScope) joinFlight(ctx context.Context, key string, execute func(context.Context) (any, error)) (*executionFlight, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, ErrExecutionScopeClosed
+	}
+	if existing := s.flights[key]; existing != nil {
+		existing.waiters++
+		existing.shared = true
+		return existing, nil
+	}
+	execCtx, cancel := context.WithCancelCause(ctx)
+	flight := &executionFlight{done: make(chan struct{}), cancel: cancel, waiters: 1}
+	s.flights[key] = flight
+	s.owners.Add(1)
+	go func() {
+		defer s.owners.Done()
+		value, err := execute(execCtx)
+		if contextErr := executionContextError(execCtx); contextErr != nil {
+			err = contextErr
+		}
+		s.mu.Lock()
+		flight.value, flight.err = value, err
+		if s.flights[key] == flight {
+			delete(s.flights, key)
+		}
+		close(flight.done)
+		s.mu.Unlock()
+		cancel(nil)
+	}()
+	return flight, nil
+}
+
+func (s *ExecutionScope) leaveFlight(flight *executionFlight) {
+	if flight == nil {
+		return
+	}
+	s.mu.Lock()
+	flight.waiters--
+	s.mu.Unlock()
+}
+
+// CoalesceArrow runs one Arrow-producing execution and gives every live caller
+// an independently retained lease. Canceled callers are removed without
+// releasing buffers still needed by other waiters. If the owning request is
+// canceled, a live same-generation waiter starts a replacement flight.
+func (s *ExecutionScope) CoalesceArrow(ctx context.Context, key string, execute func(context.Context) (ArrowFlightValue, error)) (*ArrowFlightLease, ArrowFlightStatus, error) {
+	if s == nil || execute == nil {
+		return nil, ArrowFlightStatus{}, ErrExecutionScopeClosed
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, ArrowFlightStatus{}, err
+	}
+	if err := s.admitCaller(); err != nil {
+		return nil, ArrowFlightStatus{}, err
+	}
+	defer s.callers.Done()
+	for {
+		flight, owner, err := s.joinArrowFlight(ctx, key, execute)
+		if err != nil {
+			return nil, ArrowFlightStatus{}, err
+		}
+		select {
+		case <-ctx.Done():
+			s.leaveArrowFlight(flight)
+			return nil, ArrowFlightStatus{}, ctx.Err()
+		case <-flight.done:
+		}
+
+		s.mu.Lock()
+		flightErr, shared, value := flight.err, flight.shared, flight.value
+		s.mu.Unlock()
+		if flightErr != nil {
+			s.leaveArrowFlight(flight)
+			var canceled canceledFlight
+			if ctx.Err() == nil && errors.As(flightErr, &canceled) {
+				continue
+			}
+			return nil, ArrowFlightStatus{Owner: owner, Shared: shared}, flightErr
+		}
+		if value.Data == nil {
+			s.leaveArrowFlight(flight)
+			return nil, ArrowFlightStatus{Owner: owner, Shared: shared}, fmt.Errorf("coalesced Arrow execution returned no data")
+		}
+		lease, acquireErr := value.Data.Acquire()
+		s.leaveArrowFlight(flight)
+		if acquireErr != nil {
+			return nil, ArrowFlightStatus{Owner: owner, Shared: shared}, acquireErr
+		}
+		return &ArrowFlightLease{data: lease, metadata: cloneMetadata(value.Metadata), cached: value.Cached}, ArrowFlightStatus{Owner: owner, Shared: shared}, nil
+	}
+}
+
+func (s *ExecutionScope) joinArrowFlight(ctx context.Context, key string, execute func(context.Context) (ArrowFlightValue, error)) (*arrowExecutionFlight, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, false, ErrExecutionScopeClosed
+	}
+	if existing := s.arrowFlights[key]; existing != nil {
+		existing.waiters++
+		existing.shared = true
+		return existing, false, nil
+	}
+	execCtx, cancel := context.WithCancelCause(ctx)
+	flight := &arrowExecutionFlight{done: make(chan struct{}), cancel: cancel, waiters: 1}
+	s.arrowFlights[key] = flight
+	s.owners.Add(1)
+	go func() {
+		defer s.owners.Done()
+		value, err := execute(execCtx)
+		if contextErr := executionContextError(execCtx); contextErr != nil {
+			err = contextErr
+		}
+		s.mu.Lock()
+		flight.value, flight.err, flight.complete = value, err, true
+		if s.arrowFlights[key] == flight {
+			delete(s.arrowFlights, key)
+		}
+		close(flight.done)
+		release := flight.waiters == 0 && flight.value.Data != nil
+		if release {
+			flight.value.Data = nil
+		}
+		s.mu.Unlock()
+		cancel(nil)
+		if release {
+			value.Data.Release()
+		}
+	}()
+	return flight, true, nil
+}
+
+func (s *ExecutionScope) leaveArrowFlight(flight *arrowExecutionFlight) {
+	if flight == nil {
+		return
+	}
+	s.mu.Lock()
+	flight.waiters--
+	release := flight.waiters == 0 && flight.complete && flight.value.Data != nil
+	var data *arrowresult.Lease
+	if release {
+		data = flight.value.Data
+		flight.value.Data = nil
+	}
+	s.mu.Unlock()
+	if data != nil {
+		data.Release()
+	}
+}
+
+func executionContextError(ctx context.Context) error {
+	if ctx == nil || ctx.Err() == nil {
+		return nil
+	}
+	cause := context.Cause(ctx)
+	if errors.Is(cause, ErrExecutionScopeClosed) {
+		return ErrExecutionScopeClosed
+	}
+	if cause == nil {
+		cause = ctx.Err()
+	}
+	return canceledFlight{err: cause}
+}
+
+func (s *ExecutionScope) admitCaller() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return ErrExecutionScopeClosed
+	}
+	s.callers.Add(1)
+	return nil
+}

--- a/internal/analytics/resultcache/execution_scope_test.go
+++ b/internal/analytics/resultcache/execution_scope_test.go
@@ -1,0 +1,215 @@
+package resultcache
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+func TestExecutionScopeCoalescesWithinOneGeneration(t *testing.T) {
+	scope := NewExecutionScope()
+	defer scope.Close()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	execute := func(context.Context) (any, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return "value", nil
+	}
+	results := make(chan any, 2)
+	errs := make(chan error, 2)
+	go func() {
+		value, _, err := scope.Coalesce(context.Background(), "query", execute)
+		results <- value
+		errs <- err
+	}()
+	<-started
+	go func() {
+		value, _, err := scope.Coalesce(context.Background(), "query", execute)
+		results <- value
+		errs <- err
+	}()
+	waitForExecutionFlightWaiters(t, scope, "query", 2)
+	close(release)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+		if value := <-results; value != "value" {
+			t.Fatalf("coalesced value = %#v", value)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("executions = %d, want 1", got)
+	}
+}
+
+func TestExecutionScopesDoNotCoalesceAcrossGenerations(t *testing.T) {
+	first, second := NewExecutionScope(), NewExecutionScope()
+	defer first.Close()
+	defer second.Close()
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	var calls atomic.Int32
+	execute := func(context.Context) (any, error) {
+		calls.Add(1)
+		started <- struct{}{}
+		<-release
+		return "value", nil
+	}
+	var wait sync.WaitGroup
+	for _, scope := range []*ExecutionScope{first, second} {
+		wait.Add(1)
+		go func(scope *ExecutionScope) {
+			defer wait.Done()
+			if _, shared, err := scope.Coalesce(context.Background(), "query", execute); err != nil || shared {
+				t.Errorf("generation execution shared=%v err=%v", shared, err)
+			}
+		}(scope)
+	}
+	<-started
+	<-started
+	close(release)
+	wait.Wait()
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("executions = %d, want 2", got)
+	}
+}
+
+func TestExecutionScopeCloseCancelsAndDrainsOwnerFlights(t *testing.T) {
+	scope := NewExecutionScope()
+	started := make(chan struct{})
+	exited := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := scope.Coalesce(context.Background(), "query", func(ctx context.Context) (any, error) {
+			close(started)
+			<-ctx.Done()
+			close(exited)
+			return nil, ctx.Err()
+		})
+		done <- err
+	}()
+	<-started
+	if err := scope.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-exited:
+	default:
+		t.Fatal("execution scope close returned before owner flight exited")
+	}
+	if err := <-done; !errors.Is(err, ErrExecutionScopeClosed) {
+		t.Fatalf("flight error = %v, want closed execution scope", err)
+	}
+}
+
+func TestExecutionScopeRejectsJoinsAfterClose(t *testing.T) {
+	scope := NewExecutionScope()
+	if err := scope.Close(); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	if _, _, err := scope.Coalesce(context.Background(), "query", func(context.Context) (any, error) {
+		called = true
+		return nil, nil
+	}); !errors.Is(err, ErrExecutionScopeClosed) {
+		t.Fatalf("join error = %v, want closed execution scope", err)
+	}
+	if called {
+		t.Fatal("closed execution scope invoked owner work")
+	}
+	if _, _, err := scope.CoalesceArrow(context.Background(), "arrow-query", func(context.Context) (ArrowFlightValue, error) {
+		called = true
+		return ArrowFlightValue{}, nil
+	}); !errors.Is(err, ErrExecutionScopeClosed) {
+		t.Fatalf("Arrow join error = %v, want closed execution scope", err)
+	}
+	if called {
+		t.Fatal("closed execution scope invoked Arrow owner work")
+	}
+}
+
+func TestExecutionScopeCloseDrainsArrowFlightHolds(t *testing.T) {
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer allocator.AssertSize(t, 0)
+	scope := NewExecutionScope()
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		lease, _, err := scope.CoalesceArrow(context.Background(), "query", func(ctx context.Context) (ArrowFlightValue, error) {
+			close(started)
+			<-ctx.Done()
+			result := testArrowResult(t, allocator, "value")
+			base, acquireErr := result.Acquire()
+			result.Release()
+			return ArrowFlightValue{Data: base}, acquireErr
+		})
+		if lease != nil {
+			lease.Release()
+		}
+		done <- err
+	}()
+	<-started
+	requireNoExecutionScopeCloseError(t, scope.Close())
+	if err := <-done; !errors.Is(err, ErrExecutionScopeClosed) {
+		t.Fatalf("Arrow flight error = %v, want closed execution scope", err)
+	}
+}
+
+func TestExecutionScopeConcurrentJoinCancelAndClose(t *testing.T) {
+	scope := NewExecutionScope()
+	started := make(chan struct{})
+	var once sync.Once
+	var wait sync.WaitGroup
+	for range 32 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				once.Do(func() { close(started) })
+				cancel()
+			}()
+			_, _, _ = scope.Coalesce(ctx, "query", func(ctx context.Context) (any, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			})
+		}()
+	}
+	<-started
+	if err := scope.Close(); err != nil {
+		t.Fatal(err)
+	}
+	wait.Wait()
+}
+
+func waitForExecutionFlightWaiters(t *testing.T, scope *ExecutionScope, key string, want int) {
+	t.Helper()
+	for {
+		scope.mu.Lock()
+		flight := scope.flights[key]
+		ready := flight != nil && flight.waiters >= want
+		scope.mu.Unlock()
+		if ready {
+			return
+		}
+		runtime.Gosched()
+	}
+}
+
+func requireNoExecutionScopeCloseError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/analytics/resultcache/pool.go
+++ b/internal/analytics/resultcache/pool.go
@@ -1,17 +1,14 @@
-// Package resultcache owns node-wide retention and coalescing for governed
-// analytical query results.
+// Package resultcache owns node-wide retained analytical results and
+// generation-scoped execution coalescing through separate lifetimes.
 package resultcache
 
 import (
 	"container/list"
-	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 
 	"github.com/flidai/leapview/pkg/arrowresult"
-	"golang.org/x/sync/singleflight"
 )
 
 type Constraint string
@@ -59,17 +56,15 @@ type ScopeProvider interface {
 }
 
 type Pool struct {
-	mu           sync.Mutex
-	limits       Limits
-	closed       bool
-	entries      map[string]*list.Element
-	lru          *list.List
-	scopes       map[string]*scopeState
-	bytes        int64
-	evictions    map[Constraint]uint64
-	stores       map[StoreOutcome]uint64
-	group        singleflight.Group
-	arrowFlights map[string]*arrowFlight
+	mu        sync.Mutex
+	limits    Limits
+	closed    bool
+	entries   map[string]*list.Element
+	lru       *list.List
+	scopes    map[string]*scopeState
+	bytes     int64
+	evictions map[Constraint]uint64
+	stores    map[StoreOutcome]uint64
 }
 
 type Scope struct {
@@ -159,15 +154,6 @@ func (l *ArrowFlightLease) Release() {
 	l.data = nil
 }
 
-type arrowFlight struct {
-	done     chan struct{}
-	waiters  int
-	shared   bool
-	complete bool
-	value    ArrowFlightValue
-	err      error
-}
-
 func (l *EntryLease) Data() *arrowresult.Lease {
 	if l == nil {
 		return nil
@@ -225,7 +211,7 @@ func New(limits Limits) (*Pool, error) {
 	if err := limits.Validate(); err != nil {
 		return nil, err
 	}
-	return &Pool{limits: limits, entries: map[string]*list.Element{}, lru: list.New(), scopes: map[string]*scopeState{}, evictions: map[Constraint]uint64{}, stores: map[StoreOutcome]uint64{}, arrowFlights: map[string]*arrowFlight{}}, nil
+	return &Pool{limits: limits, entries: map[string]*list.Element{}, lru: list.New(), scopes: map[string]*scopeState{}, evictions: map[Constraint]uint64{}, stores: map[StoreOutcome]uint64{}}, nil
 }
 
 func (p *Pool) OpenScope(id ScopeID) (*Scope, error) {
@@ -285,18 +271,6 @@ func (s *Scope) openStateLocked() *scopeState {
 		return nil
 	}
 	return state
-}
-
-func (s *Scope) requireOpen() error {
-	if s == nil || s.pool == nil {
-		return fmt.Errorf("result cache scope is required")
-	}
-	s.pool.mu.Lock()
-	defer s.pool.mu.Unlock()
-	if s.openStateLocked() == nil {
-		return fmt.Errorf("result cache scope is closed")
-	}
-	return nil
 }
 
 func (s *Scope) Generation() Token {
@@ -559,140 +533,6 @@ func (s *Scope) Close() error {
 	state.generation++
 	delete(p.scopes, s.key)
 	return nil
-}
-
-type canceledFlight struct{ err error }
-
-func (e canceledFlight) Error() string { return e.err.Error() }
-func (e canceledFlight) Unwrap() error { return e.err }
-
-// OwnerCanceled marks a coalesced execution whose owning context was canceled,
-// allowing a still-live waiter to replace that flight.
-func OwnerCanceled(err error) error { return canceledFlight{err: err} }
-
-func (s *Scope) Coalesce(ctx context.Context, key string, execute func() (any, error)) (any, bool, error) {
-	if err := s.requireOpen(); err != nil {
-		return nil, false, err
-	}
-	flightKey := s.key + "\x00" + key
-	for {
-		ch := s.pool.group.DoChan(flightKey, func() (any, error) {
-			value, err := execute()
-			if ownerErr := ctx.Err(); ownerErr != nil {
-				return nil, canceledFlight{ownerErr}
-			}
-			return value, err
-		})
-		select {
-		case <-ctx.Done():
-			return nil, false, ctx.Err()
-		case call := <-ch:
-			if call.Err != nil {
-				var canceled canceledFlight
-				if ctx.Err() == nil && errors.As(call.Err, &canceled) {
-					continue
-				}
-				return nil, call.Shared, call.Err
-			}
-			return call.Val, call.Shared, nil
-		}
-	}
-}
-
-// CoalesceArrow runs one Arrow-producing execution and gives every live caller
-// an independently retained lease. Canceled callers are removed without
-// releasing buffers still needed by other waiters. If the owning execution was
-// canceled, a live waiter starts a replacement flight.
-func (s *Scope) CoalesceArrow(ctx context.Context, key string, execute func() (ArrowFlightValue, error)) (*ArrowFlightLease, ArrowFlightStatus, error) {
-	if err := s.requireOpen(); err != nil {
-		return nil, ArrowFlightStatus{}, err
-	}
-	flightKey := s.key + "\x00" + key
-	for {
-		flight, owner := s.joinArrowFlight(flightKey, ctx, execute)
-		select {
-		case <-ctx.Done():
-			s.leaveArrowFlight(flight)
-			return nil, ArrowFlightStatus{}, ctx.Err()
-		case <-flight.done:
-		}
-
-		s.pool.mu.Lock()
-		flightErr := flight.err
-		shared := flight.shared
-		value := flight.value
-		s.pool.mu.Unlock()
-		if flightErr != nil {
-			s.leaveArrowFlight(flight)
-			var canceled canceledFlight
-			if ctx.Err() == nil && errors.As(flightErr, &canceled) {
-				continue
-			}
-			return nil, ArrowFlightStatus{Owner: owner, Shared: shared}, flightErr
-		}
-		if value.Data == nil {
-			s.leaveArrowFlight(flight)
-			return nil, ArrowFlightStatus{Owner: owner, Shared: shared}, fmt.Errorf("coalesced Arrow execution returned no data")
-		}
-		lease, err := value.Data.Acquire()
-		s.leaveArrowFlight(flight)
-		if err != nil {
-			return nil, ArrowFlightStatus{Owner: owner, Shared: shared}, err
-		}
-		return &ArrowFlightLease{data: lease, metadata: cloneMetadata(value.Metadata), cached: value.Cached}, ArrowFlightStatus{Owner: owner, Shared: shared}, nil
-	}
-}
-
-func (s *Scope) joinArrowFlight(key string, ctx context.Context, execute func() (ArrowFlightValue, error)) (*arrowFlight, bool) {
-	p := s.pool
-	p.mu.Lock()
-	if existing := p.arrowFlights[key]; existing != nil {
-		existing.waiters++
-		existing.shared = true
-		p.mu.Unlock()
-		return existing, false
-	}
-	flight := &arrowFlight{done: make(chan struct{}), waiters: 1}
-	p.arrowFlights[key] = flight
-	p.mu.Unlock()
-	go func() {
-		value, err := execute()
-		if ownerErr := ctx.Err(); ownerErr != nil {
-			err = canceledFlight{ownerErr}
-		}
-		p.mu.Lock()
-		flight.value, flight.err, flight.complete = value, err, true
-		delete(p.arrowFlights, key)
-		close(flight.done)
-		release := flight.waiters == 0 && flight.value.Data != nil
-		if release {
-			flight.value.Data = nil
-		}
-		p.mu.Unlock()
-		if release {
-			value.Data.Release()
-		}
-	}()
-	return flight, true
-}
-
-func (s *Scope) leaveArrowFlight(flight *arrowFlight) {
-	if flight == nil {
-		return
-	}
-	p := s.pool
-	p.mu.Lock()
-	flight.waiters--
-	release := flight.waiters == 0 && flight.complete && flight.value.Data != nil
-	var data *arrowresult.Lease
-	if release {
-		data = flight.value.Data
-		flight.value.Data = nil
-	}
-	p.mu.Unlock()
-	if data != nil {
-		data.Release()
-	}
 }
 
 func (p *Pool) Stats() Snapshot {

--- a/internal/analytics/resultcache/pool_test.go
+++ b/internal/analytics/resultcache/pool_test.go
@@ -135,14 +135,14 @@ func BenchmarkWarmTileByteLookup(b *testing.B) {
 }
 
 func TestCoalesceCancellationDoesNotPoisonLiveWaiter(t *testing.T) {
-	pool, _ := New(testLimits())
-	scope := mustScope(t, pool, ScopeID{RuntimeID: "one"})
+	scope := NewExecutionScope()
+	defer scope.Close()
 	owner, cancel := context.WithCancel(context.Background())
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var calls atomic.Int32
 	go func() {
-		_, _, _ = scope.Coalesce(owner, "key", func() (any, error) {
+		_, _, _ = scope.Coalesce(owner, "key", func(context.Context) (any, error) {
 			calls.Add(1)
 			close(started)
 			<-release
@@ -152,7 +152,7 @@ func TestCoalesceCancellationDoesNotPoisonLiveWaiter(t *testing.T) {
 	<-started
 	cancel()
 	close(release)
-	value, _, err := scope.Coalesce(context.Background(), "key", func() (any, error) { calls.Add(1); return "live", nil })
+	value, _, err := scope.Coalesce(context.Background(), "key", func(context.Context) (any, error) { calls.Add(1); return "live", nil })
 	if err != nil || value != "live" {
 		t.Fatalf("value=%v err=%v", value, err)
 	}
@@ -166,7 +166,8 @@ func TestCoalesceArrowReturnsIndependentLeasesAndReleasesFlightHold(t *testing.T
 	defer allocator.AssertSize(t, 0)
 	pool, _ := New(testLimits())
 	defer pool.Close()
-	scope := mustScope(t, pool, ScopeID{RuntimeID: "one"})
+	scope := NewExecutionScope()
+	defer scope.Close()
 	started := make(chan struct{})
 	release := make(chan struct{})
 	result := testArrowResult(t, allocator, "shared")
@@ -182,7 +183,7 @@ func TestCoalesceArrowReturnsIndependentLeasesAndReleasesFlightHold(t *testing.T
 		err    error
 	}
 	responses := make(chan response, 2)
-	execute := func() (ArrowFlightValue, error) {
+	execute := func(context.Context) (ArrowFlightValue, error) {
 		calls.Add(1)
 		close(started)
 		<-release
@@ -197,7 +198,7 @@ func TestCoalesceArrowReturnsIndependentLeasesAndReleasesFlightHold(t *testing.T
 		lease, status, executeErr := scope.CoalesceArrow(context.Background(), "key", execute)
 		responses <- response{lease: lease, status: status, err: executeErr}
 	}()
-	waitForArrowFlightWaiters(t, pool, scope.key+"\x00key", 2)
+	waitForArrowFlightWaiters(t, scope, "key", 2)
 	close(release)
 	first, second := <-responses, <-responses
 	if first.err != nil || second.err != nil {
@@ -231,13 +232,14 @@ func TestCoalesceArrowCanceledWaiterDoesNotLeakOrCancelLiveWaiter(t *testing.T) 
 	defer allocator.AssertSize(t, 0)
 	pool, _ := New(testLimits())
 	defer pool.Close()
-	scope := mustScope(t, pool, ScopeID{RuntimeID: "one"})
+	scope := NewExecutionScope()
+	defer scope.Close()
 	started := make(chan struct{})
 	release := make(chan struct{})
 	owner, cancel := context.WithCancel(context.Background())
 	ownerDone := make(chan error, 1)
 	go func() {
-		_, _, err := scope.CoalesceArrow(owner, "key", func() (ArrowFlightValue, error) {
+		_, _, err := scope.CoalesceArrow(owner, "key", func(context.Context) (ArrowFlightValue, error) {
 			close(started)
 			<-release
 			result := testArrowResult(t, allocator, "live")
@@ -251,7 +253,7 @@ func TestCoalesceArrowCanceledWaiterDoesNotLeakOrCancelLiveWaiter(t *testing.T) 
 	liveDone := make(chan *ArrowFlightLease, 1)
 	liveErr := make(chan error, 1)
 	go func() {
-		lease, _, err := scope.CoalesceArrow(context.Background(), "key", func() (ArrowFlightValue, error) {
+		lease, _, err := scope.CoalesceArrow(context.Background(), "key", func(context.Context) (ArrowFlightValue, error) {
 			result := testArrowResult(t, allocator, "replacement")
 			base, acquireErr := result.Acquire()
 			result.Release()
@@ -260,7 +262,7 @@ func TestCoalesceArrowCanceledWaiterDoesNotLeakOrCancelLiveWaiter(t *testing.T) 
 		liveDone <- lease
 		liveErr <- err
 	}()
-	waitForArrowFlightWaiters(t, pool, scope.key+"\x00key", 2)
+	waitForArrowFlightWaiters(t, scope, "key", 2)
 	cancel()
 	close(release)
 	if err := <-ownerDone; !errors.Is(err, context.Canceled) {
@@ -276,13 +278,13 @@ func TestCoalesceArrowCanceledWaiterDoesNotLeakOrCancelLiveWaiter(t *testing.T) 
 	lease.Release()
 }
 
-func waitForArrowFlightWaiters(t *testing.T, pool *Pool, key string, want int) {
+func waitForArrowFlightWaiters(t *testing.T, scope *ExecutionScope, key string, want int) {
 	t.Helper()
 	for {
-		pool.mu.Lock()
-		flight := pool.arrowFlights[key]
+		scope.mu.Lock()
+		flight := scope.arrowFlights[key]
 		ready := flight != nil && flight.waiters >= want
-		pool.mu.Unlock()
+		scope.mu.Unlock()
 		if ready {
 			return
 		}

--- a/internal/dashboard/runtime/spatial_tile_runtime.go
+++ b/internal/dashboard/runtime/spatial_tile_runtime.go
@@ -180,7 +180,7 @@ func (s *SnapshotService) querySpatialTile(ctx context.Context, dashboardID, pag
 type immutableByteCache interface {
 	LookupImmutableBytes(string) ([]byte, bool, error)
 	StoreImmutableBytes(string, []byte) bool
-	CoalesceImmutableBytes(context.Context, string, func() error) (bool, error)
+	CoalesceImmutableBytes(context.Context, string, func(context.Context) error) (bool, error)
 }
 
 func (s *VisualizationDataService) spatialTile(ctx context.Context, runtime *modelRuntime, report *dashboarddefinition.Definition, filters dashboard.Filters, visualID, revision string, rawMinimumZoom, zoom, x, y int) (SpatialTileResult, error) {
@@ -207,7 +207,7 @@ func (s *VisualizationDataService) spatialTile(ctx context.Context, runtime *mod
 		}
 	}
 	buffer := int(spatial.Tiles.CellRadius) * 16
-	execute := func(precision dataquery.SpatialTilePrecision) (dataquery.Result, error) {
+	execute := func(executionCtx context.Context, precision dataquery.SpatialTilePrecision) (dataquery.Result, error) {
 		targetZoom := spatialAggregateTargetZoom(zoom, rawMinimumZoom, int(spatial.Tiles.MaximumZoom))
 		query := dataquery.Query{
 			Surface: dataquery.SurfaceDashboard, Operation: dataquery.OperationDashboardSpatialTile,
@@ -222,11 +222,14 @@ func (s *VisualizationDataService) spatialTile(ctx context.Context, runtime *mod
 		if spatial.Time != nil {
 			query.Time = dataquery.Time{Field: spatial.Time.FieldID, Alias: spatial.Time.Alias, Grain: spatial.Time.Grain}
 		}
-		return runtime.data.ExecuteDataQuery(ctx, query)
+		return runtime.data.ExecuteDataQuery(executionCtx, query)
 	}
 	precision := spatialTilePrecision(zoom, rawMinimumZoom)
-	generate := func() (SpatialTileResult, error) {
-		result, executeErr := execute(precision)
+	generate := func(executionCtx context.Context) (SpatialTileResult, error) {
+		if err := executionCtx.Err(); err != nil {
+			return SpatialTileResult{}, err
+		}
+		result, executeErr := execute(executionCtx, precision)
 		if executeErr != nil {
 			return SpatialTileResult{}, executeErr
 		}
@@ -236,6 +239,9 @@ func (s *VisualizationDataService) spatialTile(ctx context.Context, runtime *mod
 		requested := SpatialTileResult{Precision: string(precision), CacheOutcome: result.CacheOutcome, QueryMS: result.DurationMS}
 		for childX := metatileX; childX < metatileX+metatileSize; childX++ {
 			for childY := metatileY; childY < metatileY+metatileSize; childY++ {
+				if err := executionCtx.Err(); err != nil {
+					return SpatialTileResult{}, err
+				}
 				tile, features, found, tileErr := spatialTileFromRows(result.Rows, childX, childY)
 				if tileErr != nil {
 					return SpatialTileResult{}, tileErr
@@ -258,15 +264,18 @@ func (s *VisualizationDataService) spatialTile(ctx context.Context, runtime *mod
 		return requested, nil
 	}
 	if !cacheEnabled {
-		return generate()
+		return generate(ctx)
 	}
 	var generated SpatialTileResult
-	shared, err := cache.CoalesceImmutableBytes(ctx, spatialTileMetatileCacheKey(revision, zoom, metatileX, metatileY), func() error {
+	shared, err := cache.CoalesceImmutableBytes(ctx, spatialTileMetatileCacheKey(revision, zoom, metatileX, metatileY), func(executionCtx context.Context) error {
+		if err := executionCtx.Err(); err != nil {
+			return err
+		}
 		if _, ok, lookupErr := lookupSpatialTileBytes(cache, childKey); lookupErr != nil || ok {
 			return lookupErr
 		}
 		var generateErr error
-		generated, generateErr = generate()
+		generated, generateErr = generate(executionCtx)
 		return generateErr
 	})
 	if err != nil {

--- a/internal/dashboard/runtime/spatial_tiles_test.go
+++ b/internal/dashboard/runtime/spatial_tiles_test.go
@@ -191,8 +191,8 @@ func (cache *memoryImmutableByteCache) StoreImmutableBytes(key string, value []b
 	return true
 }
 
-func (cache *memoryImmutableByteCache) CoalesceImmutableBytes(_ context.Context, _ string, execute func() error) (bool, error) {
-	return false, execute()
+func (cache *memoryImmutableByteCache) CoalesceImmutableBytes(ctx context.Context, _ string, execute func(context.Context) error) (bool, error) {
+	return false, execute(ctx)
 }
 
 func TestSpatialChildTileByteCacheRoundTripsEmptyAndRawTiles(t *testing.T) {


### PR DESCRIPTION
## Summary

Separates mutable execution/coalescing lifecycle from stable reusable cache lifecycle.

## Changes

- Added generation-owned ExecutionScope.
- Moved query, bundle, Arrow, and immutable-byte flight ownership into generation scope.
- Reduced stable result cache Scope to retained storage responsibilities:
  - lookup/store/delete
  - invalidation
  - LRU accounting
  - byte accounting
  - reference counting
- Added generation lifecycle cancellation and draining.
- Ensured immutable-byte/spatial execution observes generation cancellation.

## Guarantees

- Completed results remain reusable across serving generations.
- Concurrent cold misses across generations execute independently.
- Same-generation requests continue to coalesce.
- Generation close drains active execution before releasing resources.
- Stable cache entries cannot be affected by generation shutdown.

## Unchanged

- Result identity contract.
- Cache key format.
- Dependency evidence.
- Authorization semantics.
- Arrow transport contracts.
- Invalidation tokens.
- Stale StoreArrow rejection behavior.

## Verification

- `go test -count=1 ./internal/analytics/resultcache ./internal/analytics/materialize ./internal/dashboard/runtime`
- `go test -race -count=1 ./internal/analytics/resultcache ./internal/analytics/materialize`
- `go test -tags=duckdb_arrow -count=1 ./internal/analytics/duckdb`
- `go vet -tags=duckdb_arrow ./internal/analytics/resultcache ./internal/analytics/materialize ./internal/analytics/duckdb ./internal/dashboard/runtime`
- `git diff --check origin/main...HEAD`

All checks passed on the rebased branch.