### PR TITLE
CI: remove unused tool installation after hosted profiling

### DIFF
--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -15,10 +15,47 @@ runs:
   using: composite
   steps:
     - name: Set up Go
+      id: go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: go.mod
-        cache: true
+        cache: false
+
+    - name: Resolve Go validation cache paths
+      id: go-cache-paths
+      shell: bash
+      run: |
+        set -eu
+        gomodcache="$(go env GOMODCACHE)"
+        gocache="$(go env GOCACHE)"
+        image="${ImageOS:-}"
+        if [ -z "$image" ] && [ -r /etc/os-release ]; then
+          . /etc/os-release
+          if [ -n "${ID:-}" ] && [ -n "${VERSION_ID:-}" ]; then
+            image="${ID}-${VERSION_ID}"
+          fi
+        fi
+        if [ -z "$image" ]; then
+          echo "unable to determine the runner image identity from ImageOS or /etc/os-release" >&2
+          exit 1
+        fi
+        if [ -z "$gomodcache" ] || [ -z "$gocache" ]; then
+          echo "Go module and build cache paths must be non-empty" >&2
+          exit 1
+        fi
+        {
+          echo "gomodcache=$gomodcache"
+          echo "gocache=$gocache"
+          echo "image=$image"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Restore Go validation cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.gomodcache }}
+          ${{ steps.go-cache-paths.outputs.gocache }}
+        key: go-validation-v1-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-paths.outputs.image }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('**/go.mod', '**/go.sum', 'Taskfile.yml', '.github/actions/setup-ci/action.yml') }}
 
     - name: Set up Node.js
       uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -92,7 +92,6 @@ runs:
           done
         }
         install_go_tool github.com/go-task/task/v3/cmd/task@v3.50.0
-        install_go_tool github.com/bufbuild/buf/cmd/buf@v1.57.2
         echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
 
     - name: Install cached Chromium and system dependencies

--- a/docs/articles/architecture/github-hosted-ci.md
+++ b/docs/articles/architecture/github-hosted-ci.md
@@ -57,7 +57,7 @@ same bounded shards sequentially to avoid browser and bundler contention on a sh
 
 ## Toolchain and caches
 
-`.github/actions/setup-ci` installs pinned Go, Node.js, Bun, Task, and Buf versions. Jobs opt
+`.github/actions/setup-ci` installs pinned Go, Node.js, Bun, and Task versions. Jobs opt
 into the pinned Terraform and Playwright installations only when their validation requires
 them. The action is shared by pull-request, merge, nightly, and production qualification jobs
 so a toolchain change has one reviewable source.

--- a/docs/articles/architecture/github-hosted-ci.md
+++ b/docs/articles/architecture/github-hosted-ci.md
@@ -64,10 +64,26 @@ so a toolchain change has one reviewable source.
 
 The setup action uses separate GitHub Actions cache entries for:
 
-- Go modules and compiler outputs, keyed by the Go dependency graph;
+- Go modules and compiler outputs, scoped by validation workload, runner platform,
+  installed Go version, module manifests and pinned tool definitions;
 - Bun downloads, keyed by the root and desktop lockfiles;
 - the pinned Playwright Chromium build;
 - Terraform providers, keyed by the deployment lockfiles.
+
+Go validation uses the `go-validation-v1` cache namespace and the stable workflow
+job ID as its workload scope. Application, package and frontend
+validation jobs reuse their respective entries across PR, merge and nightly runs;
+full validation shares its scope between merge and nightly runs. Frontend matrix shards share their preparation scope. APIGen, security and
+native packaging cannot win another validation workload's cache key. Native
+packaging retains its separate setup-go cache.
+
+The validation key covers root and nested `go.mod`/`go.sum` files, `Taskfile.yml`
+and the shared setup action, including pinned SQLC and toolchain definitions.
+There is no fallback to the old shared Go cache or another workload. Each successful
+job may publish its own scope; a cache hit never skips preparation or validation.
+Default-branch nightly runs can populate the scopes for subsequent candidates,
+subject to GitHub's branch access rules. More scopes consume more cache storage;
+eviction must remain a performance concern only.
 
 Production and public-site image builds export BuildKit layers to independently scoped
 GitHub Actions caches. LeapView does not cache `node_modules`, `/var/lib/docker`, mutable

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -3675,7 +3675,6 @@ func TestGitHubHostedWorkflowsUseEphemeralRunnersAndBoundedCaches(t *testing.T) 
 		"for attempt in 1 2 3",
 		"GODEBUG=http2client=0 go install",
 		"github.com/go-task/task/v3/cmd/task@v3.50.0",
-		"github.com/bufbuild/buf/cmd/buf@v1.57.2",
 		"playwright install --with-deps chromium",
 	} {
 		if !strings.Contains(setupText, want) {
@@ -3755,7 +3754,6 @@ func TestLeapViewDeclaresGitHubHostedCIContract(t *testing.T) {
 		"bun-version: 1.3.14",
 		"terraform_version: 1.13.5",
 		"github.com/go-task/task/v3/cmd/task@v3.50.0",
-		"github.com/bufbuild/buf/cmd/buf@v1.57.2",
 		"@playwright/test@1.61.1",
 		"playwright install --with-deps chromium",
 		"PLAYWRIGHT_BROWSERS_PATH=",

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -3660,7 +3660,7 @@ func TestGitHubHostedWorkflowsUseEphemeralRunnersAndBoundedCaches(t *testing.T) 
 	for _, want := range []string{
 		"actions/setup-go@",
 		"go-version-file: go.mod",
-		"cache: true",
+		"cache: false",
 		"actions/setup-node@",
 		`node-version: "24"`,
 		"oven-sh/setup-bun@",

--- a/internal/platform/architecture/go_cache_contract_test.go
+++ b/internal/platform/architecture/go_cache_contract_test.go
@@ -1,0 +1,243 @@
+package architecture
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type goCacheAction struct {
+	Runs struct {
+		Steps []goCacheActionStep `yaml:"steps"`
+	} `yaml:"runs"`
+}
+
+type goCacheActionStep struct {
+	Name string            `yaml:"name"`
+	ID   string            `yaml:"id"`
+	Uses string            `yaml:"uses"`
+	Run  string            `yaml:"run"`
+	If   string            `yaml:"if"`
+	With map[string]string `yaml:"with"`
+}
+
+func TestSetupCIOwnsGoValidationCache(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, ".github", "actions", "setup-ci", "action.yml"))
+	if err != nil {
+		t.Fatalf("read setup-ci action: %v", err)
+	}
+
+	var action goCacheAction
+	if err := yaml.Unmarshal(body, &action); err != nil {
+		t.Fatalf("parse setup-ci action: %v", err)
+	}
+
+	var setupGo []goCacheActionStep
+	var goCaches []goCacheActionStep
+	for _, step := range action.Runs.Steps {
+		if strings.HasPrefix(step.Uses, "actions/setup-go@") {
+			setupGo = append(setupGo, step)
+		}
+		if strings.HasPrefix(step.Uses, "actions/cache@") && strings.Contains(step.With["path"], "steps.go-cache-paths.outputs.") {
+			goCaches = append(goCaches, step)
+		}
+	}
+	if len(setupGo) != 1 {
+		t.Fatalf("setup-ci must have one setup-go step, found %d", len(setupGo))
+	}
+	if setupGo[0].ID != "go" {
+		t.Fatalf("setup-go step must be id go, got %q", setupGo[0].ID)
+	}
+	if setupGo[0].With["go-version-file"] != "go.mod" {
+		t.Fatalf("setup-go must read the root go.mod, got %q", setupGo[0].With["go-version-file"])
+	}
+	if setupGo[0].With["cache"] != "false" {
+		t.Fatalf("setup-go built-in cache must be disabled, got %q", setupGo[0].With["cache"])
+	}
+
+	var resolver []goCacheActionStep
+	for _, step := range action.Runs.Steps {
+		if step.ID == "go-cache-paths" {
+			resolver = append(resolver, step)
+		}
+	}
+	if len(resolver) != 1 {
+		t.Fatalf("setup-ci must have one Go cache path resolver, found %d", len(resolver))
+	}
+	for _, want := range []string{
+		"go env GOMODCACHE",
+		"go env GOCACHE",
+		"ImageOS",
+		"/etc/os-release",
+		"${ID:-}",
+		"${VERSION_ID:-}",
+		"GITHUB_OUTPUT",
+		"unable to determine the runner image identity",
+	} {
+		if !strings.Contains(resolver[0].Run, want) {
+			t.Errorf("Go cache path resolver missing %q", want)
+		}
+	}
+
+	if len(goCaches) != 1 {
+		t.Fatalf("setup-ci must have one Go cache writer, found %d", len(goCaches))
+	}
+	goCache := goCaches[0]
+	if goCache.If != "" || goCache.Run != "" {
+		t.Fatalf("Go cache must not conditionally bypass the cache action")
+	}
+	if _, ok := goCache.With["restore-keys"]; ok {
+		t.Fatal("Go validation cache must not use a fallback restore key")
+	}
+	path := strings.Split(strings.TrimSpace(goCache.With["path"]), "\n")
+	if len(path) != 2 || path[0] != "${{ steps.go-cache-paths.outputs.gomodcache }}" || path[1] != "${{ steps.go-cache-paths.outputs.gocache }}" {
+		t.Fatalf("Go cache must contain only GOMODCACHE and GOCACHE, got %q", goCache.With["path"])
+	}
+	wantKey := "go-validation-v1-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-cache-paths.outputs.image }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('**/go.mod', '**/go.sum', 'Taskfile.yml', '.github/actions/setup-ci/action.yml') }}"
+	if got := goCache.With["key"]; got != wantKey {
+		t.Fatalf("Go validation cache key = %q, want %q", got, wantKey)
+	}
+	if !regexp.MustCompile(`^actions/cache@[0-9a-f]{40}$`).MatchString(goCache.Uses) {
+		t.Fatalf("Go cache action must be pinned to a commit, got %q", goCache.Uses)
+	}
+	if strings.Contains(string(body), "cache-hit") {
+		t.Fatal("setup-ci must not skip work based on a cache-hit output")
+	}
+	setupIndex := -1
+	resolverIndex := -1
+	cacheIndex := -1
+	toolIndex := -1
+	for index, step := range action.Runs.Steps {
+		switch {
+		case step.ID == "go":
+			setupIndex = index
+		case step.ID == "go-cache-paths":
+			resolverIndex = index
+		case strings.HasPrefix(step.Uses, "actions/cache@") && strings.Contains(step.With["path"], "steps.go-cache-paths.outputs."):
+			cacheIndex = index
+		case step.Name == "Install pinned CI tools":
+			toolIndex = index
+		}
+	}
+	if !(setupIndex >= 0 && setupIndex < resolverIndex && resolverIndex < cacheIndex && cacheIndex < toolIndex) {
+		t.Fatalf("setup-ci must set up Go, resolve paths, restore Go cache, then install tools; indexes are setup=%d resolver=%d cache=%d tools=%d", setupIndex, resolverIndex, cacheIndex, toolIndex)
+	}
+}
+
+func TestValidationWorkflowsKeepStableGoCacheWorkloadIDs(t *testing.T) {
+	root := repoRoot(t)
+	wantedJobs := map[string][]string{
+		"ci.yml":               {"apigen-validation", "go-packages-validation", "go-application-validation", "frontend-validation"},
+		"merge-validation.yml": {"apigen-validation", "go-packages-validation", "go-application-validation", "frontend-validation", "full-validation"},
+		"nightly.yml":          {"apigen-validation", "go-packages-validation", "go-application-validation", "frontend-validation", "full-validation"},
+	}
+	for workflowName, jobs := range wantedJobs {
+		body, err := os.ReadFile(filepath.Join(root, ".github", "workflows", workflowName))
+		if err != nil {
+			t.Fatalf("read %s: %v", workflowName, err)
+		}
+		var workflow struct {
+			Jobs map[string]yaml.Node `yaml:"jobs"`
+		}
+		if err := yaml.Unmarshal(body, &workflow); err != nil {
+			t.Fatalf("parse %s: %v", workflowName, err)
+		}
+		for _, job := range jobs {
+			jobNode, ok := workflow.Jobs[job]
+			if !ok {
+				t.Errorf("%s must keep stable setup-ci workload ID %q", workflowName, job)
+				continue
+			}
+			if !workflowJobUsesSetupCI(&jobNode) {
+				t.Errorf("%s job %q must use the shared setup-ci action", workflowName, job)
+			}
+		}
+	}
+}
+
+func TestNativeGoCachesRemainSeparateFromValidationCache(t *testing.T) {
+	root := repoRoot(t)
+	files := []string{
+		filepath.Join(root, ".github", "actions", "desktop-preview-candidate", "action.yml"),
+		filepath.Join(root, ".github", "workflows", "electron-security-proof.yml"),
+	}
+	for _, file := range files {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		modes := setupGoCacheModes(t, body)
+		if len(modes) == 0 {
+			t.Fatalf("%s must retain its native setup-go cache configuration", file)
+		}
+		for _, mode := range modes {
+			if mode != "true" {
+				t.Errorf("%s native setup-go cache mode = %q, want true", file, mode)
+			}
+		}
+		if strings.Contains(string(body), "go-validation-v1-") {
+			t.Errorf("%s must not populate the validation cache key family", file)
+		}
+	}
+}
+
+func workflowJobUsesSetupCI(node *yaml.Node) bool {
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == "uses" && node.Content[i+1].Value == "./.github/actions/setup-ci" {
+				return true
+			}
+		}
+	}
+	for _, child := range node.Content {
+		if workflowJobUsesSetupCI(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func setupGoCacheModes(t *testing.T, body []byte) []string {
+	t.Helper()
+	var document yaml.Node
+	if err := yaml.Unmarshal(body, &document); err != nil {
+		t.Fatalf("parse setup-go configuration: %v", err)
+	}
+
+	var modes []string
+	var visit func(*yaml.Node)
+	visit = func(node *yaml.Node) {
+		if node.Kind == yaml.MappingNode {
+			uses := ""
+			cache := ""
+			for i := 0; i+1 < len(node.Content); i += 2 {
+				key, value := node.Content[i], node.Content[i+1]
+				switch key.Value {
+				case "uses":
+					uses = value.Value
+				case "with":
+					if value.Kind == yaml.MappingNode {
+						for j := 0; j+1 < len(value.Content); j += 2 {
+							if value.Content[j].Value == "cache" {
+								cache = value.Content[j+1].Value
+							}
+						}
+					}
+				}
+			}
+			if strings.HasPrefix(uses, "actions/setup-go@") {
+				modes = append(modes, cache)
+			}
+		}
+		for _, child := range node.Content {
+			visit(child)
+		}
+	}
+	visit(&document)
+	return modes
+}

--- a/internal/platform/ci/go-cache-ownership.md
+++ b/internal/platform/ci/go-cache-ownership.md
@@ -1,0 +1,116 @@
+# Go cache ownership — #520
+
+## Cause and evidence
+
+The [preparation audit](preparation-profile.md) traced an immutable-cache race.
+Native Linux packaging job
+[102026005333](https://github.com/flidai/leapview/actions/runs/34215448215/job/102026005333)
+saved the same setup-go key used by nine broad merge-validation jobs. Its Go
+module-cache directory did not exist; the resulting archive was about 25 MB.
+All nine validation jobs subsequently failed to reserve that key for their richer
+contents. Other candidates restored the small archive and still downloaded tools
+and application dependencies.
+
+Before:
+
+```text
+native packaging ──> setup-go key X (small archive wins)
+validation lanes ──> setup-go key X (cannot replace immutable contents)
+```
+
+Changing only the native writer would leave the old archive eligible for restore.
+Giving all setup-ci callers one replacement key would still let narrower APIGen
+or security work become the first writer. The fix scopes ownership by workload.
+
+## Implemented ownership
+
+`setup-ci` disables setup-go's automatic cache and uses the already-pinned
+`actions/cache` action for Go's module and build-cache paths. It resolves those
+paths after Go installation, rather than caching a whole GOPATH or workspace.
+
+The key combines:
+
+- The semantic namespace `go-validation-v1`.
+- Runner OS, architecture and hosted image identity.
+- The actual installed Go version.
+- The stable workflow job ID (`github.job`).
+- Root and nested `go.mod`/`go.sum` files, plus `Taskfile.yml` and the setup action.
+  These last two inputs include the pinned tool versions and SQLC's explicit
+  Go 1.26.7 policy, alongside the main Go 1.26.8 toolchain.
+
+After:
+
+```text
+native packaging ──> existing setup-go namespace
+application lane ──> go-validation-v1 / go-application-validation
+package lane ─────> go-validation-v1 / go-packages-validation
+full extras ──────> go-validation-v1 / full-validation
+APIGen lane ──────> go-validation-v1 / apigen-validation
+frontend shards ──> go-validation-v1 / frontend-validation
+```
+
+These are compatible workload scopes, not run IDs or random cache busters. PR,
+merge and nightly workflows already use matching job IDs for matching lanes
+(full validation exists only in merge/nightly), so no caller or dependency
+changes are necessary. The frontend matrix deliberately
+shares a scope: each shard prepares the same generated inputs before its tests.
+Other setup-ci callers own their own job scopes. Native packaging retains its
+existing action and cache behavior.
+
+No restore prefix bridges workloads or imports the legacy namespace. A miss runs
+the same downloads, generation, tests and checks. A successful job can publish
+its own scope without competing with native packaging. Simultaneous equivalent
+writers may still race; the losing save is optional cache work, not a test result.
+
+## Correctness and rollout
+
+No workflow files, validation targets, required names, planner outputs, gate
+conditions, permissions, runner configuration or merge dependencies change.
+There is no producer barrier or shared workspace. Cache outputs are not used to
+skip validation. Fresh-container flags, generated checks and native proofs stay
+in place.
+
+GitHub's existing ref visibility and save rules continue to apply. A queue or PR
+cache is not a substitute for a trusted default-branch producer. Existing nightly
+jobs can seed the same scopes on main, after which eligible candidates can restore
+them. The new namespace deliberately starts cold; older entries need not be
+removed to establish ownership.
+
+More independent archives can increase storage and eviction pressure. Cache
+absence and save failures must remain performance-only outcomes. Source changes
+with unchanged dependency identities may require fresh compilation even on an
+exact hit; the immutable archive is not guaranteed to stay fully warm forever.
+
+## Validation and expected impact
+
+Validation completed locally:
+
+- Focused cache contracts and the full architecture and CI planner/gate packages
+  passed. Tests check cache ownership, manifest/tool identity, step ordering,
+  stable workload IDs, native-cache separation and absence of cache-hit skips.
+  An isolated fixture rejects the previous action configuration and passes with
+  the new configuration.
+- The cache-path script passed Bash syntax and execution checks with both
+  `ImageOS` and the `/etc/os-release` fallback.
+- Desktop tests passed: 141 Bun tests and 47 Node tests; the existing macOS-only
+  optional-dependency test was skipped on Linux. Native installers were not
+  rebuilt, and the native workflow/action configuration has no diff.
+- Actionlint passed for all seven setup-ci consumers with the existing unsupported
+  `stacked` event excluded. Documentation generation/checks and whitespace checks
+  passed.
+- `task ci` passed generation and SQL verification/audit, then stopped at required
+  PostgreSQL conformance because this workspace cannot access Docker. No test
+  requirement was disabled; the complete local CI contract has not passed.
+
+Hosted cache restore/save behavior still needs confirmation on an eligible run.
+
+The change removes the demonstrated reservation collision. It does **not** yet
+establish a hosted elapsed-time reduction. The audit's 1–3 minute warm-path saving
+is an experiment hypothesis; initial cold runs and larger restore/save costs can
+reduce or erase it. The prior 21–23 minute merge observations remain the baseline
+until an eligible hosted candidate tests this change.
+
+For rollout, record each scope's producer/ref, archive size, restore/save outcome,
+setup/preparation and test-command timing. Measure both cold and warm merge
+candidates with unchanged required gates and exact-SHA native proof. Do not infer
+a new p95 from one run or attribute the separate Buf-removal change twice.

--- a/internal/platform/ci/hosted-remediation-measurement.md
+++ b/internal/platform/ci/hosted-remediation-measurement.md
@@ -1,218 +1,314 @@
 # Hosted #520 remediation measurement
 
-## Publication and validation update — 2026-09-08
-
-The remediation is now published in
-[PR #537 — CI: remove merge validation dependency barrier](https://github.com/flidai/leapview/pull/537).
-
-| Item | Current value |
-|---|---|
-| Branch | `ganesh/ci-health-520-remediation` |
-| Last observed hosted PR commit | `63d4421053c75447438962511b64dec6c83e51c1` |
-| PR CI exposing the boundary failure | [34204761966](https://github.com/flidai/leapview/actions/runs/34204761966), attempt 1, `pull_request` |
-| Tested PR merge SHA | `b0a699243cdaabe90433bf1d22369f1a228f685b` |
-| Plan | Version 2; all lanes selected for cross-cutting CI inputs; planner succeeded |
-| Security / native PR proof | Security gate and Electron gate passed |
-| Required CI gate | Failed after all PR lanes completed; Go package validation is the sole failed validation lane |
-| Approving review | Not yet recorded; user is arranging it manually |
-| Merge queue entered | No; protections and the requested approval prerequisite have not been bypassed |
-| First eligible merge candidate SHA / run / date | Unavailable |
-| Measured after-remediation merge duration / p95 | Unavailable |
-
-The initial workspace was detached at `3b201d716`. A new branch was created and
-fast-forwarded to current main without rewriting history. Existing work was
-published in separate commits for reporting/selection (`7180ea302`), the merge
-barrier removal (`74a9a6944`), and audit/measurement documentation (`77c96e318`).
-GitHub MCP was disconnected, so authenticated `gh` supplied the GitHub integration.
-
-The first [PR run 34204071795](https://github.com/flidai/leapview/actions/runs/34204071795)
-exposed a reporting compatibility issue: GitHub's run metadata uses the source
-head SHA, while the plan records the tested PR merge SHA. With explicit user
-authorization, the separate reporting-only commit `63d442105` verifies the merge
-commit's parents against the run's recorded PR head/base. It preserves exact-SHA
-matching for merge-group runs, rejects stale run/attempt provenance, and leaves
-unavailable evidence untrusted. Its regression tests and a read-only report over
-the actual hosted artifact passed. Planner selection and workflow execution were
-not changed by that fix.
-
-### Hosted blocker and local boundary correction
-
-[Go package job 101991986188](https://github.com/flidai/leapview/actions/runs/34204761966/job/101991986188)
-failed in `TestDBTWarehouseBoundaryDoesNotEnterLeapViewRuntime` at 08:39:54 UTC.
-The architecture guard classifies `DBT` and dbt lane-name literals in
-`internal/platform/ci/pr_plan.go` and `health_jobs.go` as product runtime code.
-Only the `ciplan` and `cireport` command packages import that CI package.
-
-The failure reproduces locally. The authorized correction replaces the planner's
-vendor-specific concepts with a neutral warehouse validation lane. Existing
-workflow identifiers and version-2 artifact fields remain integration contracts;
-the architecture guard remains unchanged. No failed validation is skipped or
-disabled. The application lane and all other validation lanes passed; the required
-CI gate correctly failed on the package lane.
-
-Local boundary-fix validation: planner, adapter and CLI race tests passed;
-the complete architecture suite passed with 84.1% coverage (82.9% floor).
-Frontend contracts passed (4 tests, 25 assertions), as did quality budgets,
-exception checks, all critical-package coverage floors, documentation catalog
-validation and seven Mermaid diagrams. Neither runtime binary depends on the
-planner or adapter. `task ci` reached required PostgreSQL conformance and failed
-because this environment cannot access `/var/run/docker.sock`; that check remains
-mandatory and needs hosted validation.
-
-Next action: publish the boundary refactor, wait for the required gates and the manually arranged approving review, then use the normal merge queue
-with the expected head SHA. Only after an eligible
-`merge_group` run finishes can this report name the actual critical path or compare
-its first observed duration with the supplied 44m40s pre-remediation p95. One
-observation will not establish a new p95. No additional optimization is proposed
-or implemented during this operational validation.
-
-## Initial eligibility audit (before publication)
-
-Checked: **2026-09-08, approximately 07:54 UTC**.
-Status: **awaiting an eligible hosted run; impact cannot yet be measured**.
-
 ## Executive summary
 
-- **Did Phase 2.3 achieve the expected improvement?** Undetermined. Its workflow
-  change exists locally, but the checked hosted branch and newest candidates still
-  contain the old dependency barrier.
-- **Current remediated merge p95:** unavailable, with zero eligible observations.
-  The supplied pre-remediation baseline is **44m40s**. No projected timing or old
-  run is used as an after measurement.
-- **Remaining post-remediation bottleneck:** not yet observed. The immediate
-  measurement prerequisite is a hosted candidate containing the remediation.
+The merge-queue dependency barrier removal is **verified in hosted execution**.
+[PR #537's candidate, run 34215268411](https://github.com/flidai/leapview/actions/runs/34215268411),
+completed in **21m09s**. A dependent remediated candidate,
+[run 34215448203 for PR #534](https://github.com/flidai/leapview/actions/runs/34215448203),
+completed in **22m41s**. Both were successful first-attempt `merge_group` runs;
+full validation started independently alongside the base lanes.
 
-No workflow, dependency, planner, threshold, cache, runner, gate or validation
-behavior was changed in this task. The requested measurement success criteria
-remain unmet until an eligible hosted execution exists.
+An earlier, superseded PR #537 candidate also completed in **22m02s** and is
+reported separately below. These are **three individual observations**, not a new
+representative p95.
+The supplied historical pre-remediation p95 is **44m40s**. The observations are
+substantially below that baseline, but comparing individual runs with a historical
+quantile does not establish the size of a p95 improvement or isolate causality.
+None of these observed runs was below the 12-minute target.
 
-## Measurement evidence and eligibility
+The blocking lane was **full validation** for PR #537's final candidate and **Go
+application validation** for the dependent and superseded candidates. Go packages,
+application, and full validation all finished within 24 seconds of one another in
+the second run.
+Security and native proof completed much earlier; the CI gate spent only one
+second checking native proof in each primary candidate.
 
-Read-only GitHub Actions queries checked recent merge runs, new runs since the
-previous collection cutoff, hosted `main`, and workflow contents at the exact
-two newest candidate SHAs. These checks determine eligibility only. Excluded-run
-timings and the old seven-day samples are not used in the comparison below.
+No workflows, code, checks, thresholds, runners, or caches were changed. No
+further optimization was started.
 
-| Evidence | Candidate SHA | UTC timestamp | Eligibility result |
-|---|---|---|---|
-| Hosted `main` | `e704f88068696c9fe1136a51c22b088663976f31` | Commit: 2026-09-08 06:58:54 | Full validation still depends on all base jobs |
-| [Merge run 34199634415](https://github.com/flidai/leapview/actions/runs/34199634415) | `3140c97c272c018389ee8fd2e1594376463a88f3` | Created: 2026-09-08 07:30:07 | Excluded: old barrier; completed with failure |
-| [Merge run 34197131849](https://github.com/flidai/leapview/actions/runs/34197131849) | `e704f88068696c9fe1136a51c22b088663976f31` | Created: 2026-09-08 06:59:14 | Excluded: old barrier; completed successfully |
-| New merge runs after 2026-09-08 07:40:01 | — | Checked around 07:54 | API returned `total_count: 0` |
+## Corrected cohort rule and eligibility
 
-The [newest candidate's workflow](https://github.com/flidai/leapview/blob/3140c97c272c018389ee8fd2e1594376463a88f3/.github/workflows/merge-validation.yml)
-and [hosted main revision's workflow](https://github.com/flidai/leapview/blob/e704f88068696c9fe1136a51c22b088663976f31/.github/workflows/merge-validation.yml)
-both retain:
+A merge queue validates the candidate **before** completing the merge. Eligibility
+therefore depends on the tested SHA and workflow, not a run starting after
+`merged_at`. The previous report's timestamp cutoff incorrectly excluded the
+execution that gated PR #537 itself; this report supersedes that exclusion.
 
-```yaml
-full-validation:
-  name: Full merge validation
-  if: github.repository == 'flidai/leapview'
-  needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation]
-```
+A qualifying measurement must have `event=merge_group`, contain the Phase 2.3
+workflow change at its tested SHA, and use `merge-validation.yml` with no base-lane
+`needs` on `full-validation`. Completed successful first attempts whose required
+checks passed form the primary observation set. Failures, reruns, incomplete
+runs, and other events must be disclosed separately rather than blended in.
 
-Queries used:
+| Cohort | Evidence | Treatment |
+|---|---|---|
+| Pre-remediation historical baseline | User-supplied merge p95 **44m40s** | Baseline only; old seven-day runs are not after samples |
+| PR #537 merge-queue validation | **34215268411**, created before PR #537 merged | Eligible: exact candidate that gated PR #537 |
+| Dependent queue candidate containing #537 | **34215448203**, queue branch for PR #534 | Eligible remediated observation; not a second execution of PR #537 alone |
+| Superseded earlier PR #537 candidate | **34212294501**, same Phase 2.3 workflow, different candidate SHA | Eligible supplemental observation; not the final merged candidate |
+| Runs created after PR #537 merged | **34219005648**, created 11:07:13; in progress at **11:10:20 UTC** | Separate population: one pending run, no completed observation yet |
 
-```text
-gh run list --repo flidai/leapview --workflow merge-validation.yml --limit 20
-GET /repos/flidai/leapview/actions/workflows/merge-validation.yml/runs
-    ?event=merge_group&created=%3E2026-09-08T07:40:01Z&per_page=100
-GET /repos/flidai/leapview/commits/main
-GET /repos/flidai/leapview/contents/.github/workflows/merge-validation.yml?ref={SHA}
-```
+All dates below are **2026-09-08 UTC**. PR #537 merged at **10:45:55**, and PR #534
+merged at **10:49:07**.
 
-There are **no eligible run IDs, start/end timestamps or durations to report**.
-Missing observations are unavailable, not zero seconds. A local workflow edit,
-successful old candidate, or rerun of an old SHA does not satisfy eligibility.
+| Run | Tested SHA | Queue branch | Event / attempt / conclusion | Created = run started | Last job completed | Eligible |
+|---|---|---|---|---|---|---|
+| [34215268411](https://github.com/flidai/leapview/actions/runs/34215268411) | `0f50134925ac4721443751c6a313985528564416` | `gh-readonly-queue/main/pr-537-7e081e5f0806d99bf75c13bc0dee2540825f1254` | `merge_group` / 1 / success | 10:24:20 | 10:45:29 | Yes: matches PR #537's merged SHA |
+| [34215448203](https://github.com/flidai/leapview/actions/runs/34215448203) | `a1c287f409620172938c03637daad646c6a29c64` | `gh-readonly-queue/main/pr-534-0f50134925ac4721443751c6a313985528564416` | `merge_group` / 1 / success | 10:26:22 | 10:49:03 | Yes: contains the merged remediation |
 
-## Before/after comparison
+The [PR #537 merge](https://github.com/flidai/leapview/pull/537) identifies the first
+SHA. The [commit comparison](https://github.com/flidai/leapview/compare/0f50134925ac4721443751c6a313985528564416...a1c287f409620172938c03637daad646c6a29c64)
+shows the second SHA one commit ahead, zero behind, with the first SHA as merge
+base. It is the merged SHA of [PR #534](https://github.com/flidai/leapview/pull/534),
+which adds contract-projection work; these are not repeated trials of identical
+source content.
 
-Only the user-supplied baseline is retained. Other before values are not
-reconstructed from the excluded historical population.
+The [workflow at the first SHA](https://github.com/flidai/leapview/blob/0f50134925ac4721443751c6a313985528564416/.github/workflows/merge-validation.yml)
+and [workflow at the second SHA](https://github.com/flidai/leapview/blob/a1c287f409620172938c03637daad646c6a29c64/.github/workflows/merge-validation.yml)
+are byte-identical to the remediated workflow, SHA-256
+`d07183311b59571ca16ce4d0f5b8cb72e70b4d38aa0793245ad5a0e84345ea6e`.
+`full-validation` has no `needs`; CI gate retains all base/full dependencies and
+exact-SHA native proof. The squash-merged SHA is authoritative; requiring the
+original branch head to be its ancestor would incorrectly reject this candidate.
 
-| Metric | Before | After |
-|---|---:|---:|
-| Merge p50 | Not supplied | Unavailable |
-| Merge p95 | **44m40s** | **Unavailable** |
-| Workflow queue time | Not supplied | Unavailable |
-| Base validation elapsed | Not supplied | Unavailable |
-| Full extras elapsed | Not supplied | Unavailable |
-| CI gate dependency/proof wait | Not supplied | Unavailable |
+The post-merge-created [run 34219005648](https://github.com/flidai/leapview/actions/runs/34219005648)
+is a `merge_group`, attempt 1, for PR #538, tested SHA
+`a97e07e35abb11a9f97052c28a3d8a1855c850bb`. It starts from the PR #534 candidate,
+is two commits ahead of the merged remediation, and has the identical workflow
+hash above. Its CI gate and required results are not complete at the cutoff:
+**no final duration or latency sample is assigned to this pending run**.
 
-Improvement, percentage reduction and attainment of the 12-minute p95 threshold
-cannot be calculated. In particular, the earlier 20–22-minute estimate is not an
-observed after value.
+The window from PR #537's creation (08:21:34) through 11:10:20 contains six
+merge-validation runs: the three completed remediated observations, that pending
+post-merge run, and two older-workflow runs, 34204567000 and 34212032765. The latter
+two still contain the full-validation dependency barrier and remain excluded.
 
-## Updated critical path
+## Before/after measurements
 
-The following is the **local configuration awaiting hosted verification**, not
-a measured timing diagram. The longest lane and blocking job are unknown until
-that configuration executes remotely.
+Workflow elapsed is **latest job completion minus run start**, matching the
+reporter's completion-based measure. GitHub's mutable run `updated_at` values
+are 10:45:30 and 10:49:04: their respective start-to-update spans are 21m10s and
+22m42s, one second longer than the execution measure. They are not substituted
+for actual job completion times.
+
+| Metric | Historical before | PR #537 candidate | Dependent PR #534 candidate |
+|---|---:|---:|---:|
+| Merge duration | **44m40s p95** | **21m09s**, one observation | **22m41s**, one observation |
+| Workflow queue: created to run started | Not supplied | 0s | 0s |
+| Initial dispatch: run started to first job started | Not supplied | 3s | 4s |
+| Base validation wall span | Not supplied | 19m49s | 22m32s |
+| Full-validation job duration | Not supplied | 20m59s | 22m27s |
+| CI gate dependency wait from run start | Not supplied | 21m02s | 22m36s |
+| Dependency release: last validation end to gate created | Not supplied | 1s | 0s |
+| CI gate scheduling wait: created to started | Not supplied | 3s | 3s |
+| CI gate execution | Not supplied | 3s | 2s |
+| Native-proof check step inside CI gate | Not supplied | 1s | 1s |
+| Current representative merge p95 | 44m40s baseline | Not established | Not established |
+
+Base span is earliest base-job start to latest base-job completion; it is not the
+sum of parallel jobs. Gate dependency wait is expected waiting for required
+validation, not a runner queue. Job creation-to-start is an observable scheduling
+interval that may include provisioning; pure runner-capacity wait is not exposed.
+The one-second native check includes its API request and is not evidence of a
+one-second sleep/poll delay.
+
+## Job timing evidence
+
+Each table comes from the attempt-1 jobs endpoint, **10 of 10 jobs** returned and
+all concluded `success`. Job links provide the original hosted evidence.
+
+### PR #537 candidate: 34215268411
+
+| Job | Created / queued | Started | Completed | Duration | Scheduling wait |
+|---|---|---|---|---:|---:|
+| [apigen-validation](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424436) | 10:24:20 | 10:24:24 | 10:29:17 | 4m53s | 4s |
+| [frontend-validation/chat](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424769) | 10:24:20 | 10:24:24 | 10:30:52 | 6m28s | 4s |
+| [frontend-validation/core](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424699) | 10:24:20 | 10:24:24 | 10:31:17 | 6m53s | 4s |
+| [frontend-validation/data](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424889) | 10:24:20 | 10:24:24 | 10:31:06 | 6m42s | 4s |
+| [frontend-validation/reports](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424783) | 10:24:20 | 10:24:24 | 10:31:42 | 7m18s | 4s |
+| [frontend-validation/site](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424843) | 10:24:20 | 10:24:24 | 10:31:48 | 7m24s | 4s |
+| [full-validation](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424673) | 10:24:20 | 10:24:23 | 10:45:22 | 20m59s | 3s |
+| [go-application-validation](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424924) | 10:24:20 | 10:24:24 | 10:44:13 | 19m49s | 4s |
+| [go-packages-validation](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424741) | 10:24:20 | 10:24:24 | 10:40:46 | 16m22s | 4s |
+| [CI gate](https://github.com/flidai/leapview/actions/runs/34215268411/job/102031377233) | 10:45:23 | 10:45:26 | 10:45:29 | 0m03s | 3s |
+
+### Dependent candidate: 34215448203
+
+| Job | Created / queued | Started | Completed | Duration | Scheduling wait |
+|---|---|---|---|---:|---:|
+| [apigen-validation](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006539) | 10:26:23 | 10:26:26 | 10:31:13 | 4m47s | 3s |
+| [frontend-validation/chat](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006456) | 10:26:23 | 10:26:27 | 10:33:51 | 7m24s | 4s |
+| [frontend-validation/core](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006414) | 10:26:23 | 10:26:26 | 10:32:42 | 6m16s | 3s |
+| [frontend-validation/data](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006477) | 10:26:23 | 10:26:27 | 10:34:28 | 8m01s | 4s |
+| [frontend-validation/reports](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006550) | 10:26:23 | 10:26:26 | 10:34:04 | 7m38s | 3s |
+| [frontend-validation/site](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006493) | 10:26:23 | 10:26:27 | 10:34:27 | 8m00s | 4s |
+| [full-validation](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006445) | 10:26:23 | 10:26:26 | 10:48:53 | 22m27s | 3s |
+| [go-application-validation](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006476) | 10:26:23 | 10:26:27 | 10:48:58 | 22m31s | 4s |
+| [go-packages-validation](https://github.com/flidai/leapview/actions/runs/34215448203/job/102026006260) | 10:26:23 | 10:26:27 | 10:48:34 | 22m07s | 4s |
+| [CI gate](https://github.com/flidai/leapview/actions/runs/34215448203/job/102032377857) | 10:48:58 | 10:49:01 | 10:49:03 | 0m02s | 3s |
+
+### Supplemental: superseded PR #537 candidate 34212294501
+
+The corrected rule also admits this earlier successful first-attempt `merge_group`
+run, SHA `13e061045193ac0fc794ee4112e9ab0939f66fbb`, created/started **09:51:18**,
+last job completed **10:13:20**. Its queue branch identifies PR #537, and its
+[exact workflow](https://github.com/flidai/leapview/blob/13e061045193ac0fc794ee4112e9ab0939f66fbb/.github/workflows/merge-validation.yml)
+has the same SHA-256 above. Lack of descent from the later merged SHA is not a
+valid reason to exclude this earlier remediated candidate.
+
+Its workflow elapsed was **22m02s**, with zero initial workflow queue, **21m53s**
+base span, and **21m38s** full validation. CI gate dependency wait from run start
+was **21m56s**, then 0s release delay, 3s scheduling, and 3s execution. The native
+proof check step took 0s at API timestamp resolution. Go application was the
+blocker, finishing 14s after full validation. Full validation started at 09:51:22
+while base jobs were already active and overlapped them for its entire 21m38s.
+
+| Job | Created / queued | Started | Completed | Duration | Scheduling wait |
+|---|---|---|---|---:|---:|
+| [apigen-validation](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015867712) | 09:51:18 | 09:51:21 | 09:55:43 | 4m22s | 3s |
+| [frontend-validation/chat](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015867982) | 09:51:18 | 09:51:27 | 09:58:17 | 6m50s | 9s |
+| [frontend-validation/core](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015867993) | 09:51:18 | 09:51:21 | 09:57:51 | 6m30s | 3s |
+| [frontend-validation/data](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015868095) | 09:51:18 | 09:51:22 | 09:58:35 | 7m13s | 4s |
+| [frontend-validation/reports](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015868122) | 09:51:18 | 09:51:21 | 09:58:28 | 7m07s | 3s |
+| [frontend-validation/site](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015868161) | 09:51:18 | 09:51:22 | 09:57:33 | 6m11s | 4s |
+| [full-validation](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015867963) | 09:51:18 | 09:51:22 | 10:13:00 | 21m38s | 4s |
+| [go-application-validation](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015868150) | 09:51:18 | 09:51:22 | 10:13:14 | 21m52s | 4s |
+| [go-packages-validation](https://github.com/flidai/leapview/actions/runs/34212294501/job/102015868094) | 09:51:18 | 09:51:22 | 10:07:14 | 15m52s | 4s |
+| [CI gate](https://github.com/flidai/leapview/actions/runs/34212294501/job/102022211196) | 10:13:14 | 10:13:17 | 10:13:20 | 0m03s | 3s |
+
+Its exact-SHA, `merge_group` [Security run 34212294502](https://github.com/flidai/leapview/actions/runs/34212294502)
+completed successfully from 09:51:18 to 09:55:49 (**4m31s**), with Security gate
+09:55:26–09:55:49 (23s). The [Electron proof run 34212294553](https://github.com/flidai/leapview/actions/runs/34212294553)
+completed successfully from 09:51:18 to 09:54:57 (**3m39s**), with Electron gate
+09:54:53–09:54:57 (4s). Together with the successful CI gate, the required checks
+were complete. These proofs did not extend the merge critical path.
+
+## Required checks, security, and native proof
+
+The active main ruleset requires **CI gate** and **Security gate**. CI gate also
+requires the exact-candidate successful `electron-security-proof.yml` merge-group
+workflow. All these checks completed successfully for the two primary candidates; the
+supplemental candidate's successful gates are recorded above.
+
+| Candidate | Workflow run | Started | Last job completed | Elapsed | Gate created / started / completed | Gate result |
+|---|---|---|---|---:|---|---|
+| 34215268411 | [Security gate: 34215268258](https://github.com/flidai/leapview/actions/runs/34215268258) | 10:24:19 | 10:29:30 | 5m11s | 10:29:07 / 10:29:10 / 10:29:30 | success |
+| 34215268411 | [Electron gate: 34215268510](https://github.com/flidai/leapview/actions/runs/34215268510) | 10:24:20 | 10:29:23 | 5m03s | 10:29:18 / 10:29:21 / 10:29:23 | success |
+| 34215448203 | [Security gate: 34215448324](https://github.com/flidai/leapview/actions/runs/34215448324) | 10:26:22 | 10:31:33 | 5m11s | 10:31:10 / 10:31:13 / 10:31:33 | success |
+| 34215448203 | [Electron gate: 34215448215](https://github.com/flidai/leapview/actions/runs/34215448215) | 10:26:22 | 10:30:20 | 3m58s | 10:30:14 / 10:30:17 / 10:30:20 | success |
+
+Both security gates queued for 3s and executed for 20s. The Electron gates queued
+for 3s and executed for 2s / 3s. Security and native proof were complete more than
+15 minutes before the respective CI gates started. They did not extend the
+measured merge critical paths.
+
+Match proof evidence by **SHA and event**, not the newest check with that name.
+The same first SHA subsequently received `push` runs 34217166813 (security) and
+34217166812 (Electron), both cancelled after merge. Their non-success aggregate checks
+do not replace the successful `merge_group` proof above or invalidate its timing.
+Post-merge `push` runs are not merge-validation observations.
+
+The native workflows intentionally skipped their push-only main-attestation job;
+their merge-proof jobs and Electron gates succeeded. Some native jobs' raw step
+times precede their reported job starts, and skipped attestation has reversed
+start/end times. Neither anomaly is used to derive a native command duration:
+the support-workflow spans above use run start and the last completed job.
+
+## Concurrency proof and measured critical path
+
+For PR #537, full validation started at **10:24:23**, one second before the base
+lanes started at 10:24:24 and **19m50s before** the last base lane finished at
+10:44:13. It overlapped the entire **19m49s** base span and finished at 10:45:22.
+
+For the dependent candidate, full validation started at **10:26:26**, alongside
+the earliest base lanes and **22m32s before** base completion at 10:48:58. It
+finished at 10:48:53, after **22m27s** of overlap. This is timestamp evidence of
+independent execution, not a projection from YAML alone.
 
 ```mermaid
 flowchart LR
-  accTitle: Remediated merge configuration awaiting hosted timings
-  accDescr: Base lanes and full extras should start independently. The CI gate requires both and exact-candidate native proof; Security gate independently protects merging. No durations have been observed for this configuration.
-  M[Eligible merge candidate: not yet observed] --> B[APIGen, Go packages, Go application, frontend shards]
-  M --> F[Full extras]
-  B --> G[CI gate]
-  F --> G
-  M --> N[Exact-candidate native proof]
-  N --> G
-  M --> S[Security gate]
-  G --> Q[Merge requirements satisfied]
-  S --> Q
+  accTitle: Measured merge queue critical paths after the dependency barrier removal
+  accDescr: In PR 537 the base lanes finish at 10:44:13 and independent full validation finishes at 10:45:22, blocking the CI gate until 10:45:29. In the dependent PR 534 candidate full validation finishes at 10:48:53 but Go application validation finishes five seconds later, blocking the CI gate until 10:49:03. Security and native proof finish earlier in both runs.
+  subgraph A[PR 537 candidate: 21m09s]
+    A0[Run starts 10:24:20] --> AB[Base lanes: 19m49s, finish 10:44:13]
+    A0 --> AF[Full validation: 20m59s, finish 10:45:22]
+    AB --> AG[CI gate: 10:45:26 to 10:45:29]
+    AF --> AG
+  end
+  subgraph B[Dependent PR 534 candidate: 22m41s]
+    B0[Run starts 10:26:22] --> BB[Base lanes: 22m32s, application finishes 10:48:58]
+    B0 --> BF[Full validation: 22m27s, finish 10:48:53]
+    BB --> BG[CI gate: 10:49:01 to 10:49:03]
+    BF --> BG
+  end
 ```
 
-When collecting job timings, retain the workflow's actual inventory:
+The first blocker was full validation, finishing **1m09s** after the application
+lane. In the second candidate, application finished **5s** after full validation
+and **24s** after Go packages. Optimizing just one of these lanes would not
+necessarily materially reduce the next candidate's end-to-end duration.
 
-| Requested lane | Merge measurement scope |
-|---|---|
-| `apigen-validation` | Collect its job start, end, execution duration and runner wait |
-| `go-packages-validation` | Collect its job and preparation/validation steps |
-| `go-application-validation` | Collect its job and application/external-service command intervals |
-| `frontend-validation` | Collect each of core, reports, chat, data and site individually |
-| `full-validation` / full extras | Collect its job and preparation/validation steps; verify overlap with base lanes |
-| `postgres-isolation-validation` | Separate PR job in the current architecture; not an independent merge job |
-| Spatial benchmarks | Separate PR job; do not fabricate a merge-job duration |
-| dbt validation | Separate PR job; collect an eligible remediated PR separately if evaluating PR impact |
+### Expensive lane step breakdown
 
-Embedded database/external-service checks remain attributable to their owning
-merge jobs. Separate PR timings must not enter merge percentiles.
+These are measured step intervals, not CPU time or pure test-runtime estimates.
+The main validation commands include their existing internal subcommands.
 
-## Recommendation
+| Candidate / lane | Checkout | Toolchain setup | Generated preparation | Main validation command | Post-job toolchain + checkout cleanup |
+|---|---:|---:|---:|---:|---:|
+| 34215268411 / Go package | 0m07s | 2m00s | 4m02s | 9m32s | 0m02s |
+| 34215268411 / Go application | 0m07s | 1m45s | 3m26s | 14m26s | 0m01s |
+| 34215268411 / Full validation | 0m06s | 2m02s | 4m00s | 14m46s | 0m02s |
+| 34215448203 / Go package | 0m07s | 1m55s | 3m24s | 15m49s | 0m21s |
+| 34215448203 / Go application | 0m07s | 2m03s | 4m10s | 15m44s | 0m23s |
+| 34215448203 / Full validation | 0m06s | 2m17s | 4m07s | 15m04s | 0m50s |
 
-**Next engineering action: publish the existing remediation through the normal
-review process and obtain a real PR/merge candidate executing it.** This measurement
-task does not push, merge, enqueue or alter workflows. Confirm the tested SHA
-contains the changes and that full extras actually overlaps the base jobs.
+The table omits job bookkeeping gaps and separate Prometheus/generated-artifact
+checks, so its columns are not expected to sum exactly to job duration. Full
+validation's main command alone took 14m46s / 15m04s; application validation took
+14m26s / 15m44s. Package validation varied from 9m32s to 15m49s across different
+candidate content. Setup and preparation are also material (roughly 5–6 minutes
+before the principal commands), while runner dispatch and gate waits are small.
 
-After that execution, collect:
+## Interpretation and next measurement
 
-1. Exact candidate SHA, run ID, attempt, event and workflow contents; verify the
-   barrier is absent, all required jobs are present and gate/proof checks remain.
-2. Run and job timestamps. Separate initial dispatch/runner delay from dependency
-   waiting: runner wait is job start minus job creation; gate eligibility begins
-   when all required validation jobs finish.
-3. Preparation, test/qualification and cleanup step intervals; gate runner queue,
-   gate execution and native-proof polling duration separately. Match security
-   and native proof by the exact SHA and merge event.
-4. Completed successful first-attempt elapsed samples using latest job completion
-   minus run start, nearest-rank percentiles and explicit cohort/window counts.
-   Report failures, cancellations, missing timestamps and reruns separately.
+Barrier removal worked and the first remediated merge observations are about
+21–23 minutes, substantially below the supplied 44m40s historical p95. A new p95
+or an isolated causal effect is **not established by this small candidate cohort**.
+Collect a representative set of successful merge-group attempts, retain failures
+and reruns separately, and keep the final PR #537, superseded candidate, dependent
+candidate, and post-merge-created cohort labels when extending the report.
 
-A first eligible run can establish overlap and a single-run improvement; it cannot
-establish a stable p95. Collect a representative trailing window before assessing
-the threshold. Preserve the supplied historical baseline's scope when comparing.
+The remaining observed work lies in full validation and application/package
+validation, including preparation. Security/native proof and runner queues were
+not the bottleneck in these observations. Further measurement should attribute
+those long command intervals before selecting any optimization. No decomposition,
+sharding, caching, runner tuning, or workflow change was performed here.
 
-Full-extras decomposition, PostgreSQL conformance sharding, Go package splitting
-and preparation deduplication remain **unranked in this task**. Ranking expected
-latency savings before observing the remediated critical path would violate the
-measurement-first requirement. No follow-up optimization is implemented.
+## Sources, method, and validation
 
-## Validation
+GitHub MCP was disconnected (`USER_NOT_LOGGED_IN`), so authenticated read-only
+`gh api` requests provided the data. Evidence was collected on 2026-09-08 and
+reconciled against the current completed runs and active main ruleset.
 
-Documentation-only change: this report. Checked its local/remote link syntax,
-Mermaid accessibility metadata, required report sections and `git diff --check`.
-No code tests or hosted workflow dispatches were needed or run for this report.
-Existing local remediation files remain unchanged by this task.
+```text
+GET /repos/flidai/leapview/pulls/537
+GET /repos/flidai/leapview/pulls/534
+GET /repos/flidai/leapview/actions/runs/{run_id}
+GET /repos/flidai/leapview/actions/runs/{run_id}/attempts/1/jobs?per_page=100&page=1
+GET /repos/flidai/leapview/actions/runs?head_sha={sha}&event=merge_group&per_page=100
+GET /repos/flidai/leapview/contents/.github/workflows/merge-validation.yml?ref={sha}
+GET /repos/flidai/leapview/compare/{merged_remediation_sha}...{candidate_sha}
+GET /repos/flidai/leapview/rules/branches/main
+GET /repos/flidai/leapview/actions/workflows/merge-validation.yml/runs
+    ?event=merge_group&created=%3E2026-09-08T10%3A45%3A55Z&per_page=100
+```
+
+All collected job totals fit one page and were checked against `total_count`;
+each associated security/proof workflow is attempt 1, event `merge_group`, and
+matches the exact candidate SHA. Raw responses are retained in the local
+`/home/codex/.cache/ci-hosted-measurement-20260908` evidence directory. All run/job
+identifiers and timestamps needed to reproduce the tables are included above.
+
+Only this report changed. Documentation catalog checks, validation of all seven
+Mermaid diagrams, and `git diff --check` passed. No code tests, workflow changes,
+or hosted dispatches were performed for this measurement-only task.

--- a/internal/platform/ci/preparation-profile.md
+++ b/internal/platform/ci/preparation-profile.md
@@ -1,0 +1,270 @@
+# CI preparation and cache audit — #520
+
+Audit date: 2026-09-08. **Documentation only; no cache, workflow, task, runner or
+validation changes are made by this audit.**
+
+## Result and measurement scope
+
+Preparation materially contributes to merge latency: application setup plus
+preparation takes **5m11s–6m13s**, and full-validation runner setup plus preparation takes **6m02s–6m24s**. Each
+candidate runs the same `ci:prepare` on eight isolated runners, spending
+**31m39s–31m40s of aggregate runner time** on that task. Those costs overlap;
+they are not 31 minutes on the merge critical path.
+
+The strongest finding is a **cache ownership collision**, not a missing cache.
+A native packaging job populates the same Go key as the broad validation lanes
+with a small compiler cache and no module directory. The richer lanes cannot
+replace it. Fixing ownership and warm-cache publication is the first experiment
+to design. Centralizing preparation alone primarily saves runner time and adds a
+new dependency barrier; it is not an established elapsed-time improvement.
+
+Evidence comes from all **27 non-gate jobs** in these three completed, successful,
+attempt-1 `merge_group` runs:
+
+- [34212294501](https://github.com/flidai/leapview/actions/runs/34212294501), SHA `13e061045193ac0fc794ee4112e9ab0939f66fbb`.
+- [34215268411](https://github.com/flidai/leapview/actions/runs/34215268411), SHA `0f50134925ac4721443751c6a313985528564416`.
+- [34215448203](https://github.com/flidai/leapview/actions/runs/34215448203), SHA `a1c287f409620172938c03637daad646c6a29c64`.
+
+These are the deployed Phase 2.3 cohort in
+[hosted-remediation-measurement.md](hosted-remediation-measurement.md), observed at
+**22m02s, 21m09s and 22m41s**, respectively. They predate the separate Buf-removal
+follow-up in PR #540; its expected saving is not credited here. These samples do
+not establish a new p95. The historical pre-#520 p95 is **44m40s**.
+
+## Per-lane preparation cost
+
+Each row contains three observations; values are min–max, not percentiles.
+Setup is the composite toolchain step; preparation is the explicit generated/
+embedded-assets step. Test execution means the validation-command step envelope,
+including compilation and any nested setup; package validation also includes
+Prometheus and generated-artifact checks. GitHub does not expose pure test CPU or
+network-download time separately. APIGen has no standalone `ci:prepare` step;
+its own module preparation occurs inside its validation command.
+
+| Lane | Setup | Preparation | Test execution / validation envelope |
+|---|---:|---:|---:|
+| APIGen | 1m43s–2m00s | 0s | 2m29s–2m40s |
+| Full merge validation | 2m02s–2m17s | 4m00s–4m07s | 14m46s–15m12s |
+| Frontend / chat | 2m02s–2m25s | 4m00s–4m10s | 16s–17s |
+| Frontend / core | 1m59s–2m04s | 3m16s–4m01s | 35s–38s |
+| Go package | 1m55s–2m00s | 3m24s–4m02s | 9m48s–16m17s |
+| Frontend / data | 2m03s–2m34s | 3m55s–4m19s | 34s–37s |
+| Frontend / reports | 2m08s–2m19s | 4m00s–4m08s | 48s–51s |
+| Go application | 1m45s–2m03s | 3m26s–4m10s | 14m26s–15m44s |
+| Frontend / site | 2m00s–2m29s | 3m20s–4m10s | 40s–50s |
+
+Checkout takes **5–18s** across the cohort, usually 5–7s. Long-lane runner queues
+are **3–4s**. Full extras cleanup ranges **2–50s**; application **1–23s**, packages
+**1–21s**, with costly cache-save attempts on the cold-key candidate. Neither
+checkout nor queue scheduling explains the roughly 22-minute critical path.
+
+## Where work repeats
+
+`Taskfile.yml` defines `ci:prepare` as extension fixture provisioning and supply
+checks, complete generation, browser build, then public-site build. Application,
+packages, full extras and all five frontend shards run it separately. APIGen is
+independent. Task's local checksum/up-to-date state does not cross runners.
+
+1. **Go tools and dependencies:** setup compiles pinned Task (and Buf in this
+   historical cohort). All 27 logs still contain **215–395 `go: downloading`
+   records**, including after cache hits. The counts include tool dependencies
+   and are not unique-module counts or network durations. Root-module and nested
+   APIGen dependencies, SQLC's pinned tool module and the Go 1.26.7 SQLC toolchain
+   are distinct from the Go 1.26.8 application compiler.
+2. **Generated contracts and executable compilation:** every prepared runner
+   generates SQLC, API/signals, schemas, documentation and browser contracts.
+   Application job [102025424924](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424924)
+   spends **76s** between SQL generation and the next command and **59s** between
+   schema export and schema-doc generation. These are build/startup/generation
+   envelopes, not 135s of proven avoidable work.
+3. **Frontend assets:** every prepared runner installs the frozen Bun graph and
+   builds both application and site assets, including backend lanes that embed
+   generated assets. Five frontend jobs spend roughly four minutes preparing
+   inputs for validation envelopes of **16–51s**. The existing
+   `ci:prepare:frontend` target is a candidate starting point, not a proven drop-in
+   replacement for every shard: all generated/site/docs consumers need mapping.
+4. **Extension fixtures:** each fresh runner provisions its own private DuckDB
+   extension directory and validates supply contracts. The tool verifies versions,
+   loads artifacts and calculates digests. Local reuse exists; GitHub cache
+   persistence for this directory does not. Private permissions and runtime/OS/
+   architecture compatibility must survive any future transport.
+5. **PostgreSQL and Docker:** database containers, migrations, authentication and
+   readiness occur in validation commands, not in the explicit preparation column.
+   Application PostgreSQL conformance alone takes **11m58s–12m58s**. The source-
+   derived inventory runs with `-p 2`, integration tags, required containers and
+   `-count=1`. Startup and actual assertions are interleaved, so this is not a
+   measured 12-minute image-pull cost. Disposable databases and concurrent-test
+   ownership are correctness boundaries, not redundant artifacts.
+
+Command profiling in the nine application/package/full logs separates the main
+preparation costs (Task marker intervals, including subprocess compilation):
+
+| Preparation component | Observed interval |
+|---|---:|
+| Initial DuckDB provisioning plus supply check | 32.6–42.6s |
+| Complete generation graph | 168.2–205.2s |
+| SQL generation, within that graph | 71.3–93.3s |
+| Schema generation, within that graph | 55.5–70.7s |
+| Browser build | 1.0–1.8s |
+| Site build | 0.84–1.22s |
+
+Do not add nested rows to the generation total. A second extension invocation
+inside preparation is already warm and costs **0.56–0.84s** for that command;
+the nearby **5–7s** visual-doc generation is required work, not extension download
+duplication. These results favor Go preparation over caching final browser assets.
+
+The same-run runner-time arithmetic is:
+
+| Run | Preparation copies | Sum of preparation | Slowest copy | Sum minus slowest copy |
+|---|---:|---:|---:|---:|
+| 34212294501 | 8 | 31m40s | 4m17s | 27m23s |
+| 34215268411 | 8 | 31m40s | 4m08s | 27m32s |
+| 34215448203 | 8 | 31m39s | 4m19s | 27m20s |
+
+The last column is a hypothetical runner-time budget before artifact transfer and
+consumer initialization. It is **not** expected merge-latency reduction.
+
+## Existing caches and observed effectiveness
+
+Counts below are exact-key restores among jobs where the cache was enabled,
+not repository-wide hit rates. Current source is the shared setup action plus
+the other workflow/action cache consumers; sampled execution uses the exact SHAs
+above. Pinned setup-go v6 caches `GOMODCACHE` and `GOCACHE`, with OS/architecture,
+runner distribution, Go version and root `go.sum` identity. Its
+[restore implementation](https://github.com/actions/setup-go/blob/924ae3a1cded613372ab5595356fb5720e22ba16/src/cache-restore.ts)
+is the reference, rather than a newer action's defaults.
+
+| Cache | Sample exact hits | Identity / scope | Interpretation |
+|---|---:|---|---|
+| Go modules + compiler outputs | **18/27 (66.7%)** | Shared setup-go key; root dependency checksum | All nine jobs hit in each of the first two runs; all nine miss on changed checksum in the third |
+| Bun package downloads | **27/27 (100%)** | OS/arch, Bun 1.3.14, root + desktop lock hashes; version-scoped fallback prefixes | Frozen installation still runs; a hit is not permission to trust an existing `node_modules` tree |
+| Playwright Chromium | **18/18 (100%)** | OS/arch + Playwright 1.61.1 | Five frontend shards and full extras use it; system dependency installation still runs |
+| Terraform providers | **3/3 (100%)** | OS/arch, Terraform 1.13.5 and deployment lock hashes; version-scoped fallback | Full extras only; init/validation still execute |
+| Bun executable / hosted Node tool cache | Present in setup logs | Tool-version/platform identities owned by setup actions | Different from Bun package-download cache; not counted as package hits |
+| Docker BuildKit layers | Not exercised by this merge cohort | Production, site and release workflows use `gha` scopes by image/architecture | These do not populate Testcontainers' daemon image store on merge runners |
+| Python/pip | Not measured here | Reference/selected physical-contract workflows use setup-python caching | No hit-rate or merge-latency claim from this cohort |
+
+Composite substep log intervals across the 27 jobs: Go setup **7.9–13.3s**, Bun
+package-cache restore **3.1–6.2s**, historical Task+Buf install **83.6–114.0s**.
+The 18 browser-enabled jobs spend **12.3–20.4s** on cached Chromium/system
+installation. Rebuilding package trees or downloading images is not automatically
+expensive enough to justify a new archive cache.
+
+### Verified Go cache writer collision
+
+The first two candidates restore root checksum `7544f7e…`; the main cache
+**7364966855** is **24,846,316 bytes**, created 2026-09-05T16:44:48Z. The full key
+and one restore/save trace appear in the previous profiling report.
+
+For candidate `a1c287f…`, the root checksum changes to `64273d8f…`. All nine merge
+jobs log a miss. The exact-SHA native proof's
+[Hardened package (Linux x64) job 102026005333](https://github.com/flidai/leapview/actions/runs/34215448215/job/102026005333)
+then records:
+
+- 10:28:19.506 UTC: its module cache directory does not exist.
+- 10:28:21.257: it saves
+  `setup-go-Linux-x64-ubuntu24-go-1.26.8-64273d8f9f03fde2dbeeb996a9be4e1eb853a5064b32734355e4c71c0e887c9b`.
+- GitHub cache **7450424932**, on the PR #534 queue ref, has the same creation
+  timestamp and size **24,844,097 bytes**.
+- APIGen at 10:31:12 and application at 10:48:55 fail to reserve that same key
+  for saving; the larger application cache cannot replace the earlier entry.
+
+`.github/actions/desktop-preview-candidate/action.yml` and `setup-ci/action.yml`
+use the same cache-enabled setup-go configuration despite very different Go
+workloads. This establishes the writer for this queue cache, not the original
+writer of historical main cache 7364966855. A later main entry for the new checksum
+also measures about 25 MB; its writer was not traced here.
+
+GitHub caches are immutable per key and restore within permitted ref scopes;
+PR merge-ref entries are not a way to publish a reusable main cache. Matching
+keys do not transfer a just-produced workspace directly between concurrent jobs.
+A default-branch producer and a deliberate new cache generation may be needed to
+make an ownership fix useful across future merge candidates.
+[GitHub cache reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)
+
+## Sharing options and correctness
+
+| Work | Shareable form | What must remain local / mandatory |
+|---|---|---|
+| Downloaded Go modules | Same compatible dependency identities, including nested modules and pinned tools | Dependency integrity checks; missing entries fetched normally |
+| Go build cache | Trusted compatible compiler/platform/CGO context; separate broad-validation producer from narrow native probes | Do not use a hit to skip gates; retain forced fresh external-service tests |
+| Generated sources and browser/site assets | Allowlisted immutable artifact from the same tested SHA, run and attempt; producer validates outputs | Exact provenance, completeness, generated-diff checks, required consumers and failure propagation |
+| Bun downloads | Existing shared version/platform cache | `bun install --frozen-lockfile` and a single writer per checkout remain |
+| Browser and provider downloads | Existing caches, retaining pinned identities/lock validation | Host libraries, Terraform init and validation |
+| Container image bytes | Potential digest-pinned image pull reuse after separately measuring pull cost | Fresh containers, ports, networks, volumes, migrations and readiness |
+| PostgreSQL data directories, dev servers, `.tmp`, test evidence | **Do not share** as cached preparation | Fresh state, isolation, cleanup, runtime credentials and per-candidate proofs |
+| Task checksum markers / cached test results | Do not transplant as proof of validation | Verify generated outputs and preserve the intended fresh-test flags |
+
+Sharing a common module key is possible, but only if its writer actually prepares
+that dependency set. Broad validation and narrow native packaging should not race
+to freeze the same immutable archive. Separate namespaces or producer ownership
+must still respect branch trust and default-branch publication. A key change alone
+can repeat the same race, and disabling a writer alone leaves existing immutable
+entries in place. A future key proposal should cover nested module checksums,
+pinned tool versions and both compiler versions, rather than relying only on
+root `go.sum`. Keep download identity distinct from compiler/platform identity
+where that reduces churn; choose additional lane scopes only from measured
+cache contents, not one archive per job by default.
+
+Compiler caches can also contain Go test results. Go determines reuse from inputs
+and flags, while external state and C libraries have caveats; this is not a reason
+to replace required container runs with cache hits. Preserve the inventory's
+`-count=1`, fixture verification and fresh proof commands.
+[Go build and test caching](https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching)
+
+Dependency caches and executable artifacts are a trust boundary. Never include
+credentials, database state or whole workspaces. Limit publication to trusted
+contexts, retain package integrity checks, and do not allow a low-trust PR to
+supply executable cache contents to a privileged release path. The current
+configuration does not establish a cache vulnerability, and this audit does not
+claim one. Cache absence, eviction or corruption must produce normal validation
+or a visible failure, never a successful skipped check.
+[GitHub cache security guidance](https://docs.github.com/en/actions/concepts/workflows-and-actions/dependency-caching)
+
+## Candidates, expected reduction and risk
+
+No cold-versus-warm controlled run has been performed. Numeric estimates below
+are experiment hypotheses or budgets, not measured improvements or new p95s.
+
+| Priority | Candidate | Expected effect / measurement budget | Risk |
+|---:|---|---|---|
+| 1 | Separate native-probe cache ownership; publish a populated broad-validation Go cache from a trusted producer | Test a **1–3 minute** warm-path reduction across the long lanes, based on repeated tool/SQLC/schema compile envelopes; restore/save overhead and partial warming may erase some or all of it | Medium: ref publication, toolchain identity, cache size and test-result policy |
+| 2 | Same-run artifact for complete generated/embedded inputs | About **27 minutes of runner work** is a theoretical reuse budget per candidate; retained local regeneration reduces that saving, and elapsed saving is unproven and could be negative after producer queue/setup and transfer | Medium/high: new barrier, missing outputs, provenance, failure fan-out |
+| 3 | Verify a smaller frontend preparation contract using the existing target | Up to roughly four minutes per frontend runner is the total prep budget, not all removable; little merge benefit while app/full remain blockers | Medium: hidden generated consumers and docs/site contracts |
+| 4 | Avoid proven repeated extension preparation within one task invocation | Less than one second for the measured warm extension command; not a worthwhile target alone | Low/medium: mutable fixture inputs and task ordering |
+| 5 | Add image or installed-dependency archives | No defensible savings estimate yet; current Bun/browser restores are already effective at finding entries | Medium: transfer cost, platform mismatch and stale state |
+
+An artifact proposal must also account for existing dependency execution:
+`generated:check` depends on generation, and `db:check` intentionally regenerates
+SQL twice before verification and live SQL preparation. Downloading files does
+not by itself prevent these tasks from rerunning. Never transplant Task's skip
+markers or omit those checks to manufacture the theoretical runner-time saving.
+
+The first experiment should preserve every validation command and required name,
+record cache archive size/producer/ref, restore time, tool install, SQLC/schema
+commands, test envelopes and cleanup, and compare cold and warm runs at matching
+source/toolchain inputs. Do not count PR #540's independent Buf removal twice.
+A warm candidate must still run all mandatory validation. Only after collecting
+such evidence should the production cache design be selected.
+
+Even eliminating explicit setup/preparation leaves long validation envelopes of
+roughly 14–16 minutes in these samples. Preparation work is material, but this
+audit cannot promise the 12-minute target: build warming inside tests may help,
+and PostgreSQL/full-extras execution may still require separate engineering.
+
+## Reproduction and audit validation
+
+Collected read-only GitHub REST job details and logs for each run above:
+
+```text
+GET /repos/flidai/leapview/actions/runs/{run}/attempts/1/jobs?per_page=100
+GET /repos/flidai/leapview/actions/jobs/{job}/logs
+GET /repos/flidai/leapview/actions/caches?key={exact_key}&per_page=100
+```
+
+Job and step timestamps, cache markers, Task command boundaries and the native
+writer log were checked independently against workflow/Taskfile source. Raw logs
+stay outside the repository. Existing reports retain candidate eligibility and
+full job timestamp evidence. Validation: `bun run docs:validate-diagrams` passed (7 existing diagrams),
+`docsitegen --check` passed with a task-local temporary directory, and
+Markdown table-column and whitespace checks passed. No full CI was run for this audit-only file.

--- a/internal/platform/ci/remaining-critical-path-profile.md
+++ b/internal/platform/ci/remaining-critical-path-profile.md
@@ -1,0 +1,165 @@
+# Remaining merge CI critical path — #520
+
+Profiled 2026-09-08, before the tool-installation follow-up. The deployed Phase 2.3
+cohort and exact-SHA eligibility checks are in
+[hosted-remediation-measurement.md](hosted-remediation-measurement.md). The older
+[critical-path report](ci-critical-path-measurement.md) is the historical baseline,
+not the current deployed population.
+
+## Measured critical path
+
+| Merge candidate | Elapsed | Blocking lane | Gap to next lane |
+|---|---:|---|---:|
+| [34212294501](https://github.com/flidai/leapview/actions/runs/34212294501), superseded PR #537 | 22m02s | Go application | 14s after full extras |
+| [34215268411](https://github.com/flidai/leapview/actions/runs/34215268411), final PR #537 | 21m09s | Full extras | 1m09s after application |
+| [34215448203](https://github.com/flidai/leapview/actions/runs/34215448203), dependent PR #534 | 22m41s | Go application | 5s after full extras; 24s after packages |
+
+These are three observations on different candidates, not a new p95. The historical
+pre-remediation p95 remains **44m40s**. Queue delays are small and the CI gate
+executes in 2–3 seconds in this cohort. Security and native proof complete well
+before validation, as documented in the linked evidence report.
+
+```mermaid
+flowchart LR
+  accTitle: Remaining measured merge critical path
+  accDescr: Concurrent lanes include about six minutes of setup and preparation. Application and full extras finish close together and both block the final gate.
+  C[Exact merge candidate] --> A[Application: 19m49s–22m31s]
+  C --> F[Full extras: 20m59s–22m27s]
+  C --> P[Packages: 15m52s–22m07s]
+  C --> O[APIGen and frontend: complete earlier]
+  A --> G[CI gate: 2–3s execution]
+  F --> G
+  P --> G
+  O --> G
+  N[Exact-SHA native proof: complete earlier] --> G
+```
+
+## Hosted step profile
+
+Durations below use GitHub's attempt-1 job/step timestamps. Queue is
+`started_at - created_at`; total excludes that queue. Validation includes SQL
+verification, compilation, test processes and package-lane generated/Prometheus
+checks. It is not pure test CPU time. Other retains runner transitions and API
+rounding; cleanup includes post actions. No timing is inferred from local runs.
+
+| Run | Lane | Queue | Checkout | Setup | Preparation | Validation | Cleanup | Other | Total |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| 34212294501 | Full extras | 4s | 6s | 2m08s | 4m07s | 15m12s | 2s | 3s | 21m38s |
+| 34212294501 | Packages | 4s | 6s | 1m55s | 4m00s | 9m48s | 1s | 2s | 15m52s |
+| 34212294501 | Application | 4s | 5s | 1m52s | 4m06s | 15m44s | 1s | 4s | 21m52s |
+| 34215268411 | Full extras | 3s | 6s | 2m02s | 4m00s | 14m46s | 2s | 3s | 20m59s |
+| 34215268411 | Packages | 4s | 7s | 2m00s | 4m02s | 10m08s | 2s | 3s | 16m22s |
+| 34215268411 | Application | 4s | 7s | 1m45s | 3m26s | 14m26s | 1s | 4s | 19m49s |
+| 34215448203 | Packages | 4s | 7s | 1m55s | 3m24s | 16m17s | 21s | 3s | 22m07s |
+| 34215448203 | Full extras | 3s | 6s | 2m17s | 4m07s | 15m04s | 50s | 3s | 22m27s |
+| 34215448203 | Application | 4s | 7s | 2m03s | 4m10s | 15m44s | 23s | 4s | 22m31s |
+
+## Commands and resource constraints
+
+Timestamped Task command markers in those nine hosted job logs give these
+intervals. They include build/startup costs and dependencies up to the next
+command marker; ranges are sample minima/maxima, not percentiles.
+
+| Validation group | Hosted interval | Constraint |
+|---|---:|---|
+| Four application shards | 2m18s–2m40s | Three concurrent processes on one runner |
+| App MinIO integration | 8–10s | Container-backed test |
+| PostgreSQL conformance | 11m58s–12m58s | Source-derived package inventory; two concurrent packages |
+| Full: UI QA | 4m51s–5m00s | Shared managed server, PostgreSQL and temporary paths |
+| Full: critical race qualification | 3m47s–3m53s | Serial package qualification |
+| Full: lifecycle/GC conformance | 2m23s–2m26s | Container tests and generated inputs; deployment subtree about 1m49s |
+| Full: Go vet | 54–56s | Build/analysis workload |
+| Full: package race | 53–54s | Build/test workload |
+| Full: deployment contracts | 50–52s | Container lifecycle plus Terraform checks |
+| Full: PostgreSQL multinode | 28–29s | Independent qualification, but shares runner resources |
+| Full: workload qualification | 26–27s | Race, fuzz and benchmarks |
+| Full: MinIO conformance | 7–8s | Shared evidence paths and generated inputs |
+
+For the final PR #537 and dependent PR #534 samples, package validation breaks
+into SQL verification/conformance **2m14s / 1m46s**, quality checks **45s / 35s**,
+and the package sweep **6m33s / 13m29s**. The sweep's large variation is another
+reason not to forecast a fixed partition from these two runners. Both retain the
+source-derived exclusions that hand external-service packages to their dedicated
+qualification lane.
+
+Splitting only full extras can improve total elapsed by at most the 69-second
+gap after application in one sample; application already blocks the other
+two samples. Splitting only application has only 5–14 seconds of excess
+in its two blocking samples. Splitting both exposes package validation as the next
+barrier. These are fixed-timestamp bounds, not forecasts after rescheduling.
+
+Preparation repeats generation and embedded asset builds in each isolated job.
+For application job [102025424924](https://github.com/flidai/leapview/actions/runs/34215268411/job/102025424924),
+SQL generation spans 10:26:56.072–10:28:12.464 UTC (76s), and schema export spans
+10:28:23.418–10:29:22.894 (59s). SQLC deliberately uses Go 1.26.7 while the main
+module uses 1.26.8; this profile does not change that generator policy.
+
+The same job restores the primary Go cache key
+`setup-go-Linux-x64-ubuntu24-go-1.26.8-7544f7e3474cc558709d4c3f31330f4f76d62ead5362153703da92c1750fb922`,
+then downloads tools, SQLC and application dependencies. GitHub's cache API reports
+main-branch cache **7364966855**, created 2026-09-05T16:44:48Z, size **24,846,316
+bytes**. The post action explicitly declines to save because the primary key hit.
+This establishes a small shared cache that is not enriched by these runs;
+it does not establish which workflow originally wrote it or the achievable warm
+speedup. Cache ownership, scope and publication need a separate design.
+
+## Ranked choices and selected change
+
+Ranked by value for this bounded follow-up, considering global latency, risk and
+complexity together:
+
+| Rank | Candidate | Expected global reduction | Risk | Complexity |
+|---:|---|---|---|---|
+| 1 | Remove unused Buf CLI installation | Avoid a measured 36–49s install interval on each sampled long lane; net savings need hosted confirmation | Low: no command consumes it | Very low |
+| 2 | Repair shared Go cache ownership/publication | Potential minutes across all long lanes; not measured yet | Medium: scope, trust, storage and cold-cache behavior need validation | Medium |
+| 3 | Split PostgreSQL qualification and independent full groups together, then address package validation | Largest structural opportunity; single-lane changes are capped by nearby blockers | Medium/high: exact coverage, strict aggregates and isolated resources | High; several changes |
+| 4 | Parallelize only full extras groups | 0–69s fixed-timestamp bound in this cohort | Medium: CPU/memory and generated-path contention | Medium |
+| 5 | Tune queue, gate, or native-proof polling | Negligible here; proofs already ready | Adds complexity without measured benefit | Low/medium |
+
+Only rank 1 is implemented. A repository-wide search found no Buf executable
+consumer or Buf configuration; the remaining references were its installation,
+two architecture assertions and the toolchain documentation. The Task runner and
+all test/generation tools remain installed. No workflow job, dependency, task
+command, required check, planner output or gate condition changes.
+
+The removed interval starts at the first Buf download log line and ends when the
+serial tool installation action completes. Nine measurements are **36.0, 38.9,
+43.0, 43.9, 43.9, 44.6, 45.7, 46.3 and 48.9 seconds**. Shared compiler warming from
+the old installation may offset some savings in later commands; this interval is
+not a guaranteed whole-workflow reduction. This change alone cannot reach 12
+minutes.
+
+## Validation and hosted follow-up
+
+Validation at the implementation checkpoint:
+
+- Full `internal/platform/architecture` and `internal/platform/ci` tests passed;
+  these include the hosted workflow contract, planner and gate tests.
+- The two changed hosted-setup architecture tests also passed independently.
+- Actionlint passed for all seven workflows consuming the shared setup action,
+  with the pre-existing unsupported `stacked` activity ignored. A repository-wide
+  attempt additionally encountered the installed linter's unsupported
+  `macos-15-intel` label and `artifact-metadata` permission in unchanged native
+  workflows; those files are outside this diff.
+- `bun run docs:validate-diagrams`, `docsitegen --check` and `git diff --check`
+  passed.
+- `task ci` passed generation, SQLC determinism, vet/diff and SQL audit, then
+  stopped at required PostgreSQL conformance because this workspace cannot access
+  `/var/run/docker.sock`. No conformance requirement was disabled. The complete
+  local CI contract has therefore **not passed**; hosted validation is required.
+
+No after-change merge observation exists yet for this follow-up.
+
+| Population | Hosted elapsed |
+|---|---:|
+| Pre-#520 historical baseline | 44m40s p95 |
+| Deployed #520, before this follow-up | 21m09s, 22m02s, 22m41s observations |
+| After unused-tool removal | Pending eligible hosted merge candidate; no measured p95 |
+
+A valid after sample must use the new action at the tested merge SHA and pass the
+unchanged CI gate, security gate and exact-SHA native proof. Compare both the
+installation step and total elapsed; do not attribute differences in source,
+runner scheduling or cache state to this change. Follow with multiple candidates
+before drawing a p95 conclusion. The next substantial engineering investigation
+is shared preparation/cache ownership, followed by coordinated lane decomposition
+if profiling still shows PostgreSQL and full extras dominating.

--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -2790,11 +2790,8 @@ test('rejected filter validation reconciles optimistic state and announces the e
   try {
     await page.goto(baseURL)
     await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
-    await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
-      // The signal can arrive before Lit finishes the initial render and reconciliation.
-      await element.updateComplete
-    })
     const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      await element.updateComplete
       let command: any
       element.addEventListener('lv-filter-command', (event: CustomEvent) => {
         command = event.detail

--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -2790,6 +2790,10 @@ test('rejected filter validation reconciles optimistic state and announces the e
   try {
     await page.goto(baseURL)
     await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
+    await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
+      // The signal can arrive before Lit finishes the initial render and reconciliation.
+      await element.updateComplete
+    })
     const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
       let command: any
       element.addEventListener('lv-filter-command', (event: CustomEvent) => {

--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -2789,9 +2789,12 @@ test('rejected filter validation reconciles optimistic state and announces the e
   const page = await browser.newPage({ viewport: { width: 1280, height: 820 } })
   try {
     await page.goto(baseURL)
-    await page.waitForFunction(() => (document.querySelector('lv-dashboard-page') as any)?.page)
-    const result = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
-      await element.updateComplete
+    await page.waitForFunction(() => {
+      const element = document.querySelector('lv-dashboard-page') as any
+      return Boolean(element?.page && !element.isUpdatePending)
+    })
+    const moduleHandle = await page.evaluateHandle(() => import('/static/vendor/datastar-1.0.2.js?v=dev'))
+    const mutation = await page.locator('lv-dashboard-page').evaluate((element: any) => {
       let command: any
       element.addEventListener('lv-filter-command', (event: CustomEvent) => {
         command = event.detail
@@ -2801,28 +2804,25 @@ test('rejected filter validation reconciles optimistic state and announces the e
         operator: 'in',
         values: [{ kind: 'string', value: 'CA' }],
       })
-      element.requestUpdate()
-      await element.updateComplete
-      const optimistic = element.filterController.projected.appliedControls.fb_state.expression
-
-      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev')
-      mergePatch({
-        filterValidation: {
-          accepted: false,
-          message: 'range lower bound must not exceed upper bound',
-          currentRevision: 0,
-          clientMutationID: command.clientMutationID,
-        },
-      })
-      await element.updateComplete
-      return {
-        optimistic,
-        reconciled: element.filterController.projected.appliedControls.fb_state.expression,
-        pending: element.filterController.pending,
-        alert: element.shadowRoot.querySelector('[role="alert"]')?.textContent?.trim(),
-      }
+      return { command, optimistic: element.filterController.projected.appliedControls.fb_state.expression }
     })
-    expect(result).toEqual({
+    await moduleHandle.evaluate((module: any, validation: any) => module.mergePatch({ filterValidation: validation }), {
+      accepted: false,
+      message: 'range lower bound must not exceed upper bound',
+      currentRevision: 0,
+      clientMutationID: mutation.command.clientMutationID,
+    })
+    await page.waitForFunction((clientMutationID) => {
+      const element = document.querySelector('lv-dashboard-page') as any
+      const validation = element?.signal('filterValidation', null)
+      return Boolean(element && !element.filterController.pending && !element.isUpdatePending && validation?.clientMutationID === clientMutationID)
+    }, mutation.command.clientMutationID)
+    const result = await page.locator('lv-dashboard-page').evaluate((element: any) => ({
+      reconciled: element.filterController.projected.appliedControls.fb_state.expression,
+      pending: element.filterController.pending,
+      alert: element.shadowRoot.querySelector('[role="alert"]')?.textContent?.trim(),
+    }))
+    expect({ optimistic: mutation.optimistic, ...result }).toEqual({
       optimistic: {
         kind: 'set',
         operator: 'in',


### PR DESCRIPTION
## Problem

After #520, hosted merge candidates take 21m09s, 22m02s and 22m41s. Application and full validation finish close together, so splitting either lane alone offers little global improvement. Nine hosted lane logs show 36–49 seconds spent installing the Buf CLI, which no repository command consumes.

## Change

Remove only the unused Buf installation from shared CI setup, update its two obsolete architecture assertions and toolchain documentation. Include the reconciled #537 merge cohort and command-level profiling/ranking report. Validation commands, workflow dependencies, required check names, planner selection, security and native-proof requirements are unchanged.

## Verification

- Full architecture and CI planner/gate tests passed; focused setup-contract tests passed independently.
- Actionlint passed for all seven setup-action consumers with the existing unsupported `stacked` activity excluded. Repository-wide lint also encounters unsupported native-runner metadata in unchanged workflows.
- Documentation diagram and generated-site checks, and `git diff --check`, passed.
- `task ci` passed generation and SQL checks, then failed required PostgreSQL conformance because this workspace cannot access Docker. Hosted checks must complete validation.

## Measurement and limitations

The 36–49 seconds is the observed installation interval, not a measured whole-workflow saving. Removing it may shift compiler warming into later steps. An eligible hosted merge candidate is required for after timing; these three before samples do not establish a new p95. This small change alone will not reach 12 minutes. Shared preparation/cache ownership is the next profiling-backed investigation; no cache or lane optimizations are included here.

Related to #520.
