### PR TITLE
build(deps): upgrade container builds to Go 1.27

### DIFF
--- a/.security/coverage.yaml
+++ b/.security/coverage.yaml
@@ -73,7 +73,7 @@ surfaces:
     scanners: [trivy]
     images:
       - debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
-      - golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437
+      - golang:1.27.0-bookworm@sha256:ded31c68586d2e49e760acc2e65a884b23d032e9bbbed0ae0c55abd3fcaf4452
       - node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989
       - oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
   - path: Dockerfile.site
@@ -82,7 +82,7 @@ surfaces:
     scanners: [trivy]
     images:
       - gcr.io/distroless/static-debian12:nonroot@sha256:aef9602f8710ec12bde19d593fed1f76c708531bb7aba205110f1029786ead7b
-      - golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437
+      - golang:1.27.0-bookworm@sha256:ded31c68586d2e49e760acc2e65a884b23d032e9bbbed0ae0c55abd3fcaf4452
       - node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989
       - oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
   - path: deploy/compose/qualification/Dockerfile.authoring-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930
 # basemap.pmtiles. The generator verifies the pinned digest before accepting it.
 FROM scratch AS mapassetseed
 
-FROM golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437 AS go-deps
+FROM golang:1.27.0-bookworm@sha256:ded31c68586d2e49e760acc2e65a884b23d032e9bbbed0ae0c55abd3fcaf4452 AS go-deps
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/Dockerfile.site
+++ b/Dockerfile.site
@@ -2,7 +2,7 @@
 
 FROM node:24-bookworm@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989 AS node
 
-FROM golang:1.25.14-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437 AS go-deps
+FROM golang:1.27.0-bookworm@sha256:ded31c68586d2e49e760acc2e65a884b23d032e9bbbed0ae0c55abd3fcaf4452 AS go-deps
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2434,7 +2434,7 @@ func TestProductionContainerContractExists(t *testing.T) {
 	text := string(dockerfile)
 	for _, want := range []string{
 		"FROM node:24-bookworm@sha256:",
-		"FROM golang:1.25.14-bookworm@sha256:",
+		"FROM golang:1.27.0-bookworm@sha256:",
 		"AS go-deps",
 		"FROM go-deps AS sourcegen",
 		"COPY --from=node /usr/local/bin/node /usr/local/bin/node",
@@ -2649,7 +2649,7 @@ func TestPublicSiteProductionContainerContractExists(t *testing.T) {
 	text := string(dockerfile)
 	for _, want := range []string{
 		"FROM node:24-bookworm@sha256:",
-		"FROM golang:1.25.14-bookworm@sha256:",
+		"FROM golang:1.27.0-bookworm@sha256:",
 		"./scripts/generate_build_sources.sh",
 		"go run -tags=duckdb_arrow ./internal/app/tools/ducklakeprepare",
 		"go run -tags=duckdb_arrow ./internal/app/tools/visualdocgen",
@@ -2660,7 +2660,7 @@ func TestPublicSiteProductionContainerContractExists(t *testing.T) {
 		"RUN bun install --frozen-lockfile --no-cache",
 		"bun scripts/generate_visualization_validator.ts",
 		"bun run build:site",
-		"FROM golang:1.25.14-bookworm@sha256:",
+		"FROM golang:1.27.0-bookworm@sha256:",
 		"CGO_ENABLED=0 go build -trimpath",
 		"./cmd/leapview-site",
 		"FROM gcr.io/distroless/static-debian12:nonroot@sha256:",


### PR DESCRIPTION
## Problem

Dependabot PR #375 groups unrelated container-image updates and changes only the Dockerfiles, leaving the security coverage inventory and architecture pin contracts stale. The Go 1.27 toolchain change also needs validation independently from the runtime-image, Bun, and Node updates.

## Root cause

The grouped update does not model repository-owned image metadata and validation contracts as part of each dependency change.

## Solution

- Pin the build stages in `Dockerfile` and `Dockerfile.site` to `golang:1.27.0-bookworm@sha256:ded31c68586d2e49e760acc2e65a884b23d032e9bbbed0ae0c55abd3fcaf4452`.
- Synchronize the exact references in `.security/coverage.yaml`.
- Update the architecture contract to enforce Go 1.27 in both production Dockerfiles.
- Keep `go.mod` at its existing Go 1.25 language/toolchain policy; this PR changes the production container build toolchain, not the project minimum supported toolchain.

## Tests added/updated

- Updated the existing production-container architecture assertions for the new exact Go image family.

## Verification performed

- Verified the pinned manifest list and linux/amd64 + linux/arm64 images with Docker Buildx.
- Ran `task ci:prepare` using Go 1.27.0; production and site generation/builds passed.
- Ran the complete `task ci:lane:go` using Go 1.27.0; all APIGen, TypeSpec, package, application-shard, architecture, and external-contract tests passed.
- Ran `task security:policy`; coverage, exceptions, and Dependabot updater coverage passed.
- Ran `git diff --check`.

## Remaining limitations

- Local validation used `-buildvcs=false` because the copied APIGen example workspace lives outside a Git checkout in this sandbox; GitHub CI remains the authoritative VCS-stamping check.
- This PR intentionally excludes the runtime digest, Bun 1.4, and Node 26 changes, which have separate replacement PRs for #375.

Replaces the Go 1.27 portion of #375.