### PR TITLE
FAI-600: Define native-v1 effective nullability semantics

### DIFF
--- a/docs/articles/architecture/dashboard-native-arrow-contract.md
+++ b/docs/articles/architecture/dashboard-native-arrow-contract.md
@@ -32,9 +32,10 @@ table schema. In particular:
 - Arrow physical types are preserved. Boolean and signed/unsigned integer
   widths, floating-point widths, dates, timestamps, UTF-8 strings, binary
   values, decimals, and dictionary encodings must not be projected to strings.
-- The field's nullable declaration and each array's validity bitmap are
-  preserved. A null must remain null; it must not become zero, `false`, an
-  empty string, or an empty byte slice.
+- The field's nullable declaration is the final governed effective nullability
+  described below. Each array's physical validity bitmap is preserved. A null
+  must remain null; it must not become zero, `false`, an empty string, or an
+  empty byte slice.
 - A decimal preserves its precision, scale, sign, and exact unscaled value.
 - A timestamp preserves its Arrow unit and timezone. A timestamp with timezone
   `UTC` represents the same UTC instant; a timezone-neutral timestamp remains
@@ -48,6 +49,66 @@ table schema. In particular:
   emitted. It must not expose generated SQL, physical connection or source
   identifiers, policy expressions, credentials, principals, or other internal
   state.
+
+### Nullability authority
+
+`native-v1` uses **governed effective nullability with conservative fallback**.
+The server-owned output schema descriptor for the final post-governance
+projection is authoritative; neither a source-column declaration nor the
+DuckDB Arrow field flag is independently authoritative.
+
+An emitted Arrow field has `Nullable=false` only when the final projected
+expression is proven incapable of producing SQL `NULL` after every governed
+transformation. A nullable, unknown, incomplete, or conflicting derivation is
+emitted as `Nullable=true`. In particular:
+
+- a source `NOT NULL` declaration does not by itself prove that the final
+  projection is non-null;
+- the nullable side of a left relationship traversal is nullable;
+- a column mask that can produce `NULL` makes the output nullable;
+- a calculation or derived expression is nullable unless its complete
+  operator and input semantics prove otherwise;
+- metric nullability includes its governed empty-set policy; and
+- filters or the values observed in one page, including a page with zero
+  nulls, never narrow the declared nullability.
+
+Unknown always maps to nullable. The rule is stable for empty results: an empty
+stream uses the same derived output schema descriptor as a non-empty execution
+of the same governed query. It must not infer nullability from the absence of
+record batches.
+
+Runtime validity bitmaps remain the authoritative physical statement about
+which values are null. The stream forwards them without null-to-value
+conversion. If a record contains a null for a field declared non-null, the
+execution has violated the governed output contract; Arrow encoder acceptance
+does not make that stream valid.
+
+### Implementation boundary
+
+The schema foundation represents each projected field with an internal
+`query.OutputFieldDescriptor` containing:
+
+- the final alias;
+- the public governed logical type;
+- effective nullability represented internally as proven non-null, nullable,
+  or unknown; and
+- internal derivation provenance sufficient to explain the decision without
+  exposing source, policy, SQL, or connection details on the wire.
+
+`query.Planner.DescribeOutputSchema` derives the descriptor before a response
+schema could be emitted from validated final PlanIR, including relationship
+traversal, column masks, metric empty-set policy, calculations, and derived
+expressions. Unknown derivations remain nullable. The descriptor is matched to
+the governed alias and projection order; it is not reconstructed from observed
+batches or client-authored metadata.
+
+`arrowquery.OutputSchemaSink` is the un-routed enforcement boundary. It
+reconciles only the Arrow field nullability declaration required by the
+descriptor, preserves physical Arrow types and validity buffers, respects
+borrowed-batch callback lifetimes, and validates every emitted record batch.
+Its internal provenance is opaque and is not serialized as response metadata.
+No production route currently constructs this sink; this foundation does not
+authorize a handler change or native streaming migration.
 
 An empty result is a valid Arrow IPC stream containing the full governed schema
 and zero record batches. It is not a schema-less stream and it is not a JSON
@@ -127,6 +188,12 @@ leases. If the connection remains writable and no bytes have been committed,
 the failure follows the normal problem mapping; a disconnected client may
 observe only connection termination.
 
+A runtime null in a field declared non-null is a native contract failure. If
+detected before response commitment, the server returns the normal structured
+JSON problem response and does not start an Arrow stream. If detected after
+commitment, the server terminates the Arrow stream, does not append a JSON
+fallback, and does not publish a successful `X-Next-Cursor` trailer value.
+
 After the Arrow response is committed, the server cannot switch formats. A
 query, IPC, cancellation, or transport failure terminates the stream. There is
 no JSON suffix or fallback, no successful completion signal, and no
@@ -171,6 +238,19 @@ shared governed execution boundaries.
 Only after those gates pass may an experiment compare the candidate with the
 current `api_direct` dashboard path using the same query and physical query
 behavior. Warm-cache measurements are a guardrail, not a comparable lane.
+
+Nullability qualification must cover, at minimum:
+
+- base `NOT NULL` and nullable fields;
+- aliases and projection ordering;
+- empty results;
+- fields on both sides of a left relationship traversal;
+- masks that preserve, replace, or introduce nulls;
+- metrics with null and zero empty-set policies;
+- calculations and derived expressions with proven and unknown semantics;
+- multiple record batches; and
+- non-null declaration mismatches detected both before and after response
+  commitment.
 
 ## Client compatibility and activation
 

--- a/internal/analytics/arrowquery/nullability.go
+++ b/internal/analytics/arrowquery/nullability.go
@@ -1,0 +1,138 @@
+package arrowquery
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+// NullabilityViolationError reports a physical validity bitmap that violates
+// a proved non-null governed output. It intentionally names only the governed
+// response alias; physical lineage remains internal to the planner.
+type NullabilityViolationError struct {
+	Alias     string
+	NullCount int
+}
+
+func (e *NullabilityViolationError) Error() string {
+	if e == nil {
+		return "governed Arrow nullability violation"
+	}
+	return fmt.Sprintf("governed Arrow field %q declared non-null contains %d null values", e.Alias, e.NullCount)
+}
+
+// OutputSchemaSink applies a governed output descriptor to one borrowed Arrow
+// stream. It is a foundation component only: no production route constructs
+// it yet. Schema and records are inspected and forwarded synchronously, and no
+// borrowed Arrow object survives a callback.
+type OutputSchemaSink struct {
+	descriptor semanticquery.OutputSchemaDescriptor
+	downstream Sink
+	fields     []arrow.Field
+	schema     *arrow.Schema
+	wrote      bool
+}
+
+// NewOutputSchemaSink validates the governed descriptor before accepting any
+// borrowed Arrow callbacks.
+func NewOutputSchemaSink(descriptor semanticquery.OutputSchemaDescriptor, downstream Sink) (*OutputSchemaSink, error) {
+	if downstream == nil {
+		return nil, errors.New("governed output schema downstream sink is required")
+	}
+	if err := descriptor.Validate(); err != nil {
+		return nil, err
+	}
+	descriptor.Fields = append([]semanticquery.OutputFieldDescriptor(nil), descriptor.Fields...)
+	return &OutputSchemaSink{descriptor: descriptor, downstream: downstream}, nil
+}
+
+func (s *OutputSchemaSink) WriteSchema(schema *arrow.Schema) error {
+	if s == nil || s.downstream == nil {
+		return errors.New("governed output schema sink is not initialized")
+	}
+	if schema == nil {
+		return errors.New("governed output Arrow schema is required")
+	}
+	if s.wrote {
+		return errors.New("governed output Arrow schema was already written")
+	}
+	if schema.NumFields() != len(s.descriptor.Fields) {
+		return fmt.Errorf("governed output Arrow schema has %d fields, descriptor has %d", schema.NumFields(), len(s.descriptor.Fields))
+	}
+	fields := make([]arrow.Field, len(s.descriptor.Fields))
+	for index, descriptor := range s.descriptor.Fields {
+		source := schema.Field(index)
+		if source.Name != descriptor.Alias {
+			return fmt.Errorf("governed output Arrow field %d is %q, descriptor is %q", index, source.Name, descriptor.Alias)
+		}
+		fields[index] = source
+		fields[index].Nullable = descriptor.ArrowNullable()
+		fields[index].Metadata = cloneArrowMetadata(source.Metadata)
+	}
+	metadata := cloneArrowMetadata(schema.Metadata())
+	reconciled := arrow.NewSchema(fields, &metadata)
+	if err := s.downstream.WriteSchema(reconciled); err != nil {
+		return err
+	}
+	s.fields = fields
+	s.schema = reconciled
+	s.wrote = true
+	return nil
+}
+
+func (s *OutputSchemaSink) WriteRecord(record arrow.RecordBatch) error {
+	if s == nil || s.downstream == nil {
+		return errors.New("governed output schema sink is not initialized")
+	}
+	if !s.wrote {
+		return errors.New("governed output Arrow schema must be written before records")
+	}
+	if record == nil {
+		return nil
+	}
+	if record.NumCols() != int64(len(s.fields)) {
+		return fmt.Errorf("governed output Arrow record has %d fields, want %d", record.NumCols(), len(s.fields))
+	}
+	for index, field := range s.fields {
+		if record.ColumnName(index) != field.Name {
+			return fmt.Errorf("governed output Arrow record field %d is %q, want %q", index, record.ColumnName(index), field.Name)
+		}
+		if field.Nullable {
+			continue
+		}
+		nulls := record.Column(index).NullN()
+		if nulls != 0 {
+			return &NullabilityViolationError{Alias: field.Name, NullCount: nulls}
+		}
+	}
+	// The downstream schema contains the governed nullability declarations,
+	// while the producer record still references its physical schema. Rebind
+	// the borrowed arrays synchronously so the downstream sees one stable
+	// schema without copying or retaining producer-owned buffers.
+	rebound := array.NewRecordBatch(s.schema, record.Columns(), record.NumRows())
+	defer rebound.Release()
+	return s.downstream.WriteRecord(rebound)
+}
+
+func (s *OutputSchemaSink) RowsWritten() int {
+	if s == nil || s.downstream == nil {
+		return 0
+	}
+	if stats, ok := s.downstream.(SinkStats); ok {
+		return stats.RowsWritten()
+	}
+	return 0
+}
+
+func cloneArrowMetadata(metadata arrow.Metadata) arrow.Metadata {
+	return arrow.NewMetadata(
+		append([]string(nil), metadata.Keys()...),
+		append([]string(nil), metadata.Values()...),
+	)
+}
+
+var _ Sink = (*OutputSchemaSink)(nil)
+var _ SinkStats = (*OutputSchemaSink)(nil)

--- a/internal/analytics/arrowquery/nullability_test.go
+++ b/internal/analytics/arrowquery/nullability_test.go
@@ -1,0 +1,140 @@
+package arrowquery
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+func TestOutputSchemaSinkReconcilesTriStateNullability(t *testing.T) {
+	descriptor := semanticquery.OutputSchemaDescriptor{Fields: []semanticquery.OutputFieldDescriptor{
+		{Alias: "proved", LogicalType: "integer", Nullability: semanticquery.OutputDefinitelyNonNull},
+		{Alias: "nullable", LogicalType: "integer", Nullability: semanticquery.OutputNullable},
+		{Alias: "unknown", LogicalType: "integer", Nullability: semanticquery.OutputNullabilityUnknown},
+	}}
+	upstream := arrow.NewSchema([]arrow.Field{
+		{Name: "proved", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "nullable", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "unknown", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+	}, nil)
+	capture := &outputSchemaCaptureSink{}
+	sink, err := NewOutputSchemaSink(descriptor, capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteSchema(upstream); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.fields) != 3 {
+		t.Fatalf("captured fields = %d, want 3", len(capture.fields))
+	}
+	if capture.fields[0].Nullable || !capture.fields[1].Nullable || !capture.fields[2].Nullable {
+		t.Fatalf("reconciled nullability = [%v %v %v]", capture.fields[0].Nullable, capture.fields[1].Nullable, capture.fields[2].Nullable)
+	}
+	if upstream.Field(0).Nullable != true || upstream.Field(1).Nullable != false || upstream.Field(2).Nullable != false {
+		t.Fatalf("borrowed upstream schema was mutated: %#v", upstream.Fields())
+	}
+}
+
+func TestOutputSchemaSinkRejectsRuntimeNullAcrossBatches(t *testing.T) {
+	descriptor := semanticquery.OutputSchemaDescriptor{Fields: []semanticquery.OutputFieldDescriptor{
+		{Alias: "id", LogicalType: "integer", Nullability: semanticquery.OutputDefinitelyNonNull},
+		{Alias: "optional", LogicalType: "integer", Nullability: semanticquery.OutputNullable},
+	}}
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "optional", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	}, nil)
+	capture := &outputSchemaCaptureSink{}
+	sink, err := NewOutputSchemaSink(descriptor, capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteSchema(schema); err != nil {
+		t.Fatal(err)
+	}
+	good := outputSchemaRecord(t, schema, []bool{true, true}, []bool{true, false})
+	if err := sink.WriteRecord(good); err != nil {
+		good.Release()
+		t.Fatal(err)
+	}
+	good.Release()
+	bad := outputSchemaRecord(t, schema, []bool{true, false}, []bool{true, true})
+	err = sink.WriteRecord(bad)
+	bad.Release()
+	var mismatch *NullabilityViolationError
+	if !errors.As(err, &mismatch) || mismatch.Alias != "id" || mismatch.NullCount != 1 {
+		t.Fatalf("runtime mismatch = %#v / %v", mismatch, err)
+	}
+	if capture.records != 1 {
+		t.Fatalf("downstream records = %d, want only the valid first batch", capture.records)
+	}
+}
+
+func TestOutputSchemaSinkKeepsEmptySchemaStableAndRejectsAliasMismatch(t *testing.T) {
+	descriptor := semanticquery.OutputSchemaDescriptor{Fields: []semanticquery.OutputFieldDescriptor{
+		{Alias: "id", LogicalType: "integer", Nullability: semanticquery.OutputDefinitelyNonNull},
+	}}
+	capture := &outputSchemaCaptureSink{}
+	sink, err := NewOutputSchemaSink(descriptor, capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteSchema(arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true}}, nil)); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.fields) != 1 || capture.fields[0].Name != "id" || capture.fields[0].Nullable {
+		t.Fatalf("empty result schema = %#v", capture.fields)
+	}
+	if capture.records != 0 {
+		t.Fatalf("empty result wrote %d records", capture.records)
+	}
+
+	mismatched, err := NewOutputSchemaSink(descriptor, &outputSchemaCaptureSink{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mismatched.WriteSchema(arrow.NewSchema([]arrow.Field{{Name: "source_id", Type: arrow.PrimitiveTypes.Int64, Nullable: true}}, nil)); err == nil {
+		t.Fatal("schema with a non-governed alias was accepted")
+	}
+}
+
+type outputSchemaCaptureSink struct {
+	fields  []arrow.Field
+	records int
+}
+
+func (s *outputSchemaCaptureSink) WriteSchema(schema *arrow.Schema) error {
+	s.fields = schema.Fields()
+	for index := range s.fields {
+		metadata := s.fields[index].Metadata
+		s.fields[index].Metadata = arrow.NewMetadata(append([]string(nil), metadata.Keys()...), append([]string(nil), metadata.Values()...))
+	}
+	return nil
+}
+
+func (s *outputSchemaCaptureSink) WriteRecord(arrow.RecordBatch) error {
+	s.records++
+	return nil
+}
+
+func outputSchemaRecord(t testing.TB, schema *arrow.Schema, idValid, optionalValid []bool) arrow.RecordBatch {
+	t.Helper()
+	allocator := memory.DefaultAllocator
+	id := array.NewInt64Builder(allocator)
+	id.AppendValues([]int64{1, 2}, idValid)
+	optional := array.NewInt64Builder(allocator)
+	optional.AppendValues([]int64{3, 4}, optionalValid)
+	columns := []arrow.Array{id.NewArray(), optional.NewArray()}
+	id.Release()
+	optional.Release()
+	record := array.NewRecordBatch(schema, columns, 2)
+	for _, column := range columns {
+		column.Release()
+	}
+	return record
+}

--- a/internal/analytics/query/output_schema.go
+++ b/internal/analytics/query/output_schema.go
@@ -1,0 +1,520 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/flidai/leapview/internal/analytics/query/planir"
+)
+
+// OutputNullability is the tri-state proof result for one final governed
+// projection. Unknown is deliberately distinct from nullable for diagnostics,
+// but both serialize to an Arrow nullable field.
+type OutputNullability string
+
+const (
+	OutputNullabilityUnknown OutputNullability = "unknown"
+	OutputNullable           OutputNullability = "nullable"
+	OutputDefinitelyNonNull  OutputNullability = "definitely_non_null"
+)
+
+func (n OutputNullability) ArrowNullable() bool {
+	return n != OutputDefinitelyNonNull
+}
+
+// OutputFieldProvenance is intentionally opaque outside the query package.
+// It carries the governed derivation evidence needed to explain a decision,
+// but its source and relationship details must never become response metadata.
+type OutputFieldProvenance struct {
+	sourceRef            string
+	dataset              string
+	physicalField        string
+	relationshipPath     []string
+	relationshipNullable bool
+	transformation       string
+	metricEmpty          string
+}
+
+// OutputFieldDescriptor is one ordered field in the final governed response.
+type OutputFieldDescriptor struct {
+	Alias       string                `json:"alias"`
+	LogicalType string                `json:"logical_type"`
+	Nullability OutputNullability     `json:"nullability"`
+	Provenance  OutputFieldProvenance `json:"-"`
+}
+
+func (f OutputFieldDescriptor) ArrowNullable() bool {
+	return f.Nullability.ArrowNullable()
+}
+
+// OutputSchemaDescriptor preserves the final governed projection order.
+type OutputSchemaDescriptor struct {
+	Fields []OutputFieldDescriptor `json:"fields"`
+}
+
+func (d OutputSchemaDescriptor) Validate() error {
+	seen := make(map[string]struct{}, len(d.Fields))
+	for index, field := range d.Fields {
+		if strings.TrimSpace(field.Alias) == "" || field.Alias != strings.TrimSpace(field.Alias) {
+			return fmt.Errorf("output schema field %d has invalid alias %q", index, field.Alias)
+		}
+		if _, exists := seen[field.Alias]; exists {
+			return fmt.Errorf("output schema repeats alias %q", field.Alias)
+		}
+		seen[field.Alias] = struct{}{}
+		if strings.TrimSpace(field.LogicalType) == "" || field.LogicalType != strings.TrimSpace(field.LogicalType) {
+			return fmt.Errorf("output schema field %q has invalid logical type %q", field.Alias, field.LogicalType)
+		}
+		switch field.Nullability {
+		case OutputNullabilityUnknown, OutputNullable, OutputDefinitelyNonNull:
+		default:
+			return fmt.Errorf("output schema field %q has invalid nullability %q", field.Alias, field.Nullability)
+		}
+	}
+	return nil
+}
+
+type derivedOutputField struct {
+	logicalType string
+	nullability OutputNullability
+	provenance  OutputFieldProvenance
+}
+
+// DescribeOutputSchema derives the response schema from the validated final
+// PlanIR and the activation-owned compiled schema. It never observes result
+// rows, Arrow null counts, or DuckDB field nullability.
+func (p *Planner) DescribeOutputSchema(plan Plan) (OutputSchemaDescriptor, error) {
+	if p == nil || p.compiled == nil {
+		return OutputSchemaDescriptor{}, fmt.Errorf("compiled planner is required")
+	}
+	if plan.IR == nil {
+		return OutputSchemaDescriptor{}, fmt.Errorf("governed plan has no PlanIR output schema evidence")
+	}
+	if err := plan.IR.Validate(); err != nil {
+		return OutputSchemaDescriptor{}, fmt.Errorf("validate output schema PlanIR: %w", err)
+	}
+	states, err := p.deriveOutputNode(plan.IR, plan.IR.Output, map[string]map[string]derivedOutputField{}, map[string]bool{})
+	if err != nil {
+		return OutputSchemaDescriptor{}, err
+	}
+	output, ok := plan.IR.Nodes[plan.IR.Output]
+	if !ok {
+		return OutputSchemaDescriptor{}, fmt.Errorf("governed PlanIR output %q is unavailable", plan.IR.Output)
+	}
+	aliases, err := outputFieldOrder(output)
+	if err != nil {
+		return OutputSchemaDescriptor{}, err
+	}
+	descriptor := OutputSchemaDescriptor{Fields: make([]OutputFieldDescriptor, len(aliases))}
+	for index, alias := range aliases {
+		state, exists := states[alias]
+		if !exists {
+			state = derivedOutputField{nullability: OutputNullabilityUnknown}
+		}
+		descriptor.Fields[index] = OutputFieldDescriptor{
+			Alias: alias, LogicalType: state.logicalType,
+			Nullability: state.nullability, Provenance: cloneOutputProvenance(state.provenance),
+		}
+	}
+	if len(plan.Columns) != 0 {
+		if len(plan.Columns) != len(descriptor.Fields) {
+			return OutputSchemaDescriptor{}, fmt.Errorf("governed plan columns and output descriptor differ: %d != %d", len(plan.Columns), len(descriptor.Fields))
+		}
+		for index, column := range plan.Columns {
+			if column != descriptor.Fields[index].Alias {
+				return OutputSchemaDescriptor{}, fmt.Errorf("governed plan column %d is %q, descriptor is %q", index, column, descriptor.Fields[index].Alias)
+			}
+		}
+	}
+	if err := descriptor.Validate(); err != nil {
+		return OutputSchemaDescriptor{}, err
+	}
+	return descriptor, nil
+}
+
+func (p *Planner) deriveOutputNode(graph *planir.Graph, id string, memo map[string]map[string]derivedOutputField, visiting map[string]bool) (map[string]derivedOutputField, error) {
+	if cached, ok := memo[id]; ok {
+		return cloneDerivedOutputFields(cached), nil
+	}
+	if visiting[id] {
+		return nil, fmt.Errorf("output schema PlanIR cycle includes %q", id)
+	}
+	node, ok := graph.Nodes[id]
+	if !ok {
+		return nil, fmt.Errorf("output schema PlanIR node %q is unavailable", id)
+	}
+	visiting[id] = true
+	defer delete(visiting, id)
+
+	var states map[string]derivedOutputField
+	var err error
+	switch value := node.(type) {
+	case planir.ScanDataset:
+		states = p.deriveScanOutput(value.NodeMeta)
+	case planir.TraverseRelationship:
+		states, err = p.deriveOutputNode(graph, value.Input, memo, visiting)
+	case planir.FilterRows:
+		states, err = p.deriveOutputNode(graph, value.Input, memo, visiting)
+	case planir.AggregateMetrics:
+		var input map[string]derivedOutputField
+		input, err = p.deriveOutputNode(graph, value.Input, memo, visiting)
+		if err == nil {
+			states = deriveAggregateOutput(value, input)
+		}
+	case planir.StitchAggregates:
+		states = deriveStitchOutput(value)
+	case planir.ComputeRatio:
+		states, err = p.deriveOutputNode(graph, value.Input, memo, visiting)
+		if err == nil {
+			states[value.Output] = derivedOutputField{
+				logicalType: logicalTypeFromMeta(value.NodeMeta, value.Output),
+				nullability: OutputNullable,
+				provenance:  OutputFieldProvenance{sourceRef: value.Output, transformation: "ratio"},
+			}
+		}
+	case planir.ComputeDerived:
+		states, err = p.deriveOutputNode(graph, value.Input, memo, visiting)
+		if err == nil {
+			states[value.Output] = derivedOutputField{
+				logicalType: logicalTypeFromMeta(value.NodeMeta, value.Output),
+				nullability: deriveExpressionNullability(value.Expression, states),
+				provenance:  OutputFieldProvenance{sourceRef: value.Output, transformation: "derived_expression"},
+			}
+		}
+	case planir.SortLimit:
+		var input map[string]derivedOutputField
+		input, err = p.deriveOutputNode(graph, value.Input, memo, visiting)
+		if err == nil {
+			states, err = deriveProjectionOutput(value, input)
+		}
+	case planir.TotalRows:
+		states, err = p.deriveOutputNode(graph, value.Input, memo, visiting)
+		if err == nil {
+			states[value.TotalField] = derivedOutputField{
+				logicalType: "integer", nullability: OutputDefinitelyNonNull,
+				provenance: OutputFieldProvenance{sourceRef: value.TotalField, transformation: "count"},
+			}
+		}
+	default:
+		states, err = deriveUnknownNodeOutput(graph, node, p, memo, visiting)
+	}
+	if err != nil {
+		return nil, err
+	}
+	memo[id] = cloneDerivedOutputFields(states)
+	return cloneDerivedOutputFields(states), nil
+}
+
+func (p *Planner) deriveScanOutput(meta planir.NodeMeta) map[string]derivedOutputField {
+	states := make(map[string]derivedOutputField, len(meta.AvailableFields)+len(meta.AvailableMetrics))
+	for _, field := range meta.AvailableFields {
+		states[field.Name] = p.derivePhysicalOutput(meta, field.Name, field.Type)
+	}
+	for _, metric := range meta.AvailableMetrics {
+		states[metric.Name] = derivedOutputField{
+			logicalType: metric.Type, nullability: metricNullability("", metric.Empty),
+			provenance: OutputFieldProvenance{sourceRef: metric.Name, transformation: "metric", metricEmpty: metric.Empty},
+		}
+	}
+	return states
+}
+
+func (p *Planner) derivePhysicalOutput(meta planir.NodeMeta, name, logicalType string) derivedOutputField {
+	state := derivedOutputField{
+		logicalType: logicalType, nullability: OutputNullabilityUnknown,
+		provenance: OutputFieldProvenance{sourceRef: name, transformation: "projection"},
+	}
+	found := false
+	for _, lineage := range meta.PhysicalLineage {
+		if lineage.Logical != name {
+			continue
+		}
+		candidate := p.physicalOutputNullability(lineage)
+		if !found {
+			state.nullability = candidate
+			state.provenance.dataset = lineage.Dataset
+			state.provenance.physicalField = lineage.Field
+			state.provenance.relationshipPath = append([]string(nil), lineage.Route...)
+			state.provenance.relationshipNullable = len(lineage.Route) != 0
+			found = true
+		} else {
+			state.nullability = mergeOutputNullability(state.nullability, candidate)
+			if len(lineage.Route) != 0 {
+				state.provenance.relationshipNullable = true
+			}
+		}
+	}
+	return state
+}
+
+func (p *Planner) physicalOutputNullability(lineage planir.PhysicalLineage) OutputNullability {
+	if len(lineage.Route) != 0 {
+		return OutputNullable
+	}
+	table, ok := p.datasetTable(lineage.Dataset)
+	if !ok {
+		return OutputNullabilityUnknown
+	}
+	name := fieldAlias(lineage.Field)
+	for _, column := range table.Schema.Columns {
+		if column.Name != name {
+			continue
+		}
+		if column.Nullable == nil {
+			return OutputNullabilityUnknown
+		}
+		if *column.Nullable {
+			return OutputNullable
+		}
+		return OutputDefinitelyNonNull
+	}
+	return OutputNullabilityUnknown
+}
+
+func deriveAggregateOutput(node planir.AggregateMetrics, input map[string]derivedOutputField) map[string]derivedOutputField {
+	states := make(map[string]derivedOutputField, len(node.GroupBy)+len(node.Metrics))
+	for _, name := range node.GroupBy {
+		state, ok := input[name]
+		if !ok {
+			state = derivedOutputField{logicalType: logicalTypeFromMeta(node.NodeMeta, name), nullability: OutputNullabilityUnknown}
+		}
+		states[name] = state
+	}
+	for _, bucket := range node.TimeBuckets {
+		state, ok := input[bucket.Field]
+		if !ok {
+			state = derivedOutputField{nullability: OutputNullabilityUnknown}
+		}
+		state.logicalType = logicalTypeFromMeta(node.NodeMeta, bucket.Field)
+		state.provenance.transformation = "time_bucket"
+		states[bucket.Field] = state
+	}
+	for _, metric := range node.Metrics {
+		states[metric.Name] = derivedOutputField{
+			logicalType: metric.Type,
+			nullability: metricNullability(metric.Aggregation, metric.Empty),
+			provenance:  OutputFieldProvenance{sourceRef: metric.Name, transformation: "aggregate", metricEmpty: metric.Empty},
+		}
+	}
+	return states
+}
+
+func deriveStitchOutput(node planir.StitchAggregates) map[string]derivedOutputField {
+	states := make(map[string]derivedOutputField, len(node.AvailableFields)+len(node.AvailableMetrics))
+	for _, field := range node.AvailableFields {
+		nullability := OutputNullable
+		if field.Name == "__scalar_key" {
+			nullability = OutputDefinitelyNonNull
+		}
+		states[field.Name] = derivedOutputField{
+			logicalType: field.Type, nullability: nullability,
+			provenance: OutputFieldProvenance{sourceRef: field.Name, transformation: "full_outer_stitch"},
+		}
+	}
+	for _, metric := range node.AvailableMetrics {
+		states[metric.Name] = derivedOutputField{
+			logicalType: metric.Type, nullability: metricNullability("", metric.Empty),
+			provenance: OutputFieldProvenance{sourceRef: metric.Name, transformation: "full_outer_stitch", metricEmpty: metric.Empty},
+		}
+	}
+	return states
+}
+
+func deriveProjectionOutput(node planir.SortLimit, input map[string]derivedOutputField) (map[string]derivedOutputField, error) {
+	states := make(map[string]derivedOutputField, len(node.Projection))
+	for _, projection := range node.Projection {
+		state, ok := input[projection.Source]
+		if !ok {
+			state = derivedOutputField{logicalType: logicalTypeFromMeta(node.NodeMeta, projection.Name), nullability: OutputNullabilityUnknown}
+		}
+		state.provenance = cloneOutputProvenance(state.provenance)
+		state.provenance.sourceRef = projection.Source
+		switch strings.ToLower(strings.TrimSpace(projection.Mask)) {
+		case "":
+		case "null":
+			state.nullability = OutputNullable
+			state.provenance.transformation = "mask_null"
+		case "redact", "redacted":
+			state.nullability = OutputDefinitelyNonNull
+			state.provenance.transformation = "mask_redact"
+		case "zero":
+			state.nullability = OutputDefinitelyNonNull
+			state.provenance.transformation = "mask_zero"
+		default:
+			return nil, fmt.Errorf("output schema projection %q has unsupported mask %q", projection.Name, projection.Mask)
+		}
+		if state.logicalType == "" {
+			state.logicalType = logicalTypeFromMeta(node.NodeMeta, projection.Name)
+		}
+		states[projection.Name] = state
+	}
+	return states, nil
+}
+
+func deriveUnknownNodeOutput(graph *planir.Graph, node planir.Node, p *Planner, memo map[string]map[string]derivedOutputField, visiting map[string]bool) (map[string]derivedOutputField, error) {
+	states := map[string]derivedOutputField{}
+	inputs := node.Inputs()
+	if len(inputs) == 1 {
+		input, err := p.deriveOutputNode(graph, inputs[0], memo, visiting)
+		if err != nil {
+			return nil, err
+		}
+		states = input
+	}
+	for _, field := range node.Meta().AvailableFields {
+		if _, ok := states[field.Name]; !ok {
+			states[field.Name] = derivedOutputField{logicalType: field.Type, nullability: OutputNullabilityUnknown}
+		}
+	}
+	for _, metric := range node.Meta().AvailableMetrics {
+		if _, ok := states[metric.Name]; !ok {
+			states[metric.Name] = derivedOutputField{logicalType: metric.Type, nullability: OutputNullabilityUnknown}
+		}
+	}
+	return states, nil
+}
+
+func deriveExpressionNullability(expression planir.ScalarExpr, fields map[string]derivedOutputField) OutputNullability {
+	switch expression.Kind {
+	case planir.ScalarMetricRef:
+		if field, ok := fields[expression.Metric]; ok {
+			return field.nullability
+		}
+		return OutputNullabilityUnknown
+	case planir.ScalarLiteral:
+		return OutputDefinitelyNonNull
+	case planir.ScalarNeg, planir.ScalarPos:
+		if len(expression.Children) != 1 {
+			return OutputNullabilityUnknown
+		}
+		return deriveExpressionNullability(expression.Children[0], fields)
+	case planir.ScalarAdd, planir.ScalarSub, planir.ScalarMul:
+		return combineRequiredInputs(expression.Children, fields)
+	case planir.ScalarDiv, planir.ScalarSafeDiv:
+		return OutputNullable
+	case planir.ScalarFunction:
+		switch strings.ToLower(expression.Function) {
+		case "coalesce":
+			allNullable := len(expression.Children) != 0
+			for _, child := range expression.Children {
+				nullability := deriveExpressionNullability(child, fields)
+				if nullability == OutputDefinitelyNonNull {
+					return OutputDefinitelyNonNull
+				}
+				if nullability != OutputNullable {
+					allNullable = false
+				}
+			}
+			if allNullable {
+				return OutputNullable
+			}
+			return OutputNullabilityUnknown
+		case "nullif", "safe_divide":
+			return OutputNullable
+		case "abs", "round":
+			if len(expression.Children) == 0 {
+				return OutputNullabilityUnknown
+			}
+			return deriveExpressionNullability(expression.Children[0], fields)
+		default:
+			return OutputNullabilityUnknown
+		}
+	default:
+		return OutputNullabilityUnknown
+	}
+}
+
+func combineRequiredInputs(children []planir.ScalarExpr, fields map[string]derivedOutputField) OutputNullability {
+	unknown := false
+	for _, child := range children {
+		switch deriveExpressionNullability(child, fields) {
+		case OutputNullable:
+			return OutputNullable
+		case OutputNullabilityUnknown:
+			unknown = true
+		}
+	}
+	if unknown || len(children) == 0 {
+		return OutputNullabilityUnknown
+	}
+	return OutputDefinitelyNonNull
+}
+
+func metricNullability(aggregation, empty string) OutputNullability {
+	switch strings.ToUpper(strings.TrimSpace(aggregation)) {
+	case "COUNT", "COUNT_STAR", "COUNT_DISTINCT", "COUNT_DISTINCT_PAIR":
+		return OutputDefinitelyNonNull
+	}
+	switch strings.ToLower(strings.TrimSpace(empty)) {
+	case "zero":
+		return OutputDefinitelyNonNull
+	case "null":
+		return OutputNullable
+	default:
+		return OutputNullabilityUnknown
+	}
+}
+
+func mergeOutputNullability(left, right OutputNullability) OutputNullability {
+	if left == OutputNullable || right == OutputNullable {
+		return OutputNullable
+	}
+	if left == OutputNullabilityUnknown || right == OutputNullabilityUnknown {
+		return OutputNullabilityUnknown
+	}
+	return OutputDefinitelyNonNull
+}
+
+func outputFieldOrder(node planir.Node) ([]string, error) {
+	switch value := node.(type) {
+	case planir.SortLimit:
+		aliases := make([]string, len(value.Projection))
+		for index, projection := range value.Projection {
+			aliases[index] = projection.Name
+		}
+		return aliases, nil
+	case planir.TotalRows:
+		return outputMetaNames(value.NodeMeta), nil
+	default:
+		return nil, fmt.Errorf("governed PlanIR output %q has no final projection descriptor", node.Meta().NodeID)
+	}
+}
+
+func outputMetaNames(meta planir.NodeMeta) []string {
+	values := make([]string, 0, len(meta.AvailableFields)+len(meta.AvailableMetrics))
+	for _, field := range meta.AvailableFields {
+		values = append(values, field.Name)
+	}
+	for _, metric := range meta.AvailableMetrics {
+		values = append(values, metric.Name)
+	}
+	return values
+}
+
+func logicalTypeFromMeta(meta planir.NodeMeta, name string) string {
+	for _, field := range meta.AvailableFields {
+		if field.Name == name {
+			return field.Type
+		}
+	}
+	for _, metric := range meta.AvailableMetrics {
+		if metric.Name == name {
+			return metric.Type
+		}
+	}
+	return ""
+}
+
+func cloneDerivedOutputFields(values map[string]derivedOutputField) map[string]derivedOutputField {
+	out := make(map[string]derivedOutputField, len(values))
+	for name, field := range values {
+		field.provenance = cloneOutputProvenance(field.provenance)
+		out[name] = field
+	}
+	return out
+}
+
+func cloneOutputProvenance(value OutputFieldProvenance) OutputFieldProvenance {
+	value.relationshipPath = append([]string(nil), value.relationshipPath...)
+	return value
+}

--- a/internal/analytics/query/output_schema.go
+++ b/internal/analytics/query/output_schema.go
@@ -411,11 +411,13 @@ func deriveExpressionNullability(expression planir.ScalarExpr, fields map[string
 			return OutputNullabilityUnknown
 		case "nullif", "safe_divide":
 			return OutputNullable
-		case "abs", "round":
+		case "abs":
 			if len(expression.Children) == 0 {
 				return OutputNullabilityUnknown
 			}
 			return deriveExpressionNullability(expression.Children[0], fields)
+		case "round":
+			return combineRequiredInputs(expression.Children, fields)
 		default:
 			return OutputNullabilityUnknown
 		}

--- a/internal/analytics/query/output_schema_test.go
+++ b/internal/analytics/query/output_schema_test.go
@@ -1,0 +1,183 @@
+package query
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+)
+
+func TestDescribeOutputSchemaDerivesGovernedRowNullability(t *testing.T) {
+	planner := mustNewCompiledPlanner(t, outputSchemaTestModel())
+	plan, err := planner.PlanRows(RowRequest{
+		Dataset: "orders",
+		Dimensions: []Field{
+			{Field: "orders.order_id", Alias: "id"},
+			{Field: "orders.status", Alias: "order_status"},
+			{Field: "customer_state", Alias: "customer_state"},
+			{Field: "orders.unclassified", Alias: "unclassified"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	descriptor, err := planner.DescribeOutputSchema(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantAliases := []string{"id", "order_status", "customer_state", "unclassified"}
+	wantTypes := []string{"integer", "string", "string", "string"}
+	wantNullability := []OutputNullability{
+		OutputDefinitelyNonNull,
+		OutputNullable,
+		OutputNullable,
+		OutputNullabilityUnknown,
+	}
+	if len(descriptor.Fields) != len(wantAliases) {
+		t.Fatalf("descriptor fields = %d, want %d", len(descriptor.Fields), len(wantAliases))
+	}
+	for index, field := range descriptor.Fields {
+		if field.Alias != wantAliases[index] || field.LogicalType != wantTypes[index] || field.Nullability != wantNullability[index] {
+			t.Fatalf("field %d = %#v, want alias=%q type=%q nullability=%q", index, field, wantAliases[index], wantTypes[index], wantNullability[index])
+		}
+	}
+	if !descriptor.Fields[2].Provenance.relationshipNullable || len(descriptor.Fields[2].Provenance.relationshipPath) != 1 {
+		t.Fatalf("joined field provenance = %#v", descriptor.Fields[2].Provenance)
+	}
+	if descriptor.Fields[0].ArrowNullable() {
+		t.Fatal("proved local NOT NULL field serialized as nullable")
+	}
+	if !descriptor.Fields[3].ArrowNullable() {
+		t.Fatal("unknown source nullability serialized as non-null")
+	}
+}
+
+func TestDescribeOutputSchemaAppliesMaskNullability(t *testing.T) {
+	tests := []struct {
+		name string
+		mask string
+		want OutputNullability
+	}{
+		{name: "null introduces null", mask: "null", want: OutputNullable},
+		{name: "redaction replaces with value", mask: "redact", want: OutputDefinitelyNonNull},
+		{name: "zero replaces with value", mask: "zero", want: OutputDefinitelyNonNull},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			planner := mustNewCompiledPlanner(t, outputSchemaTestModel())
+			plan, err := planner.PlanRows(RowRequest{
+				Dataset:     "orders",
+				Dimensions:  []Field{{Field: "orders.status", Alias: "status"}},
+				ColumnMasks: []ColumnMask{{Field: "orders.status", Mask: test.mask}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			descriptor, err := planner.DescribeOutputSchema(plan)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := descriptor.Fields[0].Nullability; got != test.want {
+				t.Fatalf("mask %q nullability = %q, want %q", test.mask, got, test.want)
+			}
+		})
+	}
+}
+
+func TestDescribeOutputSchemaDerivesMetricAndCalculationNullability(t *testing.T) {
+	planner := mustNewCompiledPlanner(t, outputSchemaTestModel())
+	plan, err := planner.Plan(Request{Metrics: []Field{
+		{Field: "order_count", Alias: "count"},
+		{Field: "nullable_revenue", Alias: "nullable_total"},
+		{Field: "revenue_or_zero", Alias: "filled_total"},
+		{Field: "revenue_ratio", Alias: "ratio"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := planner.DescribeOutputSchema(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []OutputNullability{
+		OutputDefinitelyNonNull,
+		OutputNullable,
+		OutputDefinitelyNonNull,
+		OutputNullable,
+	}
+	for index, field := range descriptor.Fields {
+		if field.Nullability != want[index] {
+			t.Fatalf("metric field %q nullability = %q, want %q", field.Alias, field.Nullability, want[index])
+		}
+	}
+}
+
+func TestDescribeOutputSchemaDoesNotInferFromPaginationOrExposeProvenance(t *testing.T) {
+	planner := mustNewCompiledPlanner(t, outputSchemaTestModel())
+	request := RowRequest{Dataset: "orders", Dimensions: []Field{{Field: "orders.order_id", Alias: "id"}, {Field: "orders.status", Alias: "status"}}}
+	ordinary, err := planner.PlanRows(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyPage, err := planner.PlanRows(RowRequest{Dataset: request.Dataset, Dimensions: request.Dimensions, Limit: 1, Offset: 1_000_000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ordinaryDescriptor, err := planner.DescribeOutputSchema(ordinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyDescriptor, err := planner.DescribeOutputSchema(emptyPage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ordinaryDescriptor, emptyDescriptor) {
+		t.Fatalf("empty-page descriptor changed:\nordinary=%#v\nempty=%#v", ordinaryDescriptor, emptyDescriptor)
+	}
+
+	payload, err := json.Marshal(ordinaryDescriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(payload) != `{"fields":[{"alias":"id","logical_type":"integer","nullability":"definitely_non_null"},{"alias":"status","logical_type":"string","nullability":"nullable"}]}` {
+		t.Fatalf("serialized descriptor exposed internal provenance: %s", payload)
+	}
+}
+
+func outputSchemaTestModel() *semanticmodel.Model {
+	model := testModel()
+	nonNull := false
+	nullable := true
+	model.Tables["orders"] = outputSchemaTable(model.Tables["orders"], []semanticmodel.ColumnSchema{
+		{Name: "order_id", Nullable: &nonNull},
+		{Name: "customer_id", Nullable: &nonNull},
+		{Name: "status", Nullable: &nullable},
+		{Name: "revenue", Nullable: &nullable},
+		{Name: "unclassified"},
+	})
+	model.Tables["customers"] = outputSchemaTable(model.Tables["customers"], []semanticmodel.ColumnSchema{
+		{Name: "customer_id", Nullable: &nonNull},
+		{Name: "state", Nullable: &nonNull},
+	})
+	model.Tables["tags"] = outputSchemaTable(model.Tables["tags"], []semanticmodel.ColumnSchema{
+		{Name: "tag_id", Nullable: &nonNull},
+		{Name: "customer_id", Nullable: &nonNull},
+	})
+	orders := model.Tables["orders"]
+	orders.Dimensions["unclassified"] = semanticmodel.MetricDimension{Type: "string", Datatype: semanticmodel.DataTypeString}
+	model.Tables["orders"] = orders
+	model.Metrics["nullable_revenue"] = semanticmodel.Metric{
+		Type: "aggregate", Dataset: "orders", Aggregation: "sum",
+		Input: &semanticmodel.MetricInput{Field: "orders.revenue"}, Empty: "null",
+	}
+	model.Metrics["revenue_or_zero"] = semanticmodel.Metric{Type: "derived", Expression: "coalesce(${nullable_revenue}, 0)"}
+	model.Metrics["revenue_ratio"] = semanticmodel.Metric{Type: "derived", Expression: "safe_divide(${nullable_revenue}, ${order_count})"}
+	return model
+}
+
+func outputSchemaTable(table semanticmodel.Table, columns []semanticmodel.ColumnSchema) semanticmodel.Table {
+	table.Schema = semanticmodel.TableSchema{Columns: columns}
+	return table
+}

--- a/internal/analytics/query/output_schema_test.go
+++ b/internal/analytics/query/output_schema_test.go
@@ -114,6 +114,28 @@ func TestDescribeOutputSchemaDerivesMetricAndCalculationNullability(t *testing.T
 	}
 }
 
+func TestDescribeOutputSchemaRoundRequiresNonNullOptionalDigits(t *testing.T) {
+	model := outputSchemaTestModel()
+	model.Metrics["nullable_digits"] = semanticmodel.Metric{
+		Type: "derived", Expression: "nullif(${order_count}, ${order_count})",
+	}
+	model.Metrics["rounded"] = semanticmodel.Metric{
+		Type: "derived", Expression: "round(${order_count}, ${nullable_digits})",
+	}
+	planner := mustNewCompiledPlanner(t, model)
+	plan, err := planner.Plan(Request{Metrics: []Field{{Field: "rounded"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := planner.DescribeOutputSchema(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := descriptor.Fields[0].Nullability; got != OutputNullable {
+		t.Fatalf("round with nullable digits nullability = %q, want %q", got, OutputNullable)
+	}
+}
+
 func TestDescribeOutputSchemaDoesNotInferFromPaginationOrExposeProvenance(t *testing.T) {
 	planner := mustNewCompiledPlanner(t, outputSchemaTestModel())
 	request := RowRequest{Dataset: "orders", Dimensions: []Field{{Field: "orders.order_id", Alias: "id"}, {Field: "orders.status", Alias: "status"}}}

--- a/internal/dashboard/http/arrow_contract_test.go
+++ b/internal/dashboard/http/arrow_contract_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/flidai/leapview/internal/analytics/arrowquery"
 	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	httptransport "github.com/flidai/leapview/internal/platform/http/transport"
 )
 
@@ -272,6 +273,95 @@ func TestDashboardNativeArrowContractErrorsRespectCommitBoundary(t *testing.T) {
 	})
 }
 
+func TestDashboardNativeArrowContractRejectsRuntimeNullabilityMismatch(t *testing.T) {
+	descriptor := semanticquery.OutputSchemaDescriptor{Fields: []semanticquery.OutputFieldDescriptor{{
+		Alias: "order_id", LogicalType: "integer", Nullability: semanticquery.OutputDefinitelyNonNull,
+	}}}
+	physicalSchema := arrow.NewSchema([]arrow.Field{{Name: "order_id", Type: arrow.PrimitiveTypes.Int64, Nullable: true}}, nil)
+
+	t.Run("before commitment returns structured problem", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		native := &dashboardNativeArrowNullabilityContractSink{w: recorder}
+		sink, err := arrowquery.NewOutputSchemaSink(descriptor, native)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := sink.WriteSchema(physicalSchema); err != nil {
+			t.Fatal(err)
+		}
+		invalid := dashboardNativeArrowNullabilityRecord(t, physicalSchema, false)
+		err = sink.WriteRecord(invalid)
+		invalid.Release()
+		var mismatch *arrowquery.NullabilityViolationError
+		if !errors.As(err, &mismatch) || mismatch.Alias != "order_id" {
+			t.Fatalf("nullability mismatch = %#v / %v", mismatch, err)
+		}
+		if native.committed() {
+			t.Fatal("invalid first batch committed an Arrow response")
+		}
+		request := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/dashboards/sales/pages/main/visuals/orders/query", nil)
+		httptransport.WriteProblem(recorder, request, stdhttp.StatusInternalServerError, "NATIVE_ARROW_NULLABILITY_MISMATCH", "native Arrow nullability contract mismatch", nil)
+		response := recorder.Result()
+		defer response.Body.Close()
+		if got := response.Header.Get("Content-Type"); got != "application/problem+json" {
+			t.Fatalf("content type = %q, want problem JSON", got)
+		}
+		if got := response.Header.Get("X-LeapView-Arrow-Contract"); got != "" {
+			t.Fatalf("pre-commit mismatch claimed Arrow contract %q", got)
+		}
+		if got := response.Trailer.Get("X-Next-Cursor"); got != "" {
+			t.Fatalf("pre-commit mismatch exposed cursor %q", got)
+		}
+		var problem httptransport.ProblemDetails
+		if err := json.NewDecoder(response.Body).Decode(&problem); err != nil {
+			t.Fatal(err)
+		}
+		if problem.Code != "NATIVE_ARROW_NULLABILITY_MISMATCH" {
+			t.Fatalf("problem code = %q", problem.Code)
+		}
+	})
+
+	t.Run("after commitment terminates stream without cursor", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		native := &dashboardNativeArrowNullabilityContractSink{w: recorder}
+		sink, err := arrowquery.NewOutputSchemaSink(descriptor, native)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := sink.WriteSchema(physicalSchema); err != nil {
+			t.Fatal(err)
+		}
+		valid := dashboardNativeArrowNullabilityRecord(t, physicalSchema, true)
+		if err := sink.WriteRecord(valid); err != nil {
+			valid.Release()
+			t.Fatal(err)
+		}
+		valid.Release()
+		if !native.committed() {
+			t.Fatal("valid first batch did not commit the Arrow response")
+		}
+		invalid := dashboardNativeArrowNullabilityRecord(t, physicalSchema, false)
+		err = sink.WriteRecord(invalid)
+		invalid.Release()
+		var mismatch *arrowquery.NullabilityViolationError
+		if !errors.As(err, &mismatch) {
+			t.Fatalf("second-batch mismatch = %v", err)
+		}
+		// A future transport must make the already-committed stream observably
+		// incomplete. This test-only marker models termination without changing
+		// the current native semantic response implementation.
+		_, _ = recorder.Write([]byte{0xff, 0xff, 0xff, 0xff, 0x04, 0x00, 0x00, 0x00, 0x42, 0x42})
+		response := recorder.Result()
+		defer response.Body.Close()
+		if err := consumeDashboardNativeArrow(response.Body); err == nil {
+			t.Fatal("post-commit nullability mismatch looked like a successful Arrow stream")
+		}
+		if got := response.Trailer.Get("X-Next-Cursor"); got != "" {
+			t.Fatalf("post-commit mismatch exposed success cursor %q", got)
+		}
+	})
+}
+
 func TestDashboardNativeArrowContractChargesSchemaAndPaginationProbeToBudgets(t *testing.T) {
 	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	schema, record := newDashboardNativeArrowContractFixture(t, allocator)
@@ -459,6 +549,62 @@ func newDashboardNativeArrowContractFixture(t testing.TB, allocator memory.Alloc
 	}
 	return schema, record
 }
+
+func dashboardNativeArrowNullabilityRecord(t testing.TB, schema *arrow.Schema, valid bool) arrow.RecordBatch {
+	t.Helper()
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.AppendValues([]int64{101}, []bool{valid})
+	column := builder.NewArray()
+	builder.Release()
+	record := array.NewRecordBatch(schema, []arrow.Array{column}, 1)
+	column.Release()
+	return record
+}
+
+type dashboardNativeArrowNullabilityContractSink struct {
+	w      *httptest.ResponseRecorder
+	schema *arrow.Schema
+	writer *ipc.Writer
+}
+
+func (s *dashboardNativeArrowNullabilityContractSink) WriteSchema(schema *arrow.Schema) error {
+	if schema == nil {
+		return errors.New("native Arrow nullability fixture schema is required")
+	}
+	fields := schema.Fields()
+	for index := range fields {
+		fields[index].Metadata = arrow.NewMetadata(
+			append([]string(nil), fields[index].Metadata.Keys()...),
+			append([]string(nil), fields[index].Metadata.Values()...),
+		)
+	}
+	metadata := schema.Metadata()
+	metadata = arrow.NewMetadata(append([]string(nil), metadata.Keys()...), append([]string(nil), metadata.Values()...))
+	s.schema = arrow.NewSchema(fields, &metadata)
+	return nil
+}
+
+func (s *dashboardNativeArrowNullabilityContractSink) WriteRecord(record arrow.RecordBatch) error {
+	if s.schema == nil {
+		return errors.New("native Arrow nullability fixture schema must be written first")
+	}
+	if s.writer == nil {
+		s.w.Header().Set("Content-Type", "application/vnd.apache.arrow.stream")
+		s.w.Header().Set("Cache-Control", "no-store")
+		s.w.Header().Set("X-Query-ID", dashboardNativeArrowQueryID)
+		s.w.Header().Set("X-Serving-Snapshot", dashboardNativeArrowSnapshot)
+		s.w.Header().Set("X-LeapView-Arrow-Contract", dashboardNativeArrowContract)
+		s.w.Header().Set("Trailer", "X-Next-Cursor")
+		s.writer = ipc.NewWriter(s.w, ipc.WithSchema(s.schema))
+	}
+	return s.writer.Write(record)
+}
+
+func (s *dashboardNativeArrowNullabilityContractSink) committed() bool {
+	return s != nil && s.writer != nil
+}
+
+var _ arrowquery.Sink = (*dashboardNativeArrowNullabilityContractSink)(nil)
 
 func dashboardNativeArrowContractSchema(schema *arrow.Schema, logicalTypes map[string]string, queryID, snapshot string) *arrow.Schema {
 	metadata := publicDashboardNativeArrowMetadata(schema.Metadata(), nil, map[string]string{


### PR DESCRIPTION
## Problem

DuckDB Arrow field declarations are physical execution metadata and are not sufficient to define native-v1 response nullability. A source `NOT NULL` declaration can become nullable after a left relationship traversal, mask, aggregate empty-set behavior, calculation, or other governed transformation. Conversely, inferring nullability from returned rows, observed null counts, or an empty page would make the response schema data-dependent and unstable.

FAI-600 therefore needs a deterministic schema authority before any production native Arrow design can proceed.

## Solution

This PR implements governed effective nullability with conservative fallback as a foundation and executable contract oracle.

- Adds an ordered output schema descriptor containing the governed alias, logical type, tri-state effective nullability, and opaque internal provenance.
- Derives nullability from validated final governed PlanIR and compiled schema evidence.
- Emits `Nullable=false` only when the final post-governance expression is proven incapable of producing SQL `NULL`.
- Maps both nullable and unknown evidence to Arrow `Nullable=true`.
- Handles relationship traversal, masks, metric empty-set policy, calculations, derived expressions, aliases, and final projection order conservatively.
- Adds an unrouted Arrow sink that reconciles the governed declaration and validates every borrowed record batch synchronously.
- Rejects runtime nulls in declared non-null fields before downstream commitment when possible; the contract oracle requires post-commit failures to terminate the stream without a successful cursor trailer.
- Updates the dashboard native Arrow contract with nullability authority, empty-result stability, provenance safety, and mismatch behavior.

No production route constructs the new sink.

## Tests

Passed:

- `go test ./internal/analytics/query ./internal/analytics/arrowquery ./internal/dashboard/http ./internal/dashboard/queryauthz -count=1`
- `go test -race ./internal/analytics/query ./internal/analytics/arrowquery -run '^(TestDescribeOutputSchema|TestOutputSchemaSink)' -count=1`
- `go test -race ./internal/dashboard/http -run '^TestDashboardNativeArrowContract' -count=1`
- `go test ./internal/platform/architecture -count=1`
- `go test -tags=duckdb_arrow ./internal/app -count=1`
- `task docs:generate`
- `task docs:check`
- `task generated:check`
- `git diff --check`

`task ci:lane:go:packages` compiled and passed the FAI-600 packages and broader repository packages, then failed in `github.com/flidai/leapview/site` because this worktree does not contain two generated/vendor fixtures:

- `site/static/vendor/integrations/apacheiceberg.svg`
- `site/static/vendor/mcp-mark.svg`

Those files are not tracked or changed by this PR. No unrelated site/vendor files were modified to mask the environment limitation.

## Limitations

- This PR does not implement production native Arrow streaming.
- It does not change dashboard handlers, Arrow serving, routing, cache behavior, materialization, or retained-result lifecycle.
- The descriptor/enforcement sink remains an internal, unrouted foundation.
- FAI-601, FAI-602, FAI-603, and FAI-604 remain adoption blockers.
