### PR TITLE
Reject unsupported hierarchy formatting by chart type

### DIFF
--- a/dashboards/dashboards/visual-showcase.yaml
+++ b/dashboards/dashboards/visual-showcase.yaml
@@ -2027,7 +2027,6 @@ spec:
       title: Category, state, and status sunburst
       presentation:
         type: hierarchy
-        initialDepth: 2
         roam: true
     orders_table:
       type: table

--- a/docs/visuals/sunburst.md
+++ b/docs/visuals/sunburst.md
@@ -42,7 +42,7 @@ visuals:
 
 ## Three-level hierarchy
 
-Add a third ordered dimension for deeper nesting, set `initialDepth` to control the first visible level, and enable roaming for exploration.
+Add a third ordered dimension for deeper nesting and enable roaming for drill-down exploration.
 
 {{< visual id="category_state_status_sunburst" >}}
 
@@ -53,7 +53,6 @@ visuals:
     type: sunburst
     presentation:
       type: hierarchy
-      initialDepth: 2
       roam: true
     query:
       type: aggregate

--- a/internal/dashboard/compiler/dashboard_layout_canonical.go
+++ b/internal/dashboard/compiler/dashboard_layout_canonical.go
@@ -280,6 +280,9 @@ func ValidateCanonicalDashboardCompatibility(spec document.DashboardSpec) error 
 		} else if expected != presentationType {
 			return fmt.Errorf("visual %q type %q requires %s presentation, got %s", visualID, visual.Type, expected, presentationType)
 		}
+		if err := validateCanonicalPresentationApplicability(visual.Presentation, visual.Type); err != nil {
+			return fmt.Errorf("visual %q: %w", visualID, err)
+		}
 		if !canonicalQueryCompatible(visual.Type, queryType) {
 			return fmt.Errorf("visual %q type %q is incompatible with %s query", visualID, visual.Type, queryType)
 		}

--- a/internal/dashboard/compiler/dashboard_layout_canonical_test.go
+++ b/internal/dashboard/compiler/dashboard_layout_canonical_test.go
@@ -202,6 +202,21 @@ func TestValidateCanonicalDashboardCompatibilityRejectsMismatchedPresentationAnd
 	}
 }
 
+func TestValidateCanonicalDashboardCompatibilityRejectsInapplicablePresentationOption(t *testing.T) {
+	initialDepth := int32(0)
+	spec := document.DashboardSpec{Visuals: map[string]document.DashboardVisual{
+		"category_sunburst": {
+			Type:         document.DashboardVisualTypeSunburst,
+			Query:        document.DashboardQuery{Value: &document.AggregateDashboardQuery{Type: "aggregate"}},
+			Presentation: document.DashboardPresentation{Value: &document.HierarchyDashboardPresentation{Type: "hierarchy", InitialDepth: &initialDepth}},
+		},
+	}}
+	err := ValidateCanonicalDashboardCompatibility(spec)
+	if err == nil || !strings.Contains(err.Error(), `visual "category_sunburst": presentation.initialDepth is not supported for sunburst visuals`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestValidateCanonicalDashboardCompatibilityRejectsUnknownPageReference(t *testing.T) {
 	spec := document.DashboardSpec{Pages: []document.DashboardPage{{
 		ID:         "overview",

--- a/internal/dashboard/compiler/dashboard_presentation_lowering.go
+++ b/internal/dashboard/compiler/dashboard_presentation_lowering.go
@@ -28,6 +28,9 @@ func LowerCanonicalDashboardPresentation(value document.DashboardPresentation, v
 	if kind != expected {
 		return nil, fmt.Errorf("visual type %q requires %s presentation, got %s", visualType, expected, kind)
 	}
+	if err := validateCanonicalPresentationApplicability(value, visualType); err != nil {
+		return nil, err
+	}
 	switch variant := value.Value.(type) {
 	case *document.CartesianDashboardPresentation:
 		if variant.Series != nil && visualType != document.DashboardVisualTypeCombo {
@@ -190,11 +193,25 @@ func LowerCanonicalDashboardPresentation(value document.DashboardPresentation, v
 		if variant.Roam != nil {
 			out.Roam = *variant.Roam
 		}
-		out.Layout = variant.Layout
+		if variant.Layout != nil {
+			switch *variant.Layout {
+			case visualizationir.VisualizationHierarchyLayoutStandard, visualizationir.VisualizationHierarchyLayoutCircular:
+				out.Layout = variant.Layout
+			default:
+				return nil, fmt.Errorf("presentation.layout must be standard or circular")
+			}
+		}
 		out.Breadcrumb = variant.Breadcrumb
 		out.NodeGap = variant.NodeGap
 		out.Curveness = variant.Curveness
-		out.Focus = variant.Focus
+		if variant.Focus != nil {
+			switch *variant.Focus {
+			case visualizationir.VisualizationGraphFocusNone, visualizationir.VisualizationGraphFocusAdjacency:
+				out.Focus = variant.Focus
+			default:
+				return nil, fmt.Errorf("presentation.focus must be none or adjacency")
+			}
+		}
 		if out.InitialDepth != nil && *out.InitialDepth < 0 {
 			return nil, fmt.Errorf("hierarchy initialDepth must not be negative")
 		}
@@ -350,6 +367,42 @@ func LowerCanonicalDashboardPresentationForQuery(value document.DashboardPresent
 		}
 	}
 	return lowered, nil
+}
+
+func validateCanonicalPresentationApplicability(value document.DashboardPresentation, visualType document.DashboardVisualType) error {
+	variant, ok := value.Value.(*document.HierarchyDashboardPresentation)
+	if !ok || variant == nil {
+		return nil
+	}
+
+	optionSupported := func(option string, present bool, supported bool) error {
+		if present && !supported {
+			return fmt.Errorf("presentation.%s is not supported for %s visuals", option, visualType)
+		}
+		return nil
+	}
+	if err := optionSupported("orientation", variant.Orientation != nil, visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeSankey); err != nil {
+		return err
+	}
+	if err := optionSupported("initialDepth", variant.InitialDepth != nil, visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeTreemap); err != nil {
+		return err
+	}
+	if err := optionSupported("roam", variant.Roam != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeTreemap || visualType == document.DashboardVisualTypeSunburst); err != nil {
+		return err
+	}
+	if err := optionSupported("layout", variant.Layout != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeTree); err != nil {
+		return err
+	}
+	if err := optionSupported("breadcrumb", variant.Breadcrumb != nil, visualType == document.DashboardVisualTypeTreemap); err != nil {
+		return err
+	}
+	if err := optionSupported("nodeGap", variant.NodeGap != nil, visualType == document.DashboardVisualTypeSankey); err != nil {
+		return err
+	}
+	if err := optionSupported("curveness", variant.Curveness != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeSankey); err != nil {
+		return err
+	}
+	return optionSupported("focus", variant.Focus != nil, visualType == document.DashboardVisualTypeGraph)
 }
 
 // lowerCanonicalComboSeries maps the closed Dashboard combo policy into the

--- a/internal/dashboard/compiler/dashboard_presentation_lowering_test.go
+++ b/internal/dashboard/compiler/dashboard_presentation_lowering_test.go
@@ -97,10 +97,10 @@ func TestLowerCanonicalPresentationVariantsPreserveFieldsAndDefaults(t *testing.
 	legend := document.DashboardLegendPositionTop
 	labels := document.DashboardLabelPolicy{Density: document.DashboardLabelDensityAlways}
 	orientation := document.DashboardOrientationHorizontal
+	initialDepth := int32(2)
+	roam := true
 	units := visualizationir.VisualizationDisplayUnitsBillions
-	nodeGap, curveness := 18.0, .32
 	layout := visualizationir.VisualizationHierarchyLayoutCircular
-	focus := visualizationir.VisualizationGraphFocusAdjacency
 	cases := []struct {
 		name       string
 		visualType document.DashboardVisualType
@@ -119,10 +119,10 @@ func TestLowerCanonicalPresentationVariantsPreserveFieldsAndDefaults(t *testing.
 		},
 		{
 			name: "hierarchy", visualType: document.DashboardVisualTypeTree,
-			value: document.DashboardPresentation{Value: &document.HierarchyDashboardPresentation{Type: "hierarchy", Orientation: &orientation, Layout: &layout, NodeGap: &nodeGap, Curveness: &curveness, Focus: &focus}},
+			value: document.DashboardPresentation{Value: &document.HierarchyDashboardPresentation{Type: "hierarchy", Orientation: &orientation, InitialDepth: &initialDepth, Roam: &roam, Layout: &layout}},
 			check: func(t *testing.T, value any) {
 				got := value.(visualizationir.HierarchyVisualizationPresentation)
-				if got.Orientation != visualizationir.VisualizationOrientationHorizontal || got.Legend != visualizationir.VisualizationLegendPositionBottom || got.Layout == nil || *got.Layout != visualizationir.VisualizationHierarchyLayoutCircular || got.NodeGap == nil || *got.NodeGap != 18 || got.Curveness == nil || *got.Curveness != .32 || got.Focus == nil || *got.Focus != visualizationir.VisualizationGraphFocusAdjacency {
+				if got.Orientation != visualizationir.VisualizationOrientationHorizontal || got.Legend != visualizationir.VisualizationLegendPositionBottom || got.InitialDepth == nil || *got.InitialDepth != 2 || !got.Roam || got.Layout == nil || *got.Layout != visualizationir.VisualizationHierarchyLayoutCircular {
 					t.Fatalf("hierarchy = %#v", got)
 				}
 			},
@@ -170,6 +170,240 @@ func TestLowerCanonicalPresentationRejectsIncompatibleAndInvalidValues(t *testin
 	zero := int32(0)
 	if _, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: &document.TableDashboardPresentation{Type: "table", RowHeight: zero}}, document.DashboardVisualTypeTable); err == nil {
 		t.Fatal("zero table row height accepted")
+	}
+}
+
+func TestLowerCanonicalHierarchyPresentationSupportsOptionsByVisualType(t *testing.T) {
+	tests := []struct {
+		name        string
+		visualTypes []document.DashboardVisualType
+		set         func(*document.HierarchyDashboardPresentation)
+		check       func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation)
+	}{
+		{
+			name: "orientation", visualTypes: []document.DashboardVisualType{document.DashboardVisualTypeTree, document.DashboardVisualTypeSankey},
+			set: func(value *document.HierarchyDashboardPresentation) {
+				orientation := document.DashboardOrientationHorizontal
+				value.Orientation = &orientation
+			},
+			check: func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation) {
+				if got.Orientation != visualizationir.VisualizationOrientationHorizontal {
+					t.Fatalf("orientation = %q", got.Orientation)
+				}
+			},
+		},
+		{
+			name: "initialDepth", visualTypes: []document.DashboardVisualType{document.DashboardVisualTypeTree, document.DashboardVisualTypeTreemap},
+			set: func(value *document.HierarchyDashboardPresentation) {
+				initialDepth := int32(0)
+				value.InitialDepth = &initialDepth
+			},
+			check: func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation) {
+				if got.InitialDepth == nil || *got.InitialDepth != 0 {
+					t.Fatalf("initialDepth = %v", got.InitialDepth)
+				}
+			},
+		},
+		{
+			name: "roam", visualTypes: []document.DashboardVisualType{document.DashboardVisualTypeGraph, document.DashboardVisualTypeTree, document.DashboardVisualTypeTreemap, document.DashboardVisualTypeSunburst},
+			set: func(value *document.HierarchyDashboardPresentation) {
+				roam := false
+				value.Roam = &roam
+			},
+			check: func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation) {
+				if got.Roam {
+					t.Fatal("roam = true, want explicit false")
+				}
+			},
+		},
+		{
+			name: "layout", visualTypes: []document.DashboardVisualType{document.DashboardVisualTypeGraph, document.DashboardVisualTypeTree},
+			set: func(value *document.HierarchyDashboardPresentation) {
+				layout := visualizationir.VisualizationHierarchyLayoutStandard
+				value.Layout = &layout
+			},
+			check: func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation) {
+				if got.Layout == nil || *got.Layout != visualizationir.VisualizationHierarchyLayoutStandard {
+					t.Fatalf("layout = %v", got.Layout)
+				}
+			},
+		},
+		{
+			name: "breadcrumb", visualTypes: []document.DashboardVisualType{document.DashboardVisualTypeTreemap},
+			set: func(value *document.HierarchyDashboardPresentation) {
+				breadcrumb := false
+				value.Breadcrumb = &breadcrumb
+			},
+			check: func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation) {
+				if got.Breadcrumb == nil || *got.Breadcrumb {
+					t.Fatalf("breadcrumb = %v", got.Breadcrumb)
+				}
+			},
+		},
+		{
+			name: "nodeGap", visualTypes: []document.DashboardVisualType{document.DashboardVisualTypeSankey},
+			set: func(value *document.HierarchyDashboardPresentation) {
+				nodeGap := 0.0
+				value.NodeGap = &nodeGap
+			},
+			check: func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation) {
+				if got.NodeGap == nil || *got.NodeGap != 0 {
+					t.Fatalf("nodeGap = %v", got.NodeGap)
+				}
+			},
+		},
+		{
+			name: "curveness", visualTypes: []document.DashboardVisualType{document.DashboardVisualTypeGraph, document.DashboardVisualTypeSankey},
+			set: func(value *document.HierarchyDashboardPresentation) {
+				curveness := 0.0
+				value.Curveness = &curveness
+			},
+			check: func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation) {
+				if got.Curveness == nil || *got.Curveness != 0 {
+					t.Fatalf("curveness = %v", got.Curveness)
+				}
+			},
+		},
+		{
+			name: "focus", visualTypes: []document.DashboardVisualType{document.DashboardVisualTypeGraph},
+			set: func(value *document.HierarchyDashboardPresentation) {
+				focus := visualizationir.VisualizationGraphFocusNone
+				value.Focus = &focus
+			},
+			check: func(t *testing.T, got visualizationir.HierarchyVisualizationPresentation) {
+				if got.Focus == nil || *got.Focus != visualizationir.VisualizationGraphFocusNone {
+					t.Fatalf("focus = %v", got.Focus)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		for _, visualType := range test.visualTypes {
+			t.Run(test.name+"/"+string(visualType), func(t *testing.T) {
+				value := &document.HierarchyDashboardPresentation{Type: "hierarchy"}
+				test.set(value)
+				lowered, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, visualType)
+				if err != nil {
+					t.Fatalf("lower %s: %v", visualType, err)
+				}
+				got, ok := lowered.(visualizationir.HierarchyVisualizationPresentation)
+				if !ok {
+					t.Fatalf("lowered type = %T", lowered)
+				}
+				test.check(t, got)
+			})
+		}
+	}
+}
+
+func TestLowerCanonicalHierarchyPresentationRejectsInapplicableOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		visualType document.DashboardVisualType
+		set        func(*document.HierarchyDashboardPresentation)
+		want       string
+	}{
+		{
+			name: "orientation on treemap", visualType: document.DashboardVisualTypeTreemap,
+			set: func(value *document.HierarchyDashboardPresentation) {
+				orientation := document.DashboardOrientationHorizontal
+				value.Orientation = &orientation
+			}, want: "presentation.orientation",
+		},
+		{
+			name: "initialDepth on sunburst", visualType: document.DashboardVisualTypeSunburst,
+			set: func(value *document.HierarchyDashboardPresentation) {
+				initialDepth := int32(0)
+				value.InitialDepth = &initialDepth
+			}, want: "presentation.initialDepth",
+		},
+		{
+			name: "roam on sankey", visualType: document.DashboardVisualTypeSankey,
+			set: func(value *document.HierarchyDashboardPresentation) {
+				roam := false
+				value.Roam = &roam
+			}, want: "presentation.roam",
+		},
+		{
+			name: "layout on sunburst", visualType: document.DashboardVisualTypeSunburst,
+			set: func(value *document.HierarchyDashboardPresentation) {
+				layout := visualizationir.VisualizationHierarchyLayoutStandard
+				value.Layout = &layout
+			}, want: "presentation.layout",
+		},
+		{
+			name: "breadcrumb on tree", visualType: document.DashboardVisualTypeTree,
+			set: func(value *document.HierarchyDashboardPresentation) {
+				breadcrumb := false
+				value.Breadcrumb = &breadcrumb
+			}, want: "presentation.breadcrumb",
+		},
+		{
+			name: "nodeGap on graph", visualType: document.DashboardVisualTypeGraph,
+			set: func(value *document.HierarchyDashboardPresentation) {
+				nodeGap := 0.0
+				value.NodeGap = &nodeGap
+			}, want: "presentation.nodeGap",
+		},
+		{
+			name: "curveness on tree", visualType: document.DashboardVisualTypeTree,
+			set: func(value *document.HierarchyDashboardPresentation) {
+				curveness := 0.0
+				value.Curveness = &curveness
+			}, want: "presentation.curveness",
+		},
+		{
+			name: "focus on treemap", visualType: document.DashboardVisualTypeTreemap,
+			set: func(value *document.HierarchyDashboardPresentation) {
+				focus := visualizationir.VisualizationGraphFocusNone
+				value.Focus = &focus
+			}, want: "presentation.focus",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value := &document.HierarchyDashboardPresentation{Type: "hierarchy"}
+			test.set(value)
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, test.visualType)
+			if err == nil || !strings.Contains(err.Error(), test.want+" is not supported for "+string(test.visualType)+" visuals") {
+				t.Fatalf("error = %v, want path-bearing applicability error for %s", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLowerCanonicalHierarchyPresentationRejectsUnknownEnums(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(*document.HierarchyDashboardPresentation)
+		want string
+	}{
+		{
+			name: "layout",
+			set: func(value *document.HierarchyDashboardPresentation) {
+				layout := visualizationir.VisualizationHierarchyLayout("spiral")
+				value.Layout = &layout
+			},
+			want: "presentation.layout must be standard or circular",
+		},
+		{
+			name: "focus",
+			set: func(value *document.HierarchyDashboardPresentation) {
+				focus := visualizationir.VisualizationGraphFocus("neighbors")
+				value.Focus = &focus
+			},
+			want: "presentation.focus must be none or adjacency",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value := &document.HierarchyDashboardPresentation{Type: "hierarchy"}
+			test.set(value)
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, document.DashboardVisualTypeGraph)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/web/components/dashboard/visualization/adapters/echarts.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.test.ts
@@ -910,7 +910,7 @@ test('ECharts honors proportional presentation and hierarchy/network layout', ()
   expect(funnel.series[0]).toMatchObject({ id: 'series:primary:funnel', type: 'funnel', funnelAlign: 'left', sort: 'ascending', orient: 'vertical', left: '6%', right: '44%' })
 
   const graph = echartsOption(networkFixture('graph'), defaultRendererContext) as any
-  expect(graph.series[0]).toMatchObject({ id: 'series:hierarchy:graph', type: 'graph', layout: 'circular', roam: true, left: '8%', right: '8%', top: '8%', bottom: '8%', symbolSize: 16, center: ['50%', '52%'], zoom: 0.76, label: { position: 'right', distance: 8, fontSize: 13 }, labelLayout: { moveOverlap: 'shiftY' }, itemStyle: { borderColor: defaultRendererContext.colors.surface, borderWidth: 2 }, emphasis: { focus: 'adjacency' } })
+  expect(graph.series[0]).toMatchObject({ id: 'series:hierarchy:graph', type: 'graph', layout: 'circular', roam: true, left: '8%', right: '8%', top: '8%', bottom: '8%', symbolSize: 16, center: ['50%', '52%'], zoom: 0.76, label: { position: 'right', distance: 8, fontSize: 13 }, labelLayout: { moveOverlap: 'shiftY' }, itemStyle: { borderColor: defaultRendererContext.colors.surface, borderWidth: 2 }, lineStyle: { curveness: 0.3 }, emphasis: { focus: 'adjacency' } })
   expect(graph.series[0]).not.toHaveProperty('force')
   expect(graph.series[0].links[0]).toMatchObject({ source: 'A', target: 'B', __lv_dataset: 'primary', __lv_row_index: 0 })
   const layeredGraphEnvelope = networkFixture('graph') as any
@@ -926,7 +926,7 @@ test('ECharts honors proportional presentation and hierarchy/network layout', ()
   sankeyEnvelope.dataState.datasets[0].rows = [['Same', 'Same', 4], ['', 'Target', 2], ['Source', 'Target', 0]]
   const sankey = echartsOption(sankeyEnvelope, defaultRendererContext) as any
   expect(sankey.series[0]).toMatchObject({ id: 'series:hierarchy:sankey', type: 'sankey', orient: 'horizontal', nodeGap: 18 })
-  expect(sankey.series[0].lineStyle).toMatchObject({ color: 'gradient', opacity: 0.45 })
+  expect(sankey.series[0].lineStyle).toMatchObject({ color: 'gradient', opacity: 0.45, curveness: 0.3 })
   expect(sankey.series[0]).toMatchObject({ left: '4%', right: '30%', top: '8%', bottom: '8%', label: { width: 96 } })
   expect(sankey.series[0].links).toEqual([{ source: 'source:Same', target: 'target:Same', sourceLabel: 'Same', targetLabel: 'Same', value: 4, __lv_dataset: 'primary', __lv_row_index: 0 }])
   expect(sankey.series[0].data).toEqual([{ name: 'source:Same', displayName: 'Same' }, { name: 'target:Same', displayName: 'Same' }])
@@ -950,6 +950,7 @@ test('ECharts honors proportional presentation and hierarchy/network layout', ()
     expect(option.series[0].id).toBe(`series:hierarchy:${mark}`)
     expect(option.series[0].data[0].children[0].name).toBe('child')
     if (mark === 'sunburst') {
+      expect(option.series[0].nodeClick).toBe('rootToNode')
       expect(option.series[0].radius).toEqual(['10%', '92%'])
       expect(option.series[0].label).toMatchObject({
         position: 'inside',
@@ -965,6 +966,7 @@ test('ECharts honors proportional presentation and hierarchy/network layout', ()
       })
       expect(option.series[0].labelLayout).toEqual({ hideOverlap: false })
     } else {
+      expect(option.series[0]).toMatchObject({ breadcrumb: { show: true }, leafDepth: 2 })
       expect(option.series[0].label).toMatchObject({ color: '#fff', textBorderColor: 'rgba(0, 0, 0, 0.55)', textBorderWidth: 2 })
       const darkOption = echartsOption(envelope, {
         ...defaultRendererContext,
@@ -978,6 +980,9 @@ test('ECharts honors proportional presentation and hierarchy/network layout', ()
       })
     }
   }
+
+  const tree = echartsOption(hierarchyFixture('tree'), defaultRendererContext) as any
+  expect(tree.series[0]).toMatchObject({ orient: 'TB', layout: 'orthogonal', initialTreeDepth: 2, roam: true })
 })
 
 test('ECharts gives donuts legible renderer defaults without changing their categories', () => {


### PR DESCRIPTION
## What

- Reject hierarchy presentation options that the selected chart cannot render.
- Preserve supported tree, treemap, graph, Sankey, and sunburst mappings, including explicit false and zero values.
- Remove the unsupported sunburst initialDepth example and claim.

## Why

- Prevent authored formatting from compiling into silent renderer no-ops.
- Complete the Phase 1 hierarchy truthfulness slice.

## Validation

- `go test ./internal/dashboard/compiler ./internal/dashboard/document ./internal/dashboard/visualization/ir -count=1`
- `bun test web/components/dashboard/visualization/adapters/echarts.test.ts`
- `go run -tags=duckdb_arrow ./internal/app/tools/visualdocgen --check`
- `go run ./internal/app/tools/docsitegen --check`
- `go test ./internal/app/site/http -run "^TestEveryRenderedDocumentationLinkResolves$" -count=1`
- `go run ./internal/app/tools/qualitybudget`

## Contract coverage

Dashboard authoring → compiler applicability → hierarchy IR → ECharts adapter assertions → executable docs.

Linear: FAI-737
Project: https://linear.app/flid/project/leapview-chart-formatting-c482afa202ef/overview