### PR TITLE
docs(adr): adopt standards-aligned data contracts

### DIFF
--- a/adr/0016-adopt-standards-aligned-data-contracts-and-interchange.md
+++ b/adr/0016-adopt-standards-aligned-data-contracts-and-interchange.md
@@ -1,0 +1,794 @@
+# ADR-0016: Adopt standards-aligned data contracts and interchange
+
+Status: accepted
+
+Decision date: 2026-09-01
+
+Implementation: pending
+
+Deciders: LeapView maintainers
+
+Supersedes: none
+
+Amends: [ADR-0005](0005-use-project-wide-resource-graph.md), public Project
+and control-plane authoring boundaries;
+[ADR-0006](0006-adopt-ossie-aligned-semantic-contract.md), structural
+authority only;
+[ADR-0010](0010-adopt-strict-typed-data-resource-contracts.md), contract
+evolution, quality identity, and governance metadata
+
+Related: [ADR-0005](0005-use-project-wide-resource-graph.md);
+[ADR-0006](0006-adopt-ossie-aligned-semantic-contract.md);
+[ADR-0007](0007-adopt-plan-driven-project-delivery.md);
+[ADR-0010](0010-adopt-strict-typed-data-resource-contracts.md);
+[ADR-0011](0011-adopt-a-canonical-dashboard-document.md);
+[ADR-0014](0014-adopt-an-asset-selected-refresh-pipeline-contract.md);
+[ADR-0015](0015-adopt-durable-audit-and-compliance-controls.md);
+[ADR-0017](0017-adopt-a-looker-aligned-semantic-access-contract.md);
+[Data-contract versioning conformance](specifications/data-contract-versioning-conformance.md);
+[Open Data Contract Standard 3.1.0](https://github.com/bitol-io/open-data-contract-standard/tree/v3.1.0);
+[Bitol Open Data Product Standard 1.0.0](https://github.com/bitol-io/open-data-product-standard/tree/v1.0.0);
+[W3C DCAT 3](https://www.w3.org/TR/2024/REC-vocab-dcat-3-20240822/);
+[OpenLineage](https://openlineage.io/docs/spec/);
+[Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html);
+[Kubernetes RBAC v1](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/role-binding-v1/);
+[SCIM Core Schema](https://www.rfc-editor.org/rfc/rfc7643.html);
+[Cedar](https://docs.cedarpolicy.com/);
+[Perses dashboard specification](https://github.com/perses/spec);
+[Grafana Git Sync permissions](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/permissions-grafana/);
+[Looker access control](https://docs.cloud.google.com/looker/docs/access-control-and-permission-management);
+[Lightdash user attributes](https://docs.lightdash.com/workspace-admin/user-attributes);
+[Rill data access control](https://docs.rilldata.com/developers/build/metrics-view/security)
+
+## Context and problem statement
+
+LeapView already has executable data-contract behavior without a resource named
+`DataContract`. Source owns an optional inferred, compatible, or strict schema
+and typed freshness expectations. Model owns exact output fields, entities,
+grain, and a closed quality-check vocabulary. The compiler derives lineage,
+validates model output, and evaluates schema, freshness, identity, and quality
+claims against a candidate before activation. Immutable gate evidence records
+the exact source, runtime, binding, and candidate identities used in that
+decision.
+
+ADR-0006 established the pattern for external specifications: LeapView retains
+one native typed semantic contract and one executable internal representation,
+while Apache Ossie is a pinned import, export, validation, and extension
+boundary. ADR-0010 subsequently made Connection, Source, and Model strict
+native resources and deliberately separated portable authoring from
+target-owned endpoints, credentials, and connector implementation details.
+ADR-0014 selected OpenLineage as the runtime-lineage interoperability model but
+did not make it an execution contract.
+
+The Open Data Contract Standard (ODCS) now supplies a credible vendor-neutral
+document for dataset identity, schema, quality, service levels, ownership, and
+physical server descriptions. The related Bitol Open Data Product Standard
+(ODPS) describes products through contract-addressed input and output ports.
+W3C DCAT 3 describes catalogs, datasets, distributions, and data services for
+federated discovery. OpenLineage describes runtime and design lineage and has
+standard facets for schema, dataset versions, quality assertions, quality
+metrics, and column lineage. OpenTelemetry, CloudEvents, OpenAPI, SCIM, OAuth,
+OIDC, SPDX, SLSA provenance, and W3C Trace Context cover adjacent protocol and
+operational boundaries.
+
+Adopting any of those complete document shapes as LeapView's native YAML would
+weaken existing invariants. ODCS server blocks commonly contain physical
+coordinates that LeapView keeps in target bindings. ODCS roles are descriptive
+contract metadata, not LeapView authorization grants. Arbitrary SQL quality
+rules are broader than LeapView's closed, parser-governed check vocabulary.
+ODPS does not determine whether one LeapView deployment bundle is one product
+or a container for several products. DCAT is an RDF catalog vocabulary rather than
+an executable BI model. OpenLineage, OpenTelemetry, and CloudEvents describe
+observations or messages, not authored query behavior.
+
+The native YAML also lacks several useful concepts made visible by these
+standards. Quality checks do not have authored stable identity. Resource
+versions do not express consumer compatibility intent, and deployment planning
+does not classify a proposed contract change relative to the active resource.
+Field metadata is too small to carry portable governance labels,
+authoritative-definition links, or deprecation guidance. Product inputs and
+published outputs are not exposed through a standard data-product projection.
+
+The current authoring registry also crosses a product boundary. Group,
+RoleBinding, Grant, and DashboardPublication are instance control-plane state,
+not data-engineering definitions. DataPolicy combines durable query-governance
+logic with instance-bound subjects. The Project resource is only a manifest of
+directory globs plus public metadata for a deployment unit already implied by
+the source root. Keeping these resources in the same YAML graph makes identity,
+sharing, and publication changes look like data builds and makes a repository
+deployment responsible for replacing live administrative state.
+
+The question is how LeapView should become standards-compliant, use those
+standards to strengthen its native YAML, and state conformance precisely without
+creating parallel authorities, leaking target secrets, or turning an
+interchange document into an execution bypass.
+
+## Decision drivers
+
+- Preserve one authoritative native resource graph and one executable internal
+  representation for each concern.
+- Make ODCS and related standards first-class, version-pinned interoperability
+  boundaries comparable to the existing Ossie boundary.
+- Improve native authoring where a standard reveals a durable product concept,
+  but retain LeapView naming, closed unions, and capability ownership.
+- Detect breaking changes against the exact active resource and expose their
+  downstream impact before publication.
+- Give quality rules and emitted evidence stable identity across revisions.
+- Keep target endpoints, credentials, identities, memberships, role and grant
+  assignments, publication state, runtime plans, and derived lineage out of
+  portable authored documents.
+- Reject unsupported or lossy conversions instead of silently weakening a
+  contract.
+- Distinguish document conformance, round-trip fidelity, and executable support
+  so the product does not claim more than it proves.
+- Keep evolving external schemas and SDKs out of core compiler and runtime
+  domain types.
+- Reuse upstream schemas and independent tools as conformance oracles without
+  making their language runtimes product dependencies.
+
+## Considered options
+
+### Keep native resources only
+
+LeapView could document Source and Model as data contracts and avoid external
+formats. This preserves the strongest internal boundary with the least mapping
+work, but makes contract exchange, catalog federation, lineage integration, and
+data-product packaging proprietary. It also misses useful evolution and stable
+quality-identity concepts highlighted by the standards.
+
+### Adopt ODCS, ODPS, or DCAT as native analytics YAML
+
+LeapView could accept those documents directly as the authoritative Source,
+Model, deployment bundle, or catalog representation. This would maximize superficial
+format compatibility, but each standard combines concerns differently from the
+LeapView compiler. Native adoption would either expose target coordinates and
+open extension bags or require a large implicit profile whose actual behavior
+could not be read from the standard document alone. It would also make an
+external specification's release cycle part of the `leapview.dev/v1` execution
+contract.
+
+### Add a parallel DataContract resource
+
+A new resource could reference Source or Model while repeating schema,
+freshness, quality, ownership, and version metadata. This gives the concept a
+clear name but creates two places for the same guarantee. Compilation would
+need precedence, synchronization, or conflict rules, and downstream consumers
+could no longer tell which declaration is authoritative.
+
+### Delegate contract handling to Data Contract CLI or another service
+
+LeapView could invoke a Python CLI or remote contract manager for linting,
+testing, conversion, and publication. That supplies a broad connector and
+quality ecosystem, but moves candidate admission, credential handling, and
+arbitrary executable rules across a new process or network trust boundary. It
+also couples the Go product lifecycle to another tool's dependency graph and
+semantics.
+
+### Retain native authority with standards-aligned metadata and adapters
+
+LeapView can strengthen its native contracts, compile them once, and project
+the resulting typed graph and evidence into exact pinned external formats.
+Imports can lower through explicit adapters into the same generated authoring
+DTOs and compiler validation as native YAML. This retains one execution path
+while providing independently testable interoperability.
+
+## Whole authored-contract review
+
+The review covers every resource currently accepted by the authoring schema
+registry, but acceptance by the current compiler does not imply that the
+resource belongs in the authoring product. The industry comparison separates
+three concerns:
+
+1. **Analytics source** is reviewed, versioned, tested, and deployed as code.
+   It contains Connection, Source, Model, SemanticModel, Pipeline, and
+   Dashboard resources.
+2. **Consumer data-governance semantics** that change query results are also
+   reviewed as code, but live only on the SemanticModel consumption contract.
+   ADR-0017 defines the Looker-aligned access-grant and access-filter model.
+3. **Control-plane state** is administered per instance through authenticated
+   UI and API surfaces. It contains identities, group membership, roles, role
+   assignments, grants, sharing, publication, embedding configuration, and the
+   mapping of IdP claims to principal attributes.
+
+This is the common separation in mature dashboard-as-code products.
+[Grafana Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/permissions-grafana/)
+explicitly does not synchronize folder or dashboard permissions to Git.
+[Looker](https://docs.cloud.google.com/looker/docs/access-control-and-permission-management)
+keeps access filters and access grants in LookML while users, groups, roles, and
+content access are administered separately.
+[Lightdash](https://docs.lightdash.com/workspace-admin/user-attributes) keeps
+row and column restrictions in model YAML while admins assign user attributes;
+its [optional content-as-code export](https://changelog.lightdash.com/) also
+supports users, groups, roles, and permissions for backup, migration, or full
+GitOps. [Rill](https://docs.rilldata.com/developers/build/metrics-view/security)
+keeps row and column security in metrics-view YAML while project access is a
+prerequisite managed in Rill Cloud.
+[Perses](https://perses.dev/perses/docs/api/rolebinding/) exposes Project,
+Role, and RoleBinding as uniform API YAML resources, which is appropriate for
+its Kubernetes-style control-plane API but is not evidence that those resources
+belong in LeapView's data-engineering source contract.
+
+| LeapView contract | Strongest external contract reviewed | Whole-shape adoption decision |
+|---|---|---|
+| Common `apiVersion`/`kind`/`metadata`/`spec` envelope | Kubernetes API conventions and JSON Schema 2020-12 | Retain. The envelope is useful and already consistent across LeapView resources, but LeapView resources are not Kubernetes objects and must not copy cluster metadata, status, namespace, or reconciliation fields. |
+| Project | dbt project files, Rill `rill.yaml`, Perses Project API resources, and Bitol ODPS 1.0.0 | Remove completely from the public authored contract. The source root and conventional resource directories are the compilation input; deployment creates one atomic release without a `kind: Project` document. Instance, environment, deployment, and data-product identities are supplied or derived at their owning API boundary. Other tools' project files contain real defaults or package behavior; LeapView's include-only manifest does not justify a public resource. |
+| Connection | ODCS 3.1.0 servers, dbt profiles, and connector-specific source documents | Retain. Those shapes describe physical endpoints and tool-specific credentials or options; LeapView deliberately separates portable connector intent from target-owned binding and secrets. |
+| Source | ODCS 3.1.0 schema, properties, servers, and SLA properties; dbt sources | Retain the Source location and schema-mode contract. ODCS contributes contract identity, field governance, and interchange vocabulary, but a whole ODCS document can contain several schema objects and target coordinates and has weaker executable requirements. |
+| Model | ODCS 3.1.0 schema and quality rules; dbt models, contracts, and tests | Retain the governed definition, named entities, grain, exact decimal type, and closed checks. ODCS quality allows text, arbitrary SQL, and vendor custom rules; its fields do not express LeapView's named identity and grain semantics. |
+| SemanticModel | Apache Ossie and dbt MetricFlow | Keep the ADR-0006 approach: a stricter LeapView execution contract aligned with Ossie vocabulary and MetricFlow behavior, with exact Ossie documents at the adapter boundary. Ossie's current core remains a draft and permits open vendor extensions. |
+| Pipeline | Argo CronWorkflow and dbt ancestor selection | Keep the ADR-0014 approach. The scheduling sub-contract already copies pinned Argo field names and behavior where meanings match, while selection, candidate identity, evidence, and publication remain LeapView-owned. A whole Argo workflow would expose containers, scripts, secrets, and infrastructure. |
+| Dashboard and nested visuals | Perses open dashboard specification and Vega-Lite | Retain the governed BI document. Perses is observability- and plugin-oriented, while Vega-Lite permits data loading, transformations, and expression behavior that would bypass the semantic query boundary. Both are useful migration or visualization references, not native authority. |
+| Group | SCIM 2.0 Group, SAML/OIDC claims, and dashboard product team APIs | Remove from analytics YAML. LeapView's SCIM service owns provisioned users and groups; SAML/OIDC or the admin API supplies group and attribute mappings. SCIM deliberately leaves authorization meaning to the service provider. |
+| RoleBinding and Grant | Product RBAC APIs, SAML/OIDC role mapping, Terraform providers, Kubernetes RBAC, OpenFGA, and Cedar | Remove from analytics YAML. Keep LeapView's closed capabilities and authorization engine, but manage assignments through the control-plane UI/API or a future IaC provider. Repository deployment must not replace live role or grant state. |
+| DataPolicy | Looker access filters/grants, Lightdash user-attribute filters, Rill metrics-view security, Cedar, and database row/column policies | Remove the standalone, subject-bound resource. SemanticModel is the only authored policy target; ADR-0017 defines its Looker-aligned `accessGrants`, `requiredAccessGrants`, and `accessFilters`. Attribute values and assignments remain in the control plane. |
+| DashboardPublication | Grafana dashboard/folder permissions, Looker content access, W3C CSP `frame-ancestors`, and product sharing APIs | Remove from analytics YAML. Publication, sharing state, embed origins, URLs, and revision activation are environment-specific security and lifecycle state managed through UI/API. Headless automation uses a service principal and API or a future IaC provider. |
+
+The resulting public authoring registry has six top-level resource kinds:
+Connection, Source, Model, SemanticModel, Pipeline, and Dashboard. There is no
+root manifest resource; the compiler discovers these resources from fixed
+conventional directories beneath the selected source root. A later need for
+package-wide executable defaults requires a narrowly typed root configuration
+decision, not the return of a generic Project object or include registry.
+
+No reviewed external specification is a safe one-for-one replacement for any
+of those six complete LeapView resources. Exact reuse is nevertheless required
+at a matched boundary: ODCS and Ossie documents, ODPS and DCAT exports,
+OpenLineage events, SCIM API resources, OpenAPI descriptions, and emitted CSP
+syntax must conform to their standards without a proprietary wrapper. Native
+YAML may copy a version-pinned sub-contract one-for-one only when its concern,
+defaults, security boundary, and observable behavior are the same. Pipeline's
+Argo scheduling profile is the existing example.
+
+ODCS illustrates why matching YAML appearance is insufficient. Version 3.1.0
+requires the document version, standard version, kind, ID, and status, but a
+schema object requires only its name and a property requires only its name.
+Its portable types have `number` but no exact decimal type; SLA property names
+are open; server blocks contain target coordinates; and quality rules include
+arbitrary SQL and vendor-custom execution. ODCS is broader than LeapView's
+Source and Model contracts, but it is not stronger as an executable analytical
+contract. LeapView therefore adopts exact ODCS documents for interchange and a
+documented executable profile, not as its internal DTO or authored resource
+envelope.
+
+## Decision outcome
+
+LeapView adopts the standards-aligned native-authority option. Source and Model
+together remain the native executable data-contract boundary; no parallel
+`DataContract` resource is introduced. Native YAML, imported standard
+documents, interactive authoring, APIs, and agents must all lower through the
+same generated contracts, compiler, graph validation, candidate gates, and
+publication lifecycle.
+
+The public source contract contains only Connection, Source, Model,
+SemanticModel, Pipeline, and Dashboard. `Project`, `Group`, `RoleBinding`,
+`Grant`, `DataPolicy`, and `DashboardPublication` cease to be accepted authored
+resource kinds. `Project` also ceases to be a public API, identity, route, and
+authorization resource: repository root, deployment, active generation, and
+instance are sufficient boundaries. Internally, code may temporarily use
+`project` to name the compiled graph during migration, but it is not a public
+concept or stable contract.
+
+This ADR amends ADR-0005 by removing Project as a public resource while
+retaining one atomic compiled graph per instance and by moving authorization
+and publication state wholly to the control plane. It amends ADR-0006's
+structural-authority boundary for SemanticModel and ADR-0010's check and
+metadata shapes. Their remaining graph, semantic, security, and compilation
+decisions remain in force. ADR-0017 owns the executable SemanticModel access
+contract; this ADR owns only the authored/control-plane separation.
+
+External specifications are owned by capability-specific adapters. An adapter
+may validate, import, export, or emit a standard document, but its DTOs and
+version-specific vocabulary cannot become core analytics, compiled graph,
+deployment, or runtime types. Every adapter pins an exact supported standard
+version and the digest of any vendored schema. A mutable `latest`, default
+branch, or unversioned schema URL is not a conformance boundary.
+
+### Exact reuse is semantic, not cosmetic
+
+A standard shape is copied into native YAML only if LeapView can inherit its
+complete normative meaning. The copied unit must have a pinned version, a
+closed or explicitly governed extension policy, compatible defaults, one
+capability owner, and conformance fixtures against an independent
+implementation. LeapView does not rename a standard field while claiming exact
+reuse, and it does not copy a familiar field name while assigning different
+behavior.
+
+When those conditions do not hold, the standard stays in an adapter and the
+native contract is deliberately aligned or mapped. A valid standard document
+must remain valid at the adapter boundary: LeapView does not wrap an ODCS,
+Ossie, ODPS, DCAT, OpenLineage, SCIM, OpenAPI, or CloudEvents document in the
+`leapview.dev/v1` resource envelope and call the result compliant.
+
+### Authored structural authority converges on TypeSpec
+
+Each of the six authored public resource shapes will have one generated TypeSpec
+structural authority. The common resource envelope, metadata, identity scalars,
+provenance, and descriptive governance types become shared declarations rather
+than copies in data-resource TypeSpec, Pipeline TypeSpec, Dashboard TypeSpec,
+and handwritten CUE.
+
+SemanticModel moves from handwritten CUE structural definitions to TypeSpec.
+Generated JSON Schema 2020-12 remains the editor and structural validation
+artifact. CUE consumes generated schemas and owns only cross-resource and
+contextual constraints that TypeSpec cannot express. Removed resource kinds do
+not receive new authoring schemas.
+
+The generated structural schemas express constraints that currently fail only
+after decoding whenever JSON Schema can represent them. Entity and unique-check
+field lists and accepted-value lists are non-empty. Row-count checks require at
+least one bound. Source freshness requires at least one warning or error
+threshold. The compiler retains contextual rules such as reference resolution,
+compatible field datatypes, ordered thresholds, non-cyclic graphs, and
+authorization.
+
+### Control-plane state is not analytics source
+
+Group, role, grant, sharing, and publication changes are durable audited
+control-plane mutations. The UI and the same generated OpenAPI surface support
+them. Service principals provide headless automation, and a future Terraform or
+OpenTofu provider may offer declarative reconciliation without adding those
+objects to analytics YAML.
+
+SCIM is the preferred automated user and group lifecycle boundary. SAML or OIDC
+is the authentication and claims boundary. Neither standard defines LeapView's
+complete authorization or publication lifecycle: SCIM does not define the
+authorization meaning of group membership, and SAML/OIDC does not publish a
+dashboard. Role mappings, explicit grants, sharing, and publication therefore
+remain LeapView API operations even when identity is fully automated.
+
+A repository deployment never deletes, replaces, or implicitly widens
+control-plane state. References from control-plane grants or publications to
+source-managed resources use stable resource IDs and are revalidated against a
+candidate generation before activation.
+
+### Stable identity does not depend on Project
+
+An instance has at most one active compiled source bundle. A different source
+root is a candidate replacement for that graph, not a second namespace. Two
+independently active source bundles require separate instances.
+
+Authored `metadata.id` is portable across repository, source-root, directory,
+filename, branch, and symbolic-name changes. First activation binds the tuple
+of instance identity and authored ID to an immutable resource UID and kind.
+Control-plane references retain that UID, authored ID, and expected kind; they
+never resolve by name, path, or whichever candidate currently contains a
+matching string. Candidate-wide ID collisions, including cross-kind collisions,
+block graph construction.
+
+Removal tombstones the UID and suspends its grants and publications. Normal
+deployment cannot reuse the ID or silently rebind those references. An explicit
+audited restore may recover the same logical resource and UID after recompiling
+all dependencies, but control-plane grants and publications remain suspended
+until separately reauthorized. External standard projections qualify the
+portable authored ID with a stable instance or tenant URI rather than claiming
+that the raw ID is globally unique.
+
+The linked data-contract versioning conformance specification owns the exact
+collision, tombstone, restore, rollback, and projection requirements.
+
+### Semantic access policy has a separate decision
+
+The standalone `DataPolicy` resource is removed because it combines authored
+query-governance logic with instance-bound subjects. The rule that changes a
+consumer query result is SemanticModel code; the assignment of identity
+attributes is control-plane state.
+
+ADR-0017 defines the exact Looker-aligned semantic access contract, its
+fail-closed behavior, and its deliberate initial limits. Source, Model,
+Dashboard, Pipeline, and Connection do not gain authored policy blocks. This
+ADR does not create a second policy grammar or restate ADR-0017's executable
+semantics.
+
+### Native resource contracts gain evolution metadata
+
+Contract-bearing resources may declare an authored Semantic Versioning 2.0.0
+version and one closed compatibility policy in common resource metadata. The
+initial policy vocabulary is `none` and `backward`. Absence means that LeapView
+reports the change classification but does not infer a compatibility promise.
+
+The authored shape is:
+
+```yaml
+metadata:
+  contract:
+    version: 2.1.0
+    compatibility: backward
+```
+
+`contract` is absent on resources that do not expose a versioned consumer
+contract. It is not a generic metadata bag.
+
+The initial contract-bearing resource set is Source, Model, and SemanticModel.
+Adding contract-version semantics to another resource kind requires an explicit
+extension of this decision.
+
+Canonical contract bytes use the versioned `leapview.contract/v1` projection
+defined by the linked data-contract versioning conformance specification. The
+projection is generated from validated TypeSpec DTOs and includes resource
+identity, authored contract metadata, public schema and semantics, executable
+guarantees, governance and deprecation declarations, normalized
+result-affecting Model logic, and the complete SemanticModel consumption and
+access contract. It excludes prose descriptions, display metadata, tags,
+ownership and domain labels, documentation, provenance, AI context, source
+paths, credentials, target bindings, runtime state, and derived observations.
+Changing excluded metadata does not require a contract version.
+
+The typed projection is normalized and serialized as RFC 8785 canonical JSON,
+then identified by a SHA-256 digest. The profile defines map, set, and ordered
+collection behavior; Unicode, number, date, timestamp, URL, default, null, and
+logical-type normalization; and independent cross-language golden fixtures.
+Every public field must be classified in TypeSpec as contract, descriptive,
+operational, secret, or derived so an unreviewed field cannot silently enter or
+leave the digest.
+
+Once a contract version has been published, its profile, canonical bytes, and
+digest are immutable. A candidate that reuses the version with different bytes
+is rejected; a change to included content requires a new version. Build
+metadata does not establish a distinct compatibility baseline. Changing the
+canonical algorithm requires a new profile and preserves historical bytes.
+LeapView's classified public contract is the public API to which Semantic
+Versioning rules apply; a version number alone does not define what is
+compatible.
+
+`backward` means that consumers valid against the selected active contract
+continue to receive compatible names, logical types, nullability, identities,
+grain, and executable semantic members from the candidate. It does not mean
+that arbitrary physical connector types or display metadata are frozen.
+Compatibility is evaluated against the exact active resource with the same
+stable resource ID, never against whichever file happens to be present in a
+working tree.
+
+Planning classifies at least the following changes:
+
+- additive, such as an optional compatible field or descriptive metadata;
+- behavioral, such as a quality threshold or freshness-policy change whose
+  effect is not a wire-shape change;
+- breaking, such as field removal or rename, new required output, incompatible
+  type or nullability, entity or grain change, unsafe relationship change, or
+  removal or result-affecting redefinition of a published semantic member; and
+- indeterminate, when the current adapter or compiler cannot prove a safe
+  classification.
+
+An indeterminate change cannot satisfy `backward`. A breaking change requires
+a new major semantic version before it can satisfy version policy, but a major
+version does not itself authorize publication or bypass impact review. The
+plan retains the baseline identity, normalized diff, affected-resource graph,
+classification, and policy outcome as candidate evidence. Deployment policy
+decides whether a reported breaking change needs approval or must be rejected;
+the compatibility engine does not silently rewrite the resource.
+
+Authored lifecycle status is not added to these resources. Draft, active,
+superseded, and retained state remain facts of authoring, deployment,
+publication, and serving lifecycles. Standard exports derive status from the
+authorized lifecycle projection instead of accepting a YAML word that can
+contradict active state.
+
+### Quality rules gain stable authored identity
+
+Every authored Model check gains a required stable ID plus optional description
+and tags. The ID is unique within the Model and remains the evidence identity
+across threshold, severity, or description changes. Check type continues to
+determine the executable evaluator and quality dimension; authors do not repeat
+an engine name, free-form expression language, or generic dimension that can
+contradict it.
+
+Every evaluation binds the check ID to the Model contract version, candidate,
+dataset or relation version, evaluation time, configured severity, outcome,
+expected value, and safely reportable observation. Raw failing rows, sensitive
+values, credentials, and unrestricted SQL are not evidence fields. These
+records map to OpenLineage quality facets without making OpenLineage the local
+evidence authority.
+
+### Fields gain portable governance metadata
+
+Source schema fields and Model fields may carry tags, a critical-data-element
+marker, an organization-defined classification label, typed authoritative
+definition links, and typed deprecation guidance with an optional replacement
+field. Existing labels, descriptions, AI context, logical types, and
+Source-field nullability keep their current meaning. Model fields gain the same
+optional `nullable` declaration so compatibility analysis does not infer
+nullability from a quality check or a physical engine observation. Absence
+means unspecified; it does not mean nullable.
+
+Governance metadata is descriptive unless the ADR-0017 SemanticModel access
+contract references it through an explicitly defined compiler feature. A
+classification label cannot create, remove, or imply a grant, mask, or row
+policy. Imported ODCS roles and team members likewise cannot mutate LeapView
+principals, groups, roles, bindings, or grants.
+
+Authoritative definitions use typed URL entries rather than a generic
+`customProperties` bag. Unknown imported extension fields are rejected unless
+the selected adapter owns a versioned, namespaced preservation rule.
+
+Native field collections remain identifier-keyed maps so duplicate names are
+structurally impossible. Native `datatype` retains LeapView's Ossie-aligned
+portable vocabulary, including the distinction between exact `Decimal` and
+approximate `Float`; it is not renamed to ODCS `logicalType` merely to resemble
+an ODCS document. ODCS property arrays and logical types are mapped explicitly,
+with an extension or loss diagnostic when a value has no exact standard form.
+
+An illustrative Model fragment is:
+
+```yaml
+spec:
+  fields:
+    legacy_customer_id:
+      datatype: String
+      nullable: false
+      tags: [identifier]
+      criticalDataElement: true
+      classification: restricted
+      authoritativeDefinitions:
+        - type: businessDefinition
+          url: https://catalog.example/terms/customer-id
+      deprecation:
+        since: 2.1.0
+        reason: Replaced by the canonical customer key.
+        replacement: customer_key
+  checks:
+    - id: legacy_customer_id_present
+      type: non_null
+      field: legacy_customer_id
+      severity: error
+      description: Every published row carries its legacy customer identity.
+      tags: [contract]
+```
+
+Deprecation `since` is a semantic version no later than the containing contract
+version. A replacement resolves to another field in the same contract and
+cannot form a self-reference or replacement cycle.
+
+### Guarantees stay with the capability that can enforce them
+
+LeapView does not add a generic SLA or quality map. Source continues to own
+source schema and freshness. Model owns row and relationship assertions.
+Pipeline owns refresh selection and scheduling. Managed data and publication
+policy own retention. A published service owns its availability objective.
+
+A new guarantee enters native YAML only with a closed generated shape, one
+capability owner, a compiler rule, a bounded evaluator, normalized evidence,
+and documented warning, blocking, unavailable, and empty behavior. ODCS fields
+that do not meet those conditions may round-trip as standard metadata but are
+not described as LeapView-executable guarantees.
+
+### ODCS is the data-contract interchange standard
+
+The initial ODCS profile pins version 3.1.0 and provides validation, import, and
+export. The adapter maps stable resource identity, schema, field semantics,
+quality checks, freshness, ownership metadata, and authoritative definitions
+where the mapping is lossless. LeapView-only execution semantics use a
+versioned namespaced ODCS extension only when the standard permits one.
+
+Portable export omits target endpoints and secrets. A separately authorized
+target-specific test projection may include non-secret connection coordinates
+when the caller can inspect that binding, but credentials are always supplied
+out of band and never serialized. Imported server blocks resolve only through
+an explicit existing Connection and target-binding workflow; they do not create
+credentials, widen network authority, or bypass connector admission.
+
+Imported arbitrary SQL quality rules are never executed. The adapter either
+maps a rule to the closed native check vocabulary, preserves it as explicitly
+non-executable standard metadata, or rejects the import with a precise
+diagnostic. It never reports successful import after dropping the rule.
+
+### Bitol ODPS is the data-product interchange target
+
+The selected data-product standard is specifically the Linux Foundation
+Bitol Open Data Product Standard 1.0.0. LeapView does not use the ambiguous
+acronym `ODPS` without the publisher and version in public conformance claims,
+because another unrelated Open Data Product Specification uses the same
+acronym.
+
+The initial projection treats one deployed source bundle and its active
+generation as one data-product envelope. Sources selected as promised
+dependencies become input ports. Only outputs explicitly selected by the
+authorized export request or publication state become output ports; internal
+Models and dashboards do not become product promises merely because they exist
+in the graph. Ports reference the stable IDs and versions of their ODCS
+contracts. Authorized catalog, observability, and control endpoints may become
+management ports without embedding credentials.
+
+LeapView does not introduce a `DataProduct` resource in this decision. If one
+deployed source bundle must contain multiple independently owned, versioned,
+and published products, that requirement needs a separate data-product decision
+rather than an implicit grouping convention or the return of Project.
+
+### DCAT 3 is the catalog export target
+
+The initial DCAT 3 boundary is authorization-filtered export, not import. A
+LeapView catalog maps to `dcat:Catalog`; eligible Sources and published outputs
+map to `dcat:Dataset`; authorized files or representations map to
+`dcat:Distribution`; and headless or public data endpoints map to
+`dcat:DataService`. The initial serialization is deterministic JSON-LD.
+
+DCAT output includes only metadata and access coordinates visible to the
+caller. It does not expose target credentials, private object keys, internal
+attachment names, compiled SQL, or inaccessible graph nodes. RDF vocabulary
+and JSON-LD framing remain adapter concerns and do not appear in native YAML.
+
+### Runtime standards are projections, not authoring formats
+
+OpenLineage remains the lineage and data-quality event boundary selected by
+ADR-0014. Pipeline maps to Job, PipelineRun maps to Run, and Sources and
+materialized outputs map to Datasets. Standard schema, version, quality,
+statistics, and lineage facets are preferred; immutable versioned LeapView
+facets carry only evidence that has no lossless standard field. The append-only
+LeapView ledger remains authoritative.
+
+OpenTelemetry/OTLP is the target for process telemetry when LeapView creates
+local spans or exports metrics and logs. W3C Trace Context remains the
+propagation format. Telemetry may carry stable instance, deployment, plan,
+candidate, generation, pipeline, check, and query identities, but not raw result values,
+credentials, access tokens, unrestricted SQL, or unbounded principal labels.
+No OpenTelemetry field becomes authored analytics YAML.
+
+CloudEvents 1.0.2 is reserved for a future external lifecycle-event or webhook
+surface. It does not replace Pagestream SSE, the audit ledger, or OpenLineage.
+Adding that surface requires a separate API and delivery decision, but its
+event envelope and type naming must be CloudEvents-compatible rather than a
+new proprietary wrapper.
+
+OpenAPI remains authoritative for LeapView HTTP APIs and should move from the
+current 3.0 output to a generator-supported 3.1 or later profile in a separately
+tested generator change. dbt artifacts remain a valuable de facto import
+source identified by ADR-0005, but are described as dbt compatibility rather
+than standards compliance. AsyncAPI, Arrow Flight SQL, Substrait, and W3C DQV
+are not adopted by this decision: LeapView has no matching public asynchronous
+API, database-SQL service, portable execution-plan boundary, or need for a
+second quality vocabulary today.
+
+### Conformance claims are explicit and machine-readable
+
+LeapView publishes a generated conformance matrix for every external profile.
+Each entry identifies the publisher, standard, exact version, schema digest,
+supported directions, extension version, and one or more proven levels:
+
+- **document** — emitted or accepted bytes conform structurally to the pinned
+  standard;
+- **round-trip** — the declared profile survives native-to-standard-to-native
+  conversion without semantic loss;
+- **execution** — the listed standard concepts are enforced by the native
+  compiler and bounded runtime evaluator; and
+- **emission** — runtime events or telemetry conform to the pinned protocol and
+  facet schemas.
+
+The word `compliant` must name the standard version, profile, direction, and
+level. Passing an upstream JSON Schema alone proves document shape, not
+round-trip fidelity or execution. An adapter returns a machine-readable loss
+and unsupported-feature report for every conversion; success requires that the
+report satisfy the requested conformance level.
+
+## Implementation sequencing
+
+This decision is delivered as independently qualified milestones rather than
+one indivisible migration:
+
+1. **Identity and authoring boundary:** establish the instance resource-UID
+   registry, collision and tombstone behavior, remove the public Project and
+   control-plane resource kinds from authoring, and migrate durable references.
+   No new control-plane reference may depend on authored resources before this
+   milestone qualifies.
+2. **Structural and version authority:** move the six authored structures to
+   generated TypeSpec authority, implement `leapview.contract/v1`, contract
+   diffing, quality IDs, governance, and immutable publication evidence.
+3. **Semantic access:** qualify ADR-0017, the typed attribute registry, planner
+   security barriers, discovery behavior, caches, audit, and every semantic
+   consumer before any path relies on the new policy semantics.
+4. **Data-contract interchange:** implement and qualify the pinned ODCS profile
+   independently of native contract execution.
+5. **Product and catalog projections:** implement Bitol ODPS and DCAT exports
+   after stable identity, versioning, publication selection, and authorization
+   filtering qualify.
+6. **Runtime emissions:** qualify OpenLineage and later telemetry projections
+   against the already stable native identities and evidence.
+
+Each milestone has its own generated checks, fixtures, failure behavior, and
+evidence. Completion of a later milestone cannot compensate for an unqualified
+earlier dependency.
+
+## Consequences
+
+LeapView gains a coherent standards portfolio without weakening native
+execution. Customers can exchange data contracts, package a deployed source
+bundle as a data product, federate catalog metadata, and emit lineage and
+quality evidence using recognized formats. Native authors gain stable check identity, contract
+evolution policy, impact-aware planning, richer field governance, and precise
+deprecation guidance even when they never export a standard document.
+
+Analytics deployments become safer and less surprising: changing a dashboard
+or model cannot replace group membership, grants, or publication state, and an
+identity change does not require rebuilding the analytical graph. Removing the
+include-only Project manifest also makes the repository root the obvious unit
+of compilation. The migration must remove public Project IDs and routes rather
+than preserve a compatibility alias, because the product is not yet public.
+
+Semantic access rules remain reviewable and testable in the SemanticModel,
+while administrators can change user and group attribute values immediately in
+the control plane. ADR-0017 owns candidate validation, evaluation, composition,
+enforcement, cache identity, and fail-closed behavior for that boundary.
+
+The compiler and deployment lifecycle take on meaningful new work. Contract
+diffing must be deterministic and version-aware. Imported documents require
+source-positioned diagnostics and explicit mapping reports. Adapters need
+versioned schemas, fixtures, extension registries, and upgrade review. A
+standard upgrade cannot be treated as a dependency-only change because it may
+change accepted documents or emitted meaning.
+
+One deployed source bundle initially maps to one Bitol data product, which is
+simple and portable but does not model multiple product ownership boundaries in
+one deployment. DCAT is export-only initially. Some valid ODCS features remain
+non-executable in LeapView. These restrictions are documented profile limits,
+not silent partial support.
+
+The new metadata increases authoring surface area. Generated schemas,
+documentation, builder forms, CLI export, examples, and agents must expose one
+consistent shape. Organization-defined classifications need governance to
+remain useful, but do not become hidden authorization behavior.
+
+Independent conformance tooling remains a development and CI oracle. It may
+increase CI setup and update cost, but does not enter the production binary or
+receive production credentials by default.
+
+## Confirmation
+
+- The authoring registry accepts exactly Connection, Source, Model,
+  SemanticModel, Pipeline, and Dashboard. Fixtures prove `Project`, `Group`,
+  `RoleBinding`, `Grant`, `DataPolicy`, and `DashboardPublication` are rejected
+  as authored kinds with migration diagnostics.
+- Compilation selects a source root, discovers only conventional resource
+  directories, and produces one atomic graph without `leapview.yaml`, a public
+  Project ID, or include-glob behavior. Public routes, API schemas, grants, and
+  audit subjects contain no Project resource.
+- Identity fixtures prove candidate-wide cross-kind ID uniqueness, stable UIDs
+  across source-root and file moves, kind-change rejection, tombstone
+  non-reuse, explicit restore behavior, rollback identity, and durable
+  control-plane references that cannot silently rebind.
+- TypeSpec owns the six authored structures, including the shared envelope,
+  metadata, contract evolution, quality identity, field governance,
+  deprecation, and the ADR-0017 SemanticModel access contract. It generates Go
+  DTOs, JSON Schema, documentation, and any browser types from those
+  declarations.
+- Architecture tests reject handwritten public structural fields in CUE and
+  prove that CUE validation consumes the generated schemas before applying only
+  contextual graph constraints.
+- Architecture fixtures reject authored access-policy fields outside
+  SemanticModel and delegate the access-rule schema and compiler corpus to the
+  ADR-0017 conformance specification.
+- Control-plane tests prove SCIM and admin APIs own users and groups; role,
+  grant, sharing, and publication APIs own assignments and lifecycle state; and
+  analytics deployment cannot create, update, or delete any of them.
+- Schema and compiler tests reject duplicate check IDs, invalid semantic
+  versions, unknown compatibility policies, malformed authoritative links,
+  contradictory deprecation replacements, and generic extension bags.
+- Compatibility fixtures classify additive, behavioral, breaking, and
+  indeterminate changes across Source, Model, and published SemanticModel
+  contracts. Candidate evidence binds the exact active baseline, affected graph,
+  classification, and policy result.
+- Canonicalization fixtures classify every public DTO field, prove the exact
+  `leapview.contract/v1` projection and defaults, produce byte-identical RFC
+  8785 and SHA-256 results in Go and an independent implementation, and reject
+  reuse of a published version with different bytes.
+- Pinned ODCS 3.1.0 fixtures pass the upstream schema and an independent CLI
+  linter. Import/export golden tests cover supported types, nested-field
+  diagnostics, identities, relationships, checks, freshness, metadata,
+  extensions, unknown fields, and loss reports.
+- Security tests prove ODCS import/export never serializes credentials, never
+  creates a target binding or Access grant, never executes imported arbitrary
+  SQL, and cannot widen connector, filesystem, object-store, or network scope.
+- Bitol ODPS 1.0.0 fixtures prove that only selected Source dependencies and
+  explicit publications become ports, every port refers to a stable ODCS
+  contract ID and version, and internal resources remain absent.
+- DCAT 3 JSON-LD fixtures normalize to deterministic RDF graphs and contain
+  only authorization-visible catalogs, datasets, distributions, and services.
+- OpenLineage contract tests validate standard schema, version, quality,
+  statistics, parent, and lineage facets plus immutable canonical schema URLs
+  for every LeapView extension facet.
+- The generated conformance matrix is checked against registered adapters,
+  pinned schemas, documentation, CLI commands, and test fixtures. No adapter or
+  public compliance claim can exist without a matching matrix entry.
+- Architecture tests keep standards-version DTOs inside interchange or
+  telemetry adapters and prevent core compiled-graph, analytics, deployment,
+  release, and runtime packages from importing them.
+- Documentation describes the exact standard publisher, version, direction,
+  conformance level, unsupported features, extension policy, and credential
+  boundary for every advertised profile.

--- a/adr/0017-adopt-a-looker-aligned-semantic-access-contract.md
+++ b/adr/0017-adopt-a-looker-aligned-semantic-access-contract.md
@@ -1,0 +1,333 @@
+# ADR-0017: Adopt a Looker-aligned semantic access contract
+
+Status: accepted
+
+Decision date: 2026-09-01
+
+Implementation: pending
+
+Deciders: LeapView maintainers
+
+Supersedes: none
+
+Amends: none
+
+Related: [ADR-0006](0006-adopt-ossie-aligned-semantic-contract.md);
+[ADR-0015](0015-adopt-durable-audit-and-compliance-controls.md);
+[ADR-0016](0016-adopt-standards-aligned-data-contracts-and-interchange.md);
+[Semantic access-policy conformance](specifications/semantic-access-policy-conformance.md);
+[Looker `access_grant`](https://docs.cloud.google.com/looker/docs/reference/param-model-access-grant);
+[Looker `access_filter`](https://docs.cloud.google.com/looker/docs/reference/param-explore-access-filter);
+[Looker access control](https://docs.cloud.google.com/looker/docs/access-control-and-permission-management);
+[Lightdash user attributes](https://docs.lightdash.com/workspace-admin/user-attributes);
+[Rill data access control](https://docs.rilldata.com/developers/build/metrics-view/security)
+
+## Context and problem statement
+
+LeapView's SemanticModel is the governed consumption layer. Dashboards,
+Explore, agents, exports, embedded requests, and headless semantic queries must
+all resolve datasets, dimensions, measures, and metrics through the semantic
+planner. Source and Model describe ingestion and transformation; they are not
+consumer authorization surfaces.
+
+The current authored `DataPolicy` resource crosses this boundary. It can target
+a Source, Model, or SemanticModel, names a principal, group, service principal,
+or dashboard publication, and carries a separate row-filter or column-mask
+expression. Consequently the data restriction is detached from the semantic
+members it governs, identity records enter analytics source, and changing group
+membership or publication state can require an analytics deployment. ADR-0016
+removes that standalone resource and assigns identity, membership, grants,
+sharing, and publication to the instance control plane.
+
+Mature semantic products distinguish policy definitions from assignments.
+Looker defines named `access_grant` conditions from user attributes, attaches
+`required_access_grants` to Explores, joins, views, and fields, and connects an
+Explore field to a user attribute through `access_filter`. Administrators own
+the user attributes and their values. This matches LeapView's consumption
+boundary and does not require a general policy language.
+
+Rill places `access`, `row_filter`, `include`, and `exclude` under a metrics
+view, which confirms the correct ownership location, but its values are SQL and
+Go-template expressions. Lightdash similarly uses model-level SQL filters and
+attribute templates. Copying either contract one-for-one would add executable
+strings, dialect behavior, and injection-sensitive templating to LeapView's
+governed query boundary. Cedar, OpenFGA, and SCIM address object authorization
+or identity provisioning rather than semantic row filtering.
+
+LookML is a product language, not a vendor-neutral YAML standard. LeapView can
+therefore align with its proven three-part policy model but cannot claim Looker
+document compatibility or conformance.
+
+The question is which small authored contract should govern semantic dataset,
+row, and member access while keeping identities in the control plane and every
+query path fail-closed.
+
+## Decision drivers
+
+- Make SemanticModel the only authored data-access-policy target.
+- Keep identity records, group membership, role assignments, grants, and
+  attribute values out of analytics YAML.
+- Express dataset, row, and semantic-member restrictions without arbitrary SQL,
+  templates, scripts, or a general authorization language.
+- Resolve every policy reference structurally and contextually before
+  activation.
+- Apply identical restrictions to every semantic query consumer, including
+  discovery, suggestions, exports, agents, APIs, and embedding.
+- Fail closed on missing, empty, invalid, stale, or untrusted attributes.
+- Keep query planning deterministic, parameterized, auditable, and safe for
+  authorization-aware caching.
+- Prefer a small established semantic abstraction over a LeapView-specific
+  policy framework.
+
+## Considered options
+
+### Keep standalone subject-bound DataPolicy resources
+
+This retains the existing compiler path and permits direct policies for
+Sources and Models. It also duplicates policies for groups, binds portable code
+to instance identities, separates rules from the semantic fields they govern,
+and lets repository deployment mutate administrative state. It conflicts with
+the authored/control-plane boundary selected by ADR-0016.
+
+### Copy Rill metrics-view security one-for-one
+
+Rill covers resource access, row filtering, and field inclusion or exclusion
+at the correct consumption layer. Its `access`, `row_filter`, and conditional
+field rules are nevertheless SQL and template strings. Exact adoption would
+make dialect parsing, template evaluation, quoting, and injection behavior part
+of LeapView's public security contract and would bypass the closed semantic
+planner.
+
+### Use Lightdash model filters one-for-one
+
+Lightdash has strong attribute-driven row and column behavior, but its rules
+are centered on dbt or Lightdash models and use SQL templating. LeapView already
+has a distinct SemanticModel consumption layer, so model ownership and
+executable filter strings are both a poor fit.
+
+### Adopt a general policy engine or warehouse row-level security
+
+Cedar, OpenFGA, OPA, and warehouse policies can be useful enforcement or
+integration layers. None supplies a portable semantic YAML contract covering
+dataset discovery, semantic member visibility, semantic-field filtering, and
+all LeapView query consumers. Making one authoritative would also split policy
+meaning between the semantic compiler and an external engine or target.
+
+### Adopt Looker's access-grant and access-filter model
+
+Looker's model separates reusable attribute conditions, protection of semantic
+objects, and user-specific row filters. LeapView can express the same concepts
+as closed generated YAML, replace Looker's filter-expression strings with typed
+scalar and list matching, and enforce them in the existing semantic planner.
+
+## Decision outcome
+
+LeapView adopts a Looker-aligned semantic access contract. SemanticModel is the
+only authored policy target. The standalone `DataPolicy` resource is removed
+as required by ADR-0016, and Source, Model, Dashboard, Pipeline, and Connection
+do not gain authored access-policy blocks.
+
+The initial contract has exactly three concepts:
+
+- `accessGrants` defines named attribute conditions in the SemanticModel;
+- `requiredAccessGrants` attaches one or more named grants to a dataset,
+  dimension, measure, or metric; and
+- `accessFilters` attaches a semantic dimension to a principal attribute at a
+  dataset boundary.
+
+The YAML uses LeapView's existing camel-case convention while preserving the
+meaning of Looker's `access_grant`, `required_access_grants`, and
+`access_filter`. Public documentation describes the contract as
+**Looker-aligned**, never Looker-compatible or Looker-compliant.
+
+An illustrative contract is:
+
+```yaml
+apiVersion: leapview.dev/v1
+kind: SemanticModel
+metadata:
+  id: semantic_model:sales
+  name: sales
+spec:
+  accessGrants:
+    canViewSales:
+      userAttribute: department
+      allowedValues: [sales, finance]
+    canViewPII:
+      userAttribute: piiAccess
+      allowedValues: [full]
+  datasets:
+    orders:
+      model: orders
+      requiredAccessGrants: [canViewSales]
+      accessFilters:
+        - field: region
+          userAttribute: allowedRegions
+  dimensions:
+    region:
+      datatype: String
+      bindings:
+        orders:
+          field: region
+    customerEmail:
+      datatype: String
+      bindings:
+        orders:
+          field: customer_email
+      requiredAccessGrants: [canViewPII]
+```
+
+### Attribute ownership and matching
+
+The instance control plane owns the attribute registry, trusted SAML/OIDC and
+embed-claim mappings, group and principal assignments, and the resulting
+attribute values. SCIM may provision users and groups but does not define the
+authorization meaning of an attribute. Analytics YAML may reference only a
+canonical attribute name; it cannot declare values, identities, assignments,
+or claim-extraction rules.
+
+The initial value types are typed scalar and homogeneous list values supported
+by the semantic field vocabulary. A scalar attribute satisfies an access grant
+when it equals an allowed value. A list attribute satisfies it when at least
+one element equals an allowed value. Multiple `requiredAccessGrants` use logical
+AND. Missing, empty, type-incompatible, or untrusted values do not satisfy a
+grant.
+
+Profile `leapview.semantic-access/v1` defines the exact logical types,
+canonical spellings, Unicode behavior, null handling, cross-type prohibition,
+set normalization, and the fixed 1,024-value list bound. The same generated
+canonicalizer governs control-plane input, claim ingestion, compilation,
+runtime evaluation, cache identity, and audit projection.
+
+An access filter maps a scalar attribute to equality and a list attribute to a
+parameterized membership predicate. Multiple access filters use logical AND.
+The referenced field must be a dimension bound to the selected dataset and the
+attribute type must be compatible with the dimension datatype. Missing, empty,
+invalid, or incompatible values deny the query; no wildcard, administrator
+bypass, or implicit unfiltered fallback exists.
+
+The control plane rejects deletion or type mutation of an attribute referenced
+by an active or retained rollback generation. It may explicitly disable the
+attribute as an audited emergency revocation; dependent semantic objects then
+fail closed, become unhealthy, and invalidate affected caches. This is not a
+semantic-evaluator bypass. Break-glass access is absent from this profile and
+would require a separate control-plane security ADR.
+
+### Enforcement boundary
+
+Access grants control both discovery and execution. A denied dataset or member
+is absent from the authorization-filtered catalog and is rejected if addressed
+directly by ID or name. Hiding a member in the UI is not enforcement.
+
+Access filters lower through the typed semantic planner into bound parameters.
+They are enforced for dashboards, Explore, raw-value and suggestion queries,
+agents, exports, scheduled execution, APIs, and embedded requests. No consumer
+may opt out, skip nested security, provide precompiled SQL, or substitute its
+own filter expression.
+
+Every protected dataset occurrence enters the plan behind a typed security
+barrier at its governed scan. The barrier applies before joins, outer-join null
+extension, aggregation, suggestions, totals, rollups, caching, and
+consumer-supplied filters. An optimizer may push it into an equivalent scan but
+may not pull it above a join or aggregate, reduce it to a final `WHERE`, or lose
+it during rewrite.
+
+A dataset requiring an access-filter attribute is absent from discovery when
+that attribute is missing, empty, invalid, untrusted, out of bounds, or type
+incompatible, and direct execution is denied. A valid attribute permits
+discovery even if the authorized row set happens to be empty; discovery never
+probes data to infer authorization.
+
+Authorization identity, effective grant results, normalized access filters,
+semantic generation, and trusted-attribute version participate in query and
+result-cache identity. Durable audit records identify the policy inputs and
+outcome without recording unrestricted sensitive attribute values.
+
+### Deliberate initial limits
+
+The initial contract does not include arbitrary access predicates, SQL row
+filters, templates, regular expressions, group-name tests, explicit deny rules,
+policy inheritance, reusable cross-model policy resources, or column masking.
+Semantic member denial covers the initial column-security requirement.
+
+If masked-but-visible values become a demonstrated requirement, a later ADR
+must define a closed semantic masking extension, its aggregation behavior,
+planner placement, export semantics, cache identity, and conflict rules. It
+must not be added under the claim of Looker alignment.
+
+The exact generated schema, evaluation rules, diagnostics, evidence, and
+qualification matrix are maintained by the linked semantic access-policy
+conformance specification under profile `leapview.semantic-access/v1`.
+Normative changes to its shape, canonicalization, evaluation, planner,
+discovery, cache, or compatibility behavior require a new profile; new policy
+concepts, targets, bypasses, precedence, or masking require another ADR.
+
+Policy diffs report compatibility and security impact separately. The profile
+matrix makes tightening changes such as adding a required grant or access
+filter breaking, and makes weakening changes such as removing one explicitly
+access-widening. A widening result always requires security approval; an
+indeterminate result blocks publication. A semantic version never authorizes a
+widening by itself.
+
+## Consequences
+
+Policy meaning becomes visible beside the governed semantic objects, and one
+definition applies consistently to every consumption path. Identity teams can
+change users, groups, and attribute values without rebuilding analytics code,
+while changes to access grants or filters receive normal semantic-model review,
+planning, compatibility classification, and deployment evidence.
+
+The contract is substantially smaller and safer than Rill or Lightdash
+templated SQL. It is also less expressive. Complex predicates, relational
+entitlement tables, time-dependent policy, and masked values are not available
+through v1 authoring and require modeled data, control-plane attributes, or a
+future explicit decision.
+
+The control plane must gain a typed, versioned attribute registry and trusted
+claim-mapping lifecycle. Candidate preparation must prove that every referenced
+attribute exists and is type-compatible without embedding instance values in
+portable artifacts. Attribute changes must invalidate affected authorization
+and result caches promptly and generate durable audit evidence.
+
+Removing Source and Model policy targets means every consumer-visible query
+must pass through SemanticModel. Any raw Source or Model preview remains an
+authoring capability restricted by control-plane authorization and cannot be a
+consumer data-delivery API. If a future raw-data product is required, it needs
+its own governed consumption contract rather than reuse of internal resources.
+
+## Confirmation
+
+- TypeSpec is the sole public structural authority for `accessGrants`,
+  `requiredAccessGrants`, and `accessFilters`; generated JSON Schema, Go DTOs,
+  documentation, and browser types contain the same closed contract.
+- The authoring registry rejects standalone `DataPolicy` resources and rejects
+  access-policy fields on every resource other than SemanticModel.
+- Schema and compiler fixtures cover the normative cases in the semantic
+  access-policy conformance specification, including unknown fields, dangling
+  grants, incompatible attributes, unbound dimensions, and prohibited identity
+  or executable-string fields.
+- Query authorization tests prove fail-closed scalar and list matching,
+  all-grants and all-filters composition, discovery filtering, direct-reference
+  rejection, parameterized planning, and identical enforcement for every
+  semantic consumer.
+- Extracted normative YAML examples parse and validate against the generated
+  SemanticModel schema; cross-path golden fixtures prove identical typed
+  canonicalization and the 1,024-value bound.
+- Planner golden tests prove one effective security barrier per protected
+  dataset occurrence before inner and outer joins, aggregates, totals,
+  suggestions, self-joins, rollups, and coalesced multi-dataset plans, and prove
+  unsafe rewrites fail closed.
+- Compatibility fixtures cover every normative policy-change matrix row and
+  prove tightening, widening, and indeterminate results trigger the required
+  version and approval behavior.
+- Registry lifecycle tests reject referenced attribute deletion and type
+  mutation, prove explicit disablement fails closed, and prove no administrator
+  or break-glass bypass exists in semantic consumers.
+- Cache tests prove principals with different effective policies cannot share
+  authorization-sensitive results and that attribute-version changes
+  invalidate affected entries.
+- Audit tests prove grant evaluation and row-filter application are attributable
+  to the principal, semantic generation, attribute version, and policy identity
+  without leaking unrestricted attribute values.
+- Architecture tests prevent dashboards, APIs, agents, exports, and lower-level
+  analytical runtimes from bypassing the governed semantic authorization path.

--- a/adr/README.md
+++ b/adr/README.md
@@ -23,17 +23,19 @@ customer site.
 | [ADR-0002](0002-use-maplibre-for-geographic-rendering.md) | Use MapLibre for geographic rendering | Accepted | 2026-07-22 | Complete | — |
 | [ADR-0003](0003-retain-narrow-infisical-resolver.md) | Retain the narrow Infisical resolver | Accepted | 2026-07-31 | Complete | — |
 | [ADR-0004](0004-defer-incremental-project-reconciliation.md) | Defer incremental project reconciliation | Accepted | 2026-08-05 | Deferred pending corrected measurement | [ADR-0005](0005-use-project-wide-resource-graph.md), scope and identity only |
-| [ADR-0005](0005-use-project-wide-resource-graph.md) | Use a project-wide resource graph | Accepted | 2026-08-15 | Complete | — |
-| [ADR-0006](0006-adopt-ossie-aligned-semantic-contract.md) | Adopt an OSSIE-aligned typed semantic contract | Accepted | 2026-08-17 | Complete | — |
+| [ADR-0005](0005-use-project-wide-resource-graph.md) | Use a project-wide resource graph | Accepted | 2026-08-15 | Complete | [ADR-0016](0016-adopt-standards-aligned-data-contracts-and-interchange.md), public Project and control-plane authoring boundaries |
+| [ADR-0006](0006-adopt-ossie-aligned-semantic-contract.md) | Adopt an OSSIE-aligned typed semantic contract | Accepted | 2026-08-17 | Complete | [ADR-0016](0016-adopt-standards-aligned-data-contracts-and-interchange.md), structural authority; [ADR-0017](0017-adopt-a-looker-aligned-semantic-access-contract.md), semantic access contract |
 | [ADR-0007](0007-adopt-plan-driven-project-delivery.md) | Adopt plan-driven project delivery | Accepted | 2026-08-17 | In progress (controlled rollout) | — |
 | [ADR-0008](0008-isolate-ducklake-candidate-physical-state.md) | Use one immutable DuckLake catalog per candidate | Accepted | 2026-08-17 | In progress (controlled rollout) | — |
 | [ADR-0009](0009-separate-control-and-physical-transactions.md) | Separate control state from immutable physical catalogs | Accepted | 2026-08-17 | In progress (controlled rollout) | — |
-| [ADR-0010](0010-adopt-strict-typed-data-resource-contracts.md) | Adopt strict typed data-resource contracts | Accepted | 2026-08-18 | Complete | — |
+| [ADR-0010](0010-adopt-strict-typed-data-resource-contracts.md) | Adopt strict typed data-resource contracts | Accepted | 2026-08-18 | Complete | [ADR-0016](0016-adopt-standards-aligned-data-contracts-and-interchange.md), contract evolution, quality identity, and governance metadata |
 | [ADR-0011](0011-adopt-a-canonical-dashboard-document.md) | Adopt a canonical dashboard document | Accepted | 2026-08-18 | Complete | — |
 | [ADR-0012](0012-separate-duckdb-sql-analysis-from-application-policy.md) | Separate DuckDB SQL analysis from application policy | Accepted | 2026-08-19 | Complete | — |
 | [ADR-0013](0013-separate-workload-admission-from-application-policy.md) | Separate workload admission from application policy | Accepted | 2026-08-19 | Complete | — |
 | [ADR-0014](0014-adopt-an-asset-selected-refresh-pipeline-contract.md) | Adopt an asset-selected refresh pipeline contract | Accepted | 2026-08-20 | Pending | — |
 | [ADR-0015](0015-adopt-durable-audit-and-compliance-controls.md) | Adopt durable audit and compliance controls | Accepted | 2026-08-23 | Durable foundation and prioritized producer adoption | — |
+| [ADR-0016](0016-adopt-standards-aligned-data-contracts-and-interchange.md) | Adopt standards-aligned data contracts and interchange | Accepted | 2026-09-01 | Pending | — |
+| [ADR-0017](0017-adopt-a-looker-aligned-semantic-access-contract.md) | Adopt a Looker-aligned semantic access contract | Accepted | 2026-09-01 | Pending | — |
 
 ## Companion specifications
 
@@ -45,6 +47,8 @@ historical records.
 - [Project delivery conformance](specifications/project-delivery-conformance.md)
 - [DuckDB SQL analysis conformance](specifications/duckdb-sql-analysis-conformance.md)
 - [Workload admission conformance](specifications/workload-admission-conformance.md)
+- [Data-contract versioning conformance](specifications/data-contract-versioning-conformance.md)
+- [Semantic access-policy conformance](specifications/semantic-access-policy-conformance.md)
 
 ## Conventions
 
@@ -56,6 +60,9 @@ historical records.
 - Keep decision status separate from implementation progress. Allowed decision
   statuses are `proposed`, `accepted`, `rejected`, `deprecated`, and
   `superseded`.
+- Use `Supersedes` when the earlier decision no longer governs and `Amends`
+  when only a named boundary changes. Keep related but unchanged decisions under
+  `Related`.
 - Record one cohesive, architecturally significant decision per ADR. Use an ADR
   when a choice is cross-cutting, expensive to reverse, security-sensitive, or
   non-obvious enough that future maintainers will need its rationale.

--- a/adr/specifications/data-contract-versioning-conformance.md
+++ b/adr/specifications/data-contract-versioning-conformance.md
@@ -1,0 +1,218 @@
+# Data-contract versioning conformance specification
+
+Status: accepted
+
+Profile: `leapview.contract/v1`
+
+Last updated: 2026-09-01
+
+Owners: LeapView maintainers
+
+Governing decision: [ADR-0016](../0016-adopt-standards-aligned-data-contracts-and-interchange.md)
+
+## Purpose
+
+This mutable specification defines the resource-identity namespace, canonical
+contract projection, serialization, digest, and change evidence required by
+ADR-0016. It resolves two security-sensitive consequences of removing the
+public Project resource: control-plane references cannot silently rebind, and
+published contract immutability must be calculated from one deterministic
+typed projection.
+
+The terms **must**, **must not**, **should**, and **may** are normative. The
+profile identifier is part of canonical bytes and conformance evidence.
+
+## Resource identity
+
+- **RID-01:** One LeapView instance has at most one active compiled source
+  bundle. Deploying another source root creates a candidate replacement; it
+  does not add a second public namespace. Concurrent independently deployed
+  bundles require separate instances.
+- **RID-02:** An authored `metadata.id` is portable and stable across repository,
+  branch, directory, filename, symbolic-name, display-name, and source-root
+  moves. None of those locations participates in canonical identity.
+- **RID-03:** A candidate contains at most one resource with a given
+  `metadata.id` across all six authored kinds. Cross-kind and same-kind
+  collisions are rejected before graph construction.
+- **RID-04:** First activation binds `(instance identity, metadata.id)` to an
+  immutable instance resource UID and authored kind. Control-plane grants,
+  publications, audit records, and durable references store the UID plus the
+  expected authored ID and kind; they do not resolve by name or path.
+- **RID-05:** A later candidate with the same authored ID and kind updates the
+  same resource UID. A kind change is never an update and is rejected.
+- **RID-06:** Removing a resource tombstones its UID and suspends dependent
+  control-plane references. Normal deployment cannot assign the tombstoned ID
+  to a new UID or automatically reactivate suspended grants or publications.
+- **RID-07:** Restoration of a tombstoned logical resource requires an explicit,
+  audited control-plane restore operation. Restore reuses the original UID,
+  recompiles and revalidates every dependent reference, and leaves grants and
+  publications suspended until separately authorized reactivation.
+- **RID-08:** Rollback reactivates the historical UID and generation recorded by
+  the selected release. It cannot create a new identity or retarget a reference.
+- **RID-09:** The same authored ID may exist in different instances because the
+  instance identity is the namespace boundary. External ODCS, ODPS, DCAT, and
+  lineage projections qualify it with a stable instance or tenant URI; the raw
+  authored ID is never claimed to be globally unique.
+- **RID-10:** Candidate planning reports created, updated, removed, tombstoned,
+  restored, dangling, and collision outcomes before approval. An unresolved or
+  ambiguously resolved control-plane reference blocks activation.
+
+## Canonical contract envelope
+
+- **CAN-01:** Canonicalization starts from generated, validated TypeSpec DTOs,
+  never YAML nodes, map iteration, source formatting, comments, aliases,
+  anchors, default omission, or handwritten reflection.
+- **CAN-02:** Every public DTO field is classified in TypeSpec as contract,
+  descriptive, operational, secret, or derived. Generation fails when a new
+  field lacks a classification.
+- **CAN-03:** Canonical bytes contain `profile`, `apiVersion`, `kind`,
+  `metadata.id`, `metadata.name`, authored contract version, compatibility
+  policy, and the resource-specific contract projection below.
+- **CAN-04:** Canonical bytes exclude display name, prose description, owner,
+  domain, tags, documentation, provenance, AI context, source paths, comments,
+  credentials, target bindings, runtime observations, deployment state, and
+  derived lineage. Changes to excluded fields do not require a contract-version
+  change but remain visible in candidate metadata diffs.
+- **CAN-05:** Classification, critical-data-element markers, authoritative
+  definitions, and deprecation guidance are included wherever ADR-0016 permits
+  them. Their changes require a new contract version even when compatibility is
+  otherwise non-breaking.
+- **CAN-06:** Defaults are materialized before projection. An omitted field and
+  an explicitly authored value are byte-identical only when the generated
+  contract declares that value as the normative default.
+- **CAN-07:** Unknown fields, generic extension bags, non-finite numbers, and
+  values without a canonical typed representation are rejected before hashing.
+
+## Resource-specific projection
+
+### Source
+
+- **SRC-01:** Source projection includes schema mode, declared field and nested
+  structure, logical datatypes, nullability, field governance, freshness
+  guarantees, and every stable authored identity used by those declarations.
+- **SRC-02:** Source projection excludes Connection binding, physical location,
+  credentials, discovered physical types, inferred observations, refresh state,
+  and target-owned options. Inferred observations may be evidence but cannot
+  mutate published canonical bytes.
+
+### Model
+
+- **MOD-01:** Model projection includes canonical output fields and nullability,
+  entities, keys, grain, relationships promised by the Model contract, field
+  governance, and the complete normalized quality-check definitions including
+  stable IDs, types, severity, thresholds, and referenced fields.
+- **MOD-02:** Result-affecting transformation logic is represented by the
+  compiler's canonical analyzed logical-expression or SQL-AST projection.
+  Whitespace, comments, harmless parentheses, and source formatting are absent;
+  identifiers, operators, literals, casts, functions, and dependency IDs remain.
+- **MOD-03:** Materialization location, runtime plan choices, cache settings,
+  physical table names, and execution observations are excluded.
+
+### SemanticModel
+
+- **SEM-01:** SemanticModel projection includes datasets and bindings,
+  relationships, entities, dimensions and time semantics, measures, metrics,
+  filters, units, formats that affect returned consumer values, result-affecting
+  expressions, field governance, and the ADR-0017 access contract.
+- **SEM-02:** Every semantic collection is projected by stable identifier and
+  every reference is lowered to a canonical stable resource or member ID before
+  hashing. A file name, map insertion order, or display label cannot affect it.
+- **SEM-03:** Discovery-only prose, AI context, display descriptions, and
+  instance attribute values are excluded. Attribute names and authored access
+  conditions are included.
+
+## Normalization and serialization
+
+- **SER-01:** The canonical projection is encoded as UTF-8 JSON using
+  [RFC 8785 JSON Canonicalization Scheme](https://www.rfc-editor.org/rfc/rfc8785.html)
+  after the typed normalizations in this section.
+- **SER-02:** JSON object keys use RFC 8785 ordering. Collections declared as
+  sets are deduplicated and sorted by their canonical element bytes. Ordered
+  lists retain declared semantic order. TypeSpec must classify every collection
+  as a map, set, or ordered list.
+- **SER-03:** Identifiers and enumerations use their validated canonical spelling.
+  General strings are Unicode NFC and remain case-sensitive; no whitespace is
+  trimmed and forbidden control characters are rejected.
+- **SER-04:** Integers use their mathematical base-10 representation with no
+  leading plus or zeroes except `0`. Exact decimals remove insignificant trailing
+  zeroes, use no exponent, and canonicalize negative zero to `0`. Approximate
+  floats are not permitted in contract literals.
+- **SER-05:** Booleans serialize as JSON `true` or `false`. Null is emitted only
+  for a field whose generated contract distinguishes explicit null from absence;
+  otherwise absence is represented by omission after default materialization.
+- **SER-06:** Dates use valid Gregorian `YYYY-MM-DD`. Timestamps parse RFC 3339,
+  reject leap seconds, normalize to UTC `Z`, and use the shortest fractional
+  second form that preserves nanosecond precision.
+- **SER-07:** URLs use RFC 3986 syntax normalization: lowercase scheme and host,
+  uppercase percent hex, decode percent-encoded unreserved characters, remove
+  dot segments, remove default HTTP/HTTPS ports, and use `/` for an empty
+  authority path. Query-pair order and fragments remain significant.
+- **SER-08:** Logical values that JSON cannot distinguish losslessly, including
+  Decimal, Date, and Timestamp, use generated type-tagged canonical values so
+  equal text in different logical types never hashes identically by accident.
+- **SER-09:** The canonical digest is SHA-256 over the exact canonical bytes and
+  is rendered as `sha256:` plus lowercase hexadecimal. Stored evidence retains
+  the profile, bytes, digest, resource UID, authored ID, kind, and version.
+- **SER-10:** Independent fixtures in Go and one non-Go RFC 8785 implementation
+  must produce byte-identical output and digests for the supported corpus.
+
+## Version immutability and change handling
+
+- **VER-01:** The first publication of a resource contract version stores its
+  canonical bytes and digest immutably.
+- **VER-02:** A candidate using an already published version must reproduce the
+  stored profile and digest exactly. Any mismatch is rejected even when a
+  compatibility classifier would call the change additive or descriptive.
+- **VER-03:** A change to included canonical content requires a new semantic
+  version. Excluded descriptive or operational changes do not require one.
+- **VER-04:** A new version does not authorize activation. The normalized diff,
+  compatibility class, security impact, affected graph, and deployment policy
+  still determine approval or rejection.
+- **VER-05:** Changing the canonical projection, normalization, or serialization
+  requires a new profile identifier. Existing published bytes and digests remain
+  verifiable under their original profile.
+- **VER-06:** Editorial changes, added fixtures, evidence links, and stricter
+  tests that do not change accepted documents or behavior may update this file
+  without changing the profile. Any normative semantic change requires a new
+  profile version and review of whether ADR-0016 must be amended or superseded.
+
+## Qualification matrix
+
+| Scenario | Expected result |
+|---|---|
+| Source root or file moves with unchanged authored ID | Same resource UID and contract digest |
+| Two resources share an authored ID | Candidate rejected before graph construction |
+| Resource kind changes under an existing ID | Candidate rejected |
+| Deleted ID appears in a normal deployment | Tombstone-reuse rejection |
+| Explicit restore is approved | Original UID restored; grants remain suspended |
+| Description or tags change | Metadata diff only; digest unchanged |
+| Field datatype or access grant changes | Digest changes; new version required |
+| YAML key order, comments, aliases, or whitespace change | Digest unchanged |
+| Equivalent decimal or timestamp spellings | Digest unchanged after typed normalization |
+| Existing published version has different bytes | Candidate rejected |
+| Canonical profile changes | New profile required; historical digest preserved |
+
+## Evidence ledger
+
+| Requirement range | Evidence | Status |
+|---|---|---|
+| RID-01–RID-10 | Identity registry, collision, tombstone, restore, rollback, and reference tests | Pending |
+| CAN-01–CAN-07 | TypeSpec classification and generated projection checks | Pending |
+| SRC-01–SRC-02 | Source canonical golden fixtures | Pending |
+| MOD-01–MOD-03 | Model AST and quality-contract golden fixtures | Pending |
+| SEM-01–SEM-03 | Semantic and access-contract golden fixtures | Pending |
+| SER-01–SER-10 | Cross-language RFC 8785 and typed-normalization corpus | Pending |
+| VER-01–VER-06 | Publication immutability, diff, and profile-version tests | Pending |
+
+## Maintained verification
+
+Implementation must add focused identity, canonicalization, cross-language
+golden, and immutable-publication tests. Every normative YAML example must be
+parsed and validated against the generated schema. The final combined change
+must also pass:
+
+```sh
+task generate
+task generated:check
+task ci
+```

--- a/adr/specifications/semantic-access-policy-conformance.md
+++ b/adr/specifications/semantic-access-policy-conformance.md
@@ -1,0 +1,462 @@
+# Semantic access-policy conformance specification
+
+Status: accepted
+
+Profile: `leapview.semantic-access/v1`
+
+Last updated: 2026-09-01
+
+Owners: LeapView maintainers
+
+Governing decision: [ADR-0017](../0017-adopt-a-looker-aligned-semantic-access-contract.md)
+
+## Purpose
+
+This mutable specification defines the public structure, compiler semantics,
+runtime enforcement, and evidence required by ADR-0017. The governing ADR owns
+the stable architectural decision: SemanticModel is the only authored policy
+target and uses a Looker-aligned access-grant and access-filter model.
+
+The terms **must**, **must not**, **should**, and **may** are normative. A
+requirement is implemented only when its evidence is linked in the evidence
+ledger. The profile identifier participates in generated schema, compiled
+policy, cache, audit, and conformance evidence.
+
+## Change control
+
+- **CHG-01:** Editorial clarification, new non-normative examples, added test
+  cases, and evidence links may update this document without changing the
+  profile when accepted documents and authorization decisions are unchanged.
+- **CHG-02:** Any change to public shape, attribute normalization, matching,
+  list bounds, composition, planner placement, discovery, denial, or cache
+  identity requires a new semantic-access profile version.
+- **CHG-03:** A change that adds a policy concept, target, bypass, expression
+  language, precedence model, or masking behavior also requires a new ADR that
+  amends or supersedes ADR-0017.
+- **CHG-04:** Historical compiled policies and audit evidence retain their
+  original profile. A profile upgrade is planned, compatibility-classified, and
+  never applied implicitly to an active generation.
+
+## Canonical authored shape
+
+```yaml
+apiVersion: leapview.dev/v1
+kind: SemanticModel
+metadata:
+  id: semantic_model:sales
+  name: sales
+spec:
+  accessGrants:
+    canViewSales:
+      userAttribute: department
+      allowedValues:
+        - sales
+        - finance
+    canViewPII:
+      userAttribute: piiAccess
+      allowedValues:
+        - full
+  datasets:
+    orders:
+      model: orders
+      requiredAccessGrants:
+        - canViewSales
+      accessFilters:
+        - field: region
+          userAttribute: allowedRegions
+  dimensions:
+    region:
+      datatype: String
+      bindings:
+        orders:
+          field: region
+    customerEmail:
+      datatype: String
+      bindings:
+        orders:
+          field: customer_email
+      requiredAccessGrants:
+        - canViewPII
+  measures:
+    revenue:
+      dataset: orders
+      aggregation: sum
+      input:
+        field: revenue
+    cost:
+      dataset: orders
+      aggregation: sum
+      input:
+        field: cost
+  metrics:
+    grossMargin:
+      type: derived
+      expression: revenue - cost
+      requiredAccessGrants:
+        - canViewSales
+        - canViewPII
+```
+
+## Public structure
+
+- **STR-01:** `spec.accessGrants` is an optional identifier-keyed map. Keys are
+  unique by construction and use the canonical SemanticModel identifier rules.
+- **STR-02:** Each access grant is closed and requires exactly
+  `userAttribute` and a non-empty `allowedValues` list.
+- **STR-03:** `userAttribute` is a canonical control-plane attribute name. It
+  cannot contain an email, principal ID, group ID, role, grant, publication,
+  claim path, template, SQL fragment, or target-specific identity.
+- **STR-04:** `allowedValues` contains typed scalar literals only. Values in one
+  grant are homogeneous, canonicalizable, duplicate-free, and deterministically
+  ordered after normalization.
+- **STR-05:** `requiredAccessGrants` is permitted only on SemanticModel datasets,
+  dimensions, measures, and metrics. It is a non-empty, duplicate-free list of
+  access-grant names local to the same SemanticModel.
+- **STR-06:** `accessFilters` is permitted only on a SemanticModel dataset. Each
+  entry is closed and requires exactly `field` and `userAttribute`.
+- **STR-07:** An access-filter field names a SemanticModel dimension, not a
+  physical column, SQL expression, dashboard field, or external resource.
+- **STR-08:** Access-policy fields on Connection, Source, Model, Pipeline, or
+  Dashboard and standalone `DataPolicy` documents are rejected.
+- **STR-09:** Unknown keys and generic extension bags are rejected at every
+  policy node.
+- **STR-10:** TypeSpec owns this structure and generates all public projections;
+  handwritten Go, CUE, JSON Schema, or UI copies are not independent authorities.
+- **STR-11:** `allowedValues` and every list-valued principal attribute contain
+  at most 1,024 canonical values in profile v1. The bound is public
+  authorization behavior and cannot vary by target or query path.
+- **STR-12:** Every normative YAML example is extracted, parsed, and validated
+  against the generated SemanticModel schema in CI.
+
+## Control-plane attribute contract
+
+- **ATT-01:** The target instance owns a typed, versioned attribute registry.
+  Portable SemanticModel YAML references attribute names but contains neither
+  registry definitions nor values.
+- **ATT-02:** Attribute values originate only from authenticated control-plane
+  assignments, trusted SAML/OIDC claim mappings, or cryptographically verified
+  embed/service-token claims admitted by the control plane.
+- **ATT-03:** Browser parameters, dashboard filters, query arguments, headers,
+  unsigned tokens, and analytics YAML cannot create or override trusted
+  principal attributes.
+- **ATT-04:** Supported values are a scalar or homogeneous list over the
+  approved semantic literal types. Maps, nested lists, raw JSON, SQL fragments,
+  filter-expression strings, and executable values are rejected.
+- **ATT-05:** Every resolved principal context carries a stable attribute-set
+  version or digest suitable for authorization and cache identity.
+- **ATT-06:** Candidate preparation resolves every referenced attribute against
+  the target registry and rejects absent or type-incompatible declarations
+  before activation.
+- **ATT-07:** Runtime absence, emptiness, invalidity, expiry, or loss of trust
+  fails closed even if candidate validation previously succeeded.
+- **ATT-08:** Attribute assignment changes are audited control-plane operations
+  and take effect without an analytics deployment.
+- **ATT-09:** Deleting an attribute or changing its type is rejected while any
+  active or retained rollback generation references it. Type evolution creates
+  a new canonical attribute rather than mutating the existing definition.
+- **ATT-10:** An administrator may disable an attribute as an explicit audited
+  emergency revocation. Disabling never deletes the registry entry: every
+  semantic object governed through a dependency on that attribute becomes
+  unavailable, affected caches are invalidated, and health reports the disabled
+  dependency until it is restored or a new SemanticModel generation removes
+  the reference.
+- **ATT-11:** Removing a principal assignment or trusted claim mapping is
+  permitted and takes effect as a fail-closed value absence for affected
+  principals. It cannot change the attribute's registered type or provide a
+  fallback value implicitly.
+- **ATT-12:** The control plane rejects an assignment containing more than 1,024
+  canonical values. Runtime repeats the bound defensively and denies evaluation
+  if persisted or token-supplied state violates it.
+
+## Attribute value canonicalization
+
+- **VAL-01:** Attribute names use the ASCII SemanticModel identifier grammar
+  and are case-sensitive. Case folding, trimming, aliases, locale rules, and
+  Unicode confusables do not participate in name resolution.
+- **VAL-02:** Profile v1 permits String, Boolean, Integer, Decimal, Date, and
+  Timestamp attribute values and homogeneous lists of those values. Float,
+  binary, interval, JSON, map, object, nested-list, and null values are rejected.
+- **VAL-03:** Strings are valid Unicode normalized to NFC, remain
+  case-sensitive, retain leading and trailing whitespace, and reject C0/C1
+  control characters without exception. A differently cased or spaced value
+  is a different authorization value.
+- **VAL-04:** Booleans have only the typed values `true` and `false`; strings
+  such as `"true"`, integers, and truthy values are not coerced.
+- **VAL-05:** Integers are signed 64-bit mathematical integers and canonicalize
+  to base-10 with no leading plus or zeroes except `0`.
+- **VAL-06:** Decimals are finite exact base-10 values. Canonicalization removes
+  insignificant trailing zeroes, uses no exponent, and maps negative zero to
+  `0`. Integer and Decimal remain distinct types even when numerically equal.
+- **VAL-07:** Dates are valid Gregorian `YYYY-MM-DD` values. Timestamps parse
+  RFC 3339, reject leap seconds, normalize to UTC `Z`, and use the shortest
+  fractional form preserving nanosecond precision.
+- **VAL-08:** Explicit null, YAML null, an absent value, and an empty list never
+  match an allowed value and never mean unrestricted access. Null is invalid in
+  `allowedValues` and attribute assignments.
+- **VAL-09:** Lists have set semantics after element canonicalization: duplicate
+  values collapse and remaining values sort by `(logical type, canonical
+  bytes)`. Assignment order cannot change policy identity or cache identity.
+- **VAL-10:** Grant values and filter dimensions require the same registered
+  logical type. Profile v1 performs no numeric promotion, string parsing,
+  timezone inference, locale conversion, or other cross-type coercion.
+- **VAL-11:** One shared generated canonicalizer is used by control-plane input,
+  claim ingestion, candidate validation, runtime evaluation, policy digesting,
+  caching, and audit projection. Independent golden fixtures prove identical
+  decisions across these paths.
+
+## Access-grant evaluation
+
+- **GRT-01:** A scalar attribute satisfies a grant when its canonical value
+  equals one canonical `allowedValues` member.
+- **GRT-02:** A list attribute satisfies a grant when at least one canonical
+  element equals one canonical `allowedValues` member.
+- **GRT-03:** Missing, empty, invalid, expired, untrusted, or type-incompatible
+  attributes do not satisfy a grant.
+- **GRT-04:** Multiple `requiredAccessGrants` on one object use logical AND.
+- **GRT-05:** An empty required-grant list is structurally invalid; absence means
+  that this mechanism imposes no additional grant requirement on the object.
+- **GRT-06:** There is no implicit administrator, owner, service-principal, or
+  publication bypass. Every principal on a semantic consumer surface satisfies
+  the same authored requirements. Break-glass access is out of scope and does
+  not exist under this profile; adding an operational bypass requires a separate
+  control-plane security ADR and cannot alter semantic evaluation.
+- **GRT-07:** Access-grant evaluation is deterministic and independent of map
+  iteration, assignment order, repository paths, and display names.
+- **GRT-08:** Grant names and results are included in normalized policy identity;
+  raw sensitive attribute values are not included in logs or telemetry.
+- **GRT-09:** Dataset requirements apply to every dimension, measure, metric,
+  relationship traversal, raw-value request, and derived query over that
+  dataset; a member cannot weaken its dataset's requirements.
+- **GRT-10:** Required grants propagate through semantic dependencies. A
+  derived metric, filtered metric, measure, or other semantic member cannot
+  expose a denied dependency by omitting that dependency's grant.
+
+## Access-filter evaluation
+
+- **FLT-01:** The referenced dimension must be bound to the dataset containing
+  the access filter and must resolve to a planner-governed field.
+- **FLT-02:** A scalar attribute lowers to a typed equality predicate between
+  the dimension and one bound parameter.
+- **FLT-03:** A list attribute lowers to a typed membership predicate over bound
+  parameters. After deduplication it contains at most 1,024 values; an oversized
+  value denies evaluation before planning.
+- **FLT-04:** Multiple access filters on one dataset use logical AND.
+- **FLT-05:** Filters inherited through every dataset and relationship path used
+  by a query also use logical AND. A join cannot weaken or replace a dataset's
+  filter.
+- **FLT-06:** Missing, empty, invalid, expired, untrusted, oversized, or
+  type-incompatible attributes make the dataset unavailable and deny the query
+  before execution.
+- **FLT-07:** Access filters never accept an author-supplied operator, wildcard,
+  regular expression, SQL fragment, template, subquery, function, or null-as-all
+  convention in the initial profile.
+- **FLT-08:** Filter values are parameters in the typed plan. They are never
+  interpolated into authored or generated SQL.
+- **FLT-09:** Access filters constrain suggestions, raw values, totals,
+  comparisons, drill-through, spatial queries, exports, and every intermediate
+  or coalesced query derived from the semantic request.
+- **FLT-10:** Query planning retains normalized evidence of applied filters and
+  their source policy identities without retaining unrestricted values.
+
+## Planner security barrier
+
+- **PLN-01:** Every protected dataset occurrence enters the semantic plan as a
+  typed `SecurityBarrier` over that dataset's governed scan. The barrier owns
+  normalized access-filter predicates and their bound parameters.
+- **PLN-02:** The barrier restricts the dataset before joins, null extension,
+  aggregation, windowing, totals, suggestions, projections, limits, sampling,
+  spatial processing, caching, or consumer-supplied filters.
+- **PLN-03:** An optimizer may push a barrier predicate into the protected scan
+  only when it proves semantic equivalence. It may never pull the predicate
+  above a join or aggregate, turn it into a final `WHERE` filter, or remove it
+  because another predicate appears equivalent.
+- **PLN-04:** Each alias, self-join, relationship traversal, subplan, rollup,
+  materialized substitute, and coalesced query branch retains the barrier for
+  every protected dataset it reads.
+- **PLN-05:** Outer joins apply the protected side's barrier before the join so
+  unauthorized rows cannot affect matching, null extension, counts, or
+  aggregates. A post-join filter is not conformant evidence.
+- **PLN-06:** Aggregate and derived-metric plans operate only over
+  barrier-restricted inputs. Security filters cannot be represented solely as a
+  HAVING clause or final projection.
+- **PLN-07:** Rollups and caches may satisfy a protected scan only when their
+  lineage and authorization identity prove that they contain no rows outside
+  the same effective barrier.
+- **PLN-08:** Plan validation fails closed if a protected dataset scan lacks
+  exactly one effective barrier or if barrier lineage is lost during rewrite.
+- **PLN-09:** Golden plan tests cover inner, left, right, and full outer joins;
+  self-joins; many-to-many paths; totals; suggestions; derived metrics; rollups;
+  and multi-dataset coalescing.
+
+## Discovery and execution enforcement
+
+- **ENF-01:** A dataset whose required grants fail is absent from catalogs,
+  search, agent tools, builder choices, and reference resolution available to
+  the principal.
+- **ENF-02:** A dimension, measure, or metric whose required grants fail is
+  absent from field catalogs and rejected when addressed directly by canonical
+  ID, symbolic name, saved query, dashboard, API, or agent-generated request.
+- **ENF-03:** Every dashboard, Explore, agent, export, scheduled execution, API,
+  MCP, and embedded request enters one governed semantic authorization path.
+- **ENF-04:** No consumer flag, route, token scope, saved artifact, raw SQL
+  escape, `skip_nested_security` behavior, or internal caller may suppress
+  grant or filter evaluation.
+- **ENF-05:** A dashboard cannot widen SemanticModel access. Dashboard sharing
+  and publication grant access to the document, not to otherwise denied data.
+- **ENF-06:** Source and Model preview is an authoring capability controlled by
+  control-plane authorization. It is not a consumer API and does not inherit a
+  second authored policy language.
+- **ENF-07:** Denial occurs before warehouse or DuckDB execution whenever the
+  missing grant or invalid attribute is knowable before planning.
+- **ENF-08:** Error responses disclose enough stable policy identity for an
+  authorized administrator to diagnose failure without revealing inaccessible
+  members or sensitive attribute values to the requester.
+- **ENF-09:** Catalog and execution authorization calculate transitive semantic
+  dependencies before exposing or planning a member, so discovery and direct
+  execution reach the same decision.
+- **ENF-10:** A dataset with an access filter is discoverable only when the
+  principal has a valid, trusted, non-empty, type-compatible, in-bound value for
+  every referenced attribute. Otherwise the dataset and its members are absent
+  from discovery and direct execution is denied.
+- **ENF-11:** A valid access-filter attribute makes the governed object
+  discoverable even when the resulting authorized row set is empty. Discovery
+  does not probe data to decide authorization.
+
+## Compatibility and security-impact classification
+
+- **CMP-01:** Compatibility class and security impact are independent outputs.
+  Compatibility is `additive`, `behavioral`, `breaking`, or `indeterminate`;
+  security impact is `none`, `tightening`, `widening`, or `indeterminate`.
+- **CMP-02:** Classification compares authored contracts and the registered
+  attribute types, not current users, groups, assignments, data contents, or
+  observed query traffic. An apparently unused policy is not silently ignored.
+- **CMP-03:** Any canonical policy change requires a new SemanticModel contract
+  version. Additive and behavioral changes require at least a minor increment;
+  breaking changes require a major increment. Reordering or duplicate removal
+  that produces identical canonical bytes requires no increment.
+- **CMP-04:** `backward` is satisfied only when the compatibility result is not
+  breaking or indeterminate and deployment policy accepts every widening result.
+  A version number never approves widening by itself.
+- **CMP-05:** Tightening may be operationally desirable but is breaking when it
+  can deny a previously valid consumer. Widening is never treated as a harmless
+  compatibility improvement and requires explicit security approval.
+- **CMP-06:** An indeterminate compatibility or security result blocks
+  publication until the classifier or an explicit reviewed migration resolves
+  it; it cannot be downgraded to behavioral by default.
+
+| Authored change | Compatibility | Security impact |
+|---|---|---|
+| Add an unreferenced access grant | Additive | None |
+| Remove an unreferenced access grant | Behavioral | None |
+| Rename a grant and update its references | Breaking | Indeterminate |
+| Add an `allowedValues` member | Behavioral | Widening |
+| Remove an `allowedValues` member | Breaking | Tightening |
+| Change a grant's `userAttribute` | Breaking | Indeterminate |
+| Add a required grant to an existing object | Breaking | Tightening |
+| Remove a required grant from an existing object | Behavioral | Widening |
+| Add an access filter to an existing dataset | Breaking | Tightening |
+| Remove an access filter from an existing dataset | Behavioral | Widening |
+| Change an access filter's field or attribute | Breaking | Indeterminate |
+| Add a new protected dataset or member | Additive | None |
+| Add a new unprotected dataset or member | Additive | Widening |
+| Reorder canonically unordered policy values | No canonical change | None |
+| Delete or mutate a referenced registry attribute type | Rejected mutation | Indeterminate |
+
+## Caching, lifecycle, and audit
+
+- **LIF-01:** Authorization identity includes principal identity, actor identity
+  where delegated, semantic generation, normalized grant outcomes, normalized
+  filters, and attribute-set version or digest.
+- **LIF-02:** Query and result caches cannot be shared across different
+  authorization identities, even when generated analytical SQL would otherwise
+  be equal.
+- **LIF-03:** Attribute-value, registry, claim-mapping, policy, or semantic
+  generation changes invalidate all affected authorization and result caches.
+- **LIF-04:** Candidate planning classifies changes to access grants, required
+  grants, and access filters and records affected dashboards, queries, agents,
+  APIs, and published semantic members.
+- **LIF-05:** Removal or weakening of a policy is never treated as descriptive
+  metadata. Deployment policy may require explicit approval for access widening.
+- **LIF-06:** Durable audit records bind request principal, delegated actor,
+  semantic generation, dataset and member identities, normalized policy IDs,
+  attribute-set version, decision, and denial reason.
+- **LIF-07:** Audit payloads, logs, metrics, traces, and errors exclude raw
+  unrestricted attribute values unless a separate data-classification decision
+  explicitly permits a bounded projection.
+- **LIF-08:** Control-plane attribute changes and authored policy deployments
+  remain distinguishable audit events with a common correlation boundary.
+
+## Deliberate exclusions
+
+- **OUT-01:** The access-policy sub-contract has no authored SQL, Liquid, Go
+  templates, regular expressions, functions, scripts, or general expression
+  language. This does not restrict the SemanticModel's separately governed,
+  closed metric-expression language.
+- **OUT-02:** The initial contract has no principal, email, group, role,
+  RoleBinding, Grant, service-principal, or publication references.
+- **OUT-03:** The initial contract has no explicit deny rules, cross-model policy
+  inheritance, reusable top-level policy resources, policy precedence, or
+  consumer-specific overrides.
+- **OUT-04:** The initial contract has no column masking. Failed member access
+  makes the member undiscoverable and unqueryable.
+- **OUT-05:** The initial contract does not claim Looker document compatibility
+  or conformance; it claims only documented alignment with the three named
+  Looker concepts.
+
+## Qualification matrix
+
+| Scenario | Expected result |
+|---|---|
+| Missing access-grant attribute | Grant fails and object is denied |
+| Scalar grant attribute matches | Grant passes |
+| List grant attribute has one matching element | Grant passes |
+| Multiple required grants with one failure | Object is denied |
+| Missing access-filter attribute | Query is denied before execution |
+| Missing access-filter attribute during discovery | Dataset and its members are absent |
+| Scalar access-filter attribute | Parameterized equality predicate |
+| List access-filter attribute | Bounded parameterized membership predicate |
+| Access-filter assignment contains 1,025 values | Assignment is rejected; defensive runtime evaluation denies |
+| Multiple access filters | All predicates compose with AND |
+| Dataset filter reached through a relationship | Filter remains enforced |
+| Protected side participates in an outer join | Barrier filters its scan before the join |
+| Optimizer rewrite loses or moves a barrier after a join | Plan validation denies execution |
+| Denied member omitted from discovery | Member is also rejected by direct reference |
+| Same query through dashboard, API, agent, and embed | Same policy identity and result boundary |
+| Attribute-set version changes | Affected cache entries are not reused |
+| Referenced registry attribute is deleted or changes type | Control-plane mutation is rejected |
+| Referenced registry attribute is explicitly disabled | Dependent objects fail closed and affected caches are invalidated |
+| Break-glass request reaches a semantic consumer | No bypass exists under this profile |
+| Authored SQL, template, group, email, or mask | Structural rejection |
+| Policy removal widens access | Impact is classified and approval policy applies |
+| Required grant is added to an existing object | Breaking and tightening |
+| Allowed value is added to a referenced grant | Behavioral and widening |
+
+## Evidence ledger
+
+| Requirement range | Evidence | Status |
+|---|---|---|
+| CHG-01–CHG-04 | Profile-version, historical-policy, and normative-change checks | Pending |
+| STR-01–STR-12 | Generated TypeSpec, JSON Schema, DTO, extracted-YAML, and authoring-registry fixtures | Pending |
+| ATT-01–ATT-12 | Control-plane attribute registry, mutation, disablement, claim-mapping, and trust-boundary tests | Pending |
+| VAL-01–VAL-11 | Cross-path and independent typed-canonicalization golden fixtures | Pending |
+| GRT-01–GRT-10 | Access-grant compiler and evaluator fixtures | Pending |
+| FLT-01–FLT-10 | Semantic planner, parameterization, cardinality, and fail-closed tests | Pending |
+| PLN-01–PLN-09 | Security-barrier IR validation and join, aggregate, rollup, and rewrite golden plans | Pending |
+| ENF-01–ENF-11 | Catalog, dashboard, Explore, agent, export, API, and embed integration tests | Pending |
+| CMP-01–CMP-06 | Policy-diff, compatibility, security-impact, version, and approval fixtures | Pending |
+| LIF-01–LIF-08 | Cache partitioning, invalidation, planning, and durable-audit tests | Pending |
+| OUT-01–OUT-05 | Negative schema, architecture, and documentation checks | Pending |
+
+## Maintained verification
+
+Implementation must add focused commands for the generated schema, extraction
+and schema validation of every normative YAML example, semantic compiler,
+security-barrier planner, query authorization, cache identity, compatibility
+classifier, and control-plane attribute registry. The final combined change
+must also pass:
+
+```sh
+task generate
+task generated:check
+task ci
+```

--- a/adr/template.md
+++ b/adr/template.md
@@ -10,6 +10,8 @@ Deciders: responsible team or names
 
 Supersedes: ADR-NNNN or none
 
+Amends: ADR-NNNN with the amended boundary, or none
+
 Related: issue, pull request, specification, or none
 
 ## Context and problem statement


### PR DESCRIPTION
## Summary

- add ADR-0016 for standards-aligned native data contracts, authored/control-plane separation, stable resource identity, and pinned interchange adapters
- add ADR-0017 for the Looker-aligned SemanticModel access-grant and access-filter contract
- add conformance profiles for deterministic contract versioning and semantic access-policy behavior
- update the ADR index and template with explicit amendment precedence

## Validation

- `go test ./internal/platform/architecture -run ^TestArchitectureDecisionLogIsWellFormed$ -count=1`
- parsed every YAML fence in the new ADRs and conformance specifications
- `git diff origin/main...HEAD --check`
- `task ci` completed generation and the exercised frontend/API lanes, but the Go lane encountered two reproducible failures outside this documentation-only diff:
  - `deploy/host.TestBackupHookMigratesPR368InstallationThroughRealController`: existing deployment generation does not match the admitted payload
  - `internal/app/cli/composectl.TestV010ArtifactExecutionUsesIsolatedIdentityAndCleansUp`: the released v0.1 image cannot read the qualification fixture
