### PR TITLE
Honor table header visibility across tabular visuals

### DIFF
--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -1170,6 +1170,43 @@ test('selected sticky table cells preserve the visible row highlight', async () 
   }
 })
 
+test('report tables omit semantic headers without shifting body rows when showHeader is false', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
+  try {
+    await page.goto(baseURL)
+    await page.waitForFunction(() => {
+      const dashboard = document.querySelector('lv-dashboard-page') as any
+      const hosts = Array.from(dashboard?.shadowRoot?.querySelectorAll('lv-visualization-host') ?? []) as any[]
+      const tableHost = hosts.find((host) => host.envelope?.visualID === 'orders')
+      return Boolean(tableHost?.shadowRoot?.querySelector('lv-report-table')?.shadowRoot?.querySelector('.canvas > .row'))
+    })
+    const result = await page.locator('lv-dashboard-page').evaluate(async (dashboard: any) => {
+      const tableHost = Array.from(dashboard.shadowRoot.querySelectorAll('lv-visualization-host'))
+        .find((candidate: any) => candidate.envelope?.visualID === 'orders') as any
+      const table = tableHost.shadowRoot.querySelector('lv-report-table') as any
+      table.table = { ...table.table, style: { ...table.table.style, showHeader: false } }
+      await table.updateComplete
+      const root = table.shadowRoot
+      const shell = root.querySelector('.shell') as HTMLElement
+      const firstRow = root.querySelector('.canvas > .row') as HTMLElement
+      return {
+        headerNodes: root.querySelectorAll('.head, .group-head, [role="columnheader"]').length,
+        rowCount: root.querySelectorAll('.canvas > .row').length,
+        cellActionLabels: root.querySelectorAll('.cell-action[aria-label]').length,
+        headOffset: shell.style.getPropertyValue('--lv-head-top'),
+        firstRowTop: firstRow?.style.top,
+      }
+    })
+    expect(result.headerNodes).toBe(0)
+    expect(result.rowCount).toBeGreaterThan(0)
+    expect(result.cellActionLabels).toBeGreaterThan(0)
+    expect(result.headOffset).toBe('0px')
+    expect(result.firstRowTop).toBe('0px')
+  } finally {
+    await page.close()
+  }
+})
+
 test('table resize handles expose keyboard increments and accessible labels', async () => {
   const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
   try {

--- a/web/components/dashboard/table/block-source.test.ts
+++ b/web/components/dashboard/table/block-source.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, test } from 'bun:test'
 
 import { emptyTable, normalizeTable, preserveCardinality } from './block-source'
 
+test('normalizes legacy table styles with headers enabled unless explicitly hidden', () => {
+  const legacyTable = JSON.parse(JSON.stringify(emptyTable)) as typeof emptyTable
+  delete (legacyTable.style as Partial<typeof legacyTable.style>).showHeader
+
+  expect(normalizeTable(legacyTable).style.showHeader).toBe(true)
+  expect(normalizeTable({
+    ...emptyTable,
+    style: { ...emptyTable.style, showHeader: false },
+  }).style.showHeader).toBe(false)
+})
+
 describe('progressive table cardinality', () => {
   test('normalizes an unknown total without hiding the available window', () => {
     const table = normalizeTable({

--- a/web/components/dashboard/table/block-source.ts
+++ b/web/components/dashboard/table/block-source.ts
@@ -119,6 +119,7 @@ export function normalizeStyle(style: Partial<TableStyle> | undefined): TableSty
     density,
     grid,
     zebra: typeof style?.zebra === 'boolean' ? style.zebra : defaultTableStyle.zebra,
+    showHeader: typeof style?.showHeader === 'boolean' ? style.showHeader : defaultTableStyle.showHeader,
   }
 }
 

--- a/web/components/dashboard/table/report-table.ts
+++ b/web/components/dashboard/table/report-table.ts
@@ -1596,7 +1596,8 @@ export class ReportTable extends LitElement {
     const columnModels = allTableColumns(tanstack)
     const tanstackRows = new Map((tanstack.getRowModel?.().rows ?? []).map((row: any) => [row.id, row]))
     const totalHeight = this.availableRows * this.rowHeight
-    const hasGroupHeaderRow = headers.some((header: any) => header.column.columnDef.meta?.column?.group)
+    const showHeader = this.table.style.showHeader !== false
+    const hasGroupHeaderRow = showHeader && headers.some((header: any) => header.column.columnDef.meta?.column?.group)
     const rowRange = this.rowRangeText()
     const selectedCount = this.selectedRowCount()
     const hasSelection = selectedCount > 0
@@ -1668,8 +1669,8 @@ export class ReportTable extends LitElement {
           <div class="table-scrollport" role="table" aria-label=${this.table?.title ?? 'Orders'} tabindex="0" ${ref(this.bodyViewportRef)} @scroll=${this.handleScroll}>
             <div class="table-plane">
               ${this.resizeGuideX >= 0 ? html`<span class="resize-guide" style=${`--lv-resize-guide-x:${this.resizeGuideX}px`}></span>` : nothing}
-              ${this.renderGroupHeaderRows(headers)}
-              ${this.renderHeaderRow(headers)}
+              ${showHeader ? this.renderGroupHeaderRows(headers) : nothing}
+              ${showHeader ? this.renderHeaderRow(headers) : nothing}
               ${this.availableRows === 0 && !loading ? html`<div class="empty">Waiting for table data</div>` : html`
                 <div class="canvas" role="rowgroup" style=${`height:${totalHeight}px`}>
                   <div class="grid-lines" aria-hidden="true">

--- a/web/components/dashboard/table/types.ts
+++ b/web/components/dashboard/table/types.ts
@@ -52,6 +52,7 @@ export interface TableStyle {
   density: 'compact' | 'comfortable' | 'spacious'
   zebra: boolean
   grid: 'none' | 'rows' | 'columns' | 'full'
+  showHeader: boolean
 }
 
 export interface InteractionConfig {
@@ -123,4 +124,4 @@ export const blockIDs: BlockID[] = ['a', 'b', 'c']
 export const defaultChunkSize = 50
 export const defaultRowHeight = 34
 export const defaultSort: TableSort = { key: 'purchase_date', direction: 'desc' }
-export const defaultTableStyle: TableStyle = { density: 'comfortable', zebra: true, grid: 'rows' }
+export const defaultTableStyle: TableStyle = { density: 'comfortable', zebra: true, grid: 'rows', showHeader: true }

--- a/web/components/dashboard/visualization/adapters/tanstack.test.ts
+++ b/web/components/dashboard/visualization/adapters/tanstack.test.ts
@@ -67,6 +67,65 @@ test('TanStack adapter leaves row interaction disabled when the IR declares none
   expect(tableSignal(envelope).interaction).toBeUndefined()
 })
 
+test('TanStack adapter propagates showHeader for every tabular visual kind', () => {
+  const tabularEnvelope = (kind: 'table' | 'matrix' | 'pivot'): VisualizationEnvelope => {
+    const fields = [
+      { id: 'state', role: 'dimension', dataType: 'string', nullable: false, label: 'State' },
+      { id: 'revenue', role: 'metric', dataType: 'decimal', nullable: false, label: 'Revenue' },
+    ]
+    const grid = {
+      kind,
+      title: kind,
+      datasets: [{ id: 'primary', fields }],
+      dataBudget: { maxRows: 100, requiredCompleteness: 'complete' },
+      accessibility: { title: kind, description: kind },
+      interactions: [],
+      presentation: { rowHeight: 34, striped: true, showHeader: false },
+      ...(kind === 'table'
+        ? {
+            columns: [{ field: { dataset: 'primary', field: 'state' }, label: 'State', formatting: [] }],
+            defaultSort: [],
+          }
+        : {
+            rows: [{ dataset: 'primary', field: 'state' }],
+            columns: [{ dataset: 'primary', field: 'state' }],
+            metrics: [{ dataset: 'primary', field: 'revenue' }],
+            metricFormatting: {},
+            ...(kind === 'pivot' ? { totals: { rows: false, columns: false, grand: false }, window: { limit: 100 } } : {}),
+          }),
+    }
+    return {
+      schemaVersion: 9, visualID: kind, rendererID: 'tanstack', specRevision: `sha256:${kind}`, dataRevision: 1,
+      spec: grid,
+      dataState: {
+        kind: 'inline', specRevision: `sha256:${kind}`, dataRevision: 1, generation: 1,
+        datasets: [{ id: 'primary', specRevision: `sha256:${kind}`, dataRevision: 1, generation: 1, columns: ['state', 'revenue'], rows: [['CA', 42]], completeness: 'complete' }],
+      },
+      selection: [], status: { kind: 'ready' }, diagnostics: [],
+    } as VisualizationEnvelope
+  }
+
+  for (const kind of ['table', 'matrix', 'pivot'] as const) {
+    expect(tableSignal(tabularEnvelope(kind)).style.showHeader).toBe(false)
+  }
+})
+
+test('TanStack adapter preserves enabled table headers', () => {
+  const envelope = {
+    schemaVersion: 9, visualID: 'orders', rendererID: 'tanstack', specRevision: 'sha256:test', dataRevision: 1,
+    spec: {
+      kind: 'table', title: 'Orders', datasets: [{ id: 'primary', fields: [{ id: 'order_id', role: 'identity', dataType: 'string', nullable: false, label: 'Order' }] }],
+      dataBudget: { maxRows: 100, requiredCompleteness: 'complete' }, accessibility: { title: 'Orders', description: 'Orders' }, interactions: [],
+      columns: [{ field: { dataset: 'primary', field: 'order_id' }, label: 'Order', formatting: [] }], defaultSort: [],
+      presentation: { rowHeight: 34, striped: true, showHeader: true },
+    },
+    dataState: { kind: 'inline', specRevision: 'sha256:test', dataRevision: 1, generation: 1, datasets: [{ id: 'primary', specRevision: 'sha256:test', dataRevision: 1, generation: 1, columns: ['order_id'], rows: [['o1']], completeness: 'complete' }] },
+    selection: [], status: { kind: 'ready' }, diagnostics: [],
+  } as VisualizationEnvelope
+
+  expect(tableSignal(envelope).style.showHeader).toBe(true)
+})
+
 test('TanStack adapter preserves sparse window block identities', () => {
   const envelope = {
     schemaVersion: 9, visualID: 'orders', rendererID: 'tanstack', specRevision: 'sha256:test', dataRevision: 3,

--- a/web/components/dashboard/visualization/adapters/tanstack.ts
+++ b/web/components/dashboard/visualization/adapters/tanstack.ts
@@ -76,7 +76,7 @@ export function tableSignal(envelope: VisualizationEnvelope): TableSignal {
   const interaction = tableInteraction(spec)
   return {
     id: envelope.visualID, version: 2, type: spec.kind, title: resolveVisualizationMetadata(envelope).title,
-    style: { density: spec.presentation.rowHeight <= 30 ? 'compact' : spec.presentation.rowHeight >= 42 ? 'spacious' : 'comfortable', zebra: spec.presentation.striped, grid: 'rows' },
+    style: { density: spec.presentation.rowHeight <= 30 ? 'compact' : spec.presentation.rowHeight >= 42 ? 'spacious' : 'comfortable', zebra: spec.presentation.striped, grid: 'rows', showHeader: spec.presentation.showHeader },
     interaction, selection: tableSelection(envelope, interaction), columns,
     highlight: tableHighlight(envelope, schema?.id ?? 'primary'),
     cardinality: { kind: state.kind === 'windowed' ? state.cardinality.kind : 'exact', value: cardinalityCount },


### PR DESCRIPTION
## What

- Propagate `showHeader` for table, matrix, and pivot visuals.
- Preserve legacy defaults while hiding grouped and leaf headers when disabled.
- Add adapter, block-source, and dashboard DOM coverage.

## Why

- The public option previously reached IR but was ignored by the table renderer.

## Validation

- Adapter/block-source tests (12/12)
- Dashboard DOM tests (56/56)
- App typecheck and diff check

## Contract coverage

Dashboard schema/compiler → IR → TanStack signal → table renderer → tests.

Linear: FAI-739