### PR TITLE
FAI-541: Lock down dashboard native Arrow response contract

### DIFF
--- a/api/typespec/bi.tsp
+++ b/api/typespec/bi.tsp
@@ -788,7 +788,7 @@ op listSemanticModelFields(@path("model") modelName: ResourceId, @query limit?: 
     cursor: #{ source: "/page/nextCursor" }
   },
 })
-op querySemanticModel(@path("model") modelName: ResourceId, @header accept?: string, @body body?: SemanticQueryRequest): RowsetResponse<SemanticQueryResponse> | CommonErrors;
+op querySemanticModel(@path("model") modelName: ResourceId, @header accept?: string, @body body?: SemanticQueryRequest): RowsetResponse<SemanticQueryResponse> | RowsetErrors;
 
 @tag("BI")
 @summary("Explain semantic model query")
@@ -836,7 +836,7 @@ op listSemanticFields(@path("model") modelName: ResourceId, @path dataset: strin
 @extension("x-leapview-object-scope", "semantic-model")
 @extension("x-leapview-response-trailers", #["X-Next-Cursor"])
 @apigen.cli(#{ command: #["semantic-models", "preview"], args: #[#{ source: "path", name: "model", displayName: "model-id" }, #{ source: "path", name: "dataset", displayName: "dataset" }], output: #{ mode: "raw" } })
-op previewSemanticDataset(@path("model") modelName: ResourceId, @path dataset: string, @header accept?: string, @body body?: SemanticPreviewRequest): RowsetResponse<SemanticQueryResponse> | CommonErrors;
+op previewSemanticDataset(@path("model") modelName: ResourceId, @path dataset: string, @header accept?: string, @body body?: SemanticPreviewRequest): RowsetResponse<SemanticQueryResponse> | RowsetErrors;
 
 @tag("BI")
 @summary("Explain semantic model dataset row preview")
@@ -878,7 +878,7 @@ op queryDashboardPage(@path dashboard: ResourceId, @path page: string, @body bod
   ] },
   output: #{ mode: "raw" },
 })
-op queryDashboardVisualData(@path dashboard: ResourceId, @path page: string, @path visual: string, @header accept?: string, @body body?: DashboardVisualQueryRequest): RowsetResponse<LeapViewVisualization.VisualizationEnvelope> | CommonErrors;
+op queryDashboardVisualData(@path dashboard: ResourceId, @path page: string, @path visual: string, @header accept?: string, @body body?: DashboardVisualQueryRequest): RowsetResponse<LeapViewVisualization.VisualizationEnvelope> | RowsetErrors;
 
 @tag("BI")
 @summary("List dashboard filter values")

--- a/api/typespec/common.tsp
+++ b/api/typespec/common.tsp
@@ -216,4 +216,9 @@ model ServiceUnavailable {
   ...ProblemResponse<503>;
 }
 
+model GatewayTimeout {
+  ...ProblemResponse<504>;
+}
+
 alias CommonErrors = BadRequest | Unauthorized | Forbidden | NotFound | Conflict | PreconditionFailed | ContentTooLarge | UnsupportedMediaType | UnprocessableContent | RateLimited | InternalServerError | BadGateway | ServiceUnavailable;
+alias RowsetErrors = CommonErrors | GatewayTimeout;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7548,6 +7548,24 @@ paths:
                 status: 1
                 title: example
                 type: example
+        '504':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
       tags:
         - BI
       requestBody:
@@ -58613,6 +58631,24 @@ paths:
                 status: 1
                 title: example
                 type: example
+        '504':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
       tags:
         - BI
       requestBody:
@@ -59538,6 +59574,24 @@ paths:
                 type: example
         '503':
           description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '504':
+          description: Server error
           content:
             application/problem+json:
               schema:

--- a/docs/articles/architecture/dashboard-native-arrow-contract.md
+++ b/docs/articles/architecture/dashboard-native-arrow-contract.md
@@ -1,0 +1,193 @@
+# Dashboard native Arrow response contract
+
+This document defines the `native-v1` correctness oracle for a future native
+Arrow response from dashboard table data queries. It does not activate that
+response, change the current dashboard endpoint, or authorize a production
+migration. FAI-543 and later experiments must satisfy this contract before
+their performance results can be considered.
+
+The existing unversioned dashboard Arrow response is a compatibility boundary:
+it projects every cell to UTF-8, represents a source null as an empty string,
+and returns its next cursor as an initial response header. A `native-v1`
+response instead preserves governed Arrow values and uses a completion trailer.
+Those behaviors are not wire-compatible. The current stream must not silently
+change; a native response requires explicit client opt-in and the response must
+identify `native-v1` in both its header and schema metadata.
+
+## Scope
+
+The first eligible implementation is an ordinary detail/table query. It must
+use the same authorization, governance, admission, audit, result-budget,
+sorting, and pagination inputs as the current direct dashboard query. Matrix,
+pivot, calculations, multi-block shaping, Datastar SSE, retained-result cache,
+and warm-cache delivery are outside this contract's first implementation.
+
+## Schema contract
+
+The IPC stream schema is the post-governance projected schema, not the source
+table schema. In particular:
+
+- Fields appear in governed projection order. Field names are the requested
+  aliases where aliases exist; physical source names must not replace aliases.
+- Arrow physical types are preserved. Boolean and signed/unsigned integer
+  widths, floating-point widths, dates, timestamps, UTF-8 strings, binary
+  values, decimals, and dictionary encodings must not be projected to strings.
+- The field's nullable declaration and each array's validity bitmap are
+  preserved. A null must remain null; it must not become zero, `false`, an
+  empty string, or an empty byte slice.
+- A decimal preserves its precision, scale, sign, and exact unscaled value.
+- A timestamp preserves its Arrow unit and timezone. A timestamp with timezone
+  `UTC` represents the same UTC instant; a timezone-neutral timestamp remains
+  timezone-neutral rather than acquiring a server-local zone.
+- Binary values preserve their exact bytes, including zero bytes and empty
+  non-null values.
+- A dictionary field preserves its index type, value type, ordering flag,
+  dictionary values, indices, and validity bitmap. Expanding a dictionary to
+  strings is a contract change.
+- Only response-safe governed metadata from the closed allowlists below is
+  emitted. It must not expose generated SQL, physical connection or source
+  identifiers, policy expressions, credentials, principals, or other internal
+  state.
+
+An empty result is a valid Arrow IPC stream containing the full governed schema
+and zero record batches. It is not a schema-less stream and it is not a JSON
+empty array.
+
+### Reserved LeapView metadata
+
+The `leapview.*` namespace is server-owned. Upstream/source metadata cannot set
+or override it. The allowlists are closed: unknown keys are rejected whether
+they use the `leapview.*` namespace, another namespace, or no namespace. Adding
+a response metadata key requires a contract revision and corresponding oracle
+coverage.
+
+| Location | Key | Authority and required value |
+| --- | --- | --- |
+| Schema | `leapview.arrow_contract` | `native-v1` |
+| Schema | `leapview.query_id` | Same value as `X-Query-ID` |
+| Schema | `leapview.serving_snapshot` | Same value as `X-Serving-Snapshot` |
+| Schema | `leapview.visualization_schema_version` | Server-controlled visualization schema version |
+| Schema | `leapview.visualization_spec_revision` | Server-controlled visualization specification revision |
+| Schema | `leapview.visualization_data_revision` | Server-controlled visualization data revision |
+| Field | `leapview.logical_type` | Public governed logical type, when available |
+| Field | `display.label` | Approved producer metadata for the governed display label |
+
+All schema keys and `leapview.logical_type` are authoritative server values;
+producer values cannot override them. `display.label` is the only producer
+metadata currently approved for forwarding. SQL, engine, connection, physical
+source, and other producer metadata are rejected. In particular, a cursor is
+never placed in schema metadata: it is disclosed only through the response
+trailer after successful completion.
+
+## Response protocol
+
+A successful native response is an Arrow IPC stream and has these required
+headers before the body is committed:
+
+| Header | Value |
+| --- | --- |
+| `Content-Type` | `application/vnd.apache.arrow.stream` |
+| `Cache-Control` | `no-store` |
+| `X-Query-ID` | Non-empty request/query correlation ID |
+| `X-Serving-Snapshot` | Non-empty serving snapshot bound to the query |
+| `X-LeapView-Arrow-Contract` | `native-v1` |
+| `Trailer` | Declares `X-Next-Cursor` |
+
+The server executes a `limit + 1` pagination probe under the same governed
+query. At most `limit` rows are written. If the probe row exists and the stream
+closes successfully, the server writes an opaque `X-Next-Cursor` trailer. The
+cursor identifies the next offset, is bound to the normalized query scope and
+serving snapshot, and expires according to the dashboard cursor policy. A
+client must not parse it. A cursor for a different query scope is invalid; a
+cursor for a different or unavailable serving snapshot is a conflict.
+
+The final page has no `X-Next-Cursor` trailer value. The trailer name is still
+declared so clients can consume both cases uniformly. Probe rows count toward
+physical execution and result budgets even though they are not emitted.
+
+## Error and commit boundary
+
+Before the Arrow response is committed, failures use the API's JSON problem
+shape with `Content-Type: application/problem+json` and no Arrow contract
+headers. Existing resource-concealment rules remain authoritative.
+
+| Failure | Required result before commit |
+| --- | --- |
+| Authentication failure | `401` problem response |
+| Authorization failure | `403`, or `404` where the route conceals inaccessible resources |
+| Malformed or wrong-scope cursor | `400` problem response |
+| Cursor serving-snapshot mismatch | `409` problem response |
+| Row or byte budget failure | `422` problem response |
+| Admission rejection or resource exhaustion | `503` problem response, including `Retry-After` where applicable |
+| Admission queue timeout or execution timeout | `504` problem response |
+| Internal failure | `500` problem response |
+
+Request cancellation stops query work and releases borrowed batches and other
+leases. If the connection remains writable and no bytes have been committed,
+the failure follows the normal problem mapping; a disconnected client may
+observe only connection termination.
+
+After the Arrow response is committed, the server cannot switch formats. A
+query, IPC, cancellation, or transport failure terminates the stream. There is
+no JSON suffix or fallback, no successful completion signal, and no
+`X-Next-Cursor` trailer value. Consumers must treat an unreadable or incomplete
+IPC stream as failed even if the HTTP status was already `200`.
+
+## Security and governance invariants
+
+The native transport changes representation only. Before any schema or batch
+is written, the request must pass the same boundaries as the current governed
+direct query:
+
+1. Resolve the authenticated principal and active serving snapshot.
+2. Authorize the dashboard/model dependencies and preserve any resource
+   concealment behavior.
+3. Apply row policies and column masks and compute the effective policy
+   fingerprint. The emitted schema is the masked projection; it cannot reveal
+   denied source columns or pre-mask physical types/metadata.
+4. Acquire workload admission using the same class, identity, operation, and
+   memory estimate as the control query.
+5. Apply row and byte budgets to the schema, emitted rows, and pagination
+   probe. A transport encoder cannot bypass budget accounting.
+6. Record the same audit actor, credential/effective subject, operation,
+   resource target, start, success, and failure outcomes as the control query.
+
+FAI-543's borrowed DuckDB batches may be observed only synchronously inside
+the sink callback. The sink must finish reading or encoding a batch before the
+callback returns, must not retain borrowed buffers, and must not populate or
+read the retained dashboard result cache.
+
+## Correctness qualification
+
+A candidate is rejected before performance comparison if it differs from the
+control in column order, aliases, physical types, values, null positions,
+metadata, sorting, offset/limit behavior, cursor behavior, cancellation,
+partial-write handling, authorization, row policies, masks, admission,
+budgets, or audit identity. The executable fixtures in
+`internal/dashboard/http/arrow_contract_test.go` lock the native value and wire
+semantics. Existing authorization, admission, budget, and audit tests lock the
+shared governed execution boundaries.
+
+Only after those gates pass may an experiment compare the candidate with the
+current `api_direct` dashboard path using the same query and physical query
+behavior. Warm-cache measurements are a guardrail, not a comparable lane.
+
+## Client compatibility and activation
+
+No first-party browser component currently decodes this API Arrow stream, but
+API and generated-client consumers may rely on the current string/null
+projection. Therefore:
+
+- native delivery requires an explicit, documented request opt-in or a new
+  versioned route; merely sending the Arrow media type is not sufficient to
+  silently reinterpret the existing stream;
+- the response must return `X-LeapView-Arrow-Contract: native-v1`, and clients
+  must reject unknown contract versions;
+- clients must support native Arrow types, validity bitmaps, dictionaries, and
+  HTTP trailers before opting in;
+- generated clients continue to prefer JSON unless native Arrow support is
+  explicitly selected.
+
+The precise opt-in mechanism is an implementation decision for the production
+migration issue. It must be added to TypeSpec/OpenAPI before activation. FAI-541
+locks response semantics; it does not add a production negotiation path.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -241,6 +241,7 @@ Focused slices are available at `/docs/agent-tools/tools/{name}.json|md`, `/docs
 - [Architecture overview](/docs/architecture): See how the monolith, contracts, storage, and browser components fit together.
 - [Runtime architecture](/docs/architecture/runtime): Follow routing, query execution, and streamed UI updates.
 - [Evidence-gated Arrow optimization](/docs/architecture/arrow-optimization-evidence): Measure dashboard Arrow boundaries before approving a production migration.
+- [Dashboard native Arrow response contract](/docs/architecture/dashboard-native-arrow-contract): Define the native-v1 schema, protocol, governance, pagination, and compatibility oracle for future dashboard Arrow experiments.
 - [Cross-role journey qualification](/docs/architecture/journey-qualification): Map FAI-492 consumer, creator, and operator states to executable assembled-app checks and evidence rules.
 - [GitHub-hosted CI](/docs/architecture/github-hosted-ci): Understand LeapView's ephemeral runners, bounded caches, and portable validation contract.
 - [Durable audit and compliance controls](/docs/architecture/durable-audit-compliance): Understand audit guarantee classes, evidence boundaries, and compliance controls.

--- a/docs/navigation.yaml
+++ b/docs/navigation.yaml
@@ -540,6 +540,11 @@ sections:
             type: explanation
             summary: Measure dashboard Arrow boundaries before approving a production migration.
             source: articles/architecture/arrow-optimization-evidence.md
+          - slug: architecture/dashboard-native-arrow-contract
+            title: Dashboard native Arrow response contract
+            type: explanation
+            summary: Define the native-v1 schema, protocol, governance, pagination, and compatibility oracle for future dashboard Arrow experiments.
+            source: articles/architecture/dashboard-native-arrow-contract.md
           - slug: architecture/journey-qualification
             title: Cross-role journey qualification
             type: reference

--- a/internal/app/workload_metrics_test.go
+++ b/internal/app/workload_metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flidai/leapview/internal/analytics/arrowquery"
 	"github.com/flidai/leapview/internal/analytics/dataquery"
 	"github.com/flidai/leapview/internal/dashboard"
 	dashboardmodule "github.com/flidai/leapview/internal/dashboard/module"
@@ -126,6 +127,36 @@ func TestWorkloadMetricsReusesInteractivePhysicalQueryAdmission(t *testing.T) {
 	}
 }
 
+func TestDashboardNativeArrowContractPreservesAdmissionBoundary(t *testing.T) {
+	controller, err := workload.New(workload.Config{MaxRunning: 1, Classes: map[workload.Class]workload.Policy{
+		workload.Interactive: {MaximumRunning: 1},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(controller.Close)
+	inner := &arrowContractAdmissionMetrics{}
+	metrics := dashboardmodule.WithAdmission(inner, controller)
+	executor, ok := metrics.(arrowquery.Executor)
+	if !ok {
+		t.Fatal("admission decorator did not preserve native Arrow execution")
+	}
+	request := workloadTestQuery()
+	request.Operation = dataquery.OperationDashboardRows
+	if _, err := executor.ExecuteDataQueryArrow(t.Context(), request, nil); err != nil {
+		t.Fatal(err)
+	}
+	if inner.calls != 1 || inner.class != workload.Interactive || inner.principalID != "system:query" {
+		t.Fatalf("admitted native execution = calls=%d class=%q principal=%q", inner.calls, inner.class, inner.principalID)
+	}
+	if inner.operation != dataquery.OperationDashboardRows {
+		t.Fatalf("admission operation = %q", inner.operation)
+	}
+	if stats := controller.Stats(); stats.Running != 0 || stats.Queued != 0 {
+		t.Fatalf("native Arrow admission permit leaked: %#v", stats)
+	}
+}
+
 func workloadTestQuery() dataquery.Query {
 	request := dataquery.SemanticRows("sales", "orders", []dataquery.Field{{Field: "orders.id"}}, nil, nil, nil, 0, 1, false)
 	request.ProjectID = "project:sales"
@@ -148,6 +179,28 @@ type nestedAdmissionMetrics struct {
 	fakeMetrics
 	controller *workload.Controller
 }
+
+type arrowContractAdmissionMetrics struct {
+	fakeMetrics
+	calls       int
+	class       workload.Class
+	principalID string
+	operation   string
+}
+
+func (m *arrowContractAdmissionMetrics) ExecuteDataQueryArrow(ctx context.Context, request dataquery.Query, _ arrowquery.Sink) (dataquery.Result, error) {
+	m.calls++
+	m.class, m.principalID, _ = workload.Current(ctx)
+	if active, ok := workload.CurrentRequest(ctx); ok {
+		m.operation = active.Operation
+	}
+	if _, ok := workload.FromContext(ctx); !ok {
+		return dataquery.Result{}, errors.New("admitter missing from native Arrow context")
+	}
+	return dataquery.Result{ExecutionState: dataquery.ExecutionSucceeded}, nil
+}
+
+var _ arrowquery.Executor = (*arrowContractAdmissionMetrics)(nil)
 
 func (m nestedAdmissionMetrics) ExecuteDataQuery(ctx context.Context, _ dataquery.Query) (dataquery.Result, error) {
 	lease, err := m.controller.Acquire(ctx, workload.Request{

--- a/internal/dashboard/http/arrow_contract_test.go
+++ b/internal/dashboard/http/arrow_contract_test.go
@@ -1,0 +1,705 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/flidai/leapview/internal/analytics/arrowquery"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	httptransport "github.com/flidai/leapview/internal/platform/http/transport"
+)
+
+const (
+	dashboardNativeArrowContract      = "native-v1"
+	dashboardNativeArrowQueryID       = "query-contract-1"
+	dashboardNativeArrowSnapshot      = "snapshot-contract-1"
+	dashboardNativeArrowSchemaVersion = "7"
+	dashboardNativeArrowSpecRevision  = "spec-revision-1"
+	dashboardNativeArrowDataRevision  = "11"
+)
+
+var dashboardNativeArrowFieldNames = []string{
+	"is_active",
+	"tiny_signed",
+	"small_signed",
+	"order_count",
+	"order_id",
+	"tiny_unsigned",
+	"small_unsigned",
+	"medium_unsigned",
+	"large_unsigned",
+	"ratio_32",
+	"ratio_64",
+	"amount",
+	"business_date",
+	"event_time_ms",
+	"occurred_at",
+	"occurred_at_local",
+	"customer_alias",
+	"payload",
+	"status",
+}
+
+var dashboardNativeArrowSchemaMetadataAllowlist = map[string]struct{}{
+	"leapview.arrow_contract":               {},
+	"leapview.query_id":                     {},
+	"leapview.serving_snapshot":             {},
+	"leapview.visualization_schema_version": {},
+	"leapview.visualization_spec_revision":  {},
+	"leapview.visualization_data_revision":  {},
+}
+
+var dashboardNativeArrowFieldMetadataAllowlist = map[string]struct{}{
+	"display.label":         {},
+	"leapview.logical_type": {},
+}
+
+var dashboardNativeArrowFieldProducerMetadataAllowlist = map[string]struct{}{
+	"display.label": {},
+}
+
+var dashboardNativeArrowLogicalTypes = map[string]string{
+	"is_active":         "boolean",
+	"order_id":          "integer",
+	"amount":            "decimal",
+	"business_date":     "date",
+	"occurred_at":       "timestamp",
+	"occurred_at_local": "timestamp",
+	"customer_alias":    "string",
+	"payload":           "binary",
+	"status":            "category",
+}
+
+// TestDashboardNativeArrowContractPreservesValues is the reusable correctness
+// oracle for a future native dashboard implementation. It intentionally uses a
+// test-only response writer; the current dashboard serving path is unchanged.
+func TestDashboardNativeArrowContractPreservesValues(t *testing.T) {
+	response := dashboardNativeArrowContractResponse(t, 3, 0, "scope-a", false)
+	defer response.Body.Close()
+	assertDashboardNativeArrowHeaders(t, response)
+
+	reader, err := ipc.NewReader(response.Body)
+	if err != nil {
+		t.Fatalf("open Arrow IPC: %v", err)
+	}
+	defer reader.Release()
+	assertDashboardNativeArrowSchema(t, reader.Schema())
+	if !reader.Next() {
+		t.Fatalf("read Arrow record: %v", reader.Err())
+	}
+	assertDashboardNativeArrowValues(t, reader.Record())
+	next := reader.Next()
+	if next || reader.Err() != nil {
+		t.Fatalf("unexpected second record or reader error: next=%v err=%v", next, reader.Err())
+	}
+	if got := response.Trailer.Get("X-Next-Cursor"); got != "" {
+		t.Fatalf("final-page cursor = %q, want empty", got)
+	}
+}
+
+func TestDashboardNativeArrowContractMetadataAllowlist(t *testing.T) {
+	allowedSchema := arrow.MetadataFrom(map[string]string{
+		"leapview.arrow_contract":               dashboardNativeArrowContract,
+		"leapview.query_id":                     dashboardNativeArrowQueryID,
+		"leapview.serving_snapshot":             dashboardNativeArrowSnapshot,
+		"leapview.visualization_schema_version": dashboardNativeArrowSchemaVersion,
+		"leapview.visualization_spec_revision":  dashboardNativeArrowSpecRevision,
+		"leapview.visualization_data_revision":  dashboardNativeArrowDataRevision,
+	})
+	if err := validateDashboardNativeArrowMetadata(allowedSchema, dashboardNativeArrowSchemaMetadataAllowlist); err != nil {
+		t.Fatalf("allowed schema metadata rejected: %v", err)
+	}
+	allowedField := arrow.MetadataFrom(map[string]string{
+		"display.label":         "Customer",
+		"leapview.logical_type": "string",
+	})
+	if err := validateDashboardNativeArrowMetadata(allowedField, dashboardNativeArrowFieldMetadataAllowlist); err != nil {
+		t.Fatalf("allowed field metadata rejected: %v", err)
+	}
+
+	for _, key := range []string{
+		"leapview.unknown",
+		"duckdb.query_sql",
+		"source.connection",
+		"producer.unapproved",
+	} {
+		t.Run("schema rejects "+key, func(t *testing.T) {
+			metadata := arrow.MetadataFrom(map[string]string{key: "secret"})
+			if err := validateDashboardNativeArrowMetadata(metadata, dashboardNativeArrowSchemaMetadataAllowlist); err == nil {
+				t.Fatalf("unsafe schema metadata %q was accepted", key)
+			}
+		})
+		t.Run("field rejects "+key, func(t *testing.T) {
+			metadata := arrow.MetadataFrom(map[string]string{key: "secret"})
+			if err := validateDashboardNativeArrowMetadata(metadata, dashboardNativeArrowFieldMetadataAllowlist); err == nil {
+				t.Fatalf("unsafe field metadata %q was accepted", key)
+			}
+		})
+	}
+}
+
+func TestDashboardNativeArrowContractEmptyResultKeepsSchema(t *testing.T) {
+	response := dashboardNativeArrowContractResponse(t, 3, 0, "scope-a", true)
+	defer response.Body.Close()
+	assertDashboardNativeArrowHeaders(t, response)
+	reader, err := ipc.NewReader(response.Body)
+	if err != nil {
+		t.Fatalf("open empty Arrow IPC: %v", err)
+	}
+	defer reader.Release()
+	assertDashboardNativeArrowSchema(t, reader.Schema())
+	next := reader.Next()
+	if next || reader.Err() != nil {
+		t.Fatalf("empty result contained a record or failed: next=%v err=%v", next, reader.Err())
+	}
+	if got := response.Trailer.Get("X-Next-Cursor"); got != "" {
+		t.Fatalf("empty-result cursor = %q, want empty", got)
+	}
+}
+
+func TestDashboardNativeArrowContractPaginationUsesCompletionTrailer(t *testing.T) {
+	response := dashboardNativeArrowContractResponse(t, 2, 20, "scope-a", false)
+	defer response.Body.Close()
+	assertDashboardNativeArrowHeaders(t, response)
+	if got := response.Header.Get("X-Next-Cursor"); got != "" {
+		t.Fatalf("next cursor was exposed as an initial header: %q", got)
+	}
+	reader, err := ipc.NewReader(response.Body)
+	if err != nil {
+		t.Fatalf("open paged Arrow IPC: %v", err)
+	}
+	defer reader.Release()
+	var rows int64
+	for reader.Next() {
+		rows += reader.Record().NumRows()
+	}
+	if err := reader.Err(); err != nil {
+		t.Fatalf("read paged Arrow IPC: %v", err)
+	}
+	if rows != 2 {
+		t.Fatalf("emitted rows = %d, want two rows from a limit+1 fixture", rows)
+	}
+	cursor := response.Trailer.Get("X-Next-Cursor")
+	if cursor == "" {
+		t.Fatal("limit+1 probe did not produce X-Next-Cursor trailer")
+	}
+	if _, err := strconv.Atoi(cursor); err == nil {
+		t.Fatalf("cursor %q is a client-visible numeric offset", cursor)
+	}
+	if offset, err := decodeIndexCursor(cursor, "scope-a", dashboardNativeArrowSnapshot); err != nil || offset != 22 {
+		t.Fatalf("decode next cursor = (%d, %v), want offset 22", offset, err)
+	}
+	if _, err := decodeIndexCursor(cursor, "scope-b", dashboardNativeArrowSnapshot); err == nil {
+		t.Fatal("cursor was accepted for a different normalized query scope")
+	}
+	if _, err := decodeIndexCursor(cursor, "scope-a", "snapshot-other"); !errors.Is(err, errDashboardCursorSnapshot) {
+		t.Fatalf("snapshot-mismatched cursor error = %v", err)
+	}
+}
+
+func TestDashboardNativeArrowContractErrorsRespectCommitBoundary(t *testing.T) {
+	beforeCommit := []struct {
+		name   string
+		status int
+		code   string
+	}{
+		{name: "authentication", status: stdhttp.StatusUnauthorized, code: "AUTHENTICATION_REQUIRED"},
+		{name: "authorization", status: stdhttp.StatusForbidden, code: "FORBIDDEN"},
+		{name: "authorization concealed", status: stdhttp.StatusNotFound, code: "RESOURCE_NOT_FOUND"},
+		{name: "invalid cursor", status: stdhttp.StatusBadRequest, code: "INVALID_CURSOR"},
+		{name: "snapshot mismatch", status: stdhttp.StatusConflict, code: "CURSOR_SNAPSHOT_MISMATCH"},
+		{name: "result budget", status: stdhttp.StatusUnprocessableEntity, code: "QUERY_RESULT_LIMIT"},
+		{name: "admission", status: stdhttp.StatusServiceUnavailable, code: "WORKLOAD_OVERLOADED"},
+		{name: "timeout", status: stdhttp.StatusGatewayTimeout, code: "WORKLOAD_EXECUTION_TIMEOUT"},
+		{name: "internal", status: stdhttp.StatusInternalServerError, code: "INTERNAL"},
+	}
+	for _, test := range beforeCommit {
+		t.Run("before commit/"+test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/dashboards/sales/pages/main/visuals/orders/query", nil)
+			httptransport.WriteProblem(recorder, request, test.status, test.code, test.name, nil)
+			response := recorder.Result()
+			defer response.Body.Close()
+			if response.StatusCode != test.status {
+				t.Fatalf("status = %d, want %d", response.StatusCode, test.status)
+			}
+			if got := response.Header.Get("Content-Type"); got != "application/problem+json" {
+				t.Fatalf("content type = %q", got)
+			}
+			if got := response.Header.Get("X-LeapView-Arrow-Contract"); got != "" {
+				t.Fatalf("problem response claimed Arrow contract %q", got)
+			}
+			var problem httptransport.ProblemDetails
+			if err := json.NewDecoder(response.Body).Decode(&problem); err != nil {
+				t.Fatalf("decode problem response: %v", err)
+			}
+			if problem.Status != int32(test.status) || problem.Code != test.code {
+				t.Fatalf("problem = %#v", problem)
+			}
+		})
+	}
+
+	t.Run("after commit", func(t *testing.T) {
+		complete := dashboardNativeArrowContractBody(t, false, 3)
+		recorder := httptest.NewRecorder()
+		recorder.Header().Set("Content-Type", "application/vnd.apache.arrow.stream")
+		recorder.Header().Set("X-LeapView-Arrow-Contract", dashboardNativeArrowContract)
+		recorder.Header().Set("Trailer", "X-Next-Cursor")
+		recorder.WriteHeader(stdhttp.StatusOK)
+		_, _ = recorder.Write(complete[:len(complete)/2])
+		response := recorder.Result()
+		defer response.Body.Close()
+		if err := consumeDashboardNativeArrow(response.Body); err == nil {
+			t.Fatal("truncated committed Arrow stream was accepted")
+		}
+		if got := response.Trailer.Get("X-Next-Cursor"); got != "" {
+			t.Fatalf("failed stream exposed success cursor %q", got)
+		}
+	})
+}
+
+func TestDashboardNativeArrowContractChargesSchemaAndPaginationProbeToBudgets(t *testing.T) {
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	schema, record := newDashboardNativeArrowContractFixture(t, allocator)
+	defer allocator.AssertSize(t, 0)
+	defer record.Release()
+
+	rowContext := dataquery.WithResultBudget(context.Background(), dataquery.ResultLimits{MaxRows: 2, MaxBytes: 1 << 20})
+	if err := arrowquery.ConsumeSchemaBudget(rowContext, schema); err != nil {
+		t.Fatalf("consume schema budget: %v", err)
+	}
+	err := arrowquery.ConsumeResultBudget(rowContext, record)
+	var limit *dataquery.ResultLimitError
+	if !errors.As(err, &limit) || limit.Reason != dataquery.ResultRows || limit.Observed != 3 {
+		t.Fatalf("limit+1 probe budget error = %v, want observed row count 3", err)
+	}
+
+	byteContext := dataquery.WithResultBudget(context.Background(), dataquery.ResultLimits{MaxRows: 3, MaxBytes: 1})
+	err = arrowquery.ConsumeSchemaBudget(byteContext, schema)
+	if !errors.As(err, &limit) || limit.Reason != dataquery.ResultBytes || limit.Observed <= 1 {
+		t.Fatalf("schema byte budget error = %v", err)
+	}
+}
+
+func dashboardNativeArrowContractResponse(t testing.TB, limit, offset int, scope string, empty bool) *stdhttp.Response {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Content-Type", "application/vnd.apache.arrow.stream")
+	recorder.Header().Set("Cache-Control", "no-store")
+	recorder.Header().Set("X-Query-ID", dashboardNativeArrowQueryID)
+	recorder.Header().Set("X-Serving-Snapshot", dashboardNativeArrowSnapshot)
+	recorder.Header().Set("X-LeapView-Arrow-Contract", dashboardNativeArrowContract)
+	recorder.Header().Set("Trailer", "X-Next-Cursor")
+	recorder.WriteHeader(stdhttp.StatusOK)
+	body := dashboardNativeArrowContractBody(t, empty, limit)
+	_, _ = recorder.Write(body)
+	if !empty && limit < 3 {
+		recorder.Header().Set("X-Next-Cursor", encodeIndexCursor(offset+limit, scope, dashboardNativeArrowSnapshot))
+	}
+	return recorder.Result()
+}
+
+func dashboardNativeArrowContractBody(t testing.TB, empty bool, limit int) []byte {
+	t.Helper()
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	schema, record := newDashboardNativeArrowContractFixture(t, allocator)
+	var output bytes.Buffer
+	writer := ipc.NewWriter(&output, ipc.WithSchema(schema), ipc.WithAllocator(allocator))
+	if !empty {
+		emitted := record
+		sliced := false
+		if int64(limit) < record.NumRows() {
+			emitted = record.NewSlice(0, int64(limit))
+			sliced = true
+		}
+		err := writer.Write(emitted)
+		if sliced {
+			emitted.Release()
+		}
+		if err != nil {
+			record.Release()
+			_ = writer.Close()
+			allocator.AssertSize(t, 0)
+			t.Fatalf("write Arrow fixture: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		record.Release()
+		allocator.AssertSize(t, 0)
+		t.Fatalf("close Arrow fixture: %v", err)
+	}
+	record.Release()
+	allocator.AssertSize(t, 0)
+	return output.Bytes()
+}
+
+func newDashboardNativeArrowContractFixture(t testing.TB, allocator memory.Allocator) (*arrow.Schema, arrow.RecordBatch) {
+	t.Helper()
+	decimalType := &arrow.Decimal128Type{Precision: 20, Scale: 4}
+	timestampUTCType := &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "UTC"}
+	timestampLocalType := &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: ""}
+	dictionaryType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.BinaryTypes.String}
+	fields := []arrow.Field{
+		{Name: "is_active", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		{Name: "tiny_signed", Type: arrow.PrimitiveTypes.Int8, Nullable: true},
+		{Name: "small_signed", Type: arrow.PrimitiveTypes.Int16, Nullable: true},
+		{Name: "order_count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "order_id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "tiny_unsigned", Type: arrow.PrimitiveTypes.Uint8, Nullable: true},
+		{Name: "small_unsigned", Type: arrow.PrimitiveTypes.Uint16, Nullable: true},
+		{Name: "medium_unsigned", Type: arrow.PrimitiveTypes.Uint32, Nullable: true},
+		{Name: "large_unsigned", Type: arrow.PrimitiveTypes.Uint64, Nullable: true},
+		{Name: "ratio_32", Type: arrow.PrimitiveTypes.Float32, Nullable: true},
+		{Name: "ratio_64", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+		{Name: "amount", Type: decimalType, Nullable: true},
+		{Name: "business_date", Type: arrow.FixedWidthTypes.Date32, Nullable: true},
+		{Name: "event_time_ms", Type: arrow.FixedWidthTypes.Date64, Nullable: true},
+		{Name: "occurred_at", Type: timestampUTCType, Nullable: true},
+		{Name: "occurred_at_local", Type: timestampLocalType, Nullable: true},
+		{Name: "customer_alias", Type: arrow.BinaryTypes.String, Nullable: true, Metadata: arrow.MetadataFrom(map[string]string{
+			"display.label":         "Customer",
+			"duckdb.query_sql":      "select customer_name from orders",
+			"leapview.logical_type": "spoofed",
+			"leapview.source_field": "orders.customer_name",
+			"source.connection":     "warehouse-primary",
+		})},
+		{Name: "payload", Type: arrow.BinaryTypes.Binary, Nullable: true},
+		{Name: "status", Type: dictionaryType, Nullable: true},
+	}
+	upstream := arrow.NewSchema(fields, &arrow.Metadata{})
+	upstreamMetadata := arrow.MetadataFrom(map[string]string{
+		"duckdb.query_sql":        "select secret",
+		"leapview.arrow_contract": "spoofed",
+		"leapview.query_id":       "spoofed",
+		"producer.unapproved":     "must not survive",
+		"source.connection":       "warehouse-primary",
+	})
+	upstream = arrow.NewSchema(fields, &upstreamMetadata)
+	schema := dashboardNativeArrowContractSchema(upstream, dashboardNativeArrowLogicalTypes, dashboardNativeArrowQueryID, dashboardNativeArrowSnapshot)
+
+	validity := []bool{true, false, true}
+	builders := []array.Builder{
+		array.NewBooleanBuilder(allocator),
+		array.NewInt8Builder(allocator),
+		array.NewInt16Builder(allocator),
+		array.NewInt32Builder(allocator),
+		array.NewInt64Builder(allocator),
+		array.NewUint8Builder(allocator),
+		array.NewUint16Builder(allocator),
+		array.NewUint32Builder(allocator),
+		array.NewUint64Builder(allocator),
+		array.NewFloat32Builder(allocator),
+		array.NewFloat64Builder(allocator),
+		array.NewDecimal128Builder(allocator, decimalType),
+		array.NewDate32Builder(allocator),
+		array.NewDate64Builder(allocator),
+		array.NewTimestampBuilder(allocator, timestampUTCType),
+		array.NewTimestampBuilder(allocator, timestampLocalType),
+		array.NewStringBuilder(allocator),
+		array.NewBinaryBuilder(allocator, arrow.BinaryTypes.Binary),
+		array.NewDictionaryBuilder(allocator, dictionaryType),
+	}
+	builders[0].(*array.BooleanBuilder).AppendValues([]bool{true, false, false}, validity)
+	builders[1].(*array.Int8Builder).AppendValues([]int8{-8, 0, 7}, validity)
+	builders[2].(*array.Int16Builder).AppendValues([]int16{-32000, 0, 32000}, validity)
+	builders[3].(*array.Int32Builder).AppendValues([]int32{-2_000_000_000, 0, 2_000_000_000}, validity)
+	builders[4].(*array.Int64Builder).AppendValues([]int64{-9_007_199_254_740_993, 0, 9_007_199_254_740_993}, nil)
+	builders[5].(*array.Uint8Builder).AppendValues([]uint8{1, 0, 255}, validity)
+	builders[6].(*array.Uint16Builder).AppendValues([]uint16{1, 0, 65_535}, validity)
+	builders[7].(*array.Uint32Builder).AppendValues([]uint32{1, 0, 4_000_000_000}, validity)
+	builders[8].(*array.Uint64Builder).AppendValues([]uint64{1, 0, 18_000_000_000_000_000_000}, validity)
+	builders[9].(*array.Float32Builder).AppendValues([]float32{1.25, 0, -2.5}, validity)
+	builders[10].(*array.Float64Builder).AppendValues([]float64{1.0 / 3.0, 0, -9.5}, validity)
+	firstDecimal, err := decimal128.FromString("123456789012.3456", decimalType.Precision, decimalType.Scale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondDecimal, err := decimal128.FromString("-42.5000", decimalType.Precision, decimalType.Scale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	builders[11].(*array.Decimal128Builder).AppendValues([]decimal128.Num{firstDecimal, {}, secondDecimal}, validity)
+	builders[12].(*array.Date32Builder).AppendValues([]arrow.Date32{19_723, 0, 19_724}, validity)
+	builders[13].(*array.Date64Builder).AppendValues([]arrow.Date64{1_704_067_200_000, 0, 1_704_153_600_000}, validity)
+	builders[14].(*array.TimestampBuilder).AppendValues([]arrow.Timestamp{1_704_067_200_123_456, 0, 1_704_153_600_654_321}, validity)
+	builders[15].(*array.TimestampBuilder).AppendValues([]arrow.Timestamp{1_704_067_200_123_456_789, 0, 1_704_153_600_987_654_321}, validity)
+	builders[16].(*array.StringBuilder).AppendValues([]string{"alpha", "must-not-survive", ""}, validity)
+	builders[17].(*array.BinaryBuilder).AppendValues([][]byte{{0x00, 0xff, 0x7f}, {0x99}, {}}, validity)
+	dictionary := builders[18].(*array.BinaryDictionaryBuilder)
+	if err := dictionary.AppendString("new"); err != nil {
+		t.Fatal(err)
+	}
+	dictionary.AppendNull()
+	if err := dictionary.AppendString("complete"); err != nil {
+		t.Fatal(err)
+	}
+
+	columns := make([]arrow.Array, len(builders))
+	for index, builder := range builders {
+		columns[index] = builder.NewArray()
+		builder.Release()
+	}
+	record := array.NewRecordBatch(schema, columns, 3)
+	for _, column := range columns {
+		column.Release()
+	}
+	return schema, record
+}
+
+func dashboardNativeArrowContractSchema(schema *arrow.Schema, logicalTypes map[string]string, queryID, snapshot string) *arrow.Schema {
+	metadata := publicDashboardNativeArrowMetadata(schema.Metadata(), nil, map[string]string{
+		"leapview.arrow_contract":               dashboardNativeArrowContract,
+		"leapview.query_id":                     queryID,
+		"leapview.serving_snapshot":             snapshot,
+		"leapview.visualization_schema_version": dashboardNativeArrowSchemaVersion,
+		"leapview.visualization_spec_revision":  dashboardNativeArrowSpecRevision,
+		"leapview.visualization_data_revision":  dashboardNativeArrowDataRevision,
+	})
+	fields := schema.Fields()
+	for index := range fields {
+		authoritative := map[string]string{}
+		if logicalType := logicalTypes[fields[index].Name]; logicalType != "" {
+			authoritative["leapview.logical_type"] = logicalType
+		}
+		fields[index].Metadata = publicDashboardNativeArrowMetadata(fields[index].Metadata, dashboardNativeArrowFieldProducerMetadataAllowlist, authoritative)
+	}
+	return arrow.NewSchema(fields, &metadata)
+}
+
+func publicDashboardNativeArrowMetadata(upstream arrow.Metadata, producerAllowlist map[string]struct{}, authoritative map[string]string) arrow.Metadata {
+	values := make(map[string]string, upstream.Len()+len(authoritative))
+	for key, value := range upstream.ToMap() {
+		if _, allowed := producerAllowlist[key]; allowed {
+			values[key] = value
+		}
+	}
+	for key, value := range authoritative {
+		values[key] = value
+	}
+	return arrow.MetadataFrom(values)
+}
+
+func validateDashboardNativeArrowMetadata(metadata arrow.Metadata, allowlist map[string]struct{}) error {
+	for _, key := range metadata.Keys() {
+		if _, allowed := allowlist[key]; !allowed {
+			return fmt.Errorf("metadata key %q is not response-safe", key)
+		}
+	}
+	return nil
+}
+
+func assertDashboardNativeArrowHeaders(t testing.TB, response *stdhttp.Response) {
+	t.Helper()
+	want := map[string]string{
+		"Content-Type":              "application/vnd.apache.arrow.stream",
+		"Cache-Control":             "no-store",
+		"X-Query-ID":                dashboardNativeArrowQueryID,
+		"X-Serving-Snapshot":        dashboardNativeArrowSnapshot,
+		"X-LeapView-Arrow-Contract": dashboardNativeArrowContract,
+		"Trailer":                   "X-Next-Cursor",
+	}
+	for header, expected := range want {
+		if got := response.Header.Get(header); got != expected {
+			t.Fatalf("%s = %q, want %q", header, got, expected)
+		}
+	}
+}
+
+func assertDashboardNativeArrowSchema(t testing.TB, schema *arrow.Schema) {
+	t.Helper()
+	if schema == nil {
+		t.Fatal("native Arrow schema is nil")
+	}
+	gotNames := make([]string, schema.NumFields())
+	for index, field := range schema.Fields() {
+		gotNames[index] = field.Name
+	}
+	if got := gotNames; !equalStrings(got, dashboardNativeArrowFieldNames) {
+		t.Fatalf("field order/names = %#v, want %#v", got, dashboardNativeArrowFieldNames)
+	}
+	wantTypes := []arrow.Type{
+		arrow.BOOL, arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64,
+		arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64,
+		arrow.FLOAT32, arrow.FLOAT64, arrow.DECIMAL128, arrow.DATE32,
+		arrow.DATE64, arrow.TIMESTAMP, arrow.TIMESTAMP, arrow.STRING, arrow.BINARY, arrow.DICTIONARY,
+	}
+	for index, want := range wantTypes {
+		field := schema.Field(index)
+		wantNullable := index != 4
+		if field.Type.ID() != want || field.Nullable != wantNullable {
+			t.Fatalf("field %q = (%s, nullable=%v), want type %s and nullable=%v", field.Name, field.Type, field.Nullable, want, wantNullable)
+		}
+		if err := validateDashboardNativeArrowMetadata(field.Metadata, dashboardNativeArrowFieldMetadataAllowlist); err != nil {
+			t.Fatalf("field %q metadata: %v", field.Name, err)
+		}
+		wantMetadataCount := 0
+		if wantLogicalType := dashboardNativeArrowLogicalTypes[field.Name]; wantLogicalType != "" {
+			wantMetadataCount++
+			if got, ok := field.Metadata.GetValue("leapview.logical_type"); !ok || got != wantLogicalType {
+				t.Fatalf("field %q logical metadata = (%q, %v), want %q", field.Name, got, ok, wantLogicalType)
+			}
+		}
+		if field.Name == "customer_alias" {
+			wantMetadataCount++
+			if got, ok := field.Metadata.GetValue("display.label"); !ok || got != "Customer" {
+				t.Fatalf("alias field public metadata = (%q, %v)", got, ok)
+			}
+		}
+		if field.Metadata.Len() != wantMetadataCount {
+			t.Fatalf("field %q metadata count = %d, want %d", field.Name, field.Metadata.Len(), wantMetadataCount)
+		}
+	}
+	decimalType, ok := schema.Field(11).Type.(*arrow.Decimal128Type)
+	if !ok || decimalType.Precision != 20 || decimalType.Scale != 4 {
+		t.Fatalf("decimal type = %#v", schema.Field(11).Type)
+	}
+	timestampType, ok := schema.Field(14).Type.(*arrow.TimestampType)
+	if !ok || timestampType.Unit != arrow.Microsecond || timestampType.TimeZone != "UTC" {
+		t.Fatalf("timezone-aware timestamp type = %#v", schema.Field(14).Type)
+	}
+	timestampLocalType, ok := schema.Field(15).Type.(*arrow.TimestampType)
+	if !ok || timestampLocalType.Unit != arrow.Nanosecond || timestampLocalType.TimeZone != "" {
+		t.Fatalf("timezone-neutral timestamp type = %#v", schema.Field(15).Type)
+	}
+	dictionaryType, ok := schema.Field(18).Type.(*arrow.DictionaryType)
+	if !ok || dictionaryType.IndexType.ID() != arrow.INT8 || dictionaryType.ValueType.ID() != arrow.STRING || dictionaryType.Ordered {
+		t.Fatalf("dictionary type = %#v", schema.Field(18).Type)
+	}
+	metadata := schema.Metadata()
+	if err := validateDashboardNativeArrowMetadata(metadata, dashboardNativeArrowSchemaMetadataAllowlist); err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]string{
+		"leapview.arrow_contract":               dashboardNativeArrowContract,
+		"leapview.query_id":                     dashboardNativeArrowQueryID,
+		"leapview.serving_snapshot":             dashboardNativeArrowSnapshot,
+		"leapview.visualization_schema_version": dashboardNativeArrowSchemaVersion,
+		"leapview.visualization_spec_revision":  dashboardNativeArrowSpecRevision,
+		"leapview.visualization_data_revision":  dashboardNativeArrowDataRevision,
+	} {
+		if got, ok := metadata.GetValue(key); !ok || got != want {
+			t.Fatalf("schema metadata %q = (%q, %v), want %q", key, got, ok, want)
+		}
+	}
+	if metadata.Len() != len(dashboardNativeArrowSchemaMetadataAllowlist) {
+		t.Fatalf("schema metadata count = %d, want %d", metadata.Len(), len(dashboardNativeArrowSchemaMetadataAllowlist))
+	}
+}
+
+func assertDashboardNativeArrowValues(t testing.TB, record arrow.RecordBatch) {
+	t.Helper()
+	if record.NumRows() != 3 || record.NumCols() != int64(len(dashboardNativeArrowFieldNames)) {
+		t.Fatalf("record shape = %dx%d", record.NumRows(), record.NumCols())
+	}
+	for index := 0; index < int(record.NumCols()); index++ {
+		column := record.Column(index)
+		if index == 4 {
+			if column.IsNull(0) || column.IsNull(1) || column.IsNull(2) || column.NullN() != 0 {
+				t.Fatalf("non-nullable field %q null positions = [%v %v %v] count=%d", record.ColumnName(index), column.IsNull(0), column.IsNull(1), column.IsNull(2), column.NullN())
+			}
+			continue
+		}
+		if column.IsNull(0) || !column.IsNull(1) || column.IsNull(2) || column.NullN() != 1 {
+			t.Fatalf("field %q null positions = [%v %v %v] count=%d", record.ColumnName(index), column.IsNull(0), column.IsNull(1), column.IsNull(2), column.NullN())
+		}
+	}
+	if values := record.Column(0).(*array.Boolean); !values.Value(0) || values.Value(2) {
+		t.Fatalf("boolean values = %v, %v", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(1).(*array.Int8); values.Value(0) != -8 || values.Value(2) != 7 {
+		t.Fatalf("int8 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(2).(*array.Int16); values.Value(0) != -32000 || values.Value(2) != 32000 {
+		t.Fatalf("int16 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(3).(*array.Int32); values.Value(0) != -2_000_000_000 || values.Value(2) != 2_000_000_000 {
+		t.Fatalf("int32 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(4).(*array.Int64); values.Value(0) != -9_007_199_254_740_993 || values.Value(1) != 0 || values.Value(2) != 9_007_199_254_740_993 {
+		t.Fatalf("int64 values = %d, %d, %d", values.Value(0), values.Value(1), values.Value(2))
+	}
+	if values := record.Column(5).(*array.Uint8); values.Value(0) != 1 || values.Value(2) != 255 {
+		t.Fatalf("uint8 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(6).(*array.Uint16); values.Value(0) != 1 || values.Value(2) != 65_535 {
+		t.Fatalf("uint16 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(7).(*array.Uint32); values.Value(0) != 1 || values.Value(2) != 4_000_000_000 {
+		t.Fatalf("uint32 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(8).(*array.Uint64); values.Value(0) != 1 || values.Value(2) != 18_000_000_000_000_000_000 {
+		t.Fatalf("uint64 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(9).(*array.Float32); values.Value(0) != 1.25 || values.Value(2) != -2.5 {
+		t.Fatalf("float32 values = %g, %g", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(10).(*array.Float64); values.Value(0) != 1.0/3.0 || values.Value(2) != -9.5 {
+		t.Fatalf("float64 values = %g, %g", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(11).(*array.Decimal128); values.Value(0).ToString(4) != "123456789012.3456" || values.Value(2).ToString(4) != "-42.5000" {
+		t.Fatalf("decimal values = %s, %s", values.Value(0).ToString(4), values.Value(2).ToString(4))
+	}
+	if values := record.Column(12).(*array.Date32); values.Value(0) != 19_723 || values.Value(2) != 19_724 {
+		t.Fatalf("date32 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(13).(*array.Date64); values.Value(0) != 1_704_067_200_000 || values.Value(2) != 1_704_153_600_000 {
+		t.Fatalf("date64 values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(14).(*array.Timestamp); values.Value(0) != 1_704_067_200_123_456 || values.Value(2) != 1_704_153_600_654_321 || !values.Value(0).ToTime(arrow.Microsecond).Equal(time.Unix(1_704_067_200, 123_456_000).UTC()) {
+		t.Fatalf("timezone-aware timestamp values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(15).(*array.Timestamp); values.Value(0) != 1_704_067_200_123_456_789 || values.Value(2) != 1_704_153_600_987_654_321 || !values.Value(0).ToTime(arrow.Nanosecond).Equal(time.Unix(1_704_067_200, 123_456_789).UTC()) {
+		t.Fatalf("timezone-neutral timestamp values = %d, %d", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(16).(*array.String); values.Value(0) != "alpha" || values.Value(2) != "" {
+		t.Fatalf("string values = %q, %q", values.Value(0), values.Value(2))
+	}
+	if values := record.Column(17).(*array.Binary); !bytes.Equal(values.Value(0), []byte{0x00, 0xff, 0x7f}) || !bytes.Equal(values.Value(2), []byte{}) {
+		t.Fatalf("binary values = %x, %x", values.Value(0), values.Value(2))
+	}
+	dictionary := record.Column(18).(*array.Dictionary)
+	if dictionary.GetValueIndex(0) != 0 || dictionary.GetValueIndex(2) != 1 || dictionary.ValueStr(0) != "new" || dictionary.ValueStr(2) != "complete" {
+		t.Fatalf("dictionary mapping = indices [%d %d], values [%q %q]", dictionary.GetValueIndex(0), dictionary.GetValueIndex(2), dictionary.ValueStr(0), dictionary.ValueStr(2))
+	}
+	dictionaryValues, ok := dictionary.Dictionary().(*array.String)
+	if !ok || dictionaryValues.Len() != 2 || dictionaryValues.Value(0) != "new" || dictionaryValues.Value(1) != "complete" {
+		t.Fatalf("dictionary values = %v", dictionary.Dictionary())
+	}
+}
+
+func consumeDashboardNativeArrow(body io.Reader) error {
+	reader, err := ipc.NewReader(body)
+	if err != nil {
+		return err
+	}
+	defer reader.Release()
+	for reader.Next() {
+	}
+	return reader.Err()
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/dashboard/queryauthz/arrow_contract_test.go
+++ b/internal/dashboard/queryauthz/arrow_contract_test.go
@@ -1,0 +1,129 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/flidai/leapview/internal/access"
+	accesspolicy "github.com/flidai/leapview/internal/access/policy"
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	"github.com/flidai/leapview/internal/analytics/arrowquery"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+)
+
+func TestDashboardNativeArrowContractUsesGovernedMaskedProjection(t *testing.T) {
+	_, identity, _, physical, _ := canonicalGraph(t)
+	row, err := accesspolicy.Compile("rls", "row_filter", `{"field":"orders.region","operator":"equals","values":["EU"]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mask, err := accesspolicy.Compile("mask", "column_mask", `{"field":"orders.email","mask":"null"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policies := []accesssnapshot.DataPolicy{
+		{ID: "rls", Resource: physical, PolicyType: "row_filter", ExpressionJSON: `{"field":"orders.region","operator":"equals","values":["EU"]}`, Compiled: row},
+		{ID: "mask", Resource: physical, PolicyType: "column_mask", ExpressionJSON: `{"field":"orders.email","mask":"null"}`, Compiled: mask},
+	}
+	snapshot := canonicalSnapshot(t, []struct {
+		id         string
+		resource   access.ResourceRef
+		capability access.Capability
+	}{{"physical", physical, access.CapabilityResourceUse}}, policies)
+	capture := &canonicalArrowCapture{schema: func(request dataquery.Query) *arrow.Schema {
+		if len(request.Filters) != 1 || len(request.ColumnMasks) != 1 || request.EffectivePolicyFingerprint == "" {
+			t.Fatalf("executor received ungoverned request: %#v", request)
+		}
+		filter := request.Filters[0]
+		if filter.Field != "orders.region" || filter.Operator != "equals" || len(filter.Values) != 1 || filter.Values[0] != "EU" {
+			t.Fatalf("executor row policy = %#v", filter)
+		}
+		if request.ColumnMasks[0].Field != "orders.email" || request.ColumnMasks[0].Mask != "null" {
+			t.Fatalf("executor masks = %#v", request.ColumnMasks)
+		}
+		metadata := arrow.MetadataFrom(map[string]string{"leapview.logical_type": "string"})
+		return arrow.NewSchema([]arrow.Field{{Name: request.Fields[0].Alias, Type: arrow.BinaryTypes.String, Nullable: true, Metadata: metadata}}, nil)
+	}}
+	recorder := &canonicalAuditRecorder{}
+	metrics := canonicalMetricsWithSnapshot(t, snapshot, recorder, capture, "alice", "credential-a")
+	sink := &canonicalSchemaCaptureSink{}
+	request := dataquery.Query{
+		ProjectID: canonicalProject,
+		ModelID:   "semantic_sales",
+		Target:    "orders",
+		Kind:      dataquery.KindSemanticRows,
+		Fields:    []dataquery.Field{{Field: "orders.email", Alias: "customer_email"}},
+	}
+	if _, err := metrics.ExecuteDataQueryArrow(context.Background(), request, sink); err != nil {
+		t.Fatal(err)
+	}
+	if capture.calls != 1 {
+		t.Fatalf("governed Arrow executor calls = %d, want 1", capture.calls)
+	}
+	if !sink.schema.observed || sink.schema.fieldCount != 1 {
+		t.Fatalf("masked response schema = %#v", sink.schema)
+	}
+	if sink.schema.fieldName != "customer_email" || sink.schema.fieldType != arrow.STRING || !sink.schema.nullable {
+		t.Fatalf("masked response field = %#v", sink.schema)
+	}
+	if sink.schema.fieldMetadata["leapview.logical_type"] != "string" {
+		t.Fatalf("masked response field metadata = %#v", sink.schema.fieldMetadata)
+	}
+	if sink.schema.fieldName == "orders.email" {
+		t.Fatal("response schema exposed the source field instead of the governed alias")
+	}
+	if len(recorder.events) != 1 || recorder.events[0].Status != "success" || recorder.events[0].PrincipalID != "alice" || recorder.events[0].Identity != identity {
+		t.Fatalf("governed Arrow audit events = %#v", recorder.events)
+	}
+
+	deniedCapture := &canonicalArrowCapture{}
+	deniedSink := &canonicalSchemaCaptureSink{}
+	denied := canonicalMetricsWithSnapshot(t, canonicalSnapshot(t, nil, nil), nil, deniedCapture)
+	if _, err := denied.ExecuteDataQueryArrow(context.Background(), request, deniedSink); err == nil {
+		t.Fatal("unauthorized native Arrow request was accepted")
+	}
+	if deniedCapture.calls != 0 || deniedSink.schema.observed {
+		t.Fatalf("unauthorized request reached executor/schema: calls=%d schema=%v", deniedCapture.calls, deniedSink.schema)
+	}
+}
+
+type canonicalSchemaCaptureSink struct {
+	schema canonicalSchemaSnapshot
+}
+
+type canonicalSchemaSnapshot struct {
+	observed      bool
+	fieldCount    int
+	fieldName     string
+	fieldType     arrow.Type
+	nullable      bool
+	fieldMetadata map[string]string
+}
+
+func (s *canonicalSchemaCaptureSink) WriteSchema(schema *arrow.Schema) error {
+	if schema == nil {
+		return errors.New("canonical Arrow schema is nil")
+	}
+	snapshot := canonicalSchemaSnapshot{
+		observed:   true,
+		fieldCount: schema.NumFields(),
+	}
+	if schema.NumFields() > 0 {
+		field := schema.Field(0)
+		snapshot.fieldName = field.Name
+		snapshot.fieldType = field.Type.ID()
+		snapshot.nullable = field.Nullable
+		snapshot.fieldMetadata = make(map[string]string, field.Metadata.Len())
+		for key, value := range field.Metadata.ToMap() {
+			snapshot.fieldMetadata[key] = value
+		}
+	}
+	s.schema = snapshot
+	return nil
+}
+
+func (*canonicalSchemaCaptureSink) WriteRecord(arrow.RecordBatch) error { return nil }
+
+var _ arrowquery.Sink = (*canonicalSchemaCaptureSink)(nil)

--- a/internal/dashboard/queryauthz/canonical_test.go
+++ b/internal/dashboard/queryauthz/canonical_test.go
@@ -23,9 +23,16 @@ const canonicalProject = projectgraph.ResourceID("project:sales")
 
 type canonicalMetrics struct {
 	queryruntime.Metrics
-	model      *semanticmodel.Model
-	result     dataquery.Result
-	arrowError error
+	model        *semanticmodel.Model
+	result       dataquery.Result
+	arrowError   error
+	arrowCapture *canonicalArrowCapture
+}
+
+type canonicalArrowCapture struct {
+	calls   int
+	request dataquery.Query
+	schema  func(dataquery.Query) *arrow.Schema
 }
 
 func (m canonicalMetrics) Catalog() catalog.Catalog {
@@ -47,9 +54,17 @@ func (m canonicalMetrics) Planner(id string) (consumer.Planner, bool) {
 func (m canonicalMetrics) ExecuteDataQuery(context.Context, dataquery.Query) (dataquery.Result, error) {
 	return m.result, nil
 }
-func (m canonicalMetrics) ExecuteDataQueryArrow(_ context.Context, _ dataquery.Query, sink arrowquery.Sink) (dataquery.Result, error) {
+func (m canonicalMetrics) ExecuteDataQueryArrow(_ context.Context, request dataquery.Query, sink arrowquery.Sink) (dataquery.Result, error) {
+	var schema *arrow.Schema
+	if m.arrowCapture != nil {
+		m.arrowCapture.calls++
+		m.arrowCapture.request = request
+		if m.arrowCapture.schema != nil {
+			schema = m.arrowCapture.schema(request)
+		}
+	}
 	if sink != nil {
-		if err := sink.WriteSchema((*arrow.Schema)(nil)); err != nil {
+		if err := sink.WriteSchema(schema); err != nil {
 			return dataquery.Result{}, err
 		}
 	}
@@ -149,6 +164,8 @@ func canonicalMetricsWithSnapshot(t testing.TB, snapshot accesssnapshot.Authoriz
 		switch value := option.(type) {
 		case error:
 			underlying.arrowError = value
+		case *canonicalArrowCapture:
+			underlying.arrowCapture = value
 		case string:
 			if stringIndex == 0 {
 				principalID = value

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -4062,10 +4062,17 @@ func TestArrowResponseContractDeclaresCursorTrailer(t *testing.T) {
 	contract := string(body)
 	for _, fragment := range []string{
 		`@extension("x-leapview-response-trailers", #["X-Next-Cursor"])`,
+		`@header contentType: "application/vnd.apache.arrow.stream";`,
+		`@header("X-Query-ID") queryId: string;`,
+		`@header("X-Serving-Snapshot") servingSnapshot: string;`,
+		`@header("X-LeapView-Arrow-Contract") arrowContract: "native-v1";`,
 		`@header("Trailer") trailers: "X-Next-Cursor";`,
+		`@header cacheControl: "no-store";`,
+		`model GatewayTimeout`,
+		`alias RowsetErrors = CommonErrors | GatewayTimeout;`,
 	} {
 		if !strings.Contains(contract, fragment) {
-			t.Errorf("Arrow response contract missing trailer declaration %q", fragment)
+			t.Errorf("Arrow response contract missing native-v1 declaration %q", fragment)
 		}
 	}
 	if strings.Contains(contract, `@header("X-Next-Cursor")`) {
@@ -4076,10 +4083,28 @@ func TestArrowResponseContractDeclaresCursorTrailer(t *testing.T) {
 	if got := strings.Count(string(operations), `@extension("x-leapview-response-trailers", #["X-Next-Cursor"])`); got != 3 {
 		t.Errorf("Arrow operation trailer declarations = %d, want 3", got)
 	}
+	if got := strings.Count(string(operations), `RowsetErrors;`); got != 3 {
+		t.Errorf("Arrow operation timeout error declarations = %d, want 3", got)
+	}
 	openAPI, err := os.ReadFile(filepath.Join(root, "docs", "api", "openapi.yaml"))
 	require.NoError(t, err)
 	if got := strings.Count(string(openAPI), "x-leapview-response-trailers:"); got != 3 {
 		t.Errorf("generated OpenAPI trailer declarations = %d, want 3", got)
+	}
+	for _, operationID := range []string{"queryDashboardVisualData", "previewSemanticDataset", "querySemanticModel"} {
+		section := string(openAPI)
+		start := strings.Index(section, "operationId: "+operationID)
+		if start < 0 {
+			t.Errorf("generated OpenAPI is missing operation %q", operationID)
+			continue
+		}
+		section = section[start:]
+		if end := strings.Index(section, "\n  /api/"); end >= 0 {
+			section = section[:end]
+		}
+		if !strings.Contains(section, "        '504':") {
+			t.Errorf("generated OpenAPI operation %q is missing the Arrow timeout response", operationID)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

FAI-543 direct governed Arrow streaming requires a locked dashboard Arrow response contract before implementation.

The existing dashboard Arrow response behavior is a legacy string-projection format and does not define native type, null, metadata, pagination, or streaming correctness semantics.

## Solution

This PR defines the dashboard native Arrow contract and executable correctness oracle.

Added:

- Native Arrow schema contract
- Native physical type requirements
- Nullability and validity bitmap semantics
- Decimal precision/scale/value requirements
- Timestamp unit and timezone semantics
- Binary and dictionary value requirements
- Schema and field metadata safety rules
- Pagination trailer contract
- Stream error behavior before and after response commitment
- Governance/security contract coverage
- Empty-result schema behavior

## Validation

Passed:

- go test ./internal/dashboard/http ./internal/dashboard/queryauthz
- go test -race ./internal/dashboard/http -run '^TestDashboardNativeArrowContract'
- go test -tags=duckdb_arrow ./internal/app
- go test ./internal/platform/architecture
- task api:generate
- task docs:generate
- task docs:check
- git diff --check

## Scope

This PR does not:

- modify dashboard Arrow serving
- add native Arrow routing
- change cache behavior
- change materialization
- implement FAI-543

It only provides the correctness oracle required for future native Arrow experiments.