### PR TITLE
Harden restored exploration URL state

### DIFF
--- a/internal/project/http/browser.go
+++ b/internal/project/http/browser.go
@@ -378,7 +378,11 @@ func (h *BrowserHandler) Explore(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		return
 	}
 	catalog := h.navigationCatalog(r)
-	page, explorer, ok := h.dataExplorerSignals(w, r)
+	// The document request only renders the shell.  The canonical updates
+	// stream owns the first analytical execution so a deep link cannot execute
+	// the same exploration once during HTML rendering and again during signal
+	// bootstrap.
+	page, explorer, ok := h.dataExplorerSignalsForURL(w, r, false)
 	if !ok {
 		return
 	}
@@ -675,7 +679,7 @@ func (h *BrowserHandler) Updates(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 	case "data":
 		surface := r.URL.Query().Get("surface")
 		if surface == "explore" {
-			page, explorer, ok := h.dataExplorerSignals(w, r)
+			page, explorer, ok := h.dataExplorerSignalsForURL(w, r, true)
 			if !ok {
 				return
 			}
@@ -1498,6 +1502,15 @@ func projectAreaType(area string) string {
 }
 
 func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhttp.Request) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
+	return h.dataExplorerSignalsForURL(w, r, true)
+}
+
+// dataExplorerSignalsForURL restores durable exploration state from a browser
+// URL. URL state is treated as an assertion about the query, so it is checked
+// strictly after the authorized active-generation projection is available.
+// Interactive command payloads intentionally use the separate command path,
+// whose existing normalization remains permissive for incremental edits.
+func (h *BrowserHandler) dataExplorerSignalsForURL(w stdhttp.ResponseWriter, r *stdhttp.Request, executeQuery bool) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
 	values, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
 		stdhttp.Error(w, "invalid exploration URL: "+err.Error(), stdhttp.StatusBadRequest)
@@ -1516,7 +1529,7 @@ func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhtt
 		}
 		command.Explore = &explore
 	}
-	return h.dataExplorerSignalsForCommand(w, r, command)
+	return h.dataExplorerSignalsForRestoredCommand(w, r, command, executeQuery)
 }
 
 const dataExploreURLVersion = "1"
@@ -1533,6 +1546,12 @@ func dataExploreCommandFromQuery(values url.Values) (projectsignals.DataExploreC
 		if strings.TrimSpace(field) == "" {
 			return command, errors.New("dimension and metric identifiers must not be empty")
 		}
+	}
+	for index := range command.Dimensions {
+		command.Dimensions[index] = strings.TrimSpace(command.Dimensions[index])
+	}
+	for index := range command.Metrics {
+		command.Metrics[index] = strings.TrimSpace(command.Metrics[index])
 	}
 	if version := strings.TrimSpace(values.Get("v")); version != "" && version != dataExploreURLVersion {
 		return command, fmt.Errorf("unsupported version %q", version)
@@ -1551,6 +1570,12 @@ func dataExploreCommandFromQuery(values url.Values) (projectsignals.DataExploreC
 		if strings.TrimSpace(filter.Field) == "" || strings.TrimSpace(filter.Operator) == "" || filter.Values == nil {
 			return command, errors.New("filter field, operator, and values are required")
 		}
+		filter.Field = strings.TrimSpace(filter.Field)
+		filter.Operator = strings.TrimSpace(filter.Operator)
+		if filter.Dataset != nil {
+			dataset := strings.TrimSpace(projectsignals.ValueOrZero(filter.Dataset))
+			filter.Dataset = &dataset
+		}
 		command.Filters = append(command.Filters, filter)
 	}
 	for _, value := range values["sort"] {
@@ -1558,7 +1583,9 @@ func dataExploreCommandFromQuery(values url.Values) (projectsignals.DataExploreC
 		if err := decodeDataExploreURLValue(value, &sorting); err != nil {
 			return command, fmt.Errorf("sort: %w", err)
 		}
-		if strings.TrimSpace(sorting.Field) == "" || (sorting.Direction != "asc" && sorting.Direction != "desc") {
+		sorting.Field = strings.TrimSpace(sorting.Field)
+		sorting.Direction = strings.TrimSpace(sorting.Direction)
+		if sorting.Field == "" || (sorting.Direction != "asc" && sorting.Direction != "desc") {
 			return command, errors.New("sort field and asc or desc direction are required")
 		}
 		command.Sort = append(command.Sort, sorting)
@@ -1568,7 +1595,13 @@ func dataExploreCommandFromQuery(values url.Values) (projectsignals.DataExploreC
 		if err := decodeDataExploreURLValue(value, &timeSelection); err != nil {
 			return command, fmt.Errorf("time: %w", err)
 		}
-		if strings.TrimSpace(timeSelection.Field) == "" || strings.TrimSpace(timeSelection.Grain) == "" {
+		timeSelection.Field = strings.TrimSpace(timeSelection.Field)
+		timeSelection.Grain = strings.TrimSpace(timeSelection.Grain)
+		if timeSelection.Alias != nil {
+			alias := strings.TrimSpace(projectsignals.ValueOrZero(timeSelection.Alias))
+			timeSelection.Alias = &alias
+		}
+		if timeSelection.Field == "" || timeSelection.Grain == "" {
 			return command, errors.New("time field and grain are required")
 		}
 		command.Time = &timeSelection
@@ -1599,6 +1632,14 @@ func decodeDataExploreURLValue(value string, target any) error {
 }
 
 func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter, r *stdhttp.Request, command projectsignals.DataExplorerCommand) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
+	return h.dataExplorerSignalsForCommandWithOptions(w, r, command, true, false)
+}
+
+func (h *BrowserHandler) dataExplorerSignalsForRestoredCommand(w stdhttp.ResponseWriter, r *stdhttp.Request, command projectsignals.DataExplorerCommand, executeQuery bool) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
+	return h.dataExplorerSignalsForCommandWithOptions(w, r, command, executeQuery, true)
+}
+
+func (h *BrowserHandler) dataExplorerSignalsForCommandWithOptions(w stdhttp.ResponseWriter, r *stdhttp.Request, command projectsignals.DataExplorerCommand, executeQuery, strictURLState bool) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
 	command = normalizeDataExplorerCommand(command)
 	project := h.navigationCatalog(r).Project
 	page := projectsignals.DataExplorerPageSignal{Kind: projectsignals.RouteKindData, Title: "Data Explorer", Description: projectsignals.Optional("Explore governed semantic data."), Tabs: []projectsignals.ResourceTabSignal{}, Context: projectsignals.DataExplorerContextSignal{Active: true, Environment: h.Environment, ProjectID: project.ID, ProjectTitle: projectsignals.Optional(project.Title)}}
@@ -1628,6 +1669,13 @@ func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter,
 		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
 	}
 	projection := BuildDataExplorerProjection(assets, definition, exploreCommand, compiledModels)
+	if strictURLState && projectsignals.ValueOrZero(command.Mode) == "explore" {
+		modelID := strings.TrimSpace(projectsignals.ValueOrZero(projection.Command.ModelID))
+		if err := validateRestoredDataExploreState(exploreCommand, projection, definition.SemanticModels[modelID], compiledModels); err != nil {
+			stdhttp.Error(w, "invalid exploration URL state: "+err.Error(), stdhttp.StatusBadRequest)
+			return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+		}
+	}
 	explorer.Objects = projection.Objects
 	explorer.Explore.Models = projection.Models
 	explorer.Explore.SelectedModel = projection.SelectedModel
@@ -1637,7 +1685,7 @@ func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter,
 	exploreCommand = projection.Command
 	explorer.Explore.Command = exploreCommand
 	explorer.Command.Explore = &exploreCommand
-	if projectsignals.ValueOrZero(explorer.Command.Mode) == "explore" {
+	if executeQuery && projectsignals.ValueOrZero(explorer.Command.Mode) == "explore" {
 		projectID, err := h.boundProject(r.Context())
 		if err != nil {
 			stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
@@ -1677,7 +1725,7 @@ func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter,
 				stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
 				return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
 			}
-			if projectsignals.ValueOrZero(explorer.Command.Mode) != "explore" {
+			if executeQuery && projectsignals.ValueOrZero(explorer.Command.Mode) != "explore" {
 				explorer.Preview = dataExplorerPreview(r.Context(), h.QueryExecutor, projectID, object, explorer.Command)
 			}
 			break

--- a/internal/project/http/browser.go
+++ b/internal/project/http/browser.go
@@ -8,12 +8,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	stdhttp "net/http"
 	"net/url"
 	"path"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1499,136 +1497,6 @@ func projectAreaType(area string) string {
 	default:
 		return string(projectview.AssetTypeSource)
 	}
-}
-
-func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhttp.Request) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
-	return h.dataExplorerSignalsForURL(w, r, true)
-}
-
-// dataExplorerSignalsForURL restores durable exploration state from a browser
-// URL. URL state is treated as an assertion about the query, so it is checked
-// strictly after the authorized active-generation projection is available.
-// Interactive command payloads intentionally use the separate command path,
-// whose existing normalization remains permissive for incremental edits.
-func (h *BrowserHandler) dataExplorerSignalsForURL(w stdhttp.ResponseWriter, r *stdhttp.Request, executeQuery bool) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
-	values, err := url.ParseQuery(r.URL.RawQuery)
-	if err != nil {
-		stdhttp.Error(w, "invalid exploration URL: "+err.Error(), stdhttp.StatusBadRequest)
-		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
-	}
-	command := projectsignals.DataExplorerCommand{
-		ObjectKey: projectsignals.Optional(strings.TrimSpace(values.Get("object"))),
-		Mode:      projectsignals.Optional(strings.TrimSpace(values.Get("mode"))),
-		Limit:     dataExplorerDefaultLimit, Count: dataExplorerDefaultLimit, Block: projectsignals.Pointer("all"),
-	}
-	if projectsignals.ValueOrZero(command.Mode) == "explore" {
-		explore, err := dataExploreCommandFromQuery(values)
-		if err != nil {
-			stdhttp.Error(w, "invalid exploration URL: "+err.Error(), stdhttp.StatusBadRequest)
-			return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
-		}
-		command.Explore = &explore
-	}
-	return h.dataExplorerSignalsForRestoredCommand(w, r, command, executeQuery)
-}
-
-const dataExploreURLVersion = "1"
-
-func dataExploreCommandFromQuery(values url.Values) (projectsignals.DataExploreCommand, error) {
-	command := projectsignals.DataExploreCommand{
-		Dimensions: append([]string{}, values["dimension"]...),
-		Metrics:    append([]string{}, values["metric"]...),
-		Filters:    []projectsignals.DataExploreFilterSignal{},
-		Sort:       []projectsignals.DataExploreSortSignal{},
-		Limit:      dataExplorerDefaultLimit,
-	}
-	for _, field := range append(append([]string(nil), command.Dimensions...), command.Metrics...) {
-		if strings.TrimSpace(field) == "" {
-			return command, errors.New("dimension and metric identifiers must not be empty")
-		}
-	}
-	for index := range command.Dimensions {
-		command.Dimensions[index] = strings.TrimSpace(command.Dimensions[index])
-	}
-	for index := range command.Metrics {
-		command.Metrics[index] = strings.TrimSpace(command.Metrics[index])
-	}
-	if version := strings.TrimSpace(values.Get("v")); version != "" && version != dataExploreURLVersion {
-		return command, fmt.Errorf("unsupported version %q", version)
-	}
-	if value := strings.TrimSpace(values.Get("model")); value != "" {
-		command.ModelID = projectsignals.Optional(value)
-	}
-	if value := strings.TrimSpace(values.Get("dataset")); value != "" {
-		command.DatasetID = projectsignals.Optional(value)
-	}
-	for _, value := range values["filter"] {
-		var filter projectsignals.DataExploreFilterSignal
-		if err := decodeDataExploreURLValue(value, &filter); err != nil {
-			return command, fmt.Errorf("filter: %w", err)
-		}
-		if strings.TrimSpace(filter.Field) == "" || strings.TrimSpace(filter.Operator) == "" || filter.Values == nil {
-			return command, errors.New("filter field, operator, and values are required")
-		}
-		filter.Field = strings.TrimSpace(filter.Field)
-		filter.Operator = strings.TrimSpace(filter.Operator)
-		if filter.Dataset != nil {
-			dataset := strings.TrimSpace(projectsignals.ValueOrZero(filter.Dataset))
-			filter.Dataset = &dataset
-		}
-		command.Filters = append(command.Filters, filter)
-	}
-	for _, value := range values["sort"] {
-		var sorting projectsignals.DataExploreSortSignal
-		if err := decodeDataExploreURLValue(value, &sorting); err != nil {
-			return command, fmt.Errorf("sort: %w", err)
-		}
-		sorting.Field = strings.TrimSpace(sorting.Field)
-		sorting.Direction = strings.TrimSpace(sorting.Direction)
-		if sorting.Field == "" || (sorting.Direction != "asc" && sorting.Direction != "desc") {
-			return command, errors.New("sort field and asc or desc direction are required")
-		}
-		command.Sort = append(command.Sort, sorting)
-	}
-	if value := values.Get("time"); value != "" {
-		var timeSelection projectsignals.DataExploreTimeSignal
-		if err := decodeDataExploreURLValue(value, &timeSelection); err != nil {
-			return command, fmt.Errorf("time: %w", err)
-		}
-		timeSelection.Field = strings.TrimSpace(timeSelection.Field)
-		timeSelection.Grain = strings.TrimSpace(timeSelection.Grain)
-		if timeSelection.Alias != nil {
-			alias := strings.TrimSpace(projectsignals.ValueOrZero(timeSelection.Alias))
-			timeSelection.Alias = &alias
-		}
-		if timeSelection.Field == "" || timeSelection.Grain == "" {
-			return command, errors.New("time field and grain are required")
-		}
-		command.Time = &timeSelection
-	}
-	if value := strings.TrimSpace(values.Get("limit")); value != "" {
-		limit, err := strconv.ParseInt(value, 10, 64)
-		if err != nil || limit <= 0 || limit > dataExplorerMaximumLimit {
-			return command, fmt.Errorf("limit must be between 1 and %d", dataExplorerMaximumLimit)
-		}
-		command.Limit = limit
-	}
-	return command, nil
-}
-
-func decodeDataExploreURLValue(value string, target any) error {
-	decoder := json.NewDecoder(strings.NewReader(value))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(target); err != nil {
-		return err
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		if err == nil {
-			return errors.New("multiple JSON values")
-		}
-		return err
-	}
-	return nil
 }
 
 func (h *BrowserHandler) dataExplorerSignalsForCommand(w stdhttp.ResponseWriter, r *stdhttp.Request, command projectsignals.DataExplorerCommand) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {

--- a/internal/project/http/data_explorer_url.go
+++ b/internal/project/http/data_explorer_url.go
@@ -1,0 +1,256 @@
+package http
+
+import (
+	"fmt"
+	"strings"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
+)
+
+// validateRestoredDataExploreState verifies every durable URL operand against
+// the authorized active-generation projection. The normal command path keeps
+// its incremental normalization, but a URL restore must never turn a stale
+// operand into a smaller query by dropping it.
+func validateRestoredDataExploreState(command projectsignals.DataExploreCommand, projection DataExplorerProjection, model *semanticmodel.Model, compiledModels map[string]*semanticquery.CompiledModel) error {
+	modelID := strings.TrimSpace(projectsignals.ValueOrZero(command.ModelID))
+	selectedModelID := strings.TrimSpace(projectsignals.ValueOrZero(projection.Command.ModelID))
+
+	if modelID != "" {
+		if !explorerModelByID(projection.Models, modelID) {
+			return fmt.Errorf("model %q is no longer available; choose an active semantic model", modelID)
+		}
+		if selectedModelID != modelID {
+			return fmt.Errorf("model %q could not be restored; choose an active semantic model", modelID)
+		}
+	}
+	if selectedModelID == "" {
+		return fmt.Errorf("no active semantic model is available; choose an active semantic model")
+	}
+	compiled := compiledModels[selectedModelID]
+	if compiled == nil || len(compiled.DatasetNames()) == 0 {
+		return fmt.Errorf("model %q has no active compiled definition; reload the explorer after the serving state is ready", selectedModelID)
+	}
+
+	datasetID := strings.TrimSpace(projectsignals.ValueOrZero(command.DatasetID))
+	if datasetID != "" {
+		if !explorerDatasetByID(projection.Datasets, datasetID) || !compiledDataset(compiled, datasetID) {
+			return fmt.Errorf("dataset %q is no longer available in model %q; choose an active dataset", datasetID, selectedModelID)
+		}
+	}
+
+	fieldByID := make(map[string]projectsignals.DataExploreFieldSignal, len(projection.Fields))
+	for _, field := range projection.Fields {
+		fieldByID[field.ID] = field
+	}
+	filterDatasets := restoredFilterDatasetParticipation(command, projection, model, fieldByID)
+	seenFields := make(map[string]string, len(command.Dimensions)+len(command.Metrics))
+	for _, fieldID := range command.Dimensions {
+		if err := validateRestoredExploreField(fieldID, "dimension", fieldByID); err != nil {
+			return err
+		}
+		if previous := seenFields[fieldID]; previous != "" {
+			return fmt.Errorf("dimension field %q is selected more than once; remove the duplicate from the URL", fieldID)
+		}
+		seenFields[fieldID] = "dimension"
+	}
+	for _, fieldID := range command.Metrics {
+		if err := validateRestoredExploreField(fieldID, "metric", fieldByID); err != nil {
+			return err
+		}
+		if previous := seenFields[fieldID]; previous != "" {
+			return fmt.Errorf("metric field %q is selected more than once; remove the duplicate from the URL", fieldID)
+		}
+		seenFields[fieldID] = "metric"
+	}
+	for index, filter := range command.Filters {
+		_, err := restoredExploreField(filter.Field, "filter", "dimension", fieldByID)
+		if err != nil {
+			return fmt.Errorf("filter %d: %w", index+1, err)
+		}
+		if err := validateRestoredExploreFilter(index, filter); err != nil {
+			return err
+		}
+		if filter.Dataset == nil || strings.TrimSpace(projectsignals.ValueOrZero(filter.Dataset)) == "" {
+			if filter.Dataset != nil {
+				return fmt.Errorf("filter %d dataset is empty; remove the stale filter or choose an active dataset", index+1)
+			}
+		} else {
+			filterDataset := strings.TrimSpace(projectsignals.ValueOrZero(filter.Dataset))
+			if !explorerDatasetByID(projection.Datasets, filterDataset) || !compiledDataset(compiled, filterDataset) {
+				return fmt.Errorf("filter %d dataset %q is no longer available; remove the stale filter or choose an active dataset", index+1, filterDataset)
+			}
+			if !filterDatasets[filterDataset] {
+				return fmt.Errorf("filter %d dataset %q does not participate in the restored query; choose the active query dataset or a selected metric root", index+1, filterDataset)
+			}
+		}
+	}
+	for index, sorting := range command.Sort {
+		if _, err := restoredExploreField(sorting.Field, fmt.Sprintf("sort %d", index+1), "", fieldByID); err != nil {
+			return err
+		}
+		if sorting.Direction != "asc" && sorting.Direction != "desc" {
+			return fmt.Errorf("sort %d uses unsupported direction %q; choose asc or desc", index+1, sorting.Direction)
+		}
+		if !containsRestoredExploreSelection(sorting.Field, command.Dimensions, command.Metrics) {
+			return fmt.Errorf("sort %d field %q is not selected; choose a selected dimension or metric", index+1, sorting.Field)
+		}
+	}
+	if command.Time != nil {
+		field, err := restoredExploreField(command.Time.Field, "time", "dimension", fieldByID)
+		if err != nil {
+			return err
+		}
+		if !restoredTimeGrain(command.Time.Grain) {
+			return fmt.Errorf("time field %q uses unsupported grain %q; choose a supported time grain", command.Time.Field, command.Time.Grain)
+		}
+		if declared, supported := restoredCompiledSemanticTimeGrain(compiled, command.Time.Field, command.Time.Grain); declared && !supported {
+			return fmt.Errorf("time field %q does not support grain %q in the active semantic model; choose a supported grain", command.Time.Field, command.Time.Grain)
+		}
+		fieldType := strings.ToLower(strings.TrimSpace(projectsignals.ValueOrZero(field.Type)))
+		if fieldType != "date" && fieldType != "timestamp" {
+			return fmt.Errorf("time field %q is not a date or timestamp dimension; choose a temporal field", command.Time.Field)
+		}
+	}
+	return nil
+}
+
+// restoredFilterDatasetParticipation returns the datasets that an explicit
+// filter scope may legally name after projection has selected/rebased the
+// effective query base. A normal query has one participating base. When a
+// selected metric spans multiple roots, the semantic executor clears the
+// dataset target and the complete recursive root union is the safe scope.
+func restoredFilterDatasetParticipation(command projectsignals.DataExploreCommand, projection DataExplorerProjection, model *semanticmodel.Model, fields map[string]projectsignals.DataExploreFieldSignal) map[string]bool {
+	participating := map[string]bool{}
+	effectiveDataset := strings.TrimSpace(projectsignals.ValueOrZero(projection.Command.DatasetID))
+	if !explorerCommandHasMultiRootMetric(command.Metrics, fields) {
+		if effectiveDataset != "" {
+			participating[effectiveDataset] = true
+		}
+		return participating
+	}
+	for _, metric := range command.Metrics {
+		for _, root := range explorerMetricRootDatasets(model, metric) {
+			participating[root] = true
+		}
+	}
+	return participating
+}
+
+func validateRestoredExploreFilter(index int, filter projectsignals.DataExploreFilterSignal) error {
+	operator := strings.TrimSpace(filter.Operator)
+	valueCount := len(filter.Values)
+	requiresOne := false
+	requiresZero := false
+	switch operator {
+	case "equals", "not_equals", "contains", "not_contains", "starts_with", "ends_with", "greater_than", "greater_than_or_equal", "less_than", "less_than_or_equal":
+		requiresOne = true
+	case "in", "not_in":
+		if valueCount == 0 {
+			return fmt.Errorf("filter %d operator %q requires at least one value; update or remove the stale filter", index+1, operator)
+		}
+	case "is_null", "is_not_null":
+		requiresZero = true
+	default:
+		return fmt.Errorf("filter %d uses unsupported operator %q; choose a supported filter operator", index+1, filter.Operator)
+	}
+	if requiresOne && valueCount != 1 {
+		return fmt.Errorf("filter %d operator %q requires exactly one value; update or remove the stale filter", index+1, operator)
+	}
+	if requiresZero && valueCount != 0 {
+		return fmt.Errorf("filter %d operator %q does not accept values; update or remove the stale filter", index+1, operator)
+	}
+	return nil
+}
+
+// restoredCompiledSemanticTimeGrain mirrors planner resolution: only a
+// semantic-dimension reference is subject to that dimension's declared grain
+// contract. A physical binding with the same authored semantic dimension is
+// validated using the planner's global grain vocabulary and physical type.
+func restoredCompiledSemanticTimeGrain(compiled *semanticquery.CompiledModel, field, grain string) (declared, supported bool) {
+	if compiled == nil {
+		return false, false
+	}
+	field = strings.TrimSpace(field)
+	grain = strings.TrimSpace(grain)
+	dimension, ok := compiled.SemanticDimension(field)
+	if !ok {
+		return false, false
+	}
+	declared = true
+	for _, candidate := range dimension.Grains {
+		if strings.TrimSpace(candidate) == grain {
+			supported = true
+		}
+	}
+	return declared, supported
+}
+
+func explorerModelByID(models []projectsignals.DataExploreModelSignal, id string) bool {
+	for _, model := range models {
+		if model.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func explorerDatasetByID(datasets []projectsignals.DataExploreDatasetSignal, id string) bool {
+	for _, dataset := range datasets {
+		if dataset.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func compiledDataset(compiled *semanticquery.CompiledModel, id string) bool {
+	if compiled == nil {
+		return false
+	}
+	_, ok := compiled.Dataset(id)
+	return ok
+}
+
+func validateRestoredExploreField(fieldID, expectedKind string, fields map[string]projectsignals.DataExploreFieldSignal) error {
+	_, err := restoredExploreField(fieldID, expectedKind, expectedKind, fields)
+	return err
+}
+
+func restoredExploreField(fieldID, operand, expectedKind string, fields map[string]projectsignals.DataExploreFieldSignal) (projectsignals.DataExploreFieldSignal, error) {
+	fieldID = strings.TrimSpace(fieldID)
+	field, ok := fields[fieldID]
+	if !ok {
+		return projectsignals.DataExploreFieldSignal{}, fmt.Errorf("%s field %q is no longer available in the active semantic model; remove it from the URL or reload the explorer", operand, fieldID)
+	}
+	if expectedKind != "" && field.Kind != expectedKind {
+		return projectsignals.DataExploreFieldSignal{}, fmt.Errorf("%s field %q is a %s, not a %s; choose a %s field", operand, fieldID, field.Kind, expectedKind, expectedKind)
+	}
+	if !field.Compatible {
+		reason := strings.TrimSpace(projectsignals.ValueOrZero(field.CompatibilityReason))
+		if reason == "" {
+			reason = "it is incompatible with the restored dataset"
+		}
+		return projectsignals.DataExploreFieldSignal{}, fmt.Errorf("%s field %q is incompatible: %s; choose a compatible field or dataset", operand, fieldID, reason)
+	}
+	return field, nil
+}
+
+func containsRestoredExploreSelection(value string, dimensions, metrics []string) bool {
+	for _, selected := range append(append([]string(nil), dimensions...), metrics...) {
+		if selected == value {
+			return true
+		}
+	}
+	return false
+}
+
+func restoredTimeGrain(grain string) bool {
+	switch strings.TrimSpace(grain) {
+	case "second", "minute", "hour", "day", "week", "month", "quarter", "year":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/project/http/data_explorer_url.go
+++ b/internal/project/http/data_explorer_url.go
@@ -1,13 +1,149 @@
 package http
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	stdhttp "net/http"
+	"net/url"
+	"strconv"
 	"strings"
 
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
 )
+
+func (h *BrowserHandler) dataExplorerSignals(w stdhttp.ResponseWriter, r *stdhttp.Request) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
+	return h.dataExplorerSignalsForURL(w, r, true)
+}
+
+// dataExplorerSignalsForURL restores durable exploration state from a browser
+// URL. URL state is treated as an assertion about the query, so it is checked
+// strictly after the authorized active-generation projection is available.
+// Interactive command payloads intentionally use the separate command path,
+// whose existing normalization remains permissive for incremental edits.
+func (h *BrowserHandler) dataExplorerSignalsForURL(w stdhttp.ResponseWriter, r *stdhttp.Request, executeQuery bool) (projectsignals.DataExplorerPageSignal, projectsignals.DataExplorerSignal, bool) {
+	values, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		stdhttp.Error(w, "invalid exploration URL: "+err.Error(), stdhttp.StatusBadRequest)
+		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+	}
+	command := projectsignals.DataExplorerCommand{
+		ObjectKey: projectsignals.Optional(strings.TrimSpace(values.Get("object"))),
+		Mode:      projectsignals.Optional(strings.TrimSpace(values.Get("mode"))),
+		Limit:     dataExplorerDefaultLimit, Count: dataExplorerDefaultLimit, Block: projectsignals.Pointer("all"),
+	}
+	if projectsignals.ValueOrZero(command.Mode) == "explore" {
+		explore, err := dataExploreCommandFromQuery(values)
+		if err != nil {
+			stdhttp.Error(w, "invalid exploration URL: "+err.Error(), stdhttp.StatusBadRequest)
+			return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
+		}
+		command.Explore = &explore
+	}
+	return h.dataExplorerSignalsForRestoredCommand(w, r, command, executeQuery)
+}
+
+const dataExploreURLVersion = "1"
+
+func dataExploreCommandFromQuery(values url.Values) (projectsignals.DataExploreCommand, error) {
+	command := projectsignals.DataExploreCommand{
+		Dimensions: append([]string{}, values["dimension"]...),
+		Metrics:    append([]string{}, values["metric"]...),
+		Filters:    []projectsignals.DataExploreFilterSignal{},
+		Sort:       []projectsignals.DataExploreSortSignal{},
+		Limit:      dataExplorerDefaultLimit,
+	}
+	for _, field := range append(append([]string(nil), command.Dimensions...), command.Metrics...) {
+		if strings.TrimSpace(field) == "" {
+			return command, errors.New("dimension and metric identifiers must not be empty")
+		}
+	}
+	for index := range command.Dimensions {
+		command.Dimensions[index] = strings.TrimSpace(command.Dimensions[index])
+	}
+	for index := range command.Metrics {
+		command.Metrics[index] = strings.TrimSpace(command.Metrics[index])
+	}
+	if version := strings.TrimSpace(values.Get("v")); version != "" && version != dataExploreURLVersion {
+		return command, fmt.Errorf("unsupported version %q", version)
+	}
+	if value := strings.TrimSpace(values.Get("model")); value != "" {
+		command.ModelID = projectsignals.Optional(value)
+	}
+	if value := strings.TrimSpace(values.Get("dataset")); value != "" {
+		command.DatasetID = projectsignals.Optional(value)
+	}
+	for _, value := range values["filter"] {
+		var filter projectsignals.DataExploreFilterSignal
+		if err := decodeDataExploreURLValue(value, &filter); err != nil {
+			return command, fmt.Errorf("filter: %w", err)
+		}
+		if strings.TrimSpace(filter.Field) == "" || strings.TrimSpace(filter.Operator) == "" || filter.Values == nil {
+			return command, errors.New("filter field, operator, and values are required")
+		}
+		filter.Field = strings.TrimSpace(filter.Field)
+		filter.Operator = strings.TrimSpace(filter.Operator)
+		if filter.Dataset != nil {
+			dataset := strings.TrimSpace(projectsignals.ValueOrZero(filter.Dataset))
+			filter.Dataset = &dataset
+		}
+		command.Filters = append(command.Filters, filter)
+	}
+	for _, value := range values["sort"] {
+		var sorting projectsignals.DataExploreSortSignal
+		if err := decodeDataExploreURLValue(value, &sorting); err != nil {
+			return command, fmt.Errorf("sort: %w", err)
+		}
+		sorting.Field = strings.TrimSpace(sorting.Field)
+		sorting.Direction = strings.TrimSpace(sorting.Direction)
+		if sorting.Field == "" || (sorting.Direction != "asc" && sorting.Direction != "desc") {
+			return command, errors.New("sort field and asc or desc direction are required")
+		}
+		command.Sort = append(command.Sort, sorting)
+	}
+	if value := values.Get("time"); value != "" {
+		var timeSelection projectsignals.DataExploreTimeSignal
+		if err := decodeDataExploreURLValue(value, &timeSelection); err != nil {
+			return command, fmt.Errorf("time: %w", err)
+		}
+		timeSelection.Field = strings.TrimSpace(timeSelection.Field)
+		timeSelection.Grain = strings.TrimSpace(timeSelection.Grain)
+		if timeSelection.Alias != nil {
+			alias := strings.TrimSpace(projectsignals.ValueOrZero(timeSelection.Alias))
+			timeSelection.Alias = &alias
+		}
+		if timeSelection.Field == "" || timeSelection.Grain == "" {
+			return command, errors.New("time field and grain are required")
+		}
+		command.Time = &timeSelection
+	}
+	if value := strings.TrimSpace(values.Get("limit")); value != "" {
+		limit, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || limit <= 0 || limit > dataExplorerMaximumLimit {
+			return command, fmt.Errorf("limit must be between 1 and %d", dataExplorerMaximumLimit)
+		}
+		command.Limit = limit
+	}
+	return command, nil
+}
+
+func decodeDataExploreURLValue(value string, target any) error {
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
 
 // validateRestoredDataExploreState verifies every durable URL operand against
 // the authorized active-generation projection. The normal command path keeps

--- a/internal/project/http/data_explorer_url_test.go
+++ b/internal/project/http/data_explorer_url_test.go
@@ -1,0 +1,530 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	projectview "github.com/flidai/leapview/internal/project"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
+	servingstate "github.com/flidai/leapview/internal/servingstate"
+)
+
+type countingDataQueryExecutor struct {
+	calls int
+}
+
+func (e *countingDataQueryExecutor) ExecuteDataQuery(context.Context, dataquery.Query) (dataquery.Result, error) {
+	e.calls++
+	return dataquery.Result{Rows: []dataquery.Row{{"status": "paid"}}}, nil
+}
+
+func newDataExplorerURLTestHandler(t *testing.T) (*BrowserHandler, *countingDataQueryExecutor) {
+	t.Helper()
+	const projectID = "project:test"
+	const modelID = "semantic:sales"
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				ModelName: "orders",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"status":     {Label: "Status", Type: "string"},
+					"created_at": {Label: "Created at", Type: "timestamp"},
+				},
+			},
+		},
+		Metrics: map[string]semanticmodel.Metric{
+			"revenue": {Type: "aggregate", Dataset: "orders", Label: "Revenue", Aggregation: "sum", Input: &semanticmodel.MetricInput{Field: "orders.revenue"}},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+	}
+	compiled, err := semanticquery.CompileDatasetBindings(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executor := &countingDataQueryExecutor{}
+	h := &BrowserHandler{
+		Graph: browserGraphStub{graph: servingstate.AssetGraph{Assets: []servingstate.Asset{
+			{ID: "model:orders", ProjectID: projectID, ServingStateID: "state", Type: "model_table", Key: "orders", Title: "Orders", PayloadJSON: `{}`},
+			{ID: modelID, ProjectID: projectID, ServingStateID: "state", Type: "semantic_model", Key: "sales", Title: "Sales", PayloadJSON: `{}`},
+		}}},
+		ProjectDefinitionReader: browserProjectDefinitionStub{definition: projectmanifest.Project{
+			ID:             projectID,
+			Models:         map[string]semanticmodel.Table{"model:orders": model.Tables["orders"]},
+			SemanticModels: map[string]*semanticmodel.Model{modelID: model},
+			NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders"}},
+		}, compiled: map[string]*semanticquery.CompiledModel{modelID: compiled}},
+		QueryExecutor:    executor,
+		ResolveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return projectID, nil },
+		Environment:      "dev",
+		CurrentUser:      func(*http.Request) (Principal, bool) { return Principal{DevBypass: true}, true },
+	}
+	return h, executor
+}
+
+func TestDataExplorerDocumentDefersSemanticExecutionToCanonicalUpdates(t *testing.T) {
+	h, executor := newDataExplorerURLTestHandler(t)
+	values := url.Values{
+		"mode":      {"explore"},
+		"model":     {"semantic:sales"},
+		"dataset":   {"orders"},
+		"dimension": {"orders.status"},
+	}
+
+	document := httptest.NewRecorder()
+	h.Explore(document, httptest.NewRequest(http.MethodGet, "/explore?"+values.Encode(), nil))
+	if document.Code != http.StatusOK {
+		t.Fatalf("document status = %d, want 200: %s", document.Code, document.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("document executed %d analytical queries, want 0", executor.calls)
+	}
+	for _, want := range []string{"mode=explore", "model=semantic%3Asales", "dataset=orders", "dimension=orders.status"} {
+		if !strings.Contains(document.Body.String(), want) {
+			t.Fatalf("document shell missing normalized updates URL component %q:\n%s", want, document.Body.String())
+		}
+	}
+
+	streamContext, cancel := context.WithCancel(t.Context())
+	request := httptest.NewRequestWithContext(streamContext, http.MethodGet, "/updates?route=data&surface=explore&"+values.Encode(), nil)
+	stream := &notifyingResponseRecorder{ResponseRecorder: httptest.NewRecorder(), wrote: make(chan struct{})}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.Updates(stream, request)
+	}()
+	select {
+	case <-stream.wrote:
+	case <-time.After(time.Second):
+		cancel()
+		t.Fatal("updates bootstrap did not write a patch")
+	}
+	if executor.calls != 1 {
+		t.Fatalf("updates executed %d analytical queries, want exactly 1", executor.calls)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("updates stream did not stop after cancellation")
+	}
+}
+
+func TestDataExplorerRestoredURLCanonicalizesSpacedOperandsBeforeExecution(t *testing.T) {
+	h, executor := newDataExplorerURLTestHandler(t)
+	values := url.Values{
+		"mode":      {"explore"},
+		"model":     {" semantic:sales "},
+		"dataset":   {" orders "},
+		"dimension": {" orders.status "},
+	}
+	document := httptest.NewRecorder()
+	h.Explore(document, httptest.NewRequest(http.MethodGet, "/explore?"+values.Encode(), nil))
+	if document.Code != http.StatusOK {
+		t.Fatalf("spaced URL status = %d, want 200: %s", document.Code, document.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("spaced document executed %d analytical queries, want 0", executor.calls)
+	}
+	body := document.Body.String()
+	if !strings.Contains(body, "dimension=orders.status") || strings.Contains(body, "dimension=+orders.status+") {
+		t.Fatalf("spaced field was not canonicalized in updates URL:\n%s", body)
+	}
+}
+
+func TestDataExploreCommandFromQueryTrimsMetadataButPreservesFilterValues(t *testing.T) {
+	command, err := dataExploreCommandFromQuery(url.Values{
+		"dimension": {" orders.status "},
+		"metric":    {" revenue "},
+		"filter":    {`{"field":" orders.status ","operator":" equals ","dataset":" orders ","values":[" paid "]}`},
+		"sort":      {`{"field":" revenue ","direction":" desc "}`},
+		"time":      {`{"field":" orders.created_at ","grain":" month ","alias":" order_month "}`},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(command.Dimensions) != 1 || command.Dimensions[0] != "orders.status" || len(command.Metrics) != 1 || command.Metrics[0] != "revenue" {
+		t.Fatalf("trimmed fields = %#v/%#v", command.Dimensions, command.Metrics)
+	}
+	if len(command.Filters) != 1 || command.Filters[0].Field != "orders.status" || command.Filters[0].Operator != "equals" || projectsignals.ValueOrZero(command.Filters[0].Dataset) != "orders" || len(command.Filters[0].Values) != 1 || command.Filters[0].Values[0] != " paid " {
+		t.Fatalf("trimmed filter metadata or changed value = %#v", command.Filters)
+	}
+	if len(command.Sort) != 1 || command.Sort[0].Field != "revenue" || command.Sort[0].Direction != "desc" {
+		t.Fatalf("trimmed sort = %#v", command.Sort)
+	}
+	if command.Time == nil || command.Time.Field != "orders.created_at" || command.Time.Grain != "month" || projectsignals.ValueOrZero(command.Time.Alias) != "order_month" {
+		t.Fatalf("trimmed time = %#v", command.Time)
+	}
+}
+
+func TestDataExplorerRestoredURLFailsClosedForStaleField(t *testing.T) {
+	h, executor := newDataExplorerURLTestHandler(t)
+	values := url.Values{
+		"mode":      {"explore"},
+		"model":     {"semantic:sales"},
+		"dataset":   {"orders"},
+		"dimension": {"orders.removed_status"},
+	}
+	recorder := httptest.NewRecorder()
+	h.Explore(recorder, httptest.NewRequest(http.MethodGet, "/explore?"+values.Encode(), nil))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("stale URL status = %d, want 400: %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "orders.removed_status") || !strings.Contains(recorder.Body.String(), "remove it from the URL") {
+		t.Fatalf("stale URL feedback = %q, want field and remediation", recorder.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("stale URL executed %d analytical queries, want 0", executor.calls)
+	}
+}
+
+func TestDataExplorerRestoredURLFailsClosedWhenBindingsAreUnavailable(t *testing.T) {
+	h, executor := newDataExplorerURLTestHandler(t)
+	definition := h.ProjectDefinitionReader.(browserProjectDefinitionStub)
+	definition.compiled = nil
+	h.ProjectDefinitionReader = definition
+	values := url.Values{
+		"mode":      {"explore"},
+		"model":     {"semantic:sales"},
+		"dataset":   {"orders"},
+		"dimension": {"orders.status"},
+	}
+	recorder := httptest.NewRecorder()
+	h.Explore(recorder, httptest.NewRequest(http.MethodGet, "/explore?"+values.Encode(), nil))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("unavailable bindings URL status = %d, want 400: %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "no active compiled definition") || !strings.Contains(recorder.Body.String(), "reload the explorer") {
+		t.Fatalf("unavailable bindings feedback = %q, want actionable diagnostic", recorder.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("unavailable bindings URL executed %d analytical queries, want 0", executor.calls)
+	}
+}
+
+func TestDataExplorerRestoredURLFailsClosedForEmptyCompiledModel(t *testing.T) {
+	h, executor := newDataExplorerURLTestHandler(t)
+	definition := h.ProjectDefinitionReader.(browserProjectDefinitionStub)
+	definition.compiled = map[string]*semanticquery.CompiledModel{"semantic:sales": &semanticquery.CompiledModel{}}
+	h.ProjectDefinitionReader = definition
+	values := url.Values{
+		"mode":      {"explore"},
+		"model":     {"semantic:sales"},
+		"dataset":   {"orders"},
+		"dimension": {"orders.status"},
+	}
+	recorder := httptest.NewRecorder()
+	h.Explore(recorder, httptest.NewRequest(http.MethodGet, "/explore?"+values.Encode(), nil))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("empty compiled model URL status = %d, want 400: %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "no active compiled definition") {
+		t.Fatalf("empty compiled model feedback = %q, want unavailable diagnostic", recorder.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("empty compiled model URL executed %d analytical queries, want 0", executor.calls)
+	}
+}
+
+func TestDataExplorerBrowseRestoreDoesNotRequireSemanticBindings(t *testing.T) {
+	h, _ := newDataExplorerURLTestHandler(t)
+	definition := h.ProjectDefinitionReader.(browserProjectDefinitionStub)
+	definition.compiled = nil
+	h.ProjectDefinitionReader = definition
+	recorder := httptest.NewRecorder()
+	_, explorer, ok := h.dataExplorerSignalsForURL(recorder, httptest.NewRequest(http.MethodGet, "/explore?object=model%3Aorders", nil), false)
+	if !ok {
+		t.Fatalf("browse restore failed: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if recorder.Code != http.StatusOK || projectsignals.ValueOrZero(explorer.Command.Mode) != "browse" || explorer.SelectedObject == nil {
+		t.Fatalf("browse restore = status %d, explorer %#v", recorder.Code, explorer)
+	}
+}
+
+func TestDataExplorerBrowseDocumentDefersPreviewToCanonicalUpdates(t *testing.T) {
+	h, executor := newDataExplorerURLTestHandler(t)
+	document := httptest.NewRecorder()
+	h.Explore(document, httptest.NewRequest(http.MethodGet, "/explore?object=model%3Aorders", nil))
+	if document.Code != http.StatusOK {
+		t.Fatalf("browse document status = %d, want 200: %s", document.Code, document.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("browse document executed %d preview queries, want 0", executor.calls)
+	}
+
+	streamContext, cancel := context.WithCancel(t.Context())
+	request := httptest.NewRequestWithContext(streamContext, http.MethodGet, "/updates?route=data&surface=explore&object=model%3Aorders", nil)
+	stream := &notifyingResponseRecorder{ResponseRecorder: httptest.NewRecorder(), wrote: make(chan struct{})}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.Updates(stream, request)
+	}()
+	select {
+	case <-stream.wrote:
+	case <-time.After(time.Second):
+		cancel()
+		t.Fatal("browse updates bootstrap did not write a patch")
+	}
+	if executor.calls != 1 {
+		t.Fatalf("browse updates executed %d preview queries, want exactly 1", executor.calls)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("browse updates stream did not stop after cancellation")
+	}
+}
+
+func TestValidateRestoredDataExploreStateRejectsWrongKindsAndIncompatibleOperands(t *testing.T) {
+	fields := map[string]projectsignals.DataExploreFieldSignal{
+		"orders.status":       {ID: "orders.status", Kind: "dimension", Compatible: true, Type: projectsignals.Optional("string")},
+		"orders.created_at":   {ID: "orders.created_at", Kind: "dimension", Compatible: true, Type: projectsignals.Optional("timestamp")},
+		"revenue":             {ID: "revenue", Kind: "metric", Compatible: true},
+		"orders.incompatible": {ID: "orders.incompatible", Kind: "dimension", Compatible: false, CompatibilityReason: projectsignals.Optional("no safe relationship path")},
+	}
+	projection := DataExplorerProjection{
+		Models:   []projectsignals.DataExploreModelSignal{{ID: "semantic:sales"}},
+		Datasets: []projectsignals.DataExploreDatasetSignal{{ID: "orders"}},
+		Fields:   make([]projectsignals.DataExploreFieldSignal, 0, len(fields)),
+		Command: projectsignals.DataExploreCommand{
+			ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"),
+		},
+	}
+	for _, field := range fields {
+		projection.Fields = append(projection.Fields, field)
+	}
+	compiled, err := semanticquery.CompileDatasetBindings(&semanticmodel.Model{
+		Name: "sales", Tables: map[string]semanticmodel.Table{"orders": {ModelName: "orders"}},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiledModels := map[string]*semanticquery.CompiledModel{"semantic:sales": compiled}
+	for _, test := range []struct {
+		name    string
+		command projectsignals.DataExploreCommand
+		want    string
+	}{
+		{name: "dimension wrong kind", command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"), Metrics: []string{"orders.status"}}, want: "not a metric"},
+		{name: "filter wrong kind", command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"), Filters: []projectsignals.DataExploreFilterSignal{{Field: "revenue", Operator: "equals", Values: []string{"1"}}}}, want: "not a dimension"},
+		{name: "filter value cardinality", command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"), Filters: []projectsignals.DataExploreFilterSignal{{Field: "orders.status", Operator: "equals", Values: []string{"paid", "shipped"}}}}, want: "exactly one value"},
+		{name: "sort not selected", command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"), Sort: []projectsignals.DataExploreSortSignal{{Field: "orders.status", Direction: "asc"}}}, want: "not selected"},
+		{name: "incompatible", command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"), Dimensions: []string{"orders.incompatible"}}, want: "no safe relationship path"},
+		{name: "time wrong kind", command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"), Time: &projectsignals.DataExploreTimeSignal{Field: "orders.status", Grain: "month"}}, want: "not a date or timestamp"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateRestoredDataExploreState(test.command, projection, nil, compiledModels); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validation error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateRestoredDataExploreStateRejectsEmptyMembershipFilters(t *testing.T) {
+	projection := DataExplorerProjection{
+		Models:   []projectsignals.DataExploreModelSignal{{ID: "semantic:sales"}},
+		Datasets: []projectsignals.DataExploreDatasetSignal{{ID: "orders"}},
+		Fields:   []projectsignals.DataExploreFieldSignal{{ID: "orders.status", Kind: "dimension", Compatible: true, Type: projectsignals.Optional("string")}},
+		Command: projectsignals.DataExploreCommand{
+			ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"),
+		},
+	}
+	compiled, err := semanticquery.CompileDatasetBindings(&semanticmodel.Model{
+		Name: "sales", Tables: map[string]semanticmodel.Table{"orders": {ModelName: "orders"}},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, operator := range []string{"in", "not_in"} {
+		err := validateRestoredDataExploreState(projectsignals.DataExploreCommand{
+			ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"),
+			Filters: []projectsignals.DataExploreFilterSignal{{Field: "orders.status", Operator: operator, Values: []string{}}},
+		}, projection, nil, map[string]*semanticquery.CompiledModel{"semantic:sales": compiled})
+		if err == nil || !strings.Contains(err.Error(), "at least one value") {
+			t.Fatalf("empty %s filter error = %v, want non-empty arity diagnostic", operator, err)
+		}
+	}
+}
+
+func TestValidateRestoredDataExploreStateRejectsUnavailableTargets(t *testing.T) {
+	projection := DataExplorerProjection{
+		Models:   []projectsignals.DataExploreModelSignal{{ID: "semantic:sales"}},
+		Datasets: []projectsignals.DataExploreDatasetSignal{{ID: "orders"}},
+		Command: projectsignals.DataExploreCommand{
+			ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"),
+		},
+	}
+	compiled, err := semanticquery.CompileDatasetBindings(&semanticmodel.Model{
+		Name: "sales", Tables: map[string]semanticmodel.Table{"orders": {ModelName: "orders"}},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name    string
+		command projectsignals.DataExploreCommand
+		want    string
+	}{
+		{name: "model", command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:removed")}, want: "model \"semantic:removed\" is no longer available"},
+		{name: "dataset", command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("removed")}, want: "dataset \"removed\" is no longer available"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateRestoredDataExploreState(test.command, projection, nil, map[string]*semanticquery.CompiledModel{"semantic:sales": compiled}); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validation error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateRestoredDataExploreStateConstrainsFilterDatasetParticipation(t *testing.T) {
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders":    {ModelName: "orders", Dimensions: map[string]semanticmodel.MetricDimension{"status": {Type: "string"}}},
+			"customers": {ModelName: "customers", Dimensions: map[string]semanticmodel.MetricDimension{"region": {Type: "string"}}},
+			"other":     {ModelName: "other", Dimensions: map[string]semanticmodel.MetricDimension{"name": {Type: "string"}}},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{
+			"orders": {Model: "orders"}, "customers": {Model: "customers"}, "other": {Model: "other"},
+		},
+		Metrics: map[string]semanticmodel.Metric{
+			"order_count":    {Type: "aggregate", Dataset: "orders", Aggregation: "count", Input: &semanticmodel.MetricInput{Field: "orders.status"}},
+			"customer_count": {Type: "aggregate", Dataset: "customers", Aggregation: "count", Input: &semanticmodel.MetricInput{Field: "customers.region"}},
+			"combined":       {Type: "ratio", Numerator: "order_count", Denominator: "customer_count"},
+		},
+	}
+	compiled, err := semanticquery.CompileDatasetBindings(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiledModels := map[string]*semanticquery.CompiledModel{"semantic:sales": compiled}
+	base := DataExplorerProjection{
+		Models:   []projectsignals.DataExploreModelSignal{{ID: "semantic:sales"}},
+		Datasets: []projectsignals.DataExploreDatasetSignal{{ID: "orders"}, {ID: "customers"}, {ID: "other"}},
+		Fields: []projectsignals.DataExploreFieldSignal{
+			{ID: "orders.status", Kind: "dimension", Compatible: true},
+			{ID: "combined", Kind: "metric", Compatible: true},
+		},
+		Command: projectsignals.DataExploreCommand{ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders")},
+	}
+	filter := func(dataset string) []projectsignals.DataExploreFilterSignal {
+		return []projectsignals.DataExploreFilterSignal{{Field: "orders.status", Dataset: projectsignals.Optional(dataset), Operator: "equals", Values: []string{"paid"}}}
+	}
+	singleRoot := projectsignals.DataExploreCommand{
+		ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"), Filters: filter("customers"),
+	}
+	if err := validateRestoredDataExploreState(singleRoot, base, model, compiledModels); err == nil || !strings.Contains(err.Error(), "does not participate") {
+		t.Fatalf("single-root filter dataset error = %v, want participation diagnostic", err)
+	}
+	multiRoot := singleRoot
+	multiRoot.Metrics = []string{"combined"}
+	if err := validateRestoredDataExploreState(multiRoot, base, model, compiledModels); err != nil {
+		t.Fatalf("participating multi-root filter dataset rejected: %v", err)
+	}
+	nonParticipating := multiRoot
+	nonParticipating.Filters = filter("other")
+	if err := validateRestoredDataExploreState(nonParticipating, base, model, compiledModels); err == nil || !strings.Contains(err.Error(), "does not participate") {
+		t.Fatalf("nonparticipating multi-root filter dataset error = %v, want participation diagnostic", err)
+	}
+}
+
+func TestValidateRestoredDataExploreStateChecksDeclaredTimeGrains(t *testing.T) {
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				ModelName:   "orders",
+				GrainEntity: "order",
+				Entities:    map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"order_id"}}},
+				Dimensions:  map[string]semanticmodel.MetricDimension{"order_id": {Type: "number", Datatype: semanticmodel.DataTypeInteger}, "created_at": {Type: "timestamp", Datatype: semanticmodel.DataTypeDateTime}},
+			},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"created": {Type: "timestamp", Datatype: semanticmodel.DataTypeDateTime, NativeGrain: "day", Grains: []string{"day"}, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.created_at"}}},
+		},
+		Metrics: map[string]semanticmodel.Metric{
+			"order_count": {Type: "aggregate", Dataset: "orders", Aggregation: "count", Input: &semanticmodel.MetricInput{Field: "orders.order_id"}},
+		},
+	}
+	projection := DataExplorerProjection{
+		Models:   []projectsignals.DataExploreModelSignal{{ID: "semantic:sales"}},
+		Datasets: []projectsignals.DataExploreDatasetSignal{{ID: "orders"}},
+		Fields: []projectsignals.DataExploreFieldSignal{
+			{ID: "created", Kind: "dimension", Compatible: true, Type: projectsignals.Optional("timestamp")},
+			{ID: "orders.created_at", Kind: "dimension", Compatible: true, Type: projectsignals.Optional("timestamp")},
+		},
+		Command: projectsignals.DataExploreCommand{
+			ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"),
+		},
+	}
+	compiled, err := semanticquery.CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateRestoredDataExploreState(projectsignals.DataExploreCommand{
+		ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"),
+		Time: &projectsignals.DataExploreTimeSignal{Field: "created", Grain: "month"},
+	}, projection, model, map[string]*semanticquery.CompiledModel{"semantic:sales": compiled})
+	if err == nil || !strings.Contains(err.Error(), "does not support grain") {
+		t.Fatalf("time grain validation error = %v, want declared-grain diagnostic", err)
+	}
+	if err := validateRestoredDataExploreState(projectsignals.DataExploreCommand{
+		ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("orders"),
+		Time: &projectsignals.DataExploreTimeSignal{Field: "orders.created_at", Grain: "month"},
+	}, projection, model, map[string]*semanticquery.CompiledModel{"semantic:sales": compiled}); err != nil {
+		t.Fatalf("globally valid grain on physical binding rejected: %v", err)
+	}
+}
+
+func TestValidateRestoredDataExploreStateAcceptsSafeRebase(t *testing.T) {
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders":    {ModelName: "orders", Dimensions: map[string]semanticmodel.MetricDimension{"customer_id": {Field: "orders.customer_id"}, "status": {Field: "orders.status"}}},
+			"customers": {ModelName: "customers", Dimensions: map[string]semanticmodel.MetricDimension{"customer_id": {Field: "customers.customer_id"}, "region": {Field: "customers.region"}}},
+		},
+		Relationships: []semanticmodel.Relationship{{ID: "orders_customers", FromDataset: "orders", FromFields: []string{"customer_id"}, ToDataset: "customers", ToFields: []string{"customer_id"}, Cardinality: "many_to_one"}},
+		Datasets:      map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}, "customers": {Model: "customers"}},
+	}
+	project := projectmanifest.Project{
+		Models:         map[string]semanticmodel.Table{"model:orders": model.Tables["orders"], "model:customers": model.Tables["customers"]},
+		SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": model},
+		NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders", "customers": "model:customers"}},
+	}
+	assets := []projectview.DevelopAssetView{
+		{ID: "model:orders", Type: string(projectview.AssetTypeModelTable), Key: "orders", Title: "Orders"},
+		{ID: "model:customers", Type: string(projectview.AssetTypeModelTable), Key: "customers", Title: "Customers"},
+		{ID: "semantic:sales", Type: string(projectview.AssetTypeSemanticModel), Key: "sales", Title: "Sales"},
+	}
+	compiled, err := semanticquery.CompileDatasetBindings(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := projectsignals.DataExploreCommand{
+		ModelID: projectsignals.Optional("semantic:sales"), DatasetID: projectsignals.Optional("customers"),
+		Dimensions: []string{"customers.region", "orders.status"},
+	}
+	projection := BuildDataExplorerProjection(assets, project, command, map[string]*semanticquery.CompiledModel{"semantic:sales": compiled})
+	if got := projectsignals.ValueOrZero(projection.Command.DatasetID); got != "orders" {
+		t.Fatalf("safe rebase dataset = %q, want orders", got)
+	}
+	if err := validateRestoredDataExploreState(command, projection, model, map[string]*semanticquery.CompiledModel{"semantic:sales": compiled}); err != nil {
+		t.Fatalf("safe rebase rejected: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- fail closed when restored exploration URLs reference unavailable or incompatible governed state
- canonicalize durable URL operands while preserving legitimate dataset rebases and multi-root metric scopes
- defer initial exploration and browse execution from the document request to the canonical updates bootstrap
- add route, validation, race, and execution-count regression coverage

## Validation

- go test -race ./internal/project/http ./internal/project/ui -count=1
- focused restored-URL and execution tests repeated 50 times
- full task ci passed before the final rebase; the rebased diff was independently reviewed and targeted tests were repeated
- git diff --check

## Linear

FAI-655

This PR is the corrective hardening pass for the merged URL round-trip foundation. FAI-655 remains In Progress for the broader canonical specification acceptance scope.