### PR TITLE
fix(ci): eliminate dependency install races and synchronize flaky tests (FAI-754)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,11 @@ jobs:
         run: task ci:lane:go:application
 
   frontend-validation:
-    name: Frontend tests (PR)
+    name: Frontend tests (PR, ${{ matrix.shard }})
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [core, reports, chat, data, site]
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.stack == null ||
@@ -152,7 +156,7 @@ jobs:
         run: node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare
 
       - name: Run frontend validation
-        run: node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend
+        run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}
 
       - name: Verify generated artifacts
         run: task generated:check

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -91,7 +91,11 @@ jobs:
         run: task ci:lane:go:application
 
   frontend-validation:
-    name: Frontend tests (merge queue)
+    name: Frontend tests (merge queue, ${{ matrix.shard }})
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [core, reports, chat, data, site]
     if: github.repository == 'flidai/leapview'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -113,7 +117,7 @@ jobs:
         run: node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare
 
       - name: Run frontend validation
-        run: node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend
+        run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}
 
       - name: Verify generated artifacts
         run: task generated:check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,7 +83,11 @@ jobs:
         run: task ci:lane:go:application
 
   frontend-validation:
-    name: Frontend tests (nightly)
+    name: Frontend tests (nightly, ${{ matrix.shard }})
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [core, reports, chat, data, site]
     if: github.repository == 'flidai/leapview'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -103,7 +107,7 @@ jobs:
         run: node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare
 
       - name: Run frontend validation
-        run: node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend
+        run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}
 
       - name: Verify generated artifacts
         run: task generated:check

--- a/.security/javascript-vulnerability-evidence.json
+++ b/.security/javascript-vulnerability-evidence.json
@@ -1,8 +1,8 @@
 {
   "schema": "leapview.securitydependencies/javascript-vulnerability-evidence/v1",
   "provider": "npm-advisory-api",
-  "generated_at": "2026-09-06T03:32:55.206734089Z",
-  "expires_at": "2026-09-13T03:32:55.206734089Z",
+  "generated_at": "2026-09-06T14:40:17.487532157Z",
+  "expires_at": "2026-09-13T14:40:17.487532157Z",
   "graphs": [
     {
       "id": "bun:bun.lock",
@@ -19,7 +19,7 @@
       ],
       "manifest": "package.json",
       "lockfile": "bun.lock",
-      "manifest_sha256": "adfeb19dd82e2d1f899773be612ca58a9d10600bf8d982661738f1f8a1c38d6d",
+      "manifest_sha256": "9744b53c5c9217830a6602f57611c400572531aafffbe6b8d8376def6cd25965",
       "lockfile_sha256": "ef842b88f7e7ab22495d84c69ca4fe76acb1e9248144195a1fe5a472b87638fa",
       "findings": [
         {

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -305,6 +305,7 @@ tasks:
     desc: Run global browser contracts, typechecks, and core application tests
     cmds:
       - node --test scripts/ci_watchdog.test.mjs
+      - bun test scripts/frontend_ci_contract.test.ts
       - bun test scripts/ensure_playwright.test.ts
       - bun run test:primer-primitives
       - bun run test:primer-alignment
@@ -1403,18 +1404,34 @@ tasks:
       - task: test:go:external
 
   ci:lane:frontend:
-    desc: Run the bounded frontend and browser-contract lane
+    desc: Run every bounded frontend shard sequentially on a shared local machine
     cmds:
-      - task: ci:test:frontend:core
-      - task: ci:test:frontend:reports
-      - task: ci:test:frontend:chat
-      - task: ci:test:frontend:data
-      - task: ci:test:frontend:site
+      - task: ci:lane:frontend:shard
+        vars: { SHARD: core }
+      - task: ci:lane:frontend:shard
+        vars: { SHARD: reports }
+      - task: ci:lane:frontend:shard
+        vars: { SHARD: chat }
+      - task: ci:lane:frontend:shard
+        vars: { SHARD: data }
+      - task: ci:lane:frontend:shard
+        vars: { SHARD: site }
+
+  ci:lane:frontend:shard:
+    desc: Run one isolated frontend shard with the hosted-CI hang watchdog
+    requires:
+      vars:
+        - name: SHARD
+          enum: [core, reports, chat, data, site]
+    cmds:
+      # Bound a single unit of work, not the cumulative runtime of all five.
+      # Hosted CI gives each shard its own runner; local CI avoids CPU contention.
+      - node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:test:frontend:{{.SHARD}}
 
   ci:lane:frontend:local:
     desc: Run the frontend lane locally with the hosted-CI hang watchdog
     cmds:
-      - node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend
+      - task: ci:lane:frontend
 
   ci:prepare:
     desc: Generate and build the shared inputs required by every CI validation lane

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -210,12 +210,10 @@ tasks:
 
   node:deps:
     desc: Install JavaScript dependencies with Bun
-    method: checksum
-    sources:
-      - package.json
-      - bun.lock
-    generates:
-      - node_modules/.bin/esbuild
+    # Nested dependency paths must share one writer to this checkout's tree.
+    # Verify the frozen graph on every Task invocation; a binary's presence
+    # cannot establish that the complete installed dependency tree is sound.
+    run: once
     cmds:
       - bun install --frozen-lockfile
 
@@ -306,6 +304,7 @@ tasks:
     cmds:
       - node --test scripts/ci_watchdog.test.mjs
       - bun test scripts/frontend_ci_contract.test.ts
+      - bun test scripts/node_deps_contract.test.ts
       - bun test scripts/ensure_playwright.test.ts
       - bun run test:primer-primitives
       - bun run test:primer-alignment

--- a/docs/articles/architecture/github-hosted-ci.md
+++ b/docs/articles/architecture/github-hosted-ci.md
@@ -39,11 +39,18 @@ compatibility alias for the full current-machine contract.
 
 GitHub Actions distributes those same Taskfile units across clean runners. Pull requests run
 APIGen, the non-application Go packages, sharded application tests, and frontend validation
-concurrently. The three repository lanes execute `task ci:prepare`; the independent APIGen module
+concurrently. The repository validation jobs execute `task ci:prepare`; the independent APIGen module
 does not need generated or embedded application assets and skips that preparation. The merge queue
 adds `task ci:full:extras`, and the daily schedule also runs `task ci:nightly:extras`. Local
 composition remains available through the tier targets; the workflow does not duplicate individual
 test commands or introduce a runner-specific container wrapper.
+
+Frontend validation has five isolated shards: `core`, `reports`, `chat`, `data`, and `site`.
+Each hosted shard runs `task ci:lane:frontend:shard SHARD=<name>` on its own runner with a
+180-second watchdog and at most one retry for a timeout, never for an assertion failure.
+This bounds each independent suite without treating the cumulative runtime of five healthy
+suites as a hang. Every shard must succeed for `CI gate` to pass. Local `task ci` runs the
+same bounded shards sequentially to avoid browser and bundler contention on a shared machine.
 
 ## Toolchain and caches
 

--- a/docs/articles/architecture/github-hosted-ci.md
+++ b/docs/articles/architecture/github-hosted-ci.md
@@ -73,6 +73,13 @@ dependency set, and the package manager or build tool always validates restored 
 main artifact workflow populates the default-branch Bun download cache so new pull requests do
 not inherit an empty cache entry from image qualification.
 
+Each job owns its checkout's installed dependencies. `node:deps` uses Task's `run: once`
+mode so parallel and nested dependency paths await a single `bun install --frozen-lockfile`
+in that Task invocation. A later invocation verifies the tree again; it does not trust a
+cached executable marker. Download caches can be shared, but installed trees are never
+shared between runners. Run independent local Task processes in separate worktrees rather
+than allowing multiple installers to write the same checkout concurrently.
+
 The repository currently works within GitHub's default 10 GB cache allowance. The intended
 operating limit is 50 GB or more so the independent Go, Bun, browser, Terraform, and BuildKit
 caches do not evict one another. Hitting the lower limit may reduce cache hits but cannot

--- a/internal/app/deploymentpostgres/native_build_heartbeat_guard_test.go
+++ b/internal/app/deploymentpostgres/native_build_heartbeat_guard_test.go
@@ -12,27 +12,34 @@ import (
 )
 
 type nativeBuildHeartbeatRunnerFake struct {
-	mu        sync.Mutex
-	calls     int
-	err       error
-	renewed   NativeBuildHeartbeatResult
-	calledCh  chan struct{}
-	releaseCh chan struct{}
+	mu               sync.Mutex
+	calls            int
+	err              error
+	renewed          NativeBuildHeartbeatResult
+	calledCh         chan struct{}
+	releaseCh        chan struct{}
+	cancelObservedCh chan struct{}
+	returnContextErr bool
+}
+
+func (f *nativeBuildHeartbeatRunnerFake) signal(ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
 }
 
 func (f *nativeBuildHeartbeatRunnerFake) Renew(ctx context.Context, _ NativeBuildHeartbeatInput) (NativeBuildHeartbeatResult, error) {
 	f.mu.Lock()
 	f.calls++
-	if f.calledCh != nil {
-		select {
-		case f.calledCh <- struct{}{}:
-		default:
-		}
-	}
 	err := f.err
 	result := f.renewed
 	f.mu.Unlock()
 	if err != nil {
+		f.signal(f.calledCh)
 		return NativeBuildHeartbeatResult{}, err
 	}
 	select {
@@ -40,8 +47,19 @@ func (f *nativeBuildHeartbeatRunnerFake) Renew(ctx context.Context, _ NativeBuil
 		return NativeBuildHeartbeatResult{}, ctx.Err()
 	default:
 	}
+	// Signal only after accepting the context. The test can now use
+	// releaseCh to keep this renewal in flight while Stop joins it.
+	f.signal(f.calledCh)
 	if f.releaseCh != nil {
-		<-f.releaseCh
+		select {
+		case <-f.releaseCh:
+		case <-ctx.Done():
+			f.signal(f.cancelObservedCh)
+			if f.returnContextErr {
+				return NativeBuildHeartbeatResult{}, ctx.Err()
+			}
+			<-f.releaseCh
+		}
 	}
 	return result, nil
 }
@@ -55,15 +73,40 @@ func TestNativeBuildHeartbeatGuardPublishesLatestLeaseAndStops(t *testing.T) {
 	input := nativeBuildHeartbeatGuardInput()
 	renewed := input.OperationLease
 	renewed.LeaseExpiresAt = renewed.LeaseExpiresAt.Add(time.Minute)
-	fake := &nativeBuildHeartbeatRunnerFake{calledCh: make(chan struct{}, 1), releaseCh: make(chan struct{}), renewed: NativeBuildHeartbeatResult{OperationLease: renewed, TargetLease: deploymentnative.DeliveryLease{LeaseID: "target-lease", TargetID: "target", OwnerID: "owner", FencingEpoch: 1}}}
+	releaseCh := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseCh) }) }
+	t.Cleanup(release)
+	fake := &nativeBuildHeartbeatRunnerFake{calledCh: make(chan struct{}, 1), releaseCh: releaseCh, cancelObservedCh: make(chan struct{}, 1), renewed: NativeBuildHeartbeatResult{OperationLease: renewed, TargetLease: deploymentnative.DeliveryLease{LeaseID: "target-lease", TargetID: "target", OwnerID: "owner", FencingEpoch: 1}}}
 	guard := newNativeBuildHeartbeatGuard(context.Background(), fake, time.Millisecond, input, nil)
 	select {
 	case <-fake.calledCh:
 	case <-time.After(time.Second):
 		t.Fatal("heartbeat runner was not called")
 	}
-	close(fake.releaseCh)
-	latest, err := guard.Stop()
+	stopDone := make(chan struct{})
+	var latest NativeBuildHeartbeatInput
+	var err error
+	go func() {
+		latest, err = guard.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-fake.cancelObservedCh:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not cancel the in-flight renewal")
+	}
+	select {
+	case <-stopDone:
+		t.Fatal("stop returned before the in-flight renewal was released")
+	default:
+	}
+	release()
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not join the in-flight renewal")
+	}
 	if err != nil {
 		t.Fatalf("stop: %v", err)
 	}
@@ -94,14 +137,33 @@ func TestNativeBuildHeartbeatGuardCancelsBuildOnRenewalLoss(t *testing.T) {
 }
 
 func TestNativeBuildHeartbeatGuardStopDoesNotReportCancellationAsLoss(t *testing.T) {
-	fake := &nativeBuildHeartbeatRunnerFake{calledCh: make(chan struct{}, 1)}
+	releaseCh := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseCh) }) })
+	fake := &nativeBuildHeartbeatRunnerFake{calledCh: make(chan struct{}, 1), releaseCh: releaseCh, cancelObservedCh: make(chan struct{}, 1), returnContextErr: true}
 	guard := newNativeBuildHeartbeatGuard(context.Background(), fake, time.Millisecond, nativeBuildHeartbeatGuardInput(), nil)
 	select {
 	case <-fake.calledCh:
 	case <-time.After(time.Second):
 		t.Fatal("heartbeat runner was not called")
 	}
-	if _, err := guard.Stop(); err != nil {
+	stopDone := make(chan struct{})
+	var err error
+	go func() {
+		_, err = guard.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-fake.cancelObservedCh:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not cancel the in-flight renewal")
+	}
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not join the canceled renewal")
+	}
+	if err != nil {
 		t.Fatalf("intentional stop reported heartbeat loss: %v", err)
 	}
 }

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -2943,7 +2943,7 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"go-application-validation:",
 		"name: Go application tests (PR)",
 		"frontend-validation:",
-		"name: Frontend tests (PR)",
+		"name: Frontend tests (PR, ${{ matrix.shard }})",
 		"postgres-isolation-validation:",
 		"name: PostgreSQL topology isolation (PR)",
 		"spatial-tile-benchmarks:",
@@ -2954,7 +2954,7 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"run: task ci:lane:go:apigen",
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
-		"run: node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend",
+		"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
 		"run: task generated:check",
 		"ci-gate:",
 		"name: CI gate",
@@ -2977,6 +2977,16 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	goApplicationCI := workflowJobBlock(t, text, "go-application-validation")
 	frontendCI := workflowJobBlock(t, text, "frontend-validation")
 	postgresIsolationCI := workflowJobBlock(t, text, "postgres-isolation-validation")
+	for _, want := range []string{
+		"name: Frontend tests (PR, ${{ matrix.shard }})",
+		"fail-fast: false",
+		"shard: [core, reports, chat, data, site]",
+		"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
+	} {
+		if !strings.Contains(frontendCI, want) {
+			t.Fatalf("PR frontend validation missing shard contract %q", want)
+		}
+	}
 	for name, block := range map[string]string{
 		"apigen-validation":             apigenCI,
 		"go-packages-validation":        goPackagesCI,
@@ -3037,7 +3047,7 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"go-application-validation:",
 		"name: Go application tests (merge queue)",
 		"frontend-validation:",
-		"name: Frontend tests (merge queue)",
+		"name: Frontend tests (merge queue, ${{ matrix.shard }})",
 		"full-validation:",
 		"name: Full merge validation",
 		"runs-on: ubuntu-24.04",
@@ -3053,6 +3063,17 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	}
 	if strings.Contains(mergeText, "group: merge-validation-${{ github.repository }}") {
 		t.Fatal("merge validation concurrency must not cancel distinct merge-queue candidates")
+	}
+	mergeFrontendCI := workflowJobBlock(t, mergeText, "frontend-validation")
+	for _, want := range []string{
+		"name: Frontend tests (merge queue, ${{ matrix.shard }})",
+		"fail-fast: false",
+		"shard: [core, reports, chat, data, site]",
+		"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
+	} {
+		if !strings.Contains(mergeFrontendCI, want) {
+			t.Fatalf("merge-queue frontend validation missing shard contract %q", want)
+		}
 	}
 	goPackagesMerge := workflowJobBlock(t, mergeText, "go-packages-validation")
 	for _, want := range []string{
@@ -3128,7 +3149,7 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 	}{
 		{block: goPackagesCI, want: "task ci:lane:go:packages"},
 		{block: goApplicationCI, want: "task ci:lane:go:application"},
-		{block: frontendCI, want: "task ci:lane:frontend"},
+		{block: frontendCI, want: "task ci:lane:frontend:shard SHARD=${{ matrix.shard }}"},
 	} {
 		for _, want := range []string{"uses: ./.github/actions/setup-ci", "task ci:prepare", contract.want} {
 			if !strings.Contains(contract.block, want) {
@@ -3514,16 +3535,27 @@ func TestGitHubHostedCIRecoversFromHungBunProcesses(t *testing.T) {
 		for _, want := range []string{
 			contract.frontendTimeout,
 			prepareWatchdog,
-			"node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend",
+			"fail-fast: false",
+			"shard: [core, reports, chat, data, site]",
+			"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
 		} {
 			if !strings.Contains(frontend, want) {
-				t.Fatalf("%s frontend lane does not bound and retry hung Bun work: missing %q", workflow, want)
+				t.Fatalf("%s frontend shard matrix is missing %q", workflow, want)
 			}
 		}
 	}
 
 	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
 	require.NoError(t, err)
+	frontendShard := taskfileTaskBlock(t, string(taskfile), "ci:lane:frontend:shard")
+	for _, want := range []string{
+		"enum: [core, reports, chat, data, site]",
+		"node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:test:frontend:{{.SHARD}}",
+	} {
+		if !strings.Contains(frontendShard, want) {
+			t.Fatalf("frontend shard lane must retain its bounded retry contract: missing %q", want)
+		}
+	}
 	frontendCore := taskfileTaskBlock(t, string(taskfile), "ci:test:frontend:core")
 	if !strings.Contains(frontendCore, "node --test scripts/ci_watchdog.test.mjs") {
 		t.Fatal("frontend core contract must exercise the Node watchdog independently of Bun")

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -3562,9 +3562,14 @@ func TestGitHubHostedCIRecoversFromHungBunProcesses(t *testing.T) {
 	}
 
 	nodeDeps := taskfileTaskBlock(t, string(taskfile), "node:deps")
-	for _, want := range []string{"method: checksum", "package.json", "bun.lock", "node_modules/.bin/esbuild"} {
+	for _, want := range []string{"run: once", "bun install --frozen-lockfile"} {
 		if !strings.Contains(nodeDeps, want) {
-			t.Errorf("node:deps must cache a verified install across nested preparation tasks: missing %q", want)
+			t.Errorf("node:deps must share one frozen install across nested preparation tasks: missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{"sources:", "generates:", "status:", "ignore_error:"} {
+		if strings.Contains(nodeDeps, forbidden) {
+			t.Errorf("node:deps must verify the installed tree on each invocation and propagate failures, found %q", forbidden)
 		}
 	}
 

--- a/internal/platform/architecture/ci_contract_test.go
+++ b/internal/platform/architecture/ci_contract_test.go
@@ -70,9 +70,27 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 	if strings.Contains(frontendLane, "- task: build") {
 		t.Fatal("frontend lane must not replace production assets while Go tests are running")
 	}
+	for _, shard := range []string{"core", "reports", "chat", "data", "site"} {
+		want := "- task: ci:lane:frontend:shard\n        vars: { SHARD: " + shard + " }"
+		if !strings.Contains(frontendLane, want) {
+			t.Fatalf("frontend aggregate lane missing shard %q", shard)
+		}
+	}
+	frontendShard := taskfileTaskBlock(t, taskfile, "ci:lane:frontend:shard")
+	for _, want := range []string{
+		"enum: [core, reports, chat, data, site]",
+		"node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:test:frontend:{{.SHARD}}",
+	} {
+		if !strings.Contains(frontendShard, want) {
+			t.Fatalf("frontend shard lane missing bounded retry contract %q", want)
+		}
+	}
 	localFrontendLane := taskfileTaskBlock(t, taskfile, "ci:lane:frontend:local")
-	if !strings.Contains(localFrontendLane, "node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend") {
-		t.Fatal("local frontend lane must diagnose and retry a hung Bun process")
+	if !strings.Contains(localFrontendLane, "- task: ci:lane:frontend") {
+		t.Fatal("local frontend lane must invoke the aggregate frontend shards")
+	}
+	if strings.Contains(localFrontendLane, "node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend") {
+		t.Fatal("local frontend lane must not apply one aggregate watchdog to all frontend shards")
 	}
 	frontendSite := taskfileTaskBlock(t, taskfile, "ci:test:frontend:site")
 	if !strings.Contains(frontendSite, "bun run test:site:prepared") {
@@ -120,7 +138,7 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 		"run: node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare",
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
-		"run: node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend",
+		"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
 		"run: task generated:check",
 	} {
 		if !strings.Contains(prWorkflow, want) {
@@ -135,7 +153,7 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 		"run: task ci:lane:go:apigen",
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
-		"run: node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend",
+		"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
 		"run: task ci:full:extras",
 	} {
 		if !strings.Contains(mergeWorkflow, want) {
@@ -150,12 +168,28 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 		"run: task ci:lane:go:apigen",
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
-		"run: node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:lane:frontend",
+		"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
 		"run: task ci:full:extras",
 		"run: task ci:nightly:extras",
 	} {
 		if !strings.Contains(nightlyWorkflow, want) {
 			t.Fatalf("nightly workflow missing %q", want)
+		}
+	}
+	for workflowName, workflow := range map[string]string{
+		"ci.yml":               prWorkflow,
+		"merge-validation.yml": mergeWorkflow,
+		"nightly.yml":          nightlyWorkflow,
+	} {
+		frontend := workflowJobBlock(t, workflow, "frontend-validation")
+		for _, want := range []string{
+			"fail-fast: false",
+			"shard: [core, reports, chat, data, site]",
+			"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
+		} {
+			if !strings.Contains(frontend, want) {
+				t.Fatalf("%s frontend validation missing shard contract %q", workflowName, want)
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bench:datastar-bridge": "node scripts/ensure_playwright.mjs && bun scripts/benchmark_datastar_bridge.ts",
     "test:theme": "node scripts/ensure_playwright.mjs && bun test static/theme.dom.test.ts",
     "test:site": "bun run build:site && bun run test:site:prepared",
-    "test:site:prepared": "node scripts/ensure_playwright.mjs && bun test scripts/build_site.test.ts site/site.dom.test.ts site/web/visual-example-highlights.test.ts",
+    "test:site:prepared": "node scripts/ensure_playwright.mjs && bun test scripts/build_site.test.ts site/test_server.test.ts site/site.dom.test.ts site/web/visual-example-highlights.test.ts",
     "test:datastar-lit": "bun test web/components/shared/datastar-lit.test.ts web/components/shared/signal-contract.test.ts",
     "test:ui-command-boundaries": "bun test scripts/check_ui_command_boundaries.test.ts && bun scripts/check_ui_command_boundaries.ts",
     "test:visualization-ir": "bun test web/components/dashboard/visualization/ir-contract.test.ts web/components/dashboard/visualization/host.test.ts web/components/dashboard/visualization/format.test.ts web/components/dashboard/visualization/conditional-format.test.ts web/components/dashboard/visualization/metadata.test.ts web/components/dashboard/visualization/interaction-command.test.ts web/components/dashboard/visualization/signal-envelope.test.ts web/components/dashboard/visualization/layout.test.ts web/components/dashboard/visualization/adapters/*.test.ts web/components/dashboard/visualization/adapters/maplibre/spatial-selection.test.ts web/components/dashboard/table/format.test.ts web/components/dashboard/table/conditional-formatting.test.ts",

--- a/scripts/frontend_ci_contract.test.ts
+++ b/scripts/frontend_ci_contract.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { parse } from 'yaml'
+
+const shards = ['core', 'reports', 'chat', 'data', 'site']
+const tasks = parse(readFileSync('Taskfile.yml', 'utf8')).tasks
+
+test('local frontend validation runs every bounded shard without suppressing failure', () => {
+  expect(tasks['ci:lane:frontend'].cmds).toEqual(shards.map((shard) => ({
+    task: 'ci:lane:frontend:shard', vars: { SHARD: shard },
+  })))
+  expect(tasks['ci:lane:frontend:shard'].cmds).toEqual([
+    'node scripts/ci_watchdog.mjs --timeout-seconds 180 --attempts 2 -- task ci:test:frontend:{{.SHARD}}',
+  ])
+  expect(tasks['ci:lane:frontend:local'].cmds).toEqual([{ task: 'ci:lane:frontend' }])
+  expect(tasks['ci:lane:frontend'].ignore_error).toBeUndefined()
+  expect(tasks['ci:lane:frontend:shard'].ignore_error).toBeUndefined()
+})
+
+for (const workflow of ['ci', 'merge-validation', 'nightly']) {
+  test(`${workflow} requires all isolated frontend shards with the existing watchdog bound`, () => {
+    const config = parse(readFileSync(`.github/workflows/${workflow}.yml`, 'utf8'))
+    const job = config.jobs['frontend-validation']
+    expect(job.strategy.matrix.shard).toEqual(shards)
+    expect(job.strategy['fail-fast']).toBe(false)
+    expect(job['continue-on-error']).toBeUndefined()
+    expect(job.steps.find((step: any) => step.name === 'Run frontend validation').run)
+      .toBe('task ci:lane:frontend:shard SHARD=${{ matrix.shard }}')
+    const gate = config.jobs['ci-gate']
+    expect(gate.needs).toContain('frontend-validation')
+    expect(gate.steps.some((step: any) => step.env?.FRONTEND_RESULT === "${{ needs.frontend-validation.result }}"))
+      .toBe(true)
+  })
+}

--- a/scripts/node_deps_contract.test.ts
+++ b/scripts/node_deps_contract.test.ts
@@ -1,0 +1,227 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { watch } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { parse, stringify } from 'yaml'
+
+type Task = Record<string, unknown>
+
+const repoRoot = resolve(import.meta.dir, '..')
+const taskBinary = 'task'
+const handshakeTimeoutMs = 5_000
+const taskTimeoutMs = 10_000
+const installerTimeoutMs = 8_000
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, watchedDirectory: string, description: string): Promise<void> {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout>
+    const watcher = watch(watchedDirectory, () => {
+      void check()
+    })
+    const finish = (error?: unknown) => {
+      if (settled) return
+      settled = true
+      watcher.close()
+      clearTimeout(timeout)
+      if (error) rejectPromise(error)
+      else resolvePromise()
+    }
+    const check = async () => {
+      try {
+        if (await predicate()) finish()
+      } catch (error) {
+        finish(error)
+      }
+    }
+    watcher.on('error', finish)
+    timeout = setTimeout(() => {
+      finish(new Error(`timed out waiting for ${description}`))
+    }, handshakeTimeoutMs)
+    // Register the watcher before checking so a marker created between the
+    // initial check and watch setup cannot be missed.
+    void check()
+  })
+}
+
+async function readLines(path: string): Promise<string[]> {
+  try {
+    return (await readFile(path, 'utf8')).split('\n').filter(Boolean)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+}
+
+async function withFixture<T>(run: (fixture: string) => Promise<T>): Promise<T> {
+  const fixture = await mkdtemp(join(tmpdir(), 'leapview-node-deps-contract-'))
+  try {
+    return await run(fixture)
+  } finally {
+    await rm(fixture, { recursive: true, force: true })
+  }
+}
+
+async function writeFixture(fixture: string): Promise<void> {
+  const taskfile = parse(await readFile(join(repoRoot, 'Taskfile.yml'), 'utf8')) as { tasks: Record<string, Task> }
+  const nodeDeps = structuredClone(taskfile.tasks['node:deps']) as Task
+  const fakeInstaller = join(fixture, 'fake-installer.ts')
+  const consumer = join(fixture, 'consumer.ts')
+  const installCommand = `bun "${fakeInstaller}"`
+
+  nodeDeps.cmds = [installCommand]
+
+  await writeFile(fakeInstaller, `
+import { appendFile, mkdir, writeFile } from 'node:fs/promises'
+import { existsSync, watch } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.env.FIXTURE_ROOT!
+const release = join(root, 'release')
+const installLog = join(root, 'install.log')
+const sentinel = join(root, 'node_modules', '.bin', 'esbuild')
+const complete = join(root, 'install-complete')
+const deadline = setTimeout(() => process.exit(124), ${installerTimeoutMs})
+
+await appendFile(installLog, \`\${process.pid}\\n\`)
+await writeFile(join(root, 'install-started'), 'started\\n')
+if (process.env.NODE_DEPS_FAIL === '1') process.exit(23)
+
+if (!existsSync(release)) {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const watcher = watch(root, (_event, filename) => {
+      if (String(filename) !== 'release' || !existsSync(release)) return
+      watcher.close()
+      resolvePromise()
+    })
+    watcher.on('error', rejectPromise)
+    // Check again after registering the watcher to close the exists/watch race.
+    if (existsSync(release)) {
+      watcher.close()
+      resolvePromise()
+    }
+  })
+}
+
+await mkdir(join(root, 'node_modules', '.bin'), { recursive: true })
+await writeFile(sentinel, 'installed\\n')
+await writeFile(complete, 'complete\\n')
+clearTimeout(deadline)
+`)
+  await writeFile(consumer, `
+import { appendFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.env.FIXTURE_ROOT!
+if (!existsSync(join(root, 'install-complete'))) process.exit(41)
+await appendFile(join(root, 'consumers.log'), \`\${process.argv[2]}\\n\`)
+`)
+  await writeFile(join(fixture, 'package.json'), '{}\n')
+  await writeFile(join(fixture, 'bun.lock'), '{}\n')
+  await writeFile(join(fixture, 'Taskfile.yml'), stringify({
+    version: '3',
+    tasks: {
+      'node:deps': nodeDeps,
+      'visualization-ir:generate': {
+        deps: ['node:deps'],
+        cmds: [`bun "${consumer}" visualization`],
+      },
+      'dashboard-contracts:generate': {
+        deps: ['node:deps', 'visualization-ir:generate'],
+        cmds: [`bun "${consumer}" dashboard`],
+      },
+    },
+  }))
+}
+
+type SpawnOptions = { env?: Record<string, string>; force?: boolean }
+
+function spawnTask(fixture: string, taskName: string, options: SpawnOptions = {}) {
+  const args = [taskBinary]
+  if (options.force) args.push('--force')
+  args.push('--dir', fixture, taskName)
+  return Bun.spawn(args, {
+    cwd: fixture,
+    env: { ...Bun.env, FIXTURE_ROOT: fixture, ...options.env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+}
+
+async function collectTask(taskProcess: ReturnType<typeof spawnTask>) {
+  // A failed handshake must not leave a Task subprocess (or its pipes) open.
+  const watchdog = setTimeout(() => taskProcess.kill(), taskTimeoutMs)
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      taskProcess.exited,
+      new Response(taskProcess.stdout).text(),
+      new Response(taskProcess.stderr).text(),
+    ])
+    return { exitCode, stdout, stderr }
+  } finally {
+    clearTimeout(watchdog)
+  }
+}
+
+async function runTask(fixture: string, taskName: string, extraEnv: Record<string, string> = {}) {
+  return collectTask(spawnTask(fixture, taskName, { env: extraEnv }))
+}
+
+test('node:deps runs once and gates both diamond consumers until install completes', async () => {
+  await withFixture(async (fixture) => {
+    await writeFixture(fixture)
+    // Force the graph so checksum/generate metadata cannot hide a second
+    // installer if the first branch happens to finish before the other starts.
+    const taskProcess = spawnTask(fixture, 'dashboard-contracts:generate', { force: true })
+    const taskResult = collectTask(taskProcess)
+
+    let result: Awaited<typeof taskResult>
+    try {
+      await waitFor(async () => (await readLines(join(fixture, 'install.log'))).length > 0, fixture, 'installer start')
+      expect(await readLines(join(fixture, 'consumers.log'))).toEqual([])
+    } finally {
+      await writeFile(join(fixture, 'release'), 'release\n')
+      result = await taskResult
+    }
+
+    expect(result).toMatchObject({ exitCode: 0 })
+    expect(await readLines(join(fixture, 'install.log'))).toHaveLength(1)
+    expect(await readLines(join(fixture, 'consumers.log'))).toEqual(['visualization', 'dashboard'])
+  })
+}, { timeout: taskTimeoutMs + 5_000 })
+
+test('node:deps failure is nonzero and prevents both diamond consumers', async () => {
+  await withFixture(async (fixture) => {
+    await writeFixture(fixture)
+    const result = await runTask(fixture, 'dashboard-contracts:generate', { NODE_DEPS_FAIL: '1' })
+    expect(result.exitCode).not.toBe(0)
+    expect(await readLines(join(fixture, 'consumers.log'))).toEqual([])
+  })
+}, { timeout: taskTimeoutMs + 5_000 })
+
+test('node:deps revalidates on a separate Task invocation when installation files exist', async () => {
+  await withFixture(async (fixture) => {
+    await writeFixture(fixture)
+    const first = spawnTask(fixture, 'node:deps')
+    const firstResult = collectTask(first)
+    let firstOutcome: Awaited<typeof firstResult>
+    try {
+      await waitFor(async () => (await readLines(join(fixture, 'install.log'))).length > 0, fixture, 'first installer start')
+    } finally {
+      await writeFile(join(fixture, 'release'), 'release\n')
+      firstOutcome = await firstResult
+    }
+    expect(firstOutcome.exitCode).toBe(0)
+    expect(await readLines(join(fixture, 'install.log'))).toHaveLength(1)
+    // This is the real task's historical generated sentinel; its existence
+    // must not suppress a fresh install on a later Task invocation.
+    // Even the old freshness sentinel must not bypass a new frozen verification.
+    expect(await readLines(join(fixture, 'node_modules', '.bin', 'esbuild'))).toEqual(['installed'])
+
+    const second = await runTask(fixture, 'node:deps')
+    expect(second.exitCode).toBe(0)
+    expect(await readLines(join(fixture, 'install.log'))).toHaveLength(2)
+  })
+}, { timeout: taskTimeoutMs + 5_000 })

--- a/site/site.dom.test.ts
+++ b/site/site.dom.test.ts
@@ -1,27 +1,32 @@
 import { afterAll, beforeAll, expect, test } from 'bun:test'
 import { chromium, type Browser } from '@playwright/test'
+import { startSiteTestServer, type SiteTestServer } from './test_server'
 
 const sitePort = 20000 + (process.pid % 10000)
 const baseURL = `http://127.0.0.1:${sitePort}`
 let browser: Browser
-let siteProcess: ReturnType<typeof Bun.spawn>
+let siteServer: SiteTestServer | undefined
 const siteReadyTimeout = 60_000
 
 beforeAll(async () => {
-  siteProcess = Bun.spawn(['go', 'run', './cmd/leapview-site', '-addr', `127.0.0.1:${sitePort}`], {
-    cwd: process.cwd(),
-    env: process.env,
-    stdout: 'ignore',
-    stderr: 'ignore',
-  })
-  await waitForSite()
-  browser = await chromium.launch()
+  const startupDeadline = Date.now() + siteReadyTimeout
+  try {
+    siteServer = await startSiteTestServer(sitePort, startupDeadline)
+    await waitForSite(siteServer.process, startupDeadline)
+    browser = await chromium.launch()
+  } catch (error) {
+    await siteServer?.stop()
+    siteServer = undefined
+    throw error
+  }
 }, siteReadyTimeout + 10_000)
 
 afterAll(async () => {
-  await browser?.close()
-  siteProcess?.kill()
-  await siteProcess?.exited
+  try {
+    await browser?.close()
+  } finally {
+    await siteServer?.stop()
+  }
 })
 
 test('site explains the product, its workflow, and where it fits in the data stack', async () => {
@@ -2755,8 +2760,7 @@ test('visual showcase remains visibly rendered in light and dark themes', async 
   }
 }, 30_000)
 
-async function waitForSite(): Promise<void> {
-  const deadline = Date.now() + siteReadyTimeout
+async function waitForSite(siteProcess: Bun.Subprocess, deadline: number): Promise<void> {
   while (Date.now() < deadline) {
     if (siteProcess.exitCode !== null) {
       throw new Error(`LeapView site exited before becoming ready (code ${siteProcess.exitCode})`)
@@ -2765,7 +2769,7 @@ async function waitForSite(): Promise<void> {
       const response = await fetch(baseURL)
       if (response.ok) return
     } catch {
-      // The Go command is still compiling or binding its listener.
+      // The directly spawned site is still binding its listener.
     }
     await Bun.sleep(100)
   }

--- a/site/test_server.test.ts
+++ b/site/test_server.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'bun:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:net'
+
+import { startSiteTestServer } from './test_server'
+
+test('site test server rejects an expired startup deadline before spawning', async () => {
+  await assert.rejects(
+    () => startSiteTestServer(0, Date.now() - 1),
+    /startup deadline expired before build/,
+  )
+})
+
+test('site test server stops its executable and remains idempotent', async () => {
+  const startupDeadline = Date.now() + 60_000
+  const port = await availablePort()
+  const site = await startSiteTestServer(port, startupDeadline)
+  const pid = site.process.pid
+  try {
+    await waitForHealth(port, site.process, startupDeadline)
+  } finally {
+    await site.stop()
+    await site.stop()
+  }
+
+  assert.equal(site.process.exitCode !== null, true)
+  assert.throws(
+    () => process.kill(pid, 0),
+    (error: unknown) => (error as NodeJS.ErrnoException)?.code === 'ESRCH',
+  )
+}, 70_000)
+
+async function availablePort(): Promise<number> {
+  const listener = createServer()
+  await new Promise<void>((resolve, reject) => {
+    listener.once('error', reject)
+    listener.listen(0, '127.0.0.1', resolve)
+  })
+  const address = listener.address()
+  if (!address || typeof address === 'string') throw new Error('test server did not receive a port')
+  await new Promise<void>((resolve, reject) => listener.close((error) => error ? reject(error) : resolve()))
+  return address.port
+}
+
+async function waitForHealth(port: number, siteProcess: Bun.Subprocess, deadline: number): Promise<void> {
+  const url = `http://127.0.0.1:${port}/healthz`
+  while (Date.now() < deadline) {
+    if (siteProcess.exitCode !== null) throw new Error(`site exited before becoming ready with code ${siteProcess.exitCode}`)
+    try {
+      const response = await fetch(url)
+      if (response.ok) return
+    } catch {
+      // The site is still starting.
+    }
+    await Bun.sleep(100)
+  }
+  throw new Error(`site did not become ready at ${url} before startup deadline`)
+}

--- a/site/test_server.ts
+++ b/site/test_server.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+export interface SiteTestServer {
+  readonly process: Bun.Subprocess
+  stop(): Promise<void>
+}
+
+/**
+ * Build and run the public site as the process that owns the listening socket.
+ *
+ * `go run` leaves the compiled child behind when its wrapper is terminated.
+ * A temporary executable keeps the test lifecycle to one process. It remains
+ * in the caller's process group so the CI watchdog also terminates it when a
+ * test process is force-killed.
+ */
+export async function startSiteTestServer(port: number, startupDeadline = Date.now() + 60_000): Promise<SiteTestServer> {
+  const directory = await mkdtemp(join(tmpdir(), 'leapview-site-test-'))
+  const binary = join(directory, 'leapview-site')
+  try {
+    const buildTimeout = startupDeadline - Date.now()
+    if (buildTimeout <= 0) throw new Error('site test server startup deadline expired before build')
+    const build = Bun.spawn(['go', 'build', '-o', binary, './cmd/leapview-site'], {
+      cwd: root,
+      env: process.env,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      killSignal: 'SIGKILL',
+      timeout: buildTimeout,
+    })
+    const [exitCode, stdout, stderr] = await Promise.all([
+      build.exited,
+      readProcessOutput(build.stdout),
+      readProcessOutput(build.stderr),
+    ])
+    if (exitCode !== 0) {
+      throw new Error(`building leapview-site failed with exit code ${exitCode}:\n${stderr || stdout}`)
+    }
+    if (Date.now() >= startupDeadline) throw new Error('site test server startup deadline expired after build')
+
+    const siteProcess = Bun.spawn([binary, '-addr', `127.0.0.1:${port}`], {
+      cwd: root,
+      env: process.env,
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+    let stopped = false
+    return {
+      process: siteProcess,
+      async stop(): Promise<void> {
+        if (stopped) return
+        stopped = true
+        try {
+          await terminate(siteProcess)
+        } finally {
+          await rm(directory, { recursive: true, force: true })
+        }
+      },
+    }
+  } catch (error) {
+    await rm(directory, { recursive: true, force: true })
+    throw error
+  }
+}
+
+async function terminate(siteProcess: Bun.Subprocess): Promise<void> {
+  if (siteProcess.exitCode !== null) {
+    await siteProcess.exited
+    return
+  }
+
+  let forceKillTimer: ReturnType<typeof setTimeout> | undefined
+  try {
+    signal(siteProcess, 'SIGTERM')
+    forceKillTimer = setTimeout(() => {
+      if (siteProcess.exitCode === null) signal(siteProcess, 'SIGKILL')
+    }, 5_000)
+    await siteProcess.exited
+  } finally {
+    if (forceKillTimer !== undefined) clearTimeout(forceKillTimer)
+  }
+}
+
+function signal(siteProcess: Bun.Subprocess, name: 'SIGTERM' | 'SIGKILL'): void {
+  try {
+    siteProcess.kill(name)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ESRCH') throw error
+  }
+}
+
+async function readProcessOutput(stream: ReadableStream<Uint8Array> | undefined): Promise<string> {
+  if (!stream) return ''
+  return new Response(stream).text()
+}

--- a/web/components/shared/windowed-table.dom.test.ts
+++ b/web/components/shared/windowed-table.dom.test.ts
@@ -130,16 +130,42 @@ test('windowed table loads requested blocks and rejects stale payloads', async (
         },
       })
       const requests: any[] = []
-      element.addEventListener('lv-windowed-table-request', (event: CustomEvent) => requests.push(event.detail))
+      const firstRequestPromise = new Promise<any>((resolve) => {
+        const handleRequest = (event: Event) => {
+          const request = (event as CustomEvent).detail
+          requests.push(request)
+          if (request.start < 100) return
+          element.removeEventListener('lv-windowed-table-request', handleRequest)
+          resolve(request)
+        }
+        element.addEventListener('lv-windowed-table-request', handleRequest)
+      })
       document.body.append(element)
       await element.updateComplete
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
 
       const root = element.shadowRoot!
       const scrollport = root.querySelector('.scrollport') as HTMLDivElement
-      scrollport.scrollTop = 5200
-      scrollport.dispatchEvent(new Event('scroll'))
-      await new Promise((resolve) => setTimeout(resolve, 120))
-      const firstRequest = requests.find((request) => request.start >= 100)
+      const nativeRequestAnimationFrame = window.requestAnimationFrame.bind(window)
+      let heldFrame: FrameRequestCallback | undefined
+      window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+        if (heldFrame) throw new Error('multiple delayed windowed-table frames')
+        heldFrame = callback
+        return 1
+      }
+      let requestBeforeFrameRelease: Record<string, unknown> | undefined
+      let delayedFrame: FrameRequestCallback | undefined
+      try {
+        scrollport.scrollTop = 5200
+        scrollport.dispatchEvent(new Event('scroll'))
+        requestBeforeFrameRelease = requests.find((request) => request.start >= 100)
+        delayedFrame = heldFrame
+        if (!delayedFrame) throw new Error('windowed-table scroll frame was not scheduled')
+        delayedFrame(performance.now())
+      } finally {
+        window.requestAnimationFrame = nativeRequestAnimationFrame
+      }
+      const firstRequest = await firstRequestPromise
       const blockStarts = firstRequest.block === 'all'
         ? [Math.max(0, firstRequest.start - 50), firstRequest.start, firstRequest.start + 50]
         : [0, 50, 100]
@@ -175,6 +201,8 @@ test('windowed table loads requested blocks and rejects stale payloads', async (
       }))
       return {
         firstRequest,
+        delayedFrameHeld: Boolean(delayedFrame),
+        requestBeforeFrameRelease: Boolean(requestBeforeFrameRelease),
         staleAccepted: staleText.includes('stale'),
         loadedRows: rows.filter((row) => row.text?.includes('loaded')).length,
         skeletonRows: rows.filter((row) => row.busy === 'true').length,
@@ -183,6 +211,8 @@ test('windowed table loads requested blocks and rejects stale payloads', async (
 
     expect(state.firstRequest.block).toBeTruthy()
     expect(state.firstRequest.count).toBe(50)
+    expect(state.delayedFrameHeld).toBe(true)
+    expect(state.requestBeforeFrameRelease).toBe(false)
     expect(state.staleAccepted).toBe(false)
     expect(state.loadedRows).toBeGreaterThan(0)
     expect(state.skeletonRows).toBeLessThan(10)


### PR DESCRIPTION
## Problem
Unrelated CI reliability failures block validation: heartbeat and windowed-table timing races, frontend watchdog stalls, and concurrent Bun installation EEXIST errors.

## Root cause
Heartbeat fakes observed work before cancellation synchronization; windowed-table tests assumed requests had arrived after a timer. Public-site test server lifecycle leaked resources, and an aggregate frontend watchdog covered too much work. Diamond Task dependencies launched multiple Bun writers into one node_modules tree; the freshness sentinel referenced an absent esbuild executable.

## Solution
Synchronize observable test events, clean up the site test server lifecycle, run frontend shards under existing bounded watchdogs, and give node:deps one execution owner per Task invocation. Each new Task invocation still runs bun install --frozen-lockfile.

## Tests added/updated
Heartbeat shutdown and stale payload assertions retained. Added site lifecycle, frontend shard contract, and dependency ownership/failure/revalidation tests plus architecture assertions.

## Reproduction and verification
Concurrent real Bun installs into one directory failed 7/8; isolated directories sharing the download cache passed 8/8. Patched six-consumer Task graph uses one installer; later invocations verify again; frozen-lockfile mismatch fails. Dependency regression tests passed 20 repetitions.

Cold local task ci passed: one fresh root install, 52 PostgreSQL packages, all five frontend shards on first attempts, and generated checks. Hosted validation pending.

## Scope and limitations
No FAI-667, FAI-669, Project identity implementation, or security policy changes. Parallel CI, race detection, and failure propagation remain intact. Independent local Task processes must use separate worktrees; run: once is scoped to a Task invocation.

Tracks FAI-754: https://linear.app/flid/issue/FAI-754