### PR TITLE
Reject unsupported reference-layer tooltips

### DIFF
--- a/docs/visuals/map.md
+++ b/docs/visuals/map.md
@@ -160,7 +160,9 @@ visuals:
 ## Reference boundary
 
 Reference layers add immutable, content-addressed geometry without joining
-query values into the shape.
+query values into the shape. Because reference geometry has no query-row
+locator, reference layers do not support `tooltip`; use a data-backed layer
+such as `choropleth` when row-level tooltip context is needed.
 
 {{< visual id="state_reference_map" >}}
 

--- a/internal/dashboard/compiler/document_compile_geographic.go
+++ b/internal/dashboard/compiler/document_compile_geographic.go
@@ -138,6 +138,9 @@ func canonicalGeographicLayers(value *document.GeographicDashboardPresentation, 
 			if variant == nil {
 				return nil, fmt.Errorf("map layer %d variant is nil", index)
 			}
+			if variant.Tooltip != nil && len(*variant.Tooltip) > 0 {
+				return nil, fmt.Errorf("presentation.layers[%d].tooltip: reference layers do not support tooltip fields because reference geometry has no query-row locator", index)
+			}
 			layer, err = canonicalReferenceGeographicLayer(variant, query)
 		case *document.DashboardHeatGeographicLayer:
 			if variant == nil {

--- a/internal/dashboard/compiler/document_compile_visualization_test.go
+++ b/internal/dashboard/compiler/document_compile_visualization_test.go
@@ -121,6 +121,43 @@ func TestCompileVisualsAcceptsOnePointMarkFillAndRejectsDuplicate(t *testing.T) 
 	}
 }
 
+func TestCanonicalGeographicReferenceLayerTooltipContract(t *testing.T) {
+	t.Parallel()
+
+	for name, tooltip := range map[string]*[]string{
+		"omitted": nil,
+		"empty":   func() *[]string { values := []string{}; return &values }(),
+	} {
+		name, tooltip := name, tooltip
+		t.Run(name, func(t *testing.T) {
+			layers, err := canonicalGeographicLayers(referenceMapPresentation(tooltip), LoweredDashboardQuery{})
+			if err != nil {
+				t.Fatalf("canonicalGeographicLayers() error = %v", err)
+			}
+			if got := len(layers[0].Value.(*visualizationir.VisualizationReferenceLayer).Tooltip); got != 0 {
+				t.Fatalf("reference tooltip length = %d, want 0", got)
+			}
+		})
+	}
+
+	tooltip := []string{"state"}
+	_, err := canonicalGeographicLayers(referenceMapPresentation(&tooltip), LoweredDashboardQuery{})
+	if err == nil || !strings.Contains(err.Error(), "presentation.layers[0].tooltip") || !strings.Contains(err.Error(), "query-row locator") {
+		t.Fatalf("canonicalGeographicLayers() error = %v, want a path-bearing reference tooltip diagnostic", err)
+	}
+}
+
+func referenceMapPresentation(tooltip *[]string) *document.GeographicDashboardPresentation {
+	layers := []document.DashboardGeographicLayer{{Value: &document.DashboardReferenceGeographicLayer{
+		DashboardGeographicLayerBase: document.DashboardGeographicLayerBase{
+			DashboardGeographicLayerOptions: document.DashboardGeographicLayerOptions{ID: "boundaries", Tooltip: tooltip},
+			Kind:                            "reference",
+		},
+		Kind: "reference", GeometryAsset: "brazil_states",
+	}}}
+	return &document.GeographicDashboardPresentation{Type: "geographic", Layers: &layers}
+}
+
 func lowerPointColorScaleSpec(t *testing.T, color string, scale *document.PointDashboardColorScale) (visualizationir.VisualizationSpec, error) {
 	t.Helper()
 	authored := document.DashboardPresentation{Value: &document.PointDashboardPresentation{

--- a/internal/dashboard/visualization/ir/frame.go
+++ b/internal/dashboard/visualization/ir/frame.go
@@ -374,6 +374,9 @@ func validateSpecification(spec VisualizationSpec, base VisualizationSpecBase) (
 	if err := validateVisualCalculations(base.Calculations, schemas); err != nil {
 		return nil, err
 	}
+	if err := validateGeographicReferenceTooltips(spec); err != nil {
+		return nil, err
+	}
 	for _, ref := range specificationRefs(spec) {
 		if err := validateFieldRef(ref, schemas); err != nil {
 			return nil, err
@@ -425,6 +428,23 @@ func validateSpecification(spec VisualizationSpec, base VisualizationSpecBase) (
 		}
 	}
 	return schemas, nil
+}
+
+func validateGeographicReferenceTooltips(spec VisualizationSpec) error {
+	value, ok := spec.Value.(*GeographicVisualizationSpec)
+	if !ok {
+		return nil
+	}
+	for index, layer := range value.Layers {
+		base, err := layer.Base()
+		if err != nil {
+			return err
+		}
+		if _, ok := layer.Value.(*VisualizationReferenceLayer); ok && len(base.Tooltip) > 0 {
+			return fmt.Errorf("spec.layers[%d].tooltip: reference layers do not support tooltip fields because reference geometry has no query-row locator", index)
+		}
+	}
+	return nil
 }
 
 func validateLabelPolicy(spec VisualizationSpec) error {

--- a/internal/dashboard/visualization/ir/frame_test.go
+++ b/internal/dashboard/visualization/ir/frame_test.go
@@ -3,6 +3,7 @@ package ir
 import (
 	"encoding/json"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -145,6 +146,53 @@ func TestValidateSpecEnforcesGeographicLayerRequirements(t *testing.T) {
 	if err := ValidateSpec(choropleth); err == nil {
 		t.Fatal("choropleth layer without geometry was accepted")
 	}
+}
+
+func TestValidateSpecReferenceLayerTooltipContract(t *testing.T) {
+	for name, tooltip := range map[string][]VisualizationFieldRef{
+		"omitted": nil,
+		"empty":   {},
+	} {
+		name, tooltip := name, tooltip
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateSpec(referenceTooltipSpec(tooltip)); err != nil {
+				t.Fatalf("ValidateSpec() error = %v", err)
+			}
+		})
+	}
+
+	err := ValidateSpec(referenceTooltipSpec([]VisualizationFieldRef{{Dataset: "primary", Field: "label"}}))
+	if err == nil || !strings.Contains(err.Error(), "spec.layers[0].tooltip") || !strings.Contains(err.Error(), "query-row locator") {
+		t.Fatalf("ValidateSpec() error = %v, want a path-bearing reference tooltip diagnostic", err)
+	}
+}
+
+func referenceTooltipSpec(tooltip []VisualizationFieldRef) VisualizationSpec {
+	base := VisualizationSpecBase{
+		Kind: "geographic", Title: "Boundaries",
+		Datasets: []VisualizationDatasetSchema{{ID: "primary", Fields: []VisualizationField{
+			{ID: "label", Role: VisualizationFieldRoleDimension, DataType: VisualizationDataTypeString, Label: "Label"},
+		}}},
+		DataBudget:    VisualizationDataBudget{MaxRows: 100, RequiredCompleteness: VisualizationCompletenessComplete},
+		Accessibility: VisualizationAccessibility{Title: "Boundaries", Description: "Reference boundaries"},
+		Interactions:  []VisualizationInteraction{},
+	}
+	layerBase := VisualizationGeographicLayerBase{
+		ID: "boundaries", Kind: "reference", Tooltip: tooltip,
+		Position: VisualizationMapLayerPositionBelowLabels, Visibility: VisualizationMapVisibility{MaximumZoom: 24},
+	}
+	return VisualizationSpec{Value: &GeographicVisualizationSpec{
+		VisualizationSpecBase: base, Kind: "geographic",
+		Layers: []VisualizationGeographicLayer{{Value: &VisualizationReferenceLayer{
+			VisualizationGeographicLayerBase: layerBase, Kind: "reference",
+			Geometry: VisualizationGeometryAsset{
+				ID: "br-states", Source: "IBGE", License: "terms", Attribution: "IBGE",
+				IdentifierSystem: "br-uf", URL: "/static/geometry/br-states.geojson",
+				Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			},
+		}}},
+		Presentation: GeographicVisualizationPresentation{VisualizationPresentation: testVisualizationPresentation(VisualizationLegendPositionHidden)},
+	}}
 }
 
 func TestValidateEnvelopeAcceptsRowFreeSpatialTiledState(t *testing.T) {


### PR DESCRIPTION
## What

- Reject non-empty tooltips on geographic reference layers.
- Preserve omitted and empty tooltip configurations.
- Add path-bearing compiler/IR tests and accurate map docs.

## Why

- Reference-layer tooltips were silently ignored by MapLibre.

## Validation

- Focused compiler and visualization IR Go tests
- Generation and diff checks

## Contract coverage

Dashboard authoring → compiler → IR validation → renderer applicability → tests/docs.

Linear: FAI-739