### PR TITLE
Keep idle page streams alive without duplicate chat bootstrap

### DIFF
--- a/internal/admin/http/handler.go
+++ b/internal/admin/http/handler.go
@@ -596,7 +596,7 @@ func (h Handler) patchAndWait(w nethttp.ResponseWriter, r *nethttp.Request, patc
 	if err := updates.Patch(patch); err != nil {
 		return
 	}
-	<-r.Context().Done()
+	updates.Wait(r.Context())
 }
 
 func (h Handler) layout(r *nethttp.Request) webpage.Provider {

--- a/internal/agent/http/chat.go
+++ b/internal/agent/http/chat.go
@@ -57,13 +57,11 @@ type ChatTurnExecution struct {
 }
 
 func (h *Handler) Chat(w nethttp.ResponseWriter, r *nethttp.Request) {
-	scope := h.chatScope(r)
-	h.renderChat(w, r, "list", h.chatSignal(r.Context(), scope, "", "", false))
+	h.renderChat(w, r, "list", ui.ChatViewState{})
 }
 
 func (h *Handler) ChatNew(w nethttp.ResponseWriter, r *nethttp.Request) {
-	scope := h.chatScope(r)
-	h.renderChat(w, r, "new", h.chatSignal(r.Context(), scope, "", "", false))
+	h.renderChat(w, r, "new", ui.ChatViewState{})
 }
 
 func (h *Handler) ChatConversation(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -74,14 +72,14 @@ func (h *Handler) ChatConversation(w nethttp.ResponseWriter, r *nethttp.Request)
 		return
 	}
 	if h.options.Service == nil || !h.options.Service.Enabled() {
-		h.renderChat(w, r, "conversation", h.chatSignal(r.Context(), scope, "", "", false))
+		h.renderChat(w, r, "conversation", ui.ChatViewState{})
 		return
 	}
 	if scope.PrincipalID == "" {
 		nethttp.Error(w, "chat requires an authenticated principal", nethttp.StatusUnauthorized)
 		return
 	}
-	state, err := h.options.Service.ConversationTranscriptState(r.Context(), scope, conversationID)
+	_, err := h.options.Service.GetConversation(r.Context(), scope, conversationID)
 	if err != nil {
 		nethttp.Error(w, err.Error(), statusForNotFound(err))
 		return
@@ -89,7 +87,7 @@ func (h *Handler) ChatConversation(w nethttp.ResponseWriter, r *nethttp.Request)
 	if h.options.QueueMissingTitle != nil {
 		h.options.QueueMissingTitle(r.Context(), scope, conversationID, chatClientID(r))
 	}
-	h.renderChat(w, r, "conversation", h.chatSignalWith(r.Context(), scope, conversationID, state.Transcript, state.Artifacts, "", h.options.Service.ConversationRunning(conversationID)))
+	h.renderChat(w, r, "conversation", ui.ChatViewState{Agent: ui.ChatSignal{ActiveConversationID: conversationID}})
 }
 
 // ChatRestore is the Datastar adapter for restoring an embedded chat. The
@@ -199,7 +197,7 @@ func (h *Handler) ChatUpdates(w nethttp.ResponseWriter, r *nethttp.Request) {
 		return
 	}
 	if h.options.Service == nil || !h.options.Service.Enabled() || scope.PrincipalID == "" || h.options.Broker == nil {
-		<-r.Context().Done()
+		updates.Wait(r.Context())
 		return
 	}
 	_ = updates.Forward(r.Context(), h.options.Broker, streamID)

--- a/internal/agent/http/chat_active_test.go
+++ b/internal/agent/http/chat_active_test.go
@@ -151,6 +151,43 @@ func TestChatConversationQueuesTitleRepairOnlyAfterOwnedRestore(t *testing.T) {
 	}
 }
 
+func TestChatConversationDefersTranscriptAndConversationBootstrapToUpdatesStream(t *testing.T) {
+	fixture := newActiveChatFixture(t)
+	conversation, err := fixture.service.CreateConversation(t.Context(), agent.Scope{PrincipalID: fixture.owner}, "Owned")
+	if err != nil {
+		t.Fatal(err)
+	}
+	chatSignalCalls := 0
+	chatSignalWithCalls := 0
+	handler := NewHandler(Options{
+		Service: fixture.service, CurrentPrincipal: fixture.ownerRequest,
+		ChatSignal: func(context.Context, agent.Scope, string, string, bool) ui.ChatViewState {
+			chatSignalCalls++
+			return ui.ChatViewState{}
+		},
+		ChatSignalWith: func(context.Context, agent.Scope, string, []agent.ChatTranscriptItem, agent.ChatArtifactSignals, string, bool) ui.ChatViewState {
+			chatSignalWithCalls++
+			return ui.ChatViewState{}
+		},
+	})
+	router := chi.NewRouter()
+	router.Get("/chats/{conversation}", handler.ChatConversation)
+
+	request := httptest.NewRequest(http.MethodGet, "/chats/"+conversation.ID, nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("conversation status=%d body=%s", response.Code, response.Body.String())
+	}
+	if chatSignalCalls != 0 || chatSignalWithCalls != 0 {
+		t.Fatalf("page request bootstrapped chat state: ChatSignal=%d ChatSignalWith=%d", chatSignalCalls, chatSignalWithCalls)
+	}
+	if !strings.Contains(response.Body.String(), "conversation="+conversation.ID) {
+		t.Fatalf("page stream URL does not retain active conversation: %s", response.Body.String())
+	}
+}
+
 func TestChatRestoreStreamsOwnedStateAndClearsUnauthorizedState(t *testing.T) {
 	fixture := newActiveChatFixture(t)
 	owned, err := fixture.service.CreateConversation(t.Context(), agent.Scope{PrincipalID: fixture.owner}, "Owned")

--- a/internal/dashboard/http/builder.go
+++ b/internal/dashboard/http/builder.go
@@ -240,7 +240,7 @@ func (h Handler) DashboardBuilderUpdates(w nethttp.ResponseWriter, r *nethttp.Re
 	if err := updates.Patch(ui.DashboardBuilderBootstrapSignals(h.dashboardBuilderEnvelopeWithPreviewForProject(r.Context(), project, actorID, builder))); err != nil {
 		return
 	}
-	<-r.Context().Done()
+	updates.Wait(r.Context())
 }
 
 // DashboardBuilderCommand accepts the bounded builder intents and routes them

--- a/internal/platform/web/transport/page_stream.go
+++ b/internal/platform/web/transport/page_stream.go
@@ -62,8 +62,12 @@ func PatchOnce(w http.ResponseWriter, r *http.Request, patch pagestream.SignalPa
 }
 
 func PatchAndWait(w http.ResponseWriter, r *http.Request, patch pagestream.SignalPatch) {
-	if err := PatchOnce(w, r, patch); err != nil {
+	if _, err := EnsureClientID(w, r); err != nil {
 		return
 	}
-	<-r.Context().Done()
+	updates := pagestream.NewSignalStream(w, r)
+	if err := updates.Patch(patch); err != nil {
+		return
+	}
+	updates.Wait(r.Context())
 }

--- a/pkg/pagestream/README.md
+++ b/pkg/pagestream/README.md
@@ -24,4 +24,6 @@ merely because Datastar provides them.
 The broker never blocks publishers or silently drops an individual patch. Each
 subscription has a configurable pending limit (256 by default); reaching it
 closes that slow subscription so the browser reconnects and rebuilds from
-server-owned state.
+server-owned state. Persistent streams send an SSE comment every 25 seconds so
+quiet pages remain live through LeapView's stream-idle guard and ordinary HTTP
+proxy idle windows without producing a Datastar event.

--- a/pkg/pagestream/stream.go
+++ b/pkg/pagestream/stream.go
@@ -122,6 +122,9 @@ func (s SignalStream) forwardUpdates(ctx context.Context, updates <-chan SignalP
 			return nil
 		case <-ticker.C:
 			if err := s.keepAlive(); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
 				return err
 			}
 		case patch, ok := <-updates:

--- a/pkg/pagestream/stream.go
+++ b/pkg/pagestream/stream.go
@@ -3,22 +3,34 @@ package pagestream
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/starfederation/datastar-go/datastar"
 )
 
 var errMissingForwardBroker = errors.New("pagestream: broker is required")
 
+// keepAliveInterval stays below both LeapView's stream idle deadline and the
+// common one-minute idle timeout used by HTTP proxies. SSE comments are
+// deliberately invisible to Datastar while still proving the connection is
+// live end to end.
+const keepAliveInterval = 25 * time.Second
+
 // SignalStream is one long-lived Datastar SSE response that emits signal
 // patches.
 type SignalStream struct {
 	sse *datastar.ServerSentEventGenerator
+	w   http.ResponseWriter
+	mu  *sync.Mutex
 }
 
 // NewSignalStream opens a Datastar SSE signal stream for the request.
 func NewSignalStream(w http.ResponseWriter, r *http.Request) SignalStream {
-	return SignalStream{sse: datastar.NewSSE(w, r)}
+	return SignalStream{sse: datastar.NewSSE(w, r), w: w, mu: &sync.Mutex{}}
 }
 
 // Redirect emits a Datastar redirect response for short-lived command handlers.
@@ -41,7 +53,44 @@ func (s SignalStream) writeForwarded(patch SignalPatch) error {
 	if len(patch) == 0 {
 		return nil
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.sse.MarshalAndPatchSignals(patch)
+}
+
+func (s SignalStream) keepAlive() error {
+	if s.sse.IsClosed() {
+		return s.sse.Context().Err()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := io.WriteString(s.w, ": keepalive\n\n"); err != nil {
+		return fmt.Errorf("write SSE keepalive: %w", err)
+	}
+	if err := http.NewResponseController(s.w).Flush(); err != nil {
+		return fmt.Errorf("flush SSE keepalive: %w", err)
+	}
+	return nil
+}
+
+// Wait keeps an otherwise idle stream alive until ctx is canceled.
+func (s SignalStream) Wait(ctx context.Context) {
+	s.wait(ctx, keepAliveInterval)
+}
+
+func (s SignalStream) wait(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.keepAlive(); err != nil {
+				return
+			}
+		}
+	}
 }
 
 // Forward relays signal patches published to streamID until ctx is canceled.
@@ -61,10 +110,20 @@ func (s SignalStream) Forward(ctx context.Context, broker *Broker, streamID stri
 // subscribe before sending bootstrap state so no refresh event can be lost in
 // the bootstrap-to-forward handoff.
 func (s SignalStream) ForwardUpdates(ctx context.Context, updates <-chan SignalPatch) error {
+	return s.forwardUpdates(ctx, updates, keepAliveInterval)
+}
+
+func (s SignalStream) forwardUpdates(ctx context.Context, updates <-chan SignalPatch, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-ticker.C:
+			if err := s.keepAlive(); err != nil {
+				return err
+			}
 		case patch, ok := <-updates:
 			if !ok {
 				return nil

--- a/pkg/pagestream/stream_test.go
+++ b/pkg/pagestream/stream_test.go
@@ -103,6 +103,62 @@ func TestSignalStreamForwardRelaysBrokerPatchesAndCleansUp(t *testing.T) {
 	}
 }
 
+func TestSignalStreamWaitSendsKeepAlivesUntilCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/updates", nil).WithContext(ctx)
+	rec := newSynchronizedRecorder()
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		NewSignalStream(rec, req).wait(ctx, time.Millisecond)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for !strings.Contains(rec.BodyString(), ": keepalive\n\n") && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !strings.Contains(rec.BodyString(), ": keepalive\n\n") {
+		t.Fatal("idle stream did not send an SSE keepalive comment")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("idle stream did not stop after cancellation")
+	}
+}
+
+func TestSignalStreamForwardUpdatesKeepsQuietSubscriptionAlive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/updates", nil).WithContext(ctx)
+	rec := newSynchronizedRecorder()
+	done := make(chan error, 1)
+
+	go func() {
+		done <- NewSignalStream(rec, req).forwardUpdates(ctx, make(chan SignalPatch), time.Millisecond)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for !strings.Contains(rec.BodyString(), ": keepalive\n\n") && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !strings.Contains(rec.BodyString(), ": keepalive\n\n") {
+		t.Fatal("quiet forwarded stream did not send an SSE keepalive comment")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("forward updates: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("forwarded stream did not stop after cancellation")
+	}
+}
+
 type synchronizedRecorder struct {
 	*httptest.ResponseRecorder
 	mu sync.Mutex

--- a/pkg/pagestream/stream_test.go
+++ b/pkg/pagestream/stream_test.go
@@ -174,6 +174,12 @@ func (r *synchronizedRecorder) Write(p []byte) (int, error) {
 	return r.ResponseRecorder.Write(p)
 }
 
+func (r *synchronizedRecorder) WriteString(value string) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ResponseRecorder.WriteString(value)
+}
+
 func (r *synchronizedRecorder) WriteHeader(statusCode int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
## Summary

- send invisible SSE comment keepalives every 25 seconds on quiet persistent page streams
- serialize keepalives and Datastar signal patches so concurrent writes cannot interleave
- move idle patch-and-wait handlers onto the keepalive-aware stream lifecycle
- defer chat transcript bootstrap to the canonical updates stream instead of loading it during page-shell rendering

## Validation

- `go test ./pkg/pagestream ./internal/platform/web/transport ./internal/admin/http ./internal/agent/http ./internal/dashboard/http`
- `task qa:ui-framework` (13 browser routes and 12 desktop/compact visual baselines)
- focused desktop table width and compact horizontal-spacing DOM checks
- focused table-controller and QA configuration tests
- `git diff --check`
