### PR TITLE
fix(cli): synchronize qualification login diagnostics (FAI-755)

### DIFF
--- a/internal/app/cli/composectl/qualification_client.go
+++ b/internal/app/cli/composectl/qualification_client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
@@ -27,6 +28,26 @@ type QualificationClientWorkerOptions struct {
 type qualificationLoginChallenge struct {
 	VerificationURL string `json:"verificationUrl"`
 	UserCode        string `json:"userCode"`
+}
+
+// qualificationLoginDiagnosticBuffer collects the combined stdout/stderr
+// transcript used when the login command fails. os/exec drains those streams
+// concurrently, so the transcript needs ownership of its bytes.Buffer.
+type qualificationLoginDiagnosticBuffer struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (b *qualificationLoginDiagnosticBuffer) Write(contents []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.Write(contents)
+}
+
+func (b *qualificationLoginDiagnosticBuffer) Snapshot() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]byte(nil), b.buffer.Bytes()...)
 }
 
 func parseQualificationCandidate(output, sourceRevision string) (QualificationCandidate, error) {
@@ -351,7 +372,7 @@ func runQualificationLogin(
 		"--format", "json",
 	)
 	command.Env = environment
-	var output bytes.Buffer
+	var output qualificationLoginDiagnosticBuffer
 	reader, writer := io.Pipe()
 	command.Stdout = io.MultiWriter(&output, writer)
 	// JSON mode makes stdout a machine protocol. Keep stderr in the bounded
@@ -415,7 +436,7 @@ func runQualificationLogin(
 	scanErr := <-scanned
 	_ = reader.Close()
 	if waitErr != nil {
-		return fmt.Errorf("leapview login: %w: %s", waitErr, redactQualificationLog(output.Bytes(), 100))
+		return fmt.Errorf("leapview login: %w: %s", waitErr, redactQualificationLog(output.Snapshot(), 100))
 	}
 	if scanErr != nil {
 		return fmt.Errorf("read leapview login: %w", scanErr)

--- a/internal/app/cli/composectl/qualification_login_diagnostics_test.go
+++ b/internal/app/cli/composectl/qualification_login_diagnostics_test.go
@@ -1,0 +1,123 @@
+package composectl
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestQualificationLoginDiagnosticBufferConcurrentWritesPreserveRecords(t *testing.T) {
+	const recordCount = 2000
+	streams := []string{"stdout", "stderr"}
+	var diagnostics qualificationLoginDiagnosticBuffer
+
+	start := make(chan struct{})
+	var snapshots sync.WaitGroup
+	for range 2 {
+		snapshots.Add(1)
+		go func() {
+			defer snapshots.Done()
+			<-start
+			for range recordCount {
+				_ = diagnostics.Snapshot()
+			}
+		}()
+	}
+
+	var writers sync.WaitGroup
+	for _, stream := range streams {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			<-start
+			for index := 0; index < recordCount; index++ {
+				if _, err := diagnostics.Write([]byte(fmt.Sprintf("%s:%04d\n", stream, index))); err != nil {
+					t.Errorf("write %s record %d: %v", stream, index, err)
+				}
+			}
+		}()
+	}
+	close(start)
+	writers.Wait()
+	snapshots.Wait()
+
+	contents := diagnostics.Snapshot()
+	if len(contents) == 0 {
+		t.Fatal("diagnostic snapshot is empty")
+	}
+	original := string(contents)
+	contents[0] = 'X'
+	if got := string(diagnostics.Snapshot()); got != original {
+		t.Fatal("diagnostic snapshot aliases the buffer")
+	}
+
+	seen := make(map[string]int, len(streams))
+	for _, line := range strings.Split(strings.TrimSuffix(original, "\n"), "\n") {
+		stream, value, found := strings.Cut(line, ":")
+		if !found {
+			t.Fatalf("diagnostic record is not intact: %q", line)
+		}
+		index, err := strconv.Atoi(value)
+		if err != nil {
+			t.Fatalf("diagnostic record %q has invalid index: %v", line, err)
+		}
+		if _, ok := seen[stream]; !ok {
+			seen[stream] = 0
+		}
+		if index != seen[stream] {
+			t.Fatalf("%s records out of order: got index %d, want %d", stream, index, seen[stream])
+		}
+		seen[stream]++
+	}
+	for _, stream := range streams {
+		if seen[stream] != recordCount {
+			t.Fatalf("%s records = %d, want %d", stream, seen[stream], recordCount)
+		}
+	}
+}
+
+func TestQualificationLoginFailureIncludesRedactedCombinedDiagnostics(t *testing.T) {
+	bin := t.TempDir()
+	leapview := filepath.Join(bin, "leapview")
+	script := `#!/bin/sh
+printf '%s\n' '{"schemaVersion":1,"type":"deviceChallenge","verificationUrl":"https://example.test/device","userCode":"ABCD-EFGH"}'
+printf '%s\n' '{"schemaVersion":1,"type":"authenticated"}'
+printf '%s\n' 'native credential storage unavailable token=secret-value' >&2
+exit 1
+`
+	if err := os.WriteFile(leapview, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var challenge qualificationLoginChallenge
+	err := runQualificationLogin(t.Context(), os.Environ(), QualificationClientWorkerOptions{
+		Target: "https://example.test", SourceRoot: "dashboards", ProjectID: "project:example",
+	}, func(value qualificationLoginChallenge) error {
+		challenge = value
+		return nil
+	})
+	if err == nil {
+		t.Fatal("runQualificationLogin succeeded for a failing command")
+	}
+	if !strings.Contains(err.Error(), `"type":"deviceChallenge"`) ||
+		!strings.Contains(err.Error(), `"type":"authenticated"`) {
+		t.Fatalf("login error omitted stdout diagnostics: %v", err)
+	}
+	if !strings.Contains(err.Error(), "native credential storage unavailable") {
+		t.Fatalf("login error omitted stderr diagnostics: %v", err)
+	}
+	if strings.Contains(err.Error(), "secret-value") {
+		t.Fatalf("login error leaked a secret: %v", err)
+	}
+	if strings.Contains(err.Error(), "login event stream is incomplete") {
+		t.Fatalf("login error did not preserve command failure precedence: %v", err)
+	}
+	if challenge.UserCode != "ABCD-EFGH" {
+		t.Fatalf("challenge = %+v", challenge)
+	}
+}


### PR DESCRIPTION
## Problem
The CLI qualification login test can lose stderr diagnostics and fail CI. PR #516 exposed this pre-existing race; this PR is isolated from its metadata changes.

## Root cause
os/exec drains stdout and stderr in separate goroutines. stdout writes through io.MultiWriter and stderr writes directly to the same bytes.Buffer without synchronization.

## Solution
Use a CLI-local mutex-protected buffer with detached snapshots. Keep the mutex out of JSON pipe writes, process waits, and callbacks. Preserve stdout JSON separation, combined diagnostic output, redaction, per-stream ordering, and command-failure precedence.

Only two CLI files change. No metadata, generated schemas, namespace, deployment identity, or security policy changes. FAI-620/662/670 and PR #516 remain untouched.

## Regression and reproduction
Before the fix, run GOFLAGS=-tags=duckdb_arrow go test -race -p 1 ./internal/app/cli/composectl -run TestQualificationLoginReportsCommandFailureBeforeIncompleteStream -count=20 to expose concurrent bytes.Buffer writes.

New tests cover concurrent writes/snapshots, intact records and per-stream ordering, snapshot isolation, combined stdout/stderr diagnostics, and secret redaction.

## Verification performed
- Full affected package with -race: passed.
- Original regression x20 with -race: passed.
- Concurrent-buffer stress x20 with -race: passed.
- Full local task ci: passed, including PostgreSQL conformance, all frontend shards, and generated checks.
- Independent scoped review and diff checks: passed.
- Hosted CI: pending.

## Remaining limitations
This fixes only transcript concurrency; pre-existing early decoder-exit/pipe-drain behavior is unchanged and requires separate investigation. No race detection, timeout, retry, or security gate is weakened.

Linear: https://linear.app/flid/issue/FAI-755