### PR TITLE
build(deps): migrate frontend to TypeScript 7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",
+        "@babel/parser": "8.0.4",
         "@fontsource-variable/inter": "^5.2.8",
         "@playwright/test": "^1.61.1",
         "@primer/primitives": "11.10.0",
@@ -41,7 +42,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "tailwindcss": "4.3.3",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
       },
     },
   },
@@ -62,7 +63,15 @@
 
     "@axe-core/playwright": ["@axe-core/playwright@4.13.0", "", { "dependencies": { "axe-core": "~4.13.0" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg=="],
 
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
+
+    "@babel/parser": ["@babel/parser@8.0.4", "", { "dependencies": { "@babel/types": "^8.0.4" }, "bin": "./bin/babel-parser.js" }, "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g=="],
+
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
@@ -305,6 +314,46 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
 
@@ -722,7 +771,7 @@
 
     "tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "uc.micro": ["uc.micro@3.0.0", "", {}, "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw=="],
 

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -3732,7 +3732,7 @@ func TestLeapViewDeclaresGitHubHostedCIContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read package manifest: %v", err)
 	}
-	if !strings.Contains(string(packageJSON), `"typescript": "5.9.3"`) {
+	if !strings.Contains(string(packageJSON), `"typescript": "7.0.2"`) {
 		t.Fatal("LeapView must pin the TypeScript compiler used by its remote test contract")
 	}
 	setup, err := os.ReadFile(filepath.Join(root, ".github", "actions", "setup-ci", "action.yml"))

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",
+    "@babel/parser": "8.0.4",
     "@fontsource-variable/inter": "^5.2.8",
     "@playwright/test": "^1.61.1",
     "@primer/primitives": "11.10.0",
@@ -81,7 +82,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tailwindcss": "4.3.3",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   },
   "dependencies": {
     "@shikijs/monaco": "^4.3.0",

--- a/scripts/check_ui_command_boundaries.test.ts
+++ b/scripts/check_ui_command_boundaries.test.ts
@@ -30,4 +30,12 @@ describe('UI command boundary analysis', () => {
 	  const violations = inspectUICommandSource('web/components/example.ts', `fetch('/things', options)`)
 	  expect(violations).toHaveLength(1)
 	})
+
+  test('fails closed when TypeScript syntax cannot be parsed', () => {
+    expect(inspectUICommandSource('web/components/example.ts', 'const value: = 1')).toEqual([{
+      file: 'web/components/example.ts',
+      line: 1,
+      message: 'UI boundary source could not be parsed safely',
+    }])
+  })
 })

--- a/scripts/check_ui_command_boundaries.ts
+++ b/scripts/check_ui_command_boundaries.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript'
+import { parse } from '@babel/parser'
 import { relative, resolve } from 'node:path'
 import { readFileSync } from 'node:fs'
 
@@ -8,88 +8,166 @@ export type UICommandBoundaryViolation = {
   message: string
 }
 
+type ASTNode = {
+  type: string
+  loc?: { start: { line: number } } | null
+  [key: string]: unknown
+}
+
 const mutationMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
 export function inspectUICommandSource(file: string, source: string, generatedUIOperations?: ReadonlySet<string>): UICommandBoundaryViolation[] {
-  const parsed = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true)
-  const violations: UICommandBoundaryViolation[] = []
-  const report = (node: ts.Node, message: string) => {
-    const line = parsed.getLineAndCharacterOfPosition(node.getStart(parsed)).line + 1
-    violations.push({ file, line, message })
+  let parsed: ASTNode
+  try {
+    parsed = parse(source, { sourceType: 'module', plugins: ['typescript', 'jsx', 'decorators'] }) as unknown as ASTNode
+  } catch (error) {
+    const line = parserErrorLine(error)
+    return [{ file, line, message: 'UI boundary source could not be parsed safely' }]
   }
-  const visit = (node: ts.Node) => {
-	if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === 'fetch') {
-	  const options = node.arguments[1]
-	  if (options && !ts.isObjectLiteralExpression(options)) {
-		report(options, 'fetch options are dynamic, so the UI boundary cannot prove the request is read-only')
-	  } else if (options) {
-		const method = options.properties.find((property) =>
-		  property.name?.getText(parsed).replaceAll(/['"]/g, '') === 'method')
+  const violations: UICommandBoundaryViolation[] = []
+  const report = (node: ASTNode, message: string) => violations.push({ file, line: node.loc?.start.line ?? 1, message })
+  const visit = (node: ASTNode) => {
+    if (node.type === 'CallExpression' && identifierName(node.callee) === 'fetch') {
+      const options = nodeArguments(node)[1]
+      if (options && options.type !== 'ObjectExpression') {
+        report(options, 'fetch options are dynamic, so the UI boundary cannot prove the request is read-only')
+      } else if (options) {
+        const method = nodeArray(options.properties).find((property) => objectPropertyName(property) === 'method')
         if (method) {
-		  const initializer = ts.isPropertyAssignment(method) ? method.initializer : undefined
-		  if (!initializer || !ts.isStringLiteralLike(initializer) || mutationMethods.has(initializer.text.toUpperCase())) {
-			const operationID = generatedOperationHeader(options)
-			if (!operationID) {
+          const initializer = method.type === 'ObjectProperty' ? asNode(method.value) : undefined
+          const methodName = initializer ? stringValue(initializer) : undefined
+          if (!methodName || mutationMethods.has(methodName.toUpperCase())) {
+            const operationID = generatedOperationHeader(options)
+            if (!operationID) {
               report(method, 'direct mutating fetch bypasses the generated UI command transport')
-			} else if (generatedUIOperations && !generatedUIOperations.has(operationID)) {
-			  report(method, `direct mutating fetch references non-generated UI operation ${JSON.stringify(operationID)}`)
-			}
+            } else if (generatedUIOperations && !generatedUIOperations.has(operationID)) {
+              report(method, `direct mutating fetch references non-generated UI operation ${JSON.stringify(operationID)}`)
+            }
           }
         }
       }
     }
-    if (ts.isStringLiteralLike(node)) {
-      if (node.text.includes('@post(') || node.text.includes('@patch(')) {
+    const literal = stringValue(node)
+    if (literal !== undefined) {
+      if (literal.includes('@post(') || literal.includes('@patch(')) {
         report(node, 'direct Datastar mutation expression bypasses a classified UI action helper')
       }
-      if (node.text.toLowerCase() === 'x-leapview-operation-id' && !file.endsWith('web/components/shared/command.ts')) {
+      if (literal.toLowerCase() === 'x-leapview-operation-id' && !file.endsWith('web/components/shared/command.ts')) {
         report(node, 'operation identity headers must be authored by the shared command transport')
       }
     }
-    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      ts.isPropertyAccessExpression(node.left) && node.left.expression.getText(parsed) === 'window' && node.left.name.text === 'LeapViewCommand' &&
+    if (node.type === 'AssignmentExpression' && node.operator === '=' && memberPath(node.left) === 'window.LeapViewCommand' &&
       !file.endsWith('web/components/shared/command.ts')) {
       report(node, 'the LeapView command transport may only be installed by the shared command module')
     }
-    ts.forEachChild(node, visit)
+    for (const child of childNodes(node)) visit(child)
   }
   visit(parsed)
   return violations
 }
 
-export function checkUICommandBoundaries(root = process.cwd()): UICommandBoundaryViolation[] {
+export async function checkUICommandBoundaries(root = process.cwd()): Promise<UICommandBoundaryViolation[]> {
   const webRoot = resolve(root, 'web')
   const ir = JSON.parse(readFileSync(resolve(root, 'api/gen/json-ir.json'), 'utf8')) as {
-	endpoints?: Array<{ operation_id?: string, command?: { ui?: unknown } }>
+    endpoints?: Array<{ operation_id?: string, command?: { ui?: unknown } }>
   }
   const generatedUIOperations = new Set((ir.endpoints ?? [])
-	.filter((endpoint) => endpoint.command?.ui != null)
-	.map((endpoint) => endpoint.operation_id ?? '')
-	.filter(Boolean))
-  const files = ts.sys.readDirectory(webRoot, ['.ts', '.tsx'], ['**/*.test.ts', '**/*.dom.test.ts', '**/generated/**', '**/benchmarks/**'])
-  return files.flatMap((file) => inspectUICommandSource(relative(root, file), ts.sys.readFile(file) ?? '', generatedUIOperations))
+    .filter((endpoint) => endpoint.command?.ui != null)
+    .map((endpoint) => endpoint.operation_id ?? '')
+    .filter(Boolean))
+  const glob = new Bun.Glob('**/*.{ts,tsx}')
+  const files: string[] = []
+  for await (const file of glob.scan({ cwd: webRoot, onlyFiles: true })) {
+    if (/\.(?:dom\.)?test\.tsx?$/.test(file) || file.includes('/generated/') || file.startsWith('generated/') || file.includes('/benchmarks/')) continue
+    files.push(file)
+  }
+  files.sort()
+  const results = await Promise.all(files.map(async (file) => inspectUICommandSource(
+    relative(root, resolve(webRoot, file)),
+    await Bun.file(resolve(webRoot, file)).text(),
+    generatedUIOperations,
+  )))
+  return results.flat()
 }
 
-function generatedOperationHeader(options: ts.ObjectLiteralExpression): string | undefined {
+function generatedOperationHeader(options: ASTNode): string | undefined {
   let operationID: string | undefined
-  const visit = (node: ts.Node) => {
-	if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression) &&
-		node.expression.getText() === 'window.LeapViewCommand.headers') {
-	  const operation = node.arguments[0]
-	  if (operation && ts.isStringLiteralLike(operation) && operation.text.trim()) operationID = operation.text.trim()
-	}
-	ts.forEachChild(node, visit)
+  const visit = (node: ASTNode) => {
+    if (node.type === 'CallExpression' && memberPath(node.callee) === 'window.LeapViewCommand.headers') {
+      const operation = nodeArguments(node)[0]
+      const value = operation ? stringValue(operation)?.trim() : undefined
+      if (value) operationID = value
+    }
+    for (const child of childNodes(node)) visit(child)
   }
   visit(options)
   return operationID
 }
 
+function childNodes(node: ASTNode): ASTNode[] {
+  const children: ASTNode[] = []
+  for (const value of Object.values(node)) {
+    if (isNode(value)) children.push(value)
+    else if (Array.isArray(value)) for (const item of value) if (isNode(item)) children.push(item)
+  }
+  return children
+}
+
+function isNode(value: unknown): value is ASTNode {
+  return Boolean(value && typeof value === 'object' && typeof (value as { type?: unknown }).type === 'string')
+}
+
+function asNode(value: unknown): ASTNode | undefined { return isNode(value) ? value : undefined }
+
+function nodeArray(value: unknown): ASTNode[] {
+  return Array.isArray(value) ? value.filter(isNode) : []
+}
+
+function nodeArguments(node: ASTNode): ASTNode[] { return nodeArray(node.arguments) }
+
+function identifierName(value: unknown): string | undefined {
+  const node = asNode(value)
+  return node?.type === 'Identifier' && typeof node.name === 'string' ? node.name : undefined
+}
+
+function objectPropertyName(node: ASTNode): string | undefined {
+  if (node.type !== 'ObjectProperty' && node.type !== 'ObjectMethod') return undefined
+  const key = asNode(node.key)
+  return key ? identifierName(key) ?? stringValue(key) : undefined
+}
+
+function stringValue(node: ASTNode): string | undefined {
+  if (node.type === 'StringLiteral' && typeof node.value === 'string') return node.value
+  if (node.type === 'TemplateLiteral' && nodeArray(node.expressions).length === 0) {
+    const quasi = nodeArray(node.quasis)[0]
+    const value = quasi?.value
+    if (value && typeof value === 'object' && typeof (value as { cooked?: unknown }).cooked === 'string') return (value as { cooked: string }).cooked
+  }
+  return undefined
+}
+
+function memberPath(value: unknown): string | undefined {
+  const node = asNode(value)
+  if (!node) return undefined
+  const identifier = identifierName(node)
+  if (identifier) return identifier
+  if (node.type !== 'MemberExpression' && node.type !== 'OptionalMemberExpression') return undefined
+  const object = memberPath(node.object)
+  const property = asNode(node.property)
+  const name = node.computed ? property && stringValue(property) : property && identifierName(property)
+  return object && name ? `${object}.${name}` : undefined
+}
+
+function parserErrorLine(error: unknown): number {
+  if (!error || typeof error !== 'object') return 1
+  const loc = (error as { loc?: { line?: unknown } }).loc
+  return typeof loc?.line === 'number' ? loc.line : 1
+}
+
 if (import.meta.main) {
-  const violations = checkUICommandBoundaries()
+  const violations = await checkUICommandBoundaries()
   if (violations.length > 0) {
-    for (const violation of violations) {
-      console.error(`${violation.file}:${violation.line}: ${violation.message}`)
-    }
+    for (const violation of violations) console.error(`${violation.file}:${violation.line}: ${violation.message}`)
     process.exit(1)
   }
 }


### PR DESCRIPTION
## Problem

The grouped frontend Dependabot PR requested TypeScript 7 together with unrelated dependency upgrades and did not update `bun.lock`. TypeScript 7 also removes the JavaScript compiler API used by the UI command-boundary guard.

## Root cause

The repository used `typescript` both as the CLI compiler and as a runtime AST parser. The native TypeScript 7 package provides the compiler binary but no longer provides that JavaScript parser API. The Go architecture contract also still expected the old 5.9.3 compiler pin after the migration.

## Solution

- Upgrade the root compiler from TypeScript 5.9.3 to 7.0.2 with a complete cross-platform lockfile.
- Replace the removed runtime compiler API with exact `@babel/parser@8.0.4` for TypeScript/JSX/decorator syntax.
- Preserve the existing fail-closed checks for mutating fetches, Datastar expressions, operation headers, and command transport installation.
- Scan the same non-generated TypeScript/TSX browser sources using Bun's glob API.
- Update the GitHub-hosted CI architecture contract to require the intentional TypeScript 7.0.2 root pin.

## Tests added/updated

- Retained all UI command-boundary behavior tests.
- Added an explicit malformed-TypeScript regression proving parser failures remain fail-closed.
- Updated the remote compiler-pin architecture assertion.

## Verification performed

- TypeScript reports `Version 7.0.2`.
- `bun run typecheck:app`
- `bun run typecheck:contracts`
- `bun run test:ui-command-boundaries`
- `bun run build`
- `bun run build:site`
- Complete `task ci:lane:frontend`
- `go test ./internal/platform/architecture -run '^TestLeapViewDeclaresGitHubHostedCIContract$' -count=1`

## Remaining limitations

This is the tip of the frontend dependency stack. Merge #456, then #457, then this PR.

Completes the final constituent of superseded grouped PR #359.
