### PR TITLE
feat(semantic-access): govern discovery and consumer authorization (FAI-642)

### DIFF
--- a/adr/specifications/semantic-access-consumer-boundary.md
+++ b/adr/specifications/semantic-access-consumer-boundary.md
@@ -1,0 +1,58 @@
+# FAI-642 discovery and consumer boundary
+
+Status: implementation under validation; publication and exhaustive consumer
+qualification are not claimed complete. The durable boundary is described in
+[semantic access consumers](../../docs/articles/architecture/semantic-access-consumers.md).
+
+## Authority and responsibility
+
+- FAI-619's immutable SemanticModel is the authored authority. Protection is
+  derived from dataset filters and required grants, member requirements, and
+  their compiled dataset/relationship/metric dependencies. A missing model,
+  unknown member or inconsistent compiled snapshot is not a public asset.
+- FAI-637 owns definitions, assignments, trusted mappings and principal/group
+  resolution. Consumer composition must obtain coherent registry/control and
+  effective-value evidence from that authority, never browser-supplied values.
+- FAI-639 remains the only compiler/evaluator. Discovery projects its typed
+  requirements and decisions in sorted dataset/member/binding order; it does
+  not infer access by probing data or evaluate a second policy language.
+- FAI-642 binds authenticated principal, target instance, serving generation
+  and model identity to discovery and request planning. Direct references
+  receive the same authorization as listed assets. Missing or stale authority
+  fails closed, including paths that have only document-sharing authority.
+- FAI-641 retains scan enforcement. Protected consumer execution must use its
+  admitted planner and validate the resulting PlanIR/renderer envelope before
+  database execution. Predicates remain before joins and aggregation.
+
+## Consumer inventory
+
+The shared boundaries cover dashboard query authorization, planning for the
+semantic interface, Explore/catalog projection, and buffered/Arrow execution
+in materialize. Dashboard, agent/MCP, export, suggestion, raw-value and background
+paths must converge there or reject protected operations explicitly. Static
+metadata/visual-spec projections need authorization before serialization, not
+only before running a query. Source/Model authoring preview remains a distinct
+resource-authorized capability and must not substitute for protected semantic
+execution.
+
+| Current path | FAI-642 boundary |
+| --- | --- |
+| Dashboard, semantic API, agent/MCP, suggestions and raw values | Shared query authorization and request-bound materialization; metadata is gated before serialization. |
+| Explore and project catalog | Compiled-source discovery and filtered members; catalog authority comes from its exact serving lease. |
+| Public/embedded dashboards | Publication identities cannot supply semantic attribute authority; protected execution is denied, while explicit public models retain existing behavior. |
+| Protected byte/result reuse and bundles | Denied or bypassed until FAI-645 supplies lifecycle-qualified evidence; no invalidation implementation is added here. |
+| Scheduled work and exports | Current refresh scheduling publishes state rather than querying dashboards; dashboard YAML export is authoring, not a data export. No new scheduled-query or data-export implementation is introduced. |
+
+## Scope exclusions and dependencies
+
+No second registry, compiler or evaluator; no provider adapter, lifecycle
+transition, audit expansion, cache invalidation, production activation or
+cutover. Reuse paths unable to prove protected authorization must fail closed;
+FAI-645 owns policy-aware reuse/lifecycle integration. FAI-648 owns exhaustive
+cross-consumer qualification and FAI-649 owns cutover. VAL-11 remains Partial.
+Neutral activation verification must not fabricate a subject or bypass FAI-641;
+its remaining design is a dependency, not implicit consumer authorization.
+
+Historical implementation checkpoints are not qualification evidence for this
+boundary. This implementation uses the FAI-619/636/637/639/641 foundations
+already merged on main; it does not import stacked consumer or cutover work.

--- a/docs/articles/architecture/semantic-access-consumers.md
+++ b/docs/articles/architecture/semantic-access-consumers.md
@@ -1,0 +1,68 @@
+# Semantic access discovery and consumers
+
+FAI-642 connects authoritative access metadata to semantic discovery and
+request execution. Resource RBAC remains necessary: semantic permission does
+not grant document sharing, authoring, or access to another project.
+
+## Discovery authority
+
+The immutable SemanticModel carries dataset access filters and dataset/member
+required grants. FAI-639 compiles their transitive relationship and metric
+dependencies. Discovery uses these compiled requirements and the same typed
+decision as query admission, not a second policy interpreter.
+
+The shared query consumer returns sorted dataset, dimension-binding, and
+metric records with required grants, dependency/filter datasets, ownership,
+and qualified policy identity. Denied assets are omitted; direct references
+receive the same decision. Missing models, unknown members, mismatched source
+fingerprints, and invalid authority never become public assets.
+
+## Request authorization
+
+Application composition supplies the server instance, exact serving scope,
+and authenticated principal. Access resolves the live principal and active
+group closure with registry, control, and effective assignments in one owned
+PostgreSQL repeatable-read, read-only transaction. Caller-owned transactions
+are not accepted by this resolver.
+
+The direct-assignment adapter uses existing canonical values and opaque
+evidence. It does not accept browser claims or invent trusted-provider
+evidence. Publication identities, development bypass, and workload admission
+identities do not substitute for an authenticated semantic principal.
+
+Each consumer pins policy/decision identity. Fresh observations must still
+match it, preventing one response or plan from combining different valid
+authorization snapshots. Changed, disabled, tombstoned, or malformed authority
+fails closed. Discovery-only consumers cannot produce executable plans.
+
+## Execution boundary
+
+Request planners retain the activation-owned compiled model and consume the
+existing FAI-639 predicates. [SecurityBarrier enforcement](/docs/architecture/semantic-access-planner)
+remains before scans participate in joins and aggregation.
+
+Materialization requires a bound consumer for protected queries, compares its
+instance/project/environment/generation/model identity to the runtime, and
+checks private admission provenance plus exact PlanIR, SQL, arguments, and
+columns before execution. Arrow delivery rechecks authority before releasing
+schemas and batches; buffered results are rechecked after database execution
+before ownership is transferred to the caller. A copied or re-rendered
+altered graph is not admission.
+
+Dashboard queries, semantic API queries/explain, Explore, agent/MCP query
+paths, and raw-value/suggestion paths converge on these shared boundaries.
+Catalog and member projections are authorization-filtered. Whole-document
+projections that cannot safely express partial visibility deny the entire
+projection rather than expose denied members. Source/Model previews remain
+separately resource-authorized authoring capabilities, never semantic bypasses.
+
+## Deliberately unsupported paths
+
+Protected result/immutable-byte reuse and bundles without a proven request
+boundary fail closed. FAI-642 does not implement lifecycle-aware caching,
+invalidation, or audit expansion; those remain FAI-645 responsibilities.
+
+Neutral activation verification still needs its own trusted-context design;
+it must not fabricate a principal or skip planner admission. Exhaustive
+consumer qualification and production cutover remain FAI-648/FAI-649 work.
+This boundary does not complete VAL-11, which remains Partial.

--- a/docs/articles/architecture/semantic-access-planner.md
+++ b/docs/articles/architecture/semantic-access-planner.md
@@ -50,19 +50,19 @@ explicit scan/barrier input rendered as a derived relation on the joined side.
 This implementation does not introduce new relationship join kinds or claim
 provider-specific optimizer security guarantees.
 
-## Deferred composition
+## Consumer composition and deferred lifecycle
 
-FAI-642 must provide authoritative instance/generation, principal/group,
-registry/control, opaque assignment/verified-claim evidence, and current
-observation inputs to this planning boundary. It must also classify direct
-SQL and authoring-preview paths separately and wire discovery and consumers.
-This slice does not claim those consumers are protected merely because a
-planner barrier exists. VAL-11 remains Partial.
+FAI-642 provides the [shared consumer boundary](/docs/architecture/semantic-access-consumers)
+for authoritative instance/generation, principal/group, registry/control,
+opaque assignment evidence, and current observations. Direct SQL and
+authoring-preview paths remain separately classified. A planner barrier alone
+is not consumer authority, and raw claims are not trusted evidence.
+VAL-11 remains Partial.
 
 Authorization is sampled at plan admission. These seals do not constitute a
 runtime revocation watcher or permission to reuse an old plan after authority
-changes. Consumer execution context and policy-aware lifecycle/cache reuse
-remain separate follow-up responsibilities.
+changes. FAI-642 revalidates consumer execution and Arrow delivery;
+policy-aware lifecycle/cache reuse remains FAI-645 work.
 
 One concrete deferred path is `query.PrepareRepresentativePlans`, including
 its explicit-relationship verification helper. It constructs new planners
@@ -70,6 +70,7 @@ without semantic authority; `materialize.Runtime` uses this verification path.
 Policy-bearing models therefore fail closed there until the verification and
 consumer composition work supplies an appropriate trusted context. Even a
 configured planner's explicit-relationship verification currently constructs
-a separate candidate planner. FAI-642 must classify and wire that boundary;
-FAI-641 does not bypass admission for verification or claim protected-model
-deployment qualification.
+a separate candidate planner. This is a neutral activation-context dependency,
+not permission for FAI-642 to fabricate a subject. FAI-648/FAI-649 own the
+remaining qualification/cutover work; FAI-641 does not bypass admission for
+verification or claim protected-model deployment qualification.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -237,6 +237,7 @@ Focused slices are available at `/docs/agent-tools/tools/{name}.json|md`, `/docs
 - [Runtime architecture](/docs/architecture/runtime): Follow routing, query execution, and streamed UI updates.
 - [Semantic attribute registry and control plane](/docs/architecture/semantic-attribute-registry): Understand typed semantic attribute identity, ownership, lifecycle, and compatibility boundaries.
 - [Semantic access planner boundary](/docs/architecture/semantic-access-planner): Place typed authorization barriers before protected scans participate in relational operations.
+- [Semantic access discovery and consumers](/docs/architecture/semantic-access-consumers): Bind protected semantic discovery and execution to authoritative request evidence.
 - [Evidence-gated Arrow optimization](/docs/architecture/arrow-optimization-evidence): Measure dashboard Arrow boundaries before approving a production migration.
 - [Dashboard native Arrow response contract](/docs/architecture/dashboard-native-arrow-contract): Define the native-v1 schema, protocol, governance, pagination, and compatibility oracle for future dashboard Arrow experiments.
 - [Cross-role journey qualification](/docs/architecture/journey-qualification): Map FAI-492 consumer, creator, and operator states to executable assembled-app checks and evidence rules.

--- a/docs/navigation.yaml
+++ b/docs/navigation.yaml
@@ -555,6 +555,11 @@ sections:
             type: explanation
             summary: Place typed authorization barriers before protected scans participate in relational operations.
             source: articles/architecture/semantic-access-planner.md
+          - slug: architecture/semantic-access-consumers
+            title: Semantic access discovery and consumers
+            type: explanation
+            summary: Bind protected semantic discovery and execution to authoritative request evidence.
+            source: articles/architecture/semantic-access-consumers.md
           - slug: architecture/arrow-optimization-evidence
             title: Evidence-gated Arrow optimization
             type: explanation

--- a/internal/access/module/semantic_attribute_resolution.go
+++ b/internal/access/module/semantic_attribute_resolution.go
@@ -1,0 +1,59 @@
+package module
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+// ResolveSemanticAttributes resolves only the authenticated principal's
+// durable direct/group attributes. Authentication is taken from the existing
+// principal context; no caller-provided subject or raw provider claims are
+// accepted by this capability.
+func (m *Module) ResolveSemanticAttributes(ctx context.Context) (access.SemanticAttributeResolution, error) {
+	if ctx == nil {
+		return access.SemanticAttributeResolution{}, ErrUnauthorized
+	}
+	principal, ok := PrincipalFromContext(ctx)
+	if !ok || strings.TrimSpace(principal.ID) == "" || principal.ID != strings.TrimSpace(principal.ID) {
+		return access.SemanticAttributeResolution{}, ErrUnauthorized
+	}
+	if principal.DevBypass {
+		return access.SemanticAttributeResolution{}, ErrForbidden
+	}
+	// Publication and group identities are not authenticated principals for
+	// semantic attribute resolution. Service principals remain valid subjects
+	// for API and workload consumers.
+	if principal.Kind != access.PrincipalKindUser && principal.Kind != access.PrincipalKindServicePrincipal {
+		return access.SemanticAttributeResolution{}, ErrForbidden
+	}
+
+	subject, err := access.NewSubjectRef(access.SubjectKindPrincipal, principal.ID)
+	if err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+	repository := m.repositoryValue()
+	if repository == nil {
+		return access.SemanticAttributeResolution{}, errors.New("access repository is unavailable")
+	}
+	reader, ok := repository.(access.SemanticAttributeResolutionReader)
+	if !ok {
+		return access.SemanticAttributeResolution{}, fmt.Errorf("access repository does not support semantic attribute resolution")
+	}
+	resolution, err := reader.ResolveSemanticAttributes(ctx, subject)
+	if err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+	if resolution.Subject != subject {
+		return access.SemanticAttributeResolution{}, fmt.Errorf("semantic attribute resolution subject mismatch: expected %s, got %s", subject.ID, resolution.Subject.ID)
+	}
+	for _, resolvedSubject := range resolution.Subjects {
+		if resolvedSubject.Kind == access.SubjectKindPrincipal && resolvedSubject != subject {
+			return access.SemanticAttributeResolution{}, fmt.Errorf("semantic attribute resolution principal closure mismatch: expected %s, got %s", subject.ID, resolvedSubject.ID)
+		}
+	}
+	return resolution, nil
+}

--- a/internal/access/module/semantic_attribute_resolution_test.go
+++ b/internal/access/module/semantic_attribute_resolution_test.go
@@ -1,0 +1,110 @@
+package module
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+)
+
+type semanticAttributeResolutionTestRepository struct {
+	access.Repository
+	resolution access.SemanticAttributeResolution
+	err        error
+	subject    access.SubjectRef
+	calls      int
+}
+
+func (r *semanticAttributeResolutionTestRepository) ResolveSemanticAttributes(_ context.Context, subject access.SubjectRef) (access.SemanticAttributeResolution, error) {
+	r.subject = subject
+	r.calls++
+	if r.err != nil {
+		return access.SemanticAttributeResolution{}, r.err
+	}
+	return r.resolution, nil
+}
+
+func newSemanticAttributeResolutionTestModule(t *testing.T, repository access.Repository) *Module {
+	t.Helper()
+	m, err := newSurface(surfaceConfig{Repository: func() (access.Repository, error) { return repository, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func TestResolveSemanticAttributesBindsAuthenticatedPrincipal(t *testing.T) {
+	repository := &semanticAttributeResolutionTestRepository{resolution: access.SemanticAttributeResolution{
+		Subject:  access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: "principal-1"},
+		Subjects: []access.SubjectRef{{Kind: access.SubjectKindPrincipal, ID: "principal-1"}},
+	}}
+	m := newSemanticAttributeResolutionTestModule(t, repository)
+	ctx := WithPrincipal(context.Background(), Principal{ID: "principal-1", Kind: access.PrincipalKindUser})
+	resolution, err := m.ResolveSemanticAttributes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolution.Subject != repository.subject || repository.subject != (access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: "principal-1"}) {
+		t.Fatalf("resolved subject = %#v, want authenticated principal", resolution.Subject)
+	}
+	if repository.calls != 1 {
+		t.Fatalf("resolution calls = %d, want one", repository.calls)
+	}
+}
+
+func TestResolveSemanticAttributesRejectsUnauthenticatedBypassAndNonPrincipal(t *testing.T) {
+	repository := &semanticAttributeResolutionTestRepository{}
+	m := newSemanticAttributeResolutionTestModule(t, repository)
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want error
+	}{
+		{name: "missing", ctx: context.Background(), want: ErrUnauthorized},
+		{name: "development bypass", ctx: WithPrincipal(context.Background(), LocalDeveloperPrincipal()), want: ErrForbidden},
+		{name: "publication", ctx: WithPrincipal(context.Background(), Principal{ID: "publication-1", Kind: access.PrincipalKindDashboardPublication}), want: ErrForbidden},
+		{name: "group", ctx: WithPrincipal(context.Background(), Principal{ID: "group-1", Kind: access.PrincipalKindGroup}), want: ErrForbidden},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := m.ResolveSemanticAttributes(test.ctx)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+		})
+	}
+	if repository.calls != 0 {
+		t.Fatalf("rejected contexts invoked resolution %d times", repository.calls)
+	}
+}
+
+func TestResolveSemanticAttributesRejectsCrossSubjectResponse(t *testing.T) {
+	repository := &semanticAttributeResolutionTestRepository{resolution: access.SemanticAttributeResolution{
+		Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: "principal-2"},
+	}}
+	m := newSemanticAttributeResolutionTestModule(t, repository)
+	ctx := WithPrincipal(context.Background(), Principal{ID: "principal-1", Kind: access.PrincipalKindUser})
+	if _, err := m.ResolveSemanticAttributes(ctx); err == nil {
+		t.Fatal("cross-subject resolution was accepted")
+	}
+
+	repository.resolution = access.SemanticAttributeResolution{
+		Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: "principal-1"},
+		Subjects: []access.SubjectRef{
+			{Kind: access.SubjectKindPrincipal, ID: "principal-1"},
+			{Kind: access.SubjectKindPrincipal, ID: "principal-2"},
+		},
+	}
+	if _, err := m.ResolveSemanticAttributes(ctx); err == nil {
+		t.Fatal("cross-subject principal closure was accepted")
+	}
+}
+
+func TestResolveSemanticAttributesFailsClosedWithoutCapability(t *testing.T) {
+	m := newSemanticAttributeResolutionTestModule(t, &struct{ access.Repository }{})
+	ctx := WithPrincipal(context.Background(), Principal{ID: "principal-1", Kind: access.PrincipalKindUser})
+	if _, err := m.ResolveSemanticAttributes(ctx); err == nil {
+		t.Fatal("repository without resolution capability was accepted")
+	}
+}

--- a/internal/access/postgres/semantic_attribute_resolution.go
+++ b/internal/access/postgres/semantic_attribute_resolution.go
@@ -1,0 +1,133 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	accessdb "github.com/flidai/leapview/internal/access/postgres/internal/db"
+	"github.com/jackc/pgx/v5"
+)
+
+var _ access.SemanticAttributeResolutionReader = (*Repository)(nil)
+
+type semanticAttributeOwnedTransaction interface {
+	Commit(context.Context) error
+	Rollback(context.Context) error
+}
+
+// ResolveSemanticAttributes resolves one principal's direct and active-group
+// assignments together with the registry and control snapshots. The method
+// deliberately owns the transaction: callers must not be able to supply a
+// transaction with weaker isolation or write authority.
+func (r *Repository) ResolveSemanticAttributes(ctx context.Context, subject access.SubjectRef) (access.SemanticAttributeResolution, error) {
+	if ctx == nil {
+		return access.SemanticAttributeResolution{}, errors.New("semantic attribute resolution context is nil")
+	}
+	if err := access.ValidateSemanticAttributeSubject(subject); err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+	canonicalSubjectID, err := uuidID("semantic attribute subject id", subject.ID)
+	if err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+	subject.ID = canonicalSubjectID
+	if subject.Kind != access.SubjectKindPrincipal {
+		return access.SemanticAttributeResolution{}, fmt.Errorf("%w: semantic attribute resolution requires a principal subject", access.ErrSemanticAttributeSourceConflict)
+	}
+
+	db, err := r.requireDB()
+	if err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+	// A pgx transaction also implements DBTX. Detect any native transaction
+	// shape before beginning so the isolation/read-only contract cannot be
+	// silently inherited from the caller's transaction.
+	if _, ok := db.(semanticAttributeOwnedTransaction); ok {
+		return access.SemanticAttributeResolution{}, errors.New("semantic attribute resolution rejects caller-owned PostgreSQL transactions")
+	}
+
+	tx, err := r.beginTx(ctx)
+	if err != nil {
+		return access.SemanticAttributeResolution{}, fmt.Errorf("begin semantic attribute resolution transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`); err != nil {
+		return access.SemanticAttributeResolution{}, fmt.Errorf("set semantic attribute resolution transaction: %w", err)
+	}
+
+	bound := &Repository{db: tx, fingerprintKey: r.fingerprintKey}
+	if err := requireLiveSemanticAttributePrincipal(ctx, tx, subject.ID); err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+
+	// The generated group query is the same indexed closure used by the
+	// effective resolver. Keep the principal first, followed by its active
+	// membership rows in query order, and fail closed on any malformed or
+	// duplicate authority data.
+	groupIDs, err := accessdb.New(tx).ListPrincipalSemanticAttributeGroups(ctx, mustPGUUID(subject.ID))
+	if err != nil {
+		return access.SemanticAttributeResolution{}, fmt.Errorf("resolve principal semantic attribute groups: %w", err)
+	}
+	subjects := make([]access.SubjectRef, 0, len(groupIDs)+1)
+	subjects = append(subjects, subject)
+	seen := map[access.SubjectRef]struct{}{subject: {}}
+	for _, groupID := range groupIDs {
+		canonicalGroupID, groupErr := uuidID("semantic attribute group id", groupID)
+		if groupErr != nil {
+			return access.SemanticAttributeResolution{}, fmt.Errorf("%w: active semantic attribute group %q is invalid: %v", access.ErrSemanticAttributeSourceConflict, groupID, groupErr)
+		}
+		groupSubject := access.SubjectRef{Kind: access.SubjectKindGroup, ID: canonicalGroupID}
+		if _, duplicate := seen[groupSubject]; duplicate {
+			return access.SemanticAttributeResolution{}, fmt.Errorf("%w: active semantic attribute group %s is repeated", access.ErrSemanticAttributeSourceConflict, canonicalGroupID)
+		}
+		seen[groupSubject] = struct{}{}
+		subjects = append(subjects, groupSubject)
+	}
+
+	registry, err := bound.SemanticAttributeRegistry(ctx)
+	if err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+	control, err := bound.SemanticAttributeControl(ctx)
+	if err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+	attributes, err := bound.EffectiveDirectSemanticAttributeAssignments(ctx, subject)
+	if err != nil {
+		return access.SemanticAttributeResolution{}, err
+	}
+	observedAt := time.Now().UTC()
+
+	result := access.SemanticAttributeResolution{
+		Subject:    subject,
+		Subjects:   subjects,
+		Registry:   registry,
+		Control:    control,
+		Attributes: attributes,
+		ObservedAt: observedAt,
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return access.SemanticAttributeResolution{}, fmt.Errorf("commit semantic attribute resolution transaction: %w", err)
+	}
+	return result, nil
+}
+
+// requireLiveSemanticAttributePrincipal checks liveness inside the owned
+// repeatable-read snapshot. GetPrincipal excludes revoked rows; status and
+// disabled/blocked timestamps cover the remaining identity lifecycle states.
+func requireLiveSemanticAttributePrincipal(ctx context.Context, db DBTX, principalID string) error {
+	row, err := accessdb.New(db).GetPrincipal(ctx, mustPGUUID(principalID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("%w: semantic attribute principal %s is not live", access.ErrSemanticAttributeSourceConflict, principalID)
+	}
+	if err != nil {
+		return fmt.Errorf("read semantic attribute principal: %w", err)
+	}
+	if row.Status != "active" || row.DisabledAt.Valid || row.BlockedAt.Valid {
+		return fmt.Errorf("%w: semantic attribute principal %s is not live", access.ErrSemanticAttributeSourceConflict, principalID)
+	}
+	return nil
+}

--- a/internal/access/postgres/semantic_attribute_resolution.go
+++ b/internal/access/postgres/semantic_attribute_resolution.go
@@ -18,6 +18,10 @@ type semanticAttributeOwnedTransaction interface {
 	Rollback(context.Context) error
 }
 
+type semanticAttributeTransactionBeginner interface {
+	BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error)
+}
+
 // ResolveSemanticAttributes resolves one principal's direct and active-group
 // assignments together with the registry and control snapshots. The method
 // deliberately owns the transaction: callers must not be able to supply a
@@ -49,14 +53,15 @@ func (r *Repository) ResolveSemanticAttributes(ctx context.Context, subject acce
 		return access.SemanticAttributeResolution{}, errors.New("semantic attribute resolution rejects caller-owned PostgreSQL transactions")
 	}
 
-	tx, err := r.beginTx(ctx)
+	beginner, ok := db.(semanticAttributeTransactionBeginner)
+	if !ok {
+		return access.SemanticAttributeResolution{}, errors.New("access PostgreSQL database must support explicit read-only transactions")
+	}
+	tx, err := beginner.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
 	if err != nil {
 		return access.SemanticAttributeResolution{}, fmt.Errorf("begin semantic attribute resolution transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
-	if _, err := tx.Exec(ctx, `SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`); err != nil {
-		return access.SemanticAttributeResolution{}, fmt.Errorf("set semantic attribute resolution transaction: %w", err)
-	}
 
 	bound := &Repository{db: tx, fingerprintKey: r.fingerprintKey}
 	if err := requireLiveSemanticAttributePrincipal(ctx, tx, subject.ID); err != nil {

--- a/internal/access/postgres/semantic_attribute_resolution_test.go
+++ b/internal/access/postgres/semantic_attribute_resolution_test.go
@@ -1,0 +1,107 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestResolveSemanticAttributesPostgreSQL18ReturnsCoherentAuthorityAndClosure(t *testing.T) {
+	db := newAuditDatabase(t)
+	repo, err := NewAccess(db.runtime, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutation := access.SemanticAttributeMutationContext{ActorPrincipalID: auditActorID}
+	region, err := repo.RegisterSemanticAttribute(t.Context(), access.RegisterSemanticAttributeInput{
+		Name: "resolution_region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	team, err := repo.RegisterSemanticAttribute(t.Context(), access.RegisterSemanticAttributeInput{
+		Name: "resolution_team", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Mutation: mutation,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	group, err := repo.UpsertGroup(t.Context(), access.GroupInput{Name: "resolution-group"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.AddGroupMember(t.Context(), group.ID, auditActorID); err != nil {
+		t.Fatal(err)
+	}
+	principalSubject := access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: auditActorID}
+	groupSubject := access.SubjectRef{Kind: access.SubjectKindGroup, ID: group.ID}
+	if _, err := repo.SetSemanticAttributeAssignment(t.Context(), access.SemanticAttributeAssignmentInput{
+		DefinitionID: region.ID, Subject: principalSubject, Values: "west", Mutation: mutation,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.SetSemanticAttributeAssignment(t.Context(), access.SemanticAttributeAssignmentInput{
+		DefinitionID: team.ID, Subject: groupSubject, Values: "sales", Mutation: mutation,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := repo.ResolveSemanticAttributes(t.Context(), principalSubject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Subject != principalSubject {
+		t.Fatalf("subject = %#v, want %#v", resolved.Subject, principalSubject)
+	}
+	if len(resolved.Subjects) != 2 || resolved.Subjects[0] != principalSubject || resolved.Subjects[1] != groupSubject {
+		t.Fatalf("subject closure = %#v, want principal followed by active group", resolved.Subjects)
+	}
+	if resolved.Registry.State.Revision != 2 || len(resolved.Registry.Definitions) != 2 {
+		t.Fatalf("registry = %#v, want two definitions at revision 2", resolved.Registry)
+	}
+	if resolved.Control.State.Revision != 2 || resolved.Control.State.Digest == "" || len(resolved.Control.Assignments) != 2 {
+		t.Fatalf("control = %#v, want two assignments at revision 2", resolved.Control)
+	}
+	if len(resolved.Attributes) != 2 {
+		t.Fatalf("effective attributes = %#v, want direct and group values", resolved.Attributes)
+	}
+	if resolved.Attributes[0].DefinitionName != "resolution_region" || resolved.Attributes[0].CanonicalValues[0] != "west" ||
+		resolved.Attributes[1].DefinitionName != "resolution_team" || resolved.Attributes[1].CanonicalValues[0] != "sales" {
+		t.Fatalf("effective attributes = %#v", resolved.Attributes)
+	}
+	if resolved.ObservedAt.IsZero() || !resolved.ObservedAt.Equal(resolved.ObservedAt.UTC()) {
+		t.Fatalf("observed at = %v, want non-zero UTC", resolved.ObservedAt)
+	}
+}
+
+func TestResolveSemanticAttributesPostgreSQL18RejectsNonLivePrincipal(t *testing.T) {
+	db := newAuditDatabase(t)
+	repo, err := NewAccess(db.runtime, FingerprintConfig{Key: []byte("0123456789abcdef0123456789abcdef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.DisableProvisionedPrincipal(t.Context(), auditActorID); err != nil {
+		t.Fatal(err)
+	}
+	_, err = repo.ResolveSemanticAttributes(t.Context(), access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: auditActorID})
+	if !errors.Is(err, access.ErrSemanticAttributeSourceConflict) {
+		t.Fatalf("disabled principal error = %v, want source conflict", err)
+	}
+}
+
+func TestResolveSemanticAttributesPostgreSQL18RejectsCallerOwnedTransaction(t *testing.T) {
+	db := newAuditDatabase(t)
+	tx, err := db.runtime.Begin(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback(context.Background()) })
+	repo := &Repository{db: tx}
+	_, err = repo.ResolveSemanticAttributes(t.Context(), access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: auditActorID})
+	if err == nil || !strings.Contains(err.Error(), "caller-owned") {
+		t.Fatalf("caller-owned transaction error = %v, want explicit ownership rejection", err)
+	}
+}

--- a/internal/access/semantic_attribute_resolution.go
+++ b/internal/access/semantic_attribute_resolution.go
@@ -1,0 +1,28 @@
+package access
+
+import (
+	"context"
+	"time"
+)
+
+// SemanticAttributeResolution is one coherent, read-only observation of the
+// semantic-attribute authority for an authenticated principal. The subject
+// closure, registry, control state, and effective values are all read from the
+// same authority snapshot so consumers cannot accidentally combine values
+// from different membership or control revisions.
+type SemanticAttributeResolution struct {
+	Subject    SubjectRef
+	Subjects   []SubjectRef
+	Registry   SemanticAttributeRegistrySnapshot
+	Control    SemanticAttributeControlSnapshot
+	Attributes []EffectiveSemanticAttribute
+	ObservedAt time.Time
+}
+
+// SemanticAttributeResolutionReader is the narrow consumer capability for
+// coherent semantic-attribute reads. Implementations must resolve only the
+// requested subject and must fail closed when the principal or authority
+// snapshot is not live and internally consistent.
+type SemanticAttributeResolutionReader interface {
+	ResolveSemanticAttributes(context.Context, SubjectRef) (SemanticAttributeResolution, error)
+}

--- a/internal/agent/module/context.go
+++ b/internal/agent/module/context.go
@@ -100,6 +100,9 @@ func (m *Module) resolveDataTurnContext(ctx context.Context, scope agent.Scope, 
 	if err := validateDataExploration(model, exploration); err != nil {
 		return agent.TurnContext{}, err
 	}
+	if err := authorizeSemanticExploration(ctx, metrics, resolvedModel.String(), datasetID, model, exploration); err != nil {
+		return agent.TurnContext{}, errors.New("semantic context is unknown or unauthorized")
+	}
 	return agent.TurnContext{
 		Surface: "data", ModelID: resolvedModel.String(), DatasetID: datasetID,
 		Exploration: exploration,

--- a/internal/agent/module/semantic_context.go
+++ b/internal/agent/module/semantic_context.go
@@ -1,0 +1,62 @@
+package module
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flidai/leapview/internal/agent"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+// Agent turn references cannot widen semantic access. Resource authorization
+// above this boundary still applies; query execution subsequently uses the
+// same shared consumer/planner boundary rather than trusting turn metadata.
+func authorizeSemanticExploration(ctx context.Context, metrics any, modelID, dataset string, model *semanticmodel.Model, exploration *agent.DataExploration) error {
+	if model == nil {
+		return errors.New("semantic context model is unavailable")
+	}
+	port, ok := metrics.(interface {
+		SemanticConsumer(context.Context, string) (*semanticquery.SemanticAccessConsumer, error)
+	})
+	if !ok {
+		if model.AccessPolicy.Empty() {
+			return nil
+		}
+		return errors.New("semantic context authority is unavailable")
+	}
+	consumer, err := port.SemanticConsumer(ctx, modelID)
+	if err != nil {
+		return err
+	}
+	if consumer == nil || consumer.Planner() == nil || consumer.Planner().CompiledModel() == nil || !consumer.Planner().CompiledModel().MatchesModel(model) {
+		return errors.New("semantic context snapshot is stale")
+	}
+	if !model.AccessPolicy.Empty() && consumer.ModelID() != modelID {
+		return errors.New("semantic context model identity does not match")
+	}
+	if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: dataset}); err != nil {
+		return err
+	}
+	if exploration == nil {
+		return nil
+	}
+	for _, metric := range exploration.Metrics {
+		if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Metric: metric}); err != nil {
+			return err
+		}
+	}
+	fields := append([]string(nil), exploration.Dimensions...)
+	for _, filter := range exploration.Filters {
+		fields = append(fields, filter.Field)
+	}
+	if exploration.Time != nil {
+		fields = append(fields, exploration.Time.Field)
+	}
+	for _, field := range fields {
+		if _, err := consumer.Planner().PlanRows(semanticquery.RowRequest{Dataset: dataset, Dimensions: []semanticquery.Field{{Field: field}}, Limit: 1}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/agent/module/semantic_context_test.go
+++ b/internal/agent/module/semantic_context_test.go
@@ -1,0 +1,20 @@
+package module
+
+import (
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"testing"
+)
+
+func TestSemanticContextMissingAuthorityFailsClosed(t *testing.T) {
+	model := &semanticmodel.Model{}
+	if err := authorizeSemanticExploration(t.Context(), nil, "sales", "orders", model, nil); err != nil {
+		t.Fatal(err)
+	}
+	model.AccessPolicy.Datasets = map[string]semanticmodel.SemanticDatasetAccessSpec{"orders": {RequiredAccessGrants: []string{"staff"}}}
+	if err := authorizeSemanticExploration(t.Context(), nil, "sales", "orders", model, nil); err == nil {
+		t.Fatal("protected agent context accepted without authority")
+	}
+	if err := authorizeSemanticExploration(t.Context(), nil, "sales", "orders", nil, nil); err == nil {
+		t.Fatal("unknown model accepted as public")
+	}
+}

--- a/internal/analytics/dataquery/query.go
+++ b/internal/analytics/dataquery/query.go
@@ -108,7 +108,17 @@ type SpatialMetadata struct {
 type Field struct {
 	Field string
 	Alias string
+	// Kind preserves the semantic member kind when a field is carried outside
+	// its original dimensions/metrics collection (for example, into a
+	// count-only authorization projection). An empty kind is retained for
+	// legacy callers and is resolved only when the name is unambiguous.
+	Kind string `json:"Kind,omitempty"`
 }
+
+const (
+	FieldKindDimension = "dimension"
+	FieldKindMetric    = "metric"
+)
 
 type Time struct {
 	Field string

--- a/internal/analytics/duckdb/materialize.go
+++ b/internal/analytics/duckdb/materialize.go
@@ -786,7 +786,8 @@ func (r *ProjectRuntime) rebuildViews(ctx context.Context) error {
 			return "model." + physical, nil
 		}
 		view, err := analyticsmaterialize.NewRuntimeView(ctx, analyticsmaterialize.RuntimeConfig{
-			ModelID: modelID, Model: model, ResultPartition: config.ResultPartition,
+			ServingStateID: config.ServingStateID,
+			ModelID:        modelID, Model: model, ResultPartition: config.ResultPartition,
 			Database: r.db, Sources: r.sources, Resolver: r.sources,
 			SnapshotOnly: config.SnapshotID > 0, TableRelation: tableRelation,
 			QueryResultCache: config.QueryResultCache, ImmutableByteCache: config.ImmutableByteCache,

--- a/internal/analytics/materialize/runtime.go
+++ b/internal/analytics/materialize/runtime.go
@@ -22,8 +22,12 @@ import (
 )
 
 type RuntimeConfig struct {
-	ModelID string
-	Model   *semanticmodel.Model
+	// ServingStateID is the authoritative serving generation bound to this
+	// runtime. Protected semantic consumers must match it at execution time;
+	// it is not inferred from cache generations or request metadata.
+	ServingStateID string
+	ModelID        string
+	Model          *semanticmodel.Model
 	// ResultPartition is the stable production or candidate namespace for
 	// dependency-keyed query result reuse.
 	ResultPartition resultidentity.Partition
@@ -69,6 +73,7 @@ type ModelTableQuery struct {
 }
 
 type Runtime struct {
+	servingStateID     string
 	modelID            string
 	model              *semanticmodel.Model
 	planner            *semanticquery.Planner
@@ -91,14 +96,38 @@ type Runtime struct {
 // the serving-generation result-cache scope to byte-oriented consumers such
 // as vector tiles without leaking cache implementation details.
 func (r *Runtime) LookupImmutableBytes(key string) ([]byte, bool, error) {
+	state, err := r.requireSemanticProtectionState()
+	if err != nil {
+		return nil, false, err
+	}
+	if state.protected {
+		return nil, false, fmt.Errorf("protected semantic byte reuse requires lifecycle qualification")
+	}
+	if r.queryCache == nil {
+		return nil, false, fmt.Errorf("immutable byte cache is unavailable")
+	}
 	return r.queryCache.lookupBytes(key)
 }
 
 func (r *Runtime) StoreImmutableBytes(key string, value []byte) bool {
+	state, err := r.requireSemanticProtectionState()
+	if err != nil || state.protected || r.queryCache == nil {
+		return false
+	}
 	return r.queryCache.storeBytes(key, value) == resultcache.StoreStored
 }
 
 func (r *Runtime) CoalesceImmutableBytes(ctx context.Context, key string, execute func(context.Context) error) (bool, error) {
+	state, err := r.requireSemanticProtectionState()
+	if err != nil {
+		return false, err
+	}
+	if state.protected {
+		return false, fmt.Errorf("protected semantic byte reuse requires lifecycle qualification")
+	}
+	if r.queryCache == nil {
+		return false, fmt.Errorf("immutable byte cache is unavailable")
+	}
 	return r.queryCache.coalesceBytes(ctx, key, execute)
 }
 
@@ -210,7 +239,8 @@ func NewRuntimeView(ctx context.Context, config RuntimeConfig) (runtime *Runtime
 		return nil, err
 	}
 	runtime = &Runtime{
-		modelID: config.ModelID, model: config.Model, planner: planner, db: config.Database,
+		servingStateID: config.ServingStateID,
+		modelID:        config.ModelID, model: config.Model, planner: planner, db: config.Database,
 		sources: config.Sources, requiredExtensions: normalizedExtensions(config.RequiredExtensions),
 		queryCache: cache, resultPartition: config.ResultPartition,
 		resultLimits: limits, dependencyEvidence: config.DependencyEvidence,
@@ -513,6 +543,13 @@ func (r *Runtime) ExecuteDataQuery(ctx context.Context, request dataquery.Query)
 	if err := request.Validate(); err != nil {
 		return dataquery.Result{}, err
 	}
+	ctx, err := r.bindSemanticConsumerContext(ctx, request)
+	if err != nil {
+		return dataquery.Result{}, err
+	}
+	if _, _, err := r.semanticPlannerForRequest(ctx, request); err != nil {
+		return dataquery.Result{}, err
+	}
 	if _, ok := r.db.(arrowDatabase); !ok {
 		return dataquery.Result{}, fmt.Errorf("analytical database does not support native Arrow execution")
 	}
@@ -553,10 +590,18 @@ func (r *Runtime) ExecuteDataQueryArrow(ctx context.Context, request dataquery.Q
 	if err := request.Validate(); err != nil {
 		return dataquery.Result{}, err
 	}
+	ctx, err := r.bindSemanticConsumerContext(ctx, request)
+	if err != nil {
+		return dataquery.Result{}, err
+	}
+	_, semanticConsumer, err := r.semanticPlannerForRequest(ctx, request)
+	if err != nil {
+		return dataquery.Result{}, err
+	}
 
 	executePhysical := func(execCtx context.Context) (dataquery.Result, error) {
 		planningStarted := time.Now()
-		plan, err := r.planArrowQuery(request)
+		plan, err := r.planArrowQueryContext(execCtx, request)
 		planningMS := elapsedStageMS(planningStarted)
 		if err != nil {
 			return dataquery.Result{PlanningMS: planningMS}, err
@@ -574,8 +619,20 @@ func (r *Runtime) ExecuteDataQueryArrow(ctx context.Context, request dataquery.Q
 		}
 		execCtx, connectionWait := dataquery.WithConnectionWaitCounter(execCtx)
 		databaseStarted := time.Now()
+		if err := r.validateSemanticPlan(execCtx, request, plan); err != nil {
+			return dataquery.Result{PlanningMS: planningMS}, err
+		}
 		markPhysicalStatement(execCtx)
-		err = db.QueryArrow(execCtx, plan, sink)
+		querySink := sink
+		if semanticConsumer != nil {
+			guard := semanticConsumerSink{consumer: semanticConsumer, plan: plan, sink: sink}
+			if stats, ok := sink.(arrowquery.SinkStats); ok {
+				querySink = semanticConsumerStatsSink{semanticConsumerSink: guard, stats: stats}
+			} else {
+				querySink = guard
+			}
+		}
+		err = db.QueryArrow(execCtx, plan, querySink)
 		databaseMS := elapsedStageMS(databaseStarted)
 		rows, bytes := 0, int64(0)
 		if budget, found := dataquery.ResultBudgetFromContext(execCtx); found {
@@ -615,7 +672,11 @@ func (r *Runtime) ExecuteDataQueryArrow(ctx context.Context, request dataquery.Q
 }
 
 func (r *Runtime) planArrowQuery(request dataquery.Query) (semanticquery.Plan, error) {
-	planner, err := r.queryPlanner()
+	return r.planArrowQueryContext(context.Background(), request)
+}
+
+func (r *Runtime) planArrowQueryContext(ctx context.Context, request dataquery.Query) (semanticquery.Plan, error) {
+	planner, _, err := r.semanticPlannerForRequest(ctx, request)
 	if err != nil {
 		return semanticquery.Plan{}, err
 	}

--- a/internal/analytics/materialize/runtime_arrow_result.go
+++ b/internal/analytics/materialize/runtime_arrow_result.go
@@ -42,8 +42,16 @@ func rowPlanWithTotal(plan semanticquery.Plan) (semanticquery.Plan, error) {
 }
 
 func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dataquery.Query, transform dataquery.ResultTransformer) (dataquery.Result, error) {
+	state, snapshotErr := r.requireSemanticProtectionState()
+	if snapshotErr != nil {
+		return dataquery.Result{}, snapshotErr
+	}
 	cacheStarted := cacheObservationStarted(ctx, time.Now())
-	cacheable := dashboardQueryResultCacheable(request)
+	// Protected semantic results cannot enter the shared immutable-result path
+	// until lifecycle-bound cache evidence is available (FAI-645). They still
+	// execute through the request consumer and are validated immediately before
+	// every physical capture.
+	cacheable := dashboardQueryResultCacheable(request) && !state.protected
 	var planned plannedArrowQuery
 	var planErr error
 	admissionReason := dataquery.CacheAdmissionReasonQueryNotCacheable
@@ -51,7 +59,7 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 		observeQueryCacheAdmission(ctx, dataquery.CacheAdmissionBypassed, admissionReason)
 	}
 	if cacheable {
-		planned, planErr = r.planOwnedArrowQuery(request)
+		planned, planErr = r.planOwnedArrowQueryContext(ctx, request)
 		var resultIdentity semanticquery.ResultIdentity
 		var resultIdentityErr error
 		if planErr == nil {
@@ -90,7 +98,7 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 		summary, err := admitPhysicalQuery(execCtx, request, func(queryCtx context.Context) (dataquery.Result, error) {
 			if !cacheable {
 				var planningErr error
-				current, planningErr = r.planOwnedArrowQuery(request)
+				current, planningErr = r.planOwnedArrowQueryContext(queryCtx, request)
 				if planningErr != nil {
 					return dataquery.Result{PlanningMS: current.planningMS}, planningErr
 				}
@@ -108,7 +116,7 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 			}
 			queryCtx, connectionWait := dataquery.WithConnectionWaitCounter(queryCtx)
 			databaseStarted := time.Now()
-			data, queryErr := r.captureArrowPlan(queryCtx, current.plan)
+			data, queryErr := r.captureArrowPlan(queryCtx, request, current.plan)
 			databaseMS := elapsedStageMS(databaseStarted)
 			waitMS := connectionWait.Duration().Milliseconds()
 			if waitMS >= databaseMS {
@@ -130,7 +138,7 @@ func (r *Runtime) executeGovernedDataQueryArrow(ctx context.Context, request dat
 			}
 			if request.IncludeTotal && !execution.metadata.TotalRowsKnown && current.countPlan != nil {
 				countStarted := time.Now()
-				countData, countErr := r.captureArrowPlan(queryCtx, *current.countPlan)
+				countData, countErr := r.captureArrowPlan(queryCtx, request, *current.countPlan)
 				result.DatabaseMS += elapsedStageMS(countStarted)
 				if countErr != nil {
 					return result, countErr
@@ -214,7 +222,10 @@ func (r *Runtime) dependencyForPlan(plan semanticquery.Plan) (resultidentity.Dep
 	return r.dependencyForProjection(projection)
 }
 
-func (r *Runtime) captureArrowPlan(ctx context.Context, plan semanticquery.Plan) (*arrowresult.Result, error) {
+func (r *Runtime) captureArrowPlan(ctx context.Context, request dataquery.Query, plan semanticquery.Plan) (*arrowresult.Result, error) {
+	if err := r.validateSemanticPlan(ctx, request, plan); err != nil {
+		return nil, err
+	}
 	db, ok := r.db.(arrowDatabase)
 	if !ok {
 		return nil, fmt.Errorf("analytical database does not support native Arrow execution")
@@ -225,12 +236,25 @@ func (r *Runtime) captureArrowPlan(ctx context.Context, plan semanticquery.Plan)
 		collector.Abort()
 		return nil, err
 	}
+	// Buffered Arrow capture has no guarded sink between the database and the
+	// eventual result release. Recheck the request-bound admission after the
+	// database has finished writing, before Finish transfers ownership to the
+	// caller; an authority change during execution must not publish captured
+	// rows.
+	if err := r.validateSemanticPlan(ctx, request, plan); err != nil {
+		collector.Abort()
+		return nil, err
+	}
 	return collector.Finish()
 }
 
 func (r *Runtime) planOwnedArrowQuery(request dataquery.Query) (plannedArrowQuery, error) {
+	return r.planOwnedArrowQueryContext(context.Background(), request)
+}
+
+func (r *Runtime) planOwnedArrowQueryContext(ctx context.Context, request dataquery.Query) (plannedArrowQuery, error) {
 	started := time.Now()
-	planner, plannerErr := r.queryPlanner()
+	planner, consumer, plannerErr := r.semanticPlannerForRequest(ctx, request)
 	if plannerErr != nil {
 		return plannedArrowQuery{}, plannerErr
 	}
@@ -250,6 +274,11 @@ func (r *Runtime) planOwnedArrowQuery(request dataquery.Query) (plannedArrowQuer
 				err = fmt.Errorf("table count is unavailable because its authorization projection contains masked fields")
 				break
 			}
+			if consumer != nil {
+				if err = validateSemanticAuthorizationProjection(request, consumer); err != nil {
+					break
+				}
+			}
 			planned.countOnly = true
 			planned.plan, err = planner.PlanCount(semanticquery.CountRequest{Dataset: request.Target, Filters: dataQueryFilters(request.Filters)})
 			break
@@ -260,6 +289,19 @@ func (r *Runtime) planOwnedArrowQuery(request dataquery.Query) (plannedArrowQuer
 			ColumnMasks: dataQueryColumnMasks(request.ColumnMasks), Limit: request.Limit, Offset: request.Offset,
 		})
 		if err == nil && request.IncludeTotal {
+			if consumer != nil {
+				// Total rows are an explicitly safe two-plan rewrite for protected
+				// execution: both the visible rows and auxiliary count are admitted
+				// independently by the same request consumer. The public path keeps
+				// its existing one-plan transport optimization below.
+				count, countErr := planner.PlanCount(semanticquery.CountRequest{Dataset: request.Target, Filters: dataQueryFilters(request.Filters)})
+				if countErr != nil {
+					err = countErr
+				} else {
+					planned.countPlan = &count
+				}
+				break
+			}
 			planned.plan, err = rowPlanWithTotal(planned.plan)
 			planned.totalFromData = true
 			if err == nil {

--- a/internal/analytics/materialize/runtime_arrow_result.go
+++ b/internal/analytics/materialize/runtime_arrow_result.go
@@ -280,7 +280,18 @@ func (r *Runtime) planOwnedArrowQueryContext(ctx context.Context, request dataqu
 				}
 			}
 			planned.countOnly = true
-			planned.plan, err = planner.PlanCount(semanticquery.CountRequest{Dataset: request.Target, Filters: dataQueryFilters(request.Filters)})
+			if consumer != nil {
+				dimensions, metrics, projectionErr := semanticAuthorizationProjectionFields(consumer.Planner(), request)
+				if projectionErr != nil {
+					err = projectionErr
+					break
+				}
+				planned.plan, err = consumer.PlanRowsCount(semanticquery.RowRequest{
+					Dataset: request.Target, Dimensions: dimensions, Metrics: metrics, Filters: dataQueryFilters(request.Filters),
+				})
+			} else {
+				planned.plan, err = planner.PlanCount(semanticquery.CountRequest{Dataset: request.Target, Filters: dataQueryFilters(request.Filters)})
+			}
 			break
 		}
 		planned.plan, err = planner.PlanRows(semanticquery.RowRequest{
@@ -294,7 +305,9 @@ func (r *Runtime) planOwnedArrowQueryContext(ctx context.Context, request dataqu
 				// execution: both the visible rows and auxiliary count are admitted
 				// independently by the same request consumer. The public path keeps
 				// its existing one-plan transport optimization below.
-				count, countErr := planner.PlanCount(semanticquery.CountRequest{Dataset: request.Target, Filters: dataQueryFilters(request.Filters)})
+				count, countErr := consumer.PlanRowsCount(semanticquery.RowRequest{
+					Dataset: request.Target, Dimensions: dataQueryFields(request.Fields), Metrics: dataQueryFields(request.Metrics), Filters: dataQueryFilters(request.Filters),
+				})
 				if countErr != nil {
 					err = countErr
 				} else {

--- a/internal/analytics/materialize/runtime_bundle_pipeline.go
+++ b/internal/analytics/materialize/runtime_bundle_pipeline.go
@@ -105,6 +105,13 @@ func (r *Runtime) ExecuteDataQueryBundle(ctx context.Context, requests []dataque
 	if r == nil || r.db == nil {
 		return dataquery.BundleResult{}, fmt.Errorf("materialization runtime is not initialized")
 	}
+	state, err := r.requireSemanticProtectionState()
+	if err != nil {
+		return dataquery.BundleResult{}, err
+	}
+	if state.protected {
+		return dataquery.BundleResult{}, &dataquery.BundleIncompatibleError{Err: fmt.Errorf("protected semantic bundles require lifecycle qualification; execute governed branches separately")}
+	}
 	if len(requests) < 2 {
 		return dataquery.BundleResult{}, &dataquery.BundleIncompatibleError{Err: fmt.Errorf("bundle requires at least two branches")}
 	}
@@ -433,7 +440,7 @@ func (r *Runtime) executeArrowBundle(ctx context.Context, planned plannedBundle)
 	summary := dataquery.Result{PlanningMS: planned.planningMS, SQL: planned.plan.Plan.SQL}
 	// captureArrowPlan transfers one creator-owned reference to this stage.
 	// It is released here after splitting on every success and error path.
-	source, err := r.captureArrowPlan(ctx, planned.plan.Plan)
+	source, err := r.captureArrowPlan(ctx, dataquery.Query{ModelID: r.modelID}, planned.plan.Plan)
 	if source != nil {
 		defer source.Release()
 	}

--- a/internal/analytics/materialize/semantic_consumer.go
+++ b/internal/analytics/materialize/semantic_consumer.go
@@ -167,17 +167,9 @@ func validateSemanticAuthorizationProjection(request dataquery.Query, consumer *
 	if planner == nil || planner.CompiledModel() == nil {
 		return fmt.Errorf("semantic authorization projection planner is unavailable")
 	}
-	dimensions := make([]semanticquery.Field, 0, len(request.AuthorizationFields))
-	metrics := make([]semanticquery.Field, 0, len(request.AuthorizationFields))
-	for _, field := range request.AuthorizationFields {
-		if strings.TrimSpace(field.Field) == "" {
-			return fmt.Errorf("semantic authorization projection contains an empty field")
-		}
-		if _, ok := planner.CompiledModel().Metric(field.Field); ok {
-			metrics = append(metrics, semanticquery.Field{Field: field.Field, Alias: field.Alias})
-			continue
-		}
-		dimensions = append(dimensions, semanticquery.Field{Field: field.Field, Alias: field.Alias})
+	dimensions, metrics, err := semanticAuthorizationProjectionFields(planner, request)
+	if err != nil {
+		return err
 	}
 	projection, err := planner.Plan(semanticquery.Request{
 		Dataset: request.Target, Dimensions: dimensions, Metrics: metrics,
@@ -190,6 +182,58 @@ func validateSemanticAuthorizationProjection(request dataquery.Query, consumer *
 		return fmt.Errorf("validate semantic count projection: %w", err)
 	}
 	return nil
+}
+
+// semanticAuthorizationProjectionFields preserves the member kind that was
+// present in the original logical projection. Count-only requests carry no
+// physical fields, so reconstructing this projection from names alone is
+// unsafe when a model has a dimension and metric with the same name.
+//
+// Empty kinds are accepted for backwards compatibility only when the name is
+// unambiguous. Ambiguous legacy references fail closed instead of silently
+// selecting the metric namespace.
+func semanticAuthorizationProjectionFields(planner *semanticquery.Planner, request dataquery.Query) ([]semanticquery.Field, []semanticquery.Field, error) {
+	if planner == nil || planner.CompiledModel() == nil {
+		return nil, nil, fmt.Errorf("semantic authorization projection planner is unavailable")
+	}
+	compiled := planner.CompiledModel()
+	dimensions := make([]semanticquery.Field, 0, len(request.AuthorizationFields))
+	metrics := make([]semanticquery.Field, 0, len(request.AuthorizationFields))
+	for _, field := range request.AuthorizationFields {
+		name := strings.TrimSpace(field.Field)
+		if name == "" {
+			return nil, nil, fmt.Errorf("semantic authorization projection contains an empty field")
+		}
+		memberKind := strings.ToLower(strings.TrimSpace(field.Kind))
+		switch memberKind {
+		case dataquery.FieldKindMetric:
+			metrics = append(metrics, semanticquery.Field{Field: field.Field, Alias: field.Alias})
+			continue
+		case dataquery.FieldKindDimension:
+			dimensions = append(dimensions, semanticquery.Field{Field: field.Field, Alias: field.Alias})
+			continue
+		case "":
+			_, metricKnown := compiled.Metric(name)
+			_, dimensionKnown := compiled.SemanticDimension(name)
+			if !dimensionKnown {
+				_, dimensionKnown = compiled.PhysicalField(name)
+			}
+			if metricKnown && dimensionKnown {
+				return nil, nil, fmt.Errorf("semantic authorization projection field %q is ambiguous between metric and dimension", name)
+			}
+			if metricKnown {
+				metrics = append(metrics, semanticquery.Field{Field: field.Field, Alias: field.Alias})
+				continue
+			}
+			// Qualified physical fields and legacy semantic dimensions are
+			// resolved by the planner's dimension path validation below.
+			dimensions = append(dimensions, semanticquery.Field{Field: field.Field, Alias: field.Alias})
+			continue
+		default:
+			return nil, nil, fmt.Errorf("semantic authorization projection field %q has unsupported kind %q", name, field.Kind)
+		}
+	}
+	return dimensions, metrics, nil
 }
 
 // semanticConsumerSink rechecks the exact admitted plan before each Arrow

--- a/internal/analytics/materialize/semantic_consumer.go
+++ b/internal/analytics/materialize/semantic_consumer.go
@@ -1,0 +1,223 @@
+package materialize
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/flidai/leapview/internal/analytics/arrowquery"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+type semanticProtectionState struct {
+	protected bool
+	known     bool
+}
+
+// semanticProtectionState reports the policy boundary from the activation
+// planner's detached source snapshot. A missing or malformed snapshot is not
+// treated as a public model: cache and execution callers must fail closed
+// rather than allowing an unknown model to enter an unqualified path.
+func (r *Runtime) semanticProtectionState() semanticProtectionState {
+	if r == nil || r.model == nil || r.planner == nil {
+		return semanticProtectionState{}
+	}
+	compiled := r.planner.CompiledModel()
+	if compiled == nil {
+		return semanticProtectionState{}
+	}
+	model := compiled.SourceModel()
+	if model == nil {
+		return semanticProtectionState{}
+	}
+	return semanticProtectionState{protected: !model.AccessPolicy.Empty(), known: true}
+}
+
+// protectedSemanticModel reports the policy boundary from the activation
+// planner's detached source snapshot. It is intentionally independent of the
+// request: callers cannot make a protected model public by omitting fields.
+// Use semanticProtectionState when an unknown snapshot must be rejected.
+func (r *Runtime) protectedSemanticModel() bool {
+	return r.semanticProtectionState().protected
+}
+
+func (r *Runtime) requireSemanticProtectionState() (semanticProtectionState, error) {
+	state := r.semanticProtectionState()
+	if !state.known {
+		return state, fmt.Errorf("semantic access model snapshot is unavailable")
+	}
+	return state, nil
+}
+
+type semanticConsumerBinder interface {
+	BindSemanticConsumer(context.Context, string) (context.Context, error)
+}
+
+// bindSemanticConsumerContext lets an execution adapter recover the
+// request-bound capability when a governor owns the composition boundary but
+// has not explicitly attached it yet. The returned context must replace the
+// caller's context for the complete operation; creating a consumer here and
+// dropping the returned context would leave the later plan validation without
+// the same capability.
+func (r *Runtime) bindSemanticConsumerContext(ctx context.Context, request dataquery.Query) (context.Context, error) {
+	if !r.protectedSemanticModel() || request.Kind == dataquery.KindModelRows {
+		return ctx, nil
+	}
+	if _, ok := semanticquery.SemanticAccessConsumerContextFromContext(ctx); ok {
+		return ctx, nil
+	}
+	governor, ok := dataquery.GovernorFromContext(ctx)
+	if !ok {
+		return ctx, fmt.Errorf("protected semantic execution requires a request-bound consumer")
+	}
+	binder, ok := governor.(semanticConsumerBinder)
+	if !ok {
+		return ctx, fmt.Errorf("protected semantic execution governor cannot bind a consumer")
+	}
+	bound, err := binder.BindSemanticConsumer(ctx, request.ModelID)
+	if err != nil {
+		return ctx, fmt.Errorf("bind protected semantic consumer: %w", err)
+	}
+	if _, ok := semanticquery.SemanticAccessConsumerContextFromContext(bound); !ok {
+		return ctx, fmt.Errorf("protected semantic consumer binding is invalid")
+	}
+	return bound, nil
+}
+
+// semanticPlannerForRequest selects the request-bound consumer planner for a
+// protected semantic model. The activation planner is retained for public
+// models only; protected execution without an exact consumer capability fails
+// closed before planning or cache access.
+func (r *Runtime) semanticPlannerForRequest(ctx context.Context, request dataquery.Query) (*semanticquery.Planner, *semanticquery.SemanticAccessConsumer, error) {
+	planner, err := r.queryPlanner()
+	if err != nil {
+		return nil, nil, err
+	}
+	state, err := r.requireSemanticProtectionState()
+	if err != nil {
+		return nil, nil, err
+	}
+	if !state.protected {
+		return planner, nil, nil
+	}
+	if request.Kind == dataquery.KindModelRows {
+		return nil, nil, fmt.Errorf("physical authoring preview cannot use a protected semantic consumer")
+	}
+	bound, ok := semanticquery.SemanticAccessConsumerContextFromContext(ctx)
+	if !ok {
+		return nil, nil, fmt.Errorf("protected semantic execution requires a request-bound consumer")
+	}
+	if err := bound.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("protected semantic execution context: %w", err)
+	}
+	binding := bound.Binding
+	instanceID := strings.TrimSpace(r.resultPartition.TargetID())
+	if instanceID == "" || binding.InstanceID != instanceID {
+		return nil, nil, fmt.Errorf("semantic access consumer instance %q does not match runtime instance %q", binding.InstanceID, instanceID)
+	}
+	if strings.TrimSpace(r.servingStateID) == "" || binding.Generation != r.servingStateID {
+		return nil, nil, fmt.Errorf("semantic access consumer generation %q does not match runtime generation %q", binding.Generation, r.servingStateID)
+	}
+	if request.ModelID != "" && request.ModelID != binding.ModelID {
+		return nil, nil, fmt.Errorf("semantic access consumer model %q does not match request model %q", binding.ModelID, request.ModelID)
+	}
+	if strings.TrimSpace(r.modelID) == "" || binding.ModelID != r.modelID {
+		return nil, nil, fmt.Errorf("semantic access consumer model %q does not match runtime model %q", binding.ModelID, r.modelID)
+	}
+	if request.PrincipalID != "" && request.PrincipalID != binding.PrincipalID {
+		return nil, nil, fmt.Errorf("semantic access consumer principal does not match request")
+	}
+	projectID := strings.TrimSpace(r.resultPartition.ProjectID().String())
+	if projectID == "" || binding.ProjectID != projectID {
+		return nil, nil, fmt.Errorf("semantic access consumer project %q does not match runtime project %q", binding.ProjectID, projectID)
+	}
+	environment := strings.TrimSpace(r.resultPartition.Environment())
+	if environment == "" || binding.Environment != environment {
+		return nil, nil, fmt.Errorf("semantic access consumer environment %q does not match runtime environment %q", binding.Environment, environment)
+	}
+	consumerPlanner := bound.Consumer.Planner()
+	if consumerPlanner == nil || consumerPlanner.CompiledModel() == nil || !consumerPlanner.CompiledModel().MatchesModel(r.model) {
+		return nil, nil, fmt.Errorf("semantic access consumer planner is stale")
+	}
+	return consumerPlanner, bound.Consumer, nil
+}
+
+func (r *Runtime) validateSemanticPlan(ctx context.Context, request dataquery.Query, plan semanticquery.Plan) error {
+	if !r.protectedSemanticModel() {
+		return nil
+	}
+	_, consumer, err := r.semanticPlannerForRequest(ctx, request)
+	if err != nil {
+		return err
+	}
+	return consumer.ValidatePlan(plan)
+}
+
+// validateSemanticAuthorizationProjection proves the fields used to
+// authorize a count-only table through the same request-bound planner. The
+// count SQL intentionally omits those fields, so admitting only PlanCount
+// would otherwise make a denied projection invisible to execution.
+func validateSemanticAuthorizationProjection(request dataquery.Query, consumer *semanticquery.SemanticAccessConsumer) error {
+	if consumer == nil || request.Kind != dataquery.KindSemanticRows || !request.IncludeTotal || len(request.Fields) != 0 || len(request.Metrics) != 0 || len(request.AuthorizationFields) == 0 {
+		return nil
+	}
+	planner := consumer.Planner()
+	if planner == nil || planner.CompiledModel() == nil {
+		return fmt.Errorf("semantic authorization projection planner is unavailable")
+	}
+	dimensions := make([]semanticquery.Field, 0, len(request.AuthorizationFields))
+	metrics := make([]semanticquery.Field, 0, len(request.AuthorizationFields))
+	for _, field := range request.AuthorizationFields {
+		if strings.TrimSpace(field.Field) == "" {
+			return fmt.Errorf("semantic authorization projection contains an empty field")
+		}
+		if _, ok := planner.CompiledModel().Metric(field.Field); ok {
+			metrics = append(metrics, semanticquery.Field{Field: field.Field, Alias: field.Alias})
+			continue
+		}
+		dimensions = append(dimensions, semanticquery.Field{Field: field.Field, Alias: field.Alias})
+	}
+	projection, err := planner.Plan(semanticquery.Request{
+		Dataset: request.Target, Dimensions: dimensions, Metrics: metrics,
+		Filters: dataQueryFilters(request.Filters),
+	})
+	if err != nil {
+		return fmt.Errorf("authorize semantic count projection: %w", err)
+	}
+	if err := consumer.ValidatePlan(projection); err != nil {
+		return fmt.Errorf("validate semantic count projection: %w", err)
+	}
+	return nil
+}
+
+// semanticConsumerSink rechecks the exact admitted plan before each Arrow
+// delivery. Once a schema or batch has been released it cannot be retracted,
+// so authority changes during a stream must stop before the next write.
+type semanticConsumerSink struct {
+	consumer *semanticquery.SemanticAccessConsumer
+	plan     semanticquery.Plan
+	sink     arrowquery.Sink
+}
+
+type semanticConsumerStatsSink struct {
+	semanticConsumerSink
+	stats arrowquery.SinkStats
+}
+
+func (s semanticConsumerStatsSink) RowsWritten() int { return s.stats.RowsWritten() }
+
+func (s semanticConsumerSink) WriteSchema(schema *arrow.Schema) error {
+	if err := s.consumer.ValidatePlan(s.plan); err != nil {
+		return err
+	}
+	return s.sink.WriteSchema(schema)
+}
+
+func (s semanticConsumerSink) WriteRecord(record arrow.RecordBatch) error {
+	if err := s.consumer.ValidatePlan(s.plan); err != nil {
+		return err
+	}
+	return s.sink.WriteRecord(record)
+}

--- a/internal/analytics/materialize/semantic_consumer_authorization_test.go
+++ b/internal/analytics/materialize/semantic_consumer_authorization_test.go
@@ -1,0 +1,112 @@
+package materialize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+func TestProtectedCountAuthorizationPreservesSameNameMemberKinds(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowMetric bool
+		deniedKind  string
+		allowedKind string
+	}{
+		{name: "dimension denied metric allowed", allowMetric: true, deniedKind: dataquery.FieldKindDimension, allowedKind: dataquery.FieldKindMetric},
+		{name: "metric denied dimension allowed", allowMetric: false, deniedKind: dataquery.FieldKindMetric, allowedKind: dataquery.FieldKindDimension},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime, governor, _ := protectedConsumerFixtureWithMemberAccess(t, tt.allowMetric)
+			ctx := semanticquery.WithSemanticAccessConsumer(context.Background(), governor.consumer, governor.binding)
+			request := dataquery.Query{
+				ModelID: "sales", Kind: dataquery.KindSemanticRows, Target: "orders", IncludeTotal: true,
+				AuthorizationFields: []dataquery.Field{{Field: "shared", Kind: tt.deniedKind}},
+			}
+			if _, err := runtime.planOwnedArrowQueryContext(ctx, request); err == nil || !strings.Contains(err.Error(), "semantic access denied for "+tt.deniedKind) {
+				t.Fatalf("denied %s count authorization error = %v", tt.deniedKind, err)
+			}
+			request.AuthorizationFields[0].Kind = tt.allowedKind
+			if _, err := runtime.planOwnedArrowQueryContext(ctx, request); err != nil {
+				t.Fatalf("allowed %s count authorization error = %v", tt.allowedKind, err)
+			}
+		})
+	}
+}
+
+func TestSemanticAuthorizationProjectionPreservesMemberKind(t *testing.T) {
+	planner := sameNameAuthorizationPlanner(t)
+
+	tests := []struct {
+		name          string
+		field         dataquery.Field
+		wantDimension bool
+		wantMetric    bool
+	}{
+		{name: "explicit dimension", field: dataquery.Field{Field: "shared", Kind: dataquery.FieldKindDimension}, wantDimension: true},
+		{name: "explicit metric", field: dataquery.Field{Field: "shared", Kind: dataquery.FieldKindMetric}, wantMetric: true},
+		{name: "unambiguous dimension", field: dataquery.Field{Field: "dimension_only"}, wantDimension: true},
+		{name: "unambiguous metric", field: dataquery.Field{Field: "metric_only"}, wantMetric: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dimensions, metrics, err := semanticAuthorizationProjectionFields(planner, dataquery.Query{
+				AuthorizationFields: []dataquery.Field{tt.field},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (len(dimensions) == 1) != tt.wantDimension || (len(metrics) == 1) != tt.wantMetric {
+				t.Fatalf("dimensions=%#v metrics=%#v, want dimension=%v metric=%v", dimensions, metrics, tt.wantDimension, tt.wantMetric)
+			}
+		})
+	}
+}
+
+func TestSemanticAuthorizationProjectionRejectsAmbiguousLegacyMember(t *testing.T) {
+	planner := sameNameAuthorizationPlanner(t)
+	_, _, err := semanticAuthorizationProjectionFields(planner, dataquery.Query{
+		AuthorizationFields: []dataquery.Field{{Field: "shared"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("ambiguous legacy projection error = %v", err)
+	}
+}
+
+func sameNameAuthorizationPlanner(t *testing.T) *semanticquery.Planner {
+	t.Helper()
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				ModelName:   "orders",
+				Execution:   semanticmodel.ExecutionDefinition{SQL: "SELECT 1 AS id, 1 AS shared"},
+				GrainEntity: "order",
+				Entities:    map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"id"}}},
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"id":     {Field: "orders.id", Table: "orders", Name: "id", Type: "number", Datatype: semanticmodel.DataTypeInteger},
+					"shared": {Field: "orders.shared", Table: "orders", Name: "shared", Type: "number", Datatype: semanticmodel.DataTypeInteger},
+				},
+			},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"shared":         {Name: "shared", Datatype: semanticmodel.DataTypeInteger, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.shared"}}},
+			"dimension_only": {Name: "dimension_only", Datatype: semanticmodel.DataTypeInteger, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.id"}}},
+		},
+		Metrics: map[string]semanticmodel.Metric{
+			"shared":      {Name: "shared", Type: "aggregate", Dataset: "orders", Aggregation: "count", Input: &semanticmodel.MetricInput{Field: "orders.id"}},
+			"metric_only": {Name: "metric_only", Type: "aggregate", Dataset: "orders", Aggregation: "count", Input: &semanticmodel.MetricInput{Field: "orders.id"}},
+		},
+	}
+	planner, err := semanticquery.NewCompiledPlanner(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return planner
+}

--- a/internal/analytics/materialize/semantic_consumer_population_test.go
+++ b/internal/analytics/materialize/semantic_consumer_population_test.go
@@ -1,0 +1,127 @@
+package materialize
+
+import (
+	"context"
+	"database/sql"
+	"sync/atomic"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/flidai/leapview/internal/analytics/arrowquery"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+type semanticConsumerDuckDB struct {
+	cacheRuntimeDatabase
+	db      *sql.DB
+	queries atomic.Int32
+}
+
+func (d *semanticConsumerDuckDB) QueryArrow(ctx context.Context, plan semanticquery.Plan, sink arrowquery.Sink) error {
+	d.queries.Add(1)
+	rows, err := d.db.QueryContext(ctx, plan.SQL, plan.Args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	columns, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	values := make(semanticquery.Rows, 0)
+	for rows.Next() {
+		rowValues := make([]any, len(columns))
+		pointers := make([]any, len(rowValues))
+		for index := range rowValues {
+			pointers[index] = &rowValues[index]
+		}
+		if err := rows.Scan(pointers...); err != nil {
+			return err
+		}
+		row := semanticquery.Row{}
+		for index, column := range columns {
+			row[column] = rowValues[index]
+		}
+		values = append(values, row)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return writeTestRowsArrow(ctx, plan, values, sink)
+}
+
+func TestProtectedRuntimeRowsTotalUsesAdmittedMultiRowPopulation(t *testing.T) {
+	runtime, governor, _ := protectedConsumerFixtureWithModelModifier(t, true, func(model *semanticmodel.Model) {
+		table := model.Tables["orders"]
+		table.Dimensions["region"] = semanticmodel.MetricDimension{Field: "orders.region", Table: "orders", Name: "region", Type: "string", Datatype: semanticmodel.DataTypeString}
+		table.Dimensions["approved"] = semanticmodel.MetricDimension{Field: "orders.approved", Table: "orders", Name: "approved", Type: "boolean", Datatype: semanticmodel.DataTypeBoolean}
+		model.Tables["orders"] = table
+		model.Dimensions["region"] = semanticmodel.SemanticDimension{Name: "region", Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.region"}}}
+		model.Dimensions["approved"] = semanticmodel.SemanticDimension{Name: "approved", Datatype: semanticmodel.DataTypeBoolean, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.approved"}}}
+		model.Filters = map[string]semanticmodel.SemanticFilterSpec{"west_only": {Field: "orders.region", Operator: "equals", Value: "west"}}
+		metric := model.Metrics["shared"]
+		metric.Where = []string{"west_only"}
+		model.Metrics["shared"] = metric
+		model.AccessPolicy.Dimensions["region"] = []string{"canViewAccount"}
+		model.AccessPolicy.Dimensions["approved"] = []string{"canViewAccount"}
+	})
+	db, err := sql.Open("duckdb", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, statement := range []string{
+		"CREATE SCHEMA model",
+		"CREATE TABLE model.orders(id BIGINT, shared BIGINT, region VARCHAR, approved BOOLEAN)",
+		"INSERT INTO model.orders VALUES (1, 1, 'west', true), (1, 1, 'east', true), (1, 1, 'west', false), (2, 2, 'west', true)",
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	database := &semanticConsumerDuckDB{db: db}
+	runtime.db = database
+	request := dataquery.Query{
+		ModelID: "sales", PrincipalID: "alice", Kind: dataquery.KindSemanticRows, Target: "orders",
+		Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Metrics: []dataquery.Field{{Field: "shared", Alias: "shared"}},
+		Filters: []dataquery.Filter{{Field: "approved", Operator: "equals", Values: []any{true}}}, Sort: []dataquery.Sort{{Field: "orders.id", Direction: "asc"}},
+		IncludeTotal: true, Limit: 1, Offset: 1,
+	}
+	result, err := runtime.ExecuteDataQuery(dataquery.WithGovernor(context.Background(), governor), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.TotalRowsKnown || result.TotalRows != 1 {
+		t.Fatalf("total=%d known=%v, want one named/request-filtered row", result.TotalRows, result.TotalRowsKnown)
+	}
+	if len(result.Rows) != 0 {
+		t.Fatalf("returned rows = %#v, want the second row paginated away", result.Rows)
+	}
+	if got := database.queries.Load(); got != 2 {
+		t.Fatalf("physical executions = %d, want visible rows plus admitted count", got)
+	}
+	request.Offset = 0
+	request.Limit = 0
+	request.Filters = nil
+	result, err = runtime.ExecuteDataQuery(dataquery.WithGovernor(context.Background(), governor), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.TotalRowsKnown || result.TotalRows != 2 || len(result.Rows) != 2 {
+		t.Fatalf("named population: total=%d known=%v rows=%d, want two rows and total", result.TotalRows, result.TotalRowsKnown, len(result.Rows))
+	}
+	request.AuthorizationFields = []dataquery.Field{
+		{Field: "orders.id", Kind: dataquery.FieldKindDimension},
+		{Field: "shared", Kind: dataquery.FieldKindMetric},
+	}
+	request.Fields, request.Metrics = nil, nil
+	result, err = runtime.ExecuteDataQuery(dataquery.WithGovernor(context.Background(), governor), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.TotalRowsKnown || result.TotalRows != 2 {
+		t.Fatalf("count-only named population: total=%d known=%v, want 2", result.TotalRows, result.TotalRowsKnown)
+	}
+}

--- a/internal/analytics/materialize/semantic_consumer_runtime_test.go
+++ b/internal/analytics/materialize/semantic_consumer_runtime_test.go
@@ -186,10 +186,26 @@ func (s *semanticConsumerTestSink) WriteRecord(record arrow.RecordBatch) error {
 }
 
 func protectedConsumerFixture(t *testing.T) (*Runtime, semanticConsumerTestGovernor, *int64) {
+	return protectedConsumerFixtureWithMemberAccess(t, true)
+}
+
+func protectedConsumerFixtureWithMemberAccess(t *testing.T, allowMetric bool) (*Runtime, semanticConsumerTestGovernor, *int64) {
+	return protectedConsumerFixtureWithModelModifier(t, allowMetric, nil)
+}
+
+func protectedConsumerFixtureWithModelModifier(t *testing.T, allowMetric bool, modify func(*semanticmodel.Model)) (*Runtime, semanticConsumerTestGovernor, *int64) {
 	t.Helper()
 	literal, err := semanticmodel.NewSemanticAccessLiteral(json.Number("1"))
 	if err != nil {
 		t.Fatal(err)
+	}
+	otherLiteral, err := semanticmodel.NewSemanticAccessLiteral(json.Number("2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	metricValues, dimensionValues := []semanticmodel.SemanticAccessLiteral{literal}, []semanticmodel.SemanticAccessLiteral{otherLiteral}
+	if !allowMetric {
+		metricValues, dimensionValues = dimensionValues, metricValues
 	}
 	model := &semanticmodel.Model{
 		Name: "sales",
@@ -200,17 +216,24 @@ func protectedConsumerFixture(t *testing.T) (*Runtime, semanticConsumerTestGover
 				GrainEntity: "order",
 				Entities:    map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"id"}}},
 				Dimensions: map[string]semanticmodel.MetricDimension{
-					"id": {Field: "orders.id", Table: "orders", Name: "id", Type: "number", Datatype: semanticmodel.DataTypeInteger},
+					"id":     {Field: "orders.id", Table: "orders", Name: "id", Type: "number", Datatype: semanticmodel.DataTypeInteger},
+					"shared": {Field: "orders.shared", Table: "orders", Name: "shared", Type: "number", Datatype: semanticmodel.DataTypeInteger},
 				},
 			},
 		},
 		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
 		Dimensions: map[string]semanticmodel.SemanticDimension{
-			"id": {Name: "id", Datatype: semanticmodel.DataTypeInteger, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.id"}}},
+			"id":     {Name: "id", Datatype: semanticmodel.DataTypeInteger, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.id"}}},
+			"shared": {Name: "shared", Datatype: semanticmodel.DataTypeInteger, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.shared"}}},
+		},
+		Metrics: map[string]semanticmodel.Metric{
+			"shared": {Name: "shared", Type: "aggregate", Dataset: "orders", Aggregation: "count", Input: &semanticmodel.MetricInput{Field: "orders.id"}},
 		},
 		AccessPolicy: semanticmodel.SemanticAccessPolicy{
 			AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{
-				"canViewAccount": {UserAttribute: "accountIds", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal}},
+				"canViewAccount":   {UserAttribute: "accountIds", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal}},
+				"canViewMetric":    {UserAttribute: "accountIds", AllowedValues: metricValues},
+				"canViewDimension": {UserAttribute: "accountIds", AllowedValues: dimensionValues},
 			},
 			Datasets: map[string]semanticmodel.SemanticDatasetAccessSpec{
 				"orders": {
@@ -218,8 +241,12 @@ func protectedConsumerFixture(t *testing.T) (*Runtime, semanticConsumerTestGover
 					AccessFilters:        []semanticmodel.SemanticAccessFilterSpec{{Field: "id", UserAttribute: "accountIds"}},
 				},
 			},
-			Dimensions: map[string][]string{"id": {"canViewAccount"}},
+			Dimensions: map[string][]string{"id": {"canViewAccount"}, "shared": {"canViewDimension"}},
+			Metrics:    map[string][]string{"shared": {"canViewMetric"}},
 		},
+	}
+	if modify != nil {
+		modify(model)
 	}
 	planner, err := semanticquery.NewCompiledPlanner(model)
 	if err != nil {

--- a/internal/analytics/materialize/semantic_consumer_runtime_test.go
+++ b/internal/analytics/materialize/semantic_consumer_runtime_test.go
@@ -1,0 +1,360 @@
+package materialize
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/arrowquery"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	"github.com/flidai/leapview/internal/analytics/query/planir"
+	"github.com/flidai/leapview/internal/analytics/resultidentity"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func protectedMaterializeRuntime(t *testing.T) *Runtime {
+	t.Helper()
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				ModelName:   "orders",
+				Execution:   semanticmodel.ExecutionDefinition{SQL: "SELECT 1 AS id"},
+				GrainEntity: "order",
+				Entities:    map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"id"}}},
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"id": {Name: "id", Type: "integer", Datatype: semanticmodel.DataTypeInteger},
+				},
+			},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		AccessPolicy: semanticmodel.SemanticAccessPolicy{
+			Datasets: map[string]semanticmodel.SemanticDatasetAccessSpec{"orders": {}},
+		},
+	}
+	planner, err := semanticquery.NewCompiledPlanner(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Runtime{
+		modelID:    "sales",
+		model:      model,
+		planner:    planner,
+		db:         cacheRuntimeDatabase{},
+		queryCache: newQueryResultCache(8),
+	}
+}
+
+func TestProtectedRuntimeRequiresRequestConsumerBeforeExecution(t *testing.T) {
+	runtime := protectedMaterializeRuntime(t)
+	request := dataquery.Query{
+		ModelID: "sales", Kind: dataquery.KindSemanticRows, Target: "orders",
+		Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1,
+	}
+	if _, err := runtime.ExecuteDataQuery(context.Background(), request); err == nil {
+		t.Fatal("protected execution without a request consumer succeeded")
+	}
+	if _, err := runtime.planOwnedArrowQuery(request); err == nil {
+		t.Fatal("protected planning without a request consumer succeeded")
+	}
+}
+
+func TestProtectedRuntimeDeniesUnqualifiedReuseAndBundles(t *testing.T) {
+	runtime := protectedMaterializeRuntime(t)
+	if _, _, err := runtime.LookupImmutableBytes("tile"); err == nil {
+		t.Fatal("protected immutable-byte lookup succeeded")
+	}
+	if runtime.StoreImmutableBytes("tile", []byte("bytes")) {
+		t.Fatal("protected immutable-byte store succeeded")
+	}
+	if _, err := runtime.CoalesceImmutableBytes(context.Background(), "tile", func(context.Context) error { return nil }); err == nil {
+		t.Fatal("protected immutable-byte coalescing succeeded")
+	}
+	requests := []dataquery.BundleRequest{
+		{ID: "one", Query: dataquery.Query{ModelID: "sales", Kind: dataquery.KindSemanticAggregate, Target: "orders"}},
+		{ID: "two", Query: dataquery.Query{ModelID: "sales", Kind: dataquery.KindSemanticAggregate, Target: "orders"}},
+	}
+	if _, err := runtime.ExecuteDataQueryBundle(context.Background(), requests); err == nil {
+		t.Fatal("protected bundle execution succeeded")
+	}
+}
+
+func TestRuntimeFailsClosedWhenSemanticSnapshotIsUnknown(t *testing.T) {
+	runtime := &Runtime{
+		model:      &semanticmodel.Model{Name: "sales"},
+		db:         cacheRuntimeDatabase{},
+		queryCache: newQueryResultCache(8),
+	}
+	if _, _, err := runtime.LookupImmutableBytes("tile"); err == nil {
+		t.Fatal("immutable-byte lookup succeeded with an unknown semantic snapshot")
+	}
+	if runtime.StoreImmutableBytes("tile", []byte("bytes")) {
+		t.Fatal("immutable-byte store succeeded with an unknown semantic snapshot")
+	}
+	executed := false
+	if _, err := runtime.CoalesceImmutableBytes(context.Background(), "tile", func(context.Context) error {
+		executed = true
+		return nil
+	}); err == nil {
+		t.Fatal("immutable-byte coalescing succeeded with an unknown semantic snapshot")
+	}
+	if executed {
+		t.Fatal("immutable-byte coalescing callback ran with an unknown semantic snapshot")
+	}
+	requests := []dataquery.BundleRequest{
+		{ID: "one", Query: dataquery.Query{ModelID: "sales", Kind: dataquery.KindSemanticAggregate, Target: "orders"}},
+		{ID: "two", Query: dataquery.Query{ModelID: "sales", Kind: dataquery.KindSemanticAggregate, Target: "orders"}},
+	}
+	if _, err := runtime.ExecuteDataQueryBundle(context.Background(), requests); err == nil {
+		t.Fatal("bundle execution succeeded with an unknown semantic snapshot")
+	}
+}
+
+type semanticConsumerTestGovernor struct {
+	consumer *semanticquery.SemanticAccessConsumer
+	binding  semanticquery.SemanticAccessConsumerBinding
+}
+
+func (g semanticConsumerTestGovernor) GovernDataQuery(_ context.Context, request dataquery.Query) (dataquery.Query, dataquery.ResultTransformer, error) {
+	return request, nil, nil
+}
+
+func (g semanticConsumerTestGovernor) BindSemanticConsumer(ctx context.Context, modelID string) (context.Context, error) {
+	if modelID != g.binding.ModelID {
+		return ctx, context.Canceled
+	}
+	return semanticquery.WithSemanticAccessConsumer(ctx, g.consumer, g.binding), nil
+}
+
+type semanticConsumerArrowDatabase struct {
+	cacheRuntimeDatabase
+	afterSchema func()
+	assertPlan  func(semanticquery.Plan)
+	queries     atomic.Int32
+}
+
+func (d *semanticConsumerArrowDatabase) QueryArrow(ctx context.Context, plan semanticquery.Plan, sink arrowquery.Sink) error {
+	d.queries.Add(1)
+	if d.assertPlan != nil {
+		d.assertPlan(plan)
+	}
+	fields := make([]arrow.Field, len(plan.Columns))
+	arrays := make([]arrow.Array, len(plan.Columns))
+	for index, column := range plan.Columns {
+		fields[index] = arrow.Field{Name: column, Type: arrow.PrimitiveTypes.Int64}
+		builder := array.NewInt64Builder(memory.DefaultAllocator)
+		builder.Append(1)
+		arrays[index] = builder.NewArray()
+		builder.Release()
+	}
+	schema := arrow.NewSchema(fields, nil)
+	if err := sink.WriteSchema(schema); err != nil {
+		for _, value := range arrays {
+			value.Release()
+		}
+		return err
+	}
+	if d.afterSchema != nil {
+		d.afterSchema()
+	}
+	record := array.NewRecordBatch(schema, arrays, 1)
+	for _, value := range arrays {
+		value.Release()
+	}
+	defer record.Release()
+	if err := arrowquery.ConsumeResultBudget(ctx, record); err != nil {
+		return err
+	}
+	return sink.WriteRecord(record)
+}
+
+type semanticConsumerTestSink struct{ rows int }
+
+func (s *semanticConsumerTestSink) WriteSchema(*arrow.Schema) error { return nil }
+func (s *semanticConsumerTestSink) WriteRecord(record arrow.RecordBatch) error {
+	s.rows += int(record.NumRows())
+	return nil
+}
+
+func protectedConsumerFixture(t *testing.T) (*Runtime, semanticConsumerTestGovernor, *int64) {
+	t.Helper()
+	literal, err := semanticmodel.NewSemanticAccessLiteral(json.Number("1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				ModelName:   "orders",
+				Execution:   semanticmodel.ExecutionDefinition{SQL: "SELECT 1 AS id"},
+				GrainEntity: "order",
+				Entities:    map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"id"}}},
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"id": {Field: "orders.id", Table: "orders", Name: "id", Type: "number", Datatype: semanticmodel.DataTypeInteger},
+				},
+			},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"id": {Name: "id", Datatype: semanticmodel.DataTypeInteger, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.id"}}},
+		},
+		AccessPolicy: semanticmodel.SemanticAccessPolicy{
+			AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{
+				"canViewAccount": {UserAttribute: "accountIds", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal}},
+			},
+			Datasets: map[string]semanticmodel.SemanticDatasetAccessSpec{
+				"orders": {
+					RequiredAccessGrants: []string{"canViewAccount"},
+					AccessFilters:        []semanticmodel.SemanticAccessFilterSpec{{Field: "id", UserAttribute: "accountIds"}},
+				},
+			},
+			Dimensions: map[string][]string{"id": {"canViewAccount"}},
+		},
+	}
+	planner, err := semanticquery.NewCompiledPlanner(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition := access.SemanticAttributeDefinition{ID: "def-account", Name: "accountIds", Type: semanticvalue.TypeInteger, Shape: access.SemanticAttributeList, Profile: semanticvalue.Profile, DefinitionVersion: 1, LifecycleState: access.SemanticAttributeActive, Enabled: true, Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}}}
+	registryDigest, err := access.SemanticAttributeRegistryDigest(semanticvalue.Profile, []access.SemanticAttributeDefinition{definition})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := access.SemanticAttributeRegistrySnapshot{State: access.SemanticAttributeRegistryState{Profile: semanticvalue.Profile, Revision: 1, Digest: registryDigest}, Definitions: []access.SemanticAttributeDefinition{definition}}
+	values, valueDigest, err := access.CanonicalSemanticAttributeValues(definition, []int64{1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attribute := access.EffectiveSemanticAttribute{DefinitionID: definition.ID, DefinitionName: definition.Name, DefinitionVersion: definition.DefinitionVersion, Type: definition.Type, Shape: definition.Shape, CanonicalValues: values, ValueDigest: valueDigest, Source: "direct"}
+	assignment := access.SemanticAttributeAssignment{ID: "assignment-account", DefinitionID: definition.ID, DefinitionName: definition.Name, DefinitionVersion: definition.DefinitionVersion, Type: definition.Type, Shape: definition.Shape, Subject: access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: "alice"}, CanonicalValues: values, ValueDigest: valueDigest, AssignmentVersion: 1}
+	controlDigest, err := access.SemanticAttributeControlDigest([]access.SemanticAttributeAssignment{assignment}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control := access.SemanticAttributeControlSnapshot{State: access.SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 1, Digest: controlDigest}, Assignments: []access.SemanticAttributeAssignment{assignment}}
+	directEvidence, err := access.NewSemanticAttributeDirectEvidence("instance-1", "alice", []access.SubjectRef{{Kind: access.SubjectKindPrincipal, ID: "alice"}}, control, []access.EffectiveSemanticAttribute{attribute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attributeDigest, err := semanticquery.EffectiveSemanticAttributeDigest([]access.EffectiveSemanticAttribute{attribute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := semanticquery.SemanticAccessAttributeSnapshot{InstanceID: "instance-1", PrincipalID: "alice", ActorID: "alice", Registry: registry, Control: control, EffectiveAttributes: []access.EffectiveSemanticAttribute{attribute}, EffectiveAttributeDigest: attributeDigest, DirectAssignmentEvidence: directEvidence}
+	authority := semanticquery.SemanticAccessAuthority{InstanceID: "instance-1", Registry: registry, Control: control, ObservedAt: time.Now().UTC()}
+	consumer, err := semanticquery.NewSemanticAccessConsumer(planner, semanticquery.SemanticAccessConsumerConfig{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "sales", Generation: "generation-1", PrincipalID: "alice",
+		Authority: func() (semanticquery.SemanticAccessAttributeSnapshot, semanticquery.SemanticAccessAuthority, error) {
+			return snapshot, authority, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID, err := projectgraph.NewResourceID("project:test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	partition, err := resultidentity.NewPartition(resultidentity.PartitionInput{Kind: resultidentity.PartitionProduction, TargetID: "instance-1", ProjectID: projectID, Environment: "prod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlRevision := &authority.Control.State.Revision
+	database := &semanticConsumerArrowDatabase{}
+	runtime := &Runtime{modelID: "sales", model: model, planner: planner, servingStateID: "generation-1", resultPartition: partition, db: database, queryCache: newQueryResultCache(8)}
+	governor := semanticConsumerTestGovernor{consumer: consumer, binding: semanticquery.SemanticAccessConsumerBinding{InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", Generation: "generation-1", ModelID: "sales", PrincipalID: "alice"}}
+	return runtime, governor, controlRevision
+}
+
+func TestProtectedRuntimeUsesGovernorConsumerAndReleasesAllowedArrow(t *testing.T) {
+	runtime, governor, _ := protectedConsumerFixture(t)
+	database := runtime.db.(*semanticConsumerArrowDatabase)
+	database.assertPlan = func(plan semanticquery.Plan) {
+		barriers, predicates := 0, 0
+		for _, node := range plan.IR.Nodes {
+			barrier, ok := node.(planir.SecurityBarrier)
+			if !ok {
+				if pointer, pointerOK := node.(*planir.SecurityBarrier); pointerOK && pointer != nil {
+					barrier, ok = *pointer, true
+				}
+			}
+			if !ok {
+				continue
+			}
+			barriers++
+			if barrier.Predicate != nil {
+				predicates++
+			}
+		}
+		if barriers == 0 || predicates == 0 {
+			t.Errorf("protected plan barriers=%d predicates=%d, want a predicate-bearing security barrier; plan=%s", barriers, predicates, plan.SQL)
+		}
+	}
+	sink := &semanticConsumerTestSink{}
+	request := dataquery.Query{ModelID: "sales", PrincipalID: "alice", Kind: dataquery.KindSemanticRows, Target: "orders", Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1}
+	result, err := runtime.ExecuteDataQueryArrow(dataquery.WithGovernor(context.Background(), governor), request, sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sink.rows != 1 || result.RowsReturned != 1 || database.queries.Load() != 1 {
+		t.Fatalf("rows=%d result=%d queries=%d", sink.rows, result.RowsReturned, database.queries.Load())
+	}
+}
+
+func TestProtectedRuntimeUsesIndependentlyAdmittedTotalPlan(t *testing.T) {
+	runtime, governor, _ := protectedConsumerFixture(t)
+	database := runtime.db.(*semanticConsumerArrowDatabase)
+	request := dataquery.Query{ModelID: "sales", PrincipalID: "alice", Kind: dataquery.KindSemanticRows, Target: "orders", Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, IncludeTotal: true, Limit: 1}
+	result, err := runtime.ExecuteDataQuery(dataquery.WithGovernor(context.Background(), governor), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.TotalRowsKnown || result.TotalRows != 1 || database.queries.Load() != 2 {
+		t.Fatalf("total=%d known=%v queries=%d", result.TotalRows, result.TotalRowsKnown, database.queries.Load())
+	}
+}
+
+func TestProtectedRuntimeStopsArrowBeforeReleaseAfterAuthorityChange(t *testing.T) {
+	runtime, governor, controlRevision := protectedConsumerFixture(t)
+	database := runtime.db.(*semanticConsumerArrowDatabase)
+	database.afterSchema = func() { atomic.AddInt64(controlRevision, 1) }
+	sink := &semanticConsumerTestSink{}
+	request := dataquery.Query{ModelID: "sales", PrincipalID: "alice", Kind: dataquery.KindSemanticRows, Target: "orders", Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1}
+	_, err := runtime.ExecuteDataQueryArrow(dataquery.WithGovernor(context.Background(), governor), request, sink)
+	if err == nil {
+		t.Fatal("authority change during Arrow execution was accepted")
+	}
+	if sink.rows != 0 {
+		t.Fatalf("rows released after authority change = %d", sink.rows)
+	}
+	if database.queries.Load() != 1 {
+		t.Fatalf("queries=%d, want one physical query", database.queries.Load())
+	}
+}
+
+func TestProtectedRuntimeStopsBufferedArrowBeforeReleaseAfterAuthorityChange(t *testing.T) {
+	runtime, governor, controlRevision := protectedConsumerFixture(t)
+	database := runtime.db.(*semanticConsumerArrowDatabase)
+	database.afterSchema = func() { atomic.AddInt64(controlRevision, 1) }
+	request := dataquery.Query{ModelID: "sales", PrincipalID: "alice", Kind: dataquery.KindSemanticRows, Target: "orders", Fields: []dataquery.Field{{Field: "orders.id", Alias: "id"}}, Limit: 1}
+	result, err := runtime.ExecuteDataQuery(dataquery.WithGovernor(context.Background(), governor), request)
+	if err == nil {
+		t.Fatal("authority change during buffered Arrow execution was accepted")
+	}
+	if len(result.Rows) != 0 {
+		t.Fatalf("buffered rows released after authority change = %d", len(result.Rows))
+	}
+	if database.queries.Load() != 1 {
+		t.Fatalf("queries=%d, want one physical query", database.queries.Load())
+	}
+}

--- a/internal/analytics/query/compiled.go
+++ b/internal/analytics/query/compiled.go
@@ -831,6 +831,25 @@ func (c *CompiledModel) DatasetNames() []string {
 	return names
 }
 
+// SemanticDimensionNames returns activation-owned semantic dimension names in
+// stable order. It intentionally excludes physical table fields.
+func (c *CompiledModel) SemanticDimensionNames() []string {
+	if c == nil {
+		return nil
+	}
+	names := make([]string, 0, len(c.semanticDimensions))
+	for name := range c.semanticDimensions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// MetricNames returns activation-owned metric names in stable order.
+func (c *CompiledModel) MetricNames() []string {
+	return c.metricNames()
+}
+
 // ResolvePhysicalModelName validates a model transform dependency against the
 // compiled model materialization namespace. Semantic dataset aliases are not accepted
 // here: aliases are only valid for selecting a dataset, while transform SQL

--- a/internal/analytics/query/planner.go
+++ b/internal/analytics/query/planner.go
@@ -18,71 +18,12 @@ func (p *Planner) PlanRows(request RowRequest) (Plan, error) {
 }
 
 func (p *Planner) planRows(request RowRequest, secure bool) (Plan, error) {
-	view, err := p.rowView(request)
+	if _, err := columnMaskMap(request.ColumnMasks); err != nil {
+		return Plan{}, err
+	}
+	view, metricFilters, err := p.prepareRowPopulation(request)
 	if err != nil {
 		return Plan{}, err
-	}
-	_, err = columnMaskMap(request.ColumnMasks)
-	if err != nil {
-		return Plan{}, err
-	}
-	for _, dimension := range request.Dimensions {
-		_, _, _, err := view.ResolveDimensionRefPath(dimension.Field)
-		if err != nil {
-			return Plan{}, err
-		}
-	}
-	var population []CompiledNamedFilter
-	populationSignature := ""
-	populationSet := false
-	for _, metric := range request.Metrics {
-		field, resolved, err := view.ResolveMetricRef(metric.Field)
-		if err != nil {
-			return Plan{}, err
-		}
-		if resolved.Dataset != view.Dataset {
-			return Plan{}, fmt.Errorf("metric %q is not owned by dataset %q", field, view.Dataset)
-		}
-		signature, err := flatPlanFilterSignature(resolved.NamedFilters)
-		if err != nil {
-			return Plan{}, fmt.Errorf("metric %q population signature: %w", field, err)
-		}
-		if !populationSet {
-			population = canonicalCompiledNamedFilters(resolved.NamedFilters)
-			populationSignature = signature
-			populationSet = true
-		} else if signature != populationSignature {
-			return Plan{}, fmt.Errorf("row query selects metrics with divergent populations")
-		}
-		for _, field := range aggregateMetricPhysicalFields(resolved) {
-			physical, err := p.resolveDimension(field)
-			if err != nil {
-				return Plan{}, err
-			}
-			path, err := p.relationshipPath(view.Dataset, physical.Table)
-			if err != nil {
-				return Plan{}, err
-			}
-			_ = path // relationship validation is retained; lowering is PlanIR-owned
-		}
-	}
-	metricFilters := namedFlatPlanFilters(population, view.Dataset)
-	if len(metricFilters) > 0 {
-		compiledFilters := make([]Filter, 0, len(metricFilters))
-		for _, spec := range metricFilters {
-			compiledFilters = append(compiledFilters, spec.Filter)
-		}
-		if err := p.exposeViewFilters(view, compiledFilters); err != nil {
-			return Plan{}, err
-		}
-	}
-	if _, err := filterFieldBindings(view, request.Filters); err != nil {
-		return Plan{}, err
-	}
-	for _, spec := range metricFilters {
-		if _, err := filterFieldBindings(view, []Filter{spec.Filter}); err != nil {
-			return Plan{}, err
-		}
 	}
 	if len(request.Dimensions) == 0 && len(request.Metrics) == 0 {
 		return Plan{}, fmt.Errorf("row query requires at least one selected field")
@@ -123,6 +64,99 @@ func (p *Planner) planRows(request RowRequest, secure bool) (Plan, error) {
 		columnSet[column] = true
 	}
 	return Plan{SQL: rendered.SQL, Args: rendered.Args, Columns: rendered.Columns, Deterministic: true, EffectiveOrdering: effectiveOrderSorts(request.Sort, columnSet), IR: irGraph}, nil
+}
+
+// planRowsCount lowers the effective population of a row request into a
+// count-only PlanIR graph. It deliberately shares prepareRowPopulation with
+// planRows so metric named filters, request filters, and divergent-population
+// rejection cannot drift between visible rows and their total.
+func (p *Planner) planRowsCount(request RowRequest) (Plan, error) {
+	view, metricFilters, err := p.prepareRowPopulation(request)
+	if err != nil {
+		return Plan{}, err
+	}
+	filterSpecs := append(requestFlatPlanFilters(request.Filters), metricFilters...)
+	irGraph, irErr := p.buildFlatPopulationIR(view.Dataset, request.Dimensions, request.Metrics, filterSpecs, view.Paths, nil, 0, 0, true)
+	if irErr != nil {
+		return Plan{}, fmt.Errorf("build row population count plan IR: %w", irErr)
+	}
+	if _, err := p.securePlanGraph(irGraph, requestRowMemberRefs(p, request)...); err != nil {
+		return Plan{}, err
+	}
+	rendered, irErr := planir.RenderDuckDB(irGraph)
+	if irErr != nil {
+		return Plan{}, fmt.Errorf("render row population count plan IR: %w", irErr)
+	}
+	return Plan{SQL: rendered.SQL, Args: rendered.Args, Columns: rendered.Columns, Deterministic: true, IR: irGraph}, nil
+}
+
+// prepareRowPopulation resolves all row-request fields and lowers the common
+// metric population boundary used by both row and count plans. The returned
+// filters retain named-filter provenance for PlanIR admission and rendering.
+func (p *Planner) prepareRowPopulation(request RowRequest) (*queryView, []flatPlanFilter, error) {
+	view, err := p.rowView(request)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, dimension := range request.Dimensions {
+		_, _, _, err := view.ResolveDimensionRefPath(dimension.Field)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	var population []CompiledNamedFilter
+	populationSignature := ""
+	populationSet := false
+	for _, metric := range request.Metrics {
+		field, resolved, err := view.ResolveMetricRef(metric.Field)
+		if err != nil {
+			return nil, nil, err
+		}
+		if resolved.Dataset != view.Dataset {
+			return nil, nil, fmt.Errorf("metric %q is not owned by dataset %q", field, view.Dataset)
+		}
+		signature, err := flatPlanFilterSignature(resolved.NamedFilters)
+		if err != nil {
+			return nil, nil, fmt.Errorf("metric %q population signature: %w", field, err)
+		}
+		if !populationSet {
+			population = canonicalCompiledNamedFilters(resolved.NamedFilters)
+			populationSignature = signature
+			populationSet = true
+		} else if signature != populationSignature {
+			return nil, nil, fmt.Errorf("row query selects metrics with divergent populations")
+		}
+		for _, field := range aggregateMetricPhysicalFields(resolved) {
+			physical, err := p.resolveDimension(field)
+			if err != nil {
+				return nil, nil, err
+			}
+			path, err := p.relationshipPath(view.Dataset, physical.Table)
+			if err != nil {
+				return nil, nil, err
+			}
+			_ = path // relationship validation is retained; lowering is PlanIR-owned
+		}
+	}
+	metricFilters := namedFlatPlanFilters(population, view.Dataset)
+	if len(metricFilters) > 0 {
+		compiledFilters := make([]Filter, 0, len(metricFilters))
+		for _, spec := range metricFilters {
+			compiledFilters = append(compiledFilters, spec.Filter)
+		}
+		if err := p.exposeViewFilters(view, compiledFilters); err != nil {
+			return nil, nil, err
+		}
+	}
+	if _, err := filterFieldBindings(view, request.Filters); err != nil {
+		return nil, nil, err
+	}
+	for _, spec := range metricFilters {
+		if _, err := filterFieldBindings(view, []Filter{spec.Filter}); err != nil {
+			return nil, nil, err
+		}
+	}
+	return view, metricFilters, nil
 }
 
 func (p *Planner) PlanRawValues(request RawValueRequest) (Plan, error) {

--- a/internal/analytics/query/resolver.go
+++ b/internal/analytics/query/resolver.go
@@ -6,13 +6,19 @@ import (
 	"strings"
 
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/analytics/query/planir"
 )
 
 type Planner struct {
-	compiled              *CompiledModel
-	tableRelation         TableRelation
-	semanticAccessPolicy  *CompiledSemanticAccessPolicy
-	semanticAccessProvider func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error)
+	compiled                             *CompiledModel
+	tableRelation                        TableRelation
+	semanticAccessPolicy                 *CompiledSemanticAccessPolicy
+	semanticAccessProvider               func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error)
+	semanticAccessExpectedDecisionDigest string
+	// semanticAccessAdmissionHook is installed only by a request-bound
+	// SemanticAccessConsumer. It observes the graph after the existing access
+	// placement/seal and never becomes part of PlanIR or the serialized Plan.
+	semanticAccessAdmissionHook func(*planir.Graph, semanticAccessAdmission) error
 }
 
 // datasetTable resolves a semantic alias through the compiled serving

--- a/internal/analytics/query/row_plan_ir.go
+++ b/internal/analytics/query/row_plan_ir.go
@@ -89,6 +89,12 @@ func (p *Planner) buildFlatPlanIR(dataset string, dimensions, metrics []Field, f
 }
 
 func (p *Planner) buildFlatPlanIRWithFilters(dataset string, dimensions, metrics []Field, filterSpecs []flatPlanFilter, pathOverrides map[string][]semanticmodel.Relationship, sorts []Sort, limit, offset int) (*planir.Graph, error) {
+	return p.buildFlatPopulationIR(dataset, dimensions, metrics, filterSpecs, pathOverrides, sorts, limit, offset, false)
+}
+
+// buildFlatPopulationIR retains selection-driven relationship routes even when
+// only a count is projected. Count mode changes the output, not its input rows.
+func (p *Planner) buildFlatPopulationIR(dataset string, dimensions, metrics []Field, filterSpecs []flatPlanFilter, pathOverrides map[string][]semanticmodel.Relationship, sorts []Sort, limit, offset int, countOnly bool) (*planir.Graph, error) {
 	if dataset == "" {
 		return nil, fmt.Errorf("plan IR dataset is required")
 	}
@@ -252,6 +258,9 @@ func (p *Planner) buildFlatPlanIRWithFilters(dataset string, dimensions, metrics
 		input = m.NodeID
 	}
 	projection := []planir.Projection{}
+	if countOnly {
+		dimensions, metrics = nil, nil
+	}
 	for _, field := range dimensions {
 		alias, err := outputAlias(field)
 		if err != nil {

--- a/internal/analytics/query/row_population_consumer_test.go
+++ b/internal/analytics/query/row_population_consumer_test.go
@@ -1,0 +1,126 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+)
+
+func TestSemanticAccessConsumerRowsCountMatchesNamedMetricPopulation(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	policy := model.AccessPolicy.Datasets["orders"]
+	policy.AccessFilters = []semanticmodel.SemanticAccessFilterSpec{{Field: "account", UserAttribute: "accountIds"}}
+	model.AccessPolicy.Datasets["orders"] = policy
+	model.Filters = map[string]semanticmodel.SemanticFilterSpec{
+		"west_only": {Field: "orders.region", Operator: "equals", Value: "west"},
+	}
+	metric := model.Metrics["revenue"]
+	metric.Where = []string{"west_only"}
+	model.Metrics["revenue"] = metric
+	planner, err := NewCompiledPlanner(model, WithTableRelation(func(table string) (string, error) { return "model." + table, nil }))
+	if err != nil {
+		t.Fatalf("NewCompiledPlanner: %v", err)
+	}
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	consumer, err := NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID,
+		Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+			return snapshot, authority, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewSemanticAccessConsumer: %v", err)
+	}
+	db := openSemanticAccessPlannerDB(t,
+		"CREATE SCHEMA model",
+		"CREATE TABLE model.orders_model(id BIGINT, region VARCHAR, account_id BIGINT, amount DECIMAL(20,3), approved BOOLEAN, order_date DATE, occurred_at TIMESTAMPTZ)",
+		"INSERT INTO model.orders_model VALUES (1, 'west', 9007199254740993, 10, true, DATE '2026-09-06', TIMESTAMPTZ '2026-09-06 03:30:00+00'), (2, 'east', 7, 20, true, DATE '2026-09-06', TIMESTAMPTZ '2026-09-06 03:30:00+00'), (3, 'west', 7, 30, false, DATE '2026-09-06', TIMESTAMPTZ '2026-09-06 03:30:00+00'), (4, 'north', 7, 40, true, DATE '2026-09-06', TIMESTAMPTZ '2026-09-06 03:30:00+00'), (5, 'west', 7, 50, true, DATE '2026-09-06', TIMESTAMPTZ '2026-09-06 03:30:00+00')",
+	)
+	request := RowRequest{
+		Dataset: "orders", Dimensions: []Field{{Field: "orders.id"}}, Metrics: []Field{{Field: "revenue"}},
+		Filters: []Filter{{Field: "approved", Operator: "equals", Values: []any{true}}}, Sort: []Sort{{Field: "id", Direction: "asc"}}, Limit: 1, Offset: 1,
+	}
+	rowPlan, err := consumer.Planner().PlanRows(request)
+	if err != nil {
+		t.Fatalf("PlanRows: %v", err)
+	}
+	countPlan, err := consumer.PlanRowsCount(request)
+	if err != nil {
+		t.Fatalf("PlanRowsCount: %v", err)
+	}
+	if err := consumer.ValidatePlan(countPlan); err != nil {
+		t.Fatalf("ValidatePlan(count): %v", err)
+	}
+	assertSecurityBarriers(t, countPlan.IR, 1, true)
+	explain, err := countPlan.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(explain, "source=named name=west_only") {
+		t.Fatalf("count PlanIR omitted named metric population:\n%s\n%s", explain, countPlan.SQL)
+	}
+	rows, err := db.Query(rowPlan.SQL, rowPlan.Args...)
+	if err != nil {
+		t.Fatalf("execute rows: %v\n%s", err, rowPlan.SQL)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		t.Fatal("row population returned no row")
+	}
+	var rowID int64
+	if err := rows.Scan(&rowID, new(any)); err != nil {
+		t.Fatal(err)
+	}
+	if rowID != 5 {
+		t.Fatalf("row population id = %d, want 5", rowID)
+	}
+	var total int64
+	if err := db.QueryRow(countPlan.SQL, countPlan.Args...).Scan(&total); err != nil {
+		t.Fatalf("execute count: %v\n%s", err, countPlan.SQL)
+	}
+	if total != 2 {
+		t.Fatalf("named/request population count = %d, want 2", total)
+	}
+
+	divergent := request
+	divergent.Metrics = []Field{{Field: "revenue"}, {Field: "orderCount"}}
+	if _, err := consumer.PlanRowsCount(divergent); err == nil || !strings.Contains(err.Error(), "divergent populations") {
+		t.Fatalf("divergent protected count error = %v", err)
+	}
+}
+
+func TestSemanticAccessConsumerRowsCountRetainsSelectedRelationship(t *testing.T) {
+	model := rowPopulationModel()
+	consumer, err := NewSemanticAccessConsumer(mustNewCompiledPlanner(t, model), SemanticAccessConsumerConfig{})
+	if err != nil {
+		t.Fatalf("NewSemanticAccessConsumer: %v", err)
+	}
+	plan, err := consumer.PlanRowsCount(RowRequest{
+		Dataset: "orders", Dimensions: []Field{{Field: "customers.state"}}, Metrics: []Field{{Field: "order_count"}},
+	})
+	if err != nil {
+		t.Fatalf("PlanRowsCount: %v", err)
+	}
+	if err := consumer.ValidatePlan(plan); err != nil {
+		t.Fatalf("ValidatePlan(count): %v", err)
+	}
+	explain, err := plan.Explain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(explain, "orders_customers") {
+		t.Fatalf("count PlanIR omitted selected relationship route:\n%s\n%s", explain, plan.SQL)
+	}
+	db := rowPopulationDB(t)
+	if _, err := db.Exec("INSERT INTO model.customers VALUES (10, 'duplicate')"); err != nil {
+		t.Fatal(err)
+	}
+	var total int
+	if err := db.QueryRow(plan.SQL, plan.Args...).Scan(&total); err != nil {
+		t.Fatalf("execute relationship count: %v\n%s", err, plan.SQL)
+	}
+	if total != 6 {
+		t.Fatalf("relationship population count = %d, want 6 (including the unmatched left-join row)", total)
+	}
+}

--- a/internal/analytics/query/semantic_access_planner.go
+++ b/internal/analytics/query/semantic_access_planner.go
@@ -36,7 +36,15 @@ type semanticAccessMemberRef struct {
 
 type semanticAccessAdmission struct {
 	Policies       map[string]planir.SecurityPolicy
+	PolicyDigest   string
 	DecisionDigest string
+}
+
+func (p *Planner) captureSemanticAccessAdmission(graph *planir.Graph, admission semanticAccessAdmission) error {
+	if p == nil || p.semanticAccessAdmissionHook == nil {
+		return nil
+	}
+	return p.semanticAccessAdmissionHook(graph, admission)
 }
 
 // securePlanGraph is the one query-side admission boundary. It validates the
@@ -55,7 +63,11 @@ func (p *Planner) securePlanGraph(graph *planir.Graph, members ...semanticAccess
 		return semanticAccessAdmission{}, fmt.Errorf("compiled semantic model snapshot is required")
 	}
 	if model.AccessPolicy.Empty() {
-		return semanticAccessAdmission{}, nil
+		admission := semanticAccessAdmission{}
+		if err := p.captureSemanticAccessAdmission(graph, admission); err != nil {
+			return semanticAccessAdmission{}, err
+		}
+		return admission, nil
 	}
 	if p.semanticAccessPolicy == nil || p.semanticAccessPolicy.Digest() == "" || p.semanticAccessProvider == nil {
 		return semanticAccessAdmission{}, fmt.Errorf("policy-bearing semantic model requires semantic access authority")
@@ -82,6 +94,9 @@ func (p *Planner) securePlanGraph(graph *planir.Graph, members ...semanticAccess
 	decision, err := EvaluateSemanticAccess(qualified, snapshot, current)
 	if err != nil {
 		return semanticAccessAdmission{}, fmt.Errorf("evaluate semantic access: %w", err)
+	}
+	if p.semanticAccessExpectedDecisionDigest != "" && decision.IdentityDigest != p.semanticAccessExpectedDecisionDigest {
+		return semanticAccessAdmission{}, fmt.Errorf("semantic access authority decision is stale or inconsistent")
 	}
 
 	refs := append([]semanticAccessMemberRef(nil), members...)
@@ -117,12 +132,20 @@ func (p *Planner) securePlanGraph(graph *planir.Graph, members ...semanticAccess
 		policies[dataset] = planir.SecurityPolicy{PolicyDigest: qualified.Digest(), DecisionDigest: decision.IdentityDigest, Predicate: predicate}
 	}
 	if len(policies) == 0 {
-		return semanticAccessAdmission{DecisionDigest: decision.IdentityDigest}, nil
+		admission := semanticAccessAdmission{PolicyDigest: qualified.Digest(), DecisionDigest: decision.IdentityDigest}
+		if err := p.captureSemanticAccessAdmission(graph, admission); err != nil {
+			return semanticAccessAdmission{}, err
+		}
+		return admission, nil
 	}
 	if err := planir.ApplySecurityBarriers(graph, policies); err != nil {
 		return semanticAccessAdmission{}, fmt.Errorf("apply semantic access barriers: %w", err)
 	}
-	return semanticAccessAdmission{Policies: policies, DecisionDigest: decision.IdentityDigest}, nil
+	admission := semanticAccessAdmission{Policies: policies, PolicyDigest: qualified.Digest(), DecisionDigest: decision.IdentityDigest}
+	if err := p.captureSemanticAccessAdmission(graph, admission); err != nil {
+		return semanticAccessAdmission{}, err
+	}
+	return admission, nil
 }
 
 func admitSemanticMembers(p *Planner, decision *SemanticAccessDecision, refs []semanticAccessMemberRef) error {

--- a/internal/analytics/query/semantic_consumer.go
+++ b/internal/analytics/query/semantic_consumer.go
@@ -247,6 +247,18 @@ func (consumer *SemanticAccessConsumer) Planner() *Planner {
 	return &planner
 }
 
+// PlanRowsCount plans the effective population of a row request as a
+// count-only graph. The request-bound planner carries the same compiled named
+// filters as PlanRows and admits the resulting graph through this consumer's
+// private provenance hook, so ValidatePlan can prove the exact barriers and
+// renderer output before execution.
+func (consumer *SemanticAccessConsumer) PlanRowsCount(request RowRequest) (Plan, error) {
+	if consumer == nil || consumer.planner == nil {
+		return Plan{}, fmt.Errorf("semantic access consumer is required")
+	}
+	return consumer.planner.planRowsCount(request)
+}
+
 // PrincipalID returns the authenticated principal bound to a protected
 // consumer. Public consumers intentionally have no synthetic principal.
 func (consumer *SemanticAccessConsumer) PrincipalID() string {

--- a/internal/analytics/query/semantic_consumer.go
+++ b/internal/analytics/query/semantic_consumer.go
@@ -1,0 +1,739 @@
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/flidai/leapview/internal/access"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/analytics/query/planir"
+)
+
+// SemanticAccessConsumerConfig binds a query consumer to one complete serving
+// target and one authenticated subject. Protected consumers require every
+// identity field; public consumers may omit the authority and principal.
+// Authority is deliberately a function: each admission/discovery operation
+// obtains a fresh coherent registry/control and effective-attribute observation.
+type SemanticAccessConsumerConfig struct {
+	InstanceID  string
+	ProjectID   string
+	Environment string
+	ModelID     string
+	Generation  string
+	PrincipalID string
+	Authority   func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error)
+}
+
+// SemanticAccessResolutionSnapshot projects one coherent Access-owned
+// resolution into the query evaluator's detached snapshot/authority pair.
+// Keeping this adapter here prevents consumers from independently assembling
+// evidence or accidentally pairing values with a different control state.
+func SemanticAccessResolutionSnapshot(instanceID, principalID string, resolved access.SemanticAttributeResolution) (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+	if err := validateConsumerIdentity(instanceID, "instance ID"); err != nil {
+		return SemanticAccessAttributeSnapshot{}, SemanticAccessAuthority{}, err
+	}
+	if err := validateConsumerIdentity(principalID, "principal ID"); err != nil {
+		return SemanticAccessAttributeSnapshot{}, SemanticAccessAuthority{}, err
+	}
+	if resolved.Subject.Kind != access.SubjectKindPrincipal || resolved.Subject.ID != principalID {
+		return SemanticAccessAttributeSnapshot{}, SemanticAccessAuthority{}, fmt.Errorf("semantic access resolution subject does not match principal")
+	}
+	digest, err := EffectiveSemanticAttributeDigest(resolved.Attributes)
+	if err != nil {
+		return SemanticAccessAttributeSnapshot{}, SemanticAccessAuthority{}, err
+	}
+	attributes := make([]access.EffectiveSemanticAttribute, len(resolved.Attributes))
+	for index, attribute := range resolved.Attributes {
+		attributes[index] = attribute
+		attributes[index].CanonicalValues = append([]string(nil), attribute.CanonicalValues...)
+	}
+	snapshot := SemanticAccessAttributeSnapshot{InstanceID: instanceID, PrincipalID: principalID, ActorID: principalID,
+		Registry: resolved.Registry, Control: resolved.Control, EffectiveAttributes: attributes, EffectiveAttributeDigest: digest}
+	hasDirect := false
+	for _, attribute := range attributes {
+		if attribute.Source == "direct" || attribute.Source == "direct+trusted_claim" {
+			hasDirect = true
+			break
+		}
+	}
+	if hasDirect {
+		snapshot.DirectAssignmentEvidence, err = access.NewSemanticAttributeDirectEvidence(instanceID, principalID, resolved.Subjects, resolved.Control, resolved.Attributes)
+		if err != nil {
+			return SemanticAccessAttributeSnapshot{}, SemanticAccessAuthority{}, err
+		}
+	}
+	authority := SemanticAccessAuthority{InstanceID: instanceID, Registry: resolved.Registry, Control: resolved.Control, ObservedAt: resolved.ObservedAt}
+	return snapshot, authority, nil
+}
+
+// SemanticAccessTarget identifies a typed semantic asset. Dataset may qualify
+// a dimension binding or a metric; a bare metric is also a valid target.
+type SemanticAccessTarget struct {
+	Dataset   string `json:"dataset,omitempty"`
+	Dimension string `json:"dimension,omitempty"`
+	Metric    string `json:"metric,omitempty"`
+}
+
+// SemanticAccessPolicyIdentity is detached policy provenance attached to
+// every discovery asset. It contains identities only; no principal values or
+// attribute values are exposed.
+type SemanticAccessPolicyIdentity struct {
+	Profile          string `json:"profile,omitempty"`
+	InstanceID       string `json:"instanceId,omitempty"`
+	ModelID          string `json:"modelId,omitempty"`
+	Generation       string `json:"generation,omitempty"`
+	PolicyDigest     string `json:"policyDigest,omitempty"`
+	RegistryProfile  string `json:"registryProfile,omitempty"`
+	RegistryRevision int64  `json:"registryRevision,omitempty"`
+	RegistryDigest   string `json:"registryDigest,omitempty"`
+}
+
+// SemanticAccessOwnership describes registry stewardship behind one required
+// grant or dataset access filter. Grant is empty for filter-only ownership;
+// ownership is metadata, not a grant decision.
+type SemanticAccessOwnership struct {
+	Grant        string `json:"grant,omitempty"`
+	DefinitionID string `json:"definitionId,omitempty"`
+	Attribute    string `json:"attribute,omitempty"`
+	Kind         string `json:"kind,omitempty"`
+	ID           string `json:"id,omitempty"`
+}
+
+// SemanticAccessAsset is the detached discovery projection shared by query
+// consumers. Only authorized protected assets are returned. Public models
+// return the same typed projection with empty protection identity.
+type SemanticAccessAsset struct {
+	Kind                 string                       `json:"kind"`
+	Name                 string                       `json:"name"`
+	Dataset              string                       `json:"dataset,omitempty"`
+	Dimension            string                       `json:"dimension,omitempty"`
+	Metric               string                       `json:"metric,omitempty"`
+	DependencyDatasets   []string                     `json:"dependencyDatasets,omitempty"`
+	FilterDatasets       []string                     `json:"filterDatasets,omitempty"`
+	RequiredAccessGrants []string                     `json:"requiredAccessGrants,omitempty"`
+	Ownership            []SemanticAccessOwnership    `json:"ownership,omitempty"`
+	PolicyIdentity       SemanticAccessPolicyIdentity `json:"policyIdentity"`
+}
+
+type semanticAccessPlanAdmission struct {
+	canonical      []byte
+	policyDigest   string
+	decisionDigest string
+}
+
+// SemanticAccessConsumer is a request-bound semantic authorization and
+// discovery boundary. Its admitted graph map is intentionally private and
+// process-local; it is not a durable capability or serialized plan field.
+type SemanticAccessConsumer struct {
+	planner        *Planner
+	config         SemanticAccessConsumerConfig
+	policy         *CompiledSemanticAccessPolicy
+	decisionDigest string
+	protected      bool
+	admissions     map[*planir.Graph]semanticAccessPlanAdmission
+	mu             sync.RWMutex
+}
+
+// ModelRequiresSemanticAccess reports whether authored source contains a
+// policy-bearing semantic access contract. A nil model is never protected.
+func ModelRequiresSemanticAccess(model *semanticmodel.Model) bool {
+	return model != nil && !model.AccessPolicy.Empty()
+}
+
+// NewSemanticAccessConsumer validates the target identity and captures a
+// target-qualified FAI-639 policy for protected authored source. Public source
+// retains ordinary planner behavior and does not require a principal or
+// authority callback.
+func NewSemanticAccessConsumer(planner *Planner, config SemanticAccessConsumerConfig) (*SemanticAccessConsumer, error) {
+	if planner == nil || planner.compiled == nil {
+		return nil, fmt.Errorf("compiled semantic planner is required")
+	}
+	model := planner.compiled.SourceModel()
+	if model == nil {
+		return nil, fmt.Errorf("compiled semantic model snapshot is required")
+	}
+	protected := !model.AccessPolicy.Empty()
+	consumer := &SemanticAccessConsumer{config: config, protected: protected,
+		admissions: make(map[*planir.Graph]semanticAccessPlanAdmission)}
+	if !protected {
+		requestPlanner := *planner
+		requestPlanner.semanticAccessAdmissionHook = consumer.captureAdmission
+		consumer.planner = &requestPlanner
+		return consumer, nil
+	}
+	if err := validateConsumerIdentity(config.InstanceID, "instance ID"); err != nil {
+		return nil, err
+	}
+	if err := validateConsumerIdentity(config.ProjectID, "project ID"); err != nil {
+		return nil, err
+	}
+	if err := validateConsumerIdentity(config.Environment, "environment"); err != nil {
+		return nil, err
+	}
+	if err := validateConsumerIdentity(config.ModelID, "model ID"); err != nil {
+		return nil, err
+	}
+	if err := validateConsumerIdentity(config.Generation, "generation"); err != nil {
+		return nil, err
+	}
+	if err := validateConsumerIdentity(config.PrincipalID, "principal ID"); err != nil {
+		return nil, err
+	}
+	if config.Authority == nil {
+		return nil, fmt.Errorf("protected semantic model requires semantic access authority")
+	}
+	snapshot, authority, err := config.Authority()
+	if err != nil {
+		return nil, fmt.Errorf("semantic access authority: %w", err)
+	}
+	if snapshot.PrincipalID != config.PrincipalID {
+		return nil, fmt.Errorf("semantic access authority subject does not match consumer principal")
+	}
+	policy, decision, err := evaluateConsumerAuthority(planner.compiled, model, config, snapshot, authority, nil)
+	if err != nil {
+		return nil, err
+	}
+	if decision.PrincipalID != config.PrincipalID || decision.InstanceID != config.InstanceID {
+		return nil, fmt.Errorf("semantic access authority identity does not match consumer")
+	}
+	consumer.policy = policy
+	consumer.decisionDigest = decision.IdentityDigest
+	requestPlanner := *planner
+	requestPlanner.semanticAccessPolicy = policy
+	requestPlanner.semanticAccessProvider = config.Authority
+	requestPlanner.semanticAccessExpectedDecisionDigest = decision.IdentityDigest
+	requestPlanner.semanticAccessAdmissionHook = consumer.captureAdmission
+	consumer.planner = &requestPlanner
+	return consumer, nil
+}
+
+// NewSemanticAccessDiscovery binds only an activation-owned compiled graph.
+// Its planner deliberately has no executable table relation, so it can
+// project and authorize metadata without becoming a query execution
+// capability.
+func NewSemanticAccessDiscovery(compiled *CompiledModel, config SemanticAccessConsumerConfig) (*SemanticAccessConsumer, error) {
+	if compiled == nil {
+		return nil, fmt.Errorf("compiled semantic model is required")
+	}
+	planner := &Planner{compiled: compiled, tableRelation: func(string) (string, error) {
+		return "", fmt.Errorf("semantic access discovery planner cannot execute queries")
+	}}
+	return NewSemanticAccessConsumer(planner, config)
+}
+
+func validateConsumerIdentity(value, label string) error {
+	if value == "" || value != strings.TrimSpace(value) {
+		return fmt.Errorf("%s is required and must be canonical", label)
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("%s contains a control character", label)
+		}
+	}
+	return nil
+}
+
+// Planner returns a fresh request planner carrying this consumer's compiled
+// policy, authority provider, and private admission hook.
+func (consumer *SemanticAccessConsumer) Planner() *Planner {
+	if consumer == nil || consumer.planner == nil {
+		return nil
+	}
+	planner := *consumer.planner
+	return &planner
+}
+
+// PrincipalID returns the authenticated principal bound to a protected
+// consumer. Public consumers intentionally have no synthetic principal.
+func (consumer *SemanticAccessConsumer) PrincipalID() string {
+	if consumer == nil {
+		return ""
+	}
+	return consumer.config.PrincipalID
+}
+
+// ModelID returns the immutable semantic model identity bound to this
+// consumer. It is used by discovery adapters to reject a consumer composed
+// for another model before projecting any protected metadata.
+func (consumer *SemanticAccessConsumer) ModelID() string {
+	if consumer == nil {
+		return ""
+	}
+	return consumer.config.ModelID
+}
+
+// Assets returns a stable, detached, authorization-filtered asset projection.
+func (consumer *SemanticAccessConsumer) Assets() ([]SemanticAccessAsset, error) {
+	if consumer == nil || consumer.planner == nil || consumer.planner.compiled == nil {
+		return nil, fmt.Errorf("semantic access consumer is required")
+	}
+	policy, decision, registry, err := consumer.authority()
+	if err != nil {
+		return nil, err
+	}
+	identity := consumer.policyIdentity(policy)
+	ownership := semanticAccessOwnership(policy, registry)
+	filterDatasets := semanticAccessFilterDatasetSet(policy)
+	assets := make([]SemanticAccessAsset, 0)
+	compiled := consumer.planner.compiled
+
+	for _, dataset := range compiled.DatasetNames() {
+		allowed, err := consumer.allowedDataset(policy, decision, dataset)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed {
+			continue
+		}
+		spec, _ := policy.Dataset(dataset)
+		asset := makeSemanticAccessAsset("dataset", dataset, "", []string{dataset}, filterDatasetsFor([]string{dataset}, filterDatasets), spec.RequiredAccessGrants, identity, ownership)
+		appendSemanticAccessOwnership(&asset, semanticAccessFilterOwnership(policy, []string{dataset}, registry))
+		assets = append(assets, asset)
+	}
+
+	dimensionNames := consumer.planner.compiled.SemanticDimensionNames()
+	for _, dimension := range dimensionNames {
+		datasets := consumer.planner.compiled.DatasetNames()
+		for _, dataset := range datasets {
+			if _, ok := compiled.DimensionBinding(dimension, dataset); !ok {
+				continue
+			}
+			allowed, err := consumer.allowedDimension(policy, decision, dimension, dataset)
+			if err != nil {
+				return nil, err
+			}
+			if !allowed {
+				continue
+			}
+			member, _ := policy.Dimension(dimension, dataset)
+			if !consumer.protected {
+				member.Datasets = []string{dataset}
+			}
+			asset := makeSemanticAccessAsset("dimension", dimension, dataset, member.Datasets, filterDatasetsFor(member.Datasets, filterDatasets), member.RequiredAccessGrants, identity, ownership)
+			appendSemanticAccessOwnership(&asset, semanticAccessFilterOwnership(policy, member.Datasets, registry))
+			assets = append(assets, asset)
+		}
+	}
+
+	metricNames := consumer.planner.compiled.MetricNames()
+	for _, metric := range metricNames {
+		if _, ok := compiled.Metric(metric); !ok {
+			continue
+		}
+		allowed, err := consumer.allowedMetric(policy, decision, metric)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed {
+			continue
+		}
+		member, _ := policy.Metric(metric)
+		if !consumer.protected {
+			compiledMetric, _ := compiled.Metric(metric)
+			member.Datasets = append([]string(nil), compiledMetric.RootDatasets...)
+		}
+		asset := makeSemanticAccessAsset("metric", metric, "", member.Datasets, filterDatasetsFor(member.Datasets, filterDatasets), member.RequiredAccessGrants, identity, ownership)
+		appendSemanticAccessOwnership(&asset, semanticAccessFilterOwnership(policy, member.Datasets, registry))
+		assets = append(assets, asset)
+	}
+	return assets, nil
+}
+
+// Authorize applies the same typed FAI-639 decision used by discovery and
+// planner admission. Malformed combinations and unknown state fail closed.
+func (consumer *SemanticAccessConsumer) Authorize(target SemanticAccessTarget) error {
+	if consumer == nil || consumer.planner == nil || consumer.planner.compiled == nil {
+		return fmt.Errorf("semantic access consumer is required")
+	}
+	target, err := canonicalSemanticAccessTarget(target)
+	if err != nil {
+		return err
+	}
+	policy, decision, _, err := consumer.authority()
+	if err != nil {
+		return err
+	}
+	if !consumer.protected {
+		return consumer.authorizePublic(target)
+	}
+	if target.Dataset != "" {
+		if _, ok := consumer.planner.compiled.Dataset(target.Dataset); !ok {
+			return fmt.Errorf("semantic access target dataset %q is unknown", target.Dataset)
+		}
+		if allowed, err := consumer.allowedDataset(policy, decision, target.Dataset); err != nil || !allowed {
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("semantic access denied for dataset %q", target.Dataset)
+		}
+	}
+	if target.Dimension != "" {
+		if target.Dataset == "" {
+			return fmt.Errorf("semantic access dimension requires dataset")
+		}
+		if _, ok := consumer.planner.compiled.SemanticDimension(target.Dimension); !ok {
+			return fmt.Errorf("semantic access target dimension %q is unknown", target.Dimension)
+		}
+		if _, ok := consumer.planner.compiled.DimensionBinding(target.Dimension, target.Dataset); !ok {
+			return fmt.Errorf("semantic access target dimension %q is not bound to dataset %q", target.Dimension, target.Dataset)
+		}
+		allowed, err := consumer.allowedDimension(policy, decision, target.Dimension, target.Dataset)
+		if err != nil {
+			return err
+		}
+		if !allowed {
+			return fmt.Errorf("semantic access denied for dimension %q", target.Dimension)
+		}
+	}
+	if target.Metric != "" {
+		if _, ok := consumer.planner.compiled.Metric(target.Metric); !ok {
+			return fmt.Errorf("semantic access target metric %q is unknown", target.Metric)
+		}
+		member, ok := policy.Metric(target.Metric)
+		if !ok {
+			return fmt.Errorf("semantic access policy has no metric %q", target.Metric)
+		}
+		if target.Dataset != "" && !semanticConsumerContainsString(member.Datasets, target.Dataset) {
+			return fmt.Errorf("semantic access metric %q does not depend on dataset %q", target.Metric, target.Dataset)
+		}
+		allowed, err := consumer.allowedMetric(policy, decision, target.Metric)
+		if err != nil {
+			return err
+		}
+		if !allowed {
+			return fmt.Errorf("semantic access denied for metric %q", target.Metric)
+		}
+	}
+	return nil
+}
+
+func canonicalSemanticAccessTarget(target SemanticAccessTarget) (SemanticAccessTarget, error) {
+	for _, field := range []struct {
+		label string
+		value *string
+	}{{"dataset", &target.Dataset}, {"dimension", &target.Dimension}, {"metric", &target.Metric}} {
+		label, value := field.label, *field.value
+		if value != strings.TrimSpace(value) {
+			return SemanticAccessTarget{}, fmt.Errorf("semantic access target %s must be canonical", label)
+		}
+		if value != "" {
+			if err := validateConsumerIdentity(value, "semantic access target "+label); err != nil {
+				return SemanticAccessTarget{}, err
+			}
+		}
+	}
+	if target.Dataset == "" && target.Dimension == "" && target.Metric == "" {
+		return SemanticAccessTarget{}, fmt.Errorf("semantic access target is empty")
+	}
+	if target.Dimension != "" && target.Metric != "" {
+		return SemanticAccessTarget{}, fmt.Errorf("semantic access target cannot combine dimension and metric")
+	}
+	if target.Dimension != "" && target.Dataset == "" {
+		return SemanticAccessTarget{}, fmt.Errorf("semantic access dimension requires dataset")
+	}
+	return target, nil
+}
+
+func (consumer *SemanticAccessConsumer) authorizePublic(target SemanticAccessTarget) error {
+	compiled := consumer.planner.compiled
+	if target.Dataset != "" {
+		if _, ok := compiled.Dataset(target.Dataset); !ok {
+			return fmt.Errorf("semantic access target dataset %q is unknown", target.Dataset)
+		}
+	}
+	if target.Dimension != "" {
+		if target.Dataset == "" {
+			return fmt.Errorf("semantic access dimension requires dataset")
+		}
+		if _, ok := compiled.SemanticDimension(target.Dimension); !ok {
+			return fmt.Errorf("semantic access target dimension %q is unknown", target.Dimension)
+		}
+		if _, ok := compiled.DimensionBinding(target.Dimension, target.Dataset); !ok {
+			return fmt.Errorf("semantic access target dimension %q is not bound to dataset %q", target.Dimension, target.Dataset)
+		}
+	}
+	if target.Metric != "" {
+		metric, ok := compiled.Metric(target.Metric)
+		if !ok {
+			return fmt.Errorf("semantic access target metric %q is unknown", target.Metric)
+		}
+		if target.Dataset != "" && !containsString(metric.RootDatasets, target.Dataset) {
+			return fmt.Errorf("semantic access metric %q does not depend on dataset %q", target.Metric, target.Dataset)
+		}
+	}
+	return nil
+}
+
+func (consumer *SemanticAccessConsumer) authority() (*CompiledSemanticAccessPolicy, *SemanticAccessDecision, access.SemanticAttributeRegistrySnapshot, error) {
+	if !consumer.protected {
+		return nil, nil, access.SemanticAttributeRegistrySnapshot{}, nil
+	}
+	if consumer.config.Authority == nil {
+		return nil, nil, access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("protected semantic model requires semantic access authority")
+	}
+	snapshot, current, err := consumer.config.Authority()
+	if err != nil {
+		return nil, nil, access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("semantic access authority: %w", err)
+	}
+	if snapshot.PrincipalID != consumer.config.PrincipalID {
+		return nil, nil, access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("semantic access authority subject does not match consumer principal")
+	}
+	model := consumer.planner.compiled.SourceModel()
+	if model == nil {
+		return nil, nil, access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("compiled semantic model snapshot is required")
+	}
+	policy, decision, err := evaluateConsumerAuthority(consumer.planner.compiled, model, consumer.config, snapshot, current, consumer.policy)
+	if err != nil {
+		return nil, nil, access.SemanticAttributeRegistrySnapshot{}, err
+	}
+	if consumer.decisionDigest != "" && decision.IdentityDigest != consumer.decisionDigest {
+		return nil, nil, access.SemanticAttributeRegistrySnapshot{}, fmt.Errorf("semantic access authority decision is stale or inconsistent")
+	}
+	return policy, decision, current.Registry, nil
+}
+
+func evaluateConsumerAuthority(compiled *CompiledModel, model *semanticmodel.Model, config SemanticAccessConsumerConfig, snapshot SemanticAccessAttributeSnapshot, current SemanticAccessAuthority, expected *CompiledSemanticAccessPolicy) (*CompiledSemanticAccessPolicy, *SemanticAccessDecision, error) {
+	if snapshot.InstanceID != config.InstanceID || current.InstanceID != config.InstanceID {
+		return nil, nil, fmt.Errorf("semantic access authority instance does not match consumer")
+	}
+	policy, err := CompileSemanticAccessPolicy(config.InstanceID, config.ModelID, config.Generation, model, compiled, current.Registry)
+	if err != nil {
+		return nil, nil, fmt.Errorf("compile semantic access policy: %w", err)
+	}
+	if expected != nil && policy.Digest() != expected.Digest() {
+		return nil, nil, fmt.Errorf("semantic access policy identity is stale or inconsistent")
+	}
+	decision, err := EvaluateSemanticAccess(policy, snapshot, current)
+	if err != nil {
+		return nil, nil, fmt.Errorf("evaluate semantic access: %w", err)
+	}
+	return policy, decision, nil
+}
+
+func (consumer *SemanticAccessConsumer) allowedDataset(policy *CompiledSemanticAccessPolicy, decision *SemanticAccessDecision, name string) (bool, error) {
+	if !consumer.protected {
+		return true, nil
+	}
+	if _, ok := policy.Dataset(name); !ok {
+		return false, fmt.Errorf("semantic access policy has no dataset %q", name)
+	}
+	object, ok := decision.Dataset(name)
+	return ok && object.Allowed, nil
+}
+
+func (consumer *SemanticAccessConsumer) allowedDimension(policy *CompiledSemanticAccessPolicy, decision *SemanticAccessDecision, name, dataset string) (bool, error) {
+	if !consumer.protected {
+		return true, nil
+	}
+	if _, ok := policy.Dimension(name, dataset); !ok {
+		return false, fmt.Errorf("semantic access policy has no dimension binding %q on dataset %q", name, dataset)
+	}
+	object, ok := decision.Dimension(name, dataset)
+	return ok && object.Allowed, nil
+}
+
+func (consumer *SemanticAccessConsumer) allowedMetric(policy *CompiledSemanticAccessPolicy, decision *SemanticAccessDecision, name string) (bool, error) {
+	if !consumer.protected {
+		return true, nil
+	}
+	if _, ok := policy.Metric(name); !ok {
+		return false, fmt.Errorf("semantic access policy has no metric %q", name)
+	}
+	object, ok := decision.Metric(name)
+	return ok && object.Allowed, nil
+}
+
+func (consumer *SemanticAccessConsumer) policyIdentity(policy *CompiledSemanticAccessPolicy) SemanticAccessPolicyIdentity {
+	if !consumer.protected || policy == nil {
+		return SemanticAccessPolicyIdentity{}
+	}
+	registry := policy.RegistryState()
+	return SemanticAccessPolicyIdentity{Profile: policy.Profile(), InstanceID: policy.TargetInstanceID(), ModelID: policy.SemanticModelID(), Generation: policy.SemanticGeneration(), PolicyDigest: policy.Digest(), RegistryProfile: registry.Profile, RegistryRevision: registry.Revision, RegistryDigest: registry.Digest}
+}
+
+func makeSemanticAccessAsset(kind, name, dataset string, dependencies, filterDatasets, grants []string, identity SemanticAccessPolicyIdentity, ownership map[string]SemanticAccessOwnership) SemanticAccessAsset {
+	grants = append([]string(nil), grants...)
+	sort.Strings(grants)
+	asset := SemanticAccessAsset{Kind: kind, Name: name, Dataset: dataset, DependencyDatasets: append([]string(nil), dependencies...), FilterDatasets: append([]string(nil), filterDatasets...), RequiredAccessGrants: append([]string(nil), grants...), PolicyIdentity: identity}
+	switch kind {
+	case "dimension":
+		asset.Dimension = name
+	case "metric":
+		asset.Metric = name
+	}
+	for _, grant := range grants {
+		if owner, ok := ownership[grant]; ok {
+			asset.Ownership = append(asset.Ownership, owner)
+		}
+	}
+	return asset
+}
+
+func semanticAccessOwnership(policy *CompiledSemanticAccessPolicy, registry access.SemanticAttributeRegistrySnapshot) map[string]SemanticAccessOwnership {
+	result := map[string]SemanticAccessOwnership{}
+	definitions := make(map[string]access.SemanticAttributeDefinition, len(registry.Definitions))
+	for _, definition := range registry.Definitions {
+		definitions[definition.ID] = definition
+	}
+	if policy == nil {
+		return result
+	}
+	for _, grantName := range sortedStringKeys(policy.grants) {
+		grant, _ := policy.Grant(grantName)
+		definition := definitions[grant.DefinitionID]
+		result[grantName] = SemanticAccessOwnership{Grant: grantName, DefinitionID: grant.DefinitionID, Attribute: grant.UserAttribute, Kind: string(definition.Metadata.Owner.Kind), ID: definition.Metadata.Owner.ID}
+	}
+	return result
+}
+
+func semanticAccessFilterOwnership(policy *CompiledSemanticAccessPolicy, datasets []string, registry access.SemanticAttributeRegistrySnapshot) []SemanticAccessOwnership {
+	definitions := make(map[string]access.SemanticAttributeDefinition, len(registry.Definitions))
+	for _, definition := range registry.Definitions {
+		definitions[definition.Name] = definition
+	}
+	seen := map[string]bool{}
+	result := make([]SemanticAccessOwnership, 0)
+	for _, dataset := range datasets {
+		spec, ok := policy.Dataset(dataset)
+		if !ok {
+			continue
+		}
+		for _, filter := range spec.AccessFilters {
+			definition, ok := definitions[filter.UserAttribute]
+			if !ok || seen[definition.ID] {
+				continue
+			}
+			seen[definition.ID] = true
+			result = append(result, SemanticAccessOwnership{DefinitionID: definition.ID, Attribute: definition.Name, Kind: string(definition.Metadata.Owner.Kind), ID: definition.Metadata.Owner.ID})
+		}
+	}
+	return result
+}
+
+func appendSemanticAccessOwnership(asset *SemanticAccessAsset, owners []SemanticAccessOwnership) {
+	if asset == nil {
+		return
+	}
+	for _, owner := range owners {
+		duplicate := false
+		for _, existing := range asset.Ownership {
+			if existing.Grant == owner.Grant && existing.DefinitionID == owner.DefinitionID && existing.Attribute == owner.Attribute {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			asset.Ownership = append(asset.Ownership, owner)
+		}
+	}
+	sort.Slice(asset.Ownership, func(i, j int) bool {
+		if asset.Ownership[i].Grant != asset.Ownership[j].Grant {
+			return asset.Ownership[i].Grant < asset.Ownership[j].Grant
+		}
+		if asset.Ownership[i].Attribute != asset.Ownership[j].Attribute {
+			return asset.Ownership[i].Attribute < asset.Ownership[j].Attribute
+		}
+		return asset.Ownership[i].DefinitionID < asset.Ownership[j].DefinitionID
+	})
+}
+
+func semanticAccessFilterDatasetSet(policy *CompiledSemanticAccessPolicy) map[string]bool {
+	result := map[string]bool{}
+	if policy == nil {
+		return result
+	}
+	for _, dataset := range sortedStringKeys(policy.datasets) {
+		spec, _ := policy.Dataset(dataset)
+		if len(spec.AccessFilters) != 0 {
+			result[dataset] = true
+		}
+	}
+	return result
+}
+
+func filterDatasetsFor(dependencies []string, filters map[string]bool) []string {
+	result := make([]string, 0)
+	for _, dataset := range dependencies {
+		if filters[dataset] {
+			result = append(result, dataset)
+		}
+	}
+	return result
+}
+
+func semanticConsumerContainsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+// captureAdmission records the exact canonical graph and renderer-independent
+// identity emitted by one consumer planner. The map key is pointer identity,
+// preventing copies or a second consumer from satisfying validation.
+func (consumer *SemanticAccessConsumer) captureAdmission(graph *planir.Graph, admission semanticAccessAdmission) error {
+	if graph == nil {
+		return fmt.Errorf("semantic access plan graph is nil")
+	}
+	canonical, err := graph.Canonical()
+	if err != nil {
+		return fmt.Errorf("canonicalize admitted semantic plan: %w", err)
+	}
+	consumer.mu.Lock()
+	consumer.admissions[graph] = semanticAccessPlanAdmission{canonical: append([]byte(nil), canonical...), policyDigest: admission.PolicyDigest, decisionDigest: admission.DecisionDigest}
+	consumer.mu.Unlock()
+	return nil
+}
+
+// ValidatePlan proves origin, unchanged graph identity, current authority,
+// and exact renderer SQL/arguments/columns immediately before execution.
+func (consumer *SemanticAccessConsumer) ValidatePlan(plan Plan) error {
+	if consumer == nil || consumer.planner == nil {
+		return fmt.Errorf("semantic access consumer is required")
+	}
+	if plan.IR == nil {
+		return fmt.Errorf("semantic access plan has no PlanIR")
+	}
+	consumer.mu.RLock()
+	admission, ok := consumer.admissions[plan.IR]
+	consumer.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("plan was not admitted by this semantic access consumer")
+	}
+	canonical, err := plan.IR.Canonical()
+	if err != nil {
+		return fmt.Errorf("validate semantic access PlanIR: %w", err)
+	}
+	if !bytes.Equal(canonical, admission.canonical) {
+		return fmt.Errorf("semantic access plan graph changed after admission")
+	}
+	if consumer.protected {
+		_, decision, _, err := consumer.authority()
+		if err != nil {
+			return err
+		}
+		if decision.IdentityDigest != admission.decisionDigest {
+			return fmt.Errorf("semantic access authority changed after admission")
+		}
+	}
+	rendered, err := planir.RenderDuckDB(plan.IR)
+	if err != nil {
+		return fmt.Errorf("render semantic access PlanIR: %w", err)
+	}
+	if plan.SQL != rendered.SQL {
+		return fmt.Errorf("plan SQL does not match its PlanIR renderer output")
+	}
+	if !reflect.DeepEqual(plan.Args, rendered.Args) {
+		return fmt.Errorf("plan arguments do not match its PlanIR renderer output")
+	}
+	if !reflect.DeepEqual(plan.Columns, rendered.Columns) {
+		return fmt.Errorf("plan columns do not match its PlanIR renderer output")
+	}
+	return nil
+}

--- a/internal/analytics/query/semantic_consumer_admission_test.go
+++ b/internal/analytics/query/semantic_consumer_admission_test.go
@@ -1,0 +1,89 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/flidai/leapview/internal/analytics/query/planir"
+)
+
+func TestSemanticConsumerAdmissionRejectsCrossConsumerAndRerenderedMutation(t *testing.T) {
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	consumer := newDiscoveryConsumer(t, snapshot, authority)
+	plan, err := consumer.Planner().Plan(Request{Dataset: "orders", Metrics: []Field{{Field: "revenue"}}, Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := consumer.ValidatePlan(plan); err != nil {
+		t.Fatal(err)
+	}
+	other := newDiscoveryConsumer(t, snapshot, authority)
+	if err := other.ValidatePlan(plan); err == nil {
+		t.Fatal("another consumer accepted admitted plan")
+	}
+	copyPlan := plan
+	graphCopy := *plan.IR
+	copyPlan.IR = &graphCopy
+	if err := consumer.ValidatePlan(copyPlan); err == nil {
+		t.Fatal("copied graph accepted without admission")
+	}
+	output, ok := plan.IR.Nodes[plan.IR.Output].(planir.SortLimit)
+	if !ok {
+		t.Fatalf("output = %T", plan.IR.Nodes[plan.IR.Output])
+	}
+	output.Limit = 10
+	plan.IR.Nodes[plan.IR.Output] = output
+	rendered, err := planir.RenderDuckDB(plan.IR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan.SQL, plan.Args, plan.Columns = rendered.SQL, rendered.Args, rendered.Columns
+	if err := consumer.ValidatePlan(plan); err == nil {
+		t.Fatal("re-rendered graph mutation accepted")
+	}
+}
+
+func TestSemanticConsumerDoesNotMixValidDecisions(t *testing.T) {
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	planner, err := NewCompiledPlanner(semanticAccessTestModel(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID, Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+		return snapshot, authority, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := consumer.Assets(); err != nil {
+		t.Fatal(err)
+	}
+	// Another internally consistent snapshot is not the original request's
+	// authority. The consumer must not combine decisions across observations.
+	snapshot, authority = semanticAccessSnapshot(t, nil)
+	if _, err := consumer.Assets(); err == nil {
+		t.Fatal("changed valid decision mixed into discovery")
+	}
+	if _, err := consumer.Planner().Plan(Request{Dataset: "orders", Metrics: []Field{{Field: "revenue"}}}); err == nil {
+		t.Fatal("changed decision admitted a plan")
+	}
+}
+
+func TestSemanticConsumerDiscoveryPlannerCannotBecomeExecutionCapability(t *testing.T) {
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	planner, err := NewCompiledPlanner(semanticAccessTestModel(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := NewSemanticAccessDiscovery(planner.CompiledModel(), SemanticAccessConsumerConfig{InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID, Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+		return snapshot, authority, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := consumer.Assets(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := consumer.Planner().Plan(Request{Dataset: "orders", Metrics: []Field{{Field: "revenue"}}}); err == nil {
+		t.Fatal("discovery-only consumer emitted executable plan")
+	}
+}

--- a/internal/analytics/query/semantic_consumer_context.go
+++ b/internal/analytics/query/semantic_consumer_context.go
@@ -1,0 +1,102 @@
+package query
+
+import (
+	"context"
+	"fmt"
+)
+
+// SemanticAccessConsumerBinding is the request-time serving identity carried
+// alongside a semantic access consumer.  The values are deliberately scalar
+// strings so the query package does not depend on project/runtime ownership
+// packages; composition roots can copy their authoritative serving identity
+// into this value before binding it to a request.
+//
+// A protected consumer must carry every field, including project/environment
+// and the authenticated principal. Public consumers may leave PrincipalID
+// empty, but still bind a model and serving scope so a consumer cannot be
+// replayed across runtimes.
+type SemanticAccessConsumerBinding struct {
+	InstanceID  string
+	ProjectID   string
+	Environment string
+	Generation  string
+	ModelID     string
+	PrincipalID string
+}
+
+// SemanticAccessConsumerContext is a process-local capability.  It is not a
+// serialized authorization token: materialize uses the exact consumer pointer
+// to obtain its request planner and to validate the admitted PlanIR before
+// execution.
+type SemanticAccessConsumerContext struct {
+	Consumer *SemanticAccessConsumer
+	Binding  SemanticAccessConsumerBinding
+}
+
+type semanticAccessConsumerContextKey struct{}
+
+// WithSemanticAccessConsumer binds one request-bound consumer and its serving
+// identity to ctx.  The consumer itself remains the authority; the binding is
+// context metadata used by execution boundaries to reject cross-model,
+// cross-project, cross-generation, and cross-principal replay.
+func WithSemanticAccessConsumer(ctx context.Context, consumer *SemanticAccessConsumer, binding SemanticAccessConsumerBinding) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, semanticAccessConsumerContextKey{}, SemanticAccessConsumerContext{
+		Consumer: consumer,
+		Binding:  binding,
+	})
+}
+
+// SemanticAccessConsumerContextFromContext returns the request capability, if
+// one was bound.  Validation is intentionally repeated at this boundary so a
+// caller cannot pair a consumer with identity metadata from another request.
+func SemanticAccessConsumerContextFromContext(ctx context.Context) (SemanticAccessConsumerContext, bool) {
+	if ctx == nil {
+		return SemanticAccessConsumerContext{}, false
+	}
+	value, ok := ctx.Value(semanticAccessConsumerContextKey{}).(SemanticAccessConsumerContext)
+	if !ok || value.Consumer == nil {
+		return SemanticAccessConsumerContext{}, false
+	}
+	if err := value.Validate(); err != nil {
+		return SemanticAccessConsumerContext{}, false
+	}
+	return value, true
+}
+
+// Validate checks the binding against the consumer's private identity.  It is
+// exported for execution adapters that need to report a useful denial reason
+// while keeping consumer configuration immutable and inaccessible.
+func (value SemanticAccessConsumerContext) Validate() error {
+	if value.Consumer == nil {
+		return fmt.Errorf("semantic access consumer is required")
+	}
+	binding := value.Binding
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{name: "instance ID", value: binding.InstanceID},
+		{name: "project ID", value: binding.ProjectID},
+		{name: "environment", value: binding.Environment},
+		{name: "generation", value: binding.Generation},
+		{name: "model ID", value: binding.ModelID},
+	}
+	for _, field := range fields {
+		if field.value == "" {
+			return fmt.Errorf("semantic access %s is required", field.name)
+		}
+	}
+	if value.Consumer.protected && binding.PrincipalID == "" {
+		return fmt.Errorf("semantic access principal ID is required")
+	}
+	if value.Consumer.protected {
+		config := value.Consumer.config
+		if binding.InstanceID != config.InstanceID || binding.ProjectID != config.ProjectID || binding.Environment != config.Environment || binding.ModelID != config.ModelID || binding.Generation != config.Generation || binding.PrincipalID != config.PrincipalID {
+			return fmt.Errorf("semantic access consumer identity does not match request binding")
+		}
+	}
+	return nil
+}

--- a/internal/analytics/query/semantic_consumer_context_test.go
+++ b/internal/analytics/query/semantic_consumer_context_test.go
@@ -1,0 +1,65 @@
+package query
+
+import "testing"
+
+func TestProtectedConsumerRequiresProjectAndEnvironmentIdentity(t *testing.T) {
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	planner, err := NewCompiledPlanner(semanticAccessTestModel(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := SemanticAccessConsumerConfig{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod",
+		ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID,
+		Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+			return snapshot, authority, nil
+		},
+	}
+	for _, test := range []struct {
+		name string
+		edit func(*SemanticAccessConsumerConfig)
+	}{
+		{name: "missing project", edit: func(config *SemanticAccessConsumerConfig) { config.ProjectID = "" }},
+		{name: "missing environment", edit: func(config *SemanticAccessConsumerConfig) { config.Environment = "" }},
+		{name: "noncanonical project", edit: func(config *SemanticAccessConsumerConfig) { config.ProjectID = " project:test" }},
+		{name: "noncanonical environment", edit: func(config *SemanticAccessConsumerConfig) { config.Environment = "prod " }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := base
+			test.edit(&config)
+			if _, err := NewSemanticAccessConsumer(planner, config); err == nil {
+				t.Fatal("protected consumer accepted incomplete identity")
+			}
+		})
+	}
+}
+
+func TestSemanticAccessConsumerBindingRejectsProjectAndEnvironmentRelabeling(t *testing.T) {
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	consumer := newDiscoveryConsumer(t, snapshot, authority)
+	base := SemanticAccessConsumerBinding{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod",
+		Generation: "generation-1", ModelID: "semantic-model:test", PrincipalID: snapshot.PrincipalID,
+	}
+	for _, test := range []struct {
+		name string
+		edit func(*SemanticAccessConsumerBinding)
+	}{
+		{name: "project", edit: func(binding *SemanticAccessConsumerBinding) { binding.ProjectID = "project:other" }},
+		{name: "environment", edit: func(binding *SemanticAccessConsumerBinding) { binding.Environment = "staging" }},
+		{name: "missing project", edit: func(binding *SemanticAccessConsumerBinding) { binding.ProjectID = "" }},
+		{name: "missing environment", edit: func(binding *SemanticAccessConsumerBinding) { binding.Environment = "" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			binding := base
+			test.edit(&binding)
+			ctx := WithSemanticAccessConsumer(t.Context(), consumer, binding)
+			if _, ok := SemanticAccessConsumerContextFromContext(ctx); ok {
+				t.Fatal("relabelled consumer binding was accepted")
+			}
+			if err := (SemanticAccessConsumerContext{Consumer: consumer, Binding: binding}).Validate(); err == nil {
+				t.Fatal("relabelled consumer binding validated")
+			}
+		})
+	}
+}

--- a/internal/analytics/query/semantic_consumer_discovery_test.go
+++ b/internal/analytics/query/semantic_consumer_discovery_test.go
@@ -1,0 +1,192 @@
+package query
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+)
+
+func newDiscoveryConsumer(t *testing.T, snapshot SemanticAccessAttributeSnapshot, authority SemanticAccessAuthority) *SemanticAccessConsumer {
+	t.Helper()
+	planner, err := NewCompiledPlanner(semanticAccessTestModel(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID, Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+		return snapshot, authority, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return consumer
+}
+
+func TestSemanticConsumerDiscoverySortedDetachedAndTransitive(t *testing.T) {
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	consumer := newDiscoveryConsumer(t, snapshot, authority)
+	assets, err := consumer.Assets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, err := json.Marshal(assets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for _, asset := range assets {
+		found[asset.Kind] = true
+		if asset.PolicyIdentity.PolicyDigest == "" || len(asset.DependencyDatasets) == 0 {
+			t.Fatalf("unqualified discovery: %#v", asset)
+		}
+		if asset.Kind == "metric" && asset.Name == "doubledRevenue" && len(asset.RequiredAccessGrants) != 3 {
+			t.Fatalf("lost transitive grants: %#v", asset)
+		}
+	}
+	for _, kind := range []string{"dataset", "dimension", "metric"} {
+		if !found[kind] {
+			t.Fatalf("missing %s discovery", kind)
+		}
+	}
+	assets[0].Name = "mutated"
+	assets[0].DependencyDatasets[0] = "mutated"
+	if len(assets[0].RequiredAccessGrants) > 0 {
+		assets[0].RequiredAccessGrants[0] = "mutated"
+	}
+	again, err := consumer.Assets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, _ := json.Marshal(again)
+	if !bytes.Equal(original, encoded) {
+		t.Fatal("caller mutated authoritative discovery")
+	}
+	snapshot.Registry.Definitions = reverseDefinitions(snapshot.Registry.Definitions)
+	authority.Registry.Definitions = reverseDefinitions(authority.Registry.Definitions)
+	snapshot.EffectiveAttributes = reverseEffectiveAttributes(snapshot.EffectiveAttributes)
+	reordered := newDiscoveryConsumer(t, snapshot, authority)
+	other, err := reordered.Assets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, _ = json.Marshal(other)
+	if !bytes.Equal(original, encoded) {
+		t.Fatal("authority ordering changed discovery")
+	}
+}
+
+func TestSemanticConsumerDeniedAssetsAreNotDiscoverableOrDirectlyUsable(t *testing.T) {
+	snapshot, authority := semanticAccessSnapshot(t, nil)
+	consumer := newDiscoveryConsumer(t, snapshot, authority)
+	assets, err := consumer.Assets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, asset := range assets {
+		if asset.Name == "orders" || asset.Name == "revenue" {
+			t.Fatalf("denied asset discovered: %#v", asset)
+		}
+	}
+	for _, target := range []SemanticAccessTarget{{Dataset: "orders"}, {Metric: "revenue"}, {Dataset: "orders", Dimension: "region"}} {
+		if err := consumer.Authorize(target); err == nil {
+			t.Fatalf("denied direct target admitted: %#v", target)
+		}
+	}
+}
+
+func TestSemanticConsumerTombstonedAssignmentCannotAuthorizeDiscovery(t *testing.T) {
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	snapshot.Control.Assignments[0].Tombstoned = true
+	snapshot.Control.State.Digest, _ = access.SemanticAttributeControlDigest(snapshot.Control.Assignments, snapshot.Control.Mappings)
+	authority.Control = snapshot.Control
+	planner, err := NewCompiledPlanner(semanticAccessTestModel(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID, Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+		return snapshot, authority, nil
+	}})
+	if err == nil {
+		t.Fatal("tombstoned assignment evidence admitted")
+	}
+}
+
+func TestSemanticConsumerRejectsInvalidAndDuplicateAuthority(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		change func(*access.SemanticAttributeRegistrySnapshot)
+	}{
+		{"disabled", func(r *access.SemanticAttributeRegistrySnapshot) {
+			r.Definitions[0].Enabled = false
+			r.Definitions[0].LifecycleState = access.SemanticAttributeDisabled
+			r.Definitions[0].DisabledAt = semanticAccessObservedAt
+		}},
+		{"duplicate", func(r *access.SemanticAttributeRegistrySnapshot) {
+			r.Definitions = append(r.Definitions, r.Definitions[0])
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot, current := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+			test.change(&snapshot.Registry)
+			snapshot.Registry.State.Digest, _ = access.SemanticAttributeRegistryDigest(snapshot.Registry.State.Profile, snapshot.Registry.Definitions)
+			current.Registry = snapshot.Registry
+			planner, err := NewCompiledPlanner(semanticAccessTestModel(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID, Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+				return snapshot, current, nil
+			}})
+			if err == nil {
+				t.Fatal("unusable registry authority accepted")
+			}
+		})
+	}
+}
+
+func TestSemanticConsumerFilterOwnershipDoesNotUseGrantNameCollisions(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	model.AccessPolicy.AccessGrants["regions"] = semanticmodel.SemanticAccessGrantSpec{
+		UserAttribute: "department",
+		AllowedValues: []semanticmodel.SemanticAccessLiteral{{Kind: semanticmodel.SemanticAccessString, Text: "sales"}},
+	}
+	planner, err := NewCompiledPlanner(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	consumer, err := NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID,
+		Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+			return snapshot, authority, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assets, err := consumer.Assets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, asset := range assets {
+		if asset.Kind != "dataset" || asset.Name != "orders" {
+			continue
+		}
+		foundFilterOwner := false
+		for _, owner := range asset.Ownership {
+			if owner.Attribute == "regions" {
+				foundFilterOwner = true
+				if owner.DefinitionID != "def-regions" {
+					t.Fatalf("filter ownership used colliding grant definition: %#v", owner)
+				}
+			}
+		}
+		if !foundFilterOwner {
+			t.Fatal("filter-only ownership metadata was omitted")
+		}
+		return
+	}
+	t.Fatal("orders dataset was not discovered")
+}

--- a/internal/analytics/query/semantic_consumer_test.go
+++ b/internal/analytics/query/semantic_consumer_test.go
@@ -1,0 +1,93 @@
+package query
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestSemanticConsumerDiscoveryAndPlannerUseSameDecision(t *testing.T) {
+	model := semanticAccessTestModel(t)
+	planner, err := NewCompiledPlanner(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, authority := semanticAccessSnapshot(t, semanticAccessEffective(t, semanticAccessDefinitions()))
+	consumer, err := NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic-model:test", Generation: "generation-1", PrincipalID: snapshot.PrincipalID,
+		Authority: func() (SemanticAccessAttributeSnapshot, SemanticAccessAuthority, error) {
+			return snapshot, authority, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var previous []byte
+	for i := 0; i < 5; i++ {
+		assets, err := consumer.Assets()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(assets) == 0 {
+			t.Fatal("empty discovery")
+		}
+		encoded, err := json.Marshal(assets)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i > 0 && !bytes.Equal(previous, encoded) {
+			t.Fatal("unstable discovery")
+		}
+		previous = encoded
+	}
+	if err := consumer.Authorize(SemanticAccessTarget{Dataset: "orders", Metric: "revenue"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := consumer.Authorize(SemanticAccessTarget{Dataset: "unknown"}); err == nil {
+		t.Fatal("unknown asset admitted")
+	}
+	plan, err := consumer.Planner().Plan(Request{Dataset: "orders", Metrics: []Field{{Field: "revenue"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := consumer.ValidatePlan(plan); err != nil {
+		t.Fatal(err)
+	}
+	plan.SQL = "SELECT * FROM orders"
+	if err := consumer.ValidatePlan(plan); err == nil {
+		t.Fatal("unadmitted SQL accepted")
+	}
+	authority.Control.State.Revision++
+	if _, err := consumer.Assets(); err == nil {
+		t.Fatal("stale authority accepted for discovery")
+	}
+}
+
+func TestSemanticConsumerMissingAuthorityDoesNotBecomePublic(t *testing.T) {
+	planner, err := NewCompiledPlanner(semanticAccessTestModel(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{}); err == nil {
+		t.Fatal("missing authority accepted")
+	}
+	public := semanticAccessTestModel(t)
+	public.AccessPolicy.AccessGrants = nil
+	public.AccessPolicy.Datasets = nil
+	public.AccessPolicy.Dimensions = nil
+	public.AccessPolicy.Metrics = nil
+	planner, err = NewCompiledPlanner(public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := NewSemanticAccessConsumer(planner, SemanticAccessConsumerConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := consumer.Authorize(SemanticAccessTarget{Dataset: "orders"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := consumer.Authorize(SemanticAccessTarget{Metric: "missing"}); err == nil {
+		t.Fatal("unknown public asset admitted")
+	}
+}

--- a/internal/app/persistence_test.go
+++ b/internal/app/persistence_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/flidai/leapview/internal/platform"
 	projectcatalog "github.com/flidai/leapview/internal/project/catalog"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmodule "github.com/flidai/leapview/internal/project/module"
 	servingstate "github.com/flidai/leapview/internal/servingstate"
 	servingstatesqlite "github.com/flidai/leapview/internal/servingstate/sqlite"
 )
@@ -110,6 +111,7 @@ func testStoreOptions(store *platform.Store, options assemblyConfig) assemblyCon
 		catalog, err := projectcatalog.NewService(
 			projectCatalogLeaseProvider{provider: options.RuntimeHost.Provider()},
 			projectCatalogSubjectResolver{resolve: options.AccessModule.AuthorizationSubjects},
+			projectcatalog.WithSemanticModelVisibility(projectmodule.SemanticCatalogVisibility("lvinst_test", options.AccessModule.ResolveSemanticAttributes)),
 		)
 		if err != nil {
 			panic(err)

--- a/internal/app/postgres_build.go
+++ b/internal/app/postgres_build.go
@@ -553,7 +553,7 @@ func buildPostgresTarget(ctx context.Context, cfg config.Config, production bool
 	graph.ApprovalAuthorizer.SetCandidateResolver(func(resolveCtx context.Context, generationID, principalID string) (string, string, []access.Capability, error) {
 		return candidateApprovalCapabilities(resolveCtx, graph.ServingState, nativeProjectSource.Objects, accessBundle.Module.AuthorizationSubjects, generationID, principalID)
 	})
-	projectCatalogService, err := projectcatalog.NewService(projectCatalogLeaseProvider{provider: runtimeHost.Provider()}, projectCatalogSubjectResolver{resolve: accessBundle.Module.AuthorizationSubjects})
+	projectCatalogService, err := projectcatalog.NewService(projectCatalogLeaseProvider{provider: runtimeHost.Provider()}, projectCatalogSubjectResolver{resolve: accessBundle.Module.AuthorizationSubjects}, projectcatalog.WithSemanticModelVisibility(projectmodule.SemanticCatalogVisibility(instanceID, accessBundle.Module.ResolveSemanticAttributes)))
 	if err != nil {
 		return fail(err)
 	}

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -612,8 +612,10 @@ func buildApplicationSurfaces(
 	}
 	if metrics != nil && authorizationSnapshot != nil && capabilities.AccessModule != nil {
 		metrics = dashboardmodule.WithQueryAuthorization(metrics, dashboardmodule.QueryAuthorizationConfig{
-			SnapshotFromContext: authorizationSnapshot,
-			SubjectsFromContext: capabilities.AccessModule.AuthorizationSubjects,
+			InstanceID:                runtimeConfig.InstanceID,
+			ResolveSemanticAttributes: capabilities.AccessModule.ResolveSemanticAttributes,
+			SnapshotFromContext:       authorizationSnapshot,
+			SubjectsFromContext:       capabilities.AccessModule.AuthorizationSubjects,
 			PrincipalFromContext: func(ctx context.Context) (dashboardmodule.QueryPrincipal, bool) {
 				principal, ok := accessmodule.PrincipalFromContext(ctx)
 				devBypass := principal.DevBypass
@@ -682,8 +684,10 @@ func buildApplicationSurfaces(
 		}
 		if candidateAuthorizationSnapshot != nil && capabilities.AccessModule != nil {
 			candidate = dashboardmodule.WithQueryAuthorization(candidate, dashboardmodule.QueryAuthorizationConfig{
-				SnapshotFromContext: candidateAuthorizationSnapshot,
-				SubjectsFromContext: capabilities.AccessModule.AuthorizationSubjects,
+				InstanceID:                runtimeConfig.InstanceID,
+				ResolveSemanticAttributes: capabilities.AccessModule.ResolveSemanticAttributes,
+				SnapshotFromContext:       candidateAuthorizationSnapshot,
+				SubjectsFromContext:       capabilities.AccessModule.AuthorizationSubjects,
 				PrincipalFromContext: func(ctx context.Context) (dashboardmodule.QueryPrincipal, bool) {
 					principal, ok := accessmodule.PrincipalFromContext(ctx)
 					devBypass := principal.DevBypass

--- a/internal/app/runtime_router.go
+++ b/internal/app/runtime_router.go
@@ -1297,7 +1297,7 @@ func configureModules(routes *capabilityRoutes, runtime *runtimeServices, platfo
 					return principal.ID
 				},
 				AuthorizeListResource: func(ctx context.Context, principalID string, projectID projectgraph.ResourceID, resource access.ResourceRef, capability access.Capability) (bool, error) {
-					return authorizeProjectResources(ctx, routes.accessModule, runtime.runtimeHostModule, principalID, projectID, []access.ResourceRef{resource}, capability)
+					return authorizeSemanticModelResourceRead(ctx, routes.accessModule, runtime.runtimeHostModule, principalID, projectID, resource, capability)
 				},
 				QueryFreshness: func(ctx context.Context, projectID, modelID, servingSnapshot string) (dashboardmodule.QueryFreshness, bool) {
 					if routes.refreshModule == nil {

--- a/internal/app/runtimefactory/dashboard_projection.go
+++ b/internal/app/runtimefactory/dashboard_projection.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	dashboardauthoring "github.com/flidai/leapview/internal/dashboard/authoring"
 	dashboardruntime "github.com/flidai/leapview/internal/dashboard/runtime"
@@ -36,6 +37,76 @@ func (r dashboardRuntimeWithGraph) CompiledSemanticModel(modelID string) (*seman
 		return nil, false
 	}
 	return concrete.CompiledModel(), true
+}
+
+// SemanticModel exposes the activation-owned model snapshot used by the
+// planner. The dashboard service retains its authored projection for runtime
+// construction, but schema discovery is an activation fact; consumers must
+// observe the planner's detached source snapshot so metadata prechecks and
+// execution bind to one generation.
+func (r dashboardRuntimeWithGraph) SemanticModel(modelID string) (*semanticmodel.Model, bool) {
+	compiled, ok := r.CompiledSemanticModel(modelID)
+	if !ok || compiled == nil {
+		return nil, false
+	}
+	source := compiled.SourceModel()
+	if source == nil || !compiled.MatchesModel(source) {
+		return nil, false
+	}
+	// The planner is selected by the canonical model resource ID, but retain a
+	// cheap identity check at this boundary so a malformed runtime cannot expose
+	// an unrelated activation snapshot as the requested model.
+	authored, exists := r.projectManifest.SemanticModels[modelID]
+	if !exists || authored == nil || authored.Name != source.Name || !activationModelsCompatible(compiled, authored, source) {
+		return nil, false
+	}
+	runtimeSafe, err := authored.RuntimeSnapshot()
+	if err != nil || runtimeSafe == nil {
+		return nil, false
+	}
+	// Source/connection metadata is descriptive runtime state rather than
+	// planner authority. Preserve it through the same redacted detached
+	// projection used by ProjectManifest while retaining the activation-owned
+	// executable graph and discovered schema above.
+	source.Connections = runtimeSafe.Connections
+	source.Sources = runtimeSafe.Sources
+	source.DefaultConnection = runtimeSafe.DefaultConnection
+	return source, true
+}
+
+// activationModelsCompatible compares the authored execution contract with
+// the activated source snapshot through the model's existing discovery
+// derivation. Physical schemas are activation-owned inputs; resolving them on a
+// detached authored snapshot reconstructs derived dimensions/columns without
+// weakening the full compiled-model fingerprint check.
+func activationModelsCompatible(compiled *semanticquery.CompiledModel, authored, activated *semanticmodel.Model) bool {
+	authoredSnapshot := authored.ExecutionSnapshot()
+	activatedSnapshot := activated.ExecutionSnapshot()
+	if authoredSnapshot == nil || activatedSnapshot == nil {
+		return false
+	}
+	if compiled.MatchesModel(authoredSnapshot) {
+		return true
+	}
+	for name, activatedTable := range activatedSnapshot.Tables {
+		authoredTable, ok := authoredSnapshot.Tables[name]
+		if !ok {
+			return false
+		}
+		authoredTable.Schema.Columns = append([]semanticmodel.ColumnSchema(nil), activatedTable.Schema.Columns...)
+		authoredSnapshot.Tables[name] = authoredTable
+	}
+	if err := authoredSnapshot.ResolveDiscoveredModelFields(); err != nil {
+		return false
+	}
+	return compiled.MatchesModel(authoredSnapshot)
+}
+
+// SemanticModelByID is the resource-ID form of SemanticModel used by runtime
+// resolver consumers. It deliberately shares the same activation projection
+// and fail-closed behavior.
+func (r dashboardRuntimeWithGraph) SemanticModelByID(modelID projectgraph.ResourceID) (*semanticmodel.Model, bool) {
+	return r.SemanticModel(modelID.String())
 }
 
 type dashboardRuntimeWithGraph struct {

--- a/internal/app/runtimefactory/dashboard_projection_test.go
+++ b/internal/app/runtimefactory/dashboard_projection_test.go
@@ -11,6 +11,7 @@ import (
 	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	"github.com/flidai/leapview/internal/dashboard/consumer"
 	dashboarddocument "github.com/flidai/leapview/internal/dashboard/document"
+	queryauthz "github.com/flidai/leapview/internal/dashboard/queryauthz"
 	"github.com/flidai/leapview/internal/dashboard/report"
 	dashboardruntime "github.com/flidai/leapview/internal/dashboard/runtime"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
@@ -131,11 +132,15 @@ func TestCompiledSemanticModelAdaptsActivationPlannerAndFailsClosed(t *testing.T
 
 func TestRuntimeProjectManifestMatchesActivationPlannerSnapshot(t *testing.T) {
 	model := compiledPlannerTestModel()
+	model.Sources = map[string]semanticmodel.Source{"orders": {Format: "table"}}
 	model.AIContext = &semanticmodel.AIContext{Instructions: "authoring only"}
 	discovered := model.ExecutionSnapshot()
 	table := discovered.Tables["orders"]
 	table.Schema.Columns = []semanticmodel.ColumnSchema{{Name: "order_id", PhysicalType: "BIGINT"}}
 	discovered.Tables["orders"] = table
+	if err := discovered.ResolveDiscoveredModelFields(); err != nil {
+		t.Fatal(err)
+	}
 	projectID := projectgraph.ResourceID("project:demo")
 	modelID := projectgraph.ResourceID("semantic-model:sales")
 	planner, err := semanticquery.NewCompiledPlanner(discovered)
@@ -160,12 +165,78 @@ func TestRuntimeProjectManifestMatchesActivationPlannerSnapshot(t *testing.T) {
 	runtime := dashboardRuntimeWithGraph{Service: service, projectManifest: projectmanifest.ResourceManifest{
 		SemanticModels: map[string]*semanticmodel.Model{modelID.String(): model},
 	}}
+	for index := range 3 {
+		activated, ok := runtime.SemanticModel(modelID.String())
+		if !ok || activated == nil {
+			t.Fatal("activation semantic model was unavailable")
+		}
+		if !planner.CompiledModel().MatchesModel(activated) {
+			t.Fatalf("activation semantic model fingerprint = %q, want planner %q", semanticquery.SemanticModelFingerprint(activated), planner.CompiledModel().SourceFingerprint())
+		}
+		if len(activated.Tables["orders"].Schema.Columns) != 1 {
+			t.Fatalf("activation semantic model schema = %#v, want discovered schema", activated.Tables["orders"].Schema.Columns)
+		}
+		if _, ok := activated.Sources["orders"]; !ok {
+			t.Fatalf("activation semantic model omitted runtime-safe source metadata: %#v", activated.Sources)
+		}
+		if index == 0 {
+			activated.Tables["orders"].Schema.Columns[0].Name = "mutated"
+		}
+		if index > 0 && activated.Tables["orders"].Schema.Columns[0].Name != "order_id" {
+			// The first call above deliberately mutates its detached snapshot;
+			// subsequent calls must continue to expose the activation value.
+			t.Fatalf("activation semantic model snapshot was not detached: %#v", activated.Tables["orders"].Schema.Columns)
+		}
+	}
+	consumer, err := queryauthz.New(runtime, queryauthz.Options{}).SemanticConsumer(context.Background(), modelID.String())
+	if err != nil || consumer == nil {
+		t.Fatalf("public discovered semantic consumer = %v, want success", err)
+	}
 	manifest := runtime.ProjectManifest()
 	if !planner.CompiledModel().MatchesModel(manifest.SemanticModels[modelID.String()]) {
 		t.Fatalf("runtime manifest fingerprint = %q, want activation planner %q", semanticquery.SemanticModelFingerprint(manifest.SemanticModels[modelID.String()]), planner.CompiledModel().SourceFingerprint())
 	}
 	if manifest.SemanticModels[modelID.String()].AIContext != nil {
 		t.Fatal("runtime manifest retained authoring-only semantic model context")
+	}
+}
+
+func TestActivationSemanticModelFailsClosedWithoutCoherentSnapshot(t *testing.T) {
+	model := compiledPlannerTestModel()
+	modelID := projectgraph.ResourceID("semantic-model:sales")
+	projectManifest := projectmanifest.ResourceManifest{SemanticModels: map[string]*semanticmodel.Model{modelID.String(): model}}
+
+	missing := dashboardRuntimeWithGraph{projectManifest: projectManifest}
+	if _, ok := missing.SemanticModel(modelID.String()); ok {
+		t.Fatal("runtime without activation planner exposed authored semantic metadata")
+	}
+
+	plannerModel := model.ExecutionSnapshot()
+	metric := plannerModel.Metrics["order_count"]
+	metric.Aggregation = "sum"
+	plannerModel.Metrics["order_count"] = metric
+	planner, err := semanticquery.NewCompiledPlanner(plannerModel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := projectgraph.ResourceID("project:demo")
+	definition, err := dashboardruntime.NewTargetBoundProjectDefinition(
+		projectID, "Demo", "", map[projectgraph.ResourceID]*semanticmodel.Model{modelID: model}, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := dashboardruntime.NewFromGeneration(context.Background(), "", compiledPlannerDataRuntimeFactory{runtime: compiledPlannerDataRuntime{planner: planner}}, projectgraph.ServingIdentity{ProjectID: projectID, Environment: "dev", GenerationID: "state-1"}, definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer service.Close()
+	inconsistent := dashboardRuntimeWithGraph{Service: service, projectManifest: projectManifest}
+	if _, ok := inconsistent.SemanticModel(modelID.String()); ok {
+		t.Fatal("runtime exposed unrelated activation semantic metadata")
+	}
+	if _, err := queryauthz.New(inconsistent, queryauthz.Options{}).SemanticConsumer(context.Background(), modelID.String()); err == nil {
+		t.Fatal("query authorization admitted inconsistent activation metadata")
 	}
 }
 

--- a/internal/app/semantic_resource_authorization.go
+++ b/internal/app/semantic_resource_authorization.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/flidai/leapview/internal/access"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+)
+
+// authorizeSemanticModelResourceRead is the semantic metadata boundary used
+// by the dashboard semantic API. The development bypass is intentionally
+// narrower than the general project-resource authorizer: it applies only to a
+// validated semantic-model resource read in the request-local, identity-bound
+// development context. Ordinary semantic-model reads use the canonical
+// snapshot path. This does not authorize protected semantic data: the API's
+// independent consumer-authority check and planner enforcement still apply.
+func authorizeSemanticModelResourceRead(
+	ctx context.Context,
+	accessModule canonicalAccessModule,
+	runtimeHost canonicalRuntimeHost,
+	principalID string,
+	projectID projectgraph.ResourceID,
+	resource access.ResourceRef,
+	capability access.Capability,
+) (bool, error) {
+	if accessModule == nil || runtimeHost == nil {
+		return false, fmt.Errorf("authorization modules are required")
+	}
+	if strings.TrimSpace(principalID) == "" {
+		return false, nil
+	}
+	if err := projectID.Validate(); err != nil {
+		return false, err
+	}
+	if err := resource.Validate(); err != nil {
+		return false, err
+	}
+	if resource.Kind() != projectgraph.KindSemanticModel || capability != access.CapabilityResourceRead {
+		return false, nil
+	}
+	if runtimeHost.ProjectID() != projectID {
+		return false, fmt.Errorf("runtime project %q does not match requested project %q", runtimeHost.ProjectID(), projectID)
+	}
+	if requestLocalDevelopmentAuthorization(ctx, principalID) {
+		return true, nil
+	}
+	return authorizeProjectResources(ctx, accessModule, runtimeHost, principalID, projectID, []access.ResourceRef{resource}, capability)
+}

--- a/internal/app/semantic_resource_authorization_test.go
+++ b/internal/app/semantic_resource_authorization_test.go
@@ -1,0 +1,196 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	accessmodule "github.com/flidai/leapview/internal/access/module"
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+)
+
+func TestAuthorizeSemanticModelResourceRead(t *testing.T) {
+	projectID := projectgraph.ResourceID("project_demo")
+	modelID := projectgraph.ResourceID("semantic_sales")
+	resource, err := access.NewResourceRef(modelID, projectgraph.KindSemanticModel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := projectgraph.NewServingIdentity(projectID, "prod", "generation_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		principalID string
+		projectID   projectgraph.ResourceID
+		resource    access.ResourceRef
+		capability  access.Capability
+		runtime     canonicalRuntimeHost
+		access      canonicalAccessModule
+		want        bool
+		wantErr     bool
+	}{
+		{
+			name:        "trusted development read allow",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "dev", DevBypass: true}),
+			principalID: "dev",
+			projectID:   projectID,
+			resource:    resource,
+			capability:  access.CapabilityResourceRead,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "dev", DevBypass: true}, ok: true},
+			want:        true,
+		},
+		{
+			name:        "ordinary deny",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "alice"}),
+			principalID: "alice",
+			projectID:   projectID,
+			resource:    resource,
+			capability:  access.CapabilityResourceRead,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "alice"}, ok: true, subjects: []access.SubjectRef{{Kind: access.SubjectKindPrincipal, ID: "alice"}}},
+		},
+		{
+			name:        "ordinary explicit grant allow",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "alice"}),
+			principalID: "alice",
+			projectID:   projectID,
+			resource:    resource,
+			capability:  access.CapabilityResourceRead,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, true),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "alice"}, ok: true, subjects: []access.SubjectRef{{Kind: access.SubjectKindPrincipal, ID: "alice"}}},
+			want:        true,
+		},
+		{
+			name:        "missing principal",
+			ctx:         context.Background(),
+			principalID: "dev",
+			projectID:   projectID,
+			resource:    resource,
+			capability:  access.CapabilityResourceRead,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "dev", DevBypass: true}, ok: true},
+		},
+		{
+			name:        "mismatched principal",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "other", DevBypass: true}),
+			principalID: "dev",
+			projectID:   projectID,
+			resource:    resource,
+			capability:  access.CapabilityResourceRead,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "other", DevBypass: true}, ok: true},
+		},
+		{
+			name:       "empty principal",
+			ctx:        accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "dev", DevBypass: true}),
+			projectID:  projectID,
+			resource:   resource,
+			capability: access.CapabilityResourceRead,
+			runtime:    semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:     tusAccess{principal: accessmodule.Principal{ID: "dev", DevBypass: true}, ok: true},
+		},
+		{
+			name:        "invalid project",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "dev", DevBypass: true}),
+			principalID: "dev",
+			projectID:   " ",
+			resource:    resource,
+			capability:  access.CapabilityResourceRead,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "dev", DevBypass: true}, ok: true},
+			wantErr:     true,
+		},
+		{
+			name:        "cross project",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "dev", DevBypass: true}),
+			principalID: "dev",
+			projectID:   projectgraph.ResourceID("project_other"),
+			resource:    resource,
+			capability:  access.CapabilityResourceRead,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "dev", DevBypass: true}, ok: true},
+			wantErr:     true,
+		},
+		{
+			name:        "invalid resource",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "dev", DevBypass: true}),
+			principalID: "dev",
+			projectID:   projectID,
+			resource:    access.ResourceRef{},
+			capability:  access.CapabilityResourceRead,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "dev", DevBypass: true}, ok: true},
+			wantErr:     true,
+		},
+		{
+			name:        "wrong resource kind",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "dev", DevBypass: true}),
+			principalID: "dev",
+			projectID:   projectID,
+			resource: func() access.ResourceRef {
+				value, _ := access.NewResourceRef(modelID, projectgraph.KindModel)
+				return value
+			}(),
+			capability: access.CapabilityResourceRead,
+			runtime:    semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:     tusAccess{principal: accessmodule.Principal{ID: "dev", DevBypass: true}, ok: true},
+		},
+		{
+			name:        "wrong capability",
+			ctx:         accessmodule.WithPrincipal(context.Background(), accessmodule.Principal{ID: "dev", DevBypass: true}),
+			principalID: "dev",
+			projectID:   projectID,
+			resource:    resource,
+			capability:  access.CapabilityResourceEdit,
+			runtime:     semanticResourceRuntime(t, projectID, identity, modelID, false),
+			access:      tusAccess{principal: accessmodule.Principal{ID: "dev", DevBypass: true}, ok: true},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := authorizeSemanticModelResourceRead(test.ctx, test.access, test.runtime, test.principalID, test.projectID, test.resource, test.capability)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("authorizeSemanticModelResourceRead() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Fatalf("authorizeSemanticModelResourceRead() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func semanticResourceRuntime(t *testing.T, projectID projectgraph.ResourceID, identity projectgraph.ServingIdentity, modelID projectgraph.ResourceID, grant bool) canonicalRuntimeHost {
+	t.Helper()
+	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{{ID: modelID, Kind: projectgraph.KindSemanticModel, Name: "Sales"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var grants []accesssnapshot.Grant
+	if grant {
+		subject, err := access.NewSubjectRef(access.SubjectKindPrincipal, "alice")
+		if err != nil {
+			t.Fatal(err)
+		}
+		resource, err := access.NewResourceRef(modelID, projectgraph.KindSemanticModel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		canonical, err := access.NewCanonicalGrant(graph, subject, resource, access.CapabilityResourceRead)
+		if err != nil {
+			t.Fatal(err)
+		}
+		grants = []accesssnapshot.Grant{{ID: "grant:semantic-read", Name: "semantic_read", Canonical: canonical}}
+	}
+	snapshot, err := accesssnapshot.NewAuthorizationSnapshot(identity, graph, grants, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tusRuntime{project: projectID, lease: tusLease{identity: identity, snapshot: snapshot}}
+}

--- a/internal/app/test_helpers_test.go
+++ b/internal/app/test_helpers_test.go
@@ -36,6 +36,7 @@ import (
 	projectcatalog "github.com/flidai/leapview/internal/project/catalog"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	projecthttp "github.com/flidai/leapview/internal/project/http"
+	projectmodule "github.com/flidai/leapview/internal/project/module"
 	refreshmodule "github.com/flidai/leapview/internal/refresh/module"
 	releasemodule "github.com/flidai/leapview/internal/release/module"
 	"github.com/flidai/leapview/internal/runtimehost"
@@ -408,6 +409,7 @@ func assembleRuntimeChecked(ctx context.Context, metrics QueryMetrics, options a
 		catalog, err := projectcatalog.NewService(
 			projectCatalogLeaseProvider{provider: options.RuntimeHost.Provider()},
 			projectCatalogSubjectResolver{resolve: options.AccessModule.AuthorizationSubjects},
+			projectcatalog.WithSemanticModelVisibility(projectmodule.SemanticCatalogVisibility(instanceID, options.AccessModule.ResolveSemanticAttributes)),
 		)
 		if err != nil {
 			return nil, err

--- a/internal/app/test_runtime_fixture_test.go
+++ b/internal/app/test_runtime_fixture_test.go
@@ -13,8 +13,11 @@ import (
 	accessmodule "github.com/flidai/leapview/internal/access/module"
 	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
 	accesssqlite "github.com/flidai/leapview/internal/access/sqlite"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	"github.com/flidai/leapview/internal/platform"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
 	"github.com/flidai/leapview/internal/runtimehost"
 	runtimehostmodule "github.com/flidai/leapview/internal/runtimehost/module"
 	servingstate "github.com/flidai/leapview/internal/servingstate"
@@ -201,6 +204,11 @@ func (f testRuntimeFactory) Prepare(_ context.Context, input runtimehost.Runtime
 	if err != nil {
 		return nil, err
 	}
+	model := testSemanticModel()
+	planner, err := semanticquery.NewCompiledPlanner(model)
+	if err != nil {
+		return nil, fmt.Errorf("compile test semantic model: %w", err)
+	}
 	bindings := make([]accesssnapshot.RoleBinding, 0, len(f.subjects))
 	for _, subject := range f.subjects {
 		sum := sha256.Sum256([]byte(subject.subject.ID + "\x00" + string(subject.role)))
@@ -213,12 +221,17 @@ func (f testRuntimeFactory) Prepare(_ context.Context, input runtimehost.Runtime
 	if err != nil {
 		return nil, err
 	}
-	return testPreparedRuntime{authorization: authorization, snapshotID: input.State.DuckLakeSnapshotID}, nil
+	return testPreparedRuntime{
+		authorization: authorization, snapshotID: input.State.DuckLakeSnapshotID,
+		semanticModel: model, compiledModel: planner.CompiledModel(),
+	}, nil
 }
 
 type testPreparedRuntime struct {
 	authorization accesssnapshot.AuthorizationSnapshot
 	snapshotID    int64
+	semanticModel *semanticmodel.Model
+	compiledModel *semanticquery.CompiledModel
 }
 
 func (r testPreparedRuntime) Close() error { return nil }
@@ -226,6 +239,26 @@ func (r testPreparedRuntime) AuthorizationSnapshot() accesssnapshot.Authorizatio
 	return r.authorization
 }
 func (r testPreparedRuntime) DuckLakeSnapshotID() int64 { return r.snapshotID }
+
+// ProjectManifest and CompiledSemanticModel make the app fixture expose the
+// same activation-owned semantic metadata that the public catalog consumes in
+// production. Keeping both facts on one prepared runtime prevents tests from
+// accidentally making catalog visibility public without a compiled source.
+func (r testPreparedRuntime) ProjectManifest() projectmanifest.ResourceManifest {
+	if r.semanticModel == nil {
+		return projectmanifest.ResourceManifest{}
+	}
+	return projectmanifest.ResourceManifest{SemanticModels: map[string]*semanticmodel.Model{
+		"test": r.semanticModel.ExecutionSnapshot(),
+	}}
+}
+
+func (r testPreparedRuntime) CompiledSemanticModel(modelID string) (*semanticquery.CompiledModel, bool) {
+	if modelID != "test" || r.compiledModel == nil {
+		return nil, false
+	}
+	return r.compiledModel, true
+}
 
 type testRuntimeAuthorizationInstaller struct{}
 

--- a/internal/dashboard/http/api.go
+++ b/internal/dashboard/http/api.go
@@ -63,12 +63,20 @@ func (h Handler) GetDashboard(w nethttp.ResponseWriter, r *nethttp.Request) {
 		return
 	}
 	report, model := resolved.Definition, resolved.Model
+	if err := authorizeDashboardReportVisuals(r.Context(), metrics, dashboardID, report); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
+		return
+	}
 	writeJSON(w, nethttp.StatusOK, DashboardManifestProjection(report, model, metrics.Pages(dashboardID)))
 }
 
 func (h Handler) ListDashboardComponents(w nethttp.ResponseWriter, r *nethttp.Request) {
 	report, page, ok := h.dashboardReportPage(w, r)
 	if !ok {
+		return
+	}
+	if err := authorizeDashboardReportVisuals(r.Context(), h.Metrics, chi.URLParam(r, "dashboard"), report); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
 		return
 	}
 	out := make([]api.DashboardComponentResponse, 0, len(page.Visuals))
@@ -85,6 +93,10 @@ func (h Handler) ListDashboardComponents(w nethttp.ResponseWriter, r *nethttp.Re
 func (h Handler) GetDashboardPage(w nethttp.ResponseWriter, r *nethttp.Request) {
 	report, page, ok := h.dashboardReportPage(w, r)
 	if !ok {
+		return
+	}
+	if err := authorizeDashboardReportVisuals(r.Context(), h.Metrics, chi.URLParam(r, "dashboard"), report); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
 		return
 	}
 	components := make([]api.DashboardComponentResponse, 0, len(page.Visuals))
@@ -110,6 +122,10 @@ func (h Handler) GetDashboardFilter(w nethttp.ResponseWriter, r *nethttp.Request
 	filter, exists := report.FilterDefinitions[binding.Filter]
 	if !exists {
 		writeJSONError(w, fmt.Errorf("filter definition %q not found", binding.Filter), nethttp.StatusNotFound)
+		return
+	}
+	if err := authorizeDashboardFilterField(r.Context(), h.Metrics, chi.URLParam(r, "dashboard"), filter.Dataset, filter.Field); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
 		return
 	}
 	component, _ := pageComponentForFilter(page, binding.Scope, binding.ID)
@@ -148,6 +164,10 @@ func (h Handler) GetDashboardFilter(w nethttp.ResponseWriter, r *nethttp.Request
 }
 
 func (h Handler) GetDashboardVisual(w nethttp.ResponseWriter, r *nethttp.Request) {
+	metrics, metricsOK := h.biMetrics(w, r)
+	if !metricsOK {
+		return
+	}
 	report, page, ok := h.dashboardReportPage(w, r)
 	if !ok {
 		return
@@ -161,6 +181,10 @@ func (h Handler) GetDashboardVisual(w nethttp.ResponseWriter, r *nethttp.Request
 	}
 	if !onPage {
 		writeJSONError(w, fmt.Errorf("visual %q not found on page %q", visualID, page.ID), nethttp.StatusNotFound)
+		return
+	}
+	if err := authorizeDashboardVisual(r.Context(), metrics, chi.URLParam(r, "dashboard"), definition); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
 		return
 	}
 	writeJSON(w, nethttp.StatusOK, DashboardVisualProjection(definition, component))
@@ -178,6 +202,10 @@ func (h Handler) QueryDashboardPage(w nethttp.ResponseWriter, r *nethttp.Request
 	}
 	report, page, ok := h.dashboardReportPage(w, r)
 	if !ok {
+		return
+	}
+	if err := authorizeDashboardReportVisuals(r.Context(), metrics, chi.URLParam(r, "dashboard"), report); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
 		return
 	}
 	dashboardID := chi.URLParam(r, "dashboard")
@@ -222,6 +250,10 @@ func (h Handler) QueryDashboardVisualData(w nethttp.ResponseWriter, r *nethttp.R
 	_, onPage := pageComponentForVisual(page, visualID)
 	if !onPage {
 		writeJSONError(w, fmt.Errorf("visual %q not found on page %q", visualID, page.ID), nethttp.StatusNotFound)
+		return
+	}
+	if err := authorizeDashboardVisual(r.Context(), metrics, chi.URLParam(r, "dashboard"), definition); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
 		return
 	}
 	if isGridQueryKind(definition.Query.Kind) {
@@ -392,6 +424,10 @@ func (h Handler) ListDashboardFilterOptions(w nethttp.ResponseWriter, r *nethttp
 		writeJSONError(w, fmt.Errorf("filter definition %q not found", binding.Filter), nethttp.StatusNotFound)
 		return
 	}
+	if err := authorizeDashboardFilterField(r.Context(), metrics, chi.URLParam(r, "dashboard"), definition.Dataset, definition.Field); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
+		return
+	}
 	filters, err := dashboardQueryFilters(report, page.ID, input.FilterState, input.InteractionSelections, input.SpatialSelections)
 	if err != nil {
 		writeJSONError(w, err, nethttp.StatusBadRequest)
@@ -403,6 +439,10 @@ func (h Handler) ListDashboardFilterOptions(w nethttp.ResponseWriter, r *nethttp
 		out = append(out, api.DashboardFilterOptionResponse{Value: fmt.Sprint(option.Value.Value), Label: option.Label})
 	}
 	if definition.Options.Kind == "distinct" {
+		if !dashboardSemanticCacheAllowed(metrics, metrics.ModelIDForDashboard(dashboardID)) {
+			writeJSONError(w, requireDashboardSemanticAuthorization(errDashboardSemanticAuthorityUnavailable), nethttp.StatusServiceUnavailable)
+			return
+		}
 		queryMetrics, supported := metrics.(compiledFilterOptionMetrics)
 		if !supported {
 			writeJSONError(w, fmt.Errorf("compiled filter options are not supported by this runtime"), nethttp.StatusNotImplemented)

--- a/internal/dashboard/http/filter_options.go
+++ b/internal/dashboard/http/filter_options.go
@@ -50,6 +50,14 @@ func (h Handler) FilterOptions(w nethttp.ResponseWriter, r *nethttp.Request) {
 		nethttp.Error(w, "unknown compiled filter definition", nethttp.StatusInternalServerError)
 		return
 	}
+	if err := authorizeDashboardFilterField(r.Context(), metrics, dashboardID, filterDefinition.Dataset, filterDefinition.Field); err != nil {
+		writeJSONError(w, requireDashboardSemanticAuthorization(err), dashboardSemanticAuthorizationStatus(err))
+		return
+	}
+	if !dashboardSemanticCacheAllowed(metrics, metrics.ModelIDForDashboard(dashboardID)) {
+		writeJSONError(w, requireDashboardSemanticAuthorization(errDashboardSemanticAuthorityUnavailable), nethttp.StatusServiceUnavailable)
+		return
+	}
 	if h.SessionStore == nil {
 		nethttp.Error(w, "dashboard session store is unavailable", nethttp.StatusServiceUnavailable)
 		return

--- a/internal/dashboard/http/semantic_consumer_http.go
+++ b/internal/dashboard/http/semantic_consumer_http.go
@@ -1,0 +1,325 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	dashboarddefinition "github.com/flidai/leapview/internal/dashboard/definition"
+	visualizationdefinition "github.com/flidai/leapview/internal/dashboard/visualization/definition"
+)
+
+var errDashboardSemanticAuthorityUnavailable = errors.New("semantic consumer authority is unavailable")
+
+type dashboardSemanticModelProvider interface {
+	SemanticModel(string) (*semanticmodel.Model, bool)
+}
+
+type dashboardSemanticTargetAuthorizer interface {
+	AuthorizeSemanticTarget(context.Context, string, semanticquery.SemanticAccessTarget) error
+}
+
+type dashboardSemanticFieldAuthorizer interface {
+	AuthorizeSemanticField(context.Context, string, string, string) error
+}
+
+type dashboardSemanticProjectionAuthorizer interface {
+	AuthorizeSemanticModelProjection(context.Context, string) error
+}
+
+type dashboardSemanticConsumerProvider interface {
+	SemanticConsumer(context.Context, string) (*semanticquery.SemanticAccessConsumer, error)
+}
+
+type dashboardSemanticConsumerContextKey struct{}
+
+type dashboardSemanticConsumerBinding struct {
+	modelID  string
+	consumer *semanticquery.SemanticAccessConsumer
+}
+
+func dashboardSemanticModel(metrics Metrics, modelID string) (*semanticmodel.Model, bool) {
+	provider, ok := any(metrics).(dashboardSemanticModelProvider)
+	if !ok {
+		return nil, false
+	}
+	model, ok := provider.SemanticModel(modelID)
+	return model, ok && model != nil
+}
+
+func dashboardProtectedSemanticModel(metrics Metrics, modelID string) bool {
+	model, ok := dashboardSemanticModel(metrics, modelID)
+	return ok && !model.AccessPolicy.Empty()
+}
+
+func dashboardSemanticModelKnown(metrics Metrics, modelID string) bool {
+	_, ok := dashboardSemanticModel(metrics, modelID)
+	return ok
+}
+
+func dashboardSemanticConsumerForRequest(ctx context.Context, metrics Metrics, modelID string) (context.Context, error) {
+	if binding, ok := ctx.Value(dashboardSemanticConsumerContextKey{}).(dashboardSemanticConsumerBinding); ok && binding.modelID == modelID && binding.consumer != nil {
+		return ctx, nil
+	}
+	provider, ok := any(metrics).(dashboardSemanticConsumerProvider)
+	if !ok {
+		return ctx, nil
+	}
+	consumer, err := provider.SemanticConsumer(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+	if consumer == nil || consumer.Planner() == nil || consumer.Planner().CompiledModel() == nil {
+		return nil, errDashboardSemanticAuthorityUnavailable
+	}
+	model, ok := dashboardSemanticModel(metrics, modelID)
+	if !ok || !consumer.Planner().CompiledModel().MatchesModel(model) {
+		return nil, errDashboardSemanticAuthorityUnavailable
+	}
+	return context.WithValue(ctx, dashboardSemanticConsumerContextKey{}, dashboardSemanticConsumerBinding{modelID: modelID, consumer: consumer}), nil
+}
+
+func dashboardSemanticConsumerFromContext(ctx context.Context, modelID string) (*semanticquery.SemanticAccessConsumer, bool) {
+	binding, ok := ctx.Value(dashboardSemanticConsumerContextKey{}).(dashboardSemanticConsumerBinding)
+	return binding.consumer, ok && binding.modelID == modelID && binding.consumer != nil
+}
+
+func authorizeDashboardSemanticConsumerField(consumer *semanticquery.SemanticAccessConsumer, dataset, field string) error {
+	if consumer == nil || consumer.Planner() == nil {
+		return errDashboardSemanticAuthorityUnavailable
+	}
+	_, err := consumer.Planner().PlanRows(semanticquery.RowRequest{Dataset: dataset, Dimensions: []semanticquery.Field{{Field: field}}, Limit: 1})
+	return err
+}
+
+func authorizeDashboardSemanticConsumerProjection(consumer *semanticquery.SemanticAccessConsumer) error {
+	if consumer == nil || consumer.Planner() == nil || consumer.Planner().CompiledModel() == nil {
+		return errDashboardSemanticAuthorityUnavailable
+	}
+	planner := consumer.Planner()
+	compiled := planner.CompiledModel()
+	model := compiled.SourceModel()
+	if model == nil {
+		return errDashboardSemanticAuthorityUnavailable
+	}
+	for _, dataset := range compiled.DatasetNames() {
+		if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: dataset}); err != nil {
+			return err
+		}
+		dimensions := make([]string, 0, len(model.Dimensions))
+		for name := range model.Dimensions {
+			dimensions = append(dimensions, name)
+		}
+		sort.Strings(dimensions)
+		for _, name := range dimensions {
+			if _, bound := compiled.DimensionBinding(name, dataset); !bound {
+				continue
+			}
+			if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: dataset, Dimension: name}); err != nil {
+				return err
+			}
+		}
+	}
+	metrics := make([]string, 0, len(model.Metrics))
+	for name := range model.Metrics {
+		metrics = append(metrics, name)
+	}
+	sort.Strings(metrics)
+	for _, name := range metrics {
+		if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Metric: name}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func authorizeDashboardSemanticProjection(ctx context.Context, metrics Metrics, modelID string) error {
+	if consumer, ok := dashboardSemanticConsumerFromContext(ctx, modelID); ok {
+		return authorizeDashboardSemanticConsumerProjection(consumer)
+	}
+	if scoped, err := dashboardSemanticConsumerForRequest(ctx, metrics, modelID); err != nil {
+		if _, provider := any(metrics).(dashboardSemanticConsumerProvider); provider {
+			return err
+		}
+	} else if consumer, ok := dashboardSemanticConsumerFromContext(scoped, modelID); ok {
+		return authorizeDashboardSemanticConsumerProjection(consumer)
+	}
+	if provider, ok := any(metrics).(dashboardSemanticProjectionAuthorizer); ok {
+		return provider.AuthorizeSemanticModelProjection(ctx, modelID)
+	}
+	if !dashboardSemanticModelKnown(metrics, modelID) || dashboardProtectedSemanticModel(metrics, modelID) {
+		return errDashboardSemanticAuthorityUnavailable
+	}
+	return nil
+}
+
+func authorizeDashboardSemanticTarget(ctx context.Context, metrics Metrics, modelID string, target semanticquery.SemanticAccessTarget) error {
+	if consumer, ok := dashboardSemanticConsumerFromContext(ctx, modelID); ok {
+		return consumer.Authorize(target)
+	}
+	if scoped, err := dashboardSemanticConsumerForRequest(ctx, metrics, modelID); err != nil {
+		if _, provider := any(metrics).(dashboardSemanticConsumerProvider); provider {
+			return err
+		}
+	} else if consumer, ok := dashboardSemanticConsumerFromContext(scoped, modelID); ok {
+		return consumer.Authorize(target)
+	}
+	if provider, ok := any(metrics).(dashboardSemanticTargetAuthorizer); ok {
+		return provider.AuthorizeSemanticTarget(ctx, modelID, target)
+	}
+	if !dashboardSemanticModelKnown(metrics, modelID) || dashboardProtectedSemanticModel(metrics, modelID) {
+		return errDashboardSemanticAuthorityUnavailable
+	}
+	return nil
+}
+
+func authorizeDashboardSemanticField(ctx context.Context, metrics Metrics, modelID, dataset, field string) error {
+	if consumer, ok := dashboardSemanticConsumerFromContext(ctx, modelID); ok {
+		return authorizeDashboardSemanticConsumerField(consumer, dataset, field)
+	}
+	if scoped, err := dashboardSemanticConsumerForRequest(ctx, metrics, modelID); err != nil {
+		if _, provider := any(metrics).(dashboardSemanticConsumerProvider); provider {
+			return err
+		}
+	} else if consumer, ok := dashboardSemanticConsumerFromContext(scoped, modelID); ok {
+		return authorizeDashboardSemanticConsumerField(consumer, dataset, field)
+	}
+	if model, ok := dashboardSemanticModel(metrics, modelID); ok {
+		if _, isMetric := model.Metrics[field]; isMetric {
+			return authorizeDashboardSemanticTarget(ctx, metrics, modelID, semanticquery.SemanticAccessTarget{Metric: field, Dataset: dataset})
+		}
+	}
+	if provider, ok := any(metrics).(dashboardSemanticFieldAuthorizer); ok {
+		return provider.AuthorizeSemanticField(ctx, modelID, dataset, field)
+	}
+	if !dashboardSemanticModelKnown(metrics, modelID) || dashboardProtectedSemanticModel(metrics, modelID) {
+		return errDashboardSemanticAuthorityUnavailable
+	}
+	return nil
+}
+
+func authorizeDashboardFilterField(ctx context.Context, metrics Metrics, dashboardID, dataset, field string) error {
+	modelID := metrics.ModelIDForDashboard(dashboardID)
+	if strings.TrimSpace(dataset) == "" {
+		// A compiled filter without a dataset is not a safe field-level
+		// reference. Admit the already compiled semantic projection once so
+		// public metadata keeps its historical behavior without asking the
+		// planner to build an impossible dataset-less row query.
+		return authorizeDashboardSemanticProjection(ctx, metrics, modelID)
+	}
+	return authorizeDashboardSemanticField(ctx, metrics, modelID, dataset, field)
+}
+
+func dashboardSemanticDenied(err error) bool {
+	return strings.Contains(err.Error(), "semantic access denied") || strings.Contains(err.Error(), "lacks")
+}
+
+func dashboardSemanticUnavailable(err error) bool {
+	return errors.Is(err, errDashboardSemanticAuthorityUnavailable) || strings.Contains(err.Error(), "semantic consumer authority is unavailable")
+}
+
+func authorizeDashboardVisual(ctx context.Context, metrics Metrics, dashboardID string, definition visualizationdefinition.Definition) error {
+	query := definition.Query
+	modelID := query.ModelID
+	if modelID == "" {
+		modelID = metrics.ModelIDForDashboard(dashboardID)
+	}
+	if scoped, err := dashboardSemanticConsumerForRequest(ctx, metrics, modelID); err != nil {
+		return err
+	} else {
+		ctx = scoped
+	}
+	return authorizeDashboardSemanticProjection(ctx, metrics, modelID)
+}
+
+func dashboardSemanticCacheAllowed(metrics Metrics, modelID string) bool {
+	if provider, ok := any(metrics).(interface{ SemanticConsumerCacheAllowed(string) bool }); ok {
+		return provider.SemanticConsumerCacheAllowed(modelID)
+	}
+	model, ok := dashboardSemanticModel(metrics, modelID)
+	return ok && model != nil && model.AccessPolicy.Empty()
+}
+
+func authorizeDashboardReportVisuals(ctx context.Context, metrics Metrics, dashboardID string, report dashboarddefinition.Definition) error {
+	ids := make([]string, 0, len(report.Visualizations))
+	for id := range report.Visualizations {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	contexts := make(map[string]context.Context)
+	authorizedModels := make(map[string]bool)
+	for _, id := range ids {
+		definition := report.Visualizations[id]
+		modelID := definition.Query.ModelID
+		if modelID == "" {
+			modelID = metrics.ModelIDForDashboard(dashboardID)
+		}
+		scoped, ok := contexts[modelID]
+		if !ok {
+			var err error
+			scoped, err = dashboardSemanticConsumerForRequest(ctx, metrics, modelID)
+			if err != nil {
+				return err
+			}
+			contexts[modelID] = scoped
+		}
+		if !authorizedModels[modelID] {
+			if err := authorizeDashboardSemanticProjection(scoped, metrics, modelID); err != nil {
+				return err
+			}
+			authorizedModels[modelID] = true
+		}
+	}
+	filterIDs := make([]string, 0, len(report.FilterDefinitions))
+	for id := range report.FilterDefinitions {
+		filterIDs = append(filterIDs, id)
+	}
+	sort.Strings(filterIDs)
+	for _, id := range filterIDs {
+		definition := report.FilterDefinitions[id]
+		modelID := metrics.ModelIDForDashboard(dashboardID)
+		scoped, ok := contexts[modelID]
+		if !ok {
+			var err error
+			scoped, err = dashboardSemanticConsumerForRequest(ctx, metrics, modelID)
+			if err != nil {
+				return err
+			}
+			contexts[modelID] = scoped
+		}
+		if strings.TrimSpace(definition.Dataset) == "" {
+			if !authorizedModels[modelID] {
+				if err := authorizeDashboardSemanticProjection(scoped, metrics, modelID); err != nil {
+					return err
+				}
+				authorizedModels[modelID] = true
+			}
+			continue
+		}
+		if err := authorizeDashboardSemanticField(scoped, metrics, modelID, definition.Dataset, definition.Field); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dashboardSemanticAuthorizationStatus(err error) int {
+	if dashboardSemanticUnavailable(err) {
+		return 503
+	}
+	if dashboardSemanticDenied(err) {
+		return 403
+	}
+	return 503
+}
+
+func requireDashboardSemanticAuthorization(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("dashboard semantic authorization: %w", err)
+}

--- a/internal/dashboard/http/semantic_consumer_http_test.go
+++ b/internal/dashboard/http/semantic_consumer_http_test.go
@@ -1,0 +1,78 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+type dashboardSemanticCapabilityMetrics struct {
+	fakeMetrics
+	model        *semanticmodel.Model
+	cacheAllowed bool
+	consumer     *semanticquery.SemanticAccessConsumer
+}
+
+func (m dashboardSemanticCapabilityMetrics) SemanticModel(string) (*semanticmodel.Model, bool) {
+	return m.model, m.model != nil
+}
+
+func (m dashboardSemanticCapabilityMetrics) SemanticConsumerCacheAllowed(string) bool {
+	return m.cacheAllowed
+}
+
+func (m dashboardSemanticCapabilityMetrics) SemanticConsumer(context.Context, string) (*semanticquery.SemanticAccessConsumer, error) {
+	return m.consumer, nil
+}
+
+func TestDashboardSemanticTargetFailsClosedWithoutModelMetadata(t *testing.T) {
+	metrics := dashboardSemanticCapabilityMetrics{}
+	if err := authorizeDashboardSemanticTarget(context.Background(), metrics, "missing", semanticquery.SemanticAccessTarget{Dataset: "orders"}); !dashboardSemanticUnavailable(err) {
+		t.Fatalf("error = %v, want unavailable", err)
+	}
+}
+
+func TestDashboardProtectedCachePathRequiresExplicitCapability(t *testing.T) {
+	metrics := dashboardSemanticCapabilityMetrics{
+		model: &semanticmodel.Model{
+			Name: "sales",
+			AccessPolicy: semanticmodel.SemanticAccessPolicy{
+				AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{
+					"sales": {UserAttribute: "tenant"},
+				},
+			},
+		},
+	}
+	if dashboardSemanticCacheAllowed(metrics, "sales") {
+		t.Fatal("protected cache path was allowed without lifecycle evidence")
+	}
+}
+
+func TestDashboardPublicFilterWithoutDatasetUsesWholeModelProjection(t *testing.T) {
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {ModelName: "orders", GrainEntity: "order", Entities: map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"status"}}}, Dimensions: map[string]semanticmodel.MetricDimension{
+				"status": {Field: "orders.status", Table: "orders", Name: "status", Type: "string", Datatype: semanticmodel.DataTypeString},
+			}},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"status": {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.status"}}},
+		},
+	}
+	planner, err := semanticquery.NewCompiledPlanner(model, semanticquery.WithTableRelation(func(table string) (string, error) { return table, nil }))
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := semanticquery.NewSemanticAccessConsumer(planner, semanticquery.SemanticAccessConsumerConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics := dashboardSemanticCapabilityMetrics{model: model, consumer: consumer}
+	if err := authorizeDashboardFilterField(context.Background(), metrics, "dashboard", "", "orders.status"); err != nil {
+		t.Fatalf("dataset-less public filter authorization: %v", err)
+	}
+}

--- a/internal/dashboard/module/query_authorization.go
+++ b/internal/dashboard/module/query_authorization.go
@@ -15,11 +15,13 @@ type QueryPrincipal struct {
 }
 
 type QueryAuthorizationConfig struct {
-	SnapshotFromContext   func(context.Context) (accesssnapshot.AuthorizationSnapshot, error)
-	SubjectsFromContext   func(context.Context, string) ([]access.SubjectRef, error)
-	PrincipalFromContext  func(context.Context) (QueryPrincipal, bool)
-	CredentialFromContext func(context.Context) (access.APICredential, bool)
-	AuditRecorder         access.CanonicalAuditRecorder
+	InstanceID                string
+	ResolveSemanticAttributes func(context.Context) (access.SemanticAttributeResolution, error)
+	SnapshotFromContext       func(context.Context) (accesssnapshot.AuthorizationSnapshot, error)
+	SubjectsFromContext       func(context.Context, string) ([]access.SubjectRef, error)
+	PrincipalFromContext      func(context.Context) (QueryPrincipal, bool)
+	CredentialFromContext     func(context.Context) (access.APICredential, bool)
+	AuditRecorder             access.CanonicalAuditRecorder
 }
 
 func WithQueryAuthorization(metrics queryruntime.Metrics, config QueryAuthorizationConfig) queryruntime.Metrics {
@@ -27,8 +29,10 @@ func WithQueryAuthorization(metrics queryruntime.Metrics, config QueryAuthorizat
 		return metrics
 	}
 	return queryauthz.New(metrics, queryauthz.Options{
-		SnapshotFromContext: config.SnapshotFromContext,
-		SubjectsFromContext: config.SubjectsFromContext,
+		InstanceID:                config.InstanceID,
+		ResolveSemanticAttributes: config.ResolveSemanticAttributes,
+		SnapshotFromContext:       config.SnapshotFromContext,
+		SubjectsFromContext:       config.SubjectsFromContext,
 		PrincipalFromContext: func(ctx context.Context) (queryauthz.Principal, bool) {
 			if config.PrincipalFromContext == nil {
 				return queryauthz.Principal{}, false

--- a/internal/dashboard/module/semantic_consumer_ports.go
+++ b/internal/dashboard/module/semantic_consumer_ports.go
@@ -1,0 +1,111 @@
+package module
+
+import (
+	"context"
+	"fmt"
+
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+type semanticTargetAuthorizer interface {
+	AuthorizeSemanticTarget(context.Context, string, semanticquery.SemanticAccessTarget) error
+}
+
+func semanticConsumer(ctx context.Context, metrics any, modelID string) (*semanticquery.SemanticAccessConsumer, error) {
+	port, ok := metrics.(interface {
+		SemanticConsumer(context.Context, string) (*semanticquery.SemanticAccessConsumer, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("semantic consumer authority is unavailable")
+	}
+	return port.SemanticConsumer(ctx, modelID)
+}
+
+func (m auditedMetrics) SemanticConsumer(ctx context.Context, modelID string) (*semanticquery.SemanticAccessConsumer, error) {
+	return semanticConsumer(ctx, m.Metrics, modelID)
+}
+
+func (m admittedMetrics) SemanticConsumer(ctx context.Context, modelID string) (*semanticquery.SemanticAccessConsumer, error) {
+	return semanticConsumer(ctx, m.Metrics, modelID)
+}
+
+type semanticModelProjectionAuthorizer interface {
+	AuthorizeSemanticModelProjection(context.Context, string) error
+}
+
+func authorizeSemanticField(ctx context.Context, metrics any, modelID, dataset, field string) error {
+	port, ok := metrics.(interface {
+		AuthorizeSemanticField(context.Context, string, string, string) error
+	})
+	if !ok {
+		return fmt.Errorf("semantic consumer authority is unavailable")
+	}
+	return port.AuthorizeSemanticField(ctx, modelID, dataset, field)
+}
+
+func (m auditedMetrics) AuthorizeSemanticField(ctx context.Context, modelID, dataset, field string) error {
+	return authorizeSemanticField(ctx, m.Metrics, modelID, dataset, field)
+}
+func (m admittedMetrics) AuthorizeSemanticField(ctx context.Context, modelID, dataset, field string) error {
+	return authorizeSemanticField(ctx, m.Metrics, modelID, dataset, field)
+}
+
+func semanticConsumerPlanner(ctx context.Context, metrics any, modelID string) (*semanticquery.Planner, error) {
+	port, ok := metrics.(interface {
+		SemanticPlanner(context.Context, string) (*semanticquery.Planner, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("semantic consumer authority is unavailable")
+	}
+	return port.SemanticPlanner(ctx, modelID)
+}
+
+func (m auditedMetrics) SemanticPlanner(ctx context.Context, modelID string) (*semanticquery.Planner, error) {
+	return semanticConsumerPlanner(ctx, m.Metrics, modelID)
+}
+func (m admittedMetrics) SemanticPlanner(ctx context.Context, modelID string) (*semanticquery.Planner, error) {
+	return semanticConsumerPlanner(ctx, m.Metrics, modelID)
+}
+
+func authorizeSemanticTarget(ctx context.Context, metrics any, modelID string, target semanticquery.SemanticAccessTarget) error {
+	port, ok := metrics.(semanticTargetAuthorizer)
+	if !ok {
+		return fmt.Errorf("semantic consumer authority is unavailable")
+	}
+	return port.AuthorizeSemanticTarget(ctx, modelID, target)
+}
+
+func semanticConsumerCacheAllowed(metrics any, modelID string) bool {
+	port, ok := metrics.(interface{ SemanticConsumerCacheAllowed(string) bool })
+	return ok && port.SemanticConsumerCacheAllowed(modelID)
+}
+
+func (m auditedMetrics) AuthorizeSemanticTarget(ctx context.Context, modelID string, target semanticquery.SemanticAccessTarget) error {
+	return authorizeSemanticTarget(ctx, m.Metrics, modelID, target)
+}
+func (m admittedMetrics) AuthorizeSemanticTarget(ctx context.Context, modelID string, target semanticquery.SemanticAccessTarget) error {
+	return authorizeSemanticTarget(ctx, m.Metrics, modelID, target)
+}
+
+func authorizeSemanticModelProjection(ctx context.Context, metrics any, modelID string) error {
+	port, ok := metrics.(semanticModelProjectionAuthorizer)
+	if !ok {
+		return fmt.Errorf("semantic consumer authority is unavailable")
+	}
+	return port.AuthorizeSemanticModelProjection(ctx, modelID)
+}
+
+func (m auditedMetrics) AuthorizeSemanticModelProjection(ctx context.Context, modelID string) error {
+	return authorizeSemanticModelProjection(ctx, m.Metrics, modelID)
+}
+
+func (m admittedMetrics) AuthorizeSemanticModelProjection(ctx context.Context, modelID string) error {
+	return authorizeSemanticModelProjection(ctx, m.Metrics, modelID)
+}
+
+func (m auditedMetrics) SemanticConsumerCacheAllowed(modelID string) bool {
+	return semanticConsumerCacheAllowed(m.Metrics, modelID)
+}
+func (m admittedMetrics) SemanticConsumerCacheAllowed(modelID string) bool {
+	return semanticConsumerCacheAllowed(m.Metrics, modelID)
+}

--- a/internal/dashboard/module/semantic_snapshot.go
+++ b/internal/dashboard/module/semantic_snapshot.go
@@ -1,0 +1,72 @@
+package module
+
+import (
+	"context"
+	"fmt"
+
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+// SemanticPlannerSnapshot pairs physical table bindings and authorization
+// generation in one lease. Separate Planner/SemanticModel calls cannot prove
+// this pairing when identical source is activated in a new generation.
+func (m runtimeMetrics) SemanticPlannerSnapshot(ctx context.Context, modelID string) (*semanticquery.Planner, accesssnapshot.AuthorizationSnapshot, error) {
+	var empty accesssnapshot.AuthorizationSnapshot
+	if m.provider == nil {
+		return nil, empty, fmt.Errorf("semantic runtime provider is unavailable")
+	}
+	lease, err := m.provider.Acquire(ctx)
+	if err != nil {
+		return nil, empty, err
+	}
+	if lease == nil {
+		return nil, empty, fmt.Errorf("semantic runtime lease is unavailable")
+	}
+	defer lease.Release()
+	identity, err := m.identityForLease(lease)
+	if err != nil {
+		return nil, empty, err
+	}
+	authorization, ok := lease.(interface {
+		AuthorizationSnapshot() accesssnapshot.AuthorizationSnapshot
+	})
+	if !ok {
+		return nil, empty, fmt.Errorf("semantic lease authorization is unavailable")
+	}
+	snapshot := authorization.AuthorizationSnapshot()
+	if snapshot.ValidateBound() != nil || snapshot.Identity() != identity {
+		return nil, empty, fmt.Errorf("semantic lease identity is inconsistent")
+	}
+	port, ok := lease.Runtime().(semanticPlannerRuntime)
+	if !ok {
+		return nil, empty, fmt.Errorf("semantic runtime planner is unavailable")
+	}
+	value, ok := port.Planner(modelID)
+	if !ok {
+		return nil, empty, fmt.Errorf("semantic model planner is unavailable")
+	}
+	planner, ok := concretePlanner(value)
+	if !ok || planner.CompiledModel() == nil {
+		return nil, empty, fmt.Errorf("compiled semantic planner is unavailable")
+	}
+	return planner, snapshot, nil
+}
+
+func semanticPlannerSnapshot(ctx context.Context, metrics any, modelID string) (*semanticquery.Planner, accesssnapshot.AuthorizationSnapshot, error) {
+	port, ok := metrics.(interface {
+		SemanticPlannerSnapshot(context.Context, string) (*semanticquery.Planner, accesssnapshot.AuthorizationSnapshot, error)
+	})
+	if !ok {
+		return nil, accesssnapshot.AuthorizationSnapshot{}, fmt.Errorf("semantic planner snapshot is unavailable")
+	}
+	return port.SemanticPlannerSnapshot(ctx, modelID)
+}
+
+func (m admittedMetrics) SemanticPlannerSnapshot(ctx context.Context, modelID string) (*semanticquery.Planner, accesssnapshot.AuthorizationSnapshot, error) {
+	return semanticPlannerSnapshot(ctx, m.Metrics, modelID)
+}
+
+func (m auditedMetrics) SemanticPlannerSnapshot(ctx context.Context, modelID string) (*semanticquery.Planner, accesssnapshot.AuthorizationSnapshot, error) {
+	return semanticPlannerSnapshot(ctx, m.Metrics, modelID)
+}

--- a/internal/dashboard/module/semantic_snapshot_test.go
+++ b/internal/dashboard/module/semantic_snapshot_test.go
@@ -1,0 +1,65 @@
+package module
+
+import (
+	"context"
+	"testing"
+
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/internal/runtimehost"
+)
+
+type semanticSnapshotLease struct {
+	*resolverTestLease
+	snapshot accesssnapshot.AuthorizationSnapshot
+}
+
+func (l semanticSnapshotLease) AuthorizationSnapshot() accesssnapshot.AuthorizationSnapshot {
+	return l.snapshot
+}
+
+type semanticSnapshotProvider struct {
+	lease runtimehost.Lease
+	calls int
+}
+
+func (p *semanticSnapshotProvider) Acquire(context.Context) (runtimehost.Lease, error) {
+	p.calls++
+	return p.lease, nil
+}
+
+func TestSemanticPlannerSnapshotUsesOneCoherentLease(t *testing.T) {
+	model := &semanticmodel.Model{Name: "sales", Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}}, Tables: map[string]semanticmodel.Table{"orders": {ModelName: "orders", GrainEntity: "order", Entities: map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"id"}}}, Dimensions: map[string]semanticmodel.MetricDimension{"id": {Datatype: semanticmodel.DataTypeInteger}}}}}
+	planner, err := semanticquery.NewCompiledPlanner(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := &resolverTestLease{runtime: &resolverTestRuntime{planner: planner}, stateID: "generation-1"}
+	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{{ID: "semantic_sales", Kind: projectgraph.KindSemanticModel, Name: "sales"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := accesssnapshot.NewAuthorizationSnapshot(base.Identity(), graph, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &semanticSnapshotProvider{lease: semanticSnapshotLease{resolverTestLease: base, snapshot: snapshot}}
+	m := runtimeMetrics{provider: provider, projectID: "project_1"}
+	got, authority, err := m.SemanticPlannerSnapshot(t.Context(), "sales")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != planner || authority.Identity() != base.Identity() || provider.calls != 1 || base.releases != 1 {
+		t.Fatalf("unpaired planner/snapshot: calls=%d releases=%d", provider.calls, base.releases)
+	}
+	base.stateID = "generation-2"
+	if _, _, err := m.SemanticPlannerSnapshot(t.Context(), "sales"); err == nil {
+		t.Fatal("mismatched lease snapshot accepted")
+	}
+	provider.lease = base
+	if _, _, err := m.SemanticPlannerSnapshot(t.Context(), "sales"); err == nil {
+		t.Fatal("lease without authority accepted")
+	}
+}

--- a/internal/dashboard/queryauthz/data_authorization.go
+++ b/internal/dashboard/queryauthz/data_authorization.go
@@ -495,7 +495,11 @@ func (m Metrics) resolvedDependencyObjects(resourceIndex projectResourceIndex, r
 	dimensions := dataFieldsToSemanticFields(request.Fields)
 	metrics := dataFieldsToSemanticFields(request.Metrics)
 	for _, field := range request.AuthorizationFields {
-		if semanticFieldIsMetric(model, field.Field) {
+		isMetric, err := authorizationFieldIsMetric(model, field)
+		if err != nil {
+			return nil, nil, err
+		}
+		if isMetric {
 			metrics = append(metrics, semanticquery.Field{Field: field.Field, Alias: field.Alias})
 		} else {
 			dimensions = append(dimensions, semanticquery.Field{Field: field.Field, Alias: field.Alias})

--- a/internal/dashboard/queryauthz/data_authorization.go
+++ b/internal/dashboard/queryauthz/data_authorization.go
@@ -33,20 +33,24 @@ type Principal struct {
 }
 
 type Options struct {
-	SnapshotFromContext   func(context.Context) (accesssnapshot.AuthorizationSnapshot, error)
-	SubjectsFromContext   func(context.Context, string) ([]access.SubjectRef, error)
-	PrincipalFromContext  func(context.Context) (Principal, bool)
-	CredentialFromContext func(context.Context) (access.APICredential, bool)
-	AuditRecorder         access.CanonicalAuditRecorder
+	InstanceID                string
+	ResolveSemanticAttributes func(context.Context) (access.SemanticAttributeResolution, error)
+	SnapshotFromContext       func(context.Context) (accesssnapshot.AuthorizationSnapshot, error)
+	SubjectsFromContext       func(context.Context, string) ([]access.SubjectRef, error)
+	PrincipalFromContext      func(context.Context) (Principal, bool)
+	CredentialFromContext     func(context.Context) (access.APICredential, bool)
+	AuditRecorder             access.CanonicalAuditRecorder
 }
 
 type Metrics struct {
 	queryruntime.Metrics
-	snapshotFromContext   func(context.Context) (accesssnapshot.AuthorizationSnapshot, error)
-	subjectsFromContext   func(context.Context, string) ([]access.SubjectRef, error)
-	principalFromContext  func(context.Context) (Principal, bool)
-	credentialFromContext func(context.Context) (access.APICredential, bool)
-	auditRecorder         access.CanonicalAuditRecorder
+	instanceID                string
+	resolveSemanticAttributes func(context.Context) (access.SemanticAttributeResolution, error)
+	snapshotFromContext       func(context.Context) (accesssnapshot.AuthorizationSnapshot, error)
+	subjectsFromContext       func(context.Context, string) ([]access.SubjectRef, error)
+	principalFromContext      func(context.Context) (Principal, bool)
+	credentialFromContext     func(context.Context) (access.APICredential, bool)
+	auditRecorder             access.CanonicalAuditRecorder
 }
 
 // Planner forwards the activation-owned planner exposed by the active runtime.
@@ -89,12 +93,14 @@ func IsDenied(err error) bool {
 
 func New(metrics queryruntime.Metrics, options Options) Metrics {
 	return Metrics{
-		Metrics:               metrics,
-		snapshotFromContext:   options.SnapshotFromContext,
-		subjectsFromContext:   options.SubjectsFromContext,
-		principalFromContext:  options.PrincipalFromContext,
-		credentialFromContext: options.CredentialFromContext,
-		auditRecorder:         options.AuditRecorder,
+		instanceID:                options.InstanceID,
+		resolveSemanticAttributes: options.ResolveSemanticAttributes,
+		Metrics:                   metrics,
+		snapshotFromContext:       options.SnapshotFromContext,
+		subjectsFromContext:       options.SubjectsFromContext,
+		principalFromContext:      options.PrincipalFromContext,
+		credentialFromContext:     options.CredentialFromContext,
+		auditRecorder:             options.AuditRecorder,
 	}
 }
 
@@ -126,9 +132,17 @@ func (m Metrics) ExecuteDataQuery(ctx context.Context, request dataquery.Query) 
 		return dataquery.Result{}, errors.New("query metrics are not configured")
 	}
 	if m.snapshotFromContext == nil {
-		return m.Metrics.ExecuteDataQuery(ctx, request)
+		bound, err := m.bindSemanticQuery(ctx, request)
+		if err != nil {
+			return rejectedDataQueryResult(err)
+		}
+		return m.Metrics.ExecuteDataQuery(bound, request)
 	}
 	governed, transform, err := m.GovernDataQuery(ctx, request)
+	if err != nil {
+		return rejectedDataQueryResult(err)
+	}
+	ctx, err = m.bindSemanticQuery(ctx, governed)
 	if err != nil {
 		return rejectedDataQueryResult(err)
 	}
@@ -154,9 +168,17 @@ func (m Metrics) ExecuteDataQueryArrow(ctx context.Context, request dataquery.Qu
 		return dataquery.Result{}, errors.New("query metrics do not support native Arrow execution")
 	}
 	if m.snapshotFromContext == nil {
-		return executor.ExecuteDataQueryArrow(ctx, request, sink)
+		bound, err := m.bindSemanticQuery(ctx, request)
+		if err != nil {
+			return rejectedDataQueryResult(err)
+		}
+		return executor.ExecuteDataQueryArrow(bound, request, sink)
 	}
 	governed, transform, err := m.GovernDataQuery(ctx, request)
+	if err != nil {
+		return rejectedDataQueryResult(err)
+	}
+	ctx, err = m.bindSemanticQuery(ctx, governed)
 	if err != nil {
 		return rejectedDataQueryResult(err)
 	}

--- a/internal/dashboard/queryauthz/data_authorization_kind.go
+++ b/internal/dashboard/queryauthz/data_authorization_kind.go
@@ -1,0 +1,44 @@
+package authz
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+)
+
+// authorizationFieldIsMetric preserves the source collection's member kind
+// for count-only authorization projections. Legacy untyped fields are
+// resolved only when the name is unambiguous; qualified physical fields are
+// dimensions and therefore participate in the same ambiguity check when a
+// model also exposes a same-named metric.
+func authorizationFieldIsMetric(model *semanticmodel.Model, field dataquery.Field) (bool, error) {
+	if model == nil {
+		return false, fmt.Errorf("semantic model is required for authorization field %q", field.Field)
+	}
+	name := strings.TrimSpace(field.Field)
+	if name == "" {
+		return false, fmt.Errorf("semantic authorization projection contains an empty field")
+	}
+	switch strings.ToLower(strings.TrimSpace(field.Kind)) {
+	case dataquery.FieldKindMetric:
+		return true, nil
+	case dataquery.FieldKindDimension:
+		return false, nil
+	case "":
+		_, metricKnown := model.Metrics[name]
+		_, dimensionKnown := model.Dimensions[name]
+		if !dimensionKnown {
+			if _, err := model.ResolveDimension(name); err == nil {
+				dimensionKnown = true
+			}
+		}
+		if metricKnown && dimensionKnown {
+			return false, fmt.Errorf("semantic authorization projection field %q is ambiguous between metric and dimension", name)
+		}
+		return metricKnown, nil
+	default:
+		return false, fmt.Errorf("semantic authorization projection field %q has unsupported kind %q", name, field.Kind)
+	}
+}

--- a/internal/dashboard/queryauthz/data_authorization_kind_test.go
+++ b/internal/dashboard/queryauthz/data_authorization_kind_test.go
@@ -1,0 +1,72 @@
+package authz
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+)
+
+func TestAuthorizationFieldIsMetricPreservesExplicitKind(t *testing.T) {
+	model := authorizationKindTestModel()
+	tests := []struct {
+		name       string
+		field      dataquery.Field
+		wantMetric bool
+	}{
+		{name: "explicit metric", field: dataquery.Field{Field: "shared", Kind: dataquery.FieldKindMetric}, wantMetric: true},
+		{name: "explicit dimension", field: dataquery.Field{Field: "shared", Kind: dataquery.FieldKindDimension}, wantMetric: false},
+		{name: "unambiguous metric", field: dataquery.Field{Field: "metric_only"}, wantMetric: true},
+		{name: "unambiguous dimension", field: dataquery.Field{Field: "dimension_only"}, wantMetric: false},
+		{name: "qualified physical dimension", field: dataquery.Field{Field: "orders.id"}, wantMetric: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := authorizationFieldIsMetric(model, tt.field)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.wantMetric {
+				t.Fatalf("metric classification = %v, want %v", got, tt.wantMetric)
+			}
+		})
+	}
+}
+
+func TestAuthorizationFieldIsMetricRejectsAmbiguousAndInvalidLegacyKinds(t *testing.T) {
+	model := authorizationKindTestModel()
+	for _, field := range []dataquery.Field{
+		{Field: "shared"},
+		{Field: "shared", Kind: "other"},
+	} {
+		_, err := authorizationFieldIsMetric(model, field)
+		if err == nil {
+			t.Fatalf("field %#v was accepted", field)
+		}
+		if field.Kind == "" && !strings.Contains(err.Error(), "ambiguous") {
+			t.Fatalf("ambiguous field error = %v", err)
+		}
+		if field.Kind != "" && !strings.Contains(err.Error(), "unsupported kind") {
+			t.Fatalf("invalid kind error = %v", err)
+		}
+	}
+}
+
+func authorizationKindTestModel() *semanticmodel.Model {
+	return &semanticmodel.Model{
+		Tables: map[string]semanticmodel.Table{
+			"orders": {Dimensions: map[string]semanticmodel.MetricDimension{
+				"id": {Field: "orders.id", Table: "orders", Name: "id"},
+			}},
+		},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"shared":         {},
+			"dimension_only": {},
+		},
+		Metrics: map[string]semanticmodel.Metric{
+			"shared":      {},
+			"metric_only": {},
+		},
+	}
+}

--- a/internal/dashboard/queryauthz/semantic_development_access_test.go
+++ b/internal/dashboard/queryauthz/semantic_development_access_test.go
@@ -1,0 +1,58 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+// Resource-read admission for a trusted development request must not replace
+// the independent semantic consumer authority check used by API/MCP queries.
+func TestSemanticDevelopmentResourceReadDoesNotAuthorizeProtectedModels(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		prepare func(*testing.T, *Metrics, *semanticmodel.Model)
+		allow   bool
+	}{
+		{name: "protected requires real authority"},
+		{name: "public compiled model", allow: true, prepare: func(t *testing.T, m *Metrics, model *semanticmodel.Model) {
+			model.AccessPolicy = semanticmodel.SemanticAccessPolicy{}
+			planner, err := semanticquery.NewCompiledPlanner(model)
+			if err != nil {
+				t.Fatal(err)
+			}
+			underlying := m.Metrics.(semanticDiscoveryMetrics)
+			underlying.planner = planner
+			m.Metrics = underlying
+		}},
+		{name: "unknown protection from stripped policy", prepare: func(_ *testing.T, _ *Metrics, model *semanticmodel.Model) {
+			model.AccessPolicy = semanticmodel.SemanticAccessPolicy{}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			m, model, _ := semanticDiscoveryFixture(t)
+			if test.prepare != nil {
+				test.prepare(t, &m, model)
+			}
+			m.principalFromContext = func(context.Context) (Principal, bool) {
+				return Principal{ID: "alice", DevBypass: true}, true
+			}
+			for attempt := 0; attempt < 10; attempt++ {
+				consumer, err := m.SemanticConsumer(t.Context(), "sales")
+				if (err == nil) != test.allow {
+					t.Fatalf("attempt %d: consumer error = %v, want allow %v", attempt, err, test.allow)
+				}
+				if err == nil {
+					if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: "orders"}); err != nil {
+						t.Fatalf("public dataset authorization: %v", err)
+					}
+				}
+				if _, err := m.BindSemanticConsumer(t.Context(), "sales"); (err == nil) != test.allow {
+					t.Fatalf("attempt %d: binding error = %v, want allow %v", attempt, err, test.allow)
+				}
+			}
+		})
+	}
+}

--- a/internal/dashboard/queryauthz/semantic_discovery.go
+++ b/internal/dashboard/queryauthz/semantic_discovery.go
@@ -1,0 +1,214 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/flidai/leapview/internal/access"
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+// ErrSemanticConsumerAuthorityUnavailable is not a resource-not-found result:
+// a consumer without authoritative evidence must fail closed.
+var ErrSemanticConsumerAuthorityUnavailable = errors.New("semantic consumer authority is unavailable")
+
+func (m Metrics) bindSemanticQuery(ctx context.Context, request dataquery.Query) (context.Context, error) {
+	if request.Kind == dataquery.KindModelRows {
+		return ctx, nil
+	}
+	return m.BindSemanticConsumer(ctx, request.ModelID)
+}
+
+// SemanticConsumer is the common discovery port for consumers projecting an
+// already selected immutable model. The returned source fingerprint must
+// match that projection before any member metadata is released.
+func (m Metrics) SemanticConsumer(ctx context.Context, modelID string) (*semanticquery.SemanticAccessConsumer, error) {
+	return m.semanticConsumer(ctx, modelID)
+}
+
+// BindSemanticConsumer is also an optional governor capability. Dashboard
+// execution selects its model below the resource governor, so materialize may
+// request this binding there without accepting query-supplied authority.
+func (m Metrics) BindSemanticConsumer(ctx context.Context, modelID string) (context.Context, error) {
+	if m.Metrics == nil {
+		return ctx, ErrSemanticConsumerAuthorityUnavailable
+	}
+	model, ok := m.Metrics.SemanticModel(modelID)
+	if !ok || model == nil {
+		return ctx, ErrSemanticConsumerAuthorityUnavailable
+	}
+	if model.AccessPolicy.Empty() {
+		if planner, available := m.concretePlanner(modelID); available && (planner.CompiledModel() == nil || !planner.CompiledModel().MatchesModel(model)) {
+			return ctx, ErrSemanticConsumerAuthorityUnavailable
+		}
+		return ctx, nil
+	}
+	consumer, err := m.semanticConsumer(ctx, modelID)
+	if err != nil {
+		return ctx, err
+	}
+	snapshot, err := m.snapshotFromContext(ctx)
+	if err != nil || snapshot.ValidateBound() != nil {
+		return ctx, ErrSemanticConsumerAuthorityUnavailable
+	}
+	principal, ok := m.principalFromContext(ctx)
+	if !ok || principal.DevBypass {
+		return ctx, ErrSemanticConsumerAuthorityUnavailable
+	}
+	identity := snapshot.Identity()
+	bound := semanticquery.WithSemanticAccessConsumer(ctx, consumer, semanticquery.SemanticAccessConsumerBinding{
+		InstanceID: m.instanceID, ProjectID: identity.ProjectID.String(), Environment: identity.Environment,
+		Generation: identity.GenerationID, ModelID: modelID, PrincipalID: principal.ID,
+	})
+	if _, valid := semanticquery.SemanticAccessConsumerContextFromContext(bound); !valid {
+		return ctx, ErrSemanticConsumerAuthorityUnavailable
+	}
+	return bound, nil
+}
+
+// semanticConsumer binds the activation-owned model to Access-owned evidence.
+// Browser query fields, workload admission identities and document sharing do
+// not supply principals, assignments or policy authority.
+func (m Metrics) semanticConsumer(ctx context.Context, modelID string) (*semanticquery.SemanticAccessConsumer, error) {
+	if m.Metrics == nil {
+		return nil, ErrSemanticConsumerAuthorityUnavailable
+	}
+	planner, ok := m.concretePlanner(modelID)
+	model, found := m.Metrics.SemanticModel(modelID)
+	if !ok || !found || model == nil || planner.CompiledModel() == nil || !planner.CompiledModel().MatchesModel(model) {
+		return nil, ErrSemanticConsumerAuthorityUnavailable
+	}
+	if model.AccessPolicy.Empty() {
+		return semanticquery.NewSemanticAccessConsumer(planner, semanticquery.SemanticAccessConsumerConfig{})
+	}
+	plannerPort, available := m.Metrics.(interface {
+		SemanticPlannerSnapshot(context.Context, string) (*semanticquery.Planner, accesssnapshot.AuthorizationSnapshot, error)
+	})
+	if !available {
+		return nil, ErrSemanticConsumerAuthorityUnavailable
+	}
+	planner, snapshot, err := plannerPort.SemanticPlannerSnapshot(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+	if planner == nil || planner.CompiledModel() == nil || !planner.CompiledModel().MatchesModel(model) {
+		return nil, ErrSemanticConsumerAuthorityUnavailable
+	}
+	if m.instanceID == "" || m.snapshotFromContext == nil || m.resolveSemanticAttributes == nil || m.principalFromContext == nil {
+		return nil, ErrSemanticConsumerAuthorityUnavailable
+	}
+	principal, ok := m.principalFromContext(ctx)
+	if !ok || principal.ID == "" || principal.DevBypass {
+		return nil, DeniedError{Capability: access.CapabilityResourceUse}
+	}
+	if err := snapshot.ValidateBound(); err != nil {
+		return nil, err
+	}
+	identity := snapshot.Identity()
+	provider := func() (semanticquery.SemanticAccessAttributeSnapshot, semanticquery.SemanticAccessAuthority, error) {
+		var attributes semanticquery.SemanticAccessAttributeSnapshot
+		var authority semanticquery.SemanticAccessAuthority
+		currentPrincipal, authenticated := m.principalFromContext(ctx)
+		if !authenticated || currentPrincipal.ID != principal.ID || currentPrincipal.DevBypass {
+			return attributes, authority, ErrSemanticConsumerAuthorityUnavailable
+		}
+		current, err := m.snapshotFromContext(ctx)
+		if err != nil || current.ValidateBound() != nil || current.Identity() != identity {
+			return attributes, authority, ErrSemanticConsumerAuthorityUnavailable
+		}
+		resolved, err := m.resolveSemanticAttributes(ctx)
+		if err != nil {
+			return attributes, authority, err
+		}
+		if resolved.Subject.Kind != access.SubjectKindPrincipal || resolved.Subject.ID != principal.ID {
+			return attributes, authority, ErrSemanticConsumerAuthorityUnavailable
+		}
+		return semanticquery.SemanticAccessResolutionSnapshot(m.instanceID, principal.ID, resolved)
+	}
+	return semanticquery.NewSemanticAccessConsumer(planner, semanticquery.SemanticAccessConsumerConfig{
+		ProjectID: identity.ProjectID.String(), Environment: identity.Environment,
+		InstanceID: m.instanceID, ModelID: modelID, Generation: identity.GenerationID,
+		PrincipalID: principal.ID, Authority: provider,
+	})
+}
+
+// SemanticPlanner is the context-aware explain and query-shape port. Planner
+// remains activation-owned; no caller may mutate its shared authorization.
+func (m Metrics) SemanticPlanner(ctx context.Context, modelID string) (*semanticquery.Planner, error) {
+	consumer, err := m.semanticConsumer(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+	return consumer.Planner(), nil
+}
+
+func (m Metrics) AuthorizeSemanticTarget(ctx context.Context, modelID string, target semanticquery.SemanticAccessTarget) error {
+	consumer, err := m.semanticConsumer(ctx, modelID)
+	if err != nil {
+		return err
+	}
+	return consumer.Authorize(target)
+}
+
+// Whole-document projections have no partial-member contract. Admit every
+// canonical member through one consumer, or deny the projection as a whole.
+func (m Metrics) AuthorizeSemanticModelProjection(ctx context.Context, modelID string) error {
+	consumer, err := m.semanticConsumer(ctx, modelID)
+	if err != nil {
+		return err
+	}
+	model := consumer.Planner().CompiledModel().SourceModel()
+	for _, dataset := range consumer.Planner().CompiledModel().DatasetNames() {
+		if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: dataset}); err != nil {
+			return err
+		}
+		dimensions := make([]string, 0, len(model.Dimensions))
+		for name := range model.Dimensions {
+			dimensions = append(dimensions, name)
+		}
+		sort.Strings(dimensions)
+		for _, name := range dimensions {
+			if _, bound := consumer.Planner().CompiledModel().DimensionBinding(name, dataset); bound {
+				if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: dataset, Dimension: name}); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	metrics := make([]string, 0, len(model.Metrics))
+	for name := range model.Metrics {
+		metrics = append(metrics, name)
+	}
+	sort.Strings(metrics)
+	for _, name := range metrics {
+		if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Metric: name}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AuthorizeSemanticField also covers physical field names resolved by the
+// planner. It builds no data result and cannot authorize a presentation alias.
+func (m Metrics) AuthorizeSemanticField(ctx context.Context, modelID, dataset, field string) error {
+	planner, err := m.SemanticPlanner(ctx, modelID)
+	if err != nil {
+		return err
+	}
+	_, err = planner.PlanRows(semanticquery.RowRequest{Dataset: dataset, Dimensions: []semanticquery.Field{{Field: field}}, Limit: 1})
+	return err
+}
+
+// Protected reuse is unavailable until FAI-645 supplies lifecycle-bound cache
+// evidence. This is a denial boundary, not a new cache implementation.
+func (m Metrics) SemanticConsumerCacheAllowed(modelID string) bool {
+	if m.Metrics == nil {
+		return false
+	}
+	model, found := m.Metrics.SemanticModel(modelID)
+	planner, available := m.concretePlanner(modelID)
+	return found && model != nil && available && planner.CompiledModel() != nil && planner.CompiledModel().MatchesModel(model) && model.AccessPolicy.Empty()
+}

--- a/internal/dashboard/queryauthz/semantic_discovery_test.go
+++ b/internal/dashboard/queryauthz/semantic_discovery_test.go
@@ -1,0 +1,139 @@
+package authz
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	"github.com/flidai/leapview/internal/dashboard/consumer"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+type semanticDiscoveryMetrics struct {
+	canonicalMetrics
+	planner  *semanticquery.Planner
+	snapshot accesssnapshot.AuthorizationSnapshot
+}
+
+func (m semanticDiscoveryMetrics) Planner(string) (consumer.Planner, bool) {
+	return m.planner, m.planner != nil
+}
+
+func (m semanticDiscoveryMetrics) SemanticPlannerSnapshot(ctx context.Context, modelID string) (*semanticquery.Planner, accesssnapshot.AuthorizationSnapshot, error) {
+	return m.planner, m.snapshot, nil
+}
+
+func semanticDiscoveryFixture(t *testing.T) (Metrics, *semanticmodel.Model, *access.SemanticAttributeResolution) {
+	t.Helper()
+	base := canonicalMetricsWithSnapshot(t, canonicalSnapshot(t, nil, nil), nil)
+	underlying := base.Metrics.(canonicalMetrics)
+	model := underlying.model
+	model.AccessPolicy = semanticmodel.SemanticAccessPolicy{
+		AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{"region_grant": {UserAttribute: "region", AllowedValues: []semanticmodel.SemanticAccessLiteral{{Kind: semanticmodel.SemanticAccessString, Text: "us"}}}},
+		Datasets:     map[string]semanticmodel.SemanticDatasetAccessSpec{"orders": {RequiredAccessGrants: []string{"region_grant"}}},
+	}
+	definition := access.SemanticAttributeDefinition{ID: "def-region", Name: "region", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Profile: semanticvalue.Profile, DefinitionVersion: 1, LifecycleState: access.SemanticAttributeActive, Enabled: true}
+	definition.Metadata.Owner = access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}
+	registryDigest, err := access.SemanticAttributeRegistryDigest(semanticvalue.Profile, []access.SemanticAttributeDefinition{definition})
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, valueDigest, err := access.CanonicalSemanticAttributeValues(definition, "us")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: "alice"}
+	assignment := access.SemanticAttributeAssignment{ID: "assignment-region", DefinitionID: definition.ID, DefinitionName: definition.Name, DefinitionVersion: 1, Type: definition.Type, Shape: definition.Shape, Subject: subject, CanonicalValues: values, ValueDigest: valueDigest, AssignmentVersion: 1}
+	controlDigest, err := access.SemanticAttributeControlDigest([]access.SemanticAttributeAssignment{assignment}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := &access.SemanticAttributeResolution{
+		Subject: subject, Subjects: []access.SubjectRef{subject}, ObservedAt: time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC),
+		Registry:   access.SemanticAttributeRegistrySnapshot{State: access.SemanticAttributeRegistryState{Profile: semanticvalue.Profile, Revision: 1, Digest: registryDigest}, Definitions: []access.SemanticAttributeDefinition{definition}},
+		Control:    access.SemanticAttributeControlSnapshot{State: access.SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 1, Digest: controlDigest}, Assignments: []access.SemanticAttributeAssignment{assignment}},
+		Attributes: []access.EffectiveSemanticAttribute{{DefinitionID: definition.ID, DefinitionName: definition.Name, DefinitionVersion: 1, Type: definition.Type, Shape: definition.Shape, CanonicalValues: values, ValueDigest: valueDigest, Source: "direct"}},
+	}
+	planner, err := semanticquery.NewCompiledPlanner(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics := New(semanticDiscoveryMetrics{canonicalMetrics: underlying, planner: planner, snapshot: canonicalSnapshot(t, nil, nil)}, Options{
+		InstanceID:                "instance-1",
+		ResolveSemanticAttributes: func(context.Context) (access.SemanticAttributeResolution, error) { return *resolution, nil },
+		SnapshotFromContext: func(context.Context) (accesssnapshot.AuthorizationSnapshot, error) {
+			return canonicalSnapshot(t, nil, nil), nil
+		},
+		PrincipalFromContext: func(context.Context) (Principal, bool) { return Principal{ID: "alice"}, true },
+	})
+	return metrics, model, resolution
+}
+
+func TestSemanticDiscoveryAndBindingUseTrustedAuthority(t *testing.T) {
+	m, _, _ := semanticDiscoveryFixture(t)
+	if err := m.AuthorizeSemanticTarget(t.Context(), "sales", semanticquery.SemanticAccessTarget{Dataset: "orders"}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, err := m.BindSemanticConsumer(t.Context(), "sales")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, ok := semanticquery.SemanticAccessConsumerContextFromContext(ctx)
+	if !ok || value.Binding.PrincipalID != "alice" || value.Binding.InstanceID != "instance-1" {
+		t.Fatalf("binding = %#v", value)
+	}
+	if m.SemanticConsumerCacheAllowed("sales") {
+		t.Fatal("protected shared reuse was allowed")
+	}
+}
+
+func TestSemanticDiscoveryDoesNotTrustMutableModelOrSubject(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		change func(*Metrics, *semanticmodel.Model, *access.SemanticAttributeResolution)
+	}{
+		{"missing resolver", func(m *Metrics, _ *semanticmodel.Model, _ *access.SemanticAttributeResolution) {
+			m.resolveSemanticAttributes = nil
+		}},
+		{"stripped policy", func(_ *Metrics, model *semanticmodel.Model, _ *access.SemanticAttributeResolution) {
+			model.AccessPolicy = semanticmodel.SemanticAccessPolicy{}
+		}},
+		{"wrong subject", func(_ *Metrics, _ *semanticmodel.Model, r *access.SemanticAttributeResolution) {
+			r.Subject.ID = "mallory"
+		}},
+		{"stale digest", func(_ *Metrics, _ *semanticmodel.Model, r *access.SemanticAttributeResolution) {
+			r.Control.State.Digest = "invalid"
+		}},
+		{"development bypass", func(m *Metrics, _ *semanticmodel.Model, _ *access.SemanticAttributeResolution) {
+			m.principalFromContext = func(context.Context) (Principal, bool) { return Principal{ID: "alice", DevBypass: true}, true }
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			m, model, resolution := semanticDiscoveryFixture(t)
+			test.change(&m, model, resolution)
+			if _, err := m.SemanticPlanner(t.Context(), "sales"); err == nil {
+				t.Fatal("invalid semantic authority admitted")
+			}
+			if _, err := m.BindSemanticConsumer(t.Context(), "sales"); err == nil {
+				t.Fatal("invalid semantic binding admitted")
+			}
+		})
+	}
+}
+
+func TestSemanticDiscoveryPublicAndUnknownTargets(t *testing.T) {
+	base := canonicalMetricsWithSnapshot(t, canonicalSnapshot(t, nil, nil), nil)
+	if err := base.AuthorizeSemanticTarget(t.Context(), "sales", semanticquery.SemanticAccessTarget{Dataset: "orders"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := base.AuthorizeSemanticTarget(t.Context(), "sales", semanticquery.SemanticAccessTarget{Metric: "unknown"}); err == nil {
+		t.Fatal("unknown public member accepted")
+	}
+	if _, err := base.BindSemanticConsumer(t.Context(), "sales"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/dashboard/runtime/data_query.go
+++ b/internal/dashboard/runtime/data_query.go
@@ -41,7 +41,16 @@ func reportRowDataQuery(modelID string, request reportdef.RowQuery, includeTotal
 
 func countOnlyDataQuery(request dataquery.Query) dataquery.Query {
 	request.Operation = dataquery.OperationDashboardCount
-	request.AuthorizationFields = append(append([]dataquery.Field{}, request.Fields...), request.Metrics...)
+	authorizationFields := make([]dataquery.Field, 0, len(request.Fields)+len(request.Metrics))
+	for _, field := range request.Fields {
+		field.Kind = dataquery.FieldKindDimension
+		authorizationFields = append(authorizationFields, field)
+	}
+	for _, field := range request.Metrics {
+		field.Kind = dataquery.FieldKindMetric
+		authorizationFields = append(authorizationFields, field)
+	}
+	request.AuthorizationFields = authorizationFields
 	request.Fields = nil
 	request.Metrics = nil
 	request.Sort = nil

--- a/internal/dashboard/runtime/data_query_test.go
+++ b/internal/dashboard/runtime/data_query_test.go
@@ -36,7 +36,7 @@ func TestReportCountDataQueryPreservesAuthorizationProjection(t *testing.T) {
 	if len(request.Fields) != 0 || len(request.Metrics) != 0 {
 		t.Fatalf("physical projection = fields %#v metrics %#v, want count-only", request.Fields, request.Metrics)
 	}
-	if got := request.AuthorizationFields; len(got) != 3 || got[0].Field != "orders.order_id" || got[1].Field != "orders.customer_email" || got[2].Field != "order_value" {
+	if got := request.AuthorizationFields; len(got) != 3 || got[0].Field != "orders.order_id" || got[0].Kind != dataquery.FieldKindDimension || got[1].Field != "orders.customer_email" || got[1].Kind != dataquery.FieldKindDimension || got[2].Field != "order_value" || got[2].Kind != dataquery.FieldKindMetric {
 		t.Fatalf("authorization projection = %#v", got)
 	}
 }

--- a/internal/dashboard/semanticapi/handler.go
+++ b/internal/dashboard/semanticapi/handler.go
@@ -41,6 +41,17 @@ var errSemanticAuthorizationUnavailable = errors.New("semantic model authorizati
 var errSemanticModelActivationUnavailable = errors.New("active semantic model planner is unavailable")
 
 func (h Handler) authorizeSemanticModel(r *nethttp.Request, modelID string) (bool, error) {
+	allowed, err := h.authorizeSemanticModelResource(r, modelID)
+	if err != nil || !allowed {
+		return allowed, err
+	}
+	if err := authorizeSemanticModelProjection(r.Context(), h.Metrics, modelID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (h Handler) authorizeSemanticModelResource(r *nethttp.Request, modelID string) (bool, error) {
 	if h.AuthorizeListResource == nil {
 		return false, errSemanticAuthorizationUnavailable
 	}
@@ -102,6 +113,15 @@ func (h Handler) semanticModelForRequest(w nethttp.ResponseWriter, r *nethttp.Re
 		return nil, false
 	}
 	modelID := chi.URLParam(r, "model")
+	allowed, err := h.authorizeSemanticModelResource(r, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return nil, false
+	}
+	if !allowed {
+		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
+		return nil, false
+	}
 	model := semanticModelForID(metrics, modelID)
 	if model == nil {
 		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)

--- a/internal/dashboard/semanticapi/semantic_authorization.go
+++ b/internal/dashboard/semanticapi/semantic_authorization.go
@@ -265,7 +265,7 @@ func authorizeSemanticRequest(ctx context.Context, metrics Metrics, modelID stri
 	for _, field := range dimensions {
 		fieldDataset, fieldName := dataset, field.Field
 		if fieldDataset == "" {
-			fieldDataset, fieldName = qualifiedSemanticMember(field.Field)
+			fieldDataset, _ = qualifiedSemanticMember(field.Field)
 			if fieldDataset == "" {
 				continue
 			}
@@ -277,7 +277,7 @@ func authorizeSemanticRequest(ctx context.Context, metrics Metrics, modelID stri
 	if timeField != "" {
 		fieldDataset, fieldName := dataset, timeField
 		if fieldDataset == "" {
-			fieldDataset, fieldName = qualifiedSemanticMember(timeField)
+			fieldDataset, _ = qualifiedSemanticMember(timeField)
 		}
 		if fieldDataset != "" {
 			if err := authorizeSemanticField(ctx, metrics, modelID, fieldDataset, fieldName); err != nil {
@@ -302,7 +302,7 @@ func authorizeSemanticFilter(ctx context.Context, metrics Metrics, modelID strin
 	dataset := filter.Dataset
 	field := filter.Field
 	if dataset == "" {
-		dataset, field = qualifiedSemanticMember(field)
+		dataset, _ = qualifiedSemanticMember(field)
 	}
 	if dataset != "" && field != "" {
 		if err := authorizeSemanticField(ctx, metrics, modelID, dataset, field); err != nil {
@@ -311,14 +311,21 @@ func authorizeSemanticFilter(ctx context.Context, metrics Metrics, modelID strin
 	}
 	if filter.Spatial != nil {
 		spatialDataset := filter.Spatial.Dataset
-		if spatialDataset == "" {
-			spatialDataset = dataset
-		}
 		for _, field := range []string{filter.Spatial.LatitudeField, filter.Spatial.LongitudeField} {
-			if field == "" || spatialDataset == "" {
+			if field == "" {
 				continue
 			}
-			if err := authorizeSemanticField(ctx, metrics, modelID, spatialDataset, field); err != nil {
+			fieldDataset := spatialDataset
+			if fieldDataset == "" {
+				fieldDataset = dataset
+			}
+			if fieldDataset == "" {
+				fieldDataset, _ = qualifiedSemanticMember(field)
+			}
+			if fieldDataset == "" {
+				continue
+			}
+			if err := authorizeSemanticField(ctx, metrics, modelID, fieldDataset, field); err != nil {
 				return err
 			}
 		}

--- a/internal/dashboard/semanticapi/semantic_authorization.go
+++ b/internal/dashboard/semanticapi/semantic_authorization.go
@@ -1,0 +1,400 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	nethttp "net/http"
+	"sort"
+	"strings"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	queryauthz "github.com/flidai/leapview/internal/dashboard/queryauthz"
+)
+
+var errSemanticConsumerUnavailable = errors.New("semantic consumer authority is unavailable")
+
+type semanticContextPlanner interface {
+	SemanticPlanner(context.Context, string) (*semanticquery.Planner, error)
+}
+
+type semanticContextTargetAuthorizer interface {
+	AuthorizeSemanticTarget(context.Context, string, semanticquery.SemanticAccessTarget) error
+}
+
+type semanticContextFieldAuthorizer interface {
+	AuthorizeSemanticField(context.Context, string, string, string) error
+}
+
+type semanticContextProjectionAuthorizer interface {
+	AuthorizeSemanticModelProjection(context.Context, string) error
+}
+
+type semanticContextConsumerProvider interface {
+	SemanticConsumer(context.Context, string) (*semanticquery.SemanticAccessConsumer, error)
+}
+
+type semanticConsumerContextKey struct{}
+
+type semanticConsumerBinding struct {
+	modelID  string
+	consumer *semanticquery.SemanticAccessConsumer
+}
+
+func protectedSemanticModel(metrics Metrics, modelID string) bool {
+	model, ok := semanticModelSnapshot(metrics, modelID)
+	return ok && !model.AccessPolicy.Empty()
+}
+
+func semanticModelSnapshot(metrics Metrics, modelID string) (*semanticmodel.Model, bool) {
+	if planner, ok := semanticPlanner(metrics, modelID); ok && planner != nil && planner.CompiledModel() != nil {
+		if model := planner.CompiledModel().SourceModel(); model != nil {
+			return model, true
+		}
+	}
+	model := semanticModelForID(metrics, modelID)
+	return model, model != nil
+}
+
+func semanticModelKnown(metrics Metrics, modelID string) bool {
+	_, ok := semanticModelSnapshot(metrics, modelID)
+	return ok
+}
+
+func semanticPlannerMatchesModel(metrics Metrics, modelID string, planner *semanticquery.Planner) bool {
+	if planner == nil || planner.CompiledModel() == nil {
+		return false
+	}
+	model := semanticModelForID(metrics, modelID)
+	return model != nil && planner.CompiledModel().MatchesModel(model)
+}
+
+func semanticConsumerForRequest(ctx context.Context, metrics Metrics, modelID string) (context.Context, error) {
+	if binding, ok := ctx.Value(semanticConsumerContextKey{}).(semanticConsumerBinding); ok && binding.modelID == modelID && binding.consumer != nil {
+		return ctx, nil
+	}
+	provider, ok := any(metrics).(semanticContextConsumerProvider)
+	if !ok {
+		return ctx, nil
+	}
+	consumer, err := provider.SemanticConsumer(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+	if consumer == nil || !semanticPlannerMatchesModel(metrics, modelID, consumer.Planner()) {
+		return nil, errSemanticConsumerUnavailable
+	}
+	// A compiled source fingerprint alone is not sufficient identity: two
+	// semantic model resources may carry identical source. Protected consumers
+	// therefore must also be bound to the requested resource ID before any
+	// metadata is projected.
+	if protectedSemanticModel(metrics, modelID) && consumer.ModelID() != modelID {
+		return nil, errSemanticConsumerUnavailable
+	}
+	return context.WithValue(ctx, semanticConsumerContextKey{}, semanticConsumerBinding{modelID: modelID, consumer: consumer}), nil
+}
+
+func semanticConsumerFromContext(ctx context.Context, modelID string) (*semanticquery.SemanticAccessConsumer, bool) {
+	binding, ok := ctx.Value(semanticConsumerContextKey{}).(semanticConsumerBinding)
+	return binding.consumer, ok && binding.modelID == modelID && binding.consumer != nil
+}
+
+func authorizeSemanticConsumerProjection(consumer *semanticquery.SemanticAccessConsumer) error {
+	if consumer == nil || consumer.Planner() == nil || consumer.Planner().CompiledModel() == nil {
+		return errSemanticConsumerUnavailable
+	}
+	planner := consumer.Planner()
+	compiled := planner.CompiledModel()
+	model := compiled.SourceModel()
+	if model == nil {
+		return errSemanticConsumerUnavailable
+	}
+	for _, dataset := range compiled.DatasetNames() {
+		if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: dataset}); err != nil {
+			return err
+		}
+		dimensions := make([]string, 0, len(model.Dimensions))
+		for name := range model.Dimensions {
+			dimensions = append(dimensions, name)
+		}
+		sort.Strings(dimensions)
+		for _, name := range dimensions {
+			if _, bound := compiled.DimensionBinding(name, dataset); !bound {
+				continue
+			}
+			if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: dataset, Dimension: name}); err != nil {
+				return err
+			}
+		}
+	}
+	metrics := make([]string, 0, len(model.Metrics))
+	for name := range model.Metrics {
+		metrics = append(metrics, name)
+	}
+	sort.Strings(metrics)
+	for _, name := range metrics {
+		if err := consumer.Authorize(semanticquery.SemanticAccessTarget{Metric: name}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func semanticPlannerForRequest(ctx context.Context, metrics Metrics, modelID string) (*semanticquery.Planner, error) {
+	if consumer, ok := semanticConsumerFromContext(ctx, modelID); ok {
+		planner := consumer.Planner()
+		if planner == nil || !semanticPlannerMatchesModel(metrics, modelID, planner) {
+			return nil, errSemanticConsumerUnavailable
+		}
+		return planner, nil
+	}
+	if provider, ok := any(metrics).(semanticContextPlanner); ok {
+		planner, err := provider.SemanticPlanner(ctx, modelID)
+		if err != nil {
+			return nil, err
+		}
+		if planner != nil && semanticPlannerMatchesModel(metrics, modelID, planner) {
+			return planner, nil
+		}
+		return nil, errSemanticConsumerUnavailable
+	}
+	if !semanticModelKnown(metrics, modelID) || protectedSemanticModel(metrics, modelID) {
+		return nil, errSemanticConsumerUnavailable
+	}
+	planner, ok := semanticPlanner(metrics, modelID)
+	if !ok || planner == nil || !semanticPlannerMatchesModel(metrics, modelID, planner) {
+		return nil, fmt.Errorf("compiled semantic planner for model %q is unavailable", modelID)
+	}
+	return planner, nil
+}
+
+func authorizeSemanticTarget(ctx context.Context, metrics Metrics, modelID string, target semanticquery.SemanticAccessTarget) error {
+	if consumer, ok := semanticConsumerFromContext(ctx, modelID); ok {
+		return consumer.Authorize(target)
+	}
+	if scoped, err := semanticConsumerForRequest(ctx, metrics, modelID); err != nil {
+		if _, provider := any(metrics).(semanticContextConsumerProvider); provider {
+			return err
+		}
+	} else if consumer, ok := semanticConsumerFromContext(scoped, modelID); ok {
+		return consumer.Authorize(target)
+	}
+	if provider, ok := any(metrics).(semanticContextTargetAuthorizer); ok {
+		return provider.AuthorizeSemanticTarget(ctx, modelID, target)
+	}
+	if !semanticModelKnown(metrics, modelID) || protectedSemanticModel(metrics, modelID) {
+		return errSemanticConsumerUnavailable
+	}
+	return nil
+}
+
+func authorizeSemanticField(ctx context.Context, metrics Metrics, modelID, dataset, field string) error {
+	if consumer, ok := semanticConsumerFromContext(ctx, modelID); ok {
+		planner := consumer.Planner()
+		if planner == nil {
+			return errSemanticConsumerUnavailable
+		}
+		_, err := planner.PlanRows(semanticquery.RowRequest{Dataset: dataset, Dimensions: []semanticquery.Field{{Field: field}}, Limit: 1})
+		return err
+	}
+	if scoped, err := semanticConsumerForRequest(ctx, metrics, modelID); err != nil {
+		if _, provider := any(metrics).(semanticContextConsumerProvider); provider {
+			return err
+		}
+	} else if consumer, ok := semanticConsumerFromContext(scoped, modelID); ok {
+		planner := consumer.Planner()
+		if planner == nil {
+			return errSemanticConsumerUnavailable
+		}
+		_, err := planner.PlanRows(semanticquery.RowRequest{Dataset: dataset, Dimensions: []semanticquery.Field{{Field: field}}, Limit: 1})
+		return err
+	}
+	if provider, ok := any(metrics).(semanticContextFieldAuthorizer); ok {
+		return provider.AuthorizeSemanticField(ctx, modelID, dataset, field)
+	}
+	if !semanticModelKnown(metrics, modelID) || protectedSemanticModel(metrics, modelID) {
+		return errSemanticConsumerUnavailable
+	}
+	return nil
+}
+
+func authorizeSemanticModelProjection(ctx context.Context, metrics Metrics, modelID string) error {
+	if consumer, ok := semanticConsumerFromContext(ctx, modelID); ok {
+		return authorizeSemanticConsumerProjection(consumer)
+	}
+	if scoped, err := semanticConsumerForRequest(ctx, metrics, modelID); err != nil {
+		if _, provider := any(metrics).(semanticContextConsumerProvider); provider {
+			return err
+		}
+	} else if consumer, ok := semanticConsumerFromContext(scoped, modelID); ok {
+		return authorizeSemanticConsumerProjection(consumer)
+	}
+	if provider, ok := any(metrics).(semanticContextProjectionAuthorizer); ok {
+		return provider.AuthorizeSemanticModelProjection(ctx, modelID)
+	}
+	if !semanticModelKnown(metrics, modelID) || protectedSemanticModel(metrics, modelID) {
+		return errSemanticConsumerUnavailable
+	}
+	return nil
+}
+
+// authorizeSemanticRequest admits a query shape before either explain output
+// or execution. The context-aware planner remains the final authority for
+// complex dependency/filter paths; these explicit targets ensure simple
+// dataset/member requests cannot expose a protected member first.
+func authorizeSemanticRequest(ctx context.Context, metrics Metrics, modelID string, request any) error {
+	var dataset string
+	var dimensions []semanticquery.Field
+	var metricsFields []semanticquery.Field
+	var filters []semanticquery.Filter
+	var timeField string
+	switch value := request.(type) {
+	case semanticquery.Request:
+		dataset, dimensions, metricsFields, filters, timeField = value.Dataset, value.Dimensions, value.Metrics, value.Filters, value.Time.Field
+	case semanticquery.RowRequest:
+		dataset, dimensions, metricsFields, filters = value.Dataset, value.Dimensions, value.Metrics, value.Filters
+	default:
+		return fmt.Errorf("unsupported semantic request type %T", request)
+	}
+	if dataset != "" {
+		if err := authorizeSemanticTarget(ctx, metrics, modelID, semanticquery.SemanticAccessTarget{Dataset: dataset}); err != nil {
+			return err
+		}
+	}
+	for _, field := range dimensions {
+		fieldDataset, fieldName := dataset, field.Field
+		if fieldDataset == "" {
+			fieldDataset, fieldName = qualifiedSemanticMember(field.Field)
+			if fieldDataset == "" {
+				continue
+			}
+		}
+		if err := authorizeSemanticField(ctx, metrics, modelID, fieldDataset, fieldName); err != nil {
+			return err
+		}
+	}
+	if timeField != "" {
+		fieldDataset, fieldName := dataset, timeField
+		if fieldDataset == "" {
+			fieldDataset, fieldName = qualifiedSemanticMember(timeField)
+		}
+		if fieldDataset != "" {
+			if err := authorizeSemanticField(ctx, metrics, modelID, fieldDataset, fieldName); err != nil {
+				return err
+			}
+		}
+	}
+	for _, field := range metricsFields {
+		if err := authorizeSemanticTarget(ctx, metrics, modelID, semanticquery.SemanticAccessTarget{Metric: field.Field, Dataset: dataset}); err != nil {
+			return err
+		}
+	}
+	for _, filter := range filters {
+		if err := authorizeSemanticFilter(ctx, metrics, modelID, filter); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func authorizeSemanticFilter(ctx context.Context, metrics Metrics, modelID string, filter semanticquery.Filter) error {
+	dataset := filter.Dataset
+	field := filter.Field
+	if dataset == "" {
+		dataset, field = qualifiedSemanticMember(field)
+	}
+	if dataset != "" && field != "" {
+		if err := authorizeSemanticField(ctx, metrics, modelID, dataset, field); err != nil {
+			return err
+		}
+	}
+	if filter.Spatial != nil {
+		spatialDataset := filter.Spatial.Dataset
+		if spatialDataset == "" {
+			spatialDataset = dataset
+		}
+		for _, field := range []string{filter.Spatial.LatitudeField, filter.Spatial.LongitudeField} {
+			if field == "" || spatialDataset == "" {
+				continue
+			}
+			if err := authorizeSemanticField(ctx, metrics, modelID, spatialDataset, field); err != nil {
+				return err
+			}
+		}
+	}
+	for _, group := range filter.Groups {
+		for _, child := range group.Filters {
+			if err := authorizeSemanticFilter(ctx, metrics, modelID, child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func qualifiedSemanticMember(value string) (string, string) {
+	value = strings.TrimSpace(value)
+	if index := strings.IndexByte(value, '.'); index > 0 && index < len(value)-1 {
+		return value[:index], value[index+1:]
+	}
+	return "", value
+}
+
+func semanticAuthorizationUnavailable(err error) bool {
+	return errors.Is(err, errSemanticConsumerUnavailable) || errors.Is(err, queryauthz.ErrSemanticConsumerAuthorityUnavailable)
+}
+
+func semanticAuthorizationStatus(err error) int {
+	if semanticAuthorizationUnavailable(err) {
+		return 503
+	}
+	return 403
+}
+
+func semanticRequestAuthorizationStatus(metrics Metrics, modelID string, err error) int {
+	if semanticAuthorizationUnavailable(err) {
+		return nethttp.StatusServiceUnavailable
+	}
+	if !protectedSemanticModel(metrics, modelID) {
+		// Public semantic query shape errors retain the API's historical 400
+		// contract; protected unknown members remain fail-closed as 403.
+		return nethttp.StatusBadRequest
+	}
+	return semanticAuthorizationStatus(err)
+}
+
+func semanticMemberDenied(err error) bool {
+	return queryauthz.IsDenied(err) || strings.Contains(err.Error(), "semantic access denied")
+}
+
+func authorizeSemanticRelationship(ctx context.Context, metrics Metrics, modelID string, relationship semanticmodel.Relationship) error {
+	fromDataset, fromFields, err := semanticmodel.RelationshipEndpoint(relationship, true)
+	if err != nil {
+		return err
+	}
+	toDataset, toFields, err := semanticmodel.RelationshipEndpoint(relationship, false)
+	if err != nil {
+		return err
+	}
+	for _, dataset := range []string{fromDataset, toDataset} {
+		if err := authorizeSemanticTarget(ctx, metrics, modelID, semanticquery.SemanticAccessTarget{Dataset: dataset}); err != nil {
+			return err
+		}
+	}
+	for index, fields := range [][]string{fromFields, toFields} {
+		dataset := fromDataset
+		if index == 1 {
+			dataset = toDataset
+		}
+		for _, field := range fields {
+			if err := authorizeSemanticField(ctx, metrics, modelID, dataset, field); err != nil {
+				if semanticModelKnown(metrics, modelID) && !protectedSemanticModel(metrics, modelID) {
+					continue
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/dashboard/semanticapi/semantic_authorization_test.go
+++ b/internal/dashboard/semanticapi/semantic_authorization_test.go
@@ -3,6 +3,8 @@ package http
 import (
 	"context"
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
@@ -57,6 +59,165 @@ func TestAuthorizeSemanticRequestUsesFieldCapabilityForQualifiedPhysicalDimensio
 	if len(metrics.fields) != 1 || metrics.fields[0] != [3]string{"orders", "orders.created_at", ""} {
 		t.Fatalf("fields = %#v", metrics.fields)
 	}
+}
+
+func TestAuthorizeSemanticRequestPreservesQualifiedPhysicalReferences(t *testing.T) {
+	request := semanticquery.Request{
+		Dataset: "orders",
+		Dimensions: []semanticquery.Field{
+			{Field: "logicalAllowed"},
+			{Field: "orders.allowed"},
+			{Field: "orders.status"},
+		},
+		Filters: []semanticquery.Filter{
+			{Dataset: "orders", Field: "logicalAllowed"},
+			{Field: "orders.allowed"},
+			{Dataset: "orders", Field: "orders.status"},
+			{Spatial: &semanticquery.SpatialFilter{LatitudeField: "orders.latitude", LongitudeField: "orders.longitude"}},
+		},
+	}
+	want := [][3]string{
+		{"orders", "logicalAllowed", ""},
+		{"orders", "orders.allowed", ""},
+		{"orders", "orders.status", ""},
+		{"orders", "logicalAllowed", ""},
+		{"orders", "orders.allowed", ""},
+		{"orders", "orders.status", ""},
+		{"orders", "orders.latitude", ""},
+		{"orders", "orders.longitude", ""},
+	}
+
+	for iteration := 0; iteration < 10; iteration++ {
+		metrics := &semanticAuthorizationCapabilityMetrics{semanticProjectionMetrics: semanticProjectionMetrics{model: &semanticmodel.Model{Name: "sales"}}}
+		if err := authorizeSemanticRequest(context.Background(), metrics, "sales", request); err != nil {
+			t.Fatalf("iteration %d: authorize request: %v", iteration, err)
+		}
+		if !reflect.DeepEqual(metrics.fields, want) {
+			t.Fatalf("iteration %d: fields = %#v, want %#v", iteration, metrics.fields, want)
+		}
+	}
+}
+
+func TestAuthorizeSemanticRequestUsesPhysicalAndSemanticIdentitiesTogether(t *testing.T) {
+	metrics := semanticPhysicalFieldConsumerFixture(t)
+	request := semanticquery.Request{
+		Dataset:    "orders",
+		Dimensions: []semanticquery.Field{{Field: "logicalAllowed"}, {Field: "orders.allowed"}},
+		Filters: []semanticquery.Filter{
+			{Dataset: "orders", Field: "logicalStatus", Operator: "equals", Values: []any{"ready"}},
+			{Field: "orders.status", Operator: "equals", Values: []any{"ready"}},
+		},
+	}
+	if _, err := metrics.consumer.Planner().PlanRows(semanticquery.RowRequest{
+		Dataset:    request.Dataset,
+		Dimensions: request.Dimensions,
+		Filters:    request.Filters,
+		Limit:      1,
+	}); err != nil {
+		t.Fatalf("ordinary planner rejected mixed semantic and physical request: %v", err)
+	}
+	if err := authorizeSemanticRequest(context.Background(), metrics, "sales", request); err != nil {
+		t.Fatalf("authorization rejected mixed semantic and physical request: %v", err)
+	}
+}
+
+func TestAuthorizeSemanticRequestDistinguishesCollidingPhysicalAndSemanticNames(t *testing.T) {
+	metrics, _ := semanticMetadataConsumerFixture(t)
+	physical := semanticquery.RowRequest{Dataset: "orders", Dimensions: []semanticquery.Field{{Field: "orders.allowed"}}}
+	if _, err := metrics.consumer.Planner().PlanRows(physical); err != nil {
+		t.Fatalf("ordinary planner rejected physical orders.allowed: %v", err)
+	}
+	if err := authorizeSemanticRequest(context.Background(), metrics, "sales", physical); err != nil {
+		t.Fatalf("physical orders.allowed was denied by colliding semantic member: %v", err)
+	}
+
+	semantic := semanticquery.RowRequest{Dataset: "orders", Dimensions: []semanticquery.Field{{Field: "allowed"}}}
+	err := authorizeSemanticRequest(context.Background(), metrics, "sales", semantic)
+	if err == nil || !strings.Contains(err.Error(), `semantic access denied for dimension "allowed"`) {
+		t.Fatalf("semantic allowed error = %v, want denied semantic member", err)
+	}
+}
+
+func TestAuthorizeSemanticRequestPreservesQualifiedPhysicalFilterWithoutDataset(t *testing.T) {
+	metrics := semanticPhysicalFieldConsumerFixture(t)
+	ordinary, err := metrics.consumer.Planner().PlanRows(semanticquery.RowRequest{
+		Dataset:    "orders",
+		Filters:    []semanticquery.Filter{{Field: "orders.allowed", Operator: "equals", Values: []any{"yes"}}},
+		Dimensions: []semanticquery.Field{{Field: "orders.allowed"}},
+		Limit:      1,
+	})
+	if err != nil {
+		t.Fatalf("ordinary PlanRows rejected qualified physical field: %v", err)
+	}
+	if ordinary.SQL == "" {
+		t.Fatal("ordinary PlanRows returned an empty SQL plan")
+	}
+	if err := authorizeSemanticRequest(context.Background(), metrics, "sales", semanticquery.Request{
+		Filters: []semanticquery.Filter{{Field: "orders.allowed", Operator: "equals", Values: []any{"yes"}}},
+	}); err != nil {
+		t.Fatalf("authorization rejected qualified physical filter: %v", err)
+	}
+	if err := authorizeSemanticRequest(context.Background(), metrics, "sales", semanticquery.Request{
+		Dimensions: []semanticquery.Field{{Field: "orders.allowed"}},
+	}); err != nil {
+		t.Fatalf("authorization rejected qualified physical dimension without dataset: %v", err)
+	}
+}
+
+func TestAuthorizeSemanticRequestRejectsInvalidPhysicalReferences(t *testing.T) {
+	metrics := semanticPhysicalFieldConsumerFixture(t)
+	for _, test := range []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{name: "unqualified", field: "allowed", want: "must be qualified"},
+		{name: "unknown qualified", field: "orders.missing", want: "unknown field"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := authorizeSemanticRequest(context.Background(), metrics, "sales", semanticquery.RowRequest{
+				Dataset:    "orders",
+				Dimensions: []semanticquery.Field{{Field: test.field}},
+			})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func semanticPhysicalFieldConsumerFixture(t *testing.T) *semanticMetadataMetrics {
+	t.Helper()
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				ModelName:   "orders",
+				GrainEntity: "order",
+				Entities: map[string]semanticmodel.EntityDefinition{
+					"order": {Type: "primary", Fields: []string{"allowed"}},
+				},
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"allowed": {Field: "orders.allowed", Table: "orders", Name: "allowed", Type: "string", Datatype: semanticmodel.DataTypeString},
+					"status":  {Field: "orders.status", Table: "orders", Name: "status", Type: "string", Datatype: semanticmodel.DataTypeString},
+				},
+			},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"logicalAllowed": {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.allowed"}}},
+			"logicalStatus":  {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.status"}}},
+		},
+	}
+	planner, err := semanticquery.NewCompiledPlanner(model, semanticquery.WithTableRelation(func(table string) (string, error) { return table, nil }))
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := semanticquery.NewSemanticAccessConsumer(planner, semanticquery.SemanticAccessConsumerConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &semanticMetadataMetrics{semanticProjectionMetrics: semanticProjectionMetrics{model: model, planner: planner, plannerOkay: true}, consumer: consumer}
 }
 
 func TestSemanticConsumerMetadataFailsClosedForUnknownModel(t *testing.T) {

--- a/internal/dashboard/semanticapi/semantic_authorization_test.go
+++ b/internal/dashboard/semanticapi/semantic_authorization_test.go
@@ -1,0 +1,67 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+)
+
+type semanticAuthorizationCapabilityMetrics struct {
+	semanticProjectionMetrics
+	plannerErr error
+	targets    []semanticquery.SemanticAccessTarget
+	fields     [][3]string
+}
+
+func (m *semanticAuthorizationCapabilityMetrics) SemanticPlanner(context.Context, string) (*semanticquery.Planner, error) {
+	return nil, m.plannerErr
+}
+
+func (m *semanticAuthorizationCapabilityMetrics) AuthorizeSemanticTarget(_ context.Context, _ string, target semanticquery.SemanticAccessTarget) error {
+	m.targets = append(m.targets, target)
+	return nil
+}
+
+func (m *semanticAuthorizationCapabilityMetrics) AuthorizeSemanticField(_ context.Context, _ string, dataset, field string) error {
+	m.fields = append(m.fields, [3]string{dataset, field})
+	return nil
+}
+
+func TestSemanticPlannerForRequestFailsClosedWhenContextAuthorityErrors(t *testing.T) {
+	model := &semanticmodel.Model{Name: "sales"}
+	metrics := &semanticAuthorizationCapabilityMetrics{
+		semanticProjectionMetrics: semanticProjectionMetrics{model: model},
+		plannerErr:                errors.New("authority unavailable"),
+	}
+	if _, err := semanticPlannerForRequest(context.Background(), metrics, "sales"); !errors.Is(err, metrics.plannerErr) {
+		t.Fatalf("planner error = %v, want authority error", err)
+	}
+}
+
+func TestAuthorizeSemanticRequestUsesFieldCapabilityForQualifiedPhysicalDimension(t *testing.T) {
+	model := &semanticmodel.Model{Name: "sales"}
+	metrics := &semanticAuthorizationCapabilityMetrics{semanticProjectionMetrics: semanticProjectionMetrics{model: model}}
+	request := semanticquery.Request{
+		Dataset:    "orders",
+		Dimensions: []semanticquery.Field{{Field: "orders.created_at"}},
+	}
+	if err := authorizeSemanticRequest(context.Background(), metrics, "sales", request); err != nil {
+		t.Fatalf("authorize request: %v", err)
+	}
+	if len(metrics.targets) != 1 || metrics.targets[0] != (semanticquery.SemanticAccessTarget{Dataset: "orders"}) {
+		t.Fatalf("targets = %#v, want dataset only", metrics.targets)
+	}
+	if len(metrics.fields) != 1 || metrics.fields[0] != [3]string{"orders", "orders.created_at", ""} {
+		t.Fatalf("fields = %#v", metrics.fields)
+	}
+}
+
+func TestSemanticConsumerMetadataFailsClosedForUnknownModel(t *testing.T) {
+	metrics := semanticProjectionMetrics{}
+	if err := authorizeSemanticTarget(context.Background(), metrics, "missing", semanticquery.SemanticAccessTarget{Dataset: "orders"}); !semanticAuthorizationUnavailable(err) {
+		t.Fatalf("error = %v, want unavailable", err)
+	}
+}

--- a/internal/dashboard/semanticapi/semantic_consumer_metadata_integration_test.go
+++ b/internal/dashboard/semanticapi/semantic_consumer_metadata_integration_test.go
@@ -252,8 +252,11 @@ func semanticMetadataConsumerFixtureWithRole(t *testing.T, includeRole bool) (*s
 		},
 		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
 		Dimensions: map[string]semanticmodel.SemanticDimension{
-			"allowed": {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.allowed"}}},
-			"denied":  {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.denied"}}},
+			// Keep the authorized semantic identity distinct from the physical
+			// field name. The colliding semantic member below intentionally uses
+			// the short name allowed but binds to the denied physical field.
+			"logicalAllowed": {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.allowed"}}},
+			"allowed":        {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.denied"}}},
 		},
 		AccessPolicy: semanticmodel.SemanticAccessPolicy{
 			AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{
@@ -262,8 +265,8 @@ func semanticMetadataConsumerFixtureWithRole(t *testing.T, includeRole bool) (*s
 			},
 			Datasets: map[string]semanticmodel.SemanticDatasetAccessSpec{"orders": {RequiredAccessGrants: []string{"view_allowed"}}},
 			Dimensions: map[string][]string{
-				"allowed": {"view_allowed"},
-				"denied":  {"view_denied"},
+				"logicalAllowed": {"view_allowed"},
+				"allowed":        {"view_denied"},
 			},
 		},
 	}

--- a/internal/dashboard/semanticapi/semantic_consumer_metadata_integration_test.go
+++ b/internal/dashboard/semanticapi/semantic_consumer_metadata_integration_test.go
@@ -1,0 +1,318 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	"github.com/flidai/leapview/internal/dashboard"
+	"github.com/flidai/leapview/internal/dashboard/api"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/internal/semanticvalue"
+	"github.com/go-chi/chi/v5"
+)
+
+type semanticMetadataAuthority struct {
+	snapshot semanticquery.SemanticAccessAttributeSnapshot
+	current  semanticquery.SemanticAccessAuthority
+}
+
+func (a *semanticMetadataAuthority) get() (semanticquery.SemanticAccessAttributeSnapshot, semanticquery.SemanticAccessAuthority, error) {
+	return a.snapshot, a.current, nil
+}
+
+type semanticMetadataMetrics struct {
+	semanticProjectionMetrics
+	consumer *semanticquery.SemanticAccessConsumer
+}
+
+func (m *semanticMetadataMetrics) SemanticConsumer(context.Context, string) (*semanticquery.SemanticAccessConsumer, error) {
+	return m.consumer, nil
+}
+
+func (m *semanticMetadataMetrics) SemanticModel(modelID string) (*semanticmodel.Model, bool) {
+	if m.model == nil || modelID != m.model.Name {
+		return nil, false
+	}
+	return m.model, true
+}
+
+func TestSemanticMetadataUsesRealConsumerToFilterMembersAndRejectStalePin(t *testing.T) {
+	metrics, authority := semanticMetadataConsumerFixture(t)
+	handler := Handler{
+		Metrics:          metrics,
+		ResolveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return "project:test", nil },
+		AuthorizeListResource: func(context.Context, string, projectgraph.ResourceID, access.ResourceRef, access.Capability) (bool, error) {
+			return true, nil
+		},
+	}
+
+	datasetResponse := invokeSemanticMetadata(t, handler, false)
+	if datasetResponse.Code != http.StatusOK {
+		t.Fatalf("dataset metadata status = %d, body = %s", datasetResponse.Code, datasetResponse.Body.String())
+	}
+	var datasets api.SemanticDatasetListResponse
+	if err := json.Unmarshal(datasetResponse.Body.Bytes(), &datasets); err != nil {
+		t.Fatal(err)
+	}
+	if len(datasets.Items) != 0 {
+		t.Fatalf("datasets = %#v, want whole-dataset metadata denied when a member is denied", datasets.Items)
+	}
+	detail := invokeSemanticDatasetDetail(t, handler)
+	if detail.Code != http.StatusForbidden {
+		t.Fatalf("dataset detail status = %d, body = %s", detail.Code, detail.Body.String())
+	}
+
+	fieldResponse := invokeSemanticMetadata(t, handler, true)
+	if fieldResponse.Code != http.StatusOK {
+		t.Fatalf("field metadata status = %d, body = %s", fieldResponse.Code, fieldResponse.Body.String())
+	}
+	var fields api.SemanticFieldListResponse
+	if err := json.Unmarshal(fieldResponse.Body.Bytes(), &fields); err != nil {
+		t.Fatal(err)
+	}
+	if len(fields.Items) != 1 || fields.Items[0].Name != "allowed" {
+		t.Fatalf("fields = %#v, want only the authorized member", fields.Items)
+	}
+
+	// The consumer captures the original decision digest. Changing the
+	// authority behind that pinned consumer must fail the whole protected
+	// metadata response instead of projecting a mixed decision.
+	authority.snapshot.EffectiveAttributes = nil
+	authority.snapshot.EffectiveAttributeDigest, _ = semanticquery.EffectiveSemanticAttributeDigest(nil)
+	authority.snapshot.DirectAssignmentEvidence = access.SemanticAttributeDirectEvidence{}
+	staleResponse := invokeSemanticMetadata(t, handler, true)
+	if staleResponse.Code != http.StatusForbidden {
+		t.Fatalf("stale field metadata status = %d, body = %s", staleResponse.Code, staleResponse.Body.String())
+	}
+}
+
+func TestSemanticMetadataRejectsProtectedConsumerForAnotherModelID(t *testing.T) {
+	metrics, _ := semanticMetadataConsumerFixture(t)
+	if _, err := semanticConsumerForRequest(context.Background(), metrics, "other-model"); err == nil {
+		t.Fatal("protected consumer composed for sales was accepted for another model ID")
+	}
+}
+
+func TestSemanticMetadataDoesNotAuthorizeDimensionAsSameNamedMetric(t *testing.T) {
+	metrics, authority := semanticMetadataConsumerFixture(t)
+	metrics.model.Metrics = map[string]semanticmodel.Metric{"denied": {Type: "aggregate", Dataset: "orders", Aggregation: "count", Input: &semanticmodel.MetricInput{Field: "orders.allowed"}}}
+	planner, err := semanticquery.NewCompiledPlanner(metrics.model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics.planner = planner
+	metrics.consumer, err = semanticquery.NewSemanticAccessConsumer(planner, semanticquery.SemanticAccessConsumerConfig{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "sales", Generation: "generation-1", PrincipalID: "alice", Authority: authority.get,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := Handler{Metrics: metrics,
+		ResolveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return "project:test", nil },
+		AuthorizeListResource: func(context.Context, string, projectgraph.ResourceID, access.ResourceRef, access.Capability) (bool, error) {
+			return true, nil
+		},
+	}
+	response := invokeSemanticMetadata(t, handler, true)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var fields api.SemanticFieldListResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &fields); err != nil {
+		t.Fatal(err)
+	}
+	foundMetric := false
+	for _, field := range fields.Items {
+		if field.Name != "denied" {
+			continue
+		}
+		if field.Kind != "metric" {
+			t.Fatalf("denied dimension inherited metric authorization: %#v", field)
+		}
+		foundMetric = true
+	}
+	if !foundMetric {
+		t.Fatal("authorized same-named metric was omitted")
+	}
+}
+
+func TestSemanticModelListHidesProtectedModelWithoutAuthorizedDataset(t *testing.T) {
+	metrics, _ := semanticMetadataConsumerFixtureWithRole(t, false)
+	metrics.catalog = dashboard.Catalog{Models: []dashboard.CatalogModel{{ID: "sales"}}}
+	handler := Handler{
+		Metrics:          metrics,
+		ResolveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return "project:test", nil },
+		AuthorizeListResource: func(context.Context, string, projectgraph.ResourceID, access.ResourceRef, access.Capability) (bool, error) {
+			return true, nil
+		},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/semantic-models", nil)
+	request.Header.Set("X-Serving-Snapshot", "generation-1")
+	recorder := httptest.NewRecorder()
+	handler.ListSemanticModels(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("model list status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response api.SemanticModelListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Items) != 0 {
+		t.Fatalf("protected model list = %#v, want denied model omitted", response.Items)
+	}
+}
+
+func TestSemanticModelListHidesUnknownCatalogEntry(t *testing.T) {
+	metrics, _ := semanticMetadataConsumerFixture(t)
+	metrics.catalog = dashboard.Catalog{Models: []dashboard.CatalogModel{{ID: "unknown"}}}
+	handler := Handler{
+		Metrics:          metrics,
+		ResolveProjectID: func(context.Context) (projectgraph.ResourceID, error) { return "project:test", nil },
+		AuthorizeListResource: func(context.Context, string, projectgraph.ResourceID, access.ResourceRef, access.Capability) (bool, error) {
+			return true, nil
+		},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/semantic-models", nil)
+	request.Header.Set("X-Serving-Snapshot", "generation-1")
+	recorder := httptest.NewRecorder()
+	handler.ListSemanticModels(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unknown model list status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response api.SemanticModelListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Items) != 0 {
+		t.Fatalf("unknown model list = %#v, want entry omitted", response.Items)
+	}
+}
+
+func invokeSemanticMetadata(t *testing.T, handler Handler, fields bool) *httptest.ResponseRecorder {
+	t.Helper()
+	route := chi.NewRouteContext()
+	route.URLParams.Add("model", "sales")
+	if fields {
+		route.URLParams.Add("dataset", "orders")
+	}
+	request := httptest.NewRequest(http.MethodGet, "/semantic-models/sales", nil)
+	request.Header.Set("X-Serving-Snapshot", "generation-1")
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, route))
+	recorder := httptest.NewRecorder()
+	if fields {
+		handler.ListSemanticFields(recorder, request)
+	} else {
+		handler.ListSemanticDatasets(recorder, request)
+	}
+	return recorder
+}
+
+func invokeSemanticDatasetDetail(t *testing.T, handler Handler) *httptest.ResponseRecorder {
+	t.Helper()
+	route := chi.NewRouteContext()
+	route.URLParams.Add("model", "sales")
+	route.URLParams.Add("dataset", "orders")
+	request := httptest.NewRequest(http.MethodGet, "/semantic-models/sales/datasets/orders", nil)
+	request.Header.Set("X-Serving-Snapshot", "generation-1")
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, route))
+	recorder := httptest.NewRecorder()
+	handler.GetSemanticDataset(recorder, request)
+	return recorder
+}
+
+func semanticMetadataConsumerFixture(t *testing.T) (*semanticMetadataMetrics, *semanticMetadataAuthority) {
+	return semanticMetadataConsumerFixtureWithRole(t, true)
+}
+
+func semanticMetadataConsumerFixtureWithRole(t *testing.T, includeRole bool) (*semanticMetadataMetrics, *semanticMetadataAuthority) {
+	t.Helper()
+	literal, err := semanticmodel.NewSemanticAccessLiteral("member")
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				ModelName:   "orders",
+				GrainEntity: "order",
+				Entities:    map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"allowed"}}},
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"allowed": {Field: "orders.allowed", Table: "orders", Name: "allowed", Type: "string", Datatype: semanticmodel.DataTypeString},
+					"denied":  {Field: "orders.denied", Table: "orders", Name: "denied", Type: "string", Datatype: semanticmodel.DataTypeString},
+				},
+			},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"allowed": {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.allowed"}}},
+			"denied":  {Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.denied"}}},
+		},
+		AccessPolicy: semanticmodel.SemanticAccessPolicy{
+			AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{
+				"view_allowed": {UserAttribute: "role", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal}},
+				"view_denied":  {UserAttribute: "denied_role", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal}},
+			},
+			Datasets: map[string]semanticmodel.SemanticDatasetAccessSpec{"orders": {RequiredAccessGrants: []string{"view_allowed"}}},
+			Dimensions: map[string][]string{
+				"allowed": {"view_allowed"},
+				"denied":  {"view_denied"},
+			},
+		},
+	}
+	planner, err := semanticquery.NewCompiledPlanner(model, semanticquery.WithTableRelation(func(table string) (string, error) { return table, nil }))
+	if err != nil {
+		t.Fatal(err)
+	}
+	role := semanticMetadataDefinition("def-role", "role")
+	deniedRole := semanticMetadataDefinition("def-denied-role", "denied_role")
+	definitions := []access.SemanticAttributeDefinition{role, deniedRole}
+	registryDigest, err := access.SemanticAttributeRegistryDigest(semanticvalue.Profile, definitions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := access.SemanticAttributeRegistrySnapshot{State: access.SemanticAttributeRegistryState{Profile: semanticvalue.Profile, Revision: 1, Digest: registryDigest}, Definitions: definitions}
+	values, valueDigest, err := access.CanonicalSemanticAttributeValues(role, "member")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: "alice"}
+	assignment := access.SemanticAttributeAssignment{ID: "assignment-role", DefinitionID: role.ID, DefinitionName: role.Name, DefinitionVersion: role.DefinitionVersion, Type: role.Type, Shape: role.Shape, Subject: subject, CanonicalValues: values, ValueDigest: valueDigest, AssignmentVersion: 1}
+	attributes := []access.EffectiveSemanticAttribute(nil)
+	assignments := []access.SemanticAttributeAssignment(nil)
+	if includeRole {
+		attributes = []access.EffectiveSemanticAttribute{{DefinitionID: role.ID, DefinitionName: role.Name, DefinitionVersion: role.DefinitionVersion, Type: role.Type, Shape: role.Shape, CanonicalValues: values, ValueDigest: valueDigest, Source: "direct"}}
+		assignments = []access.SemanticAttributeAssignment{assignment}
+	}
+	controlDigest, err := access.SemanticAttributeControlDigest(assignments, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control := access.SemanticAttributeControlSnapshot{State: access.SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 1, Digest: controlDigest}, Assignments: assignments}
+	resolution := access.SemanticAttributeResolution{Subject: subject, Subjects: []access.SubjectRef{subject}, Registry: registry, Control: control, Attributes: attributes, ObservedAt: time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)}
+	snapshot, authority, err := semanticquery.SemanticAccessResolutionSnapshot("instance-1", "alice", resolution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorityState := &semanticMetadataAuthority{snapshot: snapshot, current: authority}
+	consumer, err := semanticquery.NewSemanticAccessConsumer(planner, semanticquery.SemanticAccessConsumerConfig{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "sales", Generation: "generation-1", PrincipalID: "alice",
+		Authority: authorityState.get,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics := &semanticMetadataMetrics{semanticProjectionMetrics: semanticProjectionMetrics{model: model, planner: planner, plannerOkay: true}, consumer: consumer}
+	return metrics, authorityState
+}
+
+func semanticMetadataDefinition(id, name string) access.SemanticAttributeDefinition {
+	return access.SemanticAttributeDefinition{ID: id, Name: name, Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar, Profile: semanticvalue.Profile, DefinitionVersion: 1, LifecycleState: access.SemanticAttributeActive, Enabled: true, Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}}}
+}

--- a/internal/dashboard/semanticapi/semantic_datasets.go
+++ b/internal/dashboard/semanticapi/semantic_datasets.go
@@ -1,17 +1,36 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	nethttp "net/http"
 
 	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	"github.com/flidai/leapview/internal/dashboard/api"
+	reportdef "github.com/flidai/leapview/internal/dashboard/report"
 	"github.com/go-chi/chi/v5"
 )
 
 func (h Handler) ListSemanticDatasets(w nethttp.ResponseWriter, r *nethttp.Request) {
 	model, ok := h.semanticModelForRequest(w, r)
 	if !ok {
+		return
+	}
+	modelID := chi.URLParam(r, "model")
+	ctx, err := semanticConsumerForRequest(r.Context(), h.Metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	allowed, err := h.authorizeSemanticModelResource(r, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	if !allowed {
+		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
 		return
 	}
 	compiled := compiledSemanticModel(h.Metrics, chi.URLParam(r, "model"))
@@ -31,16 +50,32 @@ func (h Handler) ListSemanticDatasets(w nethttp.ResponseWriter, r *nethttp.Reque
 			MetricCount: semanticDatasetMetricCount(model, datasetID),
 		})
 	}
-	modelID := chi.URLParam(r, "model")
-	allowed, err := h.authorizeSemanticModel(r, modelID)
-	if err != nil {
-		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
-		return
+	filtered := out[:0]
+	for _, item := range out {
+		if err := authorizeSemanticTarget(ctx, h.Metrics, modelID, semanticquery.SemanticAccessTarget{Dataset: item.ID}); err != nil {
+			if protectedSemanticModel(h.Metrics, modelID) && semanticMemberDenied(err) {
+				continue
+			}
+			status := nethttp.StatusServiceUnavailable
+			if !semanticAuthorizationUnavailable(err) {
+				status = nethttp.StatusForbidden
+			}
+			writeJSONError(w, err, status)
+			return
+		}
+		if protectedSemanticModel(h.Metrics, modelID) {
+			dataset, _ := compiled.Dataset(item.ID)
+			if err := authorizeSemanticDatasetMembers(ctx, h.Metrics, modelID, item.ID, model, dataset.Table()); err != nil {
+				if semanticMemberDenied(err) {
+					continue
+				}
+				writeJSONError(w, err, semanticAuthorizationStatus(err))
+				return
+			}
+		}
+		filtered = append(filtered, item)
 	}
-	if !allowed {
-		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
-		return
-	}
+	out = filtered
 	items, nextCursor, ok := pageSliceForRequest(w, r, out)
 	if !ok {
 		return
@@ -53,7 +88,45 @@ func (h Handler) GetSemanticDataset(w nethttp.ResponseWriter, r *nethttp.Request
 	if !ok {
 		return
 	}
+	modelID := chi.URLParam(r, "model")
+	ctx, err := semanticConsumerForRequest(r.Context(), h.Metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	if err := authorizeSemanticTarget(ctx, h.Metrics, modelID, semanticquery.SemanticAccessTarget{Dataset: datasetID}); err != nil {
+		writeJSONError(w, err, semanticAuthorizationStatus(err))
+		return
+	}
+	if protectedSemanticModel(h.Metrics, modelID) {
+		if err := authorizeSemanticDatasetMembers(ctx, h.Metrics, modelID, datasetID, model, table); err != nil {
+			writeJSONError(w, err, semanticAuthorizationStatus(err))
+			return
+		}
+	}
 	writeJSON(w, nethttp.StatusOK, SemanticTableProjection(model, datasetID, table))
+}
+
+// authorizeSemanticDatasetMembers protects whole-dataset responses whose
+// counts, entities, or descriptions cannot safely be filtered per member.
+// A denied member therefore denies the complete protected projection.
+func authorizeSemanticDatasetMembers(ctx context.Context, metrics Metrics, modelID, datasetID string, model *semanticmodel.Model, table semanticmodel.Table) error {
+	for _, field := range sortedMapKeys(table.Dimensions) {
+		// Table dimensions are physical fields even when a same-named metric
+		// exists in the semantic namespace; never infer kind from the name.
+		if err := authorizeSemanticField(ctx, metrics, modelID, datasetID, field); err != nil {
+			return err
+		}
+	}
+	for _, metric := range sortedMapKeys(model.Metrics) {
+		if model.Metrics[metric].Dataset != datasetID {
+			continue
+		}
+		if err := authorizeSemanticTarget(ctx, metrics, modelID, semanticquery.SemanticAccessTarget{Dataset: datasetID, Metric: metric}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (h Handler) ListSemanticFields(w nethttp.ResponseWriter, r *nethttp.Request) {
@@ -62,6 +135,34 @@ func (h Handler) ListSemanticFields(w nethttp.ResponseWriter, r *nethttp.Request
 		return
 	}
 	fields := SemanticDatasetFieldsProjection(model, datasetID, table)
+	authorized := fields[:0]
+	modelID := chi.URLParam(r, "model")
+	ctx, err := semanticConsumerForRequest(r.Context(), h.Metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	for _, field := range fields {
+		var fieldErr error
+		if field.Kind == "metric" {
+			fieldErr = authorizeSemanticTarget(ctx, h.Metrics, modelID, semanticquery.SemanticAccessTarget{Dataset: datasetID, Metric: field.Name})
+		} else {
+			fieldErr = authorizeSemanticField(ctx, h.Metrics, modelID, datasetID, field.Name)
+		}
+		if fieldErr != nil {
+			if protectedSemanticModel(h.Metrics, modelID) && semanticMemberDenied(fieldErr) {
+				continue
+			}
+			status := nethttp.StatusServiceUnavailable
+			if !semanticAuthorizationUnavailable(fieldErr) {
+				status = nethttp.StatusForbidden
+			}
+			writeJSONError(w, fieldErr, status)
+			return
+		}
+		authorized = append(authorized, field)
+	}
+	fields = authorized
 	items, nextCursor, ok := pageSliceForRequest(w, r, fields)
 	if !ok {
 		return
@@ -80,6 +181,11 @@ func (h Handler) QuerySemanticDataset(w nethttp.ResponseWriter, r *nethttp.Reque
 		return
 	}
 	modelID, datasetID := chi.URLParam(r, "model"), chi.URLParam(r, "dataset")
+	ctx, err := semanticConsumerForRequest(r.Context(), metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
 	if _, _, _, ok := h.semanticDatasetForRequest(w, r); !ok {
 		return
 	}
@@ -99,12 +205,16 @@ func (h Handler) QuerySemanticDataset(w nethttp.ResponseWriter, r *nethttp.Reque
 		writeJSONError(w, err, statusForCursorError(err))
 		return
 	}
-	plan, err := semanticExplainAggregate(metrics, modelID, request)
+	if err := authorizeSemanticRequest(ctx, metrics, modelID, reportdef.SemanticAggregateRequest(request)); err != nil {
+		writeJSONError(w, err, semanticRequestAuthorizationStatus(metrics, modelID, err))
+		return
+	}
+	plan, err := semanticExplainAggregate(ctx, metrics, modelID, request)
 	if err != nil {
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return
 	}
-	ctx := dataquery.WithMetadata(r.Context(), h.requestQueryMetadata(r, dataquery.SurfaceAPI, dataquery.OperationAPIQuery, "semantic_dataset", modelID+":"+datasetID))
+	ctx = dataquery.WithMetadata(ctx, h.requestQueryMetadata(r, dataquery.SurfaceAPI, dataquery.OperationAPIQuery, "semantic_dataset", modelID+":"+datasetID))
 	if acceptsMediaType(r.Header.Get("Accept"), arrowStreamMediaType) {
 		writeSemanticArrowResponse(w, r.WithContext(ctx), metrics, aggregateDataQuery(modelID, request), limit, request.Offset, queryID, snapshot, scope)
 		return
@@ -130,6 +240,11 @@ func (h Handler) PreviewSemanticDataset(w nethttp.ResponseWriter, r *nethttp.Req
 		return
 	}
 	modelID, datasetID := chi.URLParam(r, "model"), chi.URLParam(r, "dataset")
+	ctx, err := semanticConsumerForRequest(r.Context(), metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
 	if _, _, _, ok := h.semanticDatasetForRequest(w, r); !ok {
 		return
 	}
@@ -149,12 +264,16 @@ func (h Handler) PreviewSemanticDataset(w nethttp.ResponseWriter, r *nethttp.Req
 		writeJSONError(w, err, statusForCursorError(err))
 		return
 	}
-	plan, err := semanticExplainRows(metrics, modelID, request)
+	if err := authorizeSemanticRequest(ctx, metrics, modelID, reportdef.SemanticRowRequest(request)); err != nil {
+		writeJSONError(w, err, semanticRequestAuthorizationStatus(metrics, modelID, err))
+		return
+	}
+	plan, err := semanticExplainRows(ctx, metrics, modelID, request)
 	if err != nil {
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return
 	}
-	ctx := dataquery.WithMetadata(r.Context(), h.requestQueryMetadata(r, dataquery.SurfaceAPI, dataquery.OperationAPIPreview, "semantic_dataset", modelID+":"+datasetID))
+	ctx = dataquery.WithMetadata(ctx, h.requestQueryMetadata(r, dataquery.SurfaceAPI, dataquery.OperationAPIPreview, "semantic_dataset", modelID+":"+datasetID))
 	if acceptsMediaType(r.Header.Get("Accept"), arrowStreamMediaType) {
 		writeSemanticArrowResponse(w, r.WithContext(ctx), metrics, previewDataQuery(modelID, request), limit, request.Offset, queryID, snapshot, scope)
 		return
@@ -180,6 +299,11 @@ func (h Handler) ExplainSemanticQuery(w nethttp.ResponseWriter, r *nethttp.Reque
 		return
 	}
 	modelID, datasetID := chi.URLParam(r, "model"), chi.URLParam(r, "dataset")
+	ctx, err := semanticConsumerForRequest(r.Context(), metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
 	if _, _, _, ok := h.semanticDatasetForRequest(w, r); !ok {
 		return
 	}
@@ -193,7 +317,11 @@ func (h Handler) ExplainSemanticQuery(w nethttp.ResponseWriter, r *nethttp.Reque
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return
 	}
-	plan, err := semanticExplainAggregate(metrics, modelID, request)
+	if err := authorizeSemanticRequest(ctx, metrics, modelID, reportdef.SemanticAggregateRequest(request)); err != nil {
+		writeJSONError(w, err, semanticRequestAuthorizationStatus(metrics, modelID, err))
+		return
+	}
+	plan, err := semanticExplainAggregate(ctx, metrics, modelID, request)
 	if err != nil {
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return
@@ -212,6 +340,11 @@ func (h Handler) ExplainSemanticPreview(w nethttp.ResponseWriter, r *nethttp.Req
 		return
 	}
 	modelID, datasetID := chi.URLParam(r, "model"), chi.URLParam(r, "dataset")
+	ctx, err := semanticConsumerForRequest(r.Context(), metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
 	if _, _, _, ok := h.semanticDatasetForRequest(w, r); !ok {
 		return
 	}
@@ -225,7 +358,11 @@ func (h Handler) ExplainSemanticPreview(w nethttp.ResponseWriter, r *nethttp.Req
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return
 	}
-	plan, err := semanticExplainRows(metrics, modelID, request)
+	if err := authorizeSemanticRequest(ctx, metrics, modelID, reportdef.SemanticRowRequest(request)); err != nil {
+		writeJSONError(w, err, semanticRequestAuthorizationStatus(metrics, modelID, err))
+		return
+	}
+	plan, err := semanticExplainRows(ctx, metrics, modelID, request)
 	if err != nil {
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return

--- a/internal/dashboard/semanticapi/semantic_datasets.go
+++ b/internal/dashboard/semanticapi/semantic_datasets.go
@@ -114,7 +114,7 @@ func authorizeSemanticDatasetMembers(ctx context.Context, metrics Metrics, model
 	for _, field := range sortedMapKeys(table.Dimensions) {
 		// Table dimensions are physical fields even when a same-named metric
 		// exists in the semantic namespace; never infer kind from the name.
-		if err := authorizeSemanticField(ctx, metrics, modelID, datasetID, field); err != nil {
+		if err := authorizeSemanticField(ctx, metrics, modelID, datasetID, datasetID+"."+field); err != nil {
 			return err
 		}
 	}
@@ -147,7 +147,7 @@ func (h Handler) ListSemanticFields(w nethttp.ResponseWriter, r *nethttp.Request
 		if field.Kind == "metric" {
 			fieldErr = authorizeSemanticTarget(ctx, h.Metrics, modelID, semanticquery.SemanticAccessTarget{Dataset: datasetID, Metric: field.Name})
 		} else {
-			fieldErr = authorizeSemanticField(ctx, h.Metrics, modelID, datasetID, field.Name)
+			fieldErr = authorizeSemanticField(ctx, h.Metrics, modelID, datasetID, field.ID)
 		}
 		if fieldErr != nil {
 			if protectedSemanticModel(h.Metrics, modelID) && semanticMemberDenied(fieldErr) {

--- a/internal/dashboard/semanticapi/semantic_models.go
+++ b/internal/dashboard/semanticapi/semantic_models.go
@@ -5,6 +5,7 @@ import (
 	nethttp "net/http"
 	"sort"
 
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	"github.com/flidai/leapview/internal/dashboard/api"
 	"github.com/go-chi/chi/v5"
 )
@@ -21,12 +22,55 @@ func (h Handler) ListSemanticModels(w nethttp.ResponseWriter, r *nethttp.Request
 	}
 	filtered := make([]api.SemanticModelSummary, 0, len(out))
 	for _, row := range out {
-		allowed, err := h.authorizeSemanticModel(r, row.ID)
+		model := semanticModelForID(metrics, row.ID)
+		planner, plannerOK := semanticPlanner(metrics, row.ID)
+		if model == nil || !plannerOK || planner == nil || planner.CompiledModel() == nil || !planner.CompiledModel().MatchesModel(model) {
+			// Catalog entries without a current, lineage-matching activation
+			// snapshot are not authoritative metadata and must not be listed.
+			continue
+		}
+		allowed, err := h.authorizeSemanticModelResource(r, row.ID)
 		if err != nil {
 			writeJSONError(w, err, nethttp.StatusServiceUnavailable)
 			return
 		}
 		if allowed {
+			scoped := r.Context()
+			consumer, consumerOK := (*semanticquery.SemanticAccessConsumer)(nil), false
+			if _, hasProvider := any(metrics).(semanticContextConsumerProvider); hasProvider {
+				var consumerErr error
+				scoped, consumerErr = semanticConsumerForRequest(scoped, metrics, row.ID)
+				if consumerErr != nil {
+					writeJSONError(w, consumerErr, nethttp.StatusServiceUnavailable)
+					return
+				}
+				consumer, consumerOK = semanticConsumerFromContext(scoped, row.ID)
+				if !consumerOK {
+					writeJSONError(w, errSemanticConsumerUnavailable, nethttp.StatusServiceUnavailable)
+					return
+				}
+			}
+			if protectedSemanticModel(metrics, row.ID) {
+				if !consumerOK {
+					writeJSONError(w, errSemanticConsumerUnavailable, nethttp.StatusServiceUnavailable)
+					return
+				}
+				assets, assetsErr := consumer.Assets()
+				if assetsErr != nil {
+					writeJSONError(w, assetsErr, nethttp.StatusServiceUnavailable)
+					return
+				}
+				hasDataset := false
+				for _, asset := range assets {
+					if asset.Kind == "dataset" {
+						hasDataset = true
+						break
+					}
+				}
+				if !hasDataset {
+					continue
+				}
+			}
 			filtered = append(filtered, row)
 		}
 	}
@@ -53,6 +97,13 @@ func (h Handler) GetSemanticModel(w nethttp.ResponseWriter, r *nethttp.Request) 
 		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
 		return
 	}
+	if allowed, err := h.authorizeSemanticModel(r, modelID); err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	} else if !allowed {
+		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
+		return
+	}
 	writeJSON(w, nethttp.StatusOK, model)
 }
 
@@ -62,6 +113,59 @@ func (h Handler) ListSemanticModelFields(w nethttp.ResponseWriter, r *nethttp.Re
 		return
 	}
 	fields := SemanticModelFieldsProjection(model)
+	modelID := chi.URLParam(r, "model")
+	ctx, err := semanticConsumerForRequest(r.Context(), h.Metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	if !protectedSemanticModel(h.Metrics, modelID) {
+		items, nextCursor, ok := pageSliceForRequest(w, r, fields)
+		if !ok {
+			return
+		}
+		writeJSON(w, nethttp.StatusOK, api.SemanticFieldListResponse{Items: items, Page: api.PageInfo{NextCursor: nextCursor}})
+		return
+	}
+	authorized := fields[:0]
+	for _, field := range fields {
+		allowed := false
+		if field.Kind == "metric" {
+			if err := authorizeSemanticTarget(ctx, h.Metrics, modelID, semanticquery.SemanticAccessTarget{Metric: field.Name, Dataset: field.Dataset}); err != nil {
+				if semanticAuthorizationUnavailable(err) {
+					writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+					return
+				}
+				if !semanticMemberDenied(err) {
+					writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+					return
+				}
+			} else {
+				allowed = true
+			}
+		} else if dimension, exists := model.Dimensions[field.Name]; exists {
+			datasets := sortedMapKeys(dimension.Bindings)
+			for _, dataset := range datasets {
+				if err := authorizeSemanticField(ctx, h.Metrics, modelID, dataset, field.Name); err != nil {
+					if semanticAuthorizationUnavailable(err) {
+						writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+						return
+					}
+					if !semanticMemberDenied(err) {
+						writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+						return
+					}
+					continue
+				}
+				allowed = true
+				break
+			}
+		}
+		if allowed {
+			authorized = append(authorized, field)
+		}
+	}
+	fields = authorized
 	items, nextCursor, ok := pageSliceForRequest(w, r, fields)
 	if !ok {
 		return
@@ -74,8 +178,21 @@ func (h Handler) ListSemanticRelationships(w nethttp.ResponseWriter, r *nethttp.
 	if !ok {
 		return
 	}
+	modelID := chi.URLParam(r, "model")
+	ctx, err := semanticConsumerForRequest(r.Context(), h.Metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
 	items := make([]api.SemanticRelationshipResponse, 0, len(model.Relationships))
 	for _, relationship := range model.Relationships {
+		if err := authorizeSemanticRelationship(ctx, h.Metrics, modelID, relationship); err != nil {
+			if semanticAuthorizationUnavailable(err) {
+				writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+				return
+			}
+			continue
+		}
 		item, err := semanticRelationshipDTO(relationship)
 		if err != nil {
 			writeJSONError(w, err, nethttp.StatusInternalServerError)
@@ -94,6 +211,16 @@ func (h Handler) ListSemanticRelationships(w nethttp.ResponseWriter, r *nethttp.
 func (h Handler) ListSemanticSources(w nethttp.ResponseWriter, r *nethttp.Request) {
 	model, ok := h.semanticModelForRequest(w, r)
 	if !ok {
+		return
+	}
+	modelID := chi.URLParam(r, "model")
+	ctx, err := semanticConsumerForRequest(r.Context(), h.Metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	if err := authorizeSemanticModelProjection(ctx, h.Metrics, modelID); err != nil {
+		writeJSONError(w, err, semanticAuthorizationStatus(err))
 		return
 	}
 	names := make([]string, 0, len(model.Sources))

--- a/internal/dashboard/semanticapi/semantic_queries.go
+++ b/internal/dashboard/semanticapi/semantic_queries.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flidai/leapview/internal/analytics/dataquery"
 	"github.com/flidai/leapview/internal/dashboard/api"
+	reportdef "github.com/flidai/leapview/internal/dashboard/report"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -20,6 +21,20 @@ func (h Handler) QuerySemanticModel(w nethttp.ResponseWriter, r *nethttp.Request
 		return
 	}
 	modelID := chi.URLParam(r, "model")
+	ctx, err := semanticConsumerForRequest(r.Context(), metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	allowed, err := h.authorizeSemanticModelResource(r, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	if !allowed {
+		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
+		return
+	}
 	if semanticModelForID(metrics, modelID) == nil {
 		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
 		return
@@ -40,12 +55,16 @@ func (h Handler) QuerySemanticModel(w nethttp.ResponseWriter, r *nethttp.Request
 		writeJSONError(w, err, statusForCursorError(err))
 		return
 	}
-	plan, err := semanticExplainAggregate(metrics, modelID, request)
+	if err := authorizeSemanticRequest(ctx, metrics, modelID, reportdef.SemanticAggregateRequest(request)); err != nil {
+		writeJSONError(w, err, semanticRequestAuthorizationStatus(metrics, modelID, err))
+		return
+	}
+	plan, err := semanticExplainAggregate(ctx, metrics, modelID, request)
 	if err != nil {
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return
 	}
-	ctx := dataquery.WithMetadata(r.Context(), h.requestQueryMetadata(r, dataquery.SurfaceAPI, dataquery.OperationAPIQuery, "semantic_model", modelID))
+	ctx = dataquery.WithMetadata(ctx, h.requestQueryMetadata(r, dataquery.SurfaceAPI, dataquery.OperationAPIQuery, "semantic_model", modelID))
 	if acceptsMediaType(r.Header.Get("Accept"), arrowStreamMediaType) {
 		writeSemanticArrowResponse(w, r.WithContext(ctx), metrics, aggregateDataQuery(modelID, request), limit, request.Offset, queryID, snapshot, scope)
 		return
@@ -71,6 +90,20 @@ func (h Handler) ExplainSemanticModelQuery(w nethttp.ResponseWriter, r *nethttp.
 		return
 	}
 	modelID := chi.URLParam(r, "model")
+	ctx, err := semanticConsumerForRequest(r.Context(), metrics, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	allowed, err := h.authorizeSemanticModelResource(r, modelID)
+	if err != nil {
+		writeJSONError(w, err, nethttp.StatusServiceUnavailable)
+		return
+	}
+	if !allowed {
+		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
+		return
+	}
 	if semanticModelForID(metrics, modelID) == nil {
 		writeJSONError(w, fmt.Errorf("model %q not found", modelID), nethttp.StatusNotFound)
 		return
@@ -85,7 +118,11 @@ func (h Handler) ExplainSemanticModelQuery(w nethttp.ResponseWriter, r *nethttp.
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return
 	}
-	plan, err := semanticExplainAggregate(metrics, modelID, request)
+	if err := authorizeSemanticRequest(ctx, metrics, modelID, reportdef.SemanticAggregateRequest(request)); err != nil {
+		writeJSONError(w, err, semanticRequestAuthorizationStatus(metrics, modelID, err))
+		return
+	}
+	plan, err := semanticExplainAggregate(ctx, metrics, modelID, request)
 	if err != nil {
 		writeJSONError(w, err, nethttp.StatusBadRequest)
 		return

--- a/internal/dashboard/semanticapi/semantic_query_support.go
+++ b/internal/dashboard/semanticapi/semantic_query_support.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -79,18 +80,18 @@ func semanticQueryFields(fields []api.SemanticFieldRef) []reportdef.QueryField {
 	return out
 }
 
-func semanticExplainAggregate(metrics Metrics, modelID string, request reportdef.AggregateQuery) (semanticquery.Plan, error) {
-	compiled, ok := semanticPlanner(metrics, modelID)
-	if !ok {
-		return semanticquery.Plan{}, fmt.Errorf("compiled semantic planner for model %q is unavailable", modelID)
+func semanticExplainAggregate(ctx context.Context, metrics Metrics, modelID string, request reportdef.AggregateQuery) (semanticquery.Plan, error) {
+	compiled, err := semanticPlannerForRequest(ctx, metrics, modelID)
+	if err != nil {
+		return semanticquery.Plan{}, err
 	}
 	return compiled.Plan(reportdef.SemanticAggregateRequest(request))
 }
 
-func semanticExplainRows(metrics Metrics, modelID string, request reportdef.RowQuery) (semanticquery.Plan, error) {
-	compiled, ok := semanticPlanner(metrics, modelID)
-	if !ok {
-		return semanticquery.Plan{}, fmt.Errorf("compiled semantic planner for model %q is unavailable", modelID)
+func semanticExplainRows(ctx context.Context, metrics Metrics, modelID string, request reportdef.RowQuery) (semanticquery.Plan, error) {
+	compiled, err := semanticPlannerForRequest(ctx, metrics, modelID)
+	if err != nil {
+		return semanticquery.Plan{}, err
 	}
 	return compiled.PlanRows(reportdef.SemanticRowRequest(request))
 }

--- a/internal/platform/architecture/semantic_access_compiler_test.go
+++ b/internal/platform/architecture/semantic_access_compiler_test.go
@@ -9,7 +9,7 @@ import (
 
 // FAI-639 owns portable policy lowering, target qualification, and typed
 // evaluation. FAI-641 may consume that handoff only inside the planner;
-// FAI-642 still owns consumer composition and discovery.
+// FAI-642 owns the shared query consumer composition and discovery boundary.
 func TestSemanticAccessCompilerBoundaryRemainsClosedToConsumers(t *testing.T) {
 	root := repoRoot(t)
 	compiler := readArchitectureFixture(t, root, "internal/analytics/query/semantic_access_compile.go")
@@ -58,7 +58,7 @@ func TestSemanticAccessCompilerBoundaryRemainsClosedToConsumers(t *testing.T) {
 			return err
 		}
 		switch filepath.ToSlash(relative) {
-		case "internal/analytics/query/semantic_access_compile.go", "internal/analytics/query/semantic_access_evaluate.go", "internal/analytics/query/semantic_access_planner.go":
+		case "internal/analytics/query/semantic_access_compile.go", "internal/analytics/query/semantic_access_evaluate.go", "internal/analytics/query/semantic_access_planner.go", "internal/analytics/query/semantic_consumer.go":
 		default:
 			if compileCount != 0 || evaluateCount != 0 {
 				t.Errorf("semantic access bypasses the planner handoff in %s", relative)
@@ -71,10 +71,10 @@ func TestSemanticAccessCompilerBoundaryRemainsClosedToConsumers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if compileCalls != 2 || evaluateCalls != 2 {
-		t.Fatalf("expected one compiler/evaluator declaration and one planner call each: compile=%d evaluate=%d", compileCalls, evaluateCalls)
+	if compileCalls != 3 || evaluateCalls != 3 {
+		t.Fatalf("expected one declaration and calls only from planner and shared consumer: compile=%d evaluate=%d", compileCalls, evaluateCalls)
 	}
 	if admissionCalls != 1 {
-		t.Fatalf("expected planner admission declaration only; FAI-642 consumer composition is deferred: declarations/calls=%d", admissionCalls)
+		t.Fatalf("expected planner admission declaration only; consumer retains the same private planner policy/provider: declarations/calls=%d", admissionCalls)
 	}
 }

--- a/internal/platform/architecture/semantic_consumer_test.go
+++ b/internal/platform/architecture/semantic_consumer_test.go
@@ -14,7 +14,7 @@ func TestSemanticConsumersUseOneDiscoveryAndPlannerBoundary(t *testing.T) {
 		{"internal/dashboard/queryauthz/semantic_discovery.go", []string{"SemanticAccessResolutionSnapshot(", "NewSemanticAccessConsumer(", "snapshot.ValidateBound()", "consumer.Authorize("}},
 		{"internal/project/module/semantic_catalog.go", []string{"lease.Identity()", "compiled.MatchesModel(model)", "NewSemanticAccessDiscovery("}},
 		{"internal/analytics/materialize/semantic_consumer.go", []string{"SemanticAccessConsumerContextFromContext(", "consumer.ValidatePlan("}},
-		{"internal/access/postgres/semantic_attribute_resolution.go", []string{"REPEATABLE READ, READ ONLY", "requireLiveSemanticAttributePrincipal(", "ListPrincipalSemanticAttributeGroups("}},
+		{"internal/access/postgres/semantic_attribute_resolution.go", []string{"BeginTx(ctx, pgx.TxOptions{", "IsoLevel: pgx.RepeatableRead", "AccessMode: pgx.ReadOnly", "requireLiveSemanticAttributePrincipal(", "ListPrincipalSemanticAttributeGroups("}},
 	} {
 		body := readArchitectureFixture(t, root, check.path)
 		for _, fragment := range check.required {

--- a/internal/platform/architecture/semantic_consumer_test.go
+++ b/internal/platform/architecture/semantic_consumer_test.go
@@ -1,0 +1,31 @@
+package architecture
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSemanticConsumersUseOneDiscoveryAndPlannerBoundary(t *testing.T) {
+	root := repoRoot(t)
+	for _, check := range []struct {
+		path     string
+		required []string
+	}{
+		{"internal/dashboard/queryauthz/semantic_discovery.go", []string{"SemanticAccessResolutionSnapshot(", "NewSemanticAccessConsumer(", "snapshot.ValidateBound()", "consumer.Authorize("}},
+		{"internal/project/module/semantic_catalog.go", []string{"lease.Identity()", "compiled.MatchesModel(model)", "NewSemanticAccessDiscovery("}},
+		{"internal/analytics/materialize/semantic_consumer.go", []string{"SemanticAccessConsumerContextFromContext(", "consumer.ValidatePlan("}},
+		{"internal/access/postgres/semantic_attribute_resolution.go", []string{"REPEATABLE READ, READ ONLY", "requireLiveSemanticAttributePrincipal(", "ListPrincipalSemanticAttributeGroups("}},
+	} {
+		body := readArchitectureFixture(t, root, check.path)
+		for _, fragment := range check.required {
+			if !strings.Contains(body, fragment) {
+				t.Errorf("%s missing consumer boundary %q", check.path, fragment)
+			}
+		}
+		for _, forbidden := range []string{"unsafe.Pointer", "//go:linkname"} {
+			if strings.Contains(body, forbidden) {
+				t.Errorf("%s bypasses opaque evidence with %q", check.path, forbidden)
+			}
+		}
+	}
+}

--- a/internal/project/catalog/catalog.go
+++ b/internal/project/catalog/catalog.go
@@ -46,6 +46,20 @@ type LeaseProvider interface {
 	Acquire(context.Context) (Lease, error)
 }
 
+// SemanticModelVisibility is evaluated while the catalog's active lease is
+// held. Implementations must use that exact lease when resolving the compiled
+// semantic model, rather than acquiring a second generation snapshot.
+type SemanticModelVisibility func(context.Context, Lease, string, projectgraph.ResourceID) (bool, error)
+
+type ServiceOption func(*Service)
+
+// WithSemanticModelVisibility adds the compiled-semantic access gate used for
+// semantic-model resource discovery. A missing gate fails closed for semantic
+// model resources; non-semantic resources retain ordinary RBAC behavior.
+func WithSemanticModelVisibility(visibility SemanticModelVisibility) ServiceOption {
+	return func(service *Service) { service.semanticModelVisibility = visibility }
+}
+
 // SubjectResolver expands the authenticated principal into the principal plus
 // all group subjects.  Implementations must fail closed when group lookup is
 // unavailable; principal-only fallback would change authorization semantics.
@@ -113,15 +127,32 @@ type ListRequest struct {
 // a mutable graph cache: every operation leases the active generation and
 // reads its bound graph and immutable AuthorizationSnapshot.
 type Service struct {
-	leases   LeaseProvider
-	subjects SubjectResolver
+	leases                  LeaseProvider
+	subjects                SubjectResolver
+	semanticModelVisibility SemanticModelVisibility
 }
 
-func NewService(leasing LeaseProvider, subjects SubjectResolver) (*Service, error) {
+func NewService(leasing LeaseProvider, subjects SubjectResolver, options ...ServiceOption) (*Service, error) {
 	if leasing == nil || subjects == nil {
 		return nil, ErrUnavailable
 	}
-	return &Service{leases: leasing, subjects: subjects}, nil
+	service := &Service{leases: leasing, subjects: subjects}
+	for _, option := range options {
+		if option != nil {
+			option(service)
+		}
+	}
+	return service, nil
+}
+
+func (s *Service) semanticModelAllowed(ctx context.Context, lease Lease, principalID string, resource projectgraph.Resource) (bool, error) {
+	if resource.Kind != projectgraph.KindSemanticModel {
+		return true, nil
+	}
+	if s.semanticModelVisibility == nil {
+		return false, ErrUnavailable
+	}
+	return s.semanticModelVisibility(ctx, lease, principalID, resource.ID)
 }
 
 func (s *Service) Search(ctx context.Context, request SearchRequest) (Page, error) {
@@ -158,6 +189,13 @@ func (s *Service) Search(ctx context.Context, request SearchRequest) (Page, erro
 			continue
 		}
 		if !matches(resource, request.Query) {
+			continue
+		}
+		semanticAllowed, err := s.semanticModelAllowed(ctx, lease, request.PrincipalID, resource)
+		if err != nil {
+			return Page{}, err
+		}
+		if !semanticAllowed {
 			continue
 		}
 		allowed := request.DevAuthBypass
@@ -206,6 +244,13 @@ func (s *Service) List(ctx context.Context, request ListRequest) (Page, error) {
 		if !ok || resource.Kind != request.Parent.Kind {
 			return Page{}, ErrNotFound
 		}
+		semanticAllowed, err := s.semanticModelAllowed(ctx, lease, request.PrincipalID, resource)
+		if err != nil {
+			return Page{}, err
+		}
+		if !semanticAllowed {
+			return Page{}, ErrNotFound
+		}
 		allowed := request.DevAuthBypass
 		if !request.DevAuthBypass {
 			allowed, err = allowsAny(snapshot, subjects, resource)
@@ -229,6 +274,13 @@ func (s *Service) List(ctx context.Context, request ListRequest) (Page, error) {
 				continue
 			}
 			if domain != "" && strings.ToLower(resource.Metadata.Domain) != domain {
+				continue
+			}
+			semanticAllowed, err := s.semanticModelAllowed(ctx, lease, request.PrincipalID, resource)
+			if err != nil {
+				return Page{}, err
+			}
+			if !semanticAllowed {
 				continue
 			}
 			allowed := request.DevAuthBypass
@@ -255,6 +307,13 @@ func (s *Service) List(ctx context.Context, request ListRequest) (Page, error) {
 				continue
 			}
 			if domain != "" && strings.ToLower(resource.Metadata.Domain) != domain {
+				continue
+			}
+			semanticAllowed, err := s.semanticModelAllowed(ctx, lease, request.PrincipalID, resource)
+			if err != nil {
+				return Page{}, err
+			}
+			if !semanticAllowed {
 				continue
 			}
 			if _, ok := seen[resource.ID]; ok {
@@ -311,6 +370,13 @@ func (s *Service) Resolve(ctx context.Context, principalID string, ref Ref, capa
 		return Result{}, ErrNotFound
 	}
 	if err := access.ValidateCapabilityForKind(resource.Kind, capability); err != nil {
+		return Result{}, ErrNotFound
+	}
+	semanticAllowed, err := s.semanticModelAllowed(ctx, lease, principalID, resource)
+	if err != nil {
+		return Result{}, err
+	}
+	if !semanticAllowed {
 		return Result{}, ErrNotFound
 	}
 	if devAuthBypass {

--- a/internal/project/catalog/semantic_visibility_test.go
+++ b/internal/project/catalog/semantic_visibility_test.go
@@ -1,0 +1,67 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+)
+
+func TestSemanticCatalogDiscoveryAndDirectReferenceShareGate(t *testing.T) {
+	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{{ID: "semantic_sales", Kind: projectgraph.KindSemanticModel, Name: "sales"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := projectgraph.NewServingIdentity("project_demo", "development", "generation_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := accesssnapshot.NewAuthorizationSnapshot(identity, graph, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease := testLease{snapshot: snapshot}
+	for _, test := range []struct {
+		name       string
+		visibility SemanticModelVisibility
+		wantCount  int
+		wantError  bool
+	}{
+		{name: "missing metadata", wantError: true},
+		{name: "protected denied", visibility: func(context.Context, Lease, string, projectgraph.ResourceID) (bool, error) { return false, nil }},
+		{name: "allowed", wantCount: 1, visibility: func(_ context.Context, got Lease, principal string, id projectgraph.ResourceID) (bool, error) {
+			if got.Identity() != identity || id != "semantic_sales" || principal != "dev" {
+				t.Fatal("visibility did not use exact catalog lease")
+			}
+			return true, nil
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service, err := NewService(testLeases{lease: lease}, testSubjects{}, WithSemanticModelVisibility(test.visibility))
+			if err != nil {
+				t.Fatal(err)
+			}
+			page, err := service.Search(t.Context(), SearchRequest{PrincipalID: "dev", DevAuthBypass: true, Query: "sales"})
+			if (err != nil) != test.wantError || len(page.Items) != test.wantCount {
+				t.Fatalf("search = %#v, %v", page, err)
+			}
+			page, err = service.List(t.Context(), ListRequest{PrincipalID: "dev", DevAuthBypass: true})
+			if (err != nil) != test.wantError || len(page.Items) != test.wantCount {
+				t.Fatalf("list = %#v, %v", page, err)
+			}
+			_, err = service.Resolve(t.Context(), "dev", Ref{ID: "semantic_sales", Kind: projectgraph.KindSemanticModel}, access.CapabilityResourceRead, true)
+			if test.wantError && !errors.Is(err, ErrUnavailable) {
+				t.Fatalf("resolve = %v", err)
+			}
+			if !test.wantError && test.wantCount == 0 && !errors.Is(err, ErrNotFound) {
+				t.Fatalf("denied resolve = %v", err)
+			}
+			if test.wantCount == 1 && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/project/http/browser.go
+++ b/internal/project/http/browser.go
@@ -1509,7 +1509,8 @@ func (h *BrowserHandler) dataExplorerSignalsForCommandWithOptions(w stdhttp.Resp
 		stdhttp.Error(w, stdhttp.StatusText(stdhttp.StatusServiceUnavailable), stdhttp.StatusServiceUnavailable)
 		return projectsignals.DataExplorerPageSignal{}, projectsignals.DataExplorerSignal{}, false
 	}
-	projection := BuildDataExplorerProjection(assets, definition, exploreCommand, compiledModels)
+	consumers := dataExplorerSemanticConsumers(r.Context(), h.QueryExecutor, definition)
+	projection := BuildDataExplorerProjection(assets, definition, exploreCommand, compiledModels, consumers)
 	if strictURLState && projectsignals.ValueOrZero(command.Mode) == "explore" {
 		semanticModelID := strings.TrimSpace(projectsignals.ValueOrZero(projection.Command.SemanticModelID))
 		if err := validateRestoredDataExploreState(exploreCommand, projection, definition.SemanticModels[semanticModelID], compiledModels); err != nil {

--- a/internal/project/http/data_explorer_preview.go
+++ b/internal/project/http/data_explorer_preview.go
@@ -3,10 +3,13 @@ package http
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
 	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
 )
 
@@ -23,6 +26,39 @@ var dataExplorerBlockIDs = []string{"a", "b", "c"}
 // audit policies as dashboard and semantic API queries.
 type DataQueryExecutor interface {
 	ExecuteDataQuery(context.Context, dataquery.Query) (dataquery.Result, error)
+}
+
+// SemanticAccessConsumerProvider is an optional query-executor capability used
+// only for protected semantic discovery. Public models continue to use the
+// ordinary DataQueryExecutor path. Implementations must return a consumer
+// bound to the request principal and active serving generation.
+type SemanticAccessConsumerProvider interface {
+	SemanticConsumer(context.Context, string) (*semanticquery.SemanticAccessConsumer, error)
+}
+
+func dataExplorerSemanticConsumers(ctx context.Context, executor DataQueryExecutor, definition projectmanifest.ResourceManifest) map[string]*semanticquery.SemanticAccessConsumer {
+	provider, ok := executor.(SemanticAccessConsumerProvider)
+	if !ok || provider == nil {
+		return nil
+	}
+	consumers := make(map[string]*semanticquery.SemanticAccessConsumer)
+	modelIDs := make([]string, 0, len(definition.SemanticModels))
+	for modelID := range definition.SemanticModels {
+		modelIDs = append(modelIDs, modelID)
+	}
+	sort.Strings(modelIDs)
+	for _, modelID := range modelIDs {
+		model := definition.SemanticModels[modelID]
+		if !semanticquery.ModelRequiresSemanticAccess(model) {
+			continue
+		}
+		consumer, err := provider.SemanticConsumer(ctx, modelID)
+		if err != nil || consumer == nil {
+			continue
+		}
+		consumers[modelID] = consumer
+	}
+	return consumers
 }
 
 func normalizeDataExplorerCommand(command projectsignals.DataExplorerCommand) projectsignals.DataExplorerCommand {

--- a/internal/project/http/data_explorer_projection.go
+++ b/internal/project/http/data_explorer_projection.go
@@ -43,7 +43,11 @@ type explorerModelBinding struct {
 // compiled semantic bindings. Asset visibility is authoritative for every
 // output: manifest entries that do not have a visible serving asset are never
 // exposed to the browser.
-func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project projectmanifest.ResourceManifest, command projectsignals.DataExploreCommand, compiledModels map[string]*semanticquery.CompiledModel) DataExplorerProjection {
+func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project projectmanifest.ResourceManifest, command projectsignals.DataExploreCommand, compiledModels map[string]*semanticquery.CompiledModel, consumers ...map[string]*semanticquery.SemanticAccessConsumer) DataExplorerProjection {
+	var consumersByModel map[string]*semanticquery.SemanticAccessConsumer
+	if len(consumers) != 0 {
+		consumersByModel = consumers[0]
+	}
 	visible := make(map[string]projectview.DevelopAssetView, len(assets))
 	for _, asset := range assets {
 		if strings.TrimSpace(asset.ID) == "" {
@@ -63,6 +67,7 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 	semanticModels := make([]projectsignals.DataExploreSemanticModelSignal, 0, len(semanticIDs))
 	modelByID := make(map[string]*semanticmodel.Model, len(semanticIDs))
 	compiledByID := make(map[string]*semanticquery.CompiledModel, len(semanticIDs))
+	accessByID := make(map[string]*explorerSemanticAccess, len(semanticIDs))
 	bindingUnavailable := false
 	for _, id := range semanticIDs {
 		model := project.SemanticModels[id]
@@ -72,16 +77,23 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 		modelByID[id] = model
 		asset := visible[id]
 		compiled, ok := compiledModels[id]
-		if !ok || compiled == nil || len(compiled.DatasetNames()) == 0 {
+		if !ok || compiled == nil || len(compiled.DatasetNames()) == 0 || !compiled.MatchesModel(model) {
 			bindingUnavailable = true
-			compiled = &semanticquery.CompiledModel{}
+			continue
+		}
+		if !model.AccessPolicy.Empty() {
+			access, ok := explorerSemanticAccessForModel(model, compiled, consumersByModel[id], id)
+			if !ok {
+				continue
+			}
+			accessByID[id] = access
 		}
 		compiledByID[id] = compiled
 		semanticModels = append(semanticModels, projectsignals.DataExploreSemanticModelSignal{
 			ID:          id,
 			Title:       firstExplorerNonEmpty(model.Title, model.Name, asset.Title, id),
 			Description: projectsignals.Optional(firstExplorerNonEmpty(model.Description, asset.Description)),
-			Datasets:    explorerDatasets(model, compiled),
+			Datasets:    explorerDatasets(model, compiled, accessByID[id]),
 		})
 	}
 
@@ -92,7 +104,13 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 	for _, semanticID := range semanticIDs {
 		model := modelByID[semanticID]
 		compiled := compiledByID[semanticID]
+		if access := accessByID[semanticID]; access != nil && len(access.datasets) == 0 {
+			continue
+		}
 		for datasetID, datasetTable := range explorerDatasetTableMap(model, compiled) {
+			if access := accessByID[semanticID]; access != nil && !access.allowsDataset(datasetID) {
+				continue
+			}
 			tableName := datasetTable.ModelName
 			modelID := project.NameIndex.Models[tableName]
 			if modelID == "" {
@@ -147,17 +165,9 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 			}
 			columns := explorerTableColumns(table)
 			bindings := bindingsByModelID[asset.ID]
-			if len(bindings) == 0 {
-				objects = append(objects, explorerModelObject(asset, table, columns, "", ""))
-				continue
-			}
 			// One object per semantic dataset binding keeps field compatibility
-			// scoped to the selected model and dataset. The object key carries
-			// the full binding identity; ResourceID remains the backing logical
-			// Model resource for governed preview execution and detail links.
-			for _, binding := range bindings {
-				objects = append(objects, explorerModelObject(asset, table, columns, binding.SemanticModelID, binding.DatasetID))
-			}
+			// scoped to the selected model and dataset.
+			objects = append(objects, explorerBoundModelObjects(asset, table, columns, bindings, accessByID, compiledByID)...)
 		}
 	}
 	sortExplorerObjects(objects)
@@ -170,14 +180,10 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 			break
 		}
 	}
-	if selectedSemanticModelIndex < 0 && len(semanticModels) > 0 {
+	if selectedSemanticModelIndex < 0 && selectedSemanticModelID == "" && len(semanticModels) > 0 {
 		selectedSemanticModelIndex = 0
 	}
-	warnings := []string(nil)
-	if bindingUnavailable {
-		warnings = append(warnings, "Compiled semantic dataset bindings are unavailable for the active serving generation.")
-	}
-	result := DataExplorerProjection{Objects: objects, SemanticModels: semanticModels, Command: command, Warnings: warnings}
+	result := DataExplorerProjection{Objects: objects, SemanticModels: semanticModels, Command: command, Warnings: explorerBindingWarnings(bindingUnavailable)}
 	if selectedSemanticModelIndex < 0 {
 		return result
 	}
@@ -204,6 +210,7 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 	}
 	model := modelByID[selectedSemanticModel.ID]
 	compiled := compiledByID[selectedSemanticModel.ID]
+	access := accessByID[selectedSemanticModel.ID]
 	if resolvedBase, changed := resolveExplorerBase(model, baseTable, command, compiled); changed {
 		previousBase := baseTable
 		baseTable = resolvedBase
@@ -218,13 +225,16 @@ func BuildDataExplorerProjection(assets []projectview.DevelopAssetView, project 
 		result.Warnings = append(result.Warnings, "Grain changed from "+explorerLabel(previousBase)+" to "+explorerLabel(baseTable)+" to support the selected fields.")
 	}
 	result.Command = command
-	result.Fields = explorerFields(model, baseTable, command, compiled)
+	result.Fields = explorerFields(model, baseTable, command, compiled, access)
 	return result
 }
-
-func explorerDatasets(model *semanticmodel.Model, compiled *semanticquery.CompiledModel) []projectsignals.DataExploreDatasetSignal {
+func explorerDatasets(model *semanticmodel.Model, compiled *semanticquery.CompiledModel, accesses ...*explorerSemanticAccess) []projectsignals.DataExploreDatasetSignal {
 	if model == nil {
 		return []projectsignals.DataExploreDatasetSignal{}
+	}
+	var access *explorerSemanticAccess
+	if len(accesses) > 0 {
+		access = accesses[0]
 	}
 	tables := explorerDatasetTableMap(model, compiled)
 	names := make([]string, 0, len(tables))
@@ -234,11 +244,28 @@ func explorerDatasets(model *semanticmodel.Model, compiled *semanticquery.Compil
 	sort.Strings(names)
 	out := make([]projectsignals.DataExploreDatasetSignal, 0, len(names))
 	for _, name := range names {
+		if !access.allowsDataset(name) {
+			continue
+		}
 		table := tables[name]
 		entities, grainEntity, grainFields := explorerDatasetEntities(table)
+		if access != nil {
+			entities, grainEntity, grainFields = explorerDatasetEntitiesAuthorized(table, compiled, name, access)
+		}
 		fieldCount := len(table.Dimensions)
+		if access != nil {
+			fieldCount = 0
+			for _, dimension := range compiled.SemanticDimensionNames() {
+				if binding, ok := compiled.DimensionBinding(dimension, name); ok && access.allowsDimension(dimension, name, binding.Physical.Field) {
+					fieldCount++
+				}
+			}
+		}
 		for metricName, metric := range model.Metrics {
 			if metric.Hidden {
+				continue
+			}
+			if !access.allowsMetric(metricName) {
 				continue
 			}
 			for _, root := range explorerMetricRootDatasets(model, metricName) {
@@ -297,9 +324,13 @@ func explorerDatasetEntities(table semanticmodel.Table) ([]projectsignals.Semant
 	return entities, grainEntity, grainFields
 }
 
-func explorerFields(model *semanticmodel.Model, baseTable string, command projectsignals.DataExploreCommand, compiled *semanticquery.CompiledModel) []projectsignals.DataExploreFieldSignal {
+func explorerFields(model *semanticmodel.Model, baseTable string, command projectsignals.DataExploreCommand, compiled *semanticquery.CompiledModel, accesses ...*explorerSemanticAccess) []projectsignals.DataExploreFieldSignal {
 	if model == nil {
 		return []projectsignals.DataExploreFieldSignal{}
+	}
+	var access *explorerSemanticAccess
+	if len(accesses) > 0 {
+		access = accesses[0]
 	}
 	selectedDimensions := explorerStringSet(command.Dimensions)
 	selectedMetrics := explorerStringSet(command.Metrics)
@@ -318,6 +349,9 @@ func explorerFields(model *semanticmodel.Model, baseTable string, command projec
 		}
 		sort.Strings(fieldNames)
 		for _, fieldName := range fieldNames {
+			if !access.allowsPhysicalField(compiled, tableName, fieldName) {
+				continue
+			}
 			dimension := table.Dimensions[fieldName]
 			id := tableName + "." + fieldName
 			fieldType := firstExplorerNonEmpty(dimension.Type, table.Columns[fieldName].Type)
@@ -345,6 +379,9 @@ func explorerFields(model *semanticmodel.Model, baseTable string, command projec
 	}
 	sort.Strings(metricNames)
 	for _, name := range metricNames {
+		if !access.allowsMetric(name) {
+			continue
+		}
 		metric := model.Metrics[name]
 		roots := explorerMetricRootDatasets(model, name)
 		// Aggregate metrics have one root dataset. Derived and ratio metrics

--- a/internal/project/http/data_explorer_semantic_access.go
+++ b/internal/project/http/data_explorer_semantic_access.go
@@ -1,0 +1,165 @@
+package http
+
+import (
+	"sort"
+	"strings"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	projectview "github.com/flidai/leapview/internal/project"
+	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
+)
+
+type explorerSemanticAccess struct {
+	datasets   map[string]bool
+	dimensions map[string]map[string]bool
+	metrics    map[string]bool
+}
+
+func explorerSemanticAccessForModel(model *semanticmodel.Model, compiled *semanticquery.CompiledModel, consumer *semanticquery.SemanticAccessConsumer, modelID string) (*explorerSemanticAccess, bool) {
+	if model == nil || model.AccessPolicy.Empty() {
+		return nil, true
+	}
+	if consumer == nil || consumer.ModelID() != modelID || compiled == nil || len(compiled.DatasetNames()) == 0 {
+		return nil, false
+	}
+	planner := consumer.Planner()
+	if planner == nil || planner.CompiledModel() == nil || !planner.CompiledModel().MatchesModel(model) {
+		return nil, false
+	}
+	assets, err := consumer.Assets()
+	if err != nil {
+		return nil, false
+	}
+	allowed := &explorerSemanticAccess{datasets: map[string]bool{}, dimensions: map[string]map[string]bool{}, metrics: map[string]bool{}}
+	for _, asset := range assets {
+		switch asset.Kind {
+		case "dataset":
+			allowed.datasets[asset.Name] = true
+		case "dimension":
+			if allowed.dimensions[asset.Name] == nil {
+				allowed.dimensions[asset.Name] = map[string]bool{}
+			}
+			allowed.dimensions[asset.Name][asset.Dataset] = true
+		case "metric":
+			allowed.metrics[asset.Name] = true
+		}
+	}
+	// A valid consumer can deny every dataset. Do not advertise the model
+	// when none of its governed data can be selected.
+	return allowed, len(allowed.datasets) != 0
+}
+
+func explorerBoundModelObjects(asset projectview.DevelopAssetView, table semanticmodel.Table, columns []projectsignals.DataPreviewColumnSignal, bindings []explorerModelBinding, accessByID map[string]*explorerSemanticAccess, compiledByID map[string]*semanticquery.CompiledModel) []projectsignals.DataExplorerObjectSignal {
+	if len(bindings) == 0 {
+		return []projectsignals.DataExplorerObjectSignal{explorerModelObject(asset, table, columns, "", "")}
+	}
+	objects := make([]projectsignals.DataExplorerObjectSignal, 0, len(bindings))
+	for _, binding := range bindings {
+		bindingColumns := columns
+		if access := accessByID[binding.SemanticModelID]; access != nil {
+			bindingColumns = explorerAuthorizedTableColumns(table, compiledByID[binding.SemanticModelID], binding.DatasetID, access)
+		}
+		objects = append(objects, explorerModelObject(asset, table, bindingColumns, binding.SemanticModelID, binding.DatasetID))
+	}
+	return objects
+}
+
+func explorerBindingWarnings(unavailable bool) []string {
+	if !unavailable {
+		return nil
+	}
+	return []string{"Compiled semantic dataset bindings are unavailable for the active serving generation."}
+}
+
+func (access *explorerSemanticAccess) allowsDataset(name string) bool {
+	return access == nil || access.datasets[name]
+}
+
+func (access *explorerSemanticAccess) allowsDimension(name, dataset, field string) bool {
+	if access == nil {
+		return true
+	}
+	return access.dimensions[name][dataset]
+}
+
+func (access *explorerSemanticAccess) allowsMetric(name string) bool {
+	return access == nil || access.metrics[name]
+}
+
+// allowsPhysicalField maps an authorized semantic dimension back to the
+// physical field displayed in a dataset's schema. A protected projection must
+// never fall back to exposing every authored table column: a physical column
+// is visible only when every matching semantic binding is authorized.
+func (access *explorerSemanticAccess) allowsPhysicalField(compiled *semanticquery.CompiledModel, dataset, field string) bool {
+	if access == nil {
+		return true
+	}
+	qualified := dataset + "." + field
+	matched := false
+	for _, name := range compiled.SemanticDimensionNames() {
+		binding, ok := compiled.DimensionBinding(name, dataset)
+		if !ok {
+			continue
+		}
+		physical := strings.TrimSpace(binding.Physical.Field)
+		if physical != qualified && physical != field && strings.TrimSpace(binding.Physical.Name) != field {
+			continue
+		}
+		matched = true
+		if !access.allowsDimension(name, dataset, physical) {
+			return false
+		}
+	}
+	return matched
+}
+
+func explorerDatasetEntitiesAuthorized(table semanticmodel.Table, compiled *semanticquery.CompiledModel, dataset string, access *explorerSemanticAccess) ([]projectsignals.SemanticModelGraphEntitySignal, string, []string) {
+	entities := make([]projectsignals.SemanticModelGraphEntitySignal, 0, len(table.Entities))
+	names := make([]string, 0, len(table.Entities))
+	for name := range table.Entities {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	grainEntity := strings.TrimSpace(table.GrainEntity)
+	grainFields := []string{}
+	for _, name := range names {
+		entity := table.Entities[name]
+		fields := make([]string, 0, len(entity.Fields))
+		allVisible := true
+		for _, field := range entity.Fields {
+			if access.allowsPhysicalField(compiled, dataset, field) {
+				fields = append(fields, field)
+				continue
+			}
+			allVisible = false
+		}
+		if !allVisible || len(fields) == 0 {
+			continue
+		}
+		entities = append(entities, projectsignals.SemanticModelGraphEntitySignal{
+			Name: name, Type: entity.Type, Fields: fields, Grain: projectsignals.Optional(name == grainEntity),
+		})
+		if name == grainEntity {
+			grainFields = append([]string(nil), fields...)
+		}
+	}
+	if len(grainFields) == 0 {
+		grainEntity = ""
+	}
+	return entities, grainEntity, grainFields
+}
+
+func explorerAuthorizedTableColumns(table semanticmodel.Table, compiled *semanticquery.CompiledModel, dataset string, access *explorerSemanticAccess) []projectsignals.DataPreviewColumnSignal {
+	columns := explorerTableColumns(table)
+	if access == nil {
+		return columns
+	}
+	out := make([]projectsignals.DataPreviewColumnSignal, 0, len(columns))
+	for _, column := range columns {
+		if access.allowsPhysicalField(compiled, dataset, column.Key) {
+			out = append(out, column)
+		}
+	}
+	return out
+}

--- a/internal/project/http/data_explorer_semantic_access_test.go
+++ b/internal/project/http/data_explorer_semantic_access_test.go
@@ -1,0 +1,161 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/access"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	projectview "github.com/flidai/leapview/internal/project"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectsignals "github.com/flidai/leapview/internal/project/ui/signals"
+	"github.com/flidai/leapview/internal/semanticvalue"
+)
+
+func TestBuildDataExplorerProjectionOmitsProtectedModelWithoutConsumer(t *testing.T) {
+	model := explorerSemanticAccessProjectionModel()
+	model.AccessPolicy.AccessGrants = map[string]semanticmodel.SemanticAccessGrantSpec{
+		"view_sales": {UserAttribute: "department"},
+	}
+	compiled, err := semanticquery.CompileDatasetBindings(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := projectmanifest.ResourceManifest{
+		Models:         map[string]semanticmodel.Table{"model:orders": model.Tables["orders"]},
+		SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": model},
+		NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders"}},
+	}
+	assets := []projectview.DevelopAssetView{
+		{ID: "model:orders", Type: string(projectview.AssetTypeModel), Key: "orders"},
+		{ID: "semantic:sales", Type: string(projectview.AssetTypeSemanticModel), Key: "sales"},
+	}
+	projection := BuildDataExplorerProjection(assets, project, projectsignals.DataExploreCommand{}, map[string]*semanticquery.CompiledModel{"semantic:sales": compiled})
+	if len(projection.SemanticModels) != 0 || projection.SelectedSemanticModel != nil {
+		t.Fatalf("protected semantic projection = %#v/%#v, want omitted without consumer", projection.SemanticModels, projection.SelectedSemanticModel)
+	}
+}
+
+func TestBuildDataExplorerProjectionOmitsProtectedModelWithNoEffectiveDatasetAssignments(t *testing.T) {
+	model := explorerSemanticAccessProjectionModel()
+	literal, err := semanticmodel.NewSemanticAccessLiteral("sales")
+	if err != nil {
+		t.Fatal(err)
+	}
+	model.AccessPolicy.AccessGrants = map[string]semanticmodel.SemanticAccessGrantSpec{
+		"view_sales": {UserAttribute: "department", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal}},
+	}
+	model.AccessPolicy.Datasets = map[string]semanticmodel.SemanticDatasetAccessSpec{
+		"orders": {RequiredAccessGrants: []string{"view_sales"}},
+	}
+	compiled, err := semanticquery.CompileDatasetBindings(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer := newNoEffectiveDatasetConsumer(t, compiled)
+	project := projectmanifest.ResourceManifest{
+		Models:         map[string]semanticmodel.Table{"model:orders": model.Tables["orders"]},
+		SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": model},
+		NameIndex:      projectmanifest.NameIndex{Models: map[string]string{"orders": "model:orders"}},
+	}
+	assets := []projectview.DevelopAssetView{
+		{ID: "model:orders", Type: string(projectview.AssetTypeModel), Key: "orders", Title: "Orders"},
+		{ID: "semantic:sales", Type: string(projectview.AssetTypeSemanticModel), Key: "sales", Title: "Sales"},
+	}
+	projection := BuildDataExplorerProjection(assets, project, projectsignals.DataExploreCommand{}, map[string]*semanticquery.CompiledModel{"semantic:sales": compiled}, map[string]*semanticquery.SemanticAccessConsumer{"semantic:sales": consumer})
+	if len(projection.SemanticModels) != 0 || projection.SelectedSemanticModel != nil {
+		t.Fatalf("protected semantic projection = %#v/%#v, want omitted with no effective dataset assignment", projection.SemanticModels, projection.SelectedSemanticModel)
+	}
+}
+
+func newNoEffectiveDatasetConsumer(t *testing.T, compiled *semanticquery.CompiledModel) *semanticquery.SemanticAccessConsumer {
+	t.Helper()
+	definition := access.SemanticAttributeDefinition{
+		ID: "def-department", Name: "department", Type: semanticvalue.TypeString, Shape: access.SemanticAttributeScalar,
+		Profile: semanticvalue.Profile, DefinitionVersion: 1, LifecycleState: access.SemanticAttributeActive, Enabled: true,
+		Metadata: access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}},
+	}
+	registryDigest, err := access.SemanticAttributeRegistryDigest(semanticvalue.Profile, []access.SemanticAttributeDefinition{definition})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := access.SemanticAttributeRegistrySnapshot{
+		State:       access.SemanticAttributeRegistryState{Profile: semanticvalue.Profile, Revision: 1, Digest: registryDigest},
+		Definitions: []access.SemanticAttributeDefinition{definition},
+	}
+	controlDigest, err := access.SemanticAttributeControlDigest(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control := access.SemanticAttributeControlSnapshot{
+		State: access.SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 1, Digest: controlDigest},
+	}
+	attributeDigest, err := semanticquery.EffectiveSemanticAttributeDigest(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := semanticquery.SemanticAccessAttributeSnapshot{
+		InstanceID: "instance-1", PrincipalID: "principal-1", ActorID: "principal-1", Registry: registry, Control: control,
+		EffectiveAttributeDigest: attributeDigest,
+	}
+	authority := semanticquery.SemanticAccessAuthority{InstanceID: "instance-1", Registry: registry, Control: control, ObservedAt: time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)}
+	consumer, err := semanticquery.NewSemanticAccessDiscovery(compiled, semanticquery.SemanticAccessConsumerConfig{
+		InstanceID: "instance-1", ProjectID: "project:test", Environment: "prod", ModelID: "semantic:sales", Generation: "generation-1", PrincipalID: "principal-1",
+		Authority: func() (semanticquery.SemanticAccessAttributeSnapshot, semanticquery.SemanticAccessAuthority, error) {
+			return snapshot, authority, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return consumer
+}
+
+func TestExplorerProtectedProjectionFiltersPhysicalAndAuxiliaryFields(t *testing.T) {
+	model := explorerSemanticAccessProjectionModel()
+	compiled, err := semanticquery.CompileModel(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	access := &explorerSemanticAccess{
+		datasets:   map[string]bool{"orders": true},
+		dimensions: map[string]map[string]bool{"region": {"orders": true}},
+		metrics:    map[string]bool{},
+	}
+	fields := explorerFields(model, "orders", projectsignals.DataExploreCommand{}, compiled, access)
+	if len(fields) != 1 || fields[0].ID != "orders.region" {
+		t.Fatalf("protected fields = %#v, want only authorized region", fields)
+	}
+	datasets := explorerDatasets(model, compiled, access)
+	if len(datasets) != 1 || datasets[0].FieldCount != 1 {
+		t.Fatalf("protected datasets = %#v, want one authorized field", datasets)
+	}
+	if len(datasets[0].Entities) != 0 || datasets[0].GrainEntity != "" || len(datasets[0].GrainFields) != 0 {
+		t.Fatalf("protected auxiliary entity metadata = %#v, want hidden unauthorized grain", datasets[0])
+	}
+}
+
+func explorerSemanticAccessProjectionModel() *semanticmodel.Model {
+	return &semanticmodel.Model{
+		Name: "sales",
+		Tables: map[string]semanticmodel.Table{
+			"orders": {
+				ModelName:   "orders",
+				Entities:    map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"id"}}},
+				GrainEntity: "order",
+				Columns: map[string]semanticmodel.ModelColumn{
+					"id": {Name: "id", Type: "integer"}, "region": {Name: "region", Type: "string"}, "secret": {Name: "secret", Type: "string"},
+				},
+				Dimensions: map[string]semanticmodel.MetricDimension{
+					"id": {Type: "number", Datatype: semanticmodel.DataTypeInteger}, "region": {Type: "string", Datatype: semanticmodel.DataTypeString}, "secret": {Type: "string", Datatype: semanticmodel.DataTypeString},
+				},
+			},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}},
+		Dimensions: map[string]semanticmodel.SemanticDimension{
+			"region": {Type: "string", Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.region"}}},
+			"secret": {Type: "string", Datatype: semanticmodel.DataTypeString, Bindings: map[string]semanticmodel.DimensionBinding{"orders": {Field: "orders.secret"}}},
+		},
+	}
+}

--- a/internal/project/http/data_explorer_url.go
+++ b/internal/project/http/data_explorer_url.go
@@ -155,6 +155,10 @@ func validateRestoredDataExploreState(command projectsignals.DataExploreCommand,
 
 	if semanticModelID != "" {
 		if !explorerSemanticModelByID(projection.SemanticModels, semanticModelID) {
+			compiled, hasCompiled := compiledModels[semanticModelID]
+			if len(compiledModels) == 0 || (hasCompiled && (compiled == nil || len(compiled.DatasetNames()) == 0)) {
+				return fmt.Errorf("semantic model %q has no active compiled definition; reload the explorer after the serving state is ready", semanticModelID)
+			}
 			return fmt.Errorf("semantic model %q is no longer available; choose an active semantic model", semanticModelID)
 		}
 		if selectedSemanticModelID != semanticModelID {

--- a/internal/project/module/semantic_catalog.go
+++ b/internal/project/module/semantic_catalog.go
@@ -1,0 +1,83 @@
+package module
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flidai/leapview/internal/access"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	projectcatalog "github.com/flidai/leapview/internal/project/catalog"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectruntime "github.com/flidai/leapview/internal/project/runtime"
+)
+
+type semanticCatalogRuntime interface {
+	ProjectManifest() projectmanifest.ResourceManifest
+	CompiledSemanticModel(string) (*semanticquery.CompiledModel, bool)
+}
+
+// SemanticCatalogVisibility uses the exact catalog lease, not a second active
+// generation lookup. Resource RBAC is still required by catalog.Service.
+func SemanticCatalogVisibility(instanceID string, resolve func(context.Context) (access.SemanticAttributeResolution, error)) projectcatalog.SemanticModelVisibility {
+	return func(ctx context.Context, lease projectcatalog.Lease, principalID string, modelID projectgraph.ResourceID) (bool, error) {
+		port, ok := lease.(interface{ Runtime() projectruntime.Runtime })
+		if !ok || port.Runtime() == nil {
+			return false, projectcatalog.ErrUnavailable
+		}
+		runtime, ok := port.Runtime().(semanticCatalogRuntime)
+		if !ok {
+			return false, projectcatalog.ErrUnavailable
+		}
+		identity := lease.Identity()
+		if err := identity.Validate(); err != nil {
+			return false, err
+		}
+		definition := runtime.ProjectManifest()
+		if lease.AuthorizationSnapshot().Identity() != identity || lease.AuthorizationSnapshot().ValidateBound() != nil {
+			return false, projectcatalog.ErrSnapshotChanged
+		}
+		model := definition.SemanticModels[modelID.String()]
+		compiled, available := runtime.CompiledSemanticModel(modelID.String())
+		if model == nil || !available || compiled == nil || !compiled.MatchesModel(model) {
+			return false, projectcatalog.ErrUnavailable
+		}
+		if model.AccessPolicy.Empty() {
+			return true, nil
+		}
+		if resolve == nil {
+			return false, projectcatalog.ErrUnavailable
+		}
+		initial, err := resolve(ctx)
+		if err != nil {
+			return false, err
+		}
+		if initial.Subject.Kind != access.SubjectKindPrincipal || initial.Subject.ID != principalID {
+			return false, projectcatalog.ErrUnavailable
+		}
+		provider := func() (semanticquery.SemanticAccessAttributeSnapshot, semanticquery.SemanticAccessAuthority, error) {
+			if lease.Identity() != identity {
+				return semanticquery.SemanticAccessAttributeSnapshot{}, semanticquery.SemanticAccessAuthority{}, projectcatalog.ErrSnapshotChanged
+			}
+			resolved, err := resolve(ctx)
+			if err != nil {
+				return semanticquery.SemanticAccessAttributeSnapshot{}, semanticquery.SemanticAccessAuthority{}, err
+			}
+			return semanticquery.SemanticAccessResolutionSnapshot(instanceID, initial.Subject.ID, resolved)
+		}
+		consumer, err := semanticquery.NewSemanticAccessDiscovery(compiled, semanticquery.SemanticAccessConsumerConfig{
+			ProjectID: identity.ProjectID.String(), Environment: identity.Environment,
+			InstanceID: instanceID, ModelID: modelID.String(), Generation: identity.GenerationID,
+			PrincipalID: initial.Subject.ID, Authority: provider,
+		})
+		if err != nil {
+			return false, fmt.Errorf("semantic catalog authority: %w", err)
+		}
+		for _, dataset := range compiled.DatasetNames() {
+			if consumer.Authorize(semanticquery.SemanticAccessTarget{Dataset: dataset}) == nil {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+}

--- a/internal/project/module/semantic_catalog_test.go
+++ b/internal/project/module/semantic_catalog_test.go
@@ -1,0 +1,60 @@
+package module
+
+import (
+	"testing"
+
+	accesssnapshot "github.com/flidai/leapview/internal/access/snapshot"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	projectcatalog "github.com/flidai/leapview/internal/project/catalog"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectruntime "github.com/flidai/leapview/internal/project/runtime"
+)
+
+type semanticCatalogLease struct {
+	runtime  projectruntime.Runtime
+	snapshot accesssnapshot.AuthorizationSnapshot
+}
+
+func (l semanticCatalogLease) Runtime() projectruntime.Runtime        { return l.runtime }
+func (l semanticCatalogLease) Release()                               {}
+func (l semanticCatalogLease) Identity() projectgraph.ServingIdentity { return l.snapshot.Identity() }
+func (l semanticCatalogLease) AuthorizationSnapshot() accesssnapshot.AuthorizationSnapshot {
+	return l.snapshot
+}
+
+func TestSemanticCatalogUsesLeaseCompiledProtection(t *testing.T) {
+	model := &semanticmodel.Model{Name: "sales", Datasets: map[string]semanticmodel.SemanticDatasetSpec{"orders": {Model: "orders"}}, Tables: map[string]semanticmodel.Table{"orders": {ModelName: "orders", GrainEntity: "order", Entities: map[string]semanticmodel.EntityDefinition{"order": {Type: "primary", Fields: []string{"id"}}}, Dimensions: map[string]semanticmodel.MetricDimension{"id": {Datatype: semanticmodel.DataTypeInteger}}}}}
+	planner, err := semanticquery.NewCompiledPlanner(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{{ID: "semantic_sales", Kind: projectgraph.KindSemanticModel, Name: "sales"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := projectgraph.NewServingIdentity("project_demo", "development", "generation_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := accesssnapshot.NewAuthorizationSnapshot(identity, graph, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease := semanticCatalogLease{runtime: projectDefinitionRuntimeStub{definition: projectmanifest.ResourceManifest{SemanticModels: map[string]*semanticmodel.Model{"semantic_sales": model}}, compiled: map[string]*semanticquery.CompiledModel{"semantic_sales": planner.CompiledModel()}}, snapshot: snapshot}
+	visibility := SemanticCatalogVisibility("instance-1", nil)
+	allowed, err := visibility(t.Context(), lease, "alice", "semantic_sales")
+	if err != nil || !allowed {
+		t.Fatalf("public visibility = %v, %v", allowed, err)
+	}
+	model.AccessPolicy.Datasets = map[string]semanticmodel.SemanticDatasetAccessSpec{"orders": {RequiredAccessGrants: []string{"unknown"}}}
+	allowed, err = visibility(t.Context(), lease, "alice", "semantic_sales")
+	if allowed || err == nil {
+		t.Fatalf("mismatched model visibility = %v, %v", allowed, err)
+	}
+	var absent projectcatalog.Lease = semanticCatalogLease{snapshot: snapshot}
+	if allowed, err := visibility(t.Context(), absent, "alice", "semantic_sales"); allowed || err == nil {
+		t.Fatal("missing runtime became public")
+	}
+}


### PR DESCRIPTION
## Current remediation — trusted development semantic reads

Published head: `9817457e09883757abd695c16a5d0bfbfde5f474`.

### Problem and root cause

The dbt/MCP query smoke test returned resource_not_found: FAI-642's inner resource-read guard denied the trusted development principal by applying snapshot grants directly, despite the canonical generated API guard intentionally allowing that identity. The CI gate failure was aggregate-only.

### Solution and security boundary

Restore request-local, identity-bound development authorization only for validated semantic-model ResourceRead in the active project. Ordinary principals still require canonical snapshot grants. Protected semantic models and unknown/mismatched protection states remain fail-closed through independent consumer authorization. FAI-639 compiled predicates and FAI-641 SecurityBarrier enforcement are unchanged.

The remediation contains four files, +305/-1:
- internal/app/runtime_router.go
- internal/app/semantic_resource_authorization.go
- internal/app/semantic_resource_authorization_test.go
- internal/dashboard/queryauthz/semantic_development_access_test.go

No FAI-645/648/649 work, provider integrations, VAL-11 expansion, compiler/planner changes, unrelated generated artifacts, timeout increases or policy changes.

### Regression coverage and verification

Tests cover trusted development reads; ordinary denial and explicit grants; invalid/missing/mismatched identities; cross-project/resource/kind/capability rejection; deterministic public-model allowance; protected development denial; and stripped-policy/unknown protection rejection.

PASS on the reviewed tree:
- dbt qualification/MCP smoke test and one-shot candidate publication
- authorization regressions ×10, repeated immediately before commit
- access/compiler/planner/PlanIR/consumer suites and MCP tests
- PostgreSQL integration
- architecture tests
- task generated:check
- quality budgets
- git diff --check

Independent read-only review found no concrete correctness/security defect.

**Local task ci is NOT green:** APIGen, Go packages/application and PostgreSQL integration passed, but frontend/site exceeded the existing 180-second watchdog on both attempts during active tests, without an observed assertion failure. No frontend pass is claimed locally. No timeouts or CI policy changed. Hosted CI must establish current-head readiness.

FAI-642 remains In Review. Fresh hosted checks are queued/running; do not merge automatically. Earlier evidence below is historical, not current-head hosted clearance.

---

## Problem and root cause

SemanticModel access requirements must govern discovery, direct references and execution consistently. Consumers previously lacked one request-bound bridge from authoritative control metadata to the existing compiled policy and scan-barrier path.

## Solution and architecture boundary

FAI-637 control authority → FAI-639 compiled authorization → FAI-641 pre-join/aggregation SecurityBarrier enforcement; FAI-642 binds protected-asset discovery and consumer routing to that existing path.

- Deterministically discover protected datasets, dimension bindings and metrics, including required grants, transitive dependencies, ownership and policy identity.
- Resolve live principal/group membership, registry/control snapshots and effective assignments in one read-only, repeatable-read PostgreSQL transaction.
- Bind consumers to authenticated principal, instance, project, environment, model and serving generation. Unknown/missing/mismatched/stale/disabled/tombstoned authority fails closed.
- Authorize catalog, Explore, dashboard and semantic API metadata and direct references consistently; shared agent/MCP and materialization paths use the same boundary.
- Validate admitted plan provenance, rendered SQL/arguments/columns and pinned authorization identity before execution and protected output release.
- Preserve explicitly public paths and separately authorized Source/Model authoring previews.

No second policy evaluator or planner is introduced. FAI-639 compiler semantics and FAI-641 SecurityBarrier semantics are unchanged. Planner hooks capture existing admission and reject inconsistent decisions.

## Scope

64 files, +5746/-127: access resolution; query discovery/context; consumer adapters and materialization guards; capability-specific tests; architecture documentation (plus navigation and generated documentation index).

Explicitly excluded: FAI-645 lifecycle/cache invalidation/audit expansion, FAI-648 exhaustive qualification, FAI-649 activation/cutover, provider integrations, unrelated UI/admin work and VAL-11 expansion. Protected reuse/bundles without proven authorization deny or bypass reuse rather than introducing cache lifecycle behavior. Neutral activation verification remains fail-closed and deferred. VAL-11 remains Partial.

## Tests and verification

Original publication validation (historical head):
- Query/PlanIR/planner, materialization, query authorization, dashboard HTTP/semantic API, Explore/catalog/project module, compiler integration, access/control-plane and architecture tests.
- Real Docker/PostgreSQL 18 coherent authority resolver regressions.
- `task generated:check`
- `task security:test` (hermetic security, not live dependency-advisory clearance)
- `task quality:budget:check`
- `git diff --check`

Previously recorded on earlier heads: focused FAI-642 regressions ×10; all four application shards; complete 52-package PostgreSQL conformance lane; MinIO integration; APIGen Go and 62 TypeSpec tests; documentation links; standalone site tests (51 passed) and Mermaid tests (3 passed).

Coverage includes deterministic discovery, unknown/conflicting metadata, authority and ownership rejection, direct-reference/metadata equivalence, same-name member collisions, changed decisions, cross-scope replay, copied/mutated plans, stale buffered/streamed output and public regressions.

## Local CI limitation — full local CI is NOT green

The frontend/site lane exceeded its existing 180-second watchdog on both attempts during active tests; no assertion failure was observed. A subsequent unchanged rerun reproduced both timeouts. Core/reports/chat/data completed, leaving site tests only approximately 23–24 seconds before termination. Standalone site tests previously passed in 45.43 seconds.

This appears environment/resource-related cumulative runtime, not a demonstrated FAI-642 assertion regression. Hosted CI is the authoritative validation for this lane; a hosted pass is not assumed. No timeouts, CI policy, dependency manifests or lockfiles were changed. An earlier custom-TMPDIR securitysource test limitation was resolved by using supported TMPDIR=/var/tmp; hermetic security tests pass. Earlier npm installation reported two high-severity warnings without advisory details; live dependency-security clearance is not claimed.

## Tracking

[FAI-642 — Route discovery and every semantic consumer through one authorization boundary](https://linear.app/flid/issue/FAI-642/route-discovery-and-every-semantic-consumer-through-one-authorization)

Review publication only. Do not merge automatically. FAI-645 must wait for FAI-642 merge.


## Documentation-only Gitleaks correction and history rewrite

The pinned Gitleaks v8.30.1 generic-api-key rule falsely matched ordinary prose at adr/specifications/semantic-access-consumer-boundary.md:30 in original commit 9683a3eb5. Reproduced against both the file and candidate history; no credential was present. The sentence now describes “planning for the semantic interface” and “buffered/Arrow execution in materialize,” preserving its meaning.

Reconstructed only the two unmerged FAI-642 commits on their existing main ancestor 36204a40da64a0371ff7a1c34d0585d44e6e0171:
- 9683a3eb5 → 46682e27f1d06c5d49090afd142d32ec6a33674f (documentation wording corrected in originating commit)
- 46e6b7b51 → f4bd1c4134b86ae82e6cea159b3afb113014fdc8 (typed read-only transaction patch unchanged)

Old head: 46e6b7b5134890e7cde7422dca9b6d42c2ff2361.
New head: f4bd1c4134b86ae82e6cea159b3afb113014fdc8.

Range-diff verifies only the prose correction; every file outside that document is identical to the old head. No production behavior, generated output, merged commit, security rule/allowlist, or main change. Retained a local recovery branch. Pushed using --force-with-lease explicitly pinned to the old remote SHA; remote and PR head verified.

Validation on rewritten head PASS:
- Full task security:source, including current-tree Gitleaks (~43.53 MB, no leaks) and candidate-history Gitleaks (2 commits, no leaks), plus source/IaC scanning.
- Query/PlanIR, materialize, dashboard queryauthz/semanticapi/HTTP, project HTTP/catalog/module, access module, architecture/conformance and documentation tests (-count=1).
- task security:test; task generated:check; task quality:budget:check; git diff --check.
- Working tree clean.

Fresh GitHub CI is queued/running; no hosted pass is claimed yet. PR remains conflict-free but behind current main, intentionally preserving the documentation-only tree change. The earlier local aggregate frontend runtime limitation remains documented, not fixed by this change. FAI-642 stays In Review; no FAI-645 work or automatic merge.