### PR TITLE
Implement PostgreSQL typed attribute registry

### DIFF
--- a/docs/articles/architecture/postgresql-authority-reconciliation.md
+++ b/docs/articles/architecture/postgresql-authority-reconciliation.md
@@ -111,7 +111,8 @@ The required PostgreSQL lane must report an unavailable Docker provider or
 pinned image as a failure. Local optional runs may skip only when
 `LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED` is unset.
 
-FAI-636 remains blocked until this reconciliation is reviewed and merged.
-After that merge, its typed attribute registry must append a capability-owned
-forward migration and reuse the merged semantic-value canonicalizer. This
-change does not alter the partial VAL-11 qualification boundary.
+PR #460 merged the reconciliation. FAI-636 builds on it with an access-owned
+forward migration and the merged semantic-value canonicalizer; it does not
+rewrite this baseline. Attribute assignments and the remaining consumer paths
+stay outside the registry milestone, so the partial VAL-11 qualification
+boundary is unchanged.

--- a/docs/articles/architecture/semantic-attribute-registry.md
+++ b/docs/articles/architecture/semantic-attribute-registry.md
@@ -1,0 +1,76 @@
+# Semantic attribute registry
+
+The PostgreSQL semantic attribute registry is the control-plane authority for
+typed semantic-access attribute definitions. It gives each definition a stable
+identity, a closed logical type and shape, versioned ownership and documentation
+metadata, and an explicit active or disabled lifecycle. It does not store
+principal assignments or trusted claim mappings.
+
+## Capability ownership
+
+The access capability owns the revision-2 migration, sqlc queries, domain
+contract, repository, validation, and transactional audit records. The generic
+PostgreSQL migration runner owns only advisory locking, ordered revision
+application, checksum evidence, and replay verification. Revision 1 remains
+byte-for-byte immutable; the registry is an access-owned forward migration.
+
+The registry uses the reconciled PostgreSQL authority roles. The runtime role
+can read and mutate definitions through the access repository, readonly and
+backup roles can project non-secret registry metadata, and deletes are denied.
+Each repository mutation uses a caller-owned transaction and appends immutable
+audit evidence before that transaction can commit.
+
+## Definition and registry identity
+
+Each `access.semantic_attribute_definition` row contains:
+
+- an immutable UUID and case-sensitive semantic attribute name;
+- one logical type from `String`, `Boolean`, `Integer`, `Decimal`, `Date`, or
+  `Timestamp`;
+- a `scalar` or homogeneous `list` shape;
+- the `leapview.semantic-access/v1` canonicalization profile;
+- instance, principal, or group ownership metadata;
+- display name, description, and optional credential-free HTTPS documentation
+  URL;
+- a monotonically increasing definition version; and
+- database-owned creation, update, and disable timestamps.
+
+The UUID, name, type, shape, profile, and creation timestamp cannot be rewritten.
+Metadata and lifecycle changes advance the definition version exactly once.
+Definitions are disabled and re-enabled rather than deleted.
+
+`access.semantic_attribute_registry` is a singleton compatibility identity.
+Every effective definition change advances its revision and replaces its
+SHA-256 digest in the same caller-owned transaction. Reads recompute the digest
+from the ordered definition projection and fail closed when stored and computed
+identities differ. Idempotent replays do not advance either revision.
+
+## Repository lifecycle
+
+The access repository supports registration, lookup by name or stable UUID,
+ordered listing/search, metadata changes, and lifecycle transitions. Registering
+an existing name with the same type and shape is a replay; registering the name
+with a different type or shape returns a compatibility conflict. A logical type
+change therefore requires a new attribute identity instead of an in-place
+rewrite.
+
+Before a consumer accepts an attribute value, the repository loads the active
+definition and delegates canonicalization to `internal/semanticvalue`. Scalars
+produce one canonical value identity. Lists use the v1 bounded homogeneous-set
+contract, including canonical sorting and deduplication. Disabled definitions
+fail closed. Values themselves are not persisted by this registry.
+
+## Semantic access boundary
+
+This registry qualifies the definition-storage part of ADR-0017 and provides a
+stable identity for later assignment and consumer integrations. It deliberately
+does not implement principal or group assignments, claim ingestion, semantic
+filter evaluation, policy digest propagation, cache identity, or audit value
+projection. Those paths remain separately qualified work, so VAL-11 remains
+partial.
+
+Migration tests cover ordered revision application and replay identity.
+Repository tests cover stable registration, lookup/search, canonical value
+validation, metadata versioning, disablement, immutable type enforcement,
+registry digests, and transactional audit evidence against the PostgreSQL 18
+harness.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -241,6 +241,7 @@ Focused slices are available at `/docs/agent-tools/tools/{name}.json|md`, `/docs
 - [Architecture overview](/docs/architecture): See how the monolith, contracts, storage, and browser components fit together.
 - [Runtime architecture](/docs/architecture/runtime): Follow routing, query execution, and streamed UI updates.
 - [PostgreSQL authority reconciliation](/docs/architecture/postgresql-authority-reconciliation): Understand the reconciled PostgreSQL ownership, transaction, role, and compatibility boundaries.
+- [Semantic attribute registry](/docs/architecture/semantic-attribute-registry): Understand typed semantic attribute identity, ownership, lifecycle, and compatibility boundaries.
 - [Evidence-gated Arrow optimization](/docs/architecture/arrow-optimization-evidence): Measure dashboard Arrow boundaries before approving a production migration.
 - [Dashboard native Arrow response contract](/docs/architecture/dashboard-native-arrow-contract): Define the native-v1 schema, protocol, governance, pagination, and compatibility oracle for future dashboard Arrow experiments.
 - [Cross-role journey qualification](/docs/architecture/journey-qualification): Map FAI-492 consumer, creator, and operator states to executable assembled-app checks and evidence rules.

--- a/docs/navigation.yaml
+++ b/docs/navigation.yaml
@@ -540,6 +540,11 @@ sections:
             type: explanation
             summary: Understand the reconciled PostgreSQL ownership, transaction, role, and compatibility boundaries.
             source: articles/architecture/postgresql-authority-reconciliation.md
+          - slug: architecture/semantic-attribute-registry
+            title: Semantic attribute registry
+            type: explanation
+            summary: Understand typed semantic attribute identity, ownership, lifecycle, and compatibility boundaries.
+            source: articles/architecture/semantic-attribute-registry.md
           - slug: architecture/arrow-optimization-evidence
             title: Evidence-gated Arrow optimization
             type: explanation

--- a/internal/access/postgres/attribute_migration.go
+++ b/internal/access/postgres/attribute_migration.go
@@ -1,0 +1,17 @@
+package postgres
+
+import _ "embed"
+
+const (
+	// AttributeRegistryMigrationRevision is the first forward-only extension to
+	// the reconciled PostgreSQL control-plane baseline.
+	AttributeRegistryMigrationRevision int64 = 2
+	AttributeRegistryMigrationID             = "002_typed_attribute_registry"
+)
+
+//go:embed migrations/002_typed_attribute_registry.sql
+var attributeRegistryMigrationSQL string
+
+// AttributeRegistryMigrationSQL returns the access-owned immutable forward
+// migration for application-level PostgreSQL migration composition.
+func AttributeRegistryMigrationSQL() string { return attributeRegistryMigrationSQL }

--- a/internal/access/postgres/migrations/002_typed_attribute_registry.sql
+++ b/internal/access/postgres/migrations/002_typed_attribute_registry.sql
@@ -1,0 +1,142 @@
+-- FAI-636: typed semantic-access attribute registry.
+--
+-- This is a forward-only access-capability migration. It must not be folded
+-- into schema.sql because revision 1 is already an immutable, recorded
+-- baseline. Principal assignments and trusted claim mappings deliberately
+-- remain outside this registry migration.
+
+CREATE TABLE access.semantic_attribute_registry (
+    singleton          boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    profile            text NOT NULL CHECK (profile = 'leapview.semantic-access/v1'),
+    registry_revision  bigint NOT NULL DEFAULT 0 CHECK (registry_revision >= 0),
+    registry_digest    text NOT NULL CHECK (registry_digest ~ '^sha256:[0-9a-f]{64}$'),
+    updated_at         timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+
+INSERT INTO access.semantic_attribute_registry
+    (singleton, profile, registry_revision, registry_digest)
+VALUES
+    (true, 'leapview.semantic-access/v1', 0,
+     'sha256:9362dbdb62923a10f67bc1da04b02e2bbad74dce5b5442aaa3fb5e0cc5851b9d')
+ON CONFLICT (singleton) DO NOTHING;
+
+CREATE TABLE access.semantic_attribute_definition (
+    definition_id      uuid PRIMARY KEY DEFAULT uuidv7(),
+    name               text NOT NULL UNIQUE
+                       CHECK (name ~ '^[A-Za-z_][A-Za-z0-9_]*$'),
+    value_type         text NOT NULL
+                       CHECK (value_type IN ('String','Boolean','Integer','Decimal','Date','Timestamp')),
+    value_shape        text NOT NULL CHECK (value_shape IN ('scalar','list')),
+    profile            text NOT NULL CHECK (profile = 'leapview.semantic-access/v1'),
+    definition_version bigint NOT NULL DEFAULT 1 CHECK (definition_version > 0),
+    owner_kind         text NOT NULL DEFAULT 'instance'
+                       CHECK (owner_kind IN ('instance','principal','group')),
+    owner_id           uuid,
+    display_name       text NOT NULL DEFAULT '' CHECK (length(display_name) <= 255),
+    description        text NOT NULL DEFAULT '' CHECK (length(description) <= 4096),
+    documentation_url  text NOT NULL DEFAULT '' CHECK (length(documentation_url) <= 2048),
+    enabled            boolean NOT NULL DEFAULT true,
+    disabled_at        timestamptz,
+    created_at         timestamptz NOT NULL DEFAULT clock_timestamp(),
+    updated_at         timestamptz NOT NULL DEFAULT clock_timestamp(),
+    CHECK ((owner_kind = 'instance' AND owner_id IS NULL) OR
+           (owner_kind <> 'instance' AND owner_id IS NOT NULL)),
+    CHECK ((enabled AND disabled_at IS NULL) OR (NOT enabled AND disabled_at IS NOT NULL))
+);
+CREATE INDEX semantic_attribute_definition_owner_idx
+    ON access.semantic_attribute_definition(owner_kind, owner_id, name);
+
+CREATE OR REPLACE FUNCTION access.reject_semantic_attribute_registry_rewrite()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, access
+AS $$
+BEGIN
+    IF OLD.singleton <> NEW.singleton OR OLD.profile <> NEW.profile THEN
+        RAISE EXCEPTION 'semantic attribute registry identity is immutable';
+    END IF;
+    IF NEW.registry_revision <> OLD.registry_revision + 1 OR
+       NEW.registry_digest = OLD.registry_digest THEN
+        RAISE EXCEPTION 'semantic attribute registry revision must advance with a new digest';
+    END IF;
+    NEW.updated_at := GREATEST(clock_timestamp(), OLD.updated_at + interval '1 microsecond');
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION access.reject_semantic_attribute_definition_rewrite()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, access
+AS $$
+BEGIN
+    IF OLD.definition_id <> NEW.definition_id OR
+       OLD.name <> NEW.name OR
+       OLD.value_type <> NEW.value_type OR
+       OLD.value_shape <> NEW.value_shape OR
+       OLD.profile <> NEW.profile OR
+       OLD.created_at <> NEW.created_at THEN
+        RAISE EXCEPTION 'semantic attribute identity and type are immutable';
+    END IF;
+    IF NEW.definition_version <> OLD.definition_version + 1 THEN
+        RAISE EXCEPTION 'semantic attribute definition version must advance exactly once';
+    END IF;
+    IF OLD.owner_kind = NEW.owner_kind AND
+       OLD.owner_id IS NOT DISTINCT FROM NEW.owner_id AND
+       OLD.display_name = NEW.display_name AND
+       OLD.description = NEW.description AND
+       OLD.documentation_url = NEW.documentation_url AND
+       OLD.enabled = NEW.enabled AND
+       OLD.disabled_at IS NOT DISTINCT FROM NEW.disabled_at THEN
+        RAISE EXCEPTION 'semantic attribute update did not change mutable state';
+    END IF;
+    IF OLD.enabled = NEW.enabled AND OLD.disabled_at IS DISTINCT FROM NEW.disabled_at THEN
+        RAISE EXCEPTION 'semantic attribute disable timestamp is database-owned';
+    END IF;
+    IF OLD.enabled <> NEW.enabled THEN
+        NEW.disabled_at := CASE WHEN NEW.enabled THEN NULL ELSE clock_timestamp() END;
+    END IF;
+    NEW.updated_at := GREATEST(clock_timestamp(), OLD.updated_at + interval '1 microsecond');
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER semantic_attribute_registry_no_delete
+    BEFORE DELETE ON access.semantic_attribute_registry
+    FOR EACH ROW EXECUTE FUNCTION access.reject_access_delete();
+CREATE TRIGGER semantic_attribute_registry_immutable
+    BEFORE UPDATE ON access.semantic_attribute_registry
+    FOR EACH ROW EXECUTE FUNCTION access.reject_semantic_attribute_registry_rewrite();
+CREATE TRIGGER semantic_attribute_definition_no_delete
+    BEFORE DELETE ON access.semantic_attribute_definition
+    FOR EACH ROW EXECUTE FUNCTION access.reject_access_delete();
+CREATE TRIGGER semantic_attribute_definition_immutable
+    BEFORE UPDATE ON access.semantic_attribute_definition
+    FOR EACH ROW EXECUTE FUNCTION access.reject_semantic_attribute_definition_rewrite();
+
+REVOKE ALL ON TABLE access.semantic_attribute_registry,
+    access.semantic_attribute_definition FROM PUBLIC;
+REVOKE ALL ON FUNCTION access.reject_semantic_attribute_registry_rewrite(),
+    access.reject_semantic_attribute_definition_rewrite() FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_runtime') THEN
+        GRANT SELECT, INSERT, UPDATE ON access.semantic_attribute_registry,
+            access.semantic_attribute_definition TO leapview_control_runtime;
+        REVOKE DELETE, TRUNCATE, REFERENCES, TRIGGER ON access.semantic_attribute_registry,
+            access.semantic_attribute_definition FROM leapview_control_runtime;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_readonly') THEN
+        GRANT SELECT ON access.semantic_attribute_registry,
+            access.semantic_attribute_definition TO leapview_control_readonly;
+        REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+            ON access.semantic_attribute_registry,
+               access.semantic_attribute_definition FROM leapview_control_readonly;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_backup') THEN
+        GRANT SELECT ON access.semantic_attribute_registry,
+            access.semantic_attribute_definition TO leapview_control_backup;
+    END IF;
+END
+$$;

--- a/internal/access/postgres/queries/semantic_attributes.sql
+++ b/internal/access/postgres/queries/semantic_attributes.sql
@@ -1,0 +1,114 @@
+-- Typed semantic-access registry leaves. Mutation orchestration, canonical
+-- registry digest calculation, and audit coupling remain in the Go repository
+-- so every write uses one caller-owned transaction.
+
+-- name: LockSemanticAttributeRegistry :one
+SELECT profile, registry_revision, registry_digest, updated_at::text AS updated_at
+FROM access.semantic_attribute_registry
+WHERE singleton
+FOR UPDATE;
+
+-- name: GetSemanticAttributeRegistry :one
+SELECT profile, registry_revision, registry_digest, updated_at::text AS updated_at
+FROM access.semantic_attribute_registry
+WHERE singleton;
+
+-- name: UpdateSemanticAttributeRegistry :one
+UPDATE access.semantic_attribute_registry
+SET registry_revision = sqlc.arg(registry_revision)::bigint,
+    registry_digest = sqlc.arg(registry_digest)::text,
+    updated_at = clock_timestamp()
+WHERE singleton
+RETURNING profile, registry_revision, registry_digest, updated_at::text AS updated_at;
+
+-- name: InsertSemanticAttributeDefinition :one
+INSERT INTO access.semantic_attribute_definition
+    (definition_id, name, value_type, value_shape, profile, owner_kind,
+     owner_id, display_name, description, documentation_url)
+VALUES
+    (sqlc.arg(definition_id)::uuid, sqlc.arg(name)::text,
+     sqlc.arg(value_type)::text, sqlc.arg(value_shape)::text,
+     sqlc.arg(profile)::text, sqlc.arg(owner_kind)::text,
+     NULLIF(sqlc.arg(owner_id)::text, '')::uuid, sqlc.arg(display_name)::text,
+     sqlc.arg(description)::text, sqlc.arg(documentation_url)::text)
+RETURNING definition_id::text AS definition_id, name, value_type, value_shape,
+          profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,
+          description, documentation_url, enabled,
+          COALESCE(disabled_at::text, '')::text AS disabled_at,
+          created_at::text AS created_at, updated_at::text AS updated_at;
+
+-- name: GetSemanticAttributeDefinition :one
+SELECT definition_id::text AS definition_id, name, value_type, value_shape,
+       profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,
+       description, documentation_url, enabled,
+       COALESCE(disabled_at::text, '')::text AS disabled_at,
+       created_at::text AS created_at, updated_at::text AS updated_at
+FROM access.semantic_attribute_definition
+WHERE name = sqlc.arg(name)::text;
+
+-- name: GetSemanticAttributeDefinitionByID :one
+SELECT definition_id::text AS definition_id, name, value_type, value_shape,
+       profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,
+       description, documentation_url, enabled,
+       COALESCE(disabled_at::text, '')::text AS disabled_at,
+       created_at::text AS created_at, updated_at::text AS updated_at
+FROM access.semantic_attribute_definition
+WHERE definition_id = sqlc.arg(definition_id)::uuid;
+
+-- name: ListSemanticAttributeDefinitions :many
+SELECT definition_id::text AS definition_id, name, value_type, value_shape,
+       profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,
+       description, documentation_url, enabled,
+       COALESCE(disabled_at::text, '')::text AS disabled_at,
+       created_at::text AS created_at, updated_at::text AS updated_at
+FROM access.semantic_attribute_definition
+ORDER BY name;
+
+-- name: SearchSemanticAttributeDefinitions :many
+SELECT definition_id::text AS definition_id, name, value_type, value_shape,
+       profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,
+       description, documentation_url, enabled,
+       COALESCE(disabled_at::text, '')::text AS disabled_at,
+       created_at::text AS created_at, updated_at::text AS updated_at
+FROM access.semantic_attribute_definition
+WHERE sqlc.arg(search_query)::text = ''
+   OR strpos(lower(name), lower(sqlc.arg(search_query)::text)) > 0
+   OR strpos(lower(display_name), lower(sqlc.arg(search_query)::text)) > 0
+   OR strpos(lower(description), lower(sqlc.arg(search_query)::text)) > 0
+ORDER BY name
+LIMIT sqlc.arg(page_size)::int;
+
+-- name: UpdateSemanticAttributeDefinitionMetadata :one
+UPDATE access.semantic_attribute_definition
+SET owner_kind = sqlc.arg(owner_kind)::text,
+    owner_id = NULLIF(sqlc.arg(owner_id)::text, '')::uuid,
+    display_name = sqlc.arg(display_name)::text,
+    description = sqlc.arg(description)::text,
+    documentation_url = sqlc.arg(documentation_url)::text,
+    definition_version = definition_version + 1,
+    updated_at = clock_timestamp()
+WHERE name = sqlc.arg(name)::text
+  AND (owner_kind, owner_id, display_name, description, documentation_url)
+      IS DISTINCT FROM
+      (sqlc.arg(owner_kind)::text, NULLIF(sqlc.arg(owner_id)::text, '')::uuid,
+       sqlc.arg(display_name)::text, sqlc.arg(description)::text,
+       sqlc.arg(documentation_url)::text)
+RETURNING definition_id::text AS definition_id, name, value_type, value_shape,
+          profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,
+          description, documentation_url, enabled,
+          COALESCE(disabled_at::text, '')::text AS disabled_at,
+          created_at::text AS created_at, updated_at::text AS updated_at;
+
+-- name: SetSemanticAttributeDefinitionEnabled :one
+UPDATE access.semantic_attribute_definition
+SET enabled = sqlc.arg(enabled)::boolean,
+    disabled_at = CASE WHEN sqlc.arg(enabled)::boolean THEN NULL ELSE clock_timestamp() END,
+    definition_version = definition_version + 1,
+    updated_at = clock_timestamp()
+WHERE name = sqlc.arg(name)::text
+  AND enabled <> sqlc.arg(enabled)::boolean
+RETURNING definition_id::text AS definition_id, name, value_type, value_shape,
+          profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,
+          description, documentation_url, enabled,
+          COALESCE(disabled_at::text, '')::text AS disabled_at,
+          created_at::text AS created_at, updated_at::text AS updated_at;

--- a/internal/access/postgres/semantic_attributes.go
+++ b/internal/access/postgres/semantic_attributes.go
@@ -1,0 +1,523 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/flidai/leapview/internal/access"
+	accessdb "github.com/flidai/leapview/internal/access/postgres/internal/db"
+	"github.com/flidai/leapview/internal/semanticvalue"
+	"github.com/jackc/pgx/v5"
+)
+
+const maxSemanticAttributeSearchRows = 1000
+
+var _ access.SemanticAttributeRegistry = (*Repository)(nil)
+
+type registryDigestWire struct {
+	Profile     string                         `json:"profile"`
+	Definitions []registryDefinitionDigestWire `json:"definitions"`
+}
+
+type registryDefinitionDigestWire struct {
+	ID                string                                 `json:"id"`
+	Name              string                                 `json:"name"`
+	Type              semanticvalue.Type                     `json:"type"`
+	Shape             access.SemanticAttributeShape          `json:"shape"`
+	DefinitionVersion int64                                  `json:"definitionVersion"`
+	OwnerKind         access.SemanticAttributeOwnerKind      `json:"ownerKind"`
+	OwnerID           string                                 `json:"ownerId"`
+	DisplayName       string                                 `json:"displayName"`
+	Description       string                                 `json:"description"`
+	DocumentationURL  string                                 `json:"documentationUrl"`
+	LifecycleState    access.SemanticAttributeLifecycleState `json:"lifecycleState"`
+}
+
+type semanticAttributeRow struct {
+	ID, Name, ValueType, ValueShape, Profile   string
+	Version                                    int64
+	OwnerKind, OwnerID                         string
+	DisplayName, Description, DocumentationURL string
+	Enabled                                    bool
+	DisabledAt, CreatedAt, UpdatedAt           string
+}
+
+func (r *Repository) SemanticAttributeRegistry(ctx context.Context) (access.SemanticAttributeRegistrySnapshot, error) {
+	db, err := r.requireDB()
+	if err != nil {
+		return access.SemanticAttributeRegistrySnapshot{}, err
+	}
+	queries := accessdb.New(db)
+	stateRow, err := queries.GetSemanticAttributeRegistry(ctx)
+	if err != nil {
+		return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("read semantic attribute registry state: %w", err)
+	}
+	rows, err := queries.ListSemanticAttributeDefinitions(ctx)
+	if err != nil {
+		return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("list semantic attribute definitions: %w", err)
+	}
+	definitions := make([]access.SemanticAttributeDefinition, len(rows))
+	for index, row := range rows {
+		definitions[index] = semanticAttributeDefinitionFromList(row)
+	}
+	digest, err := semanticAttributeRegistryDigest(stateRow.Profile, definitions)
+	if err != nil {
+		return access.SemanticAttributeRegistrySnapshot{}, err
+	}
+	if digest != stateRow.RegistryDigest {
+		return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("semantic attribute registry digest mismatch: stored %q, computed %q", stateRow.RegistryDigest, digest)
+	}
+	return access.SemanticAttributeRegistrySnapshot{
+		State: access.SemanticAttributeRegistryState{
+			Profile: stateRow.Profile, Revision: stateRow.RegistryRevision,
+			Digest: stateRow.RegistryDigest, UpdatedAt: stateRow.UpdatedAt,
+		},
+		Definitions: definitions,
+	}, nil
+}
+
+func (r *Repository) SemanticAttributeDefinition(ctx context.Context, name string) (access.SemanticAttributeDefinition, error) {
+	if err := semanticvalue.ValidateAttributeName(name); err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	db, err := r.requireDB()
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	row, err := accessdb.New(db).GetSemanticAttributeDefinition(ctx, name)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	return semanticAttributeDefinitionFromGet(row), nil
+}
+
+func (r *Repository) SemanticAttributeDefinitionByID(ctx context.Context, id string) (access.SemanticAttributeDefinition, error) {
+	canonicalID, err := uuidID("semantic attribute definition id", id)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	parsedID, err := pgUUID(canonicalID)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	db, err := r.requireDB()
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	row, err := accessdb.New(db).GetSemanticAttributeDefinitionByID(ctx, parsedID)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	return semanticAttributeDefinitionFromGetByID(row), nil
+}
+
+func (r *Repository) SearchSemanticAttributes(ctx context.Context, filter access.SemanticAttributeSearch) ([]access.SemanticAttributeDefinition, error) {
+	query := strings.TrimSpace(filter.Query)
+	if len(query) > 255 || strings.ContainsRune(query, '\x00') {
+		return nil, errors.New("semantic attribute search query is invalid")
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > maxSemanticAttributeSearchRows {
+		limit = maxSemanticAttributeSearchRows
+	}
+	db, err := r.requireDB()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := accessdb.New(db).SearchSemanticAttributeDefinitions(ctx, accessdb.SearchSemanticAttributeDefinitionsParams{SearchQuery: query, PageSize: int32(limit)})
+	if err != nil {
+		return nil, fmt.Errorf("search semantic attribute definitions: %w", err)
+	}
+	definitions := make([]access.SemanticAttributeDefinition, len(rows))
+	for index, row := range rows {
+		definitions[index] = semanticAttributeDefinitionFromSearch(row)
+	}
+	return definitions, nil
+}
+
+func (r *Repository) RegisterSemanticAttribute(ctx context.Context, input access.RegisterSemanticAttributeInput) (access.SemanticAttributeDefinition, error) {
+	metadata, err := validateSemanticAttributeDefinitionInput(input.Name, input.Type, input.Shape, input.Metadata)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	actorID, err := uuidID("semantic attribute mutation actor principal id", input.Mutation.ActorPrincipalID)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	var result access.SemanticAttributeDefinition
+	err = r.RunAuditedMutation(ctx, func(repo access.Repository) (access.AuditEventInput, error) {
+		transactional, ok := repo.(*Repository)
+		if !ok {
+			return access.AuditEventInput{}, errors.New("semantic attribute mutation requires PostgreSQL transaction")
+		}
+		queries := accessdb.New(transactional.db)
+		locked, err := queries.LockSemanticAttributeRegistry(ctx)
+		if err != nil {
+			return access.AuditEventInput{}, fmt.Errorf("lock semantic attribute registry: %w", err)
+		}
+		existing, err := queries.GetSemanticAttributeDefinition(ctx, input.Name)
+		if err == nil {
+			result = semanticAttributeDefinitionFromGet(existing)
+			if result.Type != input.Type || result.Shape != input.Shape {
+				return access.AuditEventInput{}, fmt.Errorf("%w: %s is registered as %s/%s", access.ErrSemanticAttributeConflict, input.Name, result.Type, result.Shape)
+			}
+			return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.register_replay", result, locked.RegistryRevision, locked.RegistryDigest), nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return access.AuditEventInput{}, fmt.Errorf("read semantic attribute definition: %w", err)
+		}
+		definitionID, err := newUUID()
+		if err != nil {
+			return access.AuditEventInput{}, fmt.Errorf("create semantic attribute definition id: %w", err)
+		}
+		parsedDefinitionID, err := pgUUID(definitionID)
+		if err != nil {
+			return access.AuditEventInput{}, err
+		}
+		inserted, err := queries.InsertSemanticAttributeDefinition(ctx, accessdb.InsertSemanticAttributeDefinitionParams{
+			DefinitionID: parsedDefinitionID, Name: input.Name, ValueType: string(input.Type),
+			ValueShape: string(input.Shape), Profile: semanticvalue.Profile,
+			OwnerKind: string(metadata.Owner.Kind), OwnerID: metadata.Owner.ID,
+			DisplayName: metadata.DisplayName, Description: metadata.Description, DocumentationUrl: metadata.DocumentationURL,
+		})
+		if err != nil {
+			return access.AuditEventInput{}, fmt.Errorf("insert semantic attribute definition: %w", err)
+		}
+		result = semanticAttributeDefinitionFromInsert(inserted)
+		registry, err := refreshSemanticAttributeRegistry(ctx, queries, locked.RegistryRevision+1)
+		if err != nil {
+			return access.AuditEventInput{}, err
+		}
+		return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.register", result, registry.RegistryRevision, registry.RegistryDigest), nil
+	})
+	return result, err
+}
+
+func (r *Repository) UpdateSemanticAttributeMetadata(ctx context.Context, input access.UpdateSemanticAttributeMetadataInput) (access.SemanticAttributeDefinition, error) {
+	if err := semanticvalue.ValidateAttributeName(input.Name); err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	metadata, err := canonicalSemanticAttributeMetadata(input.Metadata)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	actorID, err := uuidID("semantic attribute mutation actor principal id", input.Mutation.ActorPrincipalID)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	var result access.SemanticAttributeDefinition
+	err = r.RunAuditedMutation(ctx, func(repo access.Repository) (access.AuditEventInput, error) {
+		transactional, ok := repo.(*Repository)
+		if !ok {
+			return access.AuditEventInput{}, errors.New("semantic attribute mutation requires PostgreSQL transaction")
+		}
+		queries := accessdb.New(transactional.db)
+		locked, err := queries.LockSemanticAttributeRegistry(ctx)
+		if err != nil {
+			return access.AuditEventInput{}, fmt.Errorf("lock semantic attribute registry: %w", err)
+		}
+		existing, err := queries.GetSemanticAttributeDefinition(ctx, input.Name)
+		if err != nil {
+			return access.AuditEventInput{}, err
+		}
+		result = semanticAttributeDefinitionFromGet(existing)
+		if reflect.DeepEqual(result.Metadata, metadata) {
+			return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.metadata_replay", result, locked.RegistryRevision, locked.RegistryDigest), nil
+		}
+		updated, err := queries.UpdateSemanticAttributeDefinitionMetadata(ctx, accessdb.UpdateSemanticAttributeDefinitionMetadataParams{
+			OwnerKind: string(metadata.Owner.Kind), OwnerID: metadata.Owner.ID,
+			DisplayName: metadata.DisplayName, Description: metadata.Description,
+			DocumentationUrl: metadata.DocumentationURL, Name: input.Name,
+		})
+		if err != nil {
+			return access.AuditEventInput{}, fmt.Errorf("update semantic attribute metadata: %w", err)
+		}
+		result = semanticAttributeDefinitionFromMetadata(updated)
+		registry, err := refreshSemanticAttributeRegistry(ctx, queries, locked.RegistryRevision+1)
+		if err != nil {
+			return access.AuditEventInput{}, err
+		}
+		return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.metadata_update", result, registry.RegistryRevision, registry.RegistryDigest), nil
+	})
+	return result, err
+}
+
+func (r *Repository) SetSemanticAttributeEnabled(ctx context.Context, name string, enabled bool, mutation access.SemanticAttributeMutationContext) (access.SemanticAttributeDefinition, error) {
+	if err := semanticvalue.ValidateAttributeName(name); err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	actorID, err := uuidID("semantic attribute mutation actor principal id", mutation.ActorPrincipalID)
+	if err != nil {
+		return access.SemanticAttributeDefinition{}, err
+	}
+	var result access.SemanticAttributeDefinition
+	err = r.RunAuditedMutation(ctx, func(repo access.Repository) (access.AuditEventInput, error) {
+		transactional, ok := repo.(*Repository)
+		if !ok {
+			return access.AuditEventInput{}, errors.New("semantic attribute mutation requires PostgreSQL transaction")
+		}
+		queries := accessdb.New(transactional.db)
+		locked, err := queries.LockSemanticAttributeRegistry(ctx)
+		if err != nil {
+			return access.AuditEventInput{}, fmt.Errorf("lock semantic attribute registry: %w", err)
+		}
+		existing, err := queries.GetSemanticAttributeDefinition(ctx, name)
+		if err != nil {
+			return access.AuditEventInput{}, err
+		}
+		result = semanticAttributeDefinitionFromGet(existing)
+		action := "semantic_attribute.disable"
+		if enabled {
+			action = "semantic_attribute.enable"
+		}
+		if result.Enabled == enabled {
+			return semanticAttributeAuditEvent(mutation, actorID, action+"_replay", result, locked.RegistryRevision, locked.RegistryDigest), nil
+		}
+		updated, err := queries.SetSemanticAttributeDefinitionEnabled(ctx, accessdb.SetSemanticAttributeDefinitionEnabledParams{Enabled: enabled, Name: name})
+		if err != nil {
+			return access.AuditEventInput{}, fmt.Errorf("set semantic attribute enabled state: %w", err)
+		}
+		result = semanticAttributeDefinitionFromEnabled(updated)
+		registry, err := refreshSemanticAttributeRegistry(ctx, queries, locked.RegistryRevision+1)
+		if err != nil {
+			return access.AuditEventInput{}, err
+		}
+		return semanticAttributeAuditEvent(mutation, actorID, action, result, registry.RegistryRevision, registry.RegistryDigest), nil
+	})
+	return result, err
+}
+
+func (r *Repository) ValidateSemanticAttributeValue(ctx context.Context, name string, input any) (access.CanonicalSemanticAttributeValue, error) {
+	definition, err := r.SemanticAttributeDefinition(ctx, name)
+	if err != nil {
+		return access.CanonicalSemanticAttributeValue{}, err
+	}
+	if !definition.Enabled {
+		return access.CanonicalSemanticAttributeValue{}, fmt.Errorf("%w: %s", access.ErrSemanticAttributeDisabled, name)
+	}
+	result := access.CanonicalSemanticAttributeValue{
+		DefinitionID: definition.ID, DefinitionVersion: definition.DefinitionVersion,
+		Name: definition.Name, Type: definition.Type, Shape: definition.Shape,
+	}
+	if definition.Shape == access.SemanticAttributeScalar {
+		value, err := semanticvalue.Canonicalize(definition.Type, input)
+		if err != nil {
+			return access.CanonicalSemanticAttributeValue{}, err
+		}
+		result.CanonicalValues = []string{value.Canonical()}
+		result.Digest = value.Digest()
+		return result, nil
+	}
+	values, err := semanticAttributeListInputs(input)
+	if err != nil {
+		return access.CanonicalSemanticAttributeValue{}, err
+	}
+	set, err := semanticvalue.CanonicalizeSet(definition.Type, values)
+	if err != nil {
+		return access.CanonicalSemanticAttributeValue{}, err
+	}
+	canonical := set.Values()
+	result.CanonicalValues = make([]string, len(canonical))
+	for index, value := range canonical {
+		result.CanonicalValues[index] = value.Canonical()
+	}
+	result.Digest = set.Digest()
+	return result, nil
+}
+
+func validateSemanticAttributeDefinitionInput(name string, valueType semanticvalue.Type, shape access.SemanticAttributeShape, metadata access.SemanticAttributeMetadata) (access.SemanticAttributeMetadata, error) {
+	if err := semanticvalue.ValidateAttributeName(name); err != nil {
+		return access.SemanticAttributeMetadata{}, err
+	}
+	switch valueType {
+	case semanticvalue.TypeString, semanticvalue.TypeBoolean, semanticvalue.TypeInteger,
+		semanticvalue.TypeDecimal, semanticvalue.TypeDate, semanticvalue.TypeTimestamp:
+	default:
+		return access.SemanticAttributeMetadata{}, fmt.Errorf("%w: %q is not supported by %s", semanticvalue.ErrInvalidType, valueType, semanticvalue.Profile)
+	}
+	if !shape.Valid() {
+		return access.SemanticAttributeMetadata{}, fmt.Errorf("semantic attribute shape %q is invalid", shape)
+	}
+	return canonicalSemanticAttributeMetadata(metadata)
+}
+
+func canonicalSemanticAttributeMetadata(metadata access.SemanticAttributeMetadata) (access.SemanticAttributeMetadata, error) {
+	if metadata.Owner.Kind == "" {
+		metadata.Owner.Kind = access.SemanticAttributeOwnerInstance
+	}
+	if !metadata.Owner.Kind.Valid() {
+		return access.SemanticAttributeMetadata{}, fmt.Errorf("semantic attribute owner kind %q is invalid", metadata.Owner.Kind)
+	}
+	metadata.Owner.ID = strings.TrimSpace(metadata.Owner.ID)
+	if metadata.Owner.Kind == access.SemanticAttributeOwnerInstance {
+		if metadata.Owner.ID != "" {
+			return access.SemanticAttributeMetadata{}, errors.New("instance-owned semantic attribute cannot carry an owner id")
+		}
+	} else {
+		ownerID, err := uuidID("semantic attribute owner id", metadata.Owner.ID)
+		if err != nil {
+			return access.SemanticAttributeMetadata{}, err
+		}
+		metadata.Owner.ID = ownerID
+	}
+	metadata.DisplayName = strings.TrimSpace(metadata.DisplayName)
+	metadata.Description = strings.TrimSpace(metadata.Description)
+	metadata.DocumentationURL = strings.TrimSpace(metadata.DocumentationURL)
+	if err := validateSemanticAttributeText("display name", metadata.DisplayName, 255); err != nil {
+		return access.SemanticAttributeMetadata{}, err
+	}
+	if err := validateSemanticAttributeText("description", metadata.Description, 4096); err != nil {
+		return access.SemanticAttributeMetadata{}, err
+	}
+	if len(metadata.DocumentationURL) > 2048 || strings.ContainsAny(metadata.DocumentationURL, "\x00\r\n") {
+		return access.SemanticAttributeMetadata{}, errors.New("semantic attribute documentation URL is invalid")
+	}
+	if metadata.DocumentationURL != "" {
+		parsed, err := url.ParseRequestURI(metadata.DocumentationURL)
+		if err != nil || parsed.Host == "" || parsed.User != nil || parsed.Scheme != "https" {
+			return access.SemanticAttributeMetadata{}, errors.New("semantic attribute documentation URL must be an absolute HTTPS URL without credentials")
+		}
+	}
+	return metadata, nil
+}
+
+func validateSemanticAttributeText(label, value string, max int) error {
+	if !utf8.ValidString(value) || len(value) > max || strings.ContainsRune(value, '\x00') {
+		return fmt.Errorf("semantic attribute %s is invalid", label)
+	}
+	return nil
+}
+
+func semanticAttributeListInputs(input any) ([]any, error) {
+	if input == nil {
+		return nil, fmt.Errorf("%w: null is not an access value list", semanticvalue.ErrInvalidValue)
+	}
+	value := reflect.ValueOf(input)
+	if value.Kind() != reflect.Array && value.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("%w: value of type %T is not a list", semanticvalue.ErrInvalidValue, input)
+	}
+	values := make([]any, value.Len())
+	for index := 0; index < value.Len(); index++ {
+		values[index] = value.Index(index).Interface()
+	}
+	return values, nil
+}
+
+func refreshSemanticAttributeRegistry(ctx context.Context, queries *accessdb.Queries, revision int64) (accessdb.UpdateSemanticAttributeRegistryRow, error) {
+	rows, err := queries.ListSemanticAttributeDefinitions(ctx)
+	if err != nil {
+		return accessdb.UpdateSemanticAttributeRegistryRow{}, fmt.Errorf("list semantic attribute definitions for digest: %w", err)
+	}
+	definitions := make([]access.SemanticAttributeDefinition, len(rows))
+	for index, row := range rows {
+		definitions[index] = semanticAttributeDefinitionFromList(row)
+	}
+	digest, err := semanticAttributeRegistryDigest(semanticvalue.Profile, definitions)
+	if err != nil {
+		return accessdb.UpdateSemanticAttributeRegistryRow{}, err
+	}
+	state, err := queries.UpdateSemanticAttributeRegistry(ctx, accessdb.UpdateSemanticAttributeRegistryParams{RegistryRevision: revision, RegistryDigest: digest})
+	if err != nil {
+		return accessdb.UpdateSemanticAttributeRegistryRow{}, fmt.Errorf("update semantic attribute registry state: %w", err)
+	}
+	return state, nil
+}
+
+func semanticAttributeRegistryDigest(profile string, definitions []access.SemanticAttributeDefinition) (string, error) {
+	wire := registryDigestWire{Profile: profile, Definitions: make([]registryDefinitionDigestWire, len(definitions))}
+	for index, definition := range definitions {
+		wire.Definitions[index] = registryDefinitionDigestWire{
+			ID: definition.ID, Name: definition.Name, Type: definition.Type, Shape: definition.Shape,
+			DefinitionVersion: definition.DefinitionVersion,
+			OwnerKind:         definition.Metadata.Owner.Kind, OwnerID: definition.Metadata.Owner.ID,
+			DisplayName: definition.Metadata.DisplayName, Description: definition.Metadata.Description,
+			DocumentationURL: definition.Metadata.DocumentationURL, LifecycleState: definition.LifecycleState,
+		}
+	}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return "", fmt.Errorf("encode semantic attribute registry digest: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(digest[:]), nil
+}
+
+func semanticAttributeAuditEvent(mutation access.SemanticAttributeMutationContext, actorID, action string, definition access.SemanticAttributeDefinition, revision int64, digest string) access.AuditEventInput {
+	metadata, _ := json.Marshal(struct {
+		Profile           string                                 `json:"profile"`
+		Type              semanticvalue.Type                     `json:"type"`
+		Shape             access.SemanticAttributeShape          `json:"shape"`
+		DefinitionVersion int64                                  `json:"definitionVersion"`
+		RegistryRevision  int64                                  `json:"registryRevision"`
+		RegistryDigest    string                                 `json:"registryDigest"`
+		OwnerKind         access.SemanticAttributeOwnerKind      `json:"ownerKind"`
+		OwnerID           string                                 `json:"ownerId"`
+		LifecycleState    access.SemanticAttributeLifecycleState `json:"lifecycleState"`
+	}{
+		Profile: definition.Profile, Type: definition.Type, Shape: definition.Shape,
+		DefinitionVersion: definition.DefinitionVersion, RegistryRevision: revision,
+		RegistryDigest: digest, OwnerKind: definition.Metadata.Owner.Kind,
+		OwnerID: definition.Metadata.Owner.ID, LifecycleState: definition.LifecycleState,
+	})
+	return access.AuditEventInput{
+		PrincipalID: actorID, Action: action, ResourceKind: "semantic_attribute", ResourceID: definition.Name,
+		Capability: access.CapabilityProjectAdmin, Status: "success",
+		RequestID: mutation.RequestID, CorrelationID: mutation.CorrelationID, MetadataJSON: string(metadata),
+	}
+}
+
+func semanticAttributeDefinitionFromGet(row accessdb.GetSemanticAttributeDefinitionRow) access.SemanticAttributeDefinition {
+	return semanticAttributeDefinition(semanticAttributeRow{ID: row.DefinitionID, Name: row.Name, ValueType: row.ValueType, ValueShape: row.ValueShape, Profile: row.Profile, Version: row.DefinitionVersion, OwnerKind: row.OwnerKind, OwnerID: row.OwnerID, DisplayName: row.DisplayName, Description: row.Description, DocumentationURL: row.DocumentationUrl, Enabled: row.Enabled, DisabledAt: row.DisabledAt, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt})
+}
+
+func semanticAttributeDefinitionFromGetByID(row accessdb.GetSemanticAttributeDefinitionByIDRow) access.SemanticAttributeDefinition {
+	return semanticAttributeDefinition(semanticAttributeRow{ID: row.DefinitionID, Name: row.Name, ValueType: row.ValueType, ValueShape: row.ValueShape, Profile: row.Profile, Version: row.DefinitionVersion, OwnerKind: row.OwnerKind, OwnerID: row.OwnerID, DisplayName: row.DisplayName, Description: row.Description, DocumentationURL: row.DocumentationUrl, Enabled: row.Enabled, DisabledAt: row.DisabledAt, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt})
+}
+
+func semanticAttributeDefinitionFromInsert(row accessdb.InsertSemanticAttributeDefinitionRow) access.SemanticAttributeDefinition {
+	return semanticAttributeDefinition(semanticAttributeRow{ID: row.DefinitionID, Name: row.Name, ValueType: row.ValueType, ValueShape: row.ValueShape, Profile: row.Profile, Version: row.DefinitionVersion, OwnerKind: row.OwnerKind, OwnerID: row.OwnerID, DisplayName: row.DisplayName, Description: row.Description, DocumentationURL: row.DocumentationUrl, Enabled: row.Enabled, DisabledAt: row.DisabledAt, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt})
+}
+
+func semanticAttributeDefinitionFromList(row accessdb.ListSemanticAttributeDefinitionsRow) access.SemanticAttributeDefinition {
+	return semanticAttributeDefinition(semanticAttributeRow{ID: row.DefinitionID, Name: row.Name, ValueType: row.ValueType, ValueShape: row.ValueShape, Profile: row.Profile, Version: row.DefinitionVersion, OwnerKind: row.OwnerKind, OwnerID: row.OwnerID, DisplayName: row.DisplayName, Description: row.Description, DocumentationURL: row.DocumentationUrl, Enabled: row.Enabled, DisabledAt: row.DisabledAt, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt})
+}
+
+func semanticAttributeDefinitionFromSearch(row accessdb.SearchSemanticAttributeDefinitionsRow) access.SemanticAttributeDefinition {
+	return semanticAttributeDefinition(semanticAttributeRow{ID: row.DefinitionID, Name: row.Name, ValueType: row.ValueType, ValueShape: row.ValueShape, Profile: row.Profile, Version: row.DefinitionVersion, OwnerKind: row.OwnerKind, OwnerID: row.OwnerID, DisplayName: row.DisplayName, Description: row.Description, DocumentationURL: row.DocumentationUrl, Enabled: row.Enabled, DisabledAt: row.DisabledAt, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt})
+}
+
+func semanticAttributeDefinitionFromMetadata(row accessdb.UpdateSemanticAttributeDefinitionMetadataRow) access.SemanticAttributeDefinition {
+	return semanticAttributeDefinition(semanticAttributeRow{ID: row.DefinitionID, Name: row.Name, ValueType: row.ValueType, ValueShape: row.ValueShape, Profile: row.Profile, Version: row.DefinitionVersion, OwnerKind: row.OwnerKind, OwnerID: row.OwnerID, DisplayName: row.DisplayName, Description: row.Description, DocumentationURL: row.DocumentationUrl, Enabled: row.Enabled, DisabledAt: row.DisabledAt, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt})
+}
+
+func semanticAttributeDefinitionFromEnabled(row accessdb.SetSemanticAttributeDefinitionEnabledRow) access.SemanticAttributeDefinition {
+	return semanticAttributeDefinition(semanticAttributeRow{ID: row.DefinitionID, Name: row.Name, ValueType: row.ValueType, ValueShape: row.ValueShape, Profile: row.Profile, Version: row.DefinitionVersion, OwnerKind: row.OwnerKind, OwnerID: row.OwnerID, DisplayName: row.DisplayName, Description: row.Description, DocumentationURL: row.DocumentationUrl, Enabled: row.Enabled, DisabledAt: row.DisabledAt, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt})
+}
+
+func semanticAttributeDefinition(row semanticAttributeRow) access.SemanticAttributeDefinition {
+	lifecycle := access.SemanticAttributeActive
+	if !row.Enabled {
+		lifecycle = access.SemanticAttributeDisabled
+	}
+	return access.SemanticAttributeDefinition{
+		ID: row.ID, Name: row.Name, Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
+		Profile: row.Profile, DefinitionVersion: row.Version,
+		Metadata: access.SemanticAttributeMetadata{
+			Owner:       access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerKind(row.OwnerKind), ID: row.OwnerID},
+			DisplayName: row.DisplayName, Description: row.Description, DocumentationURL: row.DocumentationURL,
+		},
+		LifecycleState: lifecycle, Enabled: row.Enabled, DisabledAt: row.DisabledAt,
+		CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt,
+	}
+}

--- a/internal/access/postgres/semantic_attributes_test.go
+++ b/internal/access/postgres/semantic_attributes_test.go
@@ -1,0 +1,237 @@
+package postgres
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestSemanticAttributeRegistryDigestIsProfileQualifiedAndDeterministic(t *testing.T) {
+	empty, err := semanticAttributeRegistryDigest(semanticvalue.Profile, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const wantEmpty = "sha256:9362dbdb62923a10f67bc1da04b02e2bbad74dce5b5442aaa3fb5e0cc5851b9d"
+	if empty != wantEmpty || !strings.Contains(AttributeRegistryMigrationSQL(), wantEmpty) {
+		t.Fatalf("empty registry digest = %q, want migration seed %q", empty, wantEmpty)
+	}
+	definitions := []access.SemanticAttributeDefinition{{
+		ID: "10000000-0000-0000-0000-000000000001", Name: "region",
+		Type: semanticvalue.TypeString, Shape: access.SemanticAttributeList,
+		DefinitionVersion: 1, Enabled: true, LifecycleState: access.SemanticAttributeActive,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}},
+	}}
+	first, err := semanticAttributeRegistryDigest(semanticvalue.Profile, definitions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := semanticAttributeRegistryDigest(semanticvalue.Profile, append([]access.SemanticAttributeDefinition(nil), definitions...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second || first == empty {
+		t.Fatalf("registry digests = %q/%q, empty %q", first, second, empty)
+	}
+	definitions[0].Enabled = false
+	definitions[0].LifecycleState = access.SemanticAttributeDisabled
+	definitions[0].DefinitionVersion++
+	disabled, err := semanticAttributeRegistryDigest(semanticvalue.Profile, definitions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled == first {
+		t.Fatal("disablement and definition version did not change registry identity")
+	}
+}
+
+func TestSemanticAttributeDefinitionInputUsesCanonicalValueContract(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		valueType semanticvalue.Type
+		shape     access.SemanticAttributeShape
+		wantErr   bool
+	}{
+		{name: "region", valueType: semanticvalue.TypeString, shape: access.SemanticAttributeScalar},
+		{name: "region_ids", valueType: semanticvalue.TypeInteger, shape: access.SemanticAttributeList},
+		{name: "bad-name", valueType: semanticvalue.TypeString, shape: access.SemanticAttributeScalar, wantErr: true},
+		{name: "region", valueType: semanticvalue.Type("Float"), shape: access.SemanticAttributeScalar, wantErr: true},
+		{name: "region", valueType: semanticvalue.TypeString, shape: access.SemanticAttributeShape("map"), wantErr: true},
+	} {
+		_, err := validateSemanticAttributeDefinitionInput(test.name, test.valueType, test.shape, access.SemanticAttributeMetadata{})
+		if (err != nil) != test.wantErr {
+			t.Errorf("validate(%q, %q, %q) error = %v, wantErr %v", test.name, test.valueType, test.shape, err, test.wantErr)
+		}
+	}
+}
+
+func TestSemanticAttributeMetadataAndCompatibilityValidation(t *testing.T) {
+	metadata, err := canonicalSemanticAttributeMetadata(access.SemanticAttributeMetadata{
+		DisplayName: "  Region  ", DocumentationURL: "https://docs.example.com/region",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metadata.Owner.Kind != access.SemanticAttributeOwnerInstance || metadata.DisplayName != "Region" {
+		t.Fatalf("canonical metadata = %#v", metadata)
+	}
+	for _, invalid := range []access.SemanticAttributeMetadata{
+		{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance, ID: auditActorID}},
+		{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerPrincipal, ID: "not-a-uuid"}},
+		{DocumentationURL: "http://docs.example.com/region"},
+		{DocumentationURL: "https://user:secret@docs.example.com/region"},
+	} {
+		if _, err := canonicalSemanticAttributeMetadata(invalid); err == nil {
+			t.Fatalf("accepted invalid metadata %#v", invalid)
+		}
+	}
+	current := access.SemanticAttributeDefinition{ID: auditActorID, Name: "region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Profile: semanticvalue.Profile}
+	candidate := current
+	candidate.Metadata.DisplayName = "Region"
+	if err := access.ValidateSemanticAttributeCompatibility(current, candidate); err != nil {
+		t.Fatalf("metadata-only compatibility error = %v", err)
+	}
+	candidate.Type = semanticvalue.TypeBoolean
+	if err := access.ValidateSemanticAttributeCompatibility(current, candidate); !errors.Is(err, access.ErrSemanticAttributeConflict) {
+		t.Fatalf("type compatibility error = %v", err)
+	}
+}
+
+func TestSemanticAttributeRegistryPostgreSQL18DefinitionLifecycle(t *testing.T) {
+	db := newStandaloneAccessDatabase(t)
+	if _, err := db.admin.Exec(t.Context(), AttributeRegistryMigrationSQL()); err != nil {
+		t.Fatalf("apply attribute registry migration: %v", err)
+	}
+	if _, err := db.admin.Exec(t.Context(), `
+		INSERT INTO access.principal (id, principal_type, status)
+		VALUES ($1::uuid, 'user', 'active')`, auditActorID); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := NewAccess(db.admin, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	empty, err := repo.SemanticAttributeRegistry(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if empty.State.Revision != 0 || len(empty.Definitions) != 0 {
+		t.Fatalf("empty registry = %#v", empty)
+	}
+
+	input := access.RegisterSemanticAttributeInput{
+		Name: "region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeList,
+		Metadata: access.SemanticAttributeMetadata{
+			Owner:       access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance},
+			DisplayName: "Region", Description: "Authorized sales regions",
+			DocumentationURL: "https://docs.example.com/attributes/region",
+		},
+		Mutation: access.SemanticAttributeMutationContext{ActorPrincipalID: auditActorID},
+	}
+	definition, err := repo.RegisterSemanticAttribute(t.Context(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if definition.Name != "region" || definition.Type != semanticvalue.TypeString || definition.Shape != access.SemanticAttributeList || !definition.Enabled || definition.LifecycleState != access.SemanticAttributeActive || definition.DefinitionVersion != 1 || definition.Metadata.DisplayName != "Region" {
+		t.Fatalf("registered definition = %#v", definition)
+	}
+	registered, err := repo.SemanticAttributeRegistry(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if registered.State.Revision != 1 || registered.State.Digest == empty.State.Digest || len(registered.Definitions) != 1 {
+		t.Fatalf("registered registry = %#v", registered)
+	}
+
+	replayed, err := repo.RegisterSemanticAttribute(t.Context(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayed.ID != definition.ID {
+		t.Fatalf("register replay id = %q, want %q", replayed.ID, definition.ID)
+	}
+	afterReplay, err := repo.SemanticAttributeRegistry(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterReplay.State.Revision != registered.State.Revision || afterReplay.State.Digest != registered.State.Digest {
+		t.Fatal("idempotent registration changed registry identity")
+	}
+
+	conflict := input
+	conflict.Type = semanticvalue.TypeBoolean
+	if _, err := repo.RegisterSemanticAttribute(t.Context(), conflict); !errors.Is(err, access.ErrSemanticAttributeConflict) {
+		t.Fatalf("type mutation registration error = %v, want conflict", err)
+	}
+
+	byID, err := repo.SemanticAttributeDefinitionByID(t.Context(), definition.ID)
+	if err != nil || byID.Name != "region" {
+		t.Fatalf("fetch by id = %#v, %v", byID, err)
+	}
+	search, err := repo.SearchSemanticAttributes(t.Context(), access.SemanticAttributeSearch{Query: "sales regions", Limit: 10})
+	if err != nil || len(search) != 1 || search[0].ID != definition.ID {
+		t.Fatalf("search = %#v, %v", search, err)
+	}
+	canonical, err := repo.ValidateSemanticAttributeValue(t.Context(), "region", []string{"west", "east", "west"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(canonical.CanonicalValues, ",") != "east,west" || !strings.HasPrefix(canonical.Digest, "sha256:") {
+		t.Fatalf("canonical value = %#v", canonical)
+	}
+
+	updatedMetadata := input.Metadata
+	updatedMetadata.DisplayName = "Regional access"
+	updated, err := repo.UpdateSemanticAttributeMetadata(t.Context(), access.UpdateSemanticAttributeMetadataInput{Name: "region", Metadata: updatedMetadata, Mutation: input.Mutation})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.DefinitionVersion != 2 || updated.Metadata.DisplayName != "Regional access" || updated.ID != definition.ID {
+		t.Fatalf("metadata update = %#v", updated)
+	}
+
+	disabled, err := repo.SetSemanticAttributeEnabled(t.Context(), "region", false, input.Mutation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled.Enabled || disabled.LifecycleState != access.SemanticAttributeDisabled || disabled.DisabledAt == "" || disabled.DefinitionVersion != 3 {
+		t.Fatalf("disabled definition = %#v", disabled)
+	}
+	afterDisable, err := repo.SemanticAttributeRegistry(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterDisable.State.Revision != 3 || afterDisable.State.Digest == registered.State.Digest {
+		t.Fatalf("disabled registry = %#v", afterDisable.State)
+	}
+	if _, err := repo.ValidateSemanticAttributeValue(t.Context(), "region", []string{"west"}); !errors.Is(err, access.ErrSemanticAttributeDisabled) {
+		t.Fatalf("disabled value validation error = %v", err)
+	}
+
+	if _, err := db.admin.Exec(t.Context(), `UPDATE access.semantic_attribute_definition SET value_type='Boolean' WHERE name='region'`); err == nil {
+		t.Fatal("database accepted semantic attribute type mutation")
+	}
+	if _, err := db.admin.Exec(t.Context(), `DELETE FROM access.semantic_attribute_definition WHERE name='region'`); err == nil {
+		t.Fatal("database accepted semantic attribute deletion")
+	}
+	if _, err := db.admin.Exec(t.Context(), `
+		UPDATE access.semantic_attribute_definition
+		SET disabled_at=disabled_at - interval '1 day',
+		    definition_version=definition_version + 1
+		WHERE name='region'`); err == nil {
+		t.Fatal("database accepted a caller-authored lifecycle timestamp")
+	}
+
+	var auditCount int
+	if err := db.admin.QueryRow(t.Context(), `
+		SELECT count(*) FROM audit.audit_event
+		WHERE resource_kind='semantic_attribute' AND resource_id='region'`).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 4 {
+		t.Fatalf("semantic attribute audit events = %d, want register, replay, metadata, disable", auditCount)
+	}
+}

--- a/internal/access/semantic_attributes.go
+++ b/internal/access/semantic_attributes.go
@@ -1,0 +1,150 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+var (
+	ErrSemanticAttributeConflict = errors.New("semantic attribute definition conflicts with the registry")
+	ErrSemanticAttributeDisabled = errors.New("semantic attribute is disabled")
+)
+
+// SemanticAttributeShape distinguishes a scalar assignment from a homogeneous
+// list assignment. The element type remains one of semanticvalue's closed v1
+// logical types.
+type SemanticAttributeShape string
+
+const (
+	SemanticAttributeScalar SemanticAttributeShape = "scalar"
+	SemanticAttributeList   SemanticAttributeShape = "list"
+)
+
+func (shape SemanticAttributeShape) Valid() bool {
+	return shape == SemanticAttributeScalar || shape == SemanticAttributeList
+}
+
+type SemanticAttributeOwnerKind string
+
+const (
+	SemanticAttributeOwnerInstance  SemanticAttributeOwnerKind = "instance"
+	SemanticAttributeOwnerPrincipal SemanticAttributeOwnerKind = "principal"
+	SemanticAttributeOwnerGroup     SemanticAttributeOwnerKind = "group"
+)
+
+func (kind SemanticAttributeOwnerKind) Valid() bool {
+	return kind == SemanticAttributeOwnerInstance || kind == SemanticAttributeOwnerPrincipal || kind == SemanticAttributeOwnerGroup
+}
+
+type SemanticAttributeLifecycleState string
+
+const (
+	SemanticAttributeActive   SemanticAttributeLifecycleState = "active"
+	SemanticAttributeDisabled SemanticAttributeLifecycleState = "disabled"
+)
+
+type SemanticAttributeOwner struct {
+	Kind SemanticAttributeOwnerKind
+	ID   string
+}
+
+type SemanticAttributeMetadata struct {
+	Owner            SemanticAttributeOwner
+	DisplayName      string
+	Description      string
+	DocumentationURL string
+}
+
+type SemanticAttributeDefinition struct {
+	ID                string
+	Name              string
+	Type              semanticvalue.Type
+	Shape             SemanticAttributeShape
+	Profile           string
+	DefinitionVersion int64
+	Metadata          SemanticAttributeMetadata
+	LifecycleState    SemanticAttributeLifecycleState
+	Enabled           bool
+	DisabledAt        string
+	CreatedAt         string
+	UpdatedAt         string
+}
+
+type SemanticAttributeRegistryState struct {
+	Profile   string
+	Revision  int64
+	Digest    string
+	UpdatedAt string
+}
+
+type SemanticAttributeRegistrySnapshot struct {
+	State       SemanticAttributeRegistryState
+	Definitions []SemanticAttributeDefinition
+}
+
+type SemanticAttributeMutationContext struct {
+	ActorPrincipalID string
+	RequestID        string
+	CorrelationID    string
+}
+
+type RegisterSemanticAttributeInput struct {
+	Name     string
+	Type     semanticvalue.Type
+	Shape    SemanticAttributeShape
+	Metadata SemanticAttributeMetadata
+	Mutation SemanticAttributeMutationContext
+}
+
+type UpdateSemanticAttributeMetadataInput struct {
+	Name     string
+	Metadata SemanticAttributeMetadata
+	Mutation SemanticAttributeMutationContext
+}
+
+type SemanticAttributeSearch struct {
+	Query string
+	Limit int
+}
+
+// CanonicalSemanticAttributeValue is the profile-qualified value identity
+// produced by the shared semanticvalue package. Scalar values contain exactly
+// one canonical value; list values are deduplicated and sorted.
+type CanonicalSemanticAttributeValue struct {
+	DefinitionID      string
+	DefinitionVersion int64
+	Name              string
+	Type              semanticvalue.Type
+	Shape             SemanticAttributeShape
+	CanonicalValues   []string
+	Digest            string
+}
+
+// ValidateSemanticAttributeCompatibility rejects identity or logical-type
+// rewrites. Metadata and lifecycle transitions are versioned registry changes;
+// changing name, type, shape, profile, or stable ID requires a new attribute.
+func ValidateSemanticAttributeCompatibility(current, candidate SemanticAttributeDefinition) error {
+	if current.ID != candidate.ID || current.Name != candidate.Name || current.Type != candidate.Type ||
+		current.Shape != candidate.Shape || current.Profile != candidate.Profile {
+		return fmt.Errorf("%w: semantic attribute identity and logical type are immutable", ErrSemanticAttributeConflict)
+	}
+	return nil
+}
+
+// SemanticAttributeRegistry is the narrow control-plane boundary for typed
+// definition lifecycle. Assignment, trusted-claim, and generation-reference
+// interfaces are added separately so consumers cannot acquire mutation powers
+// by depending on read-only registry qualification.
+type SemanticAttributeRegistry interface {
+	SemanticAttributeRegistry(context.Context) (SemanticAttributeRegistrySnapshot, error)
+	SemanticAttributeDefinition(context.Context, string) (SemanticAttributeDefinition, error)
+	SemanticAttributeDefinitionByID(context.Context, string) (SemanticAttributeDefinition, error)
+	SearchSemanticAttributes(context.Context, SemanticAttributeSearch) ([]SemanticAttributeDefinition, error)
+	RegisterSemanticAttribute(context.Context, RegisterSemanticAttributeInput) (SemanticAttributeDefinition, error)
+	UpdateSemanticAttributeMetadata(context.Context, UpdateSemanticAttributeMetadataInput) (SemanticAttributeDefinition, error)
+	SetSemanticAttributeEnabled(context.Context, string, bool, SemanticAttributeMutationContext) (SemanticAttributeDefinition, error)
+	ValidateSemanticAttributeValue(context.Context, string, any) (CanonicalSemanticAttributeValue, error)
+}

--- a/internal/access/semantic_attributes_test.go
+++ b/internal/access/semantic_attributes_test.go
@@ -1,0 +1,66 @@
+package access
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestSemanticAttributeShapeAndOwnerKindValidation(t *testing.T) {
+	for _, shape := range []SemanticAttributeShape{SemanticAttributeScalar, SemanticAttributeList} {
+		if !shape.Valid() {
+			t.Errorf("SemanticAttributeShape(%q).Valid() = false", shape)
+		}
+	}
+	if SemanticAttributeShape("map").Valid() {
+		t.Fatal("unsupported semantic attribute shape is valid")
+	}
+
+	for _, kind := range []SemanticAttributeOwnerKind{
+		SemanticAttributeOwnerInstance,
+		SemanticAttributeOwnerPrincipal,
+		SemanticAttributeOwnerGroup,
+	} {
+		if !kind.Valid() {
+			t.Errorf("SemanticAttributeOwnerKind(%q).Valid() = false", kind)
+		}
+	}
+	if SemanticAttributeOwnerKind("project").Valid() {
+		t.Fatal("unsupported semantic attribute owner kind is valid")
+	}
+}
+
+func TestValidateSemanticAttributeCompatibilityPreservesStableIdentityAndType(t *testing.T) {
+	current := SemanticAttributeDefinition{
+		ID:      "0198ff98-e3e0-7f27-9059-39d08735feda",
+		Name:    "region",
+		Type:    semanticvalue.TypeString,
+		Shape:   SemanticAttributeScalar,
+		Profile: semanticvalue.Profile,
+	}
+	compatible := current
+	compatible.Metadata.DisplayName = "Sales region"
+	compatible.DefinitionVersion = 2
+	compatible.Enabled = false
+	compatible.LifecycleState = SemanticAttributeDisabled
+	if err := ValidateSemanticAttributeCompatibility(current, compatible); err != nil {
+		t.Fatalf("compatible metadata and lifecycle change: %v", err)
+	}
+
+	for name, mutate := range map[string]func(*SemanticAttributeDefinition){
+		"id":      func(candidate *SemanticAttributeDefinition) { candidate.ID = "0198ff98-e3e0-7f27-9059-39d08735fedb" },
+		"name":    func(candidate *SemanticAttributeDefinition) { candidate.Name = "country" },
+		"type":    func(candidate *SemanticAttributeDefinition) { candidate.Type = semanticvalue.TypeInteger },
+		"shape":   func(candidate *SemanticAttributeDefinition) { candidate.Shape = SemanticAttributeList },
+		"profile": func(candidate *SemanticAttributeDefinition) { candidate.Profile = "semantic-value/v2" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := current
+			mutate(&candidate)
+			if err := ValidateSemanticAttributeCompatibility(current, candidate); !errors.Is(err, ErrSemanticAttributeConflict) {
+				t.Fatalf("error = %v, want semantic attribute conflict", err)
+			}
+		})
+	}
+}

--- a/internal/app/postgresbaseline/baseline.go
+++ b/internal/app/postgresbaseline/baseline.go
@@ -19,6 +19,7 @@ import (
 const (
 	BaselineRevision    = platformmigrations.BaselineRevision
 	BaselineMigrationID = platformmigrations.BaselineMigrationID
+	LatestRevision      = accesspostgres.AttributeRegistryMigrationRevision
 )
 
 // Keep the reconciliation baseline intentionally small. New durable
@@ -29,6 +30,13 @@ var plan = platformmigrations.Plan{
 		{Name: "access", SQL: accesspostgres.SchemaSQL()},
 		{Name: "physical_pool", SQL: physicalpoolpostgres.SchemaSQL()},
 		{Name: "ducklake.bootstrap", SQL: ducklakepostgres.SchemaSQL()},
+	},
+	Migrations: []platformmigrations.Migration{
+		{
+			Revision:    accesspostgres.AttributeRegistryMigrationRevision,
+			MigrationID: accesspostgres.AttributeRegistryMigrationID,
+			SQL:         accesspostgres.AttributeRegistryMigrationSQL(),
+		},
 	},
 	RolePolicySQL: rolePolicySQL,
 }
@@ -43,6 +51,10 @@ func Components() []platformmigrations.Component {
 	return append([]platformmigrations.Component(nil), plan.Components...)
 }
 
+func Migrations() []platformmigrations.Migration {
+	return append([]platformmigrations.Migration(nil), plan.Migrations...)
+}
+
 func FoundationSQL() string { return platformmigrations.BaselineSQL() }
 
 type RevisionReader interface {
@@ -53,13 +65,28 @@ func Verify(ctx context.Context, reader RevisionReader) error {
 	if reader == nil {
 		return errors.New("PostgreSQL baseline revision reader is required")
 	}
-	revision, err := reader.SchemaRevision(ctx, BaselineRevision)
-	if err != nil {
-		return fmt.Errorf("read PostgreSQL baseline revision: %w", err)
+	expected := []struct {
+		revision int64
+		id       string
+		checksum string
+	}{
+		{revision: BaselineRevision, id: BaselineMigrationID, checksum: Checksum()},
 	}
-	wantChecksum := Checksum()
-	if revision.Revision != BaselineRevision || revision.MigrationID != BaselineMigrationID || revision.Checksum != wantChecksum {
-		return fmt.Errorf("PostgreSQL baseline mismatch: got revision=%d migration=%q checksum=%q, want revision=%d migration=%q checksum=%q", revision.Revision, revision.MigrationID, revision.Checksum, BaselineRevision, BaselineMigrationID, wantChecksum)
+	for _, migration := range plan.Migrations {
+		expected = append(expected, struct {
+			revision int64
+			id       string
+			checksum string
+		}{revision: migration.Revision, id: migration.MigrationID, checksum: migration.Checksum()})
+	}
+	for _, want := range expected {
+		revision, err := reader.SchemaRevision(ctx, want.revision)
+		if err != nil {
+			return fmt.Errorf("read PostgreSQL schema revision %d: %w", want.revision, err)
+		}
+		if revision.Revision != want.revision || revision.MigrationID != want.id || revision.Checksum != want.checksum {
+			return fmt.Errorf("PostgreSQL schema mismatch: got revision=%d migration=%q checksum=%q, want revision=%d migration=%q checksum=%q", revision.Revision, revision.MigrationID, revision.Checksum, want.revision, want.id, want.checksum)
+		}
 	}
 	return nil
 }

--- a/internal/app/postgresbaseline/baseline_test.go
+++ b/internal/app/postgresbaseline/baseline_test.go
@@ -2,6 +2,7 @@ package postgresbaseline
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -9,12 +10,19 @@ import (
 )
 
 type revisionReader struct {
-	revision platformpostgres.SchemaRevision
-	err      error
+	revisions map[int64]platformpostgres.SchemaRevision
+	err       error
 }
 
-func (r revisionReader) SchemaRevision(context.Context, int64) (platformpostgres.SchemaRevision, error) {
-	return r.revision, r.err
+func (r revisionReader) SchemaRevision(_ context.Context, revision int64) (platformpostgres.SchemaRevision, error) {
+	if r.err != nil {
+		return platformpostgres.SchemaRevision{}, r.err
+	}
+	value, ok := r.revisions[revision]
+	if !ok {
+		return platformpostgres.SchemaRevision{}, errors.New("revision not found")
+	}
+	return value, nil
 }
 
 func TestBaselineOwnsOnlyReconciledCapabilities(t *testing.T) {
@@ -32,12 +40,22 @@ func TestBaselineOwnsOnlyReconciledCapabilities(t *testing.T) {
 }
 
 func TestVerifyRequiresExactBaselineIdentity(t *testing.T) {
-	want := platformpostgres.SchemaRevision{Revision: BaselineRevision, MigrationID: BaselineMigrationID, Checksum: Checksum()}
-	if err := Verify(context.Background(), revisionReader{revision: want}); err != nil {
+	migration := Migrations()[0]
+	revisions := map[int64]platformpostgres.SchemaRevision{
+		BaselineRevision:   {Revision: BaselineRevision, MigrationID: BaselineMigrationID, Checksum: Checksum()},
+		migration.Revision: {Revision: migration.Revision, MigrationID: migration.MigrationID, Checksum: migration.Checksum()},
+	}
+	if err := Verify(context.Background(), revisionReader{revisions: revisions}); err != nil {
 		t.Fatalf("Verify() error = %v", err)
 	}
-	want.Checksum = strings.Repeat("f", 64)
-	if err := Verify(context.Background(), revisionReader{revision: want}); err == nil {
+	bad := make(map[int64]platformpostgres.SchemaRevision, len(revisions))
+	for key, value := range revisions {
+		bad[key] = value
+	}
+	value := bad[migration.Revision]
+	value.Checksum = strings.Repeat("f", 64)
+	bad[migration.Revision] = value
+	if err := Verify(context.Background(), revisionReader{revisions: bad}); err == nil {
 		t.Fatal("Verify() accepted a mismatched checksum")
 	}
 	if err := Verify(context.Background(), nil); err == nil {

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -155,17 +155,6 @@ func TestSemanticValueIsAPublishedAnalyticsDependency(t *testing.T) {
 	}
 }
 
-func TestSemanticValueIsAPublishedAccessDependency(t *testing.T) {
-	source, sourceOK := ClassifyPackage("internal/access")
-	target, targetOK := ClassifyPackage("internal/semanticvalue")
-	if !sourceOK || !targetOK {
-		t.Fatalf("classify access=%v semanticvalue=%v", sourceOK, targetOK)
-	}
-	if violation := CapabilityImportViolation("internal/access", source, "internal/semanticvalue", target); violation != "" {
-		t.Fatalf("access -> semanticvalue violation = %q, want published contract", violation)
-	}
-}
-
 func TestAgentGeneratedAPIIsCapabilityOwned(t *testing.T) {
 	rule, ok := ClassifyPackage("internal/agent/api/gen")
 	if !ok {

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -155,6 +155,17 @@ func TestSemanticValueIsAPublishedAnalyticsDependency(t *testing.T) {
 	}
 }
 
+func TestSemanticValueIsAPublishedAccessDependency(t *testing.T) {
+	source, sourceOK := ClassifyPackage("internal/access")
+	target, targetOK := ClassifyPackage("internal/semanticvalue")
+	if !sourceOK || !targetOK {
+		t.Fatalf("classify access=%v semanticvalue=%v", sourceOK, targetOK)
+	}
+	if violation := CapabilityImportViolation("internal/access", source, "internal/semanticvalue", target); violation != "" {
+		t.Fatalf("access -> semanticvalue violation = %q, want published contract", violation)
+	}
+}
+
 func TestAgentGeneratedAPIIsCapabilityOwned(t *testing.T) {
 	rule, ok := ClassifyPackage("internal/agent/api/gen")
 	if !ok {

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -168,7 +168,7 @@ func IsDeferredPackageEdge(sourcePath, targetCapability string) bool {
 
 var CapabilityDependencies = map[string]map[string]bool{
 	"project":       {"analytics": true, "dashboard": true, "access": true, "refresh": true, "servingstate": true},
-	"access":        {},
+	"access":        {"semanticvalue": true},
 	"manageddata":   {"servingstate": true},
 	"analytics":     {"access": true, "manageddata": true, "semanticvalue": true, "servingstate": true},
 	"dashboard":     {"access": true, "analytics": true, "runtimehost": true, "workload": true},

--- a/internal/platform/architecture/semanticvalue_access_test.go
+++ b/internal/platform/architecture/semanticvalue_access_test.go
@@ -1,0 +1,14 @@
+package architecture
+
+import "testing"
+
+func TestSemanticValueIsAPublishedAccessDependency(t *testing.T) {
+	source, sourceOK := ClassifyPackage("internal/access")
+	target, targetOK := ClassifyPackage("internal/semanticvalue")
+	if !sourceOK || !targetOK {
+		t.Fatalf("classify access=%v semanticvalue=%v", sourceOK, targetOK)
+	}
+	if violation := CapabilityImportViolation("internal/access", source, "internal/semanticvalue", target); violation != "" {
+		t.Fatalf("access -> semanticvalue violation = %q, want published contract", violation)
+	}
+}

--- a/internal/platform/postgres/migrations/conformance_test.go
+++ b/internal/platform/postgres/migrations/conformance_test.go
@@ -108,6 +108,26 @@ func TestAccessBaselinePostgreSQL18(t *testing.T) {
 		checksum != postgresbaseline.Checksum() {
 		t.Fatalf("baseline identity = %d/%q/%q", revision, migrationID, checksum)
 	}
+	forward := postgresbaseline.Migrations()[0]
+	if err := admin.QueryRow(ctx,
+		"SELECT revision, migration_id, checksum FROM platform.schema_revision WHERE revision = $1",
+		forward.Revision,
+	).Scan(&revision, &migrationID, &checksum); err != nil {
+		t.Fatal(err)
+	}
+	if revision != forward.Revision || migrationID != forward.MigrationID || checksum != forward.Checksum() {
+		t.Fatalf("attribute registry migration identity = %d/%q/%q", revision, migrationID, checksum)
+	}
+	var registryProfile, registryDigest string
+	var registryRevision int64
+	if err := admin.QueryRow(ctx,
+		"SELECT profile, registry_revision, registry_digest FROM access.semantic_attribute_registry WHERE singleton",
+	).Scan(&registryProfile, &registryRevision, &registryDigest); err != nil {
+		t.Fatal(err)
+	}
+	if registryProfile != "leapview.semantic-access/v1" || registryRevision != 0 || !strings.HasPrefix(registryDigest, "sha256:") {
+		t.Fatalf("attribute registry state = %q/%d/%q", registryProfile, registryRevision, registryDigest)
+	}
 
 	for _, schema := range []string{"platform", "access", "audit", "physical_pool", "ducklake"} {
 		var ownerName string

--- a/internal/platform/postgres/migrations/migrations.go
+++ b/internal/platform/postgres/migrations/migrations.go
@@ -46,11 +46,30 @@ type Component struct {
 	SQL  string
 }
 
+// Migration is one immutable forward-only control-plane revision. Capability
+// packages own the SQL and application composition assigns its global
+// revision and stable migration ID. Revision 1 remains the clean-slate
+// baseline; forward migrations never alter its checksum.
+type Migration struct {
+	Revision    int64
+	MigrationID string
+	SQL         string
+}
+
+// Checksum is the immutable SHA-256 identity recorded for this migration.
+func (m Migration) Checksum() string {
+	h := sha256.New()
+	writeChecksumPart(h, "migration.id", m.MigrationID)
+	writeChecksumPart(h, "migration.sql", m.SQL)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 // Plan is the product-supplied ordered capability baseline. The generic
 // migration runner deliberately does not import product capabilities; the
 // application composition layer owns this list and its role policy.
 type Plan struct {
 	Components    []Component
+	Migrations    []Migration
 	RolePolicySQL string
 }
 
@@ -84,6 +103,21 @@ func (p Plan) validate() error {
 			return fmt.Errorf("duplicate PostgreSQL migration component %q", component.Name)
 		}
 		seen[component.Name] = struct{}{}
+	}
+	seenMigrationIDs := make(map[string]struct{}, len(p.Migrations))
+	wantRevision := BaselineRevision + 1
+	for _, migration := range p.Migrations {
+		if migration.Revision != wantRevision {
+			return fmt.Errorf("PostgreSQL migration revision %d is not the expected revision %d", migration.Revision, wantRevision)
+		}
+		if strings.TrimSpace(migration.MigrationID) == "" || strings.TrimSpace(migration.SQL) == "" {
+			return fmt.Errorf("PostgreSQL migration revision %d is incomplete", migration.Revision)
+		}
+		if _, exists := seenMigrationIDs[migration.MigrationID]; exists {
+			return fmt.Errorf("duplicate PostgreSQL migration ID %q", migration.MigrationID)
+		}
+		seenMigrationIDs[migration.MigrationID] = struct{}{}
+		wantRevision++
 	}
 	return nil
 }
@@ -149,38 +183,64 @@ func Apply(ctx context.Context, tx Tx, plan Plan) error {
 		if recorded.Revision != BaselineRevision || recorded.MigrationID != BaselineMigrationID || recorded.Checksum != checksum {
 			return fmt.Errorf("PostgreSQL schema revision mismatch: got revision=%d migration=%q checksum=%q", recorded.Revision, recorded.MigrationID, recorded.Checksum)
 		}
-		// Reapply the deny-by-default role policy even when DDL is already
-		// present. This repairs accidental ACL widening without replaying
-		// capability triggers that are not all CREATE OR REPLACE-safe.
-		if _, err := tx.Exec(ctx, plan.RolePolicySQL); err != nil {
-			return fmt.Errorf("reapply PostgreSQL migration role policy: %w", err)
-		}
-		return nil
-	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	} else if !errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("inspect PostgreSQL schema revision: %w", err)
+	} else {
+		for _, component := range plan.Components {
+			if _, err := tx.Exec(ctx, component.SQL); err != nil {
+				return fmt.Errorf("apply PostgreSQL capability %s: %w", component.Name, err)
+			}
+		}
+		if err := queries.InsertSchemaRevision(ctx, platformdb.InsertSchemaRevisionParams{
+			Revision: BaselineRevision, MigrationID: BaselineMigrationID, Checksum: checksum,
+		}); err != nil {
+			return fmt.Errorf("record PostgreSQL schema revision: %w", err)
+		}
+
+		recorded, err = queries.GetSchemaRevision(ctx, BaselineRevision)
+		if err != nil {
+			return fmt.Errorf("verify PostgreSQL schema revision: %w", err)
+		}
+		if recorded.Revision != BaselineRevision || recorded.MigrationID != BaselineMigrationID || recorded.Checksum != checksum {
+			return fmt.Errorf("PostgreSQL schema revision mismatch: got revision=%d migration=%q checksum=%q", recorded.Revision, recorded.MigrationID, recorded.Checksum)
+		}
 	}
 
-	for _, component := range plan.Components {
-		if _, err := tx.Exec(ctx, component.SQL); err != nil {
-			return fmt.Errorf("apply PostgreSQL capability %s: %w", component.Name, err)
+	for _, migration := range plan.Migrations {
+		migrationChecksum := migration.Checksum()
+		recorded, err = queries.GetSchemaRevision(ctx, migration.Revision)
+		if err == nil {
+			if recorded.Revision != migration.Revision || recorded.MigrationID != migration.MigrationID || recorded.Checksum != migrationChecksum {
+				return fmt.Errorf("PostgreSQL schema revision mismatch: got revision=%d migration=%q checksum=%q", recorded.Revision, recorded.MigrationID, recorded.Checksum)
+			}
+			continue
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("inspect PostgreSQL schema revision %d: %w", migration.Revision, err)
+		}
+		if _, err := tx.Exec(ctx, migration.SQL); err != nil {
+			return fmt.Errorf("apply PostgreSQL migration %s: %w", migration.MigrationID, err)
+		}
+		if err := queries.InsertSchemaRevision(ctx, platformdb.InsertSchemaRevisionParams{
+			Revision: migration.Revision, MigrationID: migration.MigrationID, Checksum: migrationChecksum,
+		}); err != nil {
+			return fmt.Errorf("record PostgreSQL schema revision %d: %w", migration.Revision, err)
+		}
+		recorded, err = queries.GetSchemaRevision(ctx, migration.Revision)
+		if err != nil {
+			return fmt.Errorf("verify PostgreSQL schema revision %d: %w", migration.Revision, err)
+		}
+		if recorded.Revision != migration.Revision || recorded.MigrationID != migration.MigrationID || recorded.Checksum != migrationChecksum {
+			return fmt.Errorf("PostgreSQL schema revision mismatch: got revision=%d migration=%q checksum=%q", recorded.Revision, recorded.MigrationID, recorded.Checksum)
 		}
 	}
+
+	// Reapply the deny-by-default baseline role policy after every newly applied
+	// capability migration and on idempotent replay. This repairs accidental
+	// ACL widening; each capability migration remains responsible for grants on
+	// its newly introduced objects.
 	if _, err := tx.Exec(ctx, plan.RolePolicySQL); err != nil {
 		return fmt.Errorf("apply PostgreSQL migration role policy: %w", err)
-	}
-	if err := queries.InsertSchemaRevision(ctx, platformdb.InsertSchemaRevisionParams{
-		Revision: BaselineRevision, MigrationID: BaselineMigrationID, Checksum: checksum,
-	}); err != nil {
-		return fmt.Errorf("record PostgreSQL schema revision: %w", err)
-	}
-
-	recorded, err = queries.GetSchemaRevision(ctx, BaselineRevision)
-	if err != nil {
-		return fmt.Errorf("verify PostgreSQL schema revision: %w", err)
-	}
-	if recorded.Revision != BaselineRevision || recorded.MigrationID != BaselineMigrationID || recorded.Checksum != checksum {
-		return fmt.Errorf("PostgreSQL schema revision mismatch: got revision=%d migration=%q checksum=%q", recorded.Revision, recorded.MigrationID, recorded.Checksum)
 	}
 	return nil
 }

--- a/internal/platform/postgres/migrations/migrations_test.go
+++ b/internal/platform/postgres/migrations/migrations_test.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -16,14 +17,28 @@ type recordingTx struct {
 	migrationID      string
 	recordedChecksum string
 	queryErr         error
+	revisions        map[int64]recordingRow
 }
 
-func (r *recordingTx) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+func (r *recordingTx) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	r.sqls = append(r.sqls, sql)
+	if strings.Contains(sql, "INSERT INTO platform.schema_revision") && len(args) == 3 {
+		if r.revisions == nil {
+			r.revisions = make(map[int64]recordingRow)
+		}
+		revision := args[0].(int64)
+		r.revisions[revision] = recordingRow{revision: revision, migrationID: args[1].(string), checksum: args[2].(string)}
+	}
 	return pgconn.CommandTag{}, nil
 }
 
-func (r *recordingTx) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+func (r *recordingTx) QueryRow(_ context.Context, _ string, args ...any) pgx.Row {
+	if len(args) == 1 && r.revisions != nil {
+		if row, ok := r.revisions[args[0].(int64)]; ok {
+			return row
+		}
+		return recordingRow{err: pgx.ErrNoRows}
+	}
 	return recordingRow{revision: r.revision, migrationID: r.migrationID, checksum: r.recordedChecksum, err: r.queryErr}
 }
 
@@ -73,13 +88,17 @@ func TestBaselineMetadata(t *testing.T) {
 func testPlan() Plan {
 	return Plan{
 		Components:    []Component{{Name: "test.capability", SQL: "SELECT 1"}},
+		Migrations:    []Migration{{Revision: 2, MigrationID: "002_test", SQL: "SELECT 3"}},
 		RolePolicySQL: "SELECT 2",
 	}
 }
 
 func TestApplyUsesCallerOwnedTransaction(t *testing.T) {
 	plan := testPlan()
-	recorder := &recordingTx{revision: BaselineRevision, migrationID: BaselineMigrationID, recordedChecksum: plan.Checksum()}
+	recorder := &recordingTx{revisions: map[int64]recordingRow{
+		BaselineRevision: {revision: BaselineRevision, migrationID: BaselineMigrationID, checksum: plan.Checksum()},
+		2:                {revision: 2, migrationID: "002_test", checksum: plan.Migrations[0].Checksum()},
+	}}
 	if err := Apply(context.Background(), recorder, plan); err != nil {
 		t.Fatalf("Apply() error = %v", err)
 	}
@@ -92,9 +111,36 @@ func TestApplyUsesCallerOwnedTransaction(t *testing.T) {
 }
 
 func TestApplyRejectsRevisionChecksumMismatch(t *testing.T) {
-	recorder := &recordingTx{revision: BaselineRevision, migrationID: BaselineMigrationID, recordedChecksum: strings.Repeat("f", 64)}
+	recorder := &recordingTx{revisions: map[int64]recordingRow{
+		BaselineRevision: {revision: BaselineRevision, migrationID: BaselineMigrationID, checksum: strings.Repeat("f", 64)},
+	}}
 	if err := Apply(context.Background(), recorder, testPlan()); err == nil {
 		t.Fatal("Apply() accepted a mismatched recorded checksum")
+	}
+}
+
+func TestApplyAppendsForwardMigrationWithoutChangingBaselineIdentity(t *testing.T) {
+	plan := testPlan()
+	withoutForward := plan
+	withoutForward.Migrations = nil
+	if plan.Checksum() != withoutForward.Checksum() {
+		t.Fatal("forward migration changed the immutable baseline checksum")
+	}
+	recorder := &recordingTx{revisions: map[int64]recordingRow{
+		BaselineRevision: {revision: BaselineRevision, migrationID: BaselineMigrationID, checksum: plan.Checksum()},
+	}}
+	if err := Apply(context.Background(), recorder, plan); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	forward := recorder.revisions[2]
+	if forward.migrationID != "002_test" || forward.checksum != plan.Migrations[0].Checksum() {
+		t.Fatalf("forward revision = %#v", forward)
+	}
+	if got := recorder.revisions[BaselineRevision].checksum; got != plan.Checksum() {
+		t.Fatalf("baseline checksum changed to %q", got)
+	}
+	if !slices.Contains(recorder.sqls, "SELECT 3") {
+		t.Fatal("forward migration SQL was not executed")
 	}
 }
 
@@ -104,6 +150,8 @@ func TestApplyRejectsIncompleteOrDuplicatePlan(t *testing.T) {
 		{},
 		{Components: []Component{{Name: "one", SQL: "SELECT 1"}}},
 		{Components: []Component{{Name: "one", SQL: "SELECT 1"}, {Name: "one", SQL: "SELECT 2"}}, RolePolicySQL: "SELECT 3"},
+		{Components: []Component{{Name: "one", SQL: "SELECT 1"}}, Migrations: []Migration{{Revision: 3, MigrationID: "003_gap", SQL: "SELECT 4"}}, RolePolicySQL: "SELECT 3"},
+		{Components: []Component{{Name: "one", SQL: "SELECT 1"}}, Migrations: []Migration{{Revision: 2, MigrationID: "", SQL: "SELECT 4"}}, RolePolicySQL: "SELECT 3"},
 	} {
 		if err := Apply(context.Background(), recorder, plan); err == nil {
 			t.Fatalf("Apply accepted invalid plan %#v", plan)

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -160,7 +160,9 @@ sql:
 
   - engine: "postgresql"
     queries: "internal/access/postgres/queries"
-    schema: "internal/access/postgres/schema.sql"
+    schema:
+      - "internal/access/postgres/schema.sql"
+      - "internal/access/postgres/migrations/002_typed_attribute_registry.sql"
     gen:
       go:
         package: "db"


### PR DESCRIPTION
## Overview

Implements the PostgreSQL typed attribute registry for FAI-636 on top of the authority foundations reconciled in PR #460. The registry supplies the durable definition and compatibility authority required by ADR-0017 — Looker-aligned semantic access contract, while preserving the current partial VAL-11 qualification boundary.

## Included

- revision-2 access-owned registry migration without changing the revision-1 checksum
- stable UUID and semantic attribute name identities
- closed semantic types and scalar/list shapes
- instance, principal, and group ownership metadata
- active/disabled lifecycle and monotonic definition versions
- display, description, and HTTPS documentation metadata
- profile-qualified registry revision and SHA-256 digest
- pgx/sqlc repository layer for create, fetch, list, search, and safe metadata/lifecycle updates
- canonical scalar and set value validation through the merged semanticvalue package
- compatibility checks that reject identity, type, shape, and profile rewrites
- caller-owned transactional mutation and immutable audit evidence

## Explicitly not included

- VAL-11 full qualification
- consumer assignments
- runtime evaluation integration
- claims integration
- cache or audit projection expansion

## Validation

Passed:

- go test ./internal/access/postgres ./internal/platform/postgres/migrations ./internal/app/postgresbaseline -count=1
- relevant architecture dependency, import, and acyclicity tests
- task generated:check, including sqlc generation, documentation rendering, public snapshots, and extension-supply checks
- the toolbelt smoke test that blocked aggregate CI passes unchanged when rerun with GOFLAGS=-buildvcs=false and localhost permission

Limitations:

- PostgreSQL 18 registry lifecycle and migration conformance tests are present but were skipped locally because access to /var/run/docker.sock is denied.
- aggregate task ci completed the frontend lanes but the Go lane stopped at an unrelated toolbelt example VCS-stamping error: error obtaining VCS status: exit status 128.
- rerunning that exact test with GOFLAGS=-buildvcs=false succeeds; no unrelated toolbelt changes are included.

Linear: FAI-636