### PR TITLE
Fix report table fast-scroll loading stalls

### DIFF
--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -1126,6 +1126,46 @@ test('windowed table keeps a bounded DOM and requests unloaded chunks while scro
   } finally { await page.close() }
 })
 
+test('windowed table keeps requesting the latest chunk during continuous fast scrolling', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => {
+      const dashboard = document.querySelector('lv-dashboard-page') as any
+      const hosts = Array.from(dashboard?.shadowRoot?.querySelectorAll('lv-visualization-host') ?? []) as any[]
+      const tableHost = hosts.find((host) => host.envelope?.visualID === 'orders')
+      return Boolean(tableHost?.shadowRoot?.querySelector('lv-report-table')?.shadowRoot?.querySelector('.table-scrollport'))
+    })
+    const requestedDuringScroll = await page.locator('lv-dashboard-page').evaluate(async (dashboard: any) => {
+      const hosts = Array.from(dashboard.shadowRoot.querySelectorAll('lv-visualization-host')) as any[]
+      const tableHost = hosts.find((host) => host.envelope?.visualID === 'orders')
+      const table = tableHost.shadowRoot.querySelector('lv-report-table') as any
+      table.table = {
+        ...table.table,
+        cardinality: { kind: 'exact', value: 1_000 },
+        availableRows: 1_000,
+      }
+      await table.updateComplete
+      const scrollport = table.shadowRoot.querySelector('.table-scrollport') as HTMLElement
+      let requested = false
+      dashboard.addEventListener('lv-visualization-window-request', () => {
+        requested = true
+      })
+      for (let index = 0; index < 10; index++) {
+        scrollport.scrollTop = (200 + index * 60) * 28
+        scrollport.dispatchEvent(new Event('scroll'))
+        await new Promise((resolve) => window.setTimeout(resolve, 20))
+      }
+      const duringScroll = requested
+      await new Promise((resolve) => window.setTimeout(resolve, 120))
+      return duringScroll
+    })
+    expect(requestedDuringScroll).toBe(true)
+  } finally {
+    await page.close()
+  }
+})
+
 test('selected sticky table cells preserve the visible row highlight', async () => {
   const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
   try {

--- a/web/components/dashboard/table/report-table.ts
+++ b/web/components/dashboard/table/report-table.ts
@@ -1736,10 +1736,12 @@ export class ReportTable extends LitElement {
   }
 
   private scheduleJumpBlock(start: number): void {
-    if (this.jumpTimer && this.pendingJumpStart === start) return
     this.pendingJumpStart = start
     this.requestUpdate()
-    this.clearJumpTimer()
+    // Keep one bounded trailing request alive while fast scrolling updates the
+    // destination. Restarting the timer for every crossed chunk can postpone
+    // loading indefinitely until scrolling stops.
+    if (this.jumpTimer) return
     this.jumpTimer = window.setTimeout(() => {
       this.jumpTimer = 0
       this.emitBlock('all', this.pendingJumpStart, this.table.sort, this.table.resetVersion)

--- a/web/components/dashboard/visualization/adapters/tanstack.test.ts
+++ b/web/components/dashboard/visualization/adapters/tanstack.test.ts
@@ -67,6 +67,30 @@ test('TanStack adapter leaves row interaction disabled when the IR declares none
   expect(tableSignal(envelope).interaction).toBeUndefined()
 })
 
+test('TanStack adapter preserves sparse window block identities', () => {
+  const envelope = {
+    schemaVersion: 9, visualID: 'orders', rendererID: 'tanstack', specRevision: 'sha256:test', dataRevision: 3,
+    spec: {
+      kind: 'table', title: 'Orders', datasets: [{ id: 'primary', fields: [{ id: 'order_id', role: 'identity', dataType: 'string', nullable: false, label: 'Order' }] }],
+      dataBudget: { maxRows: 1000, requiredCompleteness: 'partial' }, accessibility: { title: 'Orders', description: 'Orders' }, interactions: [],
+      columns: [{ field: { dataset: 'primary', field: 'order_id' }, label: 'Order', formatting: [] }], presentation: { rowHeight: 28, striped: true, showHeader: true },
+    },
+    dataState: {
+      kind: 'windowed', specRevision: 'sha256:test', dataRevision: 3, generation: 1,
+      schema: { id: 'primary', fields: [{ id: 'order_id', role: 'identity', dataType: 'string', nullable: false, label: 'Order' }] },
+      cardinality: { kind: 'lower_bound', count: 600 }, availableRows: 1000, rowCap: 1000, chunkSize: 50, resetVersion: 2,
+      sort: [{ field: { dataset: 'primary', field: 'order_id' }, direction: 'ascending' }],
+      blocks: { c: { id: 'c', start: 450, rows: [['o451']], requestSeq: 8, resetVersion: 2, sort: [{ field: { dataset: 'primary', field: 'order_id' }, direction: 'ascending' }] } },
+    },
+    selection: [], status: { kind: 'ready' }, diagnostics: [],
+  } as VisualizationEnvelope
+
+  const table = tableSignal(envelope)
+  expect(table.blocks.c).toMatchObject({ start: 450, requestSeq: 8, rows: [{ order_id: 'o451' }] })
+  expect(table.blocks.a).toMatchObject({ start: 0, requestSeq: 0, rows: [] })
+  expect(table.blocks.b).toMatchObject({ start: 50, requestSeq: 0, rows: [] })
+})
+
 test('TanStack matrix adapter renders dynamic window schema columns with compiled formatting', () => {
   const envelope = {
     schemaVersion: 9, visualID: 'matrix', rendererID: 'tanstack', specRevision: 'sha256:matrix', dataRevision: 2,

--- a/web/components/dashboard/visualization/adapters/tanstack.ts
+++ b/web/components/dashboard/visualization/adapters/tanstack.ts
@@ -185,15 +185,14 @@ function block(start: number, rows: unknown[][], fields: VisualizationField[], r
 }
 
 function tableBlocks(envelope: VisualizationEnvelope, state: Extract<VisualizationEnvelope['dataState'], { kind: 'windowed' }>, fields: VisualizationField[]): TableSignal['blocks'] {
-  const values = Object.values(state.blocks).sort((left, right) => left.start - right.start)
   const fallbackSort = tableSort(state.sort[0], fields[0]?.id)
-  const at = (index: number, start: number): TableBlock => {
-    const value = values[index]
+  const at = (id: 'a' | 'b' | 'c', start: number): TableBlock => {
+    const value = state.blocks[id]
     if (!value) return block(start, [], fields, 0, state.resetVersion, fallbackSort)
     const projection = projectVisualizationHighlights(envelope, state.schema.id, fields.map((field) => field.id), value.rows)
     return block(value.start, value.rows, fields, value.requestSeq, value.resetVersion, tableSort(value.sort[0], fallbackSort.key), projection.matchedRows)
   }
-  return { a: at(0, 0), b: at(1, state.chunkSize), c: at(2, state.chunkSize * 2) }
+  return { a: at('a', 0), b: at('b', state.chunkSize), c: at('c', state.chunkSize * 2) }
 }
 
 function inlineBlocks(envelope: VisualizationEnvelope, state: Extract<VisualizationEnvelope['dataState'], { kind: 'inline' }>, fields: VisualizationField[], sort: TableSort): TableSignal['blocks'] {


### PR DESCRIPTION
## Summary
- keep a bounded window request active during continuous fast scrolling instead of indefinitely restarting its timer
- preserve sparse TanStack window block identities so returned chunks satisfy the correct pending request
- add browser and adapter regressions for both failure modes

## Verification
- bun run test:visualization-ir (149 passed)
- bun run test:dashboard-page (58 passed)
- local Chromium stress check at rows 505-513: no skeletons, loading cleared, no console errors