### PR TITLE
FAI-531: Retain compatible Arrow results across serving generation cutover

### DIFF
--- a/internal/analytics/materialize/query_cache_test.go
+++ b/internal/analytics/materialize/query_cache_test.go
@@ -354,13 +354,10 @@ func TestRuntimeSharedPartitionCacheReusesDataWithoutStaleSQLOrByteLifetime(t *t
 		RuntimeEntries: 16, RuntimeBytes: 1 << 20, NodeEntries: 32, NodeBytes: 2 << 20,
 	})
 	require.NoError(t, err)
+	defer pool.Close()
 	firstResults, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
 	require.NoError(t, err)
-	secondResults, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
-	require.NoError(t, err)
 	firstBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "serving-one"})
-	require.NoError(t, err)
-	secondBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "serving-two"})
 	require.NoError(t, err)
 
 	model := func() *semanticmodel.Model {
@@ -373,10 +370,6 @@ func TestRuntimeSharedPartitionCacheReusesDataWithoutStaleSQLOrByteLifetime(t *t
 		modelID: "sales", model: model(), db: firstDB,
 		queryCache: newQueryResultCacheWithScopes(firstResults, firstBytes),
 	})
-	second := activatedCacheRuntime(t, &Runtime{
-		modelID: "sales", model: model(), db: secondDB,
-		queryCache: newQueryResultCacheWithScopes(secondResults, secondBytes),
-	})
 	bindPlanner := func(runtime *Runtime, snapshot string) {
 		planner, plannerErr := semanticquery.NewCompiledPlanner(runtime.model, semanticquery.WithTableRelation(func(table string) (string, error) {
 			return snapshot + "." + table, nil
@@ -385,7 +378,6 @@ func TestRuntimeSharedPartitionCacheReusesDataWithoutStaleSQLOrByteLifetime(t *t
 		runtime.planner = planner
 	}
 	bindPlanner(first, "snapshot_one")
-	bindPlanner(second, "snapshot_two")
 	request := dataquery.Query{
 		Surface: dataquery.SurfaceDashboard, Operation: dataquery.OperationDashboardRows,
 		EffectivePolicyFingerprint: materializeTestDigest('9'), ModelID: "sales",
@@ -408,8 +400,21 @@ func TestRuntimeSharedPartitionCacheReusesDataWithoutStaleSQLOrByteLifetime(t *t
 	})
 	require.True(t, first.StoreImmutableBytes("tile", []byte("generation-one")))
 
+	require.NoError(t, first.queryCache.close())
 	require.NoError(t, firstResults.Close())
 	require.NoError(t, firstBytes.Close())
+	secondResults, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "partition-production"})
+	require.NoError(t, err)
+	defer secondResults.Close()
+	secondBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "serving-two"})
+	require.NoError(t, err)
+	defer secondBytes.Close()
+	second := activatedCacheRuntime(t, &Runtime{
+		modelID: "sales", model: model(), db: secondDB,
+		queryCache: newQueryResultCacheWithScopes(secondResults, secondBytes),
+	})
+	defer second.queryCache.close()
+	bindPlanner(second, "snapshot_two")
 	secondResult, err := second.ExecuteDataQuery(context.Background(), request)
 	require.NoError(t, err)
 	require.Equal(t, dataquery.CacheHit, secondResult.CacheOutcome)
@@ -436,6 +441,53 @@ func TestRuntimeSharedPartitionCacheReusesDataWithoutStaleSQLOrByteLifetime(t *t
 	_, found, err := second.LookupImmutableBytes("tile")
 	require.NoError(t, err)
 	require.False(t, found)
+}
+
+func TestDormantSharedResultInvalidationBeforeCompatibleGenerationPreventsReuse(t *testing.T) {
+	pool, err := resultcache.New(resultcache.Limits{
+		RuntimeEntries: 16, RuntimeBytes: 1 << 20, NodeEntries: 32, NodeBytes: 2 << 20,
+	})
+	require.NoError(t, err)
+	defer pool.Close()
+	partitionID := resultcache.ScopeID{RuntimeID: "partition-production"}
+	firstScope, err := pool.OpenSharedScope(partitionID)
+	require.NoError(t, err)
+	firstBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "serving-one"})
+	require.NoError(t, err)
+	first := newQueryResultCacheWithScopes(firstScope, firstBytes)
+	request := dataquery.Query{
+		ModelID: "sales", Kind: dataquery.KindSemanticAggregate, Target: "orders",
+		Operation: dataquery.OperationDashboardFilterOptions,
+	}
+	var executions atomic.Int32
+	execute := func() (dataquery.Result, error) {
+		value := executions.Add(1)
+		return dataquery.Result{Rows: []dataquery.Row{{"value": value}}}, nil
+	}
+	result, err := first.execute(context.Background(), request, execute)
+	require.NoError(t, err)
+	require.Equal(t, dataquery.CacheMiss, result.CacheOutcome)
+	require.NoError(t, first.close())
+	require.NoError(t, firstBytes.Close())
+	require.NoError(t, firstScope.Close())
+
+	invalidator, err := pool.OpenSharedScope(partitionID)
+	require.NoError(t, err)
+	invalidator.Invalidate()
+	require.NoError(t, invalidator.Close())
+
+	secondScope, err := pool.OpenSharedScope(partitionID)
+	require.NoError(t, err)
+	defer secondScope.Close()
+	secondBytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "serving-two"})
+	require.NoError(t, err)
+	defer secondBytes.Close()
+	second := newQueryResultCacheWithScopes(secondScope, secondBytes)
+	defer second.close()
+	result, err = second.execute(context.Background(), request, execute)
+	require.NoError(t, err)
+	require.Equal(t, dataquery.CacheMiss, result.CacheOutcome)
+	require.Equal(t, int32(2), executions.Load())
 }
 
 func TestGenerationExecutionScopesDoNotCoalesceColdMissesButReuseCompletedEntries(t *testing.T) {

--- a/internal/analytics/resultcache/arrow_test.go
+++ b/internal/analytics/resultcache/arrow_test.go
@@ -46,6 +46,68 @@ func TestArrowLookupLeaseSurvivesEviction(t *testing.T) {
 	}
 }
 
+func TestArrowLookupLeaseSurvivesDormantScopePurge(t *testing.T) {
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer allocator.AssertSize(t, 0)
+	pool, err := New(testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope, err := pool.OpenSharedScope(ScopeID{RuntimeID: "partition-production"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := testArrowResult(t, allocator, "retained")
+	if got := scope.StoreArrow("query", scope.Generation(), result, Metadata{}); got != StoreStored {
+		t.Fatalf("store = %q", got)
+	}
+	result.Release()
+	lease, _, hit, err := scope.LookupArrow("query")
+	if err != nil || !hit {
+		t.Fatalf("lookup hit=%v err=%v", hit, err)
+	}
+	if err := scope.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if lease.Data().Rows() != 1 {
+		t.Fatalf("leased rows after purge = %d", lease.Data().Rows())
+	}
+	lease.Release()
+}
+
+func TestPoolShutdownReleasesDormantArrowHold(t *testing.T) {
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer allocator.AssertSize(t, 0)
+	pool, err := New(testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope, err := pool.OpenSharedScope(ScopeID{RuntimeID: "partition-production"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := testArrowResult(t, allocator, "retained")
+	if got := scope.StoreArrow("query", scope.Generation(), result, Metadata{}); got != StoreStored {
+		t.Fatalf("store = %q", got)
+	}
+	result.Release()
+	if err := scope.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if allocator.CurrentAlloc() == 0 {
+		t.Fatal("final shared handle close released dormant Arrow hold")
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := allocator.CurrentAlloc(); got != 0 {
+		t.Fatalf("allocator bytes after pool shutdown = %d, want 0", got)
+	}
+}
+
 func testArrowResult(t *testing.T, allocator memory.Allocator, value string) *arrowresult.Result {
 	t.Helper()
 	builder := array.NewStringBuilder(allocator)

--- a/internal/analytics/resultcache/pool.go
+++ b/internal/analytics/resultcache/pool.go
@@ -236,8 +236,8 @@ func (p *Pool) OpenScope(id ScopeID) (*Scope, error) {
 
 // OpenSharedScope acquires one handle to a stable cache scope. All live
 // handles with the same identity share entries and invalidation generation.
-// Closing one handle leaves the scope available to the others; the final
-// close releases the retained entries.
+// Closing the final handle leaves retained state dormant so a compatible
+// serving generation can reactivate it. Empty dormant scopes are discarded.
 func (p *Pool) OpenSharedScope(id ScopeID) (*Scope, error) {
 	if p == nil {
 		return nil, fmt.Errorf("result cache pool is required")
@@ -471,10 +471,19 @@ func (p *Pool) removeLocked(element *list.Element, constraint Constraint) {
 		delete(state.entries, e.composite)
 		state.usage.entries--
 		state.usage.bytes -= e.bytes
+		p.removeEmptyDormantScopeLocked(state)
 	}
 	if constraint != "" {
 		p.evictions[constraint]++
 	}
+}
+
+func (p *Pool) removeEmptyDormantScopeLocked(state *scopeState) {
+	if state == nil || !state.shared || state.references != 0 || len(state.entries) != 0 {
+		return
+	}
+	state.closed = true
+	delete(p.scopes, scopeKey(state.id))
 }
 
 func cloneMetadata(metadata Metadata) Metadata {
@@ -522,8 +531,11 @@ func (s *Scope) Close() error {
 	if state == nil || state.closed {
 		return nil
 	}
-	if state.shared && state.references > 1 {
-		state.references--
+	if state.shared {
+		if state.references > 0 {
+			state.references--
+		}
+		p.removeEmptyDormantScopeLocked(state)
 		return nil
 	}
 	for composite := range state.entries {

--- a/internal/analytics/resultcache/pool_test.go
+++ b/internal/analytics/resultcache/pool_test.go
@@ -292,11 +292,12 @@ func waitForArrowFlightWaiters(t *testing.T, scope *ExecutionScope, key string, 
 	}
 }
 
-func TestSharedScopeKeepsEntriesUntilLastHandleCloses(t *testing.T) {
+func TestSharedScopeRetainsEntriesAcrossZeroReferenceTransition(t *testing.T) {
 	pool, err := New(testLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer pool.Close()
 	first, err := pool.OpenSharedScope(ScopeID{RuntimeID: "partition-production"})
 	if err != nil {
 		t.Fatal(err)
@@ -324,7 +325,41 @@ func TestSharedScopeKeepsEntriesUntilLastHandleCloses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertMiss(t, reopened, "query")
+	entry, _, ok, err = reopened.LookupArrow("query")
+	if err != nil || !ok {
+		t.Fatalf("reopened dormant scope lookup ok=%v err=%v", ok, err)
+	}
+	entry.Release()
+}
+
+func TestDormantSharedScopePreservesInvalidationToken(t *testing.T) {
+	pool, err := New(testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	scope, err := pool.OpenSharedScope(ScopeID{RuntimeID: "partition-production"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope.Invalidate()
+	token := scope.Generation()
+	put(t, scope, "query", "after-invalidation")
+	if err := scope.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := pool.OpenSharedScope(ScopeID{RuntimeID: "partition-production"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reopened.Generation(); got != token {
+		t.Fatalf("reopened generation = %d, want %d", got, token)
+	}
+	entry, _, ok, err := reopened.LookupArrow("query")
+	if err != nil || !ok {
+		t.Fatalf("reopened lookup ok=%v err=%v", ok, err)
+	}
+	entry.Release()
 }
 
 func TestGenerationScopeCloseDoesNotAffectSharedResultScope(t *testing.T) {
@@ -359,6 +394,114 @@ func TestGenerationScopeCloseDoesNotAffectSharedResultScope(t *testing.T) {
 	if _, _, ok, err := reopenedBytes.LookupBytes("tile"); err != nil || ok {
 		t.Fatalf("generation-two byte lookup ok=%v err=%v", ok, err)
 	}
+}
+
+func TestDormantSharedScopeIsRemovedAfterFinalEntryEviction(t *testing.T) {
+	pool, err := New(Limits{RuntimeEntries: 1, RuntimeBytes: 1 << 20, NodeEntries: 1, NodeBytes: 1 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	stableID := ScopeID{RuntimeID: "partition-production"}
+	stable, err := pool.OpenSharedScope(stableID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	put(t, stable, "query", "stable")
+	if err := stable.Close(); err != nil {
+		t.Fatal(err)
+	}
+	active := mustScope(t, pool, ScopeID{RuntimeID: "generation-bytes"})
+	if outcome := active.StoreBytes("newer", active.Generation(), []byte("active")); outcome != StoreStored {
+		t.Fatalf("store newer entry = %q", outcome)
+	}
+	pool.mu.Lock()
+	_, retained := pool.scopes[stableID.RuntimeID]
+	pool.mu.Unlock()
+	if retained {
+		t.Fatal("empty dormant shared scope remained after final entry eviction")
+	}
+}
+
+func TestEmptyDormantSharedScopeIsRemovedAfterDeleteOrInvalidation(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		clear func(*Scope)
+	}{
+		{name: "delete", clear: func(scope *Scope) { scope.Delete("query") }},
+		{name: "invalidate", clear: func(scope *Scope) { scope.Invalidate() }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pool, err := New(testLimits())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer pool.Close()
+			id := ScopeID{RuntimeID: "partition-production"}
+			scope, err := pool.OpenSharedScope(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			put(t, scope, "query", "stable")
+			if err := scope.Close(); err != nil {
+				t.Fatal(err)
+			}
+			clearer, err := pool.OpenSharedScope(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.clear(clearer)
+			if err := clearer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			pool.mu.Lock()
+			_, retained := pool.scopes[id.RuntimeID]
+			pool.mu.Unlock()
+			if retained {
+				t.Fatal("empty dormant shared scope remained after final entry removal")
+			}
+		})
+	}
+}
+
+func TestSharedScopeConcurrentCloseReopenInvalidateLookupAndStore(t *testing.T) {
+	pool, err := New(Limits{RuntimeEntries: 32, RuntimeBytes: 4 << 20, NodeEntries: 64, NodeBytes: 8 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	id := ScopeID{RuntimeID: "partition-production"}
+	value := testArrowResult(t, memory.DefaultAllocator, "value")
+	defer value.Release()
+	var wait sync.WaitGroup
+	for worker := range 16 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			for iteration := range 100 {
+				scope, openErr := pool.OpenSharedScope(id)
+				if openErr != nil {
+					t.Errorf("worker %d open: %v", worker, openErr)
+					return
+				}
+				token := scope.Generation()
+				if iteration%5 == 0 {
+					scope.Invalidate()
+				}
+				_ = scope.StoreArrow("query", token, value, Metadata{})
+				if entry, _, ok, lookupErr := scope.LookupArrow("query"); lookupErr != nil {
+					t.Errorf("worker %d lookup: %v", worker, lookupErr)
+				} else if ok {
+					entry.Release()
+				}
+				if closeErr := scope.Close(); closeErr != nil {
+					t.Errorf("worker %d close: %v", worker, closeErr)
+					return
+				}
+			}
+		}()
+	}
+	wait.Wait()
 }
 
 func TestPoolConcurrentStatsInvalidateAndClose(t *testing.T) {


### PR DESCRIPTION
## Problem

Compatible Arrow query results were destroyed when the final serving-generation handle closed, even though the stable partition identity and retained result remained reusable.

## Root cause

Shared result retention lifetime was coupled to the active runtime handle reference count. The zero-reference transition purged stable entries and invalidation state.

## Summary

Retains compatible Arrow query results across serving generation cutovers by separating stable result retention lifetime from active runtime generation references.

## Changes

- Shared result scopes now become dormant instead of being destroyed when the final runtime handle closes.
- Dormant scopes retain:
  - Arrow cache entries
  - cache-owned Arrow holds
  - invalidation token state
- Reopening the same partition reactivates retained cache state.
- Empty dormant scopes are removed after:
  - eviction
  - deletion
  - invalidation cleanup
- Generation-owned byte/spatial scopes retain existing purge-on-close behavior.
- Pool shutdown releases dormant Arrow resources.

## Guarantees

- Compatible results survive temporary zero-runtime-reference periods.
- Cross-generation cache reuse remains safe.
- Consumer leases remain valid independently of cache eviction.
- Node-wide memory/LRU limits continue bounding retained state.
- Invalidation and stale-store protection remain unchanged.

## Unchanged

- Cache key format.
- Result identity contracts.
- Dependency evidence.
- Authorization behavior.
- ExecutionScope ownership.
- Arrow transport contracts.

## Tests added or updated

- Zero-reference shared-scope retention and reactivation.
- Dormant invalidation-token preservation and cleanup.
- Final-entry eviction, deletion, and invalidation cleanup.
- Consumer lease survival and pool-shutdown Arrow release.
- Cross-generation materialize reuse and dormant-period invalidation.
- Concurrent close, reopen, invalidate, lookup, and store coverage.

## Verification

- `go test -count=1 ./internal/analytics/resultcache ./internal/analytics/materialize`
- `go test -race -count=1 ./internal/analytics/resultcache ./internal/analytics/materialize`
- `go test -tags=duckdb_arrow -count=1 ./internal/analytics/duckdb ./internal/analytics/module`
- `go test -count=1 ./internal/dashboard/runtime ./internal/app/runtimefactory ./internal/platform/architecture`
- `go vet -tags=duckdb_arrow ./internal/analytics/resultcache ./internal/analytics/materialize ./internal/analytics/duckdb ./internal/analytics/module ./internal/dashboard/runtime ./internal/app/runtimefactory`
- `git diff --check`

## Remaining limitations

No TTL or background reaper is introduced. Dormant entries remain bounded by the existing node-wide LRU and memory limits and are released by eviction, explicit removal or invalidation, or pool shutdown.
