### PR TITLE
feat(semantic-access): compile access grants and typed predicates (FAI-639)

### DIFF
--- a/adr/0017-adopt-a-looker-aligned-semantic-access-contract.md
+++ b/adr/0017-adopt-a-looker-aligned-semantic-access-contract.md
@@ -4,7 +4,7 @@ Status: accepted
 
 Decision date: 2026-09-01
 
-Implementation: pending
+Implementation: partial
 
 Deciders: LeapView maintainers
 
@@ -200,6 +200,15 @@ assignments and claims from the opaque `trustedclaims.Envelope` may be resolved
 together. A
 source conflict is an error, never an implicit precedence decision.
 
+Registry and control snapshot admission validates the full row projection in
+addition to recomputing the persisted digest: lifecycle and stewardship/name
+invariants, definition references and type/shape agreement, and assignment or
+mapping tombstone state must be consistent. These derived checks do not change
+the registry/control digest wire formats. PostgreSQL readers perform bounded
+before/after state validation under READ COMMITTED and retry once; a second
+change or a row/digest mismatch fails closed. Effective-value resolution also
+checks registry and control state before and after resolution.
+
 The initial value types are typed scalar and homogeneous list values supported
 by the semantic field vocabulary. A scalar attribute satisfies an access grant
 when it equals an allowed value. A list attribute satisfies it when at least
@@ -333,16 +342,18 @@ concepts, targets, bypasses, precedence, or masking require another ADR.
 
 ### FAI-637 implementation boundary
 
-ADR-0017 remains **Implementation: pending**. FAI-637 implements the
+ADR-0017 remains **Implementation: partial**. FAI-637 implements the
 access-owned PostgreSQL control-plane slice: the profile-qualified definition
 registry, direct principal/group assignment rows, trusted claim-mapping rows,
 their lifecycle/version/digest/audit invariants, typed value ingress, a
 source-bound trusted-claim verifier boundary, effective direct/group
 resolution behind the opaque `trustedclaims.Envelope` boundary, and
-platform-admin management endpoints. It does
-not yet implement the SemanticModel policy compiler, planner security barrier,
-catalog or query enforcement, semantic generation references, cache/event
-invalidation, or ordinary semantic consumer integration.
+platform-admin management endpoints. FAI-639 now implements the bounded
+SemanticModel policy compiler/evaluator handoff described below, including
+target qualification and typed PlanIR predicates. It does not implement the
+planner security barrier, catalog or query enforcement, semantic generation
+references, cache/event invalidation, or ordinary semantic consumer
+integration; those remain deferred to FAI-641 and later slices.
 
 The source names SAML, OIDC, embed, and service token are accepted as closed
 mapping/verifier vocabulary only. FAI-637 does not claim an OIDC, SAML, embed,
@@ -353,18 +364,111 @@ pending.
 
 FAI-619 qualifies only the generated structural SemanticModel contract and
 compatibility lowering boundary. Its fixtures do not claim semantic access
-policy compilation, planner security barriers, or consumer admission. Those
-follow-on integration slices remain pending under FAI-639 and FAI-641, and
-VAL-11 remains Partial until generated canonicalization and complete
+policy compilation, planner security barriers, or consumer admission. FAI-639
+now supplies the compiler/evaluator boundary described below; planner
+security-barrier construction and consumer admission remain pending under
+FAI-641. VAL-11 remains Partial until generated canonicalization and complete
 control-plane/runtime equivalence are evidenced.
+
+### FAI-639 compiler/evaluator boundary
+
+FAI-639 preserves the authority split rather than moving instance state into
+the portable project artifact. The generated TypeSpec SemanticModel contract
+is lowered by the project compiler into the runtime `SemanticAccessPolicy`.
+That lowering is target-independent: it validates the closed shape, names,
+non-empty lists, duplicate references, and exact scalar/list literals (number
+tokens retain their JSON spelling), but it does not resolve registry
+definitions or principal values. The executable semantic-model snapshot
+deep-copies this policy so serving state cannot be changed through authored
+maps or slices after activation.
+
+`CompileSemanticAccessPolicy` is the target-qualification boundary. It accepts
+one target instance, semantic-model ID, semantic generation, compiled semantic
+lineage, and a complete registry snapshot. It recomputes the canonical registry
+digest and rejects inconsistent lineage, malformed or mixed registry identity,
+duplicate names or IDs, missing/disabled or
+incompatible definitions, invalid stewardship ownership, and filters that do
+not name a directly bound compatible semantic dimension. It canonicalizes
+grant values using the registered logical type, rejects canonical duplicates,
+and propagates required grants through dataset, relationship, dimension,
+metric, filter, and metric-dependency lineage. The result is immutable,
+target-qualified policy metadata with a deterministic canonical policy digest;
+it contains no principal or trusted-claim values and does not place a planner
+barrier.
+
+`EvaluateSemanticAccess` is deliberately separate from compilation. It
+consumes a `SemanticAccessAttributeSnapshot` and the current
+`SemanticAccessAuthority`. Both carry complete registry/control snapshots, not
+unqualified digest strings; the evaluator recomputes their FAI-636/637 digests,
+requires the authority instance to match the target, and rejects stale or mixed
+state. It also recomputes the effective-attribute digest and checks every
+value's definition/type/shape/source. Claim-derived values require an immutable
+`SemanticAttributeClaimEvidence` produced from the opaque verifier envelope,
+exact active control mappings, mapped canonical values, target/principal, and
+validity interval; evaluation checks that evidence at the authority's current
+observation time. Missing, malformed, expired, stale, or tampered state fails
+closed. FAI-639 does not fetch repositories, verify raw provider tokens, or
+construct a principal context itself.
+
+Direct-derived values (`direct` or `direct+trusted_claim`) additionally require
+opaque access-owned `SemanticAttributeDirectEvidence`. It binds the target
+instance and principal to the exact control state, the principal plus active-
+group subject closure, active assignment IDs/versions, and effective value
+identities. A value digest by itself is not assignment authority. Claim-derived
+values retain opaque verified-envelope evidence bound to the same control state
+and principal, exact mapping IDs/versions and source identity, the envelope's
+validity interval, and verifier fingerprints; raw values and claims are not
+identity inputs.
+
+The subject closure supplied when direct evidence is sealed is a trusted
+access-capability input, not a consumer assertion. FAI-641 integration must
+obtain it from the authoritative principal/group resolver and must not expose
+the evidence constructor as a request or browser boundary.
+
+Grant decisions use the profile's scalar equality, list-overlap, and logical
+AND rules. A satisfiable dataset access filter becomes a closed typed PlanIR
+predicate: scalar attributes produce `compare`/`=` with a typed literal, list
+attributes produce `in` with typed literals, and multiple filters compose with
+`and`. Relationship-bound members retain the complete dataset closure so later
+planner enforcement cannot drop a joined dataset's filter. Field names remain governed references and values remain typed PlanIR
+values; no SQL or template string is produced. Dataset predicates and denials
+are inherited by member decisions. Every multi-dataset dimension or metric
+decision carries `DatasetPredicates`, a complete map from each required dataset
+(including relationship/dependency datasets) to its typed predicate;
+`Predicate` is only the primary-dataset convenience view. FAI-641 must not
+infer that one predicate covers a multi-dataset object.
+
+The policy digest is over deterministic canonical qualified policy metadata.
+The evaluator's decision identity additionally binds profile, instance,
+semantic model and generation, principal/actor, registry and control
+profile/revision/digest, effective-attribute digest, policy digest, grant
+results, filter evidence (including value digests and predicate kinds), and
+sorted object outcomes. Direct-assignment and verified-claim evidence digests
+are bound when present. Raw effective values and provider claims are excluded
+from both identity projections. These identities are an in-process handoff
+and audit/cache input; FAI-639 does not yet publish invalidation events or
+partition consumer/result caches.
+
+FAI-641 remains responsible for consuming this decision and typed PlanIR
+output in the governed planner. In particular, it must attach a security
+barrier at every protected dataset occurrence before joins, outer-join null
+extension, aggregation, suggestions, totals, rewrites, and execution, then
+wire the same admission to catalogs and every semantic consumer. FAI-639's
+compiler/evaluator tests are not evidence that those barriers, catalog rules,
+consumer adapters, generation references, cache invalidation, or end-to-end
+query enforcement exist.
 
 ### Immediate invalidation identity
 
-FAI-637 establishes, but does not yet consume, durable invalidation inputs.
-The future authorization-sensitive identity is the tuple
+FAI-637 establishes durable invalidation inputs, and FAI-639 now computes the
+effective-attribute, policy, and decision identities used to consume them.
+Neither slice publishes invalidation events or implements consumer caches.
+The authorization-sensitive identity contract is the tuple
 `(instance, semantic generation, principal, registry profile/revision/digest,
 control profile/revision/digest, effective attribute-set digest, normalized
-semantic-policy identity)`. The effective attribute-set digest is an ordered
+semantic-policy identity)`. FAI-639 materializes this contract in the
+evaluator's deterministic decision identity, while the cache/event consumers
+remain future work. The effective attribute-set digest is an ordered
 projection of definition ID/version/type/shape, canonical value digest, and
 source; raw values and raw provider claims are excluded. Runtime trusted input
 also binds its credential/token fingerprint and validity interval.
@@ -421,13 +525,17 @@ its own governed consumption contract rather than reuse of internal resources.
   current FAI-637 slice does not claim that the existing legacy compiler and
   consumer paths have completed this migration.
 - FAI-619's generated-boundary, structural, extracted-YAML, and compiler
-  compatibility fixtures cover the migrated structural surface. They do not
-  claim the pending FAI-639/641 semantic policy compiler, planner, or consumer
-  integration requirements.
-- Query authorization tests prove fail-closed scalar and list matching,
-  all-grants and all-filters composition, discovery filtering, direct-reference
-  rejection, parameterized planning, and identical enforcement for every
-  semantic consumer.
+  compatibility fixtures cover the migrated structural surface. FAI-639's
+  compiler/evaluator fixtures cover the lowering, registry qualification,
+  opaque assignment/envelope evidence, trusted snapshot checks, complete
+  multi-dataset predicate maps, bounded reader/admission checks, deterministic
+  identities, grant evaluation, and typed PlanIR predicate handoff. Neither
+  slice claims FAI-641 planner or consumer integration.
+- Future query authorization tests must prove fail-closed scalar and list
+  matching, all-grants and all-filters composition, discovery filtering,
+  direct-reference rejection, parameterized planning, and identical
+  enforcement for every semantic consumer; FAI-639's evaluator tests do not
+  satisfy those planner or consumer requirements.
 - Extracted normative YAML examples parse and validate against the generated
   SemanticModel schema; cross-path golden fixtures prove identical typed
   canonicalization and the 1,024-value bound.

--- a/adr/specifications/semantic-access-policy-conformance.md
+++ b/adr/specifications/semantic-access-policy-conformance.md
@@ -27,19 +27,40 @@ specification. It currently adds the PostgreSQL definition registry (revision
 2), durable principal/group assignments and trusted-claim mappings (revision
 3), shared typed canonicalization at those boundaries, a source-bound trusted
 claim verifier package, effective direct/group resolution behind the opaque
-`trustedclaims.Envelope` boundary, and platform-admin control APIs. It does not
-yet implement the SemanticModel
-policy compiler, planner security barrier, catalog or query consumer
-integration, source-provider adapters, semantic generation references, or
-cache/event invalidation. Those requirements remain normative targets and
-their evidence remains pending or partial below.
+`trustedclaims.Envelope` boundary, and platform-admin control APIs.
 
-FAI-619 is a structural contract cutover only. Its generated SemanticModel
-boundary and compatibility-lowering fixtures do not qualify semantic policy
-compilation, planner security barriers, or consumer admission. Those follow-on
-integration slices remain pending under FAI-639 and FAI-641; VAL-11 remains
-Partial until generated canonicalization and the complete control-plane and
-runtime equivalence paths are evidenced.
+FAI-639 adds a bounded compiler/evaluator slice. The generated SemanticModel
+contract is lowered into a detached runtime policy without embedding registry
+or principal values. A target-qualified compiler checks semantic lineage,
+registry identity, active typed definitions, direct filter bindings, and
+transitive grant requirements, then emits deterministic policy metadata and a
+policy digest. An evaluator consumes a trusted effective-value snapshot plus
+complete registry/control authority snapshots, recomputes their canonical
+digests, checks target-qualified identity agreement and value digests, requires
+opaque access-owned assignment evidence for direct-derived values bound to the
+exact control state and principal/group closure, and verified-envelope
+evidence for claim-derived values bound to the exact control mappings and
+verified envelope. It evaluates grants and emits typed PlanIR equality/IN/AND
+predicates plus deterministic decision identity and non-sensitive filter
+evidence. Multi-dataset member decisions carry a complete per-dataset predicate
+set. PostgreSQL
+registry/control reads use bounded before/after validation under READ
+COMMITTED; snapshot admission validates derived lifecycle, name,
+definition-reference, and tombstone consistency without changing the persisted
+digest wire formats. It does not fetch repositories or verify raw provider
+tokens, attach planner barriers, filter catalogs, execute queries, or publish
+cache invalidation.
+
+FAI-641 owns the deferred planner security-barrier and semantic-consumer
+integration. Source-provider adapters, semantic generation references, and
+cache/event invalidation also remain pending or partial below.
+
+FAI-619 is the structural contract authority. Its generated SemanticModel
+boundary and compatibility-lowering fixtures are complemented by FAI-639's
+runtime lowering and compiler/evaluator fixtures, but neither qualifies
+planner security barriers or consumer admission. FAI-641 remains pending;
+VAL-11 remains Partial until generated canonicalization and the complete
+control-plane and runtime equivalence paths are evidenced.
 
 ## Change control
 
@@ -551,18 +572,18 @@ remain unqualified, so LIF is not complete.
 | Requirement range | Evidence | Status |
 |---|---|---|
 | CHG-01–CHG-04 | Profile-version, historical-policy, and normative-change checks | Pending |
-| FAI-619 structural authority | [`api/data-resources/main.tsp`](../../api/data-resources/main.tsp), generated [JSON Schema](../../internal/project/contracts/gen/data-resources.schema.json) and [Go DTOs](../../internal/project/contracts/models.gen.go), [generated-boundary fixtures](../../internal/project/contracts/contracts_test.go), [structural and extracted-YAML fixtures](../../internal/project/schema/semantic_access_contract_test.go), [generated-schema matrix](../../internal/project/schema/semantic_model_generated_schema_test.go), and compiler compatibility/exact-number fixtures. This is a structural cutover only; FAI-639 and FAI-641 semantic policy compilation, planner, and consumer integration remain pending. | Partial |
-| STR-01–STR-12 | The FAI-619 generated-boundary, structural, extracted-YAML, and compiler fixtures above cover the migrated surface. STR-08 remains partial: standalone transitional `DataPolicy` rejection and contextual access-reference/type-registry resolution are outside this cutover. | Partial |
+| FAI-619 structural authority + FAI-639 compiler/evaluator boundary | [`api/data-resources/main.tsp`](../../api/data-resources/main.tsp), generated [JSON Schema](../../internal/project/contracts/gen/data-resources.schema.json) and [Go DTOs](../../internal/project/contracts/models.gen.go), [generated-boundary fixtures](../../internal/project/contracts/contracts_test.go), [structural and extracted-YAML fixtures](../../internal/project/schema/semantic_access_contract_test.go), [generated-schema matrix](../../internal/project/schema/semantic_model_generated_schema_test.go), compiler compatibility/exact-number fixtures, [FAI-639 lowering fixtures](../../internal/project/compiler/data_resources_test.go), [compiler fixtures](../../internal/project/compiler/semantic_model_lowering_test.go), [snapshot fixtures](../../internal/analytics/model/semantic_access_test.go), [policy compiler/evaluator fixtures](../../internal/analytics/query/semantic_access_compile_test.go) / [evaluator fixtures](../../internal/analytics/query/semantic_access_evaluate_test.go), [direct assignment evidence](../../internal/access/semantic_attribute_direct_evidence_test.go), [verified claim evidence](../../internal/access/semantic_attribute_claim_evidence_test.go), [snapshot admission validation](../../internal/access/semantic_attribute_snapshot_validation_test.go), [bounded registry reader fixtures](../../internal/access/postgres/semantic_attribute_registry_snapshot_test.go), and the [unwired-boundary architecture guard](../../internal/platform/architecture/semantic_access_compiler_test.go). These prove the structural and bounded compiler/evaluator boundaries, opaque evidence, complete member predicate propagation, reader stability, and digest-preserving admission checks only; FAI-641 planner and consumer integration remain pending. | Partial |
+| STR-01–STR-12 | The FAI-619 generated-boundary, structural, extracted-YAML, and compiler fixtures above cover the generated surface; FAI-639 adds local grant-reference and registry/type qualification. STR-08 remains partial because standalone transitional `DataPolicy` rejection and complete target/generation admission are not evidenced by this slice. | Partial |
 | ATT-01–ATT-04, ATT-08, ATT-11–ATT-12 | PostgreSQL registry/control migrations and repositories, typed API envelopes, canonical-value tests, trustedclaims structural tests, and platform-admin route/attenuation tests | Partial: durable definition/assignment/mapping boundaries are implemented; principal-context integration, source adapters, and semantic-consumer admission are not. |
-| ATT-05–ATT-07, ATT-09–ATT-10 | Control snapshot identity and disable/tombstone behavior exist; generation-reference, provider-admission, runtime expiry wiring, dependent-object invalidation, and rollback retention checks remain unqualified | Partial |
+| ATT-05–ATT-07, ATT-09–ATT-10 | Control snapshot identity and disable/tombstone behavior exist. Bounded before/after registry/control reads, effective-resolution stability checks, opaque direct-assignment evidence, verified-envelope evidence, and derived lifecycle/name/definition-reference/tombstone admission checks are covered; generation-reference, provider-admission, runtime expiry wiring, dependent-object invalidation, and rollback retention checks remain unqualified | Partial |
 | VAL-01–VAL-10 | [`internal/semanticvalue`](../../internal/semanticvalue/value.go), its [unit](../../internal/semanticvalue/value_test.go) and [cross-path](../../internal/semanticvalue/crosspath_test.go) tests, the independent [`profile-v1.json`](../../internal/semanticvalue/testdata/profile-v1.json) fixture, and semantic-filter integration | Implemented at the shared semantic-value boundary; typed control ingress also consumes it |
-| VAL-11 | The shared `internal/semanticvalue` canonicalizer is used by registry, assignment, mapping, effective-value, and semantic-filter paths. Generated canonicalization plus complete control-plane claim-ingestion, candidate-validation, runtime-evaluation, policy-digest, cache, and audit-projection equivalence remain unqualified. | Partial |
-| GRT-01–GRT-10 | Access-grant compiler and evaluator fixtures | Pending |
-| FLT-01–FLT-10 | Semantic planner, parameterization, cardinality, and fail-closed tests | Pending |
-| PLN-01–PLN-09 | Security-barrier IR validation and join, aggregate, rollup, and rewrite golden plans | Pending |
+| VAL-11 | The shared `internal/semanticvalue` canonicalizer is used by registry, assignment, mapping, effective-value, semantic-filter, and FAI-639 compiler/evaluator paths. Generated canonicalization plus complete control-plane claim-ingestion, candidate-validation, runtime-evaluation, policy-digest, cache, and audit-projection equivalence remain unqualified. | Partial |
+| GRT-01–GRT-10 | FAI-639 [policy compiler fixtures](../../internal/analytics/query/semantic_access_compile_test.go) and [evaluator fixtures](../../internal/analytics/query/semantic_access_evaluate_test.go) cover target-independent lowering, registry-qualified grant references, canonical typed matching, logical-AND requirements, transitive member decisions, opaque direct-assignment and verified-claim evidence, stale/tampered snapshot rejection, complete multi-dataset member predicate sets, and deterministic outcomes. Provider-adapter expiry wiring, all consumer admission, and end-to-end discovery/execution remain unqualified. | Partial |
+| FLT-01–FLT-10 | FAI-639 compiler/evaluator fixtures cover direct compatible dimension binding, scalar `compare`/`=` and list `in` typed PlanIR output, filter `and` composition, complete per-dataset predicate propagation, value-digest/evidence identity, and fail-closed missing/stale values. FAI-641 planner placement, parameter binding at governed scans, discovery, and consumer enforcement remain unqualified. | Partial |
+| PLN-01–PLN-09 | FAI-641 security-barrier IR validation and join, aggregate, rollup, and rewrite golden plans | Pending |
 | ENF-01–ENF-11 | Catalog, dashboard, Explore, agent, export, API, and embed integration tests | Pending |
 | CMP-01–CMP-06 | Policy-diff, compatibility, security-impact, version, and approval fixtures | Pending |
-| LIF-01–LIF-08 | Registry/control revision+digest identities and transactional control audit are implemented; cache partitioning, immediate event invalidation, semantic planning, generation references, and complete audit projection are not | Partial |
+| LIF-01–LIF-08 | Registry/control revision+digest identities, bounded reader validation, digest-preserving snapshot admission, deterministic policy/decision/evidence identities, and transactional control audit are implemented; cache partitioning, immediate event invalidation, semantic planning, generation references, and complete audit projection are not | Partial |
 | OUT-01–OUT-05 | Negative schema, architecture, and documentation checks | Pending |
 
 ## Maintained verification

--- a/docs/articles/architecture/semantic-attribute-registry.md
+++ b/docs/articles/architecture/semantic-attribute-registry.md
@@ -3,10 +3,13 @@
 FAI-637 adds the PostgreSQL control-plane half of the `leapview.semantic-
 access/v1` profile. The registry defines what an attribute is; control rows
 record which subjects receive canonical values and which trusted provider
-claims may supply a value. This is stewardship state, not the semantic query
-authorization engine. The SemanticModel compiler, planner, catalog filtering,
-consumer adapters, cache invalidation, and generation-reference checks remain
-pending under [ADR-0017](../../../adr/0017-adopt-a-looker-aligned-semantic-access-contract.md).
+claims may supply a value. FAI-639 adds the SemanticModel compiler/evaluator
+boundary that qualifies authored policy against a registry snapshot and
+evaluates it against a trusted effective-value snapshot. This is still not the
+semantic query authorization engine: FAI-641 planner security barriers,
+catalog filtering, consumer adapters, cache invalidation, and generation-
+reference checks remain pending under
+[ADR-0017](../../../adr/0017-adopt-a-looker-aligned-semantic-access-contract.md).
 
 ## Capability ownership and authority
 
@@ -186,6 +189,103 @@ claims only through the opaque `trustedclaims.Envelope`; wiring real provider
 adapters through `Verify`, deriving a principal context, and passing that
 context to semantic consumers remain pending.
 
+## FAI-639 compiler/evaluator boundary
+
+The generated TypeSpec SemanticModel contract remains the authoritative
+portable input. The project compiler lowers it into `SemanticAccessPolicy` as
+a target-independent, detached runtime model. Lowering validates the closed
+shape, attribute and grant names, non-empty grant/filter lists, duplicate
+references, known grant references, and exact literal kinds. JSON number
+tokens retain their authored spelling until a registry type is available;
+instance definitions, assignments, claims, and effective values never enter
+the portable policy. `ExecutionSnapshot` deep-copies the policy's mutable
+maps and slices.
+
+`CompileSemanticAccessPolicy` then qualifies that portable policy against one
+complete registry snapshot and one compiled semantic lineage. It recomputes the
+FAI-636 registry digest before it binds stable
+definition IDs and versions, requires active profile-v1 definitions with
+valid stewardship ownership, canonicalizes grant values using the registered
+logical type, rejects canonical duplicates, and validates that each access
+filter names a directly bound compatible semantic dimension. Required grants
+are propagated through dataset and relationship paths, dimensions, metric
+dependencies, and referenced filter dimensions. The output is immutable
+qualified policy metadata with deterministic canonical bytes and a policy
+digest. Compilation is registry-qualified; it does not read assignment or
+mapping values and it does not evaluate a principal.
+
+Evaluation consumes two explicit inputs:
+
+```text
+compiled policy + effective attribute snapshot + current registry/control authority
+                                  |
+                                  v
+                         SemanticAccessDecision
+```
+
+`SemanticAccessAttributeSnapshot` is a trusted handoff of already-resolved
+effective values. It contains the instance and principal/actor identity,
+complete registry and control snapshots, canonical values, each value's
+definition identity/type/shape/source, and an effective-attribute digest.
+`EvaluateSemanticAccess` recomputes all three digests, checks canonical ordering
+and value digests, rejects invalid sources or definition mismatches, requires
+the authority instance to match the target, and requires captured state to
+match current authority. Claim-derived values additionally carry immutable
+`SemanticAttributeClaimEvidence` created by the access capability from the
+opaque verifier envelope, exact active mappings, mapped canonical values,
+control identity, target/principal, and validity interval. Evaluation checks it
+at the current authority observation time. The evaluator does not fetch
+repositories, verify raw provider tokens, or make a browser value trusted;
+malformed, expired, stale, missing, or tampered snapshots fail closed.
+
+Direct-derived values (`direct` or `direct+trusted_claim`) require opaque
+`SemanticAttributeDirectEvidence` from the access capability. It binds the
+target instance and principal to the exact control snapshot, the principal plus
+active-group subject closure, the active assignment IDs/versions, and the
+effective value identities. An effective-value digest alone is not assignment
+authority. Claim-derived values (`trusted_claim` or `direct+trusted_claim`)
+retain the verified-envelope evidence: opaque claim evidence binds the same
+control state and principal to the exact source, mapping IDs/versions,
+validity interval, and verifier fingerprints. Raw assignments, values, and
+claims remain outside these identity projections.
+
+The subject closure used to seal direct evidence is trusted access-capability
+input. FAI-641 must source it from the authoritative principal/group resolver;
+consumer, request, and browser code must never provide or widen that closure.
+
+For a valid snapshot, scalar grant values use equality and list values use
+overlap; required grants compose with logical AND. A dataset access filter is
+lowered to a typed PlanIR predicate: scalar values become `compare` with `=`,
+list values become `in`, and multiple filters become `and`. The PlanIR field is
+the compiler-resolved physical field and each value is a typed string,
+boolean, integer, decimal, date, or timestamp literal. No SQL, template, or
+author-supplied operator is emitted. Dataset predicates and denials are
+inherited by member decisions. Each multi-dataset dimension or metric decision
+also carries `DatasetPredicates`, a complete map from every required dataset
+(including relationship/dependency datasets) to that dataset's typed predicate;
+`Predicate` is only the primary-dataset convenience view. FAI-641 must not
+infer that one predicate covers a multi-dataset object.
+
+The effective-attribute digest is a deterministic ordered projection of
+definition ID/version/type/shape, value digest, and source; it excludes raw
+values. Policy digest is deterministic canonical policy metadata. Decision
+identity additionally binds the profile, target instance, semantic model and
+generation, principal/actor, registry and control identities, effective
+attribute digest, policy digest, grant results, filter evidence, and sorted
+dataset/dimension/metric outcomes. When present, direct-assignment and
+verified-claim evidence digests are also bound. Filter evidence carries value
+digests and predicate kinds rather than unrestricted values. These identities
+are inputs for later audit and cache partitioning, not evidence that cache
+invalidation or consumer enforcement is wired.
+
+FAI-641 is the deferred planner slice. It must consume the evaluator's typed
+predicates and install security barriers at every protected dataset occurrence
+before joins, outer-join null extension, aggregation, totals, suggestions,
+rewrites, and execution, then apply the same admission to catalogs and every
+semantic consumer. FAI-639 does not perform that placement or enforce a query;
+the existing generic/legacy access paths are not FAI-639 semantic-consumer
+evidence.
+
 ## Registry, effective values, and consumers
 
 The control-plane relationship is:
@@ -202,27 +302,45 @@ trusted mappings (source identity + exact claim -> definition)
 effective subject attributes (canonical values, source conflict checked)
         |
         v
-SemanticModel grants/filters and governed semantic consumers (pending)
+FAI-639 policy compiler/evaluator
+        |
+        v
+typed PlanIR predicates + decisions (planner handoff)
+        |
+        v
+FAI-641 planner barriers and governed semantic consumers (pending)
 ```
 
-The current FAI-637 implementation provides the first three boxes, shared
-canonical value validation, durable control identities, effective direct/group
-resolution behind the opaque `trustedclaims.Envelope` boundary, and
-platform-admin management APIs. It does not
-yet make those values the authority for SemanticModel `accessGrants`,
-`requiredAccessGrants`, or `accessFilters`; it does not filter catalogs or
-execute queries for dashboards, Explore, agents, exports, APIs, MCP, or
-embedding. The existing generic/legacy access paths therefore must not be
-described as FAI-637 semantic-consumer evidence.
+FAI-637 provides the first three boxes, shared canonical value validation,
+durable control identities, effective direct/group resolution behind the
+opaque `trustedclaims.Envelope` boundary, and platform-admin management APIs.
+FAI-639 consumes complete digest-verified registry/control snapshots, trusted
+direct-assignment and verified-claim evidence, and an effective-value snapshot
+at the compiler/evaluator boundary; it does not make repositories or raw claims
+available to portable policy artifacts. It does not yet attach
+predicates to governed scans, filter catalogs, or execute queries for
+dashboards, Explore, agents, exports, APIs, MCP, or embedding. FAI-641 owns
+that planner and consumer integration. Existing generic/legacy access paths
+therefore must not be described as FAI-639 semantic-consumer evidence.
 
 ## Immediate invalidation identity
 
-FAI-637 establishes the durable inputs needed for immediate invalidation but
-does not publish cache events or implement consumer caches. A future effective
-attribute-set identity must be derived from an ordered, profile-qualified
-projection of `(instance, subject, definition ID/version/type/shape,
-valueDigest, source)` and must never contain raw values. Runtime trusted input
+FAI-637 establishes the durable inputs needed for immediate invalidation, and
+FAI-639 computes the effective-attribute digest from an ordered,
+profile-qualified projection of `(definition ID/version/type/shape,
+valueDigest, source)`. It never contains raw values. Runtime trusted input
 also binds its source credential/token fingerprint and validity interval.
+FAI-639 does not publish cache events or implement consumer caches.
+
+PostgreSQL registry and control readers use READ COMMITTED statement snapshots,
+read state before and after the row projection, and retry once when the
+revision, digest, or profile changes during the read. A second change or a
+row/digest mismatch fails closed. Effective-value resolution applies the same
+bounded before/after check across registry and control state. The persisted
+registry/control digest wire projections are unchanged: snapshot admission
+derives and rejects inconsistent lifecycle, owner/name, definition-reference,
+and tombstone projections without adding those derived fields to the digest
+wire.
 
 Every authorization-sensitive cache key must include at least the instance
 identity, semantic generation, principal identity, registry
@@ -242,13 +360,18 @@ The PostgreSQL registry tests cover deterministic registry identity, stable
 registration/replay, metadata versioning, disablement, type immutability,
 canonical values, and transactional audit evidence. The trustedclaims tests
 cover the opaque verifier envelope, source binding, temporal checks, exact
-claims, copying, fingerprints, and structural value rejection. FAI-637's
-assignment/mapping repositories and migration are implementation scope, but
-their downstream semantic authorization and full integration qualification are
-not complete.
+claims, copying, fingerprints, and structural value rejection. FAI-639 tests
+cover authoritative lowering, registry qualification, lineage propagation,
+opaque direct-assignment and verified-claim evidence, trusted snapshot and
+stale-authority rejection, complete multi-dataset predicate maps,
+deterministic policy/decision identities, bounded reader checks, and typed
+PlanIR predicate output. Snapshot admission preserves the digest wire formats
+while validating derived lifecycle/name/tombstone consistency. FAI-641's
+planner barriers and downstream consumer authorization are not implemented.
 
 VAL-11 therefore remains **Partial**: the shared `internal/semanticvalue`
-canonicalizer is used at registry/assignment/mapping ingress and semantic-value
-tests provide cross-path fixtures, while generated canonicalization,
-candidate validation, runtime planner evaluation, cache identity/invalidation,
-and complete audit projection evidence remain unqualified.
+canonicalizer is used at registry/assignment/mapping ingress and FAI-639
+compiler/evaluator paths, while generated canonicalization, complete
+control-plane claim-ingestion equivalence, candidate validation, planner
+evaluation, cache invalidation, and complete audit projection evidence remain
+unqualified.

--- a/internal/access/postgres/semantic_attribute_control.go
+++ b/internal/access/postgres/semantic_attribute_control.go
@@ -6,12 +6,8 @@ package postgres
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -29,32 +25,6 @@ const semanticAttributeControlProfile = semanticvalue.Profile
 type semanticAttributeControlStateRow struct {
 	Profile, Digest, UpdatedAt string
 	Revision                   int64
-}
-
-type semanticAttributeAssignmentDigestWire struct {
-	ID, DefinitionID, SubjectKind, SubjectID string
-	DefinitionVersion                        int64
-	Type                                     semanticvalue.Type
-	Shape                                    access.SemanticAttributeShape
-	Values                                   []string
-	ValueDigest                              string
-	Version                                  int64
-	TombstonedAtMicros                       int64
-}
-
-type trustedClaimMappingDigestWire struct {
-	ID, SourceKind, Provider, Issuer, Audience, Claim, DefinitionID string
-	DefinitionVersion                                               int64
-	Type                                                            semanticvalue.Type
-	Shape                                                           access.SemanticAttributeShape
-	Version                                                         int64
-	TombstonedAtMicros                                              int64
-}
-
-type semanticAttributeControlDigestWire struct {
-	Profile     string                                  `json:"profile"`
-	Assignments []semanticAttributeAssignmentDigestWire `json:"assignments"`
-	Mappings    []trustedClaimMappingDigestWire         `json:"mappings"`
 }
 
 func assignmentFromRow(row accessdb.ListSemanticAttributeAssignmentsRow) access.SemanticAttributeAssignment {
@@ -151,54 +121,8 @@ func timestampAPIValue(value interface{}) string {
 	return time.UnixMicro(micros).UTC().Format(time.RFC3339Nano)
 }
 
-func timestampMicroseconds(value string) (int64, error) {
-	if value == "" {
-		return 0, nil
-	}
-	if micros, err := strconv.ParseInt(value, 10, 64); err == nil {
-		return micros, nil
-	}
-	parsed, err := time.Parse(time.RFC3339Nano, value)
-	if err != nil {
-		return 0, fmt.Errorf("invalid timestamp %q: %w", value, err)
-	}
-	return parsed.UTC().UnixMicro(), nil
-}
-
 func semanticAttributeControlDigest(assignments []access.SemanticAttributeAssignment, mappings []access.TrustedClaimMapping) (string, error) {
-	assignments = append([]access.SemanticAttributeAssignment(nil), assignments...)
-	mappings = append([]access.TrustedClaimMapping(nil), mappings...)
-	sort.Slice(assignments, func(i, j int) bool { return assignments[i].ID < assignments[j].ID })
-	sort.Slice(mappings, func(i, j int) bool { return mappings[i].ID < mappings[j].ID })
-	wire := semanticAttributeControlDigestWire{Profile: semanticAttributeControlProfile,
-		Assignments: make([]semanticAttributeAssignmentDigestWire, len(assignments)),
-		Mappings:    make([]trustedClaimMappingDigestWire, len(mappings))}
-	for i, row := range assignments {
-		tombstonedAt, err := timestampMicroseconds(row.TombstonedAt)
-		if err != nil {
-			return "", fmt.Errorf("assignment %s tombstoned timestamp: %w", row.ID, err)
-		}
-		wire.Assignments[i] = semanticAttributeAssignmentDigestWire{ID: row.ID, DefinitionID: row.DefinitionID,
-			SubjectKind: string(row.Subject.Kind), SubjectID: row.Subject.ID, DefinitionVersion: row.DefinitionVersion,
-			Type: row.Type, Shape: row.Shape, Values: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
-			Version: row.AssignmentVersion, TombstonedAtMicros: tombstonedAt}
-	}
-	for i, row := range mappings {
-		tombstonedAt, err := timestampMicroseconds(row.TombstonedAt)
-		if err != nil {
-			return "", fmt.Errorf("mapping %s tombstoned timestamp: %w", row.ID, err)
-		}
-		wire.Mappings[i] = trustedClaimMappingDigestWire{ID: row.ID, SourceKind: string(row.SourceKind),
-			Provider: row.Provider, Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim,
-			DefinitionID: row.DefinitionID, DefinitionVersion: row.DefinitionVersion, Type: row.Type,
-			Shape: row.Shape, Version: row.MappingVersion, TombstonedAtMicros: tombstonedAt}
-	}
-	encoded, err := json.Marshal(wire)
-	if err != nil {
-		return "", fmt.Errorf("encode semantic attribute control digest: %w", err)
-	}
-	sum := sha256.Sum256(encoded)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
+	return access.SemanticAttributeControlDigest(assignments, mappings)
 }
 
 func lockSemanticAttributeControlState(ctx context.Context, db DBTX) (semanticAttributeControlStateRow, error) {
@@ -293,7 +217,7 @@ func (r *Repository) SemanticAttributeControl(ctx context.Context) (access.Seman
 		if err != nil {
 			return access.SemanticAttributeControlSnapshot{}, err
 		}
-		if before.Revision != after.Revision || before.Digest != after.Digest {
+		if before.Revision != after.Revision || before.Digest != after.Digest || before.Profile != after.Profile {
 			continue
 		}
 		digest, err := semanticAttributeControlDigest(assignments, mappings)
@@ -303,7 +227,11 @@ func (r *Repository) SemanticAttributeControl(ctx context.Context) (access.Seman
 		if before.Profile != semanticAttributeControlProfile || before.Digest != digest {
 			return access.SemanticAttributeControlSnapshot{}, fmt.Errorf("%w: stored digest %q, computed %q", access.ErrSemanticAttributeControlCorrupt, before.Digest, digest)
 		}
-		return access.SemanticAttributeControlSnapshot{State: access.SemanticAttributeControlState{Profile: before.Profile, Revision: before.Revision, Digest: before.Digest, UpdatedAt: before.UpdatedAt}, Assignments: assignments, Mappings: mappings}, nil
+		snapshot := access.SemanticAttributeControlSnapshot{State: access.SemanticAttributeControlState{Profile: before.Profile, Revision: before.Revision, Digest: before.Digest, UpdatedAt: before.UpdatedAt}, Assignments: assignments, Mappings: mappings}
+		if err := access.ValidateSemanticAttributeControlSnapshot(snapshot); err != nil {
+			return access.SemanticAttributeControlSnapshot{}, err
+		}
+		return snapshot, nil
 	}
 	return access.SemanticAttributeControlSnapshot{}, fmt.Errorf("%w: control state changed during read", access.ErrSemanticAttributeControlCorrupt)
 }

--- a/internal/access/postgres/semantic_attribute_registry_snapshot_test.go
+++ b/internal/access/postgres/semantic_attribute_registry_snapshot_test.go
@@ -1,0 +1,65 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestStableSemanticAttributeRegistrySnapshotRetriesOneConcurrentMutation(t *testing.T) {
+	definition := func(id, name string) access.SemanticAttributeDefinition {
+		return access.SemanticAttributeDefinition{ID: id, Name: name, Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar,
+			Profile: semanticvalue.Profile, DefinitionVersion: 1, LifecycleState: access.SemanticAttributeActive, Enabled: true,
+			Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}}}
+	}
+	firstDefinitions := []access.SemanticAttributeDefinition{definition("definition-a", "alpha")}
+	secondDefinitions := append(append([]access.SemanticAttributeDefinition(nil), firstDefinitions...), definition("definition-b", "beta"))
+	firstDigest, err := semanticAttributeRegistryDigest(semanticvalue.Profile, firstDefinitions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondDigest, err := semanticAttributeRegistryDigest(semanticvalue.Profile, secondDefinitions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	states := []semanticAttributeRegistryStateRow{
+		{Profile: semanticvalue.Profile, Revision: 1, Digest: firstDigest},
+		{Profile: semanticvalue.Profile, Revision: 2, Digest: secondDigest},
+		{Profile: semanticvalue.Profile, Revision: 2, Digest: secondDigest},
+		{Profile: semanticvalue.Profile, Revision: 2, Digest: secondDigest},
+	}
+	stateCalls, definitionCalls := 0, 0
+	snapshot, err := stableSemanticAttributeRegistrySnapshot(func() (semanticAttributeRegistryStateRow, error) {
+		result := states[stateCalls]
+		stateCalls++
+		return result, nil
+	}, func() ([]access.SemanticAttributeDefinition, error) {
+		definitionCalls++
+		if definitionCalls == 1 {
+			return firstDefinitions, nil
+		}
+		return secondDefinitions, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stateCalls != 4 || definitionCalls != 2 || snapshot.State.Revision != 2 || snapshot.State.Digest != secondDigest || len(snapshot.Definitions) != 2 {
+		t.Fatalf("snapshot/calls = %#v, states=%d definitions=%d", snapshot, stateCalls, definitionCalls)
+	}
+}
+
+func TestStableSemanticAttributeRegistrySnapshotFailsAfterBoundedInstability(t *testing.T) {
+	stateCalls, definitionCalls := 0, 0
+	_, err := stableSemanticAttributeRegistrySnapshot(func() (semanticAttributeRegistryStateRow, error) {
+		stateCalls++
+		return semanticAttributeRegistryStateRow{Profile: semanticvalue.Profile, Revision: int64(stateCalls), Digest: "sha256:unstable"}, nil
+	}, func() ([]access.SemanticAttributeDefinition, error) {
+		definitionCalls++
+		return nil, nil
+	})
+	if !errors.Is(err, access.ErrSemanticAttributeRegistryCorrupt) || stateCalls != 4 || definitionCalls != 2 {
+		t.Fatalf("error/calls = %v, states=%d definitions=%d", err, stateCalls, definitionCalls)
+	}
+}

--- a/internal/access/postgres/semantic_attributes.go
+++ b/internal/access/postgres/semantic_attributes.go
@@ -2,8 +2,6 @@ package postgres
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,25 +21,6 @@ const maxSemanticAttributeSearchRows = 1000
 var _ access.SemanticAttributeRegistry = (*Repository)(nil)
 var _ access.VersionedSemanticAttributeRegistry = (*Repository)(nil)
 
-type registryDigestWire struct {
-	Profile     string                         `json:"profile"`
-	Definitions []registryDefinitionDigestWire `json:"definitions"`
-}
-
-type registryDefinitionDigestWire struct {
-	ID                string                                 `json:"id"`
-	Name              string                                 `json:"name"`
-	Type              semanticvalue.Type                     `json:"type"`
-	Shape             access.SemanticAttributeShape          `json:"shape"`
-	DefinitionVersion int64                                  `json:"definitionVersion"`
-	OwnerKind         access.SemanticAttributeOwnerKind      `json:"ownerKind"`
-	OwnerID           string                                 `json:"ownerId"`
-	DisplayName       string                                 `json:"displayName"`
-	Description       string                                 `json:"description"`
-	DocumentationURL  string                                 `json:"documentationUrl"`
-	LifecycleState    access.SemanticAttributeLifecycleState `json:"lifecycleState"`
-}
-
 type semanticAttributeRow struct {
 	ID, Name, ValueType, ValueShape, Profile   string
 	Version                                    int64
@@ -51,38 +30,73 @@ type semanticAttributeRow struct {
 	DisabledAt, CreatedAt, UpdatedAt           string
 }
 
+type semanticAttributeRegistryStateRow struct {
+	Profile, Digest, UpdatedAt string
+	Revision                   int64
+}
+
 func (r *Repository) SemanticAttributeRegistry(ctx context.Context) (access.SemanticAttributeRegistrySnapshot, error) {
 	db, err := r.requireDB()
 	if err != nil {
 		return access.SemanticAttributeRegistrySnapshot{}, err
 	}
 	queries := accessdb.New(db)
-	stateRow, err := queries.GetSemanticAttributeRegistry(ctx)
-	if err != nil {
-		return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("read semantic attribute registry state: %w", err)
+	readState := func() (semanticAttributeRegistryStateRow, error) {
+		row, readErr := queries.GetSemanticAttributeRegistry(ctx)
+		return semanticAttributeRegistryStateRow{Profile: row.Profile, Revision: row.RegistryRevision, Digest: row.RegistryDigest, UpdatedAt: row.UpdatedAt}, readErr
 	}
-	rows, err := queries.ListSemanticAttributeDefinitions(ctx)
-	if err != nil {
-		return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("list semantic attribute definitions: %w", err)
+	readDefinitions := func() ([]access.SemanticAttributeDefinition, error) {
+		rows, readErr := queries.ListSemanticAttributeDefinitions(ctx)
+		if readErr != nil {
+			return nil, readErr
+		}
+		definitions := make([]access.SemanticAttributeDefinition, len(rows))
+		for index, row := range rows {
+			definitions[index] = semanticAttributeDefinitionFromList(row)
+		}
+		return definitions, nil
 	}
-	definitions := make([]access.SemanticAttributeDefinition, len(rows))
-	for index, row := range rows {
-		definitions[index] = semanticAttributeDefinitionFromList(row)
+	return stableSemanticAttributeRegistrySnapshot(readState, readDefinitions)
+}
+
+func stableSemanticAttributeRegistrySnapshot(readState func() (semanticAttributeRegistryStateRow, error), readDefinitions func() ([]access.SemanticAttributeDefinition, error)) (access.SemanticAttributeRegistrySnapshot, error) {
+	// READ COMMITTED gives each statement its own snapshot. Read the registry
+	// state on both sides of the definition read and retry once if a concurrent
+	// mutation could have produced a mixed projection.
+	for attempt := 0; attempt < 2; attempt++ {
+		before, err := readState()
+		if err != nil {
+			return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("read semantic attribute registry state: %w", err)
+		}
+		definitions, err := readDefinitions()
+		if err != nil {
+			return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("list semantic attribute definitions: %w", err)
+		}
+		after, err := readState()
+		if err != nil {
+			return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("reread semantic attribute registry state: %w", err)
+		}
+		if before.Revision != after.Revision || before.Digest != after.Digest || before.Profile != after.Profile {
+			continue
+		}
+		digest, err := semanticAttributeRegistryDigest(before.Profile, definitions)
+		if err != nil {
+			return access.SemanticAttributeRegistrySnapshot{}, err
+		}
+		if digest != before.Digest {
+			return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("%w: semantic attribute registry digest mismatch: stored %q, computed %q", access.ErrSemanticAttributeRegistryCorrupt, before.Digest, digest)
+		}
+		snapshot := access.SemanticAttributeRegistrySnapshot{
+			State: access.SemanticAttributeRegistryState{Profile: before.Profile, Revision: before.Revision,
+				Digest: before.Digest, UpdatedAt: before.UpdatedAt},
+			Definitions: definitions,
+		}
+		if err := access.ValidateSemanticAttributeRegistrySnapshot(snapshot); err != nil {
+			return access.SemanticAttributeRegistrySnapshot{}, err
+		}
+		return snapshot, nil
 	}
-	digest, err := semanticAttributeRegistryDigest(stateRow.Profile, definitions)
-	if err != nil {
-		return access.SemanticAttributeRegistrySnapshot{}, err
-	}
-	if digest != stateRow.RegistryDigest {
-		return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("semantic attribute registry digest mismatch: stored %q, computed %q", stateRow.RegistryDigest, digest)
-	}
-	return access.SemanticAttributeRegistrySnapshot{
-		State: access.SemanticAttributeRegistryState{
-			Profile: stateRow.Profile, Revision: stateRow.RegistryRevision,
-			Digest: stateRow.RegistryDigest, UpdatedAt: stateRow.UpdatedAt,
-		},
-		Definitions: definitions,
-	}, nil
+	return access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("%w: registry state changed during read", access.ErrSemanticAttributeRegistryCorrupt)
 }
 
 func (r *Repository) SemanticAttributeDefinition(ctx context.Context, name string) (access.SemanticAttributeDefinition, error) {
@@ -484,22 +498,7 @@ func refreshSemanticAttributeRegistry(ctx context.Context, queries *accessdb.Que
 }
 
 func semanticAttributeRegistryDigest(profile string, definitions []access.SemanticAttributeDefinition) (string, error) {
-	wire := registryDigestWire{Profile: profile, Definitions: make([]registryDefinitionDigestWire, len(definitions))}
-	for index, definition := range definitions {
-		wire.Definitions[index] = registryDefinitionDigestWire{
-			ID: definition.ID, Name: definition.Name, Type: definition.Type, Shape: definition.Shape,
-			DefinitionVersion: definition.DefinitionVersion,
-			OwnerKind:         definition.Metadata.Owner.Kind, OwnerID: definition.Metadata.Owner.ID,
-			DisplayName: definition.Metadata.DisplayName, Description: definition.Metadata.Description,
-			DocumentationURL: definition.Metadata.DocumentationURL, LifecycleState: definition.LifecycleState,
-		}
-	}
-	encoded, err := json.Marshal(wire)
-	if err != nil {
-		return "", fmt.Errorf("encode semantic attribute registry digest: %w", err)
-	}
-	digest := sha256.Sum256(encoded)
-	return "sha256:" + hex.EncodeToString(digest[:]), nil
+	return access.SemanticAttributeRegistryDigest(profile, definitions)
 }
 
 func semanticAttributeAuditEvent(mutation access.SemanticAttributeMutationContext, actorID, action string, definition access.SemanticAttributeDefinition, revision int64, digest string) access.AuditEventInput {

--- a/internal/access/semantic_attribute_claim_evidence.go
+++ b/internal/access/semantic_attribute_claim_evidence.go
@@ -1,0 +1,149 @@
+package access
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+var ErrSemanticAttributeClaimEvidenceInvalid = errors.New("semantic attribute trusted-claim evidence is invalid")
+
+type semanticAttributeClaimValueIdentity struct {
+	DefinitionID      string `json:"definitionId"`
+	DefinitionVersion int64  `json:"definitionVersion"`
+	ValueDigest       string `json:"valueDigest"`
+	Source            string `json:"source"`
+}
+
+// SemanticAttributeClaimEvidence is an immutable binding between a verified
+// authentication envelope, the exact FAI-637 control snapshot used to map it,
+// and the claim-derived effective values. It exposes identity only, never raw
+// claims or canonical values.
+type SemanticAttributeClaimEvidence struct {
+	instanceID  string
+	principalID string
+	control     SemanticAttributeControlState
+	evaluatedAt time.Time
+	notBefore   time.Time
+	notAfter    time.Time
+	digest      string
+	values      []semanticAttributeClaimValueIdentity
+}
+
+func (evidence SemanticAttributeClaimEvidence) Digest() string { return evidence.digest }
+
+func (evidence SemanticAttributeClaimEvidence) Matches(instanceID, principalID string, control SemanticAttributeControlState, attributes []EffectiveSemanticAttribute) bool {
+	if evidence.digest == "" || evidence.instanceID != instanceID || evidence.principalID != principalID || evidence.control != control {
+		return false
+	}
+	values := semanticAttributeClaimValueIdentities(attributes)
+	return reflect.DeepEqual(values, evidence.values)
+}
+
+func (evidence SemanticAttributeClaimEvidence) ValidAt(now time.Time) bool {
+	return evidence.digest != "" && !now.IsZero() && now.Equal(now.UTC()) && !now.Before(evidence.evaluatedAt) &&
+		!now.Before(evidence.notBefore) && now.Before(evidence.notAfter)
+}
+
+// NewSemanticAttributeClaimEvidence validates and seals claim-derived values.
+// The control snapshot must be one returned by the verified FAI-637 reader;
+// its canonical digest is recomputed here before any mapping is trusted.
+func NewSemanticAttributeClaimEvidence(instanceID, principalID string, control SemanticAttributeControlSnapshot, attributes []EffectiveSemanticAttribute, envelope trustedclaims.Envelope, evaluatedAt time.Time) (SemanticAttributeClaimEvidence, error) {
+	if strings.TrimSpace(instanceID) != instanceID || instanceID == "" || strings.TrimSpace(principalID) != principalID || principalID == "" {
+		return SemanticAttributeClaimEvidence{}, fmt.Errorf("%w: target and principal identity are required", ErrSemanticAttributeClaimEvidenceInvalid)
+	}
+	if err := ValidateSemanticAttributeControlSnapshot(control); err != nil {
+		return SemanticAttributeClaimEvidence{}, fmt.Errorf("%w: control snapshot identity does not match its contents", ErrSemanticAttributeClaimEvidenceInvalid)
+	}
+	if !envelope.Valid() || envelope.Subject() != principalID || evaluatedAt.IsZero() || !evaluatedAt.Equal(evaluatedAt.UTC()) ||
+		evaluatedAt.Before(envelope.NotBefore()) || !evaluatedAt.Before(envelope.NotAfter()) {
+		return SemanticAttributeClaimEvidence{}, fmt.Errorf("%w: verified envelope identity or validity is inconsistent", ErrSemanticAttributeClaimEvidenceInvalid)
+	}
+	values := semanticAttributeClaimValueIdentities(attributes)
+	if len(values) == 0 {
+		return SemanticAttributeClaimEvidence{}, fmt.Errorf("%w: no claim-derived effective values", ErrSemanticAttributeClaimEvidenceInvalid)
+	}
+	mappingIDs := make([]string, 0, len(values))
+	for _, attribute := range attributes {
+		if attribute.Source != "trusted_claim" && attribute.Source != "direct+trusted_claim" {
+			continue
+		}
+		matched := false
+		for _, mapping := range control.Mappings {
+			if mapping.Tombstoned || string(mapping.SourceKind) != string(envelope.Source()) || mapping.Provider != envelope.Provider() ||
+				mapping.Issuer != envelope.Issuer() || mapping.Audience != envelope.Audience() || mapping.DefinitionID != attribute.DefinitionID ||
+				mapping.DefinitionName != attribute.DefinitionName || mapping.DefinitionVersion <= 0 || mapping.DefinitionVersion > attribute.DefinitionVersion ||
+				mapping.Type != attribute.Type || mapping.Shape != attribute.Shape {
+				continue
+			}
+			raw, found := envelope.Value(mapping.Claim)
+			if !found {
+				continue
+			}
+			definition := SemanticAttributeDefinition{ID: attribute.DefinitionID, Name: attribute.DefinitionName, Type: attribute.Type,
+				Shape: attribute.Shape, Profile: semanticvalue.Profile, DefinitionVersion: attribute.DefinitionVersion,
+				LifecycleState: SemanticAttributeActive, Enabled: true}
+			canonical, digest, valueErr := CanonicalSemanticAttributeValues(definition, raw)
+			if valueErr != nil || digest != attribute.ValueDigest || !reflect.DeepEqual(canonical, attribute.CanonicalValues) {
+				return SemanticAttributeClaimEvidence{}, fmt.Errorf("%w: mapped claim does not match effective attribute %q", ErrSemanticAttributeClaimEvidenceInvalid, attribute.DefinitionName)
+			}
+			matched = true
+			mappingIDs = append(mappingIDs, fmt.Sprintf("%s@%d", mapping.ID, mapping.MappingVersion))
+		}
+		if !matched {
+			return SemanticAttributeClaimEvidence{}, fmt.Errorf("%w: no active exact mapping for effective attribute %q", ErrSemanticAttributeClaimEvidenceInvalid, attribute.DefinitionName)
+		}
+	}
+	sort.Strings(mappingIDs)
+	wire := struct {
+		Profile               string                                `json:"profile"`
+		InstanceID            string                                `json:"instanceId"`
+		PrincipalID           string                                `json:"principalId"`
+		ControlRevision       int64                                 `json:"controlRevision"`
+		ControlDigest         string                                `json:"controlDigest"`
+		Source                trustedclaims.SourceKind              `json:"source"`
+		Provider              string                                `json:"provider"`
+		Issuer                string                                `json:"issuer"`
+		Audience              string                                `json:"audience"`
+		NotBefore             string                                `json:"notBefore"`
+		NotAfter              string                                `json:"notAfter"`
+		EvaluatedAt           string                                `json:"evaluatedAt"`
+		CredentialFingerprint string                                `json:"credentialFingerprint,omitempty"`
+		TokenFingerprint      string                                `json:"tokenFingerprint,omitempty"`
+		Mappings              []string                              `json:"mappings"`
+		Values                []semanticAttributeClaimValueIdentity `json:"values"`
+	}{Profile: semanticvalue.Profile, InstanceID: instanceID, PrincipalID: principalID, ControlRevision: control.State.Revision,
+		ControlDigest: control.State.Digest, Source: envelope.Source(), Provider: envelope.Provider(), Issuer: envelope.Issuer(),
+		Audience: envelope.Audience(), NotBefore: envelope.NotBefore().UTC().Format(time.RFC3339Nano),
+		NotAfter: envelope.NotAfter().UTC().Format(time.RFC3339Nano), EvaluatedAt: evaluatedAt.Format(time.RFC3339Nano),
+		CredentialFingerprint: envelope.CredentialFingerprint(), TokenFingerprint: envelope.TokenFingerprint(), Mappings: mappingIDs, Values: values}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return SemanticAttributeClaimEvidence{}, fmt.Errorf("%w: encode identity: %v", ErrSemanticAttributeClaimEvidenceInvalid, err)
+	}
+	digest, err := semanticAttributeDigestJSON(json.RawMessage(encoded), "claim evidence")
+	if err != nil {
+		return SemanticAttributeClaimEvidence{}, err
+	}
+	return SemanticAttributeClaimEvidence{instanceID: instanceID, principalID: principalID, control: control.State, evaluatedAt: evaluatedAt,
+		notBefore: envelope.NotBefore().UTC(), notAfter: envelope.NotAfter().UTC(), digest: digest, values: values}, nil
+}
+
+func semanticAttributeClaimValueIdentities(attributes []EffectiveSemanticAttribute) []semanticAttributeClaimValueIdentity {
+	values := make([]semanticAttributeClaimValueIdentity, 0, len(attributes))
+	for _, attribute := range attributes {
+		if attribute.Source == "trusted_claim" || attribute.Source == "direct+trusted_claim" {
+			values = append(values, semanticAttributeClaimValueIdentity{DefinitionID: attribute.DefinitionID,
+				DefinitionVersion: attribute.DefinitionVersion, ValueDigest: attribute.ValueDigest, Source: attribute.Source})
+		}
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i].DefinitionID < values[j].DefinitionID })
+	return values
+}

--- a/internal/access/semantic_attribute_claim_evidence_test.go
+++ b/internal/access/semantic_attribute_claim_evidence_test.go
@@ -1,0 +1,85 @@
+package access
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+type semanticAttributeEvidenceVerifier struct {
+	claims trustedclaims.VerifiedClaims
+}
+
+func (verifier semanticAttributeEvidenceVerifier) SourceKind() trustedclaims.SourceKind {
+	return trustedclaims.SourceOIDC
+}
+
+func (verifier semanticAttributeEvidenceVerifier) Verify(context.Context, []byte) (trustedclaims.VerifiedClaims, error) {
+	return verifier.claims, nil
+}
+
+func TestSemanticAttributeClaimEvidenceBindsMappedValuesAndControl(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	claims := trustedclaims.VerifiedClaims{Provider: "corp", Issuer: "https://issuer.example", Audience: "leapview", Subject: "principal-1",
+		IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Minute), TokenFingerprint: strings.Repeat("a", 64),
+		Claims: []trustedclaims.Claim{{Name: "regions", Value: []string{"west", "east"}}}}
+	envelope, err := trustedclaims.Verify(t.Context(), trustedclaims.NewRawEvidence(trustedclaims.SourceOIDC, []byte("signed")),
+		semanticAttributeEvidenceVerifier{claims: claims}, trustedclaims.VerifyOptions{Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition := SemanticAttributeDefinition{ID: "def-regions", Name: "regions", Type: semanticvalue.TypeString, Shape: SemanticAttributeList,
+		Profile: semanticvalue.Profile, DefinitionVersion: 1, LifecycleState: SemanticAttributeActive, Enabled: true}
+	values, valueDigest, err := CanonicalSemanticAttributeValues(definition, []string{"east", "west"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attribute := EffectiveSemanticAttribute{DefinitionID: definition.ID, DefinitionName: definition.Name, DefinitionVersion: 1,
+		Type: definition.Type, Shape: definition.Shape, CanonicalValues: values, ValueDigest: valueDigest, Source: "trusted_claim"}
+	mapping := TrustedClaimMapping{ID: "mapping-1", SourceKind: TrustedClaimSourceOIDC, Provider: claims.Provider, Issuer: claims.Issuer,
+		Audience: claims.Audience, Claim: "regions", DefinitionID: definition.ID, DefinitionName: definition.Name,
+		DefinitionVersion: 1, Type: definition.Type, Shape: definition.Shape, MappingVersion: 1}
+	control := SemanticAttributeControlSnapshot{Mappings: []TrustedClaimMapping{mapping}}
+	control.State = SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 3}
+	control.State.Digest, err = SemanticAttributeControlDigest(control.Assignments, control.Mappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := NewSemanticAttributeClaimEvidence("instance-1", "principal-1", control, []EffectiveSemanticAttribute{attribute}, envelope, now)
+	if err != nil || !evidence.Matches("instance-1", "principal-1", control.State, []EffectiveSemanticAttribute{attribute}) || !evidence.ValidAt(now) {
+		t.Fatalf("valid evidence = %#v, error = %v", evidence, err)
+	}
+
+	tampered := attribute
+	tampered.CanonicalValues, tampered.ValueDigest, err = CanonicalSemanticAttributeValues(definition, []string{"north"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewSemanticAttributeClaimEvidence("instance-1", "principal-1", control, []EffectiveSemanticAttribute{tampered}, envelope, now); err == nil {
+		t.Fatal("claim evidence accepted an effective value absent from the verified envelope")
+	}
+	corrupt := control
+	corrupt.State.Digest = "sha256:" + strings.Repeat("b", 64)
+	if _, err := NewSemanticAttributeClaimEvidence("instance-1", "principal-1", corrupt, []EffectiveSemanticAttribute{attribute}, envelope, now); err == nil {
+		t.Fatal("claim evidence accepted a corrupt control snapshot")
+	}
+}
+
+func TestSemanticAttributeRegistryDigestIsIndependentOfRowOrder(t *testing.T) {
+	definitions := []SemanticAttributeDefinition{{ID: "b", Name: "beta"}, {ID: "a", Name: "alpha"}}
+	first, err := SemanticAttributeRegistryDigest(semanticvalue.Profile, definitions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := SemanticAttributeRegistryDigest(semanticvalue.Profile, []SemanticAttributeDefinition{definitions[1], definitions[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("registry digest depends on row order: %q != %q", first, second)
+	}
+}

--- a/internal/access/semantic_attribute_digests.go
+++ b/internal/access/semantic_attribute_digests.go
@@ -1,0 +1,134 @@
+package access
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+type semanticAttributeRegistryDigestWire struct {
+	Profile     string                                  `json:"profile"`
+	Definitions []semanticAttributeDefinitionDigestWire `json:"definitions"`
+}
+
+type semanticAttributeDefinitionDigestWire struct {
+	ID                string                          `json:"id"`
+	Name              string                          `json:"name"`
+	Type              semanticvalue.Type              `json:"type"`
+	Shape             SemanticAttributeShape          `json:"shape"`
+	DefinitionVersion int64                           `json:"definitionVersion"`
+	OwnerKind         SemanticAttributeOwnerKind      `json:"ownerKind"`
+	OwnerID           string                          `json:"ownerId"`
+	DisplayName       string                          `json:"displayName"`
+	Description       string                          `json:"description"`
+	DocumentationURL  string                          `json:"documentationUrl"`
+	LifecycleState    SemanticAttributeLifecycleState `json:"lifecycleState"`
+}
+
+// SemanticAttributeRegistryDigest is the canonical FAI-636 registry identity.
+// Readers and consumers use the same function so a syntactically valid but
+// mixed registry snapshot cannot cross the semantic authorization boundary.
+func SemanticAttributeRegistryDigest(profile string, definitions []SemanticAttributeDefinition) (string, error) {
+	definitions = append([]SemanticAttributeDefinition(nil), definitions...)
+	sort.Slice(definitions, func(i, j int) bool {
+		if definitions[i].Name != definitions[j].Name {
+			return definitions[i].Name < definitions[j].Name
+		}
+		return definitions[i].ID < definitions[j].ID
+	})
+	wire := semanticAttributeRegistryDigestWire{Profile: profile, Definitions: make([]semanticAttributeDefinitionDigestWire, len(definitions))}
+	for index, definition := range definitions {
+		wire.Definitions[index] = semanticAttributeDefinitionDigestWire{ID: definition.ID, Name: definition.Name, Type: definition.Type,
+			Shape: definition.Shape, DefinitionVersion: definition.DefinitionVersion, OwnerKind: definition.Metadata.Owner.Kind,
+			OwnerID: definition.Metadata.Owner.ID, DisplayName: definition.Metadata.DisplayName, Description: definition.Metadata.Description,
+			DocumentationURL: definition.Metadata.DocumentationURL, LifecycleState: definition.LifecycleState}
+	}
+	return semanticAttributeDigestJSON(wire, "registry")
+}
+
+type semanticAttributeAssignmentDigestWire struct {
+	ID, DefinitionID, SubjectKind, SubjectID string
+	DefinitionVersion                        int64
+	Type                                     semanticvalue.Type
+	Shape                                    SemanticAttributeShape
+	Values                                   []string
+	ValueDigest                              string
+	Version                                  int64
+	TombstonedAtMicros                       int64
+}
+
+type semanticAttributeMappingDigestWire struct {
+	ID, SourceKind, Provider, Issuer, Audience, Claim, DefinitionID string
+	DefinitionVersion                                               int64
+	Type                                                            semanticvalue.Type
+	Shape                                                           SemanticAttributeShape
+	Version                                                         int64
+	TombstonedAtMicros                                              int64
+}
+
+type semanticAttributeControlDigestWire struct {
+	Profile     string                                  `json:"profile"`
+	Assignments []semanticAttributeAssignmentDigestWire `json:"assignments"`
+	Mappings    []semanticAttributeMappingDigestWire    `json:"mappings"`
+}
+
+// SemanticAttributeControlDigest is the canonical FAI-637 assignment and
+// trusted-mapping identity. Input order never affects the result.
+func SemanticAttributeControlDigest(assignments []SemanticAttributeAssignment, mappings []TrustedClaimMapping) (string, error) {
+	assignments = append([]SemanticAttributeAssignment(nil), assignments...)
+	mappings = append([]TrustedClaimMapping(nil), mappings...)
+	sort.Slice(assignments, func(i, j int) bool { return assignments[i].ID < assignments[j].ID })
+	sort.Slice(mappings, func(i, j int) bool { return mappings[i].ID < mappings[j].ID })
+	wire := semanticAttributeControlDigestWire{Profile: semanticvalue.Profile,
+		Assignments: make([]semanticAttributeAssignmentDigestWire, len(assignments)), Mappings: make([]semanticAttributeMappingDigestWire, len(mappings))}
+	for index, row := range assignments {
+		tombstonedAt, err := semanticAttributeTimestampMicroseconds(row.TombstonedAt)
+		if err != nil {
+			return "", fmt.Errorf("assignment %s tombstoned timestamp: %w", row.ID, err)
+		}
+		wire.Assignments[index] = semanticAttributeAssignmentDigestWire{ID: row.ID, DefinitionID: row.DefinitionID,
+			SubjectKind: string(row.Subject.Kind), SubjectID: row.Subject.ID, DefinitionVersion: row.DefinitionVersion,
+			Type: row.Type, Shape: row.Shape, Values: append([]string(nil), row.CanonicalValues...), ValueDigest: row.ValueDigest,
+			Version: row.AssignmentVersion, TombstonedAtMicros: tombstonedAt}
+	}
+	for index, row := range mappings {
+		tombstonedAt, err := semanticAttributeTimestampMicroseconds(row.TombstonedAt)
+		if err != nil {
+			return "", fmt.Errorf("mapping %s tombstoned timestamp: %w", row.ID, err)
+		}
+		wire.Mappings[index] = semanticAttributeMappingDigestWire{ID: row.ID, SourceKind: string(row.SourceKind), Provider: row.Provider,
+			Issuer: row.Issuer, Audience: row.Audience, Claim: row.Claim, DefinitionID: row.DefinitionID,
+			DefinitionVersion: row.DefinitionVersion, Type: row.Type, Shape: row.Shape, Version: row.MappingVersion,
+			TombstonedAtMicros: tombstonedAt}
+	}
+	return semanticAttributeDigestJSON(wire, "control")
+}
+
+func semanticAttributeTimestampMicroseconds(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	if micros, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return micros, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid timestamp %q: %w", value, err)
+	}
+	return parsed.UTC().UnixMicro(), nil
+}
+
+func semanticAttributeDigestJSON(value any, label string) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("encode semantic attribute %s digest: %w", label, err)
+	}
+	digest := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(digest[:]), nil
+}

--- a/internal/access/semantic_attribute_direct_evidence.go
+++ b/internal/access/semantic_attribute_direct_evidence.go
@@ -1,0 +1,152 @@
+package access
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+var ErrSemanticAttributeDirectEvidenceInvalid = errors.New("semantic attribute direct-assignment evidence is invalid")
+
+type semanticAttributeDirectAssignmentIdentity struct {
+	ID                string `json:"id"`
+	AssignmentVersion int64  `json:"assignmentVersion"`
+	DefinitionID      string `json:"definitionId"`
+	DefinitionVersion int64  `json:"definitionVersion"`
+	ValueDigest       string `json:"valueDigest"`
+}
+
+// SemanticAttributeDirectEvidence is an immutable binding between direct
+// effective values, the exact FAI-637 control snapshot that authorized them,
+// and the principal/group subject closure used during resolution. It exposes
+// identity only and never raw values.
+type SemanticAttributeDirectEvidence struct {
+	instanceID  string
+	principalID string
+	control     SemanticAttributeControlState
+	digest      string
+	values      []semanticAttributeClaimValueIdentity
+}
+
+func (evidence SemanticAttributeDirectEvidence) Digest() string { return evidence.digest }
+
+func (evidence SemanticAttributeDirectEvidence) Matches(instanceID, principalID string, control SemanticAttributeControlState, attributes []EffectiveSemanticAttribute) bool {
+	if evidence.digest == "" || evidence.instanceID != instanceID || evidence.principalID != principalID || evidence.control != control {
+		return false
+	}
+	return reflect.DeepEqual(evidence.values, semanticAttributeDirectValueIdentities(attributes))
+}
+
+// NewSemanticAttributeDirectEvidence validates and seals direct assignment
+// provenance. Subjects must contain the principal and the exact group closure
+// used by the resolver. Every direct-derived value must be backed by one or
+// more active assignments in that closure, and conflicting assignments fail.
+func NewSemanticAttributeDirectEvidence(instanceID, principalID string, subjects []SubjectRef, control SemanticAttributeControlSnapshot, attributes []EffectiveSemanticAttribute) (SemanticAttributeDirectEvidence, error) {
+	if strings.TrimSpace(instanceID) != instanceID || instanceID == "" || strings.TrimSpace(principalID) != principalID || principalID == "" {
+		return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: target and principal identity are required", ErrSemanticAttributeDirectEvidenceInvalid)
+	}
+	if err := ValidateSemanticAttributeControlSnapshot(control); err != nil {
+		return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: control snapshot identity does not match its contents", ErrSemanticAttributeDirectEvidenceInvalid)
+	}
+	subjects = append([]SubjectRef(nil), subjects...)
+	sort.Slice(subjects, func(i, j int) bool {
+		if subjects[i].Kind != subjects[j].Kind {
+			return subjects[i].Kind < subjects[j].Kind
+		}
+		return subjects[i].ID < subjects[j].ID
+	})
+	principalPresent := false
+	allowedSubjects := make(map[SubjectRef]struct{}, len(subjects))
+	for _, subject := range subjects {
+		if err := subject.Validate(); err != nil {
+			return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: invalid subject closure: %v", ErrSemanticAttributeDirectEvidenceInvalid, err)
+		}
+		if _, duplicate := allowedSubjects[subject]; duplicate {
+			return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: duplicate subject in closure", ErrSemanticAttributeDirectEvidenceInvalid)
+		}
+		allowedSubjects[subject] = struct{}{}
+		if subject.Kind == SubjectKindPrincipal && subject.ID == principalID {
+			principalPresent = true
+		}
+	}
+	if !principalPresent {
+		return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: subject closure does not contain the principal", ErrSemanticAttributeDirectEvidenceInvalid)
+	}
+
+	values := semanticAttributeDirectValueIdentities(attributes)
+	if len(values) == 0 {
+		return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: no direct effective values", ErrSemanticAttributeDirectEvidenceInvalid)
+	}
+	assignments := make([]semanticAttributeDirectAssignmentIdentity, 0, len(values))
+	for _, attribute := range attributes {
+		if attribute.Source != "direct" && attribute.Source != "direct+trusted_claim" {
+			continue
+		}
+		matched := false
+		for _, assignment := range control.Assignments {
+			if assignment.Tombstoned || assignment.DefinitionID != attribute.DefinitionID {
+				continue
+			}
+			if _, permitted := allowedSubjects[assignment.Subject]; !permitted {
+				continue
+			}
+			if assignment.DefinitionName != attribute.DefinitionName || assignment.DefinitionVersion <= 0 || assignment.DefinitionVersion > attribute.DefinitionVersion ||
+				assignment.Type != attribute.Type || assignment.Shape != attribute.Shape || assignment.ValueDigest != attribute.ValueDigest ||
+				!reflect.DeepEqual(assignment.CanonicalValues, attribute.CanonicalValues) {
+				return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: assignment %q conflicts with effective attribute %q", ErrSemanticAttributeDirectEvidenceInvalid, assignment.ID, attribute.DefinitionName)
+			}
+			if assignment.ID == "" || assignment.AssignmentVersion <= 0 {
+				return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: assignment identity is invalid", ErrSemanticAttributeDirectEvidenceInvalid)
+			}
+			matched = true
+			assignments = append(assignments, semanticAttributeDirectAssignmentIdentity{ID: assignment.ID, AssignmentVersion: assignment.AssignmentVersion,
+				DefinitionID: assignment.DefinitionID, DefinitionVersion: assignment.DefinitionVersion, ValueDigest: assignment.ValueDigest})
+		}
+		if !matched {
+			return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: no active assignment for effective attribute %q", ErrSemanticAttributeDirectEvidenceInvalid, attribute.DefinitionName)
+		}
+	}
+	sort.Slice(assignments, func(i, j int) bool {
+		if assignments[i].ID != assignments[j].ID {
+			return assignments[i].ID < assignments[j].ID
+		}
+		return assignments[i].AssignmentVersion < assignments[j].AssignmentVersion
+	})
+	wire := struct {
+		Profile         string                                      `json:"profile"`
+		InstanceID      string                                      `json:"instanceId"`
+		PrincipalID     string                                      `json:"principalId"`
+		ControlRevision int64                                       `json:"controlRevision"`
+		ControlDigest   string                                      `json:"controlDigest"`
+		Subjects        []SubjectRef                                `json:"subjects"`
+		Assignments     []semanticAttributeDirectAssignmentIdentity `json:"assignments"`
+		Values          []semanticAttributeClaimValueIdentity       `json:"values"`
+	}{Profile: semanticvalue.Profile, InstanceID: instanceID, PrincipalID: principalID, ControlRevision: control.State.Revision,
+		ControlDigest: control.State.Digest, Subjects: subjects, Assignments: assignments, Values: values}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return SemanticAttributeDirectEvidence{}, fmt.Errorf("%w: encode identity: %v", ErrSemanticAttributeDirectEvidenceInvalid, err)
+	}
+	digest, err := semanticAttributeDigestJSON(json.RawMessage(encoded), "direct evidence")
+	if err != nil {
+		return SemanticAttributeDirectEvidence{}, err
+	}
+	return SemanticAttributeDirectEvidence{instanceID: instanceID, principalID: principalID, control: control.State, digest: digest, values: values}, nil
+}
+
+func semanticAttributeDirectValueIdentities(attributes []EffectiveSemanticAttribute) []semanticAttributeClaimValueIdentity {
+	values := make([]semanticAttributeClaimValueIdentity, 0, len(attributes))
+	for _, attribute := range attributes {
+		if attribute.Source == "direct" || attribute.Source == "direct+trusted_claim" {
+			values = append(values, semanticAttributeClaimValueIdentity{DefinitionID: attribute.DefinitionID,
+				DefinitionVersion: attribute.DefinitionVersion, ValueDigest: attribute.ValueDigest, Source: attribute.Source})
+		}
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i].DefinitionID < values[j].DefinitionID })
+	return values
+}

--- a/internal/access/semantic_attribute_direct_evidence_test.go
+++ b/internal/access/semantic_attribute_direct_evidence_test.go
@@ -1,0 +1,98 @@
+package access
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestSemanticAttributeDirectEvidenceBindsSubjectClosureAndAssignments(t *testing.T) {
+	definition := SemanticAttributeDefinition{ID: "definition-region", Name: "regions", Type: semanticvalue.TypeString,
+		Shape: SemanticAttributeList, Profile: semanticvalue.Profile, DefinitionVersion: 2,
+		LifecycleState: SemanticAttributeActive, Enabled: true}
+	values, valueDigest, err := CanonicalSemanticAttributeValues(definition, []string{"west", "east"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attribute := EffectiveSemanticAttribute{DefinitionID: definition.ID, DefinitionName: definition.Name,
+		DefinitionVersion: definition.DefinitionVersion, Type: definition.Type, Shape: definition.Shape,
+		CanonicalValues: values, ValueDigest: valueDigest, Source: "direct"}
+	assignment := SemanticAttributeAssignment{ID: "assignment-region", DefinitionID: definition.ID, DefinitionName: definition.Name,
+		DefinitionVersion: definition.DefinitionVersion, Type: definition.Type, Shape: definition.Shape,
+		Subject: SubjectRef{Kind: SubjectKindGroup, ID: "group-sales"}, CanonicalValues: append([]string(nil), values...),
+		ValueDigest: valueDigest, AssignmentVersion: 4}
+	control := SemanticAttributeControlSnapshot{Assignments: []SemanticAttributeAssignment{assignment}}
+	control.State = SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 9}
+	control.State.Digest, err = SemanticAttributeControlDigest(control.Assignments, control.Mappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subjects := []SubjectRef{{Kind: SubjectKindGroup, ID: "group-sales"}, {Kind: SubjectKindPrincipal, ID: "principal-1"}}
+	evidence, err := NewSemanticAttributeDirectEvidence("instance-1", "principal-1", subjects, control, []EffectiveSemanticAttribute{attribute})
+	if err != nil || !evidence.Matches("instance-1", "principal-1", control.State, []EffectiveSemanticAttribute{attribute}) {
+		t.Fatalf("valid direct evidence = %#v, error = %v", evidence, err)
+	}
+	if !strings.HasPrefix(evidence.Digest(), "sha256:") {
+		t.Fatalf("direct evidence digest = %q", evidence.Digest())
+	}
+
+	if _, err := NewSemanticAttributeDirectEvidence("instance-1", "principal-1",
+		[]SubjectRef{{Kind: SubjectKindPrincipal, ID: "principal-1"}}, control, []EffectiveSemanticAttribute{attribute}); err == nil {
+		t.Fatal("direct evidence accepted a group assignment outside the subject closure")
+	}
+	conflicting := assignment
+	conflicting.ID = "assignment-conflict"
+	conflicting.Subject = SubjectRef{Kind: SubjectKindPrincipal, ID: "principal-1"}
+	conflicting.CanonicalValues, conflicting.ValueDigest, err = CanonicalSemanticAttributeValues(definition, []string{"north"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflictControl := control
+	conflictControl.Assignments = append(append([]SemanticAttributeAssignment(nil), control.Assignments...), conflicting)
+	conflictControl.State.Digest, err = SemanticAttributeControlDigest(conflictControl.Assignments, conflictControl.Mappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewSemanticAttributeDirectEvidence("instance-1", "principal-1", subjects, conflictControl,
+		[]EffectiveSemanticAttribute{attribute}); err == nil {
+		t.Fatal("direct evidence accepted conflicting assignments in the subject closure")
+	}
+}
+
+func TestSemanticAttributeDirectEvidenceRejectsCorruptControlAndTamperedValue(t *testing.T) {
+	definition := SemanticAttributeDefinition{ID: "definition-department", Name: "department", Type: semanticvalue.TypeString,
+		Shape: SemanticAttributeScalar, Profile: semanticvalue.Profile, DefinitionVersion: 1,
+		LifecycleState: SemanticAttributeActive, Enabled: true}
+	values, valueDigest, err := CanonicalSemanticAttributeValues(definition, "sales")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attribute := EffectiveSemanticAttribute{DefinitionID: definition.ID, DefinitionName: definition.Name,
+		DefinitionVersion: 1, Type: definition.Type, Shape: definition.Shape, CanonicalValues: values, ValueDigest: valueDigest, Source: "direct"}
+	assignment := SemanticAttributeAssignment{ID: "assignment-department", DefinitionID: definition.ID, DefinitionName: definition.Name,
+		DefinitionVersion: 1, Type: definition.Type, Shape: definition.Shape,
+		Subject: SubjectRef{Kind: SubjectKindPrincipal, ID: "principal-1"}, CanonicalValues: append([]string(nil), values...),
+		ValueDigest: valueDigest, AssignmentVersion: 1}
+	control := SemanticAttributeControlSnapshot{Assignments: []SemanticAttributeAssignment{assignment},
+		State: SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 1}}
+	control.State.Digest, err = SemanticAttributeControlDigest(control.Assignments, control.Mappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corrupt := control
+	corrupt.State.Digest = "sha256:" + strings.Repeat("f", 64)
+	if _, err := NewSemanticAttributeDirectEvidence("instance-1", "principal-1",
+		[]SubjectRef{{Kind: SubjectKindPrincipal, ID: "principal-1"}}, corrupt, []EffectiveSemanticAttribute{attribute}); err == nil {
+		t.Fatal("direct evidence accepted a corrupt control snapshot")
+	}
+	tampered := attribute
+	tampered.CanonicalValues, tampered.ValueDigest, err = CanonicalSemanticAttributeValues(definition, "finance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewSemanticAttributeDirectEvidence("instance-1", "principal-1",
+		[]SubjectRef{{Kind: SubjectKindPrincipal, ID: "principal-1"}}, control, []EffectiveSemanticAttribute{tampered}); err == nil {
+		t.Fatal("direct evidence accepted a value absent from the assignment authority")
+	}
+}

--- a/internal/access/semantic_attribute_snapshot_validation.go
+++ b/internal/access/semantic_attribute_snapshot_validation.go
@@ -1,0 +1,192 @@
+package access
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+// ValidateSemanticAttributeRegistrySnapshot verifies both canonical identity
+// and lifecycle/ownership invariants that are intentionally not duplicated in
+// the persisted FAI-636 digest format.
+func ValidateSemanticAttributeRegistrySnapshot(snapshot SemanticAttributeRegistrySnapshot) error {
+	if snapshot.State.Profile != semanticvalue.Profile || snapshot.State.Revision < 0 || !canonicalSemanticAttributeDigest(snapshot.State.Digest) {
+		return fmt.Errorf("%w: registry state identity is invalid", ErrSemanticAttributeRegistryCorrupt)
+	}
+	names := make(map[string]struct{}, len(snapshot.Definitions))
+	ids := make(map[string]struct{}, len(snapshot.Definitions))
+	for _, definition := range snapshot.Definitions {
+		if !canonicalSemanticAttributeIdentity(definition.ID) || definition.Profile != semanticvalue.Profile || definition.DefinitionVersion <= 0 ||
+			!semanticAttributeTypeValid(definition.Type) || !definition.Shape.Valid() {
+			return fmt.Errorf("%w: definition %q identity, profile, version, type, or shape is invalid", ErrSemanticAttributeRegistryCorrupt, definition.Name)
+		}
+		if err := semanticvalue.ValidateAttributeName(definition.Name); err != nil {
+			return fmt.Errorf("%w: definition name is invalid", ErrSemanticAttributeRegistryCorrupt)
+		}
+		if _, duplicate := ids[definition.ID]; duplicate {
+			return fmt.Errorf("%w: duplicate definition id %q", ErrSemanticAttributeRegistryCorrupt, definition.ID)
+		}
+		if _, duplicate := names[definition.Name]; duplicate {
+			return fmt.Errorf("%w: duplicate definition name %q", ErrSemanticAttributeRegistryCorrupt, definition.Name)
+		}
+		ids[definition.ID], names[definition.Name] = struct{}{}, struct{}{}
+		owner := definition.Metadata.Owner
+		if !owner.Kind.Valid() || owner.ID != strings.TrimSpace(owner.ID) ||
+			(owner.Kind == SemanticAttributeOwnerInstance && owner.ID != "") || (owner.Kind != SemanticAttributeOwnerInstance && owner.ID == "") {
+			return fmt.Errorf("%w: definition %q owner is invalid", ErrSemanticAttributeRegistryCorrupt, definition.Name)
+		}
+		switch definition.LifecycleState {
+		case SemanticAttributeActive:
+			if !definition.Enabled || definition.DisabledAt != "" {
+				return fmt.Errorf("%w: definition %q active lifecycle projection is inconsistent", ErrSemanticAttributeRegistryCorrupt, definition.Name)
+			}
+		case SemanticAttributeDisabled:
+			if definition.Enabled || definition.DisabledAt == "" {
+				return fmt.Errorf("%w: definition %q disabled lifecycle projection is inconsistent", ErrSemanticAttributeRegistryCorrupt, definition.Name)
+			}
+		default:
+			return fmt.Errorf("%w: definition %q lifecycle state is invalid", ErrSemanticAttributeRegistryCorrupt, definition.Name)
+		}
+	}
+	digest, err := SemanticAttributeRegistryDigest(snapshot.State.Profile, snapshot.Definitions)
+	if err != nil || digest != snapshot.State.Digest {
+		return fmt.Errorf("%w: registry digest does not match definitions", ErrSemanticAttributeRegistryCorrupt)
+	}
+	return nil
+}
+
+// ValidateSemanticAttributeControlSnapshot verifies canonical identity and
+// the row invariants whose derived projections are not part of the persisted
+// FAI-637 digest format. It does not reinterpret missing authority as empty.
+func ValidateSemanticAttributeControlSnapshot(snapshot SemanticAttributeControlSnapshot) error {
+	if snapshot.State.Profile != semanticvalue.Profile || snapshot.State.Revision < 0 || !canonicalSemanticAttributeDigest(snapshot.State.Digest) {
+		return fmt.Errorf("%w: control state identity is invalid", ErrSemanticAttributeControlCorrupt)
+	}
+	assignmentIDs := make(map[string]struct{}, len(snapshot.Assignments))
+	for _, assignment := range snapshot.Assignments {
+		if !canonicalSemanticAttributeIdentity(assignment.ID) || !canonicalSemanticAttributeIdentity(assignment.DefinitionID) ||
+			assignment.DefinitionVersion <= 0 || assignment.AssignmentVersion <= 0 || !semanticAttributeTypeValid(assignment.Type) || !assignment.Shape.Valid() ||
+			!canonicalSemanticAttributeDigest(assignment.ValueDigest) {
+			return fmt.Errorf("%w: assignment %q identity or value metadata is invalid", ErrSemanticAttributeControlCorrupt, assignment.ID)
+		}
+		if err := semanticvalue.ValidateAttributeName(assignment.DefinitionName); err != nil {
+			return fmt.Errorf("%w: assignment %q definition name is invalid", ErrSemanticAttributeControlCorrupt, assignment.ID)
+		}
+		if err := assignment.Subject.Validate(); err != nil {
+			return fmt.Errorf("%w: assignment %q subject is invalid", ErrSemanticAttributeControlCorrupt, assignment.ID)
+		}
+		if _, duplicate := assignmentIDs[assignment.ID]; duplicate {
+			return fmt.Errorf("%w: duplicate assignment id %q", ErrSemanticAttributeControlCorrupt, assignment.ID)
+		}
+		assignmentIDs[assignment.ID] = struct{}{}
+		if assignment.Tombstoned != (assignment.TombstonedAt != "") {
+			return fmt.Errorf("%w: assignment %q tombstone projection is inconsistent", ErrSemanticAttributeControlCorrupt, assignment.ID)
+		}
+		if err := validateSemanticAttributeCanonicalProjection(assignment.Type, assignment.Shape, assignment.CanonicalValues, assignment.ValueDigest); err != nil {
+			return fmt.Errorf("%w: assignment %q values are invalid: %v", ErrSemanticAttributeControlCorrupt, assignment.ID, err)
+		}
+	}
+	mappingIDs := make(map[string]struct{}, len(snapshot.Mappings))
+	for _, mapping := range snapshot.Mappings {
+		if !canonicalSemanticAttributeIdentity(mapping.ID) || !canonicalSemanticAttributeIdentity(mapping.DefinitionID) ||
+			mapping.DefinitionVersion <= 0 || mapping.MappingVersion <= 0 || !semanticAttributeTypeValid(mapping.Type) || !mapping.Shape.Valid() ||
+			!mapping.SourceKind.Valid() || !canonicalSemanticAttributeText(mapping.Claim) {
+			return fmt.Errorf("%w: mapping %q identity or value metadata is invalid", ErrSemanticAttributeControlCorrupt, mapping.ID)
+		}
+		if err := semanticvalue.ValidateAttributeName(mapping.DefinitionName); err != nil {
+			return fmt.Errorf("%w: mapping %q definition name is invalid", ErrSemanticAttributeControlCorrupt, mapping.ID)
+		}
+		if err := trustedclaims.ValidateSourceIdentity(mapping.Provider, mapping.Issuer, mapping.Audience); err != nil {
+			return fmt.Errorf("%w: mapping %q source identity is invalid", ErrSemanticAttributeControlCorrupt, mapping.ID)
+		}
+		if _, duplicate := mappingIDs[mapping.ID]; duplicate {
+			return fmt.Errorf("%w: duplicate mapping id %q", ErrSemanticAttributeControlCorrupt, mapping.ID)
+		}
+		mappingIDs[mapping.ID] = struct{}{}
+		if mapping.Tombstoned != (mapping.TombstonedAt != "") {
+			return fmt.Errorf("%w: mapping %q tombstone projection is inconsistent", ErrSemanticAttributeControlCorrupt, mapping.ID)
+		}
+	}
+	digest, err := SemanticAttributeControlDigest(snapshot.Assignments, snapshot.Mappings)
+	if err != nil || digest != snapshot.State.Digest {
+		return fmt.Errorf("%w: control digest does not match contents", ErrSemanticAttributeControlCorrupt)
+	}
+	return nil
+}
+
+func semanticAttributeTypeValid(value semanticvalue.Type) bool {
+	switch value {
+	case semanticvalue.TypeString, semanticvalue.TypeBoolean, semanticvalue.TypeInteger, semanticvalue.TypeDecimal, semanticvalue.TypeDate, semanticvalue.TypeTimestamp:
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalSemanticAttributeDigest(value string) bool {
+	if len(value) != len("sha256:")+64 || !strings.HasPrefix(value, "sha256:") {
+		return false
+	}
+	decoded, err := hex.DecodeString(value[len("sha256:"):])
+	return err == nil && len(decoded) == 32
+}
+
+func canonicalSemanticAttributeIdentity(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalSemanticAttributeText(value string) bool {
+	return canonicalSemanticAttributeIdentity(value)
+}
+
+func validateSemanticAttributeCanonicalProjection(typeName semanticvalue.Type, shape SemanticAttributeShape, values []string, digest string) error {
+	if len(values) == 0 || len(values) > semanticvalue.MaxSetValues || shape == SemanticAttributeScalar && len(values) != 1 {
+		return fmt.Errorf("invalid cardinality")
+	}
+	inputs := make([]any, len(values))
+	for index, value := range values {
+		var input any
+		switch typeName {
+		case semanticvalue.TypeString, semanticvalue.TypeDate, semanticvalue.TypeTimestamp:
+			input = value
+		case semanticvalue.TypeBoolean:
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return err
+			}
+			input = parsed
+		case semanticvalue.TypeInteger, semanticvalue.TypeDecimal:
+			input = json.Number(value)
+		default:
+			return semanticvalue.ErrInvalidType
+		}
+		inputs[index] = input
+	}
+	definition := SemanticAttributeDefinition{Type: typeName, Shape: shape, Profile: semanticvalue.Profile,
+		LifecycleState: SemanticAttributeActive, Enabled: true}
+	var input any = inputs
+	if shape == SemanticAttributeScalar {
+		input = inputs[0]
+	}
+	canonical, computed, err := CanonicalSemanticAttributeValues(definition, input)
+	if err != nil || computed != digest || !reflect.DeepEqual(canonical, values) {
+		return fmt.Errorf("canonical values or digest mismatch")
+	}
+	return nil
+}

--- a/internal/access/semantic_attribute_snapshot_validation_test.go
+++ b/internal/access/semantic_attribute_snapshot_validation_test.go
@@ -1,0 +1,60 @@
+package access
+
+import (
+	"testing"
+
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestValidateSemanticAttributeRegistrySnapshotRejectsDigestValidDerivedLifecycleMismatch(t *testing.T) {
+	definition := SemanticAttributeDefinition{ID: "definition-region", Name: "region", Type: semanticvalue.TypeString,
+		Shape: SemanticAttributeScalar, Profile: semanticvalue.Profile, DefinitionVersion: 1,
+		Metadata:       SemanticAttributeMetadata{Owner: SemanticAttributeOwner{Kind: SemanticAttributeOwnerInstance}},
+		LifecycleState: SemanticAttributeActive, Enabled: true}
+	snapshot := SemanticAttributeRegistrySnapshot{Definitions: []SemanticAttributeDefinition{definition},
+		State: SemanticAttributeRegistryState{Profile: semanticvalue.Profile, Revision: 1}}
+	var err error
+	snapshot.State.Digest, err = SemanticAttributeRegistryDigest(snapshot.State.Profile, snapshot.Definitions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateSemanticAttributeRegistrySnapshot(snapshot); err != nil {
+		t.Fatalf("valid snapshot: %v", err)
+	}
+
+	// Enabled is a derived projection and is intentionally absent from the
+	// persisted digest wire. Admission must still reject the inconsistency.
+	snapshot.Definitions[0].Enabled = false
+	if err := ValidateSemanticAttributeRegistrySnapshot(snapshot); err == nil {
+		t.Fatal("registry validation accepted a digest-valid lifecycle mismatch")
+	}
+}
+
+func TestValidateSemanticAttributeControlSnapshotRejectsDigestValidTombstoneMismatch(t *testing.T) {
+	definition := SemanticAttributeDefinition{Type: semanticvalue.TypeString, Shape: SemanticAttributeScalar,
+		Profile: semanticvalue.Profile, LifecycleState: SemanticAttributeActive, Enabled: true}
+	values, valueDigest, err := CanonicalSemanticAttributeValues(definition, "west")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assignment := SemanticAttributeAssignment{ID: "assignment-region", DefinitionID: "definition-region", DefinitionName: "region",
+		DefinitionVersion: 1, Type: semanticvalue.TypeString, Shape: SemanticAttributeScalar,
+		Subject: SubjectRef{Kind: SubjectKindPrincipal, ID: "principal-1"}, CanonicalValues: values,
+		ValueDigest: valueDigest, AssignmentVersion: 1}
+	snapshot := SemanticAttributeControlSnapshot{Assignments: []SemanticAttributeAssignment{assignment},
+		State: SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 1}}
+	snapshot.State.Digest, err = SemanticAttributeControlDigest(snapshot.Assignments, snapshot.Mappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateSemanticAttributeControlSnapshot(snapshot); err != nil {
+		t.Fatalf("valid snapshot: %v", err)
+	}
+
+	// Tombstoned is derived from TombstonedAt and intentionally absent from
+	// the persisted digest wire.
+	snapshot.Assignments[0].Tombstoned = true
+	if err := ValidateSemanticAttributeControlSnapshot(snapshot); err == nil {
+		t.Fatal("control validation accepted a digest-valid tombstone mismatch")
+	}
+}

--- a/internal/access/semantic_attributes.go
+++ b/internal/access/semantic_attributes.go
@@ -9,9 +9,20 @@ import (
 )
 
 var (
-	ErrSemanticAttributeConflict = errors.New("semantic attribute definition conflicts with the registry")
-	ErrSemanticAttributeDisabled = errors.New("semantic attribute is disabled")
+	ErrSemanticAttributeConflict        = errors.New("semantic attribute definition conflicts with the registry")
+	ErrSemanticAttributeDisabled        = errors.New("semantic attribute is disabled")
+	ErrSemanticAttributeRegistryCorrupt = errors.New("semantic attribute registry state is corrupt")
 )
+
+// MaxSemanticAttributeValues and ValidateSemanticAttributeName publish the
+// semanticvalue profile's structural limits through the access contract. This
+// lets upstream authored-contract compilers validate references without
+// acquiring a direct dependency on the canonicalization capability.
+const MaxSemanticAttributeValues = semanticvalue.MaxSetValues
+
+func ValidateSemanticAttributeName(name string) error {
+	return semanticvalue.ValidateAttributeName(name)
+}
 
 // SemanticAttributeShape distinguishes a scalar assignment from a homogeneous
 // list assignment. The element type remains one of semanticvalue's closed v1

--- a/internal/analytics/model/execution_snapshot.go
+++ b/internal/analytics/model/execution_snapshot.go
@@ -32,6 +32,7 @@ func (m *Model) ExecutionSnapshot() *Model {
 	clone.Dimensions = snapshotSemanticDimensions(m.Dimensions)
 	clone.Filters = snapshotSemanticFilters(m.Filters)
 	clone.Metrics = snapshotMetrics(m.Metrics)
+	clone.AccessPolicy = cloneSemanticAccessPolicy(m.AccessPolicy)
 	return &clone
 }
 

--- a/internal/analytics/model/semantic_access.go
+++ b/internal/analytics/model/semantic_access.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// SemanticAccessLiteral is the closed portable representation of one authored
+// access-grant literal. Number preserves the exact JSON token emitted by the
+// generated contract so artifact round trips cannot reinterpret it as a
+// float64 before the target registry supplies its logical type.
+type SemanticAccessLiteral struct {
+	Kind string `json:"kind" yaml:"kind"`
+	Text string `json:"text,omitempty" yaml:"text,omitempty"`
+	Bool bool   `json:"bool,omitempty" yaml:"bool,omitempty"`
+}
+
+const (
+	SemanticAccessString  = "string"
+	SemanticAccessNumber  = "number"
+	SemanticAccessBoolean = "boolean"
+)
+
+func NewSemanticAccessLiteral(value any) (SemanticAccessLiteral, error) {
+	switch typed := value.(type) {
+	case string:
+		return SemanticAccessLiteral{Kind: SemanticAccessString, Text: typed}, nil
+	case json.Number:
+		if typed == "" {
+			return SemanticAccessLiteral{}, fmt.Errorf("semantic access number is empty")
+		}
+		return SemanticAccessLiteral{Kind: SemanticAccessNumber, Text: string(typed)}, nil
+	case bool:
+		return SemanticAccessLiteral{Kind: SemanticAccessBoolean, Bool: typed}, nil
+	default:
+		return SemanticAccessLiteral{}, fmt.Errorf("semantic access literal has unsupported type %T", value)
+	}
+}
+
+// Value restores the strict input expected by semanticvalue. It never parses
+// or coerces a number token.
+func (value SemanticAccessLiteral) Value() (any, error) {
+	switch value.Kind {
+	case SemanticAccessString:
+		return value.Text, nil
+	case SemanticAccessNumber:
+		if value.Text == "" {
+			return nil, fmt.Errorf("semantic access number is empty")
+		}
+		return json.Number(value.Text), nil
+	case SemanticAccessBoolean:
+		return value.Bool, nil
+	default:
+		return nil, fmt.Errorf("unsupported semantic access literal kind %q", value.Kind)
+	}
+}
+
+type SemanticAccessGrantSpec struct {
+	UserAttribute string                  `json:"userAttribute" yaml:"userAttribute"`
+	AllowedValues []SemanticAccessLiteral `json:"allowedValues" yaml:"allowedValues"`
+}
+
+type SemanticAccessFilterSpec struct {
+	Field         string `json:"field" yaml:"field"`
+	UserAttribute string `json:"userAttribute" yaml:"userAttribute"`
+}
+
+type SemanticDatasetAccessSpec struct {
+	RequiredAccessGrants []string                   `json:"requiredAccessGrants,omitempty" yaml:"requiredAccessGrants,omitempty"`
+	AccessFilters        []SemanticAccessFilterSpec `json:"accessFilters,omitempty" yaml:"accessFilters,omitempty"`
+}
+
+// SemanticAccessPolicy is the portable authored policy retained by the
+// semantic model. It contains references and allowed values, never target
+// registry definitions, principal assignments, or trusted claim values.
+type SemanticAccessPolicy struct {
+	AccessGrants map[string]SemanticAccessGrantSpec   `json:"accessGrants,omitempty" yaml:"accessGrants,omitempty"`
+	Datasets     map[string]SemanticDatasetAccessSpec `json:"datasets,omitempty" yaml:"datasets,omitempty"`
+	Dimensions   map[string][]string                  `json:"dimensions,omitempty" yaml:"dimensions,omitempty"`
+	Metrics      map[string][]string                  `json:"metrics,omitempty" yaml:"metrics,omitempty"`
+}
+
+func (policy SemanticAccessPolicy) Empty() bool {
+	return len(policy.AccessGrants) == 0 && len(policy.Datasets) == 0 && len(policy.Dimensions) == 0 && len(policy.Metrics) == 0
+}
+
+func cloneSemanticAccessPolicy(policy SemanticAccessPolicy) SemanticAccessPolicy {
+	clone := SemanticAccessPolicy{}
+	if policy.AccessGrants != nil {
+		clone.AccessGrants = make(map[string]SemanticAccessGrantSpec, len(policy.AccessGrants))
+		for name, grant := range policy.AccessGrants {
+			grant.AllowedValues = append([]SemanticAccessLiteral(nil), grant.AllowedValues...)
+			clone.AccessGrants[name] = grant
+		}
+	}
+	if policy.Datasets != nil {
+		clone.Datasets = make(map[string]SemanticDatasetAccessSpec, len(policy.Datasets))
+		for name, dataset := range policy.Datasets {
+			dataset.RequiredAccessGrants = append([]string(nil), dataset.RequiredAccessGrants...)
+			dataset.AccessFilters = append([]SemanticAccessFilterSpec(nil), dataset.AccessFilters...)
+			clone.Datasets[name] = dataset
+		}
+	}
+	if policy.Dimensions != nil {
+		clone.Dimensions = make(map[string][]string, len(policy.Dimensions))
+		for name, grants := range policy.Dimensions {
+			clone.Dimensions[name] = append([]string(nil), grants...)
+		}
+	}
+	if policy.Metrics != nil {
+		clone.Metrics = make(map[string][]string, len(policy.Metrics))
+		for name, grants := range policy.Metrics {
+			clone.Metrics[name] = append([]string(nil), grants...)
+		}
+	}
+	return clone
+}

--- a/internal/analytics/model/semantic_access_test.go
+++ b/internal/analytics/model/semantic_access_test.go
@@ -1,0 +1,59 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSemanticAccessPolicyArtifactRoundTripPreservesExactNumbers(t *testing.T) {
+	literal, err := NewSemanticAccessLiteral(json.Number("9007199254740993.1250"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := Model{Name: "sales", AccessPolicy: SemanticAccessPolicy{AccessGrants: map[string]SemanticAccessGrantSpec{
+		"exact": {UserAttribute: "limit", AllowedValues: []SemanticAccessLiteral{literal}},
+	}}}
+	encoded, err := json.Marshal(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored Model
+	if err := json.Unmarshal(encoded, &restored); err != nil {
+		t.Fatal(err)
+	}
+	value, err := restored.AccessPolicy.AccessGrants["exact"].AllowedValues[0].Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != json.Number("9007199254740993.1250") {
+		t.Fatalf("restored exact number = %v (%T)", value, value)
+	}
+}
+
+func TestExecutionSnapshotDetachesSemanticAccessPolicy(t *testing.T) {
+	model := Model{Name: "sales", AccessPolicy: SemanticAccessPolicy{
+		AccessGrants: map[string]SemanticAccessGrantSpec{"view": {UserAttribute: "department", AllowedValues: []SemanticAccessLiteral{{Kind: SemanticAccessString, Text: "sales"}}}},
+		Datasets:     map[string]SemanticDatasetAccessSpec{"orders": {RequiredAccessGrants: []string{"view"}, AccessFilters: []SemanticAccessFilterSpec{{Field: "region", UserAttribute: "regions"}}}},
+		Dimensions:   map[string][]string{"region": {"view"}}, Metrics: map[string][]string{"revenue": {"view"}},
+	}}
+	snapshot := model.ExecutionSnapshot()
+	grant := model.AccessPolicy.AccessGrants["view"]
+	grant.AllowedValues[0].Text = "engineering"
+	model.AccessPolicy.AccessGrants["view"] = grant
+	dataset := model.AccessPolicy.Datasets["orders"]
+	dataset.RequiredAccessGrants[0] = "other"
+	dataset.AccessFilters[0].Field = "account"
+	model.AccessPolicy.Datasets["orders"] = dataset
+	model.AccessPolicy.Dimensions["region"][0] = "other"
+	model.AccessPolicy.Metrics["revenue"][0] = "other"
+
+	if got := snapshot.AccessPolicy.AccessGrants["view"].AllowedValues[0].Text; got != "sales" {
+		t.Fatalf("snapshot grant value = %q", got)
+	}
+	if got := snapshot.AccessPolicy.Datasets["orders"]; got.RequiredAccessGrants[0] != "view" || got.AccessFilters[0].Field != "region" {
+		t.Fatalf("snapshot dataset policy mutated: %#v", got)
+	}
+	if snapshot.AccessPolicy.Dimensions["region"][0] != "view" || snapshot.AccessPolicy.Metrics["revenue"][0] != "view" {
+		t.Fatalf("snapshot member policy mutated: %#v", snapshot.AccessPolicy)
+	}
+}

--- a/internal/analytics/model/types.go
+++ b/internal/analytics/model/types.go
@@ -171,6 +171,7 @@ type Model struct {
 	Dimensions              map[string]SemanticDimension   `yaml:"-"`
 	Filters                 map[string]SemanticFilterSpec  `yaml:"-"`
 	Metrics                 map[string]Metric              `yaml:"-"`
+	AccessPolicy            SemanticAccessPolicy           `yaml:"-" json:"accessPolicy,omitempty"`
 }
 
 type Connection struct {

--- a/internal/analytics/query/semantic_access_compile.go
+++ b/internal/analytics/query/semantic_access_compile.go
@@ -1,0 +1,604 @@
+package query
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/flidai/leapview/internal/access"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+var (
+	ErrSemanticAccessPolicyInvalid = errors.New("semantic access policy is invalid")
+	canonicalSHA256                = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+)
+
+type CompiledSemanticAccessGrant struct {
+	Name                string                        `json:"name"`
+	DefinitionID        string                        `json:"definitionId"`
+	DefinitionVersion   int64                         `json:"definitionVersion"`
+	UserAttribute       string                        `json:"userAttribute"`
+	Type                semanticvalue.Type            `json:"type"`
+	Shape               access.SemanticAttributeShape `json:"shape"`
+	AllowedValues       []string                      `json:"-"`
+	AllowedValuesDigest string                        `json:"allowedValuesDigest"`
+}
+
+type CompiledSemanticAccessFilter struct {
+	Dataset           string                        `json:"dataset"`
+	Dimension         string                        `json:"dimension"`
+	Field             string                        `json:"field"`
+	DefinitionID      string                        `json:"definitionId"`
+	DefinitionVersion int64                         `json:"definitionVersion"`
+	UserAttribute     string                        `json:"userAttribute"`
+	Type              semanticvalue.Type            `json:"type"`
+	Shape             access.SemanticAttributeShape `json:"shape"`
+}
+
+type CompiledSemanticDatasetAccess struct {
+	Dataset              string                         `json:"dataset"`
+	RequiredAccessGrants []string                       `json:"requiredAccessGrants"`
+	AccessFilters        []CompiledSemanticAccessFilter `json:"accessFilters"`
+}
+
+type CompiledSemanticMemberAccess struct {
+	Member               string   `json:"member"`
+	Datasets             []string `json:"datasets"`
+	RequiredAccessGrants []string `json:"requiredAccessGrants"`
+}
+
+// CompiledSemanticAccessPolicy is target-qualified, immutable policy metadata.
+// It owns no principal values and performs no planner placement; FAI-641 will
+// consume its evaluated predicates when constructing security barriers.
+type CompiledSemanticAccessPolicy struct {
+	profile            string
+	targetInstanceID   string
+	semanticModelID    string
+	semanticGeneration string
+	registry           access.SemanticAttributeRegistryState
+	digest             string
+	canonical          []byte
+	grants             map[string]CompiledSemanticAccessGrant
+	datasets           map[string]CompiledSemanticDatasetAccess
+	dimensions         map[string]map[string]CompiledSemanticMemberAccess
+	metrics            map[string]CompiledSemanticMemberAccess
+}
+
+func (policy *CompiledSemanticAccessPolicy) Profile() string {
+	if policy == nil {
+		return ""
+	}
+	return policy.profile
+}
+
+func (policy *CompiledSemanticAccessPolicy) SemanticModelID() string {
+	if policy == nil {
+		return ""
+	}
+	return policy.semanticModelID
+}
+
+func (policy *CompiledSemanticAccessPolicy) TargetInstanceID() string {
+	if policy == nil {
+		return ""
+	}
+	return policy.targetInstanceID
+}
+
+func (policy *CompiledSemanticAccessPolicy) SemanticGeneration() string {
+	if policy == nil {
+		return ""
+	}
+	return policy.semanticGeneration
+}
+
+func (policy *CompiledSemanticAccessPolicy) RegistryState() access.SemanticAttributeRegistryState {
+	if policy == nil {
+		return access.SemanticAttributeRegistryState{}
+	}
+	return policy.registry
+}
+
+func (policy *CompiledSemanticAccessPolicy) Digest() string {
+	if policy == nil {
+		return ""
+	}
+	return policy.digest
+}
+
+func (policy *CompiledSemanticAccessPolicy) Canonical() []byte {
+	if policy == nil {
+		return nil
+	}
+	return append([]byte(nil), policy.canonical...)
+}
+
+func (policy *CompiledSemanticAccessPolicy) Grant(name string) (CompiledSemanticAccessGrant, bool) {
+	if policy == nil {
+		return CompiledSemanticAccessGrant{}, false
+	}
+	grant, ok := policy.grants[name]
+	grant.AllowedValues = append([]string(nil), grant.AllowedValues...)
+	return grant, ok
+}
+
+func (policy *CompiledSemanticAccessPolicy) Dataset(name string) (CompiledSemanticDatasetAccess, bool) {
+	if policy == nil {
+		return CompiledSemanticDatasetAccess{}, false
+	}
+	dataset, ok := policy.datasets[name]
+	dataset.RequiredAccessGrants = append([]string(nil), dataset.RequiredAccessGrants...)
+	dataset.AccessFilters = append([]CompiledSemanticAccessFilter(nil), dataset.AccessFilters...)
+	return dataset, ok
+}
+
+func (policy *CompiledSemanticAccessPolicy) Dimension(name, dataset string) (CompiledSemanticMemberAccess, bool) {
+	if policy == nil {
+		return CompiledSemanticMemberAccess{}, false
+	}
+	member, ok := policy.dimensions[name][dataset]
+	member.Datasets = append([]string(nil), member.Datasets...)
+	member.RequiredAccessGrants = append([]string(nil), member.RequiredAccessGrants...)
+	return member, ok
+}
+
+func (policy *CompiledSemanticAccessPolicy) Metric(name string) (CompiledSemanticMemberAccess, bool) {
+	if policy == nil {
+		return CompiledSemanticMemberAccess{}, false
+	}
+	member, ok := policy.metrics[name]
+	member.Datasets = append([]string(nil), member.Datasets...)
+	member.RequiredAccessGrants = append([]string(nil), member.RequiredAccessGrants...)
+	return member, ok
+}
+
+// CompileSemanticAccessPolicy qualifies the portable authored policy against
+// one verified target registry snapshot. The query model is supplied
+// separately so stale semantic lineage cannot be paired with a newer policy.
+func CompileSemanticAccessPolicy(targetInstanceID, modelID, semanticGeneration string, model *semanticmodel.Model, compiled *CompiledModel, registry access.SemanticAttributeRegistrySnapshot) (*CompiledSemanticAccessPolicy, error) {
+	if err := validateSemanticIdentity("target instance id", targetInstanceID); err != nil {
+		return nil, err
+	}
+	if err := validateSemanticIdentity("semantic model id", modelID); err != nil {
+		return nil, err
+	}
+	if err := validateSemanticIdentity("semantic generation", semanticGeneration); err != nil {
+		return nil, err
+	}
+	if model == nil || compiled == nil || !compiled.MatchesModel(model) {
+		return nil, fmt.Errorf("%w: semantic model and compiled lineage are missing or inconsistent", ErrSemanticAccessPolicyInvalid)
+	}
+	if err := validateRegistryState(registry.State); err != nil {
+		return nil, err
+	}
+	registryDigest, err := access.SemanticAttributeRegistryDigest(registry.State.Profile, registry.Definitions)
+	if err != nil || registryDigest != registry.State.Digest {
+		return nil, fmt.Errorf("%w: registry snapshot digest does not match definitions", ErrSemanticAccessPolicyInvalid)
+	}
+	if err := access.ValidateSemanticAttributeRegistrySnapshot(registry); err != nil {
+		return nil, fmt.Errorf("%w: registry snapshot is structurally invalid: %v", ErrSemanticAccessPolicyInvalid, err)
+	}
+	definitions, err := semanticAttributeDefinitions(registry.Definitions)
+	if err != nil {
+		return nil, err
+	}
+	policy := &CompiledSemanticAccessPolicy{
+		profile: semanticvalue.Profile, targetInstanceID: targetInstanceID, semanticModelID: modelID, semanticGeneration: semanticGeneration,
+		registry: registry.State, grants: map[string]CompiledSemanticAccessGrant{}, datasets: map[string]CompiledSemanticDatasetAccess{},
+		dimensions: map[string]map[string]CompiledSemanticMemberAccess{}, metrics: map[string]CompiledSemanticMemberAccess{},
+	}
+	if err := policy.compileGrants(model.AccessPolicy, definitions); err != nil {
+		return nil, err
+	}
+	if err := policy.compileDatasets(model, compiled, definitions); err != nil {
+		return nil, err
+	}
+	if err := policy.compileDimensions(model, compiled); err != nil {
+		return nil, err
+	}
+	if err := policy.compileMetrics(model, compiled); err != nil {
+		return nil, err
+	}
+	canonical, err := policy.canonicalBytes()
+	if err != nil {
+		return nil, err
+	}
+	policy.canonical = canonical
+	policy.digest = semanticAccessDigest(canonical)
+	return policy, nil
+}
+
+func (policy *CompiledSemanticAccessPolicy) compileGrants(authored semanticmodel.SemanticAccessPolicy, definitions map[string]access.SemanticAttributeDefinition) error {
+	for _, name := range sortedStringKeys(authored.AccessGrants) {
+		spec := authored.AccessGrants[name]
+		if err := semanticvalue.ValidateAttributeName(name); err != nil {
+			return fmt.Errorf("%w: access grant name %q is invalid", ErrSemanticAccessPolicyInvalid, name)
+		}
+		if err := semanticvalue.ValidateAttributeName(spec.UserAttribute); err != nil {
+			return fmt.Errorf("%w: access grant %q attribute name is invalid", ErrSemanticAccessPolicyInvalid, name)
+		}
+		definition, ok := definitions[spec.UserAttribute]
+		if !ok {
+			return fmt.Errorf("%w: access grant %q references unknown attribute %q", ErrSemanticAccessPolicyInvalid, name, spec.UserAttribute)
+		}
+		if err := validateReferencedDefinition(definition); err != nil {
+			return fmt.Errorf("%w: access grant %q: %v", ErrSemanticAccessPolicyInvalid, name, err)
+		}
+		inputs := make([]any, len(spec.AllowedValues))
+		for index, literal := range spec.AllowedValues {
+			value, err := literal.Value()
+			if err != nil {
+				return fmt.Errorf("%w: access grant %q allowed value %d: %v", ErrSemanticAccessPolicyInvalid, name, index, err)
+			}
+			inputs[index] = value
+		}
+		set, err := semanticvalue.CanonicalizeSet(definition.Type, inputs)
+		if err != nil {
+			return fmt.Errorf("%w: access grant %q allowed values: %v", ErrSemanticAccessPolicyInvalid, name, err)
+		}
+		values := set.Values()
+		if len(values) != len(inputs) {
+			return fmt.Errorf("%w: access grant %q allowed values contain canonical duplicates", ErrSemanticAccessPolicyInvalid, name)
+		}
+		canonical := make([]string, len(values))
+		for index := range values {
+			canonical[index] = values[index].Canonical()
+		}
+		policy.grants[name] = CompiledSemanticAccessGrant{Name: name, DefinitionID: definition.ID, DefinitionVersion: definition.DefinitionVersion,
+			UserAttribute: definition.Name, Type: definition.Type, Shape: definition.Shape, AllowedValues: canonical, AllowedValuesDigest: set.Digest()}
+	}
+	return nil
+}
+
+func (policy *CompiledSemanticAccessPolicy) compileDatasets(model *semanticmodel.Model, compiled *CompiledModel, definitions map[string]access.SemanticAttributeDefinition) error {
+	for _, name := range compiled.DatasetNames() {
+		authored := model.AccessPolicy.Datasets[name]
+		if err := policy.validateAuthoredRequirements("dataset", name, authored.RequiredAccessGrants); err != nil {
+			return err
+		}
+		dataset := CompiledSemanticDatasetAccess{Dataset: name, RequiredAccessGrants: sortedUnique(authored.RequiredAccessGrants)}
+		filters := append([]semanticmodel.SemanticAccessFilterSpec(nil), authored.AccessFilters...)
+		sort.Slice(filters, func(i, j int) bool {
+			if filters[i].Field != filters[j].Field {
+				return filters[i].Field < filters[j].Field
+			}
+			return filters[i].UserAttribute < filters[j].UserAttribute
+		})
+		for _, filter := range filters {
+			definition, ok := definitions[filter.UserAttribute]
+			if !ok {
+				return fmt.Errorf("%w: dataset %q access filter references unknown attribute %q", ErrSemanticAccessPolicyInvalid, name, filter.UserAttribute)
+			}
+			if err := validateReferencedDefinition(definition); err != nil {
+				return fmt.Errorf("%w: dataset %q access filter: %v", ErrSemanticAccessPolicyInvalid, name, err)
+			}
+			dimension, ok := compiled.SemanticDimension(filter.Field)
+			if !ok {
+				return fmt.Errorf("%w: dataset %q access filter references unknown semantic dimension %q", ErrSemanticAccessPolicyInvalid, name, filter.Field)
+			}
+			binding, ok := compiled.DimensionBinding(filter.Field, name)
+			if !ok || len(binding.Path) != 0 || binding.Physical.Table != name {
+				return fmt.Errorf("%w: dataset %q access filter dimension %q is not directly bound to that dataset", ErrSemanticAccessPolicyInvalid, name, filter.Field)
+			}
+			if !semanticAccessTypeCompatible(definition.Type, dimension.Datatype) {
+				return fmt.Errorf("%w: dataset %q access filter dimension %q datatype %q is incompatible with attribute %q type %q", ErrSemanticAccessPolicyInvalid, name, filter.Field, dimension.Datatype, definition.Name, definition.Type)
+			}
+			dataset.AccessFilters = append(dataset.AccessFilters, CompiledSemanticAccessFilter{Dataset: name, Dimension: filter.Field, Field: binding.Physical.Field,
+				DefinitionID: definition.ID, DefinitionVersion: definition.DefinitionVersion, UserAttribute: definition.Name, Type: definition.Type, Shape: definition.Shape})
+		}
+		policy.datasets[name] = dataset
+	}
+	for name := range model.AccessPolicy.Datasets {
+		if _, ok := policy.datasets[name]; !ok {
+			return fmt.Errorf("%w: access policy references unknown dataset %q", ErrSemanticAccessPolicyInvalid, name)
+		}
+	}
+	return nil
+}
+
+func (policy *CompiledSemanticAccessPolicy) compileDimensions(model *semanticmodel.Model, compiled *CompiledModel) error {
+	for name := range model.AccessPolicy.Dimensions {
+		if _, ok := model.Dimensions[name]; !ok {
+			return fmt.Errorf("%w: access policy references unknown dimension %q", ErrSemanticAccessPolicyInvalid, name)
+		}
+	}
+	for _, name := range sortedStringKeys(model.Dimensions) {
+		direct := model.AccessPolicy.Dimensions[name]
+		if err := policy.validateAuthoredRequirements("dimension", name, direct); err != nil {
+			return err
+		}
+		bindings := model.Dimensions[name].Bindings
+		for _, dataset := range sortedStringKeys(bindings) {
+			required := append([]string(nil), direct...)
+			required = append(required, policy.datasets[dataset].RequiredAccessGrants...)
+			datasets := []string{dataset}
+			if binding, ok := compiled.DimensionBinding(name, dataset); ok {
+				required = append(required, policy.requirementsForPath(binding.Path)...)
+				datasets = append(datasets, semanticAccessPathDatasets(binding.Path)...)
+			}
+			if policy.dimensions[name] == nil {
+				policy.dimensions[name] = map[string]CompiledSemanticMemberAccess{}
+			}
+			policy.dimensions[name][dataset] = CompiledSemanticMemberAccess{Member: name, Datasets: sortedUnique(datasets), RequiredAccessGrants: sortedUnique(required)}
+		}
+	}
+	return nil
+}
+
+func (policy *CompiledSemanticAccessPolicy) compileMetrics(model *semanticmodel.Model, compiled *CompiledModel) error {
+	for name := range model.AccessPolicy.Metrics {
+		if _, ok := compiled.metrics[name]; !ok {
+			return fmt.Errorf("%w: access policy references unknown metric %q", ErrSemanticAccessPolicyInvalid, name)
+		}
+		if err := policy.validateAuthoredRequirements("metric", name, model.AccessPolicy.Metrics[name]); err != nil {
+			return err
+		}
+	}
+	visiting := map[string]bool{}
+	var compile func(string) (CompiledSemanticMemberAccess, error)
+	compile = func(name string) (CompiledSemanticMemberAccess, error) {
+		if member, ok := policy.metrics[name]; ok {
+			return member, nil
+		}
+		if visiting[name] {
+			return CompiledSemanticMemberAccess{}, fmt.Errorf("%w: metric dependency cycle at %q", ErrSemanticAccessPolicyInvalid, name)
+		}
+		metric, ok := compiled.metric(name)
+		if !ok {
+			return CompiledSemanticMemberAccess{}, fmt.Errorf("%w: unknown metric %q", ErrSemanticAccessPolicyInvalid, name)
+		}
+		visiting[name] = true
+		required := append([]string(nil), model.AccessPolicy.Metrics[name]...)
+		datasets := append([]string(nil), metric.RootDatasets...)
+		for _, dataset := range metric.RootDatasets {
+			required = append(required, policy.datasets[dataset].RequiredAccessGrants...)
+		}
+		for _, lineage := range metric.Lineage.Entries {
+			required = append(required, policy.requirementsForPath(lineage.Path)...)
+			datasets = append(datasets, semanticAccessPathDatasets(lineage.Path)...)
+		}
+		if metric.Aggregate != nil && metric.Aggregate.TimeDimension != "" {
+			if dimension, ok := policy.dimensions[metric.Aggregate.TimeDimension][metric.Aggregate.Dataset]; ok {
+				required = append(required, dimension.RequiredAccessGrants...)
+				datasets = append(datasets, dimension.Datasets...)
+			}
+		}
+		if metric.Aggregate != nil {
+			for _, filterName := range model.Metrics[name].Where {
+				for _, dimensionName := range semanticFilterDimensionReferences(model.Filters[filterName], model.Dimensions, metric.Aggregate.Dataset) {
+					if dimension, ok := policy.dimensions[dimensionName][metric.Aggregate.Dataset]; ok {
+						required = append(required, dimension.RequiredAccessGrants...)
+						datasets = append(datasets, dimension.Datasets...)
+					}
+				}
+			}
+		}
+		for _, dependency := range metric.Dependencies {
+			member, err := compile(dependency)
+			if err != nil {
+				return CompiledSemanticMemberAccess{}, err
+			}
+			required = append(required, member.RequiredAccessGrants...)
+			datasets = append(datasets, member.Datasets...)
+		}
+		delete(visiting, name)
+		if err := policy.validateRequirements("metric", name, required); err != nil {
+			return CompiledSemanticMemberAccess{}, err
+		}
+		member := CompiledSemanticMemberAccess{Member: name, Datasets: sortedUnique(datasets), RequiredAccessGrants: sortedUnique(required)}
+		policy.metrics[name] = member
+		return member, nil
+	}
+	for _, name := range compiled.metricNames() {
+		if _, err := compile(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (policy *CompiledSemanticAccessPolicy) requirementsForPath(path []semanticmodel.Relationship) []string {
+	var required []string
+	for _, relationship := range path {
+		required = append(required, policy.datasets[relationship.FromDataset].RequiredAccessGrants...)
+		required = append(required, policy.datasets[relationship.ToDataset].RequiredAccessGrants...)
+	}
+	return required
+}
+
+func semanticAccessPathDatasets(path []semanticmodel.Relationship) []string {
+	var datasets []string
+	for _, relationship := range path {
+		datasets = append(datasets, relationship.FromDataset, relationship.ToDataset)
+	}
+	return sortedUnique(datasets)
+}
+
+func (policy *CompiledSemanticAccessPolicy) validateRequirements(kind, name string, required []string) error {
+	for _, grant := range required {
+		if _, ok := policy.grants[grant]; !ok {
+			return fmt.Errorf("%w: %s %q references unknown access grant %q", ErrSemanticAccessPolicyInvalid, kind, name, grant)
+		}
+	}
+	return nil
+}
+
+func (policy *CompiledSemanticAccessPolicy) validateAuthoredRequirements(kind, name string, required []string) error {
+	if required != nil && len(required) == 0 {
+		return fmt.Errorf("%w: %s %q has an empty required grant list", ErrSemanticAccessPolicyInvalid, kind, name)
+	}
+	seen := make(map[string]struct{}, len(required))
+	for _, grant := range required {
+		if _, duplicate := seen[grant]; duplicate {
+			return fmt.Errorf("%w: %s %q repeats access grant %q", ErrSemanticAccessPolicyInvalid, kind, name, grant)
+		}
+		seen[grant] = struct{}{}
+	}
+	return policy.validateRequirements(kind, name, required)
+}
+
+func semanticAttributeDefinitions(values []access.SemanticAttributeDefinition) (map[string]access.SemanticAttributeDefinition, error) {
+	byName := make(map[string]access.SemanticAttributeDefinition, len(values))
+	byID := make(map[string]struct{}, len(values))
+	for _, definition := range values {
+		if err := semanticvalue.ValidateAttributeName(definition.Name); err != nil {
+			return nil, fmt.Errorf("%w: registry definition name: %v", ErrSemanticAccessPolicyInvalid, err)
+		}
+		if _, duplicate := byName[definition.Name]; duplicate {
+			return nil, fmt.Errorf("%w: registry contains duplicate attribute name %q", ErrSemanticAccessPolicyInvalid, definition.Name)
+		}
+		if definition.ID == "" {
+			return nil, fmt.Errorf("%w: registry attribute %q has no stable id", ErrSemanticAccessPolicyInvalid, definition.Name)
+		}
+		if _, duplicate := byID[definition.ID]; duplicate {
+			return nil, fmt.Errorf("%w: registry contains duplicate attribute id %q", ErrSemanticAccessPolicyInvalid, definition.ID)
+		}
+		byName[definition.Name] = definition
+		byID[definition.ID] = struct{}{}
+	}
+	return byName, nil
+}
+
+func validateReferencedDefinition(definition access.SemanticAttributeDefinition) error {
+	if definition.Profile != semanticvalue.Profile || definition.DefinitionVersion <= 0 {
+		return fmt.Errorf("attribute %q has incompatible profile or version", definition.Name)
+	}
+	if !definition.Enabled || definition.LifecycleState != access.SemanticAttributeActive {
+		return fmt.Errorf("attribute %q is disabled", definition.Name)
+	}
+	if !definition.Shape.Valid() || !semanticAccessTypeSupported(definition.Type) {
+		return fmt.Errorf("attribute %q has unsupported type or shape", definition.Name)
+	}
+	owner := definition.Metadata.Owner
+	if !owner.Kind.Valid() || owner.ID != strings.TrimSpace(owner.ID) ||
+		(owner.Kind == access.SemanticAttributeOwnerInstance && owner.ID != "") ||
+		(owner.Kind != access.SemanticAttributeOwnerInstance && owner.ID == "") {
+		return fmt.Errorf("attribute %q has invalid stewardship ownership", definition.Name)
+	}
+	return nil
+}
+
+func semanticAccessTypeSupported(value semanticvalue.Type) bool {
+	switch value {
+	case semanticvalue.TypeString, semanticvalue.TypeBoolean, semanticvalue.TypeInteger, semanticvalue.TypeDecimal, semanticvalue.TypeDate, semanticvalue.TypeTimestamp:
+		return true
+	default:
+		return false
+	}
+}
+
+func semanticAccessTypeCompatible(attribute semanticvalue.Type, dimension semanticmodel.LogicalDataType) bool {
+	return attribute == semanticvalue.TypeString && dimension == semanticmodel.DataTypeString ||
+		attribute == semanticvalue.TypeBoolean && dimension == semanticmodel.DataTypeBoolean ||
+		attribute == semanticvalue.TypeInteger && dimension == semanticmodel.DataTypeInteger ||
+		attribute == semanticvalue.TypeDecimal && dimension == semanticmodel.DataTypeDecimal ||
+		attribute == semanticvalue.TypeDate && dimension == semanticmodel.DataTypeDate ||
+		attribute == semanticvalue.TypeTimestamp && dimension == semanticmodel.DataTypeDateTimeTZ
+}
+
+func validateRegistryState(state access.SemanticAttributeRegistryState) error {
+	if state.Profile != semanticvalue.Profile || state.Revision < 0 || !canonicalSHA256.MatchString(state.Digest) {
+		return fmt.Errorf("%w: registry state identity is invalid", ErrSemanticAccessPolicyInvalid)
+	}
+	return nil
+}
+
+func validateSemanticIdentity(label, value string) error {
+	if value == "" || value != strings.TrimSpace(value) {
+		return fmt.Errorf("%w: %s is required and must be canonical", ErrSemanticAccessPolicyInvalid, label)
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return fmt.Errorf("%w: %s contains a control character", ErrSemanticAccessPolicyInvalid, label)
+		}
+	}
+	return nil
+}
+
+type semanticAccessPolicyWire struct {
+	Profile            string                          `json:"profile"`
+	TargetInstanceID   string                          `json:"targetInstanceId"`
+	SemanticModelID    string                          `json:"semanticModelId"`
+	SemanticGeneration string                          `json:"semanticGeneration"`
+	RegistryProfile    string                          `json:"registryProfile"`
+	RegistryRevision   int64                           `json:"registryRevision"`
+	RegistryDigest     string                          `json:"registryDigest"`
+	Grants             []CompiledSemanticAccessGrant   `json:"grants"`
+	Datasets           []CompiledSemanticDatasetAccess `json:"datasets"`
+	Dimensions         []CompiledSemanticMemberAccess  `json:"dimensions"`
+	Metrics            []CompiledSemanticMemberAccess  `json:"metrics"`
+}
+
+func semanticFilterDimensionReferences(filter semanticmodel.SemanticFilterSpec, dimensions map[string]semanticmodel.SemanticDimension, dataset string) []string {
+	result := []string{}
+	if _, ok := dimensions[filter.Field]; ok {
+		result = append(result, filter.Field)
+	}
+	for name, dimension := range dimensions {
+		if binding, ok := dimension.Bindings[dataset]; ok && binding.Field == filter.Field && sameStringSlice(binding.Path, filter.Path) {
+			result = append(result, name)
+		}
+	}
+	for _, child := range filter.All {
+		result = append(result, semanticFilterDimensionReferences(child, dimensions, dataset)...)
+	}
+	for _, child := range filter.Any {
+		result = append(result, semanticFilterDimensionReferences(child, dimensions, dataset)...)
+	}
+	if filter.Not != nil {
+		result = append(result, semanticFilterDimensionReferences(*filter.Not, dimensions, dataset)...)
+	}
+	return sortedUnique(result)
+}
+
+func (policy *CompiledSemanticAccessPolicy) canonicalBytes() ([]byte, error) {
+	wire := semanticAccessPolicyWire{Profile: policy.profile, TargetInstanceID: policy.targetInstanceID, SemanticModelID: policy.semanticModelID,
+		SemanticGeneration: policy.semanticGeneration, RegistryProfile: policy.registry.Profile,
+		RegistryRevision: policy.registry.Revision, RegistryDigest: policy.registry.Digest}
+	for _, name := range sortedStringKeys(policy.grants) {
+		grant := policy.grants[name]
+		grant.AllowedValues = append([]string(nil), grant.AllowedValues...)
+		wire.Grants = append(wire.Grants, grant)
+	}
+	for _, name := range sortedStringKeys(policy.datasets) {
+		dataset := policy.datasets[name]
+		dataset.RequiredAccessGrants = append([]string(nil), dataset.RequiredAccessGrants...)
+		dataset.AccessFilters = append([]CompiledSemanticAccessFilter(nil), dataset.AccessFilters...)
+		wire.Datasets = append(wire.Datasets, dataset)
+	}
+	for _, name := range sortedStringKeys(policy.dimensions) {
+		for _, dataset := range sortedStringKeys(policy.dimensions[name]) {
+			wire.Dimensions = append(wire.Dimensions, policy.dimensions[name][dataset])
+		}
+	}
+	for _, name := range sortedStringKeys(policy.metrics) {
+		wire.Metrics = append(wire.Metrics, policy.metrics[name])
+	}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return nil, fmt.Errorf("%w: encode compiled policy: %v", ErrSemanticAccessPolicyInvalid, err)
+	}
+	return encoded, nil
+}
+
+func semanticAccessDigest(value []byte) string {
+	digest := sha256.Sum256(value)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func sortedStringKeys[V any](values map[string]V) []string {
+	result := make([]string, 0, len(values))
+	for name := range values {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/analytics/query/semantic_access_compile_test.go
+++ b/internal/analytics/query/semantic_access_compile_test.go
@@ -1,0 +1,307 @@
+package query
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestCompileSemanticAccessPolicyQualifiesTypesAndIsDeterministic(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definitions := semanticAccessDefinitions()
+	first, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(definitions))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(reverseDefinitions(definitions)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Digest() != second.Digest() || !reflect.DeepEqual(first.Canonical(), second.Canonical()) {
+		t.Fatalf("compiled policy depends on registry ordering: %s != %s", first.Digest(), second.Digest())
+	}
+	account, ok := first.Grant("canViewAccount")
+	if !ok || account.Type != semanticvalue.TypeInteger || account.Shape != access.SemanticAttributeList || len(account.AllowedValues) != 1 || account.AllowedValues[0] != "9007199254740993" {
+		t.Fatalf("compiled exact-number grant = %#v", account)
+	}
+	wantGrantTypes := map[string]semanticvalue.Type{"canViewSales": semanticvalue.TypeString, "canViewAccount": semanticvalue.TypeInteger,
+		"canViewDate": semanticvalue.TypeDate, "decimalGate": semanticvalue.TypeDecimal, "booleanGate": semanticvalue.TypeBoolean, "timestampGate": semanticvalue.TypeTimestamp}
+	for name, wantType := range wantGrantTypes {
+		grant, present := first.Grant(name)
+		if !present || grant.Type != wantType || len(grant.AllowedValues) == 0 || grant.AllowedValuesDigest == "" {
+			t.Fatalf("grant %q = %#v, want type %q", name, grant, wantType)
+		}
+	}
+	dataset, ok := first.Dataset("orders")
+	if !ok || len(dataset.AccessFilters) != 6 || dataset.RequiredAccessGrants[0] != "canViewSales" {
+		t.Fatalf("compiled dataset policy = %#v", dataset)
+	}
+	wantTypes := map[string]semanticvalue.Type{"account": semanticvalue.TypeInteger, "amount": semanticvalue.TypeDecimal, "approved": semanticvalue.TypeBoolean, "occurredAt": semanticvalue.TypeTimestamp, "orderDate": semanticvalue.TypeDate, "region": semanticvalue.TypeString}
+	for _, filter := range dataset.AccessFilters {
+		if filter.Type != wantTypes[filter.Dimension] || filter.Field == "" {
+			t.Fatalf("compiled filter = %#v", filter)
+		}
+	}
+}
+
+func TestCompileSemanticAccessPolicyDigestBindsTargetAndAuthority(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherTarget, err := CompileSemanticAccessPolicy("instance-2", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherGeneration, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-10", model, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := semanticAccessRegistry(semanticAccessDefinitions())
+	registry.State.Revision++
+	registry.Definitions = replaceDefinition(registry.Definitions, "regions", func(value *access.SemanticAttributeDefinition) { value.Metadata.DisplayName = "changed" })
+	registry.State.Digest, _ = access.SemanticAttributeRegistryDigest(registry.State.Profile, registry.Definitions)
+	otherRegistry, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, policy := range map[string]*CompiledSemanticAccessPolicy{"target": otherTarget, "generation": otherGeneration, "registry": otherRegistry} {
+		if policy.Digest() == base.Digest() || reflect.DeepEqual(policy.Canonical(), base.Canonical()) {
+			t.Fatalf("%s identity is not bound into compiled policy", name)
+		}
+	}
+}
+
+func TestCompileSemanticAccessPolicyPropagatesRequirementsTransitively(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	dimension, ok := policy.Dimension("region", "orders")
+	if !ok || !reflect.DeepEqual(dimension.RequiredAccessGrants, []string{"canViewAccount", "canViewSales"}) {
+		t.Fatalf("dimension requirements = %#v", dimension)
+	}
+	revenue, ok := policy.Metric("revenue")
+	if !ok || !reflect.DeepEqual(revenue.RequiredAccessGrants, []string{"canViewAccount", "canViewSales"}) || !reflect.DeepEqual(revenue.Datasets, []string{"orders"}) {
+		t.Fatalf("aggregate requirements = %#v", revenue)
+	}
+	doubled, ok := policy.Metric("doubledRevenue")
+	if !ok || !reflect.DeepEqual(doubled.RequiredAccessGrants, []string{"canViewAccount", "canViewDate", "canViewSales"}) || !reflect.DeepEqual(doubled.Datasets, []string{"orders"}) {
+		t.Fatalf("derived requirements = %#v", doubled)
+	}
+	ratio, ok := policy.Metric("averageRevenue")
+	if !ok || !reflect.DeepEqual(ratio.RequiredAccessGrants, []string{"canViewAccount", "canViewSales"}) {
+		t.Fatalf("ratio requirements = %#v", ratio)
+	}
+}
+
+func TestCompileSemanticAccessPolicyPropagatesFilteredDimensionRequirements(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	delete(model.AccessPolicy.Metrics, "revenue")
+	model.Filters = map[string]semanticmodel.SemanticFilterSpec{
+		"western": {Field: "orders.region", Operator: "equals", Value: "west"},
+	}
+	revenue := model.Metrics["revenue"]
+	revenue.Where = []string{"western"}
+	model.Metrics["revenue"] = revenue
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	metric, _ := policy.Metric("revenue")
+	if !reflect.DeepEqual(metric.RequiredAccessGrants, []string{"canViewAccount", "canViewSales"}) {
+		t.Fatalf("filtered metric requirements = %#v", metric.RequiredAccessGrants)
+	}
+}
+
+func TestCompileSemanticAccessPolicyRetainsRelationshipDatasetClosure(t *testing.T) {
+	model := testModel()
+	populateFixtureTableModelNames(model)
+	state := model.Dimensions["customer_state"]
+	state.Bindings["customers"] = semanticmodel.DimensionBinding{Field: "customers.state"}
+	model.Dimensions["customer_state"] = state
+	literal, err := semanticmodel.NewSemanticAccessLiteral("support")
+	if err != nil {
+		t.Fatal(err)
+	}
+	model.AccessPolicy = semanticmodel.SemanticAccessPolicy{
+		AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{"customerScope": {UserAttribute: "department", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal}}},
+		Datasets: map[string]semanticmodel.SemanticDatasetAccessSpec{"customers": {
+			RequiredAccessGrants: []string{"customerScope"}, AccessFilters: []semanticmodel.SemanticAccessFilterSpec{{Field: "customer_state", UserAttribute: "regions"}},
+		}},
+	}
+	definitions := []access.SemanticAttributeDefinition{
+		{ID: "def-department", Name: "department", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Profile: semanticvalue.Profile,
+			DefinitionVersion: 1, LifecycleState: access.SemanticAttributeActive, Enabled: true, Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}}},
+		{ID: "def-regions", Name: "regions", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeList, Profile: semanticvalue.Profile,
+			DefinitionVersion: 1, LifecycleState: access.SemanticAttributeActive, Enabled: true, Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}}},
+	}
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:commerce", "generation-1", model, compiled, semanticAccessRegistry(definitions))
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, ok := policy.Dimension("customer_state", "orders")
+	if !ok || !reflect.DeepEqual(member.Datasets, []string{"customers", "orders"}) || !reflect.DeepEqual(member.RequiredAccessGrants, []string{"customerScope"}) {
+		t.Fatalf("relationship-bound dimension access = %#v", member)
+	}
+}
+
+func TestCompileSemanticAccessPolicyRejectsUnknownDisabledAndIncompatibleAttributes(t *testing.T) {
+	cases := []struct {
+		name        string
+		definitions func([]access.SemanticAttributeDefinition) []access.SemanticAttributeDefinition
+		change      func(*semanticmodel.Model)
+		want        string
+	}{
+		{name: "unknown", definitions: func(values []access.SemanticAttributeDefinition) []access.SemanticAttributeDefinition {
+			return values[:len(values)-1]
+		}, want: "unknown attribute"},
+		{name: "disabled", definitions: func(values []access.SemanticAttributeDefinition) []access.SemanticAttributeDefinition {
+			return replaceDefinition(values, "regions", func(value *access.SemanticAttributeDefinition) {
+				value.Enabled = false
+				value.LifecycleState = access.SemanticAttributeDisabled
+				value.DisabledAt = "2026-09-06T12:00:00Z"
+			})
+		}, want: "is disabled"},
+		{name: "incompatible", definitions: func(values []access.SemanticAttributeDefinition) []access.SemanticAttributeDefinition {
+			return replaceDefinition(values, "regions", func(value *access.SemanticAttributeDefinition) { value.Type = semanticvalue.TypeBoolean })
+		}, want: "incompatible"},
+		{name: "invalid ownership", definitions: func(values []access.SemanticAttributeDefinition) []access.SemanticAttributeDefinition {
+			return replaceDefinition(values, "regions", func(value *access.SemanticAttributeDefinition) {
+				value.Metadata.Owner.Kind = access.SemanticAttributeOwnerPrincipal
+				value.Metadata.Owner.ID = ""
+			})
+		}, want: "owner is invalid"},
+		{name: "invalid instance ownership", definitions: func(values []access.SemanticAttributeDefinition) []access.SemanticAttributeDefinition {
+			return replaceDefinition(values, "regions", func(value *access.SemanticAttributeDefinition) { value.Metadata.Owner.ID = "instance-1" })
+		}, want: "owner is invalid"},
+		{name: "unknown grant", definitions: func(values []access.SemanticAttributeDefinition) []access.SemanticAttributeDefinition { return values }, change: func(model *semanticmodel.Model) {
+			model.AccessPolicy.Datasets["orders"] = semanticmodel.SemanticDatasetAccessSpec{RequiredAccessGrants: []string{"missing"}}
+		}, want: "unknown access grant"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			model := semanticAccessTestModel(t)
+			if test.change != nil {
+				test.change(model)
+			}
+			compiled, err := CompileModel(model)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(test.definitions(semanticAccessDefinitions())))
+			requireSemanticAccessError(t, err, test.want)
+		})
+	}
+}
+
+func TestCompileSemanticAccessPolicyRejectsUnsafeTypeCoercionAndIndirectFilter(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	grant := model.AccessPolicy.AccessGrants["canViewAccount"]
+	grant.AllowedValues = []semanticmodel.SemanticAccessLiteral{{Kind: semanticmodel.SemanticAccessString, Text: "9007199254740993"}}
+	model.AccessPolicy.AccessGrants["canViewAccount"] = grant
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	requireSemanticAccessError(t, err, "not an integer")
+
+	model = semanticAccessTestModel(t)
+	dimension := model.Dimensions["region"]
+	dimension.Bindings["orders"] = semanticmodel.DimensionBinding{Field: "orders.region", Path: []string{"invented"}}
+	model.Dimensions["region"] = dimension
+	if _, err := CompileModel(model); err == nil {
+		// The semantic compiler itself must reject an unsafe route before the
+		// access compiler can ever create a predicate from it.
+		t.Fatal("indirect invalid binding unexpectedly compiled")
+	}
+}
+
+func TestCompileSemanticAccessPolicyRejectsCanonicalDuplicateGrantValues(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	grant := model.AccessPolicy.AccessGrants["decimalGate"]
+	grant.AllowedValues = []semanticmodel.SemanticAccessLiteral{
+		{Kind: semanticmodel.SemanticAccessNumber, Text: "1"},
+		{Kind: semanticmodel.SemanticAccessNumber, Text: "1.0"},
+	}
+	model.AccessPolicy.AccessGrants["decimalGate"] = grant
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	requireSemanticAccessError(t, err, "canonical duplicates")
+}
+
+func TestCompileSemanticAccessPolicyRejectsStaleLineageAndMalformedRegistryIdentity(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated := *model
+	mutated.AccessPolicy = model.AccessPolicy
+	mutated.AccessPolicy.AccessGrants = make(map[string]semanticmodel.SemanticAccessGrantSpec, len(model.AccessPolicy.AccessGrants))
+	for name, grant := range model.AccessPolicy.AccessGrants {
+		mutated.AccessPolicy.AccessGrants[name] = grant
+	}
+	grant := mutated.AccessPolicy.AccessGrants["canViewSales"]
+	grant.AllowedValues = []semanticmodel.SemanticAccessLiteral{{Kind: semanticmodel.SemanticAccessString, Text: "engineering"}}
+	mutated.AccessPolicy.AccessGrants["canViewSales"] = grant
+	_, err = CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", &mutated, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	requireSemanticAccessError(t, err, "inconsistent")
+
+	registry := semanticAccessRegistry(semanticAccessDefinitions())
+	registry.State.Digest = "not-a-digest"
+	_, err = CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, registry)
+	requireSemanticAccessError(t, err, "registry state identity")
+}
+
+func TestSemanticAccessLiteralRoundTripPreservesExactNumber(t *testing.T) {
+	literal, err := semanticmodel.NewSemanticAccessLiteral(json.Number("9007199254740993.1250"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(literal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded semanticmodel.SemanticAccessLiteral
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	value, err := decoded.Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if number, ok := value.(json.Number); !ok || number.String() != "9007199254740993.1250" {
+		t.Fatalf("round-trip value = %#v", value)
+	}
+}
+
+func reverseDefinitions(values []access.SemanticAttributeDefinition) []access.SemanticAttributeDefinition {
+	result := append([]access.SemanticAttributeDefinition(nil), values...)
+	for left, right := 0, len(result)-1; left < right; left, right = left+1, right-1 {
+		result[left], result[right] = result[right], result[left]
+	}
+	return result
+}

--- a/internal/analytics/query/semantic_access_evaluate.go
+++ b/internal/analytics/query/semantic_access_evaluate.go
@@ -1,0 +1,716 @@
+package query
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/query/planir"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+var ErrSemanticAccessSnapshotInvalid = errors.New("semantic access attribute snapshot is invalid")
+
+// SemanticAccessAuthority is the current registry/control identity observed at
+// authorization time. It is distinct from the identity captured with effective
+// values so a stale or mixed read fails closed.
+type SemanticAccessAuthority struct {
+	InstanceID string
+	Registry   access.SemanticAttributeRegistrySnapshot
+	Control    access.SemanticAttributeControlSnapshot
+	ObservedAt time.Time
+}
+
+type SemanticAccessAttributeSnapshot struct {
+	InstanceID               string
+	PrincipalID              string
+	ActorID                  string
+	Registry                 access.SemanticAttributeRegistrySnapshot
+	Control                  access.SemanticAttributeControlSnapshot
+	EffectiveAttributes      []access.EffectiveSemanticAttribute
+	EffectiveAttributeDigest string
+	DirectAssignmentEvidence access.SemanticAttributeDirectEvidence
+	TrustedClaimEvidence     access.SemanticAttributeClaimEvidence
+}
+
+type SemanticAccessGrantDecision struct {
+	Name         string `json:"name"`
+	DefinitionID string `json:"definitionId"`
+	Allowed      bool   `json:"allowed"`
+}
+
+type SemanticAccessFilterEvidence struct {
+	Dataset       string `json:"dataset"`
+	Dimension     string `json:"dimension"`
+	DefinitionID  string `json:"definitionId"`
+	ValueDigest   string `json:"valueDigest"`
+	PredicateKind string `json:"predicateKind"`
+}
+
+type SemanticAccessObjectDecision struct {
+	Name           string
+	Dataset        string
+	Allowed        bool
+	DeniedGrants   []string
+	DeniedDatasets []string
+	Predicate      *planir.Predicate
+	// DatasetPredicates carries every governed dataset predicate needed by
+	// this object, including relationship/dependency datasets. Consumers must
+	// not infer that Predicate alone covers a multi-dataset object.
+	DatasetPredicates map[string]planir.Predicate
+}
+
+type SemanticAccessDecision struct {
+	Profile                        string
+	InstanceID                     string
+	SemanticModelID                string
+	SemanticGeneration             string
+	PrincipalID                    string
+	ActorID                        string
+	Registry                       access.SemanticAttributeRegistryState
+	Control                        access.SemanticAttributeControlState
+	EffectiveAttributeDigest       string
+	DirectAssignmentEvidenceDigest string
+	TrustedClaimEvidenceDigest     string
+	PolicyDigest                   string
+	IdentityDigest                 string
+	GrantResults                   []SemanticAccessGrantDecision
+	FilterEvidence                 []SemanticAccessFilterEvidence
+	datasets                       map[string]SemanticAccessObjectDecision
+	dimensions                     map[string]map[string]SemanticAccessObjectDecision
+	metrics                        map[string]SemanticAccessObjectDecision
+}
+
+func (decision *SemanticAccessDecision) Dataset(name string) (SemanticAccessObjectDecision, bool) {
+	if decision == nil {
+		return SemanticAccessObjectDecision{}, false
+	}
+	value, ok := decision.datasets[name]
+	return cloneSemanticAccessObjectDecision(value), ok
+}
+
+func (decision *SemanticAccessDecision) Dimension(name, dataset string) (SemanticAccessObjectDecision, bool) {
+	if decision == nil {
+		return SemanticAccessObjectDecision{}, false
+	}
+	value, ok := decision.dimensions[name][dataset]
+	return cloneSemanticAccessObjectDecision(value), ok
+}
+
+func (decision *SemanticAccessDecision) Metric(name string) (SemanticAccessObjectDecision, bool) {
+	if decision == nil {
+		return SemanticAccessObjectDecision{}, false
+	}
+	value, ok := decision.metrics[name]
+	return cloneSemanticAccessObjectDecision(value), ok
+}
+
+func cloneSemanticAccessObjectDecision(value SemanticAccessObjectDecision) SemanticAccessObjectDecision {
+	value.DeniedGrants = append([]string(nil), value.DeniedGrants...)
+	value.DeniedDatasets = append([]string(nil), value.DeniedDatasets...)
+	if value.Predicate != nil {
+		clone := clonePlanIRPredicate(*value.Predicate)
+		value.Predicate = &clone
+	}
+	value.DatasetPredicates = cloneSemanticAccessDatasetPredicates(value.DatasetPredicates)
+	return value
+}
+
+func cloneSemanticAccessDatasetPredicates(values map[string]planir.Predicate) map[string]planir.Predicate {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make(map[string]planir.Predicate, len(values))
+	for dataset, predicate := range values {
+		result[dataset] = clonePlanIRPredicate(predicate)
+	}
+	return result
+}
+
+func clonePlanIRPredicate(value planir.Predicate) planir.Predicate {
+	value.Values = append([]planir.Literal(nil), value.Values...)
+	value.Children = append([]planir.Predicate(nil), value.Children...)
+	for index := range value.Children {
+		value.Children[index] = clonePlanIRPredicate(value.Children[index])
+	}
+	if value.Spatial != nil {
+		spatial := *value.Spatial
+		spatial.Points = append([]planir.SpatialPoint(nil), value.Spatial.Points...)
+		value.Spatial = &spatial
+	}
+	return value
+}
+
+// EffectiveSemanticAttributeDigest returns the ordered, profile-qualified
+// projection used in authorization identity. It includes value digests but not
+// raw canonical values.
+func EffectiveSemanticAttributeDigest(attributes []access.EffectiveSemanticAttribute) (string, error) {
+	validated, err := validateEffectiveSemanticAttributes(attributes)
+	if err != nil {
+		return "", err
+	}
+	type attributeWire struct {
+		DefinitionID      string                        `json:"definitionId"`
+		DefinitionVersion int64                         `json:"definitionVersion"`
+		Type              semanticvalue.Type            `json:"type"`
+		Shape             access.SemanticAttributeShape `json:"shape"`
+		ValueDigest       string                        `json:"valueDigest"`
+		Source            string                        `json:"source"`
+	}
+	wire := struct {
+		Profile    string          `json:"profile"`
+		Attributes []attributeWire `json:"attributes"`
+	}{Profile: semanticvalue.Profile, Attributes: make([]attributeWire, len(validated))}
+	for index, attribute := range validated {
+		wire.Attributes[index] = attributeWire{DefinitionID: attribute.DefinitionID,
+			DefinitionVersion: attribute.DefinitionVersion, Type: attribute.Type, Shape: attribute.Shape,
+			ValueDigest: attribute.ValueDigest, Source: attribute.Source}
+	}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return "", fmt.Errorf("%w: encode effective attribute identity: %v", ErrSemanticAccessSnapshotInvalid, err)
+	}
+	return semanticAccessDigest(encoded), nil
+}
+
+// EvaluateSemanticAccess evaluates every authored grant and lowers every
+// satisfiable dataset filter to a closed typed PlanIR predicate. Denied access
+// is represented in the returned decision; malformed/stale authority returns
+// an error and never an unfiltered decision.
+func EvaluateSemanticAccess(policy *CompiledSemanticAccessPolicy, snapshot SemanticAccessAttributeSnapshot, current SemanticAccessAuthority) (*SemanticAccessDecision, error) {
+	if policy == nil || policy.Digest() == "" {
+		return nil, fmt.Errorf("%w: compiled policy is required", ErrSemanticAccessSnapshotInvalid)
+	}
+	attributes, directEvidenceDigest, trustedClaimEvidenceDigest, err := validateSemanticAccessSnapshot(policy, snapshot, current)
+	if err != nil {
+		return nil, err
+	}
+	decision := &SemanticAccessDecision{Profile: semanticvalue.Profile, InstanceID: snapshot.InstanceID,
+		SemanticModelID: policy.semanticModelID, SemanticGeneration: policy.semanticGeneration,
+		PrincipalID: snapshot.PrincipalID, ActorID: snapshot.ActorID, Registry: snapshot.Registry.State, Control: snapshot.Control.State,
+		EffectiveAttributeDigest: snapshot.EffectiveAttributeDigest, DirectAssignmentEvidenceDigest: directEvidenceDigest,
+		TrustedClaimEvidenceDigest: trustedClaimEvidenceDigest, PolicyDigest: policy.digest,
+		datasets: map[string]SemanticAccessObjectDecision{}, dimensions: map[string]map[string]SemanticAccessObjectDecision{}, metrics: map[string]SemanticAccessObjectDecision{}}
+
+	grantAllowed := make(map[string]bool, len(policy.grants))
+	for _, name := range sortedStringKeys(policy.grants) {
+		grant := policy.grants[name]
+		attribute, present := attributes[grant.DefinitionID]
+		if present {
+			if err := validateEffectiveAttributeReference(attribute, grant.DefinitionID, grant.UserAttribute, grant.DefinitionVersion, grant.Type, grant.Shape); err != nil {
+				return nil, err
+			}
+		}
+		allowed := present && effectiveAttributeMatchesGrant(attribute, grant)
+		grantAllowed[name] = allowed
+		decision.GrantResults = append(decision.GrantResults, SemanticAccessGrantDecision{Name: name, DefinitionID: grant.DefinitionID, Allowed: allowed})
+	}
+
+	for _, name := range sortedStringKeys(policy.datasets) {
+		compiled := policy.datasets[name]
+		object := semanticAccessRequirementDecision(name, name, compiled.RequiredAccessGrants, grantAllowed)
+		var predicates []planir.Predicate
+		for _, filter := range compiled.AccessFilters {
+			attribute, present := attributes[filter.DefinitionID]
+			if !present {
+				object.Allowed = false
+				object.DeniedDatasets = appendUniqueSorted(object.DeniedDatasets, name)
+				continue
+			}
+			if err := validateEffectiveAttributeReference(attribute, filter.DefinitionID, filter.UserAttribute, filter.DefinitionVersion, filter.Type, filter.Shape); err != nil {
+				return nil, err
+			}
+			predicate, err := semanticAccessFilterPredicate(filter, attribute)
+			if err != nil {
+				return nil, err
+			}
+			predicates = append(predicates, predicate)
+			decision.FilterEvidence = append(decision.FilterEvidence, SemanticAccessFilterEvidence{Dataset: name, Dimension: filter.Dimension,
+				DefinitionID: filter.DefinitionID, ValueDigest: attribute.ValueDigest, PredicateKind: string(predicate.Kind)})
+		}
+		if object.Allowed {
+			object.Predicate = combinedSemanticAccessPredicate(predicates)
+		}
+		decision.datasets[name] = object
+	}
+
+	for _, name := range sortedStringKeys(policy.dimensions) {
+		decision.dimensions[name] = map[string]SemanticAccessObjectDecision{}
+		for _, dataset := range sortedStringKeys(policy.dimensions[name]) {
+			compiled := policy.dimensions[name][dataset]
+			object := semanticAccessRequirementDecision(name, dataset, compiled.RequiredAccessGrants, grantAllowed)
+			inheritDatasetDecisions(&object, compiled.Datasets, decision.datasets)
+			decision.dimensions[name][dataset] = object
+		}
+	}
+	for _, name := range sortedStringKeys(policy.metrics) {
+		compiled := policy.metrics[name]
+		object := semanticAccessRequirementDecision(name, "", compiled.RequiredAccessGrants, grantAllowed)
+		object.DeniedDatasets = deniedSemanticDatasets(compiled.Datasets, decision.datasets)
+		if len(object.DeniedDatasets) != 0 {
+			object.Allowed = false
+		}
+		if object.Allowed {
+			object.DatasetPredicates = semanticAccessDatasetPredicates(compiled.Datasets, decision.datasets)
+		}
+		decision.metrics[name] = object
+	}
+
+	identity, err := semanticAccessDecisionIdentity(decision)
+	if err != nil {
+		return nil, err
+	}
+	decision.IdentityDigest = semanticAccessDigest(identity)
+	return decision, nil
+}
+
+func validateSemanticAccessSnapshot(policy *CompiledSemanticAccessPolicy, snapshot SemanticAccessAttributeSnapshot, current SemanticAccessAuthority) (map[string]access.EffectiveSemanticAttribute, string, string, error) {
+	if err := validateSemanticIdentity("instance id", snapshot.InstanceID); err != nil {
+		return nil, "", "", fmt.Errorf("%w: %v", ErrSemanticAccessSnapshotInvalid, err)
+	}
+	if err := validateSemanticIdentity("principal id", snapshot.PrincipalID); err != nil {
+		return nil, "", "", fmt.Errorf("%w: %v", ErrSemanticAccessSnapshotInvalid, err)
+	}
+	if snapshot.ActorID != "" {
+		if err := validateSemanticIdentity("actor id", snapshot.ActorID); err != nil {
+			return nil, "", "", fmt.Errorf("%w: %v", ErrSemanticAccessSnapshotInvalid, err)
+		}
+	}
+	if snapshot.InstanceID != policy.targetInstanceID {
+		return nil, "", "", fmt.Errorf("%w: target instance does not match compiled policy", ErrSemanticAccessSnapshotInvalid)
+	}
+	if current.InstanceID != policy.targetInstanceID || current.InstanceID != snapshot.InstanceID {
+		return nil, "", "", fmt.Errorf("%w: current authority target instance is inconsistent", ErrSemanticAccessSnapshotInvalid)
+	}
+	if current.ObservedAt.IsZero() || !current.ObservedAt.Equal(current.ObservedAt.UTC()) {
+		return nil, "", "", fmt.Errorf("%w: current authority observation time is invalid", ErrSemanticAccessSnapshotInvalid)
+	}
+	if err := validateRegistrySnapshot(snapshot.Registry); err != nil {
+		return nil, "", "", fmt.Errorf("%w: captured registry identity is invalid", ErrSemanticAccessSnapshotInvalid)
+	}
+	if err := validateRegistrySnapshot(current.Registry); err != nil {
+		return nil, "", "", fmt.Errorf("%w: current registry identity is invalid", ErrSemanticAccessSnapshotInvalid)
+	}
+	if err := validateControlSnapshot(snapshot.Control); err != nil {
+		return nil, "", "", err
+	}
+	if err := validateControlSnapshot(current.Control); err != nil {
+		return nil, "", "", err
+	}
+	if err := validateSemanticAccessAuthorityRows(snapshot.Registry, snapshot.Control); err != nil {
+		return nil, "", "", err
+	}
+	if err := validateSemanticAccessAuthorityRows(current.Registry, current.Control); err != nil {
+		return nil, "", "", err
+	}
+	if !sameRegistryState(policy.registry, snapshot.Registry.State) || !sameRegistryState(snapshot.Registry.State, current.Registry.State) {
+		return nil, "", "", fmt.Errorf("%w: registry identity is stale or inconsistent", ErrSemanticAccessSnapshotInvalid)
+	}
+	if !sameControlState(snapshot.Control.State, current.Control.State) {
+		return nil, "", "", fmt.Errorf("%w: control identity is stale or inconsistent", ErrSemanticAccessSnapshotInvalid)
+	}
+	digest, err := EffectiveSemanticAttributeDigest(snapshot.EffectiveAttributes)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if snapshot.EffectiveAttributeDigest == "" || digest != snapshot.EffectiveAttributeDigest {
+		return nil, "", "", fmt.Errorf("%w: effective attribute digest mismatch", ErrSemanticAccessSnapshotInvalid)
+	}
+	directEvidenceDigest, err := validateSemanticAccessDirectAssignments(snapshot)
+	if err != nil {
+		return nil, "", "", err
+	}
+	trustedClaimEvidenceDigest, err := validateSemanticAccessTrustedClaims(snapshot, current.ObservedAt)
+	if err != nil {
+		return nil, "", "", err
+	}
+	attributes := make(map[string]access.EffectiveSemanticAttribute, len(snapshot.EffectiveAttributes))
+	for _, attribute := range snapshot.EffectiveAttributes {
+		attributes[attribute.DefinitionID] = attribute
+	}
+	return attributes, directEvidenceDigest, trustedClaimEvidenceDigest, nil
+}
+
+func validateSemanticAccessDirectAssignments(snapshot SemanticAccessAttributeSnapshot) (string, error) {
+	direct := false
+	for _, attribute := range snapshot.EffectiveAttributes {
+		if attribute.Source == "direct" || attribute.Source == "direct+trusted_claim" {
+			direct = true
+			break
+		}
+	}
+	if !direct {
+		if snapshot.DirectAssignmentEvidence.Digest() != "" {
+			return "", fmt.Errorf("%w: direct assignment evidence is present without direct attributes", ErrSemanticAccessSnapshotInvalid)
+		}
+		return "", nil
+	}
+	if !snapshot.DirectAssignmentEvidence.Matches(snapshot.InstanceID, snapshot.PrincipalID, snapshot.Control.State, snapshot.EffectiveAttributes) {
+		return "", fmt.Errorf("%w: verified direct assignment evidence does not match effective attributes", ErrSemanticAccessSnapshotInvalid)
+	}
+	return snapshot.DirectAssignmentEvidence.Digest(), nil
+}
+
+func validateSemanticAccessTrustedClaims(snapshot SemanticAccessAttributeSnapshot, observedAt time.Time) (string, error) {
+	claimDerived := false
+	for _, attribute := range snapshot.EffectiveAttributes {
+		if attribute.Source == "trusted_claim" || attribute.Source == "direct+trusted_claim" {
+			claimDerived = true
+			break
+		}
+	}
+	if !claimDerived {
+		if snapshot.TrustedClaimEvidence.Digest() != "" {
+			return "", fmt.Errorf("%w: trusted claim evidence is present without claim-derived attributes", ErrSemanticAccessSnapshotInvalid)
+		}
+		return "", nil
+	}
+	if !snapshot.TrustedClaimEvidence.Matches(snapshot.InstanceID, snapshot.PrincipalID, snapshot.Control.State, snapshot.EffectiveAttributes) {
+		return "", fmt.Errorf("%w: verified trusted claim evidence does not match effective attributes", ErrSemanticAccessSnapshotInvalid)
+	}
+	if !snapshot.TrustedClaimEvidence.ValidAt(observedAt) {
+		return "", fmt.Errorf("%w: trusted claim evidence is expired, future, or otherwise invalid", ErrSemanticAccessSnapshotInvalid)
+	}
+	return snapshot.TrustedClaimEvidence.Digest(), nil
+}
+
+func validateRegistrySnapshot(snapshot access.SemanticAttributeRegistrySnapshot) error {
+	if err := access.ValidateSemanticAttributeRegistrySnapshot(snapshot); err != nil {
+		return fmt.Errorf("%w: %v", ErrSemanticAccessSnapshotInvalid, err)
+	}
+	return nil
+}
+
+func validateControlSnapshot(snapshot access.SemanticAttributeControlSnapshot) error {
+	if err := access.ValidateSemanticAttributeControlSnapshot(snapshot); err != nil {
+		return fmt.Errorf("%w: %v", ErrSemanticAccessSnapshotInvalid, err)
+	}
+	return nil
+}
+
+func validateSemanticAccessAuthorityRows(registry access.SemanticAttributeRegistrySnapshot, control access.SemanticAttributeControlSnapshot) error {
+	definitions := make(map[string]access.SemanticAttributeDefinition, len(registry.Definitions))
+	for _, definition := range registry.Definitions {
+		definitions[definition.ID] = definition
+	}
+	validateReference := func(id, name string, version int64, typeName semanticvalue.Type, shape access.SemanticAttributeShape, active bool) error {
+		definition, ok := definitions[id]
+		if !ok || definition.Name != name || version <= 0 || version > definition.DefinitionVersion || definition.Type != typeName || definition.Shape != shape {
+			return fmt.Errorf("%w: control row does not match registry definition %q", ErrSemanticAccessSnapshotInvalid, name)
+		}
+		if active && (!definition.Enabled || definition.LifecycleState != access.SemanticAttributeActive) {
+			return fmt.Errorf("%w: active control row references disabled definition %q", ErrSemanticAccessSnapshotInvalid, name)
+		}
+		return nil
+	}
+	for _, assignment := range control.Assignments {
+		if err := validateReference(assignment.DefinitionID, assignment.DefinitionName, assignment.DefinitionVersion, assignment.Type, assignment.Shape, !assignment.Tombstoned); err != nil {
+			return err
+		}
+	}
+	for _, mapping := range control.Mappings {
+		if err := validateReference(mapping.DefinitionID, mapping.DefinitionName, mapping.DefinitionVersion, mapping.Type, mapping.Shape, !mapping.Tombstoned); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateControlState(state access.SemanticAttributeControlState) error {
+	if state.Profile != semanticvalue.Profile || state.Revision < 0 || !canonicalSHA256.MatchString(state.Digest) {
+		return fmt.Errorf("%w: control state identity is invalid", ErrSemanticAccessSnapshotInvalid)
+	}
+	return nil
+}
+
+func sameRegistryState(left, right access.SemanticAttributeRegistryState) bool {
+	return left.Profile == right.Profile && left.Revision == right.Revision && left.Digest == right.Digest
+}
+
+func sameControlState(left, right access.SemanticAttributeControlState) bool {
+	return left.Profile == right.Profile && left.Revision == right.Revision && left.Digest == right.Digest
+}
+
+func validateEffectiveSemanticAttributes(values []access.EffectiveSemanticAttribute) ([]access.EffectiveSemanticAttribute, error) {
+	result := append([]access.EffectiveSemanticAttribute(nil), values...)
+	sort.Slice(result, func(i, j int) bool { return result[i].DefinitionID < result[j].DefinitionID })
+	names := map[string]struct{}{}
+	for index := range result {
+		attribute := &result[index]
+		if attribute.DefinitionID == "" || attribute.DefinitionVersion <= 0 || !semanticAccessTypeSupported(attribute.Type) || !attribute.Shape.Valid() {
+			return nil, fmt.Errorf("%w: effective attribute definition identity is invalid", ErrSemanticAccessSnapshotInvalid)
+		}
+		if err := semanticvalue.ValidateAttributeName(attribute.DefinitionName); err != nil {
+			return nil, fmt.Errorf("%w: effective attribute name is invalid", ErrSemanticAccessSnapshotInvalid)
+		}
+		if index > 0 && result[index-1].DefinitionID == attribute.DefinitionID {
+			return nil, fmt.Errorf("%w: duplicate effective attribute definition id", ErrSemanticAccessSnapshotInvalid)
+		}
+		if _, duplicate := names[attribute.DefinitionName]; duplicate {
+			return nil, fmt.Errorf("%w: duplicate effective attribute name", ErrSemanticAccessSnapshotInvalid)
+		}
+		names[attribute.DefinitionName] = struct{}{}
+		if attribute.Source != "direct" && attribute.Source != "trusted_claim" && attribute.Source != "direct+trusted_claim" {
+			return nil, fmt.Errorf("%w: effective attribute source is invalid", ErrSemanticAccessSnapshotInvalid)
+		}
+		canonical, digest, err := validateCanonicalEffectiveValues(*attribute)
+		if err != nil {
+			return nil, err
+		}
+		if digest != attribute.ValueDigest {
+			return nil, fmt.Errorf("%w: effective attribute value digest mismatch", ErrSemanticAccessSnapshotInvalid)
+		}
+		attribute.CanonicalValues = canonical
+	}
+	return result, nil
+}
+
+func validateCanonicalEffectiveValues(attribute access.EffectiveSemanticAttribute) ([]string, string, error) {
+	if attribute.Shape == access.SemanticAttributeScalar && len(attribute.CanonicalValues) != 1 {
+		return nil, "", fmt.Errorf("%w: scalar effective attribute requires one value", ErrSemanticAccessSnapshotInvalid)
+	}
+	if attribute.Shape == access.SemanticAttributeList && (len(attribute.CanonicalValues) == 0 || len(attribute.CanonicalValues) > semanticvalue.MaxSetValues) {
+		return nil, "", fmt.Errorf("%w: list effective attribute cardinality is invalid", ErrSemanticAccessSnapshotInvalid)
+	}
+	inputs := make([]any, len(attribute.CanonicalValues))
+	for index, value := range attribute.CanonicalValues {
+		input, err := canonicalSemanticAccessInput(attribute.Type, value)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: effective attribute value is invalid", ErrSemanticAccessSnapshotInvalid)
+		}
+		inputs[index] = input
+	}
+	if attribute.Shape == access.SemanticAttributeScalar {
+		value, err := semanticvalue.Canonicalize(attribute.Type, inputs[0])
+		if err != nil || value.Canonical() != attribute.CanonicalValues[0] {
+			return nil, "", fmt.Errorf("%w: scalar effective attribute is not canonical", ErrSemanticAccessSnapshotInvalid)
+		}
+		return []string{value.Canonical()}, value.Digest(), nil
+	}
+	set, err := semanticvalue.CanonicalizeSet(attribute.Type, inputs)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: list effective attribute is invalid", ErrSemanticAccessSnapshotInvalid)
+	}
+	values := set.Values()
+	canonical := make([]string, len(values))
+	for index := range values {
+		canonical[index] = values[index].Canonical()
+	}
+	if len(canonical) != len(attribute.CanonicalValues) {
+		return nil, "", fmt.Errorf("%w: list effective attribute contains duplicates", ErrSemanticAccessSnapshotInvalid)
+	}
+	for index := range canonical {
+		if canonical[index] != attribute.CanonicalValues[index] {
+			return nil, "", fmt.Errorf("%w: list effective attribute is not canonically ordered", ErrSemanticAccessSnapshotInvalid)
+		}
+	}
+	return canonical, set.Digest(), nil
+}
+
+func canonicalSemanticAccessInput(typeName semanticvalue.Type, value string) (any, error) {
+	switch typeName {
+	case semanticvalue.TypeString, semanticvalue.TypeDate, semanticvalue.TypeTimestamp:
+		return value, nil
+	case semanticvalue.TypeBoolean:
+		if value != "true" && value != "false" {
+			return nil, fmt.Errorf("invalid boolean")
+		}
+		return value == "true", nil
+	case semanticvalue.TypeInteger, semanticvalue.TypeDecimal:
+		return json.Number(value), nil
+	default:
+		return nil, fmt.Errorf("unsupported type")
+	}
+}
+
+func effectiveAttributeMatchesGrant(attribute access.EffectiveSemanticAttribute, grant CompiledSemanticAccessGrant) bool {
+	if validateEffectiveAttributeReference(attribute, grant.DefinitionID, grant.UserAttribute, grant.DefinitionVersion, grant.Type, grant.Shape) != nil {
+		return false
+	}
+	allowed := make(map[string]struct{}, len(grant.AllowedValues))
+	for _, value := range grant.AllowedValues {
+		allowed[value] = struct{}{}
+	}
+	for _, value := range attribute.CanonicalValues {
+		if _, ok := allowed[value]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func validateEffectiveAttributeReference(attribute access.EffectiveSemanticAttribute, definitionID, name string, version int64, typeName semanticvalue.Type, shape access.SemanticAttributeShape) error {
+	if attribute.DefinitionID != definitionID || attribute.DefinitionName != name || attribute.DefinitionVersion != version || attribute.Type != typeName || attribute.Shape != shape {
+		return fmt.Errorf("%w: effective attribute does not match compiled definition identity", ErrSemanticAccessSnapshotInvalid)
+	}
+	return nil
+}
+
+func semanticAccessFilterPredicate(filter CompiledSemanticAccessFilter, attribute access.EffectiveSemanticAttribute) (planir.Predicate, error) {
+	values := make([]planir.Literal, len(attribute.CanonicalValues))
+	for index, value := range attribute.CanonicalValues {
+		literal, err := semanticAccessPlanIRLiteral(attribute.Type, value)
+		if err != nil {
+			return planir.Predicate{}, err
+		}
+		values[index] = literal
+	}
+	if attribute.Shape == access.SemanticAttributeScalar {
+		return planir.Predicate{Kind: planir.PredicateCompare, Field: filter.Field, Operator: "=", Value: values[0]}, nil
+	}
+	return planir.Predicate{Kind: planir.PredicateIn, Field: filter.Field, Values: values}, nil
+}
+
+func semanticAccessPlanIRLiteral(typeName semanticvalue.Type, value string) (planir.Literal, error) {
+	switch typeName {
+	case semanticvalue.TypeString, semanticvalue.TypeDate, semanticvalue.TypeTimestamp:
+		return planir.Literal{Kind: planir.LiteralString, String: value}, nil
+	case semanticvalue.TypeBoolean:
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return planir.Literal{}, fmt.Errorf("%w: invalid canonical boolean", ErrSemanticAccessSnapshotInvalid)
+		}
+		return planir.Literal{Kind: planir.LiteralBool, Bool: parsed}, nil
+	case semanticvalue.TypeInteger:
+		return planir.Literal{Kind: planir.LiteralNumber, NumberText: value, NumberKind: planir.NumberInteger}, nil
+	case semanticvalue.TypeDecimal:
+		return planir.Literal{Kind: planir.LiteralNumber, NumberText: value, NumberKind: planir.NumberDecimal}, nil
+	default:
+		return planir.Literal{}, fmt.Errorf("%w: unsupported predicate value type", ErrSemanticAccessSnapshotInvalid)
+	}
+}
+
+func combinedSemanticAccessPredicate(values []planir.Predicate) *planir.Predicate {
+	if len(values) == 0 {
+		return nil
+	}
+	if len(values) == 1 {
+		value := values[0]
+		return &value
+	}
+	return &planir.Predicate{Kind: planir.PredicateAnd, Children: append([]planir.Predicate(nil), values...)}
+}
+
+func semanticAccessRequirementDecision(name, dataset string, required []string, allowed map[string]bool) SemanticAccessObjectDecision {
+	decision := SemanticAccessObjectDecision{Name: name, Dataset: dataset, Allowed: true}
+	for _, grant := range required {
+		if !allowed[grant] {
+			decision.Allowed = false
+			decision.DeniedGrants = append(decision.DeniedGrants, grant)
+		}
+	}
+	return decision
+}
+
+func inheritDatasetDecisions(object *SemanticAccessObjectDecision, required []string, datasets map[string]SemanticAccessObjectDecision) {
+	if !object.Allowed {
+		return
+	}
+	object.DeniedDatasets = deniedSemanticDatasets(required, datasets)
+	if len(object.DeniedDatasets) != 0 {
+		object.Allowed = false
+		return
+	}
+	dataset, ok := datasets[object.Dataset]
+	if !ok {
+		object.Allowed = false
+		object.DeniedDatasets = appendUniqueSorted(object.DeniedDatasets, object.Dataset)
+		return
+	}
+	if dataset.Predicate != nil {
+		predicate := clonePlanIRPredicate(*dataset.Predicate)
+		object.Predicate = &predicate
+	}
+	object.DatasetPredicates = semanticAccessDatasetPredicates(required, datasets)
+}
+
+func semanticAccessDatasetPredicates(required []string, datasets map[string]SemanticAccessObjectDecision) map[string]planir.Predicate {
+	result := map[string]planir.Predicate{}
+	for _, name := range required {
+		if dataset, ok := datasets[name]; ok && dataset.Predicate != nil {
+			result[name] = clonePlanIRPredicate(*dataset.Predicate)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func deniedSemanticDatasets(names []string, datasets map[string]SemanticAccessObjectDecision) []string {
+	var denied []string
+	for _, name := range names {
+		if dataset, ok := datasets[name]; !ok || !dataset.Allowed {
+			denied = append(denied, name)
+		}
+	}
+	return sortedUnique(denied)
+}
+
+func appendUniqueSorted(values []string, value string) []string {
+	values = append(values, value)
+	return sortedUnique(values)
+}
+
+func semanticAccessDecisionIdentity(decision *SemanticAccessDecision) ([]byte, error) {
+	type objectWire struct {
+		Kind           string   `json:"kind"`
+		Name           string   `json:"name"`
+		Dataset        string   `json:"dataset,omitempty"`
+		Allowed        bool     `json:"allowed"`
+		DeniedGrants   []string `json:"deniedGrants,omitempty"`
+		DeniedDatasets []string `json:"deniedDatasets,omitempty"`
+	}
+	objects := []objectWire{}
+	for _, name := range sortedStringKeys(decision.datasets) {
+		value := decision.datasets[name]
+		objects = append(objects, objectWire{Kind: "dataset", Name: name, Allowed: value.Allowed, DeniedGrants: value.DeniedGrants, DeniedDatasets: value.DeniedDatasets})
+	}
+	for _, name := range sortedStringKeys(decision.dimensions) {
+		for _, dataset := range sortedStringKeys(decision.dimensions[name]) {
+			value := decision.dimensions[name][dataset]
+			objects = append(objects, objectWire{Kind: "dimension", Name: name, Dataset: dataset, Allowed: value.Allowed, DeniedGrants: value.DeniedGrants, DeniedDatasets: value.DeniedDatasets})
+		}
+	}
+	for _, name := range sortedStringKeys(decision.metrics) {
+		value := decision.metrics[name]
+		objects = append(objects, objectWire{Kind: "metric", Name: name, Allowed: value.Allowed, DeniedGrants: value.DeniedGrants, DeniedDatasets: value.DeniedDatasets})
+	}
+	wire := struct {
+		Profile                        string                         `json:"profile"`
+		InstanceID                     string                         `json:"instanceId"`
+		SemanticModelID                string                         `json:"semanticModelId"`
+		SemanticGeneration             string                         `json:"semanticGeneration"`
+		PrincipalID                    string                         `json:"principalId"`
+		ActorID                        string                         `json:"actorId,omitempty"`
+		RegistryProfile                string                         `json:"registryProfile"`
+		RegistryRevision               int64                          `json:"registryRevision"`
+		RegistryDigest                 string                         `json:"registryDigest"`
+		ControlProfile                 string                         `json:"controlProfile"`
+		ControlRevision                int64                          `json:"controlRevision"`
+		ControlDigest                  string                         `json:"controlDigest"`
+		EffectiveAttributeDigest       string                         `json:"effectiveAttributeDigest"`
+		DirectAssignmentEvidenceDigest string                         `json:"directAssignmentEvidenceDigest,omitempty"`
+		TrustedClaimEvidenceDigest     string                         `json:"trustedClaimEvidenceDigest,omitempty"`
+		PolicyDigest                   string                         `json:"policyDigest"`
+		Grants                         []SemanticAccessGrantDecision  `json:"grants"`
+		Filters                        []SemanticAccessFilterEvidence `json:"filters"`
+		Objects                        []objectWire                   `json:"objects"`
+	}{Profile: decision.Profile, InstanceID: decision.InstanceID, SemanticModelID: decision.SemanticModelID,
+		SemanticGeneration: decision.SemanticGeneration, PrincipalID: decision.PrincipalID, ActorID: decision.ActorID,
+		RegistryProfile: decision.Registry.Profile, RegistryRevision: decision.Registry.Revision, RegistryDigest: decision.Registry.Digest,
+		ControlProfile: decision.Control.Profile, ControlRevision: decision.Control.Revision, ControlDigest: decision.Control.Digest,
+		EffectiveAttributeDigest: decision.EffectiveAttributeDigest, DirectAssignmentEvidenceDigest: decision.DirectAssignmentEvidenceDigest,
+		TrustedClaimEvidenceDigest: decision.TrustedClaimEvidenceDigest,
+		PolicyDigest:               decision.PolicyDigest,
+		Grants:                     decision.GrantResults, Filters: decision.FilterEvidence, Objects: objects}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return nil, fmt.Errorf("%w: encode decision identity: %v", ErrSemanticAccessSnapshotInvalid, err)
+	}
+	return encoded, nil
+}

--- a/internal/analytics/query/semantic_access_evaluate_test.go
+++ b/internal/analytics/query/semantic_access_evaluate_test.go
@@ -1,0 +1,446 @@
+package query
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/access/trustedclaims"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/analytics/query/planir"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+type semanticAccessClaimsVerifier struct {
+	claims trustedclaims.VerifiedClaims
+}
+
+func (verifier semanticAccessClaimsVerifier) SourceKind() trustedclaims.SourceKind {
+	return trustedclaims.SourceOIDC
+}
+
+func (verifier semanticAccessClaimsVerifier) Verify(context.Context, []byte) (trustedclaims.VerifiedClaims, error) {
+	return verifier.claims, nil
+}
+
+func semanticAccessTrustedEnvelope(t *testing.T, subject string, now time.Time) trustedclaims.Envelope {
+	t.Helper()
+	claims := trustedclaims.VerifiedClaims{Provider: "identity-provider", Issuer: "https://issuer.example", Audience: "leapview",
+		Subject: subject, IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Minute),
+		TokenFingerprint: strings.Repeat("a", 64), Claims: []trustedclaims.Claim{{Name: "regions", Value: []string{"east", "west"}}}}
+	envelope, err := trustedclaims.Verify(t.Context(), trustedclaims.NewRawEvidence(trustedclaims.SourceOIDC, []byte("signed-evidence")),
+		semanticAccessClaimsVerifier{claims: claims}, trustedclaims.VerifyOptions{Now: now})
+	if err != nil {
+		t.Fatalf("verify trusted claims: %v", err)
+	}
+	return envelope
+}
+
+func TestEvaluateSemanticAccessMatchesGrantsAndBuildsTypedPredicates(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	attributes := semanticAccessEffective(t, semanticAccessDefinitions())
+	snapshot, authority := semanticAccessSnapshot(t, attributes)
+	decision, err := EvaluateSemanticAccess(policy, snapshot, authority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, result := range decision.GrantResults {
+		if !result.Allowed {
+			t.Fatalf("grant %q unexpectedly denied: %#v", result.Name, decision.GrantResults)
+		}
+	}
+	dataset, ok := decision.Dataset("orders")
+	if !ok || !dataset.Allowed || dataset.Predicate == nil || dataset.Predicate.Kind != planir.PredicateAnd || len(dataset.Predicate.Children) != 6 {
+		t.Fatalf("dataset decision = %#v", dataset)
+	}
+	wantKinds := map[string]planir.PredicateKind{
+		"orders.account_id": planir.PredicateIn, "orders.amount": planir.PredicateCompare, "orders.approved": planir.PredicateCompare,
+		"orders.occurred_at": planir.PredicateCompare, "orders.order_date": planir.PredicateCompare, "orders.region": planir.PredicateIn,
+	}
+	for _, predicate := range dataset.Predicate.Children {
+		if predicate.Kind != wantKinds[predicate.Field] {
+			t.Fatalf("predicate for %q = %#v", predicate.Field, predicate)
+		}
+		if predicate.Field == "orders.account_id" && (len(predicate.Values) != 2 || predicate.Values[1].NumberText != "9007199254740993" || predicate.Values[1].NumberKind != planir.NumberInteger) {
+			t.Fatalf("integer predicate lost exactness: %#v", predicate)
+		}
+		if predicate.Field == "orders.amount" && (predicate.Value.NumberText != "9007199254740993.125" || predicate.Value.NumberKind != planir.NumberDecimal) {
+			t.Fatalf("decimal predicate lost exactness: %#v", predicate)
+		}
+	}
+	for _, name := range []string{"revenue", "doubledRevenue", "averageRevenue"} {
+		metric, ok := decision.Metric(name)
+		if !ok || !metric.Allowed {
+			t.Fatalf("metric %q decision = %#v", name, metric)
+		}
+	}
+	if !strings.HasPrefix(decision.IdentityDigest, "sha256:") || len(decision.FilterEvidence) != 6 {
+		t.Fatalf("decision identity/evidence = %q %#v", decision.IdentityDigest, decision.FilterEvidence)
+	}
+}
+
+func TestEvaluateSemanticAccessIsIndependentOfAttributeOrdering(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	attributes := semanticAccessEffective(t, semanticAccessDefinitions())
+	firstSnapshot, firstAuthority := semanticAccessSnapshot(t, attributes)
+	first, err := EvaluateSemanticAccess(policy, firstSnapshot, firstAuthority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondSnapshot, secondAuthority := semanticAccessSnapshot(t, reverseEffectiveAttributes(attributes))
+	second, err := EvaluateSemanticAccess(policy, secondSnapshot, secondAuthority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.IdentityDigest != second.IdentityDigest || first.EffectiveAttributeDigest != second.EffectiveAttributeDigest || !reflect.DeepEqual(first.GrantResults, second.GrantResults) {
+		t.Fatalf("evaluation depends on presentation order: %#v != %#v", first, second)
+	}
+}
+
+func TestEvaluateSemanticAccessMissingAttributeDeniesWithoutAdminBypass(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	attributes := semanticAccessEffective(t, semanticAccessDefinitions())
+	filtered := attributes[:0]
+	for _, attribute := range attributes {
+		if attribute.DefinitionName != "regions" {
+			filtered = append(filtered, attribute)
+		}
+	}
+	snapshot, authority := semanticAccessSnapshotForPrincipal(t, "administrator", filtered)
+	decision, err := EvaluateSemanticAccess(policy, snapshot, authority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataset, _ := decision.Dataset("orders")
+	if dataset.Allowed || dataset.Predicate != nil || !reflect.DeepEqual(dataset.DeniedDatasets, []string{"orders"}) {
+		t.Fatalf("missing attribute did not fail closed: %#v", dataset)
+	}
+	metric, _ := decision.Metric("revenue")
+	if metric.Allowed || !reflect.DeepEqual(metric.DeniedDatasets, []string{"orders"}) {
+		t.Fatalf("protected metric did not inherit dataset denial: %#v", metric)
+	}
+}
+
+func TestEvaluateSemanticAccessRequiredGrantsUseLogicalAND(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	grant := model.AccessPolicy.AccessGrants["canViewSales"]
+	grant.AllowedValues = append([]semanticmodel.SemanticAccessLiteral(nil), grant.AllowedValues...)
+	grant.AllowedValues[0].Text = "engineering"
+	grant.AllowedValues = grant.AllowedValues[:1]
+	model.AccessPolicy.AccessGrants["engineeringOnly"] = grant
+	dataset := model.AccessPolicy.Datasets["orders"]
+	dataset.RequiredAccessGrants = []string{"engineeringOnly", "canViewSales"}
+	model.AccessPolicy.Datasets["orders"] = dataset
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	decision, err := EvaluateSemanticAccess(policy, snapshot, authority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orders, _ := decision.Dataset("orders")
+	if orders.Allowed || !reflect.DeepEqual(orders.DeniedGrants, []string{"engineeringOnly"}) {
+		t.Fatalf("conflicting required grants did not use AND: %#v", orders)
+	}
+}
+
+func TestEvaluateSemanticAccessDeniedMembersDoNotExposeDatasetPredicates(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	attributes := semanticAccessEffective(t, semanticAccessDefinitions())
+	for index := range attributes {
+		if attributes[index].DefinitionName != "accountIds" {
+			continue
+		}
+		definition := semanticAccessDefinitions()[0]
+		var err error
+		attributes[index].CanonicalValues, attributes[index].ValueDigest, err = access.CanonicalSemanticAttributeValues(definition, []int{8})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, authority := semanticAccessSnapshot(t, attributes)
+	decision, err := EvaluateSemanticAccess(policy, snapshot, authority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dimension, ok := decision.Dimension("region", "orders")
+	if !ok || dimension.Allowed || dimension.Predicate != nil || len(dimension.DatasetPredicates) != 0 {
+		t.Fatalf("denied dimension retained predicates: %#v", dimension)
+	}
+	metric, ok := decision.Metric("revenue")
+	if !ok || metric.Allowed || metric.Predicate != nil || len(metric.DatasetPredicates) != 0 {
+		t.Fatalf("denied metric retained predicates: %#v", metric)
+	}
+}
+
+func TestEvaluateSemanticAccessRejectsStaleRegistryAndControlSnapshots(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	attributes := semanticAccessEffective(t, semanticAccessDefinitions())
+	cases := []struct {
+		name   string
+		change func(*SemanticAccessAttributeSnapshot, *SemanticAccessAuthority)
+	}{
+		{name: "captured registry", change: func(snapshot *SemanticAccessAttributeSnapshot, _ *SemanticAccessAuthority) {
+			snapshot.Registry.State.Revision--
+			snapshot.Registry.Definitions = replaceDefinition(snapshot.Registry.Definitions, "regions", func(value *access.SemanticAttributeDefinition) { value.Metadata.DisplayName = "changed" })
+			snapshot.Registry.State.Digest, _ = access.SemanticAttributeRegistryDigest(snapshot.Registry.State.Profile, snapshot.Registry.Definitions)
+		}},
+		{name: "current registry", change: func(_ *SemanticAccessAttributeSnapshot, authority *SemanticAccessAuthority) {
+			authority.Registry.State.Revision++
+			authority.Registry.Definitions = replaceDefinition(authority.Registry.Definitions, "regions", func(value *access.SemanticAttributeDefinition) { value.Metadata.DisplayName = "changed" })
+			authority.Registry.State.Digest, _ = access.SemanticAttributeRegistryDigest(authority.Registry.State.Profile, authority.Registry.Definitions)
+		}},
+		{name: "current control", change: func(_ *SemanticAccessAttributeSnapshot, authority *SemanticAccessAuthority) {
+			authority.Control.State.Revision++
+		}},
+		{name: "captured control", change: func(snapshot *SemanticAccessAttributeSnapshot, _ *SemanticAccessAuthority) {
+			snapshot.Control.State.Revision--
+		}},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot, authority := semanticAccessSnapshot(t, attributes)
+			test.change(&snapshot, &authority)
+			_, err := EvaluateSemanticAccess(policy, snapshot, authority)
+			requireSemanticAccessError(t, err, "stale or inconsistent")
+		})
+	}
+}
+
+func TestEvaluateSemanticAccessRejectsCrossInstanceSnapshot(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	snapshot.InstanceID = "instance-2"
+	_, err := EvaluateSemanticAccess(policy, snapshot, authority)
+	requireSemanticAccessError(t, err, "target instance")
+
+	snapshot, authority = semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	authority.InstanceID = "instance-2"
+	_, err = EvaluateSemanticAccess(policy, snapshot, authority)
+	requireSemanticAccessError(t, err, "current authority target instance")
+}
+
+func TestEvaluateSemanticAccessRejectsUnverifiedAuthorityContents(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	attributes := semanticAccessEffective(t, semanticAccessDefinitions())
+	snapshot, authority := semanticAccessSnapshot(t, attributes)
+	snapshot.Registry.Definitions[0].Metadata.DisplayName = "tampered"
+	_, err := EvaluateSemanticAccess(policy, snapshot, authority)
+	requireSemanticAccessError(t, err, "captured registry identity")
+
+	snapshot, authority = semanticAccessSnapshot(t, attributes)
+	snapshot.Control.Mappings = []access.TrustedClaimMapping{{ID: "tampered"}}
+	_, err = EvaluateSemanticAccess(policy, snapshot, authority)
+	requireSemanticAccessError(t, err, "control state is corrupt")
+
+	snapshot, authority = semanticAccessSnapshot(t, attributes)
+	authority.ObservedAt = time.Time{}
+	_, err = EvaluateSemanticAccess(policy, snapshot, authority)
+	requireSemanticAccessError(t, err, "observation time")
+
+	snapshot, authority = semanticAccessSnapshot(t, attributes)
+	snapshot.Control.Assignments[0].DefinitionName = "wrongName"
+	authority.Control = snapshot.Control
+	_, err = EvaluateSemanticAccess(policy, snapshot, authority)
+	requireSemanticAccessError(t, err, "does not match registry definition")
+}
+
+func TestEvaluateSemanticAccessRequiresDirectAssignmentEvidence(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	attributes := semanticAccessEffective(t, semanticAccessDefinitions())
+	snapshot, authority := semanticAccessSnapshot(t, attributes)
+	snapshot.DirectAssignmentEvidence = access.SemanticAttributeDirectEvidence{}
+	_, err := EvaluateSemanticAccess(policy, snapshot, authority)
+	requireSemanticAccessError(t, err, "direct assignment evidence")
+
+	snapshot, authority = semanticAccessSnapshot(t, attributes)
+	definition := semanticAccessDefinitions()[0]
+	snapshot.Control.Assignments[0].CanonicalValues, snapshot.Control.Assignments[0].ValueDigest, err =
+		access.CanonicalSemanticAttributeValues(definition, []int{8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot.Control.State.Digest, err = access.SemanticAttributeControlDigest(snapshot.Control.Assignments, snapshot.Control.Mappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority.Control = snapshot.Control
+	_, err = EvaluateSemanticAccess(policy, snapshot, authority)
+	requireSemanticAccessError(t, err, "direct assignment evidence")
+}
+
+func TestSemanticAccessObjectDecisionRetainsEveryRequiredDatasetPredicate(t *testing.T) {
+	orders := planir.Predicate{Kind: planir.PredicateCompare, Field: "orders.region", Operator: "=", Value: planir.Literal{Kind: planir.LiteralString, String: "west"}}
+	customers := planir.Predicate{Kind: planir.PredicateIn, Field: "customers.account_id", Values: []planir.Literal{{Kind: planir.LiteralNumber, NumberText: "7", NumberKind: planir.NumberInteger}}}
+	datasets := map[string]SemanticAccessObjectDecision{
+		"orders":    {Name: "orders", Dataset: "orders", Allowed: true, Predicate: &orders},
+		"customers": {Name: "customers", Dataset: "customers", Allowed: true, Predicate: &customers},
+	}
+	object := SemanticAccessObjectDecision{Name: "customerRevenue", Dataset: "orders", Allowed: true}
+	inheritDatasetDecisions(&object, []string{"customers", "orders"}, datasets)
+	if !object.Allowed || len(object.DatasetPredicates) != 2 || object.DatasetPredicates["orders"].Field != "orders.region" ||
+		object.DatasetPredicates["customers"].Field != "customers.account_id" {
+		t.Fatalf("joined decision lost governed predicates: %#v", object)
+	}
+	clone := cloneSemanticAccessObjectDecision(object)
+	mutated := clone.DatasetPredicates["customers"]
+	mutated.Values[0].NumberText = "8"
+	clone.DatasetPredicates["customers"] = mutated
+	if object.DatasetPredicates["customers"].Values[0].NumberText != "7" {
+		t.Fatal("cloned decision aliases a dataset predicate")
+	}
+}
+
+func TestEvaluateSemanticAccessBindsClaimDerivedAttributesToVerifiedEvidence(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	attributes := semanticAccessEffective(t, semanticAccessDefinitions())
+	for index := range attributes {
+		if attributes[index].DefinitionName == "regions" {
+			attributes[index].Source = "trusted_claim"
+		}
+	}
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	snapshot, authority := semanticAccessSnapshot(t, attributes)
+	envelope := semanticAccessTrustedEnvelope(t, snapshot.PrincipalID, now)
+	mapping := access.TrustedClaimMapping{ID: "mapping-regions", SourceKind: access.TrustedClaimSourceOIDC,
+		Provider: envelope.Provider(), Issuer: envelope.Issuer(), Audience: envelope.Audience(), Claim: "regions",
+		DefinitionID: "def-regions", DefinitionName: "regions", DefinitionVersion: 1, Type: semanticvalue.TypeString,
+		Shape: access.SemanticAttributeList, MappingVersion: 1}
+	control := semanticAccessControl(snapshot.Control.Assignments, []access.TrustedClaimMapping{mapping})
+	snapshot.Control = control
+	authority.Control = control
+	authority.ObservedAt = now
+	directEvidence, err := access.NewSemanticAttributeDirectEvidence(snapshot.InstanceID, snapshot.PrincipalID,
+		[]access.SubjectRef{{Kind: access.SubjectKindPrincipal, ID: snapshot.PrincipalID}}, control, attributes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot.DirectAssignmentEvidence = directEvidence
+	evidence, err := access.NewSemanticAttributeClaimEvidence(snapshot.InstanceID, snapshot.PrincipalID, control, attributes, envelope, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot.TrustedClaimEvidence = evidence
+	decision, err := EvaluateSemanticAccess(policy, snapshot, authority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(decision.TrustedClaimEvidenceDigest, "sha256:") {
+		t.Fatalf("trusted claim evidence digest = %q", decision.TrustedClaimEvidenceDigest)
+	}
+
+	missing := snapshot
+	missing.TrustedClaimEvidence = access.SemanticAttributeClaimEvidence{}
+	_, err = EvaluateSemanticAccess(policy, missing, authority)
+	requireSemanticAccessError(t, err, "does not match")
+
+	expiredAuthority := authority
+	expiredAuthority.ObservedAt = now.Add(time.Minute)
+	_, err = EvaluateSemanticAccess(policy, snapshot, expiredAuthority)
+	requireSemanticAccessError(t, err, "expired")
+
+	wrongSubject := snapshot
+	wrongSubject.PrincipalID = "principal-2"
+	_, err = EvaluateSemanticAccess(policy, wrongSubject, authority)
+	requireSemanticAccessError(t, err, "does not match")
+
+	tampered := snapshot
+	tampered.EffectiveAttributes = append([]access.EffectiveSemanticAttribute(nil), snapshot.EffectiveAttributes...)
+	for index := range tampered.EffectiveAttributes {
+		if tampered.EffectiveAttributes[index].DefinitionName == "regions" {
+			tampered.EffectiveAttributes[index].CanonicalValues = []string{"north"}
+			definition := semanticAccessDefinitions()[6]
+			values, digest, valueErr := access.CanonicalSemanticAttributeValues(definition, []string{"north"})
+			if valueErr != nil {
+				t.Fatal(valueErr)
+			}
+			tampered.EffectiveAttributes[index].CanonicalValues = values
+			tampered.EffectiveAttributes[index].ValueDigest = digest
+		}
+	}
+	tampered.EffectiveAttributeDigest, err = EffectiveSemanticAttributeDigest(tampered.EffectiveAttributes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = EvaluateSemanticAccess(policy, tampered, authority)
+	requireSemanticAccessError(t, err, "does not match")
+}
+
+func TestEvaluateSemanticAccessRejectsTamperedEffectiveState(t *testing.T) {
+	policy, _ := compileSemanticAccessTestPolicy(t)
+	base := semanticAccessEffective(t, semanticAccessDefinitions())
+	cases := []struct {
+		name   string
+		change func([]access.EffectiveSemanticAttribute, *SemanticAccessAttributeSnapshot)
+		want   string
+	}{
+		{name: "claimed digest", change: func(_ []access.EffectiveSemanticAttribute, snapshot *SemanticAccessAttributeSnapshot) {
+			snapshot.EffectiveAttributeDigest = "sha256:" + strings.Repeat("c", 64)
+		}, want: "digest mismatch"},
+		{name: "value", change: func(values []access.EffectiveSemanticAttribute, _ *SemanticAccessAttributeSnapshot) {
+			values[0].CanonicalValues[0] = "8"
+		}, want: "value digest mismatch"},
+		{name: "version", change: func(values []access.EffectiveSemanticAttribute, snapshot *SemanticAccessAttributeSnapshot) {
+			values[0].DefinitionVersion++
+			digest, digestErr := EffectiveSemanticAttributeDigest(values)
+			if digestErr != nil {
+				t.Fatal(digestErr)
+			}
+			snapshot.EffectiveAttributeDigest = digest
+		}, want: "direct assignment evidence"},
+		{name: "source", change: func(values []access.EffectiveSemanticAttribute, _ *SemanticAccessAttributeSnapshot) {
+			values[0].Source = "browser"
+		}, want: "source is invalid"},
+		{name: "duplicate id", change: func(values []access.EffectiveSemanticAttribute, _ *SemanticAccessAttributeSnapshot) {
+			values[1].DefinitionID = values[0].DefinitionID
+		}, want: "duplicate effective attribute"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			values := make([]access.EffectiveSemanticAttribute, len(base))
+			for index, value := range base {
+				values[index] = value
+				values[index].CanonicalValues = append([]string(nil), value.CanonicalValues...)
+			}
+			snapshot, authority := semanticAccessSnapshot(t, values)
+			test.change(values, &snapshot)
+			snapshot.EffectiveAttributes = values
+			_, err := EvaluateSemanticAccess(policy, snapshot, authority)
+			requireSemanticAccessError(t, err, test.want)
+		})
+	}
+}
+
+func TestEffectiveSemanticAttributeDigestRejectsEmptyOversizedAndUnorderedLists(t *testing.T) {
+	definition := semanticAccessDefinitions()[0]
+	values, digest, err := access.CanonicalSemanticAttributeValues(definition, []int{1, 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attribute := access.EffectiveSemanticAttribute{DefinitionID: definition.ID, DefinitionName: definition.Name, DefinitionVersion: 1,
+		Type: definition.Type, Shape: definition.Shape, CanonicalValues: values, ValueDigest: digest, Source: "direct"}
+
+	unordered := attribute
+	unordered.CanonicalValues = []string{"2", "1"}
+	_, err = EffectiveSemanticAttributeDigest([]access.EffectiveSemanticAttribute{unordered})
+	requireSemanticAccessError(t, err, "canonically ordered")
+
+	empty := attribute
+	empty.CanonicalValues = nil
+	_, err = EffectiveSemanticAttributeDigest([]access.EffectiveSemanticAttribute{empty})
+	requireSemanticAccessError(t, err, "cardinality")
+
+	oversized := attribute
+	oversized.CanonicalValues = make([]string, semanticvalue.MaxSetValues+1)
+	_, err = EffectiveSemanticAttributeDigest([]access.EffectiveSemanticAttribute{oversized})
+	requireSemanticAccessError(t, err, "cardinality")
+}

--- a/internal/analytics/query/semantic_access_test.go
+++ b/internal/analytics/query/semantic_access_test.go
@@ -1,0 +1,207 @@
+package query
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+const (
+	semanticAccessObservedAt = "2026-09-06T12:00:00Z"
+)
+
+func semanticAccessTestModel(t *testing.T) *semanticmodel.Model {
+	t.Helper()
+	literal := func(value any) semanticmodel.SemanticAccessLiteral {
+		result, err := semanticmodel.NewSemanticAccessLiteral(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	fields := map[string]semanticmodel.MetricDimension{
+		"id":          {Field: "orders.id", Table: "orders", Name: "id", Type: "number", Datatype: semanticmodel.DataTypeInteger},
+		"region":      {Field: "orders.region", Table: "orders", Name: "region", Type: "string", Datatype: semanticmodel.DataTypeString},
+		"account_id":  {Field: "orders.account_id", Table: "orders", Name: "account_id", Type: "number", Datatype: semanticmodel.DataTypeInteger},
+		"amount":      {Field: "orders.amount", Table: "orders", Name: "amount", Type: "number", Datatype: semanticmodel.DataTypeDecimal},
+		"approved":    {Field: "orders.approved", Table: "orders", Name: "approved", Type: "boolean", Datatype: semanticmodel.DataTypeBoolean},
+		"order_date":  {Field: "orders.order_date", Table: "orders", Name: "order_date", Type: "date", Datatype: semanticmodel.DataTypeDate},
+		"occurred_at": {Field: "orders.occurred_at", Table: "orders", Name: "occurred_at", Type: "timestamp", Datatype: semanticmodel.DataTypeDateTimeTZ},
+	}
+	columns := map[string]semanticmodel.ModelColumn{}
+	for name, field := range fields {
+		columns[name] = semanticmodel.ModelColumn{Name: name, SourceField: name, Type: field.Type, Datatype: field.Datatype}
+	}
+	dimension := func(field string, datatype semanticmodel.LogicalDataType) semanticmodel.SemanticDimension {
+		return semanticmodel.SemanticDimension{Datatype: datatype, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders." + field}}}
+	}
+	return &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{"orders": {
+			ModelName: "orders_model", GrainEntity: "order", Entities: map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"id"}}},
+			Dimensions: fields, Columns: columns,
+		}},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders_model"}},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"region": dimension("region", semanticmodel.DataTypeString), "account": dimension("account_id", semanticmodel.DataTypeInteger),
+			"amount": dimension("amount", semanticmodel.DataTypeDecimal), "approved": dimension("approved", semanticmodel.DataTypeBoolean),
+			"orderDate": dimension("order_date", semanticmodel.DataTypeDate), "occurredAt": dimension("occurred_at", semanticmodel.DataTypeDateTimeTZ),
+		},
+		Metrics: map[string]semanticmodel.Metric{
+			"revenue":        {Type: "aggregate", Dataset: "orders", Aggregation: "sum", Input: &semanticmodel.MetricInput{Field: "orders.amount"}},
+			"orderCount":     {Type: "aggregate", Dataset: "orders", Aggregation: "count", Input: &semanticmodel.MetricInput{Field: "orders.id"}},
+			"doubledRevenue": {Type: "derived", Expression: "${revenue} * 2"},
+			"averageRevenue": {Type: "ratio", Numerator: "revenue", Denominator: "orderCount"},
+		},
+		AccessPolicy: semanticmodel.SemanticAccessPolicy{
+			AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{
+				"canViewSales":   {UserAttribute: "department", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal("sales"), literal("finance")}},
+				"canViewAccount": {UserAttribute: "accountIds", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal(json.Number("9007199254740993"))}},
+				"canViewDate":    {UserAttribute: "accessDate", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal("2026-09-06")}},
+				"decimalGate":    {UserAttribute: "amountLimit", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal(json.Number("9007199254740993.1250"))}},
+				"booleanGate":    {UserAttribute: "approval", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal(true)}},
+				"timestampGate":  {UserAttribute: "accessInstant", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal("2026-09-06T03:30:00Z")}},
+			},
+			Datasets: map[string]semanticmodel.SemanticDatasetAccessSpec{"orders": {
+				RequiredAccessGrants: []string{"canViewSales"},
+				AccessFilters: []semanticmodel.SemanticAccessFilterSpec{
+					{Field: "region", UserAttribute: "regions"}, {Field: "account", UserAttribute: "accountIds"},
+					{Field: "amount", UserAttribute: "amountLimit"}, {Field: "approved", UserAttribute: "approval"},
+					{Field: "orderDate", UserAttribute: "accessDate"}, {Field: "occurredAt", UserAttribute: "accessInstant"},
+				},
+			}},
+			Dimensions: map[string][]string{"region": {"canViewAccount"}},
+			Metrics:    map[string][]string{"revenue": {"canViewAccount"}, "doubledRevenue": {"canViewDate"}},
+		},
+	}
+}
+
+func semanticAccessDefinitions() []access.SemanticAttributeDefinition {
+	definition := func(id, name string, typeName semanticvalue.Type, shape access.SemanticAttributeShape) access.SemanticAttributeDefinition {
+		return access.SemanticAttributeDefinition{ID: id, Name: name, Type: typeName, Shape: shape, Profile: semanticvalue.Profile,
+			DefinitionVersion: 1, LifecycleState: access.SemanticAttributeActive, Enabled: true,
+			Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}}}
+	}
+	return []access.SemanticAttributeDefinition{
+		definition("def-account", "accountIds", semanticvalue.TypeInteger, access.SemanticAttributeList),
+		definition("def-date", "accessDate", semanticvalue.TypeDate, access.SemanticAttributeScalar),
+		definition("def-instant", "accessInstant", semanticvalue.TypeTimestamp, access.SemanticAttributeScalar),
+		definition("def-approval", "approval", semanticvalue.TypeBoolean, access.SemanticAttributeScalar),
+		definition("def-amount", "amountLimit", semanticvalue.TypeDecimal, access.SemanticAttributeScalar),
+		definition("def-department", "department", semanticvalue.TypeString, access.SemanticAttributeScalar),
+		definition("def-regions", "regions", semanticvalue.TypeString, access.SemanticAttributeList),
+	}
+}
+
+func semanticAccessRegistry(definitions []access.SemanticAttributeDefinition) access.SemanticAttributeRegistrySnapshot {
+	digest, _ := access.SemanticAttributeRegistryDigest(semanticvalue.Profile, definitions)
+	return access.SemanticAttributeRegistrySnapshot{State: access.SemanticAttributeRegistryState{Profile: semanticvalue.Profile, Revision: 7, Digest: digest}, Definitions: definitions}
+}
+
+func semanticAccessControl(assignments []access.SemanticAttributeAssignment, mappings []access.TrustedClaimMapping) access.SemanticAttributeControlSnapshot {
+	digest, _ := access.SemanticAttributeControlDigest(assignments, mappings)
+	return access.SemanticAttributeControlSnapshot{State: access.SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 11, Digest: digest}, Assignments: assignments, Mappings: mappings}
+}
+
+func compileSemanticAccessTestPolicy(t *testing.T) (*CompiledSemanticAccessPolicy, *semanticmodel.Model) {
+	t.Helper()
+	model := semanticAccessTestModel(t)
+	compiled, err := CompileModel(model)
+	if err != nil {
+		t.Fatalf("CompileModel: %v", err)
+	}
+	policy, err := CompileSemanticAccessPolicy("instance-1", "semantic-model:sales", "generation-9", model, compiled, semanticAccessRegistry(semanticAccessDefinitions()))
+	if err != nil {
+		t.Fatalf("CompileSemanticAccessPolicy: %v", err)
+	}
+	return policy, model
+}
+
+func semanticAccessEffective(t *testing.T, definitions []access.SemanticAttributeDefinition) []access.EffectiveSemanticAttribute {
+	t.Helper()
+	inputs := map[string]any{
+		"department": "sales", "regions": []string{"west", "east"}, "accountIds": []int64{9007199254740993, 7},
+		"amountLimit": json.Number("9007199254740993.1250"), "approval": true, "accessDate": "2026-09-06",
+		"accessInstant": "2026-09-06T05:30:00+02:00",
+	}
+	result := make([]access.EffectiveSemanticAttribute, 0, len(definitions))
+	for _, definition := range definitions {
+		values, digest, err := access.CanonicalSemanticAttributeValues(definition, inputs[definition.Name])
+		if err != nil {
+			t.Fatalf("canonicalize %s: %v", definition.Name, err)
+		}
+		result = append(result, access.EffectiveSemanticAttribute{DefinitionID: definition.ID, DefinitionName: definition.Name,
+			DefinitionVersion: definition.DefinitionVersion, Type: definition.Type, Shape: definition.Shape,
+			CanonicalValues: values, ValueDigest: digest, Source: "direct"})
+	}
+	return result
+}
+
+func semanticAccessSnapshot(t *testing.T, attributes []access.EffectiveSemanticAttribute) (SemanticAccessAttributeSnapshot, SemanticAccessAuthority) {
+	return semanticAccessSnapshotForPrincipal(t, "principal-1", attributes)
+}
+
+func semanticAccessSnapshotForPrincipal(t *testing.T, principalID string, attributes []access.EffectiveSemanticAttribute) (SemanticAccessAttributeSnapshot, SemanticAccessAuthority) {
+	t.Helper()
+	digest, err := EffectiveSemanticAttributeDigest(attributes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := semanticAccessRegistry(semanticAccessDefinitions())
+	assignments := make([]access.SemanticAttributeAssignment, 0, len(attributes))
+	for _, attribute := range attributes {
+		if attribute.Source != "direct" && attribute.Source != "direct+trusted_claim" {
+			continue
+		}
+		assignments = append(assignments, access.SemanticAttributeAssignment{ID: "assignment-" + attribute.DefinitionID,
+			DefinitionID: attribute.DefinitionID, DefinitionName: attribute.DefinitionName, DefinitionVersion: attribute.DefinitionVersion,
+			Type: attribute.Type, Shape: attribute.Shape, Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: principalID},
+			CanonicalValues: append([]string(nil), attribute.CanonicalValues...), ValueDigest: attribute.ValueDigest, AssignmentVersion: 1})
+	}
+	control := semanticAccessControl(assignments, nil)
+	directEvidence := access.SemanticAttributeDirectEvidence{}
+	if len(assignments) != 0 {
+		directEvidence, err = access.NewSemanticAttributeDirectEvidence("instance-1", principalID,
+			[]access.SubjectRef{{Kind: access.SubjectKindPrincipal, ID: principalID}}, control, attributes)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot := SemanticAccessAttributeSnapshot{InstanceID: "instance-1", PrincipalID: principalID, Registry: registry, Control: control,
+		EffectiveAttributes: attributes, EffectiveAttributeDigest: digest, DirectAssignmentEvidence: directEvidence}
+	observedAt, err := time.Parse(time.RFC3339Nano, semanticAccessObservedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot, SemanticAccessAuthority{InstanceID: "instance-1", Registry: registry, Control: control, ObservedAt: observedAt}
+}
+
+func reverseEffectiveAttributes(values []access.EffectiveSemanticAttribute) []access.EffectiveSemanticAttribute {
+	result := append([]access.EffectiveSemanticAttribute(nil), values...)
+	for left, right := 0, len(result)-1; left < right; left, right = left+1, right-1 {
+		result[left], result[right] = result[right], result[left]
+	}
+	return result
+}
+
+func replaceDefinition(definitions []access.SemanticAttributeDefinition, name string, change func(*access.SemanticAttributeDefinition)) []access.SemanticAttributeDefinition {
+	result := append([]access.SemanticAttributeDefinition(nil), definitions...)
+	for index := range result {
+		if result[index].Name == name {
+			change(&result[index])
+		}
+	}
+	return result
+}
+
+func requireSemanticAccessError(t *testing.T, err error, contains string) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), contains) {
+		t.Fatalf("error = %v, want containing %q", err, contains)
+	}
+}

--- a/internal/app/postgres_agent_admin_journey_test.go
+++ b/internal/app/postgres_agent_admin_journey_test.go
@@ -201,6 +201,12 @@ func TestPostgresAgentAdminJourney(t *testing.T) {
 		t.Fatal("PostgreSQL agent run emitted no durable events")
 	}
 	job, err := fixture.JobsModule.Get(ctx, "agent:"+run.ID+":run")
+	// The domain run commits before the handler returns and River completes
+	// the job. Poll within the existing run deadline, not a new timeout.
+	for err == nil && job.Status == jobs.StatusRunning && time.Now().Before(deadline) {
+		time.Sleep(25 * time.Millisecond)
+		job, err = fixture.JobsModule.Get(ctx, "agent:"+run.ID+":run")
+	}
 	if err != nil {
 		t.Fatalf("read completed PostgreSQL agent job: %v", err)
 	}

--- a/internal/platform/architecture/semantic_access_compiler_test.go
+++ b/internal/platform/architecture/semantic_access_compiler_test.go
@@ -1,0 +1,64 @@
+package architecture
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FAI-639 owns portable policy lowering, target qualification, and typed
+// evaluation. Planner placement remains a separate FAI-641 boundary, so this
+// guard keeps executable SQL/templates and early consumer wiring out of the
+// compiler slice.
+func TestSemanticAccessCompilerBoundaryRemainsClosedAndUnwired(t *testing.T) {
+	root := repoRoot(t)
+	compiler := readArchitectureFixture(t, root, "internal/analytics/query/semantic_access_compile.go")
+	evaluator := readArchitectureFixture(t, root, "internal/analytics/query/semantic_access_evaluate.go")
+	lowering := readArchitectureFixture(t, root, "internal/project/compiler/data_resources.go")
+	model := readArchitectureFixture(t, root, "internal/analytics/model/types.go")
+
+	for fragment, body := range map[string]string{
+		"portable policy retained on Model":    model,
+		"portable generated-contract lowering": lowering,
+		"target-qualified policy compiler":     compiler,
+		"typed PlanIR predicate evaluator":     evaluator,
+	} {
+		if !strings.Contains(body, map[string]string{
+			"portable policy retained on Model":    "AccessPolicy",
+			"portable generated-contract lowering": "lowerSemanticAccessPolicy",
+			"target-qualified policy compiler":     "CompileSemanticAccessPolicy",
+			"typed PlanIR predicate evaluator":     "planir.Predicate",
+		}[fragment]) {
+			t.Errorf("semantic access boundary is missing %s", fragment)
+		}
+	}
+	for _, forbidden := range []string{"database/sql", "internal/analytics/duckdb", "text/template", "html/template"} {
+		if strings.Contains(compiler, forbidden) || strings.Contains(evaluator, forbidden) {
+			t.Errorf("semantic access compiler/evaluator acquired executable target dependency %q", forbidden)
+		}
+	}
+
+	var compileCalls, evaluateCalls int
+	err := filepath.WalkDir(filepath.Join(root, "internal"), func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		compileCalls += strings.Count(string(body), "CompileSemanticAccessPolicy(")
+		evaluateCalls += strings.Count(string(body), "EvaluateSemanticAccess(")
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compileCalls != 1 || evaluateCalls != 1 {
+		t.Fatalf("FAI-639 boundary is wired before FAI-641: compile declarations/calls=%d evaluation declarations/calls=%d", compileCalls, evaluateCalls)
+	}
+}

--- a/internal/project/compiler/data_resources.go
+++ b/internal/project/compiler/data_resources.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flidai/leapview/internal/access"
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	projectcontracts "github.com/flidai/leapview/internal/project/contracts"
 	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
@@ -146,63 +147,134 @@ func decodeSemanticModelResource(path string, content []byte) (projectcontracts.
 	return authored.Spec, lowerAIContext(authored.AiContext), nil
 }
 
-// rejectSemanticAccessPolicy prevents policy-bearing generated fields from
-// being silently discarded while the runtime policy compiler is still
-// pending. Keep this check at the generated-to-runtime boundary so every
-// compiler path has the same fail-closed behavior.
-func rejectSemanticAccessPolicy(spec projectcontracts.SemanticModelSpec) error {
-	const pending = "compiled access-policy support is not available"
+// lowerSemanticAccessPolicy is the generated-to-runtime boundary for the
+// portable policy contract. Target registry qualification happens later; this
+// step retains exact literals and validates only target-independent structure.
+func lowerSemanticAccessPolicy(spec projectcontracts.SemanticModelSpec) (semanticmodel.SemanticAccessPolicy, error) {
+	policy := semanticmodel.SemanticAccessPolicy{}
+	grantNames := map[string]struct{}{}
 	if spec.AccessGrants != nil {
-		return fmt.Errorf("SemanticModel spec accessGrants: %s", pending)
-	}
-	datasetNames := make([]string, 0, len(spec.Datasets))
-	for name := range spec.Datasets {
-		datasetNames = append(datasetNames, name)
-	}
-	sort.Strings(datasetNames)
-	for _, name := range datasetNames {
-		dataset := spec.Datasets[name]
-		if dataset.RequiredAccessGrants != nil {
-			return fmt.Errorf("SemanticModel dataset %q requiredAccessGrants: %s", name, pending)
+		policy.AccessGrants = make(map[string]semanticmodel.SemanticAccessGrantSpec, len(*spec.AccessGrants))
+		for _, name := range sortedMapKeys(*spec.AccessGrants) {
+			grant := (*spec.AccessGrants)[name]
+			if err := access.ValidateSemanticAttributeName(name); err != nil {
+				return semanticmodel.SemanticAccessPolicy{}, fmt.Errorf("SemanticModel access grant %q: %w", name, err)
+			}
+			if err := access.ValidateSemanticAttributeName(grant.UserAttribute); err != nil {
+				return semanticmodel.SemanticAccessPolicy{}, fmt.Errorf("SemanticModel access grant %q userAttribute: %w", name, err)
+			}
+			if len(grant.AllowedValues) == 0 || len(grant.AllowedValues) > access.MaxSemanticAttributeValues {
+				return semanticmodel.SemanticAccessPolicy{}, fmt.Errorf("SemanticModel access grant %q allowedValues requires between 1 and %d values", name, access.MaxSemanticAttributeValues)
+			}
+			values := make([]semanticmodel.SemanticAccessLiteral, len(grant.AllowedValues))
+			seen := make(map[string]struct{}, len(values))
+			for index, raw := range grant.AllowedValues {
+				literal, err := semanticmodel.NewSemanticAccessLiteral(raw)
+				if err != nil {
+					return semanticmodel.SemanticAccessPolicy{}, fmt.Errorf("SemanticModel access grant %q allowedValues[%d]: %w", name, index, err)
+				}
+				keyBytes, _ := json.Marshal(literal)
+				if _, exists := seen[string(keyBytes)]; exists {
+					return semanticmodel.SemanticAccessPolicy{}, fmt.Errorf("SemanticModel access grant %q allowedValues contains duplicate value", name)
+				}
+				seen[string(keyBytes)] = struct{}{}
+				values[index] = literal
+			}
+			policy.AccessGrants[name] = semanticmodel.SemanticAccessGrantSpec{UserAttribute: grant.UserAttribute, AllowedValues: values}
+			grantNames[name] = struct{}{}
 		}
+	}
+
+	for _, name := range sortedMapKeys(spec.Datasets) {
+		dataset := spec.Datasets[name]
+		required, err := lowerRequiredAccessGrants("dataset", name, dataset.RequiredAccessGrants, grantNames)
+		if err != nil {
+			return semanticmodel.SemanticAccessPolicy{}, err
+		}
+		var filters []semanticmodel.SemanticAccessFilterSpec
 		if dataset.AccessFilters != nil {
-			return fmt.Errorf("SemanticModel dataset %q accessFilters: %s", name, pending)
+			if len(*dataset.AccessFilters) == 0 {
+				return semanticmodel.SemanticAccessPolicy{}, fmt.Errorf("SemanticModel dataset %q accessFilters requires a non-empty list", name)
+			}
+			filters = make([]semanticmodel.SemanticAccessFilterSpec, len(*dataset.AccessFilters))
+			for index, filter := range *dataset.AccessFilters {
+				if err := access.ValidateSemanticAttributeName(filter.Field); err != nil {
+					return semanticmodel.SemanticAccessPolicy{}, fmt.Errorf("SemanticModel dataset %q accessFilters[%d] field: %w", name, index, err)
+				}
+				if err := access.ValidateSemanticAttributeName(filter.UserAttribute); err != nil {
+					return semanticmodel.SemanticAccessPolicy{}, fmt.Errorf("SemanticModel dataset %q accessFilters[%d] userAttribute: %w", name, index, err)
+				}
+				filters[index] = semanticmodel.SemanticAccessFilterSpec{Field: filter.Field, UserAttribute: filter.UserAttribute}
+			}
+		}
+		if required != nil || filters != nil {
+			if policy.Datasets == nil {
+				policy.Datasets = map[string]semanticmodel.SemanticDatasetAccessSpec{}
+			}
+			policy.Datasets[name] = semanticmodel.SemanticDatasetAccessSpec{RequiredAccessGrants: required, AccessFilters: filters}
 		}
 	}
 	if spec.Dimensions != nil {
-		dimensionNames := make([]string, 0, len(*spec.Dimensions))
-		for name := range *spec.Dimensions {
-			dimensionNames = append(dimensionNames, name)
-		}
-		sort.Strings(dimensionNames)
-		for _, name := range dimensionNames {
-			dimension := (*spec.Dimensions)[name]
-			if dimension.RequiredAccessGrants != nil {
-				return fmt.Errorf("SemanticModel dimension %q requiredAccessGrants: %s", name, pending)
+		for _, name := range sortedMapKeys(*spec.Dimensions) {
+			required, err := lowerRequiredAccessGrants("dimension", name, (*spec.Dimensions)[name].RequiredAccessGrants, grantNames)
+			if err != nil {
+				return semanticmodel.SemanticAccessPolicy{}, err
+			}
+			if required != nil {
+				if policy.Dimensions == nil {
+					policy.Dimensions = map[string][]string{}
+				}
+				policy.Dimensions[name] = required
 			}
 		}
 	}
-	metricNames := make([]string, 0, len(spec.Metrics))
-	for name := range spec.Metrics {
-		metricNames = append(metricNames, name)
-	}
-	sort.Strings(metricNames)
-	for _, name := range metricNames {
-		metric := spec.Metrics[name]
-		var required *[]string
-		switch variant := metric.Value.(type) {
+	for _, name := range sortedMapKeys(spec.Metrics) {
+		var authored *[]string
+		switch variant := spec.Metrics[name].Value.(type) {
 		case *projectcontracts.SemanticMetricAggregateVariant:
-			required = variant.RequiredAccessGrants
+			authored = variant.RequiredAccessGrants
 		case *projectcontracts.SemanticMetricDerivedVariant:
-			required = variant.RequiredAccessGrants
+			authored = variant.RequiredAccessGrants
 		case *projectcontracts.SemanticMetricRatioVariant:
-			required = variant.RequiredAccessGrants
+			authored = variant.RequiredAccessGrants
+		}
+		required, err := lowerRequiredAccessGrants("metric", name, authored, grantNames)
+		if err != nil {
+			return semanticmodel.SemanticAccessPolicy{}, err
 		}
 		if required != nil {
-			return fmt.Errorf("SemanticModel metric %q requiredAccessGrants: %s", name, pending)
+			if policy.Metrics == nil {
+				policy.Metrics = map[string][]string{}
+			}
+			policy.Metrics[name] = required
 		}
 	}
-	return nil
+	return policy, nil
+}
+
+func lowerRequiredAccessGrants(kind, name string, authored *[]string, available map[string]struct{}) ([]string, error) {
+	if authored == nil {
+		return nil, nil
+	}
+	if len(*authored) == 0 {
+		return nil, fmt.Errorf("SemanticModel %s %q requiredAccessGrants requires a non-empty list", kind, name)
+	}
+	seen := make(map[string]struct{}, len(*authored))
+	result := append([]string(nil), (*authored)...)
+	for _, grant := range result {
+		if err := access.ValidateSemanticAttributeName(grant); err != nil {
+			return nil, fmt.Errorf("SemanticModel %s %q requiredAccessGrants: %w", kind, name, err)
+		}
+		if _, exists := available[grant]; !exists {
+			return nil, fmt.Errorf("SemanticModel %s %q references unknown access grant %q", kind, name, grant)
+		}
+		if _, duplicate := seen[grant]; duplicate {
+			return nil, fmt.Errorf("SemanticModel %s %q requiredAccessGrants contains duplicate %q", kind, name, grant)
+		}
+		seen[grant] = struct{}{}
+	}
+	sort.Strings(result)
+	return result, nil
 }
 
 func lowerSemanticDatasets(values map[string]projectcontracts.SemanticDataset) map[string]semanticmodel.SemanticDatasetSpec {

--- a/internal/project/compiler/data_resources_test.go
+++ b/internal/project/compiler/data_resources_test.go
@@ -271,7 +271,7 @@ spec:
 	}
 }
 
-func TestTypedSemanticModelLoweringRejectsUncompiledAccessPolicy(t *testing.T) {
+func TestTypedSemanticModelLoweringRetainsAccessPolicy(t *testing.T) {
 	spec, _, err := decodeSemanticModelResource("semantic-model.yaml", []byte(`apiVersion: leapview.dev/v1
 kind: SemanticModel
 metadata: {id: semantic-model:sales, name: sales}
@@ -285,9 +285,16 @@ spec:
 	if err != nil {
 		t.Fatalf("structural access policy decode: %v", err)
 	}
-	err = applySemanticModelSpec(&semanticmodel.Model{Name: "sales"}, spec)
-	if err == nil || !strings.Contains(err.Error(), "compiled access-policy support is not available") {
-		t.Fatalf("uncompiled access policy error = %v", err)
+	model := &semanticmodel.Model{Name: "sales", Tables: map[string]semanticmodel.Table{"orders_model": {}}}
+	if err := applySemanticModelSpec(model, spec); err != nil {
+		t.Fatalf("lower access policy: %v", err)
+	}
+	grant, ok := model.AccessPolicy.AccessGrants["canViewSales"]
+	if !ok || grant.UserAttribute != "department" || len(grant.AllowedValues) != 1 {
+		t.Fatalf("lowered access grant = %#v", model.AccessPolicy.AccessGrants)
+	}
+	if got := model.AccessPolicy.Datasets["orders"].RequiredAccessGrants; len(got) != 1 || got[0] != "canViewSales" {
+		t.Fatalf("lowered dataset requirements = %#v", got)
 	}
 }
 

--- a/internal/project/compiler/project_build.go
+++ b/internal/project/compiler/project_build.go
@@ -265,7 +265,8 @@ func addSourceAlias(aliases map[string]string, keyOwners map[string]string, key,
 }
 
 func applySemanticModelSpec(model *semanticmodel.Model, spec projectcontracts.SemanticModelSpec) error {
-	if err := rejectSemanticAccessPolicy(spec); err != nil {
+	accessPolicy, err := lowerSemanticAccessPolicy(spec)
+	if err != nil {
 		return err
 	}
 	datasets := lowerSemanticDatasets(spec.Datasets)
@@ -358,6 +359,7 @@ func applySemanticModelSpec(model *semanticmodel.Model, spec projectcontracts.Se
 	model.Dimensions = dimensions
 	model.Metrics = metrics
 	model.Filters = filters
+	model.AccessPolicy = accessPolicy
 	return nil
 }
 

--- a/internal/project/compiler/semantic_model_lowering_test.go
+++ b/internal/project/compiler/semantic_model_lowering_test.go
@@ -1,7 +1,6 @@
 package compiler
 
 import (
-	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -104,106 +103,65 @@ func TestSemanticModelLoweringRelationshipEndpointValidation(t *testing.T) {
 	}
 }
 
-func TestSemanticModelLoweringRejectsEveryAccessPolicyBoundary(t *testing.T) {
-	grants := []string{"can_view"}
-	dimensions := map[string]projectcontracts.SemanticDimension{"region": {RequiredAccessGrants: &grants}}
-	cases := []struct {
-		name string
-		spec projectcontracts.SemanticModelSpec
-	}{
-		{name: "dataset grants", spec: projectcontracts.SemanticModelSpec{Datasets: map[string]projectcontracts.SemanticDataset{"orders": {RequiredAccessGrants: &grants}}}},
-		{name: "dataset filters", spec: projectcontracts.SemanticModelSpec{Datasets: map[string]projectcontracts.SemanticDataset{"orders": {AccessFilters: &[]projectcontracts.SemanticAccessFilter{{Field: "orders.region", UserAttribute: "region"}}}}}},
-		{name: "dimension grants", spec: projectcontracts.SemanticModelSpec{Dimensions: &dimensions}},
-		{name: "aggregate grants", spec: projectcontracts.SemanticModelSpec{Metrics: map[string]projectcontracts.SemanticMetric{"revenue": {Value: &projectcontracts.SemanticMetricAggregateVariant{AggregateSemanticMetric: projectcontracts.AggregateSemanticMetric{RequiredAccessGrants: &grants}}}}}},
-		{name: "derived grants", spec: projectcontracts.SemanticModelSpec{Metrics: map[string]projectcontracts.SemanticMetric{"margin": {Value: &projectcontracts.SemanticMetricDerivedVariant{DerivedSemanticMetric: projectcontracts.DerivedSemanticMetric{RequiredAccessGrants: &grants}}}}}},
-		{name: "ratio grants", spec: projectcontracts.SemanticModelSpec{Metrics: map[string]projectcontracts.SemanticMetric{"margin_rate": {Value: &projectcontracts.SemanticMetricRatioVariant{RatioSemanticMetric: projectcontracts.RatioSemanticMetric{RequiredAccessGrants: &grants}}}}}},
+func TestSemanticModelLoweringRetainsEveryAccessPolicyBoundary(t *testing.T) {
+	required := []string{"can_view"}
+	grants := map[string]projectcontracts.SemanticAccessGrant{
+		"can_view": {UserAttribute: "department", AllowedValues: projectcontracts.SemanticAllowedValues{"sales"}},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := rejectSemanticAccessPolicy(tc.spec); err == nil || !strings.Contains(err.Error(), "compiled access-policy support is not available") {
-				t.Fatalf("access policy was accepted: %v", err)
-			}
-		})
+	dimensions := map[string]projectcontracts.SemanticDimension{"region": {RequiredAccessGrants: &required}}
+	spec := projectcontracts.SemanticModelSpec{
+		AccessGrants: &grants,
+		Datasets: map[string]projectcontracts.SemanticDataset{"orders": {
+			RequiredAccessGrants: &required,
+			AccessFilters:        &[]projectcontracts.SemanticAccessFilter{{Field: "region", UserAttribute: "allowedRegions"}},
+		}},
+		Dimensions: &dimensions,
+		Metrics: map[string]projectcontracts.SemanticMetric{
+			"revenue":     {Value: &projectcontracts.SemanticMetricAggregateVariant{AggregateSemanticMetric: projectcontracts.AggregateSemanticMetric{RequiredAccessGrants: &required}}},
+			"margin":      {Value: &projectcontracts.SemanticMetricDerivedVariant{DerivedSemanticMetric: projectcontracts.DerivedSemanticMetric{RequiredAccessGrants: &required}}},
+			"margin_rate": {Value: &projectcontracts.SemanticMetricRatioVariant{RatioSemanticMetric: projectcontracts.RatioSemanticMetric{RequiredAccessGrants: &required}}},
+		},
 	}
-
-	_, err := lowerSemanticMetrics(map[string]projectcontracts.SemanticMetric{"missing": {}})
-	if err == nil || !strings.Contains(err.Error(), `metric "missing" variant is required`) {
-		t.Fatalf("missing metric variant error = %v", err)
+	policy, err := lowerSemanticAccessPolicy(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy.AccessGrants["can_view"].UserAttribute != "department" || len(policy.AccessGrants["can_view"].AllowedValues) != 1 {
+		t.Fatalf("grant lowering = %#v", policy.AccessGrants)
+	}
+	if len(policy.Datasets["orders"].RequiredAccessGrants) != 1 || len(policy.Datasets["orders"].AccessFilters) != 1 || len(policy.Dimensions["region"]) != 1 {
+		t.Fatalf("dataset/dimension policy lowering = %#v", policy)
+	}
+	for _, name := range []string{"revenue", "margin", "margin_rate"} {
+		if !reflect.DeepEqual(policy.Metrics[name], required) {
+			t.Fatalf("metric %q grants = %#v", name, policy.Metrics[name])
+		}
 	}
 }
 
 func TestSemanticModelAccessPolicyDiagnosticsAreDeterministic(t *testing.T) {
-	grants := []string{"can_view"}
-	dimensions := map[string]projectcontracts.SemanticDimension{
-		"zeta":  {RequiredAccessGrants: &grants},
-		"alpha": {RequiredAccessGrants: &grants},
-	}
-	cases := []struct {
-		name string
-		spec projectcontracts.SemanticModelSpec
-		want string
-	}{
-		{
-			name: "datasets",
-			spec: projectcontracts.SemanticModelSpec{Datasets: map[string]projectcontracts.SemanticDataset{
-				"zeta":  {RequiredAccessGrants: &grants},
-				"alpha": {RequiredAccessGrants: &grants},
-			}},
-			want: `SemanticModel dataset "alpha" requiredAccessGrants: compiled access-policy support is not available`,
-		},
-		{
-			name: "dimensions",
-			spec: projectcontracts.SemanticModelSpec{Dimensions: &dimensions},
-			want: `SemanticModel dimension "alpha" requiredAccessGrants: compiled access-policy support is not available`,
-		},
-		{
-			name: "metrics",
-			spec: projectcontracts.SemanticModelSpec{Metrics: map[string]projectcontracts.SemanticMetric{
-				"zeta":  {Value: &projectcontracts.SemanticMetricAggregateVariant{AggregateSemanticMetric: projectcontracts.AggregateSemanticMetric{RequiredAccessGrants: &grants}}},
-				"alpha": {Value: &projectcontracts.SemanticMetricAggregateVariant{AggregateSemanticMetric: projectcontracts.AggregateSemanticMetric{RequiredAccessGrants: &grants}}},
-			}},
-			want: `SemanticModel metric "alpha" requiredAccessGrants: compiled access-policy support is not available`,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			for run := 0; run < 100; run++ {
-				err := rejectSemanticAccessPolicy(tc.spec)
-				if err == nil || err.Error() != tc.want {
-					t.Fatalf("run %d diagnostic = %v, want %q", run, err, tc.want)
-				}
-			}
-		})
+	required := []string{"missing"}
+	spec := projectcontracts.SemanticModelSpec{Datasets: map[string]projectcontracts.SemanticDataset{
+		"zeta": {RequiredAccessGrants: &required}, "alpha": {RequiredAccessGrants: &required},
+	}}
+	want := `SemanticModel dataset "alpha" references unknown access grant "missing"`
+	for run := 0; run < 100; run++ {
+		_, err := lowerSemanticAccessPolicy(spec)
+		if err == nil || err.Error() != want {
+			t.Fatalf("run %d diagnostic = %v, want %q", run, err, want)
+		}
 	}
 }
 
-func TestProjectManifestSemanticAccessPolicyDiagnosticsAreDeterministic(t *testing.T) {
-	grants := []string{"can_view"}
-	project := sourceAssembly{
-		SemanticModels: map[string]projectcontracts.SemanticModelSpec{
-			"zeta":  {Datasets: map[string]projectcontracts.SemanticDataset{"orders": {RequiredAccessGrants: &grants}}},
-			"alpha": {Datasets: map[string]projectcontracts.SemanticDataset{"orders": {RequiredAccessGrants: &grants}}},
-		},
-		SemanticModelIDs: map[string]string{
-			"zeta":  "semantic-model:zeta",
-			"alpha": "semantic-model:alpha",
-		},
-		SemanticModelPaths: map[string]string{
-			"zeta":  "semantic-models/zeta.yaml",
-			"alpha": "semantic-models/alpha.yaml",
-		},
+func TestSemanticModelAccessPolicyRejectsEmptyAndDuplicateRequirements(t *testing.T) {
+	empty := []string{}
+	if _, err := lowerSemanticAccessPolicy(projectcontracts.SemanticModelSpec{Datasets: map[string]projectcontracts.SemanticDataset{"orders": {RequiredAccessGrants: &empty}}}); err == nil || !strings.Contains(err.Error(), "non-empty") {
+		t.Fatalf("empty required grants error = %v", err)
 	}
-	wantMessage := `SemanticModel dataset "orders" requiredAccessGrants: compiled access-policy support is not available`
-	for run := 0; run < 100; run++ {
-		_, err := buildResourceManifest(project)
-		var diagnostic ResourceError
-		if !errors.As(err, &diagnostic) {
-			t.Fatalf("run %d diagnostic = %T(%v), want ResourceError", run, err, err)
-		}
-		if diagnostic.Path != "semantic-models/alpha.yaml" || diagnostic.ResourceID != "semantic-model:alpha" || diagnostic.FieldPath != "spec" || diagnostic.Message != wantMessage {
-			t.Fatalf("run %d diagnostic = %#v, want alpha resource and %q", run, diagnostic, wantMessage)
-		}
+	duplicate := []string{"can_view", "can_view"}
+	grants := map[string]projectcontracts.SemanticAccessGrant{"can_view": {UserAttribute: "department", AllowedValues: projectcontracts.SemanticAllowedValues{"sales"}}}
+	if _, err := lowerSemanticAccessPolicy(projectcontracts.SemanticModelSpec{AccessGrants: &grants, Datasets: map[string]projectcontracts.SemanticDataset{"orders": {RequiredAccessGrants: &duplicate}}}); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate required grants error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem and solution

The reconciled SemanticModel contract exposes semantic access metadata, but the runtime compiler previously rejected policy-bearing fields. This introduces the FAI-639 compiler/evaluator boundary: authored grants, required grants, and dataset filters are retained in a detached runtime policy, qualified against authoritative attribute snapshots, and evaluated into deterministic typed PlanIR predicates.

Issue: [FAI-639 — Compile access grants and typed access-filter predicates](https://linear.app/flid/issue/FAI-639/compile-access-grants-and-typed-access-filter-predicates)

## Implementation

- Consume the FAI-619 generated SemanticModel contract, compiled semantic lineage, FAI-636 registry, FAI-637 control snapshots, and canonical effective values. Preserve exact numeric literals and reuse `semanticvalue` and closed PlanIR types.
- Compile scalar/list grants, logical-AND requirements, transitive member requirements, and dataset equality/IN/AND filters for String, Boolean, Integer, Decimal, Date, and Timestamp. Retain every required dataset predicate for multi-dataset members; denied members expose no predicates.
- Validate type, ownership, lifecycle, target identity, revision/digest agreement, canonical values, and snapshot structure. Missing values deny access; malformed, stale, disabled, tombstoned, mixed, or cross-instance evidence cannot grant access. No administrator bypass or SQL/template generation is introduced.
- Bind direct values to opaque assignment evidence and claim-derived values to verified-envelope evidence. Authority, principal, subject closure, assignment/mapping versions, and value digests participate in evidence identity.
- Produce ordered canonical policy/decision identities independent of map iteration and row order. Raw effective values and provider claims are excluded from digest projections. Persisted registry/control digest wire formats remain unchanged.
- Stabilize PostgreSQL registry/control snapshot reads with bounded before/after profile, revision, and digest checks; reject inconsistent lifecycle/tombstone projections at admission.
- Document responsibilities and the compiler-to-planner handoff in ADR-0017 and architecture/conformance documentation.

## Tests and verification

Prior implementation validation on this branch:

- Focused FAI-639 access/PostgreSQL/query tests passed ×10, including grants, all supported types, coercion rejection, missing values, stale/tampered snapshots, evidence, predicate propagation, and deterministic identities.
- Full relevant Go package suite passed: access, access/postgres, analytics/model, analytics/query, project/compiler, semanticvalue, and platform/architecture.
- `task generated:check`, architecture/conformance checks, `task quality:budget:check`, and diff checks passed. Budgets are unchanged.
- Full local `task ci` passed APIGen, frontend/visualization, docs, application shards, and product package lanes except `internal/app/tools/securitysource`. That package rejects the non-system TMPDIR used to avoid the host's `/tmp` quota. It passed separately under a canonical `/tmp` path. The aggregate local CI result is therefore not reported as green. Final review refinements were subsequently covered by the focused and relevant Go package suites and generated/quality checks.
- Publication audit confirmed one FAI-639 commit, 29 files (+4,044/−351), no unrelated generated artifacts, package moves, or dependency/workflow changes. No source changes were made during publication.

## Scope and remaining limitations

FAI-641 planner barriers, consumer adoption, provider adapters, cache lifecycle work, and package moves are excluded. VAL-11 remains Partial. Production consumers do not call this compiler/evaluator yet; architecture tests guard that boundary. Future access composition must supply authoritative principal/group membership and current observation time rather than accepting either from request/browser input.

## Main reconciliation — 2026-09-06

Rebased the single FAI-639 commit onto `origin/main@f71269bbcadd435e89f996c9de7efebe4fecd091`.
Updated head: `a5670daac43dd000b7dba69c42020691f70ee33d` (previously `e4e0fcd6556801dcf72432f8f874811f76e54fac`).

Kept main's deletion of `docs/articles/architecture/postgresql-authority-reconciliation.md`. PR #386 (`210f0e1fe`) replaced the historical extracted-foundations baseline with the PostgreSQL target architecture. The obsolete reconciliation record is not a compiler dependency. Its FAI-639 additions are already covered in `docs/articles/architecture/semantic-attribute-registry.md`, ADR-0017, and the semantic-access conformance specification; no historical artifact was restored or extra documentation needed.

`git range-diff` confirms the only change to the FAI-639 patch is omission of edits to that deleted document. All implementation/test files changed by FAI-639 are byte-identical to the original head. Final PR scope: 28 files, +4,031/−345. No FAI-641, consumers/providers, cache lifecycle, VAL-11 expansion, unrelated generated artifacts, or quality-budget changes.

Post-rebase validation passed:

- Focused FAI-639 access/PostgreSQL/query tests ×10.
- Complete access, access/postgres, analytics/model, analytics/query, project/compiler, semanticvalue, and platform/architecture Go suites (`-tags=duckdb_arrow`, `-count=1`). Optional live PostgreSQL qualification is not claimed by these package results.
- `task generated:check` (normal regeneration; no tracked artifact changes).
- `task docs:check`, including diagrams, generated documentation, and rendered-link resolution.
- `task quality:budget:check` and `git diff --check` for both worktree and base-to-head diff.

Initial local validation encountered stale ignored generated files from the old base. Normal generation refreshed the bindings; an obsolete generated sqlc catalog file and retired SQLite docs index were moved outside the worktree for recovery. All requested reruns passed and the working tree is clean. Full `task ci` was not rerun for this documentation-only conflict resolution; the prior local CI limitation above remains historical evidence, not a green CI claim for this head. Fresh GitHub CI and review remain required. Do not merge automatically; FAI-639 remains In Review.

## Follow-up base reconciliation — PR #495

Main advanced again after the earlier conflict was resolved: `5d766dc4fa65700181fd10db1a45fa45a7ea378a` (FAI-666, PR #495). Rebased onto that commit. Current head: `69c8eec15e47fe910770600e9ddb4d6e5333130e`.

The new conflict was in `internal/project/compiler/semantic_model_lowering_test.go`: main renamed `Project`/`projectManifest` in an obsolete unsupported-policy diagnostic test that FAI-639 already replaced. Kept FAI-639's replacement tests and main's source-assembly refactor. The resolved test file is byte-identical to the previous PR head. Range-diff shows only the renamed base lines in the removed test; no new compiler/evaluator behavior, FAI-641 work or VAL-11 expansion. Historical documentation remains deleted.

Validation on this head passed: focused FAI-639 tests ×10; complete access, access/postgres, analytics/model, analytics/query, project/compiler, semanticvalue and architecture suites; task generated:check; task docs:check; task quality:budget:check; worktree and base-to-head diff checks. No tracked generated-artifact changes. Working tree clean. Full task ci was not rerun; hosted CI/review remains required. FAI-639 remains In Review; no merge performed.

