### PR TITLE
build(deps): upgrade container builds to Node 26

### DIFF
--- a/.security/coverage.yaml
+++ b/.security/coverage.yaml
@@ -74,7 +74,7 @@ surfaces:
     images:
       - debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
       - golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437
-      - node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989
+      - node:26-bookworm@sha256:9f94d34c787165dca03b74e5bf9c3bf90e8de79b19aa3d87fe1fa1694bf75c89
       - oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
   - path: Dockerfile.site
     kind: dockerfile
@@ -83,7 +83,7 @@ surfaces:
     images:
       - gcr.io/distroless/static-debian12:nonroot@sha256:aef9602f8710ec12bde19d593fed1f76c708531bb7aba205110f1029786ead7b
       - golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437
-      - node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989
+      - node:26-bookworm@sha256:9f94d34c787165dca03b74e5bf9c3bf90e8de79b19aa3d87fe1fa1694bf75c89
       - oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
   - path: deploy/compose/qualification/Dockerfile.authoring-client
     kind: dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
 
-FROM node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989 AS node
+FROM node:26-bookworm@sha256:9f94d34c787165dca03b74e5bf9c3bf90e8de79b19aa3d87fe1fa1694bf75c89 AS node
 
 # A caller may override this empty stage with a named build context containing
 # basemap.pmtiles. The generator verifies the pinned digest before accepting it.

--- a/Dockerfile.site
+++ b/Dockerfile.site
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
 
-FROM node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989 AS node
+FROM node:26-bookworm@sha256:9f94d34c787165dca03b74e5bf9c3bf90e8de79b19aa3d87fe1fa1694bf75c89 AS node
 
 FROM golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437 AS go-deps
 WORKDIR /src

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2433,7 +2433,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	}
 	text := string(dockerfile)
 	for _, want := range []string{
-		"FROM node:24-bookworm@sha256:",
+		"FROM node:26-bookworm@sha256:",
 		"FROM golang:1.25.14-bookworm@sha256:",
 		"AS go-deps",
 		"FROM go-deps AS sourcegen",
@@ -2648,7 +2648,7 @@ func TestPublicSiteProductionContainerContractExists(t *testing.T) {
 	}
 	text := string(dockerfile)
 	for _, want := range []string{
-		"FROM node:24-bookworm@sha256:",
+		"FROM node:26-bookworm@sha256:",
 		"FROM golang:1.25.14-bookworm@sha256:",
 		"./scripts/generate_build_sources.sh",
 		"go run -tags=duckdb_arrow ./internal/app/tools/ducklakeprepare",


### PR DESCRIPTION
## Problem

Dependabot PR #375 combines the Node 26 image with unrelated Bun, Go, and runtime digest changes. The Node major affects every `node` invocation inside both web build stages.

## Root cause

The production Dockerfiles copy Node from an exact upstream stage into Bun stages for code generation, Playwright preparation, TypeScript tooling, and site builds. The image reference is mirrored in security coverage and asserted by architecture tests.

## Solution

- Upgrade both Node stages from `node:24-bookworm` to `node:26-bookworm` at immutable index digest `sha256:9f94d34c…5c89`.
- Synchronize `.security/coverage.yaml` and exact architecture contracts.
- Leave Bun, Go, and runtime images unchanged in this PR.
- Keep project runtime declarations unchanged; this PR changes only the container build toolchain.

## Tests added/updated

Updated exact Dockerfile architecture expectations for both production images.

## Verification performed

- Docker Buildx verified the exact Node image index and linux/amd64 and linux/arm64 manifests.
- Official Node binary check: `v26.8.1`.
- `task ci:prepare` with Node 26.8.1 first in `PATH`: passed.
- Core frontend/browser contract under Node 26.8.1: passed, including watchdog process-group behavior, TypeScript checks, application-shell browser tests, and production asset tests.
- Public-site browser contract under Node 26.8.1: passed (51 tests).
- `go test ./internal/platform/architecture`: passed.
- `task security:policy`: passed.

## Remaining limitations

Node 26 is the upstream Current line until October 2026. The local environment has no usable Docker daemon, so GitHub image builds and scans remain required before merge; maintainers may also choose to defer until Node 26 reaches LTS.

Replacement for the Node portion of #375.