### PR TITLE
[FAI-655] Preserve governed exploration URL state

### DIFF
--- a/internal/project/http/browser.go
+++ b/internal/project/http/browser.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	stdhttp "net/http"
 	"net/url"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1496,12 +1498,104 @@ func projectAreaType(area string) string {
 }
 
 func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhttp.Request) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
+	values, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		stdhttp.Error(w, "invalid exploration URL: "+err.Error(), stdhttp.StatusBadRequest)
+		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+	}
 	command := projectsignals.DataExplorerCommand{
-		ObjectKey: projectsignals.Optional(strings.TrimSpace(r.URL.Query().Get("object"))),
-		Mode:      projectsignals.Optional(strings.TrimSpace(r.URL.Query().Get("mode"))),
+		ObjectKey: projectsignals.Optional(strings.TrimSpace(values.Get("object"))),
+		Mode:      projectsignals.Optional(strings.TrimSpace(values.Get("mode"))),
 		Limit:     dataExplorerDefaultLimit, Count: dataExplorerDefaultLimit, Block: projectsignals.Pointer("all"),
 	}
+	if projectsignals.ValueOrZero(command.Mode) == "explore" {
+		explore, err := dataExploreCommandFromQuery(values)
+		if err != nil {
+			stdhttp.Error(w, "invalid exploration URL: "+err.Error(), stdhttp.StatusBadRequest)
+			return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+		}
+		command.Explore = &explore
+	}
 	return h.dataExplorerSignalsForCommand(w, r, command)
+}
+
+const dataExploreURLVersion = "1"
+
+func dataExploreCommandFromQuery(values url.Values) (projectsignals.DataExploreCommand, error) {
+	command := projectsignals.DataExploreCommand{
+		Dimensions: append([]string{}, values["dimension"]...),
+		Metrics:    append([]string{}, values["metric"]...),
+		Filters:    []projectsignals.DataExploreFilterSignal{},
+		Sort:       []projectsignals.DataExploreSortSignal{},
+		Limit:      dataExplorerDefaultLimit,
+	}
+	for _, field := range append(append([]string(nil), command.Dimensions...), command.Metrics...) {
+		if strings.TrimSpace(field) == "" {
+			return command, errors.New("dimension and metric identifiers must not be empty")
+		}
+	}
+	if version := strings.TrimSpace(values.Get("v")); version != "" && version != dataExploreURLVersion {
+		return command, fmt.Errorf("unsupported version %q", version)
+	}
+	if value := strings.TrimSpace(values.Get("model")); value != "" {
+		command.ModelID = projectsignals.Optional(value)
+	}
+	if value := strings.TrimSpace(values.Get("dataset")); value != "" {
+		command.DatasetID = projectsignals.Optional(value)
+	}
+	for _, value := range values["filter"] {
+		var filter projectsignals.DataExploreFilterSignal
+		if err := decodeDataExploreURLValue(value, &filter); err != nil {
+			return command, fmt.Errorf("filter: %w", err)
+		}
+		if strings.TrimSpace(filter.Field) == "" || strings.TrimSpace(filter.Operator) == "" || filter.Values == nil {
+			return command, errors.New("filter field, operator, and values are required")
+		}
+		command.Filters = append(command.Filters, filter)
+	}
+	for _, value := range values["sort"] {
+		var sorting projectsignals.DataExploreSortSignal
+		if err := decodeDataExploreURLValue(value, &sorting); err != nil {
+			return command, fmt.Errorf("sort: %w", err)
+		}
+		if strings.TrimSpace(sorting.Field) == "" || (sorting.Direction != "asc" && sorting.Direction != "desc") {
+			return command, errors.New("sort field and asc or desc direction are required")
+		}
+		command.Sort = append(command.Sort, sorting)
+	}
+	if value := values.Get("time"); value != "" {
+		var timeSelection projectsignals.DataExploreTimeSignal
+		if err := decodeDataExploreURLValue(value, &timeSelection); err != nil {
+			return command, fmt.Errorf("time: %w", err)
+		}
+		if strings.TrimSpace(timeSelection.Field) == "" || strings.TrimSpace(timeSelection.Grain) == "" {
+			return command, errors.New("time field and grain are required")
+		}
+		command.Time = &timeSelection
+	}
+	if value := strings.TrimSpace(values.Get("limit")); value != "" {
+		limit, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || limit <= 0 || limit > dataExplorerMaximumLimit {
+			return command, fmt.Errorf("limit must be between 1 and %d", dataExplorerMaximumLimit)
+		}
+		command.Limit = limit
+	}
+	return command, nil
+}
+
+func decodeDataExploreURLValue(value string, target any) error {
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
 }
 
 func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter, r *stdhttp.Request, command projectsignals.DataExplorerCommand) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {

--- a/internal/project/http/browser_test.go
+++ b/internal/project/http/browser_test.go
@@ -867,9 +867,72 @@ func TestDataExplorerSignalsUseAuthorizedActiveDefinition(t *testing.T) {
 	if len(explorer.Explore.Models) != 1 || len(explorer.Explore.Datasets) != 1 || len(explorer.Explore.Fields) != 1 {
 		t.Fatalf("explore signal = %#v", explorer.Explore)
 	}
-	_, semanticExplorer, ok := h.dataExplorerSignals(recorder, httptest.NewRequest(stdhttp.MethodGet, "/explore?mode=explore&model=semantic:sales&dataset=orders", nil))
+	_, semanticExplorer, ok := h.dataExplorerSignals(recorder, httptest.NewRequest(stdhttp.MethodGet, "/explore?v=1&mode=explore&model=semantic:sales&dataset=orders&dimension=orders.status&filter=%7B%22field%22%3A%22orders.status%22%2C%22operator%22%3A%22equals%22%2C%22values%22%3A%5B%22paid%22%5D%7D&sort=%7B%22field%22%3A%22orders.status%22%2C%22direction%22%3A%22asc%22%7D&limit=25", nil))
 	if !ok || projectsignals.ValueOrZero(semanticExplorer.Command.Mode) != "explore" || semanticExplorer.SelectedObject == nil || semanticExplorer.SelectedObject.ResourceID != "model:orders" {
 		t.Fatalf("semantic deep link = %#v", semanticExplorer)
+	}
+	if !reflect.DeepEqual(semanticExplorer.Explore.Command.Dimensions, []string{"orders.status"}) || len(semanticExplorer.Explore.Command.Filters) != 1 || len(semanticExplorer.Explore.Command.Sort) != 1 || semanticExplorer.Explore.Command.Limit != 25 {
+		t.Fatalf("semantic deep-link state = %#v", semanticExplorer.Explore.Command)
+	}
+}
+
+func TestDataExploreCommandFromQueryRoundTripsDurableState(t *testing.T) {
+	values, err := url.ParseQuery("v=1&mode=explore&model=semantic%3Asales&dataset=orders&dimension=orders.month&dimension=customers.state&metric=revenue&filter=%7B%22field%22%3A%22customers.state%22%2C%22operator%22%3A%22equals%22%2C%22values%22%3A%5B%22CA%22%5D%7D&sort=%7B%22field%22%3A%22revenue%22%2C%22direction%22%3A%22desc%22%7D&time=%7B%22field%22%3A%22orders.created_at%22%2C%22grain%22%3A%22month%22%7D&limit=250")
+	if err != nil {
+		t.Fatal(err)
+	}
+	command, err := dataExploreCommandFromQuery(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projectsignals.ValueOrZero(command.ModelID) != "semantic:sales" || projectsignals.ValueOrZero(command.DatasetID) != "orders" {
+		t.Fatalf("target = %q/%q", projectsignals.ValueOrZero(command.ModelID), projectsignals.ValueOrZero(command.DatasetID))
+	}
+	if !reflect.DeepEqual(command.Dimensions, []string{"orders.month", "customers.state"}) || !reflect.DeepEqual(command.Metrics, []string{"revenue"}) {
+		t.Fatalf("fields = %#v / %#v", command.Dimensions, command.Metrics)
+	}
+	if len(command.Filters) != 1 || command.Filters[0].Field != "customers.state" || command.Filters[0].Values[0] != "CA" {
+		t.Fatalf("filters = %#v", command.Filters)
+	}
+	if len(command.Sort) != 1 || command.Sort[0].Field != "revenue" || command.Sort[0].Direction != "desc" {
+		t.Fatalf("sort = %#v", command.Sort)
+	}
+	if command.Time == nil || command.Time.Field != "orders.created_at" || command.Time.Grain != "month" || command.Limit != 250 {
+		t.Fatalf("time/limit = %#v / %d", command.Time, command.Limit)
+	}
+	if command.RequestSeq != 0 || command.ResetVersion != 0 {
+		t.Fatalf("runtime state leaked into URL command: %#v", command)
+	}
+}
+
+func TestDataExploreCommandFromQueryAcceptsLegacyAndRejectsMalformedState(t *testing.T) {
+	legacy, err := dataExploreCommandFromQuery(url.Values{"model": {"semantic:sales"}, "dataset": {"orders"}})
+	if err != nil || legacy.Limit != dataExplorerDefaultLimit || legacy.Dimensions == nil || legacy.Metrics == nil {
+		t.Fatalf("legacy query = %#v, %v", legacy, err)
+	}
+
+	tests := []url.Values{
+		{"v": {"2"}},
+		{"limit": {"0"}},
+		{"limit": {"1001"}},
+		{"filter": {`{"field":"status","operator":"equals","values":[],"unexpected":true}`}},
+		{"sort": {`{"field":"revenue","direction":"sideways"}`}},
+		{"time": {`{"field":"created_at","grain":"month"} trailing`}},
+	}
+	for _, values := range tests {
+		if command, err := dataExploreCommandFromQuery(values); err == nil {
+			t.Fatalf("query %#v accepted as %#v", values, command)
+		}
+	}
+}
+
+func TestDataExplorerSignalsRejectsMalformedQueryEscaping(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	if _, _, ok := (&BrowserHandler{}).dataExplorerSignals(recorder, httptest.NewRequest(stdhttp.MethodGet, "/explore?mode=explore&filter=%ZZ", nil)); ok {
+		t.Fatal("malformed query escaping was accepted")
+	}
+	if recorder.Code != stdhttp.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, stdhttp.StatusBadRequest)
 	}
 }
 

--- a/internal/project/ui/data_explorer.go
+++ b/internal/project/ui/data_explorer.go
@@ -1,6 +1,10 @@
 package ui
 
 import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
 	"github.com/flidai/leapview/internal/dashboard"
 	uiactions "github.com/flidai/leapview/internal/platform/web/actions"
 	webpage "github.com/flidai/leapview/internal/platform/web/page"
@@ -32,7 +36,7 @@ func DataExplorerPage(catalog catalog.Catalog, page uisignals.DataExplorerPageSi
 
 func DataExplorerPageWithAgent(_ catalog.Catalog, page uisignals.DataExplorerPageSignal, explorer uisignals.DataExplorerSignal, agent DataExplorerAgentBootstrap, commands DataExplorerAgentCommandBindings, csrfToken string, providers ...webpage.Provider) g.Node {
 	layout := webpage.Resolve(firstProvider(providers), webpage.Context{Active: "data-explorer", PageTitle: page.Title})
-	explorerUpdatesURL := updatesURL(uisignals.RouteKindData, "surface", "explore", "object", uisignals.ValueOrZero(explorer.Command.ObjectKey))
+	explorerUpdatesURL := dataExplorerUpdatesURL(explorer.Command)
 	agentTurn := "$agent.composer.value = evt.detail.input; $agentContext.references = evt.detail.references; " + uiactions.CommandPostConditional("$agent.activeConversationId", []uicommand.Binding{commands.CreateRun}, commands.Workflow(), "/chats/turns", "agent", "agentContext")
 	agentRestore := "$agent.activeConversationId = evt.detail.conversationId; " + uiactions.Get("/chats/restore", "agent")
 	return webpage.Render(layout, webpage.Spec{
@@ -51,6 +55,45 @@ func DataExplorerPageWithAgent(_ catalog.Catalog, page uisignals.DataExplorerPag
 		},
 	})
 }
+
+func dataExplorerUpdatesURL(command uisignals.DataExplorerCommand) string {
+	values := url.Values{"route": {string(uisignals.RouteKindData)}, "surface": {"explore"}}
+	if uisignals.ValueOrZero(command.Mode) != "explore" || command.Explore == nil {
+		if object := uisignals.ValueOrZero(command.ObjectKey); object != "" {
+			values.Set("object", object)
+		}
+		return "/updates?" + values.Encode()
+	}
+	explore := command.Explore
+	values.Set("v", "1")
+	values.Set("mode", "explore")
+	values.Set("model", uisignals.ValueOrZero(explore.ModelID))
+	values.Set("dataset", uisignals.ValueOrZero(explore.DatasetID))
+	for _, dimension := range explore.Dimensions {
+		values.Add("dimension", dimension)
+	}
+	for _, metric := range explore.Metrics {
+		values.Add("metric", metric)
+	}
+	for _, filter := range explore.Filters {
+		encoded, _ := json.Marshal(filter)
+		values.Add("filter", string(encoded))
+	}
+	for _, sorting := range explore.Sort {
+		encoded, _ := json.Marshal(sorting)
+		values.Add("sort", string(encoded))
+	}
+	if explore.Time != nil {
+		encoded, _ := json.Marshal(explore.Time)
+		values.Set("time", string(encoded))
+	}
+	if explore.Limit != dataExplorerDefaultLimit {
+		values.Set("limit", strconv.FormatInt(explore.Limit, 10))
+	}
+	return "/updates?" + values.Encode()
+}
+
+const dataExplorerDefaultLimit = int64(100)
 
 func DataExplorerBootstrapSignals(catalog catalog.Catalog, page uisignals.DataExplorerPageSignal, explorer uisignals.DataExplorerSignal, providers ...webpage.Provider) map[string]any {
 	return DataExplorerBootstrapSignalsWithAgent(catalog, page, explorer, DataExplorerAgentBootstrap{}, providers...)

--- a/internal/project/ui/data_explorer_test.go
+++ b/internal/project/ui/data_explorer_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"net/url"
+	"reflect"
 	"testing"
 
 	catalog "github.com/flidai/leapview/internal/project/navigation"
@@ -27,6 +29,31 @@ func TestDataExplorerBootstrapProjectsAgentExplorationContext(t *testing.T) {
 	}
 	if signals["agent"] == nil || signals["agentVisuals"] == nil {
 		t.Fatalf("agent bootstrap = %#v", signals)
+	}
+}
+
+func TestDataExplorerUpdatesURLPreservesDurableExplorationState(t *testing.T) {
+	command := uisignals.DataExplorerCommand{Mode: uisignals.Pointer("explore"), RequestSeq: 80, ResetVersion: 9, Explore: &uisignals.DataExploreCommand{
+		ModelID: uisignals.Pointer("semantic:sales"), DatasetID: uisignals.Pointer("orders"),
+		Dimensions: []string{"orders.month"}, Metrics: []string{"revenue"},
+		Filters: []uisignals.DataExploreFilterSignal{{Field: "orders.state", Operator: "equals", Values: []string{"paid"}}},
+		Sort:    []uisignals.DataExploreSortSignal{{Field: "revenue", Direction: "desc"}},
+		Time:    &uisignals.DataExploreTimeSignal{Field: "orders.created_at", Grain: "month"}, Limit: 250,
+		RequestSeq: 81, ResetVersion: 10,
+	}}
+	updates, err := url.Parse(dataExplorerUpdatesURL(command))
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := updates.Query()
+	if values.Get("route") != "data" || values.Get("surface") != "explore" || values.Get("mode") != "explore" || values.Get("v") != "1" {
+		t.Fatalf("routing values = %#v", values)
+	}
+	if !reflect.DeepEqual(values["dimension"], []string{"orders.month"}) || !reflect.DeepEqual(values["metric"], []string{"revenue"}) || values.Get("limit") != "250" {
+		t.Fatalf("exploration values = %#v", values)
+	}
+	if values.Has("requestSeq") || values.Has("resetVersion") {
+		t.Fatalf("runtime state leaked into updates URL: %#v", values)
 	}
 }
 

--- a/web/components/data/data-explorer-url.test.ts
+++ b/web/components/data/data-explorer-url.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'bun:test'
+import type { DataExplorerCommand } from '../../generated/signals'
+import { dataExplorerURL } from './data-explorer-url'
+
+test('exploration URL deterministically includes durable query state only', () => {
+  const command = {
+    mode: 'explore',
+    requestSeq: 91,
+    resetVersion: 18,
+    explore: {
+      modelId: 'semantic:sales',
+      datasetId: 'orders',
+      dimensions: ['orders.month', 'customers.state'],
+      metrics: ['revenue'],
+      filters: [{ field: 'customers.state', operator: 'equals', values: ['CA'] }],
+      sort: [{ field: 'revenue', direction: 'desc' }],
+      time: { field: 'orders.created_at', grain: 'month' },
+      limit: 250,
+      requestSeq: 92,
+      resetVersion: 19,
+    },
+  } as DataExplorerCommand
+
+  const url = dataExplorerURL(command)
+  const parsed = new URL(url, 'https://example.test')
+  expect(parsed.searchParams.get('v')).toBe('1')
+  expect(parsed.searchParams.getAll('dimension')).toEqual(['orders.month', 'customers.state'])
+  expect(parsed.searchParams.getAll('metric')).toEqual(['revenue'])
+  expect(parsed.searchParams.get('limit')).toBe('250')
+  expect(parsed.searchParams.has('requestSeq')).toBe(false)
+  expect(parsed.searchParams.has('resetVersion')).toBe(false)
+  expect(dataExplorerURL(command)).toBe(url)
+})
+
+test('browse URL preserves only the selected object', () => {
+  expect(dataExplorerURL({ mode: 'browse', objectKey: 'model:orders' } as DataExplorerCommand)).toBe('/explore?object=model%3Aorders')
+})

--- a/web/components/data/data-explorer-url.ts
+++ b/web/components/data/data-explorer-url.ts
@@ -1,0 +1,22 @@
+import type { DataExplorerCommand } from '../../generated/signals'
+
+export function dataExplorerURL(command: DataExplorerCommand): string {
+  const mode = command.mode === 'explore' ? 'explore' : 'browse'
+  const objectKey = command.objectKey || ''
+  const params = new URLSearchParams()
+  if (mode === 'explore') {
+    params.set('v', '1')
+    params.set('mode', 'explore')
+    if (command.explore?.modelId) params.set('model', command.explore.modelId)
+    if (command.explore?.datasetId) params.set('dataset', command.explore.datasetId)
+    for (const field of command.explore?.dimensions ?? []) params.append('dimension', field)
+    for (const metric of command.explore?.metrics ?? []) params.append('metric', metric)
+    for (const filter of command.explore?.filters ?? []) params.append('filter', JSON.stringify(filter))
+    for (const sort of command.explore?.sort ?? []) params.append('sort', JSON.stringify(sort))
+    if (command.explore?.time) params.set('time', JSON.stringify(command.explore.time))
+    if (command.explore?.limit && command.explore.limit !== 100) params.set('limit', String(command.explore.limit))
+  } else if (objectKey) {
+    params.set('object', objectKey)
+  }
+  return params.toString() ? `/explore?${params.toString()}` : '/explore'
+}

--- a/web/components/data/data-explorer.ts
+++ b/web/components/data/data-explorer.ts
@@ -26,6 +26,7 @@ import {
   DataExplorerSelectionController,
   toggleVisibleColumns,
 } from './data-explorer-controller'
+import { dataExplorerURL } from './data-explorer-url'
 import '../chat/chat-drawer'
 import './preview-table'
 import './explore-table'
@@ -1935,23 +1936,7 @@ function datasetGrainLabel(dataset: DataExploreDatasetSignal): string {
 
 function replaceDataExplorerURL(command: DataExplorerCommand) {
   if (typeof window === 'undefined') return
-  const mode = command.mode === 'explore' ? 'explore' : 'browse'
-  const objectKey = command.objectKey || ''
-  const params = new URLSearchParams()
-  if (mode === 'explore') {
-    params.set('mode', 'explore')
-    if (command.explore?.modelId) params.set('model', command.explore.modelId)
-    if (command.explore?.datasetId) params.set('dataset', command.explore.datasetId)
-    for (const field of command.explore?.dimensions ?? []) params.append('dimension', field)
-    for (const metric of command.explore?.metrics ?? []) params.append('metric', metric)
-    for (const filter of command.explore?.filters ?? []) params.append('filter', JSON.stringify(filter))
-    for (const sort of command.explore?.sort ?? []) params.append('sort', JSON.stringify(sort))
-    if (command.explore?.time) params.set('time', JSON.stringify(command.explore.time))
-    if (command.explore?.limit && command.explore.limit !== 100) params.set('limit', String(command.explore.limit))
-  } else if (objectKey) {
-    params.set('object', objectKey)
-  }
-  const next = params.toString() ? `/explore?${params.toString()}` : '/explore'
+  const next = dataExplorerURL(command)
   if (window.location.pathname + window.location.search !== next) {
     window.history.replaceState({}, '', next)
   }


### PR DESCRIPTION
## Summary

- round-trip durable governed exploration query state through versioned URLs
- preserve the same state in the initial Datastar SSE bootstrap
- reject malformed, unsupported, or structurally invalid URL state before query execution
- exclude request/reset sequence fields from shareable state

## Validation

- `go test ./internal/project/http ./internal/project/ui -count=1`
- `bun test web/components/data/data-explorer-url.test.ts`
- `task ci:test:frontend:data`

## Linear

Foundation slice of [FAI-655](https://linear.app/flid/issue/FAI-655/define-canonical-exploration-specification-and-complete-url-round). The issue remains open for the broader typed saved/display/pivot specification.
