### PR TITLE
FAI-536: Add deterministic cache cutover qualification gates

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -943,6 +943,11 @@ tasks:
     cmds:
       - go list ./... | grep -v '/internal/app$' | xargs go test -p 2
 
+  test:cache:qualification:
+    desc: Race-qualify stable cache cutover, generation execution, and bounded cache observers
+    cmds:
+      - go test -race -tags=duckdb_arrow -p 1 ./internal/analytics/resultcache ./internal/analytics/materialize ./internal/analytics/module ./internal/dashboard/observability -count=1
+
   test:go:app:0:
     cmds:
       - |

--- a/internal/analytics/materialize/cutover_qualification_test.go
+++ b/internal/analytics/materialize/cutover_qualification_test.go
@@ -1,0 +1,336 @@
+package materialize
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/flidai/leapview/internal/analytics/arrowdecode"
+	"github.com/flidai/leapview/internal/analytics/arrowquery"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	"github.com/flidai/leapview/internal/analytics/resultcache"
+	"github.com/flidai/leapview/internal/analytics/resultidentity"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeCacheCutoverQualification(t *testing.T) {
+	const nodeEntries = 32
+	const nodeBytes = int64(8 << 20)
+	pool, err := resultcache.New(resultcache.Limits{
+		RuntimeEntries: 16, RuntimeBytes: 4 << 20, NodeEntries: nodeEntries, NodeBytes: nodeBytes,
+	})
+	require.NoError(t, err)
+	production := materializeTestPartition(t, resultidentity.PartitionProduction, "")
+	evidence := cutoverQualificationEvidence(t, '1')
+	request := cutoverQualificationRequest()
+	databaseA := &cutoverQualificationDatabase{value: 101}
+	databaseB := &cutoverQualificationDatabase{value: 202}
+	generationA := newCutoverQualificationRuntime(t, pool, "generation-a", production, evidence, databaseA)
+	generationB := newCutoverQualificationRuntime(t, pool, "generation-b", production, evidence, databaseB)
+
+	first := executeCutoverQualificationQuery(t, generationA, request)
+	require.Equal(t, dataquery.CacheMiss, first.CacheOutcome)
+	require.Equal(t, int64(101), cutoverQualificationValue(t, first))
+	overlapping := executeCutoverQualificationQuery(t, generationB, request)
+	require.Equal(t, dataquery.CacheHit, overlapping.CacheOutcome)
+	require.Equal(t, int64(101), cutoverQualificationValue(t, overlapping))
+	require.Equal(t, int32(1), databaseA.queries.Load())
+	require.Zero(t, databaseB.queries.Load())
+
+	planned, err := generationB.planOwnedArrowQuery(request)
+	require.NoError(t, err)
+	dependency, reusable := generationB.dependencyForPlan(planned.plan)
+	require.True(t, reusable)
+	key, _, err := generationB.queryCache.cacheKey(request, generationB.resultPartition, dependency)
+	require.NoError(t, err)
+	consumer, _, hit, err := generationB.queryCache.scope.LookupArrow(key)
+	require.NoError(t, err)
+	require.True(t, hit)
+
+	require.NoError(t, generationA.Close())
+	stillServing := executeCutoverQualificationQuery(t, generationB, request)
+	require.Equal(t, dataquery.CacheHit, stillServing.CacheOutcome)
+	require.Equal(t, int64(101), cutoverQualificationValue(t, stillServing))
+	require.NoError(t, generationB.Close())
+	stats := pool.Stats()
+	require.Zero(t, stats.Stable.ActiveScopes)
+	require.Equal(t, 1, stats.Stable.DormantScopes)
+	assertCutoverQualificationLease(t, consumer, 101)
+
+	databaseC := &cutoverQualificationDatabase{value: 999}
+	generationC := newCutoverQualificationRuntime(t, pool, "generation-c", production, evidence, databaseC)
+	retained := executeCutoverQualificationQuery(t, generationC, request)
+	require.Equal(t, dataquery.CacheHit, retained.CacheOutcome)
+	require.Equal(t, int64(101), cutoverQualificationValue(t, retained))
+	require.Zero(t, databaseC.queries.Load())
+	consumer.Release()
+
+	changedQuery := request
+	changedQuery.Limit = 7
+	changedPolicy := request
+	changedPolicy.EffectivePolicyFingerprint = materializeTestDigest('8')
+	for index, test := range []struct {
+		name      string
+		partition resultidentity.Partition
+		evidence  resultidentity.Evidence
+		request   dataquery.Query
+		value     int64
+	}{
+		{name: "dependency", partition: production, evidence: cutoverQualificationEvidence(t, '2'), request: request, value: 401},
+		{name: "policy", partition: production, evidence: evidence, request: changedPolicy, value: 402},
+		{name: "query", partition: production, evidence: evidence, request: changedQuery, value: 403},
+		{name: "candidate", partition: materializeTestPartition(t, resultidentity.PartitionCandidate, "candidate-one"), evidence: evidence, request: cutoverCandidateRequest(request, "candidate-one"), value: 404},
+		{name: "candidate-id", partition: materializeTestPartition(t, resultidentity.PartitionCandidate, "candidate-two"), evidence: evidence, request: cutoverCandidateRequest(request, "candidate-two"), value: 405},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			database := &cutoverQualificationDatabase{value: test.value}
+			runtime := newCutoverQualificationRuntime(t, pool, fmt.Sprintf("isolation-%d", index), test.partition, test.evidence, database)
+			miss := executeCutoverQualificationQuery(t, runtime, test.request)
+			require.Equal(t, dataquery.CacheMiss, miss.CacheOutcome)
+			require.Equal(t, test.value, cutoverQualificationValue(t, miss), "isolated identity reused another sentinel")
+			hit := executeCutoverQualificationQuery(t, runtime, test.request)
+			require.Equal(t, dataquery.CacheHit, hit.CacheOutcome)
+			require.Equal(t, test.value, cutoverQualificationValue(t, hit))
+			require.Equal(t, int32(1), database.queries.Load())
+			require.NoError(t, runtime.Close())
+			assertCutoverQualificationAccounting(t, pool, nodeEntries, nodeBytes)
+		})
+	}
+
+	// FAI-534 projects unsupported external lineage to unavailable activation
+	// evidence. Materialization must execute normally without consulting the
+	// compatible managed cache entry or storing a fallback identity.
+	externalDatabase := &cutoverQualificationDatabase{value: 501}
+	external := newCutoverQualificationRuntime(t, pool, "external-bypass", production, evidence, externalDatabase)
+	external.dependencyEvidence = resultidentity.Evidence{}
+	for range 2 {
+		result := executeCutoverQualificationQuery(t, external, request)
+		require.Equal(t, dataquery.CacheMiss, result.CacheOutcome)
+		require.Equal(t, int64(501), cutoverQualificationValue(t, result))
+	}
+	require.Equal(t, int32(2), externalDatabase.queries.Load())
+	require.NoError(t, external.Close())
+	require.NoError(t, generationC.Close())
+	assertCutoverQualificationAccounting(t, pool, nodeEntries, nodeBytes)
+	require.NoError(t, pool.Close())
+}
+
+func TestRuntimeCrossGenerationCutoverQualificationDoesNotCoalesceColdMiss(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		pool, err := resultcache.New(resultcache.Limits{
+			RuntimeEntries: 8, RuntimeBytes: 2 << 20, NodeEntries: 8, NodeBytes: 2 << 20,
+		})
+		require.NoError(t, err)
+		release := make(chan struct{})
+		databaseA := &cutoverQualificationDatabase{value: 303, release: release}
+		databaseB := &cutoverQualificationDatabase{value: 303, release: release}
+		partition := materializeTestPartition(t, resultidentity.PartitionProduction, "")
+		evidence := cutoverQualificationEvidence(t, '1')
+		generationA := newCutoverQualificationRuntime(t, pool, "generation-a-cold", partition, evidence, databaseA)
+		generationB := newCutoverQualificationRuntime(t, pool, "generation-b-cold", partition, evidence, databaseB)
+		request := cutoverQualificationRequest()
+		request.Limit = 2
+		type queryResponse struct {
+			result dataquery.Result
+			err    error
+		}
+		responses := make(chan queryResponse, 2)
+		go func() {
+			result, err := generationA.ExecuteDataQuery(context.Background(), request)
+			responses <- queryResponse{result: result, err: err}
+		}()
+		go func() {
+			result, err := generationB.ExecuteDataQuery(context.Background(), request)
+			responses <- queryResponse{result: result, err: err}
+		}()
+
+		// If either request fails before execution or joins the other generation's
+		// flight, synctest still reaches quiescence and this assertion fails directly.
+		synctest.Wait()
+		if got := databaseA.queries.Load(); got != 1 {
+			t.Errorf("generation A physical executions = %d, want 1; generation A did not reach its independent cold execution owner", got)
+		}
+		if got := databaseB.queries.Load(); got != 1 {
+			t.Errorf("generation B physical executions = %d, want 1; generation B joined another generation or failed before physical execution", got)
+		}
+
+		close(release)
+		synctest.Wait()
+		require.Len(t, responses, 2, "both generation owners must complete after the execution barrier is released")
+		for range 2 {
+			response := <-responses
+			require.NoError(t, response.err)
+			require.Equal(t, dataquery.CacheMiss, response.result.CacheOutcome)
+			require.Equal(t, int64(303), cutoverQualificationValue(t, response.result))
+		}
+		require.NoError(t, generationA.Close())
+		require.NoError(t, generationB.Close())
+		require.NoError(t, pool.Close())
+	})
+}
+
+func TestRuntimeSameGenerationCutoverQualificationCoalescesColdMiss(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		pool, err := resultcache.New(resultcache.Limits{
+			RuntimeEntries: 8, RuntimeBytes: 2 << 20, NodeEntries: 8, NodeBytes: 2 << 20,
+		})
+		require.NoError(t, err)
+		release := make(chan struct{})
+		database := &cutoverQualificationDatabase{value: 601, release: release}
+		runtime := newCutoverQualificationRuntime(
+			t, pool, "same-generation", materializeTestPartition(t, resultidentity.PartitionProduction, ""),
+			cutoverQualificationEvidence(t, '1'), database,
+		)
+		request := cutoverQualificationRequest()
+		responses := make(chan dataquery.Result, 2)
+		errs := make(chan error, 2)
+		go func() {
+			result, err := runtime.ExecuteDataQuery(context.Background(), request)
+			responses <- result
+			errs <- err
+		}()
+		synctest.Wait()
+		if got := database.queries.Load(); got != 1 {
+			t.Errorf("initial same-generation physical executions = %d, want 1; the request did not reach its execution owner", got)
+		}
+		go func() {
+			result, err := runtime.ExecuteDataQuery(context.Background(), request)
+			responses <- result
+			errs <- err
+		}()
+		synctest.Wait()
+		if got := database.queries.Load(); got != 1 {
+			t.Errorf("physical executions after same-generation join = %d, want 1; the second request did not coalesce", got)
+		}
+		close(release)
+		synctest.Wait()
+		require.Len(t, responses, 2, "both same-generation callers must complete after the owner is released")
+		require.Len(t, errs, 2, "both same-generation callers must report completion")
+		outcomes := map[string]int{}
+		for range 2 {
+			require.NoError(t, <-errs)
+			result := <-responses
+			require.Equal(t, int64(601), cutoverQualificationValue(t, result))
+			outcomes[result.CacheOutcome]++
+		}
+		require.Equal(t, map[string]int{dataquery.CacheMiss: 1, dataquery.CacheCoalesced: 1}, outcomes)
+		require.NoError(t, runtime.Close())
+		require.NoError(t, pool.Close())
+	})
+}
+
+type cutoverQualificationDatabase struct {
+	cacheRuntimeDatabase
+	value   int64
+	queries atomic.Int32
+	release <-chan struct{}
+}
+
+func (d *cutoverQualificationDatabase) QueryArrow(ctx context.Context, plan semanticquery.Plan, sink arrowquery.Sink) error {
+	d.queries.Add(1)
+	if d.release != nil {
+		select {
+		case <-d.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return writeTestRowsArrow(ctx, plan, semanticquery.Rows{{"id": d.value}}, sink)
+}
+
+func newCutoverQualificationRuntime(
+	t testing.TB,
+	pool *resultcache.Pool,
+	generation string,
+	partition resultidentity.Partition,
+	evidence resultidentity.Evidence,
+	database *cutoverQualificationDatabase,
+) *Runtime {
+	t.Helper()
+	stable, err := pool.OpenSharedScope(resultcache.ScopeID{RuntimeID: "cutover:" + string(partition.Canonical())})
+	require.NoError(t, err)
+	bytes, err := pool.OpenScope(resultcache.ScopeID{RuntimeID: "cutover-generation:" + generation})
+	if err != nil {
+		_ = stable.Close()
+		require.NoError(t, err)
+	}
+	cache := newQueryResultCacheWithScopes(stable, bytes)
+	cache.ownScope()
+	return activatedCacheRuntime(t, &Runtime{
+		modelID: "sales", model: cutoverQualificationModel(), db: database,
+		queryCache: cache, resultPartition: partition, dependencyEvidence: evidence,
+	})
+}
+
+func cutoverQualificationModel() *semanticmodel.Model {
+	return &semanticmodel.Model{Name: "sales", Tables: map[string]semanticmodel.Table{
+		"orders": {Columns: map[string]semanticmodel.ModelColumn{"id": {Name: "id", Datatype: semanticmodel.DataTypeInteger}}},
+	}, Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}}}
+}
+
+func cutoverQualificationEvidence(t testing.TB, revision byte) resultidentity.Evidence {
+	t.Helper()
+	evidence, err := resultidentity.NewEvidence(resultidentity.EvidenceInput{
+		SemanticModelID: "semantic:sales", SemanticModelDigest: materializeTestDigest('a'),
+		DatasetRelations: []resultidentity.DatasetRelation{{
+			Dataset: "orders", Relation: resultidentity.RelationRevision{
+				RelationID: "model:orders", RevisionDigest: materializeTestDigest(revision),
+			},
+		}},
+		BindingFingerprint: materializeTestDigest('c'), RuntimeDigest: materializeTestDigest('d'),
+		CapabilityDigest: materializeTestDigest('e'),
+	})
+	require.NoError(t, err)
+	return evidence
+}
+
+func cutoverQualificationRequest() dataquery.Query {
+	return dataquery.Query{
+		Surface: dataquery.SurfaceDashboard, Operation: dataquery.OperationDashboardRows,
+		ProjectID: "project:test", EffectivePolicyFingerprint: materializeTestDigest('9'),
+		ModelID: "sales", Kind: dataquery.KindSemanticRows, Target: "orders",
+		Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1,
+	}
+}
+
+func cutoverCandidateRequest(request dataquery.Query, candidateID string) dataquery.Query {
+	request.CandidateID = candidateID
+	return request
+}
+
+func executeCutoverQualificationQuery(t testing.TB, runtime *Runtime, request dataquery.Query) dataquery.Result {
+	t.Helper()
+	result, err := runtime.ExecuteDataQuery(context.Background(), request)
+	require.NoError(t, err)
+	return result
+}
+
+func cutoverQualificationValue(t testing.TB, result dataquery.Result) int64 {
+	t.Helper()
+	require.Len(t, result.Rows, 1)
+	value, ok := result.Rows[0]["id"].(int64)
+	require.True(t, ok, "cutover result value = %#v", result.Rows[0]["id"])
+	return value
+}
+
+func assertCutoverQualificationLease(t testing.TB, lease *resultcache.EntryLease, want int64) {
+	t.Helper()
+	rows, err := arrowdecode.DecodeRows(lease.Data())
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, want, rows[0]["id"])
+}
+
+func assertCutoverQualificationAccounting(t testing.TB, pool *resultcache.Pool, nodeEntries int, nodeBytes int64) {
+	t.Helper()
+	stats := pool.Stats()
+	require.LessOrEqual(t, stats.Entries, nodeEntries)
+	require.LessOrEqual(t, stats.Bytes, nodeBytes)
+	require.LessOrEqual(t, stats.Stable.Entries, nodeEntries)
+	require.LessOrEqual(t, stats.Stable.Bytes, nodeBytes)
+	require.Equal(t, stats.Stable.Entries, stats.Stable.ArrowHolds)
+}

--- a/internal/analytics/resultcache/cutover_qualification_test.go
+++ b/internal/analytics/resultcache/cutover_qualification_test.go
@@ -1,0 +1,211 @@
+package resultcache
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/flidai/leapview/internal/analytics/arrowdecode"
+)
+
+func TestSharedResultScopeCutoverQualification(t *testing.T) {
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer allocator.AssertSize(t, 0)
+	limits := Limits{RuntimeEntries: 2, RuntimeBytes: 1 << 20, NodeEntries: 3, NodeBytes: 2 << 20}
+	pool, err := New(limits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partition := ScopeID{RuntimeID: "qualification-production"}
+	generationA, err := pool.OpenSharedScope(partition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warm := testArrowResult(t, allocator, "warm-a")
+	if outcome := generationA.StoreArrow("warm", generationA.Generation(), warm, Metadata{}); outcome != StoreStored {
+		warm.Release()
+		t.Fatalf("warm store = %q, want %q", outcome, StoreStored)
+	}
+	warm.Release()
+
+	generationB, err := pool.OpenSharedScope(partition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeLease, _, hit, observation, err := generationB.LookupArrowObserved("warm", QueryFamily{1})
+	if err != nil || !hit || observation.HitSource != HitSharedGeneration {
+		t.Fatalf("overlapping generation lookup hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+	if err := generationA.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertQualificationLeaseValue(t, activeLease, "warm-a")
+	if entry, _, ok, err := generationB.LookupArrow("warm"); err != nil || !ok {
+		t.Fatalf("generation B warm lookup hit=%v err=%v", ok, err)
+	} else {
+		entry.Release()
+	}
+	if err := generationB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if stats := pool.Stats(); stats.Stable.ActiveScopes != 0 || stats.Stable.DormantScopes != 1 || stats.Stable.Entries != 1 {
+		t.Fatalf("zero-reference stable state = %#v", stats.Stable)
+	}
+
+	generationC, err := pool.OpenSharedScope(partition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retained, token, hit, observation, err := generationC.LookupArrowObserved("warm", QueryFamily{1})
+	if err != nil || !hit || observation.HitSource != HitCutoverRetained {
+		t.Fatalf("reactivated generation lookup hit=%v observation=%#v err=%v", hit, observation, err)
+	}
+	assertQualificationLeaseValue(t, retained, "warm-a")
+
+	generationC.Invalidate()
+	stale := testArrowResult(t, allocator, "stale")
+	if outcome := generationC.StoreArrow("warm", token, stale, Metadata{}); outcome != StoreStale {
+		stale.Release()
+		t.Fatalf("stale store = %q, want %q", outcome, StoreStale)
+	}
+	stale.Release()
+	if _, _, ok, observation, err := generationC.LookupArrowObserved("warm", QueryFamily{1}); err != nil || ok || observation.MissReason != LookupMissInvalidated {
+		t.Fatalf("post-invalidation lookup hit=%v observation=%#v err=%v", ok, observation, err)
+	}
+	assertQualificationLeaseValue(t, activeLease, "warm-a")
+	assertQualificationLeaseValue(t, retained, "warm-a")
+	retained.Release()
+
+	first := testArrowResult(t, allocator, "evict-one")
+	if outcome := generationC.StoreArrow("one", generationC.Generation(), first, Metadata{}); outcome != StoreStored {
+		first.Release()
+		t.Fatalf("first eviction store = %q", outcome)
+	}
+	first.Release()
+	evictionLease, _, hit, err := generationC.LookupArrow("one")
+	if err != nil || !hit {
+		t.Fatalf("eviction lease lookup hit=%v err=%v", hit, err)
+	}
+	for index, value := range []string{"evict-two", "evict-three"} {
+		result := testArrowResult(t, allocator, value)
+		if outcome := generationC.StoreArrow(fmt.Sprintf("entry-%d", index), generationC.Generation(), result, Metadata{}); outcome != StoreStored {
+			result.Release()
+			t.Fatalf("pressure store %d = %q", index, outcome)
+		}
+		result.Release()
+	}
+	if _, _, ok, err := generationC.LookupArrow("one"); err != nil || ok {
+		t.Fatalf("evicted cache entry hit=%v err=%v", ok, err)
+	}
+	assertQualificationLeaseValue(t, evictionLease, "evict-one")
+	stats := pool.Stats()
+	if stats.Entries > limits.NodeEntries || stats.Bytes > limits.NodeBytes || stats.Stable.Entries > limits.NodeEntries || stats.Stable.Bytes > limits.NodeBytes {
+		t.Fatalf("cache accounting exceeded limits: %#v", stats)
+	}
+	if stats.Stable.ArrowHolds != stats.Stable.Entries {
+		t.Fatalf("stable Arrow holds = %d, entries = %d", stats.Stable.ArrowHolds, stats.Stable.Entries)
+	}
+	if stats.Stores[StoreStale] != 1 || stats.ClassEvictions[CacheClassStableResult][ConstraintRuntime] == 0 {
+		t.Fatalf("qualification outcomes = stores %#v evictions %#v", stats.Stores, stats.ClassEvictions)
+	}
+
+	if err := generationC.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertQualificationLeaseValue(t, activeLease, "warm-a")
+	assertQualificationLeaseValue(t, evictionLease, "evict-one")
+	activeLease.Release()
+	evictionLease.Release()
+}
+
+func TestExecutionScopesCutoverQualification(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const coldKeys = 4
+		const generations = 2
+		const callersPerFlight = 2
+		generationA := NewExecutionScope()
+		generationB := NewExecutionScope()
+		release := make(chan struct{})
+		var executions atomic.Int32
+		type response struct {
+			value  any
+			shared bool
+			err    error
+		}
+		responses := make(chan response, coldKeys*generations*callersPerFlight)
+
+		execute := func(ctx context.Context) (any, error) {
+			executions.Add(1)
+			select {
+			case <-release:
+				return "qualified", nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		launch := func(scope *ExecutionScope, key string) {
+			go func() {
+				value, shared, err := scope.Coalesce(context.Background(), key, execute)
+				responses <- response{value: value, shared: shared, err: err}
+			}()
+		}
+
+		for index := range coldKeys {
+			key := fmt.Sprintf("cold-%d", index)
+			launch(generationA, key)
+			launch(generationB, key)
+		}
+		synctest.Wait()
+		if got, want := executions.Load(), int32(coldKeys*generations); got != want {
+			t.Errorf("initial physical executions = %d, want %d (one owner per key and generation); a generation owner is missing or joined across generations", got, want)
+		}
+
+		for index := range coldKeys {
+			key := fmt.Sprintf("cold-%d", index)
+			launch(generationA, key)
+			launch(generationB, key)
+		}
+		synctest.Wait()
+		if got, want := executions.Load(), int32(coldKeys*generations); got != want {
+			t.Errorf("physical executions after same-generation joins = %d, want %d; same-generation callers did not coalesce", got, want)
+		}
+
+		close(release)
+		synctest.Wait()
+		if got, want := len(responses), coldKeys*generations*callersPerFlight; got != want {
+			t.Fatalf("completed coalesced responses = %d, want %d after releasing owners", got, want)
+		}
+		for range coldKeys * generations * callersPerFlight {
+			response := <-responses
+			if response.err != nil || response.value != "qualified" || !response.shared {
+				t.Fatalf("coalesced response = %#v", response)
+			}
+		}
+		if err := generationA.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := generationB.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func assertQualificationLeaseValue(t *testing.T, entry *EntryLease, want string) {
+	t.Helper()
+	if entry == nil || entry.Data() == nil {
+		t.Fatal("qualification lease is unavailable")
+	}
+	rows, err := arrowdecode.DecodeRows(entry.Data())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0]["value"] != want {
+		t.Fatalf("qualification lease rows = %#v, want value %q", rows, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds deterministic rollout qualification coverage for the result cache lifecycle.

## Problem

Cross-generation result reuse now spans stable partition cache retention, generation-owned execution flights, invalidation, eviction, and Arrow lease ownership. Rollout needs a focused deterministic gate that validates these guarantees under cutover and concurrency.

## Solution

- Validates generation A warmup, generation B overlap, zero runtime references, and generation C reactivation.
- Verifies compatible retained cache reuse across serving generations.
- Verifies cross-generation cold flights execute independently.
- Verifies same-generation cold misses coalesce.
- Covers dependency, policy, query, production/candidate, and candidate-ID isolation.
- Covers stale-store rejection after invalidation.
- Covers consumer lease survival through eviction and invalidation.
- Checks Arrow hold and node memory accounting.
- Adds a focused analytics race qualification task.

## Test reliability

- Replaced unbounded waits with deterministic synchronization.
- Uses synctest assertions for execution ownership and flight isolation.
- Contains no sleeps or polling loops.

## Safety and scope

- No production cache behavior changed.
- No cache keys changed.
- No resultidentity or dependency evidence changed.
- No Arrow transport changed.
- This PR only adds qualification coverage.

## Tests added

- Resultcache stable-scope cutover, dormancy, invalidation, eviction, lease, and accounting qualification.
- Resultcache same-generation and cross-generation execution-scope qualification.
- Materialize A-to-B-to-C cutover and retained-reuse qualification.
- Materialize identity isolation, unsupported-source bypass, and execution coalescing qualification.

## Verification

- Qualification tests repeated 100 times.
- `task test:cache:qualification` passed under the race detector.
- `go vet -tags=duckdb_arrow` passed for affected packages.
- `git diff --check` passed.