### PR TITLE
feat(dbt): add warehouse-boundary integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,9 @@ bin
 coverage.out
 node_modules
 **/node_modules
+examples/dbt-warehouse-boundary/dbt/logs
+examples/dbt-warehouse-boundary/dbt/target
+examples/dbt-warehouse-boundary/published
 
 .env
 .env.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,45 @@ jobs:
             spatial-tile-cache.txt
           retention-days: 30
 
+  dbt-warehouse-boundary-validation:
+    name: dbt physical contract (PR)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.position == github.event.pull_request.stack.size
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up pinned Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13.14"
+          cache: pip
+          cache-dependency-path: examples/dbt-warehouse-boundary/dbt/requirements.txt
+
+      - name: Install the pinned dbt toolchain
+        run: python -m pip install --disable-pip-version-check --requirement examples/dbt-warehouse-boundary/dbt/requirements.txt
+
+      - name: Set up the cached LeapView CI toolchain
+        uses: ./.github/actions/setup-ci
+        with:
+          browser: "false"
+
+      - name: Run real dbt Parquet through the headless LeapView lifecycle
+        run: DBT_BIN="$(command -v dbt)" task dbt:warehouse:qualify
+
   ci-gate:
     name: CI gate
     if: ${{ always() }}
-    needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, spatial-tile-benchmarks]
+    needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, spatial-tile-benchmarks, dbt-warehouse-boundary-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -210,8 +245,9 @@ jobs:
           GO_APPLICATION_RESULT: ${{ needs.go-application-validation.result }}
           FRONTEND_RESULT: ${{ needs.frontend-validation.result }}
           SPATIAL_BENCHMARK_RESULT: ${{ needs.spatial-tile-benchmarks.result }}
+          DBT_WAREHOUSE_RESULT: ${{ needs.dbt-warehouse-boundary-validation.result }}
         run: |
-          if [[ "${APIGEN_RESULT}" = skipped && "${GO_PACKAGES_RESULT}" = skipped && "${GO_APPLICATION_RESULT}" = skipped && "${FRONTEND_RESULT}" = skipped && "${SPATIAL_BENCHMARK_RESULT}" = skipped ]]; then
+          if [[ "${APIGEN_RESULT}" = skipped && "${GO_PACKAGES_RESULT}" = skipped && "${GO_APPLICATION_RESULT}" = skipped && "${FRONTEND_RESULT}" = skipped && "${SPATIAL_BENCHMARK_RESULT}" = skipped && "${DBT_WAREHOUSE_RESULT}" = skipped ]]; then
             printf '%s\n' 'Validation is deferred to the top of this stack.' >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
@@ -233,5 +269,9 @@ jobs:
           }
           test "${SPATIAL_BENCHMARK_RESULT}" = success || {
             printf 'Spatial tile benchmarks: %s\n' "${SPATIAL_BENCHMARK_RESULT}" >&2
+            exit 1
+          }
+          test "${DBT_WAREHOUSE_RESULT}" = success || {
+            printf 'dbt warehouse-boundary validation: %s\n' "${DBT_WAREHOUSE_RESULT}" >&2
             exit 1
           }

--- a/.github/workflows/dbt-warehouse-boundary-reference.yml
+++ b/.github/workflows/dbt-warehouse-boundary-reference.yml
@@ -1,0 +1,168 @@
+name: dbt warehouse boundary reference
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: dbt-warehouse-boundary-production
+  cancel-in-progress: false
+
+env:
+  AZURE_CORE_OUTPUT: none
+  AZURE_STORAGE_ACCOUNT: ${{ vars.DBT_PRODUCER_STORAGE_ACCOUNT }}
+  AZURE_SOURCE_CONTAINER: ${{ vars.DBT_PRODUCER_SOURCE_CONTAINER }}
+  AZURE_PUBLICATION_CONTAINER: ${{ vars.DBT_PRODUCER_PUBLICATION_CONTAINER }}
+  LEAPVIEW_TARGET: ${{ vars.LEAPVIEW_TARGET }}
+  LEAPVIEW_WORKLOAD_PROJECT: ${{ vars.LEAPVIEW_PROJECT_ID }}
+
+jobs:
+  publish-and-activate:
+    name: Publish dbt marts and activate LeapView
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: dbt-warehouse-boundary-production
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up pinned Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13.14"
+          cache: pip
+          cache-dependency-path: examples/dbt-warehouse-boundary/dbt/requirements.txt
+
+      - name: Install pinned dbt Core
+        run: python -m pip install --disable-pip-version-check 'dbt-core==1.11.14'
+
+      - name: Install pinned dbt-duckdb
+        run: python -m pip install --disable-pip-version-check 'dbt-duckdb==1.11.0'
+
+      - name: Authenticate the producer with Azure OIDC
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
+        with:
+          client-id: ${{ vars.DBT_PRODUCER_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Read the bounded producer inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          seed_dir="examples/dbt-warehouse-boundary/dbt/seeds"
+          for input in raw_customers.csv raw_orders.csv; do
+            az storage blob download \
+              --auth-mode login \
+              --account-name "$AZURE_STORAGE_ACCOUNT" \
+              --container-name "$AZURE_SOURCE_CONTAINER" \
+              --name "dbt-warehouse-boundary/$input" \
+              --file "$seed_dir/$input" \
+              --overwrite true \
+              --no-progress \
+              --output none
+          done
+
+      - name: Run dbt build and verify physical Parquet
+        run: DBT_BIN="$(command -v dbt)" ./scripts/dbt-warehouse-boundary.sh build
+
+      - name: Select a new immutable publication prefix
+        shell: bash
+        run: |
+          set -euo pipefail
+          prefix="dbt-warehouse-boundary/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_SHA}"
+          existing="$(az storage blob list \
+            --auth-mode login \
+            --account-name "$AZURE_STORAGE_ACCOUNT" \
+            --container-name "$AZURE_PUBLICATION_CONTAINER" \
+            --prefix "$prefix/" \
+            --query 'length(@)' \
+            --output tsv)"
+          test "$existing" = 0 || {
+            echo "immutable publication prefix already exists" >&2
+            exit 1
+          }
+          printf 'PUBLICATION_PREFIX=%s\n' "$prefix" >> "$GITHUB_ENV"
+
+      - name: Upload the complete selected mart set
+        shell: bash
+        run: |
+          set -euo pipefail
+          for mart in dim_customers.parquet fct_orders.parquet; do
+            az storage blob upload \
+              --auth-mode login \
+              --account-name "$AZURE_STORAGE_ACCOUNT" \
+              --container-name "$AZURE_PUBLICATION_CONTAINER" \
+              --name "$PUBLICATION_PREFIX/$mart" \
+              --file "examples/dbt-warehouse-boundary/published/$mart" \
+              --overwrite false \
+              --no-progress \
+              --output none
+          done
+
+      - name: Verify the exact published mart set
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="$(printf '%s\n' \
+            "$PUBLICATION_PREFIX/dim_customers.parquet" \
+            "$PUBLICATION_PREFIX/fct_orders.parquet")"
+          actual="$(az storage blob list \
+            --auth-mode login \
+            --account-name "$AZURE_STORAGE_ACCOUNT" \
+            --container-name "$AZURE_PUBLICATION_CONTAINER" \
+            --prefix "$PUBLICATION_PREFIX/" \
+            --query '[].name' \
+            --output tsv | LC_ALL=C sort)"
+          test "$actual" = "$expected" || {
+            echo "published prefix does not contain the exact expected mart set" >&2
+            exit 1
+          }
+
+      - name: End the producer credential session
+        run: az logout
+
+      - name: Render the ordinary Azure-backed LeapView bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/dbt-warehouse-boundary-leapview"
+          cp -R examples/dbt-warehouse-boundary/leapview "$bundle"
+          sed -i 's/type: managed/type: azure_blob/' "$bundle/connections/warehouse.yaml"
+          sed -i "s|path: dim_customers.parquet|path: az://$AZURE_PUBLICATION_CONTAINER/$PUBLICATION_PREFIX/dim_customers.parquet|" "$bundle/sources/dim_customers.yaml"
+          sed -i "s|path: fct_orders.parquet|path: az://$AZURE_PUBLICATION_CONTAINER/$PUBLICATION_PREFIX/fct_orders.parquet|" "$bundle/sources/fct_orders.yaml"
+          printf 'LEAPVIEW_PROJECT_FILE=%s/leapview.yaml\n' "$bundle" >> "$GITHUB_ENV"
+
+      - name: Set up the cached LeapView CI toolchain
+        uses: ./.github/actions/setup-ci
+        with:
+          browser: "false"
+
+      - name: Build the ordinary LeapView CLI
+        run: |
+          task ci:prepare
+          go build -o "$RUNNER_TEMP/leapview" ./cmd/leapview
+
+      - name: Qualify the physical publication through LeapView
+        shell: bash
+        env:
+          LEAPVIEW_WORKLOAD_CLIENT_ID: ${{ secrets.LEAPVIEW_WORKLOAD_CLIENT_ID }}
+          LEAPVIEW_WORKLOAD_CLIENT_SECRET: ${{ secrets.LEAPVIEW_WORKLOAD_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          candidate_key="github:dbt-warehouse:${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          candidate_json="$("$RUNNER_TEMP/leapview" dev --once --no-browser --format json \
+            --project "$LEAPVIEW_PROJECT_FILE" \
+            --target "$LEAPVIEW_TARGET" \
+            --candidate-key "$candidate_key" \
+            --source-repository "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --source-ref "$GITHUB_REF" \
+            --source-revision "$GITHUB_SHA")"
+          candidate_id="$(jq -er '.candidateId | select(type == "string" and test("^cand_[A-Za-z0-9_-]+$"))' <<<"$candidate_json")"
+          "$RUNNER_TEMP/leapview" publish "$candidate_id" --format json

--- a/.github/workflows/dbt-warehouse-boundary-reference.yml
+++ b/.github/workflows/dbt-warehouse-boundary-reference.yml
@@ -5,26 +5,33 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: dbt-warehouse-boundary-production
   cancel-in-progress: false
 
-env:
-  AZURE_CORE_OUTPUT: none
-  AZURE_STORAGE_ACCOUNT: ${{ vars.DBT_PRODUCER_STORAGE_ACCOUNT }}
-  AZURE_SOURCE_CONTAINER: ${{ vars.DBT_PRODUCER_SOURCE_CONTAINER }}
-  AZURE_PUBLICATION_CONTAINER: ${{ vars.DBT_PRODUCER_PUBLICATION_CONTAINER }}
-  LEAPVIEW_TARGET: ${{ vars.LEAPVIEW_TARGET }}
-  LEAPVIEW_WORKLOAD_PROJECT: ${{ vars.LEAPVIEW_PROJECT_ID }}
-
 jobs:
-  publish-and-activate:
-    name: Publish dbt marts and activate LeapView
+  publish-dbt:
+    name: Publish dbt marts
+    # Production credentials and OIDC are available only for a manual run from
+    # this repository's protected default branch. Keep this guard in the
+    # copyable reference so a copied workflow fails closed by default.
+    if: >-
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      github.ref_protected == true
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     environment: dbt-warehouse-boundary-production
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      publication_prefix: ${{ steps.select-prefix.outputs.publication_prefix }}
+    env:
+      AZURE_CORE_OUTPUT: none
+      AZURE_STORAGE_ACCOUNT: ${{ vars.DBT_PRODUCER_STORAGE_ACCOUNT }}
+      AZURE_SOURCE_CONTAINER: ${{ vars.DBT_PRODUCER_SOURCE_CONTAINER }}
+      AZURE_PUBLICATION_CONTAINER: ${{ vars.DBT_PRODUCER_PUBLICATION_CONTAINER }}
 
     steps:
       - name: Check out repository
@@ -73,10 +80,11 @@ jobs:
         run: DBT_BIN="$(command -v dbt)" ./scripts/dbt-warehouse-boundary.sh build
 
       - name: Select a new immutable publication prefix
+        id: select-prefix
         shell: bash
         run: |
           set -euo pipefail
-          prefix="dbt-warehouse-boundary/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_SHA}"
+          prefix="dbt-warehouse-boundary/${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_SHA}"
           existing="$(az storage blob list \
             --auth-mode login \
             --account-name "$AZURE_STORAGE_ACCOUNT" \
@@ -89,6 +97,7 @@ jobs:
             exit 1
           }
           printf 'PUBLICATION_PREFIX=%s\n' "$prefix" >> "$GITHUB_ENV"
+          printf 'publication_prefix=%s\n' "$prefix" >> "$GITHUB_OUTPUT"
 
       - name: Upload the complete selected mart set
         shell: bash
@@ -128,6 +137,32 @@ jobs:
       - name: End the producer credential session
         run: az logout
 
+  activate-leapview:
+    name: Activate LeapView
+    # Keep the activation job behind the same trusted-ref guard. It receives
+    # only the producer's non-secret publication output, never its OIDC token.
+    if: >-
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      github.ref_protected == true
+    needs: [publish-dbt]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: dbt-warehouse-boundary-production
+    permissions:
+      contents: read
+    env:
+      AZURE_CORE_OUTPUT: none
+      AZURE_PUBLICATION_CONTAINER: ${{ vars.DBT_PRODUCER_PUBLICATION_CONTAINER }}
+      LEAPVIEW_TARGET: ${{ vars.LEAPVIEW_TARGET }}
+      LEAPVIEW_WORKLOAD_PROJECT: ${{ vars.LEAPVIEW_PROJECT_ID }}
+      PUBLICATION_PREFIX: ${{ needs.publish-dbt.outputs.publication_prefix }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
       - name: Render the ordinary Azure-backed LeapView bundle
         shell: bash
         run: |
@@ -138,6 +173,24 @@ jobs:
           sed -i "s|path: dim_customers.parquet|path: az://$AZURE_PUBLICATION_CONTAINER/$PUBLICATION_PREFIX/dim_customers.parquet|" "$bundle/sources/dim_customers.yaml"
           sed -i "s|path: fct_orders.parquet|path: az://$AZURE_PUBLICATION_CONTAINER/$PUBLICATION_PREFIX/fct_orders.parquet|" "$bundle/sources/fct_orders.yaml"
           printf 'LEAPVIEW_PROJECT_FILE=%s/leapview.yaml\n' "$bundle" >> "$GITHUB_ENV"
+
+      - name: Assert authored current-profile Project identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          project_id="$(awk '
+            $0 == "kind: Project" { in_project = 1; next }
+            in_project && $0 == "metadata:" { in_metadata = 1; next }
+            in_project && in_metadata && $0 ~ /^  id:[[:space:]]*/ {
+              sub(/^  id:[[:space:]]*/, "")
+              print
+              exit
+            }
+          ' "$LEAPVIEW_PROJECT_FILE")"
+          test -n "$project_id" && test "$project_id" = "$LEAPVIEW_WORKLOAD_PROJECT" || {
+            echo "authored current-profile Project id does not match LEAPVIEW_WORKLOAD_PROJECT" >&2
+            exit 1
+          }
 
       - name: Set up the cached LeapView CI toolchain
         uses: ./.github/actions/setup-ci

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 .leapview/
 .task/
 .tmp/
+examples/dbt-warehouse-boundary/published/
+examples/dbt-warehouse-boundary/dbt/target/
+examples/dbt-warehouse-boundary/dbt/dbt_packages/
+examples/dbt-warehouse-boundary/dbt/logs/
+examples/dbt-warehouse-boundary/dbt/.user.yml
 .venv/
 node_modules/
 desktop/dist/

--- a/.security/coverage.yaml
+++ b/.security/coverage.yaml
@@ -126,6 +126,10 @@ surfaces:
     kind: github-actions
     updater: {ecosystem: github-actions, directory: /}
     scanners: [trivy, action-pin-policy]
+  - path: .github/workflows/dbt-warehouse-boundary-reference.yml
+    kind: github-actions
+    updater: {ecosystem: github-actions, directory: /}
+    scanners: [trivy, action-pin-policy]
   - path: .github/workflows/demo-deploy.yml
     kind: github-actions
     updater: {ecosystem: github-actions, directory: /}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,40 @@ tasks:
       - task: bootstrap:movielens
       - LEAPVIEW_DEV_RESTART=1 LEAPVIEW_DEV_READY_ATTEMPTS=1800 ./scripts/dev-server.sh start dashboards/experiments/movielens/leapview.yaml movielens .data/movielens
 
+  dbt:warehouse:build:
+    desc: Build and verify the pinned dbt-duckdb warehouse-boundary Parquet publication
+    sources:
+      - examples/dbt-warehouse-boundary/dbt/**/*.sql
+      - examples/dbt-warehouse-boundary/dbt/**/*.yml
+      - examples/dbt-warehouse-boundary/dbt/**/*.csv
+      - examples/dbt-warehouse-boundary/dbt/requirements.txt
+      - scripts/dbt-warehouse-boundary.sh
+    generates:
+      - examples/dbt-warehouse-boundary/published/dim_customers.parquet
+      - examples/dbt-warehouse-boundary/published/fct_orders.parquet
+    cmds:
+      - ./scripts/dbt-warehouse-boundary.sh build
+
+  dbt:warehouse:qualify:
+    desc: Run the physical dbt Parquet publication through the ordinary headless LeapView candidate lifecycle
+    deps:
+      - generate
+      - build
+      - map-assets:install
+      - dbt:warehouse:build
+    cmds:
+      - ./scripts/dev-server.sh once examples/dbt-warehouse-boundary/leapview/leapview.yaml warehouse examples/dbt-warehouse-boundary/published
+
+  dbt:warehouse:
+    desc: Build the dbt-duckdb showcase and start LeapView through the managed development flow
+    deps:
+      - generate
+      - build
+      - map-assets:install
+      - dbt:warehouse:build
+    cmds:
+      - ./scripts/dev-server.sh start examples/dbt-warehouse-boundary/leapview/leapview.yaml warehouse examples/dbt-warehouse-boundary/published
+
   bootstrap:
     desc: Download/sync Olist CSVs if missing
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,22 +37,20 @@ tasks:
 
   dbt:warehouse:qualify:
     desc: Run the physical dbt Parquet publication through the ordinary headless LeapView candidate lifecycle
-    deps:
-      - generate
-      - build
-      - map-assets:install
-      - dbt:warehouse:build
     cmds:
+      - task: generate
+      - task: build
+      - task: map-assets:install
+      - task: dbt:warehouse:build
       - ./scripts/dev-server.sh once examples/dbt-warehouse-boundary/leapview/leapview.yaml warehouse examples/dbt-warehouse-boundary/published
 
   dbt:warehouse:
     desc: Build the dbt-duckdb showcase and start LeapView through the managed development flow
-    deps:
-      - generate
-      - build
-      - map-assets:install
-      - dbt:warehouse:build
     cmds:
+      - task: generate
+      - task: build
+      - task: map-assets:install
+      - task: dbt:warehouse:build
       - ./scripts/dev-server.sh start examples/dbt-warehouse-boundary/leapview/leapview.yaml warehouse examples/dbt-warehouse-boundary/published
 
   bootstrap:

--- a/adr/0019-integrate-dbt-at-the-warehouse-contract-boundary.md
+++ b/adr/0019-integrate-dbt-at-the-warehouse-contract-boundary.md
@@ -6,6 +6,9 @@ Decision date: 2026-09-03
 
 Implementation: pending
 
+Implementation evidence:
+[dbt warehouse-boundary conformance map](specifications/dbt-warehouse-boundary-conformance.md)
+
 Deciders: LeapView maintainers
 
 Supersedes: none

--- a/adr/specifications/dbt-warehouse-boundary-conformance.md
+++ b/adr/specifications/dbt-warehouse-boundary-conformance.md
@@ -1,0 +1,60 @@
+# dbt warehouse-boundary conformance map
+
+Status: partial; Project namespace prerequisite pending
+
+Last updated: 2026-09-04
+
+Governing decision:
+[ADR-0019](../0019-integrate-dbt-at-the-warehouse-contract-boundary.md)
+
+Prerequisite:
+[ADR-0018](../0018-retain-project-as-the-durable-deployment-namespace.md) and
+[Project namespace conformance](project-namespace-conformance.md)
+
+## Scope and implementation rule
+
+ADR-0019 is composition over the ordinary LeapView data-resource and delivery
+paths. It adds a maintained producer example, orchestration, physical contract
+CI, and evidence. It adds no dbt runtime kind, parser, scheduler, public CLI,
+publication service, release envelope, or compatibility algorithm.
+
+The profile remains partial while ADR-0018 is pending: current portable source
+still uses an authored `kind: Project` manifest. The example follows the
+currently implemented compiler contract and must migrate to Project-free
+discovery with ADR-0018. ADR-0019 must not be marked implemented before that
+prerequisite is satisfied.
+
+## Confirmation map
+
+| ADR-0019 confirmation | Maintained implementation evidence | Status or remaining item |
+| --- | --- | --- |
+| Ordinary Connection → Source → Model → SemanticModel → Dashboard graph serves dbt output | `examples/dbt-warehouse-boundary/`; compiler and runtime packages under `internal/project/compiler`, `internal/analytics/duckdb`, and `internal/dashboard/runtime` | Implemented; remove the root Project manifest when ADR-0018 BND-01/BND-02 lands. |
+| One local command builds dbt, external Parquet, and starts LeapView | `task dbt:warehouse`; `scripts/dbt-warehouse-boundary.sh`; `scripts/dev-server.sh` | Implemented. |
+| Explicit resources compile and serve without dbt artifacts or dbt in LeapView | Example LeapView YAML contains no artifact reference; `internal/platform/architecture/dbt_boundary_test.go` | Implemented. |
+| Production invokes LeapView only after successful build and complete publication | `.github/workflows/dbt-warehouse-boundary-reference.yml`; architecture workflow assertions | Implemented reference workflow; target credentials remain operator configuration. |
+| Ordinary versus coordinated consistency is honest | Producer-neutral fixture and [integration guide](../../docs/articles/integrate/dbt-warehouse-boundary.md) | Implemented without a marker protocol. |
+| Schema, type, grain, and checks reject while prior generation serves | `internal/analytics/gates/gates_test.go`; `internal/app/integration_minio_source_test.go`; producer-neutral fixture; `internal/runtimehost/lifecycle_test.go` | Implemented by ADR-0010 and existing runtimehost recovery. |
+| Stable field IDs and readable labels require no physical cosmetic transform | Example Models and `semantic-models/sales.yaml` | Implemented. |
+| Optional metadata import reconciles metadata and physical state | None | Deferred by decision; this conditional confirmation does not apply until an importer is proposed. |
+| Serving and refresh require no dbt executable, repository, artifacts, or credentials | Runtime module/image architecture assertion; dbt dependencies are isolated under `examples/` and CI | Implemented. |
+| Source read, serving write, and semantic policy boundaries remain distinct | Azure workflow, existing scoped Azure secret tests in `internal/analytics/duckdb/source_test.go`, and integration guide | Implemented as target/operator contract; live Azure authorization remains deployment-specific evidence. |
+| MetricFlow/dbt Semantic Layer definitions do not silently become LeapView definitions | No artifact parser or dbt semantic dependency exists; architecture assertion | Implemented by absence and explicit deferral. |
+| Every SemanticModel dataset resolves inside the same Project candidate/generation | ADR-0018 SEM-01/SEM-02 evidence in `project-namespace-conformance.md` | Blocked on full ADR-0018 conformance; current graph resolution remains Project-local. |
+
+## Existing capability composition
+
+| Boundary responsibility | Existing authority reused |
+| --- | --- |
+| Azure Blob and scoped DuckDB secret | connector registry and `internal/analytics/duckdb/source.go` |
+| Parquet discovery and materialization | typed Source path contracts and `internal/analytics/duckdb/materialize.go` |
+| Source schema/freshness and Model output/grain/checks | `internal/analytics/gates` (ADR-0010) |
+| Candidate construction and qualification | `internal/app/runtimefactory/delivery_runner.go` and `internal/analytics/candidatecatalog` |
+| Atomic activation, retained generations, rollback, leases, recovery | `internal/runtimehost`, `internal/deployment`, and `internal/servingstate` |
+| Local non-interactive orchestration | `leapview dev --once --no-browser` via `scripts/dev-server.sh` |
+| Project/environment identity and target bindings | existing deployment and connection-binding contracts; final Project-free source semantics pending ADR-0018 |
+
+Physical Parquet is the CI contract evidence. dbt's manifest and run-results
+files are neither parsed nor admitted. The producer-neutral fixture deliberately
+does not mention dbt, so the same lifecycle evidence applies to another
+producer.
+

--- a/adr/specifications/dbt-warehouse-boundary-conformance.md
+++ b/adr/specifications/dbt-warehouse-boundary-conformance.md
@@ -24,22 +24,32 @@ currently implemented compiler contract and must migrate to Project-free
 discovery with ADR-0018. ADR-0019 must not be marked implemented before that
 prerequisite is satisfied.
 
+Evidence classifications used below:
+
+- **Proven local** means repository tests or the local showcase exercise the
+  behavior without a live cloud control plane.
+- **Structurally validated — not live Azure** means the authored workflow,
+  commands, and CI wiring are parsed and checked, but live Azure OIDC, RBAC,
+  storage retention, and checksum behavior are not claimed.
+- **Blocked on ADR-0018** means the current authored Project profile cannot yet
+  satisfy the Project-free discovery and durable namespace contract.
+
 ## Confirmation map
 
 | ADR-0019 confirmation | Maintained implementation evidence | Status or remaining item |
 | --- | --- | --- |
-| Ordinary Connection → Source → Model → SemanticModel → Dashboard graph serves dbt output | `examples/dbt-warehouse-boundary/`; compiler and runtime packages under `internal/project/compiler`, `internal/analytics/duckdb`, and `internal/dashboard/runtime` | Implemented; remove the root Project manifest when ADR-0018 BND-01/BND-02 lands. |
-| One local command builds dbt, external Parquet, and starts LeapView | `task dbt:warehouse`; `scripts/dbt-warehouse-boundary.sh`; `scripts/dev-server.sh` | Implemented. |
-| Explicit resources compile and serve without dbt artifacts or dbt in LeapView | Example LeapView YAML contains no artifact reference; `internal/platform/architecture/dbt_boundary_test.go` | Implemented. |
-| Production invokes LeapView only after successful build and complete publication | `.github/workflows/dbt-warehouse-boundary-reference.yml`; architecture workflow assertions | Implemented reference workflow; target credentials remain operator configuration. |
-| Ordinary versus coordinated consistency is honest | Producer-neutral fixture and [integration guide](../../docs/articles/integrate/dbt-warehouse-boundary.md) | Implemented without a marker protocol. |
-| Schema, type, grain, and checks reject while prior generation serves | `internal/analytics/gates/gates_test.go`; `internal/app/integration_minio_source_test.go`; producer-neutral fixture; `internal/runtimehost/lifecycle_test.go` | Implemented by ADR-0010 and existing runtimehost recovery. |
-| Stable field IDs and readable labels require no physical cosmetic transform | Example Models and `semantic-models/sales.yaml` | Implemented. |
+| Ordinary Connection → Source → Model → SemanticModel → Dashboard graph serves dbt output | `examples/dbt-warehouse-boundary/`; compiler and runtime packages under `internal/project/compiler`, `internal/analytics/duckdb`, and `internal/dashboard/runtime` | Proven local; remove the root Project manifest when ADR-0018 BND-01/BND-02 lands. |
+| One local command builds dbt, external Parquet, and starts LeapView | `task dbt:warehouse`; `scripts/dbt-warehouse-boundary.sh`; `scripts/dev-server.sh` | Proven local. |
+| Explicit resources compile and serve without dbt artifacts or dbt in LeapView | Example LeapView YAML contains no artifact reference; `internal/platform/architecture/dbt_boundary_test.go` | Proven local. |
+| Production invokes LeapView only after successful build and complete publication | `.github/workflows/dbt-warehouse-boundary-reference.yml`; architecture workflow assertions | Structurally validated — not live Azure; target credentials and IAM scopes remain operator requirements. |
+| Ordinary versus coordinated consistency is honest | Producer-neutral fixture and [integration guide](../../docs/articles/integrate/dbt-warehouse-boundary.md) | Proven local and structurally documented without a marker protocol. |
+| Schema, type, grain, and checks reject while prior generation serves | `internal/analytics/gates/gates_test.go`; `internal/app/integration_minio_source_test.go`; producer-neutral fixture; `internal/runtimehost/lifecycle_test.go` | Proven local by ADR-0010 and existing runtimehost recovery. |
+| Stable field IDs and readable labels require no physical cosmetic transform | Example Models and `semantic-models/sales.yaml` | Proven local. |
 | Optional metadata import reconciles metadata and physical state | None | Deferred by decision; this conditional confirmation does not apply until an importer is proposed. |
-| Serving and refresh require no dbt executable, repository, artifacts, or credentials | Runtime module/image architecture assertion; dbt dependencies are isolated under `examples/` and CI | Implemented. |
-| Source read, serving write, and semantic policy boundaries remain distinct | Azure workflow, existing scoped Azure secret tests in `internal/analytics/duckdb/source_test.go`, and integration guide | Implemented as target/operator contract; live Azure authorization remains deployment-specific evidence. |
+| Serving and refresh require no dbt executable, repository, artifacts, or credentials | Runtime module/image architecture assertion; dbt dependencies are isolated under `examples/` and CI | Proven local by runtime/module assertions. |
+| Source read, serving write, and semantic policy boundaries remain distinct | Azure workflow, existing scoped Azure secret tests in `internal/analytics/duckdb/source_test.go`, and integration guide | Structurally validated — not live Azure; IAM scopes are operator requirements and live Azure authorization is not claimed. |
 | MetricFlow/dbt Semantic Layer definitions do not silently become LeapView definitions | No artifact parser or dbt semantic dependency exists; architecture assertion | Implemented by absence and explicit deferral. |
-| Every SemanticModel dataset resolves inside the same Project candidate/generation | ADR-0018 SEM-01/SEM-02 evidence in `project-namespace-conformance.md` | Blocked on full ADR-0018 conformance; current graph resolution remains Project-local. |
+| Every SemanticModel dataset resolves inside the same Project candidate/generation | ADR-0018 SEM-01/SEM-02 evidence in `project-namespace-conformance.md` | Blocked on ADR-0018; current graph resolution remains Project-local. |
 
 ## Existing capability composition
 
@@ -54,7 +64,11 @@ prerequisite is satisfied.
 | Project/environment identity and target bindings | existing deployment and connection-binding contracts; final Project-free source semantics pending ADR-0018 |
 
 Physical Parquet is the CI contract evidence. dbt's manifest and run-results
-files are neither parsed nor admitted. The producer-neutral fixture deliberately
-does not mention dbt, so the same lifecycle evidence applies to another
-producer.
-
+files are neither parsed nor admitted; a targeted metadata-only case proves
+they cannot substitute for the physical relation. The fixture's discovery,
+gate, and activation behavior remains producer-neutral and applies to any
+Parquet producer. IAM scopes for producer read/write, Source read, and serving
+write are operator requirements; this map does not claim live Azure RBAC or
+checksum evidence. A failed upload may leave an orphan partial publication
+prefix. It remains unselected and must be handled by storage lifecycle
+retention, not recovery mutation.

--- a/docs/articles/integrate/dbt-warehouse-boundary.md
+++ b/docs/articles/integrate/dbt-warehouse-boundary.md
@@ -15,6 +15,22 @@ freshness, and publication state. `manifest.json` and `run_results.json` are not
 serving inputs and are not accepted as evidence that physical publication
 completed.
 
+## Evidence status
+
+The integration has three deliberately separate evidence classes:
+
+- **Proven local** — `task dbt:warehouse` builds the pinned dbt project,
+  verifies the exact two physical Parquet marts, and runs them through the
+  ordinary local LeapView candidate lifecycle.
+- **Structurally validated, not live Azure** — the CI contract and the manual
+  Azure reference are YAML-validated for ordering, trusted-ref gating,
+  immutable publication, credential scope, and CI-gate wiring. Repository CI
+  does not exercise live Azure OIDC, storage retention, or Azure RBAC.
+- **Blocked on ADR-0018** — the current authored profile still contains a
+  `kind: Project` document. The reference workflow temporarily asserts that
+  its authored `metadata.id` matches `LEAPVIEW_WORKLOAD_PROJECT`; this check is
+  required only until ADR-0018 moves the profile to Project-free discovery.
+
 ## Run the local showcase
 
 From the repository root, run:
@@ -56,24 +72,37 @@ dbt profile, package credentials, or transformation credentials.
 ## Use the production Azure reference
 
 `.github/workflows/dbt-warehouse-boundary-reference.yml` is a deliberately
-manual, copyable reference. Configure its `dbt-warehouse-boundary-production`
-GitHub environment with:
+manual, copyable reference. Its production job runs only when manually
+dispatched from the repository's protected default branch, using GitHub's
+`github.ref`, `github.event.repository.default_branch`, and
+`github.ref_protected` context. Configure its
+`dbt-warehouse-boundary-production` GitHub environment with:
 
 - `DBT_PRODUCER_CLIENT_ID`, `AZURE_TENANT_ID`, and
   `AZURE_SUBSCRIPTION_ID` variables for the producer's Azure OIDC login;
 - `DBT_PRODUCER_STORAGE_ACCOUNT`, `DBT_PRODUCER_SOURCE_CONTAINER`, and
   `DBT_PRODUCER_PUBLICATION_CONTAINER` variables;
-- `LEAPVIEW_TARGET` and `LEAPVIEW_PROJECT_ID` variables; and
+- the LeapView target URL and workload Project ID variables; and
 - `LEAPVIEW_WORKLOAD_CLIENT_ID` and `LEAPVIEW_WORKLOAD_CLIENT_SECRET` secrets.
 
-The producer identity may read only the two bounded reference inputs and may
-create objects in the publication container. It does not receive LeapView
-serving-state access. The workflow runs dbt and its tests, verifies the local
-physical files, creates a unique prefix from the workflow run, attempt, and Git
-revision, uploads exactly the selected marts without overwrite, and lists the
-prefix to prove that the complete expected set exists. Only then does it render
-an ordinary Azure-backed Connection/Source bundle and invoke `leapview dev
---once --no-browser` followed by `leapview publish`.
+The following IAM scopes are operator requirements, not live authorization
+evidence supplied by this repository: the producer identity must read only the
+two bounded reference inputs and create objects only in the publication
+container; the LeapView `azure_blob` Source binding must read only that
+publication container (and, where supported, its selected prefix); and the
+DuckLake/serving binding must write only LeapView-owned physical storage. The
+reference workflow does not claim live Azure RBAC or checksum evidence.
+
+The workflow runs dbt and its tests, verifies the local physical files, creates
+a globally namespaced prefix from the repository, workflow run, attempt, and
+Git revision, uploads exactly the selected marts without overwrite, and lists
+the prefix to prove that the complete expected set exists. The producer job
+then ends its Azure session and exposes only the non-secret prefix to a separate
+activation job. That job has no Azure OIDC permission; it asserts that the
+authored current-profile Project ID matches `LEAPVIEW_WORKLOAD_PROJECT` (a
+temporary check until ADR-0018), renders an ordinary Azure-backed
+Connection/Source bundle, and invokes `leapview dev --once --no-browser`
+followed by `leapview publish`.
 
 The LeapView target owns two credentials that are not present in the producer
 workflow:
@@ -102,7 +131,9 @@ versioned prefix (or use a warehouse transaction/snapshot with equivalent
 semantics). Start LeapView only after exact file-set verification succeeds.
 The reference workflow never selects a partially uploaded prefix and never
 rewrites an admitted prefix. No publication marker, dbt-specific release type,
-or custom release envelope is involved.
+or custom release envelope is involved. If an upload fails, an orphan partial
+prefix remains unselected; storage lifecycle retention is the cleanup and
+retention mechanism. Recovery must not mutate or reinterpret that prefix.
 
 ## Verify failure and recovery behavior
 
@@ -117,7 +148,9 @@ or custom release envelope is involved.
 
 Producer objects are not deleted or mutated to recover LeapView. Existing
 Project/environment-scoped candidate cleanup, retained generations, rollback,
-leases, and recovery remain authoritative.
+leases, and recovery remain authoritative. Orphan partial publication prefixes
+remain unselected and require storage lifecycle retention, not recovery
+mutation.
 
 Ingestion minimization and semantic policy solve different problems. The
 producer should omit unnecessary columns and rows before publication. LeapView

--- a/docs/articles/integrate/dbt-warehouse-boundary.md
+++ b/docs/articles/integrate/dbt-warehouse-boundary.md
@@ -1,0 +1,133 @@
+# Use dbt at the warehouse boundary
+
+LeapView integrates with dbt by consuming the physical data product that dbt
+publishes. dbt remains the transformation runtime; LeapView remains the BI
+serving runtime.
+
+```text
+raw inputs -> dbt staging -> dbt marts -> warehouse relation or Parquet
+                                                |
+LeapView Connection -> Source -> thin Model -> SemanticModel -> Dashboard
+```
+
+The boundary is the physical relation, including its locator, schema, grain,
+freshness, and publication state. `manifest.json` and `run_results.json` are not
+serving inputs and are not accepted as evidence that physical publication
+completed.
+
+## Run the local showcase
+
+From the repository root, run:
+
+```sh
+task dbt:warehouse
+```
+
+The task prepares the versions pinned in
+`examples/dbt-warehouse-boundary/dbt/requirements.txt`, runs `dbt build`, and
+verifies that the exact two expected non-empty Parquet files exist. It then
+delegates to the repository's managed LeapView development flow, synchronizes
+those files through the ordinary managed Connection, builds and qualifies a
+candidate, publishes it, and starts the dashboard server. No paths need manual
+editing.
+
+The non-interactive CI equivalent is:
+
+```sh
+task dbt:warehouse:qualify
+```
+
+dbt staging and mart SQL owns normalization, joins, and aggregation. The
+LeapView Models only select fields, assign the stable `snake_case` BI field
+IDs, perform safe casts, and enforce the consumer-side contract. The
+SemanticModel adds labels such as “Customer region” and formats revenue and
+average order value as currency without another cosmetic physical
+transformation.
+
+The Source schema is strict about physical field names and types. Its fields
+remain nullable because portable Parquet discovery does not carry dbt's
+row-level non-null proof; error-severity Model checks re-establish that proof
+against the candidate's actual rows before activation.
+
+Removing dbt's `target/`, manifest, or run-results files after publication does
+not affect LeapView. Serving also requires no Python installation, dbt binary,
+dbt profile, package credentials, or transformation credentials.
+
+## Use the production Azure reference
+
+`.github/workflows/dbt-warehouse-boundary-reference.yml` is a deliberately
+manual, copyable reference. Configure its `dbt-warehouse-boundary-production`
+GitHub environment with:
+
+- `DBT_PRODUCER_CLIENT_ID`, `AZURE_TENANT_ID`, and
+  `AZURE_SUBSCRIPTION_ID` variables for the producer's Azure OIDC login;
+- `DBT_PRODUCER_STORAGE_ACCOUNT`, `DBT_PRODUCER_SOURCE_CONTAINER`, and
+  `DBT_PRODUCER_PUBLICATION_CONTAINER` variables;
+- `LEAPVIEW_TARGET` and `LEAPVIEW_PROJECT_ID` variables; and
+- `LEAPVIEW_WORKLOAD_CLIENT_ID` and `LEAPVIEW_WORKLOAD_CLIENT_SECRET` secrets.
+
+The producer identity may read only the two bounded reference inputs and may
+create objects in the publication container. It does not receive LeapView
+serving-state access. The workflow runs dbt and its tests, verifies the local
+physical files, creates a unique prefix from the workflow run, attempt, and Git
+revision, uploads exactly the selected marts without overwrite, and lists the
+prefix to prove that the complete expected set exists. Only then does it render
+an ordinary Azure-backed Connection/Source bundle and invoke `leapview dev
+--once --no-browser` followed by `leapview publish`.
+
+The LeapView target owns two credentials that are not present in the producer
+workflow:
+
+- the `azure_blob` Source binding has read-only access to the publication
+  container (and should be scoped to its prefix where the target supports it);
+- the DuckLake/serving binding has write access only to LeapView-owned physical
+  storage.
+
+These are three distinct authorities: producer write, Source read, and
+DuckLake write. Never copy the producer's Azure profile or dbt credentials into
+LeapView. GitHub masks configured secrets, and the reference commands suppress
+Azure response bodies and dbt row output. Do not add raw-data previews or
+credential-bearing artifacts to the workflow.
+
+## Choose the consistency contract
+
+An ordinary mutable relation or several independently observed Sources provide
+the consistency promised by their connector and producer. LeapView does not
+claim that independent upstream reads occurred at one point in time. Candidate
+activation is atomic only after the selected inputs have been read and the
+LeapView Models have been materialized and qualified.
+
+For coordinated marts, publish the complete set under one new immutable
+versioned prefix (or use a warehouse transaction/snapshot with equivalent
+semantics). Start LeapView only after exact file-set verification succeeds.
+The reference workflow never selects a partially uploaded prefix and never
+rewrites an admitted prefix. No publication marker, dbt-specific release type,
+or custom release envelope is involved.
+
+## Verify failure and recovery behavior
+
+| Failure | Result |
+| --- | --- |
+| dbt compilation or test failure | Publication and LeapView steps do not run. |
+| upload failure or partial file set | Verification fails and LeapView does not run. |
+| stale Source observation | ADR-0010 freshness qualification blocks activation. |
+| malformed Parquet or incompatible schema | Source discovery/materialization blocks the candidate. |
+| invalid grain or failed Model check | ADR-0010 qualification blocks activation. |
+| LeapView activation failure | Existing activation/reconciliation leaves the prior generation selected. |
+
+Producer objects are not deleted or mutated to recover LeapView. Existing
+Project/environment-scoped candidate cleanup, retained generations, rollback,
+leases, and recovery remain authoritative.
+
+Ingestion minimization and semantic policy solve different problems. The
+producer should omit unnecessary columns and rows before publication. LeapView
+masking, row-level access, and semantic permissions govern downstream serving;
+they do not retroactively minimize what LeapView ingested.
+
+## Deferred features
+
+The v1 integration intentionally does not include dbt artifact import,
+MetricFlow, dbt Semantic Layer import, immutable data promotion across
+environments, or cross-Project imports. A future metadata importer may assist
+authoring, but it must remain optional and reconcile against physical data
+rather than becoming runtime authority.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -103,6 +103,7 @@ Focused slices are available at `/docs/agent-tools/tools/{name}.json|md`, `/docs
 - [API quickstart](/docs/guides/integrate/api-quickstart): Authenticate and call the headless API.
 - [API conventions](/docs/guides/integrate/api-conventions): Handle authentication, errors, and pagination consistently.
 - [Headless BI queries](/docs/guides/integrate/headless-bi): Query dashboards and semantic models through stable contracts.
+- [Use dbt at the warehouse boundary](/docs/guides/integrate/dbt-warehouse-boundary): Publish tested dbt marts and consume their physical contract through ordinary LeapView resources.
 - [Public and embedded dashboards](/docs/guides/integrate/public-dashboards): Publish an anonymous governed dashboard and embed it on an allowed origin.
 - [Agent integrations](/docs/guides/integrate/agent): Use global conversations and the shared governed tool catalog.
 - [Use the agent tool catalog](/docs/guides/integrate/agent-tools): Find, inspect, and query governed resources through the curated tool surface.

--- a/docs/navigation.yaml
+++ b/docs/navigation.yaml
@@ -376,6 +376,11 @@ sections:
         type: how-to
         summary: Query dashboards and semantic models through stable contracts.
         source: articles/integrate/headless-bi.md
+      - slug: guides/integrate/dbt-warehouse-boundary
+        title: Use dbt at the warehouse boundary
+        type: how-to
+        summary: Publish tested dbt marts and consume their physical contract through ordinary LeapView resources.
+        source: articles/integrate/dbt-warehouse-boundary.md
       - slug: guides/integrate/public-dashboards
         title: Public and embedded dashboards
         type: how-to

--- a/examples/dbt-warehouse-boundary/README.md
+++ b/examples/dbt-warehouse-boundary/README.md
@@ -1,0 +1,15 @@
+# dbt warehouse-boundary showcase
+
+This example is maintained by the repository's
+[dbt warehouse-boundary guide](../../docs/articles/integrate/dbt-warehouse-boundary.md).
+Run it from the repository root with:
+
+```sh
+task dbt:warehouse
+```
+
+The dbt project owns the transformations and writes the two selected marts to
+`published/` with dbt-duckdb's `external` materialization. LeapView consumes
+those physical Parquet files through its ordinary managed Connection, Sources,
+thin Models, SemanticModel, and Dashboard. Neither `target/`, `manifest.json`,
+nor `run_results.json` is part of the LeapView serving contract.

--- a/examples/dbt-warehouse-boundary/dbt/dbt_project.yml
+++ b/examples/dbt-warehouse-boundary/dbt/dbt_project.yml
@@ -1,0 +1,17 @@
+name: leapview_warehouse_boundary
+version: 1.0.0
+config-version: 2
+profile: leapview_warehouse_boundary
+
+model-paths: [models]
+seed-paths: [seeds]
+target-path: target
+clean-targets: [target, dbt_packages]
+
+models:
+  leapview_warehouse_boundary:
+    staging:
+      +materialized: view
+    marts:
+      +materialized: external
+      +format: parquet

--- a/examples/dbt-warehouse-boundary/dbt/models/marts/dim_customers.sql
+++ b/examples/dbt-warehouse-boundary/dbt/models/marts/dim_customers.sql
@@ -1,0 +1,9 @@
+select
+  c.customer_id,
+  c.customer_name,
+  c.region,
+  cast(count(o.order_id) as bigint) as order_count,
+  cast(coalesce(sum(o.revenue), 0) as double) as lifetime_value
+from {{ ref('stg_customers') }} c
+left join {{ ref('fct_orders') }} o using (customer_id)
+group by c.customer_id, c.customer_name, c.region

--- a/examples/dbt-warehouse-boundary/dbt/models/marts/fct_orders.sql
+++ b/examples/dbt-warehouse-boundary/dbt/models/marts/fct_orders.sql
@@ -1,0 +1,8 @@
+select
+  order_id,
+  customer_id,
+  order_date,
+  order_status,
+  cast(sum(line_amount) as double) as revenue
+from {{ ref('stg_orders') }}
+group by order_id, customer_id, order_date, order_status

--- a/examples/dbt-warehouse-boundary/dbt/models/properties.yml
+++ b/examples/dbt-warehouse-boundary/dbt/models/properties.yml
@@ -1,0 +1,61 @@
+version: 2
+
+models:
+  - name: stg_orders
+    description: Typed line-level order input owned by dbt.
+    config:
+      contract:
+        enforced: true
+    columns:
+      - {name: order_id, data_type: varchar, tests: [not_null]}
+      - {name: customer_id, data_type: varchar, tests: [not_null]}
+      - {name: order_date, data_type: date, tests: [not_null]}
+      - name: order_status
+        data_type: varchar
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [shipped, delivered, processing, cancelled]
+      - {name: line_amount, data_type: double, tests: [not_null]}
+
+  - name: stg_customers
+    description: Clean customer attributes owned by dbt.
+    config:
+      contract:
+        enforced: true
+    columns:
+      - {name: customer_id, data_type: varchar, tests: [not_null, unique]}
+      - {name: customer_name, data_type: varchar, tests: [not_null]}
+      - {name: region, data_type: varchar, tests: [not_null]}
+
+  - name: fct_orders
+    description: One tested, externally materialized row per order.
+    config:
+      contract:
+        enforced: true
+    columns:
+      - {name: order_id, data_type: varchar, tests: [not_null, unique]}
+      - name: customer_id
+        data_type: varchar
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_customers')
+                field: customer_id
+      - {name: order_date, data_type: date, tests: [not_null]}
+      - {name: order_status, data_type: varchar, tests: [not_null]}
+      - {name: revenue, data_type: double, tests: [not_null]}
+
+  - name: dim_customers
+    description: Customer-grain mart with dbt-owned lifetime aggregation.
+    config:
+      contract:
+        enforced: true
+    columns:
+      - {name: customer_id, data_type: varchar, tests: [not_null, unique]}
+      - {name: customer_name, data_type: varchar, tests: [not_null]}
+      - {name: region, data_type: varchar, tests: [not_null]}
+      - {name: order_count, data_type: bigint, tests: [not_null]}
+      - {name: lifetime_value, data_type: double, tests: [not_null]}

--- a/examples/dbt-warehouse-boundary/dbt/models/staging/stg_customers.sql
+++ b/examples/dbt-warehouse-boundary/dbt/models/staging/stg_customers.sql
@@ -1,0 +1,5 @@
+select
+  cast(customer_id as varchar) as customer_id,
+  trim(customer_name) as customer_name,
+  lower(trim(region)) as region
+from {{ ref('raw_customers') }}

--- a/examples/dbt-warehouse-boundary/dbt/models/staging/stg_orders.sql
+++ b/examples/dbt-warehouse-boundary/dbt/models/staging/stg_orders.sql
@@ -1,0 +1,7 @@
+select
+  cast(order_id as varchar) as order_id,
+  cast(customer_id as varchar) as customer_id,
+  cast(order_date as date) as order_date,
+  lower(trim(status)) as order_status,
+  cast(line_amount as double) as line_amount
+from {{ ref('raw_orders') }}

--- a/examples/dbt-warehouse-boundary/dbt/profiles.yml
+++ b/examples/dbt-warehouse-boundary/dbt/profiles.yml
@@ -1,0 +1,9 @@
+leapview_warehouse_boundary:
+  target: local
+  outputs:
+    local:
+      type: duckdb
+      path: target/warehouse.duckdb
+      schema: analytics
+      threads: 2
+      external_root: ../published

--- a/examples/dbt-warehouse-boundary/dbt/requirements.txt
+++ b/examples/dbt-warehouse-boundary/dbt/requirements.txt
@@ -1,0 +1,2 @@
+dbt-core==1.11.14
+dbt-duckdb==1.11.0

--- a/examples/dbt-warehouse-boundary/dbt/seeds/raw_customers.csv
+++ b/examples/dbt-warehouse-boundary/dbt/seeds/raw_customers.csv
@@ -1,0 +1,4 @@
+customer_id,customer_name,region
+c-1,Ada Retail,North
+c-2,Beacon Stores,South
+c-3,Cascade Market,West

--- a/examples/dbt-warehouse-boundary/dbt/seeds/raw_orders.csv
+++ b/examples/dbt-warehouse-boundary/dbt/seeds/raw_orders.csv
@@ -1,0 +1,6 @@
+order_id,customer_id,order_date,status,line_amount
+o-100,c-1,2026-08-01,SHIPPED,24.50
+o-100,c-1,2026-08-01,SHIPPED,15.50
+o-101,c-2,2026-08-02,DELIVERED,75.00
+o-102,c-1,2026-08-03,PROCESSING,12.25
+o-103,c-3,2026-08-03,CANCELLED,9.99

--- a/examples/dbt-warehouse-boundary/leapview/connections/warehouse.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/connections/warehouse.yaml
@@ -1,0 +1,12 @@
+apiVersion: leapview.dev/v1
+kind: Connection
+metadata:
+  id: connection:warehouse
+  name: warehouse
+  displayName: dbt-published warehouse boundary
+spec:
+  type: managed
+  defaults:
+    parquet:
+      hivePartitioning: false
+      unionByName: false

--- a/examples/dbt-warehouse-boundary/leapview/dashboards/sales-overview.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/dashboards/sales-overview.yaml
@@ -1,0 +1,66 @@
+apiVersion: leapview.dev/v1
+kind: Dashboard
+metadata:
+  id: dashboard:warehouse-sales-overview
+  name: warehouse-sales-overview
+  displayName: dbt Warehouse Sales
+  description: Governed view of the physical marts published by dbt.
+  tags: [dbt, warehouse-boundary]
+spec:
+  semanticModel: warehouse_sales
+  filters:
+    - id: order_date
+      label: Order date
+      dimension: order_date
+      control: {type: relativePeriod}
+      urlParameter: period
+      operators: []
+    - id: customer_region
+      label: Customer region
+      dimension: customer_region
+      control: {type: multiSelect}
+      operators: [in, notIn]
+      urlParameter: region
+  visuals:
+    revenue:
+      type: kpi
+      query: {type: aggregate, dimensions: [], metrics: [revenue]}
+      presentation: {type: kpi, note: dbt-published revenue, tone: success}
+    orders:
+      type: kpi
+      query: {type: aggregate, dimensions: [], metrics: [order_count]}
+      presentation: {type: kpi, note: Distinct orders, tone: ink}
+    average_order_value:
+      type: kpi
+      query: {type: aggregate, dimensions: [], metrics: [average_order_value]}
+      presentation: {type: kpi, note: Revenue per order, tone: warning}
+    revenue_by_month:
+      type: area
+      title: Revenue by month
+      query:
+        type: aggregate
+        dimensions:
+          - {dimension: order_date, grain: month, alias: order_month}
+        metrics: [revenue]
+        sort: [{field: order_month, direction: asc}]
+      presentation: {type: cartesian}
+    revenue_by_region:
+      type: bar
+      title: Revenue by customer region
+      query:
+        type: aggregate
+        dimensions: [customer_region]
+        metrics: [revenue]
+        sort: [{field: revenue, direction: desc}]
+      presentation: {type: cartesian}
+  pages:
+    - id: overview
+      title: Overview
+      components:
+        - {id: order-date-filter, type: filter, filter: order_date, placement: {column: 1, row: 1, columnSpan: 4, rowSpan: 2}}
+        - {id: region-filter, type: filter, filter: customer_region, placement: {column: 5, row: 1, columnSpan: 4, rowSpan: 2}}
+        - {id: revenue-kpi, type: visual, visual: revenue, placement: {column: 1, row: 3, columnSpan: 4, rowSpan: 3}}
+        - {id: orders-kpi, type: visual, visual: orders, placement: {column: 5, row: 3, columnSpan: 4, rowSpan: 3}}
+        - {id: aov-kpi, type: visual, visual: average_order_value, placement: {column: 9, row: 3, columnSpan: 4, rowSpan: 3}}
+        - {id: revenue-month, type: visual, visual: revenue_by_month, placement: {column: 1, row: 6, columnSpan: 7, rowSpan: 6}}
+        - {id: revenue-region, type: visual, visual: revenue_by_region, placement: {column: 8, row: 6, columnSpan: 5, rowSpan: 6}}

--- a/examples/dbt-warehouse-boundary/leapview/leapview.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/leapview.yaml
@@ -1,0 +1,20 @@
+apiVersion: leapview.dev/v1
+kind: Project
+metadata:
+  id: project:dbt-warehouse-boundary
+  name: dbt-warehouse-boundary
+spec:
+  connections:
+    include: [connections/*.yaml]
+  sources:
+    include: [sources/*.yaml]
+  models:
+    include: [models/*.yaml]
+  semanticModels:
+    include: [semantic-models/*.yaml]
+  pipelines:
+    include: []
+  dashboards:
+    include: [dashboards/*.yaml]
+  access:
+    include: []

--- a/examples/dbt-warehouse-boundary/leapview/models/customers.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/models/customers.yaml
@@ -1,0 +1,37 @@
+apiVersion: leapview.dev/v1
+kind: Model
+metadata:
+  id: model:customers
+  name: customers
+  displayName: Warehouse customers serving contract
+  description: Thin projection and safe-cast boundary over the dbt-owned customer mart.
+spec:
+  definition:
+    type: sql
+    sql: |
+      SELECT
+        CAST(customer_id AS VARCHAR) AS customer_id,
+        CAST(customer_name AS VARCHAR) AS customer_name,
+        CAST(region AS VARCHAR) AS region,
+        TRY_CAST(order_count AS BIGINT) AS order_count,
+        TRY_CAST(lifetime_value AS DOUBLE) AS lifetime_value
+      FROM source."warehouse.dim_customers"
+  entities:
+    customer:
+      type: primary
+      fields: [customer_id]
+  grain:
+    entity: customer
+  fields:
+    customer_id: {datatype: String, description: Stable warehouse customer identifier.}
+    customer_name: {datatype: String, description: Customer display name.}
+    region: {datatype: String, description: dbt-normalized sales region.}
+    order_count: {datatype: Integer, description: dbt-owned customer order count.}
+    lifetime_value: {datatype: Float, description: dbt-owned customer lifetime revenue.}
+  checks:
+    - {type: non_null, field: customer_id, severity: error}
+    - {type: non_null, field: customer_name, severity: error}
+    - {type: non_null, field: region, severity: error}
+    - {type: non_null, field: order_count, severity: error}
+    - {type: non_null, field: lifetime_value, severity: error}
+    - {type: row_count, minimum: 1, severity: error}

--- a/examples/dbt-warehouse-boundary/leapview/models/orders.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/models/orders.yaml
@@ -1,0 +1,44 @@
+apiVersion: leapview.dev/v1
+kind: Model
+metadata:
+  id: model:orders
+  name: orders
+  displayName: Warehouse orders serving contract
+  description: Thin projection and safe-cast boundary over the dbt-owned order mart.
+spec:
+  definition:
+    type: sql
+    sql: |
+      SELECT
+        CAST(order_id AS VARCHAR) AS order_id,
+        CAST(customer_id AS VARCHAR) AS customer_id,
+        TRY_CAST(order_date AS DATE) AS order_date,
+        CAST(order_status AS VARCHAR) AS order_status,
+        TRY_CAST(revenue AS DOUBLE) AS revenue
+      FROM source."warehouse.fct_orders"
+  entities:
+    order:
+      type: primary
+      fields: [order_id]
+    customer:
+      type: foreign
+      fields: [customer_id]
+  grain:
+    entity: order
+  fields:
+    order_id: {datatype: String, description: Stable warehouse order identifier.}
+    customer_id: {datatype: String, description: Customer attached to the order.}
+    order_date: {datatype: Date, description: Order calendar date.}
+    order_status: {datatype: String, description: dbt-normalized order state.}
+    revenue: {datatype: Float, description: dbt-aggregated order revenue.}
+  checks:
+    - {type: non_null, field: order_id, severity: error}
+    - {type: non_null, field: customer_id, severity: error}
+    - {type: non_null, field: order_date, severity: error}
+    - {type: non_null, field: order_status, severity: error}
+    - {type: non_null, field: revenue, severity: error}
+    - type: accepted_values
+      field: order_status
+      values: [shipped, delivered, processing, cancelled]
+      severity: error
+    - {type: row_count, minimum: 1, severity: error}

--- a/examples/dbt-warehouse-boundary/leapview/semantic-models/sales.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/semantic-models/sales.yaml
@@ -1,0 +1,65 @@
+apiVersion: leapview.dev/v1
+kind: SemanticModel
+metadata:
+  id: semantic-model:warehouse_sales
+  name: warehouse_sales
+  displayName: Warehouse Sales
+  description: Governed BI semantics over dbt-published marts.
+spec:
+  datasets:
+    orders:
+      model: orders
+      defaultTimeDimension: order_date
+    customers:
+      model: customers
+  relationships:
+    orders_customers:
+      from: {dataset: orders, entity: customer}
+      to: {dataset: customers, entity: customer}
+      description: Joins each order to its dbt-published customer row.
+  dimensions:
+    order_date:
+      datatype: Date
+      label: Order date
+      bindings:
+        orders: {field: orders.order_date}
+      time:
+        nativeGrain: day
+        grains: [day, week, month, quarter, year]
+        calendar: iso8601
+    order_status:
+      datatype: String
+      label: Order status
+      bindings:
+        orders: {field: orders.order_status}
+    customer_region:
+      datatype: String
+      label: Customer region
+      bindings:
+        orders:
+          field: customers.region
+          path: [orders_customers]
+  metrics:
+    revenue:
+      type: aggregate
+      dataset: orders
+      aggregation: sum
+      input: {field: orders.revenue}
+      empty: zero
+      label: Revenue
+      description: Revenue produced at order grain by dbt.
+      format: currency
+    order_count:
+      type: aggregate
+      dataset: orders
+      aggregation: count_distinct
+      input: {field: orders.order_id}
+      empty: zero
+      label: Orders
+      format: integer
+    average_order_value:
+      type: ratio
+      numerator: revenue
+      denominator: order_count
+      label: Average order value
+      format: currency

--- a/examples/dbt-warehouse-boundary/leapview/sources/dim_customers.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/sources/dim_customers.yaml
@@ -1,0 +1,20 @@
+apiVersion: leapview.dev/v1
+kind: Source
+metadata:
+  id: source:warehouse.dim_customers
+  name: warehouse.dim_customers
+  displayName: Published customer mart
+spec:
+  connection: warehouse
+  location:
+    type: path
+    path: dim_customers.parquet
+    format: parquet
+  schema:
+    mode: strict
+    fields:
+      customer_id: {datatype: String, nullable: true}
+      customer_name: {datatype: String, nullable: true}
+      region: {datatype: String, nullable: true}
+      order_count: {datatype: Integer, nullable: true}
+      lifetime_value: {datatype: Float, nullable: true}

--- a/examples/dbt-warehouse-boundary/leapview/sources/fct_orders.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/sources/fct_orders.yaml
@@ -1,0 +1,20 @@
+apiVersion: leapview.dev/v1
+kind: Source
+metadata:
+  id: source:warehouse.fct_orders
+  name: warehouse.fct_orders
+  displayName: Published order mart
+spec:
+  connection: warehouse
+  location:
+    type: path
+    path: fct_orders.parquet
+    format: parquet
+  schema:
+    mode: strict
+    fields:
+      order_id: {datatype: String, nullable: true}
+      customer_id: {datatype: String, nullable: true}
+      order_date: {datatype: Date, nullable: true}
+      order_status: {datatype: String, nullable: true}
+      revenue: {datatype: Float, nullable: true}

--- a/internal/analytics/gates/duckdb_integration_test.go
+++ b/internal/analytics/gates/duckdb_integration_test.go
@@ -32,6 +32,9 @@ func TestEvaluateExecutesAllChecksAgainstDuckDBCandidateRelations(t *testing.T) 
 		}
 	}
 	query := func(ctx context.Context, plan semanticquery.Plan) (semanticquery.Rows, error) {
+		if len(plan.Columns) != 1 {
+			t.Fatalf("gate plan columns = %v, want one declared result column", plan.Columns)
+		}
 		rows, err := db.QueryContext(ctx, plan.SQL, plan.Args...)
 		if err != nil {
 			return nil, err
@@ -40,6 +43,9 @@ func TestEvaluateExecutesAllChecksAgainstDuckDBCandidateRelations(t *testing.T) 
 		columns, err := rows.Columns()
 		if err != nil {
 			return nil, err
+		}
+		if len(columns) != 1 || columns[0] != plan.Columns[0] {
+			t.Fatalf("gate query columns = %v, plan columns = %v", columns, plan.Columns)
 		}
 		result := semanticquery.Rows{}
 		for rows.Next() {

--- a/internal/analytics/gates/gates.go
+++ b/internal/analytics/gates/gates.go
@@ -552,7 +552,7 @@ func evaluateCheck(ctx context.Context, state *budget, modelID string, table sem
 		for i, field := range fields {
 			parts[i] = quoteIdent(field)
 		}
-		rows, err = runPlan(ctx, state, fmt.Sprintf("SELECT 1 AS value FROM %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT %d", relation, strings.Join(parts, ", "), state.Bounds.MaxRows), nil)
+		rows, err = runPlan(ctx, state, "value", fmt.Sprintf("SELECT 1 AS value FROM %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT %d", relation, strings.Join(parts, ", "), state.Bounds.MaxRows), nil)
 	case "accepted_values":
 		if !validField(check.Field) || len(check.Values) == 0 {
 			return result, gateError(identity, release.GateUnavailable, ErrGateUnavailable, nil)
@@ -588,7 +588,7 @@ func evaluateCheck(ctx context.Context, state *budget, modelID string, table sem
 		if limit == nil || *limit < 0 || *limit >= state.Bounds.MaxRows {
 			return result, gateError(identity, release.GateUnavailable, ErrGateBounds, nil)
 		}
-		rows, err = runPlan(ctx, state, fmt.Sprintf("SELECT COUNT(*) AS count FROM (SELECT 1 FROM %s LIMIT ?) AS bounded", relation), []any{*limit + 1})
+		rows, err = runPlan(ctx, state, "count", fmt.Sprintf("SELECT COUNT(*) AS count FROM (SELECT 1 FROM %s LIMIT ?) AS bounded", relation), []any{*limit + 1})
 		if err == nil {
 			count, ok := int64Value(firstValue(rows, "count"))
 			if !ok {
@@ -672,7 +672,7 @@ func run(ctx context.Context, state *budget, relation, projection, predicate str
 		limit = 1
 	}
 	sql := fmt.Sprintf("SELECT %s AS value FROM %s WHERE %s LIMIT %d", projection, relation, predicate, limit)
-	return runPlan(ctx, state, sql, firstArgs(args))
+	return runPlan(ctx, state, "value", sql, firstArgs(args))
 }
 
 func runQualified(ctx context.Context, state *budget, relation, projection, predicate string, args []any) (semanticquery.Rows, error) {
@@ -680,16 +680,16 @@ func runQualified(ctx context.Context, state *budget, relation, projection, pred
 	if limit <= 0 {
 		limit = 1
 	}
-	return runPlan(ctx, state, fmt.Sprintf("SELECT %s AS value FROM %s WHERE %s LIMIT %d", projection, relation, predicate, limit), args)
+	return runPlan(ctx, state, "value", fmt.Sprintf("SELECT %s AS value FROM %s WHERE %s LIMIT %d", projection, relation, predicate, limit), args)
 }
 
-func runPlan(ctx context.Context, state *budget, sql string, args []any) (semanticquery.Rows, error) {
+func runPlan(ctx context.Context, state *budget, column, sql string, args []any) (semanticquery.Rows, error) {
 	if state.Queries >= state.Bounds.MaxQueries {
 		state.QueriesExceeded = true
 		return nil, ErrGateBounds
 	}
 	state.Queries++
-	rows, err := currentQuery(ctx, state, sql, args)
+	rows, err := currentQuery(ctx, state, column, sql, args)
 	if err != nil {
 		return nil, err
 	}
@@ -701,11 +701,11 @@ func runPlan(ctx context.Context, state *budget, sql string, args []any) (semant
 	return rows, nil
 }
 
-func currentQuery(ctx context.Context, state *budget, sql string, args []any) (semanticquery.Rows, error) {
+func currentQuery(ctx context.Context, state *budget, column, sql string, args []any) (semanticquery.Rows, error) {
 	if state == nil || state.Query == nil {
 		return nil, ErrGateUnavailable
 	}
-	return state.Query(ctx, semanticquery.Plan{SQL: sql, Args: args})
+	return state.Query(ctx, semanticquery.Plan{SQL: sql, Args: args, Columns: []string{column}})
 }
 
 func firstArgs(args [][]any) []any {

--- a/internal/app/config/spec/spec.go
+++ b/internal/app/config/spec/spec.go
@@ -90,6 +90,7 @@ var settings = []Setting{
 	{Name: "LEAPVIEW_DEV_READY_INTERVAL", Type: TypeDuration, Default: "200ms", Category: "development", Scope: "dev server", Description: "Delay between managed development server readiness attempts.", Lifecycle: "development"},
 	{Name: "LEAPVIEW_DEV_MCP_ATTEMPTS", Type: TypeInt, Default: "20", Category: "development", Scope: "dev server", Description: "Attempts made by the development MCP smoke check while the active project converges.", Lifecycle: "development"},
 	{Name: "LEAPVIEW_DEV_MCP_INTERVAL", Type: TypeDuration, Default: "500ms", Category: "development", Scope: "dev server", Description: "Delay between development MCP smoke-check attempts.", Lifecycle: "development"},
+	{Name: "LEAPVIEW_DEV_ONCE", Type: TypeBool, Default: "false", Category: "development", Scope: "dev server", Description: "Stop the managed development server after one successful candidate publication and MCP smoke check.", Lifecycle: "development"},
 	{Name: "LEAPVIEW_DEV_RESTART", Type: TypeBool, Default: "false", Category: "development", Scope: "dev server", Description: "Force the managed development server to restart.", Lifecycle: "development"},
 	{Name: "LEAPVIEW_DEV_SKIP_PUBLISH", Type: TypeBool, Default: "false", Category: "development", Scope: "dev server", Description: "Skip automatic project publishing in the managed development server.", Lifecycle: "development"},
 	{Name: "LEAPVIEW_DEV_WORKTREE", Type: TypeString, Category: "development", Scope: "dev server", Description: "Worktree path exported by the managed development server.", Lifecycle: "internal"},
@@ -314,17 +315,17 @@ type Rule struct {
 func Rules() []Rule { return append([]Rule(nil), rules...) }
 
 var (
-	production        = True("LEAPVIEW_PRODUCTION")
-	evaluation        = True("LEAPVIEW_EVALUATION_MODE")
-	oidcAny           = Any(Present("LEAPVIEW_OIDC_ISSUER_URL"), Present("LEAPVIEW_OIDC_CLIENT_ID"), Present("LEAPVIEW_OIDC_CLIENT_SECRET"), Present("LEAPVIEW_OIDC_CALLBACK_URL"), Present("LEAPVIEW_OIDC_SCOPES"))
-	oidcComplete      = All(Present("LEAPVIEW_OIDC_ISSUER_URL"), Present("LEAPVIEW_OIDC_CLIENT_ID"), Present("LEAPVIEW_OIDC_CLIENT_SECRET"), Present("LEAPVIEW_OIDC_CALLBACK_URL"))
-	azureAny          = Any(Present("LEAPVIEW_AZURE_CLIENT_ID"), Present("LEAPVIEW_AZURE_CLIENT_SECRET"), Present("LEAPVIEW_AZURE_CALLBACK_URL"), Present("LEAPVIEW_AZURE_TENANT"))
-	azureComplete     = All(Present("LEAPVIEW_AZURE_CLIENT_ID"), Present("LEAPVIEW_AZURE_CLIENT_SECRET"), Present("LEAPVIEW_AZURE_CALLBACK_URL"))
-	browserAuth       = Any(True("LEAPVIEW_LOCAL_AUTH"), oidcComplete, azureComplete)
-	managedData       = Present("LEAPVIEW_MANAGED_DATA_BACKEND")
-	managedS3         = Equals("LEAPVIEW_MANAGED_DATA_BACKEND", "s3")
-	infisicalAny      = Any(Present("LEAPVIEW_INFISICAL_BASE_URL"), Present("LEAPVIEW_INFISICAL_UNIVERSAL_CLIENT_ID"), Present("LEAPVIEW_INFISICAL_UNIVERSAL_CLIENT_SECRET"), Present("LEAPVIEW_INFISICAL_ALLOWED_SCOPES"))
-	infisicalComplete = All(Present("LEAPVIEW_INFISICAL_BASE_URL"), Present("LEAPVIEW_INFISICAL_UNIVERSAL_CLIENT_ID"), Present("LEAPVIEW_INFISICAL_UNIVERSAL_CLIENT_SECRET"), Present("LEAPVIEW_INFISICAL_ALLOWED_SCOPES"))
+	production            = True("LEAPVIEW_PRODUCTION")
+	evaluation            = True("LEAPVIEW_EVALUATION_MODE")
+	oidcAny               = Any(Present("LEAPVIEW_OIDC_ISSUER_URL"), Present("LEAPVIEW_OIDC_CLIENT_ID"), Present("LEAPVIEW_OIDC_CLIENT_SECRET"), Present("LEAPVIEW_OIDC_CALLBACK_URL"), Present("LEAPVIEW_OIDC_SCOPES"))
+	oidcComplete          = All(Present("LEAPVIEW_OIDC_ISSUER_URL"), Present("LEAPVIEW_OIDC_CLIENT_ID"), Present("LEAPVIEW_OIDC_CLIENT_SECRET"), Present("LEAPVIEW_OIDC_CALLBACK_URL"))
+	azureAny              = Any(Present("LEAPVIEW_AZURE_CLIENT_ID"), Present("LEAPVIEW_AZURE_CLIENT_SECRET"), Present("LEAPVIEW_AZURE_CALLBACK_URL"), Present("LEAPVIEW_AZURE_TENANT"))
+	azureComplete         = All(Present("LEAPVIEW_AZURE_CLIENT_ID"), Present("LEAPVIEW_AZURE_CLIENT_SECRET"), Present("LEAPVIEW_AZURE_CALLBACK_URL"))
+	browserAuth           = Any(True("LEAPVIEW_LOCAL_AUTH"), oidcComplete, azureComplete)
+	managedData           = Present("LEAPVIEW_MANAGED_DATA_BACKEND")
+	managedS3             = Equals("LEAPVIEW_MANAGED_DATA_BACKEND", "s3")
+	infisicalAny          = Any(Present("LEAPVIEW_INFISICAL_BASE_URL"), Present("LEAPVIEW_INFISICAL_UNIVERSAL_CLIENT_ID"), Present("LEAPVIEW_INFISICAL_UNIVERSAL_CLIENT_SECRET"), Present("LEAPVIEW_INFISICAL_ALLOWED_SCOPES"))
+	infisicalComplete     = All(Present("LEAPVIEW_INFISICAL_BASE_URL"), Present("LEAPVIEW_INFISICAL_UNIVERSAL_CLIENT_ID"), Present("LEAPVIEW_INFISICAL_UNIVERSAL_CLIENT_SECRET"), Present("LEAPVIEW_INFISICAL_ALLOWED_SCOPES"))
 	postgresControlIntent = OneOf("LEAPVIEW_POSTGRES_CONTROL_INTENT", "read-write")
 )
 

--- a/internal/app/warehouse_boundary_qualification_integration_test.go
+++ b/internal/app/warehouse_boundary_qualification_integration_test.go
@@ -32,7 +32,7 @@ var warehouseBoundaryNow = time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
 
 type warehouseBoundarySpec struct {
 	root        string
-	coordinated bool
+	multiSource bool
 	freshness   bool
 }
 
@@ -188,21 +188,25 @@ func TestProducerNeutralWarehouseBoundaryQualification(t *testing.T) {
 	tests := []struct {
 		name               string
 		publication        string
-		coordinated        bool
+		multiSource        bool
+		immutablePrefix    bool
 		freshness          bool
 		prepareFails       bool
 		qualificationFails bool
 		activationFails    bool
 	}{
 		{name: "compatible physical Parquet activates atomically", publication: "compatible"},
-		{name: "complete immutable multi-mart prefix activates atomically", publication: "compatible", coordinated: true},
+		{name: "compatible ordinary multi-source multi-mart publication activates atomically", publication: "compatible", multiSource: true},
+		{name: "complete immutable multi-mart prefix activates atomically", publication: "compatible", multiSource: true, immutablePrefix: true},
 		{name: "incompatible physical type is blocked", publication: "incompatible_schema", prepareFails: true},
 		{name: "removed physical field is blocked", publication: "missing_column", prepareFails: true},
+		{name: "unexpected physical field is blocked by strict schema", publication: "unexpected_column", prepareFails: true},
 		{name: "stale freshness is blocked", publication: "stale", freshness: true, qualificationFails: true},
 		{name: "invalid grain is blocked", publication: "duplicate_grain", qualificationFails: true},
 		{name: "failed Model check is blocked", publication: "failed_check", qualificationFails: true},
 		{name: "malformed Parquet is blocked", publication: "malformed", prepareFails: true},
-		{name: "partial coordinated publication is blocked", publication: "partial", coordinated: true, prepareFails: true},
+		{name: "metadata-only publication is blocked without physical Parquet", publication: "metadata_only", prepareFails: true},
+		{name: "partial coordinated publication is blocked", publication: "partial", multiSource: true, immutablePrefix: true, prepareFails: true},
 		{name: "activation failure preserves the old generation", publication: "compatible", activationFails: true},
 	}
 
@@ -211,11 +215,11 @@ func TestProducerNeutralWarehouseBoundaryQualification(t *testing.T) {
 			baseRoot := filepath.Join(t.TempDir(), "ordinary-current")
 			writeWarehouseBoundaryPublication(t, baseRoot, "compatible", false)
 			candidatePrefix := "ordinary-next"
-			if test.coordinated {
+			if test.immutablePrefix {
 				candidatePrefix = "version-2026-09-04T120000Z"
 			}
 			candidateRoot := filepath.Join(t.TempDir(), candidatePrefix)
-			writeWarehouseBoundaryPublication(t, candidateRoot, test.publication, test.coordinated)
+			writeWarehouseBoundaryPublication(t, candidateRoot, test.publication, test.multiSource)
 
 			baseID := servingstate.ID(fmt.Sprintf("generation_base_%d", index))
 			candidateID := servingstate.ID(fmt.Sprintf("generation_candidate_%d", index))
@@ -231,7 +235,7 @@ func TestProducerNeutralWarehouseBoundaryQualification(t *testing.T) {
 			}
 			repo := &warehouseBoundaryRepo{active: baseID, states: states, artifacts: artifacts}
 			factory := &warehouseBoundaryFactory{admission: admission, specs: map[servingstate.ID]warehouseBoundarySpec{
-				baseID: {root: baseRoot}, candidateID: {root: candidateRoot, coordinated: test.coordinated, freshness: test.freshness},
+				baseID: {root: baseRoot}, candidateID: {root: candidateRoot, multiSource: test.multiSource, freshness: test.freshness},
 			}}
 			registry := runtimehost.NewRegistryWithFactory(runtimehost.RegistryOptions{
 				Repo: repo, ProjectID: "project:warehouse-boundary", Environment: "test", Factory: factory, Authorization: warehouseBoundaryAuthorization{},
@@ -260,11 +264,14 @@ func TestProducerNeutralWarehouseBoundaryQualification(t *testing.T) {
 			if err != nil {
 				t.Fatalf("prepare candidate: %v", err)
 			}
-			if test.coordinated {
+			if test.multiSource {
 				observations := factory.runtime(candidateID).SourceObservations()
-				if len(observations) != 2 || !strings.HasPrefix(filepath.Base(candidateRoot), "version-") {
-					t.Fatalf("coordinated candidate observations=%d prefix=%q", len(observations), filepath.Base(candidateRoot))
+				if len(observations) != 2 {
+					t.Fatalf("multi-source candidate observations=%d, want 2", len(observations))
 				}
+			}
+			if test.immutablePrefix && !strings.HasPrefix(filepath.Base(candidateRoot), "version-") {
+				t.Fatalf("immutable candidate prefix=%q", filepath.Base(candidateRoot))
 			}
 			activationErr := registry.ActivatePrepared(prepared, func() error {
 				if err := qualifyWarehouseBoundary(t.Context(), factory.runtime(candidateID), warehouseBoundaryModel(factory.specs[candidateID]), candidateID); err != nil {
@@ -366,7 +373,7 @@ func warehouseBoundaryModel(spec warehouseBoundarySpec) *semanticmodel.Model {
 			"revenue": {Type: "aggregate", Dataset: "orders", Aggregation: "sum", Input: &semanticmodel.MetricInput{Field: "orders.revenue"}, Empty: "zero", Label: "Revenue"},
 		},
 	}
-	if spec.coordinated {
+	if spec.multiSource {
 		model.Sources["customers"] = semanticmodel.Source{
 			Connection: "warehouse", Path: "customers.parquet", Format: "parquet", SchemaMode: "strict",
 			Fields:                map[string]semanticmodel.SourceField{"customer_id": {Datatype: semanticmodel.DataTypeString}, "region": {Datatype: semanticmodel.DataTypeString}},
@@ -387,10 +394,21 @@ func warehouseBoundaryParquetLocation(path string) *projectcontracts.PathSourceL
 	return &projectcontracts.PathSourceLocation{Value: &projectcontracts.ParquetPathSourceLocation{PathSourceLocationBase: base, Format: "parquet", Options: projectcontracts.DefaultParquetReaderOptions()}}
 }
 
-func writeWarehouseBoundaryPublication(t *testing.T, root, kind string, coordinated bool) {
+func writeWarehouseBoundaryPublication(t *testing.T, root, kind string, multiSource bool) {
 	t.Helper()
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatal(err)
+	}
+	if kind == "metadata_only" {
+		for name, contents := range map[string]string{
+			"manifest.json":    `{"nodes":{"model.warehouse.orders":{"resource_type":"model"}}}`,
+			"run_results.json": `{"results":[{"unique_id":"model.warehouse.orders","status":"success"}]}`,
+		} {
+			if err := os.WriteFile(filepath.Join(root, name), []byte(contents), 0o600); err != nil {
+				t.Fatalf("write metadata-only %s: %v", name, err)
+			}
+		}
+		return
 	}
 	if kind == "malformed" {
 		if err := os.WriteFile(filepath.Join(root, "orders.parquet"), []byte("not parquet"), 0o600); err != nil {
@@ -423,11 +441,15 @@ func writeWarehouseBoundaryPublication(t *testing.T, root, kind string, coordina
 		rows = fmt.Sprintf("('o1', 'c1', %s), ('o2', 'c2', %s)", updatedAt, updatedAt)
 		columns = "order_id, customer_id, updated_at"
 	}
+	if kind == "unexpected_column" {
+		rows = fmt.Sprintf("('o1', 'c1', %s, %s, 'source-only'), ('o2', 'c2', CAST(20 AS DOUBLE), %s, 'source-only-2')", revenue, updatedAt, updatedAt)
+		columns = "order_id, customer_id, revenue, updated_at, unexpected"
+	}
 	statement := fmt.Sprintf("COPY (SELECT * FROM (VALUES %s) AS orders(%s)) TO '%s' (FORMAT PARQUET)", rows, columns, analyticsduckdb.SQLString(filepath.Join(root, "orders.parquet")))
 	if _, err := db.Exec(statement); err != nil {
 		t.Fatal(err)
 	}
-	if coordinated && kind != "partial" {
+	if multiSource && kind != "partial" {
 		customers := fmt.Sprintf("COPY (SELECT * FROM (VALUES ('c1', 'north'), ('c2', 'south')) AS customers(customer_id, region)) TO '%s' (FORMAT PARQUET)", analyticsduckdb.SQLString(filepath.Join(root, "customers.parquet")))
 		if _, err := db.Exec(customers); err != nil {
 			t.Fatal(err)
@@ -444,7 +466,7 @@ func writeWarehouseBoundaryPublication(t *testing.T, root, kind string, coordina
 		}
 	}
 	sort.Strings(files)
-	if coordinated && kind != "partial" && strings.Join(files, ",") != "customers.parquet,orders.parquet" {
-		t.Fatalf("coordinated publication contains %v", files)
+	if multiSource && kind != "partial" && strings.Join(files, ",") != "customers.parquet,orders.parquet" {
+		t.Fatalf("multi-source publication contains %v", files)
 	}
 }

--- a/internal/app/warehouse_boundary_qualification_integration_test.go
+++ b/internal/app/warehouse_boundary_qualification_integration_test.go
@@ -1,0 +1,450 @@
+//go:build duckdb_arrow
+
+package app
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	analyticsduckdb "github.com/flidai/leapview/internal/analytics/duckdb"
+	analyticsducklake "github.com/flidai/leapview/internal/analytics/ducklake"
+	analyticsgates "github.com/flidai/leapview/internal/analytics/gates"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	projectcontracts "github.com/flidai/leapview/internal/project/contracts"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/internal/runtimehost"
+	"github.com/flidai/leapview/internal/servingstate"
+	"github.com/flidai/leapview/internal/workload"
+)
+
+var warehouseBoundaryNow = time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+type warehouseBoundarySpec struct {
+	root        string
+	coordinated bool
+	freshness   bool
+}
+
+type warehouseBoundaryRuntime struct {
+	*analyticsduckdb.ProjectRuntime
+	database      *analyticsducklake.Environment
+	controller    *workload.Controller
+	authorization accesssnapshot.AuthorizationSnapshot
+	closeOnce     sync.Once
+	closeErr      error
+}
+
+func (r *warehouseBoundaryRuntime) AuthorizationSnapshot() accesssnapshot.AuthorizationSnapshot {
+	return r.authorization
+}
+
+func (r *warehouseBoundaryRuntime) Verify(ctx context.Context) error {
+	return r.VerifySemantic(ctx, "warehouse")
+}
+
+func (r *warehouseBoundaryRuntime) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		r.closeErr = errors.Join(r.ProjectRuntime.Close(), r.database.Close())
+		r.controller.Close()
+	})
+	return r.closeErr
+}
+
+type warehouseBoundaryFactory struct {
+	admission testExactExtensionAdmission
+	specs     map[servingstate.ID]warehouseBoundarySpec
+	mu        sync.Mutex
+	runtimes  map[servingstate.ID]*warehouseBoundaryRuntime
+}
+
+func (f *warehouseBoundaryFactory) Prepare(ctx context.Context, input runtimehost.RuntimeInput) (runtimehost.PreparedRuntime, error) {
+	spec, ok := f.specs[input.State.ID]
+	if !ok {
+		return nil, fmt.Errorf("warehouse-boundary specification is missing for %s", input.State.ID)
+	}
+	database, err := analyticsducklake.Open(ctx, analyticsducklake.Config{
+		RootDir: filepath.Join(spec.root, ".ducklake"), MaxConnections: 2, ExtensionAdmission: f.admission,
+	})
+	if err != nil {
+		return nil, err
+	}
+	controller, err := workload.New(workload.DefaultConfig())
+	if err != nil {
+		_ = database.Close()
+		return nil, err
+	}
+	lease, err := controller.Acquire(ctx, workload.Request{
+		Class: workload.Refresh, PrincipalID: "warehouse-boundary", Operation: "candidate.build", EstimatedMemoryBytes: 1,
+	})
+	if err != nil {
+		controller.Close()
+		_ = database.Close()
+		return nil, err
+	}
+	model := warehouseBoundaryModel(spec)
+	projectRuntime, err := analyticsduckdb.OpenProjectMaterializeRuntime(lease.Context(), analyticsduckdb.ProjectRuntimeConfig{
+		Models: map[string]*semanticmodel.Model{"warehouse": model}, Database: database,
+		ExtensionAdmission: f.admission, ProjectID: input.State.ProjectID, Environment: string(input.State.Environment),
+	})
+	lease.Release()
+	if err != nil {
+		controller.Close()
+		_ = database.Close()
+		return nil, err
+	}
+	identity, err := projectgraph.NewServingIdentity(input.State.ProjectID, string(input.State.Environment), string(input.State.ID))
+	if err != nil {
+		_ = projectRuntime.Close()
+		controller.Close()
+		_ = database.Close()
+		return nil, err
+	}
+	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{{ID: input.State.ProjectID, Kind: projectgraph.KindProject, Name: "warehouse-boundary"}}, nil)
+	if err != nil {
+		_ = projectRuntime.Close()
+		controller.Close()
+		_ = database.Close()
+		return nil, err
+	}
+	authorization, err := accesssnapshot.NewAuthorizationSnapshot(identity, graph, nil, nil)
+	if err != nil {
+		_ = projectRuntime.Close()
+		controller.Close()
+		_ = database.Close()
+		return nil, err
+	}
+	runtime := &warehouseBoundaryRuntime{ProjectRuntime: projectRuntime, database: database, controller: controller, authorization: authorization}
+	f.mu.Lock()
+	if f.runtimes == nil {
+		f.runtimes = map[servingstate.ID]*warehouseBoundaryRuntime{}
+	}
+	f.runtimes[input.State.ID] = runtime
+	f.mu.Unlock()
+	return runtime, nil
+}
+
+func (f *warehouseBoundaryFactory) runtime(id servingstate.ID) *warehouseBoundaryRuntime {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.runtimes[id]
+}
+
+type warehouseBoundaryRepo struct {
+	active    servingstate.ID
+	states    map[servingstate.ID]servingstate.State
+	artifacts map[servingstate.ID]servingstate.Artifact
+}
+
+func (r *warehouseBoundaryRepo) ActiveArtifact(context.Context, projectgraph.ResourceID, servingstate.Environment) (servingstate.State, servingstate.Artifact, error) {
+	state, ok := r.states[r.active]
+	if !ok {
+		return servingstate.State{}, servingstate.Artifact{}, servingstate.ErrNotFound
+	}
+	return state, r.artifacts[state.ID], nil
+}
+
+func (r *warehouseBoundaryRepo) ByID(_ context.Context, id servingstate.ID) (servingstate.State, error) {
+	state, ok := r.states[id]
+	if !ok {
+		return servingstate.State{}, servingstate.ErrNotFound
+	}
+	return state, nil
+}
+
+func (r *warehouseBoundaryRepo) ArtifactByServingState(_ context.Context, id servingstate.ID) (servingstate.Artifact, error) {
+	artifact, ok := r.artifacts[id]
+	if !ok {
+		return servingstate.Artifact{}, servingstate.ErrNotFound
+	}
+	return artifact, nil
+}
+
+func (*warehouseBoundaryRepo) RecordDuckLakeSnapshot(context.Context, servingstate.ID, int64) error {
+	return nil
+}
+
+type warehouseBoundaryAuthorization struct{}
+
+func (warehouseBoundaryAuthorization) InstallAuthorizationSnapshot(context.Context, accesssnapshot.AuthorizationSnapshot) error {
+	return nil
+}
+
+func TestProducerNeutralWarehouseBoundaryQualification(t *testing.T) {
+	admission := newTestExactExtensionAdmission(t, "ducklake")
+	tests := []struct {
+		name               string
+		publication        string
+		coordinated        bool
+		freshness          bool
+		prepareFails       bool
+		qualificationFails bool
+		activationFails    bool
+	}{
+		{name: "compatible physical Parquet activates atomically", publication: "compatible"},
+		{name: "complete immutable multi-mart prefix activates atomically", publication: "compatible", coordinated: true},
+		{name: "incompatible physical type is blocked", publication: "incompatible_schema", prepareFails: true},
+		{name: "removed physical field is blocked", publication: "missing_column", prepareFails: true},
+		{name: "stale freshness is blocked", publication: "stale", freshness: true, qualificationFails: true},
+		{name: "invalid grain is blocked", publication: "duplicate_grain", qualificationFails: true},
+		{name: "failed Model check is blocked", publication: "failed_check", qualificationFails: true},
+		{name: "malformed Parquet is blocked", publication: "malformed", prepareFails: true},
+		{name: "partial coordinated publication is blocked", publication: "partial", coordinated: true, prepareFails: true},
+		{name: "activation failure preserves the old generation", publication: "compatible", activationFails: true},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			baseRoot := filepath.Join(t.TempDir(), "ordinary-current")
+			writeWarehouseBoundaryPublication(t, baseRoot, "compatible", false)
+			candidatePrefix := "ordinary-next"
+			if test.coordinated {
+				candidatePrefix = "version-2026-09-04T120000Z"
+			}
+			candidateRoot := filepath.Join(t.TempDir(), candidatePrefix)
+			writeWarehouseBoundaryPublication(t, candidateRoot, test.publication, test.coordinated)
+
+			baseID := servingstate.ID(fmt.Sprintf("generation_base_%d", index))
+			candidateID := servingstate.ID(fmt.Sprintf("generation_candidate_%d", index))
+			baseDigest := "sha256:" + strings.Repeat("a", 64)
+			candidateDigest := fmt.Sprintf("sha256:%064x", index+11)
+			states := map[servingstate.ID]servingstate.State{
+				baseID:      {ID: baseID, ProjectID: "project:warehouse-boundary", Environment: "test", Status: servingstate.StatusValidated, Digest: baseDigest},
+				candidateID: {ID: candidateID, ProjectID: "project:warehouse-boundary", Environment: "test", Status: servingstate.StatusValidated, Digest: candidateDigest},
+			}
+			artifacts := map[servingstate.ID]servingstate.Artifact{
+				baseID:      {ID: "artifact_" + string(baseID), ServingStateID: baseID, Digest: baseDigest},
+				candidateID: {ID: "artifact_" + string(candidateID), ServingStateID: candidateID, Digest: candidateDigest},
+			}
+			repo := &warehouseBoundaryRepo{active: baseID, states: states, artifacts: artifacts}
+			factory := &warehouseBoundaryFactory{admission: admission, specs: map[servingstate.ID]warehouseBoundarySpec{
+				baseID: {root: baseRoot}, candidateID: {root: candidateRoot, coordinated: test.coordinated, freshness: test.freshness},
+			}}
+			registry := runtimehost.NewRegistryWithFactory(runtimehost.RegistryOptions{
+				Repo: repo, ProjectID: "project:warehouse-boundary", Environment: "test", Factory: factory, Authorization: warehouseBoundaryAuthorization{},
+			})
+			defer registry.Close()
+
+			base, err := registry.PrepareServingState(t.Context(), string(baseID))
+			if err != nil {
+				t.Fatalf("prepare base generation: %v", err)
+			}
+			if err := registry.ActivatePrepared(base, func() error {
+				return qualifyWarehouseBoundary(t.Context(), factory.runtime(baseID), warehouseBoundaryModel(factory.specs[baseID]), baseID)
+			}); err != nil {
+				t.Fatalf("activate base generation: %v", err)
+			}
+
+			prepared, err := registry.PrepareServingState(t.Context(), string(candidateID))
+			if test.prepareFails {
+				if err == nil {
+					_ = prepared.Close()
+					t.Fatal("candidate preparation unexpectedly succeeded")
+				}
+				assertWarehouseBoundaryGeneration(t, registry, baseID)
+				return
+			}
+			if err != nil {
+				t.Fatalf("prepare candidate: %v", err)
+			}
+			if test.coordinated {
+				observations := factory.runtime(candidateID).SourceObservations()
+				if len(observations) != 2 || !strings.HasPrefix(filepath.Base(candidateRoot), "version-") {
+					t.Fatalf("coordinated candidate observations=%d prefix=%q", len(observations), filepath.Base(candidateRoot))
+				}
+			}
+			activationErr := registry.ActivatePrepared(prepared, func() error {
+				if err := qualifyWarehouseBoundary(t.Context(), factory.runtime(candidateID), warehouseBoundaryModel(factory.specs[candidateID]), candidateID); err != nil {
+					return err
+				}
+				if test.activationFails {
+					return errors.New("injected durable activation failure")
+				}
+				return nil
+			})
+			if test.qualificationFails || test.activationFails {
+				if activationErr == nil {
+					t.Fatal("blocking candidate unexpectedly activated")
+				}
+				assertWarehouseBoundaryGeneration(t, registry, baseID)
+				return
+			}
+			if activationErr != nil {
+				t.Fatalf("activate compatible candidate: %v", activationErr)
+			}
+			assertWarehouseBoundaryGeneration(t, registry, candidateID)
+		})
+	}
+}
+
+func qualifyWarehouseBoundary(ctx context.Context, runtime *warehouseBoundaryRuntime, model *semanticmodel.Model, candidateID servingstate.ID) error {
+	if runtime == nil {
+		return errors.New("candidate runtime is unavailable")
+	}
+	input := analyticsgates.Input{
+		CandidateID: string(candidateID), SourceDigest: "sha256:" + strings.Repeat("c", 64),
+		BindingGeneration: "sha256:" + strings.Repeat("d", 64), RuntimeVersion: "test-runtime", DuckDBVersion: "test-duckdb",
+		Now: warehouseBoundaryNow, Bounds: analyticsgates.Bounds{MaxRows: 1000, MaxQueries: 64, MaxMillis: 5000}, Query: runtime.database.Query,
+	}
+	for _, observation := range runtime.SourceObservations() {
+		source, ok := model.Sources[observation.ID]
+		if !ok {
+			return fmt.Errorf("unknown source observation %q", observation.ID)
+		}
+		input.Sources = append(input.Sources, analyticsgates.SourceInput{
+			ID: observation.ID, Source: source, Relation: observation.ID, Observed: observation.Schema,
+			Revision: observation.Revision, RevisionObserved: observation.RevisionObserved,
+			FreshnessObserved: observation.FreshnessObserved, FreshnessEmpty: observation.FreshnessEmpty,
+			SchemaFailure: observation.SchemaFailure, FreshnessFailure: observation.FreshnessFailure,
+			ObservationQueries: observation.ObservationQueries, ObservationRows: observation.ObservationRows, ObservationMillis: observation.ObservationMillis,
+		})
+		input.PreflightQueries += observation.ObservationQueries
+		input.PreflightRows += observation.ObservationRows
+		input.PreflightMillis += observation.ObservationMillis
+	}
+	for id, table := range model.Tables {
+		input.Models = append(input.Models, analyticsgates.ModelInput{ID: id, Model: table})
+	}
+	_, err := analyticsgates.Evaluate(ctx, input)
+	return err
+}
+
+func assertWarehouseBoundaryGeneration(t *testing.T, registry *runtimehost.Registry, want servingstate.ID) {
+	t.Helper()
+	lease, err := registry.Acquire(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Release()
+	if got := servingstate.ID(lease.Identity().GenerationID); got != want {
+		t.Fatalf("active generation = %s, want %s", got, want)
+	}
+}
+
+func warehouseBoundaryModel(spec warehouseBoundarySpec) *semanticmodel.Model {
+	ordersFields := map[string]semanticmodel.SourceField{
+		"order_id": {Datatype: semanticmodel.DataTypeString}, "customer_id": {Datatype: semanticmodel.DataTypeString},
+		"revenue": {Datatype: semanticmodel.DataTypeFloat}, "updated_at": {Datatype: semanticmodel.DataTypeDateTime},
+	}
+	orders := semanticmodel.Source{
+		Connection: "warehouse", Path: "orders.parquet", Format: "parquet", SchemaMode: "strict", Fields: ordersFields,
+		EffectivePathLocation: warehouseBoundaryParquetLocation("orders.parquet"),
+	}
+	if spec.freshness {
+		orders.Freshness = &semanticmodel.SourceFreshnessSpec{Basis: "field", Field: "updated_at", ErrorAfter: &semanticmodel.FreshnessDurationSpec{Amount: 1, Unit: "hour"}}
+	}
+	model := &semanticmodel.Model{
+		Name: "warehouse", DefaultConnection: "warehouse",
+		Connections: map[string]semanticmodel.Connection{"warehouse": {Kind: "managed", Root: spec.root}},
+		Sources:     map[string]semanticmodel.Source{"orders": orders},
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				Execution: semanticmodel.ExecutionDefinition{Source: "orders"}, ModelName: "orders",
+				Entities: map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"order_id"}}}, GrainEntity: "order",
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"order_id": {Datatype: semanticmodel.DataTypeString}, "customer_id": {Datatype: semanticmodel.DataTypeString},
+					"revenue": {Type: "number", Datatype: semanticmodel.DataTypeFloat}, "updated_at": {Type: "timestamp", Datatype: semanticmodel.DataTypeDateTime},
+				},
+				Checks: []semanticmodel.ModelCheck{{Type: "non_null", Field: "revenue", Severity: "error"}},
+			},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		Metrics: map[string]semanticmodel.Metric{
+			"revenue": {Type: "aggregate", Dataset: "orders", Aggregation: "sum", Input: &semanticmodel.MetricInput{Field: "orders.revenue"}, Empty: "zero", Label: "Revenue"},
+		},
+	}
+	if spec.coordinated {
+		model.Sources["customers"] = semanticmodel.Source{
+			Connection: "warehouse", Path: "customers.parquet", Format: "parquet", SchemaMode: "strict",
+			Fields:                map[string]semanticmodel.SourceField{"customer_id": {Datatype: semanticmodel.DataTypeString}, "region": {Datatype: semanticmodel.DataTypeString}},
+			EffectivePathLocation: warehouseBoundaryParquetLocation("customers.parquet"),
+		}
+		model.Tables["customers"] = semanticmodel.Table{
+			Execution: semanticmodel.ExecutionDefinition{Source: "customers"}, ModelName: "customers",
+			Entities: map[string]semanticmodel.EntityDefinition{"customer": {Type: "primary", Fields: []string{"customer_id"}}}, GrainEntity: "customer",
+			Dimensions: map[string]semanticmodel.MetricDimension{"customer_id": {Datatype: semanticmodel.DataTypeString}, "region": {Datatype: semanticmodel.DataTypeString}},
+		}
+		model.Datasets["customers"] = semanticmodel.SemanticDatasetSpec{Model: "customers"}
+	}
+	return model
+}
+
+func warehouseBoundaryParquetLocation(path string) *projectcontracts.PathSourceLocation {
+	base := projectcontracts.PathSourceLocationBase{Type: "path", Path: path, Format: "parquet"}
+	return &projectcontracts.PathSourceLocation{Value: &projectcontracts.ParquetPathSourceLocation{PathSourceLocationBase: base, Format: "parquet", Options: projectcontracts.DefaultParquetReaderOptions()}}
+}
+
+func writeWarehouseBoundaryPublication(t *testing.T, root, kind string, coordinated bool) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if kind == "malformed" {
+		if err := os.WriteFile(filepath.Join(root, "orders.parquet"), []byte("not parquet"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	updatedAt := "TIMESTAMP '2026-09-04 11:59:00'"
+	if kind == "stale" {
+		updatedAt = "TIMESTAMP '2026-09-01 00:00:00'"
+	}
+	revenue := "CAST(10 AS DOUBLE)"
+	if kind == "incompatible_schema" {
+		revenue = "CAST('ten' AS VARCHAR)"
+	}
+	rows := fmt.Sprintf("('o1', 'c1', %s, %s), ('o2', 'c2', CAST(20 AS %s), %s)", revenue, updatedAt, map[bool]string{true: "VARCHAR", false: "DOUBLE"}[kind == "incompatible_schema"], updatedAt)
+	if kind == "duplicate_grain" {
+		rows = fmt.Sprintf("('o1', 'c1', CAST(10 AS DOUBLE), %s), ('o1', 'c2', CAST(20 AS DOUBLE), %s)", updatedAt, updatedAt)
+	}
+	if kind == "failed_check" {
+		rows = fmt.Sprintf("('o1', 'c1', CAST(NULL AS DOUBLE), %s), ('o2', 'c2', CAST(20 AS DOUBLE), %s)", updatedAt, updatedAt)
+	}
+	columns := "order_id, customer_id, revenue, updated_at"
+	if kind == "missing_column" {
+		rows = fmt.Sprintf("('o1', 'c1', %s), ('o2', 'c2', %s)", updatedAt, updatedAt)
+		columns = "order_id, customer_id, updated_at"
+	}
+	statement := fmt.Sprintf("COPY (SELECT * FROM (VALUES %s) AS orders(%s)) TO '%s' (FORMAT PARQUET)", rows, columns, analyticsduckdb.SQLString(filepath.Join(root, "orders.parquet")))
+	if _, err := db.Exec(statement); err != nil {
+		t.Fatal(err)
+	}
+	if coordinated && kind != "partial" {
+		customers := fmt.Sprintf("COPY (SELECT * FROM (VALUES ('c1', 'north'), ('c2', 'south')) AS customers(customer_id, region)) TO '%s' (FORMAT PARQUET)", analyticsduckdb.SQLString(filepath.Join(root, "customers.parquet")))
+		if _, err := db.Exec(customers); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var files []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			files = append(files, entry.Name())
+		}
+	}
+	sort.Strings(files)
+	if coordinated && kind != "partial" && strings.Join(files, ",") != "customers.parquet,orders.parquet" {
+		t.Fatalf("coordinated publication contains %v", files)
+	}
+}

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2953,8 +2953,6 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"name: Frontend tests (PR)",
 		"spatial-tile-benchmarks:",
 		"name: Spatial tile benchmarks (PR)",
-		"dbt-warehouse-boundary-validation:",
-		"name: dbt physical contract (PR)",
 		"runs-on: ubuntu-24.04",
 		"uses: ./.github/actions/setup-ci",
 		"run: node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare",
@@ -2965,13 +2963,12 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"run: task generated:check",
 		"ci-gate:",
 		"name: CI gate",
-		"needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, spatial-tile-benchmarks, dbt-warehouse-boundary-validation]",
+		"needs: [apigen-validation,",
 		"APIGEN_RESULT: ${{ needs.apigen-validation.result }}",
 		"GO_PACKAGES_RESULT: ${{ needs.go-packages-validation.result }}",
 		"GO_APPLICATION_RESULT: ${{ needs.go-application-validation.result }}",
 		"FRONTEND_RESULT: ${{ needs.frontend-validation.result }}",
 		"SPATIAL_BENCHMARK_RESULT: ${{ needs.spatial-tile-benchmarks.result }}",
-		"DBT_WAREHOUSE_RESULT: ${{ needs.dbt-warehouse-boundary-validation.result }}",
 		"Validation is deferred to the top of this stack.",
 	} {
 		if !strings.Contains(text, want) {
@@ -2982,13 +2979,11 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	goPackagesCI := workflowJobBlock(t, text, "go-packages-validation")
 	goApplicationCI := workflowJobBlock(t, text, "go-application-validation")
 	frontendCI := workflowJobBlock(t, text, "frontend-validation")
-	dbtWarehouseCI := workflowJobBlock(t, text, "dbt-warehouse-boundary-validation")
 	for name, block := range map[string]string{
 		"apigen-validation":         apigenCI,
 		"go-packages-validation":    goPackagesCI,
 		"go-application-validation": goApplicationCI,
 		"frontend-validation":       frontendCI,
-		"dbt-warehouse-boundary":    dbtWarehouseCI,
 	} {
 		for _, want := range []string{
 			"github.event_name == 'workflow_dispatch'",

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2953,6 +2953,8 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"name: Frontend tests (PR)",
 		"spatial-tile-benchmarks:",
 		"name: Spatial tile benchmarks (PR)",
+		"dbt-warehouse-boundary-validation:",
+		"name: dbt physical contract (PR)",
 		"runs-on: ubuntu-24.04",
 		"uses: ./.github/actions/setup-ci",
 		"run: node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare",
@@ -2963,12 +2965,13 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"run: task generated:check",
 		"ci-gate:",
 		"name: CI gate",
-		"needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, spatial-tile-benchmarks]",
+		"needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, spatial-tile-benchmarks, dbt-warehouse-boundary-validation]",
 		"APIGEN_RESULT: ${{ needs.apigen-validation.result }}",
 		"GO_PACKAGES_RESULT: ${{ needs.go-packages-validation.result }}",
 		"GO_APPLICATION_RESULT: ${{ needs.go-application-validation.result }}",
 		"FRONTEND_RESULT: ${{ needs.frontend-validation.result }}",
 		"SPATIAL_BENCHMARK_RESULT: ${{ needs.spatial-tile-benchmarks.result }}",
+		"DBT_WAREHOUSE_RESULT: ${{ needs.dbt-warehouse-boundary-validation.result }}",
 		"Validation is deferred to the top of this stack.",
 	} {
 		if !strings.Contains(text, want) {
@@ -2979,11 +2982,13 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	goPackagesCI := workflowJobBlock(t, text, "go-packages-validation")
 	goApplicationCI := workflowJobBlock(t, text, "go-application-validation")
 	frontendCI := workflowJobBlock(t, text, "frontend-validation")
+	dbtWarehouseCI := workflowJobBlock(t, text, "dbt-warehouse-boundary-validation")
 	for name, block := range map[string]string{
 		"apigen-validation":         apigenCI,
 		"go-packages-validation":    goPackagesCI,
 		"go-application-validation": goApplicationCI,
 		"frontend-validation":       frontendCI,
+		"dbt-warehouse-boundary":    dbtWarehouseCI,
 	} {
 		for _, want := range []string{
 			"github.event_name == 'workflow_dispatch'",

--- a/internal/platform/architecture/dbt_boundary_test.go
+++ b/internal/platform/architecture/dbt_boundary_test.go
@@ -464,6 +464,35 @@ func TestDBTWarehouseBoundaryWorkflowIsRequiredByCIGate(t *testing.T) {
 	t.Fatal("CI gate does not wire DBT_WAREHOUSE_RESULT from the dbt validation job")
 }
 
+func TestDBTWarehouseBoundaryCIJobUsesTheTieredWorkflow(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read CI workflow: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"dbt-warehouse-boundary-validation:",
+		"name: dbt physical contract (PR)",
+		"needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, spatial-tile-benchmarks, dbt-warehouse-boundary-validation]",
+		"DBT_WAREHOUSE_RESULT: ${{ needs.dbt-warehouse-boundary-validation.result }}",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("CI workflow missing dbt validation fragment %q", want)
+		}
+	}
+	dbtWarehouseCI := workflowJobBlock(t, text, "dbt-warehouse-boundary-validation")
+	for _, want := range []string{
+		"github.event_name == 'workflow_dispatch'",
+		"github.event.pull_request.stack == null",
+		"github.event.pull_request.stack.position == github.event.pull_request.stack.size",
+	} {
+		if !strings.Contains(dbtWarehouseCI, want) {
+			t.Fatalf("dbt validation job is not limited to standalone pull requests and stack tips: missing %q", want)
+		}
+	}
+}
+
 func readDBTBoundaryWorkflow(t *testing.T, path string) dbtBoundaryWorkflow {
 	t.Helper()
 	body, err := os.ReadFile(path)

--- a/internal/platform/architecture/dbt_boundary_test.go
+++ b/internal/platform/architecture/dbt_boundary_test.go
@@ -132,6 +132,38 @@ func TestDBTWarehouseBoundaryDoesNotEnterLeapViewRuntime(t *testing.T) {
 	}
 }
 
+func TestDBTWarehouseBoundaryTasksSequencePrerequisites(t *testing.T) {
+	root := repoRoot(t)
+	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	if err != nil {
+		t.Fatalf("read Taskfile.yml: %v", err)
+	}
+
+	for _, task := range []string{"dbt:warehouse:qualify", "dbt:warehouse"} {
+		block := taskfileTaskBlock(t, string(taskfile), task)
+		if strings.Contains(block, "\n    deps:") {
+			t.Fatalf("%s must sequence prerequisites in cmds so generation cannot race build", task)
+		}
+
+		previous := -1
+		for _, command := range []string{
+			"      - task: generate",
+			"      - task: build",
+			"      - task: map-assets:install",
+			"      - task: dbt:warehouse:build",
+		} {
+			index := strings.Index(block, command)
+			if index < 0 {
+				t.Fatalf("%s is missing ordered prerequisite %q", task, command)
+			}
+			if index <= previous {
+				t.Fatalf("%s runs prerequisite %q out of order", task, command)
+			}
+			previous = index
+		}
+	}
+}
+
 func isDBTModulePath(path string) bool {
 	return isDBTText(path)
 }

--- a/internal/platform/architecture/dbt_boundary_test.go
+++ b/internal/platform/architecture/dbt_boundary_test.go
@@ -1,0 +1,129 @@
+package architecture
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDBTWarehouseBoundaryDoesNotEnterLeapViewRuntime(t *testing.T) {
+	root := repoRoot(t)
+	for _, relative := range []string{"go.mod", "go.sum"} {
+		body, err := os.ReadFile(filepath.Join(root, relative))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(string(body), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) > 0 && strings.Contains(strings.ToLower(fields[0]), "dbt") {
+				t.Errorf("%s contains a dbt module dependency: %s", relative, line)
+			}
+		}
+	}
+
+	dockerfile, err := os.ReadFile(filepath.Join(root, "Dockerfile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := string(dockerfile)
+	marker := " AS runtime\n"
+	if index := strings.Index(runtime, marker); index >= 0 {
+		runtime = runtime[index+len(marker):]
+	} else {
+		t.Fatal("Dockerfile has no runtime stage")
+	}
+	for _, forbidden := range []string{"dbt-core", "dbt-duckdb", "python", "manifest.json", "run_results.json"} {
+		if strings.Contains(strings.ToLower(runtime), forbidden) {
+			t.Errorf("runtime image contains dbt-side dependency %q", forbidden)
+		}
+	}
+
+	leapviewBundle := filepath.Join(root, "examples/dbt-warehouse-boundary/leapview")
+	err = filepath.Walk(leapviewBundle, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info == nil || info.IsDir() {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for _, forbidden := range []string{"manifest.json", "run_results.json", "profiles.yml", "dbt_project.yml"} {
+			if strings.Contains(strings.ToLower(string(body)), forbidden) {
+				t.Errorf("LeapView serving bundle %s depends on %q", path, forbidden)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDBTWarehouseBoundaryWorkflowPublishesBeforeLeapView(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, ".github/workflows/dbt-warehouse-boundary-reference.yml")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(body)
+
+	ordered := []string{
+		"Set up pinned Python",
+		"Install pinned dbt Core",
+		"Install pinned dbt-duckdb",
+		"Read the bounded producer inputs",
+		"Run dbt build and verify physical Parquet",
+		"Select a new immutable publication prefix",
+		"Upload the complete selected mart set",
+		"Verify the exact published mart set",
+		"Qualify the physical publication through LeapView",
+	}
+	previous := -1
+	for _, step := range ordered {
+		index := strings.Index(workflow, step)
+		if index < 0 {
+			t.Fatalf("reference workflow is missing %q", step)
+		}
+		if index <= previous {
+			t.Fatalf("reference workflow step %q is out of order", step)
+		}
+		previous = index
+	}
+
+	for _, required := range []string{
+		"--overwrite false", "length(@)", "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_SHA}",
+		"AZURE_CORE_OUTPUT: none", "LEAPVIEW_WORKLOAD_CLIENT_ID", "type: azure_blob",
+		"dev --once --no-browser", ".candidateId", "publish \"$candidate_id\" --format json",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Errorf("reference workflow is missing fail-closed boundary %q", required)
+		}
+	}
+	for _, forbidden := range []string{"manifest.json", "run_results.json", "dbt parse", "dbt ls"} {
+		if strings.Contains(strings.ToLower(workflow), forbidden) {
+			t.Errorf("reference workflow treats dbt metadata as authority through %q", forbidden)
+		}
+	}
+}
+
+func TestDBTExampleUsesExternalNonIncrementalMarts(t *testing.T) {
+	root := repoRoot(t)
+	project, err := os.ReadFile(filepath.Join(root, "examples/dbt-warehouse-boundary/dbt/dbt_project.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(project)
+	for _, required := range []string{"+materialized: external", "+format: parquet", "clean-targets:"} {
+		if !strings.Contains(text, required) {
+			t.Errorf("dbt project is missing external publication contract %q", required)
+		}
+	}
+	if strings.Contains(strings.ToLower(text), "incremental") {
+		t.Error("dbt reference marts must remain non-incremental")
+	}
+}

--- a/internal/platform/architecture/dbt_boundary_test.go
+++ b/internal/platform/architecture/dbt_boundary_test.go
@@ -1,25 +1,94 @@
 package architecture
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"golang.org/x/mod/modfile"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDBTWarehouseBoundaryDoesNotEnterLeapViewRuntime(t *testing.T) {
 	root := repoRoot(t)
-	for _, relative := range []string{"go.mod", "go.sum"} {
-		body, err := os.ReadFile(filepath.Join(root, relative))
-		if err != nil {
-			t.Fatal(err)
+	goModPath := filepath.Join(root, "go.mod")
+	goModBody, err := os.ReadFile(goModPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goMod, err := modfile.Parse(goModPath, goModBody, nil)
+	if err != nil {
+		t.Fatalf("parse go.mod: %v", err)
+	}
+	for _, required := range goMod.Require {
+		if isDBTModulePath(required.Mod.Path) {
+			t.Errorf("go.mod requires dbt module %q", required.Mod.Path)
 		}
-		for _, line := range strings.Split(string(body), "\n") {
-			fields := strings.Fields(line)
-			if len(fields) > 0 && strings.Contains(strings.ToLower(fields[0]), "dbt") {
-				t.Errorf("%s contains a dbt module dependency: %s", relative, line)
+	}
+	for _, replaced := range goMod.Replace {
+		for _, modulePath := range []string{replaced.Old.Path, replaced.New.Path} {
+			if isDBTModulePath(modulePath) {
+				t.Errorf("go.mod replaces dbt module with %q", modulePath)
 			}
 		}
+	}
+	for _, excluded := range goMod.Exclude {
+		if isDBTModulePath(excluded.Mod.Path) {
+			t.Errorf("go.mod excludes dbt module %q", excluded.Mod.Path)
+		}
+	}
+
+	goSumPath := filepath.Join(root, "go.sum")
+	goSumBody, err := os.ReadFile(goSumPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(goSumBody), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && isDBTModulePath(fields[0]) {
+			t.Errorf("go.sum contains a dbt module dependency: %s", line)
+		}
+	}
+
+	for _, file := range productionGoFiles(t) {
+		parsed, parseErr := parser.ParseFile(token.NewFileSet(), file.path, file.body, 0)
+		if parseErr != nil {
+			t.Fatalf("parse production Go file %s: %v", file.path, parseErr)
+		}
+		for _, imported := range parsed.Imports {
+			importPath, unquoteErr := strconv.Unquote(imported.Path.Value)
+			if unquoteErr != nil {
+				t.Fatalf("parse import path in %s: %v", file.path, unquoteErr)
+			}
+			if isDBTModulePath(importPath) {
+				t.Errorf("production Go file %s imports dbt-specific package %q", file.path, importPath)
+			}
+		}
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			switch node := node.(type) {
+			case *ast.Ident:
+				if isDBTIdentifier(node.Name) {
+					t.Errorf("production Go file %s uses dbt-specific identifier %q", file.path, node.Name)
+				}
+			case *ast.BasicLit:
+				if node.Kind != token.STRING {
+					return true
+				}
+				literal := node.Value
+				if value, unquoteErr := strconv.Unquote(literal); unquoteErr == nil {
+					literal = value
+				}
+				if isDBTText(literal) {
+					t.Errorf("production Go file %s contains dbt-specific string literal %q", file.path, literal)
+				}
+			}
+			return true
+		})
 	}
 
 	dockerfile, err := os.ReadFile(filepath.Join(root, "Dockerfile"))
@@ -63,16 +132,120 @@ func TestDBTWarehouseBoundaryDoesNotEnterLeapViewRuntime(t *testing.T) {
 	}
 }
 
+func isDBTModulePath(path string) bool {
+	return isDBTText(path)
+}
+
+func isDBTText(value string) bool {
+	lower := strings.ToLower(value)
+	for {
+		index := strings.Index(lower, "dbt")
+		if index < 0 {
+			return false
+		}
+		end := index + len("dbt")
+		beforeIsBoundary := index == 0 || !isASCIIAlphaNumeric(lower[index-1])
+		afterIsBoundary := end == len(lower) || !isASCIIAlphaNumeric(lower[end])
+		if beforeIsBoundary && afterIsBoundary {
+			return true
+		}
+		lower = lower[end:]
+	}
+}
+
+func isDBTIdentifier(identifier string) bool {
+	if identifier == "DBTX" {
+		return false
+	}
+	if isDBTText(identifier) {
+		return true
+	}
+	lower := strings.ToLower(identifier)
+	if !strings.HasPrefix(lower, "dbt") {
+		return false
+	}
+	suffix := identifier[len("dbt"):]
+	if suffix == "" {
+		return true
+	}
+	first := suffix[0]
+	return first == '_' || first == '-' || (first >= 'A' && first <= 'Z')
+}
+
+func isASCIIAlphaNumeric(value byte) bool {
+	return (value >= 'a' && value <= 'z') ||
+		(value >= 'A' && value <= 'Z') ||
+		(value >= '0' && value <= '9')
+}
+
+type dbtBoundaryWorkflow struct {
+	Permissions map[string]string         `yaml:"permissions"`
+	Env         map[string]string         `yaml:"env"`
+	Jobs        map[string]dbtBoundaryJob `yaml:"jobs"`
+}
+
+type dbtBoundaryJob struct {
+	If          string                    `yaml:"if"`
+	Environment string                    `yaml:"environment"`
+	Permissions map[string]string         `yaml:"permissions"`
+	Needs       []string                  `yaml:"needs"`
+	Outputs     map[string]string         `yaml:"outputs"`
+	Env         map[string]string         `yaml:"env"`
+	Steps       []dbtBoundaryWorkflowStep `yaml:"steps"`
+}
+
+type dbtBoundaryWorkflowStep struct {
+	ID   string                 `yaml:"id"`
+	Name string                 `yaml:"name"`
+	Uses string                 `yaml:"uses"`
+	Run  string                 `yaml:"run"`
+	Env  map[string]string      `yaml:"env"`
+	With map[string]interface{} `yaml:"with"`
+}
+
 func TestDBTWarehouseBoundaryWorkflowPublishesBeforeLeapView(t *testing.T) {
 	root := repoRoot(t)
-	path := filepath.Join(root, ".github/workflows/dbt-warehouse-boundary-reference.yml")
-	body, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
+	workflow := readDBTBoundaryWorkflow(t, filepath.Join(root, ".github/workflows/dbt-warehouse-boundary-reference.yml"))
+	producer, ok := workflow.Jobs["publish-dbt"]
+	if !ok {
+		t.Fatal("reference workflow is missing publish-dbt job")
 	}
-	workflow := string(body)
+	activation, ok := workflow.Jobs["activate-leapview"]
+	if !ok {
+		t.Fatal("reference workflow is missing activate-leapview job")
+	}
 
-	ordered := []string{
+	if workflow.Permissions["contents"] != "read" {
+		t.Fatalf("reference workflow top-level contents permission = %q, want read", workflow.Permissions["contents"])
+	}
+	if _, granted := workflow.Permissions["id-token"]; granted {
+		t.Fatal("reference workflow must not grant top-level id-token permission")
+	}
+	assertDBTBoundaryTrustedJob(t, "publish-dbt", producer)
+	assertDBTBoundaryTrustedJob(t, "activate-leapview", activation)
+	if producer.Permissions["contents"] != "read" || producer.Permissions["id-token"] != "write" {
+		t.Fatalf("producer job permissions = %#v, want contents: read and id-token: write", producer.Permissions)
+	}
+	if activation.Permissions["contents"] != "read" {
+		t.Fatalf("activation job contents permission = %q, want read", activation.Permissions["contents"])
+	}
+	if _, granted := activation.Permissions["id-token"]; granted {
+		t.Fatal("activation job must not receive the producer OIDC permission")
+	}
+	if !containsString(activation.Needs, "publish-dbt") {
+		t.Fatalf("activation job needs = %v, want publish-dbt", activation.Needs)
+	}
+	if producer.Outputs["publication_prefix"] != "${{ steps.select-prefix.outputs.publication_prefix }}" {
+		t.Fatalf("producer publication output = %q", producer.Outputs["publication_prefix"])
+	}
+	if activation.Env["PUBLICATION_PREFIX"] != "${{ needs.publish-dbt.outputs.publication_prefix }}" {
+		t.Fatalf("activation publication input = %q", activation.Env["PUBLICATION_PREFIX"])
+	}
+	if producer.Env["AZURE_CORE_OUTPUT"] != "none" || activation.Env["AZURE_CORE_OUTPUT"] != "none" {
+		t.Fatal("both workflow jobs must suppress Azure response output")
+	}
+
+	producerOrder := []string{
 		"Set up pinned Python",
 		"Install pinned dbt Core",
 		"Install pinned dbt-duckdb",
@@ -81,34 +254,280 @@ func TestDBTWarehouseBoundaryWorkflowPublishesBeforeLeapView(t *testing.T) {
 		"Select a new immutable publication prefix",
 		"Upload the complete selected mart set",
 		"Verify the exact published mart set",
-		"Qualify the physical publication through LeapView",
+		"End the producer credential session",
 	}
 	previous := -1
-	for _, step := range ordered {
-		index := strings.Index(workflow, step)
+	for _, name := range producerOrder {
+		index := dbtBoundaryStepIndex(producer.Steps, name)
 		if index < 0 {
-			t.Fatalf("reference workflow is missing %q", step)
+			t.Fatalf("producer job is missing %q", name)
 		}
 		if index <= previous {
-			t.Fatalf("reference workflow step %q is out of order", step)
+			t.Fatalf("producer step %q is out of order", name)
+		}
+		previous = index
+	}
+	activationOrder := []string{
+		"Render the ordinary Azure-backed LeapView bundle",
+		"Assert authored current-profile Project identity",
+		"Set up the cached LeapView CI toolchain",
+		"Build the ordinary LeapView CLI",
+		"Qualify the physical publication through LeapView",
+	}
+	previous = -1
+	for _, name := range activationOrder {
+		index := dbtBoundaryStepIndex(activation.Steps, name)
+		if index < 0 {
+			t.Fatalf("activation job is missing %q", name)
+		}
+		if index <= previous {
+			t.Fatalf("activation step %q is out of order", name)
 		}
 		previous = index
 	}
 
-	for _, required := range []string{
-		"--overwrite false", "length(@)", "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_SHA}",
-		"AZURE_CORE_OUTPUT: none", "LEAPVIEW_WORKLOAD_CLIENT_ID", "type: azure_blob",
-		"dev --once --no-browser", ".candidateId", "publish \"$candidate_id\" --format json",
+	producerLogin := dbtBoundaryStepByName(t, producer.Steps, "Authenticate the producer with Azure OIDC")
+	if !strings.HasPrefix(producerLogin.Uses, "azure/login@") {
+		t.Errorf("producer authentication uses %q, want azure/login action", producerLogin.Uses)
+	}
+	for key, value := range map[string]string{
+		"client-id":       "${{ vars.DBT_PRODUCER_CLIENT_ID }}",
+		"tenant-id":       "${{ vars.AZURE_TENANT_ID }}",
+		"subscription-id": "${{ vars.AZURE_SUBSCRIPTION_ID }}",
 	} {
-		if !strings.Contains(workflow, required) {
-			t.Errorf("reference workflow is missing fail-closed boundary %q", required)
+		if producerLogin.With[key] != value {
+			t.Errorf("producer authentication %s = %#v, want %q", key, producerLogin.With[key], value)
 		}
 	}
-	for _, forbidden := range []string{"manifest.json", "run_results.json", "dbt parse", "dbt ls"} {
-		if strings.Contains(strings.ToLower(workflow), forbidden) {
-			t.Errorf("reference workflow treats dbt metadata as authority through %q", forbidden)
+
+	prefix := dbtBoundaryStepByName(t, producer.Steps, "Select a new immutable publication prefix")
+	if prefix.ID != "select-prefix" {
+		t.Fatalf("publication-prefix step id = %q, want select-prefix", prefix.ID)
+	}
+	for _, required := range []string{
+		`prefix="dbt-warehouse-boundary/${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_SHA}"`,
+		`--prefix "$prefix/"`,
+		"--query 'length(@)'",
+		`test "$existing" = 0`,
+		`printf 'publication_prefix=%s\n' "$prefix" >> "$GITHUB_OUTPUT"`,
+	} {
+		if !strings.Contains(prefix.Run, required) {
+			t.Errorf("publication-prefix step is missing %q", required)
 		}
 	}
+	upload := dbtBoundaryStepByName(t, producer.Steps, "Upload the complete selected mart set")
+	for _, required := range []string{`--name "$PUBLICATION_PREFIX/$mart"`, "--overwrite false"} {
+		if !strings.Contains(upload.Run, required) {
+			t.Errorf("publication upload step is missing %q", required)
+		}
+	}
+	verify := dbtBoundaryStepByName(t, producer.Steps, "Verify the exact published mart set")
+	for _, required := range []string{
+		`--prefix "$PUBLICATION_PREFIX/"`,
+		"--query '[].name'",
+		`test "$actual" = "$expected"`,
+		`"$PUBLICATION_PREFIX/dim_customers.parquet"`,
+		`"$PUBLICATION_PREFIX/fct_orders.parquet"`,
+	} {
+		if !strings.Contains(verify.Run, required) {
+			t.Errorf("exact-publication verification step is missing %q", required)
+		}
+	}
+
+	logout := dbtBoundaryStepByName(t, producer.Steps, "End the producer credential session")
+	if strings.TrimSpace(logout.Run) != "az logout" {
+		t.Errorf("producer logout command = %q, want az logout", logout.Run)
+	}
+	for _, step := range producer.Steps {
+		if dbtBoundaryStepContains(step, "${{ secrets.") {
+			t.Errorf("producer step %q receives a LeapView production secret", step.Name)
+		}
+	}
+
+	for _, step := range activation.Steps {
+		if strings.HasPrefix(step.Uses, "azure/login@") || strings.Contains(step.Run, "az login") {
+			t.Errorf("activation step %q can authenticate as the producer", step.Name)
+		}
+	}
+	assertProject := dbtBoundaryStepByName(t, activation.Steps, "Assert authored current-profile Project identity")
+	for _, required := range []string{
+		`"$LEAPVIEW_PROJECT_FILE"`,
+		"kind: Project",
+		"metadata:",
+		"LEAPVIEW_WORKLOAD_PROJECT",
+		"test \"$project_id\"",
+	} {
+		if !strings.Contains(assertProject.Run, required) {
+			t.Errorf("Project identity assertion step is missing %q", required)
+		}
+	}
+	render := dbtBoundaryStepByName(t, activation.Steps, "Render the ordinary Azure-backed LeapView bundle")
+	if !strings.Contains(render.Run, "type: azure_blob") {
+		t.Fatal("rendered LeapView bundle does not select the ordinary azure_blob connection")
+	}
+
+	qualify := dbtBoundaryStepByName(t, activation.Steps, "Qualify the physical publication through LeapView")
+	if len(qualify.Env) != 2 {
+		t.Fatalf("LeapView credential step env = %#v, want exactly two workload credentials", qualify.Env)
+	}
+	for key, value := range map[string]string{
+		"LEAPVIEW_WORKLOAD_CLIENT_ID":     "${{ secrets.LEAPVIEW_WORKLOAD_CLIENT_ID }}",
+		"LEAPVIEW_WORKLOAD_CLIENT_SECRET": "${{ secrets.LEAPVIEW_WORKLOAD_CLIENT_SECRET }}",
+	} {
+		if qualify.Env[key] != value {
+			t.Errorf("LeapView credential step env %s = %q, want secret-scoped value", key, qualify.Env[key])
+		}
+	}
+	for _, step := range activation.Steps {
+		if step.Name == qualify.Name {
+			continue
+		}
+		if dbtBoundaryStepContains(step, "${{ secrets.") {
+			t.Errorf("step %q receives a production secret outside the LeapView credential step", step.Name)
+		}
+	}
+
+	for _, required := range []string{
+		`"$RUNNER_TEMP/leapview" dev --once --no-browser --format json`,
+		`--candidate-key "$candidate_key"`,
+		"--source-repository",
+		"--source-ref",
+		"--source-revision",
+		".candidateId",
+		`"$RUNNER_TEMP/leapview" publish "$candidate_id" --format json`,
+	} {
+		if !strings.Contains(qualify.Run, required) {
+			t.Errorf("LeapView qualification step is missing %q", required)
+		}
+	}
+	for jobName, job := range map[string]dbtBoundaryJob{"publish-dbt": producer, "activate-leapview": activation} {
+		for _, step := range job.Steps {
+			if dbtBoundaryStepContains(step, "manifest.json") || dbtBoundaryStepContains(step, "run_results.json") || dbtBoundaryStepContains(step, "dbt parse") || dbtBoundaryStepContains(step, "dbt ls") {
+				t.Errorf("reference workflow treats dbt metadata as authority through %s step %q", jobName, step.Name)
+			}
+		}
+	}
+}
+
+func assertDBTBoundaryTrustedJob(t *testing.T, name string, job dbtBoundaryJob) {
+	t.Helper()
+	guard := strings.Join(strings.Fields(job.If), " ")
+	for _, required := range []string{
+		"github.ref == format('refs/heads/{0}', github.event.repository.default_branch)",
+		"github.ref_protected == true",
+	} {
+		if !strings.Contains(guard, required) {
+			t.Errorf("%s trusted-ref guard is missing %q: %q", name, required, job.If)
+		}
+	}
+	if strings.Contains(guard, "||") {
+		t.Errorf("%s trusted-ref guard is not fail-closed: %q", name, job.If)
+	}
+	if job.Environment != "dbt-warehouse-boundary-production" {
+		t.Errorf("%s environment = %q, want dbt-warehouse-boundary-production", name, job.Environment)
+	}
+}
+
+func TestDBTWarehouseBoundaryWorkflowIsRequiredByCIGate(t *testing.T) {
+	root := repoRoot(t)
+	workflow := readDBTBoundaryWorkflow(t, filepath.Join(root, ".github/workflows/ci.yml"))
+	dbtJob, ok := workflow.Jobs["dbt-warehouse-boundary-validation"]
+	if !ok {
+		t.Fatal("CI workflow is missing dbt-warehouse-boundary-validation job")
+	}
+	qualifyFound := false
+	for _, step := range dbtJob.Steps {
+		if strings.Contains(step.Run, "task dbt:warehouse:qualify") {
+			qualifyFound = true
+			break
+		}
+	}
+	if !qualifyFound {
+		t.Fatal("CI dbt validation job does not run task dbt:warehouse:qualify")
+	}
+
+	gate, ok := workflow.Jobs["ci-gate"]
+	if !ok {
+		t.Fatal("CI workflow is missing ci-gate job")
+	}
+	if !containsString(gate.Needs, "dbt-warehouse-boundary-validation") {
+		t.Fatalf("CI gate needs = %v, missing dbt validation job", gate.Needs)
+	}
+	for _, step := range gate.Steps {
+		if step.Env["DBT_WAREHOUSE_RESULT"] == "${{ needs.dbt-warehouse-boundary-validation.result }}" {
+			if !strings.Contains(step.Run, "DBT_WAREHOUSE_RESULT") {
+				t.Fatal("CI gate does not fail closed on DBT_WAREHOUSE_RESULT")
+			}
+			return
+		}
+	}
+	t.Fatal("CI gate does not wire DBT_WAREHOUSE_RESULT from the dbt validation job")
+}
+
+func readDBTBoundaryWorkflow(t *testing.T, path string) dbtBoundaryWorkflow {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow dbtBoundaryWorkflow
+	if err := yaml.Unmarshal(body, &workflow); err != nil {
+		t.Fatalf("parse workflow %s: %v", path, err)
+	}
+	return workflow
+}
+
+func dbtBoundaryStepByName(t *testing.T, steps []dbtBoundaryWorkflowStep, name string) dbtBoundaryWorkflowStep {
+	t.Helper()
+	for _, step := range steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	t.Fatalf("workflow is missing step %q", name)
+	return dbtBoundaryWorkflowStep{}
+}
+
+func dbtBoundaryStepIndex(steps []dbtBoundaryWorkflowStep, name string) int {
+	for index, step := range steps {
+		if step.Name == name {
+			return index
+		}
+	}
+	return -1
+}
+
+func dbtBoundaryStepContains(step dbtBoundaryWorkflowStep, needle string) bool {
+	if strings.Contains(step.Run, needle) || strings.Contains(step.Uses, needle) {
+		return true
+	}
+	for _, value := range step.Env {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	for _, value := range step.With {
+		if strings.Contains(toString(value), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func toString(value interface{}) string {
+	if stringValue, ok := value.(string); ok {
+		return stringValue
+	}
+	return ""
+}
+
+func containsString(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
 }
 
 func TestDBTExampleUsesExternalNonIncrementalMarts(t *testing.T) {

--- a/schemas/config/environment.schema.json
+++ b/schemas/config/environment.schema.json
@@ -2184,6 +2184,14 @@
       "x-lifecycle": "development",
       "x-scope": "dev server"
     },
+    "LEAPVIEW_DEV_ONCE": {
+      "default": "false",
+      "description": "Stop the managed development server after one successful candidate publication and MCP smoke check.",
+      "pattern": "^(1|t|T|true|TRUE|True|0|f|F|false|FALSE|False)$",
+      "type": "string",
+      "x-lifecycle": "development",
+      "x-scope": "dev server"
+    },
     "LEAPVIEW_DEV_PORT_COUNT": {
       "default": "100",
       "description": "Number of ports scanned by the managed development server.",

--- a/scripts/dbt-warehouse-boundary.sh
+++ b/scripts/dbt-warehouse-boundary.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXAMPLE="$ROOT/examples/dbt-warehouse-boundary"
+DBT_PROJECT="$EXAMPLE/dbt"
+PUBLISHED="$EXAMPLE/published"
+VENV="$ROOT/.tmp/dbt-warehouse-boundary/venv"
+REQUIREMENTS="$DBT_PROJECT/requirements.txt"
+
+prepare_dbt() {
+  if [[ -n "${DBT_BIN:-}" ]]; then
+    [[ -x "$DBT_BIN" ]] || {
+      echo "DBT_BIN is not executable" >&2
+      return 1
+    }
+    printf '%s\n' "$DBT_BIN"
+    return 0
+  fi
+
+  command -v python3 >/dev/null 2>&1 || {
+    echo "Python 3 is required for the dbt warehouse-boundary showcase" >&2
+    return 1
+  }
+  mkdir -p "$(dirname "$VENV")"
+  local requirements_digest marker
+  requirements_digest="$(sha256sum "$REQUIREMENTS" | awk '{print $1}')"
+  marker="$VENV/.leapview-requirements.sha256"
+  if [[ ! -x "$VENV/bin/dbt" || ! -f "$marker" || "$(<"$marker")" != "$requirements_digest" ]]; then
+    python3 -m venv --clear "$VENV"
+    "$VENV/bin/python" -m pip install --disable-pip-version-check --requirement "$REQUIREMENTS"
+    printf '%s\n' "$requirements_digest" > "$marker"
+  fi
+  printf '%s\n' "$VENV/bin/dbt"
+}
+
+verify_outputs() {
+  local expected actual
+  expected=$'dim_customers.parquet\nfct_orders.parquet'
+  actual="$(find "$PUBLISHED" -maxdepth 1 -type f -name '*.parquet' -printf '%f\n' | LC_ALL=C sort)"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "dbt publication does not contain the exact expected Parquet file set" >&2
+    printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+    return 1
+  fi
+  while IFS= read -r file; do
+    [[ -s "$PUBLISHED/$file" ]] || {
+      echo "dbt publication contains an empty Parquet file: $file" >&2
+      return 1
+    }
+  done <<< "$expected"
+  echo "Verified complete dbt publication: dim_customers.parquet, fct_orders.parquet"
+}
+
+build() {
+  local dbt
+  dbt="$(prepare_dbt)"
+  mkdir -p "$PUBLISHED"
+  # dbt refuses to clean outside its project root. Remove only this example's
+  # two declared generated outputs; verify_outputs rejects any unexpected file.
+  rm -f "$PUBLISHED/dim_customers.parquet" "$PUBLISHED/fct_orders.parquet"
+  (
+    cd "$DBT_PROJECT"
+    "$dbt" --quiet --no-use-colors build --profiles-dir . --project-dir .
+  )
+  verify_outputs
+}
+
+case "${1:-}" in
+  build) build ;;
+  verify) verify_outputs ;;
+  *) echo "Usage: $0 build|verify" >&2; exit 2 ;;
+esac

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -12,7 +12,7 @@ PORT_COUNT="${LEAPVIEW_DEV_PORT_COUNT:-100}"
 mkdir -p "$TMP_DIR"
 
 usage() {
-	echo "Usage: $0 start [project [connection source-root]]|publish [project [connection source-root]]|stop|status|logs"
+	echo "Usage: $0 start [project [connection source-root]]|once [project [connection source-root]]|publish [project [connection source-root]]|stop|status|logs"
 }
 
 is_alive() {
@@ -440,6 +440,10 @@ start() {
       echo "Logs: $LOG_FILE"
       echo "Publishing project candidate to existing target..."
 			publish_project "$existing_port" "$project" "$connection" "$from"
+      if [[ "${LEAPVIEW_DEV_ONCE:-}" == "1" ]]; then
+        echo "One-shot candidate publication completed on the existing target"
+        return 0
+      fi
       echo "Attached to LeapView logs. Press Ctrl-C to stop."
       attach_server "$existing_pid" "$existing_port"
       return 0
@@ -501,6 +505,14 @@ start() {
     exit 1
   fi
 
+  if [[ "${LEAPVIEW_DEV_ONCE:-}" == "1" ]]; then
+    stop_pid "$pid" "LeapView one-shot dev server"
+    rm -f "$PID_FILE"
+    stop_port "$port"
+    echo "One-shot candidate publication completed"
+    return 0
+  fi
+
   echo "LeapView listening at http://localhost:$port"
   echo "Attached to LeapView logs. Press Ctrl-C to stop."
   attach_server "$pid" "$port"
@@ -553,6 +565,7 @@ action="${1:-}"
 shift || true
 case "$action" in
   start) start "$@" ;;
+  once) LEAPVIEW_DEV_ONCE=1 start "$@" ;;
   publish) publish_running "$@" ;;
   stop) stop ;;
   status) status ;;


### PR DESCRIPTION
## Problem

LeapView lacked a maintained path for consuming dbt-produced warehouse data
without making dbt artifacts, credentials, or execution part of the serving
runtime.

## Root cause

The existing Connection, Source, Model, candidate, and activation capabilities
were present, but no integrated example, producer-neutral qualification
fixture, production reference workflow, CI gate, or conformance evidence tied
them together.

## Solution

- Add a pinned dbt-duckdb showcase that publishes exactly two physical Parquet marts.
- Consume those marts through the ordinary:
  dbt → Parquet → Connection → Source → thin Model → SemanticModel → dashboard path.
- Add producer-neutral success and failure qualification, including prior-generation retention.
- Add a protected GitHub Actions/Azure reference with producer-only OIDC,
  immutable non-overwriting publication, exact file-set verification, and
  isolated LeapView workload credentials.
- Add real dbt physical-contract validation to the fail-closed PR CI gate.
- Document consistency, credential, recovery, and ownership boundaries.
- Add maintained ADR-0019 conformance evidence.
- Exclude local generated dbt artifacts from Docker build contexts.

## Explicit non-goals

- dbt runtime dependency
- manifest or run-results authority
- MetricFlow or dbt Semantic Layer integration
- scheduler or publication service
- cross-Project imports
- new runtime abstraction

## Validation

- Producer-neutral warehouse qualification matrix passes.
- Real pinned dbt build produces the expected Parquet outputs.
- Headless LeapView qualification and semantic MCP smoke check pass.
- Repository-wide Go tests pass.
- `task generate` passes.
- `task generated:check` passes.
- Docker deployment/architecture contract tests pass.

## Known limitations

- ADR-0019 remains pending/partial until ADR-0018 provides Project-free
  discovery and durable ProjectUID bootstrap.
- Live Azure OIDC, RBAC, checksum, and storage-retention behavior was not
  exercised against live infrastructure.
- Full `task ci` remains environmentally blocked by Playwright filesystem
  quota and an unchanged APIGen toolchain timeout.
- Abandoned partial publication prefixes require operator-configured storage
  lifecycle retention.

## Related Linear issues

- FAI-680
- FAI-681
- FAI-682
- FAI-684
- FAI-688
- FAI-689
- FAI-691
