### PR TITLE
Stabilize APIGen managed TypeSpec cache tests

### DIFF
--- a/pkg/apigen/cmd/apigen/cache_test.go
+++ b/pkg/apigen/cmd/apigen/cache_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+var managedTypeSpecCacheRoot string
+
+func TestMain(m *testing.M) {
+	cacheRoot, err := os.MkdirTemp("", "apigen-typespec-test-cache-")
+	if err != nil {
+		os.Stderr.WriteString("create managed typespec test cache: " + err.Error() + "\n")
+		os.Exit(1)
+	}
+	managedTypeSpecCacheRoot = cacheRoot
+
+	code := m.Run()
+	if err := os.RemoveAll(cacheRoot); err != nil {
+		os.Stderr.WriteString("remove managed typespec test cache: " + err.Error() + "\n")
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}

--- a/pkg/apigen/cmd/apigen/main_test.go
+++ b/pkg/apigen/cmd/apigen/main_test.go
@@ -1867,7 +1867,7 @@ func setupManagedTypeSpecCache(t *testing.T) {
 	t.Setenv(typeSpecPackageDirEnv, "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	t.Setenv("XDG_CACHE_HOME", managedTypeSpecCacheRoot)
 }
 
 func writeCanonicalOpenAPI(t *testing.T, dir string, doc ir.Document) string {

--- a/pkg/apigen/cmd/apigen/main_test.go
+++ b/pkg/apigen/cmd/apigen/main_test.go
@@ -960,6 +960,20 @@ func TestInstallBundledTypeSpecPackage_UsesWritableCache(t *testing.T) {
 	require.FileExists(t, filepath.Join(pkg.Dir, "dist", "src", "index.js"))
 }
 
+func TestEnsureTypeSpecToolchain_InstallsColdManagedPackage(t *testing.T) {
+	t.Helper()
+
+	cacheRoot := t.TempDir()
+	pkg, err := installBundledTypeSpecPackage(cacheRoot)
+	require.NoError(t, err)
+	require.True(t, pkg.Managed)
+	require.FileExists(t, filepath.Join(pkg.Dir, ".apigen-bundle-sha256"))
+	require.FileExists(t, filepath.Join(pkg.Dir, "package-lock.json"))
+
+	require.NoError(t, ensureTypeSpecToolchain(pkg))
+	require.FileExists(t, filepath.Join(pkg.Dir, "node_modules", "@typespec", "compiler", "cmd", "tsp.js"))
+}
+
 func TestCompileTypeSpec_FailurePreservesExistingOutputs(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
## What

- Reuse one managed TypeSpec cache across ordinary APIGen command tests.
- Preserve per-test HOME isolation and add explicit cold managed-toolchain coverage.
- Remove the shared cache after the suite exits.

## Why

- Repeated npm ci calls caused the authoritative APIGen job to exceed its timeout.
- This independently blocks LeapView Chart Formatting validation in #478.

## Validation

- GOFLAGS=-buildvcs=false go -C pkg/apigen test ./cmd/apigen -count=1
- GOFLAGS=-buildvcs=false go -C pkg/apigen test ./cmd/apigen -count=2
- GOFLAGS=-buildvcs=false go -C pkg/apigen test ./cmd/apigen -run ^TestEnsureTypeSpecToolchain_InstallsColdManagedPackage$ -count=1
- npm test (pkg/apigen/typespec)
- npm run typecheck (pkg/apigen/typespec)
- npm run check:dist (pkg/apigen/typespec)

## Contract coverage

Test infrastructure only; no public contract, production code, or generated artifacts changed.

Linear: FAI-751
Project: LeapView Chart Formatting