### PR TITLE
Make Cartesian chart formatting truthful by mark

### DIFF
--- a/docs/visuals/index.md
+++ b/docs/visuals/index.md
@@ -37,6 +37,21 @@ Policies also bound label length by Unicode grapheme, set minimum collision spac
 
 ## Per-mark presentation
 
+Cartesian marks all support the common `labels`, `labelPosition`, `displayUnits`, and `axes` fields. Mark-specific fields are scoped to the renderer paths that consume them:
+
+| Mark | Mark-specific presentation fields |
+| --- | --- |
+| Line | `legend`, `stacking`, `orientation`, `showSymbols`, `smooth`, `step`, `dataZoom`, `symbolSize`, `referenceLines`, `referenceBands`, `eventAnnotations` |
+| Area | `legend`, `stacking`, `orientation`, `showSymbols`, `smooth`, `step`, `dataZoom`, `symbolSize`, `referenceLines`, `referenceBands`, `eventAnnotations` |
+| Bar | `legend`, `stacking`, `dataZoom`, `referenceLines`, `referenceBands`, `eventAnnotations` |
+| Column | `legend`, `stacking`, `orientation`, `dataZoom`, `referenceLines`, `referenceBands`, `eventAnnotations` |
+| Combo | `legend`, `stacking`, `orientation`, `dataZoom`, `series`, `referenceLines`, `referenceBands`, `eventAnnotations`; conditional line controls (`showSymbols`, `smooth`, `step`, `symbolSize`) apply with the default line series or when a configured series is line or area |
+| Waterfall | `dataZoom`, `referenceLines`, `referenceBands`, `eventAnnotations` |
+| Heatmap | No additional mark-specific fields |
+| Histogram | `dataZoom` |
+| Candlestick | `legend`, `dataZoom` |
+| Boxplot | `dataZoom` |
+
 Proportional and polar presentations share the common `legend`, `labels`, and `displayUnits` fields where those channels are meaningful. Mark-specific fields are intentionally scoped to the marks that can render them:
 
 | Mark | Mark-specific presentation fields |

--- a/internal/dashboard/compiler/cartesian_presentation_applicability_test.go
+++ b/internal/dashboard/compiler/cartesian_presentation_applicability_test.go
@@ -1,0 +1,131 @@
+package compiler
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/dashboard/document"
+)
+
+func TestLowerCanonicalCartesianPresentationRejectsInapplicableOptions(t *testing.T) {
+	falseValue := false
+	zero := 0.0
+	orientation := document.DashboardOrientationHorizontal
+	legend := document.DashboardLegendPositionRight
+	stacking := document.DashboardStackingModeNormal
+	emptyLines := []document.DashboardReferenceLine{}
+	emptyBands := []document.DashboardReferenceBand{}
+	emptyEvents := []document.DashboardEventAnnotation{}
+	allColumnSeries := []document.DashboardComboSeries{{Field: "revenue", Mark: document.DashboardComboSeriesMarkColumn, Axis: document.DashboardComboSeriesAxisPrimary}}
+
+	tests := []struct {
+		name       string
+		visualType document.DashboardVisualType
+		set        func(*document.CartesianDashboardPresentation)
+		want       string
+	}{
+		{name: "legend on waterfall", visualType: document.DashboardVisualTypeWaterfall, set: func(value *document.CartesianDashboardPresentation) { value.Legend = &legend }, want: "presentation.legend"},
+		{name: "legend on histogram", visualType: document.DashboardVisualTypeHistogram, set: func(value *document.CartesianDashboardPresentation) { value.Legend = &legend }, want: "presentation.legend"},
+		{name: "legend on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.Legend = &legend }, want: "presentation.legend"},
+		{name: "legend on boxplot", visualType: document.DashboardVisualTypeBoxplot, set: func(value *document.CartesianDashboardPresentation) { value.Legend = &legend }, want: "presentation.legend"},
+		{name: "stacking on waterfall", visualType: document.DashboardVisualTypeWaterfall, set: func(value *document.CartesianDashboardPresentation) { value.Stacking = &stacking }, want: "presentation.stacking"},
+		{name: "stacking on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.Stacking = &stacking }, want: "presentation.stacking"},
+		{name: "stacking on histogram", visualType: document.DashboardVisualTypeHistogram, set: func(value *document.CartesianDashboardPresentation) { value.Stacking = &stacking }, want: "presentation.stacking"},
+		{name: "stacking on candlestick", visualType: document.DashboardVisualTypeCandlestick, set: func(value *document.CartesianDashboardPresentation) { value.Stacking = &stacking }, want: "presentation.stacking"},
+		{name: "stacking on boxplot", visualType: document.DashboardVisualTypeBoxplot, set: func(value *document.CartesianDashboardPresentation) { value.Stacking = &stacking }, want: "presentation.stacking"},
+		{name: "orientation on bar", visualType: document.DashboardVisualTypeBar, set: func(value *document.CartesianDashboardPresentation) { value.Orientation = &orientation }, want: "presentation.orientation"},
+		{name: "orientation on waterfall", visualType: document.DashboardVisualTypeWaterfall, set: func(value *document.CartesianDashboardPresentation) { value.Orientation = &orientation }, want: "presentation.orientation"},
+		{name: "orientation on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.Orientation = &orientation }, want: "presentation.orientation"},
+		{name: "orientation on histogram", visualType: document.DashboardVisualTypeHistogram, set: func(value *document.CartesianDashboardPresentation) { value.Orientation = &orientation }, want: "presentation.orientation"},
+		{name: "orientation on candlestick", visualType: document.DashboardVisualTypeCandlestick, set: func(value *document.CartesianDashboardPresentation) { value.Orientation = &orientation }, want: "presentation.orientation"},
+		{name: "orientation on boxplot", visualType: document.DashboardVisualTypeBoxplot, set: func(value *document.CartesianDashboardPresentation) { value.Orientation = &orientation }, want: "presentation.orientation"},
+		{name: "data zoom on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.DataZoom = &falseValue }, want: "presentation.dataZoom"},
+		{name: "show symbols on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.ShowSymbols = &falseValue }, want: "presentation.showSymbols"},
+		{name: "smooth on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.Smooth = &falseValue }, want: "presentation.smooth"},
+		{name: "step on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.Step = &falseValue }, want: "presentation.step"},
+		{name: "symbol size on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.SymbolSize = &zero }, want: "presentation.symbolSize"},
+		{name: "show symbols on column", visualType: document.DashboardVisualTypeColumn, set: func(value *document.CartesianDashboardPresentation) { value.ShowSymbols = &falseValue }, want: "presentation.showSymbols"},
+		{name: "smooth on bar", visualType: document.DashboardVisualTypeBar, set: func(value *document.CartesianDashboardPresentation) { value.Smooth = &falseValue }, want: "presentation.smooth"},
+		{name: "step on histogram", visualType: document.DashboardVisualTypeHistogram, set: func(value *document.CartesianDashboardPresentation) { value.Step = &falseValue }, want: "presentation.step"},
+		{name: "symbol size on boxplot", visualType: document.DashboardVisualTypeBoxplot, set: func(value *document.CartesianDashboardPresentation) { value.SymbolSize = &zero }, want: "presentation.symbolSize"},
+		{name: "line control on all-column combo", visualType: document.DashboardVisualTypeCombo, set: func(value *document.CartesianDashboardPresentation) {
+			value.Series = &allColumnSeries
+			value.ShowSymbols = &falseValue
+		}, want: "presentation.showSymbols"},
+		{name: "series on line", visualType: document.DashboardVisualTypeLine, set: func(value *document.CartesianDashboardPresentation) { value.Series = &allColumnSeries }, want: "presentation.series"},
+		{name: "empty lines on heatmap", visualType: document.DashboardVisualTypeHeatmap, set: func(value *document.CartesianDashboardPresentation) { value.ReferenceLines = &emptyLines }, want: "presentation.referenceLines"},
+		{name: "empty bands on histogram", visualType: document.DashboardVisualTypeHistogram, set: func(value *document.CartesianDashboardPresentation) { value.ReferenceBands = &emptyBands }, want: "presentation.referenceBands"},
+		{name: "empty events on boxplot", visualType: document.DashboardVisualTypeBoxplot, set: func(value *document.CartesianDashboardPresentation) { value.EventAnnotations = &emptyEvents }, want: "presentation.eventAnnotations"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value := &document.CartesianDashboardPresentation{Type: "cartesian"}
+			test.set(value)
+			_, err := LowerCanonicalDashboardPresentation(document.DashboardPresentation{Value: value}, test.visualType)
+			want := test.want + " is not supported for " + string(test.visualType) + " visuals"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("error = %v, want %q", err, want)
+			}
+		})
+	}
+}
+
+func TestLowerCanonicalCartesianPresentationAllowsComboLineControlsForLineSeries(t *testing.T) {
+	showSymbols, smooth, step, symbolSize := true, true, true, 14.0
+	series := []document.DashboardComboSeries{
+		{Field: "revenue", Mark: document.DashboardComboSeriesMarkLine, Axis: document.DashboardComboSeriesAxisPrimary},
+		{Field: "orders", Mark: document.DashboardComboSeriesMarkColumn, Axis: document.DashboardComboSeriesAxisSecondary},
+	}
+	value := document.DashboardPresentation{Value: &document.CartesianDashboardPresentation{
+		Type: "cartesian", Series: &series, ShowSymbols: &showSymbols, Smooth: &smooth, Step: &step, SymbolSize: &symbolSize,
+	}}
+	if _, err := LowerCanonicalDashboardPresentation(value, document.DashboardVisualTypeCombo); err != nil {
+		t.Fatalf("combo line controls rejected: %v", err)
+	}
+}
+
+func TestLowerCanonicalCartesianPresentationDefersInvalidComboSeriesDiagnostics(t *testing.T) {
+	showSymbols := true
+	cases := []struct {
+		name   string
+		series []document.DashboardComboSeries
+		want   string
+	}{
+		{name: "empty", series: []document.DashboardComboSeries{}, want: "combo presentation.series must contain at least one entry"},
+		{name: "unknown mark", series: []document.DashboardComboSeries{{Field: "revenue", Mark: document.DashboardComboSeriesMark("spline"), Axis: document.DashboardComboSeriesAxisPrimary}}, want: "unsupported mark \"spline\""},
+		{name: "invalid axis", series: []document.DashboardComboSeries{{Field: "revenue", Mark: document.DashboardComboSeriesMarkColumn, Axis: document.DashboardComboSeriesAxis("tertiary")}}, want: "unsupported axis \"tertiary\""},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			value := document.DashboardPresentation{Value: &document.CartesianDashboardPresentation{Type: "cartesian", Series: &test.series, ShowSymbols: &showSymbols}}
+			_, err := LowerCanonicalDashboardPresentation(value, document.DashboardVisualTypeCombo)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLowerCanonicalCartesianPresentationValidatesSymbolSize(t *testing.T) {
+	cases := []struct {
+		name  string
+		value float64
+		want  string
+	}{
+		{name: "nan", value: math.NaN(), want: "presentation.symbolSize must be finite"},
+		{name: "infinity", value: math.Inf(1), want: "presentation.symbolSize must be finite"},
+		{name: "zero", value: 0, want: "presentation.symbolSize must be greater than zero"},
+		{name: "negative", value: -1, want: "presentation.symbolSize must be greater than zero"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			symbolSize := test.value
+			value := document.DashboardPresentation{Value: &document.CartesianDashboardPresentation{Type: "cartesian", SymbolSize: &symbolSize}}
+			_, err := LowerCanonicalDashboardPresentation(value, document.DashboardVisualTypeLine)
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/dashboard/compiler/dashboard_presentation_cartesian.go
+++ b/internal/dashboard/compiler/dashboard_presentation_cartesian.go
@@ -1,0 +1,112 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/flidai/leapview/internal/dashboard/document"
+	visualizationir "github.com/flidai/leapview/internal/dashboard/visualization/ir"
+)
+
+func validateCanonicalCartesianPresentationApplicability(variant *document.CartesianDashboardPresentation, visualType document.DashboardVisualType) error {
+	if variant == nil {
+		return nil
+	}
+	optionSupported := func(option string, present bool, supported bool) error {
+		if present && !supported {
+			return fmt.Errorf("presentation.%s is not supported for %s visuals", option, visualType)
+		}
+		return nil
+	}
+	// Labels, label position, display units, and axes use common paths.
+	if err := optionSupported("legend", variant.Legend != nil,
+		visualType == document.DashboardVisualTypeLine ||
+			visualType == document.DashboardVisualTypeArea ||
+			visualType == document.DashboardVisualTypeBar ||
+			visualType == document.DashboardVisualTypeColumn ||
+			visualType == document.DashboardVisualTypeCombo ||
+			visualType == document.DashboardVisualTypeCandlestick); err != nil {
+		return err
+	}
+	if err := optionSupported("stacking", variant.Stacking != nil,
+		visualType == document.DashboardVisualTypeLine ||
+			visualType == document.DashboardVisualTypeArea ||
+			visualType == document.DashboardVisualTypeBar ||
+			visualType == document.DashboardVisualTypeColumn ||
+			visualType == document.DashboardVisualTypeCombo); err != nil {
+		return err
+	}
+	if err := optionSupported("orientation", variant.Orientation != nil,
+		visualType == document.DashboardVisualTypeLine ||
+			visualType == document.DashboardVisualTypeArea ||
+			visualType == document.DashboardVisualTypeColumn ||
+			visualType == document.DashboardVisualTypeCombo); err != nil {
+		return err
+	}
+	if err := optionSupported("dataZoom", variant.DataZoom != nil, visualType != document.DashboardVisualTypeHeatmap); err != nil {
+		return err
+	}
+	comboLineArea := visualType != document.DashboardVisualTypeCombo || variant.Series == nil
+	if visualType == document.DashboardVisualTypeCombo && variant.Series != nil {
+		// Keep the existing combo-series diagnostics authoritative when the
+		// authored configuration is empty or malformed. A later lowering pass
+		// reports the precise series path in those cases.
+		comboLineArea = comboSeriesSupportsLineControls(*variant.Series)
+	}
+	if err := optionSupported("showSymbols", variant.ShowSymbols != nil,
+		(visualType == document.DashboardVisualTypeLine || visualType == document.DashboardVisualTypeArea || visualType == document.DashboardVisualTypeCombo) && comboLineArea); err != nil {
+		return err
+	}
+	if err := optionSupported("smooth", variant.Smooth != nil,
+		(visualType == document.DashboardVisualTypeLine || visualType == document.DashboardVisualTypeArea || visualType == document.DashboardVisualTypeCombo) && comboLineArea); err != nil {
+		return err
+	}
+	if err := optionSupported("step", variant.Step != nil,
+		(visualType == document.DashboardVisualTypeLine || visualType == document.DashboardVisualTypeArea || visualType == document.DashboardVisualTypeCombo) && comboLineArea); err != nil {
+		return err
+	}
+	if err := optionSupported("symbolSize", variant.SymbolSize != nil,
+		(visualType == document.DashboardVisualTypeLine || visualType == document.DashboardVisualTypeArea || visualType == document.DashboardVisualTypeCombo) && comboLineArea); err != nil {
+		return err
+	}
+	if err := optionSupported("series", variant.Series != nil, visualType == document.DashboardVisualTypeCombo); err != nil {
+		return err
+	}
+	// Decision-context declarations are lowered separately, but their authored
+	// presence is part of the same applicability contract. Empty explicitly-
+	// authored collections are still declarations and must not be accepted on
+	// marks whose renderer has no context channel.
+	for _, option := range []struct {
+		name    string
+		present bool
+	}{
+		{"referenceLines", variant.ReferenceLines != nil},
+		{"referenceBands", variant.ReferenceBands != nil},
+		{"eventAnnotations", variant.EventAnnotations != nil},
+	} {
+		if err := optionSupported(option.name, option.present,
+			visualType == document.DashboardVisualTypeLine ||
+				visualType == document.DashboardVisualTypeArea ||
+				visualType == document.DashboardVisualTypeBar ||
+				visualType == document.DashboardVisualTypeColumn ||
+				visualType == document.DashboardVisualTypeCombo ||
+				visualType == document.DashboardVisualTypeWaterfall); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func comboSeriesSupportsLineControls(values []document.DashboardComboSeries) bool {
+	compiled, err := lowerCanonicalComboSeries(values)
+	if err != nil {
+		// Applicability must not mask the established diagnostic for an invalid
+		// combo series (empty, unknown mark, duplicate, and so on).
+		return true
+	}
+	for _, series := range compiled {
+		if series.Mark == visualizationir.VisualizationCartesianMarkLine || series.Mark == visualizationir.VisualizationCartesianMarkArea {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dashboard/compiler/dashboard_presentation_lowering.go
+++ b/internal/dashboard/compiler/dashboard_presentation_lowering.go
@@ -33,9 +33,6 @@ func LowerCanonicalDashboardPresentation(value document.DashboardPresentation, v
 	}
 	switch variant := value.Value.(type) {
 	case *document.CartesianDashboardPresentation:
-		if variant.Series != nil && visualType != document.DashboardVisualTypeCombo {
-			return nil, fmt.Errorf("presentation.series is only supported for combo visuals")
-		}
 		base, err := lowerBasePresentation(variant.Legend, variant.Labels, variant.DisplayUnits)
 		if err != nil {
 			return nil, err
@@ -54,8 +51,11 @@ func LowerCanonicalDashboardPresentation(value document.DashboardPresentation, v
 			out.Step = *variant.Step
 		}
 		if variant.SymbolSize != nil {
+			if !finiteDashboardFloat(*variant.SymbolSize) {
+				return nil, fmt.Errorf("presentation.symbolSize must be finite")
+			}
 			if *variant.SymbolSize <= 0 {
-				return nil, fmt.Errorf("cartesian symbolSize must be greater than zero")
+				return nil, fmt.Errorf("presentation.symbolSize must be greater than zero")
 			}
 			out.SymbolSize = variant.SymbolSize
 		}
@@ -442,6 +442,8 @@ func validateCanonicalPresentationApplicability(value document.DashboardPresenta
 		return nil
 	}
 	switch variant := value.Value.(type) {
+	case *document.CartesianDashboardPresentation:
+		return validateCanonicalCartesianPresentationApplicability(variant, visualType)
 	case *document.HierarchyDashboardPresentation:
 		if variant == nil {
 			return nil

--- a/internal/dashboard/compiler/dashboard_presentation_lowering_test.go
+++ b/internal/dashboard/compiler/dashboard_presentation_lowering_test.go
@@ -23,7 +23,7 @@ func TestLowerCanonicalCartesianPresentationPreservesEveryField(t *testing.T) {
 	position := document.DashboardLabelPositionInside
 	units := visualizationir.VisualizationDisplayUnitsMillions
 	value := document.DashboardPresentation{Value: &document.CartesianDashboardPresentation{Type: "cartesian", Legend: &legend, Labels: &labels, Stacking: &stacking, Orientation: &orientation, ShowSymbols: &showSymbols, Smooth: &smooth, DataZoom: &dataZoom, SymbolSize: &symbolSize, LabelPosition: &position, DisplayUnits: &units}}
-	lowered, err := LowerCanonicalDashboardPresentation(value, document.DashboardVisualTypeBar)
+	lowered, err := LowerCanonicalDashboardPresentation(value, document.DashboardVisualTypeLine)
 	if err != nil {
 		t.Fatalf("lower presentation: %v", err)
 	}
@@ -741,7 +741,7 @@ func TestLowerCanonicalComboPresentationRejectsUnknownDuplicateAndInapplicableSe
 		{name: "unknown result", visualType: document.DashboardVisualTypeCombo, series: []document.DashboardComboSeries{{Field: "missing", Mark: document.DashboardComboSeriesMark("line"), Axis: document.DashboardComboSeriesAxis("primary")}}, want: "not a compiled result field"},
 		{name: "duplicate result", visualType: document.DashboardVisualTypeCombo, series: []document.DashboardComboSeries{{Field: "revenue", Mark: document.DashboardComboSeriesMark("line"), Axis: document.DashboardComboSeriesAxis("primary")}, {Field: "revenue", Mark: document.DashboardComboSeriesMark("area"), Axis: document.DashboardComboSeriesAxis("secondary")}}, want: "duplicates"},
 		{name: "empty series", visualType: document.DashboardVisualTypeCombo, series: []document.DashboardComboSeries{}, want: "at least one entry"},
-		{name: "non combo visual", visualType: document.DashboardVisualTypeLine, series: []document.DashboardComboSeries{{Field: "revenue", Mark: document.DashboardComboSeriesMark("line"), Axis: document.DashboardComboSeriesAxis("primary")}}, want: "only supported for combo"},
+		{name: "non combo visual", visualType: document.DashboardVisualTypeLine, series: []document.DashboardComboSeries{{Field: "revenue", Mark: document.DashboardComboSeriesMark("line"), Axis: document.DashboardComboSeriesAxis("primary")}}, want: "presentation.series is not supported for line visuals"},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {

--- a/web/components/dashboard/visualization/adapters/echarts-cartesian-presentation.test.ts
+++ b/web/components/dashboard/visualization/adapters/echarts-cartesian-presentation.test.ts
@@ -1,0 +1,156 @@
+import { expect, test } from 'bun:test'
+
+import type { VisualizationEnvelope } from '../../../../generated/visualization'
+import { defaultRendererContext } from '../host-controller'
+import { echartsOption } from './echarts'
+
+test('ECharts translates supported line presentation controls exactly', () => {
+  const envelope = cartesianPresentationFixture('line') as any
+  envelope.spec.presentation = {
+    legend: 'right',
+    labelPolicy: { density: 'always', priority: [], maxCharacters: 24, minimumSpacing: 0, tooltipFallback: true },
+    orientation: 'horizontal',
+    showSymbols: true,
+    smooth: true,
+    step: true,
+    symbolSize: 16,
+    dataZoom: true,
+  }
+
+  const option = echartsOption(envelope, defaultRendererContext) as any
+
+  expect(option.legend).toMatchObject({ show: true, orient: 'vertical', right: 0 })
+  expect(option.grid).toMatchObject({ top: 16, bottom: 58 })
+  expect(option.xAxis).toMatchObject({ type: 'value' })
+  expect(option.yAxis).toMatchObject({ type: 'category' })
+  expect(option.dataZoom).toEqual([{ type: 'inside' }, { type: 'slider' }])
+  expect(option.series).toHaveLength(1)
+  expect(option.series[0]).toMatchObject({
+    type: 'line',
+    encode: { x: 'value', y: 'label' },
+    smooth: true,
+    symbolSize: 16,
+    step: 'middle',
+  })
+  expect(option.series[0].symbol).toBeUndefined()
+})
+
+test('ECharts derives horizontal axis types from their physical field refs', () => {
+  const envelope = cartesianPresentationFixture('line') as any
+  envelope.spec.presentation = {
+    labelPolicy: { density: 'automatic', priority: [], maxCharacters: 24, minimumSpacing: 6, tooltipFallback: true },
+    orientation: 'horizontal',
+  }
+  envelope.spec.datasets[0].fields[0].dataType = 'temporal'
+  envelope.dataState.datasets[0].rows = [[Date.UTC(2026, 0, 1), 12]]
+
+  const option = echartsOption(envelope, defaultRendererContext) as any
+
+  expect(option.xAxis).toMatchObject({ type: 'value' })
+  expect(option.yAxis).toMatchObject({ type: 'time' })
+  expect(option.series[0].encode).toEqual({ x: 'value', y: 'label' })
+})
+
+test('ECharts propagates symbolSize to every split Cartesian series', () => {
+  const envelope = cartesianPresentationFixture('area') as any
+  envelope.spec.series = { dataset: 'primary', field: 'series' }
+  envelope.spec.presentation = {
+    legend: 'bottom',
+    labelPolicy: { density: 'automatic', priority: [], maxCharacters: 24, minimumSpacing: 6, tooltipFallback: true },
+    showSymbols: false,
+    smooth: false,
+    step: false,
+    symbolSize: 22,
+    stacking: 'normal',
+    dataZoom: false,
+  }
+  envelope.dataState.datasets[0].columns = ['label', 'series', 'value']
+  envelope.dataState.datasets[0].rows = [
+    ['Jan', 'approved', 3],
+    ['Jan', 'pending', 2],
+  ]
+
+  const option = echartsOption(envelope, defaultRendererContext) as any
+
+  expect(option.series.map((series: any) => series.name)).toEqual(['approved', 'pending'])
+  expect(option.series.map((series: any) => series.symbolSize)).toEqual([22, 22])
+  expect(option.series.map((series: any) => series.symbol)).toEqual(['none', 'none'])
+  expect(option.series.map((series: any) => series.stack)).toEqual(['normal', 'normal'])
+})
+
+test('ECharts preserves common labels, display units, and axes for heatmap', () => {
+  const envelope = cartesianPresentationFixture('heatmap') as any
+  envelope.spec.x = { dataset: 'primary', field: 'label' }
+  envelope.spec.y = [
+    { dataset: 'primary', field: 'row' },
+    { dataset: 'primary', field: 'value' },
+  ]
+  envelope.spec.datasets[0].fields = [
+    { id: 'label', role: 'dimension', dataType: 'string', nullable: false, label: 'Label' },
+    { id: 'row', role: 'dimension', dataType: 'string', nullable: false, label: 'Row' },
+    { id: 'value', role: 'metric', dataType: 'decimal', nullable: false, label: 'Value' },
+  ]
+  envelope.spec.presentation = {
+    labelPolicy: { density: 'always', priority: [], maxCharacters: 24, minimumSpacing: 0, tooltipFallback: true },
+    labelPosition: 'inside',
+    displayUnits: 'millions',
+  }
+  envelope.spec.axes = [{ id: 'x', title: 'Period', scale: 'automatic', zero: 'automatic', tickDensity: 'dense' }]
+  envelope.dataState.datasets[0].columns = ['label', 'row', 'value']
+  envelope.dataState.datasets[0].rows = [['A', 'R1', 1_000_000]]
+
+  const option = echartsOption(envelope, defaultRendererContext) as any
+
+  expect(option.legend).toBeUndefined()
+  expect(option.dataZoom).toBeUndefined()
+  expect(option.xAxis).toMatchObject({ type: 'category', name: 'Period', axisLabel: { interval: 0 } })
+  expect(option.yAxis).toMatchObject({ type: 'category' })
+  expect(option.series[0]).toMatchObject({ type: 'heatmap', encode: { x: 'label', y: 'row', value: 'value' } })
+  expect(option.series[0].label.position).toBe('inside')
+  expect(option.series[0].label.formatter({ value: ['A', 'R1', 1_000_000] })).toBe('1M')
+})
+
+function cartesianPresentationFixture(mark: string): VisualizationEnvelope {
+  return {
+    schemaVersion: 9,
+    visualID: mark,
+    rendererID: 'echarts',
+    specRevision: 'sha256:cartesian-presentation',
+    dataRevision: 1,
+    spec: {
+      kind: 'cartesian',
+      title: mark,
+      mark,
+      datasets: [{ id: 'primary', fields: [
+        { id: 'label', role: 'dimension', dataType: 'string', nullable: false, label: 'Label' },
+        { id: 'value', role: 'metric', dataType: 'decimal', nullable: false, label: 'Value' },
+      ] }],
+      dataBudget: { maxRows: 100, requiredCompleteness: 'complete' },
+      accessibility: { title: mark, description: mark },
+      interactions: [],
+      x: { dataset: 'primary', field: 'label' },
+      y: [{ dataset: 'primary', field: 'value' }],
+      presentation: {
+        labelPolicy: { density: 'automatic', priority: [], maxCharacters: 24, minimumSpacing: 6, tooltipFallback: true },
+      },
+    },
+    dataState: {
+      kind: 'inline',
+      specRevision: 'sha256:cartesian-presentation',
+      dataRevision: 1,
+      generation: 1,
+      datasets: [{
+        id: 'primary',
+        specRevision: 'sha256:cartesian-presentation',
+        dataRevision: 1,
+        generation: 1,
+        columns: ['label', 'value'],
+        rows: [['Jan', 1]],
+        completeness: 'complete',
+      }],
+    },
+    selection: [],
+    status: { kind: 'ready' },
+    diagnostics: [],
+  } as VisualizationEnvelope
+}

--- a/web/components/dashboard/visualization/adapters/echarts/cartesian.ts
+++ b/web/components/dashboard/visualization/adapters/echarts/cartesian.ts
@@ -19,9 +19,12 @@ export function cartesianOption(envelope: VisualizationEnvelope, context: Render
 function cartesianBaseOption(envelope: VisualizationEnvelope, context: RendererContext, categoryColors: CategoryColorRegistry): EChartsTranslation {
   const spec = envelope.spec as CartesianSpec
   const horizontal = spec.presentation.orientation === 'horizontal' || spec.mark === 'bar'
-  const xType = axisType(envelope, spec.x, horizontal ? 'value' : 'category')
-  const xAxis = axis(envelope, horizontal ? spec.y[0]! : spec.x, xType, context, horizontal ? 'primary_y' : 'x', horizontal ? spec.y : [spec.x])
-  const yAxis = axis(envelope, horizontal ? spec.x : spec.y[0]!, horizontal ? 'category' : 'value', context, horizontal ? 'x' : 'primary_y', horizontal ? [spec.x] : spec.y)
+  const xRef = horizontal ? spec.y[0]! : spec.x
+  const xType = axisType(envelope, xRef, horizontal ? 'value' : 'category')
+  const xAxis = axis(envelope, xRef, xType, context, horizontal ? 'primary_y' : 'x', horizontal ? spec.y : [spec.x])
+  const yRef = horizontal ? spec.x : spec.y[0]!
+  const yType = axisType(envelope, yRef, horizontal ? 'category' : 'value')
+  const yAxis = axis(envelope, yRef, yType, context, horizontal ? 'x' : 'primary_y', horizontal ? [spec.x] : spec.y)
   const stack = stackingMode(spec)
   if (stack === 'percent') applyPercentAxis(horizontal ? xAxis : yAxis, context)
   const axes = { grid: cartesianGrid(spec), xAxis, yAxis }
@@ -474,7 +477,7 @@ function splitCartesianSeries(envelope: VisualizationEnvelope, context: Renderer
     return {
       id: `series:${spec.series?.dataset}:${spec.series?.field}:${token}`, datasetId: datasetID, name: String(value), type: cartesianSeriesType(mark),
       ...(horizontal ? { xAxisIndex: combo?.axis === 'secondary' ? 1 : 0 } : { yAxisIndex: combo?.axis === 'secondary' ? 1 : 0 }),
-      encode: horizontal ? { x: normalized?.dimension ?? spec.y[0]?.field, y: spec.x.field } : { x: spec.x.field, y: normalized?.dimension ?? spec.y[0]?.field }, smooth: spec.presentation.smooth, symbol: spec.presentation.showSymbols ? undefined : 'none',
+      encode: horizontal ? { x: normalized?.dimension ?? spec.y[0]?.field, y: spec.x.field } : { x: spec.x.field, y: normalized?.dimension ?? spec.y[0]?.field }, smooth: spec.presentation.smooth, symbol: spec.presentation.showSymbols ? undefined : 'none', symbolSize: spec.presentation.symbolSize,
       stack: stack === 'none' ? undefined : stack, areaStyle: spec.presentation.area || mark === 'area' ? {} : undefined,
       itemStyle: {
         color: markColor,


### PR DESCRIPTION
## What

- Reject Cartesian presentation options that the selected mark cannot render.
- Keep combo line controls truthful to configured series and preserve precise invalid-series diagnostics.
- Fix horizontal temporal axis typing and category-series `symbolSize` propagation.
- Document the per-mark Cartesian capability matrix.

## Why

- Phase 1 requires every accepted formatting option to render or fail with an actionable path-bearing error.
- Several special Cartesian marks previously accepted silent no-ops.

## Validation

- `GOFLAGS='-tags=duckdb_arrow -buildvcs=false' PATH=/home/codex/.bun/bin:$PATH task ci`
- `go test ./internal/dashboard/compiler -count=1`
- `go test ./internal/dashboard/visualization/... ./internal/dashboard/runtime -count=1`
- `bun test web/components/dashboard/visualization/adapters/echarts.test.ts web/components/dashboard/visualization/adapters/echarts-polar.test.ts web/components/dashboard/visualization/adapters/echarts-cartesian-presentation.test.ts` (47 passed)
- `bun run typecheck:app`
- `task quality:budget:check`
- `task generate`
- `task generated:check`
- `task docs:check`

## Contract coverage

Existing dashboard schema/generated types → compiler applicability → renderer-neutral IR → ECharts → positive/negative tests → docs.

Linear: FAI-740; LeapView Chart Formatting project.
