### PR TITLE
Record dashboard refresh SLO error budget

### DIFF
--- a/deploy/observability/prometheus/leapview-recording-rules.yaml
+++ b/deploy/observability/prometheus/leapview-recording-rules.yaml
@@ -76,3 +76,26 @@ groups:
               rate(leapview_dashboard_refresh_duration_seconds_count{job="leapview",outcome!="canceled"}[30d])
             ) > 0
           )
+
+      - record: 'leapview:dashboard_refresh_reliability:objective_ratio_30d'
+        expr: |
+          (leapview:dashboard_refresh_reliability:ratio_30d * 0) + 0.99
+
+      - record: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        expr: |
+          (
+            (
+              leapview:dashboard_refresh_reliability:bad_events_30d
+              /
+              leapview:dashboard_refresh_reliability:eligible_events_30d
+            )
+            * 100
+            /
+            (100 - (leapview:dashboard_refresh_reliability:objective_ratio_30d * 100))
+          )
+          and on (job, instance)
+          (leapview:dashboard_refresh_reliability:eligible_events_30d > 0)
+
+      - record: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        expr: |
+          1 - leapview:dashboard_refresh_reliability:error_budget_consumption_30d

--- a/deploy/observability/prometheus/testdata/leapview-recording-rules.test.yaml
+++ b/deploy/observability/prometheus/testdata/leapview-recording-rules.test.yaml
@@ -40,6 +40,69 @@ tests:
         exp_samples:
           - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
             value: 1
+      - expr: 'leapview:dashboard_refresh_reliability:objective_ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:objective_ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.99
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_consumption_30d",instance="app:8080",job="leapview"}'
+            value: 0
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_remaining_30d",instance="app:8080",job="leapview"}'
+            value: 1
+
+  - name: nonzero failures within the objective consume part of the budget
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="complete"}'
+        values: '0+199x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="error"}'
+        values: '0+1x10'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:objective_ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:objective_ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.99
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_consumption_30d",instance="app:8080",job="leapview"}'
+            value: 0.5
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_remaining_30d",instance="app:8080",job="leapview"}'
+            value: 0.5
+
+  - name: exact objective threshold exhausts the budget
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="complete"}'
+        values: '0+99x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="error"}'
+        values: '0+1x10'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.99
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_consumption_30d",instance="app:8080",job="leapview"}'
+            value: 1
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_remaining_30d",instance="app:8080",job="leapview"}'
+            value: 0
 
   - name: low-volume partial history remains explicit
     interval: 1m
@@ -77,6 +140,45 @@ tests:
         exp_samples:
           - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
             value: 1
+      - expr: 'leapview:dashboard_refresh_reliability:objective_ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:objective_ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.99
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_consumption_30d",instance="app:8080",job="leapview"}'
+            value: 0
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_remaining_30d",instance="app:8080",job="leapview"}'
+            value: 1
+
+  - name: one low-volume failure visibly overdraws the budget
+    interval: 1m
+    input_series:
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="complete"}'
+        values: '0+9x10'
+      - series: 'leapview_dashboard_refresh_duration_seconds_count{job="leapview",instance="app:8080",command="initial",outcome="error"}'
+        values: '0+1x10'
+    promql_expr_test:
+      - expr: 'leapview:dashboard_refresh_reliability:eligible_events_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:eligible_events_30d",instance="app:8080",job="leapview"}'
+            value: 100
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_consumption_30d",instance="app:8080",job="leapview"}'
+            value: 10
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_remaining_30d",instance="app:8080",job="leapview"}'
+            value: -9
 
   - name: partial failures aggregate commands and prohibited labels
     interval: 1m
@@ -118,6 +220,21 @@ tests:
         exp_samples:
           - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
             value: 0.8
+      - expr: 'leapview:dashboard_refresh_reliability:objective_ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:objective_ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.99
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_consumption_30d",instance="app:8080",job="leapview"}'
+            value: 20
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_remaining_30d",instance="app:8080",job="leapview"}'
+            value: -19
 
   - name: error and unknown outcomes are bad refreshes
     interval: 1m
@@ -237,6 +354,21 @@ tests:
         exp_samples:
           - labels: '{__name__="leapview:dashboard_refresh_reliability:ratio_30d",instance="app:8080",job="leapview"}'
             value: 0.5
+      - expr: 'leapview:dashboard_refresh_reliability:objective_ratio_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:objective_ratio_30d",instance="app:8080",job="leapview"}'
+            value: 0.99
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_consumption_30d",instance="app:8080",job="leapview"}'
+            value: 50
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        eval_time: 10m
+        exp_samples:
+          - labels: '{__name__="leapview:dashboard_refresh_reliability:error_budget_remaining_30d",instance="app:8080",job="leapview"}'
+            value: -49
 
   - name: cancellation-only traffic produces zero volume and no ratio
     interval: 1m
@@ -270,6 +402,15 @@ tests:
       - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
         eval_time: 10m
         exp_samples: []
+      - expr: 'leapview:dashboard_refresh_reliability:objective_ratio_30d'
+        eval_time: 10m
+        exp_samples: []
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples: []
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
+        eval_time: 10m
+        exp_samples: []
 
   - name: missing traffic is not perfect reliability
     interval: 1m
@@ -291,5 +432,14 @@ tests:
         eval_time: 10m
         exp_samples: []
       - expr: 'leapview:dashboard_refresh_reliability:ratio_30d'
+        eval_time: 10m
+        exp_samples: []
+      - expr: 'leapview:dashboard_refresh_reliability:objective_ratio_30d'
+        eval_time: 10m
+        exp_samples: []
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_consumption_30d'
+        eval_time: 10m
+        exp_samples: []
+      - expr: 'leapview:dashboard_refresh_reliability:error_budget_remaining_30d'
         eval_time: 10m
         exp_samples: []

--- a/docs/articles/operate/observability.md
+++ b/docs/articles/operate/observability.md
@@ -48,7 +48,7 @@ Recovery alerts use current-state ledger projections. `leapview_recovery_qualifi
 
 Every alert links to [Operational troubleshooting](/docs/guides/operate/troubleshooting); recovery alerts link directly to the [recovery qualification response](/docs/guides/operate/troubleshooting#recovery-qualification-freshness-alerts-fire). Configure routing and receivers in the operator-owned Alertmanager deployment.
 
-### Dashboard refresh reliability SLI
+### Dashboard refresh reliability SLI and SLO
 
 The repository-owned recording rules at `deploy/observability/prometheus/leapview-recording-rules.yaml` derive dashboard refresh reliability only from `leapview_dashboard_refresh_duration_seconds_count`. A finished refresh is eligible unless its outcome is `canceled`. `complete` is good; `partial`, `error`, and the bounded fallback `other` are bad. Cancellations are excluded because refresh supersession and stream closure are expected lifecycle behavior rather than evidence of failed dashboard work.
 
@@ -62,7 +62,13 @@ Four companion recordings make the ratio's underlying traffic volume explicit. `
 
 Prometheus must retain at least 30 days of source samples for a complete rolling window. Until that history has accumulated after initial deployment or retention loss, the 30-day ratio and event volumes reflect only the available portion of the window. `increase` may return fractional estimates at range boundaries, so event volumes are operational context rather than accounting totals. Canceled-only traffic records zero eligible and bad events while still emitting no reliability ratio. Completely missing source metrics emit neither volume nor ratio; missing or idle traffic is never reported as perfect reliability. Sparse traffic can make the five-minute ratio volatile and the 30-day ratio statistically weak, so operators should inspect the eligible event recording before interpreting either series.
 
-This SLI measures only completed dashboard refresh work. It does not measure refreshes still in flight, HTTP or SSE transport continuity, authentication, static assets, direct API queries, or an end-to-end synthetic journey. It defines no SLO target, error budget, burn rate, or alert threshold.
+The repository-owned dashboard refresh reliability objective is 99% over a rolling 30-day window. The LeapView engineering/operations owner owns this initial target. It is a realistic baseline for detecting meaningful degradation while production behavior is still being established, without requiring an immature system to meet a stricter objective before sufficient operational history exists. Revisit the target after production reliability data establishes normal dashboard refresh behavior.
+
+`leapview:dashboard_refresh_reliability:objective_ratio_30d` records the `0.99` objective wherever the 30-day reliability ratio is evaluable. `leapview:dashboard_refresh_reliability:error_budget_consumption_30d` divides the observed bad-event fraction by the approved 1% bad-event allowance. A value below `1` is within budget, `1` is exhausted, and a value above `1` is overdrawn. `leapview:dashboard_refresh_reliability:error_budget_remaining_30d` records one minus consumption, so a negative value remains visible after exhaustion rather than being clamped. All three recordings retain only `job` and `instance`.
+
+The objective and budget recordings are absent when eligible traffic is zero or missing, including canceled-only traffic; absence must not be interpreted as compliance. Low traffic remains mathematically valid but statistically weak, so evaluate budget state together with `eligible_events_30d`. Prometheus cannot distinguish a complete 30-day history from a partial window after deployment or retention loss, and the budget recordings naturally reflect only the samples available. They inherit the SLI's `increase` estimation behavior and are not accounting totals.
+
+This SLO measures only completed dashboard refresh work. It does not measure refreshes still in flight, HTTP or SSE transport continuity, authentication, static assets, direct API queries, or an end-to-end synthetic journey. It defines no burn-rate alert, paging policy, or Alertmanager routing.
 
 ## Structured logs
 


### PR DESCRIPTION
## Problem

LeapView records canonical dashboard refresh reliability and event volumes, but operators have no repository-owned 30-day objective or error-budget state. The measurements therefore cannot show whether the approved reliability allowance remains available or has been exhausted.

## Root cause

FAI-579 intentionally stopped at the reliability SLI, and FAI-587 added the eligible and bad event volumes needed for safe policy evaluation. Neither issue encoded a product-approved objective.

## Solution

- Record the approved 99% dashboard refresh reliability objective over the rolling 30-day window.
- Record 30-day error-budget consumption from the existing bad and eligible event recordings and the approved objective.
- Record remaining budget as one minus consumption without clamping exhausted or negative values.
- Keep objective and budget series absent when the existing 30-day SLI is not evaluable, including canceled-only and missing traffic.
- Preserve job and instance as the only dynamic labels.
- Document the engineering/operations ownership, rationale, interpretation, retention assumptions, and limitations.

The existing FAI-579 SLI and FAI-587 event-volume expressions are unchanged.

## Tests added or updated

Promtool fixtures cover:

- within-budget failures;
- the exact 99% threshold and exhausted budget;
- overdrawn and negative remaining budget;
- low-volume success and failure;
- canceled-only and missing traffic;
- counter resets;
- command and prohibited-label aggregation.

## Verification performed

- task observability:check — passed; 6 alert rules and 9 recording rules validated with all fixtures.
- go test ./docs — passed.
- git diff --check — passed.
- Senior maintainer review — no correctness, security, cardinality, complexity, or regression findings.

## Limitations

- The 30-day calculations reflect partial history until Prometheus retains a complete window after deployment or retention loss.
- Sparse traffic remains statistically weak and must be interpreted alongside eligible event volume.
- This PR adds no burn-rate alerts, paging policy, dashboard, Alertmanager configuration, runtime metric, or Prometheus deployment.

Linear: https://linear.app/flid/issue/FAI-588/define-canonical-dashboard-refresh-reliability-slo-and-error-budget