### PR TITLE
fix(recovery): prevent schedule starvation across enqueue batches

### DIFF
--- a/internal/app/cli/composectl/qualification_scheduled_test.go
+++ b/internal/app/cli/composectl/qualification_scheduled_test.go
@@ -62,6 +62,17 @@ func TestReleasedHostRecoveryCompositionExecutesDueTransitionOwnersWithValidated
 		t.Fatal("embedded predecessor release is unavailable")
 	}
 	predecessor := predecessorRelease.IdentityForPlatform(runtime.GOOS + "/" + runtime.GOARCH)
+	for _, transition := range []struct {
+		operation     compatibility.Operation
+		current, next string
+	}{
+		{operation: compatibility.OperationUpgrade, current: predecessor.Image, next: identity.Image},
+		{operation: compatibility.OperationRollback, current: identity.Image, next: predecessor.Image},
+	} {
+		if err := policy.EvaluateImages(transition.operation, transition.current, transition.next, identity.Platform).Err(); err != nil {
+			t.Fatalf("valid %s transition denied before qualification: %v", transition.operation, err)
+		}
+	}
 	build := buildinfo.Identity{
 		Version: identity.Version, Revision: identity.SourceRevision, BuildTime: "2026-08-26T00:00:00Z",
 	}
@@ -170,11 +181,13 @@ esac
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Force more missed slots than the lifecycle batch can hold. Enqueueing must
+	// still distribute the bounded batch across every registered operation owner.
 	if _, err := store.SQLDB().ExecContext(t.Context(), `
 		UPDATE recovery_qualification_schedules
 		SET next_run_at = ?
 		WHERE closed_at IS NULL
-	`, time.Now().UTC().Add(-time.Hour).Format("2006-01-02T15:04:05.000000000Z")); err != nil {
+	`, time.Now().UTC().Add(-25*time.Hour).Format("2006-01-02T15:04:05.000000000Z")); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Close(); err != nil {

--- a/internal/platform/migrations/094_recovery_qualification_enqueue_cursor.sql
+++ b/internal/platform/migrations/094_recovery_qualification_enqueue_cursor.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+CREATE TABLE recovery_qualification_enqueue_cursor (
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  last_schedule_id TEXT NOT NULL,
+  last_schedule_revision_id TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+INSERT INTO recovery_qualification_enqueue_cursor (
+  singleton_id, last_schedule_id, last_schedule_revision_id, updated_at
+) VALUES (1, '', '', '1970-01-01T00:00:00.000000000Z');
+
+-- +goose Down
+DROP TABLE recovery_qualification_enqueue_cursor;

--- a/internal/platform/project_deployment_migration_test.go
+++ b/internal/platform/project_deployment_migration_test.go
@@ -198,6 +198,15 @@ func TestRecoveryQualificationLedgerMigrationUpDownAndLegacyUpgrade(t *testing.T
 	} {
 		assertSQLTableCount(t, ctx, legacy, table, 1)
 	}
+	assertSQLTableCount(t, ctx, legacy, "recovery_qualification_enqueue_cursor", 0)
+	if err := goose.UpToContext(ctx, legacy, "migrations", 94); err != nil {
+		t.Fatalf("upgrade recovery ledger fairness state: %v", err)
+	}
+	assertSQLTableCount(t, ctx, legacy, "recovery_qualification_enqueue_cursor", 1)
+	if err := goose.DownToContext(ctx, legacy, "migrations", 93); err != nil {
+		t.Fatalf("downgrade recovery ledger fairness state: %v", err)
+	}
+	assertSQLTableCount(t, ctx, legacy, "recovery_qualification_enqueue_cursor", 0)
 	if err := goose.DownToContext(ctx, legacy, "migrations", 92); err != nil {
 		t.Fatalf("downgrade recovery ledger migration: %v", err)
 	}
@@ -207,9 +216,10 @@ func TestRecoveryQualificationLedgerMigrationUpDownAndLegacyUpgrade(t *testing.T
 	} {
 		assertSQLTableCount(t, ctx, legacy, table, 0)
 	}
-	if err := goose.UpToContext(ctx, legacy, "migrations", 93); err != nil {
+	if err := goose.UpToContext(ctx, legacy, "migrations", 94); err != nil {
 		t.Fatalf("reapply recovery ledger migration: %v", err)
 	}
+	assertSQLTableCount(t, ctx, legacy, "recovery_qualification_enqueue_cursor", 1)
 }
 
 func assertDeliveryMigrationTail(t *testing.T, ctx context.Context, store *Store) {
@@ -218,19 +228,19 @@ func assertDeliveryMigrationTail(t *testing.T, ctx context.Context, store *Store
 	if err := store.SQLDB().QueryRowContext(ctx, `SELECT COALESCE(max(version_id), 0) FROM goose_db_version WHERE is_applied = 1`).Scan(&latest); err != nil {
 		t.Fatalf("inspect applied Goose migrations: %v", err)
 	}
-	if latest != 93 {
-		t.Fatalf("latest applied migration = %d, want 93", latest)
+	if latest != 94 {
+		t.Fatalf("latest applied migration = %d, want 94", latest)
 	}
 	rows, err := store.SQLDB().QueryContext(ctx, `
 		SELECT version_id
 		FROM goose_db_version
-		WHERE is_applied = 1 AND version_id BETWEEN 73 AND 93
+		WHERE is_applied = 1 AND version_id BETWEEN 73 AND 94
 		ORDER BY version_id`)
 	if err != nil {
 		t.Fatalf("inspect applied delivery migration sequence: %v", err)
 	}
 	defer rows.Close()
-	for want := int64(73); want <= 93; want++ {
+	for want := int64(73); want <= 94; want++ {
 		if !rows.Next() {
 			t.Fatalf("applied delivery migration sequence ended before %d", want)
 		}
@@ -275,6 +285,7 @@ func assertDeliveryMigrationTail(t *testing.T, ctx context.Context, store *Store
 	for _, table := range []string{
 		"recovery_qualification_schedules", "recovery_qualification_occurrences",
 		"recovery_qualification_attempts", "recovery_qualification_evidence_attempts",
+		"recovery_qualification_enqueue_cursor",
 	} {
 		assertTableCount(t, ctx, store, table, 1)
 	}

--- a/internal/refresh/sqlite/recovery_ledger_repository.go
+++ b/internal/refresh/sqlite/recovery_ledger_repository.go
@@ -218,7 +218,13 @@ func (repository *Repository) EnqueueDue(ctx context.Context, now time.Time, lim
 	if err != nil {
 		return nil, err
 	}
-	result := make([]recovery.Occurrence, 0, min(limit, len(rows)))
+	type dueScheduleCursor struct {
+		row           platformdb.ListDueRecoveryQualificationSchedulesRow
+		schedule      refreshschedule.Schedule
+		plannedAt     time.Time
+		previousRunAt string
+	}
+	cursors := make([]dueScheduleCursor, 0, len(rows))
 	for _, row := range rows {
 		plannedAt, err := recoveryParseTime(row.NextRunAt)
 		if err != nil {
@@ -228,39 +234,94 @@ func (repository *Repository) EnqueueDue(ctx context.Context, now time.Time, lim
 		if err != nil {
 			return nil, err
 		}
-		previousRunAt := row.NextRunAt
-		for !plannedAt.After(now) && len(result) < limit {
+		cursors = append(cursors, dueScheduleCursor{
+			row: row, schedule: parsed, plannedAt: plannedAt, previousRunAt: row.NextRunAt,
+		})
+	}
+	sort.Slice(cursors, func(left, right int) bool {
+		if cursors[left].row.ScheduleID != cursors[right].row.ScheduleID {
+			return cursors[left].row.ScheduleID < cursors[right].row.ScheduleID
+		}
+		return cursors[left].row.ScheduleRevisionID < cursors[right].row.ScheduleRevisionID
+	})
+	fairnessCursor, err := queries.GetRecoveryQualificationEnqueueCursor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	start := sort.Search(len(cursors), func(index int) bool {
+		if cursors[index].row.ScheduleID != fairnessCursor.LastScheduleID {
+			return cursors[index].row.ScheduleID > fairnessCursor.LastScheduleID
+		}
+		return cursors[index].row.ScheduleRevisionID > fairnessCursor.LastScheduleRevisionID
+	})
+	if start == len(cursors) {
+		start = 0
+	}
+	if start > 0 {
+		rotated := make([]dueScheduleCursor, 0, len(cursors))
+		rotated = append(rotated, cursors[start:]...)
+		rotated = append(rotated, cursors[:start]...)
+		cursors = rotated
+	}
+	result := make([]recovery.Occurrence, 0, min(limit, len(rows)))
+	lastScheduleID := ""
+	lastScheduleRevisionID := ""
+	for len(result) < limit {
+		enqueued := false
+		for index := range cursors {
+			if len(result) >= limit {
+				break
+			}
+			cursor := &cursors[index]
+			if cursor.plannedAt.After(now) {
+				continue
+			}
 			input := recovery.EnqueueInput{
-				ScheduleID: row.ScheduleID, ScheduleRevision: row.ScheduleRevisionID,
-				Scenario: row.Scenario, Operation: row.Operation,
-				PolicyVersion: row.PolicyVersion, PolicySHA256: row.PolicySha256, TargetScope: row.TargetScope,
-				ArtifactIdentity: row.ArtifactIdentity, PlannedAt: plannedAt,
-				StaleAfter: time.Duration(row.StaleAfterSeconds) * time.Second,
+				ScheduleID: cursor.row.ScheduleID, ScheduleRevision: cursor.row.ScheduleRevisionID,
+				Scenario: cursor.row.Scenario, Operation: cursor.row.Operation,
+				PolicyVersion: cursor.row.PolicyVersion, PolicySHA256: cursor.row.PolicySha256, TargetScope: cursor.row.TargetScope,
+				ArtifactIdentity: cursor.row.ArtifactIdentity, PlannedAt: cursor.plannedAt,
+				StaleAfter: time.Duration(cursor.row.StaleAfterSeconds) * time.Second,
 			}
 			occurrence, _, err := enqueueRecoveryOccurrence(ctx, queries, input, now)
 			if err != nil {
 				return nil, err
 			}
-			next := parsed.Next(plannedAt)
+			next := cursor.schedule.Next(cursor.plannedAt)
 			if next.IsZero() {
-				return nil, fmt.Errorf("recovery qualification schedule %q has no next occurrence", row.ScheduleID)
+				return nil, fmt.Errorf("recovery qualification schedule %q has no next occurrence", cursor.row.ScheduleID)
 			}
+			nextRunAt := recoveryFormatTime(next)
 			advanced, err := queries.AdvanceRecoveryQualificationSchedule(ctx, platformdb.AdvanceRecoveryQualificationScheduleParams{
-				NextRunAt: recoveryFormatTime(next), UpdatedAt: recoveryFormatTime(now),
-				ScheduleRevisionID: row.ScheduleRevisionID, PreviousRunAt: previousRunAt,
+				NextRunAt: nextRunAt, UpdatedAt: recoveryFormatTime(now),
+				ScheduleRevisionID: cursor.row.ScheduleRevisionID, PreviousRunAt: cursor.previousRunAt,
 			})
 			if err != nil {
 				return nil, err
 			}
 			if advanced != 1 {
-				return nil, fmt.Errorf("recovery qualification schedule %q changed while enqueueing", row.ScheduleID)
+				return nil, fmt.Errorf("recovery qualification schedule %q changed while enqueueing", cursor.row.ScheduleID)
 			}
 			result = append(result, occurrence)
-			plannedAt = next
-			previousRunAt = recoveryFormatTime(next)
+			lastScheduleID = cursor.row.ScheduleID
+			lastScheduleRevisionID = cursor.row.ScheduleRevisionID
+			cursor.plannedAt = next
+			cursor.previousRunAt = nextRunAt
+			enqueued = true
 		}
-		if len(result) >= limit {
+		if !enqueued {
 			break
+		}
+	}
+	if len(result) > 0 {
+		updated, err := queries.UpdateRecoveryQualificationEnqueueCursor(ctx, platformdb.UpdateRecoveryQualificationEnqueueCursorParams{
+			LastScheduleID: lastScheduleID, LastScheduleRevisionID: lastScheduleRevisionID, UpdatedAt: recoveryFormatTime(now),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if updated != 1 {
+			return nil, fmt.Errorf("recovery qualification enqueue fairness cursor is unavailable")
 		}
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/refresh/sqlite/recovery_ledger_test.go
+++ b/internal/refresh/sqlite/recovery_ledger_test.go
@@ -543,6 +543,180 @@ func TestRecoveryLifecycleChronologyRejectsImpossibleEvidence(t *testing.T) {
 	}
 }
 
+func TestRecoveryScheduleCatchupDistributesLimitedBatchAcrossOwners(t *testing.T) {
+	repository, closeStore := openRecoveryRepository(t)
+	defer closeStore()
+	base := time.Date(2026, 8, 25, 0, 30, 0, 0, time.UTC)
+	now := time.Date(2026, 8, 25, 4, 5, 0, 0, time.UTC)
+	operations := []string{
+		recovery.OperationBackup,
+		recovery.OperationRestore,
+		recovery.OperationUpgrade,
+		recovery.OperationRollback,
+	}
+	for _, operation := range operations {
+		definition := recovery.Definition{
+			ScheduleID: "hourly-" + operation, Scenario: "managed-instance", Operation: operation,
+			PolicyVersion: "ubdr-v1", PolicySHA256: recoveryPolicySHA256,
+			TargetScope: "release:candidate", ArtifactIdentity: recoveryArtifact,
+			Cron: "0 * * * *", Timezone: "UTC", StaleAfter: 24 * time.Hour, Enabled: true,
+		}
+		if err := repository.ReconcileSchedule(t.Context(), definition, base); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	due, err := repository.EnqueueDue(t.Context(), now, len(operations))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(due) != len(operations) {
+		t.Fatalf("catch-up occurrences = %d, want %d", len(due), len(operations))
+	}
+	counts := map[string]int{}
+	for _, occurrence := range due {
+		counts[occurrence.Operation]++
+	}
+	for _, operation := range operations {
+		if counts[operation] != 1 {
+			t.Fatalf("catch-up occurrence count for %s = %d, want 1: %v", operation, counts[operation], counts)
+		}
+	}
+}
+
+func TestRecoveryScheduleCatchupDoesNotStarveRecentlyDueOwners(t *testing.T) {
+	repository, closeStore := openRecoveryRepository(t)
+	defer closeStore()
+	now := time.Date(2026, 8, 25, 4, 5, 0, 0, time.UTC)
+	operations := []string{
+		recovery.OperationBackup,
+		recovery.OperationRestore,
+		recovery.OperationUpgrade,
+		recovery.OperationRollback,
+	}
+	for _, operation := range operations {
+		base := now.Add(-35 * time.Minute)
+		if operation == recovery.OperationBackup {
+			base = now.Add(-5 * 24 * time.Hour)
+		}
+		definition := recovery.Definition{
+			ScheduleID: "owner-" + operation, Scenario: "managed-instance", Operation: operation,
+			PolicyVersion: "ubdr-v1", PolicySHA256: recoveryPolicySHA256,
+			TargetScope: "release:candidate", ArtifactIdentity: recoveryArtifact,
+			Cron: "0 * * * *", Timezone: "UTC", StaleAfter: 30 * 24 * time.Hour, Enabled: true,
+		}
+		if err := repository.ReconcileSchedule(t.Context(), definition, base); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	wantOrder := []string{
+		recovery.OperationBackup,
+		recovery.OperationRestore,
+		recovery.OperationRollback,
+		recovery.OperationUpgrade,
+	}
+	for pass := range 3 {
+		due, err := repository.EnqueueDue(t.Context(), now.Add(time.Duration(pass)*time.Hour), len(operations))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(due) != len(wantOrder) {
+			t.Fatalf("catch-up pass %d occurrences = %d, want %d", pass, len(due), len(wantOrder))
+		}
+		for index, occurrence := range due {
+			if occurrence.Operation != wantOrder[index] {
+				t.Fatalf("catch-up pass %d operation %d = %s, want %s", pass, index, occurrence.Operation, wantOrder[index])
+			}
+		}
+	}
+}
+
+func TestRecoveryScheduleCatchupRotatesAcrossLimitedBatches(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "platform.db")
+	store, err := platform.Open(t.Context(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := NewRepository(store.SQLDB())
+	defer func() {
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	now := time.Date(2026, 8, 25, 4, 5, 0, 0, time.UTC)
+	scheduleIDs := []string{
+		"fairness-a",
+		"fairness-b",
+		"fairness-c",
+		"fairness-d",
+		"fairness-e",
+	}
+	operations := []string{
+		recovery.OperationBackup,
+		recovery.OperationRestore,
+		recovery.OperationUpgrade,
+		recovery.OperationRollback,
+		recovery.OperationBackup,
+	}
+	for index, scheduleID := range scheduleIDs {
+		definition := recovery.Definition{
+			ScheduleID: scheduleID, Scenario: "managed-instance", Operation: operations[index],
+			PolicyVersion: "ubdr-v1", PolicySHA256: recoveryPolicySHA256,
+			TargetScope: "release:candidate", ArtifactIdentity: recoveryArtifact,
+			Cron: "0 * * * *", Timezone: "UTC", StaleAfter: 60 * 24 * time.Hour, Enabled: true,
+		}
+		if err := repository.ReconcileSchedule(t.Context(), definition, now.Add(-30*24*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	counts := make(map[string]int, len(scheduleIDs))
+	for pass := range 10 {
+		due, err := repository.EnqueueDue(t.Context(), now, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(due) != 4 {
+			t.Fatalf("catch-up pass %d occurrences = %d, want 4", pass, len(due))
+		}
+		for _, occurrence := range due {
+			counts[occurrence.ScheduleID]++
+		}
+		if pass == 0 {
+			assertRecoveryScheduleOrder(t, due, scheduleIDs[:4])
+			if err := store.Close(); err != nil {
+				t.Fatal(err)
+			}
+			store, err = platform.Open(t.Context(), path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			repository = NewRepository(store.SQLDB())
+		}
+		if pass == 1 {
+			assertRecoveryScheduleOrder(t, due, []string{"fairness-e", "fairness-a", "fairness-b", "fairness-c"})
+		}
+	}
+	for _, scheduleID := range scheduleIDs {
+		if counts[scheduleID] != 8 {
+			t.Fatalf("catch-up count for %s = %d, want 8: %v", scheduleID, counts[scheduleID], counts)
+		}
+	}
+}
+
+func assertRecoveryScheduleOrder(t *testing.T, occurrences []recovery.Occurrence, want []string) {
+	t.Helper()
+	if len(occurrences) != len(want) {
+		t.Fatalf("occurrence count = %d, want %d", len(occurrences), len(want))
+	}
+	for index, occurrence := range occurrences {
+		if occurrence.ScheduleID != want[index] {
+			t.Fatalf("occurrence %d schedule = %s, want %s", index, occurrence.ScheduleID, want[index])
+		}
+	}
+}
+
 func TestRecoveryStatusSnapshotIsConsistentDuringConcurrentEnqueue(t *testing.T) {
 	repository, closeStore := openRecoveryRepository(t)
 	defer closeStore()

--- a/internal/refresh/sqlite/schedulequeries/recovery_qualification.sql
+++ b/internal/refresh/sqlite/schedulequeries/recovery_qualification.sql
@@ -29,6 +29,18 @@ FROM recovery_qualification_schedules
 WHERE enabled = 1 AND closed_at IS NULL AND next_run_at <= ?
 ORDER BY next_run_at, schedule_id;
 
+-- name: GetRecoveryQualificationEnqueueCursor :one
+SELECT last_schedule_id, last_schedule_revision_id
+FROM recovery_qualification_enqueue_cursor
+WHERE singleton_id = 1;
+
+-- name: UpdateRecoveryQualificationEnqueueCursor :execrows
+UPDATE recovery_qualification_enqueue_cursor
+SET last_schedule_id = sqlc.arg(last_schedule_id),
+    last_schedule_revision_id = sqlc.arg(last_schedule_revision_id),
+    updated_at = sqlc.arg(updated_at)
+WHERE singleton_id = 1;
+
 -- name: AdvanceRecoveryQualificationSchedule :execrows
 UPDATE recovery_qualification_schedules
 SET next_run_at = sqlc.arg(next_run_at), updated_at = sqlc.arg(updated_at)


### PR DESCRIPTION
## Problem

Bounded recovery catch-up can starve later schedule owners. When one owner has multiple missed occurrences, EnqueueDue drains that schedule before advancing, allowing backup and restore to consume the entire production batch while upgrade and rollback remain unserved.

This time-dependent behavior caused the repeated composectl Go package failure blocking PR #401.

## Root cause

EnqueueDue iterated due schedules in query order and exhausted every missed occurrence for each schedule before moving to the next. With a four-item batch and multiple missed slots, earlier schedule IDs monopolized the batch.

The composectl regression also used wall-clock-relative setup that exposed the defect only around the daily cron boundary.

## Solution

- Enqueue one due occurrence per schedule in deterministic schedule and revision order before starting another catch-up round.
- Persist the last served schedule in a singleton SQLite cursor so limited batches rotate fairly across process restarts.
- Update the cursor transactionally with occurrence enqueueing and schedule advancement.
- Preserve chronological ordering within each individual schedule.
- Add migration 094 with up/down coverage.
- Make the composectl regression force more missed slots than the lifecycle batch regardless of wall-clock time.

## Tests

Added or expanded coverage for:

- limited-batch distribution across backup, restore, upgrade, and rollback owners
- a heavily backlogged owner alongside recently due owners
- rotation across repeated batches
- fairness cursor persistence across database reopen
- migration 094 up/down and legacy upgrade behavior
- released-host composectl recovery composition

## Verification

Passed:

- go test ./internal/refresh/sqlite -run ^TestRecoveryScheduleCatchup -count=10
- go test -race ./internal/refresh/sqlite -run ^TestRecoveryScheduleCatchup -count=1
- go test ./internal/app/cli/composectl -run ^TestReleasedHostRecoveryCompositionExecutesDueTransitionOwnersWithValidatedEvidence$ -count=10
- go test ./internal/platform -run ^TestRecoveryQualificationLedgerMigrationUpDownAndLegacyUpgrade$ -count=1
- go test -p 2 ./internal/refresh/... ./internal/app/cli/composectl ./internal/platform
- task ci:prepare
- task ci:lane:go:packages
- task generated:check
- git diff --check origin/main...HEAD

Focused and race tests were rerun after rebasing onto the latest main.

## Limitations

Fairness is defined across due schedule revisions, not operation names. Catch-up ordering intentionally changes across schedules, while chronological ordering within a schedule remains unchanged.

This PR does not modify dashboard, Arrow, cache, materialization, or FAI-543 behavior.