### PR TITLE
Polish model detail overview layout

### DIFF
--- a/web/components/project/project-page.dom.test.ts
+++ b/web/components/project/project-page.dom.test.ts
@@ -257,6 +257,7 @@ test('model details move overview metadata into a responsive side rail', async (
       const railBounds = rail.getBoundingClientRect()
       return {
         columns: getComputedStyle(layout).gridTemplateColumns,
+        railPosition: getComputedStyle(rail).position,
         mainRight: mainBounds.right,
         railLeft: railBounds.left,
         railLabel: rail.getAttribute('aria-label'),
@@ -264,6 +265,7 @@ test('model details move overview metadata into a responsive side rail', async (
       }
     })
     expect(desktop.columns.split(' ')).toHaveLength(2)
+    expect(desktop.railPosition).toBe('sticky')
     expect(desktop.mainRight).toBeLessThanOrEqual(desktop.railLeft)
     expect(desktop.railLabel).toBe('Asset overview')
     expect(desktop.railHeading).toBe('Overview')
@@ -280,13 +282,13 @@ test('model details move overview metadata into a responsive side rail', async (
       return {
         columns: getComputedStyle(layout).gridTemplateColumns,
         mainTop: mainBounds.top,
-        mainBottom: mainBounds.bottom,
         railTop: railBounds.top,
+        railPosition: getComputedStyle(rail).position,
       }
     })
     expect(narrow.columns.split(' ')).toHaveLength(1)
-    expect(narrow.mainTop).toBeLessThan(narrow.railTop)
-    expect(narrow.mainBottom).toBeLessThanOrEqual(narrow.railTop)
+    expect(narrow.railTop).toBeLessThan(narrow.mainTop)
+    expect(narrow.railPosition).toBe('static')
   } finally {
     await page.close()
   }

--- a/web/components/project/project-page.dom.test.ts
+++ b/web/components/project/project-page.dom.test.ts
@@ -242,6 +242,56 @@ test('connections list and asset detail render without workspace terminology', a
   }
 })
 
+test('model details move overview metadata into a responsive side rail', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } })
+  try {
+    await page.goto(`${baseURL}/?root=model-field-drawer`)
+    await page.waitForFunction(() => customElements.get('lv-project-asset-page'))
+    const desktop = await page.locator('lv-project-asset-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const root = element.shadowRoot!
+      const layout = root.querySelector('.details-layout') as HTMLElement
+      const main = root.querySelector('.details-main') as HTMLElement
+      const rail = root.querySelector('.details-sidebar') as HTMLElement
+      const mainBounds = main.getBoundingClientRect()
+      const railBounds = rail.getBoundingClientRect()
+      return {
+        columns: getComputedStyle(layout).gridTemplateColumns,
+        mainRight: mainBounds.right,
+        railLeft: railBounds.left,
+        railLabel: rail.getAttribute('aria-label'),
+        railHeading: rail.querySelector('h2')?.textContent?.trim(),
+      }
+    })
+    expect(desktop.columns.split(' ')).toHaveLength(2)
+    expect(desktop.mainRight).toBeLessThanOrEqual(desktop.railLeft)
+    expect(desktop.railLabel).toBe('Asset overview')
+    expect(desktop.railHeading).toBe('Overview')
+
+    await page.setViewportSize({ width: 720, height: 800 })
+    const narrow = await page.locator('lv-project-asset-page').evaluate(async (element: any) => {
+      await element.updateComplete
+      const root = element.shadowRoot!
+      const layout = root.querySelector('.details-layout') as HTMLElement
+      const main = root.querySelector('.details-main') as HTMLElement
+      const rail = root.querySelector('.details-sidebar') as HTMLElement
+      const mainBounds = main.getBoundingClientRect()
+      const railBounds = rail.getBoundingClientRect()
+      return {
+        columns: getComputedStyle(layout).gridTemplateColumns,
+        mainTop: mainBounds.top,
+        mainBottom: mainBounds.bottom,
+        railTop: railBounds.top,
+      }
+    })
+    expect(narrow.columns.split(' ')).toHaveLength(1)
+    expect(narrow.mainTop).toBeLessThan(narrow.railTop)
+    expect(narrow.mainBottom).toBeLessThanOrEqual(narrow.railTop)
+  } finally {
+    await page.close()
+  }
+})
+
 test('asset Definition tab renders an outline and highlighted Transform SQL', async () => {
   const page = await browser.newPage()
   try {

--- a/web/components/project/project-page.ts
+++ b/web/components/project/project-page.ts
@@ -728,13 +728,32 @@ class LeapViewProjectAssetPage extends DatastarLit(LitElement) {
   }
 
   private renderDetails(page: ResourceAssetPageSignal) {
+    const overview = page.details?.overview ?? []
+    const sections = page.details?.sections ?? []
+    const hasOverview = overview.some((fact) => fact.value?.trim())
+    const hasPrimaryContent = sections.length > 0 || Boolean(page.dashboardAppearance)
+    const showOverviewRail = hasOverview && hasPrimaryContent
     return html`
       <section class="details" id="details" aria-label="Asset details">
         ${page.details?.semanticModelGraph ? renderSemanticModelGraph(page.details.semanticModelGraph, page) : nothing}
         <div class="details-content">
-		  ${page.dashboardAppearance ? html`<lv-dashboard-appearance-editor .appearance=${page.dashboardAppearance} .label=${page.title} .assetID=${page.assetId}></lv-dashboard-appearance-editor>` : nothing}
-          ${renderFacts('Overview', page.details?.overview ?? [], true)}
-          ${(page.details?.sections ?? []).map(renderDetailSection)}
+          ${showOverviewRail
+            ? html`
+                <div class="details-layout">
+                  <div class="details-main">
+                    ${page.dashboardAppearance ? html`<lv-dashboard-appearance-editor .appearance=${page.dashboardAppearance} .label=${page.title} .assetID=${page.assetId}></lv-dashboard-appearance-editor>` : nothing}
+                    ${sections.map(renderDetailSection)}
+                  </div>
+                  <aside class="details-sidebar" aria-label="Asset overview">
+                    ${renderFacts('Overview', overview, true)}
+                  </aside>
+                </div>
+              `
+            : html`
+                ${page.dashboardAppearance ? html`<lv-dashboard-appearance-editor .appearance=${page.dashboardAppearance} .label=${page.title} .assetID=${page.assetId}></lv-dashboard-appearance-editor>` : nothing}
+                ${renderFacts('Overview', overview, true)}
+                ${sections.map(renderDetailSection)}
+              `}
         </div>
       </section>
     `
@@ -1535,6 +1554,48 @@ const projectStyles = css`
     padding: var(--base-size-16);
   }
 
+  .details-layout {
+    display: grid;
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+    align-items: start;
+    gap: var(--base-size-32);
+  }
+
+  .details-main {
+    display: grid;
+    min-width: 0;
+    align-content: start;
+    gap: var(--base-size-24);
+  }
+
+  .details-sidebar {
+    min-width: 0;
+    border-left: var(--lv-border-muted);
+    padding-left: var(--base-size-24);
+  }
+
+  .details-sidebar .detail-section {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  .details-sidebar .facts.overview {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--base-size-16);
+  }
+
+  .details-sidebar .facts .wide {
+    grid-column: auto;
+  }
+
+  .details-sidebar .facts p,
+  .details-sidebar .facts code {
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
   .drawer-page {
     min-height: 100svh;
   }
@@ -1691,6 +1752,24 @@ const projectStyles = css`
     grid-template-columns: minmax(7rem, .42fr) minmax(0, 1fr);
     align-items: start;
     gap: var(--base-size-16);
+  }
+
+  @media (max-width: 60rem) {
+    .details-layout {
+      grid-template-columns: minmax(0, 1fr);
+      gap: var(--base-size-24);
+    }
+
+    .details-sidebar {
+      border-top: var(--lv-border-muted);
+      border-left: 0;
+      padding-top: var(--base-size-20);
+      padding-left: 0;
+    }
+
+    .details-sidebar .facts.overview {
+      grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    }
   }
 
   .source-drawer-body .facts .wide {

--- a/web/components/project/project-page.ts
+++ b/web/components/project/project-page.ts
@@ -1551,28 +1551,43 @@ const projectStyles = css`
   }
 
   .details-content {
-    padding: var(--base-size-16);
+    padding: var(--base-size-24);
   }
 
   .details-layout {
     display: grid;
     min-width: 0;
-    grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 20rem);
     align-items: start;
-    gap: var(--base-size-32);
+    gap: var(--base-size-20);
   }
 
   .details-main {
     display: grid;
     min-width: 0;
     align-content: start;
-    gap: var(--base-size-24);
+    gap: var(--base-size-16);
+  }
+
+  .details-main > .detail-section,
+  .details-main > .detail-section:last-child {
+    overflow: hidden;
+    border: var(--lv-border-default);
+    border-radius: var(--lv-radius-large);
+    background: var(--lv-bg-panel);
+    padding: var(--base-size-20);
+    box-shadow: var(--shadow-resting-small);
   }
 
   .details-sidebar {
+    position: sticky;
+    top: var(--base-size-16);
     min-width: 0;
-    border-left: var(--lv-border-muted);
-    padding-left: var(--base-size-24);
+    border: var(--lv-border-default);
+    border-radius: var(--lv-radius-large);
+    background: var(--lv-bg-panel);
+    padding: var(--base-size-20);
+    box-shadow: var(--shadow-resting-small);
   }
 
   .details-sidebar .detail-section {
@@ -1582,18 +1597,45 @@ const projectStyles = css`
 
   .details-sidebar .facts.overview {
     grid-template-columns: minmax(0, 1fr);
-    gap: var(--base-size-16);
+    gap: 0;
+  }
+
+  .details-sidebar .facts > div {
+    grid-template-columns: minmax(6.5rem, .75fr) minmax(0, 1.25fr);
+    align-items: start;
+    gap: var(--base-size-12);
+    border-top: var(--lv-border-muted);
+    padding-block: var(--base-size-8);
+  }
+
+  .details-sidebar .facts > div:first-child {
+    border-top: 0;
+    padding-top: 0;
   }
 
   .details-sidebar .facts .wide {
     grid-column: auto;
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--base-size-4);
+  }
+
+  .details-sidebar .facts span:first-child {
+    font: var(--lv-type-body-compact);
+    text-transform: none;
   }
 
   .details-sidebar .facts p,
   .details-sidebar .facts code {
     overflow-wrap: anywhere;
+    text-align: right;
     text-overflow: clip;
     white-space: normal;
+    font: var(--lv-type-body-compact);
+  }
+
+  .details-sidebar .facts .wide p,
+  .details-sidebar .facts .wide code {
+    text-align: left;
   }
 
   .drawer-page {
@@ -1755,20 +1797,24 @@ const projectStyles = css`
   }
 
   @media (max-width: 60rem) {
+    .details-content {
+      padding: var(--base-size-16);
+    }
+
     .details-layout {
       grid-template-columns: minmax(0, 1fr);
-      gap: var(--base-size-24);
+      gap: var(--base-size-16);
     }
 
     .details-sidebar {
-      border-top: var(--lv-border-muted);
-      border-left: 0;
-      padding-top: var(--base-size-20);
-      padding-left: 0;
+      position: static;
+      top: auto;
+      order: -1;
     }
 
-    .details-sidebar .facts.overview {
-      grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    .details-main > .detail-section,
+    .details-main > .detail-section:last-child {
+      padding: var(--base-size-16);
     }
   }
 


### PR DESCRIPTION
## Summary

- present Entities and Fields as contained, high-density table surfaces
- turn Overview into a compact sticky metadata panel with aligned label/value rows
- preserve sparse detail pages and move Overview before tables when the layout stacks on narrow screens

## Design references

- [Interactive Order List & Details Panel](https://dribbble.com/shots/24856123-Interactive-Order-List-Details-Panel): full-width data surface and contextual detail treatment
- [Dark Mode Table](https://dribbble.com/shots/11220447-Dark-Mode-Table): compact grid hierarchy and restrained table chrome
- [Dark Mode Table UI – Interactive Data Grid](https://dribbble.com/shots/26567490--Dark-Mode-Table-UI-Interactive-Data-Grid): surfaced dark table, rounded container, and focused header contrast

## Verification

- inspected `/models/model:zip_geolocations/details` in local Chromium at 1440×1000
- `bun test web/components/project/project-page.dom.test.ts`
- `bun run typecheck:app`
- Primer alignment tests and checker
- `git diff --check`