### PR TITLE
build(deps): refresh runtime image digests

### DIFF
--- a/.security/coverage.yaml
+++ b/.security/coverage.yaml
@@ -72,7 +72,7 @@ surfaces:
     updater: {ecosystem: docker, directory: /}
     scanners: [trivy]
     images:
-      - debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+      - debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
       - golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437
       - node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989
       - oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
@@ -81,7 +81,7 @@ surfaces:
     updater: {ecosystem: docker, directory: /}
     scanners: [trivy]
     images:
-      - gcr.io/distroless/static-debian12:nonroot@sha256:aef9602f8710ec12bde19d593fed1f76c708531bb7aba205110f1029786ead7b
+      - gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab
       - golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437
       - node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989
       - oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,id=leapview-go-mod,target=/go/pkg/mod,from=go-deps,source=/go/pkg/mod,sharing=locked \
     go run ./internal/app/tools/extensionsupply --out /out/extension-supply
 
-FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df AS runtime
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171 AS runtime
 
 ARG BUILD_VERSION=development
 ARG BUILD_REVISION=unknown

--- a/Dockerfile.site
+++ b/Dockerfile.site
@@ -62,7 +62,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
       -ldflags="-s -w -X main.buildRevision=${BUILD_REVISION}" \
       -o /out/leapview-site ./cmd/leapview-site
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:aef9602f8710ec12bde19d593fed1f76c708531bb7aba205110f1029786ead7b AS runtime
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab AS runtime
 
 ARG BUILD_VERSION=dev
 ARG BUILD_REVISION=unknown


### PR DESCRIPTION
## Problem

Dependabot PR #375 combines four major build-toolchain upgrades with two runtime-image digest refreshes, obscuring the lowest-risk patch-only image changes.

## Root cause

The Debian and distroless tags are intentionally mutable upstream while LeapView pins immutable multi-platform index digests. Their refreshed digests must also be mirrored in the explicit security coverage inventory.

## Solution

- Refresh `debian:bookworm-slim` to index digest `sha256:88200866…4171` in the application runtime.
- Refresh `gcr.io/distroless/static-debian12:nonroot` to `sha256:afa5c872…f7ab` in the site runtime.
- Keep `.security/coverage.yaml` exactly synchronized.
- Leave Node, Go, and Bun tags/digests unchanged in this PR.

## Tests added/updated

No product behavior changes. Existing architecture and security policy tests enforce the pinned runtime contracts.

## Verification performed

- Docker Buildx registry inspection verified both exact index digests and their amd64/arm64 manifests.
- `go test ./internal/platform/architecture`: passed.
- `task security:policy`: passed.

## Remaining limitations

The local environment has no usable Docker daemon, so GitHub container build and scan jobs remain required before merge. This PR is not merge-ready until they pass.

Replacement for the Debian and distroless digest portion of #375.