### PR TITLE
feat(project): add instance-local ResourceUID registry

### DIFF
--- a/docs/articles/architecture/contract-projections.md
+++ b/docs/articles/architecture/contract-projections.md
@@ -87,7 +87,10 @@ transactions, or deployment-history integration.
 
 FAI-662's sealed-input and coverage safeguards belong at this boundary. Its
 database publication-integrity requirements remain with publication storage.
-FAI-670 retains Project-qualified ResourceUID authority. FAI-645 remains a
+FAI-670 retains [Project-qualified ResourceUID authority](/docs/architecture/resource-uid-registry).
+Its inventory distinguishes canonical contract evidence from unversioned and
+non-contract-bearing resources; allocation does not invent publication authority.
+FAI-645 remains a
 downstream consumer; its cache, lifecycle, and audit implementation is not
 part of this reconciliation.
 

--- a/docs/articles/architecture/resource-uid-registry.md
+++ b/docs/articles/architecture/resource-uid-registry.md
@@ -1,0 +1,66 @@
+# Instance-local resource identity
+
+FAI-670 adds registry identity beneath the existing issuer-owned Project claim.
+An authored `metadata.id` is portable. A ResourceUID is an opaque, random UUID
+allocated by one instance for that authored ID within its claimed Project.
+Names, paths, environments, dbt identifiers, and artifact or serving hashes are
+not registry keys. The authored kind is immutable after allocation.
+
+## Admission and activation
+
+The verified source bundle supplies a complete resource inventory, including
+the empty inventory. Admission retains this inventory with its exact bundle,
+graph, Project, target, environment, and generation evidence. It allocates no
+ResourceUIDs and does not modify portable artifacts.
+
+The existing protected delivery activation transaction consumes the retained
+inventory. Registry allocation, reuse, removal, and generation bindings must
+commit atomically with activation. A failed activation must leave no allocated
+identities. Runtime callers cannot directly write registry rows or invoke a
+standalone allocator. Scoped reads require both instance and Project identity;
+possession of a ResourceUID is not authorization.
+
+The application compiler/admission capability remains trusted to produce
+canonical contract bytes. Its Go API accepts only a sealed inventory and uses
+FAI-620's full decoders and projectors; PostgreSQL independently checks scope,
+graph completeness, tuple identity, and byte digests. The database does not
+reimplement the compiler or SQL-AST validator. Runtime database credentials
+are not an untrusted client API and must never be exposed to callers.
+
+## Contract evidence is not publication authority
+
+The registry distinguishes three evidence states:
+
+- `canonical`: an authored versioned contract is projected through FAI-620;
+  exact `leapview.contract/v1` bytes and their digest are retained.
+- `unversioned`: a contract-bearing resource has no authoritative version;
+  the registry does not invent a version, compatibility promise, or digest.
+- `not_contract_bearing`: Connection, Pipeline, and Dashboard have no
+  `leapview.contract/v1` projection.
+
+Current Source and Model authoring can supply contract metadata. The current
+SemanticModel authoring schema has no contract-version field. ResourceUID
+allocation does not add one or manufacture a constructor fallback. Missing or
+invalid authored evidence for contract-bearing resources fails inventory
+construction rather than being silently treated as unversioned.
+
+FAI-622 remains responsible for version/publication authority, compatibility
+classification, and publication approval. Registry evidence does not authorize
+publication or semantic access, and a serving asset hash is never a contract
+digest.
+
+## Lifecycle boundary
+
+Removal retains a tombstone; normal activation cannot silently reuse that
+authored identity. Explicit, privileged restore evidence binds one resource to
+one exact generation and records its actor and request identity. A previously
+bound generation can reuse its historical ResourceUIDs during rollback, within
+the same instance and Project. Registry restore authority is not authority to
+reauthorize control-plane grants or publications; their consumer integration
+must be qualified separately before claiming complete RID-06 conformance.
+
+The additive migration does not fabricate registry evidence for historical
+generations. A generation without retained inventory is not eligible for a
+registry-backed activation merely because legacy serving assets exist.
+Governed consumer integration and semantic resolver closure remain separately
+owned by FAI-671 and FAI-675; this foundation does not claim their completion.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -240,6 +240,7 @@ Focused slices are available at `/docs/agent-tools/tools/{name}.json|md`, `/docs
 - [Architecture overview](/docs/architecture): See how the monolith, contracts, storage, and browser components fit together.
 - [Runtime architecture](/docs/architecture/runtime): Follow routing, query execution, and streamed UI updates.
 - [Canonical contract projections](/docs/architecture/contract-projections): Follow sealed projection inputs, deterministic contract identity, and fail-closed coverage checks.
+- [Instance-local resource identity](/docs/architecture/resource-uid-registry): Follow activation-owned resource identity, canonical evidence, and scoped lifecycle guarantees.
 - [Semantic attribute registry and control plane](/docs/architecture/semantic-attribute-registry): Understand typed semantic attribute identity, ownership, lifecycle, and compatibility boundaries.
 - [Semantic access planner boundary](/docs/architecture/semantic-access-planner): Place typed authorization barriers before protected scans participate in relational operations.
 - [Semantic access discovery and consumers](/docs/architecture/semantic-access-consumers): Bind protected semantic discovery and execution to authoritative request evidence.

--- a/docs/navigation.yaml
+++ b/docs/navigation.yaml
@@ -555,6 +555,11 @@ sections:
             type: explanation
             summary: Follow sealed projection inputs, deterministic contract identity, and fail-closed coverage checks.
             source: articles/architecture/contract-projections.md
+          - slug: architecture/resource-uid-registry
+            title: Instance-local resource identity
+            type: explanation
+            summary: Follow activation-owned resource identity, canonical evidence, and scoped lifecycle guarantees.
+            source: articles/architecture/resource-uid-registry.md
           - slug: architecture/semantic-attribute-registry
             title: Semantic attribute registry and control plane
             type: explanation

--- a/internal/app/deploymentpostgres/generation_admission.go
+++ b/internal/app/deploymentpostgres/generation_admission.go
@@ -21,8 +21,10 @@ import (
 	deploymentnative "github.com/flidai/leapview/internal/deployment/postgres"
 	lineagepostgres "github.com/flidai/leapview/internal/lineage/postgres"
 	"github.com/flidai/leapview/internal/manageddata"
+	project "github.com/flidai/leapview/internal/project"
 	projectbundle "github.com/flidai/leapview/internal/project/bundle"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectpostgres "github.com/flidai/leapview/internal/project/postgres"
 	"github.com/flidai/leapview/internal/release"
 	releasepostgres "github.com/flidai/leapview/internal/release/postgres"
 	servingstate "github.com/flidai/leapview/internal/servingstate"
@@ -68,6 +70,9 @@ type GenerationAdmissionInput struct {
 	// transaction before this evidence is retained.
 	Provenance release.ProvenanceInput
 	Graph      projectgraph.ProjectGraph
+	// ResourceInventory is derived from the same verified portable artifact.
+	// It is retained at admission but cannot allocate a ResourceUID.
+	ResourceInventory project.ResourceUIDInventory
 }
 
 // CommitEvidence is the immutable attempt completion proof written by the
@@ -408,6 +413,15 @@ func (a *generationAdmitter) CompleteBuildAndAdmitTx(ctx context.Context, tx dep
 	if err := verifyBundle(bundle, normalized); err != nil {
 		return GenerationAdmissionResult{}, err
 	}
+	// Retain the complete sealed inventory in the same admission transaction.
+	// This does not allocate UIDs: the database activation transition consumes
+	// this immutable evidence only when the generation becomes authoritative.
+	if err := projectpostgres.New(tx).AdmitResourceUIDInventoryTx(ctx, tx,
+		normalized.Generation.TargetID, normalized.Bundle.ProjectID.String(),
+		string(normalized.Bundle.Environment), normalized.Generation.GenerationID,
+		normalized.ResourceInventory); err != nil {
+		return GenerationAdmissionResult{}, fmt.Errorf("admit resource inventory: %w", err)
+	}
 	identity, err := projectgraph.NewServingIdentity(normalized.Bundle.ProjectID, string(normalized.Bundle.Environment), normalized.Generation.GenerationID)
 	if err != nil {
 		return GenerationAdmissionResult{}, err
@@ -689,6 +703,12 @@ func normalizeInput(input GenerationAdmissionInput) (GenerationAdmissionInput, e
 	}
 	if ctx.Generation.CompiledGraphDigest != ctx.Graph.Digest() {
 		return GenerationAdmissionInput{}, conflict("generation and graph digests differ")
+	}
+	if _, err := ctx.ResourceInventory.JSON(); err != nil {
+		return GenerationAdmissionInput{}, fmt.Errorf("%w: resource inventory: %v", deploymentnative.ErrInvalid, err)
+	}
+	if ctx.ResourceInventory.GraphDigest() != ctx.Graph.Digest() || ctx.ResourceInventory.BundleDigest() != ctx.Bundle.ProjectDigest {
+		return GenerationAdmissionInput{}, conflict("resource inventory and generation artifact differ")
 	}
 	if ctx.Bundle.Artifact.Digest != ctx.Generation.ServingArtifactDigest || ctx.Bundle.Artifact.Digest != ctx.Seal.ServingArtifactDigest {
 		return GenerationAdmissionInput{}, conflict("artifact and generation digests differ")

--- a/internal/app/deploymentpostgres/generation_admission_test.go
+++ b/internal/app/deploymentpostgres/generation_admission_test.go
@@ -10,18 +10,26 @@ import (
 
 	catalogartifact "github.com/flidai/leapview/internal/analytics/catalogartifact"
 	ducklakepostgres "github.com/flidai/leapview/internal/analytics/ducklake/postgres"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	deploymentdomain "github.com/flidai/leapview/internal/deployment"
 	deploymentnative "github.com/flidai/leapview/internal/deployment/postgres"
 	lineagepostgres "github.com/flidai/leapview/internal/lineage/postgres"
+	platformbootstrappostgres "github.com/flidai/leapview/internal/platform/bootstrap/postgres"
 	"github.com/flidai/leapview/internal/platform/postgres/postgrestest"
+	project "github.com/flidai/leapview/internal/project"
+	projectartifact "github.com/flidai/leapview/internal/project/artifact"
 	projectbundle "github.com/flidai/leapview/internal/project/bundle"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectpostgres "github.com/flidai/leapview/internal/project/postgres"
 	"github.com/flidai/leapview/internal/release"
 	releasepostgres "github.com/flidai/leapview/internal/release/postgres"
 	servingstate "github.com/flidai/leapview/internal/servingstate"
 	servingnative "github.com/flidai/leapview/internal/servingstate/postgres"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const admissionInstanceID = "lvinst_0123456789abcdefghijklmnopqrstuv"
 
 func admissionDigest(ch byte) string { return "sha256:" + strings.Repeat(string(ch), 64) }
 
@@ -68,12 +76,24 @@ func validGenerationAdmissionInput(t *testing.T) GenerationAdmissionInput {
 	leaseID := "0198f2c0-7c7a-7f00-8a11-000000000107"
 	pool := "pool-admission"
 	artifactDigest := admissionDigest('e')
-	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{{ID: "dashboard", Kind: projectgraph.KindDashboard, Name: "dashboard"}}, nil)
+	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{{ID: "connection-admission", Kind: projectgraph.KindConnection, Name: "admission"}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	portableArtifact, err := projectartifact.NewSourceBundle(graph, projectmanifest.ResourceManifest{
+		Connections: map[string]semanticmodel.Connection{
+			"connection-admission": {Kind: "postgres"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("source bundle: %v", err)
+	}
+	resourceInventory, err := project.NewResourceUIDInventory(portableArtifact)
+	if err != nil {
+		t.Fatalf("resource inventory: %v", err)
+	}
 	planRecord := nativePlanFixture(t, deploymentnative.PlanInput{
-		PlanID: planID, TargetID: "target-admission", PlanRevision: 1,
+		PlanID: planID, TargetID: admissionInstanceID, PlanRevision: 1,
 		CompiledGraphDigest: graph.Digest(), CompiledConfigDigest: admissionDigest('c'),
 		SecurityDomainFingerprint: admissionDigest('d'), ArtifactDigest: artifactDigest,
 		QualificationDigest: admissionDigest('3'),
@@ -103,20 +123,39 @@ func validGenerationAdmissionInput(t *testing.T) GenerationAdmissionInput {
 		Seal:                SnapshotSealEvidence{SealID: sealID, AttemptID: attemptID, CandidateID: candidateID, PhysicalPoolID: pool, TenantDomain: "tenant", Region: "us-east", EncryptionDomain: "enc", ObjectNamespace: "objects/admission", CatalogDatabase: "ducklake", CatalogID: "catalog-admission", CatalogUUID: "0198f2c0-7c7a-7f00-8a11-000000000108", CatalogVersion: 1, DuckLakeSnapshotID: 42, RelationNamespace: relationNamespace, RelationManifestDigest: admissionDigest('1'), ClosureDigest: admissionDigest('8'), ObjectRoot: "objects/admission/42", ObjectRootDigest: admissionDigest('6'), ArtifactRoot: "artifacts/admission", ArtifactRootDigest: admissionDigest('7'), CompiledGraphDigest: graph.Digest(), CompiledConfigDigest: admissionDigest('c'), SecurityDomainFingerprint: admissionDigest('d'), RequestDigest: admissionDigest('f'), PlanDigest: planDigest, CompatibilityDigest: admissionDigest('2'), ServingArtifactID: "artifact-" + strings.TrimPrefix(artifactDigest, "sha256:"), ServingArtifactDigest: artifactDigest, DuckDBVersion: "1", RuntimeVersion: "runtime", DuckLakeExtensionVersion: "1", DuckLakeSpecVersion: "1", CatalogSchemaVersion: "1", QualificationEvidence: json.RawMessage(`{"checks":["schema"]}`)},
 		QualificationDigest: admissionDigest('3'),
 		CandidateExpiresAt:  time.Date(2099, 1, 1, 13, 0, 0, 0, time.UTC),
-		Fence:               LeaseFenceEvidence{LeaseID: leaseID, TargetID: "target-admission", OwnerID: "builder-admission", FencingEpoch: 1},
-		Generation:          GenerationEvidence{GenerationID: genID, TargetID: "target-admission", CandidateID: candidateID, SnapshotSealID: sealID, PlanID: planID, PlanDigest: planDigest, ArtifactRoot: "artifacts/admission", ArtifactRootDigest: admissionDigest('7'), ServingArtifactDigest: artifactDigest, CompiledGraphDigest: graph.Digest(), CompiledConfigDigest: admissionDigest('c'), SecurityDomainFingerprint: admissionDigest('d')},
-		Bundle:              BundleEvidenceInput{GenerationID: genID, ProjectID: "project_admission", Environment: "prod", Artifact: servingstate.Artifact{ID: "artifact-" + strings.TrimPrefix(artifactDigest, "sha256:"), ServingStateID: servingstate.ID(genID), Digest: artifactDigest, Format: projectbundle.BundleFormat, ManifestJSON: manifest, SizeBytes: 1}, ArtifactLocator: "serving-artifacts/" + strings.TrimPrefix(artifactDigest, "sha256:") + ".tar.gz", StorageSecurityDomain: "runtime", ArtifactContentType: projectbundle.BundleContentType, ArtifactMetadataDigest: admissionDigest('9'), ProjectDigest: admissionDigest('b'), AccessPolicyJSON: `{}`, DashboardPublicationsJSON: `{}`, DashboardAppearancesJSON: `{}`, CreatedBy: "builder-admission"},
+		Fence:               LeaseFenceEvidence{LeaseID: leaseID, TargetID: admissionInstanceID, OwnerID: "builder-admission", FencingEpoch: 1},
+		Generation:          GenerationEvidence{GenerationID: genID, TargetID: admissionInstanceID, CandidateID: candidateID, SnapshotSealID: sealID, PlanID: planID, PlanDigest: planDigest, ArtifactRoot: "artifacts/admission", ArtifactRootDigest: admissionDigest('7'), ServingArtifactDigest: artifactDigest, CompiledGraphDigest: graph.Digest(), CompiledConfigDigest: admissionDigest('c'), SecurityDomainFingerprint: admissionDigest('d')},
+		Bundle:              BundleEvidenceInput{GenerationID: genID, ProjectID: "project_admission", Environment: "prod", Artifact: servingstate.Artifact{ID: "artifact-" + strings.TrimPrefix(artifactDigest, "sha256:"), ServingStateID: servingstate.ID(genID), Digest: artifactDigest, Format: projectbundle.BundleFormat, ManifestJSON: manifest, SizeBytes: 1}, ArtifactLocator: "serving-artifacts/" + strings.TrimPrefix(artifactDigest, "sha256:") + ".tar.gz", StorageSecurityDomain: "runtime", ArtifactContentType: projectbundle.BundleContentType, ArtifactMetadataDigest: admissionDigest('9'), ProjectDigest: portableArtifact.Digest(), AccessPolicyJSON: `{}`, DashboardPublicationsJSON: `{}`, DashboardAppearancesJSON: `{}`, CreatedBy: "builder-admission"},
 		Graph:               graph,
+		ResourceInventory:   resourceInventory,
 		ManagedDataPins:     []release.ManagedDataPin{},
 		Provenance: release.ProvenanceInput{
-			Artifact:  release.ProjectArtifactProvenance{SourceDigest: admissionDigest('a'), ProjectDigest: admissionDigest('b'), ContentDigest: artifactDigest, CompilerVersion: "compiler", SchemaVersion: 1},
+			Artifact:  release.ProjectArtifactProvenance{SourceDigest: admissionDigest('a'), ProjectDigest: portableArtifact.Digest(), ContentDigest: artifactDigest, CompilerVersion: "compiler", SchemaVersion: 1},
 			Candidate: release.CandidateProvenance{ID: candidateID, OwnerID: "builder-admission"},
 			Plan: release.GenerationPlanProvenance{
-				Identity: projectgraph.ServingIdentity{ProjectID: "project_admission", Environment: "prod", GenerationID: genID}, TargetID: "target-admission", RuntimeVersion: "runtime", PolicyDigest: admissionDigest('d'), DataRevision: "sources:admission", DataMode: release.GenerationDataRefreshSources,
-				AuthoredConnections: []release.AuthoredConnectionEvidence{{ConnectionID: "connection_admission", ConnectorKind: "postgres"}}, GateEvidence: &gate,
+				Identity: projectgraph.ServingIdentity{ProjectID: "project_admission", Environment: "prod", GenerationID: genID}, TargetID: admissionInstanceID, RuntimeVersion: "runtime", PolicyDigest: admissionDigest('d'), DataRevision: "sources:admission", DataMode: release.GenerationDataRefreshSources,
+				AuthoredConnections: []release.AuthoredConnectionEvidence{{ConnectionID: "connection-admission", ConnectorKind: "postgres"}}, GateEvidence: &gate,
 			},
 		},
 	}
+}
+
+func admissionSourceBundle(t *testing.T, graphID projectgraph.ResourceID, title string) projectartifact.SourceBundle {
+	t.Helper()
+	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{{ID: graphID, Kind: projectgraph.KindConnection, Name: "admission"}}, nil)
+	if err != nil {
+		t.Fatalf("source graph: %v", err)
+	}
+	bundle, err := projectartifact.NewSourceBundle(graph, projectmanifest.ResourceManifest{
+		Title: title,
+		Connections: map[string]semanticmodel.Connection{
+			graphID.String(): {Kind: "postgres"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("source bundle: %v", err)
+	}
+	return bundle
 }
 
 func TestNormalizeGenerationAdmissionAcceptsExactEvidence(t *testing.T) {
@@ -127,6 +166,44 @@ func TestNormalizeGenerationAdmissionAcceptsExactEvidence(t *testing.T) {
 	}
 	if string(got.Commit.CommitMarker) != string(input.Commit.CommitMarker) {
 		t.Fatal("normalization changed canonical commit marker")
+	}
+}
+
+func TestNormalizeGenerationAdmissionRejectsResourceInventoryAuthorityDrift(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*GenerationAdmissionInput)
+	}{
+		{name: "missing inventory", mutate: func(input *GenerationAdmissionInput) {
+			input.ResourceInventory = project.ResourceUIDInventory{}
+		}},
+		{name: "different graph", mutate: func(input *GenerationAdmissionInput) {
+			bundle := admissionSourceBundle(t, "connection-other", "")
+			inventory, err := project.NewResourceUIDInventory(bundle)
+			if err != nil {
+				t.Fatalf("other graph inventory: %v", err)
+			}
+			input.ResourceInventory = inventory
+		}},
+		{name: "different bundle digest", mutate: func(input *GenerationAdmissionInput) {
+			bundle := admissionSourceBundle(t, "connection-admission", "different")
+			inventory, err := project.NewResourceUIDInventory(bundle)
+			if err != nil {
+				t.Fatalf("other bundle inventory: %v", err)
+			}
+			input.ResourceInventory = inventory
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validGenerationAdmissionInput(t)
+			test.mutate(&input)
+			if _, err := normalizeInput(input); err == nil {
+				t.Fatal("normalize unexpectedly accepted resource inventory authority drift")
+			} else if !errors.Is(err, deploymentnative.ErrInvalid) && !errors.Is(err, deploymentnative.ErrConflict) {
+				t.Fatalf("normalize error = %v, want native invalid/conflict", err)
+			}
+		})
 	}
 }
 
@@ -258,11 +335,23 @@ func generationAdmissionDB(t *testing.T) *pgxpool.Pool {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := platformbootstrappostgres.ApplySchema(t.Context(), tx); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatal(err)
+	}
+	if err := projectpostgres.ApplySchema(t.Context(), tx); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatal(err)
+	}
 	if err := deploymentnative.ApplySchema(t.Context(), tx); err != nil {
 		_ = tx.Rollback(t.Context())
 		t.Fatal(err)
 	}
 	if err := servingnative.ApplySchema(t.Context(), tx); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(t.Context(), projectpostgres.ResourceUIDSchemaSQL()); err != nil {
 		_ = tx.Rollback(t.Context())
 		t.Fatal(err)
 	}
@@ -281,7 +370,28 @@ func generationAdmissionDB(t *testing.T) *pgxpool.Pool {
 	if err := tx.Commit(t.Context()); err != nil {
 		t.Fatal(err)
 	}
+	seedGenerationAdmissionBootstrap(t, p, admissionInstanceID, "project_admission", "prod")
 	return p
+}
+
+func seedGenerationAdmissionBootstrap(t *testing.T, db *pgxpool.Pool, instanceID, projectID, environment string) {
+	t.Helper()
+	bootstrap := platformbootstrappostgres.New(db)
+	if err := bootstrap.EnsureInstanceID(t.Context(), instanceID); err != nil {
+		t.Fatalf("ensure instance identity: %v", err)
+	}
+	if err := bootstrap.BindInstanceEnvironment(t.Context(), environment); err != nil {
+		t.Fatalf("bind instance environment: %v", err)
+	}
+	if _, err := projectpostgres.New(db).Ensure(t.Context(), projectpostgres.EnsureInput{ID: projectgraph.ResourceID(projectID), Title: projectID}); err != nil {
+		t.Fatalf("ensure project identity: %v", err)
+	}
+	if _, err := bootstrap.ClaimProject(t.Context(), platformbootstrappostgres.ProjectClaimInput{
+		ProjectID: projectID, Environment: environment, ClaimedBy: "bootstrap-admin",
+		ClaimedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("claim project: %v", err)
+	}
 }
 
 func seedGenerationAdmission(t *testing.T, repo *deploymentnative.Repository, input GenerationAdmissionInput) {
@@ -379,6 +489,17 @@ func TestGenerationAdmissionPostgresAtomicSuccessReplayAndRollback(t *testing.T)
 	if lineageDigest != expectedLineage.Digest || lineageProject != input.Bundle.ProjectID.String() {
 		t.Fatalf("committed lineage binding = digest %q project %q, want digest %q project %q", lineageDigest, lineageProject, expectedLineage.Digest, input.Bundle.ProjectID)
 	}
+	var inventoryInstance, inventoryProject, inventoryEnvironment, inventoryTarget, inventoryGraphDigest, inventoryBundleDigest, inventoryJSON string
+	if err := p.QueryRow(t.Context(), `SELECT instance_id,project_id,environment,target_id,graph_digest,bundle_digest,inventory_json::text FROM project.resource_uid_inventory WHERE generation_id=$1::uuid`, input.Generation.GenerationID).Scan(&inventoryInstance, &inventoryProject, &inventoryEnvironment, &inventoryTarget, &inventoryGraphDigest, &inventoryBundleDigest, &inventoryJSON); err != nil {
+		t.Fatalf("load committed resource UID inventory: %v", err)
+	}
+	expectedInventoryJSON, err := input.ResourceInventory.JSON()
+	if err != nil {
+		t.Fatalf("encode expected resource UID inventory: %v", err)
+	}
+	if inventoryInstance != input.Generation.TargetID || inventoryProject != input.Bundle.ProjectID.String() || inventoryEnvironment != string(input.Bundle.Environment) || inventoryTarget != input.Generation.TargetID || inventoryGraphDigest != input.Graph.Digest() || inventoryBundleDigest != input.Bundle.ProjectDigest || !sameJSON([]byte(inventoryJSON), expectedInventoryJSON) {
+		t.Fatalf("committed resource UID inventory = %q %q %q %q graph=%q bundle=%q json=%s, want exact admission scope and evidence", inventoryInstance, inventoryProject, inventoryEnvironment, inventoryTarget, inventoryGraphDigest, inventoryBundleDigest, inventoryJSON)
+	}
 	if _, err := lineage.LoadBound(t.Context(), input.Generation.TargetID, input.Generation.GenerationID); err != nil {
 		t.Fatalf("load committed lineage graph by canonical target/generation binding: %v", err)
 	}
@@ -445,12 +566,12 @@ func TestGenerationAdmissionPostgresAtomicSuccessReplayAndRollback(t *testing.T)
 	if attemptState != string(deploymentnative.AttemptRunning) {
 		t.Fatalf("rollback left attempt state %q", attemptState)
 	}
-	var bindings, seals, generations, bundles, lineageGraphs, lineageBindings int
-	if err := p.QueryRow(t.Context(), `SELECT (SELECT count(*) FROM delivery.delivery_build_artifact_binding WHERE attempt_id=$1::uuid), (SELECT count(*) FROM delivery.delivery_snapshot_seal WHERE seal_id=$2::uuid), (SELECT count(*) FROM delivery.delivery_generation WHERE generation_id=$3::uuid), (SELECT count(*) FROM serving_state.bundle WHERE generation_id=$3::uuid), (SELECT count(*) FROM lineage.graphs WHERE project_id=$4), (SELECT count(*) FROM lineage.bindings WHERE delivery_id=$5 AND generation_id=$3::text)`, rollbackInput.Commit.AttemptID, rollbackInput.Seal.SealID, rollbackInput.Generation.GenerationID, rollbackInput.Bundle.ProjectID.String(), rollbackInput.Generation.TargetID).Scan(&bindings, &seals, &generations, &bundles, &lineageGraphs, &lineageBindings); err != nil {
+	var bindings, seals, generations, bundles, inventoryRows, lineageGraphs, lineageBindings int
+	if err := p.QueryRow(t.Context(), `SELECT (SELECT count(*) FROM delivery.delivery_build_artifact_binding WHERE attempt_id=$1::uuid), (SELECT count(*) FROM delivery.delivery_snapshot_seal WHERE seal_id=$2::uuid), (SELECT count(*) FROM delivery.delivery_generation WHERE generation_id=$3::uuid), (SELECT count(*) FROM serving_state.bundle WHERE generation_id=$3::uuid), (SELECT count(*) FROM project.resource_uid_inventory WHERE generation_id=$3::uuid), (SELECT count(*) FROM lineage.graphs WHERE project_id=$4), (SELECT count(*) FROM lineage.bindings WHERE delivery_id=$5 AND generation_id=$3::text)`, rollbackInput.Commit.AttemptID, rollbackInput.Seal.SealID, rollbackInput.Generation.GenerationID, rollbackInput.Bundle.ProjectID.String(), rollbackInput.Generation.TargetID).Scan(&bindings, &seals, &generations, &bundles, &inventoryRows, &lineageGraphs, &lineageBindings); err != nil {
 		t.Fatal(err)
 	}
-	if bindings != 0 || seals != 0 || generations != 0 || bundles != 0 || lineageGraphs != lineageGraphCountBefore || lineageBindings != 0 {
-		t.Fatalf("rollback retained partial admission: bindings=%d seals=%d generations=%d bundles=%d lineage_graphs=%d lineage_bindings=%d", bindings, seals, generations, bundles, lineageGraphs, lineageBindings)
+	if bindings != 0 || seals != 0 || generations != 0 || bundles != 0 || inventoryRows != 0 || lineageGraphs != lineageGraphCountBefore || lineageBindings != 0 {
+		t.Fatalf("rollback retained partial admission: bindings=%d seals=%d generations=%d bundles=%d inventory=%d lineage_graphs=%d lineage_bindings=%d", bindings, seals, generations, bundles, inventoryRows, lineageGraphs, lineageBindings)
 	}
 	var retentionRoots int
 	if err := p.QueryRow(t.Context(), `SELECT count(*) FROM delivery.delivery_retention_root WHERE root_id=$1::uuid`, rollbackInput.Generation.CandidateID).Scan(&retentionRoots); err != nil {

--- a/internal/app/deploymentpostgres/native_build_recovery_finalization_test.go
+++ b/internal/app/deploymentpostgres/native_build_recovery_finalization_test.go
@@ -19,6 +19,7 @@ import (
 	deploymentmodule "github.com/flidai/leapview/internal/deployment/module"
 	deploymentnative "github.com/flidai/leapview/internal/deployment/postgres"
 	lineagepostgres "github.com/flidai/leapview/internal/lineage/postgres"
+	platformbootstrappostgres "github.com/flidai/leapview/internal/platform/bootstrap/postgres"
 	eventpostgres "github.com/flidai/leapview/internal/platform/events/postgres"
 	operationpostgres "github.com/flidai/leapview/internal/platform/operation/postgres"
 	"github.com/flidai/leapview/internal/platform/postgres/postgrestest"
@@ -26,6 +27,7 @@ import (
 	projectcompiler "github.com/flidai/leapview/internal/project/compiler"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectpostgres "github.com/flidai/leapview/internal/project/postgres"
 	servingnative "github.com/flidai/leapview/internal/servingstate/postgres"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -59,6 +61,14 @@ func recoveryFinalizeDB(t *testing.T) (*pgxpool.Pool, *deploymentnative.Reposito
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := platformbootstrappostgres.ApplySchema(t.Context(), tx); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatal(err)
+	}
+	if err := projectpostgres.ApplySchema(t.Context(), tx); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatal(err)
+	}
 	if err := accesspostgres.ApplySchema(t.Context(), tx); err != nil {
 		_ = tx.Rollback(t.Context())
 		t.Fatal(err)
@@ -76,6 +86,10 @@ func recoveryFinalizeDB(t *testing.T) (*pgxpool.Pool, *deploymentnative.Reposito
 		t.Fatal(err)
 	}
 	if err := servingnative.ApplySchema(t.Context(), tx); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(t.Context(), projectpostgres.ResourceUIDSchemaSQL()); err != nil {
 		_ = tx.Rollback(t.Context())
 		t.Fatal(err)
 	}
@@ -105,9 +119,10 @@ func recoveryFinalizeFixtureForTest(t *testing.T) recoveryFinalizeFixture {
 	if err != nil {
 		t.Fatal(err)
 	}
+	seedGenerationAdmissionBootstrap(t, db, base.Plan.TargetID, base.Plan.ProjectID.String(), string(base.Plan.Environment))
 	portableArtifact, err := projectartifact.NewSourceBundle(graph, projectmanifest.ResourceManifest{
 		Connections: map[string]semanticmodel.Connection{
-			"connection:recovery": {Kind: "managed"},
+			"connection:recovery": {Kind: "postgres"},
 		},
 	})
 	if err != nil {

--- a/internal/app/deploymentpostgres/native_seal_assembler.go
+++ b/internal/app/deploymentpostgres/native_seal_assembler.go
@@ -220,6 +220,10 @@ func assembleNativeSealEvidenceWithPolicy(input NativeSealEvidenceAssemblerInput
 	artifactRootDigest := artifact.ArtifactDigest
 	projectID := artifact.Identity.ProjectID
 	environment := servingstate.Environment(artifact.Identity.Environment)
+	inventory, err := project.NewResourceUIDInventory(input.Artifacts.Compiler.Artifact)
+	if err != nil {
+		return GenerationAdmissionInput{}, fmt.Errorf("%w: resource inventory: %v", deploymentnative.ErrInvalid, err)
+	}
 
 	assembled := GenerationAdmissionInput{
 		Commit: CommitEvidence{
@@ -265,8 +269,9 @@ func assembleNativeSealEvidenceWithPolicy(input NativeSealEvidenceAssemblerInput
 			DashboardPublicationsJSON: artifact.DashboardPublicationsJSON, DashboardAppearancesJSON: artifact.DashboardAppearancesJSON,
 			CreatedBy: attempt.OwnerID,
 		},
-		ManagedDataPins: append([]release.ManagedDataPin{}, artifact.ManagedDataPins...),
-		Graph:           input.Artifacts.Compiler.Graph,
+		ManagedDataPins:   append([]release.ManagedDataPin{}, artifact.ManagedDataPins...),
+		Graph:             input.Artifacts.Compiler.Graph,
+		ResourceInventory: inventory,
 	}
 	// Carry a provenance template through the value-only boundary. Candidate
 	// revision is allocated by delivery during CompleteBuildAndAdmitTx and is

--- a/internal/app/deploymentpostgres/native_seal_assembler_test.go
+++ b/internal/app/deploymentpostgres/native_seal_assembler_test.go
@@ -10,11 +10,14 @@ import (
 	catalogartifact "github.com/flidai/leapview/internal/analytics/catalogartifact"
 	ducklake "github.com/flidai/leapview/internal/analytics/ducklake"
 	ducklakepostgres "github.com/flidai/leapview/internal/analytics/ducklake/postgres"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	physicalpool "github.com/flidai/leapview/internal/analytics/physicalpool"
 	"github.com/flidai/leapview/internal/deployment"
 	deploymentnative "github.com/flidai/leapview/internal/deployment/postgres"
+	projectartifact "github.com/flidai/leapview/internal/project/artifact"
 	projectbundle "github.com/flidai/leapview/internal/project/bundle"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
 	"github.com/flidai/leapview/internal/release"
 )
 
@@ -38,10 +41,18 @@ func validNativeSealAssemblerInput(t *testing.T) NativeSealEvidenceAssemblerInpu
 	requestDigest, sourceDigest := assemblerDigest('f'), assemblerDigest('0')
 	artifactDigest := assemblerDigest('e')
 	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{
-		{ID: "dashboard-assembler", Kind: projectgraph.KindDashboard, Name: "dashboard"},
+		{ID: "connection-assembler", Kind: projectgraph.KindConnection, Name: "connection"},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+	portableArtifact, err := projectartifact.NewSourceBundle(graph, projectmanifest.ResourceManifest{
+		Connections: map[string]semanticmodel.Connection{
+			"connection-assembler": {Kind: "postgres"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("source bundle: %v", err)
 	}
 	namespace, err := deployment.DeriveRelationNamespace(deployment.RelationNamespaceInput{CandidateID: candidateID, AttemptID: attemptID, FencingEpoch: 3})
 	if err != nil {
@@ -81,7 +92,7 @@ func validNativeSealAssemblerInput(t *testing.T) NativeSealEvidenceAssemblerInpu
 
 	now := time.Date(2099, 1, 2, 12, 0, 0, 0, time.UTC)
 	plan, err := deployment.NewDeliveryPlan(deployment.DeliveryPlan{
-		ID: planID, TargetID: "target-assembler", ProjectID: projectID, Environment: "prod", Operation: deployment.DeliveryOperationCodeChange, SourceDigest: sourceDigest,
+		ID: planID, TargetID: admissionInstanceID, ProjectID: projectID, Environment: "prod", Operation: deployment.DeliveryOperationCodeChange, SourceDigest: sourceDigest,
 		Execution:  deployment.DeliveryExecutionInputs{SourceArtifactDigest: sourceDigest, CompilerDigest: assemblerDigest('1'), ExecutableDigest: assemblerDigest('2'), DependencyDigest: assemblerDigest('3'), ConfigDigest: assemblerDigest('c'), BindingDigest: bindingFingerprint, RuntimeDigest: assemblerDigest('5'), CapabilityDigest: assemblerDigest('6')},
 		Provenance: deployment.DeliveryProvenance{Builder: "assembler-test"},
 		Governance: deployment.DeliveryGovernance{PolicyDigest: assemblerDigest('7'), AuthorizationDigest: assemblerDigest('d'), QualificationDigest: assemblerDigest('8'), ApprovalPolicyRevision: 1, ExpiresAt: now.Add(time.Hour), ObservedInputsAllowed: false},
@@ -113,7 +124,7 @@ func validNativeSealAssemblerInput(t *testing.T) NativeSealEvidenceAssemblerInpu
 	build := NativePhysicalBuildEvidence{AttemptID: attemptID, CatalogID: "catalog-assembler", ObjectRoot: poolRoot, SnapshotID: 42, Marker: marker, CanonicalMarkerJSON: json.RawMessage(markerJSON), Seal: ducklake.PostgresSnapshotSealEvidence{CatalogType: "postgres", MetadataSchema: ducklake.MetadataSchemaForPool(poolID), DataPath: poolRoot, ExtensionVersion: "1", CatalogVersion: "1.0", SnapshotID: 42, CommitMarker: markerJSON}, Closure: closure}
 	artifact := release.CandidateGenerationArtifact{Identity: projectgraph.ServingIdentity{ProjectID: projectID, Environment: "prod", GenerationID: generation}, ServingArtifactID: "artifact-" + strings.TrimPrefix(artifactDigest, "sha256:"), ArtifactDigest: artifactDigest, BundleManifestJSON: `{"version":1}`, NativeArtifact: release.NativeArtifactObjectEvidence{Locator: "serving-artifacts/" + strings.TrimPrefix(artifactDigest, "sha256:") + ".tar.gz", StorageSecurityDomain: "runtime", ContentType: projectbundle.BundleContentType, MetadataDigest: assemblerDigest('9'), SizeBytes: 1}, AccessPolicyJSON: `{}`, DashboardPublicationsJSON: `{}`, DashboardAppearancesJSON: `{}`, DataMode: release.GenerationDataRefreshSources, DataRevision: "sources:assembler"}
 	attempt := deploymentnative.DeliveryBuildAttempt{AttemptID: attemptID, PlanID: plan.ID, CandidateID: candidateID, OwnerID: "builder-assembler", PhysicalPoolID: poolID, CatalogID: "catalog-assembler", FencingEpoch: 3, RequestDigest: requestDigest, PlanDigest: plan.Digest, Namespace: namespace, State: deploymentnative.AttemptRunning, LeaseExpiresAt: now.Add(time.Hour)}
-	lease := deploymentnative.DeliveryLease{LeaseID: leaseID, TargetID: "target-assembler", OwnerID: attempt.OwnerID, FencingEpoch: 3, State: "active", ExpiresAt: now.Add(time.Hour), AcquiredAt: now}
+	lease := deploymentnative.DeliveryLease{LeaseID: leaseID, TargetID: admissionInstanceID, OwnerID: attempt.OwnerID, FencingEpoch: 3, State: "active", ExpiresAt: now.Add(time.Hour), AcquiredAt: now}
 	attemptAdmission := CandidateBuildAttemptAdmissionResult{Attempt: attempt, Lease: lease, Artifact: deploymentnative.BuildArtifactBinding{AttemptID: attemptID, ServingArtifactID: artifact.ServingArtifactID, ServingArtifactDigest: artifact.ArtifactDigest, ServingStateID: generation, BoundAt: now}}
 	compatDigest, err := tuple.Digest()
 	if err != nil {
@@ -131,7 +142,7 @@ func validNativeSealAssemblerInput(t *testing.T) NativeSealEvidenceAssemblerInpu
 	if err := json.Unmarshal(qualificationJSON, &qualification); err != nil {
 		t.Fatal(err)
 	}
-	return NativeSealEvidenceAssemblerInput{Build: build, AttemptAdmission: attemptAdmission, PoolContract: &ducklake.PoolContract{Pool: pool, Tuple: tuple, Admission: admission, Evidence: evidence}, CatalogIdentity: ducklakepostgres.CatalogIdentity{PhysicalPoolID: poolID, CatalogDatabase: "ducklake", CatalogID: build.CatalogID, CatalogUUID: catalogUUID, MetadataSchema: ducklake.MetadataSchemaForPool(poolID)}, Compatibility: ducklakepostgres.RuntimeCompatibility{RuntimeTuple: ducklakepostgres.RuntimeTuple{DuckDBRuntime: tuple.DuckDBRuntime, DuckLakeExtension: tuple.DuckLakeExtension, CatalogFormat: tuple.CatalogFormat}, CompatibilityDigest: compatDigest, CatalogSchemaVersion: "schema-v1"}, Plan: plan, Artifacts: release.CandidateArtifactSet{Artifact: release.ProjectArtifactProvenance{SourceDigest: sourceDigest, ProjectDigest: assemblerDigest('b'), ContentDigest: artifactDigest, CompilerVersion: "compiler", SchemaVersion: 1}, AuthorizationFingerprint: assemblerDigest('d'), Generation: artifact, Compiler: release.CandidateCompilerEvidence{Graph: graph}}, Bindings: bindings, RuntimeVersion: "runtime-assembler", Qualification: qualification, SealID: sealID, GenerationID: generation, TenantDomain: identity.Tenant, EncryptionDomain: "encryption-assembler", ObjectNamespace: "objects/assembler"}
+	return NativeSealEvidenceAssemblerInput{Build: build, AttemptAdmission: attemptAdmission, PoolContract: &ducklake.PoolContract{Pool: pool, Tuple: tuple, Admission: admission, Evidence: evidence}, CatalogIdentity: ducklakepostgres.CatalogIdentity{PhysicalPoolID: poolID, CatalogDatabase: "ducklake", CatalogID: build.CatalogID, CatalogUUID: catalogUUID, MetadataSchema: ducklake.MetadataSchemaForPool(poolID)}, Compatibility: ducklakepostgres.RuntimeCompatibility{RuntimeTuple: ducklakepostgres.RuntimeTuple{DuckDBRuntime: tuple.DuckDBRuntime, DuckLakeExtension: tuple.DuckLakeExtension, CatalogFormat: tuple.CatalogFormat}, CompatibilityDigest: compatDigest, CatalogSchemaVersion: "schema-v1"}, Plan: plan, Artifacts: release.CandidateArtifactSet{Artifact: release.ProjectArtifactProvenance{SourceDigest: sourceDigest, ProjectDigest: portableArtifact.Digest(), ContentDigest: artifactDigest, CompilerVersion: "compiler", SchemaVersion: 1}, AuthorizationFingerprint: assemblerDigest('d'), Generation: artifact, Compiler: release.CandidateCompilerEvidence{Graph: graph, Manifest: portableArtifact.Manifest(), Artifact: portableArtifact}}, Bindings: bindings, RuntimeVersion: "runtime-assembler", Qualification: qualification, SealID: sealID, GenerationID: generation, TenantDomain: identity.Tenant, EncryptionDomain: "encryption-assembler", ObjectNamespace: "objects/assembler"}
 }
 
 func nativeAssemblerClosure(t *testing.T, catalogID, root, namespace string, relations []ducklake.BaseTable) ducklake.NativeSnapshotClosureEvidence {

--- a/internal/app/postgresbaseline/admission.go
+++ b/internal/app/postgresbaseline/admission.go
@@ -33,6 +33,15 @@ func VerifyControlRuntimeAdmission(ctx context.Context, reader AdmissionReader) 
 		return err
 	}
 	return verifyPrivileges(ctx, reader, []privilegeProbe{
+		{kind: "schema", object: "project", privilege: "USAGE", want: true},
+		{kind: "table", object: "project.resource_uid_registry", privilege: "SELECT", want: true},
+		{kind: "table", object: "project.resource_uid_registry", privilege: "INSERT", want: false},
+		{kind: "table", object: "project.resource_uid_registry", privilege: "UPDATE", want: false},
+		{kind: "table", object: "project.resource_uid_registry", privilege: "DELETE", want: false},
+		{kind: "table", object: "project.resource_uid_inventory", privilege: "INSERT", want: false},
+		{kind: "function", object: "project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb)", privilege: "EXECUTE", want: true},
+		{kind: "function", object: "project.bind_resource_uid_generation(uuid)", privilege: "EXECUTE", want: false},
+		{kind: "function", object: "project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text)", privilege: "EXECUTE", want: false},
 		{kind: "schema", object: "recovery", privilege: "USAGE", want: true},
 		{kind: "schema", object: "public", privilege: "USAGE", want: true},
 		{kind: "table", object: "public.goose_db_version", privilege: "SELECT", want: true},

--- a/internal/app/postgresbaseline/admission_test.go
+++ b/internal/app/postgresbaseline/admission_test.go
@@ -45,6 +45,9 @@ func TestServingAdmissionsAcceptReviewedPrivileges(t *testing.T) {
 				return VerifyControlRuntimeAdmission(ctx, reader)
 			},
 			allowed: map[string]bool{
+				"schema:project:USAGE": true,
+				"table:project.resource_uid_registry:SELECT": true,
+				"function:project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb):EXECUTE": true,
 				"schema:recovery:USAGE":                true,
 				"schema:public:USAGE":                  true,
 				"table:public.goose_db_version:SELECT": true,
@@ -100,12 +103,18 @@ func TestServingAdmissionsRejectExtensionAndPrivilegeDrift(t *testing.T) {
 	valid := admissionReaderFake{
 		extension: platformpostgres.Extension{Name: "pgcrypto", Schema: "managed_data"},
 		allowed: map[string]bool{
+			"schema:project:USAGE": true,
+			"table:project.resource_uid_registry:SELECT": true,
+			"function:project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb):EXECUTE": true,
 			"schema:recovery:USAGE":                true,
 			"schema:public:USAGE":                  true,
 			"table:public.goose_db_version:SELECT": true,
 			"table:recovery.recovery_set:SELECT":   true,
 			"function:managed_data.publish_binding_set(text,text,text,text,bigint,jsonb):EXECUTE": true,
 		},
+	}
+	if err := VerifyControlRuntimeAdmission(t.Context(), valid); err != nil {
+		t.Fatalf("valid runtime fixture: %v", err)
 	}
 	for _, test := range []struct {
 		name   string
@@ -115,6 +124,11 @@ func TestServingAdmissionsRejectExtensionAndPrivilegeDrift(t *testing.T) {
 		{name: "missing positive privilege", mutate: func(f *admissionReaderFake) { delete(f.allowed, "schema:recovery:USAGE") }},
 		{name: "missing public schema usage", mutate: func(f *admissionReaderFake) { delete(f.allowed, "schema:public:USAGE") }},
 		{name: "forbidden privilege", mutate: func(f *admissionReaderFake) { f.allowed["table:public.goose_db_version:UPDATE"] = true }},
+		{name: "direct resource allocation", mutate: func(f *admissionReaderFake) { f.allowed["table:project.resource_uid_registry:INSERT"] = true }},
+		{name: "direct resource mutation", mutate: func(f *admissionReaderFake) { f.allowed["table:project.resource_uid_registry:UPDATE"] = true }},
+		{name: "unsealed inventory insertion", mutate: func(f *admissionReaderFake) { f.allowed["table:project.resource_uid_inventory:INSERT"] = true }},
+		{name: "standalone allocator", mutate: func(f *admissionReaderFake) { f.allowed["function:project.bind_resource_uid_generation(uuid):EXECUTE"] = true }},
+		{name: "runtime restore authority", mutate: func(f *admissionReaderFake) { f.allowed["function:project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text):EXECUTE"] = true }},
 		{name: "runtime recovery-root function grant", mutate: func(f *admissionReaderFake) {
 			f.allowed["function:delivery.create_recovery_retention_root(uuid,text,uuid,uuid,timestamptz,jsonb):EXECUTE"] = true
 		}},

--- a/internal/app/postgresbaseline/baseline.go
+++ b/internal/app/postgresbaseline/baseline.go
@@ -71,9 +71,15 @@ REVOKE ALL ON FUNCTION delivery.lock_retention_root(uuid) FROM PUBLIC;
 REVOKE ALL ON FUNCTION delivery.lock_live_snapshot_retention(uuid) FROM PUBLIC;
 REVOKE ALL ON FUNCTION delivery.commit_activation_transition(uuid, text, uuid, bigint, bigint) FROM PUBLIC;
 REVOKE ALL ON FUNCTION dashboard.lock_authoring_dashboard(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION project.bind_resource_uid_generation(uuid) FROM PUBLIC;
 DO $$
 BEGIN
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_runtime') THEN
+		GRANT USAGE ON SCHEMA project TO leapview_control_runtime;
+		GRANT SELECT ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO leapview_control_runtime;
+		REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization FROM leapview_control_runtime;
+		GRANT EXECUTE ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb) TO leapview_control_runtime;
+		REVOKE EXECUTE ON FUNCTION project.bind_resource_uid_generation(uuid), project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text) FROM leapview_control_runtime;
 		GRANT USAGE ON SCHEMA access, admin, dashboard, delivery, event, audit, release, ducklake, jobs, agent, lineage, physical_pool, serving_state, recovery TO leapview_control_runtime;
 		GRANT USAGE ON SCHEMA platform TO leapview_control_runtime;
 		GRANT SELECT, INSERT, UPDATE ON platform.setting TO leapview_control_runtime;
@@ -182,6 +188,10 @@ BEGIN
         REVOKE ALL ON FUNCTION ducklake.admit_snapshot_retention_from_seal(uuid) FROM leapview_control_maintenance;
     END IF;
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_readonly') THEN
+		GRANT USAGE ON SCHEMA project TO leapview_control_readonly;
+		GRANT SELECT ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO leapview_control_readonly;
+		REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization FROM leapview_control_readonly;
+		REVOKE EXECUTE ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb), project.bind_resource_uid_generation(uuid), project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text) FROM leapview_control_readonly;
 		GRANT USAGE ON SCHEMA access, admin, dashboard, delivery, event, audit, release, ducklake, jobs, agent, lineage, physical_pool, serving_state, recovery TO leapview_control_readonly;
 		GRANT USAGE ON SCHEMA platform TO leapview_control_readonly;
 		GRANT SELECT ON platform.setting, platform.instance_identity, platform.instance_environment, platform.instance_project_claim TO leapview_control_readonly;
@@ -206,6 +216,10 @@ BEGIN
         REVOKE ALL ON platform.api_cursor_signing_keys FROM leapview_control_readonly;
     END IF;
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_backup') THEN
+		GRANT USAGE ON SCHEMA project TO leapview_control_backup;
+		GRANT SELECT ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO leapview_control_backup;
+		REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization FROM leapview_control_backup;
+		REVOKE EXECUTE ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb), project.bind_resource_uid_generation(uuid), project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text) FROM leapview_control_backup;
 		GRANT USAGE ON SCHEMA project, access, admin, dashboard, delivery, event, audit, release, ducklake, jobs, agent, lineage, physical_pool, serving_state, recovery TO leapview_control_backup;
 		GRANT USAGE ON SCHEMA platform TO leapview_control_backup;
 		GRANT SELECT ON platform.setting, platform.instance_identity, platform.instance_environment, platform.instance_project_claim TO leapview_control_backup;

--- a/internal/deployment/postgres/repository_test.go
+++ b/internal/deployment/postgres/repository_test.go
@@ -64,13 +64,16 @@ type testActivationLineage struct {
 	expected ActivationLineageInput
 	err      error
 	calls    int
+	mu       sync.Mutex
 }
 
 func (v *testActivationLineage) VerifyActivationLineage(_ context.Context, tx Tx, input ActivationLineageInput) error {
 	if v == nil || tx == nil {
 		return ErrInvalid
 	}
+	v.mu.Lock()
 	v.calls++
+	v.mu.Unlock()
 	if input.TargetID == "" || input.ProjectID == "" || input.GenerationID == "" || input.CompiledGraphDigest == "" {
 		return fmt.Errorf("%w: incomplete activation lineage identity", ErrConflict)
 	}

--- a/internal/deployment/postgres/resource_uid_qualification_test.go
+++ b/internal/deployment/postgres/resource_uid_qualification_test.go
@@ -1,0 +1,785 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	accesspostgres "github.com/flidai/leapview/internal/access/postgres"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	dashboarddefinition "github.com/flidai/leapview/internal/dashboard/definition"
+	dashboarddocument "github.com/flidai/leapview/internal/dashboard/document"
+	deploymentdomain "github.com/flidai/leapview/internal/deployment"
+	platformbootstrappostgres "github.com/flidai/leapview/internal/platform/bootstrap/postgres"
+	project "github.com/flidai/leapview/internal/project"
+	projectartifact "github.com/flidai/leapview/internal/project/artifact"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	projectpostgres "github.com/flidai/leapview/internal/project/postgres"
+	refreshschedule "github.com/flidai/leapview/internal/refresh/schedule"
+	servingstate "github.com/flidai/leapview/internal/servingstate"
+	servingnative "github.com/flidai/leapview/internal/servingstate/postgres"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const resourceUIDQualificationInstance = "lvinst_0123456789abcdefghijklmnopqrstuv"
+
+// TestPostgresResourceUIDAdmissionAndActivationQualification exercises the
+// complete PostgreSQL lifecycle against the canonical instance target. The
+// inventory is staged with the generation and serving bundle, while the
+// registry remains empty until the database-owned activation transition.
+func TestPostgresResourceUIDAdmissionAndActivationQualification(t *testing.T) {
+	db := deliveryTestDB(t)
+	installResourceUIDQualificationDependencies(t, db)
+	seedResourceUIDQualificationBootstrap(t, db)
+
+	adminRepository := New(db)
+	first := prepareResourceUIDQualificationGeneration(t, adminRepository, resourceUIDQualificationGenerationSpec{
+		Number: 1, IncludeDashboard: true,
+	})
+	lineage := &testActivationLineage{expected: ActivationLineageInput{
+		TargetID: resourceUIDQualificationInstance, ProjectID: first.projectID,
+		GenerationID: first.generationID, CompiledGraphDigest: first.graph.Digest(),
+	}}
+	repository := NewWithOptions(db, Options{
+		ActivationAudit: testActivationAudit{audit: accesspostgres.New()},
+		Lineage:         lineage,
+	})
+
+	t.Run("admission stages inventory without allocating UIDs", func(t *testing.T) {
+		var inventoryRows, registryRows, bundles, generations int
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_inventory WHERE generation_id=$1::uuid`, first.generationID).Scan(&inventoryRows); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_registry WHERE instance_id=$1 AND project_id=$2`, resourceUIDQualificationInstance, first.projectID).Scan(&registryRows); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM serving_state.bundle WHERE generation_id=$1::uuid`, first.generationID).Scan(&bundles); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM delivery.delivery_generation WHERE generation_id=$1::uuid`, first.generationID).Scan(&generations); err != nil {
+			t.Fatal(err)
+		}
+		if inventoryRows != 1 || registryRows != 0 || bundles != 1 || generations != 1 {
+			t.Fatalf("admission evidence = inventory %d registry %d bundle %d generation %d; want 1, 0, 1, 1", inventoryRows, registryRows, bundles, generations)
+		}
+	})
+
+	t.Run("failed activation rolls back binder writes", func(t *testing.T) {
+		failing := NewWithOptions(db, Options{
+			ActivationAudit: failingResourceUIDActivationAudit{err: errors.New("qualification audit interruption")},
+			Lineage:         lineage,
+		})
+		if _, err := failing.Activate(t.Context(), first.activation); err == nil {
+			t.Fatal("failed activation unexpectedly succeeded")
+		}
+		var registryRows, generationBindings int
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_registry WHERE instance_id=$1 AND project_id=$2`, resourceUIDQualificationInstance, first.projectID).Scan(&registryRows); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_generation WHERE instance_id=$1 AND project_id=$2`, resourceUIDQualificationInstance, first.projectID).Scan(&generationBindings); err != nil {
+			t.Fatal(err)
+		}
+		if registryRows != 0 || generationBindings != 0 {
+			t.Fatalf("failed activation left registry evidence: registry=%d bindings=%d", registryRows, generationBindings)
+		}
+		var revision int64
+		if err := db.QueryRow(t.Context(), `SELECT target_revision FROM delivery.delivery_target WHERE target_id=$1`, resourceUIDQualificationInstance).Scan(&revision); err != nil {
+			t.Fatal(err)
+		}
+		if revision != 1 {
+			t.Fatalf("failed activation advanced target revision to %d", revision)
+		}
+	})
+
+	const initialActivationCallers = 2
+	initialStart := make(chan struct{})
+	initialResults := make(chan struct {
+		result ActivationResult
+		err    error
+	}, initialActivationCallers)
+	var initialWG sync.WaitGroup
+	for range initialActivationCallers {
+		initialWG.Add(1)
+		go func() {
+			defer initialWG.Done()
+			<-initialStart
+			result, activateErr := repository.Activate(t.Context(), first.activation)
+			initialResults <- struct {
+				result ActivationResult
+				err    error
+			}{result: result, err: activateErr}
+		}()
+	}
+	close(initialStart)
+	initialWG.Wait()
+	close(initialResults)
+	var freshActivations, replayActivations int
+	for call := range initialResults {
+		if call.err != nil {
+			t.Fatalf("concurrent first activation: %v", call.err)
+		}
+		if call.result.Publication.State != "committed" || call.result.Pointer.ActiveGenerationID != first.generationID || call.result.Pointer.TargetRevision != 2 {
+			t.Fatalf("concurrent first activation result = %#v", call.result)
+		}
+		if call.result.Replay {
+			replayActivations++
+		} else {
+			freshActivations++
+		}
+	}
+	if freshActivations != 1 || replayActivations != 1 {
+		t.Fatalf("concurrent first activation outcomes = fresh %d replay %d, want one each", freshActivations, replayActivations)
+	}
+
+	t.Run("successful activation allocates stable UIDs for every kind", func(t *testing.T) {
+		bindings, err := projectpostgres.New(db).ListGenerationResourceUIDs(t.Context(), resourceUIDQualificationInstance, first.projectID, first.generationID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bindings) != 6 {
+			t.Fatalf("first generation bindings = %d, want six authored kinds", len(bindings))
+		}
+		seenKinds := make(map[projectgraph.Kind]bool, len(bindings))
+		for _, binding := range bindings {
+			seenKinds[binding.Kind] = true
+			if binding.InstanceID != resourceUIDQualificationInstance || binding.TargetID != resourceUIDQualificationInstance || binding.ProjectID != first.projectID || binding.GenerationID != first.generationID {
+				t.Fatalf("binding scope = %#v", binding)
+			}
+		}
+		for _, kind := range []projectgraph.Kind{projectgraph.KindConnection, projectgraph.KindSource, projectgraph.KindModel, projectgraph.KindSemanticModel, projectgraph.KindPipeline, projectgraph.KindDashboard} {
+			if !seenKinds[kind] {
+				t.Fatalf("binding kinds missing %q: %#v", kind, seenKinds)
+			}
+		}
+	})
+
+	firstUIDs := resourceUIDsByAuthoredID(t, db, first.projectID)
+	t.Run("exact activation replay and concurrent replay preserve UIDs", func(t *testing.T) {
+		replay, err := repository.Activate(t.Context(), first.activation)
+		if err != nil {
+			t.Fatalf("activation replay: %v", err)
+		}
+		if !replay.Replay || replay.Pointer.TargetRevision != 2 {
+			t.Fatalf("activation replay = %#v", replay)
+		}
+		const callers = 2
+		errs := make(chan error, callers)
+		results := make(chan ActivationResult, callers)
+		var wg sync.WaitGroup
+		for range callers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				result, activateErr := repository.Activate(t.Context(), first.activation)
+				results <- result
+				errs <- activateErr
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		close(results)
+		for activateErr := range errs {
+			if activateErr != nil {
+				t.Fatalf("concurrent exact replay: %v", activateErr)
+			}
+		}
+		for result := range results {
+			if !result.Replay || result.Pointer.TargetRevision != 2 {
+				t.Fatalf("concurrent replay = %#v", result)
+			}
+		}
+		if got := resourceUIDsByAuthoredID(t, db, first.projectID); !sameResourceUIDMap(got, firstUIDs) {
+			t.Fatalf("UIDs changed on replay: got=%v want=%v", got, firstUIDs)
+		}
+	})
+
+	second := prepareResourceUIDQualificationGeneration(t, adminRepository, resourceUIDQualificationGenerationSpec{
+		Number: 2, IncludeDashboard: false, BaseGenerationID: first.generationID,
+	})
+	lineage.expected = ActivationLineageInput{
+		TargetID: resourceUIDQualificationInstance, ProjectID: second.projectID,
+		GenerationID: second.generationID, CompiledGraphDigest: second.graph.Digest(),
+	}
+	if _, err := repository.Activate(t.Context(), second.activation); err != nil {
+		t.Fatalf("activate generation removing dashboard: %v", err)
+	}
+
+	t.Run("tombstone records exact generation and preserves UID", func(t *testing.T) {
+		dashboardUID, ok := firstUIDs["dashboard:sales"]
+		if !ok {
+			t.Fatal("first dashboard UID missing")
+		}
+		dashboard, err := projectpostgres.New(db).ResolveResourceUID(t.Context(), resourceUIDQualificationInstance, first.projectID, "dashboard:sales")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dashboard.UID != dashboardUID || dashboard.State != project.ResourceUIDTombstoned || dashboard.RemovedInGeneration != second.generationID {
+			t.Fatalf("dashboard tombstone = %#v", dashboard)
+		}
+		var tombstones int
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_tombstone WHERE instance_id=$1 AND project_id=$2 AND authored_resource_id='dashboard:sales' AND removed_in_generation_id=$3::uuid`, resourceUIDQualificationInstance, first.projectID, second.generationID).Scan(&tombstones); err != nil {
+			t.Fatal(err)
+		}
+		if tombstones != 1 {
+			t.Fatalf("dashboard tombstones = %d, want one", tombstones)
+		}
+	})
+
+	t.Run("tombstone evidence rejects direct SQL mutation", func(t *testing.T) {
+		mutation := `UPDATE project.resource_uid_tombstone
+			SET removed_in_generation_id = removed_in_generation_id
+			WHERE instance_id=$1 AND project_id=$2 AND authored_resource_id='dashboard:sales' AND removed_in_generation_id=$3::uuid`
+		if _, err := db.Exec(t.Context(), mutation, resourceUIDQualificationInstance, first.projectID, second.generationID); err == nil {
+			t.Fatal("direct tombstone UPDATE unexpectedly succeeded")
+		}
+		deletion := `DELETE FROM project.resource_uid_tombstone
+			WHERE instance_id=$1 AND project_id=$2 AND authored_resource_id='dashboard:sales' AND removed_in_generation_id=$3::uuid`
+		if _, err := db.Exec(t.Context(), deletion, resourceUIDQualificationInstance, first.projectID, second.generationID); err == nil {
+			t.Fatal("direct tombstone DELETE unexpectedly succeeded")
+		}
+		var tombstones int
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_tombstone WHERE instance_id=$1 AND project_id=$2 AND authored_resource_id='dashboard:sales' AND removed_in_generation_id=$3::uuid`, resourceUIDQualificationInstance, first.projectID, second.generationID).Scan(&tombstones); err != nil {
+			t.Fatal(err)
+		}
+		if tombstones != 1 {
+			t.Fatalf("direct tombstone mutations changed evidence count to %d", tombstones)
+		}
+	})
+
+	third := prepareResourceUIDQualificationGeneration(t, adminRepository, resourceUIDQualificationGenerationSpec{
+		Number: 3, IncludeDashboard: true, BaseGenerationID: second.generationID,
+	})
+	lineage.expected = ActivationLineageInput{
+		TargetID: resourceUIDQualificationInstance, ProjectID: third.projectID,
+		GenerationID: third.generationID, CompiledGraphDigest: third.graph.Digest(),
+	}
+	t.Run("restore authorization rejects unadmitted generations and wrong scopes", func(t *testing.T) {
+		dashboardUID := firstUIDs["dashboard:sales"]
+		if _, err := projectpostgres.New(db).AuthorizeResourceUIDRestore(t.Context(), projectpostgres.ResourceUIDRestoreInput{
+			ResourceUIDActivation: projectpostgres.ResourceUIDActivation{
+				InstanceID: resourceUIDQualificationInstance, TargetID: resourceUIDQualificationInstance,
+				ProjectID: first.projectID, Environment: "prod", GenerationID: "0198f2c0-7c7a-7f00-8a11-000000009999",
+			},
+			ResourceUID: dashboardUID, AuthoredID: "dashboard:sales", Kind: projectgraph.KindDashboard,
+			ActorID: "restore-operator", RequestDigest: testDigest('b'),
+		}); err == nil {
+			t.Fatal("restore authorization for random unadmitted generation unexpectedly succeeded")
+		}
+		if _, err := projectpostgres.New(db).AuthorizeResourceUIDRestore(t.Context(), projectpostgres.ResourceUIDRestoreInput{
+			ResourceUIDActivation: projectpostgres.ResourceUIDActivation{
+				InstanceID: resourceUIDQualificationInstance, TargetID: resourceUIDQualificationInstance,
+				ProjectID: "project-other", Environment: "prod", GenerationID: third.generationID,
+			},
+			ResourceUID: dashboardUID, AuthoredID: "dashboard:sales", Kind: projectgraph.KindDashboard,
+			ActorID: "restore-operator", RequestDigest: testDigest('c'),
+		}); err == nil {
+			t.Fatal("restore authorization for wrong project unexpectedly succeeded")
+		}
+		var authorizations int
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_restore_authorization WHERE resource_uid=$1::uuid`, dashboardUID).Scan(&authorizations); err != nil {
+			t.Fatal(err)
+		}
+		if authorizations != 0 {
+			t.Fatalf("rejected restore requests left %d authorization rows", authorizations)
+		}
+	})
+	t.Run("new-generation tombstone restore requires and consumes exact authorization", func(t *testing.T) {
+		if _, err := repository.Activate(t.Context(), third.activation); err == nil || !strings.Contains(strings.ToLower(err.Error()), "restore") {
+			t.Fatalf("unauthorized new-generation restore error = %v, want restore authorization failure", err)
+		}
+		var revision int64
+		if err := db.QueryRow(t.Context(), `SELECT target_revision FROM delivery.delivery_target WHERE target_id=$1`, resourceUIDQualificationInstance).Scan(&revision); err != nil {
+			t.Fatal(err)
+		}
+		if revision != 3 {
+			t.Fatalf("unauthorized restore advanced target revision to %d", revision)
+		}
+		dashboard, err := projectpostgres.New(db).ResolveResourceUID(t.Context(), resourceUIDQualificationInstance, first.projectID, "dashboard:sales")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dashboard.State != project.ResourceUIDTombstoned || dashboard.CurrentGeneration != "" {
+			t.Fatalf("unauthorized restore changed dashboard = %#v", dashboard)
+		}
+
+		dashboardUID := firstUIDs["dashboard:sales"]
+		restore, err := projectpostgres.New(db).AuthorizeResourceUIDRestore(t.Context(), projectpostgres.ResourceUIDRestoreInput{
+			ResourceUIDActivation: projectpostgres.ResourceUIDActivation{
+				InstanceID: resourceUIDQualificationInstance, TargetID: resourceUIDQualificationInstance,
+				ProjectID: first.projectID, Environment: "prod", GenerationID: third.generationID,
+			},
+			ResourceUID: dashboardUID, AuthoredID: "dashboard:sales", Kind: projectgraph.KindDashboard,
+			ActorID: "restore-operator", RequestDigest: testDigest('a'),
+		})
+		if err != nil {
+			t.Fatalf("authorize dashboard restore: %v", err)
+		}
+		if restore.Status != "pending" || restore.ResourceUID != dashboardUID || restore.Kind != projectgraph.KindDashboard {
+			t.Fatalf("restore authorization = %#v", restore)
+		}
+		activated, err := repository.Activate(t.Context(), third.activation)
+		if err != nil {
+			t.Fatalf("activate authorized new generation restore: %v", err)
+		}
+		if activated.Replay || activated.Pointer.ActiveGenerationID != third.generationID {
+			t.Fatalf("authorized restore activation = %#v", activated)
+		}
+		resolved, err := projectpostgres.New(db).ResolveResourceUID(t.Context(), resourceUIDQualificationInstance, first.projectID, "dashboard:sales")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resolved.State != project.ResourceUIDActive || resolved.CurrentGeneration != third.generationID || resolved.UID != dashboardUID {
+			t.Fatalf("restored dashboard = %#v", resolved)
+		}
+		var status string
+		var consumed bool
+		if err := db.QueryRow(t.Context(), `SELECT status, consumed_at IS NOT NULL FROM project.resource_uid_restore_authorization WHERE generation_id=$1::uuid AND resource_uid=$2::uuid`, third.generationID, dashboardUID).Scan(&status, &consumed); err != nil {
+			t.Fatal(err)
+		}
+		if status != "consumed" || !consumed {
+			t.Fatalf("restore authorization consumption = status %q consumed_at_set=%v", status, consumed)
+		}
+	})
+
+	fourth := prepareResourceUIDQualificationGeneration(t, adminRepository, resourceUIDQualificationGenerationSpec{
+		Number: 4, IncludeDashboard: false, BaseGenerationID: third.generationID, KindMismatch: true,
+	})
+	lineage.expected = ActivationLineageInput{
+		TargetID: resourceUIDQualificationInstance, ProjectID: fourth.projectID,
+		GenerationID: fourth.generationID, CompiledGraphDigest: fourth.graph.Digest(),
+	}
+	t.Run("kind mismatch rolls back an earlier fresh allocation", func(t *testing.T) {
+		before := resourceUIDsByAuthoredID(t, db, first.projectID)
+		if _, err := repository.Activate(t.Context(), fourth.activation); err == nil || !strings.Contains(strings.ToLower(err.Error()), "kind conflict") {
+			t.Fatalf("kind mismatch activation error = %v, want kind conflict", err)
+		}
+		if got := resourceUIDsByAuthoredID(t, db, first.projectID); !sameResourceUIDMap(got, before) {
+			t.Fatalf("kind mismatch changed registry UIDs: got=%v before=%v", got, before)
+		}
+		var freshRows int
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_registry WHERE instance_id=$1 AND project_id=$2 AND authored_resource_id='a_new'`, resourceUIDQualificationInstance, first.projectID).Scan(&freshRows); err != nil {
+			t.Fatal(err)
+		}
+		if freshRows != 0 {
+			t.Fatalf("kind mismatch leaked fresh earlier allocation: %d rows", freshRows)
+		}
+		var revision int64
+		if err := db.QueryRow(t.Context(), `SELECT target_revision FROM delivery.delivery_target WHERE target_id=$1`, resourceUIDQualificationInstance).Scan(&revision); err != nil {
+			t.Fatal(err)
+		}
+		if revision != 4 {
+			t.Fatalf("kind mismatch advanced target revision to %d", revision)
+		}
+	})
+
+	rollbackSecond := prepareHistoricalResourceUIDRollback(t, adminRepository, second, 4, third.generationID)
+	lineage.expected = ActivationLineageInput{
+		TargetID: resourceUIDQualificationInstance, ProjectID: second.projectID,
+		GenerationID: second.generationID, CompiledGraphDigest: second.graph.Digest(),
+	}
+	t.Run("historical generation rollback reuses UIDs without new authorization", func(t *testing.T) {
+		result, err := repository.Activate(t.Context(), rollbackSecond.activation)
+		if err != nil {
+			t.Fatalf("rollback to previously bound generation: %v", err)
+		}
+		if result.Replay || result.Pointer.ActiveGenerationID != second.generationID {
+			t.Fatalf("historical rollback result = %#v", result)
+		}
+		got := resourceUIDsByAuthoredID(t, db, first.projectID)
+		if !sameResourceUIDMap(got, firstUIDs) {
+			t.Fatalf("historical rollback changed UIDs: got=%v want=%v", got, firstUIDs)
+		}
+		dashboard, err := projectpostgres.New(db).ResolveResourceUID(t.Context(), resourceUIDQualificationInstance, first.projectID, "dashboard:sales")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dashboard.State != project.ResourceUIDTombstoned || dashboard.RemovedInGeneration != second.generationID {
+			t.Fatalf("rollback dashboard state = %#v", dashboard)
+		}
+	})
+
+	rollbackFirst := prepareHistoricalResourceUIDRollback(t, adminRepository, first, 5, second.generationID)
+	lineage.expected = ActivationLineageInput{
+		TargetID: resourceUIDQualificationInstance, ProjectID: first.projectID,
+		GenerationID: first.generationID, CompiledGraphDigest: first.graph.Digest(),
+	}
+	t.Run("historical first generation restores tombstone without authorization", func(t *testing.T) {
+		result, err := repository.Activate(t.Context(), rollbackFirst.activation)
+		if err != nil {
+			t.Fatalf("rollback to first generation: %v", err)
+		}
+		if result.Replay || result.Pointer.ActiveGenerationID != first.generationID {
+			t.Fatalf("first historical rollback result = %#v", result)
+		}
+		dashboard, err := projectpostgres.New(db).ResolveResourceUID(t.Context(), resourceUIDQualificationInstance, first.projectID, "dashboard:sales")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dashboard.State != project.ResourceUIDActive || dashboard.CurrentGeneration != first.generationID || dashboard.UID != firstUIDs["dashboard:sales"] {
+			t.Fatalf("first rollback dashboard = %#v", dashboard)
+		}
+		var pending int
+		if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_restore_authorization WHERE instance_id=$1 AND project_id=$2 AND status='pending'`, resourceUIDQualificationInstance, first.projectID).Scan(&pending); err != nil {
+			t.Fatal(err)
+		}
+		if pending != 0 {
+			t.Fatalf("historical rollback left pending restore authorizations: %d", pending)
+		}
+	})
+
+	t.Run("independent database instances allocate distinct UIDs", func(t *testing.T) {
+		isolatedDB := deliveryTestDB(t)
+		installResourceUIDQualificationDependencies(t, isolatedDB)
+		seedResourceUIDQualificationBootstrap(t, isolatedDB)
+		isolatedAdmin := New(isolatedDB)
+		isolatedFirst := prepareResourceUIDQualificationGeneration(t, isolatedAdmin, resourceUIDQualificationGenerationSpec{
+			Number: 1, IncludeDashboard: true,
+		})
+		isolatedLineage := &testActivationLineage{expected: ActivationLineageInput{
+			TargetID: resourceUIDQualificationInstance, ProjectID: isolatedFirst.projectID,
+			GenerationID: isolatedFirst.generationID, CompiledGraphDigest: isolatedFirst.graph.Digest(),
+		}}
+		isolatedRepository := NewWithOptions(isolatedDB, Options{
+			ActivationAudit: testActivationAudit{audit: accesspostgres.New()},
+			Lineage:         isolatedLineage,
+		})
+		if _, err := isolatedRepository.Activate(t.Context(), isolatedFirst.activation); err != nil {
+			t.Fatalf("activate isolated instance: %v", err)
+		}
+		isolatedUIDs := resourceUIDsByAuthoredID(t, isolatedDB, isolatedFirst.projectID)
+		if isolatedUIDs["connection:warehouse"] == firstUIDs["connection:warehouse"] {
+			t.Fatalf("independent database instances reused connection UID %q", isolatedUIDs["connection:warehouse"])
+		}
+		if isolatedUIDs["dashboard:sales"] == firstUIDs["dashboard:sales"] {
+			t.Fatalf("independent database instances reused dashboard UID %q", isolatedUIDs["dashboard:sales"])
+		}
+	})
+
+	t.Run("wrong project or instance cannot resolve the UID", func(t *testing.T) {
+		if _, err := projectpostgres.New(db).ResolveResourceUID(t.Context(), resourceUIDQualificationInstance, "project-other", "connection:warehouse"); !errors.Is(err, project.ErrResourceUIDNotFound) {
+			t.Fatalf("wrong project resolution = %v, want not found", err)
+		}
+		if _, err := projectpostgres.New(db).ResolveResourceUIDByUID(t.Context(), "lvinst_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", first.projectID, firstUIDs["connection:warehouse"]); !errors.Is(err, project.ErrResourceUIDNotFound) {
+			t.Fatalf("wrong instance resolution = %v, want not found", err)
+		}
+	})
+}
+
+type failingResourceUIDActivationAudit struct{ err error }
+
+func (a failingResourceUIDActivationAudit) AppendActivationAudit(_ context.Context, _ Tx, _ ActivationAuditInput) (AuditEvent, error) {
+	return AuditEvent{}, a.err
+}
+
+func (a failingResourceUIDActivationAudit) GetActivationAudit(_ context.Context, _ Tx, _ ActivationAuditInput) (AuditEvent, error) {
+	return AuditEvent{}, a.err
+}
+
+type resourceUIDQualificationGenerationSpec struct {
+	Number           int
+	IncludeDashboard bool
+	BaseGenerationID string
+	KindMismatch     bool
+}
+
+type resourceUIDQualificationGeneration struct {
+	projectID, generationID, publicationID string
+	candidateID, sealID                    string
+	graph                                  projectgraph.ProjectGraph
+	activation                             ActivationInput
+}
+
+func installResourceUIDQualificationDependencies(t *testing.T, db *pgxpool.Pool) {
+	t.Helper()
+	tx, err := db.Begin(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := platformbootstrappostgres.ApplySchema(t.Context(), tx); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatalf("apply bootstrap schema: %v", err)
+	}
+	if err := projectpostgres.ApplySchema(t.Context(), tx); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatalf("apply project schema: %v", err)
+	}
+	if _, err := tx.Exec(t.Context(), projectpostgres.ResourceUIDSchemaSQL()); err != nil {
+		_ = tx.Rollback(t.Context())
+		t.Fatalf("apply resource UID schema after dependencies: %v", err)
+	}
+	if err := tx.Commit(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedResourceUIDQualificationBootstrap(t *testing.T, db *pgxpool.Pool) {
+	t.Helper()
+	bootstrap := platformbootstrappostgres.New(db)
+	if err := bootstrap.EnsureInstanceID(t.Context(), resourceUIDQualificationInstance); err != nil {
+		t.Fatalf("ensure instance ID: %v", err)
+	}
+	if err := bootstrap.BindInstanceEnvironment(t.Context(), "prod"); err != nil {
+		t.Fatalf("bind instance environment: %v", err)
+	}
+	if _, err := projectpostgres.New(db).Ensure(t.Context(), projectpostgres.EnsureInput{ID: "project_uid_qualification", Title: "Resource UID qualification"}); err != nil {
+		t.Fatalf("ensure project identity: %v", err)
+	}
+	if _, err := bootstrap.ClaimProject(t.Context(), platformbootstrappostgres.ProjectClaimInput{
+		ProjectID: "project_uid_qualification", Environment: "prod", ClaimedBy: "qualification", ClaimedAt: time.Now().UTC().Truncate(time.Microsecond),
+	}); err != nil {
+		t.Fatalf("claim project: %v", err)
+	}
+}
+
+func prepareResourceUIDQualificationGeneration(t *testing.T, r *Repository, spec resourceUIDQualificationGenerationSpec) resourceUIDQualificationGeneration {
+	t.Helper()
+	ctx := t.Context()
+	projectID := "project_uid_qualification"
+	ids := fmt.Sprintf("%d", spec.Number)
+	planID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "01"
+	candidateID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "02"
+	attemptID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "03"
+	sealID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "04"
+	generationID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "05"
+	publicationID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "06"
+	leaseID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "07"
+	correlationID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "08"
+	poolID := "uid-pool-" + ids
+	catalogID := "uid-catalog-" + ids
+	artifactDigest := testDigest('e')
+	bundle, inventory, graph := resourceUIDQualificationBundle(t, spec.IncludeDashboard)
+	if spec.KindMismatch {
+		bundle, inventory, graph = resourceUIDQualificationKindMismatchBundle(t)
+	}
+
+	if spec.Number == 1 {
+		if _, err := r.CreateTarget(ctx, TargetInput{TargetID: resourceUIDQualificationInstance, ProjectID: projectID, Environment: "prod"}); err != nil {
+			t.Fatalf("create canonical instance target: %v", err)
+		}
+	}
+	rich, document := richPlanDocumentFixture(t, planID, resourceUIDQualificationInstance, projectID)
+	rich.SourceDigest = graph.Digest()
+	rich.Execution.SourceArtifactDigest = graph.Digest()
+	rich.ServingArtifactDigest = artifactDigest
+	rich.Governance.RequiresApproval = false
+	rich.Governance.ExpiresAt = time.Now().UTC().Add(2 * time.Hour)
+	rich, err := deploymentdomain.NewDeliveryPlan(rich)
+	if err != nil {
+		t.Fatalf("new resource UID plan: %v", err)
+	}
+	document, err = json.Marshal(rich)
+	if err != nil {
+		t.Fatal(err)
+	}
+	planInput := planDocumentProjectionFixture(t, rich, document)
+	planInput.PlanRevision = int64(spec.Number)
+	planInput.CompiledGraphDigest = graph.Digest()
+	planInput.ArtifactDigest = artifactDigest
+	planInput.Evidence = []byte(`{"qualification":"resource-uid"}`)
+	plan, err := r.CreatePlan(ctx, planInput)
+	if err != nil {
+		t.Fatalf("create resource UID plan: %v", err)
+	}
+	if _, err := r.CreateCandidate(ctx, CandidateInput{CandidateID: candidateID, TargetID: resourceUIDQualificationInstance, PlanID: planID, CandidateRevision: int64(spec.Number), ArtifactDigest: artifactDigest}); err != nil {
+		t.Fatalf("create resource UID candidate: %v", err)
+	}
+	requestDigest := testDigest([]byte("fabc")[spec.Number-1])
+	if _, err := r.BeginBuildAttempt(ctx, BuildAttemptInput{AttemptID: attemptID, PlanID: planID, CandidateID: candidateID, OwnerID: "uid-builder-" + ids, PhysicalPoolID: poolID, CatalogID: catalogID, FencingEpoch: 1, RequestDigest: requestDigest, PlanDigest: plan.PlanDigest, Namespace: "candidate/uid-" + ids, SessionIdentity: "session/uid-" + ids, LeaseExpiresAt: time.Now().UTC().Add(time.Hour)}); err != nil {
+		t.Fatalf("begin resource UID build attempt: %v", err)
+	}
+	if _, err := r.BindBuildArtifact(ctx, BuildArtifactBindingInput{AttemptID: attemptID, ServingArtifactID: "artifact-" + strings.TrimPrefix(artifactDigest, "sha256:"), ServingArtifactDigest: artifactDigest, ServingStateID: "generation-test", OwnerID: "uid-builder-" + ids, FencingEpoch: 1}); err != nil {
+		t.Fatalf("bind resource UID artifact: %v", err)
+	}
+	marker := testCommitMarker(attemptID, poolID, requestDigest, plan.PlanDigest)
+	if _, err := r.CommitBuildAttempt(ctx, CommitAttemptInput{AttemptID: attemptID, OwnerID: "uid-builder-" + ids, FencingEpoch: 1, SnapshotID: int64(100 + spec.Number), CommitMarker: marker}); err != nil {
+		t.Fatalf("commit resource UID build: %v", err)
+	}
+	seal := SnapshotSealInput{
+		SealID: sealID, AttemptID: attemptID, CandidateID: candidateID, PhysicalPoolID: poolID, TenantDomain: "uid-tenant", Region: "us-east", EncryptionDomain: "uid-encryption", ObjectNamespace: "objects/uid-" + ids, CatalogDatabase: "ducklake", CatalogID: catalogID, CatalogUUID: "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "09", CatalogVersion: 1, DuckLakeSnapshotID: int64(100 + spec.Number), RelationNamespace: "candidate/uid-" + ids, RelationManifestDigest: testDigest('1'), ClosureDigest: testDigest('8'), ObjectRoot: "objects/uid-" + ids + "/snapshot", ObjectRootDigest: testDigest('6'), ArtifactRoot: "artifacts/uid-" + ids, ArtifactRootDigest: testDigest('7'), CompiledGraphDigest: graph.Digest(), CompiledConfigDigest: testDigest('c'), SecurityDomainFingerprint: testDigest('d'), RequestDigest: requestDigest, PlanDigest: plan.PlanDigest, CompatibilityDigest: testDigest('2'), ServingArtifactID: "artifact-" + strings.TrimPrefix(artifactDigest, "sha256:"), ServingArtifactDigest: artifactDigest, DuckDBVersion: "1", RuntimeVersion: "runtime-v1", DuckLakeExtensionVersion: "1", DuckLakeSpecVersion: "1", CatalogSchemaVersion: "1", QualificationEvidence: []byte(`{"checks":["resource-uid"]}`),
+	}
+	if _, err := r.CreateSnapshotSeal(ctx, seal); err != nil {
+		t.Fatalf("create resource UID seal: %v", err)
+	}
+	if _, err := r.QualifyCandidate(ctx, candidateID, sealID, testDigest('3')); err != nil {
+		t.Fatalf("qualify resource UID candidate: %v", err)
+	}
+	if _, err := r.CreateGeneration(ctx, GenerationInput{GenerationID: generationID, TargetID: resourceUIDQualificationInstance, CandidateID: candidateID, SnapshotSealID: sealID, PlanID: planID, PlanDigest: plan.PlanDigest, ArtifactRoot: seal.ArtifactRoot, ArtifactRootDigest: seal.ArtifactRootDigest, ServingArtifactDigest: artifactDigest, CompiledGraphDigest: graph.Digest(), CompiledConfigDigest: testDigest('c'), SecurityDomainFingerprint: testDigest('d'), GenerationRevision: int64(spec.Number)}); err != nil {
+		t.Fatalf("create resource UID generation: %v", err)
+	}
+	seedPhysicalRetentionFixture(t, r.DB(), seal)
+	stageResourceUIDQualificationBundle(t, r.DB(), bundle, inventory, graph, generationID, projectID, artifactDigest)
+	if _, err := r.CreatePublication(ctx, PublicationInput{PublicationID: publicationID, TargetID: resourceUIDQualificationInstance, GenerationID: generationID, ExpectedBaseGenerationID: spec.BaseGenerationID, CandidateID: candidateID, SnapshotSealID: sealID, ExpectedTargetRevision: int64(spec.Number), ActorID: "operator", RequestDigest: testDigest(byte('4' + byte(spec.Number)))}); err != nil {
+		t.Fatalf("create resource UID publication: %v", err)
+	}
+	lease, err := r.AcquireLease(ctx, LeaseInput{LeaseID: leaseID, TargetID: resourceUIDQualificationInstance, OwnerID: "operator", ExpiresAt: time.Now().UTC().Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("acquire resource UID activation lease: %v", err)
+	}
+	return resourceUIDQualificationGeneration{projectID: projectID, generationID: generationID, publicationID: publicationID, candidateID: candidateID, sealID: sealID, graph: graph, activation: ActivationInput{PublicationID: publicationID, TargetID: resourceUIDQualificationInstance, GenerationID: generationID, ExpectedTargetRevision: int64(spec.Number), RequestDigest: testDigest(byte('4' + byte(spec.Number))), ActorID: "operator", CorrelationID: correlationID, LeaseID: lease.LeaseID, OwnerID: lease.OwnerID, FencingEpoch: lease.FencingEpoch}}
+}
+
+func prepareHistoricalResourceUIDRollback(t *testing.T, r *Repository, generation resourceUIDQualificationGeneration, revision int, baseGenerationID string) resourceUIDQualificationGeneration {
+	t.Helper()
+	ids := fmt.Sprintf("rollback-%d", revision)
+	publicationID := "0198f2c0-7c7a-7f00-8a11-00000000" + fmt.Sprintf("%04d", 900+revision)
+	leaseID := "0198f2c0-7c7a-7f00-8a11-00000000" + fmt.Sprintf("%04d", 910+revision)
+	correlationID := "0198f2c0-7c7a-7f00-8a11-00000000" + fmt.Sprintf("%04d", 920+revision)
+	requestDigest := testDigest([]byte("9a")[revision-4])
+	if _, err := r.CreatePublication(t.Context(), PublicationInput{PublicationID: publicationID, TargetID: resourceUIDQualificationInstance, GenerationID: generation.generationID, ExpectedBaseGenerationID: baseGenerationID, CandidateID: generation.candidateID, SnapshotSealID: generation.sealID, ExpectedTargetRevision: int64(revision), ActorID: "operator", RequestDigest: requestDigest}); err != nil {
+		t.Fatalf("create historical rollback publication %s: %v", ids, err)
+	}
+	lease, err := r.AcquireLease(t.Context(), LeaseInput{LeaseID: leaseID, TargetID: resourceUIDQualificationInstance, OwnerID: "operator", ExpiresAt: time.Now().UTC().Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("acquire historical rollback lease %s: %v", ids, err)
+	}
+	return resourceUIDQualificationGeneration{
+		projectID: generation.projectID, generationID: generation.generationID, publicationID: publicationID,
+		candidateID: generation.candidateID, sealID: generation.sealID, graph: generation.graph,
+		activation: ActivationInput{PublicationID: publicationID, TargetID: resourceUIDQualificationInstance, GenerationID: generation.generationID, ExpectedTargetRevision: int64(revision), RequestDigest: requestDigest, ActorID: "operator", CorrelationID: correlationID, LeaseID: lease.LeaseID, OwnerID: lease.OwnerID, FencingEpoch: lease.FencingEpoch},
+	}
+}
+
+func stageResourceUIDQualificationBundle(t *testing.T, db DBTX, bundle projectartifact.SourceBundle, inventory project.ResourceUIDInventory, graph projectgraph.ProjectGraph, generationID, projectID, artifactDigest string) {
+	t.Helper()
+	tx, ok := db.(interface {
+		Begin(context.Context) (pgx.Tx, error)
+	})
+	if !ok {
+		t.Fatal("resource UID bundle staging requires a PostgreSQL pool")
+	}
+	transaction, err := tx.Begin(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rollback := true
+	defer func() {
+		if rollback {
+			_ = transaction.Rollback(t.Context())
+		}
+	}()
+	if _, err := servingnative.AdmitGenerationBundleTx(t.Context(), transaction, servingnative.GenerationBundleInput{GenerationID: generationID, ProjectID: projectgraph.ResourceID(projectID), Environment: "prod", Artifact: servingstate.Artifact{ID: "artifact-" + strings.TrimPrefix(artifactDigest, "sha256:"), ServingStateID: servingstate.ID(generationID), Digest: artifactDigest, Format: servingstate.ArtifactBundleFormat, ManifestJSON: "{}", SizeBytes: 1}, ArtifactLocator: "serving-artifacts/" + strings.TrimPrefix(artifactDigest, "sha256:") + ".tar.gz", StorageSecurityDomain: "uid-storage", ArtifactContentType: servingstate.ArtifactBundleContentType, ArtifactMetadataDigest: testDigest('9'), ProjectDigest: bundle.Digest(), AccessPolicyJSON: "{}", DashboardPublicationsJSON: "{}", DashboardAppearancesJSON: "{}", CreatedBy: "uid-qualification"}, graph); err != nil {
+		t.Fatalf("admit serving bundle: %v", err)
+	}
+	if err := projectpostgres.New(transaction).AdmitResourceUIDInventoryTx(t.Context(), transaction, resourceUIDQualificationInstance, projectID, "prod", generationID, inventory); err != nil {
+		t.Fatalf("admit resource UID inventory: %v", err)
+	}
+	if err := transaction.Commit(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	rollback = false
+}
+
+func resourceUIDQualificationBundle(t *testing.T, includeDashboard bool) (projectartifact.SourceBundle, project.ResourceUIDInventory, projectgraph.ProjectGraph) {
+	t.Helper()
+	resources := []projectgraph.Resource{{ID: "connection:warehouse", Kind: projectgraph.KindConnection, Name: "warehouse"}, {ID: "source:orders", Kind: projectgraph.KindSource, Name: "orders"}, {ID: "model:orders", Kind: projectgraph.KindModel, Name: "orders_model"}, {ID: "semantic:sales", Kind: projectgraph.KindSemanticModel, Name: "sales"}, {ID: "pipeline:sales", Kind: projectgraph.KindPipeline, Name: "sales_refresh"}}
+	edges := []projectgraph.Edge{{From: "source:orders", To: "connection:warehouse", Relation: "depends_on"}, {From: "model:orders", To: "source:orders", Relation: "depends_on"}, {From: "semantic:sales", To: "model:orders", Relation: "depends_on"}, {From: "pipeline:sales", To: "semantic:sales", Relation: "depends_on"}}
+	if includeDashboard {
+		resources = append(resources, projectgraph.Resource{ID: "dashboard:sales", Kind: projectgraph.KindDashboard, Name: "sales_dashboard"})
+		edges = append(edges, projectgraph.Edge{From: "dashboard:sales", To: "semantic:sales", Relation: "depends_on"})
+	}
+	graph, err := projectgraph.NewProjectGraph(resources, edges)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := projectmanifest.ResourceManifest{Title: "Resource UID qualification", Connections: map[string]semanticmodel.Connection{"connection:warehouse": {Kind: "managed"}}, Sources: map[string]semanticmodel.Source{"source:orders": {Connection: "connection:warehouse"}}, Models: map[string]semanticmodel.Table{"model:orders": {Execution: semanticmodel.ExecutionDefinition{Source: "source:orders"}, SourceDependencies: []string{"source:orders"}}}, SemanticModels: map[string]*semanticmodel.Model{"semantic:sales": {Name: "sales"}}, RefreshPipelines: map[string]refreshschedule.Definition{"pipeline:sales": {ID: "pipeline:sales", Name: "sales_refresh", SemanticModelID: "semantic:sales"}}, AuthoredResourceSources: resourceUIDQualificationAuthoredSources()}
+	manifest.DashboardDefinitions = map[string]dashboarddefinition.Definition{}
+	manifest.DashboardSources = map[string]projectmanifest.DashboardSource{}
+	if includeDashboard {
+		manifest.DashboardDefinitions["dashboard:sales"] = dashboarddefinition.Definition{ID: "dashboard:sales", SemanticModel: "semantic:sales"}
+		manifest.DashboardSources["dashboard:sales"] = projectmanifest.DashboardSource{Document: dashboarddocument.DashboardDocument{
+			APIVersion: "leapview.dev/v1", Kind: dashboarddocument.DashboardResourceKindDashboard,
+			Metadata: dashboarddocument.DashboardMetadata{ID: "dashboard:sales", Name: "sales_dashboard"},
+			Spec:     dashboarddocument.DashboardSpec{SemanticModel: "semantic:sales"},
+		}}
+	}
+	bundle, err := projectartifact.NewSourceBundle(graph, manifest)
+	if err != nil {
+		t.Fatalf("create resource UID source bundle: %v", err)
+	}
+	inventory, err := project.NewResourceUIDInventory(bundle)
+	if err != nil {
+		t.Fatalf("seal resource UID inventory: %v", err)
+	}
+	return bundle, inventory, graph
+}
+
+func resourceUIDQualificationKindMismatchBundle(t *testing.T) (projectartifact.SourceBundle, project.ResourceUIDInventory, projectgraph.ProjectGraph) {
+	t.Helper()
+	resources := []projectgraph.Resource{
+		{ID: "a_new", Kind: projectgraph.KindConnection, Name: "new_connection"},
+		// The registry already contains connection:warehouse, but this
+		// generation intentionally presents that authored ID as a source. The
+		// inventory order allocates a_new first, then must fail on the conflict.
+		{ID: "connection:warehouse", Kind: projectgraph.KindSource, Name: "warehouse"},
+	}
+	edges := []projectgraph.Edge{{From: "connection:warehouse", To: "a_new", Relation: "depends_on"}}
+	graph, err := projectgraph.NewProjectGraph(resources, edges)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := projectmanifest.ResourceManifest{
+		Title:       "Resource UID kind mismatch qualification",
+		Connections: map[string]semanticmodel.Connection{"a_new": {Kind: "managed"}},
+		Sources:     map[string]semanticmodel.Source{"connection:warehouse": {Connection: "a_new"}},
+		AuthoredResourceSources: map[string]string{
+			"connection:warehouse": "apiVersion: leapview.dev/v1\nkind: Source\nmetadata:\n  id: connection:warehouse\n  name: warehouse\nspec:\n  connection: a_new\n  location:\n    type: path\n    path: orders.csv\n    format: csv\n",
+		},
+	}
+	bundle, err := projectartifact.NewSourceBundle(graph, manifest)
+	if err != nil {
+		t.Fatalf("create kind mismatch source bundle: %v", err)
+	}
+	inventory, err := project.NewResourceUIDInventory(bundle)
+	if err != nil {
+		t.Fatalf("seal kind mismatch inventory: %v", err)
+	}
+	return bundle, inventory, graph
+}
+
+func resourceUIDQualificationAuthoredSources() map[string]string {
+	return map[string]string{
+		"source:orders":  "apiVersion: leapview.dev/v1\nkind: Source\nmetadata:\n  id: source:orders\n  name: orders\nspec:\n  connection: connection:warehouse\n  location:\n    type: path\n    path: orders.csv\n    format: csv\n",
+		"model:orders":   "apiVersion: leapview.dev/v1\nkind: Model\nmetadata:\n  id: model:orders\n  name: orders_model\nspec:\n  definition:\n    type: sql\n    sql: SELECT 1 AS id\n  entities: {}\n  grain:\n    entity: id\n",
+		"semantic:sales": "apiVersion: leapview.dev/v1\nkind: SemanticModel\nmetadata:\n  id: semantic:sales\n  name: sales\nspec:\n  datasets:\n    orders:\n      model: orders_model\n  metrics: {}\n",
+	}
+}
+
+func resourceUIDsByAuthoredID(t *testing.T, db DBTX, projectID string) map[string]project.ResourceUID {
+	t.Helper()
+	rows, err := db.Query(t.Context(), `SELECT authored_resource_id, resource_uid FROM project.resource_uid_registry WHERE instance_id=$1 AND project_id=$2`, resourceUIDQualificationInstance, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	result := make(map[string]project.ResourceUID)
+	for rows.Next() {
+		var authored, uid string
+		if err := rows.Scan(&authored, &uid); err != nil {
+			t.Fatal(err)
+		}
+		result[authored] = project.ResourceUID(uid)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func sameResourceUIDMap(left, right map[string]project.ResourceUID) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, value := range right {
+		if left[key] != value {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/platform/postgres/migrations/005_resource_uid_registry.sql
+++ b/internal/platform/postgres/migrations/005_resource_uid_registry.sql
@@ -1,0 +1,754 @@
+-- +goose Up
+-- +goose StatementBegin
+SET LOCAL ROLE leapview_control_owner;
+
+-- Instance-local authored-resource identity registry (FAI-670). Resource UIDs
+-- are allocated only by the activation-owned SECURITY DEFINER function below.
+-- The registry is qualified by instance and Project; no global lookup is part
+-- of this capability.
+CREATE TABLE IF NOT EXISTS project.resource_uid_registry (
+    resource_uid             uuid PRIMARY KEY DEFAULT uuidv4(),
+    instance_id              text NOT NULL,
+    project_id               text NOT NULL,
+    authored_resource_id     text NOT NULL,
+    resource_kind            text NOT NULL,
+    state                    text NOT NULL DEFAULT 'active',
+    first_generation_id      uuid NOT NULL,
+    latest_generation_id     uuid NOT NULL,
+    current_generation_id    uuid,
+    removed_in_generation_id uuid,
+    created_at               timestamptz NOT NULL DEFAULT clock_timestamp(),
+    updated_at               timestamptz NOT NULL DEFAULT clock_timestamp(),
+    UNIQUE (instance_id, project_id, authored_resource_id),
+    UNIQUE (instance_id, project_id, resource_uid),
+    CHECK (instance_id = btrim(instance_id) AND instance_id ~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'),
+    CHECK (project_id = btrim(project_id) AND octet_length(project_id) BETWEEN 1 AND 255 AND project_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (authored_resource_id = btrim(authored_resource_id) AND octet_length(authored_resource_id) >= 1 AND authored_resource_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (resource_kind IN ('connection','source','model','semantic_model','pipeline','dashboard')),
+    CHECK (state IN ('active','tombstoned')),
+    CHECK (first_generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (latest_generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK ((state = 'active' AND current_generation_id IS NOT NULL AND removed_in_generation_id IS NULL AND current_generation_id = latest_generation_id)
+        OR (state = 'tombstoned' AND current_generation_id IS NULL AND removed_in_generation_id IS NOT NULL AND removed_in_generation_id = latest_generation_id)),
+    CHECK (updated_at >= created_at)
+);
+
+CREATE TABLE IF NOT EXISTS project.resource_uid_generation (
+    resource_uid          uuid NOT NULL,
+    instance_id           text NOT NULL,
+    project_id            text NOT NULL,
+    environment           text NOT NULL,
+    target_id             text NOT NULL,
+    generation_id         uuid NOT NULL,
+    authored_resource_id  text NOT NULL,
+    resource_kind         text NOT NULL,
+    contract_status       text NOT NULL,
+    contract_profile      text,
+    contract_version      text,
+    contract_digest       text,
+    contract_bytes        bytea,
+    bound_at              timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (instance_id, project_id, generation_id, authored_resource_id),
+    UNIQUE (instance_id, project_id, generation_id, resource_uid),
+    FOREIGN KEY (instance_id, project_id, resource_uid)
+        REFERENCES project.resource_uid_registry(instance_id, project_id, resource_uid) ON DELETE RESTRICT,
+    CHECK (instance_id = btrim(instance_id) AND instance_id ~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'),
+    CHECK (project_id = btrim(project_id) AND octet_length(project_id) BETWEEN 1 AND 255 AND project_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (environment = btrim(environment) AND octet_length(environment) BETWEEN 1 AND 255 AND environment ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (target_id = instance_id),
+    CHECK (generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (authored_resource_id = btrim(authored_resource_id) AND octet_length(authored_resource_id) >= 1 AND authored_resource_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (resource_kind IN ('connection','source','model','semantic_model','pipeline','dashboard')),
+    CHECK (contract_status IN ('canonical','unversioned','not_contract_bearing')),
+    CHECK ((contract_profile IS NULL AND contract_version IS NULL AND contract_digest IS NULL AND contract_bytes IS NULL)
+        OR (contract_profile IS NOT NULL AND contract_profile = 'leapview.contract/v1'
+            AND contract_version IS NOT NULL AND contract_digest IS NOT NULL
+            AND contract_digest ~ '^sha256:[0-9a-f]{64}$'
+            AND contract_bytes IS NOT NULL AND octet_length(contract_bytes) > 0)),
+    CHECK ((contract_status = 'canonical' AND contract_profile IS NOT NULL AND contract_digest IS NOT NULL AND contract_bytes IS NOT NULL)
+        OR (contract_status = 'unversioned' AND resource_kind IN ('source','model','semantic_model') AND contract_profile IS NULL AND contract_version IS NULL AND contract_digest IS NULL AND contract_bytes IS NULL)
+        OR (contract_status = 'not_contract_bearing' AND resource_kind IN ('connection','pipeline','dashboard') AND contract_profile IS NULL AND contract_version IS NULL AND contract_digest IS NULL AND contract_bytes IS NULL)),
+    CHECK (contract_profile IS NULL OR (contract_profile = btrim(contract_profile) AND octet_length(contract_profile) BETWEEN 1 AND 255)),
+    CHECK (contract_version IS NULL OR (contract_version = btrim(contract_version) AND octet_length(contract_version) > 0))
+);
+
+-- Admission seals one complete, UID-free inventory per generation. This row
+-- is immutable and is the only registry data written before activation.
+CREATE TABLE IF NOT EXISTS project.resource_uid_inventory (
+    generation_id  uuid PRIMARY KEY,
+    instance_id    text NOT NULL,
+    project_id     text NOT NULL,
+    environment    text NOT NULL,
+    target_id      text NOT NULL,
+    graph_digest   text NOT NULL,
+    bundle_digest  text NOT NULL,
+    graph_bytes    bytea NOT NULL,
+    inventory_json jsonb NOT NULL,
+    created_at     timestamptz NOT NULL DEFAULT clock_timestamp(),
+    UNIQUE (instance_id, project_id, generation_id),
+    CHECK (generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (instance_id = btrim(instance_id) AND instance_id ~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'),
+    CHECK (project_id = btrim(project_id) AND octet_length(project_id) BETWEEN 1 AND 255 AND project_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (environment = btrim(environment) AND octet_length(environment) BETWEEN 1 AND 255 AND environment ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (target_id = instance_id),
+    CHECK (graph_digest ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK (bundle_digest ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK (octet_length(graph_bytes) > 0),
+    CHECK (graph_digest = 'sha256:' || pg_catalog.encode(pg_catalog.sha256(graph_bytes), 'hex')),
+    CHECK (jsonb_typeof(inventory_json) = 'array')
+);
+
+CREATE OR REPLACE FUNCTION project.reject_resource_uid_inventory_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, project AS $$
+BEGIN
+    RAISE EXCEPTION 'resource UID inventory evidence is immutable';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS resource_uid_inventory_immutable ON project.resource_uid_inventory;
+CREATE TRIGGER resource_uid_inventory_immutable
+BEFORE UPDATE OR DELETE ON project.resource_uid_inventory
+FOR EACH ROW EXECUTE FUNCTION project.reject_resource_uid_inventory_mutation();
+
+-- Tombstones are append-only generation evidence. They make removal auditable
+-- without relying on mutable current-state fields alone.
+CREATE TABLE IF NOT EXISTS project.resource_uid_tombstone (
+    instance_id              text NOT NULL,
+    project_id               text NOT NULL,
+    resource_uid             uuid NOT NULL,
+    authored_resource_id     text NOT NULL,
+    resource_kind            text NOT NULL,
+    removed_in_generation_id uuid NOT NULL,
+    tombstoned_at            timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (instance_id, project_id, authored_resource_id, removed_in_generation_id),
+    UNIQUE (instance_id, project_id, resource_uid, removed_in_generation_id),
+    FOREIGN KEY (instance_id, project_id, resource_uid)
+        REFERENCES project.resource_uid_registry(instance_id, project_id, resource_uid) ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS project.resource_uid_restore_authorization (
+    restore_id              uuid PRIMARY KEY DEFAULT uuidv4(),
+    resource_uid            uuid NOT NULL,
+    instance_id             text NOT NULL,
+    project_id              text NOT NULL,
+    environment             text NOT NULL,
+    target_id               text NOT NULL,
+    generation_id           uuid NOT NULL,
+    authored_resource_id    text NOT NULL,
+    resource_kind           text NOT NULL,
+    actor_id                text NOT NULL,
+    request_digest          text NOT NULL,
+    status                  text NOT NULL DEFAULT 'pending',
+    created_at              timestamptz NOT NULL DEFAULT clock_timestamp(),
+    consumed_at             timestamptz,
+    UNIQUE (instance_id, project_id, resource_uid, generation_id),
+    FOREIGN KEY (instance_id, project_id, resource_uid)
+        REFERENCES project.resource_uid_registry(instance_id, project_id, resource_uid) ON DELETE RESTRICT,
+    CHECK (instance_id = btrim(instance_id) AND instance_id ~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'),
+    CHECK (project_id = btrim(project_id) AND octet_length(project_id) BETWEEN 1 AND 255 AND project_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (environment = btrim(environment) AND octet_length(environment) BETWEEN 1 AND 255 AND environment ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (target_id = instance_id),
+    CHECK (generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (authored_resource_id = btrim(authored_resource_id) AND octet_length(authored_resource_id) >= 1 AND authored_resource_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (resource_kind IN ('connection','source','model','semantic_model','pipeline','dashboard')),
+    CHECK (actor_id = btrim(actor_id) AND octet_length(actor_id) BETWEEN 1 AND 255 AND actor_id !~ '[[:cntrl:]]'),
+    CHECK (request_digest ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK ((status = 'pending' AND consumed_at IS NULL) OR (status = 'consumed' AND consumed_at IS NOT NULL))
+);
+
+CREATE OR REPLACE FUNCTION project.guard_resource_uid_registry_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, project AS $$
+BEGIN
+    IF TG_OP = 'DELETE' OR NEW.resource_uid IS DISTINCT FROM OLD.resource_uid
+       OR NEW.instance_id IS DISTINCT FROM OLD.instance_id OR NEW.project_id IS DISTINCT FROM OLD.project_id
+       OR NEW.authored_resource_id IS DISTINCT FROM OLD.authored_resource_id
+       OR NEW.resource_kind IS DISTINCT FROM OLD.resource_kind OR NEW.first_generation_id IS DISTINCT FROM OLD.first_generation_id
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'resource UID identity is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION project.reject_resource_uid_history_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, project AS $$
+BEGIN
+    RAISE EXCEPTION 'resource UID generation and tombstone evidence is immutable';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS resource_uid_registry_identity ON project.resource_uid_registry;
+CREATE TRIGGER resource_uid_registry_identity
+BEFORE UPDATE OR DELETE ON project.resource_uid_registry
+FOR EACH ROW EXECUTE FUNCTION project.guard_resource_uid_registry_mutation();
+DROP TRIGGER IF EXISTS resource_uid_generation_immutable ON project.resource_uid_generation;
+CREATE TRIGGER resource_uid_generation_immutable
+BEFORE UPDATE OR DELETE ON project.resource_uid_generation
+FOR EACH ROW EXECUTE FUNCTION project.reject_resource_uid_history_mutation();
+DROP TRIGGER IF EXISTS resource_uid_tombstone_immutable ON project.resource_uid_tombstone;
+CREATE TRIGGER resource_uid_tombstone_immutable
+BEFORE UPDATE OR DELETE ON project.resource_uid_tombstone
+FOR EACH ROW EXECUTE FUNCTION project.reject_resource_uid_history_mutation();
+
+CREATE OR REPLACE FUNCTION project.guard_resource_uid_restore_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, project AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'resource UID restore evidence is immutable';
+    END IF;
+    IF NEW.restore_id IS DISTINCT FROM OLD.restore_id OR NEW.resource_uid IS DISTINCT FROM OLD.resource_uid
+       OR NEW.instance_id IS DISTINCT FROM OLD.instance_id OR NEW.project_id IS DISTINCT FROM OLD.project_id
+       OR NEW.environment IS DISTINCT FROM OLD.environment OR NEW.target_id IS DISTINCT FROM OLD.target_id
+       OR NEW.generation_id IS DISTINCT FROM OLD.generation_id OR NEW.authored_resource_id IS DISTINCT FROM OLD.authored_resource_id
+       OR NEW.resource_kind IS DISTINCT FROM OLD.resource_kind OR NEW.actor_id IS DISTINCT FROM OLD.actor_id
+       OR NEW.request_digest IS DISTINCT FROM OLD.request_digest OR NEW.created_at IS DISTINCT FROM OLD.created_at
+       OR OLD.status <> 'pending' OR NEW.status <> 'consumed'
+       OR NEW.consumed_at IS DISTINCT FROM OLD.consumed_at THEN
+        RAISE EXCEPTION 'resource UID restore transition is invalid';
+    END IF;
+    NEW.consumed_at := clock_timestamp();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS resource_uid_restore_immutable ON project.resource_uid_restore_authorization;
+CREATE TRIGGER resource_uid_restore_immutable
+BEFORE UPDATE OR DELETE ON project.resource_uid_restore_authorization
+FOR EACH ROW EXECUTE FUNCTION project.guard_resource_uid_restore_mutation();
+
+-- The restore operation is separate from activation and creates durable,
+-- actor/request evidence. It never allocates a new UID.
+CREATE OR REPLACE FUNCTION project.authorize_resource_uid_restore(
+    p_instance_id text,
+    p_target_id text,
+    p_project_id text,
+    p_environment text,
+    p_generation_id uuid,
+    p_resource_uid uuid,
+    p_authored_resource_id text,
+    p_resource_kind text,
+    p_actor_id text,
+    p_request_digest text
+) RETURNS SETOF project.resource_uid_restore_authorization
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, project
+AS $$
+DECLARE
+    existing project.resource_uid_registry%ROWTYPE;
+    result project.resource_uid_restore_authorization%ROWTYPE;
+BEGIN
+    IF p_instance_id IS NULL OR p_instance_id <> btrim(p_instance_id) OR p_instance_id !~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'
+       OR p_target_id IS DISTINCT FROM p_instance_id OR p_project_id IS NULL OR p_project_id !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+       OR p_environment IS NULL OR p_environment <> btrim(p_environment) OR p_environment !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+       OR p_generation_id IS NULL OR p_resource_uid IS NULL OR p_authored_resource_id IS NULL
+       OR p_resource_kind IS NULL OR p_resource_kind NOT IN ('connection','source','model','semantic_model','pipeline','dashboard')
+       OR p_actor_id IS NULL OR p_actor_id <> btrim(p_actor_id) OR p_actor_id ~ '[[:cntrl:]]'
+       OR p_request_digest IS NULL OR p_request_digest !~ '^sha256:[0-9a-f]{64}$' THEN
+        RAISE EXCEPTION 'invalid resource UID restore identity';
+    END IF;
+    -- Authorize an already-admitted, not-yet-bound generation in this exact
+    -- claimed scope. Take the target lock before the registry lock, matching
+    -- activation's lock order.
+    PERFORM 1
+      FROM delivery.delivery_target t
+      JOIN delivery.delivery_generation g ON g.target_id = t.target_id
+      JOIN project.resource_uid_inventory i ON i.generation_id = g.generation_id
+       AND i.instance_id = t.target_id AND i.project_id = t.project_id
+       AND i.environment = t.environment AND i.target_id = t.target_id
+     WHERE t.target_id = p_target_id AND t.project_id = p_project_id
+       AND t.environment = p_environment AND g.generation_id = p_generation_id
+       AND EXISTS (SELECT 1 FROM platform.instance_identity ii
+                    WHERE ii.singleton_id = 1 AND ii.instance_id = p_instance_id)
+       AND EXISTS (SELECT 1 FROM platform.instance_project_claim pc
+                    WHERE pc.singleton_id = 1 AND pc.project_id = p_project_id
+                      AND pc.environment = p_environment)
+     FOR UPDATE OF t;
+    IF NOT FOUND OR EXISTS (
+        SELECT 1 FROM project.resource_uid_generation b
+         WHERE b.instance_id = p_instance_id AND b.project_id = p_project_id
+           AND b.generation_id = p_generation_id
+    ) THEN
+        RAISE EXCEPTION 'resource UID restore requires an admitted unbound generation in the claimed scope';
+    END IF;
+    SELECT * INTO existing
+      FROM project.resource_uid_registry
+     WHERE instance_id = p_instance_id AND project_id = p_project_id
+       AND resource_uid = p_resource_uid AND authored_resource_id = p_authored_resource_id
+     FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'resource UID not found';
+    END IF;
+    IF existing.resource_kind <> p_resource_kind THEN
+        RAISE EXCEPTION 'resource UID kind conflict';
+    END IF;
+    IF existing.state <> 'tombstoned' THEN
+        RAISE EXCEPTION 'resource UID is not tombstoned';
+    END IF;
+    INSERT INTO project.resource_uid_restore_authorization(
+        resource_uid, instance_id, project_id, environment, target_id,
+        generation_id, authored_resource_id, resource_kind, actor_id, request_digest
+    ) VALUES (
+        p_resource_uid, p_instance_id, p_project_id, p_environment, p_target_id,
+        p_generation_id, p_authored_resource_id, p_resource_kind, p_actor_id, p_request_digest
+    ) ON CONFLICT (instance_id, project_id, resource_uid, generation_id) DO NOTHING;
+    SELECT * INTO result
+      FROM project.resource_uid_restore_authorization
+     WHERE instance_id = p_instance_id AND project_id = p_project_id
+       AND resource_uid = p_resource_uid AND generation_id = p_generation_id
+     FOR UPDATE;
+    IF result.actor_id <> p_actor_id OR result.request_digest <> p_request_digest
+       OR result.authored_resource_id <> p_authored_resource_id OR result.resource_kind <> p_resource_kind
+       OR result.environment <> p_environment OR result.target_id <> p_target_id THEN
+        RAISE EXCEPTION 'resource UID restore authorization conflict';
+    END IF;
+    RETURN NEXT result;
+END;
+$$;
+
+-- Admission is a proof-carrying write. It accepts only a graph and inventory
+-- already attached to the exact delivery generation and serving bundle. The
+-- runtime role may execute this narrow definer, but has no registry table
+-- INSERT privilege and cannot retarget a row or alter the bundle evidence.
+CREATE OR REPLACE FUNCTION project.admit_resource_uid_inventory(
+    p_target_id text,
+    p_project_id text,
+    p_environment text,
+    p_generation_id uuid,
+    p_graph_digest text,
+    p_bundle_digest text,
+    p_graph_bytes bytea,
+    p_inventory_json jsonb
+) RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, project
+AS $$
+DECLARE
+    target_row record;
+    existing project.resource_uid_inventory%ROWTYPE;
+BEGIN
+    IF p_target_id IS NULL OR p_target_id <> btrim(p_target_id)
+       OR p_target_id !~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'
+       OR p_project_id IS NULL OR p_project_id <> btrim(p_project_id)
+       OR p_project_id !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+       OR p_environment IS NULL OR p_environment <> btrim(p_environment)
+       OR p_environment !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+       OR p_generation_id IS NULL
+       OR p_graph_digest IS NULL OR p_graph_digest !~ '^sha256:[0-9a-f]{64}$'
+       OR p_bundle_digest IS NULL OR p_bundle_digest !~ '^sha256:[0-9a-f]{64}$'
+       OR p_graph_bytes IS NULL OR octet_length(p_graph_bytes) = 0
+       OR p_inventory_json IS NULL OR jsonb_typeof(p_inventory_json) <> 'array' THEN
+        RAISE EXCEPTION 'invalid resource UID inventory proof';
+    END IF;
+    IF p_graph_digest IS DISTINCT FROM ('sha256:' || pg_catalog.encode(pg_catalog.sha256(p_graph_bytes), 'hex')) THEN
+        RAISE EXCEPTION 'resource UID graph bytes digest differs';
+    END IF;
+
+    -- This join is the admission boundary: a generation without an admitted
+    -- serving bundle, or a bundle from another target/scope, cannot acquire
+    -- registry evidence. Locking the target serializes empty inventories too.
+    SELECT t.target_id, t.project_id, t.environment,
+           g.compiled_graph_digest AS generation_graph_digest,
+           b.compiled_graph_digest AS bundle_graph_digest,
+           b.project_digest AS serving_project_digest
+      INTO target_row
+      FROM delivery.delivery_generation g
+      JOIN delivery.delivery_target t ON t.target_id = g.target_id
+      JOIN serving_state.bundle b ON b.generation_id = g.generation_id
+       AND b.project_id = t.project_id AND b.environment = t.environment
+     WHERE g.generation_id = p_generation_id
+       AND t.target_id = p_target_id AND t.project_id = p_project_id
+       AND t.environment = p_environment
+     FOR UPDATE OF t;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'resource UID generation serving bundle proof is missing';
+    END IF;
+    IF target_row.generation_graph_digest IS DISTINCT FROM p_graph_digest
+       OR target_row.bundle_graph_digest IS DISTINCT FROM p_graph_digest
+       OR target_row.serving_project_digest IS DISTINCT FROM p_bundle_digest THEN
+        RAISE EXCEPTION 'resource UID inventory lineage proof differs';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM platform.instance_identity ii
+         WHERE ii.singleton_id = 1 AND ii.instance_id = p_target_id
+    ) OR NOT EXISTS (
+        SELECT 1 FROM platform.instance_project_claim pc
+         WHERE pc.singleton_id = 1 AND pc.project_id = p_project_id
+           AND pc.environment = p_environment
+    ) THEN
+        RAISE EXCEPTION 'resource UID inventory target claim is missing';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM jsonb_array_elements(p_inventory_json) AS item(value)
+         WHERE jsonb_typeof(item.value) <> 'object'
+    ) OR EXISTS (
+        SELECT 1
+          FROM jsonb_array_elements(p_inventory_json) AS item(value)
+         GROUP BY item.value->>'authored_id'
+        HAVING item.value->>'authored_id' IS NULL OR count(*) <> 1
+    ) THEN
+        RAISE EXCEPTION 'resource UID inventory is not a complete unique object set';
+    END IF;
+    IF jsonb_typeof((convert_from(p_graph_bytes, 'UTF8'))::jsonb) <> 'object'
+       OR ((convert_from(p_graph_bytes, 'UTF8'))::jsonb)->>'version' IS DISTINCT FROM '2'
+       OR jsonb_typeof(((convert_from(p_graph_bytes, 'UTF8'))::jsonb)->'resources') <> 'array' THEN
+        RAISE EXCEPTION 'resource UID graph proof is invalid';
+    END IF;
+    IF (SELECT count(*) FROM jsonb_array_elements(((convert_from(p_graph_bytes, 'UTF8'))::jsonb)->'resources'))
+       <> jsonb_array_length(p_inventory_json) THEN
+        RAISE EXCEPTION 'resource UID inventory is not graph-complete';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+          FROM jsonb_array_elements(((convert_from(p_graph_bytes, 'UTF8'))::jsonb)->'resources') AS graph_item(value)
+         FULL OUTER JOIN jsonb_array_elements(p_inventory_json) AS inventory_item(value)
+           ON graph_item.value->>'id' = inventory_item.value->>'authored_id'
+          AND graph_item.value->>'kind' = inventory_item.value->>'kind'
+         WHERE graph_item.value IS NULL OR inventory_item.value IS NULL
+    ) THEN
+        RAISE EXCEPTION 'resource UID inventory identity set differs from graph';
+    END IF;
+
+    INSERT INTO project.resource_uid_inventory(
+        generation_id, instance_id, project_id, environment, target_id,
+        graph_digest, bundle_digest, graph_bytes, inventory_json
+    ) VALUES (
+        p_generation_id, p_target_id, p_project_id, p_environment, p_target_id,
+        p_graph_digest, p_bundle_digest, p_graph_bytes, p_inventory_json
+    ) ON CONFLICT (generation_id) DO NOTHING;
+    SELECT * INTO existing FROM project.resource_uid_inventory
+     WHERE generation_id = p_generation_id FOR UPDATE;
+    IF existing.instance_id IS DISTINCT FROM p_target_id
+       OR existing.project_id IS DISTINCT FROM p_project_id
+       OR existing.environment IS DISTINCT FROM p_environment
+       OR existing.target_id IS DISTINCT FROM p_target_id
+       OR existing.graph_digest IS DISTINCT FROM p_graph_digest
+       OR existing.bundle_digest IS DISTINCT FROM p_bundle_digest
+       OR existing.graph_bytes IS DISTINCT FROM p_graph_bytes
+       OR existing.inventory_json IS DISTINCT FROM p_inventory_json THEN
+        RAISE EXCEPTION 'resource UID inventory replay conflict';
+    END IF;
+    RETURN true;
+END;
+$$;
+
+-- Allocation is private to the delivery activation capability. The trigger
+-- invokes this function while delivery.commit_activation_transition is a
+-- SECURITY DEFINER owner transaction; no caller can supply a foreign scope
+-- or an arbitrary inventory to allocate identities.
+CREATE OR REPLACE FUNCTION project.bind_resource_uid_generation(p_generation_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, project
+AS $$
+<<binding>>
+DECLARE
+    scope record;
+    entry jsonb;
+    existing project.resource_uid_registry%ROWTYPE;
+    prior_binding project.resource_uid_generation%ROWTYPE;
+    restore_row project.resource_uid_restore_authorization%ROWTYPE;
+    authored_id text;
+    resource_kind text;
+    contract_status text;
+    contract_profile text;
+    contract_version text;
+    contract_digest text;
+    contract_bytes bytea;
+    contract_json jsonb;
+    expected_contract_kind text;
+    has_contract boolean;
+    prior_binding_found boolean;
+BEGIN
+    IF p_generation_id IS NULL OR p_generation_id = '00000000-0000-0000-0000-000000000000'::uuid THEN
+        RAISE EXCEPTION 'invalid resource UID generation';
+    END IF;
+    SELECT t.target_id, t.project_id, t.environment, g.compiled_graph_digest,
+           i.inventory_json, i.graph_digest, i.bundle_digest,
+           b.compiled_graph_digest AS serving_graph_digest,
+           b.project_digest AS serving_project_digest
+      INTO scope
+      FROM delivery.delivery_generation g
+      JOIN delivery.delivery_target t ON t.target_id = g.target_id
+      JOIN delivery.delivery_active_pointer ap
+        ON ap.target_id = t.target_id AND ap.generation_id = g.generation_id
+      JOIN delivery.delivery_publication pub
+        ON pub.publication_id = ap.publication_id
+       AND pub.generation_id = g.generation_id
+       AND pub.target_id = t.target_id
+       AND pub.state = 'committed'
+      JOIN serving_state.bundle b ON b.generation_id = g.generation_id
+       AND b.project_id = t.project_id AND b.environment = t.environment
+      JOIN project.resource_uid_inventory i
+        ON i.generation_id = g.generation_id
+       AND i.instance_id = t.target_id
+       AND i.project_id = t.project_id
+       AND i.environment = t.environment
+       AND i.target_id = t.target_id
+     WHERE g.generation_id = p_generation_id
+     FOR UPDATE OF t;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'resource UID generation or inventory proof is missing';
+    END IF;
+    IF scope.target_id !~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'
+       OR scope.graph_digest IS DISTINCT FROM scope.compiled_graph_digest
+       OR scope.serving_graph_digest IS DISTINCT FROM scope.compiled_graph_digest
+       OR scope.bundle_digest IS DISTINCT FROM scope.serving_project_digest THEN
+        RAISE EXCEPTION 'resource UID generation scope or graph proof differs';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM platform.instance_identity ii
+        WHERE ii.singleton_id = 1 AND ii.instance_id = scope.target_id
+    ) OR NOT EXISTS (
+        SELECT 1 FROM platform.instance_project_claim pc
+        WHERE pc.singleton_id = 1 AND pc.project_id = scope.project_id AND pc.environment = scope.environment
+    ) THEN
+        RAISE EXCEPTION 'resource UID generation target claim is missing';
+    END IF;
+    -- Explicitly lock the target even for an empty inventory so concurrent
+    -- removal/reconciliation passes serialize on the same scope fence.
+    PERFORM 1 FROM delivery.delivery_target t
+     WHERE t.target_id = scope.target_id AND t.project_id = scope.project_id AND t.environment = scope.environment
+     FOR UPDATE;
+
+    IF EXISTS (
+        SELECT 1
+          FROM jsonb_array_elements(scope.inventory_json) AS item(value)
+         GROUP BY item.value->>'authored_id'
+        HAVING item.value->>'authored_id' IS NULL OR count(*) <> 1
+    ) THEN
+        RAISE EXCEPTION 'resource UID inventory contains duplicate or missing authored IDs';
+    END IF;
+
+    FOR entry IN SELECT value FROM jsonb_array_elements(scope.inventory_json) LOOP
+        restore_row := NULL;
+        IF jsonb_typeof(entry) <> 'object' THEN
+            RAISE EXCEPTION 'resource UID inventory entry is not an object';
+        END IF;
+        IF EXISTS (
+            SELECT 1
+              FROM jsonb_object_keys(entry) AS key(name)
+             WHERE key.name NOT IN ('authored_id', 'kind', 'contract_status',
+                                    'contract_profile', 'contract_version',
+                                    'canonical_contract', 'contract_digest')
+        ) THEN
+            RAISE EXCEPTION 'resource UID inventory entry contains unsupported fields';
+        END IF;
+        authored_id := entry->>'authored_id';
+        resource_kind := entry->>'kind';
+        contract_status := entry->>'contract_status';
+        contract_profile := NULLIF(entry->>'contract_profile', '');
+        contract_digest := NULLIF(entry->>'contract_digest', '');
+        contract_version := NULLIF(entry->>'contract_version', '');
+        contract_bytes := NULL;
+        contract_json := NULL;
+        IF entry ? 'canonical_contract' AND entry->'canonical_contract' <> 'null'::jsonb THEN
+            IF jsonb_typeof(entry->'canonical_contract') <> 'string' THEN
+                RAISE EXCEPTION 'resource UID canonical contract must retain exact JSON bytes as a string';
+            END IF;
+            contract_bytes := convert_to(entry->>'canonical_contract', 'UTF8');
+            contract_json := (entry->>'canonical_contract')::jsonb;
+        END IF;
+        has_contract := contract_profile IS NOT NULL OR contract_digest IS NOT NULL OR contract_version IS NOT NULL OR contract_bytes IS NOT NULL;
+        IF authored_id IS NULL OR authored_id <> btrim(authored_id) OR authored_id !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+           OR resource_kind IS NULL OR resource_kind NOT IN ('connection','source','model','semantic_model','pipeline','dashboard')
+           OR contract_status IS NULL OR contract_status NOT IN ('canonical','unversioned','not_contract_bearing') THEN
+            RAISE EXCEPTION 'invalid resource UID inventory entry';
+        END IF;
+        IF contract_status = 'canonical' THEN
+            expected_contract_kind := CASE resource_kind
+                WHEN 'source' THEN 'Source'
+                WHEN 'model' THEN 'Model'
+                WHEN 'semantic_model' THEN 'SemanticModel'
+                ELSE NULL
+            END;
+            IF expected_contract_kind IS NULL OR contract_profile IS DISTINCT FROM 'leapview.contract/v1'
+               OR contract_version IS NULL OR contract_digest IS NULL OR contract_bytes IS NULL
+               OR contract_digest !~ '^sha256:[0-9a-f]{64}$'
+               OR jsonb_typeof(contract_json) <> 'object'
+               OR contract_json->>'profile' IS DISTINCT FROM contract_profile
+               OR contract_json->>'apiVersion' IS DISTINCT FROM 'leapview.dev/v1'
+               OR contract_json->>'kind' IS DISTINCT FROM expected_contract_kind
+               OR contract_json->'metadata'->>'id' IS DISTINCT FROM authored_id
+               OR contract_json->'metadata'->'contract'->>'version' IS DISTINCT FROM contract_version
+               OR contract_digest IS DISTINCT FROM ('sha256:' || pg_catalog.encode(pg_catalog.sha256(contract_bytes), 'hex')) THEN
+                RAISE EXCEPTION 'resource UID canonical contract evidence is incomplete';
+            END IF;
+        ELSIF contract_status = 'unversioned' THEN
+            IF resource_kind NOT IN ('source','model','semantic_model') OR has_contract THEN
+                RAISE EXCEPTION 'resource UID unversioned status is invalid';
+            END IF;
+        ELSIF contract_status = 'not_contract_bearing' THEN
+            IF resource_kind NOT IN ('connection','pipeline','dashboard') OR has_contract THEN
+                RAISE EXCEPTION 'resource UID non-contract-bearing status is invalid';
+            END IF;
+        END IF;
+        SELECT * INTO existing
+          FROM project.resource_uid_registry r
+         WHERE r.instance_id = scope.target_id AND r.project_id = scope.project_id
+           AND r.authored_resource_id = authored_id
+         FOR UPDATE;
+        IF NOT FOUND THEN
+            INSERT INTO project.resource_uid_registry(
+                instance_id, project_id, authored_resource_id, resource_kind,
+                first_generation_id, latest_generation_id, current_generation_id
+            ) VALUES (scope.target_id, scope.project_id, authored_id, resource_kind,
+                      p_generation_id, p_generation_id, p_generation_id)
+            RETURNING * INTO existing;
+        ELSIF existing.resource_kind <> resource_kind THEN
+            RAISE EXCEPTION 'resource UID kind conflict for %', authored_id;
+        END IF;
+
+        SELECT * INTO prior_binding
+          FROM project.resource_uid_generation b
+         WHERE b.instance_id = scope.target_id AND b.project_id = scope.project_id
+           AND b.generation_id = p_generation_id AND b.authored_resource_id = authored_id
+         FOR UPDATE;
+        prior_binding_found := FOUND;
+        IF prior_binding_found THEN
+            IF prior_binding.resource_uid <> existing.resource_uid OR prior_binding.resource_kind <> resource_kind
+               OR prior_binding.environment <> scope.environment OR prior_binding.target_id <> scope.target_id
+               OR prior_binding.contract_status IS DISTINCT FROM contract_status
+               OR prior_binding.contract_profile IS DISTINCT FROM contract_profile
+               OR prior_binding.contract_version IS DISTINCT FROM contract_version
+               OR prior_binding.contract_digest IS DISTINCT FROM contract_digest
+               OR prior_binding.contract_bytes IS DISTINCT FROM contract_bytes THEN
+                RAISE EXCEPTION 'resource UID generation binding conflict for %', authored_id;
+            END IF;
+        END IF;
+
+        IF existing.state = 'tombstoned' THEN
+            -- Re-activating an exact historical generation is rollback-safe:
+            -- its immutable binding is already the authority and does not
+            -- need a new restore request. A new generation requires explicit
+            -- audited authorization for this exact UID and generation.
+            IF NOT prior_binding_found THEN
+                SELECT ra.* INTO restore_row
+                  FROM project.resource_uid_restore_authorization ra
+                 WHERE ra.instance_id = scope.target_id AND ra.project_id = scope.project_id
+                   AND ra.target_id = scope.target_id AND ra.environment = scope.environment
+                   AND ra.generation_id = p_generation_id AND ra.resource_uid = existing.resource_uid
+                   AND ra.authored_resource_id = authored_id AND ra.resource_kind = binding.resource_kind
+                   AND ra.status = 'pending'
+                 FOR UPDATE;
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION 'resource UID restore authorization required for %', authored_id;
+                END IF;
+            END IF;
+            UPDATE project.resource_uid_registry
+               SET state = 'active', latest_generation_id = p_generation_id,
+                   current_generation_id = p_generation_id, removed_in_generation_id = NULL,
+                   updated_at = clock_timestamp()
+             WHERE resource_uid = existing.resource_uid;
+            IF restore_row.restore_id IS NOT NULL THEN
+                UPDATE project.resource_uid_restore_authorization
+                   SET status = 'consumed'
+                 WHERE restore_id = restore_row.restore_id;
+            END IF;
+        ELSIF existing.latest_generation_id IS DISTINCT FROM p_generation_id
+           OR existing.current_generation_id IS DISTINCT FROM p_generation_id THEN
+            UPDATE project.resource_uid_registry
+               SET latest_generation_id = p_generation_id,
+                   current_generation_id = p_generation_id,
+                   updated_at = clock_timestamp()
+             WHERE resource_uid = existing.resource_uid;
+        END IF;
+
+        IF NOT prior_binding_found THEN
+            INSERT INTO project.resource_uid_generation(
+                resource_uid, instance_id, project_id, environment, target_id,
+                generation_id, authored_resource_id, resource_kind, contract_status,
+                contract_profile, contract_version, contract_digest, contract_bytes
+            ) VALUES (
+                existing.resource_uid, scope.target_id, scope.project_id, scope.environment, scope.target_id,
+                p_generation_id, authored_id, resource_kind, contract_status,
+                contract_profile, contract_version, contract_digest, contract_bytes
+            );
+        END IF;
+    END LOOP;
+
+    FOR existing IN
+        SELECT * FROM project.resource_uid_registry r
+         WHERE r.instance_id = scope.target_id AND r.project_id = scope.project_id AND r.state = 'active'
+         FOR UPDATE
+    LOOP
+        IF existing.current_generation_id IS DISTINCT FROM p_generation_id
+           AND NOT EXISTS (
+               SELECT 1 FROM jsonb_array_elements(scope.inventory_json) AS item(value)
+               WHERE item.value->>'authored_id' = existing.authored_resource_id
+           ) THEN
+            UPDATE project.resource_uid_registry
+               SET state = 'tombstoned', latest_generation_id = p_generation_id,
+                   current_generation_id = NULL, removed_in_generation_id = p_generation_id,
+                   updated_at = clock_timestamp()
+             WHERE resource_uid = existing.resource_uid;
+            INSERT INTO project.resource_uid_tombstone(
+                instance_id, project_id, resource_uid, authored_resource_id, resource_kind, removed_in_generation_id
+            ) VALUES (scope.target_id, scope.project_id, existing.resource_uid, existing.authored_resource_id, existing.resource_kind, p_generation_id)
+            ON CONFLICT DO NOTHING;
+        END IF;
+    END LOOP;
+    RETURN true;
+END;
+$$;
+
+-- The only allocation trigger is attached to the authoritative publication
+-- commit. delivery.commit_activation_transition is SECURITY DEFINER and
+-- performs this update in the same caller-owned transaction as the pointer
+-- CAS; a failed bind therefore rolls back the activation and leaks no UID.
+CREATE OR REPLACE FUNCTION project.bind_resource_uid_on_publication_commit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, project
+AS $$
+BEGIN
+    IF NEW.state = 'committed' AND OLD.state IS DISTINCT FROM NEW.state THEN
+        PERFORM project.bind_resource_uid_generation(NEW.generation_id);
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS resource_uid_bind_on_publication_commit ON delivery.delivery_publication;
+CREATE TRIGGER resource_uid_bind_on_publication_commit
+AFTER UPDATE OF state ON delivery.delivery_publication
+FOR EACH ROW
+WHEN (NEW.state = 'committed' AND OLD.state IS DISTINCT FROM NEW.state)
+EXECUTE FUNCTION project.bind_resource_uid_on_publication_commit();
+
+REVOKE ALL ON TABLE project.resource_uid_registry, project.resource_uid_generation,
+    project.resource_uid_inventory, project.resource_uid_tombstone,
+    project.resource_uid_restore_authorization FROM PUBLIC;
+REVOKE ALL ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb),
+    project.bind_resource_uid_generation(uuid),
+    project.bind_resource_uid_on_publication_commit(),
+    project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text),
+    project.guard_resource_uid_restore_mutation(),
+    project.reject_resource_uid_inventory_mutation() FROM PUBLIC;
+DO $$
+DECLARE role_name text;
+BEGIN
+    FOREACH role_name IN ARRAY ARRAY['leapview_control_owner','leapview_control_migrator','leapview_control_runtime','leapview_control_readonly','leapview_control_backup'] LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+            EXECUTE format('GRANT USAGE ON SCHEMA project TO %I', role_name);
+            IF role_name IN ('leapview_control_owner','leapview_control_migrator') THEN
+                EXECUTE format('GRANT ALL ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO %I', role_name);
+                -- The binder is reached only by the delivery activation
+                -- trigger. Do not grant it as a callable repository API.
+                EXECUTE format('GRANT EXECUTE ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb), project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text) TO %I', role_name);
+            ELSIF role_name = 'leapview_control_runtime' THEN
+                EXECUTE 'GRANT EXECUTE ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb) TO leapview_control_runtime';
+                EXECUTE 'GRANT SELECT ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO leapview_control_runtime';
+            ELSE
+                EXECUTE format('GRANT SELECT ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO %I', role_name);
+            END IF;
+        END IF;
+    END LOOP;
+END
+$$;
+
+RESET ROLE;
+-- +goose StatementEnd

--- a/internal/platform/postgres/migrations/conformance_test.go
+++ b/internal/platform/postgres/migrations/conformance_test.go
@@ -3,6 +3,7 @@ package migrations_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/flidai/leapview/internal/platform/postgres/postgrestest"
 	"github.com/flidai/leapview/internal/recoveryset"
 	recoverypostgres "github.com/flidai/leapview/internal/recoveryset/postgres"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
@@ -339,6 +341,34 @@ func TestBaselinePostgreSQL18(t *testing.T) {
 	if _, err := runtimeConn.Exec(ctx, `SET ROLE leapview_control_runtime`); err != nil {
 		t.Fatal(err)
 	}
+	t.Run("ResourceUID runtime is read and admission only", func(t *testing.T) {
+		for _, table := range []string{"resource_uid_registry", "resource_uid_generation", "resource_uid_inventory", "resource_uid_tombstone", "resource_uid_restore_authorization"} {
+			if _, err := runtimeConn.Exec(ctx, "SELECT * FROM project."+table+" LIMIT 0"); err != nil {
+				t.Fatalf("runtime read %s: %v", table, err)
+			}
+			for _, statement := range []string{"INSERT INTO project." + table + " DEFAULT VALUES", "DELETE FROM project." + table, "TRUNCATE project." + table} {
+				_, err := runtimeConn.Exec(ctx, statement)
+				var denied *pgconn.PgError
+				if !errors.As(err, &denied) || denied.Code != "42501" {
+					t.Fatalf("runtime mutation must fail for privilege denial: %s: %v", statement, err)
+				}
+			}
+		}
+		for _, statement := range []string{
+			"SELECT project.bind_resource_uid_generation(NULL)",
+			"SELECT project.authorize_resource_uid_restore(NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL)",
+		} {
+			_, err := runtimeConn.Exec(ctx, statement)
+			var denied *pgconn.PgError
+			if !errors.As(err, &denied) || denied.Code != "42501" {
+				t.Fatalf("runtime authority must fail for privilege denial: %s: %v", statement, err)
+			}
+		}
+		var canAdmit bool
+		if err := runtimeConn.QueryRow(ctx, `SELECT has_function_privilege(current_user, 'project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb)', 'EXECUTE')`).Scan(&canAdmit); err != nil || !canAdmit {
+			t.Fatalf("runtime inventory admission capability missing: allowed=%t error=%v", canAdmit, err)
+		}
+	})
 	var lockedTarget, lockedKind, lockedState string
 	if err := runtimeConn.QueryRow(ctx, `SELECT target_id,root_kind,state FROM delivery.lock_retention_root($1::uuid)`, retentionLockRoot).Scan(&lockedTarget, &lockedKind, &lockedState); err != nil {
 		t.Fatalf("runtime retention-root lock capability: %v", err)

--- a/internal/platform/postgres/migrations/goose.go
+++ b/internal/platform/postgres/migrations/goose.go
@@ -25,7 +25,7 @@ const (
 	// CurrentRevision is the latest control-plane schema revision understood by
 	// this binary. Serving admission requires every embedded migration through
 	// this revision to be applied.
-	CurrentRevision int64 = 4
+	CurrentRevision int64 = 5
 	// AdvisoryLockKey serializes migration attempts across instances. Goose
 	// owns acquisition and release of this session-level PostgreSQL lock. The
 	// combined River+Goose path below uses the same key for one shared fence.

--- a/internal/platform/postgres/migrations/migrations_test.go
+++ b/internal/platform/postgres/migrations/migrations_test.go
@@ -25,7 +25,7 @@ func TestEmbeddedGooseBaselineIsImmutableAndForwardMigrationsAreOrdered(t *testi
 			sqlFiles = append(sqlFiles, entry.Name())
 		}
 	}
-	if got, want := strings.Join(sqlFiles, ","), "001_control_plane.sql,002_project_free_source_bundle.sql,003_dashboard_authoring_runtime_lock.sql,004_dashboard_authoring_capability_evidence.sql"; got != want {
+	if got, want := strings.Join(sqlFiles, ","), "001_control_plane.sql,002_project_free_source_bundle.sql,003_dashboard_authoring_runtime_lock.sql,004_dashboard_authoring_capability_evidence.sql,005_resource_uid_registry.sql"; got != want {
 		t.Fatalf("embedded Goose migrations = %v", sqlFiles)
 	}
 	contents, err := fs.ReadFile(MigrationFS(), "001_control_plane.sql")

--- a/internal/platform/postgres/migrations/resource_uid_test.go
+++ b/internal/platform/postgres/migrations/resource_uid_test.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	projectpostgres "github.com/flidai/leapview/internal/project/postgres"
+)
+
+func TestResourceUIDForwardMigrationMatchesCapability(t *testing.T) {
+	contents, err := fs.ReadFile(MigrationFS(), "005_resource_uid_registry.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "-- +goose Up\n-- +goose StatementBegin\nSET LOCAL ROLE leapview_control_owner;\n\n" +
+		strings.TrimSpace(projectpostgres.ResourceUIDSchemaSQL()) +
+		"\n\nRESET ROLE;\n-- +goose StatementEnd\n"
+	if string(contents) != want {
+		t.Fatal("ResourceUID migration differs from reviewed capability schema")
+	}
+	if CurrentRevision != 5 {
+		t.Fatalf("current schema revision = %d, want 5", CurrentRevision)
+	}
+}

--- a/internal/project/compiler/project_authoring.go
+++ b/internal/project/compiler/project_authoring.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	projectcontracts "github.com/flidai/leapview/internal/project/contracts"
 	"gopkg.in/yaml.v3"
 )
 
@@ -23,7 +24,10 @@ type metadata struct {
 	Tags          []string `yaml:"tags"`
 	Domain        string   `yaml:"domain"`
 	Documentation string   `yaml:"documentation"`
-	Provenance    struct {
+	// Generated per-kind validation owns whether contract metadata is allowed.
+	// Retain that accepted field while reading the common discovery envelope.
+	Contract   *projectcontracts.ContractMetadata `yaml:"contract"`
+	Provenance struct {
 		Origin string `yaml:"origin"`
 		Path   string `yaml:"path"`
 		Source string `yaml:"source"`

--- a/internal/project/compiler/project_contract_metadata_test.go
+++ b/internal/project/compiler/project_contract_metadata_test.go
@@ -1,0 +1,36 @@
+package compiler
+
+import "testing"
+
+// The discovery envelope must preserve generated contract metadata, not
+// reject it before canonical inventory construction or admit it on other kinds.
+func TestSourceRootContractMetadataUsesGeneratedKindAuthority(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		kind      string
+		metadata  string
+		wantError bool
+	}{
+		{"versioned source", "source", ", contract: {version: 1.0.0, compatibility: backward}", false},
+		{"malformed version", "source", ", contract: {version: bogus, compatibility: backward}", true},
+		{"unknown compatibility", "source", ", contract: {version: 1.0.0, compatibility: permissive}", true},
+		{"connection is not contract bearing", "connection", ", contract: {version: 1.0.0, compatibility: backward}", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			connectionMetadata, sourceMetadata := "", ""
+			if tc.kind == "connection" {
+				connectionMetadata = tc.metadata
+			} else {
+				sourceMetadata = tc.metadata
+			}
+			files := map[string]string{
+				"connections/warehouse.yaml": "apiVersion: leapview.dev/v1\nkind: Connection\nmetadata: {id: connection:warehouse, name: warehouse" + connectionMetadata + "}\nspec: {type: managed}\n",
+				"sources/orders.yaml":        "apiVersion: leapview.dev/v1\nkind: Source\nmetadata: {id: source:orders, name: orders" + sourceMetadata + "}\nspec: {connection: warehouse, location: {type: path, path: orders.csv, format: csv}}\n",
+			}
+			_, err := Compile(writeSourceFixture(t, files))
+			if (err != nil) != tc.wantError {
+				t.Fatalf("Compile error=%v, wantError=%t", err, tc.wantError)
+			}
+		})
+	}
+}

--- a/internal/project/postgres/queries/resource_uid.sql
+++ b/internal/project/postgres/queries/resource_uid.sql
@@ -1,0 +1,63 @@
+-- Resource UID reads are always qualified by the claimed instance and
+-- Project. There is intentionally no global UID lookup or standalone
+-- allocator query.
+
+-- name: GetResourceUIDByAuthoredID :one
+SELECT resource_uid, instance_id, project_id, authored_resource_id, resource_kind,
+       state, first_generation_id, latest_generation_id, current_generation_id,
+       removed_in_generation_id, created_at, updated_at
+FROM project.resource_uid_registry
+WHERE instance_id = $1 AND project_id = $2 AND authored_resource_id = $3;
+
+-- name: GetResourceUIDByUID :one
+SELECT resource_uid, instance_id, project_id, authored_resource_id, resource_kind,
+       state, first_generation_id, latest_generation_id, current_generation_id,
+       removed_in_generation_id, created_at, updated_at
+FROM project.resource_uid_registry
+WHERE instance_id = $1 AND project_id = $2 AND resource_uid = $3;
+
+-- name: ListGenerationResourceUIDs :many
+SELECT resource_uid, instance_id, project_id, environment, target_id,
+       generation_id, authored_resource_id, resource_kind,
+       contract_status, contract_profile, contract_version, contract_digest, contract_bytes, bound_at
+FROM project.resource_uid_generation
+WHERE instance_id = $1 AND project_id = $2 AND generation_id = $3
+ORDER BY authored_resource_id;
+
+-- Admission retains the complete compiler-sealed inventory. It allocates no
+-- UID; allocation is private to the activation transition trigger. The
+-- definer validates the inventory against the already-admitted bundle before
+-- writing, so runtime has no table INSERT capability.
+-- name: AdmitResourceUIDInventory :one
+SELECT project.admit_resource_uid_inventory(
+    sqlc.arg(target_id)::text,
+    sqlc.arg(project_id)::text,
+    sqlc.arg(environment)::text,
+    sqlc.arg(generation_id)::uuid,
+    sqlc.arg(graph_digest)::text,
+    sqlc.arg(bundle_digest)::text,
+    sqlc.arg(graph_bytes)::bytea,
+    sqlc.arg(inventory_json)::jsonb
+) AS admitted;
+
+-- name: GetResourceUIDInventory :one
+SELECT generation_id, instance_id, project_id, environment, target_id,
+       graph_digest, bundle_digest, inventory_json, created_at
+FROM project.resource_uid_inventory
+WHERE instance_id = $1 AND project_id = $2 AND generation_id = $3;
+
+-- Restore is a separate audited authority operation; activation consumes its
+-- pending row only for the exact generation and resource identity.
+-- name: AuthorizeResourceUIDRestore :one
+SELECT * FROM project.authorize_resource_uid_restore(
+    sqlc.arg(instance_id)::text,
+    sqlc.arg(target_id)::text,
+    sqlc.arg(project_id)::text,
+    sqlc.arg(environment)::text,
+    sqlc.arg(generation_id)::uuid,
+    sqlc.arg(resource_uid)::uuid,
+    sqlc.arg(authored_resource_id)::text,
+    sqlc.arg(resource_kind)::text,
+    sqlc.arg(actor_id)::text,
+    sqlc.arg(request_digest)::text
+);

--- a/internal/project/postgres/repository.go
+++ b/internal/project/postgres/repository.go
@@ -78,6 +78,14 @@ type Repository struct{ db DBTX }
 //go:embed schema.sql
 var schemaSQL string
 
+//go:embed resource_uid_schema.sql
+var resourceUIDSchemaSQL string
+
+// ResourceUIDSchemaSQL is the additive registry capability schema. It is
+// installed after bootstrap, delivery, and serving-state schemas; the immutable
+// baseline project schema is deliberately unchanged.
+func ResourceUIDSchemaSQL() string { return resourceUIDSchemaSQL }
+
 // SchemaSQL returns the capability-owned schema without transaction control.
 func SchemaSQL() string { return schemaSQL }
 

--- a/internal/project/postgres/resource_uid.go
+++ b/internal/project/postgres/resource_uid.go
@@ -1,0 +1,267 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/flidai/leapview/internal/platform/instanceidentity"
+	project "github.com/flidai/leapview/internal/project"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectdb "github.com/flidai/leapview/internal/project/postgres/internal/db"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// ResourceUIDActivation identifies the exact target scope admitted by one
+// activation. Resource UID allocation is intentionally not exposed here.
+type ResourceUIDActivation struct {
+	InstanceID   string
+	TargetID     string
+	ProjectID    string
+	Environment  string
+	GenerationID string
+}
+
+// ResourceUIDRestoreInput is audited authority for restoring one tombstoned
+// authored ID into one exact, not-yet-bound generation.
+type ResourceUIDRestoreInput struct {
+	ResourceUIDActivation
+	ResourceUID   project.ResourceUID
+	AuthoredID    string
+	Kind          projectgraph.Kind
+	ActorID       string
+	RequestDigest string
+}
+
+// AdmitResourceUIDInventoryTx admits a compiler-sealed inventory through the
+// caller-owned admission transaction. The inventory exposes only canonical
+// JSON, preventing callers from manufacturing individual UID allocations.
+func (r *Repository) AdmitResourceUIDInventoryTx(ctx context.Context, tx pgx.Tx, targetID, projectID, environment, generationID string, inventory project.ResourceUIDInventory) error {
+	if tx == nil || r == nil {
+		return project.ErrInvalidResourceUID
+	}
+	if !validActivationScope(targetID, targetID, projectID, environment, generationID) {
+		return project.ErrInvalidResourceUID
+	}
+	encoded, err := inventory.JSON()
+	if err != nil {
+		return err
+	}
+	if !json.Valid(encoded) {
+		return project.ErrInvalidResourceUID
+	}
+	if inventory.GraphDigest() == "" || inventory.BundleDigest() == "" {
+		return project.ErrInvalidResourceUID
+	}
+	q := projectdb.New(tx)
+	admitted, err := q.AdmitResourceUIDInventory(ctx, projectdb.AdmitResourceUIDInventoryParams{
+		TargetID: targetID, ProjectID: projectID, Environment: environment,
+		GenerationID: dbUUID(parseUUID(generationID)), GraphDigest: inventory.GraphDigest(),
+		BundleDigest: inventory.BundleDigest(), GraphBytes: inventory.GraphCanonicalBytes(), InventoryJson: encoded,
+	})
+	if err != nil {
+		return mapResourceUIDError(err)
+	}
+	if !admitted {
+		return project.ErrResourceUIDConflict
+	}
+	return nil
+}
+
+// ResolveResourceUID resolves an authored ID only inside the caller's
+// instance/project scope. There is deliberately no unscoped read.
+func (r *Repository) ResolveResourceUID(ctx context.Context, instanceID, projectID, authoredID string) (project.ResourceUIDRecord, error) {
+	if r == nil || r.db == nil || !resourceUIDScopeValid(instanceID, projectID) || !authoredResourceIDValid(authoredID) {
+		return project.ResourceUIDRecord{}, project.ErrInvalidResourceUID
+	}
+	row, err := projectdb.New(r.db).GetResourceUIDByAuthoredID(ctx, projectdb.GetResourceUIDByAuthoredIDParams{InstanceID: instanceID, ProjectID: projectID, AuthoredResourceID: authoredID})
+	if err != nil {
+		return project.ResourceUIDRecord{}, mapResourceUIDError(err)
+	}
+	return resourceUIDRecord(row)
+}
+
+// ResolveResourceUIDByUID is still scope-qualified: possession of an opaque
+// UID is never a capability and cannot disclose another Project's record.
+func (r *Repository) ResolveResourceUIDByUID(ctx context.Context, instanceID, projectID string, uid project.ResourceUID) (project.ResourceUIDRecord, error) {
+	parsed, err := project.ParseResourceUID(uid.String())
+	if r == nil || r.db == nil || !resourceUIDScopeValid(instanceID, projectID) || err != nil {
+		return project.ResourceUIDRecord{}, project.ErrInvalidResourceUID
+	}
+	uuidValue, _ := uuid.Parse(parsed.String())
+	row, err := projectdb.New(r.db).GetResourceUIDByUID(ctx, projectdb.GetResourceUIDByUIDParams{InstanceID: instanceID, ProjectID: projectID, ResourceUid: dbUUID(uuidValue)})
+	if err != nil {
+		return project.ResourceUIDRecord{}, mapResourceUIDError(err)
+	}
+	return resourceUIDRecord(row)
+}
+
+// ListGenerationResourceUIDs returns immutable, scope-qualified evidence for
+// diagnostics and rollback.
+func (r *Repository) ListGenerationResourceUIDs(ctx context.Context, instanceID, projectID, generationID string) ([]project.ResourceUIDBinding, error) {
+	if r == nil || r.db == nil || !resourceUIDScopeValid(instanceID, projectID) || !canonicalUUID(generationID) {
+		return nil, project.ErrInvalidResourceUID
+	}
+	uuidValue, _ := uuid.Parse(generationID)
+	rows, err := projectdb.New(r.db).ListGenerationResourceUIDs(ctx, projectdb.ListGenerationResourceUIDsParams{InstanceID: instanceID, ProjectID: projectID, GenerationID: dbUUID(uuidValue)})
+	if err != nil {
+		return nil, mapResourceUIDError(err)
+	}
+	out := make([]project.ResourceUIDBinding, len(rows))
+	for i, row := range rows {
+		out[i], err = resourceUIDBinding(row.ResourceUid, row.InstanceID, row.ProjectID, row.Environment, row.TargetID, row.GenerationID, row.AuthoredResourceID, row.ResourceKind, row.ContractStatus, textFromDB(row.ContractProfile), textFromDB(row.ContractVersion), textFromDB(row.ContractDigest), row.ContractBytes, row.BoundAt)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// AuthorizeResourceUIDRestore records explicit audited restore evidence.
+func (r *Repository) AuthorizeResourceUIDRestore(ctx context.Context, input ResourceUIDRestoreInput) (project.ResourceUIDRestoreAuthorization, error) {
+	if r == nil || r.db == nil {
+		return project.ResourceUIDRestoreAuthorization{}, project.ErrInvalidResourceUID
+	}
+	return authorizeResourceUIDRestore(ctx, r.db, input)
+}
+
+// AuthorizeResourceUIDRestoreTx is the caller-owned transaction form.
+func (r *Repository) AuthorizeResourceUIDRestoreTx(ctx context.Context, tx Tx, input ResourceUIDRestoreInput) (project.ResourceUIDRestoreAuthorization, error) {
+	if tx == nil {
+		return project.ResourceUIDRestoreAuthorization{}, project.ErrInvalidResourceUID
+	}
+	return authorizeResourceUIDRestore(ctx, tx, input)
+}
+
+func authorizeResourceUIDRestore(ctx context.Context, db DBTX, input ResourceUIDRestoreInput) (project.ResourceUIDRestoreAuthorization, error) {
+	if db == nil || !validActivationScope(input.InstanceID, input.TargetID, input.ProjectID, input.Environment, input.GenerationID) ||
+		input.ResourceUID.Validate() != nil || !authoredResourceIDValid(input.AuthoredID) || !authoredKindValid(input.Kind) ||
+		!validActorID(input.ActorID) || !resourceUIDDigestValid(input.RequestDigest) {
+		return project.ResourceUIDRestoreAuthorization{}, project.ErrInvalidResourceUID
+	}
+	resourceID, _ := uuid.Parse(input.ResourceUID.String())
+	row, err := projectdb.New(db).AuthorizeResourceUIDRestore(ctx, projectdb.AuthorizeResourceUIDRestoreParams{
+		InstanceID: input.InstanceID, TargetID: input.TargetID, ProjectID: input.ProjectID, Environment: input.Environment,
+		GenerationID: dbUUID(parseUUID(input.GenerationID)), ResourceUid: dbUUID(resourceID), AuthoredResourceID: input.AuthoredID,
+		ResourceKind: string(input.Kind), ActorID: input.ActorID, RequestDigest: input.RequestDigest,
+	})
+	if err != nil {
+		return project.ResourceUIDRestoreAuthorization{}, mapResourceUIDError(err)
+	}
+	return resourceUIDRestore(row)
+}
+
+func resourceUIDBinding(uid pgtype.UUID, instanceID, projectID, environment, targetID string, generationID pgtype.UUID, authoredID, kind, status, profile, version, digest string, bytes []byte, boundAt pgtype.Timestamptz) (project.ResourceUIDBinding, error) {
+	binding := project.ResourceUIDBinding{ResourceUID: project.ResourceUID(uuidFromDB(uid).String()), InstanceID: instanceID, ProjectID: projectID, Environment: environment, TargetID: targetID, GenerationID: uuidFromDB(generationID).String(), AuthoredID: authoredID, Kind: projectgraph.Kind(kind), ContractStatus: status, ContractProfile: profile, ContractVersion: version, ContractDigest: digest, ContractBytes: append([]byte(nil), bytes...), BoundAt: boundAt.Time}
+	if err := binding.Validate(); err != nil {
+		return project.ResourceUIDBinding{}, err
+	}
+	return binding, nil
+}
+
+func textFromDB(value pgtype.Text) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.String
+}
+
+func resourceUIDRecord(row projectdb.ProjectResourceUidRegistry) (project.ResourceUIDRecord, error) {
+	record := project.ResourceUIDRecord{UID: project.ResourceUID(uuidFromDB(row.ResourceUid).String()), InstanceID: row.InstanceID, ProjectID: row.ProjectID, AuthoredID: row.AuthoredResourceID, Kind: projectgraph.Kind(row.ResourceKind), State: project.ResourceUIDState(row.State), FirstGeneration: uuidFromDB(row.FirstGenerationID).String(), LatestGeneration: uuidFromDB(row.LatestGenerationID).String(), CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time}
+	if row.CurrentGenerationID.Valid {
+		record.CurrentGeneration = uuidFromDB(row.CurrentGenerationID).String()
+	}
+	if row.RemovedInGenerationID.Valid {
+		record.RemovedInGeneration = uuidFromDB(row.RemovedInGenerationID).String()
+	}
+	return record, record.Validate()
+}
+
+func resourceUIDRestore(row projectdb.ProjectResourceUidRestoreAuthorization) (project.ResourceUIDRestoreAuthorization, error) {
+	restore := project.ResourceUIDRestoreAuthorization{RestoreID: uuidFromDB(row.RestoreID).String(), ResourceUID: project.ResourceUID(uuidFromDB(row.ResourceUid).String()), InstanceID: row.InstanceID, ProjectID: row.ProjectID, AuthoredID: row.AuthoredResourceID, Kind: projectgraph.Kind(row.ResourceKind), Environment: row.Environment, TargetID: row.TargetID, GenerationID: uuidFromDB(row.GenerationID).String(), ActorID: row.ActorID, RequestDigest: row.RequestDigest, Status: row.Status, CreatedAt: row.CreatedAt.Time}
+	if row.ConsumedAt.Valid {
+		restore.ConsumedAt = row.ConsumedAt.Time
+	}
+	if err := restore.Validate(); err != nil {
+		return project.ResourceUIDRestoreAuthorization{}, err
+	}
+	return restore, nil
+}
+
+func validActivationScope(instanceID, targetID, projectID, environment, generationID string) bool {
+	return instanceidentityValid(instanceID) && instanceID == targetID && boundedResourceID(projectID) && boundedResourceText(environment) && projectgraph.ValidateServingEnvironment(environment) == nil && canonicalUUID(generationID)
+}
+
+func instanceidentityValid(value string) bool {
+	return instanceidentity.Valid(value)
+}
+
+func resourceUIDScopeValid(instanceID, projectID string) bool {
+	return instanceidentityValid(instanceID) && boundedResourceID(projectID)
+}
+
+func boundedResourceText(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) && len(value) <= 255 && !strings.ContainsAny(value, "\x00\r\n")
+}
+
+func boundedResourceID(value string) bool {
+	return boundedResourceText(value) && projectgraph.ResourceID(value).Valid()
+}
+
+func authoredResourceIDValid(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) &&
+		!strings.ContainsAny(value, "\x00\r\n") && projectgraph.ResourceID(value).Valid()
+}
+
+func authoredKindValid(kind projectgraph.Kind) bool {
+	switch kind {
+	case projectgraph.KindConnection, projectgraph.KindSource, projectgraph.KindModel, projectgraph.KindSemanticModel, projectgraph.KindPipeline, projectgraph.KindDashboard:
+		return true
+	default:
+		return false
+	}
+}
+
+func validActorID(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) && len(value) <= 255 && unicode.IsPrint([]rune(value)[0]) && strings.IndexFunc(value, unicode.IsControl) < 0
+}
+
+func resourceUIDDigestValid(value string) bool {
+	return len(value) == len("sha256:")+64 && strings.HasPrefix(value, "sha256:") && strings.Trim(value[len("sha256:"):], "0123456789abcdef") == ""
+}
+
+func canonicalUUID(value string) bool {
+	parsed, err := uuid.Parse(value)
+	return err == nil && parsed != uuid.Nil && parsed.String() == value
+}
+
+func parseUUID(value string) uuid.UUID { parsed, _ := uuid.Parse(value); return parsed }
+
+func mapResourceUIDError(err error) error {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return project.ErrResourceUIDNotFound
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		message := strings.ToLower(pgErr.Message)
+		switch {
+		case strings.Contains(message, "kind conflict"):
+			return fmt.Errorf("%w: %s", project.ErrResourceUIDKindConflict, pgErr.Message)
+		case strings.Contains(message, "restore authorization required"):
+			return fmt.Errorf("%w: %s", project.ErrResourceUIDRestoreRequired, pgErr.Message)
+		case strings.Contains(message, "tombstoned"):
+			return fmt.Errorf("%w: %s", project.ErrResourceUIDTombstoned, pgErr.Message)
+		case strings.Contains(message, "outside"), strings.Contains(message, "conflict"), strings.Contains(message, "does not match"):
+			return fmt.Errorf("%w: %s", project.ErrResourceUIDConflict, pgErr.Message)
+		case strings.Contains(message, "invalid"), strings.Contains(message, "unsupported"):
+			return fmt.Errorf("%w: %s", project.ErrInvalidResourceUID, pgErr.Message)
+		}
+	}
+	return err
+}

--- a/internal/project/postgres/resource_uid_schema.sql
+++ b/internal/project/postgres/resource_uid_schema.sql
@@ -1,0 +1,747 @@
+-- Instance-local authored-resource identity registry (FAI-670). Resource UIDs
+-- are allocated only by the activation-owned SECURITY DEFINER function below.
+-- The registry is qualified by instance and Project; no global lookup is part
+-- of this capability.
+CREATE TABLE IF NOT EXISTS project.resource_uid_registry (
+    resource_uid             uuid PRIMARY KEY DEFAULT uuidv4(),
+    instance_id              text NOT NULL,
+    project_id               text NOT NULL,
+    authored_resource_id     text NOT NULL,
+    resource_kind            text NOT NULL,
+    state                    text NOT NULL DEFAULT 'active',
+    first_generation_id      uuid NOT NULL,
+    latest_generation_id     uuid NOT NULL,
+    current_generation_id    uuid,
+    removed_in_generation_id uuid,
+    created_at               timestamptz NOT NULL DEFAULT clock_timestamp(),
+    updated_at               timestamptz NOT NULL DEFAULT clock_timestamp(),
+    UNIQUE (instance_id, project_id, authored_resource_id),
+    UNIQUE (instance_id, project_id, resource_uid),
+    CHECK (instance_id = btrim(instance_id) AND instance_id ~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'),
+    CHECK (project_id = btrim(project_id) AND octet_length(project_id) BETWEEN 1 AND 255 AND project_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (authored_resource_id = btrim(authored_resource_id) AND octet_length(authored_resource_id) >= 1 AND authored_resource_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (resource_kind IN ('connection','source','model','semantic_model','pipeline','dashboard')),
+    CHECK (state IN ('active','tombstoned')),
+    CHECK (first_generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (latest_generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK ((state = 'active' AND current_generation_id IS NOT NULL AND removed_in_generation_id IS NULL AND current_generation_id = latest_generation_id)
+        OR (state = 'tombstoned' AND current_generation_id IS NULL AND removed_in_generation_id IS NOT NULL AND removed_in_generation_id = latest_generation_id)),
+    CHECK (updated_at >= created_at)
+);
+
+CREATE TABLE IF NOT EXISTS project.resource_uid_generation (
+    resource_uid          uuid NOT NULL,
+    instance_id           text NOT NULL,
+    project_id            text NOT NULL,
+    environment           text NOT NULL,
+    target_id             text NOT NULL,
+    generation_id         uuid NOT NULL,
+    authored_resource_id  text NOT NULL,
+    resource_kind         text NOT NULL,
+    contract_status       text NOT NULL,
+    contract_profile      text,
+    contract_version      text,
+    contract_digest       text,
+    contract_bytes        bytea,
+    bound_at              timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (instance_id, project_id, generation_id, authored_resource_id),
+    UNIQUE (instance_id, project_id, generation_id, resource_uid),
+    FOREIGN KEY (instance_id, project_id, resource_uid)
+        REFERENCES project.resource_uid_registry(instance_id, project_id, resource_uid) ON DELETE RESTRICT,
+    CHECK (instance_id = btrim(instance_id) AND instance_id ~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'),
+    CHECK (project_id = btrim(project_id) AND octet_length(project_id) BETWEEN 1 AND 255 AND project_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (environment = btrim(environment) AND octet_length(environment) BETWEEN 1 AND 255 AND environment ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (target_id = instance_id),
+    CHECK (generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (authored_resource_id = btrim(authored_resource_id) AND octet_length(authored_resource_id) >= 1 AND authored_resource_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (resource_kind IN ('connection','source','model','semantic_model','pipeline','dashboard')),
+    CHECK (contract_status IN ('canonical','unversioned','not_contract_bearing')),
+    CHECK ((contract_profile IS NULL AND contract_version IS NULL AND contract_digest IS NULL AND contract_bytes IS NULL)
+        OR (contract_profile IS NOT NULL AND contract_profile = 'leapview.contract/v1'
+            AND contract_version IS NOT NULL AND contract_digest IS NOT NULL
+            AND contract_digest ~ '^sha256:[0-9a-f]{64}$'
+            AND contract_bytes IS NOT NULL AND octet_length(contract_bytes) > 0)),
+    CHECK ((contract_status = 'canonical' AND contract_profile IS NOT NULL AND contract_digest IS NOT NULL AND contract_bytes IS NOT NULL)
+        OR (contract_status = 'unversioned' AND resource_kind IN ('source','model','semantic_model') AND contract_profile IS NULL AND contract_version IS NULL AND contract_digest IS NULL AND contract_bytes IS NULL)
+        OR (contract_status = 'not_contract_bearing' AND resource_kind IN ('connection','pipeline','dashboard') AND contract_profile IS NULL AND contract_version IS NULL AND contract_digest IS NULL AND contract_bytes IS NULL)),
+    CHECK (contract_profile IS NULL OR (contract_profile = btrim(contract_profile) AND octet_length(contract_profile) BETWEEN 1 AND 255)),
+    CHECK (contract_version IS NULL OR (contract_version = btrim(contract_version) AND octet_length(contract_version) > 0))
+);
+
+-- Admission seals one complete, UID-free inventory per generation. This row
+-- is immutable and is the only registry data written before activation.
+CREATE TABLE IF NOT EXISTS project.resource_uid_inventory (
+    generation_id  uuid PRIMARY KEY,
+    instance_id    text NOT NULL,
+    project_id     text NOT NULL,
+    environment    text NOT NULL,
+    target_id      text NOT NULL,
+    graph_digest   text NOT NULL,
+    bundle_digest  text NOT NULL,
+    graph_bytes    bytea NOT NULL,
+    inventory_json jsonb NOT NULL,
+    created_at     timestamptz NOT NULL DEFAULT clock_timestamp(),
+    UNIQUE (instance_id, project_id, generation_id),
+    CHECK (generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (instance_id = btrim(instance_id) AND instance_id ~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'),
+    CHECK (project_id = btrim(project_id) AND octet_length(project_id) BETWEEN 1 AND 255 AND project_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (environment = btrim(environment) AND octet_length(environment) BETWEEN 1 AND 255 AND environment ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (target_id = instance_id),
+    CHECK (graph_digest ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK (bundle_digest ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK (octet_length(graph_bytes) > 0),
+    CHECK (graph_digest = 'sha256:' || pg_catalog.encode(pg_catalog.sha256(graph_bytes), 'hex')),
+    CHECK (jsonb_typeof(inventory_json) = 'array')
+);
+
+CREATE OR REPLACE FUNCTION project.reject_resource_uid_inventory_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, project AS $$
+BEGIN
+    RAISE EXCEPTION 'resource UID inventory evidence is immutable';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS resource_uid_inventory_immutable ON project.resource_uid_inventory;
+CREATE TRIGGER resource_uid_inventory_immutable
+BEFORE UPDATE OR DELETE ON project.resource_uid_inventory
+FOR EACH ROW EXECUTE FUNCTION project.reject_resource_uid_inventory_mutation();
+
+-- Tombstones are append-only generation evidence. They make removal auditable
+-- without relying on mutable current-state fields alone.
+CREATE TABLE IF NOT EXISTS project.resource_uid_tombstone (
+    instance_id              text NOT NULL,
+    project_id               text NOT NULL,
+    resource_uid             uuid NOT NULL,
+    authored_resource_id     text NOT NULL,
+    resource_kind            text NOT NULL,
+    removed_in_generation_id uuid NOT NULL,
+    tombstoned_at            timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (instance_id, project_id, authored_resource_id, removed_in_generation_id),
+    UNIQUE (instance_id, project_id, resource_uid, removed_in_generation_id),
+    FOREIGN KEY (instance_id, project_id, resource_uid)
+        REFERENCES project.resource_uid_registry(instance_id, project_id, resource_uid) ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS project.resource_uid_restore_authorization (
+    restore_id              uuid PRIMARY KEY DEFAULT uuidv4(),
+    resource_uid            uuid NOT NULL,
+    instance_id             text NOT NULL,
+    project_id              text NOT NULL,
+    environment             text NOT NULL,
+    target_id               text NOT NULL,
+    generation_id           uuid NOT NULL,
+    authored_resource_id    text NOT NULL,
+    resource_kind           text NOT NULL,
+    actor_id                text NOT NULL,
+    request_digest          text NOT NULL,
+    status                  text NOT NULL DEFAULT 'pending',
+    created_at              timestamptz NOT NULL DEFAULT clock_timestamp(),
+    consumed_at             timestamptz,
+    UNIQUE (instance_id, project_id, resource_uid, generation_id),
+    FOREIGN KEY (instance_id, project_id, resource_uid)
+        REFERENCES project.resource_uid_registry(instance_id, project_id, resource_uid) ON DELETE RESTRICT,
+    CHECK (instance_id = btrim(instance_id) AND instance_id ~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'),
+    CHECK (project_id = btrim(project_id) AND octet_length(project_id) BETWEEN 1 AND 255 AND project_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (environment = btrim(environment) AND octet_length(environment) BETWEEN 1 AND 255 AND environment ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (target_id = instance_id),
+    CHECK (generation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK (authored_resource_id = btrim(authored_resource_id) AND octet_length(authored_resource_id) >= 1 AND authored_resource_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'),
+    CHECK (resource_kind IN ('connection','source','model','semantic_model','pipeline','dashboard')),
+    CHECK (actor_id = btrim(actor_id) AND octet_length(actor_id) BETWEEN 1 AND 255 AND actor_id !~ '[[:cntrl:]]'),
+    CHECK (request_digest ~ '^sha256:[0-9a-f]{64}$'),
+    CHECK ((status = 'pending' AND consumed_at IS NULL) OR (status = 'consumed' AND consumed_at IS NOT NULL))
+);
+
+CREATE OR REPLACE FUNCTION project.guard_resource_uid_registry_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, project AS $$
+BEGIN
+    IF TG_OP = 'DELETE' OR NEW.resource_uid IS DISTINCT FROM OLD.resource_uid
+       OR NEW.instance_id IS DISTINCT FROM OLD.instance_id OR NEW.project_id IS DISTINCT FROM OLD.project_id
+       OR NEW.authored_resource_id IS DISTINCT FROM OLD.authored_resource_id
+       OR NEW.resource_kind IS DISTINCT FROM OLD.resource_kind OR NEW.first_generation_id IS DISTINCT FROM OLD.first_generation_id
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'resource UID identity is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION project.reject_resource_uid_history_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, project AS $$
+BEGIN
+    RAISE EXCEPTION 'resource UID generation and tombstone evidence is immutable';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS resource_uid_registry_identity ON project.resource_uid_registry;
+CREATE TRIGGER resource_uid_registry_identity
+BEFORE UPDATE OR DELETE ON project.resource_uid_registry
+FOR EACH ROW EXECUTE FUNCTION project.guard_resource_uid_registry_mutation();
+DROP TRIGGER IF EXISTS resource_uid_generation_immutable ON project.resource_uid_generation;
+CREATE TRIGGER resource_uid_generation_immutable
+BEFORE UPDATE OR DELETE ON project.resource_uid_generation
+FOR EACH ROW EXECUTE FUNCTION project.reject_resource_uid_history_mutation();
+DROP TRIGGER IF EXISTS resource_uid_tombstone_immutable ON project.resource_uid_tombstone;
+CREATE TRIGGER resource_uid_tombstone_immutable
+BEFORE UPDATE OR DELETE ON project.resource_uid_tombstone
+FOR EACH ROW EXECUTE FUNCTION project.reject_resource_uid_history_mutation();
+
+CREATE OR REPLACE FUNCTION project.guard_resource_uid_restore_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, project AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'resource UID restore evidence is immutable';
+    END IF;
+    IF NEW.restore_id IS DISTINCT FROM OLD.restore_id OR NEW.resource_uid IS DISTINCT FROM OLD.resource_uid
+       OR NEW.instance_id IS DISTINCT FROM OLD.instance_id OR NEW.project_id IS DISTINCT FROM OLD.project_id
+       OR NEW.environment IS DISTINCT FROM OLD.environment OR NEW.target_id IS DISTINCT FROM OLD.target_id
+       OR NEW.generation_id IS DISTINCT FROM OLD.generation_id OR NEW.authored_resource_id IS DISTINCT FROM OLD.authored_resource_id
+       OR NEW.resource_kind IS DISTINCT FROM OLD.resource_kind OR NEW.actor_id IS DISTINCT FROM OLD.actor_id
+       OR NEW.request_digest IS DISTINCT FROM OLD.request_digest OR NEW.created_at IS DISTINCT FROM OLD.created_at
+       OR OLD.status <> 'pending' OR NEW.status <> 'consumed'
+       OR NEW.consumed_at IS DISTINCT FROM OLD.consumed_at THEN
+        RAISE EXCEPTION 'resource UID restore transition is invalid';
+    END IF;
+    NEW.consumed_at := clock_timestamp();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS resource_uid_restore_immutable ON project.resource_uid_restore_authorization;
+CREATE TRIGGER resource_uid_restore_immutable
+BEFORE UPDATE OR DELETE ON project.resource_uid_restore_authorization
+FOR EACH ROW EXECUTE FUNCTION project.guard_resource_uid_restore_mutation();
+
+-- The restore operation is separate from activation and creates durable,
+-- actor/request evidence. It never allocates a new UID.
+CREATE OR REPLACE FUNCTION project.authorize_resource_uid_restore(
+    p_instance_id text,
+    p_target_id text,
+    p_project_id text,
+    p_environment text,
+    p_generation_id uuid,
+    p_resource_uid uuid,
+    p_authored_resource_id text,
+    p_resource_kind text,
+    p_actor_id text,
+    p_request_digest text
+) RETURNS SETOF project.resource_uid_restore_authorization
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, project
+AS $$
+DECLARE
+    existing project.resource_uid_registry%ROWTYPE;
+    result project.resource_uid_restore_authorization%ROWTYPE;
+BEGIN
+    IF p_instance_id IS NULL OR p_instance_id <> btrim(p_instance_id) OR p_instance_id !~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'
+       OR p_target_id IS DISTINCT FROM p_instance_id OR p_project_id IS NULL OR p_project_id !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+       OR p_environment IS NULL OR p_environment <> btrim(p_environment) OR p_environment !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+       OR p_generation_id IS NULL OR p_resource_uid IS NULL OR p_authored_resource_id IS NULL
+       OR p_resource_kind IS NULL OR p_resource_kind NOT IN ('connection','source','model','semantic_model','pipeline','dashboard')
+       OR p_actor_id IS NULL OR p_actor_id <> btrim(p_actor_id) OR p_actor_id ~ '[[:cntrl:]]'
+       OR p_request_digest IS NULL OR p_request_digest !~ '^sha256:[0-9a-f]{64}$' THEN
+        RAISE EXCEPTION 'invalid resource UID restore identity';
+    END IF;
+    -- Authorize an already-admitted, not-yet-bound generation in this exact
+    -- claimed scope. Take the target lock before the registry lock, matching
+    -- activation's lock order.
+    PERFORM 1
+      FROM delivery.delivery_target t
+      JOIN delivery.delivery_generation g ON g.target_id = t.target_id
+      JOIN project.resource_uid_inventory i ON i.generation_id = g.generation_id
+       AND i.instance_id = t.target_id AND i.project_id = t.project_id
+       AND i.environment = t.environment AND i.target_id = t.target_id
+     WHERE t.target_id = p_target_id AND t.project_id = p_project_id
+       AND t.environment = p_environment AND g.generation_id = p_generation_id
+       AND EXISTS (SELECT 1 FROM platform.instance_identity ii
+                    WHERE ii.singleton_id = 1 AND ii.instance_id = p_instance_id)
+       AND EXISTS (SELECT 1 FROM platform.instance_project_claim pc
+                    WHERE pc.singleton_id = 1 AND pc.project_id = p_project_id
+                      AND pc.environment = p_environment)
+     FOR UPDATE OF t;
+    IF NOT FOUND OR EXISTS (
+        SELECT 1 FROM project.resource_uid_generation b
+         WHERE b.instance_id = p_instance_id AND b.project_id = p_project_id
+           AND b.generation_id = p_generation_id
+    ) THEN
+        RAISE EXCEPTION 'resource UID restore requires an admitted unbound generation in the claimed scope';
+    END IF;
+    SELECT * INTO existing
+      FROM project.resource_uid_registry
+     WHERE instance_id = p_instance_id AND project_id = p_project_id
+       AND resource_uid = p_resource_uid AND authored_resource_id = p_authored_resource_id
+     FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'resource UID not found';
+    END IF;
+    IF existing.resource_kind <> p_resource_kind THEN
+        RAISE EXCEPTION 'resource UID kind conflict';
+    END IF;
+    IF existing.state <> 'tombstoned' THEN
+        RAISE EXCEPTION 'resource UID is not tombstoned';
+    END IF;
+    INSERT INTO project.resource_uid_restore_authorization(
+        resource_uid, instance_id, project_id, environment, target_id,
+        generation_id, authored_resource_id, resource_kind, actor_id, request_digest
+    ) VALUES (
+        p_resource_uid, p_instance_id, p_project_id, p_environment, p_target_id,
+        p_generation_id, p_authored_resource_id, p_resource_kind, p_actor_id, p_request_digest
+    ) ON CONFLICT (instance_id, project_id, resource_uid, generation_id) DO NOTHING;
+    SELECT * INTO result
+      FROM project.resource_uid_restore_authorization
+     WHERE instance_id = p_instance_id AND project_id = p_project_id
+       AND resource_uid = p_resource_uid AND generation_id = p_generation_id
+     FOR UPDATE;
+    IF result.actor_id <> p_actor_id OR result.request_digest <> p_request_digest
+       OR result.authored_resource_id <> p_authored_resource_id OR result.resource_kind <> p_resource_kind
+       OR result.environment <> p_environment OR result.target_id <> p_target_id THEN
+        RAISE EXCEPTION 'resource UID restore authorization conflict';
+    END IF;
+    RETURN NEXT result;
+END;
+$$;
+
+-- Admission is a proof-carrying write. It accepts only a graph and inventory
+-- already attached to the exact delivery generation and serving bundle. The
+-- runtime role may execute this narrow definer, but has no registry table
+-- INSERT privilege and cannot retarget a row or alter the bundle evidence.
+CREATE OR REPLACE FUNCTION project.admit_resource_uid_inventory(
+    p_target_id text,
+    p_project_id text,
+    p_environment text,
+    p_generation_id uuid,
+    p_graph_digest text,
+    p_bundle_digest text,
+    p_graph_bytes bytea,
+    p_inventory_json jsonb
+) RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, project
+AS $$
+DECLARE
+    target_row record;
+    existing project.resource_uid_inventory%ROWTYPE;
+BEGIN
+    IF p_target_id IS NULL OR p_target_id <> btrim(p_target_id)
+       OR p_target_id !~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'
+       OR p_project_id IS NULL OR p_project_id <> btrim(p_project_id)
+       OR p_project_id !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+       OR p_environment IS NULL OR p_environment <> btrim(p_environment)
+       OR p_environment !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+       OR p_generation_id IS NULL
+       OR p_graph_digest IS NULL OR p_graph_digest !~ '^sha256:[0-9a-f]{64}$'
+       OR p_bundle_digest IS NULL OR p_bundle_digest !~ '^sha256:[0-9a-f]{64}$'
+       OR p_graph_bytes IS NULL OR octet_length(p_graph_bytes) = 0
+       OR p_inventory_json IS NULL OR jsonb_typeof(p_inventory_json) <> 'array' THEN
+        RAISE EXCEPTION 'invalid resource UID inventory proof';
+    END IF;
+    IF p_graph_digest IS DISTINCT FROM ('sha256:' || pg_catalog.encode(pg_catalog.sha256(p_graph_bytes), 'hex')) THEN
+        RAISE EXCEPTION 'resource UID graph bytes digest differs';
+    END IF;
+
+    -- This join is the admission boundary: a generation without an admitted
+    -- serving bundle, or a bundle from another target/scope, cannot acquire
+    -- registry evidence. Locking the target serializes empty inventories too.
+    SELECT t.target_id, t.project_id, t.environment,
+           g.compiled_graph_digest AS generation_graph_digest,
+           b.compiled_graph_digest AS bundle_graph_digest,
+           b.project_digest AS serving_project_digest
+      INTO target_row
+      FROM delivery.delivery_generation g
+      JOIN delivery.delivery_target t ON t.target_id = g.target_id
+      JOIN serving_state.bundle b ON b.generation_id = g.generation_id
+       AND b.project_id = t.project_id AND b.environment = t.environment
+     WHERE g.generation_id = p_generation_id
+       AND t.target_id = p_target_id AND t.project_id = p_project_id
+       AND t.environment = p_environment
+     FOR UPDATE OF t;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'resource UID generation serving bundle proof is missing';
+    END IF;
+    IF target_row.generation_graph_digest IS DISTINCT FROM p_graph_digest
+       OR target_row.bundle_graph_digest IS DISTINCT FROM p_graph_digest
+       OR target_row.serving_project_digest IS DISTINCT FROM p_bundle_digest THEN
+        RAISE EXCEPTION 'resource UID inventory lineage proof differs';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM platform.instance_identity ii
+         WHERE ii.singleton_id = 1 AND ii.instance_id = p_target_id
+    ) OR NOT EXISTS (
+        SELECT 1 FROM platform.instance_project_claim pc
+         WHERE pc.singleton_id = 1 AND pc.project_id = p_project_id
+           AND pc.environment = p_environment
+    ) THEN
+        RAISE EXCEPTION 'resource UID inventory target claim is missing';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM jsonb_array_elements(p_inventory_json) AS item(value)
+         WHERE jsonb_typeof(item.value) <> 'object'
+    ) OR EXISTS (
+        SELECT 1
+          FROM jsonb_array_elements(p_inventory_json) AS item(value)
+         GROUP BY item.value->>'authored_id'
+        HAVING item.value->>'authored_id' IS NULL OR count(*) <> 1
+    ) THEN
+        RAISE EXCEPTION 'resource UID inventory is not a complete unique object set';
+    END IF;
+    IF jsonb_typeof((convert_from(p_graph_bytes, 'UTF8'))::jsonb) <> 'object'
+       OR ((convert_from(p_graph_bytes, 'UTF8'))::jsonb)->>'version' IS DISTINCT FROM '2'
+       OR jsonb_typeof(((convert_from(p_graph_bytes, 'UTF8'))::jsonb)->'resources') <> 'array' THEN
+        RAISE EXCEPTION 'resource UID graph proof is invalid';
+    END IF;
+    IF (SELECT count(*) FROM jsonb_array_elements(((convert_from(p_graph_bytes, 'UTF8'))::jsonb)->'resources'))
+       <> jsonb_array_length(p_inventory_json) THEN
+        RAISE EXCEPTION 'resource UID inventory is not graph-complete';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+          FROM jsonb_array_elements(((convert_from(p_graph_bytes, 'UTF8'))::jsonb)->'resources') AS graph_item(value)
+         FULL OUTER JOIN jsonb_array_elements(p_inventory_json) AS inventory_item(value)
+           ON graph_item.value->>'id' = inventory_item.value->>'authored_id'
+          AND graph_item.value->>'kind' = inventory_item.value->>'kind'
+         WHERE graph_item.value IS NULL OR inventory_item.value IS NULL
+    ) THEN
+        RAISE EXCEPTION 'resource UID inventory identity set differs from graph';
+    END IF;
+
+    INSERT INTO project.resource_uid_inventory(
+        generation_id, instance_id, project_id, environment, target_id,
+        graph_digest, bundle_digest, graph_bytes, inventory_json
+    ) VALUES (
+        p_generation_id, p_target_id, p_project_id, p_environment, p_target_id,
+        p_graph_digest, p_bundle_digest, p_graph_bytes, p_inventory_json
+    ) ON CONFLICT (generation_id) DO NOTHING;
+    SELECT * INTO existing FROM project.resource_uid_inventory
+     WHERE generation_id = p_generation_id FOR UPDATE;
+    IF existing.instance_id IS DISTINCT FROM p_target_id
+       OR existing.project_id IS DISTINCT FROM p_project_id
+       OR existing.environment IS DISTINCT FROM p_environment
+       OR existing.target_id IS DISTINCT FROM p_target_id
+       OR existing.graph_digest IS DISTINCT FROM p_graph_digest
+       OR existing.bundle_digest IS DISTINCT FROM p_bundle_digest
+       OR existing.graph_bytes IS DISTINCT FROM p_graph_bytes
+       OR existing.inventory_json IS DISTINCT FROM p_inventory_json THEN
+        RAISE EXCEPTION 'resource UID inventory replay conflict';
+    END IF;
+    RETURN true;
+END;
+$$;
+
+-- Allocation is private to the delivery activation capability. The trigger
+-- invokes this function while delivery.commit_activation_transition is a
+-- SECURITY DEFINER owner transaction; no caller can supply a foreign scope
+-- or an arbitrary inventory to allocate identities.
+CREATE OR REPLACE FUNCTION project.bind_resource_uid_generation(p_generation_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, project
+AS $$
+<<binding>>
+DECLARE
+    scope record;
+    entry jsonb;
+    existing project.resource_uid_registry%ROWTYPE;
+    prior_binding project.resource_uid_generation%ROWTYPE;
+    restore_row project.resource_uid_restore_authorization%ROWTYPE;
+    authored_id text;
+    resource_kind text;
+    contract_status text;
+    contract_profile text;
+    contract_version text;
+    contract_digest text;
+    contract_bytes bytea;
+    contract_json jsonb;
+    expected_contract_kind text;
+    has_contract boolean;
+    prior_binding_found boolean;
+BEGIN
+    IF p_generation_id IS NULL OR p_generation_id = '00000000-0000-0000-0000-000000000000'::uuid THEN
+        RAISE EXCEPTION 'invalid resource UID generation';
+    END IF;
+    SELECT t.target_id, t.project_id, t.environment, g.compiled_graph_digest,
+           i.inventory_json, i.graph_digest, i.bundle_digest,
+           b.compiled_graph_digest AS serving_graph_digest,
+           b.project_digest AS serving_project_digest
+      INTO scope
+      FROM delivery.delivery_generation g
+      JOIN delivery.delivery_target t ON t.target_id = g.target_id
+      JOIN delivery.delivery_active_pointer ap
+        ON ap.target_id = t.target_id AND ap.generation_id = g.generation_id
+      JOIN delivery.delivery_publication pub
+        ON pub.publication_id = ap.publication_id
+       AND pub.generation_id = g.generation_id
+       AND pub.target_id = t.target_id
+       AND pub.state = 'committed'
+      JOIN serving_state.bundle b ON b.generation_id = g.generation_id
+       AND b.project_id = t.project_id AND b.environment = t.environment
+      JOIN project.resource_uid_inventory i
+        ON i.generation_id = g.generation_id
+       AND i.instance_id = t.target_id
+       AND i.project_id = t.project_id
+       AND i.environment = t.environment
+       AND i.target_id = t.target_id
+     WHERE g.generation_id = p_generation_id
+     FOR UPDATE OF t;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'resource UID generation or inventory proof is missing';
+    END IF;
+    IF scope.target_id !~ '^(lvinst_[A-Za-z0-9_-]{32}|instance_[0-9a-f]{32})$'
+       OR scope.graph_digest IS DISTINCT FROM scope.compiled_graph_digest
+       OR scope.serving_graph_digest IS DISTINCT FROM scope.compiled_graph_digest
+       OR scope.bundle_digest IS DISTINCT FROM scope.serving_project_digest THEN
+        RAISE EXCEPTION 'resource UID generation scope or graph proof differs';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM platform.instance_identity ii
+        WHERE ii.singleton_id = 1 AND ii.instance_id = scope.target_id
+    ) OR NOT EXISTS (
+        SELECT 1 FROM platform.instance_project_claim pc
+        WHERE pc.singleton_id = 1 AND pc.project_id = scope.project_id AND pc.environment = scope.environment
+    ) THEN
+        RAISE EXCEPTION 'resource UID generation target claim is missing';
+    END IF;
+    -- Explicitly lock the target even for an empty inventory so concurrent
+    -- removal/reconciliation passes serialize on the same scope fence.
+    PERFORM 1 FROM delivery.delivery_target t
+     WHERE t.target_id = scope.target_id AND t.project_id = scope.project_id AND t.environment = scope.environment
+     FOR UPDATE;
+
+    IF EXISTS (
+        SELECT 1
+          FROM jsonb_array_elements(scope.inventory_json) AS item(value)
+         GROUP BY item.value->>'authored_id'
+        HAVING item.value->>'authored_id' IS NULL OR count(*) <> 1
+    ) THEN
+        RAISE EXCEPTION 'resource UID inventory contains duplicate or missing authored IDs';
+    END IF;
+
+    FOR entry IN SELECT value FROM jsonb_array_elements(scope.inventory_json) LOOP
+        restore_row := NULL;
+        IF jsonb_typeof(entry) <> 'object' THEN
+            RAISE EXCEPTION 'resource UID inventory entry is not an object';
+        END IF;
+        IF EXISTS (
+            SELECT 1
+              FROM jsonb_object_keys(entry) AS key(name)
+             WHERE key.name NOT IN ('authored_id', 'kind', 'contract_status',
+                                    'contract_profile', 'contract_version',
+                                    'canonical_contract', 'contract_digest')
+        ) THEN
+            RAISE EXCEPTION 'resource UID inventory entry contains unsupported fields';
+        END IF;
+        authored_id := entry->>'authored_id';
+        resource_kind := entry->>'kind';
+        contract_status := entry->>'contract_status';
+        contract_profile := NULLIF(entry->>'contract_profile', '');
+        contract_digest := NULLIF(entry->>'contract_digest', '');
+        contract_version := NULLIF(entry->>'contract_version', '');
+        contract_bytes := NULL;
+        contract_json := NULL;
+        IF entry ? 'canonical_contract' AND entry->'canonical_contract' <> 'null'::jsonb THEN
+            IF jsonb_typeof(entry->'canonical_contract') <> 'string' THEN
+                RAISE EXCEPTION 'resource UID canonical contract must retain exact JSON bytes as a string';
+            END IF;
+            contract_bytes := convert_to(entry->>'canonical_contract', 'UTF8');
+            contract_json := (entry->>'canonical_contract')::jsonb;
+        END IF;
+        has_contract := contract_profile IS NOT NULL OR contract_digest IS NOT NULL OR contract_version IS NOT NULL OR contract_bytes IS NOT NULL;
+        IF authored_id IS NULL OR authored_id <> btrim(authored_id) OR authored_id !~ '^[A-Za-z0-9][A-Za-z0-9_.:-]*$'
+           OR resource_kind IS NULL OR resource_kind NOT IN ('connection','source','model','semantic_model','pipeline','dashboard')
+           OR contract_status IS NULL OR contract_status NOT IN ('canonical','unversioned','not_contract_bearing') THEN
+            RAISE EXCEPTION 'invalid resource UID inventory entry';
+        END IF;
+        IF contract_status = 'canonical' THEN
+            expected_contract_kind := CASE resource_kind
+                WHEN 'source' THEN 'Source'
+                WHEN 'model' THEN 'Model'
+                WHEN 'semantic_model' THEN 'SemanticModel'
+                ELSE NULL
+            END;
+            IF expected_contract_kind IS NULL OR contract_profile IS DISTINCT FROM 'leapview.contract/v1'
+               OR contract_version IS NULL OR contract_digest IS NULL OR contract_bytes IS NULL
+               OR contract_digest !~ '^sha256:[0-9a-f]{64}$'
+               OR jsonb_typeof(contract_json) <> 'object'
+               OR contract_json->>'profile' IS DISTINCT FROM contract_profile
+               OR contract_json->>'apiVersion' IS DISTINCT FROM 'leapview.dev/v1'
+               OR contract_json->>'kind' IS DISTINCT FROM expected_contract_kind
+               OR contract_json->'metadata'->>'id' IS DISTINCT FROM authored_id
+               OR contract_json->'metadata'->'contract'->>'version' IS DISTINCT FROM contract_version
+               OR contract_digest IS DISTINCT FROM ('sha256:' || pg_catalog.encode(pg_catalog.sha256(contract_bytes), 'hex')) THEN
+                RAISE EXCEPTION 'resource UID canonical contract evidence is incomplete';
+            END IF;
+        ELSIF contract_status = 'unversioned' THEN
+            IF resource_kind NOT IN ('source','model','semantic_model') OR has_contract THEN
+                RAISE EXCEPTION 'resource UID unversioned status is invalid';
+            END IF;
+        ELSIF contract_status = 'not_contract_bearing' THEN
+            IF resource_kind NOT IN ('connection','pipeline','dashboard') OR has_contract THEN
+                RAISE EXCEPTION 'resource UID non-contract-bearing status is invalid';
+            END IF;
+        END IF;
+        SELECT * INTO existing
+          FROM project.resource_uid_registry r
+         WHERE r.instance_id = scope.target_id AND r.project_id = scope.project_id
+           AND r.authored_resource_id = authored_id
+         FOR UPDATE;
+        IF NOT FOUND THEN
+            INSERT INTO project.resource_uid_registry(
+                instance_id, project_id, authored_resource_id, resource_kind,
+                first_generation_id, latest_generation_id, current_generation_id
+            ) VALUES (scope.target_id, scope.project_id, authored_id, resource_kind,
+                      p_generation_id, p_generation_id, p_generation_id)
+            RETURNING * INTO existing;
+        ELSIF existing.resource_kind <> resource_kind THEN
+            RAISE EXCEPTION 'resource UID kind conflict for %', authored_id;
+        END IF;
+
+        SELECT * INTO prior_binding
+          FROM project.resource_uid_generation b
+         WHERE b.instance_id = scope.target_id AND b.project_id = scope.project_id
+           AND b.generation_id = p_generation_id AND b.authored_resource_id = authored_id
+         FOR UPDATE;
+        prior_binding_found := FOUND;
+        IF prior_binding_found THEN
+            IF prior_binding.resource_uid <> existing.resource_uid OR prior_binding.resource_kind <> resource_kind
+               OR prior_binding.environment <> scope.environment OR prior_binding.target_id <> scope.target_id
+               OR prior_binding.contract_status IS DISTINCT FROM contract_status
+               OR prior_binding.contract_profile IS DISTINCT FROM contract_profile
+               OR prior_binding.contract_version IS DISTINCT FROM contract_version
+               OR prior_binding.contract_digest IS DISTINCT FROM contract_digest
+               OR prior_binding.contract_bytes IS DISTINCT FROM contract_bytes THEN
+                RAISE EXCEPTION 'resource UID generation binding conflict for %', authored_id;
+            END IF;
+        END IF;
+
+        IF existing.state = 'tombstoned' THEN
+            -- Re-activating an exact historical generation is rollback-safe:
+            -- its immutable binding is already the authority and does not
+            -- need a new restore request. A new generation requires explicit
+            -- audited authorization for this exact UID and generation.
+            IF NOT prior_binding_found THEN
+                SELECT ra.* INTO restore_row
+                  FROM project.resource_uid_restore_authorization ra
+                 WHERE ra.instance_id = scope.target_id AND ra.project_id = scope.project_id
+                   AND ra.target_id = scope.target_id AND ra.environment = scope.environment
+                   AND ra.generation_id = p_generation_id AND ra.resource_uid = existing.resource_uid
+                   AND ra.authored_resource_id = authored_id AND ra.resource_kind = binding.resource_kind
+                   AND ra.status = 'pending'
+                 FOR UPDATE;
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION 'resource UID restore authorization required for %', authored_id;
+                END IF;
+            END IF;
+            UPDATE project.resource_uid_registry
+               SET state = 'active', latest_generation_id = p_generation_id,
+                   current_generation_id = p_generation_id, removed_in_generation_id = NULL,
+                   updated_at = clock_timestamp()
+             WHERE resource_uid = existing.resource_uid;
+            IF restore_row.restore_id IS NOT NULL THEN
+                UPDATE project.resource_uid_restore_authorization
+                   SET status = 'consumed'
+                 WHERE restore_id = restore_row.restore_id;
+            END IF;
+        ELSIF existing.latest_generation_id IS DISTINCT FROM p_generation_id
+           OR existing.current_generation_id IS DISTINCT FROM p_generation_id THEN
+            UPDATE project.resource_uid_registry
+               SET latest_generation_id = p_generation_id,
+                   current_generation_id = p_generation_id,
+                   updated_at = clock_timestamp()
+             WHERE resource_uid = existing.resource_uid;
+        END IF;
+
+        IF NOT prior_binding_found THEN
+            INSERT INTO project.resource_uid_generation(
+                resource_uid, instance_id, project_id, environment, target_id,
+                generation_id, authored_resource_id, resource_kind, contract_status,
+                contract_profile, contract_version, contract_digest, contract_bytes
+            ) VALUES (
+                existing.resource_uid, scope.target_id, scope.project_id, scope.environment, scope.target_id,
+                p_generation_id, authored_id, resource_kind, contract_status,
+                contract_profile, contract_version, contract_digest, contract_bytes
+            );
+        END IF;
+    END LOOP;
+
+    FOR existing IN
+        SELECT * FROM project.resource_uid_registry r
+         WHERE r.instance_id = scope.target_id AND r.project_id = scope.project_id AND r.state = 'active'
+         FOR UPDATE
+    LOOP
+        IF existing.current_generation_id IS DISTINCT FROM p_generation_id
+           AND NOT EXISTS (
+               SELECT 1 FROM jsonb_array_elements(scope.inventory_json) AS item(value)
+               WHERE item.value->>'authored_id' = existing.authored_resource_id
+           ) THEN
+            UPDATE project.resource_uid_registry
+               SET state = 'tombstoned', latest_generation_id = p_generation_id,
+                   current_generation_id = NULL, removed_in_generation_id = p_generation_id,
+                   updated_at = clock_timestamp()
+             WHERE resource_uid = existing.resource_uid;
+            INSERT INTO project.resource_uid_tombstone(
+                instance_id, project_id, resource_uid, authored_resource_id, resource_kind, removed_in_generation_id
+            ) VALUES (scope.target_id, scope.project_id, existing.resource_uid, existing.authored_resource_id, existing.resource_kind, p_generation_id)
+            ON CONFLICT DO NOTHING;
+        END IF;
+    END LOOP;
+    RETURN true;
+END;
+$$;
+
+-- The only allocation trigger is attached to the authoritative publication
+-- commit. delivery.commit_activation_transition is SECURITY DEFINER and
+-- performs this update in the same caller-owned transaction as the pointer
+-- CAS; a failed bind therefore rolls back the activation and leaks no UID.
+CREATE OR REPLACE FUNCTION project.bind_resource_uid_on_publication_commit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, project
+AS $$
+BEGIN
+    IF NEW.state = 'committed' AND OLD.state IS DISTINCT FROM NEW.state THEN
+        PERFORM project.bind_resource_uid_generation(NEW.generation_id);
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS resource_uid_bind_on_publication_commit ON delivery.delivery_publication;
+CREATE TRIGGER resource_uid_bind_on_publication_commit
+AFTER UPDATE OF state ON delivery.delivery_publication
+FOR EACH ROW
+WHEN (NEW.state = 'committed' AND OLD.state IS DISTINCT FROM NEW.state)
+EXECUTE FUNCTION project.bind_resource_uid_on_publication_commit();
+
+REVOKE ALL ON TABLE project.resource_uid_registry, project.resource_uid_generation,
+    project.resource_uid_inventory, project.resource_uid_tombstone,
+    project.resource_uid_restore_authorization FROM PUBLIC;
+REVOKE ALL ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb),
+    project.bind_resource_uid_generation(uuid),
+    project.bind_resource_uid_on_publication_commit(),
+    project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text),
+    project.guard_resource_uid_restore_mutation(),
+    project.reject_resource_uid_inventory_mutation() FROM PUBLIC;
+DO $$
+DECLARE role_name text;
+BEGIN
+    FOREACH role_name IN ARRAY ARRAY['leapview_control_owner','leapview_control_migrator','leapview_control_runtime','leapview_control_readonly','leapview_control_backup'] LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+            EXECUTE format('GRANT USAGE ON SCHEMA project TO %I', role_name);
+            IF role_name IN ('leapview_control_owner','leapview_control_migrator') THEN
+                EXECUTE format('GRANT ALL ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO %I', role_name);
+                -- The binder is reached only by the delivery activation
+                -- trigger. Do not grant it as a callable repository API.
+                EXECUTE format('GRANT EXECUTE ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb), project.authorize_resource_uid_restore(text,text,text,text,uuid,uuid,text,text,text,text) TO %I', role_name);
+            ELSIF role_name = 'leapview_control_runtime' THEN
+                EXECUTE 'GRANT EXECUTE ON FUNCTION project.admit_resource_uid_inventory(text,text,text,uuid,text,text,bytea,jsonb) TO leapview_control_runtime';
+                EXECUTE 'GRANT SELECT ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO leapview_control_runtime';
+            ELSE
+                EXECUTE format('GRANT SELECT ON project.resource_uid_registry, project.resource_uid_generation, project.resource_uid_inventory, project.resource_uid_tombstone, project.resource_uid_restore_authorization TO %I', role_name);
+            END IF;
+        END IF;
+    END LOOP;
+END
+$$;

--- a/internal/project/resource_inventory.go
+++ b/internal/project/resource_inventory.go
@@ -1,0 +1,143 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	projectartifact "github.com/flidai/leapview/internal/project/artifact"
+	"github.com/flidai/leapview/internal/project/contractprojection"
+	projectcontracts "github.com/flidai/leapview/internal/project/contracts"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	configschema "github.com/flidai/leapview/internal/project/schema"
+)
+
+// ResourceUIDInventory is a sealed, complete inventory of a validated portable
+// bundle. It contains no allocated identities. Admission retains it as immutable
+// generation evidence; only activation may allocate registry identities.
+type ResourceUIDInventory struct {
+	graphDigest  string
+	graphBytes   []byte
+	bundleDigest string
+	encoded      []byte
+}
+
+type resourceInventoryEntry struct {
+	AuthoredID        string            `json:"authored_id"`
+	Kind              projectgraph.Kind `json:"kind"`
+	ContractStatus    string            `json:"contract_status"`
+	ContractProfile   string            `json:"contract_profile,omitempty"`
+	ContractVersion   string            `json:"contract_version,omitempty"`
+	CanonicalContract string            `json:"canonical_contract,omitempty"`
+	ContractDigest    string            `json:"contract_digest,omitempty"`
+}
+
+// NewResourceUIDInventory preserves the compiler's complete resource set and
+// uses the existing canonical projector when authored contract authority exists.
+// Absence of a contract version is not permission to invent a version, profile,
+// or digest. Such resources still receive registry identity, but carry no
+// published-contract claim. FAI-622 owns publication/version authority.
+func NewResourceUIDInventory(source projectartifact.SourceBundle) (ResourceUIDInventory, error) {
+	// Reject the zero value and recheck the portable wire authority rather than
+	// accepting a graph-only or caller-built list as a complete inventory.
+	validated, err := projectartifact.Decode(source.Canonical())
+	if err != nil {
+		return ResourceUIDInventory{}, fmt.Errorf("resource inventory source bundle: %w", err)
+	}
+	graph := validated.Graph()
+	manifest := validated.Manifest()
+	resources := graph.Resources()
+	sort.Slice(resources, func(i, j int) bool { return resources[i].ID < resources[j].ID })
+	entries := make([]resourceInventoryEntry, 0, len(resources))
+	for _, resource := range resources {
+		entry := resourceInventoryEntry{AuthoredID: resource.ID.String(), Kind: resource.Kind, ContractStatus: "unversioned"}
+		var projection contractprojection.Projection
+		switch resource.Kind {
+		case projectgraph.KindSource:
+			var authored projectcontracts.Source
+			if err := configschema.DecodeResource(configschema.KindSource, "resource.yaml", []byte(manifest.AuthoredResourceSources[entry.AuthoredID]), &authored); err != nil {
+				return ResourceUIDInventory{}, fmt.Errorf("resource inventory %s: %w", entry.AuthoredID, err)
+			}
+			if authored.Metadata.ID != entry.AuthoredID || authored.Metadata.Name != resource.Name {
+				return ResourceUIDInventory{}, fmt.Errorf("resource inventory %s: authored identity differs from graph", entry.AuthoredID)
+			}
+			if authored.Metadata.Contract != nil {
+				projection, err = contractprojection.ProjectSource(authored, contractprojection.Contract{})
+				entry.ContractVersion = authored.Metadata.Contract.Version
+			}
+		case projectgraph.KindModel:
+			var authored projectcontracts.Model
+			if err := configschema.DecodeResource(configschema.KindModel, "resource.yaml", []byte(manifest.AuthoredResourceSources[entry.AuthoredID]), &authored); err != nil {
+				return ResourceUIDInventory{}, fmt.Errorf("resource inventory %s: %w", entry.AuthoredID, err)
+			}
+			if authored.Metadata.ID != entry.AuthoredID || authored.Metadata.Name != resource.Name {
+				return ResourceUIDInventory{}, fmt.Errorf("resource inventory %s: authored identity differs from graph", entry.AuthoredID)
+			}
+			if authored.Metadata.Contract != nil {
+				references, referenceErr := contractprojection.NewReferenceContext(graph)
+				if referenceErr != nil {
+					return ResourceUIDInventory{}, referenceErr
+				}
+				projection, err = contractprojection.ProjectModel(authored, contractprojection.Contract{}, references)
+				entry.ContractVersion = authored.Metadata.Contract.Version
+			}
+		case projectgraph.KindSemanticModel:
+			var authored projectcontracts.SemanticModel
+			if err := configschema.DecodeResource(configschema.KindSemanticModel, "resource.yaml", []byte(manifest.AuthoredResourceSources[entry.AuthoredID]), &authored); err != nil {
+				return ResourceUIDInventory{}, fmt.Errorf("resource inventory %s: %w", entry.AuthoredID, err)
+			}
+			if authored.Metadata.ID != entry.AuthoredID || authored.Metadata.Name != resource.Name {
+				return ResourceUIDInventory{}, fmt.Errorf("resource inventory %s: authored identity differs from graph", entry.AuthoredID)
+			}
+			// The current SemanticModel authoring schema has no contract-version
+			// field. A publication authority must supply it before projection.
+		case projectgraph.KindConnection, projectgraph.KindPipeline, projectgraph.KindDashboard:
+			// leapview.contract/v1 deliberately defines no projection for these.
+			entry.ContractStatus = "not_contract_bearing"
+		default:
+			return ResourceUIDInventory{}, fmt.Errorf("resource inventory %s: unsupported authored kind %s", entry.AuthoredID, resource.Kind)
+		}
+		if err != nil {
+			return ResourceUIDInventory{}, fmt.Errorf("resource inventory %s: %w", entry.AuthoredID, err)
+		}
+		if projection != nil {
+			canonical, canonicalErr := contractprojection.CanonicalBytes(projection)
+			if canonicalErr != nil {
+				return ResourceUIDInventory{}, canonicalErr
+			}
+			digest, digestErr := contractprojection.Digest(projection)
+			if digestErr != nil {
+				return ResourceUIDInventory{}, digestErr
+			}
+			entry.ContractProfile = contractprojection.Profile
+			entry.ContractStatus = "canonical"
+			entry.CanonicalContract = string(canonical)
+			entry.ContractDigest = digest
+		}
+		entries = append(entries, entry)
+	}
+	encoded, err := json.Marshal(entries)
+	if err != nil {
+		return ResourceUIDInventory{}, err
+	}
+	return ResourceUIDInventory{graphDigest: graph.Digest(), graphBytes: graph.CanonicalBytes(), bundleDigest: validated.Digest(), encoded: encoded}, nil
+}
+
+func (value ResourceUIDInventory) GraphDigest() string  { return value.graphDigest }
+func (value ResourceUIDInventory) BundleDigest() string { return value.bundleDigest }
+
+// GraphCanonicalBytes retains the existing compiler graph proof, not a new
+// contract digest. Storage can verify inventory completeness against its exact
+// resource set, including an empty set, without enumerating serving assets.
+func (value ResourceUIDInventory) GraphCanonicalBytes() []byte {
+	return append([]byte(nil), value.graphBytes...)
+}
+
+// JSON returns a detached inventory copy. JSON decoding cannot construct a
+// sealed inventory, and the zero value cannot become an empty-generation proof.
+func (value ResourceUIDInventory) JSON() ([]byte, error) {
+	if value.graphDigest == "" || value.bundleDigest == "" || len(value.encoded) == 0 {
+		return nil, fmt.Errorf("resource inventory is not sealed")
+	}
+	return append([]byte(nil), value.encoded...), nil
+}

--- a/internal/project/resource_inventory_test.go
+++ b/internal/project/resource_inventory_test.go
@@ -1,0 +1,167 @@
+package project_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	project "github.com/flidai/leapview/internal/project"
+	projectartifact "github.com/flidai/leapview/internal/project/artifact"
+	"github.com/flidai/leapview/internal/project/compiler"
+	"github.com/flidai/leapview/internal/project/contractprojection"
+)
+
+func inventoryBundle(t *testing.T, versioned bool) projectartifact.SourceBundle {
+	t.Helper()
+	metadata := "{id: 'source:orders', name: orders}"
+	if versioned {
+		metadata = "{id: 'source:orders', name: orders, contract: {version: 1.0.0, compatibility: backward}}"
+	}
+	files := map[string]string{
+		"connections/warehouse.yaml": "apiVersion: leapview.dev/v1\nkind: Connection\nmetadata: {id: 'connection:warehouse', name: warehouse}\nspec: {type: managed}\n",
+		"sources/orders.yaml":        "apiVersion: leapview.dev/v1\nkind: Source\nmetadata: " + metadata + "\nspec: {connection: warehouse, location: {type: path, path: orders.csv, format: csv}}\n",
+	}
+	return compileInventoryFiles(t, files)
+}
+
+func compileInventoryFiles(t *testing.T, files map[string]string) projectartifact.SourceBundle {
+	t.Helper()
+	root := t.TempDir()
+	for name, contents := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bundle, err := compiler.Compile(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bundle
+}
+
+func TestResourceUIDInventoryModelAndSemanticEvidence(t *testing.T) {
+	bundle := compileInventoryFiles(t, map[string]string{
+		"connections/warehouse.yaml": "apiVersion: leapview.dev/v1\nkind: Connection\nmetadata: {id: connection:warehouse, name: warehouse}\nspec: {type: managed}\n",
+		"sources/orders.yaml": "apiVersion: leapview.dev/v1\nkind: Source\nmetadata: {id: source:orders, name: orders}\nspec: {connection: warehouse, location: {type: path, path: orders.csv, format: csv}}\n",
+		"models/orders.yaml": "apiVersion: leapview.dev/v1\nkind: Model\nmetadata: {id: model:orders, name: orders_model, contract: {version: 2.0.0, compatibility: backward}}\nspec: {definition: {type: direct, source: orders}, entities: {id: {type: primary, fields: [id]}}, grain: {entity: id}, fields: {id: {datatype: String}}}\n",
+		"semantic-models/sales.yaml": "apiVersion: leapview.dev/v1\nkind: SemanticModel\nmetadata: {id: semantic:sales, name: sales}\nspec: {datasets: {orders: {model: orders_model}}, metrics: {}}\n",
+	})
+	inventory, err := project.NewResourceUIDInventory(bundle)
+	if err != nil { t.Fatal(err) }
+	encoded, _ := inventory.JSON()
+	var entries []struct {
+		ID string `json:"authored_id"`
+		Status string `json:"contract_status"`
+		Canonical string `json:"canonical_contract"`
+		Digest string `json:"contract_digest"`
+	}
+	if err := json.Unmarshal(encoded, &entries); err != nil { t.Fatal(err) }
+	if len(entries) != 4 { t.Fatalf("inventory: %s", encoded) }
+	for _, entry := range entries {
+		switch entry.ID {
+		case "model:orders":
+			digest, err := contractprojection.DigestModelPublication([]byte(entry.Canonical))
+			if err != nil || digest != entry.Digest || entry.Status != "canonical" { t.Fatalf("model evidence: %+v, %v", entry, err) }
+		case "semantic:sales", "source:orders":
+			if entry.Status != "unversioned" || entry.Digest != "" { t.Fatalf("invented version authority: %+v", entry) }
+		}
+	}
+}
+
+func TestResourceUIDInventorySealedCanonicalEvidence(t *testing.T) {
+	bundle := inventoryBundle(t, true)
+	before := bundle.Canonical()
+	inventory, err := project.NewResourceUIDInventory(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := inventory.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []struct {
+		ID        string `json:"authored_id"`
+		Profile   string `json:"contract_profile"`
+		Version   string `json:"contract_version"`
+		Canonical string `json:"canonical_contract"`
+		Digest    string `json:"contract_digest"`
+	}
+	if err := json.Unmarshal(encoded, &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 || entries[0].ID != "connection:warehouse" || entries[1].ID != "source:orders" {
+		t.Fatalf("inventory = %s", encoded)
+	}
+	if entries[0].Profile != "" || entries[0].Digest != "" {
+		t.Fatal("invented contract for Connection")
+	}
+	if entries[1].Profile != contractprojection.Profile {
+		t.Fatalf("profile = %q", entries[1].Profile)
+	}
+	if entries[1].Version != "1.0.0" { t.Fatalf("contract version = %q", entries[1].Version) }
+	digest, err := contractprojection.DigestSourcePublication([]byte(entries[1].Canonical))
+	if err != nil || digest != entries[1].Digest {
+		t.Fatalf("canonical replay: %s, %v", digest, err)
+	}
+	if inventory.GraphDigest() != bundle.Graph().Digest() || inventory.BundleDigest() != bundle.Digest() {
+		t.Fatal("inventory detached from bundle authority")
+	}
+	if !bytes.Equal(before, bundle.Canonical()) {
+		t.Fatal("inventory mutated portable artifact")
+	}
+	encoded[0] = 'x'
+	again, _ := inventory.JSON()
+	if again[0] != '[' {
+		t.Fatal("inventory leaked mutable bytes")
+	}
+	other, err := project.NewResourceUIDInventory(inventoryBundle(t, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherBytes, _ := other.JSON()
+	if !bytes.Equal(again, otherBytes) {
+		t.Fatal("source-root path changed registry evidence")
+	}
+}
+
+func TestResourceUIDInventoryDoesNotInventUnversionedContracts(t *testing.T) {
+	inventory, err := project.NewResourceUIDInventory(inventoryBundle(t, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, _ := inventory.JSON()
+	if strings.Contains(string(encoded), "contract_digest") || strings.Contains(string(encoded), "sha256:") {
+		t.Fatalf("invented identity: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"contract_status":"unversioned"`) || !strings.Contains(string(encoded), `"contract_status":"not_contract_bearing"`) {
+		t.Fatalf("missing explicit contract status: %s", encoded)
+	}
+}
+
+func TestResourceUIDInventoryRejectsMissingAndMismatchedAuthority(t *testing.T) {
+	if _, err := (project.ResourceUIDInventory{}).JSON(); err == nil {
+		t.Fatal("zero inventory accepted")
+	}
+	if _, err := project.NewResourceUIDInventory(projectartifact.SourceBundle{}); err == nil {
+		t.Fatal("zero bundle accepted")
+	}
+	bundle := inventoryBundle(t, true)
+	for _, source := range []string{"", strings.Replace(bundle.Manifest().AuthoredResourceSources["source:orders"], "source:orders", "source:forged", 1)} {
+		manifest := bundle.Manifest()
+		manifest.AuthoredResourceSources["source:orders"] = source
+		changed, err := projectartifact.NewSourceBundle(bundle.Graph(), manifest)
+		if err != nil {
+			continue
+		} // Earlier portable validation is also fail-closed.
+		if _, err := project.NewResourceUIDInventory(changed); err == nil {
+			t.Fatal("missing/mismatched authored evidence accepted")
+		}
+	}
+}

--- a/internal/project/resource_uid.go
+++ b/internal/project/resource_uid.go
@@ -1,0 +1,258 @@
+package project
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/flidai/leapview/internal/platform/instanceidentity"
+	"github.com/flidai/leapview/internal/project/contractprojection"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/google/uuid"
+)
+
+// ResourceUID is an opaque, instance-local identity allocated when a
+// generation is activated. It is deliberately not a portable authored field.
+type ResourceUID string
+
+var (
+	ErrInvalidResourceUID         = errors.New("invalid resource UID")
+	ErrResourceUIDConflict        = errors.New("resource UID conflict")
+	ErrResourceUIDNotFound        = errors.New("resource UID not found")
+	ErrResourceUIDKindConflict    = errors.New("resource UID kind conflict")
+	ErrResourceUIDTombstoned      = errors.New("resource UID is tombstoned")
+	ErrResourceUIDRestoreRequired = errors.New("resource UID restore authorization required")
+)
+
+const (
+	maxResourceUIDTextBytes = 255
+	contractProfile         = contractprojection.Profile
+)
+
+// ParseResourceUID accepts only canonical, non-nil UUID text.
+func ParseResourceUID(value string) (ResourceUID, error) {
+	parsed, err := uuid.Parse(value)
+	if err != nil || parsed == uuid.Nil || parsed.String() != value {
+		return "", fmt.Errorf("%w %q", ErrInvalidResourceUID, value)
+	}
+	return ResourceUID(value), nil
+}
+
+func (uid ResourceUID) String() string { return string(uid) }
+
+func (uid ResourceUID) Validate() error {
+	_, err := ParseResourceUID(uid.String())
+	return err
+}
+
+type ResourceUIDState string
+
+const (
+	ResourceUIDActive     ResourceUIDState = "active"
+	ResourceUIDTombstoned ResourceUIDState = "tombstoned"
+)
+
+// ResourceUIDRecord is the current instance/project binding for one authored
+// ID. Generation fields are retained so rollback and tombstone behavior never
+// need to infer identity from a path, name, or display value.
+type ResourceUIDRecord struct {
+	UID                 ResourceUID
+	InstanceID          string
+	ProjectID           string
+	AuthoredID          string
+	Kind                projectgraph.Kind
+	State               ResourceUIDState
+	FirstGeneration     string
+	LatestGeneration    string
+	CurrentGeneration   string
+	RemovedInGeneration string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// ResourceUIDBinding is immutable evidence that a generation used one UID.
+// Contract evidence is present for the FAI-620 versioned resource kinds and
+// absent for resources without a canonical contract projection.
+type ResourceUIDBinding struct {
+	ResourceUID     ResourceUID
+	InstanceID      string
+	ProjectID       string
+	Environment     string
+	TargetID        string
+	GenerationID    string
+	AuthoredID      string
+	Kind            projectgraph.Kind
+	ContractStatus  string
+	ContractProfile string
+	ContractVersion string
+	ContractDigest  string
+	ContractBytes   []byte
+	BoundAt         time.Time
+}
+
+// ResourceUIDRestoreAuthorization is audited evidence granting one exact
+// tombstoned ID restore. Its consumed transition is guarded by PostgreSQL.
+type ResourceUIDRestoreAuthorization struct {
+	RestoreID     string
+	ResourceUID   ResourceUID
+	InstanceID    string
+	ProjectID     string
+	Environment   string
+	TargetID      string
+	GenerationID  string
+	AuthoredID    string
+	Kind          projectgraph.Kind
+	ActorID       string
+	RequestDigest string
+	Status        string
+	CreatedAt     time.Time
+	ConsumedAt    time.Time
+}
+
+func authoredResourceKindValid(kind projectgraph.Kind) bool {
+	switch kind {
+	case projectgraph.KindConnection, projectgraph.KindSource, projectgraph.KindModel,
+		projectgraph.KindSemanticModel, projectgraph.KindPipeline, projectgraph.KindDashboard:
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalUUID(value string) bool {
+	parsed, err := uuid.Parse(value)
+	return err == nil && parsed != uuid.Nil && parsed.String() == value
+}
+
+func canonicalDigest(value string) bool {
+	if len(value) != len("sha256:")+64 || !strings.HasPrefix(value, "sha256:") {
+		return false
+	}
+	_, err := hex.DecodeString(value[len("sha256:"):])
+	return err == nil
+}
+
+func boundedResourceText(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) && len(value) <= maxResourceUIDTextBytes &&
+		!strings.ContainsAny(value, "\x00\r\n")
+}
+
+func boundedResourceID(value string) bool {
+	return boundedResourceText(value) && projectgraph.ResourceID(value).Valid()
+}
+
+// authoredResourceIDValid follows the graph resource-ID grammar directly.
+// Unlike control-plane project IDs, authored IDs are not bounded by the
+// storage metadata text limit; PostgreSQL text has no such 255-byte ceiling.
+func authoredResourceIDValid(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) &&
+		!strings.ContainsAny(value, "\x00\r\n") && projectgraph.ResourceID(value).Valid()
+}
+
+func registryIdentityValid(instanceID, projectID, authoredID string, kind projectgraph.Kind) bool {
+	return instanceidentity.Valid(instanceID) && boundedResourceID(projectID) &&
+		authoredResourceIDValid(authoredID) && authoredResourceKindValid(kind)
+}
+
+func validContractEvidence(kind projectgraph.Kind, profile, version, digest, authoredID string, bytes []byte) bool {
+	// Version syntax and canonical structure belong to FAI-620, not to a
+	// second registry-specific parser. Canonical evidence is an exact tuple.
+	if profile != contractProfile || version == "" || !canonicalDigest(digest) || len(bytes) == 0 {
+		return false
+	}
+	return validPublishedContract(kind, version, digest, authoredID, bytes)
+}
+
+// validPublishedContract delegates structural validation to the FAI-620
+// publication decoders. Registry rows must not merely contain hash-shaped
+// bytes: the bytes must be the canonical publication for this authored ID and
+// resource kind. The caller checks the authored ID separately because the
+// generated views intentionally expose it under kind-specific metadata.
+func validPublishedContract(kind projectgraph.Kind, version, digest, authoredID string, bytes []byte) bool {
+	switch kind {
+	case projectgraph.KindSource:
+		value, err := contractprojection.DecodeSourcePublication(bytes)
+		publishedDigest, digestErr := contractprojection.DigestSourcePublication(bytes)
+		return err == nil && digestErr == nil && publishedDigest == digest && value.Profile == contractprojection.Profile && value.Metadata.Contract.Version == version && value.Metadata.ID == authoredID
+	case projectgraph.KindModel:
+		value, err := contractprojection.DecodeModelPublication(bytes)
+		publishedDigest, digestErr := contractprojection.DigestModelPublication(bytes)
+		return err == nil && digestErr == nil && publishedDigest == digest && value.Profile == contractprojection.Profile && value.Metadata.Contract.Version == version && value.Metadata.ID == authoredID
+	case projectgraph.KindSemanticModel:
+		value, err := contractprojection.DecodeSemanticModelPublication(bytes)
+		publishedDigest, digestErr := contractprojection.DigestSemanticModelPublication(bytes)
+		return err == nil && digestErr == nil && publishedDigest == digest && value.Profile == contractprojection.Profile && value.Metadata.Contract.Version == version && value.Metadata.ID == authoredID
+	default:
+		return false
+	}
+}
+
+func validContractStatus(kind projectgraph.Kind, status, profile, version, digest, authoredID string, bytes []byte) bool {
+	switch status {
+	case "canonical":
+		return validContractEvidence(kind, profile, version, digest, authoredID, bytes) && profile != ""
+	case "unversioned":
+		return (kind == projectgraph.KindSource || kind == projectgraph.KindModel || kind == projectgraph.KindSemanticModel) && profile == "" && version == "" && digest == "" && len(bytes) == 0
+	case "not_contract_bearing":
+		return (kind == projectgraph.KindConnection || kind == projectgraph.KindPipeline || kind == projectgraph.KindDashboard) && profile == "" && version == "" && digest == "" && len(bytes) == 0
+	default:
+		return false
+	}
+}
+
+func (record ResourceUIDRecord) Validate() error {
+	if record.UID.Validate() != nil || !registryIdentityValid(record.InstanceID, record.ProjectID, record.AuthoredID, record.Kind) ||
+		!canonicalUUID(record.FirstGeneration) || !canonicalUUID(record.LatestGeneration) {
+		return ErrInvalidResourceUID
+	}
+	switch record.State {
+	case ResourceUIDActive:
+		if record.RemovedInGeneration != "" || !canonicalUUID(record.CurrentGeneration) || record.CurrentGeneration != record.LatestGeneration {
+			return ErrInvalidResourceUID
+		}
+	case ResourceUIDTombstoned:
+		if record.CurrentGeneration != "" || !canonicalUUID(record.RemovedInGeneration) || record.RemovedInGeneration != record.LatestGeneration {
+			return ErrInvalidResourceUID
+		}
+	default:
+		return ErrInvalidResourceUID
+	}
+	return nil
+}
+
+func (binding ResourceUIDBinding) Validate() error {
+	contractBytes := binding.ContractBytes
+	if binding.ResourceUID.Validate() != nil || !registryIdentityValid(binding.InstanceID, binding.ProjectID, binding.AuthoredID, binding.Kind) ||
+		!boundedResourceText(binding.TargetID) || binding.TargetID != binding.InstanceID ||
+		projectgraph.ValidateServingEnvironment(binding.Environment) != nil || !canonicalUUID(binding.GenerationID) ||
+		!validContractStatus(binding.Kind, binding.ContractStatus, binding.ContractProfile, binding.ContractVersion, binding.ContractDigest, binding.AuthoredID, contractBytes) {
+		return ErrInvalidResourceUID
+	}
+	return nil
+}
+
+func (restore ResourceUIDRestoreAuthorization) Validate() error {
+	if !canonicalUUID(restore.RestoreID) || restore.ResourceUID.Validate() != nil ||
+		!registryIdentityValid(restore.InstanceID, restore.ProjectID, restore.AuthoredID, restore.Kind) ||
+		projectgraph.ValidateServingEnvironment(restore.Environment) != nil || restore.TargetID != restore.InstanceID ||
+		!canonicalUUID(restore.GenerationID) || !boundedResourceText(restore.ActorID) ||
+		strings.IndexFunc(restore.ActorID, unicode.IsControl) >= 0 || !canonicalDigest(restore.RequestDigest) {
+		return ErrInvalidResourceUID
+	}
+	if restore.Status == "pending" {
+		if !restore.ConsumedAt.IsZero() {
+			return ErrInvalidResourceUID
+		}
+		return nil
+	}
+	if restore.Status == "consumed" {
+		if restore.ConsumedAt.IsZero() {
+			return ErrInvalidResourceUID
+		}
+		return nil
+	}
+	return ErrInvalidResourceUID
+}

--- a/internal/project/resource_uid_long_id_test.go
+++ b/internal/project/resource_uid_long_id_test.go
@@ -1,0 +1,46 @@
+package project
+
+import (
+	"strings"
+	"testing"
+
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+)
+
+func TestResourceUIDBindingAcceptsLongAuthoredID(t *testing.T) {
+	authoredID := strings.Repeat("a", 300)
+	instanceID := "lvinst_" + strings.Repeat("a", 32)
+	generationID := "11111111-1111-4111-8111-111111111111"
+	binding := ResourceUIDBinding{
+		ResourceUID:    ResourceUID("22222222-2222-4222-8222-222222222222"),
+		InstanceID:     instanceID,
+		ProjectID:      "project",
+		Environment:    "production",
+		TargetID:       instanceID,
+		GenerationID:   generationID,
+		AuthoredID:     authoredID,
+		Kind:           projectgraph.KindConnection,
+		ContractStatus: "not_contract_bearing",
+	}
+	if err := binding.Validate(); err != nil {
+		t.Fatalf("long authored ID rejected: %v", err)
+	}
+}
+
+func TestResourceUIDRecordAcceptsLongAuthoredID(t *testing.T) {
+	authoredID := strings.Repeat("b", 300)
+	record := ResourceUIDRecord{
+		UID:               ResourceUID("33333333-3333-4333-8333-333333333333"),
+		InstanceID:        "lvinst_" + strings.Repeat("b", 32),
+		ProjectID:         "project",
+		AuthoredID:        authoredID,
+		Kind:              projectgraph.KindModel,
+		State:             ResourceUIDActive,
+		FirstGeneration:   "44444444-4444-4444-8444-444444444444",
+		LatestGeneration:  "44444444-4444-4444-8444-444444444444",
+		CurrentGeneration: "44444444-4444-4444-8444-444444444444",
+	}
+	if err := record.Validate(); err != nil {
+		t.Fatalf("long authored ID rejected: %v", err)
+	}
+}

--- a/internal/project/resource_uid_validation_test.go
+++ b/internal/project/resource_uid_validation_test.go
@@ -1,0 +1,58 @@
+package project_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	project "github.com/flidai/leapview/internal/project"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+)
+
+func TestResourceUIDBindingRejectsUnsealedOrDriftingContractEvidence(t *testing.T) {
+	inventory, err := project.NewResourceUIDInventory(inventoryBundle(t, true))
+	if err != nil { t.Fatal(err) }
+	encoded, _ := inventory.JSON()
+	var entries []struct {
+		ID string `json:"authored_id"`
+		Profile string `json:"contract_profile"`
+		Version string `json:"contract_version"`
+		Canonical string `json:"canonical_contract"`
+		Digest string `json:"contract_digest"`
+	}
+	if err := json.Unmarshal(encoded, &entries); err != nil { t.Fatal(err) }
+	entry := entries[1]
+	instance := "lvinst_" + strings.Repeat("a", 32)
+	valid := project.ResourceUIDBinding{
+		ResourceUID: "0198f2c0-7c7a-7f00-8a11-000000001001", InstanceID: instance, TargetID: instance,
+		ProjectID: "project:test", Environment: "prod", GenerationID: "0198f2c0-7c7a-7f00-8a11-000000001002",
+		AuthoredID: entry.ID, Kind: projectgraph.KindSource, ContractStatus: "canonical",
+		ContractProfile: entry.Profile, ContractVersion: entry.Version, ContractDigest: entry.Digest, ContractBytes: []byte(entry.Canonical),
+	}
+	if err := valid.Validate(); err != nil { t.Fatalf("valid evidence: %v", err) }
+	for name, change := range map[string]func(*project.ResourceUIDBinding){
+		"missing status": func(b *project.ResourceUIDBinding) { b.ContractStatus = "" },
+		"missing version": func(b *project.ResourceUIDBinding) { b.ContractVersion = "" },
+		"different version": func(b *project.ResourceUIDBinding) { b.ContractVersion = "2.0.0" },
+		"different resource": func(b *project.ResourceUIDBinding) { b.AuthoredID = "source:other" },
+		"different kind": func(b *project.ResourceUIDBinding) { b.Kind = projectgraph.KindModel },
+		"hash-shaped fake": func(b *project.ResourceUIDBinding) { b.ContractBytes = []byte(`{}`) },
+		"different hash": func(b *project.ResourceUIDBinding) { b.ContractDigest = "sha256:" + strings.Repeat("0", 64) },
+		"invalid scope": func(b *project.ResourceUIDBinding) { b.TargetID = "lvinst_" + strings.Repeat("b", 32) },
+		"invented unversioned evidence": func(b *project.ResourceUIDBinding) { b.ContractStatus = "unversioned" },
+	} {
+		t.Run(name, func(t *testing.T) { changed := valid; change(&changed); if changed.Validate() == nil { t.Fatal("accepted invalid binding") } })
+	}
+	unversioned := valid
+	unversioned.ContractStatus = "unversioned"
+	unversioned.ContractProfile, unversioned.ContractVersion, unversioned.ContractDigest, unversioned.ContractBytes = "", "", "", nil
+	if err := unversioned.Validate(); err != nil { t.Fatalf("unversioned: %v", err) }
+	unversioned.ContractStatus = ""
+	if unversioned.Validate() == nil { t.Fatal("accepted omitted status as an unversioned fallback") }
+}
+
+func TestResourceUIDRejectsNonCanonicalIdentity(t *testing.T) {
+	for _, value := range []string{"", "00000000-0000-0000-0000-000000000000", "0198F2C0-7C7A-7F00-8A11-000000001001", "source:orders"} {
+		if _, err := project.ParseResourceUID(value); err == nil { t.Fatalf("accepted %q", value) }
+	}
+}

--- a/internal/refresh/postgres/repository_test.go
+++ b/internal/refresh/postgres/repository_test.go
@@ -217,13 +217,46 @@ func TestPostgresRefreshConcurrentOccurrenceClaimAndFence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	first, err := r.ClaimAttempt(t.Context(), "run_1", "worker-a", 1, 10*time.Millisecond)
+	first, err := r.ClaimAttempt(t.Context(), "run_1", "worker-a", 1, time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Let the short lease expire before exercising takeover; direct runtime
-	// updates cannot fabricate an expired running lease.
-	time.Sleep(25 * time.Millisecond)
+	// Fabricate an expired running lease through a narrowly scoped privileged
+	// transaction; direct runtime updates cannot bypass the lifecycle guards.
+	tx, err := admin.Begin(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(t.Context())
+	if _, err := tx.Exec(t.Context(), `SET LOCAL session_replication_role = replica`); err != nil {
+		t.Fatal(err)
+	}
+	const expiredLease = "2000-01-01 00:00:00+00"
+	if tag, err := tx.Exec(t.Context(), `UPDATE refresh.run SET lease_expires_at=$1::timestamptz WHERE run_id=$2 AND status='running' AND lease_owner=$3 AND fence_generation=$4`, expiredLease, "run_1", first.OwnerID, first.FenceGeneration); err != nil {
+		t.Fatal(err)
+	} else if tag.RowsAffected() != 1 {
+		t.Fatalf("expired run lease update affected %d rows, want one", tag.RowsAffected())
+	}
+	if tag, err := tx.Exec(t.Context(), `UPDATE refresh.attempt SET lease_expires_at=$1::timestamptz WHERE run_id=$2 AND attempt_number=$3 AND status='running' AND owner_id=$4 AND fence_generation=$5`, expiredLease, "run_1", first.AttemptNumber, first.OwnerID, first.FenceGeneration); err != nil {
+		t.Fatal(err)
+	} else if tag.RowsAffected() != 1 {
+		t.Fatalf("expired attempt lease update affected %d rows, want one", tag.RowsAffected())
+	}
+	if err := tx.Commit(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	var runExpired, attemptExpired bool
+	if err := admin.QueryRow(t.Context(), `
+		SELECT r.lease_expires_at < clock_timestamp(), a.lease_expires_at < clock_timestamp()
+		FROM refresh.run AS r
+		JOIN refresh.attempt AS a ON a.run_id = r.run_id
+		WHERE r.run_id = $1 AND a.attempt_number = $2
+	`, "run_1", first.AttemptNumber).Scan(&runExpired, &attemptExpired); err != nil {
+		t.Fatal(err)
+	}
+	if !runExpired || !attemptExpired {
+		t.Fatalf("PostgreSQL did not observe both leases expired: run=%t attempt=%t", runExpired, attemptExpired)
+	}
 	second, err := r.ClaimAttempt(t.Context(), "run_1", "worker-b", 2, time.Minute)
 	if err != nil {
 		t.Fatal(err)

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -92,7 +92,12 @@ sql:
 
   - engine: "postgresql"
     queries: "internal/project/postgres/queries"
-    schema: "internal/project/postgres/schema.sql"
+    schema:
+      - "internal/project/postgres/schema.sql"
+      - "internal/platform/bootstrap/postgres/schema.sql"
+      - "internal/deployment/postgres/schema.sql"
+      - "internal/servingstate/postgres/schema.sql"
+      - "internal/project/postgres/resource_uid_schema.sql"
     gen:
       go:
         package: "db"


### PR DESCRIPTION
## Problem

FAI-620 established canonical contract identity, but the runtime lacked stable instance-local resource identity beneath its issuer-owned Project namespace.

## Root cause

Portable authored IDs and Project-qualified serving generations did not provide an activation-owned registry with immutable ResourceUIDs, lifecycle history, or exact-generation restore authority. Serving asset hashes are not a substitute for canonical contract identity.

The compiler's common discovery envelope also omitted the already-generated `metadata.contract` field, rejecting otherwise valid versioned Source/Model authoring before projection. The narrow envelope fix preserves generated per-kind validation.

## Solution

- Add the instance-local, Project-scoped ResourceUID registry and additive migration 003; leave migrations 001/002 unchanged.
- Admit a complete, sealed inventory from the verified portable bundle without allocating UIDs or modifying portable artifacts.
- Allocate random UIDs only within authoritative activation, atomically with the protected publication/pointer transition.
- Retain FAI-620 canonical contract bytes, profile, version, and digest when authored authority exists; distinguish unversioned and non-contract-bearing resources without inventing contract versions.
- Preserve UID reuse, immutable kind, tombstones, exact-generation privileged restore, and historical rollback identity.
- Require instance/Project-qualified repository lookups and deny direct runtime registry mutation and standalone allocator access.
- Preserve generated Source/Model contract metadata in the compiler's common discovery envelope; per-kind generated validation remains authoritative.

## Guarantees

ResourceUID is instance-local, Project-scoped, stable, and independent of names, paths, environments, dbt identifiers, and artifact/serving hashes. Failed activation rolls back identity writes. Concurrent first activation produces one fresh activation and one replay, not duplicate identities.

## Tests added/updated

- Sealed inventory completeness, deterministic canonical evidence, missing/mismatched evidence rejection, and no invented versions.
- Compiler contract metadata and registry authored-ID validation regressions.
- Real PostgreSQL activation lifecycle: allocation, reuse, kind-conflict rollback without leaked UIDs, synchronized concurrent first activation, replay, tombstone immutability, authorized restore consumption, historical rollback, and instance/Project isolation.
- Migration/schema parity, runtime privilege denial, generation admission, and recovery fixtures.

## Verification

Rebased without conflicts onto `a97e07e35abb11a9f97052c28a3d8a1855c850bb`; range-diff confirms the isolated feature patch is unchanged.

- PASS: `task generate`
- PASS: `task generated:check`
- PASS: `task test:go:packages`
- PASS: `go test -tags duckdb_arrow ./... -run '^$' -count=0 -p 2`
- PASS: focused registry/compiler, activation, migration, and isolation tests, including real PostgreSQL with `LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED=1`
- BLOCKED (environment): `task ci` stopped in `TestMinIOParquetSourceRefreshContract` while uploading the fixture: HTTP 507 `XMinioStorageFull` (minimum free drive threshold). A targeted retry after removing stale disposable build-cache entries failed with the same error. No validation was disabled and no production/test code was changed to bypass this failure. Full CI must pass on a runner with sufficient disk capacity before merge.
- PASS: `git diff origin/main...HEAD --check`

## Explicit non-goals and limitations

- No semantic resolver closure, publication authority, DataPolicy cutover, or dbt integration changes.
- No FAI-622, FAI-671, FAI-675, or historical ADR-stack implementation is imported.
- Legacy generations without retained inventory require re-admission; migration does not fabricate identities or backfill authority from serving assets.
- The existing serving-asset 255-byte logical-ID limit remains unchanged; registry validation does not introduce another authored-ID limit.
- Canonical structure is validated by the trusted Go compiler/admission capability. PostgreSQL independently checks scope, graph completeness, tuple identity, and digests; it does not reimplement SQL-AST validation.
- Registry restore does not reauthorize control-plane grants or publications. This is foundation qualification, not final ADR-0018 conformance.

Refs [FAI-670](https://linear.app/flid/issue/FAI-670/implement-the-missing-instance-local-resourceuid-registry-contract).
