### PR TITLE
feat(recovery): add exact-version managed object retrieval

### DIFF
--- a/.github/workflows/recovery-evidence-qualification.yml
+++ b/.github/workflows/recovery-evidence-qualification.yml
@@ -38,6 +38,7 @@ jobs:
           go test -race -tags='duckdb_arrow fai520qualification'
           ./internal/manageddata/storage/s3
           ./internal/recoveryset/postgres
+          ./internal/recoveryset/s3reader
           ./internal/recoveryset/observationstore
           -run '^(TestFAI520|TestProviderObservation)'
           -count=2 -timeout=15m -v

--- a/docs/articles/data/storage-recovery.md
+++ b/docs/articles/data/storage-recovery.md
@@ -388,6 +388,68 @@ recovery, and measured RPO/RTO remain later UBDR work.
 
 This validates recovery evidence binding. It does not prove successful physical disaster recovery.
 
+## Exact-version S3 evidence adapter qualification
+
+This section defines the qualification scope for the exact-version S3 evidence
+adapter. The adapter is responsible for validating the configured provider
+namespace, reading an already selected historical object, and returning only
+bytes that match the declared transport size and raw SHA-256 identity. The
+RecoverySet repository separately revalidates canonical and domain identity.
+The adapter is a read-only evidence
+transport boundary, not an uploader, capture owner, or recovery lifecycle
+controller.
+
+### Trusted construction and exact verification
+
+Construction is the trusted profile/client boundary. A caller provisions the
+S3 client and an explicit profile containing the endpoint, region, bucket,
+namespace, and bounded read policy. The adapter validates that profile once and
+always uses that client; an observation's endpoint, bucket, key, or credentials
+cannot select a different client or route. Invalid or missing profile/client
+inputs fail construction. The portable evidence reference contains no client,
+credentials, or signed URL.
+
+For every source or evidence object, the adapter must issue `HeadObject` and
+`GetObject` with the supplied nonempty, non-`null` `VersionID`. It requires the
+provider to echo that exact version, requires `ContentLength` to equal the
+declared size, bounds the streamed response, and hashes the fetched bytes with
+SHA-256. A version, size, or hash mismatch fails closed; latest-object lookup,
+ETag, metadata, and a successful HEAD are not content proof. Version IDs are
+observations supplied by the capture boundary, not values inferred by this
+adapter.
+
+### Intended qualification cases
+
+The qualification uses a disposable versioned MinIO bucket and the frozen
+RecoverySet v3 evidence bundle. It uploads all six canonical payloads, captures
+their provider VersionIDs, overwrites each current object, and creates a delete
+marker before the repository reads anything. `CreateSet3` succeeds only by
+using the selected historical versions. After the PostgreSQL connection is
+closed and reopened, `ReadSet3` retrieves and verifies the same exact off-host
+bytes again; identical create/read retries preserve the canonical set bytes.
+
+The rejection matrix covers missing, `latest`, wrong, deleted, and corrupt
+versions; denied credentials; and bucket, profile, and endpoint substitution.
+Direct adapter calls reject profile substitutions before provider I/O.
+Provider failures are
+reduced to bounded categories and cannot expose provider messages, credentials,
+signed URLs, or response bodies. Every failed repository submission leaves no
+successor association.
+
+### Explicit limitations
+
+This adapter qualification uses MinIO and does not establish AWS or other
+S3-compatible provider behavior. Its trusted endpoint identity is deliberately
+separate from the disposable MinIO transport endpoint, so it does not qualify
+TLS, redirect, or endpoint-discovery behavior. It makes no retention or lifecycle guarantee and does
+not capture provider VersionIDs at managed-data write time; retention and a
+durable write-time observation binding remain separate prerequisites. It does
+not add recovery admission, publication, or startup/readiness behavior. It does
+not perform PostgreSQL restore or PITR, activation, or provider disaster
+recovery, and it makes no physical DR, RPO, or RTO claim.
+
+This validates historical managed-object retrieval. It does not prove successful physical disaster recovery.
+
 ## Proposed managed observation manifest contract
 
 The following proposal and implementation-planning sections are retained as

--- a/internal/recoveryset/postgres/successor_s3_qualification_test.go
+++ b/internal/recoveryset/postgres/successor_s3_qualification_test.go
@@ -1,0 +1,461 @@
+//go:build fai520qualification
+
+package postgres_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	recoverypg "github.com/flidai/leapview/internal/recoveryset/postgres"
+	"github.com/flidai/leapview/internal/recoveryset/s3reader"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	successorS3Image     = "minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+	successorS3Region    = "us-east-1"
+	successorS3ProfileID = "22222222-2222-4222-8222-222222222222"
+	successorS3Account   = "minio-successor-qualification"
+)
+
+// TestFAI520SuccessorS3ExactVersionQualification proves that the successor
+// repository can use real versioned MinIO objects as its exact reader. The
+// provider's mutable current object is overwritten and deleted before the
+// repository is called; only the captured immutable versions remain usable.
+func TestFAI520SuccessorS3ExactVersionQualification(t *testing.T) {
+	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
+	provider := startSuccessorS3Provider(t)
+	input, trust, _ := successorInputs(t, "minimal")
+	configureSuccessorS3Input(t, provider, &input)
+	sentinelKey := "unrelated/exact-version-sentinel"
+	sentinelBody := []byte("unrelated-versioned-sentinel")
+	sentinelVersion := putSuccessorS3Object(t, provider, sentinelKey, sentinelBody)
+
+	pool, admin, reopenURL := successorDatabase(t)
+	provisionSuccessorGeneration(t, admin, trust.Generation)
+	reader := newSuccessorS3Reader(t, provider.client, provider.config)
+	repo := recoverypg.NewSuccessorRepository(pool, recoverypg.SuccessorOptions{
+		Reader: reader,
+		Trust:  func(context.Context, string) (recoverypg.TrustInput, error) { return trust, nil },
+	})
+
+	overwriteAndDeleteCurrent(t, provider, input)
+	if latest, err := provider.client.GetObject(t.Context(), &awss3.GetObjectInput{
+		Bucket: aws.String(provider.bucket), Key: aws.String(input.Payloads.Manifest.Locator.Key),
+	}); err == nil {
+		_ = latest.Body.Close()
+		t.Fatal("MinIO latest read unexpectedly survived the delete marker")
+	}
+	created, err := repo.CreateSet3(t.Context(), input)
+	if err != nil {
+		t.Fatalf("CreateSet3 against exact MinIO versions: %v", err)
+	}
+	wantCanonical, err := created.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A deterministic retry must preserve the immutable winner and its exact
+	// canonical bytes, even though current provider objects are gone.
+	retried, err := repo.CreateSet3(t.Context(), input)
+	if err != nil {
+		t.Fatalf("deterministic CreateSet3 retry: %v", err)
+	}
+	retryCanonical, err := retried.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(retryCanonical, wantCanonical) {
+		t.Fatal("CreateSet3 retry changed canonical recovery-set bytes")
+	}
+	assertSuccessorS3Version(t, provider, sentinelKey, sentinelVersion, sentinelBody)
+
+	pool.Close()
+	reopened, err := pgxpool.New(t.Context(), reopenURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(reopened.Close)
+	reopenedReader := newSuccessorS3Reader(t, provider.client, provider.config)
+	reopenedRepo := recoverypg.NewSuccessorRepository(reopened, recoverypg.SuccessorOptions{
+		Reader: reopenedReader,
+		Trust:  func(context.Context, string) (recoverypg.TrustInput, error) { return trust, nil },
+	})
+	loaded, err := reopenedRepo.ReadSet3(t.Context(), input.Set.ID)
+	if err != nil {
+		t.Fatalf("ReadSet3 after PostgreSQL close/reopen: %v", err)
+	}
+	loadedCanonical, err := loaded.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(loadedCanonical, wantCanonical) {
+		t.Fatal("ReadSet3 after restart changed canonical recovery-set bytes")
+	}
+	assertSuccessorS3Version(t, provider, sentinelKey, sentinelVersion, sentinelBody)
+	secondRead, err := reopenedRepo.ReadSet3(t.Context(), input.Set.ID)
+	if err != nil {
+		t.Fatalf("deterministic ReadSet3 retry: %v", err)
+	}
+	secondCanonical, err := secondRead.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(secondCanonical, loadedCanonical) {
+		t.Fatal("ReadSet3 retry changed canonical recovery-set bytes")
+	}
+	assertSuccessorS3Version(t, provider, sentinelKey, sentinelVersion, sentinelBody)
+}
+
+// TestFAI520SuccessorS3ExactVersionFailures exercises provider failures at the
+// adapter boundary and through CreateSet3. Every failed submission must leave
+// all successor association tables empty.
+func TestFAI520SuccessorS3ExactVersionFailures(t *testing.T) {
+	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
+	provider := startSuccessorS3Provider(t)
+	input, trust, _ := successorInputs(t, "minimal")
+	configureSuccessorS3Input(t, provider, &input)
+
+	pool, admin, _ := successorDatabase(t)
+	provisionSuccessorGeneration(t, admin, trust.Generation)
+	reader := newSuccessorS3Reader(t, provider.client, provider.config)
+	baseRepo := func(r recoverypg.ExactVersionReader) *recoverypg.SuccessorRepository {
+		return recoverypg.NewSuccessorRepository(pool, recoverypg.SuccessorOptions{
+			Reader: r,
+			Trust:  func(context.Context, string) (recoverypg.TrustInput, error) { return trust, nil },
+		})
+	}
+
+	manifestKey := input.Payloads.Manifest.Locator.Key
+	wrongVersion := putSuccessorS3Object(t, provider, manifestKey, []byte("a different exact provider version"))
+	corrupted := bytes.Clone(input.Payloads.Manifest.CanonicalBytes)
+	corrupted[len(corrupted)-1] ^= 1
+	corruptedVersion := putSuccessorS3Object(t, provider, manifestKey, corrupted)
+	deletedVersion := putSuccessorS3Object(t, provider, manifestKey, input.Payloads.Manifest.CanonicalBytes)
+	if _, err := provider.client.DeleteObject(t.Context(), &awss3.DeleteObjectInput{
+		Bucket: aws.String(provider.bucket), Key: aws.String(manifestKey), VersionId: aws.String(deletedVersion),
+	}); err != nil {
+		t.Fatalf("delete explicit MinIO version: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		reader     recoverypg.ExactVersionReader
+		mutate     func(*recoverypg.Set3Input)
+		exactFails bool
+		wantExact  error
+	}{
+		{
+			name: "missing version has no latest fallback",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.VersionID = "missing-version-id"
+			},
+			exactFails: true,
+		},
+		{
+			name: "latest version selector is rejected",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.VersionID = "latest"
+			},
+			exactFails: true,
+			wantExact:  s3reader.ErrMissingVersion,
+		},
+		{
+			name: "wrong version bytes are rejected",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.VersionID = wrongVersion
+			},
+			exactFails: true,
+			wantExact:  s3reader.ErrIntegrity,
+		},
+		{
+			name: "deleted version is rejected",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.VersionID = deletedVersion
+			},
+			exactFails: true,
+			wantExact:  s3reader.ErrMissingVersion,
+		},
+		{
+			name: "corrupted bytes are rejected",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.VersionID = corruptedVersion
+			},
+			exactFails: true,
+			wantExact:  s3reader.ErrIntegrity,
+		},
+		{
+			name: "access denied",
+			reader: func() recoverypg.ExactVersionReader {
+				return newSuccessorS3Reader(t, provider.clientFor("wrong-secret"), provider.config)
+			}(),
+			exactFails: true,
+			wantExact:  s3reader.ErrAccessDenied,
+		},
+		{
+			name: "wrong bucket substitution",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.Bucket = "wrong-successor-bucket"
+			},
+			exactFails: true,
+			wantExact:  s3reader.ErrProfileMismatch,
+		},
+		{
+			name: "wrong profile substitution",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.StorageProfileID = "33333333-3333-4333-8333-333333333333"
+			},
+			exactFails: true,
+			wantExact:  s3reader.ErrProfileMismatch,
+		},
+		{
+			name: "wrong endpoint substitution",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.Endpoint = "https://localhost:1"
+			},
+			exactFails: true,
+			wantExact:  s3reader.ErrProfileMismatch,
+		},
+		{
+			name: "wrong namespace substitution",
+			mutate: func(candidate *recoverypg.Set3Input) {
+				candidate.Payloads.Manifest.Locator.Namespace = "other-evidence"
+			},
+			exactFails: true,
+			wantExact:  s3reader.ErrProfileMismatch,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := input
+			if tc.mutate != nil {
+				tc.mutate(&candidate)
+			}
+			caseReader := tc.reader
+			if caseReader == nil {
+				caseReader = reader
+			}
+			if tc.exactFails {
+				requireSuccessorExactReadError(t, caseReader, candidate.Payloads.Manifest.Locator, tc.wantExact)
+			}
+			if _, err := baseRepo(caseReader).CreateSet3(t.Context(), candidate); err == nil {
+				t.Fatal("CreateSet3 accepted a provider failure or locator substitution")
+			}
+			assertNoSuccessorAssociation(t, pool, candidate.Set.ID)
+		})
+	}
+}
+
+type successorS3Provider struct {
+	client    *awss3.Client
+	clientFor func(string) *awss3.Client
+	bucket    string
+	endpoint  string
+	config    s3reader.Config
+}
+
+func startSuccessorS3Provider(t *testing.T) successorS3Provider {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+	user := "q" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	secret := uuid.NewString()
+	container, err := tcminio.Run(ctx, successorS3Image,
+		tcminio.WithUsername(user), tcminio.WithPassword(secret),
+		testcontainers.WithTmpfs(map[string]string{"/data": "rw,size=1g"}),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/minio/health/ready").WithPort("9000").WithStartupTimeout(time.Minute)))
+	testcontainers.CleanupContainer(t, container)
+	if err != nil {
+		t.Fatal(err)
+	}
+	address, err := container.ConnectionString(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transportEndpoint := "http://" + strings.TrimRight(address, "/")
+	// Successor locators intentionally require a canonical HTTPS DNS endpoint.
+	// The client still talks plain HTTP to the disposable MinIO mapping; the
+	// HTTPS localhost value is the trusted endpoint identity recorded in each
+	// locator and profile tuple.
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		t.Fatalf("parse MinIO connection address: %v", err)
+	}
+	identityEndpoint := "https://localhost:" + port
+	bucket := "successor-" + strings.ReplaceAll(uuid.NewString(), "-", "")[:20]
+	clientFor := func(password string) *awss3.Client {
+		return awss3.New(awss3.Options{
+			Region:           successorS3Region,
+			BaseEndpoint:     aws.String(transportEndpoint),
+			UsePathStyle:     true,
+			Credentials:      credentials.NewStaticCredentialsProvider(user, password, ""),
+			RetryMaxAttempts: 1,
+		})
+	}
+	client := clientFor(secret)
+	if _, err := client.CreateBucket(ctx, &awss3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("create MinIO successor bucket: %v", err)
+	}
+	if _, err := client.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{
+		Bucket:                  aws.String(bucket),
+		VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+	}); err != nil {
+		t.Fatalf("enable MinIO bucket versioning: %v", err)
+	}
+	return successorS3Provider{
+		client: client, clientFor: clientFor, bucket: bucket, endpoint: identityEndpoint,
+		config: s3reader.Config{Profile: s3reader.ProfileTuple{
+			Bucket: bucket, Endpoint: identityEndpoint, Region: successorS3Region,
+			StorageProfileID: successorS3ProfileID, StorageProfileRevision: 1,
+			AccountIdentity: successorS3Account, Namespace: "evidence",
+		}},
+	}
+}
+
+func configureSuccessorS3Input(t *testing.T, provider successorS3Provider, input *recoverypg.Set3Input) {
+	t.Helper()
+	values := []*recoverypg.PayloadReference{
+		&input.Payloads.Set, &input.Payloads.Manifest, &input.Payloads.Anchor,
+		&input.Payloads.Profiles, &input.Payloads.Receipt, &input.Payloads.Authority,
+	}
+	for _, ref := range values {
+		if ref.Locator.Key == "" || len(ref.CanonicalBytes) == 0 {
+			t.Fatal("successor fixture omitted a canonical S3 payload")
+		}
+		version := putSuccessorS3Object(t, provider, ref.Locator.Key, ref.CanonicalBytes)
+		ref.Locator.Endpoint = provider.endpoint
+		ref.Locator.Region = successorS3Region
+		ref.Locator.Bucket = provider.bucket
+		ref.Locator.StorageProfileID = successorS3ProfileID
+		ref.Locator.StorageProfileRevision = 1
+		ref.Locator.AccountIdentity = successorS3Account
+		ref.Locator.VersionID = version
+	}
+}
+
+func putSuccessorS3Object(t *testing.T, provider successorS3Provider, key string, body []byte) string {
+	t.Helper()
+	out, err := provider.client.PutObject(t.Context(), &awss3.PutObjectInput{
+		Bucket: aws.String(provider.bucket), Key: aws.String(key), Body: bytes.NewReader(body),
+	})
+	if err != nil {
+		t.Fatalf("put MinIO successor object %q: %v", key, err)
+	}
+	version := aws.ToString(out.VersionId)
+	if version == "" || version == "null" {
+		t.Fatalf("MinIO successor object %q did not return an immutable version", key)
+	}
+	return version
+}
+
+func assertSuccessorS3Version(t *testing.T, provider successorS3Provider, key, version string, want []byte) {
+	t.Helper()
+	out, err := provider.client.GetObject(t.Context(), &awss3.GetObjectInput{
+		Bucket: aws.String(provider.bucket), Key: aws.String(key), VersionId: aws.String(version),
+	})
+	if err != nil {
+		t.Fatalf("get sentinel version %q: %v", version, err)
+	}
+	if out == nil || out.Body == nil {
+		t.Fatal("sentinel version returned no body")
+	}
+	got, readErr := io.ReadAll(out.Body)
+	closeErr := out.Body.Close()
+	if readErr != nil {
+		t.Fatalf("read sentinel version %q: %v", version, readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close sentinel version %q: %v", version, closeErr)
+	}
+	if gotVersion := aws.ToString(out.VersionId); gotVersion != version {
+		t.Fatalf("sentinel version = %q, want %q", gotVersion, version)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("sentinel bytes = %q, want %q", got, want)
+	}
+}
+
+func overwriteAndDeleteCurrent(t *testing.T, provider successorS3Provider, input recoverypg.Set3Input) {
+	t.Helper()
+	refs := []*recoverypg.PayloadReference{
+		&input.Payloads.Set, &input.Payloads.Manifest, &input.Payloads.Anchor,
+		&input.Payloads.Profiles, &input.Payloads.Receipt, &input.Payloads.Authority,
+	}
+	for _, ref := range refs {
+		putSuccessorS3Object(t, provider, ref.Locator.Key, []byte("mutable current replacement"))
+		if _, err := provider.client.DeleteObject(t.Context(), &awss3.DeleteObjectInput{
+			Bucket: aws.String(provider.bucket), Key: aws.String(ref.Locator.Key),
+		}); err != nil {
+			t.Fatalf("delete current MinIO successor object %q: %v", ref.Locator.Key, err)
+		}
+	}
+}
+
+func newSuccessorS3Reader(t *testing.T, client *awss3.Client, config s3reader.Config) recoverypg.ExactVersionReader {
+	t.Helper()
+	reader, err := s3reader.New(client, config)
+	if err != nil {
+		t.Fatalf("construct successor S3 reader: %v", err)
+	}
+	if reader == nil {
+		t.Fatal("successor S3 reader is nil")
+	}
+	return reader
+}
+
+func requireSuccessorExactReadError(t *testing.T, reader recoverypg.ExactVersionReader, locator recoverypg.ValidatedLocator, want error) {
+	t.Helper()
+	body, err := reader.ReadExact(t.Context(), locator)
+	if err == nil {
+		if body != nil {
+			_ = body.Close()
+		}
+		t.Fatal("exact-version read unexpectedly succeeded; adapter may have fallen back to latest")
+	}
+	if body != nil {
+		_ = body.Close()
+	}
+	if want != nil && !errors.Is(err, want) {
+		t.Fatalf("exact-version read error = %v, want %v", err, want)
+	}
+}
+
+func assertNoSuccessorAssociation(t *testing.T, pool *pgxpool.Pool, setID string) {
+	t.Helper()
+	for _, table := range []string{
+		"recovery_set_v3", "recovery_set_v3_root", "successor_manifest_binding", "successor_evidence_v2", "successor_evidence_locator_v2", "set_identity_registry",
+	} {
+		query := fmt.Sprintf("SELECT count(*) FROM recovery.%s", table)
+		var args []any
+		if table == "recovery_set_v3" || table == "recovery_set_v3_root" || table == "set_identity_registry" {
+			query += " WHERE set_id = $1::uuid"
+			args = append(args, setID)
+		} else if table == "successor_manifest_binding" {
+			query += " WHERE set_id = $1::uuid"
+			args = append(args, setID)
+		}
+		var count int
+		if err := pool.QueryRow(t.Context(), query, args...).Scan(&count); err != nil {
+			t.Fatalf("count failed successor rows in %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("failed submission left %d rows in %s", count, table)
+		}
+	}
+}

--- a/internal/recoveryset/s3reader/reader.go
+++ b/internal/recoveryset/s3reader/reader.go
@@ -1,0 +1,282 @@
+// Package s3reader provides the production-owned exact-version reader used by
+// successor recovery evidence.  It accepts an already configured AWS client;
+// locators never select credentials, endpoints, or buckets at read time.
+package s3reader
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	postgres "github.com/flidai/leapview/internal/recoveryset/postgres"
+	"github.com/flidai/leapview/internal/recoveryset/successor"
+)
+
+const (
+	defaultMaxObjectBytes int64 = successor.MaxDocumentBytes
+	zeroSHA256                  = "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+// Errors returned by Reader are deliberately static.  Provider diagnostics
+// can contain signed URLs, credentials, or other sensitive request material,
+// so they are classified and discarded at this boundary.
+var (
+	ErrInvalid             = errors.New("exact-version S3 reader input is invalid")
+	ErrMissingVersion      = errors.New("exact-version S3 object version is missing")
+	ErrAccessDenied        = errors.New("exact-version S3 object access denied")
+	ErrProfileMismatch     = errors.New("exact-version S3 storage profile does not match")
+	ErrIntegrity           = errors.New("exact-version S3 object integrity check failed")
+	ErrProviderUnavailable = errors.New("exact-version S3 provider is unavailable")
+)
+
+// Client is intentionally the narrow AWS surface needed for an exact read.
+// The caller owns credentials, endpoint selection, retry policy, and client
+// construction.  In particular, Reader does not construct a client from a
+// persisted locator.
+type Client interface {
+	HeadObject(context.Context, *awss3.HeadObjectInput, ...func(*awss3.Options)) (*awss3.HeadObjectOutput, error)
+	GetObject(context.Context, *awss3.GetObjectInput, ...func(*awss3.Options)) (*awss3.GetObjectOutput, error)
+}
+
+// ProfileTuple is the trusted, construction-time identity of one S3 storage
+// profile. All seven values are compared exactly with a locator before any
+// provider call. Endpoint is an identity value only; requests are sent by the
+// preconfigured Client.
+type ProfileTuple struct {
+	StorageProfileID       string
+	StorageProfileRevision int64
+	AccountIdentity        string
+	Endpoint               string
+	Region                 string
+	Bucket                 string
+	Namespace              string
+}
+
+// Config controls Reader construction.  Profile is copied into the Reader,
+// preventing later mutation of caller-owned profile memory from changing the
+// authority used for reads.
+type Config struct {
+	Profile        ProfileTuple
+	MaxObjectBytes int64
+}
+
+// Reader implements postgres.ExactVersionReader.  It returns an in-memory
+// ReadCloser containing bytes that have passed the exact metadata, size, and
+// SHA-256 checks.  Returning an independent reader also means the provider
+// response body is always closed before ReadExact returns.
+type Reader struct {
+	client         Client
+	profile        ProfileTuple
+	maxObjectBytes int64
+}
+
+var _ postgres.ExactVersionReader = (*Reader)(nil)
+
+// New constructs an exact-version reader with a trusted profile tuple and an
+// already configured narrow S3 client.
+func New(client Client, config Config) (*Reader, error) {
+	if nilClient(client) {
+		return nil, ErrInvalid
+	}
+	if err := config.Profile.validate(); err != nil {
+		return nil, err
+	}
+	maxObjectBytes := config.MaxObjectBytes
+	if maxObjectBytes == 0 {
+		maxObjectBytes = defaultMaxObjectBytes
+	}
+	if maxObjectBytes < 1 || maxObjectBytes > defaultMaxObjectBytes {
+		return nil, ErrInvalid
+	}
+	return &Reader{client: client, profile: config.Profile, maxObjectBytes: maxObjectBytes}, nil
+}
+
+func (p ProfileTuple) validate() error {
+	// Reuse the frozen locator owner for every target-identity rule. The
+	// synthetic payload fields are fixed valid values and do not become part of
+	// the configured profile or any provider request.
+	probe := postgres.ValidatedLocator{
+		Backend:                "s3",
+		StorageProfileID:       p.StorageProfileID,
+		StorageProfileRevision: p.StorageProfileRevision,
+		AccountIdentity:        p.AccountIdentity,
+		Endpoint:               p.Endpoint,
+		Region:                 p.Region,
+		Bucket:                 p.Bucket,
+		Namespace:              p.Namespace,
+		Key:                    p.Namespace + "/recovery-set/v3/sha256/" + zeroSHA256,
+		VersionID:              "profile-validation",
+		PayloadFamily:          postgres.PayloadFamilySet,
+		PayloadVersion:         successor.RecoverySetVersion,
+		PayloadDigest:          "sha256:" + zeroSHA256,
+		PayloadSHA256:          zeroSHA256,
+		PayloadSize:            2,
+	}
+	if err := probe.Validate(); err != nil {
+		return ErrInvalid
+	}
+	return nil
+}
+
+func (p ProfileTuple) matches(locator postgres.ValidatedLocator) bool {
+	return p.StorageProfileID == locator.StorageProfileID &&
+		p.StorageProfileRevision == locator.StorageProfileRevision &&
+		p.AccountIdentity == locator.AccountIdentity &&
+		p.Endpoint == locator.Endpoint &&
+		p.Region == locator.Region &&
+		p.Bucket == locator.Bucket &&
+		p.Namespace == locator.Namespace
+}
+
+// ReadExact reads the exact object version described by locator.  It never
+// retries without VersionId and never uses the latest object as a fallback.
+func (r *Reader) ReadExact(ctx context.Context, locator postgres.ValidatedLocator) (io.ReadCloser, error) {
+	if r == nil || nilClient(r.client) || ctx == nil {
+		return nil, ErrInvalid
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// This comparison must precede locator validation and all provider I/O:
+	// persisted locator data cannot redirect a trusted client to another
+	// profile, bucket, account, endpoint, or region.
+	if !r.profile.matches(locator) {
+		return nil, ErrProfileMismatch
+	}
+	if locator.VersionID == "" || strings.EqualFold(locator.VersionID, "latest") || strings.EqualFold(locator.VersionID, "null") {
+		return nil, ErrMissingVersion
+	}
+	if err := locator.Validate(); err != nil {
+		return nil, ErrInvalid
+	}
+	if locator.PayloadSize < 0 || locator.PayloadSize > r.maxObjectBytes {
+		return nil, ErrIntegrity
+	}
+
+	bucket := aws.String(r.profile.Bucket)
+	key := aws.String(locator.Key)
+	version := aws.String(locator.VersionID)
+	head, err := r.client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: bucket, Key: key, VersionId: version})
+	if err != nil {
+		return nil, classifyProviderError(ctx, err)
+	}
+	if head == nil {
+		return nil, ErrIntegrity
+	}
+	if aws.ToBool(head.DeleteMarker) {
+		return nil, ErrMissingVersion
+	}
+	if head.VersionId == nil || aws.ToString(head.VersionId) == "" || aws.ToString(head.VersionId) != locator.VersionID || head.ContentLength == nil || *head.ContentLength < 0 || *head.ContentLength != locator.PayloadSize {
+		return nil, ErrIntegrity
+	}
+
+	object, err := r.client.GetObject(ctx, &awss3.GetObjectInput{Bucket: bucket, Key: key, VersionId: version})
+	if err != nil {
+		if object != nil && object.Body != nil {
+			_ = object.Body.Close()
+		}
+		return nil, classifyProviderError(ctx, err)
+	}
+	if object == nil {
+		return nil, ErrProviderUnavailable
+	}
+	if aws.ToBool(object.DeleteMarker) {
+		if object.Body != nil {
+			_ = object.Body.Close()
+		}
+		return nil, ErrMissingVersion
+	}
+	if object.Body == nil {
+		return nil, ErrIntegrity
+	}
+	body := object.Body
+	if object.VersionId == nil || aws.ToString(object.VersionId) == "" || aws.ToString(object.VersionId) != locator.VersionID || object.ContentLength == nil || *object.ContentLength < 0 || *object.ContentLength != locator.PayloadSize {
+		_ = body.Close()
+		return nil, ErrIntegrity
+	}
+
+	// Read one byte beyond the expected size.  This both bounds allocation and
+	// rejects providers that return more bytes than the exact object metadata.
+	limited := io.LimitReader(body, locator.PayloadSize+1)
+	raw, readErr := io.ReadAll(limited)
+	closeErr := body.Close()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if errors.Is(readErr, context.Canceled) || errors.Is(closeErr, context.Canceled) {
+		return nil, context.Canceled
+	}
+	if errors.Is(readErr, context.DeadlineExceeded) || errors.Is(closeErr, context.DeadlineExceeded) {
+		return nil, context.DeadlineExceeded
+	}
+	if readErr != nil || closeErr != nil {
+		return nil, ErrProviderUnavailable
+	}
+	if int64(len(raw)) != locator.PayloadSize {
+		return nil, ErrIntegrity
+	}
+
+	wantHash := strings.TrimPrefix(locator.PayloadSHA256, "sha256:")
+	sum := sha256.Sum256(raw)
+	if hex.EncodeToString(sum[:]) != wantHash {
+		return nil, ErrIntegrity
+	}
+	return io.NopCloser(bytes.NewReader(raw)), nil
+}
+
+func nilClient(client Client) bool {
+	if client == nil {
+		return true
+	}
+	value := reflect.ValueOf(client)
+	return value.Kind() == reflect.Pointer && value.IsNil()
+}
+
+func classifyProviderError(ctx context.Context, err error) error {
+	if ctx != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return contextErr
+		}
+	}
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+
+	if status := providerHTTPStatus(err); status == 401 || status == 403 {
+		return ErrAccessDenied
+	}
+	if status := providerHTTPStatus(err); status == 404 {
+		return ErrMissingVersion
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch strings.ToLower(apiErr.ErrorCode()) {
+		case "nosuchversion", "invalidversionid", "nosuchkey", "nosuchobject", "notfound":
+			return ErrMissingVersion
+		case "accessdenied", "invalidaccesskeyid", "signaturedoesnotmatch", "expiredtoken", "requestexpired", "authorizationheadermalformed", "invalidsecurity":
+			return ErrAccessDenied
+		}
+	}
+	return ErrProviderUnavailable
+}
+
+func providerHTTPStatus(err error) int {
+	var responseErr *smithyhttp.ResponseError
+	if errors.As(err, &responseErr) && responseErr != nil {
+		return responseErr.HTTPStatusCode()
+	}
+	return 0
+}

--- a/internal/recoveryset/s3reader/reader_test.go
+++ b/internal/recoveryset/s3reader/reader_test.go
@@ -1,0 +1,477 @@
+package s3reader
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+	postgres "github.com/flidai/leapview/internal/recoveryset/postgres"
+	"github.com/flidai/leapview/internal/recoveryset/successor"
+)
+
+const testProfileID = "22222222-2222-4222-8222-222222222222"
+
+type fakeClient struct {
+	headOutput *awss3.HeadObjectOutput
+	headErr    error
+	getOutput  *awss3.GetObjectOutput
+	getErr     error
+	headCalls  int
+	getCalls   int
+	lastHead   *awss3.HeadObjectInput
+	lastGet    *awss3.GetObjectInput
+}
+
+func (f *fakeClient) HeadObject(_ context.Context, input *awss3.HeadObjectInput, _ ...func(*awss3.Options)) (*awss3.HeadObjectOutput, error) {
+	f.headCalls++
+	f.lastHead = input
+	return f.headOutput, f.headErr
+}
+
+func (f *fakeClient) GetObject(_ context.Context, input *awss3.GetObjectInput, _ ...func(*awss3.Options)) (*awss3.GetObjectOutput, error) {
+	f.getCalls++
+	f.lastGet = input
+	return f.getOutput, f.getErr
+}
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+	err    error
+	reads  int
+}
+
+type errorReader struct{ err error }
+
+func (r errorReader) Read([]byte) (int, error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+	return 0, io.EOF
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return b.err
+}
+
+func (b *closeTrackingBody) Read(p []byte) (int, error) {
+	b.reads++
+	return b.Reader.Read(p)
+}
+
+func TestFAI520ExactReaderUsesExactProfileAndVersionOnBothRequests(t *testing.T) {
+	body := []byte(`{"profile":"exact"}`)
+	client, reader, locator := newReader(t, body)
+	result, err := reader.ReadExact(t.Context(), locator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil {
+		t.Fatal("exact read returned nil body")
+	}
+	defer result.Close()
+	if client.headCalls != 1 || client.getCalls != 1 {
+		t.Fatalf("calls = HEAD %d, GET %d, want one each", client.headCalls, client.getCalls)
+	}
+	if got := aws.ToString(client.lastHead.Bucket); got != locator.Bucket {
+		t.Fatalf("HEAD bucket = %q, want %q", got, locator.Bucket)
+	}
+	if got := aws.ToString(client.lastHead.Key); got != locator.Key {
+		t.Fatalf("HEAD key = %q, want %q", got, locator.Key)
+	}
+	if got := aws.ToString(client.lastHead.VersionId); got != locator.VersionID {
+		t.Fatalf("HEAD version = %q, want %q", got, locator.VersionID)
+	}
+	if got := aws.ToString(client.lastGet.Bucket); got != locator.Bucket {
+		t.Fatalf("GET bucket = %q, want %q", got, locator.Bucket)
+	}
+	if got := aws.ToString(client.lastGet.Key); got != locator.Key {
+		t.Fatalf("GET key = %q, want %q", got, locator.Key)
+	}
+	if got := aws.ToString(client.lastGet.VersionId); got != locator.VersionID {
+		t.Fatalf("GET version = %q, want %q", got, locator.VersionID)
+	}
+}
+
+func TestFAI520ExactReaderRejectsDeleteMarkers(t *testing.T) {
+	t.Run("head", func(t *testing.T) {
+		client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+		client.headOutput.DeleteMarker = aws.Bool(true)
+		if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrMissingVersion) {
+			t.Fatalf("error = %v, want missing version", err)
+		}
+		if client.getCalls != 0 {
+			t.Fatalf("GET calls = %d, want zero", client.getCalls)
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+		tracking := &closeTrackingBody{Reader: bytes.NewReader([]byte(`{"ok":true}`))}
+		client.getOutput.Body = tracking
+		client.getOutput.DeleteMarker = aws.Bool(true)
+		if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrMissingVersion) {
+			t.Fatalf("error = %v, want missing version", err)
+		}
+		if !tracking.closed {
+			t.Fatal("provider response body was not closed")
+		}
+	})
+}
+
+func TestFAI520ExactReaderProfileMismatchMakesZeroProviderCalls(t *testing.T) {
+	client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+	locator.Endpoint = "https://other.example.test"
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrProfileMismatch) {
+		t.Fatalf("error = %v, want profile mismatch", err)
+	}
+	if client.headCalls != 0 || client.getCalls != 0 {
+		t.Fatalf("calls = HEAD %d, GET %d, want zero", client.headCalls, client.getCalls)
+	}
+}
+
+func TestFAI520ExactReaderRejectsInvalidConstruction(t *testing.T) {
+	_, _, locator := newReader(t, []byte(`{"ok":true}`))
+	valid := Config{Profile: ProfileTuple{
+		StorageProfileID: locator.StorageProfileID, StorageProfileRevision: locator.StorageProfileRevision,
+		AccountIdentity: locator.AccountIdentity, Endpoint: locator.Endpoint, Region: locator.Region,
+		Bucket: locator.Bucket, Namespace: locator.Namespace,
+	}}
+	client := &fakeClient{}
+	if _, err := New(nil, valid); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("nil client error = %v, want invalid", err)
+	}
+	var typedNil *fakeClient
+	if _, err := New(typedNil, valid); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("typed nil client error = %v, want invalid", err)
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{name: "profile id", mutate: func(config *Config) { config.Profile.StorageProfileID = "not-a-uuid" }},
+		{name: "profile revision", mutate: func(config *Config) { config.Profile.StorageProfileRevision = 0 }},
+		{name: "credential endpoint", mutate: func(config *Config) { config.Profile.Endpoint = "https://user:secret@objects.example.test" }},
+		{name: "bucket", mutate: func(config *Config) { config.Profile.Bucket = "UPPERCASE" }},
+		{name: "namespace", mutate: func(config *Config) { config.Profile.Namespace = "../evidence" }},
+		{name: "maximum bytes", mutate: func(config *Config) { config.MaxObjectBytes = int64(successor.MaxDocumentBytes) + 1 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := valid
+			tc.mutate(&config)
+			if _, err := New(client, config); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("error = %v, want invalid", err)
+			}
+		})
+	}
+}
+
+func TestFAI520ExactReaderRejectsMalformedLocatorBeforeIO(t *testing.T) {
+	client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+	locator.Key = "evidence/not-the-content-addressed-key"
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("error = %v, want invalid", err)
+	}
+	if client.headCalls != 0 || client.getCalls != 0 {
+		t.Fatalf("calls = HEAD %d, GET %d, want zero", client.headCalls, client.getCalls)
+	}
+}
+
+func TestFAI520ExactReaderRejectsEveryProfileTupleMismatchBeforeIO(t *testing.T) {
+	mutations := []struct {
+		name   string
+		mutate func(*postgres.ValidatedLocator)
+	}{
+		{name: "profile id", mutate: func(locator *postgres.ValidatedLocator) {
+			locator.StorageProfileID = "33333333-3333-4333-8333-333333333333"
+		}},
+		{name: "profile revision", mutate: func(locator *postgres.ValidatedLocator) { locator.StorageProfileRevision++ }},
+		{name: "account", mutate: func(locator *postgres.ValidatedLocator) { locator.AccountIdentity = "other-account" }},
+		{name: "endpoint", mutate: func(locator *postgres.ValidatedLocator) { locator.Endpoint = "https://other.example.test" }},
+		{name: "region", mutate: func(locator *postgres.ValidatedLocator) { locator.Region = "us-west-2" }},
+		{name: "bucket", mutate: func(locator *postgres.ValidatedLocator) { locator.Bucket = "other-bucket" }},
+		{name: "namespace", mutate: func(locator *postgres.ValidatedLocator) { locator.Namespace = "other" }},
+	}
+	for _, tc := range mutations {
+		t.Run(tc.name, func(t *testing.T) {
+			client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+			tc.mutate(&locator)
+			if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrProfileMismatch) {
+				t.Fatalf("error = %v, want profile mismatch", err)
+			}
+			if client.headCalls != 0 || client.getCalls != 0 {
+				t.Fatalf("calls = HEAD %d, GET %d, want zero", client.headCalls, client.getCalls)
+			}
+		})
+	}
+}
+
+func TestFAI520ExactReaderDoesNotFallbackForMissingVersion(t *testing.T) {
+	client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+	locator.VersionID = ""
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrMissingVersion) {
+		t.Fatalf("error = %v, want missing version", err)
+	}
+	if client.headCalls != 0 || client.getCalls != 0 {
+		t.Fatalf("calls = HEAD %d, GET %d, want zero", client.headCalls, client.getCalls)
+	}
+
+	for _, version := range []string{"latest", "LATEST", "null", "NULL"} {
+		client.headCalls, client.getCalls = 0, 0
+		locator.VersionID = version
+		if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrMissingVersion) {
+			t.Errorf("version %q error = %v, want missing version", version, err)
+		}
+		if client.headCalls != 0 || client.getCalls != 0 {
+			t.Errorf("version %q calls = HEAD %d, GET %d, want zero", version, client.headCalls, client.getCalls)
+		}
+	}
+}
+
+func TestFAI520ExactReaderSanitizesProviderErrors(t *testing.T) {
+	secret := "signed-url-and-secret-key"
+	for _, tc := range []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "missing version", err: &smithy.GenericAPIError{Code: "NoSuchVersion", Message: secret}, want: ErrMissingVersion},
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDenied", Message: secret}, want: ErrAccessDenied},
+		{name: "provider unavailable", err: errors.New(secret), want: ErrProviderUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+			client.headErr = tc.err
+			_, err := reader.ReadExact(t.Context(), locator)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Fatalf("error leaked provider diagnostic: %q", err)
+			}
+		})
+	}
+}
+
+func TestFAI520ExactReaderRetrySucceedsAfterProviderRepair(t *testing.T) {
+	want := []byte(`{"ok":true}`)
+	client, reader, locator := newReader(t, want)
+	client.headErr = errors.New("temporary provider outage")
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrProviderUnavailable) {
+		t.Fatalf("first error = %v, want provider unavailable", err)
+	}
+
+	client.headErr = nil
+	result, err := reader.ReadExact(t.Context(), locator)
+	if err != nil {
+		t.Fatalf("repaired read: %v", err)
+	}
+	defer result.Close()
+	got, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("read repaired result: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("repaired bytes = %q, want %q", got, want)
+	}
+}
+
+func TestFAI520ExactReaderClosesProviderBodyReturnedWithError(t *testing.T) {
+	client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+	secret := "provider-body-error-secret"
+	body := &closeTrackingBody{Reader: bytes.NewReader([]byte(secret))}
+	client.getOutput.Body = body
+	client.getErr = errors.New(secret)
+	_, err := reader.ReadExact(t.Context(), locator)
+	if !errors.Is(err, ErrProviderUnavailable) {
+		t.Fatalf("error = %v, want provider unavailable", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked provider diagnostic: %q", err)
+	}
+	if !body.closed {
+		t.Fatal("provider response body was not closed")
+	}
+}
+
+func TestFAI520ExactReaderClosesBodyOnSuccessAndIntegrityFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		body    []byte
+		getBody []byte
+		wantErr bool
+	}{
+		{name: "success", body: []byte(`{"ok":true}`), getBody: []byte(`{"ok":true}`)},
+		{name: "hash mismatch", body: []byte(`{"ok":true}`), getBody: []byte(`{"ok":null}`), wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, reader, locator := newReader(t, tc.body)
+			tracking := &closeTrackingBody{Reader: bytes.NewReader(tc.getBody)}
+			client.getOutput.Body = tracking
+			if _, err := reader.ReadExact(t.Context(), locator); (err != nil) != tc.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tracking.closed {
+				t.Fatal("provider response body was not closed")
+			}
+		})
+	}
+}
+
+func TestFAI520ExactReaderSanitizesBodyReadAndCloseErrors(t *testing.T) {
+	secret := "provider body secret"
+	for _, tc := range []struct {
+		name      string
+		readError error
+		closeErr  error
+	}{
+		{name: "read", readError: errors.New(secret)},
+		{name: "close", closeErr: errors.New(secret)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+			tracking := &closeTrackingBody{Reader: errorReader{err: tc.readError}, err: tc.closeErr}
+			client.getOutput.Body = tracking
+			_, err := reader.ReadExact(t.Context(), locator)
+			if !errors.Is(err, ErrProviderUnavailable) {
+				t.Fatalf("error = %v, want provider unavailable", err)
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Fatalf("error leaked provider diagnostic: %q", err)
+			}
+			if !tracking.closed {
+				t.Fatal("provider response body was not closed")
+			}
+		})
+	}
+}
+
+func TestFAI520ExactReaderRejectsMissingOrWrongReturnedVersionAndSize(t *testing.T) {
+	client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+	client.getOutput.VersionId = nil
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("missing GET version error = %v, want integrity", err)
+	}
+
+	client.getOutput.VersionId = aws.String("different-version")
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("wrong GET version error = %v, want integrity", err)
+	}
+
+	client.getOutput.VersionId = aws.String(locator.VersionID)
+	client.getOutput.ContentLength = nil
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("missing GET size error = %v, want integrity", err)
+	}
+
+	client.getOutput.ContentLength = aws.Int64(locator.PayloadSize + 1)
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("wrong GET size error = %v, want integrity", err)
+	}
+
+	client.headOutput.VersionId = nil
+	client.getOutput.ContentLength = aws.Int64(locator.PayloadSize)
+	if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("missing HEAD version error = %v, want integrity", err)
+	}
+}
+
+func TestFAI520ExactReaderRejectsShortAndOversizedBodies(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{name: "short", body: []byte(`{"ok":}`)},
+		{name: "oversized", body: []byte(`{"ok":true} trailing`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+			client.getOutput.Body = io.NopCloser(bytes.NewReader(tc.body))
+			if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrIntegrity) {
+				t.Fatalf("error = %v, want integrity", err)
+			}
+		})
+	}
+}
+
+func TestFAI520ExactReaderClosesBodyBeforeRejectingGETMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*awss3.GetObjectOutput)
+	}{
+		{name: "missing version", mutate: func(output *awss3.GetObjectOutput) { output.VersionId = nil }},
+		{name: "wrong version", mutate: func(output *awss3.GetObjectOutput) { output.VersionId = aws.String("other-version") }},
+		{name: "missing content length", mutate: func(output *awss3.GetObjectOutput) { output.ContentLength = nil }},
+		{name: "wrong content length", mutate: func(output *awss3.GetObjectOutput) { output.ContentLength = aws.Int64(1) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+			tracking := &closeTrackingBody{Reader: bytes.NewReader([]byte(`{"ok":true}`))}
+			client.getOutput.Body = tracking
+			tc.mutate(client.getOutput)
+			if _, err := reader.ReadExact(t.Context(), locator); !errors.Is(err, ErrIntegrity) {
+				t.Fatalf("error = %v, want integrity", err)
+			}
+			if !tracking.closed {
+				t.Fatal("provider response body was not closed")
+			}
+			if tracking.reads != 0 {
+				t.Fatalf("provider body reads = %d, want zero", tracking.reads)
+			}
+		})
+	}
+}
+
+func TestFAI520ExactReaderPreservesContextCancellation(t *testing.T) {
+	client, reader, locator := newReader(t, []byte(`{"ok":true}`))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := reader.ReadExact(ctx, locator); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if client.headCalls != 0 || client.getCalls != 0 {
+		t.Fatalf("calls = HEAD %d, GET %d, want zero", client.headCalls, client.getCalls)
+	}
+}
+
+func newReader(t *testing.T, body []byte) (*fakeClient, *Reader, postgres.ValidatedLocator) {
+	t.Helper()
+	sum := sha256.Sum256(body)
+	hash := hex.EncodeToString(sum[:])
+	locator := postgres.ValidatedLocator{
+		Backend:                "s3",
+		StorageProfileID:       testProfileID,
+		StorageProfileRevision: 3,
+		AccountIdentity:        "account-1",
+		Endpoint:               "https://objects.example.test",
+		Region:                 "us-east-1",
+		Bucket:                 "evidence-bucket",
+		Namespace:              "evidence",
+		Key:                    fmt.Sprintf("evidence/managed-observation-manifest/v2/sha256/%s", hash),
+		VersionID:              "opaque-version-1",
+		PayloadFamily:          postgres.PayloadFamilyManifest,
+		PayloadVersion:         2,
+		PayloadDigest:          "sha256:" + hash,
+		PayloadSHA256:          hash,
+		PayloadSize:            int64(len(body)),
+	}
+	client := &fakeClient{
+		headOutput: &awss3.HeadObjectOutput{VersionId: aws.String(locator.VersionID), ContentLength: aws.Int64(locator.PayloadSize)},
+		getOutput:  &awss3.GetObjectOutput{VersionId: aws.String(locator.VersionID), ContentLength: aws.Int64(locator.PayloadSize), Body: io.NopCloser(bytes.NewReader(body))},
+	}
+	reader, err := New(client, Config{Profile: ProfileTuple{StorageProfileID: locator.StorageProfileID, StorageProfileRevision: locator.StorageProfileRevision, AccountIdentity: locator.AccountIdentity, Endpoint: locator.Endpoint, Region: locator.Region, Bucket: locator.Bucket, Namespace: locator.Namespace}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client, reader, locator
+}


### PR DESCRIPTION
## Problem

RecoverySet v3 can persist immutable off-host evidence locators, but no production-shaped adapter could retrieve and verify an explicitly selected historical S3 object version.

## Root cause

The persistence foundation intentionally exposes `recoveryset/postgres.ExactVersionReader` as an integration seam. Provider retrieval, trusted client construction, exact-version enforcement, and byte verification remained unqualified.

## Solution

- Add a narrow S3 exact-version reader backed by a caller-provisioned trusted client and storage-profile tuple.
- Require explicit non-latest `VersionID` values and issue exact-version `HeadObject` and `GetObject` requests against the trusted bucket.
- Reject profile, namespace, bucket, endpoint, account, region, object, version, size, and SHA-256 substitutions.
- Reject delete markers and missing/unavailable versions without falling back to the latest object.
- Return bounded, sanitized failure categories while preserving cancellation and closing provider bodies.
- Add the adapter package to the existing FAI-520 qualification workflow.

## Tests added

- Unit coverage for exact-version requests, profile isolation, version/size/digest integrity, delete markers, credential/provider failures, deterministic retry after repair, cleanup, and sanitized diagnostics.
- Disposable versioned MinIO qualification using real PostgreSQL RecoverySet v3 repositories.
- Historical retrieval after overwrite and current-version deletion, PostgreSQL close/reopen, exact retry, unrelated sentinel isolation, and fail-closed repository state for negative cases.

## Verification

- `go test ./internal/recoveryset/s3reader -count=2`
- `go vet ./internal/recoveryset/...`
- `go test ./internal/platform/architecture -count=1`
- FAI-520 MinIO/PostgreSQL qualification under `-race`, `-count=2`
- `go test ./internal/recoveryset/... -count=1`
- `task docs:generate`
- `task docs:check`
- `task generated:check`
- `git diff --check`
- Full `task ci` with isolated Go cache/temp directory: passed

## Limitations

This slice does not implement capture authority, write-time provider version capture, provider retention enforcement, restore orchestration, recovery admission/startup integration, traffic activation, PostgreSQL restore, PITR, or RPO/RTO qualification. MinIO qualification does not establish production AWS or other provider behavior.

This validates historical managed-object retrieval. It does not prove successful physical disaster recovery.