### PR TITLE
fix(ci): stabilize sqlc dependency download transport (FAI-756)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -737,14 +737,16 @@ tasks:
       - internal/manageddata/postgres/internal/db/*.go
       - internal/platform/events/postgres/internal/db/*.go
       - internal/platform/**/sqlite/*db/*.go
+    # Match setup-ci's HTTP/1.1 workaround for checksum-service HTTP/2 stream
+    # failures; transport only, with sqlc checksums and TLS integrity unchanged.
     cmds:
-      - GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate --no-remote
+      - GODEBUG=http2client=0 GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate --no-remote
 
   db:verify:
     desc: Compile generated PostgreSQL sqlc packages and audit handwritten SQL boundaries
     cmds:
-      - GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 vet --no-remote
-      - GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 diff --no-remote
+      - GODEBUG=http2client=0 GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 vet --no-remote
+      - GODEBUG=http2client=0 GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 diff --no-remote
       - |
         packages="$(
           find internal -type f -name '*.go' -print |
@@ -812,7 +814,7 @@ tasks:
             done
         }
         git diff --binary -- '*.go' >"$before"
-        GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate --no-remote
+        GODEBUG=http2client=0 GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate --no-remote
         generated_snapshot >"$generated_after"
         git diff --binary -- '*.go' >"$after"
         if ! cmp -s "$before" "$after"; then
@@ -823,7 +825,7 @@ tasks:
         # A second local generation catches nondeterministic or newly emitted
         # untracked sqlc files without rejecting the intentionally build-only
         # output created by a clean checkout.
-        GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate --no-remote
+        GODEBUG=http2client=0 GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate --no-remote
         generated_snapshot >"$generated_repeat"
         cmp -s "$generated_after" "$generated_repeat" || {
           printf '%s\n' 'sqlc generation is nondeterministic across generated Go outputs' >&2

--- a/internal/platform/architecture/sqlc_transport_test.go
+++ b/internal/platform/architecture/sqlc_transport_test.go
@@ -1,0 +1,45 @@
+package architecture
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSQLCInvocationsPinDownloadTransport(t *testing.T) {
+	root := repoRoot(t)
+	const invocation = "go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1"
+	const expectedPrefix = "GODEBUG=http2client=0 GOTOOLCHAIN=go1.26.7 " + invocation
+
+	paths := map[string]int{
+		"Taskfile.yml": 5,
+		filepath.Join("scripts", "generate_build_sources.sh"): 1,
+	}
+	for relativePath, wantCount := range paths {
+		relativePath, wantCount := relativePath, wantCount
+		t.Run(relativePath, func(t *testing.T) {
+			body, err := os.ReadFile(filepath.Join(root, relativePath))
+			if err != nil {
+				t.Fatalf("read %s: %v", relativePath, err)
+			}
+
+			gotCount := 0
+			for _, line := range strings.Split(string(body), "\n") {
+				if !strings.Contains(line, "go run github.com/sqlc-dev/sqlc/cmd/sqlc@") {
+					continue
+				}
+				gotCount++
+				if !strings.Contains(line, expectedPrefix) {
+					t.Errorf("sqlc invocation missing pinned transport/toolchain: %q", strings.TrimSpace(line))
+				}
+				if !strings.Contains(line, "--no-remote") {
+					t.Errorf("sqlc invocation must retain --no-remote: %q", strings.TrimSpace(line))
+				}
+			}
+			if gotCount != wantCount {
+				t.Fatalf("sqlc invocation count = %d, want %d", gotCount, wantCount)
+			}
+		})
+	}
+}

--- a/scripts/generate_build_sources.sh
+++ b/scripts/generate_build_sources.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -eu
 
-GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate --no-remote
+# Match setup-ci's HTTP/1.1 workaround for checksum-service HTTP/2 stream
+# failures; transport only, with sqlc checksums and TLS integrity unchanged.
+GODEBUG=http2client=0 GOTOOLCHAIN=go1.26.7 go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate --no-remote
 go run ./internal/app/tools/configgen
 go run ./internal/app/tools/layoutcontractgen
 


### PR DESCRIPTION
## Problem
Merge validation #303 failed during db:generate when sum.golang.org returned an HTTP/2 INTERNAL_ERROR while verifying a Go dependency. Frontend tests had not started.

## Root cause
The six sqlc generation and verification invocations omitted the HTTP/1.1 workaround already used by CI tool installation.

## Solution
Apply command-local GODEBUG=http2client=0 to all six sqlc invocations. Preserve pinned Go/sqlc versions, TLS, checksum verification, --no-remote, and security gates. No retries, dependency changes, or unrelated fixes.

## Tests
Add architecture regression coverage for every sqlc invocation in Taskfile.yml and scripts/generate_build_sources.sh. Confirmed red before the fix and green afterward.

## Verification
Passed locally: real cold-module-cache db:generate, sqlc vet/diff, db determinism and verification, PostgreSQL 18 query preparation, APIGen, architecture tests, generated checks, quality budget, and diff checks.

## Limitations
Full local task ci stopped at TestMinIOParquetSourceRefreshContract: HTTP 507 XMinioStorageFull because the local disk was below the minimum free-space threshold. No storage settings or checks were changed. Hosted validation is pending.

Isolated from PR #519, PR #516, FAI-620, FAI-662, and FAI-670.

Linear: https://linear.app/flid/issue/FAI-756/apply-http11-transport-convention-to-sqlc-dependency-downloads