### PR TITLE
fix(dashboard): keep tiled map precision consistent

### DIFF
--- a/web/components/dashboard/visualization/adapters/maplibre.test.ts
+++ b/web/components/dashboard/visualization/adapters/maplibre.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test'
 
 import type { VisualizationEnvelope, VisualizationGeographicLayer } from '../../../../generated/visualization'
 import type { FeatureCollection } from 'geojson'
-import { aggregateExpansionCamera, applyFeatureScales, applyTiledPrecisionLayerVisibility, basemapBoundaryLayer, basemapLayer, basemapThemeKey, clusterExpansionForRenderedFeatures, concreteCSSColor, coordinateGeometry, coordinateReferenceGrid, createBasemapThemeScheduler, fitMapToGeographicData, installWebGLRecovery, interactionCommandForRenderedFeatures, joinGeometry, loadMapStyleAsset, mapAccessibleData, mapAccessibleRenderedFeatures, mapAccessibleTableSides, mapAccessibleTableStyle, mapClickCanRefineCamera, mapInteractionCommand, mapInteractionOptions, mapLayer, mapLibreChromeCSS, mapOutlineLayer, mapOverlayBottom, mapOverlaysNeedStacking, mapPointerOptions, mapSelectionControlAvailable, mapThemeColors, mapTooltipEntries, mapVisibleDataSummary, normalizeFeatureWeights, pathGeometry, progressiveAggregateRefinementZoom, removeRendererFrame, resetMapToHome, sameOriginGeometryURL, setRendererFramePresented, tiledAggregateCountLayer, tiledAggregateHeatLayer, tiledAggregatePointLayer, tiledLayerPaintUpdates, tiledPrecisionLayerFamily, tiledRawPrecisionVisible, tiledSourceEventReady, tiledSourceLifecycle, tiledSourceTransition, updateSelectionSources, vectorTileTemplateURL, verifyGeometryDigest, waitForMapRender } from './maplibre'
+import { aggregateExpansionCamera, applyFeatureScales, applyTiledPrecisionLayerVisibility, basemapBoundaryLayer, basemapLayer, basemapThemeKey, clusterExpansionForRenderedFeatures, concreteCSSColor, coordinateGeometry, coordinateReferenceGrid, createBasemapThemeScheduler, fitMapToGeographicData, installWebGLRecovery, interactionCommandForRenderedFeatures, joinGeometry, loadMapStyleAsset, mapAccessibleData, mapAccessibleRenderedFeatures, mapAccessibleTableSides, mapAccessibleTableStyle, mapClickCanRefineCamera, mapInteractionCommand, mapInteractionOptions, mapLayer, mapLibreChromeCSS, mapOutlineLayer, mapOverlayBottom, mapOverlaysNeedStacking, mapPointerOptions, mapSelectionControlAvailable, mapThemeColors, mapTooltipEntries, mapVisibleDataSummary, normalizeFeatureWeights, pathGeometry, progressiveAggregateRefinementZoom, removeRendererFrame, resetMapToHome, sameOriginGeometryURL, setRendererFramePresented, tiledAggregateCountLayer, tiledAggregateHeatLayer, tiledAggregatePointLayer, tiledLayerPaintUpdates, tiledPrecisionLayerFamily, tiledPrecisionLayerIDs, tiledRawPrecisionVisible, tiledSourceEventReady, tiledSourceLifecycle, tiledSourceTransition, updateSelectionSources, vectorTileTemplateURL, verifyGeometryDigest, waitForMapRender } from './maplibre'
 import { adapterObservation } from '../telemetry'
 
 test('MapLibre owns usable shadow-DOM styles for map navigation controls', () => {
@@ -367,14 +367,20 @@ test('MapLibre hides both tiled precision families during replacement and restor
   const replacement = tiledSourceLifecycle(tiledSourceTransition(previous, next), true)
   expect(replacement).toBe('waiting')
   expect(tiledPrecisionLayerFamily(replacement === 'waiting', 12, 8)).toBe('hidden')
+  expect(tiledPrecisionLayerIDs('hidden', raw, aggregate)).toEqual([])
+  expect(tiledPrecisionLayerIDs('hidden', raw, aggregate, ['raw-point', 'aggregate-count'])).toEqual([])
   applyTiledPrecisionLayerVisibility(map, raw, aggregate, tiledPrecisionLayerFamily(replacement === 'waiting', 12, 8))
   expect([...visibility.values()]).toEqual(['none', 'none', 'none', 'none'])
   const sourceReady = tiledSourceLifecycle(tiledSourceTransition(previous, next), true) === 'waiting'
+  expect(tiledPrecisionLayerIDs('raw', raw, aggregate)).toEqual(raw)
+  expect(tiledPrecisionLayerIDs('raw', raw, aggregate, ['raw-point', 'aggregate-count'])).toEqual(['raw-point'])
   applyTiledPrecisionLayerVisibility(map, raw, aggregate, tiledPrecisionLayerFamily(!sourceReady, 12, 8))
   expect(raw.map((id) => visibility.get(`${id}:visibility`))).toEqual(['visible', 'visible'])
   expect(aggregate.map((id) => visibility.get(`${id}:visibility`))).toEqual(['none', 'none'])
   const stable = tiledSourceLifecycle(tiledSourceTransition(previous, previous), true)
   expect(stable).toBe('stable')
+  expect(tiledPrecisionLayerIDs('aggregate', raw, aggregate)).toEqual(aggregate)
+  expect(tiledPrecisionLayerIDs('aggregate', raw, aggregate, ['raw-point', 'aggregate-count'])).toEqual(['aggregate-count'])
   applyTiledPrecisionLayerVisibility(map, raw, aggregate, tiledPrecisionLayerFamily(stable === 'waiting', 6, 8))
   expect(raw.map((id) => visibility.get(`${id}:visibility`))).toEqual(['none', 'none'])
   expect(aggregate.map((id) => visibility.get(`${id}:visibility`))).toEqual(['visible', 'visible'])

--- a/web/components/dashboard/visualization/adapters/maplibre.ts
+++ b/web/components/dashboard/visualization/adapters/maplibre.ts
@@ -9,7 +9,7 @@ import { blankMapStyle, loadGeometryAsset, loadMapStyleAsset, registerPMTilesPro
 import { applyBasemapTheme, basemapThemeKey, createBasemapThemeScheduler, mapThemeColors, scheduleBasemapThemeMutation, type BasemapColors } from './maplibre/basemap'
 import { installMapLibreChromeStyles } from './maplibre/chrome'
 import { coordinateGeometry, joinGeometry, pathGeometry } from './maplibre/data'
-import { applyFeatureScales, mapLayer, mapOutlineLayer, paletteColors, tiledAggregateCountLayer, tiledAggregateHeatLayer, tiledAggregatePointLayer } from './maplibre/layers'
+import { applyFeatureScales, mapLayer, mapOutlineLayer, paletteColors, tiledAggregateCountLayer, tiledAggregateHeatLayer, tiledAggregatePointLayer, tiledPrecisionLayerIDs } from './maplibre/layers'
 import { aggregateExpansionCamera, clusterExpansionForRenderedFeatures, interactionCommandForRenderedFeatures, mapInteractionCommand, mapInteractionOptions, updateSelectionSources } from './maplibre/interactions'
 import { mapAccessibleData, mapAccessibleRenderedFeatures, mapTooltipEntries, type RenderedFeatureLocator } from './maplibre/overlays'
 import { emitMapObservation, installWebGLRecovery, mapNow, removeRendererFrame, waitForMapIdle, waitForMapRender, type MapObservationStage } from './maplibre/lifecycle'
@@ -21,7 +21,7 @@ export { loadMapStyleAsset, sameOriginGeometryURL, verifyGeometryDigest } from '
 export { applyBasemapTheme, basemapBoundaryLayer, basemapLayer, basemapThemeKey, concreteCSSColor, createBasemapThemeScheduler, mapThemeColors } from './maplibre/basemap'
 export { mapLibreChromeCSS } from './maplibre/chrome'
 export { coordinateGeometry, joinGeometry, pathGeometry } from './maplibre/data'
-export { applyFeatureScales, mapLayer, mapOutlineLayer, normalizeFeatureWeights, tiledAggregateCountLayer, tiledAggregateHeatLayer, tiledAggregatePointLayer } from './maplibre/layers'
+export { applyFeatureScales, mapLayer, mapOutlineLayer, normalizeFeatureWeights, tiledAggregateCountLayer, tiledAggregateHeatLayer, tiledAggregatePointLayer, tiledPrecisionLayerIDs } from './maplibre/layers'
 export { aggregateExpansionCamera, clusterExpansionForRenderedFeatures, interactionCommandForRenderedFeatures, mapInteractionCommand, mapInteractionOptions, updateSelectionSources } from './maplibre/interactions'
 export { mapAccessibleData, mapAccessibleRenderedFeatures, mapTooltipEntries } from './maplibre/overlays'
 export { installWebGLRecovery, removeRendererFrame, waitForMapIdle, waitForMapRender } from './maplibre/lifecycle'
@@ -781,8 +781,8 @@ class MapLibreHandle implements RendererHandle {
   }
 
   private queryRenderedTiledFeatures(): RenderedFeatureLocator[] {
-    if (!this.tiledSourceID) return []
-    const layers = this.layerIDs.filter((id) => this.map.getLayer(id)?.source === this.tiledSourceID)
+    if (!this.tiledSourceID || this.envelope?.dataState.kind !== 'spatial_tiled') return []
+    const layers = tiledPrecisionLayerIDs(tiledPrecisionLayerFamily(this.tiledSourceTransitioning, this.map.getZoom(), this.envelope.dataState.rawMinimumZoom), this.tiledRawLayerIDs, this.tiledAggregateLayerIDs).filter((id) => this.map.getLayer(id)?.source === this.tiledSourceID)
     return layers.length > 0 ? this.map.queryRenderedFeatures({ layers }) : []
   }
 
@@ -835,8 +835,9 @@ class MapLibreHandle implements RendererHandle {
     if (!this.envelope) return
     if (this.spatialSelectionControl?.consumeClick()) return
     const canRefineCamera = mapClickCanRefineCamera(this.envelope)
+    const selectableLayers = this.envelope.dataState.kind === 'spatial_tiled' ? tiledPrecisionLayerIDs(tiledPrecisionLayerFamily(this.tiledSourceTransitioning, this.map.getZoom(), this.envelope.dataState.rawMinimumZoom), this.tiledRawLayerIDs, this.tiledAggregateLayerIDs, this.selectableLayerIDs) : this.selectableLayerIDs
     if (this.envelope.dataState.kind === 'spatial_tiled') {
-      const features = this.selectableLayerIDs.length ? this.map.queryRenderedFeatures(event.point, { layers: this.selectableLayerIDs }) : []
+      const features = selectableLayers.length ? this.map.queryRenderedFeatures(event.point, { layers: selectableLayers }) : []
       const aggregate = features.find((feature) => feature.properties?.__lv_aggregate === true)
       if (aggregate) {
 				if (canRefineCamera) {
@@ -855,9 +856,9 @@ class MapLibreHandle implements RendererHandle {
 		}
       return
     }
-    if (this.selectableLayerIDs.length === 0) return
-    const features = this.map.queryRenderedFeatures(event.point, { layers: this.selectableLayerIDs })
-    const command = mapInteractionCommand(this.envelope, features, this.selectableLayerIDs)
+    if (selectableLayers.length === 0) return
+    const features = this.map.queryRenderedFeatures(event.point, { layers: selectableLayers })
+    const command = mapInteractionCommand(this.envelope, features, selectableLayers)
     if (command) this.dispatchInteraction(command)
   }
 
@@ -894,8 +895,9 @@ class MapLibreHandle implements RendererHandle {
 
   private readonly handlePointerMove = (event: MapMouseEvent) => {
     if (!this.envelope) return
-    const layers = [...new Set([...this.selectableLayerIDs, ...this.tooltipLayerIDs])]
-    if (layers.length === 0) return
+    const candidates = [...new Set([...this.selectableLayerIDs, ...this.tooltipLayerIDs])]
+    const layers = this.envelope.dataState.kind === 'spatial_tiled' ? tiledPrecisionLayerIDs(tiledPrecisionLayerFamily(this.tiledSourceTransitioning, this.map.getZoom(), this.envelope.dataState.rawMinimumZoom), this.tiledRawLayerIDs, this.tiledAggregateLayerIDs, candidates) : candidates
+    if (layers.length === 0) { this.map.getCanvas().style.cursor = ''; this.tooltip.hidden = true; return }
     const features = this.map.queryRenderedFeatures(event.point, { layers })
     this.map.getCanvas().style.cursor = interactionCommandForRenderedFeatures(this.envelope, features, this.selectableLayerIDs) ? 'pointer' : ''
     this.updateTooltip(event, features)

--- a/web/components/dashboard/visualization/adapters/maplibre/layers.ts
+++ b/web/components/dashboard/visualization/adapters/maplibre/layers.ts
@@ -1,6 +1,11 @@
 import type { FeatureCollection } from 'geojson'
 import type { SpatialTiledVisualizationDataState, VisualizationGeographicLayer } from '../../../../../generated/visualization'
 
+export function tiledPrecisionLayerIDs(family: 'hidden' | 'raw' | 'aggregate', rawLayerIDs: readonly string[], aggregateLayerIDs: readonly string[], candidates?: readonly string[]): string[] {
+	const layerIDs = family === 'raw' ? [...rawLayerIDs] : family === 'aggregate' ? [...aggregateLayerIDs] : []
+	return candidates ? layerIDs.filter((id) => candidates.includes(id)) : layerIDs
+}
+
 export function mapLayer(id: string, layerOrKind: VisualizationGeographicLayer | VisualizationGeographicLayer['kind'], tiled?: SpatialTiledVisualizationDataState, sourceID = id): any {
   const layer = typeof layerOrKind === 'string' ? undefined : layerOrKind
   const kind = typeof layerOrKind === 'string' ? layerOrKind : layerOrKind.kind


### PR DESCRIPTION
## Problem

Merge validation #273 intermittently observed raw points and aggregate cells at the same time after a tiled MapLibre zoom. The route QA correctly rejected the mixed accessibility summary, which caused Full merge validation and its aggregate CI gate to fail.

## Root cause

MapLibre can retain parent and child tile data while replacement tiles load. The adapter queried every rendered layer backed by the tiled source, including both raw and aggregate layer families, even though visibility was already governed by one global active precision family.

## Solution

- Resolve the active tiled precision family before accessibility, click, and pointer rendered-feature queries.
- Query only layer IDs from that active family; query none while the source is transitioning.
- Clear stale hover cursor/tooltip state while no precision family is active.
- Preserve tile generation, URL, identity, selection, and public contracts.

## Tests added/updated

- Extended MapLibre precision lifecycle coverage for hidden, raw, aggregate, and candidate-intersection layer selection.
- Kept the existing route QA assertion that rejects concurrently visible raw and aggregate precision.

## Verification

- `bun test web/components/dashboard/visualization/adapters/maplibre.test.ts` — 49 passed
- `bun run typecheck:app` — passed
- `task quality:budget:check` — passed (Go test 8,476/8,496; TypeScript production 14,031/14,033)
- `task qa:ui-framework` — passed (13 routes, map zoom sequence, 12 visual baselines)
- `git diff --check` — passed
- `task ci` — all non-Docker lanes passed; local PostgreSQL conformance could not access `/var/run/docker.sock`, so GitHub CI is authoritative for that Docker-backed lane

## Remaining limitations

None in the implementation. Local Docker-backed PostgreSQL conformance remains unavailable because this environment does not have non-root Docker socket access.

Linear: [FAI-753](https://linear.app/flid/issue/FAI-753/keep-tiled-map-accessibility-on-one-precision-family-during-zoom)

This is a dedicated fix; PR #471 is unchanged.
