### PR TITLE
feat(recoveryset): qualify immutable recovery evidence (FAI-520)

### DIFF
--- a/.github/workflows/recovery-evidence-qualification.yml
+++ b/.github/workflows/recovery-evidence-qualification.yml
@@ -1,0 +1,65 @@
+name: Recovery evidence qualification
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/recovery-evidence-qualification.yml'
+      - 'internal/manageddata/**'
+      - 'internal/recoveryset/**'
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: recovery-evidence-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evidence-qualification:
+    name: PostgreSQL and MinIO evidence qualification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Set up the pinned CI toolchain
+        uses: ./.github/actions/setup-ci
+        with:
+          browser: 'false'
+      - name: Prepare generated contracts
+        run: task generate
+      - name: Qualify recovery evidence against disposable providers
+        env:
+          LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED: 'true'
+        run: >-
+          go test -race -tags='duckdb_arrow fai520qualification'
+          ./internal/manageddata/storage/s3
+          ./internal/recoveryset/postgres
+          ./internal/recoveryset/observationstore
+          -run '^(TestFAI520|TestProviderObservation)'
+          -count=2 -timeout=15m -v
+      - name: Verify generated snapshots
+        run: task generated:check
+
+  full-validation:
+    name: Recovery candidate full validation
+    needs: evidence-qualification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Check out candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - name: Set up the pinned CI toolchain
+        uses: ./.github/actions/setup-ci
+        with:
+          browser: 'true'
+          terraform: 'true'
+      - name: Prepare generated and embedded assets
+        run: task ci:prepare
+      - name: Run the existing full-validation extras
+        run: task ci:full:extras

--- a/.security/coverage.yaml
+++ b/.security/coverage.yaml
@@ -168,6 +168,10 @@ surfaces:
     kind: github-actions
     updater: {ecosystem: github-actions, directory: /}
     scanners: [trivy, action-pin-policy]
+  - path: .github/workflows/recovery-evidence-qualification.yml
+    kind: github-actions
+    updater: {ecosystem: github-actions, directory: /}
+    scanners: [trivy, action-pin-policy]
   - path: .github/workflows/release.yml
     kind: github-actions
     updater: {ecosystem: github-actions, directory: /}

--- a/docs/articles/data/recovery-evidence-manifest.md
+++ b/docs/articles/data/recovery-evidence-manifest.md
@@ -1,0 +1,120 @@
+# Recovery evidence manifests
+
+FAI-520 defines a small, evidence-only contract for qualifying historical
+managed-object recovery. An observation manifest records the exact managed
+revision files, provider object versions, bytes, and one PostgreSQL boundary.
+It is not a restore command, an activation request, or an authenticity proof.
+
+This validates recovery evidence binding. It does not prove successful physical disaster recovery.
+
+## Trusted capture boundary
+
+The source-side port is
+`manageddata.ProjectionCaptureSource`:
+
+```go
+CaptureManagedProjection(context.Context) (manageddata.CapturedProjection, error)
+```
+
+`internal/manageddata/postgres.Repository.CaptureManagedProjection` is the
+trusted implementation. `internal/recoveryset/postgres.Capture` adapts its
+result to an opaque `CapturedObservation`; callers cannot provide or replace
+the marker, PostgreSQL identities, or managed inventory.
+
+The capture source is a privileged composition dependency, not request input.
+An arbitrary implementation of that port is not a trusted authority. Parsed
+attestation bytes alone establish neither provenance nor backup availability.
+
+Capture uses one repeatable-read PostgreSQL transaction. It locks the managed
+observation tables, reads the reachability epoch before and after a complete,
+ordered walk of ready revisions and their files, and rejects recovery or an
+epoch change. It creates one `pg_create_restore_point` marker, verifies WAL
+flush through that exact marker on the same transaction connection, and only
+then commits and releases the locks. The bounded capture fails if marker flush
+cannot be confirmed; inserting a restore-point record alone is not durability.
+Trusted capture also requires PostgreSQL `fsync=on` before creating the marker
+and while confirming flush. Qualification containers explicitly enable it;
+the usual test-container performance default is not durability evidence.
+The resulting boundary contains database identity, numeric system identity,
+timeline, canonical WAL LSN, restore-point name, and the inventory digest.
+There is no provider I/O in this transaction. The frozen projection is the
+managed-data authority plus its WAL marker; provider version observations are
+captured separately and must not be inferred from provider listings.
+Capture is bounded to 30 seconds and can block managed-data writers while
+waiting for the marker to flush. This qualification does not provide a
+non-blocking production capture scheduler or prove backup/WAL-archive retention.
+
+## Manifest contract
+
+`internal/recoveryset/observation` owns these JSON fields:
+
+- `Boundary`: protocol version, database/system identities, timeline, LSN,
+  restore-point name, and inventory digest.
+- `Inventory`: schema version and ready `Revision` records. Each revision has
+  its operational ID, canonical managed `ManifestDigest`, and `File` records.
+- `File`: logical path, raw lowercase SHA-256, exact `s3://bucket/key` storage
+  key, and byte size.
+- `Objects`: one `Observation` for each inventory file. Each `ProviderObject`
+  records endpoint, region, bucket, key, non-null version ID, raw SHA-256, and
+  size.
+
+`Manifest.Validate` validates each existing managed-data manifest and digest,
+rejects duplicate revision/file/observation identities, and requires a full
+bijection between inventory files and observations. Provider bucket/key,
+hash, and size must match the declared storage key and file. Provider
+endpoints must be HTTPS or loopback HTTP and contain no credentials.
+
+`CanonicalJSON` sorts revisions, files, and observations only after duplicate
+rejection. Aggregate digests use lowercase `sha256:` identities; file hashes
+remain raw lowercase SHA-256 values. `Parse` and `ParseBoundary` are bounded
+(8 MiB), strict snake_case JSON parsers: unknown or duplicate keys, case
+aliases, omitted zero-valued fields, null scalars, and omitted arrays are
+rejected. Empty inventories and object closures use explicit `[]` arrays.
+
+## Off-host evidence retention
+
+`internal/recoveryset/observationstore.Store.Save` accepts the opaque captured
+projection, exact provider observations, and a required retention horizon. It
+writes immutable manifest, boundary, and descriptor objects to the configured
+evidence bucket using content digests and checks the existing object rather
+than overwriting it. `Reload` rechecks the exact provider version, size, body
+hash, descriptor bindings, and retention before returning evidence.
+
+Source objects and evidence objects must have S3 Object Lock `COMPLIANCE`
+retention through the required horizon. Retention is checked again during
+reload; an expired or weaker mode is failure, never a latest-version fallback.
+The initial store supports one configured source endpoint, region, and bucket.
+An inventory spanning unsupported provider namespaces fails rather than being
+silently reduced to a partial closure.
+The recovery caller chooses the required horizon; the provider enforces
+COMPLIANCE retention on each exact version. The store does not assume that
+versioning protects against deletion, and it does not extend source retention
+on the caller's behalf. Managed-data garbage collection cannot delete protected
+versions before that horizon. Partial captures can leave retained, unreferenced
+evidence objects; they are not accepted frontiers and cannot be reclaimed before
+their provider retention expires. No new garbage-collection workflow is added.
+The store is an off-host evidence store only and does not publish a frontier,
+activate serving state, or participate in startup.
+
+Recovery-set schema 2 may bind manifest, boundary, and descriptor digests plus
+the exact boundary for qualification-only off-host persistence. Existing
+schema-1 SQL publication/startup rejects managed-evidence fields, and schema 2
+does not add an activation path.
+
+## Validation and qualification
+
+Run against the disposable qualification fixtures with Docker and the normal
+repository toolchain. These commands exercise contracts and evidence checks;
+they do not perform SQL restore or PostgreSQL PITR:
+
+```sh
+LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED=true go test -tags='duckdb_arrow fai520qualification' ./internal/manageddata/... ./internal/recoveryset/... -count=1
+LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED=true go test -tags='duckdb_arrow fai520qualification' ./internal/recoveryset/... -count=2 -v
+git diff --check
+```
+
+Record the manifest digest, boundary digest, descriptor digest, provider
+endpoint/region/bucket/key/version, byte size/hash, and retention horizon from
+the qualification output. Do not treat those observations as production
+recovery authority until the required independent off-host evidence and
+operational restore plan exist.

--- a/docs/articles/data/storage-recovery.md
+++ b/docs/articles/data/storage-recovery.md
@@ -56,3 +56,806 @@ verification is complete.
 Development and evaluation fixtures may use embedded SQLite and a local DuckLake
 catalog, but those adapters are not a production fallback. Test fixture backup
 and restore belongs to the fixture harness, not this production runbook.
+
+## FAI-520 historical managed-object retrieval qualification
+
+### Qualification goal
+
+FAI-520's bounded PostgreSQL-era slice qualifies exact historical retrieval of
+managed content bytes. It does not restore an application or publish a recovery
+set. Existing FAI-521 admission validators and startup behavior are unchanged.
+
+This validates historical managed-object retrieval. It does not prove successful physical disaster recovery.
+
+### Provider assumptions
+
+The selected provider is disposable MinIO, pinned to
+`minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e`.
+The experiment requires bucket versioning, immutable non-null version IDs,
+explicit-version GET, retained historical versions behind a delete marker, and
+authenticated access. It qualifies that image, not all S3-compatible services
+or AWS production configurations. Expired lifecycle retention may make versions
+unavailable; retrieval must then fail, never substitute latest.
+
+### Test environment
+
+`TestFAI520HistoricalManagedObjectRetrieval` is opt-in under
+`fai520qualification`. Docker is required; inability to start the provider is a
+failure, not a skipped qualification. Each run creates a fresh container,
+random credentials, a unique versioned bucket, and two isolated prefixes.
+Credentials are configured directly; no ambient credential chain is consulted.
+MinIO's `/data` uses a bounded 1-GiB tmpfs (allocated on demand). This isolates
+the tiny fixture from shared-host disk pressure; it does not test crash
+persistence. Failed HTTP requests log only method/status, never URLs,
+credentials, or response bodies.
+Container cleanup removes the disposable data, including versions and delete
+markers. No production endpoint or credentials are accepted.
+
+The production managed-data S3 `Put` path creates two content-addressed blobs.
+Raw provider writes then replace one blob's key with different bytes and corrupt
+bytes; these writes simulate damage, not supported managed-data updates. A
+delete marker makes latest unavailable. Another prefix retains two sentinel
+versions. These are blob revisions, not PostgreSQL managed-revision records.
+
+### Commands and observation records
+
+Run from the repository root with the repository Go toolchain and Docker access:
+
+```bash
+go test -tags=fai520qualification ./internal/manageddata/storage/s3 -run '^TestFAI520' -count=2 -v
+# Use -json instead of -v to retain machine-readable test output.
+go test -tags=fai520qualification ./internal/manageddata/... ./internal/platform/objectstore/... ./internal/app/objectstore/... ./internal/recoveryset/... -count=2
+go test ./internal/app -run PostgreSQLRecoveryAdmission -count=1
+go test ./internal/app/adminpostgres/... ./internal/platform/architecture/... -count=1
+task generated:check
+task docs:check
+git diff --check
+```
+
+Baseline test logs capture endpoint, region, bucket, exact key, version ID,
+size, SHA-256 of fetched bytes, and observation time. Retrieval logs capture
+selection, expected content size/digest, observed digest, start/end timestamps,
+and allowlisted results. SDK error strings and credentials are not recorded.
+The expected size is labeled as such; it is not a measured recovery duration or
+RPO/RTO. These are test observations, not a new recovery-admission envelope.
+
+### Recorded validation
+
+Local validation on 2026-09-08 used Linux/amd64, Go 1.26.8, Docker, and the
+pinned provider above, based on main `3b201d71646ac4ec89feebfcdbb8901b4d958010`.
+The provider matrix passed ten consecutive runs after waiting for provider
+readiness (liveness alone can precede S3 initialization). The combined
+managed-data/objectstore/recovery-set suites passed twice. Startup/admin
+recovery and architecture tests, generated-state checks, and docs checks passed.
+
+One recorded retrieval at `2026-09-08T05:45:56.35791612Z` returned historical
+version `1f15342c-cc54-48e7-b191-b9b88966b55f`, 19 bytes, SHA-256
+`26d870502c4a8863b3cf3bcbfe99723b6996597ee9443d09c456a37b18538c0c`,
+matching the original managed blob. Wrong-version and corrupt-byte reads
+returned different digests and were rejected; credential repair yielded that
+same original digest twice. This ephemeral example is not a reusable recovery
+point; its disposable container was removed.
+
+### Positive evidence
+
+- Exact-version GET returns historical A after replacement and current deletion.
+- Returned version identity must match the request. Bounded response hashing
+  must match the original managed content SHA-256 and size; ETag and metadata
+  are not content proof.
+- Two retries after credential repair reproduce the same successful digest.
+- The unrelated managed blob remains readable through the production `Open`
+  path; both sentinel versions remain byte-identical.
+- Complete provider version/delete-marker inventories before and after the
+  retrieval matrix must match, proving reads and retries have no write effects.
+
+### Negative evidence
+
+| Case | Required outcome |
+|---|---|
+| Missing historical version | Provider `NoSuchVersion`; no latest fallback |
+| Empty or null version selection | `missing_version` before retrieval |
+| Wrong retained version | `integrity_mismatch` against original content |
+| Same-size corrupted bytes | `integrity_mismatch` |
+| Invalid secret | Real provider `SignatureDoesNotMatch`; no success |
+| Substituted endpoint, region, bucket, or prefix | `namespace_mismatch` before fetching |
+
+Namespace matching belongs only to this test's selected observation boundary.
+It does not add a production recovery validator. Negative observations are not
+successful evidence and cannot be used to claim recovered content.
+
+### Limitations and next dependency
+
+This proves historical object availability, integrity, and isolation for the
+selected provider. It does not prove coordinated disaster recovery, PostgreSQL
+restore, PITR, key recovery, historical replica reconstruction, replacement
+endpoint recovery, multipart recovery, governed queries, or operational RTO/RPO.
+Random per-run identities in test output must not be reused as production
+recovery evidence. Production IAM/KMS policy and provider lifecycle behavior
+require separate qualification.
+
+The next bounded slice should bind an existing recovery frontier's complete
+managed-object closure to provider-native retained versions and qualify missing
+members without mutating admission contracts. Physical restore orchestration
+must wait for that closure and a reviewed PostgreSQL/provider consistency plan.
+
+## FAI-520 managed-revision closure qualification
+
+### Design and dependency discovery
+
+`TestFAI520HistoricalManagedRevisionClosure` extends the opt-in
+`fai520qualification` suite. A disposable PostgreSQL database is initialized
+with the existing managed-data schema; fixture writes and reads use the normal
+runtime role and repository. Production S3 `Put` writes three content-addressed
+blobs before `CreateUploadSession` and `CompleteUpload` persist a revision.
+The fixture's `metadata.json` is an ordinary explicitly declared file, not an
+invented product metadata object. The canonical revision manifest remains in
+PostgreSQL.
+
+Given only the operational revision ID, discovery uses `RevisionByID` and
+`ListRevisionFiles`. The test compares the persisted canonical manifest digest
+with the listed dependencies using the existing `Manifest.RevisionID` contract.
+It traverses the complete manifest in logical-path order, not provider listing
+order or the number of observations supplied by a caller. Every member must
+pass exact-version retrieval, response-version checking, size, and fetched-byte
+SHA-256 validation before the closure result can be `verified`.
+
+### Provider version mapping boundary
+
+Neither `RevisionFile` nor `BlobStore` records a provider version ID or exposes
+a historical restore API. The fixture therefore captures versions from real
+provider HEAD responses immediately after production writes, before damage.
+It supplies that separate observation inventory to the test-only traversal.
+There is no production restore API, new recovery envelope, admission validator,
+or provider scan that guesses historical versions from ETags or latest objects.
+
+This proves closure availability only when the revision metadata and exact
+provider-version observations have survived. A durable, reviewed binding of
+that inventory to the selected recovery frontier remains a prerequisite for
+physical recovery. The test does not claim the product discovers lost provider
+version mappings automatically.
+
+### Positive and negative evidence
+
+The fixture replaces every dependency with different bytes and adds current
+delete markers, retaining the selected historical versions. It also writes
+unrelated objects. Test output records the revision ID, manifest digest,
+dependency paths/hashes/sizes, requested version IDs, traversal order, observed
+hashes, timestamps, terminal result, and verified-member count. Failures use
+bounded reason codes, not credential-bearing provider errors.
+
+| Scenario | Required result |
+|---|---|
+| Complete three-member historical closure | All three digests match |
+| Missing first dependency observation | `missing_dependency`, zero verified members |
+| Missing last dependency observation | `missing_dependency`, two members; never complete |
+| Missing historical version of second member | `NoSuchVersion`, no latest fallback |
+| Wrong retained version of second member | `integrity_mismatch` |
+| Extra unrelated observation | Ignored; same complete closure |
+| Invalid credentials on second member | `SignatureDoesNotMatch`, one member; never complete |
+| Two retries after credential repair | Same ordered complete digest list |
+
+Unrelated sentinel bytes and the complete provider version/delete-marker
+inventory must remain unchanged. Retrieval has no writes or activation side
+effects. Partial verified-member lists are diagnostics, not successful closure
+evidence. PostgreSQL and provider startup failures fail this opt-in test rather
+than skipping it.
+
+### Commands and remaining qualification
+
+The initial closure matrix passed five repeated runs and the broader suites.
+A subsequent evidence run failed during seeding with HTTP 507 while the shared
+host filesystem was nearly full. The fixture now isolates MinIO data in tmpfs;
+storage exhaustion is not bypassed or treated as successful retrieval.
+
+```bash
+go test -tags=fai520qualification ./internal/manageddata/storage/s3 -run '^TestFAI520' -count=5
+go test -tags=fai520qualification ./internal/manageddata/... ./internal/platform/objectstore/... ./internal/app/objectstore/... ./internal/recoveryset/... -count=1
+go test ./internal/platform/architecture/... -count=1
+task generated:check
+task docs:check
+git diff --check
+```
+
+Use `-json` to retain the per-member and terminal test observations. A metadata
+database is seeded, not restored. No PostgreSQL recovery, PITR, key recovery,
+coordinated restore, activation, production-provider IAM/KMS behavior, or RPO/RTO
+is qualified here. Closure means the declared managed revision's files, not
+DuckLake/catalog or serving-artifact dependencies.
+
+This validates historical managed-object retrieval. It does not prove successful physical disaster recovery.
+
+## Provider-version observation binding qualification
+
+### Model and evidence flow
+
+There are two distinct evidence boundaries today. They must not be confused:
+
+1. A managed revision owns its canonical dependency manifest (logical paths,
+   SHA-256 values, and sizes). Persisted revision files identify storage keys.
+   The S3 provider owns historical version IDs. The qualification captures
+   those IDs from provider responses after real managed-data writes, and
+   verifies the selected version's returned identity, size, and fetched bytes.
+2. A recovery set owns a digest-bound frontier and immutable validation results.
+   Its v1 contract admits exactly one DuckLake root and one serving-artifact
+   root. Each root binds a URI, version ID, digest, and provider recovery
+   frontier. It does **not** admit a managed-revision observation inventory.
+
+Thus the requested flow currently stops at a contract boundary:
+
+```text
+managed revision → manifest → object key → captured provider version → verified bytes
+                                         │
+                                         └─ no typed managed-observation binding in recovery-set v1
+
+existing DuckLake/artifact roots → frontier digest → attempt-bound validation evidence
+```
+
+The capture is not a transactionally atomic provider inventory. Managed-data
+`BlobStore` writes do not return a durable version mapping, and a later HEAD
+can race an external overwrite. Exact historical-byte verification detects a
+wrong selection, but cannot reconstruct an observation that was never saved.
+ETags, current/latest objects, or a revision digest are not substitutes for a
+provider-issued version ID.
+
+### Qualification boundaries and rejection cases
+
+The opt-in suite exercises captured-observation replay and the existing
+recovery-set evidence boundary separately. A serialized test observation
+artifact is not a new product recovery contract or an authoritative ledger.
+No managed data is relabeled as a DuckLake or serving-artifact root, and no
+inventory is hidden inside the opaque `provider_recovery_frontier` string.
+
+`TestFAI520ManagedProviderBindingObservationReplay` writes three real managed
+objects to disposable versioned MinIO, persists and rereads a test observation
+artifact, rebuilds selections from that artifact, and repeats closure validation
+after overwriting a current object. The historical selection still produces the
+same ordered content digests. The full three-test provider suite passed five
+runs per test.
+
+`TestProviderObservationDurabilityAndExactReplay` exercises the existing
+PostgreSQL recovery repository with **synthetic DuckLake/artifact root
+identities**, not the managed objects from the provider fixture. A separate
+read-only process consumes the persisted frontier and validation result and
+compares canonical bytes and digests. The set remains prepared. Its companion
+tests exercise conflicts and strict rejection of unsupported managed evidence.
+These tests intentionally do not claim a cross-system managed-inventory binding.
+
+| Case | Current boundary |
+|---|---|
+| Complete retained three-object closure | Captured versions can reproduce the manifest's exact hashes and sizes |
+| Missing provider-version observation | Existing closure qualification rejects an incomplete selection |
+| Version points to wrong bytes | Historical byte/size verification rejects it |
+| Provider endpoint/bucket/key differs | Qualification rejects the namespace mismatch before trusting bytes |
+| Typed validation-result digest differs from its evidence | Existing recovery-set validation rejects it |
+| Missing, conflicting, or stale root/frontier identity | Existing typed frontier validation rejects the mismatch |
+| Managed inventory digest, duplicate observations, or capture time outside a frontier | No typed managed-observation contract exists; these are **not qualified product rejections** |
+
+Root/frontier rejection is narrower than managed-observation rejection. A valid
+root envelope is not proof that every managed dependency was observed or that
+the observations belong to a coherent PostgreSQL/provider recovery point.
+
+### Durability and replay
+
+Existing recovery-set repositories persist exact frontier identities and
+attempt-bound canonical evidence. Identical replay is idempotent; conflicting
+replacement of the same durable identity is rejected. Another validation
+attempt can consume the same frontier, but its evidence digest changes because
+the attempt ID is part of the envelope. Only replay of the **same** attempt is
+expected to have an identical result digest.
+
+These protections do not automatically persist the separate captured managed
+provider-version inventory. The MinIO fixture only writes and rereads its
+observation file in the same process: it does not prove restart durability,
+atomic publication, or immutability of that file. The separate-process test
+applies only to existing PostgreSQL root evidence, not those managed observations.
+Provider retention and access must independently keep every referenced
+historical version available.
+
+| State | Current storage | Durability/immutability qualified |
+|---|---|---|
+| Managed revision and declared dependencies | PostgreSQL managed-data repository | Existing persisted identity; no provider version map |
+| Captured managed provider observations | Test memory and a disposable `provider-observations.json` file | File round-trip only; mutable and removed at test cleanup |
+| Recovery frontier and typed root identities | PostgreSQL recovery-set repository | Fresh-process read and same-ID conflict rejection |
+| Attempt-bound root validation result | PostgreSQL `recovery.validation_result` | Identical replay; conflicting updates rejected |
+
+The end-to-end requested binding remains blocked. A managed observation can
+survive only if its separate artifact survives, and the current product contract
+cannot decide whether that artifact is authoritative for a selected frontier.
+In particular, managed duplicate/conflict rejection and capture-frontier
+staleness are not supplied by a generic JSON file round-trip.
+
+### Contract gap and smallest future extension
+
+A reviewed future version of the existing recovery evidence contract should
+bind an immutable managed-observation manifest by digest. That manifest needs
+the managed revision/manifest identity and complete per-member logical path,
+provider identity (including endpoint/region and bucket/key), historical version
+ID, SHA-256, and size. Its capture boundary must be tied explicitly to the
+selected recovery frontier, not inferred from local timestamps or latest
+provider state. Conflicting duplicates must be rejected before canonicalization;
+the same durable identity must never be overwritten by a conflicting capture.
+
+The frontier must commit to that manifest digest, and validation must require
+complete membership and exact provider bytes before accepting the evidence.
+Retention, provenance, and credential-free provider identity semantics need
+review with that extension. This slice adds none of these production fields,
+does not change migrations, and does not create an alternate admission path.
+
+The next phase should specify and approve this minimal binding contract, then
+qualify durable capture, restart/replay, conflicts, and frontier staleness against
+it. PostgreSQL restore, PITR, coordinated recovery, activation, governed-query
+recovery, and measured RPO/RTO remain later UBDR work.
+
+This validates recovery evidence binding. It does not prove successful physical disaster recovery.
+
+## Proposed managed observation manifest contract
+
+The following proposal and implementation-planning sections are retained as
+design history, not the current implementation specification. The implemented
+evidence-only contract, resolved capture/retention decisions, and remaining
+limitations are documented in [Recovery evidence manifests](/docs/guides/data/recovery-evidence-manifest).
+Future SQL admission, restore, and activation phases below remain unimplemented.
+
+**Referenced-manifest design approved for implementation planning; not implemented
+or approved for production.**
+This section proposes the smallest versioned extension for FAI-520. It does not
+authorize migrations, restore orchestration, PostgreSQL recovery, PITR, key
+recovery, or activation changes.
+
+### Problem and current ownership
+
+The current owner is `internal/recoveryset`: `RecoverySet` and
+`ValidationEvidenceEnvelope` are both v1. `validateCanonicalObjectRoots` requires
+exactly the DuckLake and serving-artifact roots matching the serving seal.
+`ParseValidationEvidenceEnvelope` rejects unknown fields. PostgreSQL's
+`recovery.guard_validation_result_insert` reconstructs that exact v1 envelope;
+adding Go fields alone would either fail insertion or undermine the SQL guard.
+
+Managed-data owns `RevisionByID`, `ListRevisionFiles`, and the canonical
+`Manifest.RevisionID` content digest. An operational revision ID is distinct
+from its content digest. `RevisionFile` carries a storage key but no provider
+version ID. `BlobStore` offers content-addressed Put/Stat/Open, not historical
+retrieval. Existing `RecoverySet.Digest` excludes mutable publication metadata;
+`IdentityEqual` additionally protects exact creation identity. Attempt IDs are
+part of validation-result digests, so different attempts must not share a result
+digest merely because they validate the same frontier.
+
+### Alternatives
+
+| Option | Benefits | Costs / decision |
+|---|---|---|
+| A: additional recovery roots | Reuses root persistence | Root tuples lack revision membership, per-object sizes, and capture semantics; overloads seal-root meaning and changes the exactly-two invariant. Reject. |
+| B: immutable manifest referenced by frontier | One content identity covers complete membership; reusable across attempts; bounded envelope | Requires owned durable manifest storage and versioned reference validation. Recommend. |
+| C: embed all observations in each evidence envelope | One submitted document | Repeats potentially large inventory per attempt, pressures strict envelope limits, and leaves the prepared frontier ambiguous unless it also commits to the inventory. Reject in favor of a reference. |
+
+Do not encode inventory JSON inside `provider_recovery_frontier`, use an ETag as
+a digest, or label managed data as DuckLake/artifact content. B is an extension
+of the existing recovery owner, not a second recovery model or validator.
+
+### Proposed contract and scope
+
+Propose RecoverySet **v2**, ValidationEvidenceEnvelope **v2**, and a separately
+versioned ManagedObservationManifest **v1**. Names below describe proposed
+fields, not existing CLI inputs or public JSON fields.
+
+Each v2 set requires one `managed_observation_manifest_digest`. The envelope
+carries that same digest and the final frontier digest; it does not repeat the
+inventory. The manifest contains all managed revisions required by the selected
+target/generation, not just whichever revision an operator chooses to submit.
+The bounded first implementation supports one selected target, not a fleet.
+
+| Manifest component | Required contents |
+|---|---|
+| Format | Manifest version; strict known fields; canonical encoding |
+| Capture | UTC capture start/completion timestamps; immutable capture-evidence reference/digest; producing authority identity without credentials |
+| Frontier anchor | Recovery-set UUID and source-frontier anchor digest, covering exact selected database recovery identities, delivery, seal, catalog, roots, and compatibility |
+| Revision membership | Project/collection identity, operational revision ID, canonical revision manifest digest, and canonical declared dependency files |
+| Managed closure identity | Domain-separated digest of the complete sorted revision membership and dependency list, including logical path, expected SHA-256 and size; separate from the serving seal's existing ClosureDigest |
+| Provider observations | Exactly one record per required revision/path: provider implementation, non-secret account/tenant identity where applicable, canonical endpoint, region, bucket/container, namespace prefix, exact object key, opaque non-null version ID, content SHA-256 and nonnegative size |
+
+The same content may appear at multiple logical paths or revisions. Keep those
+membership edges; physical reads may be deduplicated only when provider/key/
+version/digest/size are identical. Reject conflicting versions for the same
+provider object identity within this single frontier. No maps that silently
+overwrite duplicate entries during parsing.
+
+Required revision membership must be derived by the managed-data owner from
+the selected immutable serving-generation bindings and its declared retention
+scope in the selected control recovery point. Never use current environment
+pointers or the submitted inventory itself as the completeness authority.
+Resolving and verifying this exact binding-set selection is a prerequisite,
+not a capability claimed by the current qualification fixtures. Extra raw
+provider objects are ignored; extra entries in the authoritative manifest are
+rejected. An empty manifest is valid only when that independent selection proves
+there are no required managed dependencies; missing is not equivalent to empty.
+
+### Non-circular immutable identity
+
+Use one explicitly versioned canonical projection owned by recoveryset:
+
+```text
+selected immutable frontier fields + set UUID
+                  |
+                  v
+            source anchor A
+                  |
+                  v
+capture evidence + revisions + observations --> manifest digest M
+                                                   |
+immutable frontier fields + M ----------------------+
+                  |
+                  v
+        final v2 frontier digest F
+                  |
+                  v
+        attempt-bound envelope (F, M)
+```
+
+A is a domain-separated hash of the v2 immutable frontier projection excluding
+only the managed-manifest reference and the final digest, with lifecycle/fence/
+audit/creation metadata excluded as in the current frontier identity. Freeze
+the exact projection and canonical bytes in golden fixtures. Do not obtain A by
+calling a legacy decoder or silently downgrading a v2 set to v1.
+
+The manifest stores A and the set UUID, **not F**. Its own digest M is external
+to the hashed manifest bytes. F commits to the manifest reference as well as the
+immutable frontier projection. The validator recomputes A, M, and F. This binds
+the manifest bidirectionally without asking it to contain the hash of itself.
+Any referenced capture receipt likewise binds A, not M or F; it must not create
+a second indirect hash cycle back to the containing manifest.
+A is an internal commitment, not a second publishable recovery frontier. The
+v1 digest algorithm and canonical bytes remain unchanged.
+
+Canonicalization must reject duplicate JSON keys, unknown fields, invalid
+digests and integer overflow before hashing; sort revisions by full identity
+and observations by revision/path. Preserve opaque object keys and version IDs
+exactly: never collapse path segments or decode them into aliases. Define one
+credential-free endpoint normalization rule; reject userinfo, queries, fragments,
+and ambiguous encodings. Namespace matching must respect a prefix boundary,
+not a raw string prefix. Initial qualification limits proposed for review:
+8 MiB canonical manifest and 10,000 logical members, with bounded parse/read
+allocation. Oversize fails explicitly; no truncation, opaque pagination, or
+chunking schema is introduced in this first extension.
+
+### Validation invariants
+
+1. **Completeness:** independently selected revision membership and canonical
+   dependency identities match exactly. Missing/duplicate/extra observations,
+   missing revision metadata, and scope changes fail closed.
+2. **Integrity:** exact-version provider GET returns the requested version;
+   hash all returned bytes with a size bound and compare SHA-256 and size to the
+   managed owner manifest, not only the submitted observation. Reject truncated,
+   oversized, or changed content. ETag and HEAD metadata are not byte proof.
+3. **Identity:** A and set UUID match the selected frontier, M matches immutable
+   bytes, and F matches the set. Provider/namespace/key must match the trusted
+   storage configuration for those selected bindings. No latest-version,
+   endpoint-substitution, or credential fallback.
+4. **Capture:** timestamps are canonical, ordered, and bounded by a trusted
+   verification clock, but timestamps alone do not establish a consistent
+   recovery point. The capture evidence must identify the exact source control
+   snapshot/recovery identity, binding scope, and retained provider observations.
+   A capture for another anchor or recovery identity is stale even if recent.
+   A later verification of an unchanged historical version is not a new capture.
+   No arbitrary maximum-age cutoff should invalidate a retained older recovery
+   point. Provider-specific proof of that capture boundary must be reviewed
+   before a physical-recovery claim; an opaque timestamp/token is insufficient.
+5. **Immutability:** reject replacement from first durable insertion, not merely
+   after publication. Same set UUID with different M conflicts. Same M with
+   different bytes is an integrity failure. Correction requires a new set and
+   manifest identity, never editing a prepared/published record.
+6. **Authority:** a content hash proves commitment, not honest capture or byte
+   verification. The existing authorized recovery validation path must consume
+   owner-validated probe results; copying a manifest digest into an envelope
+   cannot manufacture a passed attempt. SQL guards protect structure/identity,
+   not remote provider truth. Capture authority and offline evidence trust must
+   be specified explicitly before implementing provider verification.
+
+### Persistence, restart, and publication
+
+Recommend canonical manifest bytes in a bounded, append-only child store under
+the existing PostgreSQL recovery repository, keyed by M and bound uniquely to a
+set UUID. This avoids introducing a new evidence bucket/availability dependency.
+Store exact canonical bytes, not only JSONB (which loses original byte encoding),
+and verify digest/header consistency. It is evidence storage, not a provider
+restore API. An off-host export is still needed for total database loss; evidence
+stored in the database being recovered is not itself a disaster-recovery backup.
+
+Capture/validate inputs before creating the prepared set. Insert v2 set and
+manifest atomically in one short transaction with deferred referential checks
+or equivalent transactional completeness guards; no remote I/O inside it.
+Never expose a usable prepared set whose manifest is absent. Same-identity
+inserts compare immutable bytes; never use overwrite-on-conflict. Failure or
+crash before commit leaves no usable set; after commit a new process reloads by
+exact set UUID/M and verifies canonical identities without recapturing latest.
+
+An attempt performs completeness and byte checks, persists the small v2 result,
+and completes through the existing lifecycle. Publication still selects one
+exact passed attempt under its existing fence; no new publication state or
+activation pathway. It must require the stored manifest reference to match the
+passed envelope. A repeat of the same attempt returns identical evidence/digest;
+a different attempt has a different result digest but the same F and M. Local
+readiness consumes the selected validated identity; it must not start provider
+GETs. Retention must preserve manifest bytes and required historical objects
+for the set's retention/hold lifetime; collection must not delete referenced
+evidence. Retention policy changes do not rewrite immutable capture bytes.
+
+### Compatibility and migration impact
+
+- Preserve v1 decoding, hashing, exact retries, and historical FAI-521 fixtures.
+  A missing managed manifest means **unqualified**, not an empty managed closure.
+  Do not backfill old sets with fabricated observations or mutate their hashes.
+- New v2 requests always require an explicit manifest, including an independently
+  proven empty one. A workflow requiring managed recovery must reject v1 rather
+  than retrying with weaker semantics. Existing v1 records remain readable and
+  usable only under their original root-admission guarantee, never upgraded
+  implicitly to managed-recovery evidence.
+- Readers must explicitly dispatch supported set/envelope versions. Unknown
+  versions and mismatched set/envelope versions fail closed. Roll out compatible
+  readers and SQL guards before enabling v2 writers. An old binary cannot be
+  assumed to operate on a selected v2 set; binary downgrade needs an independent
+  compatibility decision, not evidence deletion or a v1 rewrite.
+- Future changes would add manifest storage/reference constraints, extend the
+  current `schema_version = 1` check to supported versions, update immutable
+  identity guards, and version SQL envelope reconstruction/digest checks.
+  Keep the two existing root semantics. Update recovery-owned DDL, the canonical
+  Goose migration path, generated queries, parsers, and conformance tests
+  together; changing only `CREATE TABLE IF NOT EXISTS` does not upgrade an
+  existing installation. No migration is created by this design task.
+- Maintain existing least-privilege recovery maintenance access. No application
+  role gains update/delete authority over evidence. SQL inserts must not bypass
+  version, completeness, digest, or immutable-reference checks. Raw provider
+  error text, signed URLs, credentials, and key material are excluded; hashes
+  and capture receipts do not replace key availability qualification.
+
+### Implementation phases and qualification plan
+
+1. **Approve the contract:** freeze A/M/F canonical projections, exact managed
+   binding/retention scope, bounded format, capture authority/proof, and the v1
+   compatibility matrix. These decisions gate coding; no version number alone
+   proves capture consistency.
+2. **Owner contract tests:** complete/empty manifests, order-independent
+   canonical digest, scope completeness, duplicate JSON/object rejection,
+   digest/size tampering, wrong provider/namespace, stale anchor, future/reversed
+   timestamps, limits/overflow, and preservation of all v1 golden digests.
+3. **Durable repository:** fresh install and upgrade fixtures, atomic creation,
+   crash before/after commit, separate-process read/revalidation, identical retry,
+   concurrent conflicting inserts, direct-SQL bypass rejection, immutable bytes,
+   retention holds, and no replacement of selected successful evidence.
+4. **Real provider qualification:** capture production writes in disposable
+   versioned MinIO, persist M with an exact frontier, terminate the capturing
+   process, then independently discover/retrieve all dependencies. Exercise
+   missing observation/version, same-length wrong bytes, conflicting versions,
+   substituted provider, partial results, credential repair, and changed source
+   recovery identity. Check no partial attempt becomes publishable. Do not
+   claim a provider can mutate an immutable version in place: simulate changed
+   returned bytes in a separate fault-injection test and require rejection.
+5. **Existing admission integration:** exact-attempt publication and local
+   readiness binding remain intact; two attempts use the same immutable manifest
+   without sharing attempt digests. Re-run FAI-521 completeness tests and mixed
+   v1/v2 compatibility matrices before any production writer enablement.
+
+Only after those phases should UBDR address coordinated PostgreSQL/catalog/
+object recovery, migration interruption, release rollback compatibility,
+off-host rebuild, and RPO/RTO measurement. This proposal does not resume FAI-518
+or implement PostgreSQL restore/PITR.
+
+## Managed observation implementation specification
+
+This specification refines the approved referenced-manifest architecture.
+Only documentation is changed. The detailed defaults below require the listed
+sign-offs before contract/golden fixtures are frozen; approval of the architecture
+does not imply that provider capture authority or physical consistency is solved.
+
+### Storage decision
+
+| Storage option | Assessment |
+|---|---|
+| PostgreSQL canonical bytes plus digest | Recommended first implementation: atomically committed with the frontier, existing access/backup boundaries, deterministic restart reads |
+| Immutable provider object | Adds bootstrap credentials, retention, retrieval and failure dependencies just to read admission evidence; defer |
+| Separate content-addressed store | Content addressing supplies identity, not durability or authority; another store is unnecessary |
+| PostgreSQL index plus external bytes | Useful for large future inventories, but creates a distributed commit and orphan-reclamation problem; defer |
+
+Use content addressing **inside PostgreSQL**, not a new storage service. Limit
+canonical bytes to 8 MiB and logical file memberships to 10,000 per set for the
+initial contract. Exceeding either rejects creation before persistence; no
+silent truncation or fallback to v1. These are proposed qualification limits,
+not measured production capacity. One set owns one manifest; because the set ID
+is in the manifest, sharing is across attempts, not different recovery sets.
+
+### Exact canonical shape and hashing plan
+
+The proposed fixed field order is:
+
+- Manifest: `manifest_version`, `set_id`, `source_frontier_anchor_digest`,
+  `capture`, `managed_closure_digest`, `revisions`.
+- Capture: `authority_id`, `capture_id`, `started_at`, `completed_at`,
+  `receipt_digest`. The immutable receipt binds the source control recovery
+  identity, selected scope and provider capture boundary to A; it cannot refer
+  back to M or F. Receipt verification is a gated dependency, not an arbitrary
+  self-declared success token.
+- Revision: `project_id`, `collection_id`, `revision_id`,
+  `revision_manifest_digest`, `files`.
+- File: `path`, `sha256`, `size`, `provider`.
+- Provider: `implementation`, `account_identity`, `endpoint`, `region`,
+  `bucket`, `prefix`, `key`, `version_id`.
+
+Each file is a membership edge with its expected content and exact observation;
+there is no second independently editable copy of the file inventory. Rebuild
+the managed-data `Manifest` projection from path/SHA-256/size and use its owner
+digest function, comparing with the independently loaded selected revision.
+Shared content keeps all membership edges. The managed-closure projection is
+the sorted revision array with only the provider fields removed, including
+revision identity and owner manifest digest.
+
+Define C as bounded canonical UTF-8 JSON, fixed field order above, no whitespace
+or trailing newline, decimal integers without exponent, no floats, and explicit
+arrays (`[]`, never null). UTC timestamps have exactly six fractional digits
+and `Z`; reject sub-microsecond inputs rather than silently rounding identity.
+Use the current owner encoder's string escaping convention (Go JSON marshal
+escaping, including HTML characters) and golden-test the SQL implementation
+against it. Reject invalid UTF-8, duplicate keys at every nesting level, unknown
+fields, case aliases, repeated revision identities and repeated paths **before**
+normalization. No Unicode normalization of object keys or version IDs.
+
+Sort revisions lexicographically by UTF-8 bytes of
+`(project_id, collection_id, revision_id)` and files by logical path bytes.
+SQL must use equivalent byte ordering, not database locale ordering. Endpoint
+rules lower-case scheme/host and remove only a default port; reject userinfo,
+query, fragment and endpoint path prefixes in the first contract. Preserve
+opaque keys/version IDs; compare namespace prefixes on a delimiter boundary.
+An account identity may be an explicit empty string only for an approved
+provider profile where endpoint/namespace uniquely defines it; never infer
+missing identity from credentials. HTTPS is required outside explicitly
+disposable local qualification. Freeze provider-profile rules with fixtures.
+
+Use lowercase hex SHA-256 with `sha256:` for contract digests; managed file
+digests retain the managed-data owner's existing unprefixed representation.
+Proposed domain strings below include a final newline byte:
+
+1. A = SHA256(`leapview/recovery-source-anchor/v2\n` || C(anchor)). Anchor keys
+   are exactly `schema_version` (2), `set_id`, `cluster_points`, `delivery`,
+   `serving`, `catalog`, `object_roots`, `compatibility`, preserving their existing
+   typed subfields and canonical array rules. Exclude lifecycle, fence, audit,
+   creation metadata and managed reference entirely; no recursive call to v1.
+2. Closure = SHA256(`leapview/managed-closure/v1\n` || C(closure projection)).
+3. M = SHA256(`leapview/managed-observations/v1\n` || C(manifest)). The manifest
+   contains A and Closure, not M or F.
+4. F = SHA256(`leapview/recovery-frontier/v2\n` || C(anchor fields plus
+   `managed_observation_manifest_digest` as the final field)).
+
+The v2 envelope has existing envelope fields plus that manifest reference;
+its attempt-bound digest uses a separately frozen v2 envelope domain. Preserve
+the v1 envelope algorithm exactly. A receipt digest commits to immutable receipt
+bytes whose authority/proof format must be approved; hashing does not establish
+honesty. An empty `revisions` array has defined C/Closure/M but is accepted only
+after the managed-data owner proves the selected generation requires no files.
+
+### Future SQL model (description, not DDL)
+
+| Relation | Keys / indexes | Constraints and purpose |
+|---|---|---|
+| `recovery.managed_observation_manifest` (new) | PK `manifest_digest`; UNIQUE `set_id`; UNIQUE `(set_id, manifest_digest)` for a matching composite reference | `manifest_version = 1`, set UUID, A, Closure, canonical bytes, byte length, revision/member counts, repository `recorded_at`; strict size/digest/header/count checks; insert-only |
+| `recovery.recovery_set` (extend) | Existing set PK; composite deferred FK `(set_id, managed_observation_manifest_digest)` to manifest | v1 reference must be NULL; v2 reference required; supported version check; immutable F includes M |
+| Manifest ownership FK | Manifest `set_id` references set PK, deferred to transaction commit | Enforces one coherent aggregate; prevents a manifest belonging to a different set |
+| `recovery.validation_result` (existing) | Existing attempt PK | Version-aware strict envelope guard compares exact set/F/M; no large inventory duplicated per attempt |
+
+Do **not** add a separate manifest-entry table initially. The bounded canonical
+bytes are the authority; parsed entries are ephemeral validator input, not a
+second mutable representation. Header/count columns are checked projections of
+those bytes. If entry indexing is later justified, its rows must be atomically
+derived and immutable, not an alternate source of truth. No provider-key,
+timestamp, or JSON GIN index is needed for the exact-ID read path. Do not index
+capture completion as an automatic deletion deadline.
+
+The database insertion guard must validate supported shape, canonical encoding,
+digest, header projections, duplicate rejection and the A/set association for
+direct SQL as well as repository inserts. Parsing raw JSON as JSONB first would
+lose duplicate keys; preserve raw bytes and validate before that conversion.
+Implement a schema-specific, versioned guard with Go/SQL golden conformance,
+not a generic JSON ingestion channel. SQL cannot verify remote object bytes.
+Reuse the existing owner validator and authorized evidence-submission boundary
+for that check; its trust/receipt policy is an explicit prerequisite.
+
+### Lifecycle and ownership
+
+1. **Select/capture:** the authorized maintenance qualification runner selects
+   an exact source frontier and independently resolved managed binding scope.
+   Managed-data owns revision discovery; the provider adapter owns version
+   observations and exact GET; recoveryset owns format/identity validation.
+   Inputs include the source control recovery identity, immutable generation
+   bindings, expected manifests, trusted provider configuration, read-only
+   credentials resolved outside evidence, and capture authority/receipt.
+   HEAD after Put can race external mutation: capture the returned provider
+   version where available, otherwise verify exact-version bytes and receipt
+   provenance. Never declare capture authoritative from HEAD alone.
+2. **Construct:** establish A, verify full membership and versions, produce the
+   receipt and canonical manifest, compute M/F. Capture is authoritative only
+   after approved receipt/point validation and complete byte verification.
+   No public prepared set exists while inputs are incomplete. Retry a saved
+   capture rather than changing capture timestamps; a recapture creates a new
+   set identity.
+3. **Persist:** one short transaction inserts the prepared set and immutable
+   manifest, verifies the deferred pair and commits. No network calls in this
+   transaction. Crash before commit rolls back both; crash after commit allows
+   exact reload. `ON CONFLICT` may compare existing bytes/identity, never update
+   them. Repository insertion time is not part of M. Concurrent creators with
+   different bytes for the same set deterministically conflict.
+4. **Validate/replay:** each new attempt loads exact set/M, validates canonical
+   bytes and receipt, independently checks membership and retrieves selected
+   provider versions. Complete success alone can produce passed evidence.
+   Exact retry of a terminal attempt returns its immutable recorded outcome;
+   it is not a new availability check. Rechecking live availability requires a
+   new attempt, same F/M and different attempt-bound result digest. Interrupted
+   attempts never turn a partial file list into success.
+5. **Publish:** retain existing exact-passed-attempt and fence checks. M must
+   already be immutable before Prepare becomes visible, not frozen only on
+   Publish. Selection cannot swap manifests. Startup continues reading selected
+   local evidence rather than contacting object providers. No new activation
+   path is designed here.
+6. **Retain:** initially retain manifest bytes for as long as the owning recovery
+   set exists, including prepared, invalid and superseded sets. Existing recovery
+   evidence mutation guards forbid deletion; add no expiry-based collector or
+   DELETE privilege in this extension. Referenced provider versions and capture
+   receipts need independently enforceable retention/holds; a PostgreSQL FK
+   cannot keep an S3 version alive. Future cleanup requires a separately reviewed
+   retirement procedure proving no selected set, live attempt, hold or retained
+   audit reference needs the evidence. Set-specific copies avoid shared-digest
+   deletion ambiguity. Off-host export/import and key availability are separate
+   requirements, not guaranteed by this database storage choice.
+
+### Compatibility and migration prerequisites
+
+Keep old rows, serialized v1 documents, FAI-521 fixtures and hashes untouched.
+V1 remains valid under its existing root-only guarantee; it never gains managed
+coverage. All v2 paths require M, including independently proven empty scope.
+Never catch a v2 missing-evidence error and retry as v1. A reader explicitly
+supports known version pairs; unknown/mixed versions reject before publication.
+
+Future migration order is: reviewed owner types/golden vectors; additive table
+and deferred references; version-dispatched shape/hash/immutability guards;
+repository/generated query updates and compatible readers; migration/conformance
+proof; only then authorization to enable v2 creation. Recovery maintenance gets
+bounded insert/read authority; runtime remains read-only, and no role receives
+manifest update/delete. Keep existing v1 SQL validation branches unchanged.
+Fresh-install schema and the normal Goose upgrade must produce identical
+constraints/grants; `CREATE TABLE IF NOT EXISTS` alone is insufficient.
+
+Test the migration on existing v1 prepared/published records and verify exact
+hash preservation. Schema downgrade must fail safely once v2 data exists;
+do not drop manifest evidence to make an old binary start. Compatible reader
+rollout and selected-frontier behavior need a release compatibility decision
+before enabling writers. This task creates neither DDL nor migration files.
+
+### Qualification phases and gates
+
+| Phase | Tests / evidence | Exit condition |
+|---|---|---|
+| 1: contract/golden | Fixed C/A/Closure/M/F/envelope vectors; shuffled arrays; duplicate keys/paths; shared files; empty scope; limits; wrong provider and stale anchor; v1 regression vectors | Go/SQL byte and hash rules agreed, no ambiguous identity |
+| 2: persistence/restart | Real PostgreSQL; atomic create crash before/after commit; separate process reload; missing bytes/reference; exact terminal retry; canonical-byte corruption | Reload reproduces F/M and outcome without recapture |
+| 3: concurrency/conflicts | Concurrent identical/different captures, same-ID replacement, direct SQL bypass, failed/partial attempts, retention privileges | Exactly one immutable set/manifest identity; no partial success |
+| 4: provider replay | Real versioned MinIO writes, saved receipt/manifest, capture process exit, new attempt reads exact versions; missing/wrong version, bytes/size mismatch, credential repair, provider substitution | Complete closure passes; every mismatch fails with safe diagnostics |
+| 5: admission compatibility | Existing Prepare/Validate/Publish path; passed attempt/F/M binding; v1/v2 matrix; migration upgrades; readiness consumes local selected evidence | Existing FAI-521 guarantees preserved; v2 cannot omit managed evidence |
+
+These are future acceptance tests, not claims that the unimplemented contract
+passes. Existing historical/closure qualification remains reusable; do not build
+another discovery algorithm or admission validator.
+
+### Open decisions requiring approval
+
+- **Capture trust:** select the permitted authority and receipt verification
+  mechanism, how it proves the selected control/provider boundary, and how
+  receipt bytes survive restart. The proposed digest/reference alone cannot
+  answer this; it blocks production acceptance and Phase 4's authority claims.
+- **Scope:** approve the exact generation binding-set and retention-root source
+  used to enumerate all required revisions, including retained non-serving
+  revisions. Without this, completeness cannot be authoritative.
+- **Canonical/profile limits:** approve the concrete field order, domains,
+  timestamp precision, provider endpoint/account rules, 8-MiB/10,000-member
+  limits, and proposed rejection of endpoint path prefixes before freezing goldens.
+- **Retention/rollout:** approve initial no-deletion evidence retention and its
+  capacity impact, provider version/receipt hold obligations, and v1-only reader
+  behavior once v2 frontiers exist. No automatic TTL or binary downgrade promise.
+
+Implementation planning is complete with these explicit gates. Next approve
+them and begin Phase 1 only; PostgreSQL restore, PITR, coordinated recovery,
+off-host rebuild and RPO/RTO remain later work.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -64,6 +64,7 @@ Focused slices are available at `/docs/agent-tools/tools/{name}.json|md`, `/docs
 - [Data revisions and activation](/docs/guides/data/revisions): Understand revision identity and atomic activation.
 - [Materialization and refresh](/docs/guides/data/refresh): Refresh model materializations without disrupting active queries.
 - [Storage and recovery](/docs/guides/data/storage-recovery): Operate local or object-backed analytical storage safely.
+- [Recovery evidence manifests](/docs/guides/data/recovery-evidence-manifest): Understand qualified manifest capture, boundary binding, and immutable evidence retention.
 - [Data troubleshooting](/docs/guides/data/troubleshooting): Diagnose planning, upload, revision, and refresh failures.
 
 ### Deploy and operate

--- a/docs/navigation.yaml
+++ b/docs/navigation.yaml
@@ -208,6 +208,11 @@ sections:
         type: how-to
         summary: Operate local or object-backed analytical storage safely.
         source: articles/data/storage-recovery.md
+      - slug: guides/data/recovery-evidence-manifest
+        title: Recovery evidence manifests
+        type: how-to
+        summary: Understand qualified manifest capture, boundary binding, and immutable evidence retention.
+        source: articles/data/recovery-evidence-manifest.md
       - slug: guides/data/troubleshooting
         title: Data troubleshooting
         type: how-to

--- a/internal/manageddata/observation_capture.go
+++ b/internal/manageddata/observation_capture.go
@@ -1,0 +1,36 @@
+package manageddata
+
+import "context"
+
+// CapturedProjection is the trusted source-side result of a managed-data
+// capture. It contains only facts obtained from the managed-data authority;
+// recovery-set adapters are responsible for canonicalizing these facts into
+// their own observation contract.
+type CapturedProjection struct {
+	DatabaseIdentity string
+	SystemIdentity   string
+	Timeline         uint32
+	LSN              string
+	RestorePointName string
+	Revisions        []CapturedProjectionRevision
+}
+
+type CapturedProjectionRevision struct {
+	RevisionID     string
+	ManifestDigest string
+	Files          []CapturedProjectionFile
+}
+
+type CapturedProjectionFile struct {
+	Path       string
+	SHA256     string
+	StorageKey string
+	Size       int64
+}
+
+// ProjectionCaptureSource is the narrow trusted composition port used by
+// recovery qualification. Implementations must obtain all marker and source
+// facts themselves; callers provide no marker, inventory, or identity data.
+type ProjectionCaptureSource interface {
+	CaptureManagedProjection(context.Context) (CapturedProjection, error)
+}

--- a/internal/manageddata/postgres/observation_capture.go
+++ b/internal/manageddata/postgres/observation_capture.go
@@ -1,0 +1,348 @@
+package postgres
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/flidai/leapview/internal/manageddata"
+	manageddb "github.com/flidai/leapview/internal/manageddata/postgres/internal/db"
+	"github.com/flidai/leapview/pkg/strictjson"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	providerObservationPageSize          int32 = 128
+	providerObservationMaxDuration             = 30 * time.Second
+	providerObservationMaxManifestBytes        = 1 << 20
+	providerObservationRollbackTimeout         = time.Second
+	providerObservationMaxRevisions            = 4096
+	providerObservationMaxRevisionFiles        = 4096
+	providerObservationMaxObjects              = 16384
+	providerObservationMaxInventoryBytes       = 8 << 20
+)
+
+type capturedProjectionFile = manageddata.CapturedProjectionFile
+type capturedProjectionRevision = manageddata.CapturedProjectionRevision
+
+type observationTxBeginner interface {
+	BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error)
+}
+
+var _ manageddata.ProjectionCaptureSource = (*Repository)(nil)
+
+// CaptureManagedProjection obtains one primary PostgreSQL restore marker and
+// the complete set of ready managed-data revisions under one locked snapshot.
+// It performs no object-provider I/O and accepts no caller-provided evidence.
+func (r *Repository) CaptureManagedProjection(ctx context.Context) (manageddata.CapturedProjection, error) {
+	db, err := requireDB(r)
+	if err != nil {
+		return manageddata.CapturedProjection{}, err
+	}
+	return captureManagedProjection(ctx, db)
+}
+
+func captureManagedProjection(ctx context.Context, db DBTX) (manageddata.CapturedProjection, error) {
+	if ctx == nil || db == nil {
+		return manageddata.CapturedProjection{}, fmt.Errorf("%w: database connection is required", ErrInvalid)
+	}
+	captureCtx, cancel := context.WithTimeout(ctx, providerObservationMaxDuration)
+	defer cancel()
+	beginner, ok := db.(observationTxBeginner)
+	if !ok {
+		return manageddata.CapturedProjection{}, fmt.Errorf("%w: provider observation capture requires a PostgreSQL connection or pool with BeginTx", ErrInvalid)
+	}
+	tx, err := beginner.BeginTx(captureCtx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
+	if err != nil {
+		return manageddata.CapturedProjection{}, fmt.Errorf("begin provider observation capture: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), providerObservationRollbackTimeout)
+			defer rollbackCancel()
+			_ = tx.Rollback(rollbackCtx)
+		}
+	}()
+
+	queries := manageddb.New(tx)
+	// LOCK is the first statement in the transaction. Repeatable-read's MVCC
+	// snapshot is established only by the first source read below, after all
+	// authority locks have been acquired.
+	if err := queries.LockProviderObservationTables(captureCtx); err != nil {
+		return manageddata.CapturedProjection{}, fmt.Errorf("lock managed-data observation tables: %w", err)
+	}
+	fsync, err := queries.GetProviderObservationFsync(captureCtx)
+	if err != nil {
+		return manageddata.CapturedProjection{}, fmt.Errorf("read PostgreSQL fsync setting: %w", err)
+	}
+	if err := validateProviderObservationFsync(fsync); err != nil {
+		return manageddata.CapturedProjection{}, err
+	}
+	epochBefore, err := queries.GetProviderObservationEpoch(captureCtx)
+	if err != nil {
+		return manageddata.CapturedProjection{}, fmt.Errorf("read managed-data reachability epoch: %w", err)
+	}
+	if epochBefore.InRecovery {
+		return manageddata.CapturedProjection{}, fmt.Errorf("%w: provider observation requires a writable primary", ErrInvalid)
+	}
+
+	revisions, err := captureProviderObservationInventory(captureCtx, queries)
+	if err != nil {
+		return manageddata.CapturedProjection{}, err
+	}
+	epochAfter, err := queries.GetProviderObservationEpoch(captureCtx)
+	if err != nil {
+		return manageddata.CapturedProjection{}, fmt.Errorf("read managed-data reachability epoch after inventory: %w", err)
+	}
+	if epochAfter.InRecovery {
+		return manageddata.CapturedProjection{}, fmt.Errorf("%w: provider observation primary changed during capture", ErrInvalid)
+	}
+	if epochAfter.Epoch != epochBefore.Epoch {
+		return manageddata.CapturedProjection{}, fmt.Errorf("%w: managed-data reachability epoch changed during capture", ErrInvalid)
+	}
+
+	name, err := providerObservationRestorePointName()
+	if err != nil {
+		return manageddata.CapturedProjection{}, err
+	}
+	point, err := queries.CreateProviderObservationRestorePoint(captureCtx, name)
+	if err != nil {
+		return manageddata.CapturedProjection{}, fmt.Errorf("create PostgreSQL restore point: %w", err)
+	}
+	timeline, err := providerObservationTimeline(point.WalFile)
+	if err != nil {
+		return manageddata.CapturedProjection{}, err
+	}
+	// XLogRestorePoint inserts a WAL record but does not itself flush it on
+	// PostgreSQL 18. Poll this exact marker on the same transaction connection
+	// before releasing the table locks or committing, so a failover cannot make
+	// a different timeline appear durable.
+	if err := waitForProviderObservationWALFlush(captureCtx, tx, point.Lsn, point.SystemIdentity, timeline); err != nil {
+		return manageddata.CapturedProjection{}, err
+	}
+	if err := tx.Commit(captureCtx); err != nil {
+		return manageddata.CapturedProjection{}, fmt.Errorf("commit provider observation capture: %w", err)
+	}
+	committed = true
+	return manageddata.CapturedProjection{
+		DatabaseIdentity: point.DatabaseIdentity,
+		SystemIdentity:   point.SystemIdentity,
+		Timeline:         timeline,
+		LSN:              point.Lsn,
+		RestorePointName: name,
+		Revisions:        revisions,
+	}, nil
+}
+
+func waitForProviderObservationWALFlush(ctx context.Context, db DBTX, markerLSN, systemIdentity string, timeline uint32) error {
+	marker, err := providerObservationLSN(markerLSN)
+	if err != nil {
+		return fmt.Errorf("%w: restore point returned invalid LSN: %v", ErrInvalid, err)
+	}
+	queries := manageddb.New(db)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		flushed, queryErr := queries.GetProviderObservationWALFlushLSN(ctx)
+		if queryErr != nil {
+			return fmt.Errorf("read PostgreSQL WAL flush LSN: %w", queryErr)
+		}
+		if err := validateProviderObservationFsync(flushed.Fsync); err != nil {
+			return err
+		}
+		if flushed.InRecovery || flushed.SystemIdentity != systemIdentity {
+			return fmt.Errorf("%w: PostgreSQL primary identity changed while waiting for WAL flush", ErrInvalid)
+		}
+		flushedTimeline, timelineErr := providerObservationTimeline(flushed.WalFile)
+		if timelineErr != nil {
+			return fmt.Errorf("validate PostgreSQL WAL flush timeline: %w", timelineErr)
+		}
+		if flushedTimeline != timeline {
+			return fmt.Errorf("%w: PostgreSQL WAL timeline changed while waiting for WAL flush", ErrInvalid)
+		}
+		flush, parseErr := providerObservationLSN(flushed.FlushLsn)
+		if parseErr != nil {
+			return fmt.Errorf("%w: PostgreSQL returned invalid WAL flush LSN: %v", ErrInvalid, parseErr)
+		}
+		if flush >= marker {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for PostgreSQL WAL flush through restore point %s: %w", markerLSN, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func validateProviderObservationFsync(value string) error {
+	if !strings.EqualFold(strings.TrimSpace(value), "on") {
+		return fmt.Errorf("%w: PostgreSQL fsync is %q; trusted observation capture requires fsync=on", ErrInvalid, value)
+	}
+	return nil
+}
+
+func providerObservationLSN(value string) (uint64, error) {
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return 0, fmt.Errorf("LSN %q is not two hexadecimal components", value)
+	}
+	high, err := strconv.ParseUint(parts[0], 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("LSN %q high component: %w", value, err)
+	}
+	low, err := strconv.ParseUint(parts[1], 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("LSN %q low component: %w", value, err)
+	}
+	return (high << 32) | low, nil
+}
+
+func captureProviderObservationInventory(ctx context.Context, queries *manageddb.Queries) ([]capturedProjectionRevision, error) {
+	inventory := make([]capturedProjectionRevision, 0)
+	after := ""
+	totalFiles := 0
+	// Include a conservative lower bound for the enclosing inventory object;
+	// every revision is checked against this budget before it is appended.
+	inventoryBytes := len(`{"schema_version":1,"revisions":[]}`)
+	for {
+		rows, err := queries.ListProviderObservationRevisions(ctx, manageddb.ListProviderObservationRevisionsParams{
+			AfterRevisionID: after,
+			PageSize:        providerObservationPageSize,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list ready managed-data revisions: %w", err)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, row := range rows {
+			if len(inventory) >= providerObservationMaxRevisions {
+				return nil, fmt.Errorf("%w: ready revision count exceeds capture limit", ErrInvalid)
+			}
+			if row.FileCount > int64(providerObservationMaxRevisionFiles) {
+				return nil, fmt.Errorf("%w: revision %q file count exceeds capture limit", ErrInvalid, row.RevisionID)
+			}
+			revision, count, err := captureProviderObservationRevision(ctx, queries, row)
+			if err != nil {
+				return nil, err
+			}
+			totalFiles += count
+			if totalFiles > providerObservationMaxObjects {
+				return nil, fmt.Errorf("%w: managed-data file count exceeds capture limit", ErrInvalid)
+			}
+			revisionBytes := providerObservationRevisionBytes(revision)
+			if revisionBytes > providerObservationMaxInventoryBytes-inventoryBytes {
+				return nil, fmt.Errorf("%w: managed-data inventory exceeds capture limit", ErrInvalid)
+			}
+			inventory = append(inventory, revision)
+			inventoryBytes += revisionBytes
+			after = row.RevisionID
+		}
+		if len(rows) < int(providerObservationPageSize) {
+			break
+		}
+	}
+	return inventory, nil
+}
+
+func captureProviderObservationRevision(ctx context.Context, queries *manageddb.Queries, row manageddb.ListProviderObservationRevisionsRow) (capturedProjectionRevision, int, error) {
+	if _, err := manageddata.ParseRevisionID(row.RevisionID); err != nil {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: revision %q has invalid identity: %v", ErrInvalid, row.RevisionID, err)
+	}
+	if row.FileCount < 0 || row.SizeBytes < 0 {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: revision %q has negative stored count or size", ErrInvalid, row.RevisionID)
+	}
+	var manifest manageddata.Manifest
+	if err := strictjson.DecodeWithOptions([]byte(row.Manifest), &manifest, strictjson.Options{
+		MaxBytes:           providerObservationMaxManifestBytes,
+		MaxDepth:           32,
+		DuplicateKeys:      strictjson.CaseFoldedKeys,
+		AllowUnknownFields: false,
+	}); err != nil {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: decode revision %q manifest: %v", ErrInvalid, row.RevisionID, err)
+	}
+	canonicalManifest, err := manifest.CanonicalJSON()
+	if err != nil {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: validate revision %q manifest: %v", ErrInvalid, row.RevisionID, err)
+	}
+	if got := digestBytes(canonicalManifest); got != row.Digest {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: revision %q manifest digest %q does not match canonical digest %q", ErrInvalid, row.RevisionID, row.Digest, got)
+	}
+	if len(manifest.Files) != int(row.FileCount) {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: revision %q manifest file count does not match stored count", ErrInvalid, row.RevisionID)
+	}
+	files, err := queries.ListProviderObservationRevisionFiles(ctx, row.RevisionID)
+	if err != nil {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("list files for ready revision %q: %w", row.RevisionID, err)
+	}
+	if len(files) != len(manifest.Files) || len(files) != int(row.FileCount) {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: ready revision %q stored file count is not exact", ErrInvalid, row.RevisionID)
+	}
+	manifestByPath := make(map[string]manageddata.File, len(manifest.Files))
+	for _, file := range manifest.Files {
+		manifestByPath[file.Path] = file
+	}
+	observed := make([]capturedProjectionFile, 0, len(files))
+	var totalSize int64
+	for _, file := range files {
+		if file.RevisionID != row.RevisionID {
+			return capturedProjectionRevision{}, 0, fmt.Errorf("%w: revision file returned under wrong revision", ErrInvalid)
+		}
+		admitted, ok := manifestByPath[file.LogicalPath]
+		if !ok || admitted.Size != file.SizeBytes || admitted.SHA256 != file.Sha256 || file.StorageKey == "" {
+			return capturedProjectionRevision{}, 0, fmt.Errorf("%w: ready revision %q file %q does not match its manifest", ErrInvalid, row.RevisionID, file.LogicalPath)
+		}
+		if file.SizeBytes > 0 && totalSize > int64(^uint64(0)>>1)-file.SizeBytes {
+			return capturedProjectionRevision{}, 0, fmt.Errorf("%w: ready revision %q file size overflows int64", ErrInvalid, row.RevisionID)
+		}
+		totalSize += file.SizeBytes
+		observed = append(observed, capturedProjectionFile{Path: file.LogicalPath, SHA256: file.Sha256, StorageKey: file.StorageKey, Size: file.SizeBytes})
+	}
+	if totalSize != row.SizeBytes {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: ready revision %q stored size is not exact", ErrInvalid, row.RevisionID)
+	}
+	if len(observed) != len(manifestByPath) {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: ready revision %q contains duplicate or missing file paths", ErrInvalid, row.RevisionID)
+	}
+	return capturedProjectionRevision{RevisionID: row.RevisionID, ManifestDigest: row.Digest, Files: observed}, len(observed), nil
+}
+
+func providerObservationRevisionBytes(revision capturedProjectionRevision) int {
+	// Fixed JSON field names, punctuation, and quoting are deliberately
+	// rounded up. Six bytes per source byte covers JSON \u00XX escaping, so
+	// this guard rejects before accumulating beyond the bounded source
+	// document even when source keys contain escapable characters.
+	n := 6*(len(revision.RevisionID)+len(revision.ManifestDigest)) + 128
+	for _, file := range revision.Files {
+		n += 6*(len(file.Path)+len(file.SHA256)+len(file.StorageKey)) + 128
+	}
+	return n
+}
+
+func providerObservationRestorePointName() (string, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return "", fmt.Errorf("generate provider observation restore point name: %w", err)
+	}
+	return "provider_observation_" + id.String(), nil
+}
+
+func providerObservationTimeline(walFile string) (uint32, error) {
+	if len(walFile) != 24 {
+		return 0, fmt.Errorf("%w: PostgreSQL restore point returned no WAL file", ErrInvalid)
+	}
+	if _, err := hex.DecodeString(walFile); err != nil {
+		return 0, fmt.Errorf("%w: PostgreSQL restore point returned invalid WAL file %q", ErrInvalid, walFile)
+	}
+	timeline, err := strconv.ParseUint(walFile[:8], 16, 32)
+	if err != nil || timeline == 0 {
+		return 0, fmt.Errorf("%w: PostgreSQL restore point returned invalid WAL timeline", ErrInvalid)
+	}
+	return uint32(timeline), nil
+}

--- a/internal/manageddata/postgres/queries/observation_capture.sql
+++ b/internal/manageddata/postgres/queries/observation_capture.sql
@@ -1,0 +1,49 @@
+-- Trusted provider-observation capture reads the managed-data authority while
+-- the caller-owned transaction holds the same table locks as reachability GC.
+
+-- name: LockProviderObservationTables :exec
+LOCK TABLE managed_data.upload_session,
+           managed_data.revision,
+           managed_data.collection,
+           managed_data.revision_file,
+           managed_data.reachability_epoch
+IN SHARE MODE;
+
+-- name: GetProviderObservationEpoch :one
+SELECT epoch, pg_is_in_recovery() AS in_recovery
+FROM managed_data.reachability_epoch
+WHERE singleton = true;
+
+-- name: GetProviderObservationFsync :one
+SELECT current_setting('fsync')::text AS fsync;
+
+-- name: ListProviderObservationRevisions :many
+SELECT revision_id, digest, manifest::text AS manifest, file_count, size_bytes
+FROM managed_data.revision
+WHERE status = 'ready'
+  AND revision_id > sqlc.arg(after_revision_id)
+ORDER BY revision_id
+LIMIT sqlc.arg(page_size);
+
+-- name: ListProviderObservationRevisionFiles :many
+SELECT revision_id, logical_path, size_bytes, sha256, storage_key
+FROM managed_data.revision_file
+WHERE revision_id = sqlc.arg(revision_id)
+ORDER BY logical_path;
+
+-- name: CreateProviderObservationRestorePoint :one
+WITH restore AS (
+    SELECT pg_create_restore_point(sqlc.arg(restore_point_name)::text) AS restore_lsn
+)
+SELECT current_database()::text AS database_identity,
+       (SELECT system_identifier::text FROM pg_control_system()) AS system_identity,
+       restore_lsn::text AS lsn,
+       pg_walfile_name(restore_lsn)::text AS wal_file
+FROM restore;
+
+-- name: GetProviderObservationWALFlushLSN :one
+SELECT pg_current_wal_flush_lsn()::text AS flush_lsn,
+       (SELECT system_identifier::text FROM pg_control_system()) AS system_identity,
+       pg_walfile_name(pg_current_wal_flush_lsn())::text AS wal_file,
+       pg_is_in_recovery() AS in_recovery,
+       current_setting('fsync')::text AS fsync;

--- a/internal/manageddata/storage/s3/closure_qualification_test.go
+++ b/internal/manageddata/storage/s3/closure_qualification_test.go
@@ -1,0 +1,286 @@
+//go:build fai520qualification
+
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"maps"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/flidai/leapview/internal/manageddata"
+	managedpg "github.com/flidai/leapview/internal/manageddata/postgres"
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	manageds3 "github.com/flidai/leapview/internal/manageddata/storage/s3"
+	"github.com/flidai/leapview/internal/platform/postgres/postgrestest"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// This qualifies a retained manifest's blob closure, not a physical database
+// restore or recovery activation. Provider observations are test inputs only.
+func TestFAI520HistoricalManagedRevisionClosure(t *testing.T) {
+	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
+	repo := closureRepository(t)
+	ctx, client, clientFor, bucket, endpoint := historicalProvider(t)
+	store, err := manageds3.New(client, awss3.NewPresignClient(client), manageds3.Config{Bucket: bucket, Prefix: "project-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collection, err := repo.CreateCollection(ctx, manageddata.CreateCollectionInput{ProjectID: "project_a", ConnectionID: "connection_a", Name: "closure"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest manageddata.Manifest
+	var stored []manageddata.StoredFile
+	observations := map[string]historicalSelection{}
+	wrongVersions := map[string]string{}
+	// Metadata is an ordinary explicitly declared file here. The canonical
+	// revision manifest itself remains PostgreSQL-owned, not an invented object.
+	for i, body := range [][]byte{[]byte("id,value\n1,one\n"), []byte("id,value\n2,two\n"), []byte(`{"dataset":"fixture"}`)} {
+		path := []string{"a.csv", "b.csv", "metadata.json"}[i]
+		blob, err := store.Put(ctx, blobFor(body), bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		file := manageddata.File{Path: path, SHA256: blob.SHA256, Size: blob.Size}
+		manifest.Files = append(manifest.Files, file)
+		stored = append(stored, manageddata.StoredFile{File: file, StorageKey: blob.URI})
+		key := strings.TrimPrefix(blob.URI, "s3://"+bucket+"/")
+		head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: &bucket, Key: &key})
+		if err != nil {
+			t.Fatal(err)
+		}
+		version := aws.ToString(head.VersionId)
+		if version == "" || version == "null" {
+			t.Fatal("missing immutable provider baseline")
+		}
+		observations[path] = historicalSelection{Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: key, Version: version}
+	}
+	// Create the immutable revision through the existing repository write path.
+	upload, err := repo.CreateUploadSession(ctx, manageddata.CreateUploadSessionInput{ID: "upload_closure", CollectionID: collection.ID, Manifest: manifest, StorageBackend: "s3", StagingPrefix: "staging/closure", ExpiresAt: time.Now().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := repo.CompleteUpload(ctx, manageddata.CompleteUploadInput{SessionID: upload.ID, Files: stored})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revision.Digest != manifest.RevisionID() {
+		t.Fatal("persisted revision identity differs")
+	}
+	for _, file := range manifest.Files {
+		selection := observations[file.Path]
+		out, err := client.PutObject(ctx, &awss3.PutObjectInput{Bucket: &bucket, Key: &selection.Key, Body: bytes.NewReader(bytes.Repeat([]byte("x"), int(file.Size)))})
+		if err != nil {
+			t.Fatal(err)
+		}
+		wrongVersions[file.Path] = aws.ToString(out.VersionId)
+		if wrongVersions[file.Path] == "" || wrongVersions[file.Path] == "null" {
+			t.Fatal("missing replacement version")
+		}
+		if _, err := client.DeleteObject(ctx, &awss3.DeleteObjectInput{Bucket: &bucket, Key: &selection.Key}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sentinelKey, sentinelBody := "project-b/sentinel", []byte("unrelated")
+	_, err = store.Put(ctx, blobFor(sentinelBody), bytes.NewReader(sentinelBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	put, err := client.PutObject(ctx, &awss3.PutObjectInput{Bucket: &bucket, Key: &sentinelKey, Body: bytes.NewReader(sentinelBody)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sentinelSelection := historicalSelection{Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: sentinelKey, Version: aws.ToString(put.VersionId)}
+	inventory := func() *awss3.ListObjectVersionsOutput {
+		t.Helper()
+		out, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{Bucket: &bucket})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if aws.ToBool(out.IsTruncated) {
+			t.Fatal("fixture inventory unexpectedly truncated")
+		}
+		return out
+	}
+	before := inventory()
+	good := func(int) *awss3.Client { return client }
+	qualify := func(t *testing.T, selected map[string]historicalSelection, clients func(int) *awss3.Client, want string, completed int) []string {
+		t.Helper()
+		digests, reason := observeHistoricalClosure(t, ctx, repo, revision.ID, endpoint, bucket, selected, clients)
+		if reason != want || len(digests) != completed {
+			t.Fatalf("closure: %s, %d members; want %s, %d", reason, len(digests), want, completed)
+		}
+		return digests
+	}
+	first := qualify(t, observations, good, "verified", 3)
+	for _, tc := range []struct {
+		name, path, mode, reason string
+		completed                int
+	}{
+		{"missing dependency", "a.csv", "remove", "missing_dependency", 0},
+		{"partial closure", "metadata.json", "remove", "missing_dependency", 2},
+		{"missing historical version", "b.csv", "missing", "NoSuchVersion", 1},
+		{"wrong version", "b.csv", "wrong", "integrity_mismatch", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			selected := maps.Clone(observations)
+			entry := selected[tc.path]
+			switch tc.mode {
+			case "remove":
+				delete(selected, tc.path)
+			case "missing":
+				entry.Version = uuid.NewString()
+				selected[tc.path] = entry
+			case "wrong":
+				entry.Version = wrongVersions[tc.path]
+				selected[tc.path] = entry
+			}
+			qualify(t, selected, good, tc.reason, tc.completed)
+		})
+	}
+	t.Run("unrelated object ignored", func(t *testing.T) {
+		selected := maps.Clone(observations)
+		selected["not-in-manifest"] = sentinelSelection
+		if !reflect.DeepEqual(first, qualify(t, selected, good, "verified", 3)) {
+			t.Fatal("extra object altered closure")
+		}
+	})
+	t.Run("credential failure mid closure", func(t *testing.T) {
+		bad := clientFor(uuid.NewString())
+		qualify(t, observations, func(i int) *awss3.Client {
+			if i == 1 {
+				return bad
+			}
+			return client
+		}, "SignatureDoesNotMatch", 1)
+		for range 2 {
+			if !reflect.DeepEqual(first, qualify(t, observations, good, "verified", 3)) {
+				t.Fatal("repair retry changed closure")
+			}
+		}
+	})
+	if _, reason := observeHistoricalBytes(ctx, client, sentinelSelection, sentinelSelection, blobFor(sentinelBody)); reason != "verified" {
+		t.Fatal("sentinel changed:", reason)
+	}
+	after := inventory()
+	if !reflect.DeepEqual(before.Versions, after.Versions) || !reflect.DeepEqual(before.DeleteMarkers, after.DeleteMarkers) {
+		t.Fatal("closure retrieval changed provider state")
+	}
+}
+
+func closureRepository(t *testing.T) *managedpg.Repository {
+	t.Helper()
+	h := postgrestest.Start(t)
+	role := h.EnsureRole(t, postgrestest.Role{Name: "leapview_control_runtime", Password: uuid.NewString(), Login: true})
+	db := h.NewDatabase(t, "")
+	admin, err := pgxpool.New(t.Context(), db.AdminURL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(admin.Close)
+	tx, err := admin.Begin(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(t.Context())
+	if err := managedpg.ApplySchema(t.Context(), tx); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := pgxpool.New(t.Context(), db.URL(role))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	return managedpg.New(pool)
+}
+
+func observeHistoricalClosure(t *testing.T, ctx context.Context, repo *managedpg.Repository, id manageddata.RevisionID, endpoint, bucket string, selected map[string]historicalSelection, clients func(int) *awss3.Client) (digests []string, reason string) {
+	t.Helper()
+	started := time.Now().UTC()
+	defer func() {
+		record, err := json.Marshal(struct {
+			Revision           manageddata.RevisionID
+			Started, Completed time.Time
+			VerifiedMembers    int
+			Result             string
+		}{id, started, time.Now().UTC(), len(digests), reason})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log("closure result", string(record))
+	}()
+	revision, err := repo.RevisionByID(ctx, id)
+	if err != nil {
+		return nil, "revision_unavailable"
+	}
+	files, err := repo.ListRevisionFiles(ctx, id)
+	if err != nil {
+		return nil, "dependencies_unavailable"
+	}
+	var manifest manageddata.Manifest
+	if err := json.Unmarshal([]byte(revision.ManifestJSON), &manifest); err != nil {
+		return nil, "invalid_manifest"
+	}
+	// Test assertions compose the existing manifest identity contract. Do not
+	// infer completeness from how many provider observations happen to exist.
+	if manifest.RevisionID() == "" || manifest.RevisionID() != revision.Digest || len(manifest.Files) == 0 || int64(len(manifest.Files)) != revision.FileCount {
+		return nil, "invalid_manifest"
+	}
+	var discovered manageddata.Manifest
+	for _, file := range files {
+		if file.RevisionID != id {
+			return nil, "dependency_identity_mismatch"
+		}
+		discovered.Files = append(discovered.Files, file.File)
+	}
+	if discovered.RevisionID() != revision.Digest {
+		return nil, "incomplete_manifest"
+	}
+	inventory, err := manifest.CanonicalJSON()
+	if err != nil {
+		return nil, "invalid_manifest"
+	}
+	t.Log("closure inventory", id, revision.Digest, string(inventory))
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	for i, file := range files {
+		observation, ok := selected[file.Path]
+		if !ok {
+			return digests, "missing_dependency"
+		}
+		prefix := "s3://" + bucket + "/"
+		if !strings.HasPrefix(file.StorageKey, prefix) {
+			return digests, "namespace_mismatch"
+		}
+		boundary := historicalSelection{Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: strings.TrimPrefix(file.StorageKey, prefix)}
+		digest, result := observeHistoricalBytes(ctx, clients(i), boundary, observation, storage.Blob{SHA256: file.SHA256, Size: file.Size})
+		record, err := json.Marshal(struct {
+			Revision               manageddata.RevisionID
+			ManifestDigest         string
+			Order                  int
+			Dependency             manageddata.File
+			Provider               historicalSelection
+			ObservedSHA256, Result string
+		}{id, revision.Digest, i, file.File, observation, digest, result})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log("closure member", string(record))
+		if result != "verified" {
+			return digests, result
+		}
+		digests = append(digests, digest)
+	}
+	return digests, "verified"
+}

--- a/internal/manageddata/storage/s3/historical_qualification_test.go
+++ b/internal/manageddata/storage/s3/historical_qualification_test.go
@@ -1,0 +1,297 @@
+//go:build fai520qualification
+
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	manageds3 "github.com/flidai/leapview/internal/manageddata/storage/s3"
+	"github.com/google/uuid"
+	"github.com/testcontainers/testcontainers-go"
+	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const historicalProviderImage = "minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+
+// This is a provider experiment, not an alternate recovery-admission validator.
+// This validates historical managed-object retrieval. It does not prove successful physical disaster recovery.
+func TestFAI520HistoricalManagedObjectRetrieval(t *testing.T) {
+	ctx, client, clientFor, bucket, endpoint := historicalProvider(t)
+	store, err := manageds3.New(client, awss3.NewPresignClient(client), manageds3.Config{Bucket: bucket, Prefix: "project-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	qualifyHistoricalObject(t, ctx, client, clientFor, bucket, endpoint, store)
+}
+
+func historicalProvider(t *testing.T) (context.Context, *awss3.Client, func(string) *awss3.Client, string, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+	user, secret := "q"+strings.ReplaceAll(uuid.NewString(), "-", ""), uuid.NewString()
+	// Liveness alone can pass before S3 initialization completes.
+	container, err := tcminio.Run(ctx, historicalProviderImage, tcminio.WithUsername(user), tcminio.WithPassword(secret),
+		testcontainers.WithTmpfs(map[string]string{"/data": "rw,size=1g"}),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/minio/health/ready").WithPort("9000").WithStartupTimeout(time.Minute)))
+	testcontainers.CleanupContainer(t, container)
+	if err != nil {
+		t.Fatal(err)
+	} // Explicit qualification must never silently skip.
+	address, err := container.ConnectionString(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint := "http://" + strings.TrimRight(address, "/")
+	clientFor := func(password string) *awss3.Client {
+		return awss3.New(awss3.Options{Region: "us-east-1", BaseEndpoint: aws.String(endpoint), UsePathStyle: true, Credentials: credentials.NewStaticCredentialsProvider(user, password, ""), RetryMaxAttempts: 1, HTTPClient: historicalHTTPClient{t: t}})
+	}
+	client := clientFor(secret)
+	bucket := "qualification-" + uuid.NewString()
+	if _, err := client.CreateBucket(ctx, &awss3.CreateBucketInput{Bucket: &bucket}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{Bucket: &bucket, VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled}}); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, client, clientFor, bucket, endpoint
+}
+
+// Keep setup failures diagnosable without printing credentials, URLs, or bodies.
+type historicalHTTPClient struct{ t *testing.T }
+
+func (c historicalHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		c.t.Log("provider HTTP transport failure")
+	}
+	if response != nil && response.StatusCode >= 400 {
+		c.t.Logf("provider HTTP %s status %d", request.Method, response.StatusCode)
+	}
+	return response, err
+}
+
+func qualifyHistoricalObject(t *testing.T, ctx context.Context, client *awss3.Client, clientFor func(string) *awss3.Client, bucket, endpoint string, store storage.BlobStore) {
+	put := func(key string, body []byte) string {
+		t.Helper()
+		out, err := client.PutObject(ctx, &awss3.PutObjectInput{Bucket: &bucket, Key: &key, Body: bytes.NewReader(body)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := aws.ToString(out.VersionId)
+		if id == "" || id == "null" {
+			t.Fatal("provider did not return an immutable version")
+		}
+		return id
+	}
+	baseline := func(key, version string, body []byte) {
+		t.Helper()
+		selected := historicalSelection{Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: key, Version: version}
+		digest, reason := observeHistoricalBytes(ctx, client, selected, selected, blobFor(body))
+		if reason != "verified" {
+			t.Fatalf("baseline bytes: %s", reason)
+		}
+		record, err := json.Marshal(struct {
+			Selection historicalSelection
+			Size      int
+			SHA256    string
+			Observed  time.Time
+		}{selected, len(body), digest, time.Now().UTC()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log("baseline", string(record))
+	}
+	a, b := []byte("managed revision A\n"), []byte("managed revision B\n")
+	blobA, err := store.Put(ctx, blobFor(a), bytes.NewReader(a))
+	if err != nil {
+		t.Fatal(err)
+	}
+	blobB, err := store.Put(ctx, blobFor(b), bytes.NewReader(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := strings.TrimPrefix(blobA.URI, "s3://"+bucket+"/")
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: &bucket, Key: &key})
+	if err != nil {
+		t.Fatal(err)
+	}
+	versionA := aws.ToString(head.VersionId)
+	if versionA == "" || versionA == "null" {
+		t.Fatal("unversioned baseline")
+	}
+	baseline(key, versionA, a)
+	keyB := strings.TrimPrefix(blobB.URI, "s3://"+bucket+"/")
+	headB, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: &bucket, Key: &keyB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseline(keyB, aws.ToString(headB.VersionId), b)
+	// Production writes use distinct content keys. Raw provider replacement at
+	// A's key deliberately models corruption, not a supported managed write.
+	versionB := put(key, b)
+	corrupt := put(key, bytes.Repeat([]byte("x"), len(a)))
+	sentinelKey := "project-b/sentinel"
+	sentinelBody := []byte("unrelated immutable sentinel")
+	sentinelVersion := put(sentinelKey, sentinelBody)
+	baseline(sentinelKey, sentinelVersion, sentinelBody)
+	sentinelLatestBody := []byte("unrelated later version")
+	sentinelLatestVersion := put(sentinelKey, sentinelLatestBody)
+	baseline(sentinelKey, sentinelLatestVersion, sentinelLatestBody)
+	if _, err := client.DeleteObject(ctx, &awss3.DeleteObjectInput{Bucket: &bucket, Key: &key}); err != nil {
+		t.Fatal(err)
+	}
+	if latest, err := client.GetObject(ctx, &awss3.GetObjectInput{Bucket: &bucket, Key: &key}); err == nil {
+		_ = latest.Body.Close()
+		t.Fatal("latest unexpectedly survived delete marker")
+	} else {
+		requireHistoricalCode(t, err, "NoSuchKey")
+	}
+	inventory := func() *awss3.ListObjectVersionsOutput {
+		t.Helper()
+		out, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{Bucket: &bucket})
+		if err != nil || aws.ToBool(out.IsTruncated) {
+			t.Fatalf("bounded inventory: %v", err)
+		}
+		return out
+	}
+	before := inventory()
+	selection := historicalSelection{Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: key, Version: versionA}
+	// Emit safe observation records in go test -json output, never SDK errors
+	// or credentials. These records are not a recovery-set evidence format.
+	retrieve := func(t *testing.T, name string, c *awss3.Client, selected historicalSelection, expected storage.Blob, want string) {
+		t.Helper()
+		started := time.Now().UTC()
+		digest, reason := observeHistoricalBytes(ctx, c, selection, selected, expected)
+		record, err := json.Marshal(struct {
+			Case               string
+			Selection          historicalSelection
+			SHA256             string
+			ExpectedSize       int64
+			ExpectedSHA256     string
+			Started, Completed time.Time
+			Result             string
+		}{name, selected, digest, expected.Size, expected.SHA256, started, time.Now().UTC(), reason})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(string(record))
+		if reason != want {
+			t.Fatalf("%s: got %s, want %s", name, reason, want)
+		}
+	}
+	retrieve(t, "exact historical A", client, selection, blobA, "verified")
+	for _, tc := range []struct{ name, version, want string }{{"missing version", uuid.NewString(), "NoSuchVersion"}, {"empty version", "", "missing_version"}, {"null version", "null", "missing_version"}, {"wrong version", versionB, "integrity_mismatch"}, {"corrupted bytes", corrupt, "integrity_mismatch"}} {
+		t.Run(tc.name, func(t *testing.T) {
+			selected := selection
+			selected.Version = tc.version
+			retrieve(t, tc.name, client, selected, blobA, tc.want)
+		})
+	}
+	for _, field := range []string{"endpoint", "region", "bucket", "prefix"} {
+		t.Run("substituted "+field, func(t *testing.T) {
+			selected := selection
+			switch field {
+			case "endpoint":
+				selected.Endpoint = "http://untrusted.invalid"
+			case "region":
+				selected.Region = "other"
+			case "bucket":
+				selected.Bucket = "other"
+			case "prefix":
+				selected.Key = sentinelKey
+			}
+			retrieve(t, field, client, selected, blobA, "namespace_mismatch")
+		})
+	}
+	retrieve(t, "credential failure", clientFor(uuid.NewString()), selection, blobA, "SignatureDoesNotMatch")
+	retrieve(t, "credential repaired retry 1", client, selection, blobA, "verified")
+	retrieve(t, "credential repaired retry 2", client, selection, blobA, "verified")
+	// Check another genuine managed revision through its production read path.
+	reader, err := store.Open(ctx, blobB.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if err != nil || closeErr != nil || !bytes.Equal(got, b) {
+		t.Fatal("unrelated managed revision changed")
+	}
+	sentinel, err := client.GetObject(ctx, &awss3.GetObjectInput{Bucket: &bucket, Key: &sentinelKey, VersionId: &sentinelVersion})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = io.ReadAll(sentinel.Body)
+	closeErr = sentinel.Body.Close()
+	if err != nil || closeErr != nil || !bytes.Equal(got, sentinelBody) {
+		t.Fatal("sentinel changed")
+	}
+	baseline(sentinelKey, sentinelLatestVersion, sentinelLatestBody)
+	after := inventory()
+	if !reflect.DeepEqual(before.Versions, after.Versions) || !reflect.DeepEqual(before.DeleteMarkers, after.DeleteMarkers) {
+		t.Fatal("read/retry modified provider versions")
+	}
+}
+
+type historicalSelection struct{ Endpoint, Region, Bucket, Key, Version string }
+
+// Provider observations only: no mutation, fallback, or product admission.
+func observeHistoricalBytes(ctx context.Context, client *awss3.Client, boundary, selected historicalSelection, expected storage.Blob) (string, string) {
+	options := client.Options()
+	if selected.Endpoint != boundary.Endpoint || selected.Region != boundary.Region || selected.Bucket != boundary.Bucket || selected.Key != boundary.Key || aws.ToString(options.BaseEndpoint) != boundary.Endpoint || options.Region != boundary.Region {
+		return "", "namespace_mismatch"
+	}
+	if selected.Version == "" || selected.Version == "null" {
+		return "", "missing_version"
+	}
+	out, err := client.GetObject(ctx, &awss3.GetObjectInput{Bucket: &selected.Bucket, Key: &selected.Key, VersionId: &selected.Version})
+	if err != nil {
+		var api smithy.APIError
+		if errors.As(err, &api) {
+			switch api.ErrorCode() {
+			case "NoSuchVersion", "NoSuchKey", "AccessDenied", "SignatureDoesNotMatch", "InvalidAccessKeyId":
+				return "", api.ErrorCode()
+			}
+		}
+		return "", "provider_failure"
+	}
+	defer out.Body.Close()
+	if aws.ToString(out.VersionId) != selected.Version {
+		return "", "version_mismatch"
+	}
+	h := sha256.New()
+	n, err := io.Copy(h, io.LimitReader(out.Body, expected.Size+1))
+	if err != nil {
+		return "", "read_failure"
+	}
+	digest := hex.EncodeToString(h.Sum(nil))
+	if n != expected.Size || digest != expected.SHA256 {
+		return digest, "integrity_mismatch"
+	}
+	return digest, "verified"
+}
+
+func requireHistoricalCode(t *testing.T, err error, code string) {
+	t.Helper()
+	var api smithy.APIError
+	if !errors.As(err, &api) || api.ErrorCode() != code {
+		t.Fatalf("provider did not return expected %s", code)
+	}
+}

--- a/internal/manageddata/storage/s3/provider_binding_qualification_test.go
+++ b/internal/manageddata/storage/s3/provider_binding_qualification_test.go
@@ -1,0 +1,206 @@
+//go:build fai520qualification
+
+package s3_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/flidai/leapview/internal/manageddata"
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	manageds3 "github.com/flidai/leapview/internal/manageddata/storage/s3"
+)
+
+type providerObservationArtifact struct {
+	RevisionID         manageddata.RevisionID      `json:"revisionID"`
+	ManifestRevisionID string                      `json:"manifestRevisionID"`
+	Endpoint           string                      `json:"endpoint"`
+	Region             string                      `json:"region"`
+	Bucket             string                      `json:"bucket"`
+	Objects            []providerObjectObservation `json:"objects"`
+}
+
+type providerObjectObservation struct {
+	Path     string `json:"path"`
+	Endpoint string `json:"endpoint"`
+	Region   string `json:"region"`
+	Bucket   string `json:"bucket"`
+	Key      string `json:"key"`
+	Version  string `json:"versionID"`
+	SHA256   string `json:"sha256"`
+	Size     int64  `json:"size"`
+}
+
+func TestFAI520ManagedProviderBindingObservationReplay(t *testing.T) {
+	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
+	ctx, client, _, bucket, endpoint := historicalProvider(t)
+	repo := closureRepository(t)
+	store, err := manageds3.New(client, awss3.NewPresignClient(client), manageds3.Config{Bucket: bucket, Prefix: "project-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collection, err := repo.CreateCollection(ctx, manageddata.CreateCollectionInput{ProjectID: "project_a", ConnectionID: "connection_a", Name: "provider-binding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	objects := []struct {
+		path string
+		body []byte
+		mime string
+	}{
+		{path: "orders.csv", body: []byte("order_id,amount\n1,10\n"), mime: "text/csv"},
+		{path: "customers.csv", body: []byte("customer_id,name\n1,Ada\n"), mime: "text/csv"},
+		{path: "metadata.json", body: []byte(`{"dataset":"orders","format":"qualification"}`), mime: "application/json"},
+	}
+	manifest := manageddata.Manifest{}
+	stored := make([]manageddata.StoredFile, 0, len(objects))
+	selections := make(map[string]historicalSelection, len(objects))
+	observed := make([]providerObjectObservation, 0, len(objects))
+	for _, object := range objects {
+		blob, putErr := store.Put(ctx, blobFor(object.body), bytes.NewReader(object.body))
+		if putErr != nil {
+			t.Fatal(putErr)
+		}
+		file := manageddata.File{Path: object.path, SHA256: blob.SHA256, Size: blob.Size}
+		manifest.Files = append(manifest.Files, file)
+		stored = append(stored, manageddata.StoredFile{File: file, StorageKey: blob.URI, MediaType: object.mime})
+		key := strings.TrimPrefix(blob.URI, "s3://"+bucket+"/")
+		head, headErr := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
+		if headErr != nil {
+			t.Fatal(headErr)
+		}
+		if head.ContentLength == nil || *head.ContentLength != blob.Size {
+			t.Fatalf("provider size for %s = %v, want %d", object.path, head.ContentLength, blob.Size)
+		}
+		version := aws.ToString(head.VersionId)
+		if version == "" || version == "null" {
+			t.Fatalf("provider did not return immutable version for %s", object.path)
+		}
+		selection := historicalSelection{Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: key, Version: version}
+		selections[object.path] = selection
+		observed = append(observed, providerObjectObservation{Path: object.path, Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: key, Version: version, SHA256: blob.SHA256, Size: blob.Size})
+	}
+	upload, err := repo.CreateUploadSession(ctx, manageddata.CreateUploadSessionInput{ID: "upload_provider_binding", CollectionID: collection.ID, Manifest: manifest, StorageBackend: "s3", StagingPrefix: "staging/provider-binding", ExpiresAt: time.Now().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := repo.CompleteUpload(ctx, manageddata.CompleteUploadInput{SessionID: upload.ID, RevisionID: "revision_provider_binding", Files: stored})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revision.Digest != manifest.RevisionID() || revision.FileCount != int64(len(objects)) {
+		t.Fatalf("persisted managed revision = %#v; manifest = %s", revision, manifest.RevisionID())
+	}
+	if revision.ID == "" || revision.ManifestJSON == "" {
+		t.Fatalf("persisted managed revision omitted identity or metadata: %#v", revision)
+	}
+	sort.Slice(observed, func(i, j int) bool { return observed[i].Path < observed[j].Path })
+
+	// This is a test observation artifact, not a recovery-set or authoritative
+	// frontier binding. It records the exact provider reads needed to replay the
+	// managed revision closure without inventing a product admission contract.
+	artifact := providerObservationArtifact{RevisionID: revision.ID, ManifestRevisionID: manifest.RevisionID(), Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Objects: observed}
+	artifactPath := filepath.Join(t.TempDir(), "provider-observations.json")
+	encoded, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artifactPath, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	replayedBytes, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var replay providerObservationArtifact
+	if err := json.Unmarshal(replayedBytes, &replay); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(replay, artifact) {
+		t.Fatalf("observation artifact changed across persistence round-trip:\n%#v\n%#v", replay, artifact)
+	}
+	if replay.RevisionID != revision.ID || replay.ManifestRevisionID != manifest.RevisionID() || len(replay.Objects) != len(manifest.Files) {
+		t.Fatalf("observation artifact identity = %#v", replay)
+	}
+	replayedSelections := make(map[string]historicalSelection, len(replay.Objects))
+	for _, object := range replay.Objects {
+		if object.Endpoint != endpoint || object.Region != "us-east-1" || object.Bucket != bucket || object.Key == "" || object.Version == "" || object.SHA256 == "" || object.Size <= 0 {
+			t.Fatalf("incomplete provider observation = %#v", object)
+		}
+		replayedSelections[object.Path] = historicalSelection{Endpoint: object.Endpoint, Region: object.Region, Bucket: object.Bucket, Key: object.Key, Version: object.Version}
+	}
+
+	first, reason := observeHistoricalClosure(t, ctx, repo, revision.ID, endpoint, bucket, selections, func(int) *awss3.Client { return client })
+	if reason != "verified" || len(first) != len(objects) {
+		t.Fatalf("initial managed closure = %s, %d members", reason, len(first))
+	}
+	data := objects[0]
+	dataBlob := blobFor(data.body)
+	dataSelection := selections[data.path]
+	boundary := historicalSelection{Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: dataSelection.Key}
+	if _, result := observeHistoricalBytes(ctx, client, boundary, dataSelection, storage.Blob{SHA256: strings.Repeat("0", 64), Size: dataBlob.Size}); result != "integrity_mismatch" {
+		t.Fatalf("digest mismatch result = %s", result)
+	}
+	wrongBody := bytes.Repeat([]byte("x"), len(data.body))
+	wrongVersionOutput, err := client.PutObject(ctx, &awss3.PutObjectInput{Bucket: aws.String(bucket), Key: aws.String(dataSelection.Key), Body: bytes.NewReader(wrongBody)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongVersion := aws.ToString(wrongVersionOutput.VersionId)
+	if wrongVersion == "" || wrongVersion == "null" {
+		t.Fatal("provider did not return wrong-byte version")
+	}
+	if _, result := observeHistoricalBytes(ctx, client, boundary, dataSelection, dataBlob); result != "verified" {
+		t.Fatalf("exact historical version after current overwrite = %s, want verified", result)
+	}
+	wrongSelection := dataSelection
+	wrongSelection.Version = wrongVersion
+	if _, result := observeHistoricalBytes(ctx, client, boundary, wrongSelection, dataBlob); result != "integrity_mismatch" {
+		t.Fatalf("wrong-version bytes result = %s", result)
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		replayDigests, replayReason := observeHistoricalClosure(t, ctx, repo, replay.RevisionID, replay.Endpoint, replay.Bucket, replayedSelections, func(int) *awss3.Client { return client })
+		if replayReason != "verified" || !reflect.DeepEqual(replayDigests, first) {
+			t.Fatalf("observation replay %d = %s, %#v; want verified %#v", attempt, replayReason, replayDigests, first)
+		}
+	}
+	endpointSelection := dataSelection
+	endpointSelection.Endpoint = "http://untrusted.invalid"
+	if _, result := observeHistoricalBytes(ctx, client, boundary, endpointSelection, dataBlob); result != "namespace_mismatch" {
+		t.Fatalf("provider endpoint mismatch result = %s", result)
+	}
+
+	missing := maps.Clone(selections)
+	delete(missing, "metadata.json")
+	missingDigests, missingReason := observeHistoricalClosure(t, ctx, repo, revision.ID, endpoint, bucket, missing, func(int) *awss3.Client { return client })
+	if missingReason != "missing_dependency" || len(missingDigests) != 1 {
+		t.Fatalf("missing observation = %s, %d members; want missing_dependency, 1", missingReason, len(missingDigests))
+	}
+	conflictArtifact := artifact
+	conflict := conflictArtifact.Objects[0]
+	conflict.Version = wrongVersion
+	conflictArtifact.Objects = append(append([]providerObjectObservation(nil), conflictArtifact.Objects...), conflict)
+	conflictEncoded, err := json.Marshal(conflictArtifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var conflictReplay providerObservationArtifact
+	if err := json.Unmarshal(conflictEncoded, &conflictReplay); err != nil {
+		t.Fatal(err)
+	}
+	if len(conflictReplay.Objects) != len(artifact.Objects)+1 || conflictReplay.Objects[0].Path != conflictReplay.Objects[len(conflictReplay.Objects)-1].Path || conflictReplay.Objects[len(conflictReplay.Objects)-1].Version != wrongVersion {
+		t.Fatalf("conflicting duplicate observation was not preserved for characterization: %#v", conflictReplay.Objects)
+	}
+	t.Log("unqualified gap: observation artifact preserves conflicting duplicates without a product validator or durable managed-inventory/frontier binding")
+}

--- a/internal/platform/architecture/recovery_observation_test.go
+++ b/internal/platform/architecture/recovery_observation_test.go
@@ -1,0 +1,18 @@
+package architecture
+
+import "testing"
+
+func TestRecoveryObservationUsesOneWayInventoryContract(t *testing.T) {
+	if !CapabilityDependencies["recoveryset"]["manageddata"] || CapabilityDependencies["manageddata"]["recoveryset"] {
+		t.Fatal("recovery must consume managed inventory without a reverse dependency")
+	}
+	source, _ := ClassifyPackage("internal/recoveryset/postgres")
+	contract, _ := ClassifyPackage("internal/manageddata")
+	if violation := CapabilityImportViolation("internal/recoveryset/postgres", source, "internal/manageddata", contract); violation != "" {
+		t.Fatal(violation)
+	}
+	adapter, _ := ClassifyPackage("internal/manageddata/postgres")
+	if violation := CapabilityImportViolation("internal/recoveryset/postgres", source, "internal/manageddata/postgres", adapter); violation == "" {
+		t.Fatal("recovery must not bypass managed-data contract ownership")
+	}
+}

--- a/internal/platform/architecture/rules.go
+++ b/internal/platform/architecture/rules.go
@@ -250,7 +250,9 @@ var CapabilityDependencies = map[string]map[string]bool{
 	"refresh":       {"access": true, "servingstate": true, "manageddata": true, "analytics": true, "runtimehost": true, "workload": true},
 	"runtimehost":   {"manageddata": true, "servingstate": true},
 	"lineage":       {"project": true},
-	"recoveryset":   {"analytics": true},
+	// Recovery evidence consumes the managed-data inventory contract, never
+	// its persistence adapter. Managed-data does not depend on recovery.
+	"recoveryset":   {"analytics": true, "manageddata": true},
 	"workload":      {},
 	"semanticvalue": {},
 	"platform":      {},

--- a/internal/recoveryset/frontier_identity.go
+++ b/internal/recoveryset/frontier_identity.go
@@ -1,0 +1,70 @@
+package recoveryset
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"time"
+)
+
+// Normalize returns a validated copy with child rows in their persistence
+// order. Callers should normalize before insertion or equality comparison.
+func (s RecoverySet) Normalize() (RecoverySet, error) {
+	if err := s.Validate(); err != nil {
+		return RecoverySet{}, err
+	}
+	// PostgreSQL timestamptz stores microsecond precision; canonicalize before
+	// hashing/insertion so exact replay does not differ on sub-microsecond
+	// caller clock values.
+	s.CreatedAt = s.CreatedAt.UTC().Truncate(time.Microsecond)
+	if s.ManagedEvidence != nil {
+		binding := *s.ManagedEvidence
+		s.ManagedEvidence = &binding
+	}
+	s.sortChildren()
+	return s, nil
+}
+
+func (s *RecoverySet) sortChildren() {
+	s.ClusterPoints = s.CanonicalPoints()
+	s.ObjectRoots = append([]ObjectRoot(nil), s.ObjectRoots...)
+	sort.Slice(s.ObjectRoots, func(i, j int) bool {
+		a, b := s.ObjectRoots[i], s.ObjectRoots[j]
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.URI != b.URI {
+			return a.URI < b.URI
+		}
+		return a.VersionID < b.VersionID
+	})
+}
+
+// CanonicalJSON and Digest provide a stable evidence identity for audit and
+// idempotent replay. Child collections are sorted before encoding.
+func (s RecoverySet) CanonicalJSON() ([]byte, error) {
+	n, err := s.Normalize()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(n)
+}
+
+func (s RecoverySet) Digest() (string, error) {
+	// Digest covers only the immutable frontier projection. Publication status,
+	// fence, audit actor, and creation metadata remain separate record fields.
+	n := s
+	n.Status, n.FrontierDigest, n.PublishedValidationAttemptID = StatusPrepared, "", ""
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+	n.FenceEpoch, n.AuditIdentity, n.CreatedBy, n.CreatedAt = 0, "", "", time.Time{}
+	n.sortChildren()
+	b, err := json.Marshal(n)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/recoveryset/frontier_v2.go
+++ b/internal/recoveryset/frontier_v2.go
@@ -1,0 +1,126 @@
+package recoveryset
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+	"github.com/flidai/leapview/pkg/strictjson"
+)
+
+// EvidenceSchemaVersion is opt-in, off-host qualification evidence. It is not
+// accepted by the v1 SQL publication or startup contract.
+const EvidenceSchemaVersion int32 = 2
+
+// ManagedEvidence binds an independently retained observation descriptor and
+// the exact marker attestation. Structural validation is not proof of capture
+// provenance or retention: the observation store must verify those before it
+// accepts a frontier for immutable persistence.
+type ManagedEvidence struct {
+	ManifestDigest   string               `json:"manifest_digest"`
+	BoundaryDigest   string               `json:"boundary_digest"`
+	DescriptorDigest string               `json:"descriptor_digest"`
+	Boundary         observation.Boundary `json:"boundary"`
+}
+
+func (s RecoverySet) validateEvidenceVersion() error {
+	switch s.SchemaVersion {
+	case SchemaVersion:
+		if s.ManagedEvidence != nil {
+			return fmt.Errorf("%w: v1 forbids managed evidence", ErrInvalid)
+		}
+		return nil
+	case EvidenceSchemaVersion:
+		if s.Status != StatusPrepared || s.PublishedValidationAttemptID != "" {
+			return fmt.Errorf("%w: v2 is qualification-only; activation is unsupported", ErrInvalid)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported schema version %d", ErrInvalid, s.SchemaVersion)
+	}
+	binding := s.ManagedEvidence
+	if binding == nil {
+		return fmt.Errorf("%w: v2 requires managed evidence", ErrInvalid)
+	}
+	for _, value := range []string{binding.ManifestDigest, binding.BoundaryDigest, binding.DescriptorDigest} {
+		if err := digest(value, "managed evidence digest"); err != nil {
+			return err
+		}
+	}
+	want, err := binding.Boundary.Digest()
+	if err != nil || want != binding.BoundaryDigest {
+		return fmt.Errorf("%w: boundary attestation digest mismatch", ErrInvalid)
+	}
+	for _, point := range s.ClusterPoints {
+		if point.DatabaseRole != DatabaseControl {
+			continue
+		}
+		if point.ClusterIdentity != "postgres:"+binding.Boundary.SystemIdentity ||
+			point.DatabaseIdentity != binding.Boundary.DatabaseIdentity ||
+			point.RecoveryIdentity != binding.Boundary.RecoveryIdentity() {
+			return fmt.Errorf("%w: control frontier differs from captured boundary", ErrInvalid)
+		}
+		return nil
+	}
+	return fmt.Errorf("%w: missing control boundary", ErrInvalid)
+}
+
+// ParseRecoverySet rejects unknown versions, duplicate keys and unsupported
+// evidence instead of interpreting a future version as a v1 frontier. Existing
+// v1 canonical bytes are unchanged. This is not a restore/admission API.
+func ParseRecoverySet(raw []byte) (RecoverySet, error) {
+	var set RecoverySet
+	if err := strictjson.DecodeWithOptions(raw, &set, strictjson.Options{MaxBytes: 1 << 20, MaxDepth: 32}); err != nil {
+		return RecoverySet{}, fmt.Errorf("%w: malformed recovery frontier", ErrInvalid)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return RecoverySet{}, ErrInvalid
+	}
+	if set.SchemaVersion == SchemaVersion {
+		if _, exists := fields["managed_evidence"]; exists {
+			return RecoverySet{}, fmt.Errorf("%w: v1 forbids managed evidence fields", ErrInvalid)
+		}
+	}
+	// Require the exact field spelling and presence emitted by this version.
+	// encoding/json alone accepts case aliases and missing zero-valued fields.
+	encoded, err := json.Marshal(set)
+	if err != nil {
+		return RecoverySet{}, ErrInvalid
+	}
+	var supplied, expected any
+	if json.Unmarshal(raw, &supplied) != nil || json.Unmarshal(encoded, &expected) != nil || !sameJSONShape(supplied, expected) {
+		return RecoverySet{}, fmt.Errorf("%w: frontier fields do not match the exact versioned schema", ErrInvalid)
+	}
+	return set.Normalize()
+}
+
+func sameJSONShape(supplied, expected any) bool {
+	switch value := expected.(type) {
+	case map[string]any:
+		got, ok := supplied.(map[string]any)
+		if !ok || len(got) != len(value) {
+			return false
+		}
+		for key, child := range value {
+			actual, exists := got[key]
+			if !exists || !sameJSONShape(actual, child) {
+				return false
+			}
+		}
+	case []any:
+		got, ok := supplied.([]any)
+		if !ok || len(got) != len(value) {
+			return false
+		}
+		for index, child := range value {
+			if !sameJSONShape(got[index], child) {
+				return false
+			}
+		}
+	default:
+		if (expected == nil) != (supplied == nil) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/recoveryset/frontier_v2_test.go
+++ b/internal/recoveryset/frontier_v2_test.go
@@ -1,0 +1,114 @@
+package recoveryset
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+)
+
+func TestV1FrontierDigestCompatibility(t *testing.T) {
+	set := testSet(t)
+	got, err := set.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "sha256:a1f8f8b06d9ed369f9a4b720489465a73b7c386687408f05fea0d2153d0aa7eb" {
+		t.Fatalf("v1 frontier digest changed: %s", got)
+	}
+}
+
+func v2Set(t *testing.T) RecoverySet {
+	t.Helper()
+	set := testSet(t)
+	boundary := observation.Boundary{ProtocolVersion: 1, DatabaseIdentity: "control-db", SystemIdentity: "123456789", Timeline: 1, LSN: "0/100", RestorePointName: "leapview_test_marker", InventoryDigest: testDigest('a')}
+	boundaryDigest, err := boundary.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	set.SchemaVersion = 2
+	set.ManagedEvidence = &ManagedEvidence{ManifestDigest: testDigest('b'), BoundaryDigest: boundaryDigest, DescriptorDigest: testDigest('c'), Boundary: boundary}
+	set.ClusterPoints[0].ClusterIdentity = "postgres:" + boundary.SystemIdentity
+	set.ClusterPoints[0].RecoveryIdentity = boundary.RecoveryIdentity()
+	set.ClusterPoints[1].ClusterIdentity = "separate-ducklake-cluster"
+	return set
+}
+
+func TestV2FrontierRequiresExactManagedBoundary(t *testing.T) {
+	set := v2Set(t)
+	raw, err := set.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseRecoverySet(raw)
+	if err != nil || !parsed.FrontierEqual(set) {
+		t.Fatalf("roundtrip: %v", err)
+	}
+	for name, mutate := range map[string]func(*RecoverySet){
+		"missing":         func(s *RecoverySet) { s.ManagedEvidence = nil },
+		"manifest digest": func(s *RecoverySet) { s.ManagedEvidence.ManifestDigest = "" },
+		"boundary digest": func(s *RecoverySet) { s.ManagedEvidence.BoundaryDigest = testDigest('f') },
+		"wrong LSN":       func(s *RecoverySet) { s.ManagedEvidence.Boundary.LSN = "0/101" },
+		"wrong database":  func(s *RecoverySet) { s.ClusterPoints[0].DatabaseIdentity = "other" },
+		"wrong system":    func(s *RecoverySet) { s.ClusterPoints[0].ClusterIdentity = "other" },
+		"unknown version": func(s *RecoverySet) { s.SchemaVersion = 3 },
+		"downgrade":       func(s *RecoverySet) { s.SchemaVersion = 1 },
+		"activation":      func(s *RecoverySet) { s.Status = StatusPublished },
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := v2Set(t)
+			mutate(&s)
+			if err := s.Validate(); err == nil {
+				t.Fatal("invalid frontier accepted")
+			}
+		})
+	}
+	if _, err := NewValidationEvidenceEnvelope(set, "018f3f83-7b2f-7b37-9f9e-000000000111"); err == nil {
+		t.Fatal("v2 silently converted to v1 validation evidence")
+	}
+}
+
+func TestRecoverySetParserRejectsAmbiguousEvidence(t *testing.T) {
+	raw, err := v2Set(t).CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, invalid := range []string{
+		strings.Replace(string(raw), `"schema_version":2`, `"schema_version":2,"schema_version":1`, 1),
+		strings.Replace(string(raw), `"schema_version":2`, `"schema_version":99`, 1),
+		strings.Replace(string(raw), `"managed_evidence":`, `"unknown":`, 1),
+		string(raw) + `{}`,
+	} {
+		if _, err := ParseRecoverySet([]byte(invalid)); err == nil {
+			t.Fatal("ambiguous frontier accepted")
+		}
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatal(err)
+	}
+	delete(fields, "managed_evidence")
+	missing, _ := json.Marshal(fields)
+	if _, err := ParseRecoverySet(missing); err == nil {
+		t.Fatal("missing binding accepted")
+	}
+}
+
+func TestV2DigestBindsDescriptorAndIgnoresOrdering(t *testing.T) {
+	set := v2Set(t)
+	want, err := set.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	set.ClusterPoints[0], set.ClusterPoints[1] = set.ClusterPoints[1], set.ClusterPoints[0]
+	got, err := set.Digest()
+	if err != nil || got != want {
+		t.Fatalf("ordering changed digest: %v", err)
+	}
+	set.ManagedEvidence.DescriptorDigest = testDigest('d')
+	got, err = set.Digest()
+	if err != nil || got == want {
+		t.Fatalf("descriptor not bound: %v", err)
+	}
+}

--- a/internal/recoveryset/observation/manifest.go
+++ b/internal/recoveryset/observation/manifest.go
@@ -1,0 +1,415 @@
+package observation
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/flidai/leapview/internal/manageddata"
+	"github.com/flidai/leapview/pkg/strictjson"
+)
+
+// Validate checks the complete captured contract. In particular, it verifies
+// that the provider observations form a bijection with the files in the
+// ready-revision inventory. It does not contact a provider and does not make
+// an authenticity or recovery-frontier claim.
+func (m Manifest) Validate() error {
+	if m.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: unsupported manifest schema version %d", ErrInvalid, m.SchemaVersion)
+	}
+	if err := m.Boundary.Validate(); err != nil {
+		return err
+	}
+	if err := m.Inventory.Validate(); err != nil {
+		return err
+	}
+	inventoryDigest, err := m.Inventory.Digest()
+	if err != nil {
+		return err
+	}
+	if m.Boundary.InventoryDigest != inventoryDigest {
+		return fmt.Errorf("%w: boundary inventory digest does not match inventory", ErrInvalid)
+	}
+	if m.Objects == nil {
+		return fmt.Errorf("%w: manifest objects must be an explicit array", ErrInvalid)
+	}
+	if len(m.Objects) > MaxManifestObjects {
+		return fmt.Errorf("%w: provider observation count exceeds limit %d", ErrInvalid, MaxManifestObjects)
+	}
+
+	files := make(map[string]File)
+	for _, revision := range m.Inventory.Revisions {
+		for _, file := range revision.Files {
+			files[observationKey(revision.RevisionID, file.Path)] = file
+		}
+	}
+	observed := make(map[string]struct{}, len(m.Objects))
+	providerObjects := make(map[string]providerObservation, len(m.Objects))
+	for index, observation := range m.Objects {
+		if err := observation.Validate(); err != nil {
+			return fmt.Errorf("%w: observation %d: %v", ErrInvalid, index, err)
+		}
+		key := observationKey(observation.RevisionID, observation.Path)
+		if _, duplicate := observed[key]; duplicate {
+			return fmt.Errorf("%w: duplicate observation for revision %q path %q", ErrInvalid, observation.RevisionID, observation.Path)
+		}
+		observed[key] = struct{}{}
+		file, exists := files[key]
+		if !exists {
+			return fmt.Errorf("%w: observation %q/%q has no inventory file", ErrInvalid, observation.RevisionID, observation.Path)
+		}
+		bucket, objectKey, err := storageKeyParts(file.StorageKey)
+		if err != nil {
+			return err
+		}
+		object := observation.Object
+		if object.Bucket != bucket || object.Key != objectKey {
+			return fmt.Errorf("%w: observation %q/%q does not match storage key", ErrInvalid, observation.RevisionID, observation.Path)
+		}
+		if object.SHA256 != file.SHA256 {
+			return fmt.Errorf("%w: observation %q/%q hash does not match inventory", ErrInvalid, observation.RevisionID, observation.Path)
+		}
+		if object.Size != file.Size {
+			return fmt.Errorf("%w: observation %q/%q size does not match inventory", ErrInvalid, observation.RevisionID, observation.Path)
+		}
+		providerKey := providerObjectIdentity(object)
+		if previous, exists := providerObjects[providerKey]; exists && (previous.SHA256 != object.SHA256 || previous.Size != object.Size) {
+			return fmt.Errorf("%w: provider object %q is observed with conflicting bytes", ErrInvalid, providerKey)
+		}
+		providerObjects[providerKey] = providerObservation{SHA256: object.SHA256, Size: object.Size}
+	}
+	if len(observed) != len(files) {
+		return fmt.Errorf("%w: inventory has %d files but manifest has %d observations", ErrInvalid, len(files), len(observed))
+	}
+	missing := make([]string, 0)
+	for key := range files {
+		if _, exists := observed[key]; !exists {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("%w: inventory file %q has no provider observation", ErrInvalid, missing[0])
+	}
+	return nil
+}
+
+// Normalize returns a copy in canonical ordering. Duplicate identities are
+// rejected by Validate before any sorting occurs.
+func (m Manifest) Normalize() (Manifest, error) {
+	if err := m.Validate(); err != nil {
+		return Manifest{}, err
+	}
+	normalized := m
+	boundary, err := m.Boundary.normalize()
+	if err != nil {
+		return Manifest{}, err
+	}
+	normalized.Boundary = boundary
+	inventory, err := m.Inventory.Normalize()
+	if err != nil {
+		return Manifest{}, err
+	}
+	normalized.Inventory = inventory
+	normalized.Objects = make([]Observation, len(m.Objects))
+	copy(normalized.Objects, m.Objects)
+	sort.Slice(normalized.Objects, func(i, j int) bool {
+		left, right := normalized.Objects[i], normalized.Objects[j]
+		if left.RevisionID != right.RevisionID {
+			return left.RevisionID < right.RevisionID
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		return providerObjectKey(left.Object) < providerObjectKey(right.Object)
+	})
+	return normalized, nil
+}
+
+func (i Inventory) Validate() error {
+	if i.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: unsupported inventory schema version %d", ErrInvalid, i.SchemaVersion)
+	}
+	if i.Revisions == nil {
+		return fmt.Errorf("%w: inventory revisions must be an explicit array", ErrInvalid)
+	}
+	if len(i.Revisions) > MaxInventoryRevisions {
+		return fmt.Errorf("%w: revision count exceeds limit %d", ErrInvalid, MaxInventoryRevisions)
+	}
+	seen := make(map[string]struct{}, len(i.Revisions))
+	for index, revision := range i.Revisions {
+		if _, duplicate := seen[revision.RevisionID]; duplicate {
+			return fmt.Errorf("%w: duplicate revision ID %q", ErrInvalid, revision.RevisionID)
+		}
+		seen[revision.RevisionID] = struct{}{}
+		if err := revision.Validate(); err != nil {
+			return fmt.Errorf("%w: revision %d: %v", ErrInvalid, index, err)
+		}
+	}
+	return nil
+}
+
+func (i Inventory) Normalize() (Inventory, error) {
+	if err := i.Validate(); err != nil {
+		return Inventory{}, err
+	}
+	normalized := Inventory{SchemaVersion: i.SchemaVersion, Revisions: make([]Revision, len(i.Revisions))}
+	for index, revision := range i.Revisions {
+		normalized.Revisions[index] = revision
+		normalized.Revisions[index].Files = make([]File, len(revision.Files))
+		copy(normalized.Revisions[index].Files, revision.Files)
+		sort.Slice(normalized.Revisions[index].Files, func(left, right int) bool {
+			return normalized.Revisions[index].Files[left].Path < normalized.Revisions[index].Files[right].Path
+		})
+	}
+	sort.Slice(normalized.Revisions, func(left, right int) bool {
+		return normalized.Revisions[left].RevisionID < normalized.Revisions[right].RevisionID
+	})
+	return normalized, nil
+}
+
+func (i Inventory) CanonicalJSON() ([]byte, error) {
+	normalized, err := i.Normalize()
+	if err != nil {
+		return nil, err
+	}
+	return marshalBounded(normalized)
+}
+
+func (i Inventory) Digest() (string, error) {
+	canonical, err := i.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return sha256Digest(canonical), nil
+}
+
+func (r Revision) Validate() error {
+	if _, err := manageddata.ParseRevisionID(r.RevisionID); err != nil {
+		return fmt.Errorf("%w: revision ID: %v", ErrInvalid, err)
+	}
+	if err := validateDigest(r.ManifestDigest, "revision manifest digest"); err != nil {
+		return err
+	}
+	if r.Files == nil {
+		return fmt.Errorf("%w: revision %q files must be an explicit array", ErrInvalid, r.RevisionID)
+	}
+	if len(r.Files) > MaxRevisionFiles {
+		return fmt.Errorf("%w: revision %q file count exceeds limit %d", ErrInvalid, r.RevisionID, MaxRevisionFiles)
+	}
+	exactSeen := make(map[string]struct{}, len(r.Files))
+	foldedSeen := make(map[string]struct{}, len(r.Files))
+	managedFiles := make([]manageddata.File, 0, len(r.Files))
+	for index, file := range r.Files {
+		if _, duplicate := exactSeen[file.Path]; duplicate {
+			return fmt.Errorf("%w: revision %q has duplicate file path %q", ErrInvalid, r.RevisionID, file.Path)
+		}
+		folded := strings.ToLower(file.Path)
+		if _, duplicate := foldedSeen[folded]; duplicate {
+			return fmt.Errorf("%w: revision %q has case-folded file path collision at %q", ErrInvalid, r.RevisionID, file.Path)
+		}
+		exactSeen[file.Path] = struct{}{}
+		foldedSeen[folded] = struct{}{}
+		if _, err := canonicalText(file.Path, "revision file path", 1024); err != nil {
+			return fmt.Errorf("%w: revision %q file %d: %v", ErrInvalid, r.RevisionID, index, err)
+		}
+		if err := validateRawHash(file.SHA256, "revision file SHA-256"); err != nil {
+			return err
+		}
+		if _, err := canonicalText(file.StorageKey, "revision file storage key", 2048); err != nil {
+			return err
+		}
+		if _, _, err := storageKeyParts(file.StorageKey); err != nil {
+			return err
+		}
+		if file.Size < 0 {
+			return fmt.Errorf("%w: revision file size must be nonnegative", ErrInvalid)
+		}
+		managedFiles = append(managedFiles, manageddata.File{Path: file.Path, SHA256: file.SHA256, Size: file.Size})
+	}
+	managedManifest := manageddata.Manifest{Files: managedFiles}
+	if err := managedManifest.Validate(manageddata.Limits{MaxFiles: MaxRevisionFiles}); err != nil {
+		return fmt.Errorf("%w: revision manifest: %v", ErrInvalid, err)
+	}
+	if managedManifest.RevisionID() != r.ManifestDigest {
+		return fmt.Errorf("%w: revision %q manifest digest does not match files", ErrInvalid, r.RevisionID)
+	}
+	return nil
+}
+
+func (r Revision) Normalize() (Revision, error) {
+	if err := r.Validate(); err != nil {
+		return Revision{}, err
+	}
+	normalized := r
+	normalized.Files = make([]File, len(r.Files))
+	copy(normalized.Files, r.Files)
+	sort.Slice(normalized.Files, func(left, right int) bool {
+		return normalized.Files[left].Path < normalized.Files[right].Path
+	})
+	return normalized, nil
+}
+
+func (f File) Validate() error {
+	if _, err := canonicalText(f.Path, "file path", 1024); err != nil {
+		return err
+	}
+	if err := validateRawHash(f.SHA256, "file SHA-256"); err != nil {
+		return err
+	}
+	if _, err := canonicalText(f.StorageKey, "file storage key", 2048); err != nil {
+		return err
+	}
+	if _, _, err := storageKeyParts(f.StorageKey); err != nil {
+		return err
+	}
+	if f.Size < 0 {
+		return fmt.Errorf("%w: file size must be nonnegative", ErrInvalid)
+	}
+	return nil
+}
+
+// Parse strictly decodes one bounded observation manifest and validates all
+// cross-object identities before returning it.
+func Parse(raw []byte) (Manifest, error) {
+	if len(raw) < 2 || len(raw) > MaxManifestBytes {
+		return Manifest{}, fmt.Errorf("%w: manifest JSON is out of bounds", ErrInvalid)
+	}
+	var manifest Manifest
+	if err := strictjson.DecodeWithOptions(raw, &manifest, strictjson.Options{
+		MaxBytes: MaxManifestBytes, MaxDepth: 32,
+		DuplicateKeys: strictjson.CaseFoldedKeys, AllowUnknownFields: false,
+	}); err != nil {
+		return Manifest{}, fmt.Errorf("%w: decode manifest: %v", ErrInvalid, err)
+	}
+	if err := requireExactJSONShape(raw, manifest); err != nil {
+		return Manifest{}, err
+	}
+	if err := manifest.Validate(); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+// ParseManifest is an explicit alias for callers that prefer a type-specific
+// parser name.
+func ParseManifest(raw []byte) (Manifest, error) { return Parse(raw) }
+
+func (m Manifest) CanonicalJSON() ([]byte, error) {
+	normalized, err := m.Normalize()
+	if err != nil {
+		return nil, err
+	}
+	return marshalBounded(normalized)
+}
+
+func (m Manifest) Digest() (string, error) {
+	canonical, err := m.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return sha256Digest(canonical), nil
+}
+
+func observationKey(revisionID, path string) string { return revisionID + "\x00" + path }
+
+func providerObjectKey(object ProviderObject) string {
+	return object.Endpoint + "\x00" + object.Region + "\x00" + object.Bucket + "\x00" + object.Key + "\x00" + object.VersionID + "\x00" + object.SHA256 + fmt.Sprintf("\x00%d", object.Size)
+}
+
+type providerObservation struct {
+	SHA256 string
+	Size   int64
+}
+
+func providerObjectIdentity(object ProviderObject) string {
+	return object.Endpoint + "\x00" + object.Region + "\x00" + object.Bucket + "\x00" + object.Key + "\x00" + object.VersionID
+}
+
+func storageKeyParts(value string) (string, string, error) {
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme != "s3" || u.User != nil || u.Host == "" || u.Path == "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return "", "", fmt.Errorf("%w: storage key must be a credential-free s3 URI", ErrInvalid)
+	}
+	if u.RawPath != "" {
+		return "", "", fmt.Errorf("%w: storage key must use canonical path encoding", ErrInvalid)
+	}
+	bucket := u.Host
+	objectKey := strings.TrimPrefix(u.Path, "/")
+	if objectKey == "" {
+		return "", "", fmt.Errorf("%w: storage key must include an object key", ErrInvalid)
+	}
+	if _, err := canonicalName(bucket, "storage bucket"); err != nil {
+		return "", "", err
+	}
+	if _, err := canonicalText(objectKey, "storage object key", 1024); err != nil {
+		return "", "", err
+	}
+	return bucket, objectKey, nil
+}
+
+func marshalBounded(value any) ([]byte, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	if len(encoded) > MaxManifestBytes {
+		return nil, fmt.Errorf("%w: canonical JSON exceeds %d bytes", ErrInvalid, MaxManifestBytes)
+	}
+	return encoded, nil
+}
+
+// requireExactJSONShape prevents encoding/json's case-insensitive field
+// matching and zero-value behavior from turning omitted, aliased, or null
+// fields into an apparently valid contract. Values are intentionally ignored:
+// semantic validation remains the responsibility of the typed Validate calls.
+func requireExactJSONShape(raw []byte, decoded any) error {
+	var supplied, expected any
+	if err := json.Unmarshal(raw, &supplied); err != nil {
+		return fmt.Errorf("%w: malformed JSON shape: %v", ErrInvalid, err)
+	}
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		return fmt.Errorf("%w: marshal JSON shape: %v", ErrInvalid, err)
+	}
+	if err := json.Unmarshal(encoded, &expected); err != nil {
+		return fmt.Errorf("%w: decode JSON shape: %v", ErrInvalid, err)
+	}
+	if !sameJSONShape(supplied, expected) {
+		return fmt.Errorf("%w: JSON fields do not match the exact observation schema", ErrInvalid)
+	}
+	return nil
+}
+
+func sameJSONShape(supplied, expected any) bool {
+	switch value := expected.(type) {
+	case map[string]any:
+		got, ok := supplied.(map[string]any)
+		if !ok || len(got) != len(value) {
+			return false
+		}
+		for key, child := range value {
+			actual, exists := got[key]
+			if !exists || !sameJSONShape(actual, child) {
+				return false
+			}
+		}
+	case []any:
+		got, ok := supplied.([]any)
+		if !ok || len(got) != len(value) {
+			return false
+		}
+		for index, child := range value {
+			if !sameJSONShape(got[index], child) {
+				return false
+			}
+		}
+	default:
+		if (expected == nil) != (supplied == nil) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/recoveryset/observation/manifest_test.go
+++ b/internal/recoveryset/observation/manifest_test.go
@@ -1,0 +1,316 @@
+package observation
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/manageddata"
+)
+
+func testManifest(t *testing.T) Manifest {
+	t.Helper()
+	files := []File{
+		{Path: "orders.csv", SHA256: strings.Repeat("a", 64), StorageKey: "s3://bucket-a/data/orders.csv", Size: 3},
+		{Path: "customers.csv", SHA256: strings.Repeat("b", 64), StorageKey: "s3://bucket-a/data/customers.csv", Size: 5},
+	}
+	managedManifest := manageddata.Manifest{Files: []manageddata.File{
+		{Path: files[0].Path, SHA256: files[0].SHA256, Size: files[0].Size},
+		{Path: files[1].Path, SHA256: files[1].SHA256, Size: files[1].Size},
+	}}
+	revision := Revision{
+		RevisionID:     "revision-2026-09-08",
+		ManifestDigest: managedManifest.RevisionID(),
+		Files:          files,
+	}
+	inventory := Inventory{SchemaVersion: SchemaVersion, Revisions: []Revision{revision}}
+	inventoryDigest, err := inventory.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := Manifest{
+		SchemaVersion: SchemaVersion,
+		Boundary: Boundary{
+			ProtocolVersion: ProtocolVersion, DatabaseIdentity: "control_db", SystemIdentity: "12345",
+			Timeline: 7, LSN: "0/16B6C50", RestorePointName: "restore_orders", InventoryDigest: inventoryDigest,
+		},
+		Inventory: inventory,
+		Objects: []Observation{
+			{RevisionID: revision.RevisionID, Path: files[0].Path, Object: ProviderObject{
+				Endpoint: "http://127.0.0.1:9000", Region: "us-east-1", Bucket: "bucket-a", Key: "data/orders.csv",
+				VersionID: "version-orders", SHA256: files[0].SHA256, Size: files[0].Size,
+			}},
+			{RevisionID: revision.RevisionID, Path: files[1].Path, Object: ProviderObject{
+				Endpoint: "http://127.0.0.1:9000", Region: "us-east-1", Bucket: "bucket-a", Key: "data/customers.csv",
+				VersionID: "version-customers", SHA256: files[1].SHA256, Size: files[1].Size,
+			}},
+		},
+	}
+	return manifest
+}
+
+func cloneManifest(manifest Manifest) Manifest {
+	clone := manifest
+	clone.Inventory.Revisions = make([]Revision, len(manifest.Inventory.Revisions))
+	for index, revision := range manifest.Inventory.Revisions {
+		clone.Inventory.Revisions[index] = revision
+		clone.Inventory.Revisions[index].Files = make([]File, len(revision.Files))
+		copy(clone.Inventory.Revisions[index].Files, revision.Files)
+	}
+	clone.Objects = make([]Observation, len(manifest.Objects))
+	copy(clone.Objects, manifest.Objects)
+	return clone
+}
+
+func reverse[T any](values []T) {
+	for left, right := 0, len(values)-1; left < right; left, right = left+1, right-1 {
+		values[left], values[right] = values[right], values[left]
+	}
+}
+
+func TestManifestCanonicalJSONIsOrderIndependent(t *testing.T) {
+	first := testManifest(t)
+	second := cloneManifest(first)
+	reverse(second.Inventory.Revisions[0].Files)
+	reverse(second.Objects)
+	firstJSON, err := first.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondJSON, err := second.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(firstJSON, secondJSON) {
+		t.Fatalf("canonical JSON differs:\n%s\n%s", firstJSON, secondJSON)
+	}
+	firstDigest, err := first.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondDigest, err := second.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstDigest != secondDigest || !strings.HasPrefix(firstDigest, "sha256:") {
+		t.Fatalf("digests differ or are not canonical: %q %q", firstDigest, secondDigest)
+	}
+	if !strings.Contains(string(firstJSON), `"schema_version"`) || strings.Contains(string(firstJSON), `"storageKey"`) {
+		t.Fatalf("JSON does not use the explicit snake_case contract: %s", firstJSON)
+	}
+}
+
+func TestManifestStrictParseAndRequiredArrays(t *testing.T) {
+	manifest := testManifest(t)
+	canonical, err := manifest.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := Parse(canonical)
+	if err != nil {
+		t.Fatalf("Parse(canonical) error: %v", err)
+	}
+	parsedDigest, err := parsed.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDigest, err := manifest.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsedDigest != manifestDigest {
+		t.Fatalf("parsed manifest digest = %q, source = %q", parsedDigest, manifestDigest)
+	}
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "unknown field", raw: appendJSONField(canonical, `"unknown":true`)},
+		{name: "duplicate field", raw: []byte(`{"schema_version":1,"schema_version":1}`)},
+		{name: "missing fields", raw: []byte(`{}`)},
+		{name: "oversized", raw: bytes.Repeat([]byte("x"), MaxManifestBytes+1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Parse(tc.raw); err == nil {
+				t.Fatalf("Parse accepted invalid %s", tc.name)
+			}
+		})
+	}
+	zero := testManifest(t)
+	zero.Inventory.Revisions[0].Files[0].Size = 0
+	zero.Objects[0].Object.Size = 0
+	zeroManaged := manageddata.Manifest{Files: []manageddata.File{
+		{Path: zero.Inventory.Revisions[0].Files[0].Path, SHA256: zero.Inventory.Revisions[0].Files[0].SHA256, Size: zero.Inventory.Revisions[0].Files[0].Size},
+		{Path: zero.Inventory.Revisions[0].Files[1].Path, SHA256: zero.Inventory.Revisions[0].Files[1].SHA256, Size: zero.Inventory.Revisions[0].Files[1].Size},
+	}}
+	zero.Inventory.Revisions[0].ManifestDigest = zeroManaged.RevisionID()
+	zero.Boundary.InventoryDigest, err = zero.Inventory.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	zeroJSON, err := zero.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingZeroSize := bytes.Replace(zeroJSON, []byte(`,"size":0`), nil, 1)
+	if _, err := Parse(missingZeroSize); err == nil {
+		t.Fatal("Parse accepted an omitted zero-valued size field")
+	}
+	caseAlias := bytes.Replace(canonical, []byte(`"schema_version"`), []byte(`"SCHEMA_VERSION"`), 1)
+	if _, err := Parse(caseAlias); err == nil {
+		t.Fatal("Parse accepted a case-aliased schema field")
+	}
+	nullScalar := bytes.Replace(canonical, []byte(`"size":3`), []byte(`"size":null`), 1)
+	if _, err := Parse(nullScalar); err == nil {
+		t.Fatal("Parse accepted a null scalar field")
+	}
+	unknownNested := bytes.Replace(canonical, []byte(`"version_id":"version-customers"`), []byte(`"version_id":"version-customers","unknown_nested":true`), 1)
+	if _, err := Parse(unknownNested); err == nil {
+		t.Fatal("Parse accepted an unknown nested field")
+	}
+	empty := testManifest(t)
+	empty.Inventory.Revisions = []Revision{}
+	empty.Objects = []Observation{}
+	digest, err := empty.Inventory.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	empty.Boundary.InventoryDigest = digest
+	emptyJSON, err := empty.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(emptyJSON), `"revisions":[]`) || !strings.Contains(string(emptyJSON), `"objects":[]`) {
+		t.Fatalf("empty arrays were not canonicalized as arrays: %s", emptyJSON)
+	}
+	if _, err := Parse(emptyJSON); err != nil {
+		t.Fatalf("Parse(explicit empty arrays) error: %v", err)
+	}
+	empty.Inventory.Revisions = nil
+	if err := empty.Validate(); err == nil {
+		t.Fatal("Validate accepted omitted inventory revisions")
+	}
+	boundaryJSON, err := manifest.Boundary.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundaryCases := [][]byte{
+		[]byte(`{"protocol_version":1,"database_identity":"db","system_identity":"1","lsn":"0/1","restore_point_name":"rp","inventory_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`),
+		[]byte(`{"PROTOCOL_VERSION":1,"database_identity":"db","system_identity":"1","timeline":1,"lsn":"0/1","restore_point_name":"rp","inventory_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`),
+		[]byte(`{"protocol_version":1,"database_identity":"db","system_identity":"1","timeline":1,"lsn":"0/1","restore_point_name":"rp","inventory_digest":null}`),
+	}
+	for index, invalidBoundary := range boundaryCases {
+		if _, err := ParseBoundary(invalidBoundary); err == nil {
+			t.Fatalf("ParseBoundary accepted invalid boundary case %d", index)
+		}
+	}
+	if _, err := ParseBoundary(boundaryJSON); err != nil {
+		t.Fatalf("ParseBoundary(canonical) error: %v", err)
+	}
+}
+
+func appendJSONField(raw []byte, field string) []byte {
+	result := append([]byte(nil), raw...)
+	result[len(result)-1] = ','
+	result = append(result, []byte(field+"}")...)
+	return result
+}
+
+func TestManifestValidationRejectsBrokenBijectionAndConflicts(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Manifest)
+		want   string
+	}{
+		{name: "missing observation", mutate: func(m *Manifest) { m.Objects = m.Objects[:1] }, want: "inventory has"},
+		{name: "wrong hash", mutate: func(m *Manifest) { m.Objects[0].Object.SHA256 = strings.Repeat("c", 64) }, want: "hash does not match"},
+		{name: "wrong storage key", mutate: func(m *Manifest) { m.Objects[0].Object.Key = "other.csv" }, want: "storage key"},
+		{name: "duplicate observation", mutate: func(m *Manifest) { m.Objects = append(m.Objects, m.Objects[0]) }, want: "duplicate observation"},
+		{name: "unknown inventory member", mutate: func(m *Manifest) { m.Objects[0].Path = "missing.csv" }, want: "no inventory file"},
+		{name: "version omitted", mutate: func(m *Manifest) { m.Objects[0].Object.VersionID = "" }, want: "version ID"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := testManifest(t)
+			tc.mutate(&manifest)
+			err := manifest.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+	conflicting := testManifest(t)
+	conflicting.Inventory.Revisions[0].Files[1].StorageKey = conflicting.Inventory.Revisions[0].Files[0].StorageKey
+	conflicting.Inventory.Revisions[0].Files[1].SHA256 = strings.Repeat("c", 64)
+	conflicting.Inventory.Revisions[0].Files[1].Size = 9
+	managedManifest := manageddata.Manifest{Files: []manageddata.File{
+		{Path: conflicting.Inventory.Revisions[0].Files[0].Path, SHA256: conflicting.Inventory.Revisions[0].Files[0].SHA256, Size: conflicting.Inventory.Revisions[0].Files[0].Size},
+		{Path: conflicting.Inventory.Revisions[0].Files[1].Path, SHA256: conflicting.Inventory.Revisions[0].Files[1].SHA256, Size: conflicting.Inventory.Revisions[0].Files[1].Size},
+	}}
+	conflicting.Inventory.Revisions[0].ManifestDigest = managedManifest.RevisionID()
+	digest, err := conflicting.Inventory.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflicting.Boundary.InventoryDigest = digest
+	conflicting.Objects[1].Object.Key = "data/orders.csv"
+	conflicting.Objects[1].Object.VersionID = conflicting.Objects[0].Object.VersionID
+	conflicting.Objects[1].Object.SHA256 = strings.Repeat("c", 64)
+	conflicting.Objects[1].Object.Size = 9
+	if err := conflicting.Validate(); err == nil || !strings.Contains(err.Error(), "conflicting bytes") {
+		t.Fatalf("conflicting provider object error = %v", err)
+	}
+}
+
+func TestBoundaryIdentityAndExactComparison(t *testing.T) {
+	manifest := testManifest(t)
+	boundary := manifest.Boundary
+	if got, want := boundary.RecoveryIdentity(), "postgres:12345:7:0/16B6C50:restore_orders"; got != want {
+		t.Fatalf("RecoveryIdentity() = %q, want %q", got, want)
+	}
+	if got, want := boundary.ClusterIdentity(), "postgres:12345"; got != want {
+		t.Fatalf("ClusterIdentity() = %q, want %q", got, want)
+	}
+	if !boundary.Matches(boundary) {
+		t.Fatal("boundary does not match itself")
+	}
+	changed := boundary
+	changed.LSN = "0/16B6C51"
+	if boundary.Matches(changed) || boundary.ValidateAgainst(changed) == nil {
+		t.Fatal("boundary comparison ignored changed LSN")
+	}
+	for _, invalid := range []Boundary{
+		{ProtocolVersion: ProtocolVersion, DatabaseIdentity: "db", SystemIdentity: "01", Timeline: 1, LSN: "0/1", RestorePointName: "rp", InventoryDigest: strings.Repeat("x", 71)},
+		{ProtocolVersion: ProtocolVersion, DatabaseIdentity: "db", SystemIdentity: "1", Timeline: 1, LSN: "0/0001", RestorePointName: "rp", InventoryDigest: strings.Repeat("x", 71)},
+	} {
+		if err := invalid.Validate(); err == nil {
+			t.Fatal("Validate accepted invalid boundary")
+		}
+	}
+}
+
+func TestProviderEndpointVersionAndRetention(t *testing.T) {
+	manifest := testManifest(t)
+	object := manifest.Objects[0].Object
+	for _, endpoint := range []string{"http://example.invalid", "https://user:secret@example.invalid", "https://example.invalid/path"} {
+		invalid := object
+		invalid.Endpoint = endpoint
+		if err := invalid.Validate(); err == nil {
+			t.Fatalf("ProviderObject accepted endpoint %q", endpoint)
+		}
+	}
+	invalid := object
+	invalid.VersionID = "null"
+	if err := invalid.Validate(); err == nil {
+		t.Fatal("ProviderObject accepted null version ID")
+	}
+	protection := Protection{Object: object, Mode: "legal_hold", RetainUntil: time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)}
+	if err := protection.ValidateAt(time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatal(err)
+	}
+	if err := protection.ValidateAt(time.Date(2026, 9, 11, 0, 0, 0, 0, time.UTC)); err == nil {
+		t.Fatal("ValidateAt accepted an expired retention deadline")
+	}
+}

--- a/internal/recoveryset/observation/types.go
+++ b/internal/recoveryset/observation/types.go
@@ -1,0 +1,409 @@
+// Package observation defines the provider-observation contract used by
+// recovery qualification. It is deliberately separate from recovery-set
+// admission and activation: a manifest records captured evidence, but does
+// not authenticate a provider or publish a recovery frontier.
+package observation
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/flidai/leapview/internal/manageddata"
+	"github.com/flidai/leapview/pkg/strictjson"
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	ProtocolVersion int32 = 1
+	SchemaVersion   int32 = 1
+	// Keep the document bounded while allowing the declared inventory/object
+	// limits to be represented without truncation.
+	MaxManifestBytes      = 8 << 20
+	MaxInventoryRevisions = 4096
+	MaxRevisionFiles      = 4096
+	MaxManifestObjects    = 16384
+)
+
+var (
+	ErrInvalid = errors.New("provider observation manifest is invalid")
+
+	namePattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+	lsnPattern     = regexp.MustCompile(`^[0-9A-F]+/[0-9A-F]+$`)
+	digestPattern  = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	rawHashPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+// Boundary identifies the captured PostgreSQL recovery point and the
+// inventory digest it was observed against. Trusted capture produces it;
+// parsed fields are not an authenticity proof by themselves.
+type Boundary struct {
+	ProtocolVersion  int32  `json:"protocol_version"`
+	DatabaseIdentity string `json:"database_identity"`
+	SystemIdentity   string `json:"system_identity"`
+	Timeline         uint32 `json:"timeline"`
+	LSN              string `json:"lsn"`
+	RestorePointName string `json:"restore_point_name"`
+	InventoryDigest  string `json:"inventory_digest"`
+}
+
+// Inventory is the immutable, ready-revision metadata captured alongside a
+// provider observation. Revision and file ordering is canonicalized only
+// after duplicate identities have been rejected.
+type Inventory struct {
+	SchemaVersion int32      `json:"schema_version"`
+	Revisions     []Revision `json:"revisions"`
+}
+
+type Revision struct {
+	RevisionID     string `json:"revision_id"`
+	ManifestDigest string `json:"manifest_digest"`
+	Files          []File `json:"files"`
+}
+
+type File struct {
+	Path       string `json:"path"`
+	SHA256     string `json:"sha256"`
+	StorageKey string `json:"storage_key"`
+	Size       int64  `json:"size"`
+}
+
+// ProviderObject is the exact provider object identity and byte observation.
+// SHA256 is the raw lowercase file hash, matching manageddata.File.
+type ProviderObject struct {
+	Endpoint  string `json:"endpoint"`
+	Region    string `json:"region"`
+	Bucket    string `json:"bucket"`
+	Key       string `json:"key"`
+	VersionID string `json:"version_id"`
+	SHA256    string `json:"sha256"`
+	Size      int64  `json:"size"`
+}
+
+type Observation struct {
+	RevisionID string         `json:"revision_id"`
+	Path       string         `json:"path"`
+	Object     ProviderObject `json:"object"`
+}
+
+type Manifest struct {
+	SchemaVersion int32         `json:"schema_version"`
+	Boundary      Boundary      `json:"boundary"`
+	Inventory     Inventory     `json:"inventory"`
+	Objects       []Observation `json:"objects"`
+}
+
+// Protection records retention compliance for one exact provider object. It
+// does not retain an object or establish a recovery frontier.
+type Protection struct {
+	Object      ProviderObject `json:"object"`
+	Mode        string         `json:"mode"`
+	RetainUntil time.Time      `json:"retain_until"`
+}
+
+func canonicalText(value, label string, max int) (string, error) {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > max {
+		return "", fmt.Errorf("%w: %s must be nonempty and canonical", ErrInvalid, label)
+	}
+	if !utf8.ValidString(value) {
+		return "", fmt.Errorf("%w: %s is not valid UTF-8", ErrInvalid, label)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return "", fmt.Errorf("%w: %s contains control character U+%04X", ErrInvalid, label, r)
+		}
+	}
+	if norm.NFC.String(value) != value {
+		return "", fmt.Errorf("%w: %s is not NFC-normalized", ErrInvalid, label)
+	}
+	return value, nil
+}
+
+func canonicalName(value, label string) (string, error) {
+	value, err := canonicalText(value, label, 255)
+	if err != nil {
+		return "", err
+	}
+	if !namePattern.MatchString(value) {
+		return "", fmt.Errorf("%w: %s has invalid name grammar", ErrInvalid, label)
+	}
+	return value, nil
+}
+
+func validateDigest(value, label string) error {
+	if !digestPattern.MatchString(value) {
+		return fmt.Errorf("%w: %s must be a canonical sha256 identity", ErrInvalid, label)
+	}
+	return nil
+}
+
+func validateRawHash(value, label string) error {
+	if !rawHashPattern.MatchString(value) {
+		return fmt.Errorf("%w: %s must be 64 lowercase hexadecimal characters", ErrInvalid, label)
+	}
+	return nil
+}
+
+func (b Boundary) Validate() error {
+	if b.ProtocolVersion != ProtocolVersion {
+		return fmt.Errorf("%w: unsupported boundary protocol version %d", ErrInvalid, b.ProtocolVersion)
+	}
+	if _, err := canonicalName(b.DatabaseIdentity, "database identity"); err != nil {
+		return err
+	}
+	if err := validateSystemIdentity(b.SystemIdentity); err != nil {
+		return err
+	}
+	if b.Timeline == 0 {
+		return fmt.Errorf("%w: boundary timeline must be positive", ErrInvalid)
+	}
+	if err := validateLSN(b.LSN); err != nil {
+		return err
+	}
+	if _, err := canonicalName(b.RestorePointName, "restore point name"); err != nil {
+		return err
+	}
+	return validateDigest(b.InventoryDigest, "boundary inventory digest")
+}
+
+func (b Boundary) normalize() (Boundary, error) {
+	if err := b.Validate(); err != nil {
+		return Boundary{}, err
+	}
+	var err error
+	if b.DatabaseIdentity, err = canonicalName(b.DatabaseIdentity, "database identity"); err != nil {
+		return Boundary{}, err
+	}
+	if b.SystemIdentity, err = canonicalSystemIdentity(b.SystemIdentity); err != nil {
+		return Boundary{}, err
+	}
+	if b.RestorePointName, err = canonicalName(b.RestorePointName, "restore point name"); err != nil {
+		return Boundary{}, err
+	}
+	return b, nil
+}
+
+// RecoveryIdentity is a stable, human-readable identity for this captured
+// PostgreSQL point. It is meaningful only after Boundary.Validate succeeds.
+func (b Boundary) RecoveryIdentity() string {
+	normalized, err := b.normalize()
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("postgres:%s:%d:%s:%s", normalized.SystemIdentity, normalized.Timeline, normalized.LSN, normalized.RestorePointName)
+}
+
+// ClusterIdentity identifies the PostgreSQL system independently of a point.
+func (b Boundary) ClusterIdentity() string {
+	normalized, err := b.normalize()
+	if err != nil {
+		return ""
+	}
+	return "postgres:" + normalized.SystemIdentity
+}
+
+func (b Boundary) Matches(expected Boundary) bool {
+	actual, actualErr := b.normalize()
+	want, expectedErr := expected.normalize()
+	return actualErr == nil && expectedErr == nil && actual == want
+}
+
+func (b Boundary) ValidateAgainst(expected Boundary) error {
+	actual, err := b.normalize()
+	if err != nil {
+		return err
+	}
+	want, err := expected.normalize()
+	if err != nil {
+		return err
+	}
+	if actual != want {
+		return fmt.Errorf("%w: boundary does not match expected recovery point", ErrInvalid)
+	}
+	return nil
+}
+
+func (b Boundary) CanonicalJSON() ([]byte, error) {
+	normalized, err := b.normalize()
+	if err != nil {
+		return nil, err
+	}
+	return marshalBounded(normalized)
+}
+
+func (b Boundary) Digest() (string, error) {
+	canonical, err := b.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return sha256Digest(canonical), nil
+}
+
+func ParseBoundary(raw []byte) (Boundary, error) {
+	if len(raw) < 2 || len(raw) > MaxManifestBytes {
+		return Boundary{}, fmt.Errorf("%w: boundary JSON is out of bounds", ErrInvalid)
+	}
+	var boundary Boundary
+	if err := strictjson.DecodeWithOptions(raw, &boundary, strictjson.Options{MaxBytes: MaxManifestBytes, MaxDepth: 16, DuplicateKeys: strictjson.CaseFoldedKeys, AllowUnknownFields: false}); err != nil {
+		return Boundary{}, fmt.Errorf("%w: decode boundary: %v", ErrInvalid, err)
+	}
+	if err := requireExactJSONShape(raw, boundary); err != nil {
+		return Boundary{}, err
+	}
+	if err := boundary.Validate(); err != nil {
+		return Boundary{}, err
+	}
+	return boundary, nil
+}
+
+func (p ProviderObject) Validate() error {
+	if err := validateEndpoint(p.Endpoint); err != nil {
+		return err
+	}
+	if _, err := canonicalText(p.Region, "provider region", 128); err != nil {
+		return err
+	}
+	if _, err := canonicalName(p.Bucket, "provider bucket"); err != nil {
+		return err
+	}
+	if _, err := canonicalText(p.Key, "provider object key", 1024); err != nil {
+		return err
+	}
+	if p.VersionID == "" || p.VersionID != strings.TrimSpace(p.VersionID) || strings.EqualFold(p.VersionID, "null") {
+		return fmt.Errorf("%w: provider object version ID must be nonempty and non-null", ErrInvalid)
+	}
+	if !utf8.ValidString(p.VersionID) || norm.NFC.String(p.VersionID) != p.VersionID || strings.IndexFunc(p.VersionID, unicode.IsControl) >= 0 || len(p.VersionID) > 1024 {
+		return fmt.Errorf("%w: provider object version ID is not canonical", ErrInvalid)
+	}
+	if err := validateRawHash(p.SHA256, "provider object SHA-256"); err != nil {
+		return err
+	}
+	if p.Size < 0 {
+		return fmt.Errorf("%w: provider object size must be nonnegative", ErrInvalid)
+	}
+	return nil
+}
+
+func validateEndpoint(value string) error {
+	if value == "" || value != strings.TrimSpace(value) || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return fmt.Errorf("%w: provider endpoint must be nonempty and canonical", ErrInvalid)
+	}
+	if !utf8.ValidString(value) || norm.NFC.String(value) != value {
+		return fmt.Errorf("%w: provider endpoint must be NFC-normalized", ErrInvalid)
+	}
+	u, err := url.Parse(value)
+	if err != nil || value != u.String() || u.Scheme == "" || u.Scheme != strings.ToLower(u.Scheme) || u.Host == "" || u.Host != strings.ToLower(u.Host) || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.Path != "" {
+		return fmt.Errorf("%w: provider endpoint must not contain credentials, query, fragment, or path", ErrInvalid)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		return nil
+	case "http":
+		host := u.Hostname()
+		if strings.EqualFold(host, "localhost") {
+			return nil
+		}
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: provider endpoint must use HTTPS or loopback HTTP", ErrInvalid)
+}
+
+func (o Observation) Validate() error {
+	if _, err := manageddata.ParseRevisionID(o.RevisionID); err != nil {
+		return fmt.Errorf("%w: observation revision ID: %v", ErrInvalid, err)
+	}
+	if _, err := canonicalText(o.Path, "observation path", 1024); err != nil {
+		return err
+	}
+	return o.Object.Validate()
+}
+
+func (p Protection) Validate() error {
+	if err := p.Object.Validate(); err != nil {
+		return err
+	}
+	if _, err := canonicalName(p.Mode, "protection mode"); err != nil {
+		return err
+	}
+	if p.RetainUntil.IsZero() {
+		return fmt.Errorf("%w: protection retention deadline is required", ErrInvalid)
+	}
+	return nil
+}
+
+// ValidateAt checks only whether the exact captured object remains protected
+// through requiredUntil. It performs no provider I/O and makes no frontier
+// or authenticity claim.
+func (p Protection) ValidateAt(requiredUntil time.Time) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	if requiredUntil.IsZero() {
+		return fmt.Errorf("%w: required retention deadline is required", ErrInvalid)
+	}
+	if p.RetainUntil.Before(requiredUntil) {
+		return fmt.Errorf("%w: provider object protection expires before required deadline", ErrInvalid)
+	}
+	return nil
+}
+
+func sha256Digest(value []byte) string {
+	sum := sha256.Sum256(value)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func validateSystemIdentity(value string) error {
+	if _, err := canonicalSystemIdentity(value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func canonicalSystemIdentity(value string) (string, error) {
+	value, err := canonicalText(value, "system identity", 20)
+	if err != nil {
+		return "", err
+	}
+	if value == "0" || (value[0] != '0' && isDecimal(value)) {
+		if _, err := strconv.ParseUint(value, 10, 64); err == nil {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("%w: system identity must be a canonical uint64", ErrInvalid)
+}
+
+func isDecimal(value string) bool {
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func validateLSN(value string) error {
+	if !lsnPattern.MatchString(value) {
+		return fmt.Errorf("%w: boundary LSN is not canonical", ErrInvalid)
+	}
+	parts := strings.Split(value, "/")
+	for _, part := range parts {
+		if len(part) > 1 && part[0] == '0' {
+			return fmt.Errorf("%w: boundary LSN contains a leading zero", ErrInvalid)
+		}
+		if _, err := strconv.ParseUint(part, 16, 32); err != nil {
+			return fmt.Errorf("%w: boundary LSN component is out of range", ErrInvalid)
+		}
+	}
+	return nil
+}

--- a/internal/recoveryset/observationstore/descriptor.go
+++ b/internal/recoveryset/observationstore/descriptor.go
@@ -1,0 +1,57 @@
+package observationstore
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+	"github.com/flidai/leapview/pkg/strictjson"
+)
+
+func parseDescriptor(raw []byte) (Descriptor, error) {
+	if len(raw) < 2 || len(raw) > maxDescriptorBytes {
+		return Descriptor{}, fmt.Errorf("%w: descriptor bytes are out of bounds", ErrIntegrity)
+	}
+	var descriptor Descriptor
+	if err := strictjson.DecodeWithOptions(raw, &descriptor, strictjson.Options{MaxBytes: maxDescriptorBytes, MaxDepth: 32, DuplicateKeys: strictjson.CaseFoldedKeys, AllowUnknownFields: false}); err != nil {
+		return Descriptor{}, fmt.Errorf("%w: decode descriptor: %v", ErrIntegrity, err)
+	}
+	// Preserve the distinction between an explicit empty array and an omitted
+	// field used by encoding/json's zero value.
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return Descriptor{}, fmt.Errorf("%w: decode descriptor fields", ErrIntegrity)
+	}
+	if value, ok := fields["source_protections"]; !ok || bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+		return Descriptor{}, fmt.Errorf("%w: descriptor source protections must be an explicit array", ErrIntegrity)
+	}
+	if descriptor.SourceProtections == nil {
+		descriptor.SourceProtections = make([]observation.Protection, 0)
+	}
+	if err := descriptor.Validate(); err != nil {
+		return Descriptor{}, err
+	}
+	canonical, err := descriptor.CanonicalJSON()
+	if err != nil || !bytes.Equal(raw, canonical) {
+		return Descriptor{}, fmt.Errorf("%w: descriptor bytes are not canonical", ErrIntegrity)
+	}
+	return descriptor, nil
+}
+
+func (s *Store) evidencePrefix() string {
+	if s.prefix == "" {
+		return "recovery-observations"
+	}
+	return s.prefix + "/recovery-observations"
+}
+
+func (s *Store) evidenceKey(kind, digestValue string) string {
+	return s.evidencePrefix() + "/" + kind + "/sha256/" + rawDigest(digestValue)[:2] + "/" + rawDigest(digestValue)
+}
+
+func (s *Store) frontierKey(digestValue string) string {
+	return s.evidencePrefix() + "/frontiers/sha256/" + rawDigest(digestValue)[:2] + "/" + rawDigest(digestValue)
+}
+
+func (s *Store) setIDKey(id string) string { return s.evidencePrefix() + "/frontiers/set-id/" + id }

--- a/internal/recoveryset/observationstore/frontier.go
+++ b/internal/recoveryset/observationstore/frontier.go
@@ -1,0 +1,63 @@
+package observationstore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/flidai/leapview/internal/recoveryset"
+)
+
+// ReadFrontier verifies both immutable frontier keys and returns the exact
+// schema-2 recovery set.
+func (s *Store) ReadFrontier(ctx context.Context, ref FrontierRef, horizons ...time.Time) (recoveryset.RecoverySet, error) {
+	if err := validContext(ctx); err != nil {
+		return recoveryset.RecoverySet{}, err
+	}
+	ctx, cancel := s.operationContext(ctx)
+	defer cancel()
+	if ref.SchemaVersion != SchemaVersion || ref.SetID == "" || !digest(ref.Digest) || ref.Frontier.Validate() != nil || ref.SetIDObject.Validate() != nil || ref.Evidence.Validate() != nil {
+		return recoveryset.RecoverySet{}, fmt.Errorf("%w: invalid frontier reference", ErrInvalid)
+	}
+	now := s.now()
+	required := time.Time{}
+	if len(horizons) > 1 {
+		return recoveryset.RecoverySet{}, fmt.Errorf("%w: frontier reload accepts one required horizon", ErrInvalid)
+	}
+	if len(horizons) == 1 && !horizons[0].IsZero() {
+		required = ceilSecond(horizons[0].UTC())
+	}
+	if s.setIDKey(ref.SetID) != ref.SetIDObject.Key {
+		return recoveryset.RecoverySet{}, fmt.Errorf("%w: frontier set-ID key does not match set ID", ErrIntegrity)
+	}
+	if s.frontierKey(ref.Digest) != ref.Frontier.Key {
+		return recoveryset.RecoverySet{}, fmt.Errorf("%w: frontier content key does not match digest", ErrIntegrity)
+	}
+	loaded, err := s.Reload(ctx, ref.Evidence, required)
+	if err != nil {
+		return recoveryset.RecoverySet{}, err
+	}
+	if required.IsZero() {
+		required = loaded.Descriptor.RequiredRetainUntil
+	}
+	a, _, err := s.getEvidence(ctx, ref.Frontier, now, required)
+	if err != nil {
+		return recoveryset.RecoverySet{}, err
+	}
+	b, _, err := s.getEvidence(ctx, ref.SetIDObject, now, required)
+	if err != nil {
+		return recoveryset.RecoverySet{}, err
+	}
+	if !bytes.Equal(a, b) || normalizedDigest(a) != ref.Digest || ref.Frontier.SHA256 != rawDigest(ref.Digest) || ref.SetIDObject.SHA256 != rawDigest(ref.Digest) {
+		return recoveryset.RecoverySet{}, fmt.Errorf("%w: frontier object refs do not match", ErrIntegrity)
+	}
+	set, err := recoveryset.ParseRecoverySet(a)
+	if err != nil || set.ID != ref.SetID || set.SchemaVersion != recoveryset.EvidenceSchemaVersion {
+		return recoveryset.RecoverySet{}, fmt.Errorf("%w: parse persisted frontier", ErrIntegrity)
+	}
+	if set.ManagedEvidence == nil || set.ManagedEvidence.ManifestDigest != "sha256:"+ref.Evidence.Manifest.SHA256 || set.ManagedEvidence.BoundaryDigest != "sha256:"+ref.Evidence.Boundary.SHA256 || set.ManagedEvidence.DescriptorDigest != "sha256:"+ref.Evidence.Descriptor.SHA256 || !set.ManagedEvidence.Boundary.Matches(loaded.Boundary) {
+		return recoveryset.RecoverySet{}, fmt.Errorf("%w: frontier managed evidence does not match evidence reference", ErrIntegrity)
+	}
+	return set, nil
+}

--- a/internal/recoveryset/observationstore/frontier.go
+++ b/internal/recoveryset/observationstore/frontier.go
@@ -38,9 +38,9 @@ func (s *Store) ReadFrontier(ctx context.Context, ref FrontierRef, horizons ...t
 	if err != nil {
 		return recoveryset.RecoverySet{}, err
 	}
-	if required.IsZero() {
-		required = loaded.Descriptor.RequiredRetainUntil
-	}
+	// The descriptor's recorded horizon is authoritative; an optional
+	// shorter horizon must not weaken reads of either frontier object.
+	required = loaded.Descriptor.RequiredRetainUntil
 	a, _, err := s.getEvidence(ctx, ref.Frontier, now, required)
 	if err != nil {
 		return recoveryset.RecoverySet{}, err
@@ -58,6 +58,9 @@ func (s *Store) ReadFrontier(ctx context.Context, ref FrontierRef, horizons ...t
 	}
 	if set.ManagedEvidence == nil || set.ManagedEvidence.ManifestDigest != "sha256:"+ref.Evidence.Manifest.SHA256 || set.ManagedEvidence.BoundaryDigest != "sha256:"+ref.Evidence.Boundary.SHA256 || set.ManagedEvidence.DescriptorDigest != "sha256:"+ref.Evidence.Descriptor.SHA256 || !set.ManagedEvidence.Boundary.Matches(loaded.Boundary) {
 		return recoveryset.RecoverySet{}, fmt.Errorf("%w: frontier managed evidence does not match evidence reference", ErrIntegrity)
+	}
+	if !loaded.Descriptor.RequiredRetainUntil.After(s.now()) {
+		return recoveryset.RecoverySet{}, fmt.Errorf("%w: retention horizon elapsed during frontier read", ErrRetention)
 	}
 	return set, nil
 }

--- a/internal/recoveryset/observationstore/helpers.go
+++ b/internal/recoveryset/observationstore/helpers.go
@@ -1,0 +1,160 @@
+package observationstore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/aws/smithy-go"
+)
+
+func (s *Store) now() time.Time {
+	if s.clock != nil {
+		return s.clock().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (s *Store) operationContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	timeout := s.operationTimeout
+	if timeout <= 0 {
+		timeout = DefaultOperationTimeout
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func ceilSecond(value time.Time) time.Time {
+	value = value.UTC()
+	if value.Nanosecond() == 0 {
+		return value
+	}
+	return value.Truncate(time.Second).Add(time.Second)
+}
+
+func hashBody(body io.Reader, expectedSize int64) (int64, string, error) {
+	if expectedSize < 0 || expectedSize > DefaultMaxSourceBytes {
+		return 0, "", fmt.Errorf("%w: body size is outside bounds", ErrInvalid)
+	}
+	hash := sha256.New()
+	limited := io.LimitReader(body, expectedSize+1)
+	n, err := io.Copy(hash, limited)
+	if err != nil {
+		return n, "", err
+	}
+	if n != expectedSize {
+		return n, "", fmt.Errorf("body size mismatch")
+	}
+	return n, hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func validContext(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("%w: context is required", ErrInvalid)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateText(value, label string, max int) (string, error) {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > max || !utf8.ValidString(value) || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return "", fmt.Errorf("%w: %s is invalid", ErrInvalid, label)
+	}
+	return value, nil
+}
+
+func validateBucket(value, label string) (string, error) {
+	value, err := validateText(value, label, 255)
+	if err != nil || strings.ContainsAny(value, "/\\") {
+		if err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("%w: %s is invalid", ErrInvalid, label)
+	}
+	return value, nil
+}
+
+func validateEndpoint(value string) (string, error) {
+	if value == "" || value != strings.TrimSpace(value) || strings.IndexFunc(value, unicode.IsControl) >= 0 || !utf8.ValidString(value) {
+		return "", fmt.Errorf("%w: endpoint is invalid", ErrInvalid)
+	}
+	u, err := url.Parse(value)
+	if err != nil || value != u.String() || u.Scheme == "" || u.Scheme != strings.ToLower(u.Scheme) || u.Host == "" || u.Host != strings.ToLower(u.Host) || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.Path != "" {
+		return "", fmt.Errorf("%w: endpoint is invalid", ErrInvalid)
+	}
+	if strings.EqualFold(u.Scheme, "https") {
+		return value, nil
+	}
+	host := u.Hostname()
+	if strings.EqualFold(u.Scheme, "http") && (strings.EqualFold(host, "localhost") || net.ParseIP(host) != nil && net.ParseIP(host).IsLoopback()) {
+		return value, nil
+	}
+	return "", fmt.Errorf("%w: endpoint must use HTTPS or loopback HTTP", ErrInvalid)
+}
+
+func ptr[T any](value T) *T { return &value }
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func digestBytes(value []byte) string {
+	sum := sha256.Sum256(value)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func normalizedDigest(value []byte) string { return digestBytes(value) }
+
+func rawSHA256(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil && strings.ToLower(value) == value
+}
+
+func digest(value string) bool {
+	return len(value) == 71 && strings.HasPrefix(value, "sha256:") && rawSHA256(strings.TrimPrefix(value, "sha256:"))
+}
+
+func rawDigest(value string) string {
+	if strings.HasPrefix(value, "sha256:") {
+		return strings.TrimPrefix(value, "sha256:")
+	}
+	return value
+}
+
+func apiCode(err error) string {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode()
+	}
+	return ""
+}
+
+func precondition(err error) bool {
+	code := apiCode(err)
+	return code == "PreconditionFailed" || code == "ConditionalRequestConflict"
+}
+
+func backendError(_ context.Context, operation string, err error) error {
+	if apiCode(err) == "NoSuchKey" || apiCode(err) == "NoSuchVersion" || apiCode(err) == "NotFound" {
+		return fmt.Errorf("%w: %s", ErrNotFound, operation)
+	}
+	// Do not include provider error text: AWS errors may contain signed URLs,
+	// access keys, or other credential-bearing request details.
+	return fmt.Errorf("%w: %s", ErrBackend, operation)
+}

--- a/internal/recoveryset/observationstore/qualification_test.go
+++ b/internal/recoveryset/observationstore/qualification_test.go
@@ -1,0 +1,284 @@
+//go:build fai520qualification
+
+package observationstore
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/flidai/leapview/internal/manageddata"
+	managedpostgres "github.com/flidai/leapview/internal/manageddata/postgres"
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	manageds3 "github.com/flidai/leapview/internal/manageddata/storage/s3"
+	"github.com/flidai/leapview/internal/platform/postgres/postgrestest"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+	recoverypostgres "github.com/flidai/leapview/internal/recoveryset/postgres"
+	jobspkg "github.com/flidai/leapview/pkg/jobs"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const qualificationMinIOImage = "minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+
+// This is an opt-in provider qualification, not a restore or startup test.
+// It proves that the store uses exact versions and requires Object Lock
+// COMPLIANCE retention on both source and off-host evidence objects.
+func TestFAI520ObservationStoreMinIOObjectLock(t *testing.T) {
+	ctx, client, newClient, endpoint, sourceBucket, evidenceBucket := qualificationProvider(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	until := now.Add(10 * time.Minute)
+	store, err := New(client, Config{Endpoint: endpoint, Region: "us-east-1", SourceBucket: sourceBucket, EvidenceBucket: evidenceBucket, Prefix: "qualification", Clock: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("retained source bytes\n")
+	key := "managed/revision/file.csv"
+	put, err := client.PutObject(ctx, &s3.PutObjectInput{Bucket: &sourceBucket, Key: &key, Body: bytes.NewReader(body), ObjectLockMode: types.ObjectLockModeCompliance, ObjectLockRetainUntilDate: &until})
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := aws.ToString(put.VersionId)
+	if version == "" || strings.EqualFold(version, "null") {
+		t.Fatal("MinIO did not return an immutable source version")
+	}
+	sum := sha256.Sum256(body)
+	object := observation.ProviderObject{Endpoint: endpoint, Region: "us-east-1", Bucket: sourceBucket, Key: key, VersionID: version, SHA256: hex.EncodeToString(sum[:]), Size: int64(len(body))}
+	if protection, err := store.verifySource(ctx, object, until); err != nil || protection.Mode != string(types.ObjectLockRetentionModeCompliance) {
+		t.Fatalf("verifySource() = %#v, %v", protection, err)
+	}
+
+	evidenceBody := []byte("canonical evidence\n")
+	evidenceDigest := normalizedDigest(evidenceBody)
+	ref, err := store.putEvidence(ctx, "manifest", evidenceDigest, evidenceBody, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A separately constructed client/store must reload the exact retained
+	// version; no process-local state participates in the read.
+	independent, err := New(newClient(), Config{Endpoint: endpoint, Region: "us-east-1", SourceBucket: sourceBucket, EvidenceBucket: evidenceBucket, Prefix: "qualification", Clock: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := independent.getEvidence(ctx, ref, now, until)
+	if err != nil || !bytes.Equal(got, evidenceBody) {
+		t.Fatalf("independent evidence reload = %q, %v", got, err)
+	}
+}
+
+func TestFAI520ObservationStoreMinIOFullCaptureSaveReload(t *testing.T) {
+	ctx, client, newClient, endpoint, sourceBucket, evidenceBucket := qualificationProvider(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	until := now.Add(10 * time.Minute)
+	db := qualificationPostgres(t)
+	managed := managedpostgres.New(db)
+	collection, err := managed.CreateCollection(ctx, manageddata.CreateCollectionInput{ID: projectgraph.ResourceID("collection_store_qualification"), ProjectID: projectgraph.ResourceID("project_store_qualification"), ConnectionID: projectgraph.ResourceID("connection_store_qualification"), Name: "Store Qualification"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("managed source bytes\n")
+	sum := sha256.Sum256(body)
+	hash := hex.EncodeToString(sum[:])
+	managedStore, err := manageds3.New(client, s3.NewPresignClient(client), manageds3.Config{Bucket: sourceBucket, Prefix: "managed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := manageddata.Manifest{Files: []manageddata.File{{Path: "orders.parquet", SHA256: hash, Size: int64(len(body))}}}
+	session, err := managed.CreateUploadSession(ctx, manageddata.CreateUploadSessionInput{ID: manageddata.UploadID("upload_store_qualification"), CollectionID: collection.ID, Manifest: manifest, StorageBackend: "s3", StagingPrefix: "staging/store-qualification", ExpiresAt: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := managed.BeginUploadFinalization(ctx, session.ID, jobspkg.WorkflowIntent{}); err != nil {
+		t.Fatal(err)
+	}
+	blob, err := managedStore.Put(ctx, storage.Blob{SHA256: hash, Size: int64(len(body))}, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := strings.TrimPrefix(blob.URI, "s3://"+sourceBucket+"/")
+	head, err := client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &sourceBucket, Key: &key})
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := aws.ToString(head.VersionId)
+	if version == "" || strings.EqualFold(version, "null") {
+		t.Fatal("MinIO did not return an immutable source version")
+	}
+	if _, err := managed.CompleteUpload(ctx, manageddata.CompleteUploadInput{SessionID: session.ID, RevisionID: manageddata.RevisionID("revision_store_qualification"), Files: []manageddata.StoredFile{{File: manifest.Files[0], StorageKey: "s3://" + sourceBucket + "/" + key}}}); err != nil {
+		t.Fatal(err)
+	}
+	captured, err := recoverypostgres.Capture(ctx, managed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := New(client, Config{Endpoint: endpoint, Region: "us-east-1", SourceBucket: sourceBucket, EvidenceBucket: evidenceBucket, Prefix: "full-qualification", Clock: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observations := []observation.Observation{{RevisionID: "revision_store_qualification", Path: "orders.parquet", Object: observation.ProviderObject{Endpoint: endpoint, Region: "us-east-1", Bucket: sourceBucket, Key: key, VersionID: version, SHA256: hash, Size: int64(len(body))}}}
+	if _, err := store.Save(ctx, &captured, observations, until); !errors.Is(err, ErrRetention) {
+		t.Fatalf("Save accepted an unprotected source version or returned wrong error: %v", err)
+	}
+	if _, err := client.PutObjectRetention(ctx, &s3.PutObjectRetentionInput{Bucket: &sourceBucket, Key: &key, VersionId: &version, Retention: &types.ObjectLockRetention{Mode: types.ObjectLockRetentionModeCompliance, RetainUntilDate: &until}}); err != nil {
+		t.Fatal(err)
+	}
+	// A retained newer version with the same length but different bytes must
+	// fail hash verification. The subsequent positive path must still select
+	// the original historical version, never this latest object.
+	wrongBytes := append([]byte(nil), body...)
+	wrongBytes[0] ^= 1
+	wrongPut, err := client.PutObject(ctx, &s3.PutObjectInput{Bucket: &sourceBucket, Key: &key, Body: bytes.NewReader(wrongBytes), ObjectLockMode: types.ObjectLockModeCompliance, ObjectLockRetainUntilDate: &until})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongVersion := aws.ToString(wrongPut.VersionId)
+	if wrongVersion == "" || wrongVersion == version {
+		t.Fatal("provider did not issue a different historical version")
+	}
+	wrongObservations := append([]observation.Observation(nil), observations...)
+	wrongObservations[0].Object.VersionID = wrongVersion
+	if _, err := store.Save(ctx, &captured, wrongObservations, until); !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("Save accepted wrong historical bytes or returned wrong error: %v", err)
+	}
+	ref, err := store.Save(ctx, &captured, observations, until)
+	if err != nil {
+		t.Fatalf("Save() = %v", err)
+	}
+	refBytes, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persistedRef Ref
+	if err := json.Unmarshal(refBytes, &persistedRef); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("saved evidence manifest=%s boundary=%s descriptor=%s source-version=%s", ref.Manifest.SHA256, ref.Boundary.SHA256, ref.Descriptor.SHA256, version)
+	independent, err := New(newClient(), Config{Endpoint: endpoint, Region: "us-east-1", SourceBucket: sourceBucket, EvidenceBucket: evidenceBucket, Prefix: "full-qualification", Clock: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := independent.Reload(ctx, persistedRef, until)
+	if err != nil {
+		t.Fatalf("independent Reload() = %v", err)
+	}
+	if loaded.Boundary != captured.Boundary() || len(loaded.Manifest.Objects) != 1 || loaded.Manifest.Objects[0].Object.VersionID != version {
+		t.Fatalf("reloaded evidence = %#v", loaded)
+	}
+	boundaryDigest, err := captured.Boundary().Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	set := regressionV2Set(t, captured.Boundary(), "sha256:"+ref.Manifest.SHA256, boundaryDigest, "sha256:"+ref.Descriptor.SHA256)
+	frontier, err := store.PersistFrontier(ctx, set, ref, until)
+	if err != nil {
+		t.Fatalf("PersistFrontier() = %v", err)
+	}
+	read, err := independent.ReadFrontier(ctx, frontier, until)
+	if err != nil {
+		t.Fatalf("independent ReadFrontier() = %v", err)
+	}
+	if read.ID != set.ID || read.ManagedEvidence == nil || read.ManagedEvidence.Boundary != captured.Boundary() {
+		t.Fatalf("read frontier = %#v", read)
+	}
+}
+
+func qualificationProvider(t *testing.T) (context.Context, *s3.Client, func() *s3.Client, string, string, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+	user, secret := "q"+strings.ReplaceAll(uuid.NewString(), "-", ""), uuid.NewString()
+	container, err := tcminio.Run(ctx, qualificationMinIOImage, tcminio.WithUsername(user), tcminio.WithPassword(secret), testcontainers.WithTmpfs(map[string]string{"/data": "rw,size=1g"}), testcontainers.WithWaitStrategy(wait.ForHTTP("/minio/health/ready").WithPort("9000").WithStartupTimeout(time.Minute)))
+	testcontainers.CleanupContainer(t, container)
+	if err != nil {
+		t.Fatal(err)
+	}
+	address, err := container.ConnectionString(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint := "http://" + strings.TrimRight(address, "/")
+	newClient := func() *s3.Client {
+		return s3.New(s3.Options{Region: "us-east-1", BaseEndpoint: aws.String(endpoint), UsePathStyle: true, Credentials: credentials.NewStaticCredentialsProvider(user, secret, ""), RetryMaxAttempts: 1, HTTPClient: qualificationHTTPClient{t: t}})
+	}
+	client := newClient()
+	sourceBucket, evidenceBucket := "source-"+strings.ReplaceAll(uuid.NewString(), "-", ""), "evidence-"+strings.ReplaceAll(uuid.NewString(), "-", "")
+	for _, bucket := range []string{sourceBucket, evidenceBucket} {
+		if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: &bucket, ObjectLockEnabledForBucket: aws.Bool(true)}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{Bucket: &bucket, VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ctx, client, newClient, endpoint, sourceBucket, evidenceBucket
+}
+
+func qualificationPostgres(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+	container, err := tcpostgres.Run(ctx, postgrestest.PostgreSQL18Image,
+		tcpostgres.WithDatabase("postgres"),
+		tcpostgres.WithUsername("postgres"),
+		tcpostgres.WithPassword("observation-store-qualification-secret"),
+		testcontainers.WithCmd("postgres", "-c", "fsync=on"),
+		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(90*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testcontainers.CleanupContainer(t, container)
+	adminURL, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := pgxpool.New(ctx, adminURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(p.Close)
+	if err := p.Ping(ctx); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := p.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := managedpostgres.ApplySchema(ctx, tx); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+type qualificationHTTPClient struct{ t *testing.T }
+
+func (c qualificationHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		c.t.Log("qualification provider transport failure")
+	}
+	if response != nil && response.StatusCode >= 400 {
+		c.t.Logf("qualification provider HTTP status %d", response.StatusCode)
+	}
+	return response, err
+}

--- a/internal/recoveryset/observationstore/regression_test.go
+++ b/internal/recoveryset/observationstore/regression_test.go
@@ -1,0 +1,595 @@
+package observationstore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/flidai/leapview/internal/analytics/physicalpool"
+	"github.com/flidai/leapview/internal/manageddata"
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+	managedpostgres "github.com/flidai/leapview/internal/recoveryset/postgres"
+)
+
+type emptyProjectionSource struct{}
+
+type expiringWriteClient struct {
+	*versionedFakeS3
+	afterWrite func()
+}
+
+func (c *expiringWriteClient) PutObject(ctx context.Context, input *s3.PutObjectInput, options ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	result, err := c.versionedFakeS3.PutObject(ctx, input, options...)
+	if c.afterWrite != nil {
+		c.afterWrite()
+	}
+	return result, err
+}
+
+func TestEvidenceCannotExpireDuringAcceptance(t *testing.T) {
+	for _, frontier := range []bool{false, true} {
+		name := "manifest"
+		if frontier {
+			name = "frontier"
+		}
+		t.Run(name, func(t *testing.T) {
+			now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+			until := now.Add(time.Hour)
+			provider := &expiringWriteClient{versionedFakeS3: newVersionedFakeS3()}
+			store, err := New(provider, Config{Endpoint: "http://127.0.0.1:9000", Region: "us-east-1", SourceBucket: "source", EvidenceBucket: "evidence", Clock: func() time.Time { return now }})
+			if err != nil {
+				t.Fatal(err)
+			}
+			captured := capturedEmptyObservation(t)
+			if !frontier {
+				provider.afterWrite = func() { now = until.Add(time.Second) }
+				_, err = store.Save(t.Context(), &captured, nil, until)
+			} else {
+				ref, saveErr := store.Save(t.Context(), &captured, nil, until)
+				if saveErr != nil {
+					t.Fatal(saveErr)
+				}
+				set := regressionV2Set(t, captured.Boundary(), "sha256:"+ref.Manifest.SHA256, mustDigest(t, captured.Boundary()), "sha256:"+ref.Descriptor.SHA256)
+				provider.afterWrite = func() { now = until.Add(time.Second) }
+				_, err = store.PersistFrontier(t.Context(), set, ref, until)
+			}
+			if !errors.Is(err, ErrRetention) {
+				t.Fatalf("accepted evidence after its retention expired: %v", err)
+			}
+		})
+	}
+}
+
+func TestReloadRejectsNoncanonicalEvidenceDespiteMatchingRawDigests(t *testing.T) {
+	for _, kind := range []string{"manifest", "boundary"} {
+		t.Run(kind, func(t *testing.T) {
+			provider := newFakeS3()
+			store, _, ref, until := savedEmptyEvidence(t, provider, time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC))
+			descriptor, err := parseDescriptor(fakeBody(t, provider, ref.Descriptor.Key))
+			if err != nil {
+				t.Fatal(err)
+			}
+			object := ref.Manifest
+			if kind == "boundary" {
+				object = ref.Boundary
+			}
+			raw := append([]byte("\n"), fakeBody(t, provider, object.Key)...)
+			replacement, err := store.putEvidence(t.Context(), kind, digestBytes(raw), raw, until)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if kind == "manifest" {
+				ref.Manifest, descriptor.Manifest = replacement, replacement
+				descriptor.ManifestDigest = digestBytes(raw)
+			} else {
+				ref.Boundary, descriptor.Boundary = replacement, replacement
+				descriptor.BoundaryDigest = digestBytes(raw)
+			}
+			descriptorBytes, err := descriptor.CanonicalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ref.Descriptor, err = store.putEvidence(t.Context(), "descriptor", digestBytes(descriptorBytes), descriptorBytes, until)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.Reload(t.Context(), ref); !errors.Is(err, ErrIntegrity) || !strings.Contains(err.Error(), "not canonical") {
+				t.Fatalf("noncanonical %s did not fail canonical validation: %v", kind, err)
+			}
+		})
+	}
+}
+
+func TestStoreRejectsNoncanonicalProviderEndpoints(t *testing.T) {
+	for _, endpoint := range []string{"https://example.com?", "HTTPS://example.com", "https://EXAMPLE.com"} {
+		if _, err := New(newFakeS3(), Config{Endpoint: endpoint, Region: "us-east-1", SourceBucket: "source", EvidenceBucket: "evidence"}); !errors.Is(err, ErrInvalid) {
+			t.Fatalf("accepted noncanonical endpoint %q: %v", endpoint, err)
+		}
+	}
+}
+
+func TestStoreRejectsUnverifiableSourceSizeLimits(t *testing.T) {
+	for _, limit := range []int64{-1, DefaultMaxSourceBytes + 1} {
+		if _, err := New(newFakeS3(), Config{Endpoint: "https://example.com", Region: "us-east-1", SourceBucket: "source", EvidenceBucket: "evidence", MaxSourceBytes: limit}); !errors.Is(err, ErrInvalid) {
+			t.Fatalf("accepted unverifiable source size limit %d: %v", limit, err)
+		}
+	}
+}
+
+func (emptyProjectionSource) CaptureManagedProjection(context.Context) (manageddata.CapturedProjection, error) {
+	return manageddata.CapturedProjection{
+		DatabaseIdentity: "control_db",
+		SystemIdentity:   "12345",
+		Timeline:         1,
+		LSN:              "0/100",
+		RestorePointName: "provider_observation_test",
+		Revisions:        make([]manageddata.CapturedProjectionRevision, 0),
+	}, nil
+}
+
+func capturedEmptyObservation(t *testing.T) managedpostgres.CapturedObservation {
+	t.Helper()
+	captured, err := managedpostgres.Capture(t.Context(), emptyProjectionSource{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return captured
+}
+
+func savedEmptyEvidence(t *testing.T, provider *fakeS3, now time.Time) (*Store, managedpostgres.CapturedObservation, Ref, time.Time) {
+	t.Helper()
+	return savedEmptyEvidenceWithClient(t, provider, provider, now)
+}
+
+func savedEmptyEvidenceWithClient(t *testing.T, client Client, provider *fakeS3, now time.Time) (*Store, managedpostgres.CapturedObservation, Ref, time.Time) {
+	t.Helper()
+	store := newTestStoreWithClient(t, client, now)
+	captured := capturedEmptyObservation(t)
+	until := now.Add(2 * time.Hour)
+	ref, err := store.Save(t.Context(), &captured, []observation.Observation{}, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, captured, ref, ceilSecond(until)
+}
+
+func TestPersistFrontierReadFrontierRoundTripEmptyCapture(t *testing.T) {
+	provider := newVersionedFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, captured, evidence, until := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, now)
+
+	manifestBody := fakeBody(t, provider.fakeS3, evidence.Manifest.Key)
+	manifest, err := observation.ParseManifest(manifestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Inventory.Revisions == nil || manifest.Objects == nil {
+		t.Fatalf("empty evidence arrays were not preserved: %#v", manifest)
+	}
+	if len(manifest.Inventory.Revisions) != 0 || len(manifest.Objects) != 0 {
+		t.Fatalf("empty capture manifest = %#v", manifest)
+	}
+
+	boundary := captured.Boundary()
+	boundaryDigest, err := boundary.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	set := regressionV2Set(t, boundary, "sha256:"+evidence.Manifest.SHA256, boundaryDigest, "sha256:"+evidence.Descriptor.SHA256)
+	frontier, err := store.PersistFrontier(t.Context(), set, evidence, until)
+	if err != nil {
+		t.Fatalf("PersistFrontier() = %v", err)
+	}
+	got, err := store.ReadFrontier(t.Context(), frontier, until)
+	if err != nil {
+		t.Fatalf("ReadFrontier() = %v", err)
+	}
+	if got.ID != set.ID || got.SchemaVersion != recoveryset.EvidenceSchemaVersion || got.ManagedEvidence == nil || got.ManagedEvidence.Boundary != boundary {
+		t.Fatalf("round-trip set = %#v", got)
+	}
+	wantDigest, err := set.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotDigest, err := got.Digest()
+	if err != nil || gotDigest != wantDigest {
+		t.Fatalf("round-trip digest = %q, want %q (err=%v)", gotDigest, wantDigest, err)
+	}
+}
+
+func TestReadFrontierRejectsForgedBoundaryBinding(t *testing.T) {
+	provider := newVersionedFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, captured, evidence, until := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, now)
+	boundary := captured.Boundary()
+	set := regressionV2Set(t, boundary, "sha256:"+evidence.Manifest.SHA256, mustDigest(t, boundary), "sha256:"+evidence.Descriptor.SHA256)
+	frontier, err := store.PersistFrontier(t.Context(), set, evidence, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Keep the evidence digests unchanged while forging the boundary marker in
+	// both immutable frontier objects. ReadFrontier must reject the resulting
+	// recovery set instead of treating the frontier's marker as authoritative.
+	forged := cloneRecoverySet(set)
+	forged.ManagedEvidence.Boundary.LSN = "0/101"
+	forged.ClusterPoints[0].RecoveryIdentity = forged.ManagedEvidence.Boundary.RecoveryIdentity()
+	forgedBytes, err := json.Marshal(forged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forgedDigest := normalizedDigest(forgedBytes)
+	provider.add(store.frontierKey(forgedDigest), forgedBytes, until)
+	provider.mu.Lock()
+	frontierObject := provider.objects[store.frontierKey(forgedDigest)]
+	setObject := provider.objects[frontier.SetIDObject.Key]
+	setObject.body = append([]byte(nil), forgedBytes...)
+	provider.objects[frontier.SetIDObject.Key] = setObject
+	provider.mu.Unlock()
+	forgedRef := frontier
+	forgedRef.Digest = forgedDigest
+	forgedRef.Frontier = ObjectRef{Bucket: "evidence", Key: store.frontierKey(forgedDigest), VersionID: frontierObject.version, SHA256: rawDigest(forgedDigest), Size: int64(len(forgedBytes))}
+	forgedRef.SetIDObject.SHA256 = rawDigest(forgedDigest)
+	forgedRef.SetIDObject.Size = int64(len(forgedBytes))
+	if _, err := store.ReadFrontier(t.Context(), forgedRef); err == nil {
+		t.Fatal("ReadFrontier accepted a forged boundary binding")
+	}
+}
+
+func TestReadFrontierRejectsShortFrontierRetention(t *testing.T) {
+	provider := newVersionedFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, captured, evidence, until := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, now)
+	boundary := captured.Boundary()
+	set := regressionV2Set(t, boundary, "sha256:"+evidence.Manifest.SHA256, mustDigest(t, boundary), "sha256:"+evidence.Descriptor.SHA256)
+	frontier, err := store.PersistFrontier(t.Context(), set, evidence, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider.mu.Lock()
+	for _, key := range []string{frontier.Frontier.Key, frontier.SetIDObject.Key} {
+		object := provider.objects[key]
+		object.retain = now.Add(time.Hour)
+		provider.objects[key] = object
+	}
+	provider.mu.Unlock()
+	if _, err := store.ReadFrontier(t.Context(), frontier); !errors.Is(err, ErrRetention) {
+		t.Fatalf("short frontier retention = %v, want %v", err, ErrRetention)
+	}
+}
+
+func TestPersistFrontierRejectsBoundaryAndVersionDrift(t *testing.T) {
+	provider := newVersionedFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, captured, evidence, until := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, now)
+	boundary := captured.Boundary()
+	boundaryDigest, err := boundary.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := regressionV2Set(t, boundary, "sha256:"+evidence.Manifest.SHA256, boundaryDigest, "sha256:"+evidence.Descriptor.SHA256)
+
+	for name, mutate := range map[string]func(*recoveryset.RecoverySet){
+		"wrong LSN": func(set *recoveryset.RecoverySet) {
+			set.ManagedEvidence.Boundary.LSN = "0/101"
+			set.ManagedEvidence.BoundaryDigest = mustDigest(t, set.ManagedEvidence.Boundary)
+			set.ClusterPoints[0].RecoveryIdentity = set.ManagedEvidence.Boundary.RecoveryIdentity()
+		},
+		"wrong database": func(set *recoveryset.RecoverySet) {
+			set.ManagedEvidence.Boundary.DatabaseIdentity = "other_db"
+			set.ManagedEvidence.BoundaryDigest = mustDigest(t, set.ManagedEvidence.Boundary)
+			set.ClusterPoints[0].DatabaseIdentity = "other_db"
+			set.ClusterPoints[0].RecoveryIdentity = set.ManagedEvidence.Boundary.RecoveryIdentity()
+		},
+		"unknown schema": func(set *recoveryset.RecoverySet) { set.SchemaVersion = 3 },
+		"downgrade": func(set *recoveryset.RecoverySet) {
+			set.SchemaVersion = recoveryset.SchemaVersion
+			set.ManagedEvidence = nil
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			set := cloneRecoverySet(base)
+			mutate(&set)
+			if _, err := store.PersistFrontier(t.Context(), set, evidence, until); err == nil {
+				t.Fatal("PersistFrontier accepted invalid boundary/version")
+			}
+		})
+	}
+
+	frontier, err := store.PersistFrontier(t.Context(), base, evidence, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	badRef := frontier
+	badRef.Frontier.SHA256 = strings.Repeat("f", 64)
+	if _, err := store.ReadFrontier(t.Context(), badRef, until); err == nil {
+		t.Fatal("ReadFrontier accepted a mutated frontier ref hash")
+	}
+}
+
+func TestPersistFrontierSameSetIDConflict(t *testing.T) {
+	provider := newVersionedFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, captured, evidence, until := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, now)
+	boundary := captured.Boundary()
+	boundaryDigest := mustDigest(t, boundary)
+	set := regressionV2Set(t, boundary, "sha256:"+evidence.Manifest.SHA256, boundaryDigest, "sha256:"+evidence.Descriptor.SHA256)
+	if _, err := store.PersistFrontier(t.Context(), set, evidence, until); err != nil {
+		t.Fatal(err)
+	}
+	conflict := cloneRecoverySet(set)
+	conflict.AuditIdentity = "different-audit"
+	if _, err := store.PersistFrontier(t.Context(), conflict, evidence, until); !errors.Is(err, ErrConflict) {
+		t.Fatalf("same set ID conflict = %v, want %v", err, ErrConflict)
+	}
+}
+
+func TestPersistFrontierFailsClosedOnEmptySetIDVersionListing(t *testing.T) {
+	provider := newVersionedFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, captured, evidence, until := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, now)
+	boundary := captured.Boundary()
+	set := regressionV2Set(t, boundary, "sha256:"+evidence.Manifest.SHA256, mustDigest(t, boundary), "sha256:"+evidence.Descriptor.SHA256)
+	provider.mu.Lock()
+	provider.listEmpty = true
+	provider.mu.Unlock()
+	if _, err := store.PersistFrontier(t.Context(), set, evidence, until); err == nil || (!errors.Is(err, ErrBackend) && !errors.Is(err, ErrIntegrity)) {
+		t.Fatalf("empty set-ID version listing = %v, want a fail-closed backend/integrity error", err)
+	}
+}
+
+func TestReloadRejectsHorizonRefSizeAndBadVersionClosesBody(t *testing.T) {
+	provider := newFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, _, evidence, _ := savedEmptyEvidence(t, provider, now)
+	provider.mu.Lock()
+	for key, object := range provider.objects {
+		object.retain = now.Add(10 * time.Hour)
+		provider.objects[key] = object
+	}
+	provider.mu.Unlock()
+	if _, err := store.Reload(t.Context(), evidence, now.Add(3*time.Hour)); !errors.Is(err, ErrRetention) {
+		t.Fatalf("short descriptor horizon = %v, want %v", err, ErrRetention)
+	}
+
+	tracked := &trackingFakeS3{fakeS3: provider}
+	trackedStore := newTrackedTestStore(t, tracked, now)
+	badSize := evidence
+	badSize.Descriptor.Size = maxDescriptorBytes + 1
+	getsBefore := tracked.getCount.Load()
+	if _, err := trackedStore.Reload(t.Context(), badSize); err == nil {
+		t.Fatal("Reload accepted an oversized evidence reference")
+	}
+	if tracked.getCount.Load() != getsBefore {
+		t.Fatalf("oversized ref caused GET calls: before=%d after=%d", getsBefore, tracked.getCount.Load())
+	}
+
+	tracked.closeCount.Store(0)
+	provider.mu.Lock()
+	provider.wrongGetVersion = true
+	provider.mu.Unlock()
+	trackedStore = newTrackedTestStore(t, tracked, now)
+	if _, err := trackedStore.Reload(t.Context(), evidence); err == nil || !strings.Contains(err.Error(), "integrity") {
+		t.Fatalf("bad GET version error = %v", err)
+	}
+	if tracked.closeCount.Load() == 0 {
+		t.Fatal("bad GET version did not close response body")
+	}
+}
+
+func TestParseDescriptorRejectsOmittedCaseAliasedAndNullFields(t *testing.T) {
+	provider := newFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	_, _, evidence, _ := savedEmptyEvidence(t, provider, now)
+	raw := fakeBody(t, provider, evidence.Descriptor.Key)
+	cases := map[string][]byte{
+		"omitted zero size":   removeJSONField(raw, "size"),
+		"case aliased schema": bytes.Replace(raw, []byte(`"schema_version"`), []byte(`"SCHEMA_VERSION"`), 1),
+		"null size":           replaceJSONFieldWithNull(raw, "size"),
+	}
+	for name, invalid := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseDescriptor(invalid); err == nil {
+				t.Fatal("parseDescriptor accepted malformed descriptor")
+			}
+		})
+	}
+}
+
+func TestReloadRejectsExpiredEvidenceRetention(t *testing.T) {
+	provider := newFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, _, evidence, _ := savedEmptyEvidence(t, provider, now)
+	provider.mu.Lock()
+	for key, object := range provider.objects {
+		object.retain = now.Add(-time.Minute)
+		provider.objects[key] = object
+	}
+	provider.mu.Unlock()
+	if _, err := store.Reload(t.Context(), evidence); !errors.Is(err, ErrRetention) {
+		t.Fatalf("expired evidence retention = %v, want %v", err, ErrRetention)
+	}
+}
+
+func regressionV2Set(t *testing.T, boundary observation.Boundary, manifestDigest, boundaryDigest, descriptorDigest string) recoveryset.RecoverySet {
+	t.Helper()
+	compat := physicalpool.Compatibility{DuckDBRuntime: "duckdb:1", DuckLakeExtension: "ducklake:1", CatalogFormat: "ducklake:v1", StorageImplementation: "s3", ObjectNamingContract: "uuidv7:v1"}
+	compatDigest, err := compat.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	set := recoveryset.RecoverySet{
+		ID: "018f3f83-7b2f-7b37-9f9e-000000000010", SchemaVersion: recoveryset.EvidenceSchemaVersion,
+		ClusterPoints: []recoveryset.ClusterRecoveryPoint{
+			{DatabaseRole: recoveryset.DatabaseControl, ClusterIdentity: boundary.ClusterIdentity(), DatabaseIdentity: boundary.DatabaseIdentity, RecoveryIdentity: boundary.RecoveryIdentity()},
+			{DatabaseRole: recoveryset.DatabaseDuckLake, ClusterIdentity: "ducklake-cluster", DatabaseIdentity: "ducklake-db", RecoveryIdentity: "lsn:0/100"},
+		},
+		Delivery:      recoveryset.DeliveryPointer{TargetID: "target/prod", GenerationID: "018f3f83-7b2f-7b37-9f9e-000000000002", PublicationID: "018f3f83-7b2f-7b37-9f9e-000000000003", TargetRevision: 4},
+		Serving:       recoveryset.SnapshotSeal{SealID: "018f3f83-7b2f-7b37-9f9e-000000000001", PhysicalPoolID: "pool-a", TenantDomain: "tenant-a", Region: "us-east", EncryptionDomain: "enc-a", ObjectNamespace: "objects/prod", CatalogDatabase: "ducklake-db", CatalogID: "catalog-a", CatalogUUID: "catalog-uuid-a", CatalogVersion: 9, DuckLakeSnapshotID: 42, RelationManifestDigest: testDigest('a'), RelationNamespace: "candidate/1", ClosureDigest: testDigest('b'), ObjectRoot: "s3://bucket/prod", ObjectRootDigest: testDigest('c'), ArtifactRoot: "artifacts/prod", ArtifactRootDigest: testDigest('d'), ServingArtifactID: "artifact-a", ServingArtifactDigest: testDigest('e'), CompiledGraphDigest: testDigest('f'), CompiledConfigDigest: testDigest('0'), SecurityDomainFingerprint: testDigest('1'), RequestDigest: testDigest('2'), PlanDigest: testDigest('3'), CompatibilityDigest: compatDigest, DuckDBVersion: "1", RuntimeVersion: "runtime-1", DuckLakeExtensionVersion: "1", DuckLakeSpecVersion: "1", CatalogSchemaVersion: "1"},
+		Catalog:       recoveryset.CatalogCommit{CatalogID: "catalog-a", CatalogDatabase: "ducklake-db", CatalogUUID: "catalog-uuid-a", CatalogVersion: 9, SnapshotID: 42},
+		ObjectRoots:   []recoveryset.ObjectRoot{{Kind: recoveryset.ObjectRootDuckLake, URI: "s3://bucket/prod", VersionID: "v9", Digest: testDigest('c'), ProviderRecoveryFrontier: "version:v9"}, {Kind: recoveryset.ObjectRootServingArtifact, URI: "artifacts/prod", VersionID: "v4", Digest: testDigest('d')}},
+		Compatibility: compat, FenceEpoch: 3, AuditIdentity: "audit-1", Status: recoveryset.StatusPrepared, CreatedBy: "operator", CreatedAt: time.Date(2026, 9, 1, 12, 0, 0, 0, time.FixedZone("offset", 3600)),
+		ManagedEvidence: &recoveryset.ManagedEvidence{ManifestDigest: manifestDigest, BoundaryDigest: boundaryDigest, DescriptorDigest: descriptorDigest, Boundary: boundary},
+	}
+	return set
+}
+
+func cloneRecoverySet(set recoveryset.RecoverySet) recoveryset.RecoverySet {
+	clone := set
+	clone.ClusterPoints = append([]recoveryset.ClusterRecoveryPoint(nil), set.ClusterPoints...)
+	clone.ObjectRoots = append([]recoveryset.ObjectRoot(nil), set.ObjectRoots...)
+	if set.ManagedEvidence != nil {
+		evidence := *set.ManagedEvidence
+		clone.ManagedEvidence = &evidence
+	}
+	return clone
+}
+
+func mustDigest(t *testing.T, boundary observation.Boundary) string {
+	t.Helper()
+	digest, err := boundary.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digest
+}
+
+func testDigest(ch byte) string { return "sha256:" + strings.Repeat(string(ch), 64) }
+
+func fakeBody(t *testing.T, provider *fakeS3, key string) []byte {
+	t.Helper()
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	object, ok := provider.objects[key]
+	if !ok {
+		t.Fatalf("fake object %q not found", key)
+	}
+	return append([]byte(nil), object.body...)
+}
+
+func removeJSONField(raw []byte, name string) []byte {
+	prefix := []byte(`"` + name + `":`)
+	start := bytes.Index(raw, prefix)
+	if start < 0 {
+		return raw
+	}
+	valueStart := start + len(prefix)
+	valueEnd := valueStart
+	if valueStart < len(raw) && raw[valueStart] == '"' {
+		valueEnd++
+		for valueEnd < len(raw) {
+			if raw[valueEnd] == '"' && raw[valueEnd-1] != '\\' {
+				valueEnd++
+				break
+			}
+			valueEnd++
+		}
+	} else {
+		for valueEnd < len(raw) && raw[valueEnd] != ',' && raw[valueEnd] != '}' {
+			valueEnd++
+		}
+	}
+	if valueEnd < len(raw) && raw[valueEnd] == ',' {
+		valueEnd++
+	} else if start > 0 && raw[start-1] == ',' {
+		start--
+	}
+	return append(append([]byte(nil), raw[:start]...), raw[valueEnd:]...)
+}
+
+func replaceJSONFieldWithNull(raw []byte, name string) []byte {
+	prefix := []byte(`"` + name + `":`)
+	start := bytes.Index(raw, prefix)
+	if start < 0 {
+		return raw
+	}
+	valueStart := start + len(prefix)
+	valueEnd := valueStart
+	for valueEnd < len(raw) && raw[valueEnd] != ',' && raw[valueEnd] != '}' {
+		valueEnd++
+	}
+	result := make([]byte, 0, len(raw)+4)
+	result = append(result, raw[:valueStart]...)
+	result = append(result, "null"...)
+	result = append(result, raw[valueEnd:]...)
+	return result
+}
+
+type trackingFakeS3 struct {
+	*fakeS3
+	closeCount atomic.Int32
+	getCount   atomic.Int32
+}
+
+func newTrackedTestStore(t *testing.T, provider *trackingFakeS3, now time.Time) *Store {
+	t.Helper()
+	store := newTestStoreWithClient(t, provider, now)
+	return store
+}
+
+func newTestStoreWithClient(t *testing.T, client Client, now time.Time) *Store {
+	t.Helper()
+	store, err := New(client, Config{Endpoint: "http://127.0.0.1:9000", Region: "us-east-1", SourceBucket: "source", EvidenceBucket: "evidence", Prefix: "test", Clock: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+type versionedFakeS3 struct {
+	*fakeS3
+	listEmpty bool
+}
+
+func newVersionedFakeS3() *versionedFakeS3 {
+	return &versionedFakeS3{fakeS3: newFakeS3()}
+}
+
+func (f *versionedFakeS3) ListObjectVersions(_ context.Context, in *s3.ListObjectVersionsInput, _ ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listEmpty {
+		truncated := false
+		return &s3.ListObjectVersionsOutput{IsTruncated: &truncated, Versions: []types.ObjectVersion{}}, nil
+	}
+	key := ""
+	if in != nil && in.Prefix != nil {
+		key = *in.Prefix
+	}
+	versions := make([]types.ObjectVersion, 0, 1)
+	if object, ok := f.objects[key]; ok {
+		objectKey, version := key, object.version
+		versions = append(versions, types.ObjectVersion{Key: &objectKey, VersionId: &version})
+	}
+	truncated := false
+	return &s3.ListObjectVersionsOutput{IsTruncated: &truncated, Versions: versions}, nil
+}
+
+func (f *trackingFakeS3) GetObject(ctx context.Context, in *s3.GetObjectInput, options ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	f.getCount.Add(1)
+	out, err := f.fakeS3.GetObject(ctx, in, options...)
+	if err != nil || out == nil || out.Body == nil {
+		return out, err
+	}
+	out.Body = &trackingBody{ReadCloser: out.Body, closed: &f.closeCount}
+	return out, nil
+}
+
+type trackingBody struct {
+	io.ReadCloser
+	closed *atomic.Int32
+}
+
+func (b *trackingBody) Close() error {
+	b.closed.Add(1)
+	return b.ReadCloser.Close()
+}

--- a/internal/recoveryset/observationstore/retention_regression_test.go
+++ b/internal/recoveryset/observationstore/retention_regression_test.go
@@ -1,0 +1,184 @@
+package observationstore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestPersistFrontierRejectsHorizonShorterThanDescriptor(t *testing.T) {
+	provider := newVersionedFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, captured, evidence, descriptorUntil := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, now)
+	set := regressionV2Set(t, captured.Boundary(), "sha256:"+evidence.Manifest.SHA256, mustDigest(t, captured.Boundary()), "sha256:"+evidence.Descriptor.SHA256)
+
+	requestedUntil := descriptorUntil.Add(-time.Hour)
+	if _, err := store.PersistFrontier(t.Context(), set, evidence, requestedUntil); !errors.Is(err, ErrRetention) {
+		t.Fatalf("PersistFrontier accepted horizon before descriptor horizon: %v", err)
+	}
+	provider.mu.Lock()
+	var frontierKey string
+	for key := range provider.objects {
+		if strings.HasPrefix(key, store.evidencePrefix()+"/frontiers/") {
+			frontierKey = key
+			break
+		}
+	}
+	provider.mu.Unlock()
+	if frontierKey != "" {
+		t.Fatalf("short PersistFrontier wrote frontier object %q", frontierKey)
+	}
+	frontier, err := store.PersistFrontier(t.Context(), set, evidence, descriptorUntil)
+	if err != nil {
+		t.Fatalf("PersistFrontier rejected matching descriptor horizon: %v", err)
+	}
+	if got, err := store.ReadFrontier(t.Context(), frontier); err != nil || got.ID != set.ID {
+		t.Fatalf("default reload of matching-horizon frontier: got=%#v err=%v", got, err)
+	}
+}
+
+func TestReloadUsesRecordedHorizonWhenOptionalHorizonIsShorter(t *testing.T) {
+	provider := newVersionedFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store, _, evidence, descriptorUntil := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, now)
+
+	// The descriptor is authoritative. A manifest retained only through an
+	// optional, shorter request must not be accepted by Reload.
+	provider.mu.Lock()
+	manifest := provider.objects[evidence.Manifest.Key]
+	manifest.retain = now.Add(time.Hour)
+	provider.objects[evidence.Manifest.Key] = manifest
+	provider.mu.Unlock()
+
+	if _, err := store.Reload(t.Context(), evidence, descriptorUntil.Add(-time.Hour)); !errors.Is(err, ErrRetention) {
+		t.Fatalf("Reload weakened descriptor horizon: %v", err)
+	}
+}
+
+func TestReloadRejectsRetentionExpiryDuringDescriptorBodyRead(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		now       func(time.Time) time.Time
+		wantError bool
+	}{
+		{name: "before deadline", now: func(until time.Time) time.Time { return until.Add(-time.Nanosecond) }},
+		{name: "exact deadline", now: func(until time.Time) time.Time { return until }, wantError: true},
+		{name: "after deadline", now: func(until time.Time) time.Time { return until.Add(time.Nanosecond) }, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := newVersionedFakeS3()
+			start := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+			_, _, evidence, until := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, start)
+			clock := start
+			client := &retentionAdvancingClient{
+				versionedFakeS3: provider,
+				onRead: func(key string) {
+					if key == evidence.Descriptor.Key {
+						clock = tc.now(until)
+					}
+				},
+			}
+			store := newClockedRetentionStore(t, client, func() time.Time { return clock })
+
+			_, err := store.Reload(t.Context(), evidence)
+			if tc.wantError {
+				if !errors.Is(err, ErrRetention) {
+					t.Fatalf("Reload accepted retention expiry during descriptor read: %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("Reload rejected protected evidence before deadline: %v", err)
+			}
+		})
+	}
+}
+
+func TestReadFrontierRejectsRetentionExpiryAfterNestedReload(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		now       func(time.Time) time.Time
+		wantError bool
+	}{
+		{name: "before deadline", now: func(until time.Time) time.Time { return until.Add(-time.Nanosecond) }},
+		{name: "exact deadline", now: func(until time.Time) time.Time { return until }, wantError: true},
+		{name: "after deadline", now: func(until time.Time) time.Time { return until.Add(time.Nanosecond) }, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := newVersionedFakeS3()
+			start := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+			store, captured, evidence, until := savedEmptyEvidenceWithClient(t, provider, provider.fakeS3, start)
+			set := regressionV2Set(t, captured.Boundary(), "sha256:"+evidence.Manifest.SHA256, mustDigest(t, captured.Boundary()), "sha256:"+evidence.Descriptor.SHA256)
+			frontier, err := store.PersistFrontier(t.Context(), set, evidence, until)
+			if err != nil {
+				t.Fatalf("PersistFrontier() = %v", err)
+			}
+
+			clock := start
+			client := &retentionAdvancingClient{
+				versionedFakeS3: provider,
+				onRead: func(key string) {
+					// The set-ID body is read only after the nested Reload and
+					// frontier body reads have completed.
+					if key == frontier.SetIDObject.Key {
+						clock = tc.now(until)
+					}
+				},
+			}
+			reader := newClockedRetentionStore(t, client, func() time.Time { return clock })
+
+			got, err := reader.ReadFrontier(t.Context(), frontier)
+			if tc.wantError {
+				if !errors.Is(err, ErrRetention) {
+					t.Fatalf("ReadFrontier accepted retention expiry after nested Reload: %v", err)
+				}
+			} else if err != nil || got.ID != set.ID {
+				t.Fatalf("ReadFrontier rejected protected evidence before deadline: got=%#v err=%v", got, err)
+			}
+		})
+	}
+}
+
+func newClockedRetentionStore(t *testing.T, client Client, clock func() time.Time) *Store {
+	t.Helper()
+	store, err := New(client, Config{
+		Endpoint: "http://127.0.0.1:9000", Region: "us-east-1", SourceBucket: "source", EvidenceBucket: "evidence", Prefix: "test", Clock: clock,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+type retentionAdvancingClient struct {
+	*versionedFakeS3
+	onRead func(string)
+}
+
+func (c *retentionAdvancingClient) GetObject(ctx context.Context, in *s3.GetObjectInput, options ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	out, err := c.versionedFakeS3.GetObject(ctx, in, options...)
+	if err != nil || out == nil || out.Body == nil || c.onRead == nil {
+		return out, err
+	}
+	out.Body = &retentionAdvancingBody{ReadCloser: out.Body, key: stringValue(in.Key), onRead: c.onRead}
+	return out, nil
+}
+
+type retentionAdvancingBody struct {
+	io.ReadCloser
+	key    string
+	onRead func(string)
+	once   sync.Once
+}
+
+func (b *retentionAdvancingBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if n > 0 {
+		b.once.Do(func() { b.onRead(b.key) })
+	}
+	return n, err
+}

--- a/internal/recoveryset/observationstore/source.go
+++ b/internal/recoveryset/observationstore/source.go
@@ -1,0 +1,81 @@
+package observationstore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+)
+
+func (s *Store) verifySource(ctx context.Context, object observation.ProviderObject, required time.Time) (observation.Protection, error) {
+	return s.verifySourceAt(ctx, object, time.Time{}, s.now(), required)
+}
+
+func (s *Store) verifySourceAt(ctx context.Context, object observation.ProviderObject, recordedUntil, now, required time.Time) (observation.Protection, error) {
+	if object.Endpoint != s.endpoint || object.Region != s.region || object.Bucket != s.sourceBucket {
+		return observation.Protection{}, fmt.Errorf("%w: source object is outside configured provider namespace", ErrInvalid)
+	}
+	if object.Size > s.maxSourceBytes {
+		return observation.Protection{}, fmt.Errorf("%w: source object exceeds bounded verification size", ErrInvalid)
+	}
+	head, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: ptr(s.sourceBucket), Key: ptr(object.Key), VersionId: ptr(object.VersionID)})
+	if err != nil {
+		return observation.Protection{}, backendError(ctx, "head source object", err)
+	}
+	if head == nil || head.ContentLength == nil || *head.ContentLength != object.Size || stringValue(head.VersionId) != object.VersionID {
+		return observation.Protection{}, fmt.Errorf("%w: source object version, size, or identity differs", ErrIntegrity)
+	}
+	retention, err := s.retention(ctx, s.sourceBucket, object.Key, object.VersionID)
+	if err != nil {
+		return observation.Protection{}, err
+	}
+	if retention.Mode != types.ObjectLockRetentionModeCompliance || retention.RetainUntilDate == nil || retention.RetainUntilDate.Before(required) || (!now.IsZero() && !retention.RetainUntilDate.After(now)) {
+		return observation.Protection{}, fmt.Errorf("%w: source object is not COMPLIANCE-retained through required horizon", ErrRetention)
+	}
+	get, err := s.client.GetObject(ctx, &s3.GetObjectInput{Bucket: ptr(s.sourceBucket), Key: ptr(object.Key), VersionId: ptr(object.VersionID)})
+	if err != nil {
+		return observation.Protection{}, backendError(ctx, "get source object", err)
+	}
+	if get != nil && get.Body != nil && (stringValue(get.VersionId) != object.VersionID || get.ContentLength == nil || *get.ContentLength != object.Size) {
+		_ = get.Body.Close()
+		return observation.Protection{}, fmt.Errorf("%w: source object response metadata differs", ErrIntegrity)
+	}
+	if get == nil || get.Body == nil {
+		return observation.Protection{}, fmt.Errorf("%w: source object body is missing", ErrBackend)
+	}
+	actualSize, actualHash, readErr := hashBody(get.Body, object.Size)
+	closeErr := get.Body.Close()
+	if readErr != nil || closeErr != nil {
+		return observation.Protection{}, fmt.Errorf("%w: source object body could not be verified", ErrIntegrity)
+	}
+	if actualSize != object.Size || actualHash != object.SHA256 {
+		return observation.Protection{}, fmt.Errorf("%w: source object bytes differ from captured hash and size", ErrIntegrity)
+	}
+	until := retention.RetainUntilDate.UTC()
+	if !recordedUntil.IsZero() && until.Before(recordedUntil) {
+		return observation.Protection{}, fmt.Errorf("%w: provider source protection is shorter than recorded protection", ErrIntegrity)
+	}
+	return observation.Protection{Object: object, Mode: string(retention.Mode), RetainUntil: until}, nil
+}
+
+func (s *Store) retention(ctx context.Context, bucket, key, version string) (types.ObjectLockRetention, error) {
+	result, err := s.client.GetObjectRetention(ctx, &s3.GetObjectRetentionInput{Bucket: ptr(bucket), Key: ptr(key), VersionId: ptr(version)})
+	if err != nil {
+		// Providers commonly report an object without Object Lock as either a
+		// 400 InvalidRequest or a 404 configuration/method error.  Both mean
+		// this exact source version is not admissible evidence; preserve the
+		// retention classification without exposing provider error text.
+		switch apiCode(err) {
+		case "BadRequest", "InvalidRequest", "InvalidRequestException", "MethodNotAllowed", "NoSuchObjectLockConfiguration", "NotImplemented":
+			return types.ObjectLockRetention{}, fmt.Errorf("%w: object retention is unavailable", ErrRetention)
+		}
+		return types.ObjectLockRetention{}, backendError(ctx, "get object retention", err)
+	}
+	if result == nil || result.Retention == nil {
+		return types.ObjectLockRetention{}, fmt.Errorf("%w: object retention response is incomplete", ErrRetention)
+	}
+	return *result.Retention, nil
+}

--- a/internal/recoveryset/observationstore/store.go
+++ b/internal/recoveryset/observationstore/store.go
@@ -1,0 +1,788 @@
+// Package observationstore persists provider observation evidence outside the
+// control database.  It is deliberately an evidence store only: it does not
+// publish a recovery frontier or participate in restore/startup.
+package observationstore
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+	postgrescapture "github.com/flidai/leapview/internal/recoveryset/postgres"
+)
+
+const (
+	SchemaVersion           int32 = 1
+	DefaultMaxSourceBytes         = 8 << 30
+	DefaultOperationTimeout       = 5 * time.Minute
+	maxDescriptorBytes            = 8 << 20
+	maxFrontierBytes              = 1 << 20
+)
+
+var (
+	ErrInvalid   = errors.New("observation store input is invalid")
+	ErrBackend   = errors.New("observation store backend failed")
+	ErrIntegrity = errors.New("observation store integrity check failed")
+	ErrNotFound  = errors.New("observation store object not found")
+	ErrConflict  = errors.New("observation store immutable object conflicts")
+	ErrRetention = errors.New("observation store retention requirement failed")
+)
+
+// Client is intentionally the small set of pinned S3 operations required by
+// this store.  *s3.Client satisfies it; keeping the interface here also makes
+// protocol regressions testable without weakening production verification.
+type Client interface {
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	HeadObject(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	GetObjectRetention(context.Context, *s3.GetObjectRetentionInput, ...func(*s3.Options)) (*s3.GetObjectRetentionOutput, error)
+}
+
+// Config is all provider namespace authority for an evidence store.  Endpoint
+// and Region are checked against observations, but requests always use the
+// client supplied at construction; caller-provided observation endpoints are
+// never used to choose a client or route a request.
+type Config struct {
+	Endpoint       string
+	Region         string
+	SourceBucket   string
+	EvidenceBucket string
+	Prefix         string
+
+	// MaxSourceBytes bounds one streamed source-object verification.  The
+	// default is the qualification ceiling; callers may lower it to bound
+	// provider responses more tightly.
+	MaxSourceBytes int64
+
+	// Clock is an optional trusted clock for deterministic qualification tests.
+	// Callers cannot supply a reload time that bypasses this clock.
+	Clock func() time.Time
+
+	OperationTimeout time.Duration
+}
+
+type Store struct {
+	client           Client
+	endpoint         string
+	region           string
+	sourceBucket     string
+	evidenceBucket   string
+	prefix           string
+	maxSourceBytes   int64
+	clock            func() time.Time
+	operationTimeout time.Duration
+}
+
+// New constructs a store with one already configured/pinned AWS client.
+func New(client Client, config Config) (*Store, error) {
+	if client == nil {
+		return nil, fmt.Errorf("%w: S3 client is required", ErrInvalid)
+	}
+	endpoint, err := validateEndpoint(config.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	region, err := validateText(config.Region, "region", 128)
+	if err != nil {
+		return nil, err
+	}
+	source, err := validateBucket(config.SourceBucket, "source bucket")
+	if err != nil {
+		return nil, err
+	}
+	evidence, err := validateBucket(config.EvidenceBucket, "evidence bucket")
+	if err != nil {
+		return nil, err
+	}
+	prefix := strings.Trim(config.Prefix, "/")
+	if len(prefix) > 1024 || strings.ContainsAny(prefix, "\x00\r\n") {
+		return nil, fmt.Errorf("%w: evidence prefix is invalid", ErrInvalid)
+	}
+	maxSource := config.MaxSourceBytes
+	if maxSource == 0 {
+		maxSource = DefaultMaxSourceBytes
+	}
+	if maxSource <= 0 || maxSource > DefaultMaxSourceBytes {
+		return nil, fmt.Errorf("%w: maximum source object size is outside qualification bounds", ErrInvalid)
+	}
+	timeout := config.OperationTimeout
+	if timeout == 0 {
+		timeout = DefaultOperationTimeout
+	}
+	if timeout <= 0 || timeout > 24*time.Hour {
+		return nil, fmt.Errorf("%w: operation timeout is invalid", ErrInvalid)
+	}
+	return &Store{client: client, endpoint: endpoint, region: region, sourceBucket: source,
+		evidenceBucket: evidence, prefix: prefix, maxSourceBytes: maxSource, clock: config.Clock, operationTimeout: timeout}, nil
+}
+
+// ObjectRef identifies one immutable evidence object.  VersionID is required
+// even though the content-addressed key already includes SHA256: key identity
+// and provider version identity are separate checks.
+type ObjectRef struct {
+	Bucket    string `json:"bucket"`
+	Key       string `json:"key"`
+	VersionID string `json:"version_id"`
+	SHA256    string `json:"sha256"`
+	Size      int64  `json:"size"`
+}
+
+func (r ObjectRef) Validate() error {
+	if _, err := validateBucket(r.Bucket, "object bucket"); err != nil {
+		return err
+	}
+	if _, err := validateText(r.Key, "object key", 2048); err != nil {
+		return err
+	}
+	if r.VersionID == "" || r.VersionID != strings.TrimSpace(r.VersionID) || strings.EqualFold(r.VersionID, "null") || len(r.VersionID) > 1024 || !utf8.ValidString(r.VersionID) || strings.IndexFunc(r.VersionID, unicode.IsControl) >= 0 {
+		return fmt.Errorf("%w: object version ID is invalid", ErrInvalid)
+	}
+	if !rawSHA256(r.SHA256) {
+		return fmt.Errorf("%w: object SHA-256 is invalid", ErrInvalid)
+	}
+	if r.Size < 0 {
+		return fmt.Errorf("%w: object size is negative", ErrInvalid)
+	}
+	return nil
+}
+
+func (r ObjectRef) equal(other ObjectRef) bool { return r == other }
+
+// Ref is the portable handle returned by Save and accepted by Reload.  It
+// contains no endpoint or client, so a separately configured client can reload
+// it while the store retains routing authority.
+type Ref struct {
+	SchemaVersion int32     `json:"schema_version"`
+	Manifest      ObjectRef `json:"manifest"`
+	Boundary      ObjectRef `json:"boundary"`
+	Descriptor    ObjectRef `json:"descriptor"`
+}
+
+func (r Ref) Validate() error {
+	if r.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: unsupported evidence reference schema version %d", ErrInvalid, r.SchemaVersion)
+	}
+	for _, object := range []ObjectRef{r.Manifest, r.Boundary, r.Descriptor} {
+		if err := object.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Evidence is the fully verified observation bundle returned by Reload.
+type Evidence struct {
+	Manifest   observation.Manifest
+	Boundary   observation.Boundary
+	Descriptor Descriptor
+	Ref        Ref
+}
+
+// Descriptor is the immutable, non-circular evidence index.  It binds the
+// exact manifest and boundary object refs, source bytes/protections, and the
+// required horizon.  Its own digest/ref intentionally do not appear here.
+type Descriptor struct {
+	SchemaVersion       int32                    `json:"schema_version"`
+	ManifestDigest      string                   `json:"manifest_digest"`
+	BoundaryDigest      string                   `json:"boundary_digest"`
+	Manifest            ObjectRef                `json:"manifest"`
+	Boundary            ObjectRef                `json:"boundary"`
+	RequiredRetainUntil time.Time                `json:"required_retain_until"`
+	SourceProtections   []observation.Protection `json:"source_protections"`
+}
+
+func (d Descriptor) Validate() error {
+	if d.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: unsupported descriptor schema version %d", ErrInvalid, d.SchemaVersion)
+	}
+	if !digest(d.ManifestDigest) || !digest(d.BoundaryDigest) {
+		return fmt.Errorf("%w: descriptor digests are invalid", ErrInvalid)
+	}
+	if err := d.Manifest.Validate(); err != nil {
+		return err
+	}
+	if err := d.Boundary.Validate(); err != nil {
+		return err
+	}
+	if d.Manifest.SHA256 != rawDigest(d.ManifestDigest) || d.Boundary.SHA256 != rawDigest(d.BoundaryDigest) {
+		return fmt.Errorf("%w: descriptor object ref digest mismatch", ErrIntegrity)
+	}
+	if d.RequiredRetainUntil.IsZero() {
+		return fmt.Errorf("%w: descriptor retention horizon is required", ErrInvalid)
+	}
+	if d.SourceProtections == nil || len(d.SourceProtections) > observation.MaxManifestObjects {
+		return fmt.Errorf("%w: descriptor source protections must be an explicit bounded array", ErrInvalid)
+	}
+	for _, protection := range d.SourceProtections {
+		if err := protection.ValidateAt(d.RequiredRetainUntil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d Descriptor) CanonicalJSON() ([]byte, error) {
+	if err := d.Validate(); err != nil {
+		return nil, err
+	}
+	copyOf := d
+	copyOf.RequiredRetainUntil = copyOf.RequiredRetainUntil.UTC()
+	if d.SourceProtections != nil {
+		copyOf.SourceProtections = make([]observation.Protection, len(d.SourceProtections))
+		copy(copyOf.SourceProtections, d.SourceProtections)
+		for i := range copyOf.SourceProtections {
+			copyOf.SourceProtections[i].RetainUntil = copyOf.SourceProtections[i].RetainUntil.UTC()
+		}
+		sort.Slice(copyOf.SourceProtections, func(i, j int) bool {
+			left, right := copyOf.SourceProtections[i], copyOf.SourceProtections[j]
+			if keyLeft, keyRight := providerKey(left.Object), providerKey(right.Object); keyLeft != keyRight {
+				return keyLeft < keyRight
+			}
+			if left.Mode != right.Mode {
+				return left.Mode < right.Mode
+			}
+			return left.RetainUntil.Before(right.RetainUntil)
+		})
+	}
+	// Reload additionally compares protections as a keyed set, so an
+	// independently authored descriptor cannot smuggle duplicate identities
+	// through ordering.
+	return json.Marshal(copyOf)
+}
+
+func (d Descriptor) Digest() (string, error) {
+	b, err := d.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(b), nil
+}
+
+// Save verifies the exact captured source closure, then writes canonical
+// manifest, boundary, and descriptor objects with compliance retention.
+// captured is intentionally the opaque adapter type; no caller-supplied
+// boundary or inventory is accepted.
+func (s *Store) Save(ctx context.Context, captured *postgrescapture.CapturedObservation, observations []observation.Observation, until time.Time) (Ref, error) {
+	if err := validContext(ctx); err != nil {
+		return Ref{}, err
+	}
+	ctx, cancel := s.operationContext(ctx)
+	defer cancel()
+	if captured == nil {
+		return Ref{}, fmt.Errorf("%w: trusted captured observation is required", ErrInvalid)
+	}
+	if until.IsZero() {
+		return Ref{}, fmt.Errorf("%w: retention horizon is required", ErrInvalid)
+	}
+	until = ceilSecond(until.UTC())
+	if !until.After(s.now()) {
+		return Ref{}, fmt.Errorf("%w: retention horizon must be in the future", ErrInvalid)
+	}
+	boundary := captured.Boundary()
+	inventory := captured.Inventory()
+	objects := append([]observation.Observation(nil), observations...)
+	if objects == nil {
+		objects = make([]observation.Observation, 0)
+	}
+	manifest := observation.Manifest{SchemaVersion: observation.SchemaVersion, Boundary: boundary, Inventory: inventory, Objects: objects}
+	normalized, err := manifest.Normalize()
+	if err != nil {
+		return Ref{}, err
+	}
+	for _, item := range normalized.Objects {
+		if item.Object.Endpoint != s.endpoint || item.Object.Region != s.region || item.Object.Bucket != s.sourceBucket {
+			return Ref{}, fmt.Errorf("%w: observation provider namespace does not match the configured source", ErrInvalid)
+		}
+	}
+	canonicalManifest, err := normalized.CanonicalJSON()
+	if err != nil {
+		return Ref{}, err
+	}
+	canonicalBoundary, err := normalized.Boundary.CanonicalJSON()
+	if err != nil {
+		return Ref{}, err
+	}
+	if len(canonicalManifest) > observation.MaxManifestBytes || len(canonicalBoundary) > observation.MaxManifestBytes {
+		return Ref{}, fmt.Errorf("%w: evidence document exceeds bounded size", ErrInvalid)
+	}
+
+	protections := make([]observation.Protection, 0, len(normalized.Objects))
+	for _, item := range normalized.Objects {
+		protection, err := s.verifySource(ctx, item.Object, until)
+		if err != nil {
+			return Ref{}, err
+		}
+		protections = append(protections, protection)
+	}
+	manifestDigest := normalizedDigest(canonicalManifest)
+	boundaryDigest := normalizedDigest(canonicalBoundary)
+	manifestRef, err := s.putEvidence(ctx, "manifest", manifestDigest, canonicalManifest, until)
+	if err != nil {
+		return Ref{}, err
+	}
+	boundaryRef, err := s.putEvidence(ctx, "boundary", boundaryDigest, canonicalBoundary, until)
+	if err != nil {
+		return Ref{}, err
+	}
+	descriptor := Descriptor{SchemaVersion: SchemaVersion, ManifestDigest: manifestDigest, BoundaryDigest: boundaryDigest,
+		Manifest: manifestRef, Boundary: boundaryRef, RequiredRetainUntil: until.UTC(), SourceProtections: protections}
+	descriptorBytes, err := descriptor.CanonicalJSON()
+	if err != nil {
+		return Ref{}, err
+	}
+	if len(descriptorBytes) > maxDescriptorBytes {
+		return Ref{}, fmt.Errorf("%w: descriptor exceeds bounded size", ErrInvalid)
+	}
+	descriptorDigest := digestBytes(descriptorBytes)
+	descriptorRef, err := s.putEvidence(ctx, "descriptor", descriptorDigest, descriptorBytes, until)
+	if err != nil {
+		return Ref{}, err
+	}
+	ref := Ref{SchemaVersion: SchemaVersion, Manifest: manifestRef, Boundary: boundaryRef, Descriptor: descriptorRef}
+	if err := ref.Validate(); err != nil {
+		return Ref{}, err
+	}
+	if !until.After(s.now()) {
+		return Ref{}, fmt.Errorf("%w: retention horizon elapsed during save", ErrRetention)
+	}
+	return ref, nil
+}
+
+// Reload verifies descriptor, boundary, manifest, every source object, and
+// every retention record. An optional argument raises the required retention
+// horizon; expiry still uses the trusted store clock.
+func (s *Store) Reload(ctx context.Context, ref Ref, horizons ...time.Time) (Evidence, error) {
+	if err := validContext(ctx); err != nil {
+		return Evidence{}, err
+	}
+	ctx, cancel := s.operationContext(ctx)
+	defer cancel()
+	if err := ref.Validate(); err != nil {
+		return Evidence{}, err
+	}
+	if ref.Manifest.Key != s.evidenceKey("manifest", "sha256:"+ref.Manifest.SHA256) || ref.Boundary.Key != s.evidenceKey("boundary", "sha256:"+ref.Boundary.SHA256) || ref.Descriptor.Key != s.evidenceKey("descriptor", "sha256:"+ref.Descriptor.SHA256) {
+		return Evidence{}, fmt.Errorf("%w: evidence refs are not content-addressed", ErrIntegrity)
+	}
+	now := s.now()
+	if len(horizons) > 1 {
+		return Evidence{}, fmt.Errorf("%w: reload accepts one required horizon", ErrInvalid)
+	}
+	required := time.Time{}
+	if len(horizons) == 1 && !horizons[0].IsZero() {
+		required = ceilSecond(horizons[0].UTC())
+	}
+	descriptorBytes, _, err := s.getEvidence(ctx, ref.Descriptor, now, required)
+	if err != nil {
+		return Evidence{}, err
+	}
+	descriptor, err := parseDescriptor(descriptorBytes)
+	if err != nil {
+		return Evidence{}, err
+	}
+	if required.IsZero() {
+		required = descriptor.RequiredRetainUntil
+	}
+	// The initial descriptor read proves it is live now.  Recheck it against
+	// the descriptor's recorded horizon before accepting the bundle.
+	if _, _, err := s.getEvidence(ctx, ref.Descriptor, now, descriptor.RequiredRetainUntil); err != nil {
+		return Evidence{}, err
+	}
+	if descriptor.RequiredRetainUntil.Before(required) {
+		return Evidence{}, fmt.Errorf("%w: descriptor horizon is shorter than requested horizon", ErrRetention)
+	}
+	if !descriptor.Manifest.equal(ref.Manifest) || !descriptor.Boundary.equal(ref.Boundary) {
+		return Evidence{}, fmt.Errorf("%w: descriptor does not bind supplied manifest and boundary refs", ErrIntegrity)
+	}
+	manifestBytes, _, err := s.getEvidence(ctx, ref.Manifest, now, required)
+	if err != nil {
+		return Evidence{}, err
+	}
+	boundaryBytes, _, err := s.getEvidence(ctx, ref.Boundary, now, required)
+	if err != nil {
+		return Evidence{}, err
+	}
+	manifest, err := observation.ParseManifest(manifestBytes)
+	if err != nil {
+		return Evidence{}, fmt.Errorf("%w: parse manifest: %v", ErrIntegrity, err)
+	}
+	boundary, err := observation.ParseBoundary(boundaryBytes)
+	if err != nil {
+		return Evidence{}, fmt.Errorf("%w: parse boundary: %v", ErrIntegrity, err)
+	}
+	canonicalManifest, manifestErr := manifest.CanonicalJSON()
+	canonicalBoundary, boundaryErr := boundary.CanonicalJSON()
+	if manifestErr != nil || boundaryErr != nil || !bytes.Equal(manifestBytes, canonicalManifest) || !bytes.Equal(boundaryBytes, canonicalBoundary) {
+		return Evidence{}, fmt.Errorf("%w: manifest or boundary bytes are not canonical", ErrIntegrity)
+	}
+	if !manifest.Boundary.Matches(boundary) || descriptor.ManifestDigest != normalizedDigest(manifestBytes) || descriptor.BoundaryDigest != normalizedDigest(boundaryBytes) {
+		return Evidence{}, fmt.Errorf("%w: manifest, boundary, and descriptor digests are not bound", ErrIntegrity)
+	}
+	if err := compareProtections(manifest, descriptor.SourceProtections); err != nil {
+		return Evidence{}, err
+	}
+	for _, protection := range descriptor.SourceProtections {
+		if _, err := s.verifySourceAt(ctx, protection.Object, protection.RetainUntil, now, required); err != nil {
+			return Evidence{}, err
+		}
+	}
+	return Evidence{Manifest: manifest, Boundary: boundary, Descriptor: descriptor, Ref: ref}, nil
+}
+
+// FrontierRef is an optional, qualification-only persisted recovery-set
+// pointer. It never changes the v1 SQL activation path.
+type FrontierRef struct {
+	SchemaVersion int32     `json:"schema_version"`
+	SetID         string    `json:"set_id"`
+	Digest        string    `json:"digest"`
+	Frontier      ObjectRef `json:"frontier"`
+	SetIDObject   ObjectRef `json:"set_id_object"`
+	Evidence      Ref       `json:"evidence"`
+}
+
+// PersistFrontier binds and immutably persists a schema-2 recovery set after
+// independently reloading its managed evidence. The set-ID object rejects a
+// conflicting replay even when a different content digest is supplied.
+func (s *Store) PersistFrontier(ctx context.Context, set recoveryset.RecoverySet, evidence Ref, until time.Time) (FrontierRef, error) {
+	if err := validContext(ctx); err != nil {
+		return FrontierRef{}, err
+	}
+	ctx, cancel := s.operationContext(ctx)
+	defer cancel()
+	if set.SchemaVersion != recoveryset.EvidenceSchemaVersion || set.ManagedEvidence == nil {
+		return FrontierRef{}, fmt.Errorf("%w: only schema-2 prepared recovery sets can be persisted off-host", ErrInvalid)
+	}
+	if err := set.Validate(); err != nil {
+		return FrontierRef{}, err
+	}
+	until = ceilSecond(until.UTC())
+	if !until.After(s.now()) {
+		return FrontierRef{}, fmt.Errorf("%w: retention horizon must be in the future", ErrInvalid)
+	}
+	loaded, err := s.Reload(ctx, evidence, until)
+	if err != nil {
+		return FrontierRef{}, err
+	}
+	binding := set.ManagedEvidence
+	if binding.ManifestDigest != loaded.Descriptor.ManifestDigest || binding.BoundaryDigest != loaded.Descriptor.BoundaryDigest || binding.DescriptorDigest != "sha256:"+evidence.Descriptor.SHA256 || !binding.Boundary.Matches(loaded.Boundary) {
+		return FrontierRef{}, fmt.Errorf("%w: recovery set managed evidence does not match loaded descriptor", ErrIntegrity)
+	}
+	if set.FrontierDigest == "" {
+		set.FrontierDigest, err = set.Digest()
+		if err != nil {
+			return FrontierRef{}, err
+		}
+	}
+	frontierBytes, err := set.CanonicalJSON()
+	if err != nil {
+		return FrontierRef{}, err
+	}
+	if len(frontierBytes) > maxFrontierBytes {
+		return FrontierRef{}, fmt.Errorf("%w: recovery frontier exceeds bounded size", ErrInvalid)
+	}
+	digest := normalizedDigest(frontierBytes)
+	frontier, err := s.putEvidenceAt(ctx, s.frontierKey(digest), digest, frontierBytes, until)
+	if err != nil {
+		return FrontierRef{}, err
+	}
+	setObject, err := s.putEvidenceAt(ctx, s.setIDKey(set.ID), digest, frontierBytes, until)
+	if err != nil {
+		if errors.Is(err, ErrConflict) {
+			return FrontierRef{}, err
+		}
+		return FrontierRef{}, err
+	}
+	if !until.After(s.now()) {
+		return FrontierRef{}, fmt.Errorf("%w: retention horizon elapsed during frontier persistence", ErrRetention)
+	}
+	return FrontierRef{SchemaVersion: SchemaVersion, SetID: set.ID, Digest: digest, Frontier: frontier, SetIDObject: setObject, Evidence: evidence}, nil
+}
+
+func (s *Store) putEvidence(ctx context.Context, kind, digestValue string, body []byte, until time.Time) (ObjectRef, error) {
+	return s.putEvidenceAt(ctx, s.evidenceKey(kind, digestValue), digestValue, body, until)
+}
+
+func (s *Store) putEvidenceAt(ctx context.Context, key, digestValue string, body []byte, until time.Time) (ObjectRef, error) {
+	if err := validContext(ctx); err != nil {
+		return ObjectRef{}, err
+	}
+	if !rawSHA256(digestValue) && !digest(digestValue) {
+		return ObjectRef{}, fmt.Errorf("%w: evidence digest is invalid", ErrInvalid)
+	}
+	raw := rawDigest(digestValue)
+	if raw == "" {
+		return ObjectRef{}, fmt.Errorf("%w: evidence digest is invalid", ErrInvalid)
+	}
+	if normalizedDigest(body) != "sha256:"+raw {
+		return ObjectRef{}, fmt.Errorf("%w: evidence body does not match digest", ErrIntegrity)
+	}
+	if until.IsZero() {
+		return ObjectRef{}, fmt.Errorf("%w: evidence retention horizon is required", ErrInvalid)
+	}
+	setIDKey := strings.HasPrefix(key, s.evidencePrefix()+"/frontiers/set-id/")
+	if setIDKey {
+		// A current delete marker can hide an older immutable set-ID version.
+		// Prove idempotence first; otherwise inspect all versions and fail closed
+		// before attempting a new write.
+		if existing, existingErr := s.verifyEvidence(ctx, key, nil, "sha256:"+raw, int64(len(body)), until); existingErr == nil {
+			if err := s.ensureSetIDVersionIsOnly(ctx, key, existing.VersionID); err != nil {
+				return ObjectRef{}, err
+			}
+			return existing, nil
+		} else if !errors.Is(existingErr, ErrNotFound) && !errors.Is(existingErr, ErrIntegrity) {
+			return ObjectRef{}, existingErr
+		} else if errors.Is(existingErr, ErrIntegrity) {
+			return ObjectRef{}, fmt.Errorf("%w: existing immutable set-ID differs", ErrConflict)
+		}
+		if err := s.ensureSetIDAbsent(ctx, key); err != nil {
+			return ObjectRef{}, err
+		}
+	}
+	checksum := sha256.Sum256(body)
+	checksum64 := base64.StdEncoding.EncodeToString(checksum[:])
+	put, err := s.client.PutObject(ctx, &s3.PutObjectInput{Bucket: ptr(s.evidenceBucket), Key: ptr(key), Body: bytes.NewReader(body), ContentLength: ptr(int64(len(body))), ChecksumSHA256: ptr(checksum64), IfNoneMatch: ptr("*"), ObjectLockMode: types.ObjectLockModeCompliance, ObjectLockRetainUntilDate: ptr(until.UTC()), Metadata: map[string]string{"leapview-sha256": "sha256:" + raw}})
+	if err != nil && !precondition(err) {
+		return ObjectRef{}, backendError(ctx, "put evidence object", err)
+	}
+	var version *string
+	if err == nil {
+		if put == nil || put.VersionId == nil || stringValue(put.VersionId) == "" || strings.EqualFold(stringValue(put.VersionId), "null") {
+			return ObjectRef{}, fmt.Errorf("%w: S3 did not return an immutable evidence version", ErrIntegrity)
+		}
+		version = put.VersionId
+	}
+	// On a precondition failure this verifies the extant bytes and retention;
+	// it never overwrites an immutable object.
+	ref, existingErr := s.verifyEvidence(ctx, key, version, "sha256:"+raw, int64(len(body)), until)
+	if existingErr != nil {
+		if err != nil && precondition(err) {
+			if errors.Is(existingErr, ErrIntegrity) || errors.Is(existingErr, ErrConflict) {
+				return ObjectRef{}, fmt.Errorf("%w: existing immutable evidence differs", ErrConflict)
+			}
+		}
+		return ObjectRef{}, existingErr
+	}
+	if setIDKey {
+		if err := s.ensureSetIDVersionIsOnly(ctx, key, ref.VersionID); err != nil {
+			return ObjectRef{}, err
+		}
+	}
+	return ref, nil
+}
+
+type versionLister interface {
+	ListObjectVersions(context.Context, *s3.ListObjectVersionsInput, ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error)
+}
+
+// ensureSetIDAbsent closes the delete-marker hole on the fixed set-ID index.
+// A current HEAD miss is not sufficient evidence that the key has never been
+// used, because S3 may hide retained versions behind a delete marker.
+func (s *Store) ensureSetIDAbsent(ctx context.Context, key string) error {
+	lister, ok := s.client.(versionLister)
+	if !ok {
+		return fmt.Errorf("%w: set-ID immutability requires version listing support", ErrBackend)
+	}
+	var keyMarker, versionMarker *string
+	for {
+		result, err := lister.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{Bucket: ptr(s.evidenceBucket), Prefix: ptr(key), KeyMarker: keyMarker, VersionIdMarker: versionMarker, MaxKeys: ptr(int32(1000))})
+		if err != nil {
+			return backendError(ctx, "list set-ID object versions", err)
+		}
+		if result == nil {
+			return fmt.Errorf("%w: set-ID version listing is incomplete", ErrBackend)
+		}
+		for _, version := range result.Versions {
+			if stringValue(version.Key) == key {
+				return fmt.Errorf("%w: set-ID key already has an immutable version", ErrConflict)
+			}
+		}
+		for _, marker := range result.DeleteMarkers {
+			if stringValue(marker.Key) == key {
+				return fmt.Errorf("%w: set-ID key has a delete marker", ErrConflict)
+			}
+		}
+		if result.IsTruncated == nil || !*result.IsTruncated {
+			return nil
+		}
+		if result.NextKeyMarker == nil || result.NextVersionIdMarker == nil || *result.NextKeyMarker == "" || *result.NextVersionIdMarker == "" || keyMarker != nil && *result.NextKeyMarker == *keyMarker && versionMarker != nil && *result.NextVersionIdMarker == *versionMarker {
+			return fmt.Errorf("%w: set-ID version listing pagination is invalid", ErrBackend)
+		}
+		keyMarker, versionMarker = result.NextKeyMarker, result.NextVersionIdMarker
+	}
+}
+
+// ensureSetIDVersionIsOnly detects a delete marker or older version that may
+// have appeared during the write race. The immutable object itself remains
+// retained; this operation only fails closed and never deletes anything.
+func (s *Store) ensureSetIDVersionIsOnly(ctx context.Context, key, version string) error {
+	lister, ok := s.client.(versionLister)
+	if !ok {
+		return fmt.Errorf("%w: set-ID immutability requires version listing support", ErrBackend)
+	}
+	result, err := lister.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{Bucket: ptr(s.evidenceBucket), Prefix: ptr(key), MaxKeys: ptr(int32(1000))})
+	if err != nil {
+		return backendError(ctx, "list set-ID object versions", err)
+	}
+	if result == nil {
+		return fmt.Errorf("%w: set-ID version listing is incomplete", ErrBackend)
+	}
+	if result.IsTruncated != nil && *result.IsTruncated {
+		return fmt.Errorf("%w: set-ID version listing exceeds bounded identity history", ErrBackend)
+	}
+	seen := false
+	for _, item := range result.Versions {
+		if stringValue(item.Key) == key {
+			if stringValue(item.VersionId) != version {
+				return fmt.Errorf("%w: set-ID key has a conflicting immutable version", ErrConflict)
+			}
+			seen = true
+		}
+	}
+	for _, marker := range result.DeleteMarkers {
+		if stringValue(marker.Key) == key {
+			return fmt.Errorf("%w: set-ID key has a delete marker", ErrConflict)
+		}
+	}
+	if !seen {
+		return fmt.Errorf("%w: set-ID write version is absent from immutable history", ErrIntegrity)
+	}
+	return nil
+}
+
+func (s *Store) verifyEvidence(ctx context.Context, key string, version *string, digestValue string, size int64, required time.Time) (ObjectRef, error) {
+	if size > maxDescriptorBytes {
+		return ObjectRef{}, fmt.Errorf("%w: evidence object exceeds bounded size", ErrInvalid)
+	}
+	head, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: ptr(s.evidenceBucket), Key: ptr(key), VersionId: version})
+	if err != nil {
+		if apiCode(err) == "NoSuchKey" || apiCode(err) == "NotFound" {
+			return ObjectRef{}, ErrNotFound
+		}
+		return ObjectRef{}, backendError(ctx, "head evidence object", err)
+	}
+	if head == nil || head.ContentLength == nil || *head.ContentLength != size || stringValue(head.VersionId) == "" || strings.EqualFold(stringValue(head.VersionId), "null") || version != nil && stringValue(head.VersionId) != stringValue(version) {
+		return ObjectRef{}, fmt.Errorf("%w: evidence object metadata is incomplete", ErrIntegrity)
+	}
+	retention, err := s.retention(ctx, s.evidenceBucket, key, stringValue(head.VersionId))
+	if err != nil {
+		return ObjectRef{}, err
+	}
+	if retention.Mode != types.ObjectLockRetentionModeCompliance || retention.RetainUntilDate == nil || retention.RetainUntilDate.Before(required) {
+		return ObjectRef{}, fmt.Errorf("%w: evidence object is not COMPLIANCE-retained through required horizon", ErrRetention)
+	}
+	get, err := s.client.GetObject(ctx, &s3.GetObjectInput{Bucket: ptr(s.evidenceBucket), Key: ptr(key), VersionId: head.VersionId})
+	if err != nil {
+		return ObjectRef{}, backendError(ctx, "get evidence object", err)
+	}
+	if get != nil && get.Body != nil && (stringValue(get.VersionId) != stringValue(head.VersionId) || get.ContentLength == nil || *get.ContentLength != size) {
+		_ = get.Body.Close()
+		return ObjectRef{}, fmt.Errorf("%w: evidence object response metadata differs", ErrIntegrity)
+	}
+	if get == nil || get.Body == nil {
+		return ObjectRef{}, fmt.Errorf("%w: evidence object body is missing", ErrBackend)
+	}
+	actualSize, actualHash, readErr := hashBody(get.Body, size)
+	closeErr := get.Body.Close()
+	if readErr != nil || closeErr != nil || actualSize != size || actualHash != rawDigest(digestValue) {
+		return ObjectRef{}, fmt.Errorf("%w: evidence object bytes differ", ErrIntegrity)
+	}
+	return ObjectRef{Bucket: s.evidenceBucket, Key: key, VersionID: stringValue(head.VersionId), SHA256: rawDigest(digestValue), Size: size}, nil
+}
+
+// getEvidence verifies an exact evidence ref. It returns bytes only after the
+// provider version, content length/hash, and retention have all matched.
+func (s *Store) getEvidence(ctx context.Context, ref ObjectRef, now, required time.Time) ([]byte, ObjectRef, error) {
+	if err := s.validateEvidenceRef(ref); err != nil {
+		return nil, ObjectRef{}, err
+	}
+	if ref.Size > maxDescriptorBytes {
+		return nil, ObjectRef{}, fmt.Errorf("%w: evidence ref exceeds bounded size", ErrInvalid)
+	}
+	head, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: ptr(s.evidenceBucket), Key: ptr(ref.Key), VersionId: ptr(ref.VersionID)})
+	if err != nil {
+		return nil, ObjectRef{}, backendError(ctx, "head evidence ref", err)
+	}
+	if head == nil || head.ContentLength == nil || *head.ContentLength != ref.Size || stringValue(head.VersionId) != ref.VersionID {
+		return nil, ObjectRef{}, fmt.Errorf("%w: evidence ref metadata differs", ErrIntegrity)
+	}
+	retention, err := s.retention(ctx, s.evidenceBucket, ref.Key, ref.VersionID)
+	if err != nil {
+		return nil, ObjectRef{}, err
+	}
+	if retention.Mode != types.ObjectLockRetentionModeCompliance || retention.RetainUntilDate == nil || retention.RetainUntilDate.Before(required) || (!now.IsZero() && !retention.RetainUntilDate.After(now)) {
+		return nil, ObjectRef{}, fmt.Errorf("%w: evidence ref retention is insufficient", ErrRetention)
+	}
+	get, err := s.client.GetObject(ctx, &s3.GetObjectInput{Bucket: ptr(s.evidenceBucket), Key: ptr(ref.Key), VersionId: ptr(ref.VersionID)})
+	if err != nil {
+		return nil, ObjectRef{}, backendError(ctx, "get evidence ref", err)
+	}
+	if get != nil && get.Body != nil && (stringValue(get.VersionId) != ref.VersionID || get.ContentLength == nil || *get.ContentLength != ref.Size) {
+		_ = get.Body.Close()
+		return nil, ObjectRef{}, fmt.Errorf("%w: evidence ref response metadata differs", ErrIntegrity)
+	}
+	if get == nil || get.Body == nil {
+		return nil, ObjectRef{}, fmt.Errorf("%w: evidence ref body is missing", ErrBackend)
+	}
+	body, readErr := io.ReadAll(io.LimitReader(get.Body, ref.Size+1))
+	closeErr := get.Body.Close()
+	if readErr != nil || closeErr != nil || int64(len(body)) != ref.Size || normalizedDigest(body) != "sha256:"+ref.SHA256 {
+		return nil, ObjectRef{}, fmt.Errorf("%w: evidence ref bytes differ", ErrIntegrity)
+	}
+	return body, ObjectRef{Bucket: s.evidenceBucket, Key: ref.Key, VersionID: ref.VersionID, SHA256: ref.SHA256, Size: ref.Size}, nil
+}
+
+func (s *Store) validateEvidenceRef(ref ObjectRef) error {
+	if err := ref.Validate(); err != nil {
+		return err
+	}
+	if ref.Bucket != s.evidenceBucket || !strings.HasPrefix(ref.Key, s.evidencePrefix()+"/") {
+		return fmt.Errorf("%w: evidence ref is outside configured bucket and prefix", ErrInvalid)
+	}
+	return nil
+}
+
+func compareProtections(manifest observation.Manifest, protections []observation.Protection) error {
+	if len(manifest.Objects) != len(protections) {
+		return fmt.Errorf("%w: descriptor source protection count differs from manifest", ErrIntegrity)
+	}
+	byKey := make(map[string][]observation.Protection, len(protections))
+	for _, protection := range protections {
+		key := providerKey(protection.Object)
+		byKey[key] = append(byKey[key], protection)
+	}
+	for _, item := range manifest.Objects {
+		key := providerKey(item.Object)
+		entries := byKey[key]
+		if len(entries) == 0 {
+			return fmt.Errorf("%w: descriptor source protection does not bind manifest object", ErrIntegrity)
+		}
+		protection := entries[0]
+		byKey[key] = entries[1:]
+		if protection.Mode != string(types.ObjectLockRetentionModeCompliance) || protection.Object != item.Object {
+			return fmt.Errorf("%w: descriptor source protection does not bind manifest object", ErrIntegrity)
+		}
+	}
+	for _, entries := range byKey {
+		if len(entries) != 0 {
+			return fmt.Errorf("%w: descriptor has an unreferenced source protection", ErrIntegrity)
+		}
+	}
+	return nil
+}
+
+func providerKey(object observation.ProviderObject) string {
+	return object.Endpoint + "\x00" + object.Region + "\x00" + object.Bucket + "\x00" + object.Key + "\x00" + object.VersionID + "\x00" + object.SHA256 + fmt.Sprintf("\x00%d", object.Size)
+}

--- a/internal/recoveryset/observationstore/store.go
+++ b/internal/recoveryset/observationstore/store.go
@@ -404,6 +404,9 @@ func (s *Store) Reload(ctx context.Context, ref Ref, horizons ...time.Time) (Evi
 	if descriptor.RequiredRetainUntil.Before(required) {
 		return Evidence{}, fmt.Errorf("%w: descriptor horizon is shorter than requested horizon", ErrRetention)
 	}
+	// The descriptor is authoritative. An optional horizon may raise the
+	// requirement, but it can never weaken the recorded retention horizon.
+	required = descriptor.RequiredRetainUntil
 	if !descriptor.Manifest.equal(ref.Manifest) || !descriptor.Boundary.equal(ref.Boundary) {
 		return Evidence{}, fmt.Errorf("%w: descriptor does not bind supplied manifest and boundary refs", ErrIntegrity)
 	}
@@ -438,6 +441,9 @@ func (s *Store) Reload(ctx context.Context, ref Ref, horizons ...time.Time) (Evi
 		if _, err := s.verifySourceAt(ctx, protection.Object, protection.RetainUntil, now, required); err != nil {
 			return Evidence{}, err
 		}
+	}
+	if !descriptor.RequiredRetainUntil.After(s.now()) {
+		return Evidence{}, fmt.Errorf("%w: retention horizon elapsed during reload", ErrRetention)
 	}
 	return Evidence{Manifest: manifest, Boundary: boundary, Descriptor: descriptor, Ref: ref}, nil
 }
@@ -475,6 +481,9 @@ func (s *Store) PersistFrontier(ctx context.Context, set recoveryset.RecoverySet
 	loaded, err := s.Reload(ctx, evidence, until)
 	if err != nil {
 		return FrontierRef{}, err
+	}
+	if until.Before(loaded.Descriptor.RequiredRetainUntil) {
+		return FrontierRef{}, fmt.Errorf("%w: frontier horizon is shorter than descriptor horizon", ErrRetention)
 	}
 	binding := set.ManagedEvidence
 	if binding.ManifestDigest != loaded.Descriptor.ManifestDigest || binding.BoundaryDigest != loaded.Descriptor.BoundaryDigest || binding.DescriptorDigest != "sha256:"+evidence.Descriptor.SHA256 || !binding.Boundary.Matches(loaded.Boundary) {

--- a/internal/recoveryset/observationstore/store_test.go
+++ b/internal/recoveryset/observationstore/store_test.go
@@ -1,0 +1,197 @@
+package observationstore
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+)
+
+func TestPutEvidenceIsConditionalAndComplianceRetained(t *testing.T) {
+	provider := newFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store := newTestStore(t, provider, now)
+	until := now.Add(2 * time.Hour)
+	body := []byte("immutable evidence")
+	digestValue := normalizedDigest(body)
+	ref, err := store.putEvidence(t.Context(), "manifest", digestValue, body, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.VersionID == "" || ref.SHA256 != rawDigest(digestValue) {
+		t.Fatalf("ref = %#v", ref)
+	}
+	provider.mu.Lock()
+	put := provider.puts[0]
+	provider.mu.Unlock()
+	if put.IfNoneMatch == nil || *put.IfNoneMatch != "*" || put.ObjectLockMode != types.ObjectLockModeCompliance || put.ObjectLockRetainUntilDate == nil || !put.ObjectLockRetainUntilDate.Equal(ceilSecond(until)) {
+		t.Fatalf("PutObject did not pin conditional compliance retention: %#v", put)
+	}
+	if _, err := store.putEvidence(t.Context(), "manifest", digestValue, body, until); err != nil {
+		t.Fatalf("idempotent evidence write: %v", err)
+	}
+	provider.mu.Lock()
+	puts := len(provider.puts)
+	provider.mu.Unlock()
+	if puts != 2 { // provider receives the conditional retry; it never receives an overwrite
+		t.Fatalf("PutObject calls = %d, want 2 conditional attempts", puts)
+	}
+}
+
+func TestPutEvidenceRejectsDifferentBytesOnPrecondition(t *testing.T) {
+	provider := newFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store := newTestStore(t, provider, now)
+	key := store.evidenceKey("manifest", normalizedDigest([]byte("expected")))
+	provider.add(key, []byte("different"), now.Add(time.Hour))
+	_, err := store.putEvidence(t.Context(), "manifest", normalizedDigest([]byte("expected")), []byte("expected"), now.Add(time.Minute))
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("different precondition object error = %v", err)
+	}
+	if strings.Contains(err.Error(), "different") {
+		t.Fatal("provider object bytes leaked through error")
+	}
+}
+
+func TestReloadBindsExactVersionAndRecordedHorizon(t *testing.T) {
+	provider := newFakeS3()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	store := newTestStore(t, provider, now)
+	until := now.Add(2 * time.Hour)
+	inventory := observation.Inventory{SchemaVersion: observation.SchemaVersion, Revisions: []observation.Revision{}}
+	inventoryDigest, err := inventory.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := observation.Boundary{ProtocolVersion: observation.ProtocolVersion, DatabaseIdentity: "control_db", SystemIdentity: "12345", Timeline: 1, LSN: "0/100", RestorePointName: "point", InventoryDigest: inventoryDigest}
+	manifest := observation.Manifest{SchemaVersion: observation.SchemaVersion, Boundary: boundary, Inventory: inventory, Objects: []observation.Observation{}}
+	manifestBytes, err := manifest.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundaryBytes, err := boundary.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestRef, err := store.putEvidence(t.Context(), "manifest", normalizedDigest(manifestBytes), manifestBytes, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundaryRef, err := store.putEvidence(t.Context(), "boundary", normalizedDigest(boundaryBytes), boundaryBytes, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor := Descriptor{SchemaVersion: SchemaVersion, ManifestDigest: normalizedDigest(manifestBytes), BoundaryDigest: normalizedDigest(boundaryBytes), Manifest: manifestRef, Boundary: boundaryRef, RequiredRetainUntil: ceilSecond(until), SourceProtections: []observation.Protection{}}
+	descriptorBytes, err := descriptor.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptorRef, err := store.putEvidence(t.Context(), "descriptor", normalizedDigest(descriptorBytes), descriptorBytes, until)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := Ref{SchemaVersion: SchemaVersion, Manifest: manifestRef, Boundary: boundaryRef, Descriptor: descriptorRef}
+	if _, err := store.Reload(t.Context(), ref, until); err != nil {
+		t.Fatalf("Reload() = %v", err)
+	}
+	provider.mu.Lock()
+	provider.wrongGetVersion = true
+	provider.mu.Unlock()
+	if _, err := store.Reload(t.Context(), ref, until); err == nil || !strings.Contains(err.Error(), "integrity") {
+		t.Fatalf("Reload accepted mismatched GET version: %v", err)
+	}
+}
+
+func newTestStore(t *testing.T, provider *fakeS3, now time.Time) *Store {
+	t.Helper()
+	store, err := New(provider, Config{Endpoint: "http://127.0.0.1:9000", Region: "us-east-1", SourceBucket: "source", EvidenceBucket: "evidence", Prefix: "test", Clock: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+type fakeS3 struct {
+	mu              sync.Mutex
+	objects         map[string]fakeObject
+	seq             int
+	puts            []*s3.PutObjectInput
+	gets            int
+	wrongGetVersion bool
+}
+
+type fakeObject struct {
+	body    []byte
+	version string
+	retain  time.Time
+}
+
+func newFakeS3() *fakeS3 { return &fakeS3{objects: make(map[string]fakeObject)} }
+
+func (f *fakeS3) add(key string, body []byte, retain time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seq++
+	f.objects[key] = fakeObject{body: append([]byte(nil), body...), version: "v" + string(rune('0'+f.seq)), retain: retain}
+}
+
+func (f *fakeS3) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.puts = append(f.puts, in)
+	key := *in.Key
+	if _, exists := f.objects[key]; exists && in.IfNoneMatch != nil && *in.IfNoneMatch == "*" {
+		return nil, &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "exists"}
+	}
+	f.seq++
+	version := "v" + string(rune('0'+f.seq))
+	body, _ := io.ReadAll(in.Body)
+	f.objects[key] = fakeObject{body: body, version: version, retain: in.ObjectLockRetainUntilDate.UTC()}
+	return &s3.PutObjectOutput{VersionId: &version}, nil
+}
+
+func (f *fakeS3) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	object, ok := f.objects[*in.Key]
+	if !ok || in.VersionId != nil && *in.VersionId != object.version {
+		return nil, &smithy.GenericAPIError{Code: "NoSuchVersion", Message: "missing"}
+	}
+	version := object.version
+	size := int64(len(object.body))
+	return &s3.HeadObjectOutput{VersionId: &version, ContentLength: &size}, nil
+}
+
+func (f *fakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.gets++
+	object, ok := f.objects[*in.Key]
+	if !ok || in.VersionId != nil && *in.VersionId != object.version {
+		return nil, &smithy.GenericAPIError{Code: "NoSuchVersion", Message: "missing"}
+	}
+	version := object.version
+	if f.wrongGetVersion {
+		version = "wrong-version"
+	}
+	size := int64(len(object.body))
+	return &s3.GetObjectOutput{VersionId: &version, ContentLength: &size, Body: io.NopCloser(bytes.NewReader(object.body))}, nil
+}
+
+func (f *fakeS3) GetObjectRetention(_ context.Context, in *s3.GetObjectRetentionInput, _ ...func(*s3.Options)) (*s3.GetObjectRetentionOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	object, ok := f.objects[*in.Key]
+	if !ok || in.VersionId != nil && *in.VersionId != object.version {
+		return nil, &smithy.GenericAPIError{Code: "NoSuchVersion", Message: "missing"}
+	}
+	return &s3.GetObjectRetentionOutput{Retention: &types.ObjectLockRetention{Mode: types.ObjectLockRetentionModeCompliance, RetainUntilDate: &object.retain}}, nil
+}

--- a/internal/recoveryset/postgres/observation_capture.go
+++ b/internal/recoveryset/postgres/observation_capture.go
@@ -1,0 +1,89 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flidai/leapview/internal/manageddata"
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+)
+
+// CapturedObservation is opaque trusted evidence produced by Capture.
+// Callers cannot construct a value containing arbitrary marker or inventory
+// data because the underlying fields are private to this package.
+type CapturedObservation struct {
+	boundary  observation.Boundary
+	inventory observation.Inventory
+}
+
+// Boundary returns a value copy of the trusted PostgreSQL boundary.
+func (c CapturedObservation) Boundary() observation.Boundary { return c.boundary }
+
+// Inventory returns a defensive deep copy of the trusted managed-data
+// inventory. The returned slices may be changed by the caller safely.
+func (c CapturedObservation) Inventory() observation.Inventory {
+	out := c.inventory
+	out.Revisions = make([]observation.Revision, len(c.inventory.Revisions))
+	copy(out.Revisions, c.inventory.Revisions)
+	for i := range out.Revisions {
+		out.Revisions[i].Files = make([]observation.File, len(c.inventory.Revisions[i].Files))
+		copy(out.Revisions[i].Files, c.inventory.Revisions[i].Files)
+	}
+	return out
+}
+
+// Capture converts trusted source facts into the recovery-set observation
+// contract. The source generates the PostgreSQL marker and inventory facts;
+// callers provide neither marker, identity, nor inventory data.
+func Capture(ctx context.Context, source manageddata.ProjectionCaptureSource) (CapturedObservation, error) {
+	if ctx == nil || source == nil {
+		return CapturedObservation{}, fmt.Errorf("%w: provider observation source is required", observation.ErrInvalid)
+	}
+	projection, err := source.CaptureManagedProjection(ctx)
+	if err != nil {
+		// Preserve the source error identity: database privilege, primary-role,
+		// timeout, and transport failures are not observation-contract input
+		// errors and must remain distinguishable to the caller.
+		return CapturedObservation{}, fmt.Errorf("trusted managed-data capture: %w", err)
+	}
+	inventory := observation.Inventory{
+		SchemaVersion: observation.SchemaVersion,
+		Revisions:     make([]observation.Revision, 0, len(projection.Revisions)),
+	}
+	for _, revision := range projection.Revisions {
+		files := make([]observation.File, 0, len(revision.Files))
+		for _, file := range revision.Files {
+			files = append(files, observation.File{
+				Path:       file.Path,
+				SHA256:     file.SHA256,
+				StorageKey: file.StorageKey,
+				Size:       file.Size,
+			})
+		}
+		inventory.Revisions = append(inventory.Revisions, observation.Revision{
+			RevisionID:     revision.RevisionID,
+			ManifestDigest: revision.ManifestDigest,
+			Files:          files,
+		})
+	}
+	inventoryDigest, err := inventory.Digest()
+	if err != nil {
+		return CapturedObservation{}, fmt.Errorf("%w: digest trusted managed-data inventory: %v", observation.ErrInvalid, err)
+	}
+	boundary := observation.Boundary{
+		ProtocolVersion:  observation.ProtocolVersion,
+		DatabaseIdentity: projection.DatabaseIdentity,
+		SystemIdentity:   projection.SystemIdentity,
+		Timeline:         projection.Timeline,
+		LSN:              projection.LSN,
+		RestorePointName: projection.RestorePointName,
+		InventoryDigest:  inventoryDigest,
+	}
+	if err := boundary.Validate(); err != nil {
+		return CapturedObservation{}, fmt.Errorf("%w: validate captured PostgreSQL boundary: %v", observation.ErrInvalid, err)
+	}
+	if err := inventory.Validate(); err != nil {
+		return CapturedObservation{}, fmt.Errorf("%w: validate captured managed-data inventory: %v", observation.ErrInvalid, err)
+	}
+	return CapturedObservation{boundary: boundary, inventory: inventory}, nil
+}

--- a/internal/recoveryset/postgres/observation_capture_qualification_test.go
+++ b/internal/recoveryset/postgres/observation_capture_qualification_test.go
@@ -1,0 +1,474 @@
+//go:build fai520qualification
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/manageddata"
+	managedpostgres "github.com/flidai/leapview/internal/manageddata/postgres"
+	"github.com/flidai/leapview/internal/platform/postgres/postgrestest"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/internal/recoveryset/observation"
+	jobspkg "github.com/flidai/leapview/pkg/jobs"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/log"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+var errProviderObservationSource = errors.New("provider observation source unavailable")
+
+type providerObservationErrorSource struct{}
+
+func (providerObservationErrorSource) CaptureManagedProjection(context.Context) (manageddata.CapturedProjection, error) {
+	return manageddata.CapturedProjection{}, errProviderObservationSource
+}
+
+func TestProviderObservationCapturePreservesSourceErrors(t *testing.T) {
+	_, err := Capture(t.Context(), providerObservationErrorSource{})
+	if !errors.Is(err, errProviderObservationSource) {
+		t.Fatalf("source error = %v, want %v", err, errProviderObservationSource)
+	}
+}
+
+func TestProviderObservationCaptureRejectsDisabledFsync(t *testing.T) {
+	fixture := providerObservationFixtureDB(t)
+	setProviderObservationFsync(t, fixture.admin, "off")
+
+	_, err := Capture(t.Context(), managedpostgres.New(fixture.db))
+	if err == nil {
+		t.Fatal("capture succeeded while PostgreSQL fsync was disabled")
+	}
+	if !errors.Is(err, managedpostgres.ErrInvalid) || !strings.Contains(strings.ToLower(err.Error()), "fsync") {
+		t.Fatalf("disabled fsync error = %v, want managed-data invalid fsync diagnostic", err)
+	}
+}
+
+func TestProviderObservationCaptureQualification(t *testing.T) {
+	db := providerObservationDB(t)
+	ctx := t.Context()
+	managed := managedpostgres.New(db)
+	collection, err := managed.CreateCollection(ctx, manageddata.CreateCollectionInput{
+		ID:           projectgraph.ResourceID("collection_observation"),
+		ProjectID:    projectgraph.ResourceID("project_observation"),
+		ConnectionID: projectgraph.ResourceID("connection_observation"),
+		Name:         "Observation",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	manifest := manageddata.Manifest{Files: []manageddata.File{{Path: "orders.parquet", Size: 12, SHA256: hash}}}
+	session, err := managed.CreateUploadSession(ctx, manageddata.CreateUploadSessionInput{
+		ID:             manageddata.UploadID("upload_observation"),
+		CollectionID:   collection.ID,
+		Manifest:       manifest,
+		StorageBackend: "s3",
+		StagingPrefix:  "staging/observation",
+		ExpiresAt:      time.Now().UTC().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := managed.BeginUploadFinalization(ctx, session.ID, jobspkg.WorkflowIntent{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := managed.CompleteUpload(ctx, manageddata.CompleteUploadInput{
+		SessionID:  session.ID,
+		RevisionID: manageddata.RevisionID("revision_observation"),
+		Files:      []manageddata.StoredFile{{File: manifest.Files[0], StorageKey: "s3://bucket/objects/orders.parquet"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := Capture(ctx, managed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := first.Boundary()
+	if err := boundary.Validate(); err != nil {
+		t.Fatalf("captured boundary invalid: %v", err)
+	}
+	inventory := first.Inventory()
+	if err := inventory.Validate(); err != nil {
+		t.Fatalf("captured inventory invalid: %v", err)
+	}
+	if len(inventory.Revisions) != 1 || len(inventory.Revisions[0].Files) != 1 {
+		t.Fatalf("captured inventory = %#v", inventory)
+	}
+	digest, err := inventory.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if boundary.InventoryDigest != digest {
+		t.Fatalf("boundary inventory digest %q, computed %q", boundary.InventoryDigest, digest)
+	}
+	if boundary.RestorePointName == "" || boundary.LSN == "" || boundary.SystemIdentity == "" || boundary.DatabaseIdentity == "" || boundary.Timeline == 0 {
+		t.Fatalf("captured boundary is incomplete: %#v", boundary)
+	}
+	assertProviderObservationMarkerFlushed(t, db, boundary.LSN)
+
+	// Accessors must not expose mutable backing slices owned by the capture.
+	inventory.Revisions[0].Files[0].Path = "tampered.parquet"
+	if got := first.Inventory().Revisions[0].Files[0].Path; got != "orders.parquet" {
+		t.Fatalf("inventory accessor leaked mutable state: %q", got)
+	}
+
+	second, err := Capture(ctx, managed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Boundary().RestorePointName == boundary.RestorePointName {
+		t.Fatal("repeated capture reused restore point name")
+	}
+	if second.Boundary().InventoryDigest != boundary.InventoryDigest {
+		t.Fatalf("repeated capture inventory digest = %q, want %q", second.Boundary().InventoryDigest, boundary.InventoryDigest)
+	}
+	assertProviderObservationMarkerFlushed(t, db, second.Boundary().LSN)
+	wrongMarker := boundary
+	wrongMarker.RestorePointName += "_wrong"
+	if boundary.Matches(wrongMarker) {
+		t.Fatal("boundary accepted a different restore-point identity")
+	}
+	if err := boundary.ValidateAgainst(wrongMarker); err == nil || !errors.Is(err, observation.ErrInvalid) {
+		t.Fatalf("wrong marker comparison error = %v, want observation.ErrInvalid", err)
+	}
+	wrongLSN := boundary
+	wrongLSN.LSN = "0/1"
+	if boundary.Matches(wrongLSN) {
+		t.Fatal("boundary accepted a different LSN")
+	}
+	wrongDatabase := boundary
+	wrongDatabase.DatabaseIdentity += "_other"
+	if boundary.Matches(wrongDatabase) {
+		t.Fatal("boundary accepted a different database identity")
+	}
+}
+
+func TestProviderObservationCaptureLocksWriters(t *testing.T) {
+	db := providerObservationDB(t)
+	ctx := t.Context()
+	managed := managedpostgres.New(db)
+
+	// Keep a ready revision uncommitted while capture queues its SHARE locks.
+	// The commit after the server-side lock barrier must be in the captured
+	// repeatable-read snapshot.
+	writerBefore, err := db.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = writerBefore.Rollback(context.Background()) })
+	const hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	manifest := manageddata.Manifest{Files: []manageddata.File{{Path: "before.parquet", Size: 0, SHA256: hash}}}
+	manifestJSON, err := manifest.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := manifest.RevisionID()
+	if _, err := writerBefore.Exec(ctx, `
+INSERT INTO managed_data.collection(collection_id, project_id, connection_id, name, request_digest)
+VALUES ('collection_lock_before', 'project_lock', 'connection_lock', 'Lock before', $1)
+`, digest); err != nil {
+		_ = writerBefore.Rollback(ctx)
+		t.Fatal(err)
+	}
+	if _, err := writerBefore.Exec(ctx, `
+INSERT INTO managed_data.revision(revision_id, collection_id, sequence, digest, status, manifest, file_count, size_bytes)
+VALUES ('revision_lock_before', 'collection_lock_before', 1, $1, 'pending', $2::jsonb, 1, 0)
+	`, digest, string(manifestJSON)); err != nil {
+		_ = writerBefore.Rollback(ctx)
+		t.Fatal(err)
+	}
+	if _, err := writerBefore.Exec(ctx, `
+INSERT INTO managed_data.revision_file(revision_id, logical_path, size_bytes, sha256, storage_key)
+VALUES ('revision_lock_before', 'before.parquet', 0, $1, 's3://bucket/objects/before.parquet')
+`, hash); err != nil {
+		_ = writerBefore.Rollback(ctx)
+		t.Fatal(err)
+	}
+	if _, err := writerBefore.Exec(ctx, `
+UPDATE managed_data.revision SET status='ready', ready_at=clock_timestamp()
+WHERE revision_id='revision_lock_before'
+`); err != nil {
+		_ = writerBefore.Rollback(ctx)
+		t.Fatal(err)
+	}
+
+	type captureResult struct {
+		captured CapturedObservation
+		err      error
+	}
+	captureCtx, cancelCapture := context.WithCancel(ctx)
+	defer cancelCapture()
+	captureDone := make(chan captureResult, 1)
+	captureFinished := make(chan struct{})
+	go func() {
+		captured, captureErr := Capture(captureCtx, managed)
+		captureDone <- captureResult{captured: captured, err: captureErr}
+		close(captureFinished)
+	}()
+	t.Cleanup(func() {
+		cancelCapture()
+		select {
+		case <-captureFinished:
+		case <-time.After(5 * time.Second):
+		}
+	})
+	capturePID := waitForProviderObservationShareWait(t, db)
+	if capturePID == 0 {
+		_ = writerBefore.Rollback(ctx)
+		t.Fatal("capture did not queue a SHARE lock")
+	}
+
+	writerAfter, err := db.Begin(ctx)
+	if err != nil {
+		_ = writerBefore.Rollback(ctx)
+		t.Fatal(err)
+	}
+	writerAfterCtx, cancelWriterAfter := context.WithCancel(ctx)
+	defer cancelWriterAfter()
+	type writerResult struct{ err error }
+	writerAfterDone := make(chan writerResult, 1)
+	writerAfterFinished := make(chan struct{})
+	t.Cleanup(func() {
+		cancelWriterAfter()
+		select {
+		case <-writerAfterFinished:
+		case <-time.After(5 * time.Second):
+		}
+		_ = writerAfter.Rollback(context.Background())
+	})
+	var writerAfterPID int
+	if err := writerAfter.QueryRow(ctx, "SELECT pg_backend_pid()").Scan(&writerAfterPID); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		_, writerErr := writerAfter.Exec(writerAfterCtx, `LOCK TABLE managed_data.upload_session IN ROW EXCLUSIVE MODE`)
+		writerAfterDone <- writerResult{err: writerErr}
+		close(writerAfterFinished)
+	}()
+	if !waitForProviderObservationWriterWait(t, db, writerAfterPID) {
+		t.Fatal("writer started after capture was admitted before the capture lock")
+	}
+	var captureBlocksWriter bool
+	if err := db.QueryRow(ctx, "SELECT $1 = ANY(pg_blocking_pids($2))", capturePID, writerAfterPID).Scan(&captureBlocksWriter); err != nil {
+		t.Fatal(err)
+	}
+	if !captureBlocksWriter {
+		t.Fatalf("writer is not blocked by the queued capture transaction (capture pid %d)", capturePID)
+	}
+
+	if err := writerBefore.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-captureFinished:
+		result := <-captureDone
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if len(result.captured.Inventory().Revisions) != 1 || result.captured.Inventory().Revisions[0].RevisionID != "revision_lock_before" {
+			t.Fatalf("capture snapshot omitted committed preceding revision: %#v", result.captured.Inventory().Revisions)
+		}
+	case <-time.After(35 * time.Second):
+		t.Fatal("capture did not complete after the preceding writer committed")
+	}
+	select {
+	case result := <-writerAfterDone:
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("writer remained blocked after capture completed")
+	}
+
+}
+
+func waitForProviderObservationShareWait(t *testing.T, db *pgxpool.Pool) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var pid int
+		err := db.QueryRow(ctx, `
+SELECT COALESCE((
+  SELECT pid::int FROM pg_locks
+  WHERE relation='managed_data.revision'::regclass
+    AND mode='ShareLock' AND NOT granted
+  ORDER BY pid LIMIT 1
+), 0)
+`).Scan(&pid)
+		if err == nil && pid != 0 {
+			return pid
+		}
+		select {
+		case <-ctx.Done():
+			return 0
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForProviderObservationWriterWait(t *testing.T, db *pgxpool.Pool, pid int) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var waiting bool
+		err := db.QueryRow(ctx, `
+SELECT EXISTS (
+  SELECT 1 FROM pg_locks
+  WHERE pid=$1 AND relation='managed_data.upload_session'::regclass
+    AND mode='RowExclusiveLock' AND NOT granted
+)
+`, pid).Scan(&waiting)
+		if err == nil && waiting {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+type providerObservationFixture struct {
+	db    *pgxpool.Pool
+	admin *pgxpool.Pool
+}
+
+func providerObservationDB(t *testing.T) *pgxpool.Pool {
+	return providerObservationFixtureDB(t).db
+}
+
+func providerObservationFixtureDB(t *testing.T) *providerObservationFixture {
+	t.Helper()
+	if !postgrestest.Required() {
+		testcontainers.SkipIfProviderIsNotHealthy(t)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+	container, err := tcpostgres.Run(ctx, postgrestest.PostgreSQL18Image,
+		tcpostgres.WithDatabase("postgres"),
+		tcpostgres.WithUsername("postgres"),
+		tcpostgres.WithPassword("leapview-conformance-secret"),
+		// The postgres module defaults to fsync=off. Replacing its command with
+		// the stock foreground server lets this qualification fixture verify and
+		// control the real cluster setting itself.
+		testcontainers.WithCmd("postgres"),
+		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(90*time.Second)),
+		testcontainers.WithLogger(log.TestLogger(t)),
+	)
+	if err != nil {
+		if postgrestest.Required() {
+			t.Fatalf("required PostgreSQL 18 conformance container: %v", err)
+		}
+		t.Skipf("PostgreSQL 18 conformance container unavailable: %v", err)
+	}
+	testcontainers.CleanupContainer(t, container)
+	adminURL, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	admin, err := pgxpool.New(ctx, adminURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(admin.Close)
+	if err := admin.Ping(ctx); err != nil {
+		t.Fatal(err)
+	}
+	setProviderObservationFsync(t, admin, "on")
+	if _, err := admin.Exec(ctx, "CREATE DATABASE observation_capture_test"); err != nil {
+		t.Fatal(err)
+	}
+	dbURL, err := container.ConnectionString(ctx, "sslmode=disable", "dbname=observation_capture_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(p.Close)
+	if err := p.Ping(ctx); err != nil {
+		t.Fatal(err)
+	}
+	assertProviderObservationFsync(t, p, "on")
+	tx, err := p.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := managedpostgres.ApplySchema(ctx, tx); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var walLevel string
+	if err := p.QueryRow(ctx, "SHOW wal_level").Scan(&walLevel); err != nil {
+		t.Fatal(err)
+	}
+	if walLevel == "minimal" {
+		t.Fatalf("provider observation qualification requires wal_level replica or higher, got %q", walLevel)
+	}
+	return &providerObservationFixture{db: p, admin: admin}
+}
+
+func setProviderObservationFsync(t *testing.T, db *pgxpool.Pool, value string) {
+	t.Helper()
+	query := "ALTER SYSTEM SET fsync = 'on'"
+	if value == "off" {
+		query = "ALTER SYSTEM SET fsync = 'off'"
+	}
+	if _, err := db.Exec(t.Context(), query); err != nil {
+		t.Fatalf("set PostgreSQL fsync=%s: %v", value, err)
+	}
+	if _, err := db.Exec(t.Context(), "SELECT pg_reload_conf()"); err != nil {
+		t.Fatalf("reload PostgreSQL fsync=%s: %v", value, err)
+	}
+	assertProviderObservationFsync(t, db, value)
+}
+
+func assertProviderObservationFsync(t *testing.T, db *pgxpool.Pool, want string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var got string
+		err := db.QueryRow(ctx, "SHOW fsync").Scan(&got)
+		if err == nil && strings.EqualFold(strings.TrimSpace(got), want) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("PostgreSQL fsync = %q, want %q (last error: %v)", got, want, err)
+		case <-ticker.C:
+		}
+	}
+}
+
+func assertProviderObservationMarkerFlushed(t *testing.T, db *pgxpool.Pool, lsn string) {
+	t.Helper()
+	var flushed bool
+	if err := db.QueryRow(t.Context(), "SELECT pg_current_wal_flush_lsn() >= $1::pg_lsn", lsn).Scan(&flushed); err != nil {
+		t.Fatal(err)
+	}
+	if !flushed {
+		t.Fatalf("restore point LSN %s was not flushed", lsn)
+	}
+}

--- a/internal/recoveryset/postgres/provider_observation_qualification_test.go
+++ b/internal/recoveryset/postgres/provider_observation_qualification_test.go
@@ -1,0 +1,407 @@
+//go:build fai520qualification
+
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	providerObservationHelperEnv   = "LEAPVIEW_RECOVERYSET_PROVIDER_OBSERVATION_HELPER"
+	providerObservationDSNEnv      = "LEAPVIEW_RECOVERYSET_PROVIDER_OBSERVATION_DSN"
+	providerObservationSetEnv      = "LEAPVIEW_RECOVERYSET_PROVIDER_OBSERVATION_SET_ID"
+	providerObservationAttemptEnv  = "LEAPVIEW_RECOVERYSET_PROVIDER_OBSERVATION_ATTEMPT_ID"
+	providerObservationSetJSONEnv  = "LEAPVIEW_RECOVERYSET_PROVIDER_OBSERVATION_SET_JSON"
+	providerObservationEvidenceEnv = "LEAPVIEW_RECOVERYSET_PROVIDER_OBSERVATION_EVIDENCE"
+	providerObservationFrontierEnv = "LEAPVIEW_RECOVERYSET_PROVIDER_OBSERVATION_FRONTIER_DIGEST"
+	providerObservationResultEnv   = "LEAPVIEW_RECOVERYSET_PROVIDER_OBSERVATION_RESULT_DIGEST"
+)
+
+func TestProviderObservationDurabilityAndExactReplay(t *testing.T) {
+	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
+	db := recoverySetDB(t)
+	repo := New(db)
+	set := providerObservationRemoteFixture(t)
+	assertProviderObservationRoots(t, set)
+
+	created, err := repo.Create(t.Context(), set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.FrontierDigest == "" {
+		t.Fatal("created frontier digest is empty")
+	}
+	read, err := repo.ReadExact(t.Context(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRecoverySetCanonicalBytesEqual(t, created, read)
+	if read.Status != recoveryset.StatusPrepared || read.PublishedValidationAttemptID != "" {
+		t.Fatalf("validation observation changed frontier lifecycle state: status=%q published_attempt=%q", read.Status, read.PublishedValidationAttemptID)
+	}
+
+	started := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	firstAttempt := recoveryset.ValidationAttempt{
+		AttemptID:     "018f3f83-7b2f-7b37-9f9e-000000000140",
+		SetID:         created.ID,
+		OwnerID:       "provider-observer",
+		FenceEpoch:    created.FenceEpoch,
+		AuditIdentity: created.AuditIdentity,
+		Status:        recoveryset.ValidationRunning,
+		StartedAt:     started,
+	}
+	if _, err := repo.BeginValidation(t.Context(), firstAttempt); err != nil {
+		t.Fatal(err)
+	}
+	firstEnvelope, err := recoveryset.NewValidationEvidenceEnvelope(created, firstAttempt.AttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingProviderFrontier := firstEnvelope
+	missingProviderFrontier.ObjectRoots = append([]recoveryset.ValidationEvidenceObjectRoot(nil), firstEnvelope.ObjectRoots...)
+	missingProviderFrontier.ObjectRoots[0].ProviderRecoveryFrontier = ""
+	if err := missingProviderFrontier.ValidateFor(created, firstAttempt.AttemptID); !errors.Is(err, recoveryset.ErrInvalid) {
+		t.Fatalf("missing remote provider recovery frontier = %v, want invalid", err)
+	}
+	changedRootVersion := firstEnvelope
+	changedRootVersion.ObjectRoots = append([]recoveryset.ValidationEvidenceObjectRoot(nil), firstEnvelope.ObjectRoots...)
+	changedRootVersion.ObjectRoots[0].VersionID += "-changed"
+	if err := changedRootVersion.ValidateFor(created, firstAttempt.AttemptID); !errors.Is(err, recoveryset.ErrInvalid) {
+		t.Fatalf("changed remote root version = %v, want invalid", err)
+	}
+	changedProviderFrontier := firstEnvelope
+	changedProviderFrontier.ObjectRoots = append([]recoveryset.ValidationEvidenceObjectRoot(nil), firstEnvelope.ObjectRoots...)
+	changedProviderFrontier.ObjectRoots[0].ProviderRecoveryFrontier += "-changed"
+	if err := changedProviderFrontier.ValidateFor(created, firstAttempt.AttemptID); !errors.Is(err, recoveryset.ErrInvalid) {
+		t.Fatalf("changed remote provider recovery frontier = %v, want invalid", err)
+	}
+	firstResult, err := recoveryset.NewValidationResult(firstEnvelope, started.Add(500*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.RecordValidationResult(t.Context(), firstResult); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.RecordValidationResult(t.Context(), firstResult); err != nil {
+		t.Fatalf("identical validation-result replay: %v", err)
+	}
+	retryWithFreshClock := firstResult
+	retryWithFreshClock.RecordedAt = retryWithFreshClock.RecordedAt.Add(time.Minute)
+	if err := repo.RecordValidationResult(t.Context(), retryWithFreshClock); err != nil {
+		t.Fatalf("validation-result replay with caller timestamp: %v", err)
+	}
+	storedResult, err := repo.ValidationResult(t.Context(), firstAttempt.AttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedResult.ResultDigest != firstResult.ResultDigest || !bytes.Equal(storedResult.Evidence, firstResult.Evidence) {
+		t.Fatalf("stored validation result changed on replay: %#v", storedResult)
+	}
+
+	secondAttempt := firstAttempt
+	secondAttempt.AttemptID = "018f3f83-7b2f-7b37-9f9e-000000000141"
+	if _, err := repo.BeginValidation(t.Context(), secondAttempt); err != nil {
+		t.Fatal(err)
+	}
+	secondEnvelope, err := recoveryset.NewValidationEvidenceEnvelope(created, secondAttempt.AttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondResult, err := recoveryset.NewValidationResult(secondEnvelope, started.Add(500*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondResult.ResultDigest == firstResult.ResultDigest {
+		t.Fatal("different validation attempts reused the same attempt-bound result digest")
+	}
+	if err := repo.RecordValidationResult(t.Context(), secondResult); err != nil {
+		t.Fatal(err)
+	}
+
+	conflictingEnvelope := firstEnvelope
+	conflictingEnvelope.RelationNamespace = "candidate/conflicting"
+	conflictingResult, err := recoveryset.NewValidationResult(conflictingEnvelope, firstResult.RecordedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.RecordValidationResult(t.Context(), conflictingResult); !errors.Is(err, recoveryset.ErrInvalid) {
+		t.Fatalf("repository overwrite with conflicting evidence = %v, want invalid", err)
+	}
+	if _, err := db.Exec(t.Context(), `UPDATE recovery.validation_result SET result_digest=$2 WHERE attempt_id=$1::uuid`, firstAttempt.AttemptID, secondResult.ResultDigest); err == nil {
+		t.Fatal("SQL update of immutable validation evidence succeeded")
+	}
+
+	setJSON, err := created.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runProviderObservationReadOnlyHelper(t, db.Config().ConnString(), created.ID, firstAttempt.AttemptID, setJSON, firstResult)
+}
+
+func TestProviderObservationFrontierContractRejectsConflicts(t *testing.T) {
+	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
+	db := recoverySetDB(t)
+	repo := New(db)
+	base := providerObservationRemoteFixture(t)
+	assertProviderObservationRoots(t, base)
+
+	cases := map[string]func(recoveryset.RecoverySet) recoveryset.RecoverySet{
+		"missing_ducklake_root": func(set recoveryset.RecoverySet) recoveryset.RecoverySet {
+			set.ObjectRoots = []recoveryset.ObjectRoot{set.ObjectRoots[1]}
+			return set
+		},
+		"missing_serving_artifact_root": func(set recoveryset.RecoverySet) recoveryset.RecoverySet {
+			set.ObjectRoots = []recoveryset.ObjectRoot{set.ObjectRoots[0]}
+			return set
+		},
+		"mismatched_ducklake_digest": func(set recoveryset.RecoverySet) recoveryset.RecoverySet {
+			set.ObjectRoots = append([]recoveryset.ObjectRoot(nil), set.ObjectRoots...)
+			set.ObjectRoots[0].Digest = providerObservationDigest('9')
+			return set
+		},
+		"stale_frontier_digest": func(set recoveryset.RecoverySet) recoveryset.RecoverySet {
+			set.FrontierDigest = providerObservationDigest('9')
+			return set
+		},
+		"duplicate_conflicting_roots": func(set recoveryset.RecoverySet) recoveryset.RecoverySet {
+			set.ObjectRoots = append([]recoveryset.ObjectRoot(nil), set.ObjectRoots...)
+			set.ObjectRoots[1] = set.ObjectRoots[0]
+			set.ObjectRoots[1].Digest = providerObservationDigest('9')
+			return set
+		},
+		"managed_data_third_root": func(set recoveryset.RecoverySet) recoveryset.RecoverySet {
+			set.ObjectRoots = append(append([]recoveryset.ObjectRoot(nil), set.ObjectRoots...), recoveryset.ObjectRoot{
+				Kind: "managed-data", URI: "s3://bucket/managed-inventory", VersionID: "1", Digest: providerObservationDigest('7'), ProviderRecoveryFrontier: "managed-frontier-1",
+			})
+			return set
+		},
+		"managed_data_replaces_root": func(set recoveryset.RecoverySet) recoveryset.RecoverySet {
+			set.ObjectRoots = append([]recoveryset.ObjectRoot(nil), set.ObjectRoots...)
+			set.ObjectRoots[1].Kind = "managed-data"
+			return set
+		},
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			candidate := mutate(base)
+			if _, err := repo.Create(t.Context(), candidate); !errors.Is(err, recoveryset.ErrInvalid) {
+				t.Fatalf("invalid frontier candidate = %v, want invalid", err)
+			}
+		})
+	}
+
+	created, err := repo.Create(t.Context(), base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := base
+	changed.ObjectRoots = append([]recoveryset.ObjectRoot(nil), base.ObjectRoots...)
+	changed.ObjectRoots[0].VersionID = "2"
+	if _, err := repo.Create(t.Context(), changed); !errors.Is(err, recoveryset.ErrConflict) {
+		t.Fatalf("same-ID root replacement = %v, want conflict", err)
+	}
+	if read, err := repo.ReadExact(t.Context(), created.ID); err != nil {
+		t.Fatal(err)
+	} else if read.ObjectRoots[0].VersionID != base.ObjectRoots[0].VersionID {
+		t.Fatalf("same-ID conflict changed stored root version to %q", read.ObjectRoots[0].VersionID)
+	}
+}
+
+func TestProviderObservationEvidenceRejectsArbitraryManagedFields(t *testing.T) {
+	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
+	db := recoverySetDB(t)
+	repo := New(db)
+	set := providerObservationRemoteFixture(t)
+	created, err := repo.Create(t.Context(), set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attemptID := "018f3f83-7b2f-7b37-9f9e-000000000142"
+	started := time.Date(2026, 9, 8, 12, 5, 0, 0, time.UTC)
+	if _, err := repo.BeginValidation(t.Context(), recoveryset.ValidationAttempt{
+		AttemptID: attemptID, SetID: created.ID, OwnerID: "provider-observer", FenceEpoch: created.FenceEpoch,
+		AuditIdentity: created.AuditIdentity, Status: recoveryset.ValidationRunning, StartedAt: started,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := recoveryset.NewValidationEvidenceEnvelope(created, attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := recoveryset.NewValidationResult(envelope, started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arbitraryManagedField := append(append([]byte(nil), result.Evidence[:len(result.Evidence)-1]...), []byte(`,"managed_observations":{"revision":"latest"}}`)...)
+	if _, err := recoveryset.ParseValidationEvidenceEnvelope(arbitraryManagedField); !errors.Is(err, recoveryset.ErrInvalid) {
+		t.Fatalf("managed_observations evidence field = %v, want invalid", err)
+	}
+	if err := repo.RecordValidationResult(t.Context(), recoveryset.ValidationResult{
+		AttemptID: attemptID, ResultDigest: result.ResultDigest, Evidence: arbitraryManagedField, RecordedAt: result.RecordedAt,
+	}); !errors.Is(err, recoveryset.ErrInvalid) {
+		t.Fatalf("repository accepted opaque managed_observations evidence field = %v", err)
+	}
+}
+
+func TestProviderObservationReadOnlyHelper(t *testing.T) {
+	if os.Getenv(providerObservationHelperEnv) != "1" {
+		return
+	}
+	dsn := os.Getenv(providerObservationDSNEnv)
+	setID := os.Getenv(providerObservationSetEnv)
+	attemptID := os.Getenv(providerObservationAttemptEnv)
+	if dsn == "" || setID == "" || attemptID == "" {
+		t.Fatal("provider observation helper environment is incomplete")
+	}
+	p, err := recoverySetPoolForHelper(t, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	repo := New(p)
+	set, err := repo.ReadExact(t.Context(), setID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := repo.ValidationResult(t.Context(), attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := recoveryset.ParseValidationEvidenceEnvelope(result.Evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := envelope.ValidateFor(set, attemptID); err != nil {
+		t.Fatalf("reloaded root evidence does not validate against persisted frontier: %v", err)
+	}
+	setJSON, err := set.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultEvidence, err := base64.StdEncoding.DecodeString(os.Getenv(providerObservationEvidenceEnv))
+	if err != nil {
+		t.Fatalf("decode expected evidence: %v", err)
+	}
+	expectedSetJSON, err := base64.StdEncoding.DecodeString(os.Getenv(providerObservationSetJSONEnv))
+	if err != nil {
+		t.Fatalf("decode expected set: %v", err)
+	}
+	if !bytes.Equal(setJSON, expectedSetJSON) || set.FrontierDigest != os.Getenv(providerObservationFrontierEnv) {
+		t.Fatalf("subprocess recovery frontier differs: digest=%q bytes_equal=%t", set.FrontierDigest, bytes.Equal(setJSON, expectedSetJSON))
+	}
+	if set.Status != recoveryset.StatusPrepared || set.PublishedValidationAttemptID != "" {
+		t.Fatalf("subprocess changed frontier lifecycle state: status=%q published_attempt=%q", set.Status, set.PublishedValidationAttemptID)
+	}
+	if result.ResultDigest != os.Getenv(providerObservationResultEnv) || !bytes.Equal(result.Evidence, resultEvidence) {
+		t.Fatalf("subprocess validation evidence differs: digest=%q bytes_equal=%t", result.ResultDigest, bytes.Equal(result.Evidence, resultEvidence))
+	}
+}
+
+func runProviderObservationReadOnlyHelper(t *testing.T, dsn, setID, attemptID string, setJSON []byte, result recoveryset.ValidationResult) {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, executable, "-test.run", "^TestProviderObservationReadOnlyHelper$", "-test.timeout", "30s")
+	command.Env = append(os.Environ(),
+		providerObservationHelperEnv+"=1",
+		providerObservationDSNEnv+"="+dsn,
+		providerObservationSetEnv+"="+setID,
+		providerObservationAttemptEnv+"="+attemptID,
+		providerObservationSetJSONEnv+"="+base64.StdEncoding.EncodeToString(setJSON),
+		providerObservationEvidenceEnv+"="+base64.StdEncoding.EncodeToString(result.Evidence),
+		providerObservationFrontierEnv+"="+strings.TrimSpace(resultFrontierDigest(t, setJSON)),
+		providerObservationResultEnv+"="+result.ResultDigest,
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		redacted := strings.ReplaceAll(string(output), dsn, "[redacted-dsn]")
+		if ctx.Err() != nil {
+			t.Fatalf("provider observation read-only subprocess: %v (%v)", ctx.Err(), err)
+		}
+		t.Fatalf("provider observation read-only subprocess: %v\n%s", err, redacted)
+	}
+}
+
+func recoverySetPoolForHelper(t *testing.T, dsn string) (*pgxpool.Pool, error) {
+	// Keep pool construction in one place so the subprocess performs only the
+	// existing repository read operations against a fresh connection pool.
+	return pgxpool.New(t.Context(), dsn)
+}
+
+func resultFrontierDigest(t *testing.T, setJSON []byte) string {
+	t.Helper()
+	set := recoveryset.RecoverySet{}
+	if err := json.Unmarshal(setJSON, &set); err != nil {
+		t.Fatal(err)
+	}
+	return set.FrontierDigest
+}
+
+func providerObservationRemoteFixture(t *testing.T) recoveryset.RecoverySet {
+	t.Helper()
+	set := recoverySetFixture(t)
+	set.Serving.ObjectRoot = "s3://bucket/objects/target"
+	set.Serving.ArtifactRoot = "s3://bucket/artifacts/target"
+	set.ObjectRoots = append([]recoveryset.ObjectRoot(nil), set.ObjectRoots...)
+	for index := range set.ObjectRoots {
+		switch set.ObjectRoots[index].Kind {
+		case recoveryset.ObjectRootDuckLake:
+			set.ObjectRoots[index].URI = set.Serving.ObjectRoot
+			set.ObjectRoots[index].VersionID = "ducklake-version-1"
+			set.ObjectRoots[index].ProviderRecoveryFrontier = "ducklake-frontier-1"
+		case recoveryset.ObjectRootServingArtifact:
+			set.ObjectRoots[index].URI = set.Serving.ArtifactRoot
+			set.ObjectRoots[index].VersionID = "serving-artifact-version-1"
+			set.ObjectRoots[index].ProviderRecoveryFrontier = "serving-artifact-frontier-1"
+		}
+	}
+	return set
+}
+
+func assertProviderObservationRoots(t *testing.T, set recoveryset.RecoverySet) {
+	t.Helper()
+	if len(set.ObjectRoots) != 2 {
+		t.Fatalf("provider observation fixture roots = %d, want exactly 2", len(set.ObjectRoots))
+	}
+	seen := map[string]bool{}
+	for _, root := range set.ObjectRoots {
+		seen[root.Kind] = true
+	}
+	if !seen[recoveryset.ObjectRootDuckLake] || !seen[recoveryset.ObjectRootServingArtifact] || len(seen) != 2 {
+		t.Fatalf("provider observation fixture roots = %#v, want ducklake and serving-artifact only", set.ObjectRoots)
+	}
+}
+
+func assertRecoverySetCanonicalBytesEqual(t *testing.T, want, got recoveryset.RecoverySet) {
+	t.Helper()
+	wantJSON, err := want.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotJSON, err := got.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(wantJSON, gotJSON) || !want.IdentityEqual(got) || want.FrontierDigest != got.FrontierDigest {
+		t.Fatalf("reopened recovery frontier differs: bytes_equal=%t digest=%q/%q", bytes.Equal(wantJSON, gotJSON), want.FrontierDigest, got.FrontierDigest)
+	}
+}
+
+func providerObservationDigest(ch byte) string {
+	return "sha256:" + strings.Repeat(string(ch), 64)
+}

--- a/internal/recoveryset/postgres/repository.go
+++ b/internal/recoveryset/postgres/repository.go
@@ -61,6 +61,9 @@ func (r *Repository) Configured() bool { return r != nil && r.db != nil }
 // same set ID are exact and idempotent; any identity or metadata drift is a
 // conflict and never appends child evidence to the existing row.
 func (r *Repository) Create(ctx context.Context, set recoveryset.RecoverySet) (recoveryset.RecoverySet, error) {
+	if set.SchemaVersion != recoveryset.SchemaVersion {
+		return recoveryset.RecoverySet{}, recoveryset.ErrInvalid
+	}
 	if r == nil || r.db == nil {
 		return recoveryset.RecoverySet{}, recoveryset.ErrInvalid
 	}
@@ -107,6 +110,9 @@ func (r *Repository) Create(ctx context.Context, set recoveryset.RecoverySet) (r
 
 // CreateTx composes frontier creation with another control-plane mutation.
 func (r *Repository) CreateTx(ctx context.Context, tx Tx, set recoveryset.RecoverySet) (recoveryset.RecoverySet, error) {
+	if set.SchemaVersion != recoveryset.SchemaVersion {
+		return recoveryset.RecoverySet{}, recoveryset.ErrInvalid
+	}
 	if tx == nil {
 		return recoveryset.RecoverySet{}, recoveryset.ErrInvalid
 	}

--- a/internal/recoveryset/recoveryset.go
+++ b/internal/recoveryset/recoveryset.go
@@ -107,6 +107,9 @@ type ValidationEvidenceEnvelope struct {
 // NewValidationEvidenceEnvelope constructs evidence from the exact frontier
 // and validation attempt. It never consults mutable/latest rows.
 func NewValidationEvidenceEnvelope(set RecoverySet, attemptID string) (ValidationEvidenceEnvelope, error) {
+	if set.SchemaVersion != SchemaVersion {
+		return ValidationEvidenceEnvelope{}, fmt.Errorf("%w: v1 validation cannot consume another frontier version", ErrInvalid)
+	}
 	normalized, err := set.Normalize()
 	if err != nil {
 		return ValidationEvidenceEnvelope{}, err
@@ -342,6 +345,9 @@ func validationRemoteObjectRoot(uri string) bool {
 // attempt. The comparison includes every cluster point/root identity and all
 // serving relation digests; it performs no provider I/O.
 func (e ValidationEvidenceEnvelope) ValidateFor(set RecoverySet, attemptID string) error {
+	if set.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: v1 validation cannot consume another frontier version", ErrInvalid)
+	}
 	e.normalize()
 	if err := e.Validate(); err != nil {
 		return err
@@ -502,9 +508,10 @@ type RecoverySet struct {
 	// immutable validation attempt. It is empty while a set is prepared, and
 	// publication must set it atomically after proving the attempt has passed
 	// and carries matching evidence.
-	PublishedValidationAttemptID string    `json:"published_validation_attempt_id,omitempty"`
-	CreatedBy                    string    `json:"created_by"`
-	CreatedAt                    time.Time `json:"created_at"`
+	PublishedValidationAttemptID string           `json:"published_validation_attempt_id,omitempty"`
+	CreatedBy                    string           `json:"created_by"`
+	CreatedAt                    time.Time        `json:"created_at"`
+	ManagedEvidence              *ManagedEvidence `json:"managed_evidence,omitempty"`
 }
 
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
@@ -640,8 +647,8 @@ func (s RecoverySet) Validate() error {
 	if !canonicalUUID(s.ID) {
 		return fmt.Errorf("%w: id must be a UUID", ErrInvalid)
 	}
-	if s.SchemaVersion != SchemaVersion {
-		return fmt.Errorf("%w: unsupported schema version %d", ErrInvalid, s.SchemaVersion)
+	if err := s.validateEvidenceVersion(); err != nil {
+		return err
 	}
 	if len(s.ClusterPoints) != 2 {
 		return fmt.Errorf("%w: exactly two cluster recovery points are required", ErrInvalid)
@@ -893,63 +900,6 @@ func digest(value, label string) error {
 func canonicalUUID(value string) bool {
 	u, err := uuid.Parse(value)
 	return err == nil && u.String() == value
-}
-
-// Normalize returns a validated copy with child rows in their persistence
-// order. Callers should normalize before insertion or equality comparison.
-func (s RecoverySet) Normalize() (RecoverySet, error) {
-	if err := s.Validate(); err != nil {
-		return RecoverySet{}, err
-	}
-	// PostgreSQL timestamptz stores microsecond precision; canonicalize before
-	// hashing/insertion so exact replay does not differ on sub-microsecond
-	// caller clock values.
-	s.CreatedAt = s.CreatedAt.UTC().Truncate(time.Microsecond)
-	s.sortChildren()
-	return s, nil
-}
-
-func (s *RecoverySet) sortChildren() {
-	s.ClusterPoints = s.CanonicalPoints()
-	s.ObjectRoots = append([]ObjectRoot(nil), s.ObjectRoots...)
-	sort.Slice(s.ObjectRoots, func(i, j int) bool {
-		a, b := s.ObjectRoots[i], s.ObjectRoots[j]
-		if a.Kind != b.Kind {
-			return a.Kind < b.Kind
-		}
-		if a.URI != b.URI {
-			return a.URI < b.URI
-		}
-		return a.VersionID < b.VersionID
-	})
-}
-
-// CanonicalJSON and Digest provide a stable evidence identity for audit and
-// idempotent replay. Child collections are sorted before encoding.
-func (s RecoverySet) CanonicalJSON() ([]byte, error) {
-	n, err := s.Normalize()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(n)
-}
-
-func (s RecoverySet) Digest() (string, error) {
-	// Digest covers only the immutable frontier projection. Publication status,
-	// fence, audit actor, and creation metadata remain separate record fields.
-	n := s
-	n.Status, n.FrontierDigest, n.PublishedValidationAttemptID = StatusPrepared, "", ""
-	if err := n.Validate(); err != nil {
-		return "", err
-	}
-	n.FenceEpoch, n.AuditIdentity, n.CreatedBy, n.CreatedAt = 0, "", "", time.Time{}
-	n.sortChildren()
-	b, err := json.Marshal(n)
-	if err != nil {
-		return "", err
-	}
-	sum := sha256.Sum256(b)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
 // CanonicalPoints returns points in stable role order for persistence and


### PR DESCRIPTION
## Problem

FAI-520 qualified exact historical object replay, but lacked a complete, durable managed-observation inventory bound to a trusted PostgreSQL recovery boundary.

## Root cause

Provider version observations were not an immutable, canonical, retention-protected evidence set. A digest alone did not preserve bytes, and caller-supplied marker identities could not establish inventory authority.

## Solution

- Freeze the committed ready-revision/file projection under PostgreSQL locks, create an exact restore marker, require `fsync=on`, and verify WAL flush on the same transaction connection.
- Add canonical versioned manifests and boundary attestations with strict completeness, provider identity, hash, size, duplicate and schema validation.
- Persist immutable off-host S3 manifests, boundaries, descriptors and evidence-only V2 frontiers with exact historical version references and COMPLIANCE retention.
- Preserve V1 canonical identity and publication/startup behavior; unknown versions and downgrade attempts fail closed.
- Publish the existing FAI-520 historical/closure qualification evidence and a focused PostgreSQL/MinIO hosted qualification workflow. The workflow also runs the existing full-validation extras.

## Tests added

Determinism, canonical bytes, complete inventory, missing/extra/duplicate observations, wrong historical bytes, marker mismatch, unsafe fsync, lock ordering, immutable replacement, retention expiration, exact-version reload and V1/V2 compatibility. Real PostgreSQL 18 and disposable versioned/Object Lock MinIO fixtures are used; no physical restore is performed.

## Verification

- Focused contract/store race tests: passed locally.
- Real PostgreSQL/MinIO qualification repeated twice under the race detector: passed locally.
- Architecture, quality budget, docs and diff checks: passed locally.
- Post-commit `task generate` and `task generated:check`: results recorded in the PR checks/comment.
- Prior local `task ci` failed at application/demo linking with `No space left on device`; hosted CI is required and not presumed green.

## Scope and limitations

This is the recovery-evidence qualification slice of [FAI-520](https://linear.app/flid/issue/FAI-520/ubdr-07-managed-data-s3-disaster-recovery), not completion of the broader issue. No restore orchestration, PITR, activation, startup recovery, migrations, RPO/RTO, FAI-620, FAI-670 or security-policy changes.

The initial provider adapter supports one configured source namespace and bounded inventory/object sizes. Capture may block managed writers for up to its 30-second bound. Source and evidence retention must be independently available; backup/WAL-archive retention and successful physical disaster recovery remain unqualified.

**This validates recovery evidence binding. It does not prove successful physical disaster recovery.**
