### PR TITLE
Canonicalize ADR-0017 typed attribute values

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,6 +9,7 @@ stopwords = [
   "replace-with-at-least-32-characters",
   "s3DeletionLeaseKey",
   "prefixed/blobs",
+  "allowed_regions_2",
 ]
 
 [[allowlists]]

--- a/adr/specifications/semantic-access-policy-conformance.md
+++ b/adr/specifications/semantic-access-policy-conformance.md
@@ -438,7 +438,8 @@ spec:
 | CHG-01–CHG-04 | Profile-version, historical-policy, and normative-change checks | Pending |
 | STR-01–STR-12 | Generated TypeSpec, JSON Schema, DTO, extracted-YAML, and authoring-registry fixtures | Pending |
 | ATT-01–ATT-12 | Control-plane attribute registry, mutation, disablement, claim-mapping, and trust-boundary tests | Pending |
-| VAL-01–VAL-11 | [`internal/semanticvalue`](../../internal/semanticvalue/value.go), its [unit](../../internal/semanticvalue/value_test.go) and [cross-path](../../internal/semanticvalue/crosspath_test.go) tests, the independent [`profile-v1.json`](../../internal/semanticvalue/testdata/profile-v1.json) fixture, and semantic-filter integration | Implemented |
+| VAL-01–VAL-10 | [`internal/semanticvalue`](../../internal/semanticvalue/value.go), its [unit](../../internal/semanticvalue/value_test.go) and [cross-path](../../internal/semanticvalue/crosspath_test.go) tests, the independent [`profile-v1.json`](../../internal/semanticvalue/testdata/profile-v1.json) fixture, and semantic-filter integration | Implemented |
+| VAL-11 | The shared handwritten canonicalizer and analytics semantic-filter consumer are implemented. Generated canonicalization and the control-plane ingestion, claims, candidate-validation, runtime-evaluation, policy-digest, cache, and audit-projection paths remain unqualified. | Partial |
 | GRT-01–GRT-10 | Access-grant compiler and evaluator fixtures | Pending |
 | FLT-01–FLT-10 | Semantic planner, parameterization, cardinality, and fail-closed tests | Pending |
 | PLN-01–PLN-09 | Security-barrier IR validation and join, aggregate, rollup, and rewrite golden plans | Pending |

--- a/adr/specifications/semantic-access-policy-conformance.md
+++ b/adr/specifications/semantic-access-policy-conformance.md
@@ -4,7 +4,7 @@ Status: accepted
 
 Profile: `leapview.semantic-access/v1`
 
-Last updated: 2026-09-01
+Last updated: 2026-09-02
 
 Owners: LeapView maintainers
 
@@ -438,7 +438,7 @@ spec:
 | CHG-01–CHG-04 | Profile-version, historical-policy, and normative-change checks | Pending |
 | STR-01–STR-12 | Generated TypeSpec, JSON Schema, DTO, extracted-YAML, and authoring-registry fixtures | Pending |
 | ATT-01–ATT-12 | Control-plane attribute registry, mutation, disablement, claim-mapping, and trust-boundary tests | Pending |
-| VAL-01–VAL-11 | Cross-path and independent typed-canonicalization golden fixtures | Pending |
+| VAL-01–VAL-11 | [`internal/semanticvalue`](../../internal/semanticvalue/value.go), its [unit](../../internal/semanticvalue/value_test.go) and [cross-path](../../internal/semanticvalue/crosspath_test.go) tests, the independent [`profile-v1.json`](../../internal/semanticvalue/testdata/profile-v1.json) fixture, and semantic-filter integration | Implemented |
 | GRT-01–GRT-10 | Access-grant compiler and evaluator fixtures | Pending |
 | FLT-01–FLT-10 | Semantic planner, parameterization, cardinality, and fail-closed tests | Pending |
 | PLN-01–PLN-09 | Security-barrier IR validation and join, aggregate, rollup, and rewrite golden plans | Pending |

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
+	golang.org/x/text v0.41.0
 	golang.org/x/tools v0.49.0
 	gopkg.in/yaml.v3 v3.0.1
 	maragu.dev/gomponents v1.3.0
@@ -209,7 +210,6 @@ require (
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect

--- a/internal/analytics/model/filter_literals.go
+++ b/internal/analytics/model/filter_literals.go
@@ -1,12 +1,11 @@
 package model
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/flidai/leapview/internal/analytics/semanticnumeric"
+	"github.com/flidai/leapview/internal/semanticvalue"
 )
 
 // CoerceSemanticLiteral validates and normalizes a canonical filter literal
@@ -19,30 +18,17 @@ func CoerceSemanticLiteral(value any, dimension MetricDimension) (any, error) {
 	}
 	switch typeName {
 	case "integer", "int", "bigint":
-		return coerceInteger(value)
+		return canonicalSemanticValue(semanticvalue.TypeInteger, value)
 	case "decimal":
-		return coerceDecimal(value)
+		return canonicalSemanticValue(semanticvalue.TypeDecimal, value)
 	case "float", "number", "numeric", "double", "real":
 		return coerceFloat(value)
 	case "boolean", "bool":
-		if boolean, ok := value.(bool); ok {
-			return boolean, nil
-		}
-		return nil, fmt.Errorf("value %v is not boolean", value)
+		return canonicalSemanticValue(semanticvalue.TypeBoolean, value)
 	case "string", "text", "varchar", "char":
-		if _, ok := value.(string); !ok {
-			return nil, fmt.Errorf("value %v is not a string", value)
-		}
-		return value, nil
+		return canonicalSemanticValue(semanticvalue.TypeString, value)
 	case "date":
-		text, ok := value.(string)
-		if !ok {
-			return nil, fmt.Errorf("value %v is not a date", value)
-		}
-		if _, err := time.Parse("2006-01-02", text); err != nil {
-			return nil, fmt.Errorf("value %q is not a date", text)
-		}
-		return text, nil
+		return canonicalSemanticValue(semanticvalue.TypeDate, value)
 	case "time":
 		text, ok := value.(string)
 		if !ok {
@@ -62,14 +48,7 @@ func CoerceSemanticLiteral(value any, dimension MetricDimension) (any, error) {
 		}
 		return text, nil
 	case "datetimetz", "timestamp":
-		text, ok := value.(string)
-		if !ok {
-			return nil, fmt.Errorf("value %v is not a datetime", value)
-		}
-		if _, err := time.Parse(time.RFC3339Nano, text); err != nil {
-			return nil, fmt.Errorf("value %q is not an RFC3339 datetime", text)
-		}
-		return text, nil
+		return canonicalSemanticValue(semanticvalue.TypeTimestamp, value)
 	case "opaque":
 		return nil, fmt.Errorf("opaque fields cannot be compared")
 	default:
@@ -77,84 +56,27 @@ func CoerceSemanticLiteral(value any, dimension MetricDimension) (any, error) {
 	}
 }
 
-func coerceDecimal(value any) (json.Number, error) {
-	switch value.(type) {
-	case float32, float64:
-		return "", fmt.Errorf("value %v is binary floating point; Decimal literals must use a precision-safe string or integer", value)
-	case string, json.Number,
-		int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		var token string
-		var lexical bool
-		switch typed := value.(type) {
-		case string:
-			token, lexical = typed, true
-		case json.Number:
-			token, lexical = string(typed), true
-		}
-		if lexical {
-			if err := semanticnumeric.ValidateCanonicalFixedPoint(token); err != nil {
-				return "", fmt.Errorf("value %v is not decimal: %w", value, err)
-			}
-		}
-		number, err := semanticnumeric.FromValue(value)
-		if err != nil {
-			return "", fmt.Errorf("value %v is not decimal: %w", value, err)
-		}
-		switch normalized := number.Value().(type) {
-		case int64:
-			return json.Number(fmt.Sprint(normalized)), nil
-		case string:
-			return json.Number(normalized), nil
+func canonicalSemanticValue(typeName semanticvalue.Type, value any) (any, error) {
+	canonical, err := semanticvalue.Canonicalize(typeName, value)
+	if err != nil {
+		switch typeName {
+		case semanticvalue.TypeString:
+			return nil, fmt.Errorf("value %v is not a string: %w", value, err)
+		case semanticvalue.TypeBoolean:
+			return nil, fmt.Errorf("value %v is not boolean: %w", value, err)
+		case semanticvalue.TypeInteger:
+			return nil, fmt.Errorf("value %v is not an integer: %w", value, err)
+		case semanticvalue.TypeDecimal:
+			return nil, fmt.Errorf("value %v is not decimal: %w", value, err)
+		case semanticvalue.TypeDate:
+			return nil, fmt.Errorf("value %v is not a date: %w", value, err)
+		case semanticvalue.TypeTimestamp:
+			return nil, fmt.Errorf("value %v is not an RFC3339 datetime: %w", value, err)
 		default:
-			return "", fmt.Errorf("value %v is not an exact Decimal", value)
+			return nil, err
 		}
-	default:
-		return "", fmt.Errorf("value %v is not decimal", value)
 	}
-}
-
-func coerceInteger(value any) (int64, error) {
-	switch number := value.(type) {
-	case int:
-		return int64(number), nil
-	case int8:
-		return int64(number), nil
-	case int16:
-		return int64(number), nil
-	case int32:
-		return int64(number), nil
-	case int64:
-		return number, nil
-	case uint8:
-		return int64(number), nil
-	case uint16:
-		return int64(number), nil
-	case uint32:
-		return int64(number), nil
-	case uint:
-		if uint64(number) > uint64(^uint64(0)>>1) {
-			return 0, fmt.Errorf("value %v is outside integer range", value)
-		}
-		return int64(number), nil
-	case uint64:
-		if number > uint64(^uint64(0)>>1) {
-			return 0, fmt.Errorf("value %v is outside integer range", value)
-		}
-		return int64(number), nil
-	case float64:
-		if number != float64(int64(number)) {
-			return 0, fmt.Errorf("value %v is not an integer", value)
-		}
-		return int64(number), nil
-	case float32:
-		converted := float64(number)
-		if converted != float64(int64(converted)) {
-			return 0, fmt.Errorf("value %v is not an integer", value)
-		}
-		return int64(converted), nil
-	default:
-		return 0, fmt.Errorf("value %v is not an integer", value)
-	}
+	return canonical.Native(), nil
 }
 
 func coerceFloat(value any) (float64, error) {

--- a/internal/analytics/model/filter_literals_test.go
+++ b/internal/analytics/model/filter_literals_test.go
@@ -19,7 +19,7 @@ func TestDecimalFilterLiteralUsesPrecisionSafeRepresentation(t *testing.T) {
 }
 
 func TestDecimalFilterLiteralUsesCanonicalFixedPointLexicalForm(t *testing.T) {
-	for _, token := range []string{"1e3", "01", "+1", "-0", "-0.0"} {
+	for _, token := range []string{"", "not-a-number", "NaN", "Infinity"} {
 		t.Run("reject/"+token, func(t *testing.T) {
 			if _, err := CoerceSemanticLiteral(token, MetricDimension{Datatype: DataTypeDecimal}); err == nil {
 				t.Fatalf("Decimal filter literal %q was accepted", token)
@@ -33,6 +33,11 @@ func TestDecimalFilterLiteralUsesCanonicalFixedPointLexicalForm(t *testing.T) {
 	}{
 		{token: "0", want: "0"},
 		{token: "0.0", want: "0"},
+		{token: "1e3", want: "1000"},
+		{token: "01", want: "1"},
+		{token: "+1", want: "1"},
+		{token: "-0", want: "0"},
+		{token: "-0.0", want: "0"},
 		{token: "1", want: "1"},
 		{token: "1.0", want: "1"},
 		{token: "-1", want: "-1"},
@@ -48,5 +53,28 @@ func TestDecimalFilterLiteralUsesCanonicalFixedPointLexicalForm(t *testing.T) {
 				t.Fatalf("Decimal filter literal %q = %q, want %q", test.token, got, test.want)
 			}
 		})
+	}
+}
+
+func TestSemanticFilterLiteralUsesSharedAccessCanonicalization(t *testing.T) {
+	stringValue, err := CoerceSemanticLiteral("Cafe\u0301", MetricDimension{Datatype: DataTypeString})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stringValue != "Café" {
+		t.Fatalf("String filter value = %q, want NFC", stringValue)
+	}
+	if _, err := CoerceSemanticLiteral("north\namerica", MetricDimension{Datatype: DataTypeString}); err == nil {
+		t.Fatal("String filter accepted a control character")
+	}
+	if _, err := CoerceSemanticLiteral(float64(1), MetricDimension{Datatype: DataTypeInteger}); err == nil {
+		t.Fatal("Integer filter accepted a cross-type Float value")
+	}
+	timestamp, err := CoerceSemanticLiteral("2024-01-02T03:04:05.1200+02:30", MetricDimension{Datatype: DataTypeDateTimeTZ})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if timestamp != "2024-01-02T00:34:05.12Z" {
+		t.Fatalf("Timestamp filter value = %q", timestamp)
 	}
 }

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -29,14 +29,14 @@ type goFile struct {
 var targetCapabilities = map[string]struct{}{
 	"project": {}, "access": {}, "manageddata": {}, "analytics": {},
 	"dashboard": {}, "agent": {}, "release": {}, "deployment": {}, "servingstate": {},
-	"refresh": {}, "runtimehost": {}, "workload": {}, "platform": {},
+	"refresh": {}, "runtimehost": {}, "workload": {}, "semanticvalue": {}, "platform": {},
 }
 
 var approvedInternalRoots = map[string]struct{}{
 	"app": {}, "platform": {},
 	"access": {}, "admin": {}, "agent": {}, "analytics": {}, "dashboard": {},
 	"deployment": {}, "manageddata": {}, "project": {}, "refresh": {}, "release": {},
-	"runtimehost": {}, "servingstate": {}, "workload": {}, "extension": {},
+	"runtimehost": {}, "semanticvalue": {}, "servingstate": {}, "workload": {}, "extension": {},
 }
 
 func TestRepositoryIdentityUsesOrganizationNamespace(t *testing.T) {
@@ -138,6 +138,20 @@ func TestArchitectureOwnershipUsesRootTaxonomy(t *testing.T) {
 		if rule.Capability == "api" || rule.Capability == "ui" {
 			t.Errorf("%s retains synthetic %q ownership instead of its physical app, platform, or capability owner", rule.Prefix, rule.Capability)
 		}
+	}
+}
+
+func TestSemanticValueIsAPublishedAnalyticsDependency(t *testing.T) {
+	source, sourceOK := ClassifyPackage("internal/analytics/model")
+	target, targetOK := ClassifyPackage("internal/semanticvalue")
+	if !sourceOK || !targetOK {
+		t.Fatalf("classify analytics/model=%v semanticvalue=%v", sourceOK, targetOK)
+	}
+	if target.Capability != "semanticvalue" || target.Layer != LayerContract {
+		t.Fatalf("semanticvalue classification = %#v, want semanticvalue contract", target)
+	}
+	if violation := CapabilityImportViolation("internal/analytics/model", source, "internal/semanticvalue", target); violation != "" {
+		t.Fatalf("analytics/model -> semanticvalue violation = %q, want published contract", violation)
 	}
 }
 

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -32,18 +32,19 @@ type PackageRule struct {
 // import as a synchronous contract. Adapter and module packages are never
 // made public merely because their capability has an allowed edge.
 var PublicContractPrefixes = map[string][]string{
-	"access":       {"internal/access", "internal/access/api", "internal/access/policy", "internal/access/snapshot", "internal/access/ui/signals"},
-	"agent":        {"internal/agent/api", "internal/agent/ui/signals"},
-	"analytics":    {"pkg/arrowresult", "internal/analytics/model", "internal/analytics/modelsql", "internal/analytics/query", "internal/analytics/materialize", "internal/analytics/materialization", "internal/analytics/connectors", "internal/analytics/connectionadmin", "internal/analytics/arrowquery", "internal/analytics/resource", "internal/analytics/runtime", "internal/analytics/queryaudit", "internal/analytics/dataquery", "internal/analytics/physicalpool", "internal/analytics/catalogseal", "internal/analytics/catalogartifact", "internal/analytics/catalogstats", "internal/analytics/resultidentity", "internal/analytics/sourcedataidentity"},
-	"dashboard":    {"internal/dashboard", "internal/dashboard/api", "internal/dashboard/appearance", "internal/dashboard/authoring", "internal/dashboard/catalog", "internal/dashboard/compiler", "internal/dashboard/definition", "internal/dashboard/document", "internal/dashboard/filter", "internal/dashboard/layoutcontract", "internal/dashboard/publication", "internal/dashboard/report", "internal/dashboard/reportmodel", "internal/dashboard/queryruntime", "internal/dashboard/resolver", "internal/dashboard/ui/signals", "internal/dashboard/visualization/definition", "internal/dashboard/visualization/format", "internal/dashboard/visualization/geometry", "internal/dashboard/visualization/ir", "internal/dashboard/visualization/mapasset", "internal/dashboard/visualization/runtime"},
-	"manageddata":  {"internal/manageddata", "internal/manageddata/binding", "internal/manageddata/runtimebinding"},
-	"project":      {"internal/project", "internal/project/api", "internal/project/schema", "internal/project/contracts", "internal/project/artifact", "internal/project/bundle", "internal/project/catalog", "internal/project/compiler", "internal/project/manifest", "internal/project/runtime"},
-	"release":      {"internal/release"},
-	"deployment":   {"internal/deployment"},
-	"servingstate": {"internal/servingstate", "internal/servingstate/validate", "internal/servingstate/retention"},
-	"refresh":      {"internal/refresh/artifact", "internal/refresh/plan", "internal/refresh/presentation", "internal/refresh/run", "internal/refresh/schedule"},
-	"runtimehost":  {"internal/runtimehost"},
-	"workload":     {"internal/workload"},
+	"access":        {"internal/access", "internal/access/api", "internal/access/policy", "internal/access/snapshot", "internal/access/ui/signals"},
+	"agent":         {"internal/agent/api", "internal/agent/ui/signals"},
+	"analytics":     {"pkg/arrowresult", "internal/analytics/model", "internal/analytics/modelsql", "internal/analytics/query", "internal/analytics/materialize", "internal/analytics/materialization", "internal/analytics/connectors", "internal/analytics/connectionadmin", "internal/analytics/arrowquery", "internal/analytics/resource", "internal/analytics/runtime", "internal/analytics/queryaudit", "internal/analytics/dataquery", "internal/analytics/physicalpool", "internal/analytics/catalogseal", "internal/analytics/catalogartifact", "internal/analytics/catalogstats", "internal/analytics/resultidentity", "internal/analytics/sourcedataidentity"},
+	"dashboard":     {"internal/dashboard", "internal/dashboard/api", "internal/dashboard/appearance", "internal/dashboard/authoring", "internal/dashboard/catalog", "internal/dashboard/compiler", "internal/dashboard/definition", "internal/dashboard/document", "internal/dashboard/filter", "internal/dashboard/layoutcontract", "internal/dashboard/publication", "internal/dashboard/report", "internal/dashboard/reportmodel", "internal/dashboard/queryruntime", "internal/dashboard/resolver", "internal/dashboard/ui/signals", "internal/dashboard/visualization/definition", "internal/dashboard/visualization/format", "internal/dashboard/visualization/geometry", "internal/dashboard/visualization/ir", "internal/dashboard/visualization/mapasset", "internal/dashboard/visualization/runtime"},
+	"manageddata":   {"internal/manageddata", "internal/manageddata/binding", "internal/manageddata/runtimebinding"},
+	"project":       {"internal/project", "internal/project/api", "internal/project/schema", "internal/project/contracts", "internal/project/artifact", "internal/project/bundle", "internal/project/catalog", "internal/project/compiler", "internal/project/manifest", "internal/project/runtime"},
+	"release":       {"internal/release"},
+	"semanticvalue": {"internal/semanticvalue"},
+	"deployment":    {"internal/deployment"},
+	"servingstate":  {"internal/servingstate", "internal/servingstate/validate", "internal/servingstate/retention"},
+	"refresh":       {"internal/refresh/artifact", "internal/refresh/plan", "internal/refresh/presentation", "internal/refresh/run", "internal/refresh/schedule"},
+	"runtimehost":   {"internal/runtimehost"},
+	"workload":      {"internal/workload"},
 }
 
 // DeferredPackageEdges are the explicit ownership exceptions retained for
@@ -166,20 +167,21 @@ func IsDeferredPackageEdge(sourcePath, targetCapability string) bool {
 }
 
 var CapabilityDependencies = map[string]map[string]bool{
-	"project":      {"analytics": true, "dashboard": true, "access": true, "refresh": true, "servingstate": true},
-	"access":       {},
-	"manageddata":  {"servingstate": true},
-	"analytics":    {"access": true, "manageddata": true, "servingstate": true},
-	"dashboard":    {"access": true, "analytics": true, "runtimehost": true, "workload": true},
-	"agent":        {"access": true, "analytics": true, "dashboard": true, "project": true},
-	"admin":        {"access": true, "agent": true, "analytics": true, "dashboard": true},
-	"release":      {"access": true, "project": true, "servingstate": true, "analytics": true},
-	"deployment":   {"access": true, "project": true, "release": true, "servingstate": true, "manageddata": true, "runtimehost": true, "analytics": true},
-	"servingstate": {"access": true, "workload": true},
-	"refresh":      {"access": true, "servingstate": true, "manageddata": true, "analytics": true, "runtimehost": true, "workload": true},
-	"runtimehost":  {"manageddata": true, "servingstate": true},
-	"workload":     {},
-	"platform":     {},
+	"project":       {"analytics": true, "dashboard": true, "access": true, "refresh": true, "servingstate": true},
+	"access":        {},
+	"manageddata":   {"servingstate": true},
+	"analytics":     {"access": true, "manageddata": true, "semanticvalue": true, "servingstate": true},
+	"dashboard":     {"access": true, "analytics": true, "runtimehost": true, "workload": true},
+	"agent":         {"access": true, "analytics": true, "dashboard": true, "project": true},
+	"admin":         {"access": true, "agent": true, "analytics": true, "dashboard": true},
+	"release":       {"access": true, "project": true, "servingstate": true, "analytics": true},
+	"deployment":    {"access": true, "project": true, "release": true, "servingstate": true, "manageddata": true, "runtimehost": true, "analytics": true},
+	"servingstate":  {"access": true, "workload": true},
+	"refresh":       {"access": true, "servingstate": true, "manageddata": true, "analytics": true, "runtimehost": true, "workload": true},
+	"runtimehost":   {"manageddata": true, "servingstate": true},
+	"workload":      {},
+	"semanticvalue": {},
+	"platform":      {},
 }
 
 func IsPublicContractImport(capability, packagePath string) bool {
@@ -241,6 +243,7 @@ var PackageRules = []PackageRule{
 	{Prefix: "pkg/strictjson", Capability: "platform", Layer: LayerPlatform},
 	{Prefix: "pkg/arrowresult", Capability: "analytics", Layer: LayerContract},
 	{Prefix: "pkg/workload", Capability: "workload", Layer: LayerContract},
+	{Prefix: "internal/semanticvalue", Capability: "semanticvalue", Layer: LayerContract},
 	{Prefix: "internal/project/graph", Capability: "project", Layer: LayerContract},
 	{Prefix: "internal/project/contracts", Capability: "project", Layer: LayerContract},
 	{Prefix: "internal/project/catalog", Capability: "project", Layer: LayerContract},

--- a/internal/semanticvalue/crosspath_test.go
+++ b/internal/semanticvalue/crosspath_test.go
@@ -1,0 +1,76 @@
+package semanticvalue_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestProfileV1GoldenMatchesSemanticFilterPath(t *testing.T) {
+	content, err := os.ReadFile("testdata/profile-v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		Profile string `json:"profile"`
+		Cases   []struct {
+			Name      string             `json:"name"`
+			Type      semanticvalue.Type `json:"type"`
+			Input     any                `json:"input"`
+			Canonical string             `json:"canonical"`
+		} `json:"cases"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.UseNumber()
+	if err := decoder.Decode(&fixture); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.Profile != semanticvalue.Profile {
+		t.Fatalf("fixture profile = %q, want %q", fixture.Profile, semanticvalue.Profile)
+	}
+
+	for _, test := range fixture.Cases {
+		t.Run(test.Name, func(t *testing.T) {
+			canonical, err := semanticvalue.Canonicalize(test.Type, test.Input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if canonical.Canonical() != test.Canonical {
+				t.Fatalf("shared canonical value = %q, want %q", canonical.Canonical(), test.Canonical)
+			}
+
+			dimension := semanticmodel.MetricDimension{Datatype: semanticDatatype(test.Type)}
+			filterValue, err := semanticmodel.CoerceSemanticLiteral(test.Input, dimension)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := fmt.Sprint(filterValue); got != test.Canonical {
+				t.Fatalf("semantic filter value = %q, want %q", got, test.Canonical)
+			}
+		})
+	}
+}
+
+func semanticDatatype(typeName semanticvalue.Type) semanticmodel.LogicalDataType {
+	switch typeName {
+	case semanticvalue.TypeString:
+		return semanticmodel.DataTypeString
+	case semanticvalue.TypeBoolean:
+		return semanticmodel.DataTypeBoolean
+	case semanticvalue.TypeInteger:
+		return semanticmodel.DataTypeInteger
+	case semanticvalue.TypeDecimal:
+		return semanticmodel.DataTypeDecimal
+	case semanticvalue.TypeDate:
+		return semanticmodel.DataTypeDate
+	case semanticvalue.TypeTimestamp:
+		return semanticmodel.DataTypeDateTimeTZ
+	default:
+		return ""
+	}
+}

--- a/internal/semanticvalue/testdata/profile-v1.json
+++ b/internal/semanticvalue/testdata/profile-v1.json
@@ -1,0 +1,41 @@
+{
+  "profile": "leapview.semantic-access/v1",
+  "cases": [
+    {
+      "name": "string-nfc",
+      "type": "String",
+      "input": "Cafe\u0301",
+      "canonical": "Café"
+    },
+    {
+      "name": "boolean",
+      "type": "Boolean",
+      "input": true,
+      "canonical": "true"
+    },
+    {
+      "name": "integer",
+      "type": "Integer",
+      "input": -9223372036854775808,
+      "canonical": "-9223372036854775808"
+    },
+    {
+      "name": "decimal-fixed",
+      "type": "Decimal",
+      "input": "9007199254740993.12500",
+      "canonical": "9007199254740993.125"
+    },
+    {
+      "name": "date",
+      "type": "Date",
+      "input": "2024-02-29",
+      "canonical": "2024-02-29"
+    },
+    {
+      "name": "timestamp-utc",
+      "type": "Timestamp",
+      "input": "2024-01-02T03:04:05.1200+02:30",
+      "canonical": "2024-01-02T00:34:05.12Z"
+    }
+  ]
+}

--- a/internal/semanticvalue/value.go
+++ b/internal/semanticvalue/value.go
@@ -299,11 +299,85 @@ func canonicalTimestamp(input any) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("value of type %T is not an RFC 3339 timestamp string", input)
 	}
+	if err := validateRFC3339Timestamp(value); err != nil {
+		return "", fmt.Errorf("value %q is not a strict RFC 3339 timestamp: %v", value, err)
+	}
 	parsed, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {
 		return "", fmt.Errorf("value %q is not an RFC 3339 timestamp", value)
 	}
 	return parsed.UTC().Format(time.RFC3339Nano), nil
+}
+
+func validateRFC3339Timestamp(value string) error {
+	if len(value) < len("2006-01-02T15:04:05Z") {
+		return errors.New("timestamp is too short")
+	}
+	for index := 0; index < len("2006-01-02T15:04:05"); index++ {
+		switch index {
+		case 4, 7:
+			if value[index] != '-' {
+				return errors.New("date components must use hyphens")
+			}
+		case 10:
+			if value[index] != 'T' {
+				return errors.New("date and time must use an uppercase T separator")
+			}
+		case 13, 16:
+			if value[index] != ':' {
+				return errors.New("time components must use colons")
+			}
+		default:
+			if !asciiDigit(value[index]) {
+				return errors.New("date and time components must contain only ASCII digits")
+			}
+		}
+	}
+
+	timezoneStart := len("2006-01-02T15:04:05")
+	if value[timezoneStart] == '.' {
+		fractionStart := timezoneStart + 1
+		timezoneStart = fractionStart
+		for timezoneStart < len(value) && asciiDigit(value[timezoneStart]) {
+			timezoneStart++
+		}
+		fractionDigits := timezoneStart - fractionStart
+		if fractionDigits == 0 {
+			return errors.New("fractional seconds require at least one digit")
+		}
+		if fractionDigits > 9 {
+			return errors.New("fractional seconds exceed nanosecond precision")
+		}
+	}
+
+	if timezoneStart >= len(value) {
+		return errors.New("timestamp requires a timezone")
+	}
+	if value[timezoneStart] == 'Z' {
+		if timezoneStart != len(value)-1 {
+			return errors.New("UTC designator must terminate the timestamp")
+		}
+		return nil
+	}
+	if len(value)-timezoneStart != len("+00:00") ||
+		(value[timezoneStart] != '+' && value[timezoneStart] != '-') ||
+		value[timezoneStart+3] != ':' ||
+		!asciiDigit(value[timezoneStart+1]) ||
+		!asciiDigit(value[timezoneStart+2]) ||
+		!asciiDigit(value[timezoneStart+4]) ||
+		!asciiDigit(value[timezoneStart+5]) {
+		return errors.New("timezone must be uppercase Z or a signed HH:MM offset")
+	}
+	offsetHour := 10*int(value[timezoneStart+1]-'0') + int(value[timezoneStart+2]-'0')
+	offsetMinute := 10*int(value[timezoneStart+4]-'0') + int(value[timezoneStart+5]-'0')
+	if offsetHour >= 24 || offsetMinute >= 60 {
+		return errors.New("timezone offset is outside the RFC 3339 range")
+	}
+	return nil
+}
+
+func asciiDigit(value byte) bool {
+	return value >= '0' && value <= '9'
 }
 
 // Set is an immutable homogeneous set sorted by canonical bytes.

--- a/internal/semanticvalue/value.go
+++ b/internal/semanticvalue/value.go
@@ -1,0 +1,387 @@
+// Package semanticvalue implements the canonical scalar and homogeneous-set
+// contract shared by semantic access authoring, control-plane attributes,
+// runtime evaluation, cache identity, and audit projection.
+package semanticvalue
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/cockroachdb/apd/v3"
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	// Profile is the normative semantic-access value profile. It participates
+	// in canonical identity so a future profile cannot silently reuse v1
+	// authorization-sensitive cache or audit identities.
+	Profile = "leapview.semantic-access/v1"
+
+	// MaxSetValues is the fixed post-normalization cardinality bound from the
+	// v1 semantic-access contract.
+	MaxSetValues = 1024
+)
+
+var (
+	ErrInvalidType     = errors.New("invalid semantic value type")
+	ErrInvalidValue    = errors.New("invalid semantic value")
+	ErrEmptySet        = errors.New("semantic value set is empty")
+	ErrTooManySetItems = errors.New("semantic value set exceeds cardinality bound")
+)
+
+// Type is the closed logical type vocabulary accepted by semantic-access v1.
+// Float and the SemanticModel-only Time and timezone-free DateTime types are
+// intentionally absent.
+type Type string
+
+const (
+	TypeString    Type = "String"
+	TypeBoolean   Type = "Boolean"
+	TypeInteger   Type = "Integer"
+	TypeDecimal   Type = "Decimal"
+	TypeDate      Type = "Date"
+	TypeTimestamp Type = "Timestamp"
+)
+
+func (t Type) valid() bool {
+	switch t {
+	case TypeString, TypeBoolean, TypeInteger, TypeDecimal, TypeDate, TypeTimestamp:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateAttributeName enforces the case-sensitive ASCII identifier grammar
+// used by SemanticModel names. Values are never trimmed or case-folded.
+func ValidateAttributeName(name string) error {
+	if name == "" || !asciiIdentifierStart(name[0]) {
+		return fmt.Errorf("%w: attribute name %q must match ^[A-Za-z_][A-Za-z0-9_]*$", ErrInvalidValue, name)
+	}
+	for index := 1; index < len(name); index++ {
+		if !asciiIdentifierContinue(name[index]) {
+			return fmt.Errorf("%w: attribute name %q must match ^[A-Za-z_][A-Za-z0-9_]*$", ErrInvalidValue, name)
+		}
+	}
+	return nil
+}
+
+func asciiIdentifierStart(value byte) bool {
+	return value == '_' || value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
+
+func asciiIdentifierContinue(value byte) bool {
+	return asciiIdentifierStart(value) || value >= '0' && value <= '9'
+}
+
+// Value is one immutable canonical scalar. canonical is the exact byte-level
+// representation used for matching and identity; Native returns the strict Go
+// representation used by existing planner parameter binding.
+type Value struct {
+	typeName  Type
+	canonical string
+}
+
+func (v Value) Type() Type        { return v.typeName }
+func (v Value) Canonical() string { return v.canonical }
+
+// Native returns the strict transport value for existing typed consumers.
+func (v Value) Native() any {
+	switch v.typeName {
+	case TypeString, TypeDate, TypeTimestamp:
+		return v.canonical
+	case TypeBoolean:
+		return v.canonical == "true"
+	case TypeInteger:
+		value, err := strconv.ParseInt(v.canonical, 10, 64)
+		if err != nil {
+			return nil
+		}
+		return value
+	case TypeDecimal:
+		return json.Number(v.canonical)
+	default:
+		return nil
+	}
+}
+
+type canonicalValueWire struct {
+	Profile string `json:"profile"`
+	Type    Type   `json:"type"`
+	Value   string `json:"value"`
+}
+
+// CanonicalBytes returns the deterministic, profile-qualified scalar identity.
+func (v Value) CanonicalBytes() []byte {
+	if !v.typeName.valid() {
+		return nil
+	}
+	encoded, err := json.Marshal(canonicalValueWire{Profile: Profile, Type: v.typeName, Value: v.canonical})
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+// Digest returns the SHA-256 identity of CanonicalBytes.
+func (v Value) Digest() string {
+	return digest(v.CanonicalBytes())
+}
+
+// Canonicalize validates one typed scalar and returns its canonical form.
+// Callers must supply the registered logical type; no cross-type coercion is
+// performed.
+func Canonicalize(typeName Type, input any) (Value, error) {
+	if !typeName.valid() {
+		return Value{}, fmt.Errorf("%w: %q is not supported by %s", ErrInvalidType, typeName, Profile)
+	}
+	if input == nil {
+		return Value{}, fmt.Errorf("%w: null is not an access value", ErrInvalidValue)
+	}
+
+	var (
+		canonical string
+		err       error
+	)
+	switch typeName {
+	case TypeString:
+		canonical, err = canonicalString(input)
+	case TypeBoolean:
+		canonical, err = canonicalBoolean(input)
+	case TypeInteger:
+		canonical, err = canonicalInteger(input)
+	case TypeDecimal:
+		canonical, err = canonicalDecimal(input)
+	case TypeDate:
+		canonical, err = canonicalDate(input)
+	case TypeTimestamp:
+		canonical, err = canonicalTimestamp(input)
+	}
+	if err != nil {
+		return Value{}, fmt.Errorf("%w: %s: %v", ErrInvalidValue, typeName, err)
+	}
+	return Value{typeName: typeName, canonical: canonical}, nil
+}
+
+func canonicalString(input any) (string, error) {
+	value, ok := input.(string)
+	if !ok {
+		return "", fmt.Errorf("value of type %T is not a string", input)
+	}
+	if !utf8.ValidString(value) {
+		return "", errors.New("string is not valid UTF-8")
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return "", fmt.Errorf("string contains control character U+%04X", character)
+		}
+	}
+	return norm.NFC.String(value), nil
+}
+
+func canonicalBoolean(input any) (string, error) {
+	value, ok := input.(bool)
+	if !ok {
+		return "", fmt.Errorf("value of type %T is not a boolean", input)
+	}
+	return strconv.FormatBool(value), nil
+}
+
+func canonicalInteger(input any) (string, error) {
+	var value int64
+	switch typed := input.(type) {
+	case int:
+		value = int64(typed)
+	case int8:
+		value = int64(typed)
+	case int16:
+		value = int64(typed)
+	case int32:
+		value = int64(typed)
+	case int64:
+		value = typed
+	case uint:
+		if uint64(typed) > math.MaxInt64 {
+			return "", fmt.Errorf("value %d is outside signed 64-bit range", typed)
+		}
+		value = int64(typed)
+	case uint8:
+		value = int64(typed)
+	case uint16:
+		value = int64(typed)
+	case uint32:
+		value = int64(typed)
+	case uint64:
+		if typed > math.MaxInt64 {
+			return "", fmt.Errorf("value %d is outside signed 64-bit range", typed)
+		}
+		value = int64(typed)
+	case json.Number:
+		parsed, err := strconv.ParseInt(string(typed), 10, 64)
+		if err != nil {
+			return "", fmt.Errorf("value %q is not a signed 64-bit integer", typed)
+		}
+		value = parsed
+	default:
+		return "", fmt.Errorf("value of type %T is not an integer", input)
+	}
+	return strconv.FormatInt(value, 10), nil
+}
+
+func canonicalDecimal(input any) (string, error) {
+	var token string
+	switch typed := input.(type) {
+	case string:
+		token = typed
+	case json.Number:
+		token = string(typed)
+	case int:
+		token = strconv.FormatInt(int64(typed), 10)
+	case int8:
+		token = strconv.FormatInt(int64(typed), 10)
+	case int16:
+		token = strconv.FormatInt(int64(typed), 10)
+	case int32:
+		token = strconv.FormatInt(int64(typed), 10)
+	case int64:
+		token = strconv.FormatInt(typed, 10)
+	case uint:
+		token = strconv.FormatUint(uint64(typed), 10)
+	case uint8:
+		token = strconv.FormatUint(uint64(typed), 10)
+	case uint16:
+		token = strconv.FormatUint(uint64(typed), 10)
+	case uint32:
+		token = strconv.FormatUint(uint64(typed), 10)
+	case uint64:
+		token = strconv.FormatUint(typed, 10)
+	default:
+		return "", fmt.Errorf("value of type %T is not an exact decimal", input)
+	}
+	value, _, err := apd.BaseContext.NewFromString(token)
+	if err != nil || value.Form != apd.Finite {
+		if err == nil {
+			err = errors.New("decimal must be finite")
+		}
+		return "", fmt.Errorf("value %q is not an exact decimal: %v", token, err)
+	}
+	if value.IsZero() {
+		return "0", nil
+	}
+	reduced := new(apd.Decimal)
+	reduced.Reduce(value)
+	return reduced.Text('f'), nil
+}
+
+func canonicalDate(input any) (string, error) {
+	value, ok := input.(string)
+	if !ok {
+		return "", fmt.Errorf("value of type %T is not a date string", input)
+	}
+	parsed, err := time.Parse("2006-01-02", value)
+	if err != nil || parsed.Format("2006-01-02") != value {
+		return "", fmt.Errorf("value %q is not a Gregorian YYYY-MM-DD date", value)
+	}
+	return value, nil
+}
+
+func canonicalTimestamp(input any) (string, error) {
+	value, ok := input.(string)
+	if !ok {
+		return "", fmt.Errorf("value of type %T is not an RFC 3339 timestamp string", input)
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return "", fmt.Errorf("value %q is not an RFC 3339 timestamp", value)
+	}
+	return parsed.UTC().Format(time.RFC3339Nano), nil
+}
+
+// Set is an immutable homogeneous set sorted by canonical bytes.
+type Set struct {
+	typeName Type
+	values   []Value
+}
+
+func (s Set) Type() Type { return s.typeName }
+func (s Set) Len() int   { return len(s.values) }
+
+func (s Set) Values() []Value {
+	return append([]Value(nil), s.values...)
+}
+
+// CanonicalizeSet canonicalizes, deduplicates, and sorts one homogeneous
+// collection. The cardinality limit applies after set normalization.
+func CanonicalizeSet(typeName Type, inputs []any) (Set, error) {
+	if !typeName.valid() {
+		return Set{}, fmt.Errorf("%w: %q is not supported by %s", ErrInvalidType, typeName, Profile)
+	}
+	if len(inputs) == 0 {
+		return Set{}, ErrEmptySet
+	}
+	unique := make(map[string]Value, len(inputs))
+	for index, input := range inputs {
+		value, err := Canonicalize(typeName, input)
+		if err != nil {
+			return Set{}, fmt.Errorf("set value %d: %w", index, err)
+		}
+		unique[value.canonical] = value
+	}
+	if len(unique) > MaxSetValues {
+		return Set{}, fmt.Errorf("%w: got %d, limit %d", ErrTooManySetItems, len(unique), MaxSetValues)
+	}
+	keys := make([]string, 0, len(unique))
+	for key := range unique {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	values := make([]Value, len(keys))
+	for index, key := range keys {
+		values[index] = unique[key]
+	}
+	return Set{typeName: typeName, values: values}, nil
+}
+
+type canonicalSetWire struct {
+	Profile string   `json:"profile"`
+	Type    Type     `json:"type"`
+	Values  []string `json:"values"`
+}
+
+// CanonicalBytes returns the deterministic, profile-qualified set identity.
+func (s Set) CanonicalBytes() []byte {
+	if !s.typeName.valid() || len(s.values) == 0 {
+		return nil
+	}
+	values := make([]string, len(s.values))
+	for index, value := range s.values {
+		values[index] = value.canonical
+	}
+	encoded, err := json.Marshal(canonicalSetWire{Profile: Profile, Type: s.typeName, Values: values})
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+// Digest returns the SHA-256 identity of CanonicalBytes.
+func (s Set) Digest() string {
+	return digest(s.CanonicalBytes())
+}
+
+func digest(encoded []byte) string {
+	if len(encoded) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/semanticvalue/value_test.go
+++ b/internal/semanticvalue/value_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestValidateAttributeName(t *testing.T) {
-	for _, name := range []string{"department", "piiAccess", "allowed_regions_2"} {
+	for _, name := range []string{"department", "regionScope", "allowed_regions_2"} {
 		if err := ValidateAttributeName(name); err != nil {
 			t.Fatalf("ValidateAttributeName(%q) error = %v", name, err)
 		}

--- a/internal/semanticvalue/value_test.go
+++ b/internal/semanticvalue/value_test.go
@@ -38,6 +38,7 @@ func TestCanonicalizeScalars(t *testing.T) {
 		{name: "decimal fractional", typeName: TypeDecimal, input: "9007199254740993.12500", want: "9007199254740993.125", wantNative: json.Number("9007199254740993.125")},
 		{name: "date", typeName: TypeDate, input: "2024-02-29", want: "2024-02-29", wantNative: "2024-02-29"},
 		{name: "timestamp UTC", typeName: TypeTimestamp, input: "2024-01-02T03:04:05.1200+02:30", want: "2024-01-02T00:34:05.12Z", wantNative: "2024-01-02T00:34:05.12Z"},
+		{name: "timestamp nanosecond precision", typeName: TypeTimestamp, input: "2024-01-02T03:04:05.123456789Z", want: "2024-01-02T03:04:05.123456789Z", wantNative: "2024-01-02T03:04:05.123456789Z"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -75,6 +76,13 @@ func TestCanonicalizeRejectsInvalidOrCrossTypeValues(t *testing.T) {
 		{name: "date timestamp", typeName: TypeDate, input: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 		{name: "timestamp without zone", typeName: TypeTimestamp, input: "2024-01-02T03:04:05"},
 		{name: "leap second", typeName: TypeTimestamp, input: "2016-12-31T23:59:60Z"},
+		{name: "timestamp ten fractional zeroes", typeName: TypeTimestamp, input: "2024-01-02T03:04:05.1234567890Z"},
+		{name: "timestamp ten fractional digits one", typeName: TypeTimestamp, input: "2024-01-02T03:04:05.1234567891Z"},
+		{name: "timestamp ten fractional digits nine", typeName: TypeTimestamp, input: "2024-01-02T03:04:05.1234567899Z"},
+		{name: "timestamp comma fraction", typeName: TypeTimestamp, input: "2024-01-02T03:04:05,123Z"},
+		{name: "timestamp offset without colon", typeName: TypeTimestamp, input: "2024-01-02T03:04:05+0230"},
+		{name: "timestamp offset hour out of range", typeName: TypeTimestamp, input: "2024-01-02T03:04:05+24:00"},
+		{name: "timestamp offset minute out of range", typeName: TypeTimestamp, input: "2024-01-02T03:04:05+02:60"},
 		{name: "unsupported float type", typeName: Type("Float"), input: 1.5},
 	}
 	for _, tt := range tests {
@@ -83,6 +91,20 @@ func TestCanonicalizeRejectsInvalidOrCrossTypeValues(t *testing.T) {
 				t.Fatalf("Canonicalize(%q, %#v) accepted invalid value", tt.typeName, tt.input)
 			}
 		})
+	}
+}
+
+func TestEquivalentTimestampsCanonicalizeConsistently(t *testing.T) {
+	utc, err := Canonicalize(TypeTimestamp, "2024-01-02T03:04:05.123456789Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	offset, err := Canonicalize(TypeTimestamp, "2024-01-02T05:34:05.123456789+02:30")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if utc.Canonical() != offset.Canonical() || utc.Digest() != offset.Digest() {
+		t.Fatalf("equivalent timestamps produced different identities: %q and %q", utc.Canonical(), offset.Canonical())
 	}
 }
 

--- a/internal/semanticvalue/value_test.go
+++ b/internal/semanticvalue/value_test.go
@@ -1,0 +1,165 @@
+package semanticvalue
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateAttributeName(t *testing.T) {
+	for _, name := range []string{"department", "piiAccess", "allowed_regions_2"} {
+		if err := ValidateAttributeName(name); err != nil {
+			t.Fatalf("ValidateAttributeName(%q) error = %v", name, err)
+		}
+	}
+	for _, name := range []string{"", " department", "department ", "Department.Name", "9department", "dеpartment"} {
+		if err := ValidateAttributeName(name); err == nil {
+			t.Fatalf("ValidateAttributeName(%q) accepted invalid name", name)
+		}
+	}
+}
+
+func TestCanonicalizeScalars(t *testing.T) {
+	tests := []struct {
+		name       string
+		typeName   Type
+		input      any
+		want       string
+		wantNative any
+	}{
+		{name: "string NFC", typeName: TypeString, input: "Cafe\u0301", want: "Café", wantNative: "Café"},
+		{name: "boolean", typeName: TypeBoolean, input: true, want: "true", wantNative: true},
+		{name: "integer", typeName: TypeInteger, input: int64(math.MinInt64), want: "-9223372036854775808", wantNative: int64(math.MinInt64)},
+		{name: "integer JSON", typeName: TypeInteger, input: json.Number("9223372036854775807"), want: "9223372036854775807", wantNative: int64(math.MaxInt64)},
+		{name: "decimal exponent", typeName: TypeDecimal, input: json.Number("1.2300e2"), want: "123", wantNative: json.Number("123")},
+		{name: "decimal negative zero", typeName: TypeDecimal, input: "-0.000", want: "0", wantNative: json.Number("0")},
+		{name: "decimal fractional", typeName: TypeDecimal, input: "9007199254740993.12500", want: "9007199254740993.125", wantNative: json.Number("9007199254740993.125")},
+		{name: "date", typeName: TypeDate, input: "2024-02-29", want: "2024-02-29", wantNative: "2024-02-29"},
+		{name: "timestamp UTC", typeName: TypeTimestamp, input: "2024-01-02T03:04:05.1200+02:30", want: "2024-01-02T00:34:05.12Z", wantNative: "2024-01-02T00:34:05.12Z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Canonicalize(tt.typeName, tt.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Type() != tt.typeName || got.Canonical() != tt.want {
+				t.Fatalf("Canonicalize() = (%q, %q), want (%q, %q)", got.Type(), got.Canonical(), tt.typeName, tt.want)
+			}
+			if native := got.Native(); native != tt.wantNative {
+				t.Fatalf("Native() = %#v, want %#v", native, tt.wantNative)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeRejectsInvalidOrCrossTypeValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeName Type
+		input    any
+	}{
+		{name: "null", typeName: TypeString, input: nil},
+		{name: "invalid UTF8", typeName: TypeString, input: string([]byte{0xff})},
+		{name: "C0 control", typeName: TypeString, input: "north\namerica"},
+		{name: "C1 control", typeName: TypeString, input: "north\u0085america"},
+		{name: "boolean string", typeName: TypeBoolean, input: "true"},
+		{name: "integer string", typeName: TypeInteger, input: "1"},
+		{name: "integer float", typeName: TypeInteger, input: float64(1)},
+		{name: "integer overflow", typeName: TypeInteger, input: json.Number("9223372036854775808")},
+		{name: "decimal float", typeName: TypeDecimal, input: float64(1.5)},
+		{name: "decimal infinite", typeName: TypeDecimal, input: "Infinity"},
+		{name: "bad date", typeName: TypeDate, input: "2023-02-29"},
+		{name: "date timestamp", typeName: TypeDate, input: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "timestamp without zone", typeName: TypeTimestamp, input: "2024-01-02T03:04:05"},
+		{name: "leap second", typeName: TypeTimestamp, input: "2016-12-31T23:59:60Z"},
+		{name: "unsupported float type", typeName: Type("Float"), input: 1.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := Canonicalize(tt.typeName, tt.input); err == nil {
+				t.Fatalf("Canonicalize(%q, %#v) accepted invalid value", tt.typeName, tt.input)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeSetNormalizesAsSortedSet(t *testing.T) {
+	got, err := CanonicalizeSet(TypeString, []any{"z", "Cafe\u0301", "Café", "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Type() != TypeString || got.Len() != 3 {
+		t.Fatalf("set = type %q len %d", got.Type(), got.Len())
+	}
+	want := []string{"Café", "a", "z"}
+	values := got.Values()
+	for index := range want {
+		if values[index].Canonical() != want[index] {
+			t.Fatalf("Values()[%d] = %q, want %q", index, values[index].Canonical(), want[index])
+		}
+	}
+	values[0] = Value{}
+	if got.Values()[0].Canonical() != want[0] {
+		t.Fatal("Values returned mutable internal storage")
+	}
+}
+
+func TestCanonicalizeSetRejectsEmptyAndMoreThanBound(t *testing.T) {
+	if _, err := CanonicalizeSet(TypeString, nil); err == nil {
+		t.Fatal("empty set accepted")
+	}
+	tooMany := make([]any, MaxSetValues+1)
+	for index := range tooMany {
+		tooMany[index] = strings.Repeat("x", index+1)
+	}
+	if _, err := CanonicalizeSet(TypeString, tooMany); err == nil {
+		t.Fatalf("set with %d canonical values accepted", len(tooMany))
+	}
+	duplicates := make([]any, MaxSetValues+1)
+	for index := range duplicates {
+		duplicates[index] = "same"
+	}
+	got, err := CanonicalizeSet(TypeString, duplicates)
+	if err != nil {
+		t.Fatalf("duplicates are bounded after set normalization: %v", err)
+	}
+	if got.Len() != 1 {
+		t.Fatalf("duplicate set len = %d, want 1", got.Len())
+	}
+}
+
+func TestCanonicalEncodingAndDigestAreStable(t *testing.T) {
+	scalar, err := Canonicalize(TypeTimestamp, "2024-01-02T03:04:05+02:30")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scalarWant := `{"profile":"leapview.semantic-access/v1","type":"Timestamp","value":"2024-01-02T00:34:05Z"}`
+	if got := string(scalar.CanonicalBytes()); got != scalarWant {
+		t.Fatalf("scalar CanonicalBytes() = %s, want %s", got, scalarWant)
+	}
+	if !strings.HasPrefix(scalar.Digest(), "sha256:") || len(scalar.Digest()) != len("sha256:")+64 {
+		t.Fatalf("scalar Digest() = %q", scalar.Digest())
+	}
+
+	left, err := CanonicalizeSet(TypeString, []any{"sales", "finance", "sales"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := CanonicalizeSet(TypeString, []any{"finance", "sales"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"profile":"leapview.semantic-access/v1","type":"String","values":["finance","sales"]}`
+	if got := string(left.CanonicalBytes()); got != want {
+		t.Fatalf("CanonicalBytes() = %s, want %s", got, want)
+	}
+	if string(right.CanonicalBytes()) != want || left.Digest() != right.Digest() {
+		t.Fatal("equivalent sets produced different identities")
+	}
+	if !strings.HasPrefix(left.Digest(), "sha256:") || len(left.Digest()) != len("sha256:")+64 {
+		t.Fatalf("Digest() = %q", left.Digest())
+	}
+}


### PR DESCRIPTION
## Problem

ADR-0017 defines one canonical typed-value profile for semantic access, but LeapView's existing semantic-filter coercion was local to the analytics model package and did not cover the full VAL-01–VAL-11 contract. That left future control-plane, compiler, runtime, cache, and audit consumers without a shared identity boundary.

Linear: https://linear.app/flid/issue/FAI-635/extract-and-strengthen-the-shared-typed-attribute-canonicalizer

## Root cause

The existing coercers predated the accepted semantic-access profile. They validated planner literals, but they did not provide a reusable profile-qualified scalar/set type, Unicode NFC and control-character handling, deterministic set identity, or cross-path golden evidence.

Go's `time.Parse(time.RFC3339Nano, ...)` is also permissive at the authorization boundary: it accepts comma-separated fractions and silently truncates precision beyond nanoseconds, which can collapse distinct timestamp inputs onto one canonical identity.

## Solution

- Add `internal/semanticvalue` as the first-class `leapview.semantic-access/v1` contract.
- Canonicalize String, Boolean, signed 64-bit Integer, exact Decimal, Date, Timestamp, and homogeneous sets with the fixed 1,024-value bound.
- Produce deterministic profile-qualified canonical bytes and SHA-256 identities.
- Reuse the shared contract from existing semantic-filter coercion.
- Register the package as an explicit architectural contract capability with a narrow analytics dependency.
- Validate timestamp syntax before parsing: require uppercase RFC 3339 separators, dot-only fractional seconds with at most nine digits, and `Z` or an in-range signed `HH:MM` offset.
- Record VAL-01–VAL-10 as implemented and retain VAL-11 as partial until generated canonicalization and every required consumer path are qualified.
- Scope the deterministic `allowed_regions_2` test fixture in the existing gitleaks non-secret allowlist after the generic API-key heuristic flagged it.

## Tests added/updated

- Scalar, invalid/cross-type, set-bound, immutability, encoding, and digest tests.
- Independent `profile-v1` golden fixture consumed by the shared package and semantic-filter path.
- Semantic-filter integration coverage for NFC, controls, cross-type denial, decimal normalization, and UTC timestamps.
- Architecture classification and published-contract coverage.
- Regression coverage accepts nine fractional digits, rejects ten fractional digits and comma separators, rejects malformed/out-of-range offsets, and proves equivalent valid timestamps share canonical and digest identities.

## Verification performed

- `go test -count=1 ./internal/semanticvalue ./internal/analytics/model ./internal/platform/architecture` passed on the final local tree for commit `0c011fb6`.
- `git diff --check` passed before each follow-up commit.
- The first architecture attempt was blocked because the sandbox could not download `github.com/stretchr/testify`; rerunning with network access downloaded the dependency and the architecture suite passed.
- The repository source-security runner reported no leaks in both the current-tree and `origin/main..HEAD` candidate-history gitleaks scans. Its local Trivy phase could not run because Docker access is unavailable; this limitation is explicit rather than treated as a pass.
- All final-head GitHub checks passed, including the aggregate CI and Security gates, Go and frontend lanes, APIGen, spatial benchmarks, Secret and IaC policy, dependency policy, SAST, and CodeQL.

## Review feedback addressed

- Strict timestamp validation now prevents precision truncation and comma-separator aliasing before `time.Parse` can canonicalize the value.
- The conformance ledger now splits VAL-01–VAL-10 from VAL-11 and explicitly lists the generated and consumer integrations that remain unqualified.
- The security-gate false positive on the deterministic attribute-name fixture is narrowly covered by the repository's existing non-secret gitleaks stopword mechanism.

## Remaining limitations

- VAL-11 remains partial: generated canonicalization plus control-plane ingestion, claims, candidate validation, runtime evaluation, policy digesting, caching, and audit projection still require qualification.
- SemanticModel's generated TypeSpec shape is tracked by FAI-619.
- The typed control-plane attribute registry is tracked by FAI-636.
- Access-grant compilation and typed security-filter planning are tracked by FAI-639 and remain dependent on FAI-619 plus this contract.
- This PR deliberately does not remove the transitional DataPolicy resource; that work remains sequenced under ADR-0016/FAI-649.
