### PR TITLE
fix(demo): generate clean-checkout sources before publishing

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -46,6 +46,14 @@ jobs:
           path: ~/.cache/leapview
           key: olist-v2-967e41e04fc306fe604e2a693f488995a8b41e5047418f8a5c8e4abd6deca784
 
+      - name: Set up Node.js for source generation
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Generate clean-checkout build sources
+        run: ./scripts/generate_build_sources.sh
+
       - name: Fetch demo deployment credentials
         uses: Infisical/secrets-action@6cd3f7c0e4cc0d2395ee4ef414eb6eeb5d3e73db # v1.0.17
         with:

--- a/deploy/demo/workflow_test.go
+++ b/deploy/demo/workflow_test.go
@@ -1,0 +1,24 @@
+package demo_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDemoWorkflowGeneratesSourcesBeforePublication(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "demo-deploy.yml"))
+	require.NoError(t, err)
+	workflow := string(body)
+	nodeSetup := strings.Index(workflow, "uses: actions/setup-node@")
+	generation := strings.Index(workflow, "run: ./scripts/generate_build_sources.sh")
+	credentials := strings.Index(workflow, "name: Fetch demo deployment credentials")
+	publication := strings.Index(workflow, "run: ./scripts/deploy_demo.sh")
+	require.NotEqual(t, -1, nodeSetup, "TypeSpec generation requires Node.js")
+	require.Greater(t, generation, nodeSetup, "generate clean-checkout sources after installing Node.js")
+	require.Greater(t, credentials, generation, "generate sources before fetching deployment credentials")
+	require.Greater(t, publication, credentials, "publish only after generation and credential setup")
+}


### PR DESCRIPTION
## Problem
After production image builds recovered, Hosted demo deployment failed compiling the CLI because ignored API, configuration, and sqlc sources were absent from its clean checkout.

## Root cause
The workflow configured Go but neither the TypeSpec Node runtime nor build-source generation. deploy_demo.sh invokes go build before its later configuration-only generation step.

## Solution
Set up the same pinned Node action and Node 24 used by CI, then run the existing generate_build_sources.sh pipeline before fetching deployment credentials. Keep publishing, authentication, source-revision binding, and runtime compatibility checks unchanged.

## Reproduction and regression coverage
Run the previous hosted-demo workflow from a clean checkout: CLI compilation fails with missing internal API/gen and postgres/internal/db packages (run 34197296947).
Added a workflow contract test ensuring Node setup precedes generation, which precedes credentials and publication. The test failed against the old workflow and passes with the fix.

## Verification performed
- go test workflow_test.go -count=1 in deploy/demo passed after a red-green run.
- git diff --check passed.
- Full clean-checkout generate_build_sources.sh, go test ./deploy/demo -count=1, and go build ./cmd/leapview all passed locally. Hosted PR and merge-queue validation remain required.

## Limitations
The actual hosted publication requires production workload credentials and will be verified through the main-branch workflow after merge. Generation adds work to the deployment job but reuses the canonical image-build generation pipeline.