### PR TITLE
Optimize cache result identity derivation

### DIFF
--- a/internal/analytics/materialize/runtime_arrow_result.go
+++ b/internal/analytics/materialize/runtime_arrow_result.go
@@ -15,13 +15,14 @@ import (
 )
 
 type plannedArrowQuery struct {
-	plan          semanticquery.Plan
-	countPlan     *semanticquery.Plan
-	planningMS    int64
-	countOnly     bool
-	totalFromData bool
-	dependency    resultidentity.Dependency
-	reusable      bool
+	plan                    semanticquery.Plan
+	countPlan               *semanticquery.Plan
+	planningMS              int64
+	countOnly               bool
+	totalFromData           bool
+	dependency              resultidentity.Dependency
+	resultEquivalenceDigest string
+	reusable                bool
 }
 
 func rowPlanWithTotal(plan semanticquery.Plan) (semanticquery.Plan, error) {
@@ -51,14 +52,20 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 	}
 	if cacheable {
 		planned, planErr = r.planOwnedArrowQuery(request)
+		var resultIdentity semanticquery.ResultIdentity
+		var resultIdentityErr error
 		if planErr == nil {
-			planned.dependency, planned.reusable = r.dependencyForPlan(planned.plan)
+			resultIdentity, resultIdentityErr = planned.plan.ResultIdentity()
+			if resultIdentityErr == nil {
+				planned.dependency, planned.reusable = r.dependencyForProjection(resultIdentity.Dependencies)
+				planned.resultEquivalenceDigest = resultIdentity.EquivalenceDigest
+			}
 		}
 		switch {
 		case planErr != nil:
 			admissionReason = dataquery.CacheAdmissionReasonPlanningFailed
 			observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionRejected, admissionReason)
-		case !planCacheDeterministic(r.model, planned.plan):
+		case resultIdentityErr != nil || !planned.plan.Deterministic || !dependencyProjectionCacheDeterministic(r.model, resultIdentity.Dependencies):
 			// Opaque or volatile plans, and plans whose participating datasets
 			// cannot be resolved to safe materialized tables, carry no positive
 			// cache-admission evidence.
@@ -152,7 +159,8 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 		// classification even though planning now precedes cache eligibility.
 		result = dataquery.Result{PlanningMS: planned.planningMS, ExecutionState: dataquery.ExecutionFailed}
 	} else if cacheable && admissionReason == dataquery.CacheAdmissionReasonEligible {
-		result, err = r.queryCache.executeArrowWithPlan(ctx, request, r.resultPartition, planned.dependency, planned.plan.SQL, cacheStarted, planned.plan, execute)
+		queryDigest := materializeResultEquivalenceDigest(planned.resultEquivalenceDigest, request)
+		result, err = r.queryCache.executeArrowWithDigest(ctx, request, r.resultPartition, planned.dependency, planned.plan.SQL, cacheStarted, queryDigest, execute)
 		observeQueryCacheOutcome(ctx, result, err)
 	} else {
 		execution, executeErr := execute(ctx)
@@ -203,11 +211,7 @@ func (r *Runtime) dependencyForPlan(plan semanticquery.Plan) (resultidentity.Dep
 	if err != nil {
 		return resultidentity.Dependency{}, false
 	}
-	dependency, err := r.dependencyEvidence.Dependency(r.dependencyPlanInput(projection))
-	if err != nil {
-		return resultidentity.Dependency{}, false
-	}
-	return dependency, true
+	return r.dependencyForProjection(projection)
 }
 
 func (r *Runtime) captureArrowPlan(ctx context.Context, plan semanticquery.Plan) (*arrowresult.Result, error) {

--- a/internal/analytics/query/planir/graph_canonical.go
+++ b/internal/analytics/query/planir/graph_canonical.go
@@ -27,6 +27,13 @@ func (g *Graph) Canonical() ([]byte, error) {
 	if err := g.Validate(); err != nil {
 		return nil, err
 	}
+	return g.canonicalValidated()
+}
+
+// canonicalValidated serializes a graph whose caller has already validated
+// it. Keeping validation outside this helper lets one request derive several
+// identity projections without walking the same immutable graph repeatedly.
+func (g *Graph) canonicalValidated() ([]byte, error) {
 	ids := make([]string, 0, len(g.Nodes))
 	for id := range g.Nodes {
 		ids = append(ids, id)
@@ -48,7 +55,14 @@ func (g *Graph) Canonical() ([]byte, error) {
 // dependency identity. Execution targets are deliberately removed: their
 // revisions are represented separately by relation evidence.
 func (g *Graph) DependencyCanonical() ([]byte, error) {
-	canonical, err := g.Canonical()
+	if err := g.Validate(); err != nil {
+		return nil, err
+	}
+	return g.dependencyCanonicalValidated()
+}
+
+func (g *Graph) dependencyCanonicalValidated() ([]byte, error) {
+	canonical, err := g.canonicalValidated()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/analytics/query/planir/graph_dependencies.go
+++ b/internal/analytics/query/planir/graph_dependencies.go
@@ -9,6 +9,25 @@ func (g *Graph) Dependencies() (Dependencies, error) {
 	if err := g.Validate(); err != nil {
 		return Dependencies{}, err
 	}
+	return g.dependenciesValidated(), nil
+}
+
+// DependencyEvidence derives the physical dependency scope and its canonical
+// target-independent plan bytes after one validation pass. Consumers that
+// need both values for one immutable plan should use this method instead of
+// calling Dependencies and DependencyCanonical independently.
+func (g *Graph) DependencyEvidence() (Dependencies, []byte, error) {
+	if err := g.Validate(); err != nil {
+		return Dependencies{}, nil, err
+	}
+	canonical, err := g.dependencyCanonicalValidated()
+	if err != nil {
+		return Dependencies{}, nil, err
+	}
+	return g.dependenciesValidated(), canonical, nil
+}
+
+func (g *Graph) dependenciesValidated() Dependencies {
 	datasets := map[string]struct{}{}
 	physical := map[string]struct{}{}
 	paths := map[string]struct{}{}
@@ -50,7 +69,7 @@ func (g *Graph) Dependencies() (Dependencies, error) {
 			}
 		}
 	}
-	return Dependencies{Datasets: sortedSet(datasets), PhysicalFields: sortedSet(physical), RelationshipPaths: sortedSet(paths)}, nil
+	return Dependencies{Datasets: sortedSet(datasets), PhysicalFields: sortedSet(physical), RelationshipPaths: sortedSet(paths)}
 }
 
 func (g *Graph) reachableIDs() []string {

--- a/internal/analytics/query/result_equivalence.go
+++ b/internal/analytics/query/result_equivalence.go
@@ -12,6 +12,39 @@ const ResultEquivalenceVersion = 1
 
 const resultEquivalenceDomain = "flid.resultidentity.result-equivalence.v1"
 
+// ResultIdentity contains the two target-independent projections needed to
+// address one planned result. Both values come from the same validated PlanIR
+// serialization so cache admission does not repeat graph validation and JSON
+// canonicalization.
+type ResultIdentity struct {
+	Dependencies      DependencyProjection
+	EquivalenceDigest string
+}
+
+// ResultIdentity derives dependency and result-equivalence evidence in one
+// pass while preserving the exact wire identities exposed by the independent
+// ResultDependencies and ResultEquivalenceDigest methods.
+func (p Plan) ResultIdentity() (ResultIdentity, error) {
+	if p.IR == nil {
+		return ResultIdentity{}, fmt.Errorf("plan has no PlanIR result identity evidence")
+	}
+	dependencies, canonical, err := p.IR.DependencyEvidence()
+	if err != nil {
+		return ResultIdentity{}, fmt.Errorf("canonicalize PlanIR result identity: %w", err)
+	}
+	if len(dependencies.Datasets) == 0 {
+		return ResultIdentity{}, fmt.Errorf("plan has no participating dataset")
+	}
+	plannerDigest := sha256.Sum256(canonical)
+	return ResultIdentity{
+		Dependencies: DependencyProjection{
+			Datasets:      append([]string(nil), dependencies.Datasets...),
+			PlannerDigest: "sha256:" + hex.EncodeToString(plannerDigest[:]),
+		},
+		EquivalenceDigest: digestResultEquivalence(canonical),
+	}, nil
+}
+
 // ResultEquivalenceCanonical returns the planner's canonical logical PlanIR
 // bytes. Physical relation names are intentionally omitted by using
 // DependencyCanonical; relation revisions are bound separately by

--- a/internal/analytics/query/result_equivalence_test.go
+++ b/internal/analytics/query/result_equivalence_test.go
@@ -1,6 +1,43 @@
 package query
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResultIdentityMatchesIndependentProjections(t *testing.T) {
+	planner := mustNewCompiledPlanner(t, testModel())
+	plan, err := planner.Plan(Request{
+		Dataset:    "orders",
+		Dimensions: []Field{{Field: "customer_state", Alias: "state"}},
+		Metrics:    []Field{{Field: "order_count", Alias: "count"}},
+		Filters:    []Filter{{Field: "orders.status", Operator: "equals", Values: []any{"paid"}}},
+		Sort:       []Sort{{Field: "count", Direction: "asc"}},
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := plan.ResultIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dependencies, err := plan.ResultDependencies()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := plan.ResultEquivalenceDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(identity.Dependencies, dependencies) {
+		t.Fatalf("single-pass dependencies = %#v, want %#v", identity.Dependencies, dependencies)
+	}
+	if identity.EquivalenceDigest != digest {
+		t.Fatalf("single-pass equivalence digest = %q, want %q", identity.EquivalenceDigest, digest)
+	}
+}
 
 func TestResultEquivalenceDigestUsesPlannerNormalization(t *testing.T) {
 	planner := mustNewCompiledPlanner(t, testModel())


### PR DESCRIPTION
## Summary

- derive cache dependency evidence and result-equivalence identity from one validated PlanIR traversal
- preserve the existing dependency and result-equivalence wire identities
- reuse the precomputed equivalence digest during governed Arrow cache execution

## Performance

Canonical full cache/cutover benchmark, median of 10 samples at 500ms with one CPU:

| Governed path | Old baseline | Before fix | After fix |
| --- | ---: | ---: | ---: |
| Shared warm | 113.0 us | 237.6 us | 115.2 us |
| Retained warm | 108.4 us | 247.0 us | 115.7 us |
| Cold | 151.0 us | 263.2 us | 149.5 us |
| Warm allocations | 422 | 1,007 | 420 |

End-to-end dashboard benchmark, median of 8 samples at 500ms:

- JSON: 45.54 ms cold to 41.41 ms warm (9.1% faster)
- Arrow: 33.13 ms cold to 29.10 ms warm (12.1% faster)
- warm requests: two cache hits, zero misses, zero physical queries
- all low-level cache and cutover cases remain within their regression budgets

## Verification

- go test ./internal/analytics/query/... ./internal/analytics/materialize ./internal/analytics/resultcache -count=1
- go test -race ./internal/analytics/query/... ./internal/analytics/materialize ./internal/analytics/resultcache -count=1
- go vet ./internal/analytics/query/... ./internal/analytics/materialize ./internal/analytics/resultcache
- task bench:cache:cutover:quick
- task bench:cache:cutover:full
- focused end-to-end dashboard JSON and Arrow benchmarks

The broader task ci contract was not rerun for this focused performance follow-up.