### PR TITLE
FAI-532: Add cache validity, admission, and lifecycle observability

### DIFF
--- a/internal/analytics/dataquery/cache_observer.go
+++ b/internal/analytics/dataquery/cache_observer.go
@@ -12,6 +12,92 @@ import (
 // HTTP and metrics packages.
 type CacheOutcomeObserver func(outcome string)
 
+// CacheObservationPhase identifies one bounded step in the logical cache
+// decision. A query emits at most one lookup observation; an internal
+// execution-flight second-chance lookup is deliberately not a second logical
+// lookup.
+type CacheObservationPhase string
+
+const (
+	CacheObservationAdmission CacheObservationPhase = "admission"
+	CacheObservationLookup    CacheObservationPhase = "lookup"
+	CacheObservationFinal     CacheObservationPhase = "final"
+	CacheObservationStore     CacheObservationPhase = "store"
+)
+
+type CacheAdmissionDecision string
+
+const (
+	CacheAdmissionEligible CacheAdmissionDecision = "eligible"
+	CacheAdmissionBypassed CacheAdmissionDecision = "bypassed"
+	CacheAdmissionRejected CacheAdmissionDecision = "rejected"
+)
+
+type CacheAdmissionReason string
+
+const (
+	CacheAdmissionReasonEligible              CacheAdmissionReason = "eligible"
+	CacheAdmissionReasonQueryNotCacheable     CacheAdmissionReason = "query_not_cacheable"
+	CacheAdmissionReasonPlanningFailed        CacheAdmissionReason = "planning_failed"
+	CacheAdmissionReasonCanceled              CacheAdmissionReason = "canceled"
+	CacheAdmissionReasonDependencyUnavailable CacheAdmissionReason = "dependency_unavailable"
+	CacheAdmissionReasonDependencyInvalid     CacheAdmissionReason = "dependency_invalid"
+	CacheAdmissionReasonPolicyInvalid         CacheAdmissionReason = "policy_invalid"
+	CacheAdmissionReasonPartitionInvalid      CacheAdmissionReason = "partition_invalid"
+)
+
+type CacheLookupMissReason string
+
+const (
+	CacheLookupMissColdStart     CacheLookupMissReason = "cold_start"
+	CacheLookupMissAbsentEntry   CacheLookupMissReason = "absent_entry"
+	CacheLookupMissQueryMismatch CacheLookupMissReason = "query_mismatch"
+	CacheLookupMissInvalidated   CacheLookupMissReason = "invalidated"
+	CacheLookupMissEvicted       CacheLookupMissReason = "evicted"
+)
+
+type CacheHitSource string
+
+const (
+	CacheHitCurrentGeneration CacheHitSource = "current_generation"
+	CacheHitSharedGeneration  CacheHitSource = "shared_generation"
+	CacheHitCutoverRetained   CacheHitSource = "cutover_retained"
+)
+
+type CacheObservationOutcome string
+
+const (
+	CacheObservationHit       CacheObservationOutcome = "hit"
+	CacheObservationMiss      CacheObservationOutcome = "miss"
+	CacheObservationCoalesced CacheObservationOutcome = "coalesced"
+	CacheObservationError     CacheObservationOutcome = "error"
+)
+
+type CacheStoreOutcome string
+
+const (
+	CacheStoreStored    CacheStoreOutcome = "stored"
+	CacheStoreOversized CacheStoreOutcome = "oversized"
+	CacheStoreStale     CacheStoreOutcome = "stale"
+	CacheStoreClosed    CacheStoreOutcome = "closed"
+)
+
+// CacheObservation contains only fixed-cardinality classifications and
+// durations. Query text, identities, principals, and resource labels are not
+// part of this contract.
+type CacheObservation struct {
+	Phase           CacheObservationPhase
+	Decision        CacheAdmissionDecision
+	AdmissionReason CacheAdmissionReason
+	MissReason      CacheLookupMissReason
+	HitSource       CacheHitSource
+	Outcome         CacheObservationOutcome
+	StoreOutcome    CacheStoreOutcome
+	Duration        time.Duration
+}
+
+type CacheObserver func(observation CacheObservation)
+
 type PhysicalQueryObservation struct {
 	Count  int
 	Result Result
@@ -31,6 +117,7 @@ type ConnectionWaitObserver func(wait time.Duration)
 type ConnectionWaitCounter struct{ nanoseconds atomic.Int64 }
 
 type cacheOutcomeObserverContextKey struct{}
+type cacheObserverContextKey struct{}
 type physicalQueryObserverContextKey struct{}
 type connectionWaitObserverContextKey struct{}
 
@@ -48,6 +135,23 @@ func ObserveCacheOutcome(ctx context.Context, outcome string) {
 	observer, ok := ctx.Value(cacheOutcomeObserverContextKey{}).(CacheOutcomeObserver)
 	if ok && observer != nil {
 		observer(outcome)
+	}
+}
+
+func WithCacheObserver(ctx context.Context, observer CacheObserver) context.Context {
+	if observer == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, cacheObserverContextKey{}, observer)
+}
+
+func ObserveCache(ctx context.Context, observation CacheObservation) {
+	if ctx == nil || observation.Phase == "" {
+		return
+	}
+	observer, ok := ctx.Value(cacheObserverContextKey{}).(CacheObserver)
+	if ok && observer != nil {
+		observer(observation)
 	}
 }
 

--- a/internal/analytics/dataquery/cache_observer_test.go
+++ b/internal/analytics/dataquery/cache_observer_test.go
@@ -21,6 +21,49 @@ func TestCacheOutcomeObserverUsesRequestContext(t *testing.T) {
 	}
 }
 
+func TestTypedCacheObserverUsesFixedContract(t *testing.T) {
+	observed := []CacheObservation{}
+	ctx := WithCacheObserver(context.Background(), func(observation CacheObservation) {
+		observed = append(observed, observation)
+	})
+	input := CacheObservation{
+		Phase: CacheObservationAdmission, Decision: CacheAdmissionBypassed,
+		AdmissionReason: CacheAdmissionReasonDependencyUnavailable,
+	}
+	ObserveCache(ctx, input)
+	ObserveCache(ctx, CacheObservation{})
+	ObserveCache(context.Background(), input)
+	if len(observed) != 1 || observed[0] != input {
+		t.Fatalf("typed cache observations = %#v, want %#v", observed, []CacheObservation{input})
+	}
+
+	assertUniqueCacheLabels(t, []string{
+		string(CacheAdmissionReasonEligible), string(CacheAdmissionReasonQueryNotCacheable),
+		string(CacheAdmissionReasonPlanningFailed), string(CacheAdmissionReasonCanceled),
+		string(CacheAdmissionReasonDependencyUnavailable),
+		string(CacheAdmissionReasonDependencyInvalid), string(CacheAdmissionReasonPolicyInvalid),
+		string(CacheAdmissionReasonPartitionInvalid),
+	})
+	assertUniqueCacheLabels(t, []string{
+		string(CacheLookupMissColdStart), string(CacheLookupMissAbsentEntry), string(CacheLookupMissQueryMismatch),
+		string(CacheLookupMissInvalidated), string(CacheLookupMissEvicted),
+	})
+}
+
+func assertUniqueCacheLabels(t *testing.T, values []string) {
+	t.Helper()
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" {
+			t.Fatal("cache observation label must not be empty")
+		}
+		if _, ok := seen[value]; ok {
+			t.Fatalf("duplicate cache observation label %q", value)
+		}
+		seen[value] = struct{}{}
+	}
+}
+
 func TestConnectionWaitCounterAccumulatesAndPreservesOuterObserver(t *testing.T) {
 	var observed time.Duration
 	ctx := WithConnectionWaitObserver(context.Background(), func(wait time.Duration) { observed += wait })

--- a/internal/analytics/materialize/query_cache.go
+++ b/internal/analytics/materialize/query_cache.go
@@ -2,11 +2,13 @@ package materialize
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/flidai/leapview/internal/analytics/dataquery"
 	"github.com/flidai/leapview/internal/analytics/resultcache"
@@ -41,17 +43,37 @@ type arrowQueryExecution struct {
 	summary  dataquery.Result
 }
 
-func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency, diagnosticsSQL string, execute func(context.Context) (arrowQueryExecution, error)) (dataquery.Result, error) {
-	key, generation, err := c.cacheKey(request, partition, dependency)
+type queryCacheAddress struct {
+	key        string
+	family     resultcache.QueryFamily
+	generation uint64
+}
+
+func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency, diagnosticsSQL string, observationStarted time.Time, execute func(context.Context) (arrowQueryExecution, error)) (dataquery.Result, error) {
+	if observationStarted.IsZero() {
+		observationStarted = time.Now()
+	}
+	address, err := c.cacheAddress(request, partition, dependency)
 	if err != nil {
+		observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(observationStarted))
 		return dataquery.Result{}, err
 	}
-	if cached, ok, err := c.getArrow(ctx, request, key, diagnosticsSQL); err != nil || ok {
+	lookupStarted := time.Now()
+	cached, ok, lookup, err := c.getArrowObserved(ctx, request, address, diagnosticsSQL)
+	if err != nil || ok {
+		observeTypedCacheLookup(ctx, lookup, time.Since(lookupStarted))
+		if err != nil {
+			observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(observationStarted))
+		} else {
+			observeTypedCacheFinalWithSource(ctx, dataquery.CacheObservationHit, lookup.HitSource, time.Since(observationStarted))
+		}
 		return cached, err
 	}
+	firstLookupDuration := time.Since(lookupStarted)
+	observeTypedCacheLookup(ctx, lookup, firstLookupDuration)
 	var ownerSummary dataquery.Result
-	flight, status, err := c.execution.CoalesceArrow(ctx, fmt.Sprintf("arrow-query:%d:%s", generation, key), func(flightCtx context.Context) (resultcache.ArrowFlightValue, error) {
-		if entry, _, ok, lookupErr := c.scope.LookupArrow(key); lookupErr != nil {
+	flight, status, err := c.execution.CoalesceArrow(ctx, fmt.Sprintf("arrow-query:%d:%s", address.generation, address.key), func(flightCtx context.Context) (resultcache.ArrowFlightValue, error) {
+		if entry, _, ok, observed, lookupErr := c.scope.LookupArrowObserved(address.key, address.family); lookupErr != nil {
 			return resultcache.ArrowFlightValue{}, lookupErr
 		} else if ok {
 			base, acquireErr := entry.Data().Acquire()
@@ -60,7 +82,7 @@ func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Q
 			if acquireErr != nil {
 				return resultcache.ArrowFlightValue{}, acquireErr
 			}
-			return resultcache.ArrowFlightValue{Data: base, Metadata: metadata, Cached: true}, nil
+			return resultcache.ArrowFlightValue{Data: base, Metadata: metadata, Cached: true, HitSource: observed.HitSource}, nil
 		}
 		execution, executeErr := execute(flightCtx)
 		ownerSummary = execution.summary
@@ -85,11 +107,14 @@ func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Q
 		// cache or its coalesced value.
 		cacheMetadata := execution.metadata
 		cacheMetadata.SQL = ""
-		c.scope.StoreArrow(key, resultcache.Token(generation), execution.data, cacheMetadata)
+		storeStarted := time.Now()
+		storeOutcome := c.scope.StoreArrowObserved(address.key, address.family, resultcache.Token(address.generation), execution.data, cacheMetadata)
+		dataquery.ObserveCache(ctx, dataquery.CacheObservation{Phase: dataquery.CacheObservationStore, StoreOutcome: dataquery.CacheStoreOutcome(storeOutcome), Duration: time.Since(storeStarted)})
 		c.syncStats()
 		return resultcache.ArrowFlightValue{Data: base, Metadata: cacheMetadata}, nil
 	})
 	if err != nil {
+		observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(observationStarted))
 		return dataquery.Result{}, err
 	}
 	defer flight.Release()
@@ -102,6 +127,7 @@ func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Q
 	if flight.Cached() || !status.Owner {
 		if budget, found := dataquery.ResultBudgetFromContext(ctx); found {
 			if err := budget.ConsumeSize(int(flight.Data().Rows()), flight.Data().Bytes()); err != nil {
+				observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(observationStarted))
 				return dataquery.Result{}, err
 			}
 		}
@@ -110,32 +136,44 @@ func (c *queryResultCache) executeArrow(ctx context.Context, request dataquery.Q
 	metadata.SQL = diagnosticsSQL
 	result, err := decodeArrowQueryResult(request, flight.Data(), metadata, ownerSummary)
 	if err != nil {
+		observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(observationStarted))
 		return dataquery.Result{}, err
 	}
 	result.CacheOutcome = outcome
+	typedOutcome := dataquery.CacheObservationOutcome(outcome)
+	if flight.Cached() {
+		observeTypedCacheFinalWithSource(ctx, typedOutcome, flight.HitSource(), time.Since(observationStarted))
+	} else {
+		observeTypedCacheFinal(ctx, typedOutcome, time.Since(observationStarted))
+	}
 	return result, nil
 }
 
 func (c *queryResultCache) getArrow(ctx context.Context, request dataquery.Query, key, diagnosticsSQL string) (dataquery.Result, bool, error) {
-	entry, _, ok, err := c.scope.LookupArrow(key)
+	result, hit, _, err := c.getArrowObserved(ctx, request, queryCacheAddress{key: key}, diagnosticsSQL)
+	return result, hit, err
+}
+
+func (c *queryResultCache) getArrowObserved(ctx context.Context, request dataquery.Query, address queryCacheAddress, diagnosticsSQL string) (dataquery.Result, bool, resultcache.LookupObservation, error) {
+	entry, _, ok, observation, err := c.scope.LookupArrowObserved(address.key, address.family)
 	if err != nil || !ok {
-		return dataquery.Result{}, false, err
+		return dataquery.Result{}, false, observation, err
 	}
 	defer entry.Release()
 	if budget, found := dataquery.ResultBudgetFromContext(ctx); found {
 		if err := budget.ConsumeSize(int(entry.Data().Rows()), entry.Data().Bytes()); err != nil {
-			return dataquery.Result{}, false, err
+			return dataquery.Result{}, false, observation, err
 		}
 	}
 	metadata := entry.Metadata()
 	metadata.SQL = diagnosticsSQL
 	result, err := decodeArrowQueryResult(request, entry.Data(), metadata, dataquery.Result{CacheOutcome: dataquery.CacheHit})
 	if err != nil {
-		return dataquery.Result{}, false, err
+		return dataquery.Result{}, false, observation, err
 	}
 	result.CacheOutcome = dataquery.CacheHit
 	c.syncStats()
-	return result, true, nil
+	return result, true, observation, nil
 }
 
 func newQueryResultCache(capacity int) *queryResultCache {
@@ -216,18 +254,23 @@ func (c *queryResultCache) coalesceBytes(ctx context.Context, key string, execut
 	return shared, err
 }
 
-func (c *queryResultCache) lookupArrow(ctx context.Context, request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency, diagnosticsSQL string) (dataquery.Result, string, uint64, bool, error) {
-	key, generation, err := c.cacheKey(request, partition, dependency)
+func (c *queryResultCache) lookupArrow(ctx context.Context, request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency, diagnosticsSQL string) (dataquery.Result, queryCacheAddress, bool, resultcache.LookupObservation, error) {
+	address, err := c.cacheAddress(request, partition, dependency)
 	if err != nil {
-		return dataquery.Result{}, "", 0, false, err
+		return dataquery.Result{}, queryCacheAddress{}, false, resultcache.LookupObservation{}, err
 	}
-	result, hit, err := c.getArrow(ctx, request, key, diagnosticsSQL)
-	return result, key, generation, hit, err
+	result, hit, observation, err := c.getArrowObserved(ctx, request, address, diagnosticsSQL)
+	return result, address, hit, observation, err
 }
 
 func (c *queryResultCache) cacheKey(request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency) (string, uint64, error) {
+	address, err := c.cacheAddress(request, partition, dependency)
+	return address.key, address.generation, err
+}
+
+func (c *queryResultCache) cacheAddress(request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency) (queryCacheAddress, error) {
 	if !queryCacheIdentityAvailable(request, partition, dependency) {
-		return "", 0, fmt.Errorf("complete query result cache identity is required")
+		return queryCacheAddress{}, fmt.Errorf("complete query result cache identity is required")
 	}
 	spatialTileGenerationVersion := 0
 	if request.SpatialTile != nil || request.SpatialTileBudget != nil {
@@ -236,7 +279,7 @@ func (c *queryResultCache) cacheKey(request dataquery.Query, partition resultide
 		spatialTileGenerationVersion = 5
 	}
 	partitionCanonical := partition.Canonical()
-	keyBytes, err := json.Marshal(queryResultCacheKey{
+	key := queryResultCacheKey{
 		Version:                    resultidentity.CacheKeyFormatVersion,
 		Partition:                  json.RawMessage(partitionCanonical),
 		DependencyDigest:           dependency.Digest(),
@@ -251,36 +294,58 @@ func (c *queryResultCache) cacheKey(request dataquery.Query, partition resultide
 			SpatialTileBudget:            request.SpatialTileBudget,
 			SpatialTileGenerationVersion: spatialTileGenerationVersion, SpatialMetadata: request.SpatialMetadata,
 		},
+	}
+	keyBytes, err := json.Marshal(key)
+	if err != nil {
+		return queryCacheAddress{}, fmt.Errorf("encode governed query cache key: %w", err)
+	}
+	familyBytes, err := json.Marshal(queryResultCacheFamily{
+		Version:                    key.Version,
+		Partition:                  key.Partition,
+		DependencyDigest:           key.DependencyDigest,
+		EffectivePolicyFingerprint: key.EffectivePolicyFingerprint,
 	})
 	if err != nil {
-		return "", 0, fmt.Errorf("encode governed query cache key: %w", err)
+		return queryCacheAddress{}, fmt.Errorf("encode governed query cache family: %w", err)
 	}
+	family := sha256.Sum256(familyBytes)
 	generation := uint64(c.scope.Generation())
 	c.mu.Lock()
 	c.generation = generation
 	c.mu.Unlock()
-	return string(keyBytes), generation, nil
+	return queryCacheAddress{key: string(keyBytes), family: resultcache.QueryFamily(family), generation: generation}, nil
 }
 
 func queryCacheIdentityAvailable(request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency) bool {
-	if partition.Version() != resultidentity.PartitionVersion || dependency.Version() != resultidentity.DependencyVersion {
-		return false
+	return queryCacheIdentityReason(request, partition, dependency) == dataquery.CacheAdmissionReasonEligible
+}
+
+func queryCacheIdentityReason(request dataquery.Query, partition resultidentity.Partition, dependency resultidentity.Dependency) dataquery.CacheAdmissionReason {
+	if partition.Version() != resultidentity.PartitionVersion {
+		return dataquery.CacheAdmissionReasonPartitionInvalid
 	}
-	if platformdigest.ValidateSHA256Identity(dependency.Digest()) != nil ||
-		platformdigest.ValidateSHA256Identity(request.EffectivePolicyFingerprint) != nil {
-		return false
+	if dependency.Version() != resultidentity.DependencyVersion || platformdigest.ValidateSHA256Identity(dependency.Digest()) != nil {
+		return dataquery.CacheAdmissionReasonDependencyInvalid
+	}
+	if platformdigest.ValidateSHA256Identity(request.EffectivePolicyFingerprint) != nil {
+		return dataquery.CacheAdmissionReasonPolicyInvalid
 	}
 	if partition.ProjectID() != request.ProjectID && request.ProjectID != "" {
-		return false
+		return dataquery.CacheAdmissionReasonPartitionInvalid
 	}
 	switch partition.Kind() {
 	case resultidentity.PartitionProduction:
-		return request.CandidateID == ""
+		if request.CandidateID != "" {
+			return dataquery.CacheAdmissionReasonPartitionInvalid
+		}
 	case resultidentity.PartitionCandidate:
-		return request.CandidateID == partition.CandidateID()
+		if request.CandidateID != partition.CandidateID() {
+			return dataquery.CacheAdmissionReasonPartitionInvalid
+		}
 	default:
-		return false
+		return dataquery.CacheAdmissionReasonPartitionInvalid
 	}
+	return dataquery.CacheAdmissionReasonEligible
 }
 
 type queryResultCacheKey struct {
@@ -289,6 +354,34 @@ type queryResultCacheKey struct {
 	DependencyDigest           string                `json:"dependencyDigest"`
 	EffectivePolicyFingerprint string                `json:"effectivePolicyFingerprint"`
 	Query                      governedQueryCacheKey `json:"query"`
+}
+
+type queryResultCacheFamily struct {
+	Version                    int             `json:"version"`
+	Partition                  json.RawMessage `json:"partition"`
+	DependencyDigest           string          `json:"dependencyDigest"`
+	EffectivePolicyFingerprint string          `json:"effectivePolicyFingerprint"`
+}
+
+func observeTypedCacheLookup(ctx context.Context, observation resultcache.LookupObservation, duration time.Duration) {
+	control, _ := ctx.Value(cacheObservationContextKey{}).(cacheObservationControl)
+	if control.suppressLookup {
+		return
+	}
+	dataquery.ObserveCache(ctx, dataquery.CacheObservation{
+		Phase:      dataquery.CacheObservationLookup,
+		MissReason: dataquery.CacheLookupMissReason(observation.MissReason),
+		HitSource:  dataquery.CacheHitSource(observation.HitSource),
+		Duration:   duration,
+	})
+}
+
+func observeTypedCacheFinal(ctx context.Context, outcome dataquery.CacheObservationOutcome, duration time.Duration) {
+	dataquery.ObserveCache(ctx, dataquery.CacheObservation{Phase: dataquery.CacheObservationFinal, Outcome: outcome, Duration: duration})
+}
+
+func observeTypedCacheFinalWithSource(ctx context.Context, outcome dataquery.CacheObservationOutcome, source resultcache.HitSource, duration time.Duration) {
+	dataquery.ObserveCache(ctx, dataquery.CacheObservation{Phase: dataquery.CacheObservationFinal, Outcome: outcome, HitSource: dataquery.CacheHitSource(source), Duration: duration})
 }
 
 type governedQueryCacheKey struct {

--- a/internal/analytics/materialize/query_cache_test.go
+++ b/internal/analytics/materialize/query_cache_test.go
@@ -214,6 +214,26 @@ func TestQueryResultCacheKeyUsesStableCompositeIdentity(t *testing.T) {
 	require.NotEqual(t, first, candidateKey)
 }
 
+func TestQueryCacheIdentityReasonClassifiesValidatedEvidence(t *testing.T) {
+	partition := materializeTestPartition(t, resultidentity.PartitionProduction, "")
+	dependency := materializeTestDependency(t, '2')
+	request := dataquery.Query{ProjectID: "project:test", EffectivePolicyFingerprint: materializeTestDigest('9')}
+	if got := queryCacheIdentityReason(request, partition, dependency); got != dataquery.CacheAdmissionReasonEligible {
+		t.Fatalf("valid identity reason = %q", got)
+	}
+	invalidPolicy := request
+	invalidPolicy.EffectivePolicyFingerprint = "malformed"
+	if got := queryCacheIdentityReason(invalidPolicy, partition, dependency); got != dataquery.CacheAdmissionReasonPolicyInvalid {
+		t.Fatalf("invalid policy reason = %q", got)
+	}
+	if got := queryCacheIdentityReason(request, resultidentity.Partition{}, dependency); got != dataquery.CacheAdmissionReasonPartitionInvalid {
+		t.Fatalf("invalid partition reason = %q", got)
+	}
+	if got := queryCacheIdentityReason(request, partition, resultidentity.Dependency{}); got != dataquery.CacheAdmissionReasonDependencyInvalid {
+		t.Fatalf("invalid dependency reason = %q", got)
+	}
+}
+
 // The row-shaped helpers below exist only to preserve cache-policy tests while
 // production cache storage is Arrow-only.
 func (c *queryResultCache) execute(ctx context.Context, request dataquery.Query, execute func() (dataquery.Result, error)) (dataquery.Result, error) {
@@ -415,13 +435,20 @@ func TestRuntimeSharedPartitionCacheReusesDataWithoutStaleSQLOrByteLifetime(t *t
 	})
 	defer second.queryCache.close()
 	bindPlanner(second, "snapshot_two")
-	secondResult, err := second.ExecuteDataQuery(context.Background(), request)
+	cutoverObservations := []dataquery.CacheObservation{}
+	cutoverCtx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) {
+		cutoverObservations = append(cutoverObservations, observation)
+	})
+	secondResult, err := second.ExecuteDataQuery(cutoverCtx, request)
 	require.NoError(t, err)
 	require.Equal(t, dataquery.CacheHit, secondResult.CacheOutcome)
 	require.Contains(t, secondResult.SQL, "snapshot_two")
 	require.NotContains(t, secondResult.SQL, "snapshot_one")
 	require.Equal(t, int32(1), firstDB.queries.Load())
 	require.Zero(t, secondDB.queries.Load())
+	require.Equal(t, 1, countCacheObservations(cutoverObservations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationLookup && observation.HitSource == dataquery.CacheHitCutoverRetained
+	}))
 	changedEvidence, err := resultidentity.NewEvidence(resultidentity.EvidenceInput{
 		SemanticModelID: "sales", SemanticModelDigest: materializeTestDigest('a'),
 		DatasetRelations: []resultidentity.DatasetRelation{{
@@ -733,8 +760,10 @@ func TestRuntimeInvalidDependencyEvidenceBypassesResultReuseAndRetainsCurrentPla
 		ModelID:                    "sales", Kind: dataquery.KindSemanticRows, Target: "orders",
 		Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1,
 	}
+	observations := []dataquery.CacheObservation{}
+	ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) { observations = append(observations, observation) })
 	for range 2 {
-		result, err := runtime.ExecuteDataQuery(context.Background(), request)
+		result, err := runtime.ExecuteDataQuery(ctx, request)
 		require.NoError(t, err)
 		require.Equal(t, dataquery.CacheMiss, result.CacheOutcome)
 		require.NotEmpty(t, result.SQL)
@@ -742,6 +771,12 @@ func TestRuntimeInvalidDependencyEvidenceBypassesResultReuseAndRetainsCurrentPla
 	}
 	require.Equal(t, int32(2), database.queries.Load())
 	require.Zero(t, runtime.queryCache.scope.Stats().Entries)
+	require.Equal(t, 2, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission && observation.Decision == dataquery.CacheAdmissionBypassed && observation.AdmissionReason == dataquery.CacheAdmissionReasonDependencyUnavailable
+	}))
+	require.Zero(t, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationLookup
+	}))
 }
 
 func TestRuntimeNonCacheableQueryRetainsCurrentPlanSQL(t *testing.T) {
@@ -757,10 +792,18 @@ func TestRuntimeNonCacheableQueryRetainsCurrentPlanSQL(t *testing.T) {
 		ModelID: "sales", Kind: dataquery.KindSemanticRows, Target: "orders",
 		Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1,
 	}
-	result, err := runtime.ExecuteDataQuery(context.Background(), request)
+	observations := []dataquery.CacheObservation{}
+	ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) { observations = append(observations, observation) })
+	result, err := runtime.ExecuteDataQuery(ctx, request)
 	require.NoError(t, err)
 	require.NotEmpty(t, result.SQL)
 	require.Contains(t, result.SQL, "orders")
+	require.Equal(t, 1, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission && observation.AdmissionReason == dataquery.CacheAdmissionReasonQueryNotCacheable
+	}))
+	require.Zero(t, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationLookup
+	}))
 }
 
 func TestRuntimeInvalidPolicyEvidenceBypassesResultReuse(t *testing.T) {
@@ -778,13 +821,87 @@ func TestRuntimeInvalidPolicyEvidenceBypassesResultReuse(t *testing.T) {
 		Kind: dataquery.KindSemanticRows, Target: "orders",
 		Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1,
 	}
+	observations := []dataquery.CacheObservation{}
+	ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) { observations = append(observations, observation) })
 	for range 2 {
-		result, err := runtime.ExecuteDataQuery(context.Background(), request)
+		result, err := runtime.ExecuteDataQuery(ctx, request)
 		require.NoError(t, err)
 		require.Equal(t, dataquery.CacheMiss, result.CacheOutcome)
 	}
 	require.Equal(t, int32(2), database.queries.Load())
 	require.Zero(t, runtime.queryCache.scope.Stats().Entries)
+	require.Equal(t, 2, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission && observation.AdmissionReason == dataquery.CacheAdmissionReasonPolicyInvalid
+	}))
+}
+
+func TestRuntimeCacheFinalLatencyUsesLogicalAttemptOriginForHitMissAndBypass(t *testing.T) {
+	runtime := activatedCacheRuntime(t, &Runtime{
+		modelID: "sales",
+		model: &semanticmodel.Model{Name: "sales", Tables: map[string]semanticmodel.Table{
+			"orders": {Columns: map[string]semanticmodel.ModelColumn{"id": {Name: "id", Datatype: semanticmodel.DataTypeInteger}}},
+		}, Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}}},
+		db: &countingCacheRuntimeDatabase{}, queryCache: newQueryResultCache(256),
+	})
+	request := dataquery.Query{
+		Surface: dataquery.SurfaceDashboard, Operation: dataquery.OperationDashboardRows,
+		EffectivePolicyFingerprint: materializeTestDigest('9'),
+		ModelID:                    "sales", Kind: dataquery.KindSemanticRows, Target: "orders",
+		Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1,
+	}
+	require.NoError(t, primeBundleBranch(runtime, dataquery.BundleRequest{Query: request}))
+
+	observe := func() []dataquery.CacheObservation {
+		observations := []dataquery.CacheObservation{}
+		ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) {
+			observations = append(observations, observation)
+		})
+		ctx = withCacheObservationStarted(ctx, time.Now().Add(-2*time.Second))
+		_, err := runtime.ExecuteDataQuery(ctx, request)
+		require.NoError(t, err)
+		return observations
+	}
+
+	hit := observe()
+	runtime.ClearQueryCache()
+	miss := observe()
+	runtime.dependencyEvidence = resultidentity.Evidence{}
+	bypass := observe()
+
+	hitFinal := cacheObservationByPhase(t, hit, dataquery.CacheObservationFinal)
+	missFinal := cacheObservationByPhase(t, miss, dataquery.CacheObservationFinal)
+	bypassFinal := cacheObservationByPhase(t, bypass, dataquery.CacheObservationFinal)
+	require.Equal(t, dataquery.CacheObservationHit, hitFinal.Outcome)
+	require.Equal(t, dataquery.CacheObservationMiss, missFinal.Outcome)
+	require.Equal(t, dataquery.CacheObservationMiss, bypassFinal.Outcome)
+	finals := []dataquery.CacheObservation{hitFinal, missFinal, bypassFinal}
+	for _, final := range finals {
+		require.GreaterOrEqual(t, final.Duration, 1500*time.Millisecond)
+	}
+	minimum, maximum := finals[0].Duration, finals[0].Duration
+	for _, final := range finals[1:] {
+		if final.Duration < minimum {
+			minimum = final.Duration
+		}
+		if final.Duration > maximum {
+			maximum = final.Duration
+		}
+	}
+	require.Less(t, maximum-minimum, time.Second)
+	lookup := cacheObservationByPhase(t, hit, dataquery.CacheObservationLookup)
+	require.Less(t, lookup.Duration, hitFinal.Duration, "lookup latency must remain narrower than logical cache-attempt latency")
+}
+
+func cacheObservationByPhase(t testing.TB, observations []dataquery.CacheObservation, phase dataquery.CacheObservationPhase) dataquery.CacheObservation {
+	t.Helper()
+	var matches []dataquery.CacheObservation
+	for _, observation := range observations {
+		if observation.Phase == phase {
+			matches = append(matches, observation)
+		}
+	}
+	require.Len(t, matches, 1)
+	return matches[0]
 }
 
 func TestRuntimePlanningFailureRetainsExecutionFailureClassification(t *testing.T) {
@@ -803,7 +920,9 @@ func TestRuntimePlanningFailureRetainsExecutionFailureClassification(t *testing.
 		},
 	})
 	require.NoError(t, err)
+	observations := []dataquery.CacheObservation{}
 	ctx := workload.WithAdmitter(context.Background(), admission)
+	ctx = dataquery.WithCacheObserver(ctx, func(observation dataquery.CacheObservation) { observations = append(observations, observation) })
 	request := dataquery.Query{
 		Surface: dataquery.SurfaceDashboard, Operation: dataquery.OperationDashboardRows,
 		ModelID: "sales", Kind: dataquery.KindSemanticRows, Target: "orders",
@@ -822,6 +941,12 @@ func TestRuntimePlanningFailureRetainsExecutionFailureClassification(t *testing.
 	require.Empty(t, result.Error)
 	require.Equal(t, int32(0), database.queries.Load())
 	require.Equal(t, 1, runtime.queryCache.scope.Stats().Entries)
+	require.Equal(t, 1, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission && observation.Decision == dataquery.CacheAdmissionRejected && observation.AdmissionReason == dataquery.CacheAdmissionReasonPlanningFailed
+	}))
+	require.Zero(t, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationLookup
+	}))
 }
 
 type rejectingQueryAdmitter struct{ calls int }
@@ -1313,10 +1438,14 @@ func TestRuntimeCountsFilterOptionCacheMissAsPhysicalAndHitAsZero(t *testing.T) 
 	})
 	physicalQueries := 0
 	cacheOutcomes := []string{}
+	typedObservations := []dataquery.CacheObservation{}
 	ctx := dataquery.WithPhysicalQueryObserver(context.Background(), func(observation dataquery.PhysicalQueryObservation) {
 		physicalQueries += observation.Count
 	})
 	ctx = dataquery.WithCacheOutcomeObserver(ctx, func(outcome string) { cacheOutcomes = append(cacheOutcomes, outcome) })
+	ctx = dataquery.WithCacheObserver(ctx, func(observation dataquery.CacheObservation) {
+		typedObservations = append(typedObservations, observation)
+	})
 	request := dataquery.Query{
 		Surface:                    dataquery.SurfaceDashboard,
 		EffectivePolicyFingerprint: materializeTestDigest('9'),
@@ -1340,6 +1469,15 @@ func TestRuntimeCountsFilterOptionCacheMissAsPhysicalAndHitAsZero(t *testing.T) 
 	if len(cacheOutcomes) != len(wantOutcomes) || cacheOutcomes[0] != wantOutcomes[0] || cacheOutcomes[1] != wantOutcomes[1] {
 		t.Fatalf("cache outcomes = %#v, want %#v", cacheOutcomes, wantOutcomes)
 	}
+	lookups := make([]dataquery.CacheObservation, 0, 2)
+	for _, observation := range typedObservations {
+		if observation.Phase == dataquery.CacheObservationLookup {
+			lookups = append(lookups, observation)
+		}
+	}
+	require.Len(t, lookups, 2, "execution-flight second chance must not count as a logical lookup")
+	require.Equal(t, dataquery.CacheLookupMissColdStart, lookups[0].MissReason)
+	require.Equal(t, dataquery.CacheHitCurrentGeneration, lookups[1].HitSource)
 }
 
 func TestRuntimeCachesGovernedDashboardQueriesAndToggleBackExecutesZeroSQL(t *testing.T) {
@@ -1523,7 +1661,9 @@ func TestRuntimeBundleCacheMixedHitExecutesOnlyLoneMiss(t *testing.T) {
 	if _, err := runtime.ExecuteDataQuery(context.Background(), requests[0].Query); err != nil {
 		t.Fatal(err)
 	}
-	result, err := runtime.ExecuteDataQueryBundle(context.Background(), requests)
+	observations := []dataquery.CacheObservation{}
+	ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) { observations = append(observations, observation) })
+	result, err := runtime.ExecuteDataQueryBundle(ctx, requests)
 	require.NoError(t, err)
 	if got := database.queries.Load(); got != 2 {
 		t.Fatalf("physical executions = %d, want prime plus lone miss", got)
@@ -1531,6 +1671,70 @@ func TestRuntimeBundleCacheMixedHitExecutesOnlyLoneMiss(t *testing.T) {
 	if result.Results[requests[0].ID].CacheOutcome != dataquery.CacheHit {
 		t.Fatalf("first branch outcome = %q", result.Results[requests[0].ID].CacheOutcome)
 	}
+	require.Equal(t, 2, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission
+	}))
+	require.Equal(t, 2, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationLookup
+	}))
+	require.Equal(t, 2, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationFinal
+	}))
+}
+
+func TestRuntimeDegenerateBundleObservesFirstLogicalLookupReason(t *testing.T) {
+	database := &bundleCountingDatabase{}
+	runtime := bundleCacheRuntime(t, database)
+	requests := bundleCacheRequests()
+	for _, request := range requests {
+		require.NoError(t, primeBundleBranch(runtime, request))
+	}
+
+	planned, err := runtime.planOwnedArrowQuery(requests[1].Query)
+	require.NoError(t, err)
+	dependency, reusable := runtime.dependencyForPlan(planned.plan)
+	require.True(t, reusable)
+	address, err := runtime.queryCache.cacheAddress(requests[1].Query, runtime.resultPartition, dependency)
+	require.NoError(t, err)
+	runtime.queryCache.scope.Delete(address.key)
+
+	observations := []dataquery.CacheObservation{}
+	restored := false
+	ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) {
+		observations = append(observations, observation)
+		if !restored && observation.Phase == dataquery.CacheObservationLookup && observation.MissReason != "" {
+			restored = true
+			runtime.queryCache.store(address.key, address.generation, dataquery.Result{
+				Columns: dataquery.ColumnsFromNames([]string{"value"}),
+				Rows:    []dataquery.Row{{"value": int64(1)}},
+			})
+		}
+	})
+	result, err := runtime.ExecuteDataQueryBundle(ctx, requests)
+	require.NoError(t, err)
+	require.True(t, restored)
+	require.Equal(t, int32(2), database.queries.Load(), "the internal safety lookup should see the restored entry")
+	require.Equal(t, dataquery.CacheHit, result.Results[requests[1].ID].CacheOutcome)
+
+	lookups := make([]dataquery.CacheObservation, 0, len(requests))
+	for _, observation := range observations {
+		if observation.Phase == dataquery.CacheObservationLookup {
+			lookups = append(lookups, observation)
+		}
+	}
+	require.Len(t, lookups, len(requests), "each bundle branch must emit one logical lookup")
+	require.Equal(t, dataquery.CacheHitCurrentGeneration, lookups[0].HitSource)
+	require.Equal(t, dataquery.CacheLookupMissAbsentEntry, lookups[1].MissReason, "the recorded miss must come from the first bundle lookup")
+}
+
+func countCacheObservations(observations []dataquery.CacheObservation, match func(dataquery.CacheObservation) bool) int {
+	count := 0
+	for _, observation := range observations {
+		if match(observation) {
+			count++
+		}
+	}
+	return count
 }
 
 func TestRuntimeBundleCanceledExecutionDoesNotCacheOrAuditSuccess(t *testing.T) {

--- a/internal/analytics/materialize/query_cache_test.go
+++ b/internal/analytics/materialize/query_cache_test.go
@@ -1682,6 +1682,32 @@ func TestRuntimeBundleCacheMixedHitExecutesOnlyLoneMiss(t *testing.T) {
 	}))
 }
 
+func TestRuntimeBundleLookupErrorFlushesEarlierBranchObservations(t *testing.T) {
+	runtime := bundleCacheRuntime(t, &bundleCountingDatabase{})
+	observations := []dataquery.CacheObservation{}
+	closed := false
+	ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) {
+		observations = append(observations, observation)
+		if !closed && observation.Phase == dataquery.CacheObservationLookup && observation.MissReason != "" {
+			closed = true
+			require.NoError(t, runtime.queryCache.scope.Close())
+		}
+	})
+
+	_, err := runtime.ExecuteDataQueryBundle(ctx, bundleCacheRequests())
+	require.Error(t, err)
+	require.True(t, closed)
+	require.Equal(t, len(bundleCacheRequests()), countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission
+	}))
+	require.Equal(t, len(bundleCacheRequests()), countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationLookup
+	}))
+	require.Equal(t, len(bundleCacheRequests()), countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationFinal && observation.Outcome == dataquery.CacheObservationError
+	}))
+}
+
 func TestRuntimeDegenerateBundleObservesFirstLogicalLookupReason(t *testing.T) {
 	database := &bundleCountingDatabase{}
 	runtime := bundleCacheRuntime(t, database)

--- a/internal/analytics/materialize/runtime.go
+++ b/internal/analytics/materialize/runtime.go
@@ -750,6 +750,47 @@ func observeQueryCacheOutcome(ctx context.Context, result dataquery.Result, err 
 	dataquery.ObserveCacheOutcome(ctx, outcome)
 }
 
+type cacheObservationContextKey struct{}
+
+type cacheObservationControl struct {
+	started           time.Time
+	suppressAdmission bool
+	suppressLookup    bool
+}
+
+func cacheObservationStarted(ctx context.Context, fallback time.Time) time.Time {
+	control, _ := ctx.Value(cacheObservationContextKey{}).(cacheObservationControl)
+	if !control.started.IsZero() {
+		return control.started
+	}
+	return fallback
+}
+
+func withCacheObservationStarted(ctx context.Context, started time.Time) context.Context {
+	control, _ := ctx.Value(cacheObservationContextKey{}).(cacheObservationControl)
+	control.started = started
+	return context.WithValue(ctx, cacheObservationContextKey{}, control)
+}
+
+func withCacheObservationSuppression(ctx context.Context, admission, lookup bool) context.Context {
+	control, _ := ctx.Value(cacheObservationContextKey{}).(cacheObservationControl)
+	control.suppressAdmission = control.suppressAdmission || admission
+	control.suppressLookup = control.suppressLookup || lookup
+	return context.WithValue(ctx, cacheObservationContextKey{}, control)
+}
+
+func observeQueryCacheAdmission(ctx context.Context, decision dataquery.CacheAdmissionDecision, reason dataquery.CacheAdmissionReason) {
+	control, _ := ctx.Value(cacheObservationContextKey{}).(cacheObservationControl)
+	if control.suppressAdmission {
+		return
+	}
+	dataquery.ObserveCache(ctx, dataquery.CacheObservation{
+		Phase:           dataquery.CacheObservationAdmission,
+		Decision:        decision,
+		AdmissionReason: reason,
+	})
+}
+
 // dashboardQueryResultCacheable is deliberately explicit. API, CLI, agent,
 // preview, and unclassified calls must not populate the dashboard result cache
 // even if they happen to use an equivalent physical query shape.

--- a/internal/analytics/materialize/runtime_arrow_result.go
+++ b/internal/analytics/materialize/runtime_arrow_result.go
@@ -41,13 +41,33 @@ func rowPlanWithTotal(plan semanticquery.Plan) (semanticquery.Plan, error) {
 }
 
 func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dataquery.Query, transform dataquery.ResultTransformer) (dataquery.Result, error) {
+	cacheStarted := cacheObservationStarted(ctx, time.Now())
 	cacheable := dashboardQueryResultCacheable(request)
 	var planned plannedArrowQuery
 	var planErr error
+	admissionReason := dataquery.CacheAdmissionReasonQueryNotCacheable
+	if !cacheable {
+		observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionBypassed, admissionReason)
+	}
 	if cacheable {
 		planned, planErr = r.planOwnedArrowQuery(request)
 		if planErr == nil {
 			planned.dependency, planned.reusable = r.dependencyForPlan(planned.plan)
+		}
+		switch {
+		case planErr != nil:
+			admissionReason = dataquery.CacheAdmissionReasonPlanningFailed
+			observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionRejected, admissionReason)
+		case !planned.reusable:
+			admissionReason = dataquery.CacheAdmissionReasonDependencyUnavailable
+			observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionBypassed, admissionReason)
+		default:
+			admissionReason = queryCacheIdentityReason(request, r.resultPartition, planned.dependency)
+			decision := dataquery.CacheAdmissionBypassed
+			if admissionReason == dataquery.CacheAdmissionReasonEligible {
+				decision = dataquery.CacheAdmissionEligible
+			}
+			observeQueryCacheAdmission(ctx, decision, admissionReason)
 		}
 	}
 	execute := func(executionCtx context.Context) (arrowQueryExecution, error) {
@@ -125,8 +145,8 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 		// unsuccessful attempt as an execution failure. Preserve that public
 		// classification even though planning now precedes cache eligibility.
 		result = dataquery.Result{PlanningMS: planned.planningMS, ExecutionState: dataquery.ExecutionFailed}
-	} else if cacheable && planned.reusable && queryCacheIdentityAvailable(request, r.resultPartition, planned.dependency) {
-		result, err = r.queryCache.executeArrow(ctx, request, r.resultPartition, planned.dependency, planned.plan.SQL, execute)
+	} else if cacheable && admissionReason == dataquery.CacheAdmissionReasonEligible {
+		result, err = r.queryCache.executeArrow(ctx, request, r.resultPartition, planned.dependency, planned.plan.SQL, cacheStarted, execute)
 		observeQueryCacheOutcome(ctx, result, err)
 	} else {
 		execution, executeErr := execute(ctx)
@@ -147,10 +167,16 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 		if cacheable {
 			result.CacheOutcome = dataquery.CacheMiss
 			observeQueryCacheOutcome(ctx, result, err)
+			outcome := dataquery.CacheObservationMiss
+			if err != nil {
+				outcome = dataquery.CacheObservationError
+			}
+			observeTypedCacheFinal(ctx, outcome, time.Since(cacheStarted))
 		}
 	}
 	if planErr != nil && cacheable {
 		observeQueryCacheOutcome(ctx, result, err)
+		observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(cacheStarted))
 	}
 	if _, ok := dataquery.ResultLimitReasonOf(err); ok {
 		return dataquery.Result{Status: dataquery.StatusError, ExecutionState: dataquery.ExecutionFailed, Error: err.Error()}, err

--- a/internal/analytics/materialize/runtime_bundle_pipeline.go
+++ b/internal/analytics/materialize/runtime_bundle_pipeline.go
@@ -207,6 +207,7 @@ func (r *Runtime) resolveBundleCache(ctx context.Context, governed governedBundl
 		cached, address, hit, lookup, err := r.queryCache.lookupArrow(ctx, branch.Query, r.resultPartition, dependency, plan.Plan.SQL)
 		duration := time.Since(started)
 		if err != nil {
+			observePendingBundleCacheError(ctx, out)
 			observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionEligible, reason)
 			observeTypedCacheLookup(ctx, lookup, duration)
 			observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(cacheStarted))
@@ -229,9 +230,7 @@ func (r *Runtime) resolveBundleCache(ctx context.Context, governed governedBundl
 		out.misses = append(out.misses, branch)
 	}
 	if len(out.misses) > 1 {
-		for _, branch := range out.misses {
-			observeBundleCacheDecision(ctx, out.slots[branch.ID])
-		}
+		observeBundleCacheDecisions(ctx, out)
 	}
 	return out, nil
 }
@@ -251,6 +250,17 @@ func observeBundleCacheDecision(ctx context.Context, slot bundleCacheSlot) {
 	if slot.reusable && !slot.lookupObserved {
 		observeTypedCacheLookup(ctx, slot.lookup, slot.lookupDuration)
 	}
+}
+
+func observeBundleCacheDecisions(ctx context.Context, resolved resolvedBundle) {
+	for _, branch := range resolved.misses {
+		observeBundleCacheDecision(ctx, resolved.slots[branch.ID])
+	}
+}
+
+func observePendingBundleCacheError(ctx context.Context, resolved resolvedBundle) {
+	observeBundleCacheDecisions(ctx, resolved)
+	observeBundleFinal(ctx, resolved, dataquery.CacheObservationError)
 }
 
 func cachePlanningAdmissionReason(err error) dataquery.CacheAdmissionReason {

--- a/internal/analytics/materialize/runtime_bundle_pipeline.go
+++ b/internal/analytics/materialize/runtime_bundle_pipeline.go
@@ -3,6 +3,7 @@ package materialize
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -19,6 +20,7 @@ type bundleStage string
 const (
 	bundleStageGovern           bundleStage = "govern_validate"
 	bundleStagePlan             bundleStage = "plan"
+	bundleStagePlanCall         bundleStage = "plan_call"
 	bundleStageCache            bundleStage = "cache_resolve"
 	bundleStageExecute          bundleStage = "admit_execute"
 	bundleStageSplitStoreDecode bundleStage = "arrow_split_store_decode"
@@ -31,10 +33,14 @@ func withBundleStageObserver(ctx context.Context, observer func(bundleStage)) co
 	return context.WithValue(ctx, bundleStageObserverContextKey{}, observer)
 }
 
-func enterBundleStage(ctx context.Context, stage bundleStage) error {
+func observeBundleStage(ctx context.Context, stage bundleStage) {
 	if observer, ok := ctx.Value(bundleStageObserverContextKey{}).(func(bundleStage)); ok && observer != nil {
 		observer(stage)
 	}
+}
+
+func enterBundleStage(ctx context.Context, stage bundleStage) error {
+	observeBundleStage(ctx, stage)
 	return ctx.Err()
 }
 
@@ -45,9 +51,15 @@ type governedBundle struct {
 }
 
 type bundleCacheSlot struct {
-	key        string
-	generation uint64
-	reusable   bool
+	address          queryCacheAddress
+	reusable         bool
+	decision         dataquery.CacheAdmissionDecision
+	admissionReason  dataquery.CacheAdmissionReason
+	lookup           resultcache.LookupObservation
+	lookupDuration   time.Duration
+	started          time.Time
+	decisionObserved bool
+	lookupObserved   bool
 }
 
 type bundleFlightSlot struct {
@@ -95,11 +107,13 @@ func (r *Runtime) ExecuteDataQueryBundle(ctx context.Context, requests []dataque
 	if err != nil {
 		return dataquery.BundleResult{}, err
 	}
+	cacheStarted := cacheObservationStarted(ctx, time.Now())
 	preplanned, err := r.planGovernedBundle(ctx, governed)
 	if err != nil {
+		observeBundlePlanningFailure(ctx, governed, err, cacheStarted)
 		return dataquery.BundleResult{}, err
 	}
-	resolved, err := r.resolveBundleCache(ctx, governed, preplanned.plan)
+	resolved, err := r.resolveBundleCache(ctx, governed, preplanned.plan, cacheStarted)
 	if err != nil {
 		return dataquery.BundleResult{}, err
 	}
@@ -110,6 +124,7 @@ func (r *Runtime) ExecuteDataQueryBundle(ctx context.Context, requests []dataque
 	if len(resolved.misses) != len(governed.branches) {
 		planned, err = r.planBundle(ctx, resolved)
 		if err != nil {
+			observeBundleFinal(ctx, resolved, dataquery.CacheObservationError)
 			return dataquery.BundleResult{}, err
 		}
 	} else {
@@ -120,6 +135,7 @@ func (r *Runtime) ExecuteDataQueryBundle(ctx context.Context, requests []dataque
 	}
 	execution, shared, err := r.executePlannedBundle(ctx, planned)
 	if err != nil {
+		observeBundleFinal(ctx, planned.resolved, dataquery.CacheObservationError)
 		return finishBundle(ctx, planned.resolved, err)
 	}
 	return finishExecutedBundle(ctx, planned, execution, shared)
@@ -159,7 +175,7 @@ func (r *Runtime) governAndValidateBundle(ctx context.Context, requests []dataqu
 	return out, nil
 }
 
-func (r *Runtime) resolveBundleCache(ctx context.Context, governed governedBundle, plan semanticquery.BundlePlan) (resolvedBundle, error) {
+func (r *Runtime) resolveBundleCache(ctx context.Context, governed governedBundle, plan semanticquery.BundlePlan, cacheStarted time.Time) (resolvedBundle, error) {
 	if err := enterBundleStage(ctx, bundleStageCache); err != nil {
 		return resolvedBundle{}, err
 	}
@@ -171,27 +187,51 @@ func (r *Runtime) resolveBundleCache(ctx context.Context, governed governedBundl
 	for _, branch := range governed.branches {
 		projection, ok := projections[branch.ID]
 		if !ok {
-			out.slots[branch.ID] = bundleCacheSlot{}
+			out.slots[branch.ID] = bundleCacheSlot{decision: dataquery.CacheAdmissionBypassed, admissionReason: dataquery.CacheAdmissionReasonDependencyUnavailable, started: cacheStarted}
 			out.misses = append(out.misses, branch)
 			continue
 		}
 		dependency, reusable := r.dependencyForProjection(projection)
-		if !reusable || !queryCacheIdentityAvailable(branch.Query, r.resultPartition, dependency) {
-			out.slots[branch.ID] = bundleCacheSlot{}
+		if !reusable {
+			out.slots[branch.ID] = bundleCacheSlot{decision: dataquery.CacheAdmissionBypassed, admissionReason: dataquery.CacheAdmissionReasonDependencyUnavailable, started: cacheStarted}
 			out.misses = append(out.misses, branch)
 			continue
 		}
-		cached, key, generation, hit, err := r.queryCache.lookupArrow(ctx, branch.Query, r.resultPartition, dependency, plan.Plan.SQL)
+		reason := queryCacheIdentityReason(branch.Query, r.resultPartition, dependency)
+		if reason != dataquery.CacheAdmissionReasonEligible {
+			out.slots[branch.ID] = bundleCacheSlot{decision: dataquery.CacheAdmissionBypassed, admissionReason: reason, started: cacheStarted}
+			out.misses = append(out.misses, branch)
+			continue
+		}
+		started := time.Now()
+		cached, address, hit, lookup, err := r.queryCache.lookupArrow(ctx, branch.Query, r.resultPartition, dependency, plan.Plan.SQL)
+		duration := time.Since(started)
 		if err != nil {
+			observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionEligible, reason)
+			observeTypedCacheLookup(ctx, lookup, duration)
+			observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(cacheStarted))
 			return resolvedBundle{}, &dataquery.BundleBranchError{ID: branch.ID, Err: err}
 		}
 		if hit {
+			observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionEligible, reason)
+			observeTypedCacheLookup(ctx, lookup, duration)
+			observeTypedCacheFinalWithSource(ctx, dataquery.CacheObservationHit, lookup.HitSource, time.Since(cacheStarted))
 			dataquery.ObserveCacheOutcome(ctx, dataquery.CacheHit)
 			out.result.Results[branch.ID] = cached
 			continue
 		}
-		out.slots[branch.ID] = bundleCacheSlot{key: key, generation: generation, reusable: true}
+		observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionEligible, reason)
+		observeTypedCacheLookup(ctx, lookup, duration)
+		out.slots[branch.ID] = bundleCacheSlot{
+			address: address, reusable: true, decision: dataquery.CacheAdmissionEligible, admissionReason: reason,
+			lookup: lookup, lookupDuration: duration, started: cacheStarted, decisionObserved: true, lookupObserved: true,
+		}
 		out.misses = append(out.misses, branch)
+	}
+	if len(out.misses) > 1 {
+		for _, branch := range out.misses {
+			observeBundleCacheDecision(ctx, out.slots[branch.ID])
+		}
 	}
 	return out, nil
 }
@@ -204,12 +244,52 @@ func (r *Runtime) dependencyForProjection(projection semanticquery.DependencyPro
 	return dependency, err == nil
 }
 
+func observeBundleCacheDecision(ctx context.Context, slot bundleCacheSlot) {
+	if !slot.decisionObserved {
+		observeQueryCacheAdmission(ctx, slot.decision, slot.admissionReason)
+	}
+	if slot.reusable && !slot.lookupObserved {
+		observeTypedCacheLookup(ctx, slot.lookup, slot.lookupDuration)
+	}
+}
+
+func cachePlanningAdmissionReason(err error) dataquery.CacheAdmissionReason {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return dataquery.CacheAdmissionReasonCanceled
+	}
+	return dataquery.CacheAdmissionReasonPlanningFailed
+}
+
+func observeBundlePlanningFailure(ctx context.Context, governed governedBundle, err error, started time.Time) {
+	reason := cachePlanningAdmissionReason(err)
+	for range governed.branches {
+		observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionRejected, reason)
+		observeTypedCacheFinal(ctx, dataquery.CacheObservationError, time.Since(started))
+	}
+}
+
+func observeBundleFinal(ctx context.Context, resolved resolvedBundle, outcome dataquery.CacheObservationOutcome) {
+	for _, branch := range resolved.misses {
+		duration := time.Duration(0)
+		if started := resolved.slots[branch.ID].started; !started.IsZero() {
+			duration = time.Since(started)
+		}
+		observeTypedCacheFinal(ctx, outcome, duration)
+	}
+}
+
 func (r *Runtime) executeDegenerateBundle(ctx context.Context, resolved resolvedBundle) (dataquery.BundleResult, error) {
 	if len(resolved.misses) == 0 {
 		return finishBundle(ctx, resolved, nil)
 	}
 	branch := resolved.misses[0]
-	branchResult, err := r.ExecuteDataQuery(dataquery.WithGovernanceApplied(ctx), branch.Query)
+	branchCtx := dataquery.WithGovernanceApplied(ctx)
+	slot := resolved.slots[branch.ID]
+	if !slot.started.IsZero() {
+		branchCtx = withCacheObservationStarted(branchCtx, slot.started)
+	}
+	branchCtx = withCacheObservationSuppression(branchCtx, slot.decisionObserved, slot.lookupObserved)
+	branchResult, err := r.ExecuteDataQuery(branchCtx, branch.Query)
 	if err != nil {
 		_ = applyBundleTransforms(resolved, err)
 		return dataquery.BundleResult{}, &dataquery.BundleBranchError{ID: branch.ID, Err: err}
@@ -224,7 +304,7 @@ func (r *Runtime) executeDegenerateBundle(ctx context.Context, resolved resolved
 }
 
 func (r *Runtime) planBundle(ctx context.Context, resolved resolvedBundle) (plannedBundle, error) {
-	planned, err := r.compileBundle(resolved.misses)
+	planned, err := r.compileBundle(ctx, resolved.misses)
 	if err != nil {
 		return plannedBundle{}, err
 	}
@@ -235,10 +315,10 @@ func (r *Runtime) planGovernedBundle(ctx context.Context, governed governedBundl
 	if err := enterBundleStage(ctx, bundleStagePlan); err != nil {
 		return plannedBundle{}, err
 	}
-	return r.compileBundle(governed.branches)
+	return r.compileBundle(ctx, governed.branches)
 }
 
-func (r *Runtime) compileBundle(branches []dataquery.BundleRequest) (plannedBundle, error) {
+func (r *Runtime) compileBundle(ctx context.Context, branches []dataquery.BundleRequest) (plannedBundle, error) {
 	semanticRequests := make([]semanticquery.BundleRequest, len(branches))
 	for index, branch := range branches {
 		request := branch.Query
@@ -249,8 +329,12 @@ func (r *Runtime) compileBundle(branches []dataquery.BundleRequest) (plannedBund
 	if err != nil {
 		return plannedBundle{}, err
 	}
+	observeBundleStage(ctx, bundleStagePlanCall)
 	plan, err := planner.PlanBundle(semanticRequests)
 	planningMS := elapsedStageMS(started)
+	if contextErr := ctx.Err(); contextErr != nil {
+		return plannedBundle{}, contextErr
+	}
 	if err != nil {
 		return plannedBundle{}, &dataquery.BundleIncompatibleError{Err: err}
 	}
@@ -266,7 +350,7 @@ func bindResolvedBundle(planned plannedBundle, resolved resolvedBundle) (planned
 			planned.flightKey = ""
 			return planned, nil
 		}
-		identity = append(identity, bundleFlightSlot{ID: branch.ID, Key: slot.key, Generation: slot.generation})
+		identity = append(identity, bundleFlightSlot{ID: branch.ID, Key: slot.address.key, Generation: slot.address.generation})
 	}
 	encoded, err := json.Marshal(identity)
 	if err != nil {
@@ -405,7 +489,9 @@ func (r *Runtime) splitStoreDecodeBundle(ctx context.Context, planned plannedBun
 		if !slot.reusable {
 			continue
 		}
-		r.queryCache.scope.StoreArrow(slot.key, resultcache.Token(slot.generation), branches[request.ID], resultcache.Metadata{})
+		started := time.Now()
+		outcome := r.queryCache.scope.StoreArrowObserved(slot.address.key, slot.address.family, resultcache.Token(slot.address.generation), branches[request.ID], resultcache.Metadata{})
+		dataquery.ObserveCache(ctx, dataquery.CacheObservation{Phase: dataquery.CacheObservationStore, StoreOutcome: dataquery.CacheStoreOutcome(outcome), Duration: time.Since(started)})
 	}
 	r.queryCache.syncStats()
 	return execution, nil
@@ -421,6 +507,11 @@ func finishExecutedBundle(ctx context.Context, planned plannedBundle, execution 
 			branchResult.CacheOutcome = dataquery.CacheCoalesced
 		}
 		dataquery.ObserveCacheOutcome(ctx, branchResult.CacheOutcome)
+		duration := time.Duration(0)
+		if started := resolved.slots[branch.ID].started; !started.IsZero() {
+			duration = time.Since(started)
+		}
+		observeTypedCacheFinal(ctx, dataquery.CacheObservationOutcome(branchResult.CacheOutcome), duration)
 		resolved.result.Results[branch.ID] = branchResult
 	}
 	return finishBundle(ctx, resolved, nil)

--- a/internal/analytics/materialize/runtime_bundle_pipeline_test.go
+++ b/internal/analytics/materialize/runtime_bundle_pipeline_test.go
@@ -42,6 +42,95 @@ func TestBundlePipelineCancellationBoundariesReleaseArrowOwnership(t *testing.T)
 	}
 }
 
+func TestBundlePlanningCancellationEmitsCanceledAdmission(t *testing.T) {
+	runtime := bundleCacheRuntime(t, &bundleCountingDatabase{})
+	defer runtime.CloseView()
+	observations := []dataquery.CacheObservation{}
+	ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) {
+		observations = append(observations, observation)
+	})
+	ctx, cancel := context.WithCancel(ctx)
+	ctx = withBundleStageObserver(ctx, func(stage bundleStage) {
+		if stage == bundleStagePlan {
+			cancel()
+		}
+	})
+
+	_, err := runtime.ExecuteDataQueryBundle(ctx, bundleCacheRequests())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, len(bundleCacheRequests()), countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission &&
+			observation.Decision == dataquery.CacheAdmissionRejected &&
+			observation.AdmissionReason == dataquery.CacheAdmissionReasonCanceled
+	}))
+	require.Zero(t, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission && observation.AdmissionReason == dataquery.CacheAdmissionReasonPlanningFailed
+	}))
+}
+
+func TestBundlePlanningCancellationDuringPlannerCallEmitsCanceledAdmission(t *testing.T) {
+	runtime := bundleCacheRuntime(t, &bundleCountingDatabase{})
+	defer runtime.CloseView()
+	observations := []dataquery.CacheObservation{}
+	ctx := dataquery.WithCacheObserver(context.Background(), func(observation dataquery.CacheObservation) {
+		observations = append(observations, observation)
+	})
+	ctx, cancel := context.WithCancel(ctx)
+	planningStarted := make(chan struct{})
+	releasePlanning := make(chan struct{})
+	defer func() {
+		select {
+		case <-releasePlanning:
+		default:
+			close(releasePlanning)
+		}
+	}()
+	ctx = withBundleStageObserver(ctx, func(stage bundleStage) {
+		if stage == bundleStagePlanCall {
+			close(planningStarted)
+			<-releasePlanning
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := runtime.ExecuteDataQueryBundle(ctx, bundleCacheRequests())
+		done <- err
+	}()
+	select {
+	case <-planningStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for bundle planner call")
+	}
+	cancel()
+	close(releasePlanning)
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.Equal(t, len(bundleCacheRequests()), countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission &&
+			observation.Decision == dataquery.CacheAdmissionRejected &&
+			observation.AdmissionReason == dataquery.CacheAdmissionReasonCanceled
+	}))
+	require.Zero(t, countCacheObservations(observations, func(observation dataquery.CacheObservation) bool {
+		return observation.Phase == dataquery.CacheObservationAdmission && observation.AdmissionReason == dataquery.CacheAdmissionReasonPlanningFailed
+	}))
+}
+
+func TestCachePlanningAdmissionReasonDistinguishesCancellation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		want dataquery.CacheAdmissionReason
+	}{
+		{name: "canceled", err: context.Canceled, want: dataquery.CacheAdmissionReasonCanceled},
+		{name: "deadline", err: context.DeadlineExceeded, want: dataquery.CacheAdmissionReasonCanceled},
+		{name: "planner", err: errors.New("planner failed"), want: dataquery.CacheAdmissionReasonPlanningFailed},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, cachePlanningAdmissionReason(test.err))
+		})
+	}
+}
+
 func TestBundlePipelineTransformFailureIsBranchAttributedAndReleasesArrowOwnership(t *testing.T) {
 	database := &bundleCountingDatabase{}
 	runtime := bundleCacheRuntime(t, database)

--- a/internal/analytics/module/metrics.go
+++ b/internal/analytics/module/metrics.go
@@ -8,14 +8,17 @@ import (
 )
 
 type Collector struct {
-	database                                                   *analyticsducklake.Environment
-	cache                                                      *resultcache.Pool
-	connectionsOpen, connectionsActive, connectionsIdle        *prometheus.Desc
-	cacheEntries, cacheBytes, cacheEvictions, cacheStores      *prometheus.Desc
-	arrowResults, arrowLeases, arrowBytes, arrowTransientBytes *prometheus.Desc
-	connectionAcquisitions, extensionInitializations           *prometheus.Desc
-	sourceAcquisitions, scopeContention, commitRetries         *prometheus.Desc
-	refreshCleanup, fatalHealth                                *prometheus.Desc
+	database                                                                                *analyticsducklake.Environment
+	cache                                                                                   *resultcache.Pool
+	connectionsOpen, connectionsActive, connectionsIdle                                     *prometheus.Desc
+	cacheEntries, cacheBytes, cacheEvictions, cacheStores                                   *prometheus.Desc
+	stableScopes, stableEntries, stableBytes, stableArrowHolds                              *prometheus.Desc
+	generationScopes, generationByteEntries, generationByteBytes                            *prometheus.Desc
+	cacheInvalidations, cacheInvalidatedEntries, cacheClassEvictions, cacheScopeTransitions *prometheus.Desc
+	arrowResults, arrowLeases, arrowBytes, arrowTransientBytes                              *prometheus.Desc
+	connectionAcquisitions, extensionInitializations                                        *prometheus.Desc
+	sourceAcquisitions, scopeContention, commitRetries                                      *prometheus.Desc
+	refreshCleanup, fatalHealth                                                             *prometheus.Desc
 }
 
 func NewCollector(database *analyticsducklake.Environment, cache *resultcache.Pool) *Collector {
@@ -33,6 +36,17 @@ func NewCollector(database *analyticsducklake.Environment, cache *resultcache.Po
 		arrowTransientBytes:      prometheus.NewDesc("leapview_arrow_transient_bytes", "Transient bytes retained while materializing owned Arrow analytical results.", nil, nil),
 		cacheEvictions:           prometheus.NewDesc("leapview_query_cache_evictions_total", "Query-result cache evictions by limiting constraint.", []string{"constraint"}, nil),
 		cacheStores:              prometheus.NewDesc("leapview_query_cache_store_total", "Query-result cache store outcomes.", []string{"outcome"}, nil),
+		stableScopes:             prometheus.NewDesc("leapview_query_result_cache_scopes", "Stable partition result-cache scopes by lifecycle state.", []string{"state"}, nil),
+		stableEntries:            prometheus.NewDesc("leapview_query_result_cache_entries", "Arrow entries retained in stable partition result-cache scopes.", nil, nil),
+		stableBytes:              prometheus.NewDesc("leapview_query_result_cache_bytes", "Conservatively retained bytes in stable partition result-cache scopes.", nil, nil),
+		stableArrowHolds:         prometheus.NewDesc("leapview_query_result_cache_arrow_holds", "Cache-owned Arrow holds retained in stable partition result-cache scopes.", nil, nil),
+		generationScopes:         prometheus.NewDesc("leapview_generation_cache_scopes", "Generation-owned immutable-byte cache scopes.", nil, nil),
+		generationByteEntries:    prometheus.NewDesc("leapview_generation_byte_cache_entries", "Immutable-byte entries retained in generation-owned scopes.", nil, nil),
+		generationByteBytes:      prometheus.NewDesc("leapview_generation_byte_cache_bytes", "Bytes retained by immutable-byte entries in generation-owned scopes.", nil, nil),
+		cacheInvalidations:       prometheus.NewDesc("leapview_cache_invalidations_total", "Cache invalidation operations by fixed cache class.", []string{"cache"}, nil),
+		cacheInvalidatedEntries:  prometheus.NewDesc("leapview_cache_invalidated_entries_total", "Entries removed by cache invalidation by fixed cache class.", []string{"cache"}, nil),
+		cacheClassEvictions:      prometheus.NewDesc("leapview_cache_evicted_entries_total", "Cache evictions by fixed cache class and limiting constraint.", []string{"cache", "constraint"}, nil),
+		cacheScopeTransitions:    prometheus.NewDesc("leapview_query_result_cache_scope_transitions_total", "Stable result-cache scope lifecycle transitions.", []string{"transition"}, nil),
 		connectionAcquisitions:   prometheus.NewDesc("leapview_duckdb_connection_acquisitions_total", "Admitted analytical connection acquisitions.", nil, nil),
 		extensionInitializations: prometheus.NewDesc("leapview_duckdb_extension_initializations_total", "Approved extension initialization outcomes.", []string{"outcome"}, nil),
 		sourceAcquisitions:       prometheus.NewDesc("leapview_duckdb_source_acquisitions_total", "Refresh-only source acquisition outcomes.", []string{"connector", "outcome"}, nil),
@@ -44,7 +58,7 @@ func NewCollector(database *analyticsducklake.Environment, cache *resultcache.Po
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
-	for _, description := range []*prometheus.Desc{c.connectionsOpen, c.connectionsActive, c.connectionsIdle, c.cacheEntries, c.cacheBytes, c.cacheEvictions, c.cacheStores, c.arrowResults, c.arrowLeases, c.arrowBytes, c.arrowTransientBytes, c.connectionAcquisitions, c.extensionInitializations, c.sourceAcquisitions, c.scopeContention, c.commitRetries, c.refreshCleanup, c.fatalHealth} {
+	for _, description := range []*prometheus.Desc{c.connectionsOpen, c.connectionsActive, c.connectionsIdle, c.cacheEntries, c.cacheBytes, c.cacheEvictions, c.cacheStores, c.stableScopes, c.stableEntries, c.stableBytes, c.stableArrowHolds, c.generationScopes, c.generationByteEntries, c.generationByteBytes, c.cacheInvalidations, c.cacheInvalidatedEntries, c.cacheClassEvictions, c.cacheScopeTransitions, c.arrowResults, c.arrowLeases, c.arrowBytes, c.arrowTransientBytes, c.connectionAcquisitions, c.extensionInitializations, c.sourceAcquisitions, c.scopeContention, c.commitRetries, c.refreshCleanup, c.fatalHealth} {
 		ch <- description
 	}
 }
@@ -97,6 +111,24 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		}
 		for _, outcome := range []resultcache.StoreOutcome{resultcache.StoreStored, resultcache.StoreOversized, resultcache.StoreStale, resultcache.StoreClosed} {
 			ch <- prometheus.MustNewConstMetric(c.cacheStores, prometheus.CounterValue, float64(stats.Stores[outcome]), string(outcome))
+		}
+		ch <- prometheus.MustNewConstMetric(c.stableScopes, prometheus.GaugeValue, float64(stats.Stable.ActiveScopes), "active")
+		ch <- prometheus.MustNewConstMetric(c.stableScopes, prometheus.GaugeValue, float64(stats.Stable.DormantScopes), "dormant")
+		ch <- prometheus.MustNewConstMetric(c.stableEntries, prometheus.GaugeValue, float64(stats.Stable.Entries))
+		ch <- prometheus.MustNewConstMetric(c.stableBytes, prometheus.GaugeValue, float64(stats.Stable.Bytes))
+		ch <- prometheus.MustNewConstMetric(c.stableArrowHolds, prometheus.GaugeValue, float64(stats.Stable.ArrowHolds))
+		ch <- prometheus.MustNewConstMetric(c.generationScopes, prometheus.GaugeValue, float64(stats.Generation.Scopes))
+		ch <- prometheus.MustNewConstMetric(c.generationByteEntries, prometheus.GaugeValue, float64(stats.Generation.ByteEntries))
+		ch <- prometheus.MustNewConstMetric(c.generationByteBytes, prometheus.GaugeValue, float64(stats.Generation.ByteBytes))
+		for _, class := range []resultcache.CacheClass{resultcache.CacheClassStableResult, resultcache.CacheClassGenerationByte} {
+			ch <- prometheus.MustNewConstMetric(c.cacheInvalidations, prometheus.CounterValue, float64(stats.Invalidations[class]), string(class))
+			ch <- prometheus.MustNewConstMetric(c.cacheInvalidatedEntries, prometheus.CounterValue, float64(stats.InvalidatedEntries[class]), string(class))
+			for _, constraint := range []resultcache.Constraint{resultcache.ConstraintRuntime, resultcache.ConstraintNode} {
+				ch <- prometheus.MustNewConstMetric(c.cacheClassEvictions, prometheus.CounterValue, float64(stats.ClassEvictions[class][constraint]), string(class), string(constraint))
+			}
+		}
+		for _, transition := range []resultcache.ScopeTransition{resultcache.ScopeTransitionCreated, resultcache.ScopeTransitionDormant, resultcache.ScopeTransitionReactivated, resultcache.ScopeTransitionRemoved} {
+			ch <- prometheus.MustNewConstMetric(c.cacheScopeTransitions, prometheus.CounterValue, float64(stats.ScopeTransitions[transition]), string(transition))
 		}
 	}
 }

--- a/internal/analytics/module/metrics_test.go
+++ b/internal/analytics/module/metrics_test.go
@@ -204,3 +204,59 @@ func TestAnalyticalCollectorExportsZeroProcessConnectionsWithoutProcessEnvironme
 	}
 	t.Fatal("leapview_duckdb_connections_open metric missing")
 }
+
+func TestAnalyticalCollectorExportsCacheLifecycleWithoutScopeIdentity(t *testing.T) {
+	cache, err := resultcache.New(resultcache.Limits{RuntimeEntries: 2, RuntimeBytes: 1024, NodeEntries: 4, NodeBytes: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cache.Close()
+	secret := "project-principal-query-secret"
+	stable, err := cache.OpenSharedScope(resultcache.ScopeID{RuntimeID: secret})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stable.Close()
+	generation, err := cache.OpenScope(resultcache.ScopeID{RuntimeID: secret + "-generation"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer generation.Close()
+	if outcome := generation.StoreBytes(secret, generation.Generation(), []byte("tile")); outcome != resultcache.StoreStored {
+		t.Fatalf("store bytes = %q", outcome)
+	}
+	stable.Invalidate()
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(NewCollector(nil, cache))
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{
+		"leapview_query_result_cache_scopes":                  false,
+		"leapview_query_result_cache_entries":                 false,
+		"leapview_query_result_cache_bytes":                   false,
+		"leapview_query_result_cache_arrow_holds":             false,
+		"leapview_generation_cache_scopes":                    false,
+		"leapview_generation_byte_cache_entries":              false,
+		"leapview_generation_byte_cache_bytes":                false,
+		"leapview_cache_invalidations_total":                  false,
+		"leapview_cache_invalidated_entries_total":            false,
+		"leapview_cache_evicted_entries_total":                false,
+		"leapview_query_result_cache_scope_transitions_total": false,
+	}
+	for _, family := range families {
+		if strings.Contains(family.String(), secret) {
+			t.Fatalf("metric %s exposed scope or cache identity", family.GetName())
+		}
+		if _, ok := want[family.GetName()]; ok {
+			want[family.GetName()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Fatalf("metric %s missing", name)
+		}
+	}
+}

--- a/internal/analytics/resultcache/execution_scope.go
+++ b/internal/analytics/resultcache/execution_scope.go
@@ -217,7 +217,7 @@ func (s *ExecutionScope) CoalesceArrow(ctx context.Context, key string, execute 
 		if acquireErr != nil {
 			return nil, ArrowFlightStatus{Owner: owner, Shared: shared}, acquireErr
 		}
-		return &ArrowFlightLease{data: lease, metadata: cloneMetadata(value.Metadata), cached: value.Cached}, ArrowFlightStatus{Owner: owner, Shared: shared}, nil
+		return &ArrowFlightLease{data: lease, metadata: cloneMetadata(value.Metadata), cached: value.Cached, hitSource: value.HitSource}, ArrowFlightStatus{Owner: owner, Shared: shared}, nil
 	}
 }
 

--- a/internal/analytics/resultcache/pool.go
+++ b/internal/analytics/resultcache/pool.go
@@ -4,6 +4,7 @@ package resultcache
 
 import (
 	"container/list"
+	"crypto/sha256"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,50 @@ const (
 	StoreOversized StoreOutcome = "oversized"
 	StoreStale     StoreOutcome = "stale"
 	StoreClosed    StoreOutcome = "closed"
+)
+
+// QueryFamily is an opaque, process-local projection used only to classify an
+// exact-key miss as a canonical-query mismatch. It never participates in the
+// serialized cache key and is never exported as telemetry.
+type QueryFamily [sha256.Size]byte
+
+type LookupMissReason string
+
+const (
+	LookupMissColdStart     LookupMissReason = "cold_start"
+	LookupMissAbsentEntry   LookupMissReason = "absent_entry"
+	LookupMissQueryMismatch LookupMissReason = "query_mismatch"
+	LookupMissInvalidated   LookupMissReason = "invalidated"
+	LookupMissEvicted       LookupMissReason = "evicted"
+)
+
+type HitSource string
+
+const (
+	HitCurrentGeneration HitSource = "current_generation"
+	HitSharedGeneration  HitSource = "shared_generation"
+	HitCutoverRetained   HitSource = "cutover_retained"
+)
+
+type LookupObservation struct {
+	MissReason LookupMissReason
+	HitSource  HitSource
+}
+
+type CacheClass string
+
+const (
+	CacheClassStableResult   CacheClass = "stable_result"
+	CacheClassGenerationByte CacheClass = "generation_byte"
+)
+
+type ScopeTransition string
+
+const (
+	ScopeTransitionCreated     ScopeTransition = "created"
+	ScopeTransitionDormant     ScopeTransition = "dormant"
+	ScopeTransitionReactivated ScopeTransition = "reactivated"
+	ScopeTransitionRemoved     ScopeTransition = "removed"
 )
 
 type Limits struct {
@@ -56,30 +101,43 @@ type ScopeProvider interface {
 }
 
 type Pool struct {
-	mu        sync.Mutex
-	limits    Limits
-	closed    bool
-	entries   map[string]*list.Element
-	lru       *list.List
-	scopes    map[string]*scopeState
-	bytes     int64
-	evictions map[Constraint]uint64
-	stores    map[StoreOutcome]uint64
+	mu                  sync.Mutex
+	limits              Limits
+	closed              bool
+	entries             map[string]*list.Element
+	lru                 *list.List
+	scopes              map[string]*scopeState
+	bytes               int64
+	evictions           map[Constraint]uint64
+	stores              map[StoreOutcome]uint64
+	invalidations       map[CacheClass]uint64
+	invalidatedEntries  map[CacheClass]uint64
+	classEvictions      map[CacheClass]map[Constraint]uint64
+	scopeTransitions    map[ScopeTransition]uint64
+	removalHistory      map[[sha256.Size]byte]*list.Element
+	removalOrder        *list.List
+	removalHistoryLimit int
+	nextHandleID        uint64
 }
 
 type Scope struct {
-	pool   *Pool
-	key    string
-	closed atomic.Bool
+	pool       *Pool
+	key        string
+	handleID   uint64
+	activation uint64
+	closed     atomic.Bool
 }
 type scopeState struct {
-	id         ScopeID
-	generation Token
-	closed     bool
-	shared     bool
-	references int
-	entries    map[string]struct{}
-	usage      usage
+	id              ScopeID
+	generation      Token
+	closed          bool
+	shared          bool
+	references      int
+	entries         map[string]struct{}
+	queryFamilies   map[QueryFamily]int
+	everStoredArrow bool
+	activation      uint64
+	usage           usage
 }
 type usage struct {
 	entries int
@@ -92,6 +150,14 @@ type entry struct {
 	byteValue             []byte
 	metadata              Metadata
 	bytes                 int64
+	family                QueryFamily
+	writerHandle          uint64
+	writerActivation      uint64
+}
+
+type removalRecord struct {
+	digest [sha256.Size]byte
+	reason LookupMissReason
 }
 
 // Metadata is stable result information that may be retained across requests.
@@ -112,9 +178,10 @@ type EntryLease struct {
 // coalescer releases it after every registered caller has either acquired an
 // independent sibling lease or canceled.
 type ArrowFlightValue struct {
-	Data     *arrowresult.Lease
-	Metadata Metadata
-	Cached   bool
+	Data      *arrowresult.Lease
+	Metadata  Metadata
+	Cached    bool
+	HitSource HitSource
 }
 
 type ArrowFlightStatus struct {
@@ -123,9 +190,10 @@ type ArrowFlightStatus struct {
 }
 
 type ArrowFlightLease struct {
-	data     *arrowresult.Lease
-	metadata Metadata
-	cached   bool
+	data      *arrowresult.Lease
+	metadata  Metadata
+	cached    bool
+	hitSource HitSource
 }
 
 func (l *ArrowFlightLease) Data() *arrowresult.Lease {
@@ -144,6 +212,13 @@ func (l *ArrowFlightLease) Metadata() Metadata {
 
 func (l *ArrowFlightLease) Cached() bool {
 	return l != nil && l.cached
+}
+
+func (l *ArrowFlightLease) HitSource() HitSource {
+	if l == nil {
+		return ""
+	}
+	return l.hitSource
 }
 
 func (l *ArrowFlightLease) Release() {
@@ -200,18 +275,45 @@ func (s *Scope) Stats() UsageSnapshot {
 }
 
 type Snapshot struct {
-	Entries   int
-	Bytes     int64
-	Scopes    map[string]ScopeSnapshot
-	Evictions map[Constraint]uint64
-	Stores    map[StoreOutcome]uint64
+	Entries            int
+	Bytes              int64
+	Scopes             map[string]ScopeSnapshot
+	Evictions          map[Constraint]uint64
+	Stores             map[StoreOutcome]uint64
+	Stable             StableSnapshot
+	Generation         GenerationSnapshot
+	Invalidations      map[CacheClass]uint64
+	InvalidatedEntries map[CacheClass]uint64
+	ClassEvictions     map[CacheClass]map[Constraint]uint64
+	ScopeTransitions   map[ScopeTransition]uint64
+}
+
+type StableSnapshot struct {
+	ActiveScopes  int
+	DormantScopes int
+	Entries       int
+	Bytes         int64
+	ArrowHolds    int
+}
+
+type GenerationSnapshot struct {
+	Scopes      int
+	ByteEntries int
+	ByteBytes   int64
 }
 
 func New(limits Limits) (*Pool, error) {
 	if err := limits.Validate(); err != nil {
 		return nil, err
 	}
-	return &Pool{limits: limits, entries: map[string]*list.Element{}, lru: list.New(), scopes: map[string]*scopeState{}, evictions: map[Constraint]uint64{}, stores: map[StoreOutcome]uint64{}}, nil
+	removalHistoryLimit := min(limits.NodeEntries, 4096)
+	return &Pool{
+		limits: limits, entries: map[string]*list.Element{}, lru: list.New(), scopes: map[string]*scopeState{},
+		evictions: map[Constraint]uint64{}, stores: map[StoreOutcome]uint64{},
+		invalidations: map[CacheClass]uint64{}, invalidatedEntries: map[CacheClass]uint64{},
+		classEvictions: map[CacheClass]map[Constraint]uint64{}, scopeTransitions: map[ScopeTransition]uint64{},
+		removalHistory: map[[sha256.Size]byte]*list.Element{}, removalOrder: list.New(), removalHistoryLimit: removalHistoryLimit,
+	}, nil
 }
 
 func (p *Pool) OpenScope(id ScopeID) (*Scope, error) {
@@ -230,8 +332,9 @@ func (p *Pool) OpenScope(id ScopeID) (*Scope, error) {
 	if existing := p.scopes[key]; existing != nil && !existing.closed {
 		return nil, fmt.Errorf("result cache scope already exists")
 	}
-	p.scopes[key] = &scopeState{id: id, references: 1, entries: map[string]struct{}{}}
-	return &Scope{pool: p, key: key}, nil
+	p.nextHandleID++
+	p.scopes[key] = &scopeState{id: id, references: 1, entries: map[string]struct{}{}, queryFamilies: map[QueryFamily]int{}, activation: 1}
+	return &Scope{pool: p, key: key, handleID: p.nextHandleID, activation: 1}, nil
 }
 
 // OpenSharedScope acquires one handle to a stable cache scope. All live
@@ -255,11 +358,21 @@ func (p *Pool) OpenSharedScope(id ScopeID) (*Scope, error) {
 		if !existing.shared {
 			return nil, fmt.Errorf("result cache scope already exists")
 		}
+		cutover := existing.references == 0
+		if cutover {
+			existing.activation++
+		}
 		existing.references++
-		return &Scope{pool: p, key: key}, nil
+		p.nextHandleID++
+		if cutover {
+			p.scopeTransitions[ScopeTransitionReactivated]++
+		}
+		return &Scope{pool: p, key: key, handleID: p.nextHandleID, activation: existing.activation}, nil
 	}
-	p.scopes[key] = &scopeState{id: id, shared: true, references: 1, entries: map[string]struct{}{}}
-	return &Scope{pool: p, key: key}, nil
+	p.nextHandleID++
+	p.scopes[key] = &scopeState{id: id, shared: true, references: 1, entries: map[string]struct{}{}, queryFamilies: map[QueryFamily]int{}, activation: 1}
+	p.scopeTransitions[ScopeTransitionCreated]++
+	return &Scope{pool: p, key: key, handleID: p.nextHandleID, activation: 1}, nil
 }
 
 func (s *Scope) openStateLocked() *scopeState {
@@ -288,30 +401,46 @@ func (s *Scope) Generation() Token {
 // LookupArrow returns an independently retained lease. Eviction, invalidation,
 // or scope closure can remove the cache's reference without invalidating it.
 func (s *Scope) LookupArrow(key string) (*EntryLease, Token, bool, error) {
+	lease, token, hit, _, err := s.LookupArrowObserved(key, QueryFamily{})
+	return lease, token, hit, err
+}
+
+// LookupArrowObserved returns the cache lookup classification without exposing
+// the key or family through telemetry. The family is only compared while the
+// pool mutex is held.
+func (s *Scope) LookupArrowObserved(key string, family QueryFamily) (*EntryLease, Token, bool, LookupObservation, error) {
 	if s == nil || s.pool == nil {
-		return nil, 0, false, fmt.Errorf("result cache scope is required")
+		return nil, 0, false, LookupObservation{}, fmt.Errorf("result cache scope is required")
 	}
 	p := s.pool
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	state := s.openStateLocked()
 	if state == nil {
-		return nil, 0, false, fmt.Errorf("result cache scope is closed")
+		return nil, 0, false, LookupObservation{}, fmt.Errorf("result cache scope is closed")
 	}
-	element := p.entries[s.key+"\x00"+key]
+	composite := s.key + "\x00" + key
+	element := p.entries[composite]
 	if element == nil {
-		return nil, state.generation, false, nil
+		return nil, state.generation, false, LookupObservation{MissReason: p.lookupMissReasonLocked(state, composite, family)}, nil
 	}
 	e := element.Value.(entry)
 	if e.arrowResult == nil {
-		return nil, state.generation, false, nil
+		return nil, state.generation, false, LookupObservation{MissReason: p.lookupMissReasonLocked(state, composite, family)}, nil
 	}
 	lease, err := e.arrowResult.Acquire()
 	if err != nil {
-		return nil, state.generation, false, err
+		return nil, state.generation, false, LookupObservation{}, err
 	}
 	p.lru.MoveToFront(element)
-	return &EntryLease{data: lease, metadata: cloneMetadata(e.metadata)}, state.generation, true, nil
+	source := HitCurrentGeneration
+	if e.writerHandle != s.handleID {
+		source = HitSharedGeneration
+		if e.writerActivation < s.activation {
+			source = HitCutoverRetained
+		}
+	}
+	return &EntryLease{data: lease, metadata: cloneMetadata(e.metadata)}, state.generation, true, LookupObservation{HitSource: source}, nil
 }
 
 // LookupBytes returns a copy of an immutable byte entry. Callers can mutate
@@ -342,6 +471,10 @@ func (s *Scope) LookupBytes(key string) ([]byte, Token, bool, error) {
 // StoreArrow retains one cache-owned reference when the value fits every
 // applicable budget. The caller retains ownership of its original reference.
 func (s *Scope) StoreArrow(key string, token Token, result *arrowresult.Result, metadata Metadata) StoreOutcome {
+	return s.StoreArrowObserved(key, QueryFamily{}, token, result, metadata)
+}
+
+func (s *Scope) StoreArrowObserved(key string, family QueryFamily, token Token, result *arrowresult.Result, metadata Metadata) StoreOutcome {
 	if s == nil || s.pool == nil || result == nil {
 		return StoreClosed
 	}
@@ -369,12 +502,15 @@ func (s *Scope) StoreArrow(key string, token Token, result *arrowresult.Result, 
 	}
 	composite := s.key + "\x00" + key
 	if old := p.entries[composite]; old != nil {
-		p.removeLocked(old, "")
+		p.removeLocked(old, "", "")
 	}
-	e := entry{composite: composite, key: key, scope: s.key, arrowResult: result, arrowHold: hold, metadata: cloneMetadata(metadata), bytes: bytes}
+	p.forgetRemovalLocked(composite)
+	e := entry{composite: composite, key: key, scope: s.key, arrowResult: result, arrowHold: hold, metadata: cloneMetadata(metadata), bytes: bytes, family: family, writerHandle: s.handleID, writerActivation: s.activation}
 	element := p.lru.PushFront(e)
 	p.entries[composite] = element
 	state.entries[composite] = struct{}{}
+	state.queryFamilies[family]++
+	state.everStoredArrow = true
 	state.usage.entries++
 	state.usage.bytes += bytes
 	p.bytes += bytes
@@ -408,7 +544,7 @@ func (s *Scope) StoreBytes(key string, token Token, value []byte) StoreOutcome {
 	}
 	composite := s.key + "\x00" + key
 	if old := p.entries[composite]; old != nil {
-		p.removeLocked(old, "")
+		p.removeLocked(old, "", "")
 	}
 	stored := make([]byte, len(value))
 	copy(stored, value)
@@ -435,15 +571,15 @@ func (s *Scope) Delete(key string) {
 	if state == nil {
 		return
 	}
-	p.removeLocked(p.entries[s.key+"\x00"+key], "")
+	p.removeLocked(p.entries[s.key+"\x00"+key], "", "")
 }
 
 func (p *Pool) enforceLocked(state *scopeState) {
 	for state.usage.entries > p.limits.RuntimeEntries || state.usage.bytes > p.limits.RuntimeBytes {
-		p.removeLocked(p.oldestLocked(func(e entry) bool { return e.scope == scopeKey(state.id) }), ConstraintRuntime)
+		p.removeLocked(p.oldestLocked(func(e entry) bool { return e.scope == scopeKey(state.id) }), ConstraintRuntime, LookupMissEvicted)
 	}
 	for len(p.entries) > p.limits.NodeEntries || p.bytes > p.limits.NodeBytes {
-		p.removeLocked(p.lru.Back(), ConstraintNode)
+		p.removeLocked(p.lru.Back(), ConstraintNode, LookupMissEvicted)
 	}
 }
 
@@ -455,7 +591,7 @@ func (p *Pool) oldestLocked(match func(entry) bool) *list.Element {
 	}
 	return nil
 }
-func (p *Pool) removeLocked(element *list.Element, constraint Constraint) {
+func (p *Pool) removeLocked(element *list.Element, constraint Constraint, reason LookupMissReason) {
 	if element == nil {
 		return
 	}
@@ -469,12 +605,26 @@ func (p *Pool) removeLocked(element *list.Element, constraint Constraint) {
 	p.bytes -= e.bytes
 	if state != nil {
 		delete(state.entries, e.composite)
+		if e.arrowResult != nil {
+			state.queryFamilies[e.family]--
+			if state.queryFamilies[e.family] == 0 {
+				delete(state.queryFamilies, e.family)
+			}
+		}
 		state.usage.entries--
 		state.usage.bytes -= e.bytes
 		p.removeEmptyDormantScopeLocked(state)
 	}
 	if constraint != "" {
 		p.evictions[constraint]++
+		class := cacheClassOf(state, e)
+		if p.classEvictions[class] == nil {
+			p.classEvictions[class] = map[Constraint]uint64{}
+		}
+		p.classEvictions[class][constraint]++
+	}
+	if e.arrowResult != nil && (reason == LookupMissEvicted || reason == LookupMissInvalidated) {
+		p.rememberRemovalLocked(e.composite, reason)
 	}
 }
 
@@ -484,6 +634,57 @@ func (p *Pool) removeEmptyDormantScopeLocked(state *scopeState) {
 	}
 	state.closed = true
 	delete(p.scopes, scopeKey(state.id))
+	p.scopeTransitions[ScopeTransitionRemoved]++
+}
+
+func (p *Pool) lookupMissReasonLocked(state *scopeState, composite string, family QueryFamily) LookupMissReason {
+	digest := sha256.Sum256([]byte(composite))
+	if element := p.removalHistory[digest]; element != nil {
+		p.removalOrder.MoveToFront(element)
+		return element.Value.(removalRecord).reason
+	}
+	if !state.everStoredArrow {
+		return LookupMissColdStart
+	}
+	if state.queryFamilies[family] > 0 {
+		return LookupMissQueryMismatch
+	}
+	return LookupMissAbsentEntry
+}
+
+func (p *Pool) rememberRemovalLocked(composite string, reason LookupMissReason) {
+	if p.removalHistoryLimit <= 0 {
+		return
+	}
+	digest := sha256.Sum256([]byte(composite))
+	if existing := p.removalHistory[digest]; existing != nil {
+		existing.Value = removalRecord{digest: digest, reason: reason}
+		p.removalOrder.MoveToFront(existing)
+		return
+	}
+	element := p.removalOrder.PushFront(removalRecord{digest: digest, reason: reason})
+	p.removalHistory[digest] = element
+	for p.removalOrder.Len() > p.removalHistoryLimit {
+		oldest := p.removalOrder.Back()
+		record := oldest.Value.(removalRecord)
+		delete(p.removalHistory, record.digest)
+		p.removalOrder.Remove(oldest)
+	}
+}
+
+func (p *Pool) forgetRemovalLocked(composite string) {
+	digest := sha256.Sum256([]byte(composite))
+	if element := p.removalHistory[digest]; element != nil {
+		delete(p.removalHistory, digest)
+		p.removalOrder.Remove(element)
+	}
+}
+
+func cacheClassOf(state *scopeState, e entry) CacheClass {
+	if e.arrowResult != nil {
+		return CacheClassStableResult
+	}
+	return CacheClassGenerationByte
 }
 
 func cloneMetadata(metadata Metadata) Metadata {
@@ -511,8 +712,24 @@ func (s *Scope) Invalidate() {
 	if state == nil {
 		return
 	}
+	classes := map[CacheClass]uint64{}
+	if len(state.entries) == 0 {
+		class := CacheClassGenerationByte
+		if state.shared {
+			class = CacheClassStableResult
+		}
+		classes[class] = 0
+	}
 	for composite := range state.entries {
-		p.removeLocked(p.entries[composite], "")
+		element := p.entries[composite]
+		if element != nil {
+			classes[cacheClassOf(state, element.Value.(entry))]++
+		}
+		p.removeLocked(element, "", LookupMissInvalidated)
+	}
+	for class, removed := range classes {
+		p.invalidations[class]++
+		p.invalidatedEntries[class] += removed
 	}
 	state.generation++
 }
@@ -535,11 +752,14 @@ func (s *Scope) Close() error {
 		if state.references > 0 {
 			state.references--
 		}
+		if state.references == 0 && len(state.entries) > 0 {
+			p.scopeTransitions[ScopeTransitionDormant]++
+		}
 		p.removeEmptyDormantScopeLocked(state)
 		return nil
 	}
 	for composite := range state.entries {
-		p.removeLocked(p.entries[composite], "")
+		p.removeLocked(p.entries[composite], "", "")
 	}
 	state.closed = true
 	state.generation++
@@ -553,15 +773,61 @@ func (p *Pool) Stats() Snapshot {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	result := Snapshot{Entries: len(p.entries), Bytes: p.bytes, Scopes: map[string]ScopeSnapshot{}, Evictions: map[Constraint]uint64{}, Stores: map[StoreOutcome]uint64{}}
+	result := Snapshot{
+		Entries: len(p.entries), Bytes: p.bytes, Scopes: map[string]ScopeSnapshot{},
+		Evictions: map[Constraint]uint64{}, Stores: map[StoreOutcome]uint64{},
+		Invalidations: map[CacheClass]uint64{}, InvalidatedEntries: map[CacheClass]uint64{},
+		ClassEvictions: map[CacheClass]map[Constraint]uint64{}, ScopeTransitions: map[ScopeTransition]uint64{},
+	}
 	for key, state := range p.scopes {
 		result.Scopes[key] = ScopeSnapshot{ScopeID: state.id, Entries: state.usage.entries, Bytes: state.usage.bytes, Generation: state.generation}
+		if state.shared {
+			if state.references > 0 {
+				result.Stable.ActiveScopes++
+			} else {
+				result.Stable.DormantScopes++
+			}
+		} else {
+			result.Generation.Scopes++
+		}
+		for composite := range state.entries {
+			element := p.entries[composite]
+			if element == nil {
+				continue
+			}
+			e := element.Value.(entry)
+			if state.shared && e.arrowResult != nil {
+				result.Stable.Entries++
+				result.Stable.Bytes += e.bytes
+				if e.arrowHold != nil {
+					result.Stable.ArrowHolds++
+				}
+			} else if !state.shared && e.byteValue != nil {
+				result.Generation.ByteEntries++
+				result.Generation.ByteBytes += e.bytes
+			}
+		}
 	}
 	for key, value := range p.evictions {
 		result.Evictions[key] = value
 	}
 	for key, value := range p.stores {
 		result.Stores[key] = value
+	}
+	for key, value := range p.invalidations {
+		result.Invalidations[key] = value
+	}
+	for key, value := range p.invalidatedEntries {
+		result.InvalidatedEntries[key] = value
+	}
+	for class, counts := range p.classEvictions {
+		result.ClassEvictions[class] = map[Constraint]uint64{}
+		for constraint, value := range counts {
+			result.ClassEvictions[class][constraint] = value
+		}
+	}
+	for key, value := range p.scopeTransitions {
+		result.ScopeTransitions[key] = value
 	}
 	return result
 }
@@ -578,7 +844,7 @@ func (p *Pool) Close() error {
 	p.closed = true
 	for e := p.lru.Back(); e != nil; {
 		previous := e.Prev()
-		p.removeLocked(e, "")
+		p.removeLocked(e, "", "")
 		e = previous
 	}
 	for _, state := range p.scopes {

--- a/internal/analytics/resultcache/pool_test.go
+++ b/internal/analytics/resultcache/pool_test.go
@@ -332,6 +332,108 @@ func TestSharedScopeRetainsEntriesAcrossZeroReferenceTransition(t *testing.T) {
 	entry.Release()
 }
 
+func TestObservedArrowLookupClassifiesEveryMissAndHitSource(t *testing.T) {
+	pool, err := New(Limits{RuntimeEntries: 1, RuntimeBytes: 1 << 20, NodeEntries: 2, NodeBytes: 2 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	family := QueryFamily{1}
+	otherFamily := QueryFamily{2}
+	first, err := pool.OpenSharedScope(ScopeID{RuntimeID: "private-partition-id"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, hit, observation, err := first.LookupArrowObserved("query-one", family); err != nil || hit || observation.MissReason != LookupMissColdStart {
+		t.Fatalf("cold lookup hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+	putObserved(t, first, "query-one", family, "first")
+	if _, _, hit, observation, err := first.LookupArrowObserved("query-two", family); err != nil || hit || observation.MissReason != LookupMissQueryMismatch {
+		t.Fatalf("query mismatch hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+	if _, _, hit, observation, err := first.LookupArrowObserved("unrelated", otherFamily); err != nil || hit || observation.MissReason != LookupMissAbsentEntry {
+		t.Fatalf("absent lookup hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+
+	second, err := pool.OpenSharedScope(ScopeID{RuntimeID: "private-partition-id"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, _, hit, observation, err := second.LookupArrowObserved("query-one", family)
+	if err != nil || !hit || observation.HitSource != HitSharedGeneration {
+		t.Fatalf("shared hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+	entry.Release()
+	first.Invalidate()
+	if _, _, hit, observation, err := first.LookupArrowObserved("query-one", family); err != nil || hit || observation.MissReason != LookupMissInvalidated {
+		t.Fatalf("invalidated lookup hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+	putObserved(t, first, "query-one", family, "replacement")
+	putObserved(t, first, "query-two", family, "evict-first")
+	if _, _, hit, observation, err := first.LookupArrowObserved("query-one", family); err != nil || hit || observation.MissReason != LookupMissEvicted {
+		t.Fatalf("evicted lookup hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := pool.OpenSharedScope(ScopeID{RuntimeID: "private-partition-id"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, _, hit, observation, err = reopened.LookupArrowObserved("query-two", family)
+	if err != nil || !hit || observation.HitSource != HitCutoverRetained {
+		t.Fatalf("cutover hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+	entry.Release()
+	if got := pool.Stats().ScopeTransitions[ScopeTransitionReactivated]; got != 1 {
+		t.Fatalf("reactivation transitions = %d, want 1", got)
+	}
+}
+
+func TestPoolTelemetrySeparatesStableAndGenerationState(t *testing.T) {
+	pool, err := New(Limits{RuntimeEntries: 1, RuntimeBytes: 1 << 20, NodeEntries: 2, NodeBytes: 2 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	stable, err := pool.OpenSharedScope(ScopeID{RuntimeID: "must-not-be-exported"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation := mustScope(t, pool, ScopeID{RuntimeID: "also-private"})
+	putObserved(t, stable, "private-query", QueryFamily{1}, "stable")
+	if outcome := generation.StoreBytes("private-tile", generation.Generation(), []byte("tile")); outcome != StoreStored {
+		t.Fatalf("store bytes = %q", outcome)
+	}
+	stable.Invalidate()
+	putObserved(t, stable, "first", QueryFamily{1}, "first")
+	putObserved(t, stable, "second", QueryFamily{1}, "second")
+	if err := stable.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	stats := pool.Stats()
+	if stats.Stable.ActiveScopes != 0 || stats.Stable.DormantScopes != 1 || stats.Stable.Entries != 1 || stats.Stable.ArrowHolds != 1 {
+		t.Fatalf("stable telemetry = %#v", stats.Stable)
+	}
+	if stats.Generation.Scopes != 1 || stats.Generation.ByteEntries != 1 || stats.Generation.ByteBytes == 0 {
+		t.Fatalf("generation telemetry = %#v", stats.Generation)
+	}
+	if stats.Invalidations[CacheClassStableResult] != 1 || stats.InvalidatedEntries[CacheClassStableResult] != 1 {
+		t.Fatalf("invalidation telemetry = %#v entries=%#v", stats.Invalidations, stats.InvalidatedEntries)
+	}
+	if stats.ClassEvictions[CacheClassStableResult][ConstraintRuntime] != 1 {
+		t.Fatalf("class evictions = %#v", stats.ClassEvictions)
+	}
+	if stats.ScopeTransitions[ScopeTransitionCreated] != 1 || stats.ScopeTransitions[ScopeTransitionDormant] != 1 {
+		t.Fatalf("scope transitions = %#v", stats.ScopeTransitions)
+	}
+}
+
 func TestDormantSharedScopePreservesInvalidationToken(t *testing.T) {
 	pool, err := New(testLimits())
 	if err != nil {
@@ -420,6 +522,9 @@ func TestDormantSharedScopeIsRemovedAfterFinalEntryEviction(t *testing.T) {
 	pool.mu.Unlock()
 	if retained {
 		t.Fatal("empty dormant shared scope remained after final entry eviction")
+	}
+	if got := pool.Stats().ScopeTransitions[ScopeTransitionRemoved]; got != 1 {
+		t.Fatalf("removed transitions = %d, want 1", got)
 	}
 }
 
@@ -544,6 +649,14 @@ func put(t *testing.T, s *Scope, key, value string) {
 	result := testArrowResult(t, memory.DefaultAllocator, value)
 	defer result.Release()
 	if got := s.StoreArrow(key, s.Generation(), result, Metadata{}); got != StoreStored {
+		t.Fatalf("store %q = %q", key, got)
+	}
+}
+func putObserved(t *testing.T, s *Scope, key string, family QueryFamily, value string) {
+	t.Helper()
+	result := testArrowResult(t, memory.DefaultAllocator, value)
+	defer result.Release()
+	if got := s.StoreArrowObserved(key, family, s.Generation(), result, Metadata{}); got != StoreStored {
 		t.Fatalf("store %q = %q", key, got)
 	}
 }

--- a/internal/dashboard/http/commands.go
+++ b/internal/dashboard/http/commands.go
@@ -116,13 +116,14 @@ func (h Handler) handleCommandWithBefore(w nethttp.ResponseWriter, r *nethttp.Re
 	}, func(preparation dashboardstream.RefreshPreparation) dashboardstream.RefreshWork {
 		plan, _ := preparation.Plan.(command.RefreshPlan)
 		workRequest := dashboardstream.WorkRequest{
-			DashboardID:   dashboardID,
-			PageID:        pageID,
-			ModelID:       modelID,
-			Filters:       preparation.Filters,
-			Plan:          plan,
-			EventObserved: h.RefreshEventObserved,
-			CacheObserved: h.CacheObserved,
+			DashboardID:              dashboardID,
+			PageID:                   pageID,
+			ModelID:                  modelID,
+			Filters:                  preparation.Filters,
+			Plan:                     plan,
+			EventObserved:            h.RefreshEventObserved,
+			CacheObserved:            h.CacheObserved,
+			CacheObservationObserved: h.CacheObservationObserved,
 		}
 		if before != nil {
 			workRequest.Before = before(metrics, request)

--- a/internal/dashboard/http/filter_commands.go
+++ b/internal/dashboard/http/filter_commands.go
@@ -150,7 +150,7 @@ func (h Handler) FilterCommand(w nethttp.ResponseWriter, r *nethttp.Request) {
 		return dashboardstream.TargetWork(metrics, dashboardstream.WorkRequest{
 			DashboardID: dashboardID, PageID: pageID, ModelID: request.ModelID,
 			Filters: preparation.Filters, Plan: plan,
-			EventObserved: h.RefreshEventObserved, CacheObserved: h.CacheObserved,
+			EventObserved: h.RefreshEventObserved, CacheObserved: h.CacheObserved, CacheObservationObserved: h.CacheObservationObserved,
 		})
 	})
 	if refreshErr != nil {

--- a/internal/dashboard/http/handlers.go
+++ b/internal/dashboard/http/handlers.go
@@ -150,39 +150,40 @@ type Handler struct {
 	// ProjectID is the stable graph project resource selected by app
 	// composition. It is deliberately not taken from a route segment. When
 	// ResolveProjectID is configured, the lease-bound resolver is authoritative.
-	ProjectID               projectgraph.ResourceID
-	ResolveProjectID        func(context.Context) (projectgraph.ResourceID, error)
-	AnalyticalContext       func(context.Context) context.Context
-	Broker                  SignalBroker
-	Coordinators            *dashboardstream.Registry
-	Logger                  *slog.Logger
-	RefreshStarted          dashboardstream.StartObserver
-	RefreshFinished         dashboardstream.SummaryObserver
-	RefreshEventObserved    dashboardstream.EventPublisher
-	CacheObserved           dataquery.CacheOutcomeObserver
-	CurrentPrincipalID      func(r *nethttp.Request) string
-	CurrentUsagePrincipal   func(r *nethttp.Request) (string, bool)
-	RecordDashboardView     func(context.Context, usage.View) error
-	AuthorizeListResource   func(ctx context.Context, principalID string, resource access.ResourceRef, capability access.Capability) (bool, error)
-	CSRFToken               func(r *nethttp.Request) string
-	Layout                  func(r *nethttp.Request) webpage.Provider
-	Presentation            reportui.Presentation
-	Assets                  staticasset.Resolver
-	Environment             func(*nethttp.Request) string
-	DataRefreshedAt         func(context.Context, string, string, string) string
-	QueryFreshness          func(context.Context, string, string, string) (api.QueryFreshness, bool)
-	CommandGuard            func(*nethttp.Request, Metrics, command.Request, dashboard.Signals) error
-	SharedCommandPrepare    SharedCommandPrepare
-	SessionStore            dashboardsession.Store
-	SessionKey              SessionKeyFactory
-	OptionCursorSecret      []byte
-	OptionCache             *dashboardfilter.OptionCache
-	AgentBootstrap          func(*nethttp.Request, string) reportui.AgentBootstrap
-	AgentCommands           reportui.AgentCommandBindings
-	RouteScope              reportui.RouteScope
-	StreamNamespace         string
-	SpatialTileStreamClosed func(Metrics, string)
-	Authoring               AuthoringApplication
+	ProjectID                projectgraph.ResourceID
+	ResolveProjectID         func(context.Context) (projectgraph.ResourceID, error)
+	AnalyticalContext        func(context.Context) context.Context
+	Broker                   SignalBroker
+	Coordinators             *dashboardstream.Registry
+	Logger                   *slog.Logger
+	RefreshStarted           dashboardstream.StartObserver
+	RefreshFinished          dashboardstream.SummaryObserver
+	RefreshEventObserved     dashboardstream.EventPublisher
+	CacheObserved            dataquery.CacheOutcomeObserver
+	CacheObservationObserved dataquery.CacheObserver
+	CurrentPrincipalID       func(r *nethttp.Request) string
+	CurrentUsagePrincipal    func(r *nethttp.Request) (string, bool)
+	RecordDashboardView      func(context.Context, usage.View) error
+	AuthorizeListResource    func(ctx context.Context, principalID string, resource access.ResourceRef, capability access.Capability) (bool, error)
+	CSRFToken                func(r *nethttp.Request) string
+	Layout                   func(r *nethttp.Request) webpage.Provider
+	Presentation             reportui.Presentation
+	Assets                   staticasset.Resolver
+	Environment              func(*nethttp.Request) string
+	DataRefreshedAt          func(context.Context, string, string, string) string
+	QueryFreshness           func(context.Context, string, string, string) (api.QueryFreshness, bool)
+	CommandGuard             func(*nethttp.Request, Metrics, command.Request, dashboard.Signals) error
+	SharedCommandPrepare     SharedCommandPrepare
+	SessionStore             dashboardsession.Store
+	SessionKey               SessionKeyFactory
+	OptionCursorSecret       []byte
+	OptionCache              *dashboardfilter.OptionCache
+	AgentBootstrap           func(*nethttp.Request, string) reportui.AgentBootstrap
+	AgentCommands            reportui.AgentCommandBindings
+	RouteScope               reportui.RouteScope
+	StreamNamespace          string
+	SpatialTileStreamClosed  func(Metrics, string)
+	Authoring                AuthoringApplication
 }
 
 func (h Handler) projectIDForRequest(ctx context.Context) (projectgraph.ResourceID, error) {

--- a/internal/dashboard/http/navigation.go
+++ b/internal/dashboard/http/navigation.go
@@ -173,7 +173,7 @@ func (h Handler) Navigate(w nethttp.ResponseWriter, r *nethttp.Request) {
 		return dashboardstream.TargetWork(metrics, dashboardstream.WorkRequest{
 			DashboardID: dashboardID, PageID: targetPage.ID, ModelID: request.ModelID,
 			Filters: preparation.Filters, Plan: plan,
-			EventObserved: h.RefreshEventObserved, CacheObserved: h.CacheObserved,
+			EventObserved: h.RefreshEventObserved, CacheObserved: h.CacheObserved, CacheObservationObserved: h.CacheObservationObserved,
 		})
 	})
 	if err != nil && !errors.Is(err, dashboardstream.ErrStalePreparation) {

--- a/internal/dashboard/http/updates.go
+++ b/internal/dashboard/http/updates.go
@@ -179,7 +179,7 @@ func (h Handler) Updates(w nethttp.ResponseWriter, r *nethttp.Request) {
 			plan, _ := preparation.Plan.(command.RefreshPlan)
 			return dashboardstream.TargetWork(metrics, dashboardstream.WorkRequest{
 				DashboardID: dashboardID, PageID: activePage.ID, ModelID: request.ModelID,
-				Filters: preparation.Filters, Plan: plan, EventObserved: h.RefreshEventObserved, CacheObserved: h.CacheObserved,
+				Filters: preparation.Filters, Plan: plan, EventObserved: h.RefreshEventObserved, CacheObserved: h.CacheObserved, CacheObservationObserved: h.CacheObservationObserved,
 			})
 		})
 	})
@@ -189,13 +189,14 @@ func (h Handler) Updates(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}, func(preparation dashboardstream.RefreshPreparation) dashboardstream.RefreshWork {
 		plan, _ := preparation.Plan.(command.RefreshPlan)
 		return dashboardstream.TargetWork(metrics, dashboardstream.WorkRequest{
-			DashboardID:   dashboardID,
-			PageID:        activePage.ID,
-			ModelID:       request.ModelID,
-			Filters:       preparation.Filters,
-			Plan:          plan,
-			EventObserved: h.RefreshEventObserved,
-			CacheObserved: h.CacheObserved,
+			DashboardID:              dashboardID,
+			PageID:                   activePage.ID,
+			ModelID:                  request.ModelID,
+			Filters:                  preparation.Filters,
+			Plan:                     plan,
+			EventObserved:            h.RefreshEventObserved,
+			CacheObserved:            h.CacheObserved,
+			CacheObservationObserved: h.CacheObservationObserved,
 		})
 	})
 	if err != nil {

--- a/internal/dashboard/module/module.go
+++ b/internal/dashboard/module/module.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
 	"github.com/flidai/leapview/internal/dashboard/api"
 	dashboardauthoringapplication "github.com/flidai/leapview/internal/dashboard/authoring/application"
 	dashboarddefinition "github.com/flidai/leapview/internal/dashboard/definition"
@@ -144,6 +145,7 @@ type DashboardTelemetry interface {
 	DashboardRefreshEventObserved(string, string)
 	VisualizationFrameObserved(kind string, rows, cardinality, encodedBytes int)
 	DashboardCacheObserved(string)
+	DashboardCacheObservationObserved(dataquery.CacheObservation)
 	SpatialTileObserved(outcome, cache, precision string, queryMS, encodingMS int64, encodedBytes, features int, fallback bool)
 }
 
@@ -218,6 +220,11 @@ func Build(_ context.Context, config Config) (*Module, error) {
 		CacheObserved: func(outcome string) {
 			if telemetry != nil {
 				telemetry.DashboardCacheObserved(outcome)
+			}
+		},
+		CacheObservationObserved: func(observation dataquery.CacheObservation) {
+			if telemetry != nil {
+				telemetry.DashboardCacheObservationObserved(observation)
 			}
 		},
 		SessionStore:       sessionStore,

--- a/internal/dashboard/module/observability_test.go
+++ b/internal/dashboard/module/observability_test.go
@@ -2,6 +2,8 @@ package module
 
 import (
 	"testing"
+
+	"github.com/flidai/leapview/internal/analytics/dataquery"
 )
 
 type testDashboardTelemetry struct{}
@@ -11,6 +13,7 @@ func (testDashboardTelemetry) DashboardRefreshFinished(string, string, int, map[
 func (testDashboardTelemetry) DashboardRefreshEventObserved(string, string)                     {}
 func (testDashboardTelemetry) VisualizationFrameObserved(string, int, int, int)                 {}
 func (testDashboardTelemetry) DashboardCacheObserved(string)                                    {}
+func (testDashboardTelemetry) DashboardCacheObservationObserved(dataquery.CacheObservation)     {}
 func (testDashboardTelemetry) SpatialTileObserved(string, string, string, int64, int64, int, int, bool) {
 }
 
@@ -27,5 +30,8 @@ func TestBuildWiresProgressiveObservers(t *testing.T) {
 	}
 	if handler.CacheObserved == nil {
 		t.Fatal("dashboard cache observer is not configured")
+	}
+	if handler.CacheObservationObserved == nil {
+		t.Fatal("typed dashboard cache observer is not configured")
 	}
 }

--- a/internal/dashboard/observability/telemetry.go
+++ b/internal/dashboard/observability/telemetry.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"strings"
 
+	"github.com/flidai/leapview/internal/analytics/dataquery"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -12,6 +13,12 @@ type Telemetry struct {
 	refreshInFlight      *prometheus.GaugeVec
 	refreshCancellations *prometheus.CounterVec
 	cacheOutcomes        *prometheus.CounterVec
+	cacheAdmissions      *prometheus.CounterVec
+	cacheMisses          *prometheus.CounterVec
+	cacheHits            *prometheus.CounterVec
+	cacheLookupDuration  *prometheus.HistogramVec
+	cacheRequestDuration *prometheus.HistogramVec
+	cacheStores          *prometheus.CounterVec
 	targetOutcomes       *prometheus.CounterVec
 	frameRows            *prometheus.HistogramVec
 	frameBytes           *prometheus.HistogramVec
@@ -51,6 +58,32 @@ func New(registerer prometheus.Registerer) *Telemetry {
 		cacheOutcomes: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "leapview_dashboard_cache_outcomes_total",
 			Help: "Dashboard query cache outcomes.",
+		}, []string{"outcome"}),
+		cacheAdmissions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "leapview_dashboard_query_cache_admissions_total",
+			Help: "Dashboard query cache admission decisions by fixed reason.",
+		}, []string{"decision", "reason"}),
+		cacheMisses: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "leapview_dashboard_query_cache_misses_total",
+			Help: "Logical dashboard query cache misses by evidence-backed reason.",
+		}, []string{"reason"}),
+		cacheHits: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "leapview_dashboard_query_cache_hits_total",
+			Help: "Dashboard query cache hits by fixed retention source.",
+		}, []string{"source"}),
+		cacheLookupDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "leapview_dashboard_query_cache_lookup_duration_seconds",
+			Help:    "Logical dashboard query cache lookup duration in seconds.",
+			Buckets: []float64{0.00001, 0.000025, 0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025},
+		}, []string{"outcome"}),
+		cacheRequestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "leapview_dashboard_query_cache_request_duration_seconds",
+			Help:    "Cache-eligible dashboard query duration through its final cache outcome.",
+			Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"outcome"}),
+		cacheStores: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "leapview_dashboard_query_cache_stores_total",
+			Help: "Dashboard query result cache store outcomes.",
 		}, []string{"outcome"}),
 		targetOutcomes: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "leapview_dashboard_target_outcomes_total",
@@ -113,6 +146,12 @@ func New(registerer prometheus.Registerer) *Telemetry {
 			telemetry.refreshInFlight,
 			telemetry.refreshCancellations,
 			telemetry.cacheOutcomes,
+			telemetry.cacheAdmissions,
+			telemetry.cacheMisses,
+			telemetry.cacheHits,
+			telemetry.cacheLookupDuration,
+			telemetry.cacheRequestDuration,
+			telemetry.cacheStores,
 			telemetry.targetOutcomes,
 			telemetry.frameRows,
 			telemetry.frameBytes,
@@ -184,6 +223,36 @@ func (t *Telemetry) DashboardRefreshFinished(commandValue, outcomeValue string, 
 func (t *Telemetry) DashboardCacheObserved(outcome string) {
 	if t != nil {
 		t.cacheOutcomes.WithLabelValues(cacheLabel(outcome)).Inc()
+	}
+}
+
+func (t *Telemetry) DashboardCacheObservationObserved(observation dataquery.CacheObservation) {
+	if t == nil {
+		return
+	}
+	durationSeconds := observation.Duration.Seconds()
+	if durationSeconds < 0 {
+		durationSeconds = 0
+	}
+	switch observation.Phase {
+	case dataquery.CacheObservationAdmission:
+		t.cacheAdmissions.WithLabelValues(cacheAdmissionDecisionLabel(observation.Decision), cacheAdmissionReasonLabel(observation.AdmissionReason)).Inc()
+	case dataquery.CacheObservationLookup:
+		outcome := "error"
+		if observation.HitSource != "" {
+			outcome = "hit"
+		} else if observation.MissReason != "" {
+			outcome = "miss"
+			t.cacheMisses.WithLabelValues(cacheMissReasonLabel(observation.MissReason)).Inc()
+		}
+		t.cacheLookupDuration.WithLabelValues(outcome).Observe(durationSeconds)
+	case dataquery.CacheObservationFinal:
+		if observation.HitSource != "" {
+			t.cacheHits.WithLabelValues(cacheHitSourceLabel(observation.HitSource)).Inc()
+		}
+		t.cacheRequestDuration.WithLabelValues(cacheObservationOutcomeLabel(observation.Outcome)).Observe(durationSeconds)
+	case dataquery.CacheObservationStore:
+		t.cacheStores.WithLabelValues(cacheStoreOutcomeLabel(observation.StoreOutcome)).Inc()
 	}
 }
 
@@ -300,6 +369,71 @@ func cacheLabel(value string) string {
 	switch normalizedLabel(value) {
 	case "hit", "miss", "coalesced", "disabled", "error":
 		return normalizedLabel(value)
+	default:
+		return "other"
+	}
+}
+
+func cacheAdmissionDecisionLabel(value dataquery.CacheAdmissionDecision) string {
+	switch value {
+	case dataquery.CacheAdmissionEligible, dataquery.CacheAdmissionBypassed, dataquery.CacheAdmissionRejected:
+		return string(value)
+	default:
+		return "other"
+	}
+}
+
+func cacheAdmissionReasonLabel(value dataquery.CacheAdmissionReason) string {
+	switch value {
+	case dataquery.CacheAdmissionReasonEligible,
+		dataquery.CacheAdmissionReasonQueryNotCacheable,
+		dataquery.CacheAdmissionReasonPlanningFailed,
+		dataquery.CacheAdmissionReasonCanceled,
+		dataquery.CacheAdmissionReasonDependencyUnavailable,
+		dataquery.CacheAdmissionReasonDependencyInvalid,
+		dataquery.CacheAdmissionReasonPolicyInvalid,
+		dataquery.CacheAdmissionReasonPartitionInvalid:
+		return string(value)
+	default:
+		return "other"
+	}
+}
+
+func cacheMissReasonLabel(value dataquery.CacheLookupMissReason) string {
+	switch value {
+	case dataquery.CacheLookupMissColdStart,
+		dataquery.CacheLookupMissAbsentEntry,
+		dataquery.CacheLookupMissQueryMismatch,
+		dataquery.CacheLookupMissInvalidated,
+		dataquery.CacheLookupMissEvicted:
+		return string(value)
+	default:
+		return "other"
+	}
+}
+
+func cacheHitSourceLabel(value dataquery.CacheHitSource) string {
+	switch value {
+	case dataquery.CacheHitCurrentGeneration, dataquery.CacheHitSharedGeneration, dataquery.CacheHitCutoverRetained:
+		return string(value)
+	default:
+		return "other"
+	}
+}
+
+func cacheObservationOutcomeLabel(value dataquery.CacheObservationOutcome) string {
+	switch value {
+	case dataquery.CacheObservationHit, dataquery.CacheObservationMiss, dataquery.CacheObservationCoalesced, dataquery.CacheObservationError:
+		return string(value)
+	default:
+		return "other"
+	}
+}
+
+func cacheStoreOutcomeLabel(value dataquery.CacheStoreOutcome) string {
+	switch value {
+	case dataquery.CacheStoreStored, dataquery.CacheStoreOversized, dataquery.CacheStoreStale, dataquery.CacheStoreClosed:
+		return string(value)
 	default:
 		return "other"
 	}

--- a/internal/dashboard/observability/telemetry_test.go
+++ b/internal/dashboard/observability/telemetry_test.go
@@ -1,8 +1,11 @@
 package observability
 
 import (
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/flidai/leapview/internal/analytics/dataquery"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -90,6 +93,77 @@ func TestTelemetryUsesBoundedLabelsAndRecordsRefreshLifecycle(t *testing.T) {
 	}
 	if got := stageLabel("targetCriticalPath"); got != "target_critical_path" {
 		t.Fatalf("target critical path stage label = %q, want target_critical_path", got)
+	}
+}
+
+func TestCacheValidityTelemetryCoversFixedReasonsWithoutIdentityLabels(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	telemetry := New(registry)
+	for _, test := range []struct {
+		decision dataquery.CacheAdmissionDecision
+		reason   dataquery.CacheAdmissionReason
+	}{
+		{dataquery.CacheAdmissionEligible, dataquery.CacheAdmissionReasonEligible},
+		{dataquery.CacheAdmissionBypassed, dataquery.CacheAdmissionReasonQueryNotCacheable},
+		{dataquery.CacheAdmissionRejected, dataquery.CacheAdmissionReasonPlanningFailed},
+		{dataquery.CacheAdmissionRejected, dataquery.CacheAdmissionReasonCanceled},
+		{dataquery.CacheAdmissionBypassed, dataquery.CacheAdmissionReasonDependencyUnavailable},
+		{dataquery.CacheAdmissionBypassed, dataquery.CacheAdmissionReasonDependencyInvalid},
+		{dataquery.CacheAdmissionBypassed, dataquery.CacheAdmissionReasonPolicyInvalid},
+		{dataquery.CacheAdmissionBypassed, dataquery.CacheAdmissionReasonPartitionInvalid},
+	} {
+		telemetry.DashboardCacheObservationObserved(dataquery.CacheObservation{Phase: dataquery.CacheObservationAdmission, Decision: test.decision, AdmissionReason: test.reason})
+	}
+	for _, reason := range []dataquery.CacheLookupMissReason{
+		dataquery.CacheLookupMissColdStart, dataquery.CacheLookupMissAbsentEntry, dataquery.CacheLookupMissQueryMismatch,
+		dataquery.CacheLookupMissInvalidated, dataquery.CacheLookupMissEvicted,
+	} {
+		telemetry.DashboardCacheObservationObserved(dataquery.CacheObservation{Phase: dataquery.CacheObservationLookup, MissReason: reason, Duration: time.Microsecond})
+	}
+	for _, source := range []dataquery.CacheHitSource{
+		dataquery.CacheHitCurrentGeneration, dataquery.CacheHitSharedGeneration, dataquery.CacheHitCutoverRetained,
+	} {
+		telemetry.DashboardCacheObservationObserved(dataquery.CacheObservation{Phase: dataquery.CacheObservationLookup, HitSource: source, Duration: time.Microsecond})
+		telemetry.DashboardCacheObservationObserved(dataquery.CacheObservation{Phase: dataquery.CacheObservationFinal, Outcome: dataquery.CacheObservationHit, HitSource: source, Duration: time.Millisecond})
+	}
+	for _, outcome := range []dataquery.CacheObservationOutcome{
+		dataquery.CacheObservationHit, dataquery.CacheObservationMiss, dataquery.CacheObservationCoalesced, dataquery.CacheObservationError,
+	} {
+		telemetry.DashboardCacheObservationObserved(dataquery.CacheObservation{Phase: dataquery.CacheObservationFinal, Outcome: outcome, Duration: time.Millisecond})
+	}
+	for _, outcome := range []dataquery.CacheStoreOutcome{
+		dataquery.CacheStoreStored, dataquery.CacheStoreOversized, dataquery.CacheStoreStale, dataquery.CacheStoreClosed,
+	} {
+		telemetry.DashboardCacheObservationObserved(dataquery.CacheObservation{Phase: dataquery.CacheObservationStore, StoreOutcome: outcome})
+	}
+	secret := "principal-query-project-model-secret"
+	telemetry.DashboardCacheObservationObserved(dataquery.CacheObservation{
+		Phase: dataquery.CacheObservationAdmission, Decision: dataquery.CacheAdmissionDecision(secret), AdmissionReason: dataquery.CacheAdmissionReason(secret),
+	})
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSeries := map[string]int{
+		"leapview_dashboard_query_cache_admissions_total": 9,
+		"leapview_dashboard_query_cache_misses_total":     5,
+		"leapview_dashboard_query_cache_hits_total":       3,
+		"leapview_dashboard_query_cache_stores_total":     4,
+	}
+	for _, family := range families {
+		if strings.Contains(family.String(), secret) {
+			t.Fatalf("cache metrics exposed identity/query data in %s", family.GetName())
+		}
+		if want, ok := wantSeries[family.GetName()]; ok {
+			if got := len(family.Metric); got != want {
+				t.Fatalf("%s series = %d, want %d", family.GetName(), got, want)
+			}
+			delete(wantSeries, family.GetName())
+		}
+	}
+	if len(wantSeries) != 0 {
+		t.Fatalf("missing cache metric families: %#v", wantSeries)
 	}
 }
 

--- a/internal/dashboard/stream/executor.go
+++ b/internal/dashboard/stream/executor.go
@@ -34,8 +34,9 @@ type WorkRequest struct {
 	Plan        command.RefreshPlan
 	Before      func(context.Context) error
 	// Observers may be invoked concurrently by independent consumer jobs.
-	EventObserved EventPublisher
-	CacheObserved dataquery.CacheOutcomeObserver
+	EventObserved            EventPublisher
+	CacheObserved            dataquery.CacheOutcomeObserver
+	CacheObservationObserved dataquery.CacheObserver
 }
 
 // TargetWork owns refresh delivery only. The consumer executor owns query
@@ -55,6 +56,7 @@ func TargetWork(metrics TargetMetrics, request WorkRequest) RefreshWork {
 				request.CacheObserved(outcome)
 			}
 		})
+		ctx = dataquery.WithCacheObserver(ctx, request.CacheObservationObserved)
 		if request.Before != nil {
 			if err := request.Before(ctx); err != nil {
 				publishRefreshError(ctx, observedPublish, err)

--- a/internal/dashboard/stream/executor_test.go
+++ b/internal/dashboard/stream/executor_test.go
@@ -79,9 +79,11 @@ func TestTargetWorkScopesConsumerFailuresAndSuppressesCancellation(t *testing.T)
 func TestTargetWorkPublishesAcceptedCacheOutcomes(t *testing.T) {
 	executor := &consumerExecutorStub{execute: func(ctx context.Context, _ consumer.Request, _ consumer.Publisher) error {
 		dataquery.ObserveCacheOutcome(ctx, dataquery.CacheHit)
+		dataquery.ObserveCache(ctx, dataquery.CacheObservation{Phase: dataquery.CacheObservationLookup, HitSource: dataquery.CacheHitCurrentGeneration})
 		return nil
 	}}
 	observed := ""
+	typed := dataquery.CacheObservation{}
 	events := []RefreshEvent{}
 	TargetWork(executor, WorkRequest{
 		DashboardID: "commerce",
@@ -89,12 +91,16 @@ func TestTargetWorkPublishesAcceptedCacheOutcomes(t *testing.T) {
 		CacheObserved: func(outcome string) {
 			observed = outcome
 		},
+		CacheObservationObserved: func(observation dataquery.CacheObservation) { typed = observation },
 	})(context.Background(), func(event RefreshEvent) bool {
 		events = append(events, event)
 		return true
 	})
 	if observed != dataquery.CacheHit || len(events) != 1 || events[0].CacheOutcome != dataquery.CacheHit {
 		t.Fatalf("observed=%q events=%#v", observed, events)
+	}
+	if typed.Phase != dataquery.CacheObservationLookup || typed.HitSource != dataquery.CacheHitCurrentGeneration {
+		t.Fatalf("typed cache observation = %#v", typed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds bounded cache observability for validity, admission decisions, lifecycle transitions, and cold-start behavior.

## Changes

- Added cache outcome telemetry:
  - hits
  - misses
  - bypasses
  - lookup latency
- Added bounded miss/bypass reason classification.
- Added lifecycle metrics for:
  - active/dormant scopes
  - retained Arrow state
  - generation byte state
  - invalidations
  - evictions
  - transitions
- Preserved bundle and query lookup attribution.
- Added cancellation/deadline classification for planning outcomes.
- Ensured metrics callbacks execute outside cache locks.
- Prevented sensitive information exposure:
  - no SQL
  - no identities
  - no hashes
  - no principals
  - no resource identifiers

## Guarantees

- One logical lookup is recorded per query/bundle branch.
- Second-chance and degenerate lookups do not double count.
- Metric labels remain bounded.
- Unknown values collapse safely.
- Cache identity, dependency derivation, authorization, and Arrow behavior remain unchanged.

## Unchanged

- resultidentity contract
- cache key format
- dependency evidence
- execution ownership (FAI-533)
- Arrow transport
- invalidation semantics

## Verification

- Focused FAI-532 tests with `duckdb_arrow`
- Race tests:
  - materialize
  - resultcache
  - dashboard observability
  - stream
- `go vet` on affected packages
- architecture tests
- `git diff --check`