### PR TITLE
fix(runtime): enforce server-bound Project boundaries (FAI-671)

### DIFF
--- a/adr/specifications/project-runtime-boundary-audit.md
+++ b/adr/specifications/project-runtime-boundary-audit.md
@@ -1,0 +1,48 @@
+# FAI-671 isolated runtime boundary evidence
+
+This is a partial implementation slice of [ADR-0018](../0018-retain-project-as-the-durable-deployment-namespace.md),
+not final Project namespace conformance. FAI-671 completion remains blocked by
+FAI-670. No downstream work is unblocked by this patch.
+
+## Extraction inventory
+
+Base: `a97e07e35abb11a9f97052c28a3d8a1855c850bb`. Historical commit
+`9fa6851e1a7108af1e4b93802e817614b3d0fedd` is a reference, not a merged branch.
+
+| Historical surface | Treatment in this slice |
+| --- | --- |
+| `internal/access/module/apigen.go` and boundary tests | Adapt locator rejection at the existing authorizer |
+| `internal/app/runtime_router_routes.go` and boundary tests | Adapt shared query-selector rejection |
+| `internal/app/composition.go` and claim tests | Adapt validation of existing durable claim evidence |
+| `internal/analytics/cache/key_test.go` | Extract and extend partition assertions into `project_boundary_test.go`; no cache production changes |
+| `internal/app/api/protocol/project_boundary_test.go` | Reuse locator partition and replay reauthorization coverage |
+| Historical evidence matrix / architecture link test | Replace with this limited matrix; do not import wider completion claims |
+| Historical delta map and API operation-count updates | Exclude |
+| All `internal/deployment/module/*` changes | Exclude, including rollback and publication replay |
+| All `internal/release/*` changes | Exclude, including finalization and candidate provenance |
+
+There is no ResourceUID registry, activation, rollback, deployment binding,
+schema, migration, compiler identity, or canonical contract digest change.
+
+## Boundary matrix
+
+| Boundary | Existing authority and changed omission | Maintained evidence |
+| --- | --- | --- |
+| API-02 shared ingress | Singleton claim/runtime stays authoritative; reject query Project selectors before domain dispatch. Preserve the exact platform audit filter and bootstrap body. This does not claim to audit every request body. | `TestProjectBoundaryRejectsRequestSelectorsBeforeDispatch`, `TestProjectBoundaryPreservesBootstrapAndPlatformAuditFilter` in [app tests](../../internal/app/project_boundary_test.go) |
+| API-03 generated locators | Principal/platform authentication alone did not constrain Project locators. Resolve the existing server-bound `CurrentProjectID`, reject disagreement with a populated runtime-host identity, and leave resource snapshot and bootstrap/delivery authorizers intact. A valid resolver does not require an allocated runtime host. | `TestAPIGenProjectBoundaryPrincipalAndPlatformLocators` in [authorizer tests](../../internal/access/module/project_boundary_test.go); `TestProjectBoundaryGeneratedLocatorsCannotRetarget` in [app tests](../../internal/app/project_boundary_test.go); existing `TestPostgresRefreshRouteJourney` in [PostgreSQL journey tests](../../internal/app/postgres_refresh_journey_test.go) |
+| API-07 startup | Existing claim reader checks environment; now also validates the claim's identity and durable evidence. | `TestReadClaimedProjectFailsClosedAndChecksEnvironment` in [claim tests](../../internal/app/composition_project_claim_test.go) |
+| API-06 cache partition | Existing sealed partition includes target, Project, environment, and candidate identity; preserve the dependency-addressed cache design. No UID or generation token is substituted for contract/data identity. | `TestProjectBoundaryCacheKeysDoNotCollide`, `TestProjectBoundaryCacheRejectsMissingScope` in [cache tests](../../internal/analytics/cache/project_boundary_test.go); policy rotation in [key tests](../../internal/analytics/cache/key_test.go) |
+| API-06 idempotency | Existing protocol partitions by authenticated caller/credential, method, and path, validates request digest, and reauthorizes replay. Protocol-only tests do not claim multiple Projects can be served by one instance. | `TestProjectBoundaryIdempotencySeparatesLocatorsAndReauthorizes` in [protocol tests](../../internal/app/api/protocol/project_boundary_test.go) |
+
+## Remaining boundaries
+
+FAI-670 owns ResourceUID allocation, tombstone/restore audit and lifecycle
+qualification. This slice does not assess or change those guarantees.
+Release/deployment/rollback, storage/retention/cleanup, and the exhaustive
+catalog/lineage/audit/metadata/error-surface audit remain outside this extraction.
+Authorization and generation evidence at cache consumers still require the
+remaining end-to-end FAI-671 audit; partition tests alone do not prove it.
+
+Project is a product namespace, not a claim of same-process multi-Project
+isolation. Existing instance, claim, serving identity, and authorization
+mechanisms are preserved; no parallel Project-context abstraction is added.

--- a/internal/access/module/apigen.go
+++ b/internal/access/module/apigen.go
@@ -209,6 +209,27 @@ func (a *APIGenAuthorizer) Protect(operationID string, next http.Handler) (http.
 	if !apiGenExtensionModeMatches(contract) {
 		return nil, false
 	}
+	if strings.Contains(contract.Path, "{project}") && (scope == "platform" || contract.AuthzMode == "authenticated") {
+		// A principal/platform-scoped operation can still carry a Project
+		// locator (refresh, authoring, managed-data discovery). Authentication
+		// or platform admin must never turn that locator into a context switch.
+		// Resource and bootstrap operations use their existing snapshot/claim
+		// checks below, including before the first serving generation exists.
+		dispatch := next
+		next = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			projectID, err := projectgraph.NewResourceID(chi.URLParam(r, "project"))
+			if err != nil {
+				http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+				return
+			}
+			boundProjectID, ok := a.projectBoundaryProjectID(r.Context())
+			if !ok || projectID != boundProjectID {
+				http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+				return
+			}
+			dispatch.ServeHTTP(w, r)
+		})
+	}
 	if scope == "platform" {
 		return a.module.RequirePlatformAdmin(next), true
 	}
@@ -259,6 +280,39 @@ func (a *APIGenAuthorizer) Protect(operationID string, next http.Handler) (http.
 		return nil, false
 	}
 	return a.protectResources(operationID, capability, resolver, next), true
+}
+
+// projectBoundaryProjectID resolves the authoritative project identity for
+// principal/platform operations that carry a project locator. Application
+// composition supplies Module.CurrentProjectID even when no serving runtime
+// host exists; when configured, that resolver is authoritative and any
+// non-empty runtime-host identity must agree with it. Direct authorizer users
+// without the resolver retain the valid runtime-host path.
+func (a *APIGenAuthorizer) projectBoundaryProjectID(ctx context.Context) (projectgraph.ResourceID, bool) {
+	if a == nil || a.module == nil {
+		return "", false
+	}
+	if a.module.currentProjectID != nil {
+		boundProjectID, err := a.module.CurrentProjectID(ctx)
+		if err != nil || boundProjectID.Validate() != nil {
+			return "", false
+		}
+		if a.runtime != nil {
+			runtimeProjectID := a.runtime.ProjectID()
+			if runtimeProjectID != "" && (runtimeProjectID.Validate() != nil || runtimeProjectID != boundProjectID) {
+				return "", false
+			}
+		}
+		return boundProjectID, true
+	}
+	if a.runtime == nil {
+		return "", false
+	}
+	boundProjectID := a.runtime.ProjectID()
+	if boundProjectID.Validate() != nil {
+		return "", false
+	}
+	return boundProjectID, true
 }
 
 // isBootstrapAPIGenOperation is the exact pre-activation operation allowlist.

--- a/internal/access/module/project_boundary_test.go
+++ b/internal/access/module/project_boundary_test.go
@@ -1,0 +1,248 @@
+package module
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	runtimehostmodule "github.com/flidai/leapview/internal/runtimehost/module"
+)
+
+func TestAPIGenProjectBoundaryPrincipalAndPlatformLocators(t *testing.T) {
+	for _, scope := range []string{"principal", "platform"} {
+		t.Run(scope, func(t *testing.T) {
+			module := browserGuardModule(browserGuardRepository{admin: true}, Principal{ID: "admin"}, true)
+			contract := APIGenOperationContract{
+				OperationID: "boundMetadata",
+				Method:      http.MethodGet,
+				Path:        "/api/v1/projects/{project}/metadata",
+				Protected:   true,
+				AuthzMode:   "authenticated",
+				Extensions:  map[string]any{apiGenObjectScopeExtension: scope},
+			}
+			for _, bound := range []projectgraph.ResourceID{"project_demo", "", "invalid project"} {
+				authorizer, err := module.APIGenAuthorizer(
+					apigenRuntimeFake{project: bound},
+					map[string]APIGenOperationContract{"boundMetadata": contract},
+					APIGenResourceResolvers{},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				calls := 0
+				handler, ok := authorizer.Protect("boundMetadata", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					calls++
+					w.WriteHeader(http.StatusNoContent)
+				}))
+				if !ok {
+					t.Fatal("authorizer did not construct")
+				}
+				for _, locator := range []string{"project_demo", "foreign", ""} {
+					request := apigenRequest(http.MethodGet, "/api/v1/projects/"+locator+"/metadata", map[string]string{"project": locator})
+					response := httptest.NewRecorder()
+					before := calls
+					handler.ServeHTTP(response, request)
+					allowed := bound != "" && locator == bound.String()
+					if allowed {
+						if response.Code != http.StatusNoContent || calls != before+1 || !authorizer.AuthorizeReplay(request) {
+							t.Fatal("bound metadata/replay was rejected")
+						}
+					} else if response.Code != http.StatusNotFound || calls != before || authorizer.AuthorizeReplay(request) {
+						t.Fatalf("foreign or missing bound identity dispatched: %q / %q", bound, locator)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAPIGenProjectBoundaryUsesConfiguredResolverWithoutRuntime(t *testing.T) {
+	bound := projectgraph.ResourceID("project_demo")
+	contract := APIGenOperationContract{
+		OperationID: "boundMetadata",
+		Method:      http.MethodGet,
+		Path:        "/api/v1/projects/{project}/metadata",
+		Protected:   true,
+		AuthzMode:   "authenticated",
+		Extensions:  map[string]any{apiGenObjectScopeExtension: "principal"},
+	}
+	for _, test := range []struct {
+		name      string
+		configure func(*Module)
+		allowed   bool
+	}{
+		{
+			name: "configured resolver",
+			configure: func(module *Module) {
+				module.SetCurrentProjectID(func(context.Context) (projectgraph.ResourceID, error) {
+					return bound, nil
+				})
+			},
+			allowed: true,
+		},
+		{
+			name: "resolver error",
+			configure: func(module *Module) {
+				module.SetCurrentProjectID(func(context.Context) (projectgraph.ResourceID, error) {
+					return "", errors.New("project resolver unavailable")
+				})
+			},
+		},
+		{
+			name: "invalid resolver identity",
+			configure: func(module *Module) {
+				module.SetCurrentProjectID(func(context.Context) (projectgraph.ResourceID, error) {
+					return "!", nil
+				})
+			},
+		},
+		{name: "missing resolver"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			module := browserGuardModule(nil, Principal{ID: "principal"}, true)
+			if test.configure != nil {
+				test.configure(module)
+			}
+			authorizer, err := module.APIGenAuthorizer(nil, map[string]APIGenOperationContract{"boundMetadata": contract}, APIGenResourceResolvers{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			calls := 0
+			handler, ok := authorizer.Protect("boundMetadata", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			if !ok {
+				t.Fatal("authorizer did not construct")
+			}
+			for _, locator := range []string{"project_demo", "foreign"} {
+				request := apigenRequest(http.MethodGet, "/api/v1/projects/"+locator+"/metadata", map[string]string{"project": locator})
+				response := httptest.NewRecorder()
+				before := calls
+				handler.ServeHTTP(response, request)
+				allowed := test.allowed && locator == bound.String()
+				if allowed {
+					if response.Code != http.StatusNoContent || calls != before+1 || !authorizer.AuthorizeReplay(request) {
+						t.Fatal("configured project resolver rejected bound metadata/replay")
+					}
+				} else if response.Code != http.StatusNotFound || calls != before || authorizer.AuthorizeReplay(request) {
+					t.Fatalf("unconfigured or foreign project identity dispatched: %q / %q", test.name, locator)
+				}
+			}
+		})
+	}
+}
+
+func TestAPIGenProjectBoundaryConfiguredResolverCrossChecksRuntimeHost(t *testing.T) {
+	bound := projectgraph.ResourceID("project_demo")
+	contract := APIGenOperationContract{
+		OperationID: "boundMetadata",
+		Method:      http.MethodGet,
+		Path:        "/api/v1/projects/{project}/metadata",
+		Protected:   true,
+		AuthzMode:   "authenticated",
+		Extensions:  map[string]any{apiGenObjectScopeExtension: "principal"},
+	}
+	var typedNilHost *runtimehostmodule.Module
+	for _, test := range []struct {
+		name       string
+		runtime    apigenRuntimeHost
+		configure  func(*Module)
+		wantStatus int
+	}{
+		{
+			name:       "matching runtime host",
+			runtime:    apigenRuntimeFake{project: bound},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "differing runtime host",
+			runtime:    apigenRuntimeFake{project: "project_other"},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "invalid nonempty runtime host",
+			runtime:    apigenRuntimeFake{project: "!"},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "empty runtime host",
+			runtime:    apigenRuntimeFake{project: ""},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "typed nil runtime host",
+			runtime:    typedNilHost,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:    "resolver error takes precedence over valid runtime host",
+			runtime: apigenRuntimeFake{project: bound},
+			configure: func(module *Module) {
+				module.SetCurrentProjectID(func(context.Context) (projectgraph.ResourceID, error) {
+					return "", errors.New("project resolver unavailable")
+				})
+			},
+			wantStatus: http.StatusNotFound,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			module := browserGuardModule(nil, Principal{ID: "principal"}, true)
+			if test.configure != nil {
+				test.configure(module)
+			} else {
+				module.SetCurrentProjectID(func(context.Context) (projectgraph.ResourceID, error) {
+					return bound, nil
+				})
+			}
+			authorizer, err := module.APIGenAuthorizer(test.runtime, map[string]APIGenOperationContract{"boundMetadata": contract}, APIGenResourceResolvers{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			calls := 0
+			handler, ok := authorizer.Protect("boundMetadata", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			if !ok {
+				t.Fatal("authorizer did not construct")
+			}
+			request := apigenRequest(http.MethodGet, "/api/v1/projects/project_demo/metadata", map[string]string{"project": bound.String()})
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != test.wantStatus {
+				t.Fatalf("bound metadata status = %d, want %d", response.Code, test.wantStatus)
+			}
+			if test.wantStatus == http.StatusNoContent {
+				if calls != 1 || !authorizer.AuthorizeReplay(request) {
+					t.Fatalf("matching configured/runtime boundary did not dispatch and replay: calls=%d", calls)
+				}
+			} else if calls != 0 || authorizer.AuthorizeReplay(request) {
+				t.Fatalf("invalid configured/runtime boundary dispatched or replayed: calls=%d", calls)
+			}
+		})
+	}
+}
+
+func TestAPIGenProjectBoundaryRejectsNilRuntime(t *testing.T) {
+	module := browserGuardModule(browserGuardRepository{admin: true}, Principal{ID: "admin"}, true)
+	contract := APIGenOperationContract{OperationID: "boundMetadata", Method: http.MethodGet, Path: "/api/v1/projects/{project}/metadata", Protected: true, AuthzMode: "authenticated", Extensions: map[string]any{apiGenObjectScopeExtension: "principal"}}
+	authorizer, err := module.APIGenAuthorizer(nil, map[string]APIGenOperationContract{"boundMetadata": contract}, APIGenResourceResolvers{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	handler, ok := authorizer.Protect("boundMetadata", http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls++ }))
+	if !ok {
+		t.Fatal("authorizer did not construct")
+	}
+	request := apigenRequest(http.MethodGet, "/api/v1/projects/project_demo/metadata", map[string]string{"project": "project_demo"})
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound || calls != 0 || authorizer.AuthorizeReplay(request) {
+		t.Fatalf("nil runtime dispatched or replayed: status=%d calls=%d", response.Code, calls)
+	}
+}

--- a/internal/analytics/cache/project_boundary_test.go
+++ b/internal/analytics/cache/project_boundary_test.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/flidai/leapview/internal/analytics/resultidentity"
+)
+
+func TestProjectBoundaryCacheKeysDoNotCollide(t *testing.T) {
+	seen := map[string]bool{}
+	for _, input := range []resultidentity.PartitionInput{
+		{Kind: resultidentity.PartitionProduction, TargetID: "instance_a", ProjectID: "project_a", Environment: "prod"},
+		{Kind: resultidentity.PartitionProduction, TargetID: "instance_a", ProjectID: "project_b", Environment: "prod"},
+		{Kind: resultidentity.PartitionProduction, TargetID: "instance_a", ProjectID: "project_a", Environment: "dev"},
+		{Kind: resultidentity.PartitionProduction, TargetID: "instance_b", ProjectID: "project_a", Environment: "prod"},
+		{Kind: resultidentity.PartitionCandidate, TargetID: "instance_a", ProjectID: "project_a", Environment: "prod", CandidateID: "candidate_a"},
+		{Kind: resultidentity.PartitionCandidate, TargetID: "instance_a", ProjectID: "project_a", Environment: "prod", CandidateID: "candidate_b"},
+	} {
+		partition, err := resultidentity.NewPartition(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key, err := NewKeyFromDigests(partition, digest('a'), digest('b'), digest('c'))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if seen[key.Digest()] {
+			t.Fatal("identical query/data/policy collided across serving partitions")
+		}
+		seen[key.Digest()] = true
+	}
+}
+
+func TestProjectBoundaryCacheRejectsMissingScope(t *testing.T) {
+	for _, input := range []resultidentity.PartitionInput{
+		{Kind: resultidentity.PartitionProduction, TargetID: "instance_a", Environment: "prod"},
+		{Kind: resultidentity.PartitionProduction, ProjectID: "project_a", Environment: "prod"},
+		{Kind: resultidentity.PartitionProduction, TargetID: "instance_a", ProjectID: "project_a"},
+	} {
+		if _, err := resultidentity.NewPartition(input); err == nil {
+			t.Fatalf("accepted incomplete cache scope: %#v", input)
+		}
+	}
+	if _, err := NewKeyFromDigests(resultidentity.Partition{}, digest('a'), digest('b'), digest('c')); err == nil {
+		t.Fatal("accepted an unvalidated zero partition")
+	}
+}

--- a/internal/app/api/protocol/project_boundary_test.go
+++ b/internal/app/api/protocol/project_boundary_test.go
@@ -1,0 +1,58 @@
+package protocol
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/platform/http/cursorsigning"
+	"github.com/flidai/leapview/internal/platform/http/idempotency"
+)
+
+func TestProjectBoundaryIdempotencySeparatesLocatorsAndReauthorizes(t *testing.T) {
+	allowed, calls := true, 0
+	p, err := Build(t.Context(), Config{
+		Store: idempotency.NewMemoryStore(), CursorSigning: cursorsigning.NewEphemeralInitializer(),
+		BearerToken: func(*http.Request) string { return "credential" }, AcceptsBearer: func(*http.Request) bool { return true },
+		PrincipalID:     func(*http.Request) (string, bool) { return "principal", true },
+		ReplayAuthorize: func(*http.Request) bool { return allowed },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := p.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{"path":%q}`, r.URL.Path)
+	}))
+	request := func(project, body string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/projects/"+project+"/releases", strings.NewReader(body))
+		r.Header.Set("Idempotency-Key", "same-key")
+		r.Header.Set("Authorization", "Bearer credential")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		return w
+	}
+	for _, project := range []string{"project_a", "project_b", "project_a"} {
+		response := request(project, `{}`)
+		if response.Code != http.StatusCreated || !strings.Contains(response.Body.String(), "/"+project+"/") {
+			t.Fatalf("cross-Project replay: %d %s", response.Code, response.Body)
+		}
+	}
+	if calls != 2 {
+		t.Fatalf("executions=%d, want one per locator", calls)
+	}
+	if response := request("project_a", `{"changed":true}`); response.Code != http.StatusConflict {
+		t.Fatal("changed request replayed")
+	}
+	allowed = false
+	if response := request("project_a", `{}`); response.Code != http.StatusForbidden {
+		t.Fatal("revoked request replayed")
+	}
+	if calls != 2 {
+		t.Fatal("rejected replay executed domain work")
+	}
+}

--- a/internal/app/composition.go
+++ b/internal/app/composition.go
@@ -82,6 +82,9 @@ func readClaimedProject(repository deploymentmodule.ProjectClaimReader, environm
 		if err != nil {
 			return "", false, fmt.Errorf("read claimed project: %w", err)
 		}
+		if err := claim.Validate(); err != nil {
+			return "", false, fmt.Errorf("invalid durable project claim: %w", err)
+		}
 		if claim.Environment != environment {
 			return "", false, fmt.Errorf("claimed project environment %q does not match configured environment %q", claim.Environment, environment)
 		}

--- a/internal/app/composition_project_claim_test.go
+++ b/internal/app/composition_project_claim_test.go
@@ -39,6 +39,8 @@ func TestReadClaimedProjectFailsClosedAndChecksEnvironment(t *testing.T) {
 	}{
 		{name: "repository error", repo: projectClaimRepositoryStub{err: errors.New("database unavailable")}, env: "prod", wantErr: "read claimed project"},
 		{name: "environment mismatch", repo: projectClaimRepositoryStub{claim: claim}, env: "dev", wantErr: "does not match configured environment"},
+		{name: "missing project evidence", repo: projectClaimRepositoryStub{claim: deployment.ProjectClaim{Environment: "prod", ClaimedBy: "principal", ClaimedAt: time.Now().UTC()}}, env: "prod", wantErr: "invalid"},
+		{name: "missing claim evidence", repo: projectClaimRepositoryStub{claim: deployment.ProjectClaim{ProjectID: "finance", Environment: "prod"}}, env: "prod", wantErr: "invalid"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			projectID, found, err := readClaimedProject(test.repo, test.env)(context.Background())

--- a/internal/app/project_boundary_test.go
+++ b/internal/app/project_boundary_test.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/access"
+	accessmodule "github.com/flidai/leapview/internal/access/module"
+	apiaggregate "github.com/flidai/leapview/internal/app/api/aggregate"
+	"github.com/flidai/leapview/internal/platform/observability"
+	"github.com/go-chi/chi/v5"
+)
+
+// This exercises the shared ingress used before browser/API authorization,
+// cursor lookup, idempotency, and domain dispatch. It cannot select a Project.
+func TestProjectBoundaryRejectsRequestSelectorsBeforeDispatch(t *testing.T) {
+	for _, path := range []string{"/", "/explore", "/search", "/catalog/search", "/sources", "/dashboards/sales", "/updates", "/agent", "/api/v1/search", "/api/v1/semantic-models/sales/query", "/api/v1/projects/bound/releases", "/api/v1/projects/bound/audit-events"} {
+		t.Run(path, func(t *testing.T) {
+			calls := 0
+			mux := chi.NewRouter()
+			mountRouterMiddleware(mux, routerMiddlewareDependencies{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), telemetry: observability.New()})
+			mux.Handle(path, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { calls++; w.WriteHeader(http.StatusNoContent) }))
+			for _, selector := range []string{"project=foreign", "projectId=foreign", "projectUid=foreign", "projectUID=foreign", "project_id=foreign", "project=", "project=bound&project=foreign", "%70rojectId=foreign"} {
+				response := httptest.NewRecorder()
+				mux.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path+"?"+selector, nil))
+				if response.Code != http.StatusBadRequest || calls != 0 {
+					t.Fatalf("%s: status=%d dispatches=%d, want rejection before dispatch", selector, response.Code, calls)
+				}
+				if strings.Contains(response.Body.String(), "foreign") {
+					t.Fatal("selector value leaked into diagnostic")
+				}
+			}
+			response := httptest.NewRecorder()
+			mux.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path+"?q=sales", nil))
+			if response.Code != http.StatusNoContent || calls != 1 {
+				t.Fatal("ordinary bound request was rejected")
+			}
+		})
+	}
+}
+
+func TestProjectBoundaryRejectsMalformedQueryBeforeDispatch(t *testing.T) {
+	calls := 0
+	mux := chi.NewRouter()
+	mountRouterMiddleware(mux, routerMiddlewareDependencies{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), telemetry: observability.New()})
+	mux.Get("/search", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { calls++; w.WriteHeader(http.StatusNoContent) }))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/search?%zz", nil))
+	if response.Code != http.StatusBadRequest || calls != 0 {
+		t.Fatalf("malformed query: status=%d dispatches=%d, want rejection before dispatch", response.Code, calls)
+	}
+}
+
+func TestProjectBoundaryPreservesBootstrapAndPlatformAuditFilter(t *testing.T) {
+	mux := chi.NewRouter()
+	mountRouterMiddleware(mux, routerMiddlewareDependencies{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), telemetry: observability.New()})
+	const body = `{"projectUid":"issuer_uid","environment":"prod"}`
+	mux.Post("/api/v1/instance/project-claim", func(w http.ResponseWriter, r *http.Request) {
+		got, err := io.ReadAll(r.Body)
+		if err != nil || string(got) != body {
+			t.Fatal("ingress changed bootstrap payload")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.Get("/api/v1/audit-events", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	for _, request := range []*http.Request{
+		httptest.NewRequest(http.MethodPost, "/api/v1/instance/project-claim", strings.NewReader(body)),
+		httptest.NewRequest(http.MethodGet, "/api/v1/audit-events?project=bound", nil),
+	} {
+		response := httptest.NewRecorder()
+		mux.ServeHTTP(response, request)
+		if response.Code != http.StatusNoContent {
+			t.Fatalf("legal contract rejected: %d", response.Code)
+		}
+	}
+}
+
+func TestProjectBoundaryGeneratedLocatorsCannotRetarget(t *testing.T) {
+	store := testStore(t)
+	principal := testPrincipal(t, t.Context(), store, "boundary@example.com", "Boundary")
+	token, _ := testScopedAPIToken(t, t.Context(), store, access.APITokenInput{PrincipalID: principal.ID, Name: "boundary", Capabilities: []access.Capability{access.CapabilityProjectAdmin, access.CapabilityResourceRead, access.CapabilityResourceUse}})
+	server := assembleRuntime(fakeMetrics{}, testStoreOptions(store, assemblyConfig{Auth: testAuth(store, accessmodule.AuthConfig{APITokenOnly: true})}))
+	router := server.Routes()
+	parameters := regexp.MustCompile(`\{[^}]+\}`)
+	count := 0
+	for operation, contract := range apiaggregate.GetAPIGenOperationContracts() {
+		if !strings.Contains(contract.Path, "{project}") {
+			continue
+		}
+		count++
+		t.Run(operation, func(t *testing.T) {
+			path := strings.ReplaceAll(contract.Path, "{project}", "foreign_project")
+			path = parameters.ReplaceAllString(path, "0198f2c0-7c7a-7f00-8a11-000000000001")
+			request := httptest.NewRequest(contract.Method, path, strings.NewReader(`{}`))
+			request.Header.Set("Authorization", "Bearer "+token)
+			request.Header.Set("Idempotency-Key", "boundary-"+operation)
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("foreign locator %s: %d %s", path, response.Code, response.Body)
+			}
+		})
+	}
+	if count == 0 {
+		t.Fatal("no generated Project locator routes audited")
+	}
+}

--- a/internal/app/runtime_router_routes.go
+++ b/internal/app/runtime_router_routes.go
@@ -3,6 +3,7 @@ package app
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/flidai/leapview/internal/access"
@@ -93,6 +94,31 @@ func mountRouterMiddleware(mux *chi.Mux, dependencies routerMiddlewareDependenci
 	mux.Use(apihttpmiddleware.SecurityHeadersMiddleware(dependencies.securityHeaders))
 	mux.Use(apihttpmiddleware.AllowedHosts(dependencies.allowedHosts))
 	mux.Use(apihttpmiddleware.RequestBodyLimit(dependencies.requestBodyLimit))
+	// Reject selectors at the existing shared ingress before cursor,
+	// idempotency, authorization, or domain work. This establishes no context:
+	// the durable claim and leased runtime remain the only Project authority.
+	mux.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			query, err := url.ParseQuery(r.URL.RawQuery)
+			if err != nil {
+				apitransport.WriteProblem(w, r, http.StatusBadRequest, "INVALID_QUERY", "The query string is invalid", nil)
+				return
+			}
+			for name := range query {
+				switch strings.ToLower(strings.ReplaceAll(name, "_", "")) {
+				case "project", "projectid", "projectuid":
+					// The generated platform-admin audit operation declares an
+					// exact `project` filter, not a serving-context selector.
+					if name == "project" && r.Method == http.MethodGet && r.URL.Path == "/api/v1/audit-events" {
+						continue
+					}
+					apitransport.WriteProblem(w, r, http.StatusBadRequest, "PROJECT_SELECTOR_UNSUPPORTED", "Project is server-bound and must not be selected in the query string", nil)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
 }
 
 func mountPlatformRoutes(mux *chi.Mux, dependencies platformRouteDependencies) {


### PR DESCRIPTION
## Problem

FAI-671 audits ADR-0018's existing server-bound Project boundary. Principal/platform authentication alone did not constrain every generated Project locator, and shared ingress accepted Project query selectors.

## Root cause

Those request paths could reach dispatch without checking the existing canonical server-bound Project identity. Startup claim reads also needed to validate the durable claim evidence, beyond checking its environment.

## Solution

- Reject Project query selectors at shared ingress, preserving the exact platform audit filter and bootstrap body contracts.
- Enforce bound Project locators and replay authorization through the existing authorizer/resolver; reject resolver errors and conflicting runtime-host identities.
- Validate existing durable claim evidence at the runtime composition boundary.
- Prove existing cache partitions isolate Project, target, environment, and candidate identities; keep policy/dependency-addressed cache semantics unchanged.
- Document the reference extraction inventory and partial boundary matrix in `adr/specifications/project-runtime-boundary-audit.md`.

## Tests added/updated

Selector rejection, malformed selectors, generated foreign locators, configured resolver and nil/typed-nil runtime hosts, resolver/host disagreement, claim evidence rejection, cache partition isolation, and idempotency/replay reauthorization.

## Verification

Exact unchanged commit: `b0093ef6fc8d0d5d1136455ab56f629197e66bb9`.

- Independent PostgreSQL conformance lane: PASS (54 packages).
- Full local `task ci`: PASS, including Go/application, PostgreSQL, APIGen, frontend, architecture and generated checks.
- `task quality:budget:check`: PASS; clean worktree and no generated drift.
- Previous focused race tests and PostgreSQL refresh journey: PASS x3.
- Hosted [CI](https://github.com/flidai/leapview/actions/runs/34303206797): PASS, including spatial, dbt, all five frontend shards and Go/application.
- Hosted [Security](https://github.com/flidai/leapview/actions/runs/34303208620): PASS, including dependency policy, secret/IaC, Go and JavaScript/TypeScript CodeQL, and aggregate gate.

Hosted evidence was obtained through an explicitly authorized temporary validation branch pointing to this exact commit before opening this PR. PR-event checks will run separately.

Prior Testcontainers reaper removal/package timeout and frontend browser failures did not recur on this validation pass. No timeouts, checks, or infrastructure were changed to obtain green results.

## Scope and remaining limitations

This is only the isolated runtime/API/cache hardening slice of FAI-671. FAI-670 remains a Linear dependency; FAI-671 stays In Progress and this PR does not unblock downstream work or claim complete conformance.

ResourceUID registry/allocation, activation, rollback, deployment binding, migrations, compiler and contract-digest implementation are intentionally untouched. Historical commit `9fa6851e1` was reference-only; its deployment/release changes were not imported. Wider FAI-671 end-to-end boundaries remain documented work, not implied complete by cache partition tests.

Do not merge as part of this publication task.
