### PR TITLE
fix(ci): repair ARM64 OCI admission for site deploys

### DIFF
--- a/.github/actions/oci-admission/action.yml
+++ b/.github/actions/oci-admission/action.yml
@@ -18,6 +18,9 @@ inputs:
     description: Pinned container vulnerability policy JSON.
     required: false
     default: .github/security/container-vulnerability-policy.json
+  platform:
+    description: Optional target image platform for deterministic vulnerability scanning.
+    required: false
   mode:
     description: live performs registry verification; hermetic validates evidence.
     required: false
@@ -55,6 +58,7 @@ runs:
         EXPECTED_WORKFLOW: ${{ inputs.expected-workflow }}
         SOURCE_REVISION: ${{ inputs.source-revision }}
         POLICY: ${{ inputs.policy }}
+        PLATFORM: ${{ inputs.platform }}
         MODE: ${{ inputs.mode }}
         EVIDENCE: ${{ inputs.evidence }}
         ADMISSION_OUTPUT: ${{ inputs.output }}
@@ -66,12 +70,17 @@ runs:
           output_path="$RUNNER_TEMP/oci-admission.json"
         fi
         cd "$GITHUB_ACTION_PATH/../../.."
+        platform_args=()
+        if [[ -n "$PLATFORM" ]]; then
+          platform_args=(--platform "$PLATFORM")
+        fi
         go run ./internal/app/tools/ociadmission \
           --image "$IMAGE" \
           --repository "$OCI_REPOSITORY" \
           --expected-workflow "$EXPECTED_WORKFLOW" \
           --source-revision "$SOURCE_REVISION" \
           --policy "$POLICY" \
+          "${platform_args[@]}" \
           --mode "$MODE" \
           --evidence "$EVIDENCE" \
           --output "$output_path"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,7 @@ jobs:
           repository: ${{ env.IMAGE_NAME }}
           expected-workflow: flidai/leapview/.github/workflows/release.yml
           source-revision: ${{ needs.identity.outputs.revision }}
+          platform: linux/${{ matrix.arch }}
 
       - name: Record admitted native image digest
         env:

--- a/.github/workflows/site-image.yml
+++ b/.github/workflows/site-image.yml
@@ -125,6 +125,7 @@ jobs:
           repository: ${{ env.IMAGE_NAME }}
           expected-workflow: flidai/leapview/.github/workflows/site-image.yml
           source-revision: ${{ needs.identity.outputs.revision }}
+          platform: linux/${{ matrix.arch }}
 
       - name: Record admitted native site image digest
         env:

--- a/internal/app/tools/ociadmission/admission.go
+++ b/internal/app/tools/ociadmission/admission.go
@@ -34,6 +34,7 @@ var (
 	revisionPattern      = regexp.MustCompile(`^[0-9a-f]{40}$`)
 	semverPattern        = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
 	digestPattern        = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	platformPattern      = regexp.MustCompile(`^linux/(amd64|arm64)$`)
 )
 
 type usageError struct{ message string }
@@ -46,6 +47,7 @@ type admissionOptions struct {
 	expectedWorkflow string
 	sourceRevision   string
 	policyPath       string
+	platform         string
 	mode             string
 	evidencePath     string
 	outputPath       string
@@ -77,9 +79,10 @@ type hermeticEvidence struct {
 		PredicateType string `json:"predicateType"`
 	} `json:"sbom"`
 	VulnerabilityPolicy struct {
-		SHA256  string `json:"sha256"`
-		Scanner string `json:"scanner"`
-		Passed  bool   `json:"passed"`
+		SHA256   string `json:"sha256"`
+		Scanner  string `json:"scanner"`
+		Passed   bool   `json:"passed"`
+		Platform string `json:"platform,omitempty"`
 	} `json:"vulnerabilityPolicy"`
 }
 
@@ -149,6 +152,7 @@ func parseOptions(args []string, stderr io.Writer) (admissionOptions, error) {
 	flags.StringVar(&opts.expectedWorkflow, "expected-workflow", "", "expected GitHub workflow")
 	flags.StringVar(&opts.sourceRevision, "source-revision", "", "source commit SHA")
 	flags.StringVar(&opts.policyPath, "policy", "", "vulnerability policy path")
+	flags.StringVar(&opts.platform, "platform", "", "target image platform (linux/amd64 or linux/arm64)")
 	flags.StringVar(&opts.mode, "mode", "live", "live or hermetic")
 	flags.StringVar(&opts.evidencePath, "evidence", "", "hermetic evidence path")
 	flags.StringVar(&opts.outputPath, "output", "", "optional output path")
@@ -158,6 +162,7 @@ func parseOptions(args []string, stderr io.Writer) (admissionOptions, error) {
 		fmt.Fprintln(stderr, "  --expected-workflow OWNER/REPO/.github/workflows/WORKFLOW.yml")
 		fmt.Fprintln(stderr, "  --source-revision HEX_SHA")
 		fmt.Fprintln(stderr, "  --policy PATH")
+		fmt.Fprintln(stderr, "  [--platform linux/amd64|linux/arm64]")
 		fmt.Fprintln(stderr, "  [--mode live|hermetic] [--evidence PATH] [--output PATH]")
 	}
 	if err := flags.Parse(args); err != nil {
@@ -190,6 +195,9 @@ func validateOptions(opts admissionOptions) error {
 	}
 	if !revisionPattern.MatchString(opts.sourceRevision) {
 		return errors.New("source revision must be a full commit SHA")
+	}
+	if opts.platform != "" && !platformPattern.MatchString(opts.platform) {
+		return errors.New("platform must be linux/amd64 or linux/arm64")
 	}
 	if info, err := os.Stat(opts.policyPath); err != nil || info.IsDir() {
 		return errors.New("vulnerability policy is missing")
@@ -261,7 +269,7 @@ func verifyHermetic(opts admissionOptions, policySHA256 string) error {
 	digest := opts.image[strings.LastIndex(opts.image, "@")+1:]
 	if evidence.SchemaVersion != 1 || evidence.Image != opts.image || evidence.Digest != digest || evidence.RegistryDigest != digest ||
 		!evidence.Attestation.Verified || evidence.Attestation.Repository != repositoryIdentity || evidence.Attestation.Workflow != opts.expectedWorkflow || evidence.Attestation.SourceRevision != opts.sourceRevision ||
-		!evidence.SBOM.Discoverable || evidence.SBOM.PredicateType != "https://spdx.dev/Document/v2.3" || evidence.VulnerabilityPolicy.SHA256 != policySHA256 || evidence.VulnerabilityPolicy.Scanner != "trivy" || !evidence.VulnerabilityPolicy.Passed {
+		!evidence.SBOM.Discoverable || evidence.SBOM.PredicateType != "https://spdx.dev/Document/v2.3" || evidence.VulnerabilityPolicy.SHA256 != policySHA256 || evidence.VulnerabilityPolicy.Scanner != "trivy" || !evidence.VulnerabilityPolicy.Passed || evidence.VulnerabilityPolicy.Platform != opts.platform {
 		return errors.New("hermetic evidence is missing verified identity, SBOM, digest, or policy")
 	}
 	return nil

--- a/internal/app/tools/ociadmission/main_test.go
+++ b/internal/app/tools/ociadmission/main_test.go
@@ -46,6 +46,19 @@ func TestHermeticAdmissionContract(t *testing.T) {
 	}
 }
 
+func TestHermeticAdmissionRejectsMismatchedScannerPlatform(t *testing.T) {
+	policyPath, policyHash := testPolicy(t)
+	evidence := writeEvidence(t, policyHash, func(e map[string]any) {
+		e["vulnerabilityPolicy"].(map[string]any)["platform"] = "linux/amd64"
+	})
+	args := append(admissionArgs(policyPath, testImage, evidence), "--platform", "linux/arm64")
+	var output bytes.Buffer
+	err := runAdmission(args, testEnv(nil), &output, &output)
+	if err == nil || !strings.Contains(err.Error(), "hermetic evidence") {
+		t.Fatalf("runAdmission error = %v, want mismatched hermetic scanner platform", err)
+	}
+}
+
 func TestLiveAdmissionContractWithFakeTools(t *testing.T) {
 	policyPath, _ := testPolicy(t)
 	tests := []struct {
@@ -74,6 +87,11 @@ func TestLiveAdmissionContractWithFakeTools(t *testing.T) {
 				}
 			} else if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("runAdmission error = %v, want %q", err, tc.want)
+			}
+			if tc.mode == "unavailable" {
+				if strings.Contains(err.Error(), "fixture-token") || !strings.Contains(err.Error(), "registry unavailable with token ***") {
+					t.Fatalf("runAdmission diagnostic = %q, want useful redacted scanner failure", err)
+				}
 			}
 		})
 	}
@@ -104,6 +122,16 @@ func TestLiveAdmissionRejectsMissingVerifier(t *testing.T) {
 	err := runAdmission(liveArgs(policyPath), testEnv(map[string]string{"PATH": t.TempDir(), "GITHUB_TOKEN": "test"}), &output, &output)
 	if err == nil || !strings.Contains(err.Error(), "verifier") || !strings.Contains(err.Error(), "missing") {
 		t.Fatalf("runAdmission error = %v", err)
+	}
+}
+
+func TestAdmissionRejectsInvalidPlatform(t *testing.T) {
+	policyPath, _ := testPolicy(t)
+	args := append(liveArgs(policyPath), "--platform", "linux/ppc64le")
+	var output bytes.Buffer
+	err := runAdmission(args, testEnv(nil), &output, &output)
+	if err == nil || !strings.Contains(err.Error(), "platform") {
+		t.Fatalf("runAdmission error = %v, want invalid platform", err)
 	}
 }
 
@@ -260,7 +288,7 @@ func admissionArgs(policy, image, evidence string) []string {
 }
 
 func liveArgs(policy string) []string {
-	return []string{"--image", testImage, "--repository", "ghcr.io/flidai/leapview", "--expected-workflow", testWorkflow, "--source-revision", testRevision, "--policy", policy}
+	return []string{"--image", testImage, "--repository", "ghcr.io/flidai/leapview", "--expected-workflow", testWorkflow, "--source-revision", testRevision, "--policy", policy, "--platform", "linux/arm64"}
 }
 
 func testEnv(values map[string]string) []string {
@@ -276,7 +304,7 @@ func liveTools(t *testing.T) string {
 	dir := t.TempDir()
 	writeTool(t, filepath.Join(dir, "gh"), "#!/bin/sh\nset -eu\nif [ \"$3\" = --help ]; then exit 0; fi\nrepository='https://github.com/"+repositoryIdentity+"'\nworkflow='https://github.com/"+testWorkflow+"@refs/heads/main'\nrevision='"+testRevision+"'\n[ \"$OCI_TEST_MODE\" = wrong-repository ] && repository='https://github.com/attacker/example'\n[ \"$OCI_TEST_MODE\" = wrong-workflow ] && workflow='https://github.com/flidai/leapview/.github/workflows/untrusted.yml@refs/heads/main'\n[ \"$OCI_TEST_MODE\" = wrong-revision ] && revision='ffffffffffffffffffffffffffffffffffffffff'\nprintf '[{\"verificationResult\":{\"signature\":{\"certificate\":{\"sourceRepositoryURI\":\"%s\",\"buildSignerURI\":\"%s\",\"sourceRepositoryDigest\":\"%s\"}}}}]\\n' \"$repository\" \"$workflow\" \"$revision\"\n")
 	writeTool(t, filepath.Join(dir, "docker"), "#!/bin/sh\nset -eu\ncase \"$*\" in\n  *'imagetools inspect'*)\n    [ \"$OCI_TEST_MODE\" = missing-sbom ] && printf '{}\\n' || printf '{\"SPDX\":{\"SPDXID\":\"SPDXRef-DOCUMENT\"}}\\n';;\n  *) exit 64;;\nesac\n")
-	writeTool(t, filepath.Join(dir, "trivy"), "#!/bin/sh\nset -eu\nif [ \"$1\" = version ]; then printf '{\"Version\":\"0.74.0\"}\\n'; exit 0; fi\n[ \"$OCI_TEST_MODE\" = unavailable ] && exit 70\n[ \"$OCI_TEST_MODE\" = vulnerable ] && printf '{\"Results\":[{\"Vulnerabilities\":[{\"VulnerabilityID\":\"CVE-2026-0001\"}]}]}\\n' || printf '{\"Results\":[]}\\n'\n")
+	writeTool(t, filepath.Join(dir, "trivy"), "#!/bin/sh\nset -eu\nif [ \"$1\" = version ]; then printf '{\"Version\":\"0.74.0\"}\\n'; exit 0; fi\ncase \" $* \" in *' --platform linux/arm64 '*) ;; *) printf 'target platform was not explicit\\n' >&2; exit 71;; esac\nif [ \"$OCI_TEST_MODE\" = unavailable ]; then printf 'registry unavailable with token %s\\n' \"$GH_TOKEN\" >&2; exit 70; fi\n[ \"$OCI_TEST_MODE\" = vulnerable ] && printf '{\"Results\":[{\"Vulnerabilities\":[{\"VulnerabilityID\":\"CVE-2026-0001\"}]}]}\\n' || printf '{\"Results\":[]}\\n'\n")
 	return dir
 }
 

--- a/internal/app/tools/ociadmission/runner.go
+++ b/internal/app/tools/ociadmission/runner.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -68,9 +69,15 @@ func (r commandRunner) verifyLive(opts admissionOptions, policy vulnerabilityPol
 	if *policy.IgnoreUnfixed {
 		args = append(args, "--ignore-unfixed")
 	}
+	if opts.platform != "" {
+		args = append(args, "--platform", opts.platform)
+	}
 	args = append(args, opts.image)
-	trivyJSON, err := r.runCommandParts(args)
+	trivyJSON, diagnostic, err := r.runCommandPartsWithDiagnostic(args)
 	if err != nil {
+		if diagnostic != "" {
+			return fmt.Errorf("pinned vulnerability scan could not complete: %s", diagnostic)
+		}
 		return errors.New("pinned vulnerability scan could not complete")
 	}
 	unresolved, err := unresolvedCount(trivyJSON, contract)
@@ -85,11 +92,15 @@ func (r commandRunner) verifyLive(opts admissionOptions, policy vulnerabilityPol
 		return errors.New("vulnerability evidence exceeds policy")
 	}
 	digest := opts.image[strings.LastIndex(opts.image, "@")+1:]
+	vulnerabilityResult := map[string]any{"sha256": policySHA256, "scanner": "trivy", "passed": true}
+	if opts.platform != "" {
+		vulnerabilityResult["platform"] = opts.platform
+	}
 	result := map[string]any{
 		"schemaVersion": 1, "image": opts.image, "digest": digest, "registryDigest": digest,
 		"attestation":         map[string]any{"verified": true, "repository": repositoryIdentity, "workflow": opts.expectedWorkflow, "sourceRevision": opts.sourceRevision},
 		"sbom":                map[string]any{"discoverable": true, "predicateType": "https://spdx.dev/Document/v2.3"},
-		"vulnerabilityPolicy": map[string]any{"sha256": policySHA256, "scanner": "trivy", "passed": true},
+		"vulnerabilityPolicy": vulnerabilityResult,
 	}
 	return writeResult(opts, r.env, result, stdout)
 }
@@ -133,6 +144,37 @@ func (r commandRunner) runCommandParts(parts []string) ([]byte, error) {
 		return nil, errors.New("empty command")
 	}
 	return r.run(parts[0], parts[1:], "")
+}
+
+func (r commandRunner) runCommandPartsWithDiagnostic(parts []string) ([]byte, string, error) {
+	if len(parts) == 0 {
+		return nil, "", errors.New("empty command")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	cmd.Env = r.env
+	var diagnostic strings.Builder
+	cmd.Stderr = &diagnostic
+	output, err := cmd.Output()
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return output, r.redactDiagnostic(diagnostic.String()), err
+}
+
+func (r commandRunner) redactDiagnostic(value string) string {
+	value = strings.TrimSpace(value)
+	for _, key := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if secret, ok := envValue(r.env, key); ok && secret != "" {
+			value = strings.ReplaceAll(value, secret, "***")
+		}
+	}
+	const limit = 2000
+	if len(value) > limit {
+		value = value[:limit] + "..."
+	}
+	return value
 }
 
 func (r commandRunner) loadExceptionContract(policyPath string) (*securitypolicy.Exceptions, error) {


### PR DESCRIPTION
## Summary
- pass the intended Linux platform into native OCI admission scans
- record and verify the scanned platform in admission evidence
- surface bounded, token-redacted Trivy diagnostics while preserving fail-closed behavior

## Verification
- go test ./internal/app/tools/ociadmission
- reproduced the failed site ARM digest with Trivy: ambiguous/default selection fails; explicit linux/arm64 succeeds with zero HIGH/CRITICAL findings
- task ci reaches the changed admission tests successfully, but the current local Docker environment fails unrelated v0.1 preservation/deploy-host fixtures
