### PR TITLE
Add semantic attribute control plane

### DIFF
--- a/adr/0017-adopt-a-looker-aligned-semantic-access-contract.md
+++ b/adr/0017-adopt-a-looker-aligned-semantic-access-contract.md
@@ -177,14 +177,28 @@ spec:
       requiredAccessGrants: [canViewPII]
 ```
 
-### Attribute ownership and matching
+### Attribute ownership, stewardship, and matching
 
-The instance control plane owns the attribute registry, trusted SAML/OIDC and
-embed-claim mappings, group and principal assignments, and the resulting
-attribute values. SCIM may provision users and groups but does not define the
-authorization meaning of an attribute. Analytics YAML may reference only a
-canonical attribute name; it cannot declare values, identities, assignments,
-or claim-extraction rules.
+The instance access control plane owns the typed attribute registry, direct
+principal/group assignments, trusted claim-mapping records, and resulting
+effective values. `owner_kind`/`owner_id` on a registry definition is
+stewardship metadata, not an access grant or an administrator role. Assignment
+targets and trusted source identities are separate from definition ownership.
+SCIM may provision users and groups but does not define the authorization
+meaning of an attribute. Analytics YAML may reference only a canonical
+attribute name; it cannot declare values, identities, assignments, or
+claim-extraction rules.
+
+FAI-637's PostgreSQL control state is split deliberately: the definition
+registry has `(profile, registry_revision, registry_digest)` identity, while
+assignments and mappings have an independent
+`(profile, control_revision, control_digest)` identity. Definitions describe
+name/type/shape/lifecycle; assignments bind canonical values to subjects;
+mappings bind an exact source/provider/issuer/audience/claim to a definition
+without persisting a claim value. Direct principal and active-group
+assignments and claims from the opaque `trustedclaims.Envelope` may be resolved
+together. A
+source conflict is an error, never an implicit precedence decision.
 
 The initial value types are typed scalar and homogeneous list values supported
 by the semantic field vocabulary. A scalar attribute satisfies an access grant
@@ -206,14 +220,36 @@ attribute type must be compatible with the dimension datatype. Missing, empty,
 invalid, or incompatible values deny the query; no wildcard, administrator
 bypass, or implicit unfiltered fallback exists.
 
-The control plane rejects deletion or type mutation of an attribute referenced
-by an active or retained rollback generation. It may explicitly disable the
-attribute as an audited emergency revocation; dependent semantic objects then
-fail closed, become unhealthy, and invalidate affected caches. This is not a
-semantic-evaluator bypass. Break-glass access is absent from this profile and
-would require a separate control-plane security ADR.
+The control plane rejects deletion or type mutation at the registry identity
+boundary. Generation-reference retention checks and dependent semantic-object
+invalidation are required future integrations, not evidence supplied by
+FAI-637. It may explicitly disable the attribute as an audited emergency
+revocation; consumers must then fail closed. This is not a semantic-evaluator
+bypass. Break-glass access is absent from this profile and would require a
+separate control-plane security ADR.
 
 ### Enforcement boundary
+
+#### Control-plane administration boundary
+
+Registry, assignment, mapping, impact-preview, and semantic-attribute audit
+operations are platform-admin operations. Authentication first resolves the
+canonical principal. The request then checks the durable instance-wide
+platform role through `RequestPlatformAdmin`/`IsPlatformAdmin`; a project
+authorization snapshot cannot create that role. Request credentials can only
+attenuate it: a session with no API credential inherits the role, an authoring
+credential is denied, an API token with nil capabilities inherits, an explicit
+empty capability list denies, and a non-empty capability list must include
+`PROJECT_ADMIN`. A credential for a different principal denies. The explicit
+development bypass is limited to non-production configuration. Repository or
+role-check failure fails closed.
+
+This is the administration gate for the control-plane state. It does not make
+an administrator an unconditional semantic-consumer bypass; semantic
+authorization is a separate, still-pending planner integration.
+
+The following grant/filter rules are the decided target boundary. They are not
+evidence that FAI-637 has already migrated each consumer.
 
 Access grants control both discovery and execution. A denied dataset or member
 is absent from the authorization-filtered catalog and is rejected if addressed
@@ -243,6 +279,39 @@ semantic generation, and trusted-attribute version participate in query and
 result-cache identity. Durable audit records identify the policy inputs and
 outcome without recording unrestricted sensitive attribute values.
 
+#### Control-plane lifecycle state machines
+
+The durable control-plane rows use explicit, forward-only state transitions:
+
+```text
+Definition:
+  absent --register(v1)--> active
+  active --metadata/disable (version +1)--> active/disabled
+  disabled --metadata/restore (version +1)--> disabled/active
+  active or disabled --delete or identity/type/shape/profile rewrite--> reject
+
+Assignment:
+  absent --set(expected=0, v1)--> active
+  active --set(expected=current, values changed, version +1)--> active
+  active --remove(expected=current, version +1)--> tombstoned
+  tombstoned --set--> new active incarnation (new ID, version 1)
+
+Trusted claim mapping:
+  absent --set(expected=0, v1)--> active
+  active --same identity replay--> active (no state advance)
+  active --remove(expected=current, version +1)--> tombstoned
+  tombstoned --set--> new mapping incarnation (old row retained)
+  active or tombstoned --in-place identity rewrite/restore--> reject
+```
+
+Definition changes lock and advance the registry singleton; assignment and
+mapping changes lock and advance the independent control singleton. Expected
+versions are checked at transport and repository boundaries, stale versions
+are conflicts, and database-owned timestamps/tombstones plus immutable IDs and
+types prevent silent rewrites. Top-level mutations couple the state change,
+digest advancement, and audit append in one transaction; explicit transaction
+helpers preserve the same rule for callers that own the transaction.
+
 ### Deliberate initial limits
 
 The initial contract does not include arbitrary access predicates, SQL row
@@ -261,6 +330,44 @@ conformance specification under profile `leapview.semantic-access/v1`.
 Normative changes to its shape, canonicalization, evaluation, planner,
 discovery, cache, or compatibility behavior require a new profile; new policy
 concepts, targets, bypasses, precedence, or masking require another ADR.
+
+### FAI-637 implementation boundary
+
+ADR-0017 remains **Implementation: pending**. FAI-637 implements the
+access-owned PostgreSQL control-plane slice: the profile-qualified definition
+registry, direct principal/group assignment rows, trusted claim-mapping rows,
+their lifecycle/version/digest/audit invariants, typed value ingress, a
+source-bound trusted-claim verifier boundary, effective direct/group
+resolution behind the opaque `trustedclaims.Envelope` boundary, and
+platform-admin management endpoints. It does
+not yet implement the SemanticModel policy compiler, planner security barrier,
+catalog or query enforcement, semantic generation references, cache/event
+invalidation, or ordinary semantic consumer integration.
+
+The source names SAML, OIDC, embed, and service token are accepted as closed
+mapping/verifier vocabulary only. FAI-637 does not claim an OIDC, SAML, embed,
+or service-consumer adapter. The current effective-value resolver's claim
+input is the opaque `trustedclaims.Envelope` boundary; wiring a real provider
+through the verifier and into a principal authorization context remains
+pending.
+
+### Immediate invalidation identity
+
+FAI-637 establishes, but does not yet consume, durable invalidation inputs.
+The future authorization-sensitive identity is the tuple
+`(instance, semantic generation, principal, registry profile/revision/digest,
+control profile/revision/digest, effective attribute-set digest, normalized
+semantic-policy identity)`. The effective attribute-set digest is an ordered
+projection of definition ID/version/type/shape, canonical value digest, and
+source; raw values and raw provider claims are excluded. Runtime trusted input
+also binds its credential/token fingerprint and validity interval.
+
+A committed definition change invalidates by registry identity. A committed
+assignment or mapping change invalidates by control identity and, where known,
+affected definition and subject. A digest mismatch is an immediate,
+conservative invalidation signal, never permission to continue with stale
+state. Cache/event propagation and consumer use of this identity remain
+pending, so this ADR does not claim completed LIF qualification.
 
 Policy diffs report compatibility and security impact separately. The profile
 matrix makes tightening changes such as adding a required grant or access
@@ -283,11 +390,13 @@ entitlement tables, time-dependent policy, and masked values are not available
 through v1 authoring and require modeled data, control-plane attributes, or a
 future explicit decision.
 
-The control plane must gain a typed, versioned attribute registry and trusted
-claim-mapping lifecycle. Candidate preparation must prove that every referenced
-attribute exists and is type-compatible without embedding instance values in
-portable artifacts. Attribute changes must invalidate affected authorization
-and result caches promptly and generate durable audit evidence.
+FAI-637 supplies a typed, versioned attribute registry, direct assignment and
+trusted claim-mapping lifecycle, typed ingress, durable revision/digest
+identities, and transactional audit evidence. Candidate preparation must still
+prove that every referenced attribute exists and is type-compatible without
+embedding instance values in portable artifacts. Consumer integration must
+invalidate affected authorization and result caches promptly using the
+identity above; that propagation is not implemented by FAI-637.
 
 Removing Source and Model policy targets means every consumer-visible query
 must pass through SemanticModel. Any raw Source or Model preview remains an
@@ -300,8 +409,10 @@ its own governed consumption contract rather than reuse of internal resources.
 - TypeSpec is the sole public structural authority for `accessGrants`,
   `requiredAccessGrants`, and `accessFilters`; generated JSON Schema, Go DTOs,
   documentation, and browser types contain the same closed contract.
-- The authoring registry rejects standalone `DataPolicy` resources and rejects
-  access-policy fields on every resource other than SemanticModel.
+- The accepted authoring contract rejects standalone `DataPolicy` resources and
+  rejects access-policy fields on every resource other than SemanticModel. The
+  current FAI-637 slice does not claim that the existing legacy compiler and
+  consumer paths have completed this migration.
 - Schema and compiler fixtures cover the normative cases in the semantic
   access-policy conformance specification, including unknown fields, dangling
   grants, incompatible attributes, unbound dimensions, and prohibited identity
@@ -320,12 +431,14 @@ its own governed consumption contract rather than reuse of internal resources.
 - Compatibility fixtures cover every normative policy-change matrix row and
   prove tightening, widening, and indeterminate results trigger the required
   version and approval behavior.
-- Registry lifecycle tests reject referenced attribute deletion and type
-  mutation, prove explicit disablement fails closed, and prove no administrator
-  or break-glass bypass exists in semantic consumers.
-- Cache tests prove principals with different effective policies cannot share
-  authorization-sensitive results and that attribute-version changes
-  invalidate affected entries.
+- Registry/control tests reject identity/type mutation, prove explicit
+  disablement and tombstone lifecycle behavior, and prove platform-admin
+  request attenuation. Generation-reference retention, dependent-consumer
+  invalidation, and administrator/break-glass behavior in semantic consumers
+  remain pending.
+- Cache tests must prove principals with different effective policies cannot
+  share authorization-sensitive results and that registry/control identity
+  changes invalidate affected entries; those consumer tests remain pending.
 - Audit tests prove grant evaluation and row-filter application are attributable
   to the principal, semantic generation, attribute version, and policy identity
   without leaking unrestricted attribute values.

--- a/adr/specifications/semantic-access-policy-conformance.md
+++ b/adr/specifications/semantic-access-policy-conformance.md
@@ -4,7 +4,7 @@ Status: accepted
 
 Profile: `leapview.semantic-access/v1`
 
-Last updated: 2026-09-02
+Last updated: 2026-09-03
 
 Owners: LeapView maintainers
 
@@ -21,6 +21,18 @@ The terms **must**, **must not**, **should**, and **may** are normative. A
 requirement is implemented only when its evidence is linked in the evidence
 ledger. The profile identifier participates in generated schema, compiled
 policy, cache, audit, and conformance evidence.
+
+FAI-637 is the control-plane implementation slice, not completion of this
+specification. It currently adds the PostgreSQL definition registry (revision
+2), durable principal/group assignments and trusted-claim mappings (revision
+3), shared typed canonicalization at those boundaries, a source-bound trusted
+claim verifier package, effective direct/group resolution behind the opaque
+`trustedclaims.Envelope` boundary, and platform-admin control APIs. It does not
+yet implement the SemanticModel
+policy compiler, planner security barrier, catalog or query consumer
+integration, source-provider adapters, semantic generation references, or
+cache/event invalidation. Those requirements remain normative targets and
+their evidence remains pending or partial below.
 
 ## Change control
 
@@ -134,8 +146,10 @@ spec:
   Portable SemanticModel YAML references attribute names but contains neither
   registry definitions nor values.
 - **ATT-02:** Attribute values originate only from authenticated control-plane
-  assignments, trusted SAML/OIDC claim mappings, or cryptographically verified
-  embed/service-token claims admitted by the control plane.
+  assignments, or claim values admitted through a source-bound verifier and
+  durable mapping. The profile names SAML, OIDC, embed, and service-token
+  sources, but a source adapter must perform cryptographic verification before
+  a claim can be admitted.
 - **ATT-03:** Browser parameters, dashboard filters, query arguments, headers,
   unsigned tokens, and analytics YAML cannot create or override trusted
   principal attributes.
@@ -167,6 +181,75 @@ spec:
 - **ATT-12:** The control plane rejects an assignment containing more than 1,024
   canonical values. Runtime repeats the bound defensively and denies evaluation
   if persisted or token-supplied state violates it.
+
+The registry's `owner_kind`/`owner_id` is stewardship metadata only. It does
+not grant the owner data access, create an assignment, or confer the durable
+platform-admin role. Assignment subject (`principal` or `group`) and trusted
+claim source identity are separate authorization inputs.
+
+## Control-plane lifecycle state machines
+
+The following state machines describe the durable PostgreSQL control rows. A
+tombstone is retained history; it is not a disabled definition and cannot be
+silently restored in place.
+
+```text
+Definition:
+  absent --register(v1)--> active
+  active --metadata/disable (version +1)--> active/disabled
+  disabled --metadata/restore (version +1)--> disabled/active
+  active or disabled --delete or identity/type/shape/profile rewrite--> reject
+
+Assignment:
+  absent --set(expected=0, v1)--> active
+  active --set(expected=current, values changed, version +1)--> active
+  active --remove(expected=current, version +1)--> tombstoned
+  tombstoned --set--> new active incarnation (new ID, version 1)
+
+Trusted claim mapping:
+  absent --set(expected=0, v1)--> active
+  active --same identity replay--> active (no version/control advance)
+  active --remove(expected=current, version +1)--> tombstoned
+  tombstoned --set--> new mapping incarnation (old row retained)
+  active or tombstoned --in-place identity rewrite/restore--> reject
+```
+
+Definition metadata/lifecycle changes lock and advance the registry singleton
+`(profile, registry_revision, registry_digest)`. Assignment and mapping
+mutations lock the independent control singleton
+`(profile, control_revision, control_digest)`, whose digest covers ordered
+active and tombstoned control projections. Each effective mutation advances
+the corresponding revision exactly once with a new digest; idempotent replays
+do not advance it. `If-Match`/expected-version checks occur at both the
+transport and repository boundary, and stale versions are conflicts. Database
+triggers reject identity/type rewrites, enforce one-step version advancement,
+and make tombstone/updated timestamps database-owned.
+
+The current effective resolver combines direct principal and active-group
+assignments with claims admitted through the opaque `trustedclaims.Envelope`
+boundary for matching trusted mappings. It canonicalizes values through the
+shared semantic-value boundary. Equal values from multiple sources may be
+combined; conflicting values for one definition return a source-conflict
+error. The resolver is not yet wired to a real provider adapter or semantic
+consumer.
+
+## Platform-admin control flow
+
+The generated API metadata requires an authenticated principal; semantic
+attribute handlers add the stronger platform-admin guard. Authentication
+resolves the canonical principal, `RequestPlatformAdmin` rechecks the durable
+instance-wide platform role, and request credentials can only attenuate it.
+No project snapshot grant creates a platform role. A session with no API
+credential inherits the role; an authoring credential is denied; an API token
+with nil capabilities inherits, an explicit empty list denies, and a non-empty
+list must include `PROJECT_ADMIN`. A credential whose principal differs from
+the authenticated principal is denied. The explicit development bypass is
+non-production only. Repository or role-check failure fails closed.
+
+This guard protects registry, assignment, mapping, impact-preview, and
+semantic-attribute audit operations. It is an administration boundary, not
+evidence that ordinary dashboards, APIs, embeds, or other semantic consumers
+already evaluate the profile.
 
 ## Attribute value canonicalization
 
@@ -386,6 +469,30 @@ spec:
 - **LIF-08:** Control-plane attribute changes and authored policy deployments
   remain distinguishable audit events with a common correlation boundary.
 
+FAI-637 currently persists and validates the two durable identity pairs above,
+but it does not publish invalidation events or provide a semantic result-cache
+consumer. The immediate invalidation identity for the future consumer boundary
+is therefore:
+
+```text
+(instance, semantic generation, principal,
+ registry profile/revision/digest,
+ control profile/revision/digest,
+ effective attribute-set digest,
+ normalized semantic-policy identity)
+```
+
+The effective attribute-set digest is an ordered, profile-qualified projection
+of definition ID/version/type/shape, canonical value digest, and source. It
+must not contain raw attribute or claim values. Runtime trusted input also
+binds source credential/token fingerprint and validity interval. A committed
+definition mutation invalidates by registry identity; an assignment or mapping
+mutation invalidates by control identity and, where known, affected
+definition/subject. A stored/computed digest mismatch is an immediate,
+conservative invalidation signal and never a reason to continue with stale
+authorization state. Cache/event propagation and consumer use of this identity
+remain unqualified, so LIF is not complete.
+
 ## Deliberate exclusions
 
 - **OUT-01:** The access-policy sub-contract has no authored SQL, Liquid, Go
@@ -437,15 +544,16 @@ spec:
 |---|---|---|
 | CHG-01–CHG-04 | Profile-version, historical-policy, and normative-change checks | Pending |
 | STR-01–STR-12 | Generated TypeSpec, JSON Schema, DTO, extracted-YAML, and authoring-registry fixtures | Pending |
-| ATT-01–ATT-12 | Control-plane attribute registry, mutation, disablement, claim-mapping, and trust-boundary tests | Pending |
-| VAL-01–VAL-10 | [`internal/semanticvalue`](../../internal/semanticvalue/value.go), its [unit](../../internal/semanticvalue/value_test.go) and [cross-path](../../internal/semanticvalue/crosspath_test.go) tests, the independent [`profile-v1.json`](../../internal/semanticvalue/testdata/profile-v1.json) fixture, and semantic-filter integration | Implemented |
-| VAL-11 | The shared handwritten canonicalizer and analytics semantic-filter consumer are implemented. Generated canonicalization and the control-plane ingestion, claims, candidate-validation, runtime-evaluation, policy-digest, cache, and audit-projection paths remain unqualified. | Partial |
+| ATT-01–ATT-04, ATT-08, ATT-11–ATT-12 | PostgreSQL registry/control migrations and repositories, typed API envelopes, canonical-value tests, trustedclaims structural tests, and platform-admin route/attenuation tests | Partial: durable definition/assignment/mapping boundaries are implemented; principal-context integration, source adapters, and semantic-consumer admission are not. |
+| ATT-05–ATT-07, ATT-09–ATT-10 | Control snapshot identity and disable/tombstone behavior exist; generation-reference, provider-admission, runtime expiry wiring, dependent-object invalidation, and rollback retention checks remain unqualified | Partial |
+| VAL-01–VAL-10 | [`internal/semanticvalue`](../../internal/semanticvalue/value.go), its [unit](../../internal/semanticvalue/value_test.go) and [cross-path](../../internal/semanticvalue/crosspath_test.go) tests, the independent [`profile-v1.json`](../../internal/semanticvalue/testdata/profile-v1.json) fixture, and semantic-filter integration | Implemented at the shared semantic-value boundary; typed control ingress also consumes it |
+| VAL-11 | The shared `internal/semanticvalue` canonicalizer is used by registry, assignment, mapping, effective-value, and semantic-filter paths. Generated canonicalization plus complete control-plane claim-ingestion, candidate-validation, runtime-evaluation, policy-digest, cache, and audit-projection equivalence remain unqualified. | Partial |
 | GRT-01–GRT-10 | Access-grant compiler and evaluator fixtures | Pending |
 | FLT-01–FLT-10 | Semantic planner, parameterization, cardinality, and fail-closed tests | Pending |
 | PLN-01–PLN-09 | Security-barrier IR validation and join, aggregate, rollup, and rewrite golden plans | Pending |
 | ENF-01–ENF-11 | Catalog, dashboard, Explore, agent, export, API, and embed integration tests | Pending |
 | CMP-01–CMP-06 | Policy-diff, compatibility, security-impact, version, and approval fixtures | Pending |
-| LIF-01–LIF-08 | Cache partitioning, invalidation, planning, and durable-audit tests | Pending |
+| LIF-01–LIF-08 | Registry/control revision+digest identities and transactional control audit are implemented; cache partitioning, immediate event invalidation, semantic planning, generation references, and complete audit projection are not | Partial |
 | OUT-01–OUT-05 | Negative schema, architecture, and documentation checks | Pending |
 
 ## Maintained verification

--- a/api/typespec/access.tsp
+++ b/api/typespec/access.tsp
@@ -1173,6 +1173,8 @@ model SemanticAttributeClaimMappingListResponse {
 model SemanticAttributeImpactPreviewRequest {
   targetKind: SemanticAttributeAssignmentTargetKindValue;
   targetId: string;
+  // An empty values array previews removal of the active assignment. A
+  // non-empty array previews adding or changing the target's assignment.
   values: SemanticAttributeValue[];
 }
 
@@ -1200,36 +1202,80 @@ model SemanticAttributeAssignmentNotFoundFailure {}
 @apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "SEMANTIC_ATTRIBUTE_CLAIM_MAPPING_NOT_FOUND", publicDetail: "Semantic attribute claim mapping was not found." })
 model SemanticAttributeClaimMappingNotFoundFailure {}
 
+// These payloads mirror the repository's durable audit metadata projections.
+// Assignment values and value digests are intentionally absent.
 @apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
 model SemanticAttributeDefinitionAuditPayload {
   @apigen.auditInternal
-  attributeName: string;
-  @apigen.auditPublic
-  lifecycle: string;
+  profile: string;
+  @apigen.auditInternal
+  type: string;
+  @apigen.auditInternal
+  shape: string;
   @apigen.auditInternal
   definitionVersion: int64;
+  @apigen.auditInternal
+  registryRevision: int64;
+  @apigen.auditInternal
+  registryDigest: string;
+  @apigen.auditInternal
+  ownerKind: string;
+  @apigen.auditPii
+  ownerId: string;
+  @apigen.auditPublic
+  lifecycleState: string;
 }
 
 @apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
 model SemanticAttributeAssignmentAuditPayload {
   @apigen.auditInternal
-  attributeName: string;
+  definitionId: string;
   @apigen.auditInternal
-  targetKind: string;
+  definitionName: string;
+  @apigen.auditInternal
+  subjectKind: string;
   @apigen.auditPii
-  targetId: string;
+  subjectId: string;
+  @apigen.auditInternal
+  definitionVersion: int64;
+  @apigen.auditInternal
+  assignmentVersion: int64;
+  @apigen.auditInternal
+  controlRevision: int64;
+  @apigen.auditInternal
+  valueCount: int32;
+  @apigen.auditInternal
+  tombstoned: boolean;
+  @apigen.auditInternal
+  controlDigest: string;
 }
 
 @apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
 model SemanticAttributeClaimMappingAuditPayload {
-  @apigen.auditInternal
-  attributeName: string;
   @apigen.auditPublic
   sourceKind: string;
   @apigen.auditPublic
   provider: string;
+  @apigen.auditInternal
+  issuer: string;
+  @apigen.auditInternal
+  audience: string;
   @apigen.auditPublic
   claim: string;
+  @apigen.auditInternal
+  definitionId: string;
+  @apigen.auditInternal
+  definitionName: string;
+  @apigen.auditInternal
+  definitionVersion: int64;
+  @apigen.auditInternal
+  mappingVersion: int64;
+  @apigen.auditInternal
+  controlRevision: int64;
+  @apigen.auditInternal
+  tombstoned: boolean;
+  @apigen.auditInternal
+  controlDigest: string;
 }
 
 alias ListSemanticAttributeDefinitionsOK = OkJson<SemanticAttributeDefinitionListResponse>;
@@ -1253,7 +1299,10 @@ interface SemanticAttributeDefinitions {
   @post
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.registered" })
+  // The repository's durable audit event is semantic_attribute.register.
+  // Replays use a distinct durable replay action but retain this canonical
+  // operation action in the generated contract.
+  @apigen.command(#{ auditAction: "semantic_attribute.register" })
   @apigen.failsWith(SemanticAttributeInvalidFailure)
   @apigen.failsWith(SemanticAttributeConflictFailure)
   @apigen.auditPayload(SemanticAttributeDefinitionAuditPayload)
@@ -1270,7 +1319,7 @@ interface SemanticAttributeDefinitions {
   @patch
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.metadata_updated" })
+  @apigen.command(#{ auditAction: "semantic_attribute.metadata_update" })
   @apigen.failsWith(SemanticAttributeNotFoundFailure)
   @apigen.failsWith(SemanticAttributeInvalidFailure)
   @apigen.auditPayload(SemanticAttributeDefinitionAuditPayload)
@@ -1280,7 +1329,7 @@ interface SemanticAttributeDefinitions {
   @post
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.disabled" })
+  @apigen.command(#{ auditAction: "semantic_attribute.disable" })
   @apigen.failsWith(SemanticAttributeNotFoundFailure)
   @apigen.auditPayload(SemanticAttributeDefinitionAuditPayload)
   disableSemanticAttribute(@path @apigen.target attribute: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @header("If-Match") ifMatch: string): GetSemanticAttributeDefinitionOK | CommonErrors;
@@ -1289,7 +1338,7 @@ interface SemanticAttributeDefinitions {
   @post
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.restored" })
+  @apigen.command(#{ auditAction: "semantic_attribute.enable" })
   @apigen.failsWith(SemanticAttributeNotFoundFailure)
   @apigen.auditPayload(SemanticAttributeDefinitionAuditPayload)
   restoreSemanticAttribute(@path @apigen.target attribute: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @header("If-Match") ifMatch: string): GetSemanticAttributeDefinitionOK | CommonErrors;
@@ -1309,7 +1358,7 @@ interface PrincipalSemanticAttributeAssignments {
   @put
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.principal_assignment_upserted" })
+  @apigen.command(#{ auditAction: "semantic_attribute.assignment.set" })
   @apigen.failsWith(SemanticAttributeInvalidFailure)
   @apigen.failsWith(SemanticAttributeNotFoundFailure)
   @apigen.auditPayload(SemanticAttributeAssignmentAuditPayload)
@@ -1319,7 +1368,7 @@ interface PrincipalSemanticAttributeAssignments {
   @delete
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.principal_assignment_removed" })
+  @apigen.command(#{ auditAction: "semantic_attribute.assignment.tombstone" })
   @apigen.failsWith(SemanticAttributeAssignmentNotFoundFailure)
   @apigen.auditPayload(SemanticAttributeAssignmentAuditPayload)
   removePrincipalSemanticAttributeAssignment(@path @apigen.target principal: string, @path attribute: string, @header("If-Match") ifMatch: string): EmptyResponse | CommonErrors;
@@ -1339,7 +1388,7 @@ interface GroupSemanticAttributeAssignments {
   @put
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.group_assignment_upserted" })
+  @apigen.command(#{ auditAction: "semantic_attribute.assignment.set" })
   @apigen.failsWith(SemanticAttributeInvalidFailure)
   @apigen.failsWith(SemanticAttributeNotFoundFailure)
   @apigen.auditPayload(SemanticAttributeAssignmentAuditPayload)
@@ -1349,7 +1398,7 @@ interface GroupSemanticAttributeAssignments {
   @delete
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.group_assignment_removed" })
+  @apigen.command(#{ auditAction: "semantic_attribute.assignment.tombstone" })
   @apigen.failsWith(SemanticAttributeAssignmentNotFoundFailure)
   @apigen.auditPayload(SemanticAttributeAssignmentAuditPayload)
   removeGroupSemanticAttributeAssignment(@path @apigen.target group: string, @path attribute: string, @header("If-Match") ifMatch: string): EmptyResponse | CommonErrors;
@@ -1368,7 +1417,7 @@ interface SemanticAttributeClaimMappings {
   @post
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.claim_mapping_upserted" })
+  @apigen.command(#{ auditAction: "semantic_attribute.claim_mapping.set" })
   @apigen.failsWith(SemanticAttributeInvalidFailure)
   @apigen.failsWith(SemanticAttributeNotFoundFailure)
   @apigen.auditPayload(SemanticAttributeClaimMappingAuditPayload)
@@ -1378,7 +1427,7 @@ interface SemanticAttributeClaimMappings {
   @delete
   @apigen.authz(#{ mode: "authenticated" })
   @extension("x-leapview-object-scope", "platform")
-  @apigen.command(#{ auditAction: "semantic_attribute.claim_mapping_removed" })
+  @apigen.command(#{ auditAction: "semantic_attribute.claim_mapping.tombstone" })
   @apigen.failsWith(SemanticAttributeClaimMappingNotFoundFailure)
   @apigen.auditPayload(SemanticAttributeClaimMappingAuditPayload)
   removeSemanticAttributeClaimMapping(@path @apigen.target attribute: string, @path mapping: string, @header("If-Match") ifMatch: string): EmptyResponse | CommonErrors;

--- a/api/typespec/access.tsp
+++ b/api/typespec/access.tsp
@@ -1035,3 +1035,362 @@ interface DataPolicies {
 @apigen.authz(#{ mode: "authenticated" })
 @apigen.query
 op checkAuthorizationBatch(@path project: ResourceId, @body body: AuthorizationBatchCheckRequest): OkJson<AuthorizationBatchCheckResponse> | CommonErrors;
+
+// Semantic attributes are a platform-owned control-plane resource. The
+// request models intentionally use a closed scalar union: callers cannot
+// smuggle arbitrary JSON objects, maps, or nested lists into an assignment.
+enum SemanticAttributeValueType {
+  stringValue: "String";
+  booleanValue: "Boolean";
+  integerValue: "Integer";
+  decimalValue: "Decimal";
+  dateValue: "Date";
+  timestampValue: "Timestamp";
+}
+
+enum SemanticAttributeShapeValue {
+  scalarShape: "scalar";
+  listShape: "list";
+}
+
+enum SemanticAttributeOwnerKindValue {
+  instanceOwner: "instance";
+  principalOwner: "principal";
+  groupOwner: "group";
+}
+
+enum SemanticAttributeAssignmentTargetKindValue {
+  principalTarget: "principal";
+  groupTarget: "group";
+}
+
+enum SemanticAttributeClaimSourceKindValue {
+  saml;
+  oidc;
+  embed;
+  serviceToken: "service_token";
+}
+
+model SemanticAttributeValue {
+  type: SemanticAttributeValueType;
+  stringValue?: string;
+  booleanValue?: boolean;
+  // Integers and decimals remain strings on the wire to preserve precision.
+  integerValue?: string;
+  decimalValue?: string;
+  dateValue?: string;
+  timestampValue?: string;
+}
+
+model SemanticAttributeMetadataRequest {
+  ownerKind: SemanticAttributeOwnerKindValue;
+  ownerId?: string;
+  displayName: string;
+  description: string;
+  documentationUrl?: string;
+}
+
+model SemanticAttributeDefinitionResponse {
+  id: string;
+  name: string;
+  type: SemanticAttributeValueType;
+  shape: SemanticAttributeShapeValue;
+  profile: string;
+  definitionVersion: int64;
+  ownerKind: SemanticAttributeOwnerKindValue;
+  ownerId?: string;
+  displayName: string;
+  description: string;
+  documentationUrl?: string;
+  lifecycleState: string;
+  createdAt: utcDateTime;
+  updatedAt: utcDateTime;
+  disabledAt?: utcDateTime;
+}
+
+model SemanticAttributeDefinitionListResponse {
+  items: SemanticAttributeDefinitionResponse[];
+  page: PageInfo;
+}
+
+model SemanticAttributeRegisterRequest {
+  name: string;
+  type: SemanticAttributeValueType;
+  shape: SemanticAttributeShapeValue;
+  metadata: SemanticAttributeMetadataRequest;
+}
+
+model SemanticAttributeAssignmentRequest {
+  values: SemanticAttributeValue[];
+}
+
+model SemanticAttributeAssignmentResponse {
+  id: string;
+  attributeName: string;
+  targetKind: SemanticAttributeAssignmentTargetKindValue;
+  targetId: string;
+  values: SemanticAttributeValue[];
+  assignmentVersion: int64;
+  lifecycleState: string;
+  removedAt?: utcDateTime;
+  createdAt: utcDateTime;
+  updatedAt: utcDateTime;
+}
+
+model SemanticAttributeAssignmentListResponse {
+  items: SemanticAttributeAssignmentResponse[];
+  page: PageInfo;
+}
+
+model SemanticAttributeClaimMappingRequest {
+  sourceKind: SemanticAttributeClaimSourceKindValue;
+  provider: string;
+  issuer: string;
+  audience: string;
+  claim: string;
+}
+
+model SemanticAttributeClaimMappingResponse {
+  id: string;
+  attributeName: string;
+  sourceKind: SemanticAttributeClaimSourceKindValue;
+  provider: string;
+  issuer: string;
+  audience: string;
+  claim: string;
+  mappingVersion: int64;
+  lifecycleState: string;
+  removedAt?: utcDateTime;
+  createdAt: utcDateTime;
+  updatedAt: utcDateTime;
+}
+
+model SemanticAttributeClaimMappingListResponse {
+  items: SemanticAttributeClaimMappingResponse[];
+  page: PageInfo;
+}
+
+model SemanticAttributeImpactPreviewRequest {
+  targetKind: SemanticAttributeAssignmentTargetKindValue;
+  targetId: string;
+  values: SemanticAttributeValue[];
+}
+
+model SemanticAttributeImpactPreviewResponse {
+  attributeName: string;
+  targetKind: SemanticAttributeAssignmentTargetKindValue;
+  targetId: string;
+  affectedPrincipalCount: int32;
+  affectedGroupCount: int32;
+  warnings: string[];
+}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "SEMANTIC_ATTRIBUTE_NOT_FOUND", publicDetail: "Semantic attribute was not found." })
+model SemanticAttributeNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "invalid", statusCode: 400, code: "SEMANTIC_ATTRIBUTE_INVALID", publicDetail: "Semantic attribute request is invalid." })
+model SemanticAttributeInvalidFailure {}
+
+@apigen.failureDefinition(#{ kind: "conflict", statusCode: 409, code: "SEMANTIC_ATTRIBUTE_CONFLICT", publicDetail: "Semantic attribute conflicts with current state." })
+model SemanticAttributeConflictFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "SEMANTIC_ATTRIBUTE_ASSIGNMENT_NOT_FOUND", publicDetail: "Semantic attribute assignment was not found." })
+model SemanticAttributeAssignmentNotFoundFailure {}
+
+@apigen.failureDefinition(#{ kind: "not_found", statusCode: 404, code: "SEMANTIC_ATTRIBUTE_CLAIM_MAPPING_NOT_FOUND", publicDetail: "Semantic attribute claim mapping was not found." })
+model SemanticAttributeClaimMappingNotFoundFailure {}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model SemanticAttributeDefinitionAuditPayload {
+  @apigen.auditInternal
+  attributeName: string;
+  @apigen.auditPublic
+  lifecycle: string;
+  @apigen.auditInternal
+  definitionVersion: int64;
+}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model SemanticAttributeAssignmentAuditPayload {
+  @apigen.auditInternal
+  attributeName: string;
+  @apigen.auditInternal
+  targetKind: string;
+  @apigen.auditPii
+  targetId: string;
+}
+
+@apigen.auditSchema(#{ schemaVersion: 1, retention: "security" })
+model SemanticAttributeClaimMappingAuditPayload {
+  @apigen.auditInternal
+  attributeName: string;
+  @apigen.auditPublic
+  sourceKind: string;
+  @apigen.auditPublic
+  provider: string;
+  @apigen.auditPublic
+  claim: string;
+}
+
+alias ListSemanticAttributeDefinitionsOK = OkJson<SemanticAttributeDefinitionListResponse>;
+alias RegisterSemanticAttributeCreated = CreatedJson<SemanticAttributeDefinitionResponse>;
+alias GetSemanticAttributeDefinitionOK = OkJson<SemanticAttributeDefinitionResponse>;
+alias UpdateSemanticAttributeMetadataOK = OkJson<SemanticAttributeDefinitionResponse>;
+alias SemanticAttributeAssignmentOK = OkJson<SemanticAttributeAssignmentResponse>;
+alias SemanticAttributeClaimMappingOK = OkJson<SemanticAttributeClaimMappingResponse>;
+alias SemanticAttributeImpactPreviewOK = OkJson<SemanticAttributeImpactPreviewResponse>;
+
+@tag("Access")
+@summary("List semantic attribute definitions")
+@route("/semantic-attributes")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
+interface SemanticAttributeDefinitions {
+  @get
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  listSemanticAttributeDefinitions(@query q?: string, @query ownerKind?: SemanticAttributeOwnerKindValue, @query limit?: ListLimit, @query pageToken?: PageToken): ListSemanticAttributeDefinitionsOK | CommonErrors;
+
+  @post
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.registered" })
+  @apigen.failsWith(SemanticAttributeInvalidFailure)
+  @apigen.failsWith(SemanticAttributeConflictFailure)
+  @apigen.auditPayload(SemanticAttributeDefinitionAuditPayload)
+  registerSemanticAttribute(@header("Idempotency-Key") idempotencyKey: IdempotencyKey, @body body: SemanticAttributeRegisterRequest): RegisterSemanticAttributeCreated | CommonErrors;
+
+  @route("/{attribute}")
+  @get
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.failsWith(SemanticAttributeNotFoundFailure)
+  getSemanticAttributeDefinition(@path attribute: string): GetSemanticAttributeDefinitionOK | CommonErrors;
+
+  @route("/{attribute}")
+  @patch
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.metadata_updated" })
+  @apigen.failsWith(SemanticAttributeNotFoundFailure)
+  @apigen.failsWith(SemanticAttributeInvalidFailure)
+  @apigen.auditPayload(SemanticAttributeDefinitionAuditPayload)
+  updateSemanticAttributeMetadata(@path attribute: string, @header("If-Match") ifMatch: string, @body body: SemanticAttributeMetadataRequest): UpdateSemanticAttributeMetadataOK | CommonErrors;
+
+  @route("/{attribute}/disable")
+  @post
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.disabled" })
+  @apigen.failsWith(SemanticAttributeNotFoundFailure)
+  @apigen.auditPayload(SemanticAttributeDefinitionAuditPayload)
+  disableSemanticAttribute(@path @apigen.target attribute: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @header("If-Match") ifMatch: string): GetSemanticAttributeDefinitionOK | CommonErrors;
+
+  @route("/{attribute}/restore")
+  @post
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.restored" })
+  @apigen.failsWith(SemanticAttributeNotFoundFailure)
+  @apigen.auditPayload(SemanticAttributeDefinitionAuditPayload)
+  restoreSemanticAttribute(@path @apigen.target attribute: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @header("If-Match") ifMatch: string): GetSemanticAttributeDefinitionOK | CommonErrors;
+}
+
+@tag("Access")
+@summary("List and mutate principal semantic attribute assignments")
+@route("/principals/{principal}/semantic-attributes")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
+interface PrincipalSemanticAttributeAssignments {
+  @get
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  listPrincipalSemanticAttributeAssignments(@path principal: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticAttributeAssignmentListResponse> | CommonErrors;
+
+  @route("/{attribute}")
+  @put
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.principal_assignment_upserted" })
+  @apigen.failsWith(SemanticAttributeInvalidFailure)
+  @apigen.failsWith(SemanticAttributeNotFoundFailure)
+  @apigen.auditPayload(SemanticAttributeAssignmentAuditPayload)
+  upsertPrincipalSemanticAttributeAssignment(@path @apigen.target principal: string, @path attribute: string, @header("If-Match") ifMatch: string, @body body: SemanticAttributeAssignmentRequest): SemanticAttributeAssignmentOK | CommonErrors;
+
+  @route("/{attribute}")
+  @delete
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.principal_assignment_removed" })
+  @apigen.failsWith(SemanticAttributeAssignmentNotFoundFailure)
+  @apigen.auditPayload(SemanticAttributeAssignmentAuditPayload)
+  removePrincipalSemanticAttributeAssignment(@path @apigen.target principal: string, @path attribute: string, @header("If-Match") ifMatch: string): EmptyResponse | CommonErrors;
+}
+
+@tag("Access")
+@summary("List and mutate group semantic attribute assignments")
+@route("/groups/{group}/semantic-attributes")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
+interface GroupSemanticAttributeAssignments {
+  @get
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  listGroupSemanticAttributeAssignments(@path group: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticAttributeAssignmentListResponse> | CommonErrors;
+
+  @route("/{attribute}")
+  @put
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.group_assignment_upserted" })
+  @apigen.failsWith(SemanticAttributeInvalidFailure)
+  @apigen.failsWith(SemanticAttributeNotFoundFailure)
+  @apigen.auditPayload(SemanticAttributeAssignmentAuditPayload)
+  upsertGroupSemanticAttributeAssignment(@path @apigen.target group: string, @path attribute: string, @header("If-Match") ifMatch: string, @body body: SemanticAttributeAssignmentRequest): SemanticAttributeAssignmentOK | CommonErrors;
+
+  @route("/{attribute}")
+  @delete
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.group_assignment_removed" })
+  @apigen.failsWith(SemanticAttributeAssignmentNotFoundFailure)
+  @apigen.auditPayload(SemanticAttributeAssignmentAuditPayload)
+  removeGroupSemanticAttributeAssignment(@path @apigen.target group: string, @path attribute: string, @header("If-Match") ifMatch: string): EmptyResponse | CommonErrors;
+}
+
+@tag("Access")
+@summary("List and mutate trusted semantic attribute claim mappings")
+@route("/semantic-attributes/{attribute}/claim-mappings")
+@apigen.commandDefaults(#{ guarantee: "transactional" })
+interface SemanticAttributeClaimMappings {
+  @get
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  listSemanticAttributeClaimMappings(@path attribute: string, @query limit?: ListLimit, @query pageToken?: PageToken): OkJson<SemanticAttributeClaimMappingListResponse> | CommonErrors;
+
+  @post
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.claim_mapping_upserted" })
+  @apigen.failsWith(SemanticAttributeInvalidFailure)
+  @apigen.failsWith(SemanticAttributeNotFoundFailure)
+  @apigen.auditPayload(SemanticAttributeClaimMappingAuditPayload)
+  upsertSemanticAttributeClaimMapping(@path @apigen.target attribute: string, @header("Idempotency-Key") idempotencyKey: IdempotencyKey, @header("If-Match") ifMatch: string, @body body: SemanticAttributeClaimMappingRequest): SemanticAttributeClaimMappingOK | CommonErrors;
+
+  @route("/{mapping}")
+  @delete
+  @apigen.authz(#{ mode: "authenticated" })
+  @extension("x-leapview-object-scope", "platform")
+  @apigen.command(#{ auditAction: "semantic_attribute.claim_mapping_removed" })
+  @apigen.failsWith(SemanticAttributeClaimMappingNotFoundFailure)
+  @apigen.auditPayload(SemanticAttributeClaimMappingAuditPayload)
+  removeSemanticAttributeClaimMapping(@path @apigen.target attribute: string, @path mapping: string, @header("If-Match") ifMatch: string): EmptyResponse | CommonErrors;
+}
+
+@tag("Access")
+@summary("Preview semantic attribute assignment impact")
+@route("/semantic-attributes/{attribute}/impact-preview")
+@post
+@apigen.query
+@apigen.authz(#{ mode: "authenticated" })
+@extension("x-leapview-object-scope", "platform")
+  @apigen.failsWith(SemanticAttributeInvalidFailure)
+  @apigen.failsWith(SemanticAttributeNotFoundFailure)
+op previewSemanticAttributeImpact(@path @apigen.target attribute: string, @body body: SemanticAttributeImpactPreviewRequest): SemanticAttributeImpactPreviewOK | CommonErrors;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -10592,18 +10592,32 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
+              - name: assignmentVersion
                 sensitivity: internal
-              - name: targetId
+              - name: controlDigest
+                sensitivity: internal
+              - name: controlRevision
+                sensitivity: internal
+              - name: definitionId
+                sensitivity: internal
+              - name: definitionName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: subjectId
                 sensitivity: pii
-              - name: targetKind
+              - name: subjectKind
+                sensitivity: internal
+              - name: tombstoned
+                sensitivity: internal
+              - name: valueCount
                 sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeAssignmentAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.group_assignment_removed
+          success_action: semantic_attribute.assignment.tombstone
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -10920,18 +10934,32 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
+              - name: assignmentVersion
                 sensitivity: internal
-              - name: targetId
+              - name: controlDigest
+                sensitivity: internal
+              - name: controlRevision
+                sensitivity: internal
+              - name: definitionId
+                sensitivity: internal
+              - name: definitionName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: subjectId
                 sensitivity: pii
-              - name: targetKind
+              - name: subjectKind
+                sensitivity: internal
+              - name: tombstoned
+                sensitivity: internal
+              - name: valueCount
                 sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeAssignmentAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.group_assignment_upserted
+          success_action: semantic_attribute.assignment.set
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -20970,18 +20998,32 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
+              - name: assignmentVersion
                 sensitivity: internal
-              - name: targetId
+              - name: controlDigest
+                sensitivity: internal
+              - name: controlRevision
+                sensitivity: internal
+              - name: definitionId
+                sensitivity: internal
+              - name: definitionName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: subjectId
                 sensitivity: pii
-              - name: targetKind
+              - name: subjectKind
+                sensitivity: internal
+              - name: tombstoned
+                sensitivity: internal
+              - name: valueCount
                 sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeAssignmentAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.principal_assignment_removed
+          success_action: semantic_attribute.assignment.tombstone
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -21298,18 +21340,32 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
+              - name: assignmentVersion
                 sensitivity: internal
-              - name: targetId
+              - name: controlDigest
+                sensitivity: internal
+              - name: controlRevision
+                sensitivity: internal
+              - name: definitionId
+                sensitivity: internal
+              - name: definitionName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: subjectId
                 sensitivity: pii
-              - name: targetKind
+              - name: subjectKind
+                sensitivity: internal
+              - name: tombstoned
+                sensitivity: internal
+              - name: valueCount
                 sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeAssignmentAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.principal_assignment_upserted
+          success_action: semantic_attribute.assignment.set
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -59585,18 +59641,30 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
-                sensitivity: internal
               - name: definitionVersion
                 sensitivity: internal
-              - name: lifecycle
+              - name: lifecycleState
                 sensitivity: public
+              - name: ownerId
+                sensitivity: pii
+              - name: ownerKind
+                sensitivity: internal
+              - name: profile
+                sensitivity: internal
+              - name: registryDigest
+                sensitivity: internal
+              - name: registryRevision
+                sensitivity: internal
+              - name: shape
+                sensitivity: internal
+              - name: type
+                sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeDefinitionAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.registered
+          success_action: semantic_attribute.register
         authz_mode: authenticated
         failures:
           - code: SEMANTIC_ATTRIBUTE_CONFLICT
@@ -60175,18 +60243,30 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
-                sensitivity: internal
               - name: definitionVersion
                 sensitivity: internal
-              - name: lifecycle
+              - name: lifecycleState
                 sensitivity: public
+              - name: ownerId
+                sensitivity: pii
+              - name: ownerKind
+                sensitivity: internal
+              - name: profile
+                sensitivity: internal
+              - name: registryDigest
+                sensitivity: internal
+              - name: registryRevision
+                sensitivity: internal
+              - name: shape
+                sensitivity: internal
+              - name: type
+                sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeDefinitionAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.metadata_updated
+          success_action: semantic_attribute.metadata_update
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -60792,20 +60872,36 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
+              - name: audience
                 sensitivity: internal
               - name: claim
                 sensitivity: public
+              - name: controlDigest
+                sensitivity: internal
+              - name: controlRevision
+                sensitivity: internal
+              - name: definitionId
+                sensitivity: internal
+              - name: definitionName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: issuer
+                sensitivity: internal
+              - name: mappingVersion
+                sensitivity: internal
               - name: provider
                 sensitivity: public
               - name: sourceKind
                 sensitivity: public
+              - name: tombstoned
+                sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeClaimMappingAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.claim_mapping_upserted
+          success_action: semantic_attribute.claim_mapping.set
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -61092,20 +61188,36 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
+              - name: audience
                 sensitivity: internal
               - name: claim
                 sensitivity: public
+              - name: controlDigest
+                sensitivity: internal
+              - name: controlRevision
+                sensitivity: internal
+              - name: definitionId
+                sensitivity: internal
+              - name: definitionName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: issuer
+                sensitivity: internal
+              - name: mappingVersion
+                sensitivity: internal
               - name: provider
                 sensitivity: public
               - name: sourceKind
                 sensitivity: public
+              - name: tombstoned
+                sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeClaimMappingAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.claim_mapping_removed
+          success_action: semantic_attribute.claim_mapping.tombstone
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -61408,18 +61520,30 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
-                sensitivity: internal
               - name: definitionVersion
                 sensitivity: internal
-              - name: lifecycle
+              - name: lifecycleState
                 sensitivity: public
+              - name: ownerId
+                sensitivity: pii
+              - name: ownerKind
+                sensitivity: internal
+              - name: profile
+                sensitivity: internal
+              - name: registryDigest
+                sensitivity: internal
+              - name: registryRevision
+                sensitivity: internal
+              - name: shape
+                sensitivity: internal
+              - name: type
+                sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeDefinitionAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.disabled
+          success_action: semantic_attribute.disable
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -62005,18 +62129,30 @@ paths:
           guarantee: transactional
           payload:
             fields:
-              - name: attributeName
-                sensitivity: internal
               - name: definitionVersion
                 sensitivity: internal
-              - name: lifecycle
+              - name: lifecycleState
                 sensitivity: public
+              - name: ownerId
+                sensitivity: pii
+              - name: ownerKind
+                sensitivity: internal
+              - name: profile
+                sensitivity: internal
+              - name: registryDigest
+                sensitivity: internal
+              - name: registryRevision
+                sensitivity: internal
+              - name: shape
+                sensitivity: internal
+              - name: type
+                sensitivity: internal
             retention: security
             schema:
               ref: SemanticAttributeDefinitionAuditPayload
             schema_version: 1
           required: true
-          success_action: semantic_attribute.restored
+          success_action: semantic_attribute.enable
         authz_mode: authenticated
         concurrency: if-match
         failures:
@@ -87122,23 +87258,62 @@ components:
     SemanticAttributeAssignmentAuditPayload:
       type: object
       required:
-        - attributeName
-        - targetKind
-        - targetId
+        - definitionId
+        - definitionName
+        - subjectKind
+        - subjectId
+        - definitionVersion
+        - assignmentVersion
+        - controlRevision
+        - valueCount
+        - tombstoned
+        - controlDigest
       properties:
-        attributeName:
+        definitionId:
           type: string
           example: example
-        targetKind:
+        definitionName:
           type: string
           example: example
-        targetId:
+        subjectKind:
+          type: string
+          example: example
+        subjectId:
+          type: string
+          example: example
+        definitionVersion:
+          type: integer
+          format: int64
+          example: 1
+        assignmentVersion:
+          type: integer
+          format: int64
+          example: 1
+        controlRevision:
+          type: integer
+          format: int64
+          example: 1
+        valueCount:
+          type: integer
+          format: int32
+          example: 1
+        tombstoned:
+          type: boolean
+          example: true
+        controlDigest:
           type: string
           example: example
       example:
-        attributeName: example
-        targetId: example
-        targetKind: example
+        assignmentVersion: 1
+        controlDigest: example
+        controlRevision: 1
+        definitionId: example
+        definitionName: example
+        definitionVersion: 1
+        subjectId: example
+        subjectKind: example
+        tombstoned: true
+        valueCount: 1
     SemanticAttributeAssignmentListResponse:
       type: object
       required:
@@ -87298,28 +87473,71 @@ components:
     SemanticAttributeClaimMappingAuditPayload:
       type: object
       required:
-        - attributeName
         - sourceKind
         - provider
+        - issuer
+        - audience
         - claim
+        - definitionId
+        - definitionName
+        - definitionVersion
+        - mappingVersion
+        - controlRevision
+        - tombstoned
+        - controlDigest
       properties:
-        attributeName:
-          type: string
-          example: example
         sourceKind:
           type: string
           example: example
         provider:
           type: string
           example: example
+        issuer:
+          type: string
+          example: example
+        audience:
+          type: string
+          example: example
         claim:
           type: string
           example: example
+        definitionId:
+          type: string
+          example: example
+        definitionName:
+          type: string
+          example: example
+        definitionVersion:
+          type: integer
+          format: int64
+          example: 1
+        mappingVersion:
+          type: integer
+          format: int64
+          example: 1
+        controlRevision:
+          type: integer
+          format: int64
+          example: 1
+        tombstoned:
+          type: boolean
+          example: true
+        controlDigest:
+          type: string
+          example: example
       example:
-        attributeName: example
+        audience: example
         claim: example
+        controlDigest: example
+        controlRevision: 1
+        definitionId: example
+        definitionName: example
+        definitionVersion: 1
+        issuer: example
+        mappingVersion: 1
         provider: example
         sourceKind: example
+        tombstoned: true
     SemanticAttributeClaimMappingListResponse:
       type: object
       required:
@@ -87468,24 +87686,55 @@ components:
     SemanticAttributeDefinitionAuditPayload:
       type: object
       required:
-        - attributeName
-        - lifecycle
+        - profile
+        - type
+        - shape
         - definitionVersion
+        - registryRevision
+        - registryDigest
+        - ownerKind
+        - ownerId
+        - lifecycleState
       properties:
-        attributeName:
+        profile:
           type: string
           example: example
-        lifecycle:
+        type:
+          type: string
+          example: example
+        shape:
           type: string
           example: example
         definitionVersion:
           type: integer
           format: int64
           example: 1
+        registryRevision:
+          type: integer
+          format: int64
+          example: 1
+        registryDigest:
+          type: string
+          example: example
+        ownerKind:
+          type: string
+          example: example
+        ownerId:
+          type: string
+          example: example
+        lifecycleState:
+          type: string
+          example: example
       example:
-        attributeName: example
         definitionVersion: 1
-        lifecycle: example
+        lifecycleState: example
+        ownerId: example
+        ownerKind: example
+        profile: example
+        registryDigest: example
+        registryRevision: 1
+        shape: example
+        type: example
     SemanticAttributeDefinitionListResponse:
       type: object
       required:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -10027,6 +10027,927 @@ paths:
         ui:
           action_id: group.member.add
       x-leapview-object-scope: platform
+  /api/v1/groups/{group}/semantic-attributes:
+    get:
+      operationId: listGroupSemanticAttributeAssignments
+      parameters:
+        - name: group
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 200
+          example: 1
+          explode: false
+        - name: pageToken
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 2048
+          example: example
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeAssignmentListResponse'
+              example:
+                items:
+                  - assignmentVersion: 1
+                    attributeName: example
+                    createdAt: "2026-01-02T15:04:05Z"
+                    id: example
+                    lifecycleState: example
+                    removedAt: "2026-01-02T15:04:05Z"
+                    targetId: example
+                    targetKind: principal
+                    updatedAt: "2026-01-02T15:04:05Z"
+                    values:
+                      - booleanValue: true
+                        dateValue: example
+                        decimalValue: example
+                        integerValue: example
+                        stringValue: example
+                        timestampValue: example
+                        type: String
+                page:
+                  nextCursor: example
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: query
+      x-leapview-object-scope: platform
+  /api/v1/groups/{group}/semantic-attributes/{attribute}:
+    delete:
+      operationId: removeGroupSemanticAttributeAssignment
+      parameters:
+        - name: group
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: targetId
+                sensitivity: pii
+              - name: targetKind
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: SemanticAttributeAssignmentAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.group_assignment_removed
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_ASSIGNMENT_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute assignment was not found.
+            status_code: 404
+        owner: LeapViewAPI.Access
+        target:
+          parameter: group
+          type: group
+      x-leapview-object-scope: platform
+    put:
+      operationId: upsertGroupSemanticAttributeAssignment
+      parameters:
+        - name: group
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeAssignmentResponse'
+              example:
+                assignmentVersion: 1
+                attributeName: example
+                createdAt: "2026-01-02T15:04:05Z"
+                id: example
+                lifecycleState: example
+                removedAt: "2026-01-02T15:04:05Z"
+                targetId: example
+                targetKind: principal
+                updatedAt: "2026-01-02T15:04:05Z"
+                values:
+                  - booleanValue: true
+                    dateValue: example
+                    decimalValue: example
+                    integerValue: example
+                    stringValue: example
+                    timestampValue: example
+                    type: String
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticAttributeAssignmentRequest'
+            example:
+              values:
+                - booleanValue: true
+                  dateValue: example
+                  decimalValue: example
+                  integerValue: example
+                  stringValue: example
+                  timestampValue: example
+                  type: String
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: targetId
+                sensitivity: pii
+              - name: targetKind
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: SemanticAttributeAssignmentAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.group_assignment_upserted
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_INVALID
+            kind: invalid
+            public_detail: Semantic attribute request is invalid.
+            status_code: 400
+          - code: SEMANTIC_ATTRIBUTE_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute was not found.
+            status_code: 404
+        owner: LeapViewAPI.Access
+        target:
+          parameter: group
+          type: group
+      x-leapview-object-scope: platform
   /api/v1/instance:
     get:
       operationId: getInstance
@@ -19483,6 +20404,927 @@ paths:
           type: principal
         ui:
           action_id: principal.password.reset
+      x-leapview-object-scope: platform
+  /api/v1/principals/{principal}/semantic-attributes:
+    get:
+      operationId: listPrincipalSemanticAttributeAssignments
+      parameters:
+        - name: principal
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 200
+          example: 1
+          explode: false
+        - name: pageToken
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 2048
+          example: example
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeAssignmentListResponse'
+              example:
+                items:
+                  - assignmentVersion: 1
+                    attributeName: example
+                    createdAt: "2026-01-02T15:04:05Z"
+                    id: example
+                    lifecycleState: example
+                    removedAt: "2026-01-02T15:04:05Z"
+                    targetId: example
+                    targetKind: principal
+                    updatedAt: "2026-01-02T15:04:05Z"
+                    values:
+                      - booleanValue: true
+                        dateValue: example
+                        decimalValue: example
+                        integerValue: example
+                        stringValue: example
+                        timestampValue: example
+                        type: String
+                page:
+                  nextCursor: example
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: query
+      x-leapview-object-scope: platform
+  /api/v1/principals/{principal}/semantic-attributes/{attribute}:
+    delete:
+      operationId: removePrincipalSemanticAttributeAssignment
+      parameters:
+        - name: principal
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: targetId
+                sensitivity: pii
+              - name: targetKind
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: SemanticAttributeAssignmentAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.principal_assignment_removed
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_ASSIGNMENT_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute assignment was not found.
+            status_code: 404
+        owner: LeapViewAPI.Access
+        target:
+          parameter: principal
+          type: principal
+      x-leapview-object-scope: platform
+    put:
+      operationId: upsertPrincipalSemanticAttributeAssignment
+      parameters:
+        - name: principal
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeAssignmentResponse'
+              example:
+                assignmentVersion: 1
+                attributeName: example
+                createdAt: "2026-01-02T15:04:05Z"
+                id: example
+                lifecycleState: example
+                removedAt: "2026-01-02T15:04:05Z"
+                targetId: example
+                targetKind: principal
+                updatedAt: "2026-01-02T15:04:05Z"
+                values:
+                  - booleanValue: true
+                    dateValue: example
+                    decimalValue: example
+                    integerValue: example
+                    stringValue: example
+                    timestampValue: example
+                    type: String
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticAttributeAssignmentRequest'
+            example:
+              values:
+                - booleanValue: true
+                  dateValue: example
+                  decimalValue: example
+                  integerValue: example
+                  stringValue: example
+                  timestampValue: example
+                  type: String
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: targetId
+                sensitivity: pii
+              - name: targetKind
+                sensitivity: internal
+            retention: security
+            schema:
+              ref: SemanticAttributeAssignmentAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.principal_assignment_upserted
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_INVALID
+            kind: invalid
+            public_detail: Semantic attribute request is invalid.
+            status_code: 400
+          - code: SEMANTIC_ATTRIBUTE_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute was not found.
+            status_code: 404
+        owner: LeapViewAPI.Access
+        target:
+          parameter: principal
+          type: principal
       x-leapview-object-scope: platform
   /api/v1/principals/{principal}/sessions:
     get:
@@ -57142,6 +58984,3052 @@ paths:
       tags:
         - Search
       x-apigen-operation-kind: query
+  /api/v1/semantic-attributes:
+    get:
+      operationId: listSemanticAttributeDefinitions
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          example: example
+          explode: false
+        - name: ownerKind
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/SemanticAttributeOwnerKindValue'
+          example: instance
+          explode: false
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 200
+          example: 1
+          explode: false
+        - name: pageToken
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 2048
+          example: example
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeDefinitionListResponse'
+              example:
+                items:
+                  - createdAt: "2026-01-02T15:04:05Z"
+                    definitionVersion: 1
+                    description: example
+                    disabledAt: "2026-01-02T15:04:05Z"
+                    displayName: example
+                    documentationUrl: example
+                    id: example
+                    lifecycleState: example
+                    name: example
+                    ownerId: example
+                    ownerKind: instance
+                    profile: example
+                    shape: scalar
+                    type: String
+                    updatedAt: "2026-01-02T15:04:05Z"
+                page:
+                  nextCursor: example
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: query
+      x-leapview-object-scope: platform
+    post:
+      operationId: registerSemanticAttribute
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+          example: example
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created
+            as a result.
+          headers:
+            location:
+              required: true
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeDefinitionResponse'
+              example:
+                createdAt: "2026-01-02T15:04:05Z"
+                definitionVersion: 1
+                description: example
+                disabledAt: "2026-01-02T15:04:05Z"
+                displayName: example
+                documentationUrl: example
+                id: example
+                lifecycleState: example
+                name: example
+                ownerId: example
+                ownerKind: instance
+                profile: example
+                shape: scalar
+                type: String
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticAttributeRegisterRequest'
+            example:
+              metadata:
+                description: example
+                displayName: example
+                documentationUrl: example
+                ownerId: example
+                ownerKind: instance
+              name: example
+              shape: scalar
+              type: String
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: lifecycle
+                sensitivity: public
+            retention: security
+            schema:
+              ref: SemanticAttributeDefinitionAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.registered
+        authz_mode: authenticated
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_CONFLICT
+            kind: conflict
+            public_detail: Semantic attribute conflicts with current state.
+            status_code: 409
+          - code: SEMANTIC_ATTRIBUTE_INVALID
+            kind: invalid
+            public_detail: Semantic attribute request is invalid.
+            status_code: 400
+        idempotency: required
+        owner: LeapViewAPI.Access
+      x-leapview-object-scope: platform
+  /api/v1/semantic-attributes/{attribute}:
+    get:
+      operationId: getSemanticAttributeDefinition
+      parameters:
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeDefinitionResponse'
+              example:
+                createdAt: "2026-01-02T15:04:05Z"
+                definitionVersion: 1
+                description: example
+                disabledAt: "2026-01-02T15:04:05Z"
+                displayName: example
+                documentationUrl: example
+                id: example
+                lifecycleState: example
+                name: example
+                ownerId: example
+                ownerKind: instance
+                profile: example
+                shape: scalar
+                type: String
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: query
+      x-leapview-object-scope: platform
+    patch:
+      operationId: updateSemanticAttributeMetadata
+      parameters:
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeDefinitionResponse'
+              example:
+                createdAt: "2026-01-02T15:04:05Z"
+                definitionVersion: 1
+                description: example
+                disabledAt: "2026-01-02T15:04:05Z"
+                displayName: example
+                documentationUrl: example
+                id: example
+                lifecycleState: example
+                name: example
+                ownerId: example
+                ownerKind: instance
+                profile: example
+                shape: scalar
+                type: String
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticAttributeMetadataRequest'
+            example:
+              description: example
+              displayName: example
+              documentationUrl: example
+              ownerId: example
+              ownerKind: instance
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: lifecycle
+                sensitivity: public
+            retention: security
+            schema:
+              ref: SemanticAttributeDefinitionAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.metadata_updated
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_INVALID
+            kind: invalid
+            public_detail: Semantic attribute request is invalid.
+            status_code: 400
+          - code: SEMANTIC_ATTRIBUTE_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute was not found.
+            status_code: 404
+        owner: LeapViewAPI.Access
+        target:
+          parameter: attribute
+          type: attribute
+      x-leapview-object-scope: platform
+  /api/v1/semantic-attributes/{attribute}/claim-mappings:
+    get:
+      operationId: listSemanticAttributeClaimMappings
+      parameters:
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 200
+          example: 1
+          explode: false
+        - name: pageToken
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 2048
+          example: example
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeClaimMappingListResponse'
+              example:
+                items:
+                  - attributeName: example
+                    audience: example
+                    claim: example
+                    createdAt: "2026-01-02T15:04:05Z"
+                    id: example
+                    issuer: example
+                    lifecycleState: example
+                    mappingVersion: 1
+                    provider: example
+                    removedAt: "2026-01-02T15:04:05Z"
+                    sourceKind: saml
+                    updatedAt: "2026-01-02T15:04:05Z"
+                page:
+                  nextCursor: example
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: query
+      x-leapview-object-scope: platform
+    post:
+      operationId: upsertSemanticAttributeClaimMapping
+      parameters:
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeClaimMappingResponse'
+              example:
+                attributeName: example
+                audience: example
+                claim: example
+                createdAt: "2026-01-02T15:04:05Z"
+                id: example
+                issuer: example
+                lifecycleState: example
+                mappingVersion: 1
+                provider: example
+                removedAt: "2026-01-02T15:04:05Z"
+                sourceKind: saml
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticAttributeClaimMappingRequest'
+            example:
+              audience: example
+              claim: example
+              issuer: example
+              provider: example
+              sourceKind: saml
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: claim
+                sensitivity: public
+              - name: provider
+                sensitivity: public
+              - name: sourceKind
+                sensitivity: public
+            retention: security
+            schema:
+              ref: SemanticAttributeClaimMappingAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.claim_mapping_upserted
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_INVALID
+            kind: invalid
+            public_detail: Semantic attribute request is invalid.
+            status_code: 400
+          - code: SEMANTIC_ATTRIBUTE_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute was not found.
+            status_code: 404
+        idempotency: required
+        owner: LeapViewAPI.Access
+        target:
+          parameter: attribute
+          type: attribute
+      x-leapview-object-scope: platform
+  /api/v1/semantic-attributes/{attribute}/claim-mappings/{mapping}:
+    delete:
+      operationId: removeSemanticAttributeClaimMapping
+      parameters:
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: mapping
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers
+            may be useful. '
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: claim
+                sensitivity: public
+              - name: provider
+                sensitivity: public
+              - name: sourceKind
+                sensitivity: public
+            retention: security
+            schema:
+              ref: SemanticAttributeClaimMappingAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.claim_mapping_removed
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_CLAIM_MAPPING_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute claim mapping was not found.
+            status_code: 404
+        owner: LeapViewAPI.Access
+        target:
+          parameter: attribute
+          type: attribute
+      x-leapview-object-scope: platform
+  /api/v1/semantic-attributes/{attribute}/disable:
+    post:
+      operationId: disableSemanticAttribute
+      parameters:
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeDefinitionResponse'
+              example:
+                createdAt: "2026-01-02T15:04:05Z"
+                definitionVersion: 1
+                description: example
+                disabledAt: "2026-01-02T15:04:05Z"
+                displayName: example
+                documentationUrl: example
+                id: example
+                lifecycleState: example
+                name: example
+                ownerId: example
+                ownerKind: instance
+                profile: example
+                shape: scalar
+                type: String
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: lifecycle
+                sensitivity: public
+            retention: security
+            schema:
+              ref: SemanticAttributeDefinitionAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.disabled
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute was not found.
+            status_code: 404
+        idempotency: required
+        owner: LeapViewAPI.Access
+        target:
+          parameter: attribute
+          type: attribute
+      x-leapview-object-scope: platform
+  /api/v1/semantic-attributes/{attribute}/impact-preview:
+    post:
+      operationId: previewSemanticAttributeImpact
+      summary: Preview semantic attribute assignment impact
+      parameters:
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeImpactPreviewResponse'
+              example:
+                affectedGroupCount: 1
+                affectedPrincipalCount: 1
+                attributeName: example
+                targetId: example
+                targetKind: principal
+                warnings:
+                  - example
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticAttributeImpactPreviewRequest'
+            example:
+              targetId: example
+              targetKind: principal
+              values:
+                - booleanValue: true
+                  dateValue: example
+                  decimalValue: example
+                  integerValue: example
+                  stringValue: example
+                  timestampValue: example
+                  type: String
+      x-apigen-operation-kind: query
+      x-leapview-object-scope: platform
+  /api/v1/semantic-attributes/{attribute}/restore:
+    post:
+      operationId: restoreSemanticAttribute
+      parameters:
+        - name: attribute
+          in: path
+          required: true
+          schema:
+            type: string
+          example: example
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 200
+          example: example
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+          example: example
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticAttributeDefinitionResponse'
+              example:
+                createdAt: "2026-01-02T15:04:05Z"
+                definitionVersion: 1
+                description: example
+                disabledAt: "2026-01-02T15:04:05Z"
+                displayName: example
+                documentationUrl: example
+                id: example
+                lifecycleState: example
+                name: example
+                ownerId: example
+                ownerKind: instance
+                profile: example
+                shape: scalar
+                type: String
+                updatedAt: "2026-01-02T15:04:05Z"
+        '400':
+          description: The server could not understand the request due to invalid
+            syntax.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '403':
+          description: Access is forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '412':
+          description: Precondition failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '413':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '415':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '422':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '429':
+          description: Client error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '500':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '502':
+          description: Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                code: example
+                detail: example
+                errors:
+                  - code: example
+                    detail: example
+                    field: example
+                instance: example
+                requestId: example
+                status: 1
+                title: example
+                type: example
+      tags:
+        - Access
+      x-apigen-operation-kind: command
+      x-apigen-command:
+        audit:
+          guarantee: transactional
+          payload:
+            fields:
+              - name: attributeName
+                sensitivity: internal
+              - name: definitionVersion
+                sensitivity: internal
+              - name: lifecycle
+                sensitivity: public
+            retention: security
+            schema:
+              ref: SemanticAttributeDefinitionAuditPayload
+            schema_version: 1
+          required: true
+          success_action: semantic_attribute.restored
+        authz_mode: authenticated
+        concurrency: if-match
+        failures:
+          - code: SEMANTIC_ATTRIBUTE_NOT_FOUND
+            kind: not_found
+            public_detail: Semantic attribute was not found.
+            status_code: 404
+        idempotency: required
+        owner: LeapViewAPI.Access
+        target:
+          parameter: attribute
+          type: attribute
+      x-leapview-object-scope: platform
   /api/v1/semantic-models:
     get:
       operationId: listSemanticModels
@@ -82231,6 +87119,683 @@ components:
           - example
         toggle: true
         type: example
+    SemanticAttributeAssignmentAuditPayload:
+      type: object
+      required:
+        - attributeName
+        - targetKind
+        - targetId
+      properties:
+        attributeName:
+          type: string
+          example: example
+        targetKind:
+          type: string
+          example: example
+        targetId:
+          type: string
+          example: example
+      example:
+        attributeName: example
+        targetId: example
+        targetKind: example
+    SemanticAttributeAssignmentListResponse:
+      type: object
+      required:
+        - items
+        - page
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SemanticAttributeAssignmentResponse'
+          example:
+            - assignmentVersion: 1
+              attributeName: example
+              createdAt: "2026-01-02T15:04:05Z"
+              id: example
+              lifecycleState: example
+              removedAt: "2026-01-02T15:04:05Z"
+              targetId: example
+              targetKind: principal
+              updatedAt: "2026-01-02T15:04:05Z"
+              values:
+                - booleanValue: true
+                  dateValue: example
+                  decimalValue: example
+                  integerValue: example
+                  stringValue: example
+                  timestampValue: example
+                  type: String
+        page:
+          $ref: '#/components/schemas/PageInfo'
+      example:
+        items:
+          - assignmentVersion: 1
+            attributeName: example
+            createdAt: "2026-01-02T15:04:05Z"
+            id: example
+            lifecycleState: example
+            removedAt: "2026-01-02T15:04:05Z"
+            targetId: example
+            targetKind: principal
+            updatedAt: "2026-01-02T15:04:05Z"
+            values:
+              - booleanValue: true
+                dateValue: example
+                decimalValue: example
+                integerValue: example
+                stringValue: example
+                timestampValue: example
+                type: String
+        page:
+          nextCursor: example
+    SemanticAttributeAssignmentRequest:
+      type: object
+      required:
+        - values
+      properties:
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/SemanticAttributeValue'
+          example:
+            - booleanValue: true
+              dateValue: example
+              decimalValue: example
+              integerValue: example
+              stringValue: example
+              timestampValue: example
+              type: String
+      example:
+        values:
+          - booleanValue: true
+            dateValue: example
+            decimalValue: example
+            integerValue: example
+            stringValue: example
+            timestampValue: example
+            type: String
+    SemanticAttributeAssignmentResponse:
+      type: object
+      required:
+        - id
+        - attributeName
+        - targetKind
+        - targetId
+        - values
+        - assignmentVersion
+        - lifecycleState
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          example: example
+        attributeName:
+          type: string
+          example: example
+        targetKind:
+          $ref: '#/components/schemas/SemanticAttributeAssignmentTargetKindValue'
+        targetId:
+          type: string
+          example: example
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/SemanticAttributeValue'
+          example:
+            - booleanValue: true
+              dateValue: example
+              decimalValue: example
+              integerValue: example
+              stringValue: example
+              timestampValue: example
+              type: String
+        assignmentVersion:
+          type: integer
+          format: int64
+          example: 1
+        lifecycleState:
+          type: string
+          example: example
+        removedAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        createdAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+      example:
+        assignmentVersion: 1
+        attributeName: example
+        createdAt: "2026-01-02T15:04:05Z"
+        id: example
+        lifecycleState: example
+        removedAt: "2026-01-02T15:04:05Z"
+        targetId: example
+        targetKind: principal
+        updatedAt: "2026-01-02T15:04:05Z"
+        values:
+          - booleanValue: true
+            dateValue: example
+            decimalValue: example
+            integerValue: example
+            stringValue: example
+            timestampValue: example
+            type: String
+    SemanticAttributeAssignmentTargetKindValue:
+      type: string
+      enum:
+        - principal
+        - group
+      example: principal
+    SemanticAttributeClaimMappingAuditPayload:
+      type: object
+      required:
+        - attributeName
+        - sourceKind
+        - provider
+        - claim
+      properties:
+        attributeName:
+          type: string
+          example: example
+        sourceKind:
+          type: string
+          example: example
+        provider:
+          type: string
+          example: example
+        claim:
+          type: string
+          example: example
+      example:
+        attributeName: example
+        claim: example
+        provider: example
+        sourceKind: example
+    SemanticAttributeClaimMappingListResponse:
+      type: object
+      required:
+        - items
+        - page
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SemanticAttributeClaimMappingResponse'
+          example:
+            - attributeName: example
+              audience: example
+              claim: example
+              createdAt: "2026-01-02T15:04:05Z"
+              id: example
+              issuer: example
+              lifecycleState: example
+              mappingVersion: 1
+              provider: example
+              removedAt: "2026-01-02T15:04:05Z"
+              sourceKind: saml
+              updatedAt: "2026-01-02T15:04:05Z"
+        page:
+          $ref: '#/components/schemas/PageInfo'
+      example:
+        items:
+          - attributeName: example
+            audience: example
+            claim: example
+            createdAt: "2026-01-02T15:04:05Z"
+            id: example
+            issuer: example
+            lifecycleState: example
+            mappingVersion: 1
+            provider: example
+            removedAt: "2026-01-02T15:04:05Z"
+            sourceKind: saml
+            updatedAt: "2026-01-02T15:04:05Z"
+        page:
+          nextCursor: example
+    SemanticAttributeClaimMappingRequest:
+      type: object
+      required:
+        - sourceKind
+        - provider
+        - issuer
+        - audience
+        - claim
+      properties:
+        sourceKind:
+          $ref: '#/components/schemas/SemanticAttributeClaimSourceKindValue'
+        provider:
+          type: string
+          example: example
+        issuer:
+          type: string
+          example: example
+        audience:
+          type: string
+          example: example
+        claim:
+          type: string
+          example: example
+      example:
+        audience: example
+        claim: example
+        issuer: example
+        provider: example
+        sourceKind: saml
+    SemanticAttributeClaimMappingResponse:
+      type: object
+      required:
+        - id
+        - attributeName
+        - sourceKind
+        - provider
+        - issuer
+        - audience
+        - claim
+        - mappingVersion
+        - lifecycleState
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          example: example
+        attributeName:
+          type: string
+          example: example
+        sourceKind:
+          $ref: '#/components/schemas/SemanticAttributeClaimSourceKindValue'
+        provider:
+          type: string
+          example: example
+        issuer:
+          type: string
+          example: example
+        audience:
+          type: string
+          example: example
+        claim:
+          type: string
+          example: example
+        mappingVersion:
+          type: integer
+          format: int64
+          example: 1
+        lifecycleState:
+          type: string
+          example: example
+        removedAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        createdAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+      example:
+        attributeName: example
+        audience: example
+        claim: example
+        createdAt: "2026-01-02T15:04:05Z"
+        id: example
+        issuer: example
+        lifecycleState: example
+        mappingVersion: 1
+        provider: example
+        removedAt: "2026-01-02T15:04:05Z"
+        sourceKind: saml
+        updatedAt: "2026-01-02T15:04:05Z"
+    SemanticAttributeClaimSourceKindValue:
+      type: string
+      enum:
+        - saml
+        - oidc
+        - embed
+        - service_token
+      example: saml
+    SemanticAttributeDefinitionAuditPayload:
+      type: object
+      required:
+        - attributeName
+        - lifecycle
+        - definitionVersion
+      properties:
+        attributeName:
+          type: string
+          example: example
+        lifecycle:
+          type: string
+          example: example
+        definitionVersion:
+          type: integer
+          format: int64
+          example: 1
+      example:
+        attributeName: example
+        definitionVersion: 1
+        lifecycle: example
+    SemanticAttributeDefinitionListResponse:
+      type: object
+      required:
+        - items
+        - page
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SemanticAttributeDefinitionResponse'
+          example:
+            - createdAt: "2026-01-02T15:04:05Z"
+              definitionVersion: 1
+              description: example
+              disabledAt: "2026-01-02T15:04:05Z"
+              displayName: example
+              documentationUrl: example
+              id: example
+              lifecycleState: example
+              name: example
+              ownerId: example
+              ownerKind: instance
+              profile: example
+              shape: scalar
+              type: String
+              updatedAt: "2026-01-02T15:04:05Z"
+        page:
+          $ref: '#/components/schemas/PageInfo'
+      example:
+        items:
+          - createdAt: "2026-01-02T15:04:05Z"
+            definitionVersion: 1
+            description: example
+            disabledAt: "2026-01-02T15:04:05Z"
+            displayName: example
+            documentationUrl: example
+            id: example
+            lifecycleState: example
+            name: example
+            ownerId: example
+            ownerKind: instance
+            profile: example
+            shape: scalar
+            type: String
+            updatedAt: "2026-01-02T15:04:05Z"
+        page:
+          nextCursor: example
+    SemanticAttributeDefinitionResponse:
+      type: object
+      required:
+        - id
+        - name
+        - type
+        - shape
+        - profile
+        - definitionVersion
+        - ownerKind
+        - displayName
+        - description
+        - lifecycleState
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          example: example
+        name:
+          type: string
+          example: example
+        type:
+          $ref: '#/components/schemas/SemanticAttributeValueType'
+        shape:
+          $ref: '#/components/schemas/SemanticAttributeShapeValue'
+        profile:
+          type: string
+          example: example
+        definitionVersion:
+          type: integer
+          format: int64
+          example: 1
+        ownerKind:
+          $ref: '#/components/schemas/SemanticAttributeOwnerKindValue'
+        ownerId:
+          type: string
+          example: example
+        displayName:
+          type: string
+          example: example
+        description:
+          type: string
+          example: example
+        documentationUrl:
+          type: string
+          example: example
+        lifecycleState:
+          type: string
+          example: example
+        createdAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+        disabledAt:
+          type: string
+          format: date-time
+          example: "2026-01-02T15:04:05Z"
+      example:
+        createdAt: "2026-01-02T15:04:05Z"
+        definitionVersion: 1
+        description: example
+        disabledAt: "2026-01-02T15:04:05Z"
+        displayName: example
+        documentationUrl: example
+        id: example
+        lifecycleState: example
+        name: example
+        ownerId: example
+        ownerKind: instance
+        profile: example
+        shape: scalar
+        type: String
+        updatedAt: "2026-01-02T15:04:05Z"
+    SemanticAttributeImpactPreviewRequest:
+      type: object
+      required:
+        - targetKind
+        - targetId
+        - values
+      properties:
+        targetKind:
+          $ref: '#/components/schemas/SemanticAttributeAssignmentTargetKindValue'
+        targetId:
+          type: string
+          example: example
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/SemanticAttributeValue'
+          example:
+            - booleanValue: true
+              dateValue: example
+              decimalValue: example
+              integerValue: example
+              stringValue: example
+              timestampValue: example
+              type: String
+      example:
+        targetId: example
+        targetKind: principal
+        values:
+          - booleanValue: true
+            dateValue: example
+            decimalValue: example
+            integerValue: example
+            stringValue: example
+            timestampValue: example
+            type: String
+    SemanticAttributeImpactPreviewResponse:
+      type: object
+      required:
+        - attributeName
+        - targetKind
+        - targetId
+        - affectedPrincipalCount
+        - affectedGroupCount
+        - warnings
+      properties:
+        attributeName:
+          type: string
+          example: example
+        targetKind:
+          $ref: '#/components/schemas/SemanticAttributeAssignmentTargetKindValue'
+        targetId:
+          type: string
+          example: example
+        affectedPrincipalCount:
+          type: integer
+          format: int32
+          example: 1
+        affectedGroupCount:
+          type: integer
+          format: int32
+          example: 1
+        warnings:
+          type: array
+          items:
+            type: string
+          example:
+            - example
+      example:
+        affectedGroupCount: 1
+        affectedPrincipalCount: 1
+        attributeName: example
+        targetId: example
+        targetKind: principal
+        warnings:
+          - example
+    SemanticAttributeMetadataRequest:
+      type: object
+      required:
+        - ownerKind
+        - displayName
+        - description
+      properties:
+        ownerKind:
+          $ref: '#/components/schemas/SemanticAttributeOwnerKindValue'
+        ownerId:
+          type: string
+          example: example
+        displayName:
+          type: string
+          example: example
+        description:
+          type: string
+          example: example
+        documentationUrl:
+          type: string
+          example: example
+      example:
+        description: example
+        displayName: example
+        documentationUrl: example
+        ownerId: example
+        ownerKind: instance
+    SemanticAttributeOwnerKindValue:
+      type: string
+      enum:
+        - instance
+        - principal
+        - group
+      example: instance
+    SemanticAttributeRegisterRequest:
+      type: object
+      required:
+        - name
+        - type
+        - shape
+        - metadata
+      properties:
+        name:
+          type: string
+          example: example
+        type:
+          $ref: '#/components/schemas/SemanticAttributeValueType'
+        shape:
+          $ref: '#/components/schemas/SemanticAttributeShapeValue'
+        metadata:
+          $ref: '#/components/schemas/SemanticAttributeMetadataRequest'
+      example:
+        metadata:
+          description: example
+          displayName: example
+          documentationUrl: example
+          ownerId: example
+          ownerKind: instance
+        name: example
+        shape: scalar
+        type: String
+    SemanticAttributeShapeValue:
+      type: string
+      enum:
+        - scalar
+        - list
+      example: scalar
+    SemanticAttributeValue:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          $ref: '#/components/schemas/SemanticAttributeValueType'
+        stringValue:
+          type: string
+          example: example
+        booleanValue:
+          type: boolean
+          example: true
+        integerValue:
+          type: string
+          example: example
+        decimalValue:
+          type: string
+          example: example
+        dateValue:
+          type: string
+          example: example
+        timestampValue:
+          type: string
+          example: example
+      example:
+        booleanValue: true
+        dateValue: example
+        decimalValue: example
+        integerValue: example
+        stringValue: example
+        timestampValue: example
+        type: String
+    SemanticAttributeValueType:
+      type: string
+      enum:
+        - String
+        - Boolean
+        - Integer
+        - Decimal
+        - Date
+        - Timestamp
+      example: String
     SemanticDashboardBooleanFilterValue:
       type: object
       allOf:

--- a/docs/articles/architecture/postgresql-authority-reconciliation.md
+++ b/docs/articles/architecture/postgresql-authority-reconciliation.md
@@ -1,13 +1,14 @@
 # PostgreSQL authority reconciliation
 
-This change reconciles the reusable PostgreSQL authority foundations from
-draft PR #386 onto the current architecture. It is deliberately a clean-slate
-baseline, not a merge of that branch and not an implementation of the
-ADR-0017 typed attribute registry.
+This document records the reusable PostgreSQL authority foundations extracted
+from draft PR #386 and reconciled by PR #460. FAI-636 and FAI-637 now extend
+that baseline with access-owned, forward-only typed semantic-attribute state.
+They do not claim a PostgreSQL-only serving cutover or completion of the
+ADR-0017 semantic-consumer integration.
 
 ## Reconciliation classification
 
-| Classification | PR #386 material | Reconciled outcome |
+| Classification | PR #386 material or later extension | Reconciled outcome |
 | --- | --- | --- |
 | Keep | PostgreSQL 18 pool/runtime policy | `internal/platform/postgres` owns bounded pool configuration, TLS and role checks, cancellation, timeouts, explicit read/write intent, and leased query rows. |
 | Keep | Capability-owned migrations | The platform runner owns only advisory locking, checksum/revision evidence, and ordered execution. `platform.bootstrap`, `access`, `physical_pool`, and the minimal DuckLake catalog-bootstrap ledger each own their DDL. |
@@ -17,14 +18,19 @@ ADR-0017 typed attribute registry.
 | Keep | Least-privilege roles | Non-login owner roles are distinct from login migrator, runtime, maintenance, readonly, and backup roles. The baseline fails if the required control roles were not provisioned first and reasserts ACLs on replay. |
 | Keep | PostgreSQL 18 harness | The pinned PostgreSQL 18 container harness exercises pool behavior, migration replay, immutable evidence, and privilege boundaries. |
 | Keep | Native initialization and pool bootstrap | Production admin initialization uses PostgreSQL platform/access authorities. Physical-pool bootstrap verifies exact compatibility evidence, creates the namespace ownership marker, initializes the separate PostgreSQL DuckLake catalog, and registers the exact catalog identity in the caller-owned control transaction. |
+| Keep | FAI-636 typed registry, revision 2 | `internal/access/postgres` owns `semantic_attribute_registry` and `semantic_attribute_definition`: profile-qualified identity, type/shape, stewardship metadata, lifecycle, versioning, deterministic registry digest, and audited mutations. |
+| Keep | FAI-637 durable control, revision 3 | `internal/access/postgres` owns `semantic_attribute_control_state`, direct principal/group assignments, trusted claim mappings, control digest/revision, tombstone lifecycle, expected-version concurrency, canonical-value validation, and audited mutations. |
 | Drop | Other capability migrations and repositories | Jobs, deployment, cache, lineage, refresh, source, project, serving-state, and retention ports from PR #386 are not part of this baseline. |
 | Drop | Branch-wide generated/deployment state | Stale generated files, merge-resolution artifacts, historical deployment rewrites, and the draft branch's aggregate application graph are excluded. |
-| Defer | ADR-0017 registry and integrations | Typed attribute definitions/assignments, semantic attribute storage, VAL-11 expansion, claim ingestion, validation, runtime evaluation, digest/cache, audit projection, and consumer-facing semantic access behavior remain outside this change. |
+| Defer | ADR-0017 semantic-consumer integration | SemanticModel policy compilation, candidate/generation references, planner evaluation, catalog filtering, dashboards, Explore, agents, exports, APIs/MCP, embedding, cache/event invalidation, and source-provider adapters remain outside FAI-637. |
 
-The existing generic `principal.attributes` and `access_group.attributes`
-columns retain their pre-registry access metadata role. They are not the
-typed ADR-0017 registry, do not use semantic-value canonical identities, and
-provide no VAL-11 qualification evidence.
+The existing generic `principal.attributes` and
+`access_group.attributes` JSON columns retain their pre-registry access and
+SCIM metadata role. They are not the typed ADR-0017 registry, do not use
+semantic-value canonical identities, and provide no semantic authorization
+evidence. No project YAML or legacy `DataPolicy` value can populate the typed
+registry/control tables; a future typed semantic policy must enter through the
+SemanticModel contract and the access control plane.
 
 ## Ownership boundaries
 
@@ -35,7 +41,15 @@ Each capability exposes an embedded `SchemaSQL` and a narrow pgx repository.
 The application composition in `internal/app/postgresbaseline` orders those
 components and records one checksummed baseline revision. Adding another
 capability requires adding its component explicitly; a platform migration
-must not absorb capability tables.
+must not absorb capability tables. FAI-636 and FAI-637 remain access-owned
+forward migrations, and revision 1 is never edited.
+
+The semantic-attribute registry and control tables are product authority, not
+platform connection metadata. Access repositories perform domain validation,
+lock the appropriate singleton, canonicalize values, advance the corresponding
+identity, and append audit evidence. Top-level methods create one transaction;
+the explicit `...Tx` methods accept a caller-owned transaction. Audit is written
+before commit, so a failed audit append rolls back the state change.
 
 The production admin adapter separates credentials by operation:
 
@@ -49,7 +63,8 @@ The production admin adapter separates credentials by operation:
 - DuckLake runtime and maintenance roles receive DML/sequence rights on that
   exact metadata schema but no schema creation or owner membership; and
 - readonly and backup control roles receive only the explicit projections
-  granted by the baseline.
+  granted by the baseline, including non-secret semantic-attribute metadata
+  and control projections.
 
 Production provisioning must grant database `CONNECT` to
 `leapview_control_migrator` and database `CREATE` to the non-login
@@ -57,23 +72,41 @@ Production provisioning must grant database `CONNECT` to
 credential, then `Apply` assumes the owner role for all baseline DDL; the
 migrator must not be granted database `CREATE` directly.
 
+Database roles are separate from the application platform-admin role. A
+semantic-attribute HTTP request first authenticates a principal, then checks
+the durable instance-wide platform role. A request API token may attenuate that
+role (nil capabilities inherit, explicit empty denies, explicit non-empty must
+include `PROJECT_ADMIN`); authoring credentials and principal-mismatched
+credentials are denied. Possessing a database runtime credential does not
+make a principal a platform administrator.
+
 Production initialization and physical-pool bootstrap never open SQLite.
 Development and the isolated evaluation target continue to use the explicit
-offline adapter.
+offline adapter. The broader PostgreSQL-only serving application graph remains
+a separate architecture milestone.
 
-This is the focused extraction of the FAI-609 prerequisite: native production
-administrator initialization, one-time credential handoff, and physical-pool
-bootstrap run against the PostgreSQL authorities above. The broader
-PostgreSQL-only serving application graph remains a separate architecture
-milestone; this reconciliation does not claim that cutover.
-
-## Lifecycle and compatibility
+## Lifecycle, identity, and compatibility
 
 The baseline is a clean-slate revision. Its checksum frames the platform
 foundation, ordered capability name and SQL bytes, and role policy. A matching
 revision is replay-safe; a different migration ID or checksum fails closed.
 Because the revision is immutable, changing any component after release
 requires a new forward revision rather than editing revision 1.
+
+FAI-636 revision 2 and FAI-637 revision 3 follow the same rule. Their migration
+IDs and SQL bytes are access-owned and composed in order after revision 1.
+Revision 2's registry singleton has `(profile, registry_revision,
+registry_digest)` identity. Revision 3's control singleton independently has
+`(profile, control_revision, control_digest)` identity over ordered active and
+tombstoned assignments and mappings. Replay leaves each identity unchanged;
+an effective mutation advances its revision exactly once with a new digest.
+
+Definition identity and logical type are immutable. Metadata and lifecycle
+changes increment definition version; deletion is rejected. An assignment or
+claim mapping is an immutable incarnation with versioned updates/tombstoning;
+expected-version mismatches fail closed, tombstones remain, and restoration
+creates a new identity. Database triggers enforce identity/type stability,
+database-owned timestamps, monotonic versions, and control-state advancement.
 
 SQLite development databases that already applied migration 073 receive
 `encryption_domain` through forward migration 095. Existing rows are
@@ -101,7 +134,7 @@ Run the following before review:
 ```sh
 task db:generate
 task generated:check
-go test -tags=duckdb_arrow ./internal/analytics/ducklake/... ./internal/analytics/physicalpool/... ./internal/access/postgres ./internal/platform/bootstrap/postgres ./internal/app/adminpostgres ./internal/app/postgresbaseline
+go test -tags=duckdb_arrow ./internal/analytics/ducklake/... ./internal/analytics/physicalpool/... ./internal/access/postgres ./internal/access/trustedclaims ./internal/platform/bootstrap/postgres ./internal/app/adminpostgres ./internal/app/postgresbaseline
 go test ./internal/platform/architecture
 LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED=1 go test ./internal/platform/postgres/... ./internal/platform/bootstrap/postgres ./internal/access/postgres ./internal/analytics/physicalpool/postgres ./internal/access/http/mcpoauth -count=1 -v
 task ci
@@ -111,8 +144,9 @@ The required PostgreSQL lane must report an unavailable Docker provider or
 pinned image as a failure. Local optional runs may skip only when
 `LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED` is unset.
 
-PR #460 merged the reconciliation. FAI-636 builds on it with an access-owned
-forward migration and the merged semantic-value canonicalizer; it does not
-rewrite this baseline. Attribute assignments and the remaining consumer paths
-stay outside the registry milestone, so the partial VAL-11 qualification
-boundary is unchanged.
+PR #460 merged the reconciliation. FAI-636 and FAI-637 build on it with
+access-owned forward migrations and the merged semantic-value canonicalizer;
+they do not rewrite this baseline. The typed registry/control identities and
+audit boundaries are in place, while semantic compiler/consumer integration,
+real SAML/OIDC/embed/service-token adapters, and cache/event invalidation
+remain deferred. VAL-11 consequently remains explicitly **Partial**.

--- a/docs/articles/architecture/semantic-attribute-registry.md
+++ b/docs/articles/architecture/semantic-attribute-registry.md
@@ -1,76 +1,254 @@
-# Semantic attribute registry
+# Semantic attribute registry and control plane
 
-The PostgreSQL semantic attribute registry is the control-plane authority for
-typed semantic-access attribute definitions. It gives each definition a stable
-identity, a closed logical type and shape, versioned ownership and documentation
-metadata, and an explicit active or disabled lifecycle. It does not store
-principal assignments or trusted claim mappings.
+FAI-637 adds the PostgreSQL control-plane half of the `leapview.semantic-
+access/v1` profile. The registry defines what an attribute is; control rows
+record which subjects receive canonical values and which trusted provider
+claims may supply a value. This is stewardship state, not the semantic query
+authorization engine. The SemanticModel compiler, planner, catalog filtering,
+consumer adapters, cache invalidation, and generation-reference checks remain
+pending under [ADR-0017](../../../adr/0017-adopt-a-looker-aligned-semantic-access-contract.md).
 
-## Capability ownership
+## Capability ownership and authority
 
-The access capability owns the revision-2 migration, sqlc queries, domain
-contract, repository, validation, and transactional audit records. The generic
-PostgreSQL migration runner owns only advisory locking, ordered revision
-application, checksum evidence, and replay verification. Revision 1 remains
-byte-for-byte immutable; the registry is an access-owned forward migration.
+The access capability owns the access-owned forward migrations, sqlc query
+sources, domain contracts, repositories, validation, and audit projections.
+The generic PostgreSQL migration runner owns only advisory locking, ordered
+revision application, checksum evidence, and replay verification. Baseline
+revision 1 is immutable; FAI-636 owns revision 2 and FAI-637 owns revision 3.
 
-The registry uses the reconciled PostgreSQL authority roles. The runtime role
-can read and mutate definitions through the access repository, readonly and
-backup roles can project non-secret registry metadata, and deletes are denied.
-Each repository mutation uses a caller-owned transaction and appends immutable
-audit evidence before that transaction can commit.
+There are three distinct kinds of authority:
 
-## Definition and registry identity
+| State | Authority and purpose | Not implied |
+| --- | --- | --- |
+| `semantic_attribute_definition` and `semantic_attribute_registry` | Access control plane defines the stable name, logical type, shape, profile, stewardship metadata, lifecycle, revision, and registry digest. | Owning an attribute does not grant a principal access to data or assign a value. |
+| `semantic_attribute_assignment` and `semantic_attribute_control_state` | Access control plane binds canonical values to a principal or group and maintains the control snapshot identity. Group membership is resolved from access membership state. | An assignment is not a semantic-model policy and does not by itself authorize a query. |
+| `semantic_attribute_claim_mapping` | Access control plane records a source-bound provider/issuer/audience/claim name and its typed definition. The mapping has no value payload. | A mapping does not authenticate a claim or make an unverified request value trusted. |
+
+`owner_kind`/`owner_id` on a definition is stewardship metadata for the
+attribute record. It is deliberately separate from an assignment target and
+from the durable platform role used to administer the control plane. An
+instance-owned attribute may be assigned to subjects; a principal- or
+group-owned definition does not make that subject an administrator.
+
+The existing `principal.attributes` and `access_group.attributes` JSON
+columns are legacy access metadata (including SCIM-facing metadata). They are
+not registry definitions, assignments, claim mappings, typed values, or
+authorization evidence. The FAI-637 tables are the only typed semantic
+attribute authority.
+
+## Platform-admin authorization and attenuation
+
+The semantic-attribute HTTP endpoints are platform administration endpoints.
+The generated transport contract describes them as requiring an authenticated
+principal; the handler adds the stronger platform-admin guard. The request
+flow is:
+
+1. authentication resolves the canonical principal;
+2. `RequestPlatformAdmin` rechecks the durable, instance-wide platform role
+   through `PlatformAdminReader.IsPlatformAdmin`; and
+3. the request credential, if present, can only attenuate that role.
+
+A browser/session request with no API credential inherits the durable role. An
+authoring credential is denied on this platform-admin surface. An API token
+with nil capabilities inherits the role, an explicit empty capability list is
+deny-all, and a non-empty list must contain `PROJECT_ADMIN`. A credential for
+another principal is denied. No project authorization snapshot can create a
+platform role. The explicit local-development `DevBypass` is accepted only by
+the non-production development configuration; it is not a production
+authorization path.
+
+This flow means a credential may reduce a platform administrator's authority,
+never elevate a non-administrator. Definition, assignment, mapping, preview,
+and semantic-attribute audit routes all use this guard and fail closed when
+the repository or durable role check is unavailable.
+
+## Definition identity and lifecycle
 
 Each `access.semantic_attribute_definition` row contains:
 
-- an immutable UUID and case-sensitive semantic attribute name;
-- one logical type from `String`, `Boolean`, `Integer`, `Decimal`, `Date`, or
+- an immutable UUID and case-sensitive SemanticModel identifier name;
+- one logical type: `String`, `Boolean`, `Integer`, `Decimal`, `Date`, or
   `Timestamp`;
 - a `scalar` or homogeneous `list` shape;
-- the `leapview.semantic-access/v1` canonicalization profile;
-- instance, principal, or group ownership metadata;
+- profile `leapview.semantic-access/v1`;
+- stewardship owner (`instance`, `principal`, or `group`);
 - display name, description, and optional credential-free HTTPS documentation
-  URL;
-- a monotonically increasing definition version; and
-- database-owned creation, update, and disable timestamps.
+  URL; and
+- database-owned timestamps, lifecycle, and a positive definition version.
 
-The UUID, name, type, shape, profile, and creation timestamp cannot be rewritten.
-Metadata and lifecycle changes advance the definition version exactly once.
-Definitions are disabled and re-enabled rather than deleted.
+The UUID, name, type, shape, profile, and creation timestamp cannot change.
+Metadata changes and enable/disable transitions advance the definition version
+exactly once. Deletion is rejected. Disablement sets a database-owned
+`disabled_at`; restoration clears it through the same guarded transition.
 
-`access.semantic_attribute_registry` is a singleton compatibility identity.
-Every effective definition change advances its revision and replaces its
-SHA-256 digest in the same caller-owned transaction. Reads recompute the digest
-from the ordered definition projection and fail closed when stored and computed
-identities differ. Idempotent replays do not advance either revision.
+```text
+absent --register(v1)--> active
+active --metadata update (v+1)--> active
+active --disable (v+1)--> disabled
+disabled --metadata update (v+1)--> disabled
+disabled --restore (v+1)--> active
+active/disabled --delete or type/name/shape/profile rewrite--> rejected
+```
 
-## Repository lifecycle
+Registering an existing name with the same type and shape is an idempotent
+replay; a different type or shape is a compatibility conflict. The stable
+registry singleton advances `registry_revision` and replaces its SHA-256
+`registry_digest` for each effective definition change. The digest is
+recomputed from the ordered definition projection on reads, and a mismatch
+fails closed. Replays do not advance either identity.
 
-The access repository supports registration, lookup by name or stable UUID,
-ordered listing/search, metadata changes, and lifecycle transitions. Registering
-an existing name with the same type and shape is a replay; registering the name
-with a different type or shape returns a compatibility conflict. A logical type
-change therefore requires a new attribute identity instead of an in-place
-rewrite.
+## Assignment and mapping lifecycles
 
-Before a consumer accepts an attribute value, the repository loads the active
-definition and delegates canonicalization to `internal/semanticvalue`. Scalars
-produce one canonical value identity. Lists use the v1 bounded homogeneous-set
-contract, including canonical sorting and deduplication. Disabled definitions
-fail closed. Values themselves are not persisted by this registry.
+Assignments are immutable incarnations of a definition/subject binding. A
+subject is a principal or group, and each active definition/subject pair has
+one active assignment. Values are canonicalized before storage; scalar values
+have one element and list values are bounded homogeneous sets.
 
-## Semantic access boundary
+```text
+absent --set(expected=0, v1)--> active
+active --set(expected=current, canonical values changed, v+1)--> active
+active --remove(expected=current, v+1)--> tombstoned
+tombstoned --set--> new active assignment identity (old row retained)
+tombstoned --restore or delete--> rejected
+```
 
-This registry qualifies the definition-storage part of ADR-0017 and provides a
-stable identity for later assignment and consumer integrations. It deliberately
-does not implement principal or group assignments, claim ingestion, semantic
-filter evaluation, policy digest propagation, cache identity, or audit value
-projection. Those paths remain separately qualified work, so VAL-11 remains
-partial.
+Tombstone time is database-owned and tombstones are retained. A new assignment
+incarnation receives a new ID rather than reviving history. Assignment writes
+carry `definition_id`, definition version, type, and shape so persisted state
+cannot silently change meaning; database triggers and repository validation
+reject disabled or incompatible definitions and invalid subjects.
 
-Migration tests cover ordered revision application and replay identity.
-Repository tests cover stable registration, lookup/search, canonical value
-validation, metadata versioning, disablement, immutable type enforcement,
-registry digests, and transactional audit evidence against the PostgreSQL 18
-harness.
+A trusted claim mapping binds the exact source kind, provider, issuer,
+audience, claim name, and definition. Source identity is closed to `saml`,
+`oidc`, `embed`, and `service_token`; provider and claim names are exact and
+bounded. Mapping rows have no value payload.
+
+```text
+absent --set(expected=0, v1)--> active
+active --same identity replay--> active (no state advance)
+active --remove(expected=current, v+1)--> tombstoned
+tombstoned --set--> new mapping identity (old row retained)
+tombstoned --restore or in-place identity rewrite--> rejected
+```
+
+Mapping identity includes the source tuple, exact claim, and target
+definition. A desired remap is represented by a retained tombstone and a new
+mapping row; it must not mutate an existing row in place. If simultaneously
+resolved sources provide different canonical values for one definition, the
+effective-value resolver returns a source conflict rather than selecting a
+winner. Equal direct and trusted values may be represented as one effective
+value with a combined source marker.
+
+## Concurrency, control identity, and audit
+
+Definition mutations lock the registry singleton. Assignment and mapping
+mutations lock the independent `semantic_attribute_control_state` singleton.
+The control state records profile `leapview.semantic-access/v1`, a monotonic
+`control_revision`, and a deterministic SHA-256 `control_digest` over ordered
+active and tombstoned assignment/mapping projections. The registry and control
+identities are intentionally separate: a definition metadata/lifecycle change
+advances registry identity, while assignment/mapping changes advance control
+identity.
+
+Updates use `If-Match`/expected versions at the HTTP and repository boundary.
+Expected version zero creates; updates and tombstones require the current
+positive assignment or mapping version. A stale version is a conflict. The
+database requires each mutable update to advance exactly once, rejects
+identity/type rewrites, and rejects control-state rewrites that do not advance
+the revision with a new digest. Idempotent replays preserve versions and
+identities.
+
+Top-level repository mutations run the state change, control digest advance,
+and audit append in one transaction. The `...Tx` variants accept a
+caller-owned transaction and append the event before the caller commits. A
+failed audit append rolls back the state mutation. Audit metadata records
+stable IDs, definition/type/version, source identity, value count, control
+revision/digest, actor, request, and correlation identity; it never
+records canonical value payloads or raw provider claim values. The closed API
+value envelope uses typed scalar fields, keeps integer/decimal precision, and
+rejects maps, nested lists, executable values, nulls, and oversized lists.
+
+## Trusted verifier boundary
+
+`internal/access/trustedclaims` is an admission boundary, not an identity
+provider. `Verify` accepts raw source evidence only together with a
+source-bound cryptographic verifier. The source adapter owns signature, issuer,
+audience, nonce, key, and token validation. The package enforces exact source
+binding, trust identity, issued/expiry interval, fingerprint shape, exact
+claim names, duplicate rejection, and scalar/homogeneous-list structure. It
+returns an opaque envelope with private fields, copied values, and no raw
+evidence; callers cannot forge an envelope by constructing its fields.
+
+The four source names are vocabulary and boundary checks only in this slice.
+No SAML, OIDC, embed, or service-token provider integration is claimed. The
+durable mapping repository and effective resolver are intended to consume
+claims only through the opaque `trustedclaims.Envelope`; wiring real provider
+adapters through `Verify`, deriving a principal context, and passing that
+context to semantic consumers remain pending.
+
+## Registry, effective values, and consumers
+
+The control-plane relationship is:
+
+```text
+definition registry (what/name/type/shape/lifecycle)
+        +
+direct assignments (principal/group -> canonical values)
+        +
+trusted mappings (source identity + exact claim -> definition)
+        + authenticated claim envelope (future source adapter)
+        |
+        v
+effective subject attributes (canonical values, source conflict checked)
+        |
+        v
+SemanticModel grants/filters and governed semantic consumers (pending)
+```
+
+The current FAI-637 implementation provides the first three boxes, shared
+canonical value validation, durable control identities, effective direct/group
+resolution behind the opaque `trustedclaims.Envelope` boundary, and
+platform-admin management APIs. It does not
+yet make those values the authority for SemanticModel `accessGrants`,
+`requiredAccessGrants`, or `accessFilters`; it does not filter catalogs or
+execute queries for dashboards, Explore, agents, exports, APIs, MCP, or
+embedding. The existing generic/legacy access paths therefore must not be
+described as FAI-637 semantic-consumer evidence.
+
+## Immediate invalidation identity
+
+FAI-637 establishes the durable inputs needed for immediate invalidation but
+does not publish cache events or implement consumer caches. A future effective
+attribute-set identity must be derived from an ordered, profile-qualified
+projection of `(instance, subject, definition ID/version/type/shape,
+valueDigest, source)` and must never contain raw values. Runtime trusted input
+also binds its source credential/token fingerprint and validity interval.
+
+Every authorization-sensitive cache key must include at least the instance
+identity, semantic generation, principal identity, registry
+`(profile, registry_revision, registry_digest)`, control
+`(profile, control_revision, control_digest)`, effective attribute-set
+identity, and normalized semantic policy identity. A committed definition
+change invalidates by registry identity; a committed assignment or mapping
+change invalidates by control identity and, when known, affected definition and
+subject. A digest mismatch is a conservative immediate invalidation signal,
+not permission to continue with stale state. Cache/event propagation and
+consumer use of this identity are LIF- and consumer-integration work still
+pending under ADR-0017.
+
+## Current evidence and limits
+
+The PostgreSQL registry tests cover deterministic registry identity, stable
+registration/replay, metadata versioning, disablement, type immutability,
+canonical values, and transactional audit evidence. The trustedclaims tests
+cover the opaque verifier envelope, source binding, temporal checks, exact
+claims, copying, fingerprints, and structural value rejection. FAI-637's
+assignment/mapping repositories and migration are implementation scope, but
+their downstream semantic authorization and full integration qualification are
+not complete.
+
+VAL-11 therefore remains **Partial**: the shared `internal/semanticvalue`
+canonicalizer is used at registry/assignment/mapping ingress and semantic-value
+tests provide cross-path fixtures, while generated canonicalization,
+candidate validation, runtime planner evaluation, cache identity/invalidation,
+and complete audit projection evidence remain unqualified.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -241,7 +241,7 @@ Focused slices are available at `/docs/agent-tools/tools/{name}.json|md`, `/docs
 - [Architecture overview](/docs/architecture): See how the monolith, contracts, storage, and browser components fit together.
 - [Runtime architecture](/docs/architecture/runtime): Follow routing, query execution, and streamed UI updates.
 - [PostgreSQL authority reconciliation](/docs/architecture/postgresql-authority-reconciliation): Understand the reconciled PostgreSQL ownership, transaction, role, and compatibility boundaries.
-- [Semantic attribute registry](/docs/architecture/semantic-attribute-registry): Understand typed semantic attribute identity, ownership, lifecycle, and compatibility boundaries.
+- [Semantic attribute registry and control plane](/docs/architecture/semantic-attribute-registry): Understand typed semantic attribute identity, ownership, lifecycle, and compatibility boundaries.
 - [Evidence-gated Arrow optimization](/docs/architecture/arrow-optimization-evidence): Measure dashboard Arrow boundaries before approving a production migration.
 - [Dashboard native Arrow response contract](/docs/architecture/dashboard-native-arrow-contract): Define the native-v1 schema, protocol, governance, pagination, and compatibility oracle for future dashboard Arrow experiments.
 - [Cross-role journey qualification](/docs/architecture/journey-qualification): Map FAI-492 consumer, creator, and operator states to executable assembled-app checks and evidence rules.

--- a/docs/navigation.yaml
+++ b/docs/navigation.yaml
@@ -541,7 +541,7 @@ sections:
             summary: Understand the reconciled PostgreSQL ownership, transaction, role, and compatibility boundaries.
             source: articles/architecture/postgresql-authority-reconciliation.md
           - slug: architecture/semantic-attribute-registry
-            title: Semantic attribute registry
+            title: Semantic attribute registry and control plane
             type: explanation
             summary: Understand typed semantic attribute identity, ownership, lifecycle, and compatibility boundaries.
             source: articles/architecture/semantic-attribute-registry.md

--- a/internal/access/http/apigen.go
+++ b/internal/access/http/apigen.go
@@ -8,9 +8,10 @@ import (
 	accessgen "github.com/flidai/leapview/internal/access/api/gen"
 )
 
-// APIGenDispatcher contains only identity, credential, group, audit, avatar,
-// and authoring operations. Project authorization endpoints are owned by the
-// immutable serving-state authorization surface.
+// APIGenDispatcher contains identity, credential, group, audit, avatar,
+// authoring, and platform semantic-attribute administration operations.
+// Project authorization endpoints are owned by the immutable serving-state
+// authorization surface.
 type APIGenDispatcher struct{ handler Handler }
 
 // APIGenTransportErrorResponder adapts generated transport failures to the
@@ -149,6 +150,93 @@ func (d *APIGenDispatcher) AddGroupMember(w stdhttp.ResponseWriter, r *stdhttp.R
 }
 func (d *APIGenDispatcher) RemoveGroupMember(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string) {
 	d.handler.RemoveGroupMember(w, r)
+}
+func (d *APIGenDispatcher) ListGroupSemanticAttributeAssignments(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListGroupSemanticAttributeAssignmentsParams) {
+	d.handler.ListGroupSemanticAttributeAssignments(w, r)
+}
+func (d *APIGenDispatcher) RemoveGroupSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenRemoveGroupSemanticAttributeAssignmentHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	d.handler.RemoveGroupSemanticAttributeAssignment(w, r)
+}
+func (d *APIGenDispatcher) UpsertGroupSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenUpsertGroupSemanticAttributeAssignmentHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	d.handler.UpsertGroupSemanticAttributeAssignment(w, r)
+}
+func (d *APIGenDispatcher) ListPrincipalSemanticAttributeAssignments(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListPrincipalSemanticAttributeAssignmentsParams) {
+	d.handler.ListPrincipalSemanticAttributeAssignments(w, r)
+}
+func (d *APIGenDispatcher) RemovePrincipalSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenRemovePrincipalSemanticAttributeAssignmentHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	d.handler.RemovePrincipalSemanticAttributeAssignment(w, r)
+}
+func (d *APIGenDispatcher) UpsertPrincipalSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenUpsertPrincipalSemanticAttributeAssignmentHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	d.handler.UpsertPrincipalSemanticAttributeAssignment(w, r)
+}
+func (d *APIGenDispatcher) ListSemanticAttributeDefinitions(w stdhttp.ResponseWriter, r *stdhttp.Request, _ accessgen.GenListSemanticAttributeDefinitionsParams) {
+	d.handler.ListSemanticAttributeDefinitions(w, r)
+}
+func (d *APIGenDispatcher) RegisterSemanticAttribute(w stdhttp.ResponseWriter, r *stdhttp.Request, headers accessgen.GenRegisterSemanticAttributeHeaders) {
+	if headers.IdempotencyKey != "" {
+		r.Header.Set("Idempotency-Key", headers.IdempotencyKey)
+	}
+	d.handler.RegisterSemanticAttribute(w, r)
+}
+func (d *APIGenDispatcher) GetSemanticAttributeDefinition(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.GetSemanticAttributeDefinition(w, r)
+}
+func (d *APIGenDispatcher) UpdateSemanticAttributeMetadata(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, headers accessgen.GenUpdateSemanticAttributeMetadataHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	d.handler.UpdateSemanticAttributeMetadata(w, r)
+}
+func (d *APIGenDispatcher) ListSemanticAttributeClaimMappings(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, _ accessgen.GenListSemanticAttributeClaimMappingsParams) {
+	d.handler.ListSemanticAttributeClaimMappings(w, r)
+}
+func (d *APIGenDispatcher) UpsertSemanticAttributeClaimMapping(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, headers accessgen.GenUpsertSemanticAttributeClaimMappingHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	if headers.IdempotencyKey != "" {
+		r.Header.Set("Idempotency-Key", headers.IdempotencyKey)
+	}
+	d.handler.UpsertSemanticAttributeClaimMapping(w, r)
+}
+func (d *APIGenDispatcher) RemoveSemanticAttributeClaimMapping(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, headers accessgen.GenRemoveSemanticAttributeClaimMappingHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	d.handler.RemoveSemanticAttributeClaimMapping(w, r)
+}
+func (d *APIGenDispatcher) DisableSemanticAttribute(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, headers accessgen.GenDisableSemanticAttributeHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	if headers.IdempotencyKey != "" {
+		r.Header.Set("Idempotency-Key", headers.IdempotencyKey)
+	}
+	d.handler.DisableSemanticAttribute(w, r)
+}
+func (d *APIGenDispatcher) PreviewSemanticAttributeImpact(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string) {
+	d.handler.PreviewSemanticAttributeImpact(w, r)
+}
+func (d *APIGenDispatcher) RestoreSemanticAttribute(w stdhttp.ResponseWriter, r *stdhttp.Request, _ string, headers accessgen.GenRestoreSemanticAttributeHeaders) {
+	if headers.IfMatch != "" {
+		r.Header.Set("If-Match", headers.IfMatch)
+	}
+	if headers.IdempotencyKey != "" {
+		r.Header.Set("Idempotency-Key", headers.IdempotencyKey)
+	}
+	d.handler.RestoreSemanticAttribute(w, r)
 }
 func (d *APIGenDispatcher) ListAuditEvents(w stdhttp.ResponseWriter, r *stdhttp.Request, _, _ string, _ accessgen.GenListAuditEventsParams) {
 	d.handler.ListAuditEvents(w, r)

--- a/internal/access/http/semantic_attribute_definitions.go
+++ b/internal/access/http/semantic_attribute_definitions.go
@@ -18,6 +18,21 @@ func (h Handler) ListSemanticAttributeDefinitions(w stdhttp.ResponseWriter, r *s
 	if !h.requirePlatformAdmin(w, r) {
 		return
 	}
+	owner := strings.TrimSpace(r.URL.Query().Get("ownerKind"))
+	if owner != "" && !access.SemanticAttributeOwnerKind(owner).Valid() {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(errors.New("ownerKind is invalid")))
+		return
+	}
+	limit, err := parseAPILimitQuery(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusBadRequest)
+		return
+	}
+	afterName, afterDefinitionID, err := semanticAttributePageCursor(r.URL.Query().Get("pageToken"))
+	if err != nil {
+		writeJSONError(w, err, stdhttp.StatusBadRequest)
+		return
+	}
 	repo, err := h.repository()
 	if err != nil {
 		writeSemanticAttributeError(w, err)
@@ -28,23 +43,40 @@ func (h Handler) ListSemanticAttributeDefinitions(w stdhttp.ResponseWriter, r *s
 		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
 		return
 	}
-	rows, err := registry.SearchSemanticAttributes(r.Context(), access.SemanticAttributeSearch{Query: strings.TrimSpace(r.URL.Query().Get("q")), Limit: 200})
+	rows, err := registry.SearchSemanticAttributes(r.Context(), access.SemanticAttributeSearch{
+		Query: strings.TrimSpace(r.URL.Query().Get("q")), OwnerKind: access.SemanticAttributeOwnerKind(owner),
+		AfterName: afterName, AfterDefinitionID: afterDefinitionID, Limit: limit + 1,
+	})
 	if err != nil {
 		writeSemanticAttributeError(w, err)
 		return
 	}
-	owner := strings.TrimSpace(r.URL.Query().Get("ownerKind"))
-	if owner != "" && !access.SemanticAttributeOwnerKind(owner).Valid() {
-		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(errors.New("ownerKind is invalid")))
-		return
+	nextCursor := ""
+	if len(rows) > limit {
+		last := rows[limit-1]
+		nextCursor = encodeKeyCursor(last.Name + "\x00" + last.ID)
+		rows = rows[:limit]
 	}
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
-		if owner == "" || string(row.Metadata.Owner.Kind) == owner {
-			items = append(items, semanticAttributeDefinitionDTO(row))
-		}
+		items = append(items, semanticAttributeDefinitionDTO(row))
 	}
-	_ = writePagedJSON(w, r, items)
+	writeJSON(w, stdhttp.StatusOK, map[string]any{"items": items, "page": map[string]any{"nextCursor": nextCursor}})
+}
+
+func semanticAttributePageCursor(token string) (string, string, error) {
+	if strings.TrimSpace(token) == "" {
+		return "", "", nil
+	}
+	cursor, err := decodeKeyCursor(token)
+	if err != nil {
+		return "", "", err
+	}
+	name, definitionID, ok := strings.Cut(cursor, "\x00")
+	if !ok || strings.TrimSpace(name) == "" || strings.TrimSpace(definitionID) == "" {
+		return "", "", errors.New("pageToken is invalid")
+	}
+	return name, definitionID, nil
 }
 
 func (h Handler) GetSemanticAttributeDefinition(w stdhttp.ResponseWriter, r *stdhttp.Request) {

--- a/internal/access/http/semantic_attribute_definitions.go
+++ b/internal/access/http/semantic_attribute_definitions.go
@@ -3,6 +3,7 @@ package http
 import (
 	"errors"
 	stdhttp "net/http"
+	"net/url"
 	"strings"
 
 	"github.com/flidai/leapview/internal/access"
@@ -113,7 +114,7 @@ func (h Handler) RegisterSemanticAttribute(w stdhttp.ResponseWriter, r *stdhttp.
 		writeSemanticAttributeError(w, err)
 		return
 	}
-	w.Header().Set("Location", "/semantic-attributes/"+row.Name)
+	w.Header().Set("Location", "/api/v1/semantic-attributes/"+url.PathEscape(row.Name))
 	w.Header().Set("ETag", semanticAttributeDefinitionETag(row))
 	writeJSON(w, stdhttp.StatusCreated, semanticAttributeDefinitionDTO(row))
 }

--- a/internal/access/http/semantic_attribute_definitions.go
+++ b/internal/access/http/semantic_attribute_definitions.go
@@ -1,0 +1,223 @@
+package http
+
+import (
+	"errors"
+	stdhttp "net/http"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access"
+	accessgen "github.com/flidai/leapview/internal/access/api/gen"
+	"github.com/go-chi/chi/v5"
+)
+
+// Definition mutations must use this boundary so the expected version is
+// checked in the same transaction as the write. Falling back to a read-then-
+// write adapter would make If-Match vulnerable to a race.
+func (h Handler) ListSemanticAttributeDefinitions(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, ok := repo.(access.SemanticAttributeRegistry)
+	if !ok {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	rows, err := registry.SearchSemanticAttributes(r.Context(), access.SemanticAttributeSearch{Query: strings.TrimSpace(r.URL.Query().Get("q")), Limit: 200})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	owner := strings.TrimSpace(r.URL.Query().Get("ownerKind"))
+	if owner != "" && !access.SemanticAttributeOwnerKind(owner).Valid() {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(errors.New("ownerKind is invalid")))
+		return
+	}
+	items := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		if owner == "" || string(row.Metadata.Owner.Kind) == owner {
+			items = append(items, semanticAttributeDefinitionDTO(row))
+		}
+	}
+	_ = writePagedJSON(w, r, items)
+}
+
+func (h Handler) GetSemanticAttributeDefinition(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, ok := repo.(access.SemanticAttributeRegistry)
+	if !ok {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	row, err := registry.SemanticAttributeDefinition(r.Context(), chi.URLParam(r, "attribute"))
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	w.Header().Set("ETag", semanticAttributeDefinitionETag(row))
+	writeJSON(w, stdhttp.StatusOK, semanticAttributeDefinitionDTO(row))
+}
+
+func (h Handler) RegisterSemanticAttribute(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	var input semanticAttributeRegisterWire
+	if err := decodeStrictJSON(r, &input); err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	typeName, err := semanticAttributeType(input.Type)
+	if err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	shape, err := semanticAttributeShape(input.Shape)
+	if err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	metadata, err := semanticAttributeMetadata(input.Metadata)
+	if err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, ok := repo.(access.SemanticAttributeRegistry)
+	if !ok {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	var row access.SemanticAttributeDefinition
+	err = executeSemanticAttributeMutation(r, repo, accessgen.GenCommandOperationRegisterSemanticAttribute(), func() error {
+		var callErr error
+		row, callErr = registry.RegisterSemanticAttribute(r.Context(), access.RegisterSemanticAttributeInput{Name: input.Name, Type: typeName, Shape: shape, Metadata: metadata, Mutation: h.semanticAttributeMutationContext(r)})
+		return callErr
+	})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	w.Header().Set("Location", "/semantic-attributes/"+row.Name)
+	w.Header().Set("ETag", semanticAttributeDefinitionETag(row))
+	writeJSON(w, stdhttp.StatusCreated, semanticAttributeDefinitionDTO(row))
+}
+
+func (h Handler) UpdateSemanticAttributeMetadata(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	var input semanticAttributeMetadataWire
+	if err := decodeStrictJSON(r, &input); err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	metadata, err := semanticAttributeMetadata(input)
+	if err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, ok := repo.(access.SemanticAttributeRegistry)
+	if !ok {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	versioned, versionedOK := repo.(access.VersionedSemanticAttributeRegistry)
+	if !versionedOK {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	name := chi.URLParam(r, "attribute")
+	current, err := registry.SemanticAttributeDefinition(r.Context(), name)
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	if err := checkIfMatch(r.Header.Get("If-Match"), semanticAttributeDefinitionETag(current)); err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	var row access.SemanticAttributeDefinition
+	err = executeSemanticAttributeMutation(r, repo, accessgen.GenCommandOperationUpdateSemanticAttributeMetadata(), func() error {
+		var callErr error
+		input := access.UpdateSemanticAttributeMetadataInput{Name: name, Metadata: metadata, ExpectedVersion: current.DefinitionVersion, Mutation: h.semanticAttributeMutationContext(r)}
+		row, callErr = versioned.UpdateSemanticAttributeMetadataExpected(r.Context(), input)
+		return callErr
+	})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	w.Header().Set("ETag", semanticAttributeDefinitionETag(row))
+	writeJSON(w, stdhttp.StatusOK, semanticAttributeDefinitionDTO(row))
+}
+
+func (h Handler) DisableSemanticAttribute(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.setSemanticAttributeEnabled(w, r, false, accessgen.GenCommandOperationDisableSemanticAttribute())
+}
+func (h Handler) RestoreSemanticAttribute(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.setSemanticAttributeEnabled(w, r, true, accessgen.GenCommandOperationRestoreSemanticAttribute())
+}
+
+func (h Handler) setSemanticAttributeEnabled(w stdhttp.ResponseWriter, r *stdhttp.Request, enabled bool, operation accessgen.GenCommandOperationID) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, ok := repo.(access.SemanticAttributeRegistry)
+	if !ok {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	versioned, versionedOK := repo.(access.VersionedSemanticAttributeRegistry)
+	if !versionedOK {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	name := chi.URLParam(r, "attribute")
+	current, err := registry.SemanticAttributeDefinition(r.Context(), name)
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	if err := checkIfMatch(r.Header.Get("If-Match"), semanticAttributeDefinitionETag(current)); err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	var row access.SemanticAttributeDefinition
+	err = executeSemanticAttributeMutation(r, repo, operation, func() error {
+		var callErr error
+		row, callErr = versioned.SetSemanticAttributeEnabledExpected(r.Context(), name, enabled, current.DefinitionVersion, h.semanticAttributeMutationContext(r))
+		return callErr
+	})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	w.Header().Set("ETag", semanticAttributeDefinitionETag(row))
+	writeJSON(w, stdhttp.StatusOK, semanticAttributeDefinitionDTO(row))
+}

--- a/internal/access/http/semantic_attribute_handler.go
+++ b/internal/access/http/semantic_attribute_handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	stdhttp "net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -379,33 +380,47 @@ func (h Handler) PreviewSemanticAttributeImpact(w stdhttp.ResponseWriter, r *std
 		writeSemanticAttributeError(w, err)
 		return
 	}
-	if _, err := semanticAttributeValues(definition, input.Values); err != nil {
-		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+	if input.Values == nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(errors.New("values is required")))
 		return
 	}
-	rows, err := reader.SemanticAttributeAssignments(r.Context(), access.SemanticAttributeAssignmentFilter{DefinitionID: definition.ID})
-	if err != nil {
+	var requestedValues []string
+	if len(input.Values) > 0 {
+		decodedValues, err := semanticAttributeValues(definition, input.Values)
+		if err != nil {
+			writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+			return
+		}
+		requestedValues, _, err = access.CanonicalSemanticAttributeValues(definition, decodedValues)
+		if err != nil {
+			writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+			return
+		}
+	}
+	current, err := findSemanticAttributeAssignment(r, reader, definition.ID, subject)
+	if err != nil && !errors.Is(err, errSemanticAttributeAssignmentMissing) {
 		writeSemanticAttributeError(w, err)
 		return
 	}
+	changed := current.ID != ""
+	if len(input.Values) > 0 {
+		changed = current.ID == "" || !slices.Equal(current.CanonicalValues, requestedValues)
+	}
 	principalCount, groupCount := int32(0), int32(0)
-	for _, row := range rows {
-		if row.Tombstoned {
-			continue
-		}
-		if row.Subject.Kind == access.SubjectKindPrincipal {
-			principalCount++
-		}
-		if row.Subject.Kind == access.SubjectKindGroup {
-			groupCount++
+	if changed {
+		if subject.Kind == access.SubjectKindPrincipal {
+			principalCount = 1
+		} else {
+			groupCount = 1
 		}
 	}
 	warnings := []string{}
-	if subject.Kind == access.SubjectKindPrincipal && principalCount == 0 {
-		warnings = append(warnings, "no active assignments are currently affected")
-	}
-	if subject.Kind == access.SubjectKindGroup && groupCount == 0 {
-		warnings = append(warnings, "no active assignments are currently affected")
+	if !changed {
+		if current.ID == "" {
+			warnings = append(warnings, "no active assignments are currently affected")
+		} else {
+			warnings = append(warnings, "requested assignment is already in the requested state")
+		}
 	}
 	writeJSON(w, stdhttp.StatusOK, map[string]any{"attributeName": name, "targetKind": string(kind), "targetId": subject.ID, "affectedPrincipalCount": principalCount, "affectedGroupCount": groupCount, "warnings": warnings})
 }
@@ -428,10 +443,25 @@ func (h Handler) semanticAttributeMutationContext(r *stdhttp.Request) access.Sem
 	return access.SemanticAttributeMutationContext{ActorPrincipalID: h.currentPrincipalID(r), RequestID: requestIDFromRequest(r), CorrelationID: correlationIDFromRequest(r)}
 }
 
+var semanticAttributeOperationAuditActions = map[string]string{
+	"registerSemanticAttribute":                  access.SemanticAttributeAuditActionRegister,
+	"updateSemanticAttributeMetadata":            access.SemanticAttributeAuditActionMetadataUpdate,
+	"disableSemanticAttribute":                   access.SemanticAttributeAuditActionDisable,
+	"restoreSemanticAttribute":                   access.SemanticAttributeAuditActionEnable,
+	"upsertPrincipalSemanticAttributeAssignment": access.SemanticAttributeAuditActionAssignmentSet,
+	"removePrincipalSemanticAttributeAssignment": access.SemanticAttributeAuditActionAssignmentTombstone,
+	"upsertGroupSemanticAttributeAssignment":     access.SemanticAttributeAuditActionAssignmentSet,
+	"removeGroupSemanticAttributeAssignment":     access.SemanticAttributeAuditActionAssignmentTombstone,
+	"upsertSemanticAttributeClaimMapping":        access.SemanticAttributeAuditActionClaimMappingSet,
+	"removeSemanticAttributeClaimMapping":        access.SemanticAttributeAuditActionClaimMappingTombstone,
+}
+
 // Domain semantic-control methods own their audit transaction. The executor
 // wrapper is still required for generated API invocations so the transport
 // command guard observes successful execution without opening a second
-// repository transaction around an already transactional domain call.
+// repository transaction around an already transactional domain call. The
+// contract action is checked here so a TypeSpec drift cannot silently report a
+// different event than the repository appends.
 func executeSemanticAttributeMutation(r *stdhttp.Request, repo access.Repository, operation accessgen.GenCommandOperationID, mutation func() error) error {
 	if _, generated := apigencommand.OperationID(r.Context()); !generated {
 		return mutation()
@@ -441,7 +471,12 @@ func executeSemanticAttributeMutation(r *stdhttp.Request, repo access.Repository
 		return err
 	}
 	return executor.Execute(r.Context(), operation.APIGenOperationID(), apigencommand.Execution{
-		Transactional: func(context.Context, apigencommand.Contract) error { return mutation() },
+		Transactional: func(_ context.Context, contract apigencommand.Contract) error {
+			if durableAction := semanticAttributeOperationAuditActions[operation.APIGenOperationID()]; durableAction != "" && contract.AuditAction != durableAction {
+				return fmt.Errorf("generated audit action %q does not match semantic attribute durable action %q", contract.AuditAction, durableAction)
+			}
+			return mutation()
+		},
 	})
 }
 

--- a/internal/access/http/semantic_attribute_handler.go
+++ b/internal/access/http/semantic_attribute_handler.go
@@ -1,0 +1,707 @@
+package http
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	stdhttp "net/http"
+	"strconv"
+	"strings"
+
+	apigencommand "github.com/Yacobolo/toolbelt/apigen/runtime/command"
+	"github.com/flidai/leapview/internal/access"
+	accessgen "github.com/flidai/leapview/internal/access/api/gen"
+	"github.com/flidai/leapview/internal/semanticvalue"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+)
+
+func (h Handler) ListPrincipalSemanticAttributeAssignments(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.listSemanticAttributeAssignments(w, r, access.SubjectKindPrincipal)
+}
+
+func (h Handler) ListGroupSemanticAttributeAssignments(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.listSemanticAttributeAssignments(w, r, access.SubjectKindGroup)
+}
+
+func (h Handler) listSemanticAttributeAssignments(w stdhttp.ResponseWriter, r *stdhttp.Request, kind access.SubjectKind) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	reader, ok := repo.(access.SemanticAttributeAssignmentReader)
+	if !ok {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	subject, err := access.NewSubjectRef(kind, firstNonEmpty(chi.URLParam(r, string(kind))))
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	rows, err := reader.SemanticAttributeAssignments(r.Context(), access.SemanticAttributeAssignmentFilter{Subject: subject})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	items := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		if row.Tombstoned {
+			continue
+		}
+		items = append(items, semanticAttributeAssignmentDTO(row))
+	}
+	_ = writePagedJSON(w, r, items)
+}
+
+func (h Handler) UpsertPrincipalSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.upsertSemanticAttributeAssignment(w, r, access.SubjectKindPrincipal, accessgen.GenCommandOperationUpsertPrincipalSemanticAttributeAssignment())
+}
+
+func (h Handler) UpsertGroupSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.upsertSemanticAttributeAssignment(w, r, access.SubjectKindGroup, accessgen.GenCommandOperationUpsertGroupSemanticAttributeAssignment())
+}
+
+func (h Handler) upsertSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request, kind access.SubjectKind, operation accessgen.GenCommandOperationID) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	var input semanticAttributeAssignmentWire
+	if err := decodeStrictJSON(r, &input); err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, registryOK := repo.(access.SemanticAttributeRegistry)
+	reader, readerOK := repo.(access.SemanticAttributeAssignmentReader)
+	writer, writerOK := repo.(access.SemanticAttributeAssignmentWriter)
+	if !registryOK || !readerOK || !writerOK {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	name := chi.URLParam(r, "attribute")
+	definition, err := registry.SemanticAttributeDefinition(r.Context(), name)
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	values, err := semanticAttributeValues(definition, input.Values)
+	if err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	subject, err := access.NewSubjectRef(kind, chi.URLParam(r, string(kind)))
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	current, err := findSemanticAttributeAssignment(r, reader, definition.ID, subject)
+	if err != nil && !errors.Is(err, errSemanticAttributeAssignmentMissing) {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	if err := checkIfMatch(r.Header.Get("If-Match"), semanticAttributeAssignmentETag(current)); err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	var row access.SemanticAttributeAssignment
+	err = executeSemanticAttributeMutation(r, repo, operation, func() error {
+		var callErr error
+		row, callErr = writer.SetSemanticAttributeAssignment(r.Context(), access.SemanticAttributeAssignmentInput{
+			AssignmentID: current.ID, DefinitionID: definition.ID, DefinitionName: definition.Name,
+			Subject: subject, Values: values, ExpectedVersion: current.AssignmentVersion,
+			Mutation: h.semanticAttributeMutationContext(r),
+		})
+		return callErr
+	})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	w.Header().Set("ETag", semanticAttributeAssignmentETag(row))
+	writeJSON(w, stdhttp.StatusOK, semanticAttributeAssignmentDTO(row))
+}
+
+func (h Handler) RemovePrincipalSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.removeSemanticAttributeAssignment(w, r, access.SubjectKindPrincipal, accessgen.GenCommandOperationRemovePrincipalSemanticAttributeAssignment())
+}
+
+func (h Handler) RemoveGroupSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	h.removeSemanticAttributeAssignment(w, r, access.SubjectKindGroup, accessgen.GenCommandOperationRemoveGroupSemanticAttributeAssignment())
+}
+
+func (h Handler) removeSemanticAttributeAssignment(w stdhttp.ResponseWriter, r *stdhttp.Request, kind access.SubjectKind, operation accessgen.GenCommandOperationID) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, registryOK := repo.(access.SemanticAttributeRegistry)
+	reader, readerOK := repo.(access.SemanticAttributeAssignmentReader)
+	writer, writerOK := repo.(access.SemanticAttributeAssignmentWriter)
+	if !registryOK || !readerOK || !writerOK {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	definition, err := registry.SemanticAttributeDefinition(r.Context(), chi.URLParam(r, "attribute"))
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	subject, err := access.NewSubjectRef(kind, chi.URLParam(r, string(kind)))
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	current, err := findSemanticAttributeAssignment(r, reader, definition.ID, subject)
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	if err := checkIfMatch(r.Header.Get("If-Match"), semanticAttributeAssignmentETag(current)); err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	err = executeSemanticAttributeMutation(r, repo, operation, func() error {
+		_, callErr := writer.TombstoneSemanticAttributeAssignment(r.Context(), current.ID, current.AssignmentVersion, h.semanticAttributeMutationContext(r))
+		return callErr
+	})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	w.WriteHeader(stdhttp.StatusNoContent)
+}
+
+func (h Handler) ListSemanticAttributeClaimMappings(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, registryOK := repo.(access.SemanticAttributeRegistry)
+	reader, readerOK := repo.(access.TrustedClaimMappingReader)
+	if !registryOK || !readerOK {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	definition, err := registry.SemanticAttributeDefinition(r.Context(), chi.URLParam(r, "attribute"))
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	rows, err := reader.TrustedClaimMappings(r.Context(), access.TrustedClaimMappingFilter{})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	items := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		if row.DefinitionID == definition.ID && !row.Tombstoned {
+			items = append(items, semanticAttributeClaimMappingDTO(row))
+		}
+	}
+	_ = writePagedJSON(w, r, items)
+}
+
+func (h Handler) UpsertSemanticAttributeClaimMapping(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	var input semanticAttributeClaimMappingWire
+	if err := decodeStrictJSON(r, &input); err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	sourceKind, err := semanticAttributeClaimSourceKind(input.SourceKind)
+	if err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	if strings.TrimSpace(input.Provider) == "" || strings.TrimSpace(input.Issuer) == "" || strings.TrimSpace(input.Audience) == "" || strings.TrimSpace(input.Claim) == "" {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(errors.New("provider, issuer, audience, and claim are required")))
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, registryOK := repo.(access.SemanticAttributeRegistry)
+	reader, readerOK := repo.(access.TrustedClaimMappingReader)
+	writer, writerOK := repo.(access.TrustedClaimMappingWriter)
+	if !registryOK || !readerOK || !writerOK {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	definition, err := registry.SemanticAttributeDefinition(r.Context(), chi.URLParam(r, "attribute"))
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	source := access.TrustedClaimMappingFilter{SourceKind: sourceKind, Provider: input.Provider, Issuer: input.Issuer, Audience: input.Audience, Claim: input.Claim}
+	rows, err := reader.TrustedClaimMappings(r.Context(), source)
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	var current access.TrustedClaimMapping
+	for _, candidate := range rows {
+		if candidate.DefinitionID == definition.ID && !candidate.Tombstoned {
+			current = candidate
+			break
+		}
+	}
+	if err := checkIfMatch(r.Header.Get("If-Match"), semanticAttributeMappingETag(current)); err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	var row access.TrustedClaimMapping
+	err = executeSemanticAttributeMutation(r, repo, accessgen.GenCommandOperationUpsertSemanticAttributeClaimMapping(), func() error {
+		var callErr error
+		row, callErr = writer.SetTrustedClaimMapping(r.Context(), access.TrustedClaimMappingInput{
+			MappingID: current.ID, SourceKind: sourceKind, Provider: input.Provider,
+			Issuer: source.Issuer, Audience: source.Audience, Claim: input.Claim,
+			DefinitionID: definition.ID, DefinitionName: definition.Name, ExpectedVersion: current.MappingVersion,
+			Mutation: h.semanticAttributeMutationContext(r),
+		})
+		return callErr
+	})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	w.Header().Set("ETag", semanticAttributeMappingETag(row))
+	writeJSON(w, stdhttp.StatusOK, semanticAttributeClaimMappingDTO(row))
+}
+
+func (h Handler) RemoveSemanticAttributeClaimMapping(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, registryOK := repo.(access.SemanticAttributeRegistry)
+	reader, readerOK := repo.(access.TrustedClaimMappingReader)
+	writer, writerOK := repo.(access.TrustedClaimMappingWriter)
+	if !registryOK || !readerOK || !writerOK {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	definition, err := registry.SemanticAttributeDefinition(r.Context(), chi.URLParam(r, "attribute"))
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	rows, err := reader.TrustedClaimMappings(r.Context(), access.TrustedClaimMappingFilter{IncludeTombstones: true})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	mappingID := chi.URLParam(r, "mapping")
+	var current access.TrustedClaimMapping
+	for _, candidate := range rows {
+		if candidate.ID == mappingID && candidate.DefinitionID == definition.ID && !candidate.Tombstoned {
+			current = candidate
+			break
+		}
+	}
+	if current.ID == "" {
+		writeSemanticAttributeError(w, errSemanticAttributeMappingMissing)
+		return
+	}
+	if err := checkIfMatch(r.Header.Get("If-Match"), semanticAttributeMappingETag(current)); err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	err = executeSemanticAttributeMutation(r, repo, accessgen.GenCommandOperationRemoveSemanticAttributeClaimMapping(), func() error {
+		_, callErr := writer.TombstoneTrustedClaimMapping(r.Context(), current.ID, current.MappingVersion, h.semanticAttributeMutationContext(r))
+		return callErr
+	})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	w.WriteHeader(stdhttp.StatusNoContent)
+}
+
+func (h Handler) PreviewSemanticAttributeImpact(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if !h.requirePlatformAdmin(w, r) {
+		return
+	}
+	var input semanticAttributeImpactWire
+	if err := decodeStrictJSON(r, &input); err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	kind, err := semanticAttributeSubjectKind(input.TargetKind)
+	if err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	subject, err := access.NewSubjectRef(kind, input.TargetID)
+	if err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	repo, err := h.repository()
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	registry, registryOK := repo.(access.SemanticAttributeRegistry)
+	reader, readerOK := repo.(access.SemanticAttributeAssignmentReader)
+	if !registryOK || !readerOK {
+		writeSemanticAttributeError(w, errSemanticAttributeUnavailable)
+		return
+	}
+	name := chi.URLParam(r, "attribute")
+	definition, err := registry.SemanticAttributeDefinition(r.Context(), name)
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	if _, err := semanticAttributeValues(definition, input.Values); err != nil {
+		writeSemanticAttributeError(w, invalidSemanticAttributeRequest(err))
+		return
+	}
+	rows, err := reader.SemanticAttributeAssignments(r.Context(), access.SemanticAttributeAssignmentFilter{DefinitionID: definition.ID})
+	if err != nil {
+		writeSemanticAttributeError(w, err)
+		return
+	}
+	principalCount, groupCount := int32(0), int32(0)
+	for _, row := range rows {
+		if row.Tombstoned {
+			continue
+		}
+		if row.Subject.Kind == access.SubjectKindPrincipal {
+			principalCount++
+		}
+		if row.Subject.Kind == access.SubjectKindGroup {
+			groupCount++
+		}
+	}
+	warnings := []string{}
+	if subject.Kind == access.SubjectKindPrincipal && principalCount == 0 {
+		warnings = append(warnings, "no active assignments are currently affected")
+	}
+	if subject.Kind == access.SubjectKindGroup && groupCount == 0 {
+		warnings = append(warnings, "no active assignments are currently affected")
+	}
+	writeJSON(w, stdhttp.StatusOK, map[string]any{"attributeName": name, "targetKind": string(kind), "targetId": subject.ID, "affectedPrincipalCount": principalCount, "affectedGroupCount": groupCount, "warnings": warnings})
+}
+
+var (
+	errSemanticAttributeUnavailable       = errors.New("semantic attribute control is unavailable")
+	errSemanticAttributeAssignmentMissing = errors.New("semantic attribute assignment was not found")
+	errSemanticAttributeMappingMissing    = errors.New("semantic attribute claim mapping was not found")
+	errSemanticAttributeInvalid           = errors.New("invalid semantic attribute request")
+)
+
+func invalidSemanticAttributeRequest(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %v", errSemanticAttributeInvalid, err)
+}
+
+func (h Handler) semanticAttributeMutationContext(r *stdhttp.Request) access.SemanticAttributeMutationContext {
+	return access.SemanticAttributeMutationContext{ActorPrincipalID: h.currentPrincipalID(r), RequestID: requestIDFromRequest(r), CorrelationID: correlationIDFromRequest(r)}
+}
+
+// Domain semantic-control methods own their audit transaction. The executor
+// wrapper is still required for generated API invocations so the transport
+// command guard observes successful execution without opening a second
+// repository transaction around an already transactional domain call.
+func executeSemanticAttributeMutation(r *stdhttp.Request, repo access.Repository, operation accessgen.GenCommandOperationID, mutation func() error) error {
+	if _, generated := apigencommand.OperationID(r.Context()); !generated {
+		return mutation()
+	}
+	executor, err := apigencommand.NewExecutor(accessgen.GetAPIGenCommandRuntimeContract, nil)
+	if err != nil {
+		return err
+	}
+	return executor.Execute(r.Context(), operation.APIGenOperationID(), apigencommand.Execution{
+		Transactional: func(context.Context, apigencommand.Contract) error { return mutation() },
+	})
+}
+
+func semanticAttributeType(value string) (semanticvalue.Type, error) {
+	typeName := semanticvalue.Type(value)
+	switch typeName {
+	case semanticvalue.TypeString, semanticvalue.TypeBoolean, semanticvalue.TypeInteger, semanticvalue.TypeDecimal, semanticvalue.TypeDate, semanticvalue.TypeTimestamp:
+		return typeName, nil
+	}
+	return "", errors.New("unsupported semantic attribute value type")
+}
+
+func semanticAttributeShape(value string) (access.SemanticAttributeShape, error) {
+	shape := access.SemanticAttributeShape(value)
+	if !shape.Valid() {
+		return "", errors.New("unsupported semantic attribute value shape")
+	}
+	return shape, nil
+}
+
+func semanticAttributeMetadata(input semanticAttributeMetadataWire) (access.SemanticAttributeMetadata, error) {
+	kind := access.SemanticAttributeOwnerKind(input.OwnerKind)
+	if !kind.Valid() {
+		return access.SemanticAttributeMetadata{}, errors.New("unsupported semantic attribute owner kind")
+	}
+	id := ""
+	if input.OwnerID != nil {
+		id = strings.TrimSpace(*input.OwnerID)
+	}
+	if kind != access.SemanticAttributeOwnerInstance && id == "" {
+		return access.SemanticAttributeMetadata{}, errors.New("ownerId is required for principal and group owners")
+	}
+	if kind == access.SemanticAttributeOwnerInstance && id != "" {
+		return access.SemanticAttributeMetadata{}, errors.New("instance ownerId must be omitted")
+	}
+	documentation := ""
+	if input.DocumentationURL != nil {
+		documentation = *input.DocumentationURL
+	}
+	return access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: kind, ID: id}, DisplayName: input.DisplayName, Description: input.Description, DocumentationURL: documentation}, nil
+}
+
+func semanticAttributeSubjectKind(value string) (access.SubjectKind, error) {
+	kind := access.SubjectKind(value)
+	if kind != access.SubjectKindPrincipal && kind != access.SubjectKindGroup {
+		return "", errors.New("targetKind must be principal or group")
+	}
+	return kind, nil
+}
+
+func semanticAttributeClaimSourceKind(value string) (access.TrustedClaimSourceKind, error) {
+	kind := access.TrustedClaimSourceKind(value)
+	if !kind.Valid() {
+		return "", errors.New("unsupported semantic attribute claim source kind")
+	}
+	return kind, nil
+}
+
+func semanticAttributeValues(definition access.SemanticAttributeDefinition, values []semanticAttributeValueWire) (any, error) {
+	if len(values) == 0 {
+		return nil, errors.New("values must contain at least one item")
+	}
+	decoded := make([]any, len(values))
+	for i, value := range values {
+		item, err := semanticAttributeValue(definition.Type, value)
+		if err != nil {
+			return nil, fmt.Errorf("values[%d]: %w", i, err)
+		}
+		decoded[i] = item
+	}
+	if definition.Shape == access.SemanticAttributeScalar {
+		if len(decoded) != 1 {
+			return nil, errors.New("scalar attributes require exactly one value")
+		}
+		return decoded[0], nil
+	}
+	return decoded, nil
+}
+
+func semanticAttributeValue(expected semanticvalue.Type, value semanticAttributeValueWire) (any, error) {
+	got, err := semanticAttributeType(value.Type)
+	if err != nil || got != expected {
+		return nil, errors.New("value type does not match the registered attribute type")
+	}
+	set := 0
+	if value.StringValue != nil {
+		set++
+	}
+	if value.BooleanValue != nil {
+		set++
+	}
+	if value.IntegerValue != nil {
+		set++
+	}
+	if value.DecimalValue != nil {
+		set++
+	}
+	if value.DateValue != nil {
+		set++
+	}
+	if value.TimestampValue != nil {
+		set++
+	}
+	if set != 1 {
+		return nil, errors.New("exactly one typed value field is required")
+	}
+	switch expected {
+	case semanticvalue.TypeString:
+		if value.StringValue == nil {
+			return nil, errors.New("stringValue is required")
+		}
+		return *value.StringValue, nil
+	case semanticvalue.TypeBoolean:
+		if value.BooleanValue == nil {
+			return nil, errors.New("booleanValue is required")
+		}
+		return *value.BooleanValue, nil
+	case semanticvalue.TypeInteger:
+		if value.IntegerValue == nil {
+			return nil, errors.New("integerValue is required")
+		}
+		n, err := strconv.ParseInt(*value.IntegerValue, 10, 64)
+		if err != nil {
+			return nil, errors.New("integerValue is invalid")
+		}
+		return n, nil
+	case semanticvalue.TypeDecimal:
+		if value.DecimalValue == nil {
+			return nil, errors.New("decimalValue is required")
+		}
+		return *value.DecimalValue, nil
+	case semanticvalue.TypeDate:
+		if value.DateValue == nil {
+			return nil, errors.New("dateValue is required")
+		}
+		return *value.DateValue, nil
+	case semanticvalue.TypeTimestamp:
+		if value.TimestampValue == nil {
+			return nil, errors.New("timestampValue is required")
+		}
+		return *value.TimestampValue, nil
+	default:
+		return nil, errors.New("unsupported semantic attribute value type")
+	}
+}
+
+func findSemanticAttributeAssignment(r *stdhttp.Request, reader access.SemanticAttributeAssignmentReader, definitionID string, subject access.SubjectRef) (access.SemanticAttributeAssignment, error) {
+	rows, err := reader.SemanticAttributeAssignments(r.Context(), access.SemanticAttributeAssignmentFilter{DefinitionID: definitionID, Subject: subject})
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, err
+	}
+	for _, row := range rows {
+		if !row.Tombstoned {
+			return row, nil
+		}
+	}
+	return access.SemanticAttributeAssignment{}, errSemanticAttributeAssignmentMissing
+}
+
+func semanticAttributeDefinitionDTO(row access.SemanticAttributeDefinition) map[string]any {
+	return map[string]any{"id": row.ID, "name": row.Name, "type": string(row.Type), "shape": string(row.Shape), "profile": row.Profile, "definitionVersion": row.DefinitionVersion, "ownerKind": string(row.Metadata.Owner.Kind), "ownerId": emptyToNil(row.Metadata.Owner.ID), "displayName": row.Metadata.DisplayName, "description": row.Metadata.Description, "documentationUrl": emptyToNil(row.Metadata.DocumentationURL), "lifecycleState": string(row.LifecycleState), "createdAt": row.CreatedAt, "updatedAt": row.UpdatedAt, "disabledAt": emptyToNil(row.DisabledAt)}
+}
+
+func semanticAttributeAssignmentDTO(row access.SemanticAttributeAssignment) map[string]any {
+	values := make([]map[string]any, 0, len(row.CanonicalValues))
+	for _, canonical := range row.CanonicalValues {
+		values = append(values, semanticAttributeCanonicalValueDTO(row.Type, canonical))
+	}
+	lifecycle := "active"
+	if row.Tombstoned {
+		lifecycle = "tombstoned"
+	}
+	return map[string]any{"id": row.ID, "attributeName": row.DefinitionName, "targetKind": string(row.Subject.Kind), "targetId": row.Subject.ID, "values": values, "assignmentVersion": row.AssignmentVersion, "lifecycleState": lifecycle, "removedAt": emptyToNil(row.TombstonedAt), "createdAt": row.CreatedAt, "updatedAt": row.UpdatedAt}
+}
+
+func semanticAttributeCanonicalValueDTO(typeName semanticvalue.Type, canonical string) map[string]any {
+	result := map[string]any{"type": string(typeName)}
+	switch typeName {
+	case semanticvalue.TypeString:
+		result["stringValue"] = canonical
+	case semanticvalue.TypeBoolean:
+		result["booleanValue"] = canonical == "true"
+	case semanticvalue.TypeInteger:
+		result["integerValue"] = canonical
+	case semanticvalue.TypeDecimal:
+		result["decimalValue"] = canonical
+	case semanticvalue.TypeDate:
+		result["dateValue"] = canonical
+	case semanticvalue.TypeTimestamp:
+		result["timestampValue"] = canonical
+	}
+	return result
+}
+
+func semanticAttributeClaimMappingDTO(row access.TrustedClaimMapping) map[string]any {
+	lifecycle := "active"
+	if row.Tombstoned {
+		lifecycle = "tombstoned"
+	}
+	return map[string]any{"id": row.ID, "attributeName": row.DefinitionName, "sourceKind": string(row.SourceKind), "provider": row.Provider, "issuer": row.Issuer, "audience": row.Audience, "claim": row.Claim, "mappingVersion": row.MappingVersion, "lifecycleState": lifecycle, "removedAt": emptyToNil(row.TombstonedAt), "createdAt": row.CreatedAt, "updatedAt": row.UpdatedAt}
+}
+
+func semanticAttributeDefinitionETag(row access.SemanticAttributeDefinition) string {
+	return resourceETag(struct {
+		ID      string
+		Version int64
+	}{row.ID, row.DefinitionVersion})
+}
+func semanticAttributeAssignmentETag(row access.SemanticAttributeAssignment) string {
+	if row.ID == "" {
+		return ""
+	}
+	return resourceETag(struct {
+		ID      string
+		Version int64
+	}{row.ID, row.AssignmentVersion})
+}
+func semanticAttributeMappingETag(row access.TrustedClaimMapping) string {
+	if row.ID == "" {
+		return ""
+	}
+	return resourceETag(struct {
+		ID      string
+		Version int64
+	}{row.ID, row.MappingVersion})
+}
+
+func writeSemanticAttributeError(w stdhttp.ResponseWriter, err error) {
+	status := stdhttp.StatusInternalServerError
+	switch {
+	case errors.Is(err, errIfMatchRequired), errors.Is(err, errIfMatchFailed), errors.Is(err, apigencommand.ErrPreconditionFailed):
+		status = stdhttp.StatusPreconditionFailed
+	case errors.Is(err, sql.ErrNoRows), errors.Is(err, pgx.ErrNoRows), errors.Is(err, access.ErrSemanticAttributeNotFound), errors.Is(err, errSemanticAttributeAssignmentMissing), errors.Is(err, errSemanticAttributeMappingMissing):
+		status = stdhttp.StatusNotFound
+	case errors.Is(err, access.ErrSemanticAttributeConflict), errors.Is(err, access.ErrSemanticAttributeAssignmentConflict), errors.Is(err, access.ErrSemanticAttributeMappingConflict), errors.Is(err, access.ErrSemanticAttributeSourceConflict):
+		status = stdhttp.StatusConflict
+	case errors.Is(err, errSemanticAttributeUnavailable):
+		status = stdhttp.StatusServiceUnavailable
+	case errors.Is(err, access.ErrSemanticAttributeControlCorrupt):
+		status = stdhttp.StatusServiceUnavailable
+	case errors.Is(err, errSemanticAttributeInvalid), errors.Is(err, semanticvalue.ErrInvalidValue), errors.Is(err, semanticvalue.ErrInvalidType), errors.Is(err, access.ErrInvalidSubjectRef), errors.Is(err, access.ErrSemanticAttributeDisabled):
+		status = stdhttp.StatusBadRequest
+	default:
+		// Handler errors are intentionally not sent to clients: SQL and claim
+		// details can disclose durable identifiers or provider configuration.
+		writeJSONError(w, errors.New("internal server error"), status)
+		return
+	}
+	detail := "invalid semantic attribute request"
+	if status == stdhttp.StatusNotFound {
+		detail = "semantic attribute resource was not found"
+	}
+	if status == stdhttp.StatusConflict {
+		detail = "semantic attribute resource conflicts with current state"
+	}
+	if status == stdhttp.StatusPreconditionFailed {
+		detail = "resource changed; refresh and retry with its current ETag"
+	}
+	if status == stdhttp.StatusServiceUnavailable {
+		detail = "semantic attribute control is unavailable"
+	}
+	writeJSONError(w, errors.New(detail), status)
+}

--- a/internal/access/http/semantic_attribute_handler_test.go
+++ b/internal/access/http/semantic_attribute_handler_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -242,6 +243,82 @@ func TestSemanticAttributeHTTPRejectsMixedValuesAndInvalidOwner(t *testing.T) {
 	handler.RegisterSemanticAttribute(response, owner)
 	if response.Code != http.StatusBadRequest {
 		t.Fatalf("owner status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestSemanticAttributeHTTPRegisterLocationUsesCanonicalAPIPath(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	request := semanticAttributeRequest(http.MethodPost, "/api/v1/semantic-attributes", `{"name":"cost_center","type":"String","shape":"scalar","metadata":{"ownerKind":"instance","displayName":"Cost center","description":"Cost center"}}`)
+	response := httptest.NewRecorder()
+	semanticAttributeHTTPHandler(repo, true).RegisterSemanticAttribute(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("register status=%d body=%s", response.Code, response.Body.String())
+	}
+	if got := response.Header().Get("Location"); got != "/api/v1/semantic-attributes/cost_center" {
+		t.Fatalf("register Location=%q", got)
+	}
+}
+
+func TestSemanticAttributeHTTPPreviewUsesRequestedAssignmentDelta(t *testing.T) {
+	tests := []struct {
+		name            string
+		assignmentValue string
+		requestedValues string
+		targetKind      access.SubjectKind
+		targetID        string
+		principalCount  int32
+		groupCount      int32
+	}{
+		{name: "add", requestedValues: `[{"type":"String","stringValue":"us"}]`, principalCount: 1},
+		{name: "no-op", assignmentValue: "us", requestedValues: `[{"type":"String","stringValue":"us"}]`},
+		{name: "change", assignmentValue: "us", requestedValues: `[{"type":"String","stringValue":"eu"}]`, principalCount: 1},
+		{name: "remove", assignmentValue: "us", requestedValues: `[]`, principalCount: 1},
+		{name: "group change", assignmentValue: "us", requestedValues: `[{"type":"String","stringValue":"eu"}]`, targetKind: access.SubjectKindGroup, groupCount: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := semanticAttributeHTTPRepository()
+			targetKind, targetID := test.targetKind, test.targetID
+			if targetKind == "" {
+				targetKind = access.SubjectKindPrincipal
+			}
+			if targetID == "" {
+				targetID = string(targetKind) + "-1"
+			}
+			if test.assignmentValue != "" {
+				values, digest, err := access.CanonicalSemanticAttributeValues(repo.definition, test.assignmentValue)
+				if err != nil {
+					t.Fatal(err)
+				}
+				repo.assignment = access.SemanticAttributeAssignment{ID: "assignment-1", DefinitionID: repo.definition.ID, DefinitionName: repo.definition.Name, Subject: access.SubjectRef{Kind: targetKind, ID: targetID}, Type: repo.definition.Type, Shape: repo.definition.Shape, CanonicalValues: values, ValueDigest: digest, AssignmentVersion: 1}
+			}
+			request := semanticAttributeRequest(http.MethodPost, "/api/v1/semantic-attributes/region/impact-preview", `{"targetKind":"`+string(targetKind)+`","targetId":"`+targetID+`","values":`+test.requestedValues+`}`, "attribute", "region")
+			response := httptest.NewRecorder()
+			semanticAttributeHTTPHandler(repo, true).PreviewSemanticAttributeImpact(response, request)
+			if response.Code != http.StatusOK {
+				t.Fatalf("preview status=%d body=%s", response.Code, response.Body.String())
+			}
+			var body struct {
+				AffectedPrincipalCount int32 `json:"affectedPrincipalCount"`
+				AffectedGroupCount     int32 `json:"affectedGroupCount"`
+			}
+			if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.AffectedPrincipalCount != test.principalCount || body.AffectedGroupCount != test.groupCount {
+				t.Fatalf("preview counts = (%d, %d), want (%d, %d)", body.AffectedPrincipalCount, body.AffectedGroupCount, test.principalCount, test.groupCount)
+			}
+		})
+	}
+}
+
+func TestSemanticAttributeHTTPPreviewRequiresValues(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	request := semanticAttributeRequest(http.MethodPost, "/api/v1/semantic-attributes/region/impact-preview", `{"targetKind":"principal","targetId":"principal-1"}`, "attribute", "region")
+	response := httptest.NewRecorder()
+	semanticAttributeHTTPHandler(repo, true).PreviewSemanticAttributeImpact(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("preview omitted values status=%d body=%s", response.Code, response.Body.String())
 	}
 }
 

--- a/internal/access/http/semantic_attribute_handler_test.go
+++ b/internal/access/http/semantic_attribute_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -20,6 +21,8 @@ type semanticAttributeHTTPTestRepository struct {
 	access.Repository
 	admin       bool
 	definition  access.SemanticAttributeDefinition
+	definitions []access.SemanticAttributeDefinition
+	lastSearch  access.SemanticAttributeSearch
 	assignment  access.SemanticAttributeAssignment
 	mapping     access.TrustedClaimMapping
 	mappingErr  error
@@ -45,8 +48,26 @@ func (r *semanticAttributeHTTPTestRepository) SemanticAttributeDefinitionByID(_ 
 	}
 	return r.definition, nil
 }
-func (r *semanticAttributeHTTPTestRepository) SearchSemanticAttributes(context.Context, access.SemanticAttributeSearch) ([]access.SemanticAttributeDefinition, error) {
-	return []access.SemanticAttributeDefinition{r.definition}, nil
+func (r *semanticAttributeHTTPTestRepository) SearchSemanticAttributes(_ context.Context, filter access.SemanticAttributeSearch) ([]access.SemanticAttributeDefinition, error) {
+	r.lastSearch = filter
+	definitions := r.definitions
+	if len(definitions) == 0 {
+		definitions = []access.SemanticAttributeDefinition{r.definition}
+	}
+	filtered := make([]access.SemanticAttributeDefinition, 0, len(definitions))
+	for _, definition := range definitions {
+		if filter.OwnerKind != "" && definition.Metadata.Owner.Kind != filter.OwnerKind {
+			continue
+		}
+		if filter.AfterName != "" && (definition.Name < filter.AfterName || (definition.Name == filter.AfterName && definition.ID <= filter.AfterDefinitionID)) {
+			continue
+		}
+		filtered = append(filtered, definition)
+	}
+	if filter.Limit > 0 && len(filtered) > filter.Limit {
+		filtered = filtered[:filter.Limit]
+	}
+	return filtered, nil
 }
 func (r *semanticAttributeHTTPTestRepository) RegisterSemanticAttribute(_ context.Context, input access.RegisterSemanticAttributeInput) (access.SemanticAttributeDefinition, error) {
 	r.definition = access.SemanticAttributeDefinition{ID: "definition-2", Name: input.Name, Type: input.Type, Shape: input.Shape, Profile: semanticvalue.Profile, DefinitionVersion: 1, Metadata: input.Metadata, LifecycleState: access.SemanticAttributeActive, Enabled: true}
@@ -179,6 +200,87 @@ func semanticAttributeRequest(method, path, body string, params ...string) *http
 }
 func semanticAttributeHTTPRepository() *semanticAttributeHTTPTestRepository {
 	return &semanticAttributeHTTPTestRepository{admin: true, definition: access.SemanticAttributeDefinition{ID: "definition-1", Name: "region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Profile: semanticvalue.Profile, DefinitionVersion: 1, Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}, DisplayName: "Region", Description: "Region"}, LifecycleState: access.SemanticAttributeActive, Enabled: true}}
+}
+
+func TestSemanticAttributeHTTPDefinitionListFiltersBeforePagination(t *testing.T) {
+	const nonMatchingDefinitions = 45
+	const matchingDefinitions = 205
+	definitions := make([]access.SemanticAttributeDefinition, 0, nonMatchingDefinitions+matchingDefinitions)
+	for i := 0; i < nonMatchingDefinitions+matchingDefinitions; i++ {
+		ownerKind := access.SemanticAttributeOwnerInstance
+		if i >= nonMatchingDefinitions {
+			ownerKind = access.SemanticAttributeOwnerGroup
+		}
+		definitions = append(definitions, access.SemanticAttributeDefinition{
+			ID: fmt.Sprintf("definition-%03d", i), Name: fmt.Sprintf("attribute-%03d", i),
+			Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Profile: semanticvalue.Profile,
+			DefinitionVersion: 1, Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: ownerKind}},
+			LifecycleState: access.SemanticAttributeActive, Enabled: true,
+		})
+	}
+	repo := &semanticAttributeHTTPTestRepository{admin: true, definitions: definitions}
+	handler := semanticAttributeHTTPHandler(repo, true)
+
+	var names []string
+	pageToken := ""
+	for {
+		path := "/api/v1/semantic-attributes?ownerKind=group&limit=50"
+		if pageToken != "" {
+			path += "&pageToken=" + pageToken
+		}
+		response := httptest.NewRecorder()
+		handler.ListSemanticAttributeDefinitions(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code != http.StatusOK {
+			t.Fatalf("list status=%d body=%s", response.Code, response.Body.String())
+		}
+		var body struct {
+			Items []struct {
+				Name      string `json:"name"`
+				OwnerKind string `json:"ownerKind"`
+			} `json:"items"`
+			Page struct {
+				NextCursor string `json:"nextCursor"`
+			} `json:"page"`
+		}
+		if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		for _, item := range body.Items {
+			if item.OwnerKind != string(access.SemanticAttributeOwnerGroup) {
+				t.Fatalf("page included owner kind %q", item.OwnerKind)
+			}
+			names = append(names, item.Name)
+		}
+		pageToken = body.Page.NextCursor
+		if pageToken == "" {
+			break
+		}
+	}
+
+	if len(names) != matchingDefinitions {
+		t.Fatalf("filtered definitions = %d, want %d", len(names), matchingDefinitions)
+	}
+	for i, name := range names {
+		want := fmt.Sprintf("attribute-%03d", nonMatchingDefinitions+i)
+		if name != want {
+			t.Fatalf("filtered definition %d = %q, want %q", i, name, want)
+		}
+	}
+	if repo.lastSearch.OwnerKind != access.SemanticAttributeOwnerGroup || repo.lastSearch.Limit != 51 {
+		t.Fatalf("repository search = %#v, want owner filter and limit+1 request", repo.lastSearch)
+	}
+}
+
+func TestSemanticAttributeHTTPDefinitionListRejectsInvalidPageToken(t *testing.T) {
+	handler := semanticAttributeHTTPHandler(semanticAttributeHTTPRepository(), true)
+	for _, token := range []string{"not-base64", encodeKeyCursor("region"), encodeKeyCursor("\x00definition-1")} {
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/semantic-attributes?pageToken="+token, nil)
+		response := httptest.NewRecorder()
+		handler.ListSemanticAttributeDefinitions(response, request)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("pageToken %q status=%d body=%s", token, response.Code, response.Body.String())
+		}
+	}
 }
 
 func TestSemanticAttributeHTTPPlatformBoundary(t *testing.T) {

--- a/internal/access/http/semantic_attribute_handler_test.go
+++ b/internal/access/http/semantic_attribute_handler_test.go
@@ -1,0 +1,354 @@
+package http
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+	"github.com/flidai/leapview/internal/semanticvalue"
+	"github.com/go-chi/chi/v5"
+)
+
+type semanticAttributeHTTPTestRepository struct {
+	access.Repository
+	admin       bool
+	definition  access.SemanticAttributeDefinition
+	assignment  access.SemanticAttributeAssignment
+	mapping     access.TrustedClaimMapping
+	mappingErr  error
+	bumpOnWrite bool
+}
+
+func (r *semanticAttributeHTTPTestRepository) IsPlatformAdmin(context.Context, string) (bool, error) {
+	return r.admin, nil
+}
+
+func (r *semanticAttributeHTTPTestRepository) SemanticAttributeRegistry(context.Context) (access.SemanticAttributeRegistrySnapshot, error) {
+	return access.SemanticAttributeRegistrySnapshot{Definitions: []access.SemanticAttributeDefinition{r.definition}}, nil
+}
+func (r *semanticAttributeHTTPTestRepository) SemanticAttributeDefinition(_ context.Context, name string) (access.SemanticAttributeDefinition, error) {
+	if name != r.definition.Name {
+		return access.SemanticAttributeDefinition{}, sql.ErrNoRows
+	}
+	return r.definition, nil
+}
+func (r *semanticAttributeHTTPTestRepository) SemanticAttributeDefinitionByID(_ context.Context, id string) (access.SemanticAttributeDefinition, error) {
+	if id != r.definition.ID {
+		return access.SemanticAttributeDefinition{}, sql.ErrNoRows
+	}
+	return r.definition, nil
+}
+func (r *semanticAttributeHTTPTestRepository) SearchSemanticAttributes(context.Context, access.SemanticAttributeSearch) ([]access.SemanticAttributeDefinition, error) {
+	return []access.SemanticAttributeDefinition{r.definition}, nil
+}
+func (r *semanticAttributeHTTPTestRepository) RegisterSemanticAttribute(_ context.Context, input access.RegisterSemanticAttributeInput) (access.SemanticAttributeDefinition, error) {
+	r.definition = access.SemanticAttributeDefinition{ID: "definition-2", Name: input.Name, Type: input.Type, Shape: input.Shape, Profile: semanticvalue.Profile, DefinitionVersion: 1, Metadata: input.Metadata, LifecycleState: access.SemanticAttributeActive, Enabled: true}
+	return r.definition, nil
+}
+func (r *semanticAttributeHTTPTestRepository) UpdateSemanticAttributeMetadata(_ context.Context, input access.UpdateSemanticAttributeMetadataInput) (access.SemanticAttributeDefinition, error) {
+	r.definition.Metadata = input.Metadata
+	r.definition.DefinitionVersion++
+	return r.definition, nil
+}
+func (r *semanticAttributeHTTPTestRepository) UpdateSemanticAttributeMetadataExpected(ctx context.Context, input access.UpdateSemanticAttributeMetadataInput) (access.SemanticAttributeDefinition, error) {
+	if r.bumpOnWrite {
+		r.definition.DefinitionVersion++
+		r.bumpOnWrite = false
+	}
+	if input.ExpectedVersion != 0 && input.ExpectedVersion != r.definition.DefinitionVersion {
+		return access.SemanticAttributeDefinition{}, access.ErrSemanticAttributeConflict
+	}
+	return r.UpdateSemanticAttributeMetadata(ctx, input)
+}
+func (r *semanticAttributeHTTPTestRepository) SetSemanticAttributeEnabled(_ context.Context, _ string, enabled bool, _ access.SemanticAttributeMutationContext) (access.SemanticAttributeDefinition, error) {
+	r.definition.Enabled = enabled
+	if enabled {
+		r.definition.LifecycleState = access.SemanticAttributeActive
+	} else {
+		r.definition.LifecycleState = access.SemanticAttributeDisabled
+	}
+	r.definition.DefinitionVersion++
+	return r.definition, nil
+}
+func (r *semanticAttributeHTTPTestRepository) SetSemanticAttributeEnabledExpected(ctx context.Context, name string, enabled bool, expected int64, mutation access.SemanticAttributeMutationContext) (access.SemanticAttributeDefinition, error) {
+	if r.bumpOnWrite {
+		r.definition.DefinitionVersion++
+		r.bumpOnWrite = false
+	}
+	if expected != 0 && expected != r.definition.DefinitionVersion {
+		return access.SemanticAttributeDefinition{}, access.ErrSemanticAttributeConflict
+	}
+	return r.SetSemanticAttributeEnabled(ctx, name, enabled, mutation)
+}
+func (r *semanticAttributeHTTPTestRepository) ValidateSemanticAttributeValue(_ context.Context, _ string, input any) (access.CanonicalSemanticAttributeValue, error) {
+	values, digest, err := access.CanonicalSemanticAttributeValues(r.definition, input)
+	return access.CanonicalSemanticAttributeValue{DefinitionID: r.definition.ID, DefinitionVersion: r.definition.DefinitionVersion, Name: r.definition.Name, Type: r.definition.Type, Shape: r.definition.Shape, CanonicalValues: values, Digest: digest}, err
+}
+
+func (r *semanticAttributeHTTPTestRepository) SemanticAttributeAssignments(_ context.Context, filter access.SemanticAttributeAssignmentFilter) ([]access.SemanticAttributeAssignment, error) {
+	if r.assignment.ID == "" || (filter.DefinitionID != "" && filter.DefinitionID != r.assignment.DefinitionID) || (filter.Subject.ID != "" && filter.Subject != r.assignment.Subject) {
+		return nil, nil
+	}
+	return []access.SemanticAttributeAssignment{r.assignment}, nil
+}
+func (r *semanticAttributeHTTPTestRepository) EffectiveSemanticAttributeAssignments(context.Context, access.SubjectRef, trustedclaims.Envelope) ([]access.EffectiveSemanticAttribute, error) {
+	return nil, nil
+}
+func (r *semanticAttributeHTTPTestRepository) EffectiveDirectSemanticAttributeAssignments(context.Context, access.SubjectRef) ([]access.EffectiveSemanticAttribute, error) {
+	return nil, nil
+}
+func (r *semanticAttributeHTTPTestRepository) SetSemanticAttributeAssignment(_ context.Context, input access.SemanticAttributeAssignmentInput) (access.SemanticAttributeAssignment, error) {
+	if r.assignment.ID != "" && !r.assignment.Tombstoned {
+		if input.ExpectedVersion != r.assignment.AssignmentVersion {
+			return access.SemanticAttributeAssignment{}, access.ErrSemanticAttributeAssignmentConflict
+		}
+		r.assignment.CanonicalValues, r.assignment.ValueDigest, _ = access.CanonicalSemanticAttributeValues(r.definition, input.Values)
+		r.assignment.AssignmentVersion++
+		return r.assignment, nil
+	}
+	if input.ExpectedVersion != 0 {
+		return access.SemanticAttributeAssignment{}, access.ErrSemanticAttributeAssignmentConflict
+	}
+	values, digest, err := access.CanonicalSemanticAttributeValues(r.definition, input.Values)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, err
+	}
+	r.assignment = access.SemanticAttributeAssignment{ID: "assignment-1", DefinitionID: r.definition.ID, DefinitionName: r.definition.Name, DefinitionVersion: r.definition.DefinitionVersion, Type: r.definition.Type, Shape: r.definition.Shape, Subject: input.Subject, CanonicalValues: values, ValueDigest: digest, AssignmentVersion: 1, CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"}
+	return r.assignment, nil
+}
+func (r *semanticAttributeHTTPTestRepository) TombstoneSemanticAttributeAssignment(_ context.Context, id string, expected int64, _ access.SemanticAttributeMutationContext) (access.SemanticAttributeAssignment, error) {
+	if id != r.assignment.ID || expected != r.assignment.AssignmentVersion || r.assignment.Tombstoned {
+		return access.SemanticAttributeAssignment{}, access.ErrSemanticAttributeAssignmentConflict
+	}
+	r.assignment.Tombstoned = true
+	r.assignment.TombstonedAt = "2026-01-01T01:00:00Z"
+	r.assignment.AssignmentVersion++
+	return r.assignment, nil
+}
+
+func (r *semanticAttributeHTTPTestRepository) TrustedClaimMappings(_ context.Context, _ access.TrustedClaimMappingFilter) ([]access.TrustedClaimMapping, error) {
+	if r.mappingErr != nil {
+		return nil, r.mappingErr
+	}
+	if r.mapping.ID == "" {
+		return nil, nil
+	}
+	return []access.TrustedClaimMapping{r.mapping}, nil
+}
+func (r *semanticAttributeHTTPTestRepository) SetTrustedClaimMapping(_ context.Context, input access.TrustedClaimMappingInput) (access.TrustedClaimMapping, error) {
+	if r.mapping.ID != "" && !r.mapping.Tombstoned {
+		if input.ExpectedVersion != r.mapping.MappingVersion {
+			return access.TrustedClaimMapping{}, access.ErrSemanticAttributeMappingConflict
+		}
+		r.mapping.MappingVersion++
+		return r.mapping, nil
+	}
+	if input.ExpectedVersion != 0 {
+		return access.TrustedClaimMapping{}, access.ErrSemanticAttributeMappingConflict
+	}
+	r.mapping = access.TrustedClaimMapping{ID: "mapping-1", SourceKind: input.SourceKind, Provider: input.Provider, Issuer: input.Issuer, Audience: input.Audience, Claim: input.Claim, DefinitionID: r.definition.ID, DefinitionName: r.definition.Name, MappingVersion: 1, Type: r.definition.Type, Shape: r.definition.Shape, CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z"}
+	return r.mapping, nil
+}
+func (r *semanticAttributeHTTPTestRepository) TombstoneTrustedClaimMapping(_ context.Context, id string, expected int64, _ access.SemanticAttributeMutationContext) (access.TrustedClaimMapping, error) {
+	if id != r.mapping.ID || expected != r.mapping.MappingVersion || r.mapping.Tombstoned {
+		return access.TrustedClaimMapping{}, access.ErrSemanticAttributeMappingConflict
+	}
+	r.mapping.Tombstoned = true
+	r.mapping.TombstonedAt = "2026-01-01T01:00:00Z"
+	r.mapping.MappingVersion++
+	return r.mapping, nil
+}
+
+func semanticAttributeHTTPHandler(repo *semanticAttributeHTTPTestRepository, principal bool) Handler {
+	return Handler{Repository: func() (access.Repository, error) { return repo, nil }, CurrentPrincipal: func(*http.Request) (Principal, bool) { return Principal{ID: "admin"}, principal }, PlatformAdmin: func(context.Context, string) (bool, error) { return repo.admin, nil }}
+}
+func semanticAttributeRequest(method, path, body string, params ...string) *http.Request {
+	r := httptest.NewRequest(method, path, strings.NewReader(body))
+	route := chi.NewRouteContext()
+	for i := 0; i+1 < len(params); i += 2 {
+		route.URLParams.Add(params[i], params[i+1])
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, route))
+}
+func semanticAttributeHTTPRepository() *semanticAttributeHTTPTestRepository {
+	return &semanticAttributeHTTPTestRepository{admin: true, definition: access.SemanticAttributeDefinition{ID: "definition-1", Name: "region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Profile: semanticvalue.Profile, DefinitionVersion: 1, Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}, DisplayName: "Region", Description: "Region"}, LifecycleState: access.SemanticAttributeActive, Enabled: true}}
+}
+
+func TestSemanticAttributeHTTPPlatformBoundary(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	response := httptest.NewRecorder()
+	semanticAttributeHTTPHandler(repo, false).GetSemanticAttributeDefinition(response, semanticAttributeRequest(http.MethodGet, "/semantic-attributes/region", "", "attribute", "region"))
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status=%d", response.Code)
+	}
+	response = httptest.NewRecorder()
+	semanticAttributeHTTPHandler(repo, true).GetSemanticAttributeDefinition(response, semanticAttributeRequest(http.MethodGet, "/semantic-attributes/region", "", "attribute", "region"))
+	if response.Code != http.StatusOK {
+		t.Fatalf("admin status=%d body=%s", response.Code, response.Body.String())
+	}
+	repo.admin = false
+	response = httptest.NewRecorder()
+	semanticAttributeHTTPHandler(repo, true).GetSemanticAttributeDefinition(response, semanticAttributeRequest(http.MethodGet, "/semantic-attributes/region", "", "attribute", "region"))
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("non-admin status=%d", response.Code)
+	}
+}
+
+func TestSemanticAttributeHTTPCredentialAttenuation(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	handler := semanticAttributeHTTPHandler(repo, true)
+	credential := access.APICredential{Principal: access.Principal{ID: "admin"}, Token: access.APIToken{ID: "narrow", PrincipalID: "admin", Capabilities: []access.Capability{access.CapabilityResourceRead}}}
+	handler.CurrentCredential = func(*http.Request) (access.APICredential, bool) { return credential, true }
+	request := semanticAttributeRequest(http.MethodGet, "/semantic-attributes/region", "", "attribute", "region")
+	response := httptest.NewRecorder()
+	handler.GetSemanticAttributeDefinition(response, request)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("narrow token status=%d", response.Code)
+	}
+	credential.Token.Capabilities = []access.Capability{access.CapabilityProjectAdmin}
+	response = httptest.NewRecorder()
+	handler.GetSemanticAttributeDefinition(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("project-admin token status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestSemanticAttributeHTTPRejectsMixedValuesAndInvalidOwner(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	handler := semanticAttributeHTTPHandler(repo, true)
+	for name, body := range map[string]string{
+		"mixed":  `{"values":[{"type":"String","stringValue":"us","integerValue":"1"}]}`,
+		"object": `{"values":[{"type":"String","stringValue":{"raw":"us"}}]}`,
+		"nested": `{"values":[{"type":"String","stringValue":["us"]}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := semanticAttributeRequest(http.MethodPut, "/principals/p/semantic-attributes/region", body, "principal", "p", "attribute", "region")
+			request.Header.Set("If-Match", "*")
+			response := httptest.NewRecorder()
+			handler.UpsertPrincipalSemanticAttributeAssignment(response, request)
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+	owner := semanticAttributeRequest(http.MethodPost, "/semantic-attributes", `{"name":"cost","type":"String","shape":"scalar","metadata":{"ownerKind":"principal","displayName":"Cost","description":"Cost"}}`)
+	response := httptest.NewRecorder()
+	handler.RegisterSemanticAttribute(response, owner)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("owner status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestSemanticAttributeHTTPDefinitionLifecycleAndTransactionConflict(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	handler := semanticAttributeHTTPHandler(repo, true)
+	get := httptest.NewRecorder()
+	handler.GetSemanticAttributeDefinition(get, semanticAttributeRequest(http.MethodGet, "/semantic-attributes/region", "", "attribute", "region"))
+	etag := get.Header().Get("ETag")
+	stale := semanticAttributeRequest(http.MethodPatch, "/semantic-attributes/region", `{"ownerKind":"instance","displayName":"New","description":"New"}`, "attribute", "region")
+	stale.Header.Set("If-Match", `"stale"`)
+	response := httptest.NewRecorder()
+	handler.UpdateSemanticAttributeMetadata(response, stale)
+	if response.Code != http.StatusPreconditionFailed {
+		t.Fatalf("stale status=%d", response.Code)
+	}
+	racy := semanticAttributeRequest(http.MethodPatch, "/semantic-attributes/region", `{"ownerKind":"instance","displayName":"New","description":"New"}`, "attribute", "region")
+	racy.Header.Set("If-Match", etag)
+	repo.bumpOnWrite = true
+	response = httptest.NewRecorder()
+	handler.UpdateSemanticAttributeMetadata(response, racy)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("transaction conflict status=%d body=%s", response.Code, response.Body.String())
+	}
+	get = httptest.NewRecorder()
+	handler.GetSemanticAttributeDefinition(get, semanticAttributeRequest(http.MethodGet, "/semantic-attributes/region", "", "attribute", "region"))
+	etag = get.Header().Get("ETag")
+	disable := semanticAttributeRequest(http.MethodPost, "/semantic-attributes/region/disable", "", "attribute", "region")
+	disable.Header.Set("If-Match", etag)
+	response = httptest.NewRecorder()
+	handler.DisableSemanticAttribute(response, disable)
+	if response.Code != http.StatusOK || repo.definition.Enabled {
+		t.Fatalf("disable response=%d enabled=%v", response.Code, repo.definition.Enabled)
+	}
+}
+
+func TestSemanticAttributeHTTPAssignmentAndMappingTombstoneRequireETag(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	handler := semanticAttributeHTTPHandler(repo, true)
+	upsert := semanticAttributeRequest(http.MethodPut, "/principals/p/semantic-attributes/region", `{"values":[{"type":"String","stringValue":"us"}]}`, "principal", "p", "attribute", "region")
+	upsert.Header.Set("If-Match", "*")
+	created := httptest.NewRecorder()
+	handler.UpsertPrincipalSemanticAttributeAssignment(created, upsert)
+	if created.Code != http.StatusOK {
+		t.Fatalf("assignment create=%d body=%s", created.Code, created.Body.String())
+	}
+	remove := semanticAttributeRequest(http.MethodDelete, "/principals/p/semantic-attributes/region", "", "principal", "p", "attribute", "region")
+	response := httptest.NewRecorder()
+	handler.RemovePrincipalSemanticAttributeAssignment(response, remove)
+	if response.Code != http.StatusPreconditionFailed {
+		t.Fatalf("missing assignment If-Match=%d", response.Code)
+	}
+	remove.Header.Set("If-Match", created.Header().Get("ETag"))
+	response = httptest.NewRecorder()
+	handler.RemovePrincipalSemanticAttributeAssignment(response, remove)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("assignment remove=%d body=%s", response.Code, response.Body.String())
+	}
+
+	claim := semanticAttributeRequest(http.MethodPost, "/semantic-attributes/region/claim-mappings", `{"sourceKind":"oidc","provider":"corp","issuer":"https://issuer","audience":"aud","claim":"department"}`, "attribute", "region")
+	claim.Header.Set("If-Match", "*")
+	claim.Header.Set("Idempotency-Key", "test-1")
+	createdMapping := httptest.NewRecorder()
+	handler.UpsertSemanticAttributeClaimMapping(createdMapping, claim)
+	if createdMapping.Code != http.StatusOK {
+		t.Fatalf("mapping create=%d body=%s", createdMapping.Code, createdMapping.Body.String())
+	}
+	removeMapping := semanticAttributeRequest(http.MethodDelete, "/semantic-attributes/region/claim-mappings/mapping-1", "", "attribute", "region", "mapping", "mapping-1")
+	removeMapping.Header.Set("If-Match", createdMapping.Header().Get("ETag"))
+	removedMapping := httptest.NewRecorder()
+	handler.RemoveSemanticAttributeClaimMapping(removedMapping, removeMapping)
+	if removedMapping.Code != http.StatusNoContent {
+		t.Fatalf("mapping remove=%d body=%s", removedMapping.Code, removedMapping.Body.String())
+	}
+}
+
+func TestSemanticAttributeHTTPClaimMappingRequiresCompleteTrustIdentity(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	handler := semanticAttributeHTTPHandler(repo, true)
+
+	for _, body := range []string{
+		`{"sourceKind":"oidc","provider":"corp","audience":"aud","claim":"department"}`,
+		`{"sourceKind":"oidc","provider":"corp","issuer":"https://issuer","audience":" ","claim":"department"}`,
+	} {
+		request := semanticAttributeRequest(http.MethodPost, "/semantic-attributes/region/claim-mappings", body, "attribute", "region")
+		request.Header.Set("If-Match", "*")
+		response := httptest.NewRecorder()
+		handler.UpsertSemanticAttributeClaimMapping(response, request)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("incomplete trust identity status=%d body=%s", response.Code, response.Body.String())
+		}
+		if repo.mapping.ID != "" {
+			t.Fatal("incomplete trust identity reached the mapping writer")
+		}
+	}
+}
+
+func TestSemanticAttributeHTTPDoesNotExposeRepositoryErrors(t *testing.T) {
+	repo := semanticAttributeHTTPRepository()
+	handler := semanticAttributeHTTPHandler(repo, true)
+	// A malformed provider failure must not be reflected verbatim in the HTTP
+	// response, where it could disclose raw claim values or SQL diagnostics.
+	request := semanticAttributeRequest(http.MethodGet, "/semantic-attributes/region/claim-mappings", "", "attribute", "region")
+	repo.mappingErr = errors.New("raw-secret claim value leaked")
+	response := httptest.NewRecorder()
+	handler.ListSemanticAttributeClaimMappings(response, request)
+	if strings.Contains(response.Body.String(), "raw-secret") {
+		t.Fatal("repository diagnostics leaked")
+	}
+}

--- a/internal/access/http/semantic_attribute_wire.go
+++ b/internal/access/http/semantic_attribute_wire.go
@@ -1,0 +1,48 @@
+package http
+
+// The API deliberately has closed value envelopes. In particular, these are
+// not map[string]any decoders: accepting an object here would make the
+// canonical semantic-value profile and its audit identity ambiguous.
+
+type semanticAttributeValueWire struct {
+	Type           string  `json:"type"`
+	StringValue    *string `json:"stringValue"`
+	BooleanValue   *bool   `json:"booleanValue"`
+	IntegerValue   *string `json:"integerValue"`
+	DecimalValue   *string `json:"decimalValue"`
+	DateValue      *string `json:"dateValue"`
+	TimestampValue *string `json:"timestampValue"`
+}
+
+type semanticAttributeMetadataWire struct {
+	OwnerKind        string  `json:"ownerKind"`
+	OwnerID          *string `json:"ownerId"`
+	DisplayName      string  `json:"displayName"`
+	Description      string  `json:"description"`
+	DocumentationURL *string `json:"documentationUrl"`
+}
+
+type semanticAttributeRegisterWire struct {
+	Name     string                        `json:"name"`
+	Type     string                        `json:"type"`
+	Shape    string                        `json:"shape"`
+	Metadata semanticAttributeMetadataWire `json:"metadata"`
+}
+
+type semanticAttributeAssignmentWire struct {
+	Values []semanticAttributeValueWire `json:"values"`
+}
+
+type semanticAttributeClaimMappingWire struct {
+	SourceKind string `json:"sourceKind"`
+	Provider   string `json:"provider"`
+	Issuer     string `json:"issuer"`
+	Audience   string `json:"audience"`
+	Claim      string `json:"claim"`
+}
+
+type semanticAttributeImpactWire struct {
+	TargetKind string                       `json:"targetKind"`
+	TargetID   string                       `json:"targetId"`
+	Values     []semanticAttributeValueWire `json:"values"`
+}

--- a/internal/access/module/api.go
+++ b/internal/access/module/api.go
@@ -93,6 +93,38 @@ func (m *Module) DispatchAPIGenOperation(operationID string, w http.ResponseWrit
 		m.handler.AddGroupMember(w, r)
 	case "removeGroupMember":
 		m.handler.RemoveGroupMember(w, r)
+	case "listGroupSemanticAttributeAssignments":
+		m.handler.ListGroupSemanticAttributeAssignments(w, r)
+	case "removeGroupSemanticAttributeAssignment":
+		m.handler.RemoveGroupSemanticAttributeAssignment(w, r)
+	case "upsertGroupSemanticAttributeAssignment":
+		m.handler.UpsertGroupSemanticAttributeAssignment(w, r)
+	case "listPrincipalSemanticAttributeAssignments":
+		m.handler.ListPrincipalSemanticAttributeAssignments(w, r)
+	case "removePrincipalSemanticAttributeAssignment":
+		m.handler.RemovePrincipalSemanticAttributeAssignment(w, r)
+	case "upsertPrincipalSemanticAttributeAssignment":
+		m.handler.UpsertPrincipalSemanticAttributeAssignment(w, r)
+	case "listSemanticAttributeDefinitions":
+		m.handler.ListSemanticAttributeDefinitions(w, r)
+	case "registerSemanticAttribute":
+		m.handler.RegisterSemanticAttribute(w, r)
+	case "getSemanticAttributeDefinition":
+		m.handler.GetSemanticAttributeDefinition(w, r)
+	case "updateSemanticAttributeMetadata":
+		m.handler.UpdateSemanticAttributeMetadata(w, r)
+	case "listSemanticAttributeClaimMappings":
+		m.handler.ListSemanticAttributeClaimMappings(w, r)
+	case "upsertSemanticAttributeClaimMapping":
+		m.handler.UpsertSemanticAttributeClaimMapping(w, r)
+	case "removeSemanticAttributeClaimMapping":
+		m.handler.RemoveSemanticAttributeClaimMapping(w, r)
+	case "disableSemanticAttribute":
+		m.handler.DisableSemanticAttribute(w, r)
+	case "previewSemanticAttributeImpact":
+		m.handler.PreviewSemanticAttributeImpact(w, r)
+	case "restoreSemanticAttribute":
+		m.handler.RestoreSemanticAttribute(w, r)
 	case "listAuditEvents", "listPlatformAuditEvents":
 		m.handler.ListAuditEvents(w, r)
 	default:

--- a/internal/access/postgres/attribute_migration.go
+++ b/internal/access/postgres/attribute_migration.go
@@ -15,3 +15,15 @@ var attributeRegistryMigrationSQL string
 // AttributeRegistryMigrationSQL returns the access-owned immutable forward
 // migration for application-level PostgreSQL migration composition.
 func AttributeRegistryMigrationSQL() string { return attributeRegistryMigrationSQL }
+
+const (
+	// SemanticAttributeControlMigrationRevision adds durable subject assignments
+	// and exact trusted-claim mappings without changing revision 002.
+	SemanticAttributeControlMigrationRevision int64 = 3
+	SemanticAttributeControlMigrationID             = "003_semantic_attribute_control"
+)
+
+//go:embed migrations/003_semantic_attribute_control.sql
+var semanticAttributeControlMigrationSQL string
+
+func SemanticAttributeControlMigrationSQL() string { return semanticAttributeControlMigrationSQL }

--- a/internal/access/postgres/migrations/003_semantic_attribute_control.sql
+++ b/internal/access/postgres/migrations/003_semantic_attribute_control.sql
@@ -1,0 +1,286 @@
+-- FAI-637: durable semantic-access assignments and trusted claim mappings.
+--
+-- Revision 002 is intentionally not edited.  This migration owns only the
+-- control-plane rows which reference the immutable definition registry.
+
+CREATE TABLE access.semantic_attribute_control_state (
+    singleton         boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    profile           text NOT NULL CHECK (profile = 'leapview.semantic-access/v1'),
+    control_revision  bigint NOT NULL DEFAULT 0 CHECK (control_revision >= 0),
+    control_digest    text NOT NULL CHECK (control_digest ~ '^sha256:[0-9a-f]{64}$'),
+    updated_at        timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+
+INSERT INTO access.semantic_attribute_control_state
+    (singleton, profile, control_revision, control_digest)
+VALUES
+    (true, 'leapview.semantic-access/v1', 0,
+     'sha256:e05005cdeee20cc98d9e8de8f32ed4b8da34a95f82872dc3b65a451ce7de4e37')
+ON CONFLICT (singleton) DO NOTHING;
+
+-- A row is one assignment incarnation.  Tombstones remain in place forever;
+-- restoring a subject/definition pair creates a new immutable assignment id.
+CREATE TABLE access.semantic_attribute_assignment (
+    assignment_id       uuid PRIMARY KEY DEFAULT uuidv7(),
+    definition_id       uuid NOT NULL REFERENCES access.semantic_attribute_definition(definition_id),
+    subject_kind        text NOT NULL CHECK (subject_kind IN ('principal','group')),
+    subject_id          uuid NOT NULL,
+    definition_version  bigint NOT NULL CHECK (definition_version > 0),
+    value_type          text NOT NULL CHECK (value_type IN ('String','Boolean','Integer','Decimal','Date','Timestamp')),
+    value_shape         text NOT NULL CHECK (value_shape IN ('scalar','list')),
+    canonical_values    text[] NOT NULL,
+    value_digest        text NOT NULL CHECK (value_digest ~ '^sha256:[0-9a-f]{64}$'),
+    assignment_version  bigint NOT NULL DEFAULT 1 CHECK (assignment_version > 0),
+    tombstoned_at       timestamptz,
+    created_at          timestamptz NOT NULL DEFAULT clock_timestamp(),
+    updated_at          timestamptz NOT NULL DEFAULT clock_timestamp(),
+    CHECK (array_ndims(canonical_values) = 1),
+    CHECK (cardinality(canonical_values) BETWEEN 1 AND 1024),
+    CHECK ((value_shape = 'scalar' AND cardinality(canonical_values) = 1) OR value_shape = 'list')
+);
+CREATE UNIQUE INDEX semantic_attribute_assignment_active_key
+    ON access.semantic_attribute_assignment(definition_id, subject_kind, subject_id)
+    WHERE tombstoned_at IS NULL;
+CREATE INDEX semantic_attribute_assignment_subject_idx
+    ON access.semantic_attribute_assignment(subject_kind, subject_id, definition_id, assignment_id);
+
+-- A mapping has no value payload: it names the trusted provider claim which
+-- will be canonicalized at authentication/evaluation time.
+CREATE TABLE access.semantic_attribute_claim_mapping (
+    mapping_id          uuid PRIMARY KEY DEFAULT uuidv7(),
+    source_kind        text NOT NULL CHECK (source_kind IN ('saml','oidc','embed','service_token')),
+    provider            text NOT NULL CHECK (provider = btrim(provider) AND octet_length(provider) BETWEEN 1 AND 128 AND provider !~ '[[:cntrl:]]'),
+    issuer              text NOT NULL CHECK (issuer = btrim(issuer) AND octet_length(issuer) BETWEEN 1 AND 2048 AND issuer !~ '[[:cntrl:]]'),
+    audience            text NOT NULL CHECK (audience = btrim(audience) AND octet_length(audience) BETWEEN 1 AND 512 AND audience !~ '[[:cntrl:]]'),
+    claim               text NOT NULL CHECK (claim = btrim(claim) AND octet_length(claim) BETWEEN 1 AND 1024 AND claim !~ '[[:cntrl:]]'),
+    definition_id       uuid NOT NULL REFERENCES access.semantic_attribute_definition(definition_id),
+    definition_version  bigint NOT NULL CHECK (definition_version > 0),
+    value_type          text NOT NULL CHECK (value_type IN ('String','Boolean','Integer','Decimal','Date','Timestamp')),
+    value_shape         text NOT NULL CHECK (value_shape IN ('scalar','list')),
+    mapping_version     bigint NOT NULL DEFAULT 1 CHECK (mapping_version > 0),
+    tombstoned_at       timestamptz,
+    created_at          timestamptz NOT NULL DEFAULT clock_timestamp(),
+    updated_at          timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+CREATE UNIQUE INDEX semantic_attribute_claim_mapping_active_key
+    ON access.semantic_attribute_claim_mapping(source_kind, provider, issuer, audience, claim, definition_id)
+    WHERE tombstoned_at IS NULL;
+CREATE INDEX semantic_attribute_claim_mapping_lookup_idx
+    ON access.semantic_attribute_claim_mapping(source_kind, provider, issuer, audience, claim, mapping_id);
+
+CREATE OR REPLACE FUNCTION access.validate_semantic_attribute_owner_exists()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, access
+AS $$
+BEGIN
+    -- An already-owned definition may still be edited after its owner is
+    -- revoked. Requiring the owner to remain active on every metadata update
+    -- would strand the definition and prevent its lifecycle from completing.
+    IF TG_OP = 'UPDATE' AND OLD.owner_kind = NEW.owner_kind AND OLD.owner_id IS NOT DISTINCT FROM NEW.owner_id THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.owner_kind = 'principal' AND NOT EXISTS (
+        SELECT 1 FROM access.principal WHERE id = NEW.owner_id AND revoked_at IS NULL
+    ) THEN
+        RAISE EXCEPTION 'semantic attribute owner principal does not exist';
+    ELSIF NEW.owner_kind = 'group' AND NOT EXISTS (
+        SELECT 1 FROM access.access_group WHERE id = NEW.owner_id AND revoked_at IS NULL
+    ) THEN
+        RAISE EXCEPTION 'semantic attribute owner group does not exist';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER semantic_attribute_definition_owner_exists
+    BEFORE INSERT OR UPDATE ON access.semantic_attribute_definition
+    FOR EACH ROW EXECUTE FUNCTION access.validate_semantic_attribute_owner_exists();
+
+CREATE OR REPLACE FUNCTION access.validate_semantic_attribute_assignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, access
+AS $$
+DECLARE definition_type text; definition_shape text; definition_enabled boolean; tombstone_transition boolean := false;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        tombstone_transition := OLD.tombstoned_at IS NULL AND NEW.tombstoned_at IS NOT NULL;
+    END IF;
+    SELECT value_type, value_shape, enabled
+      INTO definition_type, definition_shape, definition_enabled
+      FROM access.semantic_attribute_definition
+     WHERE definition_id = NEW.definition_id;
+    IF NOT FOUND OR (NOT definition_enabled AND NOT tombstone_transition) THEN
+        RAISE EXCEPTION 'semantic attribute definition is missing or disabled';
+    END IF;
+    IF definition_type <> NEW.value_type OR definition_shape <> NEW.value_shape THEN
+        RAISE EXCEPTION 'semantic attribute assignment type is not the definition type';
+    END IF;
+    IF TG_OP = 'INSERT' OR NOT tombstone_transition THEN
+        IF NEW.subject_kind = 'principal' AND NOT EXISTS (
+            SELECT 1 FROM access.principal WHERE id = NEW.subject_id AND revoked_at IS NULL
+        ) THEN
+            RAISE EXCEPTION 'semantic attribute assignment principal does not exist';
+        ELSIF NEW.subject_kind = 'group' AND NOT EXISTS (
+            SELECT 1 FROM access.access_group WHERE id = NEW.subject_id AND revoked_at IS NULL
+        ) THEN
+            RAISE EXCEPTION 'semantic attribute assignment group does not exist';
+        END IF;
+    END IF;
+    IF TG_OP = 'UPDATE' THEN
+        IF OLD.assignment_id <> NEW.assignment_id OR OLD.definition_id <> NEW.definition_id OR
+           OLD.subject_kind <> NEW.subject_kind OR OLD.subject_id <> NEW.subject_id OR
+           OLD.definition_version <> NEW.definition_version OR OLD.value_type <> NEW.value_type OR
+           OLD.value_shape <> NEW.value_shape OR OLD.created_at <> NEW.created_at THEN
+            RAISE EXCEPTION 'semantic attribute assignment identity and type are immutable';
+        END IF;
+        IF OLD.tombstoned_at IS NOT NULL AND NEW.tombstoned_at IS NULL THEN
+            RAISE EXCEPTION 'semantic attribute assignment tombstone is immutable';
+        END IF;
+        IF OLD.tombstoned_at IS NOT NULL THEN
+            RAISE EXCEPTION 'semantic attribute assignment tombstone is immutable';
+        END IF;
+        IF OLD.tombstoned_at IS NULL AND NEW.tombstoned_at IS NOT NULL AND
+           (OLD.canonical_values IS DISTINCT FROM NEW.canonical_values OR OLD.value_digest <> NEW.value_digest) THEN
+            RAISE EXCEPTION 'semantic attribute assignment tombstone cannot rewrite its value';
+        END IF;
+        IF NEW.assignment_version <> OLD.assignment_version + 1 THEN
+            RAISE EXCEPTION 'semantic attribute assignment version must advance exactly once';
+        END IF;
+        IF OLD.canonical_values = NEW.canonical_values AND OLD.value_digest = NEW.value_digest AND
+           OLD.tombstoned_at IS NOT DISTINCT FROM NEW.tombstoned_at THEN
+            RAISE EXCEPTION 'semantic attribute assignment update did not change mutable state';
+        END IF;
+        IF OLD.tombstoned_at IS DISTINCT FROM NEW.tombstoned_at AND NEW.tombstoned_at IS NULL THEN
+            RAISE EXCEPTION 'semantic attribute assignment tombstone is database-owned';
+        END IF;
+    END IF;
+    NEW.updated_at := CASE WHEN TG_OP = 'UPDATE'
+        THEN GREATEST(clock_timestamp(), OLD.updated_at + interval '1 microsecond')
+        ELSE clock_timestamp() END;
+    IF TG_OP = 'UPDATE' AND OLD.tombstoned_at IS NULL AND NEW.tombstoned_at IS NOT NULL THEN
+        NEW.tombstoned_at := clock_timestamp();
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION access.validate_semantic_attribute_claim_mapping()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, access
+AS $$
+DECLARE definition_type text; definition_shape text; definition_enabled boolean; tombstone_transition boolean := false;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        tombstone_transition := OLD.tombstoned_at IS NULL AND NEW.tombstoned_at IS NOT NULL;
+    END IF;
+    SELECT value_type, value_shape, enabled
+      INTO definition_type, definition_shape, definition_enabled
+      FROM access.semantic_attribute_definition
+     WHERE definition_id = NEW.definition_id;
+    IF NOT FOUND OR (NOT definition_enabled AND NOT tombstone_transition) THEN
+        RAISE EXCEPTION 'semantic attribute mapping definition is missing or disabled';
+    END IF;
+    IF definition_type <> NEW.value_type OR definition_shape <> NEW.value_shape THEN
+        RAISE EXCEPTION 'semantic attribute mapping type is not the definition type';
+    END IF;
+    IF TG_OP = 'UPDATE' THEN
+        IF OLD.mapping_id <> NEW.mapping_id OR OLD.source_kind <> NEW.source_kind OR
+           OLD.provider <> NEW.provider OR OLD.issuer <> NEW.issuer OR OLD.audience <> NEW.audience OR
+           OLD.claim <> NEW.claim OR OLD.definition_id <> NEW.definition_id OR
+           OLD.definition_version <> NEW.definition_version OR
+           OLD.value_type <> NEW.value_type OR OLD.value_shape <> NEW.value_shape OR OLD.created_at <> NEW.created_at THEN
+            RAISE EXCEPTION 'semantic attribute mapping identity and type are immutable';
+        END IF;
+        IF OLD.tombstoned_at IS NOT NULL AND NEW.tombstoned_at IS NULL THEN
+            RAISE EXCEPTION 'semantic attribute mapping tombstone is immutable';
+        END IF;
+        IF OLD.tombstoned_at IS NOT NULL THEN
+            RAISE EXCEPTION 'semantic attribute mapping tombstone is immutable';
+        END IF;
+        IF NEW.mapping_version <> OLD.mapping_version + 1 THEN
+            RAISE EXCEPTION 'semantic attribute mapping version must advance exactly once';
+        END IF;
+        IF OLD.tombstoned_at IS NOT DISTINCT FROM NEW.tombstoned_at THEN
+            RAISE EXCEPTION 'semantic attribute mapping update did not change mutable state';
+        END IF;
+    END IF;
+    NEW.updated_at := CASE WHEN TG_OP = 'UPDATE'
+        THEN GREATEST(clock_timestamp(), OLD.updated_at + interval '1 microsecond')
+        ELSE clock_timestamp() END;
+    IF TG_OP = 'UPDATE' AND OLD.tombstoned_at IS NULL AND NEW.tombstoned_at IS NOT NULL THEN
+        NEW.tombstoned_at := clock_timestamp();
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION access.reject_semantic_attribute_control_state_rewrite()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, access
+AS $$
+BEGIN
+    IF OLD.singleton <> NEW.singleton OR OLD.profile <> NEW.profile OR
+       NEW.control_revision <> OLD.control_revision + 1 OR NEW.control_digest = OLD.control_digest THEN
+        RAISE EXCEPTION 'semantic attribute control revision must advance with a new digest';
+    END IF;
+    NEW.updated_at := GREATEST(clock_timestamp(), OLD.updated_at + interval '1 microsecond');
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER semantic_attribute_control_state_no_delete
+    BEFORE DELETE ON access.semantic_attribute_control_state
+    FOR EACH ROW EXECUTE FUNCTION access.reject_access_delete();
+CREATE TRIGGER semantic_attribute_control_state_immutable
+    BEFORE UPDATE ON access.semantic_attribute_control_state
+    FOR EACH ROW EXECUTE FUNCTION access.reject_semantic_attribute_control_state_rewrite();
+CREATE TRIGGER semantic_attribute_assignment_no_delete
+    BEFORE DELETE ON access.semantic_attribute_assignment
+    FOR EACH ROW EXECUTE FUNCTION access.reject_access_delete();
+CREATE TRIGGER semantic_attribute_assignment_immutable
+    BEFORE INSERT OR UPDATE ON access.semantic_attribute_assignment
+    FOR EACH ROW EXECUTE FUNCTION access.validate_semantic_attribute_assignment();
+CREATE TRIGGER semantic_attribute_claim_mapping_no_delete
+    BEFORE DELETE ON access.semantic_attribute_claim_mapping
+    FOR EACH ROW EXECUTE FUNCTION access.reject_access_delete();
+CREATE TRIGGER semantic_attribute_claim_mapping_immutable
+    BEFORE INSERT OR UPDATE ON access.semantic_attribute_claim_mapping
+    FOR EACH ROW EXECUTE FUNCTION access.validate_semantic_attribute_claim_mapping();
+
+REVOKE ALL ON TABLE access.semantic_attribute_control_state,
+    access.semantic_attribute_assignment,
+    access.semantic_attribute_claim_mapping FROM PUBLIC;
+REVOKE ALL ON FUNCTION access.validate_semantic_attribute_owner_exists(),
+    access.validate_semantic_attribute_assignment(),
+    access.validate_semantic_attribute_claim_mapping(),
+    access.reject_semantic_attribute_control_state_rewrite() FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_runtime') THEN
+        GRANT SELECT, INSERT, UPDATE ON access.semantic_attribute_control_state,
+            access.semantic_attribute_assignment,
+            access.semantic_attribute_claim_mapping TO leapview_control_runtime;
+        REVOKE DELETE, TRUNCATE, REFERENCES, TRIGGER ON access.semantic_attribute_control_state,
+            access.semantic_attribute_assignment,
+            access.semantic_attribute_claim_mapping FROM leapview_control_runtime;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_readonly') THEN
+        GRANT SELECT ON access.semantic_attribute_control_state,
+            access.semantic_attribute_assignment,
+            access.semantic_attribute_claim_mapping TO leapview_control_readonly;
+        REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+            ON access.semantic_attribute_control_state,
+               access.semantic_attribute_assignment,
+               access.semantic_attribute_claim_mapping FROM leapview_control_readonly;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_backup') THEN
+        GRANT SELECT ON access.semantic_attribute_control_state,
+            access.semantic_attribute_assignment,
+            access.semantic_attribute_claim_mapping TO leapview_control_backup;
+    END IF;
+END
+$$;

--- a/internal/access/postgres/migrations/003_semantic_attribute_control.sql
+++ b/internal/access/postgres/migrations/003_semantic_attribute_control.sql
@@ -50,7 +50,7 @@ CREATE TABLE access.semantic_attribute_claim_mapping (
     mapping_id          uuid PRIMARY KEY DEFAULT uuidv7(),
     source_kind        text NOT NULL CHECK (source_kind IN ('saml','oidc','embed','service_token')),
     provider            text NOT NULL CHECK (provider = btrim(provider) AND octet_length(provider) BETWEEN 1 AND 128 AND provider !~ '[[:cntrl:]]'),
-    issuer              text NOT NULL CHECK (issuer = btrim(issuer) AND octet_length(issuer) BETWEEN 1 AND 2048 AND issuer !~ '[[:cntrl:]]'),
+    issuer              text NOT NULL CHECK (issuer = btrim(issuer) AND octet_length(issuer) BETWEEN 1 AND 1024 AND issuer !~ '[[:cntrl:]]'),
     audience            text NOT NULL CHECK (audience = btrim(audience) AND octet_length(audience) BETWEEN 1 AND 512 AND audience !~ '[[:cntrl:]]'),
     claim               text NOT NULL CHECK (claim = btrim(claim) AND octet_length(claim) BETWEEN 1 AND 1024 AND claim !~ '[[:cntrl:]]'),
     definition_id       uuid NOT NULL REFERENCES access.semantic_attribute_definition(definition_id),

--- a/internal/access/postgres/queries/semantic_attribute_control.sql
+++ b/internal/access/postgres/queries/semantic_attribute_control.sql
@@ -2,12 +2,14 @@
 -- optimistic concurrency, control digest refresh, and audit coupling.
 
 -- name: GetSemanticAttributeControlState :one
-SELECT profile, control_revision, control_digest, updated_at::text AS updated_at
+SELECT profile, control_revision, control_digest,
+       ((extract(epoch FROM updated_at) * 1000000)::bigint)::text AS updated_at
 FROM access.semantic_attribute_control_state
 WHERE singleton;
 
 -- name: LockSemanticAttributeControlState :one
-SELECT profile, control_revision, control_digest, updated_at::text AS updated_at
+SELECT profile, control_revision, control_digest,
+       ((extract(epoch FROM updated_at) * 1000000)::bigint)::text AS updated_at
 FROM access.semantic_attribute_control_state
 WHERE singleton
 FOR UPDATE;
@@ -18,7 +20,8 @@ SET control_revision = sqlc.arg(control_revision)::bigint,
     control_digest = sqlc.arg(control_digest)::text,
     updated_at = clock_timestamp()
 WHERE singleton
-RETURNING profile, control_revision, control_digest, updated_at::text AS updated_at;
+RETURNING profile, control_revision, control_digest,
+       ((extract(epoch FROM updated_at) * 1000000)::bigint)::text AS updated_at;
 
 -- name: InsertSemanticAttributeAssignment :one
 INSERT INTO access.semantic_attribute_assignment
@@ -33,16 +36,19 @@ VALUES
 RETURNING assignment_id::text AS assignment_id, definition_id::text AS definition_id,
           subject_kind, subject_id::text AS subject_id, definition_version,
           value_type, value_shape, canonical_values, value_digest,
-          assignment_version, COALESCE(tombstoned_at::text, '') AS tombstoned_at,
-          created_at::text AS created_at, updated_at::text AS updated_at;
+          assignment_version,
+          COALESCE(((extract(epoch FROM tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+          ((extract(epoch FROM created_at) * 1000000)::bigint)::text AS created_at,
+          ((extract(epoch FROM updated_at) * 1000000)::bigint)::text AS updated_at;
 
 -- name: GetActiveSemanticAttributeAssignment :one
 SELECT a.assignment_id::text AS assignment_id, a.definition_id::text AS definition_id,
        d.name AS definition_name, a.subject_kind, a.subject_id::text AS subject_id,
        a.definition_version, a.value_type, a.value_shape, a.canonical_values,
        a.value_digest, a.assignment_version,
-       COALESCE(a.tombstoned_at::text, '') AS tombstoned_at,
-       a.created_at::text AS created_at, a.updated_at::text AS updated_at
+       COALESCE(((extract(epoch FROM a.tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+       ((extract(epoch FROM a.created_at) * 1000000)::bigint)::text AS created_at,
+       ((extract(epoch FROM a.updated_at) * 1000000)::bigint)::text AS updated_at
 FROM access.semantic_attribute_assignment a
 JOIN access.semantic_attribute_definition d ON d.definition_id = a.definition_id
 WHERE a.definition_id = sqlc.arg(definition_id)::uuid
@@ -55,8 +61,9 @@ SELECT a.assignment_id::text AS assignment_id, a.definition_id::text AS definiti
        d.name AS definition_name, a.subject_kind, a.subject_id::text AS subject_id,
        a.definition_version, a.value_type, a.value_shape, a.canonical_values,
        a.value_digest, a.assignment_version,
-       COALESCE(a.tombstoned_at::text, '') AS tombstoned_at,
-       a.created_at::text AS created_at, a.updated_at::text AS updated_at
+       COALESCE(((extract(epoch FROM a.tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+       ((extract(epoch FROM a.created_at) * 1000000)::bigint)::text AS created_at,
+       ((extract(epoch FROM a.updated_at) * 1000000)::bigint)::text AS updated_at
 FROM access.semantic_attribute_assignment a
 JOIN access.semantic_attribute_definition d ON d.definition_id = a.definition_id
 WHERE a.assignment_id = sqlc.arg(assignment_id)::uuid;
@@ -66,8 +73,9 @@ SELECT a.assignment_id::text AS assignment_id, a.definition_id::text AS definiti
        d.name AS definition_name, a.subject_kind, a.subject_id::text AS subject_id,
        a.definition_version, a.value_type, a.value_shape, a.canonical_values,
        a.value_digest, a.assignment_version,
-       COALESCE(a.tombstoned_at::text, '') AS tombstoned_at,
-       a.created_at::text AS created_at, a.updated_at::text AS updated_at
+       COALESCE(((extract(epoch FROM a.tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+       ((extract(epoch FROM a.created_at) * 1000000)::bigint)::text AS created_at,
+       ((extract(epoch FROM a.updated_at) * 1000000)::bigint)::text AS updated_at
 FROM access.semantic_attribute_assignment a
 JOIN access.semantic_attribute_definition d ON d.definition_id = a.definition_id
 WHERE (sqlc.arg(definition_id)::text = '' OR a.definition_id::text = sqlc.arg(definition_id)::text)
@@ -88,8 +96,10 @@ WHERE assignment_id = sqlc.arg(assignment_id)::uuid
 RETURNING assignment_id::text AS assignment_id, definition_id::text AS definition_id,
           subject_kind, subject_id::text AS subject_id, definition_version,
           value_type, value_shape, canonical_values, value_digest,
-          assignment_version, COALESCE(tombstoned_at::text, '') AS tombstoned_at,
-          created_at::text AS created_at, updated_at::text AS updated_at;
+          assignment_version,
+          COALESCE(((extract(epoch FROM tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+          ((extract(epoch FROM created_at) * 1000000)::bigint)::text AS created_at,
+          ((extract(epoch FROM updated_at) * 1000000)::bigint)::text AS updated_at;
 
 -- name: TombstoneSemanticAttributeAssignment :one
 UPDATE access.semantic_attribute_assignment
@@ -101,8 +111,10 @@ WHERE assignment_id = sqlc.arg(assignment_id)::uuid
 RETURNING assignment_id::text AS assignment_id, definition_id::text AS definition_id,
           subject_kind, subject_id::text AS subject_id, definition_version,
           value_type, value_shape, canonical_values, value_digest,
-          assignment_version, COALESCE(tombstoned_at::text, '') AS tombstoned_at,
-          created_at::text AS created_at, updated_at::text AS updated_at;
+          assignment_version,
+          COALESCE(((extract(epoch FROM tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+          ((extract(epoch FROM created_at) * 1000000)::bigint)::text AS created_at,
+          ((extract(epoch FROM updated_at) * 1000000)::bigint)::text AS updated_at;
 
 -- name: InsertTrustedClaimMapping :one
 INSERT INTO access.semantic_attribute_claim_mapping
@@ -113,15 +125,18 @@ VALUES
      sqlc.arg(value_type)::text, sqlc.arg(value_shape)::text)
 RETURNING mapping_id::text AS mapping_id, source_kind, provider, issuer, audience, claim,
           definition_id::text AS definition_id, definition_version, value_type,
-          value_shape, mapping_version, COALESCE(tombstoned_at::text, '') AS tombstoned_at,
-          created_at::text AS created_at, updated_at::text AS updated_at;
+          value_shape, mapping_version,
+          COALESCE(((extract(epoch FROM tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+          ((extract(epoch FROM created_at) * 1000000)::bigint)::text AS created_at,
+          ((extract(epoch FROM updated_at) * 1000000)::bigint)::text AS updated_at;
 
 -- name: GetActiveTrustedClaimMapping :one
 SELECT m.mapping_id::text AS mapping_id, m.source_kind, m.provider, m.issuer, m.audience, m.claim,
        m.definition_id::text AS definition_id, d.name AS definition_name,
        m.definition_version, m.value_type, m.value_shape, m.mapping_version,
-       COALESCE(m.tombstoned_at::text, '') AS tombstoned_at,
-       m.created_at::text AS created_at, m.updated_at::text AS updated_at
+       COALESCE(((extract(epoch FROM m.tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+       ((extract(epoch FROM m.created_at) * 1000000)::bigint)::text AS created_at,
+       ((extract(epoch FROM m.updated_at) * 1000000)::bigint)::text AS updated_at
 FROM access.semantic_attribute_claim_mapping m
 JOIN access.semantic_attribute_definition d ON d.definition_id = m.definition_id
 WHERE m.source_kind = sqlc.arg(source_kind)::text AND m.provider = sqlc.arg(provider)::text
@@ -132,8 +147,9 @@ WHERE m.source_kind = sqlc.arg(source_kind)::text AND m.provider = sqlc.arg(prov
 SELECT m.mapping_id::text AS mapping_id, m.source_kind, m.provider, m.issuer, m.audience, m.claim,
        m.definition_id::text AS definition_id, d.name AS definition_name,
        m.definition_version, m.value_type, m.value_shape, m.mapping_version,
-       COALESCE(m.tombstoned_at::text, '') AS tombstoned_at,
-       m.created_at::text AS created_at, m.updated_at::text AS updated_at
+       COALESCE(((extract(epoch FROM m.tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+       ((extract(epoch FROM m.created_at) * 1000000)::bigint)::text AS created_at,
+       ((extract(epoch FROM m.updated_at) * 1000000)::bigint)::text AS updated_at
 FROM access.semantic_attribute_claim_mapping m
 JOIN access.semantic_attribute_definition d ON d.definition_id = m.definition_id
 WHERE m.mapping_id = sqlc.arg(mapping_id)::uuid;
@@ -142,8 +158,9 @@ WHERE m.mapping_id = sqlc.arg(mapping_id)::uuid;
 SELECT m.mapping_id::text AS mapping_id, m.source_kind, m.provider, m.issuer, m.audience, m.claim,
        m.definition_id::text AS definition_id, d.name AS definition_name,
        m.definition_version, m.value_type, m.value_shape, m.mapping_version,
-       COALESCE(m.tombstoned_at::text, '') AS tombstoned_at,
-       m.created_at::text AS created_at, m.updated_at::text AS updated_at
+       COALESCE(((extract(epoch FROM m.tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+       ((extract(epoch FROM m.created_at) * 1000000)::bigint)::text AS created_at,
+       ((extract(epoch FROM m.updated_at) * 1000000)::bigint)::text AS updated_at
 FROM access.semantic_attribute_claim_mapping m
 JOIN access.semantic_attribute_definition d ON d.definition_id = m.definition_id
 WHERE (sqlc.arg(source_kind)::text = '' OR m.source_kind = sqlc.arg(source_kind)::text)
@@ -164,8 +181,9 @@ WHERE mapping_id = sqlc.arg(mapping_id)::uuid
 RETURNING mapping_id::text AS mapping_id, source_kind, provider, issuer, audience, claim,
           definition_id::text AS definition_id, mapping_version,
           definition_version, value_type, value_shape,
-          COALESCE(tombstoned_at::text, '') AS tombstoned_at,
-          created_at::text AS created_at, updated_at::text AS updated_at;
+          COALESCE(((extract(epoch FROM tombstoned_at) * 1000000)::bigint)::text, '') AS tombstoned_at,
+          ((extract(epoch FROM created_at) * 1000000)::bigint)::text AS created_at,
+          ((extract(epoch FROM updated_at) * 1000000)::bigint)::text AS updated_at;
 
 -- name: ListPrincipalSemanticAttributeGroups :many
 SELECT pg.group_id::text AS group_id

--- a/internal/access/postgres/queries/semantic_attribute_control.sql
+++ b/internal/access/postgres/queries/semantic_attribute_control.sql
@@ -168,7 +168,10 @@ RETURNING mapping_id::text AS mapping_id, source_kind, provider, issuer, audienc
           created_at::text AS created_at, updated_at::text AS updated_at;
 
 -- name: ListPrincipalSemanticAttributeGroups :many
-SELECT group_id::text AS group_id
-FROM access.principal_group
-WHERE principal_id = sqlc.arg(principal_id)::uuid AND revoked_at IS NULL
-ORDER BY group_id;
+SELECT pg.group_id::text AS group_id
+FROM access.principal_group pg
+JOIN access.access_group g ON g.id = pg.group_id
+WHERE pg.principal_id = sqlc.arg(principal_id)::uuid
+  AND pg.revoked_at IS NULL
+  AND g.revoked_at IS NULL
+ORDER BY pg.group_id;

--- a/internal/access/postgres/queries/semantic_attribute_control.sql
+++ b/internal/access/postgres/queries/semantic_attribute_control.sql
@@ -1,0 +1,174 @@
+-- FAI-637 durable control leaves. The repository owns canonicalization,
+-- optimistic concurrency, control digest refresh, and audit coupling.
+
+-- name: GetSemanticAttributeControlState :one
+SELECT profile, control_revision, control_digest, updated_at::text AS updated_at
+FROM access.semantic_attribute_control_state
+WHERE singleton;
+
+-- name: LockSemanticAttributeControlState :one
+SELECT profile, control_revision, control_digest, updated_at::text AS updated_at
+FROM access.semantic_attribute_control_state
+WHERE singleton
+FOR UPDATE;
+
+-- name: UpdateSemanticAttributeControlState :one
+UPDATE access.semantic_attribute_control_state
+SET control_revision = sqlc.arg(control_revision)::bigint,
+    control_digest = sqlc.arg(control_digest)::text,
+    updated_at = clock_timestamp()
+WHERE singleton
+RETURNING profile, control_revision, control_digest, updated_at::text AS updated_at;
+
+-- name: InsertSemanticAttributeAssignment :one
+INSERT INTO access.semantic_attribute_assignment
+    (assignment_id, definition_id, subject_kind, subject_id, definition_version,
+     value_type, value_shape, canonical_values, value_digest)
+VALUES
+    (sqlc.arg(assignment_id)::uuid, sqlc.arg(definition_id)::uuid,
+     sqlc.arg(subject_kind)::text, sqlc.arg(subject_id)::uuid,
+     sqlc.arg(definition_version)::bigint, sqlc.arg(value_type)::text,
+     sqlc.arg(value_shape)::text, sqlc.arg(canonical_values)::text[],
+     sqlc.arg(value_digest)::text)
+RETURNING assignment_id::text AS assignment_id, definition_id::text AS definition_id,
+          subject_kind, subject_id::text AS subject_id, definition_version,
+          value_type, value_shape, canonical_values, value_digest,
+          assignment_version, COALESCE(tombstoned_at::text, '') AS tombstoned_at,
+          created_at::text AS created_at, updated_at::text AS updated_at;
+
+-- name: GetActiveSemanticAttributeAssignment :one
+SELECT a.assignment_id::text AS assignment_id, a.definition_id::text AS definition_id,
+       d.name AS definition_name, a.subject_kind, a.subject_id::text AS subject_id,
+       a.definition_version, a.value_type, a.value_shape, a.canonical_values,
+       a.value_digest, a.assignment_version,
+       COALESCE(a.tombstoned_at::text, '') AS tombstoned_at,
+       a.created_at::text AS created_at, a.updated_at::text AS updated_at
+FROM access.semantic_attribute_assignment a
+JOIN access.semantic_attribute_definition d ON d.definition_id = a.definition_id
+WHERE a.definition_id = sqlc.arg(definition_id)::uuid
+  AND a.subject_kind = sqlc.arg(subject_kind)::text
+  AND a.subject_id = sqlc.arg(subject_id)::uuid
+  AND a.tombstoned_at IS NULL;
+
+-- name: GetSemanticAttributeAssignment :one
+SELECT a.assignment_id::text AS assignment_id, a.definition_id::text AS definition_id,
+       d.name AS definition_name, a.subject_kind, a.subject_id::text AS subject_id,
+       a.definition_version, a.value_type, a.value_shape, a.canonical_values,
+       a.value_digest, a.assignment_version,
+       COALESCE(a.tombstoned_at::text, '') AS tombstoned_at,
+       a.created_at::text AS created_at, a.updated_at::text AS updated_at
+FROM access.semantic_attribute_assignment a
+JOIN access.semantic_attribute_definition d ON d.definition_id = a.definition_id
+WHERE a.assignment_id = sqlc.arg(assignment_id)::uuid;
+
+-- name: ListSemanticAttributeAssignments :many
+SELECT a.assignment_id::text AS assignment_id, a.definition_id::text AS definition_id,
+       d.name AS definition_name, a.subject_kind, a.subject_id::text AS subject_id,
+       a.definition_version, a.value_type, a.value_shape, a.canonical_values,
+       a.value_digest, a.assignment_version,
+       COALESCE(a.tombstoned_at::text, '') AS tombstoned_at,
+       a.created_at::text AS created_at, a.updated_at::text AS updated_at
+FROM access.semantic_attribute_assignment a
+JOIN access.semantic_attribute_definition d ON d.definition_id = a.definition_id
+WHERE (sqlc.arg(definition_id)::text = '' OR a.definition_id::text = sqlc.arg(definition_id)::text)
+  AND (sqlc.arg(subject_kind)::text = '' OR a.subject_kind = sqlc.arg(subject_kind)::text)
+  AND (sqlc.arg(subject_id)::text = '' OR a.subject_id::text = sqlc.arg(subject_id)::text)
+  AND (sqlc.arg(include_tombstones)::boolean OR a.tombstoned_at IS NULL)
+ORDER BY a.definition_id, a.subject_kind, a.subject_id, a.created_at, a.assignment_id;
+
+-- name: UpdateSemanticAttributeAssignment :one
+UPDATE access.semantic_attribute_assignment
+SET canonical_values = sqlc.arg(canonical_values)::text[],
+    value_digest = sqlc.arg(value_digest)::text,
+    assignment_version = assignment_version + 1,
+    updated_at = clock_timestamp()
+WHERE assignment_id = sqlc.arg(assignment_id)::uuid
+  AND assignment_version = sqlc.arg(expected_version)::bigint
+  AND tombstoned_at IS NULL
+RETURNING assignment_id::text AS assignment_id, definition_id::text AS definition_id,
+          subject_kind, subject_id::text AS subject_id, definition_version,
+          value_type, value_shape, canonical_values, value_digest,
+          assignment_version, COALESCE(tombstoned_at::text, '') AS tombstoned_at,
+          created_at::text AS created_at, updated_at::text AS updated_at;
+
+-- name: TombstoneSemanticAttributeAssignment :one
+UPDATE access.semantic_attribute_assignment
+SET tombstoned_at = clock_timestamp(), assignment_version = assignment_version + 1,
+    updated_at = clock_timestamp()
+WHERE assignment_id = sqlc.arg(assignment_id)::uuid
+  AND assignment_version = sqlc.arg(expected_version)::bigint
+  AND tombstoned_at IS NULL
+RETURNING assignment_id::text AS assignment_id, definition_id::text AS definition_id,
+          subject_kind, subject_id::text AS subject_id, definition_version,
+          value_type, value_shape, canonical_values, value_digest,
+          assignment_version, COALESCE(tombstoned_at::text, '') AS tombstoned_at,
+          created_at::text AS created_at, updated_at::text AS updated_at;
+
+-- name: InsertTrustedClaimMapping :one
+INSERT INTO access.semantic_attribute_claim_mapping
+    (mapping_id, source_kind, provider, issuer, audience, claim, definition_id, definition_version, value_type, value_shape)
+VALUES
+    (sqlc.arg(mapping_id)::uuid, sqlc.arg(source_kind)::text, sqlc.arg(provider)::text, sqlc.arg(issuer)::text, sqlc.arg(audience)::text, sqlc.arg(claim)::text,
+     sqlc.arg(definition_id)::uuid, sqlc.arg(definition_version)::bigint,
+     sqlc.arg(value_type)::text, sqlc.arg(value_shape)::text)
+RETURNING mapping_id::text AS mapping_id, source_kind, provider, issuer, audience, claim,
+          definition_id::text AS definition_id, definition_version, value_type,
+          value_shape, mapping_version, COALESCE(tombstoned_at::text, '') AS tombstoned_at,
+          created_at::text AS created_at, updated_at::text AS updated_at;
+
+-- name: GetActiveTrustedClaimMapping :one
+SELECT m.mapping_id::text AS mapping_id, m.source_kind, m.provider, m.issuer, m.audience, m.claim,
+       m.definition_id::text AS definition_id, d.name AS definition_name,
+       m.definition_version, m.value_type, m.value_shape, m.mapping_version,
+       COALESCE(m.tombstoned_at::text, '') AS tombstoned_at,
+       m.created_at::text AS created_at, m.updated_at::text AS updated_at
+FROM access.semantic_attribute_claim_mapping m
+JOIN access.semantic_attribute_definition d ON d.definition_id = m.definition_id
+WHERE m.source_kind = sqlc.arg(source_kind)::text AND m.provider = sqlc.arg(provider)::text
+  AND m.issuer = sqlc.arg(issuer)::text AND m.audience = sqlc.arg(audience)::text
+  AND m.claim = sqlc.arg(claim)::text AND m.definition_id = sqlc.arg(definition_id)::uuid AND m.tombstoned_at IS NULL;
+
+-- name: GetTrustedClaimMapping :one
+SELECT m.mapping_id::text AS mapping_id, m.source_kind, m.provider, m.issuer, m.audience, m.claim,
+       m.definition_id::text AS definition_id, d.name AS definition_name,
+       m.definition_version, m.value_type, m.value_shape, m.mapping_version,
+       COALESCE(m.tombstoned_at::text, '') AS tombstoned_at,
+       m.created_at::text AS created_at, m.updated_at::text AS updated_at
+FROM access.semantic_attribute_claim_mapping m
+JOIN access.semantic_attribute_definition d ON d.definition_id = m.definition_id
+WHERE m.mapping_id = sqlc.arg(mapping_id)::uuid;
+
+-- name: ListTrustedClaimMappings :many
+SELECT m.mapping_id::text AS mapping_id, m.source_kind, m.provider, m.issuer, m.audience, m.claim,
+       m.definition_id::text AS definition_id, d.name AS definition_name,
+       m.definition_version, m.value_type, m.value_shape, m.mapping_version,
+       COALESCE(m.tombstoned_at::text, '') AS tombstoned_at,
+       m.created_at::text AS created_at, m.updated_at::text AS updated_at
+FROM access.semantic_attribute_claim_mapping m
+JOIN access.semantic_attribute_definition d ON d.definition_id = m.definition_id
+WHERE (sqlc.arg(source_kind)::text = '' OR m.source_kind = sqlc.arg(source_kind)::text)
+  AND (sqlc.arg(provider)::text = '' OR m.provider = sqlc.arg(provider)::text)
+  AND (sqlc.arg(issuer)::text = '' OR m.issuer = sqlc.arg(issuer)::text)
+  AND (sqlc.arg(audience)::text = '' OR m.audience = sqlc.arg(audience)::text)
+  AND (sqlc.arg(claim)::text = '' OR m.claim = sqlc.arg(claim)::text)
+  AND (sqlc.arg(include_tombstones)::boolean OR m.tombstoned_at IS NULL)
+ORDER BY m.source_kind, m.provider, m.issuer, m.audience, m.claim, m.definition_id, m.created_at, m.mapping_id;
+
+-- name: TombstoneTrustedClaimMapping :one
+UPDATE access.semantic_attribute_claim_mapping
+SET tombstoned_at = clock_timestamp(), mapping_version = mapping_version + 1,
+    updated_at = clock_timestamp()
+WHERE mapping_id = sqlc.arg(mapping_id)::uuid
+  AND mapping_version = sqlc.arg(expected_version)::bigint
+  AND tombstoned_at IS NULL
+RETURNING mapping_id::text AS mapping_id, source_kind, provider, issuer, audience, claim,
+          definition_id::text AS definition_id, mapping_version,
+          definition_version, value_type, value_shape,
+          COALESCE(tombstoned_at::text, '') AS tombstoned_at,
+          created_at::text AS created_at, updated_at::text AS updated_at;
+
+-- name: ListPrincipalSemanticAttributeGroups :many
+SELECT group_id::text AS group_id
+FROM access.principal_group
+WHERE principal_id = sqlc.arg(principal_id)::uuid AND revoked_at IS NULL
+ORDER BY group_id;

--- a/internal/access/postgres/queries/semantic_attributes.sql
+++ b/internal/access/postgres/queries/semantic_attributes.sql
@@ -37,6 +37,18 @@ RETURNING definition_id::text AS definition_id, name, value_type, value_shape,
           COALESCE(disabled_at::text, '')::text AS disabled_at,
           created_at::text AS created_at, updated_at::text AS updated_at;
 
+-- name: SemanticAttributePrincipalOwnerExists :one
+SELECT EXISTS (
+    SELECT 1 FROM access.principal
+    WHERE id = sqlc.arg(owner_id)::uuid AND revoked_at IS NULL
+);
+
+-- name: SemanticAttributeGroupOwnerExists :one
+SELECT EXISTS (
+    SELECT 1 FROM access.access_group
+    WHERE id = sqlc.arg(owner_id)::uuid AND revoked_at IS NULL
+);
+
 -- name: GetSemanticAttributeDefinition :one
 SELECT definition_id::text AS definition_id, name, value_type, value_shape,
        profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,
@@ -88,6 +100,7 @@ SET owner_kind = sqlc.arg(owner_kind)::text,
     definition_version = definition_version + 1,
     updated_at = clock_timestamp()
 WHERE name = sqlc.arg(name)::text
+  AND (sqlc.arg(expected_version)::bigint <= 0 OR definition_version = sqlc.arg(expected_version)::bigint)
   AND (owner_kind, owner_id, display_name, description, documentation_url)
       IS DISTINCT FROM
       (sqlc.arg(owner_kind)::text, NULLIF(sqlc.arg(owner_id)::text, '')::uuid,
@@ -106,6 +119,7 @@ SET enabled = sqlc.arg(enabled)::boolean,
     definition_version = definition_version + 1,
     updated_at = clock_timestamp()
 WHERE name = sqlc.arg(name)::text
+  AND (sqlc.arg(expected_version)::bigint <= 0 OR definition_version = sqlc.arg(expected_version)::bigint)
   AND enabled <> sqlc.arg(enabled)::boolean
 RETURNING definition_id::text AS definition_id, name, value_type, value_shape,
           profile, definition_version, owner_kind, COALESCE(owner_id::text, '')::text AS owner_id, display_name,

--- a/internal/access/postgres/queries/semantic_attributes.sql
+++ b/internal/access/postgres/queries/semantic_attributes.sql
@@ -83,11 +83,16 @@ SELECT definition_id::text AS definition_id, name, value_type, value_shape,
        COALESCE(disabled_at::text, '')::text AS disabled_at,
        created_at::text AS created_at, updated_at::text AS updated_at
 FROM access.semantic_attribute_definition
-WHERE sqlc.arg(search_query)::text = ''
+WHERE (sqlc.arg(search_query)::text = ''
    OR strpos(lower(name), lower(sqlc.arg(search_query)::text)) > 0
    OR strpos(lower(display_name), lower(sqlc.arg(search_query)::text)) > 0
-   OR strpos(lower(description), lower(sqlc.arg(search_query)::text)) > 0
-ORDER BY name
+   OR strpos(lower(description), lower(sqlc.arg(search_query)::text)) > 0)
+  AND (sqlc.arg(owner_kind)::text = '' OR owner_kind = sqlc.arg(owner_kind)::text)
+  AND (sqlc.arg(after_name)::text = ''
+       OR name > sqlc.arg(after_name)::text
+       OR (name = sqlc.arg(after_name)::text
+           AND definition_id > NULLIF(sqlc.arg(after_definition_id)::text, '')::uuid))
+ORDER BY name, definition_id
 LIMIT sqlc.arg(page_size)::int;
 
 -- name: UpdateSemanticAttributeDefinitionMetadata :one

--- a/internal/access/postgres/semantic_attribute_assignments.go
+++ b/internal/access/postgres/semantic_attribute_assignments.go
@@ -105,7 +105,7 @@ func (r *Repository) setSemanticAttributeAssignmentCore(ctx context.Context, db 
 }
 
 func assignmentFromActive(row accessdb.GetActiveSemanticAttributeAssignmentRow) access.SemanticAttributeAssignment {
-	return access.SemanticAttributeAssignment{ID: row.AssignmentID, DefinitionID: row.DefinitionID, DefinitionName: row.DefinitionName, DefinitionVersion: row.DefinitionVersion, Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape), Subject: access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID}, CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest, AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+	return access.SemanticAttributeAssignment{ID: row.AssignmentID, DefinitionID: row.DefinitionID, DefinitionName: row.DefinitionName, DefinitionVersion: row.DefinitionVersion, Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape), Subject: access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID}, CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest, AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: timestampAPIValue(row.TombstonedAt), CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func mustPGUUID(value string) pgtype.UUID {

--- a/internal/access/postgres/semantic_attribute_assignments.go
+++ b/internal/access/postgres/semantic_attribute_assignments.go
@@ -66,7 +66,7 @@ func (r *Repository) setSemanticAttributeAssignmentCore(ctx context.Context, db 
 			return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, fmt.Errorf("%w: expected %d, current %d", access.ErrSemanticAttributeAssignmentConflict, input.ExpectedVersion, current.AssignmentVersion)
 		}
 		if current.ValueDigest == digest && reflect.DeepEqual(current.CanonicalValues, values) {
-			return current, semanticAttributeControlAudit(input.Mutation, "semantic_attribute.assignment.replay", current, state), nil
+			return current, semanticAttributeControlAudit(input.Mutation, access.SemanticAttributeAuditActionAssignmentReplay, current, state), nil
 		}
 		updated, updateErr := queries.UpdateSemanticAttributeAssignment(ctx, accessdb.UpdateSemanticAttributeAssignmentParams{CanonicalValues: values, ValueDigest: digest, AssignmentID: mustPGUUID(current.ID), ExpectedVersion: input.ExpectedVersion})
 		if updateErr != nil {
@@ -80,7 +80,7 @@ func (r *Repository) setSemanticAttributeAssignmentCore(ctx context.Context, db 
 		if advanceErr != nil {
 			return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, advanceErr
 		}
-		return result, semanticAttributeControlAudit(input.Mutation, "semantic_attribute.assignment.set", result, next), nil
+		return result, semanticAttributeControlAudit(input.Mutation, access.SemanticAttributeAuditActionAssignmentSet, result, next), nil
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
@@ -101,7 +101,7 @@ func (r *Repository) setSemanticAttributeAssignmentCore(ctx context.Context, db 
 	if err != nil {
 		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
 	}
-	return result, semanticAttributeControlAudit(input.Mutation, "semantic_attribute.assignment.set", result, next), nil
+	return result, semanticAttributeControlAudit(input.Mutation, access.SemanticAttributeAuditActionAssignmentSet, result, next), nil
 }
 
 func assignmentFromActive(row accessdb.GetActiveSemanticAttributeAssignmentRow) access.SemanticAttributeAssignment {
@@ -178,7 +178,7 @@ func tombstoneSemanticAttributeAssignmentCore(ctx context.Context, db DBTX, id s
 	if err != nil {
 		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
 	}
-	return result, semanticAttributeControlAudit(mutation, "semantic_attribute.assignment.tombstone", result, next), nil
+	return result, semanticAttributeControlAudit(mutation, access.SemanticAttributeAuditActionAssignmentTombstone, result, next), nil
 }
 
 func TombstoneSemanticAttributeAssignmentTx(ctx context.Context, tx Tx, id string, expected int64, mutation access.SemanticAttributeMutationContext) (access.SemanticAttributeAssignment, error) {

--- a/internal/access/postgres/semantic_attribute_assignments.go
+++ b/internal/access/postgres/semantic_attribute_assignments.go
@@ -1,0 +1,212 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/flidai/leapview/internal/access"
+	accessdb "github.com/flidai/leapview/internal/access/postgres/internal/db"
+	"github.com/flidai/leapview/internal/semanticvalue"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func (r *Repository) setSemanticAttributeAssignmentCore(ctx context.Context, db DBTX, input access.SemanticAttributeAssignmentInput) (access.SemanticAttributeAssignment, access.AuditEventInput, error) {
+	if err := access.ValidateSemanticAttributeSubject(input.Subject); err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	canonicalSubjectID, err := uuidID("semantic attribute subject id", input.Subject.ID)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	input.Subject.ID = canonicalSubjectID
+	if input.ExpectedVersion < 0 {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, errors.New("semantic attribute assignment expected version cannot be negative")
+	}
+	requestedID := ""
+	if input.AssignmentID != "" {
+		requestedID, err = uuidID("semantic attribute assignment id", input.AssignmentID)
+		if err != nil {
+			return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+		}
+	}
+	var definition access.SemanticAttributeDefinition
+	if input.DefinitionID != "" {
+		definition, err = (&Repository{db: db}).SemanticAttributeDefinitionByID(ctx, input.DefinitionID)
+	} else if input.DefinitionName != "" {
+		definition, err = (&Repository{db: db}).SemanticAttributeDefinition(ctx, input.DefinitionName)
+	} else {
+		err = errors.New("semantic attribute assignment definition id or name is required")
+	}
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	values, digest, err := access.CanonicalSemanticAttributeValues(definition, input.Values)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	state, err := lockSemanticAttributeControlState(ctx, db)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	if _, _, err := validateSemanticAttributeControlState(ctx, db, state); err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	queries := accessdb.New(db)
+	existing, err := queries.GetActiveSemanticAttributeAssignment(ctx, accessdb.GetActiveSemanticAttributeAssignmentParams{DefinitionID: mustPGUUID(definition.ID), SubjectKind: string(input.Subject.Kind), SubjectID: mustPGUUID(input.Subject.ID)})
+	if err == nil {
+		current := assignmentFromActive(existing)
+		if requestedID != "" && requestedID != current.ID {
+			return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, fmt.Errorf("%w: assignment identity does not match the definition and subject", access.ErrSemanticAttributeAssignmentConflict)
+		}
+		if input.ExpectedVersion != current.AssignmentVersion {
+			return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, fmt.Errorf("%w: expected %d, current %d", access.ErrSemanticAttributeAssignmentConflict, input.ExpectedVersion, current.AssignmentVersion)
+		}
+		if current.ValueDigest == digest && reflect.DeepEqual(current.CanonicalValues, values) {
+			return current, semanticAttributeControlAudit(input.Mutation, "semantic_attribute.assignment.replay", current, state), nil
+		}
+		updated, updateErr := queries.UpdateSemanticAttributeAssignment(ctx, accessdb.UpdateSemanticAttributeAssignmentParams{CanonicalValues: values, ValueDigest: digest, AssignmentID: mustPGUUID(current.ID), ExpectedVersion: input.ExpectedVersion})
+		if updateErr != nil {
+			if errors.Is(updateErr, pgx.ErrNoRows) {
+				return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, fmt.Errorf("%w: expected %d", access.ErrSemanticAttributeAssignmentConflict, input.ExpectedVersion)
+			}
+			return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, updateErr
+		}
+		result := assignmentFromUpdate(updated, definition.Name)
+		next, advanceErr := advanceSemanticAttributeControl(ctx, db, state)
+		if advanceErr != nil {
+			return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, advanceErr
+		}
+		return result, semanticAttributeControlAudit(input.Mutation, "semantic_attribute.assignment.set", result, next), nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	if input.ExpectedVersion != 0 {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, fmt.Errorf("%w: assignment does not exist, expected %d", access.ErrSemanticAttributeAssignmentConflict, input.ExpectedVersion)
+	}
+	id, err := newUUID()
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	inserted, err := queries.InsertSemanticAttributeAssignment(ctx, accessdb.InsertSemanticAttributeAssignmentParams{AssignmentID: mustPGUUID(id), DefinitionID: mustPGUUID(definition.ID), SubjectKind: string(input.Subject.Kind), SubjectID: mustPGUUID(input.Subject.ID), DefinitionVersion: definition.DefinitionVersion, ValueType: string(definition.Type), ValueShape: string(definition.Shape), CanonicalValues: values, ValueDigest: digest})
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	result := assignmentFromInsert(inserted, definition.Name)
+	next, err := advanceSemanticAttributeControl(ctx, db, state)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	return result, semanticAttributeControlAudit(input.Mutation, "semantic_attribute.assignment.set", result, next), nil
+}
+
+func assignmentFromActive(row accessdb.GetActiveSemanticAttributeAssignmentRow) access.SemanticAttributeAssignment {
+	return access.SemanticAttributeAssignment{ID: row.AssignmentID, DefinitionID: row.DefinitionID, DefinitionName: row.DefinitionName, DefinitionVersion: row.DefinitionVersion, Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape), Subject: access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID}, CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest, AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func mustPGUUID(value string) pgtype.UUID {
+	parsed, _ := pgUUID(value)
+	return parsed
+}
+
+func (r *Repository) SetSemanticAttributeAssignment(ctx context.Context, input access.SemanticAttributeAssignmentInput) (result access.SemanticAttributeAssignment, err error) {
+	err = r.RunAuditedMutation(ctx, func(repo access.Repository) (access.AuditEventInput, error) {
+		var audit access.AuditEventInput
+		var coreErr error
+		result, audit, coreErr = repo.(*Repository).setSemanticAttributeAssignmentCore(ctx, repo.(*Repository).db, input)
+		return audit, coreErr
+	})
+	return result, err
+}
+
+func SetSemanticAttributeAssignmentTx(ctx context.Context, tx Tx, input access.SemanticAttributeAssignmentInput) (access.SemanticAttributeAssignment, error) {
+	if tx == nil {
+		return access.SemanticAttributeAssignment{}, errors.New("semantic attribute assignment PostgreSQL transaction is required")
+	}
+	result, audit, err := (&Repository{db: tx}).setSemanticAttributeAssignmentCore(ctx, tx, input)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, err
+	}
+	if err := (&Repository{db: tx}).RecordAuditEvent(ctx, audit); err != nil {
+		return access.SemanticAttributeAssignment{}, fmt.Errorf("record semantic attribute assignment audit: %w", err)
+	}
+	return result, nil
+}
+
+func (r *Repository) TombstoneSemanticAttributeAssignment(ctx context.Context, id string, expected int64, mutation access.SemanticAttributeMutationContext) (result access.SemanticAttributeAssignment, err error) {
+	err = r.RunAuditedMutation(ctx, func(repo access.Repository) (access.AuditEventInput, error) {
+		var audit access.AuditEventInput
+		var coreErr error
+		result, audit, coreErr = tombstoneSemanticAttributeAssignmentCore(ctx, repo.(*Repository).db, id, expected, mutation)
+		return audit, coreErr
+	})
+	return result, err
+}
+
+func tombstoneSemanticAttributeAssignmentCore(ctx context.Context, db DBTX, id string, expected int64, mutation access.SemanticAttributeMutationContext) (access.SemanticAttributeAssignment, access.AuditEventInput, error) {
+	if expected <= 0 {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, errors.New("semantic attribute assignment expected version must be positive")
+	}
+	canonicalID, err := uuidID("semantic attribute assignment id", id)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	state, err := lockSemanticAttributeControlState(ctx, db)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	if _, _, err := validateSemanticAttributeControlState(ctx, db, state); err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	row, err := accessdb.New(db).TombstoneSemanticAttributeAssignment(ctx, accessdb.TombstoneSemanticAttributeAssignmentParams{AssignmentID: mustPGUUID(canonicalID), ExpectedVersion: expected})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, fmt.Errorf("%w: expected %d", access.ErrSemanticAttributeAssignmentConflict, expected)
+		}
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	definition, err := (&Repository{db: db}).SemanticAttributeDefinitionByID(ctx, row.DefinitionID)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	result := assignmentFromTombstone(row, definition.Name)
+	next, err := advanceSemanticAttributeControl(ctx, db, state)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, access.AuditEventInput{}, err
+	}
+	return result, semanticAttributeControlAudit(mutation, "semantic_attribute.assignment.tombstone", result, next), nil
+}
+
+func TombstoneSemanticAttributeAssignmentTx(ctx context.Context, tx Tx, id string, expected int64, mutation access.SemanticAttributeMutationContext) (access.SemanticAttributeAssignment, error) {
+	if tx == nil {
+		return access.SemanticAttributeAssignment{}, errors.New("semantic attribute assignment PostgreSQL transaction is required")
+	}
+	result, audit, err := tombstoneSemanticAttributeAssignmentCore(ctx, tx, id, expected, mutation)
+	if err != nil {
+		return access.SemanticAttributeAssignment{}, err
+	}
+	if err := (&Repository{db: tx}).RecordAuditEvent(ctx, audit); err != nil {
+		return access.SemanticAttributeAssignment{}, fmt.Errorf("record semantic attribute assignment audit: %w", err)
+	}
+	return result, nil
+}
+
+func semanticAttributeControlAudit(mutation access.SemanticAttributeMutationContext, action string, row access.SemanticAttributeAssignment, state semanticAttributeControlStateRow) access.AuditEventInput {
+	metadata, _ := json.Marshal(struct {
+		DefinitionID      string `json:"definitionId"`
+		DefinitionName    string `json:"definitionName"`
+		SubjectKind       string `json:"subjectKind"`
+		SubjectID         string `json:"subjectId"`
+		DefinitionVersion int64  `json:"definitionVersion"`
+		AssignmentVersion int64  `json:"assignmentVersion"`
+		ControlRevision   int64  `json:"controlRevision"`
+		ValueCount        int    `json:"valueCount"`
+		Tombstoned        bool   `json:"tombstoned"`
+		ControlDigest     string `json:"controlDigest"`
+	}{row.DefinitionID, row.DefinitionName, string(row.Subject.Kind), row.Subject.ID, row.DefinitionVersion, row.AssignmentVersion, state.Revision, len(row.CanonicalValues), row.Tombstoned, state.Digest})
+	return access.AuditEventInput{PrincipalID: mutation.ActorPrincipalID, Action: action, ResourceKind: "semantic_attribute_assignment", ResourceID: row.ID, Capability: access.CapabilityProjectAdmin, Status: "success", RequestID: mutation.RequestID, CorrelationID: mutation.CorrelationID, MetadataJSON: string(metadata)}
+}

--- a/internal/access/postgres/semantic_attribute_claims.go
+++ b/internal/access/postgres/semantic_attribute_claims.go
@@ -63,7 +63,7 @@ func (r *Repository) setTrustedClaimMappingCore(ctx context.Context, db DBTX, in
 		if input.ExpectedVersion != current.MappingVersion {
 			return access.TrustedClaimMapping{}, access.AuditEventInput{}, fmt.Errorf("%w: expected %d, current %d", access.ErrSemanticAttributeMappingConflict, input.ExpectedVersion, current.MappingVersion)
 		}
-		return current, semanticAttributeMappingAudit(input.Mutation, "semantic_attribute.claim_mapping.replay", current, state), nil
+		return current, semanticAttributeMappingAudit(input.Mutation, access.SemanticAttributeAuditActionClaimMappingReplay, current, state), nil
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
@@ -84,7 +84,7 @@ func (r *Repository) setTrustedClaimMappingCore(ctx context.Context, db DBTX, in
 	if err != nil {
 		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
 	}
-	return result, semanticAttributeMappingAudit(input.Mutation, "semantic_attribute.claim_mapping.set", result, next), nil
+	return result, semanticAttributeMappingAudit(input.Mutation, access.SemanticAttributeAuditActionClaimMappingSet, result, next), nil
 }
 
 func (r *Repository) SetTrustedClaimMapping(ctx context.Context, input access.TrustedClaimMappingInput) (result access.TrustedClaimMapping, err error) {
@@ -152,7 +152,7 @@ func tombstoneTrustedClaimMappingCore(ctx context.Context, db DBTX, id string, e
 	if err != nil {
 		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
 	}
-	return result, semanticAttributeMappingAudit(mutation, "semantic_attribute.claim_mapping.tombstone", result, next), nil
+	return result, semanticAttributeMappingAudit(mutation, access.SemanticAttributeAuditActionClaimMappingTombstone, result, next), nil
 }
 
 func TombstoneTrustedClaimMappingTx(ctx context.Context, tx Tx, id string, expected int64, mutation access.SemanticAttributeMutationContext) (access.TrustedClaimMapping, error) {
@@ -201,6 +201,15 @@ func (r *Repository) EffectiveDirectSemanticAttributeAssignments(ctx context.Con
 func (r *Repository) EffectiveSemanticAttributeAssignments(ctx context.Context, subject access.SubjectRef, envelope trustedclaims.Envelope) ([]access.EffectiveSemanticAttribute, error) {
 	if !envelope.Valid() {
 		return nil, fmt.Errorf("%w: trusted claim envelope is invalid", trustedclaims.ErrInvalidEvidence)
+	}
+	if err := access.ValidateSemanticAttributeSubject(subject); err != nil {
+		return nil, err
+	}
+	if subject.Kind != access.SubjectKindPrincipal {
+		return nil, fmt.Errorf("%w: trusted claims require a principal subject", trustedclaims.ErrInvalidEvidence)
+	}
+	if envelope.Subject() != subject.ID {
+		return nil, fmt.Errorf("%w: trusted claim subject does not match requested principal", trustedclaims.ErrInvalidEvidence)
 	}
 	now := time.Now().UTC()
 	if now.Before(envelope.NotBefore()) {

--- a/internal/access/postgres/semantic_attribute_claims.go
+++ b/internal/access/postgres/semantic_attribute_claims.go
@@ -1,0 +1,351 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	accessdb "github.com/flidai/leapview/internal/access/postgres/internal/db"
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+	"github.com/flidai/leapview/internal/semanticvalue"
+	"github.com/jackc/pgx/v5"
+)
+
+func mappingFromActive(row accessdb.GetActiveTrustedClaimMappingRow) access.TrustedClaimMapping {
+	return access.TrustedClaimMapping{ID: row.MappingID, SourceKind: access.TrustedClaimSourceKind(row.SourceKind), Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim, DefinitionID: row.DefinitionID, DefinitionName: row.DefinitionName, DefinitionVersion: row.DefinitionVersion, Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape), MappingVersion: row.MappingVersion, Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func (r *Repository) setTrustedClaimMappingCore(ctx context.Context, db DBTX, input access.TrustedClaimMappingInput) (access.TrustedClaimMapping, access.AuditEventInput, error) {
+	source, claim, err := canonicalTrustedClaim(access.TrustedClaimSource{Kind: input.SourceKind, Provider: input.Provider, Issuer: input.Issuer, Audience: input.Audience}, input.Claim)
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	if input.ExpectedVersion < 0 {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, errors.New("trusted claim mapping expected version cannot be negative")
+	}
+	requestedID := ""
+	if input.MappingID != "" {
+		requestedID, err = uuidID("trusted claim mapping id", input.MappingID)
+		if err != nil {
+			return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+		}
+	}
+	var definition access.SemanticAttributeDefinition
+	if input.DefinitionID != "" {
+		definition, err = (&Repository{db: db}).SemanticAttributeDefinitionByID(ctx, input.DefinitionID)
+	} else if input.DefinitionName != "" {
+		definition, err = (&Repository{db: db}).SemanticAttributeDefinition(ctx, input.DefinitionName)
+	} else {
+		err = errors.New("trusted claim mapping definition id or name is required")
+	}
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	state, err := lockSemanticAttributeControlState(ctx, db)
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	if _, _, err := validateSemanticAttributeControlState(ctx, db, state); err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	queries := accessdb.New(db)
+	existing, err := queries.GetActiveTrustedClaimMapping(ctx, accessdb.GetActiveTrustedClaimMappingParams{SourceKind: string(source.Kind), Provider: source.Provider, Issuer: source.Issuer, Audience: source.Audience, Claim: claim, DefinitionID: mustPGUUID(definition.ID)})
+	if err == nil {
+		current := mappingFromActive(existing)
+		if requestedID != "" && requestedID != current.ID {
+			return access.TrustedClaimMapping{}, access.AuditEventInput{}, fmt.Errorf("%w: mapping identity does not match the source and claim", access.ErrSemanticAttributeMappingConflict)
+		}
+		if input.ExpectedVersion != current.MappingVersion {
+			return access.TrustedClaimMapping{}, access.AuditEventInput{}, fmt.Errorf("%w: expected %d, current %d", access.ErrSemanticAttributeMappingConflict, input.ExpectedVersion, current.MappingVersion)
+		}
+		return current, semanticAttributeMappingAudit(input.Mutation, "semantic_attribute.claim_mapping.replay", current, state), nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	if input.ExpectedVersion != 0 {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, fmt.Errorf("%w: mapping does not exist, expected %d", access.ErrSemanticAttributeMappingConflict, input.ExpectedVersion)
+	}
+	id, err := newUUID()
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	row, err := queries.InsertTrustedClaimMapping(ctx, accessdb.InsertTrustedClaimMappingParams{MappingID: mustPGUUID(id), SourceKind: string(source.Kind), Provider: source.Provider, Issuer: source.Issuer, Audience: source.Audience, Claim: claim, DefinitionID: mustPGUUID(definition.ID), DefinitionVersion: definition.DefinitionVersion, ValueType: string(definition.Type), ValueShape: string(definition.Shape)})
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	result := mappingFromInsert(row, definition.Name)
+	next, err := advanceSemanticAttributeControl(ctx, db, state)
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	return result, semanticAttributeMappingAudit(input.Mutation, "semantic_attribute.claim_mapping.set", result, next), nil
+}
+
+func (r *Repository) SetTrustedClaimMapping(ctx context.Context, input access.TrustedClaimMappingInput) (result access.TrustedClaimMapping, err error) {
+	err = r.RunAuditedMutation(ctx, func(repo access.Repository) (access.AuditEventInput, error) {
+		var audit access.AuditEventInput
+		var coreErr error
+		result, audit, coreErr = repo.(*Repository).setTrustedClaimMappingCore(ctx, repo.(*Repository).db, input)
+		return audit, coreErr
+	})
+	return result, err
+}
+
+func SetTrustedClaimMappingTx(ctx context.Context, tx Tx, input access.TrustedClaimMappingInput) (access.TrustedClaimMapping, error) {
+	if tx == nil {
+		return access.TrustedClaimMapping{}, errors.New("trusted claim mapping PostgreSQL transaction is required")
+	}
+	result, audit, err := (&Repository{db: tx}).setTrustedClaimMappingCore(ctx, tx, input)
+	if err != nil {
+		return access.TrustedClaimMapping{}, err
+	}
+	if err := (&Repository{db: tx}).RecordAuditEvent(ctx, audit); err != nil {
+		return access.TrustedClaimMapping{}, fmt.Errorf("record trusted claim mapping audit: %w", err)
+	}
+	return result, nil
+}
+
+func (r *Repository) TombstoneTrustedClaimMapping(ctx context.Context, id string, expected int64, mutation access.SemanticAttributeMutationContext) (result access.TrustedClaimMapping, err error) {
+	err = r.RunAuditedMutation(ctx, func(repo access.Repository) (access.AuditEventInput, error) {
+		var audit access.AuditEventInput
+		var coreErr error
+		result, audit, coreErr = tombstoneTrustedClaimMappingCore(ctx, repo.(*Repository).db, id, expected, mutation)
+		return audit, coreErr
+	})
+	return result, err
+}
+
+func tombstoneTrustedClaimMappingCore(ctx context.Context, db DBTX, id string, expected int64, mutation access.SemanticAttributeMutationContext) (access.TrustedClaimMapping, access.AuditEventInput, error) {
+	if expected <= 0 {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, errors.New("trusted claim mapping expected version must be positive")
+	}
+	canonicalID, err := uuidID("trusted claim mapping id", id)
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	state, err := lockSemanticAttributeControlState(ctx, db)
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	if _, _, err := validateSemanticAttributeControlState(ctx, db, state); err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	row, err := accessdb.New(db).TombstoneTrustedClaimMapping(ctx, accessdb.TombstoneTrustedClaimMappingParams{MappingID: mustPGUUID(canonicalID), ExpectedVersion: expected})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return access.TrustedClaimMapping{}, access.AuditEventInput{}, fmt.Errorf("%w: expected %d", access.ErrSemanticAttributeMappingConflict, expected)
+		}
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	definition, err := (&Repository{db: db}).SemanticAttributeDefinitionByID(ctx, row.DefinitionID)
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	result := mappingFromTombstone(row, definition.Name)
+	next, err := advanceSemanticAttributeControl(ctx, db, state)
+	if err != nil {
+		return access.TrustedClaimMapping{}, access.AuditEventInput{}, err
+	}
+	return result, semanticAttributeMappingAudit(mutation, "semantic_attribute.claim_mapping.tombstone", result, next), nil
+}
+
+func TombstoneTrustedClaimMappingTx(ctx context.Context, tx Tx, id string, expected int64, mutation access.SemanticAttributeMutationContext) (access.TrustedClaimMapping, error) {
+	if tx == nil {
+		return access.TrustedClaimMapping{}, errors.New("trusted claim mapping PostgreSQL transaction is required")
+	}
+	result, audit, err := tombstoneTrustedClaimMappingCore(ctx, tx, id, expected, mutation)
+	if err != nil {
+		return access.TrustedClaimMapping{}, err
+	}
+	if err := (&Repository{db: tx}).RecordAuditEvent(ctx, audit); err != nil {
+		return access.TrustedClaimMapping{}, fmt.Errorf("record trusted claim mapping audit: %w", err)
+	}
+	return result, nil
+}
+
+func semanticAttributeMappingAudit(mutation access.SemanticAttributeMutationContext, action string, row access.TrustedClaimMapping, state semanticAttributeControlStateRow) access.AuditEventInput {
+	metadata, _ := json.Marshal(struct {
+		SourceKind        string `json:"sourceKind"`
+		Provider          string `json:"provider"`
+		Issuer            string `json:"issuer"`
+		Audience          string `json:"audience"`
+		Claim             string `json:"claim"`
+		DefinitionID      string `json:"definitionId"`
+		DefinitionName    string `json:"definitionName"`
+		DefinitionVersion int64  `json:"definitionVersion"`
+		MappingVersion    int64  `json:"mappingVersion"`
+		ControlRevision   int64  `json:"controlRevision"`
+		Tombstoned        bool   `json:"tombstoned"`
+		ControlDigest     string `json:"controlDigest"`
+	}{string(row.SourceKind), row.Provider, row.Issuer, row.Audience, row.Claim, row.DefinitionID, row.DefinitionName, row.DefinitionVersion, row.MappingVersion, state.Revision, row.Tombstoned, state.Digest})
+	return access.AuditEventInput{PrincipalID: mutation.ActorPrincipalID, Action: action, ResourceKind: "semantic_attribute_claim_mapping", ResourceID: row.ID, Capability: access.CapabilityProjectAdmin, Status: "success", RequestID: mutation.RequestID, CorrelationID: mutation.CorrelationID, MetadataJSON: string(metadata)}
+}
+
+// EffectiveDirectSemanticAttributeAssignments resolves only durable direct
+// principal/group assignments. It intentionally has no claim argument, so a
+// caller cannot smuggle unverified authentication evidence into resolution.
+func (r *Repository) EffectiveDirectSemanticAttributeAssignments(ctx context.Context, subject access.SubjectRef) ([]access.EffectiveSemanticAttribute, error) {
+	return r.effectiveSemanticAttributeAssignments(ctx, subject, access.TrustedClaimSource{}, nil)
+}
+
+// EffectiveSemanticAttributeAssignments accepts only a verifier-gated
+// trustedclaims.Envelope. The envelope's exact source identity and claims are
+// copied through immutable accessors and its temporal validity is checked at
+// the point of authorization use.
+func (r *Repository) EffectiveSemanticAttributeAssignments(ctx context.Context, subject access.SubjectRef, envelope trustedclaims.Envelope) ([]access.EffectiveSemanticAttribute, error) {
+	if !envelope.Valid() {
+		return nil, fmt.Errorf("%w: trusted claim envelope is invalid", trustedclaims.ErrInvalidEvidence)
+	}
+	now := time.Now().UTC()
+	if now.Before(envelope.NotBefore()) {
+		return nil, trustedclaims.ErrEvidenceNotYetValid
+	}
+	if !now.Before(envelope.NotAfter()) {
+		return nil, trustedclaims.ErrEvidenceExpired
+	}
+	source := access.TrustedClaimSource{Kind: access.TrustedClaimSourceKind(envelope.Source()), Provider: envelope.Provider(), Issuer: envelope.Issuer(), Audience: envelope.Audience()}
+	if !source.Kind.Valid() {
+		return nil, fmt.Errorf("%w: unsupported envelope source", trustedclaims.ErrInvalidEvidence)
+	}
+	return r.effectiveSemanticAttributeAssignments(ctx, subject, source, envelope.Claims())
+}
+
+func (r *Repository) effectiveSemanticAttributeAssignments(ctx context.Context, subject access.SubjectRef, source access.TrustedClaimSource, claims []trustedclaims.Claim) ([]access.EffectiveSemanticAttribute, error) {
+	if err := access.ValidateSemanticAttributeSubject(subject); err != nil {
+		return nil, err
+	}
+	canonicalSubjectID, err := uuidID("semantic attribute subject id", subject.ID)
+	if err != nil {
+		return nil, err
+	}
+	subject.ID = canonicalSubjectID
+	if source.Kind != "" {
+		source, err = canonicalTrustedClaimSource(source)
+		if err != nil {
+			return nil, err
+		}
+	}
+	db, err := r.requireDB()
+	if err != nil {
+		return nil, err
+	}
+	controlBefore, err := readSemanticAttributeControlState(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	registryBefore, err := r.SemanticAttributeRegistry(ctx)
+	if err != nil {
+		return nil, err
+	}
+	assignments, err := r.SemanticAttributeAssignments(ctx, access.SemanticAttributeAssignmentFilter{Subject: subject})
+	if err != nil {
+		return nil, err
+	}
+	if subject.Kind == access.SubjectKindPrincipal {
+		groups, queryErr := accessdb.New(db).ListPrincipalSemanticAttributeGroups(ctx, mustPGUUID(subject.ID))
+		if queryErr != nil {
+			return nil, queryErr
+		}
+		for _, groupID := range groups {
+			groupAssignments, listErr := r.SemanticAttributeAssignments(ctx, access.SemanticAttributeAssignmentFilter{Subject: access.SubjectRef{Kind: access.SubjectKindGroup, ID: groupID}})
+			if listErr != nil {
+				return nil, listErr
+			}
+			assignments = append(assignments, groupAssignments...)
+		}
+	}
+	byDefinition := make(map[string]access.EffectiveSemanticAttribute)
+	for _, assignment := range assignments {
+		if assignment.Tombstoned {
+			continue
+		}
+		definition, defErr := r.SemanticAttributeDefinitionByID(ctx, assignment.DefinitionID)
+		if defErr != nil {
+			return nil, defErr
+		}
+		if !definition.Enabled || definition.Type != assignment.Type || definition.Shape != assignment.Shape {
+			return nil, fmt.Errorf("%w: assignment %s no longer matches its active definition", access.ErrSemanticAttributeSourceConflict, assignment.ID)
+		}
+		candidate := access.EffectiveSemanticAttribute{DefinitionID: assignment.DefinitionID, DefinitionName: definition.Name, DefinitionVersion: definition.DefinitionVersion, Type: definition.Type, Shape: definition.Shape, CanonicalValues: append([]string(nil), assignment.CanonicalValues...), ValueDigest: assignment.ValueDigest, Source: "direct"}
+		if prior, ok := byDefinition[assignment.DefinitionID]; ok {
+			if prior.ValueDigest != candidate.ValueDigest || !reflect.DeepEqual(prior.CanonicalValues, candidate.CanonicalValues) {
+				return nil, fmt.Errorf("%w: definition %s has %s and %s values", access.ErrSemanticAttributeSourceConflict, assignment.DefinitionID, prior.Source, candidate.Source)
+			}
+			prior.Source = "direct"
+			byDefinition[assignment.DefinitionID] = prior
+		} else {
+			byDefinition[assignment.DefinitionID] = candidate
+		}
+	}
+	if source.Kind != "" {
+		mappings, err := r.TrustedClaimMappings(ctx, access.TrustedClaimMappingFilter{SourceKind: source.Kind, Provider: source.Provider, Issuer: source.Issuer, Audience: source.Audience})
+		if err != nil {
+			return nil, err
+		}
+		for _, mapping := range mappings {
+			var found bool
+			var raw any
+			for _, claim := range claims {
+				if claim.Name == mapping.Claim {
+					if found {
+						return nil, fmt.Errorf("%w: claim %s is repeated", access.ErrSemanticAttributeSourceConflict, mapping.Claim)
+					}
+					found, raw = true, claim.Value
+				}
+			}
+			if !found {
+				continue
+			}
+			definition, defErr := r.SemanticAttributeDefinitionByID(ctx, mapping.DefinitionID)
+			if defErr != nil {
+				return nil, defErr
+			}
+			if !definition.Enabled || definition.Type != mapping.Type || definition.Shape != mapping.Shape {
+				return nil, fmt.Errorf("%w: trusted mapping %s no longer matches its active definition", access.ErrSemanticAttributeSourceConflict, mapping.ID)
+			}
+			values, digest, valueErr := access.CanonicalSemanticAttributeValues(definition, raw)
+			if valueErr != nil {
+				return nil, valueErr
+			}
+			candidate := access.EffectiveSemanticAttribute{DefinitionID: mapping.DefinitionID, DefinitionName: definition.Name, DefinitionVersion: definition.DefinitionVersion, Type: definition.Type, Shape: definition.Shape, CanonicalValues: values, ValueDigest: digest, Source: "trusted_claim"}
+			if prior, ok := byDefinition[mapping.DefinitionID]; ok {
+				if prior.ValueDigest != candidate.ValueDigest || !reflect.DeepEqual(prior.CanonicalValues, candidate.CanonicalValues) {
+					return nil, fmt.Errorf("%w: definition %s has %s and trusted_claim values", access.ErrSemanticAttributeSourceConflict, mapping.DefinitionID, prior.Source)
+				}
+				if prior.Source == "direct" {
+					prior.Source = "direct+trusted_claim"
+				}
+				byDefinition[mapping.DefinitionID] = prior
+			} else {
+				byDefinition[mapping.DefinitionID] = candidate
+			}
+		}
+	}
+	controlAfter, err := readSemanticAttributeControlState(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if controlBefore.Revision != controlAfter.Revision || controlBefore.Digest != controlAfter.Digest {
+		return nil, fmt.Errorf("%w: control state changed during effective resolution", access.ErrSemanticAttributeSourceConflict)
+	}
+	registryAfter, err := r.SemanticAttributeRegistry(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if registryBefore.State.Revision != registryAfter.State.Revision || registryBefore.State.Digest != registryAfter.State.Digest {
+		return nil, fmt.Errorf("%w: definition registry changed during effective resolution", access.ErrSemanticAttributeSourceConflict)
+	}
+	result := make([]access.EffectiveSemanticAttribute, 0, len(byDefinition))
+	for _, value := range byDefinition {
+		value.CanonicalValues = append([]string(nil), value.CanonicalValues...)
+		result = append(result, value)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].DefinitionID < result[j].DefinitionID })
+	return result, nil
+}

--- a/internal/access/postgres/semantic_attribute_claims.go
+++ b/internal/access/postgres/semantic_attribute_claims.go
@@ -17,7 +17,7 @@ import (
 )
 
 func mappingFromActive(row accessdb.GetActiveTrustedClaimMappingRow) access.TrustedClaimMapping {
-	return access.TrustedClaimMapping{ID: row.MappingID, SourceKind: access.TrustedClaimSourceKind(row.SourceKind), Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim, DefinitionID: row.DefinitionID, DefinitionName: row.DefinitionName, DefinitionVersion: row.DefinitionVersion, Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape), MappingVersion: row.MappingVersion, Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+	return access.TrustedClaimMapping{ID: row.MappingID, SourceKind: access.TrustedClaimSourceKind(row.SourceKind), Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim, DefinitionID: row.DefinitionID, DefinitionName: row.DefinitionName, DefinitionVersion: row.DefinitionVersion, Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape), MappingVersion: row.MappingVersion, Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: timestampAPIValue(row.TombstonedAt), CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func (r *Repository) setTrustedClaimMappingCore(ctx context.Context, db DBTX, input access.TrustedClaimMappingInput) (access.TrustedClaimMapping, access.AuditEventInput, error) {
@@ -244,7 +244,7 @@ func (r *Repository) effectiveSemanticAttributeAssignments(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	controlBefore, err := readSemanticAttributeControlState(ctx, db)
+	controlBefore, err := r.SemanticAttributeControl(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -252,9 +252,12 @@ func (r *Repository) effectiveSemanticAttributeAssignments(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	assignments, err := r.SemanticAttributeAssignments(ctx, access.SemanticAttributeAssignmentFilter{Subject: subject})
-	if err != nil {
-		return nil, err
+	assignments := make([]access.SemanticAttributeAssignment, 0, len(controlBefore.Assignments))
+	for _, assignment := range controlBefore.Assignments {
+		if assignment.Tombstoned || assignment.Subject != subject {
+			continue
+		}
+		assignments = append(assignments, assignment)
 	}
 	if subject.Kind == access.SubjectKindPrincipal {
 		groups, queryErr := accessdb.New(db).ListPrincipalSemanticAttributeGroups(ctx, mustPGUUID(subject.ID))
@@ -262,11 +265,13 @@ func (r *Repository) effectiveSemanticAttributeAssignments(ctx context.Context, 
 			return nil, queryErr
 		}
 		for _, groupID := range groups {
-			groupAssignments, listErr := r.SemanticAttributeAssignments(ctx, access.SemanticAttributeAssignmentFilter{Subject: access.SubjectRef{Kind: access.SubjectKindGroup, ID: groupID}})
-			if listErr != nil {
-				return nil, listErr
+			groupSubject := access.SubjectRef{Kind: access.SubjectKindGroup, ID: groupID}
+			for _, assignment := range controlBefore.Assignments {
+				if assignment.Tombstoned || assignment.Subject != groupSubject {
+					continue
+				}
+				assignments = append(assignments, assignment)
 			}
-			assignments = append(assignments, groupAssignments...)
 		}
 	}
 	byDefinition := make(map[string]access.EffectiveSemanticAttribute)
@@ -293,11 +298,10 @@ func (r *Repository) effectiveSemanticAttributeAssignments(ctx context.Context, 
 		}
 	}
 	if source.Kind != "" {
-		mappings, err := r.TrustedClaimMappings(ctx, access.TrustedClaimMappingFilter{SourceKind: source.Kind, Provider: source.Provider, Issuer: source.Issuer, Audience: source.Audience})
-		if err != nil {
-			return nil, err
-		}
-		for _, mapping := range mappings {
+		for _, mapping := range controlBefore.Mappings {
+			if mapping.Tombstoned || mapping.SourceKind != source.Kind || mapping.Provider != source.Provider || mapping.Issuer != source.Issuer || mapping.Audience != source.Audience {
+				continue
+			}
 			var found bool
 			var raw any
 			for _, claim := range claims {
@@ -336,11 +340,11 @@ func (r *Repository) effectiveSemanticAttributeAssignments(ctx context.Context, 
 			}
 		}
 	}
-	controlAfter, err := readSemanticAttributeControlState(ctx, db)
+	controlAfter, err := r.SemanticAttributeControl(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if controlBefore.Revision != controlAfter.Revision || controlBefore.Digest != controlAfter.Digest {
+	if controlBefore.State.Revision != controlAfter.State.Revision || controlBefore.State.Digest != controlAfter.State.Digest {
 		return nil, fmt.Errorf("%w: control state changed during effective resolution", access.ErrSemanticAttributeSourceConflict)
 	}
 	registryAfter, err := r.SemanticAttributeRegistry(ctx)

--- a/internal/access/postgres/semantic_attribute_control.go
+++ b/internal/access/postgres/semantic_attribute_control.go
@@ -12,12 +12,15 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/flidai/leapview/internal/access"
 	accessdb "github.com/flidai/leapview/internal/access/postgres/internal/db"
+	"github.com/flidai/leapview/internal/access/trustedclaims"
 	"github.com/flidai/leapview/internal/semanticvalue"
 )
 
@@ -36,7 +39,7 @@ type semanticAttributeAssignmentDigestWire struct {
 	Values                                   []string
 	ValueDigest                              string
 	Version                                  int64
-	TombstonedAt                             string
+	TombstonedAtMicros                       int64
 }
 
 type trustedClaimMappingDigestWire struct {
@@ -45,7 +48,7 @@ type trustedClaimMappingDigestWire struct {
 	Type                                                            semanticvalue.Type
 	Shape                                                           access.SemanticAttributeShape
 	Version                                                         int64
-	TombstonedAt                                                    string
+	TombstonedAtMicros                                              int64
 }
 
 type semanticAttributeControlDigestWire struct {
@@ -60,8 +63,8 @@ func assignmentFromRow(row accessdb.ListSemanticAttributeAssignmentsRow) access.
 		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
 		Subject:         access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID},
 		CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
-		AssignmentVersion: row.AssignmentVersion, Tombstoned: row.TombstonedAt != "",
-		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+		AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "",
+		TombstonedAt: timestampAPIValue(row.TombstonedAt), CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func assignmentFromInsert(row accessdb.InsertSemanticAttributeAssignmentRow, name string) access.SemanticAttributeAssignment {
@@ -71,7 +74,7 @@ func assignmentFromInsert(row accessdb.InsertSemanticAttributeAssignmentRow, nam
 		Subject:         access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID},
 		CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
 		AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "",
-		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+		TombstonedAt: timestampAPIValue(row.TombstonedAt), CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func assignmentFromUpdate(row accessdb.UpdateSemanticAttributeAssignmentRow, name string) access.SemanticAttributeAssignment {
@@ -81,7 +84,7 @@ func assignmentFromUpdate(row accessdb.UpdateSemanticAttributeAssignmentRow, nam
 		Subject:         access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID},
 		CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
 		AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "",
-		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+		TombstonedAt: timestampAPIValue(row.TombstonedAt), CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func assignmentFromTombstone(row accessdb.TombstoneSemanticAttributeAssignmentRow, name string) access.SemanticAttributeAssignment {
@@ -91,7 +94,7 @@ func assignmentFromTombstone(row accessdb.TombstoneSemanticAttributeAssignmentRo
 		Subject:         access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID},
 		CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
 		AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "",
-		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+		TombstonedAt: timestampAPIValue(row.TombstonedAt), CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func mappingFromList(row accessdb.ListTrustedClaimMappingsRow) access.TrustedClaimMapping {
@@ -100,8 +103,8 @@ func mappingFromList(row accessdb.ListTrustedClaimMappingsRow) access.TrustedCla
 		DefinitionID: row.DefinitionID, DefinitionName: row.DefinitionName,
 		DefinitionVersion: row.DefinitionVersion, Type: semanticvalue.Type(row.ValueType),
 		Shape: access.SemanticAttributeShape(row.ValueShape), MappingVersion: row.MappingVersion,
-		Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: textValue(row.TombstonedAt),
-		CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+		Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: timestampAPIValue(row.TombstonedAt),
+		CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func mappingFromInsert(row accessdb.InsertTrustedClaimMappingRow, name string) access.TrustedClaimMapping {
@@ -110,7 +113,7 @@ func mappingFromInsert(row accessdb.InsertTrustedClaimMappingRow, name string) a
 		DefinitionID: row.DefinitionID, DefinitionName: name, DefinitionVersion: row.DefinitionVersion,
 		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
 		MappingVersion: row.MappingVersion, Tombstoned: textValue(row.TombstonedAt) != "",
-		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+		TombstonedAt: timestampAPIValue(row.TombstonedAt), CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func mappingFromTombstone(row accessdb.TombstoneTrustedClaimMappingRow, name string) access.TrustedClaimMapping {
@@ -119,14 +122,47 @@ func mappingFromTombstone(row accessdb.TombstoneTrustedClaimMappingRow, name str
 		DefinitionID: row.DefinitionID, DefinitionName: name, DefinitionVersion: row.DefinitionVersion,
 		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
 		MappingVersion: row.MappingVersion, Tombstoned: textValue(row.TombstonedAt) != "",
-		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+		TombstonedAt: timestampAPIValue(row.TombstonedAt), CreatedAt: timestampAPIValue(row.CreatedAt), UpdatedAt: timestampAPIValue(row.UpdatedAt)}
 }
 
 func textValue(value interface{}) string {
 	if value == nil {
 		return ""
 	}
+	if bytes, ok := value.([]byte); ok {
+		return string(bytes)
+	}
 	return fmt.Sprint(value)
+}
+
+// timestampAPIValue converts the control query's epoch-microsecond wire value
+// into the stable UTC representation exposed by access APIs. The SQL query
+// deliberately does not return timestamptz::text because that representation
+// changes with the PostgreSQL session's TimeZone and DateStyle settings.
+func timestampAPIValue(value interface{}) string {
+	raw := textValue(value)
+	if raw == "" {
+		return ""
+	}
+	micros, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return ""
+	}
+	return time.UnixMicro(micros).UTC().Format(time.RFC3339Nano)
+}
+
+func timestampMicroseconds(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	if micros, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return micros, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid timestamp %q: %w", value, err)
+	}
+	return parsed.UTC().UnixMicro(), nil
 }
 
 func semanticAttributeControlDigest(assignments []access.SemanticAttributeAssignment, mappings []access.TrustedClaimMapping) (string, error) {
@@ -138,16 +174,24 @@ func semanticAttributeControlDigest(assignments []access.SemanticAttributeAssign
 		Assignments: make([]semanticAttributeAssignmentDigestWire, len(assignments)),
 		Mappings:    make([]trustedClaimMappingDigestWire, len(mappings))}
 	for i, row := range assignments {
+		tombstonedAt, err := timestampMicroseconds(row.TombstonedAt)
+		if err != nil {
+			return "", fmt.Errorf("assignment %s tombstoned timestamp: %w", row.ID, err)
+		}
 		wire.Assignments[i] = semanticAttributeAssignmentDigestWire{ID: row.ID, DefinitionID: row.DefinitionID,
 			SubjectKind: string(row.Subject.Kind), SubjectID: row.Subject.ID, DefinitionVersion: row.DefinitionVersion,
 			Type: row.Type, Shape: row.Shape, Values: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
-			Version: row.AssignmentVersion, TombstonedAt: row.TombstonedAt}
+			Version: row.AssignmentVersion, TombstonedAtMicros: tombstonedAt}
 	}
 	for i, row := range mappings {
+		tombstonedAt, err := timestampMicroseconds(row.TombstonedAt)
+		if err != nil {
+			return "", fmt.Errorf("mapping %s tombstoned timestamp: %w", row.ID, err)
+		}
 		wire.Mappings[i] = trustedClaimMappingDigestWire{ID: row.ID, SourceKind: string(row.SourceKind),
 			Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim,
 			DefinitionID: row.DefinitionID, DefinitionVersion: row.DefinitionVersion, Type: row.Type,
-			Shape: row.Shape, Version: row.MappingVersion, TombstonedAt: row.TombstonedAt}
+			Shape: row.Shape, Version: row.MappingVersion, TombstonedAtMicros: tombstonedAt}
 	}
 	encoded, err := json.Marshal(wire)
 	if err != nil {
@@ -162,7 +206,7 @@ func lockSemanticAttributeControlState(ctx context.Context, db DBTX) (semanticAt
 	if err != nil {
 		return semanticAttributeControlStateRow{}, fmt.Errorf("lock semantic attribute control state: %w", err)
 	}
-	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: row.UpdatedAt}, nil
+	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: timestampAPIValue(row.UpdatedAt)}, nil
 }
 
 func readSemanticAttributeControlState(ctx context.Context, db DBTX) (semanticAttributeControlStateRow, error) {
@@ -170,7 +214,7 @@ func readSemanticAttributeControlState(ctx context.Context, db DBTX) (semanticAt
 	if err != nil {
 		return semanticAttributeControlStateRow{}, fmt.Errorf("read semantic attribute control state: %w", err)
 	}
-	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: row.UpdatedAt}, nil
+	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: timestampAPIValue(row.UpdatedAt)}, nil
 }
 
 func allControlRows(ctx context.Context, db DBTX) ([]access.SemanticAttributeAssignment, []access.TrustedClaimMapping, error) {
@@ -225,7 +269,7 @@ func advanceSemanticAttributeControl(ctx context.Context, db DBTX, current seman
 	if err != nil {
 		return semanticAttributeControlStateRow{}, fmt.Errorf("advance semantic attribute control state: %w", err)
 	}
-	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: row.UpdatedAt}, nil
+	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: timestampAPIValue(row.UpdatedAt)}, nil
 }
 
 func (r *Repository) SemanticAttributeControl(ctx context.Context) (access.SemanticAttributeControlSnapshot, error) {
@@ -299,8 +343,8 @@ func canonicalTrustedClaimSource(source access.TrustedClaimSource) (access.Trust
 	if !source.Kind.Valid() {
 		return access.TrustedClaimSource{}, errors.New("trusted claim source kind is invalid")
 	}
-	if !validTrustedClaimText(source.Provider, 128) || !validTrustedClaimText(source.Issuer, 2048) || !validTrustedClaimText(source.Audience, 512) {
-		return access.TrustedClaimSource{}, errors.New("trusted claim source identity is invalid")
+	if err := trustedclaims.ValidateSourceIdentity(source.Provider, source.Issuer, source.Audience); err != nil {
+		return access.TrustedClaimSource{}, fmt.Errorf("trusted claim source identity is invalid: %w", err)
 	}
 	return source, nil
 }
@@ -334,16 +378,20 @@ func (r *Repository) TrustedClaimMappings(ctx context.Context, filter access.Tru
 		return nil, errors.New("trusted claim source kind is invalid")
 	}
 	for _, field := range []struct {
-		label string
-		value string
-		limit int
+		label    string
+		value    string
+		validate func(string) error
 	}{
-		{label: "provider", value: source.Provider, limit: 128}, {label: "issuer", value: source.Issuer, limit: 2048},
-		{label: "audience", value: source.Audience, limit: 512}, {label: "claim", value: filter.Claim, limit: 1024},
+		{label: "provider", value: source.Provider, validate: trustedclaims.ValidateProvider},
+		{label: "issuer", value: source.Issuer, validate: trustedclaims.ValidateIssuer},
+		{label: "audience", value: source.Audience, validate: trustedclaims.ValidateAudience},
 	} {
-		if field.value != "" && !validTrustedClaimText(field.value, field.limit) {
+		if field.value != "" && field.validate(field.value) != nil {
 			return nil, fmt.Errorf("trusted claim %s is invalid", field.label)
 		}
+	}
+	if filter.Claim != "" && !validTrustedClaimText(filter.Claim, 1024) {
+		return nil, errors.New("trusted claim claim is invalid")
 	}
 	claim := filter.Claim
 	db, err := r.requireDB()

--- a/internal/access/postgres/semantic_attribute_control.go
+++ b/internal/access/postgres/semantic_attribute_control.go
@@ -1,0 +1,365 @@
+package postgres
+
+// Durable semantic-access control state. Assignment and trusted-claim
+// mutations live in focused sibling files; this file owns shared projections,
+// deterministic control identity, and read-only interfaces.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/flidai/leapview/internal/access"
+	accessdb "github.com/flidai/leapview/internal/access/postgres/internal/db"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+const semanticAttributeControlProfile = semanticvalue.Profile
+
+type semanticAttributeControlStateRow struct {
+	Profile, Digest, UpdatedAt string
+	Revision                   int64
+}
+
+type semanticAttributeAssignmentDigestWire struct {
+	ID, DefinitionID, SubjectKind, SubjectID string
+	DefinitionVersion                        int64
+	Type                                     semanticvalue.Type
+	Shape                                    access.SemanticAttributeShape
+	Values                                   []string
+	ValueDigest                              string
+	Version                                  int64
+	TombstonedAt                             string
+}
+
+type trustedClaimMappingDigestWire struct {
+	ID, SourceKind, Provider, Issuer, Audience, Claim, DefinitionID string
+	DefinitionVersion                                               int64
+	Type                                                            semanticvalue.Type
+	Shape                                                           access.SemanticAttributeShape
+	Version                                                         int64
+	TombstonedAt                                                    string
+}
+
+type semanticAttributeControlDigestWire struct {
+	Profile     string                                  `json:"profile"`
+	Assignments []semanticAttributeAssignmentDigestWire `json:"assignments"`
+	Mappings    []trustedClaimMappingDigestWire         `json:"mappings"`
+}
+
+func assignmentFromRow(row accessdb.ListSemanticAttributeAssignmentsRow) access.SemanticAttributeAssignment {
+	return access.SemanticAttributeAssignment{ID: row.AssignmentID, DefinitionID: row.DefinitionID,
+		DefinitionName: row.DefinitionName, DefinitionVersion: row.DefinitionVersion,
+		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
+		Subject:         access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID},
+		CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
+		AssignmentVersion: row.AssignmentVersion, Tombstoned: row.TombstonedAt != "",
+		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func assignmentFromInsert(row accessdb.InsertSemanticAttributeAssignmentRow, name string) access.SemanticAttributeAssignment {
+	return access.SemanticAttributeAssignment{ID: row.AssignmentID, DefinitionID: row.DefinitionID,
+		DefinitionName: name, DefinitionVersion: row.DefinitionVersion,
+		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
+		Subject:         access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID},
+		CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
+		AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "",
+		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func assignmentFromUpdate(row accessdb.UpdateSemanticAttributeAssignmentRow, name string) access.SemanticAttributeAssignment {
+	return access.SemanticAttributeAssignment{ID: row.AssignmentID, DefinitionID: row.DefinitionID,
+		DefinitionName: name, DefinitionVersion: row.DefinitionVersion,
+		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
+		Subject:         access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID},
+		CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
+		AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "",
+		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func assignmentFromTombstone(row accessdb.TombstoneSemanticAttributeAssignmentRow, name string) access.SemanticAttributeAssignment {
+	return access.SemanticAttributeAssignment{ID: row.AssignmentID, DefinitionID: row.DefinitionID,
+		DefinitionName: name, DefinitionVersion: row.DefinitionVersion,
+		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
+		Subject:         access.SubjectRef{Kind: access.SubjectKind(row.SubjectKind), ID: row.SubjectID},
+		CanonicalValues: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
+		AssignmentVersion: row.AssignmentVersion, Tombstoned: textValue(row.TombstonedAt) != "",
+		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func mappingFromList(row accessdb.ListTrustedClaimMappingsRow) access.TrustedClaimMapping {
+	return access.TrustedClaimMapping{ID: row.MappingID, SourceKind: access.TrustedClaimSourceKind(row.SourceKind),
+		Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim,
+		DefinitionID: row.DefinitionID, DefinitionName: row.DefinitionName,
+		DefinitionVersion: row.DefinitionVersion, Type: semanticvalue.Type(row.ValueType),
+		Shape: access.SemanticAttributeShape(row.ValueShape), MappingVersion: row.MappingVersion,
+		Tombstoned: textValue(row.TombstonedAt) != "", TombstonedAt: textValue(row.TombstonedAt),
+		CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func mappingFromInsert(row accessdb.InsertTrustedClaimMappingRow, name string) access.TrustedClaimMapping {
+	return access.TrustedClaimMapping{ID: row.MappingID, SourceKind: access.TrustedClaimSourceKind(row.SourceKind),
+		Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim,
+		DefinitionID: row.DefinitionID, DefinitionName: name, DefinitionVersion: row.DefinitionVersion,
+		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
+		MappingVersion: row.MappingVersion, Tombstoned: textValue(row.TombstonedAt) != "",
+		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func mappingFromTombstone(row accessdb.TombstoneTrustedClaimMappingRow, name string) access.TrustedClaimMapping {
+	return access.TrustedClaimMapping{ID: row.MappingID, SourceKind: access.TrustedClaimSourceKind(row.SourceKind),
+		Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim,
+		DefinitionID: row.DefinitionID, DefinitionName: name, DefinitionVersion: row.DefinitionVersion,
+		Type: semanticvalue.Type(row.ValueType), Shape: access.SemanticAttributeShape(row.ValueShape),
+		MappingVersion: row.MappingVersion, Tombstoned: textValue(row.TombstonedAt) != "",
+		TombstonedAt: textValue(row.TombstonedAt), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+}
+
+func textValue(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(value)
+}
+
+func semanticAttributeControlDigest(assignments []access.SemanticAttributeAssignment, mappings []access.TrustedClaimMapping) (string, error) {
+	assignments = append([]access.SemanticAttributeAssignment(nil), assignments...)
+	mappings = append([]access.TrustedClaimMapping(nil), mappings...)
+	sort.Slice(assignments, func(i, j int) bool { return assignments[i].ID < assignments[j].ID })
+	sort.Slice(mappings, func(i, j int) bool { return mappings[i].ID < mappings[j].ID })
+	wire := semanticAttributeControlDigestWire{Profile: semanticAttributeControlProfile,
+		Assignments: make([]semanticAttributeAssignmentDigestWire, len(assignments)),
+		Mappings:    make([]trustedClaimMappingDigestWire, len(mappings))}
+	for i, row := range assignments {
+		wire.Assignments[i] = semanticAttributeAssignmentDigestWire{ID: row.ID, DefinitionID: row.DefinitionID,
+			SubjectKind: string(row.Subject.Kind), SubjectID: row.Subject.ID, DefinitionVersion: row.DefinitionVersion,
+			Type: row.Type, Shape: row.Shape, Values: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
+			Version: row.AssignmentVersion, TombstonedAt: row.TombstonedAt}
+	}
+	for i, row := range mappings {
+		wire.Mappings[i] = trustedClaimMappingDigestWire{ID: row.ID, SourceKind: string(row.SourceKind),
+			Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim,
+			DefinitionID: row.DefinitionID, DefinitionVersion: row.DefinitionVersion, Type: row.Type,
+			Shape: row.Shape, Version: row.MappingVersion, TombstonedAt: row.TombstonedAt}
+	}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return "", fmt.Errorf("encode semantic attribute control digest: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func lockSemanticAttributeControlState(ctx context.Context, db DBTX) (semanticAttributeControlStateRow, error) {
+	row, err := accessdb.New(db).LockSemanticAttributeControlState(ctx)
+	if err != nil {
+		return semanticAttributeControlStateRow{}, fmt.Errorf("lock semantic attribute control state: %w", err)
+	}
+	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: row.UpdatedAt}, nil
+}
+
+func readSemanticAttributeControlState(ctx context.Context, db DBTX) (semanticAttributeControlStateRow, error) {
+	row, err := accessdb.New(db).GetSemanticAttributeControlState(ctx)
+	if err != nil {
+		return semanticAttributeControlStateRow{}, fmt.Errorf("read semantic attribute control state: %w", err)
+	}
+	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: row.UpdatedAt}, nil
+}
+
+func allControlRows(ctx context.Context, db DBTX) ([]access.SemanticAttributeAssignment, []access.TrustedClaimMapping, error) {
+	queries := accessdb.New(db)
+	assignmentRows, err := queries.ListSemanticAttributeAssignments(ctx, accessdb.ListSemanticAttributeAssignmentsParams{IncludeTombstones: true})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list semantic attribute assignments: %w", err)
+	}
+	mappingRows, err := queries.ListTrustedClaimMappings(ctx, accessdb.ListTrustedClaimMappingsParams{IncludeTombstones: true})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list trusted claim mappings: %w", err)
+	}
+	assignments := make([]access.SemanticAttributeAssignment, len(assignmentRows))
+	for i := range assignmentRows {
+		assignments[i] = assignmentFromRow(assignmentRows[i])
+	}
+	mappings := make([]access.TrustedClaimMapping, len(mappingRows))
+	for i := range mappingRows {
+		mappings[i] = mappingFromList(mappingRows[i])
+	}
+	return assignments, mappings, nil
+}
+
+func validateSemanticAttributeControlState(ctx context.Context, db DBTX, state semanticAttributeControlStateRow) ([]access.SemanticAttributeAssignment, []access.TrustedClaimMapping, error) {
+	assignments, mappings, err := allControlRows(ctx, db)
+	if err != nil {
+		return nil, nil, err
+	}
+	digest, err := semanticAttributeControlDigest(assignments, mappings)
+	if err != nil {
+		return nil, nil, err
+	}
+	if state.Profile != semanticAttributeControlProfile || state.Digest != digest {
+		return nil, nil, fmt.Errorf("%w: stored digest %q, computed %q", access.ErrSemanticAttributeControlCorrupt, state.Digest, digest)
+	}
+	return assignments, mappings, nil
+}
+
+func advanceSemanticAttributeControl(ctx context.Context, db DBTX, current semanticAttributeControlStateRow) (semanticAttributeControlStateRow, error) {
+	assignments, mappings, err := allControlRows(ctx, db)
+	if err != nil {
+		return semanticAttributeControlStateRow{}, err
+	}
+	digest, err := semanticAttributeControlDigest(assignments, mappings)
+	if err != nil {
+		return semanticAttributeControlStateRow{}, err
+	}
+	if digest == current.Digest {
+		return current, nil
+	}
+	row, err := accessdb.New(db).UpdateSemanticAttributeControlState(ctx, accessdb.UpdateSemanticAttributeControlStateParams{ControlRevision: current.Revision + 1, ControlDigest: digest})
+	if err != nil {
+		return semanticAttributeControlStateRow{}, fmt.Errorf("advance semantic attribute control state: %w", err)
+	}
+	return semanticAttributeControlStateRow{Profile: row.Profile, Revision: row.ControlRevision, Digest: row.ControlDigest, UpdatedAt: row.UpdatedAt}, nil
+}
+
+func (r *Repository) SemanticAttributeControl(ctx context.Context) (access.SemanticAttributeControlSnapshot, error) {
+	db, err := r.requireDB()
+	if err != nil {
+		return access.SemanticAttributeControlSnapshot{}, err
+	}
+	// READ COMMITTED gives each statement its own snapshot. Read the control
+	// state on both sides of the row reads and fail closed if a concurrent
+	// mutation could have produced a mixed projection.
+	for attempt := 0; attempt < 2; attempt++ {
+		before, err := readSemanticAttributeControlState(ctx, db)
+		if err != nil {
+			return access.SemanticAttributeControlSnapshot{}, err
+		}
+		assignments, mappings, err := allControlRows(ctx, db)
+		if err != nil {
+			return access.SemanticAttributeControlSnapshot{}, err
+		}
+		after, err := readSemanticAttributeControlState(ctx, db)
+		if err != nil {
+			return access.SemanticAttributeControlSnapshot{}, err
+		}
+		if before.Revision != after.Revision || before.Digest != after.Digest {
+			continue
+		}
+		digest, err := semanticAttributeControlDigest(assignments, mappings)
+		if err != nil {
+			return access.SemanticAttributeControlSnapshot{}, err
+		}
+		if before.Profile != semanticAttributeControlProfile || before.Digest != digest {
+			return access.SemanticAttributeControlSnapshot{}, fmt.Errorf("%w: stored digest %q, computed %q", access.ErrSemanticAttributeControlCorrupt, before.Digest, digest)
+		}
+		return access.SemanticAttributeControlSnapshot{State: access.SemanticAttributeControlState{Profile: before.Profile, Revision: before.Revision, Digest: before.Digest, UpdatedAt: before.UpdatedAt}, Assignments: assignments, Mappings: mappings}, nil
+	}
+	return access.SemanticAttributeControlSnapshot{}, fmt.Errorf("%w: control state changed during read", access.ErrSemanticAttributeControlCorrupt)
+}
+
+func (r *Repository) SemanticAttributeAssignments(ctx context.Context, filter access.SemanticAttributeAssignmentFilter) ([]access.SemanticAttributeAssignment, error) {
+	if filter.DefinitionID != "" {
+		if _, err := uuidID("semantic attribute definition id", filter.DefinitionID); err != nil {
+			return nil, err
+		}
+	}
+	params := accessdb.ListSemanticAttributeAssignmentsParams{DefinitionID: filter.DefinitionID, IncludeTombstones: filter.IncludeTombstones}
+	if filter.Subject.Kind != "" || filter.Subject.ID != "" {
+		if err := access.ValidateSemanticAttributeSubject(filter.Subject); err != nil {
+			return nil, err
+		}
+		params.SubjectKind, params.SubjectID = string(filter.Subject.Kind), filter.Subject.ID
+		if _, err := uuidID("semantic attribute subject id", params.SubjectID); err != nil {
+			return nil, err
+		}
+	}
+	db, err := r.requireDB()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := accessdb.New(db).ListSemanticAttributeAssignments(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("list semantic attribute assignments: %w", err)
+	}
+	result := make([]access.SemanticAttributeAssignment, len(rows))
+	for i := range rows {
+		result[i] = assignmentFromRow(rows[i])
+	}
+	return result, nil
+}
+
+func canonicalTrustedClaimSource(source access.TrustedClaimSource) (access.TrustedClaimSource, error) {
+	if !source.Kind.Valid() {
+		return access.TrustedClaimSource{}, errors.New("trusted claim source kind is invalid")
+	}
+	if !validTrustedClaimText(source.Provider, 128) || !validTrustedClaimText(source.Issuer, 2048) || !validTrustedClaimText(source.Audience, 512) {
+		return access.TrustedClaimSource{}, errors.New("trusted claim source identity is invalid")
+	}
+	return source, nil
+}
+
+func canonicalTrustedClaim(source access.TrustedClaimSource, claim string) (access.TrustedClaimSource, string, error) {
+	source, err := canonicalTrustedClaimSource(source)
+	if err != nil {
+		return access.TrustedClaimSource{}, "", err
+	}
+	if !validTrustedClaimText(claim, 1024) {
+		return access.TrustedClaimSource{}, "", errors.New("trusted claim name is invalid")
+	}
+	return source, claim, nil
+}
+
+func validTrustedClaimText(value string, maxBytes int) bool {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > maxBytes || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *Repository) TrustedClaimMappings(ctx context.Context, filter access.TrustedClaimMappingFilter) ([]access.TrustedClaimMapping, error) {
+	source := access.TrustedClaimSource{Kind: filter.SourceKind, Provider: filter.Provider, Issuer: filter.Issuer, Audience: filter.Audience}
+	if source.Kind != "" && !source.Kind.Valid() {
+		return nil, errors.New("trusted claim source kind is invalid")
+	}
+	for _, field := range []struct {
+		label string
+		value string
+		limit int
+	}{
+		{label: "provider", value: source.Provider, limit: 128}, {label: "issuer", value: source.Issuer, limit: 2048},
+		{label: "audience", value: source.Audience, limit: 512}, {label: "claim", value: filter.Claim, limit: 1024},
+	} {
+		if field.value != "" && !validTrustedClaimText(field.value, field.limit) {
+			return nil, fmt.Errorf("trusted claim %s is invalid", field.label)
+		}
+	}
+	claim := filter.Claim
+	db, err := r.requireDB()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := accessdb.New(db).ListTrustedClaimMappings(ctx, accessdb.ListTrustedClaimMappingsParams{SourceKind: string(source.Kind), Provider: source.Provider, Issuer: source.Issuer, Audience: source.Audience, Claim: claim, IncludeTombstones: filter.IncludeTombstones})
+	if err != nil {
+		return nil, fmt.Errorf("list trusted claim mappings: %w", err)
+	}
+	result := make([]access.TrustedClaimMapping, len(rows))
+	for i := range rows {
+		result[i] = mappingFromList(rows[i])
+	}
+	return result, nil
+}
+
+var _ access.SemanticAttributeControlReader = (*Repository)(nil)
+var _ access.SemanticAttributeControlWriter = (*Repository)(nil)

--- a/internal/access/postgres/semantic_attribute_control_test.go
+++ b/internal/access/postgres/semantic_attribute_control_test.go
@@ -135,6 +135,158 @@ func TestSemanticAttributeControlAuditProjectionOmitsValues(t *testing.T) {
 	}
 }
 
+func TestEffectiveSemanticAttributeAssignmentsRejectsOutOfBandRowCorruption(t *testing.T) {
+	db := newStandaloneAccessDatabase(t)
+	ctx := t.Context()
+	if _, err := db.admin.Exec(ctx, AttributeRegistryMigrationSQL()); err != nil {
+		t.Fatalf("apply attribute registry migration: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, SemanticAttributeControlMigrationSQL()); err != nil {
+		t.Fatalf("apply semantic attribute control migration: %v", err)
+	}
+	for _, id := range []string{auditActorID, controlSubjectID} {
+		if _, err := db.admin.Exec(ctx, `INSERT INTO access.principal (id, principal_type, status) VALUES ($1::uuid, 'user', 'active')`, id); err != nil {
+			t.Fatalf("insert principal %s: %v", id, err)
+		}
+	}
+	repo, err := NewAccess(db.runtime, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutation := access.SemanticAttributeMutationContext{ActorPrincipalID: auditActorID}
+	definition, err := repo.RegisterSemanticAttribute(ctx, access.RegisterSemanticAttributeInput{
+		Name: "integrity_region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatalf("register definition: %v", err)
+	}
+	assignment, err := repo.SetSemanticAttributeAssignment(ctx, access.SemanticAttributeAssignmentInput{
+		DefinitionID: definition.ID, Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID}, Values: "west", Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatalf("set assignment: %v", err)
+	}
+	if _, err := repo.SemanticAttributeControl(ctx); err != nil {
+		t.Fatalf("validate initial control snapshot: %v", err)
+	}
+
+	// A privileged out-of-band writer can bypass the repository's control-state
+	// advancement. Effective resolution must recompute the snapshot digest and
+	// reject the row instead of trusting the unchanged revision/digest pair.
+	if _, err := db.admin.Exec(ctx, `
+		UPDATE access.semantic_attribute_assignment
+		SET canonical_values = ARRAY['tampered'], assignment_version = assignment_version + 1
+		WHERE assignment_id = $1::uuid`, assignment.ID); err != nil {
+		t.Fatalf("corrupt assignment out of band: %v", err)
+	}
+	_, err = repo.EffectiveDirectSemanticAttributeAssignments(ctx, access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID})
+	if !errors.Is(err, access.ErrSemanticAttributeControlCorrupt) {
+		t.Fatalf("out-of-band assignment corruption error = %v, want control corruption", err)
+	}
+}
+
+func TestSemanticAttributeControlPostgreSQL18CanonicalTimestampsAreSessionIndependent(t *testing.T) {
+	db := newStandaloneAccessDatabase(t)
+	ctx := t.Context()
+	if _, err := db.admin.Exec(ctx, AttributeRegistryMigrationSQL()); err != nil {
+		t.Fatalf("apply attribute registry migration: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, SemanticAttributeControlMigrationSQL()); err != nil {
+		t.Fatalf("apply semantic attribute control migration: %v", err)
+	}
+	for _, id := range []string{auditActorID, controlSubjectID} {
+		if _, err := db.admin.Exec(ctx, `INSERT INTO access.principal (id, principal_type, status) VALUES ($1::uuid, 'user', 'active')`, id); err != nil {
+			t.Fatalf("insert principal %s: %v", id, err)
+		}
+	}
+	repo, err := NewAccess(db.runtime, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutation := access.SemanticAttributeMutationContext{ActorPrincipalID: auditActorID}
+	definition, err := repo.RegisterSemanticAttribute(ctx, access.RegisterSemanticAttributeInput{
+		Name: "timestamp_region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatalf("register definition: %v", err)
+	}
+	assignment, err := repo.SetSemanticAttributeAssignment(ctx, access.SemanticAttributeAssignmentInput{
+		DefinitionID: definition.ID, Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID}, Values: "west", Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatalf("set assignment: %v", err)
+	}
+	if _, err := repo.TombstoneSemanticAttributeAssignment(ctx, assignment.ID, assignment.AssignmentVersion, mutation); err != nil {
+		t.Fatalf("tombstone assignment: %v", err)
+	}
+	baseline, err := repo.SemanticAttributeControl(ctx)
+	if err != nil {
+		t.Fatalf("read baseline control snapshot: %v", err)
+	}
+
+	conn, err := db.runtime.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire non-default session: %v", err)
+	}
+	defer conn.Release()
+	if _, err := conn.Exec(ctx, `SET TIME ZONE 'America/Los_Angeles'`); err != nil {
+		t.Fatalf("set non-default timezone: %v", err)
+	}
+	if _, err := conn.Exec(ctx, `SET DateStyle = 'SQL, DMY'`); err != nil {
+		t.Fatalf("set non-default datestyle: %v", err)
+	}
+	nonDefaultRepo, err := NewAccess(conn, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonDefault, err := nonDefaultRepo.SemanticAttributeControl(ctx)
+	if err != nil {
+		t.Fatalf("read non-default control snapshot: %v", err)
+	}
+	if nonDefault.State.Digest != baseline.State.Digest {
+		t.Fatalf("control digest changed with session formatting: %q != %q", nonDefault.State.Digest, baseline.State.Digest)
+	}
+	if nonDefault.State.UpdatedAt == "" {
+		t.Fatal("control state updated timestamp is empty")
+	}
+	assertRFC3339UTCTimestamp(t, nonDefault.State.UpdatedAt)
+	var tombstoned access.SemanticAttributeAssignment
+	for _, row := range nonDefault.Assignments {
+		if row.ID == assignment.ID {
+			tombstoned = row
+			break
+		}
+	}
+	if tombstoned.ID == "" {
+		t.Fatalf("tombstoned assignment missing from control snapshot: %#v", nonDefault.Assignments)
+	}
+	assertRFC3339UTCTimestamp(t, tombstoned.CreatedAt)
+	assertRFC3339UTCTimestamp(t, tombstoned.UpdatedAt)
+	assertRFC3339UTCTimestamp(t, tombstoned.TombstonedAt)
+	var tombstonedMicros int64
+	if err := conn.QueryRow(ctx, `SELECT (extract(epoch FROM tombstoned_at) * 1000000)::bigint FROM access.semantic_attribute_assignment WHERE assignment_id = $1::uuid`, assignment.ID).Scan(&tombstonedMicros); err != nil {
+		t.Fatalf("read tombstone microseconds: %v", err)
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, tombstoned.TombstonedAt)
+	if err != nil {
+		t.Fatalf("parse canonical tombstone timestamp: %v", err)
+	}
+	if parsed.UTC().UnixMicro() != tombstonedMicros {
+		t.Fatalf("tombstone timestamp lost microsecond precision: API=%d database=%d", parsed.UTC().UnixMicro(), tombstonedMicros)
+	}
+}
+
+func assertRFC3339UTCTimestamp(t *testing.T, value string) {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatalf("timestamp %q is not RFC3339: %v", value, err)
+	}
+	if parsed.Location() != time.UTC || !strings.HasSuffix(value, "Z") {
+		t.Fatalf("timestamp %q is not UTC", value)
+	}
+}
+
 func TestSemanticAttributeControlPostgreSQL18LifecycleAndTrust(t *testing.T) {
 	db := newStandaloneAccessDatabase(t)
 	ctx := t.Context()

--- a/internal/access/postgres/semantic_attribute_control_test.go
+++ b/internal/access/postgres/semantic_attribute_control_test.go
@@ -1,0 +1,354 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+const (
+	controlSubjectID = "30000000-0000-0000-0000-000000000001"
+	controlOwnerID   = "30000000-0000-0000-0000-000000000002"
+	controlGroupID   = "30000000-0000-0000-0000-000000000003"
+)
+
+func TestSemanticAttributeControlDigestSeedAndOrdering(t *testing.T) {
+	empty, err := semanticAttributeControlDigest(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const wantEmpty = "sha256:e05005cdeee20cc98d9e8de8f32ed4b8da34a95f82872dc3b65a451ce7de4e37"
+	if empty != wantEmpty || !strings.Contains(SemanticAttributeControlMigrationSQL(), wantEmpty) {
+		t.Fatalf("empty control digest = %q, want %q", empty, wantEmpty)
+	}
+	rows := []access.SemanticAttributeAssignment{
+		{ID: "20000000-0000-0000-0000-000000000002", DefinitionID: "10000000-0000-0000-0000-000000000002", Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID}, Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, CanonicalValues: []string{"b"}, ValueDigest: "sha256:" + strings.Repeat("b", 64), AssignmentVersion: 1},
+		{ID: "20000000-0000-0000-0000-000000000001", DefinitionID: "10000000-0000-0000-0000-000000000001", Subject: access.SubjectRef{Kind: access.SubjectKindGroup, ID: controlGroupID}, Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, CanonicalValues: []string{"a"}, ValueDigest: "sha256:" + strings.Repeat("a", 64), AssignmentVersion: 1},
+	}
+	first, err := semanticAttributeControlDigest(rows, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := semanticAttributeControlDigest([]access.SemanticAttributeAssignment{rows[1], rows[0]}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("control digest depends on input order: %q != %q", first, second)
+	}
+}
+
+func TestTrustedClaimMappingIdentityRejectsNormalization(t *testing.T) {
+	valid := access.TrustedClaimSource{Kind: access.TrustedClaimSourceOIDC, Provider: "corp", Issuer: "https://issuer.example", Audience: "dashboard"}
+	for name, source := range map[string]access.TrustedClaimSource{
+		"provider whitespace": {Kind: valid.Kind, Provider: " corp", Issuer: valid.Issuer, Audience: valid.Audience},
+		"issuer whitespace":   {Kind: valid.Kind, Provider: valid.Provider, Issuer: valid.Issuer + " ", Audience: valid.Audience},
+		"audience control":    {Kind: valid.Kind, Provider: valid.Provider, Issuer: valid.Issuer, Audience: "dashboard\u0007"},
+	} {
+		if _, err := canonicalTrustedClaimSource(source); err == nil {
+			t.Errorf("accepted %s", name)
+		}
+	}
+	for _, claim := range []string{" claim", "claim ", "claim\u0007", ""} {
+		if _, _, err := canonicalTrustedClaim(valid, claim); err == nil {
+			t.Errorf("accepted invalid claim %q", claim)
+		}
+	}
+}
+
+type staticControlVerifier struct {
+	source trustedclaims.SourceKind
+	claims trustedclaims.VerifiedClaims
+}
+
+func (v staticControlVerifier) SourceKind() trustedclaims.SourceKind { return v.source }
+func (v staticControlVerifier) Verify(context.Context, []byte) (trustedclaims.VerifiedClaims, error) {
+	return v.claims, nil
+}
+
+func TestSemanticAttributeControlAuditProjectionOmitsValues(t *testing.T) {
+	assignment := access.SemanticAttributeAssignment{
+		ID: "assignment-1", DefinitionID: "definition-1", DefinitionName: "region",
+		Subject:         access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID},
+		CanonicalValues: []string{"secret-region"}, ValueDigest: "sha256:" + strings.Repeat("a", 64), AssignmentVersion: 2,
+	}
+	event := semanticAttributeControlAudit(access.SemanticAttributeMutationContext{}, "semantic_attribute.assignment.set", assignment, semanticAttributeControlStateRow{Revision: 4, Digest: "sha256:" + strings.Repeat("b", 64)})
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(event.MetadataJSON), &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if metadata["valueCount"] != float64(1) || metadata["definitionId"] != assignment.DefinitionID {
+		t.Fatalf("stable audit metadata = %#v", metadata)
+	}
+	for _, forbidden := range []string{"canonicalValues", "valueDigest", "secret-region"} {
+		if strings.Contains(event.MetadataJSON, forbidden) {
+			t.Fatalf("assignment audit contains %q: %s", forbidden, event.MetadataJSON)
+		}
+	}
+}
+
+func TestSemanticAttributeControlPostgreSQL18LifecycleAndTrust(t *testing.T) {
+	db := newStandaloneAccessDatabase(t)
+	ctx := t.Context()
+	if _, err := db.admin.Exec(ctx, AttributeRegistryMigrationSQL()); err != nil {
+		t.Fatalf("apply attribute registry migration: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, SemanticAttributeControlMigrationSQL()); err != nil {
+		t.Fatalf("apply semantic attribute control migration: %v", err)
+	}
+	for _, id := range []string{auditActorID, controlSubjectID, controlOwnerID} {
+		if _, err := db.admin.Exec(ctx, `
+			INSERT INTO access.principal (id, principal_type, status)
+			VALUES ($1::uuid, 'user', 'active')`, id); err != nil {
+			t.Fatalf("insert principal %s: %v", id, err)
+		}
+	}
+	if _, err := db.admin.Exec(ctx, `
+		INSERT INTO access.access_group (id, name)
+		VALUES ($1::uuid, 'Control Test Group')`, controlGroupID); err != nil {
+		t.Fatalf("insert group: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, `
+		INSERT INTO access.principal_group (principal_id, group_id)
+		VALUES ($1::uuid, $2::uuid)`, controlSubjectID, controlGroupID); err != nil {
+		t.Fatalf("insert membership: %v", err)
+	}
+
+	repo, err := NewAccess(db.runtime, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutation := access.SemanticAttributeMutationContext{ActorPrincipalID: auditActorID, RequestID: "40000000-0000-0000-0000-000000000001"}
+	if _, err := repo.RegisterSemanticAttribute(ctx, access.RegisterSemanticAttributeInput{
+		Name: "missing_owner", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerPrincipal, ID: "30000000-0000-0000-0000-000000000099"}}, Mutation: mutation,
+	}); err == nil {
+		t.Fatal("registered a definition with a missing owner")
+	}
+	ownerDefinition, err := repo.RegisterSemanticAttribute(ctx, access.RegisterSemanticAttributeInput{
+		Name: "owned_region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerPrincipal, ID: controlOwnerID}}, Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatalf("register owner-scoped definition: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, `UPDATE access.principal SET status='disabled', disabled_at=clock_timestamp(), revoked_at=clock_timestamp() WHERE id=$1::uuid`, controlOwnerID); err != nil {
+		t.Fatalf("revoke definition owner: %v", err)
+	}
+	if _, err := repo.UpdateSemanticAttributeMetadataExpected(ctx, access.UpdateSemanticAttributeMetadataInput{
+		Name: ownerDefinition.Name, ExpectedVersion: ownerDefinition.DefinitionVersion,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerPrincipal, ID: controlOwnerID}, DisplayName: "Owned Region"}, Mutation: mutation,
+	}); err != nil {
+		t.Fatalf("update definition after owner revocation: %v", err)
+	}
+	definition, err := repo.RegisterSemanticAttribute(ctx, access.RegisterSemanticAttributeInput{
+		Name: "region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeList,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}, DisplayName: "Region"},
+		Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatalf("register definition: %v", err)
+	}
+
+	assignment, err := repo.SetSemanticAttributeAssignment(ctx, access.SemanticAttributeAssignmentInput{
+		DefinitionID: definition.ID, Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID},
+		Values: []string{"west", "east"}, Mutation: mutation,
+	})
+	if err != nil || assignment.AssignmentVersion != 1 {
+		t.Fatalf("create assignment = %#v, err=%v", assignment, err)
+	}
+	updatedAssignment, err := repo.SetSemanticAttributeAssignment(ctx, access.SemanticAttributeAssignmentInput{
+		DefinitionID: definition.ID, Subject: assignment.Subject, Values: []string{"west"}, ExpectedVersion: 1, Mutation: mutation,
+	})
+	if err != nil || updatedAssignment.AssignmentVersion != 2 {
+		t.Fatalf("update assignment = %#v, err=%v", updatedAssignment, err)
+	}
+	groupAssignment, err := repo.SetSemanticAttributeAssignment(ctx, access.SemanticAttributeAssignmentInput{
+		DefinitionID: definition.ID, Subject: access.SubjectRef{Kind: access.SubjectKindGroup, ID: controlGroupID}, Values: []string{"west"}, Mutation: mutation,
+	})
+	if err != nil || groupAssignment.AssignmentVersion != 1 {
+		t.Fatalf("create group assignment = %#v, err=%v", groupAssignment, err)
+	}
+	if _, err := repo.SetSemanticAttributeAssignment(ctx, access.SemanticAttributeAssignmentInput{
+		DefinitionID: definition.ID, Subject: assignment.Subject, Values: []string{"north"}, ExpectedVersion: 1, Mutation: mutation,
+	}); !errors.Is(err, access.ErrSemanticAttributeAssignmentConflict) {
+		t.Fatalf("stale assignment update error = %v", err)
+	}
+
+	claimName := "https://claims.example/region"
+	mapping, err := repo.SetTrustedClaimMapping(ctx, access.TrustedClaimMappingInput{
+		SourceKind: access.TrustedClaimSourceOIDC, Provider: "corp", Issuer: "https://issuer.example", Audience: "dashboard", Claim: claimName,
+		DefinitionID: definition.ID, Mutation: mutation,
+	})
+	if err != nil || mapping.MappingVersion != 1 {
+		t.Fatalf("create mapping = %#v, err=%v", mapping, err)
+	}
+	embedMapping, err := repo.SetTrustedClaimMapping(ctx, access.TrustedClaimMappingInput{
+		SourceKind: access.TrustedClaimSourceEmbed, Provider: "corp", Issuer: "https://issuer.example", Audience: "dashboard", Claim: claimName,
+		DefinitionID: definition.ID, Mutation: mutation,
+	})
+	if err != nil || embedMapping.ID == mapping.ID {
+		t.Fatalf("create source-distinct mapping = %#v, err=%v", embedMapping, err)
+	}
+	if _, err := repo.TombstoneTrustedClaimMapping(ctx, mapping.ID, 99, mutation); !errors.Is(err, access.ErrSemanticAttributeMappingConflict) {
+		t.Fatalf("stale mapping tombstone error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	envelope, err := trustedclaims.Verify(ctx, trustedclaims.NewRawEvidence(trustedclaims.SourceOIDC, []byte("signed")), staticControlVerifier{
+		source: trustedclaims.SourceOIDC,
+		claims: trustedclaims.VerifiedClaims{Provider: "corp", Issuer: "https://issuer.example", Audience: "dashboard", Subject: "subject-1", IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Minute), TokenFingerprint: "sha256:" + strings.Repeat("a", 64), Claims: []trustedclaims.Claim{{Name: claimName, Value: []string{"east"}}}},
+	}, trustedclaims.VerifyOptions{Now: now})
+	if err != nil {
+		t.Fatalf("verify test envelope: %v", err)
+	}
+	if _, err := repo.EffectiveDirectSemanticAttributeAssignments(ctx, access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID}); err != nil {
+		t.Fatalf("direct-only resolution: %v", err)
+	}
+	if _, err := repo.EffectiveSemanticAttributeAssignments(ctx, access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID}, envelope); !errors.Is(err, access.ErrSemanticAttributeSourceConflict) {
+		t.Fatalf("conflicting direct/trusted resolution error = %v", err)
+	}
+
+	// Metadata changes update the current definition identity but do not make
+	// a still-compatible assignment unusable. Stale writes are checked after
+	// the registry lock, and the SQL WHERE repeats the same version predicate.
+	updatedDefinition, err := repo.UpdateSemanticAttributeMetadataExpected(ctx, access.UpdateSemanticAttributeMetadataInput{
+		Name: definition.Name, ExpectedVersion: definition.DefinitionVersion,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}, DisplayName: "Region Names"}, Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatalf("metadata update: %v", err)
+	}
+	if _, err := repo.UpdateSemanticAttributeMetadataExpected(ctx, access.UpdateSemanticAttributeMetadataInput{
+		Name: definition.Name, ExpectedVersion: definition.DefinitionVersion,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}, DisplayName: "stale"}, Mutation: mutation,
+	}); !errors.Is(err, access.ErrSemanticAttributeConflict) {
+		t.Fatalf("stale definition metadata error = %v", err)
+	}
+	resolved, err := repo.EffectiveDirectSemanticAttributeAssignments(ctx, access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID})
+	if err != nil {
+		t.Fatalf("resolve after metadata-only definition change: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0].DefinitionVersion != updatedDefinition.DefinitionVersion {
+		t.Fatalf("resolved current definition version = %#v, want %d", resolved, updatedDefinition.DefinitionVersion)
+	}
+	disabled, err := repo.SetSemanticAttributeEnabledExpected(ctx, definition.Name, false, updatedDefinition.DefinitionVersion, mutation)
+	if err != nil {
+		t.Fatalf("disable definition: %v", err)
+	}
+	if _, err := repo.SetSemanticAttributeEnabledExpected(ctx, definition.Name, true, updatedDefinition.DefinitionVersion, mutation); !errors.Is(err, access.ErrSemanticAttributeConflict) {
+		t.Fatalf("stale lifecycle error = %v", err)
+	}
+	if disabled.DefinitionVersion <= updatedDefinition.DefinitionVersion {
+		t.Fatalf("disable version = %d, metadata version = %d", disabled.DefinitionVersion, updatedDefinition.DefinitionVersion)
+	}
+
+	// Definition disablement and subject revocation must not strand the
+	// immutable tombstone operation, while active value updates remain blocked.
+	if _, err := db.admin.Exec(ctx, `UPDATE access.principal SET status='disabled', disabled_at=clock_timestamp(), revoked_at=clock_timestamp() WHERE id=$1::uuid`, controlSubjectID); err != nil {
+		t.Fatalf("revoke subject: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, `
+		UPDATE access.semantic_attribute_assignment
+		SET canonical_values=ARRAY['tampered'], value_digest=$2, tombstoned_at=clock_timestamp(), assignment_version=assignment_version+1
+		WHERE assignment_id=$1::uuid`, assignment.ID, "sha256:"+strings.Repeat("f", 64)); err == nil || !strings.Contains(err.Error(), "cannot rewrite") {
+		t.Fatalf("payload rewrite during tombstone error = %v", err)
+	}
+	if _, err := repo.TombstoneSemanticAttributeAssignment(ctx, assignment.ID, updatedAssignment.AssignmentVersion, mutation); err != nil {
+		t.Fatalf("tombstone revoked subject assignment: %v", err)
+	}
+	if _, err := repo.TombstoneSemanticAttributeAssignment(ctx, groupAssignment.ID, groupAssignment.AssignmentVersion, mutation); err != nil {
+		t.Fatalf("tombstone disabled definition group assignment: %v", err)
+	}
+	if _, err := repo.TombstoneTrustedClaimMapping(ctx, mapping.ID, mapping.MappingVersion, mutation); err != nil {
+		t.Fatalf("tombstone disabled definition mapping: %v", err)
+	}
+	if _, err := repo.TombstoneTrustedClaimMapping(ctx, embedMapping.ID, embedMapping.MappingVersion, mutation); err != nil {
+		t.Fatalf("tombstone source-distinct mapping: %v", err)
+	}
+
+	var metadata string
+	if err := db.admin.QueryRow(ctx, `SELECT metadata::text FROM audit.audit_event WHERE resource_kind='semantic_attribute_assignment' ORDER BY occurred_at DESC LIMIT 1`).Scan(&metadata); err != nil {
+		t.Fatalf("read assignment audit: %v", err)
+	}
+	var auditObject map[string]any
+	if err := json.Unmarshal([]byte(metadata), &auditObject); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := auditObject["value_digest"]; present {
+		t.Fatalf("assignment audit leaked value digest: %s", metadata)
+	}
+	if strings.Contains(metadata, "west") || strings.Contains(metadata, "east") {
+		t.Fatalf("assignment audit leaked raw value: %s", metadata)
+	}
+}
+
+func TestSemanticAttributeControlPostgreSQL18TransactionRollback(t *testing.T) {
+	db := newStandaloneAccessDatabase(t)
+	ctx := t.Context()
+	if _, err := db.admin.Exec(ctx, AttributeRegistryMigrationSQL()); err != nil {
+		t.Fatalf("apply attribute registry migration: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, SemanticAttributeControlMigrationSQL()); err != nil {
+		t.Fatalf("apply semantic attribute control migration: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, `INSERT INTO access.principal (id, principal_type, status) VALUES ($1::uuid, 'user', 'active')`, auditActorID); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := NewAccess(db.runtime, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutation := access.SemanticAttributeMutationContext{ActorPrincipalID: auditActorID}
+	definition, err := repo.RegisterSemanticAttribute(ctx, access.RegisterSemanticAttributeInput{Name: "rollback_region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Mutation: mutation})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := repo.SemanticAttributeControl(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var auditCount int
+	if err := db.admin.QueryRow(ctx, `SELECT count(*) FROM audit.audit_event`).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.runtime.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SetSemanticAttributeAssignmentTx(ctx, tx, access.SemanticAttributeAssignmentInput{DefinitionID: definition.ID, Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: auditActorID}, Values: "temporary", Mutation: mutation}); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("transactional assignment: %v", err)
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := repo.SemanticAttributeAssignments(ctx, access.SemanticAttributeAssignmentFilter{DefinitionID: definition.ID, IncludeTombstones: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("rolled-back assignment rows = %d", len(rows))
+	}
+	after, err := repo.SemanticAttributeControl(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.State.Revision != after.State.Revision || before.State.Digest != after.State.Digest {
+		t.Fatalf("rolled-back control identity changed: before=%#v after=%#v", before.State, after.State)
+	}
+	var afterAuditCount int
+	if err := db.admin.QueryRow(ctx, `SELECT count(*) FROM audit.audit_event`).Scan(&afterAuditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != afterAuditCount {
+		t.Fatalf("rolled-back audit count = %d, before %d", afterAuditCount, auditCount)
+	}
+}

--- a/internal/access/postgres/semantic_attribute_control_test.go
+++ b/internal/access/postgres/semantic_attribute_control_test.go
@@ -73,6 +73,47 @@ func (v staticControlVerifier) Verify(context.Context, []byte) (trustedclaims.Ve
 	return v.claims, nil
 }
 
+func TestEffectiveSemanticAttributeAssignmentsRejectsEnvelopeSubjectMismatch(t *testing.T) {
+	now := time.Now().UTC()
+	envelope, err := trustedclaims.Verify(t.Context(), trustedclaims.NewRawEvidence(trustedclaims.SourceOIDC, []byte("signed")), staticControlVerifier{
+		source: trustedclaims.SourceOIDC,
+		claims: trustedclaims.VerifiedClaims{
+			Provider: "corp", Issuer: "https://issuer.example", Audience: "dashboard", Subject: controlSubjectID,
+			IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Minute), TokenFingerprint: "sha256:" + strings.Repeat("a", 64),
+		},
+	}, trustedclaims.VerifyOptions{Now: now})
+	if err != nil {
+		t.Fatalf("verify test envelope: %v", err)
+	}
+
+	// The identity binding is checked before any database access, so a
+	// mismatched envelope cannot contribute claims to another principal.
+	repo := &Repository{}
+	_, err = repo.EffectiveSemanticAttributeAssignments(t.Context(), access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlOwnerID}, envelope)
+	if !errors.Is(err, trustedclaims.ErrInvalidEvidence) {
+		t.Fatalf("mismatched envelope subject error = %v, want invalid evidence", err)
+	}
+}
+
+func hasEffectiveSemanticAttribute(rows []access.EffectiveSemanticAttribute, definitionID string, values []string) bool {
+	for _, row := range rows {
+		if row.DefinitionID != definitionID || len(row.CanonicalValues) != len(values) {
+			continue
+		}
+		match := true
+		for i := range values {
+			if row.CanonicalValues[i] != values[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
 func TestSemanticAttributeControlAuditProjectionOmitsValues(t *testing.T) {
 	assignment := access.SemanticAttributeAssignment{
 		ID: "assignment-1", DefinitionID: "definition-1", DefinitionName: "region",
@@ -176,6 +217,35 @@ func TestSemanticAttributeControlPostgreSQL18LifecycleAndTrust(t *testing.T) {
 	if err != nil || groupAssignment.AssignmentVersion != 1 {
 		t.Fatalf("create group assignment = %#v, err=%v", groupAssignment, err)
 	}
+	groupOnlyDefinition, err := repo.RegisterSemanticAttribute(ctx, access.RegisterSemanticAttributeInput{
+		Name: "group_region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}}, Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatalf("register group-only definition: %v", err)
+	}
+	if _, err := repo.SetSemanticAttributeAssignment(ctx, access.SemanticAttributeAssignmentInput{
+		DefinitionID: groupOnlyDefinition.ID, Subject: access.SubjectRef{Kind: access.SubjectKindGroup, ID: controlGroupID}, Values: "north", Mutation: mutation,
+	}); err != nil {
+		t.Fatalf("create group-only assignment: %v", err)
+	}
+	resolvedWithGroup, err := repo.EffectiveDirectSemanticAttributeAssignments(ctx, access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID})
+	if err != nil {
+		t.Fatalf("resolve active group assignment: %v", err)
+	}
+	if !hasEffectiveSemanticAttribute(resolvedWithGroup, groupOnlyDefinition.ID, []string{"north"}) {
+		t.Fatalf("active group assignment missing from resolution: %#v", resolvedWithGroup)
+	}
+	if _, err := db.admin.Exec(ctx, `UPDATE access.access_group SET revoked_at=clock_timestamp() WHERE id=$1::uuid`, controlGroupID); err != nil {
+		t.Fatalf("revoke group: %v", err)
+	}
+	resolvedWithoutGroup, err := repo.EffectiveDirectSemanticAttributeAssignments(ctx, access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: controlSubjectID})
+	if err != nil {
+		t.Fatalf("resolve revoked group assignment: %v", err)
+	}
+	if hasEffectiveSemanticAttribute(resolvedWithoutGroup, groupOnlyDefinition.ID, []string{"north"}) {
+		t.Fatalf("revoked group assignment contributed to resolution: %#v", resolvedWithoutGroup)
+	}
 	if _, err := repo.SetSemanticAttributeAssignment(ctx, access.SemanticAttributeAssignmentInput{
 		DefinitionID: definition.ID, Subject: assignment.Subject, Values: []string{"north"}, ExpectedVersion: 1, Mutation: mutation,
 	}); !errors.Is(err, access.ErrSemanticAttributeAssignmentConflict) {
@@ -204,7 +274,7 @@ func TestSemanticAttributeControlPostgreSQL18LifecycleAndTrust(t *testing.T) {
 	now := time.Now().UTC()
 	envelope, err := trustedclaims.Verify(ctx, trustedclaims.NewRawEvidence(trustedclaims.SourceOIDC, []byte("signed")), staticControlVerifier{
 		source: trustedclaims.SourceOIDC,
-		claims: trustedclaims.VerifiedClaims{Provider: "corp", Issuer: "https://issuer.example", Audience: "dashboard", Subject: "subject-1", IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Minute), TokenFingerprint: "sha256:" + strings.Repeat("a", 64), Claims: []trustedclaims.Claim{{Name: claimName, Value: []string{"east"}}}},
+		claims: trustedclaims.VerifiedClaims{Provider: "corp", Issuer: "https://issuer.example", Audience: "dashboard", Subject: controlSubjectID, IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Minute), TokenFingerprint: "sha256:" + strings.Repeat("a", 64), Claims: []trustedclaims.Claim{{Name: claimName, Value: []string{"east"}}}},
 	}, trustedclaims.VerifyOptions{Now: now})
 	if err != nil {
 		t.Fatalf("verify test envelope: %v", err)

--- a/internal/access/postgres/semantic_attribute_group_query_test.go
+++ b/internal/access/postgres/semantic_attribute_group_query_test.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestListPrincipalSemanticAttributeGroupsExcludesRevokedGroups(t *testing.T) {
+	_, sourcePath, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate PostgreSQL access package source")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(sourcePath), "queries", "semantic_attribute_control.sql"))
+	if err != nil {
+		t.Fatalf("read semantic attribute control queries: %v", err)
+	}
+
+	source := string(body)
+	start := strings.Index(source, "-- name: ListPrincipalSemanticAttributeGroups :many")
+	if start < 0 {
+		t.Fatal("ListPrincipalSemanticAttributeGroups query is missing")
+	}
+	query := source[start:]
+	if next := strings.Index(query, "\n-- name:"); next >= 0 {
+		query = query[:next]
+	}
+	for _, predicate := range []string{
+		"JOIN access.access_group g ON g.id = pg.group_id",
+		"pg.revoked_at IS NULL",
+		"g.revoked_at IS NULL",
+	} {
+		if !strings.Contains(query, predicate) {
+			t.Errorf("ListPrincipalSemanticAttributeGroups query lacks %q:\n%s", predicate, query)
+		}
+	}
+}

--- a/internal/access/postgres/semantic_attribute_pagination_test.go
+++ b/internal/access/postgres/semantic_attribute_pagination_test.go
@@ -1,0 +1,72 @@
+package postgres
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+func TestSemanticAttributeSearchOwnerCursorPaginatesCompleteFilteredResult(t *testing.T) {
+	db := newStandaloneAccessDatabase(t)
+	ctx := t.Context()
+	if _, err := db.admin.Exec(ctx, AttributeRegistryMigrationSQL()); err != nil {
+		t.Fatalf("apply attribute registry migration: %v", err)
+	}
+	if _, err := db.admin.Exec(ctx, `
+		INSERT INTO access.principal (id, principal_type, status)
+		VALUES ($1::uuid, 'user', 'active')`, auditActorID); err != nil {
+		t.Fatal(err)
+	}
+	_, err := db.admin.Exec(ctx, `
+		INSERT INTO access.semantic_attribute_definition
+			(definition_id, name, value_type, value_shape, profile, owner_kind, owner_id)
+		SELECT ('00000000-0000-0000-0000-' || lpad(to_hex(i + 1), 12, '0'))::uuid,
+			'pagination_attribute_' || lpad(i::text, 3, '0'), 'String', 'scalar',
+			'leapview.semantic-access/v1',
+			CASE WHEN i < 45 THEN 'instance' ELSE 'principal' END,
+			CASE WHEN i < 45 THEN NULL ELSE $1::uuid END
+		FROM generate_series(0, 249) AS series(i)`, auditActorID)
+	if err != nil {
+		t.Fatalf("insert pagination definitions: %v", err)
+	}
+	repo, err := NewAccess(db.admin, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const pageSize = 50
+	var names []string
+	filter := access.SemanticAttributeSearch{OwnerKind: access.SemanticAttributeOwnerPrincipal, Limit: pageSize + 1}
+	for {
+		rows, searchErr := repo.SearchSemanticAttributes(ctx, filter)
+		if searchErr != nil {
+			t.Fatal(searchErr)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		page := rows
+		if len(page) > pageSize {
+			page = page[:pageSize]
+		}
+		for _, row := range page {
+			names = append(names, row.Name)
+		}
+		if len(rows) <= pageSize {
+			break
+		}
+		last := page[len(page)-1]
+		filter.AfterName, filter.AfterDefinitionID = last.Name, last.ID
+	}
+
+	if len(names) != 205 {
+		t.Fatalf("filtered definitions = %d, want 205", len(names))
+	}
+	for i, name := range names {
+		want := fmt.Sprintf("pagination_attribute_%03d", 45+i)
+		if name != want {
+			t.Fatalf("filtered definition %d = %q, want %q", i, name, want)
+		}
+	}
+}

--- a/internal/access/postgres/semantic_attribute_trusted_identity_test.go
+++ b/internal/access/postgres/semantic_attribute_trusted_identity_test.go
@@ -1,0 +1,62 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+)
+
+func TestTrustedClaimSourceIdentityUsesVerifierLimits(t *testing.T) {
+	source := access.TrustedClaimSource{
+		Kind:     access.TrustedClaimSourceOIDC,
+		Provider: strings.Repeat("p", trustedclaims.MaxProviderBytes),
+		Issuer:   strings.Repeat("i", trustedclaims.MaxIssuerBytes),
+		Audience: strings.Repeat("a", trustedclaims.MaxAudienceBytes),
+	}
+	if _, err := canonicalTrustedClaimSource(source); err != nil {
+		t.Fatalf("source identity at verifier limits rejected: %v", err)
+	}
+
+	for _, test := range []struct {
+		name string
+		edit func(*access.TrustedClaimSource)
+	}{
+		{name: "provider", edit: func(source *access.TrustedClaimSource) { source.Provider += "p" }},
+		{name: "issuer", edit: func(source *access.TrustedClaimSource) { source.Issuer += "i" }},
+		{name: "audience", edit: func(source *access.TrustedClaimSource) { source.Audience += "a" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := source
+			test.edit(&candidate)
+			if _, err := canonicalTrustedClaimSource(candidate); err == nil {
+				t.Fatal("source identity above verifier limit was accepted")
+			}
+		})
+	}
+}
+
+func TestSemanticAttributeControlMigrationUsesVerifierIssuerLimit(t *testing.T) {
+	constraint := "octet_length(issuer) BETWEEN 1 AND 1024"
+	if !strings.Contains(SemanticAttributeControlMigrationSQL(), constraint) {
+		t.Fatalf("semantic attribute control migration is missing %q", constraint)
+	}
+}
+
+func TestEffectiveResolutionRejectsSourceAboveVerifierLimitBeforeDatabaseAccess(t *testing.T) {
+	repo := &Repository{}
+	source := access.TrustedClaimSource{
+		Kind:     access.TrustedClaimSourceOIDC,
+		Provider: "provider",
+		Issuer:   strings.Repeat("i", trustedclaims.MaxIssuerBytes+1),
+		Audience: "audience",
+	}
+	_, err := repo.effectiveSemanticAttributeAssignments(t.Context(), access.SubjectRef{
+		Kind: access.SubjectKindPrincipal,
+		ID:   controlSubjectID,
+	}, source, nil)
+	if err == nil {
+		t.Fatal("effective resolution accepted a source identity above the verifier limit")
+	}
+}

--- a/internal/access/postgres/semantic_attributes.go
+++ b/internal/access/postgres/semantic_attributes.go
@@ -125,6 +125,20 @@ func (r *Repository) SearchSemanticAttributes(ctx context.Context, filter access
 	if len(query) > 255 || strings.ContainsRune(query, '\x00') {
 		return nil, errors.New("semantic attribute search query is invalid")
 	}
+	if filter.OwnerKind != "" && !filter.OwnerKind.Valid() {
+		return nil, errors.New("semantic attribute owner kind is invalid")
+	}
+	if (filter.AfterName == "") != (filter.AfterDefinitionID == "") {
+		return nil, errors.New("semantic attribute search cursor is invalid")
+	}
+	if filter.AfterName != "" {
+		if err := semanticvalue.ValidateAttributeName(filter.AfterName); err != nil {
+			return nil, fmt.Errorf("semantic attribute search cursor is invalid: %w", err)
+		}
+		if _, err := uuidID("semantic attribute search cursor definition id", filter.AfterDefinitionID); err != nil {
+			return nil, err
+		}
+	}
 	limit := filter.Limit
 	if limit <= 0 {
 		limit = 100
@@ -136,7 +150,7 @@ func (r *Repository) SearchSemanticAttributes(ctx context.Context, filter access
 	if err != nil {
 		return nil, err
 	}
-	rows, err := accessdb.New(db).SearchSemanticAttributeDefinitions(ctx, accessdb.SearchSemanticAttributeDefinitionsParams{SearchQuery: query, PageSize: int32(limit)})
+	rows, err := accessdb.New(db).SearchSemanticAttributeDefinitions(ctx, accessdb.SearchSemanticAttributeDefinitionsParams{SearchQuery: query, OwnerKind: string(filter.OwnerKind), AfterName: filter.AfterName, AfterDefinitionID: filter.AfterDefinitionID, PageSize: int32(limit)})
 	if err != nil {
 		return nil, fmt.Errorf("search semantic attribute definitions: %w", err)
 	}

--- a/internal/access/postgres/semantic_attributes.go
+++ b/internal/access/postgres/semantic_attributes.go
@@ -21,6 +21,7 @@ import (
 const maxSemanticAttributeSearchRows = 1000
 
 var _ access.SemanticAttributeRegistry = (*Repository)(nil)
+var _ access.VersionedSemanticAttributeRegistry = (*Repository)(nil)
 
 type registryDigestWire struct {
 	Profile     string                         `json:"profile"`
@@ -162,6 +163,9 @@ func (r *Repository) RegisterSemanticAttribute(ctx context.Context, input access
 			return access.AuditEventInput{}, errors.New("semantic attribute mutation requires PostgreSQL transaction")
 		}
 		queries := accessdb.New(transactional.db)
+		if err := validateSemanticAttributeOwnerExists(ctx, transactional.db, metadata); err != nil {
+			return access.AuditEventInput{}, err
+		}
 		locked, err := queries.LockSemanticAttributeRegistry(ctx)
 		if err != nil {
 			return access.AuditEventInput{}, fmt.Errorf("lock semantic attribute registry: %w", err)
@@ -205,8 +209,15 @@ func (r *Repository) RegisterSemanticAttribute(ctx context.Context, input access
 }
 
 func (r *Repository) UpdateSemanticAttributeMetadata(ctx context.Context, input access.UpdateSemanticAttributeMetadataInput) (access.SemanticAttributeDefinition, error) {
+	return r.UpdateSemanticAttributeMetadataExpected(ctx, input)
+}
+
+func (r *Repository) UpdateSemanticAttributeMetadataExpected(ctx context.Context, input access.UpdateSemanticAttributeMetadataInput) (access.SemanticAttributeDefinition, error) {
 	if err := semanticvalue.ValidateAttributeName(input.Name); err != nil {
 		return access.SemanticAttributeDefinition{}, err
+	}
+	if input.ExpectedVersion < 0 {
+		return access.SemanticAttributeDefinition{}, errors.New("semantic attribute expected version cannot be negative")
 	}
 	metadata, err := canonicalSemanticAttributeMetadata(input.Metadata)
 	if err != nil {
@@ -232,15 +243,26 @@ func (r *Repository) UpdateSemanticAttributeMetadata(ctx context.Context, input 
 			return access.AuditEventInput{}, err
 		}
 		result = semanticAttributeDefinitionFromGet(existing)
+		if input.ExpectedVersion > 0 && result.DefinitionVersion != input.ExpectedVersion {
+			return access.AuditEventInput{}, fmt.Errorf("%w: semantic attribute %s expected version %d, current %d", access.ErrSemanticAttributeConflict, input.Name, input.ExpectedVersion, result.DefinitionVersion)
+		}
+		if result.Metadata.Owner != metadata.Owner {
+			if err := validateSemanticAttributeOwnerExists(ctx, transactional.db, metadata); err != nil {
+				return access.AuditEventInput{}, err
+			}
+		}
 		if reflect.DeepEqual(result.Metadata, metadata) {
 			return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.metadata_replay", result, locked.RegistryRevision, locked.RegistryDigest), nil
 		}
 		updated, err := queries.UpdateSemanticAttributeDefinitionMetadata(ctx, accessdb.UpdateSemanticAttributeDefinitionMetadataParams{
 			OwnerKind: string(metadata.Owner.Kind), OwnerID: metadata.Owner.ID,
 			DisplayName: metadata.DisplayName, Description: metadata.Description,
-			DocumentationUrl: metadata.DocumentationURL, Name: input.Name,
+			DocumentationUrl: metadata.DocumentationURL, Name: input.Name, ExpectedVersion: input.ExpectedVersion,
 		})
 		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) && input.ExpectedVersion > 0 {
+				return access.AuditEventInput{}, fmt.Errorf("%w: semantic attribute %s expected version %d", access.ErrSemanticAttributeConflict, input.Name, input.ExpectedVersion)
+			}
 			return access.AuditEventInput{}, fmt.Errorf("update semantic attribute metadata: %w", err)
 		}
 		result = semanticAttributeDefinitionFromMetadata(updated)
@@ -254,8 +276,15 @@ func (r *Repository) UpdateSemanticAttributeMetadata(ctx context.Context, input 
 }
 
 func (r *Repository) SetSemanticAttributeEnabled(ctx context.Context, name string, enabled bool, mutation access.SemanticAttributeMutationContext) (access.SemanticAttributeDefinition, error) {
+	return r.SetSemanticAttributeEnabledExpected(ctx, name, enabled, 0, mutation)
+}
+
+func (r *Repository) SetSemanticAttributeEnabledExpected(ctx context.Context, name string, enabled bool, expectedVersion int64, mutation access.SemanticAttributeMutationContext) (access.SemanticAttributeDefinition, error) {
 	if err := semanticvalue.ValidateAttributeName(name); err != nil {
 		return access.SemanticAttributeDefinition{}, err
+	}
+	if expectedVersion < 0 {
+		return access.SemanticAttributeDefinition{}, errors.New("semantic attribute expected version cannot be negative")
 	}
 	actorID, err := uuidID("semantic attribute mutation actor principal id", mutation.ActorPrincipalID)
 	if err != nil {
@@ -277,6 +306,9 @@ func (r *Repository) SetSemanticAttributeEnabled(ctx context.Context, name strin
 			return access.AuditEventInput{}, err
 		}
 		result = semanticAttributeDefinitionFromGet(existing)
+		if expectedVersion > 0 && result.DefinitionVersion != expectedVersion {
+			return access.AuditEventInput{}, fmt.Errorf("%w: semantic attribute %s expected version %d, current %d", access.ErrSemanticAttributeConflict, name, expectedVersion, result.DefinitionVersion)
+		}
 		action := "semantic_attribute.disable"
 		if enabled {
 			action = "semantic_attribute.enable"
@@ -284,8 +316,11 @@ func (r *Repository) SetSemanticAttributeEnabled(ctx context.Context, name strin
 		if result.Enabled == enabled {
 			return semanticAttributeAuditEvent(mutation, actorID, action+"_replay", result, locked.RegistryRevision, locked.RegistryDigest), nil
 		}
-		updated, err := queries.SetSemanticAttributeDefinitionEnabled(ctx, accessdb.SetSemanticAttributeDefinitionEnabledParams{Enabled: enabled, Name: name})
+		updated, err := queries.SetSemanticAttributeDefinitionEnabled(ctx, accessdb.SetSemanticAttributeDefinitionEnabledParams{Enabled: enabled, Name: name, ExpectedVersion: expectedVersion})
 		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) && expectedVersion > 0 {
+				return access.AuditEventInput{}, fmt.Errorf("%w: semantic attribute %s expected version %d", access.ErrSemanticAttributeConflict, name, expectedVersion)
+			}
 			return access.AuditEventInput{}, fmt.Errorf("set semantic attribute enabled state: %w", err)
 		}
 		result = semanticAttributeDefinitionFromEnabled(updated)
@@ -520,4 +555,31 @@ func semanticAttributeDefinition(row semanticAttributeRow) access.SemanticAttrib
 		LifecycleState: lifecycle, Enabled: row.Enabled, DisabledAt: row.DisabledAt,
 		CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt,
 	}
+}
+
+func validateSemanticAttributeOwnerExists(ctx context.Context, db DBTX, metadata access.SemanticAttributeMetadata) error {
+	if metadata.Owner.Kind == access.SemanticAttributeOwnerInstance {
+		return nil
+	}
+	ownerID, err := pgUUID(metadata.Owner.ID)
+	if err != nil {
+		return fmt.Errorf("validate semantic attribute owner: %w", err)
+	}
+	var exists bool
+	queries := accessdb.New(db)
+	switch metadata.Owner.Kind {
+	case access.SemanticAttributeOwnerPrincipal:
+		exists, err = queries.SemanticAttributePrincipalOwnerExists(ctx, ownerID)
+	case access.SemanticAttributeOwnerGroup:
+		exists, err = queries.SemanticAttributeGroupOwnerExists(ctx, ownerID)
+	default:
+		return fmt.Errorf("semantic attribute owner %s is invalid", metadata.Owner.Kind)
+	}
+	if err != nil {
+		return fmt.Errorf("validate semantic attribute owner: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("semantic attribute owner %s %q does not exist", metadata.Owner.Kind, metadata.Owner.ID)
+	}
+	return nil
 }

--- a/internal/access/postgres/semantic_attributes.go
+++ b/internal/access/postgres/semantic_attributes.go
@@ -176,7 +176,7 @@ func (r *Repository) RegisterSemanticAttribute(ctx context.Context, input access
 			if result.Type != input.Type || result.Shape != input.Shape {
 				return access.AuditEventInput{}, fmt.Errorf("%w: %s is registered as %s/%s", access.ErrSemanticAttributeConflict, input.Name, result.Type, result.Shape)
 			}
-			return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.register_replay", result, locked.RegistryRevision, locked.RegistryDigest), nil
+			return semanticAttributeAuditEvent(input.Mutation, actorID, access.SemanticAttributeAuditActionRegisterReplay, result, locked.RegistryRevision, locked.RegistryDigest), nil
 		}
 		if !errors.Is(err, pgx.ErrNoRows) {
 			return access.AuditEventInput{}, fmt.Errorf("read semantic attribute definition: %w", err)
@@ -203,7 +203,7 @@ func (r *Repository) RegisterSemanticAttribute(ctx context.Context, input access
 		if err != nil {
 			return access.AuditEventInput{}, err
 		}
-		return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.register", result, registry.RegistryRevision, registry.RegistryDigest), nil
+		return semanticAttributeAuditEvent(input.Mutation, actorID, access.SemanticAttributeAuditActionRegister, result, registry.RegistryRevision, registry.RegistryDigest), nil
 	})
 	return result, err
 }
@@ -252,7 +252,7 @@ func (r *Repository) UpdateSemanticAttributeMetadataExpected(ctx context.Context
 			}
 		}
 		if reflect.DeepEqual(result.Metadata, metadata) {
-			return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.metadata_replay", result, locked.RegistryRevision, locked.RegistryDigest), nil
+			return semanticAttributeAuditEvent(input.Mutation, actorID, access.SemanticAttributeAuditActionMetadataReplay, result, locked.RegistryRevision, locked.RegistryDigest), nil
 		}
 		updated, err := queries.UpdateSemanticAttributeDefinitionMetadata(ctx, accessdb.UpdateSemanticAttributeDefinitionMetadataParams{
 			OwnerKind: string(metadata.Owner.Kind), OwnerID: metadata.Owner.ID,
@@ -270,7 +270,7 @@ func (r *Repository) UpdateSemanticAttributeMetadataExpected(ctx context.Context
 		if err != nil {
 			return access.AuditEventInput{}, err
 		}
-		return semanticAttributeAuditEvent(input.Mutation, actorID, "semantic_attribute.metadata_update", result, registry.RegistryRevision, registry.RegistryDigest), nil
+		return semanticAttributeAuditEvent(input.Mutation, actorID, access.SemanticAttributeAuditActionMetadataUpdate, result, registry.RegistryRevision, registry.RegistryDigest), nil
 	})
 	return result, err
 }
@@ -309,9 +309,9 @@ func (r *Repository) SetSemanticAttributeEnabledExpected(ctx context.Context, na
 		if expectedVersion > 0 && result.DefinitionVersion != expectedVersion {
 			return access.AuditEventInput{}, fmt.Errorf("%w: semantic attribute %s expected version %d, current %d", access.ErrSemanticAttributeConflict, name, expectedVersion, result.DefinitionVersion)
 		}
-		action := "semantic_attribute.disable"
+		action := access.SemanticAttributeAuditActionDisable
 		if enabled {
-			action = "semantic_attribute.enable"
+			action = access.SemanticAttributeAuditActionEnable
 		}
 		if result.Enabled == enabled {
 			return semanticAttributeAuditEvent(mutation, actorID, action+"_replay", result, locked.RegistryRevision, locked.RegistryDigest), nil

--- a/internal/access/postgres/sqlc_exceptions.md
+++ b/internal/access/postgres/sqlc_exceptions.md
@@ -12,6 +12,14 @@ tables, indexes, constraints, append-only/revocation triggers, helper
 functions, role grants, and the `DO` grant blocks.  SQLC must parse this file,
 but must never replace or generate it.
 
+The same rule applies to the access-owned forward migrations
+`002_typed_attribute_registry.sql` and `003_semantic_attribute_control.sql`.
+They define the profile-qualified registry/control tables, immutable identity
+and tombstone triggers, singleton revision/digest guards, subject/definition
+checks, and role ACLs. Those are schema authority and remain handwritten
+migration input. SQLC generates only the stable leaves declared in the
+capability-local query files.
+
 ## Repository SQL
 
 - `repository.go`: `RecordAuditEvent` performs canonical replay detection in
@@ -48,20 +56,50 @@ but must never replace or generate it.
 - `instance_initialization.go`: initialization is a one-time, database-clock
   guarded marker used during process bootstrap; the surrounding transaction
   and idempotency handling remain in Go.
+- `semantic_attributes.go`: registry projection/digest calculation, metadata
+  and owner validation, logical-type compatibility, URL validation, and
+  canonical value conversion remain domain logic. Registry singleton locking,
+  revision advancement, replay handling, and the audit mutation wrapper must
+  stay coupled to those generated leaves.
+- `semantic_attribute_control.go`: assignment/mapping projections are sorted
+  into one deterministic control digest over active and tombstoned rows.
+  Control-state locking, stored-vs-computed digest verification, and the
+  distinction between registry and control identities are repository
+  invariants, not independent generated calls.
+- `semantic_attribute_assignments.go`: assignment ingress canonicalizes closed
+  scalar/list values, validates the definition and subject, enforces
+  expected-version concurrency, and chooses insert/update/tombstone behavior.
+  The `...Tx` helper records audit in the caller-owned transaction before
+  commit; splitting these operations would allow state and evidence to drift.
+- `semantic_attribute_claims.go`: source kind/provider/issuer/audience/claim
+  identity is canonicalized before lookup. Mapping replay, immutable mapping
+  identity, expected-version tombstoning, effective direct/group resolution
+  behind the opaque `trustedclaims.Envelope` boundary, and source-conflict
+  errors remain in Go. Raw claim values are canonicalized only in memory and
+  are never copied into audit metadata.
 
 ## Generated leaves
 
 `queries/oauth.sql` and `queries/principal.sql` contain the stable OAuth
-client/session/assertion leaves and principal reads.  `internal/db/*.go` is
-generated with sqlc v1.30.0 and `sql_package: pgx/v5`; `postgres_store.go` and
-`access_core.go` retain transaction ownership, fosite replay/error mapping,
-secret handling, and domain conversion around those methods.
+client/session/assertion leaves and principal reads.  The
+`queries/semantic_attribute_control.sql` file contains stable registry/control
+reads and writes, including expected-version predicates and ordered
+projections. `internal/db/*.go` is generated with sqlc v1.30.0 and
+`sql_package: pgx/v5`; `postgres_store.go`, `access_core.go`, and the semantic
+attribute repositories retain transaction ownership, replay/error mapping,
+secret handling, canonicalization, and domain conversion around those
+methods. Generated SQLC code is not a second authority for semantic policy or
+legacy JSON attribute columns.
 
 ## Coverage
 
 The PostgreSQL 18 integration suites in `internal/access/postgres/*_test.go`
-exercise the principal reads and their revocation/clock invariants.  OAuth
-replay, rotation, invalidation, and transaction behavior are covered by
-`internal/access/http/mcpoauth/*_test.go`.  These tests intentionally use
-direct admin SQL for schema/permission and invariant assertions; that test SQL
-is not production repository code.
+exercise principal reads and revocation/clock invariants, the typed registry
+lifecycle, deterministic registry identity, and transactional registry audit.
+The `internal/access/trustedclaims` tests cover the source-bound opaque
+verifier envelope and structural claim boundary. Assignment/mapping control
+integration and semantic-consumer/planner qualification remain FAI-637 follow-
+up evidence, not SQLC exceptions. OAuth replay, rotation, invalidation, and
+transaction behavior are covered by `internal/access/http/mcpoauth/*_test.go`.
+These tests intentionally use direct admin SQL for schema/permission and
+invariant assertions; that test SQL is not production repository code.

--- a/internal/access/semantic_attribute_audit.go
+++ b/internal/access/semantic_attribute_audit.go
@@ -1,0 +1,19 @@
+package access
+
+// Semantic-attribute audit actions are owned by the durable access
+// repository. API contracts use these canonical mutation actions; repository
+// idempotent replays may append their corresponding replay evidence action.
+const (
+	SemanticAttributeAuditActionRegister              = "semantic_attribute.register"
+	SemanticAttributeAuditActionRegisterReplay        = "semantic_attribute.register_replay"
+	SemanticAttributeAuditActionMetadataUpdate        = "semantic_attribute.metadata_update"
+	SemanticAttributeAuditActionMetadataReplay        = "semantic_attribute.metadata_replay"
+	SemanticAttributeAuditActionDisable               = "semantic_attribute.disable"
+	SemanticAttributeAuditActionEnable                = "semantic_attribute.enable"
+	SemanticAttributeAuditActionAssignmentSet         = "semantic_attribute.assignment.set"
+	SemanticAttributeAuditActionAssignmentReplay      = "semantic_attribute.assignment.replay"
+	SemanticAttributeAuditActionAssignmentTombstone   = "semantic_attribute.assignment.tombstone"
+	SemanticAttributeAuditActionClaimMappingSet       = "semantic_attribute.claim_mapping.set"
+	SemanticAttributeAuditActionClaimMappingReplay    = "semantic_attribute.claim_mapping.replay"
+	SemanticAttributeAuditActionClaimMappingTombstone = "semantic_attribute.claim_mapping.tombstone"
+)

--- a/internal/access/semantic_attribute_control.go
+++ b/internal/access/semantic_attribute_control.go
@@ -1,0 +1,263 @@
+package access
+
+// This file contains the control-plane half of semantic access.  It is kept
+// separate from semantic_attributes.go deliberately: a caller that only
+// qualifies definitions must not accidentally receive authority to mutate
+// subject assignments or trusted provider mappings.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+var (
+	ErrSemanticAttributeAssignmentConflict = errors.New("semantic attribute assignment conflicts with current state")
+	ErrSemanticAttributeMappingConflict    = errors.New("trusted claim mapping conflicts with current state")
+	ErrSemanticAttributeSourceConflict     = errors.New("semantic attribute sources conflict")
+	ErrSemanticAttributeNotFound           = errors.New("semantic attribute control row was not found")
+	ErrSemanticAttributeControlCorrupt     = errors.New("semantic attribute control state is corrupt")
+)
+
+// SemanticAttributeAssignment is one direct principal/group value.  Values
+// are already canonical and are safe to project into authorization decisions;
+// callers must never mutate the returned slice.
+type SemanticAttributeAssignment struct {
+	ID                string
+	DefinitionID      string
+	DefinitionName    string
+	DefinitionVersion int64
+	Type              semanticvalue.Type
+	Shape             SemanticAttributeShape
+	Subject           SubjectRef
+	CanonicalValues   []string
+	ValueDigest       string
+	AssignmentVersion int64
+	Tombstoned        bool
+	TombstonedAt      string
+	CreatedAt         string
+	UpdatedAt         string
+}
+
+// SemanticAttributeAssignmentInput addresses an assignment by definition and
+// subject. DefinitionID is preferred; DefinitionName is retained as a
+// convenient name-qualified boundary for control-plane callers. Exactly one
+// is required. ExpectedVersion is zero for creation and otherwise must match
+// the current row version.
+type SemanticAttributeAssignmentInput struct {
+	AssignmentID    string
+	DefinitionID    string
+	DefinitionName  string
+	Subject         SubjectRef
+	Values          any
+	ExpectedVersion int64
+	Mutation        SemanticAttributeMutationContext
+}
+
+// SetSemanticAttributeAssignmentInput is the explicit command name used by
+// command adapters. Keep the shorter input above as a source-compatible alias.
+type SetSemanticAttributeAssignmentInput = SemanticAttributeAssignmentInput
+
+// SemanticAttributeAssignmentFilter limits durable assignment reads. A zero
+// filter returns every current and tombstoned row in deterministic order.
+type SemanticAttributeAssignmentFilter struct {
+	DefinitionID      string
+	Subject           SubjectRef
+	IncludeTombstones bool
+}
+
+// TrustedClaimMapping maps one trusted provider claim to one definition. The
+// provider and claim path are immutable identity fields; remapping requires a
+// tombstone followed by a new mapping.
+type TrustedClaimMapping struct {
+	ID                string
+	SourceKind        TrustedClaimSourceKind
+	Provider          string
+	Issuer            string
+	Audience          string
+	Claim             string
+	DefinitionID      string
+	DefinitionName    string
+	DefinitionVersion int64
+	Type              semanticvalue.Type
+	Shape             SemanticAttributeShape
+	MappingVersion    int64
+	Tombstoned        bool
+	TombstonedAt      string
+	CreatedAt         string
+	UpdatedAt         string
+}
+
+type TrustedClaimMappingInput struct {
+	MappingID       string
+	SourceKind      TrustedClaimSourceKind
+	Provider        string
+	Issuer          string
+	Audience        string
+	Claim           string
+	DefinitionID    string
+	DefinitionName  string
+	ExpectedVersion int64
+	Mutation        SemanticAttributeMutationContext
+}
+
+type SetTrustedClaimMappingInput = TrustedClaimMappingInput
+
+type TrustedClaimMappingFilter struct {
+	SourceKind        TrustedClaimSourceKind
+	Provider          string
+	Issuer            string
+	Audience          string
+	Claim             string
+	IncludeTombstones bool
+}
+
+// TrustedClaimSourceKind is part of the trust identity. A provider named
+// "corp" in OIDC is not interchangeable with a provider named
+// "corp" in an embed or service-token source.
+type TrustedClaimSourceKind string
+
+const (
+	TrustedClaimSourceSAML         TrustedClaimSourceKind = "saml"
+	TrustedClaimSourceOIDC         TrustedClaimSourceKind = "oidc"
+	TrustedClaimSourceEmbed        TrustedClaimSourceKind = "embed"
+	TrustedClaimSourceServiceToken TrustedClaimSourceKind = "service_token"
+)
+
+func (kind TrustedClaimSourceKind) Valid() bool {
+	return kind == TrustedClaimSourceSAML || kind == TrustedClaimSourceOIDC || kind == TrustedClaimSourceEmbed || kind == TrustedClaimSourceServiceToken
+}
+
+type TrustedClaimSource struct {
+	Kind     TrustedClaimSourceKind
+	Provider string
+	Issuer   string
+	Audience string
+}
+
+// SemanticAttributeControlState is independent from
+// SemanticAttributeRegistryState. Registry metadata changes therefore do not
+// invalidate an assignment/control snapshot unless a control row changed.
+type SemanticAttributeControlState struct {
+	Profile   string
+	Revision  int64
+	Digest    string
+	UpdatedAt string
+}
+
+type SemanticAttributeControlSnapshot struct {
+	State       SemanticAttributeControlState
+	Assignments []SemanticAttributeAssignment
+	Mappings    []TrustedClaimMapping
+}
+
+// EffectiveSemanticAttribute is one resolved value and its source. A source
+// conflict is an error; callers must not guess which source wins.
+type EffectiveSemanticAttribute struct {
+	DefinitionID      string
+	DefinitionName    string
+	DefinitionVersion int64
+	Type              semanticvalue.Type
+	Shape             SemanticAttributeShape
+	CanonicalValues   []string
+	ValueDigest       string
+	Source            string
+}
+
+type SemanticAttributeAssignmentReader interface {
+	SemanticAttributeAssignments(context.Context, SemanticAttributeAssignmentFilter) ([]SemanticAttributeAssignment, error)
+	EffectiveDirectSemanticAttributeAssignments(context.Context, SubjectRef) ([]EffectiveSemanticAttribute, error)
+	EffectiveSemanticAttributeAssignments(context.Context, SubjectRef, trustedclaims.Envelope) ([]EffectiveSemanticAttribute, error)
+}
+
+type SemanticAttributeAssignmentWriter interface {
+	SetSemanticAttributeAssignment(context.Context, SemanticAttributeAssignmentInput) (SemanticAttributeAssignment, error)
+	TombstoneSemanticAttributeAssignment(context.Context, string, int64, SemanticAttributeMutationContext) (SemanticAttributeAssignment, error)
+}
+
+type TrustedClaimMappingReader interface {
+	TrustedClaimMappings(context.Context, TrustedClaimMappingFilter) ([]TrustedClaimMapping, error)
+}
+
+type TrustedClaimMappingWriter interface {
+	SetTrustedClaimMapping(context.Context, TrustedClaimMappingInput) (TrustedClaimMapping, error)
+	TombstoneTrustedClaimMapping(context.Context, string, int64, SemanticAttributeMutationContext) (TrustedClaimMapping, error)
+}
+
+// These aggregate interfaces are intentionally composed from the narrow
+// pieces. Definition registry users do not need to depend on either one.
+type SemanticAttributeControlReader interface {
+	SemanticAttributeAssignmentReader
+	TrustedClaimMappingReader
+	SemanticAttributeControl(context.Context) (SemanticAttributeControlSnapshot, error)
+}
+
+type SemanticAttributeControlWriter interface {
+	SemanticAttributeAssignmentWriter
+	TrustedClaimMappingWriter
+}
+
+// CanonicalSemanticAttributeValues applies the shared semantic-access v1
+// canonicalization profile to one assignment. Maps, functions, nested lists,
+// and all other executable/structured values are rejected by the scalar
+// canonicalizer; list values are homogeneous, deduplicated, sorted, and
+// bounded at semanticvalue.MaxSetValues.
+func CanonicalSemanticAttributeValues(definition SemanticAttributeDefinition, input any) ([]string, string, error) {
+	if !definition.Enabled {
+		return nil, "", fmt.Errorf("%w: %s", ErrSemanticAttributeDisabled, definition.Name)
+	}
+	if definition.Shape == SemanticAttributeScalar {
+		value := reflect.ValueOf(input)
+		if value.IsValid() && (value.Kind() == reflect.Array || value.Kind() == reflect.Slice || value.Kind() == reflect.Map || value.Kind() == reflect.Func) {
+			return nil, "", fmt.Errorf("%w: scalar assignment cannot be a collection or executable value", semanticvalue.ErrInvalidValue)
+		}
+		canonical, err := semanticvalue.Canonicalize(definition.Type, input)
+		if err != nil {
+			return nil, "", err
+		}
+		return []string{canonical.Canonical()}, canonical.Digest(), nil
+	}
+	if definition.Shape != SemanticAttributeList {
+		return nil, "", fmt.Errorf("%w: semantic attribute shape %q is invalid", semanticvalue.ErrInvalidValue, definition.Shape)
+	}
+	if input == nil {
+		return nil, "", fmt.Errorf("%w: list assignment is nil", semanticvalue.ErrInvalidValue)
+	}
+	value := reflect.ValueOf(input)
+	if value.Kind() != reflect.Array && value.Kind() != reflect.Slice {
+		return nil, "", fmt.Errorf("%w: list assignment of type %T is not a list", semanticvalue.ErrInvalidValue, input)
+	}
+	values := make([]any, value.Len())
+	for i := 0; i < value.Len(); i++ {
+		item := value.Index(i)
+		if !item.IsValid() {
+			return nil, "", fmt.Errorf("%w: list item %d is invalid", semanticvalue.ErrInvalidValue, i)
+		}
+		values[i] = item.Interface()
+	}
+	set, err := semanticvalue.CanonicalizeSet(definition.Type, values)
+	if err != nil {
+		return nil, "", err
+	}
+	canonical := set.Values()
+	result := make([]string, len(canonical))
+	for i := range canonical {
+		result[i] = canonical[i].Canonical()
+	}
+	return result, set.Digest(), nil
+}
+
+func ValidateSemanticAttributeSubject(subject SubjectRef) error {
+	if subject.Kind != SubjectKindPrincipal && subject.Kind != SubjectKindGroup {
+		return fmt.Errorf("%w: unsupported subject kind %q", ErrInvalidSubjectRef, subject.Kind)
+	}
+	if strings.TrimSpace(subject.ID) == "" {
+		return fmt.Errorf("%w: subject id is required", ErrInvalidSubjectRef)
+	}
+	return nil
+}

--- a/internal/access/semantic_attribute_control_contract_test.go
+++ b/internal/access/semantic_attribute_control_contract_test.go
@@ -1,0 +1,77 @@
+package access
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestTrustedClaimSourceKindValid(t *testing.T) {
+	for _, kind := range []TrustedClaimSourceKind{
+		TrustedClaimSourceSAML,
+		TrustedClaimSourceOIDC,
+		TrustedClaimSourceEmbed,
+		TrustedClaimSourceServiceToken,
+	} {
+		if !kind.Valid() {
+			t.Errorf("TrustedClaimSourceKind(%q).Valid() = false", kind)
+		}
+	}
+	for _, kind := range []TrustedClaimSourceKind{"", "SAML", "oidc ", "browser"} {
+		if kind.Valid() {
+			t.Errorf("TrustedClaimSourceKind(%q).Valid() = true", kind)
+		}
+	}
+}
+
+func TestValidateSemanticAttributeSubject(t *testing.T) {
+	for _, subject := range []SubjectRef{
+		{Kind: SubjectKindPrincipal, ID: "principal-1"},
+		{Kind: SubjectKindGroup, ID: "group-1"},
+	} {
+		if err := ValidateSemanticAttributeSubject(subject); err != nil {
+			t.Errorf("ValidateSemanticAttributeSubject(%#v) = %v", subject, err)
+		}
+	}
+	for _, subject := range []SubjectRef{
+		{},
+		{Kind: SubjectKind("domain"), ID: "domain-1"},
+		{Kind: SubjectKindPrincipal},
+		{Kind: SubjectKindGroup, ID: "  \t"},
+	} {
+		if err := ValidateSemanticAttributeSubject(subject); !errors.Is(err, ErrInvalidSubjectRef) {
+			t.Errorf("ValidateSemanticAttributeSubject(%#v) = %v, want invalid subject", subject, err)
+		}
+	}
+}
+
+func TestCanonicalSemanticAttributeValuesRejectsInvalidShapesAndInputs(t *testing.T) {
+	if _, _, err := CanonicalSemanticAttributeValues(SemanticAttributeDefinition{Name: "disabled"}, "value"); !errors.Is(err, ErrSemanticAttributeDisabled) {
+		t.Fatalf("disabled definition error = %v, want disabled error", err)
+	}
+	if _, _, err := CanonicalSemanticAttributeValues(SemanticAttributeDefinition{Enabled: true, Shape: SemanticAttributeShape("map")}, "value"); !errors.Is(err, semanticvalue.ErrInvalidValue) {
+		t.Fatalf("invalid shape error = %v, want invalid value", err)
+	}
+
+	list := SemanticAttributeDefinition{Enabled: true, Type: semanticvalue.TypeString, Shape: SemanticAttributeList}
+	for _, input := range []any{nil, "not-a-list", []any{nil}, []any{1}} {
+		if _, _, err := CanonicalSemanticAttributeValues(list, input); !errors.Is(err, semanticvalue.ErrInvalidValue) {
+			t.Errorf("list input %#v error = %v, want invalid value", input, err)
+		}
+	}
+	if values, _, err := CanonicalSemanticAttributeValues(list, [2]string{"b", "a"}); err != nil || strings.Join(values, ",") != "a,b" {
+		t.Fatalf("array list canonicalization = %#v, %v", values, err)
+	}
+
+	scalar := SemanticAttributeDefinition{Enabled: true, Type: semanticvalue.TypeString, Shape: SemanticAttributeScalar}
+	if values, _, err := CanonicalSemanticAttributeValues(scalar, "value"); err != nil || len(values) != 1 || values[0] != "value" {
+		t.Fatalf("scalar canonicalization = %#v, %v", values, err)
+	}
+	for _, input := range []any{nil, map[string]string{"blocked": "value"}, func() {}} {
+		if _, _, err := CanonicalSemanticAttributeValues(scalar, input); !errors.Is(err, semanticvalue.ErrInvalidValue) {
+			t.Errorf("scalar input %#v error = %v, want invalid value", input, err)
+		}
+	}
+}

--- a/internal/access/semantic_attribute_control_test.go
+++ b/internal/access/semantic_attribute_control_test.go
@@ -1,0 +1,37 @@
+package access
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestCanonicalSemanticAttributeValuesUsesSemanticValueBounds(t *testing.T) {
+	definition := SemanticAttributeDefinition{Enabled: true, Name: "labels", Type: semanticvalue.TypeString, Shape: SemanticAttributeList}
+	values, _, err := CanonicalSemanticAttributeValues(definition, []string{"b", "a", "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(values, ",") != "a,b" {
+		t.Fatalf("canonical list = %#v", values)
+	}
+	if values, _, err := CanonicalSemanticAttributeValues(definition, []string{"{literal}", "[literal]", "left=>right"}); err != nil || len(values) != 3 {
+		t.Fatalf("rejected valid punctuation-bearing strings: values=%#v err=%v", values, err)
+	}
+	for _, input := range []any{map[string]string{"blocked": "value"}, []any{[]string{"nested"}}, func() {}} {
+		if _, _, err := CanonicalSemanticAttributeValues(definition, input); err == nil {
+			t.Errorf("accepted unsupported list value %#v", input)
+		}
+	}
+	if _, _, err := CanonicalSemanticAttributeValues(SemanticAttributeDefinition{Enabled: true, Type: semanticvalue.TypeString, Shape: SemanticAttributeScalar}, []string{"not-scalar"}); err == nil {
+		t.Fatal("accepted a collection for a scalar attribute")
+	}
+	tooMany := make([]any, semanticvalue.MaxSetValues+1)
+	for index := range tooMany {
+		tooMany[index] = strings.Repeat("x", index+1)
+	}
+	if _, _, err := CanonicalSemanticAttributeValues(definition, tooMany); err == nil {
+		t.Fatal("accepted more than the semanticvalue cardinality bound")
+	}
+}

--- a/internal/access/semantic_attributes.go
+++ b/internal/access/semantic_attributes.go
@@ -106,12 +106,15 @@ type UpdateSemanticAttributeMetadataInput struct {
 	// legacy internal callers source-compatible; version-aware command paths
 	// must provide the version returned by the previous read.
 	ExpectedVersion int64
-	Mutation SemanticAttributeMutationContext
+	Mutation        SemanticAttributeMutationContext
 }
 
 type SemanticAttributeSearch struct {
-	Query string
-	Limit int
+	Query             string
+	OwnerKind         SemanticAttributeOwnerKind
+	AfterName         string
+	AfterDefinitionID string
+	Limit             int
 }
 
 // CanonicalSemanticAttributeValue is the profile-qualified value identity

--- a/internal/access/semantic_attributes.go
+++ b/internal/access/semantic_attributes.go
@@ -102,6 +102,10 @@ type RegisterSemanticAttributeInput struct {
 type UpdateSemanticAttributeMetadataInput struct {
 	Name     string
 	Metadata SemanticAttributeMetadata
+	// ExpectedVersion is checked after the registry row is locked. Zero keeps
+	// legacy internal callers source-compatible; version-aware command paths
+	// must provide the version returned by the previous read.
+	ExpectedVersion int64
 	Mutation SemanticAttributeMutationContext
 }
 
@@ -147,4 +151,12 @@ type SemanticAttributeRegistry interface {
 	UpdateSemanticAttributeMetadata(context.Context, UpdateSemanticAttributeMetadataInput) (SemanticAttributeDefinition, error)
 	SetSemanticAttributeEnabled(context.Context, string, bool, SemanticAttributeMutationContext) (SemanticAttributeDefinition, error)
 	ValidateSemanticAttributeValue(context.Context, string, any) (CanonicalSemanticAttributeValue, error)
+}
+
+// VersionedSemanticAttributeRegistry is the optimistic-concurrency surface
+// used by command adapters. It is separate so read-only registry consumers do
+// not acquire lifecycle mutation authority.
+type VersionedSemanticAttributeRegistry interface {
+	UpdateSemanticAttributeMetadataExpected(context.Context, UpdateSemanticAttributeMetadataInput) (SemanticAttributeDefinition, error)
+	SetSemanticAttributeEnabledExpected(context.Context, string, bool, int64, SemanticAttributeMutationContext) (SemanticAttributeDefinition, error)
 }

--- a/internal/access/trustedclaims/doc.go
+++ b/internal/access/trustedclaims/doc.go
@@ -1,0 +1,9 @@
+// Package trustedclaims defines the narrow trust boundary between
+// cryptographic authentication adapters and semantic-attribute admission.
+//
+// Callers may present raw evidence only to Verify, together with a verifier
+// owned by the evidence source. Verify is the only operation that can produce
+// an Envelope. The envelope intentionally exposes no raw evidence and keeps
+// its claim values private; accessors return copies suitable for a downstream
+// admission repository to canonicalize.
+package trustedclaims

--- a/internal/access/trustedclaims/identity.go
+++ b/internal/access/trustedclaims/identity.go
@@ -1,0 +1,87 @@
+package trustedclaims
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// The source identity limits are part of the trusted-claim contract. They
+// bound the exact values used to select a durable mapping and must therefore
+// be shared by verifier and admission/repository callers.
+const (
+	MaxProviderBytes = 128
+	MaxIssuerBytes   = 1024
+	MaxAudienceBytes = 512
+	MaxSubjectBytes  = 1024
+)
+
+// ValidateSourceIdentity validates the exact provider, issuer, and audience
+// tuple used to identify a trusted claim source. Values are never trimmed or
+// normalized: a caller must provide the canonical identity it intends to
+// match. Limits are measured in bytes, as they are for persisted text.
+func ValidateSourceIdentity(provider, issuer, audience string) error {
+	if err := ValidateProvider(provider); err != nil {
+		return err
+	}
+	if err := ValidateIssuer(issuer); err != nil {
+		return err
+	}
+	if err := ValidateAudience(audience); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateProvider validates one trusted source provider identifier. It is
+// also useful to validate optional provider filters without treating an empty
+// filter as a complete source identity.
+func ValidateProvider(provider string) error {
+	return validateIdentity("provider", provider, MaxProviderBytes)
+}
+
+// ValidateIssuer validates one trusted source issuer identifier.
+func ValidateIssuer(issuer string) error {
+	return validateIdentity("issuer", issuer, MaxIssuerBytes)
+}
+
+// ValidateAudience validates one trusted source audience identifier.
+func ValidateAudience(audience string) error {
+	return validateIdentity("audience", audience, MaxAudienceBytes)
+}
+
+// ValidateSubjectIdentity validates the subject returned by a trusted
+// evidence verifier. Subjects use the existing verified-identity limit and
+// the same exact-text rules as source identity fields.
+func ValidateSubjectIdentity(subject string) error {
+	return validateIdentity("subject", subject, MaxSubjectBytes)
+}
+
+func validateIdentity(label, value string, maxBytes int) error {
+	if value == "" {
+		return fmt.Errorf("%w: %s is required", ErrTrustIdentityMissing, label)
+	}
+	if value != strings.TrimSpace(value) {
+		return fmt.Errorf("%w: %s must not contain surrounding whitespace", ErrTrustIdentityMissing, label)
+	}
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%w: %s is not valid UTF-8", ErrTrustIdentityMissing, label)
+	}
+	if hasControl(value) {
+		return fmt.Errorf("%w: %s contains a control character", ErrTrustIdentityMissing, label)
+	}
+	if len(value) > maxBytes {
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrTrustIdentityMissing, label, maxBytes)
+	}
+	return nil
+}
+
+func hasControl(value string) bool {
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/access/trustedclaims/trustedclaims.go
+++ b/internal/access/trustedclaims/trustedclaims.go
@@ -1,0 +1,540 @@
+package trustedclaims
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+// SourceKind is the closed set of authentication evidence sources accepted by
+// the trusted-claim boundary. Values are deliberately lower-case and exact;
+// aliases and request transport names are not accepted.
+type SourceKind string
+
+const MaxClaimNameBytes = 1024
+
+const (
+	SourceSAML         SourceKind = "saml"
+	SourceOIDC         SourceKind = "oidc"
+	SourceEmbed        SourceKind = "embed"
+	SourceServiceToken SourceKind = "service_token"
+)
+
+const (
+	SourceKindSAML         = SourceSAML
+	SourceKindOIDC         = SourceOIDC
+	SourceKindEmbed        = SourceEmbed
+	SourceKindServiceToken = SourceServiceToken
+)
+
+// Short aliases make the source vocabulary convenient without introducing a
+// second set of wire values.
+const (
+	SAML         = SourceSAML
+	OIDC         = SourceOIDC
+	Embed        = SourceEmbed
+	ServiceToken = SourceServiceToken
+)
+
+// Valid reports whether kind is one of the four supported cryptographic
+// evidence sources.
+func (kind SourceKind) Valid() bool {
+	switch kind {
+	case SourceSAML, SourceOIDC, SourceEmbed, SourceServiceToken:
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	ErrInvalidEvidence      = errors.New("invalid trusted claim evidence")
+	ErrUnsupportedSource    = errors.New("unsupported trusted claim source")
+	ErrVerifierUnavailable  = errors.New("trusted claim verifier is unavailable")
+	ErrVerificationFailed   = errors.New("trusted claim cryptographic verification failed")
+	ErrTrustIdentityMissing = errors.New("trusted claim trust identity is missing")
+	ErrClaimInvalid         = errors.New("trusted claim is invalid")
+	ErrClaimNameInvalid     = errors.New("trusted claim name is invalid")
+	ErrClaimDuplicate       = errors.New("trusted claim name is duplicated")
+	ErrEvidenceExpired      = errors.New("trusted claim evidence is expired")
+	ErrEvidenceNotYetValid  = errors.New("trusted claim evidence is not yet valid")
+	ErrEvidenceTimeInvalid  = errors.New("trusted claim evidence time is invalid")
+	ErrRawEvidenceEmpty     = errors.New("trusted claim raw evidence is empty")
+	ErrRawEvidenceMutated   = errors.New("trusted claim verifier mutated raw evidence")
+)
+
+// RawEvidence is unverified source evidence. It can only be consumed by
+// Verify; no admission API accepts this type. Verify copies Raw before
+// invoking the verifier and checks that the verifier did not mutate it.
+type RawEvidence struct {
+	Source SourceKind
+	Raw    []byte
+}
+
+// Evidence is the concise alias used by adapters at call sites.
+type Evidence = RawEvidence
+
+// NewRawEvidence creates a raw evidence value while copying the caller's
+// bytes. Verify still copies again because a caller can mutate a slice after
+// construction and before verification.
+func NewRawEvidence(source SourceKind, raw []byte) RawEvidence {
+	return RawEvidence{Source: source, Raw: append([]byte(nil), raw...)}
+}
+
+// VerifiedClaims is the authenticated output of a source-specific
+// cryptographic verifier. It is intentionally not the admission envelope:
+// callers can construct this result, but only Verify can turn it into an
+// Envelope after validating every field and value.
+//
+// Claims use an ordered slice rather than a map so exact top-level names are
+// retained and duplicate names can be rejected. Values are limited by Verify
+// to semanticvalue-compatible scalars or one-dimensional homogeneous lists;
+// admission remains responsible for logical-type canonicalization.
+type VerifiedClaims struct {
+	Provider              string
+	Issuer                string
+	Audience              string
+	Subject               string
+	IssuedAt              time.Time
+	ExpiresAt             time.Time
+	CredentialFingerprint string
+	TokenFingerprint      string
+	Claims                []Claim
+}
+
+// Verification is an alias for the authenticated verifier result. It is not
+// an admission value; only Verify can produce an Envelope from it.
+type Verification = VerifiedClaims
+
+// Claim is one exact top-level claim. Name is never trimmed, folded, or
+// canonicalized. Value is copied into the verified envelope and can only be a
+// supported scalar or homogeneous list.
+type Claim struct {
+	Name  string
+	Value any
+}
+
+// CryptographicVerifier authenticates raw evidence for one source. The
+// implementation owns signature, issuer, audience, nonce, key, and token
+// validation appropriate to its source. Verify binds the returned metadata to
+// the requested source and applies the common structural/time boundary.
+type CryptographicVerifier interface {
+	Verify(context.Context, []byte) (VerifiedClaims, error)
+}
+
+// SourceVerifier associates a cryptographic verifier with exactly one source.
+// A verifier must not be reused for another source: Verify rejects a source
+// mismatch before calling it.
+type SourceVerifier interface {
+	SourceKind() SourceKind
+	CryptographicVerifier
+}
+
+// Verifier is the primary name for the source-bound verifier contract.
+type Verifier = SourceVerifier
+
+// VerifyOptions controls the common temporal check. A zero Now uses the UTC
+// wall clock. ClockSkew is intentionally not supported: accepting evidence
+// outside its exact issued/expiry interval is an authorization policy decision
+// that belongs to the source adapter or admission layer.
+type VerifyOptions struct {
+	Now time.Time
+}
+
+// Verify authenticates and structurally validates one source's raw evidence,
+// returning the only value accepted by trusted-claim admission. The returned
+// Envelope contains no raw evidence and cannot be constructed by a caller.
+func Verify(ctx context.Context, evidence RawEvidence, verifier SourceVerifier, options ...VerifyOptions) (Envelope, error) {
+	if ctx == nil {
+		return Envelope{}, fmt.Errorf("%w: nil context", ErrInvalidEvidence)
+	}
+	if !evidence.Source.Valid() {
+		if evidence.Source == "" {
+			return Envelope{}, fmt.Errorf("%w: source is required", ErrInvalidEvidence)
+		}
+		return Envelope{}, fmt.Errorf("%w: %q", ErrUnsupportedSource, evidence.Source)
+	}
+	if len(evidence.Raw) == 0 {
+		return Envelope{}, ErrRawEvidenceEmpty
+	}
+	if verifier == nil || isNilInterface(verifier) {
+		return Envelope{}, ErrVerifierUnavailable
+	}
+	if verifier.SourceKind() != evidence.Source {
+		return Envelope{}, fmt.Errorf("%w: evidence source %q does not match verifier source %q", ErrInvalidEvidence, evidence.Source, verifier.SourceKind())
+	}
+
+	now := time.Now().UTC()
+	if len(options) > 0 && !options[0].Now.IsZero() {
+		now = options[0].Now.UTC()
+	}
+	if len(options) > 1 {
+		return Envelope{}, fmt.Errorf("%w: at most one options value is accepted", ErrInvalidEvidence)
+	}
+
+	raw := append([]byte(nil), evidence.Raw...)
+	verified, err := verifier.Verify(ctx, raw)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("%w: %w", ErrVerificationFailed, err)
+	}
+	if !bytes.Equal(raw, evidence.Raw) {
+		return Envelope{}, ErrRawEvidenceMutated
+	}
+	if err := validateVerifiedClaims(verified, evidence.Source, now); err != nil {
+		return Envelope{}, err
+	}
+
+	claims := make([]storedClaim, len(verified.Claims))
+	for index, claim := range verified.Claims {
+		value, err := copyClaimValue(claim.Value)
+		if err != nil {
+			return Envelope{}, fmt.Errorf("%w: claim %q: %v", ErrClaimInvalid, claim.Name, err)
+		}
+		claims[index] = storedClaim{name: claim.Name, value: value}
+	}
+
+	return Envelope{
+		source:                evidence.Source,
+		provider:              verified.Provider,
+		issuer:                verified.Issuer,
+		audience:              verified.Audience,
+		subject:               verified.Subject,
+		issuedAt:              verified.IssuedAt.UTC(),
+		expiresAt:             verified.ExpiresAt.UTC(),
+		credentialFingerprint: verified.CredentialFingerprint,
+		tokenFingerprint:      verified.TokenFingerprint,
+		claims:                claims,
+	}, nil
+}
+
+func validateVerifiedClaims(claims VerifiedClaims, source SourceKind, now time.Time) error {
+	provider := strings.TrimSpace(claims.Provider)
+	issuer := strings.TrimSpace(claims.Issuer)
+	audience := strings.TrimSpace(claims.Audience)
+	subject := strings.TrimSpace(claims.Subject)
+	if provider == "" || issuer == "" || audience == "" || subject == "" {
+		return fmt.Errorf("%w: provider, issuer, audience, and subject are required", ErrTrustIdentityMissing)
+	}
+	if provider != claims.Provider || issuer != claims.Issuer || audience != claims.Audience || subject != claims.Subject {
+		return fmt.Errorf("%w: provider, issuer, audience, and subject must not contain surrounding whitespace", ErrTrustIdentityMissing)
+	}
+	if !validIdentity(provider) || !validIdentity(issuer) || !validIdentity(audience) || !validIdentity(subject) {
+		return fmt.Errorf("%w: trust identity contains invalid text", ErrTrustIdentityMissing)
+	}
+	if claims.IssuedAt.IsZero() || claims.ExpiresAt.IsZero() {
+		return fmt.Errorf("%w: issued and expiry times are required", ErrTrustIdentityMissing)
+	}
+	issuedAt := claims.IssuedAt.UTC()
+	expiresAt := claims.ExpiresAt.UTC()
+	if !expiresAt.After(issuedAt) {
+		return fmt.Errorf("%w: expiry must be after issued time", ErrEvidenceTimeInvalid)
+	}
+	if now.Before(issuedAt) {
+		return fmt.Errorf("%w: issued at %s", ErrEvidenceNotYetValid, issuedAt.Format(time.RFC3339Nano))
+	}
+	if !now.Before(expiresAt) {
+		return fmt.Errorf("%w: expired at %s", ErrEvidenceExpired, expiresAt.Format(time.RFC3339Nano))
+	}
+
+	if claims.CredentialFingerprint == "" && claims.TokenFingerprint == "" {
+		return fmt.Errorf("%w: credential or token fingerprint is required", ErrTrustIdentityMissing)
+	}
+	if claims.CredentialFingerprint != "" && !validFingerprint(claims.CredentialFingerprint) {
+		return fmt.Errorf("%w: credential fingerprint is invalid", ErrTrustIdentityMissing)
+	}
+	if claims.TokenFingerprint != "" && !validFingerprint(claims.TokenFingerprint) {
+		return fmt.Errorf("%w: token fingerprint is invalid", ErrTrustIdentityMissing)
+	}
+	if source == SourceServiceToken && claims.TokenFingerprint == "" {
+		return fmt.Errorf("%w: service_token requires token fingerprint", ErrTrustIdentityMissing)
+	}
+
+	seenNames := make(map[string]struct{}, len(claims.Claims))
+	for _, claim := range claims.Claims {
+		if err := validateClaimName(claim.Name); err != nil {
+			return err
+		}
+		if _, exists := seenNames[claim.Name]; exists {
+			return fmt.Errorf("%w: %q", ErrClaimDuplicate, claim.Name)
+		}
+		seenNames[claim.Name] = struct{}{}
+		if err := validateClaimValue(claim.Value); err != nil {
+			return fmt.Errorf("%w: claim %q: %v", ErrClaimInvalid, claim.Name, err)
+		}
+	}
+	return nil
+}
+
+func validateClaimName(name string) error {
+	if name == "" {
+		return fmt.Errorf("%w: name is required", ErrClaimNameInvalid)
+	}
+	if name != strings.TrimSpace(name) {
+		return fmt.Errorf("%w: name must not contain surrounding whitespace", ErrClaimNameInvalid)
+	}
+	if len(name) > MaxClaimNameBytes {
+		return fmt.Errorf("%w: name exceeds %d bytes", ErrClaimNameInvalid, MaxClaimNameBytes)
+	}
+	if !utf8.ValidString(name) {
+		return fmt.Errorf("%w: name is not valid UTF-8", ErrClaimNameInvalid)
+	}
+	if hasControl(name) {
+		return fmt.Errorf("%w: name contains a control character", ErrClaimNameInvalid)
+	}
+	return nil
+}
+
+func validateClaimValue(value any) error {
+	if value == nil {
+		return errors.New("null is not supported")
+	}
+	if isScalarValue(value) {
+		return nil
+	}
+	rv := reflect.ValueOf(value)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return fmt.Errorf("value of type %T is not a semantic scalar or list", value)
+	}
+	if rv.Type().Elem().Kind() == reflect.Uint8 {
+		return fmt.Errorf("binary value of type %T is not supported", value)
+	}
+	if rv.Len() == 0 {
+		return errors.New("empty lists are not supported")
+	}
+	if rv.Len() > semanticvalue.MaxSetValues {
+		return fmt.Errorf("list exceeds %d values", semanticvalue.MaxSetValues)
+	}
+	var listKind reflect.Type
+	for index := 0; index < rv.Len(); index++ {
+		item := rv.Index(index).Interface()
+		if item == nil {
+			return fmt.Errorf("list item %d is null", index)
+		}
+		if !isScalarValue(item) {
+			return fmt.Errorf("list item %d of type %T is not a supported scalar", index, item)
+		}
+		itemType := reflect.TypeOf(item)
+		if listKind == nil {
+			listKind = itemType
+		} else if listKind != itemType {
+			return fmt.Errorf("list mixes scalar types %s and %s", listKind, itemType)
+		}
+	}
+	return nil
+}
+
+func isScalarValue(value any) bool {
+	switch typed := value.(type) {
+	case string:
+		return utf8.ValidString(typed) && !hasControl(typed)
+	case bool:
+		return true
+	case json.Number:
+		return validJSONNumber(typed)
+	case int, int8, int16, int32, int64:
+		return true
+	case uint:
+		return uint64(typed) <= math.MaxInt64
+	case uint8:
+		return uint64(typed) <= math.MaxInt64
+	case uint16:
+		return uint64(typed) <= math.MaxInt64
+	case uint32:
+		return uint64(typed) <= math.MaxInt64
+	case uint64:
+		return typed <= math.MaxInt64
+	default:
+		return false
+	}
+}
+
+func validJSONNumber(value json.Number) bool {
+	if value == "" || !json.Valid([]byte(value)) {
+		return false
+	}
+	first := value[0]
+	return first == '-' || first >= '0' && first <= '9'
+}
+
+func copyClaimValue(value any) (any, error) {
+	if err := validateClaimValue(value); err != nil {
+		return nil, err
+	}
+	if isScalarValue(value) {
+		return value, nil
+	}
+	rv := reflect.ValueOf(value)
+	copy := make([]any, rv.Len())
+	for index := range copy {
+		item, err := copyClaimValue(rv.Index(index).Interface())
+		if err != nil {
+			return nil, err
+		}
+		copy[index] = item
+	}
+	return copy, nil
+}
+
+func validFingerprint(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || !utf8.ValidString(value) || hasControl(value) {
+		return false
+	}
+	if len(value) == 64 {
+		return lowerHex(value)
+	}
+	return len(value) == len("sha256:")+64 && strings.HasPrefix(value, "sha256:") && lowerHex(value[len("sha256:"):])
+}
+
+func lowerHex(value string) bool {
+	for _, character := range value {
+		if !(character >= '0' && character <= '9' || character >= 'a' && character <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func validIdentity(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) && utf8.ValidString(value) && !hasControl(value) && len(value) <= 1024
+}
+
+func hasControl(value string) bool {
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+type storedClaim struct {
+	name  string
+	value any
+}
+
+// Envelope is an immutable, verifier-gated trusted-claim envelope. Its
+// fields are private by design: callers cannot forge or mutate a verified
+// value. Use Verify to produce one and the accessors below to inspect it.
+type Envelope struct {
+	source                SourceKind
+	provider              string
+	issuer                string
+	audience              string
+	subject               string
+	issuedAt              time.Time
+	expiresAt             time.Time
+	credentialFingerprint string
+	tokenFingerprint      string
+	claims                []storedClaim
+}
+
+func (envelope Envelope) Valid() bool                   { return envelope.source.Valid() }
+func (envelope Envelope) Source() SourceKind            { return envelope.source }
+func (envelope Envelope) SourceKind() SourceKind        { return envelope.source }
+func (envelope Envelope) Provider() string              { return envelope.provider }
+func (envelope Envelope) Issuer() string                { return envelope.issuer }
+func (envelope Envelope) Audience() string              { return envelope.audience }
+func (envelope Envelope) Subject() string               { return envelope.subject }
+func (envelope Envelope) IssuedAt() time.Time           { return envelope.issuedAt }
+func (envelope Envelope) ExpiresAt() time.Time          { return envelope.expiresAt }
+func (envelope Envelope) CredentialFingerprint() string { return envelope.credentialFingerprint }
+func (envelope Envelope) TokenFingerprint() string      { return envelope.tokenFingerprint }
+
+// Fingerprint returns the first verifier-bound credential or token identity.
+// Callers that need to distinguish both can use the explicit accessors above.
+func (envelope Envelope) Fingerprint() string {
+	if envelope.credentialFingerprint != "" {
+		return envelope.credentialFingerprint
+	}
+	return envelope.tokenFingerprint
+}
+
+// Claims returns a deep copy preserving verifier order and exact names.
+func (envelope Envelope) Claims() []Claim {
+	claims := make([]Claim, len(envelope.claims))
+	for index, claim := range envelope.claims {
+		value, err := copyClaimValue(claim.value)
+		if err != nil {
+			// Values were validated before entering the envelope. Returning nil
+			// here is defensive in case package internals are changed later.
+			return nil
+		}
+		claims[index] = Claim{Name: claim.name, Value: value}
+	}
+	return claims
+}
+
+// ClaimNames returns a copy of the exact top-level claim names.
+func (envelope Envelope) ClaimNames() []string {
+	names := make([]string, len(envelope.claims))
+	for index, claim := range envelope.claims {
+		names[index] = claim.name
+	}
+	return names
+}
+
+// Claim returns a copied claim by exact, case-sensitive name. The name is not
+// normalized, so callers cannot accidentally turn a different spelling into a
+// trusted match.
+func (envelope Envelope) Claim(name string) (Claim, bool) {
+	for _, claim := range envelope.claims {
+		if claim.name != name {
+			continue
+		}
+		value, err := copyClaimValue(claim.value)
+		if err != nil {
+			return Claim{}, false
+		}
+		return Claim{Name: claim.name, Value: value}, true
+	}
+	return Claim{}, false
+}
+
+// Value returns a copied raw value by exact, case-sensitive claim name. The
+// returned value is intended for the admission repository's canonicalizer and
+// is never canonicalized here.
+func (envelope Envelope) Value(name string) (any, bool) {
+	claim, ok := envelope.Claim(name)
+	if !ok {
+		return nil, false
+	}
+	return claim.Value, true
+}
+
+// HasClaim reports whether an exact top-level claim exists.
+func (envelope Envelope) HasClaim(name string) bool {
+	for _, claim := range envelope.claims {
+		if claim.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// NotBefore and NotAfter aliases make temporal checks readable at consumers
+// while retaining the exact issued/expiry vocabulary in the contract.
+func (envelope Envelope) NotBefore() time.Time { return envelope.issuedAt }
+func (envelope Envelope) NotAfter() time.Time  { return envelope.expiresAt }

--- a/internal/access/trustedclaims/trustedclaims.go
+++ b/internal/access/trustedclaims/trustedclaims.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 	"time"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/flidai/leapview/internal/semanticvalue"
@@ -218,18 +217,11 @@ func Verify(ctx context.Context, evidence RawEvidence, verifier SourceVerifier, 
 }
 
 func validateVerifiedClaims(claims VerifiedClaims, source SourceKind, now time.Time) error {
-	provider := strings.TrimSpace(claims.Provider)
-	issuer := strings.TrimSpace(claims.Issuer)
-	audience := strings.TrimSpace(claims.Audience)
-	subject := strings.TrimSpace(claims.Subject)
-	if provider == "" || issuer == "" || audience == "" || subject == "" {
-		return fmt.Errorf("%w: provider, issuer, audience, and subject are required", ErrTrustIdentityMissing)
+	if err := ValidateSourceIdentity(claims.Provider, claims.Issuer, claims.Audience); err != nil {
+		return err
 	}
-	if provider != claims.Provider || issuer != claims.Issuer || audience != claims.Audience || subject != claims.Subject {
-		return fmt.Errorf("%w: provider, issuer, audience, and subject must not contain surrounding whitespace", ErrTrustIdentityMissing)
-	}
-	if !validIdentity(provider) || !validIdentity(issuer) || !validIdentity(audience) || !validIdentity(subject) {
-		return fmt.Errorf("%w: trust identity contains invalid text", ErrTrustIdentityMissing)
+	if err := ValidateSubjectIdentity(claims.Subject); err != nil {
+		return err
 	}
 	if claims.IssuedAt.IsZero() || claims.ExpiresAt.IsZero() {
 		return fmt.Errorf("%w: issued and expiry times are required", ErrTrustIdentityMissing)
@@ -402,19 +394,6 @@ func lowerHex(value string) bool {
 		}
 	}
 	return true
-}
-
-func validIdentity(value string) bool {
-	return value != "" && value == strings.TrimSpace(value) && utf8.ValidString(value) && !hasControl(value) && len(value) <= 1024
-}
-
-func hasControl(value string) bool {
-	for _, character := range value {
-		if unicode.IsControl(character) {
-			return true
-		}
-	}
-	return false
 }
 
 func isNilInterface(value any) bool {

--- a/internal/access/trustedclaims/trustedclaims_test.go
+++ b/internal/access/trustedclaims/trustedclaims_test.go
@@ -1,0 +1,276 @@
+package trustedclaims
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testVerifier struct {
+	kind      SourceKind
+	result    VerifiedClaims
+	err       error
+	called    bool
+	mutateRaw bool
+}
+
+func (verifier *testVerifier) SourceKind() SourceKind { return verifier.kind }
+
+func (verifier *testVerifier) Verify(_ context.Context, raw []byte) (VerifiedClaims, error) {
+	verifier.called = true
+	if verifier.mutateRaw {
+		raw[0] ^= 0xff
+	}
+	return verifier.result, verifier.err
+}
+
+func validVerifiedClaims(now time.Time) VerifiedClaims {
+	return VerifiedClaims{
+		Provider:              "provider-1",
+		Issuer:                "https://issuer.example",
+		Audience:              "leapview",
+		Subject:               "subject-1",
+		IssuedAt:              now.Add(-time.Minute),
+		ExpiresAt:             now.Add(time.Minute),
+		CredentialFingerprint: strings.Repeat("a", 64),
+		Claims: []Claim{
+			{Name: "department", Value: "sales"},
+			{Name: "regions", Value: []string{"west", "east"}},
+		},
+	}
+}
+
+func TestVerifyCreatesOpaqueEnvelopeAndInvokesMatchingSourceVerifier(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	raw := []byte("signed-evidence")
+	verifier := &testVerifier{kind: SourceOIDC, result: validVerifiedClaims(now)}
+	envelope, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: raw}, verifier, VerifyOptions{Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifier.called || !envelope.Valid() {
+		t.Fatalf("called=%v valid=%v", verifier.called, envelope.Valid())
+	}
+	if envelope.Source() != SourceOIDC || envelope.Provider() != "provider-1" || envelope.Issuer() != "https://issuer.example" || envelope.Audience() != "leapview" || envelope.Subject() != "subject-1" {
+		t.Fatalf("identity accessors = %q/%q/%q/%q/%q", envelope.Source(), envelope.Provider(), envelope.Issuer(), envelope.Audience(), envelope.Subject())
+	}
+	if !envelope.IssuedAt().Equal(now.Add(-time.Minute)) || !envelope.ExpiresAt().Equal(now.Add(time.Minute)) || envelope.Fingerprint() != strings.Repeat("a", 64) {
+		t.Fatalf("time/fingerprint accessors = %s/%s/%q", envelope.IssuedAt(), envelope.ExpiresAt(), envelope.Fingerprint())
+	}
+	if !reflect.DeepEqual(envelope.ClaimNames(), []string{"department", "regions"}) {
+		t.Fatalf("claim names = %#v", envelope.ClaimNames())
+	}
+}
+
+func TestVerifyRejectsEmptyEvidenceWithoutCallingVerifier(t *testing.T) {
+	verifier := &testVerifier{kind: SourceOIDC, result: validVerifiedClaims(time.Now())}
+	_, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC}, verifier)
+	if !errors.Is(err, ErrRawEvidenceEmpty) || verifier.called {
+		t.Fatalf("err=%v called=%v", err, verifier.called)
+	}
+}
+
+func TestVerifyRejectsVerifierMutationOfRawEvidence(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	verifier := &testVerifier{kind: SourceOIDC, result: validVerifiedClaims(now), mutateRaw: true}
+	_, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: []byte("evidence")}, verifier, VerifyOptions{Now: now})
+	if !errors.Is(err, ErrRawEvidenceMutated) {
+		t.Fatalf("err=%v, want raw evidence mutation rejection", err)
+	}
+}
+
+func TestVerifyRejectsUnknownTransportSourcesAndMismatchedVerifier(t *testing.T) {
+	now := time.Now().UTC()
+	verifier := &testVerifier{kind: SourceOIDC, result: validVerifiedClaims(now)}
+	for _, source := range []SourceKind{"", "browser", "query", "header", "SAML", "saml "} {
+		t.Run(string(source), func(t *testing.T) {
+			verifier.called = false
+			_, err := Verify(context.Background(), RawEvidence{Source: source, Raw: []byte("evidence")}, verifier, VerifyOptions{Now: now})
+			if err == nil || verifier.called {
+				t.Fatalf("err=%v called=%v", err, verifier.called)
+			}
+		})
+	}
+	for _, source := range []SourceKind{SourceSAML, SourceEmbed, SourceServiceToken} {
+		verifier.called = false
+		_, err := Verify(context.Background(), RawEvidence{Source: source, Raw: []byte("evidence")}, verifier, VerifyOptions{Now: now})
+		if err == nil || verifier.called {
+			t.Fatalf("source=%q err=%v called=%v", source, err, verifier.called)
+		}
+	}
+}
+
+func TestVerifyRejectsExpiredAndNotYetValidEvidence(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		edit func(*VerifiedClaims)
+		want error
+	}{
+		{name: "expired", edit: func(claims *VerifiedClaims) { claims.ExpiresAt = now }, want: ErrEvidenceExpired},
+		{name: "not yet valid", edit: func(claims *VerifiedClaims) { claims.IssuedAt = now.Add(time.Second) }, want: ErrEvidenceNotYetValid},
+		{name: "reversed", edit: func(claims *VerifiedClaims) { claims.IssuedAt = now; claims.ExpiresAt = now.Add(-time.Second) }, want: ErrEvidenceTimeInvalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := validVerifiedClaims(now)
+			tt.edit(&claims)
+			_, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: []byte("evidence")}, &testVerifier{kind: SourceOIDC, result: claims}, VerifyOptions{Now: now})
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("err=%v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifyRequiresBoundTrustIdentityAndSourceFingerprint(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		edit func(*VerifiedClaims)
+	}{
+		{name: "provider", edit: func(claims *VerifiedClaims) { claims.Provider = "" }},
+		{name: "issuer", edit: func(claims *VerifiedClaims) { claims.Issuer = "" }},
+		{name: "audience", edit: func(claims *VerifiedClaims) { claims.Audience = "" }},
+		{name: "subject", edit: func(claims *VerifiedClaims) { claims.Subject = "" }},
+		{name: "credential fingerprint", edit: func(claims *VerifiedClaims) { claims.CredentialFingerprint = "" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := validVerifiedClaims(now)
+			tt.edit(&claims)
+			_, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: []byte("evidence")}, &testVerifier{kind: SourceOIDC, result: claims}, VerifyOptions{Now: now})
+			if !errors.Is(err, ErrTrustIdentityMissing) {
+				t.Fatalf("err=%v, want trust identity missing", err)
+			}
+		})
+	}
+
+	claims := validVerifiedClaims(now)
+	claims.TokenFingerprint = strings.Repeat("b", 64)
+	claims.CredentialFingerprint = ""
+	_, err := Verify(context.Background(), RawEvidence{Source: SourceServiceToken, Raw: []byte("evidence")}, &testVerifier{kind: SourceServiceToken, result: claims}, VerifyOptions{Now: now})
+	if err != nil {
+		t.Fatalf("service token with token fingerprint: %v", err)
+	}
+}
+
+func TestVerifyRejectsMapsNestedListsNullsAndUnsupportedValuesWithoutCoercion(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	values := []struct {
+		name  string
+		value any
+	}{
+		{name: "map", value: map[string]any{"role": "admin"}},
+		{name: "nested list", value: [][]string{{"admin"}}},
+		{name: "null", value: nil},
+		{name: "float", value: 1.5},
+		{name: "invalid number", value: json.Number("null")},
+		{name: "uint overflow", value: ^uint64(0)},
+		{name: "function", value: func() {}},
+		{name: "channel", value: make(chan int)},
+		{name: "bytes", value: []byte("admin")},
+		{name: "mixed list", value: []any{"admin", 1}},
+		{name: "empty list", value: []string{}},
+	}
+	for _, tt := range values {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := validVerifiedClaims(now)
+			claims.Claims = []Claim{{Name: "role", Value: tt.value}}
+			_, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: []byte("evidence")}, &testVerifier{kind: SourceOIDC, result: claims}, VerifyOptions{Now: now})
+			if !errors.Is(err, ErrClaimInvalid) {
+				t.Fatalf("err=%v, want claim invalid", err)
+			}
+		})
+	}
+}
+
+func TestVerifyPreservesExactClaimNamesAndRejectsDuplicates(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	claims := validVerifiedClaims(now)
+	claims.Claims = []Claim{{Name: "http://schemas.example/Role", Value: "admin"}}
+	envelope, err := Verify(context.Background(), RawEvidence{Source: SourceSAML, Raw: []byte("evidence")}, &testVerifier{kind: SourceSAML, result: claims}, VerifyOptions{Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !envelope.HasClaim("http://schemas.example/Role") || envelope.HasClaim("http://schemas.example/role") {
+		t.Fatal("claim lookup was not exact")
+	}
+	claims.Claims = append(claims.Claims, Claim{Name: "http://schemas.example/Role", Value: "other"})
+	if _, err := Verify(context.Background(), RawEvidence{Source: SourceSAML, Raw: []byte("evidence")}, &testVerifier{kind: SourceSAML, result: claims}, VerifyOptions{Now: now}); !errors.Is(err, ErrClaimDuplicate) {
+		t.Fatalf("duplicate err=%v", err)
+	}
+	for _, name := range []string{"", string([]byte{0xff}), "role\n", " role", strings.Repeat("a", MaxClaimNameBytes+1)} {
+		claims := validVerifiedClaims(now)
+		claims.Claims = []Claim{{Name: name, Value: "admin"}}
+		if _, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: []byte("evidence")}, &testVerifier{kind: SourceOIDC, result: claims}, VerifyOptions{Now: now}); !errors.Is(err, ErrClaimNameInvalid) {
+			t.Fatalf("name %q err=%v", name, err)
+		}
+	}
+}
+
+func TestVerifyRequiresCanonicalSHA256Fingerprint(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	for _, fingerprint := range []string{
+		"credential-fingerprint",
+		strings.Repeat("a", 63),
+		strings.Repeat("A", 64),
+		"sha256:" + strings.Repeat("a", 63),
+		"SHA256:" + strings.Repeat("a", 64),
+		"sha256:" + strings.Repeat("A", 64),
+	} {
+		claims := validVerifiedClaims(now)
+		claims.CredentialFingerprint = fingerprint
+		_, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: []byte("evidence")}, &testVerifier{kind: SourceOIDC, result: claims}, VerifyOptions{Now: now})
+		if !errors.Is(err, ErrTrustIdentityMissing) {
+			t.Fatalf("fingerprint %q err=%v, want trust identity missing", fingerprint, err)
+		}
+	}
+	for _, fingerprint := range []string{strings.Repeat("a", 64), "sha256:" + strings.Repeat("a", 64)} {
+		claims := validVerifiedClaims(now)
+		claims.CredentialFingerprint = fingerprint
+		if _, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: []byte("evidence")}, &testVerifier{kind: SourceOIDC, result: claims}, VerifyOptions{Now: now}); err != nil {
+			t.Fatalf("fingerprint %q rejected: %v", fingerprint, err)
+		}
+	}
+}
+
+func TestEnvelopeAccessorsReturnCopies(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	claims := validVerifiedClaims(now)
+	envelope, err := Verify(context.Background(), RawEvidence{Source: SourceEmbed, Raw: []byte("evidence")}, &testVerifier{kind: SourceEmbed, result: claims}, VerifyOptions{Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := envelope.ClaimNames()
+	names[0] = "changed"
+	if envelope.ClaimNames()[0] != "department" {
+		t.Fatal("claim names exposed mutable storage")
+	}
+	got, ok := envelope.Value("regions")
+	if !ok {
+		t.Fatal("regions claim missing")
+	}
+	values := got.([]any)
+	values[0] = "changed"
+	fresh, _ := envelope.Value("regions")
+	if fresh.([]any)[0] == "changed" {
+		t.Fatal("claim list exposed mutable storage")
+	}
+	all := envelope.Claims()
+	all[0].Name = "changed"
+	if envelope.Claims()[0].Name != "department" {
+		t.Fatal("claims exposed mutable storage")
+	}
+
+	typ := reflect.TypeOf(envelope)
+	for index := 0; index < typ.NumField(); index++ {
+		if typ.Field(index).PkgPath == "" {
+			t.Fatalf("Envelope field %q is exported", typ.Field(index).Name)
+		}
+	}
+}

--- a/internal/access/trustedclaims/trustedclaims_test.go
+++ b/internal/access/trustedclaims/trustedclaims_test.go
@@ -159,6 +159,61 @@ func TestVerifyRequiresBoundTrustIdentityAndSourceFingerprint(t *testing.T) {
 	}
 }
 
+func TestSourceIdentityLimitsAreExactAndFieldSpecific(t *testing.T) {
+	validProvider := strings.Repeat("p", MaxProviderBytes)
+	validIssuer := strings.Repeat("i", MaxIssuerBytes)
+	validAudience := strings.Repeat("a", MaxAudienceBytes)
+	if err := ValidateSourceIdentity(validProvider, validIssuer, validAudience); err != nil {
+		t.Fatalf("source identity at each limit rejected: %v", err)
+	}
+
+	for _, test := range []struct {
+		name     string
+		provider string
+		issuer   string
+		audience string
+	}{
+		{name: "provider", provider: strings.Repeat("p", MaxProviderBytes+1), issuer: "issuer", audience: "audience"},
+		{name: "issuer", provider: "provider", issuer: strings.Repeat("i", MaxIssuerBytes+1), audience: "audience"},
+		{name: "audience", provider: "provider", issuer: "issuer", audience: strings.Repeat("a", MaxAudienceBytes+1)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateSourceIdentity(test.provider, test.issuer, test.audience); !errors.Is(err, ErrTrustIdentityMissing) {
+				t.Fatalf("ValidateSourceIdentity() error = %v, want trust identity rejection", err)
+			}
+		})
+	}
+
+	if err := ValidateSubjectIdentity(strings.Repeat("s", MaxSubjectBytes)); err != nil {
+		t.Fatalf("subject at its limit rejected: %v", err)
+	}
+	if err := ValidateSubjectIdentity(strings.Repeat("s", MaxSubjectBytes+1)); !errors.Is(err, ErrTrustIdentityMissing) {
+		t.Fatalf("subject over limit error = %v, want trust identity rejection", err)
+	}
+}
+
+func TestVerifyUsesFieldSpecificSourceIdentityLimits(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name string
+		edit func(*VerifiedClaims)
+	}{
+		{name: "provider", edit: func(claims *VerifiedClaims) { claims.Provider = strings.Repeat("p", MaxProviderBytes+1) }},
+		{name: "issuer", edit: func(claims *VerifiedClaims) { claims.Issuer = strings.Repeat("i", MaxIssuerBytes+1) }},
+		{name: "audience", edit: func(claims *VerifiedClaims) { claims.Audience = strings.Repeat("a", MaxAudienceBytes+1) }},
+		{name: "subject", edit: func(claims *VerifiedClaims) { claims.Subject = strings.Repeat("s", MaxSubjectBytes+1) }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			claims := validVerifiedClaims(now)
+			test.edit(&claims)
+			_, err := Verify(context.Background(), RawEvidence{Source: SourceOIDC, Raw: []byte("evidence")}, &testVerifier{kind: SourceOIDC, result: claims}, VerifyOptions{Now: now})
+			if !errors.Is(err, ErrTrustIdentityMissing) {
+				t.Fatalf("Verify() error = %v, want trust identity rejection", err)
+			}
+		})
+	}
+}
+
 func TestVerifyRejectsMapsNestedListsNullsAndUnsupportedValuesWithoutCoercion(t *testing.T) {
 	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
 	values := []struct {

--- a/internal/app/api_apigen_test.go
+++ b/internal/app/api_apigen_test.go
@@ -25,7 +25,7 @@ import (
 	releasegen "github.com/flidai/leapview/internal/release/api/gen"
 )
 
-const expectedAPIGenAggregateOperationCount = 197
+const expectedAPIGenAggregateOperationCount = 213
 
 func TestAPIGenUsesTypedClientGenerator(t *testing.T) {
 	root := projectRoot(t)
@@ -242,7 +242,7 @@ func TestAPIGenAccessCapabilityOwnsItsGeneratedPackage(t *testing.T) {
 
 func TestAPIGenAccessCapabilityOwnsItsOperationSurface(t *testing.T) {
 	accessContracts := accessgen.GetAPIGenOperationContracts()
-	if got, want := len(accessContracts), 58; got != want {
+	if got, want := len(accessContracts), 74; got != want {
 		t.Fatalf("Access generated operations = %d, want %d", got, want)
 	}
 	allowedTags := map[string]bool{"Access": true, "Audit": true, "Current User": true}
@@ -1034,7 +1034,7 @@ func TestAPIGenOperationExtensions(t *testing.T) {
 			}
 			continue
 		}
-		if authenticatedOperations[operationID] {
+		if authenticatedOperations[operationID] || slices.Contains(semanticAttributeAuthenticatedOperations, operationID) {
 			if got := authz["mode"]; got != "authenticated" {
 				t.Fatalf("%s x-authz mode = %#v, want authenticated", operationID, got)
 			}

--- a/internal/app/postgresbaseline/baseline.go
+++ b/internal/app/postgresbaseline/baseline.go
@@ -19,7 +19,7 @@ import (
 const (
 	BaselineRevision    = platformmigrations.BaselineRevision
 	BaselineMigrationID = platformmigrations.BaselineMigrationID
-	LatestRevision      = accesspostgres.AttributeRegistryMigrationRevision
+	LatestRevision      = accesspostgres.SemanticAttributeControlMigrationRevision
 )
 
 // Keep the reconciliation baseline intentionally small. New durable
@@ -36,6 +36,11 @@ var plan = platformmigrations.Plan{
 			Revision:    accesspostgres.AttributeRegistryMigrationRevision,
 			MigrationID: accesspostgres.AttributeRegistryMigrationID,
 			SQL:         accesspostgres.AttributeRegistryMigrationSQL(),
+		},
+		{
+			Revision:    accesspostgres.SemanticAttributeControlMigrationRevision,
+			MigrationID: accesspostgres.SemanticAttributeControlMigrationID,
+			SQL:         accesspostgres.SemanticAttributeControlMigrationSQL(),
 		},
 	},
 	RolePolicySQL: rolePolicySQL,
@@ -109,7 +114,9 @@ BEGIN
         REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON audit.audit_event FROM leapview_control_runtime;
         REVOKE DELETE ON access.session, access.api_token, access.service_principal_secret,
             access.desktop_authorization_code, access.device_authorization,
-            access.authoring_session, access.authoring_credential FROM leapview_control_runtime;
+            access.authoring_session, access.authoring_credential,
+            access.semantic_attribute_control_state, access.semantic_attribute_assignment,
+            access.semantic_attribute_claim_mapping FROM leapview_control_runtime;
         GRANT USAGE ON SCHEMA physical_pool TO leapview_control_runtime;
         GRANT SELECT ON ALL TABLES IN SCHEMA physical_pool TO leapview_control_runtime;
         REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER

--- a/internal/app/postgresbaseline/baseline_test.go
+++ b/internal/app/postgresbaseline/baseline_test.go
@@ -40,10 +40,10 @@ func TestBaselineOwnsOnlyReconciledCapabilities(t *testing.T) {
 }
 
 func TestVerifyRequiresExactBaselineIdentity(t *testing.T) {
-	migration := Migrations()[0]
-	revisions := map[int64]platformpostgres.SchemaRevision{
-		BaselineRevision:   {Revision: BaselineRevision, MigrationID: BaselineMigrationID, Checksum: Checksum()},
-		migration.Revision: {Revision: migration.Revision, MigrationID: migration.MigrationID, Checksum: migration.Checksum()},
+	migrations := Migrations()
+	revisions := map[int64]platformpostgres.SchemaRevision{BaselineRevision: {Revision: BaselineRevision, MigrationID: BaselineMigrationID, Checksum: Checksum()}}
+	for _, migration := range migrations {
+		revisions[migration.Revision] = platformpostgres.SchemaRevision{Revision: migration.Revision, MigrationID: migration.MigrationID, Checksum: migration.Checksum()}
 	}
 	if err := Verify(context.Background(), revisionReader{revisions: revisions}); err != nil {
 		t.Fatalf("Verify() error = %v", err)
@@ -52,6 +52,7 @@ func TestVerifyRequiresExactBaselineIdentity(t *testing.T) {
 	for key, value := range revisions {
 		bad[key] = value
 	}
+	migration := migrations[0]
 	value := bad[migration.Revision]
 	value.Checksum = strings.Repeat("f", 64)
 	bad[migration.Revision] = value

--- a/internal/app/route_inventory_test.go
+++ b/internal/app/route_inventory_test.go
@@ -84,7 +84,7 @@ func TestRouteInventory(t *testing.T) {
 		rows = append(rows, fmt.Sprintf("%s|%s|%s|%s", key, contract.owner, contract.access, contract.privilege))
 	}
 	sort.Strings(rows)
-	const expectedRouteContractDigest = "83cbbbf01f349945c6acfd81bd957ff847b1a1a62cd8b4e0c7878189713e9d61"
+	const expectedRouteContractDigest = "3c766379e08695e9eede4e06482422d8fafcb00b54860b63105474a4ded41a66"
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(rows, "\n"))))
 	if digest != expectedRouteContractDigest {
 		t.Fatalf("route ownership/auth contract changed: got digest %s\n%s", digest, strings.Join(rows, "\n"))

--- a/internal/app/semantic_attribute_api_conformance_test.go
+++ b/internal/app/semantic_attribute_api_conformance_test.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"testing"
+
+	accessgen "github.com/flidai/leapview/internal/access/api/gen"
+)
+
+var semanticAttributeAuthenticatedOperations = []string{
+	"listSemanticAttributeDefinitions",
+	"registerSemanticAttribute",
+	"getSemanticAttributeDefinition",
+	"updateSemanticAttributeMetadata",
+	"disableSemanticAttribute",
+	"restoreSemanticAttribute",
+	"listPrincipalSemanticAttributeAssignments",
+	"upsertPrincipalSemanticAttributeAssignment",
+	"removePrincipalSemanticAttributeAssignment",
+	"listGroupSemanticAttributeAssignments",
+	"upsertGroupSemanticAttributeAssignment",
+	"removeGroupSemanticAttributeAssignment",
+	"listSemanticAttributeClaimMappings",
+	"upsertSemanticAttributeClaimMapping",
+	"removeSemanticAttributeClaimMapping",
+	"previewSemanticAttributeImpact",
+}
+
+func TestSemanticAttributeAPIGenOperationContracts(t *testing.T) {
+	contracts := accessgen.GetAPIGenOperationContracts()
+	for _, operationID := range semanticAttributeAuthenticatedOperations {
+		t.Run(operationID, func(t *testing.T) {
+			contract, ok := contracts[operationID]
+			if !ok {
+				t.Fatalf("Access generated operations missing %q", operationID)
+			}
+			authz, ok := contract.Extensions["x-authz"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s missing generated x-authz extension: %#v", operationID, contract.Extensions["x-authz"])
+			}
+			if got := authz["mode"]; got != "authenticated" {
+				t.Fatalf("%s x-authz mode = %#v, want authenticated", operationID, got)
+			}
+			if got := contract.Extensions["x-leapview-object-scope"]; got != "platform" {
+				t.Fatalf("%s object scope = %#v, want platform", operationID, got)
+			}
+		})
+	}
+}

--- a/internal/app/semantic_attribute_audit_conformance_test.go
+++ b/internal/app/semantic_attribute_audit_conformance_test.go
@@ -1,0 +1,122 @@
+package app
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/Yacobolo/toolbelt/apigen/runtime/command"
+	"github.com/flidai/leapview/internal/access"
+	accessgen "github.com/flidai/leapview/internal/access/api/gen"
+)
+
+// These are the semantic commands whose state transitions are implemented by
+// the access repository. The repository owns the durable event; the generated
+// API contract declares the same canonical action for each operation family.
+func TestSemanticAttributeAuditContractsMatchDurableActions(t *testing.T) {
+	type contractExpectation struct {
+		action string
+		fields []string
+	}
+	expected := map[string]contractExpectation{
+		"registerSemanticAttribute": {
+			action: access.SemanticAttributeAuditActionRegister,
+			fields: []string{"profile", "type", "shape", "definitionVersion", "registryRevision", "registryDigest", "ownerKind", "ownerId", "lifecycleState"},
+		},
+		"updateSemanticAttributeMetadata": {
+			action: access.SemanticAttributeAuditActionMetadataUpdate,
+			fields: []string{"profile", "type", "shape", "definitionVersion", "registryRevision", "registryDigest", "ownerKind", "ownerId", "lifecycleState"},
+		},
+		"disableSemanticAttribute": {
+			action: access.SemanticAttributeAuditActionDisable,
+			fields: []string{"profile", "type", "shape", "definitionVersion", "registryRevision", "registryDigest", "ownerKind", "ownerId", "lifecycleState"},
+		},
+		"restoreSemanticAttribute": {
+			action: access.SemanticAttributeAuditActionEnable,
+			fields: []string{"profile", "type", "shape", "definitionVersion", "registryRevision", "registryDigest", "ownerKind", "ownerId", "lifecycleState"},
+		},
+		"upsertPrincipalSemanticAttributeAssignment": {
+			action: access.SemanticAttributeAuditActionAssignmentSet,
+			fields: []string{"definitionId", "definitionName", "subjectKind", "subjectId", "definitionVersion", "assignmentVersion", "controlRevision", "valueCount", "tombstoned", "controlDigest"},
+		},
+		"removePrincipalSemanticAttributeAssignment": {
+			action: access.SemanticAttributeAuditActionAssignmentTombstone,
+			fields: []string{"definitionId", "definitionName", "subjectKind", "subjectId", "definitionVersion", "assignmentVersion", "controlRevision", "valueCount", "tombstoned", "controlDigest"},
+		},
+		"upsertGroupSemanticAttributeAssignment": {
+			action: access.SemanticAttributeAuditActionAssignmentSet,
+			fields: []string{"definitionId", "definitionName", "subjectKind", "subjectId", "definitionVersion", "assignmentVersion", "controlRevision", "valueCount", "tombstoned", "controlDigest"},
+		},
+		"removeGroupSemanticAttributeAssignment": {
+			action: access.SemanticAttributeAuditActionAssignmentTombstone,
+			fields: []string{"definitionId", "definitionName", "subjectKind", "subjectId", "definitionVersion", "assignmentVersion", "controlRevision", "valueCount", "tombstoned", "controlDigest"},
+		},
+		"upsertSemanticAttributeClaimMapping": {
+			action: access.SemanticAttributeAuditActionClaimMappingSet,
+			fields: []string{"sourceKind", "provider", "issuer", "audience", "claim", "definitionId", "definitionName", "definitionVersion", "mappingVersion", "controlRevision", "tombstoned", "controlDigest"},
+		},
+		"removeSemanticAttributeClaimMapping": {
+			action: access.SemanticAttributeAuditActionClaimMappingTombstone,
+			fields: []string{"sourceKind", "provider", "issuer", "audience", "claim", "definitionId", "definitionName", "definitionVersion", "mappingVersion", "controlRevision", "tombstoned", "controlDigest"},
+		},
+	}
+	contracts := accessgen.GetAPIGenOperationContracts()
+	for operationID, want := range expected {
+		t.Run(operationID, func(t *testing.T) {
+			generated, ok := contracts[operationID]
+			if !ok || generated.Command == nil {
+				t.Fatalf("generated command contract = %#v", generated)
+			}
+			if got := generated.Command.Audit.SuccessAction; got != want.action {
+				t.Fatalf("declared audit action = %q, durable action = %q", got, want.action)
+			}
+			if generated.Command.Audit.Guarantee != "transactional" {
+				t.Fatalf("audit guarantee = %q, want transactional", generated.Command.Audit.Guarantee)
+			}
+			if generated.Command.Audit.Payload == nil {
+				t.Fatal("generated audit payload contract is missing")
+			}
+			generatedFields := make([]string, len(generated.Command.Audit.Payload.Fields))
+			for index, field := range generated.Command.Audit.Payload.Fields {
+				generatedFields[index] = field.Name
+				name := strings.ToLower(field.Name)
+				if name == "values" || name == "canonicalvalues" || name == "valuedigest" {
+					t.Errorf("audit payload field %q could expose attribute values or value digests", field.Name)
+				}
+			}
+			sort.Strings(generatedFields)
+			wantFields := append([]string(nil), want.fields...)
+			sort.Strings(wantFields)
+			if !reflect.DeepEqual(generatedFields, wantFields) {
+				t.Fatalf("declared audit payload fields = %#v, durable fields = %#v", generatedFields, wantFields)
+			}
+
+			runtimeContract, ok := accessgen.GetAPIGenCommandRuntimeContract(operationID)
+			if !ok {
+				t.Fatal("generated runtime command contract is missing")
+			}
+			if err := runtimeContract.Validate(); err != nil {
+				t.Fatalf("runtime command contract is invalid: %v", err)
+			}
+			if runtimeContract.AuditAction != want.action || runtimeContract.Guarantee != command.GuaranteeTransactional {
+				t.Fatalf("runtime audit contract = action %q, guarantee %q; want %q, transactional", runtimeContract.AuditAction, runtimeContract.Guarantee, want.action)
+			}
+			if runtimeContract.AuditPayload == nil {
+				t.Fatal("runtime audit payload contract is missing")
+			}
+			runtimeFields := make([]string, 0, len(runtimeContract.AuditPayload.Fields))
+			for _, field := range runtimeContract.AuditPayload.Fields {
+				runtimeFields = append(runtimeFields, field.Name)
+				name := strings.ToLower(field.Name)
+				if name == "values" || name == "canonicalvalues" || name == "valuedigest" {
+					t.Errorf("audit payload field %q could expose attribute values or value digests", field.Name)
+				}
+			}
+			sort.Strings(runtimeFields)
+			if !reflect.DeepEqual(runtimeFields, wantFields) {
+				t.Fatalf("runtime audit payload fields = %#v, durable fields = %#v", runtimeFields, wantFields)
+			}
+		})
+	}
+}

--- a/internal/platform/architecture/semantic_attribute_authority_test.go
+++ b/internal/platform/architecture/semantic_attribute_authority_test.go
@@ -1,0 +1,122 @@
+package architecture
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FAI-637 must not accidentally turn the legacy JSON metadata columns or
+// authored YAML into the typed semantic-attribute authority. The guard is
+// intentionally structural: it leaves those columns available to their
+// existing SCIM/access callers while requiring typed state to enter through
+// the access-owned registry/control migrations and repositories.
+func TestSemanticAttributeAuthorityIsTypedAndControlPlaneOwned(t *testing.T) {
+	root := repoRoot(t)
+	baseline := readArchitectureFixture(t, root, "internal/access/postgres/schema.sql")
+	for _, declaration := range []string{
+		"CREATE TABLE access.principal",
+		"CREATE TABLE access.access_group",
+		"attributes jsonb NOT NULL",
+	} {
+		if !strings.Contains(baseline, declaration) {
+			t.Fatalf("baseline schema lost legacy metadata declaration %q", declaration)
+		}
+	}
+
+	typedFiles := []string{
+		"internal/access/postgres/migrations/002_typed_attribute_registry.sql",
+		"internal/access/postgres/migrations/003_semantic_attribute_control.sql",
+		"internal/access/postgres/queries/semantic_attribute_control.sql",
+		"internal/access/postgres/semantic_attributes.go",
+		"internal/access/postgres/semantic_attribute_control.go",
+		"internal/access/postgres/semantic_attribute_assignments.go",
+		"internal/access/postgres/semantic_attribute_claims.go",
+	}
+	for _, relative := range typedFiles {
+		body := readArchitectureFixture(t, root, relative)
+		lower := strings.ToLower(body)
+		for _, legacy := range []string{"principal.attributes", "access_group.attributes", "attributes jsonb"} {
+			if strings.Contains(lower, legacy) {
+				t.Errorf("typed semantic authority %s references legacy JSON metadata %q", relative, legacy)
+			}
+		}
+	}
+
+	for relative, tables := range map[string][]string{
+		"internal/access/postgres/migrations/002_typed_attribute_registry.sql": {
+			"access.semantic_attribute_registry",
+			"access.semantic_attribute_definition",
+		},
+		"internal/access/postgres/migrations/003_semantic_attribute_control.sql": {
+			"access.semantic_attribute_control_state",
+			"access.semantic_attribute_assignment",
+			"access.semantic_attribute_claim_mapping",
+		},
+	} {
+		body := readArchitectureFixture(t, root, relative)
+		for _, table := range tables {
+			if !strings.Contains(body, table) {
+				t.Errorf("typed migration %s does not declare/reference %s", relative, table)
+			}
+		}
+	}
+
+	for _, directory := range []string{"dashboards", "config", "evaluation"} {
+		path := filepath.Join(root, directory)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+		err := filepath.WalkDir(path, func(filePath string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+				return nil
+			}
+			extension := strings.ToLower(filepath.Ext(filePath))
+			if extension != ".yaml" && extension != ".yml" {
+				return nil
+			}
+			body, readErr := os.ReadFile(filePath)
+			if readErr != nil {
+				return readErr
+			}
+			for lineNumber, line := range strings.Split(string(body), "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "#") {
+					continue
+				}
+				for _, forbidden := range []string{
+					"semanticAttributeDefinitions:",
+					"semanticAttributeAssignments:",
+					"semanticAttributeClaimMappings:",
+					"trustedClaimMappings:",
+					"attributeValues:",
+				} {
+					if strings.HasPrefix(trimmed, forbidden) || strings.HasPrefix(trimmed, "- "+forbidden) {
+						relative, relErr := filepath.Rel(root, filePath)
+						if relErr != nil {
+							return relErr
+						}
+						t.Errorf("%s:%d authors typed semantic control state with %s", filepath.ToSlash(relative), lineNumber+1, forbidden)
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("scan %s for typed semantic control YAML: %v", directory, err)
+		}
+	}
+}
+
+func readArchitectureFixture(t *testing.T, root, relative string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(relative)))
+	if err != nil {
+		t.Fatalf("read %s: %v", relative, err)
+	}
+	return string(body)
+}

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -163,6 +163,7 @@ sql:
     schema:
       - "internal/access/postgres/schema.sql"
       - "internal/access/postgres/migrations/002_typed_attribute_registry.sql"
+      - "internal/access/postgres/migrations/003_semantic_attribute_control.sql"
     gen:
       go:
         package: "db"


### PR DESCRIPTION
## Problem

ADR-0017 had a typed PostgreSQL attribute registry from FAI-636, but no administrative control plane for governed ownership, mutation authorization, lifecycle, assignments, or trusted claim mappings. Review of the initial FAI-637 implementation also found five correctness gaps that had to be closed before merge.

## Root cause

The registry intentionally established type and identity authority first. Administrative state, assignment authority, exact claim mapping, lifecycle fencing, and API contracts were deferred to FAI-637. The first control-plane slice did not yet recompute the exact effective-resolution control projection, used session-formatted PostgreSQL timestamps, paged before owner filtering, and duplicated trusted-source limits; its new access branches also reduced package coverage below the existing floor.

## Solution

### Control-plane implementation

- Adds PostgreSQL control state, direct and group assignments, exact trusted-claim mappings, tombstones, ACLs, triggers, and sqlc repositories on top of the FAI-636 registry.
- Reuses `semanticvalue` canonicalization, PostgreSQL authority and pool infrastructure, caller-owned transactions, registry identity/version/digest fencing, and immutable audit patterns.
- Adds the generated Access API surface for definition, lifecycle, assignment, claim-mapping, and impact-preview operations.

### Ownership and authorization model

- Definitions have explicit instance, group, or principal ownership metadata with owner existence checks.
- Administrative API operations require durable platform-admin authorization and honor credential attenuation.
- Trusted-claim envelopes are verifier-gated and bound to exact source kind, provider, issuer, audience, claim, verification fingerprint, time window, and principal subject.
- Revoked groups and revoked memberships cannot contribute effective assignments.

### Lifecycle, versioning, compatibility, and audit

- Definitions use explicit enabled/disabled lifecycle transitions; assignments and mappings use set/tombstone mutations rather than destructive deletion.
- Illegal transitions and stale expected versions fail closed. Immutable name/type/shape/profile/ID compatibility requires creating a new attribute identity.
- Mutations double-fence definition version and control revision, then persist the state change and immutable audit event in the same caller-owned PostgreSQL transaction.
- Audit metadata records governed identities, versions, revisions, lifecycle state, and digests without exposing semantic values or value digests.

### Blocking review findings resolved

1. **Control digest validation:** effective resolution now consumes the exact stable assignments and mappings returned by `SemanticAttributeControl()`. That projection recomputes the digest, validates it before use, and is checked again after resolution. An out-of-band row-corruption regression proves the resolver returns `ErrSemanticAttributeControlCorrupt`.
2. **Canonical PostgreSQL timestamps:** control queries transport timestamps as epoch microseconds. Digest input uses microseconds, and API-facing assignment, mapping, and control-state timestamps are emitted as RFC 3339 UTC. A PostgreSQL regression changes `TimeZone` and `DateStyle`, then checks stable digest, canonical UTC output, and preserved microsecond precision.
3. **Coverage budget:** dedicated control-contract tests cover `TrustedClaimSourceKind.Valid`, `ValidateSemanticAttributeSubject`, and previously uncovered canonicalization branches. `internal/access` is now 76.9% against the unchanged 75.8% floor.
4. **Filter before pagination:** `ownerKind`, `(name, definition_id)` keyset cursor, deterministic ordering, and page limit now execute in PostgreSQL over the complete filtered result set. Handler and repository regressions traverse all 205 matching rows in a 250-row data set across multiple pages.
5. **Trusted identity limits:** one shared validator contract now enforces provider 128 bytes, issuer 1024 bytes, audience 512 bytes, and subject 1024 bytes in verified envelopes, mapping admission/filtering, resolver matching, and the database issuer constraint. Exact-boundary and over-limit regressions cover every path.

## Tests added or updated

- Dedicated access control-contract coverage tests.
- Trusted-claims exact-boundary and over-limit tests.
- Handler filtered keyset pagination and invalid-token tests.
- PostgreSQL >200-row filtered pagination integration test.
- PostgreSQL control corruption, non-default session timestamp, microsecond precision, and shared identity-limit tests.

## Verification performed

- `go test ./internal/access/... -count=1`: passed (container-backed bodies skip in optional mode).
- Focused changed packages with isolated caches: passed; `internal/access` 76.9%, `trustedclaims` 82.9%.
- `task quality:critical:coverage`: passed; all existing floors unchanged.
- `task quality:budget:check`: passed; no budget increases.
- `task generated:check`: passed.
- Architecture tests passed through the critical coverage gate.
- `git diff --check`: passed.
- The two unrelated Playwright tests that timed out under parallel host load both passed in isolation.

## Remaining limitations

- The required PostgreSQL 18/Testcontainers run cannot start locally because access to `/var/run/docker.sock` is denied. Those three new container-backed regressions are present but are not claimed as locally passed.
- A complete local `task ci` could not be qualified on this host: the normal tmpfs paths exhausted their quota; using host-backed `TMPDIR` violates the security-source test's expected temporary-root policy; and the shared Go cache was concurrently removed during one run. GitHub-hosted CI is the authoritative clean-host gate; all 13 checks passed on the new head.
- Provider adapters, principal hydration, consumer admission, planner propagation, and cache invalidation remain later ADR-0017 work. VAL-11 remains Partial.

Linear: https://linear.app/flid/issue/FAI-637/add-attribute-administration-assignments-and-trusted-claim-mappings

