### PR TITLE
Stabilize scheduled recovery qualification clock

### DIFF
--- a/internal/app/cli/composectl/qualification_scheduled.go
+++ b/internal/app/cli/composectl/qualification_scheduled.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/flidai/leapview/internal/app"
 	"github.com/flidai/leapview/internal/app/config"
@@ -73,8 +74,17 @@ func (c *Controller) runScheduledRecoveryQualification(ctx context.Context, buil
 			return err
 		}
 		lifecycle = refreshmodule.NewRecoveryLifecycle(store.SQLDB(), *lifecycle)
+		lifecycle.Clock = scheduledRecoveryClock{now: c.now}
 		return lifecycle.RunOnce(ctx)
 	})
+}
+
+type scheduledRecoveryClock struct {
+	now func() time.Time
+}
+
+func (clock scheduledRecoveryClock) Now() time.Time {
+	return clock.now()
 }
 
 func (c *Controller) managedContainerStateSource(ctx context.Context) (string, error) {

--- a/internal/app/cli/composectl/qualification_scheduled_test.go
+++ b/internal/app/cli/composectl/qualification_scheduled_test.go
@@ -41,6 +41,10 @@ func TestScheduledRecoveryQualificationRejectsDisabledBootstrap(t *testing.T) {
 }
 
 func TestReleasedHostRecoveryCompositionExecutesDueTransitionOwnersWithValidatedEvidence(t *testing.T) {
+	wallNow := time.Now().UTC()
+	// Run after the next 03:00 UTC schedule boundary so one overdue occurrence
+	// per owner is due and wall-clock backup evidence predates ledger completion.
+	now := time.Date(wallNow.Year(), wallNow.Month(), wallNow.Day()+1, 4, 5, 0, 0, time.UTC)
 	basePolicy, err := compatibility.EmbeddedPolicy()
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +98,7 @@ func TestReleasedHostRecoveryCompositionExecutesDueTransitionOwnersWithValidated
 	}
 	policyDigest := fmt.Sprintf("%x", sha256.Sum256(policyDocument))
 	evidencePath := filepath.Join(root, "owner-transition-evidence.json")
-	if err := writeScheduledTransitionEvidence(evidencePath, predecessor, identity, policy.PolicyVersion, policyDigest); err != nil {
+	if err := writeScheduledTransitionEvidence(evidencePath, predecessor, identity, policy.PolicyVersion, policyDigest, now.Add(-time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	identityDocument, err := json.Marshal(build)
@@ -138,7 +142,7 @@ esac
 	if err := os.WriteFile(filepath.Join(root, deploymentEnvName), []byte(deploymentEnvironment), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	controller, err := New(Options{Root: root, DockerBin: dockerPath})
+	controller, err := New(Options{Root: root, DockerBin: dockerPath, Now: func() time.Time { return now }})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +178,7 @@ esac
 		UPDATE recovery_qualification_schedules
 		SET next_run_at = ?
 		WHERE closed_at IS NULL
-	`, time.Now().UTC().Add(-time.Hour).Format("2006-01-02T15:04:05.000000000Z")); err != nil {
+		`, now.Add(-time.Hour).Format("2006-01-02T15:04:05.000000000Z")); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Close(); err != nil {
@@ -245,14 +249,14 @@ func writeScheduledQualificationBundle(root string, policy []byte) error {
 	return nil
 }
 
-func writeScheduledTransitionEvidence(path string, predecessor, candidate compatibility.ReleaseIdentity, policyVersion, policyDigest string) error {
+func writeScheduledTransitionEvidence(path string, predecessor, candidate compatibility.ReleaseIdentity, policyVersion, policyDigest string, recoveryPointAt time.Time) error {
 	state := compatibility.TransitionQualificationState{
 		InstanceID: "lvinst_scheduled_transition", Environment: "qualification", CanonicalOrigin: "https://qualification.example",
 		PrincipalID: "principal_qualification", PrincipalKind: "user", PrincipalEmail: "qualification@example.com", PrincipalName: "Qualification",
 	}
 	evidence := compatibility.TransitionQualificationEvidence{
 		SchemaVersion: 1, PolicyVersion: policyVersion, PolicySHA256: policyDigest,
-		RecoveryPointAt: time.Now().UTC().Add(-time.Minute), Predecessor: predecessor, Candidate: candidate,
+		RecoveryPointAt: recoveryPointAt, Predecessor: predecessor, Candidate: candidate,
 		StateBeforeUpgrade: strings.Repeat("d", 64), StateAfterUpgrade: strings.Repeat("d", 64), StateAfterRollback: strings.Repeat("d", 64),
 		InventoryBefore: state, InventoryAfterUpgrade: state, InventoryAfterRollback: state,
 		UpgradeResult: "success", RollbackResult: "success", PreservationVerified: true,


### PR DESCRIPTION
Problem:
The scheduled recovery qualification composition test depended on the current UTC hour. Between 03:00 and 04:00 UTC, its one-hour-old fixture crossed the production cron boundary, created catch-up occurrences, and exhausted the four-item batch before upgrade and rollback ran. This unrelated flake blocked PR #403 in the merge queue.

Root cause:
The fixture used the wall clock independently from the recovery lifecycle clock.

Solution:
Forward the controller clock into the recovery lifecycle and anchor the composition test at 04:05 UTC. Production controllers continue to default to time.Now. Existing owner validation, evidence, due-transition, and ordering assertions are unchanged.

Tests added/updated:
The existing composition test now uses one deterministic clock for schedules and transition evidence.

Verification performed:
- Focused test: 10 consecutive runs passed
- Focused test on current main: 3 consecutive runs passed
- composectl package with count=3 passed
- Focused race test passed
- go vet passed
- gofmt clean
- git diff --check passed

Remaining limitations:
This maintenance PR changes only recovery qualification clock plumbing and the flaky fixture. It does not include or alter the FAI-589 observability feature in PR #403.