### PR TITLE
build(deps): upgrade Electron to 44.0.0

### DIFF
--- a/desktop/bun.lock
+++ b/desktop/bun.lock
@@ -21,7 +21,7 @@
         "@types/debug": "4.1.13",
         "@types/node": "24.13.3",
         "brace-expansion": "file:vendor/brace-expansion-compat",
-        "electron": "43.2.0",
+        "electron": "44.0.0",
         "image-size": "file:vendor/image-size-next-compat",
         "minimatch-modern": "npm:minimatch@10.2.6",
         "node": "24.14.0",
@@ -239,7 +239,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "electron": ["electron@43.2.0", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA=="],
+    "electron": ["electron@44.0.0", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-FkTqPrFPZYljdPI5b7KORGsJTd6FgUQDefl5MrU3Xz9R87pAj9JLreIjDqcRN8hJIkFHIou0o8kKzvcpT9qiRQ=="],
 
     "electron-installer-common": ["electron-installer-common@0.10.4", "", { "dependencies": { "@electron/asar": "^3.2.5", "@malept/cross-spawn-promise": "^1.0.0", "debug": "^4.1.1", "fs-extra": "^9.0.0", "glob": "^7.1.4", "lodash": "^4.17.15", "parse-author": "^2.0.0", "semver": "^7.1.1", "tmp-promise": "^3.0.2" }, "optionalDependencies": { "@types/fs-extra": "^9.0.1" } }, "sha512-8gMNPXfAqUE5CfXg8RL0vXpLE9HAaPkgLXVoHE3BMUzogMWenf4LmwQ27BdCUrEhkjrKl+igs2IHJibclR3z3Q=="],
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -29,7 +29,7 @@
     "@tailwindcss/cli": "4.3.1",
     "@types/debug": "4.1.13",
     "@types/node": "24.13.3",
-    "electron": "43.2.0",
+    "electron": "44.0.0",
     "brace-expansion": "file:vendor/brace-expansion-compat",
     "image-size": "file:vendor/image-size-next-compat",
     "minimatch-modern": "npm:minimatch@10.2.6",

--- a/desktop/release-policy.json
+++ b/desktop/release-policy.json
@@ -23,9 +23,9 @@
     }
   },
   "runtime": {
-    "electron": "43.2.0",
-    "electronMajor": 43,
-    "chromium": "150.0.7871.129",
+    "electron": "44.0.0",
+    "electronMajor": 44,
+    "chromium": "152.0.7977.54",
     "node": "24.14.0",
     "forge": "8.0.0-alpha.9",
     "bun": "1.3.14"
@@ -36,7 +36,7 @@
     "channel": "stable",
     "productName": "LeapView",
     "applicationId": "dev.leapview.desktop",
-    "electronMajor": 43,
+    "electronMajor": 44,
     "windowsPackageId": "leapview"
   },
   "supportMatrix": [

--- a/desktop/scripts/release-evidence.test.mjs
+++ b/desktop/scripts/release-evidence.test.mjs
@@ -20,7 +20,7 @@ const packageDocument = {
   productName: "LeapView",
   version: "0.1.0",
   devDependencies: {
-    electron: "43.2.0",
+    electron: "44.0.0",
     node: "24.14.0",
     "@electron-forge/cli": "8.0.0-alpha.9",
   },
@@ -51,9 +51,9 @@ const policy = {
     },
   },
   runtime: {
-    electron: "43.2.0",
-    electronMajor: 43,
-    chromium: "150.0.7871.129",
+    electron: "44.0.0",
+    electronMajor: 44,
+    chromium: "152.0.7977.54",
     node: "24.14.0",
     forge: "8.0.0-alpha.9",
     bun: "1.3.14",
@@ -64,7 +64,7 @@ const policy = {
     channel: "stable",
     productName: "LeapView",
     applicationId: "dev.leapview.desktop",
-    electronMajor: 43,
+    electronMajor: 44,
     windowsPackageId: "leapview",
   },
   supportMatrix: [
@@ -121,8 +121,8 @@ const packageVerification = {
   packageFormat: "dmg",
   asarOnly: true,
   runtime: {
-    electron: "43.2.0",
-    chromium: "150.0.7871.129",
+    electron: "44.0.0",
+    chromium: "152.0.7977.54",
     node: "24.14.0",
   },
   fuses: {
@@ -150,7 +150,7 @@ const packageVerification = {
     channel: "stable",
     productName: "LeapView",
     applicationId: "dev.leapview.desktop",
-    electronMajor: 43,
+    electronMajor: 44,
     delivery: "electron-auto-updater",
   },
   installer: {
@@ -175,7 +175,7 @@ test("release policy pins the supported Electron line and packaging contract", (
   );
 
   const mutable = structuredClone(packageDocument);
-  mutable.devDependencies.electron = "^43.2.0";
+  mutable.devDependencies.electron = "^44.0.0";
   assert.throws(
     () => validateReleasePolicy(policy, mutable),
     /exact Electron version/,
@@ -188,9 +188,9 @@ test("release policy pins the supported Electron line and packaging contract", (
         createdAt: "2026-07-29T12:00:00.000Z",
         files: [],
         lock: {
-          workspaces: { "": { devDependencies: { electron: "^43.0.0" } } },
+          workspaces: { "": { devDependencies: { electron: "^44.0.0" } } },
           packages: {
-            electron: ["electron@^43.0.0", "", {}, "sha512-ZWx1Y3Ryb24="],
+            electron: ["electron@^44.0.0", "", {}, "sha512-ZWx1Y3Ryb24="],
           },
         },
         packageDocument,
@@ -206,14 +206,14 @@ test("SPDX document covers every locked dependency and packaged runtime file", (
     workspaces: {
       "": {
         devDependencies: {
-          electron: "43.2.0",
+          electron: "44.0.0",
           rxjs: "7.8.2",
         },
       },
     },
     packages: {
       electron: [
-        "electron@43.2.0",
+        "electron@44.0.0",
         "",
         { dependencies: { "@electron/get": "^3.0.0" } },
         "sha512-ZWx1Y3Ryb24=",

--- a/desktop/src/diagnostics.test.ts
+++ b/desktop/src/diagnostics.test.ts
@@ -20,8 +20,8 @@ import {
 
 const environment: DiagnosticEnvironment = {
   applicationVersion: "0.1.0",
-  electronVersion: "43.2.0",
-  chromiumVersion: "150.0.7339.3",
+  electronVersion: "44.0.0",
+  chromiumVersion: "152.0.7977.54",
   nodeVersion: "24.14.0",
   platform: "darwin",
   osRelease: "25.5.0",

--- a/desktop/src/update-coordinator.test.ts
+++ b/desktop/src/update-coordinator.test.ts
@@ -64,7 +64,7 @@ function coordinator(options: {
       platform: options.platform ?? "win32",
       architecture: "x64",
       applicationVersion: "1.2.3",
-      electronVersion: "43.2.0",
+      electronVersion: "44.0.0",
       packaged: true,
       releaseChannel: "stable",
     },

--- a/desktop/src/updater.test.ts
+++ b/desktop/src/updater.test.ts
@@ -47,7 +47,7 @@ const supportedRuntime = {
   platform: "win32" as const,
   architecture: "x64",
   applicationVersion: "1.2.3",
-  electronVersion: "43.2.0",
+  electronVersion: "44.0.0",
   packaged: true,
   releaseChannel: "stable" as const,
 };
@@ -96,7 +96,7 @@ describe("desktopUpdateFeedURL", () => {
     expect(
       desktopUpdateFeedURL({
         ...supportedRuntime,
-        electronVersion: "44.0.0",
+        electronVersion: "43.2.0",
       }),
     ).toBeNull();
     expect(

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -1,4 +1,4 @@
-export const DESKTOP_UPDATE_ELECTRON_MAJOR = 43;
+export const DESKTOP_UPDATE_ELECTRON_MAJOR = 44;
 export const DESKTOP_UPDATE_ORIGIN = "https://releases.leapview.dev";
 export const DESKTOP_UPDATE_CHANNEL = "stable";
 


### PR DESCRIPTION
## Problem

Dependabot PR #353 combines eighteen desktop dependency updates, including the Electron 44 runtime migration, which makes failures difficult to attribute and review.

## Root cause

Electron 44 changes the embedded Chromium runtime and the application update compatibility boundary. The grouped PR changed only package metadata and did not migrate LeapView release-policy evidence or its fail-closed updater major guard.

## Solution

- Upgrade Electron from 43.2.0 to 44.0.0 in the desktop manifest and lockfile.
- Pin Chromium 152.0.7977.54 in the release policy, matching Electron 44.0.0.
- Move the release-evidence, diagnostics, update coordinator, and updater compatibility contracts to Electron major 44.
- Retain an explicit negative test proving Electron 43 is rejected by the Electron 44 update feed.

Electron 44 breaking changes were reviewed against the repository: LeapView already requires macOS 13+, ships only x64/arm64, does not use Unity Linux builds, renderer clipboard APIs, removed login-item fields, or ANGLE sidecar assumptions. The Electron 44 malicious-instance proof is already covered by merged PR #348.

## Tests added/updated

Updated exact runtime and fail-closed compatibility fixtures for release evidence, diagnostics, and desktop updates.

## Verification performed

- `task desktop:test`: passed (141 Bun tests; 45 Node tests passed and one existing macOS-only test skipped; desktop build passed).
- `task desktop:audit`: no vulnerabilities found.
- `task security:policy`: passed.
- `task desktop:package`: Forge assembly, native dependency preparation, finalization, and post-package hooks passed. Local startup verification then stopped because this Linux host lacks `libgtk-3.so.0`.

## Remaining limitations

The local environment cannot launch the packaged Electron binary without GTK 3. GitHub desktop packaging jobs remain the required multi-platform qualification and this PR is not merge-ready until those checks pass.

Replacement for the Electron portion of #353.