### PR TITLE
docs(adr): adopt local-first analytics development

### DIFF
--- a/adr/0007-adopt-plan-driven-project-delivery.md
+++ b/adr/0007-adopt-plan-driven-project-delivery.md
@@ -6,6 +6,9 @@ Decision date: 2026-08-17
 
 Implementation: in progress (controlled rollout)
 
+Amended by: [ADR-0021](0021-adopt-a-local-first-analytics-development-workflow.md),
+human-facing command orchestration and local runtime startup only
+
 Deciders: LeapView maintainers
 
 Supersedes: none

--- a/adr/0020-adopt-a-postgresql-centered-target-data-architecture.md
+++ b/adr/0020-adopt-a-postgresql-centered-target-data-architecture.md
@@ -6,6 +6,9 @@ Decision date: 2026-08-28
 
 Implementation: in progress (clean-slate target architecture; draft PR #386)
 
+Amended by: [ADR-0021](0021-adopt-a-local-first-analytics-development-workflow.md),
+local analytics development topology and filesystem storage profile only
+
 Deciders: LeapView maintainers
 
 Supersedes:

--- a/adr/0021-adopt-a-local-first-analytics-development-workflow.md
+++ b/adr/0021-adopt-a-local-first-analytics-development-workflow.md
@@ -1,0 +1,530 @@
+# ADR-0021: Adopt a local-first analytics development workflow
+
+Status: accepted
+
+Decision date: 2026-09-09
+
+Implementation: pending
+
+Deciders: LeapView maintainers
+
+Supersedes: none
+
+Amends: [ADR-0007](0007-adopt-plan-driven-project-delivery.md), human-facing
+command orchestration and local runtime startup only;
+[ADR-0020](0020-adopt-a-postgresql-centered-target-data-architecture.md), local
+analytics development topology and filesystem storage profile only
+
+Related: [ADR-0003](0003-retain-narrow-infisical-resolver.md),
+[ADR-0004](0004-defer-incremental-project-reconciliation.md),
+[ADR-0018](0018-retain-project-as-the-durable-deployment-namespace.md),
+[ADR-0019](0019-integrate-dbt-at-the-warehouse-contract-boundary.md),
+[project-delivery conformance](specifications/project-delivery-conformance.md),
+[analytics development CLI contract](specifications/analytics-development-cli-contract.md)
+
+## Context and problem statement
+
+LeapView supports authoring analytics in YAML, but the ordinary author must
+first obtain an initialized server. The existing `leapview dev` synchronizes
+source into a private candidate on an already-running target. It does not
+start that target. The production Compose package expects PostgreSQL URLs,
+database roles, and delivery-pool configuration supplied by an operator.
+
+The repository's `task dev` hides much of the bootstrap, but requires a source
+checkout, Go, Bun, and Task. It builds LeapView itself, provisions contributor
+fixtures, and enables software-development conveniences such as the Datastar
+inspector. It is a contributor harness, not the installation experience for a
+person changing a dashboard or semantic model.
+
+The distinction between software development and analytics development is
+currently obscured by the shared word "dev." A YAML author should be able to
+clone a project, preview changes locally, and deliver them to an existing
+production instance without learning the internal bootstrap protocol or
+manually carrying candidate IDs between routine commands.
+
+PostgreSQL remains required for LeapView's control plane and DuckLake catalog.
+DuckLake's analytical files require file storage, not a separate data lake
+service. A local filesystem can supply that storage. Automating a local
+PostgreSQL service and persistent volumes can therefore preserve the existing
+authority model without adding S3, MinIO, or an embedded control-plane mode.
+
+Research into Rill, Supabase, Lightdash, Terraform, and CLI design guidance
+supports combining runnable local analytics, automated dependency startup,
+optional remote previews, and guided delivery over durable plans. These are
+documented precedents, not comparative usability or performance measurements.
+
+Beyond the synthetic example, authors need to connect the local runtime to real
+upstream systems, including approved sources also read by production. Existing
+target bindings and the development credential resolver provide the execution
+boundary, but not a convenient profile-based setup experience. A project can
+need several upstream connections at once; those connections are distinct from
+the LeapView server selected for deployment.
+
+## Decision drivers
+
+- A released CLI and Docker with Compose must be sufficient for the basic
+  analytics development experience.
+- First use must produce a working sample dashboard; subsequent use must
+  preserve data and minimize repeated setup.
+- The edit/save/preview loop must explain invalid edits and retain the last
+  working result without exposing partially validated state.
+- Development data must be repeatable, bounded, and visibly distinct from
+  production data.
+- Local source setup must support multiple approved remote inputs without
+  copying production credentials or changing the portable analytics graph.
+- Local, remote, interactive, and automated delivery must retain one source
+  snapshot, plan, candidate, and generation state machine.
+- Production targeting, approval, and completion must remain explicit while
+  internal identifiers become optional inspection details for routine users.
+- PostgreSQL authority, target-owned credentials, whole-project validation,
+  physical reuse rules, and atomic activation must remain intact.
+
+## Considered options
+
+- Keep remote-only `leapview dev` and require an operator-provisioned
+  development instance for every author.
+- Make the contributor `task dev` harness the supported analytics onboarding
+  path.
+- Add an embedded local control plane and a separate publication path for
+  production.
+- Publish a manually configured local Compose example while leaving
+  bootstrap and lifecycle orchestration to each author.
+- Adopt CLI-managed Docker development with optional remote previews and a
+  guided deployment command over the existing delivery lifecycle.
+
+For connection profiles, consider adopting dbt's schema unchanged, Rill's
+templated connector resources, SQLMesh gateways, dlt's layered configuration,
+or a strict native profile over LeapView's existing bindings. Lightdash's dbt
+profile conversion is an interoperability precedent, not an independent schema.
+
+## Decision outcome
+
+Choose CLI-managed Docker development as the default analytics authoring
+experience. The ordinary journey is:
+
+```sh
+# Create a project with a working synthetic example.
+leapview init my-analytics
+cd my-analytics
+
+# Start or resume local services, watch YAML, and open a private preview.
+leapview dev
+
+# After configuring an existing production target, review and deliver source.
+leapview deploy --target prod
+```
+
+An existing checkout needs only `leapview dev` once prerequisites and its
+development data configuration are available. These commands describe the
+accepted end state; acceptance of this ADR does not imply they are already
+implemented or available in a release.
+
+### Local runtime ownership
+
+The CLI owns a namespaced Compose project with two persistent services: a
+version-matched LeapView application and PostgreSQL. PostgreSQL contains
+separate control and DuckLake catalog databases with their existing role and
+migration boundaries. Docker volumes retain PostgreSQL state and the local
+analytical files, managed objects, and artifacts needed by the runtime.
+
+The launcher automates database provisioning, migrations, local credentials,
+instance and Project bootstrap, physical-pool qualification/admission, and
+health reconciliation through their owning components. Bootstrap is
+idempotent and resumable. Packaging and orchestration reuse the product's
+contracts rather than invoking the contributor toolchain or maintaining an
+independent bootstrap implementation.
+
+The default local stack requires no external PostgreSQL, object-storage
+service, secret-provider service, or analytical warehouse. Local filesystem
+storage preserves immutable file ownership, candidate isolation, snapshot
+seals, leases, and retention. This profile does not change production
+provisioning or weaken its admission and recovery requirements.
+
+Local endpoints bind to loopback. The launcher establishes a local browser
+and CLI session without requiring the author to perform production operator
+onboarding. Local session setup must not become a remote authentication bypass.
+The normal released product UI is used, with the Datastar inspector and
+contributor diagnostics disabled by default independently of the environment
+name. `task dev` remains the workflow for changing LeapView software.
+
+### Predictable lifecycle and target selection
+
+Bare `leapview dev` selects local development. An ambient `LEAPVIEW_TARGET`,
+previous production login, or default remote profile must not silently redirect
+it. Explicit remote development remains supported:
+
+```sh
+leapview dev --target staging
+```
+
+Remote mode uses an existing authorized target and starts no local containers.
+It serves teams requiring shared QA, private-network data access, or compute
+beyond a laptop. A separate development VPS is optional. Remote development is
+an application connection, not authorization to provision a remote Docker host.
+
+Local mode must resolve Docker's effective endpoint, including active context
+and ambient `DOCKER_HOST` and `DOCKER_CONTEXT`, and validate that it is a
+supported local runtime before provisioning, pulling images, or staging data.
+Unsupported or unverifiable endpoints fail closed with actionable diagnostics.
+Loopback publication, a context name, or a daemon label alone is not evidence
+that the daemon is on the author's machine. Docker Desktop's supported local
+VM can qualify as local; arbitrary remote daemons and forwarding tunnels do not.
+Subsequent operations must use the validated endpoint, not resolve ambient
+configuration again and silently act elsewhere.
+
+Local development provides `dev status`, `dev logs`, `dev stop`, and an explicit
+local `dev reset`. Ctrl-C detaches the current session and stops managed services
+only when no other live attached session for the selected checkout requires
+them, retaining volumes. Concurrent joins and exits must preserve this invariant;
+crashed sessions must eventually cease to count as live.
+
+`dev stop` and `dev reset` refuse without mutation while live sessions remain;
+the user must detach them first. Lifecycle operations are scoped to the selected
+checkout and its managed resources, and uncertain ownership must not authorize
+stopping or deleting resources. Reset identifies and confirms the exact local
+state being removed and has no remote-target behavior. The linked CLI contract
+defines observable behavior without prescribing locking or liveness mechanisms.
+
+Separate checkouts and worktrees have isolated state and storage namespaces.
+Port conflicts are resolved automatically and the actual URL is reported.
+Rerunning development after interruption reuses and reconciles existing state.
+Runtime versions are pinned and compatible with the CLI; upgrades that change
+persistent state are explicit rather than a side effect of starting a session.
+
+### Source ownership and preview behavior
+
+The host CLI watches authored files, captures coherent immutable snapshots,
+and sends them through the normal candidate APIs. A live YAML mount is not an
+alternative server configuration or activation mechanism. The compiler still
+validates the complete resource graph. A file watcher never activates shared
+serving state.
+
+One stable development-session URL follows the latest valid private candidate
+in the same browser tab. Each dashboard render or refresh resolves the session
+pointer once, then pins every associated query to that exact candidate and
+required snapshot leases. Widgets, filter options, pagination, cached responses,
+and streamed results must not independently re-resolve the pointer within that
+view. A moving session pointer is a navigation convenience, not deployment or
+approval identity. Page, filters, and selections are preserved where their
+contracts remain compatible. Exact candidate URLs remain pinned and available
+for review.
+
+A candidate transition invalidates incompatible in-flight responses. The UI
+must not combine results from the previous candidate with the new candidate as
+one current dashboard. It may retain the complete previous view while loading
+its replacement, or clear obsolete results. Cancellation alone is insufficient:
+late responses must be rejected using the pinned view identity. This preserves
+the existing immutable generation and lease contracts; it does not promise
+transactional snapshots across independently changing external systems.
+
+Invalid edits produce actionable file-and-line diagnostics in the terminal
+and preview. The previous working candidate remains visible with an explicit
+out-of-date indication. Obsolete work must not replace a newer valid result.
+Normal output describes resource changes, progress, reuse, and the next useful
+action. Detailed evidence remains accessible through inspection, verbose
+output, and structured JSON suitable for CI and agents.
+
+Code edits and data refresh are separate intents. Reuse unchanged physical
+work when execution identity proves it safe; presentation-only changes must
+not trigger avoidable ingestion. This does not authorize an incremental
+compiler or partial publication: ADR-0004's measurement gate remains in force.
+
+### Development data and reproducibility
+
+`leapview init` creates a complete example with small synthetic data. Existing
+projects declare their development inputs: schema-compatible CSV/Parquet
+fixtures, approved immutable sample revisions, or explicit development
+connections. The launcher automatically stages declared local fixtures through
+managed-data APIs. It must not silently download production data, substitute
+unrelated sample data, or upload fixtures to production during deployment.
+
+Fixture selection and refresh bounds preserve the relationships required by
+the models. Arbitrary row limits are not a promise of representative results.
+The preview identifies sample/bounded inputs and reports missing bindings with
+an actionable setup path. Changing a fixture produces a new explicit data
+revision; ordinary YAML saves do not silently refresh mutable inputs.
+
+Semantic models and dashboards stay portable across environments. Each target
+owns its data bindings, credentials, grants, and policy. Dedicated development
+credentials may be configured once through the local resolver; production
+secrets are not pulled onto laptops or propagated from local configuration by
+`deploy`. Remote preview remains available when data cannot be used locally.
+
+Version pins and non-secret development configuration can be committed so a
+teammate can reproduce the setup. Secrets, machine-specific state, and delivery
+checkpoints remain outside the portable source bundle. Tooling configuration
+does not reintroduce `kind: Project`, authored access/publication resources,
+or environment forks of the analytics graph. Project identity follows
+ADR-0018: local bootstrap resolves the appropriate issuer-owned identity, and
+production delivery binds to the existing target claim without replacing it.
+
+### Local connection profiles and remote sources
+
+Adopt a small, strict, versioned YAML profile over existing target connection
+bindings. Use dbt's separation of analytical code from connection profiles as
+the primary design precedent, and Rill's multiple named connectors as the
+multi-source model. This is a LeapView-native contract, not a claim of dbt
+`profiles.yml` compatibility.
+
+A profile is a named set of local source bindings. Each entry resolves a
+logical Connection from the authored graph and supplies its endpoint and an
+explicit credential reference. Connector type comes from that Connection;
+validation reuses LeapView's typed connector and binding contracts. Profiles
+must not introduce independent connector definitions, Project authority,
+runtime storage topology, scheduler configuration, or a second secret system.
+
+The selected profile fully covers required external target bindings; retained
+omitted records are not execution fallback. Applying a multi-connection profile
+must not admit new work or report success against a partially applied set. An
+interrupted application reconciles its exact retained intent before admission
+resumes. This can use an incomplete state and execution gate without a new
+cross-binding transaction or delivery state machine.
+
+Attached sessions must agree on applied credential versions as well as binding
+configuration. Identical variable names do not establish credential agreement.
+Rotation or replacement is explicit and preserves existing qualification,
+authorization, cache, and lease rules; a principal/scope change is not assumed
+to be secret-only rotation. Switching away retires the old runtime credentials
+and pools with bounded reader draining, while stored binding evidence may remain.
+
+Local means that LeapView runs and maintains working state locally, not that
+its input sources must be local. The local runtime may read the same approved
+upstream database, replica, warehouse, or object store as production using
+developer-specific, least-privilege credentials. It connects to that upstream
+directly, not through the production LeapView instance. Local isolation does
+not eliminate upstream query load, network access requirements, or restrictions
+on copying sensitive data onto a workstation.
+
+Profiles remain outside the portable analytics bundle. Secret values are
+resolved through existing credential mechanisms, never embedded in profile
+URLs or executable templates. Strict parsing, editor schema validation, and
+explicit references replace Jinja, Python, and shell evaluation. Select one
+profile file without hidden cross-file merging or ambient production selection.
+`dev --profile local` selects local source bindings; `deploy --target prod`
+selects a LeapView destination. Local profiles cannot retarget that destination
+or provision remote credentials. Production retains its own bindings and
+credential resolution.
+
+Guided setup and CLI configuration use the same profile representation and
+owning binding APIs. Connection testing runs inside the local runtime and
+reports reachability, VPN/DNS, TLS, authentication, and permission failures
+without exposing secrets. Only explicitly selected credentials enter the
+validated local runtime; the launcher must not forward the entire host
+environment or silently mount credential directories.
+
+The author explicitly chooses approved upstream reads and refresh bounds.
+Direct reads still require upstream connectivity; explicit refresh/build work
+can produce retained local materializations under the existing pipeline and
+snapshot contracts. A profile is neither an ingestion recipe nor a guarantee
+of offline operation. YAML saves do not silently refresh mutable inputs.
+
+An explicit, reviewed import of supported dbt profile targets into individual
+local bindings may be added later. It is optional interoperability, not required
+for initial delivery. Unsupported adapter settings must fail clearly; import
+must not execute arbitrary project code or imply general dbt compatibility.
+
+### Guided production delivery
+
+`leapview deploy --target prod` becomes the normal interactive delivery command.
+It orchestrates capture, target-owned planning, review, build, publication,
+and status reconciliation. It captures source once and shows the destination,
+resource impact, removals, required physical work, reusable work, and approval
+requirements before avoidable expensive work. Human confirmation or configured
+automation policy authorizes proceeding with that exact plan.
+
+The explicit `plan`, `build`, and `publish` commands remain supported for
+separate review gates, CI, inspection, and recovery. Durable plan, candidate,
+publication, and idempotency identities remain available and are persisted for
+retry. A convenience command creates no second delivery state machine.
+
+After interruption or a lost acknowledgement, resumption reconciles the
+retained operation. It never silently captures new source, changes target,
+rebuilds a sealed candidate, or replans under an earlier approval. A stale plan
+requires a fresh plan and review under target policy. Noninteractive callers
+receive structured results and defined completion/pending/failure semantics
+without unexpected prompts.
+
+Starting a new deployment and resuming retained work are distinct intents. The
+CLI must never silently choose between them when retained work makes the choice
+ambiguous, nor select the most recent of several operations. Interactive
+selection identifies the retained destination and source before the author
+chooses to resume, without requiring internal ID copying. Automation uses
+explicit intent and a deterministic operation handle. Missing or ambiguous
+selection fails without beginning or advancing delivery.
+
+Local edits do not change a resumed operation. Indeterminate earlier publication
+must be reconciled before conflicting new publication can proceed. Human-readable
+handles select retained work; they are not new target authority or replacements
+for immutable delivery identities. All target-owned qualification, approval,
+authorization, and staleness checks still apply. The linked CLI contract defines
+command selection and recovery behavior in detail.
+
+Production independently plans and qualifies the same portable source against
+its own bindings, inputs, policy, and active revision. Local candidates,
+catalogs, data volumes, and approvals are not promoted across targets.
+Development verification is useful evidence, not proof of production data
+availability or viewer authorization. Required managed data must already be
+staged to production through an explicit data workflow.
+
+The command distinguishes active deployment, awaiting approval, failed work,
+and an indeterminate outcome. It exposes a status/review URL and the next
+action. It never reports a pending publication as active. Protected targets
+retain independent approval and activation controls; immediate-policy targets
+may activate automatically. Git and CI invoke this same contract, with
+retained evidence tied to the reviewed source revision.
+
+### Compatibility and scope
+
+This decision amends ADR-0007's removal of `deploy` from the normal human model
+and its assumption that `dev` begins with a running target. Its plan-driven
+protocol, exact publication, staleness checks, target-owned credentials,
+rollback, and audit requirements continue to govern.
+
+ADR-0018 continues to own durable Project and instance-bound environment identity.
+ADR-0020 continues to own PostgreSQL role boundaries, immutable files, and snapshot
+leases. ADR-0004's measurement gate for incremental reconciliation is unchanged.
+
+Changing bare `dev` target resolution requires a documented command migration,
+updates to scripts that rely on ambient remote targets, and compatibility
+tests. Documentation must distinguish accepted behavior from released behavior
+until implementation ships. This ADR does not select a new production
+installer, hosted platform, multi-project server, or production database
+topology. It does not make a local Docker volume a production backup strategy.
+
+## Consequences
+
+Authors can preview analytics with one startup command and use an existing
+production instance for delivery. Small teams can operate one production VPS
+without requiring shared development infrastructure. The local runtime retains
+the same PostgreSQL and immutable-delivery foundations used in production.
+
+The product takes ownership of Docker prerequisites, image distribution,
+version compatibility, portable bootstrap, persistent lifecycle, diagnostics,
+and development data setup. First-run image downloads and Docker resource
+usage remain real costs. Local data and policies may differ from production;
+production qualification remains necessary.
+
+Local runtime support needs explicit platform validation; an unrecognized Docker
+endpoint may require the author to select a supported configuration. Authors
+sharing a checkout must detach before stop or reset. Preview delivery needs
+view-scoped identity and stale-response rejection, not just per-query candidate
+identity. Deployment tooling must retain selectable operation descriptors and
+expose ambiguity instead of guessing. These costs buy predictable data placement,
+non-disruptive shared sessions, coherent previews, and recovery that cannot
+silently substitute edited source.
+
+Keeping remote-only development would preserve less client orchestration but
+retain mandatory infrastructure setup. Requiring `task dev` would move build
+toolchain costs onto analytics authors. An embedded control plane would create
+an additional correctness and support model. A manual Compose recipe would
+leave the same bootstrap and recovery friction distributed across projects.
+These alternatives are rejected as the default onboarding experience.
+
+For profiles, unchanged dbt schemas would import warehouse-execution concepts
+and still need adaptation for simultaneous upstream connections. Rill-style
+environment branches and templating inside portable connector YAML would
+weaken the chosen source/binding separation. Lightdash-style credential upload
+is not a substitute for production-owned resolution. SQLMesh gateways include
+state, execution, and scheduler responsibilities that the local launcher already
+owns. dlt's configuration/secret separation is useful precedent, but its layered
+fallback lookup is not adopted. A native profile adds a small schema and setup
+surface to maintain while reusing existing validators, bindings, and resolvers.
+
+Delivery requires coordinated work across packaging/bootstrap, preview and
+data ergonomics, and guided deployment. Implementation sequencing and progress
+belong in delivery tracking, not this historical decision. Reusing proven
+physical work is required where applicable, but numerical performance claims
+must be supported by measurement.
+
+## Confirmation
+
+Conformance is demonstrated by a clean-machine authoring journey using only
+the released CLI and Docker with Compose: initialize a sample, open a working
+dashboard, edit a metric, repair an invalid edit, restart with retained data,
+and deliver to a prepared test production target without manual database setup
+or copying candidate IDs.
+
+Lifecycle and architecture checks must cover checkout isolation, port
+collisions, interrupted bootstrap, repeat startup, version compatibility,
+scoped stop/reset, local-only default targeting despite ambient production
+configuration, and explicit remote mode without local startup. They must also
+cover ambient remote Docker targeting and context changes during startup,
+concurrent session exit and join, crashed attachments, and stop/reset refusal
+while sessions remain live.
+
+Preview checks must prove stable navigation, compatible UI-state preservation,
+useful diagnostics, last-valid behavior, exact candidate/query identity, and
+rejection of obsolete results. Data checks must prove repeatable fixture
+staging, correct schema/reference behavior, explicit refresh, safe reuse, and
+absence of implicit production data or credential transfer.
+
+Profile checks must cover multiple remote sources, deterministic file/profile
+selection, typed validation, exact logical-connection resolution, missing
+credentials without fallback, runtime-side connectivity diagnostics, secret
+redaction, and exclusion from deployment bundles. Changing local bindings must
+not mutate production bindings or silently replace another attached session's
+source configuration. Explicit refresh and retained local results must remain
+distinct from live upstream reads.
+
+Preview checks must include a candidate transition while several dashboard
+queries are running, proving that all associated results stay pinned to one view
+and incompatible late responses cannot mix into its replacement.
+
+Delivery checks must exercise unchanged source identity across the guided
+steps, target binding, independent production qualification, approval gates,
+stale rejection, resumable lost acknowledgements, and accurate pending/active
+reporting. Existing whole-project and atomic-publication checks remain active.
+
+Delivery selection checks must cover interrupted publication followed by local
+edits, competing checkpoints, deterministic automation selection, and missing
+or ambiguous operation handles. The
+[CLI contract](specifications/analytics-development-cli-contract.md) records
+the detailed conformance scenarios. Passing document structure checks does not
+constitute implementation conformance.
+
+Measure cold start with and without cached images, warm restart, and
+edit-to-visible-result p50/p95 on representative hardware and datasets. Include
+actual semantic, model, dashboard, and invalid-edit scenarios. Report fixture
+size and network conditions separately; apply ADR-0004 before introducing
+incremental compilation. Usability validation includes a new analytics author
+and a teammate starting from a fresh checkout.
+
+## Research references
+
+Consulted on 2026-09-09:
+
+- [Rill onboarding](https://docs.rilldata.com/): runnable local analytics.
+- [Rill deployment](https://docs.rilldata.com/developers/deploy/deploy-dashboard):
+  a distinct deploy/update action.
+- [Rill PostgreSQL connector](https://docs.rilldata.com/developers/build/connectors/data-source/postgres):
+  bounded development ingestion.
+- [Supabase local workflow](https://supabase.com/docs/guides/local-development/cli-workflows):
+  CLI-managed services, initialization, seeds, and persistent development state.
+- [Lightdash CLI](https://docs.lightdash.com/workflow/cli/reference): named
+  remote previews and separate deployment.
+- [Terraform plan](https://developer.hashicorp.com/terraform/cli/commands/plan):
+  interactive review and saved plans for automation.
+- [DuckLake storage](https://ducklake.select/docs/stable/duckdb/usage/choosing_storage):
+  local filesystem and object-storage choices, not LeapView's higher-level
+  isolation or recovery guarantees.
+- [Docker contexts](https://docs.docker.com/engine/manage-resources/contexts/)
+  and [Docker CLI configuration](https://docs.docker.com/reference/cli/docker/):
+  independent daemon targeting and configuration precedence.
+- [Command Line Interface Guidelines](https://clig.dev/): progress, actionable
+  errors, discoverability, and recoverable operations.
+
+Connection-profile references consulted on 2026-09-10 using the Flid reference
+library, Sourcebook, and official documentation:
+
+- [dbt profiles](https://docs.getdbt.com/docs/local/profiles.yml): profile/code
+  separation, named targets, and environment-based credential references.
+- [Rill connectors](https://docs.rilldata.com/developers/build/connectors/templating)
+  and [local credentials](https://docs.rilldata.com/developers/build/connectors/credentials):
+  named connectors and guided local setup; environment branching and credential
+  push/pull are not adopted.
+- [Lightdash profile conversion](https://github.com/lightdash/lightdash/blob/35906ad9e116df59d2d59da2f58e45e9b39eaff8/packages/cli/src/dbt/profile.ts):
+  explicit dbt-profile adaptation as an interoperability precedent.
+- [SQLMesh gateways](https://sqlmesh.readthedocs.io/en/stable/guides/configuration/#gateways):
+  typed connections within a broader execution/state/scheduler configuration.
+- [dlt configuration and secrets](https://dlthub.com/docs/general-usage/credentials/setup):
+  separation of configuration from secrets; layered fallback is not adopted.

--- a/adr/README.md
+++ b/adr/README.md
@@ -25,7 +25,7 @@ customer site.
 | [ADR-0004](0004-defer-incremental-project-reconciliation.md) | Defer incremental project reconciliation | Accepted | 2026-08-05 | Deferred pending corrected measurement | [ADR-0005](0005-use-project-wide-resource-graph.md), scope and identity only |
 | [ADR-0005](0005-use-project-wide-resource-graph.md) | Use a project-wide resource graph | Accepted | 2026-08-15 | Complete | [ADR-0016](0016-adopt-standards-aligned-data-contracts-and-interchange.md), public Project and control-plane authoring boundaries |
 | [ADR-0006](0006-adopt-ossie-aligned-semantic-contract.md) | Adopt an OSSIE-aligned typed semantic contract | Accepted | 2026-08-17 | Complete | [ADR-0016](0016-adopt-standards-aligned-data-contracts-and-interchange.md), structural authority; [ADR-0017](0017-adopt-a-looker-aligned-semantic-access-contract.md), semantic access contract |
-| [ADR-0007](0007-adopt-plan-driven-project-delivery.md) | Adopt plan-driven project delivery | Accepted | 2026-08-17 | In progress (controlled rollout) | — |
+| [ADR-0007](0007-adopt-plan-driven-project-delivery.md) | Adopt plan-driven project delivery | Accepted | 2026-08-17 | In progress (controlled rollout) | [ADR-0021](0021-adopt-a-local-first-analytics-development-workflow.md), human-facing command orchestration and local runtime startup only |
 | [ADR-0008](0008-isolate-ducklake-candidate-physical-state.md) | Use one immutable DuckLake catalog per candidate | Accepted | 2026-08-17 | In progress (controlled rollout) | [ADR-0020](0020-adopt-a-postgresql-centered-target-data-architecture.md), private file-backed catalog mechanics only |
 | [ADR-0009](0009-separate-control-and-physical-transactions.md) | Separate control state from immutable physical catalogs | Accepted | 2026-08-17 | In progress (controlled rollout) | [ADR-0020](0020-adopt-a-postgresql-centered-target-data-architecture.md), control-store selection only |
 | [ADR-0010](0010-adopt-strict-typed-data-resource-contracts.md) | Adopt strict typed data-resource contracts | Accepted | 2026-08-18 | Complete | [ADR-0016](0016-adopt-standards-aligned-data-contracts-and-interchange.md), contract evolution, quality identity, and governance metadata |
@@ -38,7 +38,8 @@ customer site.
 | [ADR-0017](0017-adopt-a-looker-aligned-semantic-access-contract.md) | Adopt a Looker-aligned semantic access contract | Accepted | 2026-09-01 | Pending | — |
 | [ADR-0018](0018-retain-project-as-the-durable-deployment-namespace.md) | Retain Project as the durable deployment namespace | Accepted | 2026-09-02 | Pending | [ADR-0019](0019-integrate-dbt-at-the-warehouse-contract-boundary.md), dbt mapping and external-source examples only |
 | [ADR-0019](0019-integrate-dbt-at-the-warehouse-contract-boundary.md) | Integrate dbt at the warehouse contract boundary | Accepted | 2026-09-03 | Pending | — |
-| [ADR-0020](0020-adopt-a-postgresql-centered-target-data-architecture.md) | Adopt a PostgreSQL-centered target data architecture | Accepted | 2026-08-28 | In progress (clean-slate target architecture) | — |
+| [ADR-0020](0020-adopt-a-postgresql-centered-target-data-architecture.md) | Adopt a PostgreSQL-centered target data architecture | Accepted | 2026-08-28 | In progress (clean-slate target architecture) | [ADR-0021](0021-adopt-a-local-first-analytics-development-workflow.md), local analytics development topology and filesystem storage profile only |
+| [ADR-0021](0021-adopt-a-local-first-analytics-development-workflow.md) | Adopt a local-first analytics development workflow | Accepted | 2026-09-09 | Pending | — |
 
 ## Companion specifications
 
@@ -58,6 +59,7 @@ historical records.
 - [OpenLineage projection conformance](specifications/openlineage-conformance.md)
 - [Semantic access-policy conformance](specifications/semantic-access-policy-conformance.md)
 - [Project namespace conformance](specifications/project-namespace-conformance.md)
+- [Analytics development CLI contract](specifications/analytics-development-cli-contract.md)
 
 ## Conventions
 

--- a/adr/specifications/analytics-development-cli-contract.md
+++ b/adr/specifications/analytics-development-cli-contract.md
@@ -1,0 +1,505 @@
+# Analytics development CLI contract
+
+Status: accepted
+
+Implementation: pending
+
+Last updated: 2026-09-10
+
+Owners: LeapView maintainers
+
+Governing decision:
+[ADR-0021](../0021-adopt-a-local-first-analytics-development-workflow.md)
+
+Related: [project delivery conformance](project-delivery-conformance.md) and
+[Project namespace conformance](project-namespace-conformance.md)
+
+## Scope
+
+This mutable implementation-facing contract defines observable local lifecycle,
+source connection profiles, preview coherence, and deployment selection behavior.
+The command syntax below is the intended interface, not documentation of released
+functionality. Must
+and must not are normative. Implementation mechanisms remain open where the
+observable contract is preserved.
+
+## Local runtime selection
+
+Before any Docker mutation, image pull, or development-data staging, local mode
+must resolve and inspect the effective Docker endpoint using Docker's actual
+configuration precedence. This includes the selected context, active context,
+`DOCKER_CONTEXT`, and `DOCKER_HOST`, and any supported explicit CLI override.
+It must not infer locality from `LEAPVIEW_TARGET`, the word `default` in a
+context name, or a published loopback port.
+
+The implementation must document supported local-runtime transports and their
+verification checks. Recognized local Engine sockets and supported Docker
+Desktop local-VM endpoints may qualify. SSH, arbitrary TCP endpoints (including
+loopback tunnels), and unrecognized socket proxies must not qualify merely
+because they respond to the Docker API. This is a documented host-runtime trust
+boundary, not a claim to detect a compromised host or maliciously replaced
+trusted runtime socket. Ambiguous locality fails closed.
+
+Every subsequent Docker/Compose operation must use the pinned, validated
+endpoint. A context switch during startup must not redirect a later subprocess.
+Reattachment and lifecycle commands must verify the endpoint and checkout-owned
+resource identity before mutation. A changed or unavailable daemon must not
+cause fallback provisioning or deletion on a different daemon.
+
+Failure diagnostics identify the rejected context/endpoint without exposing
+credentials and explain how to select a supported local runtime. LeapView must
+not silently rewrite the user's global Docker context. `dev --target staging`
+uses an existing LeapView target and must not provision through remote Docker.
+
+## Local source connection profiles
+
+### Format and identity
+
+The intended v1 document is strict YAML containing `version: 1` and a `profiles`
+map. Each named profile contains a `connections` map keyed by logical Connection
+name. For example, given a PostgreSQL Connection named `commerce` in the graph:
+
+```yaml
+version: 1
+
+profiles:
+  local:
+    connections:
+      commerce:
+        endpoint:
+          host: analytics-reader.example.com
+          port: 5432
+          database: commerce
+          tlsMode: verify-full
+        credentials:
+          env: LEAPVIEW_DEV_CONNECTION_COMMERCE
+```
+
+This is the intended interface, not an implemented schema. Each connection entry
+contains `endpoint` and `credentials`; endpoint fields and connector-specific
+options reuse the existing binding contracts. The compiler resolves the name to
+the Connection's exact graph identity and derives its connector type. Unknown
+names, unsupported options, duplicate YAML keys, unsupported versions, and
+unknown document fields must fail with file-and-field diagnostics. Names must
+not be silently case-folded or matched to a different resource.
+
+The initial authenticated local profile uses `credentials.env` to reference one
+allowlisted `LEAPVIEW_DEV_CONNECTION_<NAME>` variable containing an atomic JSON
+credential bundle. It delegates to the existing development environment resolver
+and its connector-specific validation; it does not interpolate secret values
+into profile YAML. Public unauthenticated connections may explicitly use
+`credentials: {none: true}` only where the connector contract permits it.
+Exactly one credential mode is allowed. Managed connections continue to use
+managed-data setup and do not require external credential entries.
+
+Profile v1 does not add arbitrary secret providers or an implicit host credential
+chain. It does not replace existing Infisical authority or permit environment
+fallback when Infisical is configured. Such a configuration conflict must be
+reported, not resolved by silently changing the target's resolver selection.
+
+Publish editor-validation schemas generated from the owning contracts and test
+them against runtime validation. Do not add general YAML/Jinja templating,
+Python evaluation, shell substitution, or executable authentication helpers.
+Inline credentials, including credentials embedded in endpoint URLs or options,
+are rejected rather than copied into target binding persistence.
+
+### File and profile selection
+
+The default local file is `.leapview/profiles.local.yaml` relative to the selected
+checkout root. `--profile-file <path>` explicitly selects another single file;
+relative flag paths resolve from the invocation directory. `--profile <name>`
+selects one named profile, defaulting to `local`. These flags apply to local
+`dev`, not production delivery or remote `dev --target ...`.
+
+Do not merge files from the current directory, checkout, home directory, or a
+remote target. A missing explicitly selected file or named profile fails; it
+does not select another profile or target. A fixture-only project may run with
+no profile file. When external bindings are required but missing, show guided
+setup instead of substituting sample data or inferring production credentials.
+
+The selected profile completely specifies the external target bindings required
+by the compiled resource graph; it is not an overlay on retained bindings.
+Required coverage is determined by the compiler and binding contracts for the
+whole graph, not only the currently open dashboard. Managed inputs and authored
+connections that do not require target bindings retain their existing contracts.
+Every required target-bound connection must have an explicit profile entry.
+Profile v1 has no implicit or explicit adoption-by-binding-ID shortcut: reusing
+an existing binding requires an entry describing its intended configuration.
+
+Omitted binding records may remain stored, but are ineligible for new work under
+the selected profile, even if enabled or previously healthy. No browser command,
+watcher, background refresh, or direct candidate API may bypass this eligibility
+boundary on the local runtime. Recheck coverage on graph changes and restart.
+An A-to-B switch that omits a still-required connection fails before binding
+mutation; it does not report B as applied or execute B with A's omitted binding.
+Diagnostics may identify the retained record as a setup aid, never as fallback.
+
+Report the resolved file, selected profile, and redacted effective endpoints
+before upstream access. A profile name, even `prod`, cannot select a remote
+LeapView server, change the local instance's environment, or elevate credentials.
+Reject combinations of local profile flags and remote-target mode.
+
+Bootstrap excludes the local profile file and secret files from Git by default.
+Non-secret example profiles may be committed outside `dashboards/`. Neither
+profiles nor secret files enter portable source bundles, deployment operation
+artifacts, or generated analytics resources. Explicitly selected profile files
+inside the portable source root are rejected. Profile data is not an alternative
+authored Project or access resource.
+
+### Setup, application, and connection tests
+
+Guided setup and CLI editing must round-trip this same representation. Show the
+intended file changes before overwriting existing configuration. Secret entry
+must use a protected channel, never shell command arguments or echoed output.
+Reuse existing binding administration and credential resolvers when applying a
+profile to the local target. Generate target-owned IDs through the owning APIs;
+do not persist human-readable names as replacement execution identities.
+
+Only the selected profile's credential references may be supplied to the
+validated local application runtime. No wholesale host-environment forwarding,
+credential-directory mounting, production credential pull, or remote credential
+upload occurs. Missing or invalid bundles fail closed. Diagnostics, logs, and
+structured output redact secret values. Profile loading does not implicitly
+delete existing bindings absent from the file; retention does not grant execution
+eligibility or permission to retain their usable runtime credentials.
+
+Concurrent sessions sharing a checkout must agree on the selected profile and
+effective binding configuration. A conflicting attachment must fail before
+mutating bindings. Switching profiles or applying endpoint changes requires an
+explicit action coordinated with existing sessions and binding revision checks;
+editing the profile file is not an implicit live retargeting mechanism. Any
+changed execution inputs require normal planning and qualification, not mutation
+of a sealed candidate or its evidence.
+
+Connection testing runs from the actual local application container. It checks
+connector-appropriate network reachability, TLS, authentication, and required
+read permissions without bulk ingestion or upstream writes. Failures distinguish
+DNS/VPN/routing, TLS trust, credentials, permissions, and unsupported connectors
+where available evidence permits; uncertain causes must not be presented as
+diagnosed facts. Passing a host-side connection test alone is insufficient.
+
+### Complete application and interruption recovery
+
+Before applying changes, capture the complete selected configuration and validate
+its schema, graph coverage, endpoints, credential references and supplied bundles,
+resolver compatibility, session ownership, and expected binding revisions as far
+as possible without mutation. Connector health checks that require prepared
+runtime resources remain part of application, not proof that preflight alone
+has succeeded.
+
+Profile application has observable `applying`, `incomplete`, and `applied` states.
+Before the first binding or credential-state mutation, retain a checkout- and
+runtime-scoped application identity with the intended configuration, exact graph
+identity, required/selected connection set, and expected binding/credential
+evidence. Retain references and protected comparison evidence, not secret values.
+The profile file path and name alone are not application identity. This is a
+local configuration checkpoint, not a second plan/build/publish state machine or
+a requirement for a cross-binding database transaction.
+
+Admission of new profile-dependent work closes before mutation and opens only
+when every selected binding and supplied credential state has been reconciled
+to the captured intent, every required connection is covered, and runtime health
+and retirement requirements are satisfied. The gate is enforced by the local
+runtime, not only by the foreground CLI. It covers new plans, builds, queries,
+and refreshes; only bounded application probes and recovery actions may proceed.
+Already-admitted readers may drain against their exact old evidence and current
+authorization within the bounded retirement policy below. A previous rendered
+view may remain visibly stale, but no mixed configuration is presented as ready.
+
+Any partial failure or interruption leaves the application incomplete and the
+gate closed, including after CLI or runtime restart. `dev status` and attachment
+diagnostics distinguish the last completed application from the attempted one
+and report incomplete connections without secrets. An attachment never declares
+success merely because each stored binding is individually healthy. The runtime
+must verify that all belong to the intended complete application; `applied` does
+not itself mean a new analytics candidate has been qualified or published.
+
+Recovery reconciles actual binding revisions, prepared/active credential evidence,
+and acknowledgements against that exact retained intent, then idempotently
+completes the missing work. Do not infer completion from a client progress counter
+or silently recapture edited profiles, changed credentials, or a changed graph.
+Missing credentials must be resupplied and matched to the intended evidence.
+A revision conflict, unavailable intended credential version, or missing checkpoint
+keeps admission closed and requires an explicit replacement/recovery action.
+An explicit return to profile A or replacement with a revised B is another
+complete application; there is no automatic rollback or silent partial adoption.
+A preflight rejection before any mutation can leave the previously applied
+profile available, but must clearly report that the requested profile was rejected.
+
+### Credential agreement, rotation, and retirement
+
+Compare supplied credentials with the runtime's applied credential state, not
+just the profile YAML, variable name, or presence of a binding. For environment
+credentials, use the existing resolver's exact bundle-version semantics for
+each reference and compare against the applied version in a protected channel.
+The existing resolver derives a version from the supplied bundle bytes, so even
+different encodings must not be assumed equivalent without explicit validation.
+Keep secret-derived comparison material private to the local credential/application
+boundary; do not expose raw bundle hashes in diagnostics, portable artifacts,
+or ordinary status output. Comparison tokens are not credentials or proof of
+principal or authorization equivalence.
+
+An attaching session with the same profile and variable name but a different
+bundle fails before changing runtime state. It must not silently overwrite the
+runtime's credentials or succeed using the previous session's credentials.
+Unverifiable agreement after restart also fails closed until reconciliation.
+The environment backing a running container does not change merely because a
+second terminal exports a different value.
+
+Supplying a replacement bundle requires an explicit rotation/replacement action
+through existing credential resolver and binding operations. It is a new
+application intent, coordinated with session ownership and the admission gate,
+not a side effect of attachment, YAML saving, or scheduled resolver refresh.
+Other attached sessions must detach before such a local configuration change;
+they may subsequently attach with the new applied credential state. If the
+environment-backed runtime cannot safely replace its inputs in place, explicit
+local runtime recreation is allowed under those same ownership rules.
+
+Prepare and health-check replacements before selecting their pools; preserve
+exact provider versions, binding revision checks, audit behavior, and reader
+leases through existing rotation mechanisms. A failed replacement is not reported
+as applied. Pre-mutation failure may retain the previous applied state; failure
+after mutation follows the incomplete-application gate above, even if an old pool
+could otherwise remain usable under its stale policy.
+
+Treat a secret-only rotation for the same verified principal, endpoint, role,
+privileges, and result-affecting semantics separately from a principal or scope
+change. Only established execution equivalence permits existing physical/cache
+reuse, and normal qualification and live authorization still apply. Changed
+principal or authorization scope requires renewed authorization and qualification
+and invalidates incompatible cache/reuse evidence. If equivalence cannot be
+established, treat the change conservatively as replacement, not harmless rotation.
+An unchanged secret reference or a successful health check is insufficient proof.
+These rules preserve EP-04 through EP-06 and PI-09/PI-10 in the
+[delivery contract](project-delivery-conformance.md#execution-provenance-and-governance).
+
+Switching away from a credential-bearing connection immediately prevents new
+leases and credential resolution for that connection. Stop its refresh loop,
+retire its pools, and remove the old resolver input. Existing authorized readers
+may finish only within a documented finite drain deadline; on expiry cancel the
+remaining readers and close their pools. Destroy retired credential snapshots
+and temporary credential material once readers drain. Remove obsolete injected values from
+runtime/container configuration, recreating or removing credential-bearing local
+containers when required; merely stopping a container does not remove its stored
+environment. Do not mark the replacement application complete until retirement
+has completed. Restart must not rehydrate omitted credentials from old runtime
+configuration. Persisted binding references and audit evidence may remain; usable
+old credentials may not. This is local retirement, not revocation of the account
+or secret at the upstream provider.
+
+### Existing mechanisms and implementation boundary
+
+The [environment resolver](../../internal/analytics/environment/resolver.go)
+already scopes references, versions bundle bytes, and rejects unavailable exact
+versions. [Binding administration](../../internal/analytics/connectionbinding/administration.go)
+owns revision-checked changes. The
+[pool manager](../../internal/analytics/connectionbinding/rotation.go) prepares
+and health-checks replacement pools, records rotation evidence, and retires old
+pools while leases drain. These mechanisms do not by themselves establish full
+profile coverage, all-binding application completion, attachment credential
+agreement, or removal of obsolete container inputs. Those integration guarantees
+remain pending and require the conformance scenarios below.
+
+### Upstream reads and retained local data
+
+Local bindings may point to an approved upstream also used by production, but
+use developer-specific least-privilege credentials, preferably read-only source
+access. Network reachability and data-handling approval remain prerequisites.
+Connecting locally does not require credentials from the production LeapView
+instance or imply that all remote rows should be copied.
+
+Before first upstream data access, surface the selected source and intended
+read/refresh scope for explicit confirmation or an explicit automation policy.
+Distinguish live reads from refresh/build work producing retained local results.
+Use existing pipeline/input contracts for refresh bounds; do not invent generic
+row-limit sampling or place transformation SQL in connection profiles. Tests and
+metadata probes are identified separately from data ingestion.
+
+Ordinary source-code saves do not silently refresh mutable upstream inputs.
+Retained local materializations can be reused only under existing execution
+identity and snapshot rules. Direct external reads still require connectivity;
+local profiles do not guarantee offline operation or cross-system snapshots.
+Deploy sends portable analytics source; production independently uses its own
+bindings, data, and credentials.
+
+### Optional dbt interoperability
+
+An importer may later translate an explicitly selected, supported dbt profile
+target into one selected logical local connection. Preview the mapping, require
+confirmation before replacing configuration, and preserve secret-reference
+handling. Reject unsupported adapter settings and unsupported expressions rather
+than silently dropping them or executing arbitrary code. Imports neither push
+credentials to production nor establish general dbt `profiles.yml` compatibility.
+An importer is not required for initial profile conformance.
+
+## Attached sessions and lifecycle
+
+A live session is a CLI attachment whose ownership and liveness are verified
+for one canonical checkout and managed runtime. A saved PID alone is not
+sufficient identity. The implementation must define bounded crash detection;
+stale records must not keep services owned forever. Uncertain ownership blocks
+destructive lifecycle operations until resolved.
+
+| Event or command | Required behavior |
+| --- | --- |
+| First `dev` attachment | Start or reuse this checkout's validated runtime and attach. |
+| Another attachment to the same checkout | Share the runtime; register independent session ownership. |
+| Ctrl-C with another live attachment | Detach only the caller; keep services running. |
+| Ctrl-C of the last live attachment | Detach and gracefully stop managed services; retain volumes. |
+| `dev stop` with live attachments | Refuse without mutation; identify the sessions to detach first. |
+| `dev stop` without live attachments | Gracefully stop only this checkout's services; retain volumes. |
+| `dev reset` with live attachments | Refuse without mutation, even if removal was otherwise confirmed. |
+| `dev reset` without live attachments | Identify exact local resources, confirm removal, stop gracefully, then remove only the confirmed state. |
+
+Session join, last-session shutdown, stop, and reset must coordinate so a new
+attachment cannot be registered against resources concurrently being stopped
+or removed. A join waits or returns an actionable retry result during teardown.
+Reset must recheck ownership and liveness at mutation time. It must not silently
+recreate deleted state through a surviving watcher. There is no implicit
+all-sessions force behavior in this contract.
+
+`dev status` reports runtime state, active attachments, and checkout ownership;
+`dev logs` is read-only. Lifecycle commands never act on another checkout's
+resources, even if project names match. Noninteractive reset must require an
+explicit confirmation bound to the selected checkout and resource set.
+
+## Dashboard view identity
+
+At the beginning of a render or refresh, resolve the session pointer once and
+acquire the candidate's required snapshot leases. Assign the resulting view a
+revision identity. All chart, KPI, filter-option, table-page, and lazy queries
+for that view use this pinned identity; none independently follows the pointer.
+Existing authorization checks continue on every operation.
+
+Cache reuse is allowed only when compatible with the pinned candidate,
+snapshots, query inputs, and authorization scope. A newer candidate becoming
+available starts a new view revision, not an in-place identity change for old
+queries. Old leases remain protected until their readers drain.
+
+The browser must reject responses incompatible with its current view revision,
+including delayed SSE patches and cached completions. Cancelling old work is an
+optimization, not the correctness mechanism. On transition, either retain the
+previous complete view as visibly pending replacement, or clear obsolete
+results before showing new results. Never label a mixture of candidate A and
+candidate B results as one current view. Failed builds preserve the last valid
+candidate and its coherent view. Explicit candidate preview URLs remain pinned
+and do not acquire session-following behavior.
+
+This contract pins LeapView candidate and managed-snapshot identity. It does
+not imply snapshot isolation across external data systems that lack it.
+
+## Deployment operation selection
+
+An operation descriptor binds a human-readable handle to its canonical target
+identity, Project/environment, immutable source snapshot and digest, and exact
+delivery identities as they become known. It is durable before a mutating
+request whose lost acknowledgement would otherwise lose operation identity.
+Descriptors must support safe reconciliation at every interruption boundary,
+including before a plan or candidate response reaches the client.
+
+A handle selects existing delivery state; it is not a credential, approval,
+mutable source alias, or new server-side deployment state machine. Handles must
+not be reassigned within their documented workspace/target namespace. Concurrent
+commands selecting the same operation must not advance it inconsistently.
+
+### Interactive workflow
+
+| Invocation | Selection contract |
+| --- | --- |
+| `leapview deploy --target prod` with no unresolved work | Begin the guided new-deployment flow. |
+| Same command with unresolved work | Show retained operations and require a choice to resume one or start new; no automatic newest-operation selection. |
+| `leapview deploy --target prod --new` | Explicit new-source intent; allocate a fresh handle and run the normal review flow. |
+| `leapview deploy --target prod --resume` | Present retained operations for explicit selection and confirmation. |
+| `leapview deploy --target prod --resume --operation release-42` | Select exactly that retained operation and show its identity before resuming. |
+
+Before resumption, show the canonical destination, Project/environment, source
+revision when available, source digest, creation time, and known outcome. A
+dirty checkout's source digest remains authoritative when no commit describes
+it. If current files differ, explain that resume uses retained source and does
+not include those edits. The author need not copy plan or candidate IDs.
+
+Selection must precede source upload, new planning, building, or publication.
+Read-only reconciliation may populate the selection screen. Choosing an
+operation does not substitute for target-required review and approval.
+
+### Automation and ambiguity
+
+Noninteractive calls must use explicit `--new` or `--resume`, together with
+`--operation <handle>`. The two intent flags are mutually exclusive. For example:
+
+```sh
+leapview deploy --target prod --new --operation release-42
+leapview deploy --target prod --resume --operation release-42
+```
+
+New intent with an existing handle fails and instructs the caller to resume or
+choose a fresh handle. Resume with an unknown handle fails; it never falls back
+to new. Missing intent, missing selection, multiple matching descriptors, or a
+target identity mismatch returns a nonzero structured selection error without
+advancing delivery. A mutable target alias cannot retarget a retained operation.
+
+CI must retain the operation descriptor as an artifact when later steps run on
+another machine. Import verifies the descriptor and target association; losing
+the descriptor must not cause reconstruction from current files or selection
+of the target's latest candidate. Handles alone do not guarantee recovery on a
+fresh runner. Credentials remain in the target/client credential mechanisms,
+not in exported descriptors.
+
+### Reconciliation after selection
+
+Resume reconciles the selected operation's exact retained identities, including
+any request that might have succeeded without an acknowledgement. It does not
+recapture edited source, rebuild a sealed candidate, change destination, or
+silently obtain a replacement plan under an earlier approval. A stale plan
+requires fresh planning and review, recorded as new work rather than silently
+replacing the resumed operation's identity.
+
+An indeterminate publication for the same destination must be reconciled before
+conflicting new publication proceeds, including with `--new`. If its outcome
+cannot be established, report that uncertainty and stop. Explicit new intent
+does not implicitly cancel another pending operation or its approvals; normal
+target policy governs conflicts and supersession. Resuming a terminal operation
+reports its outcome without publishing it again.
+
+Structured output distinguishes selection errors, failure, pending approval,
+active completion, and indeterminate outcomes. It includes the selected handle
+and immutable identities that are known, with no unexpected prompts in
+noninteractive mode. Only confirmed activation may be reported as active success.
+
+## Required conformance evidence
+
+| Scenario | Required evidence |
+| --- | --- |
+| Remote active Docker context, `DOCKER_HOST`, or `DOCKER_CONTEXT` | Each is tested, including precedence conflicts; reject before mutations, pulls, or staging. |
+| Misleading context name or loopback tunnel | Neither alone passes locality validation. |
+| Supported local Engine and Docker Desktop | Both supported profiles start with documented locality checks. |
+| Docker context changes during startup | All operations stay on the validated endpoint or fail without redirection. |
+| PostgreSQL and object-storage sources in one local profile | Both resolve exact logical Connection identities and use their own typed endpoints and credential bundles. |
+| Profile-file/name selection, missing files, or conflicting remote flags | Deterministic single-file selection; no hidden merge, target redirection, or silent fallback. |
+| Invalid schema, duplicate keys, unsupported version, or secret-bearing URL | Reject with redacted file/field diagnostics before applying bindings or contacting upstreams. |
+| Missing credential, unselected host secret, or configured Infisical | No credential leakage, host-environment forwarding, or fallback across resolver authority. |
+| Different profiles attach to one checkout | Reject conflicting configuration before mutating bindings; no implicit retargeting of existing sessions. |
+| A covers commerce/inventory; B omits still-required inventory | Reject B before mutation; retained inventory is never fallback for B, including after restart or direct API requests. |
+| Graph gains a required external connection | Coverage gate prevents new work until the selected profile explicitly covers it. |
+| Second binding fails after first changed; CLI or runtime crashes | Application stays incomplete across restart; no mixed-profile work or false success; exact-intent reconciliation is idempotent. |
+| Crash after all changes but before completion acknowledgement | Reconcile the full intended binding/credential set before reporting applied; do not repeat or infer changes from a progress counter. |
+| Recovery sees edited YAML, different bundles, missing checkpoint, or revision drift | Keep admission closed; require explicit recovery/replacement rather than silently adopting current state. |
+| Same profile and variable name in two terminals, different bundles | Reject conflicting attachment without mutation or credential disclosure; restart cannot silently select either bundle. |
+| Explicit secret rotation versus principal/scope replacement | Validate replacement pools and exact evidence; reuse only with established equivalence and current authorization; failed partial rotation remains incomplete. |
+| Switch away from a credential-bearing connection with in-flight readers | Block new leases/resolution, stop refresh, drain within a finite deadline, remove old inputs/pools/container credentials, and prevent restart rehydration. |
+| Connection works on host but not in Docker | Runtime-side test reports evidenced network/TLS/authentication failures without bulk ingestion or writes. |
+| Guided setup, manual profile editing, and repeated application | Same schema and owning binding APIs; protect existing files, credentials, and binding revisions. |
+| Approved remote reads and subsequent YAML edits | Explicit read/refresh scope; no unrequested mutable-data refresh or offline guarantee for live reads. |
+| Local profile followed by production deployment | Profiles and credentials excluded from bundles; production bindings remain unchanged. |
+| Two sessions; one receives Ctrl-C | Other session and services remain usable; last detach stops services and retains data. |
+| Crash or concurrent join/last exit | Stale ownership expires; a newly registered live session is never stopped implicitly. |
+| Stop/reset with attachments or a racing join | Refuse or serialize safely; no active session loses resources and no other checkout is affected. |
+| Several dashboard queries for A run while B arrives | One pinned view per cohort; delayed A results cannot overwrite or mix into B, including filters, table pages, caches, and SSE. |
+| A loses publication acknowledgement; files change; bare deploy runs | Present explicit choice; resume reconciles A, while new intent does not substitute edited bytes into A. |
+| Multiple checkpoints or concurrent invocations | Never select latest implicitly; exact-handle selection is deterministic and same-operation advancement is safe. |
+| Headless missing/unknown handle, conflicting flags, or changed target alias | Structured nonzero selection error with no delivery mutation. |
+| Resume from retained CI artifact | Exact source and target survive a different checkout state; missing artifacts never trigger guessed recovery. |
+| Pending approval, stale plan, or unresolved activation | Preserve target policy and report distinct outcomes; never claim active success or silently replan. |
+
+These are implementation acceptance requirements, not assertions that current
+runtime tests already cover the proposed workflow.


### PR DESCRIPTION
## Summary

- adopt a Docker-managed local analytics authoring workflow while retaining target-owned deployment and security boundaries
- define deterministic lifecycle, coherent preview, and guided deployment/recovery contracts
- specify native local connection profiles with complete application, credential rotation, and conformance semantics

## Testing

- `task ci` (all non-browser lanes passed; dashboard Playwright lane hit a 5-second host-pressure timeout)
- `bun test --timeout 15000 web/components/dashboard/dashboard-page.dom.test.ts`
- `bun test --timeout 15000 web/components/dashboard/dashboard-page.visuals.dom.test.ts`