### PR TITLE
Keep tiled map scales truthful without value bindings

### DIFF
--- a/docs/visuals/map.md
+++ b/docs/visuals/map.md
@@ -130,6 +130,8 @@ visuals:
 ## Density
 
 Emphasize the concentration of observations without requiring a value binding.
+With no value binding, raw features contribute one observation and aggregate
+cells are weighted by their contained row count.
 
 {{< visual id="order_density_map" >}}
 

--- a/web/components/dashboard/visualization/adapters/maplibre.test.ts
+++ b/web/components/dashboard/visualization/adapters/maplibre.test.ts
@@ -321,6 +321,83 @@ test('MapLibre tiled layers reuse one native source and stable server-provided d
   expect(vectorTileTemplateURL(envelope.dataState.kind === 'spatial_tiled' ? envelope.dataState.tileURL : '', 'https://example.test/dashboard')).toBe('https://example.test/dashboards/orders/visuals/orders-map/tiles/revision/{z}/{x}/{y}.mvt')
 })
 
+test('MapLibre tiled no-value layers weight raw observations and aggregate counts', () => {
+	const envelope = tiledPointEnvelope()
+	if (envelope.spec.kind !== 'geographic' || envelope.dataState.kind !== 'spatial_tiled') throw new Error('tiled map fixture is unavailable')
+	const point = envelope.spec.layers[0]
+	if (!point || point.kind !== 'point') throw new Error('point layer fixture is unavailable')
+	const pointWithoutValue = { ...point, value: undefined }
+	const pointStyle = mapLayer('lv-orders', pointWithoutValue, envelope.dataState, 'lv-map-tiles')
+	const pointWeight = (((pointStyle.paint['circle-radius'][3] as unknown[])[3] as unknown[])[2] as unknown[])[1] as unknown[]
+	expect(pointWeight[3]).toBe(1)
+	expect(JSON.stringify(pointWeight)).toContain('__lv_count')
+	expect(JSON.stringify(pointWeight)).toContain('14999')
+	const density = {
+		id: 'customers', kind: 'density',
+		latitude: { dataset: 'primary', field: 'latitude' }, longitude: { dataset: 'primary', field: 'longitude' },
+		tooltip: [], position: 'above_labels', visibility: { minimumZoom: 0, maximumZoom: 18 },
+		color: { kind: 'sequential', palette: 'blue', reverse: false, nullColor: '#d0d7de' },
+		heat: { radius: 22, intensity: 1.35 }, opacity: .86,
+	} as VisualizationGeographicLayer
+	if (density.kind !== 'density') throw new Error('density layer fixture is unavailable')
+	const raw = mapLayer('lv-customers', density, envelope.dataState, 'lv-map-tiles')
+	const aggregate = tiledAggregateHeatLayer('lv-customers-aggregate', 'lv-map-tiles', density, envelope.dataState)
+	const rawWeight = (raw.paint['heatmap-weight'] as unknown[])[1] as unknown[]
+	expect(rawWeight[3]).toBe(1)
+	expect(JSON.stringify(aggregate.paint['heatmap-weight'])).toContain('__lv_count')
+	expect(JSON.stringify(aggregate.paint['heatmap-weight'])).toContain('14999')
+	const heat = { ...density, kind: 'heat' } as VisualizationGeographicLayer
+	const heatRaw = mapLayer('lv-heat', heat, envelope.dataState, 'lv-map-tiles')
+	const heatAggregate = tiledAggregateHeatLayer('lv-heat-aggregate', 'lv-map-tiles', heat as Extract<VisualizationGeographicLayer, { kind: 'heat' }>, envelope.dataState)
+	expect(((heatRaw.paint['heatmap-weight'] as unknown[])[1] as unknown[])[3]).toBe(1)
+	expect(JSON.stringify(heatAggregate.paint['heatmap-weight'])).toContain('__lv_count')
+})
+
+test('MapLibre tiled scales merge partial and full authored domains with server domains', () => {
+	const envelope = tiledPointEnvelope()
+	if (envelope.spec.kind !== 'geographic' || envelope.dataState.kind !== 'spatial_tiled') throw new Error('tiled map fixture is unavailable')
+	const point = envelope.spec.layers[0]
+	if (!point || point.kind !== 'point') throw new Error('point layer fixture is unavailable')
+	const partial = {
+		...point,
+		size: { ...point.size, domainMinimum: 100 },
+		color: { ...point.color, domainMinimum: 50 },
+	}
+	const partialStyle = mapLayer('lv-orders', partial, envelope.dataState, 'lv-map-tiles')
+	const partialRadius = JSON.stringify(partialStyle.paint['circle-radius'])
+	const partialColor = JSON.stringify(partialStyle.paint['circle-color'])
+	expect(partialRadius).toContain('100')
+	expect(partialRadius).toContain('400')
+	expect(partialRadius).toContain('4900')
+	expect(partialColor).toContain('50')
+	expect(partialColor).toContain('450')
+	expect(partialColor).toContain('4950')
+	const full = {
+		...point,
+		color: { ...point.color, domainMinimum: 100, domainMidpoint: 200, domainMaximum: 320 },
+	}
+	const fullColor = JSON.stringify(mapLayer('lv-orders', full, envelope.dataState, 'lv-map-tiles').paint['circle-color'])
+	expect(fullColor).toContain('100')
+	expect(fullColor).toContain('200')
+	expect(fullColor).toContain('120')
+	expect(fullColor).toContain('"<="')
+	expect(fullColor).not.toContain('5000')
+})
+
+test('MapLibre tiled scales preserve constant and boundary domain semantics', () => {
+	const envelope = tiledPointEnvelope()
+	if (envelope.spec.kind !== 'geographic' || envelope.dataState.kind !== 'spatial_tiled') throw new Error('tiled map fixture is unavailable')
+	const point = envelope.spec.layers[0]
+	if (!point || point.kind !== 'point') throw new Error('point layer fixture is unavailable')
+	const state = { ...envelope.dataState, rawDomains: [{ field: 'revenue', minimum: 10, maximum: 10 }], aggregateDomains: [{ field: 'revenue', minimum: 100, maximum: 100 }] }
+	const color = JSON.stringify(mapLayer('lv-orders', point, state, 'lv-map-tiles').paint['circle-color'])
+	expect(color).toContain('["case",["==",["to-number",["get","revenue"],0],0],0,1]')
+	const bounded = JSON.stringify(mapLayer('lv-orders', { ...point, color: { ...point.color, domainMinimum: 20, domainMaximum: 80 } }, envelope.dataState, 'lv-map-tiles').paint['circle-color'])
+	expect(bounded).toContain('["max",0,["min",1')
+	expect(bounded).toContain('20')
+	expect(bounded).toContain('80')
+})
+
 test('MapLibre exposes selection controls for inline and tile-backed maps', () => {
   const tiled = tiledPointEnvelope()
   expect(tiled.spec.interactions.some((candidate) => candidate.kind === 'select')).toBe(true)

--- a/web/components/dashboard/visualization/adapters/maplibre/layers.ts
+++ b/web/components/dashboard/visualization/adapters/maplibre/layers.ts
@@ -29,7 +29,7 @@ export function mapLayer(id: string, layerOrKind: VisualizationGeographicLayer |
 	if (kind === 'point') {
 		const point = layer?.kind === 'point' ? layer : undefined
 		const minimumRadius = point?.size?.minimumRadius ?? 5, maximumRadius = point?.size?.maximumRadius ?? 10
-		const weight = tiled && point ? tiledWeightExpression(point, tiled) : ['get', '__lv_weight']
+		const weight = tiled && point ? tiledWeightExpression(point, tiled, point.size) : ['get', '__lv_weight']
 		const aggregateMinimumRadius = Math.max(12, minimumRadius)
 		const aggregateMaximumRadius = Math.max(50, maximumRadius)
 		const radius = tiled
@@ -39,7 +39,7 @@ export function mapLayer(id: string, layerOrKind: VisualizationGeographicLayer |
 	}
 	const heat = layer?.kind === 'heat' || layer?.kind === 'density' ? layer : undefined
 	const colors = paletteColors(heat?.color)
-	const weight = tiled && heat ? tiledWeightExpression(heat, tiled) : ['get', '__lv_weight']
+	const weight = tiled && heat ? tiledWeightExpression(heat, tiled, heat.color) : ['get', '__lv_weight']
 	return { id, source: sourceID, ...(tiled ? { 'source-layer': 'primary', filter: ['==', ['boolean', ['get', '__lv_aggregate'], false], false], minzoom: Math.max(heat?.visibility.minimumZoom ?? 0, tiled.rawMinimumZoom), maxzoom: heat?.visibility.maximumZoom } : {}), type: 'heatmap', paint: {
 		'heatmap-weight': ['*', weight, ['case', featureFlag('__lv_selected'), 1, featureFlag('__lv_has_selection'), 0.75, featureFlag('__lv_highlighted'), 1, featureFlag('__lv_has_highlight'), 0.15, 0.75]],
     'heatmap-intensity': heat?.heat.intensity ?? (kind === 'density' ? 1.35 : 1),
@@ -113,24 +113,31 @@ function tiledValueField(layer: Extract<VisualizationGeographicLayer, { kind: 'p
 	return layer.value?.field ?? '__lv_count'
 }
 
-function tiledWeightExpression(layer: Extract<VisualizationGeographicLayer, { kind: 'point' | 'heat' | 'density' }>, state: SpatialTiledVisualizationDataState): unknown[] {
+type TiledScaleDomain = { minimum?: number; maximum?: number; total?: number }
+type AuthoredScaleDomain = { domainMinimum?: number; domainMidpoint?: number; domainMaximum?: number }
+
+function tiledWeightExpression(layer: Extract<VisualizationGeographicLayer, { kind: 'point' | 'heat' | 'density' }>, state: SpatialTiledVisualizationDataState, authored?: AuthoredScaleDomain): unknown[] {
 	const field = tiledValueField(layer)
 	const raw = state.rawDomains.find((domain) => domain.field === field)
 	const aggregate = state.aggregateDomains.find((domain) => domain.field === field)
-	const normalize = (domain: typeof raw): unknown[] => {
-		const minimum = domain?.minimum ?? 0, maximum = domain?.maximum ?? Math.max(minimum + 1, 1)
-		if (minimum === maximum) return ['case', ['==', ['to-number', ['get', field], 0], 0], 0, 1]
-		return ['max', 0, ['min', 1, ['/', ['-', ['to-number', ['get', field], 0], minimum], maximum - minimum]]]
+	if (!layer.value) {
+		// Raw tiles carry one feature per coordinate and do not have a synthetic
+		// count property. Aggregate tiles carry __lv_count, so normalize it against
+		// the exact revision cardinality instead of treating every cell as 1.
+		const countDomain = aggregate ?? countFallbackDomain(state)
+		const rawDomain = resolveTiledDomain(raw, authored, { minimum: 1, maximum: 1 })
+		const aggregateDomain = resolveTiledDomain(countDomain, authored, countFallbackDomain(state))
+		return ['case', ['boolean', ['get', '__lv_aggregate'], false], normalizeTiledValue('__lv_count', aggregateDomain, 1), authoredDomainSpecified(authored) ? normalizeTiledValue('__lv_count', rawDomain, 1) : 1]
 	}
-	return ['case', ['boolean', ['get', '__lv_aggregate'], false], normalize(aggregate), normalize(raw)]
+	const rawDomain = resolveTiledDomain(raw, authored)
+	const aggregateDomain = resolveTiledDomain(aggregate, authored)
+	return ['case', ['boolean', ['get', '__lv_aggregate'], false], normalizeTiledValue(field, aggregateDomain), normalizeTiledValue(field, rawDomain)]
 }
 
 function tiledAggregateHeatWeightExpression(layer: Extract<VisualizationGeographicLayer, { kind: 'heat' | 'density' }>, state: SpatialTiledVisualizationDataState): unknown[] {
 	const field = tiledValueField(layer)
-	const domain = state.aggregateDomains.find((candidate) => candidate.field === field)
-	const minimum = domain?.minimum ?? 0, maximum = domain?.maximum ?? Math.max(minimum + 1, 1)
-	if (minimum === maximum) return ['case', ['==', ['to-number', ['get', field], 0], 0], 0, 1]
-	const normalized = ['max', 0, ['min', 1, ['/', ['-', ['to-number', ['get', field], 0], minimum], maximum - minimum]]]
+	const domain = resolveTiledDomain(state.aggregateDomains.find((candidate) => candidate.field === field), layer.color, !layer.value ? countFallbackDomain(state) : undefined)
+	const normalized = normalizeTiledValue(field, domain, 1)
 	// Whole-filter totals provide a stable aggregate domain across tile loads,
 	// but make low-zoom cell values tiny on large datasets. Square-root scaling
 	// preserves that stable domain while retaining visible differences.
@@ -139,10 +146,49 @@ function tiledAggregateHeatWeightExpression(layer: Extract<VisualizationGeograph
 
 function tiledColorExpression(layer: Extract<VisualizationGeographicLayer, { kind: 'point' | 'heat' | 'density' }>, state: SpatialTiledVisualizationDataState): unknown[] {
 	const colors = paletteColors(layer.color)
-	const weight = tiledWeightExpression(layer, state)
+	const weight = tiledWeightExpression(layer, state, layer.color)
 	const raw = ['interpolate', ['linear'], weight, 0, colors[0], 0.25, colors[1], 0.5, colors[2], 0.75, colors[3], 1, colors[4]]
 	const aggregate = ['interpolate', ['linear'], ['sqrt', weight], 0, colors[2], 0.5, colors[3], 1, colors[4]]
 	return ['case', ['boolean', ['get', '__lv_aggregate'], false], aggregate, raw]
+}
+
+function countFallbackDomain(state: SpatialTiledVisualizationDataState): TiledScaleDomain {
+	const cardinality = state.cardinality.kind === 'exact' && typeof state.cardinality.count === 'number' && Number.isFinite(state.cardinality.count)
+		? Math.max(1, state.cardinality.count)
+		: 1
+	return { minimum: 1, maximum: cardinality }
+}
+
+function authoredDomainSpecified(domain?: AuthoredScaleDomain): boolean {
+	return domain?.domainMinimum !== undefined || domain?.domainMidpoint !== undefined || domain?.domainMaximum !== undefined
+}
+
+function resolveTiledDomain(server: TiledScaleDomain | undefined, authored?: AuthoredScaleDomain, fallback?: TiledScaleDomain): TiledScaleDomain & { midpoint?: number } {
+	let minimum = authored?.domainMinimum ?? server?.minimum ?? fallback?.minimum ?? 0
+	let maximum = authored?.domainMaximum ?? server?.maximum ?? fallback?.maximum ?? Math.max(minimum + 1, 1)
+	// A partial authored domain may be the only bound available (notably for
+	// count-weighted layers, which have no server metric domain). Keep the
+	// existing bounded normalization semantics instead of allowing a negative
+	// span to invert the scale.
+	if (maximum < minimum) {
+		if (authored?.domainMinimum !== undefined && authored.domainMaximum === undefined) maximum = Math.max(minimum + 1, maximum)
+		else if (authored?.domainMaximum !== undefined && authored.domainMinimum === undefined) minimum = Math.min(maximum - 1, minimum)
+		else maximum = minimum
+	}
+	const midpoint = authored?.domainMidpoint
+	return { minimum, maximum, midpoint: midpoint !== undefined && midpoint > minimum && midpoint < maximum ? midpoint : undefined }
+}
+
+function normalizeTiledValue(field: string, domain: TiledScaleDomain & { midpoint?: number }, fallback = 0): unknown[] {
+	const minimum = domain.minimum ?? 0
+	const maximum = domain.maximum ?? Math.max(minimum + 1, 1)
+	const value = ['to-number', ['get', field], fallback]
+	if (minimum === maximum) return ['case', ['==', value, 0], 0, 1]
+	const clamp = (numerator: unknown[], denominator: number): unknown[] => ['max', 0, ['min', 1, ['/', numerator, denominator]]]
+	const linear = clamp(['-', value, minimum], maximum - minimum)
+	if (domain.midpoint === undefined) return linear
+	const midpoint = domain.midpoint
+	return ['case', ['<=', value, midpoint], ['*', 0.5, clamp(['-', value, minimum], midpoint - minimum)], ['+', 0.5, ['*', 0.5, clamp(['-', value, midpoint], maximum - midpoint)]]]
 }
 
 function abbreviatedNumberExpression(field: string): unknown[] {


### PR DESCRIPTION
## What

- Weight value-less tiled point, heat, and density layers by observation counts.
- Apply authored color and size domains over server-derived tiled domains.
- Cover partial, constant, midpoint, and boundary domains.

## Why

- Prevent tiled maps from ignoring public scale intent or flattening count-based density.

## Validation

- 52 targeted MapLibre tests
- TypeScript typecheck and diff check
- Independent review: PASS

## Contract coverage

Visualization IR/data state → MapLibre renderer → tests/docs.

Linear: FAI-739