### PR TITLE
Make proportional and polar chart formatting truthful by mark

### DIFF
--- a/docs/visuals/donut.md
+++ b/docs/visuals/donut.md
@@ -4,6 +4,8 @@ Use a donut chart for part-to-whole comparisons that benefit from a central anno
 
 Every preview on this page is generated from the YAML shown below it using a fixed documentation dataset.
 
+Donut presentation supports `rose`, `centerLabel`, `labelPosition`, `innerRadius`, and `outerRadius`. `innerRadius: 0` is the boundary that closes the center; use the pie visual when no center is needed.
+
 ## Basic
 
 Use one categorical dimension and one metric to show each status as a share of the whole.

--- a/docs/visuals/funnel.md
+++ b/docs/visuals/funnel.md
@@ -4,6 +4,8 @@ Use a funnel chart to show ordered stages whose values usually decrease through 
 
 Every preview on this page is generated from the YAML shown below it using a fixed documentation dataset.
 
+Funnel presentation supports `orientation`, `labelPosition`, `align`, and `sort`. Pie and donut geometry fields such as `rose`, `centerLabel`, `innerRadius`, and `outerRadius` do not apply to stages.
+
 ## Ordered conversion stages
 
 Use actual sequential stages whose population narrows through one process. Numeric prefixes keep the business sequence explicit and stable.

--- a/docs/visuals/gauge.md
+++ b/docs/visuals/gauge.md
@@ -4,6 +4,8 @@ Use a gauge to communicate one value against a known range or threshold scale.
 
 Every preview on this page is generated from the YAML shown below it using a fixed documentation dataset.
 
+Gauge presentation requires an explicit `minimum` and `maximum` domain. Optional `target`, `showPointer`, `progressWidth`, and `thresholds` annotate that domain; gauge values at either configured boundary remain in range.
+
 ## Customer review health
 
 Use a naturally bounded score with an explicit target, so the position and distance from goal are immediately interpretable.

--- a/docs/visuals/index.md
+++ b/docs/visuals/index.md
@@ -35,6 +35,20 @@ Fixed units remain fixed even when the current filtered values are smaller or la
 
 Policies also bound label length by Unicode grapheme, set minimum collision spacing, and declare whether selected, anomalous, or threshold-crossing data should win a collision. The same frame, locale, dimensions, and policy always produce the same label decision. Full untruncated values remain in governed tooltips when `tooltipFallback` is enabled.
 
+## Per-mark presentation
+
+Proportional and polar presentations share the common `legend`, `labels`, and `displayUnits` fields where those channels are meaningful. Mark-specific fields are intentionally scoped to the marks that can render them:
+
+| Mark | Mark-specific presentation fields |
+| --- | --- |
+| Pie | `rose`, `labelPosition`, `outerRadius` |
+| Donut | `rose`, `centerLabel`, `labelPosition`, `innerRadius`, `outerRadius` |
+| Funnel | `orientation`, `labelPosition`, `align`, `sort` |
+| Radar | `area`, `maximum` |
+| Gauge | `minimum`, `maximum`, `target`, `showPointer`, `progressWidth`, `thresholds` |
+
+Gauge has no categorical legend; radar uses `legend` for named governed series. A field from another mark's row is rejected during project validation rather than silently changing the rendered visual.
+
 ## Decision-context capability matrix
 
 All entries below describe renderer-neutral compiled contracts. Unsupported combinations fail project validation; LeapView never accepts an ECharts option object as a substitute.

--- a/docs/visuals/index.md
+++ b/docs/visuals/index.md
@@ -47,7 +47,7 @@ Proportional and polar presentations share the common `legend`, `labels`, and `d
 | Radar | `area`, `maximum` |
 | Gauge | `minimum`, `maximum`, `target`, `showPointer`, `progressWidth`, `thresholds` |
 
-Gauge has no categorical legend; radar uses `legend` for named governed series. A field from another mark's row is rejected during project validation rather than silently changing the rendered visual.
+Gauge has no categorical legend; radar can use `legend` when its aggregate query includes a second governed dimension for series values. A field from another mark's row is rejected during project validation rather than silently changing the rendered visual.
 
 ## Decision-context capability matrix
 

--- a/docs/visuals/pie.md
+++ b/docs/visuals/pie.md
@@ -4,6 +4,8 @@ Use a pie chart for a small number of categories that form a meaningful whole.
 
 Every preview on this page is generated from the YAML shown below it using a fixed documentation dataset.
 
+Pie presentation supports `rose`, `labelPosition`, and an optional `outerRadius`. Donut-only fields such as `centerLabel` and `innerRadius` are not part of the pie contract.
+
 ## Basic
 
 Use one categorical dimension and one metric for a part-to-whole comparison, sorting by value to keep the largest sectors easy to find.

--- a/docs/visuals/radar.md
+++ b/docs/visuals/radar.md
@@ -4,6 +4,8 @@ Use a radar chart to compare a compact set of category values around a shared sc
 
 Every preview on this page is generated from the YAML shown below it using a fixed documentation dataset.
 
+Radar presentation supports `area` and an optional shared `maximum` across its indicators. Gauge-only fields such as `minimum`, `target`, `showPointer`, `progressWidth`, and `thresholds` do not apply.
+
 ## Basic
 
 Use one categorical dimension to create the radar indicators and one metric to set each spoke length.

--- a/docs/visuals/radar.md
+++ b/docs/visuals/radar.md
@@ -8,7 +8,7 @@ Radar presentation supports `area` and an optional shared `maximum` across its i
 
 ## Basic
 
-Use one categorical dimension to create the radar indicators and one metric to set each spoke length.
+Use one categorical dimension to create the radar indicators and one metric to set each spoke length. Add a second dimension to compare governed series; the first dimension remains the category and `presentation.legend` controls the series legend.
 
 {{< visual id="status_radar" >}}
 

--- a/internal/dashboard/compiler/dashboard_presentation_lowering.go
+++ b/internal/dashboard/compiler/dashboard_presentation_lowering.go
@@ -140,6 +140,9 @@ func LowerCanonicalDashboardPresentation(value document.DashboardPresentation, v
 		if err != nil {
 			return nil, err
 		}
+		if visualType == document.DashboardVisualTypeDonut && variant.CenterLabel != nil && strings.TrimSpace(*variant.CenterLabel) == "" {
+			return nil, fmt.Errorf("presentation.centerLabel must not be empty")
+		}
 		out := visualizationir.ProportionalVisualizationPresentation{VisualizationPresentation: base, Orientation: visualizationir.VisualizationOrientationVertical}
 		if variant.Orientation != nil {
 			orientation, orientationErr := lowerOrientation(*variant.Orientation)

--- a/internal/dashboard/compiler/dashboard_presentation_lowering.go
+++ b/internal/dashboard/compiler/dashboard_presentation_lowering.go
@@ -161,18 +161,40 @@ func LowerCanonicalDashboardPresentation(value document.DashboardPresentation, v
 		}
 		out.InnerRadius = variant.InnerRadius
 		out.OuterRadius = variant.OuterRadius
-		if out.InnerRadius != nil && (*out.InnerRadius < 0 || *out.InnerRadius > 1) {
-			return nil, fmt.Errorf("proportional innerRadius must be between zero and one")
+		if out.InnerRadius != nil {
+			if !finiteDashboardFloat(*out.InnerRadius) {
+				return nil, fmt.Errorf("presentation.innerRadius must be finite")
+			}
+			if *out.InnerRadius < 0 || *out.InnerRadius > 1 {
+				return nil, fmt.Errorf("presentation.innerRadius must be between zero and one")
+			}
 		}
-		if out.OuterRadius != nil && (*out.OuterRadius <= 0 || *out.OuterRadius > 1) {
-			return nil, fmt.Errorf("proportional outerRadius must be greater than zero and at most one")
+		if out.OuterRadius != nil {
+			if !finiteDashboardFloat(*out.OuterRadius) {
+				return nil, fmt.Errorf("presentation.outerRadius must be finite")
+			}
+			if *out.OuterRadius <= 0 || *out.OuterRadius > 1 {
+				return nil, fmt.Errorf("presentation.outerRadius must be greater than zero and at most one")
+			}
 		}
 		if out.InnerRadius != nil && out.OuterRadius != nil && *out.InnerRadius >= *out.OuterRadius {
-			return nil, fmt.Errorf("proportional innerRadius must be less than outerRadius")
+			return nil, fmt.Errorf("presentation.innerRadius must be less than outerRadius")
 		}
 		if variant.Align != nil {
+			switch *variant.Align {
+			case document.DashboardProportionalAlignmentLeft, document.DashboardProportionalAlignmentCenter, document.DashboardProportionalAlignmentRight:
+			default:
+				return nil, fmt.Errorf("presentation.align must be left, center, or right")
+			}
 			align := string(*variant.Align)
 			out.Align = &align
+		}
+		if variant.Sort != nil {
+			switch *variant.Sort {
+			case visualizationir.VisualizationSortDirectionAscending, visualizationir.VisualizationSortDirectionDescending:
+			default:
+				return nil, fmt.Errorf("presentation.sort must be ascending or descending")
+			}
 		}
 		out.Sort = variant.Sort
 		return out, nil
@@ -240,11 +262,51 @@ func LowerCanonicalDashboardPresentation(value document.DashboardPresentation, v
 		if variant.ShowPointer != nil {
 			out.ShowPointer = *variant.ShowPointer
 		}
-		if out.Minimum != nil && out.Maximum != nil && *out.Minimum >= *out.Maximum {
-			return nil, fmt.Errorf("polar minimum must be less than maximum")
+		if out.Minimum != nil && !finiteDashboardFloat(*out.Minimum) {
+			return nil, fmt.Errorf("presentation.minimum must be finite")
 		}
-		if out.ProgressWidth != nil && *out.ProgressWidth <= 0 {
-			return nil, fmt.Errorf("polar progressWidth must be greater than zero")
+		if out.Maximum != nil && !finiteDashboardFloat(*out.Maximum) {
+			return nil, fmt.Errorf("presentation.maximum must be finite")
+		}
+		if visualType == document.DashboardVisualTypeGauge && (out.Minimum == nil || out.Maximum == nil) {
+			return nil, fmt.Errorf("presentation.minimum and presentation.maximum are required for gauge visuals")
+		}
+		if out.Minimum != nil && out.Maximum != nil && *out.Minimum >= *out.Maximum {
+			return nil, fmt.Errorf("presentation.minimum must be less than maximum")
+		}
+		if visualType == document.DashboardVisualTypeRadar && out.Maximum != nil && *out.Maximum <= 0 {
+			return nil, fmt.Errorf("presentation.maximum must be greater than zero for radar visuals")
+		}
+		if out.Target != nil {
+			if !finiteDashboardFloat(*out.Target) {
+				return nil, fmt.Errorf("presentation.target must be finite")
+			}
+			if out.Minimum != nil && out.Maximum != nil && (*out.Target < *out.Minimum || *out.Target > *out.Maximum) {
+				return nil, fmt.Errorf("presentation.target must be within the gauge domain")
+			}
+		}
+		if out.ProgressWidth != nil {
+			if !finiteDashboardFloat(*out.ProgressWidth) {
+				return nil, fmt.Errorf("presentation.progressWidth must be finite")
+			}
+			if *out.ProgressWidth <= 0 {
+				return nil, fmt.Errorf("presentation.progressWidth must be greater than zero")
+			}
+		}
+		if out.Thresholds != nil {
+			var previous float64
+			for index, threshold := range *out.Thresholds {
+				if !finiteDashboardFloat(threshold.Value) {
+					return nil, fmt.Errorf("presentation.thresholds[%d].value must be finite", index)
+				}
+				if out.Minimum != nil && out.Maximum != nil && (threshold.Value < *out.Minimum || threshold.Value > *out.Maximum) {
+					return nil, fmt.Errorf("presentation.thresholds[%d].value must be within the gauge domain", index)
+				}
+				if index > 0 && threshold.Value <= previous {
+					return nil, fmt.Errorf("presentation.thresholds[%d].value must be greater than the previous threshold", index)
+				}
+				previous = threshold.Value
+			}
 		}
 		return out, nil
 	case *document.GeographicDashboardPresentation:
@@ -370,39 +432,91 @@ func LowerCanonicalDashboardPresentationForQuery(value document.DashboardPresent
 }
 
 func validateCanonicalPresentationApplicability(value document.DashboardPresentation, visualType document.DashboardVisualType) error {
-	variant, ok := value.Value.(*document.HierarchyDashboardPresentation)
-	if !ok || variant == nil {
-		return nil
-	}
-
 	optionSupported := func(option string, present bool, supported bool) error {
 		if present && !supported {
 			return fmt.Errorf("presentation.%s is not supported for %s visuals", option, visualType)
 		}
 		return nil
 	}
-	if err := optionSupported("orientation", variant.Orientation != nil, visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeSankey); err != nil {
-		return err
+	switch variant := value.Value.(type) {
+	case *document.HierarchyDashboardPresentation:
+		if variant == nil {
+			return nil
+		}
+		if err := optionSupported("orientation", variant.Orientation != nil, visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeSankey); err != nil {
+			return err
+		}
+		if err := optionSupported("initialDepth", variant.InitialDepth != nil, visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeTreemap); err != nil {
+			return err
+		}
+		if err := optionSupported("roam", variant.Roam != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeTreemap || visualType == document.DashboardVisualTypeSunburst); err != nil {
+			return err
+		}
+		if err := optionSupported("layout", variant.Layout != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeTree); err != nil {
+			return err
+		}
+		if err := optionSupported("breadcrumb", variant.Breadcrumb != nil, visualType == document.DashboardVisualTypeTreemap); err != nil {
+			return err
+		}
+		if err := optionSupported("nodeGap", variant.NodeGap != nil, visualType == document.DashboardVisualTypeSankey); err != nil {
+			return err
+		}
+		if err := optionSupported("curveness", variant.Curveness != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeSankey); err != nil {
+			return err
+		}
+		return optionSupported("focus", variant.Focus != nil, visualType == document.DashboardVisualTypeGraph)
+	case *document.ProportionalDashboardPresentation:
+		if variant == nil {
+			return nil
+		}
+		if err := optionSupported("orientation", variant.Orientation != nil, visualType == document.DashboardVisualTypeFunnel); err != nil {
+			return err
+		}
+		if err := optionSupported("rose", variant.Rose != nil, visualType == document.DashboardVisualTypePie || visualType == document.DashboardVisualTypeDonut); err != nil {
+			return err
+		}
+		if err := optionSupported("centerLabel", variant.CenterLabel != nil, visualType == document.DashboardVisualTypeDonut); err != nil {
+			return err
+		}
+		if err := optionSupported("innerRadius", variant.InnerRadius != nil, visualType == document.DashboardVisualTypeDonut); err != nil {
+			return err
+		}
+		if err := optionSupported("outerRadius", variant.OuterRadius != nil, visualType == document.DashboardVisualTypePie || visualType == document.DashboardVisualTypeDonut); err != nil {
+			return err
+		}
+		if err := optionSupported("align", variant.Align != nil, visualType == document.DashboardVisualTypeFunnel); err != nil {
+			return err
+		}
+		return optionSupported("sort", variant.Sort != nil, visualType == document.DashboardVisualTypeFunnel)
+	case *document.PolarDashboardPresentation:
+		if variant == nil {
+			return nil
+		}
+		if err := optionSupported("legend", variant.Legend != nil, visualType == document.DashboardVisualTypeRadar); err != nil {
+			return err
+		}
+		if err := optionSupported("minimum", variant.Minimum != nil, visualType == document.DashboardVisualTypeGauge); err != nil {
+			return err
+		}
+		if err := optionSupported("maximum", variant.Maximum != nil, visualType == document.DashboardVisualTypeGauge || visualType == document.DashboardVisualTypeRadar); err != nil {
+			return err
+		}
+		if err := optionSupported("target", variant.Target != nil, visualType == document.DashboardVisualTypeGauge); err != nil {
+			return err
+		}
+		if err := optionSupported("showPointer", variant.ShowPointer != nil, visualType == document.DashboardVisualTypeGauge); err != nil {
+			return err
+		}
+		if err := optionSupported("area", variant.Area != nil, visualType == document.DashboardVisualTypeRadar); err != nil {
+			return err
+		}
+		if err := optionSupported("progressWidth", variant.ProgressWidth != nil, visualType == document.DashboardVisualTypeGauge); err != nil {
+			return err
+		}
+		return optionSupported("thresholds", variant.Thresholds != nil, visualType == document.DashboardVisualTypeGauge)
+	default:
+		return nil
 	}
-	if err := optionSupported("initialDepth", variant.InitialDepth != nil, visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeTreemap); err != nil {
-		return err
-	}
-	if err := optionSupported("roam", variant.Roam != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeTree || visualType == document.DashboardVisualTypeTreemap || visualType == document.DashboardVisualTypeSunburst); err != nil {
-		return err
-	}
-	if err := optionSupported("layout", variant.Layout != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeTree); err != nil {
-		return err
-	}
-	if err := optionSupported("breadcrumb", variant.Breadcrumb != nil, visualType == document.DashboardVisualTypeTreemap); err != nil {
-		return err
-	}
-	if err := optionSupported("nodeGap", variant.NodeGap != nil, visualType == document.DashboardVisualTypeSankey); err != nil {
-		return err
-	}
-	if err := optionSupported("curveness", variant.Curveness != nil, visualType == document.DashboardVisualTypeGraph || visualType == document.DashboardVisualTypeSankey); err != nil {
-		return err
-	}
-	return optionSupported("focus", variant.Focus != nil, visualType == document.DashboardVisualTypeGraph)
 }
 
 // lowerCanonicalComboSeries maps the closed Dashboard combo policy into the

--- a/internal/dashboard/compiler/dashboard_presentation_lowering_test.go
+++ b/internal/dashboard/compiler/dashboard_presentation_lowering_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -100,6 +101,7 @@ func TestLowerCanonicalPresentationVariantsPreserveFieldsAndDefaults(t *testing.
 	initialDepth := int32(2)
 	roam := true
 	units := visualizationir.VisualizationDisplayUnitsBillions
+	minimum, maximum := 0.0, 100.0
 	layout := visualizationir.VisualizationHierarchyLayoutCircular
 	cases := []struct {
 		name       string
@@ -129,7 +131,7 @@ func TestLowerCanonicalPresentationVariantsPreserveFieldsAndDefaults(t *testing.
 		},
 		{
 			name: "polar", visualType: document.DashboardVisualTypeGauge,
-			value: document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", DisplayUnits: &units}},
+			value: document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", DisplayUnits: &units, Minimum: &minimum, Maximum: &maximum}},
 			check: func(t *testing.T, value any) {
 				got := value.(visualizationir.PolarVisualizationPresentation)
 				if got.DisplayUnits == nil || *got.DisplayUnits != visualizationir.VisualizationDisplayUnitsBillions || !got.ShowPointer {
@@ -172,6 +174,273 @@ func TestLowerCanonicalPresentationRejectsIncompatibleAndInvalidValues(t *testin
 		t.Fatal("zero table row height accepted")
 	}
 }
+
+func TestLowerCanonicalProportionalPresentationSupportsMarkSpecificOptions(t *testing.T) {
+	falseValue := false
+	zero, one := 0.0, 1.0
+	horizontal := document.DashboardOrientationHorizontal
+	center := document.DashboardProportionalAlignmentCenter
+	ascending := visualizationir.VisualizationSortDirectionAscending
+	cases := []struct {
+		name       string
+		visualType document.DashboardVisualType
+		value      document.ProportionalDashboardPresentation
+		check      func(t *testing.T, got visualizationir.ProportionalVisualizationPresentation)
+	}{
+		{
+			name: "pie preserves rose false and outer radius", visualType: document.DashboardVisualTypePie,
+			value: document.ProportionalDashboardPresentation{Type: "proportional", Rose: &falseValue, OuterRadius: &one},
+			check: func(t *testing.T, got visualizationir.ProportionalVisualizationPresentation) {
+				if got.Rose || got.OuterRadius == nil || *got.OuterRadius != 1 {
+					t.Fatalf("pie presentation = %#v", got)
+				}
+			},
+		},
+		{
+			name: "donut preserves zero inner radius", visualType: document.DashboardVisualTypeDonut,
+			value: document.ProportionalDashboardPresentation{Type: "proportional", Rose: &falseValue, InnerRadius: &zero, OuterRadius: &one, CenterLabel: stringPointer("Total")},
+			check: func(t *testing.T, got visualizationir.ProportionalVisualizationPresentation) {
+				if got.Rose || got.InnerRadius == nil || *got.InnerRadius != 0 || got.OuterRadius == nil || *got.OuterRadius != 1 || got.CenterLabel == nil || *got.CenterLabel != "Total" {
+					t.Fatalf("donut presentation = %#v", got)
+				}
+			},
+		},
+		{
+			name: "funnel preserves closed options", visualType: document.DashboardVisualTypeFunnel,
+			value: document.ProportionalDashboardPresentation{Type: "proportional", Orientation: &horizontal, Align: &center, Sort: &ascending},
+			check: func(t *testing.T, got visualizationir.ProportionalVisualizationPresentation) {
+				if got.Orientation != visualizationir.VisualizationOrientationHorizontal || got.Align == nil || *got.Align != "center" || got.Sort == nil || *got.Sort != ascending {
+					t.Fatalf("funnel presentation = %#v", got)
+				}
+			},
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			lowered, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: &test.value}, test.visualType)
+			if err != nil {
+				t.Fatalf("lower: %v", err)
+			}
+			got, ok := lowered.(visualizationir.ProportionalVisualizationPresentation)
+			if !ok {
+				t.Fatalf("lowered type = %T", lowered)
+			}
+			test.check(t, got)
+		})
+	}
+}
+
+func TestLowerCanonicalProportionalPresentationRejectsInapplicableOptions(t *testing.T) {
+	falseValue := false
+	zero := 0.0
+	vertical := document.DashboardOrientationVertical
+	center := document.DashboardProportionalAlignmentCenter
+	ascending := visualizationir.VisualizationSortDirectionAscending
+	cases := []struct {
+		name       string
+		visualType document.DashboardVisualType
+		set        func(*document.ProportionalDashboardPresentation)
+		want       string
+	}{
+		{name: "orientation on pie", visualType: document.DashboardVisualTypePie, set: func(value *document.ProportionalDashboardPresentation) { value.Orientation = &vertical }, want: "presentation.orientation"},
+		{name: "rose false on funnel", visualType: document.DashboardVisualTypeFunnel, set: func(value *document.ProportionalDashboardPresentation) { value.Rose = &falseValue }, want: "presentation.rose"},
+		{name: "center label on pie", visualType: document.DashboardVisualTypePie, set: func(value *document.ProportionalDashboardPresentation) { value.CenterLabel = stringPointer("ignored") }, want: "presentation.centerLabel"},
+		{name: "inner radius on pie", visualType: document.DashboardVisualTypePie, set: func(value *document.ProportionalDashboardPresentation) { value.InnerRadius = &zero }, want: "presentation.innerRadius"},
+		{name: "outer radius on funnel", visualType: document.DashboardVisualTypeFunnel, set: func(value *document.ProportionalDashboardPresentation) { value.OuterRadius = &zero }, want: "presentation.outerRadius"},
+		{name: "align on donut", visualType: document.DashboardVisualTypeDonut, set: func(value *document.ProportionalDashboardPresentation) { value.Align = &center }, want: "presentation.align"},
+		{name: "sort on pie", visualType: document.DashboardVisualTypePie, set: func(value *document.ProportionalDashboardPresentation) { value.Sort = &ascending }, want: "presentation.sort"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			value := &document.ProportionalDashboardPresentation{Type: "proportional"}
+			test.set(value)
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, test.visualType)
+			if err == nil || !strings.Contains(err.Error(), test.want+" is not supported for "+string(test.visualType)+" visuals") {
+				t.Fatalf("error = %v, want path-bearing applicability error", err)
+			}
+		})
+	}
+}
+
+func TestLowerCanonicalProportionalPresentationRejectsNonFiniteAndUnknownFunnelValues(t *testing.T) {
+	cases := []struct {
+		name string
+		set  func(*document.ProportionalDashboardPresentation)
+		want string
+	}{
+		{name: "non-finite inner radius", set: func(value *document.ProportionalDashboardPresentation) {
+			radius := math.NaN()
+			value.InnerRadius = &radius
+		}, want: "presentation.innerRadius must be finite"},
+		{name: "non-finite outer radius", set: func(value *document.ProportionalDashboardPresentation) {
+			radius := math.Inf(1)
+			value.OuterRadius = &radius
+		}, want: "presentation.outerRadius must be finite"},
+		{name: "inner radius below zero", set: func(value *document.ProportionalDashboardPresentation) { radius := -0.1; value.InnerRadius = &radius }, want: "presentation.innerRadius must be between zero and one"},
+		{name: "outer radius zero", set: func(value *document.ProportionalDashboardPresentation) { radius := 0.0; value.OuterRadius = &radius }, want: "presentation.outerRadius must be greater than zero"},
+		{name: "inner radius not below outer radius", set: func(value *document.ProportionalDashboardPresentation) {
+			inner, outer := 0.8, 0.8
+			value.InnerRadius, value.OuterRadius = &inner, &outer
+		}, want: "presentation.innerRadius must be less than outerRadius"},
+		{name: "unknown align", set: func(value *document.ProportionalDashboardPresentation) {
+			align := document.DashboardProportionalAlignment("start")
+			value.Align = &align
+		}, want: "presentation.align must be left, center, or right"},
+		{name: "unknown sort", set: func(value *document.ProportionalDashboardPresentation) {
+			sort := visualizationir.VisualizationSortDirection("natural")
+			value.Sort = &sort
+		}, want: "presentation.sort must be ascending or descending"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			value := &document.ProportionalDashboardPresentation{Type: "proportional"}
+			test.set(value)
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, func() document.DashboardVisualType {
+				if value.Align != nil || value.Sort != nil {
+					return document.DashboardVisualTypeFunnel
+				}
+				return document.DashboardVisualTypeDonut
+			}())
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLowerCanonicalPolarPresentationSupportsGaugeAndRadarOptions(t *testing.T) {
+	minimum, maximum, target, progressWidth := 0.0, 100.0, 100.0, 12.0
+	showPointer := false
+	area := false
+	thresholds := []visualizationir.VisualizationThreshold{{Value: 0, Tone: visualizationir.VisualizationToneSuccess}, {Value: 50, Tone: visualizationir.VisualizationToneWarning}, {Value: 100, Tone: visualizationir.VisualizationToneDanger}}
+	gauge, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", Minimum: &minimum, Maximum: &maximum, Target: &target, ShowPointer: &showPointer, ProgressWidth: &progressWidth, Thresholds: &thresholds}}, document.DashboardVisualTypeGauge)
+	if err != nil {
+		t.Fatalf("lower gauge: %v", err)
+	}
+	gaugePresentation := gauge.(visualizationir.PolarVisualizationPresentation)
+	if gaugePresentation.ShowPointer || gaugePresentation.Target == nil || *gaugePresentation.Target != 100 || gaugePresentation.ProgressWidth == nil || *gaugePresentation.ProgressWidth != 12 || gaugePresentation.Thresholds == nil || len(*gaugePresentation.Thresholds) != 3 {
+		t.Fatalf("gauge presentation = %#v", gaugePresentation)
+	}
+
+	maximum = 10
+	legend := document.DashboardLegendPositionRight
+	radar, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", Legend: &legend, Maximum: &maximum, Area: &area}}, document.DashboardVisualTypeRadar)
+	if err != nil {
+		t.Fatalf("lower radar: %v", err)
+	}
+	radarPresentation := radar.(visualizationir.PolarVisualizationPresentation)
+	if radarPresentation.Legend != visualizationir.VisualizationLegendPositionRight || radarPresentation.Maximum == nil || *radarPresentation.Maximum != 10 || radarPresentation.Area == nil || *radarPresentation.Area {
+		t.Fatalf("radar presentation = %#v", radarPresentation)
+	}
+}
+
+func TestLowerCanonicalPolarPresentationRejectsInapplicableAndInvalidOptions(t *testing.T) {
+	falseValue := false
+	zero := 0.0
+	minimum, maximum := 0.0, 100.0
+	legend := document.DashboardLegendPositionRight
+	emptyThresholds := []visualizationir.VisualizationThreshold{}
+	cases := []struct {
+		name       string
+		visualType document.DashboardVisualType
+		set        func(*document.PolarDashboardPresentation)
+		want       string
+	}{
+		{name: "minimum on radar", visualType: document.DashboardVisualTypeRadar, set: func(value *document.PolarDashboardPresentation) { value.Minimum = &zero }, want: "presentation.minimum is not supported for radar visuals"},
+		{name: "legend on gauge", visualType: document.DashboardVisualTypeGauge, set: func(value *document.PolarDashboardPresentation) { value.Legend = &legend }, want: "presentation.legend is not supported for gauge visuals"},
+		{name: "target on radar", visualType: document.DashboardVisualTypeRadar, set: func(value *document.PolarDashboardPresentation) { value.Target = &zero }, want: "presentation.target is not supported for radar visuals"},
+		{name: "pointer false on radar", visualType: document.DashboardVisualTypeRadar, set: func(value *document.PolarDashboardPresentation) { value.ShowPointer = &falseValue }, want: "presentation.showPointer is not supported for radar visuals"},
+		{name: "area false on gauge", visualType: document.DashboardVisualTypeGauge, set: func(value *document.PolarDashboardPresentation) { value.Area = &falseValue }, want: "presentation.area is not supported for gauge visuals"},
+		{name: "progress zero on radar", visualType: document.DashboardVisualTypeRadar, set: func(value *document.PolarDashboardPresentation) { value.ProgressWidth = &zero }, want: "presentation.progressWidth is not supported for radar visuals"},
+		{name: "empty thresholds on radar", visualType: document.DashboardVisualTypeRadar, set: func(value *document.PolarDashboardPresentation) { value.Thresholds = &emptyThresholds }, want: "presentation.thresholds is not supported for radar visuals"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			value := &document.PolarDashboardPresentation{Type: "polar"}
+			test.set(value)
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, test.visualType)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name string
+		set  func(*document.PolarDashboardPresentation)
+		want string
+	}{
+		{name: "missing minimum", set: func(value *document.PolarDashboardPresentation) { value.Maximum = &maximum }, want: "presentation.minimum and presentation.maximum are required"},
+		{name: "missing maximum", set: func(value *document.PolarDashboardPresentation) { value.Minimum = &minimum }, want: "presentation.minimum and presentation.maximum are required"},
+		{name: "non-finite minimum", set: func(value *document.PolarDashboardPresentation) {
+			value.Minimum, value.Maximum = floatPointer(math.NaN()), &maximum
+		}, want: "presentation.minimum must be finite"},
+		{name: "non-finite maximum", set: func(value *document.PolarDashboardPresentation) {
+			value.Minimum, value.Maximum = &minimum, floatPointer(math.Inf(1))
+		}, want: "presentation.maximum must be finite"},
+		{name: "reversed domain", set: func(value *document.PolarDashboardPresentation) {
+			lower, upper := 10.0, 1.0
+			value.Minimum, value.Maximum = &lower, &upper
+		}, want: "presentation.minimum must be less than maximum"},
+		{name: "non-finite target", set: func(value *document.PolarDashboardPresentation) {
+			value.Minimum, value.Maximum, value.Target = &minimum, &maximum, floatPointer(math.NaN())
+		}, want: "presentation.target must be finite"},
+		{name: "target below domain", set: func(value *document.PolarDashboardPresentation) {
+			target := -1.0
+			value.Minimum, value.Maximum, value.Target = &minimum, &maximum, &target
+		}, want: "presentation.target must be within the gauge domain"},
+		{name: "non-finite progress width", set: func(value *document.PolarDashboardPresentation) {
+			value.Minimum, value.Maximum, value.ProgressWidth = &minimum, &maximum, floatPointer(math.Inf(1))
+		}, want: "presentation.progressWidth must be finite"},
+		{name: "zero progress width", set: func(value *document.PolarDashboardPresentation) {
+			value.Minimum, value.Maximum, value.ProgressWidth = &minimum, &maximum, floatPointer(0)
+		}, want: "presentation.progressWidth must be greater than zero"},
+		{name: "non-finite threshold", set: func(value *document.PolarDashboardPresentation) {
+			thresholds := []visualizationir.VisualizationThreshold{{Value: math.NaN()}}
+			value.Minimum, value.Maximum, value.Thresholds = &minimum, &maximum, &thresholds
+		}, want: "presentation.thresholds[0].value must be finite"},
+		{name: "threshold outside domain", set: func(value *document.PolarDashboardPresentation) {
+			thresholds := []visualizationir.VisualizationThreshold{{Value: 101}}
+			value.Minimum, value.Maximum, value.Thresholds = &minimum, &maximum, &thresholds
+		}, want: "presentation.thresholds[0].value must be within the gauge domain"},
+		{name: "thresholds not ordered", set: func(value *document.PolarDashboardPresentation) {
+			thresholds := []visualizationir.VisualizationThreshold{{Value: 50}, {Value: 50}}
+			value.Minimum, value.Maximum, value.Thresholds = &minimum, &maximum, &thresholds
+		}, want: "presentation.thresholds[1].value must be greater than the previous threshold"},
+	}
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			value := &document.PolarDashboardPresentation{Type: "polar"}
+			test.set(value)
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, document.DashboardVisualTypeGauge)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		name  string
+		value float64
+		want  string
+	}{
+		{name: "non-finite maximum", value: math.NaN(), want: "presentation.maximum must be finite"},
+		{name: "zero maximum", value: 0, want: "presentation.maximum must be greater than zero for radar visuals"},
+		{name: "negative maximum", value: -1, want: "presentation.maximum must be greater than zero for radar visuals"},
+	} {
+		t.Run("radar "+test.name, func(t *testing.T) {
+			maximum := test.value
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", Maximum: &maximum}}, document.DashboardVisualTypeRadar)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func stringPointer(value string) *string { return &value }
+
+func floatPointer(value float64) *float64 { return &value }
 
 func TestLowerCanonicalHierarchyPresentationSupportsOptionsByVisualType(t *testing.T) {
 	tests := []struct {

--- a/internal/dashboard/compiler/dashboard_presentation_lowering_test.go
+++ b/internal/dashboard/compiler/dashboard_presentation_lowering_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -257,6 +258,17 @@ func TestLowerCanonicalProportionalPresentationRejectsInapplicableOptions(t *tes
 			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, test.visualType)
 			if err == nil || !strings.Contains(err.Error(), test.want+" is not supported for "+string(test.visualType)+" visuals") {
 				t.Fatalf("error = %v, want path-bearing applicability error", err)
+			}
+		})
+	}
+}
+
+func TestLowerCanonicalDonutRejectsBlankCenterLabel(t *testing.T) {
+	for _, label := range []string{"", "   \t"} {
+		t.Run(fmt.Sprintf("%q", label), func(t *testing.T) {
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: &document.ProportionalDashboardPresentation{Type: "proportional", CenterLabel: stringPointer(label)}}, document.DashboardVisualTypeDonut)
+			if err == nil || !strings.Contains(err.Error(), "presentation.centerLabel must not be empty") {
+				t.Fatalf("error = %v, want actionable centerLabel error", err)
 			}
 		})
 	}

--- a/internal/dashboard/compiler/document_compile_contract_test.go
+++ b/internal/dashboard/compiler/document_compile_contract_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/flidai/leapview/internal/dashboard/document"
@@ -260,6 +261,92 @@ func TestCanonicalVisualizationSpecsCompileProportionalAndPolarAuthoredOptions(t
 			test.check(t, spec)
 		})
 	}
+}
+
+func TestCanonicalPolarVisualizationSpecEnforcesShapeAndSeriesContracts(t *testing.T) {
+	model := dashboardQueryTestModel()
+	metric := []visualizationdefinition.FieldBinding{{FieldID: "revenue", Alias: "revenue"}}
+	query := func(dimensions []visualizationdefinition.FieldBinding, shape visualizationdefinition.ResultShape) LoweredDashboardQuery {
+		frame := make([]DashboardQueryResultField, 0, len(dimensions)+1)
+		for _, dimension := range dimensions {
+			frame = append(frame, DashboardQueryResultField{Source: dimension.FieldID, Name: dimension.Alias})
+		}
+		frame = append(frame, DashboardQueryResultField{Source: "revenue", Name: "revenue"})
+		return LoweredDashboardQuery{
+			Type: "aggregate",
+			Binding: visualizationdefinition.QueryBinding{
+				ResultShape: shape,
+				Aggregate:   &visualizationdefinition.AggregateQueryBinding{Dimensions: dimensions, Metrics: metric},
+			},
+			ResultFrame: frame,
+		}
+	}
+	compile := func(t *testing.T, visualType document.DashboardVisualType, visual document.DashboardVisual, lowered LoweredDashboardQuery) visualizationir.VisualizationSpec {
+		t.Helper()
+		presentation, err := LowerCanonicalDashboardPresentationForQuery(visual.Presentation, visualType, lowered)
+		if err != nil {
+			t.Fatalf("lower presentation: %v", err)
+		}
+		spec, err := canonicalVisualizationSpec(string(visualType), visual, lowered, presentation, nil, model)
+		if err != nil {
+			t.Fatalf("compile spec: %v", err)
+		}
+		return spec
+	}
+
+	t.Run("gauge accepts scalar shape only", func(t *testing.T) {
+		visual := document.DashboardVisual{Type: document.DashboardVisualTypeGauge, Presentation: document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", Minimum: floatPointer(0), Maximum: floatPointer(100)}}}
+		spec := compile(t, document.DashboardVisualTypeGauge, visual, query(nil, visualizationdefinition.ResultScalar))
+		got := spec.Value.(*visualizationir.PolarVisualizationSpec)
+		if got.Category != nil || got.Series != nil || got.Value.Field != "revenue" {
+			t.Fatalf("gauge spec = %#v", got)
+		}
+	})
+
+	t.Run("gauge rejects category dimension", func(t *testing.T) {
+		visual := document.DashboardVisual{Type: document.DashboardVisualTypeGauge, Presentation: document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", Minimum: floatPointer(0), Maximum: floatPointer(100)}}}
+		presentation, err := LowerCanonicalDashboardPresentationForQuery(visual.Presentation, visual.Type, query([]visualizationdefinition.FieldBinding{{FieldID: "state", Alias: "state"}}, visualizationdefinition.ResultCategoryValue))
+		if err != nil {
+			t.Fatalf("lower presentation: %v", err)
+		}
+		_, err = canonicalVisualizationSpec("gauge", visual, query([]visualizationdefinition.FieldBinding{{FieldID: "state", Alias: "state"}}, visualizationdefinition.ResultCategoryValue), presentation, nil, model)
+		if err == nil || !strings.Contains(err.Error(), "gauge requires zero dimensions") {
+			t.Fatalf("error = %v, want gauge dimension contract", err)
+		}
+	})
+
+	t.Run("radar requires category dimension", func(t *testing.T) {
+		visual := document.DashboardVisual{Type: document.DashboardVisualTypeRadar, Presentation: document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar"}}}
+		lowered := query(nil, visualizationdefinition.ResultScalar)
+		presentation, err := LowerCanonicalDashboardPresentationForQuery(visual.Presentation, visual.Type, lowered)
+		if err != nil {
+			t.Fatalf("lower presentation: %v", err)
+		}
+		_, err = canonicalVisualizationSpec("radar", visual, lowered, presentation, nil, model)
+		if err == nil || !strings.Contains(err.Error(), "radar requires exactly one category dimension") {
+			t.Fatalf("error = %v, want radar category contract", err)
+		}
+	})
+
+	t.Run("radar derives second dimension as governed series", func(t *testing.T) {
+		dimensions := []visualizationdefinition.FieldBinding{{FieldID: "state", Alias: "state"}, {FieldID: "status", Alias: "status"}}
+		lowered := query(dimensions, visualizationdefinition.ResultCategoryMultiMeasure)
+		if err := lowerCanonicalVisualSeries(&lowered, document.DashboardVisualTypeRadar); err != nil {
+			t.Fatalf("lower radar series: %v", err)
+		}
+		if lowered.Binding.ResultShape != visualizationdefinition.ResultCategorySeriesValue || lowered.Binding.Aggregate.Series == nil || lowered.Binding.Aggregate.Series.Alias != "status" {
+			t.Fatalf("radar query series = %#v", lowered.Binding)
+		}
+		visual := document.DashboardVisual{Type: document.DashboardVisualTypeRadar, Presentation: document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", Legend: func() *document.DashboardLegendPosition {
+			value := document.DashboardLegendPositionRight
+			return &value
+		}()}}}
+		spec := compile(t, document.DashboardVisualTypeRadar, visual, lowered)
+		got := spec.Value.(*visualizationir.PolarVisualizationSpec)
+		if got.Category == nil || got.Category.Field != "state" || got.Series == nil || got.Series.Field != "status" || got.Value.Field != "revenue" {
+			t.Fatalf("radar spec = %#v", got)
+		}
+	})
 }
 
 func alignmentPointer(value document.DashboardProportionalAlignment) *document.DashboardProportionalAlignment {

--- a/internal/dashboard/compiler/document_compile_contract_test.go
+++ b/internal/dashboard/compiler/document_compile_contract_test.go
@@ -176,6 +176,100 @@ func TestCanonicalVisualizationSpecBoxplotAndCandlestickContracts(t *testing.T) 
 	}
 }
 
+func TestCanonicalVisualizationSpecsCompileProportionalAndPolarAuthoredOptions(t *testing.T) {
+	model := dashboardQueryTestModel()
+	dimension := []visualizationdefinition.FieldBinding{{FieldID: "status", Alias: "status"}}
+	metric := []visualizationdefinition.FieldBinding{{FieldID: "revenue", Alias: "revenue"}}
+	categoryQuery := LoweredDashboardQuery{
+		Type: "aggregate",
+		Binding: visualizationdefinition.QueryBinding{
+			ResultShape: visualizationdefinition.ResultCategoryValue,
+			Aggregate:   &visualizationdefinition.AggregateQueryBinding{Dimensions: dimension, Metrics: metric},
+		},
+		ResultFrame: []DashboardQueryResultField{{Name: "status"}, {Name: "revenue"}},
+	}
+	valueQuery := LoweredDashboardQuery{
+		Type: "aggregate",
+		Binding: visualizationdefinition.QueryBinding{
+			ResultShape: visualizationdefinition.ResultCategoryValue,
+			Aggregate:   &visualizationdefinition.AggregateQueryBinding{Metrics: metric},
+		},
+		ResultFrame: []DashboardQueryResultField{{Name: "revenue"}},
+	}
+	outerRadius := 1.0
+	minimum, maximum := 0.0, 100.0
+	showPointer := false
+	cases := []struct {
+		name       string
+		visualType document.DashboardVisualType
+		visual     document.DashboardVisual
+		query      LoweredDashboardQuery
+		check      func(t *testing.T, spec visualizationir.VisualizationSpec)
+	}{
+		{
+			name: "donut authored geometry", visualType: document.DashboardVisualTypeDonut, query: categoryQuery,
+			visual: document.DashboardVisual{Type: document.DashboardVisualTypeDonut, Presentation: document.DashboardPresentation{Value: &document.ProportionalDashboardPresentation{Type: "proportional", InnerRadius: floatPointer(0), OuterRadius: &outerRadius, CenterLabel: stringPointer("Orders")}}},
+			check: func(t *testing.T, spec visualizationir.VisualizationSpec) {
+				got := spec.Value.(*visualizationir.ProportionalVisualizationSpec)
+				if got.Mark != visualizationir.VisualizationProportionalMarkDonut || got.Category.Field != "status" || got.Value.Field != "revenue" || got.Presentation.InnerRadius == nil || *got.Presentation.InnerRadius != 0 || got.Presentation.CenterLabel == nil || *got.Presentation.CenterLabel != "Orders" {
+					t.Fatalf("donut spec = %#v", got)
+				}
+			},
+		},
+		{
+			name: "funnel authored ordering", visualType: document.DashboardVisualTypeFunnel, query: categoryQuery,
+			visual: document.DashboardVisual{Type: document.DashboardVisualTypeFunnel, Presentation: document.DashboardPresentation{Value: &document.ProportionalDashboardPresentation{Type: "proportional", Align: alignmentPointer(document.DashboardProportionalAlignmentCenter), Sort: sortPointer(visualizationir.VisualizationSortDirectionDescending)}}},
+			check: func(t *testing.T, spec visualizationir.VisualizationSpec) {
+				got := spec.Value.(*visualizationir.ProportionalVisualizationSpec)
+				if got.Mark != visualizationir.VisualizationProportionalMarkFunnel || got.Presentation.Align == nil || *got.Presentation.Align != "center" || got.Presentation.Sort == nil || *got.Presentation.Sort != visualizationir.VisualizationSortDirectionDescending {
+					t.Fatalf("funnel spec = %#v", got)
+				}
+			},
+		},
+		{
+			name: "gauge authored domain and pointer", visualType: document.DashboardVisualTypeGauge, query: valueQuery,
+			visual: document.DashboardVisual{Type: document.DashboardVisualTypeGauge, Presentation: document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", Minimum: &minimum, Maximum: &maximum, ShowPointer: &showPointer}}},
+			check: func(t *testing.T, spec visualizationir.VisualizationSpec) {
+				got := spec.Value.(*visualizationir.PolarVisualizationSpec)
+				if got.Mark != visualizationir.VisualizationPolarMarkGauge || got.Value.Field != "revenue" || got.Presentation.Minimum == nil || *got.Presentation.Minimum != 0 || got.Presentation.Maximum == nil || *got.Presentation.Maximum != 100 || got.Presentation.ShowPointer {
+					t.Fatalf("gauge spec = %#v", got)
+				}
+			},
+		},
+		{
+			name: "radar authored maximum", visualType: document.DashboardVisualTypeRadar, query: categoryQuery,
+			visual: document.DashboardVisual{Type: document.DashboardVisualTypeRadar, Presentation: document.DashboardPresentation{Value: &document.PolarDashboardPresentation{Type: "polar", Maximum: floatPointer(10)}}},
+			check: func(t *testing.T, spec visualizationir.VisualizationSpec) {
+				got := spec.Value.(*visualizationir.PolarVisualizationSpec)
+				if got.Mark != visualizationir.VisualizationPolarMarkRadar || got.Category == nil || got.Category.Field != "status" || got.Presentation.Maximum == nil || *got.Presentation.Maximum != 10 {
+					t.Fatalf("radar spec = %#v", got)
+				}
+			},
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			presentation, err := LowerCanonicalDashboardPresentationForQuery(test.visual.Presentation, test.visualType, test.query)
+			if err != nil {
+				t.Fatalf("lower presentation: %v", err)
+			}
+			spec, err := canonicalVisualizationSpec(test.name, test.visual, test.query, presentation, nil, model)
+			if err != nil {
+				t.Fatalf("compile spec: %v", err)
+			}
+			test.check(t, spec)
+		})
+	}
+}
+
+func alignmentPointer(value document.DashboardProportionalAlignment) *document.DashboardProportionalAlignment {
+	return &value
+}
+
+func sortPointer(value visualizationir.VisualizationSortDirection) *visualizationir.VisualizationSortDirection {
+	return &value
+}
+
 func fieldIDs(fields []visualizationir.VisualizationField) string {
 	ids := make([]string, len(fields))
 	for i, field := range fields {

--- a/internal/dashboard/compiler/document_compile_validation.go
+++ b/internal/dashboard/compiler/document_compile_validation.go
@@ -13,7 +13,7 @@ func lowerCanonicalVisualSeries(query *LoweredDashboardQuery, visualType documen
 		return nil
 	}
 	switch visualType {
-	case document.DashboardVisualTypeLine, document.DashboardVisualTypeArea, document.DashboardVisualTypeBar, document.DashboardVisualTypeColumn:
+	case document.DashboardVisualTypeLine, document.DashboardVisualTypeArea, document.DashboardVisualTypeBar, document.DashboardVisualTypeColumn, document.DashboardVisualTypeRadar:
 	default:
 		return nil
 	}

--- a/internal/dashboard/compiler/document_compile_visualization.go
+++ b/internal/dashboard/compiler/document_compile_visualization.go
@@ -222,8 +222,12 @@ func canonicalVisualizationSpec(id string, visual document.DashboardVisual, quer
 		if !ok {
 			return visualizationir.VisualizationSpec{}, fmt.Errorf("polar presentation lowering returned %T", presentation)
 		}
-		if len(dimensions) > 1 || len(metrics) != 1 {
-			return visualizationir.VisualizationSpec{}, fmt.Errorf("polar requires zero or one dimension and exactly one metric, got %d and %d", len(dimensions), len(metrics))
+		if typ == document.DashboardVisualTypeGauge {
+			if len(dimensions) != 0 || len(metrics) != 1 {
+				return visualizationir.VisualizationSpec{}, fmt.Errorf("gauge requires zero dimensions and exactly one metric, got %d and %d", len(dimensions), len(metrics))
+			}
+		} else if len(dimensions) != 1 || len(metrics) != 1 {
+			return visualizationir.VisualizationSpec{}, fmt.Errorf("radar requires exactly one category dimension and exactly one metric, got %d and %d", len(dimensions), len(metrics))
 		}
 		base.Kind = "polar"
 		var category *visualizationir.VisualizationFieldRef
@@ -231,7 +235,12 @@ func canonicalVisualizationSpec(id string, visual document.DashboardVisual, quer
 			categoryRef := dimensions[0]
 			category = &categoryRef
 		}
-		return visualizationir.VisualizationSpec{Value: &visualizationir.PolarVisualizationSpec{VisualizationSpecBase: base, Kind: "polar", Mark: visualizationir.VisualizationPolarMark(typ), Category: category, Value: metricRef(0), Presentation: p}}, nil
+		var series *visualizationir.VisualizationFieldRef
+		if query.Binding.Aggregate != nil && query.Binding.Aggregate.Series != nil {
+			seriesRef := visualizationir.VisualizationFieldRef{Dataset: "primary", Field: query.Binding.Aggregate.Series.Alias}
+			series = &seriesRef
+		}
+		return visualizationir.VisualizationSpec{Value: &visualizationir.PolarVisualizationSpec{VisualizationSpecBase: base, Kind: "polar", Mark: visualizationir.VisualizationPolarMark(typ), Category: category, Value: metricRef(0), Series: series, Presentation: p}}, nil
 	case document.DashboardVisualTypeScatter:
 		p, ok := presentation.(visualizationir.PointVisualizationPresentation)
 		if !ok {

--- a/web/components/dashboard/visualization/adapters/echarts-polar.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts-polar.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from 'bun:test'
+
+import type { VisualizationEnvelope } from '../../../../generated/visualization'
+import { defaultRendererContext } from '../host-controller'
+import { echartsOption } from './echarts'
+
+test('ECharts translation builds radar indicators and aligned series from typed fields', () => {
+  const envelope = {
+    schemaVersion: 9, visualID: 'quality', rendererID: 'echarts', specRevision: 'sha256:test', dataRevision: 1,
+    spec: {
+      kind: 'polar', title: 'Quality', mark: 'radar',
+      datasets: [{ id: 'primary', fields: [
+        { id: 'metric', role: 'dimension', dataType: 'string', nullable: false, label: 'Metric' },
+        { id: 'team', role: 'dimension', dataType: 'string', nullable: false, label: 'Team' },
+        { id: 'value', role: 'metric', dataType: 'decimal', nullable: false, label: 'Value' },
+      ] }],
+      dataBudget: { maxRows: 100, requiredCompleteness: 'complete' }, accessibility: { title: 'Quality', description: 'Quality by team' }, interactions: [],
+      category: { dataset: 'primary', field: 'metric' }, series: { dataset: 'primary', field: 'team' }, value: { dataset: 'primary', field: 'value' },
+      presentation: { legend: 'bottom', labelPolicy: { density: 'hidden', priority: [], maxCharacters: 24, minimumSpacing: 0, tooltipFallback: true }, showPointer: false, area: true },
+    },
+    dataState: { kind: 'inline', specRevision: 'sha256:test', dataRevision: 1, generation: 1, datasets: [{
+      id: 'primary', specRevision: 'sha256:test', dataRevision: 1, generation: 1, columns: ['metric', 'team', 'value'],
+      rows: [['Speed', 'A', '8'], ['Quality', 'A', '9'], ['Speed', 'B', '6'], ['Quality', 'B', '7']], completeness: 'complete',
+    }] },
+    selection: [], status: { kind: 'ready' }, diagnostics: [],
+  } as VisualizationEnvelope
+  const context = {
+    ...defaultRendererContext,
+    theme: 'dark' as const,
+    colors: { ...defaultRendererContext.colors, muted: '#9198a1', grid: '#3d444d', surface: '#151b23' },
+  }
+  const option = echartsOption(envelope, context) as any
+  expect(option.radar.indicator.map((item: any) => item.name)).toEqual(['Speed', 'Quality'])
+  expect(option.radar.indicator.map((item: any) => item.max)).toEqual([10, 10])
+  expect(option.radar).toMatchObject({
+    axisLine: { lineStyle: { color: context.colors.grid } },
+    splitLine: { lineStyle: { color: context.colors.grid } },
+    splitArea: { areaStyle: { color: [context.colors.surface, context.colors.grid], opacity: 0.18 } },
+  })
+  expect(option.series[0]).toMatchObject({ id: 'series:polar:radar', type: 'radar', areaStyle: {} })
+  expect(option.series[0]).not.toHaveProperty('pointer')
+  expect(option.series[0]).not.toHaveProperty('progress')
+  expect(option.series[0].data).toEqual([{ name: 'A', value: ['8', '9'] }, { name: 'B', value: ['6', '7'] }])
+
+  envelope.spec.presentation.maximum = 12
+  envelope.spec.presentation.area = false
+  const configured = echartsOption(envelope, context) as any
+  expect(configured.radar.indicator.map((item: any) => item.max)).toEqual([12, 12])
+  expect(configured.series[0]).toMatchObject({ id: 'series:polar:radar', type: 'radar' })
+  expect(configured.series[0].areaStyle).toBeUndefined()
+
+  envelope.spec.presentation.maximum = undefined
+  envelope.dataState.datasets[0].rows = [['Speed', 'A', '0'], ['Quality', 'A', '0']]
+  const zero = echartsOption(envelope, context) as any
+  expect(zero.radar.indicator.map((item: any) => item.max)).toEqual([1, 1])
+  expect(zero.series[0].data).toEqual([{ name: 'A', value: ['0', '0'] }])
+
+  envelope.dataState.datasets[0].rows = []
+  const empty = echartsOption(envelope, context) as any
+  expect(empty.radar.indicator).toEqual([])
+  expect(empty.series[0].data).toEqual([])
+})
+
+test('ECharts emits only mark-supported proportional fields and preserves explicit false and zero', () => {
+  const pie = proportionalFixture('pie') as any
+  pie.spec.presentation.rose = false
+  pie.spec.presentation.outerRadius = 1
+  pie.spec.presentation.labelPosition = 'inside'
+  pie.spec.presentation.centerLabel = 'Not a pie center'
+  const pieOption = echartsOption(pie, defaultRendererContext) as any
+  expect(pieOption.series[0]).toMatchObject({
+    id: 'series:primary:pie', type: 'pie', encode: { itemName: 'label', value: 'value' },
+    radius: '100%', roseType: false, avoidLabelOverlap: true, minShowLabelAngle: 3,
+    label: { position: 'inside' }, labelLine: { show: false },
+  })
+  expect(pieOption.series[0].itemStyle.color).toEqual(expect.any(Function))
+  expect(pieOption.series[0]).not.toHaveProperty('funnelAlign')
+  expect(pieOption.series[0]).not.toHaveProperty('sort')
+  expect(pieOption.graphic).toBeUndefined()
+
+  const donut = proportionalFixture('donut') as any
+  donut.spec.presentation.rose = false
+  donut.spec.presentation.innerRadius = 0
+  donut.spec.presentation.outerRadius = 1
+  const donutOption = echartsOption(donut, defaultRendererContext) as any
+  expect(donutOption.series[0]).toMatchObject({
+    id: 'series:primary:donut', type: 'pie', encode: { itemName: 'label', value: 'value' },
+    radius: ['0%', '100%'], roseType: false, avoidLabelOverlap: true, minShowLabelAngle: 3,
+  })
+  expect(donutOption.graphic[0].style.text).toBe('Orders')
+  expect(donutOption.series[0].labelLine.show).toBe(true)
+
+  const emptyDonut = structuredClone(donut)
+  emptyDonut.spec.presentation.centerLabel = undefined
+  emptyDonut.dataState.datasets[0].rows = []
+  const emptyDonutOption = echartsOption(emptyDonut, defaultRendererContext) as any
+  expect(emptyDonutOption.dataset.source).toEqual([['label', 'value']])
+  expect(emptyDonutOption.graphic[0].style.text).toBe('{centerValue|0}\n{centerLabel|Total}')
+
+  const funnel = proportionalFixture('funnel') as any
+  funnel.spec.presentation.rose = true
+  funnel.spec.presentation.outerRadius = 0.8
+  funnel.spec.presentation.orientation = 'horizontal'
+  funnel.spec.presentation.align = 'center'
+  funnel.spec.presentation.sort = 'descending'
+  funnel.spec.presentation.labelPosition = 'inside'
+  const funnelOption = echartsOption(funnel, defaultRendererContext) as any
+  expect(funnelOption.series[0]).toMatchObject({
+    id: 'series:primary:funnel', type: 'funnel', encode: { itemName: 'label', value: 'value' },
+    orient: 'horizontal', funnelAlign: 'center', sort: 'descending', label: { position: 'inside' },
+  })
+  expect(funnelOption.series[0].itemStyle.color).toEqual(expect.any(Function))
+  for (const pieOnly of ['radius', 'roseType', 'avoidLabelOverlap', 'minShowLabelAngle', 'labelLine']) {
+    expect(funnelOption.series[0]).not.toHaveProperty(pieOnly)
+  }
+})
+
+function proportionalFixture(mark: 'pie' | 'donut' | 'funnel'): VisualizationEnvelope {
+  return {
+    schemaVersion: 9, visualID: mark, rendererID: 'echarts', specRevision: 'sha256:test', dataRevision: 1,
+    spec: { kind: 'proportional', title: mark, mark, datasets: [{ id: 'primary', fields: [{ id: 'label', role: 'dimension', dataType: 'string', nullable: false, label: 'Label' }, { id: 'value', role: 'metric', dataType: 'decimal', nullable: false, label: 'Value' }] }], dataBudget: { maxRows: 100, requiredCompleteness: 'complete' }, accessibility: { title: mark, description: mark }, interactions: [], category: { dataset: 'primary', field: 'label' }, value: { dataset: 'primary', field: 'value' }, presentation: { legend: 'right', labelPolicy: { density: 'automatic', priority: ['selected', 'anomaly', 'threshold'], maxCharacters: 24, minimumSpacing: 6, tooltipFallback: true }, orientation: 'vertical', rose: true, centerLabel: mark === 'donut' ? 'Orders' : undefined, labelPosition: 'outside', innerRadius: mark === 'donut' ? 0.54 : undefined, outerRadius: mark === 'donut' ? 0.76 : undefined, align: mark === 'funnel' ? 'left' : undefined, sort: mark === 'funnel' ? 'ascending' : undefined } },
+    dataState: { kind: 'inline', specRevision: 'sha256:test', dataRevision: 1, generation: 1, datasets: [{ id: 'primary', specRevision: 'sha256:test', dataRevision: 1, generation: 1, columns: ['label', 'value'], rows: [['A', 10]], completeness: 'complete' }] }, selection: [], status: { kind: 'ready' }, diagnostics: [],
+  } as VisualizationEnvelope
+}

--- a/web/components/dashboard/visualization/adapters/echarts.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.test.ts
@@ -595,63 +595,6 @@ test('ECharts renders labels inside colored cartesian marks in outlined white', 
   expect(hiddenOption.series[0].barMinHeight).toBeUndefined()
 })
 
-test('ECharts translation builds radar indicators and aligned series from typed fields', () => {
-  const envelope = {
-    schemaVersion: 9, visualID: 'quality', rendererID: 'echarts', specRevision: 'sha256:test', dataRevision: 1,
-    spec: {
-      kind: 'polar', title: 'Quality', mark: 'radar',
-      datasets: [{ id: 'primary', fields: [
-        { id: 'metric', role: 'dimension', dataType: 'string', nullable: false, label: 'Metric' },
-        { id: 'team', role: 'dimension', dataType: 'string', nullable: false, label: 'Team' },
-        { id: 'value', role: 'metric', dataType: 'decimal', nullable: false, label: 'Value' },
-      ] }],
-      dataBudget: { maxRows: 100, requiredCompleteness: 'complete' }, accessibility: { title: 'Quality', description: 'Quality by team' }, interactions: [],
-      category: { dataset: 'primary', field: 'metric' }, series: { dataset: 'primary', field: 'team' }, value: { dataset: 'primary', field: 'value' },
-      presentation: { legend: 'bottom', labelPolicy: { density: 'hidden', priority: [], maxCharacters: 24, minimumSpacing: 0, tooltipFallback: true }, showPointer: false, area: true },
-    },
-    dataState: { kind: 'inline', specRevision: 'sha256:test', dataRevision: 1, generation: 1, datasets: [{
-      id: 'primary', specRevision: 'sha256:test', dataRevision: 1, generation: 1, columns: ['metric', 'team', 'value'],
-      rows: [['Speed', 'A', '8'], ['Quality', 'A', '9'], ['Speed', 'B', '6'], ['Quality', 'B', '7']], completeness: 'complete',
-    }] },
-    selection: [], status: { kind: 'ready' }, diagnostics: [],
-  } as VisualizationEnvelope
-  const context = {
-    ...defaultRendererContext,
-    theme: 'dark' as const,
-    colors: { ...defaultRendererContext.colors, muted: '#9198a1', grid: '#3d444d', surface: '#151b23' },
-  }
-  const option = echartsOption(envelope, context) as any
-  expect(option.radar.indicator.map((item: any) => item.name)).toEqual(['Speed', 'Quality'])
-  expect(option.radar.indicator.map((item: any) => item.max)).toEqual([10, 10])
-  expect(option.radar).toMatchObject({
-    axisLine: { lineStyle: { color: context.colors.grid } },
-    splitLine: { lineStyle: { color: context.colors.grid } },
-    splitArea: { areaStyle: { color: [context.colors.surface, context.colors.grid], opacity: 0.18 } },
-  })
-  expect(option.series[0]).toMatchObject({ id: 'series:polar:radar', type: 'radar', areaStyle: {} })
-  expect(option.series[0]).not.toHaveProperty('pointer')
-  expect(option.series[0]).not.toHaveProperty('progress')
-  expect(option.series[0].data).toEqual([{ name: 'A', value: ['8', '9'] }, { name: 'B', value: ['6', '7'] }])
-
-  envelope.spec.presentation.maximum = 12
-  envelope.spec.presentation.area = false
-  const configured = echartsOption(envelope, context) as any
-  expect(configured.radar.indicator.map((item: any) => item.max)).toEqual([12, 12])
-  expect(configured.series[0]).toMatchObject({ id: 'series:polar:radar', type: 'radar' })
-  expect(configured.series[0].areaStyle).toBeUndefined()
-
-  envelope.spec.presentation.maximum = undefined
-  envelope.dataState.datasets[0].rows = [['Speed', 'A', '0'], ['Quality', 'A', '0']]
-  const zero = echartsOption(envelope, context) as any
-  expect(zero.radar.indicator.map((item: any) => item.max)).toEqual([1, 1])
-  expect(zero.series[0].data).toEqual([{ name: 'A', value: ['0', '0'] }])
-
-  envelope.dataState.datasets[0].rows = []
-  const empty = echartsOption(envelope, context) as any
-  expect(empty.radar.indicator).toEqual([])
-  expect(empty.series[0].data).toEqual([])
-})
-
 test('ECharts normalizes supported document locales and fails closed on unknown locales', () => {
   expect(normalizeRendererLocale('en')).toBe('en-US')
   expect(normalizeRendererLocale('pt-BR')).toBe('pt-BR')
@@ -1004,60 +947,6 @@ test('ECharts honors proportional presentation and hierarchy/network layout', ()
 
   const tree = echartsOption(hierarchyFixture('tree'), defaultRendererContext) as any
   expect(tree.series[0]).toMatchObject({ orient: 'TB', layout: 'orthogonal', initialTreeDepth: 2, roam: true })
-})
-
-test('ECharts emits only mark-supported proportional fields and preserves explicit false and zero', () => {
-  const pie = proportionalFixture('pie') as any
-  pie.spec.presentation.rose = false
-  pie.spec.presentation.outerRadius = 1
-  pie.spec.presentation.labelPosition = 'inside'
-  pie.spec.presentation.centerLabel = 'Not a pie center'
-  const pieOption = echartsOption(pie, defaultRendererContext) as any
-  expect(pieOption.series[0]).toMatchObject({
-    id: 'series:primary:pie', type: 'pie', encode: { itemName: 'label', value: 'value' },
-    radius: '100%', roseType: false, avoidLabelOverlap: true, minShowLabelAngle: 3,
-    label: { position: 'inside' }, labelLine: { show: false },
-  })
-  expect(pieOption.series[0].itemStyle.color).toEqual(expect.any(Function))
-  expect(pieOption.series[0]).not.toHaveProperty('funnelAlign')
-  expect(pieOption.series[0]).not.toHaveProperty('sort')
-  expect(pieOption.graphic).toBeUndefined()
-
-  const donut = proportionalFixture('donut') as any
-  donut.spec.presentation.rose = false
-  donut.spec.presentation.innerRadius = 0
-  donut.spec.presentation.outerRadius = 1
-  const donutOption = echartsOption(donut, defaultRendererContext) as any
-  expect(donutOption.series[0]).toMatchObject({
-    id: 'series:primary:donut', type: 'pie', encode: { itemName: 'label', value: 'value' },
-    radius: ['0%', '100%'], roseType: false, avoidLabelOverlap: true, minShowLabelAngle: 3,
-  })
-  expect(donutOption.graphic[0].style.text).toBe('Orders')
-  expect(donutOption.series[0].labelLine.show).toBe(true)
-
-  const emptyDonut = structuredClone(donut)
-  emptyDonut.spec.presentation.centerLabel = undefined
-  emptyDonut.dataState.datasets[0].rows = []
-  const emptyDonutOption = echartsOption(emptyDonut, defaultRendererContext) as any
-  expect(emptyDonutOption.dataset.source).toEqual([['label', 'value']])
-  expect(emptyDonutOption.graphic[0].style.text).toBe('{centerValue|0}\n{centerLabel|Total}')
-
-  const funnel = proportionalFixture('funnel') as any
-  funnel.spec.presentation.rose = true
-  funnel.spec.presentation.outerRadius = 0.8
-  funnel.spec.presentation.orientation = 'horizontal'
-  funnel.spec.presentation.align = 'center'
-  funnel.spec.presentation.sort = 'descending'
-  funnel.spec.presentation.labelPosition = 'inside'
-  const funnelOption = echartsOption(funnel, defaultRendererContext) as any
-  expect(funnelOption.series[0]).toMatchObject({
-    id: 'series:primary:funnel', type: 'funnel', encode: { itemName: 'label', value: 'value' },
-    orient: 'horizontal', funnelAlign: 'center', sort: 'descending', label: { position: 'inside' },
-  })
-  expect(funnelOption.series[0].itemStyle.color).toEqual(expect.any(Function))
-  for (const pieOnly of ['radius', 'roseType', 'avoidLabelOverlap', 'minShowLabelAngle', 'labelLine']) {
-    expect(funnelOption.series[0]).not.toHaveProperty(pieOnly)
-  }
 })
 
 test('ECharts gives donuts legible renderer defaults without changing their categories', () => {

--- a/web/components/dashboard/visualization/adapters/echarts.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.test.ts
@@ -611,7 +611,7 @@ test('ECharts translation builds radar indicators and aligned series from typed 
     },
     dataState: { kind: 'inline', specRevision: 'sha256:test', dataRevision: 1, generation: 1, datasets: [{
       id: 'primary', specRevision: 'sha256:test', dataRevision: 1, generation: 1, columns: ['metric', 'team', 'value'],
-      rows: [['Speed', 'A', 8], ['Quality', 'A', 9], ['Speed', 'B', 6], ['Quality', 'B', 7]], completeness: 'complete',
+      rows: [['Speed', 'A', '8'], ['Quality', 'A', '9'], ['Speed', 'B', '6'], ['Quality', 'B', '7']], completeness: 'complete',
     }] },
     selection: [], status: { kind: 'ready' }, diagnostics: [],
   } as VisualizationEnvelope
@@ -631,7 +631,7 @@ test('ECharts translation builds radar indicators and aligned series from typed 
   expect(option.series[0]).toMatchObject({ id: 'series:polar:radar', type: 'radar', areaStyle: {} })
   expect(option.series[0]).not.toHaveProperty('pointer')
   expect(option.series[0]).not.toHaveProperty('progress')
-  expect(option.series[0].data).toEqual([{ name: 'A', value: [8, 9] }, { name: 'B', value: [6, 7] }])
+  expect(option.series[0].data).toEqual([{ name: 'A', value: ['8', '9'] }, { name: 'B', value: ['6', '7'] }])
 
   envelope.spec.presentation.maximum = 12
   envelope.spec.presentation.area = false
@@ -641,10 +641,10 @@ test('ECharts translation builds radar indicators and aligned series from typed 
   expect(configured.series[0].areaStyle).toBeUndefined()
 
   envelope.spec.presentation.maximum = undefined
-  envelope.dataState.datasets[0].rows = [['Speed', 'A', 0], ['Quality', 'A', 0]]
+  envelope.dataState.datasets[0].rows = [['Speed', 'A', '0'], ['Quality', 'A', '0']]
   const zero = echartsOption(envelope, context) as any
   expect(zero.radar.indicator.map((item: any) => item.max)).toEqual([1, 1])
-  expect(zero.series[0].data).toEqual([{ name: 'A', value: [0, 0] }])
+  expect(zero.series[0].data).toEqual([{ name: 'A', value: ['0', '0'] }])
 
   envelope.dataState.datasets[0].rows = []
   const empty = echartsOption(envelope, context) as any
@@ -1239,7 +1239,7 @@ test('ECharts formats gauges, applies semantic thresholds, and renders status st
   expect(option.series[0]).toMatchObject({
     id: 'series:polar:gauge', type: 'gauge', min: 0, max: 1,
     pointer: { show: true }, progress: { show: true, width: 12 },
-    data: [{ value: 0.75, __lv_dataset: 'primary', __lv_row_index: 0 }],
+    data: [{ value: '0.75', __lv_dataset: 'primary', __lv_row_index: 0 }],
   })
   expect(option.series[0].axisLine.lineStyle.color).toEqual([[0.5, defaultRendererContext.colors.attention], [0.8, defaultRendererContext.colors.danger]])
   expect(option.series[0].detail.formatter(0.75)).toBe('75%')
@@ -1249,15 +1249,15 @@ test('ECharts formats gauges, applies semantic thresholds, and renders status st
   envelope.spec.presentation.maximum = 1
   envelope.spec.presentation.target = 0
   envelope.spec.presentation.thresholds = [{ value: 0, tone: 'success' }, { value: 1, tone: 'danger' }]
-  envelope.dataState.datasets[0].rows = [[0]]
+  envelope.dataState.datasets[0].rows = [['0']]
   const bounded = echartsOption(envelope, defaultRendererContext) as any
-  expect(bounded.series[0]).toMatchObject({ min: 0, max: 1, pointer: { show: false }, data: [{ value: 0 }] })
+  expect(bounded.series[0]).toMatchObject({ min: 0, max: 1, pointer: { show: false }, data: [{ value: '0' }] })
   expect(bounded.series[0].axisLine.lineStyle.color).toEqual([[0, defaultRendererContext.colors.success], [1, defaultRendererContext.colors.danger]])
   expect(bounded.series[1].data[0]).toMatchObject({ value: 0, name: 'Target 0%' })
 
-  envelope.dataState.datasets[0].rows = [[1]]
+  envelope.dataState.datasets[0].rows = [['1']]
   const upperBoundary = echartsOption(envelope, defaultRendererContext) as any
-  expect(upperBoundary.series[0]).toMatchObject({ min: 0, max: 1, data: [{ value: 1 }] })
+  expect(upperBoundary.series[0]).toMatchObject({ min: 0, max: 1, data: [{ value: '1' }] })
   expect(upperBoundary.graphic).toBeUndefined()
 
   const noData = { ...cartesianFixture('line'), status: { kind: 'no_data', message: 'No matching rows' } } as VisualizationEnvelope
@@ -1299,7 +1299,7 @@ test('ECharts renders an explicit labeled target independently from the metricd 
 
 test('ECharts renders a visible diagnostic instead of clipping an out-of-domain gauge value', () => {
   const envelope = gaugeFixture() as any
-  envelope.dataState.datasets[0].rows = [[1.2]]
+  envelope.dataState.datasets[0].rows = [['1.2']]
   const option = echartsOption(envelope, defaultRendererContext) as any
   expect(option.series).toEqual([])
   expect(option.graphic[0].style.text).toContain('outside configured gauge domain 0.0%–100.0%')
@@ -1377,6 +1377,6 @@ function gaugeFixture(): VisualizationEnvelope {
   return {
     schemaVersion: 9, visualID: 'gauge', rendererID: 'echarts', specRevision: 'sha256:test', dataRevision: 1,
     spec: { kind: 'polar', title: 'Gauge', mark: 'gauge', datasets: [{ id: 'primary', fields: [{ id: 'value', role: 'metric', dataType: 'decimal', nullable: false, label: 'Rate', format: { kind: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1 } }] }], dataBudget: { maxRows: 1, requiredCompleteness: 'complete' }, accessibility: { title: 'Gauge', description: 'Gauge' }, interactions: [], value: { dataset: 'primary', field: 'value' }, presentation: { legend: 'hidden', labelPolicy: { density: 'automatic', priority: ['selected', 'anomaly', 'threshold'], maxCharacters: 24, minimumSpacing: 6, tooltipFallback: true }, minimum: 0, maximum: 1, showPointer: true, progressWidth: 12, thresholds: [{ value: 0.5, tone: 'warning' }, { value: 0.8, tone: 'danger' }] } },
-    dataState: { kind: 'inline', specRevision: 'sha256:test', dataRevision: 1, generation: 1, datasets: [{ id: 'primary', specRevision: 'sha256:test', dataRevision: 1, generation: 1, columns: ['value'], rows: [[0.75]], completeness: 'complete' }] }, selection: [], status: { kind: 'ready' }, diagnostics: [],
+    dataState: { kind: 'inline', specRevision: 'sha256:test', dataRevision: 1, generation: 1, datasets: [{ id: 'primary', specRevision: 'sha256:test', dataRevision: 1, generation: 1, columns: ['value'], rows: [['0.75']], completeness: 'complete' }] }, selection: [], status: { kind: 'ready' }, diagnostics: [],
   } as VisualizationEnvelope
 }

--- a/web/components/dashboard/visualization/adapters/echarts.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts.test.ts
@@ -628,7 +628,28 @@ test('ECharts translation builds radar indicators and aligned series from typed 
     splitLine: { lineStyle: { color: context.colors.grid } },
     splitArea: { areaStyle: { color: [context.colors.surface, context.colors.grid], opacity: 0.18 } },
   })
+  expect(option.series[0]).toMatchObject({ id: 'series:polar:radar', type: 'radar', areaStyle: {} })
+  expect(option.series[0]).not.toHaveProperty('pointer')
+  expect(option.series[0]).not.toHaveProperty('progress')
   expect(option.series[0].data).toEqual([{ name: 'A', value: [8, 9] }, { name: 'B', value: [6, 7] }])
+
+  envelope.spec.presentation.maximum = 12
+  envelope.spec.presentation.area = false
+  const configured = echartsOption(envelope, context) as any
+  expect(configured.radar.indicator.map((item: any) => item.max)).toEqual([12, 12])
+  expect(configured.series[0]).toMatchObject({ id: 'series:polar:radar', type: 'radar' })
+  expect(configured.series[0].areaStyle).toBeUndefined()
+
+  envelope.spec.presentation.maximum = undefined
+  envelope.dataState.datasets[0].rows = [['Speed', 'A', 0], ['Quality', 'A', 0]]
+  const zero = echartsOption(envelope, context) as any
+  expect(zero.radar.indicator.map((item: any) => item.max)).toEqual([1, 1])
+  expect(zero.series[0].data).toEqual([{ name: 'A', value: [0, 0] }])
+
+  envelope.dataState.datasets[0].rows = []
+  const empty = echartsOption(envelope, context) as any
+  expect(empty.radar.indicator).toEqual([])
+  expect(empty.series[0].data).toEqual([])
 })
 
 test('ECharts normalizes supported document locales and fails closed on unknown locales', () => {
@@ -985,6 +1006,60 @@ test('ECharts honors proportional presentation and hierarchy/network layout', ()
   expect(tree.series[0]).toMatchObject({ orient: 'TB', layout: 'orthogonal', initialTreeDepth: 2, roam: true })
 })
 
+test('ECharts emits only mark-supported proportional fields and preserves explicit false and zero', () => {
+  const pie = proportionalFixture('pie') as any
+  pie.spec.presentation.rose = false
+  pie.spec.presentation.outerRadius = 1
+  pie.spec.presentation.labelPosition = 'inside'
+  pie.spec.presentation.centerLabel = 'Not a pie center'
+  const pieOption = echartsOption(pie, defaultRendererContext) as any
+  expect(pieOption.series[0]).toMatchObject({
+    id: 'series:primary:pie', type: 'pie', encode: { itemName: 'label', value: 'value' },
+    radius: '100%', roseType: false, avoidLabelOverlap: true, minShowLabelAngle: 3,
+    label: { position: 'inside' }, labelLine: { show: false },
+  })
+  expect(pieOption.series[0].itemStyle.color).toEqual(expect.any(Function))
+  expect(pieOption.series[0]).not.toHaveProperty('funnelAlign')
+  expect(pieOption.series[0]).not.toHaveProperty('sort')
+  expect(pieOption.graphic).toBeUndefined()
+
+  const donut = proportionalFixture('donut') as any
+  donut.spec.presentation.rose = false
+  donut.spec.presentation.innerRadius = 0
+  donut.spec.presentation.outerRadius = 1
+  const donutOption = echartsOption(donut, defaultRendererContext) as any
+  expect(donutOption.series[0]).toMatchObject({
+    id: 'series:primary:donut', type: 'pie', encode: { itemName: 'label', value: 'value' },
+    radius: ['0%', '100%'], roseType: false, avoidLabelOverlap: true, minShowLabelAngle: 3,
+  })
+  expect(donutOption.graphic[0].style.text).toBe('Orders')
+  expect(donutOption.series[0].labelLine.show).toBe(true)
+
+  const emptyDonut = structuredClone(donut)
+  emptyDonut.spec.presentation.centerLabel = undefined
+  emptyDonut.dataState.datasets[0].rows = []
+  const emptyDonutOption = echartsOption(emptyDonut, defaultRendererContext) as any
+  expect(emptyDonutOption.dataset.source).toEqual([['label', 'value']])
+  expect(emptyDonutOption.graphic[0].style.text).toBe('{centerValue|0}\n{centerLabel|Total}')
+
+  const funnel = proportionalFixture('funnel') as any
+  funnel.spec.presentation.rose = true
+  funnel.spec.presentation.outerRadius = 0.8
+  funnel.spec.presentation.orientation = 'horizontal'
+  funnel.spec.presentation.align = 'center'
+  funnel.spec.presentation.sort = 'descending'
+  funnel.spec.presentation.labelPosition = 'inside'
+  const funnelOption = echartsOption(funnel, defaultRendererContext) as any
+  expect(funnelOption.series[0]).toMatchObject({
+    id: 'series:primary:funnel', type: 'funnel', encode: { itemName: 'label', value: 'value' },
+    orient: 'horizontal', funnelAlign: 'center', sort: 'descending', label: { position: 'inside' },
+  })
+  expect(funnelOption.series[0].itemStyle.color).toEqual(expect.any(Function))
+  for (const pieOnly of ['radius', 'roseType', 'avoidLabelOverlap', 'minShowLabelAngle', 'labelLine']) {
+    expect(funnelOption.series[0]).not.toHaveProperty(pieOnly)
+  }
+})
+
 test('ECharts gives donuts legible renderer defaults without changing their categories', () => {
   const envelope = proportionalFixture('donut') as any
   envelope.spec.presentation.centerLabel = undefined
@@ -1161,9 +1236,29 @@ test('ECharts leaves absent proportional geometry fields to renderer defaults', 
 test('ECharts formats gauges, applies semantic thresholds, and renders status states', () => {
   const envelope = gaugeFixture()
   const option = echartsOption(envelope, { ...defaultRendererContext, locale: 'pt-BR' },) as any
-  expect(option.series[0].id).toBe('series:polar:gauge')
+  expect(option.series[0]).toMatchObject({
+    id: 'series:polar:gauge', type: 'gauge', min: 0, max: 1,
+    pointer: { show: true }, progress: { show: true, width: 12 },
+    data: [{ value: 0.75, __lv_dataset: 'primary', __lv_row_index: 0 }],
+  })
   expect(option.series[0].axisLine.lineStyle.color).toEqual([[0.5, defaultRendererContext.colors.attention], [0.8, defaultRendererContext.colors.danger]])
   expect(option.series[0].detail.formatter(0.75)).toBe('75%')
+
+  envelope.spec.presentation.showPointer = false
+  envelope.spec.presentation.minimum = 0
+  envelope.spec.presentation.maximum = 1
+  envelope.spec.presentation.target = 0
+  envelope.spec.presentation.thresholds = [{ value: 0, tone: 'success' }, { value: 1, tone: 'danger' }]
+  envelope.dataState.datasets[0].rows = [[0]]
+  const bounded = echartsOption(envelope, defaultRendererContext) as any
+  expect(bounded.series[0]).toMatchObject({ min: 0, max: 1, pointer: { show: false }, data: [{ value: 0 }] })
+  expect(bounded.series[0].axisLine.lineStyle.color).toEqual([[0, defaultRendererContext.colors.success], [1, defaultRendererContext.colors.danger]])
+  expect(bounded.series[1].data[0]).toMatchObject({ value: 0, name: 'Target 0%' })
+
+  envelope.dataState.datasets[0].rows = [[1]]
+  const upperBoundary = echartsOption(envelope, defaultRendererContext) as any
+  expect(upperBoundary.series[0]).toMatchObject({ min: 0, max: 1, data: [{ value: 1 }] })
+  expect(upperBoundary.graphic).toBeUndefined()
 
   const noData = { ...cartesianFixture('line'), status: { kind: 'no_data', message: 'No matching rows' } } as VisualizationEnvelope
   const statusOption = echartsOption(noData, defaultRendererContext) as any

--- a/web/components/dashboard/visualization/adapters/echarts/polar.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/polar.ts
@@ -2,6 +2,7 @@ import type { VisualizationEnvelope } from '../../../../../generated/visualizati
 import type { RendererContext } from '../../host-controller'
 import { displayUnitForField, formatDisplayField, formatField, inlineDataset, legend, toneColor, type EChartsTranslation } from './common'
 import { echartsLabelPolicy, truncateVisualizationLabel } from './label-policy'
+import { parseDecimal } from '../../decimal'
 
 export function polarOption(envelope: VisualizationEnvelope, context: RendererContext): EChartsTranslation {
   const spec = envelope.spec
@@ -13,9 +14,10 @@ export function polarOption(envelope: VisualizationEnvelope, context: RendererCo
     const dataset = inlineDataset(envelope, spec.value.dataset)
     const valueIndex = dataset?.columns.indexOf(spec.value.field) ?? -1
     const value = valueIndex >= 0 ? dataset?.rows[0]?.[valueIndex] : undefined
+    const approximateValue = approximateNumericValue(value)
     const minimum = spec.presentation.minimum, maximum = spec.presentation.maximum
     const displayUnit = displayUnitForField(envelope, spec.value, undefined, [spec.value], [minimum, maximum, spec.presentation.target])
-    if (typeof value === 'number' && Number.isFinite(value) && (value < minimum || value > maximum)) {
+    if (approximateValue !== undefined && (approximateValue < minimum || approximateValue > maximum)) {
       const formattedValue = formatField(envelope, spec.value, value, context)
       const formattedMinimum = formatField(envelope, spec.value, minimum, context)
       const formattedMaximum = formatField(envelope, spec.value, maximum, context)
@@ -98,7 +100,10 @@ export function polarOption(envelope: VisualizationEnvelope, context: RendererCo
     value: categories.map((category) => dataset.rows.find((row, index) => String(seriesIndex >= 0 ? row[seriesIndex] : spec.title) === series && String(categoryIndex >= 0 ? row[categoryIndex] : index + 1) === category)?.[valueIndex] ?? null),
   }))
   const configuredMaximum = spec.presentation.maximum
-  const observedMaximum = Math.max(0, ...values.flatMap((series) => series.value.flatMap((value) => typeof value === 'number' && Number.isFinite(value) ? [value] : [])))
+  const observedMaximum = Math.max(0, ...values.flatMap((series) => series.value.flatMap((value) => {
+    const approximate = approximateNumericValue(value)
+    return approximate === undefined ? [] : [approximate]
+  })))
   const sharedMaximum = configuredMaximum ?? niceRadarMaximum(observedMaximum)
   const maxima = categories.map(() => sharedMaximum)
   const labels = echartsLabelPolicy(
@@ -126,4 +131,11 @@ function niceRadarMaximum(value: number): number {
   const normalized = value / magnitude
   const factor = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10
   return factor * magnitude
+}
+
+function approximateNumericValue(value: unknown): number | undefined {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined
+  if (typeof value !== 'string' || !parseDecimal(value)) return undefined
+  const approximate = Number(value)
+  return Number.isFinite(approximate) ? approximate : undefined
 }

--- a/web/components/dashboard/visualization/adapters/echarts/proportional.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/proportional.ts
@@ -11,14 +11,14 @@ export function proportionalOption(envelope: VisualizationEnvelope, context: Ren
   const spec = envelope.spec
   if (spec.kind !== 'proportional') return {}
   const presentation = spec.presentation
+  const isPie = spec.mark === 'pie' || spec.mark === 'donut'
   const radius = spec.mark === 'donut'
     ? [percent(presentation.innerRadius, 0.45), percent(presentation.outerRadius, 0.72)]
-    : presentation.outerRadius ? percent(presentation.outerRadius, 0.72) : undefined
+    : spec.mark === 'pie' && presentation.outerRadius !== undefined ? percent(presentation.outerRadius, 0.72) : undefined
   const dataset = inlineDataset(envelope, spec.category.dataset)
   const categoryIndex = dataset?.columns.indexOf(spec.category.field) ?? -1
   const valueIndex = dataset?.columns.indexOf(spec.value.field) ?? -1
   const outside = presentation.labelPosition !== 'inside'
-  const isPie = spec.mark === 'pie' || spec.mark === 'donut'
   const labels = echartsLabelPolicy(envelope, spec.value.dataset, presentation.labelPolicy, ({ value }) => {
     const row = Array.isArray(value) ? value : []
     const amount = formatDisplayField(envelope, spec.value, valueIndex >= 0 ? row[valueIndex] : undefined, context)
@@ -49,7 +49,7 @@ export function proportionalOption(envelope: VisualizationEnvelope, context: Ren
         lineStyle: { color: context.colors.muted },
       },
     } : {}),
-    roseType: presentation.rose ? 'radius' : false,
+    ...(isPie ? { roseType: presentation.rose ? 'radius' : false } : {}),
     itemStyle: {
       color: governedColor ?? ((params: { value?: unknown[] }) => categoryColors.color(envelope, spec.category, Array.isArray(params.value) ? params.value[categoryIndex] : undefined, context)),
     },


### PR DESCRIPTION
## What

- Enforce mark-specific proportional and polar presentation applicability.
- Require truthful gauge/radar query shapes, finite gauge domains, and validated targets, thresholds, radii, alignment, and sort values.
- Preserve decimal transport and explicit false/zero values while preventing unsupported renderer fields from leaking across marks.
- Document the supported per-mark contract.

## Why

- Phase 1 requires every accepted formatting option to render or fail with an actionable validation error.
- Gauge, radar, and cross-mark no-op configurations previously reached the renderer silently or too late.

## Validation

- `GOFLAGS='-tags=duckdb_arrow -buildvcs=false' PATH=/home/codex/.bun/bin:$PATH task ci`
- `go test ./internal/dashboard/compiler ./internal/dashboard/document ./internal/dashboard/visualization/ir -count=1`
- `bun test web/components/dashboard/visualization/adapters/echarts.test.ts web/components/dashboard/visualization/adapters/echarts-polar.test.ts` (43 passed)
- `bun run typecheck:app`
- `task quality:budget:check`

## Contract coverage

Existing dashboard schema/generated types → compiler/query shape → renderer-neutral IR → ECharts → positive/negative tests → docs.

Linear: FAI-738; LeapView Chart Formatting project.
