### PR TITLE
Enforce Prometheus rule validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
         with:
           browser: "false"
 
+      - name: Validate Prometheus rules and fixtures
+        run: task observability:check
+
       - name: Prepare generated and embedded assets
         run: node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare
 

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           browser: "false"
 
+      - name: Validate Prometheus rules and fixtures
+        run: task observability:check
+
       - name: Prepare generated and embedded assets
         run: node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -869,6 +869,12 @@ tasks:
     cmds:
       - task: ci:pr
 
+  observability:check:
+    desc: Validate all repository-owned Prometheus rules and fixtures
+    cmds:
+      - task: observability:alerts:check
+      - task: observability:sli:check
+
   observability:alerts:check:
     desc: Validate repository-owned Prometheus alert rules and fixtures
     cmds:

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2975,6 +2975,14 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 			}
 		}
 	}
+	for _, want := range []string{
+		"name: Validate Prometheus rules and fixtures",
+		"run: task observability:check",
+	} {
+		if !strings.Contains(goPackagesCI, want) {
+			t.Fatalf("PR Go package validation missing observability check %q", want)
+		}
+	}
 	for _, forbidden := range []string{
 		"push:",
 		"Build and qualify the production image remotely",
@@ -3016,6 +3024,24 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	}
 	if strings.Contains(mergeText, "group: merge-validation-${{ github.repository }}") {
 		t.Fatal("merge validation concurrency must not cancel distinct merge-queue candidates")
+	}
+	goPackagesMerge := workflowJobBlock(t, mergeText, "go-packages-validation")
+	for _, want := range []string{
+		"name: Validate Prometheus rules and fixtures",
+		"run: task observability:check",
+	} {
+		if !strings.Contains(goPackagesMerge, want) {
+			t.Fatalf("merge-queue Go package validation missing observability check %q", want)
+		}
+	}
+	for _, want := range []string{
+		"observability:check:",
+		"task: observability:alerts:check",
+		"task: observability:sli:check",
+	} {
+		if !strings.Contains(string(taskfile), want) {
+			t.Fatalf("Taskfile missing aggregate observability check %q", want)
+		}
 	}
 	artifactText := string(artifactWorkflow)
 	for _, want := range []string{


### PR DESCRIPTION
## Problem

LeapView owns executable Prometheus alert and recording rules, but the pull-request and merge-queue workflows did not run their pinned promtool validation. Invalid rule syntax or broken fixtures could therefore merge without exercising the repository-owned observability contract.

## Root cause

FAI-554, FAI-578, and FAI-579 added reproducible rule-specific Task targets, but no aggregate entry point or CI wiring invoked them.

## Solution

- Add `observability:check` as the single repository-owned entry point, delegating to the existing alert and SLI validation tasks.
- Run that aggregate task in the existing Go-package lane for both pull-request and merge-queue workflows.
- Add focused architecture assertions that keep the two workflow paths aligned and verify the aggregate task delegates to both existing checks.

The existing checksum-pinned promtool wrapper and rule-specific commands remain unchanged.

## Tests added or updated

- Extended `TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware` to cover the aggregate task and both workflow paths.

## Verification performed

- `task observability:check` — passed; six alert rules, two recording rules, and all fixtures validated.
- `go test ./internal/platform/architecture -run '^TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware$' -count=1` — passed.
- `git diff --check` — passed.

The full architecture package was not used as focused verification because the isolated worktree had not generated the repository-wide API assets; its generated-surface failures were unrelated to this change.

## Limitations

This validates repository rule syntax, PromQL fixtures, and workflow enforcement only. It does not deploy Prometheus or verify that a production Prometheus server loads and evaluates these rules.

Linear: [FAI-586](https://linear.app/flid/issue/FAI-586/enforce-repository-owned-prometheus-rule-validation-in-ci)
