### PR TITLE
build(deps): upgrade APIGen YAML to rc.6

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2,7 +2,8 @@ openapi: 3.0.0
 info:
   title: LeapView Headless API
   version: 1.0.0
-  description: Headless API for LeapView projects, deployments, managed data, access control, refreshes, and agent operations.
+  description: Headless API for LeapView projects, deployments, managed data, access
+    control, refreshes, and agent operations.
 tags:
   - name: System
     description: API capabilities and protocol discovery.
@@ -19,7 +20,8 @@ tags:
   - name: BI
     description: Dashboard and semantic model read APIs.
   - name: Connections
-    description: Target-owned logical connection bindings, tests, refreshes, and redacted health.
+    description: Target-owned logical connection bindings, tests, refreshes, and redacted
+      health.
   - name: Deployments
     description: Atomic project release deployment.
   - name: Refresh Runs
@@ -58,7 +60,8 @@ paths:
               example:
                 status: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -321,7 +324,7 @@ paths:
             retention: security
             schema:
               ref: DeviceAuthorizationDecidedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: authoring.device.decided
         authz_mode: authenticated
@@ -329,19 +332,19 @@ paths:
           - code: DEVICE_AUTHORIZATION_DENIED
             kind: denied
             public_detail: Device authorization was denied.
-            status_code: !!float 400
+            status_code: 400
           - code: DEVICE_AUTHORIZATION_EXPIRED
             kind: expired
             public_detail: Device authorization has expired.
-            status_code: !!float 400
+            status_code: 400
           - code: INVALID_PRINCIPAL
             kind: invalid_principal
             public_detail: The authorizing principal is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: DEVICE_AUTHORIZATION_NOT_FOUND
             kind: not_found
             public_detail: Device authorization was not found.
-            status_code: !!float 404
+            status_code: 404
         idempotency: required
         owner: LeapViewAPI.Access
   /api/v1/agent/config:
@@ -359,7 +362,8 @@ paths:
               example:
                 systemPrompt: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -615,7 +619,8 @@ paths:
               example:
                 systemPrompt: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -877,7 +882,7 @@ paths:
             retention: security
             schema:
               ref: AgentCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: agent.config.updated
         authz_mode: authenticated
@@ -886,11 +891,11 @@ paths:
           - code: INVALID_AGENT_CONFIG
             kind: invalid
             public_detail: The agent configuration is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: AGENT_CONFIG_UNAVAILABLE
             kind: unavailable
             public_detail: Agent configuration is unavailable.
-            status_code: !!float 503
+            status_code: 503
         owner: LeapViewAPI.Agent
         ui:
           action_id: agent.config.update
@@ -905,8 +910,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -940,7 +945,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -1190,7 +1196,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -1212,7 +1219,8 @@ paths:
                 titlePending: true
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -1474,7 +1482,7 @@ paths:
             retention: security
             schema:
               ref: AgentCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: agent.conversation.created
         authz_mode: authenticated
@@ -1482,7 +1490,7 @@ paths:
           - code: AGENT_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Agent service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Agent
         ui:
@@ -1500,9 +1508,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -1754,7 +1764,7 @@ paths:
             retention: security
             schema:
               ref: AgentCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: agent.conversation.archived
         authz_mode: authenticated
@@ -1762,7 +1772,7 @@ paths:
           - code: AGENT_CONVERSATION_NOT_FOUND
             kind: not_found
             public_detail: Agent conversation not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Agent
         target:
           parameter: conversation
@@ -1796,7 +1806,8 @@ paths:
                 titlePending: true
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -2067,7 +2078,8 @@ paths:
                 titlePending: true
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -2327,7 +2339,7 @@ paths:
             retention: security
             schema:
               ref: AgentCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: agent.conversation.updated
         authz_mode: authenticated
@@ -2336,11 +2348,11 @@ paths:
           - code: INVALID_AGENT_CONVERSATION
             kind: invalid
             public_detail: The agent conversation request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: AGENT_CONVERSATION_NOT_FOUND
             kind: not_found
             public_detail: Agent conversation not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Agent
         target:
           parameter: conversation
@@ -2362,8 +2374,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -2398,7 +2410,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -2651,8 +2664,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -2686,7 +2699,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -2942,7 +2956,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -2964,7 +2979,8 @@ paths:
                 status: example
                 stopReason: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -3227,7 +3243,7 @@ paths:
             retention: security
             schema:
               ref: AgentCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: agent.run.created
         authz_mode: authenticated
@@ -3245,19 +3261,19 @@ paths:
           - code: AGENT_RUN_CONFLICT
             kind: conflict
             public_detail: The agent conversation already has an active run.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_AGENT_RUN
             kind: invalid
             public_detail: The agent run request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: AGENT_CONVERSATION_NOT_FOUND
             kind: not_found
             public_detail: Agent conversation not found.
-            status_code: !!float 404
+            status_code: 404
           - code: AGENT_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Agent service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Agent
         target:
@@ -3301,7 +3317,8 @@ paths:
                 status: example
                 stopReason: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -3541,7 +3558,9 @@ paths:
     post:
       operationId: cancelAgentRun
       summary: Cancel an agent run
-      description: Cancels an existing run and its queued work synchronously. The 202 response reports the resulting run state; this operation does not create a new asynchronous execution.
+      description: Cancels an existing run and its queued work synchronously. The
+        202 response reports the resulting run state; this operation does not create
+        a new asynchronous execution.
       parameters:
         - name: conversation
           in: path
@@ -3565,7 +3584,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -3587,7 +3607,8 @@ paths:
                 status: example
                 stopReason: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -3839,7 +3860,7 @@ paths:
             retention: security
             schema:
               ref: AgentCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: agent.run.cancelled
         authz_mode: authenticated
@@ -3847,15 +3868,15 @@ paths:
           - code: AGENT_RUN_NOT_CANCELLABLE
             kind: not_cancellable
             public_detail: The agent run cannot be cancelled in its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: AGENT_RUN_NOT_FOUND
             kind: not_found
             public_detail: Agent run not found.
-            status_code: !!float 404
+            status_code: 404
           - code: AGENT_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Agent service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Agent
         target:
@@ -3896,8 +3917,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -3929,7 +3950,7 @@ paths:
                     progress:
                       current: 1
                       message: example
-                      percent: !!float 1
+                      percent: 1
                       total: 1
                     resourceId: example
                     resourceType: example
@@ -3940,7 +3961,8 @@ paths:
                 type: string
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -4247,8 +4269,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -4285,7 +4307,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -4557,7 +4580,8 @@ paths:
                       version: example
                   schemaVersion: 1
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -4804,8 +4828,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -4836,7 +4860,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -5117,7 +5142,8 @@ paths:
                 semantic_model: example
                 title: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -5383,7 +5409,8 @@ paths:
                 icon: example
                 revision: 1
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -5640,7 +5667,7 @@ paths:
             retention: standard
             schema:
               ref: DashboardAppearanceUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: dashboard.appearance.updated
         authz_mode: privilege
@@ -5648,7 +5675,7 @@ paths:
           - code: INVALID_DASHBOARD_APPEARANCE
             kind: invalid
             public_detail: The selected dashboard appearance is invalid.
-            status_code: !!float 422
+            status_code: 422
         owner: LeapViewAPI.Dashboard
         target:
           parameter: dashboard
@@ -5693,7 +5720,8 @@ paths:
                 id: example
                 title: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -6023,7 +6051,8 @@ paths:
                   style: example
                   title: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -6295,8 +6324,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -6322,7 +6351,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -6573,18 +6603,18 @@ paths:
               spatialSelections:
                 - geometry:
                     bounds:
-                      east: !!float 1
-                      north: !!float 1
-                      south: !!float 1
-                      west: !!float 1
+                      east: 1
+                      north: 1
+                      south: 1
+                      west: 1
                     center:
-                      latitude: !!float 1
-                      longitude: !!float 1
+                      latitude: 1
+                      longitude: 1
                     kind: example
                     points:
-                      - latitude: !!float 1
-                        longitude: !!float 1
-                    radiusMeters: !!float 1
+                      - latitude: 1
+                        longitude: 1
+                    radiusMeters: 1
                   gesture: box
                   interactionID: example
                   order: 1
@@ -6670,7 +6700,8 @@ paths:
                       message: example
                     visualID: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -6921,18 +6952,18 @@ paths:
               spatialSelections:
                 - geometry:
                     bounds:
-                      east: !!float 1
-                      north: !!float 1
-                      south: !!float 1
-                      west: !!float 1
+                      east: 1
+                      north: 1
+                      south: 1
+                      west: 1
                     center:
-                      latitude: !!float 1
-                      longitude: !!float 1
+                      latitude: 1
+                      longitude: 1
                     kind: example
                     points:
-                      - latitude: !!float 1
-                        longitude: !!float 1
-                    radiusMeters: !!float 1
+                      - latitude: 1
+                        longitude: 1
+                    radiusMeters: 1
                   gesture: box
                   interactionID: example
                   order: 1
@@ -6977,7 +7008,7 @@ paths:
                 $ref: '#/components/schemas/DashboardVisualDescribeResponse'
               example:
                 componentId: example
-                height: !!float 1
+                height: 1
                 id: example
                 placement:
                   col: 1
@@ -6986,11 +7017,12 @@ paths:
                   rowSpan: 1
                 rendererID: example
                 specRevision: example
-                width: !!float 1
-                x: !!float 1
-                'y': !!float 1
+                width: 1
+                x: 1
+                'y': 1
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -7233,7 +7265,8 @@ paths:
   /api/v1/dashboards/{dashboard}/pages/{page}/visuals/{visual}/query:
     post:
       operationId: queryDashboardVisualData
-      summary: Query an existing dashboard visual with governed filters and compact analytical output
+      summary: Query an existing dashboard visual with governed filters and compact
+        analytical output
       parameters:
         - name: dashboard
           in: path
@@ -7315,7 +7348,8 @@ paths:
                 format: binary
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -7586,18 +7620,18 @@ paths:
               spatialSelections:
                 - geometry:
                     bounds:
-                      east: !!float 1
-                      north: !!float 1
-                      south: !!float 1
-                      west: !!float 1
+                      east: 1
+                      north: 1
+                      south: 1
+                      west: 1
                     center:
-                      latitude: !!float 1
-                      longitude: !!float 1
+                      latitude: 1
+                      longitude: 1
                     kind: example
                     points:
-                      - latitude: !!float 1
-                        longitude: !!float 1
-                    radiusMeters: !!float 1
+                      - latitude: 1
+                        longitude: 1
+                    radiusMeters: 1
                   gesture: box
                   interactionID: example
                   order: 1
@@ -7612,7 +7646,7 @@ paths:
               mode: model
               name: dashboard
               source: path
-            - default: !!float 50
+            - default: 50
               name: limit
               source: body
             - mode: omit
@@ -7648,8 +7682,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -7685,7 +7719,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -7936,7 +7971,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -7960,7 +7996,8 @@ paths:
                 provider: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -8221,7 +8258,7 @@ paths:
             retention: security
             schema:
               ref: GroupAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: group.created
         authz_mode: authenticated
@@ -8229,7 +8266,7 @@ paths:
           - code: GROUP_INVALID
             kind: invalid
             public_detail: The group request is invalid.
-            status_code: !!float 400
+            status_code: 400
         idempotency: required
         owner: LeapViewAPI.Access
         ui:
@@ -8248,9 +8285,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -8502,7 +8541,7 @@ paths:
             retention: security
             schema:
               ref: GroupAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: group.deleted
         authz_mode: authenticated
@@ -8510,11 +8549,11 @@ paths:
           - code: GROUP_NOT_MUTABLE
             kind: invalid
             public_detail: This group is managed by an external provisioning system.
-            status_code: !!float 422
+            status_code: 422
           - code: GROUP_NOT_FOUND
             kind: not_found
             public_detail: Group not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: group
@@ -8553,7 +8592,8 @@ paths:
                 provider: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -8827,7 +8867,8 @@ paths:
                 provider: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -9087,7 +9128,7 @@ paths:
             retention: security
             schema:
               ref: GroupAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: group.updated
         authz_mode: authenticated
@@ -9096,11 +9137,11 @@ paths:
           - code: GROUP_NOT_MUTABLE
             kind: invalid
             public_detail: This group is managed by an external provisioning system.
-            status_code: !!float 422
+            status_code: 422
           - code: GROUP_NOT_FOUND
             kind: not_found
             public_detail: Group not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: group
@@ -9125,8 +9166,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -9158,7 +9199,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -9414,9 +9456,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -9666,7 +9710,7 @@ paths:
             retention: security
             schema:
               ref: GroupMemberAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: group.member_removed
         authz_mode: authenticated
@@ -9674,11 +9718,11 @@ paths:
           - code: GROUP_NOT_MUTABLE
             kind: invalid
             public_detail: This group is managed by an external provisioning system.
-            status_code: !!float 422
+            status_code: 422
           - code: GROUP_MEMBER_NOT_FOUND
             kind: not_found
             public_detail: Group member not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: group
@@ -9712,7 +9756,8 @@ paths:
               example:
                 status: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -9962,7 +10007,7 @@ paths:
             retention: security
             schema:
               ref: GroupMemberAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: group.member_added
         authz_mode: authenticated
@@ -9970,11 +10015,11 @@ paths:
           - code: GROUP_NOT_MUTABLE
             kind: invalid
             public_detail: This group is managed by an external provisioning system.
-            status_code: !!float 422
+            status_code: 422
           - code: GROUP_MEMBER_NOT_FOUND
             kind: not_found
             public_detail: Group or principal not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: group
@@ -9999,7 +10044,8 @@ paths:
                 environment: example
                 id: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -10120,7 +10166,8 @@ paths:
                   available: true
                   enabled: true
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -10388,7 +10435,8 @@ paths:
                   available: true
                   enabled: true
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -10660,7 +10708,8 @@ paths:
                   width: 1
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -10908,7 +10957,7 @@ paths:
             retention: security
             schema:
               ref: ProductLogoDeletedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: product.logo.deleted
         authz_mode: authenticated
@@ -10917,7 +10966,7 @@ paths:
           - code: PRODUCT_IDENTITY_PRECONDITION_FAILED
             kind: precondition
             public_detail: The product identity changed before this request was applied.
-            status_code: !!float 412
+            status_code: 412
         owner: LeapViewAPI
         ui:
           action_id: product-settings.logo.delete
@@ -10962,7 +11011,8 @@ paths:
                   width: 1
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -11218,7 +11268,7 @@ paths:
             retention: security
             schema:
               ref: ProductLogoUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: product.logo.updated
         authz_mode: authenticated
@@ -11227,11 +11277,11 @@ paths:
           - code: INVALID_PRODUCT_LOGO
             kind: invalid
             public_detail: The product logo is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: PRODUCT_IDENTITY_PRECONDITION_FAILED
             kind: precondition
             public_detail: The product identity changed before this request was applied.
-            status_code: !!float 412
+            status_code: 412
         owner: LeapViewAPI
         ui:
           action_id: product-settings.logo.upload
@@ -11272,7 +11322,8 @@ paths:
                 format: binary
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -11538,7 +11589,8 @@ paths:
                   width: 1
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -11809,7 +11861,8 @@ paths:
                   width: 1
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -12065,7 +12118,7 @@ paths:
             retention: security
             schema:
               ref: ProductIdentityUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: product.identity.updated
         authz_mode: authenticated
@@ -12074,11 +12127,11 @@ paths:
           - code: INVALID_PRODUCT_IDENTITY
             kind: invalid
             public_detail: The product identity is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: PRODUCT_IDENTITY_PRECONDITION_FAILED
             kind: precondition
             public_detail: The product identity changed before this request was applied.
-            status_code: !!float 412
+            status_code: 412
         owner: LeapViewAPI
         ui:
           action_id: product-settings.identity.update
@@ -12126,7 +12179,8 @@ paths:
                   width: 1
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -12374,7 +12428,7 @@ paths:
             retention: security
             schema:
               ref: ProductIdentityUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: product.identity.reset
         authz_mode: authenticated
@@ -12383,7 +12437,7 @@ paths:
           - code: PRODUCT_IDENTITY_PRECONDITION_FAILED
             kind: precondition
             public_detail: The product identity changed before this request was applied.
-            status_code: !!float 412
+            status_code: 412
         idempotency: required
         owner: LeapViewAPI
         ui:
@@ -12426,7 +12480,8 @@ paths:
                   queryResultMaxRows: 1
                 storageBackend: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -12705,7 +12760,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -12988,7 +13044,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -13246,7 +13303,7 @@ paths:
             retention: security
             schema:
               ref: CurrentPrincipalUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.profile.updated
         authz_mode: authenticated
@@ -13255,7 +13312,7 @@ paths:
           - code: PRINCIPAL_PROFILE_NOT_MUTABLE
             kind: invalid
             public_detail: The current principal profile cannot be modified.
-            status_code: !!float 422
+            status_code: 422
         owner: LeapViewAPI.Access
         ui:
           action_id: current-user.profile.update
@@ -13271,8 +13328,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -13304,7 +13361,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -13555,7 +13613,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -13577,7 +13636,8 @@ paths:
                   revokedAt: "2026-01-02T15:04:05Z"
                 token: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -13838,7 +13898,7 @@ paths:
             retention: security
             schema:
               ref: APITokenAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: api_token.created
         authz_mode: authenticated
@@ -13846,7 +13906,7 @@ paths:
           - code: API_TOKEN_INVALID
             kind: invalid
             public_detail: The API token request is invalid.
-            status_code: !!float 400
+            status_code: 400
         idempotency: required
         owner: LeapViewAPI.Access
         ui:
@@ -13865,9 +13925,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -14117,7 +14179,7 @@ paths:
             retention: security
             schema:
               ref: APITokenAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: api_token.revoked
         authz_mode: authenticated
@@ -14125,7 +14187,7 @@ paths:
           - code: API_TOKEN_NOT_FOUND
             kind: not_found
             public_detail: API token not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: token
@@ -14144,8 +14206,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -14181,7 +14243,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -14438,7 +14501,8 @@ paths:
               example:
                 status: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -14694,7 +14758,7 @@ paths:
             retention: security
             schema:
               ref: AuthoringSessionRevokedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: authoring.session.revoked
         authz_mode: authenticated
@@ -14702,11 +14766,11 @@ paths:
           - code: INVALID_AUTHORING_CREDENTIAL
             kind: invalid_credential
             public_detail: The authoring session is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: AUTHORING_SESSION_NOT_FOUND
             kind: not_found
             public_detail: Authoring session not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: session
@@ -14720,9 +14784,11 @@ paths:
       parameters: []
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -14970,7 +15036,7 @@ paths:
             retention: security
             schema:
               ref: CurrentAvatarDeletedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.avatar.deleted
         authz_mode: authenticated
@@ -14978,7 +15044,7 @@ paths:
           - code: AVATAR_NOT_FOUND
             kind: not_found
             public_detail: The current principal has no avatar.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         ui:
           action_id: current-user.avatar.delete
@@ -15010,7 +15076,8 @@ paths:
                 url: example
                 width: 1
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -15268,7 +15335,7 @@ paths:
             retention: security
             schema:
               ref: CurrentAvatarUploadedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.avatar.updated
         authz_mode: authenticated
@@ -15276,11 +15343,11 @@ paths:
           - code: INVALID_AVATAR_IMAGE
             kind: invalid
             public_detail: The avatar image is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: UNSUPPORTED_AVATAR_MEDIA_TYPE
             kind: unsupported_media_type
             public_detail: The avatar media type is unsupported.
-            status_code: !!float 415
+            status_code: 415
         owner: LeapViewAPI.Access
         ui:
           action_id: current-user.avatar.upload
@@ -15301,7 +15368,8 @@ paths:
                 capabilities:
                   - PROJECT_ADMIN
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -15553,9 +15621,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -15814,7 +15884,7 @@ paths:
             retention: security
             schema:
               ref: CurrentPasswordChangedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: password.changed
         authz_mode: authenticated
@@ -15822,7 +15892,7 @@ paths:
           - code: PASSWORD_CHANGE_INVALID
             kind: invalid
             public_detail: The password change request is invalid.
-            status_code: !!float 400
+            status_code: 400
         idempotency: required
         owner: LeapViewAPI.Access
         ui:
@@ -15839,8 +15909,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -15875,7 +15945,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -16125,9 +16196,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -16375,7 +16448,7 @@ paths:
             retention: security
             schema:
               ref: CurrentSessionRevokedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: session.revoked
         authz_mode: authenticated
@@ -16383,7 +16456,7 @@ paths:
           - code: SESSION_NOT_FOUND
             kind: not_found
             public_detail: Session not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: session
@@ -16398,9 +16471,11 @@ paths:
       parameters: []
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -16656,7 +16731,7 @@ paths:
             retention: standard
             schema:
               ref: CurrentThemeUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.theme.updated
         authz_mode: authenticated
@@ -16664,7 +16739,7 @@ paths:
           - code: INVALID_THEME
             kind: invalid
             public_detail: The selected theme is invalid.
-            status_code: !!float 422
+            status_code: 422
         owner: LeapViewAPI.Access
         ui:
           action_id: current-user.theme.update
@@ -16694,8 +16769,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -16738,7 +16813,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -16989,7 +17065,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -17011,7 +17088,8 @@ paths:
                   updatedAt: "2026-01-02T15:04:05Z"
                 temporaryPassword: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -17268,7 +17346,7 @@ paths:
             retention: security
             schema:
               ref: PrincipalCreatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.local_user.created
         authz_mode: authenticated
@@ -17276,7 +17354,7 @@ paths:
           - code: PRINCIPAL_ALREADY_EXISTS
             kind: conflict
             public_detail: A principal with this email already exists.
-            status_code: !!float 409
+            status_code: 409
         idempotency: required
         owner: LeapViewAPI.Access
         ui:
@@ -17295,9 +17373,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -17549,7 +17629,7 @@ paths:
             retention: security
             schema:
               ref: PrincipalDeletedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.deleted
         authz_mode: authenticated
@@ -17557,15 +17637,15 @@ paths:
           - code: PRINCIPAL_OWNS_OBJECTS
             kind: conflict
             public_detail: Transfer owned objects before deleting this principal.
-            status_code: !!float 409
+            status_code: 409
           - code: PRINCIPAL_NOT_MUTABLE
             kind: invalid
             public_detail: This principal cannot be deleted by this operation.
-            status_code: !!float 422
+            status_code: 422
           - code: PRINCIPAL_NOT_FOUND
             kind: not_found
             public_detail: Principal not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: principal
@@ -17611,7 +17691,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -17892,7 +17973,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -18152,7 +18234,7 @@ paths:
             retention: security
             schema:
               ref: PrincipalUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.updated
         authz_mode: authenticated
@@ -18161,11 +18243,11 @@ paths:
           - code: PRINCIPAL_NOT_MUTABLE
             kind: invalid
             public_detail: This principal cannot be modified by this operation.
-            status_code: !!float 422
+            status_code: 422
           - code: PRINCIPAL_NOT_FOUND
             kind: not_found
             public_detail: Principal not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: principal
@@ -18214,7 +18296,8 @@ paths:
                 format: binary
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -18455,7 +18538,8 @@ paths:
     post:
       operationId: disablePrincipal
       summary: Block a principal in LeapView and reject its credentials
-      description: Sets an independent LeapView administrator block. External provisioning cannot clear this block.
+      description: Sets an independent LeapView administrator block. External provisioning
+        cannot clear this block.
       parameters:
         - name: principal
           in: path
@@ -18499,7 +18583,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -18751,7 +18836,7 @@ paths:
             retention: security
             schema:
               ref: PrincipalUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.blocked
         authz_mode: authenticated
@@ -18759,11 +18844,11 @@ paths:
           - code: PRINCIPAL_NOT_MUTABLE
             kind: invalid
             public_detail: This principal cannot be disabled by this operation.
-            status_code: !!float 422
+            status_code: 422
           - code: PRINCIPAL_NOT_FOUND
             kind: not_found
             public_detail: Principal not found.
-            status_code: !!float 404
+            status_code: 404
         idempotency: required
         owner: LeapViewAPI.Access
         target:
@@ -18776,7 +18861,8 @@ paths:
     post:
       operationId: enablePrincipal
       summary: Remove a principal's LeapView administrator block
-      description: Clears only the LeapView administrator block. An externally disabled principal remains disabled.
+      description: Clears only the LeapView administrator block. An externally disabled
+        principal remains disabled.
       parameters:
         - name: principal
           in: path
@@ -18820,7 +18906,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -19072,7 +19159,7 @@ paths:
             retention: security
             schema:
               ref: PrincipalUpdatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.unblocked
         authz_mode: authenticated
@@ -19080,11 +19167,11 @@ paths:
           - code: PRINCIPAL_NOT_MUTABLE
             kind: invalid
             public_detail: This principal cannot be enabled by this operation.
-            status_code: !!float 422
+            status_code: 422
           - code: PRINCIPAL_NOT_FOUND
             kind: not_found
             public_detail: Principal not found.
-            status_code: !!float 404
+            status_code: 404
         idempotency: required
         owner: LeapViewAPI.Access
         target:
@@ -19131,7 +19218,8 @@ paths:
                   updatedAt: "2026-01-02T15:04:05Z"
                 temporaryPassword: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -19379,7 +19467,7 @@ paths:
             retention: security
             schema:
               ref: PrincipalPasswordResetAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: principal.local_password.reset
         authz_mode: authenticated
@@ -19387,7 +19475,7 @@ paths:
           - code: PRINCIPAL_NOT_FOUND
             kind: not_found
             public_detail: Principal not found.
-            status_code: !!float 404
+            status_code: 404
         idempotency: required
         owner: LeapViewAPI.Access
         target:
@@ -19413,8 +19501,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -19449,7 +19537,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -19705,9 +19794,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -19955,7 +20046,7 @@ paths:
             retention: security
             schema:
               ref: PrincipalSessionRevokedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: session.revoked
         authz_mode: authenticated
@@ -19963,7 +20054,7 @@ paths:
           - code: SESSION_NOT_FOUND
             kind: not_found
             public_detail: Session not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: principal
@@ -20001,7 +20092,8 @@ paths:
                 title: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -20311,8 +20403,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -20349,7 +20441,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -20651,7 +20744,8 @@ paths:
                     visibility: example
                 projectCount: 1
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -20997,7 +21091,8 @@ paths:
                   number: 1
                   revisionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -21259,7 +21354,7 @@ paths:
             retention: security
             schema:
               ref: DashboardAuthoringCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: dashboard_authoring.command_executed
         authz_mode: authenticated
@@ -21338,7 +21433,8 @@ paths:
                 title: example
                 visibility: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -21811,7 +21907,8 @@ paths:
                   number: 1
                   revisionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -22125,7 +22222,7 @@ paths:
                             key: example
                           description: example
                           eyebrow: example
-                          height: !!float 1
+                          height: 1
                           id: example
                           kind: example
                           placement:
@@ -22138,9 +22235,9 @@ paths:
                           subtitle: example
                           title: example
                           visual: example
-                          width: !!float 1
-                          x: !!float 1
-                          'y': !!float 1
+                          width: 1
+                          x: 1
+                          'y': 1
                       width: 1
                   semanticModel: example
                   title: example
@@ -22178,7 +22275,7 @@ paths:
                     generation: 1
                     lastUpdated: example
                     loading: true
-                    progressPercent: !!float 1
+                    progressPercent: 1
                     refreshId: example
                     setupRequired: true
                   visuals:
@@ -22235,7 +22332,8 @@ paths:
                   runtimeModel: example
                   semanticModel: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -22694,7 +22792,8 @@ paths:
                   number: 1
                   revisionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -23114,7 +23213,8 @@ paths:
                   number: 1
                   revisionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -23378,7 +23478,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -23469,7 +23570,8 @@ paths:
                   number: 1
                   revisionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -23734,7 +23836,7 @@ paths:
             retention: security
             schema:
               ref: DashboardAuthoringCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: dashboard_authoring.draft_created
         authz_mode: authenticated
@@ -23768,7 +23870,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -23859,7 +23962,8 @@ paths:
                   number: 1
                   revisionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -24126,7 +24230,7 @@ paths:
             retention: security
             schema:
               ref: DashboardAuthoringCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: dashboard_authoring.draft_forked
         authz_mode: authenticated
@@ -24180,7 +24284,8 @@ paths:
                 format: binary
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -24456,7 +24561,8 @@ paths:
                     subjectId: example
                     subjectType: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -24749,7 +24855,8 @@ paths:
                 targetId: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -24992,7 +25099,8 @@ paths:
   /api/v1/projects/{project}/candidate-sessions/{candidateKey}/cancel:
     post:
       operationId: cancelProjectCandidateByKey
-      summary: Cancel the current principal's active candidate by stable authoring key
+      summary: Cancel the current principal's active candidate by stable authoring
+        key
       parameters:
         - name: project
           in: path
@@ -25043,7 +25151,8 @@ paths:
                 targetId: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -25305,7 +25414,7 @@ paths:
             retention: security
             schema:
               ref: CandidateAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: candidate.cancelled
         authz_mode: privilege
@@ -25313,19 +25422,19 @@ paths:
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_NOT_FOUND
             kind: candidate_not_found
             public_detail: Candidate not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -25372,7 +25481,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -25386,7 +25496,8 @@ paths:
                 digest: example
                 sizeBytes: 1
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -25646,7 +25757,7 @@ paths:
             retention: security
             schema:
               ref: CandidateSourceBlobAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: candidate.source_blob_uploaded
         authz_mode: privilege
@@ -25654,23 +25765,24 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Candidate source blob audit is temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: INVALID_CANDIDATE_SOURCE_BLOB
             kind: source_blob_invalid
-            public_detail: Candidate source blob headers do not match the canonical content identity.
-            status_code: !!float 422
+            public_detail: Candidate source blob headers do not match the canonical
+              content identity.
+            status_code: 422
         owner: LeapViewAPI.Deployment
         target:
           parameter: project
@@ -25684,7 +25796,8 @@ paths:
   /api/v1/projects/{project}/candidate-sync/commit:
     post:
       operationId: commitProjectCandidateSynchronization
-      summary: Atomically commit a complete source snapshot to the current author's private candidate
+      summary: Atomically commit a complete source snapshot to the current author's
+        private candidate
       parameters:
         - name: project
           in: path
@@ -25729,7 +25842,8 @@ paths:
                 targetId: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -26012,7 +26126,7 @@ paths:
             retention: security
             schema:
               ref: CandidateAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: candidate.ready
         authz_mode: privilege
@@ -26020,19 +26134,19 @@ paths:
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_NOT_FOUND
             kind: candidate_not_found
             public_detail: Candidate not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -26046,8 +26160,10 @@ paths:
   /api/v1/projects/{project}/candidate-sync/plan:
     post:
       operationId: planProjectCandidateSynchronization
-      summary: Plan content-addressed synchronization for the current author's private candidate
-      description: 'Query classification: reports missing immutable blobs without uploading or committing source state.'
+      summary: Plan content-addressed synchronization for the current author's private
+        candidate
+      description: 'Query classification: reports missing immutable blobs without
+        uploading or committing source state.'
       parameters:
         - name: project
           in: path
@@ -26078,7 +26194,8 @@ paths:
                 missingDigests:
                   - example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -26343,7 +26460,9 @@ paths:
     post:
       operationId: retainProjectCandidateSource
       summary: Retain an exact source snapshot without preparing a candidate
-      description: This source-only operation stores immutable bytes for a later target-owned delivery plan. It must not create a candidate, acquire physical credentials, or perform catalog work.
+      description: This source-only operation stores immutable bytes for a later target-owned
+        delivery plan. It must not create a candidate, acquire physical credentials,
+        or perform catalog work.
       parameters:
         - name: project
           in: path
@@ -26364,7 +26483,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -26382,7 +26502,8 @@ paths:
                 sourceDigest: example
                 targetId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -26657,7 +26778,7 @@ paths:
             retention: security
             schema:
               ref: CandidateSourceRetainedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: candidate.source_retained
         authz_mode: privilege
@@ -26665,15 +26786,15 @@ paths:
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -26708,7 +26829,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -26737,7 +26859,8 @@ paths:
                 targetId: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -27008,7 +27131,7 @@ paths:
             retention: security
             schema:
               ref: CandidateAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: candidate.started
         authz_mode: privilege
@@ -27016,23 +27139,23 @@ paths:
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_NOT_FOUND
             kind: candidate_not_found
             public_detail: Candidate not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CANDIDATE_QUOTA_EXCEEDED
             kind: candidate_quota
             public_detail: Candidate quota exceeded.
-            status_code: !!float 429
+            status_code: 429
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -27089,7 +27212,8 @@ paths:
                 targetId: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -27383,7 +27507,8 @@ paths:
                 targetId: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -27654,7 +27779,7 @@ paths:
             retention: security
             schema:
               ref: CandidateAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: candidate.artifact_replaced
         authz_mode: privilege
@@ -27662,19 +27787,19 @@ paths:
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_NOT_FOUND
             kind: candidate_not_found
             public_detail: Candidate not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -27739,7 +27864,8 @@ paths:
                 targetId: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -28001,7 +28127,7 @@ paths:
             retention: security
             schema:
               ref: CandidateAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: candidate.cancelled
         authz_mode: privilege
@@ -28009,19 +28135,19 @@ paths:
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_NOT_FOUND
             kind: candidate_not_found
             public_detail: Candidate not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -28062,7 +28188,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -28128,7 +28255,8 @@ paths:
                   digest: example
                   verifiedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -28391,7 +28519,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentQueuedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.queued
         authz_mode: privilege
@@ -28409,55 +28537,55 @@ paths:
           - code: APPROVAL_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded publication credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: AUTHORIZATION_UNAVAILABLE
             kind: authorization_unavailable
             public_detail: Publication activation authorization could not be evaluated.
-            status_code: !!float 503
+            status_code: 503
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_NOT_FOUND
             kind: candidate_not_found
             public_detail: Candidate not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_CONFLICT
             kind: conflict
             public_detail: The deployment conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DEPLOYMENT
             kind: invalid
             public_detail: The deployment request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: PUBLICATION_MANAGEMENT_REQUIRED
             kind: publication_forbidden
             public_detail: PROJECT_ADMIN is required to activate this publication.
-            status_code: !!float 403
+            status_code: 403
           - code: RELEASE_INCOMPLETE
             kind: release_incomplete
             public_detail: The release is missing its project-generation artifact.
-            status_code: !!float 409
+            status_code: 409
           - code: RELEASE_NOT_READY
             kind: release_not_ready
             public_detail: Only ready releases can be deployed.
-            status_code: !!float 409
+            status_code: 409
           - code: DEPLOYMENT_SERVICE_UNAVAILABLE
             kind: service_unavailable
             public_detail: Deployment service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -28522,7 +28650,8 @@ paths:
                 targetId: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -28784,7 +28913,7 @@ paths:
             retention: security
             schema:
               ref: CandidateAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: candidate.retried
         authz_mode: privilege
@@ -28792,19 +28921,19 @@ paths:
           - code: CANDIDATE_CONFLICT
             kind: candidate_conflict
             public_detail: The candidate conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CANDIDATE
             kind: candidate_invalid
             public_detail: The candidate request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: CANDIDATE_NOT_FOUND
             kind: candidate_not_found
             public_detail: Candidate not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CANDIDATE_SERVICE_UNAVAILABLE
             kind: candidate_unavailable
             public_detail: Candidate service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -28835,8 +28964,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -28865,7 +28994,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -29138,7 +29268,8 @@ paths:
                 projectId: example
                 title: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -29419,7 +29550,8 @@ paths:
                   status: available
                   uploadSessionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -29688,8 +29820,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -29719,7 +29851,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -30011,7 +30144,8 @@ paths:
                 status: available
                 uploadSessionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -30280,8 +30414,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -30338,7 +30472,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -30610,7 +30745,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -30655,7 +30791,8 @@ paths:
                 revisionId: example
                 status: open
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -30921,7 +31058,7 @@ paths:
             retention: security
             schema:
               ref: ManagedDataCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: managed_data.upload_session.created
         authz_mode: privilege
@@ -30929,43 +31066,43 @@ paths:
           - code: BACKEND_UNAVAILABLE
             kind: backend
             public_detail: Managed-data storage is unavailable.
-            status_code: !!float 502
+            status_code: 502
           - code: MANAGED_DATA_UPLOAD_CONFLICT
             kind: conflict
             public_detail: Managed-data upload conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_EXPIRED
             kind: expired
             public_detail: Managed-data upload has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INCOMPLETE
             kind: incomplete
             public_detail: Managed-data upload is incomplete.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INTEGRITY_FAILED
             kind: integrity
             public_detail: Managed-data upload failed integrity verification.
-            status_code: !!float 409
+            status_code: 409
           - code: MANAGED_DATA_UPLOAD_INTERNAL_ERROR
             kind: internal
             public_detail: Managed-data upload could not be completed.
-            status_code: !!float 500
+            status_code: 500
           - code: MANAGED_DATA_UPLOAD_INVALID
             kind: invalid
             public_detail: The managed-data upload request is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: MANAGED_DATA_UPLOAD_NOT_FOUND
             kind: not_found
             public_detail: Managed-data upload resource not found.
-            status_code: !!float 404
+            status_code: 404
           - code: MANAGED_DATA_UPLOAD_TOO_LARGE
             kind: too_large
             public_detail: Managed-data upload request is too large.
-            status_code: !!float 413
+            status_code: 413
           - code: MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Managed-data upload service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.ManagedData
         target:
@@ -31049,7 +31186,8 @@ paths:
                 revisionId: example
                 status: open
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -31370,7 +31508,8 @@ paths:
                 revisionId: example
                 status: open
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -31624,7 +31763,7 @@ paths:
             retention: security
             schema:
               ref: ManagedDataCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: managed_data.upload_session.cancelled
         authz_mode: privilege
@@ -31632,43 +31771,43 @@ paths:
           - code: BACKEND_UNAVAILABLE
             kind: backend
             public_detail: Managed-data storage is unavailable.
-            status_code: !!float 502
+            status_code: 502
           - code: MANAGED_DATA_UPLOAD_CONFLICT
             kind: conflict
             public_detail: Managed-data upload conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_EXPIRED
             kind: expired
             public_detail: Managed-data upload has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INCOMPLETE
             kind: incomplete
             public_detail: Managed-data upload is incomplete.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INTEGRITY_FAILED
             kind: integrity
             public_detail: Managed-data upload failed integrity verification.
-            status_code: !!float 409
+            status_code: 409
           - code: MANAGED_DATA_UPLOAD_INTERNAL_ERROR
             kind: internal
             public_detail: Managed-data upload could not be completed.
-            status_code: !!float 500
+            status_code: 500
           - code: MANAGED_DATA_UPLOAD_INVALID
             kind: invalid
             public_detail: The managed-data upload request is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: MANAGED_DATA_UPLOAD_NOT_FOUND
             kind: not_found
             public_detail: Managed-data upload resource not found.
-            status_code: !!float 404
+            status_code: 404
           - code: MANAGED_DATA_UPLOAD_TOO_LARGE
             kind: too_large
             public_detail: Managed-data upload request is too large.
-            status_code: !!float 413
+            status_code: 413
           - code: MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Managed-data upload service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.ManagedData
         target:
@@ -31728,8 +31867,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -31761,7 +31900,7 @@ paths:
                     progress:
                       current: 1
                       message: example
-                      percent: !!float 1
+                      percent: 1
                       total: 1
                     resourceId: example
                     resourceType: example
@@ -31772,7 +31911,8 @@ paths:
                 type: string
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -32053,7 +32193,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -32098,7 +32239,8 @@ paths:
                 revisionId: example
                 status: open
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -32352,7 +32494,7 @@ paths:
             retention: security
             schema:
               ref: ManagedDataCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: managed_data.upload_session.finalization_requested
         authz_mode: privilege
@@ -32370,43 +32512,43 @@ paths:
           - code: BACKEND_UNAVAILABLE
             kind: backend
             public_detail: Managed-data storage is unavailable.
-            status_code: !!float 502
+            status_code: 502
           - code: MANAGED_DATA_UPLOAD_CONFLICT
             kind: conflict
             public_detail: Managed-data upload conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_EXPIRED
             kind: expired
             public_detail: Managed-data upload has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INCOMPLETE
             kind: incomplete
             public_detail: Managed-data upload is incomplete.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INTEGRITY_FAILED
             kind: integrity
             public_detail: Managed-data upload failed integrity verification.
-            status_code: !!float 409
+            status_code: 409
           - code: MANAGED_DATA_UPLOAD_INTERNAL_ERROR
             kind: internal
             public_detail: Managed-data upload could not be completed.
-            status_code: !!float 500
+            status_code: 500
           - code: MANAGED_DATA_UPLOAD_INVALID
             kind: invalid
             public_detail: The managed-data upload request is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: MANAGED_DATA_UPLOAD_NOT_FOUND
             kind: not_found
             public_detail: Managed-data upload resource not found.
-            status_code: !!float 404
+            status_code: 404
           - code: MANAGED_DATA_UPLOAD_TOO_LARGE
             kind: too_large
             public_detail: Managed-data upload request is too large.
-            status_code: !!float 413
+            status_code: 413
           - code: MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Managed-data upload service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.ManagedData
         target:
@@ -32458,7 +32600,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -32480,7 +32623,8 @@ paths:
                 status: open
                 uploadSessionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -32742,7 +32886,7 @@ paths:
             retention: security
             schema:
               ref: ManagedDataS3MultipartAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: managed_data.s3_multipart_upload.created
         authz_mode: privilege
@@ -32750,39 +32894,39 @@ paths:
           - code: BACKEND_UNAVAILABLE
             kind: backend
             public_detail: Managed-data storage is unavailable.
-            status_code: !!float 502
+            status_code: 502
           - code: MANAGED_DATA_UPLOAD_CONFLICT
             kind: conflict
             public_detail: Managed-data upload conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_EXPIRED
             kind: expired
             public_detail: Managed-data upload has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INCOMPLETE
             kind: incomplete
             public_detail: Managed-data upload is incomplete.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INTEGRITY_FAILED
             kind: integrity
             public_detail: Managed-data upload failed integrity verification.
-            status_code: !!float 409
+            status_code: 409
           - code: MANAGED_DATA_UPLOAD_INTERNAL_ERROR
             kind: internal
             public_detail: Managed-data upload could not be completed.
-            status_code: !!float 500
+            status_code: 500
           - code: MANAGED_DATA_UPLOAD_INVALID
             kind: invalid
             public_detail: The managed-data upload request is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: MANAGED_DATA_UPLOAD_NOT_FOUND
             kind: not_found
             public_detail: Managed-data upload resource not found.
-            status_code: !!float 404
+            status_code: 404
           - code: MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Managed-data upload service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.ManagedData
         target:
@@ -32859,7 +33003,8 @@ paths:
                 status: open
                 uploadSessionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -33113,7 +33258,7 @@ paths:
             retention: security
             schema:
               ref: ManagedDataS3MultipartAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: managed_data.s3_multipart_upload.abort_requested
         authz_mode: privilege
@@ -33121,39 +33266,39 @@ paths:
           - code: BACKEND_UNAVAILABLE
             kind: backend
             public_detail: Managed-data storage is unavailable.
-            status_code: !!float 502
+            status_code: 502
           - code: MANAGED_DATA_UPLOAD_CONFLICT
             kind: conflict
             public_detail: Managed-data upload conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_EXPIRED
             kind: expired
             public_detail: Managed-data upload has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INCOMPLETE
             kind: incomplete
             public_detail: Managed-data upload is incomplete.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INTEGRITY_FAILED
             kind: integrity
             public_detail: Managed-data upload failed integrity verification.
-            status_code: !!float 409
+            status_code: 409
           - code: MANAGED_DATA_UPLOAD_INTERNAL_ERROR
             kind: internal
             public_detail: Managed-data upload could not be completed.
-            status_code: !!float 500
+            status_code: 500
           - code: MANAGED_DATA_UPLOAD_INVALID
             kind: invalid
             public_detail: The managed-data upload request is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: MANAGED_DATA_UPLOAD_NOT_FOUND
             kind: not_found
             public_detail: Managed-data upload resource not found.
-            status_code: !!float 404
+            status_code: 404
           - code: MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Managed-data upload service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.ManagedData
         target:
@@ -33230,7 +33375,8 @@ paths:
                 status: open
                 uploadSessionId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -33495,7 +33641,7 @@ paths:
             retention: security
             schema:
               ref: ManagedDataS3MultipartAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: managed_data.s3_multipart_upload.completion_requested
         authz_mode: privilege
@@ -33503,43 +33649,43 @@ paths:
           - code: BACKEND_UNAVAILABLE
             kind: backend
             public_detail: Managed-data storage is unavailable.
-            status_code: !!float 502
+            status_code: 502
           - code: MANAGED_DATA_UPLOAD_CONFLICT
             kind: conflict
             public_detail: Managed-data upload conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_EXPIRED
             kind: expired
             public_detail: Managed-data upload has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INCOMPLETE
             kind: incomplete
             public_detail: Managed-data upload is incomplete.
-            status_code: !!float 409
+            status_code: 409
           - code: UPLOAD_INTEGRITY_FAILED
             kind: integrity
             public_detail: Managed-data upload failed integrity verification.
-            status_code: !!float 409
+            status_code: 409
           - code: MANAGED_DATA_UPLOAD_INTERNAL_ERROR
             kind: internal
             public_detail: Managed-data upload could not be completed.
-            status_code: !!float 500
+            status_code: 500
           - code: MANAGED_DATA_UPLOAD_INVALID
             kind: invalid
             public_detail: The managed-data upload request is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: MANAGED_DATA_UPLOAD_NOT_FOUND
             kind: not_found
             public_detail: Managed-data upload resource not found.
-            status_code: !!float 404
+            status_code: 404
           - code: MANAGED_DATA_UPLOAD_TOO_LARGE
             kind: too_large
             public_detail: Managed-data upload request is too large.
-            status_code: !!float 413
+            status_code: 413
           - code: MANAGED_DATA_UPLOAD_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Managed-data upload service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.ManagedData
         target:
@@ -33554,7 +33700,8 @@ paths:
   : post:
       operationId: signManagedDataS3MultipartPart
       summary: Sign one S3 multipart upload part
-      description: 'Query: issues a short-lived signed part-upload request and does not change durable multipart state.'
+      description: 'Query: issues a short-lived signed part-upload request and does
+        not change durable multipart state.'
       parameters:
         - name: project
           in: path
@@ -33596,8 +33743,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 10000
+            minimum: 1
+            maximum: 10000
           example: 1
         - name: Idempotency-Key
           in: header
@@ -33622,7 +33769,8 @@ paths:
                 partNumber: 1
                 url: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -33914,7 +34062,8 @@ paths:
                     suspendedBy: example
                     updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -34198,7 +34347,8 @@ paths:
                 suspendedBy: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -34490,7 +34640,8 @@ paths:
                 suspendedBy: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -34742,7 +34893,7 @@ paths:
             retention: security
             schema:
               ref: DashboardPublicationCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: dashboard_publication.resumed
         authz_mode: authenticated
@@ -34750,19 +34901,19 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Dashboard publication audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: AUTHORIZATION_UNAVAILABLE
             kind: authorization_unavailable
             public_detail: Dashboard authorization could not be evaluated.
-            status_code: !!float 503
+            status_code: 503
           - code: PUBLICATION_NOT_CONFIGURED
             kind: conflict
             public_detail: Dashboard publication is not present in the active configuration.
-            status_code: !!float 409
+            status_code: 409
           - code: PUBLICATION_NOT_FOUND
             kind: not_found
             public_detail: Dashboard publication not found.
-            status_code: !!float 404
+            status_code: 404
         idempotency: required
         owner: LeapViewAPI.Dashboard
         target:
@@ -34826,7 +34977,8 @@ paths:
                 suspendedBy: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -35078,7 +35230,7 @@ paths:
             retention: security
             schema:
               ref: DashboardPublicationCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: dashboard_publication.public_id_rotated
         authz_mode: authenticated
@@ -35086,19 +35238,19 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Dashboard publication audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: AUTHORIZATION_UNAVAILABLE
             kind: authorization_unavailable
             public_detail: Dashboard authorization could not be evaluated.
-            status_code: !!float 503
+            status_code: 503
           - code: PUBLICATION_NOT_CONFIGURED
             kind: conflict
             public_detail: Dashboard publication is not present in the active configuration.
-            status_code: !!float 409
+            status_code: 409
           - code: PUBLICATION_NOT_FOUND
             kind: not_found
             public_detail: Dashboard publication not found.
-            status_code: !!float 404
+            status_code: 404
         idempotency: required
         owner: LeapViewAPI.Dashboard
         target:
@@ -35162,7 +35314,8 @@ paths:
                 suspendedBy: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -35414,7 +35567,7 @@ paths:
             retention: security
             schema:
               ref: DashboardPublicationCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: dashboard_publication.suspended
         authz_mode: authenticated
@@ -35422,19 +35575,19 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Dashboard publication audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: AUTHORIZATION_UNAVAILABLE
             kind: authorization_unavailable
             public_detail: Dashboard authorization could not be evaluated.
-            status_code: !!float 503
+            status_code: 503
           - code: PUBLICATION_NOT_CONFIGURED
             kind: conflict
             public_detail: Dashboard publication is not present in the active configuration.
-            status_code: !!float 409
+            status_code: 409
           - code: PUBLICATION_NOT_FOUND
             kind: not_found
             public_detail: Dashboard publication not found.
-            status_code: !!float 404
+            status_code: 404
         idempotency: required
         owner: LeapViewAPI.Dashboard
         target:
@@ -35486,8 +35639,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -35521,7 +35674,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -35784,7 +35938,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -35806,7 +35961,8 @@ paths:
                 subjectType: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -36070,7 +36226,7 @@ paths:
             retention: security
             schema:
               ref: DataPolicyAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: data_policy.created
         authz_mode: privilege
@@ -36078,7 +36234,7 @@ paths:
           - code: DATA_POLICY_INVALID
             kind: invalid
             public_detail: The data policy request is invalid.
-            status_code: !!float 400
+            status_code: 400
         idempotency: required
         owner: LeapViewAPI.Access
         target:
@@ -36111,9 +36267,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -36363,7 +36521,7 @@ paths:
             retention: security
             schema:
               ref: DataPolicyAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: data_policy.deleted
         authz_mode: privilege
@@ -36371,7 +36529,7 @@ paths:
           - code: DATA_POLICY_NOT_FOUND
             kind: not_found
             public_detail: Data policy not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: project
@@ -36419,7 +36577,8 @@ paths:
                 subjectType: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -36703,7 +36862,8 @@ paths:
                 subjectType: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -36967,7 +37127,7 @@ paths:
             retention: security
             schema:
               ref: DataPolicyAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: data_policy.updated
         authz_mode: privilege
@@ -36976,11 +37136,11 @@ paths:
           - code: DATA_POLICY_INVALID
             kind: invalid
             public_detail: The data policy is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DATA_POLICY_NOT_FOUND
             kind: not_found
             public_detail: Data policy not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: project
@@ -37014,7 +37174,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -37078,7 +37239,8 @@ paths:
                 status: planned
                 targetId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -37341,47 +37503,48 @@ paths:
             retention: security
             schema:
               ref: DeliveryCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: delivery.plan.created
         authz_mode: privilege
         failures:
           - code: DELIVERY_IDEMPOTENCY_DRIFT
             kind: delivery_idempotency_drift
-            public_detail: The idempotency key was reused with different delivery inputs.
-            status_code: !!float 409
+            public_detail: The idempotency key was reused with different delivery
+              inputs.
+            status_code: 409
           - code: DELIVERY_INPUT_UNAVAILABLE
             kind: delivery_input_unavailable
             public_detail: Target-owned delivery inputs are temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DELIVERY_CONFLICT
             kind: delivery_mutation_conflict
             public_detail: The delivery operation conflicts with current target state.
-            status_code: !!float 409
+            status_code: 409
           - code: DELIVERY_FORBIDDEN
             kind: delivery_mutation_forbidden
             public_detail: The caller is not authorized for this delivery operation.
-            status_code: !!float 403
+            status_code: 403
           - code: INVALID_DELIVERY_MUTATION
             kind: delivery_mutation_invalid
             public_detail: The delivery mutation request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DELIVERY_STALE
             kind: delivery_mutation_stale
             public_detail: The delivery plan or target fence is stale.
-            status_code: !!float 409
+            status_code: 409
           - code: DELIVERY_PLAN_EXPIRED
             kind: delivery_plan_expired
             public_detail: The immutable delivery plan has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DELIVERY_READ
             kind: delivery_read_invalid
             public_detail: The delivery status request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DELIVERY_READ_UNAVAILABLE
             kind: delivery_read_unavailable
             public_detail: Delivery status is temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -37439,7 +37602,8 @@ paths:
                 updatedAt: "2026-01-02T15:04:05Z"
                 writerLeaseId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -37744,7 +37908,8 @@ paths:
                 status: preparing
                 targetId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -38015,7 +38180,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -38043,7 +38209,8 @@ paths:
                 status: pending
                 targetId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -38295,51 +38462,52 @@ paths:
             retention: security
             schema:
               ref: DeliveryCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: delivery.publication.requested
         authz_mode: privilege
         failures:
           - code: DELIVERY_IDEMPOTENCY_DRIFT
             kind: delivery_idempotency_drift
-            public_detail: The idempotency key was reused with different delivery inputs.
-            status_code: !!float 409
+            public_detail: The idempotency key was reused with different delivery
+              inputs.
+            status_code: 409
           - code: DELIVERY_INPUT_UNAVAILABLE
             kind: delivery_input_unavailable
             public_detail: Target-owned delivery inputs are temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DELIVERY_CONFLICT
             kind: delivery_mutation_conflict
             public_detail: The delivery operation conflicts with current target state.
-            status_code: !!float 409
+            status_code: 409
           - code: DELIVERY_FORBIDDEN
             kind: delivery_mutation_forbidden
             public_detail: The caller is not authorized for this delivery operation.
-            status_code: !!float 403
+            status_code: 403
           - code: INVALID_DELIVERY_MUTATION
             kind: delivery_mutation_invalid
             public_detail: The delivery mutation request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DELIVERY_STALE
             kind: delivery_mutation_stale
             public_detail: The delivery plan or target fence is stale.
-            status_code: !!float 409
+            status_code: 409
           - code: DELIVERY_PLAN_EXPIRED
             kind: delivery_plan_expired
             public_detail: The immutable delivery plan has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DELIVERY_READ
             kind: delivery_read_invalid
             public_detail: The delivery status request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DELIVERY_OBJECT_NOT_FOUND
             kind: delivery_read_not_found
             public_detail: The requested delivery object was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DELIVERY_READ_UNAVAILABLE
             kind: delivery_read_unavailable
             public_detail: Delivery status is temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -38398,7 +38566,8 @@ paths:
                 status: prepared
                 targetId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -38669,7 +38838,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -38697,7 +38867,8 @@ paths:
                 status: pending
                 targetId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -38949,51 +39120,52 @@ paths:
             retention: security
             schema:
               ref: DeliveryCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: delivery.rollback.requested
         authz_mode: privilege
         failures:
           - code: DELIVERY_IDEMPOTENCY_DRIFT
             kind: delivery_idempotency_drift
-            public_detail: The idempotency key was reused with different delivery inputs.
-            status_code: !!float 409
+            public_detail: The idempotency key was reused with different delivery
+              inputs.
+            status_code: 409
           - code: DELIVERY_INPUT_UNAVAILABLE
             kind: delivery_input_unavailable
             public_detail: Target-owned delivery inputs are temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DELIVERY_CONFLICT
             kind: delivery_mutation_conflict
             public_detail: The delivery operation conflicts with current target state.
-            status_code: !!float 409
+            status_code: 409
           - code: DELIVERY_FORBIDDEN
             kind: delivery_mutation_forbidden
             public_detail: The caller is not authorized for this delivery operation.
-            status_code: !!float 403
+            status_code: 403
           - code: INVALID_DELIVERY_MUTATION
             kind: delivery_mutation_invalid
             public_detail: The delivery mutation request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DELIVERY_STALE
             kind: delivery_mutation_stale
             public_detail: The delivery plan or target fence is stale.
-            status_code: !!float 409
+            status_code: 409
           - code: DELIVERY_PLAN_EXPIRED
             kind: delivery_plan_expired
             public_detail: The immutable delivery plan has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DELIVERY_READ
             kind: delivery_read_invalid
             public_detail: The delivery status request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DELIVERY_OBJECT_NOT_FOUND
             kind: delivery_read_not_found
             public_detail: The requested delivery object was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DELIVERY_READ_UNAVAILABLE
             kind: delivery_read_unavailable
             public_detail: Delivery status is temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -39097,7 +39269,8 @@ paths:
                     releasedAt: "2026-01-02T15:04:05Z"
                     status: active
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -39419,7 +39592,8 @@ paths:
                 status: planned
                 targetId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -39715,7 +39889,8 @@ paths:
                 updatedAt: "2026-01-02T15:04:05Z"
                 writerLeaseId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -39967,51 +40142,52 @@ paths:
             retention: security
             schema:
               ref: DeliveryCommandAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: delivery.build.sealed
         authz_mode: privilege
         failures:
           - code: DELIVERY_IDEMPOTENCY_DRIFT
             kind: delivery_idempotency_drift
-            public_detail: The idempotency key was reused with different delivery inputs.
-            status_code: !!float 409
+            public_detail: The idempotency key was reused with different delivery
+              inputs.
+            status_code: 409
           - code: DELIVERY_INPUT_UNAVAILABLE
             kind: delivery_input_unavailable
             public_detail: Target-owned delivery inputs are temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DELIVERY_CONFLICT
             kind: delivery_mutation_conflict
             public_detail: The delivery operation conflicts with current target state.
-            status_code: !!float 409
+            status_code: 409
           - code: DELIVERY_FORBIDDEN
             kind: delivery_mutation_forbidden
             public_detail: The caller is not authorized for this delivery operation.
-            status_code: !!float 403
+            status_code: 403
           - code: INVALID_DELIVERY_MUTATION
             kind: delivery_mutation_invalid
             public_detail: The delivery mutation request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DELIVERY_STALE
             kind: delivery_mutation_stale
             public_detail: The delivery plan or target fence is stale.
-            status_code: !!float 409
+            status_code: 409
           - code: DELIVERY_PLAN_EXPIRED
             kind: delivery_plan_expired
             public_detail: The immutable delivery plan has expired.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DELIVERY_READ
             kind: delivery_read_invalid
             public_detail: The delivery status request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DELIVERY_OBJECT_NOT_FOUND
             kind: delivery_read_not_found
             public_detail: The requested delivery object was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DELIVERY_READ_UNAVAILABLE
             kind: delivery_read_unavailable
             public_detail: Delivery status is temporarily unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -40067,7 +40243,8 @@ paths:
                 status: pending
                 targetId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -40338,7 +40515,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -40367,7 +40545,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -40615,7 +40794,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentApprovalRequestedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: delivery.publication.approval_requested
         authz_mode: privilege
@@ -40623,23 +40802,23 @@ paths:
           - code: DEPLOYMENT_APPROVAL_CONFLICT
             kind: approval_conflict
             public_detail: The deployment approval conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: SEPARATION_OF_DUTY_REQUIRED
             kind: separation_of_duty
             public_detail: A separate principal must approve this deployment.
-            status_code: !!float 409
+            status_code: 409
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -40702,7 +40881,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -41002,7 +41182,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -41260,7 +41441,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentApprovalDecisionAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: delivery.publication.approved
         authz_mode: privilege
@@ -41268,23 +41449,23 @@ paths:
           - code: DEPLOYMENT_APPROVAL_CONFLICT
             kind: approval_conflict
             public_detail: The deployment approval conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: SEPARATION_OF_DUTY_REQUIRED
             kind: separation_of_duty
             public_detail: A separate principal must approve this deployment.
-            status_code: !!float 409
+            status_code: 409
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -41355,7 +41536,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -41613,7 +41795,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentApprovalDecisionAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: delivery.publication.denied
         authz_mode: privilege
@@ -41621,23 +41803,23 @@ paths:
           - code: DEPLOYMENT_APPROVAL_CONFLICT
             kind: approval_conflict
             public_detail: The deployment approval conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: SEPARATION_OF_DUTY_REQUIRED
             kind: separation_of_duty
             public_detail: A separate principal must approve this deployment.
-            status_code: !!float 409
+            status_code: 409
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -41708,7 +41890,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -41966,7 +42149,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentApprovalDecisionAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: delivery.publication.approval_revoked
         authz_mode: privilege
@@ -41974,19 +42157,19 @@ paths:
           - code: DEPLOYMENT_APPROVAL_CONFLICT
             kind: approval_conflict
             public_detail: The deployment approval conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -42046,7 +42229,8 @@ paths:
                 status: preparing
                 verifiedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -42307,8 +42491,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -42386,7 +42570,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -42649,7 +42834,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -42715,7 +42901,8 @@ paths:
                   digest: example
                   verifiedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -42975,7 +43162,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentQueuedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.queued
         authz_mode: privilege
@@ -42993,55 +43180,55 @@ paths:
           - code: DEPLOYMENT_APPROVAL_CONFLICT
             kind: approval_conflict
             public_detail: The deployment approval conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: APPROVAL_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded publication credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: INVALID_DEPLOYMENT_APPROVAL
             kind: approval_invalid
             public_detail: The deployment approval request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: AUTHORIZATION_UNAVAILABLE
             kind: authorization_unavailable
             public_detail: Publication activation authorization could not be evaluated.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_CONFLICT
             kind: conflict
             public_detail: The deployment conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DEPLOYMENT
             kind: invalid
             public_detail: The deployment request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: PUBLICATION_MANAGEMENT_REQUIRED
             kind: publication_forbidden
             public_detail: PROJECT_ADMIN is required to activate this publication.
-            status_code: !!float 403
+            status_code: 403
           - code: RELEASE_INCOMPLETE
             kind: release_incomplete
             public_detail: The release is missing its project-generation artifact.
-            status_code: !!float 409
+            status_code: 409
           - code: RELEASE_NOT_READY
             kind: release_not_ready
             public_detail: Only ready releases can be deployed.
-            status_code: !!float 409
+            status_code: 409
           - code: DEPLOYMENT_SERVICE_UNAVAILABLE
             kind: service_unavailable
             public_detail: Deployment service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -43135,7 +43322,8 @@ paths:
                   digest: example
                   verifiedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -43405,7 +43593,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -43471,7 +43660,8 @@ paths:
                   digest: example
                   verifiedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -43723,7 +43913,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentQueuedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.activation_requested
         authz_mode: privilege
@@ -43741,51 +43931,51 @@ paths:
           - code: ACTIVATION_FORBIDDEN
             kind: activation_forbidden
             public_detail: Deployment activation is forbidden.
-            status_code: !!float 403
+            status_code: 403
           - code: DEPLOYMENT_APPROVAL_REQUIRED
             kind: approval_conflict
             public_detail: An approved deployment is required for activation.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: ACTIVATION_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded activation credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: APPROVAL_FORBIDDEN
             kind: approval_forbidden
             public_detail: Deployment approval is forbidden.
-            status_code: !!float 403
+            status_code: 403
           - code: INVALID_DEPLOYMENT_APPROVAL
             kind: approval_invalid
             public_detail: The deployment approval is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: AUTHORIZATION_UNAVAILABLE
             kind: authorization_unavailable
             public_detail: Deployment activation authorization could not be evaluated.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_CONFLICT
             kind: conflict
             public_detail: The deployment conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: ASYNC_QUEUE_UNAVAILABLE
             kind: queue_unavailable
             public_detail: Deployment activation could not be persisted.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -43826,7 +44016,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -43855,7 +44046,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -44103,7 +44295,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentApprovalRequestedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.approval_requested
         authz_mode: privilege
@@ -44111,35 +44303,35 @@ paths:
           - code: DEPLOYMENT_APPROVAL_REQUIRED
             kind: approval_conflict
             public_detail: The deployment approval is not valid for this action.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: APPROVAL_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded publication credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_CONFLICT
             kind: conflict
             public_detail: The deployment conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DEPLOYMENT
             kind: invalid
             public_detail: The deployment request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -44210,7 +44402,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -44468,7 +44661,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentApprovalDecisionAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.approved
         authz_mode: privilege
@@ -44476,35 +44669,35 @@ paths:
           - code: DEPLOYMENT_APPROVAL_REQUIRED
             kind: approval_conflict
             public_detail: The deployment approval is not valid for this action.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: APPROVAL_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded approval credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: INVALID_DEPLOYMENT_APPROVAL
             kind: approval_invalid
             public_detail: The deployment approval request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: SEPARATION_OF_DUTY_REQUIRED
             kind: separation_of_duty
             public_detail: A separate principal must approve this deployment.
-            status_code: !!float 409
+            status_code: 409
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -44575,7 +44768,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -44833,7 +45027,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentApprovalDecisionAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.denied
         authz_mode: privilege
@@ -44841,35 +45035,35 @@ paths:
           - code: DEPLOYMENT_APPROVAL_REQUIRED
             kind: approval_conflict
             public_detail: The deployment approval is not valid for this action.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: APPROVAL_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded approval credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: INVALID_DEPLOYMENT_APPROVAL
             kind: approval_invalid
             public_detail: The deployment approval request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: SEPARATION_OF_DUTY_REQUIRED
             kind: separation_of_duty
             public_detail: A separate principal must approve this deployment.
-            status_code: !!float 409
+            status_code: 409
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -44940,7 +45134,8 @@ paths:
                 revokedBy: example
                 status: pending
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -45198,7 +45393,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentApprovalDecisionAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.approval_revoked
         authz_mode: privilege
@@ -45206,35 +45401,35 @@ paths:
           - code: DEPLOYMENT_APPROVAL_REQUIRED
             kind: approval_conflict
             public_detail: The deployment approval is not valid for this action.
-            status_code: !!float 409
+            status_code: 409
           - code: APPROVAL_CREDENTIAL_EXPIRED
             kind: approval_credential_expired
             public_detail: The deployment approval credential has expired.
-            status_code: !!float 401
+            status_code: 401
           - code: APPROVAL_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded approval credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: INVALID_DEPLOYMENT_APPROVAL
             kind: approval_invalid
             public_detail: The deployment approval request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_APPROVAL_NOT_FOUND
             kind: approval_not_found
             public_detail: Deployment approval not found.
-            status_code: !!float 404
+            status_code: 404
           - code: DEPLOYMENT_APPROVAL_UNAVAILABLE
             kind: approval_unavailable
             public_detail: Deployment approvals are unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: SEPARATION_OF_DUTY_REQUIRED
             kind: separation_of_duty
             public_detail: A separate principal must approve this deployment.
-            status_code: !!float 409
+            status_code: 409
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -45275,7 +45470,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -45341,7 +45537,8 @@ paths:
                   digest: example
                   verifiedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -45589,7 +45786,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentCancelledAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.cancelled
         authz_mode: privilege
@@ -45597,23 +45794,23 @@ paths:
           - code: DEPLOYMENT_CONFLICT
             kind: conflict
             public_detail: The deployment conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DEPLOYMENT
             kind: invalid
             public_detail: The deployment request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: ASYNC_QUEUE_UNAVAILABLE
             kind: queue_unavailable
             public_detail: Deployment cancellation could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_SERVICE_UNAVAILABLE
             kind: service_unavailable
             public_detail: Deployment service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -45662,8 +45859,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -45695,7 +45892,7 @@ paths:
                     progress:
                       current: 1
                       message: example
-                      percent: !!float 1
+                      percent: 1
                       total: 1
                     resourceId: example
                     resourceType: example
@@ -45706,7 +45903,8 @@ paths:
                 type: string
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -45949,7 +46147,8 @@ paths:
   /api/v1/projects/{project}/deployments/{deployment}/retry:
     post:
       operationId: retryDeployment
-      summary: Retry a terminal publication request without changing its immutable release
+      summary: Retry a terminal publication request without changing its immutable
+        release
       parameters:
         - name: project
           in: path
@@ -45976,7 +46175,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -46042,7 +46242,8 @@ paths:
                   digest: example
                   verifiedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -46294,7 +46495,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentQueuedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.queued
         authz_mode: privilege
@@ -46312,39 +46513,39 @@ paths:
           - code: APPROVAL_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded publication credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: AUTHORIZATION_UNAVAILABLE
             kind: authorization_unavailable
             public_detail: Publication activation authorization could not be evaluated.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_CONFLICT
             kind: conflict
             public_detail: The deployment conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DEPLOYMENT
             kind: invalid
             public_detail: The deployment request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: PUBLICATION_MANAGEMENT_REQUIRED
             kind: publication_forbidden
             public_detail: PROJECT_ADMIN is required to activate this publication.
-            status_code: !!float 403
+            status_code: 403
           - code: RELEASE_INCOMPLETE
             kind: release_incomplete
             public_detail: The release is missing its project-generation artifact.
-            status_code: !!float 409
+            status_code: 409
           - code: RELEASE_NOT_READY
             kind: release_not_ready
             public_detail: Only ready releases can be deployed.
-            status_code: !!float 409
+            status_code: 409
           - code: DEPLOYMENT_SERVICE_UNAVAILABLE
             kind: service_unavailable
             public_detail: Deployment service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -46385,7 +46586,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -46451,7 +46653,8 @@ paths:
                   digest: example
                   verifiedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -46703,7 +46906,7 @@ paths:
             retention: security
             schema:
               ref: DeploymentQueuedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: deployment.queued
         authz_mode: privilege
@@ -46721,39 +46924,39 @@ paths:
           - code: APPROVAL_CREDENTIAL_REQUIRED
             kind: approval_credential_required
             public_detail: A bounded publication credential is required.
-            status_code: !!float 401
+            status_code: 401
           - code: AUTHORIZATION_UNAVAILABLE
             kind: authorization_unavailable
             public_detail: Publication activation authorization could not be evaluated.
-            status_code: !!float 503
+            status_code: 503
           - code: DEPLOYMENT_CONFLICT
             kind: conflict
             public_detail: The deployment conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_DEPLOYMENT
             kind: invalid
             public_detail: The deployment request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: DEPLOYMENT_NOT_FOUND
             kind: not_found
             public_detail: Deployment not found.
-            status_code: !!float 404
+            status_code: 404
           - code: PUBLICATION_MANAGEMENT_REQUIRED
             kind: publication_forbidden
             public_detail: PROJECT_ADMIN is required to activate this publication.
-            status_code: !!float 403
+            status_code: 403
           - code: RELEASE_INCOMPLETE
             kind: release_incomplete
             public_detail: The release is missing its project-generation artifact.
-            status_code: !!float 409
+            status_code: 409
           - code: RELEASE_NOT_READY
             kind: release_not_ready
             public_detail: Only ready releases can be deployed.
-            status_code: !!float 409
+            status_code: 409
           - code: DEPLOYMENT_SERVICE_UNAVAILABLE
             kind: service_unavailable
             public_detail: Deployment service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Deployment
         target:
@@ -46821,7 +47024,8 @@ paths:
                 resourceId: example
                 resourceKind: project
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -47105,8 +47309,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -47141,7 +47345,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -47404,7 +47609,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -47427,7 +47633,8 @@ paths:
                 subjectId: example
                 subjectType: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -47701,7 +47908,7 @@ paths:
             retention: security
             schema:
               ref: GrantAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: grant.created
         authz_mode: privilege
@@ -47709,7 +47916,7 @@ paths:
           - code: GRANT_INVALID
             kind: invalid
             public_detail: The grant request is invalid.
-            status_code: !!float 400
+            status_code: 400
         idempotency: required
         owner: LeapViewAPI.Access
         target:
@@ -47744,9 +47951,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -48008,7 +48217,7 @@ paths:
             retention: security
             schema:
               ref: GrantAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: grant.deleted
         authz_mode: privilege
@@ -48016,7 +48225,7 @@ paths:
           - code: GRANT_NOT_FOUND
             kind: not_found
             public_detail: Grant not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: project
@@ -48067,7 +48276,8 @@ paths:
                 subjectId: example
                 subjectType: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -48352,7 +48562,8 @@ paths:
                 subjectId: example
                 subjectType: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -48624,7 +48835,7 @@ paths:
             retention: security
             schema:
               ref: GrantAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: grant.updated
         authz_mode: privilege
@@ -48633,11 +48844,11 @@ paths:
           - code: GRANT_INVALID
             kind: invalid
             public_detail: The grant is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: GRANT_NOT_FOUND
             kind: not_found
             public_detail: Grant not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: project
@@ -48755,8 +48966,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -48801,7 +49012,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -49061,8 +49273,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -49107,7 +49319,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -49366,7 +49579,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -49399,7 +49613,8 @@ paths:
                 startedAt: "2026-01-02T15:04:05Z"
                 status: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -49667,7 +49882,7 @@ paths:
             retention: security
             schema:
               ref: RefreshQueuedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: refresh.queued
         authz_mode: authenticated
@@ -49685,19 +49900,19 @@ paths:
           - code: REFRESH_RUN_CONFLICT
             kind: conflict
             public_detail: The refresh run conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_REFRESH_RUN
             kind: invalid
             public_detail: The refresh run request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: REFRESH_PIPELINE_NOT_FOUND
             kind: not_found
             public_detail: Refresh pipeline not found.
-            status_code: !!float 404
+            status_code: 404
           - code: REFRESH_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Refresh service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Refresh
         target:
@@ -49755,7 +49970,8 @@ paths:
                 startedAt: "2026-01-02T15:04:05Z"
                 status: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -50021,7 +50237,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -50054,7 +50271,8 @@ paths:
                 startedAt: "2026-01-02T15:04:05Z"
                 status: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -50310,7 +50528,7 @@ paths:
             retention: security
             schema:
               ref: RefreshCancelledAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: refresh.cancelled
         authz_mode: authenticated
@@ -50318,15 +50536,15 @@ paths:
           - code: REFRESH_RUN_NOT_CANCELLABLE
             kind: not_cancellable
             public_detail: Only queued refresh runs can be cancelled.
-            status_code: !!float 409
+            status_code: 409
           - code: REFRESH_RUN_NOT_FOUND
             kind: not_found
             public_detail: Refresh run not found.
-            status_code: !!float 404
+            status_code: 404
           - code: REFRESH_SERVICE_UNAVAILABLE
             kind: unavailable
             public_detail: Refresh service is unavailable.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Refresh
         target:
@@ -50372,8 +50590,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -50405,7 +50623,7 @@ paths:
                     progress:
                       current: 1
                       message: example
-                      percent: !!float 1
+                      percent: 1
                       total: 1
                     resourceId: example
                     resourceType: example
@@ -50416,7 +50634,8 @@ paths:
                 type: string
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -50672,8 +50891,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -50761,7 +50980,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -51024,7 +51244,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -51100,7 +51321,8 @@ paths:
                   version: 1
                 status: draft
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -51419,7 +51641,7 @@ paths:
             retention: security
             schema:
               ref: ReleaseCreatedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: release.created
         authz_mode: privilege
@@ -51427,11 +51649,11 @@ paths:
           - code: RELEASE_CONFLICT
             kind: conflict
             public_detail: The release conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_RELEASE
             kind: invalid
             public_detail: The release request is invalid.
-            status_code: !!float 422
+            status_code: 422
         idempotency: required
         owner: LeapViewAPI.Release
         target:
@@ -51535,7 +51757,8 @@ paths:
                   version: 1
                 status: draft
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -51811,7 +52034,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -51828,7 +52052,8 @@ paths:
                 releaseId: example
                 sizeBytes: 1
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -52090,7 +52315,7 @@ paths:
             retention: security
             schema:
               ref: ReleaseArtifactUploadedAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: release.artifact_uploaded
         authz_mode: privilege
@@ -52098,23 +52323,24 @@ paths:
           - code: RELEASE_CONFLICT
             kind: conflict
             public_detail: The release conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: CONTENT_DIGEST_MISMATCH
             kind: digest_mismatch
-            public_detail: The release artifact digest does not match the expected content.
-            status_code: !!float 422
+            public_detail: The release artifact digest does not match the expected
+              content.
+            status_code: 422
           - code: RELEASE_IMMUTABLE
             kind: immutable
             public_detail: The release is immutable.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_RELEASE
             kind: invalid
             public_detail: The release artifact request is invalid.
-            status_code: !!float 422
+            status_code: 422
           - code: RELEASE_NOT_FOUND
             kind: not_found
             public_detail: Release artifact not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Release
         target:
           parameter: project
@@ -52163,8 +52389,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -52196,7 +52422,7 @@ paths:
                     progress:
                       current: 1
                       message: example
-                      percent: !!float 1
+                      percent: 1
                       total: 1
                     resourceId: example
                     resourceType: example
@@ -52207,7 +52433,8 @@ paths:
                 type: string
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -52477,7 +52704,8 @@ paths:
           example: example
       responses:
         '202':
-          description: The request has been accepted for processing, but processing has not yet completed.
+          description: The request has been accepted for processing, but processing
+            has not yet completed.
           headers:
             location:
               required: true
@@ -52553,7 +52781,8 @@ paths:
                   version: 1
                 status: draft
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -52805,7 +53034,7 @@ paths:
             retention: security
             schema:
               ref: ReleaseValidatingAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: release.validating
         authz_mode: privilege
@@ -52823,23 +53052,23 @@ paths:
           - code: RELEASE_CONFLICT
             kind: conflict
             public_detail: The release conflicts with its current state.
-            status_code: !!float 409
+            status_code: 409
           - code: RELEASE_IMMUTABLE
             kind: immutable
             public_detail: The release is immutable.
-            status_code: !!float 409
+            status_code: 409
           - code: RELEASE_INCOMPLETE
             kind: incomplete
             public_detail: The release artifacts are incomplete.
-            status_code: !!float 409
+            status_code: 409
           - code: RELEASE_NOT_FOUND
             kind: not_found
             public_detail: Release not found.
-            status_code: !!float 404
+            status_code: 404
           - code: ASYNC_QUEUE_UNAVAILABLE
             kind: queue_unavailable
             public_detail: Release finalization could not be queued.
-            status_code: !!float 503
+            status_code: 503
         idempotency: required
         owner: LeapViewAPI.Release
         target:
@@ -52870,8 +53099,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -52898,7 +53127,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -53193,7 +53423,8 @@ paths:
                     updatedAt: "2026-01-02T15:04:05Z"
                     validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -53465,7 +53696,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -53499,7 +53731,8 @@ paths:
                 updatedAt: "2026-01-02T15:04:05Z"
                 validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -53778,7 +54011,7 @@ paths:
             retention: security
             schema:
               ref: TargetConnectionAdministrationAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: connection.binding.created
         authz_mode: privilege
@@ -53786,31 +54019,31 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Connection binding audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: CONNECTION_BINDING_CONFLICT
             kind: conflict
             public_detail: Connection binding changed concurrently or is incompatible.
-            status_code: !!float 409
+            status_code: 409
           - code: CONNECTION_TEST_FAILED
             kind: credential_invalid
             public_detail: Connection validation failed.
-            status_code: !!float 422
+            status_code: 422
           - code: INVALID_CONNECTION_BINDING
             kind: invalid
             public_detail: Connection binding is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: CONNECTION_BINDING_NOT_FOUND
             kind: not_found
             public_detail: Connection binding was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CONNECTION_PROVIDER_UNAVAILABLE
             kind: provider_unavailable
             public_detail: Connection provider is unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: FORBIDDEN
             kind: unauthorized
             public_detail: Connection operation is forbidden.
-            status_code: !!float 403
+            status_code: 403
         idempotency: required
         owner: LeapViewAPI.Analytics
         target:
@@ -53886,7 +54119,8 @@ paths:
                 updatedAt: "2026-01-02T15:04:05Z"
                 validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -54188,7 +54422,8 @@ paths:
                 updatedAt: "2026-01-02T15:04:05Z"
                 validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -54466,7 +54701,7 @@ paths:
             retention: security
             schema:
               ref: TargetConnectionAdministrationAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: connection.binding.updated
         authz_mode: privilege
@@ -54474,35 +54709,35 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Connection binding audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: CONFIRMATION_REQUIRED
             kind: confirmation_required
             public_detail: Dependency confirmation is required.
-            status_code: !!float 412
+            status_code: 412
           - code: CONNECTION_BINDING_CONFLICT
             kind: conflict
             public_detail: Connection binding changed concurrently or is incompatible.
-            status_code: !!float 409
+            status_code: 409
           - code: CONNECTION_BINDING_DISABLED
             kind: disabled
             public_detail: Connection binding is disabled.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CONNECTION_BINDING
             kind: invalid
             public_detail: Connection binding is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: CONNECTION_BINDING_NOT_FOUND
             kind: not_found
             public_detail: Connection binding was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CONNECTION_PROVIDER_UNAVAILABLE
             kind: provider_unavailable
             public_detail: Connection provider is unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: FORBIDDEN
             kind: unauthorized
             public_detail: Connection operation is forbidden.
-            status_code: !!float 403
+            status_code: 403
         owner: LeapViewAPI.Analytics
         target:
           parameter: connection
@@ -54585,7 +54820,8 @@ paths:
                 updatedAt: "2026-01-02T15:04:05Z"
                 validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -54837,7 +55073,7 @@ paths:
             retention: security
             schema:
               ref: TargetConnectionAdministrationAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: connection.binding.disabled
         authz_mode: privilege
@@ -54845,31 +55081,31 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Connection binding audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: CONNECTION_BINDING_CONFLICT
             kind: conflict
             public_detail: Connection binding changed concurrently or is incompatible.
-            status_code: !!float 409
+            status_code: 409
           - code: CONNECTION_BINDING_DISABLED
             kind: disabled
             public_detail: Connection binding is disabled.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CONNECTION_BINDING
             kind: invalid
             public_detail: Connection binding is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: CONNECTION_BINDING_NOT_FOUND
             kind: not_found
             public_detail: Connection binding was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CONNECTION_PROVIDER_UNAVAILABLE
             kind: provider_unavailable
             public_detail: Connection provider is unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: FORBIDDEN
             kind: unauthorized
             public_detail: Connection operation is forbidden.
-            status_code: !!float 403
+            status_code: 403
         idempotency: required
         owner: LeapViewAPI.Analytics
         target:
@@ -54953,7 +55189,8 @@ paths:
                 updatedAt: "2026-01-02T15:04:05Z"
                 validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -55205,7 +55442,7 @@ paths:
             retention: security
             schema:
               ref: TargetConnectionAdministrationAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: connection.binding.enabled
         authz_mode: privilege
@@ -55213,27 +55450,27 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Connection binding audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: CONNECTION_BINDING_CONFLICT
             kind: conflict
             public_detail: Connection binding changed concurrently or is incompatible.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CONNECTION_BINDING
             kind: invalid
             public_detail: Connection binding is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: CONNECTION_BINDING_NOT_FOUND
             kind: not_found
             public_detail: Connection binding was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CONNECTION_PROVIDER_UNAVAILABLE
             kind: provider_unavailable
             public_detail: Connection provider is unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: FORBIDDEN
             kind: unauthorized
             public_detail: Connection operation is forbidden.
-            status_code: !!float 403
+            status_code: 403
         idempotency: required
         owner: LeapViewAPI.Analytics
         target:
@@ -55300,7 +55537,8 @@ paths:
                 targetId: example
                 validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -55544,7 +55782,8 @@ paths:
     post:
       operationId: planTargetConnectionBindingChange
       summary: Plan a dependency-aware target connection change
-      description: 'Query classification: computes dependencies and a confirmation token without mutating durable binding or runtime state.'
+      description: 'Query classification: computes dependencies and a confirmation
+        token without mutating durable binding or runtime state.'
       parameters:
         - name: project
           in: path
@@ -55590,7 +55829,8 @@ paths:
                 expectedRevision: 1
                 requiresConfirmation: true
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -55916,7 +56156,8 @@ paths:
                 targetId: example
                 validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -56172,7 +56413,7 @@ paths:
             retention: security
             schema:
               ref: TargetConnectionRotationAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: credential.refresh.requested
         authz_mode: privilege
@@ -56180,35 +56421,35 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Connection binding audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: CONNECTION_BINDING_CONFLICT
             kind: conflict
             public_detail: Connection binding changed concurrently or is incompatible.
-            status_code: !!float 409
+            status_code: 409
           - code: CONNECTION_TEST_FAILED
             kind: credential_invalid
             public_detail: Connection validation failed.
-            status_code: !!float 422
+            status_code: 422
           - code: CONNECTION_BINDING_DISABLED
             kind: disabled
             public_detail: Connection binding is disabled.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CONNECTION_BINDING
             kind: invalid
             public_detail: Connection binding is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: CONNECTION_BINDING_NOT_FOUND
             kind: not_found
             public_detail: Connection binding was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CONNECTION_PROVIDER_UNAVAILABLE
             kind: provider_unavailable
             public_detail: Connection provider is unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: FORBIDDEN
             kind: unauthorized
             public_detail: Connection operation is forbidden.
-            status_code: !!float 403
+            status_code: 403
         idempotency: required
         owner: LeapViewAPI.Analytics
         target:
@@ -56225,7 +56466,8 @@ paths:
     post:
       operationId: testTargetConnectionBinding
       summary: Test a target connection through the candidate runtime path
-      description: 'Command classification: testing can persist validated health/version state and promote the replacement runtime pool.'
+      description: 'Command classification: testing can persist validated health/version
+        state and promote the replacement runtime pool.'
       parameters:
         - name: project
           in: path
@@ -56284,7 +56526,8 @@ paths:
                 targetId: example
                 validatedVersion: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -56540,7 +56783,7 @@ paths:
             retention: security
             schema:
               ref: TargetConnectionRotationAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: credential.test.requested
         authz_mode: privilege
@@ -56548,35 +56791,35 @@ paths:
           - code: AUDIT_UNAVAILABLE
             kind: audit_unavailable
             public_detail: Connection binding audit could not be persisted.
-            status_code: !!float 503
+            status_code: 503
           - code: CONNECTION_BINDING_CONFLICT
             kind: conflict
             public_detail: Connection binding changed concurrently or is incompatible.
-            status_code: !!float 409
+            status_code: 409
           - code: CONNECTION_TEST_FAILED
             kind: credential_invalid
             public_detail: Connection validation failed.
-            status_code: !!float 422
+            status_code: 422
           - code: CONNECTION_BINDING_DISABLED
             kind: disabled
             public_detail: Connection binding is disabled.
-            status_code: !!float 409
+            status_code: 409
           - code: INVALID_CONNECTION_BINDING
             kind: invalid
             public_detail: Connection binding is invalid.
-            status_code: !!float 400
+            status_code: 400
           - code: CONNECTION_BINDING_NOT_FOUND
             kind: not_found
             public_detail: Connection binding was not found.
-            status_code: !!float 404
+            status_code: 404
           - code: CONNECTION_PROVIDER_UNAVAILABLE
             kind: provider_unavailable
             public_detail: Connection provider is unavailable.
-            status_code: !!float 503
+            status_code: 503
           - code: FORBIDDEN
             kind: unauthorized
             public_detail: Connection operation is forbidden.
-            status_code: !!float 403
+            status_code: 403
         idempotency: required
         owner: LeapViewAPI.Analytics
         target:
@@ -56626,8 +56869,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: cursor
@@ -56662,7 +56905,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -56909,8 +57153,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -56937,7 +57181,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -57217,7 +57462,8 @@ paths:
                 id: example
                 title: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -57477,8 +57723,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -57507,7 +57753,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -57787,7 +58034,8 @@ paths:
                 metricCount: 1
                 model: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -58053,8 +58301,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -58092,7 +58340,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -58398,7 +58647,8 @@ paths:
                 format: binary
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -58732,7 +58982,8 @@ paths:
                 warnings:
                   - example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -59018,8 +59269,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -59057,7 +59308,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -59300,7 +59552,8 @@ paths:
   /api/v1/semantic-models/{model}/query:
     post:
       operationId: querySemanticModel
-      summary: Query governed semantic data with typed columns, filters, pagination, and provenance
+      summary: Query governed semantic data with typed columns, filters, pagination,
+        and provenance
       parameters:
         - name: model
           in: path
@@ -59357,7 +59610,8 @@ paths:
                 format: binary
               example: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -59650,7 +59904,7 @@ paths:
               mode: model
               name: model
               source: path
-            - default: !!float 25
+            - default: 25
               name: limit
               source: body
         name: query_semantic_model
@@ -59738,7 +59992,8 @@ paths:
                 warnings:
                   - example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -60028,8 +60283,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -60062,7 +60317,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -60322,8 +60578,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -60353,7 +60609,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -60604,8 +60861,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -60637,7 +60894,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -60888,7 +61146,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -60908,7 +61167,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -61165,7 +61425,7 @@ paths:
             retention: security
             schema:
               ref: ServicePrincipalAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: service_principal.created
         authz_mode: authenticated
@@ -61173,7 +61433,7 @@ paths:
           - code: SERVICE_PRINCIPAL_INVALID
             kind: invalid
             public_detail: The service principal request is invalid.
-            status_code: !!float 400
+            status_code: 400
         idempotency: required
         owner: LeapViewAPI.Access
         ui:
@@ -61192,9 +61452,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -61442,7 +61704,7 @@ paths:
             retention: security
             schema:
               ref: ServicePrincipalAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: service_principal.deleted
         authz_mode: authenticated
@@ -61450,7 +61712,7 @@ paths:
           - code: SERVICE_PRINCIPAL_NOT_FOUND
             kind: not_found
             public_detail: Service principal not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: servicePrincipal
@@ -61485,7 +61747,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -61755,7 +62018,8 @@ paths:
                 kind: example
                 updatedAt: "2026-01-02T15:04:05Z"
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -62009,7 +62273,7 @@ paths:
             retention: security
             schema:
               ref: ServicePrincipalAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: service_principal.updated
         authz_mode: authenticated
@@ -62018,11 +62282,11 @@ paths:
           - code: SERVICE_PRINCIPAL_OWNS_OBJECTS
             kind: conflict
             public_detail: Transfer owned objects before deleting this service principal.
-            status_code: !!float 409
+            status_code: 409
           - code: SERVICE_PRINCIPAL_NOT_FOUND
             kind: not_found
             public_detail: Service principal not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: servicePrincipal
@@ -62045,8 +62309,8 @@ paths:
           schema:
             type: integer
             format: int32
-            minimum: !!float 1
-            maximum: !!float 200
+            minimum: 1
+            maximum: 200
           example: 1
           explode: false
         - name: pageToken
@@ -62077,7 +62341,8 @@ paths:
                 page:
                   nextCursor: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -62334,7 +62599,8 @@ paths:
           example: example
       responses:
         '201':
-          description: The request has succeeded and a new resource has been created as a result.
+          description: The request has succeeded and a new resource has been created
+            as a result.
           headers:
             location:
               required: true
@@ -62355,7 +62621,8 @@ paths:
                   servicePrincipalId: example
                 secret: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -62612,7 +62879,7 @@ paths:
             retention: security
             schema:
               ref: ServicePrincipalSecretAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: service_principal_secret.created
         authz_mode: authenticated
@@ -62620,7 +62887,7 @@ paths:
           - code: SERVICE_PRINCIPAL_SECRET_INVALID
             kind: invalid
             public_detail: The service principal secret request is invalid.
-            status_code: !!float 400
+            status_code: 400
         idempotency: required
         owner: LeapViewAPI.Access
         target:
@@ -62648,9 +62915,11 @@ paths:
           example: example
       responses:
         '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -62898,7 +63167,7 @@ paths:
             retention: security
             schema:
               ref: ServicePrincipalSecretAuditPayload
-            schema_version: !!float 1
+            schema_version: 1
           required: true
           success_action: service_principal_secret.revoked
         authz_mode: authenticated
@@ -62906,7 +63175,7 @@ paths:
           - code: SERVICE_PRINCIPAL_SECRET_NOT_FOUND
             kind: not_found
             public_detail: Service principal secret not found.
-            status_code: !!float 404
+            status_code: 404
         owner: LeapViewAPI.Access
         target:
           parameter: servicePrincipal
@@ -62946,7 +63215,8 @@ paths:
                 secret: example
                 servicePrincipalId: example
         '400':
-          description: The server could not understand the request due to invalid syntax.
+          description: The server could not understand the request due to invalid
+            syntax.
           content:
             application/problem+json:
               schema:
@@ -63218,7 +63488,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Capability'
-          description: Omit to keep the token dynamically constrained by the principal's effective capabilities at request time. An explicit list must be a subset of the principal's current effective capabilities.
+          description: Omit to keep the token dynamically constrained by the principal's
+            effective capabilities at request time. An explicit list must be a subset
+            of the principal's current effective capabilities.
           example:
             - PROJECT_ADMIN
         expiresAt:
@@ -63302,7 +63574,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Capability'
-          description: Present when the token has an explicit capability allowlist. When omitted, the principal's effective capabilities are evaluated dynamically at request time.
+          description: Present when the token has an explicit capability allowlist.
+            When omitted, the principal's effective capabilities are evaluated dynamically
+            at request time.
           example:
             - PROJECT_ADMIN
         expiresAt:
@@ -63751,7 +64025,7 @@ components:
               progress:
                 current: 1
                 message: example
-                percent: !!float 1
+                percent: 1
                 total: 1
               resourceId: example
               resourceType: example
@@ -63770,7 +64044,7 @@ components:
             progress:
               current: 1
               message: example
-              percent: !!float 1
+              percent: 1
               total: 1
             resourceId: example
             resourceType: example
@@ -63823,7 +64097,7 @@ components:
         progress:
           current: 1
           message: example
-          percent: !!float 1
+          percent: 1
           total: 1
         resourceId: example
         resourceType: example
@@ -63841,14 +64115,14 @@ components:
         percent:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         message:
           type: string
           example: example
       example:
         current: 1
         message: example
-        percent: !!float 1
+        percent: 1
         total: 1
     AsyncStructuredError:
       type: object
@@ -64732,7 +65006,9 @@ components:
           example: example
         sourceOnly:
           type: boolean
-          description: Retain the exact source snapshot without preparing a candidate or writing physical state. Delivery planning sets this true; Build owns the first writer operation.
+          description: Retain the exact source snapshot without preparing a candidate
+            or writing physical state. Delivery planning sets this true; Build owns
+            the first writer operation.
           example: true
         candidateKey:
           type: string
@@ -64892,7 +65168,7 @@ components:
         symbolSize:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         labelPosition:
           $ref: '#/components/schemas/DashboardLabelPosition'
         displayUnits:
@@ -64927,7 +65203,7 @@ components:
         smooth: true
         stacking: none
         step: true
-        symbolSize: !!float 1
+        symbolSize: 1
         type: example
     CartesianVisualizationPresentation:
       type: object
@@ -64966,7 +65242,7 @@ components:
         symbolSize:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         histogramBins:
           type: integer
           format: int32
@@ -65008,7 +65284,7 @@ components:
         stacked: true
         stacking: none
         step: true
-        symbolSize: !!float 1
+        symbolSize: 1
     CartesianVisualizationSpec:
       type: object
       allOf:
@@ -65045,8 +65321,8 @@ components:
           example:
             - displayUnits: auto
               id: x
-              maximum: !!float 1
-              minimum: !!float 1
+              maximum: 1
+              minimum: 1
               scale: automatic
               tickDensity: automatic
               title: example
@@ -65093,8 +65369,8 @@ components:
         axes:
           - displayUnits: auto
             id: x
-            maximum: !!float 1
-            minimum: !!float 1
+            maximum: 1
+            minimum: 1
             scale: automatic
             tickDensity: automatic
             title: example
@@ -65127,7 +65403,7 @@ components:
           stacked: true
           stacking: none
           step: true
-          symbolSize: !!float 1
+          symbolSize: 1
         referenceBands:
           - axis: x
             id: example
@@ -65348,12 +65624,14 @@ components:
         disabledAt:
           type: string
           format: date-time
-          description: Lifecycle disable owned by the identity provisioning authority, such as SCIM active=false.
+          description: Lifecycle disable owned by the identity provisioning authority,
+            such as SCIM active=false.
           example: "2026-01-02T15:04:05Z"
         blockedAt:
           type: string
           format: date-time
-          description: LeapView administrator block. This is independent from externally managed lifecycle state.
+          description: LeapView administrator block. This is independent from externally
+            managed lifecycle state.
           example: "2026-01-02T15:04:05Z"
         createdAt:
           type: string
@@ -66877,7 +67155,7 @@ components:
                     key: example
                   description: example
                   eyebrow: example
-                  height: !!float 1
+                  height: 1
                   id: example
                   kind: example
                   placement:
@@ -66890,9 +67168,9 @@ components:
                   subtitle: example
                   title: example
                   visual: example
-                  width: !!float 1
-                  x: !!float 1
-                  'y': !!float 1
+                  width: 1
+                  x: 1
+                  'y': 1
               width: 1
         visualizations:
           type: object
@@ -66942,7 +67220,7 @@ components:
                   key: example
                 description: example
                 eyebrow: example
-                height: !!float 1
+                height: 1
                 id: example
                 kind: example
                 placement:
@@ -66955,9 +67233,9 @@ components:
                 subtitle: example
                 title: example
                 visual: example
-                width: !!float 1
-                x: !!float 1
-                'y': !!float 1
+                width: 1
+                x: 1
+                'y': 1
             width: 1
         semanticModel: example
         title: example
@@ -67117,7 +67395,7 @@ components:
         interactionRevision:
           type: integer
           format: int64
-          minimum: !!float 0
+          minimum: 0
           example: 1
       example:
         interactionRevision: 1
@@ -67306,7 +67584,7 @@ components:
                 key: example
               description: example
               eyebrow: example
-              height: !!float 1
+              height: 1
               id: example
               kind: example
               placement:
@@ -67319,9 +67597,9 @@ components:
               subtitle: example
               title: example
               visual: example
-              width: !!float 1
-              x: !!float 1
-              'y': !!float 1
+              width: 1
+              x: 1
+              'y': 1
         width:
           type: integer
           format: int32
@@ -67354,7 +67632,7 @@ components:
               key: example
             description: example
             eyebrow: example
-            height: !!float 1
+            height: 1
             id: example
             kind: example
             placement:
@@ -67367,9 +67645,9 @@ components:
             subtitle: example
             title: example
             visual: example
-            width: !!float 1
-            x: !!float 1
-            'y': !!float 1
+            width: 1
+            x: 1
+            'y': 1
         width: 1
     DashboardAuthoringPreviewPagePatch:
       type: object
@@ -67454,7 +67732,7 @@ components:
           generation: 1
           lastUpdated: example
           loading: true
-          progressPercent: !!float 1
+          progressPercent: 1
           refreshId: example
           setupRequired: true
         visuals:
@@ -67551,19 +67829,19 @@ components:
         x:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         'y':
           type: number
           format: double
-          example: !!float 1
+          example: 1
         width:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         height:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         badges:
           - example
@@ -67571,7 +67849,7 @@ components:
           key: example
         description: example
         eyebrow: example
-        height: !!float 1
+        height: 1
         id: example
         kind: example
         placement:
@@ -67584,9 +67862,9 @@ components:
         subtitle: example
         title: example
         visual: example
-        width: !!float 1
-        x: !!float 1
-        'y': !!float 1
+        width: 1
+        x: 1
+        'y': 1
     DashboardAuthoringPreviewPivotQuery:
       type: object
       allOf:
@@ -67894,7 +68172,7 @@ components:
                     key: example
                   description: example
                   eyebrow: example
-                  height: !!float 1
+                  height: 1
                   id: example
                   kind: example
                   placement:
@@ -67907,9 +68185,9 @@ components:
                   subtitle: example
                   title: example
                   visual: example
-                  width: !!float 1
-                  x: !!float 1
-                  'y': !!float 1
+                  width: 1
+                  x: 1
+                  'y': 1
               width: 1
           semanticModel: example
           title: example
@@ -67947,7 +68225,7 @@ components:
             generation: 1
             lastUpdated: example
             loading: true
-            progressPercent: !!float 1
+            progressPercent: 1
             refreshId: example
             setupRequired: true
           visuals:
@@ -68028,7 +68306,8 @@ components:
         interactionKind:
           type: string
           minLength: 1
-          description: Stable interaction ID from the source visualization specification. The legacy field name is retained for wire compatibility.
+          description: Stable interaction ID from the source visualization specification.
+            The legacy field name is retained for wire compatibility.
           example: example
         entries:
           type: array
@@ -68298,13 +68577,13 @@ components:
         progressPercent:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         error: example
         generation: 1
         lastUpdated: example
         loading: true
-        progressPercent: !!float 1
+        progressPercent: 1
         refreshId: example
         setupRequired: true
     DashboardAuthoringPreviewTimeBinding:
@@ -68668,7 +68947,7 @@ components:
         number:
           type: integer
           format: int64
-          minimum: !!float 0
+          minimum: 0
           example: 1
         contentHash:
           type: string
@@ -68870,7 +69149,7 @@ components:
         number:
           type: integer
           format: int64
-          minimum: !!float 0
+          minimum: 0
           example: 1
         contentHash:
           type: string
@@ -68898,7 +69177,8 @@ components:
         generationId:
           type: string
           example: example
-      description: Exact graph serving identity persisted with authored provenance and compilation evidence.
+      description: Exact graph serving identity persisted with authored provenance
+        and compilation evidence.
       example:
         environment: example
         generationId: example
@@ -69576,13 +69856,13 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         category: example
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
@@ -69590,11 +69870,11 @@ components:
         geometryAsset: example
         join: example
         kind: example
-        opacity: !!float 1
+        opacity: 1
         stroke:
           color: example
-          opacity: !!float 1
-          width: !!float 1
+          opacity: 1
+          width: 1
         value: example
     DashboardComboSeries:
       type: object
@@ -69875,22 +70155,22 @@ components:
         x:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         'y':
           type: number
           format: double
-          example: !!float 1
+          example: 1
         width:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         height:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         description: example
-        height: !!float 1
+        height: 1
         id: example
         kind: example
         placement:
@@ -69900,9 +70180,9 @@ components:
           rowSpan: 1
         ref: example
         title: example
-        width: !!float 1
-        x: !!float 1
-        'y': !!float 1
+        width: 1
+        x: 1
+        'y': 1
     DashboardConditionalFormat:
       type: object
       required:
@@ -69926,7 +70206,8 @@ components:
           example: example
         rule:
           $ref: '#/components/schemas/DashboardConditionalRule'
-      description: A closed, governed conditional-format binding over compiled result names.
+      description: A closed, governed conditional-format binding over compiled result
+        names.
       example:
         field: example
         id: example
@@ -69959,7 +70240,8 @@ components:
           $ref: '#/components/schemas/VisualizationColorIntent'
         icon:
           $ref: '#/components/schemas/VisualizationIconIntent'
-      description: A renderer-neutral color or icon intent applied by a conditional rule.
+      description: A renderer-neutral color or icon intent applied by a conditional
+        rule.
       example:
         color: accent
         icon: circle
@@ -69975,7 +70257,7 @@ components:
         value:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         style:
           $ref: '#/components/schemas/DashboardConditionalStyle'
       description: One ordered numeric comparison in a rules-based conditional format.
@@ -69984,7 +70266,7 @@ components:
         style:
           color: accent
           icon: circle
-        value: !!float 1
+        value: 1
     DashboardDataBudget:
       type: object
       required:
@@ -70035,23 +70317,23 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
           reverse: true
         heat:
-          intensity: !!float 1
-          radius: !!float 1
+          intensity: 1
+          radius: 1
         kind: example
         latitude: example
         longitude: example
-        opacity: !!float 1
+        opacity: 1
         value: example
     DashboardDimensionReference:
       type: object
@@ -70070,7 +70352,8 @@ components:
           minLength: 1
           pattern: ^[A-Za-z_][A-Za-z0-9_]*$
           example: example
-      description: A semantic dimension reference. Physical dataset fields are not accepted.
+      description: A semantic dimension reference. Physical dataset fields are not
+        accepted.
       example:
         alias: example
         dimension: example
@@ -70096,14 +70379,14 @@ components:
         lower:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         upper:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        lower: !!float 1
-        upper: !!float 1
+        lower: 1
+        upper: 1
     DashboardDocument:
       type: object
       required:
@@ -70805,16 +71088,16 @@ components:
         minimumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         id: example
         label: example
-        maximumZoom: !!float 1
-        minimumZoom: !!float 1
+        maximumZoom: 1
+        minimumZoom: 1
         position: below_labels
         tooltip:
           - example
@@ -70838,11 +71121,11 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         low:
           $ref: '#/components/schemas/DashboardConditionalStyle'
         high:
@@ -70857,8 +71140,8 @@ components:
         low:
           color: accent
           icon: circle
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
         nullStyle:
           color: accent
           icon: circle
@@ -70912,23 +71195,23 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
           reverse: true
         heat:
-          intensity: !!float 1
-          radius: !!float 1
+          intensity: 1
+          radius: 1
         kind: example
         latitude: example
         longitude: example
-        opacity: !!float 1
+        opacity: 1
         value: example
     DashboardHistogramApproximation:
       type: string
@@ -70942,14 +71225,14 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
     DashboardHistogramNullPolicy:
       type: string
       enum:
@@ -70983,7 +71266,8 @@ components:
             type: string
           example:
             - example
-      description: Typed local fragment collections. Includes are resolved before validation.
+      description: Typed local fragment collections. Includes are resolved before
+        validation.
       example:
         components:
           - example
@@ -71429,11 +71713,11 @@ components:
             type: number
             format: double
           example:
-            - !!float 1
+            - 1
         zoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         padding:
           type: integer
           format: int32
@@ -71441,19 +71725,19 @@ components:
         minimumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         center:
-          - !!float 1
-        maximumZoom: !!float 1
-        minimumZoom: !!float 1
+          - 1
+        maximumZoom: 1
+        minimumZoom: 1
         mode: fit_data
         padding: 1
-        zoom: !!float 1
+        zoom: 1
     DashboardMapCluster:
       type: object
       properties:
@@ -71495,22 +71779,22 @@ components:
         domainMinimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         domainMidpoint:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         domainMaximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         nullColor:
           type: string
           example: example
       example:
-        domainMaximum: !!float 1
-        domainMidpoint: !!float 1
-        domainMinimum: !!float 1
+        domainMaximum: 1
+        domainMidpoint: 1
+        domainMinimum: 1
         kind: sequential
         nullColor: example
         palette: example
@@ -71537,52 +71821,52 @@ components:
         radius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         intensity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        intensity: !!float 1
-        radius: !!float 1
+        intensity: 1
+        radius: 1
     DashboardMapLineStyle:
       type: object
       properties:
         width:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         curvature:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        curvature: !!float 1
-        width: !!float 1
+        curvature: 1
+        width: 1
     DashboardMapSizeScale:
       type: object
       properties:
         minimumRadius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumRadius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         domainMinimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         domainMaximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        domainMaximum: !!float 1
-        domainMinimum: !!float 1
-        maximumRadius: !!float 1
-        minimumRadius: !!float 1
+        domainMaximum: 1
+        domainMinimum: 1
+        maximumRadius: 1
+        minimumRadius: 1
     DashboardMapStroke:
       type: object
       properties:
@@ -71592,15 +71876,15 @@ components:
         width:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color: example
-        opacity: !!float 1
-        width: !!float 1
+        opacity: 1
+        width: 1
     DashboardMetadata:
       type: object
       required:
@@ -71705,7 +71989,8 @@ components:
           minLength: 1
           pattern: ^[A-Za-z_][A-Za-z0-9_]*$
           example: example
-      description: A semantic metric reference. Metric expressions are never part of this type.
+      description: A semantic metric reference. Metric expressions are never part
+        of this type.
       example:
         alias: example
         metric: example
@@ -71813,18 +72098,18 @@ components:
           example:
             - geometry:
                 bounds:
-                  east: !!float 1
-                  north: !!float 1
-                  south: !!float 1
-                  west: !!float 1
+                  east: 1
+                  north: 1
+                  south: 1
+                  west: 1
                 center:
-                  latitude: !!float 1
-                  longitude: !!float 1
+                  latitude: 1
+                  longitude: 1
                 kind: example
                 points:
-                  - latitude: !!float 1
-                    longitude: !!float 1
-                radiusMeters: !!float 1
+                  - latitude: 1
+                    longitude: 1
+                radiusMeters: 1
               gesture: box
               interactionID: example
               order: 1
@@ -71839,18 +72124,18 @@ components:
         spatialSelections:
           - geometry:
               bounds:
-                east: !!float 1
-                north: !!float 1
-                south: !!float 1
-                west: !!float 1
+                east: 1
+                north: 1
+                south: 1
+                west: 1
               center:
-                latitude: !!float 1
-                longitude: !!float 1
+                latitude: 1
+                longitude: 1
               kind: example
               points:
-                - latitude: !!float 1
-                  longitude: !!float 1
-              radiusMeters: !!float 1
+                - latitude: 1
+                  longitude: 1
+              radiusMeters: 1
             gesture: box
             interactionID: example
             order: 1
@@ -72042,13 +72327,13 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         category: example
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
@@ -72056,16 +72341,16 @@ components:
         kind: example
         latitude: example
         line:
-          curvature: !!float 1
-          width: !!float 1
+          curvature: 1
+          width: 1
         longitude: example
-        opacity: !!float 1
+        opacity: 1
         order: example
         path: example
         stroke:
           color: example
-          opacity: !!float 1
-          width: !!float 1
+          opacity: 1
+          width: 1
         value: example
     DashboardPivotTotals:
       type: object
@@ -72173,7 +72458,7 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         category: example
         cluster:
@@ -72183,9 +72468,9 @@ components:
           radius: 1
           showCount: true
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
@@ -72193,16 +72478,16 @@ components:
         kind: example
         latitude: example
         longitude: example
-        opacity: !!float 1
+        opacity: 1
         size:
-          domainMaximum: !!float 1
-          domainMinimum: !!float 1
-          maximumRadius: !!float 1
-          minimumRadius: !!float 1
+          domainMaximum: 1
+          domainMinimum: 1
+          maximumRadius: 1
+          minimumRadius: 1
         stroke:
           color: example
-          opacity: !!float 1
-          width: !!float 1
+          opacity: 1
+          width: 1
         value: example
     DashboardPresentation:
       oneOf:
@@ -72241,7 +72526,8 @@ components:
             - field: example
               id: example
               target: mark_fill
-      description: Renderer-neutral presentation policies; renderer options are intentionally absent.
+      description: Renderer-neutral presentation policies; renderer options are intentionally
+        absent.
       example:
         conditionalFormatting:
           - field: example
@@ -72476,7 +72762,8 @@ components:
           minLength: 1
           pattern: ^[A-Za-z_][A-Za-z0-9_]*$
           example: example
-      description: A physical field reference is only valid for a records query root dataset.
+      description: A physical field reference is only valid for a records query root
+        dataset.
       example:
         alias: example
         field: example
@@ -72509,23 +72796,23 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
           reverse: true
         geometryAsset: example
         kind: example
-        opacity: !!float 1
+        opacity: 1
         stroke:
           color: example
-          opacity: !!float 1
-          width: !!float 1
+          opacity: 1
+          width: 1
     DashboardRelativeAnchor:
       type: string
       enum:
@@ -72582,7 +72869,7 @@ components:
               style:
                 color: accent
                 icon: circle
-              value: !!float 1
+              value: 1
         nullStyle:
           $ref: '#/components/schemas/DashboardConditionalStyle'
         defaultStyle:
@@ -72600,7 +72887,7 @@ components:
             style:
               color: accent
               icon: circle
-            value: !!float 1
+            value: 1
     DashboardSelectionMode:
       type: string
       enum:
@@ -72636,7 +72923,8 @@ components:
           type: string
           minLength: 1
           pattern: ^[A-Za-z_][A-Za-z0-9_]*$
-          description: A compiled result-frame field name, never a source member or expression.
+          description: A compiled result-frame field name, never a source member or
+            expression.
           example: example
         direction:
           $ref: '#/components/schemas/DashboardSortDirection'
@@ -72682,18 +72970,18 @@ components:
       example:
         geometry:
           bounds:
-            east: !!float 1
-            north: !!float 1
-            south: !!float 1
-            west: !!float 1
+            east: 1
+            north: 1
+            south: 1
+            west: 1
           center:
-            latitude: !!float 1
-            longitude: !!float 1
+            latitude: 1
+            longitude: 1
           kind: example
           points:
-            - latitude: !!float 1
-              longitude: !!float 1
-          radiusMeters: !!float 1
+            - latitude: 1
+              longitude: 1
+          radiusMeters: 1
         gesture: box
         interactionID: example
         order: 1
@@ -72743,28 +73031,28 @@ components:
           items:
             $ref: '#/components/schemas/VisualizationSpatialCoordinate'
           example:
-            - latitude: !!float 1
-              longitude: !!float 1
+            - latitude: 1
+              longitude: 1
         center:
           $ref: '#/components/schemas/VisualizationSpatialCoordinate'
         radiusMeters:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         bounds:
-          east: !!float 1
-          north: !!float 1
-          south: !!float 1
-          west: !!float 1
+          east: 1
+          north: 1
+          south: 1
+          west: 1
         center:
-          latitude: !!float 1
-          longitude: !!float 1
+          latitude: 1
+          longitude: 1
         kind: example
         points:
-          - latitude: !!float 1
-            longitude: !!float 1
-        radiusMeters: !!float 1
+          - latitude: 1
+            longitude: 1
+        radiusMeters: 1
     DashboardSpec:
       type: object
       required:
@@ -73272,22 +73560,22 @@ components:
         x:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         'y':
           type: number
           format: double
-          example: !!float 1
+          example: 1
         width:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         height:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         componentId: example
-        height: !!float 1
+        height: 1
         id: example
         placement:
           col: 1
@@ -73296,17 +73584,17 @@ components:
           rowSpan: 1
         rendererID: example
         specRevision: example
-        width: !!float 1
-        x: !!float 1
-        'y': !!float 1
+        width: 1
+        x: 1
+        'y': 1
     DashboardVisualQueryRequest:
       type: object
       properties:
         limit:
           type: integer
           format: int32
-          minimum: !!float 1
-          maximum: !!float 1000
+          minimum: 1
+          maximum: 1000
           example: 1
         pageToken:
           type: string
@@ -73329,18 +73617,18 @@ components:
           example:
             - geometry:
                 bounds:
-                  east: !!float 1
-                  north: !!float 1
-                  south: !!float 1
-                  west: !!float 1
+                  east: 1
+                  north: 1
+                  south: 1
+                  west: 1
                 center:
-                  latitude: !!float 1
-                  longitude: !!float 1
+                  latitude: 1
+                  longitude: 1
                 kind: example
                 points:
-                  - latitude: !!float 1
-                    longitude: !!float 1
-                radiusMeters: !!float 1
+                  - latitude: 1
+                    longitude: 1
+                radiusMeters: 1
               gesture: box
               interactionID: example
               order: 1
@@ -73357,18 +73645,18 @@ components:
         spatialSelections:
           - geometry:
               bounds:
-                east: !!float 1
-                north: !!float 1
-                south: !!float 1
-                west: !!float 1
+                east: 1
+                north: 1
+                south: 1
+                west: 1
               center:
-                latitude: !!float 1
-                longitude: !!float 1
+                latitude: 1
+                longitude: 1
               kind: example
               points:
-                - latitude: !!float 1
-                  longitude: !!float 1
-              radiusMeters: !!float 1
+                - latitude: 1
+                  longitude: 1
+              radiusMeters: 1
             gesture: box
             interactionID: example
             order: 1
@@ -75895,7 +76183,7 @@ components:
             type: number
             format: double
           example:
-            - !!float 1
+            - 1
         whiskers:
           $ref: '#/components/schemas/DashboardDistributionWhiskers'
         outliers:
@@ -75911,11 +76199,11 @@ components:
         limit: 1
         outliers: omit
         quantiles:
-          - !!float 1
+          - 1
         type: example
         whiskers:
-          lower: !!float 1
-          upper: !!float 1
+          lower: 1
+          upper: 1
     DurationVisualizationFormat:
       type: object
       allOf:
@@ -76134,12 +76422,12 @@ components:
         basemap: example
         camera:
           center:
-            - !!float 1
-          maximumZoom: !!float 1
-          minimumZoom: !!float 1
+            - 1
+          maximumZoom: 1
+          minimumZoom: 1
           mode: fit_data
           padding: 1
-          zoom: !!float 1
+          zoom: 1
         controls:
           compass: true
           reset: true
@@ -76186,25 +76474,25 @@ components:
           archiveUrl: example
           attribution: example
           bounds:
-            - !!float 1
+            - 1
           glyphsUrl: example
           id: example
           labelAnchor: example
           license: example
-          maximumZoom: !!float 1
-          minimumZoom: !!float 1
+          maximumZoom: 1
+          minimumZoom: 1
           source: example
           spriteUrl: example
           styleDigest: example
           styleUrl: example
         camera:
           center:
-            - !!float 1
-          maximumZoom: !!float 1
-          minimumZoom: !!float 1
+            - 1
+          maximumZoom: 1
+          minimumZoom: 1
           mode: fit_data
           padding: 1
-          zoom: !!float 1
+          zoom: 1
         controls:
           compass: true
           reset: true
@@ -76266,25 +76554,25 @@ components:
             archiveUrl: example
             attribution: example
             bounds:
-              - !!float 1
+              - 1
             glyphsUrl: example
             id: example
             labelAnchor: example
             license: example
-            maximumZoom: !!float 1
-            minimumZoom: !!float 1
+            maximumZoom: 1
+            minimumZoom: 1
             source: example
             spriteUrl: example
             styleDigest: example
             styleUrl: example
           camera:
             center:
-              - !!float 1
-            maximumZoom: !!float 1
-            minimumZoom: !!float 1
+              - 1
+            maximumZoom: 1
+            minimumZoom: 1
             mode: fit_data
             padding: 1
-            zoom: !!float 1
+            zoom: 1
           controls:
             compass: true
             reset: true
@@ -76331,11 +76619,11 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         low:
           $ref: '#/components/schemas/VisualizationConditionalStyle'
         high:
@@ -76350,8 +76638,8 @@ components:
         low:
           color: accent
           icon: circle
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
         nullStyle:
           color: accent
           icon: circle
@@ -76813,16 +77101,16 @@ components:
         nodeGap:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         curveness:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         focus:
           $ref: '#/components/schemas/VisualizationGraphFocus'
       example:
         breadcrumb: true
-        curveness: !!float 1
+        curveness: 1
         focus: none
         initialDepth: 1
         labels:
@@ -76834,7 +77122,7 @@ components:
           tooltipFallback: true
         layout: standard
         legend: none
-        nodeGap: !!float 1
+        nodeGap: 1
         orientation: horizontal
         roam: true
         type: example
@@ -76863,20 +77151,20 @@ components:
         nodeGap:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         curveness:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         focus:
           $ref: '#/components/schemas/VisualizationGraphFocus'
       example:
         breadcrumb: true
-        curveness: !!float 1
+        curveness: 1
         focus: none
         initialDepth: 1
         layout: standard
-        nodeGap: !!float 1
+        nodeGap: 1
         orientation: horizontal
         roam: true
     HierarchyVisualizationSpec:
@@ -76919,11 +77207,11 @@ components:
           field: example
         presentation:
           breadcrumb: true
-          curveness: !!float 1
+          curveness: 1
           focus: none
           initialDepth: 1
           layout: standard
-          nodeGap: !!float 1
+          nodeGap: 1
           orientation: horizontal
           roam: true
         source:
@@ -76967,8 +77255,8 @@ components:
         approximation: exact
         bins: 1
         domain:
-          maximum: !!float 1
-          minimum: !!float 1
+          maximum: 1
+          minimum: 1
         nullPolicy: omit
         type: example
     IdentityManagementResponse:
@@ -77096,8 +77384,8 @@ components:
             $ref: '#/components/schemas/VisualizationKPIQualitativeRange'
           example:
             - label: example
-              maximum: !!float 1
-              minimum: !!float 1
+              maximum: 1
+              minimum: 1
               tone: neutral
         thresholds:
           type: array
@@ -77105,7 +77393,7 @@ components:
             $ref: '#/components/schemas/VisualizationThreshold'
           example:
             - tone: neutral
-              value: !!float 1
+              value: 1
         comparison:
           $ref: '#/components/schemas/DashboardKPIValueBinding'
         goal:
@@ -77138,12 +77426,12 @@ components:
         note: example
         ranges:
           - label: example
-            maximum: !!float 1
-            minimum: !!float 1
+            maximum: 1
+            minimum: 1
             tone: neutral
         thresholds:
           - tone: neutral
-            value: !!float 1
+            value: 1
         tone: neutral
         trend:
           category: example
@@ -77173,8 +77461,8 @@ components:
             $ref: '#/components/schemas/VisualizationKPIQualitativeRange'
           example:
             - label: example
-              maximum: !!float 1
-              minimum: !!float 1
+              maximum: 1
+              minimum: 1
               tone: neutral
         displayUnits:
           $ref: '#/components/schemas/VisualizationDisplayUnits'
@@ -77189,7 +77477,7 @@ components:
             $ref: '#/components/schemas/VisualizationThreshold'
           example:
             - tone: neutral
-              value: !!float 1
+              value: 1
       example:
         delta: absolute
         displayUnits: auto
@@ -77199,12 +77487,12 @@ components:
         note: example
         ranges:
           - label: example
-            maximum: !!float 1
-            minimum: !!float 1
+            maximum: 1
+            minimum: 1
             tone: neutral
         thresholds:
           - tone: neutral
-            value: !!float 1
+            value: 1
         tone: neutral
     KPIVisualizationSpec:
       type: object
@@ -77253,12 +77541,12 @@ components:
           note: example
           ranges:
             - label: example
-              maximum: !!float 1
-              minimum: !!float 1
+              maximum: 1
+              minimum: 1
               tone: neutral
           thresholds:
             - tone: neutral
-              value: !!float 1
+              value: 1
           tone: neutral
         trend:
           category:
@@ -77427,7 +77715,7 @@ components:
         size:
           type: integer
           format: int64
-          minimum: !!float 0
+          minimum: 0
           example: 1
         sha256:
           type: string
@@ -77452,7 +77740,8 @@ components:
           $ref: '#/components/schemas/ManagedDataFileUploadStatus'
         negotiation:
           $ref: '#/components/schemas/ManagedDataUploadNegotiation'
-          description: Upload instructions, present only while the file can still be uploaded.
+          description: Upload instructions, present only while the file can still
+            be uploaded.
         error:
           type: string
           minLength: 1
@@ -77569,7 +77858,8 @@ components:
           minLength: 71
           maxLength: 71
           pattern: ^sha256:[0-9a-f]{64}$
-          description: The immutable revision identity, formatted as sha256 followed by a colon and 64 lowercase hexadecimal characters.
+          description: The immutable revision identity, formatted as sha256 followed
+            by a colon and 64 lowercase hexadecimal characters.
           example: example
         status:
           $ref: '#/components/schemas/ManagedDataRevisionStatus'
@@ -77578,13 +77868,13 @@ components:
         fileCount:
           type: integer
           format: int32
-          minimum: !!float 1
-          maximum: !!float 10000
+          minimum: 1
+          maximum: 10000
           example: 1
         size:
           type: integer
           format: int64
-          minimum: !!float 0
+          minimum: 0
           example: 1
         createdAt:
           type: string
@@ -77627,20 +77917,21 @@ components:
           minLength: 71
           maxLength: 71
           pattern: ^sha256:[0-9a-f]{64}$
-          description: The immutable revision identity, formatted as sha256 followed by a colon and 64 lowercase hexadecimal characters.
+          description: The immutable revision identity, formatted as sha256 followed
+            by a colon and 64 lowercase hexadecimal characters.
           example: example
         status:
           $ref: '#/components/schemas/ManagedDataRevisionStatus'
         fileCount:
           type: integer
           format: int32
-          minimum: !!float 1
-          maximum: !!float 10000
+          minimum: 1
+          maximum: 10000
           example: 1
         size:
           type: integer
           format: int64
-          minimum: !!float 0
+          minimum: 0
           example: 1
         createdAt:
           type: string
@@ -77667,8 +77958,8 @@ components:
         partNumber:
           type: integer
           format: int32
-          minimum: !!float 1
-          maximum: !!float 10000
+          minimum: 1
+          maximum: 10000
           example: 1
         etag:
           type: string
@@ -77768,20 +78059,21 @@ components:
         minimumPartSize:
           type: integer
           format: int64
-          minimum: !!float 1
+          minimum: 1
           example: 1
         maximumPartSize:
           type: integer
           format: int64
-          minimum: !!float 1
+          minimum: 1
           example: 1
         maximumParts:
           type: integer
           format: int32
-          minimum: !!float 1
-          maximum: !!float 10000
+          minimum: 1
+          maximum: 10000
           example: 1
-      description: Negotiated S3 multipart transport. Commands below manage transport only; upload-session finalization remains a separate lifecycle operation.
+      description: Negotiated S3 multipart transport. Commands below manage transport
+        only; upload-session finalization remains a separate lifecycle operation.
       example:
         createEndpoint: example
         maximumPartSize: 1
@@ -77795,7 +78087,7 @@ components:
         size:
           type: integer
           format: int64
-          minimum: !!float 1
+          minimum: 1
           example: 1
         sha256:
           type: string
@@ -77817,8 +78109,8 @@ components:
         partNumber:
           type: integer
           format: int32
-          minimum: !!float 1
-          maximum: !!float 10000
+          minimum: 1
+          maximum: 10000
           example: 1
         url:
           type: string
@@ -77917,13 +78209,15 @@ components:
         offset:
           type: integer
           format: int64
-          minimum: !!float 0
+          minimum: 0
           example: 1
         expiresAt:
           type: string
           format: date-time
           example: "2026-01-02T15:04:05Z"
-      description: Negotiated TUS transport. TUS protocol requests update transport progress but are not LeapView application operations; the durable command boundary remains the upload-session lifecycle.
+      description: Negotiated TUS transport. TUS protocol requests update transport
+        progress but are not LeapView application operations; the durable command
+        boundary remains the upload-session lifecycle.
       example:
         endpoint: example
         expiresAt: "2026-01-02T15:04:05Z"
@@ -77940,7 +78234,8 @@ components:
           $ref: '#/components/schemas/ManagedDataTusUploadNegotiation'
         s3Multipart:
           $ref: '#/components/schemas/ManagedDataS3MultipartNegotiation'
-      description: Backend-neutral upload instructions. Exactly one protocol-specific object is present for tus or S3 multipart; already-present files have neither.
+      description: Backend-neutral upload instructions. Exactly one protocol-specific
+        object is present for tus or S3 multipart; already-present files have neither.
       example:
         protocol: tus
         s3Multipart:
@@ -78371,10 +78666,10 @@ components:
         value:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         kind: example
-        value: !!float 1
+        value: 1
     NumericRangeDashboardFilterControl:
       type: object
       allOf:
@@ -78552,19 +78847,19 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         scheme:
           type: string
           example: example
       description: A governed result-frame binding used by a point/scatter visual.
       example:
         kind: categorical
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
         scheme: example
     PointDashboardOverplot:
       type: object
@@ -78576,7 +78871,7 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         largeMode:
           $ref: '#/components/schemas/VisualizationPointLargeMode'
         largeThreshold:
@@ -78587,7 +78882,7 @@ components:
       example:
         largeMode: automatic
         largeThreshold: 1
-        opacity: !!float 1
+        opacity: 1
         strategy: show_all
     PointDashboardPresentation:
       type: object
@@ -78666,15 +78961,16 @@ components:
             $ref: '#/components/schemas/VisualizationPointBrushGesture'
           example:
             - rectangle
-      description: Strict point/scatter presentation and its governed result-frame channels.
+      description: Strict point/scatter presentation and its governed result-frame
+        channels.
       example:
         brush:
           - rectangle
         color: example
         colorScale:
           kind: categorical
-          maximum: !!float 1
-          minimum: !!float 1
+          maximum: 1
+          minimum: 1
           scheme: example
         identity:
           - example
@@ -78690,15 +78986,15 @@ components:
         overplot:
           largeMode: automatic
           largeThreshold: 1
-          opacity: !!float 1
+          opacity: 1
           strategy: show_all
         series: example
         size: example
         sizeScale:
-          maximum: !!float 1
-          maximumPixels: !!float 1
-          minimum: !!float 1
-          minimumPixels: !!float 1
+          maximum: 1
+          maximumPixels: 1
+          minimum: 1
+          minimumPixels: 1
         tooltip:
           - example
         type: example
@@ -78713,25 +79009,25 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         minimumPixels:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumPixels:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       description: Pixel and optional domain bounds for a governed point size binding.
       example:
-        maximum: !!float 1
-        maximumPixels: !!float 1
-        minimum: !!float 1
-        minimumPixels: !!float 1
+        maximum: 1
+        maximumPixels: 1
+        minimum: 1
+        minimumPixels: 1
     PointVisualizationColorScale:
       type: object
       required:
@@ -78742,18 +79038,18 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         scheme:
           type: string
           example: example
       example:
         kind: categorical
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
         scheme: example
     PointVisualizationPresentation:
       type: object
@@ -78771,7 +79067,7 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         largeMode:
           $ref: '#/components/schemas/VisualizationPointLargeMode'
         largeThreshold:
@@ -78789,7 +79085,7 @@ components:
           - rectangle
         largeMode: automatic
         largeThreshold: 1
-        opacity: !!float 1
+        opacity: 1
         overplot: show_all
     PointVisualizationSizeScale:
       type: object
@@ -78800,24 +79096,24 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         minimumPixels:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumPixels:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        maximum: !!float 1
-        maximumPixels: !!float 1
-        minimum: !!float 1
-        minimumPixels: !!float 1
+        maximum: 1
+        maximumPixels: 1
+        minimum: 1
+        minimumPixels: 1
     PointVisualizationSpec:
       type: object
       allOf:
@@ -78871,8 +79167,8 @@ components:
           example:
             - displayUnits: auto
               id: x
-              maximum: !!float 1
-              minimum: !!float 1
+              maximum: 1
+              minimum: 1
               scale: automatic
               tickDensity: automatic
               title: example
@@ -78912,8 +79208,8 @@ components:
         axes:
           - displayUnits: auto
             id: x
-            maximum: !!float 1
-            minimum: !!float 1
+            maximum: 1
+            minimum: 1
             scale: automatic
             tickDensity: automatic
             title: example
@@ -78924,8 +79220,8 @@ components:
           field: example
         colorScale:
           kind: categorical
-          maximum: !!float 1
-          minimum: !!float 1
+          maximum: 1
+          minimum: 1
           scheme: example
         eventAnnotations:
           - axis: x
@@ -78945,7 +79241,7 @@ components:
             - rectangle
           largeMode: automatic
           largeThreshold: 1
-          opacity: !!float 1
+          opacity: 1
           overplot: show_all
         referenceBands:
           - axis: x
@@ -78964,10 +79260,10 @@ components:
           dataset: example
           field: example
         sizeScale:
-          maximum: !!float 1
-          maximumPixels: !!float 1
-          minimum: !!float 1
-          minimumPixels: !!float 1
+          maximum: 1
+          maximumPixels: 1
+          minimum: 1
+          minimumPixels: 1
         tooltip:
           - dataset: example
             field: example
@@ -78998,15 +79294,15 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         target:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         showPointer:
           type: boolean
           example: true
@@ -79016,14 +79312,14 @@ components:
         progressWidth:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         thresholds:
           type: array
           items:
             $ref: '#/components/schemas/VisualizationThreshold'
           example:
             - tone: neutral
-              value: !!float 1
+              value: 1
       example:
         area: true
         displayUnits: auto
@@ -79035,14 +79331,14 @@ components:
             - selected
           tooltipFallback: true
         legend: none
-        maximum: !!float 1
-        minimum: !!float 1
-        progressWidth: !!float 1
+        maximum: 1
+        minimum: 1
+        progressWidth: 1
         showPointer: true
-        target: !!float 1
+        target: 1
         thresholds:
           - tone: neutral
-            value: !!float 1
+            value: 1
         type: example
     PolarVisualizationPresentation:
       type: object
@@ -79054,15 +79350,15 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         target:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         showPointer:
           type: boolean
           example: true
@@ -79072,24 +79368,24 @@ components:
         progressWidth:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         thresholds:
           type: array
           items:
             $ref: '#/components/schemas/VisualizationThreshold'
           example:
             - tone: neutral
-              value: !!float 1
+              value: 1
       example:
         area: true
-        maximum: !!float 1
-        minimum: !!float 1
-        progressWidth: !!float 1
+        maximum: 1
+        minimum: 1
+        progressWidth: 1
         showPointer: true
-        target: !!float 1
+        target: 1
         thresholds:
           - tone: neutral
-            value: !!float 1
+            value: 1
     PolarVisualizationSpec:
       type: object
       allOf:
@@ -79123,14 +79419,14 @@ components:
         mark: radar
         presentation:
           area: true
-          maximum: !!float 1
-          minimum: !!float 1
-          progressWidth: !!float 1
+          maximum: 1
+          minimum: 1
+          progressWidth: 1
           showPointer: true
-          target: !!float 1
+          target: 1
           thresholds:
             - tone: neutral
-              value: !!float 1
+              value: 1
         series:
           dataset: example
           field: example
@@ -79204,12 +79500,14 @@ components:
         disabledAt:
           type: string
           format: date-time
-          description: Lifecycle disable owned by the identity provisioning authority, such as SCIM active=false.
+          description: Lifecycle disable owned by the identity provisioning authority,
+            such as SCIM active=false.
           example: "2026-01-02T15:04:05Z"
         blockedAt:
           type: string
           format: date-time
-          description: LeapView administrator block. This is independent from externally managed lifecycle state.
+          description: LeapView administrator block. This is independent from externally
+            managed lifecycle state.
           example: "2026-01-02T15:04:05Z"
         createdAt:
           type: string
@@ -79385,12 +79683,14 @@ components:
         disabledAt:
           type: string
           format: date-time
-          description: Lifecycle disable owned by the identity provisioning authority, such as SCIM active=false.
+          description: Lifecycle disable owned by the identity provisioning authority,
+            such as SCIM active=false.
           example: "2026-01-02T15:04:05Z"
         blockedAt:
           type: string
           format: date-time
-          description: LeapView administrator block. This is independent from externally managed lifecycle state.
+          description: LeapView administrator block. This is independent from externally
+            managed lifecycle state.
           example: "2026-01-02T15:04:05Z"
         createdAt:
           type: string
@@ -79953,11 +80253,11 @@ components:
         innerRadius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         outerRadius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         align:
           $ref: '#/components/schemas/DashboardProportionalAlignment'
         sort:
@@ -79966,7 +80266,7 @@ components:
         align: left
         centerLabel: example
         displayUnits: auto
-        innerRadius: !!float 1
+        innerRadius: 1
         labelPosition: automatic
         labels:
           density: hidden
@@ -79977,7 +80277,7 @@ components:
           tooltipFallback: true
         legend: none
         orientation: horizontal
-        outerRadius: !!float 1
+        outerRadius: 1
         rose: true
         sort: ascending
         type: example
@@ -80002,11 +80302,11 @@ components:
         innerRadius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         outerRadius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         align:
           type: string
           example: example
@@ -80015,10 +80315,10 @@ components:
       example:
         align: example
         centerLabel: example
-        innerRadius: !!float 1
+        innerRadius: 1
         labelPosition: automatic
         orientation: horizontal
-        outerRadius: !!float 1
+        outerRadius: 1
         rose: true
         sort: ascending
     ProportionalVisualizationSpec:
@@ -80056,10 +80356,10 @@ components:
         presentation:
           align: example
           centerLabel: example
-          innerRadius: !!float 1
+          innerRadius: 1
           labelPosition: automatic
           orientation: horizontal
-          outerRadius: !!float 1
+          outerRadius: 1
           rose: true
           sort: ascending
         series:
@@ -80081,7 +80381,8 @@ components:
           example: example
         type:
           $ref: '#/components/schemas/QueryColumnType'
-          description: Precision-safe wire data type. Agent tools expose this property as dataType.
+          description: Precision-safe wire data type. Agent tools expose this property
+            as dataType.
         nullable:
           type: boolean
           description: Whether the governed semantic definition can produce SQL NULL.
@@ -80369,7 +80670,8 @@ components:
         lastSuccessfulRefreshAt:
           type: string
           format: date-time
-          description: Completion time of the last successful publish or refresh. This is not an upstream event-time watermark.
+          description: Completion time of the last successful publish or refresh.
+            This is not an upstream event-time watermark.
           example: "2026-01-02T15:04:05Z"
         snapshotId:
           type: string
@@ -80391,7 +80693,8 @@ components:
           enum:
             - current
             - stale
-          description: current when the successful data version belongs to the queried serving snapshot; stale otherwise.
+          description: current when the successful data version belongs to the queried
+            serving snapshot; stale otherwise.
           example: example
       example:
         lastSuccessfulRefreshAt: "2026-01-02T15:04:05Z"
@@ -81735,7 +82038,7 @@ components:
               style:
                 color: accent
                 icon: circle
-              value: !!float 1
+              value: 1
         nullStyle:
           $ref: '#/components/schemas/VisualizationConditionalStyle'
         defaultStyle:
@@ -81753,7 +82056,7 @@ components:
             style:
               color: accent
               icon: circle
-            value: !!float 1
+            value: 1
     SearchKind:
       type: string
       enum:
@@ -82489,7 +82792,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SemanticSort'
-          description: Total ordering applied to the result, including deterministic tie-breakers.
+          description: Total ordering applied to the result, including deterministic
+            tie-breakers.
           example:
             - direction: asc
               field: example
@@ -82571,7 +82875,8 @@ components:
       properties:
         field:
           type: string
-          description: Semantic field or metric ID. Use the ID returned by catalog_list or catalog_get.
+          description: Semantic field or metric ID. Use the ID returned by catalog_list
+            or catalog_get.
           example: example
         alias:
           type: string
@@ -82654,7 +82959,8 @@ components:
           example: example
         dataset:
           type: string
-          description: Dataset used to resolve a conformed dimension when it is otherwise ambiguous.
+          description: Dataset used to resolve a conformed dimension when it is otherwise
+            ambiguous.
           example: example
         operator:
           $ref: '#/components/schemas/SemanticFilterOperator'
@@ -82903,8 +83209,8 @@ components:
         limit:
           type: integer
           format: int32
-          minimum: !!float 1
-          maximum: !!float 1000
+          minimum: 1
+          maximum: 1000
           example: 1
         pageToken:
           type: string
@@ -82972,8 +83278,8 @@ components:
         limit:
           type: integer
           format: int32
-          minimum: !!float 1
-          maximum: !!float 1000
+          minimum: 1
+          maximum: 1000
           example: 1
         pageToken:
           type: string
@@ -83020,11 +83326,13 @@ components:
           example: example
         servingSnapshot:
           type: string
-          description: Immutable serving state used by the query and its continuation cursor.
+          description: Immutable serving state used by the query and its continuation
+            cursor.
           example: example
         freshness:
           $ref: '#/components/schemas/QueryFreshness'
-          description: Last successful data-version metadata when the model has a recorded publish or refresh.
+          description: Last successful data-version metadata when the model has a
+            recorded publish or refresh.
         completeness:
           $ref: '#/components/schemas/QueryCompleteness'
           description: Completeness of the exact row page returned.
@@ -83694,18 +84002,18 @@ components:
             $ref: '#/components/schemas/VisualizationSpatialScaleDomain'
           example:
             - field: example
-              maximum: !!float 1
-              minimum: !!float 1
-              total: !!float 1
+              maximum: 1
+              minimum: 1
+              total: 1
         aggregateDomains:
           type: array
           items:
             $ref: '#/components/schemas/VisualizationSpatialScaleDomain'
           example:
             - field: example
-              maximum: !!float 1
-              minimum: !!float 1
-              total: !!float 1
+              maximum: 1
+              minimum: 1
+              total: 1
         tileURL:
           type: string
           example: example
@@ -83739,17 +84047,17 @@ components:
       example:
         aggregateDomains:
           - field: example
-            maximum: !!float 1
-            minimum: !!float 1
-            total: !!float 1
+            maximum: 1
+            minimum: 1
+            total: 1
         cardinality:
           count: 1
           kind: unknown
         extent:
-          east: !!float 1
-          north: !!float 1
-          south: !!float 1
-          west: !!float 1
+          east: 1
+          north: 1
+          south: 1
+          west: 1
         featureCap: 1
         kind: example
         maximumTileBytes: 1
@@ -83757,9 +84065,9 @@ components:
         minimumZoom: 1
         rawDomains:
           - field: example
-            maximum: !!float 1
-            minimum: !!float 1
-            total: !!float 1
+            maximum: 1
+            minimum: 1
+            total: 1
         rawMinimumZoom: 1
         schema:
           fields:
@@ -83859,11 +84167,11 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         lowColor:
           type: string
           example: example
@@ -83874,8 +84182,8 @@ components:
         highColor: example
         kind: example
         lowColor: example
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
     TableBadgeFormattingRule:
       type: object
       allOf:
@@ -83945,11 +84253,11 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         color:
           type: string
           example: example
@@ -83960,8 +84268,8 @@ components:
         background: example
         color: example
         kind: example
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
     TableTextColorFormattingRule:
       type: object
       allOf:
@@ -83987,16 +84295,16 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color: example
         kind: example
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
         values:
           key: example
     TableVisualizationColumn:
@@ -84167,7 +84475,7 @@ components:
         expectedRevision:
           type: integer
           format: int64
-          minimum: !!float 1
+          minimum: 1
           example: 1
         requiresConfirmation:
           type: boolean
@@ -84277,7 +84585,7 @@ components:
         bindingRevision:
           type: integer
           format: int64
-          minimum: !!float 1
+          minimum: 1
           example: 1
         validatedVersion:
           type: string
@@ -84302,7 +84610,8 @@ components:
         hasActivePool:
           type: boolean
           example: true
-      description: Redacted runtime health. Diagnostic codes are bounded LeapView codes, never raw provider errors.
+      description: Redacted runtime health. Diagnostic codes are bounded LeapView
+        codes, never raw provider errors.
       example:
         bindingId: example
         bindingRevision: 1
@@ -84465,9 +84774,10 @@ components:
         revision:
           type: integer
           format: int64
-          minimum: !!float 1
+          minimum: 1
           example: 1
-      description: Target binding metadata. Credential references are write-only configuration and are never returned.
+      description: Target binding metadata. Credential references are write-only configuration
+        and are never returned.
       example:
         authenticationMode: none
         connectorKind: example
@@ -84502,7 +84812,7 @@ components:
         expectedRevision:
           type: integer
           format: int64
-          minimum: !!float 1
+          minimum: 1
           example: 1
         confirmationToken:
           type: string
@@ -84586,7 +84896,8 @@ components:
         secretKey:
           type: string
           example: example
-      description: A provider-side reference only. LeapView never returns or accepts the referenced secret value.
+      description: A provider-side reference only. LeapView never returns or accepts
+        the referenced secret value.
       example:
         environment: example
         projectId: example
@@ -84853,11 +85164,11 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         unit:
           type: string
           example: example
@@ -84868,8 +85179,8 @@ components:
       example:
         displayUnits: auto
         id: x
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
         scale: automatic
         tickDensity: automatic
         title: example
@@ -85151,15 +85462,15 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         category:
           dataset: example
           field: example
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
@@ -85176,11 +85487,11 @@ components:
           dataset: example
           field: example
         kind: example
-        opacity: !!float 1
+        opacity: 1
         stroke:
           color: example
-          opacity: !!float 1
-          width: !!float 1
+          opacity: 1
+          width: 1
         value:
           dataset: example
           field: example
@@ -85317,7 +85628,7 @@ components:
         value:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         style:
           $ref: '#/components/schemas/VisualizationConditionalStyle'
       example:
@@ -85325,7 +85636,7 @@ components:
         style:
           color: accent
           icon: circle
-        value: !!float 1
+        value: 1
     VisualizationDataBudget:
       type: object
       required:
@@ -85525,19 +85836,19 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
           reverse: true
         heat:
-          intensity: !!float 1
-          radius: !!float 1
+          intensity: 1
+          radius: 1
         kind: example
         latitude:
           dataset: example
@@ -85545,7 +85856,7 @@ components:
         longitude:
           dataset: example
           field: example
-        opacity: !!float 1
+        opacity: 1
         value:
           dataset: example
           field: example
@@ -85936,8 +86247,8 @@ components:
           - dataset: example
             field: example
         visibility:
-          maximumZoom: !!float 1
-          minimumZoom: !!float 1
+          maximumZoom: 1
+          minimumZoom: 1
     VisualizationGeographicMetadata:
       type: object
       required:
@@ -86063,19 +86374,19 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
           reverse: true
         heat:
-          intensity: !!float 1
-          radius: !!float 1
+          intensity: 1
+          radius: 1
         kind: example
         latitude:
           dataset: example
@@ -86083,7 +86394,7 @@ components:
         longitude:
           dataset: example
           field: example
-        opacity: !!float 1
+        opacity: 1
         value:
           dataset: example
           field: example
@@ -86280,7 +86591,8 @@ components:
       properties:
         id:
           type: string
-          description: Stable compiler-owned interaction identity. Commands and persisted selections must reference this exact value.
+          description: Stable compiler-owned interaction identity. Commands and persisted
+            selections must reference this exact value.
           example: example
         kind:
           $ref: '#/components/schemas/VisualizationInteractionKind'
@@ -86421,11 +86733,11 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         label:
           type: string
           example: example
@@ -86433,8 +86745,8 @@ components:
           $ref: '#/components/schemas/VisualizationTone'
       example:
         label: example
-        maximum: !!float 1
-        minimum: !!float 1
+        maximum: 1
+        minimum: 1
         tone: neutral
     VisualizationKPITrendBinding:
       type: object
@@ -86556,11 +86868,11 @@ components:
             type: number
             format: double
           example:
-            - !!float 1
+            - 1
         zoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         padding:
           type: integer
           format: int32
@@ -86568,19 +86880,19 @@ components:
         minimumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         center:
-          - !!float 1
-        maximumZoom: !!float 1
-        minimumZoom: !!float 1
+          - 1
+        maximumZoom: 1
+        minimumZoom: 1
         mode: fit_data
         padding: 1
-        zoom: !!float 1
+        zoom: 1
     VisualizationMapCameraMode:
       type: string
       enum:
@@ -86640,22 +86952,22 @@ components:
         domainMinimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         domainMidpoint:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         domainMaximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         nullColor:
           type: string
           example: example
       example:
-        domainMaximum: !!float 1
-        domainMidpoint: !!float 1
-        domainMinimum: !!float 1
+        domainMaximum: 1
+        domainMidpoint: 1
+        domainMinimum: 1
         kind: sequential
         nullColor: example
         palette: example
@@ -86696,14 +87008,14 @@ components:
         radius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         intensity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        intensity: !!float 1
-        radius: !!float 1
+        intensity: 1
+        radius: 1
     VisualizationMapLabelDensity:
       type: string
       enum:
@@ -86726,14 +87038,14 @@ components:
         width:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         curvature:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        curvature: !!float 1
-        width: !!float 1
+        curvature: 1
+        width: 1
     VisualizationMapSizeScale:
       type: object
       required:
@@ -86743,24 +87055,24 @@ components:
         minimumRadius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumRadius:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         domainMinimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         domainMaximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        domainMaximum: !!float 1
-        domainMinimum: !!float 1
-        maximumRadius: !!float 1
-        minimumRadius: !!float 1
+        domainMaximum: 1
+        domainMinimum: 1
+        maximumRadius: 1
+        minimumRadius: 1
     VisualizationMapStroke:
       type: object
       required:
@@ -86774,15 +87086,15 @@ components:
         width:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color: example
-        opacity: !!float 1
-        width: !!float 1
+        opacity: 1
+        width: 1
     VisualizationMapStyleAsset:
       type: object
       required:
@@ -86834,18 +87146,18 @@ components:
         minimumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         bounds:
           type: array
           items:
             type: number
             format: double
           example:
-            - !!float 1
+            - 1
         labelAnchor:
           type: string
           example: example
@@ -86854,13 +87166,13 @@ components:
         archiveUrl: example
         attribution: example
         bounds:
-          - !!float 1
+          - 1
         glyphsUrl: example
         id: example
         labelAnchor: example
         license: example
-        maximumZoom: !!float 1
-        minimumZoom: !!float 1
+        maximumZoom: 1
+        minimumZoom: 1
         source: example
         spriteUrl: example
         styleDigest: example
@@ -86881,14 +87193,14 @@ components:
         minimumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximumZoom:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        maximumZoom: !!float 1
-        minimumZoom: !!float 1
+        maximumZoom: 1
+        minimumZoom: 1
     VisualizationMetadataBindings:
       type: object
       properties:
@@ -86980,15 +87292,15 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         category:
           dataset: example
           field: example
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
@@ -86998,12 +87310,12 @@ components:
           dataset: example
           field: example
         line:
-          curvature: !!float 1
-          width: !!float 1
+          curvature: 1
+          width: 1
         longitude:
           dataset: example
           field: example
-        opacity: !!float 1
+        opacity: 1
         order:
           dataset: example
           field: example
@@ -87012,8 +87324,8 @@ components:
           field: example
         stroke:
           color: example
-          opacity: !!float 1
-          width: !!float 1
+          opacity: 1
+          width: 1
         value:
           dataset: example
           field: example
@@ -87074,7 +87386,7 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         category:
           dataset: example
@@ -87086,9 +87398,9 @@ components:
           radius: 1
           showCount: true
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
@@ -87100,16 +87412,16 @@ components:
         longitude:
           dataset: example
           field: example
-        opacity: !!float 1
+        opacity: 1
         size:
-          domainMaximum: !!float 1
-          domainMinimum: !!float 1
-          maximumRadius: !!float 1
-          minimumRadius: !!float 1
+          domainMaximum: 1
+          domainMinimum: 1
+          maximumRadius: 1
+          minimumRadius: 1
         stroke:
           color: example
-          opacity: !!float 1
-          width: !!float 1
+          opacity: 1
+          width: 1
         value:
           dataset: example
           field: example
@@ -87207,12 +87519,12 @@ components:
         opacity:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         color:
-          domainMaximum: !!float 1
-          domainMidpoint: !!float 1
-          domainMinimum: !!float 1
+          domainMaximum: 1
+          domainMidpoint: 1
+          domainMinimum: 1
           kind: sequential
           nullColor: example
           palette: example
@@ -87226,11 +87538,11 @@ components:
           source: example
           url: example
         kind: example
-        opacity: !!float 1
+        opacity: 1
         stroke:
           color: example
-          opacity: !!float 1
-          width: !!float 1
+          opacity: 1
+          width: 1
     VisualizationReferenceLine:
       type: object
       required:
@@ -87398,24 +87710,24 @@ components:
         west:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         south:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         east:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         north:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        east: !!float 1
-        north: !!float 1
-        south: !!float 1
-        west: !!float 1
+        east: 1
+        north: 1
+        south: 1
+        west: 1
     VisualizationSpatialBoxSelection:
       type: object
       allOf:
@@ -87433,10 +87745,10 @@ components:
           $ref: '#/components/schemas/VisualizationSpatialBounds'
       example:
         bounds:
-          east: !!float 1
-          north: !!float 1
-          south: !!float 1
-          west: !!float 1
+          east: 1
+          north: 1
+          south: 1
+          west: 1
         kind: example
     VisualizationSpatialCoordinate:
       type: object
@@ -87447,14 +87759,14 @@ components:
         longitude:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         latitude:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
-        latitude: !!float 1
-        longitude: !!float 1
+        latitude: 1
+        longitude: 1
     VisualizationSpatialFieldMapping:
       type: object
       required:
@@ -87493,13 +87805,13 @@ components:
           items:
             $ref: '#/components/schemas/VisualizationSpatialCoordinate'
           example:
-            - latitude: !!float 1
-              longitude: !!float 1
+            - latitude: 1
+              longitude: 1
       example:
         kind: example
         points:
-          - latitude: !!float 1
-            longitude: !!float 1
+          - latitude: 1
+            longitude: 1
     VisualizationSpatialRadiusSelection:
       type: object
       allOf:
@@ -87519,13 +87831,13 @@ components:
         radiusMeters:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         center:
-          latitude: !!float 1
-          longitude: !!float 1
+          latitude: 1
+          longitude: 1
         kind: example
-        radiusMeters: !!float 1
+        radiusMeters: 1
     VisualizationSpatialScaleDomain:
       type: object
       required:
@@ -87537,20 +87849,20 @@ components:
         minimum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         maximum:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         total:
           type: number
           format: double
-          example: !!float 1
+          example: 1
       example:
         field: example
-        maximum: !!float 1
-        minimum: !!float 1
-        total: !!float 1
+        maximum: 1
+        minimum: 1
+        total: 1
     VisualizationSpatialSelectionGeometry:
       oneOf:
         - $ref: '#/components/schemas/VisualizationSpatialBoxSelection'
@@ -88039,12 +88351,12 @@ components:
         value:
           type: number
           format: double
-          example: !!float 1
+          example: 1
         tone:
           $ref: '#/components/schemas/VisualizationTone'
       example:
         tone: neutral
-        value: !!float 1
+        value: 1
     VisualizationTone:
       type: string
       enum:

--- a/pkg/apigen/emit/openapi/openapi_test.go
+++ b/pkg/apigen/emit/openapi/openapi_test.go
@@ -162,6 +162,7 @@ func TestEmitYAMLIncludesTypedCommandMetadata(t *testing.T) {
 
 	content, err := EmitYAML(doc, Options{})
 	require.NoError(t, err)
+	require.NotContains(t, string(content), "!!float")
 	var raw map[string]any
 	require.NoError(t, yaml.Unmarshal(content, &raw))
 	operation := raw["paths"].(map[string]any)["/workspaces/{workspace}/bindings/{binding}"].(map[string]any)["delete"].(map[string]any)
@@ -169,7 +170,7 @@ func TestEmitYAMLIncludesTypedCommandMetadata(t *testing.T) {
 		"owner": "CommandAPI.Access",
 		"audit": map[string]any{"required": true, "success_action": "binding.deleted", "guarantee": "transactional"},
 		"failures": []any{map[string]any{
-			"kind": "conflict", "status_code": float64(409), "code": "BINDING_CONFLICT", "public_detail": "The binding conflicts with its current state.",
+			"kind": "conflict", "status_code": 409, "code": "BINDING_CONFLICT", "public_detail": "The binding conflicts with its current state.",
 		}},
 		"additional_exposures": []any{"ui"},
 		"ui":                   map[string]any{"action_id": "workspace.access.binding.delete"},

--- a/pkg/apigen/go.mod
+++ b/pkg/apigen/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	go.yaml.in/yaml/v4 v4.0.0-rc.4
+	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/term v0.41.0
 )
 

--- a/pkg/apigen/go.sum
+++ b/pkg/apigen/go.sum
@@ -46,8 +46,8 @@ github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
-go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
+go.yaml.in/yaml/v4 v4.0.0-rc.6 h1:1h7H1ohdUh93/FyE4YaDa1Zh64K6VVbjF4K6WUxMtH4=
+go.yaml.in/yaml/v4 v4.0.0-rc.6/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=


### PR DESCRIPTION
## Problem

Dependabot PR #349 combines the YAML v4 release-candidate upgrade with unrelated Go and `kin-openapi` changes. YAML rc.6 also rewrites the checked-in OpenAPI snapshot by more than 3,200 lines, so accepting the grouped diff without understanding it would hide a material serialization change.

## Root cause

`go.yaml.in/yaml/v4` rc.6 refactors loading/dumping into staged resolver/constructor/representer pipelines. Integer-valued numeric metadata decoded through `any` is now preserved as `int` instead of rc.4's `float64`. rc.4 subsequently emitted integer-valued floats as explicit `!!float` scalars; rc.6 emits portable plain numeric scalars and uses a different line-width formatter.

## Solution

- upgrade only `go.yaml.in/yaml/v4` from rc.4 to rc.6
- update the typed command metadata expectation from `float64(409)` to `int(409)`
- add a regression assertion preventing explicit `!!float` tags
- intentionally regenerate `docs/api/openapi.yaml`

The 3,232-line snapshot diff consists of line wrapping plus 1,154 scalar conversions from explicit/string-like float representations to plain numeric values. A recursive object-graph comparison found no changed lexical value: every changed leaf retains the same numeric text and changes only from string/explicit-float representation to a number. This makes OpenAPI examples, limits, schema versions, and command status codes more portable to YAML/OpenAPI consumers.

## Tests added/updated

The OpenAPI emitter test now verifies numeric command metadata decodes as an integer and the emitted document contains no `!!float` tag.

## Verification performed

- focused OpenAPI emitter test before and after the expectation change
- full `task apigen:test`
- `go -C pkg/apigen vet ./...`
- `task --force generate`
- reviewed representative numeric, enum, schema metadata, command-extension, and formatting diffs
- classified all 1,154 semantic leaf changes; all are string/explicit-float to number with identical lexical values
- `task generated:check` after committing the intentional snapshot
- `task security:policy`
- `task security:dependencies`
- `git diff --check`

## Remaining limitations

GitHub CI and human review of the intentionally large generated OpenAPI snapshot are required before merge. This replaces only the YAML rc.6 portion of #349.
