### PR TITLE
fix(mapassets): pin archive compression toolchain

### DIFF
--- a/internal/app/tools/mapassets/main.go
+++ b/internal/app/tools/mapassets/main.go
@@ -290,9 +290,17 @@ func reuseVerifiedArchive(primary, legacy, digest, target string) error {
 }
 
 func runPMTiles(ctx context.Context, arguments ...string) error {
+	return pmtilesCommand(ctx, arguments...).Run()
+}
+
+func pmtilesCommand(ctx context.Context, arguments ...string) *exec.Cmd {
 	command := exec.CommandContext(ctx, "go", append([]string{"run", "github.com/protomaps/go-pmtiles@v1.31.1"}, arguments...)...)
+	// Archive digests cover compressed bytes, not just tile contents. Go 1.27
+	// changed DEFLATE output, so pin the encoder independently of the host Go
+	// version. Changing this toolchain requires regenerating the archive digests.
+	command.Env = append(os.Environ(), "GOTOOLCHAIN=go1.26.8")
 	command.Stdout, command.Stderr = os.Stdout, os.Stderr
-	return command.Run()
+	return command
 }
 
 func downloadIfMissing(ctx context.Context, client *http.Client, remote, target, expected string) error {

--- a/internal/app/tools/mapassets/main_test.go
+++ b/internal/app/tools/mapassets/main_test.go
@@ -1,12 +1,36 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 )
+
+func TestPMTilesCommandPinsArchiveEncodingToolchain(t *testing.T) {
+	t.Setenv("GOTOOLCHAIN", "go1.27.1")
+	t.Setenv("LEAPVIEW_MAP_TEST_ENV", "preserved")
+	command := pmtilesCommand(context.Background(), "extract", "input", "output", "--maxzoom=6")
+	want := []string{"go", "run", "github.com/protomaps/go-pmtiles@v1.31.1", "extract", "input", "output", "--maxzoom=6"}
+	if !slices.Equal(command.Args, want) {
+		t.Fatalf("command arguments = %q, want %q", command.Args, want)
+	}
+	environment := make(map[string]string)
+	for _, entry := range command.Environ() {
+		key, value, _ := strings.Cut(entry, "=")
+		environment[key] = value
+	}
+	if environment["GOTOOLCHAIN"] != "go1.26.8" {
+		t.Fatalf("archive encoder toolchain = %q, want go1.26.8", environment["GOTOOLCHAIN"])
+	}
+	if environment["LEAPVIEW_MAP_TEST_ENV"] != "preserved" {
+		t.Fatal("archive command discarded the inherited environment")
+	}
+}
 
 func TestVerifyFileFailsClosedOnDigestMismatch(t *testing.T) {
 	name := filepath.Join(t.TempDir(), "asset")


### PR DESCRIPTION
## Problem
Production and public-site image builds fail when fresh map extraction produces a checksum different from the immutable archive contract.

## Root cause
The container uses Go 1.27, whose DEFLATE encoder changed output bytes. Pinning go-pmtiles alone does not pin its standard-library encoder. The existing checksums were generated with the Go 1.26 encoder. See https://go.dev/doc/go1.27#compressflatepkgcompressflate.

## Solution
Pin only the go-pmtiles child process to Go 1.26.8, independently of the host compiler. Preserve the inherited environment and all existing digest verification. No asset checksums or container versions change.

## Reproduction and regression coverage
Run fresh map generation under the container toolchain: the global archive hashes to bf3bd02be1c2b5914d71d274fb7855bba57b82c47c8e6aab0310545ef45caa09 instead of the expected 2d97ee8907670936ab722da7ca06eafec0734392f73fa1cd337d4debd85d676f.
Added a command contract test with an inherited Go 1.27 toolchain. It failed before the fix and passes afterward; it also checks argument and environment preservation.

## Verification performed
- go test ./internal/app/tools/mapassets ./internal/dashboard/visualization/mapasset/... -count=1 passed.
- Fresh network-backed global extraction with Go 1.26.8 reproduced the expected global digest.
- Full fresh mapassets installation passed, including regional extraction, merge, glyphs, sprites, and installed inventory verification.
- Final merged archive reproduced af527dbc24444b4f87e89190319f65bd6e6e6ef0db8d8054f19e2017932ab392.
- git diff --check passed.

## Limitations
First use may download the pinned Go toolchain. A future encoder upgrade requires deliberate archive regeneration. Hosted CI and post-merge image builds remain required.

Additional verification: focused tests and a full fresh network-backed installation also passed with GOTOOLCHAIN=go1.27.1, matching the Docker host compiler while the child encoder remained pinned.