### PR TITLE
Make heatmap range legends interactive

### DIFF
--- a/site/site.dom.test.ts
+++ b/site/site.dom.test.ts
@@ -2502,7 +2502,7 @@ test('visual showcase renders every supported visual type', async () => {
   }
 }, 20_000)
 
-test('heatmap scale is a fixed legend that keeps every cell visible', async () => {
+test('heatmap scale is a calculable range that hides only out-of-range cells', async () => {
   const page = await browser.newPage({ viewport: { width: 966, height: 749 } })
   try {
     await page.goto(`${baseURL}/visuals`)
@@ -2512,7 +2512,7 @@ test('heatmap scale is a fixed legend that keeps every cell visible', async () =
       return Boolean(host?.shadowRoot?.querySelector('[_echarts_instance_]'))
     })
 
-    const state = await page.locator('lv-site-visual-showcase').evaluate(async (element) => {
+    const states = await page.locator('lv-site-visual-showcase').evaluate(async (element) => {
       const host = Array.from(element.shadowRoot?.querySelectorAll('lv-visualization-host') ?? []).find((candidate: any) => candidate.envelope?.visualID === 'state_status_heatmap') as HTMLElement
       const frame = host.shadowRoot?.querySelector<HTMLElement>('[_echarts_instance_]')
       if (!frame) throw new Error('heatmap ECharts frame is missing')
@@ -2529,30 +2529,47 @@ test('heatmap scale is a fixed legend that keeps every cell visible', async () =
       }
       if (!chart) throw new Error('heatmap ECharts instance is missing')
 
-      const visualMap = chart.getOption().visualMap[0]
-      const data = chart.getModel().getSeriesByIndex(0).getData()
-      let hiddenRows = 0
-      for (let index = 0; index < data.count(); index++) {
-        if (data.getItemVisual(index, 'style')?.opacity === 0) hiddenRows++
+      const inspect = () => {
+        const visualMap = chart.getOption().visualMap[0]
+        const data = chart.getModel().getSeriesByIndex(0).getData()
+        let hiddenRows = 0
+        let visibleRows = 0
+        for (let index = 0; index < data.count(); index++) {
+          if (data.getItemVisual(index, 'style')?.opacity === 0) hiddenRows++
+          else visibleRows++
+        }
+        return {
+          calculable: visualMap.calculable as boolean,
+          hiddenRows,
+          maximum: visualMap.max as number,
+          minimum: visualMap.min as number,
+          rowCount: data.count(),
+          text: visualMap.text as string[],
+          visibleRows,
+        }
       }
-      return {
-        calculable: visualMap.calculable as boolean,
-        hiddenRows,
-        maximum: visualMap.max as number,
-        minimum: visualMap.min as number,
-        rowCount: data.count(),
-        text: visualMap.text as string[],
+
+      const select = async (selected: [number, number]) => {
+        chart.dispatchAction({ type: 'selectDataRange', selected })
+        await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+        return inspect()
       }
+
+      return { initial: inspect(), narrowed: await select([2, 3]) }
     })
 
-    expect(state).toEqual({
-      calculable: false,
+    expect(states.initial).toEqual({
+      calculable: true,
       hiddenRows: 0,
       maximum: 3,
       minimum: 1,
       rowCount: 29,
       text: ['3', '1'],
+      visibleRows: 29,
     })
+    expect(states.narrowed.hiddenRows).toBeGreaterThan(0)
+    expect(states.narrowed.visibleRows).toBeGreaterThan(0)
+    expect(states.narrowed.hiddenRows + states.narrowed.visibleRows).toBe(states.initial.rowCount)
   } finally {
     await page.close()
   }

--- a/web/components/dashboard/visualization/adapters/echarts.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.test.ts
@@ -228,11 +228,14 @@ test('ECharts translates governed heatmap gradients and waterfall rule styles', 
   }]
   const heatmapOption = echartsOption(heatmap, defaultRendererContext) as any
   expect(heatmapOption.visualMap).toMatchObject({
+    type: 'continuous',
+    dimension: 'value',
     min: 0,
     max: 100,
-    calculable: false,
+    calculable: true,
     text: ['100', '0'],
     inRange: { color: [defaultRendererContext.colors.danger, defaultRendererContext.colors.success] },
+    outOfRange: { opacity: 0 },
   })
 
   const waterfall = cartesianFixture('waterfall', ['label', 'start', 'value']) as any
@@ -864,14 +867,16 @@ test('ECharts translates every cartesian mark with stable renderer-owned identit
   const heatmap = echartsOption(heatmapEnvelope, defaultRendererContext) as any
   expect(heatmap.series[0]).toMatchObject({ id: 'series:primary:heatmap', type: 'heatmap', encode: { x: 'label', y: 'row', value: 'value' } })
   expect(heatmap.visualMap).toMatchObject({
+    type: 'continuous',
+    dimension: 'value',
     min: 1,
     max: 3,
-    calculable: false,
+    calculable: true,
     text: ['3', '1'],
     inRange: { color: ['rgba(0, 110, 219, 0.18)', defaultRendererContext.colors.data[0]] },
+    outOfRange: { opacity: 0 },
   })
   expect(heatmap.visualMap.precision).toBeUndefined()
-  expect(heatmap.visualMap.outOfRange).toBeUndefined()
   const boxplot = echartsOption(cartesianFixture('boxplot', ['label', 'min', 'q1', 'median', 'q3', 'max']), defaultRendererContext) as any
   expect(boxplot.xAxis.data).toEqual(['A'])
   expect(boxplot.series[0]).toMatchObject({ id: 'series:primary:boxplot', type: 'boxplot', data: [{ name: 'A', value: [1, 2, 3, 4, 5], __lv_dataset: 'primary', __lv_row_index: 0 }] })

--- a/web/components/dashboard/visualization/adapters/echarts/cartesian.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/cartesian.ts
@@ -117,14 +117,18 @@ function cartesianBaseOption(envelope: VisualizationEnvelope, context: RendererC
       xAxis: axis(envelope, spec.x, 'category', context), yAxis: axis(envelope, spec.y[0]!, 'category', context),
       visualMap: gradient
         ? {
-            min: gradient.minimum, max: gradient.maximum, calculable: false, orient: 'horizontal', left: 'center', bottom: 0,
+            type: 'continuous', dimension: value.field,
+            min: gradient.minimum, max: gradient.maximum, calculable: true, orient: 'horizontal', left: 'center', bottom: 0,
             inRange: { color: [seriesColor('', gradient.low.color, context), seriesColor('', gradient.high.color, context)] },
+            outOfRange: { opacity: 0 },
             text: [formatDisplayField(envelope, value, gradient.maximum, context), formatDisplayField(envelope, value, gradient.minimum, context)],
             textStyle: { color: context.colors.muted },
           }
         : fill ? undefined : {
-            min: extent.minimum, max: extent.maximum, calculable: false, orient: 'horizontal', left: 'center', bottom: 0,
+            type: 'continuous', dimension: value.field,
+            min: extent.minimum, max: extent.maximum, calculable: true, orient: 'horizontal', left: 'center', bottom: 0,
             inRange: { color: [colorWithAlpha(primary, 0.18), primary] },
+            outOfRange: { opacity: 0 },
             text: [formatDisplayField(envelope, value, extent.maximum, context), formatDisplayField(envelope, value, extent.minimum, context)],
             textStyle: { color: context.colors.muted },
           },


### PR DESCRIPTION
## Summary
- make cartesian heatmap visual maps calculable
- hide cells outside the selected range
- cover initial and narrowed range behavior in adapter and browser tests

## Validation
- frontend CI lane passed, including the browser regression and typechecks
- generated-file checks passed
- isolated apigen test passed; the full CI run reached its global 10-minute timeout while that unrelated Go test was still running
- staged diff check passed

Related: FAI-171, FAI-48