### PR TITLE
feat(contracts): restore FAI-619 authored metadata prerequisite

### DIFF
--- a/api/data-resources/main.tsp
+++ b/api/data-resources/main.tsp
@@ -26,6 +26,35 @@ scalar SemanticModelResourceName extends string;
 @pattern("^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
 scalar ResourceID extends string;
 
+// Semantic Versioning 2.0.0. Numeric prerelease identifiers may not contain
+// leading zeroes; identifiers containing letters or hyphens remain valid.
+@pattern("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$")
+scalar SemanticVersion extends string;
+
+// APIGen currently does not emit custom scalar `@format` annotations into its
+// JSON Schema output. Keep the annotation for downstream consumers and use a
+// narrow scheme/non-whitespace shape constraint at this contract boundary;
+// complete URI conformance remains a separate hardening concern.
+@format("uri")
+@pattern("^[A-Za-z][A-Za-z0-9+.-]*:[^\\s]+$")
+scalar AuthoritativeURL extends string;
+
+model ContractMetadata {
+  version: SemanticVersion;
+  compatibility: "backward";
+}
+
+model AuthoritativeDefinition {
+  type: "businessDefinition" | "transformationImplementation";
+  url: AuthoritativeURL;
+}
+
+model FieldDeprecation {
+  since: SemanticVersion;
+  reason: string;
+  replacement?: Identifier;
+}
+
 /**
  * Portable access is intentionally tiny. Endpoints, credentials, secret
  * providers, and resolved authentication are target-owned bindings.
@@ -276,6 +305,11 @@ model SourceSchemaField {
   datatype: "String" | "Integer" | "Decimal" | "Float" | "Boolean" | "Date" | "Time" | "DateTime" | "DateTimeTz" | "Opaque";
   nullable?: boolean;
   description?: string;
+  tags?: string[];
+  criticalDataElement?: boolean;
+  classification?: Identifier;
+  authoritativeDefinitions?: AuthoritativeDefinition[];
+  deprecation?: FieldDeprecation;
 }
 
 model AIContext {
@@ -435,6 +469,12 @@ model ModelField {
   label?: string;
   description?: string;
   aiContext?: AIContext;
+  nullable?: boolean;
+  tags?: string[];
+  criticalDataElement?: boolean;
+  classification?: Identifier;
+  authoritativeDefinitions?: AuthoritativeDefinition[];
+  deprecation?: FieldDeprecation;
 }
 
 model ModelEntity {
@@ -449,36 +489,51 @@ model ModelGrain {
 }
 
 model NonNullModelCheck {
+  id: Identifier;
   type: "non_null";
   field: Identifier;
   severity?: "warning" | "error";
+  description?: string;
+  tags?: string[];
 }
 
 model UniqueModelCheck {
+  id: Identifier;
   type: "unique";
   fields: Identifier[];
   severity?: "warning" | "error";
+  description?: string;
+  tags?: string[];
 }
 
 model AcceptedValuesModelCheck {
+  id: Identifier;
   type: "accepted_values";
   field: Identifier;
   values: string[];
   severity?: "warning" | "error";
+  description?: string;
+  tags?: string[];
 }
 
 model RelationshipModelCheck {
+  id: Identifier;
   type: "relationship";
   field: Identifier;
   to: ModelReference;
   severity?: "warning" | "error";
+  description?: string;
+  tags?: string[];
 }
 
 model RowCountModelCheck {
+  id: Identifier;
   type: "row_count";
   minimum?: int64;
   maximum?: int64;
   severity?: "warning" | "error";
+  description?: string;
+  tags?: string[];
 }
 
 @discriminated(#{ envelope: "none", discriminatorPropertyName: "type" })
@@ -797,6 +852,11 @@ model ResourceMetadata {
   provenance?: ResourceProvenance;
 }
 
+model ContractResourceMetadata {
+  ...ResourceMetadata;
+  contract?: ContractMetadata;
+}
+
 // SemanticModel retains the legacy ResourceName grammar while other authored
 // resources use the stricter shared ResourceName contract.
 model SemanticModelMetadata {
@@ -823,7 +883,7 @@ model Connection {
 model Source {
   apiVersion: "leapview.dev/v1";
   kind: "Source";
-  metadata: ResourceMetadata;
+  metadata: ContractResourceMetadata;
   spec: SourceSpec;
 }
 
@@ -831,7 +891,7 @@ model Source {
 model Model {
   apiVersion: "leapview.dev/v1";
   kind: "Model";
-  metadata: ResourceMetadata;
+  metadata: ContractResourceMetadata;
   aiContext?: AIContext;
   spec: ModelSpec;
 }

--- a/docs/articles/concepts/models.md
+++ b/docs/articles/concepts/models.md
@@ -39,6 +39,28 @@ spec:
 
 The generated [Model configuration](/docs/config/model) is the exact field reference. Governed source/model relations can feed a transformation, and the compiler derives the resulting lineage so downstream semantic models see every exposed field.
 
+### Authored contract metadata
+
+Source and Model resources may declare `metadata.contract` with a semantic
+`version` and `compatibility: backward`. Source schema fields and Model fields
+support `nullable`, `tags`, `criticalDataElement`, `classification`,
+`authoritativeDefinitions`, and `deprecation`. These are authored contract and
+governance inputs, not authorization grants or a change to runtime nullability
+inference. An authoritative definition records a type (`businessDefinition` or
+`transformationImplementation`) and an absolute URI. Deprecation records a
+semantic `since` version, a reason, and an optional replacement field identifier.
+The current generated schema checks the URI's scheme/non-whitespace shape,
+not full URI syntax or whether the referenced definition exists.
+
+Every authored Model check requires an `id`, unique within that Model, in
+addition to its existing type-specific fields. Checks may also carry descriptive
+`description` and `tags` metadata. Keep the ID stable when editing a check;
+changing its list position does not change its authored identity.
+
+Accepting this metadata does not calculate a canonical contract digest, enforce
+publication compatibility, or authorize deployment. Those remain separate
+contract-projection and delivery responsibilities.
+
 ## Grain and identity entities
 
 The grain states what one row represents through `grain.entity`; identity entities declare the ordered field tuple that identifies or relates those rows. Use `type: primary` for the row identity, `type: unique` for alternate identities, and `type: foreign` for relationships to another entity. For example:

--- a/examples/dbt-warehouse-boundary/leapview/models/customers.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/models/customers.yaml
@@ -29,9 +29,9 @@ spec:
     order_count: {datatype: Integer, description: dbt-owned customer order count.}
     lifetime_value: {datatype: Float, description: dbt-owned customer lifetime revenue.}
   checks:
-    - {type: non_null, field: customer_id, severity: error}
-    - {type: non_null, field: customer_name, severity: error}
-    - {type: non_null, field: region, severity: error}
-    - {type: non_null, field: order_count, severity: error}
-    - {type: non_null, field: lifetime_value, severity: error}
-    - {type: row_count, minimum: 1, severity: error}
+    - {id: customers_customer_id_not_null, type: non_null, field: customer_id, severity: error}
+    - {id: customers_customer_name_not_null, type: non_null, field: customer_name, severity: error}
+    - {id: customers_region_not_null, type: non_null, field: region, severity: error}
+    - {id: customers_order_count_not_null, type: non_null, field: order_count, severity: error}
+    - {id: customers_lifetime_value_not_null, type: non_null, field: lifetime_value, severity: error}
+    - {id: customers_row_count, type: row_count, minimum: 1, severity: error}

--- a/examples/dbt-warehouse-boundary/leapview/models/orders.yaml
+++ b/examples/dbt-warehouse-boundary/leapview/models/orders.yaml
@@ -32,13 +32,14 @@ spec:
     order_status: {datatype: String, description: dbt-normalized order state.}
     revenue: {datatype: Float, description: dbt-aggregated order revenue.}
   checks:
-    - {type: non_null, field: order_id, severity: error}
-    - {type: non_null, field: customer_id, severity: error}
-    - {type: non_null, field: order_date, severity: error}
-    - {type: non_null, field: order_status, severity: error}
-    - {type: non_null, field: revenue, severity: error}
-    - type: accepted_values
+    - {id: orders_order_id_not_null, type: non_null, field: order_id, severity: error}
+    - {id: orders_customer_id_not_null, type: non_null, field: customer_id, severity: error}
+    - {id: orders_order_date_not_null, type: non_null, field: order_date, severity: error}
+    - {id: orders_order_status_not_null, type: non_null, field: order_status, severity: error}
+    - {id: orders_revenue_not_null, type: non_null, field: revenue, severity: error}
+    - id: orders_status_accepted_values
+      type: accepted_values
       field: order_status
       values: [shipped, delivered, processing, cancelled]
       severity: error
-    - {type: row_count, minimum: 1, severity: error}
+    - {id: orders_row_count, type: row_count, minimum: 1, severity: error}

--- a/internal/analytics/model/execution_snapshot.go
+++ b/internal/analytics/model/execution_snapshot.go
@@ -218,6 +218,7 @@ func snapshotModelChecks(values []ModelCheck) []ModelCheck {
 		clone[index] = value
 		clone[index].Fields = append([]string(nil), value.Fields...)
 		clone[index].Values = append([]string(nil), value.Values...)
+		clone[index].Tags = append([]string(nil), value.Tags...)
 		if value.Minimum != nil {
 			minimum := *value.Minimum
 			clone[index].Minimum = &minimum

--- a/internal/analytics/model/execution_snapshot_test.go
+++ b/internal/analytics/model/execution_snapshot_test.go
@@ -88,7 +88,7 @@ func TestExecutionSnapshotDetachesEvidenceAndChecks(t *testing.T) {
 	minimum, maximum := int64(1), int64(9)
 	model := &Model{Tables: map[string]Table{"orders": Table{
 		SQLAnalysisEvidence: &SQLAnalysisEvidence{Validated: true, SourceRefs: []string{"orders"}, ModelRefs: []string{"customers"}},
-		Checks:              []ModelCheck{{Type: "accepted_values", Fields: []string{"status"}, Values: []string{"open", "closed"}, Minimum: &minimum, Maximum: &maximum}},
+		Checks:              []ModelCheck{{ID: "status_values", Type: "accepted_values", Fields: []string{"status"}, Values: []string{"open", "closed"}, Tags: []string{"governance"}, Minimum: &minimum, Maximum: &maximum}},
 	}}}
 	snapshot := model.ExecutionSnapshot()
 	if snapshot == nil || snapshot.Tables["orders"].SQLAnalysisEvidence == nil || len(snapshot.Tables["orders"].Checks) != 1 {
@@ -98,11 +98,18 @@ func TestExecutionSnapshotDetachesEvidenceAndChecks(t *testing.T) {
 	snapshotEvidence.SourceRefs[0] = "changed"
 	snapshotEvidence.ModelRefs[0] = "changed"
 	snapshotCheck := &snapshot.Tables["orders"].Checks[0]
+	if snapshotCheck.ID != "status_values" {
+		t.Fatal("snapshot lost authored check identity")
+	}
 	snapshotCheck.Fields[0] = "changed"
 	snapshotCheck.Values[0] = "changed"
+	snapshotCheck.Tags[0] = "changed"
 	*snapshotCheck.Minimum = 100
 	*snapshotCheck.Maximum = 200
 	authored := model.Tables["orders"]
+	if authored.Checks[0].Tags[0] != "governance" {
+		t.Fatal("snapshot check tags alias authored state")
+	}
 	if authored.SQLAnalysisEvidence.SourceRefs[0] != "orders" || authored.SQLAnalysisEvidence.ModelRefs[0] != "customers" || authored.Checks[0].Fields[0] != "status" || authored.Checks[0].Values[0] != "open" || *authored.Checks[0].Minimum != minimum || *authored.Checks[0].Maximum != maximum {
 		t.Fatal("snapshot table evidence or checks alias authored state")
 	}

--- a/internal/analytics/model/types.go
+++ b/internal/analytics/model/types.go
@@ -332,14 +332,17 @@ type Table struct {
 // ModelCheck is the compiler-owned normalized form of the closed authored
 // Model check union. It is evidence input, not an authoring DTO.
 type ModelCheck struct {
-	Type     string
-	Field    string
-	Fields   []string
-	Values   []string
-	To       string
-	Minimum  *int64
-	Maximum  *int64
-	Severity string
+	ID          string
+	Type        string
+	Field       string
+	Fields      []string
+	Values      []string
+	To          string
+	Minimum     *int64
+	Maximum     *int64
+	Severity    string
+	Description string
+	Tags        []string
 }
 
 // FreshnessDurationSpec is intentionally scalar and portable. The generated

--- a/internal/project/compiler/data_resources.go
+++ b/internal/project/compiler/data_resources.go
@@ -566,6 +566,7 @@ func lowerModelChecks(value *[]projectcontracts.ModelCheck) ([]semanticmodel.Mod
 		return nil, nil
 	}
 	checks := make([]semanticmodel.ModelCheck, 0, len(*value))
+	seenIDs := make(map[string]struct{}, len(*value))
 	for index, check := range *value {
 		lowered := semanticmodel.ModelCheck{}
 		switch variant := check.Value.(type) {
@@ -573,7 +574,7 @@ func lowerModelChecks(value *[]projectcontracts.ModelCheck) ([]semanticmodel.Mod
 			if strings.TrimSpace(variant.Field) == "" {
 				return nil, fmt.Errorf("checks[%d] non_null requires field", index)
 			}
-			lowered.Type, lowered.Field, lowered.Severity = variant.Type, variant.Field, optionalString(variant.Severity)
+			lowered.ID, lowered.Type, lowered.Field, lowered.Severity, lowered.Description, lowered.Tags = variant.ID, variant.Type, variant.Field, optionalString(variant.Severity), optionalString(variant.Description), optionalStrings(variant.Tags)
 		case *projectcontracts.ModelCheckUniqueVariant:
 			if len(variant.Fields) == 0 {
 				return nil, fmt.Errorf("checks[%d] unique requires fields", index)
@@ -588,7 +589,7 @@ func lowerModelChecks(value *[]projectcontracts.ModelCheck) ([]semanticmodel.Mod
 				}
 				seenFields[field] = struct{}{}
 			}
-			lowered.Type, lowered.Fields, lowered.Severity = variant.Type, append([]string(nil), variant.Fields...), optionalString(variant.Severity)
+			lowered.ID, lowered.Type, lowered.Fields, lowered.Severity, lowered.Description, lowered.Tags = variant.ID, variant.Type, append([]string(nil), variant.Fields...), optionalString(variant.Severity), optionalString(variant.Description), optionalStrings(variant.Tags)
 		case *projectcontracts.ModelCheckAcceptedValuesVariant:
 			if strings.TrimSpace(variant.Field) == "" || len(variant.Values) == 0 {
 				return nil, fmt.Errorf("checks[%d] accepted_values requires field and values", index)
@@ -600,12 +601,12 @@ func lowerModelChecks(value *[]projectcontracts.ModelCheck) ([]semanticmodel.Mod
 				}
 				seenValues[accepted] = struct{}{}
 			}
-			lowered.Type, lowered.Field, lowered.Values, lowered.Severity = variant.Type, variant.Field, append([]string(nil), variant.Values...), optionalString(variant.Severity)
+			lowered.ID, lowered.Type, lowered.Field, lowered.Values, lowered.Severity, lowered.Description, lowered.Tags = variant.ID, variant.Type, variant.Field, append([]string(nil), variant.Values...), optionalString(variant.Severity), optionalString(variant.Description), optionalStrings(variant.Tags)
 		case *projectcontracts.ModelCheckRelationshipVariant:
 			if strings.TrimSpace(variant.Field) == "" || strings.TrimSpace(variant.To) == "" {
 				return nil, fmt.Errorf("checks[%d] relationship requires field and to", index)
 			}
-			lowered.Type, lowered.Field, lowered.To, lowered.Severity = variant.Type, variant.Field, variant.To, optionalString(variant.Severity)
+			lowered.ID, lowered.Type, lowered.Field, lowered.To, lowered.Severity, lowered.Description, lowered.Tags = variant.ID, variant.Type, variant.Field, variant.To, optionalString(variant.Severity), optionalString(variant.Description), optionalStrings(variant.Tags)
 		case *projectcontracts.ModelCheckRowCountVariant:
 			if variant.Minimum == nil && variant.Maximum == nil {
 				return nil, fmt.Errorf("checks[%d] row_count requires minimum or maximum", index)
@@ -619,7 +620,7 @@ func lowerModelChecks(value *[]projectcontracts.ModelCheck) ([]semanticmodel.Mod
 			if variant.Minimum != nil && variant.Maximum != nil && *variant.Minimum > *variant.Maximum {
 				return nil, fmt.Errorf("checks[%d] row_count minimum exceeds maximum", index)
 			}
-			lowered.Type, lowered.Minimum, lowered.Maximum, lowered.Severity = variant.Type, variant.Minimum, variant.Maximum, optionalString(variant.Severity)
+			lowered.ID, lowered.Type, lowered.Minimum, lowered.Maximum, lowered.Severity, lowered.Description, lowered.Tags = variant.ID, variant.Type, variant.Minimum, variant.Maximum, optionalString(variant.Severity), optionalString(variant.Description), optionalStrings(variant.Tags)
 		case nil:
 			return nil, fmt.Errorf("model check variant is required")
 		default:
@@ -628,6 +629,13 @@ func lowerModelChecks(value *[]projectcontracts.ModelCheck) ([]semanticmodel.Mod
 		if lowered.Severity != "" && !strings.EqualFold(lowered.Severity, "warning") && !strings.EqualFold(lowered.Severity, "error") {
 			return nil, fmt.Errorf("checks[%d] severity must be warning or error", index)
 		}
+		if strings.TrimSpace(lowered.ID) == "" {
+			return nil, fmt.Errorf("checks[%d] id is required", index)
+		}
+		if _, exists := seenIDs[lowered.ID]; exists {
+			return nil, fmt.Errorf("checks[%d] duplicates id %q", index, lowered.ID)
+		}
+		seenIDs[lowered.ID] = struct{}{}
 		checks = append(checks, lowered)
 	}
 	return checks, nil

--- a/internal/project/compiler/model_checks_test.go
+++ b/internal/project/compiler/model_checks_test.go
@@ -1,0 +1,127 @@
+package compiler
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	projectcontracts "github.com/flidai/leapview/internal/project/contracts"
+)
+
+func TestLowerModelChecksPreservesMetadataAcrossVariants(t *testing.T) {
+	checks := modelCheckFixture()
+	lowered, err := lowerModelChecks(&checks)
+	if err != nil {
+		t.Fatalf("lower model checks: %v", err)
+	}
+
+	minimum, maximum := int64(1), int64(100)
+	want := []semanticmodel.ModelCheck{
+		{ID: "orders_not_null", Type: "non_null", Field: "order_id", Severity: "error", Description: "Order identifiers are required", Tags: []string{"quality", "orders"}},
+		{ID: "orders_unique", Type: "unique", Fields: []string{"order_id", "tenant_id"}, Severity: "warning", Description: "Order identity is unique per tenant", Tags: []string{"quality", "orders"}},
+		{ID: "orders_status_values", Type: "accepted_values", Field: "status", Values: []string{"open", "closed"}, Severity: "error", Description: "Order status is governed", Tags: []string{"quality", "orders"}},
+		{ID: "orders_customer_relation", Type: "relationship", Field: "customer_id", To: "customers.customer_id", Severity: "warning", Description: "Orders refer to customers", Tags: []string{"quality", "relationships"}},
+		{ID: "orders_row_count", Type: "row_count", Minimum: &minimum, Maximum: &maximum, Severity: "error", Description: "Orders must be populated", Tags: []string{"quality", "volume"}},
+	}
+	if !reflect.DeepEqual(lowered, want) {
+		t.Fatalf("lowered checks = %#v, want %#v", lowered, want)
+	}
+
+	// The normalized slice must not retain the authored tags backing array.
+	authoredTags := checks[0].Value.(*projectcontracts.ModelCheckNonNullVariant).Tags
+	(*authoredTags)[0] = "changed"
+	if lowered[0].Tags[0] != "quality" {
+		t.Fatal("lowered check tags alias authored state")
+	}
+}
+
+func TestLowerModelChecksWithoutChecksRemainsEmpty(t *testing.T) {
+	if got, err := lowerModelChecks(nil); err != nil || got != nil {
+		t.Fatalf("nil checks = %#v, %v; want nil, nil", got, err)
+	}
+	empty := []projectcontracts.ModelCheck{}
+	if got, err := lowerModelChecks(&empty); err != nil || len(got) != 0 {
+		t.Fatalf("empty checks = %#v, %v; want empty, nil", got, err)
+	}
+}
+
+func TestLowerModelChecksRequiresStableID(t *testing.T) {
+	for index := range modelCheckFixture() {
+		t.Run(fmt.Sprintf("variant_%d", index), func(t *testing.T) {
+			checks := []projectcontracts.ModelCheck{modelCheckFixture()[index]}
+			setModelCheckID(&checks[0], "")
+			_, err := lowerModelChecks(&checks)
+			if err == nil || err.Error() != "checks[0] id is required" {
+				t.Fatalf("missing ID error = %v, want checks[0] id is required", err)
+			}
+		})
+	}
+}
+
+func TestLowerModelChecksRejectsDuplicateStableID(t *testing.T) {
+	checks := modelCheckFixture()[:2]
+	setModelCheckID(&checks[1], "orders_not_null")
+	_, err := lowerModelChecks(&checks)
+	if err == nil || err.Error() != `checks[1] duplicates id "orders_not_null"` {
+		t.Fatalf("duplicate ID error = %v, want deterministic duplicate error", err)
+	}
+}
+
+func modelCheckFixture() []projectcontracts.ModelCheck {
+	severityError, severityWarning := "error", "warning"
+	descriptions := []string{
+		"Order identifiers are required",
+		"Order identity is unique per tenant",
+		"Order status is governed",
+		"Orders refer to customers",
+		"Orders must be populated",
+	}
+	tags := [][]string{
+		{"quality", "orders"},
+		{"quality", "orders"},
+		{"quality", "orders"},
+		{"quality", "relationships"},
+		{"quality", "volume"},
+	}
+	minimum, maximum := int64(1), int64(100)
+	return []projectcontracts.ModelCheck{
+		{Value: &projectcontracts.ModelCheckNonNullVariant{
+			NonNullModelCheck: projectcontracts.NonNullModelCheck{ID: "orders_not_null", Field: "order_id", Severity: &severityError, Description: &descriptions[0], Tags: &tags[0]},
+			Type:              "non_null",
+		}},
+		{Value: &projectcontracts.ModelCheckUniqueVariant{
+			UniqueModelCheck: projectcontracts.UniqueModelCheck{ID: "orders_unique", Fields: []string{"order_id", "tenant_id"}, Severity: &severityWarning, Description: &descriptions[1], Tags: &tags[1]},
+			Type:             "unique",
+		}},
+		{Value: &projectcontracts.ModelCheckAcceptedValuesVariant{
+			AcceptedValuesModelCheck: projectcontracts.AcceptedValuesModelCheck{ID: "orders_status_values", Field: "status", Values: []string{"open", "closed"}, Severity: &severityError, Description: &descriptions[2], Tags: &tags[2]},
+			Type:                     "accepted_values",
+		}},
+		{Value: &projectcontracts.ModelCheckRelationshipVariant{
+			RelationshipModelCheck: projectcontracts.RelationshipModelCheck{ID: "orders_customer_relation", Field: "customer_id", To: "customers.customer_id", Severity: &severityWarning, Description: &descriptions[3], Tags: &tags[3]},
+			Type:                   "relationship",
+		}},
+		{Value: &projectcontracts.ModelCheckRowCountVariant{
+			RowCountModelCheck: projectcontracts.RowCountModelCheck{ID: "orders_row_count", Minimum: &minimum, Maximum: &maximum, Severity: &severityError, Description: &descriptions[4], Tags: &tags[4]},
+			Type:               "row_count",
+		}},
+	}
+}
+
+func setModelCheckID(check *projectcontracts.ModelCheck, id string) {
+	switch variant := check.Value.(type) {
+	case *projectcontracts.ModelCheckNonNullVariant:
+		variant.ID = id
+	case *projectcontracts.ModelCheckUniqueVariant:
+		variant.ID = id
+	case *projectcontracts.ModelCheckAcceptedValuesVariant:
+		variant.ID = id
+	case *projectcontracts.ModelCheckRelationshipVariant:
+		variant.ID = id
+	case *projectcontracts.ModelCheckRowCountVariant:
+		variant.ID = id
+	default:
+		panic("unsupported model check fixture variant")
+	}
+}

--- a/internal/project/contracts/gen/data-resources.schema.json
+++ b/internal/project/contracts/gen/data-resources.schema.json
@@ -23,7 +23,14 @@
     },
     "AcceptedValuesModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -33,6 +40,12 @@
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "type": {
           "enum": [
@@ -49,6 +62,7 @@
       },
       "required": [
         "field",
+        "id",
         "type",
         "values"
       ],
@@ -163,6 +177,27 @@
       },
       "required": [
         "any"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "AuthoritativeDefinition": {
+      "properties": {
+        "type": {
+          "enum": [
+            "businessDefinition",
+            "transformationImplementation"
+          ],
+          "type": "string"
+        },
+        "url": {
+          "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
       ],
       "type": "object",
       "unevaluatedProperties": false
@@ -420,6 +455,71 @@
       ],
       "type": "object"
     },
+    "ContractMetadata": {
+      "properties": {
+        "compatibility": {
+          "enum": [
+            "backward"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "compatibility",
+        "version"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ContractResourceMetadata": {
+      "properties": {
+        "contract": {
+          "$ref": "#/$defs/ContractMetadata"
+        },
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+          "type": "string"
+        },
+        "name": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*$",
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/$defs/ResourceProvenance"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
     "DeltaPathSourceLocation": {
       "allOf": [
         {
@@ -647,6 +747,27 @@
         "scanKind": "table_function",
         "sourceDataIdentityCapability": "unavailable"
       }
+    },
+    "FieldDeprecation": {
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "replacement": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "since": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason",
+        "since"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "FieldFreshness": {
       "properties": {
@@ -1233,7 +1354,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/ResourceMetadata"
+          "$ref": "#/$defs/ContractResourceMetadata"
         },
         "spec": {
           "$ref": "#/$defs/ModelSpec"
@@ -1425,6 +1546,19 @@
         "aiContext": {
           "$ref": "#/$defs/AIContext"
         },
+        "authoritativeDefinitions": {
+          "items": {
+            "$ref": "#/$defs/AuthoritativeDefinition"
+          },
+          "type": "array"
+        },
+        "classification": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "criticalDataElement": {
+          "type": "boolean"
+        },
         "datatype": {
           "enum": [
             "String",
@@ -1440,11 +1574,23 @@
           ],
           "type": "string"
         },
+        "deprecation": {
+          "$ref": "#/$defs/FieldDeprecation"
+        },
         "description": {
           "type": "string"
         },
         "label": {
           "type": "string"
+        },
+        "nullable": {
+          "type": "boolean"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object",
@@ -1560,7 +1706,14 @@
     },
     "NonNullModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -1571,6 +1724,12 @@
           ],
           "type": "string"
         },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "type": {
           "enum": [
             "non_null"
@@ -1580,6 +1739,7 @@
       },
       "required": [
         "field",
+        "id",
         "type"
       ],
       "type": "object"
@@ -2002,7 +2162,14 @@
     },
     "RelationshipModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -2012,6 +2179,12 @@
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "to": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*\\.[A-Za-z_][A-Za-z0-9_]*$",
@@ -2026,6 +2199,7 @@
       },
       "required": [
         "field",
+        "id",
         "to",
         "type"
       ],
@@ -2115,6 +2289,13 @@
     },
     "RowCountModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
         "maximum": {
           "format": "int64",
           "type": "integer"
@@ -2130,6 +2311,12 @@
           ],
           "type": "string"
         },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "type": {
           "enum": [
             "row_count"
@@ -2138,6 +2325,7 @@
         }
       },
       "required": [
+        "id",
         "type"
       ],
       "type": "object"
@@ -2805,7 +2993,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/ResourceMetadata"
+          "$ref": "#/$defs/ContractResourceMetadata"
         },
         "spec": {
           "$ref": "#/$defs/SourceSpec"
@@ -2955,6 +3143,19 @@
     },
     "SourceSchemaField": {
       "properties": {
+        "authoritativeDefinitions": {
+          "items": {
+            "$ref": "#/$defs/AuthoritativeDefinition"
+          },
+          "type": "array"
+        },
+        "classification": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "criticalDataElement": {
+          "type": "boolean"
+        },
         "datatype": {
           "enum": [
             "String",
@@ -2970,11 +3171,20 @@
           ],
           "type": "string"
         },
+        "deprecation": {
+          "$ref": "#/$defs/FieldDeprecation"
+        },
         "description": {
           "type": "string"
         },
         "nullable": {
           "type": "boolean"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -3125,6 +3335,9 @@
     },
     "UniqueModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "fields": {
           "items": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
@@ -3132,12 +3345,22 @@
           },
           "type": "array"
         },
+        "id": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
         "severity": {
           "enum": [
             "warning",
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "type": {
           "enum": [
@@ -3148,6 +3371,7 @@
       },
       "required": [
         "fields",
+        "id",
         "type"
       ],
       "type": "object"

--- a/internal/project/contracts/models.gen.go
+++ b/internal/project/contracts/models.gen.go
@@ -15,10 +15,13 @@ type AIContext struct {
 }
 
 type AcceptedValuesModelCheck struct {
-	Type     string   `json:"type" yaml:"type"`
-	Field    string   `json:"field" yaml:"field"`
-	Values   []string `json:"values" yaml:"values"`
-	Severity *string  `json:"severity,omitempty" yaml:"severity,omitempty"`
+	ID          string    `json:"id" yaml:"id"`
+	Type        string    `json:"type" yaml:"type"`
+	Field       string    `json:"field" yaml:"field"`
+	Values      []string  `json:"values" yaml:"values"`
+	Severity    *string   `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Description *string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type AggregateSemanticMetric struct {
@@ -44,6 +47,11 @@ type AllSemanticFilter struct {
 
 type AnySemanticFilter struct {
 	Any []SemanticFilter `json:"any" yaml:"any"`
+}
+
+type AuthoritativeDefinition struct {
+	Type string `json:"type" yaml:"type"`
+	URL  string `json:"url" yaml:"url"`
 }
 
 type AzureBlobConnection struct {
@@ -523,6 +531,24 @@ type ConnectionSpecBase struct {
 	Type string `json:"type" yaml:"type"`
 }
 
+type ContractMetadata struct {
+	Version       string `json:"version" yaml:"version"`
+	Compatibility string `json:"compatibility" yaml:"compatibility"`
+}
+
+type ContractResourceMetadata struct {
+	ID            string              `json:"id" yaml:"id"`
+	Name          string              `json:"name" yaml:"name"`
+	DisplayName   *string             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description   *string             `json:"description,omitempty" yaml:"description,omitempty"`
+	Owner         *string             `json:"owner,omitempty" yaml:"owner,omitempty"`
+	Domain        *string             `json:"domain,omitempty" yaml:"domain,omitempty"`
+	Tags          *[]string           `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Documentation *string             `json:"documentation,omitempty" yaml:"documentation,omitempty"`
+	Provenance    *ResourceProvenance `json:"provenance,omitempty" yaml:"provenance,omitempty"`
+	Contract      *ContractMetadata   `json:"contract,omitempty" yaml:"contract,omitempty"`
+}
+
 type DeltaPathSourceLocation struct {
 	PathSourceLocationBase
 	Format  string              `json:"format" yaml:"format"`
@@ -573,6 +599,12 @@ type ExcelPathSourceLocation struct {
 type ExcelReaderOptions struct {
 	Sheet  *string `json:"sheet,omitempty" yaml:"sheet,omitempty"`
 	Header *bool   `json:"header,omitempty" yaml:"header,omitempty"`
+}
+
+type FieldDeprecation struct {
+	Since       string  `json:"since" yaml:"since"`
+	Reason      string  `json:"reason" yaml:"reason"`
+	Replacement *string `json:"replacement,omitempty" yaml:"replacement,omitempty"`
 }
 
 type FieldFreshness struct {
@@ -698,11 +730,11 @@ type ManagedConnection struct {
 }
 
 type Model struct {
-	APIVersion string           `json:"apiVersion" yaml:"apiVersion"`
-	Kind       string           `json:"kind" yaml:"kind"`
-	Metadata   ResourceMetadata `json:"metadata" yaml:"metadata"`
-	AiContext  *AIContext       `json:"aiContext,omitempty" yaml:"aiContext,omitempty"`
-	Spec       ModelSpec        `json:"spec" yaml:"spec"`
+	APIVersion string                   `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string                   `json:"kind" yaml:"kind"`
+	Metadata   ContractResourceMetadata `json:"metadata" yaml:"metadata"`
+	AiContext  *AIContext               `json:"aiContext,omitempty" yaml:"aiContext,omitempty"`
+	Spec       ModelSpec                `json:"spec" yaml:"spec"`
 }
 
 type ModelCheckVariant interface {
@@ -780,6 +812,9 @@ func (value *ModelCheck) UnmarshalJSON(data []byte) error {
 		if _, ok := fields["field"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property field is missing", tag.Value)
 		}
+		if _, ok := fields["id"]; !ok {
+			return fmt.Errorf("decode ModelCheck variant %q: required property id is missing", tag.Value)
+		}
 		if _, ok := fields["type"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property type is missing", tag.Value)
 		}
@@ -795,6 +830,9 @@ func (value *ModelCheck) UnmarshalJSON(data []byte) error {
 		if _, ok := fields["field"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property field is missing", tag.Value)
 		}
+		if _, ok := fields["id"]; !ok {
+			return fmt.Errorf("decode ModelCheck variant %q: required property id is missing", tag.Value)
+		}
 		if _, ok := fields["type"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property type is missing", tag.Value)
 		}
@@ -806,6 +844,9 @@ func (value *ModelCheck) UnmarshalJSON(data []byte) error {
 	case "relationship":
 		if _, ok := fields["field"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property field is missing", tag.Value)
+		}
+		if _, ok := fields["id"]; !ok {
+			return fmt.Errorf("decode ModelCheck variant %q: required property id is missing", tag.Value)
 		}
 		if _, ok := fields["to"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property to is missing", tag.Value)
@@ -819,6 +860,9 @@ func (value *ModelCheck) UnmarshalJSON(data []byte) error {
 		}
 		value.Value = &variant
 	case "row_count":
+		if _, ok := fields["id"]; !ok {
+			return fmt.Errorf("decode ModelCheck variant %q: required property id is missing", tag.Value)
+		}
 		if _, ok := fields["type"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property type is missing", tag.Value)
 		}
@@ -830,6 +874,9 @@ func (value *ModelCheck) UnmarshalJSON(data []byte) error {
 	case "unique":
 		if _, ok := fields["fields"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property fields is missing", tag.Value)
+		}
+		if _, ok := fields["id"]; !ok {
+			return fmt.Errorf("decode ModelCheck variant %q: required property id is missing", tag.Value)
 		}
 		if _, ok := fields["type"]; !ok {
 			return fmt.Errorf("decode ModelCheck variant %q: required property type is missing", tag.Value)
@@ -1124,10 +1171,16 @@ type ModelEntity struct {
 }
 
 type ModelField struct {
-	Datatype    *string    `json:"datatype,omitempty" yaml:"datatype,omitempty"`
-	Label       *string    `json:"label,omitempty" yaml:"label,omitempty"`
-	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
-	AiContext   *AIContext `json:"aiContext,omitempty" yaml:"aiContext,omitempty"`
+	Datatype                 *string                    `json:"datatype,omitempty" yaml:"datatype,omitempty"`
+	Label                    *string                    `json:"label,omitempty" yaml:"label,omitempty"`
+	Description              *string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	AiContext                *AIContext                 `json:"aiContext,omitempty" yaml:"aiContext,omitempty"`
+	Nullable                 *bool                      `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	Tags                     *[]string                  `json:"tags,omitempty" yaml:"tags,omitempty"`
+	CriticalDataElement      *bool                      `json:"criticalDataElement,omitempty" yaml:"criticalDataElement,omitempty"`
+	Classification           *string                    `json:"classification,omitempty" yaml:"classification,omitempty"`
+	AuthoritativeDefinitions *[]AuthoritativeDefinition `json:"authoritativeDefinitions,omitempty" yaml:"authoritativeDefinitions,omitempty"`
+	Deprecation              *FieldDeprecation          `json:"deprecation,omitempty" yaml:"deprecation,omitempty"`
 }
 
 type ModelGrain struct {
@@ -1153,9 +1206,12 @@ type NamedSemanticRelationshipEndpoint struct {
 }
 
 type NonNullModelCheck struct {
-	Type     string  `json:"type" yaml:"type"`
-	Field    string  `json:"field" yaml:"field"`
-	Severity *string `json:"severity,omitempty" yaml:"severity,omitempty"`
+	ID          string    `json:"id" yaml:"id"`
+	Type        string    `json:"type" yaml:"type"`
+	Field       string    `json:"field" yaml:"field"`
+	Severity    *string   `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Description *string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type NotEqualsSemanticFilter struct {
@@ -1710,10 +1766,13 @@ type RelationSourceLocation struct {
 }
 
 type RelationshipModelCheck struct {
-	Type     string  `json:"type" yaml:"type"`
-	Field    string  `json:"field" yaml:"field"`
-	To       string  `json:"to" yaml:"to"`
-	Severity *string `json:"severity,omitempty" yaml:"severity,omitempty"`
+	ID          string    `json:"id" yaml:"id"`
+	Type        string    `json:"type" yaml:"type"`
+	Field       string    `json:"field" yaml:"field"`
+	To          string    `json:"to" yaml:"to"`
+	Severity    *string   `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Description *string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type ResourceMetadata struct {
@@ -1742,10 +1801,13 @@ type RevisionFreshness struct {
 }
 
 type RowCountModelCheck struct {
-	Type     string  `json:"type" yaml:"type"`
-	Minimum  *int64  `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-	Maximum  *int64  `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-	Severity *string `json:"severity,omitempty" yaml:"severity,omitempty"`
+	ID          string    `json:"id" yaml:"id"`
+	Type        string    `json:"type" yaml:"type"`
+	Minimum     *int64    `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	Maximum     *int64    `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	Severity    *string   `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Description *string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type S3Connection struct {
@@ -2760,10 +2822,10 @@ type SemanticTimeSemantics struct {
 }
 
 type Source struct {
-	APIVersion string           `json:"apiVersion" yaml:"apiVersion"`
-	Kind       string           `json:"kind" yaml:"kind"`
-	Metadata   ResourceMetadata `json:"metadata" yaml:"metadata"`
-	Spec       SourceSpec       `json:"spec" yaml:"spec"`
+	APIVersion string                   `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string                   `json:"kind" yaml:"kind"`
+	Metadata   ContractResourceMetadata `json:"metadata" yaml:"metadata"`
+	Spec       SourceSpec               `json:"spec" yaml:"spec"`
 }
 
 type SourceFreshnessVariant interface {
@@ -3220,9 +3282,14 @@ type SourceSchemaCompatibleVariant struct {
 }
 
 type SourceSchemaField struct {
-	Datatype    string  `json:"datatype" yaml:"datatype"`
-	Nullable    *bool   `json:"nullable,omitempty" yaml:"nullable,omitempty"`
-	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Datatype                 string                     `json:"datatype" yaml:"datatype"`
+	Nullable                 *bool                      `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	Description              *string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags                     *[]string                  `json:"tags,omitempty" yaml:"tags,omitempty"`
+	CriticalDataElement      *bool                      `json:"criticalDataElement,omitempty" yaml:"criticalDataElement,omitempty"`
+	Classification           *string                    `json:"classification,omitempty" yaml:"classification,omitempty"`
+	AuthoritativeDefinitions *[]AuthoritativeDefinition `json:"authoritativeDefinitions,omitempty" yaml:"authoritativeDefinitions,omitempty"`
+	Deprecation              *FieldDeprecation          `json:"deprecation,omitempty" yaml:"deprecation,omitempty"`
 }
 
 type SourceSchemaInferredVariant struct {
@@ -3260,9 +3327,12 @@ type TextReaderOptions struct {
 }
 
 type UniqueModelCheck struct {
-	Type     string   `json:"type" yaml:"type"`
-	Fields   []string `json:"fields" yaml:"fields"`
-	Severity *string  `json:"severity,omitempty" yaml:"severity,omitempty"`
+	ID          string    `json:"id" yaml:"id"`
+	Type        string    `json:"type" yaml:"type"`
+	Fields      []string  `json:"fields" yaml:"fields"`
+	Severity    *string   `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Description *string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type VortexPathSourceLocation struct {

--- a/internal/project/schema/metadata_contract_test.go
+++ b/internal/project/schema/metadata_contract_test.go
@@ -1,0 +1,266 @@
+package configschema
+
+import (
+	"strings"
+	"testing"
+
+	projectcontracts "github.com/flidai/leapview/internal/project/contracts"
+)
+
+const metadataSourceDocument = `apiVersion: leapview.dev/v1
+kind: Source
+metadata:
+  id: source:orders
+  name: orders
+  contract:
+    version: 1.2.3-rc.1+build.5
+    compatibility: backward
+spec:
+  connection: managed:local
+  location: {type: path, path: orders.csv, format: csv}
+  schema:
+    mode: strict
+    fields:
+      order_id:
+        datatype: String
+        nullable: false
+        tags: [identifier]
+        criticalDataElement: true
+        classification: pii
+        authoritativeDefinitions:
+          - type: businessDefinition
+            url: https://example.test/definitions/order-id
+        deprecation:
+          since: 1.2.0
+          reason: use order_key instead
+          replacement: order_key
+`
+
+const metadataModelDocument = `apiVersion: leapview.dev/v1
+kind: Model
+metadata:
+  id: model:orders
+  name: orders
+  contract:
+    version: 2.0.0
+    compatibility: backward
+spec:
+  definition: {type: direct, source: source:orders}
+  entities:
+    order: {type: primary, fields: [order_id]}
+  grain: {entity: order}
+  fields:
+    order_id:
+      datatype: String
+      nullable: false
+      tags: [identifier]
+      criticalDataElement: true
+      classification: pii
+      authoritativeDefinitions:
+        - type: transformationImplementation
+          url: https://example.test/models/orders
+      deprecation:
+        since: 1.0.0
+        reason: use order_key instead
+        replacement: order_key
+  checks:
+    - id: order_id_not_null
+      type: non_null
+      field: order_id
+      description: Order IDs must be present
+      tags: [quality]
+    - id: order_id_unique
+      type: unique
+      fields: [order_id]
+      description: Order IDs must be unique
+      tags: [quality]
+    - id: order_status_allowed
+      type: accepted_values
+      field: status
+      values: [open, closed]
+      description: Status is a governed enum
+      tags: [quality]
+    - id: customer_exists
+      type: relationship
+      field: customer_id
+      to: sales.customers.customer
+      description: Customers must exist
+      tags: [integrity]
+    - id: row_count_positive
+      type: row_count
+      minimum: 1
+      description: The model must not be empty
+      tags: [freshness]
+`
+
+func TestContractMetadataAndGovernanceFieldsAreAccepted(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		kind Kind
+		doc  string
+	}{
+		{name: "source", kind: KindSource, doc: metadataSourceDocument},
+		{name: "source urn", kind: KindSource, doc: strings.Replace(metadataSourceDocument, "https://example.test/definitions/order-id", "urn:example:order-id", 1)},
+		{name: "source without optional contract", kind: KindSource, doc: withoutContract(metadataSourceDocument, "1.2.3-rc.1+build.5")},
+		{name: "model", kind: KindModel, doc: metadataModelDocument},
+		{name: "model without optional contract", kind: KindModel, doc: withoutContract(metadataModelDocument, "2.0.0")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateBytes(tc.kind, tc.name+".yaml", []byte(tc.doc)); err != nil {
+				t.Fatalf("valid metadata rejected: %v", err)
+			}
+		})
+	}
+}
+
+func withoutContract(document, version string) string {
+	return strings.Replace(document, "  contract:\n    version: "+version+"\n    compatibility: backward\n", "", 1)
+}
+
+func TestDecodeResourceRetainsTypedMetadataAndGovernance(t *testing.T) {
+	var source projectcontracts.Source
+	if err := DecodeResource(KindSource, "source.yaml", []byte(metadataSourceDocument), &source); err != nil {
+		t.Fatalf("DecodeResource(source): %v", err)
+	}
+	if source.Metadata.Contract == nil || source.Metadata.Contract.Version != "1.2.3-rc.1+build.5" || source.Metadata.Contract.Compatibility != "backward" {
+		t.Fatalf("decoded source contract = %#v", source.Metadata.Contract)
+	}
+	strict, ok := source.Spec.Schema.Value.(*projectcontracts.SourceSchemaStrictVariant)
+	if !ok {
+		t.Fatalf("decoded source schema variant = %T, want strict", source.Spec.Schema.Value)
+	}
+	field := strict.Fields["order_id"]
+	if field.Nullable == nil || *field.Nullable || field.CriticalDataElement == nil || !*field.CriticalDataElement || field.AuthoritativeDefinitions == nil || len(*field.AuthoritativeDefinitions) != 1 || field.Deprecation == nil {
+		t.Fatalf("decoded source governance field = %#v", field)
+	}
+
+	var model projectcontracts.Model
+	if err := DecodeResource(KindModel, "model.yaml", []byte(metadataModelDocument), &model); err != nil {
+		t.Fatalf("DecodeResource(model): %v", err)
+	}
+	if model.Metadata.Contract == nil || model.Metadata.Contract.Version != "2.0.0" {
+		t.Fatalf("decoded model contract = %#v", model.Metadata.Contract)
+	}
+	modelField := (*model.Spec.Fields)["order_id"]
+	if modelField.Nullable == nil || *modelField.Nullable || modelField.Tags == nil || len(*modelField.Tags) != 1 || modelField.Deprecation == nil {
+		t.Fatalf("decoded model governance field = %#v", modelField)
+	}
+	checks := *model.Spec.Checks
+	if len(checks) != 5 {
+		t.Fatalf("decoded model checks = %d, want 5", len(checks))
+	}
+	if variant, ok := checks[0].Value.(*projectcontracts.ModelCheckNonNullVariant); !ok || variant.ID != "order_id_not_null" || variant.Description == nil || variant.Tags == nil {
+		t.Fatalf("decoded model check = %#v (%T)", checks[0].Value, checks[0].Value)
+	}
+}
+
+func TestContractMetadataRejectsInvalidVersionURIAndUnknownFields(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{
+			name: "numeric prerelease leading zero",
+			doc:  strings.Replace(metadataSourceDocument, "1.2.3-rc.1+build.5", "1.2.3-01", 1),
+		},
+		{
+			name: "invalid authoritative URI",
+			doc:  strings.Replace(metadataSourceDocument, "https://example.test/definitions/order-id", "not a URI", 1),
+		},
+		{
+			name: "unknown contract field",
+			doc:  strings.Replace(metadataSourceDocument, "    compatibility: backward\n", "    compatibility: backward\n    unsupported: true\n", 1),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateBytes(KindSource, tc.name+".yaml", []byte(tc.doc)); err == nil {
+				t.Fatal("ValidateBytes accepted invalid contract metadata")
+			}
+		})
+	}
+}
+
+func TestModelChecksRequireStableIDs(t *testing.T) {
+	for _, id := range []string{
+		"order_id_not_null",
+		"order_id_unique",
+		"order_status_allowed",
+		"customer_exists",
+		"row_count_positive",
+	} {
+		t.Run(id, func(t *testing.T) {
+			doc := strings.Replace(metadataModelDocument, "    - id: "+id+"\n", "    -\n", 1)
+			if err := ValidateBytes(KindModel, "model.yaml", []byte(doc)); err == nil {
+				t.Fatal("ValidateBytes accepted a model check without an id")
+			}
+		})
+	}
+}
+
+func TestModelChecksRejectInvalidIDs(t *testing.T) {
+	for _, id := range []string{"1order_id", "order id", "order-id", "order.id"} {
+		t.Run(id, func(t *testing.T) {
+			doc := strings.Replace(metadataModelDocument, "order_id_not_null", id, 1)
+			if err := ValidateBytes(KindModel, "model.yaml", []byte(doc)); err == nil {
+				t.Fatal("ValidateBytes accepted a model check with an invalid id")
+			}
+		})
+	}
+}
+
+func TestContractMetadataRemainsSourceAndModelScoped(t *testing.T) {
+	connection := `apiVersion: leapview.dev/v1
+kind: Connection
+metadata:
+  id: connection:warehouse
+  name: warehouse
+spec: {type: managed}
+`
+	semanticModel := `apiVersion: leapview.dev/v1
+kind: SemanticModel
+metadata:
+  id: semantic-model:sales
+  name: sales
+spec:
+  datasets: {orders: {model: orders}}
+  metrics: {}
+`
+	for _, tc := range []struct {
+		name string
+		kind Kind
+		doc  string
+	}{
+		{name: "connection baseline", kind: KindConnection, doc: connection},
+		{name: "semantic model baseline", kind: KindSemanticModel, doc: semanticModel},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateBytes(tc.kind, tc.name+".yaml", []byte(tc.doc)); err != nil {
+				t.Fatalf("baseline without contract rejected: %v", err)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		kind Kind
+		doc  string
+	}{
+		{
+			name: "connection",
+			kind: KindConnection,
+			doc:  strings.Replace(connection, "  name: warehouse\n", "  name: warehouse\n  contract: {version: 1.0.0, compatibility: backward}\n", 1),
+		},
+		{
+			name: "semantic model",
+			kind: KindSemanticModel,
+			doc:  strings.Replace(semanticModel, "  name: sales\n", "  name: sales\n  contract: {version: 1.0.0, compatibility: backward}\n", 1),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateBytes(tc.kind, tc.name+".yaml", []byte(tc.doc)); err == nil {
+				t.Fatal("ValidateBytes accepted contract metadata outside Source/Model")
+			}
+		})
+	}
+}

--- a/schemas/json/connection.schema.json
+++ b/schemas/json/connection.schema.json
@@ -23,7 +23,14 @@
     },
     "AcceptedValuesModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -33,6 +40,12 @@
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "type": {
           "enum": [
@@ -49,10 +62,32 @@
       },
       "required": [
         "field",
+        "id",
         "type",
         "values"
       ],
       "type": "object"
+    },
+    "AuthoritativeDefinition": {
+      "properties": {
+        "type": {
+          "enum": [
+            "businessDefinition",
+            "transformationImplementation"
+          ],
+          "type": "string"
+        },
+        "url": {
+          "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "AzureBlobConnection": {
       "allOf": [
@@ -305,6 +340,71 @@
       ],
       "type": "object"
     },
+    "ContractMetadata": {
+      "properties": {
+        "compatibility": {
+          "enum": [
+            "backward"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "compatibility",
+        "version"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ContractResourceMetadata": {
+      "properties": {
+        "contract": {
+          "$ref": "#/$defs/ContractMetadata"
+        },
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+          "type": "string"
+        },
+        "name": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*$",
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/$defs/ResourceProvenance"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
     "DeltaPathSourceLocation": {
       "allOf": [
         {
@@ -453,6 +553,27 @@
         "scanKind": "table_function",
         "sourceDataIdentityCapability": "unavailable"
       }
+    },
+    "FieldDeprecation": {
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "replacement": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "since": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason",
+        "since"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "FieldFreshness": {
       "properties": {
@@ -783,7 +904,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/ResourceMetadata"
+          "$ref": "#/$defs/ContractResourceMetadata"
         },
         "spec": {
           "$ref": "#/$defs/ModelSpec"
@@ -975,6 +1096,19 @@
         "aiContext": {
           "$ref": "#/$defs/AIContext"
         },
+        "authoritativeDefinitions": {
+          "items": {
+            "$ref": "#/$defs/AuthoritativeDefinition"
+          },
+          "type": "array"
+        },
+        "classification": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "criticalDataElement": {
+          "type": "boolean"
+        },
         "datatype": {
           "enum": [
             "String",
@@ -990,11 +1124,23 @@
           ],
           "type": "string"
         },
+        "deprecation": {
+          "$ref": "#/$defs/FieldDeprecation"
+        },
         "description": {
           "type": "string"
         },
         "label": {
           "type": "string"
+        },
+        "nullable": {
+          "type": "boolean"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object",
@@ -1092,7 +1238,14 @@
     },
     "NonNullModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -1103,6 +1256,12 @@
           ],
           "type": "string"
         },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "type": {
           "enum": [
             "non_null"
@@ -1112,6 +1271,7 @@
       },
       "required": [
         "field",
+        "id",
         "type"
       ],
       "type": "object"
@@ -1399,7 +1559,14 @@
     },
     "RelationshipModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -1409,6 +1576,12 @@
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "to": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*\\.[A-Za-z_][A-Za-z0-9_]*$",
@@ -1423,6 +1596,7 @@
       },
       "required": [
         "field",
+        "id",
         "to",
         "type"
       ],
@@ -1512,6 +1686,13 @@
     },
     "RowCountModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
         "maximum": {
           "format": "int64",
           "type": "integer"
@@ -1527,6 +1708,12 @@
           ],
           "type": "string"
         },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "type": {
           "enum": [
             "row_count"
@@ -1535,6 +1722,7 @@
         }
       },
       "required": [
+        "id",
         "type"
       ],
       "type": "object"
@@ -1652,7 +1840,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/ResourceMetadata"
+          "$ref": "#/$defs/ContractResourceMetadata"
         },
         "spec": {
           "$ref": "#/$defs/SourceSpec"
@@ -1802,6 +1990,19 @@
     },
     "SourceSchemaField": {
       "properties": {
+        "authoritativeDefinitions": {
+          "items": {
+            "$ref": "#/$defs/AuthoritativeDefinition"
+          },
+          "type": "array"
+        },
+        "classification": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "criticalDataElement": {
+          "type": "boolean"
+        },
         "datatype": {
           "enum": [
             "String",
@@ -1817,11 +2018,20 @@
           ],
           "type": "string"
         },
+        "deprecation": {
+          "$ref": "#/$defs/FieldDeprecation"
+        },
         "description": {
           "type": "string"
         },
         "nullable": {
           "type": "boolean"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -1972,6 +2182,9 @@
     },
     "UniqueModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "fields": {
           "items": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
@@ -1979,12 +2192,22 @@
           },
           "type": "array"
         },
+        "id": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
         "severity": {
           "enum": [
             "warning",
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "type": {
           "enum": [
@@ -1995,6 +2218,7 @@
       },
       "required": [
         "fields",
+        "id",
         "type"
       ],
       "type": "object"

--- a/schemas/json/model.schema.json
+++ b/schemas/json/model.schema.json
@@ -23,7 +23,14 @@
     },
     "AcceptedValuesModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -33,6 +40,12 @@
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "type": {
           "enum": [
@@ -49,10 +62,32 @@
       },
       "required": [
         "field",
+        "id",
         "type",
         "values"
       ],
       "type": "object"
+    },
+    "AuthoritativeDefinition": {
+      "properties": {
+        "type": {
+          "enum": [
+            "businessDefinition",
+            "transformationImplementation"
+          ],
+          "type": "string"
+        },
+        "url": {
+          "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "AzureBlobConnection": {
       "allOf": [
@@ -307,6 +342,71 @@
       ],
       "type": "object"
     },
+    "ContractMetadata": {
+      "properties": {
+        "compatibility": {
+          "enum": [
+            "backward"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "compatibility",
+        "version"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ContractResourceMetadata": {
+      "properties": {
+        "contract": {
+          "$ref": "#/$defs/ContractMetadata"
+        },
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+          "type": "string"
+        },
+        "name": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*$",
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/$defs/ResourceProvenance"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
     "DeltaPathSourceLocation": {
       "allOf": [
         {
@@ -455,6 +555,27 @@
         "scanKind": "table_function",
         "sourceDataIdentityCapability": "unavailable"
       }
+    },
+    "FieldDeprecation": {
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "replacement": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "since": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason",
+        "since"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "FieldFreshness": {
       "properties": {
@@ -783,7 +904,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/ResourceMetadata"
+          "$ref": "#/$defs/ContractResourceMetadata"
         },
         "spec": {
           "$ref": "#/$defs/ModelSpec"
@@ -975,6 +1096,19 @@
         "aiContext": {
           "$ref": "#/$defs/AIContext"
         },
+        "authoritativeDefinitions": {
+          "items": {
+            "$ref": "#/$defs/AuthoritativeDefinition"
+          },
+          "type": "array"
+        },
+        "classification": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "criticalDataElement": {
+          "type": "boolean"
+        },
         "datatype": {
           "enum": [
             "String",
@@ -990,11 +1124,23 @@
           ],
           "type": "string"
         },
+        "deprecation": {
+          "$ref": "#/$defs/FieldDeprecation"
+        },
         "description": {
           "type": "string"
         },
         "label": {
           "type": "string"
+        },
+        "nullable": {
+          "type": "boolean"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object",
@@ -1092,7 +1238,14 @@
     },
     "NonNullModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -1103,6 +1256,12 @@
           ],
           "type": "string"
         },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "type": {
           "enum": [
             "non_null"
@@ -1112,6 +1271,7 @@
       },
       "required": [
         "field",
+        "id",
         "type"
       ],
       "type": "object"
@@ -1399,7 +1559,14 @@
     },
     "RelationshipModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -1409,6 +1576,12 @@
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "to": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*\\.[A-Za-z_][A-Za-z0-9_]*$",
@@ -1423,6 +1596,7 @@
       },
       "required": [
         "field",
+        "id",
         "to",
         "type"
       ],
@@ -1512,6 +1686,13 @@
     },
     "RowCountModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
         "maximum": {
           "format": "int64",
           "type": "integer"
@@ -1527,6 +1708,12 @@
           ],
           "type": "string"
         },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "type": {
           "enum": [
             "row_count"
@@ -1535,6 +1722,7 @@
         }
       },
       "required": [
+        "id",
         "type"
       ],
       "type": "object"
@@ -1652,7 +1840,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/ResourceMetadata"
+          "$ref": "#/$defs/ContractResourceMetadata"
         },
         "spec": {
           "$ref": "#/$defs/SourceSpec"
@@ -1802,6 +1990,19 @@
     },
     "SourceSchemaField": {
       "properties": {
+        "authoritativeDefinitions": {
+          "items": {
+            "$ref": "#/$defs/AuthoritativeDefinition"
+          },
+          "type": "array"
+        },
+        "classification": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "criticalDataElement": {
+          "type": "boolean"
+        },
         "datatype": {
           "enum": [
             "String",
@@ -1817,11 +2018,20 @@
           ],
           "type": "string"
         },
+        "deprecation": {
+          "$ref": "#/$defs/FieldDeprecation"
+        },
         "description": {
           "type": "string"
         },
         "nullable": {
           "type": "boolean"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -1972,6 +2182,9 @@
     },
     "UniqueModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "fields": {
           "items": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
@@ -1979,12 +2192,22 @@
           },
           "type": "array"
         },
+        "id": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
         "severity": {
           "enum": [
             "warning",
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "type": {
           "enum": [
@@ -1995,6 +2218,7 @@
       },
       "required": [
         "fields",
+        "id",
         "type"
       ],
       "type": "object"
@@ -2061,7 +2285,7 @@
       "type": "string"
     },
     "metadata": {
-      "$ref": "#/$defs/ResourceMetadata"
+      "$ref": "#/$defs/ContractResourceMetadata"
     },
     "spec": {
       "$ref": "#/$defs/ModelSpec"

--- a/schemas/json/source.schema.json
+++ b/schemas/json/source.schema.json
@@ -23,7 +23,14 @@
     },
     "AcceptedValuesModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -33,6 +40,12 @@
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "type": {
           "enum": [
@@ -49,10 +62,32 @@
       },
       "required": [
         "field",
+        "id",
         "type",
         "values"
       ],
       "type": "object"
+    },
+    "AuthoritativeDefinition": {
+      "properties": {
+        "type": {
+          "enum": [
+            "businessDefinition",
+            "transformationImplementation"
+          ],
+          "type": "string"
+        },
+        "url": {
+          "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "AzureBlobConnection": {
       "allOf": [
@@ -307,6 +342,71 @@
       ],
       "type": "object"
     },
+    "ContractMetadata": {
+      "properties": {
+        "compatibility": {
+          "enum": [
+            "backward"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "compatibility",
+        "version"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ContractResourceMetadata": {
+      "properties": {
+        "contract": {
+          "$ref": "#/$defs/ContractMetadata"
+        },
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "documentation": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$",
+          "type": "string"
+        },
+        "name": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*$",
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/$defs/ResourceProvenance"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
     "DeltaPathSourceLocation": {
       "allOf": [
         {
@@ -455,6 +555,27 @@
         "scanKind": "table_function",
         "sourceDataIdentityCapability": "unavailable"
       }
+    },
+    "FieldDeprecation": {
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "replacement": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "since": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason",
+        "since"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
     },
     "FieldFreshness": {
       "properties": {
@@ -785,7 +906,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/ResourceMetadata"
+          "$ref": "#/$defs/ContractResourceMetadata"
         },
         "spec": {
           "$ref": "#/$defs/ModelSpec"
@@ -977,6 +1098,19 @@
         "aiContext": {
           "$ref": "#/$defs/AIContext"
         },
+        "authoritativeDefinitions": {
+          "items": {
+            "$ref": "#/$defs/AuthoritativeDefinition"
+          },
+          "type": "array"
+        },
+        "classification": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "criticalDataElement": {
+          "type": "boolean"
+        },
         "datatype": {
           "enum": [
             "String",
@@ -992,11 +1126,23 @@
           ],
           "type": "string"
         },
+        "deprecation": {
+          "$ref": "#/$defs/FieldDeprecation"
+        },
         "description": {
           "type": "string"
         },
         "label": {
           "type": "string"
+        },
+        "nullable": {
+          "type": "boolean"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object",
@@ -1094,7 +1240,14 @@
     },
     "NonNullModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -1105,6 +1258,12 @@
           ],
           "type": "string"
         },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "type": {
           "enum": [
             "non_null"
@@ -1114,6 +1273,7 @@
       },
       "required": [
         "field",
+        "id",
         "type"
       ],
       "type": "object"
@@ -1401,7 +1561,14 @@
     },
     "RelationshipModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "field": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "id": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
           "type": "string"
         },
@@ -1411,6 +1578,12 @@
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "to": {
           "pattern": "^[A-Za-z_][A-Za-z0-9_-]*(\\.[A-Za-z_][A-Za-z0-9_-]*)*\\.[A-Za-z_][A-Za-z0-9_]*$",
@@ -1425,6 +1598,7 @@
       },
       "required": [
         "field",
+        "id",
         "to",
         "type"
       ],
@@ -1514,6 +1688,13 @@
     },
     "RowCountModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
         "maximum": {
           "format": "int64",
           "type": "integer"
@@ -1529,6 +1710,12 @@
           ],
           "type": "string"
         },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "type": {
           "enum": [
             "row_count"
@@ -1537,6 +1724,7 @@
         }
       },
       "required": [
+        "id",
         "type"
       ],
       "type": "object"
@@ -1652,7 +1840,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/ResourceMetadata"
+          "$ref": "#/$defs/ContractResourceMetadata"
         },
         "spec": {
           "$ref": "#/$defs/SourceSpec"
@@ -1802,6 +1990,19 @@
     },
     "SourceSchemaField": {
       "properties": {
+        "authoritativeDefinitions": {
+          "items": {
+            "$ref": "#/$defs/AuthoritativeDefinition"
+          },
+          "type": "array"
+        },
+        "classification": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        "criticalDataElement": {
+          "type": "boolean"
+        },
         "datatype": {
           "enum": [
             "String",
@@ -1817,11 +2018,20 @@
           ],
           "type": "string"
         },
+        "deprecation": {
+          "$ref": "#/$defs/FieldDeprecation"
+        },
         "description": {
           "type": "string"
         },
         "nullable": {
           "type": "boolean"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -1972,6 +2182,9 @@
     },
     "UniqueModelCheck": {
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "fields": {
           "items": {
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
@@ -1979,12 +2192,22 @@
           },
           "type": "array"
         },
+        "id": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
         "severity": {
           "enum": [
             "warning",
             "error"
           ],
           "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "type": {
           "enum": [
@@ -1995,6 +2218,7 @@
       },
       "required": [
         "fields",
+        "id",
         "type"
       ],
       "type": "object"
@@ -2058,7 +2282,7 @@
       "type": "string"
     },
     "metadata": {
-      "$ref": "#/$defs/ResourceMetadata"
+      "$ref": "#/$defs/ContractResourceMetadata"
     },
     "spec": {
       "$ref": "#/$defs/SourceSpec"


### PR DESCRIPTION
## Problem
FAI-620 reconciliation needs authored contract/governance metadata that is absent from main. The historical implementation branch is too broad to merge.

## Root cause
The existing SemanticModel authority reconciliation did not include the metadata prerequisite from 62157604b.

## Solution
Isolate only Source/Model contract metadata, field governance/deprecation shapes, and stable authored Model check IDs. Preserve check metadata through lowering and copy tags defensively in snapshots. Regenerate DTOs and schemas; update focused fixtures and documentation.

No canonical contract digest implementation, quality-gate identity change, FAI-662 projection bypass hardening, ResourceUID registry, runtime/API boundary, or deployment identity changes.

## Tests added/updated
- Typed metadata decoding and positive/negative schema cases.
- Required, unique authored check IDs and metadata retention across all five check variants.
- Snapshot tag-alias regression: reproduced before the copy fix and passing after it.
- Minimal check IDs in two dbt example fixtures.

## Verification performed
Local full task ci passed, including PostgreSQL conformance and all five frontend shards. Full generation, generated checks, architecture tests, focused compiler/model/contracts/schema/gates/artifact tests, quality budget, and diff checks passed. Hosted validation is pending.

## Remaining limitations
Authoritative URLs receive scheme/non-whitespace shape validation, not full URI validation or reference resolution. Contextual deprecation validation and complete quality-identity integration are not claimed. FAI-620 remains waiting; FAI-662 and FAI-670 are untouched.

Issue: https://linear.app/flid/issue/FAI-619
FAI-624 remains a duplicate of FAI-619. Do not merge automatically.