### PR TITLE
CI: overlap independent full validation groups

### DIFF
--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Run merge-only validation
         id: merge-validation
-        run: task ci:full:extras
+        run: task ci:full:extras:hosted
 
       - name: Upload UI visual-regression failure artifacts
         if: ${{ failure() && steps.merge-validation.outcome == 'failure' }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1483,18 +1483,58 @@ tasks:
       - task: ci:full:extras
 
   ci:full:extras:
-    desc: Run merge-only validation on prepared inputs; hosted merge CI runs this alongside base lanes
+    desc: Run merge-only validation sequentially on prepared inputs for local and nightly CI
     cmds:
       - task: desktop:test
+      - task: ci:full:extras:static
+      - task: ci:full:extras:runtime:multinode
+      - task: qa:ui-framework
+      - task: ci:full:extras:runtime:tail
+
+  ci:full:extras:static:
+    internal: true
+    desc: Run static merge-only validation
+    cmds:
       - go vet ./...
       - go test -race ./pkg/...
       - task: quality:critical:race
       - task: test:workload:qualify
+
+  ci:full:extras:runtime:
+    internal: true
+    desc: Run runtime merge-only validation
+    cmds:
+      - task: ci:full:extras:runtime:multinode
+      - task: ci:full:extras:runtime:tail
+
+  ci:full:extras:parallel:
+    internal: true
+    desc: Run independent static and runtime validation concurrently
+    deps:
+      - task: ci:full:extras:static
+      - task: ci:full:extras:runtime
+
+  ci:full:extras:runtime:multinode:
+    internal: true
+    desc: Run container-backed PostgreSQL multinode validation
+    cmds:
       - task: test:go:postgres-multinode-qualification
-      - task: qa:ui-framework
+
+  ci:full:extras:runtime:tail:
+    internal: true
+    desc: Run deployment and object-backed runtime validation
+    cmds:
       - task: deploy:check
       - task: test:go:minio-conformance
       - task: test:go:plan-gc-conformance
+
+  ci:full:extras:hosted:
+    desc: Run merge-only validation with bounded hosted parallelism
+    cmds:
+      - task: desktop:test
+      - task: qa:ui-framework
+      - task: generate
+      - task: ci:full:extras:parallel
 
   ci:nightly:
     desc: Run exhaustive scheduled validation, including dependency security scans

--- a/deploy/hetzner-site/deployment_test.go
+++ b/deploy/hetzner-site/deployment_test.go
@@ -505,7 +505,7 @@ func TestMergeValidationValidatesPermanentSiteInfrastructure(t *testing.T) {
 	for _, fragment := range []string{
 		"runs-on: ubuntu-24.04",
 		"uses: ./.github/actions/setup-ci",
-		"run: task ci:full:extras",
+		"run: task ci:full:extras:hosted",
 	} {
 		requireContains(t, mergeValidation, fragment)
 	}

--- a/docs/articles/architecture/github-hosted-ci.md
+++ b/docs/articles/architecture/github-hosted-ci.md
@@ -42,7 +42,9 @@ candidate, then run selected APIGen, Go package/application, frontend, docs/site
 dbt, and spatial validation lanes concurrently. Unknown and cross-cutting inputs, manual
 dispatch, the `ci:full` label, and deterministic audit PRs run the full PR tier. The repository validation jobs execute `task ci:prepare`; the independent APIGen module
 does not need generated or embedded application assets and skips that preparation. The merge queue
-adds `task ci:full:extras`, and the daily schedule also runs `task ci:nightly:extras`. Local
+adds bounded overlap through `task ci:full:extras:hosted`; local and nightly full validation retain
+the sequential `task ci:full:extras` contract, and the daily schedule also runs
+`task ci:nightly:extras`. Local
 composition remains available through the tier targets; the workflow does not duplicate individual
 test commands or introduce a runner-specific container wrapper.
 

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -3051,7 +3051,7 @@ func TestContinuousIntegrationWorkflowsAreTieredAndMergeQueueAware(t *testing.T)
 		"name: Full merge validation",
 		"runs-on: ubuntu-24.04",
 		"uses: ./.github/actions/setup-ci",
-		"run: task ci:full:extras",
+		"run: task ci:full:extras:hosted",
 		"name: CI gate",
 		"needs: [apigen-validation, go-packages-validation, go-application-validation, frontend-validation, full-validation]",
 	} {

--- a/internal/platform/architecture/ci_contract_test.go
+++ b/internal/platform/architecture/ci_contract_test.go
@@ -105,15 +105,94 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 	fullExtras := taskfileTaskBlock(t, taskfile, "ci:full:extras")
 	for _, want := range []string{
 		"- task: desktop:test",
-		"go vet ./...",
-		"go test -race ./pkg/...",
-		"- task: quality:critical:race",
-		"- task: test:go:postgres-multinode-qualification",
+		"- task: ci:full:extras:static",
+		"- task: ci:full:extras:runtime:multinode",
 		"- task: qa:ui-framework",
-		"- task: deploy:check",
+		"- task: ci:full:extras:runtime:tail",
 	} {
 		if !strings.Contains(fullExtras, want) {
 			t.Fatalf("ci:full:extras missing %q", want)
+		}
+	}
+	fullExtrasOrder := []string{
+		"- task: desktop:test",
+		"- task: ci:full:extras:static",
+		"- task: ci:full:extras:runtime:multinode",
+		"- task: qa:ui-framework",
+		"- task: ci:full:extras:runtime:tail",
+	}
+	for index := 1; index < len(fullExtrasOrder); index++ {
+		if strings.Index(fullExtras, fullExtrasOrder[index-1]) > strings.Index(fullExtras, fullExtrasOrder[index]) {
+			t.Fatalf("ci:full:extras changed sequential command order: %q before %q", fullExtrasOrder[index-1], fullExtrasOrder[index])
+		}
+	}
+	staticExtras := taskfileTaskBlock(t, taskfile, "ci:full:extras:static")
+	for _, want := range []string{
+		"go vet ./...",
+		"go test -race ./pkg/...",
+		"- task: quality:critical:race",
+		"- task: test:workload:qualify",
+	} {
+		if !strings.Contains(staticExtras, want) {
+			t.Fatalf("ci:full:extras:static missing %q", want)
+		}
+	}
+	if strings.Contains(staticExtras, "test:go:postgres-multinode-qualification") {
+		t.Fatal("container-backed PostgreSQL multinode validation must remain in the runtime branch")
+	}
+	runtimeExtras := taskfileTaskBlock(t, taskfile, "ci:full:extras:runtime")
+	for _, want := range []string{
+		"- task: ci:full:extras:runtime:multinode",
+		"- task: ci:full:extras:runtime:tail",
+	} {
+		if !strings.Contains(runtimeExtras, want) {
+			t.Fatalf("ci:full:extras:runtime missing %q", want)
+		}
+	}
+	parallelExtras := taskfileTaskBlock(t, taskfile, "ci:full:extras:parallel")
+	for _, want := range []string{
+		"deps:",
+		"- task: ci:full:extras:static",
+		"- task: ci:full:extras:runtime",
+	} {
+		if !strings.Contains(parallelExtras, want) {
+			t.Fatalf("ci:full:extras:parallel missing %q", want)
+		}
+	}
+	runtimeMultinode := taskfileTaskBlock(t, taskfile, "ci:full:extras:runtime:multinode")
+	if !strings.Contains(runtimeMultinode, "- task: test:go:postgres-multinode-qualification") {
+		t.Fatal("runtime multinode group missing PostgreSQL qualification")
+	}
+	runtimeTail := taskfileTaskBlock(t, taskfile, "ci:full:extras:runtime:tail")
+	for _, want := range []string{
+		"- task: deploy:check",
+		"- task: test:go:minio-conformance",
+		"- task: test:go:plan-gc-conformance",
+	} {
+		if !strings.Contains(runtimeTail, want) {
+			t.Fatalf("ci:full:extras:runtime:tail missing %q", want)
+		}
+	}
+	hostedExtras := taskfileTaskBlock(t, taskfile, "ci:full:extras:hosted")
+	for _, want := range []string{
+		"- task: desktop:test",
+		"- task: qa:ui-framework",
+		"- task: generate",
+		"- task: ci:full:extras:parallel",
+	} {
+		if !strings.Contains(hostedExtras, want) {
+			t.Fatalf("ci:full:extras:hosted missing %q", want)
+		}
+	}
+	hostedExtrasOrder := []string{
+		"- task: desktop:test",
+		"- task: qa:ui-framework",
+		"- task: generate",
+		"- task: ci:full:extras:parallel",
+	}
+	for index := 1; index < len(hostedExtrasOrder); index++ {
+		if strings.Index(hostedExtras, hostedExtrasOrder[index-1]) > strings.Index(hostedExtras, hostedExtrasOrder[index]) {
+			t.Fatalf("ci:full:extras:hosted changed barrier/order: %q before %q", hostedExtrasOrder[index-1], hostedExtrasOrder[index])
 		}
 	}
 	nightly := taskfileTaskBlock(t, taskfile, "ci:nightly")
@@ -154,7 +233,7 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 		"run: task ci:lane:go:packages",
 		"run: task ci:lane:go:application",
 		"run: task ci:lane:frontend:shard SHARD=${{ matrix.shard }}",
-		"run: task ci:full:extras",
+		"run: task ci:full:extras:hosted",
 	} {
 		if !strings.Contains(mergeWorkflow, want) {
 			t.Fatalf("merge queue must run the split full tier against the exact merge group: missing %q", want)

--- a/internal/platform/ci/merge_workflow_test.go
+++ b/internal/platform/ci/merge_workflow_test.go
@@ -49,7 +49,7 @@ func TestMergeWorkflowIndependentLanesAndStrictGate(t *testing.T) {
 		if step.Run == "node scripts/ci_watchdog.mjs --timeout-seconds 420 --attempts 2 -- task ci:prepare" && step.If == "" {
 			prepared = true
 		}
-		if step.Run == "task ci:full:extras" && step.If == "" {
+		if step.Run == "task ci:full:extras:hosted" && step.If == "" {
 			if !prepared {
 				t.Fatal("independent extras must prepare their own inputs first")
 			}

--- a/internal/platform/ci/remaining-critical-path-profile.md
+++ b/internal/platform/ci/remaining-critical-path-profile.md
@@ -2,10 +2,11 @@
 
 ## Current optimization record — post-#540, 2026-09-08
 
-**Target not achieved — further work deferred pending hosted experiment evidence.**
-The latest successful merge-group candidate observation is **16m14s**. There is only one
-successful post-#540 candidate; a representative post-#540 merge p95 is **not
-established**. No projected result is treated as a measured quantile.
+**Target not achieved — further work deferred.**
+The latest eligible merge-group candidate observation is **13m19s**. Across one
+pre-#544 warm baseline and two successful post-#544 candidates, a representative
+post-#540 merge p95 is **not established**. No projected result is treated as a
+measured quantile.
 
 ### Baseline and eligibility
 
@@ -176,9 +177,7 @@ not evidence that tests executed.
 **Decision criteria:** compare exact-SHA successful hosted merge candidates with
 matching warm-cache provenance, record cold/miss runs separately, confirm every
 required lane/security/native proof, and measure PostgreSQL and total elapsed.
-If no material elapsed reduction is supported, revert the concurrency change
-rather than adding another optimization. One after run is an observation, not a
-new representative p95. Hosted result and final retain/revert decision are pending.
+One after run is an observation, not a new representative p95.
 
 **Local validation:** planner/gate/reporting and complete architecture tests passed;
 frontend workflow contracts, quality budget/exception checks, and workflow lint
@@ -188,6 +187,71 @@ source inventory is byte-identical at 54 packages after adding the contract test
 `task ci` ran generation and SQL verification, then stopped at PostgreSQL baseline
 validation because this workspace cannot access Docker. This is an environment
 blocker; real PostgreSQL execution and resource contention require hosted CI.
+
+### Hosted outcome after PR #544
+
+Two successful `merge_group` runs contain the four-worker change. Run
+[34245738076](https://github.com/flidai/leapview/actions/runs/34245738076) tested
+PR #544's merge SHA `d1bc8043939311f53f6b01708a7833992daa227e`, attempt 1.
+Run [34276117337](https://github.com/flidai/leapview/actions/runs/34276117337)
+tested `4f677d4b9e18c65085299734556eeeca390f5305`, attempt 1; GitHub's commit
+comparison reports that SHA is one commit ahead of the PR #544 merge SHA. Both
+workflows and every merge-validation job, including CI gate, completed
+successfully.
+
+Merge duration below is workflow start through CI gate completion. PostgreSQL
+duration is the hosted command interval from the conformance task marker through
+its final package result. All timestamps are UTC on 2026-09-08.
+
+| Metric | Pre-#544 warm observation | Run 34245738076 | Run 34276117337 |
+|---|---:|---:|---:|
+| Workflow start / gate completion | 14:25:05 / 14:41:19 | 15:35:32 / 15:54:25 | 20:39:47 / 20:53:06 |
+| Merge duration | **16m14s** | **18m53s** | **13m19s** |
+| Go packages job | 8m05s | 7m33s | 10m10s |
+| Go application job | 16m01s | 12m15s | 11m43s |
+| PostgreSQL conformance | 12m36s | **8m50s** | **8m03s** |
+| Full validation job | 13m22s | 18m43s | 13m07s |
+| Critical-path validation | Go application | Full validation | Full validation |
+
+The exact tested version of `scripts/postgres-conformance-tests.sh` contains
+`go test ... -p 4 -count=1` at both SHAs. Each application log has 54 unique,
+successful package result lines after the PostgreSQL conformance marker, matching
+the complete source inventory. Coverage, freshness and failure behavior therefore
+remained active in these observations.
+
+The targeted lane improved materially: PostgreSQL fell by 3m46s and 4m33s, and
+Go application fell by 3m46s and 4m18s. End-to-end merge improvement is not yet
+consistent. The first candidate was 2m39s slower because full validation expanded
+to 18m43s; the next was 2m55s faster, at 13m19s. Across only these two after runs,
+there is no representative p95 and no defensible claim of a material typical
+merge-latency reduction. Full validation replaced Go application as the blocking
+lane in both runs.
+
+**Decision:** retain the bounded concurrency result as successful for its targeted
+lane, but stop this experiment without claiming the merge p95 improved. The best
+observed merge remains 1m19s above the threshold, so the **<12m target was not
+reached**.
+
+### Experiment 2 — bounded full-validation overlap
+
+**Before:** run 34276117337 completed full validation in **13m07s**, including a
+9m44s merge-extras body. Its slowest sequential groups were UI QA at 3m30s,
+plan/GC conformance at 2m15s, and critical race qualification at 2m10s.
+
+**Implementation:** the merge workflow uses `ci:full:extras:hosted`. Desktop and
+UI QA remain serial because they build or regenerate workspace inputs and UI QA
+owns fixed `.tmp` server state. A serial `generate` barrier follows UI QA. The
+remaining work then has two concurrent Task dependency branches: a static branch
+with vet, package race, critical race and workload validation; and a runtime
+branch with PostgreSQL multinode, deployment, MinIO and plan/GC validation. The
+runtime branch remains serial so container-backed checks do not compete with one
+another. The ordinary `ci:full:extras` target retains its original sequential
+order for local and nightly execution.
+
+Every existing validation command remains present. The workflow job name, CI gate
+dependency, required checks, candidate checkout, native proof and failure-artifact
+behavior are unchanged. Hosted evidence and the retain/revert decision are
+pending.
 
 ## Historical pre-#540 profile
 


### PR DESCRIPTION
## Problem

The best post-#544 merge candidate took 13m19s, with Full merge validation blocking for 13m07s. Its merge-only commands ran serially for 9m44s; UI QA, lifecycle/GC conformance, and critical race qualification were the largest groups.

## Solution

Keep desktop and UI QA serial, then re-establish generated inputs before running two independent Task dependency branches concurrently:

- static: vet, package race, critical race, workload
- runtime: PostgreSQL multinode, deployment, MinIO, lifecycle/GC, all serial within the branch

Local and nightly full validation retain their original sequential order. The merge workflow remains one `Full merge validation` job.

## Safety

Every validation command remains present. UI QA completes before concurrency because it owns fixed temporary server state and regenerates assets. A generation barrier prevents writers from overlapping static readers. Container-backed work remains serial. CI gate dependencies, required check names, exact-candidate checkout, native proof, caches, planner behavior, and security workflows are unchanged.

## Verification

Passed focused CI/gate/reporting, architecture, deployment, frontend workflow, UI QA contract, quality, workflow lint, Task graph, documentation, and diff checks. The hosted target and `task ci` both reached required Docker-backed checks locally and failed closed because this account cannot access the Docker daemon.

Hosted PR and merge-queue evidence is required before claiming an elapsed-time improvement or the 12-minute target.

Related to #520.